### PR TITLE
test(app-shell): ratchet the component-props-to-`any` cast that hid #3025's dead prop, and pin the schema.direction boundary

### DIFF
--- a/packages/app-shell/src/no-component-any-cast.ratchet.test.ts
+++ b/packages/app-shell/src/no-component-any-cast.ratchet.test.ts
@@ -1,0 +1,133 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#3025 ratchet (AGENTS.md Commandment #6 — "No `any`"). Same shape as
+ * the ADR-0054 and #2269 ratchets: runs in the gating `pnpm test` job and fails
+ * if the anti-pattern reappears.
+ *
+ * The bug this guards. Two call sites carried
+ * `const PanelGroup = ResizablePanelGroup as React.FC<any>`. The cast erased
+ * the component's props to `any`, so when react-resizable-panels v4 renamed
+ * `PanelGroup`'s `direction` prop to `orientation`, the stale `direction` kept
+ * type-checking against nothing — for a whole major version. It silently became
+ * a dead prop that React forwarded to the DOM as a stray attribute. Removing
+ * the casts is what turned it back into a hard `TS2322`.
+ *
+ * Both comments blamed the toolchain (vite-plugin-dts "not resolving the prop
+ * type correctly"; a prop that "does not always narrow cleanly in our TS
+ * config"). Neither was true. That is the real hazard here: a cast like this
+ * reads as a workaround for a tooling quirk while actually disabling the check
+ * that would have caught a breaking upstream rename.
+ *
+ * If this fails: do not widen a component's props to `any` to make an error go
+ * away. Read the dependency's current prop types — the prop was probably
+ * renamed or removed. If a genuinely-invalid prop must be passed, type the
+ * escape hatch narrowly (`as ComponentProps<typeof X> & { extra?: T }`), never
+ * with a blanket `any`.
+ *
+ * SCOPE — repo-wide over `packages/<pkg>/src` and `apps/<app>/src`, production
+ * sources only. Test files are excluded, both to match the existing ratchets
+ * and because this file necessarily contains the pattern in its own regex.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/app-shell/src  ->  repo root
+const repoRoot = path.resolve(here, '../../..');
+
+/**
+ * Banned: casting a value to a component type parameterised with `any`.
+ *
+ * Covers the three spellings that erase props identically — `FC`,
+ * `FunctionComponent`, `ComponentType` — with or without the `React.`
+ * qualifier, and tolerant of whitespace inside the type arguments.
+ */
+const COMPONENT_ANY_CAST =
+  /\bas\s+(?:React\.)?(?:FC|FunctionComponent|ComponentType)\s*<\s*any\s*>/;
+
+function collectSourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const name = entry.name;
+      if (name === 'node_modules' || name === 'dist' || name.startsWith('.wt-') || name === '.next') {
+        continue;
+      }
+      const full = path.join(dir, name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (/\.tsx?$/.test(name) && !/\.(test|spec)\.tsx?$/.test(name)) {
+        out.push(full);
+      }
+    }
+  };
+  for (const group of ['packages', 'apps']) {
+    const groupDir = path.join(repoRoot, group);
+    let pkgs: string[];
+    try {
+      pkgs = readdirSync(groupDir);
+    } catch {
+      continue;
+    }
+    for (const pkg of pkgs) {
+      const srcDir = path.join(groupDir, pkg, 'src');
+      try {
+        if (statSync(srcDir).isDirectory()) walk(srcDir);
+      } catch {
+        /* package has no src/ */
+      }
+    }
+  }
+  return out;
+}
+
+describe('objectui#3025 — no component-props-to-any cast ratchet', () => {
+  it('finds the repo sources (guards against a broken scan path)', () => {
+    // The repo has thousands of source files; if this collapses, the scan
+    // globs have gone stale and the ratchet would silently pass on nothing.
+    expect(collectSourceFiles().length).toBeGreaterThan(500);
+  });
+
+  it('detects the pattern it is meant to ban (guards against a dead regex)', () => {
+    // A ratchet whose regex silently stops matching is worse than no ratchet,
+    // so pin it against the exact casts #3025 removed, plus spelling variants.
+    for (const sample of [
+      'const PanelGroup = ResizablePanelGroup as React.FC<any>;',
+      'const X = Y as FC<any>',
+      'const X = Y as React.ComponentType< any >',
+      'const X = Y as FunctionComponent<any>',
+    ]) {
+      expect(COMPONENT_ANY_CAST.test(sample), sample).toBe(true);
+    }
+    // ...and must not fire on legitimate neighbours.
+    for (const ok of [
+      'const x = y as Record<string, any>',
+      'const x = y as ComponentProps<typeof Button>',
+      'const C: React.FC<Props> = (p) => null',
+    ]) {
+      expect(COMPONENT_ANY_CAST.test(ok), ok).toBe(false);
+    }
+  });
+
+  it('has zero component-props-to-any casts in production sources', () => {
+    const offenders: string[] = [];
+    for (const file of collectSourceFiles()) {
+      const src = readFileSync(file, 'utf8');
+      for (const line of src.split('\n')) {
+        if (COMPONENT_ANY_CAST.test(line)) {
+          offenders.push(`${path.relative(repoRoot, file)} :: ${line.trim()}`);
+        }
+      }
+    }
+    // If this fails: you widened a component's props to `any`. That disables
+    // the check that catches renamed/removed props across a dependency major —
+    // exactly how #3025's dead `direction` prop survived. Read the current
+    // prop types instead, or type the escape hatch narrowly. Do not allowlist.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/components/src/renderers/complex/resizable.tsx
+++ b/packages/components/src/renderers/complex/resizable.tsx
@@ -20,7 +20,13 @@ ComponentRegistry.register('resizable',
   ({ schema, className, ...props }: { schema: ResizableSchema; className?: string; [key: string]: any }) => {
     const panels = Array.isArray(schema.panels) ? schema.panels : [];
     return (
-      <ResizablePanelGroup 
+      <ResizablePanelGroup
+          /* `schema.direction` → `orientation` is a deliberate boundary
+             translation, not a leftover from the react-resizable-panels v3→v4
+             rename (#3025). `direction` is ObjectUI's own public authoring
+             vocabulary and appears in stored view metadata, so renaming it to
+             match the library's prop would break every saved `resizable`
+             schema. Keep the two names distinct and translate here. */
           orientation={(schema.direction || 'horizontal') as "horizontal" | "vertical"}
           className={className} 
           {...props}


### PR DESCRIPTION
Two follow-ups to #3025, both about stopping that bug from recurring rather than fixing anything new.

## 1. The ratchet

#3025 removed two `const PanelGroup = ResizablePanelGroup as React.FC<any>` casts. Those casts weren't incidental to the bug — **they caused it.** Erasing a component's props to `any` meant that when react-resizable-panels v4 renamed `direction` → `orientation`, the stale prop type-checked against nothing and survived an entire major version as a dead prop React forwarded to the DOM.

What makes this worth a gate rather than review vigilance is *how both casts were justified*:

> vite-plugin-dts may not resolve the direction prop type correctly

> react-resizable-panels' `direction` prop type does not always narrow cleanly in our TS config

Neither was true — v4's `GroupProps` has no `direction` key at all. **The cast reads as a workaround for a toolchain quirk while actually disabling the check that catches a breaking upstream rename.** That's precisely the kind of thing that gets re-added in good faith, by someone reasoning exactly as those two comments did.

Repo-wide over `packages/<pkg>/src` and `apps/<app>/src`, following the existing `*.ratchet.test.ts` shape (#2269, ADR-0054) so it runs in the gating `pnpm test` job. Covers `FC` / `FunctionComponent` / `ComponentType` parameterised with `any`, `React.`-qualified or not.

I chose a ratchet test over an ESLint rule deliberately: it matches existing house precedent, runs in a job that already gates, and needs no per-package ESLint config changes while the #2713 lint-gate sweep is still mid-flight.

**Current count is zero** — which is exactly why now is the moment to set the gate.

### It's tested against its own failure modes

A ratchet has two silent ways to become worthless: a scan path that finds nothing, and a regex that quietly stops matching. Both are pinned. The regex test asserts it fires on the exact casts #3025 removed plus spelling variants, **and** that it does *not* fire on legitimate neighbours:

```
as Record<string, any>            → not flagged
as ComponentProps<typeof Button>  → not flagged
const C: React.FC<Props> = …      → not flagged
```

### Proof it bites

Reintroducing the exact cast into `custom/navigation-overlay.tsx`:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+   "packages/components/src/custom/navigation-overlay.tsx :: const PanelGroup = ResizablePanelGroup as React.FC<any>;"
 Tests  1 failed | 2 passed (3)
```

Reverted after testing.

## 2. The `schema.direction` boundary comment

`renderers/complex/resizable.tsx:24` maps `schema.direction` onto the library's `orientation`. It looks exactly like a site #3025 missed — same prop name, same file family. It isn't: `direction` is ObjectUI's own **public authoring vocabulary** and appears in stored view metadata, so renaming it to match the library would break every saved `resizable` schema.

Documented in place, because the next person to grep for `direction` will land there and reach for the wrong fix.

## Verification

- New ratchet: 3 tests pass; fails correctly on reintroduction (above)
- Four sibling ratchets (`actions-envelope`, `flow-envelope`, `no-refresh-key-remount`, `adr0054`): 8 tests pass
- `resizable-orientation` + `form-field-panes`: 15 tests pass
- `pnpm --filter @object-ui/components type-check`: clean
- `eslint`: exit 0 (2 pre-existing `no-explicit-any` *warnings* in `complex/resizable.tsx` on lines I didn't touch — `[key: string]: any` in the props type and `panel: any` in the map; a props index signature is a different thing from a component cast, so the ratchet correctly ignores them)

No changeset — a test and a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)