### PR TITLE
feat(core): 混合键响亮化 — 说清谁赢了 (#3104 PR3,收官)

### DIFF
--- a/.changeset/column-identity-say-who-wins.md
+++ b/.changeset/column-identity-say-who-wins.md
@@ -1,0 +1,56 @@
+---
+"@object-ui/core": patch
+---
+
+feat(core): say which column identity key won, out loud (#3104 PR3)
+
+Closes the battle opened in #3104. PR1 (#3119) put the canonicalizing fold at
+ingestion; PR2 (#3122) converged all 22 read sites onto `columnIdentity()`.
+This is the audible half.
+
+A column carrying two identity keys that **disagree** — `{ field: 'account',
+name: 'account_name' }` — now logs a one-time dev-mode warning naming which key
+won and what to change:
+
+```
+[ObjectUI] Column carries two identities: `field: 'account'` and
+`name: 'account_name'`. `field` wins — it is the only key `ListColumnSchema`
+declares — and `name` has been rewritten to match, so the rendered column and
+the requested field agree. Fix the producer: drop `name` and author `field`
+only. (objectui#3104)
+```
+
+The fold making the two halves agree is what stops the bug, but silently
+rewriting `name` to match `field` also hides that the producer is emitting a
+contradiction. The renderer recovering is not the same as the metadata being
+right, so the recovery says so.
+
+Deliberately narrow:
+
+- **Only contradictions.** A legacy-only column (`{ name: 'stage' }`) is legacy,
+  not conflicting — it is stamped without noise.
+- **Warn once per (identity, conflicting spelling).** Columns are re-normalized
+  on every render; a warning that floods the console is a warning that gets
+  muted. Keyed by the pair rather than the identity alone, so a column carrying
+  two different stale spellings reports both — the author needs to fix every
+  producer, not just the first one seen.
+- **Silent under `NODE_ENV=production`**, and the fold still runs there.
+
+`resetColumnIdentityWarnings()` is exported for tests.
+
+**No lint rule, and that is a measured decision.** #3104 asked for
+`no-restricted-syntax` on `.field ?? .name` to be evaluated on its
+false-positive rate first. With the family at zero, all 12 remaining scanner
+hits are legitimate — a syntactic rule cannot tell a two-layer join from a dual
+read, because the distinction is what the keys mean in that layer, not how the
+expression is spelled. Adopting it would mean 12 inline disables on correct
+code, which trains the next author to reach for the disable. The ratchet carries
+a `verdict` and a `why` per site instead, so a new hit gets triaged rather than
+silenced. The evaluation is written into the ratchet's header.
+
+**Ledger item resolved with no change needed.** #3104 flagged `ListColumn` for
+disposition under objectstack#4115 (spec-named symbols must be imports, not
+declarations). `ListColumnSchema` is already a by-reference re-export of
+`@objectstack/spec/ui`, and `spec-subschema-parity.test.ts` already pins it by
+reference identity — the only check that distinguishes a re-export from a
+faithful fork. Already compliant; nothing to do.

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -321,7 +321,17 @@ working, and both resolve the canonical key first:
   node, for instance) still resolves the same field the request asked for.
 
 Legacy keys are still accepted, but they are a migration bridge, not a second
-contract: fix the producer.
+contract: fix the producer. A column that carries two identity keys that
+*disagree* logs a one-time dev-mode warning naming which key won and what to
+change — the renderer recovering is not the same as the metadata being right:
+
+```
+[ObjectUI] Column carries two identities: `field: 'account'` and
+`name: 'account_name'`. `field` wins — it is the only key `ListColumnSchema`
+declares — and `name` has been rewritten to match, so the rendered column and
+the requested field agree. Fix the producer: drop `name` and author `field`
+only. (objectui#3104)
+```
 
 If you read column identity in your own code, use the one reader rather than
 spelling out a fallback chain — it resolves canonical-first, so it agrees with

--- a/packages/core/src/utils/__tests__/column-identity.ratchet.test.ts
+++ b/packages/core/src/utils/__tests__/column-identity.ratchet.test.ts
@@ -30,6 +30,24 @@
  * accesses. That is precise enough to ratchet and loose enough to catch
  * spellings nobody has written yet; it is NOT a judgement that every hit is a
  * defect, which is what `verdict` below records.
+ *
+ * ## Why this is the gate, and no `no-restricted-syntax` lint rule
+ *
+ * objectui#3104 PR3 asked for the eslint option to be evaluated on its
+ * false-positive rate before adopting it. It was, and the answer is decisive:
+ * with the family at zero, **all 12 remaining scanner hits are legitimate** —
+ * two-layer joins where both precedences are correct, the form cluster #3090
+ * settled the other way, and display fallbacks that merely share the key names.
+ * A syntactic rule matching `.field ?? .name` cannot tell any of those from a
+ * real dual read, because the distinction is what the keys MEAN in that layer,
+ * not how the expression is spelled. Adopting it would mean 12 inline disables
+ * on correct code — which trains the next author to reach for the disable, the
+ * precise reflex that lets a real one through.
+ *
+ * The ratchet does what the lint rule cannot: it carries a `verdict` and a
+ * `why` per site, so a new hit has to be triaged rather than silenced. The
+ * assertion that the family is 0 (below) is exactly the statement that every
+ * hit a lint rule would fire on today is a false positive.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/core/src/utils/__tests__/column-identity.test.ts
+++ b/packages/core/src/utils/__tests__/column-identity.test.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   CANONICAL_COLUMN_IDENTITY_KEY,
   LEGACY_COLUMN_IDENTITY_KEYS,
@@ -15,6 +15,7 @@ import {
   hasConflictingColumnIdentity,
   normalizeColumnIdentity,
   normalizeColumnIdentities,
+  resetColumnIdentityWarnings,
 } from '../column-identity';
 import { normalizeListViewSchema } from '../normalize-list-view';
 import { buildExpandFields } from '../expand-fields';
@@ -212,5 +213,86 @@ describe('normalizeListViewSchema — column identity fold (#3104)', () => {
   it('leaves string columns alone', () => {
     const schema = { viewType: 'grid', columns: ['name', 'stage'] };
     expect(normalizeListViewSchema(schema)).toBe(schema);
+  });
+});
+
+describe('conflicting-identity warning (#3104 PR3)', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetColumnIdentityWarnings();
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => warn.mockRestore());
+
+  it('names the winner, the loser, and both values', () => {
+    normalizeColumnIdentity({ field: 'account', name: 'account_name' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = String(warn.mock.calls[0]?.[0]);
+    // The whole point is that the author can act on it without reading source.
+    expect(msg).toContain("field: 'account'");
+    expect(msg).toContain("name: 'account_name'");
+    expect(msg).toContain('`field` wins');
+    expect(msg).toContain('objectui#3104');
+  });
+
+  it('warns once per conflict, not once per fold', () => {
+    const entry = { field: 'account', name: 'account_name' };
+    normalizeColumnIdentity(entry);
+    normalizeColumnIdentity(entry);
+    normalizeColumnIdentity({ ...entry });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports each distinct conflicting spelling, not just the first', () => {
+    normalizeColumnIdentity({ field: 'account', name: 'a_name', fieldName: 'a_fname' });
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('stays silent for a legacy-only column — that is not a contradiction', () => {
+    normalizeColumnIdentity({ name: 'stage' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the keys already agree', () => {
+    normalizeColumnIdentity({ field: 'stage', name: 'stage' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for a clean spec column', () => {
+    normalizeColumnIdentity({ field: 'stage' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('fires through the ingestion fold, which is where hosts actually hit it', () => {
+    normalizeListViewSchema({
+      viewType: 'grid',
+      columns: [{ field: 'account', name: 'account_name' }],
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('is silent in production — a shipped app gets no console noise', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      normalizeColumnIdentity({ field: 'account', name: 'account_name' });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
+  it('still folds the column when the warning is suppressed', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      expect(normalizeColumnIdentity({ field: 'account', name: 'account_name' })).toEqual({
+        field: 'account',
+        name: 'account',
+      });
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
   });
 });

--- a/packages/core/src/utils/column-identity.ts
+++ b/packages/core/src/utils/column-identity.ts
@@ -95,6 +95,58 @@ export function hasConflictingColumnIdentity(entry: unknown): boolean {
   return false;
 }
 
+// Warn once per (identity, conflicting spelling), not once per fold: columns are
+// re-normalized on every ListView render, and a warning that floods the console
+// is a warning that gets muted. Keyed by the pair rather than by the identity
+// alone so a column carrying two different stale spellings reports both — the
+// author needs to fix every producer, not just the first one seen.
+const warnedConflicts = new Set<string>();
+
+/** Reset the warn-once memo. Exported for tests. */
+export function resetColumnIdentityWarnings(): void {
+  warnedConflicts.clear();
+}
+
+const isDev = (): boolean =>
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.NODE_ENV !==
+  'production';
+
+/**
+ * Dev-mode only: say which key won, out loud, when a column carries two identity
+ * spellings that disagree.
+ *
+ * This is the audible half of objectui#3104. The fold below makes the two halves
+ * of such a column agree, which is what stops the bug — but silently rewriting
+ * `name` to match `field` also hides that the metadata producer is emitting a
+ * contradiction. The renderer recovering is not the same as the metadata being
+ * right, so the recovery says so.
+ *
+ * Non-breaking by construction: changes no types, rejects nothing, and is a
+ * no-op under `NODE_ENV=production`.
+ */
+function warnOnConflictingIdentity(
+  entry: Record<string, unknown>,
+  identity: string,
+  losing: readonly string[],
+): void {
+  if (!isDev() || losing.length === 0) return;
+  for (const key of losing) {
+    const memo = `${identity}:${key}:${String(entry[key])}`;
+    if (warnedConflicts.has(memo)) continue;
+    warnedConflicts.add(memo);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ObjectUI] Column carries two identities: \`${CANONICAL_COLUMN_IDENTITY_KEY}: ` +
+        `'${identity}'\` and \`${key}: '${String(entry[key])}'\`. ` +
+        `\`${CANONICAL_COLUMN_IDENTITY_KEY}\` wins — it is the only key ` +
+        `\`ListColumnSchema\` declares — and \`${key}\` has been rewritten to match, ` +
+        `so the rendered column and the requested field agree. Fix the producer: ` +
+        `drop \`${key}\` and author \`${CANONICAL_COLUMN_IDENTITY_KEY}\` only. ` +
+        `(objectui#3104)`,
+    );
+  }
+}
+
 /**
  * Stamp the canonical identity onto one column entry.
  *
@@ -134,6 +186,12 @@ export function normalizeColumnIdentity<T>(entry: T): T {
     (key) => entry[key] !== undefined && entry[key] !== identity,
   );
   if (!needsCanonical && staleLegacy.length === 0) return entry;
+
+  // Say who won before rewriting, while the losing spelling is still readable.
+  // Only genuine contradictions are reported: a column that merely lacks the
+  // canonical key (`{ name: 'stage' }`) is legacy, not conflicting, and gets
+  // stamped without noise.
+  warnOnConflictingIdentity(entry, identity, staleLegacy);
 
   const next: Record<string, unknown> = { ...entry };
   next[CANONICAL_COLUMN_IDENTITY_KEY] = identity;


### PR DESCRIPTION
#3104 **PR3**(闸门 + 响亮化),本战役收官。接 #3119(PR1)、#3122(PR2),均已合。

PR1 把归一挂在 ingestion,PR2 把 22 处读点收敛到 `columnIdentity()`。这一件是**能听见的那一半**。

## 响亮化:renderer 恢复了,不等于元数据是对的

fold 让一列的两半达成一致 —— 这是止血的部分。但**悄悄地**把 `name` 改写成 `field` 的值,同时也把「生产方正在发出自相矛盾的元数据」这件事藏了起来。所以这次恢复自己会开口:

```
[ObjectUI] Column carries two identities: `field: 'account'` and
`name: 'account_name'`. `field` wins — it is the only key `ListColumnSchema`
declares — and `name` has been rewritten to match, so the rendered column and
the requested field agree. Fix the producer: drop `name` and author `field`
only. (objectui#3104)
```

作者不用读源码就能照着改:谁赢、谁输、两边的值、以及下一步动什么。

**刻意收窄的三点:**

| 约束 | 为什么 |
|---|---|
| **只报真矛盾** | `{ name: 'stage' }` 是遗留,不是矛盾 —— 照常 stamp,不出声 |
| **warn once per(身份, 冲突拼写)** | 列在每次渲染都会被重新归一,刷屏的告警就是被静音的告警。按**对**而不是按身份记忆,所以一列带两个不同的陈旧拼写会**两条都报** —— 作者要修的是每一个生产方,不是第一个 |
| **`NODE_ENV=production` 下静默**,且 fold 照常运行 | 上线的 app 不该有 console 噪音;有测试钉住「静默时仍然折叠」 |

`resetColumnIdentityWarnings()` 导出给测试用(沿用 `actionKeys.ts:213` 已有的 warn-once 先例)。

## 不加 lint 规则 —— 这是量出来的,不是拍的

issue 要求「评估 `no-restricted-syntax` 匹配 `.field ?? .name` 的误报率后决定是否叠 lint」。评估做了,结论很干脆:

**家族归零之后,扫描器剩下的 12 处命中,12 处都是合法的。** 误报率 100%,真阳性 0。

因为区别在于**这两个键在那一层里意味着什么**,而不在于表达式怎么写 —— 语法规则看不见这个。叠上去就是在 12 处正确代码上写 inline disable,而那恰好训练下一个作者去伸手拿 disable,正是让真的漏网的那个反射。

ratchet 能做 lint 做不到的事:每个点位带 `verdict` 和 `why`,新命中必须**被分流**而不是被消音。「家族 = 0」这条断言,本身就等于「今天 lint 会报的每一处都是误报」。评估过程写进了 ratchet 的 header。

## 台账条目:查证后无需改动

#3104 要求「台账相关条目处置(ListColumn 等),同步 objectstack#4115」。查了 —— objectstack#4115 是「**与 spec 同名的符号必须是 import 而不是本地声明**」这条规则。`ListColumn` 的实况:

```ts
// packages/types/src/zod/objectql.zod.ts:73
export const ListColumnSchema = SpecListColumnSchema;   // 按引用 re-export
```

而且 `spec-subschema-parity.test.ts:154` **已经**有 `toBe(SpecListColumnSchema)` 的 identity pin —— 也就是 #4115 特别强调的那条(「忠实的副本能通过所有值比较,引用同一性是唯一能区分 re-export 和 fork 的检查」)。

**本来就合规,无需改动。** 记在这里而不是去 #4115 下面刷一条评论。

## mutation-test

| 变异 | 结果 |
|---|---|
| M5 摘掉 `warnOnConflictingIdentity` 调用 | 🔴 4 failed(命名/去重/多拼写/经 fold 触发) |

(M1–M4 分别在 PR1 / PR2 验过,闸门未变。)

## 验证

```
vitest  core+list+grid+detail+tree+view+types  →  188 files / 2663 tests 全绿
vitest  app-shell                              →  250 files / 2089 tests 全绿(5 skipped)
turbo   type-check                             →  3/3 successful
eslint  改动文件 --quiet                        →  0 error
```

## 我没做 fold 的「镜像 → 删除」

我在 PR1 描述里把它列成了 PR3 的活,但 **issue 的 PR3 清单里没有这一项**,而且我当时就写清了它的风险:`columns` 条目会越过包边界进入宿主应用和第三方 renderer,把 `name` 从它们脚下抽掉是**我们没有清单的破坏性变更**。PR2 收敛的是**仓内**消费者,这个前提只覆盖仓内。

真要删,需要单独一件:major/minor + 迁移说明 + 宿主侧的排查。现在这个状态是完整且自洽的 —— 缺陷已闭合(家族归零 + ratchet 守住),矛盾元数据会自己喊出来。

关联:#3119(PR1)、#3122(PR2)、objectstack#4115、#3090(判别法)、#2598(chokepoint 先例)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2pdPmf2yZSd4wFDs1NHY5)_