### PR TITLE
fix(deps): 模态表单里 lookup 搜索框聚焦即被夺回——补丁修复 focus-scope 栈驱逐竞态 (#3183)

### DIFF
--- a/.changeset/lookup-search-focus-trap.md
+++ b/.changeset/lookup-search-focus-trap.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/console": patch
+"@object-ui/components": patch
+---
+
+Lookup search inside a create/edit modal is typeable again (objectui#3183).
+
+In every production console build, the search input of a lookup field's
+quick-select popover — and the nested Record Picker dialog — could not take
+focus while the form modal was open: every click/focus was synchronously
+yanked back to the field trigger, so "新建记录时 lookup 无法搜索".
+
+Root cause is a race in stock `@radix-ui/react-focus-scope@1.1.16`: the
+focus-scopes stack effect's cleanup schedules `focusScopesStack.remove(scope)`
+in a `setTimeout(0)`. When the effect re-runs for a still-mounted scope (a
+`container` ref flicker), the re-run re-`add`s the scope and the stale timeout
+then evicts it — the dialog's trap listeners stay active but its scope is no
+longer in the stack, so an opening popover pauses nothing and the trap yanks
+focus out of the popover forever.
+
+Fixed via `patches/@radix-ui__react-focus-scope.patch`: an effect re-run for a
+live scope cancels the pending eviction; a real unmount still runs the full
+delayed cleanup (autofocus-on-unmount + stack removal). Regression-tested in
+`packages/components` with a deterministic reproduction of the race.

--- a/package.json
+++ b/package.json
@@ -115,6 +115,9 @@
       "shell-quote@<1.8.4": "^1.8.4",
       "tmp@<0.2.6": "^0.2.6",
       "uuid@<11.1.1": "^11.1.1"
+    },
+    "patchedDependencies": {
+      "@radix-ui/react-focus-scope": "patches/@radix-ui__react-focus-scope.patch"
     }
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -91,6 +91,7 @@
   },
   "devDependencies": {
     "@objectstack/spec": "^17.0.0-rc.0",
+    "@radix-ui/react-focus-scope": "^1.1.16",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/packages/components/src/__tests__/dialog-popover-focus-scope.test.tsx
+++ b/packages/components/src/__tests__/dialog-popover-focus-scope.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * A lookup popover's search input inside a modal Dialog must be focusable.
+ *
+ * Radix's FocusScope keeps a module-level stack: when the popover's scope
+ * mounts it pauses the dialog's trap, so focus may travel into the portalled
+ * popover (which lives at document.body, OUTSIDE the dialog's DOM). Stock
+ * @radix-ui/react-focus-scope@1.1.16 has a race that silently breaks this
+ * pact: the stack-add effect's cleanup schedules
+ * `focusScopesStack.remove(scope)` in a `setTimeout(0)`. When the effect
+ * re-runs for a still-mounted scope (any `container`/dep flicker), the re-run
+ * `add`s the scope back and THEN the stale timeout evicts it. The dialog's
+ * trap listeners stay alive but its scope is gone from the stack, so a later
+ * popover pauses nothing and every focus into the popover's search input is
+ * yanked straight back into the dialog — "lookup 无法搜索" in the production
+ * console (objectui#3183).
+ *
+ * `patches/@radix-ui__react-focus-scope.patch` fixes the race by cancelling
+ * the pending eviction when the effect re-runs for a live scope. The first
+ * test drives the race deterministically (child key swap → new DOM node →
+ * container ref reattach → effect re-run) and fails without the patch.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as React from 'react';
+import { render, cleanup, act, screen } from '@testing-library/react';
+import { FocusScope } from '@radix-ui/react-focus-scope';
+import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
+import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover';
+
+afterEach(cleanup);
+
+/** Flush the focus-scope cleanup timers (the `setTimeout(0)` eviction path). */
+const flushEvictionTimers = () => act(() => new Promise<void>((r) => setTimeout(r, 25)));
+
+/**
+ * Minimal stand-in for "modal dialog with a portalled lookup popover":
+ * a trapped outer scope (the dialog) and an optional untrapped inner scope
+ * (the popover) that must pause it via the shared focus-scopes stack.
+ * `contentKey` swaps the trapped scope's child element identity, forcing the
+ * container ref to detach/reattach — the deterministic version of the
+ * production dep flicker that re-runs the stack effect.
+ */
+function Harness({ contentKey, popoverOpen }: { contentKey: string; popoverOpen: boolean }) {
+  return (
+    <>
+      <FocusScope trapped loop asChild>
+        <div key={contentKey}>
+          <button type="button">inside dialog</button>
+        </div>
+      </FocusScope>
+      {popoverOpen && (
+        <FocusScope asChild trapped={false}>
+          <div>
+            <input placeholder="search records" />
+          </div>
+        </FocusScope>
+      )}
+    </>
+  );
+}
+
+describe('focus-scope stack race (patched @radix-ui/react-focus-scope)', () => {
+  it('a re-run of the trapped scope effect must not evict it — the popover still pauses the dialog trap', async () => {
+    const { rerender } = render(<Harness contentKey="a" popoverOpen={false} />);
+    await flushEvictionTimers();
+
+    // Swap the child key: the trapped scope's container node is replaced, its
+    // ref detaches/reattaches, and the stack effect cleans up + re-runs.
+    // Un-patched, the stale cleanup timeout then evicts the re-added scope
+    // while its trap listeners stay active and `paused` is still false.
+    rerender(<Harness contentKey="b" popoverOpen={false} />);
+    await flushEvictionTimers();
+
+    // Open the "popover". Its scope pauses the stack top — which, un-patched,
+    // no longer contains the dialog scope, so the trap keeps yanking.
+    rerender(<Harness contentKey="b" popoverOpen />);
+    await flushEvictionTimers();
+
+    const inside = screen.getByRole('button', { name: 'inside dialog' });
+    const input = screen.getByPlaceholderText('search records');
+    act(() => {
+      inside.focus();
+    });
+    act(() => {
+      input.focus();
+    });
+    await flushEvictionTimers();
+
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('sanity: without a popover the trapped scope still yanks outside focus back', async () => {
+    render(<Harness contentKey="a" popoverOpen={false} />);
+    await flushEvictionTimers();
+
+    const inside = screen.getByRole('button', { name: 'inside dialog' });
+    act(() => {
+      inside.focus();
+    });
+
+    const outside = document.createElement('button');
+    outside.textContent = 'outside';
+    document.body.appendChild(outside);
+    act(() => {
+      outside.focus();
+    });
+    await flushEvictionTimers();
+
+    expect(document.activeElement).not.toBe(outside);
+    outside.remove();
+  });
+});
+
+describe('lookup popover search inside a modal dialog (integration)', () => {
+  it('the popover search input inside a Dialog receives and keeps focus', async () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>host dialog</DialogTitle>
+          <Popover open>
+            <PopoverTrigger asChild>
+              <button type="button">pick</button>
+            </PopoverTrigger>
+            <PopoverContent>
+              <input placeholder="search records" />
+            </PopoverContent>
+          </Popover>
+        </DialogContent>
+      </Dialog>,
+    );
+    await flushEvictionTimers();
+
+    // Focus starts on an element INSIDE the dialog (the field trigger), then
+    // moves into the portalled popover input — the real interaction shape.
+    const trigger = screen.getByRole('button', { name: 'pick' });
+    const input = screen.getByPlaceholderText('search records');
+    act(() => {
+      trigger.focus();
+    });
+    act(() => {
+      input.focus();
+    });
+    await flushEvictionTimers();
+
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/patches/@radix-ui__react-focus-scope.patch
+++ b/patches/@radix-ui__react-focus-scope.patch
@@ -1,0 +1,50 @@
+diff --git a/dist/index.js b/dist/index.js
+index e8906db3b1e87bfc568b75d72b7ed3d8d1d3c09a..7a05e0e4cffba466301ba1fb67067c0861af0a4d 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -110,6 +110,10 @@ var FocusScope = /* @__PURE__ */ React.forwardRef(
+     }, [trapped, container, focusScope.paused]);
+     React.useEffect(() => {
+       if (container) {
++        if (focusScope.__pendingStackRemove !== void 0) {
++          clearTimeout(focusScope.__pendingStackRemove);
++          focusScope.__pendingStackRemove = void 0;
++        }
+         focusScopesStack.add(focusScope);
+         const previouslyFocusedElement = document.activeElement;
+         const hasFocusedCandidate = container.contains(previouslyFocusedElement);
+@@ -126,7 +130,8 @@ var FocusScope = /* @__PURE__ */ React.forwardRef(
+         }
+         return () => {
+           container.removeEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
+-          setTimeout(() => {
++          focusScope.__pendingStackRemove = setTimeout(() => {
++            focusScope.__pendingStackRemove = void 0;
+             const unmountEvent = new CustomEvent(AUTOFOCUS_ON_UNMOUNT, EVENT_OPTIONS);
+             container.addEventListener(AUTOFOCUS_ON_UNMOUNT, onUnmountAutoFocus);
+             container.dispatchEvent(unmountEvent);
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 030ff1a4d2383c9a0a1ba850aa4591890f028784..3dd39a90db9886bc495014a6e4136773e3548448 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -75,6 +75,10 @@ var FocusScope = /* @__PURE__ */ React.forwardRef(
+     }, [trapped, container, focusScope.paused]);
+     React.useEffect(() => {
+       if (container) {
++        if (focusScope.__pendingStackRemove !== void 0) {
++          clearTimeout(focusScope.__pendingStackRemove);
++          focusScope.__pendingStackRemove = void 0;
++        }
+         focusScopesStack.add(focusScope);
+         const previouslyFocusedElement = document.activeElement;
+         const hasFocusedCandidate = container.contains(previouslyFocusedElement);
+@@ -91,7 +95,8 @@ var FocusScope = /* @__PURE__ */ React.forwardRef(
+         }
+         return () => {
+           container.removeEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
+-          setTimeout(() => {
++          focusScope.__pendingStackRemove = setTimeout(() => {
++            focusScope.__pendingStackRemove = void 0;
+             const unmountEvent = new CustomEvent(AUTOFOCUS_ON_UNMOUNT, EVENT_OPTIONS);
+             container.addEventListener(AUTOFOCUS_ON_UNMOUNT, onUnmountAutoFocus);
+             container.dispatchEvent(unmountEvent);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,11 @@ overrides:
   tmp@<0.2.6: ^0.2.6
   uuid@<11.1.1: ^11.1.1
 
+patchedDependencies:
+  '@radix-ui/react-focus-scope':
+    hash: 41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822
+    path: patches/@radix-ui__react-focus-scope.patch
+
 importers:
 
   .:
@@ -818,7 +823,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.4
-        version: 6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       chalk:
         specifier: ^6.0.0
         version: 6.0.0
@@ -839,7 +844,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: ^8.1.5
-        version: 8.1.5(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -858,7 +863,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.0(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.0(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1038,6 +1043,9 @@ importers:
       '@objectstack/spec':
         specifier: ^17.0.0-rc.0
         version: 17.0.0-rc.0(ai@7.0.37(zod@4.4.3))
+      '@radix-ui/react-focus-scope':
+        specifier: ^1.1.16
+        version: 1.1.16(patch_hash=41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1132,7 +1140,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.0(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.0(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.1)(typescript@6.0.3))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/data-objectstack:
     dependencies:
@@ -12538,7 +12546,7 @@ snapshots:
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.16(patch_hash=41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12594,7 +12602,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@radix-ui/react-focus-scope@1.1.16(patch_hash=41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12654,7 +12662,7 @@ snapshots:
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.16(patch_hash=41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12718,7 +12726,7 @@ snapshots:
       '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.16(patch_hash=41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -12862,7 +12870,7 @@ snapshots:
       '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-focus-scope': 1.1.16(patch_hash=41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -14158,11 +14166,6 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       maplibre-gl: 6.0.0
-
-  '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## 问题

产线构建的 console(如 `@objectstack/console@17.0.0-rc.1`)中,新建/编辑记录的模态表单里 lookup 字段无法搜索:

- 快捷下拉的搜索框**拿不到焦点**——点击/聚焦瞬间被同步拽回「选择...」触发按钮,列表永不过滤;
- 「浏览全部」弹出的 Record Picker 表格弹窗同样无法搜索。

**仅产线 bundle 复现,`vite dev`(HMR)正常**,因此现有测试与日常开发均未暴露。Closes #3183。

## 根因

`@radix-ui/react-focus-scope@1.1.16`(上游最新 rc 同样存在)的栈驱逐竞态:

- 焦点栈管理 effect 的 cleanup 用 `setTimeout(0)` 延迟执行 `focusScopesStack.remove(scope)`;
- 当该 effect 因 container ref 抖动在组件**未卸载**时重跑,顺序变成「重跑先 `add` → 旧 cleanup 的延时 `remove` 后执行」,刚加回去的 scope 被永久踢出栈;
- 此后 Dialog 的焦点陷阱监听器仍然活着,但没有任何弹层能 `pause` 它 → 弹层内输入框的焦点永远被同步夺回。

排查过程(服务端排除、浏览器插桩、fiber 状态挖掘)详见 #3183。

## 修复

`pnpm patch`(`patches/@radix-ui__react-focus-scope.patch`):

- effect 重跑(scope 仍存活)时,`clearTimeout` 取消上一次 cleanup 挂起的延时驱逐;
- 真实卸载路径不变(autofocus-on-unmount 派发 + 栈移除照旧)。

## 验证

- 回归测试 `packages/components/src/__tests__/dialog-popover-focus-scope.test.tsx`:用「asChild 子元素换 key → container ref 重挂 → effect 必然重跑」确定性复现竞态,**未打补丁必红、打补丁转绿**(已双向验证);另附 Dialog+Popover 集成用例与陷阱恢复用例。
- 真机:os-tianshun-ehr rc.1 后端 + 修复后产线 console,下拉搜索 `zzz`→「未找到选项」、`Dev`→正确过滤;Record Picker 弹窗搜索恢复;showcase 后端 + 修复版产线构建同样验证通过。

## 备注

- pnpm patch 只作用于**本仓构建产物**(console bundle,即产品发货路径);直接从 npm 消费 `@object-ui/components` 的第三方需等上游修复。
- 上游 radix-ui/primitives 最新版本仍未修复该竞态,补丁需保留至上游修复;升级 radix 时须确认并迁移补丁。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
