### PR TITLE
fix(dashboard): date 型 globalFilter 的预设名默认值应提升为区间 (objectstack#4475)

### DIFF
--- a/.changeset/dashboard-date-filter-preset-default.md
+++ b/.changeset/dashboard-date-filter-preset-default.md
@@ -1,0 +1,56 @@
+---
+"@object-ui/core": minor
+---
+
+fix(dashboard): a date globalFilter's preset-name default becomes a range, not an equality
+
+Setup → System Overview rendered EVERY KPI tile as 0 while its period selector
+read "All time" (objectstack#4475). Every request was `200 OK`, the widgets
+rendered normally, and nothing in the UI signalled a failure — zeros read as
+"nothing has happened yet" rather than as an error, which is why this survived
+to an RC.
+
+Both symptoms are one missing normalization. `resolveDashboardFilterDefs` lifts
+the built-in `dateRange` declaration's preset NAME to `{ preset }`, but passed a
+`globalFilters` entry's `defaultValue` through raw. `@objectstack/spec`'s
+`GlobalFilterSchema.defaultValue` is `string | number | boolean`, so a bare
+preset name is the ONLY spelling an author can write — and nothing ever mapped
+it. System Overview declares
+`{ field: 'created_at', type: 'date', defaultValue: 'last_7_days' }`, so:
+
+- `buildFilterCondition` fell through to its "a bare string date means equality
+  on that day" branch and the widget sent
+  `runtimeFilter: { created_at: 'last_7_days' }`. The backend compiled
+  `SELECT COUNT(*) AS "user_count" FROM "sys_user" WHERE created_at = $1`
+  — verified against a live server, byte-for-byte the SQL in the issue. The
+  actual `sys_user` count is 4; that equality matches no row.
+- `DateRangeFilter` derives its selected item from `value.preset` / `.from` /
+  `.to`, all `undefined` on a bare string, so the control fell through to its
+  ALL sentinel and displayed "All time" while sending that equality. The tiles
+  therefore looked deliberately unfiltered and merely empty.
+
+`normalizeDateDefault` now applies the same lift the sibling `dateRange`
+declaration already receives, for `date`/`dateRange` filters whose default names
+a preset this module actually knows. This is not consumer-side leniency: it is
+one normalization function completing the same conversion for the sibling
+declaration, and the spec admits no other spelling for an author to fix at the
+producer. A genuine ISO date string still means equality on that day (the
+documented behaviour), and numbers, booleans and unrecognised strings are left
+exactly as declared.
+
+No backend change is needed: given a real range the dataset path already lowers
+it correctly (`WHERE (created_at >= $1 AND created_at < $2)` → 4). The
+framework's dashboard metadata needs none either — it is spec-compliant as
+written, and editing it would only hide the defect.
+
+Levelled `minor` rather than `patch` because the change is visible in rendered
+dashboards rather than internal: any dashboard declaring a date-typed
+`globalFilters` default now emits a different query shape, its numbers change
+(from 0 to real values), and its filter control's displayed label changes with
+them. Anything asserting on the previously-emitted condition will see it move.
+
+Known residual, filed separately rather than widened into here: a `date` filter
+whose value is neither a known preset nor a parseable ISO date still degrades
+silently to an equality that matches nothing, producing the same
+healthy-looking zero. Preset names are covered by this change; a misspelled
+custom value is not.

--- a/packages/core/src/utils/__tests__/dashboard-filters.test.ts
+++ b/packages/core/src/utils/__tests__/dashboard-filters.test.ts
@@ -99,6 +99,73 @@ describe('resolveDashboardFilterDefs', () => {
     expect(defs).toHaveLength(1);
     expect(defs[0].field).toBe('sales_region');
   });
+
+  // ---------------------------------------------------------------------
+  // framework#4475 — a `date` globalFilter's preset-name default.
+  //
+  // Setup → System Overview rendered EVERY KPI tile as 0 while its period
+  // selector read "All time". The dashboard declares
+  //   globalFilters: [{ field: 'created_at', type: 'date',
+  //                     defaultValue: 'last_7_days' }]
+  // and `GlobalFilterSchema.defaultValue` is `string | number | boolean`, so
+  // a bare preset name is the ONLY spelling an author can write — but only
+  // the built-in `dateRange` declaration was ever lifted to `{ preset }`.
+  // The raw string then flowed to `buildFilterCondition`, hit its
+  // "bare string date means equality" branch, and the backend compiled
+  //   SELECT COUNT(*) … FROM "sys_user" WHERE created_at = $1
+  // (verified against a live server) — 200 OK, zero rows, no error anywhere.
+  // The same missing lift is why the control showed "All time": DateRangeFilter
+  // reads `.preset`/`.from`/`.to`, all undefined on a string.
+  // ---------------------------------------------------------------------
+  it('[#4475] lifts a date filter\'s preset-name default to { preset }', () => {
+    const defs = resolveDashboardFilterDefs({
+      globalFilters: [
+        { field: 'created_at', type: 'date', label: 'Date Range', defaultValue: 'last_7_days' },
+      ] as any,
+    });
+    expect(defs[0].defaultValue).toEqual({ preset: 'last_7_days' });
+  });
+
+  it('[#4475] the lifted default produces a RANGE, never an equality', () => {
+    // The end-to-end assertion: what the dashboard declares must reach the
+    // query as bounds. Pre-fix this was the literal string 'last_7_days'.
+    const [def] = resolveDashboardFilterDefs({
+      globalFilters: [
+        { field: 'created_at', type: 'date', defaultValue: 'last_7_days' },
+      ] as any,
+    });
+    expect(buildFilterCondition(def, def.defaultValue)).toEqual({
+      $gte: '{7_days_ago}',
+      $lte: '{today}',
+    });
+    // And the widget-scoped shape a dataset widget forwards as runtimeFilter.
+    expect(buildWidgetScopedFilter({ id: 'w' }, [def], { created_at: def.defaultValue })).toEqual({
+      created_at: { $gte: '{7_days_ago}', $lte: '{today}' },
+    });
+  });
+
+  it('[#4475] leaves a genuine ISO date default as an equality', () => {
+    // The documented bare-string behaviour is unchanged — only names this
+    // module actually knows as presets are lifted.
+    const defs = resolveDashboardFilterDefs({
+      globalFilters: [
+        { field: 'created_at', type: 'date', defaultValue: '2026-01-15' },
+      ] as any,
+    });
+    expect(defs[0].defaultValue).toBe('2026-01-15');
+    expect(buildFilterCondition(defs[0], defs[0].defaultValue)).toBe('2026-01-15');
+  });
+
+  it('[#4475] does not touch non-date filters that share a preset-like default', () => {
+    const defs = resolveDashboardFilterDefs({
+      globalFilters: [
+        { field: 'bucket', type: 'select', defaultValue: 'last_7_days' },
+        { field: 'score', type: 'number', defaultValue: 7 },
+      ] as any,
+    });
+    expect(defs[0].defaultValue).toBe('last_7_days');
+    expect(defs[1].defaultValue).toBe(7);
+  });
 });
 
 describe('dashboardFilterVariableDefs', () => {

--- a/packages/core/src/utils/dashboard-filters.ts
+++ b/packages/core/src/utils/dashboard-filters.ts
@@ -89,6 +89,36 @@ const PRESET_RANGES: Record<string, { from?: string; to?: string }> = {
 export const DATE_RANGE_PRESETS = Object.keys(PRESET_RANGES);
 
 /**
+ * Normalize a date filter's DECLARED default into the `DateRangeValue` shape
+ * every date consumer in this module reads (framework#4475).
+ *
+ * The built-in `dateRange` declaration has always been normalized this way —
+ * `schema.dateRange.defaultRange` is a preset NAME and
+ * `resolveDashboardFilterDefs` lifts it to `{ preset }`. A `globalFilters`
+ * entry of `type: 'date'` was passed through raw instead, and that asymmetry
+ * is the whole bug: `@objectstack/spec`'s `GlobalFilterSchema.defaultValue` is
+ * `string | number | boolean`, so a bare preset name is the ONLY spelling an
+ * author can write, yet nothing ever mapped it. Both symptoms of Setup's
+ * System Overview reading 0 across every KPI tile follow from that:
+ *
+ *  - `buildFilterCondition` fell through to its "a bare string date means
+ *    equality on that day" branch and emitted `created_at = 'last_7_days'`,
+ *    which matches no row — a query the backend answers `200 OK` with a 0;
+ *  - `DateRangeFilter` reads `value.preset` / `.from` / `.to`, all `undefined`
+ *    on a bare string, so the control displayed "All time" while sending that
+ *    equality — the tiles looked deliberately unfiltered and merely empty.
+ *
+ * Only a name this module actually knows is lifted. A genuine ISO date string
+ * still means equality on that day (the documented behaviour), and a number /
+ * boolean / unrecognised string is left exactly as declared.
+ */
+function normalizeDateDefault(type: DashboardFilterDef['type'], defaultValue: unknown): unknown {
+  if (type !== 'date' && type !== 'dateRange') return defaultValue;
+  if (typeof defaultValue !== 'string') return defaultValue;
+  return defaultValue in PRESET_RANGES ? { preset: defaultValue } : defaultValue;
+}
+
+/**
  * Normalize a filter's static `options` declaration to `{ value, label }`
  * pairs. The @objectstack/spec `GlobalFilterSchema.options` form is
  * `{ value, label }` objects (label possibly an i18n record); the bare-string
@@ -147,14 +177,18 @@ export function resolveDashboardFilterDefs(
     if (byName.has(name) && typeof console !== 'undefined') {
       console.warn(`[dashboard-filters] duplicate filter name "${name}" — the later definition wins`);
     }
+    const type = f.type ?? 'text';
     byName.set(name, {
       name,
       field: f.field,
       label: f.label,
-      type: f.type ?? 'text',
+      type,
       options: normalizeFilterOptions(f.options),
       optionsFrom: f.optionsFrom,
-      defaultValue: f.defaultValue,
+      // framework#4475 — same preset-name lifting the built-in `dateRange`
+      // above already does; see normalizeDateDefault for why a bare string is
+      // the only thing an author can declare here.
+      defaultValue: normalizeDateDefault(type, f.defaultValue),
       targetWidgets: f.targetWidgets,
     });
   }

--- a/packages/plugin-dashboard/src/__tests__/DashboardFilterBar.dateDefault.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardFilterBar.dateDefault.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * framework#4475 — the date filter's control must AGREE with the query it
+ * drives.
+ *
+ * Setup → System Overview rendered every KPI tile as 0 while its period
+ * selector read "All time". Both halves were one missing normalization: a
+ * `globalFilters` entry of `type: 'date'` declares its default as a bare
+ * preset NAME (`GlobalFilterSchema.defaultValue` is `string | number |
+ * boolean`, so there is no object spelling to write), and only the built-in
+ * `dateRange` declaration was ever lifted to `{ preset }`.
+ *
+ * `DateRangeFilter` derives its selected item from `value.preset` / `.from` /
+ * `.to` — all `undefined` on a bare string — so the control fell through to
+ * its ALL sentinel and displayed "All time" while the same raw string went
+ * out as `created_at = 'last_7_days'`. The tiles therefore looked deliberately
+ * unfiltered and merely empty, which is why nothing in the UI signalled a
+ * failure. This pins the display half; the query half lives in
+ * `@object-ui/core`'s dashboard-filters tests.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DashboardFilterBar } from '../DashboardFilterBar';
+import { resolveDashboardFilterDefs } from '@object-ui/core';
+
+afterEach(cleanup);
+
+/** The System Overview declaration verbatim. */
+const SYSTEM_OVERVIEW_FILTERS = [
+  { field: 'created_at', type: 'date', label: 'Date Range', scope: 'dashboard', defaultValue: 'last_7_days' },
+] as any;
+
+describe('DashboardFilterBar — date filter default (framework#4475)', () => {
+  it('shows the declared preset, not "All time"', () => {
+    const defs = resolveDashboardFilterDefs({ globalFilters: SYSTEM_OVERVIEW_FILTERS });
+    // The dashboard variables provider seeds values from the resolved defaults.
+    const values = Object.fromEntries(defs.map((d) => [d.name, d.defaultValue]));
+
+    render(<DashboardFilterBar defs={defs} values={values} onChange={vi.fn()} />);
+
+    const control = screen.getByTestId('dashboard-filter-created_at');
+    expect(control.textContent).not.toMatch(/All time/i);
+    expect(control.textContent).toMatch(/last 7 days/i);
+  });
+
+  it('still shows "All time" when the filter genuinely has no value', () => {
+    // Clearing the selector sets the value to `undefined` — that IS all-time,
+    // and it must keep reading that way.
+    const defs = resolveDashboardFilterDefs({ globalFilters: SYSTEM_OVERVIEW_FILTERS });
+
+    render(<DashboardFilterBar defs={defs} values={{ created_at: undefined }} onChange={vi.fn()} />);
+
+    expect(screen.getByTestId('dashboard-filter-created_at').textContent).toMatch(/All time/i);
+  });
+});


### PR DESCRIPTION
修复 objectstack#4475 —— Setup → 系统概览(System Overview)每块 KPI 都读 0。

配套的 framework 侧 PR:objectstack-ai/objectstack#4494(修 #4467 / #4437,同名分支)。**framework 侧无需为本缺陷改动任何代码**,理由见下。

---

## 现象

Setup → 系统概览,周期选择器显示 **全部时间 / All time**,而每块 KPI 都是 0:

| tile | 显示 | 实际 |
|---|---|---|
| 用户总数 | 0 | 4 |
| 活跃会话 | 0 | 16 |
| 登录事件 | 0 | 非 0 |

所有请求都是 `200 OK`,widget 正常渲染,UI 里没有任何失败信号——0 读起来像"还没有数据",而不是像错误。这是最难被发现的那一类。

## 根因:一处缺失的归一化,同时造成两个症状

issue 原文推测是 dataset 路径把 all-time 区间降级成了等值比较。**实测证明不是**:dataset 路径拿到真正的区间时 lowering 完全正确,它收到的本来就是一个标量。我用 curl 把 Console 实际发出的请求复现了出来(issue 里没能从 curl 复现,关键是 `dataset` 要内联传、`selection.measures` 必须非空):

```
POST /api/v1/analytics/dataset/query
{"dataset":{...,"object":"sys_user","measures":[{"name":"user_count","aggregate":"count"}]},
 "selection":{"measures":["user_count"],"runtimeFilter":{"created_at":"last_7_days"}}}

→ {"rows":[{"user_count":0}],
   "sql":"SELECT COUNT(*) AS \"user_count\" FROM \"sys_user\" WHERE created_at = $1"}
```

**与 issue 里贴的 SQL 一字不差。** 而同一条路径拿到区间时:

```
runtimeFilter:{"created_at":{"$gte":"{7_days_ago}","$lte":"{today}"}}
→ "… WHERE (created_at >= $1 AND created_at < $2)"   rows: [{"user_count":4}]
无 filter → rows: [{"user_count":4}]      /data/sys_user → total 4
```

真正的问题在 Console:**一个裸的预设名字符串被当成比较值发了出去。**

链路:

1. framework 的 `system_overview.dashboard.ts` 声明
   `globalFilters: [{ field:'created_at', type:'date', defaultValue:'last_7_days' }]`。
   这是**合规写法**——`GlobalFilterSchema.defaultValue` 是 `z.union([string, number, boolean])`,根本不允许对象形式,所以裸预设名是作者唯一能写的拼法。
2. `resolveDashboardFilterDefs` 对**内置 `dateRange`** 声明会把预设名提升成 `{ preset }`
   (`defaultValue: preset && preset !== 'custom' ? { preset } : undefined`),
   但 **`globalFilters` 分支原样透传 `f.defaultValue`**。这个不对称就是本缺陷。
3. 于是 `buildFilterCondition` 里 `typeof v === 'object'` 为 false,落到
   "A bare string date means equality on that day" 那一支,原样返回字符串 →
   `WHERE created_at = 'last_7_days'` → 恒 0。
4. **同一个缺失也解释了为什么选择器显示"全部时间"**:`DateRangeFilter` 的
   `selectValue = value?.preset ?? (value?.from || value?.to ? CUSTOM : ALL)`,
   裸字符串上这三个属性全是 `undefined`,于是落到 ALL 哨兵显示"全部时间",
   而底下发出去的却是那个字符串。

**"显示全部时间"和"KPI 全为 0"不是两件事,是同一个根因的两个症状。** 这也是为什么 UI 看起来像"刻意没有过滤、只是恰好没数据"。

## 改动

`normalizeDateDefault` 给 `globalFilters` 分支补上与内置 `dateRange` **同一套**归一化:`type` 为 `date`/`dateRange`、且 `defaultValue` 是本模块**确实认识**的预设名时,提升为 `{ preset }`。

这不是"在消费端加 `??` 兜底"(AGENTS.md Prime Directive #12):它是**同一个归一化函数对兄弟声明补齐同一个转换**,而且 spec 只允许标量,producer 侧根本没有别的写法可改。framework 的 dashboard metadata **不应该动**——它是合规的,改它只会把缺陷藏起来。

保守边界:真正的 ISO 日期字符串仍然表示"当天等值"(既有的文档化行为),数字、布尔、以及不认识的字符串**原样保留**。

## 验证

**真实 dev server**(framework worktree,`pnpm dev -- --fresh -p 38101`),对比修复前后 Console 发出的两种 `runtimeFilter`:

```
--- Users ---      truth (/data) = 4
  BEFORE (裸字符串)   [{'user_count': 0}] | … WHERE created_at = $1
  AFTER  (提升后)     [{'user_count': 4}] | … WHERE (created_at >= $1 AND created_at < $2)
--- Sessions ---   truth (/data) = 3
  BEFORE             [{'session_count': 0}] | … WHERE created_at = $1
  AFTER              [{'session_count': 3}] | … WHERE (created_at >= $1 AND created_at < $2)
```

(该环境 session 实际为 3 条,非 issue 里的 16;要点是 **0 → 与 `/data` 一致的真值**。)

**回归测试**

- `packages/core/src/utils/__tests__/dashboard-filters.test.ts` 新增 4 例:预设名提升为 `{preset}`、提升后产出**区间而非等值**(并断言 widget-scoped 的 `runtimeFilter` 形状)、真正的 ISO 日期仍为等值、非 date 型 filter 不受影响。
- 新增 `packages/plugin-dashboard/src/__tests__/DashboardFilterBar.dateDefault.test.tsx`:直接用 System Overview 的声明原文断言控件显示"Last 7 days"而非"All time";并保留"值确实为空时仍显示 All time"。

| 闸门 | 结果 |
|:---|:---|
| `pnpm --filter @object-ui/core test` | 17 files / **124 passed** |
| `pnpm --filter @object-ui/plugin-dashboard test` | 17 files / **124 passed** |
| `pnpm type-check` | 运行中,结果将在下方评论补充 |

## 残留问题(已单独立项:#3151)

`date` 型 filter 拿到一个既不是已知预设、也不是合法 ISO 日期的字符串时,仍会静默降级成一个永不命中的等值比较,继续产生"看着健康的 0"。预设名这一类由本 PR 覆盖,拼错的自定义值不会。按 Prime Directive #10 单独记录在 **#3151**(未认领),不在本 PR 扩大范围。

Fixes objectstack-ai/objectstack#4475