### PR TITLE
fix(grid): 批量删除 / 按名字派发也要清掉行复选框 (#3056)

### DIFF
--- a/.changeset/bulk-selection-reset-both-sources.md
+++ b/.changeset/bulk-selection-reset-both-sources.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/plugin-grid": patch
+---
+
+fix(grid): a bulk delete / by-name action clears the row checkboxes, not just the toolbar — objectui#3056
+
+After a successful bulk delete (or a bulk action dispatched to a
+consumer-registered runner handler), the selection toolbar vanished but every
+row stayed visibly ticked. The user was left on a page of selected rows with no
+toolbar to act on them, and no way back except unticking each row or reloading.
+
+`ObjectGrid` carries two selection sources that must move together:
+`selectedRows` (ours — drives the toolbar) and the data-table's internal
+`selectedRowIds` (drives the checkboxes, cleared only when the host bumps
+`selectionResetKey`). `handleBulkDialogClose` reset both; `dispatchBulkAction`
+reset only the first, on both of its branches.
+
+Both now go through one `resetSelection()` helper — including the dialog path,
+so the invariant is structural rather than three call sites remembering to
+agree. Failure semantics are untouched: a by-name action that reports
+`success: false` still keeps the toolbar AND the checkboxes so the user can fix
+the cause and retry the same rows.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1711,24 +1711,35 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // Bulk action dispatcher — for the implicit 'delete' action, route through
   // the consumer-provided onBulkDelete (which already knows about confirm +
   // refresh). Other actions fall through to the generic action runner.
+  //
+  // [#3056] Both branches must clear BOTH selection sources. `selectedRows` is
+  // ours and drives the toolbar; the row checkboxes live inside the data-table
+  // and only clear when `selectionResetKey` moves. Bumping one without the
+  // other strands the user on a page of ticked rows with no toolbar to act on
+  // them — the exact drift `handleBulkDialogClose` below already guards.
+  const resetSelection = () => {
+    setSelectedRows([]);
+    setSelectAllMatching(false);
+    setSelectionResetKey(k => k + 1);
+  };
+
   const dispatchBulkAction = (action: string, rows: any[]) => {
     void (async () => {
       const expanded = await resolveBulkRows(rows);
       if (action === 'delete' && onBulkDelete) {
         onBulkDelete(expanded);
-        setSelectedRows([]);
-        setSelectAllMatching(false);
+        resetSelection();
         return;
       }
-      // A string bulk action (e.g. 下推 / 派工) mutated the selected records,
-      // usually through a custom API that never touches dataSource.update — so
-      // nothing else signals the grid to refetch. On success, reset the
-      // selection toolbar and refresh so the list reflects the server state
-      // (mirrors the delete branch and handleBulkDialogClose).
+      // A string bulk action (e.g. a consumer-registered runner handler)
+      // mutated the selected records, usually through a custom API that never
+      // touches dataSource.update — so nothing else signals the grid to
+      // refetch. On success, reset the selection and refresh so the list
+      // reflects the server state (mirrors the delete branch and
+      // handleBulkDialogClose).
       const res = await executeAction({ type: action, params: { records: expanded } });
       if (res?.success) {
-        setSelectedRows([]);
-        setSelectAllMatching(false);
+        resetSelection();
         setRefreshKey(k => k + 1);
       }
     })();
@@ -1791,13 +1802,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     // Only reset selection when the run actually changed something. A total
     // failure (0 succeeded — e.g. a "推计划" precondition error) leaves the data
     // untouched, so we keep the selection *and* the toolbar so the user can fix
-    // it and retry the same rows. Both selection sources must move together, or
-    // the checkboxes (table-internal) and the toolbar (our `selectedRows`) drift
-    // out of sync — ticked rows with no toolbar.
+    // it and retry the same rows.
     if (result && result.succeeded > 0) {
-      setSelectedRows([]);
-      setSelectAllMatching(false);
-      setSelectionResetKey(k => k + 1);
+      resetSelection();
       // Trigger refresh via the same path used by single-record mutations.
       setRefreshKey(k => k + 1);
     }

--- a/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionRefresh.test.tsx
@@ -291,3 +291,85 @@ describe('ObjectGrid — bulk dialog Done keeps selection in sync', () => {
     expect(headerChecked()).toBe('checked');
   });
 });
+
+/**
+ * Same desync, the OTHER dispatcher (#3056). `dispatchBulkAction` — the
+ * by-name path and the bulk-delete path — cleared `selectedRows` (toolbar) but
+ * never bumped `selectionResetKey` (checkboxes), so a successful run left the
+ * user staring at a page of ticked rows with no toolbar to act on them. Only
+ * the rich-def path above upheld the invariant; these pin the other two.
+ *
+ * Both survive objectui#3002: a name that resolves to a declared object action
+ * is now promoted to a def and routes through the dialog instead, so what still
+ * reaches `dispatchBulkAction` is a consumer-registered runner handler
+ * (`approve` here) and the canonical `'delete'`.
+ */
+describe('ObjectGrid — dispatchBulkAction keeps selection in sync (#3056)', () => {
+  const headerChecked = () =>
+    (document.querySelector('thead [role="checkbox"]') as HTMLElement)?.getAttribute('data-state');
+
+  it('clears the row checkboxes (not just the toolbar) after a by-name action', async () => {
+    const ds = makeDataSource();
+    const approve = vi.fn(async () => ({ success: true }));
+    renderGrid(ds, { approve });
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    fireEvent.click(document.querySelector('thead [role="checkbox"]') as HTMLElement);
+    await waitFor(() => expect(headerChecked()).toBe('checked'));
+
+    fireEvent.click(await screen.findByTestId('bulk-action-approve'));
+    await waitFor(() => expect(approve).toHaveBeenCalledTimes(1));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(headerChecked()).toBe('unchecked'));
+  });
+
+  it('leaves the checkboxes ticked when the by-name action fails', async () => {
+    const ds = makeDataSource();
+    const approve = vi.fn(async () => ({ success: false, error: 'nope' }));
+    renderGrid(ds, { approve });
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    fireEvent.click(document.querySelector('thead [role="checkbox"]') as HTMLElement);
+    await waitFor(() => expect(headerChecked()).toBe('checked'));
+
+    fireEvent.click(await screen.findByTestId('bulk-action-approve'));
+    await waitFor(() => expect(approve).toHaveBeenCalledTimes(1));
+
+    // Failure keeps BOTH sources, so the user can retry the same rows.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId('bulk-actions-bar')).toBeInTheDocument();
+    expect(headerChecked()).toBe('checked');
+  });
+
+  it('clears the row checkboxes after a bulk delete', async () => {
+    const ds = makeDataSource();
+    const onBulkDelete = vi.fn();
+    const schema: any = {
+      type: 'object-grid',
+      objectName: OBJECT,
+      bulkActions: ['delete'],
+      columns: [{ field: 'name', label: 'Name' }],
+      pagination: { pageSize: 50 },
+    };
+    render(
+      <ActionProvider handlers={{}}>
+        <ObjectGrid schema={schema} dataSource={ds} onBulkDelete={onBulkDelete} />
+      </ActionProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Plan A')).toBeInTheDocument());
+    fireEvent.click(document.querySelector('thead [role="checkbox"]') as HTMLElement);
+    await waitFor(() => expect(headerChecked()).toBe('checked'));
+
+    fireEvent.click(await screen.findByTestId('bulk-action-delete'));
+    await waitFor(() => expect(onBulkDelete).toHaveBeenCalledTimes(1));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('bulk-actions-bar')).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(headerChecked()).toBe('unchecked'));
+  });
+});


### PR DESCRIPTION
Fixes #3056.

## 症状

批量删除成功后（或按名字派发到消费方注册的 runner handler 后），选择栏消失了，但每行复选框**还全勾着**。用户面对的是「一堆勾选的行 + 没有任何批量操作入口」，只能逐行取消或刷新页面。

## 根因

`ObjectGrid` 有两套必须同步移动的选择状态：

- `selectedRows`（自己的 state）→ 驱动 `BulkActionBar`
- data-table 内部的 `selectedRowIds` → 驱动行复选框，**只有**宿主 bump `selectionResetKey` 时才清空

`handleBulkDialogClose`（富 def 那条路）两个都清；`dispatchBulkAction` 只清了第一个，**两条分支都漏**——走 `onBulkDelete` 的删除分支，和按名字派发的分支。

这个不变量其实早就写在 `handleBulkDialogClose` 的注释里了，只是另一条路径没遵守：

> Both selection sources must move together, or the checkboxes (table-internal) and the toolbar (our `selectedRows`) drift out of sync — ticked rows with no toolbar.

## 改动

三处调用点统一走一个 `resetSelection()` helper，把规则做成**结构性**的，而不是靠三个地方各自记得保持一致。失败语义没动：action 返回 `success: false` 时两套状态都保留，用户可以修好原因后重试同一批行。

## 验证

- **反向对照**：只回退 `ObjectGrid.tsx` 后，两条新增的正向断言全部失败——按名字 action 成功后、批量删除后，header 复选框仍是 `checked`（应为 `unchecked`）。
- **新增 3 条测试**：按名字成功清空、按名字失败保留（防止矫枉过正）、批量删除清空。
- `plugin-grid` 44 文件 / 354 测试全绿；改动文件 0 lint error。

注：#3002 之后这条路径变窄了——能解析到对象 action 的名字现在会被提升成 def 走对话框，所以仍然到达 `dispatchBulkAction` 的是消费方注册的 handler 和内建的 `'delete'`。删除是其中最常见的一条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
