### PR TITLE
fix(app-shell): datasource preview 不再报告读副本数量（objectstack#4468 配套）

### DIFF
--- a/.changeset/datasource-preview-drop-read-replicas.md
+++ b/.changeset/datasource-preview-drop-read-replicas.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Datasource preview stops reporting read replicas
+
+`DatasourcePreview` rendered a "2 read replicas" pill from
+`datasource.readReplicas`. That key is retired in `@objectstack/spec` 17
+(objectstack#4468): nothing in the platform ever opened a replica connection —
+no driver reads the key and no query path splits reads from writes — so the
+pill confirmed a configuration that did not exist.
+
+It is worth being precise about what the pill did wrong, because a preview
+panel echoing the draft back is normally harmless. This one did not echo, it
+concluded: an author who configured replicas, saved, and saw the pill light up
+got the platform telling them it had understood. It was the only surface in
+either repo that acknowledged the key at all, which made it the whole of the
+evidence that the feature worked. `packages/spec/liveness/README.md` has the
+standing rule — an authoring or preview renderer is never a runtime consumer —
+and a 2026-06 sweep that classified 13 properties on preview-renderer evidence
+alone was later found wrong on 10 of them.
+
+Read-replica routing does not exist yet; it is tracked as a feature request
+rather than reflected in the UI as though it shipped.

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.tsx
@@ -15,7 +15,15 @@
  *     verbatim; nested objects render as their key count.
  *   • Pool, SSL, retry, health-check pills derived from optional
  *     sibling blocks.
- *   • Read-replica count and capabilities chip strip.
+ *   • Capabilities chip strip.
+ *
+ * A read-replica count pill used to sit in that strip. It is gone with
+ * `datasource.readReplicas` itself (objectstack#4468): nothing in the
+ * platform ever opened a replica connection, so the pill reported a
+ * configuration that did not exist — and, being the only surface that
+ * acknowledged the key at all, it was the strongest signal an author had
+ * that it worked. A preview echoes what was typed; it can never stand in
+ * for a runtime consumer (`packages/spec/liveness/README.md`).
  *
  * The preview never attempts a live "test connection" — it runs
  * inside the editor sandbox and must remain side-effect free.
@@ -24,7 +32,6 @@
 import * as React from 'react';
 import {
   Activity,
-  Copy,
   Database,
   HardDrive,
   Lock,
@@ -70,7 +77,6 @@ export function DatasourcePreview({ name, draft }: MetadataPreviewProps) {
   const ssl = d.ssl as Record<string, unknown> | boolean | undefined;
   const retryPolicy = d.retryPolicy as Record<string, unknown> | undefined;
   const healthCheck = d.healthCheck as Record<string, unknown> | undefined;
-  const readReplicas = Array.isArray(d.readReplicas) ? d.readReplicas : [];
   const capabilities = Array.isArray(d.capabilities) ? (d.capabilities as string[]) : [];
 
   // External Datasource Federation (ADR-0015): a non-'managed' schemaMode
@@ -113,9 +119,6 @@ export function DatasourcePreview({ name, draft }: MetadataPreviewProps) {
                   </span>
                   <Pill icon={Power} label={active ? 'Active' : 'Disabled'} tone={active ? 'green' : 'gray'} />
                   {isDefault && <Pill icon={Star} label="default" tone="amber" />}
-                  {readReplicas.length > 0 && (
-                    <Pill icon={Copy} label={`${readReplicas.length} read replica${readReplicas.length === 1 ? '' : 's'}`} />
-                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
配套 objectstack-ai/objectstack#4481（issue objectstack-ai/objectstack#4468）。

## 改了什么

`DatasourcePreview` 从 `datasource.readReplicas` 渲染一枚 "2 read replicas" 的 pill。这个 key 在 `@objectstack/spec` 17 里被退休了 —— 平台里没有任何东西打开过副本连接：没有驱动读这个 key，也没有任何查询路径区分读和写。

删除：`readReplicas` 常量、那枚 Pill、以及随之不再使用的 `Copy` 图标 import。文件头的 feature 列表相应更新，并留下一句说明去向。

## 为什么这不是"顺手清理"

preview 面板把草稿回显出来通常是无害的，那正是它的用途。这一枚不是回显，是**结论** —— "2 read replicas"。作者配好副本、保存、看到 pill 亮起，得到的信号是平台确认它理解了配置。

而它是**两个仓库里唯一承认这个 key 存在的地方**，所以它就是"这个功能能用"的全部证据。

`packages/spec/liveness/README.md` 里有一条常设规则专门讲这个：authoring / preview renderer 永远不算 runtime consumer。2026-06 那次仅凭 preview renderer 就把 13 个属性定性为 `live` 的扫描，复核后 **10 个是错的**。这枚 pill 是同一类错误的下游产物。

## 验证

- `npx eslint packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.tsx` — clean（确认没有留下未使用的 import）
- 该文件没有测试覆盖，改动是纯删除：一个未再引用的常量、一段 JSX、一个 import。无类型面变化

## 合并顺序

两边可以独立合并，先后都安全 —— spec 的删除不会让这段代码报错（读的是 `Record<string, unknown>` 上的可选 key），这段代码的删除也不依赖 spec 的版本。但**两边都合完之前**会存在一个中间态：spec 已经拒收 `readReplicas`，而 UI 还在数副本数量。建议贴近合并。

## 后续

读副本路由本身立在 objectstack-ai/objectstack#4479（从查询路径的读写判定开始，不是从加字段开始）。UI 侧等那个功能真正存在时再重新出现，而不是继续替一个不存在的机制作证。

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsgTqRF58HsQYKLsrZ5pQY)_