### PR TITLE
fix(console): binding-reach 探针少报了自己 6 个块的覆盖面，而且是静默的 (#3149 第 1 层)

### DIFF
--- a/.changeset/binding-reach-lazy-candidate-coverage.md
+++ b/.changeset/binding-reach-lazy-candidate-coverage.md
@@ -1,0 +1,46 @@
+---
+"@object-ui/console": patch
+---
+
+The binding-reach probe was under-reporting its own coverage by six object blocks, silently (#3149).
+
+`public-block-binding-reach.test.tsx` selects what to probe by filtering `getPublicConfigs()`
+for a declared `objectName` input. The console registers most object blocks with
+`registerLazy`, and a pending stub carries no `inputs` — `Registry.getMeta` says in as many
+words that a consumer must read that as *"not yet known"*, not as *"declares no props"*. The
+filter read it as the latter, so `object-chart`, `object-kanban`, `object-calendar`,
+`object-gantt`, `object-timeline` and `object-map` — six Tier-A blocks, every one declaring
+`objectName` as **required** — dropped out of the candidate set while the suite reported eight
+green probes and no gap.
+
+That is objectui#2953's shape (a lazy registration falling out of the contract) recurring in a
+consumer, and objectstack#4472's shape recurring inside the suite written to answer it: a gate
+whose stated scope was wider than its reach. The coverage guard could not see it — `length > 0`
+and `toContain('object-form')` both stayed true at 8 of 14.
+
+- Pending public lazy loaders are resolved through the registry's own `loadLazy` before
+  candidates are selected — driven off the recorded loaders, not a hand-written list of plugin
+  imports that would drift out of step with `register-plugins.ts` and reintroduce the same
+  shrinkage by another route.
+- The guard is now an **exact** candidate list, the lesson `public-contract.test.ts` already
+  carries: the failure mode is a set getting smaller, and only an exact comparison makes both
+  directions a deliberate edit. Verified by simulating the regression — with resolution
+  disabled the assertion fails naming the missing blocks.
+
+All six were already wired correctly (`ObjectChart` reads the context itself; gantt/timeline/map
+and kanban/calendar have context→prop wrappers), so this found no new defect of the #3144 kind.
+It found two more probe artifacts, which is the same lesson a third and fourth time — a
+plausible value for every input is not a plausible *configuration*:
+
+- **`data` supersedes the binding.** `ObjectChart`'s fetch is guarded by
+  `if ((schema.objectName || schema.dataset) && !boundData && !schema.data)`, and the spec
+  glosses `data` as static data to chart *instead of* binding via `objectName`. Filling it and
+  then reporting "objectName never reached" would have been the probe manufacturing its own
+  finding. Binding-superseding inputs are now excluded, narrowly and with the guard quoted.
+- **Teardown is not the subject.** `object-map` mounts maplibre-gl, whose `map.remove()` throws
+  in jsdom for want of a WebGL context. Unmount is caught so the assertion speaks to data reach;
+  an error thrown during *render* still propagates.
+
+Coverage after this: 14 of 14 object-bound public blocks. The rest of #3149 — bindings other
+than `objectName`, the `record:*` family under a record context, and the display primitives —
+is untouched and still open.

--- a/apps/console/src/__tests__/public-block-binding-reach.test.tsx
+++ b/apps/console/src/__tests__/public-block-binding-reach.test.tsx
@@ -50,6 +50,12 @@
  * non-reaching block carries a written reason, and the ledger is asserted to
  * equal the observed set in BOTH directions, so a block that starts reaching
  * must be removed from it and a block that stops reaching fails here.
+ *
+ * The other half of "not over-read" is COVERAGE, and it has to be asserted
+ * rather than assumed — see {@link EXPECTED_CANDIDATES}. This suite's first
+ * release under-reported its own scope by 6 of 14 object-bound blocks and said
+ * nothing (objectui#3149), which is the same shape as the gate it was written to
+ * compensate for: a claim wider than the thing behind it.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -122,9 +128,100 @@ const NO_DATA_REACH: Readonly<Record<string, string>> = {
   // objectstack#4413 ship.
 };
 
+/**
+ * Every public block this suite must probe, exactly.
+ *
+ * An exact list rather than a floor, because the failure mode is a SHRINKING
+ * candidate set — and that is not hypothetical, it is what shipped
+ * (objectui#3149). The console registers most object blocks with
+ * `registerLazy`, and a pending stub carries no `inputs`: `Registry.getMeta`
+ * says in as many words that consumers must treat that as *"not yet known"*,
+ * not as *"declares no props"*. The first release of this file filtered on
+ * `inputs` directly and so silently dropped `object-chart`, `object-kanban`,
+ * `object-calendar`, `object-gantt`, `object-timeline` and `object-map` — six
+ * Tier-A object blocks, every one of them declaring `objectName` as
+ * **required** — while reporting eight green probes and no gap.
+ *
+ * That is objectui#2953's shape (a lazy registration falling out of the
+ * contract) recurring one layer up, in the consumer this time; and it is
+ * objectstack#4472's shape recurring in the very suite written to answer it — a
+ * gate whose stated scope was wider than its actual reach. The lesson both
+ * times is the same one `public-contract.test.ts` already carries: a `toContain`
+ * or a `length > 0` sails straight past a set that quietly got smaller. Only an
+ * exact list makes both directions a deliberate edit.
+ */
+const EXPECTED_CANDIDATES = [
+  'object-grid',
+  'list-view',
+  'object-form',
+  'embeddable-form',
+  'object-master-detail-form',
+  'object-metric',
+  'object-pivot',
+  'record:related_list',
+  // The six objectui#3149 restored. Lazily registered by the console, so they
+  // only surface here once their loaders have run (see resolveLazyPublicBlocks).
+  'object-chart',
+  'object-kanban',
+  'object-calendar',
+  'object-gantt',
+  'object-timeline',
+  'object-map',
+];
+
+/**
+ * Run every pending public lazy loader, so `getPublicConfigs()` reports each
+ * block's real `inputs` instead of a stub's absent ones.
+ *
+ * Driven off the registry's OWN recorded loaders rather than a hand-written list
+ * of plugin imports: a list here would drift out of step with
+ * `register-plugins.ts` and reintroduce the same silent shrinkage by a different
+ * route. It also keeps the registry mutation scoped to this file — loading via
+ * `loadLazy` is what the app itself does on first use, not a test-only override
+ * of what is registered.
+ */
+async function resolveLazyPublicBlocks(): Promise<void> {
+  const pending = ComponentRegistry.getPublicConfigs().filter((c) => c.lazy);
+  await Promise.all(
+    pending.map((c) => {
+      // A lazy entry is keyed under both its bare tag and `namespace:tag`;
+      // `getPublicConfigs` reports the canonical (namespaced) one.
+      const bare = c.type.includes(':') ? c.type.slice(c.type.indexOf(':') + 1) : c.type;
+      return (
+        ComponentRegistry.loadLazy(c.type) ??
+        ComponentRegistry.loadLazy(bare) ??
+        Promise.resolve()
+      );
+    }),
+  );
+}
+
+await resolveLazyPublicBlocks();
+
 /** Does this config declare an `objectName` input? */
 const declaresObjectName = (cfg: { inputs?: Array<{ name?: string }> }) =>
   (cfg.inputs ?? []).some((i) => i?.name === 'objectName');
+
+/**
+ * Inputs that SUPERSEDE the `objectName` binding — filling them is the author
+ * telling the block not to fetch, so the probe must leave them unset.
+ *
+ * Narrow and reasoned, not a convenience escape hatch. `data` is the documented
+ * alternative data source: @objectstack/spec's react overlay glosses it as
+ * *"static/precomputed data to chart directly **instead of** binding via
+ * objectName + aggregate"*, and `ObjectChart`'s fetch is guarded by
+ * `if ((schema.objectName || schema.dataset) && !boundData && !schema.data)`.
+ * Filling it and then reporting "objectName never reached the data layer" would
+ * be the probe manufacturing its own finding — the same mistake as seeding
+ * `columns: []` (which makes a list render its empty state without fetching) or
+ * spreading a bare Proxy (which strips a derived source of every method). Three
+ * instances of one lesson: a plausible value for EVERY input is not the same as
+ * a plausible CONFIGURATION.
+ *
+ * Add to this list only with the guard quoted, so the next reader can check the
+ * claim instead of trusting it.
+ */
+const SUPERSEDES_BINDING = new Set(['data']);
 
 /**
  * A plausible value for one declared input.
@@ -185,14 +282,12 @@ async function dataCallsFor(cfg: any): Promise<string[]> {
     get: (target, key: string) => (key in target ? (target as any)[key] : record(key)),
   });
 
-  // Only `objectName` + the inputs the block declares REQUIRED. A bogus value
-  // for an optional input is a degenerate config that can make a block bail out
-  // before it ever asks for data — which would read here as a false finding.
   // EVERY declared input, not just the required ones — see the file header: a
   // read path can be gated on an optional input, and leaving it out would report
   // a block as unbound when it was simply never asked to fetch.
   const schema: Record<string, unknown> = { type: cfg.type };
   for (const input of cfg.inputs ?? []) {
+    if (SUPERSEDES_BINDING.has(input.name)) continue;
     schema[input.name] = sampleFor(input);
   }
 
@@ -208,18 +303,33 @@ async function dataCallsFor(cfg: any): Promise<string[]> {
       await new Promise((resolve) => setTimeout(resolve, 50));
     });
   }
-  view.unmount();
+  // Teardown is not the subject. `object-map` mounts maplibre-gl, whose
+  // `map.remove()` throws in jsdom because there is no WebGL context to release
+  // — a fact about the DOM implementation, not about whether the block bound to
+  // its object. Every call it made is already recorded above, so swallow the
+  // unmount and let the assertion speak to the data reach. Deliberately scoped
+  // to unmount: an error thrown during RENDER still propagates and fails.
+  try {
+    view.unmount();
+  } catch {
+    /* see above */
+  }
   return calls;
 }
 
 const candidates = ComponentRegistry.getPublicConfigs().filter(declaresObjectName);
 
 describe('public blocks — a declared objectName reaches the data layer (objectstack#4472)', () => {
-  it('finds the object-bound blocks to probe (guards against probing nothing)', () => {
-    // If the registry ever stops exposing these, this suite would pass by
-    // probing an empty list — the failure mode a coverage gate must not have.
-    expect(candidates.length).toBeGreaterThan(0);
-    expect(candidates.map((c) => c.type)).toContain('object-form');
+  it('probes exactly the public blocks that declare an objectName (objectui#3149)', () => {
+    // The guard this replaces was `length > 0` + `toContain('object-form')`,
+    // which is precisely the shape that let six blocks fall out unnoticed: both
+    // assertions stayed true the whole time the candidate set was 8 instead of
+    // 14. A gate that cannot report its own coverage shrinking is not reporting
+    // coverage.
+    //
+    // A block appearing here is additive and cheap to accept; a block
+    // DISAPPEARING is the regression, and only the exact comparison catches it.
+    expect([...candidates.map((c) => c.type)].sort()).toEqual([...EXPECTED_CANDIDATES].sort());
   });
 
   for (const cfg of candidates) {


### PR DESCRIPTION
#3149 的**第 1 层**。第 2、3 层（objectName 之外的绑定、record:* 家族、展示原语）未动，issue 仍开着。

## 缺陷

`public-block-binding-reach.test.tsx`（#3146）靠 `getPublicConfigs()` 里"有没有 `objectName` 输入"选候选。但 console 对多数对象块走 `registerLazy`，pending stub 不带 `inputs`——`Registry.getMeta` 的注释原话：

> A stub carries only what `registerLazy` was given, so `inputs` is usually absent until the chunk loads. **Consumers should treat that as "not yet known", not as "declares no props".**

过滤器当成了后者。于是这六个整批落出候选集，而套件报告"八个探针全绿、无缺口"：

| block | 注册处 | 声明 |
|---|---|---|
| `object-chart` | `plugin-charts/src/index.tsx:64` | `objectName` **required** |
| `object-kanban` | `plugin-kanban/src/index.tsx:359` | `objectName` **required** |
| `object-calendar` | `plugin-calendar/src/index.tsx:37` | `objectName` **required** |
| `object-gantt` | `plugin-gantt/src/index.tsx:67` | `objectName` **required** |
| `object-timeline` | `plugin-timeline/src/index.tsx:321` | `objectName` **required** |
| `object-map` | `plugin-map/src/index.tsx:30` | `objectName` **required** |

这是 #2953 的形状（lazy 注册悄悄掉出契约）在消费端复发，也是 objectstack#4472 的形状在**那个为了回答它而写的套件**内部复发：声明的作用域比实际够得着的范围宽。原来的守卫看不见——`length > 0` 和 `toContain('object-form')` 在 8/14 的时候都是真的。

## 改了什么

- 候选筛选前先经注册表自己的 `loadLazy` 解析所有 pending 的 public lazy 条目。**用注册表记录的 loader，不是在测试里手写一份插件 import 清单**——那份清单会和 `register-plugins.ts` 脱节，换条路把同样的缩水再引入一次。
- 守卫改成**精确**候选清单（照搬 `public-contract.test.ts` 已写明的教训：失败模式是集合变小，`toContain` 会径直放过）。

## 结果：没有新缺陷，但抓出两个探针假信号

六个块的接线本来就是对的——`ObjectChart` 自己读 context（`ObjectChart.tsx:253`：`props.dataSource || context?.dataSource`，所以裸注册在它这里是安全的），gantt/timeline/map 与 kanban/calendar 都有 context→prop wrapper。**没有第三个 #3144。**

倒是又抓出两个探针自身的假信号，同一个教训的第三、第四次——*给每个输入一个合理值，不等于一份合理的配置*：

1. **`data` 会盖掉绑定**。`ObjectChart` 的取数判据是 `if ((schema.objectName || schema.dataset) && !boundData && !schema.data)`，而 spec 对 `data` 的注释就是"直接图示静态数据，**取代**经 objectName 绑定"。填了它再报告"objectName 没到达"，是探针自造发现。现在排除这类"盖掉绑定"的输入，范围很窄，判据原文抄在注释里，让下一个人能核而不是只能信。
2. **卸载不是被测对象**。`object-map` 挂 maplibre-gl，其 `map.remove()` 在 jsdom 里因为没有 WebGL context 抛异常。unmount 被 catch，断言只讲数据到达；**渲染**期抛的异常仍照常传播。

## 验证

- `apps/console` 全套 27 tests 全绿（16 binding-reach + 11 public-contract）。特别确认 `public-contract.test.ts` 的 `EXPECTED_LAZY` 精确断言不受影响——console 项目 `isolate: true`，`loadLazy` 的注册表变更不跨文件泄漏
- **回归模拟**：把 `resolveLazyPublicBlocks()` 关掉，套件从 16 掉到 10，新断言变红并列出缺失的 `object-chart` / `object-map` 等
- 改动文件 eslint clean（仅剩既有风格的 `no-explicit-any` warning）、`tsc --noEmit` 在该文件零错误

覆盖面：**14/14** 个对象绑定 public block。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3cP1eY1novcNhQEDBrSZD

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3cP1eY1novcNhQEDBrSZD)_