### PR TITLE
fix(plugin-grid): bulk-action params render the shared form field widgets — lookup errors get Retry, sys_user params get the PeoplePicker (#3064, ADR-0059)

### DIFF
--- a/.changeset/bulk-dialog-shared-field-widgets.md
+++ b/.changeset/bulk-dialog-shared-field-widgets.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/plugin-grid": patch
+---
+
+fix(grid): bulk-action params render the shared form field widgets — a failed lookup fetch shows an error + Retry instead of a permanent "Loading…" (#3064, ADR-0059)
+
+`BulkActionDialog`'s hand-rolled param controls (a 2026-05 MVP predating the
+PeoplePicker and ADR-0059) are replaced by the same field-widget renderer the
+object form and `ActionParamDialog` use, via a new pure `bulkParamToField()`
+adapter + `getLazyFieldWidget()`:
+
+- `lookup` params get the real searchable `LookupField` (server-side search,
+  record-picker dialog, loading/error/empty states owned by `useRecordQuery`);
+  a `sys_user` target — or a `user`-typed param — is promoted to the form's
+  search-first PeoplePicker (avatar + subtitle rows, recents, banned users
+  excluded). Every other param type (date/datetime/boolean/select/multiselect/
+  textarea/number/…) renders its form widget too, so param support can no
+  longer drift behind the form surface.
+- The #3064 failure pipeline is gone by construction: no more eager
+  `find($top:200)` prefetch on open, no error swallowed into an empty option
+  list rendering as permanent "Loading…", and no per-param failure cache —
+  reopening or Retry refetches.
+- Preserved semantics: #2204 schema-fallback multi-value detection, required
+  gating, #2185 nested-popper dismissal guard, and human-readable confirm-step
+  labels (now resolved per selected id via `findOne`, replacing the removed
+  candidate prefetch).

--- a/packages/plugin-grid/demo/bulk-actions.tsx
+++ b/packages/plugin-grid/demo/bulk-actions.tsx
@@ -20,6 +20,13 @@
  *      by-name dispatch — it must still render ALONGSIDE the two defs above.
  *   3. Record `t3` fails server-side (422), proving per-record attribution: the
  *      result panel reports 4/5 with an error row rather than a blanket success.
+ *   4. Rich `bulkActionDefs` with picker params (#3064 / ADR-0059): `Set
+ *      Manager` (lookup → sys_user, single) and `Assign Executors` (lookup →
+ *      sys_user, multiple) must render the form's PeoplePicker; `Set Queue`
+ *      (lookup → demo_queue) the searchable LookupField. Open with
+ *      `?failUsers=1` to make the FIRST sys_user candidate fetch fail — the
+ *      picker must show an error + Retry (never a permanent "Loading…"), and
+ *      Retry / reopening must refetch.
  */
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
@@ -90,11 +97,57 @@ const RECALC = {
   ],
 };
 
+/** Candidate directories for the picker-param defs (#3064). */
+const USERS = [
+  { id: 'u1', name: '现场工人-测试', email: 'worker@demo.dev' },
+  { id: 'u2', name: '工厂长-测试', email: 'chief@demo.dev' },
+  { id: 'u3', name: '质检员-测试', email: 'qa@demo.dev' },
+  { id: 'u4', name: 'Dev Admin', email: 'admin@demo.dev' },
+];
+const QUEUES = [
+  { id: 'q1', title: 'Frontline support' },
+  { id: 'q2', title: 'Escalations' },
+];
+
+// `?failUsers=1` — the first sys_user candidate fetch rejects, later ones
+// succeed: the manual repro for #3064 (error + Retry, no failure caching).
+let failNextUserFetch = new URLSearchParams(location.search).has('failUsers');
+
+function searchable(rows: Array<Record<string, any>>, params: any) {
+  const q = typeof params?.$search === 'string' ? params.$search.trim().toLowerCase() : '';
+  const data = q
+    ? rows.filter(r => Object.values(r).some(v => String(v).toLowerCase().includes(q)))
+    : rows;
+  return { data: data.map(r => ({ ...r })), total: data.length, hasMore: false, pageSize: 50 };
+}
+
 const dataSource: any = {
-  async find() {
+  async find(resource: string, params: any) {
+    if (resource === 'sys_user') {
+      if (failNextUserFetch) {
+        failNextUserFetch = false;
+        throw new Error('sys_user directory unavailable (simulated)');
+      }
+      return searchable(USERS, params);
+    }
+    if (resource === 'demo_queue') return searchable(QUEUES, params);
     return { data: ROWS.map(r => ({ ...r })), total: ROWS.length, hasMore: false, pageSize: 50 };
   },
+  async findOne(resource: string, id: string) {
+    const pool = resource === 'sys_user' ? USERS : resource === 'demo_queue' ? QUEUES : ROWS;
+    return pool.find(r => r.id === id) ?? null;
+  },
+  async update(resource: string, id: string, patch: Record<string, unknown>) {
+    pushLog({ url: `(update ${resource})`, recordId: id, params: JSON.stringify(patch), status: 200 });
+    return { id, ...patch };
+  },
   async getObjectSchema(name: string) {
+    if (name === 'sys_user') {
+      return { name, label: 'User', fields: { id: { type: 'text' }, name: { type: 'text', label: 'Name' }, email: { type: 'email', label: 'Email' } } };
+    }
+    if (name === 'demo_queue') {
+      return { name, label: 'Queue', fields: { id: { type: 'text' }, title: { type: 'text', label: 'Title' } } };
+    }
     return {
       name,
       label: 'Task',
@@ -170,6 +223,33 @@ const schema: any = {
   pagination: { pageSize: 50 },
   // Bare names: two resolve to declared actions, one doesn't.
   bulkActions: ['bulk_mark_done', 'bulk_recalc_estimate', 'legacy_only_handler'],
+  // Rich defs with picker params — the shared-field-widget surface (#3064).
+  bulkActionDefs: [
+    {
+      name: 'set_manager',
+      label: 'Set Manager',
+      operation: 'update',
+      params: [
+        { name: 'manager', label: 'Manager', type: 'lookup', object: 'sys_user', required: true },
+      ],
+    },
+    {
+      name: 'assign_executors',
+      label: 'Assign Executors',
+      operation: 'update',
+      params: [
+        { name: 'executors', label: 'Executors', type: 'lookup', object: 'sys_user', multiple: true, required: true },
+      ],
+    },
+    {
+      name: 'set_queue',
+      label: 'Set Queue',
+      operation: 'update',
+      params: [
+        { name: 'queue', label: 'Queue', type: 'lookup', object: 'demo_queue', labelField: 'title', required: true },
+      ],
+    },
+  ],
 };
 
 function Demo() {

--- a/packages/plugin-grid/src/__tests__/bulkActionDialogParams.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionDialogParams.test.tsx
@@ -7,14 +7,18 @@
  */
 
 /**
- * BulkActionDialog param widgets (#2185): the bulk-edit dialog previously only
- * rendered single-value controls, so a multi-value backend field (e.g. a
- * multi-user `executors`) could not be set — the picker collapsed to one value
- * and overwrote the array. These tests pin the multi-select path end-to-end
- * (empty-array required-gating → pick many → array patch → label preview) plus
- * the new date widget.
+ * BulkActionDialog param widgets.
+ *
+ * #2185/#2204 pinned the multi-value path (empty-array required-gating → pick
+ * many → array patch → label preview) and the date widget. Since the ADR-0059
+ * migration (#3064) params render through the SHARED form field widgets
+ * (`@object-ui/fields` via `bulkParamToField`), so these tests now assert the
+ * form-widget DOM (multiselect toggle chips, native date input) — and the new
+ * lookup suite pins the #3064 contract itself: no eager candidate prefetch,
+ * fetch errors surfaced with a Retry affordance, and no failure caching
+ * (reopening the picker refetches).
  */
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
@@ -32,6 +36,20 @@ beforeAll(() => {
   if (!(Element.prototype as any).setPointerCapture) {
     (Element.prototype as any).setPointerCapture = () => {};
   }
+});
+
+beforeEach(() => {
+  // happy-dom lacks matchMedia; the lookup widgets' useIsMobile needs it.
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as any;
 });
 
 function makeDataSource() {
@@ -77,10 +95,10 @@ describe('BulkActionDialog — multi-select param produces an array patch', () =
     const next = screen.getByRole('button', { name: 'Next' });
     expect(next).toBeDisabled();
 
-    // Open the multi-select popover and pick both options.
-    fireEvent.click(screen.getByRole('combobox'));
-    fireEvent.click(await screen.findByText('Red'));
-    fireEvent.click(await screen.findByText('Blue'));
+    // The shared MultiSelectField renders toggle chips (same as the form) —
+    // await them through the lazy-widget Suspense boundary, then pick both.
+    fireEvent.click(await screen.findByTestId('multiselect-option-red'));
+    fireEvent.click(await screen.findByTestId('multiselect-option-blue'));
 
     // Now valid → advance to confirm.
     await waitFor(() => expect(next).toBeEnabled());
@@ -100,7 +118,7 @@ describe('BulkActionDialog — multi-select param produces an array patch', () =
 });
 
 describe('BulkActionDialog — date param renders a date picker', () => {
-  it('renders a native date input rather than a free-text box', () => {
+  it('renders a native date input rather than a free-text box', async () => {
     const ds = makeDataSource();
     const def: any = {
       name: 'set_due',
@@ -118,8 +136,70 @@ describe('BulkActionDialog — date param renders a date picker', () => {
         onClose={() => {}}
       />,
     );
-    // Radix Dialog portals its content to document.body, not the render root.
-    const dateInput = document.querySelector('input[type="date"]');
-    expect(dateInput).toBeInTheDocument();
+    // Radix Dialog portals to document.body, and the widget loads lazily.
+    await waitFor(() => {
+      expect(document.querySelector('input[type="date"]')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('BulkActionDialog — lookup param uses the shared record picker (#3064)', () => {
+  const lookupDef: any = {
+    name: 'assign_queue',
+    label: 'Assign queue',
+    operation: 'update',
+    params: [
+      { name: 'queue', label: 'Queue', type: 'lookup', object: 'queues', required: true },
+    ],
+  };
+
+  it('does not prefetch candidates when the dialog opens', async () => {
+    const ds = makeDataSource();
+    ds.find = vi.fn(async () => ({ data: [], total: 0 }));
+    render(
+      <BulkActionDialog
+        def={lookupDef}
+        rows={[{ id: 'r1' }]}
+        resource="thing"
+        dataSource={ds}
+        open
+        onClose={() => {}}
+      />,
+    );
+    // The picker trigger renders (lazy widget) with no candidate query issued —
+    // the old dialog fired find(object, {$top: 200}) on open.
+    await screen.findByTestId('lookup-trigger-queue');
+    expect(ds.find).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed candidate fetch and retries instead of caching the failure', async () => {
+    const ds = makeDataSource();
+    ds.find = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue({ data: [{ id: 'q1', name: 'Support queue' }], total: 1 });
+    render(
+      <BulkActionDialog
+        def={lookupDef}
+        rows={[{ id: 'r1' }]}
+        resource="thing"
+        dataSource={ds}
+        open
+        onClose={() => {}}
+      />,
+    );
+
+    // Open the picker → the fetch fails → an error state with a Retry
+    // affordance renders (previously: a permanent "Loading…" placeholder).
+    fireEvent.click(await screen.findByTestId('lookup-trigger-queue'));
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('boom');
+    expect(ds.find).toHaveBeenCalledTimes(1);
+
+    // Retry refetches (previously: the failure was cached per param name and
+    // no further request was ever issued) and the candidates render.
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await screen.findByText('Support queue');
+    expect(ds.find).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/plugin-grid/src/__tests__/bulkActionSchemaMultiple.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionSchemaMultiple.test.tsx
@@ -127,11 +127,11 @@ describe('BulkActionDialog — schema fallback when param.multiple is omitted (#
       />,
     );
 
-    // Schema says multi → the combobox (Popover multi-select) renders, not a
-    // single-select trigger that collapses to one value.
-    fireEvent.click(screen.getByRole('combobox'));
-    fireEvent.click(await screen.findByText('Frontend'));
-    fireEvent.click(await screen.findByText('Design'));
+    // Schema says multi → the shared MultiSelectField (toggle chips) renders,
+    // not a single-select trigger that collapses to one value.
+    await screen.findByTestId('multiselect-labels');
+    fireEvent.click(screen.getByTestId('multiselect-option-frontend'));
+    fireEvent.click(screen.getByTestId('multiselect-option-design'));
 
     const next = screen.getByRole('button', { name: 'Next' });
     await waitFor(() => expect(next).toBeEnabled());

--- a/packages/plugin-grid/src/__tests__/bulkParamToField.test.ts
+++ b/packages/plugin-grid/src/__tests__/bulkParamToField.test.ts
@@ -1,0 +1,123 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * bulkParamToField — the pure BulkActionParam → field-widget-metadata adapter
+ * behind the ADR-0059 bulk-dialog migration (#3064). Pins the type mapping
+ * (aliases, lookup degradation, sys_user promotion), the #2204 multiple
+ * threading, and the option-value stringification the confirm step relies on.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import {
+  bulkParamToField,
+  fieldNeedsDataSource,
+  isLookupishParam,
+  lookupTargetObject,
+  resolveBulkParamWidgetType,
+} from '../components/bulkParamToField';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveBulkParamWidgetType', () => {
+  it('passes canonical widget types through and folds param-only aliases', () => {
+    expect(resolveBulkParamWidgetType('lookup')).toBe('lookup');
+    expect(resolveBulkParamWidgetType('date')).toBe('date');
+    expect(resolveBulkParamWidgetType('checkbox')).toBe('boolean');
+    expect(resolveBulkParamWidgetType('reference')).toBe('lookup');
+    expect(resolveBulkParamWidgetType('datetime-local')).toBe('datetime');
+  });
+
+  it('falls back to text for unknown types (same as the form renderer)', () => {
+    expect(resolveBulkParamWidgetType('no-such-type')).toBe('text');
+  });
+});
+
+describe('bulkParamToField', () => {
+  it('maps a lookup param to the record-picker field shape', () => {
+    const field = bulkParamToField(
+      { name: 'queue', label: 'Queue', type: 'lookup', object: 'queues', labelField: 'title', required: true },
+      false,
+    );
+    expect(field).toMatchObject({
+      name: 'queue',
+      label: 'Queue',
+      type: 'lookup',
+      required: true,
+      reference_to: 'queues',
+      display_field: 'title',
+      multiple: false,
+    });
+  });
+
+  it('promotes a sys_user-targeting lookup to the user widget (form PeoplePicker parity)', () => {
+    const field = bulkParamToField(
+      { name: 'manager', type: 'lookup', object: 'sys_user' },
+      false,
+    );
+    expect(field.type).toBe('user');
+    expect(field.reference_to).toBe('sys_user');
+  });
+
+  it('degrades a targetless lookup to a text input with a dev warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const field = bulkParamToField({ name: 'ref', type: 'lookup' }, false);
+    expect(field.type).toBe('text');
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('threads the EFFECTIVE multiple flag (#2204), ignoring the raw param flag', () => {
+    // Schema-derived multi wins over the omitted param flag…
+    expect(bulkParamToField({ name: 'tags', type: 'select', options: [] }, true).multiple).toBe(true);
+    // …and the argument is authoritative in the other direction too.
+    expect(bulkParamToField({ name: 'tags', type: 'select', multiple: true, options: [] }, false).multiple).toBe(false);
+  });
+
+  it('stringifies option values so widget output matches confirm-step lookups', () => {
+    const field = bulkParamToField(
+      { name: 'level', type: 'select', options: [{ label: 'One', value: 1 }, { label: 'Yes', value: true }] },
+      false,
+    );
+    expect(field.options).toEqual([
+      { label: 'One', value: '1' },
+      { label: 'Yes', value: 'true' },
+    ]);
+  });
+
+  it('forwards catch-all widget config and strips dialog-owned keys', () => {
+    const field = bulkParamToField(
+      { name: 'amount', type: 'number', min: 0, step: 5, help: 'shown by the dialog', default: 10 },
+      false,
+    );
+    expect(field.min).toBe(0);
+    expect(field.step).toBe(5);
+    expect(field).not.toHaveProperty('help');
+    expect(field).not.toHaveProperty('default');
+  });
+});
+
+describe('lookup helpers', () => {
+  it('identifies picker params and their target object', () => {
+    expect(isLookupishParam({ name: 'q', type: 'lookup', object: 'queues' })).toBe(true);
+    expect(isLookupishParam({ name: 'u', type: 'user' })).toBe(true);
+    expect(isLookupishParam({ name: 't', type: 'text' })).toBe(false);
+
+    expect(lookupTargetObject({ name: 'q', type: 'lookup', object: 'queues' })).toBe('queues');
+    // Person params default to sys_user like the form's UserField.
+    expect(lookupTargetObject({ name: 'u', type: 'user' })).toBe('sys_user');
+    expect(lookupTargetObject({ name: 'x', type: 'lookup' })).toBeUndefined();
+  });
+
+  it('only picker field shapes get the DataSource threaded', () => {
+    expect(fieldNeedsDataSource({ type: 'user' })).toBe(true);
+    expect(fieldNeedsDataSource({ type: 'lookup' })).toBe(true);
+    expect(fieldNeedsDataSource({ type: 'date' })).toBe(false);
+  });
+});

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -6,42 +6,31 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Badge,
   Button,
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
   Label,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
   Progress,
   ScrollArea,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Switch,
-  Textarea,
 } from '@object-ui/components';
-import { AlertTriangle, Check, CheckCircle2, ChevronsUpDown, Loader2, XCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Loader2, XCircle } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
+import { getLazyFieldWidget } from '@object-ui/fields';
 import type { BulkActionDef, BulkActionParam } from '@object-ui/types';
 import { useBulkExecutor, type BulkExecutorOptions, type BulkResult } from '../hooks/useBulkExecutor';
 import { isMultiValueField, type MultiValueFieldDef } from '../hooks/multiValueFields';
+import {
+  bulkParamToField,
+  fieldNeedsDataSource,
+  isLookupishParam,
+  lookupTargetObject,
+} from './bulkParamToField';
 
 export interface BulkActionDialogProps {
   /** The action being executed. */
@@ -50,12 +39,20 @@ export interface BulkActionDialogProps {
   rows: Array<Record<string, unknown>>;
   /** Object resource name (passed to the executor + lookup loader). */
   resource: string;
-  /** Data source used by the executor + lookup-param loader. */
+  /**
+   * Data source used by the executor and threaded into the lookup/user param
+   * widgets (candidate search) + the confirm step's id→label resolution.
+   */
   dataSource: BulkExecutorOptions['dataSource'] & {
     find?: (
       resource: string,
       query?: Record<string, unknown>,
     ) => Promise<{ data?: Array<Record<string, unknown>> } | Array<Record<string, unknown>>>;
+    findOne?: (
+      resource: string,
+      id: string | number,
+      params?: Record<string, unknown>,
+    ) => Promise<Record<string, unknown> | null>;
   };
   /** Open state. */
   open: boolean;
@@ -129,7 +126,11 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
 
   const [step, setStep] = useState<Step>('params');
   const [values, setValues] = useState<Record<string, unknown>>(initialParamValues);
-  const [lookupCache, setLookupCache] = useState<Record<string, LookupOption[]>>({});
+  // Confirm-step display labels for picker params: param name → id → label.
+  // Resolved lazily (findOne per selected id) when the user reaches the
+  // confirm step — the params step needs no preloaded option list because the
+  // picker widgets fetch their own candidates (#3064).
+  const [lookupLabels, setLookupLabels] = useState<Record<string, Record<string, string>>>({});
   const { run, undo, retry, progress, result, reset } = useBulkExecutor({ resource, dataSource, objectFields, runAction });
   const [retrying, setRetrying] = useState<string | null>(null);
   const [undoing, setUndoing] = useState(false);
@@ -162,6 +163,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
     if (!open) return;
     reset();
     setValues(initialParamValues);
+    setLookupLabels({});
     setUndoneAt(null);
     setUndoing(false);
     setRetrying(null);
@@ -169,39 +171,51 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
     setStep(params.length === 0 ? 'confirm' : 'params');
   }, [open, def?.name, initialParamValues, params.length, reset]);
 
-  // Eagerly load lookup options for any lookup param. Cheap for the MVP since
-  // most CRM lookups (users, queues) cap out at a few hundred rows.
+  // Resolve picker-param ids into display labels for the confirm step. The
+  // widgets show labels while picking, but the committed value is just id(s);
+  // a failed or impossible resolution silently falls back to showing the raw
+  // id — purely cosmetic, so no error surface needed here.
   useEffect(() => {
-    if (!open) return;
-    if (typeof dataSource.find !== 'function') return;
-    const lookups = params.filter(p => p.type === 'lookup' && p.object && !lookupCache[p.name]);
-    if (lookups.length === 0) return;
+    if (step !== 'confirm') return;
+    if (typeof dataSource.findOne !== 'function') return;
     let cancelled = false;
     (async () => {
-      const next: Record<string, LookupOption[]> = {};
-      for (const p of lookups) {
-        try {
-          const res = await dataSource.find!(p.object as string, { $top: 200 });
-          const items = Array.isArray(res) ? res : (res?.data ?? []);
-          const labelField = typeof p.labelField === 'string' ? p.labelField : undefined;
-          next[p.name] = items.map(r => ({
-            value: String(r.id ?? r._id ?? ''),
-            label: String(
-              (labelField ? r[labelField] : undefined)
-              ?? r.name ?? r.full_name ?? r.email ?? r.id ?? '(unnamed)',
-            ),
-          })).filter(o => o.value);
-        } catch {
-          next[p.name] = [];
+      const updates: Record<string, Record<string, string>> = {};
+      for (const p of params) {
+        const target = lookupTargetObject(p);
+        if (!isLookupishParam(p) || !target) continue;
+        const v = values[p.name];
+        const ids = (Array.isArray(v) ? v : v == null || v === '' ? [] : [v]).map(String);
+        for (const id of ids) {
+          if (lookupLabels[p.name]?.[id]) continue;
+          try {
+            const rec = await dataSource.findOne!(target, id);
+            if (!rec) continue;
+            const labelField = typeof p.labelField === 'string' ? p.labelField : undefined;
+            const label =
+              (labelField ? rec[labelField] : undefined)
+              ?? rec.name ?? rec.full_name ?? rec.email;
+            if (label != null) (updates[p.name] ??= {})[id] = String(label);
+          } catch {
+            // Leave the id unresolved; describeValue falls back to the raw id.
+          }
         }
       }
-      if (!cancelled) setLookupCache(prev => ({ ...prev, ...next }));
+      if (!cancelled && Object.keys(updates).length > 0) {
+        setLookupLabels(prev => {
+          const next = { ...prev };
+          for (const [name, labels] of Object.entries(updates)) {
+            next[name] = { ...next[name], ...labels };
+          }
+          return next;
+        });
+      }
     })();
     return () => {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, def?.name]);
+  }, [step]);
 
   const paramsValid = useMemo(() => {
     for (const p of params) {
@@ -221,12 +235,12 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   const describeValue = useCallback((param: BulkActionParam | undefined, v: unknown): string => {
     if (v === null || v === undefined || v === '' || (Array.isArray(v) && v.length === 0)) return '—';
     if (typeof v === 'boolean') return v ? t('grid.yes', { defaultValue: 'Yes' }) : t('grid.no', { defaultValue: 'No' });
-    const optSource: LookupOption[] = param?.type === 'lookup'
-      ? (lookupCache[param.name] ?? [])
+    const optSource: LookupOption[] = param && isLookupishParam(param)
+      ? Object.entries(lookupLabels[param.name] ?? {}).map(([value, label]) => ({ value, label }))
       : (param?.options ?? []).map(o => ({ value: String(o.value), label: String(o.label) }));
     const labelOf = (x: unknown) => optSource.find(o => o.value === String(x))?.label ?? String(x);
     return Array.isArray(v) ? v.map(labelOf).join(', ') : labelOf(v);
-  }, [t, lookupCache]);
+  }, [t, lookupLabels]);
 
   const maxRecords = def?.maxRecords ?? Infinity;
   const overLimit = rows.length > maxRecords;
@@ -330,7 +344,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
                 param={p}
                 multiple={isParamMultiple(p)}
                 value={values[p.name]}
-                lookupOptions={lookupCache[p.name]}
+                dataSource={dataSource}
                 onChange={(v) => setValues(prev => ({ ...prev, [p.name]: v }))}
               />
             ))}
@@ -511,215 +525,48 @@ interface ParamFieldProps {
   multiple: boolean;
   value: unknown;
   onChange: (v: unknown) => void;
-  lookupOptions?: LookupOption[];
+  /** Threaded into picker widgets (lookup/user) for candidate search. */
+  dataSource: BulkActionDialogProps['dataSource'];
 }
 
-const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChange, lookupOptions }) => {
-  const { t } = useObjectTranslation();
+/**
+ * One param row: label → shared form field widget → help text. The widget is
+ * the SAME component the object form (and ActionParamDialog, ADR-0059) renders
+ * for that field type, resolved via `bulkParamToField` + `getLazyFieldWidget`
+ * — so a `lookup` param gets the searchable record picker with its own
+ * loading/error/empty states (#3064) and a `sys_user` target gets the form's
+ * PeoplePicker. Widgets stay lazy behind `<Suspense>` so opening a dialog only
+ * loads the widgets its params actually use.
+ */
+const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChange, dataSource }) => {
   const id = `bulk-param-${param.name}`;
-  const label = (
-    <Label htmlFor={id} className="text-xs">
-      {param.label ?? param.name}
-      {param.required && <span className="text-destructive ml-0.5">*</span>}
-    </Label>
-  );
-
-  // Assigned by every switch branch (including `default`) before it's read
-  // below — no dead initializer needed.
-  let control: React.ReactNode;
-  switch (param.type) {
-    case 'boolean':
-      control = (
-        <Switch
-          id={id}
-          checked={!!value}
-          onCheckedChange={onChange}
-        />
-      );
-      break;
-    case 'textarea':
-      control = (
-        <Textarea
-          id={id}
-          value={(value as string) ?? ''}
-          onChange={e => onChange(e.target.value)}
-          placeholder={param.placeholder}
-        />
-      );
-      break;
-    case 'select': {
-      const options = (param.options ?? []).map(o => ({ value: String(o.value), label: o.label }));
-      control = multiple ? (
-        <MultiSelectControl
-          id={id}
-          options={options}
-          value={value}
-          onChange={onChange}
-          placeholder={param.placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' })}
-        />
-      ) : (
-        <Select value={value !== undefined && value !== null ? String(value) : ''} onValueChange={onChange}>
-          <SelectTrigger id={id}>
-            <SelectValue placeholder={param.placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' })} />
-          </SelectTrigger>
-          <SelectContent>
-            {options.map(o => (
-              <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      );
-      break;
-    }
-    case 'lookup': {
-      const opts = lookupOptions ?? [];
-      const loadingPlaceholder = opts.length === 0
-        ? t('grid.bulk.loading', { defaultValue: 'Loading…' })
-        : (param.placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' }));
-      control = multiple ? (
-        <MultiSelectControl
-          id={id}
-          options={opts}
-          value={value}
-          onChange={onChange}
-          placeholder={loadingPlaceholder}
-        />
-      ) : (
-        <Select value={(value as string) ?? ''} onValueChange={onChange}>
-          <SelectTrigger id={id}>
-            <SelectValue placeholder={loadingPlaceholder} />
-          </SelectTrigger>
-          <SelectContent>
-            {opts.map(o => (
-              <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      );
-      break;
-    }
-    case 'date':
-      control = (
-        <Input
-          id={id}
-          type="date"
-          value={(value as string) ?? ''}
-          onChange={e => onChange(e.target.value === '' ? undefined : e.target.value)}
-          placeholder={param.placeholder}
-        />
-      );
-      break;
-    case 'datetime':
-      control = (
-        <Input
-          id={id}
-          type="datetime-local"
-          value={(value as string) ?? ''}
-          onChange={e => onChange(e.target.value === '' ? undefined : e.target.value)}
-          placeholder={param.placeholder}
-        />
-      );
-      break;
-    case 'number':
-      control = (
-        <Input
-          id={id}
-          type="number"
-          value={(value as number | string) ?? ''}
-          onChange={e => onChange(e.target.value === '' ? undefined : Number(e.target.value))}
-          placeholder={param.placeholder}
-        />
-      );
-      break;
-    default:
-      control = (
-        <Input
-          id={id}
-          type="text"
-          value={(value as string) ?? ''}
-          onChange={e => onChange(e.target.value)}
-          placeholder={param.placeholder}
-        />
-      );
-  }
+  const field = useMemo(() => bulkParamToField(param, multiple), [param, multiple]);
+  // getLazyFieldWidget caches per type, and the useMemo keeps the reference
+  // hook-stable for a given param (react-hooks/static-components).
+  const Widget = useMemo(() => getLazyFieldWidget(field.type), [field.type]);
+  // Only picker widgets receive the dataSource — the simple widgets spread
+  // unknown props toward the DOM.
+  const dataSourceProps = fieldNeedsDataSource(field) ? { dataSource } : {};
 
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        {label}
+        <Label htmlFor={id} className="text-xs">
+          {param.label ?? param.name}
+          {param.required && <span className="text-destructive ml-0.5">*</span>}
+        </Label>
       </div>
-      {control}
+      <Suspense fallback={<div className="h-9 w-full animate-pulse rounded-md bg-muted" aria-hidden="true" />}>
+        {/* eslint-disable-next-line react-hooks/static-components -- getLazyFieldWidget returns a per-type cached lazy component (stable identity), not a component created during render */}
+        <Widget
+          id={id}
+          value={value ?? null}
+          onChange={onChange}
+          field={field}
+          {...dataSourceProps}
+        />
+      </Suspense>
       {param.help && <p className="text-[11px] text-muted-foreground">{param.help}</p>}
     </div>
-  );
-};
-
-interface MultiSelectControlProps {
-  id: string;
-  options: LookupOption[];
-  value: unknown;
-  onChange: (v: string[]) => void;
-  placeholder?: string;
-}
-
-/**
- * Popover + Command multi-select used for `multiple` select/lookup params. The
- * value is a string array (written straight into the patch to match a
- * multi-value backend field). Search filters the already-loaded option set.
- */
-const MultiSelectControl: React.FC<MultiSelectControlProps> = ({ id, options, value, onChange, placeholder }) => {
-  const { t } = useObjectTranslation();
-  const [open, setOpen] = useState(false);
-  const selected = Array.isArray(value) ? (value as unknown[]).map(String) : [];
-  const labelOf = (v: string) => options.find(o => o.value === v)?.label ?? v;
-  const toggle = (v: string) => {
-    const next = selected.includes(v) ? selected.filter(x => x !== v) : [...selected, v];
-    onChange(next);
-  };
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          id={id}
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className="w-full justify-between h-auto min-h-9 font-normal"
-        >
-          <span className="flex flex-wrap gap-1 items-center text-left">
-            {selected.length === 0 && (
-              <span className="text-muted-foreground">
-                {placeholder ?? t('grid.bulk.selectPlaceholder', { defaultValue: 'Select…' })}
-              </span>
-            )}
-            {selected.map(v => (
-              <Badge key={v} variant="secondary" className="font-normal">{labelOf(v)}</Badge>
-            ))}
-          </span>
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
-        <Command>
-          <CommandInput placeholder={t('grid.bulk.searchPlaceholder', { defaultValue: 'Search…' })} />
-          <CommandList>
-            <CommandEmpty>{t('grid.bulk.noOptions', { defaultValue: 'No options.' })}</CommandEmpty>
-            <CommandGroup>
-              {options.map(o => {
-                const checked = selected.includes(o.value);
-                return (
-                  <CommandItem key={o.value} value={o.label} onSelect={() => toggle(o.value)}>
-                    <Check className={`mr-2 h-4 w-4 ${checked ? 'opacity-100' : 'opacity-0'}`} />
-                    {o.label}
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
   );
 };

--- a/packages/plugin-grid/src/components/bulkParamToField.ts
+++ b/packages/plugin-grid/src/components/bulkParamToField.ts
@@ -1,0 +1,146 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * bulkParamToField — pure adapter from a `BulkActionParam` to the
+ * `{ name, type, ...config }` field shape the shared form field widgets
+ * (`@object-ui/fields`) consume.
+ *
+ * `BulkActionDialog` renders every param through the same field-widget
+ * renderer the object form and `ActionParamDialog` use (`getLazyFieldWidget`),
+ * so a bulk param of any form-supported field type gets its real widget — a
+ * `lookup` param gets the searchable record picker instead of a preloaded
+ * 200-row `<Select>` (#3064), a `user`-targeting param gets the PeoplePicker
+ * the form uses — completing ADR-0059 for the bulk surface. This module is
+ * the whole translation layer: pure and exported so the mapping is
+ * unit-testable without the dialog render tree (mirrors app-shell's
+ * `paramToField`).
+ */
+import { resolveFormWidgetType } from '@object-ui/fields';
+import type { BulkActionParam } from '@object-ui/types';
+
+/**
+ * Param-only type spellings folded onto the canonical form widget vocabulary,
+ * kept for params already authored with them — new params should use spec
+ * `FieldType` values directly. (Same dialect app-shell's `paramToField`
+ * accepts, so the two param surfaces don't drift.)
+ */
+const BULK_PARAM_TYPE_ALIASES: Record<string, string> = {
+  checkbox: 'boolean',
+  reference: 'lookup',
+  'datetime-local': 'datetime',
+};
+
+/** Widget keys that render the record-picker family and need a reference target. */
+const LOOKUP_WIDGET_TYPES = new Set(['lookup', 'master_detail']);
+
+/** Widget keys that render the person-picker family (target defaults to sys_user). */
+const USER_WIDGET_TYPES = new Set(['user', 'owner']);
+
+/** Widget keys whose widget must be handed the grid's DataSource explicitly. */
+const DATA_SOURCE_WIDGET_TYPES = new Set([...LOOKUP_WIDGET_TYPES, ...USER_WIDGET_TYPES]);
+
+/** Resolve a param `type` to the form widget key that renders it. */
+export function resolveBulkParamWidgetType(paramType: string): string {
+  return resolveFormWidgetType(BULK_PARAM_TYPE_ALIASES[paramType] ?? paramType);
+}
+
+/** True when the resolved widget is a record/person picker (id-valued). */
+export function isLookupishParam(param: BulkActionParam): boolean {
+  const type = resolveBulkParamWidgetType(param.type);
+  return DATA_SOURCE_WIDGET_TYPES.has(type);
+}
+
+/**
+ * The object a picker param queries for candidates/labels: the declared
+ * `object`, else `sys_user` for person params (mirroring UserField's default).
+ */
+export function lookupTargetObject(param: BulkActionParam): string | undefined {
+  const type = resolveBulkParamWidgetType(param.type);
+  if (param.object) return param.object as string;
+  return USER_WIDGET_TYPES.has(type) ? 'sys_user' : undefined;
+}
+
+/**
+ * Map a `BulkActionParam` to the field-metadata shape `FieldWidgetProps.field`
+ * expects. `multiple` is the EFFECTIVE multi-value semantics (explicit
+ * `param.multiple` or the target field's schema, #2204) — passed in by the
+ * dialog, not re-derived here.
+ *
+ * - A `lookup` param with no `object` target degrades to a plain text input
+ *   (the picker cannot query without a target), warning in dev — same
+ *   last-resort fallback as app-shell's `paramToField`.
+ * - A `lookup` param targeting `sys_user` is promoted to the `user` widget so
+ *   bulk person params get the exact PeoplePicker the form's user fields use
+ *   (search-first, avatar + department·email rows, banned users excluded).
+ * - `BulkActionParam`'s documented catch-all keys (min/max/step/format/…) are
+ *   forwarded to the widget as-is.
+ */
+export function bulkParamToField(
+  param: BulkActionParam,
+  multiple: boolean,
+): Record<string, any> {
+  let type = resolveBulkParamWidgetType(param.type);
+
+  if (LOOKUP_WIDGET_TYPES.has(type) && !param.object) {
+    if ((globalThis as any).process?.env?.NODE_ENV !== 'production') {
+      console.warn(
+        `[BulkActionDialog] Param "${param.name}" is type "${param.type}" but has no \`object\` target, ` +
+          'so it degrades to a plain record-id text input. Declare `object: \'<object>\'` on the param.',
+      );
+    }
+    type = 'text';
+  }
+
+  if (LOOKUP_WIDGET_TYPES.has(type) && param.object === 'sys_user') {
+    type = 'user';
+  }
+
+  const {
+    name,
+    label,
+    type: _type,
+    required,
+    // Rendered by the dialog beneath the control, not by the widget.
+    help: _help,
+    // Seeded into the dialog's initial values, not widget metadata.
+    default: _default,
+    // Effective multi-ness comes from the `multiple` argument (#2204).
+    multiple: _multiple,
+    options,
+    object,
+    labelField,
+    placeholder,
+    ...extra
+  } = param;
+
+  const field: Record<string, any> = {
+    ...extra,
+    name,
+    label: label ?? name,
+    type,
+    required,
+    placeholder,
+    // Radix Select values are strings — stringify to match what the select
+    // widgets emit, so option lookups on the confirm step compare equal.
+    options: options?.map(o => ({ ...o, value: String(o.value) })),
+    multiple,
+  };
+
+  if (DATA_SOURCE_WIDGET_TYPES.has(type)) {
+    field.reference_to = object;
+    if (typeof labelField === 'string') field.display_field = labelField;
+  }
+
+  return field;
+}
+
+/** Whether the widget for this field shape needs the DataSource threaded in. */
+export function fieldNeedsDataSource(field: Record<string, any>): boolean {
+  return DATA_SOURCE_WIDGET_TYPES.has(field.type);
+}


### PR DESCRIPTION
Closes #3064

## 问题

`BulkActionDialog` 的参数步是 2026-05 的手搓 MVP(早于 PeoplePicker #2112 和 ADR-0059),两类后果:

1. **#3064**:lookup 参数打开弹窗即 `find(object, {$top:200})` 全量预取,fetch 失败被吞成空数组 → 渲染成**永久 "Loading…"**,且失败按参数名缓存、重开弹窗**永不重试**,只能整页刷新;同页两个按钮一死一活的"分裂"现象即源于此。
2. 选人参数与表单选人字段**样式/交互完全不同**(无搜索、无头像、超 200 人选不到)。

## 方案(issue 内「方案 B」)

参数改走对象表单 / `ActionParamDialog` 同一套共享字段控件管线,把 ADR-0059 补完到批量面:

- 新增纯适配器 `bulkParamToField()`(镜像 app-shell `paramToField`,含 drift 对齐的类型别名):`BulkActionParam` → 字段元数据,经 `getLazyFieldWidget()` 渲染;仅 picker 控件被注入 DataSource。
- `lookup` 参数 → 真 `LookupField`(服务端搜索、分页、表格选择器;加载/错误/空态由共享 `useRecordQuery` 内核持有,**每次打开重新拉取**);指向 `sys_user` 的 lookup / `user` 类型参数 → 表单同款搜索式 **PeoplePicker**(头像、副标题、最近使用、排除停用用户)。无 `object` 目标的 lookup 降级文本框 + dev 告警。
- 删除手搓 `ParamField` switch、`MultiSelectControl`、eager 预取与 `lookupCache` —— #3064 的"吞错→永久 Loading…→失败缓存"管线**从结构上不复存在**。
- 保留语义:#2204 schema 兜底 multi 判定、必填门控、#2185 嵌套弹层误关守卫;确认页标签改为按选中 id `findOne` 惰性解析(失败仅回退显示裸 id,纯装饰性)。

## 测试与验证

- `tsc` 干净;plugin-grid 全套 **45 文件 / 366 用例通过**;build 通过;改动文件 eslint 0 error。
- 新增回归:#3064 两条(打开弹窗零预取;失败显示错误+Retry、Retry 真正重发请求)+ `bulkParamToField` 13 条纯函数用例;既有 #2185/#2204 用例更新到共享控件 DOM。
- 真浏览器(plugin-grid demo,新增 picker defs + `?failUsers=1` 故障注入)逐项走查:单/多选 PeoplePicker、确认页人名解析、patch 形态(标量/数组)、错误+重试恢复无需刷新、#2185 弹层守卫。

🤖 Generated with [Claude Code](https://claude.com/claude-code)