### PR TITLE
chore(plugin-grid): 对象声明批量 action 的浏览器验证 demo (#3002)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -21,6 +21,22 @@
       "port": 5181
     },
     {
+      "name": "grid-bulk-demo",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "--dir",
+        "packages/plugin-grid",
+        "exec",
+        "vite",
+        "demo",
+        "--port",
+        "5198",
+        "--strictPort"
+      ],
+      "port": 5198,
+      "url": "http://localhost:5198"
+    },
+    {
       "name": "gantt-demo",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": [

--- a/packages/plugin-grid/demo/bulk-actions.html
+++ b/packages/plugin-grid/demo/bulk-actions.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Object-declared Bulk Actions Demo</title>
+    <style>
+      /* Same console theme tokens as index.html, so the selection bar and the
+         bulk dialog render exactly as they do in the real app. */
+      :root {
+        --background: 0 0% 100%;
+        --foreground: 222.2 84% 4.9%;
+        --card: 0 0% 100%;
+        --card-foreground: 222.2 84% 4.9%;
+        --popover: 0 0% 100%;
+        --popover-foreground: 222.2 84% 4.9%;
+        --primary: 243 75% 59%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 210 40% 96.1%;
+        --secondary-foreground: 222.2 47.4% 11.2%;
+        --muted: 210 40% 96.1%;
+        --muted-foreground: 215.4 16.3% 46.9%;
+        --accent: 210 40% 96.1%;
+        --accent-foreground: 222.2 47.4% 11.2%;
+        --destructive: 0 84.2% 60.2%;
+        --destructive-foreground: 210 40% 98%;
+        --border: 214.3 31.8% 91.4%;
+        --input: 214.3 31.8% 91.4%;
+        --ring: 243 75% 59%;
+        --radius: 0.5rem;
+      }
+      html, body, #root { height: 100%; margin: 0; }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; background: hsl(var(--background)); color: hsl(var(--foreground)); }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/bulk-actions.tsx"></script>
+  </body>
+</html>

--- a/packages/plugin-grid/demo/bulk-actions.tsx
+++ b/packages/plugin-grid/demo/bulk-actions.tsx
@@ -113,9 +113,32 @@ const dataSource: any = {
   },
 };
 
-/** Request log, rendered on the page so each per-record dispatch is visible. */
+/**
+ * Request log, rendered on the page so each per-record dispatch is visible.
+ * A tiny external store rather than a captured setState: the fetch stub lives
+ * outside React, and assigning a module-level slot from render is exactly what
+ * the compiler lint forbids.
+ */
 type LogEntry = { url: string; recordId: string; params: string; status: number };
-let pushLog: (e: LogEntry) => void = () => {};
+const logEntries: LogEntry[] = [];
+const logListeners = new Set<() => void>();
+function pushLog(e: LogEntry) {
+  logEntries.push(e);
+  logListeners.forEach(notify => notify());
+}
+function useLog(): LogEntry[] {
+  // Subscribe on the append COUNT — a stable scalar snapshot, so the store
+  // contract holds while the array itself stays mutable.
+  React.useSyncExternalStore(
+    (onChange) => {
+      logListeners.add(onChange);
+      return () => logListeners.delete(onChange);
+    },
+    () => logEntries.length,
+    () => 0,
+  );
+  return logEntries;
+}
 
 const realFetch = window.fetch.bind(window);
 window.fetch = (async (input: any, init: any) => {
@@ -153,8 +176,7 @@ const schema: any = {
 };
 
 function Demo() {
-  const [log, setLog] = React.useState<LogEntry[]>([]);
-  pushLog = (e) => setLog(prev => [...prev, e]);
+  const log = useLog();
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>

--- a/packages/plugin-grid/demo/bulk-actions.tsx
+++ b/packages/plugin-grid/demo/bulk-actions.tsx
@@ -1,0 +1,219 @@
+/**
+ * Manual-verification demo for object-declared bulk actions (objectui#3002).
+ *
+ *   pnpm --dir packages/plugin-grid exec vite demo --port 5198
+ *   open http://localhost:5198/bulk-actions.html
+ *
+ * Everything below the mock boundary is the REAL stack — `ObjectGrid`,
+ * `BulkActionBar`, `BulkActionDialog`, `useBulkExecutor`, `ActionRunner`. Only
+ * two things are faked: the data source (an in-memory store, standing in for
+ * `/api/v1/<object>`) and `window.fetch` (which logs each action request to the
+ * on-page panel instead of hitting a server).
+ *
+ * What it exercises:
+ *   1. `bulk_mark_done` is declared on the OBJECT with `bulkEnabled: true` and
+ *      is named by no view — before #3002 an object simply could not express a
+ *      bulk action, so this button did not exist.
+ *   2. `bulk_recalc_estimate` is declared on the object WITHOUT the flag; the
+ *      view names it in legacy `bulkActions: [...]`. That name used to be
+ *      dispatched as `{ type: 'bulk_recalc_estimate' }` and never ran.
+ *   3. `legacy_only_handler` resolves to no declared action and stays a
+ *      by-name dispatch — it must still render ALONGSIDE the two defs above.
+ *   4. Record `t3` fails server-side (422), proving per-record attribution: the
+ *      result panel reports 4/5 with an error row rather than a blanket success.
+ */
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import '@object-ui/components/style.css';
+import { ActionProvider, I18nProvider } from '@object-ui/react';
+import { registerAllFields } from '@object-ui/fields';
+import { en } from '@object-ui/i18n';
+import { ObjectGrid } from '../src/ObjectGrid';
+
+registerAllFields();
+
+// The prebuilt components CSS ships its own :root theme and (being injected at
+// runtime) wins over the html file — re-apply the console brand tokens last.
+const themeStyle = document.createElement('style');
+themeStyle.textContent = `:root {
+  --primary: 243 75% 59%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 243 75% 59%;
+}`;
+document.head.appendChild(themeStyle);
+
+// ─────────────────────────── mock boundary ───────────────────────────
+
+const ROWS = [
+  { id: 't1', title: 'Ship the release notes', assignee: 'Ada', progress: 20, done: false },
+  { id: 't2', title: 'Review the migration plan', assignee: 'Alan', progress: 40, done: false },
+  { id: 't3', title: 'Rotate the staging keys', assignee: 'Grace', progress: 60, done: false },
+  { id: 't4', title: 'Draft the incident postmortem', assignee: 'Ada', progress: 80, done: false },
+  { id: 't5', title: 'Prune stale feature flags', assignee: 'Alan', progress: 10, done: false },
+];
+
+/**
+ * `bulkEnabled: true` is the spec's object-level declaration — "this action can
+ * be applied to multiple selected records". It also carries `locations:
+ * ['list_item']`, so the same action is a row entry AND a bulk entry.
+ */
+const MARK_DONE = {
+  name: 'bulk_mark_done',
+  label: 'Mark Done',
+  icon: 'check',
+  type: 'api',
+  target: '/api/demo/mark-done',
+  recordIdParam: 'taskId',
+  locations: ['list_item'],
+  bulkEnabled: true,
+};
+
+/** No `bulkEnabled` — the VIEW names it in legacy `bulkActions` instead. */
+const RECALC = {
+  name: 'bulk_recalc_estimate',
+  label: 'Recalculate Estimate',
+  icon: 'calculator',
+  type: 'api',
+  target: '/api/demo/recalc',
+  recordIdParam: 'taskId',
+  locations: ['record_more'],
+  // Collected ONCE by the bulk dialog, then handed to every per-record dispatch.
+  params: [
+    {
+      name: 'basis',
+      label: 'Estimate basis',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Story points', value: 'points' },
+        { label: 'Hours', value: 'hours' },
+      ],
+      defaultValue: 'points',
+    },
+  ],
+};
+
+const dataSource: any = {
+  async find() {
+    return { data: ROWS.map(r => ({ ...r })), total: ROWS.length, hasMore: false, pageSize: 50 };
+  },
+  async getObjectSchema(name: string) {
+    return {
+      name,
+      label: 'Task',
+      fields: {
+        id: { type: 'text' },
+        title: { type: 'text', label: 'Title' },
+        assignee: { type: 'text', label: 'Assignee' },
+        progress: { type: 'percent', label: 'Progress' },
+      },
+      // The single source the grid folds into the selection bar.
+      actions: [MARK_DONE, RECALC],
+    };
+  },
+};
+
+/** Request log, rendered on the page so each per-record dispatch is visible. */
+type LogEntry = { url: string; recordId: string; params: string; status: number };
+let pushLog: (e: LogEntry) => void = () => {};
+
+const realFetch = window.fetch.bind(window);
+window.fetch = (async (input: any, init: any) => {
+  const url = String(input);
+  if (!url.startsWith('/api/demo/')) return realFetch(input, init);
+  const body = init?.body ? JSON.parse(init.body) : {};
+  const recordId = body._rowRecord?.id ?? '(none)';
+  // t3 fails — proves the result panel attributes failures per record instead
+  // of reporting a blanket success.
+  const status = recordId === 't3' ? 422 : 200;
+  const { _rowRecord, ...rest } = body;
+  pushLog({ url, recordId, params: JSON.stringify(rest), status });
+  return {
+    ok: status === 200,
+    status,
+    statusText: status === 200 ? 'OK' : 'Unprocessable Entity',
+    headers: { get: () => 'application/json' },
+    json: async () => ({ success: status === 200 }),
+  } as any;
+}) as typeof window.fetch;
+
+// ───────────────────────────── the demo ──────────────────────────────
+
+const schema: any = {
+  type: 'object-grid',
+  objectName: 'demo_task',
+  columns: [
+    { field: 'title', label: 'Title' },
+    { field: 'assignee', label: 'Assignee' },
+    { field: 'progress', label: 'Progress' },
+  ],
+  pagination: { pageSize: 50 },
+  // Legacy bare names: one resolves to a declared action, one doesn't.
+  bulkActions: ['bulk_recalc_estimate', 'legacy_only_handler'],
+};
+
+function Demo() {
+  const [log, setLog] = React.useState<LogEntry[]>([]);
+  pushLog = (e) => setLog(prev => [...prev, e]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <header style={{ padding: '12px 16px', borderBottom: '1px solid hsl(var(--border))' }}>
+        <h1 style={{ fontSize: 16, fontWeight: 600, margin: 0 }}>
+          Object-declared bulk actions — objectui#3002
+        </h1>
+        <p style={{ fontSize: 12, color: 'hsl(var(--muted-foreground))', margin: '4px 0 0' }}>
+          Select rows → the bar shows <b>Mark Done</b> (derived from the object&apos;s
+          <code> bulkEnabled: true</code>), <b>Recalculate Estimate</b> (legacy name promoted to
+          its declared action) and <b>Legacy Only Handler</b> (unresolvable, dispatched by name).
+        </p>
+      </header>
+
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <ObjectGrid schema={schema} dataSource={dataSource} />
+      </div>
+
+      <section
+        style={{
+          borderTop: '1px solid hsl(var(--border))',
+          padding: '8px 16px',
+          maxHeight: 200,
+          overflow: 'auto',
+          fontSize: 12,
+          fontFamily: 'ui-monospace, monospace',
+        }}
+      >
+        <div style={{ fontWeight: 600, marginBottom: 4 }} data-testid="log-count">
+          Action requests: {log.length}
+        </div>
+        {log.length === 0 && (
+          <div style={{ color: 'hsl(var(--muted-foreground))' }}>
+            (none yet — one line will appear per selected record)
+          </div>
+        )}
+        {log.map((e, i) => (
+          <div key={i} style={{ color: e.status === 200 ? 'inherit' : 'hsl(var(--destructive))' }}>
+            {e.status} {e.url} · record={e.recordId} · params={e.params}
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(
+  <I18nProvider resources={{ en }} language="en">
+    {/* A handler registered under a bare NAME — the compat path that legacy
+        `bulkActions` entries must keep working for. */}
+    <ActionProvider
+      handlers={{
+        legacy_only_handler: async () => {
+          pushLog({ url: '(runner handler)', recordId: 'all-selected', params: '{}', status: 200 });
+          return { success: true };
+        },
+      }}
+    >
+      <Demo />
+    </ActionProvider>
+  </I18nProvider>,
+);


### PR DESCRIPTION
#3002 的手工验证页，沿用仓库既有的 plugin 本地 vite demo 约定（`demo/index.html` 是 Import Wizard 的，`plugin-gantt/demo` 同理）。

```bash
pnpm --dir packages/plugin-grid exec vite demo --port 5198
```

然后打开 `http://localhost:5198/bulk-actions.html`（`.claude/launch.json` 里也加了 `grid-bulk-demo` 配置）。

## 为什么加这个

#3031 合并时只跑了 DOM 测试。这个 demo 让同一条链路能在**真实浏览器**里点出来：mock 边界以下全是真实栈 —— `ObjectGrid` / `BulkActionBar` / `BulkActionDialog` / `useBulkExecutor` / `ActionRunner`。只 mock 了两样：数据源（内存 store）和 `window.fetch`（把每条 action 请求打到页面底部的日志面板，于是逐记录 fan-out 直接可见）。

三条词汇全覆盖：

| 按钮 | 声明方式 | 修复前 |
|---|---|---|
| Mark Done | 对象 action `bulkEnabled: true`，没有任何 view 声明 | 按钮**根本不存在** |
| Recalculate Estimate | 对象声明了但没打标，view 用 legacy `bulkActions: [...]` 点名 | 派发 `{type: <名字>}`，从不执行 |
| Legacy Only Handler | 解析不到任何 action，仍按名字派发到 runner handler | 因为存在别的 def 而被**整个隐藏** |

`Recalculate Estimate` 带一个 `select` 参数，用来验证「参数只收一次」——对话框收集后随每条记录派发，runner 不会逐条再弹。记录 `t3` 固定返回 422，于是逐条归因（成功 4/5 + 错误行 + 重试 + 错误 CSV）可见，而不是一刀切的成功。

## 实测结果

- Mark Done：5 条请求 `/api/demo/mark-done`，`record=t1..t5` 各带自己的 `_rowRecord`；t3 → 422；结果面板「成功 4 / 5 · 失败 1」。
- Recalculate Estimate：参数步骤渲染出 spec 的 `options`/`defaultValue`；确认步骤汇总一次；5 条请求各带 `params={"basis":"points"}`。
- Legacy Only Handler：与两个 def 并排渲染，点击后命中注册的 runner handler。
- 浏览器控制台与 vite 服务端日志均无错误。

纯新增，不碰任何产品代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
