### PR TITLE
feat(deps)!: upgrade to @objectstack/spec 17.0.0-rc.1 and retire the wait timeout fields (#3101)

### DIFF
--- a/.changeset/spec-rc1-wait-timeout-fields-retired.md
+++ b/.changeset/spec-rc1-wait-timeout-fields-retired.md
@@ -1,0 +1,61 @@
+---
+"@object-ui/app-shell": minor
+"@object-ui/types": minor
+"@object-ui/plugin-dashboard": patch
+"@object-ui/plugin-report": patch
+---
+
+Upgrade to `@objectstack/spec@17.0.0-rc.1`, stop offering the retired `wait` timeout fields (#3101), and route the newly-adopted `combo` chart type.
+
+**Breaking for authoring, and the reason to do it now**: the `wait` panel no longer offers
+`waitEventConfig.timeoutMs` or `.onTimeout`. Both are `retiredKey()` tombstones as of spec
+17.0.0-rc.1 (framework#4158), which means a value written there is **rejected at load** —
+so until this lands, Studio can produce flow metadata the author's own runtime refuses.
+That hazard opened the moment rc.1 published, independent of when this repo bumps.
+
+`wait` never had a timeout: `onTimeout` had zero readers, so neither `'fail'` nor
+`'continue'` ever happened, and `timeoutMs`'s only reader used it as the timer **duration**
+when `timerDuration` was absent. Use **Duration** — it accepts a bare number as
+milliseconds, making the old `timeoutMs: 60000` and `timerDuration: '60000'` the same wait.
+Stored flows are converted by framework's D2 conversion; the designer simply stops offering
+the entry. The two `zh` label overrides go with the fields.
+
+#3101 asked for this to ride along with the bump rather than land alone, and that is
+load-bearing: the sibling-block assertion is **bidirectional**, so deleting the fields
+against a spec that still declares them fails in the other direction.
+
+**`combo` is now a spec chart type** — the sole addition to `ChartTypeSchema` in rc.1 (19
+members → 20). It had been a renderer-local family the chart renderer derived from the
+series, so nothing classified it on the two surfaces that route a *spec* chart type: a
+spec-valid `combo` fell through to the red "Unknown component type" panel on a dashboard
+and to the out-of-spec notice on a report. Both now route it
+(`widgetDispatch.SERIES_CHART_TYPES`, `planReportChart`). The renderer-local derivation
+stays — it is what makes an authored `type: 'combo'` render rather than merely validate.
+
+**Retired spec exports this repo bound to**, all removed upstream in spec 17.0.0:
+
+- `JoinStrategy` / `WindowFunction` (framework#4286 tombstoned `query.joins` and
+  `query.windowFunctions`: no engine or driver ever read either on the query path). They
+  were derived off the spec enums under objectstack#4115's "come off the spec enum, not a
+  restatement" rule; with no enum left, `data-protocol.ts` now restates the members locally
+  — verbatim from the last spec that published them — as the objectui query-AST vocabulary
+  they have become. The AST itself is unchanged.
+- `PerformanceConfig`, retired with `dashboard.performance` (framework#3896). Nothing bound
+  to it — `@object-ui/react`'s `usePerformance` declares its own interface and is untouched.
+  The dashboard form is derived from the spec's own `dashboardForm`, so the field
+  disappears from the inspector for free; its test now pins the absence.
+
+**Three inverted pins fired, and are recorded rather than resolved.** objectstack#4171's
+tripwires asserted that `NavigationItem`, `FormField` and `ConditionalValidation`'s branches
+still erased to `any`/`unknown` upstream — the premise that justified objectui keeping local
+declarations. rc.1 types them properly, so the assertions are inverted to state the new
+fact. The burn-down each one asks for — deriving those types from the spec — touches
+widely-used public types and is deliberately **not** bundled into a version bump; it is
+tracked in #3177. `JoinNode`'s pin is gone outright: the symbol no longer exists.
+
+**What the bump arms.** The reconciliation ledger's `subflow` and `decision` panels
+feature-detect their spec exports and had never actually run — rc.0 predates the exports
+(framework#4278). They now execute and pass. The `script` panel's full bidirectional check
+stays deliberately skipped: rc.1 predates framework#4343, so the retired dispatch branches
+are still contract keys there, and only the "offers nothing the executor ignores" direction
+is meaningful. It arms itself on the next rc.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
     "@eslint/js": "^10.0.1",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@playwright/test": "^1.62.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -50,7 +50,7 @@
     "@object-ui/types": "workspace:*",
     "@objectstack/formula": "^17.0.0-rc.0",
     "@objectstack/lint": "^17.0.0-rc.0",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@sentry/react": "^10.68.0",
     "jsonc-parser": "^3.3.1",
     "lucide-react": "^1.25.0",

--- a/packages/app-shell/src/views/metadata-admin/dashboard-schema.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/dashboard-schema.test.ts
@@ -44,7 +44,7 @@ describe('dashboard-schema — getDashboardForm', () => {
     expect(declared.has('name')).toBe(false);
   });
 
-  it('keeps non-owned spec fields (e.g. layout / filters / performance)', () => {
+  it('keeps non-owned spec fields (e.g. layout / filters), and carries a retirement through', () => {
     const form = getDashboardForm();
     const declared = new Set<string>();
     for (const s of form?.sections ?? []) {
@@ -52,10 +52,16 @@ describe('dashboard-schema — getDashboardForm', () => {
         declared.add(typeof f === 'string' ? f : (f as { field: string }).field);
       }
     }
-    // Layout, filter and advanced fields survive the prune.
+    // Layout and filter fields survive the prune.
     expect(declared.has('columns')).toBe(true);
     expect(declared.has('globalFilters')).toBe(true);
-    expect(declared.has('performance')).toBe(true);
+    // `performance` was RETIRED in spec 17.0.0 (framework#3896 audit close-out):
+    // no renderer or runtime ever read it. This form is derived from the spec's
+    // own `dashboardForm`, so the removal arrives here for free — which is the
+    // point of deriving instead of hand-listing, and worth pinning: were this
+    // file ever to hardcode a field list again, a retirement would silently
+    // keep offering an input the loader rejects.
+    expect(declared.has('performance')).toBe(false);
   });
 
   it('drops sections that become empty after pruning', () => {

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -3516,8 +3516,8 @@ const FLOW_FIELD_ZH: Record<string, Record<string, FlowFieldZh>> = {
     },
     'waitEventConfig.timerDuration': { label: '时长', help: 'ISO 8601 时长(如 PT1H、P3D)。' },
     'waitEventConfig.signalName': { label: '信号名称' },
-    'waitEventConfig.timeoutMs': { label: '超时(毫秒)' },
-    'waitEventConfig.onTimeout': { label: '超时时', opts: { fail: '失败', continue: '继续' } },
+    // `waitEventConfig.timeoutMs` / `.onTimeout` 的覆盖随字段一并移除(#3101):
+    // 两个键在 spec 17.0.0-rc.1 已是墓碑,表单不再提供授权入口。
   },
   subflow: {
     flowName: { label: '流程' },

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -763,15 +763,17 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
       showWhen: { field: 'waitEventConfig.eventType', equals: ['signal', 'webhook'] },
       fallbackPath: ['config', 'signalName'],
     }),
-    at('waitEventConfig', 'timeoutMs', 'Timeout (ms)', 'number', { placeholder: '3600000', fallbackPath: ['config', 'timeoutMs'] }),
-    at('waitEventConfig', 'onTimeout', 'On timeout', 'select', {
-      options: [
-        { value: 'fail', label: 'Fail' },
-        { value: 'continue', label: 'Continue' },
-      ],
-      defaultValue: 'fail',
-      fallbackPath: ['config', 'onTimeout'],
-    }),
+    // `waitEventConfig.timeoutMs` / `.onTimeout` were REMOVED here (#3101,
+    // framework#4158): `wait` never had a timeout. `onTimeout` had zero readers
+    // — neither 'fail' nor 'continue' ever happened — and `timeoutMs`'s only
+    // reader used it as the timer DURATION when `timerDuration` was absent, so
+    // it did something, just not what it said. Both are `retiredKey()`
+    // tombstones on `FlowNodeSchema` since spec 17.0.0-rc.1, so a value written
+    // here is now REJECTED at load: keeping the fields would let an author
+    // produce metadata their own runtime refuses. Use `Duration` above — it
+    // accepts a bare number as milliseconds, making the old `timeoutMs: 60000`
+    // and `timerDuration: '60000'` the same wait. Stored flows are converted by
+    // framework's D2 conversion; the designer just stops offering the entry.
   ],
   subflow: [
     cfg('flowName', 'Flow', 'reference', { ref: { kind: 'flow' }, placeholder: 'escalation_flow' }),

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "better-auth": "^1.6.25"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -90,7 +90,7 @@
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@object-ui/types": "workspace:*",
     "@objectstack/formula": "^17.0.0-rc.0",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "lodash": "^4.18.1",
     "zod": "^4.4.3"
   },

--- a/packages/data-objectstack/package.json
+++ b/packages/data-objectstack/package.json
@@ -35,7 +35,7 @@
     "@objectstack/client": "^17.0.0-rc.0"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.4",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -40,7 +40,7 @@
     "@object-ui/types": "workspace:*"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@types/react": "19.2.17",
     "react": "19.2.8",
     "typescript": "^6.0.3",

--- a/packages/plugin-charts/package.json
+++ b/packages/plugin-charts/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.4",

--- a/packages/plugin-dashboard/package.json
+++ b/packages/plugin-dashboard/package.json
@@ -42,7 +42,7 @@
     "react-grid-layout": "^2.2.0 || ^1.4.0"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@types/react-grid-layout": "^2.1.0",
     "@vitejs/plugin-react": "^6.0.4",
     "react-grid-layout": "^2.2.3",

--- a/packages/plugin-dashboard/src/widgetDispatch.ts
+++ b/packages/plugin-dashboard/src/widgetDispatch.ts
@@ -44,6 +44,12 @@ export const CHART_TYPE_ALIASES: Record<string, string> = {
 export const SERIES_CHART_TYPES: ReadonlySet<string> = new Set([
   'bar', 'horizontal-bar', 'line', 'area', 'pie', 'donut',
   'scatter', 'funnel', 'radar', 'treemap', 'sankey',
+  // `combo` joined `ChartTypeSchema` in spec 17.0.0-rc.1. The chart renderer
+  // has always drawn it (it derives the base family from the series), but it
+  // was renderer-local, so nothing routed it from a dashboard surface — a
+  // stored `combo` widget fell through to the red "Unknown component type"
+  // panel the moment the spec started accepting it.
+  'combo',
 ]);
 
 /**

--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@object-ui/i18n": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "lucide-react": "^1.25.0"
   },
   "peerDependencies": {

--- a/packages/plugin-form/package.json
+++ b/packages/plugin-form/package.json
@@ -28,7 +28,7 @@
     "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "lucide-react": "^1.25.0"
   },
   "peerDependencies": {

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -38,7 +38,7 @@
     "@object-ui/plugin-detail": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "lucide-react": "^1.25.0",
     "sonner": "^2.0.7"
   },

--- a/packages/plugin-grid/package.json
+++ b/packages/plugin-grid/package.json
@@ -29,7 +29,7 @@
     "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@tanstack/react-virtual": "^3.14.8",
     "exceljs": "^4.4.0",
     "lucide-react": "^1.25.0"
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@object-ui/data-objectstack": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@vitejs/plugin-react": "^6.0.4",
     "msw": "^2.15.0",
     "typescript": "^6.0.3",

--- a/packages/plugin-list/package.json
+++ b/packages/plugin-list/package.json
@@ -53,7 +53,7 @@
     "@object-ui/mobile": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "^6.0.4",

--- a/packages/plugin-map/package.json
+++ b/packages/plugin-map/package.json
@@ -35,7 +35,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "lucide-react": "^1.25.0",
     "maplibre-gl": "^6.0.0",
     "react-map-gl": "^8.1.1",

--- a/packages/plugin-report/package.json
+++ b/packages/plugin-report/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@types/node": "^26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -545,6 +545,11 @@ export type ReportChartPlan =
  *   renders beneath the chart slot is exactly the tabular presentation;
  * - anything else is out-of-spec and gets a visible notice.
  *
+ * `combo` joined `ChartTypeSchema` in spec 17.0.0-rc.1 and routes as a series
+ * chart. It was renderer-local until then — the chart renderer derives the base
+ * family from the series — so nothing here classified it, and a spec-valid combo
+ * report hit the out-of-spec notice the moment the spec started accepting one.
+ *
  * Exported for the spec-parity test, which fails the moment `ChartTypeSchema`
  * and this classification drift in either direction.
  */
@@ -562,6 +567,7 @@ export function planReportChart(t: unknown): ReportChartPlan {
     case 'treemap':
     case 'sankey':
     case 'radar':
+    case 'combo':
       return { kind: 'series', chartType: t };
     case 'gauge':
     case 'solid-gauge':

--- a/packages/plugin-timeline/package.json
+++ b/packages/plugin-timeline/package.json
@@ -37,7 +37,7 @@
     "@object-ui/mobile": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "class-variance-authority": "^0.7.1",
     "zod": "^4.4.3"
   },

--- a/packages/plugin-tree/package.json
+++ b/packages/plugin-tree/package.json
@@ -35,7 +35,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "lucide-react": "^1.25.0"
   },
   "peerDependencies": {

--- a/packages/plugin-view/package.json
+++ b/packages/plugin-view/package.json
@@ -31,7 +31,7 @@
     "@object-ui/plugin-grid": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "class-variance-authority": "^0.7.1",
     "lucide-react": "^1.25.0"
   },

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -37,7 +37,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "typescript": "^6.0.3"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
     "@object-ui/data-objectstack": "workspace:*",
     "@object-ui/i18n": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "react-hook-form": "^7.83.0"
   },
   "peerDependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -90,7 +90,7 @@
     "directory": "packages/types"
   },
   "dependencies": {
-    "@objectstack/spec": "^17.0.0-rc.0",
+    "@objectstack/spec": "^17.0.0-rc.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/types/src/__tests__/spec-derived-unions.test.ts
+++ b/packages/types/src/__tests__/spec-derived-unions.test.ts
@@ -60,10 +60,7 @@ import {
 } from '@objectstack/spec/ui';
 import {
   FieldType as SpecFieldType,
-  JoinStrategy as SpecJoinStrategy,
-  WindowFunction as SpecWindowFunction,
 } from '@objectstack/spec/data';
-import type { JoinNode as SpecJoinNode } from '@objectstack/spec/data';
 // The objectstack#4171 inverted pin must import the banned name to probe its
 // any-ness — this guard is a sanctioned importer (#3090 tripwire).
 /* eslint-disable no-restricted-imports -- reported at the specifier line, out of -next-line reach */
@@ -74,7 +71,6 @@ import type {
 /* eslint-enable no-restricted-imports */
 import type { BreakpointName } from '../mobile';
 import type { ExportJobStatus, ImportJobStatus, ImportWriteMode, ValidationError } from '../data';
-import type { JoinStrategy, WindowFunction } from '../data-protocol';
 import {
   OBJECTUI_LOCAL_ACTION_TYPES,
   OBJECTUI_LOCAL_PARAM_FIELD_TYPES,
@@ -139,47 +135,50 @@ const _importStatusCovers = null as unknown as
 const _exportStatusCovers = null as unknown as
   | 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled' | 'expired' satisfies ExportJobStatus;
 const _validationErrorShape: ValidationError = { field: 'name', message: 'required' };
-// The spec exports these two as zod enums, not types, so objectui derives them
-// with `z.infer`. Reading the members back off the schema keeps the check honest
-// if the spec widens either enum.
-type SpecJoin = typeof SpecJoinStrategy extends { options: readonly (infer T)[] } ? T : never;
-const _joinStrategyCovers = null as unknown as SpecJoin satisfies JoinStrategy;
-type SpecWindow = typeof SpecWindowFunction extends { options: readonly (infer T)[] } ? T : never;
-const _windowFunctionCovers = null as unknown as SpecWindow satisfies WindowFunction;
+// `JoinStrategy` / `WindowFunction` USED to be derived off the spec's zod enums
+// (objectstack#4115, "come off the spec enum, not a restatement"). Spec 17.0.0
+// retired both — `query.joins` and `query.windowFunctions` were tombstoned
+// because no engine or driver ever read them on the query path (framework#4286)
+// — so there is no enum left to derive from and the pins that enforced it are
+// gone with the imports. `packages/types/src/data-protocol.ts` now restates the
+// members locally, verbatim from the last spec that published them, as the
+// objectui query-AST vocabulary they have become.
 
 /**
- * Inverted pins — three collisions that are NOT burnable, and the tripwire that
- * says when they become burnable.
+ * Inverted pins — the tripwire FIRED on spec 17.0.0-rc.1 (#3177).
  *
- * `NavigationItem`, `JoinNode` and `FormField` collide with a spec export whose
- * own declaration resolves to `any` (the spec annotates the recursive schemas
- * behind them as `z.ZodType<any>`, and `z.infer` of that is `any`). Binding
- * objectui's local interface to the spec would replace a precise, documented
- * shape with `any` — a type-safety regression wearing a burn-down's clothes. So
- * they stay in the ledger with their local declarations intact, which is the
- * right answer for as long as the spec cannot describe them.
+ * `NavigationItem`, `JoinNode` and `FormField` used to collide with a spec
+ * export whose own declaration resolved to `any` (the spec annotated the
+ * recursive schemas behind them as `z.ZodType<any>`, and `z.infer` of that is
+ * `any`). Binding objectui's local interface to that would have replaced a
+ * precise, documented shape with `any` — a type-safety regression wearing a
+ * burn-down's clothes — so they stayed local, and these pins asserted the
+ * premise held. Filed upstream as objectstack#4171.
  *
- * Filed upstream as objectstack#4171 (4 of the spec's 2240 exported types).
+ * Two of them are now typed properly upstream, so the assertions below are
+ * inverted to record that fact rather than the old one. **They are a record,
+ * not a resolution**: the burn-down each one asks for — deriving objectui's
+ * `NavigationItem` / `FormField` from the spec — touches widely-used public
+ * types and is deliberately NOT bundled into a version bump. Tracked in #3177.
  *
- * Mutual assignability CANNOT distinguish this case on its own: `any` answers
- * every `extends` question affirmatively, so a naive probe reports these three
- * as "identical to the spec" and recommends exactly the wrong edit.
+ * `JoinNode`'s pin is gone entirely: spec 17.0.0 retired the symbol
+ * (framework#4286), so there is no collision left to reason about.
  *
- * The day the spec types any of them properly, `IsAny<…>` flips to `false`,
- * `true satisfies false` stops compiling, and the failure is the instruction:
- * re-run the triage and burn that symbol down.
+ * Mutual assignability CANNOT distinguish the `any` case on its own: `any`
+ * answers every `extends` question affirmatively, so a naive probe reports such
+ * a symbol as "identical to the spec" and recommends exactly the wrong edit.
+ * That is why these are written as explicit `IsAny` probes.
  */
 type IsAny<T> = 0 extends 1 & T ? true : false;
-const _specNavigationItemIsStillAny = true satisfies IsAny<SpecNavigationItem>;
-const _specJoinNodeIsStillAny = true satisfies IsAny<SpecJoinNode>;
-const _specFormFieldIsStillAny = true satisfies IsAny<SpecFormField>;
+const _specNavigationItemIsStillAny = false satisfies IsAny<SpecNavigationItem>;
+const _specFormFieldIsStillAny = false satisfies IsAny<SpecFormField>;
 
 void _chartCovers; void _reportCovers; void _actionCovers; void _pageCovers; void _vizCovers;
 void _runnableCovers; void _componentCovers; void _paramFieldCovers; void _resolvableCovers;
 void _fieldBackedParam; void _minimalTypedParam;
 void _breakpointCovers; void _importModeCovers; void _importStatusCovers; void _exportStatusCovers;
-void _validationErrorShape; void _joinStrategyCovers; void _windowFunctionCovers;
-void _specNavigationItemIsStillAny; void _specJoinNodeIsStillAny; void _specFormFieldIsStillAny;
+void _validationErrorShape;
+void _specNavigationItemIsStillAny; void _specFormFieldIsStillAny;
 
 /** Read a spec enum's members, failing loudly if the shape ever changes. */
 const optionsOf = (schema: unknown, name: string): string[] => {
@@ -218,17 +217,26 @@ describe('unions derived from a spec vocabulary stay derived (#2944)', () => {
     expect([...OBJECTUI_LOCAL_ACTION_TYPES]).toEqual(['navigation']);
   });
 
-  it('`combo` is not a spec chart type — the spec models it per-series', () => {
+  it('`combo` IS a spec chart type since 17.0.0-rc.1 — the tripwire fired', () => {
     // `plugin-charts`'s `ChartFamily` carries `combo`, which #2945 listed as
-    // "promote or delete". Neither: `ChartSeries.type` already exists and its
-    // own field comment reads "Series type override (combo charts)", so the
-    // spec expresses a combo per-series, exactly as it expresses stacking with
-    // `ChartSeries.stack` rather than a `stacked-bar` family. `combo` stays a
-    // renderer-local marker that `effectiveChartFamily` DERIVES from the series.
+    // "promote or delete". For a long time the answer was neither: the spec
+    // expressed a combo PER-SERIES (`ChartSeries.type`, "Series type override
+    // (combo charts)"), exactly as it expresses stacking with `ChartSeries.stack`
+    // rather than a `stacked-bar` family — so `combo` stayed a renderer-local
+    // marker that `effectiveChartFamily` DERIVES from the series, and this test
+    // was the tripwire watching for the spec to adopt it.
     //
-    // Tripwire, same shape as `navigation` above: if the spec ever adopts
-    // `combo`, this fails and the derivation is what to retire.
-    expect(optionsOf(SpecChartTypeSchema, 'ChartTypeSchema')).not.toContain('combo');
+    // Spec 17.0.0-rc.1 adopted it (the sole addition to `ChartTypeSchema`, 19
+    // members → 20). The assertion is inverted to pin the new fact, and the two
+    // surfaces that classify a spec chart type were taught to route it —
+    // `widgetDispatch.SERIES_CHART_TYPES` and `planReportChart` — because until
+    // they were, a spec-valid `combo` fell through to a red error box on a
+    // dashboard and to the out-of-spec notice on a report.
+    //
+    // The renderer-local DERIVATION stays: `effectiveChartFamily` still infers a
+    // combo from mixed series types, which is what makes an authored
+    // `type: 'combo'` render rather than merely validate.
+    expect(optionsOf(SpecChartTypeSchema, 'ChartTypeSchema')).toContain('combo');
   });
 
   it('ReportType includes `joined` — the member the fork dropped', () => {
@@ -316,16 +324,8 @@ describe('unions derived from a spec vocabulary stay derived (#2944)', () => {
     expect(local.filter((v) => spec.includes(v))).toEqual([]);
   });
 
-  it('JoinStrategy / WindowFunction come off the spec enum, not a restatement (objectstack#4115)', () => {
-    // The type aliases erase, so the runtime witness is the schema they are
-    // `z.infer`-ed from. Both were hand-written unions carrying a "(ObjectStack
-    // Spec v2.0.1)" doc header — a version claim nothing checked.
-    const joins = optionsOf(SpecJoinStrategy, 'JoinStrategy');
-    expect(joins).toEqual(expect.arrayContaining(['auto', 'database', 'hash', 'loop']));
-
-    const windows = optionsOf(SpecWindowFunction, 'WindowFunction');
-    for (const member of ['row_number', 'rank', 'dense_rank', 'lag', 'lead', 'sum', 'count']) {
-      expect(windows).toContain(member);
-    }
-  });
+  // The `JoinStrategy` / `WindowFunction` runtime pin (objectstack#4115) was
+  // REMOVED with spec 17.0.0: both enums were retired there (framework#4286), so
+  // there is no spec schema left to read members off. See the note beside the
+  // type-level pins above.
 });

--- a/packages/types/src/__tests__/validation-rule-spec-parity.test.ts
+++ b/packages/types/src/__tests__/validation-rule-spec-parity.test.ts
@@ -104,14 +104,17 @@ const _conditionalNonBranchKeysAreSpec = true satisfies Equal<
 // …and the branches are precise here, not `unknown`.
 const _conditionalBranchIsTyped = false satisfies IsUnknown<ConditionalValidation['then']>;
 
-// INVERTED PIN (objectstack#4171). The divergence above is only justified while
-// the spec's own `then`/`otherwise` erase to `unknown`. The day the spec types
-// them, these fail — and the failure is the instruction: delete the divergence
-// and derive `ConditionalValidation` whole.
-const _specThenIsStillUnknown = true satisfies IsUnknown<
+// INVERTED PIN (objectstack#4171) — FIRED on spec 17.0.0-rc.1 (#3177).
+//
+// The divergence above was only justified while the spec's own
+// `then`/`otherwise` erased to `unknown`. They no longer do, so the assertions
+// are inverted to record that. **A record, not a resolution**: what the pin asks
+// for — deleting the divergence and deriving `ConditionalValidation` whole — is
+// deliberately not bundled into a version bump. Tracked in #3177.
+const _specThenIsStillUnknown = false satisfies IsUnknown<
   z.input<typeof ConditionalValidationSchema>['then']
 >;
-const _specOtherwiseIsStillUnknown = true satisfies IsUnknown<
+const _specOtherwiseIsStillUnknown = false satisfies IsUnknown<
   z.input<typeof ConditionalValidationSchema>['otherwise']
 >;
 

--- a/packages/types/src/data-protocol.ts
+++ b/packages/types/src/data-protocol.ts
@@ -27,8 +27,6 @@ import type { FilterBuilderOperator as BaseFilterOperator } from './complex';
 // derived on the `z.input` (authored/wire) side rather than `z.infer`.
 import type { z } from 'zod';
 import type {
-  JoinStrategy as SpecJoinStrategy,
-  WindowFunction as SpecWindowFunction,
   ScriptValidationSchema as SpecScriptValidationSchema,
   StateMachineValidationSchema as SpecStateMachineValidationSchema,
   CrossFieldValidationSchema as SpecCrossFieldValidationSchema,
@@ -97,9 +95,17 @@ export interface WhereNode extends QueryASTNode {
 }
 
 /**
- * Join execution strategy hint — derived from the spec's `JoinStrategy` zod enum.
+ * Join execution strategy hint — objectui query-AST vocabulary.
+ *
+ * Was bound to the spec's `JoinStrategy` zod enum until spec 17.0.0, which
+ * retired `query.joins` and the whole JoinNode cluster with it (framework#4286:
+ * no engine or driver ever read a join on the query path, so every join a
+ * caller declared was silently dropped — `expand` is the live spelling of
+ * related-record retrieval). The members below are that enum's, verbatim: this
+ * repo's query AST is unchanged, it simply no longer derives from a retired
+ * export.
  */
-export type JoinStrategy = z.infer<typeof SpecJoinStrategy>;
+export type JoinStrategy = 'auto' | 'database' | 'hash' | 'loop';
 
 /**
  * JOIN clause node (Phase 3.3.4)
@@ -171,9 +177,18 @@ export interface AggregateNode extends QueryASTNode {
 }
 
 /**
- * Window function type — derived from the spec's `WindowFunction` zod enum.
+ * Window function type — objectui query-AST vocabulary.
+ *
+ * Was bound to the spec's `WindowFunction` zod enum until spec 17.0.0, which
+ * retired `query.windowFunctions` and its cluster (framework#4286: OVER clauses
+ * only ever ran behind a driver-level door whose flat input shape the spec
+ * vocabulary never matched, so every window function declared on the query path
+ * was dropped). The members below are that enum's, verbatim.
  */
-export type WindowFunction = z.infer<typeof SpecWindowFunction>;
+export type WindowFunction =
+  | 'row_number' | 'rank' | 'dense_rank' | 'percent_rank'
+  | 'lag' | 'lead' | 'first_value' | 'last_value'
+  | 'sum' | 'avg' | 'count' | 'min' | 'max';
 
 /**
  * Window frame unit — objectui query-AST vocabulary (no spec counterpart).

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1159,8 +1159,12 @@ export type {
 // ============================================================================
 // v2.0.7 Spec UI Types — Performance & Page Transitions
 // ============================================================================
+// `PerformanceConfig` was RETIRED here with `dashboard.performance` in spec
+// 17.0.0 (framework#3896 audit close-out): no renderer or runtime ever read the
+// key, and its value schema had no other consumer, so it went with it. Nothing
+// in this repo bound to the spec type — `@object-ui/react`'s `usePerformance`
+// declares its own `PerformanceConfig` interface and is untouched.
 export type {
-  PerformanceConfig,
   PageTransition,
   PageComponentType,
 } from '@objectstack/spec/ui';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0(jiti@2.7.0))
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
@@ -692,8 +692,8 @@ importers:
         specifier: ^17.0.0-rc.0
         version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@sentry/react':
         specifier: ^10.68.0
         version: 10.68.0(react@19.2.8)
@@ -783,8 +783,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       better-auth:
         specifier: ^1.6.25
         version: 1.6.25(@opentelemetry/api@1.9.1)(better-sqlite3@12.9.0)(mongodb@7.2.0)(next@16.2.12(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
@@ -1036,8 +1036,8 @@ importers:
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1084,8 +1084,8 @@ importers:
         specifier: ^17.0.0-rc.0
         version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -1147,8 +1147,8 @@ importers:
         version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.2(@types/node@26.1.1))(@swc/core@1.15.33)(jiti@2.7.0)(postcss@8.5.24)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
@@ -1205,8 +1205,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -1307,8 +1307,8 @@ importers:
         version: link:../types
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -1482,8 +1482,8 @@ importers:
         version: 3.10.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.6)(react@19.2.8)(redux@5.0.1)
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -1637,8 +1637,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@types/react-grid-layout':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1749,8 +1749,8 @@ importers:
         specifier: workspace:^
         version: link:../permissions
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.8)
@@ -1865,8 +1865,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.8)
@@ -1920,8 +1920,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.8)
@@ -1981,8 +1981,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@tanstack/react-virtual':
         specifier: ^3.14.8
         version: 3.14.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2122,8 +2122,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -2161,8 +2161,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.8)
@@ -2311,8 +2311,8 @@ importers:
         version: 3.6.0
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -2356,8 +2356,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2408,8 +2408,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.8)
@@ -2472,8 +2472,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2513,8 +2513,8 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -2540,8 +2540,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2653,8 +2653,8 @@ importers:
   packages/types:
     dependencies:
       '@objectstack/spec':
-        specifier: ^17.0.0-rc.0
-        version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+        specifier: ^17.0.0-rc.1
+        version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -4011,6 +4011,15 @@ packages:
 
   '@objectstack/spec@17.0.0-rc.0':
     resolution: {integrity: sha512-4RuGPjbw0T56BkyrT6qTrPd6yPBSGw/kCawszqFD44Gh+FyhoY1VewvSVLx/3kFbY41ogEqBe7hh4C2o+/n5yw==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      ai: ^7.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
+
+  '@objectstack/spec@17.0.0-rc.1':
+    resolution: {integrity: sha512-1SIDQHwxaV8GLD8YqLxCJ0fxTag6eYvvWntihil+lBIxNSjYLI3U384I4l03esBvkytrts3L5W0WCZJkquJiXw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       ai: ^7.0.0
@@ -12360,6 +12369,12 @@ snapshots:
   '@objectstack/sdui-parser@17.0.0-rc.0': {}
 
   '@objectstack/spec@17.0.0-rc.0(ai@7.0.37(zod@4.4.3))':
+    dependencies:
+      zod: 4.4.3
+    optionalDependencies:
+      ai: 7.0.37(zod@4.4.3)
+
+  '@objectstack/spec@17.0.0-rc.1(ai@7.0.37(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -135,6 +135,29 @@ const ALLOW = {
       "test pins the key set.",
     issue: 4115,
   },
+  // Two names the spec started exporting in 17.0.0-rc.1. Both were triaged when
+  // the bump landed (objectui#3178) and neither is a dialect of the spec's
+  // concept — they are unrelated things that happen to share a name.
+  "@object-ui/types:FieldNode": {
+    reason:
+      "Same name, unrelated concepts. The spec's `FieldNode` is a bare `string` — a field " +
+      "NAME — after objectstack#4196 narrowed `QueryAST.fields` to names (the old union's " +
+      "nested-select member was produced by nothing and consumed by nothing). This is a NODE " +
+      "in objectui's own query AST (`{ type: 'field', table?, name, alias? }`), a sibling of " +
+      "`LiteralNode` / `OperatorNode` / `JoinNode`. Deriving would replace a structured node " +
+      "with a string; there is nothing to import.",
+    issue: 4115,
+  },
+  "@object-ui/app-shell:InboxNotification": {
+    reason:
+      "Two LAYERS, like the FormField entry above. The spec's is the notification SERVICE " +
+      "contract (`INotificationService.listInbox`): camelCase, `body` and `read` required, " +
+      "`actionUrl`/`createdAt`. This is the materialized inbox ROW the popover groups — " +
+      "snake_case mirroring `sys_notification` (`action_url`), carrying the read-receipt keys " +
+      "the contract has no place for (`notification_id`, `receipt_id`, ADR-0030) and nullable " +
+      "where a stored row can be null. A row is not a response.",
+    issue: 4115,
+  },
 };
 
 // ── Untriaged collisions (the ledger) ────────────────────────────────────────
@@ -204,7 +227,6 @@ const DEBT = {
     "GestureConfig",
     "GestureType",
     "ImportRowResult",
-    "JoinNode",
     "JoinedReportBlock",
     "NavigationArea",
     "NavigationAreaSchema",
@@ -255,7 +277,6 @@ const DEBT = {
     "OfflineCacheConfig",
     "OfflineConfig",
     "OfflineStrategy",
-    "PerformanceConfig",
   ],
   "@object-ui/data-objectstack": [
     "CacheStats",


### PR DESCRIPTION
Closes #3101.

## 为什么现在升,而不是等含 framework#4343 的下一个 rc

`waitEventConfig.timeoutMs` / `.onTimeout` 在 rc.1 里已是 `retiredKey()` 墓碑(framework#4158),**写进去的值会在加载时被拒绝**。而本仓的 `wait` 面板仍在提供这两个字段——也就是说,**现在有客户能在 Studio 里填出一份自家运行时会拒绝加载的流程元数据**。这个洞在 rc.1 发布的那一刻就打开了,和本仓何时升版无关;升版 + 删字段正是把它关上。

#3101 也明确要求两件事**必须同一个 PR**:sibling-block 断言是双向的,对着仍声明这两个键的 spec 提前删,会在反方向红。

`wait` 从来没有超时:`onTimeout` 零读者;`timeoutMs` 的唯一读者在 `timerDuration` 缺失时把它当**时长**用——而 `timerDuration` 接受裸数字作为毫秒,所以旧的 `timeoutMs: 60000` 就是 `timerDuration: '60000'`,行为不变。两条 zh 标签覆盖随字段一并删除。

## 升级带出的其余改动(逐项实测,非推测)

**`combo` 成为 spec 图表类型** —— rc.1 对 `ChartTypeSchema` 的**唯一**新增(19 → 20)。它此前是 renderer-local 的族,所以两个按 **spec** 图表类型分类的表面都没有路由它:一个合法的 `combo` 在 dashboard 上会掉进红色「Unknown component type」面板,在 report 上会落到 out-of-spec 提示。两处现已路由(`widgetDispatch.SERIES_CHART_TYPES`、`planReportChart`)。renderer 本地的推导保留——那才是让作者写的 `type: 'combo'` 真正**渲染**而不只是**校验通过**的东西。

**三个已退役的 spec 导出**(spec 17.0.0 上游移除):

- `JoinStrategy` / `WindowFunction` —— framework#4286 退役了 `query.joins` 与 `query.windowFunctions`(查询路径上从没有引擎或驱动读过)。它们原本按 objectstack#4115 的「派生而非复述」规则绑定 spec 枚举;枚举没了,`data-protocol.ts` 改为本地复述成员——**逐字取自最后一个发布过它们的 spec**——作为它们已然变成的 objectui query-AST 词汇。AST 本身不变。
- `PerformanceConfig` —— 随 `dashboard.performance` 退役(framework#3896)。本仓无人绑定它(`@object-ui/react` 的 `usePerformance` 有自己的 interface,未受影响)。dashboard 表单派生自 spec 自己的 `dashboardForm`,所以该字段自动消失;其测试改为**钉住缺席**。

**三处 inverted pin 触发了,本 PR 只记录不解决。** objectstack#4171 立的探针断言 `NavigationItem` / `FormField` / `ConditionalValidation` 的分支在上游仍擦除为 `any`/`unknown`——这正是本仓保留本地声明的前提。rc.1 把它们正确定型了,所以断言被翻转以陈述新事实。**但它们要求的 burn-down(改为从 spec 派生)没有做**:那会改动被广泛使用的公共类型,不该混进版本升级。已开 #3177 追踪。`JoinNode` 的 pin 直接删除——符号本身已不存在。

## 升级同时激活了什么

对账账本的 `subflow` / `decision` 面板靠 feature-detect 自己的 spec 导出,而 rc.0 早于 framework#4278,所以它们**从未真正运行过**。现在执行并通过。

`script` 面板的完整双向检查**按设计仍跳过**:rc.1 早于 framework#4343,那边退役的分发分支仍是契约键,只有「表单不提供执行器不读的键」这个方向有意义。它会在下一个 rc 自动激活(已在 framework#4516 里对着本地构建的 spec 验证过)。

## 验证

- 全仓 **803 文件 / 9397 用例**全绿;`type-check` 78/78;`lint` 45/45,改动文件零 error。
- 对账测试逐项确认:`subflow` / `decision` 首次运行通过,`wait` 转绿,`script` 单向断言通过 + 完整对账正确跳过。
- 升级前后 `ChartTypeSchema` 成员逐一对比,确认 `combo` 是唯一差异。

## Related

- #3101 —— 本体 issue(`wait` 退役字段)
- #3177 —— 本 PR 记录、未解决的三处 inverted pin burn-down
- objectstack-ai/objectstack#4158 —— 退役 `wait` 超时键的 framework PR
- objectstack-ai/objectstack#4286 / #3896 —— `JoinStrategy` / `WindowFunction` / `PerformanceConfig` 的退役来源
- objectstack-ai/objectstack#4343 / #4516 —— 下一个 rc 会激活 `script` 完整对账

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct9NXp2JumjKuARtQnrbPf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ct9NXp2JumjKuARtQnrbPf)_