### PR TITLE
fix(permissions,console): /me/permissions 的瞬时失败改为重试，不再把 console 钉在 spinner 上 (#3050)

### DIFF
--- a/.changeset/me-permissions-retry-transient.md
+++ b/.changeset/me-permissions-retry-transient.md
@@ -1,0 +1,47 @@
+---
+"@object-ui/permissions": minor
+"@object-ui/console": patch
+---
+
+fix(permissions,console): `MePermissionsProvider` retries a transient `/me/permissions` failure instead of stranding the app on its loading state
+
+"Not now" is a real answer from this endpoint. On a multi-tenant host it is served
+by the environment kernel that owns the session, and a COLD one answers `503` +
+`Retry-After` while it warms (objectstack#4159 / cloud#927). The provider treated
+that like any other failure: it set `error` — and a consumer that passes no
+`errorFallback` renders `loadingFallback` for the error state too. The console
+does exactly that (`loadingFallback={<LoadingScreen />}`, no `errorFallback`), so
+the app sat on its spinner indefinitely, with a `retry` nobody could reach.
+
+The fetch now re-attempts a **transient** failure — `408`, `425`, `429`, `502`,
+`503`, `504`, or a thrown fetch (offline / DNS / aborted), which never got an
+answer at all. A server-stated `Retry-After` wins over the exponential backoff
+(both wire forms are read, and clamped to 30s so a hostile value cannot park the
+UI); otherwise the delay doubles from `retryBaseDelayMs`. `loading` stays true
+across the waits, so the fail-closed loading state holds and consumers never see
+a permissive flash mid-recovery.
+
+Unchanged for a real answer about the caller: `401`, `403`, `404` and `500` fail
+on the first attempt exactly as before. `500` is deliberately not retried — a
+genuine server fault neither benefits from hammering nor should be hidden behind
+a spinner.
+
+**New props**, both optional and defaulted so no call site needs to change:
+
+- `maxRetries` (default `3`) — `0` restores the previous single-attempt
+  behaviour.
+- `retryBaseDelayMs` (default `500`) — base for the exponential backoff.
+
+Also fixes a latent race the retries made much wider: the in-flight fetch is now
+cancelled when the effect tears down, so a slow answer for a previous `endpoint`
+or `fetcher` can no longer overwrite a fast answer for the current one. The retry
+primitives (`parseRetryAfterMs`, `backoffMs`, `isTransientFailure`,
+`TRANSIENT_STATUS`, `PermissionsFetchError`) live in a new internal `./retry`
+module — not exported from the package root.
+
+**The console now passes an `errorFallback`.** Retrying narrows the window but
+cannot close it — a kernel build slower than the retry budget still lands in the
+error state, and rendering `loadingFallback` there is what produced the eternal
+spinner. It now renders `<LoadingScreen error={...} onRetry={retry} />`, using the
+error + retry affordance that component has carried all along, so a user is never
+left with a spinner and no way forward.

--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -132,7 +132,18 @@ export function AppContent() {
   // rendering fell open (restricted fields rendered editable).
   const authFetch = useMemo(() => createAuthenticatedFetch(), []);
   return (
-    <MePermissionsProvider endpoint={endpoint} fetcher={authFetch} loadingFallback={<LoadingScreen />}>
+    <MePermissionsProvider
+      endpoint={endpoint}
+      fetcher={authFetch}
+      loadingFallback={<LoadingScreen />}
+      // Without this, the provider's error state renders `loadingFallback` too —
+      // an eternal spinner with a `retry` nobody can reach. The provider already
+      // re-attempts a transient failure (a cold environment kernel answers 503 +
+      // `Retry-After` while it warms, objectstack#4159); this is what the user
+      // sees once those are exhausted, and `LoadingScreen` has carried the
+      // error + retry affordance all along.
+      errorFallback={(err, retry) => <LoadingScreen error={err.message} onRetry={retry} />}
+    >
       <LocalizationFetchProvider endpoint={localizationEndpoint}>
         <UploadProvider adapter={uploadAdapter}>
           <DefaultAppContent extraRoutes={systemRoutes} extraRoutesNoApp={systemRoutes} />

--- a/packages/permissions/src/MePermissionsProvider.tsx
+++ b/packages/permissions/src/MePermissionsProvider.tsx
@@ -7,6 +7,13 @@
  */
 
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import {
+  PermissionsFetchError,
+  backoffMs,
+  isTransientFailure,
+  parseRetryAfterMs,
+  sleep,
+} from './retry';
 import type {
   PermissionAction,
   PermissionCheckResult,
@@ -65,6 +72,27 @@ export interface MePermissionsProviderProps {
   loadingFallback?: React.ReactNode;
   /** Rendered when load fails */
   errorFallback?: (err: Error, retry: () => void) => React.ReactNode;
+  /**
+   * How many times to re-attempt a TRANSIENT failure before giving up — a
+   * response that says "not now" (`TRANSIENT_STATUS` in `./retry`) or a network
+   * error. `0` disables retrying.
+   *
+   * This exists because "not now" is a real answer from this endpoint. On a
+   * multi-tenant host it is served by the environment kernel that owns the
+   * session, and a cold one answers `503` + `Retry-After` while it warms
+   * (objectstack#4159). Without a retry the provider keeps `loadingFallback`
+   * on screen forever, because a consumer that passes no `errorFallback` — the
+   * console does exactly that — renders the loading node for the error state
+   * too, and nothing ever calls `retry`.
+   *
+   * @default 3
+   */
+  maxRetries?: number;
+  /**
+   * Base for the exponential backoff between retries, in ms. A `Retry-After`
+   * header on the response wins over it. @default 500
+   */
+  retryBaseDelayMs?: number;
   /** Children */
   children: React.ReactNode;
 }
@@ -88,34 +116,75 @@ export function MePermissionsProvider({
   initialPermissions,
   loadingFallback = null,
   errorFallback,
+  maxRetries = 3,
+  retryBaseDelayMs = 500,
   children,
 }: MePermissionsProviderProps) {
   const [data, setData] = useState<MePermissionsResponse | null>(initialPermissions ?? null);
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(!initialPermissions);
 
-  const fetchPermissions = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
+  /**
+   * Run the fetch, re-attempting a transient failure.
+   *
+   * `token` cancels an in-flight attempt. Retries put real time (a backoff, or
+   * a server-stated `Retry-After`) between the request and the `setState`, and
+   * during that window the effect may be torn down — by an unmount, or by
+   * `endpoint`/`fetcher` changing. Without the token a superseded attempt would
+   * still land, so a slow answer for the OLD endpoint could overwrite a fast
+   * answer for the new one.
+   */
+  const fetchPermissions = useCallback(
+    async (token?: { cancelled: boolean }) => {
+      const live = () => !token?.cancelled;
+      setLoading(true);
+      setError(null);
       const doFetch = fetcher ?? fetch;
-      const res = await doFetch(endpoint, {
-        credentials: 'include',
-        headers: { Accept: 'application/json' },
-      });
-      if (!res.ok) throw new Error(`Permissions endpoint returned ${res.status}`);
-      const json = (await res.json()) as MePermissionsResponse;
-      setData(json);
-    } catch (e) {
-      setError(e instanceof Error ? e : new Error(String(e)));
-    } finally {
-      setLoading(false);
-    }
-  }, [endpoint, fetcher]);
+      const attempts = Math.max(0, maxRetries) + 1;
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        try {
+          const res = await doFetch(endpoint, {
+            credentials: 'include',
+            headers: { Accept: 'application/json' },
+          });
+          if (!res.ok) {
+            throw new PermissionsFetchError(
+              res.status,
+              parseRetryAfterMs(res.headers?.get?.('Retry-After'), Date.now()),
+            );
+          }
+          const json = (await res.json()) as MePermissionsResponse;
+          if (!live()) return;
+          setData(json);
+          setLoading(false);
+          return;
+        } catch (e) {
+          const err = e instanceof Error ? e : new Error(String(e));
+          if (!isTransientFailure(err) || attempt === attempts - 1) {
+            if (!live()) return;
+            setError(err);
+            setLoading(false);
+            return;
+          }
+          // `loading` stays true across the wait, so the fail-closed loading
+          // state holds and the recovery is invisible to consumers.
+          const stated = err instanceof PermissionsFetchError ? err.retryAfterMs : undefined;
+          await sleep(backoffMs(attempt, retryBaseDelayMs, stated));
+          if (!live()) return;
+        }
+      }
+    },
+    [endpoint, fetcher, maxRetries, retryBaseDelayMs],
+  );
+
+  /** The `retry` handed to `errorFallback` — uncancelled, it is user-initiated. */
+  const retry = useCallback(() => { void fetchPermissions(); }, [fetchPermissions]);
 
   useEffect(() => {
     if (initialPermissions) return;
-    void fetchPermissions();
+    const token = { cancelled: false };
+    void fetchPermissions(token);
+    return () => { token.cancelled = true; };
   }, [fetchPermissions, initialPermissions]);
 
   const checkField = useCallback(
@@ -232,7 +301,7 @@ export function MePermissionsProvider({
 
   if (loading && !data) return <>{loadingFallback}</>;
   if (error && !data) {
-    if (errorFallback) return <>{errorFallback(error, fetchPermissions)}</>;
+    if (errorFallback) return <>{errorFallback(error, retry)}</>;
     return <>{loadingFallback}</>;
   }
 

--- a/packages/permissions/src/__tests__/MePermissionsProvider.retry.test.tsx
+++ b/packages/permissions/src/__tests__/MePermissionsProvider.retry.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * "Not now" is a real answer from `/me/permissions`, and it used to strand the
+ * console.
+ *
+ * On a multi-tenant host the endpoint is served by the environment kernel that
+ * owns the session, and a COLD one answers `503` + `Retry-After` while it warms
+ * (objectstack#4159 / cloud#927). The provider treated that like any other
+ * failure: it set `error`, and a consumer that passes no `errorFallback` — the
+ * console passes only `loadingFallback={<LoadingScreen />}` — renders the
+ * loading node for the error state too. So the app sat on its spinner forever,
+ * with a `retry` nobody could reach.
+ *
+ * These pin the retry: transient answers are re-attempted (server-stated delay
+ * first), real answers about the caller are not, and the fail-closed loading
+ * state holds throughout rather than flashing permissive.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MePermissionsProvider } from '../MePermissionsProvider';
+import { parseRetryAfterMs } from '../retry';
+import { usePermissions } from '../usePermissions';
+
+function Probe() {
+  const { isLoaded, check } = usePermissions();
+  return (
+    <div>
+      <span data-testid="loaded">{String(isLoaded)}</span>
+      <span data-testid="edit">{String(check('account', 'update').allowed)}</span>
+    </div>
+  );
+}
+
+const PAYLOAD = {
+  authenticated: true,
+  userId: 'u1',
+  tenantId: 't1',
+  roles: [],
+  permissionSets: ['member_default'],
+  objects: { account: { allowRead: true, allowEdit: false } },
+  fields: {},
+};
+
+const ok = () => ({ ok: true, status: 200, headers: new Headers(), json: async () => PAYLOAD });
+const fail = (status: number, headers: Record<string, string> = {}) => ({
+  ok: false,
+  status,
+  headers: new Headers(headers),
+  json: async () => ({}),
+});
+
+/** Render with retries fast enough that the tests need no timer control. */
+const renderProvider = (props: Record<string, unknown> = {}) =>
+  render(
+    <MePermissionsProvider retryBaseDelayMs={1} {...props}>
+      <Probe />
+    </MePermissionsProvider>,
+  );
+
+describe('MePermissionsProvider retries a transient failure', () => {
+  beforeEach(() => { vi.spyOn(global, 'fetch' as any); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('recovers from a warming 503 and serves the real answer', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce(fail(503, { 'Retry-After': '0' }))
+      .mockResolvedValueOnce(ok());
+
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId('loaded').textContent).toBe('true'));
+    // The permission answer really arrived — not the anonymous fail-open.
+    expect(screen.getByTestId('edit').textContent).toBe('false');
+    expect((global.fetch as any)).toHaveBeenCalledTimes(2);
+  });
+
+  it('prefers the server-stated Retry-After over its own backoff', async () => {
+    // Timer-free proof: the backoff base is 100s, so if the header were ignored
+    // this test could not finish. `Retry-After: 0` says "now".
+    (global.fetch as any)
+      .mockResolvedValueOnce(fail(503, { 'Retry-After': '0' }))
+      .mockResolvedValueOnce(ok());
+
+    renderProvider({ retryBaseDelayMs: 100_000 });
+
+    await waitFor(() => expect(screen.getByTestId('loaded').textContent).toBe('true'));
+  });
+
+  it('retries a thrown fetch (offline / DNS / aborted) too', async () => {
+    (global.fetch as any)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(ok());
+
+    renderProvider();
+
+    await waitFor(() => expect(screen.getByTestId('loaded').textContent).toBe('true'));
+  });
+
+  it('holds the fail-closed loading state while retrying — never a permissive flash', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce(fail(503))
+      .mockResolvedValueOnce(fail(503))
+      .mockResolvedValueOnce(ok());
+
+    renderProvider({ loadingFallback: <span data-testid="spinner" /> });
+
+    // Children (and therefore any permissive default) are not rendered yet.
+    expect(screen.getByTestId('spinner')).toBeTruthy();
+    expect(screen.queryByTestId('loaded')).toBeNull();
+    await waitFor(() => expect(screen.getByTestId('loaded').textContent).toBe('true'));
+  });
+
+  it('gives up after maxRetries and surfaces the error', async () => {
+    (global.fetch as any).mockResolvedValue(fail(503));
+
+    const errorFallback = vi.fn((err: Error) => <span data-testid="err">{err.message}</span>);
+    renderProvider({ maxRetries: 2, errorFallback });
+
+    await waitFor(() => expect(screen.getByTestId('err')).toBeTruthy());
+    expect(screen.getByTestId('err').textContent).toContain('503');
+    expect((global.fetch as any)).toHaveBeenCalledTimes(3); // 1 attempt + 2 retries
+  });
+});
+
+describe('MePermissionsProvider does NOT retry a real answer about the caller', () => {
+  beforeEach(() => { vi.spyOn(global, 'fetch' as any); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it.each([401, 403, 404, 500])('gives up immediately on %i', async (status) => {
+    (global.fetch as any).mockResolvedValue(fail(status));
+
+    const errorFallback = vi.fn((err: Error) => <span data-testid="err">{err.message}</span>);
+    renderProvider({ errorFallback });
+
+    await waitFor(() => expect(screen.getByTestId('err')).toBeTruthy());
+    expect((global.fetch as any)).toHaveBeenCalledTimes(1);
+  });
+
+  it('maxRetries: 0 disables retrying entirely', async () => {
+    (global.fetch as any).mockResolvedValue(fail(503));
+
+    const errorFallback = vi.fn((err: Error) => <span data-testid="err">{err.message}</span>);
+    renderProvider({ maxRetries: 0, errorFallback });
+
+    await waitFor(() => expect(screen.getByTestId('err')).toBeTruthy());
+    expect((global.fetch as any)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  const NOW = Date.parse('2026-07-30T12:00:00Z');
+
+  it('reads delta-seconds', () => {
+    expect(parseRetryAfterMs('4', NOW)).toBe(4000);
+    expect(parseRetryAfterMs('0', NOW)).toBe(0);
+    expect(parseRetryAfterMs('  7  ', NOW)).toBe(7000);
+  });
+
+  it('reads an HTTP-date, relative to now', () => {
+    expect(parseRetryAfterMs('Thu, 30 Jul 2026 12:00:03 GMT', NOW)).toBe(3000);
+  });
+
+  it('clamps a far-future value so it cannot park the UI', () => {
+    expect(parseRetryAfterMs('999999', NOW)).toBe(30_000);
+    expect(parseRetryAfterMs('Fri, 31 Jul 2026 12:00:00 GMT', NOW)).toBe(30_000);
+  });
+
+  it('ignores absent, empty, unparseable and past values', () => {
+    for (const v of [null, undefined, '', '   ', 'soon', 'Thu, 30 Jul 2026 11:59:00 GMT']) {
+      expect(parseRetryAfterMs(v, NOW), String(v)).toBeUndefined();
+    }
+  });
+});

--- a/packages/permissions/src/retry.ts
+++ b/packages/permissions/src/retry.ts
@@ -1,0 +1,83 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retry primitives for {@link MePermissionsProvider}'s `/me/permissions` fetch.
+ *
+ * Their own module rather than the component's: they are plain functions with
+ * plain tests, and a component file that also exports helpers breaks fast
+ * refresh.
+ */
+
+/** Upper bound on any single backoff wait, so a bad `Retry-After` cannot park the UI. */
+export const MAX_RETRY_DELAY_MS = 30_000;
+
+/**
+ * Statuses that mean "not now", so retrying can succeed without anything
+ * changing on the caller's side:
+ *
+ *  - `408` / `425` — the request itself did not land.
+ *  - `429` — rate limited; `Retry-After` usually accompanies it.
+ *  - `502` / `503` / `504` — the upstream is absent, warming or timing out.
+ *    `503` is the load-bearing one here: on a multi-tenant host this endpoint is
+ *    served by the environment kernel that owns the session, and the framework
+ *    answers `503` + `Retry-After` while a cold one is still being built
+ *    (objectstack#4159).
+ *
+ * Deliberately NOT retried: `401` / `403` (a real answer about this caller),
+ * `404` (no such endpoint — retrying cannot conjure one) and `500` (a genuine
+ * server fault; hammering it neither helps nor is honest about the failure).
+ */
+export const TRANSIENT_STATUS: ReadonlySet<number> = new Set([408, 425, 429, 502, 503, 504]);
+
+/** An `Error` that also carries the HTTP status it came from. */
+export class PermissionsFetchError extends Error {
+  constructor(readonly status: number, readonly retryAfterMs?: number) {
+    super(`Permissions endpoint returned ${status}`);
+    this.name = 'PermissionsFetchError';
+  }
+}
+
+/**
+ * Whether a failed attempt is worth re-attempting. A THROWN fetch (offline,
+ * DNS, aborted connection) is transient the same way a `503` is — the request
+ * never got an answer at all.
+ */
+export function isTransientFailure(err: unknown): boolean {
+  return err instanceof PermissionsFetchError ? TRANSIENT_STATUS.has(err.status) : true;
+}
+
+/**
+ * `Retry-After` in ms, or `undefined` when absent/unparseable. Accepts both wire
+ * forms (delta-seconds and an HTTP-date) and clamps to {@link MAX_RETRY_DELAY_MS}
+ * so a hostile or buggy value cannot park the UI on its loading state for hours.
+ */
+export function parseRetryAfterMs(value: string | null | undefined, nowMs: number): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  let ms: number;
+  if (/^\d+$/.test(trimmed)) {
+    ms = Number(trimmed) * 1000;
+  } else {
+    const at = Date.parse(trimmed);
+    if (Number.isNaN(at)) return undefined;
+    ms = at - nowMs;
+  }
+  if (!Number.isFinite(ms) || ms < 0) return undefined;
+  return Math.min(ms, MAX_RETRY_DELAY_MS);
+}
+
+/** How long to wait before attempt `attempt + 1`. A server-stated delay wins. */
+export function backoffMs(attempt: number, baseDelayMs: number, statedMs?: number): number {
+  if (statedMs !== undefined) return statedMs;
+  return Math.min(baseDelayMs * 2 ** attempt, MAX_RETRY_DELAY_MS);
+}
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Closes #3050。在实施 objectstack#4159 / cloud#927 时发现并核实 —— 那两个改动让 `503` 成为这条端点的**常规答案**，于是这个既有缺口从"偶发"变成"结构性会发生"。

## 问题

`MePermissionsProvider` 取失败时只置 `error`，而渲染分支是：

```tsx
if (error && !data) {
  if (errorFallback) return <>{errorFallback(error, fetchPermissions)}</>;
  return <>{loadingFallback}</>;      // ← 没传 errorFallback 时，错误态也渲染 loading 节点
}
```

`apps/console/src/AppContent.tsx` 恰恰**只传 `loadingFallback`**。两条合起来：**任何一次取失败 → console 永远停在 LoadingScreen**，而那个本该救场的 `retry` 参数没有任何路径能被调用到。

objectstack#4159 之后，多租户宿主上这条由环境 kernel 应答，**冷 kernel** 返回 `503` + `Retry-After`（cloud `KernelWarmingError`，默认 `retryAfterSeconds = 15`）。所以：租户环境冷启动期间打开 console → 白屏 spinner，且不会自愈。

## 改法：两处都改，单修任一处都不够

**① `MePermissionsProvider` 重试瞬时失败。**

| 状态 | 处理 |
|:---|:---|
| `408` / `425` | 请求本身没落地 → 重试 |
| `429` | 限流，通常带 `Retry-After` → 重试 |
| `502` / `503` / `504` | 上游缺席／预热中／超时 → 重试（**`503` 是这里的承重项**） |
| 抛出的 fetch（离线/DNS/连接中断） | 压根没拿到答案 → 重试 |
| `401` / `403` / `404` / `500` | 关于调用者的**真实答案** → 第一次就失败，与改动前一致 |

`500` 刻意不重试：真实的服务端故障，猛敲既没用也不诚实。

服务端给的 `Retry-After` 优先于指数退避（两种 wire 形式都读，并夹到 30s 上限 —— 否则一个恶意或错误的值能把 UI 钉住几小时）。**重试期间 `loading` 保持 `true`**，所以 fail-closed 状态不会闪出宽松默认，恢复过程对消费者完全不可见。

新增两个 prop，都有默认值，**没有任何调用点需要改**：`maxRetries`（默认 `3`，传 `0` 恢复旧的单次行为）、`retryBaseDelayMs`（默认 `500`）。

**② console 传 `errorFallback`。** 重试只能收窄窗口、不能关闭它：kernel 构建比重试预算还慢时仍会落到错误态，而在那里渲染 `loadingFallback` 正是永久 spinner 的成因。现在渲染 `<LoadingScreen error={...} onRetry={retry} />` —— `LoadingScreen` 本来就有 `error` / `onRetry` / `retrying` 三个 props，一直没人接。

## 顺带修掉的既有竞态

`fetchPermissions` 没有取消机制：`endpoint` / `fetcher` 变化时，旧请求的慢响应会覆盖新请求的快响应。加了重试（中间隔着真实等待）后这个窗口显著变宽，改用 per-effect 取消令牌处理掉。

## 关于实现形态（一处自我推翻）

第一版用 `mounted` ref 做卸载守卫，引入了两条**新的** lint 警告（`react-hooks/refs`、`react-refresh/only-export-components`）。没有去抑制它们，而是按它们指的方向重构：

- 重试原语（`parseRetryAfterMs` / `backoffMs` / `isTransientFailure` / `TRANSIENT_STATUS` / `PermissionsFetchError`）抽到内部 `./retry` 模块 —— 纯函数、纯测试，且组件文件同时导出助手会破坏 fast refresh。**不从包根导出**；
- ref 换成 per-effect 取消令牌 —— 顺带就修好了上面那个竞态。

lint 回到该文件改动前的基线（0 error，无新增警告）。

## 验证

| 范围 | 结果 |
|:---|:---|
| `pnpm type-check`（全仓） | **78/78** |
| `packages/permissions` | 107 passed |
| `apps/console` | 107 passed |
| 新增重试用例 | **14 passed** |
| 改动文件 eslint | 0 error，**无新增警告** |

新增 14 例：

- 从预热 `503` 恢复，并拿到**真实**权限答案（不是匿名 fail-open）；
- **`Retry-After` 优先于自己的退避** —— 无需操控计时器即可证明：退避基数设成 100s，若不采用 header 该用例根本跑不完；
- 抛出的 fetch 同样重试；
- 重试期间**保持 fail-closed loading**，children 不渲染（不会闪出宽松默认）；
- 用尽 `maxRetries` 后暴露错误，且 fetch 次数恰为 `1 + maxRetries`；
- `401/403/404/500` 各自只调用一次 fetch；
- `maxRetries: 0` 完全关闭重试；
- `parseRetryAfterMs` 覆盖 delta-seconds、HTTP-date、夹取上限，以及所有不可解析/过期输入。

> 全量 `pnpm test`（基线 746 files / 8651 tests）正在跑，结果出来我会更新在这里；上面四项已覆盖本 PR 触及的全部包。

## 关联

- #3050（本 PR 关闭）；
- objectstack#4159 / cloud#927（让 `503` 成为常规答案）、cloud#924 / cloud#928。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gEeLZ4oTeSXG6fKG1r3vd


---
_Generated by [Claude Code](https://claude.ai/code/session_016gEeLZ4oTeSXG6fKG1r3vd)_