### PR TITLE
docs(components): document the remaining nine Shadcn divergences — every tracked component now says why it diverges

### DIFF
--- a/packages/components/shadcn-components.json
+++ b/packages/components/shadcn-components.json
@@ -53,7 +53,8 @@
     "badge": {
       "source": "https://ui.shadcn.com/r/styles/default/badge.json",
       "dependencies": [],
-      "registryDependencies": []
+      "registryDependencies": [],
+      "localEdits": "Adds `whitespace-nowrap`: a badge is a single-line pill by definition, and without it CJK labels (e.g. 待审批) break per-character inside a cramped table cell and stack vertically (objectui#2762 P0-1). The reasoning is also comment-documented in the file."
     },
     "breadcrumb": {
       "source": "https://ui.shadcn.com/r/styles/default/breadcrumb.json",
@@ -75,7 +76,8 @@
       ],
       "registryDependencies": [
         "button"
-      ]
+      ],
+      "localEdits": "Tailwind v4 syntax: upstream still ships v3’s `[--var]` arbitrary values, which on Tailwind 4.x compile to a bare custom-property name instead of `var(--var)` — invalid CSS that browsers drop. Applied repo-wide in 925051db6. Here it covers `h-`, `w-`, `px-`, `size-` and `max-w-` on `--cell-size`."
     },
     "card": {
       "source": "https://ui.shadcn.com/r/styles/default/card.json",
@@ -97,7 +99,8 @@
         "recharts",
         "lucide-react"
       ],
-      "registryDependencies": []
+      "registryDependencies": [],
+      "localEdits": "Three local edits. (1) The container is `block … w-full` rather than upstream’s `flex justify-center`: a flex box gives ResponsiveContainer no measurable width, so charts render axes but no marks (#1634, commit 9b163173b). (2) Tooltip/Legend props are hand-written instead of derived from Recharts’ own types, which did not type-check here (2e11aa72f). (3) Tailwind v4 syntax: upstream still ships v3’s `[--var]` arbitrary values, which on Tailwind 4.x compile to a bare custom-property name instead of `var(--var)` — invalid CSS that browsers drop. Applied repo-wide in 925051db6."
     },
     "checkbox": {
       "source": "https://ui.shadcn.com/r/styles/default/checkbox.json",
@@ -120,7 +123,8 @@
       ],
       "registryDependencies": [
         "dialog"
-      ]
+      ],
+      "localEdits": "Two local additions to CommandDialog. (1) `contentProps`, so callers can attach a stable locator/ARIA name to the underlying dialog element — a `data-testid` spread onto CommandDialog lands on the Radix Dialog root, which renders no DOM (ADR-0054 C4). (2) `sr-only` DialogTitle/DialogDescription, which Radix requires for an accessible name. Upstream has neither, and drops each addition together with its usages — so syncing deletes ~38 lines and still type-checks clean. Verified: `--update command --force` compiles."
     },
     "context-menu": {
       "source": "https://ui.shadcn.com/r/styles/default/context-menu.json",
@@ -248,7 +252,8 @@
       "dependencies": [
         "radix-ui"
       ],
-      "registryDependencies": []
+      "registryDependencies": [],
+      "localEdits": "Wraps SelectPrimitive.Root to swallow `onValueChange(\"\")`. Radix mirrors the value into a hidden native `<select>`; SelectContent registers its options a commit AFTER the trigger mounts, so a value arriving mid-hydration (an edit form whose record lands after first paint) finds no matching `<option>`, and Radix echoes back an empty string that silently wipes the field — latching the form when a `visibleWhen` predicate reads it (#2968). SelectItem rejects `value=\"\"`, so `\"\"` is never a real user choice. Also tailwind v4 syntax: upstream still ships v3’s `[--var]` arbitrary values, which on Tailwind 4.x compile to a bare custom-property name instead of `var(--var)` — invalid CSS that browsers drop. Applied repo-wide in 925051db6."
     },
     "separator": {
       "source": "https://ui.shadcn.com/r/styles/default/separator.json",
@@ -262,7 +267,8 @@
       "dependencies": [
         "radix-ui"
       ],
-      "registryDependencies": []
+      "registryDependencies": [],
+      "localEdits": "Adds a `hideOverlay` prop that suppresses `<SheetOverlay />`, for sheets that must not dim the page behind them. Upstream renders the overlay unconditionally."
     },
     "sidebar": {
       "source": "https://ui.shadcn.com/r/styles/default/sidebar.json",
@@ -275,7 +281,8 @@
         "sheet",
         "skeleton",
         "tooltip"
-      ]
+      ],
+      "localEdits": "Three systematic edits, not 24 independent ones. (1) Tailwind v4 syntax: upstream still ships v3’s `[--var]` arbitrary values, which on Tailwind 4.x compile to a bare custom-property name instead of `var(--var)` — invalid CSS that browsers drop. Applied repo-wide in 925051db6. (2) `theme(spacing.4)` → `1rem`: cosmetic only — verified that Tailwind 4.3.3 still resolves the v3 `theme()` dot-notation, and both spellings compile to the identical `calc(var(--sidebar-width-icon) + 1rem)`. Unlike (1) this one is NOT load-bearing; it is just avoiding a deprecated idiom. (3) `data-collapsible` is set unconditionally and each rule qualified with `group-data-[state=collapsed]:`, where upstream blanks the attribute when expanded — same result, but the attribute stays in the DOM for styling and test locators. Also carries an `eslint-disable react-hooks/purity` the skeleton’s random width needs under this repo’s lint config; syncing removes it and Lint fails."
     },
     "skeleton": {
       "source": "https://ui.shadcn.com/r/styles/default/skeleton.json",
@@ -287,7 +294,8 @@
       "dependencies": [
         "radix-ui"
       ],
-      "registryDependencies": []
+      "registryDependencies": [],
+      "localEdits": "Forwards `aria-label` to `SliderPrimitive.Thumb`. Upstream renders the Thumb with only a className, so the accessible name never reaches the element screen readers focus."
     },
     "sonner": {
       "source": "https://ui.shadcn.com/r/styles/default/sonner.json",
@@ -308,7 +316,8 @@
     "table": {
       "source": "https://ui.shadcn.com/r/styles/default/table.json",
       "dependencies": [],
-      "registryDependencies": []
+      "registryDependencies": [],
+      "localEdits": "Adds `containerClassName` to override the scroll-wrapper `<div>`. The wrapper is its own `overflow-auto` container by default; inside an already-bounded scroll region (DataTable’s `flex-1 min-h-0 overflow-auto`) that creates a SECOND, height-unbounded scroll container whose horizontal scrollbar sits below every row, reachable only after scrolling to the last one. `containerClassName=\"overflow-visible\"` hands both axes to the outer container. Rationale is spelled out in the file’s JSDoc."
     },
     "tabs": {
       "source": "https://ui.shadcn.com/r/styles/default/tabs.json",

--- a/scripts/shadcn-sync.js
+++ b/scripts/shadcn-sync.js
@@ -256,7 +256,12 @@ async function checkComponent(name, manifest) {
         // `--update` refuses these; the local lines would be deleted.
         status = 'modified';
         message = `${localOnly.length} local line(s) upstream lacks — --update would refuse`;
-        if (upstreamOnly.length > 0) message += `, ${upstreamOnly.length} upstream line(s) pending`;
+        // Deliberately NOT "N updates available". Both counts are set
+        // differences, so a line we edited locally appears on both sides: once
+        // as ours, once as the upstream original it replaced. For a modified
+        // component this number is mostly the mirror image of its own local
+        // edits, not new upstream work waiting to be collected.
+        if (upstreamOnly.length > 0) message += `, ${upstreamOnly.length} not matching upstream verbatim`;
         // Divergence with a recorded reason is a decision; divergence without
         // one is an open question. Surfacing the split makes the untriaged
         // components a visible to-do instead of undifferentiated noise.


### PR DESCRIPTION
Completes the triage started in #3054. All 17 locally-modified components now carry a `localEdits` note, and `--check` reports **0 UNDOCUMENTED**.

## None of the nine are droppable either

Same result as the first eight — every one is a deliberate fix or API extension:

| | why it diverges |
|---|---|
| `command` (35) | ADR-0054 C4 `contentProps` + the `sr-only` DialogTitle Radix requires. Upstream drops each addition *with its usages*, so a sync deletes ~38 lines and still type-checks — verified. |
| `select` (32) | Wraps Root to swallow `onValueChange("")`. Radix's hidden native mirror registers options a commit after the trigger, so a value arriving mid-hydration echoes back empty and wipes the field, latching forms whose `visibleWhen` reads it (#2968). |
| `sidebar` (24) | Tailwind v4 syntax, a `data-collapsible`-always-present refactor, and an `eslint-disable react-hooks/purity`. |
| `table` (17) | `containerClassName`, to stop the wrapper becoming a second height-unbounded scroll container inside DataTable. |
| `chart` (11) | `block … w-full` instead of `flex justify-center`, or ResponsiveContainer measures no width and charts draw axes with no marks (#1634, `9b163173b`); plus hand-written Recharts prop types that actually type-check (`2e11aa72f`). |
| `calendar` (7) | Tailwind v4 syntax on `--cell-size`. |
| `badge` (4) | `whitespace-nowrap`, or CJK labels (待审批) break per-character in a cramped table cell (objectui#2762 P0-1). |
| `sheet` (4) | `hideOverlay` prop. |
| `slider` (4) | Forwards `aria-label` to the Thumb. |

## Two claims I checked instead of asserting

Both could have shipped as confident wrong statements:

**Sidebar's `eslint-disable` is load-bearing.** Removed it and re-ran ESLint: `react-hooks/purity` fires as an **error**, not a warning, and Lint gates CI. Claim stands.

**`theme(spacing.4)` → `1rem` is cosmetic, not a fix.** I initially wrote that upstream's `theme()` is "a v3 idiom", implying it's broken. Compiling both against tailwindcss 4.3.3:

```
.w-\[calc\(var\(--zz-icon\)_\+_1rem\)\]                    { width: calc(var(--zz-icon) + 1rem) }
.w-\[calc\(var\(--zz-icon\)_\+_theme\(spacing\.4\)\)\]     { width: calc(var(--zz-icon) + 1rem) }
```

Identical. v4 still resolves the dot-notation. The note now says so explicitly — only the `[--var]` → `(--var)` half of that migration is load-bearing.

## Fixes a misleading `--check` label

Both counts are **set differences**, so a locally-edited line appears on *both* sides — once as ours, once as the upstream original it replaced. Labelling that "N upstream line(s) pending" reads as updates waiting to be collected.

That's exactly how I misread `sidebar`'s 21 and recommended it as the highest-value target with "21 lines to reclaim". There is essentially nothing to reclaim — the 21 are mostly the mirror image of sidebar's own 24 edits. Now reads **"N not matching upstream verbatim"**.

The `outdated` bucket keeps its original wording: there `localOnly` is 0, so the count genuinely *is* new upstream work.

## Where this leaves the sync

```
✓ Identical: 29    ↑ Outdated: 0    ⚠ Modified: 17 (17 documented)    ● Custom: 2    ✗ Errors: 0
```

Every tracked component is now either byte-identical to upstream or carries a written reason for diverging. `--update` prints that reason at the moment someone is about to `--force` past it.

## Verification

- All 17 annotations derived from reading the actual diffs, cross-checked against `git log -S` provenance where a commit exists (`925051db6`, `9b163173b`, `2e11aa72f`)
- Manifest stays canonically formatted (byte-identical to `JSON.stringify(…, null, 2)`)
- `--check` / `--diff` / `--update` and the #3033 / #3035 guards regression-checked
- `eslint` clean; **no component source changes** — manifest and script only

No changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)