### PR TITLE
fix(grid): 批量 action 的 `visible` 改为逐条记录求值 (#3067)

### DIFF
--- a/.changeset/bulk-visible-per-record.md
+++ b/.changeset/bulk-visible-per-record.md
@@ -1,0 +1,35 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/i18n": patch
+---
+
+fix(grid): a bulk action's `visible` is evaluated per selected record — objectui#3067
+
+The selection bar evaluated a def's `visible` against the ambient scope with no
+record bound. That does not fail open, it answers wrongly: with no `record` in
+scope the lenient evaluator returned `true` for **every** row-scoped predicate,
+including the ones that should be false — `${record.done}` and
+`${record.owner == user.id}` both came back `true`. An authored gate was not
+weakened, it was inverted for half its inputs, and nothing distinguished that
+from a real verdict.
+
+`visible` is now evaluated **once per selected record, with that record in
+scope**, fail-closed per record and warning once on a fault — the same contract
+the row kebab uses. One evaluation answers both questions:
+
+- **Is the button offered?** When at least one selected record passes. A
+  record-free predicate (`features.x`, `current_user.y`) returns the same
+  verdict for every row, so it still behaves as a plain button-level gate — no
+  syntactic sniffing for `record` references is involved.
+- **Which records does it run on?** The ones that passed. The confirm step
+  states how many were skipped, so a run over fewer records than the user
+  ticked says so instead of quietly shrinking the selection.
+
+Eligibility is re-applied to the EXPANDED set after "select all N matching",
+not just the page selection the button could see.
+
+The mechanism predates objectui#3002, but only inline-authored
+`bulkActionDefs[].visible` used to reach it — written by authors who knew there
+was no record. #3031 began promoting object actions into the bar, and their
+`visible` is typically written for a row/record surface, which is what put
+row-scoped predicates in front of a record-free evaluation.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -245,6 +245,7 @@ const ar = {
       confirmDefault: "سيُطبَّق هذا على {{count}} من السجلات.",
       overLimit: "التحديد ({{count}}) يتجاوز حد الإجراء ({{limit}}). قلّل التحديد للمتابعة.",
       affectedRecords: "السجلات المتأثرة ({{count}}):",
+      skippedIneligible: '{{count}} من السجلات المحددة غير مؤهلة لهذا الإجراء وسيتم تخطيها.',
       rowFallback: "الصف {{index}}",
       andMore: "… و{{count}} أخرى",
       processed: "تمت معالجة {{count}} / {{total}}",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -245,6 +245,7 @@ const de = {
       confirmDefault: "Dies wird auf {{count}} Datensätze angewendet.",
       overLimit: "Die Auswahl ({{count}}) überschreitet das Aktionslimit ({{limit}}). Verkleinern Sie die Auswahl, um fortzufahren.",
       affectedRecords: "Betroffene Datensätze ({{count}}):",
+      skippedIneligible: '{{count}} der ausgewählten Datensätze sind für diese Aktion nicht zulässig und werden übersprungen.',
       rowFallback: "Zeile {{index}}",
       andMore: "… und {{count}} weitere",
       processed: "{{count}} / {{total}} verarbeitet",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -420,6 +420,7 @@ const en = {
       confirmDefault: 'This will apply to {{count}} record(s).',
       overLimit: 'Selection ({{count}}) exceeds the action limit ({{limit}}). Reduce the selection to proceed.',
       affectedRecords: 'Affected records ({{count}}):',
+      skippedIneligible: '{{count}} selected record(s) are not eligible for this action and will be skipped.',
       rowFallback: 'Row {{index}}',
       andMore: '\u2026 and {{count}} more',
       processed: '{{count}} / {{total}} processed',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -245,6 +245,7 @@ const es = {
       confirmDefault: "Esto se aplicará a {{count}} registro(s).",
       overLimit: "La selección ({{count}}) supera el límite de la acción ({{limit}}). Reduzca la selección para continuar.",
       affectedRecords: "Registros afectados ({{count}}):",
+      skippedIneligible: '{{count}} de los registros seleccionados no son aptos para esta acción y se omitirán.',
       rowFallback: "Fila {{index}}",
       andMore: "… y {{count}} más",
       processed: "{{count}} / {{total}} procesados",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -245,6 +245,7 @@ const fr = {
       confirmDefault: "Ceci s'appliquera à {{count}} enregistrement(s).",
       overLimit: "La sélection ({{count}}) dépasse la limite de l'action ({{limit}}). Réduisez la sélection pour continuer.",
       affectedRecords: "Enregistrements concernés ({{count}}) :",
+      skippedIneligible: '{{count}} des enregistrements sélectionnés ne sont pas éligibles à cette action et seront ignorés.',
       rowFallback: "Ligne {{index}}",
       andMore: "… et {{count}} de plus",
       processed: "{{count}} / {{total}} traités",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -245,6 +245,7 @@ const ja = {
       confirmDefault: "{{count}} 件のレコードに適用されます。",
       overLimit: "選択件数（{{count}}）がアクションの上限（{{limit}}）を超えています。選択を減らしてください。",
       affectedRecords: "対象レコード（{{count}}）:",
+      skippedIneligible: "選択したレコードのうち {{count}} 件はこのアクションの対象外のため、スキップされます。",
       rowFallback: "{{index}} 行目",
       andMore: "… 他 {{count}} 件",
       processed: "{{count}} / {{total}} 件を処理",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -245,6 +245,7 @@ const ko = {
       confirmDefault: "레코드 {{count}}건에 적용됩니다.",
       overLimit: "선택 건수({{count}})가 작업 한도({{limit}})를 초과합니다. 선택을 줄여 주세요.",
       affectedRecords: "영향을 받는 레코드({{count}}):",
+      skippedIneligible: "선택한 레코드 중 {{count}}건은 이 작업의 대상이 아니므로 건너뜁니다.",
       rowFallback: "{{index}}행",
       andMore: "… 외 {{count}}건",
       processed: "{{count}} / {{total}} 처리됨",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -245,6 +245,7 @@ const pt = {
       confirmDefault: "Isto será aplicado a {{count}} registro(s).",
       overLimit: "A seleção ({{count}}) excede o limite da ação ({{limit}}). Reduza a seleção para prosseguir.",
       affectedRecords: "Registros afetados ({{count}}):",
+      skippedIneligible: '{{count}} dos registros selecionados não são elegíveis para esta ação e serão ignorados.',
       rowFallback: "Linha {{index}}",
       andMore: "… e mais {{count}}",
       processed: "{{count}} / {{total}} processados",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -245,6 +245,7 @@ const ru = {
       confirmDefault: "Будет применено к записям: {{count}}.",
       overLimit: "Выбрано ({{count}}) больше лимита действия ({{limit}}). Уменьшите выбор, чтобы продолжить.",
       affectedRecords: "Затрагиваемые записи ({{count}}):",
+      skippedIneligible: '{{count}} из выбранных записей не подходят для этого действия и будут пропущены.',
       rowFallback: "Строка {{index}}",
       andMore: "… и ещё {{count}}",
       processed: "Обработано {{count}} / {{total}}",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -428,6 +428,7 @@ const zh = {
       confirmDefault: '此操作将应用于 {{count}} 条记录。',
       overLimit: '所选记录（{{count}}）超过该动作的上限（{{limit}}）。请减少选择后再继续。',
       affectedRecords: '受影响的记录（{{count}}）：',
+      skippedIneligible: '{{count}} 条所选记录不符合该动作的条件，将被跳过。',
       rowFallback: '第 {{index}} 行',
       andMore: '……以及另外 {{count}} 条',
       processed: '已处理 {{count}} / {{total}}',

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -46,6 +46,7 @@ import { useColumnSummary } from './useColumnSummary';
 import { resolveRowCrudAffordances } from './rowCrudAffordances';
 import { resolveLegacyRowActions } from './resolveLegacyRowActions';
 import { resolveBulkActions } from './resolveBulkActions';
+import { partitionBulkRows } from './bulkEligibility';
 import { RowActionMenu, formatActionLabel } from './components/RowActionMenu';
 import { BulkActionBar } from './components/BulkActionBar';
 import { BulkActionDialog } from './components/BulkActionDialog';
@@ -254,6 +255,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const [totalMatching, setTotalMatching] = useState<number | undefined>(undefined);
   const [activeBulkDef, setActiveBulkDef] = useState<BulkActionDef | null>(null);
   const [activeBulkRows, setActiveBulkRows] = useState<any[]>([]);
+  // Selected records the def's `visible` excluded (#3067) — shown in the
+  // dialog so a run over fewer records than the user picked says so.
+  const [activeBulkSkipped, setActiveBulkSkipped] = useState(0);
   const lastFindParamsRef = React.useRef<Record<string, unknown> | null>(null);
   // Grouped view paginates whole groups (groups stay intact, never split across
   // pages). Defaults to the schema page size, falling back to 10 groups/page.
@@ -1751,8 +1755,14 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const dispatchBulkActionDef = (def: BulkActionDef, rows: any[]) => {
     void (async () => {
       const expanded = await resolveBulkRows(rows);
+      // [#3067] Re-apply `visible` to the EXPANDED set, not just the page
+      // selection the bar could see: "select all N matching" pulls in records
+      // the button's own eligibility check never evaluated, and running the
+      // action on those would defeat the gate the author wrote.
+      const { eligible, skipped } = partitionBulkRows(def, expanded, { scope: predicateScope });
       setActiveBulkDef(def);
-      setActiveBulkRows(expanded);
+      setActiveBulkRows(eligible);
+      setActiveBulkSkipped(skipped);
     })();
   };
 
@@ -1799,6 +1809,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const handleBulkDialogClose = (result?: BulkResult | null) => {
     setActiveBulkDef(null);
     setActiveBulkRows([]);
+    setActiveBulkSkipped(0);
     // Only reset selection when the run actually changed something. A total
     // failure (0 succeeded — e.g. a "推计划" precondition error) leaves the data
     // untouched, so we keep the selection *and* the toolbar so the user can fix
@@ -2603,6 +2614,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     <BulkActionDialog
       def={activeBulkDef}
       rows={activeBulkRows}
+      skippedCount={activeBulkSkipped}
       open={!!activeBulkDef}
       onClose={handleBulkDialogClose}
       dataSource={dataSource as any}

--- a/packages/plugin-grid/src/__tests__/bulkEligibility.test.ts
+++ b/packages/plugin-grid/src/__tests__/bulkEligibility.test.ts
@@ -1,0 +1,99 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { partitionBulkRows } from '../bulkEligibility';
+
+const ROWS = [
+  { id: 'r1', done: false, owner: 'u1' },
+  { id: 'r2', done: true, owner: 'u2' },
+  { id: 'r3', done: false, owner: 'u2' },
+];
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('partitionBulkRows', () => {
+  it('passes everything through when the def declares no visible', () => {
+    const { eligible, skipped } = partitionBulkRows({ name: 'push' }, ROWS);
+
+    // By reference — the ungated case must not bust downstream memos.
+    expect(eligible).toBe(ROWS);
+    expect(skipped).toBe(0);
+  });
+
+  it('evaluates a row-scoped predicate PER RECORD', () => {
+    const { eligible, skipped } = partitionBulkRows({ name: 'mark_done', visible: '!record.done' }, ROWS);
+
+    expect(eligible.map(r => r.id)).toEqual(['r1', 'r3']);
+    expect(skipped).toBe(1);
+  });
+
+  it('answers the inverse predicate correctly too', () => {
+    // The regression this exists for: with no record in scope BOTH
+    // `!record.done` and `record.done` evaluated `true`, so one of them was
+    // necessarily wrong and nothing could tell which.
+    const { eligible } = partitionBulkRows({ name: 'reopen', visible: 'record.done' }, ROWS);
+
+    expect(eligible.map(r => r.id)).toEqual(['r2']);
+  });
+
+  it('binds the host scope alongside the record', () => {
+    const { eligible } = partitionBulkRows(
+      { name: 'mine', visible: 'record.owner == current_user.id' },
+      ROWS,
+      { scope: { current_user: { id: 'u2' } } },
+    );
+
+    expect(eligible.map(r => r.id)).toEqual(['r2', 'r3']);
+  });
+
+  it('gives a record-free predicate the same verdict for every row', () => {
+    // This is what makes a plain feature/permission gate keep behaving as a
+    // BUTTON-level gate without the fold having to detect record references.
+    const on = partitionBulkRows({ name: 'x', visible: 'features.bulk_ops' }, ROWS, {
+      scope: { features: { bulk_ops: true } },
+    });
+    const off = partitionBulkRows({ name: 'x', visible: 'features.bulk_ops' }, ROWS, {
+      scope: { features: { bulk_ops: false } },
+    });
+
+    expect(on.eligible).toHaveLength(3);
+    expect(off.eligible).toHaveLength(0);
+    expect(off.skipped).toBe(3);
+  });
+
+  it('fails CLOSED and warns when a predicate faults', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { eligible, skipped } = partitionBulkRows(
+      { name: 'broken', visible: 'record.missing.deep == 1' },
+      ROWS,
+    );
+
+    expect(eligible).toEqual([]);
+    expect(skipped).toBe(3);
+    // Diagnosable rather than a silent hide.
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('accepts the { dialect, source } envelope', () => {
+    const { eligible } = partitionBulkRows(
+      { name: 'mark_done', visible: { dialect: 'cel', source: '!record.done' } },
+      ROWS,
+    );
+
+    expect(eligible.map(r => r.id)).toEqual(['r1', 'r3']);
+  });
+
+  it('handles an empty selection without faulting', () => {
+    const { eligible, skipped } = partitionBulkRows({ name: 'x', visible: '!record.done' }, []);
+
+    expect(eligible).toEqual([]);
+    expect(skipped).toBe(0);
+  });
+});

--- a/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
@@ -74,12 +74,15 @@ function renderGrid(opts: {
   objectActions?: unknown[];
   schema?: Record<string, unknown>;
   handlers?: Record<string, any>;
+  /** Override the seed records — e.g. to give a `visible` predicate something to bite on. */
+  rows?: Array<Record<string, unknown>>;
 }) {
+  const rows = opts.rows ?? ROWS;
   const dataSource: any = {
-    find: vi.fn(async () => ({ data: ROWS.map(r => ({ ...r })), total: ROWS.length, hasMore: false, pageSize: 50 })),
+    find: vi.fn(async () => ({ data: rows.map(r => ({ ...r })), total: rows.length, hasMore: false, pageSize: 50 })),
     getObjectSchema: async (name: string) => ({
       name,
-      fields: { id: { type: 'text' }, name: { type: 'text', label: 'Name' } },
+      fields: { id: { type: 'text' }, name: { type: 'text', label: 'Name' }, done: { type: 'boolean' } },
       ...(opts.objectActions ? { actions: opts.objectActions } : {}),
     }),
   };
@@ -218,5 +221,69 @@ describe('view-declared bulk actions (objectui#3002)', () => {
     const legacy = await screen.findByTestId('bulk-action-crm_only_handler');
     fireEvent.click(legacy);
     await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+  });
+});
+
+/**
+ * `visible` is evaluated per selected record, with that record in scope
+ * (objectui#3067). Before this the bar evaluated it with NO record bound, and
+ * the lenient path returned `true` for every row-scoped predicate — so an
+ * authored gate was not weakened but inverted for half its inputs.
+ */
+describe('per-record `visible` on a bulk action (objectui#3067)', () => {
+  /** Row-scoped gate: only r1 is un-done, so only r1 may be acted on. */
+  const GATED = { ...PUSH_DOWN, visible: '!record.done' };
+
+  it('runs on the eligible records only, and says how many it skipped', async () => {
+    await renderAndSelectAll({
+      objectActions: [GATED],
+      schema: { bulkActions: ['push_down'] },
+      rows: [
+        { id: 'r1', name: 'Plan A', done: false },
+        { id: 'r2', name: 'Plan B', done: true },
+      ],
+    });
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
+    // The confirm step owns up to the shrunken selection.
+    expect(await screen.findByTestId('bulk-skipped-notice')).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    // One request, for the one eligible record — not two.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(JSON.parse((fetchMock.mock.calls[0][1] as any).body)._rowRecord.id).toBe('r1');
+  });
+
+  it('hides the button when no selected record qualifies', async () => {
+    await renderAndSelectAll({
+      objectActions: [GATED],
+      schema: { bulkActions: ['push_down'] },
+      rows: [
+        { id: 'r1', name: 'Plan A', done: true },
+        { id: 'r2', name: 'Plan B', done: true },
+      ],
+    });
+
+    // The bar is up (rows are selected) but this action has nothing to act on.
+    expect(await screen.findByTestId('bulk-actions-bar')).toBeInTheDocument();
+    expect(screen.queryByTestId('bulk-action-push_down')).not.toBeInTheDocument();
+  });
+
+  it('leaves an ungated action acting on the whole selection', async () => {
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: { bulkActions: ['push_down'] },
+      rows: [
+        { id: 'r1', name: 'Plan A', done: true },
+        { id: 'r2', name: 'Plan B', done: true },
+      ],
+    });
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
+    expect(screen.queryByTestId('bulk-skipped-notice')).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/packages/plugin-grid/src/bulkEligibility.ts
+++ b/packages/plugin-grid/src/bulkEligibility.ts
@@ -1,0 +1,84 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Per-record `visible` eligibility for a bulk action (objectui#3067).
+ *
+ * ## The rule
+ *
+ * A bulk def's `visible` is evaluated **once per selected record, with that
+ * record in scope** — the same binding and the same fail-closed contract the
+ * row kebab uses (`useRowPredicate(..., { fallback: false })`). From that one
+ * evaluation both questions are answered:
+ *
+ *   - **Is the button offered?** Yes when at least one selected record passes.
+ *     A record-free predicate (`features.x`, `current_user.y`) returns the same
+ *     verdict for every row, so it behaves exactly like a button-level gate —
+ *     no need to detect whether the author referenced `record`.
+ *   - **Which records does it run on?** The ones that passed. The rest are
+ *     reported as skipped rather than silently included.
+ *
+ * ## What this replaces
+ *
+ * The bar used to evaluate `visible` against the ambient scope with no record
+ * bound, on the lenient path. That does not fail open — it returns `true` for
+ * *every* row-scoped predicate, including the ones that should be false:
+ * `${record.done}` and `${record.owner == user.id}` both evaluated `true` with
+ * no record in scope. So an authored gate was not weakened, it was inverted for
+ * half its inputs, and nothing distinguished that from a real verdict.
+ *
+ * The mechanism predates objectui#3002, but only inline-authored
+ * `bulkActionDefs[].visible` used to reach it — written by authors who knew
+ * there was no record. #3031 began promoting object actions into the bar, and
+ * their `visible` is typically written for a row/record surface, which is what
+ * made row-scoped predicates land in a record-free evaluation.
+ */
+
+import { evalRowPredicate } from '@object-ui/core';
+import type { BulkActionDef } from '@object-ui/types';
+
+export interface BulkEligibility<TRow> {
+  /** Records whose `visible` passed — the ones the action actually runs on. */
+  eligible: TRow[];
+  /**
+   * How many selected records were filtered out. Surfaced to the user in the
+   * dialog: a run over fewer records than they selected must say so.
+   */
+  skipped: number;
+}
+
+/**
+ * Split selected records into the ones this def may act on and a count of the
+ * ones it may not. A def without `visible` is a no-op: `rows` is returned by
+ * REFERENCE so the common case allocates nothing and downstream memos hold.
+ */
+export function partitionBulkRows<TRow extends Record<string, unknown>>(
+  def: Pick<BulkActionDef, 'name' | 'visible'> | null | undefined,
+  rows: readonly TRow[],
+  opts: { scope?: Record<string, unknown> } = {},
+): BulkEligibility<TRow> {
+  const visible = def?.visible;
+  if (visible == null || visible === '') {
+    return { eligible: rows as TRow[], skipped: 0 };
+  }
+
+  const eligible = (rows as TRow[]).filter(row =>
+    evalRowPredicate(visible as never, row, {
+      // Fail CLOSED, exactly as the row kebab does: a predicate that faults
+      // must not hand the user a button that acts on records it was written to
+      // exclude. `warnOnError` makes the resulting hide diagnosable (once per
+      // predicate) instead of silent.
+      fallback: false,
+      scope: opts.scope,
+      warnOnError: true,
+      label: def?.name,
+    }),
+  );
+
+  return { eligible, skipped: rows.length - eligible.length };
+}

--- a/packages/plugin-grid/src/components/BulkActionBar.tsx
+++ b/packages/plugin-grid/src/components/BulkActionBar.tsx
@@ -10,28 +10,39 @@ import React from 'react';
 import { Button } from '@object-ui/components';
 import { Trash2, CheckSquare, X } from 'lucide-react';
 import { LazyIcon, toKebabIconName } from '@object-ui/components';
-import { useObjectTranslation, useCondition, toPredicateInput } from '@object-ui/react';
+import { useObjectTranslation, usePredicateScope } from '@object-ui/react';
 import type { BulkActionDef } from '@object-ui/types';
+import { partitionBulkRows } from '../bulkEligibility';
 import { formatActionLabel } from './RowActionMenu';
 
 /**
  * One rich bulk-action button. Extracted into its own component so the def's
- * `visible` CEL predicate can be evaluated with a hook (`useCondition`)
- * without violating the rules-of-hooks inside a `.map()` — previously
- * `bulkActionDefs` rendered unconditionally, ignoring `visible` entirely.
+ * `visible` CEL predicate can be evaluated with a hook without violating the
+ * rules-of-hooks inside a `.map()` — previously `bulkActionDefs` rendered
+ * unconditionally, ignoring `visible` entirely.
  *
- * `visible` is a permission / feature gate evaluated against the ambient
- * ExpressionProvider scope (`features`/`user`); when it evaluates false the
- * button is hidden, matching how the row (`RowActionMenuItem` /
- * `DataTableRowActionItem`) and related-list toolbar renderers treat `visible`.
+ * `visible` is evaluated ONCE PER SELECTED RECORD with that record in scope
+ * (objectui#3067), fail-closed per record — the same contract the row kebab
+ * uses. The button is offered when at least one selected record passes; the
+ * run then acts only on those. A record-free predicate (`features.x`) answers
+ * identically for every row, so it still behaves as a plain button-level gate.
+ * See `partitionBulkRows` for why the previous record-free evaluation was not
+ * merely lenient but wrong.
  */
 const BulkActionButton: React.FC<{
   def: BulkActionDef;
   selectedRows: any[];
   onActionDef?: (def: BulkActionDef, selectedRows: any[]) => void;
 }> = ({ def, selectedRows, onActionDef }) => {
-  const isVisible = useCondition(toPredicateInput(def.visible));
-  if (def.visible && !isVisible) return null;
+  const scope = usePredicateScope();
+  const { eligible } = React.useMemo(
+    () => partitionBulkRows(def, selectedRows, { scope }),
+    [def, selectedRows, scope],
+  );
+  // Only a def that actually declares `visible` can be gated away — an
+  // ungated def always renders, even against an empty selection (the bar
+  // itself is what decides there is a selection at all).
+  if (def.visible && eligible.length === 0) return null;
   const isDestructive = def.variant === 'danger' || def.operation === 'delete';
   const iconName = def.icon ? toKebabIconName(def.icon) : null;
   return (

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -79,6 +79,13 @@ export interface BulkActionDialogProps {
    * the runner re-prompting per record.
    */
   runAction?: BulkExecutorOptions['runAction'];
+  /**
+   * Selected records the def's `visible` predicate excluded (objectui#3067).
+   * `rows` already has them removed; this is what lets the confirm step say
+   * the run covers fewer records than the user picked, instead of quietly
+   * shrinking the selection.
+   */
+  skippedCount?: number;
 }
 
 type Step = 'params' | 'confirm' | 'running' | 'result';
@@ -103,6 +110,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   labelKey = 'name',
   objectFields,
   runAction,
+  skippedCount = 0,
 }) => {
   const { t } = useObjectTranslation();
   const params = def?.params ?? [];
@@ -354,6 +362,17 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
             <div className="text-muted-foreground">
               {t('grid.bulk.affectedRecords', { count: rows.length, defaultValue: `Affected records (${rows.length}):` })}
             </div>
+            {/* [#3067] The selection shrank because this action's `visible`
+                excluded some records. Say it here rather than let the count
+                silently disagree with what the user ticked. */}
+            {skippedCount > 0 && (
+              <div className="text-muted-foreground text-xs" data-testid="bulk-skipped-notice">
+                {t('grid.bulk.skippedIneligible', {
+                  count: skippedCount,
+                  defaultValue: `${skippedCount} selected record(s) are not eligible for this action and will be skipped.`,
+                })}
+              </div>
+            )}
             <ScrollArea className="max-h-32 rounded border bg-muted/30 p-2">
               <ul className="text-xs space-y-1">
                 {previewRows.map((r, i) => (


### PR DESCRIPTION
Fixes #3067。按 issue 里的方案 (A) 实现。

## 根因回顾

选择栏用**没有绑定 record** 的 ambient 作用域求值 `visible`。这不是「求不出来所以放行」—— 宽松求值对**任何**行级谓词都返回 `true`，包括本该为 false 的：

| 谓词 | 无 record（选择栏） | 有 record（行菜单） |
|---|---|---|
| `${!record.done}` | `true` | `true` |
| `${record.done}` | **`true`** | `false` |
| `${record.owner == user.id}` | **`true`** | 按实际值 |

作者写的门禁不是被削弱，而是**对一半输入给出了相反答案**，且调用方无从分辨。

## 方案 (A)：一次求值，回答两个问题

`visible` 现在**逐条选中记录求值、record 在作用域内**，逐条失败关闭 + 首次故障 warn —— 和行菜单同一套契约。由此：

- **按钮是否提供** —— 至少一条选中记录通过就提供。
- **作用在哪些记录上** —— 通过的那些；其余在确认步骤里明说跳过了几条。

关键在于**不需要**去语法嗅探谓词有没有引用 `record`：不引用 record 的谓词（`features.x` / `current_user.y`）对每一行给出相同答案，因此天然退化成「按钮级门禁」，行为与今天一致。这是我选 (A) 而不是拆解谓词的原因 —— 拆解只能靠脆弱的字符串启发式。

「全选 N 条匹配」展开后会**重新**做一次资格过滤，而不是只信按钮当时能看到的当页选择 —— 否则展开进来的记录会绕过门禁。

## 用户可见变化

- 确认步骤新增一行「N 条所选记录不符合条件，将被跳过」（10 个语言包都补了 `grid.bulk.skippedIneligible`）。
- 谓词故障从「静默显示」变成「隐藏 + warn 一次」。这是有意收紧，与行菜单一致。

## 验证

- **反向对照**：只回退 `BulkActionBar.tsx` + `ObjectGrid.tsx` 后，两条新增正向断言失败 —— 全部选中记录都被派发（应只派发合格的那条）、无合格记录时按钮仍渲染。
- **新增 11 条测试**：8 条纯函数（逐条求值、反向谓词、host scope 绑定、record-free 谓词全行一致、故障失败关闭 + warn、`{dialect,source}` 信封、空选择），3 条驱动真实 grid（只跑合格记录 + 跳过提示、无合格记录隐藏按钮、无门禁 action 照旧全量）。
- `plugin-grid` + `i18n` 61 文件 / 520 测试全绿；type-check 31 任务全过；改动文件 0 lint error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
