### PR TITLE
fix(studio): stop offering the retired `action.shortcut` / `action.bulkEnabled` keys

### DIFF
--- a/.changeset/retired-action-keys-unauthorable.md
+++ b/.changeset/retired-action-keys-unauthorable.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/app-shell": minor
+"@object-ui/core": minor
+---
+
+Stop offering the retired `action.shortcut` / `action.bulkEnabled` keys.
+
+`@objectstack/spec` 17 retired both as `retiredKey()` tombstones: authoring
+either one is a hard PARSE REJECTION, so a draft carrying it cannot be saved
+at all. The designer still offered controls for both — a "Bulk — apply to
+multiple selected rows" checkbox and a "Shortcut" text field — which meant the
+Studio action inspector let an author build a draft the platform would then
+refuse, with the rejection arriving later and nowhere near the checkbox.
+
+- **Action inspector**: both controls removed. The keys stay hidden from the
+  fallback form (the server's live schema still advertises them, so dropping
+  them from the hidden list would put the inputs straight back) — now under a
+  `RETIRED_FIELDS` list that says why, so nobody "restores the missing
+  control". `bulkEnabled`'s replacement is the list view's `bulkActions` /
+  `bulkActionDefs`; `shortcut` has none.
+- **Action preview**: the `shortcut` and `bulk` pills are gone — they could
+  only ever render for metadata the platform now refuses.
+- **`ActionEngine.registerActions`**: no longer harvests the two retired keys
+  from authored metadata, which made two dead registration options look
+  load-bearing. Both are still accepted on the single-action
+  `registerAction(action, options)` overload, where a HOST passes them
+  explicitly.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
@@ -180,10 +180,28 @@ function ActionTargetField({ type, value, onCommit, cfg, readOnly }: {
 const CURATED_FIELDS = [
   'name', 'label', 'objectName', 'icon', 'variant', 'component',
   'type', 'target', 'execute', 'body', 'method',
-  'params', 'locations', 'bulkEnabled',
-  'confirmText', 'successMessage', 'errorMessage', 'refreshAfter', 'undoable', 'mode', 'shortcut',
+  'params', 'locations',
+  'confirmText', 'successMessage', 'errorMessage', 'refreshAfter', 'undoable', 'mode',
   'visible', 'disabled', 'aiExposed', 'aiDescription',
 ];
+
+/**
+ * Keys hidden from the fallback form for the OPPOSITE reason: not because this
+ * inspector edits them, but because `@objectstack/spec` 17 retired them as
+ * `retiredKey()` tombstones — authoring either one is a hard PARSE REJECTION,
+ * so a draft carrying it cannot be saved at all.
+ *
+ * They stay listed because the fallback renders from the server's live schema,
+ * which still advertises both; dropping them here would put the inputs back.
+ * This inspector used to offer its own controls for them (a "Bulk — apply to
+ * multiple selected rows" checkbox and a "Shortcut" text field), which is how
+ * the designer let an author build a draft the platform would then refuse.
+ *
+ * Do not add controls back. `bulkEnabled`'s replacement is the LIST VIEW's
+ * `bulkActions` / `bulkActionDefs`; `shortcut` has none — register the key in
+ * the Console keyboard stack and have its handler invoke the action by name.
+ */
+const RETIRED_FIELDS = ['bulkEnabled', 'shortcut'];
 
 /* ─────────────── small helpers ─────────────── */
 
@@ -420,7 +438,9 @@ export function ActionDefaultInspector({
         <div className="grid grid-cols-2 gap-2 pt-1">
           <InspectorSelectField label="Component" value={str('component') || undefined} options={COMPONENT_OPTS} onCommit={(v) => onPatch({ component: v })} disabled={readOnly} />
         </div>
-        <InspectorCheckboxField label="Bulk — apply to multiple selected rows" value={!!draft.bulkEnabled} onCommit={(v) => onPatch({ bulkEnabled: v })} disabled={readOnly} />
+        {/* No "Bulk" checkbox here: `action.bulkEnabled` is a spec-17
+            tombstone (see RETIRED_FIELDS). Selection placement is declared on
+            the LIST VIEW, in `bulkActions` / `bulkActionDefs`. */}
       </div>
 
       {/* 5 ─ Feedback */}
@@ -429,9 +449,11 @@ export function ActionDefaultInspector({
         <InspectorTextField label="Confirm prompt" value={localize(draft.confirmText)} onCommit={(v) => onPatch({ confirmText: v })} placeholder="Ask before running (leave blank to skip)" disabled={readOnly} />
         <InspectorTextField label="Success message" value={localize(draft.successMessage)} onCommit={(v) => onPatch({ successMessage: v })} disabled={readOnly} />
         <InspectorTextField label="Error message" value={localize(draft.errorMessage)} onCommit={(v) => onPatch({ errorMessage: v })} disabled={readOnly} />
+        {/* No "Shortcut" field beside Mode: `action.shortcut` is a spec-17
+            tombstone (see RETIRED_FIELDS) — nothing ever read it, and
+            authoring it now fails the parse. */}
         <div className="grid grid-cols-2 gap-2">
           <InspectorSelectField label="Mode" value={str('mode') || undefined} options={MODE_OPTS} onCommit={(v) => onPatch({ mode: v })} disabled={readOnly} />
-          <InspectorTextField label="Shortcut" value={str('shortcut')} onCommit={(v) => onPatch({ shortcut: v })} placeholder="e.g. Ctrl+S" disabled={readOnly} mono />
         </div>
         <div className="flex flex-wrap gap-x-4 gap-y-1">
           <InspectorCheckboxField label="Refresh view after" value={!!draft.refreshAfter} onCommit={(v) => onPatch({ refreshAfter: v })} disabled={readOnly} />
@@ -475,7 +497,7 @@ export function ActionDefaultInspector({
           <SchemaForm
             schema={fallbackSchema}
             value={draft}
-            hiddenFields={CURATED_FIELDS}
+            hiddenFields={[...CURATED_FIELDS, ...RETIRED_FIELDS]}
             readOnly={readOnly}
             onChange={(next) => onPatch(next)}
           />

--- a/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
@@ -10,7 +10,7 @@
  *      and `label` so authors can see the visual weight before they
  *      ship it (primary buttons are highlighted, danger turns red,
  *      icon-only actions render a compact icon button).
- *   2. A metadata strip: type, target, locations, shortcut, bulk
+ *   2. A metadata strip: type, target, locations
  *      flag, AI exposure, refreshAfter, confirmText.
  *   3. A params table when the action prompts the user — this is the
  *      modal/drawer it would open on click. We render it as a static
@@ -30,14 +30,12 @@ import {
   Code2,
   Eye,
   Globe,
-  Keyboard,
   LayoutGrid,
   Link2,
   Lock,
   MoreHorizontal,
   Pencil,
   RefreshCw,
-  ScanLine,
   Sparkles,
   Square,
   Workflow,
@@ -158,8 +156,9 @@ export function ActionPreview({ name, draft }: MetadataPreviewProps) {
   const variant = (d.variant as string | undefined) || undefined;
   const component = String(d.component ?? '');
   const locations = Array.isArray(d.locations) ? (d.locations as string[]) : [];
-  const shortcut = (d.shortcut as string | undefined) || undefined;
-  const bulkEnabled = !!d.bulkEnabled;
+  // No `shortcut` / `bulkEnabled` here: both are spec-17 `retiredKey()`
+  // tombstones, so a preview of them could only ever render for metadata the
+  // platform now refuses to parse. See ActionDefaultInspector's RETIRED_FIELDS.
   const refreshAfter = !!d.refreshAfter;
   const aiExposed = d.aiExposed;
   const confirmText = localize(d.confirmText);
@@ -204,8 +203,6 @@ export function ActionPreview({ name, draft }: MetadataPreviewProps) {
               {objectName && <Pill icon={Square} label={`object: ${objectName}`} mono />}
               {variant && <Pill label={`variant: ${variant}`} />}
               {component && <Pill icon={MoreHorizontal} label={component} />}
-              {shortcut && <Pill icon={Keyboard} label={shortcut} mono />}
-              {bulkEnabled && <Pill icon={ScanLine} label="bulk" tone="green" />}
               {refreshAfter && <Pill icon={RefreshCw} label="refresh after" />}
               {aiExposed === false && <Pill icon={Bot} label="AI: opted out" tone="amber" />}
               {aiExposed === true && <Pill icon={Sparkles} label="AI: exposed" />}

--- a/packages/core/src/actions/ActionEngine.ts
+++ b/packages/core/src/actions/ActionEngine.ts
@@ -142,13 +142,21 @@ export class ActionEngine {
     }
   }
 
-  /** Register multiple actions from an ActionSchema array */
+  /**
+   * Register multiple actions from an ActionSchema array.
+   *
+   * Only `locations` is harvested from the metadata. `shortcut` and
+   * `bulkEnabled` used to be read here too, but spec 17 retired both as
+   * `retiredKey()` tombstones — a declaration carrying either one no longer
+   * parses, so harvesting them read a key that cannot exist and made two dead
+   * options look load-bearing. Both remain accepted on the single-action
+   * `registerAction(action, options)` overload, where a HOST passes them
+   * explicitly; they are simply no longer sourced from authored metadata.
+   */
   registerActions(actions: ActionDef[]): void {
     for (const action of actions) {
       this.registerAction(action, {
         locations: (action as any).locations,
-        shortcut: (action as any).shortcut,
-        bulkEnabled: (action as any).bulkEnabled,
       });
     }
   }

--- a/packages/core/src/actions/__tests__/ActionEngine.test.ts
+++ b/packages/core/src/actions/__tests__/ActionEngine.test.ts
@@ -56,6 +56,19 @@ describe('ActionEngine', () => {
       expect(engine.getAction('save')).toBeDefined();
       expect(engine.getAction('delete')).toBeDefined();
     });
+
+    it('does not harvest the retired `shortcut` / `bulkEnabled` keys from metadata', () => {
+      // spec 17 retired both as `retiredKey()` tombstones — a declaration
+      // carrying either no longer parses, so reading them here made two dead
+      // options look load-bearing. A host may still pass them explicitly to
+      // `registerAction`; they are just not sourced from authored metadata.
+      engine.registerActions([
+        { name: 'stale', type: 'api', shortcut: 'ctrl+k', bulkEnabled: true } as never,
+      ]);
+      expect(engine.getAction('stale')).toBeDefined();
+      expect(engine.getShortcuts()).toHaveLength(0);
+      expect(engine.getBulkActions().map((a) => a.name)).not.toContain('stale');
+    });
   });
 
   describe('unregisterAction', () => {

--- a/packages/react/src/hooks/__tests__/useActionEngine.test.ts
+++ b/packages/react/src/hooks/__tests__/useActionEngine.test.ts
@@ -78,14 +78,20 @@ describe('useActionEngine', () => {
   });
 
   describe('getBulkActions', () => {
-    it('returns only bulk-enabled actions', () => {
+    // Deliberately INVERTED. `sampleActions` still carries the stale
+    // `bulkEnabled: true` — spec 17 retired the key as a `retiredKey()`
+    // tombstone, so metadata like this no longer parses at all, and harvesting
+    // it here made a dead registration option look load-bearing. Same posture
+    // as plugin-grid's "ignores a stale bulkEnabled flag on an object action".
+    // The engine's bulk mechanics keep their coverage in ActionEngine.test.ts,
+    // where a HOST passes `{ bulkEnabled: true }` to `registerAction`
+    // explicitly — which is still supported.
+    it('does not harvest the retired bulkEnabled key from metadata', () => {
       const { result } = renderHook(() =>
         useActionEngine({ actions: sampleActions }),
       );
 
-      const bulkActions = result.current.getBulkActions();
-      expect(bulkActions.length).toBe(1);
-      expect(bulkActions[0].name).toBe('mark_complete');
+      expect(result.current.getBulkActions()).toEqual([]);
     });
   });
 
@@ -119,7 +125,14 @@ describe('useActionEngine', () => {
   });
 
   describe('handleShortcut', () => {
-    it('handles registered keyboard shortcut', async () => {
+    // Deliberately INVERTED, for the same reason as getBulkActions above:
+    // `sampleActions` still declares the stale `shortcut: 'ctrl+k'`, which
+    // spec 17 retired. Its tombstone is explicit that nothing ever consumed it
+    // ("no keydown listener feeds ActionEngine.getShortcuts(), and objectui's
+    // keyboard stack is hand-registered and never consults action metadata"),
+    // so harvesting it only kept a dead path looking alive. A host that wants
+    // a shortcut still passes one to `registerAction` explicitly.
+    it('does not harvest the retired shortcut key from metadata', async () => {
       const { result } = renderHook(() =>
         useActionEngine({ actions: sampleActions }),
       );
@@ -129,8 +142,7 @@ describe('useActionEngine', () => {
         shortcutResult = await result.current.handleShortcut('ctrl+k');
       });
 
-      expect(shortcutResult).not.toBeNull();
-      expect(shortcutResult.success).toBe(true);
+      expect(shortcutResult).toBeNull();
     });
 
     it('returns null for unregistered shortcut', async () => {


### PR DESCRIPTION
## 问题

spec 17 用 `retiredKey()` 退役了 `action.shortcut` 与 `action.bulkEnabled` —— **写了就是硬解析拒绝**,带这两个 key 的草稿根本存不下去。

但 Studio 的动作检查器至今还给它们提供控件:一个「Bulk — apply to multiple selected rows」复选框和一个「Shortcut」文本框。也就是说,设计器**引导作者构造一份平台注定拒收的草稿**,而拒绝信息出现在保存时、离那个复选框十万八千里。

## 改动

- **检查器**:两个控件删除。两个 key 仍留在回退表单的隐藏名单里 —— 服务端 live schema 目前**还在**声明它们(根源在 objectstack-ai/objectstack#4501 里一并修),把它们从隐藏名单里拿掉反而会让输入框原样回来。现在它们归入一个新的 `RETIRED_FIELDS` 列表并写明缘由,免得后来者把"缺失的控件"补回去。
- **预览**:`shortcut` / `bulk` 两个徽标删除 —— 它们只可能为平台已拒收的元数据渲染。
- **`ActionEngine.registerActions`**:不再从作者元数据里采集这两个退役 key。此前的采集让两个死掉的注册选项**看起来仍在承重**。两者在单动作重载 `registerAction(action, options)` 上继续保留 —— 那是**主机**显式传入的运行期 API,与元数据 key 不是一回事。

## 为什么两个 key 一起处理

同一个墓碑、同一次退役、同三处表面(检查器控件 / 预览徽标 / 引擎采集)。只修 `bulkEnabled` 而把 `shortcut` 留在一行之隔,是任意的。

## 替代路径

`bulkEnabled` 的替代是列表视图的 `bulkActions` / `bulkActionDefs`(墓碑原文如此);`shortcut` 没有替代 —— 按墓碑说明,在 Console 键盘栈里注册按键、让其 handler 按名字调用动作。

## 测试

- 新增 pin:`registerActions` 不再从元数据采集这两个 key,并写清主机显式传入的路径不受影响。
- **有意翻转**了 `useActionEngine` 的两条测试(`getBulkActions` / `handleShortcut`),它们此前正是靠这条采集才通过。翻转前先确认没有打断活的能力 —— 该 hook 的产品消费者(`record-quick-actions`、`record-alert`)只用 `getActionsForLocation` / `executeAction`,这两个能力无人调用。fixture 里的陈旧 key **特意保留**,让断言正面证明"它们被忽略",而不是删掉证据让测试变绿(与 plugin-grid 既有的 "ignores a stale bulkEnabled flag" 同一形态)。引擎自身的 bulk / shortcut 机制在 `ActionEngine.test.ts` 由主机显式传参覆盖,未损失。

验证:仓根 `pnpm test` **9277 项通过 / 0 失败**(795 文件);全量构建通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9aiswZBzoVYsyLKRuGByE