### PR TITLE
fix(registry): prefix every namespaced key exactly once, in every namespace

### DIFF
--- a/.changeset/namespace-double-prefix-sweep.md
+++ b/.changeset/namespace-double-prefix-sweep.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/components": patch
+"@object-ui/console": patch
+---
+
+fix(registry): prefix every namespaced key exactly once, in every namespace
+
+objectui#3023 fixed eleven `record:*` blocks registered as
+`register('record:x', …, { namespace: 'record' })` — an already-prefixed name
+handed to a registry that prefixes it again, landing the block at
+`record:record:x` — and guarded that namespace alone. Twenty-two more were
+sitting in `action:` (5), `element:` (10) and `page:` (7), two of them
+(`page:header`, `element:divider`) curated public blocks.
+
+Checking one namespace is exactly what let them keep sitting there, so the
+guard now asks the whole registry rather than a prefix of it.
+
+Same fix as before: register the bare name and let `namespace` do the
+prefixing, with `skipFallback: true` so the fallback does not claim that bare
+name globally. It would otherwise take over `header`, `footer`, `sidebar`,
+`tabs`, `card`, `accordion`, `section`, `text`, `image`, `button`, `icon` —
+every one of which belongs to `ui:`. All 22 stay reachable exactly as
+`<namespace>:<name>`; the registry goes 522 keys to 500, and the contract is
+unchanged at 42/42.
+
+Found while probing why six curated Tier B primitives report no `inputs`. They
+do declare them — `vitest.setup.dom.tsx` registers simplified `text` / `image` /
+`html` / `grid` stubs that shadow the real registrations inside the test
+environment only. That shadowing is a separate question, left alone here; the
+doubled keys it turned up are not test-environment artifacts.

--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -202,14 +202,7 @@ describe('PUBLIC_BLOCKS ↔ console coverage (reverse direction)', () => {
   });
 
   it('registers each record:* block under one key, prefixed once', () => {
-    // `register('record:x', …, { namespace: 'record' })` prefixes an
-    // already-prefixed name: the block lands at `record:record:x` and stays
-    // reachable only through the un-namespaced fallback, which happens to spell
-    // `record:x`. Eleven blocks were registered that way. The contract hid it —
-    // `getPublicConfigs()` rewrites `type` to the curated tag — so nothing
-    // failed while the registry carried a phantom key per block.
     const keys = shippedRecordBlocks();
-    expect(keys.filter((k) => k.startsWith(`${NS}:${NS}:`))).toEqual([]);
     expect(keys.every((k) => k.startsWith(`${NS}:`))).toBe(true);
   });
 
@@ -222,6 +215,27 @@ describe('PUBLIC_BLOCKS ↔ console coverage (reverse direction)', () => {
       const bare = tag.slice(NS.length + 1);
       expect(ComponentRegistry.getMeta(bare)?.namespace ?? null).not.toBe(NS);
     }
+  });
+
+  it('prefixes every namespaced key exactly once, in every namespace', () => {
+    // `register('page:header', …, { namespace: 'page' })` hands an
+    // already-prefixed name to a registry that prefixes it again: the block
+    // lands at `page:page:header` and stays reachable only through the
+    // un-namespaced fallback, which happens to spell `page:header`. Nothing
+    // fails — `getPublicConfigs()` rewrites `type` to the curated tag — so the
+    // registry quietly carries a phantom key per block.
+    //
+    // objectui#3023 fixed the eleven in `record:` and guarded that namespace
+    // alone. Twenty-two more were sitting in `action:`, `element:` and `page:`,
+    // two of them (`page:header`, `element:divider`) curated public blocks.
+    // Checking one namespace is what let them keep sitting there, so this asks
+    // the whole registry.
+    const doubled = ComponentRegistry.getKnownTypes().filter((k) => {
+      const ns = ComponentRegistry.getMeta(k)?.namespace;
+      return !!ns && k.startsWith(`${ns}:${ns}:`);
+    });
+
+    expect(doubled).toEqual([]);
   });
 
   it('keeps the chatter alias identical to the block it aliases', () => {

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -282,8 +282,9 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
 
 ActionBarRenderer.displayName = 'ActionBarRenderer';
 
-ComponentRegistry.register('action:bar', ActionBarRenderer, {
+ComponentRegistry.register('bar', ActionBarRenderer, {
   namespace: 'action',
+  skipFallback: true,
   label: 'Action Bar',
   inputs: [
     { name: 'actions', type: 'object', label: 'Actions' },

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -175,8 +175,9 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
 
 ActionButtonRenderer.displayName = 'ActionButtonRenderer';
 
-ComponentRegistry.register('action:button', ActionButtonRenderer, {
+ComponentRegistry.register('button', ActionButtonRenderer, {
   namespace: 'action',
+  skipFallback: true,
   label: 'Action Button',
   inputs: [
     { name: 'name', type: 'string', label: 'Action Name' },

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -294,8 +294,9 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
 
 ActionGroupRenderer.displayName = 'ActionGroupRenderer';
 
-ComponentRegistry.register('action:group', ActionGroupRenderer, {
+ComponentRegistry.register('group', ActionGroupRenderer, {
   namespace: 'action',
+  skipFallback: true,
   label: 'Action Group',
   inputs: [
     { name: 'name', type: 'string', label: 'Group Name' },

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -130,8 +130,9 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
 
 ActionIconRenderer.displayName = 'ActionIconRenderer';
 
-ComponentRegistry.register('action:icon', ActionIconRenderer, {
+ComponentRegistry.register('icon', ActionIconRenderer, {
   namespace: 'action',
+  skipFallback: true,
   label: 'Action Icon',
   inputs: [
     { name: 'name', type: 'string', label: 'Action Name' },

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -220,8 +220,9 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
 
 ActionMenuRenderer.displayName = 'ActionMenuRenderer';
 
-ComponentRegistry.register('action:menu', ActionMenuRenderer, {
+ComponentRegistry.register('menu', ActionMenuRenderer, {
   namespace: 'action',
+  skipFallback: true,
   label: 'Action Menu',
   inputs: [
     { name: 'label', type: 'string', label: 'Trigger Label' },

--- a/packages/components/src/renderers/basic/data-list.tsx
+++ b/packages/components/src/renderers/basic/data-list.tsx
@@ -77,8 +77,9 @@ function DefinitionListRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:definition-list', DefinitionListRenderer, {
+ComponentRegistry.register('definition-list', DefinitionListRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Definition List',
   category: 'content',
 });
@@ -172,8 +173,9 @@ function RepeaterRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:repeater', RepeaterRenderer, {
+ComponentRegistry.register('repeater', RepeaterRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Repeater',
   category: 'content',
 });

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -92,8 +92,9 @@ function ElementTextRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:text', ElementTextRenderer, {
+ComponentRegistry.register('text', ElementTextRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Text',
   category: 'content',
 });
@@ -106,8 +107,9 @@ function ElementDividerRenderer({ schema }: { schema: any }) {
   return <Separator className={cn('my-4', schema?.className)} />;
 }
 
-ComponentRegistry.register('element:divider', ElementDividerRenderer, {
+ComponentRegistry.register('divider', ElementDividerRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Divider',
   category: 'content',
 });
@@ -155,8 +157,9 @@ function ElementImageRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:image', ElementImageRenderer, {
+ComponentRegistry.register('image', ElementImageRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Image',
   category: 'content',
 });
@@ -260,8 +263,9 @@ function ElementButtonRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:button', ElementButtonRenderer, {
+ComponentRegistry.register('button', ElementButtonRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Button',
   category: 'action',
 });
@@ -381,8 +385,9 @@ function ElementNumberRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:number', ElementNumberRenderer, {
+ComponentRegistry.register('number', ElementNumberRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Number',
   category: 'content',
 });

--- a/packages/components/src/renderers/basic/metadata-viewer.tsx
+++ b/packages/components/src/renderers/basic/metadata-viewer.tsx
@@ -379,8 +379,9 @@ export function ElementMetadataViewerRenderer({ schema }: { schema: any }) {
   }
 }
 
-ComponentRegistry.register('element:metadata_viewer', ElementMetadataViewerRenderer, {
+ComponentRegistry.register('metadata_viewer', ElementMetadataViewerRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Metadata Viewer',
   category: 'content',
 });

--- a/packages/components/src/renderers/basic/record-picker.tsx
+++ b/packages/components/src/renderers/basic/record-picker.tsx
@@ -173,8 +173,9 @@ function ElementRecordPickerRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:record_picker', ElementRecordPickerRenderer, {
+ComponentRegistry.register('record_picker', ElementRecordPickerRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Record Picker',
   category: 'input',
   inputs: [

--- a/packages/components/src/renderers/basic/text-input.tsx
+++ b/packages/components/src/renderers/basic/text-input.tsx
@@ -126,8 +126,9 @@ function ElementTextInputRenderer({ schema }: { schema: any }) {
   );
 }
 
-ComponentRegistry.register('element:text_input', ElementTextInputRenderer, {
+ComponentRegistry.register('text_input', ElementTextInputRenderer, {
   namespace: 'element',
+  skipFallback: true,
   label: 'Text Input',
   category: 'input',
   inputs: [

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -553,8 +553,9 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   );
 };
 
-ComponentRegistry.register('page:tabs', PageTabsRenderer, {
+ComponentRegistry.register('tabs', PageTabsRenderer, {
   namespace: 'page',
+  skipFallback: true,
   label: 'Page Tabs',
   category: 'layout',
   isContainer: true,
@@ -595,8 +596,9 @@ const PageCardRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   );
 };
 
-ComponentRegistry.register('page:card', PageCardRenderer, {
+ComponentRegistry.register('card', PageCardRenderer, {
   namespace: 'page',
+  skipFallback: true,
   label: 'Page Card',
   category: 'layout',
   isContainer: true,
@@ -675,8 +677,9 @@ const PageAccordionRenderer: React.FC<any> = ({ schema, className, ...props }) =
   );
 };
 
-ComponentRegistry.register('page:accordion', PageAccordionRenderer, {
+ComponentRegistry.register('accordion', PageAccordionRenderer, {
   namespace: 'page',
+  skipFallback: true,
   label: 'Page Accordion',
   category: 'layout',
   isContainer: true,
@@ -698,8 +701,9 @@ const PageSectionRenderer: React.FC<any> = ({ schema, className, ...props }) => 
   );
 };
 
-ComponentRegistry.register('page:section', PageSectionRenderer, {
+ComponentRegistry.register('section', PageSectionRenderer, {
   namespace: 'page',
+  skipFallback: true,
   label: 'Page Section',
   category: 'layout',
   isContainer: true,
@@ -1297,8 +1301,9 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   );
 };
 
-ComponentRegistry.register('page:header', PageHeaderRenderer, {
+ComponentRegistry.register('header', PageHeaderRenderer, {
   namespace: 'page',
+  skipFallback: true,
   label: 'Page Header',
   category: 'layout',
 });
@@ -1322,8 +1327,9 @@ const PageFooterRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   );
 };
 
-ComponentRegistry.register('page:footer', PageFooterRenderer, {
+ComponentRegistry.register('footer', PageFooterRenderer, {
   namespace: 'page',
+  skipFallback: true,
   label: 'Page Footer',
   category: 'layout',
   isContainer: true,
@@ -1345,8 +1351,9 @@ const PageSidebarRenderer: React.FC<any> = ({ schema, className, ...props }) => 
   );
 };
 
-ComponentRegistry.register('page:sidebar', PageSidebarRenderer, {
+ComponentRegistry.register('sidebar', PageSidebarRenderer, {
   namespace: 'page',
+  skipFallback: true,
   label: 'Page Sidebar',
   category: 'layout',
   isContainer: true,


### PR DESCRIPTION
#3023 fixed eleven `record:*` blocks registered as `register('record:x', …, { namespace: 'record' })` — an already-prefixed name handed to a registry that prefixes it again — and **guarded that namespace alone**. Twenty-two more were sitting elsewhere:

| namespace | doubled keys | includes |
|---|---|---|
| `element:` | 10 | **`element:divider`** (curated) |
| `page:` | 7 | **`page:header`** (curated) |
| `action:` | 5 | — |

Checking one namespace is exactly what let them keep sitting there, so the guard now asks the whole registry rather than a prefix of it.

## Fix

Same as before — register the bare name, let `namespace` do the prefixing, `skipFallback: true` so the fallback doesn't claim that bare name globally:

```diff
-ComponentRegistry.register('page:header', PageHeaderRenderer, {
+ComponentRegistry.register('header', PageHeaderRenderer, {
   namespace: 'page',
+  skipFallback: true,
```

`skipFallback` is doing real work here. Without it these 22 would take over `header`, `footer`, `sidebar`, `tabs`, `card`, `accordion`, `section`, `text`, `image`, `button`, `icon` as top-level tags — **every one of which belongs to `ui:`**. Verified after the change: all still owned by `ui`, none stolen.

| | before | after |
|---|---|---|
| registry keys | 522 | **500** |
| doubled keys | 22 | **0** |
| contract | 42/42 | **42/42** |
| `page:header` canonical | `page:page:header` | **`page:header`** |
| `element:divider` canonical | `element:element:divider` | **`element:divider`** |

Nothing in the repo referenced a doubled key.

## Guard generalized

The record-only doubled-prefix assertion is replaced by a registry-wide one. Verified by reverting a single registration:

```
AssertionError: expected [ 'element:element:divider' ] to deeply equal []
```

## What this came out of, and a correction

I went looking because six curated Tier B primitives (`grid`, `page:header`, `text`, `image`, `element:divider`, `html`) reported **no `inputs`** in the console contract.

**They do declare inputs.** `vitest.setup.dom.tsx` registers simplified `text` / `image` / `html` / `grid` stubs, and because the setup imports `@object-ui/components` first, the real registrations run and are then overwritten by the stubs — inside the test environment only. `text`, for one, really declares `content` (required) in `packages/components/src/renderers/basic/text.tsx`.

So the "missing inputs" was a test-environment artifact, not a product gap. That shadowing is a separate question and I've left it alone — but it does mean this file's picture of the contract is partly fiction for those four tags, which is worth knowing before anyone writes an assertion that depends on them.

The doubled keys the probe turned up along the way are **not** artifacts — they reproduce against the real registrations.

Full suite `737 passed | 1 skipped`, lint 0 errors, type-check 38/38, changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4mrr1ihhwnfEHFSWmGoMp)_