### PR TITLE
fix(console,app-shell): readable reassign hand-off + "System" label for svc:* audit actors

### DIFF
--- a/.changeset/approvals-reassign-and-system-actor-display.md
+++ b/.changeset/approvals-reassign-and-system-actor-display.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/console": patch
+"@object-ui/app-shell": patch
+"@object-ui/i18n": patch
+---
+
+fix(console,app-shell): readable reassign hand-off + "System" label for svc:* audit actors — objectstack#4365 / objectstack#4366
+
+- **Approvals inbox** (`ApprovalsInboxPage`): a reassign timeline entry now
+  renders "from A to B" from the structured
+  `reassign_from`/`reassign_to` fields (and their server-resolved
+  `*_name` companions) that objectstack#4365 added to
+  `sys_approval_action`, instead of relying on the old default comment that
+  baked two raw user ids into user-facing text. Legacy rows without the
+  structured fields keep the comment fallback. New i18n key
+  `approvalsInbox.reassignFromTo` across all ten locales.
+- **Record history** (`RecordDetailView`): an audit row attributed to a
+  service principal (`svc:*` on the `actor` column — e.g. a
+  `runAs:'system'` flow's `svc:flow:<name>` label from objectstack#4366) now
+  renders the localized "System" label instead of the raw principal string;
+  the raw value stays on the entry for tooling.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -1904,6 +1904,25 @@ export function ApprovalsInboxPage() {
                               {formatRelative(a.created_at)}
                             </span>
                           </div>
+                          {/* Structured reassign hand-off (framework#4365): render
+                              "from A to B" from the resolved parties. Legacy rows
+                              predate the fields and only carry the old default
+                              comment — those keep the comment fallback below. */}
+                          {(() => {
+                            const ax = a as typeof a & {
+                              reassign_from?: string; reassign_to?: string;
+                              reassign_from_name?: string; reassign_to_name?: string;
+                            };
+                            if (a.action !== 'reassign' || (!ax.reassign_from && !ax.reassign_to)) return null;
+                            return (
+                              <div className="text-muted-foreground mt-0.5">
+                                {tr('reassignFromTo', 'from {{from}} to {{to}}', {
+                                  from: ax.reassign_from_name ?? formatIdentity(ax.reassign_from),
+                                  to: ax.reassign_to_name ?? formatIdentity(ax.reassign_to),
+                                })}
+                              </div>
+                            );
+                          })()}
                           {a.comment && (
                             <div className="text-muted-foreground italic mt-0.5">"{a.comment}"</div>
                           )}

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1225,12 +1225,18 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         const enriched = items.map((it, idx) => {
           const u = it?.user_id ? userMap.get(it.user_id) : undefined;
           // Attribution fallback chain: resolved user name → service/automation
-          // principal from the `actor` column (e.g. "svc:scheduler") → null
+          // principal from the `actor` column (e.g. "svc:flow:<name>") → null
           // (the timeline then shows its localized unknown-user text).
-          const actorLabel =
+          // A `svc:*` principal is a machine, not a person — render the
+          // localized "System" label rather than the raw principal string
+          // (framework#4366); the raw value stays available on the entry.
+          const rawActor =
             typeof it?.actor === 'string' && it.actor.trim() && it.actor !== it?.user_id
               ? it.actor.trim()
               : null;
+          const actorLabel = rawActor?.startsWith('svc:')
+            ? t('detail.systemActor', { defaultValue: 'System' })
+            : rawActor;
           const changes = rawChangesPerItem[idx].map((c) => ({
             field: c.field,
             label: fieldLabels[c.field] || c.field,

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -2757,6 +2757,7 @@ const ar = {
     slaRemaining: 'SLA المتبقي {{dur}}',
     slaOverdue: 'SLA متأخر {{dur}}',
     actReassign: 'إعادة إسناد',
+    reassignFromTo: 'من {{from}} إلى {{to}}',
     actRemind: 'تذكير',
     actRequestInfo: 'طلب معلومات',
     actComment: 'تعليق',

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -2757,6 +2757,7 @@ const de = {
     slaRemaining: 'SLA noch {{dur}}',
     slaOverdue: 'SLA überfällig {{dur}}',
     actReassign: 'Übergeben',
+    reassignFromTo: 'von {{from}} an {{to}}',
     actRemind: 'Erinnert',
     actRequestInfo: 'Rückfrage gestellt',
     actComment: 'Kommentiert',

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -2861,6 +2861,7 @@ const en = {
     slaRemaining: 'SLA {{dur}} left',
     slaOverdue: 'SLA overdue {{dur}}',
     actReassign: 'Reassigned',
+    reassignFromTo: 'from {{from}} to {{to}}',
     actRemind: 'Reminder sent',
     actRequestInfo: 'Requested more info',
     actComment: 'Commented',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -2757,6 +2757,7 @@ const es = {
     slaRemaining: 'SLA: quedan {{dur}}',
     slaOverdue: 'SLA vencido {{dur}}',
     actReassign: 'Reasignada',
+    reassignFromTo: 'de {{from}} a {{to}}',
     actRemind: 'Recordatorio',
     actRequestInfo: 'Pidió más información',
     actComment: 'Comentó',

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -2757,6 +2757,7 @@ const fr = {
     slaRemaining: 'SLA : {{dur}} restants',
     slaOverdue: 'SLA dépassé de {{dur}}',
     actReassign: 'Réattribuée',
+    reassignFromTo: 'de {{from}} à {{to}}',
     actRemind: 'Relance',
     actRequestInfo: 'Infos demandées',
     actComment: 'Commentaire',

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -2757,6 +2757,7 @@ const ja = {
     slaRemaining: 'SLA 残り {{dur}}',
     slaOverdue: 'SLA 超過 {{dur}}',
     actReassign: '引き継ぎ',
+    reassignFromTo: '{{from}} から {{to}} へ',
     actRemind: 'リマインド',
     actRequestInfo: '追加情報を要求',
     actComment: 'コメント',

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -2757,6 +2757,7 @@ const ko = {
     slaRemaining: 'SLA {{dur}} 남음',
     slaOverdue: 'SLA {{dur}} 초과',
     actReassign: '재할당',
+    reassignFromTo: '{{from}} 님에서 {{to}} 님으로',
     actRemind: '독촉',
     actRequestInfo: '보완 요청',
     actComment: '댓글',

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -2757,6 +2757,7 @@ const pt = {
     slaRemaining: 'SLA: faltam {{dur}}',
     slaOverdue: 'SLA vencido há {{dur}}',
     actReassign: 'Reatribuída',
+    reassignFromTo: 'de {{from}} para {{to}}',
     actRemind: 'Lembrete',
     actRequestInfo: 'Pediu mais informações',
     actComment: 'Comentou',

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -2757,6 +2757,7 @@ const ru = {
     slaRemaining: 'SLA: осталось {{dur}}',
     slaOverdue: 'SLA просрочен на {{dur}}',
     actReassign: 'Передано',
+    reassignFromTo: 'от {{from}} к {{to}}',
     actRemind: 'Напоминание',
     actRequestInfo: 'Запрошены данные',
     actComment: 'Комментарий',

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -2845,6 +2845,7 @@ const zh = {
     slaRemaining: 'SLA 剩余 {{dur}}',
     slaOverdue: 'SLA 已超期 {{dur}}',
     actReassign: '转签',
+    reassignFromTo: '从 {{from}} 转给 {{to}}',
     actRemind: '催办',
     actRequestInfo: '要求补充材料',
     actComment: '评论',


### PR DESCRIPTION
配套 objectstack-ai/objectstack#4365 / objectstack-ai/objectstack#4366(framework 侧修复见 objectstack-ai/objectstack#4403)。

- **审批中心**(`ApprovalsInboxPage`):转签时间线条目改从结构化 `reassign_from`/`reassign_to`(及服务端解析的 `*_name`)渲染「从 A 转给 B」,不再依赖把两个裸 user id 拼进用户可见文本的旧默认 comment;存量老行(无结构化字段)保留 comment 兜底。新 i18n 键 `approvalsInbox.reassignFromTo`,十个语言包齐。
- **记录历史**(`RecordDetailView`):`actor` 列为 `svc:*` 服务主体的审计行(如 `runAs:'system'` 流的 `svc:flow:<name>`)渲染本地化「系统」标签而非裸主体串;原始值仍保留在 entry 上。

验证:app-shell 124/124、console 124/124 全绿;配 framework 分支起 showcase 真机验过两处渲染(转签条目「从 Dev Admin 转给 Mei Phone (demo)」、历史页签「系统 UPDATE」)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)