### PR TITLE
fix(types): 把 objectstack#4171 三处反向 pin 对准真正的触发条件 (#3177)

### DIFF
--- a/.changeset/inverted-pin-burndown-probes.md
+++ b/.changeset/inverted-pin-burndown-probes.md
@@ -1,0 +1,45 @@
+---
+"@object-ui/types": patch
+---
+
+Fix the admission probes behind objectstack#4171's three inverted pins, and
+derive the `NavigationItem` keys that genuinely became derivable (objectui#3177).
+
+Spec 17.0.0-rc.1 typed `NavigationItem`, `FormField` and
+`ConditionalValidation.then`/`.otherwise`, so the `IsAny` / `IsUnknown` pins
+guarding them fired. Firing was supposed to mean "the burn-down is due". A
+per-symbol triage found it did not: **`any` was never the only blocker for any
+of the three**, so "no longer `any`" was never the right admission question.
+Nothing was bound; the probes now ask the condition that actually governs each
+symbol, and each still asserts today's state — so they pass now and stop
+compiling the day their own blocker lifts.
+
+- `NavigationItem` — the spec models navigation as a nine-variant discriminated
+  union; objectui keeps one flat shape, and the spec has no counterpart at
+  either tier for `visible: boolean` (which `menuItemToNavigationItem`
+  manufactures when it inverts legacy `MenuItem.hidden`), `pinned` (backs
+  `useNavPins`), the legacy `defaultOpen` spelling, or a separator carrying a
+  `label`. Four probes, one per blocker.
+- `FormField` — two concepts on two layers, not two dialects of one: the
+  required keys are disjoint (objectui `name` = the form data path; spec
+  `field` = an object-field reference, with no `name` at either tier), and the
+  shared `field` key is a string on one side and the resolved metadata object
+  on the other. Binding would also collapse the objectui#3090 disambiguation
+  that exports `SpecFormField` separately, and revert framework#4074's
+  `dependsOn` widening.
+- `ConditionalValidation` — the branches went from `unknown` to
+  `BaseValidationRuleShape`, which is `{ type: string; …; [key: string]:
+  unknown }`. Better than `unknown`, still not derivable: `type` is not a
+  literal union so a branch cannot narrow by discriminant, and the index
+  signature waves through any member — a typo'd `type: 'formatt'` included. The
+  spec says so itself and names the remaining work as objectstack#4075. The
+  probe now pins "literal discriminant / no index signature", so it goes green
+  exactly when that lands.
+
+What DID become derivable is derived. `NavigationItemType` now comes off the
+spec's own nav-item discriminant instead of a hand-written nine-member copy —
+the objectstack#4115 failure class, and it also makes a future spec variant a
+compile error at exhaustive consumers rather than a silent `default:`. Same for
+`recordMode`, `filters`, `badge`, `target`, `params` and `actionDef`, each taken
+from the spec branch that owns it, extending the existing `badgeVariant`
+precedent. No member changes today, so no consumer is affected.

--- a/packages/types/src/__tests__/spec-derived-unions.test.ts
+++ b/packages/types/src/__tests__/spec-derived-unions.test.ts
@@ -61,14 +61,18 @@ import {
 import {
   FieldType as SpecFieldType,
 } from '@objectstack/spec/data';
-// The objectstack#4171 inverted pin must import the banned name to probe its
-// any-ness — this guard is a sanctioned importer (#3090 tripwire).
+// The objectstack#4171 / #3177 pins must import the banned name to probe it —
+// this guard is a sanctioned importer (#3090 tripwire).
 /* eslint-disable no-restricted-imports -- reported at the specifier line, out of -next-line reach */
 import type {
   NavigationItem as SpecNavigationItem,
+  NavigationItemInput as SpecNavigationItemInput,
   FormField as SpecFormField,
+  FormFieldInput as SpecFormFieldInput,
 } from '@objectstack/spec/ui';
 /* eslint-enable no-restricted-imports */
+import type { NavigationItem, NavigationItemType } from '../app';
+import type { FormField } from '../form';
 import type { BreakpointName } from '../mobile';
 import type { ExportJobStatus, ImportJobStatus, ImportWriteMode, ValidationError } from '../data';
 import {
@@ -145,40 +149,157 @@ const _validationErrorShape: ValidationError = { field: 'name', message: 'requir
 // objectui query-AST vocabulary they have become.
 
 /**
- * Inverted pins — the tripwire FIRED on spec 17.0.0-rc.1 (#3177).
+ * Admission probes for `NavigationItem` and `FormField` (#3177).
+ *
+ * ## What these used to be, and why they were replaced
  *
  * `NavigationItem`, `JoinNode` and `FormField` used to collide with a spec
  * export whose own declaration resolved to `any` (the spec annotated the
  * recursive schemas behind them as `z.ZodType<any>`, and `z.infer` of that is
  * `any`). Binding objectui's local interface to that would have replaced a
  * precise, documented shape with `any` — a type-safety regression wearing a
- * burn-down's clothes — so they stayed local, and these pins asserted the
+ * burn-down's clothes — so they stayed local, and two `IsAny` pins asserted the
  * premise held. Filed upstream as objectstack#4171.
  *
- * Two of them are now typed properly upstream, so the assertions below are
- * inverted to record that fact rather than the old one. **They are a record,
- * not a resolution**: the burn-down each one asks for — deriving objectui's
- * `NavigationItem` / `FormField` from the spec — touches widely-used public
- * types and is deliberately NOT bundled into a version bump. Tracked in #3177.
+ * Spec 17.0.0-rc.1 typed both properly and the `IsAny` pins fired. The #3177
+ * triage then measured what the burn-down they demanded would actually cost —
+ * and found that **`any` was never the only blocker for either symbol**, so
+ * "no longer `any`" was never the right admission question. `IsAny` going
+ * `false` proves the spec type is no longer EMPTY; it says nothing about
+ * whether it is PRECISE enough to bind, which is what the burn-down needs.
  *
- * `JoinNode`'s pin is gone entirely: spec 17.0.0 retired the symbol
- * (framework#4286), so there is no collision left to reason about.
+ * So the probes below ask the real question instead, one blocker per line. Each
+ * asserts the CURRENT state (so this file is green today) and stops compiling
+ * the day that specific blocker lifts — at which point that line names exactly
+ * what became derivable. `JoinNode` needs none of this: spec 17.0.0 retired the
+ * symbol (framework#4286), so there is no collision left to reason about.
  *
- * Mutual assignability CANNOT distinguish the `any` case on its own: `any`
- * answers every `extends` question affirmatively, so a naive probe reports such
- * a symbol as "identical to the spec" and recommends exactly the wrong edit.
- * That is why these are written as explicit `IsAny` probes.
+ * ## Why not simply compare the two types
+ *
+ * Mutual assignability lies here, in three separate ways, all of them present
+ * in this repo (the list is `scripts/check-spec-symbol-derivation.mjs`'s):
+ * `any` answers every `extends` question affirmatively; so does `unknown` on
+ * one side; and objectui's `FormField` carries `[key: string]: any`, which
+ * absorbs any member the spec has and makes the two compare equal while they
+ * accept wildly different objects. A structural `extends` ALSO silently permits
+ * excess properties, so it cannot see that the spec declares no `pinned`. Hence
+ * per-key, per-tier probes rather than one verdict.
  */
 type IsAny<T> = 0 extends 1 & T ? true : false;
-const _specNavigationItemIsStillAny = false satisfies IsAny<SpecNavigationItem>;
-const _specFormFieldIsStillAny = false satisfies IsAny<SpecFormField>;
+
+/** Every key of every branch of a union (plain `keyof` on a union gives the intersection). */
+type KeysOfUnion<T> = T extends unknown ? keyof T : never;
+/** Does the spec declare this key on ANY nav branch, at EITHER tier? */
+type SpecNavDeclares<K extends string> =
+  K extends KeysOfUnion<SpecNavigationItem> | KeysOfUnion<SpecNavigationItemInput> ? true : false;
+
+// ── NavigationItem: the three blockers, none of which `any` ever caused ──────
+//
+// Umbrella verdict: still not bindable. The lines under it say why, and are the
+// ones to act on — this one stays `false` while ANY blocker remains.
+const _localNavIsNotYetTheSpecUnion = false satisfies [NavigationItem] extends [SpecNavigationItem]
+  ? true
+  : false;
+
+// 1. `visible: boolean`. The spec takes a CEL string (input) / Expression
+//    envelope (output); neither tier admits a boolean. `NavigationRenderer`
+//    evaluates one, and `menuItemToNavigationItem` MANUFACTURES one when it
+//    inverts legacy `MenuItem.hidden`. Measured: binding to the input tier
+//    fails with 3x TS2322 on exactly those lines.
+type SpecNavVisible =
+  | NonNullable<Extract<SpecNavigationItem, { type: 'url' }>['visible']>
+  | NonNullable<Extract<SpecNavigationItemInput, { type: 'url' }>['visible']>;
+const _specNavVisibleStillRejectsBoolean = false satisfies boolean extends SpecNavVisible
+  ? true
+  : false;
+
+// 2. Keys the spec has no counterpart for at either tier. `pinned` backs
+//    `useNavPins` + `FavoritesProvider`; `defaultOpen` is the legacy spelling
+//    `navigation-spec-parity.test.ts` keeps accepting for published metadata.
+//    If the spec ever claims either NAME, this fails and the two meanings must
+//    be reconciled rather than silently shadowed.
+const _specNavStillHasNoPinned = false satisfies SpecNavDeclares<'pinned'>;
+const _specNavStillHasNoDefaultOpen = false satisfies SpecNavDeclares<'defaultOpen'>;
+
+// 3. objectui's separator carries a `label`; the spec's separator branch
+//    declares only `type` / `id?` / `order?`. `menuItemToNavigationItem` emits
+//    one (measured: TS2353), so this is load-bearing, not decorative.
+const _specSeparatorStillHasNoLabel = false satisfies 'label' extends keyof Extract<
+  SpecNavigationItem,
+  { type: 'separator' }
+>
+  ? true
+  : false;
+
+// What IS derivable today is derived: `app.ts` now takes `NavigationItemType`
+// off the spec's discriminant, and `recordMode` / `filters` / `badge` /
+// `target` / `params` / `actionDef` / `badgeVariant` off the branch that owns
+// each. This asserts the membership list really is the spec's — a restatement
+// that drops a member (the objectstack#4115 failure class) fails here.
+const _navTypeCoversSpec = null as unknown as SpecNavigationItem['type'] satisfies NavigationItemType;
+
+// ── FormField: not one concept in two dialects, but two concepts on two layers ─
+//
+// `select-option-spec-parity.test.ts` states the distinction in its own header —
+// "Unlike the FormField pair — two genuinely different concepts on two layers —
+// a select option is ONE concept in two dialects" — and `index.ts` exports
+// `SpecFormField` SEPARATELY as the disambiguation the #3090 tripwire exists to
+// force. Binding would make `FormField === SpecFormField` and collapse that.
+//
+// The decisive, mechanical form of "two layers": the two types' REQUIRED keys
+// are disjoint. objectui requires `name` (the form data path); the spec requires
+// `field` (a reference to an object field) and has no `name` at either tier.
+const _specFormFieldIsNoLongerAny = false satisfies IsAny<SpecFormField>;
+const _specFormFieldStillHasNoName = false satisfies 'name' extends keyof SpecFormField
+  ? true
+  : false;
+const _specFormFieldInputStillHasNoName = false satisfies 'name' extends keyof SpecFormFieldInput
+  ? true
+  : false;
+
+// The same key on both sides, meaning different things — the pun `form.ts`
+// flags with a ⚠️. The spec's `field` is the referenced field's NAME; on a
+// runtime `FormField` the slot holds the RESOLVED metadata object, and
+// `normalizeSectionField` (@object-ui/plugin-form) is the only place the two
+// layers meet.
+const _specFieldSlotIsStillAName = true satisfies [SpecFormField['field']] extends [string]
+  ? true
+  : false;
+const _localFieldSlotIsStillAnObject = false satisfies [NonNullable<FormField['field']>] extends [
+  string,
+]
+  ? true
+  : false;
+
+// framework#4074 widened objectui's `dependsOn` to match its runtime reader
+// (`resolveCascadingOptions` has always accepted arrays and `{ field, param }`
+// entries). The spec still says `string`, so binding would revert that fix.
+const _specDependsOnStillTakesNoArray = false satisfies string[] extends NonNullable<
+  SpecFormFieldInput['dependsOn']
+>
+  ? true
+  : false;
+
+// ADR-0089 D2 folds `visibleOn` into `visibleWhen` at the spec's schema
+// boundary, so it is absent from the OUTPUT type by construction — while
+// objectui's #2212 wire contract keeps it. (The spec's input tier still
+// accepts it; this asks the output tier on purpose.)
+const _specOutputStillDropsVisibleOn = false satisfies 'visibleOn' extends keyof SpecFormField
+  ? true
+  : false;
 
 void _chartCovers; void _reportCovers; void _actionCovers; void _pageCovers; void _vizCovers;
 void _runnableCovers; void _componentCovers; void _paramFieldCovers; void _resolvableCovers;
 void _fieldBackedParam; void _minimalTypedParam;
 void _breakpointCovers; void _importModeCovers; void _importStatusCovers; void _exportStatusCovers;
 void _validationErrorShape;
-void _specNavigationItemIsStillAny; void _specFormFieldIsStillAny;
+void _localNavIsNotYetTheSpecUnion; void _specNavVisibleStillRejectsBoolean;
+void _specNavStillHasNoPinned; void _specNavStillHasNoDefaultOpen;
+void _specSeparatorStillHasNoLabel; void _navTypeCoversSpec;
+void _specFormFieldIsNoLongerAny; void _specFormFieldStillHasNoName;
+void _specFormFieldInputStillHasNoName; void _specFieldSlotIsStillAName;
+void _localFieldSlotIsStillAnObject; void _specDependsOnStillTakesNoArray;
+void _specOutputStillDropsVisibleOn;
 
 /** Read a spec enum's members, failing loudly if the shape ever changes. */
 const optionsOf = (schema: unknown, name: string): string[] => {

--- a/packages/types/src/__tests__/validation-rule-spec-parity.test.ts
+++ b/packages/types/src/__tests__/validation-rule-spec-parity.test.ts
@@ -104,19 +104,55 @@ const _conditionalNonBranchKeysAreSpec = true satisfies Equal<
 // …and the branches are precise here, not `unknown`.
 const _conditionalBranchIsTyped = false satisfies IsUnknown<ConditionalValidation['then']>;
 
-// INVERTED PIN (objectstack#4171) — FIRED on spec 17.0.0-rc.1 (#3177).
+// ── The branch probes, retargeted (#3177) ───────────────────────────────────
 //
-// The divergence above was only justified while the spec's own
-// `then`/`otherwise` erased to `unknown`. They no longer do, so the assertions
-// are inverted to record that. **A record, not a resolution**: what the pin asks
-// for — deleting the divergence and deriving `ConditionalValidation` whole — is
-// deliberately not bundled into a version bump. Tracked in #3177.
-const _specThenIsStillUnknown = false satisfies IsUnknown<
-  z.input<typeof ConditionalValidationSchema>['then']
->;
-const _specOtherwiseIsStillUnknown = false satisfies IsUnknown<
-  z.input<typeof ConditionalValidationSchema>['otherwise']
->;
+// These used to ask `IsUnknown<…>`, on the reasoning that the divergence was
+// justified only while the spec's `then`/`otherwise` erased to `unknown`. Spec
+// 17.0.0-rc.1 made that `false` and the pins fired — but the #3177 triage found
+// the pins had asked too weak a question, and firing did NOT mean the branches
+// had become derivable.
+//
+// What they actually became is `BaseValidationRuleShape`:
+//
+//   interface BaseValidationRuleShape {
+//     type: string; name: string; message: string; …; [key: string]: unknown;
+//   }
+//
+// The spec says so itself, at that type's declaration: "it types the KNOWN keys
+// and accepts any others. That is a real improvement over `unknown` (which types
+// nothing) but **it is not strictness** — the discriminated union below is what
+// actually rejects a malformed rule, at parse time. Removing the index signature
+// is the #4075 family of work, not this change."
+//
+// So deriving wholesale today would trade a 9-member discriminated union for a
+// bag: `then.type` degrades from a literal union to `string`, `then.condition`
+// to `unknown`, and a typo'd `type: 'formatt'` starts compiling. That is the
+// same regression the original pin existed to prevent, one notch weaker — and
+// it lands where it costs most, because renderers read plain objects and never
+// parse, so the authoring-time discriminant is the ONLY gate on these rules.
+//
+// The probes below therefore ask the pin's TRUE trigger — "does the spec type
+// them PROPERLY", not "does it type them at all". Both assert today's state, so
+// this file is green now; both stop compiling when objectstack#4075 removes the
+// index signature and the branches become a real union, which is when the
+// wholesale derivation genuinely comes due.
+type SpecThen = z.input<typeof ConditionalValidationSchema>['then'];
+type SpecOtherwise = NonNullable<z.input<typeof ConditionalValidationSchema>['otherwise']>;
+
+/** A discriminated union has a LITERAL `type`; a bag widens it to `string`. */
+type HasLiteralDiscriminant<T extends { type: unknown }> = string extends T['type'] ? false : true;
+/** `[key: string]: unknown` absorbs any member, so nothing is rejected at authoring time. */
+type HasIndexSignature<T> = string extends keyof T ? true : false;
+
+const _specThenStillCannotNarrow = false satisfies HasLiteralDiscriminant<SpecThen>;
+const _specOtherwiseStillCannotNarrow = false satisfies HasLiteralDiscriminant<SpecOtherwise>;
+const _specThenStillCarriesAnIndexSignature = true satisfies HasIndexSignature<SpecThen>;
+const _specOtherwiseStillCarriesAnIndexSignature = true satisfies HasIndexSignature<SpecOtherwise>;
+
+// Kept as the record of WHY the predicate had to change: the branches are no
+// longer `unknown`, so the original pin's own stated condition really did lapse
+// — it was simply not the condition that governed the burn-down.
+const _specThenIsNoLongerUnknown = false satisfies IsUnknown<SpecThen>;
 
 /**
  * The spec ships these as `lazySchema()` thunks, so `.shape` is only reachable
@@ -332,13 +368,20 @@ describe('predicates are on the ExpressionInput wire shape, not `string`', () =>
   });
 });
 
-describe('pinned divergence: `then` / `otherwise` (objectstack#4171)', () => {
+describe('pinned divergence: `then` / `otherwise` (objectstack#4171, #4075)', () => {
   // The type half of this divergence is pinned at the top of this file
-  // (`_specThenIsStillUnknown` / `_conditionalBranchIsTyped`), because that is
-  // the half a runtime assertion cannot reach. What IS observable at runtime is
-  // that the spec's own parser still rejects a nonsense branch — so the erasure
-  // is purely a published-typing defect, not a loosened contract, and objectui
-  // re-typing the branch cannot admit anything the server would refuse.
+  // (`_specThenStillCannotNarrow` / `_specThenStillCarriesAnIndexSignature` /
+  // `_conditionalBranchIsTyped`), because that is the half a runtime assertion
+  // cannot reach. What IS observable at runtime is that the spec's own parser
+  // still rejects a nonsense branch — so the weak typing is purely a published-
+  // typing defect, not a loosened contract, and objectui re-typing the branch
+  // cannot admit anything the server would refuse.
+  //
+  // That asymmetry is the whole argument for keeping the divergence: the spec
+  // REJECTS this payload at parse time and DESCRIBES it as legal at compile
+  // time. objectui's renderers read plain objects and never parse, so only the
+  // compile-time half is ever consulted on the client — which is precisely why
+  // adopting the spec's weaker branch type would matter.
   it('is a typing gap only — the spec`s parser still rejects a nonsense branch', () => {
     expect(() =>
       ConditionalValidationSchema.parse({

--- a/packages/types/src/app.ts
+++ b/packages/types/src/app.ts
@@ -19,11 +19,37 @@
  * configurations should use `NavigationItem` and the `navigation` / `areas` fields.
  */
 
-// The spec's own `NavigationItem` erases to `any` (its schema is declared
-// `z.ZodType<any>` to carry the recursive group variant), so objectui keeps a
-// real interface. Its per-variant types ARE properly typed, though, so the
-// fields below are derived from one of them rather than restated.
-import type { ObjectNavItem as SpecObjectNavItem } from '@objectstack/spec/ui';
+// Spec 17.0.0-rc.1 gave the spec's own `NavigationItem` a real type — it is no
+// longer the `z.ZodType<any>` erasure objectstack#4171 was filed about. That
+// removed the ORIGINAL reason this stayed a local interface, but not the
+// remaining ones (#3177 triage), and they were never caused by `any`:
+//
+//   1. Shape. The spec models navigation as a discriminated union of nine
+//      `$strict` variants with a `superRefine` exclusivity rule; this is one
+//      flat, all-optional shape. Converging is a breaking change for every
+//      consumer that reads a target field without narrowing — the verdict
+//      already recorded in `__tests__/navigation-spec-parity.test.ts`.
+//   2. Three semantics the spec has at NEITHER tier: `visible: boolean` (the
+//      spec takes only a CEL string / Expression envelope, yet
+//      `menuItemToNavigationItem` below inverts legacy `MenuItem.hidden` into
+//      a boolean), `pinned` (backs `useNavPins` + `FavoritesProvider`), and the
+//      legacy `defaultOpen` spelling. Binding deletes all three from the type
+//      while their implementations keep running.
+//   3. A separator carrying a `label`; the spec's separator branch declares none.
+//
+// So the symbol stays local and the KEYS come off the spec one by one — the
+// `badgeVariant` precedent (objectstack#4115), widened here to every key with a
+// precise spec counterpart. That is the part of the burn-down that is safe
+// today: a restated enum or payload shape can drift, and now cannot.
+// `spec-derived-unions.test.ts` pins the three blockers above, each written so
+// it fails the day the spec closes it.
+import type {
+  NavigationItem as SpecNavigationItem,
+  ObjectNavItem as SpecObjectNavItem,
+  UrlNavItem as SpecUrlNavItem,
+  ActionNavItem as SpecActionNavItem,
+  ComponentNavItem as SpecComponentNavItem,
+} from '@objectstack/spec/ui';
 import type { BaseSchema } from './base';
 
 // ============================================================================
@@ -32,17 +58,19 @@ import type { BaseSchema } from './base';
 
 /**
  * Navigation item type — determines the target and required fields.
+ *
+ * The MEMBERSHIP list is the spec's, read off the discriminant of its nav-item
+ * union rather than restated (#3177). A hand-written copy of a spec vocabulary
+ * is the objectstack#4115 failure class — `ChartType` carried 7 of 19 members,
+ * `ActionType` was missing `form` — and this one had drifted into an identical
+ * nine-member copy that nothing checked.
+ *
+ * Deriving also makes a future spec addition LOUD instead of silent: exhaustive
+ * consumers (`NAV_TYPE_META` in `plugin-designer`'s `NavigationDesigner` is a
+ * `Record< NavigationItemType, … >`) stop compiling until the new variant is
+ * handled, which is where a renderer gap belongs — not in a dead `default:`.
  */
-export type NavigationItemType =
-  | 'object'
-  | 'dashboard'
-  | 'page'
-  | 'report'
-  | 'url'
-  | 'component'
-  | 'group'
-  | 'separator'
-  | 'action';
+export type NavigationItemType = SpecNavigationItem['type'];
 
 /**
  * Unified Navigation Item
@@ -93,8 +121,11 @@ export interface NavigationItem {
   /**
    * Record opening mode when `recordId` is set. Defaults to `'view'`.
    * Use `'edit'` to land directly on the edit form (e.g. "Edit my profile").
+   *
+   * Derived from the spec's own object-nav variant (#3177) — a restated
+   * two-member enum is one spec release away from drifting.
    */
-  recordMode?: 'view' | 'edit';
+  recordMode?: NonNullable<SpecObjectNavItem['recordMode']>;
 
   /**
    * URL filter conditions (for type: 'object') — the entry targets the
@@ -109,8 +140,10 @@ export interface NavigationItem {
    * be resolved are dropped from the URL.
    *
    * Precedence within `type: 'object'`: `recordId` → `filters` → `viewName`.
+   *
+   * Shape derived from the spec's object-nav variant (#3177).
    */
-  filters?: Record<string, string>;
+  filters?: SpecObjectNavItem['filters'];
 
   /** Target dashboard name (for type: 'dashboard') */
   dashboardName?: string;
@@ -124,8 +157,16 @@ export interface NavigationItem {
   /** Target URL (for type: 'url') */
   url?: string;
 
-  /** Link target (for type: 'url') */
-  target?: '_blank' | '_self';
+  /**
+   * Link target (for type: 'url').
+   *
+   * Derived from the spec's url-nav variant (#3177). The spec declares it
+   * `.default('_self')`, so it is REQUIRED in that schema's output and optional
+   * here — objectui reads a plain object and never parses, so the default is
+   * never applied and the key is genuinely absent. `NonNullable` takes the
+   * member list without importing that requiredness.
+   */
+  target?: NonNullable<SpecUrlNavItem['target']>;
 
   /**
    * Target component reference (for type: 'component') — a colon-joined
@@ -140,8 +181,11 @@ export interface NavigationItem {
    * querystring so the same component/page can be reused across nav entries
    * with different inputs (e.g. `params: { type: 'object' }`). String values
    * support the same template variables as `recordId`.
+   *
+   * Shape derived from the spec's component-nav variant (#3177); the page
+   * variant declares the identical shape.
    */
-  params?: Record<string, unknown>;
+  params?: SpecComponentNavItem['params'];
 
   // -- Grouping --
 
@@ -150,7 +194,16 @@ export interface NavigationItem {
 
   // -- Visibility & Permissions --
 
-  /** Visibility expression — boolean or expression string e.g. "${user.role === 'admin'}" */
+  /**
+   * Visibility expression — boolean or expression string e.g. "${user.role === 'admin'}".
+   *
+   * NOT derived (#3177): the spec takes a CEL string on input and an Expression
+   * envelope `{ dialect, source }` on output — `boolean` is absent at BOTH
+   * tiers. `NavigationRenderer`'s `evalVis(item.visible)` honours the boolean,
+   * and `menuItemToNavigationItem` produces one when mapping legacy
+   * `MenuItem.hidden`. Pinned in `spec-derived-unions.test.ts`, which fails the
+   * day the spec accepts a boolean and this can come off it.
+   */
   visible?: boolean | string;
 
   /** Required permissions to see/access this item */
@@ -173,8 +226,8 @@ export interface NavigationItem {
 
   // -- UX Enhancements --
 
-  /** Badge text or count */
-  badge?: string | number;
+  /** Badge text or count — derived from the spec's nav-item base (#3177). */
+  badge?: NonNullable<SpecObjectNavItem['badge']>;
 
   /**
    * Badge visual variant — derived from the spec's own nav-item variant
@@ -201,10 +254,21 @@ export interface NavigationItem {
    * Action payload for `type: 'action'` items. Without it the item names an
    * action it cannot invoke — and before this was declared, `objectui validate`
    * silently stripped it, so a broken action item validated clean.
+   *
+   * Derived from the spec's action-nav variant (#3177). This is a structured
+   * payload rather than a scalar, so a restatement is exactly the kind that
+   * goes stale unnoticed — which is how it came to be stripped in the first
+   * place (objectstack#4115).
    */
-  actionDef?: { actionName: string; params?: Record<string, unknown> };
+  actionDef?: NonNullable<SpecActionNavItem['actionDef']>;
 
-  /** Whether this item is pinned. objectui-only; the spec has no counterpart. */
+  /**
+   * Whether this item is pinned. objectui-only; the spec has no counterpart at
+   * either tier, so NOT derived (#3177). `useNavPins` and `FavoritesProvider`
+   * are built on it. Pinned in `spec-derived-unions.test.ts`, which fails the
+   * day the spec claims the name — at which point the two meanings have to be
+   * reconciled rather than silently shadowed.
+   */
   pinned?: boolean;
 
   /** Sort order weight (lower = higher) */

--- a/packages/types/src/data-protocol.ts
+++ b/packages/types/src/data-protocol.ts
@@ -946,15 +946,32 @@ export type FormatValidation = z.input<typeof SpecFormatValidationSchema>;
 /**
  * Conditional validation — evaluate `when`, then apply `then` or `otherwise`.
  *
- * PINNED DIVERGENCE (objectstack#4171): every key comes from the spec except
- * `then` / `otherwise`, which the spec's published types erase to `unknown`
- * (its `ValidationRuleSchema` is annotated `z.ZodType<BaseValidationRuleShape>`,
- * an index-signature bag). Re-exporting that would replace a discriminated
- * union with `unknown` — a type-safety regression wearing a burn-down's
- * clothes. They are re-typed to objectui's union here, and
- * `validation-rule-spec-parity.test.ts` carries an inverted pin that fails the
- * day the spec types them properly, so this divergence cannot outlive its
- * reason.
+ * PINNED DIVERGENCE (objectstack#4171, narrowed to objectstack#4075 by #3177):
+ * every key comes from the spec except `then` / `otherwise`.
+ *
+ * Those two used to erase to `unknown`. Spec 17.0.0-rc.1 typed them — as
+ * `BaseValidationRuleShape`, which is `{ type: string; name: string; message:
+ * string; …; [key: string]: unknown }`. That is better than `unknown` and still
+ * not enough to derive from: `type` is `string` rather than a literal union, so
+ * a branch cannot narrow by discriminant, `then.condition` reads back as
+ * `unknown`, and the index signature waves through any member at all — a typo'd
+ * `type: 'formatt'` included. The spec's own comment on `ValidationRuleSchema`
+ * says as much and names the remaining work: "it is not strictness … Removing
+ * the index signature is the #4075 family of work, not this change."
+ *
+ * So the branches stay re-typed to objectui's discriminated union here. What
+ * changed in #3177 is the tripwire, not the divergence:
+ * `validation-rule-spec-parity.test.ts` used to pin "the spec still says
+ * `unknown`" — too weak a question, which fired without the burn-down having
+ * become correct. It now pins the condition that actually governs (literal
+ * discriminant / no index signature), so this divergence still cannot outlive
+ * its reason, but the reason is stated accurately.
+ *
+ * Why this side of the trade matters more than it looks: renderers read plain
+ * objects and never parse, so the spec's parse-time union — the thing that DOES
+ * reject a malformed rule — is not on the client path at all. The compile-time
+ * discriminant here is the only gate an authored (or AI-generated) rule meets
+ * before it runs.
  */
 export type ConditionalValidation = Omit<
   z.input<typeof SpecConditionalValidationSchema>,

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -191,14 +191,36 @@ const ALLOW = {
 //      annotated `z.ZodType<any>` (`FilterConditionSchema`,
 //      `NavigationItemSchema`). `any` answers every assignability question
 //      affirmatively.  Detect: `0 extends (1 & Local) ? true : false`.
-//   2. The SPEC export resolves to `any` (`NavigationItem`, `JoinNode`,
-//      `FormField`). Re-exporting these REPLACES a precise local interface with
-//      `any` — a type-safety regression wearing a burn-down's clothes. These
-//      cannot be burned down here at all; the fix belongs upstream in the spec,
-//      filed as objectstack#4171. `spec-derived-unions.test.ts` carries an
-//      inverted pin that fails the day the spec types one of them properly.
-//      Detect: the same `0 extends (1 & Spec)` probe — but see the variant
-//      below, which that probe does NOT catch.
+//   2. The SPEC export resolves to `any`. Re-exporting such a symbol REPLACES a
+//      precise local interface with `any` — a type-safety regression wearing a
+//      burn-down's clothes. Detect: the same `0 extends (1 & Spec)` probe — but
+//      see 2b and 2c, which that probe does NOT catch.
+//
+//      History worth keeping, because it is the reason this whole list exists:
+//      `NavigationItem`, `JoinNode` and `FormField` were the instances, filed
+//      upstream as objectstack#4171. All three are resolved as premises now —
+//      `JoinNode` was retired with `query.joins` (framework#4286) and the other
+//      two were typed properly in spec 17.0.0-rc.1 — and NEITHER became
+//      derivable as a result (objectui#3177). Do not read "no longer `any`" as
+//      "safe to bind"; see 2c.
+//   2c. The SPEC export is typed but NOT PRECISE, which the `any` and `unknown`
+//      probes both report as clean. Two live instances, each pinned with a probe
+//      that asks its real blocker (objectui#3177):
+//        - `ConditionalValidation.then` / `.otherwise` are
+//          `BaseValidationRuleShape` — `type: string` plus `[key: string]:
+//          unknown`, i.e. case 3 on the SPEC side. Deriving swaps a
+//          discriminated union for a bag. Blocked on objectstack#4075.
+//          Detect: `string extends Spec['type']`, and the case-3 probe.
+//        - `NavigationItem` / `FormField` are precise but describe a DIFFERENT
+//          shape (a nine-variant union vs objectui's flat one) or a different
+//          LAYER (spec `field` = an object-field reference; objectui `name` =
+//          the form data path, with disjoint required keys). Precision is not
+//          equivalence. Detect: per-key, per-tier probes — a structural
+//          `extends` permits excess properties and so cannot see a key the spec
+//          does not declare.
+//      Both sets live in `spec-derived-unions.test.ts` /
+//      `validation-rule-spec-parity.test.ts`, written to fail the day the
+//      blocker they name lifts.
 //   2b. The SPEC export resolves to `unknown` (`JoinedReportBlock`, whose
 //      `JoinedReportBlockSchema` the spec declares as `z.ZodTypeAny`). Just as
 //      empty as case 2 and just as unburnable, but the `any` probe reports


### PR DESCRIPTION
Fixes #3177

## 前提被修正了:pin 触发 ≠ burn-down 到期

spec 17.0.0-rc.1 给 `NavigationItem` / `FormField` / `ConditionalValidation.then`·`.otherwise` 都定了型,三处 `IsAny` / `IsUnknown` 反向 pin 按设计触发。按 issue 计划第 1 步逐符号 triage 之后,结论是:**触发它们的谓词问错了问题**。

`any` 从来不是这三个符号里**唯一**的阻碍,所以「不再是 any」从来就不是正确的准入条件。三个符号今天都**不该绑定**,一个都没绑。改的是探针:每条现在问那个真正说了算的条件,并且**断言当下的事实** —— 今天绿,而各自的阻碍被解除的那天就编译失败,那时才是 burn-down 真正到期。

维护者决定见 #3177 的决策评论(Q1 B+C / Q2 B / Q3 B / Q4 B)。

## 逐符号

### `NavigationItem` —— 阻碍有三个,没有一个是 `any` 造成的

spec 把导航建模成九个 `$strict` 变体的判别联合 + `superRefine` 互斥规则;objectui 是一个扁平全可选形状。除此之外,下面这些 spec 在**两个 tier 上都没有**:

| 本地语义 | 谁在用 | 实测代价 |
|---|---|---|
| `visible: boolean` | `NavigationRenderer` 的 `evalVis`;`menuItemToNavigationItem` 把 legacy `MenuItem.hidden` 取反**生产**出布尔值 | 绑到 input tier:3 个 TS2322 |
| `pinned` | `useNavPins` + `FavoritesProvider` | spec 无此键 |
| `defaultOpen` | 已发布 app metadata 的兼容承诺,`navigation-spec-parity.test.ts` 有用例 | spec 无此键 |
| separator 带 `label` | `menuItemToNavigationItem` 会发一个 | 绑定:TS2353 |

四条探针,一个阻碍一条。另有一条伞形判定 `[NavigationItem] extends [SpecNavigationItem]` 记录总体结论。

**注意不能用结构化 `extends` 当探针**:它对多余属性是放行的,所以看不见「spec 根本没声明 `pinned`」。这里用的是逐键、逐 tier 的 `KeysOfUnion` 探测。

### `FormField` —— 两个层,不是一个概念的两种方言

决定性的、机械化的形式是:**两边的必填键不相交**。objectui 必填 `name`(表单数据路径),spec 必填 `field`(对象字段引用),而且 spec **两个 tier 都没有 `name`**。同名的 `field` 一边是字符串、一边是解析后的元数据对象 —— `form.ts` 早就用 ⚠️ 标了这个双关。

仓库自己已经有判词,`select-option-spec-parity.test.ts` 开头:

> Unlike **the FormField pair — two genuinely different concepts on two layers** — a select option is ONE concept in two dialects …

而且 `index.ts` 是**单独**导出 `SpecFormField` 的,那正是 #3090 tripwire 要强制的消歧;绑定会让 `FormField === SpecFormField`,消歧一起塌掉。顺带还会把 framework#4074 的 `dependsOn` 放宽原地退回去。

### `ConditionalValidation` —— 从 `unknown` 变成了「弱一档」

分支现在是 `BaseValidationRuleShape`:

```ts
interface BaseValidationRuleShape {
  type: string; name: string; message: string; …; [key: string]: unknown;
}
```

比 `unknown` 强,但仍然不能派生:`type` 不是字面量联合,分支**无法按判别式收窄**;`then.condition` 读回来是 `unknown`;索引签名放行任何成员 —— 包括拼错的 `type: 'formatt'`。spec 自己在 `ValidationRuleSchema` 上就写了:

> it types the KNOWN keys and accepts any others … **but it is not strictness** … Removing the index signature is the #4075 family of work, not this change.

所以整体派生等于用一个带索引签名的 bag 换掉 9 成员判别联合 —— 正是当初立 pin 要防的那类倒退,只是弱了一档。探针改为钉「字面量判别式 / 无索引签名」,objectstack#4075 落地那天自动到期。

**为什么这一处的代价比看上去大**:渲染器读裸对象、**从不 parse**,所以 spec 真正拒绝畸形规则的那道 parse 期联合根本不在客户端路径上。作者端(含 AI 生成)的判别式检查是这些规则运行前唯一的关。

## 真正能派生的,已经派生了

按决策 Q1 的 C 子集,扩展现有的 `badgeVariant` 先例:

- `NavigationItemType` ← spec 导航联合的判别式。原来是手写的九成员副本,正是 objectstack#4115 那一类(`ChartType` 19 个里只有 7 个、`ActionType` 漏了 `form`)。派生还让未来 spec 新增变体在穷举消费者处**编译失败**(`plugin-designer` 的 `NAV_TYPE_META` 是 `Record< NavigationItemType, … >`),而不是掉进死的 `default:`。
- `recordMode` / `filters` / `badge` / `target` / `params` / `actionDef` ← 各自所属的 spec 分支。`actionDef` 是结构化载荷,恰恰是最容易悄悄走样的那种 —— 它当初被 `objectui validate` 整个吃掉就是这么来的。

**成员今天一个没变**,所以没有消费者受影响。

`visible` / `pinned` / `defaultOpen` 保持本地,声明处都写清了「为什么不派生」以及对应探针在哪。

## 顺带

`scripts/check-spec-symbol-derivation.mjs` 的注释还写着这三个符号「the SPEC export resolves to `any`」—— 这已经是错的(`JoinNode` 随 framework#4286 退役,另两个 rc.1 已定型)。这个 guard 自己就警告过「a wrong canonical-claim is not stale documentation — it is a planted premise for the next session」,所以一并修正,并新增 case 2c:**spec 侧已定型但不够精确**,`any` 和 `unknown` 两个探针都报干净。

## 验证

- `pnpm type-check`(全仓 turbo,即 #3181 的 typetests lane —— `packages/types/tsconfig.test.json` 由该包 `type-check` 串联):**78 successful, 78 total**
- 四个 parity/union 测试文件:**Test Files 4 passed (4) / Tests 69 passed (69)**
- `vitest run packages/types packages/layout`:26 files / 399 tests passed
- `vitest run packages/plugin-designer packages/plugin-form`:33 files / 332 tests passed
- `vitest run packages/core/src/validation`:4 files / 62 tests passed
- `pnpm --filter @object-ui/types lint`:0 errors
- `node scripts/check-spec-symbol-derivation.mjs`:✅;`node scripts/check-changeset-fixed.mjs`:✅

**Revert-proof**(改动探针的期望值必须让 typetests lane 红):

```
_specNavStillHasNoPinned false -> true
  → error TS1360: Type 'true' does not satisfy the expected type 'false'.
_specThenStillCarriesAnIndexSignature true -> false
  → error TS1360: Type 'false' does not satisfy the expected type 'true'.
NavigationItemType 退回手写联合(去掉 'action')
  → error TS1360: Type '"object" | … | "action"' does not satisfy the expected type 'NavigationItemType'.
    Type '"action"' is not assignable to type 'NavigationItemType'.
```

changeset:patch(无用户可见形状变化)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012C2cd7tL8QDoZ2QKN3djJ5)_