### PR TITLE
docs(grid): point the boolean-token retirement note at objectstack#4173

### DIFF
--- a/packages/plugin-grid/src/importCoercionContract.test.ts
+++ b/packages/plugin-grid/src/importCoercionContract.test.ts
@@ -12,7 +12,7 @@
  *
  * `REFERENCE_IMPORT_TYPES` is derived from the same spec constant the server
  * derives from, so the two ends share one source. The boolean token table has
- * no spec export yet (framework#3786), so it cannot be derived — the pinned
+ * no spec export yet (objectstack#4173), so it cannot be derived — the pinned
  * inventory below is the tripwire that makes edits deliberate instead of
  * silent. When the spec starts publishing the table, replace the local sets
  * with the import and delete the inventory.

--- a/packages/plugin-grid/src/importCoercionContract.ts
+++ b/packages/plugin-grid/src/importCoercionContract.ts
@@ -23,7 +23,7 @@ import { REFERENCE_VALUE_TYPES } from '@objectstack/spec/data';
  *
  * The spec does not publish this table yet, so it cannot be derived — the
  * paired inventory in the test is the tripwire that keeps edits deliberate
- * (framework#3786 tracks exporting it from the source of truth).
+ * (objectstack#4173 tracks exporting it from the source of truth).
  */
 export const BOOLEAN_TRUE_IMPORT_TOKENS: ReadonlySet<string> = new Set([
   'true', 't', 'yes', 'y', '1', 'on', '是', '对', '✓', '√',


### PR DESCRIPTION
纯注释改动,两行。

`importCoercionContract.ts` 及其测试的头注释原本指向 framework#3786 —— 那是「手抄 spec 清单」模式排查的**母 issue,已关闭**。这张布尔 token 表能被删掉的具体前置条件(spec 导出 `BOOL_TRUE`/`BOOL_FALSE`)跟踪在 [objectstack#4173](https://github.com/objectstack-ai/objectstack/issues/4173),指针改到那里,免得后来人顺着链接走进一个已关闭的 issue 而找不到退役路径。

无行为改动;`importCoercionContract.test.ts` 6 断言仍绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)