### PR TITLE
fix(core): 未知的 date filter 值改为跳过并警告,不再降级成永不命中的等值 (#3151)

### DIFF
--- a/.changeset/dashboard-date-filter-unknown-value.md
+++ b/.changeset/dashboard-date-filter-unknown-value.md
@@ -1,0 +1,55 @@
+---
+"@object-ui/core": minor
+---
+
+fix(dashboard): an unrecognised date filter value is skipped and named, not compared
+
+The residual the preset-name fix (objectui#3150 / objectstack#4475) left behind,
+and the more deceptive half of it: a `date`/`dateRange` filter value that is
+neither a known preset name nor a parseable date used to fall through to the
+"a bare string date means equality on that day" branch. A misspelled default —
+`defaultValue: 'last_7_dayz'` — therefore reached the widget query as
+`runtimeFilter: { created_at: 'last_7_dayz' }`, which the backend faithfully
+compiled to `WHERE created_at = $1`. `200 OK`, widget renders, count is 0 —
+indistinguishable from "this range genuinely has no data". No 4xx, no console
+warning, no UI signal. objectstack#4475 took a full RC cycle to catch for
+exactly this reason: **0 looks like a legitimate answer**.
+
+`buildFilterCondition` now holds a date value to three spellings, and only
+three:
+
+1. a known preset name → range bounds (unchanged, objectui#3150);
+2. an ISO date (`2026-01-15`, `2026-01-15T08:30:00Z`) or a date-macro token
+   (`{today}`, `{7_days_ago}`) → equality on that day (the documented
+   behaviour, unchanged);
+3. **anything else → the filter is skipped and `console.warn` names the filter,
+   the offending value, and the accepted spellings.**
+
+The `{ preset: '<unknown>' }` object form gets the same voice. It already
+dropped the filter — silently — because the preset lookup missed and no
+`from`/`to` remained; that drop is now announced. When explicit bounds ride
+along with an unknown preset the bounds are still honoured, and the warning says
+which of the two won.
+
+Rule 3 is deliberately the same strictness `buildWidgetScopedFilter` already
+applies to a *default binding on a field the object does not have* — skip and
+warn, with the same rationale spelled out there: never emit a query the backend
+can only empty-match. Field *names* had that guard; field *values* did not.
+
+The macro-token check asks `resolveDateMacros` itself whether it recognises the
+string, rather than restating its token grammar in a second place. One
+vocabulary, no dialect to drift — and a token that resolver does not know
+(`{last_7_dayz}`) is precisely the typo this guard exists to catch.
+
+Levelled `minor`, matching objectui#3150, because the emitted query shape
+changes: a dashboard carrying a misspelled date value stops sending a
+never-matching equality and instead sends no constraint for that filter (its
+numbers go from 0 to unfiltered) while the console says why. Anything asserting
+on the previously-emitted equality will see it disappear.
+
+Note the direction of the relaxation is chosen, not incidental: skipping widens
+the result set, so the number visibly changes and the warning explains it —
+whereas the old behaviour narrowed it to zero, which is the one outcome an
+author cannot tell from a correct answer. Author-time rejection (validating
+`GlobalFilterSchema.defaultValue` at publish, in `@objectstack/spec`) is the
+stricter complement and belongs on the platform side; it is filed separately.

--- a/content/docs/guide/dashboard-filters.md
+++ b/content/docs/guide/dashboard-filters.md
@@ -114,6 +114,20 @@ Add a `globalFilters` entry. Each entry renders one control in the filter bar:
 | `select` / `lookup` | dropdown | `{ field: value }` (or `$in` for arrays) |
 | `date` | preset/custom range | `{ field: { "$gte": from, "$lte": to } }` |
 
+A `date` filter's `defaultValue` is a **string**, and exactly three spellings
+are accepted:
+
+- a **preset name** from the `defaultRange` list above (`"last_7_days"`) — it
+  is lifted to that preset's range, the same as picking it in the control;
+- an **ISO date** (`"2026-01-15"`) — equality on that day;
+- a **date-macro token** (`"{today}"`, `"{7_days_ago}"`) — resolved at query
+  time like any other filter token.
+
+Anything else — a misspelled preset such as `"last_7_dayz"` — is **skipped**,
+and the runtime logs a `console.warn` naming the filter and the value. It is
+deliberately not compared as-is: `field = "last_7_dayz"` matches no row, and
+the widget would render a perfectly healthy-looking `0`.
+
 Static `options` accept the `@objectstack/spec` object form
 (`{ "value": "amer", "label": "AMER" }` — canonical, and what the spec
 validates) or a bare-string shorthand (`["EMEA", "APAC"]`); the runtime

--- a/packages/core/src/utils/__tests__/dashboard-filters.test.ts
+++ b/packages/core/src/utils/__tests__/dashboard-filters.test.ts
@@ -219,6 +219,119 @@ describe('buildFilterCondition', () => {
     expect(buildFilterCondition(dateDef, {})).toBeUndefined();
     expect(buildFilterCondition(dateDef, { preset: undefined })).toBeUndefined();
   });
+
+  // ---------------------------------------------------------------------
+  // #3151 — a date value that is neither a known preset nor an ISO date.
+  //
+  // The sister case of framework#4475, and the more deceptive direction of
+  // the same failure: a misspelled preset ('last_7_dayz') used to fall
+  // through to the "bare string means equality" branch and emit
+  //   SELECT COUNT(*) … WHERE created_at = 'last_7_dayz'
+  // — 200 OK, zero rows, no warning anywhere, indistinguishable from a range
+  // that genuinely has no data. It is now skipped and named out loud, the
+  // same strictness buildWidgetScopedFilter applies to unknown field names.
+  // ---------------------------------------------------------------------
+  describe('[#3151] unrecognised date values', () => {
+    const withWarn = (fn: (warn: ReturnType<typeof vi.spyOn>) => void) => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        fn(warn);
+      } finally {
+        warn.mockRestore();
+      }
+    };
+
+    it('skips a misspelled preset string and warns, naming the filter and the value', () => {
+      withWarn((warn) => {
+        expect(buildFilterCondition(dateDef, 'last_7_dayz')).toBeUndefined();
+        expect(warn).toHaveBeenCalledTimes(1);
+        const msg = String(warn.mock.calls[0][0]);
+        expect(msg).toContain('skipping filter "dateRange"');
+        expect(msg).toContain('last_7_dayz');
+        // The remedy travels with the rejection.
+        expect(msg).toContain('last_7_days');
+      });
+    });
+
+    it('keeps a valid ISO date string as an equality, with no warning', () => {
+      withWarn((warn) => {
+        expect(buildFilterCondition(dateDef, '2026-01-15')).toBe('2026-01-15');
+        expect(buildFilterCondition(dateDef, '2026-01-15T08:30:00Z')).toBe('2026-01-15T08:30:00Z');
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+
+    it('keeps a date-macro token as an equality, with no warning', () => {
+      // Macro tokens stay symbolic in the condition and are resolved at query
+      // time by resolveDateMacros — the same vocabulary PRESET_RANGES emits.
+      withWarn((warn) => {
+        expect(buildFilterCondition(dateDef, '{today}')).toBe('{today}');
+        expect(buildFilterCondition(dateDef, '{7_days_ago}')).toBe('{7_days_ago}');
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+
+    it('rejects a string that only looks like a date or a macro', () => {
+      withWarn((warn) => {
+        expect(buildFilterCondition(dateDef, '{last_7_dayz}')).toBeUndefined();
+        expect(buildFilterCondition(dateDef, '15/01/2026')).toBeUndefined();
+        expect(buildFilterCondition(dateDef, '2026-13-45')).toBeUndefined();
+        expect(warn).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    it('[#4475 regression] a valid preset name still becomes a RANGE, with no warning', () => {
+      withWarn((warn) => {
+        const [def] = resolveDashboardFilterDefs({
+          globalFilters: [
+            { field: 'created_at', type: 'date', defaultValue: 'last_7_days' },
+          ] as any,
+        });
+        expect(buildFilterCondition(def, def.defaultValue)).toEqual({
+          $gte: '{7_days_ago}',
+          $lte: '{today}',
+        });
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+
+    it('skips an unknown object preset and warns (was a silent drop)', () => {
+      withWarn((warn) => {
+        expect(buildFilterCondition(dateDef, { preset: 'last_7_dayz' })).toBeUndefined();
+        expect(warn).toHaveBeenCalledTimes(1);
+        const msg = String(warn.mock.calls[0][0]);
+        expect(msg).toContain('skipping filter "dateRange"');
+        expect(msg).toContain('unknown date range preset "last_7_dayz"');
+      });
+    });
+
+    it('keeps explicit bounds when an unknown preset rides along, and says so', () => {
+      withWarn((warn) => {
+        expect(
+          buildFilterCondition(dateDef, { preset: 'last_7_dayz', from: '2026-01-01' }),
+        ).toEqual({ $gte: '2026-01-01' });
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toContain('ignoring unknown date range preset');
+      });
+    });
+
+    it('drops the filter end-to-end: no runtimeFilter reaches the widget query', () => {
+      withWarn((warn) => {
+        // What the dashboard actually forwards as `runtimeFilter`. Pre-fix
+        // this was { created_at: 'last_7_dayz' } — the zero-row query.
+        const [def] = resolveDashboardFilterDefs({
+          globalFilters: [
+            { field: 'created_at', type: 'date', defaultValue: 'last_7_dayz' },
+          ] as any,
+        });
+        expect(
+          buildWidgetScopedFilter({ id: 'kpi_users' }, [def], { created_at: def.defaultValue }),
+        ).toBeUndefined();
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toContain('last_7_dayz');
+      });
+    });
+  });
 });
 
 describe('buildWidgetScopedFilter', () => {

--- a/packages/core/src/utils/dashboard-filters.ts
+++ b/packages/core/src/utils/dashboard-filters.ts
@@ -21,6 +21,7 @@
  */
 
 import type { DashboardComponentSchema, DashboardWidgetSchema, PageVariable } from '@object-ui/types';
+import { resolveDateMacros } from './date-macros.js';
 
 /** Reserved filter name for the dashboard's built-in date range. */
 export const DATE_RANGE_FILTER_NAME = 'dateRange';
@@ -89,6 +90,41 @@ const PRESET_RANGES: Record<string, { from?: string; to?: string }> = {
 export const DATE_RANGE_PRESETS = Object.keys(PRESET_RANGES);
 
 /**
+ * ISO calendar date, optionally carrying a time part — `2026-01-15`,
+ * `2026-01-15T08:30:00Z`. Deliberately narrower than `Date.parse`, which
+ * also accepts locale prose (`March 5, 2026`) and bare years (`2026`);
+ * neither is a value the backend compares a date column against usefully.
+ */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(?:[T ][\d:.]+(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/**
+ * True when a bare string value can legitimately reach a query as a date
+ * (#3151). Two spellings qualify:
+ *
+ *  - a **date-macro token** (`{today}`, `${current_month_start}`,
+ *    `{7_days_ago}`) — it stays symbolic in the generated condition and is
+ *    resolved at query time by `resolveDateMacros`, exactly like the bounds
+ *    `PRESET_RANGES` emits. The check asks that resolver itself instead of
+ *    restating its grammar here: one token vocabulary, no second dialect to
+ *    drift — and a token it does not know is precisely the typo this guard
+ *    exists to catch;
+ *  - an **ISO date**, which means equality on that day (documented behaviour).
+ */
+function isUsableDateString(value: string): boolean {
+  if (resolveDateMacros(value) !== value) return true;
+  return ISO_DATE_RE.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+/** `today, yesterday, …` — quoted in every rejection so the fix is in reach. */
+function presetList(): string {
+  return DATE_RANGE_PRESETS.join(', ');
+}
+
+function warnDateFilter(message: string): void {
+  if (typeof console !== 'undefined') console.warn(`[dashboard-filters] ${message}`);
+}
+
+/**
  * Normalize a date filter's DECLARED default into the `DateRangeValue` shape
  * every date consumer in this module reads (framework#4475).
  *
@@ -110,7 +146,9 @@ export const DATE_RANGE_PRESETS = Object.keys(PRESET_RANGES);
  *
  * Only a name this module actually knows is lifted. A genuine ISO date string
  * still means equality on that day (the documented behaviour), and a number /
- * boolean / unrecognised string is left exactly as declared.
+ * boolean / unrecognised string is left exactly as declared — an unrecognised
+ * string then never reaches a query at all: `buildFilterCondition` skips it
+ * with a warning rather than comparing a column against it (#3151).
  */
 function normalizeDateDefault(type: DashboardFilterDef['type'], defaultValue: unknown): unknown {
   if (type !== 'date' && type !== 'dateRange') return defaultValue;
@@ -227,6 +265,15 @@ function isEmptyValue(def: DashboardFilterDef, value: unknown): boolean {
  * Build the operator shape (the value side of a `FilterCondition` entry) for
  * one filter's current value. Returns `undefined` when the value imposes no
  * constraint. The caller keys the result by the bound field name.
+ *
+ * A `date`/`dateRange` value is held to three spellings (#3151): a known
+ * preset name → range bounds; a date-macro token or ISO date → equality on
+ * that day; **anything else → skipped with a console warning**, never
+ * silently downgraded to an equality nothing can match. That last branch is
+ * the same strictness `buildWidgetScopedFilter` applies to a default binding
+ * on an unknown field name, for the same reason: a query the backend answers
+ * `200 OK` with zero rows is indistinguishable from "this range has no data",
+ * so the typo has to be said out loud somewhere.
  */
 export function buildFilterCondition(
   def: DashboardFilterDef,
@@ -237,16 +284,35 @@ export function buildFilterCondition(
   if (def.type === 'dateRange' || def.type === 'date') {
     const v = value as DateRangeValue;
     if (typeof v === 'object') {
-      const range = v.preset ? PRESET_RANGES[v.preset] : undefined;
+      const preset = typeof v.preset === 'string' && v.preset ? v.preset : undefined;
+      const range = preset ? PRESET_RANGES[preset] : undefined;
       const from = range?.from ?? v.from;
       const to = range?.to ?? v.to;
+      if (preset && !range) {
+        // Was already dropped here — but silently, which reads as "no data".
+        warnDateFilter(
+          from || to
+            ? `filter "${def.name}": ignoring unknown date range preset "${preset}" — ` +
+                `using the explicit from/to bounds instead; known presets: ${presetList()}`
+            : `skipping filter "${def.name}": unknown date range preset "${preset}" — ` +
+                `expected one of: ${presetList()}`,
+        );
+      }
       if (!from && !to) return undefined;
       return {
         ...(from ? { $gte: from } : {}),
         ...(to ? { $lte: to } : {}),
       };
     }
-    // A bare string date means equality on that day.
+    if (typeof v === 'string' && !isUsableDateString(v)) {
+      warnDateFilter(
+        `skipping filter "${def.name}": value "${v}" is neither a known date range preset ` +
+          `nor an ISO date — expected one of: ${presetList()}, an ISO date (YYYY-MM-DD), ` +
+          `or a date macro such as {today}`,
+      );
+      return undefined;
+    }
+    // A bare string date (or date macro) means equality on that day.
     return value;
   }
 


### PR DESCRIPTION
Fixes #3151

## 问题

`date` / `dateRange` 型 dashboard filter 拿到一个**既不是已知预设名、也不是可解析日期**的字符串时,会掉进 `buildFilterCondition` 的「裸字符串 = 当天等值」分支。于是一个拼错的默认值 `defaultValue: 'last_7_dayz'` 原样成为比较值,widget 发出 `runtimeFilter: { created_at: 'last_7_dayz' }`,后端如实编译成 `WHERE created_at = $1` —— `200 OK`、widget 正常渲染、数字是 0,和「这个区间确实没有数据」完全无法区分。这是 objectstack#4475(已由 objectui#3150 修掉预设名那一半)旁边更隐蔽的姐妹情形:**0 看起来像一个合法答案**,没有 4xx、没有警告、没有任何 UI 信号。

## 改动

`buildFilterCondition` 现在只认三种日期值写法,按分诊裁决实现期望第 3 条(**跳过 + console.warn 点名 filter 与那个值**):

1. 已知预设名 → 提升为区间(objectui#3150,不变);
2. ISO 日期(`2026-01-15`、`2026-01-15T08:30:00Z`)或日期宏 token(`{today}`、`{7_days_ago}`)→ 当天等值(现有文档化行为,不变);
3. **两者都不是 → 跳过该 filter,并 console.warn 点名 filter 名、越界的值、以及可接受的写法**。

`{ preset: 某个未知预设 }` 这种对象形式一并补上警告:它原先就会丢弃该 filter,但是**静默**丢弃;现在这次丢弃会被说出来。如果对象里同时带了显式 `from`/`to`,边界仍然生效,警告会说明是哪一边胜出。

第 3 条刻意与 `buildWidgetScopedFilter` 对**未知字段名**的默认绑定采用同一种严格度(跳过 + 警告),理由也是它自己写下的那一条:不要发一个后端只会空匹配或直接拒绝的查询。字段**名**早就有这道闸,字段**值**一直没有。

日期宏 token 的识别直接问 `resolveDateMacros` 本人(「它认不认这个字符串」),而不是在这里把 token 语法再抄一遍 —— 一套词汇表,不产生会漂移的第二种方言;而它认不出来的 token(`{last_7_dayz}`)恰好就是这道闸要抓的拼写错误。

顺带一个自洽:未知值被跳过后,`DateRangeFilter` 显示的 "All time" 与实际发出的查询终于一致(#4475 里两者是矛盾的 —— 控件说 All time,查询却发了一个永不命中的等值)。

## 测试

`packages/core/src/utils/__tests__/dashboard-filters.test.ts` 新增 `[#3151] unrecognised date values` 一组(8 例):拼错的预设字符串被跳过并警告(断言警告文本含 filter 名与该值)、合法 ISO 日期仍为等值且不警告、日期宏 token 仍为等值且不警告、只是「长得像」日期/宏的字符串(`{last_7_dayz}` / `15/01/2026` / `2026-13-45`)被拒、合法预设名仍产生区间且不警告(#3150 回归)、未知对象预设被跳过并警告、未知预设 + 显式边界时保留边界并说明,以及端到端经 `buildWidgetScopedFilter` 确认没有 `runtimeFilter` 到达 widget 查询。

```
pnpm exec vitest run packages/core packages/plugin-dashboard --maxWorkers=2
 Test Files  85 passed | 1 skipped (86)
      Tests  1532 passed | 24 skipped (1556)

pnpm --filter @object-ui/core type-check
 (tsc --noEmit,无输出)

pnpm --filter @object-ui/core exec eslint dashboard-filters.ts dashboard-filters.test.ts
 12 problems (0 errors, 12 warnings)   # 全部是仓库既有的 no-explicit-any warning
```

## 范围

- changeset:`.changeset/dashboard-date-filter-unknown-value.md`(`@object-ui/core: minor`,与 #3150 同级 —— 发出的查询形状变了)。
- 文档(Commandment #2):`content/docs/guide/dashboard-filters.md` 补上 `date` filter 的 `defaultValue` 到底能写什么 —— 三种拼法 + 其余一律跳过并警告。此前这份指南根本没写过 `defaultValue`,拼错的预设能一路走到查询,也有这一半原因。
- **未动 objectstack/spec**:issue 里「校验能不能上移到 spec/lint 层(`GlobalFilterSchema.defaultValue`)」属于 objectstack 侧的作者时收紧,按分诊裁决另行立项,不在本 PR 扩大范围。本次实现确认它确有价值(运行时跳过 + 警告是**放宽**方向,只有作者时拒绝才能在发布前挡住),已按越界发现另立 unassigned issue:objectstack-ai/objectstack#4614(A/B/C 三个选项 + 倾向 A,交维护者定夺)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA