### PR TITLE
feat(core): declare the 18 spec-owned action keys ActionDef absorbed silently (objectstack#4075 第 2 步)

### DIFF
--- a/.changeset/actiondef-spec-owned-keys-explicit.md
+++ b/.changeset/actiondef-spec-owned-keys-explicit.md
@@ -1,0 +1,51 @@
+---
+"@object-ui/core": minor
+---
+
+Declare the 18 spec-owned action keys `ActionDef` had been absorbing silently.
+
+`ActionDef` ends with `[key: string]: any`, so it accepted any key of any type —
+a typo (`targt`) and a retired spec key (`execute`) both type-checked, then the
+runner silently bound no handler (the #2169 "Mark Done does nothing" shape).
+Step 1 (objectstack#4075) made that audible with a dev-mode warning. This is
+step 2: the keys the warning identified as legitimate are now real fields.
+
+- **18 keys promoted to explicit optional fields** — `ai`, `aria`, `bodyExtra`,
+  `bodyShape`, `bulkEnabled`, `component`, `icon`, `locations`, `mode`,
+  `objectName`, `order`, `recordIdField`, `recordIdParam`, `requiredPermissions`,
+  `requiresFeature`, `shortcut`, `variant`, `visible`. Every type is **derived**
+  from `@objectstack/spec`'s `ActionInput` (`SpecActionInput['locations']`, …),
+  never hand-copied: a hand-written duplicate of a spec shape is a second
+  contract that drifts, which is the failure this issue is about. Wrong-typed
+  values are now compile errors — `order: 'first'`, `variant: 'chartreuse'`,
+  `locations: ['nope']` — where before they were absorbed silently.
+- **Derived from `z.input`, not `z.infer`.** `ActionSchema` is a `ZodPipe` whose
+  transform narrows `visible` from `string | { dialect, source }` to the
+  envelope alone. This runner consumes authored/stored rows, which are
+  rehydrated unparsed, so it sees the input shape; deriving from the inferred
+  `Action` would have rejected the raw-string predicate `ActionEngine`
+  explicitly supports.
+- **Three `as any` casts deleted** in `ActionEngine` — `visible` and
+  `requiredPermissions` at the location filter, `locations` at registration.
+  They existed only because the fields were undeclared.
+- **Four objectui-dialect keys marked `@deprecated`** with the spec spelling to
+  use instead — `actionType` (→ `type`), `api` and `endpoint` (→ `target`;
+  `executeAPI` already resolves `api || endpoint || target`), and `navigate`
+  (→ flat `target` / `openIn`). Only these four: the remaining dialect keys are
+  runner mechanics (chaining, toasts, post-execution reload/close) with no spec
+  counterpart, and pointing them at a spelling that does not exist would be
+  worse than leaving them declared.
+
+**Breaking edge, deliberate.** `shortcut` and `bulkEnabled` were retired by
+`@objectstack/spec` 17 as `retiredKey()` tombstones (`z.never()`), so authoring
+either is already a hard parse rejection. Deriving their types rather than
+hand-writing them turns that runtime rejection into a **compile error**: code
+that assigned `shortcut: 'ctrl+k'` to an `ActionDef` compiled before and does
+not now. Such metadata was already refused by the platform — this only moves the
+failure to where it can be fixed. A host may still pass either explicitly via
+`ActionEngine.registerAction(action, { shortcut, bulkEnabled })`; only authored
+metadata stopped carrying them. `bulkEnabled`'s replacement is the list view's
+`bulkActions` / `bulkActionDefs`; `shortcut` has none.
+
+The index signature **stays** — removing it is step 3, and the inverted pin
+asserting it is still present remains the issue's own completion check.

--- a/packages/core/src/actions/ActionEngine.ts
+++ b/packages/core/src/actions/ActionEngine.ts
@@ -156,7 +156,10 @@ export class ActionEngine {
   registerActions(actions: ActionDef[]): void {
     for (const action of actions) {
       this.registerAction(action, {
-        locations: (action as any).locations,
+        // No cast: `locations` is a declared `ActionDef` field as of
+        // objectstack#4075 step 2. The `as any` it replaces existed only
+        // because the key reached this reader through the index signature.
+        locations: action.locations,
       });
     }
   }
@@ -210,21 +213,21 @@ export class ActionEngine {
         // systemPermissions is unknown (undefined): the server still 403s, and
         // hiding on missing data is a worse regression than showing a button
         // that errors clearly. Mirrors the App/nav requiredPermissions gate.
-        const required = (ra.action as any).requiredPermissions as string[] | undefined;
+        const required = ra.action.requiredPermissions;
         if (!Array.isArray(required) || required.length === 0) return true;
         const held = (this.runner.getContext() as any)?.user?.systemPermissions as string[] | undefined;
         if (!Array.isArray(held)) return true;
         return required.every((p) => held.includes(p));
       })
       .filter(ra => {
-        const raw = (ra.action as any).visible;
+        const raw = ra.action.visible;
         if (raw == null || raw === '' || raw === true) return true;
         if (raw === false) return false;
         let expr: string | boolean;
         if (typeof raw === 'string') {
           expr = `\${${raw}}`;
-        } else if (typeof raw === 'object' && typeof (raw as any).source === 'string') {
-          const src = (raw as any).source as string;
+        } else if (typeof raw === 'object' && typeof raw.source === 'string') {
+          const src = raw.source;
           if (!src) return true;
           expr = `\${${src}}`;
         } else {
@@ -246,7 +249,7 @@ export class ActionEngine {
           // user }` eval scope. Silently hiding it makes that bug invisible
           // (the #2183 hunt). Warn once per predicate so it is diagnosable
           // without spamming re-renders.
-          warnHiddenPredicate((ra.action as any).name, raw, err);
+          warnHiddenPredicate(ra.action.name, raw, err);
           return false;
         }
       })

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -22,6 +22,7 @@
  */
 
 import type { RunnableActionType } from '@object-ui/types';
+import type { ActionInput as SpecActionInput } from '@objectstack/spec/ui';
 import { ExpressionEvaluator } from '../evaluator/ExpressionEvaluator';
 import { globalUndoManager, type UndoableOperation } from './UndoManager';
 import { warnOnUnknownActionKeys } from './actionKeys';
@@ -87,7 +88,12 @@ export interface ActionDef {
   /** Action type identifier — a `RunnableActionType` (the spec's six plus the
    *  `navigation` alias of `url`) or a custom type with a registered handler. */
   type?: string;
-  /** Legacy action type field */
+  /**
+   * Legacy action type field.
+   *
+   * @deprecated objectui dialect — use the spec spelling `type`. Both are read,
+   * `type` first (objectstack#4075 step 2).
+   */
   actionType?: string;
   /** Action name (from UIActionSchema) */
   name?: string;
@@ -101,13 +107,36 @@ export interface ActionDef {
   condition?: string;
   /** Disabled expression — if truthy, skip action */
   disabled?: string | boolean;
-  /** API endpoint (string URL or complex config) */
+  /**
+   * API endpoint (string URL or complex config).
+   *
+   * @deprecated objectui dialect — the spec spells an `api` action's endpoint
+   * `target` (with the verb in `method`). `executeAPI` resolves
+   * `api || endpoint || target`, so `target` alone is sufficient. The
+   * `ApiConfig` object form has no spec counterpart and is objectui-only
+   * (objectstack#4075 step 2).
+   */
   api?: string | ApiConfig;
-  /** API endpoint URL (spec v2.0.1 alias) */
+  /**
+   * API endpoint URL.
+   *
+   * @deprecated objectui dialect — this was the "spec v2.0.1 alias", but spec 17
+   * spells it `target`. `executeAPI` resolves `api || endpoint || target`
+   * (objectstack#4075 step 2).
+   */
   endpoint?: string;
   /** HTTP method */
   method?: string;
-  /** Navigation target */
+  /**
+   * Navigation target — a nested envelope carrying the `navigation` alias's own
+   * spelling (`to` / `external` / `newTab` / `replace`).
+   *
+   * @deprecated objectui dialect — the spec has no nested navigation envelope;
+   * it spells a navigation action `{ type: 'url', target, openIn }`.
+   * `executeNavigation` reads `navigate.to || navigate.target || navigate.redirect`,
+   * falling back to the same keys on the action itself, so a flat `target` works
+   * today (objectstack#4075 step 2).
+   */
   navigate?: any;
   /** onClick callback (legacy) */
   onClick?: () => void | Promise<void>;
@@ -190,6 +219,97 @@ export interface ActionDef {
    *  must perform all auth/authz itself (e.g. the cloud `/sso-open` endpoint,
    *  which re-runs every check the POST half would have done). */
   newTabUrl?: string;
+
+  // ── Spec-owned keys, promoted from the index signature ─────────────────────
+  //
+  // objectstack#4075 step 2. Step 1's inventory found 18 keys that
+  // `@objectstack/spec`'s `ActionSchema` owns and that authored metadata
+  // carries today, but that `ActionDef` never declared — so they reached
+  // readers only through `[key: string]: any`, and the two `ActionEngine`
+  // actually reads (`visible`, `locations`) had to be read through an `as any`
+  // cast. Declaring them is what removes those casts.
+  //
+  // Every type below is DERIVED from the spec via `SpecActionInput[...]`, never
+  // hand-copied: a hand-written duplicate of a spec shape is a second contract
+  // that drifts silently, which is the failure this whole issue is about.
+  //
+  // Derived from `z.input` (`ActionInput`), not `z.infer` (`Action`), and the
+  // difference is load-bearing rather than stylistic. `ActionSchema` is a
+  // `ZodPipe` whose transforms narrow the authored shape — `visible` is authored
+  // as `string | { dialect, source }` but INFERS to the object form alone. This
+  // runner consumes authored/stored rows, which #3903 established are rehydrated
+  // UNPARSED, so it sees the input shape. Deriving from `Action` would have
+  // type-errored the raw-string predicate that `ActionEngine` explicitly
+  // supports and that `ActionEngine.visibility.test.ts` pins.
+  //
+  // `shortcut` and `bulkEnabled` land here as `undefined`, not as a usable type
+  // — that is correct and deliberate. Spec 17 retired both as `retiredKey()`
+  // tombstones (`z.never()`), so authoring either is a hard parse rejection.
+  // Deriving rather than hand-writing turns that rejection into a COMPILE error
+  // for free; hand-copying would have re-legitimized two dead keys.
+
+  /** Where this action renders (`record_header`, `list_toolbar`, …). Read by
+   *  `ActionEngine.registerActions` to seed the location filter. */
+  locations?: SpecActionInput['locations'];
+  /**
+   * Visibility predicate, evaluated against the runner's context.
+   *
+   * The `boolean` arm is objectui's own, deliberately wider than the spec:
+   * `ActionSchema.visible` admits only a CEL string or a `{ dialect, source }`
+   * envelope, while `ActionEngine.getActionsForLocation` also honours a literal
+   * `visible: true` / `false` (pinned by `ActionEngine.visibility.test.ts`).
+   * Declared rather than left to the index signature so the tolerance is
+   * auditable instead of invisible — but it IS a dialect, and objectstack#4075
+   * step 3 has to decide whether the spec adopts the boolean or objectui drops
+   * it. Do not widen this further.
+   */
+  visible?: SpecActionInput['visible'] | boolean;
+  /** System permissions the caller must ALL hold for the action to be offered
+   *  (ADR-0066 D4 UI half — the server enforces the source of truth). */
+  requiredPermissions?: SpecActionInput['requiredPermissions'];
+  /** Icon name for the rendered control. */
+  icon?: SpecActionInput['icon'];
+  /** Visual emphasis of the rendered control (`primary`, `danger`, …). */
+  variant?: SpecActionInput['variant'];
+  /** Sort weight among sibling actions. */
+  order?: SpecActionInput['order'];
+  /** Which renderer surfaces the action (`action:button`, `action:menu`, …). */
+  component?: SpecActionInput['component'];
+  /** Object this action is declared against. */
+  objectName?: SpecActionInput['objectName'];
+  /** AI affordance metadata (tool exposure, prompts). */
+  ai?: SpecActionInput['ai'];
+  /** Accessibility overrides for the rendered control. */
+  aria?: SpecActionInput['aria'];
+  /** Extra properties merged into the request body alongside the collected params. */
+  bodyExtra?: SpecActionInput['bodyExtra'];
+  /** How collected params are shaped into the request body (`flat` or nested). */
+  bodyShape?: SpecActionInput['bodyShape'];
+  /** Execution mode of the action. */
+  mode?: SpecActionInput['mode'];
+  /** Field on the record supplying the record id sent to the endpoint. */
+  recordIdField?: SpecActionInput['recordIdField'];
+  /** Request-parameter name carrying the record id. */
+  recordIdParam?: SpecActionInput['recordIdParam'];
+  /** Auth/tenancy feature the action requires before it is offered. */
+  requiresFeature?: SpecActionInput['requiresFeature'];
+  /**
+   * @deprecated Retired in `@objectstack/spec` 17 as a `retiredKey()` tombstone —
+   * authoring it is a hard parse rejection, so this resolves to `undefined` and
+   * assigning a value is a compile error. A HOST may still pass a shortcut
+   * explicitly via `ActionEngine.registerAction(action, { shortcut })`; it is
+   * only no longer sourced from authored metadata. No replacement key.
+   */
+  shortcut?: SpecActionInput['shortcut'];
+  /**
+   * @deprecated Retired in `@objectstack/spec` 17 as a `retiredKey()` tombstone —
+   * authoring it is a hard parse rejection, so this resolves to `undefined` and
+   * assigning a value is a compile error. Use the list view's `bulkActions` /
+   * `bulkActionDefs` instead; `ActionEngine.registerAction(action, { bulkEnabled })`
+   * remains available to a HOST passing it explicitly.
+   */
+  bulkEnabled?: SpecActionInput['bulkEnabled'];
+
   /** Any additional properties */
   [key: string]: any;
 }

--- a/packages/core/src/actions/__tests__/actionKeys.types.test.ts
+++ b/packages/core/src/actions/__tests__/actionKeys.types.test.ts
@@ -1,0 +1,181 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Type-level pins for objectstack#4075 step 2 — the 18 spec-owned keys that
+ * `ActionDef` now declares explicitly.
+ *
+ * Why this file has to drive `tsc` itself: the property under test is that the
+ * COMPILER rejects a wrong-typed value. A normal runtime test cannot observe
+ * that, and `expectTypeOf` is not available here (vitest's `typecheck` mode is
+ * not enabled in `vitest.config.mts`, and enabling it is a shared-config change
+ * that belongs to objectui#3181's gate, not to this issue). So the assertions
+ * compile a small virtual module against the real `ActionDef` and read the
+ * diagnostics back.
+ *
+ * The discrimination proof is built in rather than asserted in prose: the same
+ * bad assignments are compiled a SECOND time against `IndexSignatureOnly` — an
+ * interface carrying nothing but `[key: string]: any`, i.e. `ActionDef` as it
+ * was before step 2 — and every one of them must come back CLEAN. That control
+ * is what makes this file revert-proof: undo the promotion and the "rejects"
+ * assertions go green-to-red, because the index signature swallows them again,
+ * which is the entire bug objectstack#4075 describes.
+ *
+ * Cost note (AGENTS.md 测试纪律): the program is built once at MODULE SCOPE, not
+ * in `beforeAll`. Module-scope work runs in the import phase and is bound by no
+ * test or hook timeout; a `beforeAll` would put ~3s of compiler work under the
+ * 10s `hookTimeout`, which is the narrower budget and the documented way to
+ * turn a slow setup into a load-dependent flake.
+ */
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RUNNER_IMPORT = join(HERE, '..', 'ActionRunner').replace(/\\/g, '/');
+
+/** A single assignment, and whether `tsc` is required to reject it. */
+interface Case {
+  readonly what: string;
+  readonly code: string;
+  readonly rejected: boolean;
+}
+
+/**
+ * Every case is a value assigned to one of the promoted keys. `rejected: true`
+ * means step 2 made it a compile error; `rejected: false` means it is a shape
+ * the runner genuinely accepts and must keep accepting.
+ */
+const CASES: readonly Case[] = [
+  // ── Wrong-typed values the spec-derived types now reject ───────────────────
+  { what: 'locations rejects a string outside the spec location enum', rejected: true, code: `{ locations: ['nope'] }` },
+  { what: 'order rejects a string where the spec says number', rejected: true, code: `{ order: 'first' }` },
+  { what: 'variant rejects a colour the spec enum does not list', rejected: true, code: `{ variant: 'chartreuse' }` },
+  { what: 'component rejects a renderer the spec enum does not list', rejected: true, code: `{ component: 'action:carousel' }` },
+  { what: 'icon rejects a number', rejected: true, code: `{ icon: 42 }` },
+  { what: 'objectName rejects a number', rejected: true, code: `{ objectName: 42 }` },
+  { what: 'recordIdField rejects a number', rejected: true, code: `{ recordIdField: 42 }` },
+  { what: 'recordIdParam rejects a number', rejected: true, code: `{ recordIdParam: 42 }` },
+  { what: 'requiredPermissions rejects a bare string where the spec says string[]', rejected: true, code: `{ requiredPermissions: 'admin' }` },
+  { what: 'requiresFeature rejects a feature the spec enum does not list', rejected: true, code: `{ requiresFeature: 'telepathy' }` },
+  { what: 'mode rejects a value the spec enum does not list', rejected: true, code: `{ mode: 'telepathic' }` },
+  { what: 'bodyShape rejects a string other than "flat"', rejected: true, code: `{ bodyShape: 'nested-ish' }` },
+  { what: 'bodyExtra rejects a non-object', rejected: true, code: `{ bodyExtra: 'extra' }` },
+  { what: 'aria rejects a string', rejected: true, code: `{ aria: 'label' }` },
+  { what: 'ai rejects a string', rejected: true, code: `{ ai: 'yes' }` },
+  { what: 'visible rejects a number — neither predicate, envelope, nor boolean', rejected: true, code: `{ visible: 42 }` },
+
+  // The two tombstones. Spec 17 retired both as `retiredKey()` (`z.never()`),
+  // so DERIVING the type — rather than hand-writing `shortcut?: string` —
+  // turns "authoring this is a hard parse rejection" into a compile error.
+  { what: 'shortcut is a retired tombstone, so any value is a compile error', rejected: true, code: `{ shortcut: 'ctrl+k' }` },
+  { what: 'bulkEnabled is a retired tombstone, so any value is a compile error', rejected: true, code: `{ bulkEnabled: true }` },
+
+  // ── Shapes the runner genuinely accepts and must keep accepting ────────────
+  { what: 'locations accepts a real spec location', rejected: false, code: `{ locations: ['record_header'] }` },
+  { what: 'order accepts a number', rejected: false, code: `{ order: 10 }` },
+  { what: 'variant accepts a spec variant', rejected: false, code: `{ variant: 'primary' }` },
+  { what: 'component accepts a spec renderer', rejected: false, code: `{ component: 'action:button' }` },
+  { what: 'requiredPermissions accepts a string array', rejected: false, code: `{ requiredPermissions: ['admin'] }` },
+  { what: 'requiresFeature accepts a spec feature', rejected: false, code: `{ requiresFeature: 'sso' }` },
+
+  // `visible`'s three accepted arms. The raw-string one is why these types are
+  // derived from `z.input` and not `z.infer`: `ActionSchema` is a `ZodPipe`
+  // whose transform narrows `visible` to the envelope alone, so deriving from
+  // the inferred `Action` would have type-errored a predicate that
+  // `ActionEngine.getActionsForLocation` explicitly supports.
+  { what: 'visible accepts a raw CEL string (the z.infer-vs-z.input arm)', rejected: false, code: `{ visible: 'record.done == false' }` },
+  { what: 'visible accepts a { dialect, source } envelope', rejected: false, code: `{ visible: { dialect: 'cel', source: 'record.done == false' } }` },
+  { what: 'visible accepts a literal boolean (objectui tolerance, pinned by ActionEngine.visibility.test.ts)', rejected: false, code: `{ visible: true }` },
+
+  // Step 3's completion check, from the type side. While `[key: string]: any`
+  // stands, a typo is still absorbed silently — which is precisely why the
+  // dev-mode warning in `actionKeys.ts` exists. When this case starts FAILING,
+  // step 3 has landed and the warning can retire.
+  { what: 'an unrecognized key is still absorbed — the index signature stands', rejected: false, code: `{ targt: 'form_1' }` },
+];
+
+/** `ActionDef` as it was BEFORE step 2: nothing but the open index signature. */
+const CONTROL_DECL = `interface IndexSignatureOnly { [key: string]: any; }`;
+
+/**
+ * Compile every case as `const c<N>: <Type> = <value>;`, one per line, and
+ * return the set of line numbers that produced a diagnostic. One program for
+ * all cases keeps this to a single type-resolution of `@objectstack/spec`.
+ */
+function erroringLines(typeName: string, preamble: string): Set<number> {
+  const header = `${preamble}\n`;
+  const body = CASES.map((c, i) => `const c${i}: ${typeName} = ${c.code};`).join('\n');
+  const source = `${header}${body}\n`;
+  const headerLines = header.split('\n').length - 1;
+
+  const VIRTUAL = join(HERE, '__actionDefTypePins.virtual.ts').replace(/\\/g, '/');
+  const options: ts.CompilerOptions = {
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ESNext,
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, languageVersion, ...rest) =>
+    fileName === VIRTUAL
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(fileName, languageVersion, ...rest);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (fileName) => (fileName === VIRTUAL ? true : fileExists(fileName));
+  const readFile = host.readFile.bind(host);
+  host.readFile = (fileName) => (fileName === VIRTUAL ? source : readFile(fileName));
+
+  const program = ts.createProgram([VIRTUAL], options, host);
+  const sf = program.getSourceFile(VIRTUAL);
+  if (!sf) throw new Error('virtual source file was not added to the program');
+
+  const lines = new Set<number>();
+  for (const d of program.getSemanticDiagnostics(sf)) {
+    if (d.start == null) continue;
+    lines.add(sf.getLineAndCharacterOfPosition(d.start).line - headerLines);
+  }
+  return lines;
+}
+
+// Module scope on purpose — see the file header. Both programs are built here so
+// the compiler cost lands in the import phase rather than under a hook timeout.
+const againstActionDef = erroringLines('ActionDef', `import type { ActionDef } from '${RUNNER_IMPORT}';`);
+const againstIndexSignature = erroringLines('IndexSignatureOnly', CONTROL_DECL);
+
+describe('ActionDef spec-owned key types (objectstack#4075 step 2)', () => {
+  for (const [i, c] of CASES.entries()) {
+    it(c.what, () => {
+      expect({ case: c.what, rejected: againstActionDef.has(i) }).toEqual({ case: c.what, rejected: c.rejected });
+    });
+  }
+});
+
+describe('discrimination: the same code against a bare index signature', () => {
+  it('absorbs every rejected case silently — which is the bug step 2 fixes', () => {
+    // If this ever fails, the control interface stopped modelling "ActionDef
+    // before step 2" and the suite above has lost its meaning.
+    const leaked = CASES.map((c, i) => ({ what: c.what, i }))
+      .filter(({ i }) => againstIndexSignature.has(i))
+      .map(({ what }) => what);
+    expect(leaked).toEqual([]);
+  });
+
+  it('proves the promotion is what rejects them, not some unrelated diagnostic', () => {
+    const shouldReject = CASES.map((c, i) => [c, i] as const).filter(([c]) => c.rejected);
+    expect(shouldReject.length).toBeGreaterThan(0);
+    // Every rejected case errors against ActionDef and is clean against the
+    // index-signature-only control. That difference IS the step-2 delta.
+    const delta = shouldReject.filter(([, i]) => againstActionDef.has(i) && !againstIndexSignature.has(i));
+    expect(delta.length).toBe(shouldReject.length);
+  });
+});

--- a/packages/core/src/actions/actionKeys.ts
+++ b/packages/core/src/actions/actionKeys.ts
@@ -33,25 +33,42 @@
  * interface it mirrors would be the same "declared ≠ enforced" trap this whole
  * thread is about.
  *
- * ── What the inventory found, i.e. step 2's worklist ─────────────────────────
- * `ActionDef` declares 34 keys, the spec's `ActionSchema` declares 36, and they
- * overlap on 17. The two halves of the difference are different problems:
+ * ── What the inventory found, and what step 2 did with it ────────────────────
+ * Step 1 found `ActionDef` declaring 34 keys against the spec `ActionSchema`'s
+ * 36, overlapping on 17. The two halves of the difference were different
+ * problems, and step 2 (objectstack#4075) treated them differently:
  *
  * 18 keys the SPEC owns that `ActionDef` never declared — `ai`, `aria`,
  * `bodyExtra`, `bodyShape`, `bulkEnabled`, `component`, `icon`, `locations`,
  * `mode`, `objectName`, `order`, `recordIdField`, `recordIdParam`,
  * `requiredPermissions`, `requiresFeature`, `shortcut`, `variant`, `visible`.
- * These are authored today and reach readers through the index signature.
- * `ActionEngine` reads two of them (`visible` at the location filter, `locations`
- * at registration) through an `as any` cast — a cast that exists ONLY because the
- * field is undeclared, and that goes away when step 2 promotes them.
+ * These are authored today and used to reach readers through the index
+ * signature. **Step 2 promoted all 18 to explicit optional fields**, typed by
+ * DERIVATION from `@objectstack/spec`'s `ActionInput` rather than by hand-copied
+ * shapes. The `as any` casts `ActionEngine` needed to read `visible`,
+ * `locations` and `requiredPermissions` are gone with them — those casts existed
+ * only because the fields were undeclared.
+ *
+ * Two of the 18 landed as `undefined` rather than as usable types, which is the
+ * correct outcome: spec 17 retired `shortcut` and `bulkEnabled` as `retiredKey()`
+ * tombstones (`z.never()`), so deriving turns "authoring this is a parse
+ * rejection" into a compile error at no cost. Hand-copying would have quietly
+ * re-legitimized two dead keys — which is why the types are derived.
  *
  * 17 keys `ActionDef` declares that the spec does not own — `actionType`, `api`,
  * `chain`, `chainMode`, `close`, `condition`, `confirm`, `endpoint`, `modal`,
  * `navigate`, `onClick`, `onFailure`, `onSuccess`, `redirect`, `reload`, `toast`,
- * `actionParams`. Several are already marked legacy at their declaration. These
- * are objectui's own dialect and need the #4115 treatment: kept and documented as
- * deliberate, or retired — but not silently carried.
+ * `actionParams`. Step 2 marked `@deprecated`, with the spec spelling to use
+ * instead, ONLY the four the runner itself proves are aliases: `actionType` (→
+ * `type`), `api` and `endpoint` (→ `target`; `executeAPI` resolves
+ * `api || endpoint || target`), and `navigate` (→ flat `target`/`openIn`;
+ * `executeNavigation` already falls back to them). The rest are runner mechanics
+ * with no spec counterpart — chaining, toasts, post-execution reload/close — and
+ * deprecating them toward a spelling that does not exist would be worse than
+ * leaving them declared.
+ *
+ * Step 3 remains: remove the index signature, at which point `tsc` catches both
+ * typos and retired keys and the dev-mode warning below can retire with it.
  */
 
 /**
@@ -96,6 +113,29 @@ export const ACTION_DEF_KEYS = [
   'onFailure',
   'opensInNewTab',
   'newTabUrl',
+  // Promoted out of the index signature by objectstack#4075 step 2 — the 18 keys
+  // the spec owns that `ActionDef` had never declared. Their types are derived
+  // from `@objectstack/spec`'s `ActionInput`, so this list is the only
+  // hand-maintained half, and `actionKeys.pin.test.ts` re-derives it from the
+  // interface's AST.
+  'locations',
+  'visible',
+  'requiredPermissions',
+  'icon',
+  'variant',
+  'order',
+  'component',
+  'objectName',
+  'ai',
+  'aria',
+  'bodyExtra',
+  'bodyShape',
+  'mode',
+  'recordIdField',
+  'recordIdParam',
+  'requiresFeature',
+  'shortcut',
+  'bulkEnabled',
 ] as const;
 
 /**


### PR DESCRIPTION
Refs objectstack-ai/objectstack#4075(第 2 步,不关闭)

分阶段路线的第 2 步。第 1 步(objectui#3032)已经把「未识别键」变成 dev 警告并盘点出清单;本 PR 把清单里**合法的那一半变成真正的字段**。第 3 步(删除索引签名)仍未做,issue 保持打开。

## 背景

`ActionDef` 以 `[key: string]: any` 结尾,因此任何键、任何类型都能通过编译。错拼(`targt`)和已退役的 spec 键(`execute`)都能 type-check,然后 runner 静默地不绑定任何 handler —— 这正是 #2169「Mark Done 什么都不做」的形状。

## 本 PR 做了什么

**1. 18 个 spec 拥有、`ActionDef` 从未声明的键,提升为显式可选字段**

`ai`、`aria`、`bodyExtra`、`bodyShape`、`bulkEnabled`、`component`、`icon`、`locations`、`mode`、`objectName`、`order`、`recordIdField`、`recordIdParam`、`requiredPermissions`、`requiresFeature`、`shortcut`、`variant`、`visible`。

每个类型都从 `@objectstack/spec` 的 `ActionInput` **派生**(`SpecActionInput['locations']` 等),**不手抄**。手抄一份 spec 形状等于造出第二份会静默漂移的契约 —— 而这正是本 issue 要解决的失败模式本身。效果:`order: 'first'`、`variant: 'chartreuse'`、`locations: ['nope']` 现在是编译错误,此前被索引签名静默吞掉。

**2. 从 `z.input` 派生,而不是 `z.infer` —— 这一点是承重的,不是风格选择**

`ActionSchema` 是一个 `ZodPipe`,它的 transform 会**收窄**作者写下的形状:`visible` 的作者侧是 `string | { dialect, source }`,但 infer 之后只剩下 envelope 对象那一支。本 runner 消费的是**未经解析**回灌的 authored/stored 行(#3903 已确立),看到的是 input 形状。若按既有 `ActionComponent` 的先例从 `Action`(z.infer)派生,就会把 `ActionEngine` 明确支持、且被 `ActionEngine.visibility.test.ts` 钉住的**裸字符串谓词**判成类型错误。`component` 是纯 enum,两者恰好重合,所以旧先例没有暴露这个差异。

**3. 删掉 `ActionEngine` 里 3 处 `as any`**

`visible`、`requiredPermissions`(位置过滤器)、`locations`(注册)。这些 cast 只因字段未声明而存在。该文件 `as any` 从 9 处降到 3 处,剩下的 3 处与本 issue 无关(`ActionContext` 的开放数据袋、evaluator API),按 issue 要求**不动 `ActionContext` 的索引签名**。

**4. 只给 4 个 objectui 方言键标 `@deprecated`**

`actionType` → `type`;`api` 与 `endpoint` → `target`(`executeAPI` 本就按 `api || endpoint || target` 解析);`navigate` → 扁平的 `target` / `openIn`(`executeNavigation` 本就回退到它们)。

**刻意没有**给其余 13 个方言键加 `@deprecated`:它们是 runner 自身的机制(chain/chainMode、onSuccess/onFailure、toast、close、reload、redirect、modal、confirm、condition 等),spec 里没有对应拼写,指向一个不存在的替代品比保持现状更糟。

> 说明一处与派发指令的偏差:派发要求把 `to`/`external`/`newTab`/`replace` 标记为 deprecated,但第 1 步的盘点结论恰恰相反 —— 它们是 `navigation` 别名**自己的合法拼写**,已被显式声明并配有「spec 若采纳其中之一即失败」的 tripwire 测试。给它们标 deprecated 会与第 1 步的结论直接冲突,故未执行。

## 一个刻意的破坏性边缘

`shortcut` 和 `bulkEnabled` 派生出来是 `undefined` 而不是可用类型 —— 这是**正确**结果。spec 17 把两者退役为 `retiredKey()` 墓碑(`z.never()`),作者写任何一个都是**硬解析拒绝**。派生(而非手写 `shortcut?: string`)零成本地把这个运行时拒绝提升成了**编译错误**;手抄则会悄悄把两个死键重新合法化。

因此:此前能编译的 `shortcut: 'ctrl+k'` 现在编译不过。这类元数据本就已被平台拒绝,本 PR 只是把失败挪到能被修复的地方。宿主仍可通过 `ActionEngine.registerAction(action, { shortcut, bulkEnabled })` 显式传入。

**changeset 因此标 `minor` 而非 `patch`** —— AGENTS.md 的版本策略明确要求 objectui 自身的破坏性变更标 minor(绝不 major),正文里写清 breaking 语义。派发指令写的是 patch,这里按仓库约定取 minor;若维护者认为该边缘不算 breaking,改一个词即可。

## 测试

新增 `packages/core/src/actions/__tests__/actionKeys.types.test.ts`(30 条)。被验证的性质是「**编译器**会拒绝错误类型的值」,运行时断言观察不到,而 `expectTypeOf` 在本仓不可用(`vitest.config.mts` 未开 `typecheck` 模式,开启它属于 objectui#3181 的门禁改动,不该搭本 PR 的车)。所以测试用 TS 编译器 API 把一小段虚拟模块编译到真实的 `ActionDef` 上,再读回诊断。

**区分度是内建的,不是靠正文声称的**:同一批坏赋值会被**第二次**编译到 `IndexSignatureOnly`(一个只有 `[key: string]: any` 的接口,即第 2 步之前的 `ActionDef`),并要求**全部干净通过**。这个对照组就是「revert 即红」的证明:撤掉提升,索引签名重新把它们吞掉,断言即由绿转红。

已实测:把 `order?: SpecActionInput['order']` 改成 `order?: any`,精确地红 2 条(`order rejects a string where the spec says number` 与区分度断言)。

按 AGENTS.md 测试纪律,编译在**模块作用域**完成(约 2.9s 落在 import 阶段,不受任何 test/hook 超时约束),而不是放进 `beforeAll`(那会落到更窄的 10s `hookTimeout` 下,是把慢 setup 变成负载相关 flake 的标准做法)。

- `vitest run --project unit`:330 files / 4619 passed
- `vitest run --project dom`:433 files / 4466 passed
- `pnpm type-check`(全仓):0 errors
- `pnpm --filter @object-ui/core lint`:0 errors;改动的三个文件中 `actionKeys.ts` 与新测试 0 warning,`ActionEngine.ts` 的 warning 数因删 cast 而下降

## 不在本 PR 范围

索引签名**保留** —— 删除它是第 3 步。断言「索引签名仍然存在」的那条反向 pin 保持绿色,它是本 issue 自己的完工检查。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012C2cd7tL8QDoZ2QKN3djJ5)_