### PR TITLE
fix(actions): one placement rule for `locations` — declare it or it renders nowhere (#3142)

### DIFF
--- a/.changeset/action-locations-one-rule.md
+++ b/.changeset/action-locations-one-rule.md
@@ -1,0 +1,42 @@
+---
+"@object-ui/types": minor
+"@object-ui/components": minor
+"@object-ui/app-shell": minor
+---
+
+One placement rule for action `locations` (objectui#3142).
+
+**Breaking for metadata**: an action that declares no `locations` (missing key
+or `[]`) no longer renders in a located surface. FROM: omitting `locations`
+made an action appear on the list toolbar, the record header, and every
+metadata-admin toolbar. TO: declare where it belongs —
+`locations: ['record_header']` for the record header, `['list_toolbar']` for
+the list toolbar, and so on. Nothing else changes; actions that already
+declare a location are untouched.
+
+Four renderers each answered "where does an action with no `locations` go?"
+differently — `action:bar` and metadata-admin showed it EVERYWHERE,
+`page:header` showed it on the header, `action:group` showed it for
+`undefined` but hid it for `[]` — while `ActionEngine`, `RecordDetailView`,
+`DeclaredActionsBar`, the related-list bridge and the environment toolbar all
+showed it NOWHERE. The same action therefore appeared or vanished depending on
+which component happened to draw it. All eight now go through one exported
+predicate, `actionRendersAt(action, location)` from `@object-ui/types`: an
+action renders at a location only if it declares that location.
+
+The strict reading is the platform's own — ADR-0078 lists "an `action` with no
+`locations`" as a verified inert shape, and the detail-page synthesizer already
+documented "must include `locations: ['record_header']` to render". The
+leniency contradicted both, and it is what let an aggregate-only bulk action
+(objectui#3139) — one with no single-record placement by construction — mint a
+list-toolbar button whose dispatch could only fail.
+
+Two placements are declared elsewhere and need no `locations`, both unchanged:
+host-injected chrome in the `systemActions` / `headerSystemActions` slot (now
+consistently exempt on `page:header` too, where it used to be filtered), and an
+action named in a view's `bulkActions` / `bulkActionDefs`.
+
+Authoring side: Studio seeds `locations: ['record_header']` on a new action
+instead of minting one that renders nowhere, and the action inspector says so
+when no placement is ticked. The `ActionSchema.locations` JSDoc claimed a
+`['record_header']` default that no renderer ever implemented — corrected.

--- a/content/docs/guide/slotted-pages.md
+++ b/content/docs/guide/slotted-pages.md
@@ -103,6 +103,35 @@ Delete) as a button row. Up to **`maxVisible`** actions render inline,
 side by side (default **3** on desktop, **`mobileMaxVisible`**, default
 **1**, on mobile); the rest collapse into a `⋯` "More actions" menu.
 
+### Declaring placement
+
+An authored action renders here only if its **`locations`** declares
+`record_header` (inline) or `record_more` (straight into the `⋯` menu).
+There is no default: an action that declares no location renders in **no**
+located surface — not here, not the list toolbar, not the row menu. That
+one rule is shared by every surface that places actions by location
+(`action:bar`, `action:group`, `record:quick_actions`, related lists, the
+metadata-admin toolbars and the action engine), so an action behaves the
+same wherever it is drawn.
+
+```ts
+actions: [
+  { name: 'convert_lead', label: 'Convert', locations: ['record_header'] },
+  { name: 'export_pdf',   label: 'Export',  locations: ['record_more'] },
+]
+```
+
+Two placements come from somewhere other than `locations`, and neither
+needs an entry here:
+
+- **Host chrome** — the Edit / Share / Delete set the host injects is
+  placed by the host, not authored, so it is never location-filtered.
+- **Selection actions** — an action named in a list view's `bulkActions`
+  or `bulkActionDefs` is placed by that declaration. An action that only
+  makes sense over a selection (an aggregate export, say) can therefore
+  declare no `locations` at all and still be reachable from the
+  selection bar.
+
 Which actions claim the inline slots is declared in metadata, using the
 same rules as `action:bar`:
 

--- a/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.test.tsx
@@ -43,6 +43,42 @@ beforeEach(() => {
 });
 
 describe('MetadataTypeActions', () => {
+  // [#3142] These actions come off the server's `/meta/types` feed, and this
+  // component used to carry a byte-identical copy of `action:bar`'s lenient
+  // rule — so a type shipping an action with no `locations` got a button on
+  // BOTH the list toolbar and the record header. Placement is declared now,
+  // like everywhere else. Nothing pinned the lenient branch before, which is
+  // how the two copies drifted from the rest of the repo unnoticed.
+  it('renders only actions that declare the requested location', () => {
+    const { container } = render(
+      <MetadataTypeActions
+        location="record_header"
+        recordId="ds1"
+        entry={{
+          actions: [
+            { name: 'here', label: 'Here', type: 'api', target: '/x', locations: ['record_header'] },
+            { name: 'elsewhere', label: 'Elsewhere', type: 'api', target: '/x', locations: ['list_toolbar'] },
+            { name: 'undeclared', label: 'Undeclared', type: 'api', target: '/x' },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByTitle('Here')).toBeTruthy();
+    expect(screen.queryByTitle('Elsewhere')).toBeNull();
+    expect(screen.queryByTitle('Undeclared')).toBeNull();
+    expect(container.textContent).not.toContain('Undeclared');
+  });
+
+  it('renders nothing when no action declares the requested location', () => {
+    const { container } = render(
+      <MetadataTypeActions
+        location="list_toolbar"
+        entry={{ actions: [{ name: 'undeclared', label: 'Undeclared', type: 'api', target: '/x' }] }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
   it('runs an api action without params directly (no dialog)', async () => {
     render(
       <MetadataTypeActions

--- a/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.tsx
+++ b/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.tsx
@@ -37,7 +37,7 @@ import { Loader2 } from 'lucide-react';
 import { Button } from '@object-ui/components';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import type { ActionParamDef } from '@object-ui/core';
-import { actionRendersAt } from '@object-ui/types';
+import { actionRendersAt, type ActionLocation } from '@object-ui/types';
 import { getIcon } from '../../utils/getIcon';
 import { ActionParamDialog, type ParamDialogState } from '../ActionParamDialog';
 import { ActionResultDialog, type ResultDialogState } from '../ActionResultDialog';
@@ -75,8 +75,12 @@ function interpolateTarget(
 export interface MetadataTypeActionsProps {
   /** The rich type entry whose `actions` to render. */
   entry?: Pick<RichMetadataTypeEntry, 'actions'> | undefined;
-  /** Which chrome slot is asking — actions are filtered by their `locations`. */
-  location: string;
+  /**
+   * Which chrome slot is asking — actions are filtered by their `locations`.
+   * Typed as the spec vocabulary rather than `string` so a typo cannot quietly
+   * match nothing: both call sites pass a literal, so this costs them nothing.
+   */
+  location: ActionLocation;
   /** Current item name, exposed to actions as `${ctx.recordId}`. */
   recordId?: string;
   /** Called after a successful action when `refreshAfter` is set. */

--- a/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.tsx
+++ b/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.tsx
@@ -37,6 +37,7 @@ import { Loader2 } from 'lucide-react';
 import { Button } from '@object-ui/components';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import type { ActionParamDef } from '@object-ui/core';
+import { actionRendersAt } from '@object-ui/types';
 import { getIcon } from '../../utils/getIcon';
 import { ActionParamDialog, type ParamDialogState } from '../ActionParamDialog';
 import { ActionResultDialog, type ResultDialogState } from '../ActionResultDialog';
@@ -93,11 +94,12 @@ export function MetadataTypeActions({ entry, location, recordId, onAfter }: Meta
   const [resultState, setResultState] = React.useState<ResultDialogState>({ open: false });
   const authFetch = React.useMemo(() => createAuthenticatedFetch(), []);
 
+  // Placement is `actionRendersAt`'s call (objectui#3142). These actions come
+  // from the server's `/meta/types` feed, so a type shipping an action with no
+  // `locations` used to get a button on BOTH the list toolbar and the record
+  // header; now it must declare where it belongs, like every other surface.
   const actions = React.useMemo(
-    () =>
-      (entry?.actions ?? []).filter(
-        (a) => !a.locations || a.locations.length === 0 || a.locations.includes(location),
-      ),
+    () => (entry?.actions ?? []).filter((a) => actionRendersAt(a, location)),
     [entry?.actions, location],
   );
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
@@ -406,6 +406,17 @@ export function ActionDefaultInspector({
             <InspectorCheckboxField key={loc.value} label={loc.label} value={locations.includes(loc.value)} onCommit={(v) => toggleLocation(loc.value, v)} disabled={readOnly} />
           ))}
         </div>
+        {/* [#3142] No placement = renders in no located surface. Saying so
+            here is the difference between an author seeing an empty list and
+            an author hunting for a button that was never going to appear.
+            Not an error: a selection-only action is placed by a view's
+            `bulkActions` / `bulkActionDefs` instead, which is legitimate. */}
+        {locations.length === 0 && (
+          <div className="text-[11px] text-destructive">
+            No placement selected — this action will not appear on any record or list surface. Tick a
+            placement above, or place it from a view’s bulk actions.
+          </div>
+        )}
         <div className="grid grid-cols-2 gap-2 pt-1">
           <InspectorSelectField label="Component" value={str('component') || undefined} options={COMPONENT_OPTS} onCommit={(v) => onPatch({ component: v })} disabled={readOnly} />
         </div>

--- a/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
@@ -115,11 +115,19 @@ export function ObjectActionsPanel({
     // the user types into the body (same dead-end class as a fresh validation
     // rule needing a placeholder condition). The user configures the rest
     // (behavior/placement/…) in the form on the right.
+    //
+    // `locations` is seeded for the same reason (objectui#3142): an action
+    // that declares no location renders in no located surface, so an unseeded
+    // skeleton would save clean and then be invisible everywhere — the author
+    // would have no button to click and nothing to tell them why. Placement
+    // stays fully editable in the Placement checkboxes; `record_header` is
+    // just the starting point.
     const fresh: ActionItem = {
       name,
       label: t('engine.studio.actions.newLabel', locale),
       type: 'script',
       objectName,
+      locations: ['record_header'],
       body: { language: 'js', source: 'return { ok: true };' },
     };
     onPatch({ actions: [...actions, fresh] });

--- a/packages/components/src/__tests__/action-bar.test.tsx
+++ b/packages/components/src/__tests__/action-bar.test.tsx
@@ -70,18 +70,30 @@ describe('ActionBar (action:bar)', () => {
       expect(container.textContent).toContain('Both Action');
     });
 
-    it('shows actions without locations when filtering by location', () => {
+    // [#3142] Deliberately INVERTED from "shows actions without locations".
+    // An undeclared placement is not a wildcard: this bar used to show such an
+    // action at every location, while ActionEngine, RecordDetailView,
+    // DeclaredActionsBar and the related-list bridge all showed it at none —
+    // so the same action appeared or vanished with the renderer. `locations`
+    // is the declaration; no declaration, no located placement (ADR-0078 reads
+    // an action with no `locations` as inert for exactly this reason).
+    it('hides an action that declares no locations when filtering by location', () => {
       const { container } = renderComponent({
         type: 'action:bar',
         location: 'record_header',
         actions: [
           { name: 'no_loc', label: 'No Location', type: 'script' },
-          { name: 'has_loc', label: 'Has Location', type: 'script', locations: ['list_toolbar'] },
+          { name: 'empty_loc', label: 'Empty Location', type: 'script', locations: [] },
+          { name: 'other_loc', label: 'Other Location', type: 'script', locations: ['list_toolbar'] },
+          { name: 'here_loc', label: 'Here Location', type: 'script', locations: ['record_header'] },
         ],
       });
-      // Action without locations should show in any location
-      expect(container.textContent).toContain('No Location');
-      expect(container.textContent).not.toContain('Has Location');
+      expect(container.textContent).not.toContain('No Location');
+      // An empty array reads the same as an absent one — the third dialect
+      // (`action:group` hid `[]` but showed `undefined`) is gone too.
+      expect(container.textContent).not.toContain('Empty Location');
+      expect(container.textContent).not.toContain('Other Location');
+      expect(container.textContent).toContain('Here Location');
     });
 
     it('renders all actions when no location filter is set', () => {
@@ -400,8 +412,12 @@ describe('ActionBar (action:bar)', () => {
     const withUser = (user: unknown, props: { actions?: any[]; systemActions?: any[] }) =>
       render(<ActionProvider context={{ user } as any}><Bar {...props} /></ActionProvider>);
 
-    const gated = { name: 'gated', label: 'Bulk Reassign', type: 'api', requiredPermissions: ['manage_users'] };
-    const plain = { name: 'plain', label: 'Export', type: 'api' };
+    // Both fixtures declare the harness's location (#3142): without it the
+    // strict placement filter would drop them before the capability gate ever
+    // ran, and every `not.toContain` below would pass VACUOUSLY — the suite
+    // would keep reporting green while testing nothing.
+    const gated = { name: 'gated', label: 'Bulk Reassign', type: 'api', locations: ['list_toolbar'], requiredPermissions: ['manage_users'] };
+    const plain = { name: 'plain', label: 'Export', type: 'api', locations: ['list_toolbar'] };
 
     it('hides an action whose capability the caller lacks', () => {
       const { container } = withUser({ id: 'u1', systemPermissions: ['setup.access'] }, { actions: [gated, plain] });

--- a/packages/components/src/__tests__/action-group.test.tsx
+++ b/packages/components/src/__tests__/action-group.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `action:group` placement (objectui#3142).
+ *
+ * This renderer carried a THIRD reading of `locations`: `!a.locations ||
+ * a.locations.includes(loc)` — an action with `locations: undefined` showed,
+ * while one with `locations: []` was hidden, for no stated reason. Both now
+ * mean the same thing (no declared placement → not rendered here) because both
+ * go through `actionRendersAt`. Nothing pinned this file's behaviour before,
+ * which is how the third dialect survived.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { renderComponent } from './test-utils';
+
+// Action renderers are loaded by the shared vitest setup (see action-bar.test).
+const renderGroup = (schema: Record<string, unknown>) => renderComponent(schema as never);
+
+describe('action:group — placement', () => {
+  it('renders only actions that declare the requested location', () => {
+    renderGroup({
+      type: 'action:group',
+      location: 'list_toolbar',
+      actions: [
+        { name: 'here', label: 'Here', type: 'script', locations: ['list_toolbar'] },
+        { name: 'elsewhere', label: 'Elsewhere', type: 'script', locations: ['record_header'] },
+      ],
+    });
+    expect(screen.getByText('Here')).toBeInTheDocument();
+    expect(screen.queryByText('Elsewhere')).not.toBeInTheDocument();
+  });
+
+  it('treats an undeclared placement the same as an empty one — both hide', () => {
+    renderGroup({
+      type: 'action:group',
+      location: 'list_toolbar',
+      actions: [
+        { name: 'undeclared', label: 'Undeclared', type: 'script' },
+        { name: 'empty', label: 'Empty', type: 'script', locations: [] },
+        { name: 'here', label: 'Here', type: 'script', locations: ['list_toolbar'] },
+      ],
+    });
+    // Pre-#3142 `Undeclared` rendered and `Empty` did not — same key, two answers.
+    expect(screen.queryByText('Undeclared')).not.toBeInTheDocument();
+    expect(screen.queryByText('Empty')).not.toBeInTheDocument();
+    expect(screen.getByText('Here')).toBeInTheDocument();
+  });
+
+  it('renders every action when the group sets no location filter', () => {
+    renderGroup({
+      type: 'action:group',
+      actions: [
+        { name: 'a', label: 'Alpha', type: 'script' },
+        { name: 'b', label: 'Beta', type: 'script', locations: ['record_header'] },
+      ],
+    });
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -57,7 +57,7 @@ describe('PageHeaderRenderer — actions slot', () => {
       type: 'page:header',
       title: 'Lead',
       actions: [
-        { name: 'convert', label: 'Convert Lead', type: 'flow' },
+        { name: 'convert', locations: ['record_header'], label: 'Convert Lead', type: 'flow' },
       ],
     });
     expect(screen.getByRole('button', { name: /Convert Lead/i })).toBeTruthy();
@@ -69,7 +69,7 @@ describe('PageHeaderRenderer — actions slot', () => {
       properties: {
         title: 'Lead',
         actions: [
-          { name: 'convert', label: 'Convert Lead', type: 'flow' },
+          { name: 'convert', locations: ['record_header'], label: 'Convert Lead', type: 'flow' },
         ],
       },
     });
@@ -88,6 +88,41 @@ describe('PageHeaderRenderer — actions slot', () => {
     expect(screen.queryByRole('button', { name: /List Only/i })).toBeNull();
   });
 
+  // [#3142] An AUTHORED action must declare its placement — the header used to
+  // render an undeclared one, alone among the surfaces that draw the same
+  // record's actions (RecordDetailView pre-filters strictly, and the
+  // synthesizer's own contract already said "must include
+  // `locations: ['record_header']` to render"). Host-injected chrome is
+  // exempt, which the next test pins.
+  it('skips an authored action that declares no placement', () => {
+    renderHeader({
+      type: 'page:header',
+      actions: [
+        { name: 'declared', label: 'Declared Action', locations: ['record_header'] },
+        { name: 'undeclared', label: 'Undeclared Action' },
+        { name: 'empty', label: 'Empty Placement', locations: [] },
+      ],
+    });
+    expect(screen.getByRole('button', { name: /Declared Action/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Undeclared Action/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Empty Placement/i })).toBeNull();
+  });
+
+  it('still renders host system actions that declare no placement — chrome is placed by the host', () => {
+    // The host injects Edit/Share/Delete; nobody authored a `locations` for
+    // them, and `action:bar` has always exempted its `systemActions` slot for
+    // exactly that reason. Before #3142 this renderer filtered them, so the
+    // same `sys_delete` obeyed two rules depending on which drew the header.
+    renderHeader(
+      { type: 'page:header', title: 'Lead' },
+      {
+        record: { id: '1' },
+        headerSystemActions: [{ name: 'sys_delete', label: 'Delete Record' }],
+      },
+    );
+    expect(screen.getByRole('button', { name: /Delete Record/i })).toBeTruthy();
+  });
+
   it('shows action when visible expression matches record', () => {
     renderHeader(
       {
@@ -95,6 +130,7 @@ describe('PageHeaderRenderer — actions slot', () => {
         actions: [
           {
             name: 'convert',
+            locations: ['record_header'],
             label: 'Convert Lead',
             visible: 'record.status == "qualified"',
           },
@@ -112,6 +148,7 @@ describe('PageHeaderRenderer — actions slot', () => {
         actions: [
           {
             name: 'convert',
+            locations: ['record_header'],
             label: 'Convert Lead',
             visible: 'record.status == "qualified"',
           },
@@ -129,6 +166,7 @@ describe('PageHeaderRenderer — actions slot', () => {
         actions: [
           {
             name: 'convert',
+            locations: ['record_header'],
             label: 'Convert Lead',
             visible: { dialect: 'cel', source: 'record.status == "qualified"' },
           },
@@ -143,8 +181,8 @@ describe('PageHeaderRenderer — actions slot', () => {
     renderHeader({
       type: 'page:header',
       actions: [
-        { name: 'shown', label: 'Shown' },
-        { name: 'gone', label: 'Hidden Action', hidden: true },
+        { name: 'shown', locations: ['record_header'], label: 'Shown' },
+        { name: 'gone', locations: ['record_header'], label: 'Hidden Action', hidden: true },
       ],
     });
     expect(screen.getByRole('button', { name: /Shown/i })).toBeTruthy();
@@ -154,7 +192,7 @@ describe('PageHeaderRenderer — actions slot', () => {
   it('emits a toolbar role with aria-label when actions render', () => {
     renderHeader({
       type: 'page:header',
-      actions: [{ name: 'a', label: 'A' }],
+      actions: [{ name: 'a', locations: ['record_header'], label: 'A' }],
     });
     const bar = screen.getByRole('toolbar', { name: /Page header actions/i });
     expect(bar).toBeTruthy();
@@ -173,7 +211,7 @@ describe('PageHeaderRenderer — actions slot', () => {
     const onClick = vi.fn();
     renderHeader({
       type: 'page:header',
-      actions: [{ name: 'a', label: 'Click Me', onClick }],
+      actions: [{ name: 'a', locations: ['record_header'], label: 'Click Me', onClick }],
     });
     fireEvent.click(screen.getByRole('button', { name: /Click Me/i }));
     expect(onClick).toHaveBeenCalledTimes(1);
@@ -183,7 +221,7 @@ describe('PageHeaderRenderer — actions slot', () => {
     renderHeader(
       {
         type: 'page:header',
-        actions: [{ name: 'biz', label: 'Convert Lead' }],
+        actions: [{ name: 'biz', locations: ['record_header'], label: 'Convert Lead' }],
       },
       {
         record: { id: '1' },
@@ -207,7 +245,7 @@ describe('PageHeaderRenderer — actions slot', () => {
     renderHeader(
       {
         type: 'page:header',
-        actions: [{ name: 'sys_edit', label: 'Authored Edit' }],
+        actions: [{ name: 'sys_edit', locations: ['record_header'], label: 'Authored Edit' }],
       },
       {
         record: { id: '1' },
@@ -261,7 +299,7 @@ describe('PageHeaderRenderer — inline-edit session gate (objectui#2572)', () =
     );
   }
 
-  const editCta = { name: 'sys_edit', label: 'Edit', disableDuringInlineEdit: true };
+  const editCta = { name: 'sys_edit', locations: ['record_header'], label: 'Edit', disableDuringInlineEdit: true };
 
   it('disables a `disableDuringInlineEdit` action while the session is active', () => {
     renderWithInlineEdit({ editing: true, actions: [editCta] });
@@ -276,7 +314,7 @@ describe('PageHeaderRenderer — inline-edit session gate (objectui#2572)', () =
   it('leaves unflagged actions alone during the session', () => {
     renderWithInlineEdit({
       editing: true,
-      actions: [editCta, { name: 'convert', label: 'Convert' }],
+      actions: [editCta, { name: 'convert', locations: ['record_header'], label: 'Convert' }],
     });
     expect(screen.getByRole('button', { name: /Edit/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /Convert/i })).toBeEnabled();
@@ -288,9 +326,9 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
     renderHeader({
       type: 'page:header',
       actions: [
-        { name: 'convert', label: 'Convert Lead' },
-        { name: 'assign', label: 'Assign' },
-        { name: 'return', label: 'Return' },
+        { name: 'convert', locations: ['record_header'], label: 'Convert Lead' },
+        { name: 'assign', locations: ['record_header'], label: 'Assign' },
+        { name: 'return', locations: ['record_header'], label: 'Return' },
       ],
     });
     expect(screen.getByRole('button', { name: /Convert Lead/i })).toBeTruthy();
@@ -303,10 +341,10 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
     renderHeader({
       type: 'page:header',
       actions: [
-        { name: 'a', label: 'Action A' },
-        { name: 'b', label: 'Action B' },
-        { name: 'c', label: 'Action C' },
-        { name: 'd', label: 'Action D' },
+        { name: 'a', locations: ['record_header'], label: 'Action A' },
+        { name: 'b', locations: ['record_header'], label: 'Action B' },
+        { name: 'c', locations: ['record_header'], label: 'Action C' },
+        { name: 'd', locations: ['record_header'], label: 'Action D' },
       ],
     });
     expect(screen.getByRole('button', { name: /Action C/i })).toBeTruthy();
@@ -319,8 +357,8 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
       type: 'page:header',
       maxVisible: 1,
       actions: [
-        { name: 'a', label: 'Action A' },
-        { name: 'b', label: 'Action B' },
+        { name: 'a', locations: ['record_header'], label: 'Action A' },
+        { name: 'b', locations: ['record_header'], label: 'Action B' },
       ],
     });
     expect(screen.getByRole('button', { name: /Action A/i })).toBeTruthy();
@@ -334,10 +372,10 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
       properties: {
         maxVisible: 4,
         actions: [
-          { name: 'a', label: 'Action A' },
-          { name: 'b', label: 'Action B' },
-          { name: 'c', label: 'Action C' },
-          { name: 'd', label: 'Action D' },
+          { name: 'a', locations: ['record_header'], label: 'Action A' },
+          { name: 'b', locations: ['record_header'], label: 'Action B' },
+          { name: 'c', locations: ['record_header'], label: 'Action C' },
+          { name: 'd', locations: ['record_header'], label: 'Action D' },
         ],
       },
     });
@@ -350,8 +388,8 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
       type: 'page:header',
       maxVisible: 1,
       actions: [
-        { name: 'a', label: 'Action A' },
-        { name: 'b', label: 'Action B', order: -1 },
+        { name: 'a', locations: ['record_header'], label: 'Action A' },
+        { name: 'b', locations: ['record_header'], label: 'Action B', order: -1 },
       ],
     });
     expect(screen.getByRole('button', { name: /Action B/i })).toBeTruthy();
@@ -363,8 +401,8 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
       type: 'page:header',
       maxVisible: 1,
       actions: [
-        { name: 'a', label: 'Action A' },
-        { name: 'b', label: 'Action B', variant: 'primary' },
+        { name: 'a', locations: ['record_header'], label: 'Action A' },
+        { name: 'b', locations: ['record_header'], label: 'Action B', variant: 'primary' },
       ],
     });
     expect(screen.getByRole('button', { name: /Action B/i })).toBeTruthy();
@@ -375,8 +413,8 @@ describe('PageHeaderRenderer — inline/overflow split (objectui#2361)', () => {
     renderHeader({
       type: 'page:header',
       actions: [
-        { name: 'convert', label: 'Convert Lead' },
-        { name: 'sys_delete', label: 'Delete', component: 'action:menu' },
+        { name: 'convert', locations: ['record_header'], label: 'Convert Lead' },
+        { name: 'sys_delete', locations: ['record_header'], label: 'Delete', component: 'action:menu' },
       ],
     });
     expect(screen.getByRole('button', { name: /Convert Lead/i })).toBeTruthy();
@@ -395,7 +433,7 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
         {
           type: 'page:header',
           actions: [
-            { name: 'convert2358', label: 'Convert Lead' },
+            { name: 'convert2358', locations: ['record_header'], label: 'Convert Lead' },
             { name: 'export_pdf_2358', label: 'Export PDF', locations: ['record_more'] },
           ],
         },
@@ -445,6 +483,7 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
           actions: [
             {
               name: 'admin_gate_2358',
+              locations: ['record_header'],
               label: 'Admin Gate',
               visible: 'os.user.role == "admin"',
             },
@@ -462,6 +501,7 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
           actions: [
             {
               name: 'admin_gate_no_match_2358',
+              locations: ['record_header'],
               label: 'Admin Gate',
               visible: 'os.user.role == "admin"',
             },
@@ -482,6 +522,7 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
           actions: [
             {
               name: 'bad_scope_2358',
+              locations: ['record_header'],
               label: 'Bad Scope',
               visible: 'undeclared_var_2358 == 1',
             },
@@ -512,6 +553,7 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
             actions: [
               {
                 name: 'hidden_field_gate_2358',
+                locations: ['record_header'],
                 label: 'Hidden Field Gate',
                 visible: 'record.secret_level_2358 == "high"',
               },
@@ -542,6 +584,7 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
             actions: [
               {
                 name: 'null_field_gate_2358',
+                locations: ['record_header'],
                 label: 'Null Field Gate',
                 visible: 'record.approver_2358 == "u1"',
               },

--- a/packages/components/src/__tests__/page-header-capability-gate.test.tsx
+++ b/packages/components/src/__tests__/page-header-capability-gate.test.tsx
@@ -38,8 +38,8 @@ const schema = {
   type: 'page:header',
   title: 'Invoice',
   actions: [
-    { name: 'gated', label: 'Set Parallel Reviewers', type: 'api', requiredPermissions: ['ehr_probe_capability'] },
-    { name: 'plain', label: 'Print', type: 'api' },
+    { name: 'gated', locations: ['record_header'], label: 'Set Parallel Reviewers', type: 'api', requiredPermissions: ['ehr_probe_capability'] },
+    { name: 'plain', locations: ['record_header'], label: 'Print', type: 'api' },
   ],
 };
 
@@ -70,7 +70,7 @@ describe('page:header — ADR-0066 D4 capability gate (#3923)', () => {
           schema={{
             type: 'page:header',
             title: 'Invoice',
-            actions: [{ name: 'both', label: 'Needs Both', type: 'api', requiredPermissions: ['a', 'b'] }],
+            actions: [{ name: 'both', locations: ['record_header'], label: 'Needs Both', type: 'api', requiredPermissions: ['a', 'b'] }],
           }}
         />
       </ActionProvider>,

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -34,7 +34,7 @@
 import React, { forwardRef, useMemo } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import type { ActionSchema, ActionLocation, ActionComponent } from '@object-ui/types';
-import { ACTION_LOCATIONS } from '@object-ui/types';
+import { ACTION_LOCATIONS, actionRendersAt } from '@object-ui/types';
 import { useCondition, toPredicateInput, useCapabilityGate } from '@object-ui/react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { cn } from '../../lib/utils';
@@ -131,11 +131,13 @@ const ActionBarRenderer = forwardRef<HTMLDivElement, { schema: ActionBarSchema; 
       // holds rendered as a live button. Same rule as the engine; unknown
       // capabilities fail OPEN (see `useCapabilityGate`).
       const permitted = actions.filter(a => mayInvoke((a as any)?.requiredPermissions));
-      const located = !schema.location
-        ? permitted
-        : permitted.filter(
-            a => !a.locations || a.locations.length === 0 || a.locations.includes(schema.location!),
-          );
+      // Placement is `actionRendersAt`'s call, not ours (objectui#3142): an
+      // action renders here only if it DECLARES this location. This bar used
+      // to show a locationless action at every location, which is how an
+      // aggregate-only bulk action — one with no single-record placement by
+      // construction — ended up as a list-toolbar button that could only fail.
+      // `schema.location` unset still means "no location filtering".
+      const located = permitted.filter(a => actionRendersAt(a, schema.location));
       // Deduplicate by action name — keep first occurrence
       const seen = new Set<string>();
       const deduped = located.filter(a => {

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -19,6 +19,7 @@
 import React, { forwardRef, useCallback, useState } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import type { ActionSchema, ActionGroup, ActionLocation } from '@object-ui/types';
+import { actionRendersAt } from '@object-ui/types';
 import { useAction } from '@object-ui/react';
 import { useCondition, toPredicateInput } from '@object-ui/react';
 import { Button } from '../../ui';
@@ -185,13 +186,10 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
 
     const isVisible = useCondition(toPredicateInput(schema.visible));
 
-    // Filter actions by location if specified
-    let actions = schema.actions || [];
-    if (schema.location) {
-      actions = actions.filter(
-        a => !a.locations || a.locations.includes(schema.location!),
-      );
-    }
+    // Placement is `actionRendersAt`'s call (objectui#3142) — this used to
+    // show an action with `locations: undefined` while hiding one with
+    // `locations: []`, a third reading of the same key.
+    const actions = (schema.actions || []).filter(a => actionRendersAt(a, schema.location));
 
     const handleExecute = useCallback(
       async (action: ActionSchema) => {

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 import { ComponentRegistry, ExpressionEvaluator, getRecordDisplayName } from '@object-ui/core';
+import { actionRendersAt } from '@object-ui/types';
 import { useRecordContext, useAction, useCapabilityGate, usePredicateScope, usePageVariables, useInlineEdit } from '@object-ui/react';
 import { renderChildren, cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
@@ -976,16 +977,6 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       // ActionProvider user, no host predicate scope) — unknown is not denied,
       // and hiding on missing data is the worse regression.
       if (!mayInvoke(a?.requiredPermissions)) return false;
-      // Location filter — when `locations` is declared, require record_header
-      // or record_more (the latter renders in the header's ⋯ overflow menu —
-      // see renderHeaderActions; #2358 trap 2). Missing/empty `locations`
-      // defaults to "show here" since the action is inlined on the header
-      // itself.
-      if (Array.isArray(a?.locations) && a.locations.length > 0) {
-        if (!a.locations.includes('record_header') && !a.locations.includes('record_more')) {
-          return false;
-        }
-      }
       // Boolean / expression visibility — supports both `visible: false`,
       // `visible: 'record.status == "open"'` and the structured shape
       // `visible: { dialect: 'cel', source: '…' }` used by spec authors.
@@ -1030,9 +1021,26 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       }
       return true;
     };
+    // Placement, for AUTHORED actions only (objectui#3142). The header serves
+    // TWO locations — `record_header` (inline) and `record_more` (the ⋯
+    // overflow menu; see renderHeaderActions, #2358 trap 2) — so declaring
+    // either one places the action here. A missing or empty `locations` used
+    // to mean "show here", which made this header the one surface where an
+    // action nobody placed still appeared; `RecordDetailView` pre-filters the
+    // same actions strictly, and the synthesizer's own contract already says
+    // "must include `locations: ['record_header']` to render"
+    // (buildDefaultPageSchema.ts), so the leniency contradicted both.
+    const placedOnHeader = (a: any): boolean =>
+      actionRendersAt(a, 'record_header') || actionRendersAt(a, 'record_more');
     const authored = Array.isArray(rawHeaderActions)
-      ? rawHeaderActions.filter(filterAction)
+      ? rawHeaderActions.filter(a => placedOnHeader(a) && filterAction(a))
       : [];
+    // Host-injected chrome (Edit / Share / Delete / Open-in-new-tab) is placed
+    // by the HOST, not authored — so it is not location-filtered, matching
+    // `action:bar`'s `systemActions` carve-out. Before #3142 this slot WAS
+    // location-filtered here and not there, so the same `sys_delete` obeyed
+    // two different rules depending on which renderer drew the header.
+    // Capability and visibility gates still apply.
     const system = Array.isArray(hostSystemActions)
       ? hostSystemActions.filter(filterAction)
       : [];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -905,6 +905,7 @@ export {
   OBJECTUI_LOCAL_ACTION_TYPES,
   OBJECTUI_LOCAL_PARAM_FIELD_TYPES,
   ACTION_PARAM_FIELD_TYPES,
+  actionRendersAt,
 } from './ui-action';
 
 // ============================================================================

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -53,6 +53,45 @@ export type { ActionLocation } from '@objectstack/spec/ui';
 export { ACTION_LOCATIONS, ActionLocationSchema } from '@objectstack/spec/ui';
 
 /**
+ * THE placement rule: does `action` render at `location`?
+ *
+ * `locations` is an action's placement declaration, and this predicate is the
+ * single owner of what it means (objectui#3142). An action renders at a
+ * location only if it **declares** that location — a missing or empty
+ * `locations` places the action NOWHERE, it does not place it everywhere.
+ *
+ * That reading is the platform's: ADR-0078 lists "an `action` with no
+ * `locations`" as a verified inert shape — metadata that parses, reports
+ * success and does nothing — which only holds if omitting the key means "no
+ * placement". The engine (`ActionEngine.getActionsForLocation`), the record
+ * header (`RecordDetailView`), related lists (`RelatedRecordActionsBridge`),
+ * the environment toolbar and `DeclaredActionsBar` all already read it that
+ * way. Four renderers disagreed, in three different directions — `action:bar`
+ * and metadata-admin showed an undeclared action EVERYWHERE, `page:header`
+ * showed it on the header, `action:group` showed it for `undefined` but hid it
+ * for `[]` — so the same action appeared or vanished depending on which
+ * component happened to render it. #3142 collapsed all four onto this
+ * function; add a fifth caller rather than a fifth dialect.
+ *
+ * A locationless action is still reachable where placement comes from
+ * somewhere other than `locations`: the selection bar driven by a view's
+ * `bulkActions` / `bulkActionDefs` (naming it there IS the declaration), and
+ * the `systemActions` chrome slot, which is placed by the host, not authored.
+ *
+ * `location: undefined` means the caller is not filtering by location at all
+ * (e.g. an `action:bar` rendering an explicitly-supplied list) — every action
+ * passes.
+ */
+export function actionRendersAt(
+  action: { locations?: readonly ActionLocation[] } | null | undefined,
+  location: ActionLocation | undefined,
+): boolean {
+  if (!location) return true;
+  const declared = action?.locations;
+  return Array.isArray(declared) && declared.includes(location);
+}
+
+/**
  * Visual component type for actions — derived from the spec's
  * `ActionSchema.component` enum (#4074; formerly a hand-written union).
  *
@@ -315,7 +354,12 @@ export interface ActionSchema {
   
   // === Placement ===
   
-  /** Where to show this action (defaults to ['record_header']) */
+  /**
+   * Where this action renders. There is NO default: an action that declares
+   * no location renders in no located surface (see {@link actionRendersAt}).
+   * Placement from a view's `bulkActions` / `bulkActionDefs`, or from a host's
+   * `systemActions` slot, is declared there instead and needs no entry here.
+   */
   locations?: ActionLocation[];
   
   /** Visual component type (defaults to 'action:button') */

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -83,7 +83,13 @@ export { ACTION_LOCATIONS, ActionLocationSchema } from '@objectstack/spec/ui';
  * passes.
  */
 export function actionRendersAt(
-  action: { locations?: readonly ActionLocation[] } | null | undefined,
+  // `locations` is deliberately `readonly string[]`, not `ActionLocation[]`:
+  // several call sites hold actions straight off the wire (the metadata-admin
+  // `/meta/types` feed types them as plain strings), and a narrower parameter
+  // would push a cast onto every one of them — which is how a shared predicate
+  // grows per-caller variants and stops being shared. An unrecognized string
+  // simply matches no location.
+  action: { locations?: readonly string[] } | null | undefined,
   location: ActionLocation | undefined,
 ): boolean {
   if (!location) return true;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -83,6 +83,7 @@ const heavyDomTests = [
   'packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx',
   'packages/app-shell/src/views/metadata-admin/previews/ReportPreview.dataset.test.tsx',
   'packages/components/src/__tests__/action-bar.test.tsx',
+  'packages/components/src/__tests__/action-group.test.tsx',
   'packages/components/src/__tests__/page-card-i18n-title.test.tsx',
   'packages/components/src/__tests__/page-header-actions.test.tsx',
   'packages/components/src/__tests__/page-header-capability-gate.test.tsx',


### PR DESCRIPTION
Closes #3142.

## 问题

「一个没有 `locations` 的动作应该出现在哪」这个问题,仓内有 **5 套答案**:

| 语义 | 位置 |
|---|---|
| 宽松:`undefined` 和 `[]` 都**到处**显示 | `action-bar.tsx:137`、`MetadataTypeActions.tsx:99`(逐字节相同的两份拷贝) |
| 半宽松:声明了非空才过滤,否则显示 | `containers.tsx:984`(`page:header`) |
| 混合:`undefined` 显示、`[]` 隐藏 | `action-group.tsx:192` |
| **严格**:必须声明且命中 | `ActionEngine`、`RecordDetailView`、`DeclaredActionsBar`、`RelatedRecordActionsBridge`、`EnvironmentListToolbar`、`record:quick_actions` |

**同一个动作,由哪个组件渲染决定它出现还是消失。** 这正是 #3139 聚合批量动作踩中的坑:一个按构造就没有单记录位置的动作,不写 `locations` 后凭空长出一个列表工具栏按钮,而它的分发必然失败(实测 HTTP 400)。

## 方案:一条规则 + 一个具名豁免

新增 `actionRendersAt(action, location)`(从 `@object-ui/types` 导出),上述**八个**表面全部共用这一份判定:动作只有**声明**了某位置才在该位置渲染;缺失或空数组 = 没有位置。

这不是新发明,是回归平台自己的既定读法:
- **ADR-0078** 把「an `action` with no `locations`」列为已验证的 **Tier-A inert 形态** —— 该结论只有在「不声明 = 没有位置」时才成立;
- `buildDefaultPageSchema.ts:131` 早就把契约写成「**must include `locations: ['record_header']` to render**」。

宽松规则同时违背了这两条。

**具名豁免**:主机注入的 chrome(`systemActions` / `headerSystemActions`)由主机放置、不参与位置过滤。这里顺带修掉一个**今天就存在**的不一致 —— `action:bar` 一直豁免它,`page:header` 却在过滤它,所以同一个 `sys_delete` 取决于谁渲染而有两种命运。

选中集的放置同样来自别处:视图 `bulkActions` / `bulkActionDefs` 里命名一个动作**就是**它的声明,这类动作可以不写 `locations`(#3139 的聚合动作正是如此)。

## 防「改严格反而造出隐形动作」

严格化若不配套授权侧,只会把问题挪到作者手上。三处一并修:

- **Studio 新建动作补种 `locations: ['record_header']`** —— 此前 `ObjectActionsPanel` 的骨架不写 `locations`、Placement 复选框默认全不勾,即"每个 Studio 新建的动作都没有位置",靠宽松规则蒙混显示;
- **动作检查器在位置全空时明确提示**(不是报错 —— 只服务选中集的动作是合法形态);
- **删除 `ActionSchema.locations` 那句 `defaults to ['record_header']` 的 JSDoc** —— 那是第三个从未被任何渲染器兑现的"默认值"。

## 迁移

对元数据是破坏性的,但迁移是一行:

```diff
- { name: 'convert_lead', label: 'Convert' }
+ { name: 'convert_lead', label: 'Convert', locations: ['record_header'] }
```

已声明位置的动作完全不受影响。核过的存量面:objectstack 侧示例 20/20、platform-objects 73 个动作**全部**已声明 `locations`;本仓内唯一未声明的 4 个(`sys_share`/`sys_edit_mobile`/`sys_delete`/`sys_open_new_tab`)全走 `systemActions` 豁免通道。

## 测试

- **有意翻转**了 `action-bar.test.tsx` 那条唯一以名字和注释断言宽松契约的 pin,并写清为何反转;
- 能力门 fixture 补上 harness 的位置 —— 否则严格过滤会让它们在能力门跑到之前就被丢弃,5 条断言**空真通过**,套件继续报绿却什么都没测;
- `page:header` fixture 按既定契约补声明(排除类用例 `list_item`/`record_more` 的语义原样保留);
- 新增 `metadata-admin` 与 `action:group` 的严格 pin —— 这两处的宽松分支**此前完全没有测试**,正是两份拷贝能悄悄漂移的原因;
- 新增 `action-group.test.tsx` 并登记进 `heavyDomTests`(registry 渲染类,AGENTS.md 指定做法)。

验证:仓根 `pnpm test` **9266 项通过 / 0 失败**(794 文件);改动文件 lint 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9aiswZBzoVYsyLKRuGByE

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9aiswZBzoVYsyLKRuGByE)_