### PR TITLE
fix(app-shell): 让 spec-symbol-parity 的「编译期」断言真的被 CI 编译 (#3181)

### DIFF
--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json",
+    "type-check:typetests": "tsc -p tsconfig.typetests.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
+++ b/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
@@ -37,6 +37,24 @@
  * subpath's `.d.ts` through the TypeScript checker, exactly as
  * `scripts/check-spec-symbol-derivation.mjs` does, and gets types and values
  * alike.
+ *
+ * ## What compiles the `type _X = Assert<…>` lines below (objectui#3181)
+ *
+ * Nothing did, for the first stretch of this file's life. `tsconfig.json` here
+ * is the package BUILD config and excludes `**\/*.test.ts`; CI's only type gate
+ * drives that config (`pnpm type-check` -> turbo -> per-package `tsc --noEmit`),
+ * and types are erased before vitest ever runs. Appending a provably-false
+ * `Assert<Equal<1, 2>>` to this file therefore passed `pnpm type-check` at exit
+ * 0 — the type half of this "tripwire" was, literally, commentary. Which is the
+ * same landmine this file's own header cites objectui#3009 for.
+ *
+ * They are now compiled by `packages/app-shell/tsconfig.typetests.json`, chained
+ * from this package's `type-check` script, i.e. run by the CI `Type Check` job.
+ * That project lists its files EXPLICITLY (app-shell's wider test tree still has
+ * a pre-existing error backlog, tracked as TEST_DEBT), so **a new
+ * type-assertion test file is unchecked until it is added to that include
+ * list** — and `scripts/check-type-check-coverage.mjs` fails if the chaining is
+ * ever dropped, so the gate cannot go quiet again the way it did here.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -193,7 +211,11 @@ describe('re-exported values are the spec binding itself', () => {
 /* divergence cannot silently grow and cannot silently outlive its reason.      */
 /* -------------------------------------------------------------------------- */
 
-/** Compile-time assertions. A violation is a `tsc` error, not a runtime failure. */
+/**
+ * Compile-time assertions. A violation is a `tsc` error, not a runtime failure —
+ * so it surfaces only under `tsconfig.typetests.json` (see the file header), not
+ * under vitest.
+ */
 type Assert<T extends true> = T;
 type Extends<A, B> = [A] extends [B] ? true : false;
 type IsAny<T> = 0 extends 1 & T ? true : false;

--- a/packages/app-shell/tsconfig.typetests.json
+++ b/packages/app-shell/tsconfig.typetests.json
@@ -1,0 +1,48 @@
+{
+  // Compiles the test files whose ENTIRE value is compile-time type assertions,
+  // so that those assertions are actually checked by CI (objectui#3181).
+  //
+  // Why this exists as a THIRD project rather than as `tsconfig.test.json`:
+  //
+  //  - `tsconfig.json` is the package BUILD (`tsc` -> dist, "rootDir": "src",
+  //    "composite", "declaration"). It excludes `**/*.test.ts` correctly — test
+  //    files would otherwise emit into the published dist.
+  //  - `tsconfig.test.json` is the repo's name for "this package compiles ALL of
+  //    its tests" (see packages/types). app-shell cannot claim that yet: its
+  //    test tree still has a large pre-existing error backlog, declared as
+  //    TEST_DEBT in scripts/check-type-check-coverage.mjs. Naming this file
+  //    `tsconfig.test.json` would tell that guard the debt is paid and make it
+  //    demand the entry be deleted — trading one false "checked" claim for
+  //    another.
+  //
+  // So: a narrow, explicitly-listed project that compiles only files which are
+  // ALREADY clean and whose assertions are load-bearing. It is chained from the
+  // package's `type-check` script, which is what the CI `Type Check` job runs
+  // (`pnpm type-check` -> `turbo run type-check`), and that chaining is enforced
+  // by scripts/check-type-check-coverage.mjs — a config nothing runs is exactly
+  // the objectui#3009 / objectui#3181 failure this file is fixing.
+  //
+  // Adding a file here is a one-line change; the bar is that it compiles clean
+  // today. Do NOT switch this to a glob: a glob would sweep in the backlog and
+  // the first agent to hit it would "fix" that by deleting the whole project.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // A checking project, never an emitting one — and explicitly not part of
+    // the build graph, so it cannot leak test output into dist.
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "lib": ["ES2020", "DOM"],
+    // `spec-symbol-parity.test.ts` resolves `@objectstack/spec`'s own `.d.ts`
+    // files off disk (createRequire / readFileSync / node:path) to read the
+    // spec's export names through the TypeScript checker.
+    "types": ["node"],
+    // Same reason as tsconfig.json: drop the root tsconfig's source-tree `paths`
+    // so `@objectstack/spec` and the `@object-ui/*` workspace deps resolve
+    // through the real dependency graph rather than through sibling `src/`.
+    "paths": {}
+  },
+  // Explicit list, not a glob. Every entry is a file whose type assertions are
+  // the point of the file.
+  "include": ["src/__tests__/spec-symbol-parity.test.ts"]
+}

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -89,6 +89,10 @@ const CHECKED_BY_OWN_BUILD = {
 //     type to silence it.
 const TEST_DEBT = {
   "@object-ui/core": { errors: 72, issue: 4118, note: "TS2741x32, TS2322x17 — mostly the input-vs-output fixture confusion" },
+  // Partially covered already: `tsconfig.typetests.json` compiles the test files
+  // whose whole value is compile-time type assertions (objectui#3181). The entry
+  // stays because the REST of the test tree is still unchecked — the number below
+  // is that remainder, not the whole package.
   "@object-ui/app-shell": { errors: 53, issue: 4118, note: "TS2339x24 — implementation wider than the type" },
   "@object-ui/components": { errors: 31, issue: 4118, note: "TS7006x12, TS7031x12 — untyped test callback params" },
   "@object-ui/react": { errors: 27, issue: 4118, note: "TS2769x9 — overload mismatch on render helpers" },
@@ -158,6 +162,12 @@ function collect() {
       } catch {
         /* no test config */
       }
+      let typeTestsConfig = null;
+      try {
+        typeTestsConfig = readFileSync(resolve(root, dir, "tsconfig.typetests.json"), "utf8");
+      } catch {
+        /* no type-tests config */
+      }
       const typeCheck = pkg.scripts?.["type-check"] ?? "";
       out.push({
         name: pkg.name,
@@ -176,6 +186,12 @@ function collect() {
         // The config existing is not the same as anything running it — that gap
         // IS objectui#3009. `type-check` has to chain it.
         chainsTestConfig: /-p\s+tsconfig\.test\.json/.test(typeCheck),
+        hasTypeTestsConfig: typeTestsConfig !== null,
+        typeTestsConfig,
+        // Same question, same answer, for the narrow type-assertion project
+        // (objectui#3181): `type-check` is what CI runs, so `type-check` — not
+        // some sibling script CI never invokes — has to be the thing that runs it.
+        chainsTypeTestsConfig: /-p\s+tsconfig\.typetests\.json/.test(typeCheck),
       });
     }
   }
@@ -324,6 +340,47 @@ for (const pkg of packages) {
   }
 }
 
+// ── 5½. The narrow type-assertion project, if a package has one ──────────────
+// Some test files exist ONLY for their COMPILE-TIME assertions (`Assert<Equal<A,
+// B>>`). Types are erased at runtime, so vitest proves nothing about those; only
+// `tsc` does. That is objectui#3181: app-shell's `spec-symbol-parity.test.ts`
+// carried a header calling its assertions a tripwire, while a provably-false
+// `Assert<Equal<1, 2>>` appended to it passed `pnpm type-check` at exit 0.
+//
+// A package whose test tree is still in TEST_DEBT can rescue those specific
+// files with a `tsconfig.typetests.json` that lists them explicitly, instead of
+// waiting for the whole backlog. This section keeps that project honest — it is
+// worth exactly as much as the gate that runs it, and nothing at all otherwise.
+for (const pkg of packages) {
+  if (!pkg.hasTypeTestsConfig) continue;
+
+  if (!pkg.chainsTypeTestsConfig) {
+    errors.push(
+      `${pkg.name} (${pkg.dir}) has a tsconfig.typetests.json that its "type-check" script never\n` +
+        `      runs, so its compile-time assertions are erased at runtime and compiled by nothing —\n` +
+        `      the exact state objectui#3181 fixed. CI runs \`pnpm type-check\` (turbo -> the package's\n` +
+        `      own "type-check"), so that is the script that has to chain it:\n` +
+        `      "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json"`
+    );
+    continue;
+  }
+
+  if (!/"noEmit"\s*:\s*true/.test(pkg.typeTestsConfig)) {
+    errors.push(
+      `${pkg.name} (${pkg.dir}): tsconfig.typetests.json must set "noEmit": true — it is a checking\n` +
+        `      project, and emitting would put test output in the published dist.`
+    );
+  }
+
+  if (!/\.test\.tsx?"/.test(pkg.typeTestsConfig)) {
+    errors.push(
+      `${pkg.name} (${pkg.dir}): tsconfig.typetests.json does not "include" any test file, so it\n` +
+        `      compiles nothing and passes vacuously. List the files whose type assertions it exists\n` +
+        `      to check, e.g. "include": ["src/__tests__/spec-symbol-parity.test.ts"]`
+    );
+  }
+}
+
 // 6. Ratchet — a declared test gap that has been closed must leave the list.
 for (const [name, spec] of Object.entries(TEST_DEBT)) {
   const pkg = byName.get(name);
@@ -363,6 +420,7 @@ const byBuild = Object.keys(CHECKED_BY_OWN_BUILD).length;
 const withTests = packages.filter((p) => p.hasScript && p.testFiles > 0);
 const testsChecked = withTests.filter(testsCovered).length;
 const testDebtErrors = Object.values(TEST_DEBT).reduce((sum, d) => sum + d.errors, 0);
+const typeTestProjects = packages.filter((p) => p.hasTypeTestsConfig && p.chainsTypeTestsConfig).length;
 
 if (errors.length === 0) {
   console.log(
@@ -373,7 +431,8 @@ if (errors.length === 0) {
   );
   console.log(
     `✅  test type-check coverage: ${testsChecked}/${withTests.length} packages compile their tests, ` +
-      `${Object.keys(TEST_DEBT).length} declared debt (${testDebtErrors} errors outstanding).`
+      `${Object.keys(TEST_DEBT).length} declared debt (${testDebtErrors} errors outstanding), ` +
+      `${typeTestProjects} with a narrow type-assertion project.`
   );
   process.exit(0);
 }


### PR DESCRIPTION
Fixes #3181

> 注:正文里的泛型都在 `< ` 后带一个空格(`Assert< Equal< 1, 2 > >`)。GitHub 的 sanitizer 会把 `<` 紧跟字母的片段当成标签吃掉,加空格才能存活。

## 问题

`packages/app-shell/src/__tests__/spec-symbol-parity.test.ts` 里那些 `type _X = Assert< Equal< A, B > >` **从来没有被任何编译器读过**:

- `packages/app-shell/tsconfig.json` 是**构建**配置,`exclude` 掉了 `**/*.test.ts`(正确 —— 否则测试会 emit 进 `dist`);
- CI 唯一的类型 gate 就是跑这份配置(`pnpm type-check` → turbo → 每包 `tsc --noEmit`);
- eslint 不是 type-aware;vitest 里类型在运行前已被擦除。

于是在该文件末尾追加一个必然为假的 `Assert< Equal< 1, 2 > >`,`pnpm type-check` 依然 **exit 0**。这个文件自己的头注释引用 #3009 批评的正是这种「declared ≠ enforced」地雷,而它自己就踩在上面。#3185 刚刚反转的 `DecisionOutputDef` pin 在此之前也只是装饰。

## 改动

1. **新增 `packages/app-shell/tsconfig.typetests.json`** —— `noEmit` 的独立 project,**显式列出文件名,不用 glob**。
2. **`packages/app-shell/package.json`**:`"type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json"`,并另给一个 `type-check:typetests` 方便本地单跑。链在 `type-check` 上是本仓既有约定(见 `packages/types`),也意味着它**直接落在现有 CI `Type Check` job 里**,不需要新增 workflow 步骤。
3. **`scripts/check-type-check-coverage.mjs`** 增加对应棘轮:若某包存在 `tsconfig.typetests.json` 而 `type-check` 没有 chain 它、或它会 emit、或它的 include 里一个测试文件都没有,则**直接失败**。否则今天修好的 gate 明天会以同样的方式悄悄失效(这是 issue 里的方案 3)。

### 为什么显式列文件,而不是把 `exclude` 里的 test glob 拿掉

app-shell 的测试树还有大量既有类型错误(`check-type-check-coverage.mjs` 的 `TEST_DEBT` 里记着 53 个;issue 用另一套配置量到 189 个)。用 glob 会把这些一次性扫进来,结果不是有人去修,而是下一个 agent 直接删掉整个 project。**全量修复明确不在本 PR 范围内**,继续留在 #3181 正文里跟踪。

同理,这个文件**没有**命名为 `tsconfig.test.json`:那个名字在本仓的含义是「本包所有测试都编译」,coverage guard 会据此要求删掉 `TEST_DEBT` 条目 —— 那只是把一个假的「已检查」换成另一个假的「已检查」。

### 关于 changeset

纯 CI/工具链改动,对已发布产物无行为影响,按 AGENTS.md「纯 bug 修复不需要 changeset」处理;`changeset-check` job 只校验 fixed 组完整性,不要求每个 PR 带 changeset。

## 验证

### 1. 正向:新 gate 在干净 main + 本改动上通过

```
$ pnpm type-check --filter=@object-ui/app-shell
@object-ui/app-shell:type-check: > tsc --noEmit && tsc -p tsconfig.typetests.json
 Tasks:    29 successful, 29 total
EXIT=0

$ node scripts/check-type-check-coverage.mjs
✅  type-check coverage: 43/45 via `type-check`, 1 via their own build, 0 known-broken (0 errors outstanding), 1 not compiled.
✅  test type-check coverage: 21/36 packages compile their tests, 15 declared debt (240 errors outstanding), 1 with a narrow type-assertion project.
```

### 2. 反向对照:追加一个必然为假的断言

在 `spec-symbol-parity.test.ts` 末尾临时追加 `type _Probe = Assert< Equal< 1, 2 > >;`。

**旧 gate(本 PR 之前 CI 唯一跑的那个)—— 依然放行,复现 issue:**

```
$ cd packages/app-shell && tsc --noEmit
OLD_GATE_EXIT=0
```

**新 gate —— 失败:**

```
$ pnpm type-check --filter=@object-ui/app-shell
@object-ui/app-shell:type-check: > tsc --noEmit && tsc -p tsconfig.typetests.json
@object-ui/app-shell:type-check: src/__tests__/spec-symbol-parity.test.ts(293,23): error TS2344: Type 'false' does not satisfy the constraint 'true'.
Failed:    @object-ui/app-shell#type-check
 ERROR  run failed: command  exited (2)
TURBO_EXIT=2
```

**移除探针后重新变绿:**

```
$ pnpm type-check --filter=@object-ui/app-shell
 Tasks:    29 successful, 29 total
TURBO_EXIT=0
```

### 3. 反向对照:棘轮本身

把 `type-check` 改回 `tsc --noEmit`(即「配置还在,但没人跑它」):

```
$ node scripts/check-type-check-coverage.mjs
❌  type-check coverage regressed:

    • @object-ui/app-shell (packages/app-shell) has a tsconfig.typetests.json that its "type-check" script never
      runs, so its compile-time assertions are erased at runtime and compiled by nothing —
      the exact state objectui#3181 fixed. ...
EXIT=1
```

### 4. 运行时测试未受影响

```
$ npx vitest run packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

### 5. CI

新 gate 走的是既有 `Type Check` job(`pnpm type-check` → turbo → app-shell 的 `type-check`),外加同 job 里已有的 `Verify type-check coverage` 步骤跑加固后的棘轮 —— 不是只存在于本地的 npm script。见本 PR 的 CI 检查结果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012C2cd7tL8QDoZ2QKN3djJ5)_