### PR TITLE
docs(app-shell): the wait-key retirement lands in spec 17.0.0, not the "18" its tombstone claims (#3101)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
@@ -52,9 +52,17 @@ const SCRIPT_INVOKE_FUNCTION_ACTION_TYPE = spec.SCRIPT_INVOKE_FUNCTION_ACTION_TY
  * marks it with a `[REMOVED]` description), but it is NOT part of the
  * authorable contract — a form field writing one produces metadata the loader
  * rejects. Counting tombstones as contract keys would false-pass exactly that
- * drift (e.g. `waitEventConfig.timeoutMs` / `.onTimeout`, retired at spec 18
- * by framework#4198 — this filter is what makes the `wait` panel fire on that
- * bump until the form drops the two fields).
+ * drift (e.g. `waitEventConfig.timeoutMs` / `.onTimeout`, retired by
+ * framework#4198 — this filter is what makes the `wait` panel fire on the spec
+ * bump that carries their tombstones, until the form drops the two fields).
+ *
+ * That bump is a **17.0.0-rc refresh**, not the "spec 18" the tombstone text
+ * itself names: changesets computes a pre-release train off the last
+ * *published* major (`@objectstack/spec` latest is 16.1.0, `rc` is
+ * 17.0.0-rc.0), so the retirement's `major` resolves to **17.0.0** — and
+ * framework main carries the tombstones with `PROTOCOL_VERSION = '17.0.0'`.
+ * The trigger is the next rc this repo installs, not a major that the current
+ * release train cannot produce. Tracked in #3101.
  */
 function zodKeys(schema: unknown): string[] {
   const shape = (schema as { shape?: Record<string, unknown> }).shape;


### PR DESCRIPTION
#3101 记了一条待办:`wait` 表单还提供 `waitEventConfig.timeoutMs` / `.onTimeout`,而 framework#4198 已经给它们上了墓碑。待办本身成立 —— **触发时机写错了**。

## 没有 18 可等

`zodKeys` 的 TSDoc(以及 #3101 正文、以及 framework#4198 自己的 changeset 正文)都写着这两个键"retired at spec 18",于是 #3101 的处置写成「在把 `@objectstack/spec` 升到 18 的那个 PR 里一并处理」。当前的发布机器**产不出 18**:

| 事实 | 值 |
|:---|:---|
| npm dist-tags | `latest` = **16.1.0**,`rc` = 17.0.0-rc.0 —— 17.0.0 从未发布 |
| framework `.changeset/pre.json` | `mode: "pre"`, `tag: "rc"`,`@objectstack/spec` initialVersion = **16.1.0** |
| #4198 的 changeset | `'@objectstack/spec': major` |
| 算出来的下一版 | pre 模式从**上一个已发布**版本起算:16.1.0 + major = **17.0.0**(发成 `17.0.0-rc.1`) |
| framework main | 两个墓碑已在树上(`ab1633122`),同一棵树上 `PROTOCOL_VERSION = '17.0.0'`,且 `protocol-version.test.ts` 把它钉死在 package.json 的 major 上 |
| ADR-0059 §4 | 删除 → "bump to a new **major**";相对已发布的 16.1.0,那个 new major 就是 **17** |

"18" 是从**在研版本号** `17.0.0-rc.0` 往上数了一位得来的,而 changesets 是从 16.1.0 往上算的。framework main 上 9 处墓碑文案写 18、32 处写 17;那 9 处的共同点只是"在 rc.0 切出之后才落地",全都还在 17 这趟车上(objectstack#3909 "the 17.0.0 train" 仍开着)。已装的 rc.0 里 `spec 18` 出现 0 次,`spec 17` 出现 200 次。

## 这条注释为什么值得改

它是这个 ratchet 的**触发条件说明**。写成"等 18",这条待办就会等一个不会到来的事件,然后在下一次 rc 刷新时被动踩雷 —— 正是 #3101 想避免的那件事。改后的注释把推导过程也记下来,免得下一个人重新数错一遍。

仅注释;`zodKeys` 的过滤逻辑与三处断言一字未动。

## 不受影响的部分

`不要单独先删这两个字段` 仍然成立,只是理由要换:sibling-block 断言是**双向**的(`flow-node-config.spec-reconciliation.test.ts` L192-199),而**已装的 rc.0** 里 `waitEventConfig` 仍把两个键声明为活键,现在删会在反方向红(`declared by the spec block but absent from the designer form`)。轴是"已装 rc.0 vs 下一次 rc",不是"17 vs 18"。

## 验证

```
pnpm exec vitest run packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
→ 1 passed | 3 passed | 5 skipped
```

(5 skipped = script/subflow/decision 三个 feature-detect 面板,已装 spec 尚未导出它们的契约 —— 与改动前一致。)

## Related

- #3101 —— 待办本体;正文的触发条件已同步更正
- objectstack-ai/objectstack#4350 —— framework 侧同源的 10 处墓碑文案(含本 PR 引用的那两处)版本号更正
- objectstack-ai/objectstack#4198 —— 退役这两个键的 framework PR
- objectstack-ai/objectstack#4278 / #4325 —— 引入对账的两半

🤖 Generated with [Claude Code](https://claude.com/claude-code)
