### PR TITLE
fix(grid,types): 对象声明的批量 action 能真正跑在选中记录上 (#3002)

### DIFF
--- a/.changeset/object-declared-bulk-actions.md
+++ b/.changeset/object-declared-bulk-actions.md
@@ -1,0 +1,57 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/types": patch
+"@object-ui/app-shell": patch
+---
+
+fix(grid): an object-declared bulk action runs over the selected records — objectui#3002
+
+A list view declaring `bulkActions: ['push_down']` rendered a selection-bar
+button that never ran the action: `ObjectGrid` dispatched the legacy form as
+`{ type: <action name>, params: { records } }`, putting the action *name* in the
+runner's `type` slot. Since objectui#2996 that fails loudly instead of
+green-toasting a no-op, but it still never ran. Nor could the object declare a
+bulk action to resolve against — `bulkActionDefs` was passed through from the
+view JSON verbatim, never derived from `objectDef.actions` the way
+`rowActionDefs` is derived from `locations: ['list_item']`.
+
+**No spec change was needed.** `ActionSchema.bulkEnabled` — *"Whether this
+action can be applied to multiple selected records"* — has always been the
+declaration; what was missing was a consumer, exactly as framework's own
+property-liveness audit recorded (*"engine has `getBulkActions`/`executeBulk`,
+but no spec-driven view path calls `executeBulk`"*). So no new `locations`
+entry: a list's selection bar is the only surface on which records are
+multi-selected, which is what the flag already names. `locations` stays
+orthogonal — it places an action's single-record entry, and an action may carry
+both (`locations: ['list_item'], bulkEnabled: true` = one row from the kebab, N
+rows from the selection bar).
+
+**`ObjectGrid` folds three sources into the selection bar** (new pure
+`resolveBulkActions`, the twin of `resolveLegacyRowActions`; `ObjectGrid` is the
+single convergence point of all three list callers):
+
+- defs authored inline in the view JSON — unchanged, they win every collision;
+- object actions declaring `bulkEnabled: true` — **derived**, which is what
+  "declare a bulk action on the object" now means;
+- legacy `bulkActions` names — resolved against `objectDef.actions` and
+  **promoted** to that def, so they carry the action's label, icon, `visible`
+  predicate, confirm text and params instead of a bare humanized name. A name
+  matching a def already on the bar is dropped rather than rendered as a dead
+  twin; a name matching nothing is still dispatched by name, since a consumer
+  may have registered a runner handler under it.
+
+**Execution reuses the existing `BulkActionDialog` model** (params → confirm →
+progress → result). A derived def carries the source action under `actionDef`,
+and `useBulkExecutor` dispatches it through the action runner once per selected
+record with the row attached as `_rowRecord` — so `recordIdParam` injection
+behaves exactly as it does for a `list_item` row action. Client fan-out is the
+only semantics the single-record action contract supports; a server-side "take
+every id at once" variant would need its own spec key and endpoint contract.
+Params and confirmation are collected once by the dialog and handed to the
+runner as values so it never re-prompts per record, per-record toasts are muted
+in favour of the dialog's aggregate result, and a failing record is attributed
+in the result list (and error CSV) rather than counted as a success.
+
+Also fixed: the bar rendered legacy string buttons **only when no defs
+existed**, so a view mixing both silently lost half its buttons. After the fold
+the two lists are disjoint, and both render.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1419,6 +1419,16 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                       }),
                     }))
                 : []),
+            /**
+             * Selection-bar actions. Unlike `rowActionDefs` above, these are
+             * NOT derived here: `ObjectGrid` is the single convergence point of
+             * all three list callers (this view, plugin-view's ObjectView and
+             * plugin-list's ListView), so it folds `objectDef.actions` — the
+             * spec's `bulkEnabled: true` declaration, plus any legacy
+             * `bulkActions` name that resolves to a declared action — into the
+             * def list itself (`resolveBulkActions`, objectui#3002). What we
+             * pass through is the view author's own inline declaration.
+             */
             bulkActions: viewDef.bulkActions ?? listSchema.bulkActions,
             bulkActionDefs: (viewDef as any).bulkActionDefs ?? (listSchema as any).bulkActionDefs,
             sharing: viewDef.sharing ?? listSchema.sharing,

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -45,6 +45,7 @@ import { GroupRow } from './GroupRow';
 import { useColumnSummary } from './useColumnSummary';
 import { resolveRowCrudAffordances } from './rowCrudAffordances';
 import { resolveLegacyRowActions } from './resolveLegacyRowActions';
+import { resolveBulkActions } from './resolveBulkActions';
 import { RowActionMenu, formatActionLabel } from './components/RowActionMenu';
 import { BulkActionBar } from './components/BulkActionBar';
 import { BulkActionDialog } from './components/BulkActionDialog';
@@ -236,7 +237,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // Tenant default currency (ADR-0053) backstops amount cells that lack a code.
   const { currency: tenantCurrency } = useLocalization();
   const { t } = useGridTranslation();
-  const { fieldLabel: resolveFieldLabel, translateOptions } = useSafeFieldLabel();
+  const { fieldLabel: resolveFieldLabel, translateOptions, actionLabel: resolveActionLabel } = useSafeFieldLabel();
   const [objectSchema, setObjectSchema] = useState<any>(null);
   const [useCardView, setUseCardView] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -1633,13 +1634,34 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const explicitBulkActions = objectCanDelete
     ? declaredBulkActions
     : declaredBulkActions?.filter((a: unknown) => String(a).toLowerCase() !== 'delete');
-  const bulkActionDefs: BulkActionDef[] = (Array.isArray(schema.bulkActionDefs)
-    ? schema.bulkActionDefs
-    : []
-  ).filter((def: BulkActionDef) => objectCanDelete || def?.operation !== 'delete');
+  // Legacy `bulkActions` carry a bare action NAME, which the runner cannot
+  // execute on its own, and the object's own `bulkEnabled: true` actions were
+  // never surfaced at all — resolve both against `objectDef.actions` so they
+  // dispatch as real defs. See `resolveBulkActions` (objectui#3002). The
+  // canonical `'delete'` is held back: it routes to `onBulkDelete` (which owns
+  // confirm + refresh), not the runner, even if the object declares an action
+  // that happens to be named `delete`.
+  const legacyBulkNames = (explicitBulkActions ?? []).filter(
+    (a: unknown) => String(a).toLowerCase() !== 'delete',
+  );
+  const { defs: resolvedBulkDefs, unresolved: unresolvedBulkActions } = resolveBulkActions({
+    bulkActions: legacyBulkNames,
+    bulkActionDefs: Array.isArray(schema.bulkActionDefs) ? schema.bulkActionDefs : [],
+    objectActions: (objectSchema as any)?.actions,
+    localizeLabel: (actionName, fallback) =>
+      resolveActionLabel(schema.objectName, actionName, fallback),
+  });
+  const bulkActionDefs: BulkActionDef[] = resolvedBulkDefs.filter(
+    (def: BulkActionDef) => objectCanDelete || def?.operation !== 'delete',
+  );
+  // Names still dispatched by string: the unresolved ones, plus `'delete'`
+  // when the author asked for it — or the implicit bulk-delete affordance.
+  const keptDeleteAction = (explicitBulkActions ?? []).filter(
+    (a: unknown) => String(a).toLowerCase() === 'delete',
+  );
   const effectiveBulkActions: string[] =
     explicitBulkActions && explicitBulkActions.length > 0
-      ? explicitBulkActions
+      ? [...unresolvedBulkActions, ...keptDeleteAction]
       : canDelete && onBulkDelete && bulkActionDefs.length === 0
         ? ['delete']
         : [];
@@ -1722,6 +1744,47 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       setActiveBulkDef(def);
       setActiveBulkRows(expanded);
     })();
+  };
+
+  // Per-record executor for a DERIVED bulk action (objectui#3002) — one
+  // declared object action applied to each selected record through the action
+  // runner. The dialog already collected params and took the confirmation, so
+  // this dispatch strips both from the def: leaving them on would make the
+  // runner re-prompt once per record. Toasts are muted for the same reason —
+  // the dialog's progress/result panel is the single report for the whole run.
+  // (Plain function for the same reason as `resolveBulkRows` above: this point
+  // in the body is past render paths that short-circuit, so a hook here would
+  // tripwire the rules-of-hooks balance.)
+  const runBulkActionRecord = async (
+    def: BulkActionDef,
+    row: Record<string, unknown>,
+    params: Record<string, unknown>,
+  ): Promise<void> => {
+    const source = def.actionDef as Record<string, any> | undefined;
+    if (!source) return;
+    const {
+      params: _declaredParams,
+      actionParams: _actionParams,
+      confirmText: _confirmText,
+      confirm: _confirm,
+      // A one-shot reveal (2FA code, fresh OAuth secret) is a single-record
+      // affordance by construction, and the runner AWAITS acknowledgement —
+      // one modal per record would stall the run behind N dialogs.
+      resultDialog: _resultDialog,
+      ...rest
+    } = source;
+    const res = await executeAction({
+      ...rest,
+      // `_rowRecord` is the same row-context key the list_item path attaches,
+      // so `recordIdParam` / `recordIdField` injection behaves identically.
+      params: { ...params, _rowRecord: row },
+      toast: { showOnSuccess: false, showOnError: false },
+    } as any);
+    // Reject so the executor records this row under its own id in the result
+    // (and the error CSV) instead of counting a failed action as succeeded.
+    if (!res?.success) {
+      throw new Error(res?.error || `Action ${def.name} failed`);
+    }
   };
   const handleBulkDialogClose = (result?: BulkResult | null) => {
     setActiveBulkDef(null);
@@ -2539,6 +2602,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       dataSource={dataSource as any}
       resource={schema.objectName ?? ''}
       objectFields={objectSchema?.fields}
+      runAction={runBulkActionRecord}
     />
   );
 

--- a/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * An object-declared bulk action must reach the ActionRunner as a real action
+ * DEF, applied to every selected record (objectui#3002).
+ *
+ * Before this, `bulkActions: ['push_down']` dispatched the action NAME in the
+ * runner's `type` slot — `{ type: 'push_down', params: { records } }` — which
+ * matches no built-in type and no handler, so it fell through the runner's
+ * schema fallback (green success toast pre-#2996, a loud failure after it).
+ * Either way the action never ran. And an object could not declare a bulk
+ * action at all: `bulkActionDefs` was passed through from view JSON verbatim,
+ * never derived from `objectDef.actions`.
+ *
+ * These drive the REAL ObjectGrid through a real ActionProvider and assert the
+ * user-visible outcome: selecting rows and clicking the button issues one
+ * request per selected record.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({ isLoaded: false, checkField: () => true, getObjectApiOperations: () => undefined }),
+}));
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const OBJECT = 'os_prod_plan';
+const ROWS = [
+  { id: 'r1', name: 'Plan A' },
+  { id: 'r2', name: 'Plan B' },
+];
+
+/**
+ * The object's own bulk action. The label is deliberately NOT the humanization
+ * of the name ("Push Down"), so an assertion on it distinguishes the resolved
+ * def from the legacy path — which could only ever render `formatActionLabel`.
+ */
+const PUSH_DOWN = {
+  name: 'push_down',
+  label: '下推',
+  type: 'api',
+  target: '/api/v1/plans/push',
+  recordIdParam: 'planId',
+  bulkEnabled: true,
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function renderGrid(opts: {
+  objectActions?: unknown[];
+  schema?: Record<string, unknown>;
+  handlers?: Record<string, any>;
+}) {
+  const dataSource: any = {
+    find: vi.fn(async () => ({ data: ROWS.map(r => ({ ...r })), total: ROWS.length, hasMore: false, pageSize: 50 })),
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: { id: { type: 'text' }, name: { type: 'text', label: 'Name' } },
+      ...(opts.objectActions ? { actions: opts.objectActions } : {}),
+    }),
+  };
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    columns: [{ field: 'name', label: 'Name' }],
+    pagination: { pageSize: 50 },
+    ...opts.schema,
+  };
+  render(
+    <ActionProvider handlers={opts.handlers ?? {}}>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+  return dataSource;
+}
+
+/** Render, wait for rows + the async schema fetch, then select every row. */
+async function renderAndSelectAll(opts: Parameters<typeof renderGrid>[0]) {
+  const ds = renderGrid(opts);
+  await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+  // The derivation depends on `getObjectSchema`, so an assertion taken before
+  // it lands would read the pre-fetch (underived) state.
+  await waitFor(() => expect(document.querySelector('thead [role="checkbox"]')).toBeTruthy());
+  fireEvent.click(document.querySelector('thead [role="checkbox"]') as HTMLElement);
+  return ds;
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: () => 'application/json' },
+    json: async () => ({ success: true }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('object-declared bulk actions (objectui#3002)', () => {
+  it('surfaces a bulkEnabled object action with no view declaration at all', async () => {
+    await renderAndSelectAll({ objectActions: [PUSH_DOWN] });
+
+    const button = await screen.findByTestId('bulk-action-push_down');
+    // The object action's own label, not `formatActionLabel('push_down')`.
+    expect(button).toHaveTextContent('下推');
+  });
+
+  it('issues one request per selected record instead of no-opping', async () => {
+    await renderAndSelectAll({ objectActions: [PUSH_DOWN] });
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
+    // No params on this action → the dialog opens straight on confirm.
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/plans/push');
+    // Each dispatch carries ITS OWN record under `_rowRecord` — the same
+    // row-context key the list_item path attaches, which is what lets the
+    // host's api handler perform `recordIdParam` injection unchanged.
+    const sentIds = fetchMock.mock.calls
+      .map(c => JSON.parse((c[1] as any).body)._rowRecord.id)
+      .sort();
+    expect(sentIds).toEqual(['r1', 'r2']);
+  });
+
+  it('resolves a legacy bulkActions name to the declared action', async () => {
+    // The reported shape: the object never flagged the action, the view names it.
+    const unflagged = { ...PUSH_DOWN, bulkEnabled: undefined };
+    await renderAndSelectAll({
+      objectActions: [unflagged],
+      schema: { bulkActions: ['push_down'] },
+    });
+
+    const button = await screen.findByTestId('bulk-action-push_down');
+    expect(button).toHaveTextContent('下推');
+
+    fireEvent.click(button);
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('reports per-record failures instead of counting them as successes', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      headers: { get: () => 'application/json' },
+      json: async () => ({ error: 'precondition not met' }),
+    });
+    await renderAndSelectAll({ objectActions: [PUSH_DOWN] });
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    // The result panel attributes a failure to each record — a runAction that
+    // resolved regardless would report "Succeeded 2 / 2", the #2960 lie in bulk
+    // form (and exactly what `operation: 'custom'` did before it could run).
+    await waitFor(() => expect(screen.getByText(/Succeeded 0 \/ 2/)).toBeInTheDocument());
+    expect(screen.getByTestId('bulk-error-row-r1')).toHaveTextContent('HTTP 422');
+    expect(screen.getByTestId('bulk-error-row-r2')).toBeInTheDocument();
+    // A derived def re-dispatches for one record, so the row keeps its Retry.
+    expect(screen.getByTestId('bulk-error-retry-r1')).toBeInTheDocument();
+  });
+
+  it('renders one button when a legacy name repeats a derived action', async () => {
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: { bulkActions: ['push_down'] },
+    });
+
+    await waitFor(() => expect(screen.getAllByTestId('bulk-action-push_down')).toHaveLength(1));
+  });
+
+  it('keeps an unresolvable legacy name alongside the derived defs', async () => {
+    // A name the object never declared may still have a runner handler
+    // registered under it; hiding it because some OTHER def exists dropped
+    // half the bar's buttons.
+    const handler = vi.fn(async () => ({ success: true }));
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: { bulkActions: ['crm_only_handler'] },
+      handlers: { crm_only_handler: handler },
+    });
+
+    expect(await screen.findByTestId('bulk-action-push_down')).toBeInTheDocument();
+    const legacy = await screen.findByTestId('bulk-action-crm_only_handler');
+    fireEvent.click(legacy);
+    await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
+++ b/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
@@ -1,0 +1,188 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveBulkActions, DERIVED_BULK_BATCH_SIZE } from '../resolveBulkActions';
+import type { BulkActionDef } from '@object-ui/types';
+
+const PUSH_DOWN = {
+  name: 'push_down',
+  label: '下推',
+  type: 'api',
+  target: '/api/v1/plans/push',
+  bulkEnabled: true,
+};
+
+const AUTHORED: BulkActionDef = {
+  name: 'archive',
+  label: 'Archive',
+  operation: 'update',
+  patch: { archived: true },
+};
+
+describe('resolveBulkActions', () => {
+  it('derives a def from an object action declaring bulkEnabled', () => {
+    const { defs, unresolved } = resolveBulkActions({ objectActions: [PUSH_DOWN] });
+
+    expect(unresolved).toEqual([]);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]).toMatchObject({
+      name: 'push_down',
+      label: '下推',
+      operation: 'custom',
+      actionDef: PUSH_DOWN,
+      batchSize: DERIVED_BULK_BATCH_SIZE,
+    });
+  });
+
+  it('leaves an action alone that never opted into bulk', () => {
+    const rowOnly = { name: 'convert_lead', label: 'Convert', locations: ['list_item'] };
+    const { defs, unresolved } = resolveBulkActions({ objectActions: [rowOnly] });
+
+    expect(defs).toEqual([]);
+    expect(unresolved).toEqual([]);
+  });
+
+  it('promotes a legacy name to its declared action even without bulkEnabled', () => {
+    // Naming the action in the view's `bulkActions` IS the declaration of
+    // intent at the view level — same rule the row fold applies to `rowActions`.
+    const noFlag = { name: 'dispatch_job', label: '派工', type: 'api', target: '/x' };
+    const { defs, unresolved } = resolveBulkActions({
+      bulkActions: ['dispatch_job'],
+      objectActions: [noFlag],
+    });
+
+    expect(unresolved).toEqual([]);
+    expect(defs).toHaveLength(1);
+    expect(defs[0]).toMatchObject({ name: 'dispatch_job', operation: 'custom', actionDef: noFlag });
+  });
+
+  it('keeps a name that matches no declared action for by-name dispatch', () => {
+    const { defs, unresolved } = resolveBulkActions({
+      bulkActions: ['crm_only_handler'],
+      objectActions: [PUSH_DOWN],
+    });
+
+    // push_down still derives from its own flag; the unknown name stays legacy.
+    expect(defs.map(d => d.name)).toEqual(['push_down']);
+    expect(unresolved).toEqual(['crm_only_handler']);
+  });
+
+  it('does not render a legacy name twice when it also derives from bulkEnabled', () => {
+    const { defs, unresolved } = resolveBulkActions({
+      bulkActions: ['push_down'],
+      objectActions: [PUSH_DOWN],
+    });
+
+    expect(defs.map(d => d.name)).toEqual(['push_down']);
+    expect(unresolved).toEqual([]);
+  });
+
+  it('lets an inline-authored def win over the object action of the same name', () => {
+    const authoredPush: BulkActionDef = { name: 'push_down', operation: 'update', patch: { s: 1 } };
+    const { defs } = resolveBulkActions({
+      bulkActions: ['push_down'],
+      bulkActionDefs: [authoredPush],
+      objectActions: [PUSH_DOWN],
+    });
+
+    expect(defs).toEqual([authoredPush]);
+  });
+
+  it('drops a repeated legacy name', () => {
+    const { defs, unresolved } = resolveBulkActions({
+      bulkActions: ['dispatch_job', 'dispatch_job', 'ghost', 'ghost'],
+      objectActions: [{ name: 'dispatch_job' }],
+    });
+
+    expect(defs).toHaveLength(1);
+    expect(unresolved).toEqual(['ghost']);
+  });
+
+  it('returns the authored array by reference when nothing folds in', () => {
+    const authored = [AUTHORED];
+    const { defs } = resolveBulkActions({ bulkActionDefs: authored, objectActions: [] });
+
+    expect(defs).toBe(authored);
+  });
+
+  it('maps spec param keys onto the dialog vocabulary', () => {
+    const withParams = {
+      name: 'reassign',
+      bulkEnabled: true,
+      params: [
+        {
+          field: 'owner',
+          label: 'New owner',
+          type: 'lookup',
+          reference: 'sys_user',
+          helpText: 'Who takes over',
+          defaultValue: 'u1',
+          required: true,
+        },
+        // Not authorable as a body key — no `name` and no `field` to fall back to.
+        { label: 'orphan' },
+      ],
+    };
+    const { defs } = resolveBulkActions({ objectActions: [withParams] });
+
+    expect(defs[0].params).toEqual([
+      expect.objectContaining({
+        name: 'owner',
+        label: 'New owner',
+        type: 'lookup',
+        object: 'sys_user',
+        help: 'Who takes over',
+        default: 'u1',
+        required: true,
+      }),
+    ]);
+  });
+
+  it('drops a non-string I18nLabel rather than handing an object to the renderer', () => {
+    const mapLabel = { name: 'push_down', bulkEnabled: true, label: { en: 'Push', 'zh-CN': '下推' } };
+    const { defs } = resolveBulkActions({ objectActions: [mapLabel] });
+
+    expect(defs[0].label).toBeUndefined();
+  });
+
+  it('carries confirm text, icon and visible from the action', () => {
+    const rich = {
+      name: 'push_down',
+      bulkEnabled: true,
+      icon: 'send',
+      variant: 'danger',
+      confirm: { message: '确认下推?' },
+      visible: { dialect: 'cel', source: 'current_user.is_admin' },
+    };
+    const { defs } = resolveBulkActions({ objectActions: [rich] });
+
+    expect(defs[0]).toMatchObject({
+      icon: 'send',
+      variant: 'danger',
+      confirmText: '确认下推?',
+      visible: { dialect: 'cel', source: 'current_user.is_admin' },
+    });
+  });
+
+  it('drops an action variant the bulk bar cannot render', () => {
+    const linkVariant = { name: 'push_down', bulkEnabled: true, variant: 'link' };
+    const { defs } = resolveBulkActions({ objectActions: [linkVariant] });
+
+    expect(defs[0].variant).toBeUndefined();
+  });
+
+  it('localizes derived labels through the supplied resolver', () => {
+    const { defs } = resolveBulkActions({
+      objectActions: [PUSH_DOWN],
+      localizeLabel: (name, fallback) => (name === 'push_down' ? 'Push Down' : fallback),
+    });
+
+    expect(defs[0].label).toBe('Push Down');
+  });
+});

--- a/packages/plugin-grid/src/components/BulkActionBar.tsx
+++ b/packages/plugin-grid/src/components/BulkActionBar.tsx
@@ -55,9 +55,14 @@ const BulkActionButton: React.FC<{
 export interface BulkActionBarProps {
   /** Array of selected row records */
   selectedRows: any[];
-  /** Bulk/batch action identifiers (legacy string list) */
+  /**
+   * Bulk/batch action identifiers (legacy string list) that resolved to no
+   * declared action — dispatched by name for consumers that registered a
+   * runner handler under it. Names that DID resolve arrive in `actionDefs`
+   * instead (see `resolveBulkActions`), so the two lists never overlap.
+   */
   actions: string[];
-  /** Rich action definitions — takes precedence over string ids when both present. */
+  /** Rich action definitions — authored inline or derived from the object. */
   actionDefs?: BulkActionDef[];
   /** Callback when a legacy string-id bulk action button is clicked */
   onAction?: (action: string, selectedRows: any[]) => void;
@@ -182,7 +187,12 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
             onActionDef={onActionDef}
           />
         ))}
-        {!hasDefs && hasLegacy && actions.map(action => {
+        {/* Legacy names render ALONGSIDE defs, not only in their absence: after
+            `resolveBulkActions` folds every resolvable name into `actionDefs`,
+            what's left here is a disjoint set (a handler-registered name the
+            object never declared). Hiding it whenever any def existed made a
+            view that mixes both silently lose half its buttons. */}
+        {hasLegacy && actions.map(action => {
           const actionStr = String(action).toLowerCase();
           const isDestructive = actionStr.includes('delete') || actionStr.includes('remove') || actionStr.includes('destroy');
           const Icon = isDestructive ? Trash2 : null;

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -72,6 +72,13 @@ export interface BulkActionDialogProps {
    * an array, instead of silently degrading to single-select + scalar.
    */
   objectFields?: Record<string, MultiValueFieldDef>;
+  /**
+   * Per-record dispatcher for a def DERIVED from an object action
+   * (objectui#3002) — see {@link BulkExecutorOptions.runAction}. The dialog's
+   * params → confirm steps are what let one action run over N records without
+   * the runner re-prompting per record.
+   */
+  runAction?: BulkExecutorOptions['runAction'];
 }
 
 type Step = 'params' | 'confirm' | 'running' | 'result';
@@ -95,6 +102,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   onClose,
   labelKey = 'name',
   objectFields,
+  runAction,
 }) => {
   const { t } = useObjectTranslation();
   const params = def?.params ?? [];
@@ -122,7 +130,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   const [step, setStep] = useState<Step>('params');
   const [values, setValues] = useState<Record<string, unknown>>(initialParamValues);
   const [lookupCache, setLookupCache] = useState<Record<string, LookupOption[]>>({});
-  const { run, undo, retry, progress, result, reset } = useBulkExecutor({ resource, dataSource, objectFields });
+  const { run, undo, retry, progress, result, reset } = useBulkExecutor({ resource, dataSource, objectFields, runAction });
   const [retrying, setRetrying] = useState<string | null>(null);
   const [undoing, setUndoing] = useState(false);
   const [undoneAt, setUndoneAt] = useState<number | null>(null);
@@ -423,7 +431,10 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
                             <span className="text-muted-foreground">{e.id}:</span> {e.error}
                           </div>
                         </div>
-                        {def.operation !== 'custom' && (
+                        {/* A plain `custom` callout has nothing to re-run, but
+                            a DERIVED def (#3002) re-dispatches its object
+                            action for that one record — same as update/delete. */}
+                        {(def.operation !== 'custom' || !!def.actionDef) && (
                           <Button
                             variant="ghost"
                             size="sm"

--- a/packages/plugin-grid/src/hooks/useBulkExecutor.ts
+++ b/packages/plugin-grid/src/hooks/useBulkExecutor.ts
@@ -80,6 +80,30 @@ export interface BulkExecutorOptions {
       ids: ReadonlyArray<string | number>,
     ) => Promise<number>;
   };
+  /**
+   * Per-record dispatcher for a DERIVED bulk action — one declared object
+   * action (`bulkEnabled: true`, or a legacy `bulkActions` name resolved
+   * against `objectDef.actions`) applied to N selected records (objectui#3002).
+   *
+   * Such a def carries `operation: 'custom'` plus `def.actionDef`; the data
+   * source has no idea what the action does, so the grid injects this to run it
+   * through the action runner. Client fan-out — one dispatch per record — is
+   * the only semantics the single-record action contract supports (`params` /
+   * `recordIdParam` / `visible` are all per-record); a server-side "take every
+   * id at once" variant would need its own spec key and endpoint contract.
+   *
+   * MUST reject on failure: the executor attributes per-row errors from the
+   * rejection reason, so resolving on a failed action would report it as a
+   * success (the exact #2960 failure mode this whole path exists to kill).
+   *
+   * When absent, `operation: 'custom'` keeps its historical meaning: no
+   * mutation, the consumer wires `onComplete`.
+   */
+  runAction?: (
+    def: BulkActionDef,
+    row: Record<string, unknown>,
+    params: Record<string, unknown>,
+  ) => Promise<unknown>;
 }
 
 /**
@@ -102,7 +126,7 @@ export interface BulkExecutorOptions {
  *   Soft (`succeeded < total`) shortfalls surface as a single aggregate
  *   error entry per batch — see comments inline.
  */
-export function useBulkExecutor({ resource, dataSource, objectFields }: BulkExecutorOptions) {
+export function useBulkExecutor({ resource, dataSource, objectFields, runAction }: BulkExecutorOptions) {
   const [progress, setProgress] = useState<BulkProgress>({
     total: 0,
     done: 0,
@@ -196,6 +220,14 @@ export function useBulkExecutor({ resource, dataSource, objectFields }: BulkExec
           label = 'bulk delete';
         }
 
+        // Row lookup for the runner path, which needs the whole record (not
+        // just its id) to attach as `_rowRecord`.
+        const rowById = new Map<string, Record<string, unknown>>();
+        for (const row of batch) {
+          const id = row.id != null ? String(row.id) : '';
+          if (id) rowById.set(id, row);
+        }
+
         const perRow = (id: string): Promise<unknown> => {
           switch (def.operation) {
             case 'delete':
@@ -203,8 +235,13 @@ export function useBulkExecutor({ resource, dataSource, objectFields }: BulkExec
             case 'update':
               return dataSource.update(resource, id, buildPatch());
             case 'custom':
-              // No mutation — caller wires onComplete events for callouts.
-              return Promise.resolve();
+              // A DERIVED def (`actionDef` present) runs its object action once
+              // per record through the injected runner. Without one, this is
+              // the historical callout shape — no mutation, caller wires
+              // onComplete.
+              return def.actionDef && runAction
+                ? runAction(def, rowById.get(id) ?? { id }, { ...params })
+                : Promise.resolve();
             default:
               return Promise.reject(new Error(`Unknown operation: ${def.operation}`));
           }
@@ -237,7 +274,7 @@ export function useBulkExecutor({ resource, dataSource, objectFields }: BulkExec
       }
       return finalResult;
     },
-    [resource, dataSource, objectFields],
+    [resource, dataSource, objectFields, runAction],
   );
 
   /**
@@ -303,7 +340,11 @@ export function useBulkExecutor({ resource, dataSource, objectFields }: BulkExec
             await dataSource.update(resource, rowId, patch);
             break;
           case 'custom':
-            return true;
+            // A derived def re-dispatches the action for real; a plain callout
+            // def has nothing to retry, so it reports success unchanged.
+            if (!last.def.actionDef || !runAction) return true;
+            await runAction(last.def, row, { ...last.params });
+            break;
           default:
             return false;
         }
@@ -324,7 +365,7 @@ export function useBulkExecutor({ resource, dataSource, objectFields }: BulkExec
         return false;
       }
     },
-    [resource, dataSource, objectFields],
+    [resource, dataSource, objectFields, runAction],
   );
 
   return { run, undo, retry, progress, result, reset };

--- a/packages/plugin-grid/src/resolveBulkActions.ts
+++ b/packages/plugin-grid/src/resolveBulkActions.ts
@@ -1,0 +1,211 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Fold an object's declared actions — and a list view's legacy
+ * `bulkActions: string[]` — into the rich `BulkActionDef` list the selection
+ * bar renders.
+ *
+ * This is the selection-scoped twin of {@link resolveLegacyRowActions}
+ * (objectui#2960 / #2996), and it closes the same `{type: <name>}` dead end on
+ * the bulk path (objectui#3002): dispatching `bulkActions: ['push_down']` put
+ * the action's NAME in the runner's `type` slot, which resolves to nothing.
+ *
+ * ## Where an object-level bulk action is declared
+ *
+ * `ActionSchema.bulkEnabled` — *"Whether this action can be applied to
+ * multiple selected records"*. The spec has carried this flag all along; what
+ * was missing was a consumer (framework's own liveness audit: *"engine has
+ * `getBulkActions`/`executeBulk`, but no spec-driven view path calls
+ * `executeBulk`"*). So no new `locations` entry is needed — a list selection
+ * bar is the only surface on which records are multi-selected, which is
+ * exactly what the flag already names. `locations` stays orthogonal: it places
+ * an action's SINGLE-record entry (toolbar / row kebab / record header), and
+ * an action may carry both (`locations: ['list_item'], bulkEnabled: true` =
+ * runs on one row from the kebab, on N rows from the selection bar).
+ *
+ * ## Three vocabularies reach the selection bar
+ *
+ *  1. `bulkActionDefs` — rich defs authored inline in the view JSON. Untouched
+ *     here; they own their names and win every collision.
+ *  2. `objectDef.actions` with `bulkEnabled: true` — DERIVED into defs by this
+ *     fold. This is what "declare a bulk action on the object" now means.
+ *  3. `bulkActions: string[]` — the legacy bare-name form, kept as a
+ *     view-level override (name an action the object didn't flag, or order it
+ *     explicitly). Resolved against `objectDef.actions` by name.
+ *
+ * A derived def carries `operation: 'custom'` plus the source action under
+ * {@link BulkActionDef.actionDef}: it is NOT a data-plane mass update, it is
+ * one action run over N records through the action runner. `useBulkExecutor`
+ * routes on exactly that key — a `custom` def WITHOUT `actionDef` keeps its
+ * historical no-op-per-row meaning (callout handled by the consumer's
+ * `onComplete`).
+ *
+ * Names that resolve to nothing stay in `unresolved` and are still dispatched
+ * by name: consumers may have registered a runner handler under exactly that
+ * name (`runner.registerHandler('my_action', …)`), and that path must keep
+ * working. When no such handler exists the runner reports the dead end rather
+ * than toasting success (#2996).
+ */
+
+import type { BulkActionDef, BulkActionParam } from '@object-ui/types';
+
+/** The subset of an `ActionDef` this fold reads; everything else is carried. */
+export interface NamedActionDef {
+  name?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Concurrency for a derived action's per-record fan-out. Well below the
+ * `BulkActionDef` default (200) because each record here is a distinct runner
+ * dispatch — typically an HTTP call to a custom endpoint or a flow run, not a
+ * single batched data-API write. 200 in flight would be a thundering herd
+ * against an endpoint that never opted into bulk traffic.
+ */
+export const DERIVED_BULK_BATCH_SIZE = 25;
+
+/** Action `variant`s that have no `BulkActionDef` counterpart are dropped. */
+const BULK_VARIANTS = new Set(['primary', 'secondary', 'danger', 'ghost']);
+
+/**
+ * Map a spec `ActionParam` onto the dialog's `BulkActionParam`. The two carry
+ * the same information under different key names — collecting the values ONCE
+ * in the bulk dialog is the whole point, so the runner must not be handed the
+ * param defs again (it would re-prompt per record).
+ */
+function toBulkParam(p: Record<string, unknown>): BulkActionParam | null {
+  const name = (typeof p.name === 'string' && p.name) || (typeof p.field === 'string' && p.field) || '';
+  if (!name) return null;
+  const out: BulkActionParam = {
+    ...p,
+    name,
+    type: typeof p.type === 'string' ? p.type : 'text',
+  };
+  if (typeof p.label === 'string') out.label = p.label;
+  if (typeof p.helpText === 'string') out.help = p.helpText;
+  if (p.defaultValue !== undefined) out.default = p.defaultValue;
+  // `reference` is the spec spelling of the lookup target; the dialog reads `object`.
+  if (typeof p.reference === 'string') out.object = p.reference;
+  return out;
+}
+
+/** Resolves an action's display label through the app's i18n bundle. */
+export type ActionLabelResolver = (actionName: string, fallback: string) => string;
+
+/** Build the selection-bar def for an object action. */
+function toBulkActionDef(action: NamedActionDef, localize?: ActionLabelResolver): BulkActionDef {
+  const name = String(action.name);
+  const rawParams = Array.isArray(action.params) ? action.params : [];
+  const params = rawParams
+    .map(p => (p && typeof p === 'object' ? toBulkParam(p as Record<string, unknown>) : null))
+    .filter((p): p is BulkActionParam => p !== null);
+  const variant = typeof action.variant === 'string' && BULK_VARIANTS.has(action.variant)
+    ? (action.variant as BulkActionDef['variant'])
+    : undefined;
+  const confirmText =
+    typeof action.confirmText === 'string'
+      ? action.confirmText
+      : typeof (action.confirm as { message?: unknown } | undefined)?.message === 'string'
+        ? String((action.confirm as { message: string }).message)
+        : undefined;
+  // A non-string `I18nLabel` (the `{ en, zh }` map form) is dropped rather than
+  // forwarded: the bar renders `def.label` as a React child, so an object here
+  // would take the page down. Falling through to `formatActionLabel(name)`
+  // matches how the grid treats a non-string column label.
+  const rawLabel = typeof action.label === 'string' ? action.label : undefined;
+  const label = localize ? localize(name, rawLabel ?? name) : rawLabel;
+
+  return {
+    name,
+    ...(label !== undefined && { label }),
+    ...(typeof action.icon === 'string' && { icon: action.icon }),
+    ...(variant && { variant }),
+    // Not an `update`/`delete` mass mutation — the source action owns what it
+    // does. `actionDef` below is what makes this run (see useBulkExecutor).
+    operation: 'custom',
+    ...(params.length > 0 && { params }),
+    ...(confirmText !== undefined && { confirmText }),
+    ...(action.visible != null && { visible: action.visible as BulkActionDef['visible'] }),
+    batchSize: DERIVED_BULK_BATCH_SIZE,
+    actionDef: action,
+  };
+}
+
+export function resolveBulkActions(opts: {
+  /**
+   * Legacy `bulkActions` names, already stripped of the canonical `'delete'`
+   * entry (it routes to the grid's `onBulkDelete`, not the runner — same
+   * carve-out the row fold makes for `'edit'` / `'delete'`).
+   */
+  bulkActions?: readonly string[] | null;
+  /** Rich defs authored inline in the view/list JSON. */
+  bulkActionDefs?: readonly BulkActionDef[] | null;
+  /** Every action declared on the object (`objectDef.actions`). */
+  objectActions?: readonly NamedActionDef[] | null;
+  /**
+   * Resolves a derived def's label through the app's i18n bundle, so an
+   * object-declared bulk action reads the same in the selection bar as its row
+   * entry does in the kebab. Omit to use the authored label verbatim.
+   */
+  localizeLabel?: ActionLabelResolver;
+}): {
+  /**
+   * Authored defs, then the object's `bulkEnabled` actions, then promoted
+   * legacy names. Returned by REFERENCE when nothing was derived or promoted,
+   * so a view with no object actions to fold keeps its identity across renders.
+   */
+  defs: readonly BulkActionDef[];
+  /** Legacy names that matched no declared action; dispatched by name. */
+  unresolved: string[];
+} {
+  const authored = Array.isArray(opts.bulkActionDefs) ? opts.bulkActionDefs : [];
+  const names = Array.isArray(opts.bulkActions) ? opts.bulkActions : [];
+  const objectActions = Array.isArray(opts.objectActions) ? opts.objectActions : [];
+
+  const claimed = new Set(
+    authored.map(d => d?.name).filter((n): n is string => typeof n === 'string' && n !== ''),
+  );
+
+  // (2) The object's own declaration: `bulkEnabled: true`.
+  const derived: BulkActionDef[] = [];
+  for (const action of objectActions) {
+    if (action?.bulkEnabled !== true) continue;
+    const name = action?.name;
+    if (typeof name !== 'string' || name === '') continue;
+    if (claimed.has(name)) continue;
+    claimed.add(name);
+    derived.push(toBulkActionDef(action, opts.localizeLabel));
+  }
+
+  // (3) The view-level legacy override.
+  const promoted: BulkActionDef[] = [];
+  const unresolved: string[] = [];
+  for (const name of names) {
+    if (typeof name !== 'string' || name === '') continue;
+    // Already surfaced (authored, derived, or an earlier pass over a repeated
+    // legacy entry) — drop the duplicate rather than render a twin. Both
+    // outcomes claim the name: the bar keys its buttons on it, so even two
+    // dead-name entries would collide.
+    if (claimed.has(name)) continue;
+    claimed.add(name);
+    const match = objectActions.find(a => a?.name === name);
+    if (match) {
+      promoted.push(toBulkActionDef(match, opts.localizeLabel));
+    } else {
+      unresolved.push(name);
+    }
+  }
+
+  return {
+    defs: derived.length > 0 || promoted.length > 0
+      ? [...authored, ...derived, ...promoted]
+      : authored,
+    unresolved,
+  };
+}

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -296,7 +296,9 @@ export interface BulkActionParam {
 /**
  * Bulk action operation kind. Determines which `dataSource` method the executor
  * calls per batch. `custom` defers entirely to `onComplete` event handlers and
- * is intended for callouts (notify/export/...) that don't mutate records.
+ * is intended for callouts (notify/export/...) that don't mutate records —
+ * UNLESS the def carries {@link BulkActionDef.actionDef}, in which case the
+ * executor dispatches that action through the action runner once per record.
  */
 export type BulkActionOperation = 'update' | 'delete' | 'custom';
 
@@ -305,11 +307,16 @@ export type BulkActionOperation = 'update' | 'delete' | 'custom';
  *
  * The grid renders one button per def in the BulkActionBar. Clicking it opens
  * the BulkActionDialog: params form → confirm → progress → result. The executor
- * batches selected records via `dataSource.bulk(resource, op, items)`.
+ * batches selected records via `dataSource.bulk(resource, op, items)` — or, for
+ * a def derived from an object action ({@link BulkActionDef.actionDef}),
+ * dispatches that action once per record through the action runner.
  *
- * Pair with the legacy `bulkActions: string[]` field — `bulkActionDefs` takes
- * precedence when both are set, but legacy IDs still render alongside as
- * fallback buttons.
+ * Three sources feed the bar (folded by `resolveBulkActions` in plugin-grid):
+ * defs authored inline in the view JSON, object actions declaring the spec's
+ * `bulkEnabled: true`, and the legacy `bulkActions: string[]` names — each of
+ * which is resolved against `objectDef.actions` and promoted to a def when it
+ * matches one. Names that match nothing still render as by-name buttons, since
+ * a consumer may have registered a runner handler under exactly that name.
  */
 export interface BulkActionDef {
   /** Stable identifier — also used as the action key in audit logs. */
@@ -337,12 +344,30 @@ export interface BulkActionDef {
   confirmText?: string;
   /** Custom Confirm button label (default: "Run"). */
   confirmLabel?: string;
-  /** Permission / feature gate expression — hides the button when it evaluates falsy. */
-  visible?: string;
+  /**
+   * Permission / feature gate predicate — hides the button when it evaluates
+   * falsy. Accepts the spec's `ExpressionInput` shape (a bare CEL string, or
+   * the `{ dialect, source }` envelope `objectstack build` emits) so a def
+   * derived from an object action can forward `action.visible` untouched.
+   */
+  visible?: string | { dialect?: string; source: string };
   /** Max records the action will operate on; selection above this is blocked. */
   maxRecords?: number;
   /** Batch size for the executor loop (default: 200). */
   batchSize?: number;
+  /**
+   * Source object `ActionDef` when this entry was DERIVED from
+   * `objectDef.actions` — either the spec's `bulkEnabled: true` declaration or
+   * a legacy `bulkActions: ['<name>']` entry resolved by name (objectui#3002).
+   *
+   * Presence of this key changes what `operation: 'custom'` means: instead of
+   * a per-row no-op, the executor dispatches THIS action through the action
+   * runner once per selected record, with the row attached as `_rowRecord` so
+   * `recordIdParam` injection works exactly as it does for a `list_item` row
+   * action. Params and confirmation are collected once by the BulkActionDialog
+   * and handed to the runner as values, so it never re-prompts per record.
+   */
+  actionDef?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
Fixes #3002.

## 结论先行：spec 不用改

issue 的前提是「spec 的 `locations` 枚举里没有 bulk 这一档，对象 action 无法声明『我是一个批量操作』」，所以这是跨仓库的、动手前得先定设计。

**查下来这个前提不成立**：`ActionSchema` 一直有 `bulkEnabled`——

```ts
/** Bulk Operations */
bulkEnabled: z.boolean().optional()
  .describe('Whether this action can be applied to multiple selected records'),
```

缺的从来不是声明，而是**消费方**。framework 自己的 property-liveness 审计逐字记着这件事：

> **`bulkEnabled`** — engine has `getBulkActions`/`executeBulk`, but no spec-driven view path calls `executeBulk`.

所以本 PR **纯 objectui 改动**，framework/spec 一行没动。

### 对 issue 四个设计问题的回答

1. **加 `list_bulk` / `mass_action` 这一档吗？** 不加。列表选择栏是唯一「记录被多选」的界面，这正是 `bulkEnabled` 已经命名的东西；再加一档 location 等于承认 `bulkEnabled` 表达不了它。`locations` 保持正交——它安放的是 action 的**单条**入口，一个 action 可以两者都带（`locations: ['list_item'] + bulkEnabled: true` = 行菜单点一条、选择栏跑 N 条）。
2. **`bulkActionDefs` 要不要像 `rowActionDefs` 一样推导？** 要，且推导点放在 `ObjectGrid`——它是三个列表调用方（app-shell `ObjectView`、plugin-view `ObjectView`、plugin-list `ListView`）的唯一收敛点，和 #2996 的选择一致，改一处覆盖三处。
3. **N 条记录的语义谁定？** 客户端 fan-out。单条 action 的契约（`params` / `recordIdParam` / `visible`）本来就是逐记录的，服务端「一次收全量 id」需要自己的 spec key + endpoint 契约，那是新功能不是修 bug。
4. **老的 `bulkActions: string[]` 保留还是废弃？** 保留为 view 级覆盖：名字先拿去和 `objectDef.actions` 解析，解析得到就**提升**成真 def；解析不到仍按名字派发（消费方可能用该名字注册过 runner handler）。

## 改动

**① 新增纯函数 `resolveBulkActions`**（`resolveLegacyRowActions` 的批量孪生），把三路词汇折叠成一份 def 列表：

- view JSON 里内联写的 `bulkActionDefs` —— 原样保留，同名永远它赢；
- `objectDef.actions` 里 `bulkEnabled: true` 的 —— **推导**出来，这就是「在对象上声明一个批量 action」的新含义；
- `bulkActions` 里的名字 —— 按名字解析到对象 action 后**提升**成该 def，于是带上 label / icon / `visible` 谓词 / 确认文案 / 参数（字符串形式一个都带不了）。已在栏上的同名项直接丢弃，不再渲染死副本。

**② 执行接进现有 `BulkActionDialog`**（params → confirm → progress → result，issue 里点名要求的）。推导出的 def 带 `operation: 'custom'` + `actionDef`（源 action）；`useBulkExecutor` 按这个 key 分流，逐记录经 action runner 派发，行记录挂在 `_rowRecord` 上——和 `list_item` 行 action 完全同一个键，所以 `recordIdParam` 注入行为一模一样。参数和确认由对话框收**一次**再交给 runner，runner 不会逐条再弹；逐条 toast 静音，对话框的聚合结果是唯一报告；失败的记录进错误列表 / 错误 CSV，而不是被记成成功（那正是 #2960 的批量版）。不带 `actionDef` 的 `custom` def 语义不变（consumer 自己 wire `onComplete`）。

**③ 顺带修**：`BulkActionBar` 过去只在**没有任何 def 时**才渲染 legacy 字符串按钮，于是同时写了两者的 view 会**静默丢掉一半按钮**。折叠之后两个列表互斥，两边都渲染。

## 验证

- **新增测试**：`resolveBulkActions.test.ts`（13 条纯函数）、`objectBulkActionDispatch.test.tsx`（6 条，驱动真实 ObjectGrid + 真实 ActionProvider + 真实对话框，断言 `fetch` 真的按选中记录数发出、每条带自己的记录、失败被逐条归因）。
- **受影响包**：`plugin-grid` 42 文件 / 342 测试全绿；`app-shell` + `plugin-list` + `plugin-view` 257 文件 / 2325 测试全绿；`types` + `core/actions` + `react/hooks` 35 文件 / 537 测试全绿。
- **type-check**：`types` / `core` / `plugin-grid` / `app-shell` 及其依赖 32 个任务全过。
- **lint**：改动文件 0 error（仓库既有 warning 基线未变）。
- 未做浏览器实测：这条路径需要后端里存在一个声明了 `bulkEnabled` 的对象 action，而上面的 DOM 测试已经驱动真实 grid/runner/对话框并断言真实 `fetch`，覆盖同一条链路。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
