### PR TITLE
fix(app-shell): lookup-param helpText only renders when the param actually degraded to a raw-id input (#3094)

### DIFF
--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -184,6 +184,28 @@ describe('ActionParamDialog — shared field-widget rendering (ADR-0059)', () =>
     await waitFor(() => expect(resolve).toHaveBeenCalledWith({ x: 'v' }));
   });
 
+  it('a lookup param WITH a reference target renders the picker without the degraded-lookup helpText (#3094)', async () => {
+    openDialog([def({ name: 'manager', type: 'lookup', referenceTo: 'sys_user' })]);
+    // The real picker widget mounts (its trigger button, behind Suspense)…
+    expect(await screen.findByTestId('lookup-trigger-manager')).toBeTruthy();
+    // …and the "no reference object configured" warning must NOT appear.
+    expect(screen.queryByText('actionDialog.lookupHelpText')).toBeNull();
+  });
+
+  it('a lookup param WITHOUT a reference target degrades to text and shows the degraded-lookup helpText', async () => {
+    openDialog([def({ name: 'manager', type: 'lookup' })]);
+    const input = await screen.findByLabelText('Param One');
+    expect(input.getAttribute('type')).toBe('text');
+    expect(await screen.findByText('actionDialog.lookupHelpText')).toBeTruthy();
+  });
+
+  it('a degraded lookup param with a custom helpText shows that text instead of the built-in warning', async () => {
+    openDialog([def({ name: 'manager', type: 'lookup', helpText: 'Paste the user id from the admin list' })]);
+    await screen.findByLabelText('Param One');
+    expect(await screen.findByText('Paste the user id from the admin list')).toBeTruthy();
+    expect(screen.queryByText('actionDialog.lookupHelpText')).toBeNull();
+  });
+
   it('seeds defaultValue and returns it untouched on confirm', async () => {
     const resolve = openDialog([def({ name: 'note', type: 'text', defaultValue: 'seed' })]);
     const input = await screen.findByLabelText('Param One');

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -277,7 +277,7 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
               {param.helpText && (
                 <p className="text-xs text-muted-foreground">{param.helpText}</p>
               )}
-              {isLookupParam && !param.helpText && (
+              {isLookupParam && field.type === 'text' && !param.helpText && (
                 <p className="text-xs text-muted-foreground">
                   {t('actionDialog.lookupHelpText')}
                 </p>


### PR DESCRIPTION
Closes #3094

## 问题

Action 参数对话框(RecordDetailView 记录头动作)里,`lookup`/`reference` 类型参数**无条件**渲染 `actionDialog.lookupHelpText`("该参数未配置引用对象,无法使用记录选择器。请直接填写记录 ID…")——即使 `reference` 已正确配置、记录选择器完全可用。用户被误导去贴裸记录 ID,而不去用旁边正常工作的选择器。

## 根因

`ActionParamDialog.tsx` 中该警告的渲染条件只有 `isLookupParam && !param.helpText`,从不检查参数是否真的降级。警告文案描述的降级判定在 `paramToField()` 里(lookup 且无 `referenceTo` → 降为 text 输入),但不参与该条件;同文件上方 `lookupPlaceholder` 分支是有 `field.type === 'text'` 检查的,两个分支不对称。

## 修复

一行改动:给 helpText 分支补上 `field.type === 'text'`,与 placeholder 分支镜像——只有参数真降级成"贴 ID"文本框时才显示警告。

## 测试

`ActionParamDialog.test.tsx` 新增三个用例钉住三种状态:

- 带 `referenceTo` → 渲染真选择器(trigger 挂载)且**无**警告(本 issue 的回归用例);
- 无 `referenceTo` → 降级为 text 输入 + 显示警告;
- 自定义 `helpText` → 显示自定义文案,内置警告不出现。

该文件 31 用例全过;相邻 `ActionParamDialog.uploading` / `paramToField` / `resolveActionParams` 套件 28 用例全过;`turbo build --filter=@object-ui/app-shell` 通过。纯 bug 修复,按 AGENTS.md 无需 changeset。

🤖 Generated with [Claude Code](https://claude.com/claude-code)