### PR TITLE
fix(app-shell,i18n): drop the developer-voiced default form subtitle

### DIFF
--- a/.changeset/drop-default-form-subtitle.md
+++ b/.changeset/drop-default-form-subtitle.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/i18n": patch
+---
+
+fix(app-shell,i18n): record forms no longer render the developer-voiced default subtitle
+
+Every create/edit record form (both the console dialog in `AppContent` and the
+full-page `RecordFormPage`) hardcoded a platform default description under the
+title: "Add a new {{object}} to your database." / "Update details for
+{{object}}" (zh: 「向数据库添加新的{{object}}。」/「更新{{object}}的详情」).
+
+The copy is developer-tooling voice leaking into end-user business apps — a
+scheduling clerk filling in a 排班计划 has no business being told about "the
+database", and the phrasing came straight from admin-panel boilerplate. The
+line carried no information the form title didn't already have, and neither
+call site let a form view override it.
+
+The default subtitle is now gone: both call sites stop passing `description`,
+and the unused `form.createDescription` / `form.editDescription` keys are
+removed from all ten locale bundles (the `workspace.createDescription` key is
+unrelated and stays).

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -786,9 +786,6 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                 title: editingRecord
                   ? t('form.editTitle', { object: objectLabel(formObjectDef as any) })
                   : t('form.createTitle', { object: objectLabel(formObjectDef as any) }),
-                description: editingRecord
-                  ? t('form.editDescription', { object: objectLabel(formObjectDef as any) })
-                  : t('form.createDescription', { object: objectLabel(formObjectDef as any) }),
                 open: isDialogOpen,
                 onOpenChange: (open: boolean) => { if (!open) closeRecordForm(); },
                 layout: 'vertical',

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -337,16 +337,6 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
                 ...(formDef.buttons && { buttons: formDef.buttons }),
                 ...(formDef.defaults && { defaults: formDef.defaults }),
                 title: pageTitle,
-                description:
-                  mode === 'create'
-                    ? t('form.createDescription', {
-                        object: label,
-                        defaultValue: `Create a new ${label}.`,
-                      })
-                    : t('form.editDescription', {
-                        object: label,
-                        defaultValue: `Edit this ${label}.`,
-                      }),
                 layout: 'vertical',
                 fields,
                 // Master-detail by config: if the object's form view declares

--- a/packages/i18n/src/__tests__/i18n.test.ts
+++ b/packages/i18n/src/__tests__/i18n.test.ts
@@ -56,8 +56,6 @@ describe('@object-ui/i18n', () => {
       const i18n = createI18n({ defaultLanguage: 'en', detectBrowserLanguage: false });
       expect(i18n.t('form.createTitle', { object: 'Contact' })).toBe('Create Contact');
       expect(i18n.t('form.editTitle', { object: 'Contact' })).toBe('Edit Contact');
-      expect(i18n.t('form.createDescription', { object: 'Contact' })).toBe('Add a new Contact to your database.');
-      expect(i18n.t('form.editDescription', { object: 'Contact' })).toBe('Update details for Contact');
       expect(i18n.t('form.saveRecord')).toBe('Save');
     });
 
@@ -75,8 +73,6 @@ describe('@object-ui/i18n', () => {
       const i18n = createI18n({ defaultLanguage: 'zh', detectBrowserLanguage: false });
       expect(i18n.t('form.createTitle', { object: '联系人' })).toBe('新建联系人');
       expect(i18n.t('form.editTitle', { object: '联系人' })).toBe('编辑联系人');
-      expect(i18n.t('form.createDescription', { object: '联系人' })).toBe('向数据库添加新的联系人。');
-      expect(i18n.t('form.editDescription', { object: '联系人' })).toBe('更新联系人的详情');
       expect(i18n.t('form.saveRecord')).toBe('保存');
     });
 

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -127,8 +127,6 @@ const ar = {
     stepOf: "الخطوة {{current}} من {{total}}",
     createTitle: "إنشاء {{object}}",
     editTitle: "تعديل {{object}}",
-    createDescription: "إضافة {{object}} جديد إلى قاعدة البيانات.",
-    editDescription: "تحديث تفاصيل {{object}}",
     saveRecord: "حفظ السجل",
     create: "إنشاء",
     update: "تحديث",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -127,8 +127,6 @@ const de = {
     stepOf: "Schritt {{current}} von {{total}}",
     createTitle: "{{object}} erstellen",
     editTitle: "{{object}} bearbeiten",
-    createDescription: "Neues {{object}} zur Datenbank hinzufügen.",
-    editDescription: "Details für {{object}} aktualisieren",
     saveRecord: "Datensatz speichern",
     create: "Erstellen",
     update: "Aktualisieren",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -133,8 +133,6 @@ const en = {
     stepOf: 'Step {{current}} of {{total}}',
     createTitle: 'Create {{object}}',
     editTitle: 'Edit {{object}}',
-    createDescription: 'Add a new {{object}} to your database.',
-    editDescription: 'Update details for {{object}}',
     saveRecord: 'Save',
     create: 'Create',
     update: 'Update',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -127,8 +127,6 @@ const es = {
     stepOf: "Paso {{current}} de {{total}}",
     createTitle: "Crear {{object}}",
     editTitle: "Editar {{object}}",
-    createDescription: "Agregar un nuevo {{object}} a su base de datos.",
-    editDescription: "Actualizar detalles de {{object}}",
     saveRecord: "Guardar registro",
     create: "Crear",
     update: "Actualizar",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -127,8 +127,6 @@ const fr = {
     stepOf: "Étape {{current}} sur {{total}}",
     createTitle: "Créer {{object}}",
     editTitle: "Modifier {{object}}",
-    createDescription: "Ajouter un nouveau {{object}} à votre base de données.",
-    editDescription: "Mettre à jour les détails de {{object}}",
     saveRecord: "Enregistrer",
     create: "Créer",
     update: "Mettre à jour",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -127,8 +127,6 @@ const ja = {
     stepOf: "ステップ {{current}} / {{total}}",
     createTitle: "{{object}}を作成",
     editTitle: "{{object}}を編集",
-    createDescription: "新しい{{object}}をデータベースに追加します。",
-    editDescription: "{{object}}の詳細を更新",
     saveRecord: "レコードを保存",
     create: "作成",
     update: "更新",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -127,8 +127,6 @@ const ko = {
     stepOf: "{{total}}단계 중 {{current}}단계",
     createTitle: "{{object}} 생성",
     editTitle: "{{object}} 편집",
-    createDescription: "새 {{object}}을(를) 데이터베이스에 추가합니다.",
-    editDescription: "{{object}} 세부 정보 업데이트",
     saveRecord: "레코드 저장",
     create: "생성",
     update: "업데이트",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -127,8 +127,6 @@ const pt = {
     stepOf: "Etapa {{current}} de {{total}}",
     createTitle: "Criar {{object}}",
     editTitle: "Editar {{object}}",
-    createDescription: "Adicionar um novo {{object}} ao seu banco de dados.",
-    editDescription: "Atualizar detalhes de {{object}}",
     saveRecord: "Salvar registro",
     create: "Criar",
     update: "Atualizar",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -127,8 +127,6 @@ const ru = {
     stepOf: "Шаг {{current}} из {{total}}",
     createTitle: "Создать {{object}}",
     editTitle: "Редактировать {{object}}",
-    createDescription: "Добавить новый {{object}} в базу данных.",
-    editDescription: "Обновить данные {{object}}",
     saveRecord: "Сохранить запись",
     create: "Создать",
     update: "Обновить",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -132,8 +132,6 @@ const zh = {
     stepOf: '第{{current}}步，共{{total}}步',
     createTitle: '新建{{object}}',
     editTitle: '编辑{{object}}',
-    createDescription: '向数据库添加新的{{object}}。',
-    editDescription: '更新{{object}}的详情',
     saveRecord: '保存',
     create: '创建',
     update: '更新',


### PR DESCRIPTION
## Summary

Every create/edit record form — the console dialog in `AppContent` and the full-page `RecordFormPage` — hardcoded a platform default description under the title:

> Add a new {{object}} to your database. / Update details for {{object}}
> (zh: 「向数据库添加新的{{object}}。」/「更新{{object}}的详情」)

The copy is developer-tooling voice leaking into end-user business apps — a scheduling clerk filling in a form has no business being told about "the database". The line carried no information the form title didn't already have, and neither call site let a form view override it.

## Changes

- Both call sites stop passing `description` — record forms no longer render a default subtitle.
- The now-unused `form.createDescription` / `form.editDescription` keys are removed from all ten locale bundles (`workspace.createDescription` is unrelated and stays).
- The four i18n assertions pinning the old strings are removed.
- Patch changeset for `@object-ui/app-shell` + `@object-ui/i18n`.

## Testing

- Full worktree build: 43/43 tasks green.
- `npx vitest run packages/i18n packages/app-shell`: 264 files, 2221 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)