### PR TITLE
chore(release): pending changesets stay minor — a major would desync from objectstack 17

### DIFF
--- a/.changeset/action-target-is-the-only-handler-slot.md
+++ b/.changeset/action-target-is-the-only-handler-slot.md
@@ -1,8 +1,8 @@
 ---
-'@object-ui/types': major
-'@object-ui/core': major
-'@object-ui/components': major
-'@object-ui/app-shell': major
+'@object-ui/types': minor
+'@object-ui/core': minor
+'@object-ui/components': minor
+'@object-ui/app-shell': minor
 ---
 
 **`target` is the only action handler slot — the `execute` alias is gone from the renderer (framework#3856).**

--- a/.changeset/action-url-identifies-by-name.md
+++ b/.changeset/action-url-identifies-by-name.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/app-shell': major
+'@object-ui/app-shell': minor
 ---
 
 **[ADR-0110 D1] The server-action URL identifies an action by `name`, not `target`.**

--- a/.changeset/action-vocabularies-derive-from-spec.md
+++ b/.changeset/action-vocabularies-derive-from-spec.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/types': major
+'@object-ui/types': minor
 ---
 
 **The action sub-vocabularies derive from `@objectstack/spec` instead of restating it (framework#4074).**

--- a/.changeset/authoring-types-are-input-types.md
+++ b/.changeset/authoring-types-are-input-types.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/types': major
+'@object-ui/types': minor
 '@object-ui/core': patch
 '@object-ui/components': patch
 ---

--- a/.changeset/modal-actions-are-client-only.md
+++ b/.changeset/modal-actions-are-client-only.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/app-shell': major
+'@object-ui/app-shell': minor
 ---
 
 **[objectstack#3959] A `type: 'modal'` action is client-side only — the server fallthrough is removed.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ export const SchemaRenderer = ({ schema }: { schema: UIComponent }) => {
 - **objectui 的 major 与 `@objectstack`(spec/client/formula)的 major 保持一致**:依赖到 `@objectstack ^11.x` 时,objectui 这个固定版本组(`.changeset/config.json` 的 `fixed`,39 个包一起发)的 major 必须是 `11`。心智模型:**major 相同即兼容**。
 - minor/patch **独立演进**——objectstack 没动时不必跟发;objectui 自己的改动照常用 changeset 推进(从当前 major 起步,如 `11.0.0 → 11.1.0`)。
 - objectstack 跨 major(→12)时,下一次 objectui 发版一并把 major 提到 `12`。
+- 推论:**changeset 里不要声明 `major`** —— fixed 组任一 `major` 都会把全组推上去、脱离 objectstack 的节奏(如 17.x 期间被推到 18)。objectui 自身的破坏性变更也标 `minor`(在正文里写清 breaking 语义即可);唯一例外是跟随 objectstack 跨 major 的那一次同步升级。
 - 这是约定优先于 semver 纯粹性的取舍(为可维护/好记),因此 objectui 的 major 不代表「它自身 API 的破坏性变更次数」。`@object-ui/site` 与 `@object-ui/example-*` 在 `ignore` 列表,不随组联动。
 
 ### 多 agent 协作纪律(并行修改本仓库,务必遵守)


### PR DESCRIPTION
## 问题

objectui 的版本跟随 objectstack 的节奏(AGENTS.md §9「版本号策略」):fixed 组(39 个包)当前在 **17.0.0**,因为 `@objectstack/*` 在 17.x。待发布的 changeset 里有 **5 个文件、8 处 `major` 声明** —— fixed 组下任何一个 major 都会把全组推到 **18.0.0**,而 objectstack 还停在 17,破坏「major 相同即兼容」的约定。

## 改动

- 8 处 `major` 全部降为 `minor`(各 changeset 正文中的 breaking 语义描述原样保留,只改 bump 级别):
  - `action-target-is-the-only-handler-slot.md`(types/core/components/app-shell)
  - `action-url-identifies-by-name.md`(app-shell)
  - `action-vocabularies-derive-from-spec.md`(types)
  - `authoring-types-are-input-types.md`(types)
  - `modal-actions-are-client-only.md`(app-shell)
- AGENTS.md §9 补一条显式推论:**changeset 里不要声明 `major`**;objectui 自身的破坏性变更也标 `minor`,唯一例外是跟随 objectstack 跨 major 的同步升级。(规则原本已在,但 5 个 changeset 仍写成了 major,说明需要点名禁止。)

## 验证

`pnpm changeset status`:**NO packages to be bumped at major** —— 下次发版为 17.1.0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)