### PR TITLE
feat(grid): aggregate single-call mode for bulk actions — `execution: 'aggregate'` (#3139)

### DIFF
--- a/.changeset/bulk-action-aggregate-execution.md
+++ b/.changeset/bulk-action-aggregate-execution.md
@@ -1,0 +1,36 @@
+---
+"@object-ui/types": minor
+"@object-ui/plugin-grid": minor
+"@object-ui/core": minor
+"@object-ui/app-shell": minor
+---
+
+Aggregate single-call mode for bulk actions: `execution: 'aggregate'` (objectui#3139).
+
+A `bulkActionDefs` entry with `operation: 'custom'` used to have exactly one
+dispatch shape: one action-runner call per selected record (`_rowRecord`
+attached). "Select N rows → ONE call that receives every selected id" — the
+zip-of-QR-codes / merged-PDF / batch-print shape — could not be expressed, so
+downstream projects fell back to per-row `window.open` storms or gave up.
+
+`BulkActionDef` now carries `execution?: 'perRecord' | 'aggregate'` (default
+`'perRecord'`, existing views untouched). An aggregate def dispatches its
+action exactly once for the whole selection with `params._selectedIds:
+string[]` injected and the full records published as
+`context.selectedRecords`. The authored form usually just names a declared
+object action — `{ name, operation: 'custom', execution: 'aggregate' }` —
+and `resolveBulkActions` attaches the declaration. Results are
+all-or-nothing: a failure is attributed to every id with the real error and
+per-row Retry is hidden (re-running the action is the retry; a total failure
+keeps the selection). `batchSize` does not apply; `maxRecords` still gates.
+
+The executor rides the existing `executeBulkBatch` bulk-first decision tree —
+the aggregate call is its `bulkCall`, and the per-row "fallback" only
+re-throws the captured error for attribution, never fans out N dispatches
+against an endpoint written for one `_selectedIds` call.
+
+Also: url/api target interpolation now exposes `${ctx.selection.ids}` (comma
+-joined) and `${ctx.selection.count}` from the grid's checkbox selection, so
+a plain `list_toolbar` action can carry the selection without bulk plumbing;
+the console's server-action handler recognizes `_selectedIds` and skips the
+single-record multi-select guard for aggregate dispatches.

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -914,6 +914,37 @@ describe('serverActionHandler — list_toolbar selection fallback', () => {
     expect(res).toMatchObject({ success: true });
     expect(String(authFetchSpy.mock.calls[0][0])).toContain('/api/v1/actions/inv/export_all');
   });
+
+  it('an aggregate dispatch (_selectedIds) passes the multi-select guard and posts no recordId (#3139)', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { result } = renderHook(() =>
+      useConsoleActionRuntime({ dataSource: {}, objects: [], objectName: 'inv' }),
+    );
+
+    let res: any;
+    await act(async () => {
+      res = await result.current.serverActionHandler(
+        {
+          type: 'script',
+          name: 'generate_qr_zip',
+          locations: ['list_item', 'list_toolbar'],
+          params: { _selectedIds: ['a', 'b'], format: 'png' },
+        } as any,
+        // Multi-select would block a single-record dispatch — the injected
+        // `_selectedIds` marks this as the aggregate shape instead.
+        { selectedRecords: [{ id: 'a' }, { id: 'b' }] } as any,
+      );
+    });
+
+    expect(res).toMatchObject({ success: true });
+    const [url, init] = authFetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/api/v1/actions/inv/generate_qr_zip');
+    const body = JSON.parse(init.body);
+    // The server reads the id array, never a synthesized single recordId.
+    expect(body.recordId).toBeUndefined();
+    expect(body.params._selectedIds).toEqual(['a', 'b']);
+    expect(body.params.format).toBe('png');
+  });
 });
 
 describe('ConsoleActionRuntimeProvider — page-level action execution', () => {

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -535,12 +535,18 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
     delete (params as any)._rowRecord;
     const recordIdField = (action as any).recordIdField || 'id';
     let resolvedRecordId = (params as any).recordId ?? _rowRecord?.[recordIdField];
+    // An AGGREGATE bulk dispatch (objectui#3139) carries the whole selection
+    // as `params._selectedIds` — the server reads that array, not `recordId`.
+    // The single-record fallback below must not touch it: resolving a
+    // recordId would mislabel the run as record-scoped, and the multi-select
+    // guard would block exactly the selection this dispatch exists to carry.
+    const isAggregateDispatch = Array.isArray((params as any)._selectedIds);
     // Same list_toolbar fallback as flowHandler: no `_rowRecord` means the
     // action came from the toolbar — resolve the recordId from the grid's
     // checkbox selection (published as `selectedRecords`). Multi-select is
     // ambiguous for a single-record action, so block with a message; so is
     // zero selection when the action is record-scoped (see isRecordScoped).
-    if (resolvedRecordId == null) {
+    if (resolvedRecordId == null && !isAggregateDispatch) {
       const selected = Array.isArray(context?.selectedRecords) ? context!.selectedRecords : [];
       if (selected.length === 1) {
         resolvedRecordId = selected[0]?.[recordIdField];

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -1162,9 +1162,15 @@ export class ActionRunner {
    * fragment.
    *
    * `ctx.origin`, `ctx.user.*`, `ctx.org.*`, `ctx.recordId` are surfaced
-   * implicitly from the runner's ActionContext + window. Consumers can
-   * extend by stuffing extra keys under `context.ctx = {...}` before
-   * calling `runner.execute()`.
+   * implicitly from the runner's ActionContext + window, and
+   * `ctx.selection.ids` / `ctx.selection.count` reflect the grid's current
+   * checkbox selection (`context.selectedRecords`) — `${ctx.selection.ids}`
+   * comma-joins the ids via the standard `String(array)` behaviour, so a
+   * list_toolbar url/api action can carry the selection without any bulk
+   * plumbing (objectui#3139). In an aggregate bulk dispatch,
+   * `${param._selectedIds}` interpolates the same ids from the injected
+   * param. Consumers can extend by stuffing extra keys under
+   * `context.ctx = {...}` before calling `runner.execute()`.
    */
   private interpolateTarget(target: string, action: ActionDef): string {
     if (typeof target !== 'string' || target.indexOf('${') === -1) return target;
@@ -1198,6 +1204,22 @@ export class ActionRunner {
       user: this.context.user ?? {},
       org: this.context.org ?? this.context.organization ?? {},
       recordId: this.context.record?.id ?? this.context.recordId,
+      // Current list selection (published by the grid as `selectedRecords`).
+      // `${ctx.selection.ids}` in a url/api target comma-joins the ids —
+      // String(array) — giving toolbar actions selection access without any
+      // bulk-executor involvement (objectui#3139). Empty when nothing is
+      // selected, so authors can treat "" as "no selection".
+      selection: {
+        ids: Array.isArray(this.context.selectedRecords)
+          ? this.context.selectedRecords
+              .map((r: Record<string, unknown> | null | undefined) => r?.id)
+              .filter((v: unknown) => v != null)
+              .map(String)
+          : [],
+        count: Array.isArray(this.context.selectedRecords)
+          ? this.context.selectedRecords.length
+          : 0,
+      },
     };
     if (this.context.ctx && typeof this.context.ctx === 'object') {
       Object.assign(ctx, this.context.ctx);

--- a/packages/core/src/actions/__tests__/ActionRunner.resultDialog.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.resultDialog.test.ts
@@ -203,6 +203,52 @@ describe('ActionRunner - target interpolation', () => {
     expect(navHandler.mock.calls[0][0]).toBe('/u/u_42');
   });
 
+  it('exposes ctx.selection.ids / ctx.selection.count from selectedRecords (#3139)', async () => {
+    const navHandler = vi.fn();
+    const runner = new ActionRunner({
+      selectedRecords: [{ id: 'd1' }, { id: 'd2' }, { name: 'no-id' }],
+    });
+    runner.setNavigationHandler(navHandler);
+
+    await runner.execute({
+      type: 'url',
+      target: '/qr/zip?ids=${ctx.selection.ids}&n=${ctx.selection.count}',
+    });
+
+    // String(array) comma-joins; the comma arrives percent-encoded in query
+    // position (standard encodeURIComponent behaviour, servers decode it).
+    // Rows without an id are dropped from ids but still counted — count
+    // reflects the selection size, ids only the addressable rows.
+    expect(navHandler.mock.calls[0][0]).toBe('/qr/zip?ids=d1%2Cd2&n=3');
+  });
+
+  it('resolves ctx.selection to empty ids and zero count when nothing is selected', async () => {
+    const navHandler = vi.fn();
+    const runner = new ActionRunner({});
+    runner.setNavigationHandler(navHandler);
+
+    await runner.execute({
+      type: 'url',
+      target: '/qr/zip?ids=${ctx.selection.ids}&n=${ctx.selection.count}',
+    });
+
+    expect(navHandler.mock.calls[0][0]).toBe('/qr/zip?ids=&n=0');
+  });
+
+  it('interpolates ${param._selectedIds} injected by an aggregate bulk dispatch', async () => {
+    const navHandler = vi.fn();
+    const runner = new ActionRunner({});
+    runner.setNavigationHandler(navHandler);
+
+    await runner.execute({
+      type: 'url',
+      target: '/qr/zip?ids=${param._selectedIds}',
+      params: { _selectedIds: ['d1', 'd2'] },
+    });
+
+    expect(navHandler.mock.calls[0][0]).toBe('/qr/zip?ids=d1%2Cd2');
+  });
+
   it('substitutes ${param.X} into api endpoints (fetch URL)', async () => {
     const fetchSpy = vi
       .spyOn(globalThis as any, 'fetch')

--- a/packages/plugin-grid/demo/bulk-actions.tsx
+++ b/packages/plugin-grid/demo/bulk-actions.tsx
@@ -97,6 +97,19 @@ const RECALC = {
   ],
 };
 
+/**
+ * Aggregate counterpart (#3139): the view opts in with `execution:
+ * 'aggregate'` below, so the whole selection arrives in ONE dispatch carrying
+ * `params._selectedIds` — the "zip of QR codes for N devices" shape.
+ */
+const EXPORT_ZIP = {
+  name: 'bulk_export_zip',
+  label: 'Export Zip',
+  icon: 'archive',
+  type: 'api',
+  target: '/api/demo/export-zip',
+};
+
 /** Candidate directories for the picker-param defs (#3064). */
 const USERS = [
   { id: 'u1', name: '现场工人-测试', email: 'worker@demo.dev' },
@@ -158,7 +171,7 @@ const dataSource: any = {
         progress: { type: 'percent', label: 'Progress' },
       },
       // The single source the grid folds into the selection bar.
-      actions: [MARK_DONE, RECALC],
+      actions: [MARK_DONE, RECALC, EXPORT_ZIP],
     };
   },
 };
@@ -195,11 +208,14 @@ window.fetch = (async (input: any, init: any) => {
   const url = String(input);
   if (!url.startsWith('/api/demo/')) return realFetch(input, init);
   const body = init?.body ? JSON.parse(init.body) : {};
-  const recordId = body._rowRecord?.id ?? '(none)';
+  // An aggregate dispatch (#3139) carries the whole selection in one call.
+  const recordId = Array.isArray(body._selectedIds)
+    ? `[${body._selectedIds.join(',')}]`
+    : body._rowRecord?.id ?? '(none)';
   // t3 fails — proves the result panel attributes failures per record instead
   // of reporting a blanket success.
   const status = recordId === 't3' ? 422 : 200;
-  const { _rowRecord, ...rest } = body;
+  const { _rowRecord, _selectedIds, ...rest } = body;
   pushLog({ url, recordId, params: JSON.stringify(rest), status });
   return {
     ok: status === 200,
@@ -225,6 +241,10 @@ const schema: any = {
   bulkActions: ['bulk_mark_done', 'bulk_recalc_estimate', 'legacy_only_handler'],
   // Rich defs with picker params — the shared-field-widget surface (#3064).
   bulkActionDefs: [
+    // Aggregate mode (#3139): names the declared action, ONE dispatch for the
+    // whole selection with `params._selectedIds` — contrast with Mark Done's
+    // one-line-per-record log output.
+    { name: 'bulk_export_zip', operation: 'custom', execution: 'aggregate' },
     {
       name: 'set_manager',
       label: 'Set Manager',
@@ -264,7 +284,9 @@ function Demo() {
         <p style={{ fontSize: 12, color: 'hsl(var(--muted-foreground))', margin: '4px 0 0' }}>
           Select rows → the bar shows <b>Mark Done</b> and <b>Recalculate Estimate</b> (names
           from the view&apos;s <code>bulkActions</code>, promoted to their declared object
-          actions) and <b>Legacy Only Handler</b> (unresolvable, dispatched by name).
+          actions), <b>Export Zip</b> (an <code>execution: &apos;aggregate&apos;</code> def —
+          ONE dispatch carrying every selected id, #3139) and <b>Legacy Only
+          Handler</b> (unresolvable, dispatched by name).
         </p>
       </header>
 

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1871,6 +1871,22 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // (Plain function for the same reason as `resolveBulkRows` above: this point
   // in the body is past render paths that short-circuit, so a hook here would
   // tripwire the rules-of-hooks balance.)
+  // Shared def-key strip for BOTH bulk dispatchers below. The dialog already
+  // collected params and took the confirmation, so the dispatch must remove
+  // them from the source action — leaving them on would make the runner
+  // re-prompt (once per record on the per-record path). Kept in one place so
+  // the two dispatchers cannot drift on what gets stripped.
+  const stripCollectedActionKeys = (source: Record<string, any>) => {
+    const {
+      params: _declaredParams,
+      actionParams: _actionParams,
+      confirmText: _confirmText,
+      confirm: _confirm,
+      ...rest
+    } = source;
+    return rest;
+  };
+
   const runBulkActionRecord = async (
     def: BulkActionDef,
     row: Record<string, unknown>,
@@ -1879,16 +1895,12 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     const source = def.actionDef as Record<string, any> | undefined;
     if (!source) return;
     const {
-      params: _declaredParams,
-      actionParams: _actionParams,
-      confirmText: _confirmText,
-      confirm: _confirm,
       // A one-shot reveal (2FA code, fresh OAuth secret) is a single-record
       // affordance by construction, and the runner AWAITS acknowledgement —
       // one modal per record would stall the run behind N dialogs.
       resultDialog: _resultDialog,
       ...rest
-    } = source;
+    } = stripCollectedActionKeys(source);
     const res = await executeAction({
       ...rest,
       // `_rowRecord` is the same row-context key the list_item path attaches,
@@ -1898,6 +1910,39 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     } as any);
     // Reject so the executor records this row under its own id in the result
     // (and the error CSV) instead of counting a failed action as succeeded.
+    if (!res?.success) {
+      throw new Error(res?.error || `Action ${def.name} failed`);
+    }
+  };
+
+  // Whole-selection dispatcher for a def that opted into
+  // `execution: 'aggregate'` (objectui#3139): ONE runner dispatch carrying
+  // every selected id as `params._selectedIds`, so the target endpoint can
+  // produce a single aggregate artifact (zip of QR codes, merged PDF…).
+  // Unlike the per-record path, `resultDialog` is NOT stripped — the
+  // per-record rationale (one modal per record stalls the run) does not
+  // apply to a single call, and a one-shot reveal of the aggregate result
+  // (download URL, generated codes) is exactly this mode's use case.
+  const runBulkActionAggregate = async (
+    def: BulkActionDef,
+    rows: Array<Record<string, unknown>>,
+    params: Record<string, unknown>,
+  ): Promise<void> => {
+    const source = def.actionDef as Record<string, any> | undefined;
+    if (!source) return;
+    const rest = stripCollectedActionKeys(source);
+    const ids = rows.map((r) => (r.id != null ? String(r.id) : '')).filter(Boolean);
+    // Publish the EXPANDED, eligibility-filtered rows the run actually covers
+    // — the standing selection effect only carries the current page's ticks,
+    // while "select all N matching" and the `visible` partition can both
+    // change the real set. Handlers and `${ctx.selection.*}` interpolation
+    // read this. The next selection change re-publishes, so no cleanup here.
+    updateActionContext({ selectedRecords: rows });
+    const res = await executeAction({
+      ...rest,
+      params: { ...params, _selectedIds: ids },
+      toast: { showOnSuccess: false, showOnError: false },
+    } as any);
     if (!res?.success) {
       throw new Error(res?.error || `Action ${def.name} failed`);
     }
@@ -2729,6 +2774,7 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
       resource={schema.objectName ?? ''}
       objectFields={objectSchema?.fields}
       runAction={runBulkActionRecord}
+      runAggregate={runBulkActionAggregate}
     />
   );
 

--- a/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
@@ -225,6 +225,85 @@ describe('view-declared bulk actions (objectui#3002)', () => {
 });
 
 /**
+ * `execution: 'aggregate'` (objectui#3139): the whole selection in ONE
+ * dispatch, pinned side by side with the per-record semantics above. The
+ * authored def names the object action; the dispatch carries every selected
+ * id under `params._selectedIds` so the server can produce a single
+ * aggregate artifact (zip of QR codes, merged PDF…).
+ */
+describe('aggregate bulk actions (objectui#3139)', () => {
+  const AGGREGATE_VIEW = {
+    bulkActionDefs: [{ name: 'push_down', operation: 'custom', execution: 'aggregate' }],
+  };
+
+  it('issues exactly ONE request carrying every selected id under _selectedIds', async () => {
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: AGGREGATE_VIEW,
+    });
+
+    const button = await screen.findByTestId('bulk-action-push_down');
+    // The authored def resolved the object action, so it carries its label.
+    expect(button).toHaveTextContent('下推');
+    fireEvent.click(button);
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/plans/push');
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body._selectedIds).toEqual(['r1', 'r2']);
+    // The per-record row-context key must NOT ride along — this is the
+    // aggregate shape, not a per-record dispatch that happens to be first.
+    expect(body._rowRecord).toBeUndefined();
+    await waitFor(() => expect(screen.getByText(/Succeeded 2 \/ 2/)).toBeInTheDocument());
+  });
+
+  it('attributes a failed aggregate call to every record, with no per-row Retry', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: { get: () => 'application/json' },
+      json: async () => ({ error: 'zip generation failed' }),
+    });
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: AGGREGATE_VIEW,
+    });
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    // ONE call — a failed aggregate run must not fan out per-record dispatches
+    // against an endpoint written for a single `_selectedIds` call.
+    await waitFor(() => expect(screen.getByText(/Succeeded 0 \/ 2/)).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Each record shows the one real error (the builtin api executor
+    // formats a non-2xx response as `HTTP <status>`, same as the
+    // per-record pin above)…
+    expect(screen.getByTestId('bulk-error-row-r1')).toHaveTextContent('HTTP 500');
+    expect(screen.getByTestId('bulk-error-row-r2')).toHaveTextContent('HTTP 500');
+    // …but there is no per-row slice to re-attempt: the whole-run re-run is
+    // the retry (a total failure keeps the selection for exactly that).
+    expect(screen.queryByTestId('bulk-error-retry-r1')).not.toBeInTheDocument();
+  });
+
+  it('a per-record def with the same shape still fans out — mode lives on the def', async () => {
+    await renderAndSelectAll({
+      objectActions: [PUSH_DOWN],
+      schema: { bulkActions: ['push_down'] },
+    });
+
+    fireEvent.click(await screen.findByTestId('bulk-action-push_down'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const bodies = fetchMock.mock.calls.map(c => JSON.parse((c[1] as any).body));
+    expect(bodies.every(b => b._selectedIds === undefined)).toBe(true);
+  });
+});
+
+/**
  * `visible` is evaluated per selected record, with that record in scope
  * (objectui#3067). Before this the bar evaluated it with NO record bound, and
  * the lenient path returned `true` for every row-scoped predicate — so an

--- a/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
+++ b/packages/plugin-grid/src/__tests__/resolveBulkActions.test.ts
@@ -186,4 +186,120 @@ describe('resolveBulkActions', () => {
 
     expect(defs[0].label).toBe('Push Down');
   });
+
+  // [#3139] `execution: 'aggregate'` authored defs — the ONE case where an
+  // authored def gets the object action resolved onto it.
+  describe('aggregate authored defs', () => {
+    it('attaches the named object action as actionDef, without the promoted batchSize', () => {
+      const authored: BulkActionDef = {
+        name: 'push_down',
+        operation: 'custom',
+        execution: 'aggregate',
+      };
+      const { defs, unresolved } = resolveBulkActions({
+        bulkActionDefs: [authored],
+        objectActions: [PUSH_DOWN],
+      });
+
+      expect(unresolved).toEqual([]);
+      expect(defs).toHaveLength(1);
+      expect(defs[0]).toMatchObject({
+        name: 'push_down',
+        operation: 'custom',
+        execution: 'aggregate',
+        label: '下推',
+        actionDef: PUSH_DOWN,
+      });
+      // One call by contract — never chunked, so the per-record fan-out
+      // concurrency cap must not ride along.
+      expect(defs[0].batchSize).toBeUndefined();
+    });
+
+    it('authored keys win over the resolved action', () => {
+      const authored: BulkActionDef = {
+        name: 'push_down',
+        label: 'Batch push',
+        variant: 'danger',
+        operation: 'custom',
+        execution: 'aggregate',
+        maxRecords: 100,
+      };
+      const { defs } = resolveBulkActions({
+        bulkActionDefs: [authored],
+        objectActions: [PUSH_DOWN],
+      });
+
+      expect(defs[0]).toMatchObject({
+        label: 'Batch push',
+        variant: 'danger',
+        maxRecords: 100,
+        actionDef: PUSH_DOWN,
+      });
+    });
+
+    it('leaves an aggregate def naming no declared action untouched', () => {
+      const authored: BulkActionDef = {
+        name: 'ghost_action',
+        operation: 'custom',
+        execution: 'aggregate',
+      };
+      const { defs } = resolveBulkActions({
+        bulkActionDefs: [authored],
+        objectActions: [PUSH_DOWN],
+      });
+
+      // No actionDef → the executor has nothing to dispatch (no-op), same as
+      // any other plain custom def.
+      expect(defs).toEqual([authored]);
+      expect(defs[0].actionDef).toBeUndefined();
+    });
+
+    it('does NOT touch a plain custom def that shares a declared action name', () => {
+      // Regression guard for the merge's scoping: without an explicit
+      // `execution: 'aggregate'`, an authored custom def keeps its historical
+      // no-op/callout meaning even when an object action shares its name.
+      const authored: BulkActionDef = { name: 'push_down', operation: 'custom' };
+      const { defs } = resolveBulkActions({
+        bulkActionDefs: [authored],
+        objectActions: [PUSH_DOWN],
+      });
+
+      expect(defs).toEqual([authored]);
+      expect(defs[0].actionDef).toBeUndefined();
+    });
+
+    it('an aggregate def with an inline actionDef is left as authored', () => {
+      const inline = { name: 'push_down', type: 'api', target: '/custom' };
+      const authored: BulkActionDef = {
+        name: 'push_down',
+        operation: 'custom',
+        execution: 'aggregate',
+        actionDef: inline,
+      };
+      const { defs } = resolveBulkActions({
+        bulkActionDefs: [authored],
+        objectActions: [PUSH_DOWN],
+      });
+
+      expect(defs).toEqual([authored]);
+      expect(defs[0].actionDef).toBe(inline);
+    });
+
+    it('still claims its name against bulkActions duplicates', () => {
+      const authored: BulkActionDef = {
+        name: 'push_down',
+        operation: 'custom',
+        execution: 'aggregate',
+      };
+      const { defs } = resolveBulkActions({
+        bulkActions: ['push_down'],
+        bulkActionDefs: [authored],
+        objectActions: [PUSH_DOWN],
+      });
+
+      // One button, the authored aggregate one — not a promoted twin.
+      expect(defs).toHaveLength(1);
+      expect(defs[0].execution).toBe('aggregate');
+    });
+  });
 });

--- a/packages/plugin-grid/src/__tests__/useBulkExecutor.test.ts
+++ b/packages/plugin-grid/src/__tests__/useBulkExecutor.test.ts
@@ -340,4 +340,142 @@ describe('useBulkExecutor', () => {
       expect(update).toHaveBeenCalledWith('task', '2', { priority: 'medium' });
     });
   });
+
+  // [#3139] `execution: 'aggregate'` — ONE dispatch for the whole selection,
+  // pinned side by side with the per-record semantics above so neither can
+  // drift into the other.
+  describe('aggregate execution', () => {
+    const agg = (op: Partial<BulkActionDef> = {}): BulkActionDef => ({
+      name: 'generate_qr_zip',
+      operation: 'custom',
+      execution: 'aggregate',
+      actionDef: { name: 'generate_qr_zip', type: 'api', target: '/api/v1/qr/zip' },
+      ...op,
+    } as BulkActionDef);
+    const ds = () => ({ update: vi.fn(), delete: vi.fn() });
+
+    it('dispatches runAggregate exactly once with every row and the params', async () => {
+      const runAggregate = vi.fn(async () => undefined);
+      const runAction = vi.fn(async () => undefined);
+      const rows = [{ id: 'r1' }, { id: 'r2' }, { id: 'r3' }];
+      const { result } = renderHook(() =>
+        useBulkExecutor({ resource: 'device', dataSource: ds(), runAction, runAggregate }));
+
+      await act(async () => {
+        await result.current.run(agg(), rows, { format: 'png' });
+      });
+
+      expect(runAggregate).toHaveBeenCalledTimes(1);
+      const [defArg, rowsArg, paramsArg] = runAggregate.mock.calls[0] as unknown as [
+        BulkActionDef, Array<Record<string, unknown>>, Record<string, unknown>,
+      ];
+      expect(defArg.name).toBe('generate_qr_zip');
+      expect(rowsArg.map(r => r.id)).toEqual(['r1', 'r2', 'r3']);
+      expect(paramsArg).toEqual({ format: 'png' });
+      // The per-record dispatcher must never fire in aggregate mode.
+      expect(runAction).not.toHaveBeenCalled();
+      expect(result.current.result).toMatchObject({ total: 3, succeeded: 3, failed: 0 });
+    });
+
+    it('a single-row selection still goes through the ONE aggregate call, never per-record', async () => {
+      const runAggregate = vi.fn(async () => undefined);
+      const runAction = vi.fn(async () => undefined);
+      const { result } = renderHook(() =>
+        useBulkExecutor({ resource: 'device', dataSource: ds(), runAction, runAggregate }));
+
+      await act(async () => {
+        await result.current.run(agg(), [{ id: 'only' }], {});
+      });
+
+      expect(runAggregate).toHaveBeenCalledTimes(1);
+      expect(runAction).not.toHaveBeenCalled();
+      expect(result.current.result?.succeeded).toBe(1);
+    });
+
+    it('ignores batchSize — 5 rows with batchSize 2 is still one call', async () => {
+      const runAggregate = vi.fn(async () => undefined);
+      const rows = [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }];
+      const { result } = renderHook(() =>
+        useBulkExecutor({ resource: 'device', dataSource: ds(), runAggregate }));
+
+      await act(async () => {
+        await result.current.run(agg({ batchSize: 2 }), rows, {});
+      });
+
+      expect(runAggregate).toHaveBeenCalledTimes(1);
+      expect((runAggregate.mock.calls[0][1] as unknown[]).length).toBe(5);
+      expect(result.current.result?.succeeded).toBe(5);
+    });
+
+    it('attributes a failed aggregate call to every id with the real error — no per-record re-dispatch', async () => {
+      const runAggregate = vi.fn(async () => {
+        throw new Error('zip generation failed');
+      });
+      const runAction = vi.fn(async () => undefined);
+      const { result } = renderHook(() =>
+        useBulkExecutor({ resource: 'device', dataSource: ds(), runAction, runAggregate }));
+
+      await act(async () => {
+        await result.current.run(agg(), [{ id: 'a' }, { id: 'b' }], {});
+      });
+
+      expect(runAggregate).toHaveBeenCalledTimes(1);
+      expect(runAction).not.toHaveBeenCalled();
+      expect(result.current.result?.succeeded).toBe(0);
+      expect(result.current.result?.failed).toBe(2);
+      expect(result.current.result?.errors).toEqual([
+        { id: 'a', error: 'zip generation failed' },
+        { id: 'b', error: 'zip generation failed' },
+      ]);
+    });
+
+    it('fails loudly when no runAggregate is wired instead of degrading to per-record fan-out', async () => {
+      const runAction = vi.fn(async () => undefined);
+      const { result } = renderHook(() =>
+        useBulkExecutor({ resource: 'device', dataSource: ds(), runAction }));
+
+      await act(async () => {
+        await result.current.run(agg(), [{ id: 'a' }, { id: 'b' }], {});
+      });
+
+      expect(runAction).not.toHaveBeenCalled();
+      expect(result.current.result?.failed).toBe(2);
+      expect(result.current.result?.errors[0].error).toContain('no dispatcher wired');
+    });
+
+    it('retry() refuses aggregate rows — the whole-run re-run is the retry', async () => {
+      const runAggregate = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      const { result } = renderHook(() =>
+        useBulkExecutor({ resource: 'device', dataSource: ds(), runAggregate }));
+
+      await act(async () => {
+        await result.current.run(agg(), [{ id: 'a' }], {});
+      });
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.retry('a');
+      });
+      expect(ok).toBe(false);
+      expect(runAggregate).toHaveBeenCalledTimes(1);
+    });
+
+    it('a def WITHOUT execution: aggregate keeps per-record dispatch even when runAggregate is wired', async () => {
+      const runAggregate = vi.fn(async () => undefined);
+      const runAction = vi.fn(async () => undefined);
+      const rows = [{ id: '1' }, { id: '2' }];
+      const { result } = renderHook(() =>
+        useBulkExecutor({ resource: 'device', dataSource: ds(), runAction, runAggregate }));
+
+      await act(async () => {
+        await result.current.run(agg({ execution: undefined }), rows, {});
+      });
+
+      // Mode selection lives on the def, not on which capabilities are wired.
+      expect(runAggregate).not.toHaveBeenCalled();
+      expect(runAction).toHaveBeenCalledTimes(2);
+      expect(result.current.result?.succeeded).toBe(2);
+    });
+  });
 });

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -77,6 +77,13 @@ export interface BulkActionDialogProps {
    */
   runAction?: BulkExecutorOptions['runAction'];
   /**
+   * Whole-selection dispatcher for a def with `execution: 'aggregate'`
+   * (objectui#3139) — see {@link BulkExecutorOptions.runAggregate}. Same
+   * params/confirm collection as `runAction`, but the executor calls this
+   * exactly once with every eligible row instead of once per record.
+   */
+  runAggregate?: BulkExecutorOptions['runAggregate'];
+  /**
    * Selected records the def's `visible` predicate excluded (objectui#3067).
    * `rows` already has them removed; this is what lets the confirm step say
    * the run covers fewer records than the user picked, instead of quietly
@@ -107,6 +114,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   labelKey = 'name',
   objectFields,
   runAction,
+  runAggregate,
   skippedCount = 0,
 }) => {
   const { t } = useObjectTranslation();
@@ -139,7 +147,7 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
   // confirm step — the params step needs no preloaded option list because the
   // picker widgets fetch their own candidates (#3064).
   const [lookupLabels, setLookupLabels] = useState<Record<string, Record<string, string>>>({});
-  const { run, undo, retry, progress, result, reset } = useBulkExecutor({ resource, dataSource, objectFields, runAction });
+  const { run, undo, retry, progress, result, reset } = useBulkExecutor({ resource, dataSource, objectFields, runAction, runAggregate });
   const [retrying, setRetrying] = useState<string | null>(null);
   const [undoing, setUndoing] = useState(false);
   const [undoneAt, setUndoneAt] = useState<number | null>(null);
@@ -466,8 +474,14 @@ export const BulkActionDialog: React.FC<BulkActionDialogProps> = ({
                         </div>
                         {/* A plain `custom` callout has nothing to re-run, but
                             a PROMOTED def (#3002) re-dispatches its object
-                            action for that one record — same as update/delete. */}
-                        {(def.operation !== 'custom' || !!def.actionDef) && (
+                            action for that one record — same as update/delete.
+                            An aggregate def (#3139) has no per-row slice to
+                            re-attempt: the whole-run re-run is the retry (a
+                            total failure keeps the selection for exactly that),
+                            so the button is hidden — the executor's retry()
+                            refuses it anyway. */}
+                        {(def.operation !== 'custom' || !!def.actionDef)
+                          && def.execution !== 'aggregate' && (
                           <Button
                             variant="ghost"
                             size="sm"

--- a/packages/plugin-grid/src/hooks/useBulkExecutor.ts
+++ b/packages/plugin-grid/src/hooks/useBulkExecutor.ts
@@ -104,6 +104,31 @@ export interface BulkExecutorOptions {
     row: Record<string, unknown>,
     params: Record<string, unknown>,
   ) => Promise<unknown>;
+  /**
+   * Whole-selection dispatcher for a promoted def that opted into
+   * `execution: 'aggregate'` (objectui#3139) — the "take every id at once"
+   * variant the per-record contract above cannot express. Called EXACTLY ONCE
+   * per run with every eligible row; the grid's implementation injects
+   * `params._selectedIds` and dispatches the action a single time, so the
+   * server can produce one aggregate artifact (zip, merged PDF…) for the
+   * whole selection.
+   *
+   * MUST reject on failure, like `runAction`: the executor treats the one
+   * call as all-or-nothing and attributes the rejection reason to every
+   * selected id in the result, so resolving on a failed action would report
+   * the entire selection as succeeded.
+   *
+   * When absent, an `execution: 'aggregate'` def FAILS LOUDLY rather than
+   * quietly degrading to per-record fan-out — N dispatches against an
+   * endpoint written for one `_selectedIds` call would be N misfires, not a
+   * fallback. Wiring this without the def opting in changes nothing: the
+   * def's own `execution` key selects the mode, never the capability.
+   */
+  runAggregate?: (
+    def: BulkActionDef,
+    rows: Array<Record<string, unknown>>,
+    params: Record<string, unknown>,
+  ) => Promise<unknown>;
 }
 
 /**
@@ -125,8 +150,14 @@ export interface BulkExecutorOptions {
  *   throws, so users still get actionable error detail on hard failures.
  *   Soft (`succeeded < total`) shortfalls surface as a single aggregate
  *   error entry per batch — see comments inline.
+ *
+ * A `custom` def with `execution: 'aggregate'` (objectui#3139) rides the same
+ * bulk-first decision tree, but its "bulk call" is ONE `runAggregate` dispatch
+ * for the entire selection (never chunked, all-or-nothing) and its per-row
+ * "fallback" only re-throws the captured error for per-id attribution — it
+ * never fans out per-record dispatches against a single-call endpoint.
  */
-export function useBulkExecutor({ resource, dataSource, objectFields, runAction }: BulkExecutorOptions) {
+export function useBulkExecutor({ resource, dataSource, objectFields, runAction, runAggregate }: BulkExecutorOptions) {
   const [progress, setProgress] = useState<BulkProgress>({
     total: 0,
     done: 0,
@@ -158,7 +189,16 @@ export function useBulkExecutor({ resource, dataSource, objectFields, runAction 
       params: Record<string, unknown>,
     ): Promise<BulkResult> => {
       const total = rows.length;
-      const batchSize = Math.max(1, def.batchSize ?? 200);
+      // An aggregate custom def (objectui#3139) is ONE call for the whole
+      // selection by contract, so `batchSize` deliberately does not apply —
+      // chunking would turn "one zip for N devices" into ceil(N/batchSize)
+      // zips. `maxRecords` still gates the run (the dialog blocks over-limit
+      // selections before this executes).
+      const isAggregate =
+        def.operation === 'custom' && def.execution === 'aggregate' && !!def.actionDef;
+      const batchSize = isAggregate
+        ? Math.max(1, rows.length)
+        : Math.max(1, def.batchSize ?? 200);
       const errors: BulkRowError[] = [];
       let succeeded = 0;
       let failed = 0;
@@ -207,25 +247,46 @@ export function useBulkExecutor({ resource, dataSource, objectFields, runAction 
           continue;
         }
 
+        // Row lookup for the runner paths, which need the whole record (not
+        // just its id) to attach as `_rowRecord` / hand to the aggregate call.
+        const rowById = new Map<string, Record<string, unknown>>();
+        for (const row of batch) {
+          const id = row.id != null ? String(row.id) : '';
+          if (id) rowById.set(id, row);
+        }
+
         // Decide whether the adapter can collapse this whole batch into 1
-        // call. Single-row batches skip bulk (no win, just overhead).
-        const allowBulk = validIds.length >= 2;
+        // call. Single-row batches skip bulk (no win, just overhead) — EXCEPT
+        // in aggregate mode, where even one selected row must go through the
+        // single aggregate call: the target endpoint reads `_selectedIds`,
+        // which the per-record dispatch shape never carries.
+        const allowBulk = validIds.length >= 2 || isAggregate;
         let bulkCall: ((ids: string[]) => Promise<number>) | undefined;
         let label = 'bulk';
-        if (def.operation === 'update' && typeof dataSource.bulkUpdate === 'function') {
+        // The one real error from a failed aggregate call. The perRow
+        // "fallback" below re-throws it per id for attribution — it must
+        // never re-dispatch (see the `custom` case).
+        let aggregateError: unknown;
+        if (isAggregate && runAggregate) {
+          bulkCall = async (ids) => {
+            try {
+              await runAggregate(def, ids.map((id) => rowById.get(id) ?? { id }), { ...params });
+              // All-or-nothing: the single call resolving means it covered
+              // every id. Partial success has no envelope on this path — a
+              // server that cannot cover the whole selection must reject.
+              return ids.length;
+            } catch (e) {
+              aggregateError = e;
+              throw e;
+            }
+          };
+          label = 'aggregate action';
+        } else if (def.operation === 'update' && typeof dataSource.bulkUpdate === 'function') {
           bulkCall = (ids) => dataSource.bulkUpdate!(resource, ids, buildPatch());
           label = 'bulk update';
         } else if (def.operation === 'delete' && typeof dataSource.bulkDelete === 'function') {
           bulkCall = (ids) => dataSource.bulkDelete!(resource, ids);
           label = 'bulk delete';
-        }
-
-        // Row lookup for the runner path, which needs the whole record (not
-        // just its id) to attach as `_rowRecord`.
-        const rowById = new Map<string, Record<string, unknown>>();
-        for (const row of batch) {
-          const id = row.id != null ? String(row.id) : '';
-          if (id) rowById.set(id, row);
         }
 
         const perRow = (id: string): Promise<unknown> => {
@@ -235,6 +296,22 @@ export function useBulkExecutor({ resource, dataSource, objectFields, runAction 
             case 'update':
               return dataSource.update(resource, id, buildPatch());
             case 'custom':
+              // Aggregate mode never fans out: the ONE bulkCall above either
+              // covered every id or failed as a whole. Reaching here means it
+              // threw (or `runAggregate` was never wired) — attribute the real
+              // error to each id rather than re-dispatching N per-record calls
+              // against an endpoint written for one `_selectedIds` call.
+              if (isAggregate) {
+                return Promise.reject(
+                  aggregateError instanceof Error
+                    ? aggregateError
+                    : new Error(
+                        aggregateError !== undefined
+                          ? String(aggregateError)
+                          : `Aggregate action ${def.name} has no dispatcher wired`,
+                      ),
+                );
+              }
               // A PROMOTED def (`actionDef` present) runs its object action once
               // per record through the injected runner. Without one, this is
               // the historical callout shape — no mutation, caller wires
@@ -274,7 +351,7 @@ export function useBulkExecutor({ resource, dataSource, objectFields, runAction 
       }
       return finalResult;
     },
-    [resource, dataSource, objectFields, runAction],
+    [resource, dataSource, objectFields, runAction, runAggregate],
   );
 
   /**
@@ -340,6 +417,10 @@ export function useBulkExecutor({ resource, dataSource, objectFields, runAction 
             await dataSource.update(resource, rowId, patch);
             break;
           case 'custom':
+            // An aggregate run is a single all-or-nothing call — there is no
+            // per-row slice to re-attempt. Re-running the whole action is the
+            // retry (a total failure keeps the selection for exactly that).
+            if (last.def.execution === 'aggregate') return false;
             // A promoted def re-dispatches the action for real; a plain callout
             // def has nothing to retry, so it reports success unchanged.
             if (!last.def.actionDef || !runAction) return true;

--- a/packages/plugin-grid/src/resolveBulkActions.ts
+++ b/packages/plugin-grid/src/resolveBulkActions.ts
@@ -37,12 +37,17 @@
  *
  * ## Two vocabularies reach the selection bar
  *
- *  1. `bulkActionDefs` — rich defs authored inline in the view JSON. Untouched
- *     here; they own their names and win every collision.
+ *  1. `bulkActionDefs` — rich defs authored inline in the view JSON. Left
+ *     as-authored, with ONE narrowly-scoped exception: a def carrying
+ *     `execution: 'aggregate'` and no inline `actionDef` resolves its `name`
+ *     against `objectDef.actions` and gets the matched action attached (see
+ *     below). They own their names and win every collision either way.
  *  2. `bulkActions: string[]` — bare action names, resolved against
  *     `objectDef.actions` and PROMOTED to that def, so they carry the action's
  *     label, icon, `visible` predicate, confirm text and params instead of a
- *     bare humanized name.
+ *     bare humanized name. The bare-string form always promotes to the
+ *     per-record dispatch — it has nowhere to carry an `execution` flag, so
+ *     aggregate mode (objectui#3139) requires the authored-def form above.
  *
  * A promoted def carries `operation: 'custom'` plus the source action under
  * {@link BulkActionDef.actionDef}: it is NOT a data-plane mass update, it is
@@ -169,9 +174,38 @@ export function resolveBulkActions(opts: {
   /** Names that matched no declared action; dispatched by name. */
   unresolved: string[];
 } {
-  const authored = Array.isArray(opts.bulkActionDefs) ? opts.bulkActionDefs : [];
+  const rawAuthored = Array.isArray(opts.bulkActionDefs) ? opts.bulkActionDefs : [];
   const names = Array.isArray(opts.bulkActions) ? opts.bulkActions : [];
   const objectActions = Array.isArray(opts.objectActions) ? opts.objectActions : [];
+
+  // [#3139] An authored def opting into the aggregate dispatch usually just
+  // NAMES a declared object action (`{ name, operation: 'custom', execution:
+  // 'aggregate' }`) instead of duplicating it inline. Resolve that name and
+  // attach the action as `actionDef` — merged so authored keys win — because
+  // `useBulkExecutor` dispatches nothing without one. Scoping the merge to an
+  // EXPLICIT `execution: 'aggregate'` (with no inline `actionDef`) is what
+  // keeps it safe: a plain authored `custom` def that happens to share a name
+  // with an object action keeps its historical no-op/callout meaning. The
+  // promoted `batchSize` is dropped — an aggregate run is one call by
+  // contract, never chunked.
+  const wantsAggregateResolve = (def: BulkActionDef | undefined | null): boolean =>
+    !!def
+    && def.execution === 'aggregate'
+    && def.operation === 'custom'
+    && !def.actionDef
+    && typeof def.name === 'string'
+    && def.name !== '';
+  // Mapped only when at least one def qualifies, so the common case keeps the
+  // authored array's referential identity (see the `defs` return doc).
+  const authored = rawAuthored.some(wantsAggregateResolve)
+    ? rawAuthored.map((def) => {
+        if (!wantsAggregateResolve(def)) return def;
+        const match = objectActions.find(a => a?.name === def.name);
+        if (!match) return def;
+        const { batchSize: _batchSize, ...promoted } = toBulkActionDef(match, opts.localizeLabel);
+        return { ...promoted, ...def };
+      })
+    : rawAuthored;
 
   const claimed = new Set(
     authored.map(d => d?.name).filter((n): n is string => typeof n === 'string' && n !== ''),

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -298,7 +298,9 @@ export interface BulkActionParam {
  * calls per batch. `custom` defers entirely to `onComplete` event handlers and
  * is intended for callouts (notify/export/...) that don't mutate records —
  * UNLESS the def carries {@link BulkActionDef.actionDef}, in which case the
- * executor dispatches that action through the action runner once per record.
+ * executor dispatches that action through the action runner: once per record by
+ * default, or once for the whole selection when the def opts into
+ * {@link BulkActionDef.execution} `'aggregate'` (objectui#3139).
  */
 export type BulkActionOperation = 'update' | 'delete' | 'custom';
 
@@ -357,15 +359,37 @@ export interface BulkActionDef {
   /** Batch size for the executor loop (default: 200). */
   batchSize?: number;
   /**
+   * How a `custom` def with {@link BulkActionDef.actionDef} dispatches over the
+   * selection (objectui#3139).
+   *
+   * - `'perRecord'` (default, and the only pre-17.1 semantics): one runner
+   *   dispatch per selected record, with the row attached as `_rowRecord`.
+   * - `'aggregate'`: ONE dispatch for the entire selection. The executor
+   *   injects `params._selectedIds: string[]` (every selected record id) and
+   *   publishes the full records as `context.selectedRecords`, so the server
+   *   can produce a single aggregate artifact (zip of QR codes, merged PDF,
+   *   batch print job…). Result semantics are all-or-nothing: the one call
+   *   covers the whole selection, so per-row retry is unavailable — a total
+   *   failure keeps the selection for a whole-run re-run.
+   *
+   * Ignored for `operation: 'update' | 'delete'` (their bulk fast-path already
+   * aggregates per batch) and for a `custom` def without `actionDef` (nothing
+   * to dispatch). In aggregate mode `batchSize` does not apply — the whole
+   * selection is one call; `maxRecords` still gates it.
+   */
+  execution?: 'perRecord' | 'aggregate';
+  /**
    * Source object `ActionDef` when this entry was PROMOTED from a
    * `bulkActions: ['<name>']` entry resolved against `objectDef.actions`
-   * (objectui#3002).
+   * (objectui#3002) — or attached by `resolveBulkActions` when an authored def
+   * with `execution: 'aggregate'` names a declared object action (#3139).
    *
    * Presence of this key changes what `operation: 'custom'` means: instead of
    * a per-row no-op, the executor dispatches THIS action through the action
    * runner once per selected record, with the row attached as `_rowRecord` so
    * `recordIdParam` injection works exactly as it does for a `list_item` row
-   * action. Params and confirmation are collected once by the BulkActionDialog
+   * action — or once for the whole selection under `execution: 'aggregate'`.
+   * Params and confirmation are collected once by the BulkActionDialog
    * and handed to the runner as values, so it never re-prompts per record.
    */
   actionDef?: Record<string, unknown>;


### PR DESCRIPTION
Closes #3139.

## 问题

批量选择条的 `bulkActionDefs` 中,`operation: 'custom'` 只有**逐行**语义:runner 对每个选中记录各调一次 `runAction(actionDef, row, params)`(注入 `_rowRecord`)。「勾选 N 行 → **一次**调用拿到全部选中 id → 服务端产出单一聚合产物」(多台设备二维码打包成一个 zip、批量打印、合并导出 PDF)无法表达。

现状还很不对称:`operation: 'update'/'delete'` 早有聚合通道(`executeBulkBatch` 的 `bulkCall`,一次带全部 ids),未解析的字符串批量动作也已有一条 `executeAction({ type, params: { records } })` 单次全量通道 —— 把动作**正确**声明为对象动作反而丢失聚合语义。

## 方案

`BulkActionDef` 新增 `execution?: 'perRecord' | 'aggregate'`(缺省 `'perRecord'`,存量视图零影响)。作者书写形态就是命名一个已声明的对象动作:

```ts
bulkActionDefs: [{ name: 'generate_qr_zip', operation: 'custom', execution: 'aggregate' }]
```

聚合模式下 runner **恰好调用一次**,注入 `params._selectedIds: string[]`,整记录走已类型化的 `context.selectedRecords` 通道(5000 行上限时 POST body 只带 ids,不背整记录)。能力放在**视图侧 def** 而非 `ActionSchema` —— spec 17 的 `action.bulkEnabled` 墓碑明示多选工具栏只由视图 `bulkActions`/`bulkActionDefs` 驱动,本方案不重开该退役决定,也不需要新的服务端路由。

## 改动

- **executor**(`useBulkExecutor.ts`):聚合调用复用 `executeBulkBatch` 现有的 `bulkCall` 槽位 —— `bulkFastPath.ts` **一字未改**。整批一次调用(忽略 `batchSize`,`maxRecords` 仍生效),单行选择也走聚合(服务端契约不同)。失败为 all-or-nothing:真实错误归因到每个 id 供结果面板/错误 CSV 使用,`perRow` 分支**只重抛不重放** —— 绝不对单次调用契约的端点扇出 N 次;未接线 dispatcher 时响亮报错而非静默降级为逐行。
- **grid**(`ObjectGrid.tsx`):新增 `runBulkActionAggregate`,与 `runBulkActionRecord` 共用剥离 helper(防两个分发器漂移)。聚合模式**保留** `resultDialog`(逐行「N 个弹窗阻塞」的理由不成立,一次性揭示下载链接正是该场景)。
- **dialog**:透传 `runAggregate`;逐行 Retry 对聚合隐藏(整批失败保留选中集,重跑动作即重试)。
- **resolver**(`resolveBulkActions.ts`):仅当 def **显式** `execution: 'aggregate'` 且无内联 `actionDef` 时才解析同名对象动作并附上(authored 键胜出,丢弃逐行并发上限 `batchSize: 25`)。普通 custom def 与对象动作同名时保持历史 no-op 语义(有回归守卫)。
- **console runtime**:`serverActionHandler` 识别 `_selectedIds`,跳过「select exactly one row」多选拦截、不合成 `recordId`(服务端读 id 数组)。flow 动作维持拦截 —— flow 只有单 `recordId` 输入变量,多选歧义。
- **插值**:`${ctx.selection.ids}` / `${ctx.selection.count}`(逗号拼接,沿用现有 `String(array)` 行为)—— issue 建议方案 3 的低成本切片,普通 `list_toolbar` url/api 动作也能拿到当前选中集;聚合模式下 `${param._selectedIds}` 天然可用。

配套的服务端契约(`_selectedIds` 进入 ADR-0104 参数白名单 + spec describe + showcase specimen)在 objectstack-ai/objectstack#4461。

## 防 AI 犯错措施

- 聚合分支留在现有 `executeBulkBatch` 决策树内,不开并行代码路径。
- **两种语义的 pin 测试并排**:现有「issues one request per selected record」pin **未改动**,新增「恰好一次 + 全部 id」pin 紧邻其后。
- `execution` 在类型、executor 分支、resolver 合并、两个分发器四处都写了决策注释。
- demo(`demo/bulk-actions.tsx`)双语义并示:Mark Done 每行一行日志,Export Zip 一行带 `[t1,t2,t3]`。

## 测试

新增覆盖:恰好一次调用带全部行与参数;单行选择仍走聚合;`batchSize: 2` 对 5 行仍一次调用;失败 → N 条带真实错误的 per-id 记录且零次逐行分发;未接线 → 响亮失败;`retry()` 返回 false;`execution` 缺省时即便接线了 `runAggregate` 仍走逐行(模式由 def 决定,不由能力决定);resolver 合并的四种边界;`${ctx.selection.ids}` 空/非空;console 多选守卫放行。

验证:plugin-grid 全量 **409** 测试通过、core actions **211** 通过、app-shell console runtime 套件通过;lint 0 error;types/core/plugin-grid/app-shell 构建通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9aiswZBzoVYsyLKRuGByE