### PR TITLE
fix(form): harden the spec↔runtime form-field chokepoint, derive SelectOption, complete FormFieldSchema (#3090 PR1)

### DIFF
--- a/.changeset/form-field-chokepoint-hardening.md
+++ b/.changeset/form-field-chokepoint-hardening.md
@@ -1,0 +1,34 @@
+---
+"@object-ui/types": patch
+"@object-ui/plugin-form": patch
+---
+
+fix(form): the spec↔runtime form-field chokepoint stops dropping spec 17 vocabulary, and the validator stops contradicting the renderer — #3090
+
+`normalizeSectionField` — the one translation point between the spec's authored
+form-field shape (`field` = object-field reference) and the runtime shape
+(`name` = data path) — silently dropped four spec keys, worst of all the
+ADR-0089 **canonical** `visibleWhen` spelling while the deprecated `visibleOn`
+worked. Now:
+
+- view-level `visibleWhen` routes into the view-level slot (`visibleOn`) so it
+  ANDs with the object-level rule instead of clobbering it, and the wizard's
+  final-submit gate folds the same slot into its verdict (before, a required
+  field the view itself hides could block submission from off-screen);
+- `dependsOn`, `keyField`, and `disclosure` carry through;
+- a behavioral parity gate walks the spec `FormFieldSchema` key set — a key the
+  spec adds fails as unmapped, a key it retires fails as stale.
+
+`SelectOptionSchema` is now derived from `@objectstack/spec/data` by reference
+(it used to strip `color` — which `@object-ui/fields` renders — plus `default`
+and the per-option `visibleWhen` gate), with pinned divergences (`value`
+widened for UI forms, `visibleWhen` on the #2212 wire contract) and documented
+UI-only extensions (`disabled`, `icon`). `SelectOption` (TS) gains `color` and
+`default`.
+
+`FormFieldSchema` (the runtime vocabulary `objectui validate` enforces) now
+covers every key the `FormField` interface declares — `widget`, `dependsOn`,
+`hidden`, `readonly`, `visibleOn`/`visibleWhen`/`readonlyWhen`/`requiredWhen`,
+`span` — and `type` is optional, matching the interface. A typo'd predicate now
+fails loudly instead of being stripped; spec-shape fields (`{ field: … }`) are
+still rejected, pinning the two-layer boundary.

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -17,7 +17,7 @@ import React, { useState, useCallback, useMemo } from 'react';
 import type { FormField, DataSource } from '@object-ui/types';
 import { Button, cn, toast } from '@object-ui/components';
 import { AlertCircle, Check, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
-import { resolveFieldRuleState } from '@object-ui/core';
+import { resolveFieldRuleState, evalFieldPredicate } from '@object-ui/core';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { FormSection } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
@@ -352,8 +352,16 @@ export const WizardForm: React.FC<WizardFormProps> = ({
             record,
             { required: !!field.required, readonly: (field as any).readonly === true },
           );
+          // View-level FormField.visibleOn hides the field the same way a
+          // field-level visibleWhen does — fold it into the verdict exactly
+          // like the form renderer (form.tsx) does, or the gate demands a
+          // field the view itself hides (#3090). Since #3090 this slot also
+          // receives the ADR-0089 canonical view-level `visibleWhen` spelling.
+          const viewVisible =
+            (field as any).visibleOn == null ||
+            evalFieldPredicate((field as any).visibleOn, record, true);
           // A hidden or read-only field is not the user's to fill in.
-          if (!state.visible || state.readonly || !state.required) continue;
+          if (!viewVisible || !state.visible || state.readonly || !state.required) continue;
           if (!isEmptyValue(record[name])) continue;
           out.set(index, [...(out.get(index) ?? []), (field as any).label || name]);
         }

--- a/packages/plugin-form/src/sectionFields.spec-parity.test.ts
+++ b/packages/plugin-form/src/sectionFields.spec-parity.test.ts
@@ -1,0 +1,138 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `normalizeSectionField` ↔ `@objectstack/spec` FormFieldSchema coverage gate
+ * (#3090, objectstack#4115).
+ *
+ * The normalizer is THE chokepoint between the two form-field vocabularies:
+ * the spec's authored shape (`field` = object-field reference, presentation
+ * deltas only) and the runtime shape (`name` = data path, self-contained
+ * widget config). It cannot be a derivation — every key is a *translation*
+ * with a destination of its own — so the gate is behavioral instead:
+ *
+ *   - TABLE below holds one row per spec key: a sample authored value and an
+ *     assertion that the normalized output reflects it at its documented
+ *     destination. Deleting a mapping line in `sectionFields.ts` fails the
+ *     row — the rows are mutation-tested coverage, not a mirror list.
+ *   - The key sets are then compared BOTH ways against the spec's own
+ *     enumeration: a key the spec adds fails as UNMAPPED (decide: map it or
+ *     exempt it with a reason); a key the spec retires fails as STALE.
+ *
+ * Until this gate existed the drift was real: the ADR-0089 canonical
+ * `visibleWhen` spelling, `dependsOn`, `keyField` and `disclosure` were all
+ * silently dropped while the DEPRECATED `visibleOn` spelling worked.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FormFieldSchema as SpecFormFieldSchema } from '@objectstack/spec/ui';
+import { mapFieldTypeToFormType } from '@object-ui/fields';
+import { normalizeSectionField } from './sectionFields';
+
+const objectSchema = {
+  name: 'crm_account',
+  fields: {
+    industry: {
+      type: 'select',
+      label: 'Industry',
+      options: [{ label: 'Tech', value: 'tech' }],
+    },
+  },
+};
+
+const ctx = {
+  objectSchema,
+  objectName: 'crm_account',
+  fieldLabel: (_obj: string, _name: string, fallback: string) => fallback || _name,
+};
+
+/** Normalize a spec field def against a schema that does NOT define `ghost`,
+ * so every override is observable verbatim (no object-metadata interference). */
+const norm = (def: Record<string, unknown>) =>
+  normalizeSectionField({ field: 'ghost', ...def }, ctx) as any;
+
+/**
+ * One row per spec FormFieldSchema key: sample authored value → where the
+ * runtime FormField must carry it. Non-obvious destinations are the point:
+ * `helpText`→`description`, `readonly`→`disabled`, and BOTH visibility
+ * spellings→the view-level `visibleOn` slot (the runtime `visibleWhen` slot
+ * belongs to the object-level rule and must not be clobbered).
+ */
+const TABLE: Record<string, (f: (def: Record<string, unknown>) => any) => void> = {
+  field: () => {
+    const out = normalizeSectionField({ field: 'industry' }, ctx) as any;
+    expect(out.name).toBe('industry'); // identity key translated to the data path
+    expect(out.type).toBe(mapFieldTypeToFormType('select')); // object schema merged in
+  },
+  type: (f) => expect(f({ type: 'text' }).type).toBe(mapFieldTypeToFormType('text')),
+  options: (f) =>
+    expect(f({ options: [{ label: 'A', value: 'a' }] }).options).toEqual([
+      { label: 'A', value: 'a' },
+    ]),
+  reference: (f) => {
+    const out = f({ reference: 'accounts' });
+    expect(out.reference).toBe('accounts');
+    expect(out.reference_to).toBe('accounts'); // both spellings stamped (#2407)
+  },
+  maxLength: (f) => expect(f({ maxLength: 10 }).maxLength).toBe(10),
+  minLength: (f) => expect(f({ minLength: 2 }).minLength).toBe(2),
+  min: (f) => expect(f({ min: 1 }).min).toBe(1),
+  max: (f) => expect(f({ max: 9 }).max).toBe(9),
+  precision: (f) => expect(f({ precision: 10 }).precision).toBe(10),
+  scale: (f) => expect(f({ scale: 2 }).scale).toBe(2),
+  multiple: (f) => expect(f({ multiple: true }).multiple).toBe(true),
+  label: (f) => expect(f({ label: 'Custom' }).label).toBe('Custom'),
+  placeholder: (f) => expect(f({ placeholder: 'Type…' }).placeholder).toBe('Type…'),
+  helpText: (f) => expect(f({ helpText: 'Hint' }).description).toBe('Hint'),
+  readonly: (f) => expect(f({ readonly: true }).disabled).toBe(true),
+  immutable: (f) => expect(f({ immutable: true }).immutable).toBe(true),
+  required: (f) => expect(f({ required: true }).required).toBe(true),
+  hidden: (f) => expect(f({ hidden: true }).hidden).toBe(true),
+  colSpan: (f) => expect(f({ colSpan: 2 }).colSpan).toBe(2),
+  span: (f) => expect(f({ span: 'full' }).span).toBe('full'),
+  widget: (f) => expect(f({ widget: 'rating' }).widget).toBe('rating'),
+  language: (f) => expect(f({ language: 'sql' }).language).toBe('sql'),
+  fields: (f) =>
+    expect(f({ fields: [{ field: 'inner' }] }).fields).toEqual([{ field: 'inner' }]),
+  keyField: (f) =>
+    expect(f({ keyField: { field: 'name' } }).keyField).toEqual({ field: 'name' }),
+  dependsOn: (f) => expect(f({ dependsOn: 'country' }).dependsOn).toBe('country'),
+  visibleWhen: (f) =>
+    expect(f({ visibleWhen: 'record.a == 1' }).visibleOn).toBe('record.a == 1'),
+  visibleOn: (f) =>
+    expect(f({ visibleOn: 'record.b == 2' }).visibleOn).toBe('record.b == 2'),
+  disclosure: (f) => expect(f({ disclosure: 'popover' }).disclosure).toBe('popover'),
+};
+
+/** Spec keys the normalizer deliberately does not carry, each with a reason.
+ * Empty today — add entries here (never silently) when the spec grows a key
+ * that genuinely has no runtime destination. */
+const EXEMPT: Record<string, string> = {};
+
+describe('normalizeSectionField covers the spec FormFieldSchema key set', () => {
+  // `.strict().transform()` wraps the object in a ZodPipe; `.in` is the
+  // strict object carrying the authoring shape.
+  const specKeys = Object.keys((SpecFormFieldSchema as any).in.shape).sort();
+
+  it('has a behavioral row (or an exemption with a reason) for every spec key', () => {
+    const covered = [...Object.keys(TABLE), ...Object.keys(EXEMPT)].sort();
+    expect(covered).toEqual(specKeys);
+  });
+
+  it('has no stale rows for keys the spec has retired', () => {
+    for (const key of [...Object.keys(TABLE), ...Object.keys(EXEMPT)]) {
+      expect(specKeys, `'${key}' is no longer a spec FormField key`).toContain(key);
+    }
+  });
+
+  for (const [key, assertRow] of Object.entries(TABLE)) {
+    it(`carries spec '${key}' to its runtime destination`, () => {
+      assertRow(norm);
+    });
+  }
+});

--- a/packages/plugin-form/src/sectionFields.test.ts
+++ b/packages/plugin-form/src/sectionFields.test.ts
@@ -106,6 +106,71 @@ describe('normalizeSectionField', () => {
     expect((f as any).visibleOn).toEqual(expr);
   });
 
+  // ── Spec 17 late-added / renamed keys (#3090) ─────────────────────────────
+  // ADR-0089 renamed the view-level predicate to `visibleWhen` — which is also
+  // the runtime slot for the OBJECT-level rule. The view predicate must land in
+  // the view-level slot (`visibleOn`) so the renderer ANDs both layers
+  // (form.tsx evaluates the two slots independently) instead of one clobbering
+  // the other. Before the fix the canonical spelling was silently dropped while
+  // the DEPRECATED spelling worked.
+
+  it('routes a view-level `visibleWhen` (canonical spelling) into the view-level slot', () => {
+    const f = normalizeSectionField(
+      { field: 'name', visibleWhen: "record.stage == 'won'" },
+      ctx,
+    ) as any;
+    expect(f.visibleOn).toBe("record.stage == 'won'");
+  });
+
+  it('carries a `{ dialect, source }` view-level visibleWhen expression', () => {
+    const expr = { dialect: 'cel', source: "record.priority == 'urgent'" };
+    const f = normalizeSectionField({ field: 'name', visibleWhen: expr }, ctx) as any;
+    expect(f.visibleOn).toEqual(expr);
+  });
+
+  it('layers the view predicate OVER the object-level rule instead of clobbering it', () => {
+    const rulesCtx = {
+      ...ctx,
+      objectSchema: {
+        ...objectSchema,
+        fields: {
+          ...objectSchema.fields,
+          paid_on: { type: 'date', label: 'Paid on', visibleWhen: "record.status == 'paid'" },
+        },
+      },
+    };
+    const f = normalizeSectionField(
+      { field: 'paid_on', visibleWhen: 'record.amount > 0' },
+      rulesCtx,
+    ) as any;
+    expect(f.visibleWhen).toBe("record.status == 'paid'"); // object-level rule intact
+    expect(f.visibleOn).toBe('record.amount > 0'); // view predicate in the view slot
+  });
+
+  it('prefers the canonical spelling when both visibleWhen and deprecated visibleOn are authored', () => {
+    // `saveMeta` persists verbatim, so served metadata can carry either (or,
+    // after a partial migration, both). Canonical wins.
+    const f = normalizeSectionField(
+      { field: 'name', visibleWhen: "record.a == 1", visibleOn: "record.b == 2" },
+      ctx,
+    ) as any;
+    expect(f.visibleOn).toBe("record.a == 1");
+  });
+
+  it('carries a view-level dependsOn (spec cascading declaration)', () => {
+    const f = normalizeSectionField({ field: 'industry', dependsOn: 'country' }, ctx) as any;
+    expect(f.dependsOn).toBe('country');
+  });
+
+  it('carries keyField and disclosure through for record/composite widgets', () => {
+    const f = normalizeSectionField(
+      { field: 'billing_address', keyField: { field: 'name', immutable: true }, disclosure: 'popover' },
+      ctx,
+    ) as any;
+    expect(f.keyField).toEqual({ field: 'name', immutable: true });
+    expect(f.disclosure).toBe('popover');
+  });
+
   it('copies field-level conditional rules from the object schema (#2212)', () => {
     const rulesSchema = {
       ...objectSchema,

--- a/packages/plugin-form/src/sectionFields.ts
+++ b/packages/plugin-form/src/sectionFields.ts
@@ -152,8 +152,25 @@ export function normalizeSectionField(
   if (fd.scale != null) base.scale = fd.scale;
   if (fd.language != null) base.language = fd.language;
   if (Array.isArray(fd.fields)) base.fields = fd.fields;
+  // View-level cascading declaration (spec FormField.dependsOn, a bare parent
+  // name). The form renderer gates + recomputes options off the runtime
+  // field's top-level `dependsOn`; without this copy the declaration vanished.
+  if (fd.dependsOn != null) base.dependsOn = fd.dependsOn;
+  // Record/composite widget config (ADR-0007). Pass-through: no widget reads
+  // them from the runtime field yet, but dropping them here would make that
+  // support impossible to ship metadata-first.
+  if (fd.keyField != null) base.keyField = fd.keyField;
+  if (fd.disclosure != null) base.disclosure = fd.disclosure;
 
-  return attachVisibility(base as FormField, fd.visibleOn);
+  // View-level visibility predicate. ADR-0089 renamed it to `visibleWhen` —
+  // which collides with the runtime slot holding the OBJECT-level rule (copied
+  // from the object schema in `fromObjectSchema`). Route the view predicate
+  // into the view-level slot (`visibleOn`) instead: the renderer evaluates the
+  // two slots independently and ANDs them, so layering is preserved and the
+  // object rule is never clobbered. Canonical spelling wins over the
+  // deprecated one when both are authored (`saveMeta` persists verbatim, so
+  // served metadata can carry either).
+  return attachVisibility(base as FormField, fd.visibleWhen ?? fd.visibleOn);
 }
 
 /** Normalize every field def in a section. */

--- a/packages/plugin-form/src/wizardSkipValidation.test.tsx
+++ b/packages/plugin-form/src/wizardSkipValidation.test.tsx
@@ -175,6 +175,36 @@ describe('WizardForm allowSkip — required fields on a skipped step (#2959)', (
     expect(stepIndicator(1)).not.toHaveAttribute('data-error');
   });
 
+  it('does not demand a required field the view itself hides (view-level visibleWhen false)', async () => {
+    // The section field def carries the SPEC vocabulary: `field` + a view-level
+    // `visibleWhen` (ADR-0089 canonical spelling). `normalizeSectionField`
+    // routes that predicate into the view-level slot (`visibleOn`, #3090) and
+    // the renderer hides the field — so the submit gate must fold the same
+    // slot into its verdict, or it demands a field the user cannot see.
+    const dataSource = renderWizard({
+      allowSkip: true,
+      sections: [
+        { name: 's1', label: 'Step 1', fields: ['subject'] },
+        {
+          name: 's2',
+          label: 'Step 2',
+          fields: [{ field: 'owner', visibleWhen: "record.subject == 'urgent'" }],
+        },
+        { name: 's3', label: 'Step 3', fields: ['notes'] },
+      ],
+    });
+
+    await waitFor(() => expect(document.body.querySelector('[data-field="subject"]')).toBeTruthy());
+    fill('subject', 'routine'); // predicate false → owner is view-hidden
+    fireEvent.click(stepIndicator(2));
+    await waitFor(() => expect(document.body.querySelector('[data-field="notes"]')).toBeTruthy());
+    fill('notes', 'S3');
+    fireEvent.click(screen.getByRole('button', { name: /Create/i }));
+
+    await waitFor(() => expect(dataSource.create).toHaveBeenCalledTimes(1));
+    expect(stepIndicator(1)).not.toHaveAttribute('data-error');
+  });
+
   it('still lets the sequential wizard submit (the gate is not a new blocker)', async () => {
     const dataSource = renderWizard();
 

--- a/packages/types/src/__tests__/form-field-zod-coverage.test.ts
+++ b/packages/types/src/__tests__/form-field-zod-coverage.test.ts
@@ -1,0 +1,102 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FormFieldSchema` (zod) ↔ `FormField` (TS) coverage gate (#3090).
+ *
+ * The zod schema is the ONLY runtime enforcement of the form-field contract —
+ * `@object-ui/cli`'s published `objectui validate` parses through it, while
+ * renderers read plain objects and never parse. Until #3090 it validated 13 of
+ * the interface's declared keys and required `type` (the interface says
+ * optional): metadata the renderer accepts failed validation, and a typo in
+ * `visibleWhen`/`widget`/`dependsOn` passed silently (strip mode).
+ *
+ * Why a PINNED LIST instead of a derivation: TS interface keys cannot be
+ * enumerated at runtime, and `FormField` carries an index signature, which
+ * defeats both directions of a compile-time assignability probe (the
+ * objectstack#4075 mechanism — see check-spec-symbol-derivation.mjs, lie #3).
+ * A set-coverage assertion is the #3017 fallback for exactly this case: the
+ * zod side stays deliberate and reviewed, and any schema edit must touch the
+ * list here in the same PR.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FormFieldSchema } from '../zod/form.zod.js';
+
+/** Every key `FormField` (../form.ts) declares by name, in declaration order. */
+const DECLARED_KEYS = [
+  'id',
+  'name',
+  'label',
+  'description',
+  'type',
+  'inputType',
+  'required',
+  'disabled',
+  'placeholder',
+  'options',
+  'validation',
+  'condition',
+  'widget',
+  'dependsOn',
+  'hidden',
+  'readonly',
+  'visibleOn',
+  'visibleWhen',
+  'readonlyWhen',
+  'requiredWhen',
+  'colSpan',
+  'span',
+];
+
+describe('FormFieldSchema covers the FormField contract', () => {
+  it('validates exactly the declared key set', () => {
+    expect(Object.keys(FormFieldSchema.shape).sort()).toEqual([...DECLARED_KEYS].sort());
+  });
+
+  it('requires only `name` — `type` is optional, matching the interface', () => {
+    expect(FormFieldSchema.safeParse({ name: 'email' }).success).toBe(true);
+  });
+
+  it('keeps the spec-aligned keys it used to strip', () => {
+    const parsed = FormFieldSchema.parse({
+      name: 'state',
+      widget: 'rating',
+      dependsOn: ['country', { field: 'region', param: 'region_id' }],
+      hidden: false,
+      readonly: true,
+      visibleOn: { dialect: 'cel', source: "record.priority == 'urgent'" },
+      visibleWhen: "record.status == 'sent'",
+      readonlyWhen: 'record.locked == true',
+      requiredWhen: "record.stage == 'won'",
+      span: 'full',
+    });
+    expect(parsed.widget).toBe('rating');
+    expect(parsed.dependsOn).toEqual(['country', { field: 'region', param: 'region_id' }]);
+    expect(parsed.visibleOn).toEqual({ dialect: 'cel', source: "record.priority == 'urgent'" });
+    expect(parsed.visibleWhen).toBe("record.status == 'sent'");
+    expect(parsed.readonlyWhen).toBe('record.locked == true');
+    expect(parsed.requiredWhen).toBe("record.stage == 'won'");
+    expect(parsed.span).toBe('full');
+    expect(parsed.readonly).toBe(true);
+  });
+
+  it('now REJECTS a malformed value for a declared key instead of stripping it', () => {
+    // Before #3090 `visibleWhen` was unknown to the schema, so `visibleWhen: 42`
+    // validated clean with the predicate thrown away.
+    expect(FormFieldSchema.safeParse({ name: 'x', visibleWhen: 42 }).success).toBe(false);
+  });
+
+  it('still rejects the SPEC form-field vocabulary — the layers stay distinct', () => {
+    // `{ field: 'email' }` is the authored (spec) shape; this schema is the
+    // runtime shape. The boundary between them is `normalizeSectionField` in
+    // @object-ui/plugin-form, not a dual-key read here. (#3090 PR2 upgrades
+    // the CLI's error MESSAGE for this case; the verdict must not change.)
+    expect(FormFieldSchema.safeParse({ field: 'email', required: true }).success).toBe(false);
+  });
+});

--- a/packages/types/src/__tests__/select-option-spec-parity.test.ts
+++ b/packages/types/src/__tests__/select-option-spec-parity.test.ts
@@ -1,0 +1,86 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * SelectOption ↔ `@objectstack/spec` drift guard (#3090, objectstack#4115).
+ *
+ * Unlike the FormField pair — two genuinely different concepts on two layers —
+ * a select option is ONE concept in two dialects, so the zod schema is now a
+ * spec derivation: spec keys flow in by reference, with two pinned divergences
+ * (`value` widened for UI-land, `visibleWhen` kept on objectui's #2212 wire
+ * contract) and two UI-only extensions (`disabled`, `icon`).
+ *
+ * What the old hand copy silently did, all fixed by the derivation and pinned
+ * here so it cannot regress:
+ *
+ *  - `color` — stripped, while `@object-ui/fields` renders it (badge/dot).
+ *  - `default` — stripped.
+ *  - `visibleWhen` — stripped, while the select widgets evaluate it for
+ *    per-option gating; a gated option survived `objectui validate` with its
+ *    gate removed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SelectOptionSchema as SpecSelectOptionSchema } from '@objectstack/spec/data';
+import { SelectOptionSchema } from '../zod/form.zod.js';
+
+const specKeys = Object.keys(SpecSelectOptionSchema.shape).sort();
+const localKeys = Object.keys(SelectOptionSchema.shape).sort();
+
+describe('SelectOptionSchema derives from the spec', () => {
+  it('carries every spec key', () => {
+    for (const key of specKeys) {
+      expect(localKeys, `spec key '${key}' missing locally`).toContain(key);
+    }
+  });
+
+  it('extends the spec by exactly the documented UI-only keys', () => {
+    const extensions = localKeys.filter((k) => !specKeys.includes(k));
+    // If the spec ever claims one of these names, this fails and the two
+    // meanings must be reconciled instead of silently shadowed.
+    expect(extensions).toEqual(['disabled', 'icon']);
+  });
+
+  it('keeps the spec keys the old hand copy stripped', () => {
+    const parsed = SelectOptionSchema.parse({
+      label: 'China',
+      value: 'cn',
+      color: 'red',
+      default: true,
+      visibleWhen: "'admin' in current_user.positions",
+    });
+    expect(parsed.color).toBe('red');
+    expect(parsed.default).toBe(true);
+    expect(parsed.visibleWhen).toBe("'admin' in current_user.positions");
+  });
+
+  it('accepts the { dialect, source } expression shape too (#2212)', () => {
+    const expr = { dialect: 'cel', source: 'record.country == "cn"' };
+    const parsed = SelectOptionSchema.parse({ label: 'X', value: 'x', visibleWhen: expr });
+    expect(parsed.visibleWhen).toEqual(expr);
+  });
+});
+
+describe('pinned divergences from the spec', () => {
+  it('widens `value` beyond the spec on purpose (UI forms bind numbers/booleans)', () => {
+    // Ours accepts…
+    expect(SelectOptionSchema.safeParse({ label: 'N', value: 42 }).success).toBe(true);
+    expect(SelectOptionSchema.safeParse({ label: 'B', value: true }).success).toBe(true);
+    // …what the spec (machine-identifier values) rejects. If the spec widens,
+    // this fails → drop the local `value` override.
+    expect(SpecSelectOptionSchema.safeParse({ label: 'N', value: 42 }).success).toBe(false);
+  });
+
+  it('keeps a bare-string visibleWhen verbatim (no envelope canonicalization)', () => {
+    // The spec's ExpressionInput pipe rewrites a string into an envelope at
+    // parse time; this schema's output shape must stay stable for existing
+    // consumers of `safeValidateSchema` output.
+    const parsed = SelectOptionSchema.parse({ label: 'X', value: 'x', visibleWhen: 'record.a == 1' });
+    expect(parsed.visibleWhen).toBe('record.a == 1');
+  });
+});

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -279,6 +279,17 @@ export interface SelectOption {
    */
   icon?: string;
   /**
+   * Color code for badges/charts. Aligns with @objectstack/spec
+   * SelectOption.color — `@object-ui/fields` already resolves it for the
+   * select badge/dot rendering; only this contract lagged (objectstack#4115).
+   */
+  color?: string;
+  /**
+   * Whether this is the default option. Aligns with @objectstack/spec
+   * SelectOption.default.
+   */
+  default?: boolean;
+  /**
    * Per-option visibility predicate (CEL). The option is offered only when this
    * evaluates TRUE against the live record + `current_user` (same engine/env as
    * field-level {@link FormFieldConfig.visibleWhen}). Omit = always available.

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -17,14 +17,43 @@
  */
 
 import { z } from 'zod';
+import { SelectOptionSchema as SpecSelectOptionSchema } from '@objectstack/spec/data';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 
 /**
- * Select Option Schema
+ * The wire shape of a CEL predicate (#2212): a bare string or the spec
+ * Expression object `{ dialect?, source }`. Deliberately NOT the spec's
+ * ExpressionInput pipe, which canonicalizes strings into an envelope at parse
+ * time and would change this module's output shape.
+ */
+const ExpressionWireSchema = z.union([
+  z.string(),
+  z.object({ dialect: z.string().optional(), source: z.string() }),
+]);
+
+/**
+ * Select Option Schema — derived from `@objectstack/spec/data`
+ * `SelectOptionSchema` (objectstack#4115), with two pinned divergences and two
+ * UI-only extensions. Drift guard: `__tests__/select-option-spec-parity.test.ts`.
+ *
+ * Spec keys flow in **by reference** via the spread: before this derivation the
+ * schema silently stripped `color` (which `@object-ui/fields` renders as
+ * badge/dot colors), `default`, and `visibleWhen` (which the select widgets
+ * evaluate for per-option gating) — a strip-mode schema fails silently, which
+ * is why the gap survived.
  */
 export const SelectOptionSchema = z.object({
-  label: z.string().describe('Option label'),
+  ...SpecSelectOptionSchema.shape,
+  // Deliberate divergence: the spec requires a lowercase machine identifier;
+  // standalone UI forms legitimately bind numeric/boolean values. The parity
+  // test pins both directions so a future spec widening gets noticed.
   value: z.union([z.string(), z.number(), z.boolean()]).describe('Option value'),
+  // Deliberate divergence: keep objectui's wire contract (#2212) instead of
+  // the spec's envelope-canonicalizing ExpressionInput pipe.
+  visibleWhen: ExpressionWireSchema.optional()
+    .describe('Per-option visibility predicate (CEL) — option offered only when TRUE'),
+  // objectui-only UI extensions (not in the spec; the parity test asserts the
+  // spec has not claimed these names).
   disabled: z.boolean().optional().describe('Whether option is disabled'),
   icon: z.string().optional().describe('Option icon'),
 });
@@ -369,22 +398,52 @@ export const CommandSchema = BaseSchema.extend({
 });
 
 /**
- * Form Field Schema
+ * Form Field Schema — the RUNTIME form-field vocabulary (`name` = data path,
+ * `type` = widget). This is deliberately NOT the spec's `FormFieldSchema`
+ * (`field` = object-field reference, presentation deltas only): the two are
+ * different layers, and `normalizeSectionField` in `@object-ui/plugin-form` is
+ * the translation chokepoint between them (#3090).
+ *
+ * Keys mirror the `FormField` interface in `../form.ts`. Until #3090 this
+ * schema validated only 13 of the interface's declared keys and *required*
+ * `type` (the interface says optional) — so `objectui validate` silently
+ * ignored typos in `visibleWhen`/`widget`/`dependsOn`/… (strip mode) and
+ * rejected metadata the renderer accepts. The pinned key list lives in
+ * `__tests__/form-field-zod-coverage.test.ts`.
  */
 export const FormFieldSchema = z.object({
   id: z.string().optional().describe('Field ID'),
-  name: z.string().describe('Field name'),
+  name: z.string().describe('Field name (form data path)'),
   label: z.string().optional().describe('Field label'),
   description: z.string().optional().describe('Field description'),
-  type: z.string().describe('Field type'),
+  type: z.string().optional().describe('Widget type (defaults per renderer when omitted)'),
   inputType: z.string().optional().describe('Input type'),
   required: z.boolean().optional().describe('Required flag'),
   disabled: z.boolean().optional().describe('Disabled flag'),
   placeholder: z.string().optional().describe('Placeholder text'),
   options: z.array(SelectOptionSchema).optional().describe('Options for select/radio'),
   validation: FieldConstraintsSchema.optional().describe('Validation rules'),
-  condition: FieldConditionSchema.optional().describe('Conditional display'),
-  colSpan: z.number().optional().describe('Column span in grid layout'),
+  condition: FieldConditionSchema.optional().describe('Conditional display (legacy)'),
+  widget: z.string().optional().describe('Custom widget/component name override'),
+  dependsOn: z.union([
+    z.string(),
+    z.array(z.union([
+      z.string(),
+      z.object({ field: z.string(), param: z.string().optional() }),
+    ])),
+  ]).nullish().describe('Parent field(s) for cascading/dependent fields'),
+  hidden: z.boolean().optional().describe('Whether the field is hidden'),
+  readonly: z.boolean().optional().describe('Whether the field is read-only'),
+  visibleOn: ExpressionWireSchema.optional()
+    .describe('View-level visibility predicate (CEL) — ANDed with visibleWhen'),
+  visibleWhen: ExpressionWireSchema.optional()
+    .describe('Field-level visibility rule (CEL) — field shown only when TRUE'),
+  readonlyWhen: ExpressionWireSchema.optional()
+    .describe('Field-level read-only rule (CEL)'),
+  requiredWhen: ExpressionWireSchema.optional()
+    .describe('Field-level required rule (CEL)'),
+  colSpan: z.number().optional().describe('Column span in grid layout (legacy — prefer span)'),
+  span: z.enum(['auto', 'full']).optional().describe('Relative field width'),
 });
 
 /**

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -77,6 +77,26 @@ const ALLOW = {
       "shape kept for backward compatibility and slated for removal in a future major.",
     issue: 4115,
   },
+  "@object-ui/types:SelectOptionSchema": {
+    reason:
+      "Spec-derived dialect (objectui#3090): spec keys flow in by reference via " +
+      "`SpecSelectOptionSchema.shape`, with two pinned divergences (`value` widened to " +
+      "string|number|boolean for standalone UI forms; `visibleWhen` kept on the #2212 wire " +
+      "contract instead of the spec's envelope-canonicalizing ExpressionInput pipe) and two " +
+      "UI-only extensions (`disabled`, `icon`). Drift guard: " +
+      "packages/types/src/__tests__/select-option-spec-parity.test.ts — it fails if the spec " +
+      "adds a key, retires one, claims an extension name, or widens `value` itself.",
+    issue: 4115,
+  },
+  "@object-ui/types:SelectOption": {
+    reason:
+      "TS twin of the SelectOptionSchema dialect (objectui#3090): carries every spec key " +
+      "(label/value/color/default/visibleWhen) plus the documented UI-only extensions " +
+      "(`disabled`, `icon`). Kept an interface because the spec type is sound but the " +
+      "objectui `value`/`visibleWhen` divergences are deliberate; the zod twin's parity " +
+      "test pins the key set.",
+    issue: 4115,
+  },
 };
 
 // ── Untriaged collisions (the ledger) ────────────────────────────────────────
@@ -164,8 +184,6 @@ const DEBT = {
     "QuerySchema",
     "ResponsiveConfig",
     "ScriptValidation",
-    "SelectOption",
-    "SelectOptionSchema",
     "StateMachineValidation",
     "Theme",
     "WidgetManifest",


### PR DESCRIPTION
#3090 的 **PR1(修缺陷,零破坏)**。三块,每块都带 mutation-tested 闸门。

## 1. 枢纽补缺:`normalizeSectionField` 丢了四个 spec 17 键

最恶劣的一个:ADR-0089 把视图级可见性谓词的**规范拼写**定为 `visibleWhen`,而枢纽只 attach 弃用的 `visibleOn` —— 用规范拼写写的表单视图丢谓词,用弃用拼写反而能用。修法:视图级 `visibleWhen` 路由进视图层槽位(`visibleOn`),与对象级规则(`fromObjectSchema` 拷入的 `visibleWhen` 槽)**AND 叠加**而非互相覆盖(渲染器本来就分别评估两个槽位);两个拼写同时出现时规范拼写赢(`saveMeta` 按原样持久化,线上的元数据两种都有)。

连带堵住一个新暴露面:WizardForm 的最终提交重查只评估 `visibleWhen` 槽 —— 视图级谓词生效后,一个**被视图隐藏的必填字段**会在屏幕外卡死提交。重查现在与 form.tsx 一样折叠 `visibleOn` 槽(回归测试:谓词为假时提交放行)。

另三个键:`dependsOn`(级联声明,渲染器读顶层)、`keyField`、`disclosure`(record/composite 控件配置,透传)。

**闸门**:`sectionFields.spec-parity.test.ts` 按 spec `FormFieldSchema.in.shape` 逐键行为断言(28 键各有一行,断言落点:`helpText`→`description`、`readonly`→`disabled`、双拼写→`visibleOn` 槽……),并双向比对键集 —— spec 加键红(unmapped)、退键红(stale)。已突变验证:删掉 `keyField` 映射行,对应行即红。

## 2. `SelectOptionSchema` 改为 spec 派生(台账 124 → 122)

旧手抄件静默剥掉 `color`(`@object-ui/fields` 实际渲染 badge/dot 颜色)、`default`、以及逐选项 `visibleWhen` 门控 —— 一个带权限门控的选项过了 `objectui validate`,门却被扒了。现在 spec 键按引用流入,两个钉住的有意分歧(`value` 放宽到 string|number|boolean;`visibleWhen` 保持 #2212 wire 契约,不用 spec 的 envelope 规范化管道,输出形状不变)+ 两个 UI 扩展(`disabled`/`icon`)。TS `SelectOption` 补 `color`/`default`。

台账:`SelectOption`/`SelectOptionSchema` 从 DEBT 移入 ALLOW(带理由与守卫指针)。parity 测试四向守卫:spec 加键、退键、认领扩展名、自行放宽 `value`,任一发生即红。

## 3. `FormFieldSchema`(runtime 词汇)补齐自家契约

CLI 唯一强制执行的表单字段契约此前只覆盖 TS 接口 13 个声明键、且要求接口里可选的 `type` 必填:渲染器接受的元数据过不了校验,而 `visibleWhen: 42` 这种错值被 strip 静默吞掉。补齐 `widget`/`dependsOn`/`hidden`/`readonly`/`visibleOn`/`visibleWhen`/`readonlyWhen`/`requiredWhen`/`span`,`type` 改可选。

**边界钉死**:`{ field: 'email' }`(spec 词汇)**仍然拒绝** —— 双层边界属于枢纽,不属于双键读(PR2 只改错误文案,不改判定)。set-coverage 断言钉住键集(TS 接口带 index signature,两个方向的可赋值性探针都会说谎 —— 见 checker 头注 lie #3 —— 故按 #3017 模板用 pinned list)。

## 验证

- 592 tests 过(types + plugin-form 全量),新增 43 个断言
- types/plugin-form/components/cli 四包 tsc 干净;改动文件 eslint 0 errors
- 全部治理脚本绿:spec-symbols(122)、type-check-coverage、lint-coverage、changeset-fixed

Closes 部分 #3090(PR1 复选框)。关联 objectstack#4115。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
