### PR TITLE
refactor: hand-copied checklists become derivations or gated inventories (#3017)

### DIFF
--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -37,6 +37,10 @@ import { decisionOutputDefs, decisionOutputParams, foldDecisionOutputs } from '.
 import { interpretActionResponse } from '../utils/actionResponse';
 import { interpretFlowResponse } from '../utils/flowResponse';
 import { useRecordBreadcrumbTitle } from '../context/NavigationContext';
+// Audit provenance renders as the one-line <RecordMetaFooter>; the other
+// framework-injected bookkeeping columns are hidden from the body outright.
+// Both sets are derived, not restated — see record-detail-system-fields.ts.
+import { AUDIT_FIELD_NAMES, HIDDEN_SYSTEM_FIELD_NAMES } from './record-detail-system-fields';
 import type { FeedItem } from '@object-ui/types';
 import type { ActionDef, ActionParamDef } from '@object-ui/core';
 import { useRecordApprovals, recordLockedByApproval } from '../hooks/useRecordApprovals';
@@ -106,27 +110,6 @@ export function resolveActionUser(
     ? { ...identity, systemPermissions: systemPermissions ?? [] }
     : identity;
 }
-
-/**
- * Audit field names auto-injected by the framework's `applySystemFields`.
- * Filtered out of the auto-generated body sections — they are rendered
- * separately as a single subtle one-line `<RecordMetaFooter>` (see
- * `@object-ui/plugin-detail`) so provenance stays discoverable without a
- * heavy "System Information" panel. The inline-edit drawer also hides
- * them via `DEFAULT_SYSTEM_FIELDS` in
- * `@object-ui/plugin-detail/RecordDetailDrawer`.
- */
-const AUDIT_FIELD_NAMES = new Set(['created_at', 'created_by', 'updated_at', 'updated_by']);
-
-/**
- * System/tenant fields that the framework auto-injects on every record but
- * which carry no business value on a detail page. Hidden from the
- * auto-generated sections. Authors who really want to surface one can
- * assign it to a `fieldGroups` group explicitly (explicit listing wins).
- */
-const HIDDEN_SYSTEM_FIELD_NAMES = new Set([
-  'organization_id', 'tenant_id', 'is_deleted', 'deleted_at',
-]);
 
 /**
  * Field-type signals that suggest a "secondary / system / metadata"

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-bridge.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-bridge.ts
@@ -18,41 +18,18 @@
  *    is destroyed.
  */
 
+import { DESIGNER_FIELD_TYPES } from '@object-ui/types';
 import type {
   DesignerFieldDefinition,
   DesignerFieldType,
 } from '@object-ui/types';
 
-/** Set of types the designer can edit losslessly. Keep in sync with FieldDesigner. */
-const DESIGNER_TYPES = new Set<DesignerFieldType>([
-  'text',
-  'textarea',
-  'number',
-  'boolean',
-  'date',
-  'datetime',
-  'time',
-  'select',
-  'email',
-  'phone',
-  'url',
-  'password',
-  'currency',
-  'percent',
-  'lookup',
-  'formula',
-  'autonumber',
-  'file',
-  'image',
-  'markdown',
-  'html',
-  'color',
-  'code',
-  'location',
-  'address',
-  'rating',
-  'slider',
-]);
+/**
+ * Set of types the designer can edit losslessly — derived from the canonical
+ * `DESIGNER_FIELD_TYPES` vocabulary rather than restated (objectui#3017), so
+ * this bridge and `FieldDesigner`'s palette cannot drift by construction.
+ */
+const DESIGNER_TYPES: ReadonlySet<DesignerFieldType> = new Set(DESIGNER_FIELD_TYPES);
 
 interface FrameworkFieldDef {
   type?: string;

--- a/packages/app-shell/src/views/record-detail-system-fields.test.ts
+++ b/packages/app-shell/src/views/record-detail-system-fields.test.ts
@@ -1,0 +1,51 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * **The detail page's system-field partition is derived, not restated**
+ * (objectui#3017). `HIDDEN_SYSTEM_FIELD_NAMES` used to hard-code four
+ * bookkeeping columns under a comment; it is now the spec's
+ * `FIELD_GROUP_SYSTEM_FIELDS` minus the audit set, so a system column the
+ * framework starts injecting tomorrow defaults to hidden instead of leaking
+ * into the auto-generated body sections until someone edits a hand list.
+ *
+ * What is worth asserting is that the partition stays a partition, and that
+ * the columns each side exists for are still on that side.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FIELD_GROUP_SYSTEM_FIELDS } from '@objectstack/spec/data';
+import { AUDIT_FIELD_NAMES, HIDDEN_SYSTEM_FIELD_NAMES } from './record-detail-system-fields';
+
+describe('record-detail system-field partition (objectui#3017)', () => {
+  it('audit ∪ hidden covers the spec vocabulary exactly — nothing leaks into the body', () => {
+    const union = [...AUDIT_FIELD_NAMES, ...HIDDEN_SYSTEM_FIELD_NAMES].sort();
+    expect(union).toEqual([...FIELD_GROUP_SYSTEM_FIELDS].sort());
+  });
+
+  it('audit and hidden are disjoint — a column gets one treatment, not two', () => {
+    for (const name of AUDIT_FIELD_NAMES) {
+      expect(HIDDEN_SYSTEM_FIELD_NAMES.has(name), `'${name}' is both footer-rendered and hidden`).toBe(false);
+    }
+  });
+
+  it('is not vacuous — the bookkeeping columns the hidden set exists for are still hidden', () => {
+    // If the spec dropped or renamed one of these, the derivation would
+    // silently stop hiding it and the column would surface as a raw field on
+    // every detail page. Fail loudly and make that a deliberate decision.
+    for (const name of ['organization_id', 'tenant_id', 'is_deleted', 'deleted_at']) {
+      expect(HIDDEN_SYSTEM_FIELD_NAMES.has(name), `'${name}' no longer derived as hidden — spec vocabulary moved?`).toBe(true);
+    }
+  });
+
+  it('provenance stays in the footer, never silently swallowed by the hidden set', () => {
+    for (const name of ['created_at', 'created_by', 'updated_at', 'updated_by']) {
+      expect(AUDIT_FIELD_NAMES.has(name)).toBe(true);
+    }
+  });
+});

--- a/packages/app-shell/src/views/record-detail-system-fields.ts
+++ b/packages/app-shell/src/views/record-detail-system-fields.ts
@@ -1,0 +1,37 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * How `RecordDetailView` partitions the framework-injected system columns
+ * (spec `FIELD_GROUP_SYSTEM_FIELDS`) between its two treatments:
+ *
+ *  - the four audit-provenance columns (`AUDIT_FIELD_NAMES`, single source in
+ *    `@object-ui/types`) are rendered as a single subtle one-line
+ *    `<RecordMetaFooter>` (see `@object-ui/plugin-detail`) so provenance stays
+ *    discoverable without a heavy "System Information" panel;
+ *  - every other system column is hidden from the auto-generated body
+ *    sections outright — tenancy / soft-delete bookkeeping carries no business
+ *    value on a detail page. Authors who really want to surface one can
+ *    assign it to a `fieldGroups` group explicitly (explicit listing wins).
+ *
+ * `HIDDEN_SYSTEM_FIELD_NAMES` is derived as spec-set minus audit-set rather
+ * than restated (objectui#3017): a system column the framework starts
+ * injecting tomorrow is bookkeeping until someone deliberately surfaces it,
+ * so it should default to hidden without waiting for a hand-list edit here.
+ * `record-detail-system-fields.test.ts` pins the partition's invariants.
+ */
+
+import { AUDIT_FIELD_NAMES } from '@object-ui/types';
+import { FIELD_GROUP_SYSTEM_FIELDS } from '@objectstack/spec/data';
+
+export { AUDIT_FIELD_NAMES };
+
+/** Framework-injected bookkeeping columns hidden from detail body sections. */
+export const HIDDEN_SYSTEM_FIELD_NAMES: ReadonlySet<string> = new Set(
+  [...FIELD_GROUP_SYSTEM_FIELDS].filter((name) => !AUDIT_FIELD_NAMES.has(name)),
+);

--- a/packages/plugin-designer/src/FieldDesigner.tsx
+++ b/packages/plugin-designer/src/FieldDesigner.tsx
@@ -102,11 +102,16 @@ const FIELD_TYPE_META: Record<DesignerFieldType, { label: string; Icon: React.FC
   slider: { label: 'Slider', Icon: SlidersHorizontal },
 };
 
-const ALL_FIELD_TYPES = Object.keys(FIELD_TYPE_META) as DesignerFieldType[];
-
 type FieldTypeCategory = 'text' | 'number' | 'date' | 'choice' | 'relation' | 'advanced';
 
-const FIELD_TYPE_CATEGORIES: Record<FieldTypeCategory, DesignerFieldType[]> = {
+/**
+ * Category partition of the designer vocabulary, driving the type filter and
+ * the drawer's type `<select>`. Exported (with {@link CATEGORY_ORDER}) so
+ * `fieldTypeCategories.test.ts` can assert it stays a complete partition of
+ * `DESIGNER_FIELD_TYPES` — a type added to the vocabulary but left out here
+ * would otherwise silently vanish from those pickers (objectui#3017).
+ */
+export const FIELD_TYPE_CATEGORIES: Record<FieldTypeCategory, DesignerFieldType[]> = {
   text: ['text', 'textarea', 'email', 'phone', 'url', 'password', 'markdown', 'html'],
   number: ['number', 'currency', 'percent', 'autonumber', 'rating', 'slider'],
   date: ['date', 'datetime', 'time'],
@@ -115,7 +120,7 @@ const FIELD_TYPE_CATEGORIES: Record<FieldTypeCategory, DesignerFieldType[]> = {
   advanced: ['formula', 'file', 'image', 'color', 'code', 'location', 'address'],
 };
 
-const CATEGORY_ORDER: FieldTypeCategory[] = ['text', 'number', 'date', 'choice', 'relation', 'advanced'];
+export const CATEGORY_ORDER: FieldTypeCategory[] = ['text', 'number', 'date', 'choice', 'relation', 'advanced'];
 
 
 // ============================================================================

--- a/packages/plugin-designer/src/MetadataFieldsPage.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.tsx
@@ -31,6 +31,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { DESIGNER_FIELD_TYPES } from '@object-ui/types';
 import type { DesignerFieldDefinition, DesignerFieldType } from '@object-ui/types';
 import { MetadataClient, type MetadataClientConfig } from '@object-ui/data-objectstack';
 import { FieldDesigner } from './FieldDesigner';
@@ -68,12 +69,8 @@ interface ServerObjectSchema {
   [key: string]: unknown;
 }
 
-const KNOWN_FIELD_TYPES = new Set<DesignerFieldType>([
-  'text', 'textarea', 'number', 'boolean', 'date', 'datetime', 'time', 'select',
-  'email', 'phone', 'url', 'password', 'currency', 'percent', 'lookup', 'formula',
-  'autonumber', 'file', 'image', 'markdown', 'html', 'color', 'code', 'location',
-  'address', 'rating', 'slider',
-]);
+// Derived from the canonical vocabulary rather than restated (objectui#3017).
+const KNOWN_FIELD_TYPES: ReadonlySet<DesignerFieldType> = new Set(DESIGNER_FIELD_TYPES);
 
 function toDesignerType(raw: string | undefined): DesignerFieldType {
   if (raw && KNOWN_FIELD_TYPES.has(raw as DesignerFieldType)) {

--- a/packages/plugin-designer/src/__tests__/fieldTypeCategories.test.ts
+++ b/packages/plugin-designer/src/__tests__/fieldTypeCategories.test.ts
@@ -1,0 +1,34 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FIELD_TYPE_CATEGORIES` partitions the designer vocabulary for the type
+ * filter and the drawer's type `<select>`. tsc guarantees every entry IS a
+ * `DesignerFieldType` (and that `FIELD_TYPE_META` covers the whole union),
+ * but nothing at compile time guarantees every type LANDS in a category — a
+ * freshly added type would silently be missing from those pickers. This is
+ * that gate (objectui#3017).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DESIGNER_FIELD_TYPES } from '@object-ui/types';
+import { CATEGORY_ORDER, FIELD_TYPE_CATEGORIES } from '../FieldDesigner';
+
+describe('FIELD_TYPE_CATEGORIES covers the designer vocabulary (objectui#3017)', () => {
+  const flattened = Object.values(FIELD_TYPE_CATEGORIES).flat();
+
+  it('every DesignerFieldType appears in exactly one category', () => {
+    expect(new Set(flattened).size, 'a type appears in two categories').toBe(flattened.length);
+    expect([...flattened].sort()).toEqual([...DESIGNER_FIELD_TYPES].sort());
+  });
+
+  it('CATEGORY_ORDER renders every category — a dropped entry hides its whole group', () => {
+    expect([...CATEGORY_ORDER].sort()).toEqual(Object.keys(FIELD_TYPE_CATEGORIES).sort());
+    expect(new Set(CATEGORY_ORDER).size).toBe(CATEGORY_ORDER.length);
+  });
+});

--- a/packages/plugin-detail/src/RecordMetaFooter.tsx
+++ b/packages/plugin-detail/src/RecordMetaFooter.tsx
@@ -9,19 +9,16 @@
 import * as React from 'react';
 import { cn, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@object-ui/components';
 import { getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
+import { AUDIT_FIELD_BY_ROLE } from '@object-ui/types';
 import type { FieldMetadata } from '@object-ui/types';
 import { useDetailTranslation } from './useDetailTranslation';
 
 /**
- * Audit field names auto-injected by the framework's `applySystemFields`.
- * Kept in sync with `AUDIT_FIELD_NAMES` in `RecordDetailView`.
+ * Audit field names auto-injected by the framework's `applySystemFields` —
+ * the shared vocabulary `RecordDetailView` also uses to keep these out of the
+ * body sections (single source in `@object-ui/types`, objectui#3017).
  */
-const AUDIT_FIELDS = {
-  createdAt: 'created_at',
-  createdBy: 'created_by',
-  updatedAt: 'updated_at',
-  updatedBy: 'updated_by',
-} as const;
+const AUDIT_FIELDS = AUDIT_FIELD_BY_ROLE;
 
 export interface RecordMetaFooterProps {
   /** The current record data; expected to contain audit fields when available. */

--- a/packages/plugin-grid/package.json
+++ b/packages/plugin-grid/package.json
@@ -29,6 +29,7 @@
     "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
+    "@objectstack/spec": "^17.0.0-rc.0",
     "@tanstack/react-virtual": "^3.14.8",
     "exceljs": "^4.4.0",
     "lucide-react": "^1.25.0"

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -13,6 +13,7 @@ import {
 import { Upload, FileSpreadsheet, CheckCircle2, AlertCircle, X, ArrowRight, ArrowLeft, Save, Trash2, ClipboardPaste, Download, Undo2 } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import { sanitizeFileNameBase } from '@object-ui/core';
+import { BOOLEAN_IMPORT_TOKENS, REFERENCE_IMPORT_TYPES } from './importCoercionContract';
 import type {
   DataSource,
   ImportRequestOptions,
@@ -360,21 +361,6 @@ const CONFIDENCE_CLASS: Record<MappingConfidence, string> = {
   medium: 'text-sky-600',
   low: 'text-muted-foreground',
 };
-
-/** Boolean tokens the server's import coercion accepts (import-coerce.ts).
- *  Kept in sync so the preview step doesn't flag a cell the server would take
- *  (e.g. Chinese 是/否, on/off, ✓/×). Compared case-insensitively. */
-const BOOLEAN_IMPORT_TOKENS = new Set([
-  'true', 't', 'yes', 'y', '1', 'on', '是', '对', '✓', '√',
-  'false', 'f', 'no', 'n', '0', 'off', '否', '错', '✗', '×',
-]);
-
-/** Field types the server resolves from display text to record IDs during
- *  `/import` (kept in step with the server's import-coerce REFERENCE_TYPES).
- *  The legacy per-row create fallback has no resolution step — raw cell text
- *  would be stored verbatim into relation fields — so the fallback must refuse
- *  to run when any mapped column targets one of these types. */
-const REFERENCE_IMPORT_TYPES = new Set(['lookup', 'master_detail', 'user', 'reference', 'tree']);
 
 /** Mapped fields whose type the legacy fallback cannot import safely. */
 function mappedReferenceFields(

--- a/packages/plugin-grid/src/hooks/multiValueFields.test.ts
+++ b/packages/plugin-grid/src/hooks/multiValueFields.test.ts
@@ -1,0 +1,47 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `isMultiValueField` consumes the spec's `MULTI_OPTION_TYPES` /
+ * `MULTI_CAPABLE_TYPES` instead of restating them (objectui#3017). The
+ * anchors below are the non-vacuity gate: if the spec vocabulary silently
+ * shrank, `normalizeMultiValuePatch` would stop wrapping lone scalars for
+ * that type and the column-shape corruption of #2204 would return — fail
+ * loudly here instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isMultiValueField, normalizeMultiValuePatch } from './multiValueFields';
+
+describe('isMultiValueField (spec-derived, objectui#3017)', () => {
+  it('always-multi option types stay covered', () => {
+    for (const type of ['multiselect', 'checkboxes', 'tags']) {
+      expect(isMultiValueField({ type }), `'${type}' no longer always-multi — spec vocabulary moved?`).toBe(true);
+    }
+  });
+
+  it('multi-capable types stay covered when flagged multiple', () => {
+    for (const type of ['select', 'radio', 'lookup', 'user', 'file', 'image']) {
+      expect(isMultiValueField({ type, multiple: true }), `'${type}' no longer multi-capable — spec vocabulary moved?`).toBe(true);
+      expect(isMultiValueField({ type }), `'${type}' must stay single-value without the flag`).toBe(false);
+    }
+  });
+
+  it('stays null-tolerant and conservative for everything else', () => {
+    expect(isMultiValueField(undefined)).toBe(false);
+    expect(isMultiValueField(null)).toBe(false);
+    expect(isMultiValueField({})).toBe(false);
+    expect(isMultiValueField({ type: 'text', multiple: true })).toBe(false);
+  });
+
+  it('normalizeMultiValuePatch still wraps a lone scalar for a spec-classified field', () => {
+    const fields = { assignees: { type: 'user', multiple: true } };
+    expect(normalizeMultiValuePatch({ assignees: 'u1' }, fields)).toEqual({ assignees: ['u1'] });
+    expect(normalizeMultiValuePatch({ assignees: ['u1'] }, fields)).toEqual({ assignees: ['u1'] });
+  });
+});

--- a/packages/plugin-grid/src/hooks/multiValueFields.ts
+++ b/packages/plugin-grid/src/hooks/multiValueFields.ts
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { MULTI_CAPABLE_TYPES, MULTI_OPTION_TYPES } from '@objectstack/spec/data';
+
 /**
  * Minimal object-schema field shape needed to decide single- vs multi-value
  * semantics. Matches the `fields` map served by the ObjectStack meta API
@@ -16,23 +18,19 @@ export interface MultiValueFieldDef {
   multiple?: boolean;
 }
 
-/** Types whose persisted value is ALWAYS an array of scalars. */
-const ALWAYS_MULTI_TYPES = new Set(['multiselect', 'checkboxes', 'tags']);
-
 /**
- * Types that become array-shaped when flagged `multiple: true`. Mirrors the
- * server-side write pipeline (framework #2552): per the spec, `multiple`
- * applies to select/lookup/file/image; `radio` shares the select semantics
- * and `user` is stored identically to `lookup` (the runtime expands
- * `Field.user` to `type: 'user'`, not `'lookup'`).
+ * Whether the given object-schema field stores an array of scalars.
+ *
+ * A null-tolerant wrapper over the spec's own classification (its
+ * `isMultiValueField` requires a def): `MULTI_OPTION_TYPES` are always
+ * array-shaped, `MULTI_CAPABLE_TYPES` become array-shaped when flagged
+ * `multiple: true` — the same sets the server-side write pipeline derives
+ * from (framework #2552), consumed instead of restated (objectui#3017).
  */
-const MULTI_CAPABLE_TYPES = new Set(['select', 'radio', 'lookup', 'user', 'file', 'image']);
-
-/** Whether the given object-schema field stores an array of scalars. */
 export function isMultiValueField(def: MultiValueFieldDef | undefined | null): boolean {
   const t = def?.type;
   if (!t) return false;
-  if (ALWAYS_MULTI_TYPES.has(t)) return true;
+  if (MULTI_OPTION_TYPES.has(t)) return true;
   return MULTI_CAPABLE_TYPES.has(t) && def?.multiple === true;
 }
 

--- a/packages/plugin-grid/src/importCoercionContract.test.ts
+++ b/packages/plugin-grid/src/importCoercionContract.test.ts
@@ -1,0 +1,90 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Gates on the Import Wizard's mirror of the server's import-coercion
+ * contract (`import-coerce.ts` in the framework) — objectui#3017.
+ *
+ * `REFERENCE_IMPORT_TYPES` is derived from the same spec constant the server
+ * derives from, so the two ends share one source. The boolean token table has
+ * no spec export yet (framework#3786), so it cannot be derived — the pinned
+ * inventory below is the tripwire that makes edits deliberate instead of
+ * silent. When the spec starts publishing the table, replace the local sets
+ * with the import and delete the inventory.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { REFERENCE_VALUE_TYPES } from '@objectstack/spec/data';
+import {
+  BOOLEAN_FALSE_IMPORT_TOKENS,
+  BOOLEAN_IMPORT_TOKENS,
+  BOOLEAN_TRUE_IMPORT_TOKENS,
+  REFERENCE_IMPORT_TYPES,
+} from './importCoercionContract';
+
+describe('BOOLEAN_IMPORT_TOKENS (server BOOL_TRUE/BOOL_FALSE mirror)', () => {
+  it('pins the token inventory — edits must be checked against the server table', () => {
+    // Deliberate second statement: if this fails you edited the wizard's
+    // boolean vocabulary. Verify the server's BOOL_TRUE/BOOL_FALSE in
+    // import-coerce.ts accepts the same tokens before re-pinning, or the
+    // preview will flag cells the server takes (or wave through cells it
+    // rejects as `invalid_boolean`).
+    expect([...BOOLEAN_TRUE_IMPORT_TOKENS].sort()).toEqual(
+      ['true', 't', 'yes', 'y', '1', 'on', '是', '对', '✓', '√'].sort(),
+    );
+    expect([...BOOLEAN_FALSE_IMPORT_TOKENS].sort()).toEqual(
+      ['false', 'f', 'no', 'n', '0', 'off', '否', '错', '✗', '×'].sort(),
+    );
+  });
+
+  it('true and false tokens are disjoint — one token, one verdict', () => {
+    for (const token of BOOLEAN_TRUE_IMPORT_TOKENS) {
+      expect(BOOLEAN_FALSE_IMPORT_TOKENS.has(token), `'${token}' is both truthy and falsy`).toBe(false);
+    }
+  });
+
+  it('every token survives the lookup normalization (trim + lowercase)', () => {
+    // validateValue checks `value.trim().toLowerCase()` against the set — a
+    // token stored with case or whitespace could never match anything.
+    for (const token of BOOLEAN_IMPORT_TOKENS) {
+      expect(token, `'${token}' is not trim/lowercase-normalized`).toBe(token.trim().toLowerCase());
+      expect(token.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('the combined set is exactly the union of the two verdict sets', () => {
+    expect(BOOLEAN_IMPORT_TOKENS.size).toBe(
+      BOOLEAN_TRUE_IMPORT_TOKENS.size + BOOLEAN_FALSE_IMPORT_TOKENS.size,
+    );
+    for (const token of [...BOOLEAN_TRUE_IMPORT_TOKENS, ...BOOLEAN_FALSE_IMPORT_TOKENS]) {
+      expect(BOOLEAN_IMPORT_TOKENS.has(token)).toBe(true);
+    }
+  });
+});
+
+describe('REFERENCE_IMPORT_TYPES (derived from spec REFERENCE_VALUE_TYPES)', () => {
+  it('is spec plus the generic reference alias, nothing else', () => {
+    for (const type of REFERENCE_VALUE_TYPES) {
+      expect(REFERENCE_IMPORT_TYPES.has(type)).toBe(true);
+    }
+    expect(REFERENCE_IMPORT_TYPES.has('reference')).toBe(true);
+    // Also implies 'reference' ∉ REFERENCE_VALUE_TYPES today — if the spec
+    // starts including it, this fails so the local alias can be retired.
+    expect(REFERENCE_IMPORT_TYPES.size).toBe(REFERENCE_VALUE_TYPES.size + 1);
+  });
+
+  it('is not vacuous — the types the legacy-fallback refusal exists for are still covered', () => {
+    // The per-row create fallback stores raw cell text verbatim; if a member
+    // vanished from the spec set, the wizard would silently stop refusing to
+    // fall back for that type and corrupt relation fields. Fail loudly and
+    // make the vocabulary change a deliberate review.
+    for (const type of ['lookup', 'master_detail', 'user', 'tree', 'reference']) {
+      expect(REFERENCE_IMPORT_TYPES.has(type), `'${type}' no longer covered — spec vocabulary moved?`).toBe(true);
+    }
+  });
+});

--- a/packages/plugin-grid/src/importCoercionContract.ts
+++ b/packages/plugin-grid/src/importCoercionContract.ts
@@ -1,0 +1,57 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The slice of the server's import-coercion contract (`import-coerce.ts` in
+ * the framework) that the Import Wizard's preview step re-checks client-side,
+ * so a cell is flagged red here exactly when the server would reject it —
+ * and never flagged for a value the server would take (objectui#3017).
+ */
+
+import { REFERENCE_VALUE_TYPES } from '@objectstack/spec/data';
+
+/**
+ * Truthy tokens the server's boolean coercion accepts (`BOOL_TRUE`), compared
+ * after `trim().toLowerCase()` — so every entry must already be lower-case
+ * and trimmed (`importCoercionContract.test.ts` enforces both, plus
+ * disjointness from the falsy set).
+ *
+ * The spec does not publish this table yet, so it cannot be derived — the
+ * paired inventory in the test is the tripwire that keeps edits deliberate
+ * (framework#3786 tracks exporting it from the source of truth).
+ */
+export const BOOLEAN_TRUE_IMPORT_TOKENS: ReadonlySet<string> = new Set([
+  'true', 't', 'yes', 'y', '1', 'on', '是', '对', '✓', '√',
+]);
+
+/** Falsy tokens the server's boolean coercion accepts (`BOOL_FALSE`). */
+export const BOOLEAN_FALSE_IMPORT_TOKENS: ReadonlySet<string> = new Set([
+  'false', 'f', 'no', 'n', '0', 'off', '否', '错', '✗', '×',
+]);
+
+/** Every boolean token the server accepts (e.g. Chinese 是/否, on/off, ✓/×). */
+export const BOOLEAN_IMPORT_TOKENS: ReadonlySet<string> = new Set([
+  ...BOOLEAN_TRUE_IMPORT_TOKENS,
+  ...BOOLEAN_FALSE_IMPORT_TOKENS,
+]);
+
+/**
+ * Field types the server resolves from display text to record IDs during
+ * `/import`. Derived exactly the way the server derives its
+ * `REFERENCE_TYPES` — the spec's reference-shaped value types plus the
+ * generic `'reference'` alias — so the two ends share one source instead of
+ * two hand lists.
+ *
+ * The legacy per-row create fallback has no resolution step — raw cell text
+ * would be stored verbatim into relation fields — so the fallback must refuse
+ * to run when any mapped column targets one of these types.
+ */
+export const REFERENCE_IMPORT_TYPES: ReadonlySet<string> = new Set([
+  ...REFERENCE_VALUE_TYPES,
+  'reference',
+]);

--- a/packages/types/src/__tests__/designer-field-types.test.ts
+++ b/packages/types/src/__tests__/designer-field-types.test.ts
@@ -1,0 +1,44 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * **`DESIGNER_FIELD_TYPES` is the single vocabulary source** (objectui#3017).
+ *
+ * `DesignerFieldType` is derived from this array, `FieldDesigner`'s
+ * `FIELD_TYPE_META` must cover it (total `Record`, so tsc gates that side),
+ * and app-shell's `object-fields-bridge` builds its editable-subset check
+ * from it. The inventory below is a deliberate second statement of the list:
+ * growing or shrinking the vocabulary is a two-file edit by design, so it
+ * cannot happen as a drive-by — the failure message routes the editor to the
+ * consumers that must be reviewed alongside it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DESIGNER_FIELD_TYPES } from '../index';
+
+const INVENTORY = [
+  'address', 'autonumber', 'boolean', 'code', 'color', 'currency', 'date',
+  'datetime', 'email', 'file', 'formula', 'html', 'image', 'location',
+  'lookup', 'markdown', 'number', 'password', 'percent', 'phone', 'rating',
+  'select', 'slider', 'text', 'textarea', 'time', 'url',
+] as const;
+
+describe('DESIGNER_FIELD_TYPES (canonical Field Designer vocabulary)', () => {
+  it('has no duplicate entries — a duplicate would silently shrink every derived Set', () => {
+    expect(new Set(DESIGNER_FIELD_TYPES).size).toBe(DESIGNER_FIELD_TYPES.length);
+  });
+
+  it('matches the checked-in inventory — vocabulary edits must be deliberate', () => {
+    // If this fails you changed the designer's type vocabulary. That is fine,
+    // but it is never only a types change: FieldDesigner needs presentation
+    // (FIELD_TYPE_META + FIELD_TYPE_CATEGORIES), the object-fields-bridge
+    // round-trip should be re-checked for the new/removed type, and this
+    // inventory re-pinned to acknowledge the review happened.
+    expect([...DESIGNER_FIELD_TYPES].sort()).toEqual([...INVENTORY]);
+  });
+});

--- a/packages/types/src/__tests__/system-fields.test.ts
+++ b/packages/types/src/__tests__/system-fields.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isSystemManagedField, SYSTEM_MANAGED_FIELD_NAMES } from '../index';
+import { FIELD_GROUP_SYSTEM_FIELDS } from '@objectstack/spec/data';
+import {
+  AUDIT_FIELD_BY_ROLE,
+  AUDIT_FIELD_NAMES,
+  isSystemManagedField,
+  SYSTEM_MANAGED_FIELD_NAMES,
+} from '../index';
 
 describe('isSystemManagedField', () => {
   it('treats fields flagged `system: true` as system-managed (the single source of truth)', () => {
@@ -40,5 +46,40 @@ describe('isSystemManagedField', () => {
     expect(SYSTEM_MANAGED_FIELD_NAMES.has('organization_id')).toBe(true);
     expect(SYSTEM_MANAGED_FIELD_NAMES.has('created_at')).toBe(true);
     expect(SYSTEM_MANAGED_FIELD_NAMES.has('name')).toBe(false);
+  });
+});
+
+describe('AUDIT_FIELD_BY_ROLE / AUDIT_FIELD_NAMES (single audit vocabulary, objectui#3017)', () => {
+  it('pins the four provenance columns — edits must be deliberate', () => {
+    // A deliberate second statement: RecordMetaFooter renders exactly these,
+    // RecordDetailView excludes exactly these from body sections, and the
+    // framework injects them via `applySystemFields`. Changing the list is a
+    // cross-surface decision, not a drive-by — re-pin after reviewing both
+    // consumers (and the framework's registry, which owns the wire names).
+    expect(AUDIT_FIELD_BY_ROLE).toEqual({
+      createdAt: 'created_at',
+      createdBy: 'created_by',
+      updatedAt: 'updated_at',
+      updatedBy: 'updated_by',
+    });
+    expect([...AUDIT_FIELD_NAMES].sort()).toEqual(
+      Object.values(AUDIT_FIELD_BY_ROLE).sort(),
+    );
+  });
+
+  it('stays within the display-oriented system-managed superset', () => {
+    for (const name of AUDIT_FIELD_NAMES) {
+      expect(SYSTEM_MANAGED_FIELD_NAMES.has(name), `${name} missing from SYSTEM_MANAGED_FIELD_NAMES`).toBe(true);
+    }
+  });
+
+  it('stays within the spec-published system-field vocabulary (cross-repo tripwire)', () => {
+    // FIELD_GROUP_SYSTEM_FIELDS is the spec's own list of the columns the
+    // framework injects. If the framework renames an audit column (say
+    // created_at → createdAt), the spec set moves and this fails — turning a
+    // silent cross-repo drift into a red test.
+    for (const name of AUDIT_FIELD_NAMES) {
+      expect(FIELD_GROUP_SYSTEM_FIELDS.has(name), `spec no longer lists '${name}' as a system field`).toBe(true);
+    }
   });
 });

--- a/packages/types/src/designer.ts
+++ b/packages/types/src/designer.ts
@@ -688,35 +688,48 @@ export interface ObjectManagerSchema extends BaseSchema {
 // Field Designer (Field Configuration Wizard)
 // ============================================================================
 
+/**
+ * Canonical, ordered list of field types the Field Designer supports.
+ *
+ * Single runtime source for every surface that enumerates the designer's
+ * vocabulary: `FieldDesigner` renders its palette in exactly this order (its
+ * `FIELD_TYPE_META` is a `Record<DesignerFieldType, …>`, so adding a member
+ * here without presentation is a compile error), and app-shell's
+ * `object-fields-bridge` derives its editable-subset check from it instead of
+ * restating the list (objectui#3017).
+ */
+export const DESIGNER_FIELD_TYPES = [
+  'text',
+  'textarea',
+  'number',
+  'boolean',
+  'date',
+  'datetime',
+  'time',
+  'select',
+  'email',
+  'phone',
+  'url',
+  'password',
+  'currency',
+  'percent',
+  'lookup',
+  'formula',
+  'autonumber',
+  'file',
+  'image',
+  'markdown',
+  'html',
+  'color',
+  'code',
+  'location',
+  'address',
+  'rating',
+  'slider',
+] as const;
+
 /** Supported field types in the Field Designer */
-export type DesignerFieldType =
-  | 'text'
-  | 'textarea'
-  | 'number'
-  | 'boolean'
-  | 'date'
-  | 'datetime'
-  | 'time'
-  | 'select'
-  | 'email'
-  | 'phone'
-  | 'url'
-  | 'password'
-  | 'currency'
-  | 'percent'
-  | 'lookup'
-  | 'formula'
-  | 'autonumber'
-  | 'file'
-  | 'image'
-  | 'markdown'
-  | 'html'
-  | 'color'
-  | 'code'
-  | 'location'
-  | 'address'
-  | 'rating'
-  | 'slider';
+export type DesignerFieldType = (typeof DESIGNER_FIELD_TYPES)[number];
 
 /** Select option for field designer */
 export interface DesignerFieldOption {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -438,7 +438,13 @@ export type {
 // System / audit / ownership field classification — runtime helper + name set,
 // used by default list-column derivation to keep framework-injected fields
 // (notably `owner_id`) out of the leading business columns.
-export { SYSTEM_MANAGED_FIELD_NAMES, isSystemManagedField } from './system-fields';
+export {
+  SYSTEM_MANAGED_FIELD_NAMES,
+  AUDIT_FIELD_BY_ROLE,
+  AUDIT_FIELD_NAMES,
+  isSystemManagedField,
+} from './system-fields';
+export type { AuditFieldName } from './system-fields';
 export { MANAGED_BY_BUCKETS } from './managed-by';
 export type { ManagedByBucket } from './managed-by';
 
@@ -607,6 +613,7 @@ export type {
 export {
   DASHBOARD_COLOR_VARIANTS,
   DASHBOARD_WIDGET_TYPES,
+  DESIGNER_FIELD_TYPES,
 } from './designer';
 
 // ============================================================================

--- a/packages/types/src/system-fields.ts
+++ b/packages/types/src/system-fields.ts
@@ -38,6 +38,33 @@ export const SYSTEM_MANAGED_FIELD_NAMES: ReadonlySet<string> = new Set<string>([
 ]);
 
 /**
+ * The four audit-provenance columns `applySystemFields` injects on every
+ * business object, keyed by display role.
+ *
+ * Single source for the surfaces that treat provenance specially
+ * (objectui#3017): `RecordMetaFooter` (`@object-ui/plugin-detail`) renders
+ * exactly these four as the one-line footer, and `RecordDetailView`
+ * (`@object-ui/app-shell`) excludes the same four from the auto-generated
+ * body sections so they only appear in that footer. The snake_case values are
+ * the wire names the framework stores — they are a strict subset of the
+ * spec's `FIELD_GROUP_SYSTEM_FIELDS` (asserted in `system-fields.test.ts`).
+ */
+export const AUDIT_FIELD_BY_ROLE = {
+  createdAt: 'created_at',
+  createdBy: 'created_by',
+  updatedAt: 'updated_at',
+  updatedBy: 'updated_by',
+} as const;
+
+/** Wire name of one audit-provenance column. */
+export type AuditFieldName = (typeof AUDIT_FIELD_BY_ROLE)[keyof typeof AUDIT_FIELD_BY_ROLE];
+
+/** {@link AUDIT_FIELD_BY_ROLE} as a set, for name-filtering call sites. */
+export const AUDIT_FIELD_NAMES: ReadonlySet<string> = new Set<string>(
+  Object.values(AUDIT_FIELD_BY_ROLE),
+);
+
+/**
  * Whether a field is a framework-managed system / audit / ownership column
  * rather than an author-declared business field.
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1977,6 +1977,9 @@ importers:
       '@object-ui/types':
         specifier: workspace:*
         version: link:../types
+      '@objectstack/spec':
+        specifier: ^17.0.0-rc.0
+        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
       '@tanstack/react-virtual':
         specifier: ^3.14.8
         version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1996,9 +1999,6 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
-      '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
       '@vitejs/plugin-react':
         specifier: ^6.0.4
         version: 6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
Closes #3017. 承 framework#3786 / objectstack#4120 的修法模板:**能派生就从唯一来源派生;确实无法派生的,加集合覆盖/不相交断言当闸门;闸门必须变异测试证明会红。**

Issue 六处中 #1/#2 已由 #3019 落地;本 PR 处理其余四处,并在加闸门过程中捞到**三处同种残留**(issue 表格之外)。

## 逐处修法

| # | 位置 | 修法 |
|:--|:---|:---|
| 3 | `object-fields-bridge.ts` `DESIGNER_TYPES` | `DesignerFieldType` 联合改为从新的运行时数组 `DESIGNER_FIELD_TYPES`(`@object-ui/types`)派生;bridge 直接 `new Set(DESIGNER_FIELD_TYPES)`。`FieldDesigner` 的 `FIELD_TYPE_META` 本就是 `Record<DesignerFieldType,…>`,词汇增删自动变编译错误;顺手删掉死代码 `ALL_FIELD_TYPES` |
| 4 | `RecordMetaFooter` `AUDIT_FIELDS` ↔ `RecordDetailView` `AUDIT_FIELD_NAMES` | 单一来源 `AUDIT_FIELD_BY_ROLE` / `AUDIT_FIELD_NAMES` 落在 `@object-ui/types`(两包公共底座;app-shell 不依赖 plugin-detail,反向也不行)。`RecordDetailView` 的 `HIDDEN_SYSTEM_FIELD_NAMES` 进一步改为 **spec `FIELD_GROUP_SYSTEM_FIELDS` − 审计集** 派生 —— framework 明天新注入的 bookkeeping 列默认隐藏,而不是漏进 detail 正文等人补清单 |
| 5 | `ImportWizard` `BOOLEAN_IMPORT_TOKENS` | spec 未导出 token 表,无法派生(framework#3786 跟踪)→ 拆成 true/false 两集,闸门:不相交 + trim/lowercase 归一化(查找路径依赖此性质)+ 清单钉扎(改动必须有意识地双处落笔) |
| 6 | `ImportWizard` `REFERENCE_IMPORT_TYPES` | 与服务端同一条派生链:spec `REFERENCE_VALUE_TYPES` + `'reference'`(新模块 `importCoercionContract.ts`);plugin-grid 新增 `@objectstack/spec` 运行时依赖 |
| +7 | `FieldDesigner` `FIELD_TYPE_CATEGORIES`/`CATEGORY_ORDER` | tsc 只保证成员合法,不保证**每个类型都落进某个类目**(新类型会悄悄从类型下拉里消失)→ 覆盖闸门:摊平后与 `DESIGNER_FIELD_TYPES` 集合相等、无重复、`CATEGORY_ORDER` 覆盖全部类目 |
| +8 | `MetadataFieldsPage` `KNOWN_FIELD_TYPES` | 又一份 27 型手抄(变异测试把它炸了出来)→ 派生自 `DESIGNER_FIELD_TYPES` |
| +9 | `multiValueFields.ts` 两个 Set | 与 spec `MULTI_OPTION_TYPES`/`MULTI_CAPABLE_TYPES` 逐项相同 → 直接消费 spec(保留 null 容错包装),锚点断言防词汇缩水复发 #2204 形状腐蚀 |

## 变异测试(闸门真的会红)

七处注入漂移(词汇删 `slider`、审计删 `updated_by`、hidden 派生偷排 `tenant_id`、布尔加 `'True'`/两侧同置 `'on'`、别名 `'reference'` 删除、`CATEGORY_ORDER` 掉 `date`):

- **13 个测试失败,分布在全部 5 个闸门文件**,逐项可归因;
- 编译闸门同步引爆:`FieldDesigner` TS2353/TS2322、`MetadataFieldsPage` TS2769、`RecordMetaFooter` TS2339;
- 回滚后 10 文件 102 断言全绿,5 包 type-check + lint 全绿。

## 行为不变

每个派生集与被替换清单**逐值相同**(hidden 集今天恰为原 4 项字面量;spec 词汇未来增长时行为按上表设计演化)。测试内的清单钉扎是有意的第二份陈述(照 #3032 ActionDef inventory / #4120 的登记表模式):它把「静默漂移」换成「红着的、指路的测试」。

沿途观察、**未**动的:`ObjectFieldInspector` 的 `SUMMARY_NUMERIC_TYPES` 是语义选择(可汇总类型)而非清单拷贝;`isPlausibleEmail`/`importJobUndoable` 等是算法镜像,不属本 issue 的清单模式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)