### PR TITLE
fix(notifications): the config, position and action variant are read instead of forked or ignored (#3014 follow-up)

### DIFF
--- a/.changeset/notification-config-contract.md
+++ b/.changeset/notification-config-contract.md
@@ -1,0 +1,52 @@
+---
+"@object-ui/react": minor
+"@object-ui/components": minor
+"@object-ui/app-shell": minor
+---
+
+fix(notifications): the config, `position` and action `variant` are read instead of forked or ignored (#3014 follow-up)
+
+The last of the notification contract. After `displayType` (#3071) and `icon`
+(#3076), four gaps of the same family were left:
+
+- **the config was 3/4 inert** — only `defaultDuration` was ever read.
+  `maxVisible` and `stacking` were carried and ignored, while
+  `NotificationBanners` capped at a hard-coded `3` of its own;
+- **its field names forked from `NotificationConfigSchema`** — `position` vs
+  `defaultPosition`, a renderer-local `stacking` boolean with no spec
+  counterpart, and no `pauseOnHover` at all;
+- **a notification could not declare a `position`.** The #3008 parity guard
+  asserted the position *vocabulary* matched the spec while nothing positioned
+  anything by it — a guard passing over an unused value;
+- **`NotificationActionButton.variant` was the shadcn Button vocabulary**
+  (`default | destructive | outline`) under a spec-shaped name, forking
+  `NotificationActionSchema.variant` (`primary | secondary | link`).
+
+**How positioning resolves now** — `notification.position ?? config.defaultPosition
+?? nothing`, and "nothing" is a real answer:
+
+- **declared** → the surface pins itself there, always. `presentNotificationToast`
+  passes it per-toast so the contract wins over the container;
+- **undeclared** → the surface keeps its own anchor (a snackbar's bottom edge) or
+  defers to the host's toast chrome.
+
+That asymmetry is the design decision. The host's sonner container also serves
+toasts that are *not* spec notifications (the console action runtime's own
+`toast.*` calls), so it stays the fallback authority for placement — never a
+competing one. A declared position a component prop could silently override
+would be the same "validates, then does nothing" shape this whole area is about.
+Hence `defaultPosition` has no fabricated default: "the host didn't say" has to
+be representable.
+
+Also: `maxVisible` / `stackDirection` now drive every stacking surface through
+one shared `visibleNotificationStack` (cap keeps the NEWEST, stack grows in the
+declared direction); `pauseOnHover` holds a transient notification's timer and
+resumes it with the time it had left, which needed the provider to track live
+timers rather than fire-and-forget `setTimeout`s. Legacy spellings still resolve:
+`position` folds into `defaultPosition`, and `stacking: false` reads as
+`maxVisible: 1` rather than being ignored.
+
+`onToast` now receives the resolved config as a second argument, so the delegate
+can apply the parts of the contract only it can. Existing one-argument handlers
+are unaffected. The spec-parity guard gained the action-variant vocabulary, the
+one notification enum it did not cover.

--- a/content/docs/guide/notifications.md
+++ b/content/docs/guide/notifications.md
@@ -96,6 +96,26 @@ notify({ title: 'Viewing a draft', severity: 'warning', displayType: 'banner' })
 notify({ title: 'Session expired', severity: 'error', displayType: 'alert' });
 ```
 
+### `actions`
+
+An action's `variant` is the spec vocabulary — `primary` (default) / `secondary`
+/ `link` — describing the action's **role**. Each surface maps it onto its own
+button styling; it is not the shadcn Button vocabulary, which is a look.
+
+```tsx
+notify({
+  title: 'Storage almost full', severity: 'warning', displayType: 'banner',
+  actions: [
+    { label: 'Upgrade', onClick: upgrade },                    // primary by default
+    { label: 'Learn more', onClick: openDocs, variant: 'link' },
+  ],
+});
+```
+
+A `snackbar` and a `toast` render only the **first** action — both have one
+action slot by nature. A `banner` and an `inline` render all of them; an `alert`
+renders them beside its acknowledge button.
+
 ### `inline` and `scope`
 
 An inline notification is rendered by the surface that raised it. `scope` is the
@@ -129,6 +149,41 @@ A name Lucide doesn't have costs the author their override and nothing more —
 deliberately *not* the generic `Database` glyph `getLazyIcon` returns for
 data-shaped schema slots, which on an error notification would replace a
 meaningful icon with a meaningless one.
+
+### `position`
+
+Honored by the **floating** presentations — `toast` and `snackbar`. `banner`,
+`inline` and `alert` are anchored by what they are (content top / in place /
+centred modal) and ignore it.
+
+Resolution is `notification.position ?? config.defaultPosition ?? nothing`, and
+"nothing" is a real answer rather than a missing one:
+
+- **declared** → the surface pins itself there, always;
+- **undeclared** → the surface keeps its own anchor (a snackbar's bottom edge)
+  or defers to the host's toast chrome.
+
+That asymmetry is deliberate. The host's toast container is shared with toasts
+that are *not* spec notifications (in the console, the action runtime's own
+`toast.*` calls), so it stays the fallback authority for placement — but never a
+competing one. A declared position that a component prop could silently override
+would be the same "validates, then does nothing" shape this whole area is about.
+
+## Configuring the system
+
+`NotificationProvider`'s `config` is the spec `NotificationConfigSchema`:
+
+| Key | Default | Effect |
+|---|---|---|
+| `defaultPosition` | — | Fallback position for the floating presentations. Deliberately unset: see above. |
+| `defaultDuration` | `5000` | Auto-dismiss for the transient presentations. |
+| `maxVisible` | `5` | Cap on a stacking surface (banner, inline); the newest survive. |
+| `stackDirection` | `down` | Which way a stack grows — `down` puts the newest below. |
+| `pauseOnHover` | `true` | Hold a transient notification's timer while it is hovered. |
+
+The legacy spellings `position` and `stacking` are still accepted:
+`defaultPosition` wins over `position`, and `stacking: false` reads as
+`maxVisible: 1` ("show only the newest") rather than being ignored.
 
 ### `dismissible`
 

--- a/packages/app-shell/src/chrome/notificationToast.test.tsx
+++ b/packages/app-shell/src/chrome/notificationToast.test.tsx
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { isValidElement } from 'react';
-import type { NotificationItem } from '@object-ui/react';
+import { resolveNotificationConfig, type NotificationItem } from '@object-ui/react';
 
 vi.mock('sonner', () => ({
   toast: Object.assign(vi.fn(), {
@@ -132,5 +132,40 @@ describe('presentNotificationToast', () => {
     presentNotificationToast(item());
     const options = vi.mocked(toast.success).mock.calls[0][1] as Record<string, unknown>;
     expect(options).not.toHaveProperty('icon');
+  });
+
+  // Position is the half of the contract that had to be settled: declared wins,
+  // undeclared defers to the sonner container (host chrome, which also places
+  // the console's many direct `toast.*` calls).
+  describe('position', () => {
+    it('omits the key when neither the notification nor the config declares one', () => {
+      presentNotificationToast(item(), resolveNotificationConfig());
+      const options = vi.mocked(toast.success).mock.calls[0][1] as Record<string, unknown>;
+      expect(options).not.toHaveProperty('position');
+    });
+
+    it('passes the configured default, translated to sonner ids', () => {
+      presentNotificationToast(item(), resolveNotificationConfig({ defaultPosition: 'top_right' }));
+      expect(toast.success).toHaveBeenCalledWith('Saved', expect.objectContaining({
+        position: 'top-right',
+      }));
+    });
+
+    it("lets the notification's own position win", () => {
+      presentNotificationToast(
+        item({ position: 'bottom_left' }),
+        resolveNotificationConfig({ defaultPosition: 'top_right' }),
+      );
+      expect(toast.success).toHaveBeenCalledWith('Saved', expect.objectContaining({
+        position: 'bottom-left',
+      }));
+    });
+
+    it('works with no config at all', () => {
+      presentNotificationToast(item({ position: 'top_center' }));
+      expect(toast.success).toHaveBeenCalledWith('Saved', expect.objectContaining({
+        position: 'top-center',
+      }));
+    });
   });
 });

--- a/packages/app-shell/src/chrome/notificationToast.tsx
+++ b/packages/app-shell/src/chrome/notificationToast.tsx
@@ -14,8 +14,13 @@
  */
 
 import { toast } from 'sonner';
-import type { NotificationItem, NotificationSeverityLevel } from '@object-ui/react';
-import { isLucideIconName, LazyIcon } from '@object-ui/components';
+import {
+  resolveNotificationPosition,
+  type NotificationItem,
+  type NotificationSeverityLevel,
+  type ResolvedNotificationConfig,
+} from '@object-ui/react';
+import { isLucideIconName, LazyIcon, TOASTER_POSITIONS } from '@object-ui/components';
 
 /**
  * Typed as `Record<NotificationSeverityLevel, …>` so a new severity in the spec
@@ -35,8 +40,19 @@ const TOAST_BY_SEVERITY: Record<NotificationSeverityLevel, (message: string, dat
  * Duration follows the notification contract: `0` means persistent (sonner's
  * `Infinity`), and an absent duration defers to the `ConsoleToaster` default
  * rather than being invented here.
+ *
+ * Position follows the same rule, and it is the one that had to be settled: a
+ * DECLARED position (the notification's own, else `config.defaultPosition`) is
+ * passed per-toast so the contract always wins, and an UNDECLARED one omits the
+ * key entirely so the sonner container keeps placing it. That container is host
+ * chrome — it also serves the console's many direct `toast.*` calls, which are
+ * not spec notifications — so it stays the fallback authority, never a
+ * competing one.
  */
-export function presentNotificationToast(notification: NotificationItem): void {
+export function presentNotificationToast(
+  notification: NotificationItem,
+  config?: Pick<ResolvedNotificationConfig, 'defaultPosition'>,
+): void {
   const show = TOAST_BY_SEVERITY[notification.severity] ?? TOAST_BY_SEVERITY.info;
   // A toast carries at most one action button — sonner has one `action` slot,
   // and a notification needing more than one belongs on a banner or an alert.
@@ -48,12 +64,15 @@ export function presentNotificationToast(notification: NotificationItem): void {
   const icon = isLucideIconName(notification.icon)
     ? <LazyIcon name={notification.icon} className="h-4 w-4" />
     : undefined;
+  const declared = resolveNotificationPosition(notification, config);
+  const position = declared ? TOASTER_POSITIONS[declared] : undefined;
 
   show(notification.title, {
     description: notification.message,
     duration: notification.duration === 0 ? Infinity : notification.duration,
     dismissible: notification.dismissible,
     ...(icon ? { icon } : {}),
+    ...(position ? { position } : {}),
     ...(action ? { action: { label: action.label, onClick: action.onClick } } : {}),
   });
 }

--- a/packages/app-shell/src/console/ConsoleShell.tsx
+++ b/packages/app-shell/src/console/ConsoleShell.tsx
@@ -132,8 +132,13 @@ function GlobalActionRuntimeProvider({ dataSource, children }: { dataSource: unk
 export function ConsoleShell({ children }: { children: ReactNode }) {
   return (
     <ThemeProvider defaultTheme="system" storageKey="object-ui-theme">
-      {/* `defaultDuration` matches ConsoleToaster's 4s toast default, so a
-          snackbar and a toast raised together disappear together. */}
+      {/* `defaultDuration` matches ConsoleToaster's 4s toast default and
+          `maxVisible` its `visibleToasts={4}`, so a snackbar and a toast raised
+          together disappear together and the banner stack caps like the toast
+          stack. No `defaultPosition`: nothing declared means the sonner
+          container keeps placing toasts (it also serves the console's direct
+          `toast.*` calls) and the snackbar keeps its own bottom anchor — a
+          notification that DECLARES a position still overrides both. */}
       <NotificationProvider config={{ defaultDuration: 4000, maxVisible: 4 }} onToast={presentNotificationToast}>
         <NavigationProvider>
           <UserStateAdaptersProvider>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -58,6 +58,8 @@ export * from './custom';
 
 // Export the notification surfaces — one per spec `displayType` (#3014).
 export * from './notifications';
+// Spec position → sonner position ids, shared with the console's toast bridge.
+export { TOASTER_POSITIONS } from './renderers/feedback/toaster';
 
 // Export hooks
 export { useConfigDraft } from './hooks/use-config-draft';

--- a/packages/components/src/notifications/NotificationAlerts.tsx
+++ b/packages/components/src/notifications/NotificationAlerts.tsx
@@ -32,7 +32,18 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../ui/alert-dialog';
-import { notificationIcon, notificationSeverityStyle } from './severity';
+import { notificationActionVariant, notificationIcon, notificationSeverityStyle } from './severity';
+
+/**
+ * Button-variant classes for the dialog footer. `AlertDialogAction` bakes in
+ * `buttonVariants()` (the `default` look), so a variant is expressed as an
+ * override rather than a prop — `primary` needs none.
+ */
+const ALERT_ACTION_CLASSES: Record<'default' | 'secondary' | 'link', string | undefined> = {
+  default: undefined,
+  secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+  link: 'bg-transparent text-primary underline-offset-4 hover:bg-transparent hover:underline',
+};
 
 export interface NotificationAlertsProps {
   /** Extra classes for the dialog content. */
@@ -90,14 +101,18 @@ export function NotificationAlerts({ className, acknowledgeLabel = 'OK' }: Notif
           {notification.actions?.map((action) => (
             <AlertDialogAction
               key={action.label}
-              className={cn(action.variant === 'destructive' && 'bg-destructive text-destructive-foreground hover:bg-destructive/90')}
+              // AlertDialogAction hard-codes the default Button styling, so the
+              // spec variant is applied as an override on top of it.
+              className={cn(ALERT_ACTION_CLASSES[notificationActionVariant(action.variant)])}
               onClick={() => { action.onClick(); acknowledge(); }}
             >
               {action.label}
             </AlertDialogAction>
           ))}
           <AlertDialogAction
-            className={cn(notification.actions?.length ? 'bg-secondary text-secondary-foreground hover:bg-secondary/80' : undefined)}
+            // Declared actions are the primary ones; the bare acknowledge steps
+            // back to secondary when it is not the only button.
+            className={cn(notification.actions?.length ? ALERT_ACTION_CLASSES.secondary : undefined)}
             onClick={acknowledge}
           >
             {acknowledgeLabel}

--- a/packages/components/src/notifications/NotificationBanners.tsx
+++ b/packages/components/src/notifications/NotificationBanners.tsx
@@ -18,19 +18,18 @@
 
 import * as React from 'react';
 import { X } from 'lucide-react';
-import { useNotifications, useNotificationsByPresentation } from '@object-ui/react';
+import {
+  useNotifications,
+  useNotificationsByPresentation,
+  visibleNotificationStack,
+} from '@object-ui/react';
 import { cn } from '../lib/utils';
 import { Button } from '../ui/button';
-import { notificationIcon, notificationSeverityStyle } from './severity';
+import { notificationActionVariant, notificationIcon, notificationSeverityStyle } from './severity';
 
 export interface NotificationBannersProps {
   /** Extra classes for the banner stack container. */
   className?: string;
-  /**
-   * Cap on simultaneously rendered banners (newest first). Banners are
-   * persistent, so an uncapped stack can swallow the viewport. Default 3.
-   */
-  max?: number;
 }
 
 /**
@@ -44,15 +43,19 @@ export interface NotificationBannersProps {
  * </main>
  * ```
  */
-export function NotificationBanners({ className, max = 3 }: NotificationBannersProps) {
+export function NotificationBanners({ className }: NotificationBannersProps) {
   const banners = useNotificationsByPresentation('banner');
-  const { dismiss } = useNotifications();
+  const { dismiss, config } = useNotifications();
 
   if (banners.length === 0) return null;
 
+  // `maxVisible` / `stackDirection` come from the provider config — the spec's
+  // own knobs — instead of a cap this component invents for itself.
+  const visible = visibleNotificationStack(banners, config);
+
   return (
     <div className={cn('flex w-full flex-col', className)} data-notification-surface="banner">
-      {banners.slice(0, max).map((notification) => {
+      {visible.map((notification) => {
         const { tone } = notificationSeverityStyle(notification.severity);
         const Icon = notificationIcon(notification);
         return (
@@ -76,7 +79,7 @@ export function NotificationBanners({ className, max = 3 }: NotificationBannersP
               <Button
                 key={action.label}
                 size="sm"
-                variant={action.variant ?? 'outline'}
+                variant={notificationActionVariant(action.variant)}
                 className="h-7 shrink-0"
                 onClick={action.onClick}
               >

--- a/packages/components/src/notifications/NotificationInline.tsx
+++ b/packages/components/src/notifications/NotificationInline.tsx
@@ -18,10 +18,14 @@
 
 import * as React from 'react';
 import { X } from 'lucide-react';
-import { useNotifications, useNotificationsByPresentation } from '@object-ui/react';
+import {
+  useNotifications,
+  useNotificationsByPresentation,
+  visibleNotificationStack,
+} from '@object-ui/react';
 import { cn } from '../lib/utils';
 import { Button } from '../ui/button';
-import { notificationIcon, notificationSeverityStyle } from './severity';
+import { notificationActionVariant, notificationIcon, notificationSeverityStyle } from './severity';
 
 export interface NotificationInlineProps {
   /**
@@ -46,9 +50,12 @@ export interface NotificationInlineProps {
  */
 export function NotificationInline({ scope, className }: NotificationInlineProps) {
   const items = useNotificationsByPresentation('inline', scope);
-  const { dismiss } = useNotifications();
+  const { dismiss, config } = useNotifications();
 
   if (items.length === 0) return null;
+
+  // Same `maxVisible` / `stackDirection` contract as the banner stack.
+  const visible = visibleNotificationStack(items, config);
 
   return (
     <div
@@ -56,7 +63,7 @@ export function NotificationInline({ scope, className }: NotificationInlineProps
       data-notification-surface="inline"
       data-scope={scope}
     >
-      {items.map((notification) => {
+      {visible.map((notification) => {
         const { tone } = notificationSeverityStyle(notification.severity);
         const Icon = notificationIcon(notification);
         return (
@@ -78,7 +85,7 @@ export function NotificationInline({ scope, className }: NotificationInlineProps
                     <Button
                       key={action.label}
                       size="sm"
-                      variant={action.variant ?? 'outline'}
+                      variant={notificationActionVariant(action.variant)}
                       className="h-7"
                       onClick={action.onClick}
                     >

--- a/packages/components/src/notifications/NotificationSnackbar.tsx
+++ b/packages/components/src/notifications/NotificationSnackbar.tsx
@@ -18,10 +18,19 @@
 
 import * as React from 'react';
 import { X } from 'lucide-react';
-import { useNotifications, useNotificationsByPresentation } from '@object-ui/react';
+import {
+  resolveNotificationPosition,
+  useNotifications,
+  useNotificationsByPresentation,
+} from '@object-ui/react';
 import { cn } from '../lib/utils';
 import { Button } from '../ui/button';
-import { notificationIcon, notificationSeverityStyle } from './severity';
+import {
+  NOTIFICATION_POSITION_CLASSES,
+  notificationActionVariant,
+  notificationIcon,
+  notificationSeverityStyle,
+} from './severity';
 
 export interface NotificationSnackbarProps {
   /** Extra classes for the snackbar container. */
@@ -29,7 +38,7 @@ export interface NotificationSnackbarProps {
 }
 
 /**
- * Renders the most recent `snackbar` notification, anchored bottom-center.
+ * Renders the most recent `snackbar` notification, bottom-anchored by default.
  *
  * @example
  * ```tsx
@@ -41,7 +50,7 @@ export interface NotificationSnackbarProps {
  */
 export function NotificationSnackbar({ className }: NotificationSnackbarProps) {
   const snackbars = useNotificationsByPresentation('snackbar');
-  const { dismiss } = useNotifications();
+  const { dismiss, config, pauseAutoDismiss, resumeAutoDismiss } = useNotifications();
 
   // Newest-first — a snackbar supersedes rather than stacks.
   const notification = snackbars[0];
@@ -52,19 +61,35 @@ export function NotificationSnackbar({ className }: NotificationSnackbarProps) {
   // The spec frames a snackbar as carrying "an optional single action"; extra
   // actions belong on a banner or an alert.
   const action = notification.actions?.[0];
+  // A declared position wins; nothing declared keeps the snackbar's own bottom
+  // anchor rather than being moved by a default nobody asked for.
+  const position = resolveNotificationPosition(notification, config);
+  const anchor = position
+    ? NOTIFICATION_POSITION_CLASSES[position]
+    : 'bottom-4 left-1/2 -translate-x-1/2';
+  const enterFrom = position?.startsWith('top')
+    ? 'motion-safe:slide-in-from-top-4'
+    : 'motion-safe:slide-in-from-bottom-4';
 
   return (
     <div
       className={cn(
-        'fixed bottom-4 left-1/2 z-50 flex w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2',
+        'fixed z-50 flex w-[min(28rem,calc(100vw-2rem))]',
+        anchor,
         'items-center gap-3 rounded-md border bg-popover px-4 py-3 text-sm text-popover-foreground shadow-lg',
-        'motion-safe:animate-in motion-safe:slide-in-from-bottom-4 motion-safe:fade-in',
+        'motion-safe:animate-in motion-safe:fade-in',
+        enterFrom,
         className,
       )}
       role="status"
       aria-live="polite"
       data-notification-surface="snackbar"
       data-severity={notification.severity}
+      data-position={position}
+      // Spec `pauseOnHover` — hold the auto-dismiss timer while the pointer is
+      // on the snackbar, so its single action stays clickable.
+      onPointerEnter={config.pauseOnHover ? () => pauseAutoDismiss(notification.id) : undefined}
+      onPointerLeave={config.pauseOnHover ? () => resumeAutoDismiss(notification.id) : undefined}
     >
       {/* eslint-disable-next-line react-hooks/static-components -- notificationIcon returns a module-cached stable component per name, not one created during render */}
       <Icon className={cn('h-4 w-4 shrink-0', iconTone)} aria-hidden="true" />
@@ -77,7 +102,7 @@ export function NotificationSnackbar({ className }: NotificationSnackbarProps) {
       {action ? (
         <Button
           size="sm"
-          variant="ghost"
+          variant={notificationActionVariant(action.variant)}
           className="h-7 shrink-0 font-semibold uppercase tracking-wide"
           onClick={() => {
             action.onClick();

--- a/packages/components/src/notifications/__tests__/notification-surfaces.test.tsx
+++ b/packages/components/src/notifications/__tests__/notification-surfaces.test.tsx
@@ -27,12 +27,13 @@ import {
   useNotifications,
   type NotificationItem,
   type NotificationPresentation,
+  type NotificationSystemConfig,
 } from '@object-ui/react';
 import { NotificationBanners } from '../NotificationBanners';
 import { NotificationSnackbar } from '../NotificationSnackbar';
 import { NotificationAlerts } from '../NotificationAlerts';
 import { NotificationInline } from '../NotificationInline';
-import { notificationIcon, notificationSeverityStyle } from '../severity';
+import { notificationActionVariant, notificationIcon, notificationSeverityStyle } from '../severity';
 
 function specDisplayTypes(): string[] {
   const raw = (NotificationTypeSchema as { options?: readonly string[] }).options;
@@ -226,6 +227,103 @@ describe('notificationIcon', () => {
     // is always the better fallback, so a typo costs the override and no more.
     expect(notificationIcon({ severity: 'warning', icon: 'not-a-real-icon' }))
       .toBe(notificationSeverityStyle('warning').Icon);
+  });
+});
+
+/**
+ * The config used to be inert — `maxVisible` was carried and unread while
+ * `NotificationBanners` capped at a hard-coded 3 of its own, and no
+ * notification could declare a `position` at all.
+ */
+describe('config-driven surface behaviour', () => {
+  function renderWith(config: NotificationSystemConfig) {
+    return render(
+      <NotificationProvider config={config} onToast={vi.fn()}>
+        <Raiser />
+        <NotificationBanners />
+        <NotificationSnackbar />
+      </NotificationProvider>,
+    );
+  }
+
+  it('caps the banner stack at maxVisible, keeping the newest', () => {
+    renderWith({ maxVisible: 2 });
+    act(() => {
+      raise({ title: 'B oldest', severity: 'info', displayType: 'banner' });
+      raise({ title: 'B middle', severity: 'info', displayType: 'banner' });
+      raise({ title: 'B newest', severity: 'info', displayType: 'banner' });
+    });
+
+    expect(screen.queryByText('B oldest')).not.toBeInTheDocument();
+    expect(screen.getByText('B middle')).toBeInTheDocument();
+    expect(screen.getByText('B newest')).toBeInTheDocument();
+  });
+
+  /** Banner titles in DOM order. */
+  function bannerOrder(): string[] {
+    return [...document.querySelectorAll('[data-notification-surface="banner"] [role="status"]')]
+      .map((el) => el.querySelector('span')?.textContent ?? '');
+  }
+
+  it('grows the banner stack downward by default — newest below', () => {
+    renderWith({});
+    act(() => {
+      raise({ title: 'B first', severity: 'info', displayType: 'banner' });
+      raise({ title: 'B second', severity: 'info', displayType: 'banner' });
+    });
+
+    expect(bannerOrder()).toEqual(['B first', 'B second']);
+  });
+
+  it('grows the banner stack upward when stackDirection says so', () => {
+    renderWith({ stackDirection: 'up' });
+    act(() => {
+      raise({ title: 'B first', severity: 'info', displayType: 'banner' });
+      raise({ title: 'B second', severity: 'info', displayType: 'banner' });
+    });
+
+    expect(bannerOrder()).toEqual(['B second', 'B first']);
+  });
+
+  it('keeps the snackbar on its own anchor when nothing declares a position', () => {
+    renderWith({});
+    act(() => { raise({ title: 'Anchored', severity: 'info', displayType: 'snackbar' }); });
+
+    const bar = screen.getByText('Anchored').closest('[data-notification-surface="snackbar"]')!;
+    expect(bar).not.toHaveAttribute('data-position');
+    expect(bar.className).toMatch(/bottom-4/);
+  });
+
+  it('moves the snackbar to the configured default position', () => {
+    renderWith({ defaultPosition: 'top_right' });
+    act(() => { raise({ title: 'Top right', severity: 'info', displayType: 'snackbar' }); });
+
+    const bar = screen.getByText('Top right').closest('[data-notification-surface="snackbar"]')!;
+    expect(bar).toHaveAttribute('data-position', 'top_right');
+    expect(bar.className).toMatch(/top-4/);
+    expect(bar.className).toMatch(/right-4/);
+  });
+
+  it("lets a notification's own position beat the configured default", () => {
+    renderWith({ defaultPosition: 'top_right' });
+    act(() => {
+      raise({ title: 'Bottom left', severity: 'info', displayType: 'snackbar', position: 'bottom_left' });
+    });
+
+    const bar = screen.getByText('Bottom left').closest('[data-notification-surface="snackbar"]')!;
+    expect(bar).toHaveAttribute('data-position', 'bottom_left');
+  });
+});
+
+describe('action variants', () => {
+  it('maps the spec vocabulary onto Button variants', () => {
+    expect(notificationActionVariant('primary')).toBe('default');
+    expect(notificationActionVariant('secondary')).toBe('secondary');
+    expect(notificationActionVariant('link')).toBe('link');
+  });
+
+  it('defaults to the spec default (primary)', () => {
+    expect(notificationActionVariant()).toBe('default');
   });
 });
 

--- a/packages/components/src/notifications/index.ts
+++ b/packages/components/src/notifications/index.ts
@@ -26,7 +26,10 @@ export { NotificationSnackbar, type NotificationSnackbarProps } from './Notifica
 export { NotificationAlerts, type NotificationAlertsProps } from './NotificationAlerts';
 export { NotificationInline, type NotificationInlineProps } from './NotificationInline';
 export {
+  NOTIFICATION_ACTION_BUTTON_VARIANTS,
+  NOTIFICATION_POSITION_CLASSES,
   NOTIFICATION_SEVERITY_STYLES,
+  notificationActionVariant,
   notificationIcon,
   notificationSeverityStyle,
   type NotificationSeverityStyle,

--- a/packages/components/src/notifications/severity.ts
+++ b/packages/components/src/notifications/severity.ts
@@ -17,7 +17,12 @@
 
 import type { ElementType } from 'react';
 import { AlertTriangle, CheckCircle2, Info, XCircle, type LucideIcon } from 'lucide-react';
-import type { NotificationItem, NotificationSeverityLevel } from '@object-ui/react';
+import type {
+  NotificationActionVariant,
+  NotificationItem,
+  NotificationPositionValue,
+  NotificationSeverityLevel,
+} from '@object-ui/react';
 import { getLazyIcon, isLucideIconName } from '../lib/lazy-icon';
 
 export interface NotificationSeverityStyle {
@@ -82,3 +87,50 @@ export function notificationIcon(
   if (isLucideIconName(notification.icon)) return getLazyIcon(notification.icon);
   return notificationSeverityStyle(notification.severity).Icon;
 }
+
+/**
+ * Spec `NotificationActionSchema.variant` → the shadcn Button variant that
+ * renders it. Typed as `Record<NotificationActionVariant, …>`, so a new member
+ * in the spec enum fails type-check here instead of falling back to `default`.
+ *
+ * The two vocabularies are NOT the same list, which is exactly why the mapping
+ * is explicit: the spec describes an action's ROLE (primary / secondary / link)
+ * and Button describes its LOOK.
+ */
+export const NOTIFICATION_ACTION_BUTTON_VARIANTS: Record<
+  NotificationActionVariant,
+  'default' | 'secondary' | 'link'
+> = {
+  primary: 'default',
+  secondary: 'secondary',
+  link: 'link',
+};
+
+/** Resolve an action's Button variant, defaulting to the spec's `primary`. */
+export function notificationActionVariant(
+  variant?: NotificationActionVariant,
+): 'default' | 'secondary' | 'link' {
+  return NOTIFICATION_ACTION_BUTTON_VARIANTS[variant ?? 'primary']
+    ?? NOTIFICATION_ACTION_BUTTON_VARIANTS.primary;
+}
+
+/**
+ * Spec `NotificationPositionSchema` → the fixed-position classes a floating
+ * surface pins itself with. `undefined` (nothing declared) is the caller's cue
+ * to keep its own anchor, so there is no entry for it here.
+ */
+export const NOTIFICATION_POSITION_CLASSES: Record<NotificationPositionValue, string> = {
+  top_left: 'top-4 left-4',
+  top_center: 'top-4 left-1/2 -translate-x-1/2',
+  top_right: 'top-4 right-4',
+  bottom_left: 'bottom-4 left-4',
+  bottom_center: 'bottom-4 left-1/2 -translate-x-1/2',
+  bottom_right: 'bottom-4 right-4',
+  // The hyphen spellings stored items may still carry (#2942).
+  'top-left': 'top-4 left-4',
+  'top-center': 'top-4 left-1/2 -translate-x-1/2',
+  'top-right': 'top-4 right-4',
+  'bottom-left': 'bottom-4 left-4',
+  'bottom-center': 'bottom-4 left-1/2 -translate-x-1/2',
+  'bottom-right': 'bottom-4 right-4',
+};

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -211,7 +211,16 @@ notify({ title: 'Fix 2 fields', severity: 'error', displayType: 'inline', scope:
 
 A surface component subscribes with `useNotificationsByPresentation(type, scope?)`,
 which also registers the surface — raising a `banner` with no banner surface
-mounted warns in dev instead of vanishing. See the
+mounted warns in dev instead of vanishing.
+
+`config` is the spec `NotificationConfigSchema` (`defaultPosition`,
+`defaultDuration`, `maxVisible`, `stackDirection`, `pauseOnHover`); the legacy
+`position` / `stacking` spellings still resolve through
+`resolveNotificationConfig`. Three helpers apply it so every surface agrees:
+`resolveNotificationPosition` (a declared position always wins; nothing declared
+leaves the surface on its own anchor), `visibleNotificationStack` (`maxVisible` +
+`stackDirection`), and the context's `pauseAutoDismiss` / `resumeAutoDismiss`
+(`pauseOnHover`). See the
 [notifications guide](https://objectui.org/docs/guide/notifications).
 
 ## API Reference

--- a/packages/react/src/context/NotificationContext.tsx
+++ b/packages/react/src/context/NotificationContext.tsx
@@ -143,11 +143,27 @@ export const SUPPORTED_NOTIFICATION_POSITIONS: ReadonlySet<string> = new Set([
   'top_left', 'top_center', 'top_right', 'bottom_left', 'bottom_center', 'bottom_right',
 ]);
 
+/**
+ * Action button variant — the spec `NotificationActionSchema.variant`
+ * (`primary | secondary | link`, default `primary`).
+ *
+ * This used to be the shadcn Button vocabulary (`default | destructive |
+ * outline`) — a renderer-local fork of a spec enum, i.e. a second de-facto
+ * contract. Surfaces map these three onto their own button styling instead.
+ */
+export type NotificationActionVariant = 'primary' | 'secondary' | 'link';
+
+/** The spec vocabulary this context implements — exported for the parity test. */
+export const SUPPORTED_NOTIFICATION_ACTION_VARIANTS: ReadonlySet<string> = new Set([
+  'primary', 'secondary', 'link',
+]);
+
 /** Action button on a notification */
 export interface NotificationActionButton {
   label: string;
   onClick: () => void;
-  variant?: 'default' | 'destructive' | 'outline';
+  /** Spec `NotificationActionSchema.variant`. Default: `primary`. */
+  variant?: NotificationActionVariant;
 }
 
 /** A single notification item */
@@ -183,6 +199,13 @@ export interface NotificationItem {
    * IS, not which React subtree hosts it.
    */
   scope?: string;
+  /**
+   * Spec `NotificationSchema.position` — "Override default position", falling
+   * back to `config.defaultPosition`. Honored by the FLOATING presentations
+   * (toast, snackbar); `banner` / `inline` / `alert` are anchored by what they
+   * are (content top / in place / centered modal) and ignore it.
+   */
+  position?: NotificationPositionValue;
   /** Whether the notification has been read */
   read?: boolean;
   /** Timestamp */
@@ -191,16 +214,70 @@ export interface NotificationItem {
   icon?: string;
 }
 
-/** Configuration for the notification system */
+/**
+ * Configuration for the notification system — the spec
+ * `NotificationConfigSchema` (`defaultPosition` / `defaultDuration` /
+ * `maxVisible` / `stackDirection` / `pauseOnHover`).
+ *
+ * The field names used to fork from it (`position`, and a renderer-local
+ * `stacking` boolean with no spec counterpart), and only `defaultDuration` was
+ * ever read — the other three were stored and ignored. The legacy names are
+ * still accepted; see {@link resolveNotificationConfig}.
+ */
 export interface NotificationSystemConfig {
-  /** Default position for toast notifications */
-  position?: NotificationPositionValue;
-  /** Default duration in ms */
+  /**
+   * Default screen position for the FLOATING presentations (toast, snackbar).
+   * A notification's own `position` overrides it.
+   *
+   * Deliberately undefined by default: "the host didn't say" has to be
+   * representable, otherwise a fabricated default silently competes with the
+   * host's own toast chrome (which also serves non-notification `toast.*`
+   * calls). Declared wins; undeclared defers to the surface's own anchor.
+   */
+  defaultPosition?: NotificationPositionValue;
+  /** Default duration in ms for the transient presentations. */
   defaultDuration?: number;
-  /** Maximum number of visible notifications */
+  /** Maximum number of notifications a stacking surface renders at once. */
   maxVisible?: number;
-  /** Whether to stack notifications */
+  /** Which way a stack grows: `down` puts the newest below (spec default). */
+  stackDirection?: 'up' | 'down';
+  /** Pause a transient notification's auto-dismiss timer while hovered. */
+  pauseOnHover?: boolean;
+  /** @deprecated renderer dialect — use `defaultPosition` */
+  position?: NotificationPositionValue;
+  /**
+   * @deprecated renderer dialect with no spec counterpart. Read as "show only
+   * the newest" (`maxVisible: 1`) when false, so it is honored rather than
+   * fossilized; declare `maxVisible` instead.
+   */
   stacking?: boolean;
+}
+
+/** Config with the legacy spellings folded in and the spec defaults applied. */
+export interface ResolvedNotificationConfig {
+  defaultPosition?: NotificationPositionValue;
+  defaultDuration: number;
+  maxVisible: number;
+  stackDirection: 'up' | 'down';
+  pauseOnHover: boolean;
+}
+
+/**
+ * Fold the deprecated spellings into the spec ones and apply the spec defaults
+ * (`NotificationConfigSchema`: 5000ms / 5 visible / stack down / pause on
+ * hover). `defaultPosition` gets no fabricated default — see the field docs.
+ */
+export function resolveNotificationConfig(
+  config: NotificationSystemConfig = {},
+): ResolvedNotificationConfig {
+  return {
+    defaultPosition: config.defaultPosition ?? config.position,
+    defaultDuration: config.defaultDuration ?? 5000,
+    // `stacking: false` means "don't stack" — one visible item.
+    maxVisible: config.stacking === false ? 1 : config.maxVisible ?? 5,
+    stackDirection: config.stackDirection ?? 'down',
+    pauseOnHover: config.pauseOnHover ?? true,
+  };
 }
 
 export interface NotificationProviderProps {
@@ -214,8 +291,12 @@ export interface NotificationProviderProps {
    * notification, which is why the other four spec types all surfaced as
    * toasts (#3014); they now render through their own surface components,
    * which subscribe via {@link useNotificationsByPresentation}.
+   *
+   * The resolved config comes with it so the delegate can honor the parts of
+   * the contract only it can apply — `defaultPosition` above all, since the
+   * toast overlay is the host's.
    */
-  onToast?: (notification: NotificationItem) => void;
+  onToast?: (notification: NotificationItem, config: ResolvedNotificationConfig) => void;
 }
 
 interface NotificationContextValue {
@@ -241,8 +322,16 @@ interface NotificationContextValue {
   dismiss: (id: string) => void;
   /** Clear all notifications */
   clearAll: () => void;
-  /** System configuration */
-  config: NotificationSystemConfig;
+  /** System configuration, spec-normalized (see {@link resolveNotificationConfig}). */
+  config: ResolvedNotificationConfig;
+  /**
+   * Hold a transient notification's auto-dismiss timer (spec `pauseOnHover`).
+   * A surface calls this on pointer-enter; no-op when the notification is
+   * persistent or the config opted out.
+   */
+  pauseAutoDismiss: (id: string) => void;
+  /** Resume a held timer with the time it had left. */
+  resumeAutoDismiss: (id: string) => void;
   /**
    * Announce that a surface is mounted and will render `surface` items.
    * Returns the unregister callback. Surfaces call this from an effect; the
@@ -303,14 +392,8 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
   config: userConfig = {},
   onToast,
 }) => {
-  const config = useMemo<NotificationSystemConfig>(
-    () => ({
-      position: 'top-right',
-      defaultDuration: 5000,
-      maxVisible: 5,
-      stacking: true,
-      ...userConfig,
-    }),
+  const config = useMemo<ResolvedNotificationConfig>(
+    () => resolveNotificationConfig(userConfig),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [JSON.stringify(userConfig)],
   );
@@ -320,6 +403,39 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
   // Surfaces currently mounted, by presentation surface. A ref (not state) so
   // `notify` can read the live set without re-creating itself on every mount.
   const mountedSurfaces = useRef<Map<NotificationSurface, number>>(new Map());
+
+  // Live auto-dismiss timers, so `pauseOnHover` can hold one and resume it with
+  // the time it had left. A plain `setTimeout` could only ever be cancelled,
+  // which is why the spec's `pauseOnHover` had nothing to attach to.
+  const timers = useRef<Map<string, { handle: ReturnType<typeof setTimeout>; endsAt: number; left: number }>>(new Map());
+
+  const scheduleAutoDismiss = useCallback((id: string, ms: number) => {
+    const handle = setTimeout(() => {
+      timers.current.delete(id);
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+    }, ms);
+    timers.current.set(id, { handle, endsAt: Date.now() + ms, left: ms });
+  }, []);
+
+  const pauseAutoDismiss = useCallback((id: string) => {
+    const timer = timers.current.get(id);
+    if (!timer) return;
+    clearTimeout(timer.handle);
+    timers.current.set(id, { ...timer, left: Math.max(0, timer.endsAt - Date.now()) });
+  }, []);
+
+  const resumeAutoDismiss = useCallback((id: string) => {
+    const timer = timers.current.get(id);
+    if (!timer) return;
+    clearTimeout(timer.handle);
+    scheduleAutoDismiss(id, timer.left);
+  }, [scheduleAutoDismiss]);
+
+  // Never leave a timer running past unmount.
+  useEffect(() => () => {
+    for (const { handle } of timers.current.values()) clearTimeout(handle);
+    timers.current.clear();
+  }, []);
 
   const registerSurface = useCallback((surface: NotificationSurface) => {
     const counts = mountedSurfaces.current;
@@ -353,7 +469,7 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
       // it used to receive EVERY type, so a banner/alert/inline notification
       // presented as a toast (#3014). The other four are rendered by the
       // surface components subscribing through the context below.
-      if (surface === 'delegate') onToast?.(notification);
+      if (surface === 'delegate') onToast?.(notification, config);
 
       // A surface-rendered presentation with no surface mounted is invisible —
       // the "silently absent" shape this whole issue is about. Say so loudly in
@@ -370,16 +486,12 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
       // Auto-dismiss transient presentations. A banner/alert/inline stays until
       // it is dismissed unless the raiser asked for a duration explicitly —
       // sharing the toast timer made "persistent" presentations evaporate.
-      const duration = input.duration ?? (transient ? config.defaultDuration ?? 5000 : 0);
-      if (duration > 0) {
-        setTimeout(() => {
-          setNotifications((prev) => prev.filter((n) => n.id !== id));
-        }, duration);
-      }
+      const duration = input.duration ?? (transient ? config.defaultDuration : 0);
+      if (duration > 0) scheduleAutoDismiss(id, duration);
 
       return id;
     },
-    [config.defaultDuration, onToast],
+    [config, onToast, scheduleAutoDismiss],
   );
 
   const info = useCallback(
@@ -417,6 +529,10 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
   }, []);
 
   const dismiss = useCallback((id: string) => {
+    // Drop any pending auto-dismiss with it — a held (hovered) timer would
+    // otherwise sit in the map until unmount.
+    const timer = timers.current.get(id);
+    if (timer) { clearTimeout(timer.handle); timers.current.delete(id); }
     setNotifications((prev) => prev.filter((n) => n.id !== id));
   }, []);
 
@@ -443,6 +559,8 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
       dismiss,
       clearAll,
       config,
+      pauseAutoDismiss,
+      resumeAutoDismiss,
       registerSurface,
     }),
     [
@@ -458,6 +576,8 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({
       dismiss,
       clearAll,
       config,
+      pauseAutoDismiss,
+      resumeAutoDismiss,
       registerSurface,
     ],
   );
@@ -492,6 +612,45 @@ export function useNotifications(): NotificationContextValue {
  */
 export function useHasNotificationProvider(): boolean {
   return useContext(NotificationCtx) !== null;
+}
+
+/**
+ * Apply the config's stack rules to a surface's items: keep the newest
+ * `maxVisible`, then order them so the stack GROWS in `stackDirection`
+ * (`down`, the spec default, puts the newest below the older ones).
+ *
+ * Shared by the stacking surfaces (banner, inline) so `maxVisible` means one
+ * thing. It used to mean nothing at all — the config carried it and no surface
+ * read it, while `NotificationBanners` capped at a hard-coded 3 of its own.
+ *
+ * @param items the surface's notifications, newest-first
+ */
+export function visibleNotificationStack(
+  items: NotificationItem[],
+  config: Pick<ResolvedNotificationConfig, 'maxVisible' | 'stackDirection'>,
+): NotificationItem[] {
+  // Cap BEFORE ordering — an over-long stack drops its oldest, never its newest.
+  const capped = config.maxVisible > 0 ? items.slice(0, config.maxVisible) : items;
+  return config.stackDirection === 'up' ? capped : [...capped].reverse();
+}
+
+/**
+ * The screen position a FLOATING notification (toast, snackbar) should take:
+ * its own `position`, else the configured `defaultPosition`, else `undefined`.
+ *
+ * `undefined` is a meaningful answer, not a missing one — it means "nothing was
+ * declared", and the surface should keep its own anchor (a snackbar's bottom
+ * edge) or defer to the host's toast chrome, rather than being moved by a
+ * default nobody asked for. Always returns the spec (underscore) spelling.
+ */
+export function resolveNotificationPosition(
+  notification: Pick<NotificationItem, 'position'>,
+  config?: Pick<ResolvedNotificationConfig, 'defaultPosition'>,
+): NotificationPositionValue | undefined {
+  const declared = notification.position ?? config?.defaultPosition;
+  if (!declared) return undefined;
+  const underscored = declared.replace(/-/g, '_') as NotificationPositionValue;
+  return SUPPORTED_NOTIFICATION_POSITIONS.has(underscored) ? underscored : undefined;
 }
 
 /**

--- a/packages/react/src/context/__tests__/NotificationContext.test.tsx
+++ b/packages/react/src/context/__tests__/NotificationContext.test.tsx
@@ -7,10 +7,15 @@ import React from 'react';
 import {
   NOTIFICATION_PRESENTATIONS,
   NotificationProvider,
+  resolveNotificationConfig,
+  resolveNotificationPosition,
   resolveNotificationPresentation,
   useNotifications,
   useNotificationsByPresentation,
   useHasNotificationProvider,
+  visibleNotificationStack,
+  type NotificationItem,
+  type NotificationPositionValue,
   type NotificationPresentation,
 } from '../NotificationContext';
 
@@ -153,8 +158,11 @@ describe('NotificationProvider', () => {
     });
 
     expect(onToast).toHaveBeenCalledTimes(1);
+    // The resolved config rides along so the delegate can honor the parts of
+    // the contract only it can apply (`defaultPosition`).
     expect(onToast).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Toast test', severity: 'info' })
+      expect.objectContaining({ title: 'Toast test', severity: 'info' }),
+      expect.objectContaining({ defaultDuration: 5000, maxVisible: 5 }),
     );
   });
 });
@@ -201,7 +209,10 @@ describe('displayType routes to a distinct presentation', () => {
     });
 
     expect(onToast).toHaveBeenCalledTimes(1);
-    expect(onToast).toHaveBeenCalledWith(expect.objectContaining({ title: 'A toast' }));
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'A toast' }),
+      expect.anything(),
+    );
   });
 
   it('exposes each notification to exactly one presentation surface', () => {
@@ -349,6 +360,125 @@ describe('presentation table', () => {
     expect(resolveNotificationPresentation(undefined)).toBe('toast');
     expect(resolveNotificationPresentation('modal')).toBe('alert');
     expect(resolveNotificationPresentation('nonsense' as NotificationPresentation)).toBe('toast');
+  });
+});
+
+/**
+ * The config used to be inert: `maxVisible`, `stacking` and `position` were
+ * carried and never read, and its field names forked from the spec
+ * `NotificationConfigSchema`. Per-notification `position` did not exist at all,
+ * so the #3008 parity guard asserted a position VOCABULARY that nothing used.
+ */
+describe('notification config', () => {
+  it('applies the spec defaults', () => {
+    expect(resolveNotificationConfig()).toEqual({
+      defaultPosition: undefined,
+      defaultDuration: 5000,
+      maxVisible: 5,
+      stackDirection: 'down',
+      pauseOnHover: true,
+    });
+  });
+
+  it('leaves defaultPosition unset so "the host did not say" is representable', () => {
+    // A fabricated default here would silently compete with the host's own
+    // toast chrome, which also places non-notification `toast.*` calls.
+    expect(resolveNotificationConfig({}).defaultPosition).toBeUndefined();
+  });
+
+  it('folds the deprecated position spelling in', () => {
+    expect(resolveNotificationConfig({ position: 'bottom_left' }).defaultPosition)
+      .toBe('bottom_left');
+    expect(resolveNotificationConfig({ defaultPosition: 'top_left', position: 'bottom_left' }).defaultPosition)
+      .toBe('top_left');
+  });
+
+  it('reads the deprecated `stacking: false` as "show only the newest"', () => {
+    expect(resolveNotificationConfig({ stacking: false }).maxVisible).toBe(1);
+    expect(resolveNotificationConfig({ stacking: true, maxVisible: 3 }).maxVisible).toBe(3);
+  });
+});
+
+describe('resolveNotificationPosition', () => {
+  const config = resolveNotificationConfig({ defaultPosition: 'top_right' });
+
+  it('prefers the notification over the config default', () => {
+    expect(resolveNotificationPosition({ position: 'bottom_left' }, config)).toBe('bottom_left');
+  });
+
+  it('falls back to the configured default', () => {
+    expect(resolveNotificationPosition({}, config)).toBe('top_right');
+  });
+
+  it('returns undefined when nothing is declared — the surface keeps its anchor', () => {
+    expect(resolveNotificationPosition({}, resolveNotificationConfig())).toBeUndefined();
+    expect(resolveNotificationPosition({})).toBeUndefined();
+  });
+
+  it('normalizes the legacy hyphen spelling to the spec one', () => {
+    expect(resolveNotificationPosition({ position: 'bottom-center' })).toBe('bottom_center');
+  });
+
+  it('drops a value outside the spec vocabulary', () => {
+    expect(resolveNotificationPosition({ position: 'middle' as NotificationPositionValue }))
+      .toBeUndefined();
+  });
+});
+
+describe('visibleNotificationStack', () => {
+  const items = ['newest', 'middle', 'oldest'].map(
+    (title, i) => ({ id: `n${i}`, title, severity: 'info', createdAt: new Date(0) }) as NotificationItem,
+  );
+
+  it('keeps the NEWEST maxVisible, never the oldest', () => {
+    const kept = visibleNotificationStack(items, { maxVisible: 2, stackDirection: 'up' });
+    expect(kept.map((n) => n.title)).toEqual(['newest', 'middle']);
+  });
+
+  it('grows downward by default — newest below', () => {
+    const stack = visibleNotificationStack(items, { maxVisible: 5, stackDirection: 'down' });
+    expect(stack.map((n) => n.title)).toEqual(['oldest', 'middle', 'newest']);
+  });
+
+  it('grows upward when asked — newest on top', () => {
+    const stack = visibleNotificationStack(items, { maxVisible: 5, stackDirection: 'up' });
+    expect(stack.map((n) => n.title)).toEqual(['newest', 'middle', 'oldest']);
+  });
+});
+
+describe('pauseOnHover', () => {
+  it('holds a transient timer and resumes it with the time left', () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useNotifications(), { wrapper });
+      let id = '';
+      act(() => { id = result.current.notify({ title: 'Transient', severity: 'info' }); });
+
+      act(() => { vi.advanceTimersByTime(4000); });
+      act(() => { result.current.pauseAutoDismiss(id); });
+      // Held: the remaining 1s must not elapse while hovered.
+      act(() => { vi.advanceTimersByTime(60_000); });
+      expect(result.current.notifications).toHaveLength(1);
+
+      act(() => { result.current.resumeAutoDismiss(id); });
+      act(() => { vi.advanceTimersByTime(999); });
+      expect(result.current.notifications).toHaveLength(1);
+      act(() => { vi.advanceTimersByTime(2); });
+      expect(result.current.notifications).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('is a no-op for a persistent notification', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+    let id = '';
+    act(() => {
+      id = result.current.notify({ title: 'Banner', severity: 'info', displayType: 'banner' });
+    });
+    expect(() => { result.current.pauseAutoDismiss(id); result.current.resumeAutoDismiss(id); })
+      .not.toThrow();
+    expect(result.current.notifications).toHaveLength(1);
   });
 });
 

--- a/packages/react/src/hooks/__tests__/animation-notification-spec-parity.test.tsx
+++ b/packages/react/src/hooks/__tests__/animation-notification-spec-parity.test.tsx
@@ -27,6 +27,7 @@ import { renderHook } from '@testing-library/react';
 import {
   TransitionPresetSchema,
   EasingFunctionSchema,
+  NotificationActionSchema,
   NotificationTypeSchema,
   NotificationPositionSchema,
 } from '@objectstack/spec/ui';
@@ -37,6 +38,7 @@ import {
 } from '../useAnimation';
 import { resolveOverlayWidth } from '../useNavigationOverlay';
 import {
+  SUPPORTED_NOTIFICATION_ACTION_VARIANTS,
   SUPPORTED_NOTIFICATION_DISPLAY_TYPES,
   SUPPORTED_NOTIFICATION_POSITIONS,
 } from '../../context/NotificationContext';
@@ -73,6 +75,24 @@ describe('react hooks cover the spec animation/notification vocabularies', () =>
 
   it('notification positions match NotificationPositionSchema both ways', () => {
     assertParity(options(NotificationPositionSchema), SUPPORTED_NOTIFICATION_POSITIONS, 'notification position');
+  });
+
+  // `NotificationActionButton.variant` was the shadcn Button vocabulary
+  // (`default | destructive | outline`) under a spec-shaped name — a fork of
+  // `NotificationActionSchema.variant`, and the one notification vocabulary
+  // this guard did not cover.
+  it('notification action variants match NotificationActionSchema both ways', () => {
+    // `variant` carries `.default('primary')`, so the enum sits one wrapper
+    // down: reading `.options` off the field itself returns nothing, which
+    // would make this guard pass by finding no spec values at all (the empty
+    // assertion in assertParity is what catches that).
+    const field = (NotificationActionSchema as { shape?: Record<string, unknown> })
+      .shape?.variant as { def?: { innerType?: unknown } } | undefined;
+    assertParity(
+      options(field?.def?.innerType),
+      SUPPORTED_NOTIFICATION_ACTION_VARIANTS,
+      'notification action variant',
+    );
   });
 });
 


### PR DESCRIPTION
The last of the notification contract. After `displayType` (#3071) and `icon` (#3076), four gaps of the same family were left — values that validate, are carried, and change nothing.

## What was wrong

- **The config was 3/4 inert.** Only `defaultDuration` was ever read. `maxVisible` and `stacking` were carried and ignored, while `NotificationBanners` capped at a hard-coded `3` of its own.
- **Its field names forked from `NotificationConfigSchema`** — `position` vs `defaultPosition`, a renderer-local `stacking` boolean with no spec counterpart, and no `pauseOnHover` at all.
- **A notification could not declare a `position`.** The #3008 parity guard asserted the position *vocabulary* matched the spec while nothing positioned anything by it — a guard passing over an unused value.
- **`NotificationActionButton.variant` was the shadcn Button vocabulary** (`default | destructive | outline`) under a spec-shaped name, forking `NotificationActionSchema.variant` (`primary | secondary | link`).

## The decision this PR settles: who owns position

`notification.position ?? config.defaultPosition ?? nothing` — and **"nothing" is a real answer, not a missing one**:

- **declared** → the surface pins itself there, always. `presentNotificationToast` passes it **per-toast**, so the contract beats the container;
- **undeclared** → the surface keeps its own anchor (a snackbar's bottom edge), or defers to the host's toast chrome.

That asymmetry is the point. The sonner container also serves toasts that are **not** spec notifications — the console action runtime's own `toast.*` calls — so it stays the *fallback* authority for placement, never a competing one. A declared position that a component prop could silently override is the same "validates, then does nothing" shape this whole area is about.

Consequence: `defaultPosition` gets **no fabricated default**. "The host didn't say" has to be representable, otherwise an invented `top_right` silently fights the host's own chrome. This also means **no visible change in the console** — nothing declares a position there today, so toasts stay bottom-right and snackbars stay bottom-anchored.

## The rest

- `maxVisible` / `stackDirection` drive every stacking surface through one shared `visibleNotificationStack` — the cap keeps the **newest**, the stack grows in the declared direction (`down` = newest below, the spec default). `NotificationBanners`' invented `max` prop is gone.
- `pauseOnHover` holds a transient notification's timer and resumes it **with the time it had left** — which required the provider to track live timers rather than fire-and-forget `setTimeout`s. That is why the spec key had nothing to attach to before.
- Legacy spellings still resolve rather than being fossilized: `position` folds into `defaultPosition`, and `stacking: false` reads as `maxVisible: 1` ("show only the newest").
- `onToast` receives the resolved config as a second argument so the delegate can apply the parts of the contract only it can. Existing one-argument handlers are unaffected.
- The spec-parity guard gained the **action-variant** vocabulary — the one notification enum it did not cover. Note the access path: `variant` carries `.default('primary')`, so the enum sits one wrapper down (`shape.variant.def.innerType`); reading `.options` off the field returns nothing, which would have made the guard pass by finding no spec values at all. `assertParity`'s empty-check is what catches that.

## Verification

**In the running console, in one frame:** an undeclared toast stays where the sonner container puts it (bottom-right), a toast declaring `position: 'top_left'` moves there, and a snackbar declaring `position: 'top_right'` leaves its bottom anchor — "declared wins, undeclared defers", proven end to end. No console errors.

**Suites:** `packages/react` + `packages/components` + `packages/app-shell` — **2872 tests, 332 files, all green** (25 new). `tsc --noEmit` clean on all three; eslint 0 errors on every touched file.

Docs: the [notifications guide](content/docs/guide/notifications.md) gains `position`, `actions` and a full config table, plus the `@object-ui/react` README.

Refs #3014, #2942, #2944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
