### PR TITLE
ci: 修正 turbo 2.x 的 Actions 缓存路径(Type Check 关键路径 ~6min → 预计 ~4min)

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Turbo Cache
         uses: actions/cache@v6
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Turbo Cache
         uses: actions/cache@v6
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-type-check-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-type-check-
@@ -324,7 +324,7 @@ jobs:
         if: steps.docs-changes.outputs.should_run == 'true'
         uses: actions/cache@v6
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-docs-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-docs-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Turbo Cache
         uses: actions/cache@v6
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-

--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Turbo Cache
         uses: actions/cache@v6
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Turbo Cache
         uses: actions/cache@v6
         with:
-          path: node_modules/.cache/turbo
+          path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ runner.os }}-


### PR DESCRIPTION
## 问题

六处缓存步骤(ci.yml 的 type-check/docs、lint.yml、release.yml、changeset-release.yml、performance-budget.yml)仍指向 **turbo 1.x** 的缓存目录 `node_modules/.cache/turbo`,而仓库用的是 `turbo ^2.10.7`,实际读写 **`.turbo/cache`**。已在本仓库实测确认:跑一个 turbo 任务后 `node_modules/.cache/turbo` 不存在,缓存 tarball 写入 `.turbo/cache/`,且 `turbo config` 报告 `cacheDir: ".turbo/cache"`。

也就是说这些 job 每次恢复和保存的都是不存在的目录,Turbo 缓存**完全失效**。实测后果(run 30700529091):Type Check 的缓存恢复步骤 1 秒(空),随后 `turbo run type-check` 在冷缓存下全量重建 `^build` 依赖并全量检查,耗时 **5m26s**,是该仓库 CI 的关键路径。作为对照,objectstack 的 ci.yml 用的是正确路径,其注释记录了同一构建"无缓存 ~4.5 分钟 / 有缓存不到 1 分钟"。

## 改动

6 处 `path: node_modules/.cache/turbo` → `path: .turbo/cache`,无其它变更。缓存键沿用现状,旧键下的既有缓存条目会自然失配换新。

## 预期效果

Type Check(及 lint、docs、release 系列)在未变更包上命中缓存;PR 关键路径从 ~6 min 降到 ~4 min(转为由 test 分片决定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8Ms7unkKxTrmNCX2r1dfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8Ms7unkKxTrmNCX2r1dfs)_