### PR TITLE
refactor(app-shell): 把 `DecisionOutputDef` 收敛成 spec 的纯 re-export,并反转 parity pin

### DIFF
--- a/.changeset/decision-output-def-collapses-to-spec.md
+++ b/.changeset/decision-output-def-collapses-to-spec.md
@@ -1,0 +1,38 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Collapse app-shell's `DecisionOutputDef` to a plain re-export of the spec's
+(objectstack#4562).
+
+The local type was `interface DecisionOutputDef extends SpecDecisionOutputDef
+{ required?: boolean }` — a structural derivation carrying ONE documented
+divergence, because the server enforced `required` (`decide()` rejects a blank
+required output before any write) while `@objectstack/spec` did not model it.
+The spec adopted `required` in cd6b9f202 and pinned it at the schema level in
+objectstack#4561, and this repo now resolves a spec that has it
+(`@objectstack/spec@17.0.0-rc.1`, #3178). The addition is therefore redundant
+and the type becomes `export type DecisionOutputDef = SpecDecisionOutputDef`.
+
+No behavior change and no API change: the symbol is internal to this package
+(it is not re-exported from `src/index.ts`), the resolved shape is identical
+key-for-key, and `decisionOutputParams()` still reads `d.required` — now off
+the spec's own field.
+
+The module TSDoc still asserted "the spec does not model it yet", which was
+stale and actively misleading — an agent reading it would take the divergence
+as ground truth and build on it, which is the objectstack#4115 failure class
+this file's own tripwires exist to prevent. It now states the current truth.
+
+The parity pin in `__tests__/spec-symbol-parity.test.ts` is inverted
+accordingly: `Exclude<keyof DecisionOutputDef, keyof SpecDecisionOutputDef>`
+is asserted `never` rather than `'required'`, plus an exact-identity
+assertion, so a future local addition to this symbol cannot slip in
+undocumented. The `type`-is-the-spec's-closed-enum pin is unchanged — that
+narrowing is still what stops a typo'd picker kind from silently degrading to
+a raw record-id text box (objectui#2955).
+
+Note that this pin, like every other type-level assertion in that file, is not
+yet compiled by any gate — package tsconfigs exclude `**/*.test.ts`, so
+nothing type-checks it. It was verified by compiling the file explicitly. See
+objectui#3181.

--- a/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
+++ b/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
@@ -12,9 +12,10 @@
  *
  * Twenty-eight app-shell symbols used to be declared under names the spec
  * already owns. Twenty were burned down by importing or deriving the spec's own
- * type (eighteen plain re-exports, plus `ScreenSpec` and `DecisionOutputDef`
- * derived structurally with one documented divergence each); eight were renamed
- * because they model something the spec's same-named export does not.
+ * type (nineteen plain re-exports — `DecisionOutputDef` joined them once the
+ * spec adopted `required`, objectstack#4562 — plus `ScreenSpec`, still derived
+ * structurally with one documented divergence); eight were renamed because they
+ * model something the spec's same-named export does not.
  *
  * One symbol is in both camps: the object designer's `FieldGroup` was renamed to
  * `ObjectFieldGroup` AND derived — the spec owns that exact shape, just under
@@ -232,19 +233,22 @@ describe('ScreenSpec derives from the spec, widening only `fields`', () => {
   });
 });
 
-describe('DecisionOutputDef derives from the spec, adding only `required`', () => {
+describe('DecisionOutputDef is the spec type, with no local divergence left', () => {
   it('is pinned at compile time', () => {
     type _NotAny = Assert<Equal<IsAny<SpecDecisionOutputDef>, false>>;
 
     // Every spec decision output is usable here.
     type _SpecIsUsableHere = Assert<Extends<SpecDecisionOutputDef, DecisionOutputDef>>;
 
-    // `required` is the ONLY local addition. When the spec adopts it, this
-    // becomes `never`, the assertion fails, and the interface should collapse
-    // to a plain re-export.
-    type _OnlyRequiredAdded = Assert<
-      Equal<Exclude<keyof DecisionOutputDef, keyof SpecDecisionOutputDef>, 'required'>
+    // …and the reverse, because this is now a plain re-export rather than a
+    // structural derivation. `required` used to be the ONE local addition; the
+    // spec adopted it (cd6b9f202, pinned by objectstack#4561), so the interface
+    // collapsed (objectstack#4562) and the exclusion set is empty. If a key ever
+    // reappears here, this fails and the divergence has to be documented again.
+    type _NoLocalAdditions = Assert<
+      Equal<Exclude<keyof DecisionOutputDef, keyof SpecDecisionOutputDef>, never>
     >;
+    type _IsExactlyTheSpecType = Assert<Equal<DecisionOutputDef, SpecDecisionOutputDef>>;
 
     // Deriving NARROWED `type` from the bare `string` this file used to declare
     // to the spec's closed enum — that narrowing is the point, so pin it.

--- a/packages/app-shell/src/utils/decisionOutputParams.ts
+++ b/packages/app-shell/src/utils/decisionOutputParams.ts
@@ -39,23 +39,27 @@ import type { DecisionOutputDef as SpecDecisionOutputDef } from '@objectstack/sp
 /**
  * An approval node's declared decision output, as the server surfaces it.
  *
- * Derived from `@objectstack/spec/automation`'s `DecisionOutputDef` (structural
- * `extends`, objectstack#4115) with ONE local addition. Deriving also narrows
- * `type` from the bare `string` this file used to declare to the spec's closed
- * `'user' | 'department' | 'position' | 'team' | 'text'` enum — a typo'd kind
- * now fails to compile instead of silently degrading to a raw record-id text
- * box, which is the objectui#2955 failure this module exists to prevent.
+ * A plain re-export of `@objectstack/spec/automation`'s `DecisionOutputDef` —
+ * the spec models every key this module needs, so there is nothing left to
+ * derive (objectstack#4562). The re-export is kept rather than pointing call
+ * sites at the spec directly because this module is the ONE place decision
+ * outputs become action params, and its consumers read the type from here.
  *
- * `required` is the documented divergence: the server enforces it (`decide()`
+ * Two properties the re-export inherits are load-bearing here. `type` is the
+ * spec's closed `'user' | 'department' | 'position' | 'team' | 'text'` enum,
+ * so a typo'd kind fails to compile instead of silently degrading to a raw
+ * record-id text box — the objectui#2955 failure this module exists to
+ * prevent. `required` is now spec-modelled too (objectui#2955 shipped it
+ * locally while the spec lagged; the spec adopted it in cd6b9f202, pinned at
+ * the schema level by objectstack#4561): the server enforces it (`decide()`
  * rejects a blank required output before any write) and the dialog mirrors it
- * so the approver is stopped at the field rather than by a 400 — but the spec
- * does not model it yet. It is optional here so a backend predating the flag
- * still parses. When the spec adopts `required`, this interface collapses to a
- * plain re-export; `__tests__/spec-symbol-parity.test.ts` fails on that day.
+ * so the approver is stopped at the field rather than by a 400. It stays
+ * optional — a backend predating the flag still parses.
+ *
+ * `__tests__/spec-symbol-parity.test.ts` pins the exclusion set at empty, so
+ * a future local addition to this symbol cannot slip in undocumented.
  */
-export interface DecisionOutputDef extends SpecDecisionOutputDef {
-  required?: boolean;
-}
+export type DecisionOutputDef = SpecDecisionOutputDef;
 
 /** Param-name prefix the api handler folds back into the nested `outputs` body. */
 export const DECISION_OUTPUT_PARAM_PREFIX = 'outputs.';


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#4562

> 注:正文里的泛型都写成 `Equal< Exclude< … > >` —— 尖括号后**故意加了空格**。GitHub 会把「`<` 紧跟字母」的序列当成 HTML 标签吞掉,加空格后仍是**合法 TypeScript**,可直接复制。仓库里的真实代码没有这些空格。

## 背景

app-shell 的 `DecisionOutputDef` 一直是一个**结构派生**,带着 ONE documented divergence:

```ts
export interface DecisionOutputDef extends SpecDecisionOutputDef {
  required?: boolean;
}
```

`required` 之所以是本地加的,是因为服务端会强制它(`decide()` 在任何写入前就拒绝空的 required output),而 `@objectstack/spec` 当时还没建模这个字段。

现在这个前提没了:spec 在 cd6b9f202 采纳了 `required`,objectstack#4561 把它钉在 schema 层,而本仓在 #3178 升到 `@objectstack/spec@17.0.0-rc.1` 之后已经解析到含 `required` 的版本。派生因此**变成纯冗余**。

## 改动(三项,一个 PR)

### 1. 收敛冗余派生

`packages/app-shell/src/utils/decisionOutputParams.ts`

```ts
export type DecisionOutputDef = SpecDecisionOutputDef;
```

保留 re-export(而不是让调用方直接 import spec),是因为这个模块是 approval 的 decision outputs 变成 action params 的**唯一入口**,它的消费者(`useRecordApprovals`、`DeclaredActionsBar`、`RecordDetailView`)都从这里读类型。

### 2. 修掉过期的模块 TSDoc

原注释仍然断言 "**the spec does not model it yet**" —— 已经不成立,而且**主动误导**。这正是 objectstack#4115 那一类失败:下一个 agent 读到这句会把这个 divergence 当成地面真值并在其上继续构建(#2901 就是这么被填了个反的前提)。现已改写为当前事实,并说明 `type` 的闭合枚举收窄仍然是 load-bearing 的(它才是阻止拼错的 picker kind 静默降级成裸 record-id 文本框的东西 —— objectui#2955)。

### 3. 反转 parity pin

`packages/app-shell/src/__tests__/spec-symbol-parity.test.ts`

之前 —— `required` 是唯一的本地新增:

```ts
Equal< Exclude< keyof DecisionOutputDef, keyof SpecDecisionOutputDef >, 'required' >
```

现在 —— 排除集为空,外加一条精确同一性断言:

```ts
Equal< Exclude< keyof DecisionOutputDef, keyof SpecDecisionOutputDef >, never >
Equal< DecisionOutputDef, SpecDecisionOutputDef >
```

这就是原注释承诺的 "fails on that day" —— 今天就是那天。`_TypeIsClosed` 那条保持不变。文件头的计数也从「eighteen plain re-exports + ScreenSpec 和 DecisionOutputDef 各带一处 divergence」更新为「nineteen plain re-exports + ScreenSpec 仍带一处 divergence」。

## ⚠️ 关于 guard 状态(请 reviewer 注意)

**这条 pin 目前不被任何 CI gate 编译。** `packages/app-shell/tsconfig.json` 的 `exclude` 含 `**/*.test.ts`,而 CI 的类型 gate 是 turbo 的逐包 `tsc --noEmit`,所以 `spec-symbol-parity.test.ts` 里所有 `Assert< Equal< … > >` 都**从未进入编译单元**。实测:往该文件追加 `type _Probe = Assert< Equal< 1, 2 > >` 之后 `pnpm type-check` 依然 **exit 0**。

这一点已单独记录在 **objectui#3181**;**本 PR 的反转断言要等 #3181 落地后才真正被 CI 强制**。在那之前我用一个临时 tsconfig(`include: ["src"]`、去掉 test 的 exclude)显式编译验证,证据见下。这也解释了 objectstack#4562 的前提为何写成「parity 测试会在那天失败」—— 它其实永远不会失败。

## 验证(实测输出)

均在 merge 了 origin/main(含 #3178,spec 解析为 **17.0.0-rc.1**)之后运行。

**类型检查**

```
$ cd packages/app-shell && pnpm type-check
> tsc --noEmit
EXIT=0
```

**反转后的断言显式编译**(绕开 test exclude)

```
$ npx tsc --noEmit -p tsconfig.paritycheck.json | grep spec-symbol-parity
(无输出 = 干净)
```

**负向对照 —— 旧的 `'required'` pin 现在必须失败**

```
$ # 把旧断言重新加回去
src/__tests__/spec-symbol-parity.test.ts(293,3): error TS2344:
  Type 'false' does not satisfy the constraint 'true'.
```

说明反转不是把断言写松了,而是确实反了向。

**测试**

```
$ npx vitest run packages/app-shell
 Test Files  252 passed (252)
      Tests  2150 passed | 1 skipped (2151)
   Duration  180.18s
```

**Lint**

```
$ cd packages/app-shell && pnpm lint
✖ 2090 problems (0 errors, 2090 warnings)
EXIT=0
```

(2090 条全是既有 warning,与本 PR 无关。)

**spec 符号 guard**

```
$ pnpm check:spec-symbols
✅  spec symbol derivation: 1200 files scanned against 4344 spec export names;
    8 declared dialects, 75 untriaged collisions in 18 packages.
EXIT=0
```

**changeset gate**

```
$ pnpm changeset:check
✅  All workspace packages are in the changeset fixed group.
```

## 影响面

**无行为变更。** `DecisionOutputDef` 是本包内部符号(**未**从 `src/index.ts` re-export,包只有 `.` 一个 entry),收敛前后解析出的形状逐键相同,`decisionOutputParams()` 仍然读 `d.required` —— 只是现在读的是 spec 自己的字段。调用方(`useRecordApprovals.ts`、`DeclaredActionsBar.tsx`、`RecordDetailView.tsx`)**一行都不用改**,已确认没有 ripple。

changeset 标 `patch`(内部类型重构,无 API 变更;按 AGENTS.md 版本号策略,不声明 `major`)。

## 一点顺带的观察

#3178 只升了 `@objectstack/spec`,`@objectstack/client` / `core` / `formula` / `lint` 仍是 `17.0.0-rc.0`,而它们对 spec 的依赖是**精确版本**,所以图里现在同时存在两份 spec:

```
spec copies in graph: @objectstack+spec@17.0.0-rc.0, @objectstack+spec@17.0.0-rc.1
client / core / formula / lint  ->  都仍然看到 spec 17.0.0-rc.0
```

这不影响本 PR(app-shell 侧解析到 rc.1,收敛所需的 `required` 在),但对依赖**引用同一性**的 guard(`spec-subschema-parity.test.ts`、以及用 `createRequire` 解析 spec `.d.ts` 的两处)是潜在隐患。已记录在 **objectui#3182**,不在本 PR 范围内。

## 备注

分支上第一个 commit(139b9df)的 message 写着 "BLOCKED — does not compile against 17.0.0-rc.0" —— 那是 #3178 合并**之前**的状态,现已不成立。因为分支已推送且本仓禁止 force-push,该 commit message 原样保留,以此说明。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)