### PR TITLE
fix(flow-designer): the default path is the edge marker, not the branch (framework#4414)

### DIFF
--- a/.changeset/decision-default-path-is-the-edge.md
+++ b/.changeset/decision-default-path-is-the-edge.md
@@ -1,0 +1,29 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Say what the Decision inspector actually does: the default path is the edge marker, not the branch.
+
+Two help strings described mechanisms the engine does not have.
+
+The **Branches** editor said a branch whose expression is `"true"` *is* the
+default/else path. It is how you **ask** for one — `FlowEdgeInspector.applyBranch()`
+turns such a branch into `isDefault: true` on the out-edge it wires, and the marker
+on that edge is what routes. Conflating the two is the reading that let
+objectstack-ai/objectstack#4414 ship a decision whose guard did not guard, and it is
+worth being exact about now that `isDefault` is finally enforced: the key had **zero
+readers** in the engine until then, so this designer had been writing a marker
+nothing honoured, and every Studio "default/else" edge ran unconditionally alongside
+whichever branch matched. The help also now states that branches are tried in order
+and that the expression is bare CEL — a braced predicate there is a build failure
+since objectstack-ai/objectstack#4439.
+
+The legacy single **Condition** field said *"Prefer Branches above"*, which reads as
+"this works, but the other is better". It does not work at all: the decision executor
+never reads `config.condition`. The engine honours that key only on a Start node, as
+the trigger gate, and `os validate` now reports it as `flow-inert-node-condition`.
+The field stays render-only (its `__legacy__` controller never matches, so it is not
+offered for new authoring) so a stored value is not invisible — but the help says it
+is inert and where the predicate belongs instead.
+
+Text only; no behaviour change on this side.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -407,7 +407,12 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
   ],
   decision: [
     cfg('conditions', 'Branches', 'objectList', {
-      help: 'Each branch has a label, a CEL expression, and a target node. A branch whose expression is "true" is the default/else path. Picking a target wires the branch’s outgoing edge (creating or updating it); clearing it detaches that edge.',
+      // framework#4414: the default/else path is the out-edge marked
+      // `isDefault`, not the branch itself — a `true` branch is how you ask for
+      // one, and FlowEdgeInspector.applyBranch() writes the marker. Saying
+      // "a `true` branch IS the default path" conflated the two, which is the
+      // reading that let a decision ship with a guard that did not guard.
+      help: 'Each branch has a label, a CEL expression (no {braces}), and a target node. Branches are tried in order and the first match wins. A branch whose expression is "true" is the catch-all: picking its target marks that out-edge as the default path, taken only when no other branch matched. Picking a target wires the branch’s outgoing edge (creating or updating it); clearing it detaches that edge.',
       columns: [
         { key: 'label', label: 'Label', kind: 'text', placeholder: 'Has deals' },
         { key: 'expression', label: 'Expression', kind: 'expression', placeholder: 'expiring_deals.length > 0' },
@@ -416,9 +421,16 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
         { key: 'target', label: 'Target', kind: 'reference', placeholder: 'next node', ref: { kind: 'node' } },
       ],
     }),
+    // Render-only for a stored legacy value (`__legacy__` never matches, so it
+    // is not offered for new authoring). The old help said "Prefer Branches
+    // above", which reads as "this works, but the other is better" — it does
+    // not work at all: framework#4414 confirmed the decision executor never
+    // reads `config.condition`. The key is the trigger gate on a `start` node
+    // and inert on every other node type, and `os validate` now reports it as
+    // `flow-inert-node-condition`.
     cfg('condition', 'Condition (single)', 'expression', {
       placeholder: 'amount > 10000',
-      help: 'Legacy single-branch condition (CEL). Prefer Branches above; per-edge conditions also live on the outgoing edges.',
+      help: 'Inert — nothing reads this. The engine only honours `condition` on a Start node (the trigger gate); on a Decision it gates nothing. Shown so a stored value is not invisible. Move the predicate to a branch above, or to the outgoing edge’s own condition, then clear this.',
       showWhen: { field: '__legacy__', equals: [] },
     }),
   ],


### PR DESCRIPTION
Decision 检查器上两处 help 文案描述了引擎并不具备的机制。纯文案,本侧无行为变更。

配套框架侧:objectstack-ai/objectstack#4414 / #4440(`isDefault` 落地)、#4439 / #4474(表达式账本)。

## ① Branches 编辑器:把「分支」和「边上的标记」混为一谈

原文写「`expression` 为 `"true"` 的分支**就是** default/else 路径」。实际它是**申请**一条:`FlowEdgeInspector.applyBranch()` 会把这种分支接成出边上的 `isDefault: true`,真正路由的是**那条边上的标记**。

这个混淆正是 framework#4414 里「守卫不守」得以出厂的读法,而且现在特别值得说准 —— **`isDefault` 在引擎里此前是零读者**。也就是说这个 designer 一直在写一个没人认领的标记,每一条 Studio 画出来的「default/else」边实际上都是无条件执行的,和真正命中的分支**并行**跑。框架侧 enforcement 落地后它们才开始只走一条。

顺带补上两点原本没说的:分支是**按顺序**试、第一个命中的赢;`expression` 是**裸 CEL** —— 带花括号的谓词自 framework#4439 起是构建失败,不再是「另一种方言」。

## ② Legacy 单数 `Condition`:不是「次一等」,是根本不生效

原文写「Prefer Branches above」,读起来像「这个能用,只是那个更好」。它**完全不工作**:decision 执行器从不读 `config.condition`。引擎只在 **Start 节点**上认这个键(作为触发门),framework#4414 为此新增了 `flow-inert-node-condition`,`os validate` 现在会报。

字段本身保持 render-only(`__legacy__` 控制器永不匹配,所以不对新建开放)—— 存量节点的值不该在界面上凭空消失 —— 但 help 现在如实说它是惰性的,以及谓词该搬去哪里。

## 验证

`pnpm exec vitest run --project unit flow-node-config` → 40 passed / 5 skipped;`flow-node-config.spec-reconciliation.test.ts` 一并通过(它对账的是 key 集合,文案不影响);ESLint 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8as8yR67v41xEdomiTba9
