### PR TITLE
fix(approvals): record-header Reject fires after one dialog again (#3126)

### DIFF
--- a/.changeset/reject-decision-one-dialog.md
+++ b/.changeset/reject-decision-one-dialog.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(approvals): record-header Reject fires after ONE dialog again (objectui#3126)
+
+Since #2961 made the record header's decision inputs live (`actionParams`),
+the Reject action carried BOTH `confirmText` and a collectable comment param.
+The ActionRunner chains confirmation before param collection, so rejecting
+queued two dialogs: the approver answered "Reject this approval request? →
+Continue", the alertdialog closed — and no request fired, because it was
+waiting on a second, unexpected "Action parameters / Comment (optional)"
+dialog. Anyone on the rc.0 contract (one confirm → request) read that as a
+silent no-op: zero network traffic, no toast, the flow stuck pending. Approve
+never declared `confirmText`, which is why it kept working on the same node.
+
+The Reject action no longer declares `confirmText`. The param dialog is the
+confirmation surface: it is titled by the action ("Reject"), carries the old
+confirm question as its description (same `approvals.rejectConfirm` i18n key,
+so every locale keeps its translation), collects the optional comment and any
+declared decision outputs, and nothing is sent until its own Confirm — one
+decision, one dialog, matching Approve and the Approval Center.

--- a/packages/app-shell/src/views/RecordDetailView.approvalDecisionActions.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.approvalDecisionActions.test.tsx
@@ -56,7 +56,22 @@ describe('buildApprovalDecisionActions — param key (objectui#2955)', () => {
     const actions = byName(buildApprovalDecisionActions(pending(), t) as any[]);
     expect(actions.approve_request.order).toBe(-100);
     expect(actions.reject_request.order).toBe(-99);
-    expect(actions.reject_request.confirmText).toBeDefined();
+  });
+});
+
+describe('buildApprovalDecisionActions — one dialog per decision (objectui#3126)', () => {
+  it('never carries `confirmText` — the param dialog is the confirmation', () => {
+    // The runner chains confirm THEN param collection, so `confirmText` +
+    // `actionParams` queued TWO dialogs: after "Continue" nothing was sent
+    // until a second, unexpected comment dialog was also confirmed — the
+    // #3126 "reject silently does nothing" report. One decision, one dialog.
+    const actions = buildApprovalDecisionActions(pending(), t) as any[];
+    for (const a of actions) expect(a.confirmText).toBeUndefined();
+  });
+
+  it('keeps the reject confirm question as the dialog description', () => {
+    const actions = byName(buildApprovalDecisionActions(pending(), t) as any[]);
+    expect(actions.reject_request.description).toBe('Reject this approval request?');
   });
 });
 

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -228,7 +228,15 @@ export function buildApprovalDecisionActions(
       order: -99,
       locations: ['record_header'],
       refreshAfter: true,
-      confirmText: t('approvals.rejectConfirm', { defaultValue: 'Reject this approval request?' }),
+      // NO `confirmText` here (objectui#3126). The runner chains confirm THEN
+      // param collection, so carrying both queued two dialogs: the approver
+      // answered "Reject this approval request? → Continue" and the request
+      // still didn't fire — it waited on a second, unexpected comment dialog
+      // (opened since #2961 made `actionParams` live on this surface), which
+      // reads as a silent no-op. The param dialog IS the confirmation: it is
+      // titled by this label, carries the confirm question as its description,
+      // and nothing is sent until its own Confirm.
+      description: t('approvals.rejectConfirm', { defaultValue: 'Reject this approval request?' }),
       actionParams: decisionParams('reject'),
       successMessage: t('approvals.rejectSuccess', { defaultValue: 'Rejected' }),
     },


### PR DESCRIPTION
Closes #3126.

## 根因(不是回调丢失)

#2961 把记录页头决策动作的死键 `collectParams` 改成 runner 真读的 `actionParams` 之后,Reject 动作同时携带 `confirmText` **和** 可收集的 comment 参数。`ActionRunner` 的管线是先确认、后收参([ActionRunner.ts L517–541](https://github.com/objectstack-ai/objectui/blob/main/packages/core/src/actions/ActionRunner.ts)),于是驳回变成**串联两个弹窗**:

1. 「确认操作 / 确定驳回该审批请求吗?」→ 点「继续」
2. 又弹「操作参数 / Comment (optional)」→ 只有点它的「确认」才发 `POST …/reject`

按 rc.0 契约(确认即发请求)操作的用户和 e2e 在第 1 步就停了——第 2 个弹窗没人理,请求永远不发,表现为"零请求、无报错、无 toast 的静默哑火"。Approve 从未声明 `confirmText`(单弹窗),所以 issue 里"批准正常、驳回哑火、审批中心正常"三组对照全部吻合。

已在真机 Chromium harness 全链路复现:修复前确认后确实弹出第二个弹窗、其「确认」后请求正常发出——dispatch 链路本身完好,坏的是交互契约。

## 修复

- `buildApprovalDecisionActions`:Reject 不再声明 `confirmText`;原确认文案(同一个 `approvals.rejectConfirm` i18n key,各语言译文原样生效)改挂在 `description` 上,由参数弹窗展示。
- 参数弹窗即确认面:标题=「驳回」,说明=「确定驳回该审批请求吗?」,意见框 + 取消/确认,点「确认」即发请求。**一次决策,一个弹窗**,与 Approve 及审批中心对齐;#2961 的 comment / decisionOutputs 收集能力原样保留。

## 测试

- 回归组新增:决策动作永不携带 `confirmText`(防双弹层回潮)+ 确认文案落在 `description`。
- 相关套件全绿:RecordDetailView.approvalDecisionActions / ActionParamDialog(含 uploading)/ useRecordApprovals.decisionOutputs / decisionOutputParams,共 69 条。
- 真机 Chromium harness 实测修复后:点「驳回」→ 单弹窗 → 「确认」→ `reject_request` 成功 dispatch,旧 alertdialog 不再出现。

## Changeset

`@object-ui/app-shell` patch。

🤖 Generated with [Claude Code](https://claude.com/claude-code)