### PR TITLE
fix(types): Page/App/Dashboard validate the spec's own fields instead of passing them through (#4115 C 组)

### DIFF
--- a/packages/types/src/__tests__/page-app-dashboard-spec-parity.test.ts
+++ b/packages/types/src/__tests__/page-app-dashboard-spec-parity.test.ts
@@ -1,0 +1,191 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Page / App / Dashboard ↔ `@objectstack/spec` drift guard (objectstack#4115).
+ *
+ * These three renderer nodes extend `BaseSchema`, which is `.passthrough()`,
+ * while their spec counterparts are strict. That combination is the objectui
+ * equivalent of the objectstack#4120 silent-drop failure: every spec-only key
+ * — `branding`, `sharing`, `interfaceConfig`, `source`, `header`,
+ * `performance`, the whole `_lock*` package envelope — rode through
+ * *completely unvalidated*, so `brading: {…}` was indistinguishable from
+ * `branding: {…}` and a spec-authored `kind: 'html'` page could not even
+ * express its body (`source` was never declared).
+ *
+ * The fix is NOT `.strict()` — these are component nodes and the open envelope
+ * is deliberate. It is to let the spec's own fields flow in by reference
+ * (`SpecXFields = SpecXSchema.omit({…}).partial()`), the pattern
+ * `zod/objectql.zod.ts`'s `ListViewSchema` already uses.
+ *
+ * The derivation picks up new spec fields automatically, but can still break
+ * silently in three ways, which these tests catch:
+ *
+ *   1. The spec grows a field objectui never triaged. Asserted: every spec key
+ *      is present in the objectui shape, or envelope-owned by BaseSchema.
+ *   2. The spec renames/removes a field objectui deliberately omits and
+ *      re-declares locally — the local override would then shadow nothing.
+ *      Asserted: every omitted anchor still exists upstream.
+ *   3. Someone adds an objectui-local key that should have been a spec field.
+ *      Asserted: every objectui-only key is in the sanctioned set below.
+ *
+ * When one fails, do NOT edit the sets to make it green — decide whether the
+ * field belongs upstream in `@objectstack/spec` or is a genuine objectui-only
+ * extension, and record the reason.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AppSchema as SpecAppSchema,
+  DashboardSchema as SpecDashboardSchema,
+  PageSchema as SpecPageSchema,
+} from '@objectstack/spec/ui';
+import { AppSchema as OuiAppSchema } from '../zod/app.zod.js';
+import { DashboardSchema as OuiDashboardSchema } from '../zod/complex.zod.js';
+import { PageSchema as OuiPageSchema } from '../zod/layout.zod.js';
+import { BaseSchema } from '../zod/base.zod.js';
+
+const shapeOf = (s: unknown) => (s as { shape: Record<string, unknown> }).shape;
+
+/** Component-envelope keys owned by BaseSchema — derived, never hand-listed. */
+const ENVELOPE = new Set(Object.keys(shapeOf(BaseSchema)));
+
+interface Case {
+  spec: unknown;
+  oui: unknown;
+  /** Spec keys objectui deliberately omits and re-declares locally. */
+  omitted: string[];
+  /** objectui-only keys, each a conscious local-vs-upstream decision. */
+  local: string[];
+}
+
+const CASES: Record<string, Case> = {
+  Page: {
+    spec: SpecPageSchema,
+    oui: OuiPageSchema,
+    // `type` collides semantically (spec = page kind, objectui = component
+    // discriminator, kind lives on `pageType`); `regions` is a local fork.
+    omitted: ['type', 'regions'],
+    local: ['title', 'pageType', 'body', 'children'],
+  },
+  App: {
+    spec: SpecAppSchema,
+    oui: OuiAppSchema,
+    omitted: ['navigation', 'areas', 'contextSelectors'],
+    local: ['title', 'logo', 'favicon', 'layout', 'menu', 'actions'],
+  },
+  Dashboard: {
+    spec: SpecDashboardSchema,
+    oui: OuiDashboardSchema,
+    omitted: ['widgets', 'globalFilters', 'dateRange'],
+    local: [],
+  },
+};
+
+describe.each(Object.keys(CASES))('%s spec parity (objectstack#4115 drift guard)', (name) => {
+  const { spec, oui, omitted, local } = CASES[name];
+  const specShape = shapeOf(spec);
+  const ouiShape = shapeOf(oui);
+  const ouiKeys = new Set(Object.keys(ouiShape));
+
+  it('covers every spec field — the spec cannot grow a key objectui ignores', () => {
+    const missing = Object.keys(specShape).filter((k) => !ouiKeys.has(k) && !ENVELOPE.has(k));
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps the upstream anchors it deliberately omits and re-declares', () => {
+    // A rename upstream would orphan the local override, silently reopening
+    // the very drift this derivation closed.
+    for (const key of omitted) {
+      expect(specShape, `spec no longer declares '${key}'`).toHaveProperty(key);
+    }
+  });
+
+  it('declares no objectui-only key outside the sanctioned set', () => {
+    const rogue = [...ouiKeys].filter(
+      (k) => !(k in specShape) && !ENVELOPE.has(k) && !local.includes(k),
+    );
+    expect(rogue).toEqual([]);
+  });
+});
+
+describe('spec-only keys are now VALIDATED, not passed through (objectstack#4115)', () => {
+  it('Page declares the five keys that used to ride through unchecked', () => {
+    const keys = Object.keys(shapeOf(OuiPageSchema));
+    for (const key of ['interfaceConfig', 'kind', 'slots', 'source', 'requires']) {
+      expect(keys, `'${key}' is still undeclared`).toContain(key);
+    }
+  });
+
+  it('Page can finally express a source-authored page (kind html/react)', () => {
+    // Before the derivation `source` was not declared at all, so `kind: 'html'`
+    // was unauthorable — the body had nowhere to live.
+    const ok = OuiPageSchema.safeParse({ type: 'page', kind: 'html', source: '<h1>hi</h1>' });
+    expect(ok.success).toBe(true);
+    expect(ok.success && (ok.data as { source?: string }).source).toBe('<h1>hi</h1>');
+  });
+
+  it('Page rejects a bad `kind` instead of waving it through', () => {
+    expect(OuiPageSchema.safeParse({ type: 'page', kind: 'nonsense' }).success).toBe(false);
+  });
+
+  it('App declares the package-lock and access keys that used to ride through', () => {
+    const keys = Object.keys(shapeOf(OuiAppSchema));
+    for (const key of ['branding', 'sharing', 'embed', 'objects', 'apis', 'requiredPermissions', 'homePageId', '_packageId']) {
+      expect(keys, `'${key}' is still undeclared`).toContain(key);
+    }
+  });
+
+  it('App validates branding instead of accepting any shape', () => {
+    expect(OuiAppSchema.safeParse({ type: 'app', branding: { primaryColor: '#fff' } }).success).toBe(true);
+    // A wrong-typed branding used to be indistinguishable from a correct one.
+    expect(OuiAppSchema.safeParse({ type: 'app', branding: 'blue' }).success).toBe(false);
+  });
+
+  it('Dashboard declares header/refreshInterval/performance', () => {
+    const keys = Object.keys(shapeOf(OuiDashboardSchema));
+    for (const key of ['header', 'refreshInterval', 'performance', 'protection']) {
+      expect(keys, `'${key}' is still undeclared`).toContain(key);
+    }
+  });
+
+  it('Dashboard validates header instead of accepting any shape', () => {
+    expect(
+      OuiDashboardSchema.safeParse({ type: 'dashboard', widgets: [], header: { showTitle: true } }).success,
+    ).toBe(true);
+    expect(
+      OuiDashboardSchema.safeParse({ type: 'dashboard', widgets: [], header: 'yes' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('the derivation stays permissive where objectui needs it', () => {
+  it('no spec field became required — stored payloads keep validating', () => {
+    // `.partial()` on the imported shape is what guarantees this; without it a
+    // spec field gaining `required` would invalidate every stored node.
+    expect(OuiPageSchema.safeParse({ type: 'page' }).success).toBe(true);
+    expect(OuiAppSchema.safeParse({ type: 'app' }).success).toBe(true);
+    expect(OuiDashboardSchema.safeParse({ type: 'dashboard', widgets: [] }).success).toBe(true);
+  });
+
+  it('the local vocabulary still parses', () => {
+    expect(
+      OuiPageSchema.safeParse({ type: 'page', pageType: 'record', title: 'T', regions: [] }).success,
+    ).toBe(true);
+    expect(
+      OuiAppSchema.safeParse({ type: 'app', title: 'T', logo: '/l.png', layout: 'sidebar' }).success,
+    ).toBe(true);
+  });
+
+  it('the component envelope still passes unknown renderer props through', () => {
+    // BaseSchema is deliberately open for type-specific extensions; the fix
+    // narrows what the SPEC owns, it does not close the node.
+    const r = OuiPageSchema.safeParse({ type: 'page', someRendererProp: 42 });
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/types/src/zod/app.zod.ts
+++ b/packages/types/src/zod/app.zod.ts
@@ -17,7 +17,8 @@
  */
 
 import { z } from 'zod';
-import { BaseSchema } from './base.zod.js';
+import { AppSchema as SpecAppSchema } from '@objectstack/spec/ui';
+import { BaseSchema, specFieldsExcept } from './base.zod.js';
 
 // ============================================================================
 // Unified NavigationItem Schema
@@ -151,7 +152,42 @@ export const AppContextSelectorSchema = z.object({
 /**
  * App Schema - Top-level application configuration
  */
-export const AppSchema = BaseSchema.extend({
+/**
+ * Spec-owned App fields, flowing in **by reference** (objectstack#4115).
+ *
+ * `BaseSchema` is `.passthrough()` while the spec's `AppSchema` is strict, so
+ * before this derivation 23 spec-only keys rode through objectui completely
+ * unvalidated — `branding`, `sharing`, `embed`, `objects`, `apis`,
+ * `requiredPermissions`, `homePageId`, `protection` and the whole
+ * `_lock*`/`_package*`/`_provenance` package-lock envelope. A typo in any of
+ * them (`brading: {…}`) was invisible, and a packaged app round-tripped
+ * through this schema lost nothing only by luck.
+ *
+ * Omitted, each for a stated reason:
+ *  - `name`/`label`/`description` — component-envelope keys owned by BaseSchema;
+ *  - `navigation`/`areas`/`contextSelectors` — objectui's element schemas are
+ *    their own ledger entries (they drift from the spec's on `badgeVariant`,
+ *    `expanded`/`defaultOpen`, `visible` and target-field requiredness);
+ *    migrating them is a separate, larger decision.
+ *
+ * `.partial()` guarantees no *future* spec field can become required and
+ * silently invalidate stored objectui apps.
+ */
+const SpecAppFields = specFieldsExcept(SpecAppSchema.shape, [
+  'name',
+  'label',
+  'description',
+  'navigation',
+  'areas',
+  'contextSelectors',
+] as const);
+
+/**
+ * App Schema — the objectui app-shell renderer node, derived from
+ * `@objectstack/spec/ui` `AppSchema` (see {@link SpecAppFields}). The drift
+ * guard is `__tests__/page-app-dashboard-spec-parity.test.ts`.
+ */
+export const AppSchema = BaseSchema.extend(SpecAppFields.shape).extend({
   type: z.literal('app'),
   name: z.string().optional().describe('Application name (system ID)'),
   title: z.string().optional().describe('Display title'),

--- a/packages/types/src/zod/base.zod.ts
+++ b/packages/types/src/zod/base.zod.ts
@@ -148,6 +148,36 @@ const BaseSchemaCore = z.object({
 export const BaseSchema = BaseSchemaCore;
 
 /**
+ * A spec schema's fields, minus the keys objectui declares locally, as an
+ * all-optional shape ready for `BaseSchema.extend(…)` (objectstack#4115).
+ *
+ * `BaseSchema` is `.passthrough()` while the spec's document schemas are
+ * strict, so a renderer node that does not declare the spec's fields lets
+ * every one of them ride through *unvalidated*. Spreading this result back in
+ * makes them validated again without closing the node to renderer props.
+ *
+ * Two deliberate properties:
+ *  - **by reference** — a field the spec adds is picked up automatically
+ *    rather than re-typed (and the per-node drift guard fails if it was never
+ *    triaged);
+ *  - **`.partial()`** — no future spec field can become required and silently
+ *    invalidate payloads objectui has already stored.
+ *
+ * Reads `.shape` rather than calling `SpecSchema.omit({…}).partial()` because
+ * zod 4 refuses `.omit()` on an object carrying refinements — spec's
+ * `PageSchema` has one, so the idiomatic form throws at import time.
+ */
+export function specFieldsExcept<T extends z.ZodRawShape, K extends keyof T & string>(
+  shape: T,
+  omit: readonly K[],
+) {
+  const kept = Object.fromEntries(
+    Object.entries(shape).filter(([key]) => !omit.includes(key as K)),
+  ) as Omit<T, K>;
+  return z.object(kept).partial();
+}
+
+/**
  * Component Input Configuration
  */
 export const ComponentInputSchema = z.object({

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -17,7 +17,8 @@
  */
 
 import { z } from 'zod';
-import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
+import { DashboardSchema as SpecDashboardSchema } from '@objectstack/spec/ui';
+import { BaseSchema, SchemaNodeSchema, specFieldsExcept } from './base.zod.js';
 import { DASHBOARD_COLOR_VARIANTS, DASHBOARD_WIDGET_TYPES } from '../designer.js';
 
 /**
@@ -322,7 +323,40 @@ export const GlobalFilterSchema = z.object({
 /**
  * Dashboard Schema - Dashboard component
  */
-export const DashboardSchema = BaseSchema.extend({
+/**
+ * Spec-owned Dashboard fields, flowing in **by reference** (objectstack#4115).
+ *
+ * `BaseSchema` is `.passthrough()` while the spec's `DashboardSchema` is
+ * strict, so before this derivation every spec-only key rode through objectui
+ * unvalidated — `header`, `refreshInterval`, `performance`, `aria`,
+ * `protection` and the `_lock*`/`_package*`/`_provenance` package-lock
+ * envelope were neither checked nor declared.
+ *
+ * Omitted, each for a stated reason:
+ *  - `name`/`label`/`description` — component-envelope keys owned by BaseSchema;
+ *  - `widgets`/`globalFilters`/`dateRange` — objectui's element schemas are
+ *    their own ledger entries (the local widget still carries the legacy
+ *    `component` envelope the spec has no room for, and both local configs are
+ *    deliberately looser than spec's); migration deferred.
+ *
+ * `.partial()` guarantees no *future* spec field can become required and
+ * silently invalidate stored objectui dashboards.
+ */
+const SpecDashboardFields = specFieldsExcept(SpecDashboardSchema.shape, [
+  'name',
+  'label',
+  'description',
+  'widgets',
+  'globalFilters',
+  'dateRange',
+] as const);
+
+/**
+ * Dashboard Schema — the objectui dashboard renderer node, derived from
+ * `@objectstack/spec/ui` `DashboardSchema` (see {@link SpecDashboardFields}).
+ * The drift guard is `__tests__/page-app-dashboard-spec-parity.test.ts`.
+ */
+export const DashboardSchema = BaseSchema.extend(SpecDashboardFields.shape).extend({
   type: z.literal('dashboard'),
   columns: z.number().optional().describe('Number of columns'),
   gap: z.number().optional().describe('Grid gap'),

--- a/packages/types/src/zod/layout.zod.ts
+++ b/packages/types/src/zod/layout.zod.ts
@@ -18,10 +18,11 @@
 
 import { z } from 'zod';
 import {
+  PageSchema as SpecPageSchema,
   PageTypeSchema as SpecPageTypeSchema,
   PageVariableSchema as SpecPageVariableSchema,
 } from '@objectstack/spec/ui';
-import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
+import { BaseSchema, SchemaNodeSchema, specFieldsExcept } from './base.zod.js';
 
 /**
  * Div Schema - Basic HTML container
@@ -273,10 +274,41 @@ export const PageVariableSchema = SpecPageVariableSchema;
 export const PageTypeSchema = SpecPageTypeSchema;
 
 /**
- * Page Schema - Top-level page layout
- * Aligned with @objectstack/spec PageSchema
+ * Spec-owned Page fields, flowing in **by reference** (objectstack#4115).
+ *
+ * `BaseSchema` is `.passthrough()` while the spec's `PageSchema` is strict, so
+ * before this derivation every spec-only key rode through objectui completely
+ * unvalidated — `interfaceConfig`, `kind`, `slots`, `source`, `requires` and
+ * `aria` were neither checked nor even declared. `source` was the sharpest
+ * hole: `kind: 'html' | 'react'` pages carry their body in `source`, so a
+ * source-authored page could not be expressed here at all.
+ *
+ * Omitted, each for a stated reason:
+ *  - `name`/`label`/`description` — component-envelope keys owned by BaseSchema;
+ *  - `type` — the names genuinely collide: spec's `type` IS the page kind
+ *    (`record|app|utility|list|home`), objectui's is the component
+ *    discriminator (`'page'`) and the kind lives on `pageType` below.
+ *    Reconciling the two is a rename decision tracked separately;
+ *  - `regions` — objectui's `PageRegionSchema` adds `type`/`className` and
+ *    widens `width`; migration deferred (it is its own ledger entry).
+ *
+ * `.partial()` guarantees no *future* spec field can become required and
+ * silently invalidate stored objectui pages.
  */
-export const PageSchema = BaseSchema.extend({
+const SpecPageFields = specFieldsExcept(SpecPageSchema.shape, [
+  'name',
+  'label',
+  'description',
+  'type',
+  'regions',
+] as const);
+
+/**
+ * Page Schema — top-level page layout, derived from `@objectstack/spec/ui`
+ * `PageSchema` (see {@link SpecPageFields}). The drift guard is
+ * `__tests__/page-app-dashboard-spec-parity.test.ts`.
+ */
+export const PageSchema = BaseSchema.extend(SpecPageFields.shape).extend({
   type: z.literal('page'),
   title: z.string().optional().describe('Page title'),
   icon: z.string().optional().describe('Page icon (Lucide icon name)'),


### PR DESCRIPTION
承 objectstack#4115 [分诊评论](https://github.com/objectstack-ai/objectstack/issues/4115#issuecomment-5132223353)里划出的 **C 组** —— 该组的选择理由是:它是 #4120 失效形态在 objectui 的等价物,**且不需要任何重命名决策**(A 组要改公开导出名,B 组要先定 `type` 判别式的命名约定)。

## 问题:`.passthrough()` 遇上 `.strict()`

`AppSchema`/`DashboardSchema`/`PageSchema` 都 `extend` 自 `BaseSchema`,而后者是 `.passthrough()`;spec 侧对应的三个是 strict。结果是 **spec 独有的键完全不经校验穿过去**:

| 节点 | 未校验的 spec 键 | 数量 |
|:--|:--|--:|
| App | `branding` `sharing` `embed` `objects` `apis` `requiredPermissions` `homePageId` `protection` + `_lock*`/`_package*`/`_provenance` 整个包锁封套 | 23 |
| Dashboard | `header` `refreshInterval` `performance` `aria` `protection` + 包锁封套 | 10 |
| Page | `interfaceConfig` `kind` `slots` `source` `requires` `aria` | 6 |

`brading: {…}` 和 `branding: {…}` 在校验层面无从区分 —— 这正是 #4120 抓到的那类静默失效。

**Page 还带一个活的后果**:`source` 从未被声明,而 `kind: 'html' | 'react'` 的页面正是把正文放在 `source` 里的 —— 也就是说这类页面在这里**根本无法表达**。

## 修法:不是 `.strict()`,是把 spec 的字段按引用引进来

加 `.strict()` 是错的 —— 这三个是**组件节点**,开放封套是有意为之(渲染器属性本就该穿透)。正解是让 spec 自己的字段按引用流入,也就是 `zod/objectql.zod.ts` 的 `ListViewSchema` 已经在用的范式。

新增 `specFieldsExcept()`(base.zod.ts)承载这个模式。**它读 `.shape` 而不是调 `SpecSchema.omit({…}).partial()`,因为 zod 4 拒绝对带 refinement 的对象 `.omit()`** —— spec 的 `PageSchema` 恰好有一个,惯用写法会在 import 期直接抛异常。这个坑记在 helper 的文档注释里(踩过一次就够了)。

每处 omit 都在原地写明理由:
- `name`/`label`/`description` → 组件外壳,归 `BaseSchema`;
- **Page 的 `type` 是真冲突**:spec 的 `type` 是页面**种类**(`record|app|utility|list|home`),objectui 的是组件**判别式**(`'page'`),种类被放在 `pageType`。二者的调和是 B 组的重命名决策,本 PR 不动;
- 各自的元素 schema(`navigation`/`areas`/`contextSelectors`、`widgets`/`globalFilters`/`dateRange`、`regions`)本身就是台账里独立的条目,保持本地、迁移另议。

`.partial()` 保证**未来任何 spec 字段变成必填都不会让已存的 objectui 载荷失效**。

## 闸门与变异测试

新增 `page-app-dashboard-spec-parity.test.ts`(19 断言),三个方向:spec 长出未分诊字段 / spec 重命名被本地覆盖的锚点 / 有人加了未分诊的本地键。另有一组断言直接钉住「这些键现在真的被校验了」——例如 `branding: 'blue'` 从**通过**变成**拒绝**,`kind: 'nonsense'` 从通过变成拒绝,以及 `kind:'html' + source` 现在能正常表达。

变异测试(两个方向都会红):
- 从 App 的派生里偷偷 omit 掉 `branding` → **3 个测试按名报红**(`expected [ 'branding' ] to deeply equal []`、`'branding' is still undeclared`、以及 branding 校验断言);
- 给 Page 加一个未登记的本地键 → rogue-key 断言报红(`expected [ 'myUntriagedField' ] to deeply equal []`)。

## 验证

全仓 `type-check` 78/78 绿;`@object-ui/types` 271 断言绿;下游消费方(app-shell / plugin-dashboard / plugin-list / core)**3626 断言绿** —— 确认收紧校验没有挡住任何现有渲染路径。另有一组断言专门守住「组件外壳仍然放行未知渲染器属性」,即这次收紧的只是 **spec 拥有的那部分**,节点本身没有被关上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)