### PR TITLE
feat(console): settings validation errors render against the fields that caused them (objectstack#4224 follow-up)

### DIFF
--- a/.changeset/settings-per-field-validation-errors.md
+++ b/.changeset/settings-per-field-validation-errors.md
@@ -1,0 +1,35 @@
+---
+"@object-ui/console": patch
+---
+
+feat(settings): a rejected save marks the fields that caused it — objectstack#4224 follow-up
+
+A `SETTINGS_VALIDATION` rejection names the offending keys, and the settings page
+threw all of it away. Every failure collapsed into one toast carrying the
+server's summary sentence, with nothing marked on the inputs — so on a namespace
+with a dozen keys the user was told a value was wrong and left to find which.
+
+**That was not the console's fault, which is the part worth recording.** The
+server sent `fields` as a `Record<key, message>` hung *beside* `error.code`, a
+position `ApiErrorSchema` never declared — it survived only because the schema
+is a plain `z.object` and strips undeclared keys rather than rejecting them.
+`extractFieldErrors` reads arrays (`details.fields`, `fields`,
+`validationErrors`), so a map at an undeclared position matched nothing and
+returned `null`. objectstack#4224 moved it to `error.details.fields` as the
+declared `FieldError[]`, which is what makes this wiring a few lines rather than
+a parser.
+
+What changes for a user: the server's message now renders against the input that
+caused it, in the slot the help text occupies, and clears the moment that field
+is edited, on Discard, or on the next successful save. `SettingsField` gained an
+`error` prop; it sets `aria-invalid` and `aria-describedby` on the control and
+gives the message `role="alert"`, so the rejection is announced rather than being
+conveyed by colour alone.
+
+The toast still fires alongside the per-field marks. The offending field can be
+scrolled out of view or hidden behind a `visible` expression, and a save that
+appears to do nothing is the worse failure.
+
+Fields the server did not name are left unmarked — a wrong mark on an innocent
+input is worse than the generic toast that was already there — and a failure
+carrying no field array (a 500, an unknown namespace) behaves exactly as before.

--- a/apps/console/src/pages/settings/SettingsField.tsx
+++ b/apps/console/src/pages/settings/SettingsField.tsx
@@ -6,7 +6,7 @@
  * (which carries provenance and lock state).
  */
 
-import { useId } from 'react';
+import { cloneElement, isValidElement, useId, type ReactElement } from 'react';
 import {
   Input,
   Textarea,
@@ -46,6 +46,16 @@ export interface SettingsFieldProps {
   locked?: boolean;
   /** i18n helpers bound to the parent settings namespace. */
   labels?: SettingsLabelHelpers;
+  /**
+   * Server-side rejection for THIS field, from the last failed save
+   * (objectstack#4224). Already localized by the server — rendered verbatim,
+   * not re-worded here.
+   *
+   * Replaces the help text while present, rather than stacking below it: the
+   * two occupy the same slot and say the same kind of thing, and a description
+   * sitting under a red error reads as if the field has two states at once.
+   */
+  error?: string;
 }
 
 function InheritanceBadges({
@@ -132,8 +142,25 @@ function FieldDescription({ description }: { description?: string }) {
   return <p className="text-xs text-muted-foreground mt-1">{description}</p>;
 }
 
+/**
+ * The server's rejection for this field, in the slot the help text normally
+ * occupies (objectstack#4224).
+ *
+ * `role="alert"` so a screen reader announces it when it appears after a save
+ * attempt — the sighted cue is colour, which is not a cue at all for everyone.
+ * The `id` is what the input points `aria-describedby` at, so the association
+ * survives for assistive tech rather than being purely visual adjacency.
+ */
+function FieldError({ id, message }: { id: string; message: string }) {
+  return (
+    <p id={id} role="alert" className="text-xs text-destructive mt-1">
+      {message}
+    </p>
+  );
+}
+
 export function SettingsField(props: SettingsFieldProps) {
-  const { spec, resolved, value, onChange, onAction, locked, saving, labels } = props;
+  const { spec, resolved, value, onChange, onAction, locked, saving, labels, error } = props;
   const id = useId();
   const disabled = Boolean(locked || saving);
   const literalLabel = resolveLabel(spec.label);
@@ -231,11 +258,26 @@ export function SettingsField(props: SettingsFieldProps) {
 
   // -------- Inputs --------
 
+  // Wired onto the control itself, not just rendered beside it: `aria-invalid`
+  // is what announces "this one was rejected", and `aria-describedby` is what
+  // ties the message to the input for a screen reader. Every input type goes
+  // through `wrapper`, so marking it here covers all of them at once instead of
+  // per-case (objectstack#4224).
+  const errorId = `${id}-error`;
   const wrapper = (children: React.ReactNode) => (
     <div className="space-y-1.5 py-2">
       <FieldHeader spec={spec} resolved={resolved} labelText={fieldLabel} labels={labels} />
-      {children}
-      <FieldDescription description={fieldHelp} />
+      {error && isValidElement(children)
+        ? cloneElement(children as ReactElement<Record<string, unknown>>, {
+            'aria-invalid': true,
+            'aria-describedby': errorId,
+          })
+        : children}
+      {error ? (
+        <FieldError id={errorId} message={error} />
+      ) : (
+        <FieldDescription description={fieldHelp} />
+      )}
     </div>
   );
 

--- a/apps/console/src/pages/settings/SettingsView.tsx
+++ b/apps/console/src/pages/settings/SettingsView.tsx
@@ -11,6 +11,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Loader2, ArrowLeft, RotateCcw } from 'lucide-react';
 import { Button, Card, CardContent, Skeleton, Badge } from '@object-ui/components';
+import { extractFieldErrors } from '@object-ui/react';
 import { getIcon } from '../../utils/getIcon';
 import { SettingsField } from './SettingsField';
 import {
@@ -42,6 +43,12 @@ function evalVisibility(expr: string | undefined, data: Record<string, unknown>)
   }
 }
 
+/** `{ ...rest }` without `key`, returned as a new object so React sees the change. */
+function omitKey<T>(map: Record<string, T>, key: string): Record<string, T> {
+  const { [key]: _dropped, ...rest } = map;
+  return rest;
+}
+
 export function SettingsView() {
   const params = useParams<{ namespace?: string }>();
   const navigate = useNavigate();
@@ -53,6 +60,16 @@ export function SettingsView() {
   const [error, setError] = useState<string | null>(null);
   /** Live edit map keyed by spec.key. Falls back to resolved value when undefined. */
   const [draft, setDraft] = useState<Record<string, unknown>>({});
+  /**
+   * Per-field rejections from the last failed save, keyed by field name
+   * (objectstack#4224). Empty until a save comes back `SETTINGS_VALIDATION`.
+   *
+   * Before #4224 the server sent this as a `Record<key, message>` hung beside
+   * `error.code`, which `extractFieldErrors` could not read — so the whole
+   * batch collapsed into one toast that named no field. It now arrives as the
+   * declared `FieldError[]` under `error.details.fields`.
+   */
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -61,6 +78,7 @@ export function SettingsView() {
       const p = await getSettingsNamespace(namespace);
       setPayload(p);
       setDraft({});
+      setFieldErrors({});
     } catch (err: any) {
       setError(err?.message ?? 'Failed to load settings');
     } finally {
@@ -127,6 +145,7 @@ export function SettingsView() {
       const res = await saveSettingsNamespace(namespace, draft);
       setPayload({ ...payload, values: { ...values, ...res.values } });
       setDraft({});
+      setFieldErrors({});
       toast.success('Settings saved');
     } catch (err: any) {
       const apiError = err?.payload?.error;
@@ -135,6 +154,19 @@ export function SettingsView() {
         const key = lockedKeyOf(apiError);
         toast.error(key ? `Locked by environment: ${key}` : 'Locked by environment');
       } else {
+        // Per-field rejections render against the inputs that caused them
+        // (objectstack#4224). `extractFieldErrors` reads `details.fields`, so it
+        // is handed `error` — the object that carries `details` — not the
+        // whole body.
+        //
+        // The toast still fires: the offending field can be scrolled out of
+        // view, or hidden behind a `visible` expression, and a save that
+        // silently does nothing is the worse failure. It carries the server's
+        // summary message, which already names the fields.
+        const perField = extractFieldErrors(apiError);
+        if (perField?.length) {
+          setFieldErrors(Object.fromEntries(perField.map((f) => [f.field, f.message])));
+        }
         toast.error(err?.message ?? 'Save failed');
       }
     } finally {
@@ -194,11 +226,20 @@ export function SettingsView() {
                 spec={spec}
                 resolved={resolved}
                 value={current}
-                onChange={(v) => key && setDraft((d) => ({ ...d, [key]: v }))}
+                onChange={(v) => {
+                  if (!key) return;
+                  setDraft((d) => ({ ...d, [key]: v }));
+                  // Clear this field's rejection the moment it is edited. The
+                  // error describes the value the server saw, so keeping it on
+                  // screen while the user types contradicts what is in the box —
+                  // and the next save re-derives the set from scratch anyway.
+                  setFieldErrors((e) => (key in e ? omitKey(e, key) : e));
+                }}
                 onAction={spec.type === 'action_button' ? () => onAction(spec.id ?? key ?? 'test') : undefined}
                 locked={resolved?.locked}
                 saving={saving}
                 labels={labels}
+                error={key ? fieldErrors[key] : undefined}
               />
             );
           })}
@@ -211,7 +252,17 @@ export function SettingsView() {
               {dirtyKeys.length} unsaved change{dirtyKeys.length > 1 ? 's' : ''}
             </div>
             <div className="flex gap-2">
-              <Button variant="ghost" size="sm" onClick={() => setDraft({})} disabled={saving}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setDraft({});
+                  // Discarding reverts to the stored values, so rejections of
+                  // the edits being thrown away go with them.
+                  setFieldErrors({});
+                }}
+                disabled={saving}
+              >
                 <RotateCcw className="h-4 w-4 mr-1" /> Discard
               </Button>
               <Button onClick={onSave} disabled={saving}>

--- a/apps/console/src/pages/settings/__tests__/SettingsView.field-errors.test.tsx
+++ b/apps/console/src/pages/settings/__tests__/SettingsView.field-errors.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * SettingsView — per-field rendering of a rejected save (objectstack#4224).
+ *
+ * What this closes: a `SETTINGS_VALIDATION` rejection names the offending keys,
+ * and the console threw all of that away. Every failure collapsed into one
+ * toast reading the server's summary sentence, with nothing marked on the
+ * inputs — so on a namespace with a dozen keys the user was told a value was
+ * wrong and left to find which.
+ *
+ * It was not the console's fault, and that is the part worth recording: the
+ * server sent `fields` as a `Record<key, message>` hung BESIDE `error.code`, a
+ * position `ApiErrorSchema` never declared. `extractFieldErrors` only reads
+ * arrays (`details.fields`, `fields`, `validationErrors`), so a map at an
+ * undeclared position matched nothing and returned null. objectstack#4224 moved
+ * it to `error.details.fields` as the declared `FieldError[]`, which is what
+ * makes this wiring a few lines rather than a parser.
+ *
+ * So the assertions below deliberately drive the REAL post-#4224 wire body
+ * rather than a hand-tuned fixture — if the server ever regresses to the map,
+ * these go red instead of quietly passing against a shape nobody sends.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const getSettingsNamespace = vi.fn();
+const saveSettingsNamespace = vi.fn();
+const runSettingsAction = vi.fn();
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api');
+  return {
+    ...actual,
+    getSettingsNamespace: (...a: unknown[]) => getSettingsNamespace(...a),
+    saveSettingsNamespace: (...a: unknown[]) => saveSettingsNamespace(...a),
+    runSettingsAction: (...a: unknown[]) => runSettingsAction(...a),
+  };
+});
+
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...a: unknown[]) => toastError(...a),
+    success: (...a: unknown[]) => toastSuccess(...a),
+  },
+}));
+
+import { SettingsView } from '../SettingsView';
+
+/** Two text keys, so "the right one is marked" is a real assertion. */
+const PAYLOAD = {
+  manifest: {
+    namespace: 'ai',
+    label: 'AI',
+    specifiers: [
+      { type: 'text', key: 'gateway_model', label: 'Gateway model', description: 'Use provider/model.' },
+      { type: 'text', key: 'account_id', label: 'Account ID', description: 'Cloudflare account.' },
+    ],
+  },
+  values: {
+    gateway_model: { value: 'gpt-4o', source: 'default' },
+    account_id: { value: 'acct_1', source: 'default' },
+  },
+};
+
+/**
+ * The real body `/api/settings/:namespace` answers on a rejected write, post
+ * objectstack#4224 — `FieldError[]` under the declared `error.details.fields`.
+ * `api.ts`'s `jsonOrThrow` parks the parsed body on `err.payload`.
+ */
+function validationRejection() {
+  const err = new Error('Settings for \'ai\' are incomplete: gateway_model — …') as Error & {
+    status?: number;
+    payload?: unknown;
+  };
+  err.status = 400;
+  err.payload = {
+    success: false,
+    error: {
+      code: 'SETTINGS_VALIDATION',
+      message: "Settings for 'ai' are incomplete: gateway_model — Gateway model does not match the expected format.",
+      details: {
+        namespace: 'ai',
+        fields: [
+          {
+            field: 'gateway_model',
+            code: 'invalid_format',
+            message: 'Gateway model does not match the expected format. Use provider/model.',
+            label: 'Gateway model',
+            constraint: { pattern: '^[a-z]+/[a-z]+$' },
+          },
+        ],
+      },
+    },
+  };
+  return err;
+}
+
+function renderView() {
+  return render(
+    <MemoryRouter initialEntries={['/settings/ai']}>
+      <Routes>
+        <Route path="/settings/:namespace" element={<SettingsView />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** The input rendered for a given field label. */
+const inputFor = (label: string) =>
+  screen.getByText(label).closest('div')?.parentElement?.querySelector('input') ?? null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSettingsNamespace.mockResolvedValue(structuredClone(PAYLOAD));
+});
+afterEach(cleanup);
+
+describe('SettingsView — a rejected save marks the field that caused it', () => {
+  it('renders the server message against the offending input, and leaves the others alone', async () => {
+    saveSettingsNamespace.mockRejectedValue(validationRejection());
+    renderView();
+    await screen.findByText('Gateway model');
+
+    // Dirty the field so the save bar appears, then save.
+    fireEvent.change(inputFor('Gateway model')!, { target: { value: 'gpt4o' } });
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+
+    // The server's own sentence, verbatim — not re-worded by the console.
+    const msg = await screen.findByText(/does not match the expected format/i);
+    expect(msg).toBeTruthy();
+    expect(msg.getAttribute('role')).toBe('alert');
+
+    // The rejected input is marked, and points at the message for a screen reader.
+    await waitFor(() => {
+      expect(inputFor('Gateway model')!.getAttribute('aria-invalid')).toBe('true');
+    });
+    expect(inputFor('Gateway model')!.getAttribute('aria-describedby')).toBe(msg.getAttribute('id'));
+
+    // The innocent field is untouched — a wrong mark is worse than no mark.
+    expect(inputFor('Account ID')!.getAttribute('aria-invalid')).toBeNull();
+
+    // The toast still fires: the field can be scrolled off-screen or hidden
+    // behind a `visible` expression, and a silent no-op save is the worse bug.
+    expect(toastError).toHaveBeenCalled();
+  });
+
+  it('replaces the help text rather than stacking under it', async () => {
+    saveSettingsNamespace.mockRejectedValue(validationRejection());
+    renderView();
+    await screen.findByText('Gateway model');
+    // The description is what's shown before any save.
+    expect(screen.queryByText('Use provider/model.')).toBeTruthy();
+
+    fireEvent.change(inputFor('Gateway model')!, { target: { value: 'gpt4o' } });
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+    await screen.findByText(/does not match the expected format/i);
+
+    // Gone — the two say the same kind of thing and share one slot.
+    expect(screen.queryByText('Use provider/model.')).toBeNull();
+    // The untouched field keeps its own description.
+    expect(screen.queryByText('Cloudflare account.')).toBeTruthy();
+  });
+
+  it('clears the mark as soon as the field is edited', async () => {
+    saveSettingsNamespace.mockRejectedValue(validationRejection());
+    renderView();
+    await screen.findByText('Gateway model');
+
+    fireEvent.change(inputFor('Gateway model')!, { target: { value: 'gpt4o' } });
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+    await screen.findByText(/does not match the expected format/i);
+
+    // Typing contradicts an error describing the value the server saw.
+    fireEvent.change(inputFor('Gateway model')!, { target: { value: 'anthropic/claude' } });
+    await waitFor(() => {
+      expect(screen.queryByText(/does not match the expected format/i)).toBeNull();
+    });
+    expect(inputFor('Gateway model')!.getAttribute('aria-invalid')).toBeNull();
+    // …and the help text comes back with it.
+    expect(screen.queryByText('Use provider/model.')).toBeTruthy();
+  });
+
+  it('clears every mark once a save succeeds', async () => {
+    saveSettingsNamespace.mockRejectedValueOnce(validationRejection());
+    renderView();
+    await screen.findByText('Gateway model');
+
+    fireEvent.change(inputFor('Gateway model')!, { target: { value: 'gpt4o' } });
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+    await screen.findByText(/does not match the expected format/i);
+
+    saveSettingsNamespace.mockResolvedValueOnce({
+      values: { gateway_model: { value: 'anthropic/claude', source: 'tenant' } },
+    });
+    fireEvent.change(inputFor('Gateway model')!, { target: { value: 'anthropic/claude' } });
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(screen.queryByText(/does not match the expected format/i)).toBeNull();
+  });
+
+  it('a failure carrying no field array still toasts, and marks nothing', async () => {
+    // The 500 / UNKNOWN_NAMESPACE shape — no `details.fields` to read.
+    const err = new Error('Failed to write namespace') as Error & { payload?: unknown };
+    err.payload = { success: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to write namespace' } };
+    saveSettingsNamespace.mockRejectedValue(err);
+    renderView();
+    await screen.findByText('Gateway model');
+
+    fireEvent.change(inputFor('Gateway model')!, { target: { value: 'gpt4o' } });
+    fireEvent.click(await screen.findByRole('button', { name: /save/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(inputFor('Gateway model')!.getAttribute('aria-invalid')).toBeNull();
+    expect(inputFor('Account ID')!.getAttribute('aria-invalid')).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to objectstack-ai/objectstack#4224 (merged) and objectui#3079 (merged) — the piece that change unblocked.

## What was broken

A `SETTINGS_VALIDATION` rejection names the offending keys. The settings page threw all of it away: every failure collapsed into one toast carrying the server's summary sentence, with nothing marked on the inputs. On a namespace with a dozen keys, the user was told a value was wrong and left to find which.

## Why it was not the console's fault

This is the part worth recording, because it explains why the fix is small.

The server sent `fields` as a `Record<key, message>` hung **beside** `error.code` — a position `ApiErrorSchema` never declared. It survived only because that schema is a plain `z.object` and *strips* undeclared keys rather than rejecting them, so nothing on either side of the wire ever flagged it.

`extractFieldErrors` reads arrays:

```ts
(Array.isArray(e.validationErrors) && e.validationErrors) ||
(Array.isArray(e.details?.fields)  && e.details.fields)   ||
(Array.isArray(e.fields)           && e.fields)           || null
```

A map at an undeclared position matched none of those and returned `null`. objectstack#4224 moved it to `error.details.fields` as the declared `FieldError[]` — the second branch above — which is what makes this a few lines of wiring rather than a parser.

## The change

- **`SettingsField` gains an `error` prop**, rendered in the slot the help text occupies rather than stacked under it. The two say the same kind of thing, and a description sitting below a red error reads as if the field has two states at once.
- **The mark is on the control, not just beside it** — `aria-invalid` plus `aria-describedby` pointing at a `role="alert"` message. Colour is not a cue for everyone. It's wired in `wrapper`, the shared layout every input type already goes through, so all of them are covered at once instead of case by case.
- **Cleared per-field the moment that field is edited** — the error describes the value the server saw, so leaving it up while the user types contradicts what's in the box. Cleared wholesale on Discard, on reload, and on a successful save.
- **Fields the server did not name stay unmarked.** A wrong mark on an innocent input is worse than the generic toast that was already there.

The toast still fires alongside the marks, deliberately: the offending field can be scrolled out of view or hidden behind a `visible` expression, and a save that appears to do nothing is the worse failure.

## Verification

- `pnpm --filter @object-ui/console test` — 16 files, **116 tests green** (5 new)
- **The new tests were verified to fail without the wiring** — removing the `extractFieldErrors` call turns 4 of 5 red. The fifth stays green by design: it asserts that a failure *without* a field array marks nothing, which must hold either way.
- The tests drive the **real post-#4224 wire body** rather than a hand-tuned fixture, so a server regression back to the map turns them red instead of quietly passing against a shape nobody sends.
- `tsc --noEmit` — no new errors. Two appear in this environment only because `@object-ui/react` isn't built here (`Cannot find module`, plus the implicit-`any` it cascades into); both disappear after `pnpm --filter @object-ui/react... build`, and CI builds packages first.

## Not in scope

`FieldError` also carries `label` and `constraint` (e.g. `{ pattern }`). This renders the server's `message` verbatim, which is already localized. Composing client-side text from `constraint` is a separate call — worth making once there's a reason to diverge from what the server writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tv2NYMBTrzVVRWiWWuyec5)_