### PR TITLE
chore(core): 弃用 `ObjectValidationEngine` —— 规则 enforcement 单实现在服务端 (#3110)

### DIFF
--- a/.changeset/deprecate-object-validation-engine.md
+++ b/.changeset/deprecate-object-validation-engine.md
@@ -1,0 +1,44 @@
+---
+"@object-ui/core": patch
+---
+
+chore(core): deprecate `ObjectValidationEngine` — rule enforcement stays single-implementation on the server (#3110)
+
+`ObjectValidationEngine` / `defaultObjectValidationEngine` / `validateRecord` are
+now `@deprecated`. **Nothing is removed and no behaviour changes** — existing
+callers keep working exactly as they did after #3103.
+
+**Why.** Object-level validation rules are *enforcement*, and enforcement is
+single-implementation on the server (`objectql`'s rule-validator). objectui
+already draws that line for the predicates it *does* evaluate client-side:
+`evaluator/fieldRules.ts` handles the presentation predicates (`visibleWhen` /
+`readonlyWhen` / `requiredWhen`) by delegating to the canonical
+`ExpressionEngine`, "rather than re-implementing a parallel evaluator"
+(ADR-0036). This engine was that parallel evaluator, on the enforcement side.
+
+#3103 converged its semantics onto the server rule-for-rule, with eight
+mutation-tested gates — and still left a known divergence: the server carries
+ADR-0113's legacy-violation exemption (reject only when the merged state violates
+*and* this write makes it worse), which this engine does not implement. Editing
+an unrelated field on a legacy row would be blocked here and accepted there. One
+careful pass still left a gap, which is the argument: mirroring cross-repo
+behaviour is structurally unreliable, not unreliable-this-time.
+
+**What to use instead.** Let the write fail and render the server's rejection —
+it is already structured (`field` / `code` / `message`, plus a label since
+objectstack#3957). For pre-submit feedback, the answer is a validate-only
+(dry-run) write on the server: identical UX, zero parity risk, and it covers the
+two rule kinds a client can never check — `unique` (needs the database) and
+`json_schema` (ajv lives server-side).
+
+**The decision is a mechanism, not a comment.** What #3103 removed was a doc
+comment claiming spec canonicity that had been false for fifteen majors;
+shipping its successor as another comment would repeat the mistake one level up.
+`validation-engine-stays-unwired.test.ts` scans `packages/*/src` and fails if a
+production module starts referencing the engine, naming the file and the issue to
+reverse first. Barrels still re-export it — publishing a deprecated API is not
+wiring — and host applications are free to keep importing it.
+
+The five spec-derived rule TYPES in `@object-ui/types` are unaffected: they are
+the anchor for objectstack#4115's ledger and are independent of whether objectui
+ships an engine.

--- a/packages/core/src/validation/__tests__/validation-engine-stays-unwired.test.ts
+++ b/packages/core/src/validation/__tests__/validation-engine-stays-unwired.test.ts
@@ -1,0 +1,200 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ObjectValidationEngine` stays unwired — the mechanism behind #3110.
+ *
+ * The decision was: validation rules are ENFORCEMENT, enforcement is
+ * single-implementation on the server, and objectui renders the server's
+ * rejection rather than predicting it. `evaluator/fieldRules.ts` draws the same
+ * line for the presentation predicates it DOES evaluate client-side — it
+ * delegates to the canonical `ExpressionEngine` "rather than re-implementing a
+ * parallel evaluator" (ADR-0036). This engine is that parallel evaluator.
+ *
+ * #3103 converged it onto the server rule-for-rule and still left a known
+ * divergence (ADR-0113's legacy-violation exemption), which is the whole
+ * argument: mirroring cross-repo behaviour is structurally unreliable.
+ *
+ * Why a test and not just the `@deprecated` tag: the thing this replaced was a
+ * doc comment claiming spec canonicity that had been false for fifteen majors
+ * (#3103). Shipping the successor decision as another comment would repeat the
+ * mistake one level up — a rule that is not a check is not a rule (#3017,
+ * objectstack#4115). So the ban is compiled here: wire the engine into a
+ * production module and this file names the file, the line, and the issue to
+ * reverse first.
+ *
+ * This is deliberately a REACHABILITY ban, not a mention ban. Nothing stops a
+ * host application from importing the deprecated engine — it is still exported,
+ * still functional. What is banned is objectui itself growing a client-side
+ * enforcement path again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve, relative } from 'node:path';
+
+/** `packages/` — three levels up from `packages/core/src/validation/__tests__`. */
+const PACKAGES_DIR = resolve(__dirname, '../../../..');
+
+/**
+ * The engine's own module, its barrels, and its tests. A barrel re-export is not
+ * a wiring: it publishes the deprecated API for host applications, which is
+ * exactly what "deprecated but not removed" means.
+ */
+const ALLOWED = [
+  'core/src/validation/validators/object-validation-engine.ts',
+  'core/src/validation/validators/index.ts',
+  'core/src/validation/index.ts',
+];
+
+/** The engine's module path, and the entry points a caller would name. */
+const ENGINE_REFERENCE =
+  /object-validation-engine|ObjectValidationEngine|defaultObjectValidationEngine/;
+
+/**
+ * Strip comments and string bodies before looking for a reference.
+ *
+ * Prose is not a wiring: `@object-ui/types` names the engine in a doc comment
+ * explaining which defaults it applies, and that must not read as a production
+ * import. Scanning the CODE (rather than the import statements alone) still
+ * catches the indirect route — `import * as core` followed by
+ * `core.ObjectValidationEngine` — which an import-list regex would miss.
+ *
+ * String bodies go too, so a URL or an error message quoting the name is prose
+ * as well. Template-literal substitutions are kept, since that is real code.
+ */
+function stripCommentsAndStrings(src: string): string {
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const two = src.slice(i, i + 2);
+    if (two === '//') {
+      while (i < src.length && src[i] !== '\n') i++;
+      continue;
+    }
+    if (two === '/*') {
+      i += 2;
+      while (i < src.length && src.slice(i, i + 2) !== '*/') i++;
+      i += 2;
+      continue;
+    }
+    const ch = src[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const quote = ch;
+      i++;
+      while (i < src.length) {
+        if (src[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        // Keep `${…}` substitutions — they are code, not prose.
+        if (quote === '`' && src.slice(i, i + 2) === '${') {
+          let depth = 1;
+          i += 2;
+          const start = i;
+          while (i < src.length && depth > 0) {
+            if (src[i] === '{') depth++;
+            else if (src[i] === '}') depth--;
+            if (depth > 0) i++;
+          }
+          out += src.slice(start, i);
+          i++;
+          continue;
+        }
+        if (src[i] === quote) break;
+        i++;
+      }
+      i++;
+      // A module specifier is a string, so preserve the ones that name the
+      // engine's module — an `import … from '…/object-validation-engine'` must
+      // still be caught.
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/** Module specifiers are strings, so they are checked separately. */
+const IMPORT_SPECIFIER = /(?:from|import|require)\s*\(?\s*['"]([^'"]+)['"]/g;
+
+function referencesEngine(src: string): boolean {
+  if (ENGINE_REFERENCE.test(stripCommentsAndStrings(src))) return true;
+  for (const [, specifier] of src.matchAll(IMPORT_SPECIFIER)) {
+    if (specifier.includes('object-validation-engine')) return true;
+  }
+  return false;
+}
+
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Tests are not a production path, and `dist` is build output.
+        if (['node_modules', 'dist', '__tests__'].includes(entry.name)) continue;
+        walk(full);
+        continue;
+      }
+      if (!/\.tsx?$/.test(entry.name) || /\.d\.ts$/.test(entry.name)) continue;
+      if (/\.(test|stories)\.tsx?$/.test(entry.name)) continue;
+      out.push(full);
+    }
+  };
+
+  for (const pkg of readdirSync(PACKAGES_DIR)) {
+    const src = join(PACKAGES_DIR, pkg, 'src');
+    try {
+      if (!statSync(src).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    walk(src);
+  }
+  return out;
+}
+
+describe('the deprecated ObjectValidationEngine stays out of production paths (#3110)', () => {
+  it('scans a plausible source tree — so a passing result means something', () => {
+    // Without this, a broken path silently scans zero files and the ban above
+    // reports success forever. That failure mode is the one objectstack#4115
+    // was filed about, so the guard guards itself.
+    const files = sourceFiles();
+    expect(files.length).toBeGreaterThan(500);
+    expect(
+      files.some((f) => f.endsWith('core/src/validation/validators/object-validation-engine.ts'))
+    ).toBe(true);
+  });
+
+  it('is referenced only by its own module and the barrels that publish it', () => {
+    const offenders = sourceFiles()
+      .filter((file) => referencesEngine(readFileSync(file, 'utf8')))
+      .map((file) => relative(PACKAGES_DIR, file))
+      .filter((rel) => !ALLOWED.includes(rel))
+      .sort();
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ''
+        : `A production module now references the deprecated ObjectValidationEngine:\n` +
+            offenders.map((o) => `  - packages/${o}`).join('\n') +
+            `\n\n` +
+            `#3110 decided objectui does NOT run object-level validation rules on the\n` +
+            `client: enforcement is single-implementation on the server, and mirroring\n` +
+            `it drifts (see ADR-0113's legacy-violation exemption, still divergent).\n\n` +
+            `For pre-submit feedback, use a validate-only (dry-run) write instead — it\n` +
+            `also covers \`unique\` and \`json_schema\`, which a client cannot check.\n\n` +
+            `If you are deliberately reversing the decision (e.g. offline writes),\n` +
+            `reverse it in #3110 first, land the spec conformance fixtures it names,\n` +
+            `then update ALLOWED here with the reason.`
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -2,9 +2,15 @@
  * @object-ui/core - Validation Module
  * 
  * Phase 3.5: Validation engine
+ *
  * Object-level validation. The rule vocabulary is owned by
  * `@objectstack/spec/data` and derived in `@object-ui/types`; canonicity is
  * carried by that derivation and its parity gate, not by this comment.
+ *
+ * The object-level rule ENGINE (`validators/`) is @deprecated (#3110) — the
+ * server is the single implementation of rule enforcement. Field/record SHAPE
+ * validation (`schema-validator.js`, `validation-engine.js`) is unaffected: it
+ * is client-side form validation, not a mirror of a server rule.
  */
 
 export * from './validation-engine.js';

--- a/packages/core/src/validation/validators/index.ts
+++ b/packages/core/src/validation/validators/index.ts
@@ -8,9 +8,15 @@
 
 /**
  * @object-ui/core - Validators
- * 
- * Validators for the spec-owned object-level rule vocabulary.
- * 
+ *
+ * Publishes the @deprecated `ObjectValidationEngine` (#3110). Object-level
+ * validation rules are enforcement, and enforcement is single-implementation on
+ * the server (`objectql`'s rule-validator); objectui renders the server's
+ * rejection rather than predicting it, and pre-submit feedback belongs in a
+ * validate-only (dry-run) write. This barrel keeps the API exported for host
+ * applications that already depend on it — re-exporting is not wiring, and
+ * `validation-engine-stays-unwired.test.ts` enforces that distinction.
+ *
  * @module validators
  * @packageDocumentation
  */

--- a/packages/core/src/validation/validators/object-validation-engine.ts
+++ b/packages/core/src/validation/validators/object-validation-engine.ts
@@ -7,16 +7,55 @@
  */
 
 /**
- * @object-ui/core - Object-Level Validation Engine
+ * @object-ui/core - Object-Level Validation Engine — **DEPRECATED** (#3110)
  *
- * A CLIENT-SIDE PRE-CHECK of the rules an object declares in
+ * A client-side pre-check of the rules an object declares in
  * `ObjectSchema.validations`. The authority is the server
  * (`objectql/src/validation/rule-validator.ts`), which evaluates the same rules
- * on the write path; this engine exists to surface a violation before the round
- * trip, never to invent one. That framing sets every semantic below — a
- * pre-check that disagrees with the server is worse than no pre-check, because
- * it either blocks writes the server would accept or greenlights ones it
- * rejects.
+ * on the write path.
+ *
+ * ## Why this is deprecated rather than finished
+ *
+ * Validation rules are ENFORCEMENT, and enforcement is single-implementation on
+ * the server by design. `evaluator/fieldRules.ts` draws that line explicitly:
+ * PRESENTATION predicates (`visibleWhen` / `readonlyWhen` / `requiredWhen`) are
+ * evaluated client-side by delegating to the canonical `ExpressionEngine`,
+ * "rather than re-implementing a parallel evaluator" (ADR-0036). This module is
+ * that parallel evaluator, on the enforcement side of the line.
+ *
+ * #3103 converged its semantics onto the server rule-for-rule, with eight
+ * mutation-tested gates — and it STILL left a known divergence: the server
+ * carries ADR-0113's legacy-violation exemption (reject only when the merged
+ * state violates AND this write makes it worse, so a pre-existing violation on
+ * an old row passes), and this engine does not. Editing an unrelated field on a
+ * legacy row would be blocked here and accepted there. That is the argument in
+ * one line: mirroring cross-repo behaviour is structurally unreliable, not
+ * unreliable-this-time.
+ *
+ * ## What to use instead
+ *
+ * Let the write fail and render the server's rejection — it is already
+ * structured (`field` / `code` / `message`, plus a label since objectstack#3957).
+ * If pre-submit feedback is wanted, the answer is a **validate-only (dry-run)
+ * write** on the server: identical UX, zero parity risk, and it also covers the
+ * two rule kinds a client can never check — `unique` (needs the database) and
+ * `json_schema` (ajv lives server-side).
+ *
+ * Nothing here has been removed or changed in behaviour; existing callers keep
+ * working. `validation-engine-stays-unwired.test.ts` fails if a production
+ * module starts importing this one, so the decision is a mechanism rather than
+ * this comment (#3017).
+ *
+ * ## When to revisit
+ *
+ * Offline writes (`OfflineConfig`). With no server to ask, a client evaluator
+ * stops being redundant and becomes necessary. The precondition then is
+ * conformance fixtures shipped by `@objectstack/spec` — golden
+ * (rule, record, verdict) triples both repos run in CI — because that is the
+ * only thing that turns cross-repo parity into a mechanism instead of a habit.
+ * Reverse the decision in #3110 before reversing it here.
+ *
+ * ## Semantics (unchanged, for as long as this exists)
  *
  * The rule types come from `@object-ui/types`, which derives them from
  * `@objectstack/spec/data` (objectstack#4115). Semantics mirrored from the
@@ -340,6 +379,13 @@ class SimpleExpressionEvaluator implements ValidationExpressionEvaluator {
 /**
  * Object-Level Validation Engine — the client pre-check described at the top of
  * this module.
+ *
+ * @deprecated (#3110) Validation rules are enforcement, and enforcement is
+ * single-implementation on the server (`objectql`'s rule-validator). Render the
+ * server's rejection instead; for pre-submit feedback, use a validate-only
+ * (dry-run) write. Still functional and still correct as of #3103 — but it
+ * cannot stay in step with the server without a conformance-fixture mechanism
+ * that does not exist yet. See the module header.
  */
 export class ObjectValidationEngine {
   private expressionEvaluator: ValidationExpressionEvaluator;
@@ -872,11 +918,15 @@ function matchesNamedFormat(format: FormatValidation['format'], str: string): bo
 
 /**
  * Default instance
+ *
+ * @deprecated (#3110) See `ObjectValidationEngine`.
  */
 export const defaultObjectValidationEngine = new ObjectValidationEngine();
 
 /**
  * Convenience function to validate a record
+ *
+ * @deprecated (#3110) See `ObjectValidationEngine`.
  */
 export async function validateRecord(
   rules: ObjectValidationRule[],


### PR DESCRIPTION
执行 #3110 的拍板结论(**选 B**,理由见 [该 issue 的决策评论](https://github.com/objectstack-ai/objectui/issues/3110#issuecomment-5141313532))。

**零行为变更,零删除。** 现有调用方原样工作,barrel 照常再导出——发布一个 deprecated API 不是接线。

## 拍板一句话

**规则是 enforcement,enforcement 单实现在服务端。** 要「提交前反馈」就加 validate-only(dry-run),而不是养第二个求值器。

仓里这条线本来就画好了:[`evaluator/fieldRules.ts`](https://github.com/objectstack-ai/objectui/blob/main/packages/core/src/evaluator/fieldRules.ts) 的头注释明写,客户端 CEL 委托给 canonical 的 `ExpressionEngine`,*"rather than re-implementing a parallel evaluator"*(ADR-0036)。**presentation** 谓词(`visibleWhen`/`readonlyWhen`/`requiredWhen`)客户端评估——判错了最坏是多显示一个字段;**enforcement** 谓词单实现在服务端——判错了是数据或可用性事故。`ObjectValidationEngine` 正是那句注释说的 parallel evaluator,而且在边界的 enforcement 一侧。

## 决定性证据

#3103 是一轮**认真的**收敛:逐条对着服务端 `rule-validator.ts` 源码改,配 8 个 mutation-test 闸门。**它仍然留了一处分歧**——服务端带 ADR-0113 的 legacy-violation 豁免(仅当合并后状态违规**且本次写入使其恶化**时才拒,存量违规行原样放行),引擎没有。用户在一条老数据上改个无关字段,预检报红、服务端本来会接受。

一轮认真收敛尚且留尾巴 ⇒ 跨仓镜像 parity 是**结构性**不可靠,不是这一轮执行力的问题。

## 替代路径

渲染服务端拒绝即可——它已经是结构化的(`field`/`code`/`message`,objectstack#3957 起带 label)。要提交前反馈走 **objectstack#4372**(写路径 validate-only):同样的 UX、零 parity 风险,并且覆盖客户端**永远做不到**的两类——`unique`(要查库;客户端 SELECT-then-check 本身就是 TOCTOU 竞态,正是 spec 移除它的理由)和 `json_schema`(ajv 在服务端)。

## 决策做成机制,不是注释

这是本 PR 的重点。#3103 删掉的是一条**冒领 spec canonicity、错了十五个大版本**的文档注释;把它的继任决策再写成一条注释,就是在上一层重犯同一个错(#3017:comments are not mechanisms)。

新增 `validation-engine-stays-unwired.test.ts`,扫 `packages/*/src`,生产模块一旦引用引擎就红,失败文案点名文件 + 指向要先翻的 issue。三个设计取舍:

- **可达性禁令,不是提及禁令**。先剥掉注释与字符串体再匹配——`@object-ui/types` 的文档注释里正当地提到了引擎名,那不是接线。剥字符串同时意味着报错文案里引用该名字也不算。
- **扫代码而非扫 import 列表**,所以 `import * as core` + `core.ObjectValidationEngine` 的间接路径也会被抓到(纯 import 正则会漏)。
- **闸门自体检**:断言扫到 >500 个文件且命中引擎自身。扫描路径写坏 ⇒ 扫到 0 个文件 ⇒ 永远报绿,那正是 objectstack#4115 的失败模式,所以闸门要守住自己。

**闸门 mutation-test(3/3 红)**:

| 变异 | 结果 |
|---|---|
| T1 生产模块直接 import 引擎 | 🔴 失败文案点名 `fieldRules.ts` |
| T2 经 namespace 间接触达(`core.ObjectValidationEngine`) | 🔴 同上 |
| T3 扫描路径写坏(扫到 0 文件) | 🔴 自体检先红 |

## 未动的东西

- **五个 spec 派生类型**(`@object-ui/types`):它们是 objectstack#4115 台账的锚,与引擎存废无关。
- **字段/记录 shape 校验**(`schema-validator.ts` / `validation-engine.ts`):那是客户端表单校验,不是服务端规则的镜像,不在本决策范围。已在 `validation/index.ts` 头注释里点明,免得下一个 agent 误伤。

## 重启条件(tripwire 写在代码里)

**offline 写入进路线图之日**(`types` 里已有 `OfflineConfig`)。离线时没有服务端可问,客户端求值器从「冗余」变成「必需」。届时前置条件必须是 **spec 携带 conformance fixtures**——golden 的「规则 + 记录 + 判定」三元组,两仓 CI 各跑同一套;那是唯一能把跨仓行为 parity 从约定变成机制的办法。要翻案先翻 #3110。

## 验证

```
vitest  packages/core/src/validation   →  4 files / 62 tests 全绿
tsc     packages/core --noEmit         →  绿
eslint  packages/core/src/validation --quiet  →  0 error
mutation 3/3 红(见上表)
```

关联:#3110(拍板)、#3103 / #3107(语义收敛与留下的 ADR-0113 分歧)、objectstack#4372(dry-run)、objectstack#4115(台账)。
