### PR TITLE
fix(charts): pie/donut 图例给扇区标上分类名，并真正读 showLegend (#3135)

### DIFF
--- a/packages/plugin-charts/src/AdvancedChartImpl.pieLegend.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.pieLegend.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pie/donut legend (#3135) — the legend must NAME each slice's category, and it
+ * must obey `showLegend`.
+ *
+ * Two defects lived here. The legend resolved its label through the shadcn
+ * config helper, which read the legend ITEM's own `type`/`color` props before
+ * the data row — so a category dimension literally named `type` (a dashboard
+ * staple: "按类型分布") resolved to the legend ICON shape ("rect"), missed the
+ * config, and drew colour swatches with NO text: a pie of anonymous dots. And
+ * the pie branch rendered its legend unconditionally, so `showLegend: false`
+ * did nothing.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+
+// Recharts' ResponsiveContainer measures its parent via ResizeObserver, which
+// reports 0×0 under the headless DOM — so the chart never paints. Replace it
+// with a fixed-size passthrough so the pie (and its legend) actually render.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 320, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+// Recharts registers the pie's legend payload from a layout effect and the
+// Legend re-renders off that store update, so read the legend after a tick.
+const settle = () => act(async () => { await new Promise((r) => setTimeout(r, 60)); });
+
+const legendText = (c: HTMLElement) =>
+  c.querySelector('.recharts-legend-wrapper')?.textContent ?? '';
+
+describe('AdvancedChartImpl — pie/donut legend', () => {
+  // `type` is the exact dimension name from the reported dashboard, and it
+  // collides with the recharts legend item's own `type` (icon shape) prop.
+  it.each(['type', 'color', 'urgency'])('labels each slice for a dimension named `%s`', async (dim) => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="pie"
+        data={[{ [dim]: '设备', total_count: 3 }, { [dim]: '质量', total_count: 2 }]}
+        xAxisKey={dim}
+        series={[{ dataKey: 'total_count' }]}
+        showLegend
+        isAnimationActive={false}
+      />,
+    );
+    await settle();
+    expect(legendText(container)).toContain('设备');
+    expect(legendText(container)).toContain('质量');
+  });
+
+  // Single-category data is the degenerate case the issue calls out: one full
+  // circle in one colour is zero information without the category's name.
+  it('donut: a single category is still named', async () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="donut"
+        data={[{ type: '设备', total_count: 3 }]}
+        xAxisKey="type"
+        series={[{ dataKey: 'total_count' }]}
+        showLegend
+        isAnimationActive={false}
+      />,
+    );
+    await settle();
+    expect(legendText(container)).toContain('设备');
+  });
+
+  it('honors showLegend: false', async () => {
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="pie"
+        data={[{ type: '设备', total_count: 3 }, { type: '质量', total_count: 2 }]}
+        xAxisKey="type"
+        series={[{ dataKey: 'total_count' }]}
+        showLegend={false}
+        isAnimationActive={false}
+      />,
+    );
+    await settle();
+    expect(container.querySelectorAll('.recharts-legend-wrapper')).toHaveLength(0);
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -689,11 +689,13 @@ function AdvancedChartImplInner({
                 return <Cell key={`cell-${index}`} fill={resolveColor(c)} />;
              })}
           </Pie>
-          <ChartLegend
-            verticalAlign="bottom"
-            wrapperStyle={{ fontSize: isMobile ? '11px' : '12px', paddingTop: '8px' }}
-            content={<ChartLegendContent nameKey={xAxisKey} className="flex-wrap" />}
-          />
+          {legendVisible ? (
+            <ChartLegend
+              verticalAlign="bottom"
+              wrapperStyle={{ fontSize: isMobile ? '11px' : '12px', paddingTop: '8px' }}
+              content={<ChartLegendContent nameKey={xAxisKey} className="flex-wrap" />}
+            />
+          ) : null}
         </PieChart>
       </ChartContainer>
     );

--- a/packages/plugin-charts/src/ChartContainerImpl.tsx
+++ b/packages/plugin-charts/src/ChartContainerImpl.tsx
@@ -401,12 +401,14 @@ function getPayloadConfigFromPayload(
 
   let configLabelKey: string = key
 
+  // The DATA ROW wins over the legend/tooltip item's own same-named prop.
+  // Recharts item entries carry `type` (the legend ICON shape, e.g. "rect"),
+  // `color`, `dataKey` and `value` of their own, so a pie whose category
+  // dimension is literally named `type` (`nameKey="type"`) used to resolve to
+  // "rect", miss the config, and render legend swatches with NO text at all —
+  // a pie of unlabelled colour dots (#3135). Reading the row first keys off the
+  // actual category ("设备"), which is what `nameKey` was pointing at.
   if (
-    key in payload &&
-    typeof payload[key as keyof typeof payload] === "string"
-  ) {
-    configLabelKey = payload[key as keyof typeof payload] as string
-  } else if (
     payloadPayload &&
     key in payloadPayload &&
     typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
@@ -414,6 +416,11 @@ function getPayloadConfigFromPayload(
     configLabelKey = payloadPayload[
       key as keyof typeof payloadPayload
     ] as string
+  } else if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
   }
 
   return configLabelKey in config

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -592,6 +592,18 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   });
   const effectiveCategoryOrder = explicitOrder?.length ? explicitOrder : categoryOrder;
 
+  // `chartConfig.showLegend` (#3135). The widget's chart config never reached
+  // the renderer — this component read `options` and nothing else — so an author
+  // who wrote `showLegend: false` still got a legend, and one who wrote `true`
+  // only got one because "on" happens to be the renderer's default. Lower the
+  // one flag the renderer already honors; the rest of `chartConfig` stays
+  // unforwarded (the renderer derives axes/series from the dataset selection).
+  const chartConfig: Record<string, unknown> =
+    widget?.chartConfig && typeof widget.chartConfig === 'object' && !Array.isArray(widget.chartConfig)
+      ? (widget.chartConfig as Record<string, unknown>)
+      : {};
+  const showLegend = typeof chartConfig.showLegend === 'boolean' ? chartConfig.showLegend : undefined;
+
   // Map a clicked chart segment back to its dataset row, then drill through to
   // the underlying records — same governed path the table/pivot rows use.
   const handleChartDrill = (ev: { category?: string; series?: string; value?: number }) => {
@@ -617,7 +629,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
         // measurement churn, can freeze there — bars never draw until an unrelated
         // re-render (#2756, follow-up to #2727's ineffective settle re-mount).
         // Turning the tween off makes the first paint deterministic.
-        schema={{ type: 'chart', chartType, data: chartData, xAxisKey, series, isAnimationActive: false, ...(categoryColors ? { categoryColors } : {}), ...(effectiveCategoryOrder ? { categoryOrder: effectiveCategoryOrder } : {}) } as any}
+        schema={{ type: 'chart', chartType, data: chartData, xAxisKey, series, isAnimationActive: false, ...(showLegend != null ? { showLegend } : {}), ...(categoryColors ? { categoryColors } : {}), ...(effectiveCategoryOrder ? { categoryOrder: effectiveCategoryOrder } : {}) } as any}
         onChartClick={chartDrill}
         onSegmentClick={chartDrill}
       />

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.showLegend.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.showLegend.test.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #3135 — a dataset widget's `chartConfig.showLegend` must reach the chart
+ * renderer. It never did: this component read `options` and nothing else, so
+ * the flag was inert metadata — `false` still drew a legend, and `true` only
+ * "worked" because the renderer defaults to showing one.
+ *
+ * Asserted at the source (the schema handed to the renderer), via a stubbed
+ * SchemaRenderer — the same seam DatasetWidget.animation uses.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+
+let lastChartSchema: any = null;
+
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  SchemaRenderer: (props: any) => {
+    lastChartSchema = props.schema;
+    return null;
+  },
+}));
+
+import { DatasetWidget } from '../DatasetWidget';
+
+afterEach(() => {
+  cleanup();
+  lastChartSchema = null;
+});
+
+const rows = [
+  { type: '设备', total_count: 5 },
+  { type: '质量', total_count: 3 },
+];
+
+const renderWidget = (chartConfig?: Record<string, unknown>) => {
+  const src = { queryDataset: vi.fn(async () => ({ rows })) };
+  render(
+    <DatasetWidget
+      widget={{
+        type: 'pie',
+        dataset: 'andon_metrics',
+        dimensions: ['type'],
+        values: ['total_count'],
+        ...(chartConfig ? { chartConfig } : {}),
+      }}
+      dataSource={src}
+    />,
+  );
+};
+
+describe('DatasetWidget — chartConfig.showLegend (#3135)', () => {
+  it('forwards showLegend: true', async () => {
+    renderWidget({ type: 'pie', showLegend: true, showDataLabels: false });
+    await waitFor(() => expect(lastChartSchema).not.toBeNull());
+    expect(lastChartSchema.chartType).toBe('pie');
+    expect(lastChartSchema.showLegend).toBe(true);
+  });
+
+  it('forwards showLegend: false', async () => {
+    renderWidget({ type: 'pie', showLegend: false });
+    await waitFor(() => expect(lastChartSchema).not.toBeNull());
+    expect(lastChartSchema.showLegend).toBe(false);
+  });
+
+  // No declaration → the key stays off the schema so the renderer's own default
+  // (legend shown) still decides. Every existing widget keeps its behaviour.
+  it('omits the key when the widget declares no chartConfig', async () => {
+    renderWidget();
+    await waitFor(() => expect(lastChartSchema).not.toBeNull());
+    expect('showLegend' in lastChartSchema).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3135

## 根因：`type` 这个维度名把图例文字吃掉了

图例标签由 shadcn 的 `getPayloadConfigFromPayload` 解析：它拿 `nameKey`（= 维度字段名）**先在 recharts 的 legend item 上找**，找不到才看数据行。而 recharts 的 legend item 自带一个 `type` 字段 —— 图例**图标形状**，值是 `"rect"`。

于是 `dimensions: ['type']`（"按类型分布"，看板里极常见）→ `nameKey="type"` → 解析成 `"rect"` → `config["rect"]` 查不到 → 回退 `config["type"]` 也没有 → **label 为 undefined，只剩 2px 色块，一个字不渲染**。维度叫 `color` 同样受害。单类别数据下最致命：整圆一色 + 一个无字色点。

改法：数据行优先于 legend item 自身的同名属性 —— `nameKey` 本来指的就是数据行的字段。

## 同一份报告里的另外两个缺口

- **饼/环图分支的图例是无条件渲染的**，`legendVisible` 只用在 radar/combo 上。写 `showLegend: false` 关不掉；写 `true` 也不是"生效"，只是撞上了默认值。
- **`DatasetWidget` 根本不读 `widget.chartConfig`**（只读 `options`），声明的 `showLegend` 从元数据层到渲染器之间断链，是死配置。现在把这一个渲染器已支持的标志下沉进 chart schema；未声明就不带这个键，存量看板行为不变。

## 验证

**单测**：新增 `AdvancedChartImpl.pieLegend.test.tsx`（`type`/`color`/`urgency` 三种维度名 + 单类别 + `showLegend:false`）与 `DatasetWidget.showLegend.test.tsx`。回滚源码改动后新测试 4 失败 1 通过（通过的正是 `urgency` 对照组），修复后全绿。plugin-charts 129/129、plugin-dashboard 156/156。

**真机 UI（app-showcase 真后端 + console dev，真实 seed 数据）**：按 issue 原样造 dataset 维度名 `type` + pie/donut widget，同一页面只切源码做 A/B：

| 状态 | 图例 DOM |
|---|---|
| 修复前 | `text: ""` / `swatches: 5`（两个 widget 都是裸色点） |
| 修复后 | `text: "BacklogDoneIn ProgressIn ReviewTo Do"` |
| `showLegend:false` / `true` 并排 | 只剩 1 个 legend wrapper，false 那侧图例消失 |

对照：原生 Chart Gallery 里 `status`/`priority` 维度的饼/环图两态都正常 —— 触发条件确实是维度名与 recharts legend item 自带属性撞名，所以 showcase 一直没盖住这个 bug。

## 未动

`packages/components/src/ui/chart.tsx` 有同一 helper 的副本、同样的 bug，但它没从 index 导出、无人引用，属于死代码，未顺手改以免扩大 diff。

🤖 Generated with [Claude Code](https://claude.com/claude-code)