### PR TITLE
fix(form): spec-vocabulary fields stop crashing the standalone form; every surface names the boundary (#3090 PR2)

### DIFF
--- a/.changeset/form-vocabulary-boundary-loudening.md
+++ b/.changeset/form-vocabulary-boundary-loudening.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/components": patch
+"@object-ui/plugin-form": patch
+"@object-ui/cli": patch
+---
+
+fix(form): a spec-vocabulary field no longer crashes the standalone form, and every surface now says which vocabulary you meant — #3090
+
+Writing the regression test against the unfixed renderer proved the failure
+was worse than the assumed silent drop: a `{ field: 'x' }` entry (spec
+form-VIEW vocabulary) slipped past the `f?.name` guards into a
+react-hook-form Controller with `name === undefined` and crashed the whole
+standalone form on `name.split('.')`, with nothing naming the culprit entry.
+The renderer now partitions such entries out — the rest of the form renders —
+and surfaces them with an inline alert plus a console.error whose text is the
+fix instruction (rename to `name`, or use an object-bound form whose sections
+accept the spec shape).
+
+`objectui validate` grows the same boundary awareness: on failure, a
+`{ field: … }` entry in a standalone form gets a "likely cause" hint naming
+the real fix instead of the bare `invalid_union` — the previous message read
+as "bolt a `name` on", which converts spec metadata wrongly. On success,
+mixed-vocabulary entries (`name` + string `field`) get a warning: they
+validate, but the spec key is dead weight the renderer ignores.
+
+`normalizeSectionField` warns (once per site) when an authored section field
+mixes both identity keys — the spec branch derives the runtime name from
+`field`, so an authored `name` was silently overwritten.

--- a/packages/cli/src/__tests__/spec-vocabulary-hint.test.ts
+++ b/packages/cli/src/__tests__/spec-vocabulary-hint.test.ts
@@ -1,0 +1,74 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `findSpecVocabularyFormFields` (#3090) — the detector behind `objectui
+ * validate`'s directed hint. Its precision is the point: the same `field` key
+ * means three different things across the platform (spec string reference /
+ * runtime metadata object / absent), and flagging the wrong one would make
+ * the CLI teach agents the wrong lesson.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findSpecVocabularyFormFields } from '../utils/spec-vocabulary-hint.js';
+
+describe('findSpecVocabularyFormFields', () => {
+  it('finds a spec-shaped entry inside a nested standalone form, with its path', () => {
+    const schema = {
+      type: 'page',
+      children: [
+        { type: 'text', content: 'hi' },
+        {
+          type: 'form',
+          fields: [
+            { name: 'subject', type: 'input' },
+            { field: 'owner', required: true },
+          ],
+        },
+      ],
+    };
+    expect(findSpecVocabularyFormFields(schema)).toEqual([
+      { path: 'children[1].fields[1]', field: 'owner' },
+    ]);
+  });
+
+  it('reports a mixed-vocabulary entry with its runtime name', () => {
+    const schema = {
+      type: 'form',
+      fields: [{ name: 'subject', field: 'subject_line', type: 'input' }],
+    };
+    expect(findSpecVocabularyFormFields(schema)).toEqual([
+      { path: 'fields[0]', field: 'subject_line', mixedName: 'subject' },
+    ]);
+  });
+
+  it('does NOT flag section fields — the object-form path accepts the spec shape', () => {
+    const schema = {
+      type: 'object-form',
+      objectName: 'case',
+      sections: [{ name: 's1', fields: [{ field: 'owner', required: true }] }],
+    };
+    expect(findSpecVocabularyFormFields(schema)).toEqual([]);
+  });
+
+  it('does NOT flag the runtime metadata-object `field` slot (the pun)', () => {
+    const schema = {
+      type: 'form',
+      fields: [{ name: 'amount', type: 'input', field: { type: 'currency', scale: 2 } }],
+    };
+    expect(findSpecVocabularyFormFields(schema)).toEqual([]);
+  });
+
+  it('handles primitives, nulls and arrays without faulting', () => {
+    expect(findSpecVocabularyFormFields(null)).toEqual([]);
+    expect(findSpecVocabularyFormFields('form')).toEqual([]);
+    expect(findSpecVocabularyFormFields([{ type: 'form', fields: [{ field: 'x' }] }])).toEqual([
+      { path: '[0].fields[0]', field: 'x' },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -11,6 +11,7 @@ import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { load as loadYaml } from 'js-yaml';
 import { safeValidateSchema } from '@object-ui/types/zod';
+import { findSpecVocabularyFormFields } from '../utils/spec-vocabulary-hint.js';
 
 /**
  * Validate a schema file
@@ -76,7 +77,21 @@ export async function validate(schemaPath: string) {
       if (data.children && Array.isArray(data.children)) {
         console.log(chalk.gray('  Children:'), data.children.length);
       }
-      
+
+      // Mixed-vocabulary entries validate (the runtime `name` satisfies the
+      // schema) but the spec `field` key is dead weight: the renderer ignores
+      // it and strip-mode validation drops it. Valid ≠ clean — say so (#3090).
+      const mixed = findSpecVocabularyFormFields(schema).filter((f) => f.mixedName);
+      if (mixed.length > 0) {
+        console.log(chalk.yellow('\nWarnings:'));
+        for (const m of mixed) {
+          console.log(chalk.yellow(
+            `  ${m.path}: '${m.mixedName}' also carries { field: '${m.field}' } — mixed form-field ` +
+            `vocabularies. The renderer ignores \`field\` here; drop one of the two.`,
+          ));
+        }
+      }
+
       console.log('');
       process.exit(0);
     } else {
@@ -97,7 +112,28 @@ export async function validate(schemaPath: string) {
           console.error(chalk.gray(`   Code: ${issue.code}`));
         }
       });
-      
+
+      // "name: expected string, received undefined" on a `{ field: … }` entry
+      // reads as an instruction to bolt a `name` on — which converts the
+      // metadata WRONGLY (the spec shape stands for an object-schema merge
+      // that a bare rename throws away). When the input matches that
+      // signature, name the actual boundary and the real fixes (#3090).
+      const specShaped = findSpecVocabularyFormFields(schema).filter((f) => !f.mixedName);
+      if (specShaped.length > 0) {
+        console.error(chalk.bold('\nLikely cause — spec form-view vocabulary in a standalone form:'));
+        for (const s of specShaped) {
+          console.error(chalk.yellow(
+            `   ${s.path}: { field: '${s.field}' } is the spec form-VIEW shape (an object-field reference).`,
+          ));
+        }
+        console.error(chalk.yellow(
+          `   A standalone \`type: 'form'\` component uses { name: … } (the form data path).\n` +
+          `   Fix: author the field with \`name\` and its own type/label — or, to reference object fields\n` +
+          `   with the spec shape, use an object-bound form (\`type: 'object-form'\` with objectName +\n` +
+          `   sections), whose section fields are translated by the renderer.`,
+        ));
+      }
+
       console.error('');
       process.exit(1);
     }

--- a/packages/cli/src/utils/spec-vocabulary-hint.ts
+++ b/packages/cli/src/utils/spec-vocabulary-hint.ts
@@ -1,0 +1,72 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Spec-vocabulary detector for `objectui validate` (#3090).
+ *
+ * `{ field: 'x' }` inside a standalone `type: 'form'` component is the spec
+ * form-VIEW vocabulary (an object-field reference) — a different layer from
+ * the runtime vocabulary this CLI validates (`name` = form data path). The
+ * zod error for it ("name: expected string, received undefined") reads as an
+ * instruction to bolt a `name` on, which converts the metadata WRONGLY: an
+ * agent following it loses the object-schema merge the spec shape stands for.
+ * This detector lets the CLI say what actually happened and what the real fix
+ * is. The error message is the prompt the next agent executes — it has to
+ * point at the boundary, not at the symptom.
+ *
+ * Scope is deliberately exact: only `fields` arrays hanging DIRECTLY off a
+ * `type: 'form'` node. Section fields (`type: 'object-form'` → `sections[]`)
+ * legitimately accept the spec shape — `normalizeSectionField` translates
+ * them — and a runtime FormField's `field` key legitimately holds the
+ * resolved metadata OBJECT, so only a STRING `field` marks the spec shape.
+ */
+
+export interface SpecVocabularyFinding {
+  /** JSON-ish path to the entry, e.g. `children[0].fields[2]`. */
+  path: string;
+  /** The spec `field` value (the referenced object field). */
+  field: string;
+  /** Set when the entry ALSO carries a runtime `name` (mixed vocabularies). */
+  mixedName?: string;
+}
+
+export function findSpecVocabularyFormFields(
+  node: unknown,
+  path = '',
+): SpecVocabularyFinding[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((child, i) => findSpecVocabularyFormFields(child, `${path}[${i}]`));
+  }
+  if (node === null || typeof node !== 'object') return [];
+
+  const record = node as Record<string, unknown>;
+  const findings: SpecVocabularyFinding[] = [];
+
+  if (record.type === 'form' && Array.isArray(record.fields)) {
+    record.fields.forEach((f, i) => {
+      if (f && typeof f === 'object' && typeof (f as any).field === 'string') {
+        const name = (f as any).name;
+        findings.push({
+          path: `${path ? `${path}.` : ''}fields[${i}]`,
+          field: (f as any).field,
+          ...(typeof name === 'string' ? { mixedName: name } : {}),
+        });
+      }
+    });
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    // The entries themselves were just inspected; don't re-walk them as
+    // generic children or each finding would double-report.
+    if (record.type === 'form' && key === 'fields') continue;
+    findings.push(
+      ...findSpecVocabularyFormFields(value, path ? `${path}.${key}` : key),
+    );
+  }
+  return findings;
+}

--- a/packages/components/src/renderers/form/__tests__/form-spec-vocabulary.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-spec-vocabulary.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Spec-vocabulary boundary in the standalone form renderer (#3090).
+ *
+ * `{ field: 'x' }` is the spec form-VIEW vocabulary — an object-field
+ * reference the standalone renderer cannot resolve (no object schema). Writing
+ * the first test here against the unfixed renderer proved the pre-#3090
+ * behavior was even worse than the assumed silent drop: the entry slipped past
+ * the `f?.name` guards into a react-hook-form Controller with
+ * `name === undefined` and CRASHED the whole form on `name.split('.')`,
+ * with nothing naming the culprit entry. The renderer now partitions such
+ * entries out (the rest of the form renders) and surfaces them: an inline
+ * alert naming the fields, and a console.error whose text doubles as the fix
+ * instruction.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../../../renderers';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields }} />,
+  );
+}
+
+describe('form renderer — spec-vocabulary entries surface loudly (#3090)', () => {
+  it('renders an inline alert naming the unrenderable fields, and still renders the rest', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderForm([
+      { name: 'subject', label: 'Subject', type: 'input' },
+      { field: 'owner', required: true }, // spec form-view shape — unrenderable here
+    ]);
+
+    // The valid field still renders…
+    expect(document.body.querySelector('[data-field="subject"]')).toBeTruthy();
+    // …the spec-shaped one is called out instead of silently dropped.
+    const alert = screen.getByTestId('form-spec-vocabulary-error');
+    expect(alert.textContent).toContain('owner');
+    expect(alert.textContent).toContain('{ name:');
+
+    // The console message is the fix instruction an agent will follow.
+    const said = error.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(said).toContain("{ field: 'owner' }");
+    expect(said).toContain('Rename the key to `name`');
+  });
+
+  it('renders no alert and logs nothing for a well-formed standalone form', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderForm([{ name: 'subject', label: 'Subject', type: 'input' }]);
+
+    expect(screen.queryByTestId('form-spec-vocabulary-error')).toBeNull();
+    const noise = [...error.mock.calls, ...warn.mock.calls]
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('[object-ui]'));
+    expect(noise).toEqual([]);
+  });
+
+  it('warns (but renders by `name`) when an entry mixes both vocabularies', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderForm([{ name: 'subject', field: 'subject_line', label: 'Subject', type: 'input' }]);
+
+    // `name` wins — the field renders, no destructive alert…
+    expect(document.body.querySelector('[data-field="subject"]')).toBeTruthy();
+    expect(screen.queryByTestId('form-spec-vocabulary-error')).toBeNull();
+    // …but the ignored spec key is called out.
+    const said = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(said).toContain('mixes vocabularies');
+    expect(said).toContain("{ field: 'subject_line' }");
+  });
+
+  it('does NOT flag the runtime metadata-object `field` slot (the #3090 pun)', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Object-bound paths stash the resolved field-metadata OBJECT under
+    // `field` — same key, different layer. Only a STRING `field` marks the
+    // spec authored shape; the object slot must pass without noise.
+    renderForm([
+      { name: 'amount', type: 'input', field: { type: 'currency', scale: 2 } },
+    ]);
+
+    expect(document.body.querySelector('[data-field="amount"]')).toBeTruthy();
+    expect(screen.queryByTestId('form-spec-vocabulary-error')).toBeNull();
+    const noise = [...error.mock.calls, ...warn.mock.calls]
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('[object-ui]'));
+    expect(noise).toEqual([]);
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -345,7 +345,7 @@ ComponentRegistry.register('form',
     const { t } = useSafeFormTranslation();
     const {
       defaultValues = {},
-      fields = [],
+      fields: rawFields = [],
       submitLabel = 'Submit',
       cancelLabel = 'Cancel',
       showCancel = false,
@@ -360,6 +360,50 @@ ComponentRegistry.register('form',
       validationMode = 'onSubmit',
       disabled = false,
     } = schema;
+
+    // ── Spec-vocabulary boundary (#3090) ──────────────────────────────────
+    // `{ field: 'x' }` is the spec form-VIEW vocabulary — a reference to an
+    // object field, resolvable only where an object schema exists (the
+    // `normalizeSectionField` chokepoint in @object-ui/plugin-form). This
+    // standalone renderer's vocabulary is `{ name: 'x' }` (the form data
+    // path). Such an entry used to slip past the `f?.name` guards below and
+    // reach a react-hook-form Controller with `name === undefined`, crashing
+    // the WHOLE form on `name.split('.')` — with nothing saying which entry
+    // was to blame. Partition them out and surface them loudly instead.
+    const specVocabularyFields = React.useMemo(
+      () =>
+        (rawFields as any[]).filter(
+          (f) => f && typeof f.field === 'string' && typeof f.name !== 'string',
+        ),
+      [rawFields],
+    );
+    const fields = React.useMemo(
+      () =>
+        specVocabularyFields.length === 0
+          ? rawFields
+          : (rawFields as any[]).filter((f) => !specVocabularyFields.includes(f)),
+      [rawFields, specVocabularyFields],
+    );
+    React.useEffect(() => {
+      for (const f of specVocabularyFields) {
+        // This message doubles as the fix instruction — it is what an agent
+        // iterating on the metadata will read and follow.
+        console.error(
+          `[object-ui] form field { field: '${f.field}' } was NOT rendered: \`field\` is the spec form-view ` +
+            `vocabulary (a reference to an object field), and a standalone form has no object schema to resolve ` +
+            `it against. Rename the key to \`name\` (the form data path) — or use an object-bound form ` +
+            `(objectName + sections), whose section fields accept the spec shape.`,
+        );
+      }
+      for (const f of rawFields as any[]) {
+        if (f && typeof f.field === 'string' && typeof f.name === 'string') {
+          console.warn(
+            `[object-ui] form field '${f.name}' mixes vocabularies: it also carries { field: '${f.field}' } ` +
+              `(spec form-view key), which this standalone renderer ignores. Drop one of the two.`,
+          );
+        }
+      }
+    }, [rawFields, specVocabularyFields]);
 
     // Initialize react-hook-form. `shouldFocusError: false` because RHF's
     // native focus-on-error only works for fields whose registered ref is a
@@ -1305,6 +1349,19 @@ ComponentRegistry.register('form',
             <Alert variant="destructive" className="mb-4">
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>{submitError}</AlertDescription>
+            </Alert>
+          )}
+
+          {/* Spec-vocabulary entries cannot be rendered here (#3090) — say so
+              in the form instead of silently dropping the fields. */}
+          {specVocabularyFields.length > 0 && (
+            <Alert variant="destructive" className="mb-4" data-testid="form-spec-vocabulary-error">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {`Not rendered — spec form-view vocabulary ({ field: … }) in a standalone form: ` +
+                  specVocabularyFields.map((f: any) => f.field).join(', ') +
+                  '. Use { name: … }, or an object-bound form with sections.'}
+              </AlertDescription>
             </Alert>
           )}
 

--- a/packages/plugin-form/src/sectionFields.test.ts
+++ b/packages/plugin-form/src/sectionFields.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { normalizeSectionField, buildSectionFields } from './sectionFields';
 import { mapFieldTypeToFormType } from '@object-ui/fields';
 
@@ -160,6 +160,21 @@ describe('normalizeSectionField', () => {
   it('carries a view-level dependsOn (spec cascading declaration)', () => {
     const f = normalizeSectionField({ field: 'industry', dependsOn: 'country' }, ctx) as any;
     expect(f.dependsOn).toBe('country');
+  });
+
+  it('warns once when an entry mixes both vocabularies, and the spec key wins', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const f = normalizeSectionField({ field: 'industry', name: 'legacy_key' }, ctx);
+      expect(f.name).toBe('industry'); // spec branch derives the name from `field`
+      normalizeSectionField({ field: 'industry', name: 'legacy_key' }, ctx); // same site again
+      const said = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('mixed'));
+      expect(said).toHaveLength(1); // deduped — this runs inside render loops
+      expect(said[0]).toContain("{ field: 'industry' }");
+      expect(said[0]).toContain("name: 'legacy_key'");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('carries keyField and disclosure through for record/composite widgets', () => {

--- a/packages/plugin-form/src/sectionFields.ts
+++ b/packages/plugin-form/src/sectionFields.ts
@@ -69,6 +69,26 @@ function attachVisibility(formField: FormField, expr: any): FormField {
   return formField;
 }
 
+/**
+ * Mixed-vocabulary lint (#3090): an authored section field carrying BOTH the
+ * spec identity key (`field`, a string) and the runtime one (`name`) is
+ * ambiguous — the spec branch below derives the runtime name from `field`, so
+ * an authored `name` is silently overwritten. Say so once per site (this runs
+ * inside render loops, hence the dedupe).
+ */
+const warnedMixedVocabulary = new Set<string>();
+function warnOnMixedVocabulary(fd: Record<string, any>, objectName: string): void {
+  if (typeof fd.name !== 'string' || fd.name === fd.field) return;
+  const key = `${objectName}:${fd.field}:${fd.name}`;
+  if (warnedMixedVocabulary.has(key)) return;
+  warnedMixedVocabulary.add(key);
+  console.warn(
+    `[object-ui] section field { field: '${fd.field}' } also carries name: '${fd.name}' — mixed form-field ` +
+      `vocabularies. The spec key wins (the runtime name becomes '${fd.field}'); drop \`name\` from authored ` +
+      `form views.`,
+  );
+}
+
 /** Build a runtime FormField from object-schema metadata for `fieldName`. */
 function fromObjectSchema(fieldName: string, ctx: SectionFieldsContext): FormField {
   const field = ctx.objectSchema?.fields?.[fieldName];
@@ -121,6 +141,7 @@ export function normalizeSectionField(
   }
 
   // (2) spec FormFieldSchema object — merge object-schema base + spec overrides.
+  warnOnMixedVocabulary(fd, ctx.objectName);
   const fieldName = fd.field;
   const base = fromObjectSchema(fieldName, ctx) as any;
 


### PR DESCRIPTION
#3090 的 **PR2(边界响亮化)**。写复现测试时把预设推翻了一次:spec 形态条目在独立表单里**不是静默消失,是把整个表单弄崩** —— `{ field: 'owner' }` 溜过各处 `f?.name` 守卫、进到 react-hook-form Controller 时 `name === undefined`,`name.split('.')` TypeError 崩掉全表,且没有任何信息指向肇事条目。

## 1. 独立表单渲染器(components)

把 spec 形态条目从渲染列表**剔除**(其余字段照常渲染,不再全表崩),同时:

- 表单内联 destructive Alert 点名未渲染的字段(`data-testid="form-spec-vocabulary-error"`)
- `console.error` 的文案就是修复指令 —— 这是迭代元数据的 agent 实际会读并执行的东西:改 `name`,或用 object-bound form(sections 走枢纽翻译)
- 混合词汇(`name` + string `field`)→ `console.warn`,按 `name` 渲染
- **双关不误伤**(测试钉死):runtime 字段的 `field` 槽合法地装着解析后的元数据**对象**,只有 **string** `field` 且无 `name` 才标记违例

## 2. `objectui validate`(cli)

实测原始报错只有 `Invalid input / invalid_union`(union 坍缩)—— 或在非 union 上下文里是 `name: expected string`,读起来像「补个 name」,会把 spec 元数据**改坏**(裸改名丢掉对象 schema 合并语义)。现在:

- 失败分支:检测到 spec 形态 → 「Likely cause」定向提示,指出层边界与两条真修法
- 成功分支:混合词汇 → Warning(校验通过但 spec 键是死重,渲染器忽略、strip 丢弃)
- 检测器 `findSpecVocabularyFormFields` 是纯函数,精度即要点:只扫 `type: 'form'` 直挂的 `fields`;object-form 的 `sections[].fields[]` 合法接受 spec 形态,**不**报

已用真实 CLI dist 对两个 fixture 冒烟验证,两分支输出如设计。

## 3. `normalizeSectionField`(plugin-form)

分区路径的混合词汇 lint:spec 分支从 `field` 推导 runtime name,作者写的 `name` 被静默覆盖 —— 现在每站点一次 `console.warn` 说明谁赢了、该删哪个。

## 验证

- 718 tests 全过(components form 全套 + plugin-form + cli),新增 12 个断言
- components/plugin-form/cli 三包 tsc 干净;改动文件 eslint 0 errors
- 真实 CLI 冒烟两分支验证

Closes 部分 #3090(PR2 复选框)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
