### PR TITLE
fix(components,grid): 服务端分页下搜索框搜的是整个列表,不是你看得见的那一页 (#3118)

### DIFF
--- a/.changeset/grid-search-is-not-page-scoped.md
+++ b/.changeset/grid-search-is-not-page-scoped.md
@@ -1,0 +1,42 @@
+---
+"@object-ui/types": patch
+"@object-ui/components": patch
+"@object-ui/plugin-grid": patch
+---
+
+A standalone grid's search box searches the list, not the page you can see (objectui#3118).
+
+Under server-side pagination a standalone `ObjectGrid` rendered `data-table`'s
+built-in search box, and that box filtered the rows the table was holding —
+which is one page. The user read "2 results for X in this list" while 3075 rows
+never participated, with the pager beside it still reading `1 / 63`. Every piece
+was individually correct: `searchable` defaults to true, `manualPagination` is
+true, and the two are declared next to each other in the same object literal.
+
+This is objectui#3106 one axis over — sort there, filter here — and it takes the
+same shape. `DataTable` gains `manualSearch` + a controlled `search` +
+`onSearchChange`. In that mode it filters nothing, reports the typed term, and
+renders `search` as the box's value, holding **no** term of its own: a private
+copy beside a controlled prop is the shape the defect had. `ObjectGrid` turns
+that term into a `$search` on the refetch — the server picks the matching fields
+from the object's metadata (ADR-0061), the same channel the ListView toolbar has
+always used — and returns to page 1, since a new term makes the old page index a
+different set of rows (usually no rows at all). `$searchFields` rides along only
+when the view declared `searchableFields`, which can narrow the server-resolved
+set and never widen it.
+
+Two things worth naming:
+
+- Both paths are never live at once. The server's answer is the answer; a client
+  pass left running underneath would silently re-narrow it to whichever returned
+  rows happen to contain the term as *rendered text*, overruling the server's
+  own notion of which fields are searchable.
+- Under `manualSearch` a table with no `onSearchChange` renders **no** search
+  box. The sort axis could degrade to inert headers; here there is no honest
+  local behaviour to fall back to, because the rows to search are not in the
+  browser.
+
+Client-paginated grids are untouched: inline, bound and grouped grids hold every
+row they display, so their box keeps filtering in memory, where the count it
+produces is true. The ListView path was never affected — it passes
+`showSearch: false` and searches from its own toolbar.

--- a/packages/components/src/__tests__/data-table-manual-search.test.tsx
+++ b/packages/components/src/__tests__/data-table-manual-search.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Server-side ("manual") search for DataTable (objectui#3118).
+ *
+ * The defect: the search box filtered whatever rows the table was holding.
+ * Under server pagination that is ONE PAGE, so "2 results" was true of fifty
+ * rows and said nothing about the 3075 the user believed they had searched —
+ * with the pager next to it reading `1 / 63`.
+ *
+ * In manual mode the table filters nothing, reports the term through
+ * `onSearchChange`, and renders `search` as the box's value. It keeps **no**
+ * term of its own, for the same reason `manualSorting` keeps no sort: a private
+ * copy alongside a controlled prop is a term the fetching layer cannot see.
+ *
+ * The filter axis has no honest local fallback the sort axis had — the rows to
+ * search are not in the browser — so a manual-search table with nowhere to
+ * report the term renders no box at all.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { renderComponent } from './test-utils';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout` (objectui#3010/#3021).
+import '../renderers';
+
+/**
+ * One window of a larger collection. Deliberately shares no substring with the
+ * term the tests type, so any surviving client-side pass would empty the table.
+ */
+const pageData = [
+  { id: 'r1', name: 'Alpha', status: 'open' },
+  { id: 'r2', name: 'Bravo', status: 'done' },
+  { id: 'r3', name: 'Charlie', status: 'hold' },
+];
+
+const columns = [
+  { header: 'Name', accessorKey: 'name' },
+  { header: 'Status', accessorKey: 'status' },
+];
+
+const baseSchema = {
+  type: 'data-table' as const,
+  columns,
+  data: pageData,
+  manualSearch: true,
+  search: '',
+} as any;
+
+const rowNames = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('tbody tr')).map(
+    (tr) => tr.querySelector('td')?.textContent?.trim(),
+  );
+
+const searchBox = (container: HTMLElement) =>
+  container.querySelector('input[placeholder="Search..."]') as HTMLInputElement | null;
+
+describe('data-table — manual (server-side) search', () => {
+  it('does not filter the rows it was handed', () => {
+    // `search` is set and matches nothing on screen. These rows ARE the server's
+    // answer to it; narrowing them again here is the whole defect, and would
+    // leave the user staring at "No results" for a query that matched.
+    const { container } = renderComponent({
+      ...baseSchema,
+      search: 'zzz-no-local-match',
+      onSearchChange: vi.fn(),
+    });
+
+    expect(rowNames(container)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('reports the typed term instead of filtering locally', () => {
+    const onSearchChange = vi.fn();
+    const { container } = renderComponent({ ...baseSchema, onSearchChange });
+
+    fireEvent.change(searchBox(container)!, { target: { value: 'acme' } });
+
+    expect(onSearchChange).toHaveBeenCalledWith('acme');
+    expect(rowNames(container)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+  });
+
+  it('holds no term of its own — the box follows the prop, not the keystroke', () => {
+    // The controlled value never changes, so the box must not appear to have
+    // accepted anything. A table keeping a private copy is how a term ends up
+    // somewhere the fetching layer cannot see it.
+    const { container } = renderComponent({ ...baseSchema, onSearchChange: vi.fn() });
+
+    fireEvent.change(searchBox(container)!, { target: { value: 'acme' } });
+
+    expect(searchBox(container)!.value).toBe('');
+  });
+
+  it('renders the controlled term as the box value', () => {
+    const { container } = renderComponent({
+      ...baseSchema,
+      search: 'northwind',
+      onSearchChange: vi.fn(),
+    });
+    expect(searchBox(container)!.value).toBe('northwind');
+  });
+
+  it('renders no search box when no onSearchChange was supplied', () => {
+    // Unlike a sort, there is no honest local behaviour to fall back to: the
+    // rows to search are on the server. A box that can only reach this window
+    // is the defect, so it is withheld rather than degraded.
+    const { container } = renderComponent(baseSchema);
+    expect(searchBox(container)).toBeNull();
+  });
+
+  it('leaves client-side search exactly as it was', () => {
+    // No `manualSearch`: the table holds every row it displays, so filtering
+    // them is a true statement about the list. This mode is untouched by #3118.
+    const { container } = renderComponent({
+      type: 'data-table',
+      columns,
+      data: pageData,
+    } as any);
+
+    fireEvent.change(searchBox(container)!, { target: { value: 'Brav' } });
+
+    expect(rowNames(container)).toEqual(['Bravo']);
+    expect(searchBox(container)!.value).toBe('Brav');
+  });
+
+  it('keeps the client-side box on a client-paginated table', () => {
+    // `manualPagination` is off, so this table owns its rows AND its pager.
+    const { container } = renderComponent({
+      type: 'data-table',
+      columns,
+      data: pageData,
+      pageSize: 2,
+    } as any);
+
+    expect(searchBox(container)).not.toBeNull();
+    fireEvent.change(searchBox(container)!, { target: { value: 'hold' } });
+    expect(rowNames(container)).toEqual(['Charlie']);
+    // …and the narrower result set snaps back to page 1 rather than stranding
+    // the user on a page the new result set no longer has.
+    expect(screen.queryByText('No results found')).toBeNull();
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -365,6 +365,9 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     sort: controlledSort,
     onSortChange,
     searchable = true,
+    manualSearch = false,
+    search: controlledSearch,
+    onSearchChange,
     selectable: selectableProp = false,
     showSelectionCount = true,
     selectionResetKey,
@@ -590,17 +593,27 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     setSelectedRowIds(new Set());
   }, [selectionResetKey]);
 
-  // Filtering
+  // Filtering — client-side, over the rows this table was handed.
+  //
+  // Under `manualSearch` there is nothing to do: `data` is already the server's
+  // answer to the term, computed over the whole collection rather than this
+  // window. Re-filtering it here would search the CURRENT PAGE — the defect
+  // objectui#3118 reports, where "2 results" is true of fifty rows and says
+  // nothing about the 3075 that never participated. Note this is the *only*
+  // filter path, so leaving both active would not even be redundant: the client
+  // pass would narrow the server's answer to whichever of its rows happen to
+  // contain the term as rendered text.
   const filteredData = useMemo(() => {
+    if (manualSearch) return data;
     if (!searchQuery) return data;
-    
+
     return data.filter((row) =>
       columns.some((col) => {
         const value = row[col.accessorKey];
         return value?.toString().toLowerCase().includes(searchQuery.toLowerCase());
       })
     );
-  }, [data, searchQuery, columns]);
+  }, [data, searchQuery, columns, manualSearch]);
 
   // Sorting — client-side, over the rows this table was handed.
   //
@@ -703,6 +716,40 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   // rather than clickable ones that do nothing — a dead affordance is the same
   // class of lie as a sort that only covers the current page.
   const sortingEnabled = sortable && (!manualSorting || !!onSortChange);
+
+  // The term the search box displays.
+  //
+  // Under `manualSearch` this is the caller's prop and nothing else — the
+  // `searchQuery` state is not read, not written, and not mirrored, for the
+  // same reason `activeSort` keeps no copy: a private term beside a controlled
+  // one is a term the layer that fetches the rows cannot see (objectui#3118).
+  const activeSearch = manualSearch ? (controlledSearch ?? '') : searchQuery;
+
+  // A manual-search table with nowhere to report the term renders NO search box
+  // rather than one that filters the page it can see. There is no honest local
+  // fallback here — the rows to search are on the server — so the box is
+  // withheld entirely, which is also the shape ListView already relies on when
+  // it passes `showSearch: false` and searches from its own toolbar.
+  const searchEnabled = searchable && (!manualSearch || !!onSearchChange);
+
+  /**
+   * Apply a new search term — the single write path, so the controlled and
+   * local modes cannot diverge about where the term lands.
+   *
+   * Page reset: in client mode the table owns its page and snaps it to 1, since
+   * a narrower result set makes the old page index meaningless. Under
+   * `manualSearch` the host owns both the page and the refetch, and resets there
+   * (the term and the page have to reach the server in the same request; a reset
+   * issued from here would be a second, racing one).
+   */
+  const applySearch = (value: string) => {
+    if (manualSearch) {
+      onSearchChange?.(value);
+      return;
+    }
+    setSearchQuery(value);
+    setCurrentPage(1);
+  };
 
   /**
    * Sort by one column in a given direction — the single write path, so the
@@ -1284,7 +1331,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   }) && !allPageRowsSelected;
 
   const hasPendingChanges = pendingChanges.size > 0;
-  const showToolbar = searchable || exportable || (showSelectionCount && selectable && selectedRowIds.size > 0) || hasPendingChanges;
+  const showToolbar = searchEnabled || exportable || (showSelectionCount && selectable && selectedRowIds.size > 0) || hasPendingChanges;
 
   return (
     <div className={`flex flex-col h-full gap-2 sm:gap-4 ${className || ''}`}>
@@ -1292,16 +1339,13 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       {showToolbar && (
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-2 sm:gap-4 flex-none">
           <div className="flex items-center gap-2 flex-1">
-            {searchable && (
+            {searchEnabled && (
               <div className="relative w-full sm:max-w-sm flex-1">
                 <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   placeholder={t('table.search')}
-                  value={searchQuery}
-                  onChange={(e) => {
-                    setSearchQuery(e.target.value);
-                    setCurrentPage(1);
-                  }}
+                  value={activeSearch}
+                  onChange={(e) => applySearch(e.target.value)}
                   className="pl-8"
                 />
               </div>

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -452,6 +452,16 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // edit) invalidates a header sort taken against the previous one.
   useEffect(() => { setHeaderSort(null); }, [JSON.stringify(schema.sort ?? null)]);
 
+  // Toolbar search term, when this grid fetches its own rows (objectui#3118).
+  // It goes out as `$search` on the refetch — the server decides which fields
+  // it matches from the object's metadata (ADR-0061), the same channel the
+  // ListView toolbar uses. Filtering the rows we hold instead would search the
+  // page on screen and call the answer "the results in this list".
+  const [searchTerm, setSearchTerm] = useState('');
+  // A term is asked of one collection. Pointing the grid at another object
+  // makes it a question about rows it was never typed for.
+  useEffect(() => { setSearchTerm(''); }, [objectName]);
+
   // --- Inline data effect (synchronous, no fetch needed) ---
   useEffect(() => {
     if (hasInlineData && dataConfig?.provider === 'value') {
@@ -595,6 +605,22 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
             params.$orderby = `${(schema.defaultSort as any).field} ${(schema.defaultSort as any).order}`;
           }
 
+          // Search (objectui#3118). The term the toolbar box holds is a question
+          // about the collection, so it goes to the server rather than to a
+          // `.filter()` over the window we happen to be holding. Per ADR-0061 the
+          // client sends only the term; the server resolves which fields it
+          // matches from the object's metadata. `$searchFields` goes along only
+          // when the view declared `searchableFields` — it can narrow that
+          // server-resolved set, never widen it — which is exactly what the
+          // ListView toolbar sends.
+          const trimmedSearch = searchTerm.trim();
+          if (trimmedSearch) {
+            params.$search = trimmedSearch;
+            if (schema.searchableFields && schema.searchableFields.length > 0) {
+              params.$searchFields = schema.searchableFields;
+            }
+          }
+
           // Auto-inject $expand for lookup/master_detail fields
           const expand = buildExpandFields(resolvedSchema?.fields, schemaColumns ?? schemaFields);
           if (expand.length > 0) {
@@ -629,15 +655,17 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [objectName, schemaFields, schemaColumns, schemaFilter, schemaSort, headerSort, schemaPagination, schemaPageSize, serverPage, serverPageSize, dataSource, hasInlineData, dataConfig, refreshKey]);
+  }, [objectName, schemaFields, schemaColumns, schemaFilter, schemaSort, headerSort, searchTerm, schemaPagination, schemaPageSize, serverPage, serverPageSize, dataSource, hasInlineData, dataConfig, refreshKey]);
 
-  // Reset to page 1 whenever the query itself changes (object / filter / sort),
-  // so we never request a page index that no longer exists for the new result
-  // set (e.g. applying a filter while sitting on page 5 of the old query).
+  // Reset to page 1 whenever the query itself changes (object / filter / sort /
+  // search), so we never request a page index that no longer exists for the new
+  // result set (e.g. applying a filter while sitting on page 5 of the old
+  // query). A new search term is the sharpest case of this: 3075 rows can
+  // become 2, and "page 5" of that is nothing at all.
   React.useEffect(() => {
     setServerPage(1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [objectName, schemaFilter, schemaSort, headerSort]);
+  }, [objectName, schemaFilter, schemaSort, headerSort, searchTerm]);
 
   // --- NavigationConfig support ---
   // Must be called before any early returns to satisfy React hooks rules
@@ -1675,6 +1703,14 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // keeps DataTable's own client-side sort.
   const manualSortingOn = manualPaginationOn;
 
+  // Server-side search, on exactly the same condition (objectui#3118). Same
+  // question, filter axis: when `data` is one window, a `.filter()` over it
+  // narrows the fifty rows on screen while the rest of the collection never
+  // participates — and unlike a mis-scoped sort, the count it produces reads as
+  // a statement about the whole list. Grouped/inline grids hold every row they
+  // display, so their box keeps filtering client-side, where it is honest.
+  const manualSearchOn = manualPaginationOn;
+
   /**
    * Withhold the sort affordance from a relational column when the sort is the
    * server's (objectui#3096 + #3106).
@@ -2058,6 +2094,19 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     ? (rest as any).onSortChange
     : setHeaderSort;
 
+  // The search term, in whichever server mode applies. When a parent owns the
+  // rows it owns the term too (ListView already does, from its own toolbar —
+  // which is why it passes `showSearch: false` and no box is rendered here);
+  // when we own the fetch, the box writes `searchTerm` and the effect above
+  // turns it into `$search`. A parent that drives the rows but offers no
+  // `onSearchChange` gets NO box rather than one scoped to its window.
+  const manualSearch = externalManualPagination
+    ? ((rest as any).search ?? '')
+    : searchTerm;
+  const manualOnSearchChange = externalManualPagination
+    ? (rest as any).onSearchChange
+    : setSearchTerm;
+
   const dataTableSchema: any = {
     type: 'data-table',
     caption: schema.label || schema.title,
@@ -2081,6 +2130,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     sort: manualSortingOn ? manualSort : undefined,
     onSortChange: manualSortingOn ? manualOnSortChange : undefined,
     searchable: searchEnabled,
+    manualSearch: manualSearchOn,
+    search: manualSearchOn ? manualSearch : undefined,
+    onSearchChange: manualSearchOn ? manualOnSearchChange : undefined,
     selectable: selectionMode,
     // ObjectGrid surfaces the selection via its own bottom BulkActionBar
     // (count + Clear + bulk actions). Suppress the data-table's built-in

--- a/packages/plugin-grid/src/__tests__/serverSearch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/serverSearch.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * The grid's search box reaches the server (objectui#3118).
+ *
+ * Before the fix, DataTable's search box filtered whatever rows the table was
+ * holding. Under server pagination that is ONE PAGE, so "2 results" was true of
+ * fifty rows and said nothing about the 3075 that never participated — with the
+ * pager beside it reading `1 / 63`.
+ *
+ * After the fix a typed term becomes a `$search` on the refetch — the server
+ * resolves which fields it matches from the object's metadata (ADR-0061), the
+ * same channel the ListView toolbar has always used — and the grid returns to
+ * page 1, because a new term makes "page 5" a different set of rows (usually
+ * no rows at all).
+ *
+ * This is #3106's collapse of a window-scoped operation, one axis over: sort
+ * there, filter here. The tests below are its structural twins, plus one the
+ * sort axis did not need — that the client-side pass is OFF rather than
+ * stacked underneath the server's answer.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = vi.fn(() => false) as any;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const TOTAL = 300;
+const PAGE_SIZE = 50;
+/** How many records the fake server says match any search term. */
+const MATCHES = 2;
+
+/**
+ * A server that actually honours `$search`: it answers with a different, much
+ * smaller collection, and — the load-bearing detail — one whose rows do NOT
+ * contain the typed term as rendered text. A client-side pass left running on
+ * top would therefore reduce the server's answer to nothing, which is how these
+ * tests can tell "the server searched" from "the browser searched".
+ */
+function makeDataSource() {
+  const find = vi.fn(async (_object: string, params: any) => {
+    const searching = typeof params.$search === 'string' && params.$search !== '';
+    const total = searching ? MATCHES : TOTAL;
+    const top = params.$top ?? PAGE_SIZE;
+    const skip = params.$skip ?? 0;
+    const count = Math.max(0, Math.min(top, total - skip));
+    const rows = Array.from({ length: count }, (_, i) => ({
+      id: `id-${skip + i}`,
+      name: searching ? `Match ${skip + i}` : `Row ${skip + i}`,
+      status: 'open',
+    }));
+    return { data: rows, total, hasMore: skip + rows.length < total, pageSize: top };
+  });
+  return {
+    find,
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text' },
+        status: { type: 'text' },
+      },
+    }),
+  } as any;
+}
+
+function renderGrid(dataSource: any, opts?: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'task',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'status', label: 'Status' },
+    ],
+    pagination: { pageSize: PAGE_SIZE },
+    ...opts,
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} dataSource={dataSource} />
+    </ActionProvider>,
+  );
+}
+
+const lastFindParams = (ds: any) => ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+
+const searchBox = (container: HTMLElement) =>
+  container.querySelector('input[placeholder="Search..."]') as HTMLInputElement;
+
+/**
+ * The rendered rows, as their full text. Whole-row text rather than the first
+ * cell: the grid prepends chrome columns (row number, selection) whose content
+ * is not the record's.
+ */
+const rowTexts = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('tbody tr')).map((tr) => tr.textContent ?? '');
+
+describe('ObjectGrid — the search box is server-side under server pagination (#3118)', () => {
+  it('turns a typed term into a $search on the refetch', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    fireEvent.change(searchBox(container), { target: { value: 'acme' } });
+
+    await waitFor(() => {
+      expect(lastFindParams(ds).$search).toBe('acme');
+    });
+  });
+
+  it('does NOT filter the page it is holding — the server\'s answer is what renders', async () => {
+    // The revert-proof assertion. Remove the wiring and this test reports the
+    // defect verbatim: `Match 0` never arrives (no request carried the term)
+    // and the grid renders the current page filtered down to the rows whose
+    // text happens to contain "acme" — none — i.e. "no results" out of 300.
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    fireEvent.change(searchBox(container), { target: { value: 'acme' } });
+
+    await waitFor(() => expect(screen.getByText('Match 0')).toBeInTheDocument());
+    // Every row the server returned is on screen, including the ones that do
+    // not contain the term as text: matching is the server's business (which
+    // fields, and how) and a second local pass would silently overrule it.
+    const rows = rowTexts(container);
+    expect(rows).toHaveLength(MATCHES);
+    expect(rows[0]).toContain('Match 0');
+    expect(rows[1]).toContain('Match 1');
+  });
+
+  it('reports the real match total, not the count within one page', async () => {
+    // The half of the defect the user actually reads: "N results" has to be a
+    // statement about the collection. It comes from the same response.
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    fireEvent.change(searchBox(container), { target: { value: 'acme' } });
+
+    await waitFor(() => expect(screen.getByText('Match 0')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(container.textContent).toContain(`${MATCHES}`),
+    );
+    // 300 records over 50 per page was `1 / 6`; the searched collection is one
+    // page, so the old page count must be gone rather than left standing next
+    // to two rows.
+    expect(container.textContent).not.toContain('/ 6');
+  });
+
+  it('returns to page 1 — a new term makes the old page index a different set of rows', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    // Advance off page 1 first (last-page button guarantees a forward jump).
+    const navButtons = Array.from(container.querySelectorAll('button')).filter(
+      (b) => !(b as HTMLButtonElement).disabled,
+    );
+    fireEvent.click(navButtons[navButtons.length - 1]);
+    await waitFor(() => expect(lastFindParams(ds).$skip).toBeGreaterThan(0));
+
+    fireEvent.change(searchBox(container), { target: { value: 'acme' } });
+
+    await waitFor(() => {
+      const p = lastFindParams(ds);
+      expect(p.$search).toBe('acme');
+      expect(p.$skip ?? 0).toBe(0);
+    });
+  });
+
+  it('sends $searchFields only when the view declared searchableFields (ADR-0061)', async () => {
+    // The term is the client's; WHICH fields it matches is the server's, read
+    // from the object's metadata. A view may narrow that set — never widen it —
+    // so the parameter is absent unless the view asked for the narrowing.
+    const plain = makeDataSource();
+    const { container: c1 } = renderGrid(plain);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+    fireEvent.change(searchBox(c1), { target: { value: 'acme' } });
+    await waitFor(() => expect(lastFindParams(plain).$search).toBe('acme'));
+    expect(lastFindParams(plain).$searchFields).toBeUndefined();
+
+    const narrowed = makeDataSource();
+    const { container: c2 } = renderGrid(narrowed, { searchableFields: ['name'] });
+    await waitFor(() => expect(narrowed.find).toHaveBeenCalled());
+    fireEvent.change(searchBox(c2), { target: { value: 'acme' } });
+    await waitFor(() => {
+      expect(lastFindParams(narrowed).$searchFields).toEqual(['name']);
+    });
+  });
+
+  it('clearing the box returns to the unsearched collection', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    fireEvent.change(searchBox(container), { target: { value: 'acme' } });
+    await waitFor(() => expect(screen.getByText('Match 0')).toBeInTheDocument());
+
+    fireEvent.change(searchBox(container), { target: { value: '' } });
+
+    await waitFor(() => {
+      // Absent, not `$search: ''` — an empty term is not a query the server
+      // should have to interpret.
+      expect(lastFindParams(ds).$search).toBeUndefined();
+    });
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+  });
+
+  it('renders no search box when the view turned search off', async () => {
+    const ds = makeDataSource();
+    const { container } = renderGrid(ds, { showSearch: false });
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+    expect(searchBox(container)).toBeNull();
+    // This is the ListView path: it passes `showSearch: false` and searches
+    // from its own toolbar, which is why #3118 never reached it.
+  });
+});
+
+describe('ObjectGrid — a client-paginated grid still searches client-side', () => {
+  const inlineRows = [
+    { id: 'a', name: 'Alpha', status: 'open' },
+    { id: 'b', name: 'Bravo', status: 'done' },
+    { id: 'c', name: 'Charlie', status: 'hold' },
+  ];
+
+  const renderInline = (opts?: Record<string, any>) =>
+    render(
+      <ActionProvider>
+        <ObjectGrid
+          schema={{
+            type: 'object-grid',
+            objectName: 'task',
+            columns: [
+              { field: 'name', label: 'Name' },
+              { field: 'status', label: 'Status' },
+            ],
+            data: { provider: 'value', items: inlineRows },
+            ...opts,
+          } as any}
+        />
+      </ActionProvider>,
+    );
+
+  it('filters in memory — there is no window, so the count is honest', async () => {
+    // Inline data IS the collection. Filtering it says something true about the
+    // list, so #3118 leaves this path exactly as it was.
+    const { container } = renderInline();
+    await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
+
+    fireEvent.change(searchBox(container), { target: { value: 'Brav' } });
+
+    await waitFor(() => {
+      const rows = rowTexts(container);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toContain('Bravo');
+    });
+  });
+
+  it('keeps the term it was typed — the box is uncontrolled here', async () => {
+    const { container } = renderInline();
+    await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument());
+
+    fireEvent.change(searchBox(container), { target: { value: 'hold' } });
+
+    await waitFor(() => expect(searchBox(container).value).toBe('hold'));
+    const rows = rowTexts(container);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toContain('Charlie');
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -465,6 +465,43 @@ export interface DataTableSchema extends BaseSchema {
    */
   searchable?: boolean;
   /**
+   * Server-side ("manual") search. When true the table does NOT filter `data`
+   * locally — it is already the result the server produced for the whole
+   * collection — and typing in the search box reports the term through
+   * `onSearchChange` instead.
+   *
+   * Set this whenever `data` is one window of a larger collection. Filtering a
+   * window locally searches **that page**, which reads on screen as "2 results
+   * in this list" while every row outside the window never participated
+   * (objectui#3118). It is the filter-axis twin of `manualSorting`, and tied to
+   * the same question: is `data` a window, or the collection?
+   *
+   * The table keeps NO search state of its own in this mode — `search` is the
+   * only source of truth, and the box renders that. A private copy alongside a
+   * controlled prop is how the original defect arose.
+   * @default false
+   */
+  manualSearch?: boolean;
+  /**
+   * The active search term, when `manualSearch` is on. Drives the search box's
+   * value and is what the host turned into a server `$search` (ADR-0061: the
+   * client sends the term, the server resolves which fields it matches from the
+   * object's metadata). Ignored otherwise (the table owns its term in client
+   * mode).
+   */
+  search?: string;
+  /**
+   * Called with the term the user typed, when `manualSearch` is on. The host is
+   * expected to re-read the collection with it and return to page 1 — a new
+   * term makes the old page index a different set of rows.
+   *
+   * Without this callback the search box is not rendered at all under
+   * `manualSearch`. A box that filters nothing is the same class of lie as one
+   * that filters only the page you can see, and there is no honest local
+   * fallback: the rows to search are not in the browser.
+   */
+  onSearchChange?: (search: string) => void;
+  /**
    * Enable row selection
    * - boolean: Enable/disable selection (true = multiple selection)
    * - 'single': Single row selection


### PR DESCRIPTION
Fixes #3118

## 问题

服务端分页下,独立 `ObjectGrid` 渲染的是 `data-table` 的内置搜索框,而它过滤的是**手上那批行** —— 也就是当前这一页。用户读到的是「这个列表里搜 X 只有 2 条」,实际是「这 50 行里有 2 条,另外 3075 行没参与」;分页器还在旁边写着 `1 / 63`。

每一项单独看都对:`searchable` 默认 true,`manualPagination` 也是 true,两者在同一个对象字面量里相邻声明 —— 这正是它不易被看见的原因。

## 修法(issue 选项 1,与 #3106 同构)

同一条原则的第三次复现,维度从排序键(#3096)、排序范围(#3106)换到了**过滤范围**,所以结构照抄 #3106:

- **`DataTable`** 新增 `manualSearch` + 受控 `search` + `onSearchChange`。该模式下它**不做任何过滤**,只把用户输入的词报出去,并把 `search` 渲染为搜索框的值;它**不持有自己的词** —— 「受控 prop 旁边再留一份私有副本」正是缺陷本身的形状。
- **`ObjectGrid`** 把这个词变成取数时的 `$search`(ADR-0061:客户端只传词,服务端按对象元数据决定匹配哪些字段 —— ListView 工具栏一直走的就是这条通路),并**回到第 1 页**:新的词让旧的页码指向另一批行(通常一行都没有)。仅当视图声明了 `searchableFields` 时才附带 `$searchFields`,它只能**收窄**服务端解析出的可搜字段集,不能放宽。

两点值得点名:

1. **两条通路绝不同时生效。** 服务端的答案就是答案;底下若还留着客户端那一遍,会把返回的行再按「渲染出来的文本是否含该词」筛一次,悄悄推翻服务端自己关于「哪些字段可搜」的判断。测试用「返回的行本身不含该词」的假服务端把这一点钉死。
2. **`manualSearch` 且没有 `onSearchChange` 时,不渲染搜索框。** 排序那一轴还能退化成「不可点的表头」;过滤这一轴没有可退的诚实行为 —— 要搜的行根本不在浏览器里。

**客户端分页的网格原样不动**:inline / bound / 分组网格持有它展示的每一行,搜索框继续在内存里过滤,那里的计数是真话。ListView 路径本来就不受影响(它传 `showSearch: false`,搜索由自己的工具栏负责)。

## 测试

- `packages/plugin-grid/src/__tests__/serverSearch.test.tsx`(9 个):输入词 → 发出带 `$search` 的请求且 `$skip` 归零;**不**过滤手上的那一页(服务端返回什么就渲染什么);总数是真实匹配总数而非「本页命中数」;`$searchFields` 仅在视图声明时出现;清空搜索框回到未搜索的集合;`showSearch: false` 不渲染搜索框;客户端分页(inline data)行为不变。
- `packages/components/src/__tests__/data-table-manual-search.test.tsx`(7 个):`manualSearch` 下不过滤、只上报、不持有自己的词、无回调则不渲染搜索框;客户端模式逐字不变。
- **防回退验证**:临时把 `ObjectGrid` 里的 `manualSearch`/`search`/`onSearchChange` 三行注释掉后,服务端那组 6 个测试立刻失败,失败信息就是缺陷本身 —— `$search` 为 `undefined`(词从未发给服务端)、`Match 0` 永远不出现(搜索框把当前页过滤成了空)。恢复后 9 个全绿。

命令与结果:

```
npx vitest run packages/plugin-grid                       → 49 files / 418 tests passed
npx vitest run packages/components                        → 61 files / 482 tests passed
npx vitest run packages/plugin-list packages/types        → 41 files / 609 tests passed
npx vitest run packages/plugin-detail packages/app-shell  → 287 files / 2464 passed, 1 skipped
npx turbo run type-check --filter=@object-ui/types --filter=@object-ui/components --filter=@object-ui/plugin-grid → 15/15 successful
npx turbo run lint(同三个包)                              → 0 errors
```

Changeset:`.changeset/grid-search-is-not-page-scoped.md`(patch,fixed 组三个包)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012C2cd7tL8QDoZ2QKN3djJ5)_