### PR TITLE
fix(scripts): --check reports real divergence instead of calling all 46 components "modified"

### DIFF
--- a/scripts/shadcn-sync.js
+++ b/scripts/shadcn-sync.js
@@ -229,7 +229,7 @@ async function checkComponent(name, manifest) {
   try {
     const localContent = await fs.readFile(localPath, 'utf-8');
     const localLines = localContent.split('\n').length;
-    
+
     // Fetch latest from registry
     try {
       const registryData = await fetchUrl(componentInfo.source);
@@ -237,20 +237,42 @@ async function checkComponent(name, manifest) {
       // a difference — the local file has already been through this transform.
       const shadcnContent = rewriteRegistryImports(registryData.files?.[0]?.content || '');
       const shadcnLines = shadcnContent.split('\n').length;
-      
-      // Simple heuristic: check if significantly different
-      const lineDiff = Math.abs(localLines - shadcnLines);
-      const isDifferent = lineDiff > 10 || localContent.includes('ObjectUI') || localContent.includes('data-slot');
-      
+
+      // `localOnlyLines` is directional — lines in the first argument that the
+      // second lacks — so calling it both ways answers the two questions that
+      // actually decide whether to sync: what would a sync DESTROY, and what
+      // would it GAIN?
+      //
+      // The previous heuristic (`lineDiff > 10 || includes('ObjectUI')`) could
+      // not answer either. Every synced file carries the ObjectUI header this
+      // script prepends, so the second clause was true for all 46 of them and
+      // `--check` reported the entire set as "modified" — no signal at all.
+      const localOnly = localOnlyLines(localContent, shadcnContent);
+      const upstreamOnly = localOnlyLines(shadcnContent, localContent);
+
+      let status;
+      let message;
+      if (localOnly.length > 0) {
+        // `--update` refuses these; the local lines would be deleted.
+        status = 'modified';
+        message = `${localOnly.length} local line(s) upstream lacks — --update would refuse`;
+        if (upstreamOnly.length > 0) message += `, ${upstreamOnly.length} upstream line(s) pending`;
+      } else if (upstreamOnly.length > 0) {
+        status = 'outdated';
+        message = `${upstreamOnly.length} upstream line(s) to pick up — safe to sync`;
+      } else {
+        status = 'synced';
+        message = 'Identical to upstream';
+      }
+
       return {
         name,
-        status: isDifferent ? 'modified' : 'synced',
+        status,
         localLines,
         shadcnLines,
-        lineDiff,
-        message: isDifferent ? 
-          `Modified (${lineDiff} lines difference)` : 
-          'Synced with Shadcn',
+        localOnly: localOnly.length,
+        upstreamOnly: upstreamOnly.length,
+        message,
       };
     } catch (fetchError) {
       return {
@@ -280,45 +302,59 @@ async function checkAllComponents() {
   
   const results = {
     synced: [],
+    outdated: [],
     modified: [],
     custom: [],
     error: [],
   };
-  
+
   for (const component of localComponents) {
     const result = await checkComponent(component, manifest);
     results[result.status].push(result);
-    
+
     const symbol = {
       synced: '✓',
+      outdated: '↑',
       modified: '⚠',
       custom: '●',
       error: '✗',
     }[result.status];
-    
+
     const color = {
       synced: 'green',
+      outdated: 'cyan',
       modified: 'yellow',
       custom: 'blue',
       error: 'red',
     }[result.status];
-    
+
     log(`${symbol} ${result.name.padEnd(25)} ${result.message}`, color);
   }
-  
+
   // Summary
   logSection('Summary');
-  log(`✓ Synced:   ${results.synced.length} components`, 'green');
-  log(`⚠ Modified: ${results.modified.length} components`, 'yellow');
-  log(`● Custom:   ${results.custom.length} components`, 'blue');
-  log(`✗ Errors:   ${results.error.length} components`, 'red');
-  
-  if (results.modified.length > 0) {
-    log('\nTo update a component:', 'cyan');
-    log('  node scripts/shadcn-sync.js --update <component-name>', 'dim');
-    log('  node scripts/shadcn-sync.js --update-all', 'dim');
+  log(`✓ Identical: ${results.synced.length} components`, 'green');
+  log(`↑ Outdated:  ${results.outdated.length} components (no local edits — safe to sync)`, 'cyan');
+  log(`⚠ Modified:  ${results.modified.length} components (local edits — --update refuses)`, 'yellow');
+  log(`● Custom:    ${results.custom.length} components (not tracked upstream)`, 'blue');
+  log(`✗ Errors:    ${results.error.length} components`, 'red');
+
+  // The actionable bucket: upstream moved and nothing local is at risk.
+  if (results.outdated.length > 0) {
+    log('\nSafe to sync now:', 'cyan');
+    log(`  node scripts/shadcn-sync.js --update ${results.outdated[0].name}`, 'dim');
+    if (results.outdated.length > 1) {
+      log(`  (${results.outdated.length} in total: ${results.outdated.map((r) => r.name).join(', ')})`, 'dim');
+    }
   }
-  
+
+  if (results.modified.length > 0) {
+    log('\nThese carry local edits a sync would delete:', 'yellow');
+    log(`  ${results.modified.map((r) => `${r.name}(${r.localOnly})`).join(', ')}`, 'dim');
+    log('  Port the edits onto the new upstream version by hand, or --force to', 'dim');
+    log('  take upstream as-is. `--diff <name>` shows both sides.', 'dim');
+  }
+
   return results;
 }
 


### PR DESCRIPTION
`--check` was structurally incapable of telling you anything. The heuristic:

```js
const isDifferent = lineDiff > 10 || localContent.includes('ObjectUI') || localContent.includes('data-slot');
```

Every synced file carries the ObjectUI header **this script prepends**, so the second clause was true for all 46 tracked components. `--check` reported the entire set as "modified", every run. That is the same as reporting nothing.

## Using the primitive #3035 already built

`localOnlyLines` is directional — lines in the first argument the second lacks. Calling it **both ways** answers the two questions that actually decide whether to sync:

- **what would a sync destroy?** → `localOnlyLines(local, upstream)`
- **what would it gain?** → `localOnlyLines(upstream, local)`

That replaces the heuristic and splits the old "modified" bucket into the two states that need different actions:

| | meaning | action |
|---|---|---|
| `↑ outdated` | upstream moved, no local edits | **safe to sync** |
| `⚠ modified` | local edits present | `--update` refuses |

Because `--check` and the write guard now call the same function, the counts `--check` shows are exactly the counts that will stop a write.

## What it says about this repo right now

```
✓ Identical: 29    ↑ Outdated: 0    ⚠ Modified: 17    ● Custom: 2
```

**Zero outdated is the headline.** Every component where upstream has moved *also* carries local edits — so there is currently no component `--update-all` could touch without deleting something. It has no safe work to do at all. That was completely invisible under the old output.

The summary also names the components per bucket with their counts, so triage doesn't need 46 `--diff` runs:

```
These carry local edits a sync would delete:
  badge(4), calendar(7), chart(11), command(35), context-menu(2), dropdown-menu(2),
  form(1), hover-card(1), menubar(2), popover(1), select(32), sheet(4), sidebar(24),
  slider(4), sonner(2), table(17), tooltip(1)
```

## Verification

Against the live registry:

- Counts reconcile: 46 tracked = 29 identical + 17 modified; +2 untracked files on disk = 48 local components
- Per-component numbers match the #3035 guard that enforces them (`command` 35, `select` 32, `sidebar` 24 …) — same function, both sides
- **The `outdated` bucket is the one real traffic never exercises** (it's 0), so I tested it by deleting a line from an identical component (`separator`). It flips to `↑ 1 upstream line(s) to pick up — safe to sync` and the summary offers the exact `--update separator` command. Restored after.
- `lineDiff` had no consumers outside the function that produced it
- `--list`, `--diff`, `--update`, and both the #3033 unmapped-path guard and #3035 local-edit guard regression-checked
- `--check` stays **exit 0** — it's a status report, and 17 locally-modified components is the steady state here, not a failure
- `eslint` clean; no component file changes

No changeset — tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)