### PR TITLE
fix(grid): 删掉 `bulkEnabled` 推导 —— 这个 spec key 已是墓碑 (#3002)

### DIFF
--- a/.changeset/bulk-enabled-is-a-tombstone.md
+++ b/.changeset/bulk-enabled-is-a-tombstone.md
@@ -1,0 +1,42 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/types": patch
+"@object-ui/app-shell": patch
+---
+
+fix(grid): drop the `bulkEnabled` derivation — the spec key is a tombstone
+
+Follow-up to objectui#3002 / #3031. That change folded two sources into the
+selection bar: a view's `bulkActions` names resolved against
+`objectDef.actions`, and object actions declaring `ActionSchema.bulkEnabled`.
+The second source is dead.
+
+`@objectstack/spec` 17.0.0 retired `action.bulkEnabled` in the #3896 audit
+close-out (framework#4054, landed while #3031 was in flight — the spec source
+still carried the key when its design was settled). It is now a `retiredKey()`
+tombstone, so it is not merely ignored: `defineStack` **hard-rejects** a config
+that sets it, and the backend refuses to boot. Browser verification against a
+real showcase backend is what surfaced this — the derivation branch could never
+run, and #3031's changeset pointed authors at a key that breaks their app.
+
+The tombstone's own prescription is the path that survives:
+
+> the multi-select toolbar is driven by the LIST VIEW's `bulkActions` /
+> `bulkActionDefs`, never by this flag … declare the action in the view's
+> `bulkActions` instead.
+
+So `resolveBulkActions` now folds exactly two vocabularies — inline-authored
+`bulkActionDefs`, and `bulkActions` names promoted to their declared object
+action — which is what #3031's other half already did and what the end-to-end
+run exercised: naming `showcase_mark_done` in the view's `bulkActions` issued
+one `POST /api/v1/actions/showcase_task/showcase_mark_done` per selected
+record (10/10 → `done: true, progress: 100` server-side). Everything downstream
+of the fold is unchanged: promoted defs still carry the action's label, icon,
+`visible`, confirm text and params; still run through `BulkActionDialog`
+(params → confirm → progress → result); still dispatch per record with
+`_rowRecord` attached; still attribute failures per record.
+
+A stale `bulkEnabled: true` on an object action is now inert rather than a
+second path into the bar. Note tsc cannot catch this class of drift here — the
+fold reads a loosely-typed `NamedActionDef` with an index signature, so the
+retired key never surfaces as `never`.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1421,13 +1421,12 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 : []),
             /**
              * Selection-bar actions. Unlike `rowActionDefs` above, these are
-             * NOT derived here: `ObjectGrid` is the single convergence point of
-             * all three list callers (this view, plugin-view's ObjectView and
-             * plugin-list's ListView), so it folds `objectDef.actions` — the
-             * spec's `bulkEnabled: true` declaration, plus any legacy
-             * `bulkActions` name that resolves to a declared action — into the
-             * def list itself (`resolveBulkActions`, objectui#3002). What we
-             * pass through is the view author's own inline declaration.
+             * NOT resolved here: `ObjectGrid` is the single convergence point
+             * of all three list callers (this view, plugin-view's ObjectView
+             * and plugin-list's ListView), so it resolves each `bulkActions`
+             * name against `objectDef.actions` and promotes it into the def
+             * list itself (`resolveBulkActions`, objectui#3002). What we pass
+             * through is the view author's own declaration.
              */
             bulkActions: viewDef.bulkActions ?? listSchema.bulkActions,
             bulkActionDefs: (viewDef as any).bulkActionDefs ?? (listSchema as any).bulkActionDefs,

--- a/packages/plugin-grid/demo/bulk-actions.tsx
+++ b/packages/plugin-grid/demo/bulk-actions.tsx
@@ -11,15 +11,14 @@
  * on-page panel instead of hitting a server).
  *
  * What it exercises:
- *   1. `bulk_mark_done` is declared on the OBJECT with `bulkEnabled: true` and
- *      is named by no view — before #3002 an object simply could not express a
- *      bulk action, so this button did not exist.
- *   2. `bulk_recalc_estimate` is declared on the object WITHOUT the flag; the
- *      view names it in legacy `bulkActions: [...]`. That name used to be
- *      dispatched as `{ type: 'bulk_recalc_estimate' }` and never ran.
- *   3. `legacy_only_handler` resolves to no declared action and stays a
+ *   1. `bulk_mark_done` and `bulk_recalc_estimate` are declared on the object
+ *      and NAMED in the view's `bulkActions` — the only way to declare a bulk
+ *      action (spec 17 retired `action.bulkEnabled` as a tombstone). Both
+ *      names used to dispatch as `{ type: '<name>' }` and never run; the
+ *      buttons also carried none of the def's label / icon / params.
+ *   2. `legacy_only_handler` resolves to no declared action and stays a
  *      by-name dispatch — it must still render ALONGSIDE the two defs above.
- *   4. Record `t3` fails server-side (422), proving per-record attribution: the
+ *   3. Record `t3` fails server-side (422), proving per-record attribution: the
  *      result panel reports 4/5 with an error row rather than a blanket success.
  */
 import * as React from 'react';
@@ -53,9 +52,8 @@ const ROWS = [
 ];
 
 /**
- * `bulkEnabled: true` is the spec's object-level declaration — "this action can
- * be applied to multiple selected records". It also carries `locations:
- * ['list_item']`, so the same action is a row entry AND a bulk entry.
+ * Also carries `locations: ['list_item']`, so naming it in the view's
+ * `bulkActions` makes the same action a row entry AND a bulk entry.
  */
 const MARK_DONE = {
   name: 'bulk_mark_done',
@@ -65,10 +63,9 @@ const MARK_DONE = {
   target: '/api/demo/mark-done',
   recordIdParam: 'taskId',
   locations: ['list_item'],
-  bulkEnabled: true,
 };
 
-/** No `bulkEnabled` — the VIEW names it in legacy `bulkActions` instead. */
+/** Surfaces only on the record overflow menu — until the view names it. */
 const RECALC = {
   name: 'bulk_recalc_estimate',
   label: 'Recalculate Estimate',
@@ -171,8 +168,8 @@ const schema: any = {
     { field: 'progress', label: 'Progress' },
   ],
   pagination: { pageSize: 50 },
-  // Legacy bare names: one resolves to a declared action, one doesn't.
-  bulkActions: ['bulk_recalc_estimate', 'legacy_only_handler'],
+  // Bare names: two resolve to declared actions, one doesn't.
+  bulkActions: ['bulk_mark_done', 'bulk_recalc_estimate', 'legacy_only_handler'],
 };
 
 function Demo() {
@@ -185,9 +182,9 @@ function Demo() {
           Object-declared bulk actions — objectui#3002
         </h1>
         <p style={{ fontSize: 12, color: 'hsl(var(--muted-foreground))', margin: '4px 0 0' }}>
-          Select rows → the bar shows <b>Mark Done</b> (derived from the object&apos;s
-          <code> bulkEnabled: true</code>), <b>Recalculate Estimate</b> (legacy name promoted to
-          its declared action) and <b>Legacy Only Handler</b> (unresolvable, dispatched by name).
+          Select rows → the bar shows <b>Mark Done</b> and <b>Recalculate Estimate</b> (names
+          from the view&apos;s <code>bulkActions</code>, promoted to their declared object
+          actions) and <b>Legacy Only Handler</b> (unresolvable, dispatched by name).
         </p>
       </header>
 

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1634,10 +1634,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const explicitBulkActions = objectCanDelete
     ? declaredBulkActions
     : declaredBulkActions?.filter((a: unknown) => String(a).toLowerCase() !== 'delete');
-  // Legacy `bulkActions` carry a bare action NAME, which the runner cannot
-  // execute on its own, and the object's own `bulkEnabled: true` actions were
-  // never surfaced at all — resolve both against `objectDef.actions` so they
-  // dispatch as real defs. See `resolveBulkActions` (objectui#3002). The
+  // `bulkActions` carries a bare action NAME, which the runner cannot execute
+  // on its own — resolve each against `objectDef.actions` so it dispatches as a
+  // real def. See `resolveBulkActions` (objectui#3002). The
   // canonical `'delete'` is held back: it routes to `onBulkDelete` (which owns
   // confirm + refresh), not the runner, even if the object declares an action
   // that happens to be named `delete`.
@@ -1746,7 +1745,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     })();
   };
 
-  // Per-record executor for a DERIVED bulk action (objectui#3002) — one
+  // Per-record executor for a PROMOTED bulk action (objectui#3002) — one
   // declared object action applied to each selected record through the action
   // runner. The dialog already collected params and took the confirmation, so
   // this dispatch strips both from the def: leaving them on would make the

--- a/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
@@ -7,16 +7,20 @@
  */
 
 /**
- * An object-declared bulk action must reach the ActionRunner as a real action
+ * A view's `bulkActions` name must reach the ActionRunner as a real action
  * DEF, applied to every selected record (objectui#3002).
  *
  * Before this, `bulkActions: ['push_down']` dispatched the action NAME in the
  * runner's `type` slot — `{ type: 'push_down', params: { records } }` — which
  * matches no built-in type and no handler, so it fell through the runner's
  * schema fallback (green success toast pre-#2996, a loud failure after it).
- * Either way the action never ran. And an object could not declare a bulk
- * action at all: `bulkActionDefs` was passed through from view JSON verbatim,
- * never derived from `objectDef.actions`.
+ * Either way the action never ran, and the button carried none of the def's
+ * label / icon / params: `bulkActionDefs` was passed through from view JSON
+ * verbatim, never resolved against `objectDef.actions`.
+ *
+ * Naming the action in the view is the ONLY way to declare a bulk action —
+ * spec 17 retired `action.bulkEnabled` as a tombstone (framework#4054) and
+ * prescribes exactly this. See `resolveBulkActions`.
  *
  * These drive the REAL ObjectGrid through a real ActionProvider and assert the
  * user-visible outcome: selecting rows and clicking the button issues one
@@ -51,9 +55,10 @@ const ROWS = [
 ];
 
 /**
- * The object's own bulk action. The label is deliberately NOT the humanization
+ * The object's declared action. The label is deliberately NOT the humanization
  * of the name ("Push Down"), so an assertion on it distinguishes the resolved
- * def from the legacy path — which could only ever render `formatActionLabel`.
+ * def from the by-name path — which could only ever render
+ * `formatActionLabel`.
  */
 const PUSH_DOWN = {
   name: 'push_down',
@@ -61,7 +66,6 @@ const PUSH_DOWN = {
   type: 'api',
   target: '/api/v1/plans/push',
   recordIdParam: 'planId',
-  bulkEnabled: true,
 };
 
 let fetchMock: ReturnType<typeof vi.fn>;
@@ -121,17 +125,32 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('object-declared bulk actions (objectui#3002)', () => {
-  it('surfaces a bulkEnabled object action with no view declaration at all', async () => {
-    await renderAndSelectAll({ objectActions: [PUSH_DOWN] });
+describe('view-declared bulk actions (objectui#3002)', () => {
+  it('renders the declared action label, not the humanized name', async () => {
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: { bulkActions: ['push_down'] },
+    });
 
     const button = await screen.findByTestId('bulk-action-push_down');
     // The object action's own label, not `formatActionLabel('push_down')`.
     expect(button).toHaveTextContent('下推');
   });
 
+  it('surfaces nothing for an object action the view never names', async () => {
+    // `action.bulkEnabled` is a spec-17 tombstone, so there is no object-level
+    // opt-in: an unnamed action must not reach the selection bar.
+    renderGrid({ objectActions: [{ ...PUSH_DOWN, bulkEnabled: true }] });
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('bulk-action-push_down')).not.toBeInTheDocument();
+  });
+
   it('issues one request per selected record instead of no-opping', async () => {
-    await renderAndSelectAll({ objectActions: [PUSH_DOWN] });
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: { bulkActions: ['push_down'] },
+    });
 
     fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
     // No params on this action → the dialog opens straight on confirm.
@@ -148,22 +167,6 @@ describe('object-declared bulk actions (objectui#3002)', () => {
     expect(sentIds).toEqual(['r1', 'r2']);
   });
 
-  it('resolves a legacy bulkActions name to the declared action', async () => {
-    // The reported shape: the object never flagged the action, the view names it.
-    const unflagged = { ...PUSH_DOWN, bulkEnabled: undefined };
-    await renderAndSelectAll({
-      objectActions: [unflagged],
-      schema: { bulkActions: ['push_down'] },
-    });
-
-    const button = await screen.findByTestId('bulk-action-push_down');
-    expect(button).toHaveTextContent('下推');
-
-    fireEvent.click(button);
-    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-  });
-
   it('reports per-record failures instead of counting them as successes', async () => {
     fetchMock.mockResolvedValue({
       ok: false,
@@ -172,7 +175,10 @@ describe('object-declared bulk actions (objectui#3002)', () => {
       headers: { get: () => 'application/json' },
       json: async () => ({ error: 'precondition not met' }),
     });
-    await renderAndSelectAll({ objectActions: [PUSH_DOWN] });
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: { bulkActions: ['push_down'] },
+    });
 
     fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
     fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
@@ -184,27 +190,27 @@ describe('object-declared bulk actions (objectui#3002)', () => {
     await waitFor(() => expect(screen.getByText(/Succeeded 0 \/ 2/)).toBeInTheDocument());
     expect(screen.getByTestId('bulk-error-row-r1')).toHaveTextContent('HTTP 422');
     expect(screen.getByTestId('bulk-error-row-r2')).toBeInTheDocument();
-    // A derived def re-dispatches for one record, so the row keeps its Retry.
+    // A promoted def re-dispatches for one record, so the row keeps its Retry.
     expect(screen.getByTestId('bulk-error-retry-r1')).toBeInTheDocument();
   });
 
-  it('renders one button when a legacy name repeats a derived action', async () => {
+  it('renders one button for a repeated name', async () => {
     await renderAndSelectAll({
       objectActions: [PUSH_DOWN],
-      schema: { bulkActions: ['push_down'] },
+      schema: { bulkActions: ['push_down', 'push_down'] },
     });
 
     await waitFor(() => expect(screen.getAllByTestId('bulk-action-push_down')).toHaveLength(1));
   });
 
-  it('keeps an unresolvable legacy name alongside the derived defs', async () => {
+  it('keeps an unresolvable name alongside the promoted defs', async () => {
     // A name the object never declared may still have a runner handler
     // registered under it; hiding it because some OTHER def exists dropped
     // half the bar's buttons.
     const handler = vi.fn(async () => ({ success: true }));
     await renderAndSelectAll({
       objectActions: [PUSH_DOWN],
-      schema: { bulkActions: ['crm_only_handler'] },
+      schema: { bulkActions: ['push_down', 'crm_only_handler'] },
       handlers: { crm_only_handler: handler },
     });
 

--- a/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
+++ b/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolveBulkActions, DERIVED_BULK_BATCH_SIZE } from '../resolveBulkActions';
+import { resolveBulkActions, PROMOTED_BULK_BATCH_SIZE } from '../resolveBulkActions';
 import type { BulkActionDef } from '@object-ui/types';
 
 const PUSH_DOWN = {
@@ -15,7 +15,6 @@ const PUSH_DOWN = {
   label: '下推',
   type: 'api',
   target: '/api/v1/plans/push',
-  bulkEnabled: true,
 };
 
 const AUTHORED: BulkActionDef = {
@@ -26,8 +25,14 @@ const AUTHORED: BulkActionDef = {
 };
 
 describe('resolveBulkActions', () => {
-  it('derives a def from an object action declaring bulkEnabled', () => {
-    const { defs, unresolved } = resolveBulkActions({ objectActions: [PUSH_DOWN] });
+  it('promotes a named action to its declared def', () => {
+    // Naming the action in the view's `bulkActions` is the ONLY declaration —
+    // spec 17 retired `action.bulkEnabled` (framework#4054) and its tombstone
+    // prescribes exactly this.
+    const { defs, unresolved } = resolveBulkActions({
+      bulkActions: ['push_down'],
+      objectActions: [PUSH_DOWN],
+    });
 
     expect(unresolved).toEqual([]);
     expect(defs).toHaveLength(1);
@@ -36,51 +41,36 @@ describe('resolveBulkActions', () => {
       label: '下推',
       operation: 'custom',
       actionDef: PUSH_DOWN,
-      batchSize: DERIVED_BULK_BATCH_SIZE,
+      batchSize: PROMOTED_BULK_BATCH_SIZE,
     });
   });
 
-  it('leaves an action alone that never opted into bulk', () => {
+  it('surfaces nothing for an object action the view never names', () => {
     const rowOnly = { name: 'convert_lead', label: 'Convert', locations: ['list_item'] };
-    const { defs, unresolved } = resolveBulkActions({ objectActions: [rowOnly] });
+    const { defs, unresolved } = resolveBulkActions({ objectActions: [rowOnly, PUSH_DOWN] });
 
     expect(defs).toEqual([]);
     expect(unresolved).toEqual([]);
   });
 
-  it('promotes a legacy name to its declared action even without bulkEnabled', () => {
-    // Naming the action in the view's `bulkActions` IS the declaration of
-    // intent at the view level — same rule the row fold applies to `rowActions`.
-    const noFlag = { name: 'dispatch_job', label: '派工', type: 'api', target: '/x' };
-    const { defs, unresolved } = resolveBulkActions({
-      bulkActions: ['dispatch_job'],
-      objectActions: [noFlag],
-    });
+  it('ignores a stale bulkEnabled flag on an object action', () => {
+    // The key is a retiredKey() tombstone: `defineStack` hard-rejects a config
+    // that sets it, so it must never be a path into the bar on its own.
+    const stale = { name: 'push_down', label: '下推', bulkEnabled: true };
+    const { defs, unresolved } = resolveBulkActions({ objectActions: [stale] });
 
+    expect(defs).toEqual([]);
     expect(unresolved).toEqual([]);
-    expect(defs).toHaveLength(1);
-    expect(defs[0]).toMatchObject({ name: 'dispatch_job', operation: 'custom', actionDef: noFlag });
   });
 
   it('keeps a name that matches no declared action for by-name dispatch', () => {
     const { defs, unresolved } = resolveBulkActions({
-      bulkActions: ['crm_only_handler'],
+      bulkActions: ['push_down', 'crm_only_handler'],
       objectActions: [PUSH_DOWN],
     });
 
-    // push_down still derives from its own flag; the unknown name stays legacy.
     expect(defs.map(d => d.name)).toEqual(['push_down']);
     expect(unresolved).toEqual(['crm_only_handler']);
-  });
-
-  it('does not render a legacy name twice when it also derives from bulkEnabled', () => {
-    const { defs, unresolved } = resolveBulkActions({
-      bulkActions: ['push_down'],
-      objectActions: [PUSH_DOWN],
-    });
-
-    expect(defs.map(d => d.name)).toEqual(['push_down']);
-    expect(unresolved).toEqual([]);
   });
 
   it('lets an inline-authored def win over the object action of the same name', () => {
@@ -94,7 +84,7 @@ describe('resolveBulkActions', () => {
     expect(defs).toEqual([authoredPush]);
   });
 
-  it('drops a repeated legacy name', () => {
+  it('drops a repeated name', () => {
     const { defs, unresolved } = resolveBulkActions({
       bulkActions: ['dispatch_job', 'dispatch_job', 'ghost', 'ghost'],
       objectActions: [{ name: 'dispatch_job' }],
@@ -114,7 +104,6 @@ describe('resolveBulkActions', () => {
   it('maps spec param keys onto the dialog vocabulary', () => {
     const withParams = {
       name: 'reassign',
-      bulkEnabled: true,
       params: [
         {
           field: 'owner',
@@ -129,7 +118,10 @@ describe('resolveBulkActions', () => {
         { label: 'orphan' },
       ],
     };
-    const { defs } = resolveBulkActions({ objectActions: [withParams] });
+    const { defs } = resolveBulkActions({
+      bulkActions: ['reassign'],
+      objectActions: [withParams],
+    });
 
     expect(defs[0].params).toEqual([
       expect.objectContaining({
@@ -145,8 +137,11 @@ describe('resolveBulkActions', () => {
   });
 
   it('drops a non-string I18nLabel rather than handing an object to the renderer', () => {
-    const mapLabel = { name: 'push_down', bulkEnabled: true, label: { en: 'Push', 'zh-CN': '下推' } };
-    const { defs } = resolveBulkActions({ objectActions: [mapLabel] });
+    const mapLabel = { name: 'push_down', label: { en: 'Push', 'zh-CN': '下推' } };
+    const { defs } = resolveBulkActions({
+      bulkActions: ['push_down'],
+      objectActions: [mapLabel],
+    });
 
     expect(defs[0].label).toBeUndefined();
   });
@@ -154,13 +149,15 @@ describe('resolveBulkActions', () => {
   it('carries confirm text, icon and visible from the action', () => {
     const rich = {
       name: 'push_down',
-      bulkEnabled: true,
       icon: 'send',
       variant: 'danger',
       confirm: { message: '确认下推?' },
       visible: { dialect: 'cel', source: 'current_user.is_admin' },
     };
-    const { defs } = resolveBulkActions({ objectActions: [rich] });
+    const { defs } = resolveBulkActions({
+      bulkActions: ['push_down'],
+      objectActions: [rich],
+    });
 
     expect(defs[0]).toMatchObject({
       icon: 'send',
@@ -171,14 +168,18 @@ describe('resolveBulkActions', () => {
   });
 
   it('drops an action variant the bulk bar cannot render', () => {
-    const linkVariant = { name: 'push_down', bulkEnabled: true, variant: 'link' };
-    const { defs } = resolveBulkActions({ objectActions: [linkVariant] });
+    const linkVariant = { name: 'push_down', variant: 'link' };
+    const { defs } = resolveBulkActions({
+      bulkActions: ['push_down'],
+      objectActions: [linkVariant],
+    });
 
     expect(defs[0].variant).toBeUndefined();
   });
 
-  it('localizes derived labels through the supplied resolver', () => {
+  it('localizes promoted labels through the supplied resolver', () => {
     const { defs } = resolveBulkActions({
+      bulkActions: ['push_down'],
       objectActions: [PUSH_DOWN],
       localizeLabel: (name, fallback) => (name === 'push_down' ? 'Push Down' : fallback),
     });

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -73,7 +73,7 @@ export interface BulkActionDialogProps {
    */
   objectFields?: Record<string, MultiValueFieldDef>;
   /**
-   * Per-record dispatcher for a def DERIVED from an object action
+   * Per-record dispatcher for a def PROMOTED from an object action
    * (objectui#3002) — see {@link BulkExecutorOptions.runAction}. The dialog's
    * params → confirm steps are what let one action run over N records without
    * the runner re-prompting per record.
@@ -432,7 +432,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
                           </div>
                         </div>
                         {/* A plain `custom` callout has nothing to re-run, but
-                            a DERIVED def (#3002) re-dispatches its object
+                            a PROMOTED def (#3002) re-dispatches its object
                             action for that one record — same as update/delete. */}
                         {(def.operation !== 'custom' || !!def.actionDef) && (
                           <Button

--- a/packages/plugin-grid/src/hooks/useBulkExecutor.ts
+++ b/packages/plugin-grid/src/hooks/useBulkExecutor.ts
@@ -81,9 +81,9 @@ export interface BulkExecutorOptions {
     ) => Promise<number>;
   };
   /**
-   * Per-record dispatcher for a DERIVED bulk action — one declared object
-   * action (`bulkEnabled: true`, or a legacy `bulkActions` name resolved
-   * against `objectDef.actions`) applied to N selected records (objectui#3002).
+   * Per-record dispatcher for a PROMOTED bulk action — one declared object
+   * action (named in the view's `bulkActions` and resolved against
+   * `objectDef.actions`) applied to N selected records (objectui#3002).
    *
    * Such a def carries `operation: 'custom'` plus `def.actionDef`; the data
    * source has no idea what the action does, so the grid injects this to run it
@@ -235,7 +235,7 @@ export function useBulkExecutor({ resource, dataSource, objectFields, runAction 
             case 'update':
               return dataSource.update(resource, id, buildPatch());
             case 'custom':
-              // A DERIVED def (`actionDef` present) runs its object action once
+              // A PROMOTED def (`actionDef` present) runs its object action once
               // per record through the injected runner. Without one, this is
               // the historical callout shape — no mutation, caller wires
               // onComplete.
@@ -340,7 +340,7 @@ export function useBulkExecutor({ resource, dataSource, objectFields, runAction 
             await dataSource.update(resource, rowId, patch);
             break;
           case 'custom':
-            // A derived def re-dispatches the action for real; a plain callout
+            // A promoted def re-dispatches the action for real; a plain callout
             // def has nothing to retry, so it reports success unchanged.
             if (!last.def.actionDef || !runAction) return true;
             await runAction(last.def, row, { ...last.params });

--- a/packages/plugin-grid/src/resolveBulkActions.ts
+++ b/packages/plugin-grid/src/resolveBulkActions.ts
@@ -7,39 +7,44 @@
  */
 
 /**
- * Fold an object's declared actions — and a list view's legacy
- * `bulkActions: string[]` — into the rich `BulkActionDef` list the selection
- * bar renders.
+ * Resolve a list view's `bulkActions: string[]` against the object's declared
+ * actions, folding each resolvable name into the rich `BulkActionDef` list the
+ * selection bar renders.
  *
  * This is the selection-scoped twin of {@link resolveLegacyRowActions}
  * (objectui#2960 / #2996), and it closes the same `{type: <name>}` dead end on
  * the bulk path (objectui#3002): dispatching `bulkActions: ['push_down']` put
- * the action's NAME in the runner's `type` slot, which resolves to nothing.
+ * the action's NAME in the runner's `type` slot, which resolves to nothing —
+ * zero requests, and (since #2996) a loud failure instead of a green toast.
  *
- * ## Where an object-level bulk action is declared
+ * ## Where a bulk action is declared
  *
- * `ActionSchema.bulkEnabled` — *"Whether this action can be applied to
- * multiple selected records"*. The spec has carried this flag all along; what
- * was missing was a consumer (framework's own liveness audit: *"engine has
- * `getBulkActions`/`executeBulk`, but no spec-driven view path calls
- * `executeBulk`"*). So no new `locations` entry is needed — a list selection
- * bar is the only surface on which records are multi-selected, which is
- * exactly what the flag already names. `locations` stays orthogonal: it places
- * an action's SINGLE-record entry (toolbar / row kebab / record header), and
- * an action may carry both (`locations: ['list_item'], bulkEnabled: true` =
- * runs on one row from the kebab, on N rows from the selection bar).
+ * **In the VIEW's `bulkActions`, naming an action the object declares.** That
+ * is the whole vocabulary. `ActionSchema.bulkEnabled` looked like an
+ * object-level alternative and this module briefly derived from it, but spec
+ * 17.0.0 retired the key (#3896 close-out / framework#4054) — it is now a
+ * `retiredKey()` tombstone, so authoring it is a HARD parse rejection whose
+ * own prescription is: *"the multi-select toolbar is driven by the LIST VIEW's
+ * `bulkActions` / `bulkActionDefs`, never by this flag … declare the action in
+ * the view's `bulkActions` instead."* Do not reintroduce a `bulkEnabled` read
+ * here: `defineStack` refuses to compile a config that sets it, so the branch
+ * can never run.
  *
- * ## Three vocabularies reach the selection bar
+ * `locations` stays orthogonal — it places an action's SINGLE-record entry
+ * (toolbar / row kebab / record header). One action can be both: declared
+ * `locations: ['list_item']` AND named in `bulkActions`, it runs on one row
+ * from the kebab and on N rows from the selection bar.
+ *
+ * ## Two vocabularies reach the selection bar
  *
  *  1. `bulkActionDefs` — rich defs authored inline in the view JSON. Untouched
  *     here; they own their names and win every collision.
- *  2. `objectDef.actions` with `bulkEnabled: true` — DERIVED into defs by this
- *     fold. This is what "declare a bulk action on the object" now means.
- *  3. `bulkActions: string[]` — the legacy bare-name form, kept as a
- *     view-level override (name an action the object didn't flag, or order it
- *     explicitly). Resolved against `objectDef.actions` by name.
+ *  2. `bulkActions: string[]` — bare action names, resolved against
+ *     `objectDef.actions` and PROMOTED to that def, so they carry the action's
+ *     label, icon, `visible` predicate, confirm text and params instead of a
+ *     bare humanized name.
  *
- * A derived def carries `operation: 'custom'` plus the source action under
+ * A promoted def carries `operation: 'custom'` plus the source action under
  * {@link BulkActionDef.actionDef}: it is NOT a data-plane mass update, it is
  * one action run over N records through the action runner. `useBulkExecutor`
  * routes on exactly that key — a `custom` def WITHOUT `actionDef` keeps its
@@ -62,13 +67,13 @@ export interface NamedActionDef {
 }
 
 /**
- * Concurrency for a derived action's per-record fan-out. Well below the
+ * Concurrency for a promoted action's per-record fan-out. Well below the
  * `BulkActionDef` default (200) because each record here is a distinct runner
  * dispatch — typically an HTTP call to a custom endpoint or a flow run, not a
  * single batched data-API write. 200 in flight would be a thundering herd
  * against an endpoint that never opted into bulk traffic.
  */
-export const DERIVED_BULK_BATCH_SIZE = 25;
+export const PROMOTED_BULK_BATCH_SIZE = 25;
 
 /** Action `variant`s that have no `BulkActionDef` counterpart are dropped. */
 const BULK_VARIANTS = new Set(['primary', 'secondary', 'danger', 'ghost']);
@@ -132,16 +137,16 @@ function toBulkActionDef(action: NamedActionDef, localize?: ActionLabelResolver)
     ...(params.length > 0 && { params }),
     ...(confirmText !== undefined && { confirmText }),
     ...(action.visible != null && { visible: action.visible as BulkActionDef['visible'] }),
-    batchSize: DERIVED_BULK_BATCH_SIZE,
+    batchSize: PROMOTED_BULK_BATCH_SIZE,
     actionDef: action,
   };
 }
 
 export function resolveBulkActions(opts: {
   /**
-   * Legacy `bulkActions` names, already stripped of the canonical `'delete'`
-   * entry (it routes to the grid's `onBulkDelete`, not the runner — same
-   * carve-out the row fold makes for `'edit'` / `'delete'`).
+   * The view's `bulkActions` names, already stripped of the canonical
+   * `'delete'` entry (it routes to the grid's `onBulkDelete`, not the runner —
+   * same carve-out the row fold makes for `'edit'` / `'delete'`).
    */
   bulkActions?: readonly string[] | null;
   /** Rich defs authored inline in the view/list JSON. */
@@ -149,19 +154,19 @@ export function resolveBulkActions(opts: {
   /** Every action declared on the object (`objectDef.actions`). */
   objectActions?: readonly NamedActionDef[] | null;
   /**
-   * Resolves a derived def's label through the app's i18n bundle, so an
-   * object-declared bulk action reads the same in the selection bar as its row
-   * entry does in the kebab. Omit to use the authored label verbatim.
+   * Resolves a promoted def's label through the app's i18n bundle, so a bulk
+   * action reads the same in the selection bar as its row entry does in the
+   * kebab. Omit to use the authored label verbatim.
    */
   localizeLabel?: ActionLabelResolver;
 }): {
   /**
-   * Authored defs, then the object's `bulkEnabled` actions, then promoted
-   * legacy names. Returned by REFERENCE when nothing was derived or promoted,
-   * so a view with no object actions to fold keeps its identity across renders.
+   * Authored defs, then the promoted names in `bulkActions` order. Returned by
+   * REFERENCE when nothing was promoted, so a view with no names to fold keeps
+   * its identity across renders.
    */
   defs: readonly BulkActionDef[];
-  /** Legacy names that matched no declared action; dispatched by name. */
+  /** Names that matched no declared action; dispatched by name. */
   unresolved: string[];
 } {
   const authored = Array.isArray(opts.bulkActionDefs) ? opts.bulkActionDefs : [];
@@ -172,26 +177,14 @@ export function resolveBulkActions(opts: {
     authored.map(d => d?.name).filter((n): n is string => typeof n === 'string' && n !== ''),
   );
 
-  // (2) The object's own declaration: `bulkEnabled: true`.
-  const derived: BulkActionDef[] = [];
-  for (const action of objectActions) {
-    if (action?.bulkEnabled !== true) continue;
-    const name = action?.name;
-    if (typeof name !== 'string' || name === '') continue;
-    if (claimed.has(name)) continue;
-    claimed.add(name);
-    derived.push(toBulkActionDef(action, opts.localizeLabel));
-  }
-
-  // (3) The view-level legacy override.
   const promoted: BulkActionDef[] = [];
   const unresolved: string[] = [];
   for (const name of names) {
     if (typeof name !== 'string' || name === '') continue;
-    // Already surfaced (authored, derived, or an earlier pass over a repeated
-    // legacy entry) — drop the duplicate rather than render a twin. Both
-    // outcomes claim the name: the bar keys its buttons on it, so even two
-    // dead-name entries would collide.
+    // Already surfaced (an authored def of the same name, or an earlier pass
+    // over a repeated entry) — drop the duplicate rather than render a twin.
+    // Both outcomes claim the name: the bar keys its buttons on it, so even
+    // two dead-name entries would collide.
     if (claimed.has(name)) continue;
     claimed.add(name);
     const match = objectActions.find(a => a?.name === name);
@@ -203,9 +196,7 @@ export function resolveBulkActions(opts: {
   }
 
   return {
-    defs: derived.length > 0 || promoted.length > 0
-      ? [...authored, ...derived, ...promoted]
-      : authored,
+    defs: promoted.length > 0 ? [...authored, ...promoted] : authored,
     unresolved,
   };
 }

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -311,12 +311,13 @@ export type BulkActionOperation = 'update' | 'delete' | 'custom';
  * a def derived from an object action ({@link BulkActionDef.actionDef}),
  * dispatches that action once per record through the action runner.
  *
- * Three sources feed the bar (folded by `resolveBulkActions` in plugin-grid):
- * defs authored inline in the view JSON, object actions declaring the spec's
- * `bulkEnabled: true`, and the legacy `bulkActions: string[]` names — each of
- * which is resolved against `objectDef.actions` and promoted to a def when it
- * matches one. Names that match nothing still render as by-name buttons, since
- * a consumer may have registered a runner handler under exactly that name.
+ * Two sources feed the bar (folded by `resolveBulkActions` in plugin-grid):
+ * defs authored inline in the view JSON, and the view's `bulkActions: string[]`
+ * names — each resolved against `objectDef.actions` and promoted to that def
+ * when it matches one. Naming the action in the view is the only way to declare
+ * a bulk action: spec 17 retired `action.bulkEnabled` as a tombstone and
+ * prescribes exactly this. Names that match nothing still render as by-name
+ * buttons, since a consumer may have registered a runner handler under one.
  */
 export interface BulkActionDef {
   /** Stable identifier — also used as the action key in audit logs. */
@@ -356,9 +357,9 @@ export interface BulkActionDef {
   /** Batch size for the executor loop (default: 200). */
   batchSize?: number;
   /**
-   * Source object `ActionDef` when this entry was DERIVED from
-   * `objectDef.actions` — either the spec's `bulkEnabled: true` declaration or
-   * a legacy `bulkActions: ['<name>']` entry resolved by name (objectui#3002).
+   * Source object `ActionDef` when this entry was PROMOTED from a
+   * `bulkActions: ['<name>']` entry resolved against `objectDef.actions`
+   * (objectui#3002).
    *
    * Presence of this key changes what `operation: 'custom'` means: instead of
    * a per-row no-op, the executor dispatches THIS action through the action


### PR DESCRIPTION
#3031 的跟进修复。**#3031 的一半设计是错的，浏览器实测把它抓出来了。**

## 发生了什么

#3031 让选择栏折叠两路来源：view 的 `bulkActions` 名字解析到 `objectDef.actions`，以及对象 action 上的 `ActionSchema.bulkEnabled`。**第二路是死的。**

`@objectstack/spec` 17.0.0 在 #3896 审计收尾里退役了 `action.bulkEnabled`（[framework#4054](https://github.com/objectstack-ai/framework) `12a19a88a`）—— 这个提交在 #3031 进行途中落地，我定设计时读到的 spec 源码里这个 key 还在。

它现在是 `retiredKey()` 墓碑，不是「被忽略」而是**硬拒绝**：

```
✗ `action.bulkEnabled` was removed in @objectstack/spec 17.0.0 (#3896 audit
  close-out) — the multi-select toolbar is driven by the LIST VIEW's
  `bulkActions` / `bulkActionDefs`, never by this flag, so setting it changed
  nothing. Delete the key and declare the action in the view's `bulkActions`
  instead.
✗ Compile failed — fix errors above before starting dev server
```

`defineStack` 直接拒绝编译，后端起不来。所以那条推导分支永远不可能执行，而 #3031 的 changeset 还在教作者用一个会让应用启动失败的 key。

**是浏览器验证发现的** —— 我在 showcase 里加 `bulkEnabled: true` 想跑端到端，后端直接拒绝启动。单测和 type-check 都抓不到：折叠函数读的是带索引签名的 `NamedActionDef`，退役 key 不会显现成 `never`（见 objectui 的 spec-tombstone 经验）。

## 改动

墓碑自己给的处方正是 #3031 活下来的那一半 —— *"declare the action in the view's `bulkActions` instead"*。所以 `resolveBulkActions` 现在只折叠两路词汇：

1. view JSON 里内联写的 `bulkActionDefs`；
2. `bulkActions` 里的名字，解析到对象 action 后**提升**成该 def。

折叠之下的一切都没变：提升出的 def 照样带 action 的 label / icon / `visible` / 确认文案 / 参数，照样走 `BulkActionDialog`（params → confirm → progress → result），照样逐记录带 `_rowRecord` 派发、逐条归因失败。对象 action 上残留的 `bulkEnabled: true` 现在是惰性的，不再是进入选择栏的第二条路。

`DERIVED_BULK_BATCH_SIZE` → `PROMOTED_BULK_BATCH_SIZE`（未导出到包外，只在本模块和测试里用）。

## 验证

**真实 console + 真实后端**（objectstack worktree 起 showcase 于 :3010，console dev 从本 worktree 起于 :5182）：

- view 声明 `bulkActions: ['showcase_mark_done', 'showcase_recalc_estimate']`，两个名字都被提升 —— 选择栏显示的是 action 自己的标签 "Mark Done" / "Recalculate Estimate"（不是 humanize 出来的 "Showcase Mark Done"）和 action 的图标。
- 全选 10 条点 Mark Done → **10 个 `POST /api/v1/actions/showcase_task/showcase_mark_done` 全部 200**，逐记录一次。
- 数据侧确认：10 条记录服务端全部变成 `done: true, progress: 100`。修复前这条路径零请求、零改动。

**测试**：`plugin-grid` 44 文件 / 351 测试全绿；`types` + `plugin-grid` + `app-shell` type-check 31 任务全过；改动文件 0 lint error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
