### PR TITLE
fix(ci): never render a budget FAIL for a run that measured nothing

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -56,6 +56,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build packages
+        id: build_packages
         run: pnpm turbo run build --filter='./packages/*'
 
       - name: Build Console
@@ -72,6 +73,12 @@ jobs:
           DIST_DIR="apps/console/dist/assets"
           if [ ! -d "$DIST_DIR" ]; then
             echo "❌ Build output not found at $DIST_DIR"
+            # Declare the outcome instead of leaving every output empty. An
+            # empty `budget_status` used to render as a ❌ FAIL verdict
+            # downstream (objectui#3152); the comment renderer now needs each
+            # path to say what happened rather than infer it from silence.
+            echo "budget_status=error" >> "$GITHUB_OUTPUT"
+            echo "budget_message=Build output not found at $DIST_DIR" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -84,6 +91,8 @@ jobs:
 
           if [ -z "$ENTRY_FILE" ]; then
             echo "❌ No JS files found in $DIST_DIR"
+            echo "budget_status=error" >> "$GITHUB_OUTPUT"
+            echo "budget_message=No JS files found in $DIST_DIR" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -116,7 +125,12 @@ jobs:
 
       - name: Generate package size report
         id: size-report
-        if: always()
+        # NOT `always()`. `always()` also fires on a cancelled run, where
+        # `packages/*/dist` is only partly populated — the report was then
+        # emitted from that partial tree and looked complete while silently
+        # missing 7 packages (objectui#3152). The report is only meaningful
+        # once every package has finished building, so gate it on that.
+        if: ${{ !cancelled() && steps.build_packages.outcome == 'success' }}
         run: |
           echo "## 📦 Bundle Size Report" > size-report.md
           echo "" >> size-report.md
@@ -150,8 +164,31 @@ jobs:
           echo "- ✅ Component packages should be < 100KB gzipped" >> size-report.md
           echo "- ⚠️ Plugin packages should be < 150KB gzipped" >> size-report.md
 
+      # Rendering lives in `scripts/render-budget-comment.mjs` so it can be unit
+      # tested (`scripts/__tests__/render-budget-comment.test.ts`) — the bug this
+      # replaces was purely a rendering bug, and logic inlined in YAML is
+      # untestable. Step outputs are passed through `env` rather than
+      # interpolated into a JS string literal, so an absent output stays an
+      # empty *variable* instead of vanishing into source text.
+      - name: Render performance budget comment
+        id: render_comment
+        # `!cancelled()`, NOT `always()`: a cancelled run measured nothing, and
+        # the superseding run posts the real verdict moments later. Commenting
+        # on cancellation is what produced a ❌ FAIL on every PR that got a
+        # second push (objectui#3152).
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
+        env:
+          BUDGET_STATUS: ${{ steps.budget.outputs.budget_status }}
+          BUDGET_MESSAGE: ${{ steps.budget.outputs.budget_message }}
+          BUDGET_GZIP_KB: ${{ steps.budget.outputs.gzip_kb }}
+          BUDGET_LIMIT_KB: ${{ steps.budget.outputs.budget_kb }}
+          BUDGET_ENTRY_FILE: ${{ steps.budget.outputs.entry_file }}
+          BUDGET_STEP_OUTCOME: ${{ steps.budget.outcome }}
+          BUILD_PACKAGES_OUTCOME: ${{ steps.build_packages.outcome }}
+        run: node scripts/render-budget-comment.mjs > budget-comment.md
+
       - name: Comment PR with results
-        if: github.event_name == 'pull_request' && always()
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         continue-on-error: true
         uses: actions/github-script@v9
         with:
@@ -161,29 +198,12 @@ jobs:
           retry-exempt-status-codes: 400,404,422
           script: |
             const fs = require('fs');
-            const status = '${{ steps.budget.outputs.budget_status }}';
-            const gzipKb = '${{ steps.budget.outputs.gzip_kb }}';
-            const budgetKb = '${{ steps.budget.outputs.budget_kb }}';
-            const entryFile = '${{ steps.budget.outputs.entry_file }}';
-            const icon = status === 'pass' ? '✅' : '❌';
 
-            let body = `## ${icon} Console Performance Budget
-
-            | Metric | Value | Budget |
-            |--------|-------|--------|
-            | Main entry (gzip) | **${gzipKb} KB** | ${budgetKb} KB |
-            | Entry file | \`${entryFile}\` | — |
-            | Status | **${status === 'pass' ? 'PASS' : 'FAIL'}** | — |
-
-            `;
-
-            // Append package size report if available
-            try {
-              const sizeReport = fs.readFileSync('size-report.md', 'utf8');
-              body += '\n---\n\n' + sizeReport;
-            } catch (e) {
-              // Size report not generated
+            if (!fs.existsSync('budget-comment.md')) {
+              core.warning('budget-comment.md was not rendered; skipping PR comment.');
+              return;
             }
+            const body = fs.readFileSync('budget-comment.md', 'utf8');
 
             try {
               await github.rest.issues.createComment({

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -83,7 +83,8 @@ Uses: Node 22, pnpm (via `corepack`), Turbo remote caching.
 | Console main entry | 60 KB |
 
 - Builds the console app and measures bundle sizes.
-- Posts a PR comment with the budget report and pass/fail status.
+- Posts a PR comment with the budget report and pass/fail status — but **only when the bundle was actually measured**. A run that was cancelled (a second push supersedes the first via `cancel-in-progress`) posts nothing, and a run whose build never produced a bundle posts a neutral "not measured" note instead of a verdict. A `FAIL` verdict therefore always carries the measured size that exceeded the budget.
+- The package size report is generated only from a complete package build, so it is never truncated into a report that looks complete.
 
 ## Size Check (`size-check.yml`)
 

--- a/scripts/__tests__/render-budget-comment.test.ts
+++ b/scripts/__tests__/render-budget-comment.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// @ts-expect-error — plain-JS CI helper, intentionally untyped
+import { renderBudgetComment, renderFromEnv } from '../render-budget-comment.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowPath = path.join(repoRoot, '.github/workflows/performance-budget.yml');
+const rendererPath = path.join(repoRoot, 'scripts/render-budget-comment.mjs');
+const NO_SUCH_REPORT = path.join(repoRoot, 'scripts/__tests__/__no-size-report__.md');
+
+/**
+ * objectui#3152: a cancelled Bundle Analysis run posted
+ * "❌ Console Performance Budget / Status: FAIL" with all three metrics empty.
+ * The measurement had never happened — `cancel-in-progress` had killed the run
+ * — but the renderer treated "not `pass`" as "FAIL". Every PR that got a second
+ * push within one build therefore received a fake budget alarm.
+ *
+ * The invariant these tests pin: FAIL is rendered only when the bundle was
+ * measured AND found over budget. Everything else renders as "not measured",
+ * never as a verdict.
+ */
+describe('renderBudgetComment', () => {
+  const measured = {
+    gzipKb: '28.1',
+    budgetKb: '350',
+    entryFile: 'index-BRKCVm_4.js',
+  };
+
+  it('renders PASS with the measurement when the bundle is within budget', () => {
+    const { kind, body } = renderBudgetComment({ status: 'pass', ...measured });
+
+    expect(kind).toBe('pass');
+    expect(body).toContain('## ✅ Console Performance Budget');
+    expect(body).toContain('| Main entry (gzip) | **28.1 KB** | 350 KB |');
+    expect(body).toContain('| Entry file | `index-BRKCVm_4.js` | — |');
+    expect(body).toContain('| Status | **PASS** | — |');
+    expect(body).not.toContain('FAIL');
+  });
+
+  it('still renders a full FAIL verdict when the bundle IS over budget', () => {
+    const { kind, body } = renderBudgetComment({
+      status: 'fail',
+      gzipKb: '412.7',
+      budgetKb: '350',
+      entryFile: 'index-BRKCVm_4.js',
+    });
+
+    expect(kind).toBe('fail');
+    expect(body).toContain('## ❌ Console Performance Budget');
+    expect(body).toContain('| Main entry (gzip) | **412.7 KB** | 350 KB |');
+    expect(body).toContain('| Status | **FAIL** | — |');
+    // The real signal must stay unambiguous — no hedging language on a
+    // genuine violation.
+    expect(body).not.toContain('not measured');
+  });
+
+  // The regression itself: run 30699128418 (`cancelled`) vs 30699202638
+  // (`success`) on the same commit gave FAIL and PASS respectively.
+  it('does NOT render FAIL when the budget step never ran (cancelled run)', () => {
+    const { kind, body } = renderBudgetComment({
+      status: '',
+      gzipKb: '',
+      budgetKb: '',
+      entryFile: '',
+      budgetOutcome: 'skipped',
+      buildOutcome: 'cancelled',
+    });
+
+    expect(kind).toBe('not-measured');
+    expect(body).not.toContain('FAIL');
+    expect(body).not.toContain('❌');
+    expect(body).toContain('## ℹ️ Console Performance Budget — not measured');
+    expect(body).toContain('**This is not a budget violation.**');
+    // The empty-metric table that made the fake alarm look like a report.
+    expect(body).not.toContain('| Main entry (gzip) | ** KB** |');
+  });
+
+  it.each([
+    ['dist directory missing', 'Build output not found at apps/console/dist/assets'],
+    ['no JS files in dist', 'No JS files found in apps/console/dist/assets'],
+  ])('reports "not measured" with the reason when the budget step errors (%s)', (_label, message) => {
+    const { kind, body } = renderBudgetComment({
+      status: 'error',
+      message,
+      budgetOutcome: 'failure',
+      buildOutcome: 'success',
+    });
+
+    expect(kind).toBe('not-measured');
+    expect(body).not.toContain('FAIL');
+    expect(body).toContain(`Reason: ${message}`);
+    expect(body).toContain('| Check console performance budget | `failure` |');
+    expect(body).toContain('| Build packages | `success` |');
+  });
+
+  it('treats a status without its measurement as not measured, never as FAIL', () => {
+    // Defensive: if the producer ever writes `budget_status` without the
+    // numbers, the consumer must not manufacture a verdict out of it.
+    for (const partial of [
+      { status: 'fail', gzipKb: '', budgetKb: '350', entryFile: 'index.js' },
+      { status: 'fail', gzipKb: '412.7', budgetKb: '', entryFile: 'index.js' },
+      { status: 'pass', gzipKb: '28.1', budgetKb: '350', entryFile: '' },
+    ]) {
+      const { kind, body } = renderBudgetComment(partial);
+      expect(kind).toBe('not-measured');
+      expect(body).not.toContain('| Status | **FAIL** | — |');
+    }
+  });
+
+  it('appends the package size report when one was generated', () => {
+    const sizeReport = '## 📦 Bundle Size Report\n\n| Package | Size | Gzipped |';
+    const { body } = renderBudgetComment({ status: 'pass', ...measured, sizeReport });
+
+    expect(body).toContain('---\n\n## 📦 Bundle Size Report');
+    expect(body).not.toContain('No package size report');
+  });
+
+  it('says the size report is missing rather than silently omitting it', () => {
+    // A partial report reads exactly like a complete one — the cancelled run in
+    // objectui#3152 shipped a report that was silently missing 7 packages.
+    const { body } = renderBudgetComment({ status: 'pass', ...measured, sizeReport: '' });
+
+    expect(body).toContain('No package size report');
+    expect(body).toContain('only generated from a complete package build');
+  });
+});
+
+describe('renderFromEnv', () => {
+  it('reads the exact env names the workflow sets', () => {
+    const { kind, body } = renderFromEnv(
+      {
+        BUDGET_STATUS: 'pass',
+        BUDGET_GZIP_KB: '28.1',
+        BUDGET_LIMIT_KB: '350',
+        BUDGET_ENTRY_FILE: 'index-BRKCVm_4.js',
+        BUDGET_STEP_OUTCOME: 'success',
+        BUILD_PACKAGES_OUTCOME: 'success',
+        GITHUB_SERVER_URL: 'https://github.com',
+        GITHUB_REPOSITORY: 'objectstack-ai/objectui',
+        GITHUB_RUN_ID: '30699202638',
+      },
+      NO_SUCH_REPORT,
+    );
+
+    expect(kind).toBe('pass');
+    expect(body).toContain('| Main entry (gzip) | **28.1 KB** | 350 KB |');
+  });
+
+  it('links the run so a "not measured" note can be checked against the log', () => {
+    const { body } = renderFromEnv(
+      {
+        BUDGET_STATUS: '',
+        BUILD_PACKAGES_OUTCOME: 'failure',
+        BUDGET_STEP_OUTCOME: 'skipped',
+        GITHUB_SERVER_URL: 'https://github.com',
+        GITHUB_REPOSITORY: 'objectstack-ai/objectui',
+        GITHUB_RUN_ID: '30699128418',
+      },
+      NO_SUCH_REPORT,
+    );
+
+    expect(body).toContain(
+      'https://github.com/objectstack-ai/objectui/actions/runs/30699128418',
+    );
+  });
+
+  it('renders without crashing on a completely empty environment', () => {
+    const { kind, body } = renderFromEnv({}, NO_SUCH_REPORT);
+    expect(kind).toBe('not-measured');
+    expect(body).toContain('| Build packages | `unknown` |');
+  });
+});
+
+/**
+ * The renderer can only be correct if the workflow keeps feeding it. These pin
+ * the two workflow-level halves of the fix, which no unit test can exercise:
+ * the step conditions, and the env contract between the two files.
+ */
+describe('performance-budget.yml contract', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+  const renderer = fs.readFileSync(rendererPath, 'utf8');
+  // Only the step conditions — prose in `#` comments discusses `always()` and
+  // must not be mistaken for a use of it.
+  const conditions = [...workflow.matchAll(/^\s*if:\s*(.+)$/gm)].map((m) => m[1]);
+
+  it('never gates a step on always() — it fires on cancelled runs, which measure nothing', () => {
+    expect(conditions.filter((c) => c.includes('always()'))).toEqual([]);
+  });
+
+  it('gates the size report, the renderer and the comment on !cancelled()', () => {
+    expect(conditions.filter((c) => c.includes('!cancelled()'))).toHaveLength(3);
+  });
+
+  it('generates the size report only from a complete package build', () => {
+    expect(workflow).toContain(
+      "if: ${{ !cancelled() && steps.build_packages.outcome == 'success' }}",
+    );
+    expect(workflow).toContain('id: build_packages');
+  });
+
+  it('never interpolates a step output into the comment JS source', () => {
+    // `const status = '${{ steps.budget.outputs.budget_status }}'` is how an
+    // absent output became the empty string that rendered as FAIL.
+    expect(workflow).not.toMatch(/=\s*'\$\{\{\s*steps\.budget\.outputs/);
+  });
+
+  it('passes every env var the renderer reads, and reads every one it passes', () => {
+    const declared = [...workflow.matchAll(/^\s{10}([A-Z_]+): \$\{\{ steps\./gm)].map((m) => m[1]);
+
+    expect(declared.length).toBeGreaterThan(0);
+    for (const name of declared) {
+      expect(renderer, `renderer must read env.${name}`).toContain(`env.${name}`);
+    }
+  });
+
+  it('writes budget_status on every path the budget step can exit through', () => {
+    // pass, fail, and the two "nothing to measure" errors.
+    const statuses = [...workflow.matchAll(/budget_status=(\w+)/g)].map((m) => m[1]);
+    expect(new Set(statuses)).toEqual(new Set(['pass', 'fail', 'error']));
+  });
+});

--- a/scripts/render-budget-comment.mjs
+++ b/scripts/render-budget-comment.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Renders the "Console Performance Budget" PR comment body for
+ * `.github/workflows/performance-budget.yml`.
+ *
+ * Why this is a file and not an inline `script:` block: the bug it fixes
+ * (objectui#3152) *was* the rendering logic — an ABSENT measurement was
+ * rendered as a `❌ ... Status: FAIL` verdict, so every PR that got a second
+ * push (cancelling the first run via `cancel-in-progress`) received a comment
+ * asserting a budget failure whose own body showed three empty metrics.
+ * Logic embedded in YAML cannot be tested; this file is covered by
+ * `scripts/__tests__/render-budget-comment.test.ts`.
+ *
+ * The contract with the workflow is one output — `budget_status`:
+ *
+ *   `pass`  the console bundle was measured and is within budget
+ *   `fail`  the console bundle was measured and is OVER budget
+ *   `error` the budget step ran but the build produced nothing measurable
+ *           (no `dist` directory, or no JS in it)
+ *   absent  the budget step never ran at all — an earlier step failed, or the
+ *           run was cancelled
+ *
+ * Only `pass` and `fail` are verdicts. `error` and absent mean "not measured",
+ * and "not measured" must never render as FAIL: a comment that claims a size
+ * regression while showing no size teaches readers to ignore this gate, which
+ * would take the real over-budget FAIL down with it.
+ */
+
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * The only two statuses that carry a measurement. Kept as an explicit
+ * allow-list rather than `status !== 'pass' ? fail : pass` — that inversion is
+ * exactly how "no data" became "FAIL".
+ */
+const MEASURED_STATUSES = new Set(['pass', 'fail']);
+
+const text = (value) => (typeof value === 'string' ? value.trim() : '');
+
+/**
+ * @param {object} input
+ * @param {string} [input.status]        `budget_status` output of the budget step
+ * @param {string} [input.gzipKb]        measured gzip size of the main entry, in KB
+ * @param {string} [input.budgetKb]      the budget the measurement was compared against
+ * @param {string} [input.entryFile]     basename of the measured entry chunk
+ * @param {string} [input.message]       human-readable reason when `status` is `error`
+ * @param {string} [input.budgetOutcome] `steps.budget.outcome`
+ * @param {string} [input.buildOutcome]  `steps.build_packages.outcome`
+ * @param {string} [input.sizeReport]    contents of `size-report.md`, empty when not generated
+ * @param {string} [input.runUrl]        link to the workflow run
+ * @returns {{ kind: 'pass' | 'fail' | 'not-measured', body: string }}
+ */
+export function renderBudgetComment(input = {}) {
+  const status = text(input.status);
+  const gzipKb = text(input.gzipKb);
+  const budgetKb = text(input.budgetKb);
+  const entryFile = text(input.entryFile);
+  const sizeReport = text(input.sizeReport);
+
+  // A verdict needs an affirmative status AND the numbers that status was
+  // derived from. A real over-budget failure always arrives with a
+  // measurement; "every metric empty" is the discriminator for "never ran".
+  const measured =
+    MEASURED_STATUSES.has(status) && gzipKb !== '' && budgetKb !== '' && entryFile !== '';
+
+  const body = measured
+    ? verdictBody({ status, gzipKb, budgetKb, entryFile, sizeReport })
+    : notMeasuredBody({
+        message: text(input.message),
+        budgetOutcome: text(input.budgetOutcome),
+        buildOutcome: text(input.buildOutcome),
+        sizeReport,
+        runUrl: text(input.runUrl),
+      });
+
+  return { kind: measured ? status : 'not-measured', body };
+}
+
+function verdictBody({ status, gzipKb, budgetKb, entryFile, sizeReport }) {
+  const pass = status === 'pass';
+  const lines = [
+    `## ${pass ? '✅' : '❌'} Console Performance Budget`,
+    '',
+    '| Metric | Value | Budget |',
+    '|--------|-------|--------|',
+    `| Main entry (gzip) | **${gzipKb} KB** | ${budgetKb} KB |`,
+    `| Entry file | \`${entryFile}\` | — |`,
+    `| Status | **${pass ? 'PASS' : 'FAIL'}** | — |`,
+    '',
+  ];
+  return withSizeReport(lines.join('\n'), sizeReport);
+}
+
+function notMeasuredBody({ message, budgetOutcome, buildOutcome, sizeReport, runUrl }) {
+  const lines = [
+    '## ℹ️ Console Performance Budget — not measured',
+    '',
+    'This run did not produce a console bundle to measure, so there is **no pass/fail verdict** for the performance budget.',
+    '',
+    '**This is not a budget violation.** Nothing was measured — the numbers a real violation would carry are simply absent.',
+    '',
+    '| Step | Outcome |',
+    '|------|---------|',
+    `| Build packages | \`${outcome(buildOutcome)}\` |`,
+    `| Check console performance budget | \`${outcome(budgetOutcome)}\` |`,
+    '',
+  ];
+
+  if (message) {
+    lines.push(`Reason: ${message}`, '');
+  }
+  if (runUrl) {
+    lines.push(`See the [workflow run](${runUrl}) for details.`, '');
+  }
+
+  return withSizeReport(lines.join('\n'), sizeReport);
+}
+
+const outcome = (value) => value || 'unknown';
+
+/**
+ * `size-report.md` is only generated when every package finished building, so
+ * an absent report is expected on an incomplete run — and is called out rather
+ * than silently omitted, because a truncated report reads exactly like a
+ * complete one (objectui#3152: 7 packages missing, no indication of it).
+ */
+function withSizeReport(body, sizeReport) {
+  if (sizeReport) {
+    return `${body}\n---\n\n${sizeReport}\n`;
+  }
+  return `${body}\n_No package size report: it is only generated from a complete package build, so a partial one is never shown._\n`;
+}
+
+/** Reads `size-report.md` if the report step produced one. */
+function readSizeReport(path = 'size-report.md') {
+  try {
+    return fs.readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+export function renderFromEnv(env = process.env, sizeReportPath = 'size-report.md') {
+  const serverUrl = env.GITHUB_SERVER_URL;
+  const repository = env.GITHUB_REPOSITORY;
+  const runId = env.GITHUB_RUN_ID;
+  return renderBudgetComment({
+    status: env.BUDGET_STATUS,
+    message: env.BUDGET_MESSAGE,
+    gzipKb: env.BUDGET_GZIP_KB,
+    budgetKb: env.BUDGET_LIMIT_KB,
+    entryFile: env.BUDGET_ENTRY_FILE,
+    budgetOutcome: env.BUDGET_STEP_OUTCOME,
+    buildOutcome: env.BUILD_PACKAGES_OUTCOME,
+    sizeReport: readSizeReport(sizeReportPath),
+    runUrl: serverUrl && repository && runId ? `${serverUrl}/${repository}/actions/runs/${runId}` : '',
+  });
+}
+
+// CLI: write the comment body to stdout for the workflow to capture.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { kind, body } = renderFromEnv();
+  process.stderr.write(`Rendered performance budget comment (kind: ${kind})\n`);
+  process.stdout.write(body);
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -144,7 +144,15 @@ export default defineConfig({
           // `eslint-rules/**` holds the local ESLint plugin's RuleTester specs.
           // They were previously matched by no project glob, so the ratchet
           // rules shipped with tests that never ran (objectui#2879).
-          include: ['packages/**/*.test.ts', 'examples/**/*.test.ts', 'eslint-rules/**/*.test.js'],
+          // `scripts/**` covers the repo-level CI helpers with no package of
+          // their own (e.g. the PR-comment renderer behind
+          // `.github/workflows/performance-budget.yml`).
+          include: [
+            'packages/**/*.test.ts',
+            'examples/**/*.test.ts',
+            'eslint-rules/**/*.test.js',
+            'scripts/**/*.test.ts',
+          ],
           exclude: [...sharedExclude, ...domTsTests],
         },
       },


### PR DESCRIPTION
Fixes #3152

## 问题

`.github/workflows/performance-budget.yml` 在运行被**取消**时仍会发一条 ❌ FAIL 评论,而预算从未被测量过。工作流设了 `concurrency: cancel-in-progress: true`,这意味着**每个连推两次提交的 PR** 都会收到这条假警报。

同一份代码上的对照:运行 `30699128418`(`cancelled`)判 FAIL 且三项指标全空;运行 `30699202638`(`success`)判 PASS,实测 28.1 KB / 350 KB —— 只用掉预算的 8%。

两处机制:

1. 发评论的步骤条件是 `if: ... && always()`。`always()` 在运行被取消时**照样触发**;而渲染逻辑把「非 pass」等同于 FAIL(`status === 'pass' ? '✅' : '❌'`),于是「没测到」被渲染成了「测到了且超标」。
2. `Generate package size report` 同样是 `if: always()`,取消时它对着只构建了一部分的 `packages/*/dist` 跑完并输出 —— 报告少了 7 个包(app-shell、plugin-calendar、plugin-designer、plugin-gantt、plugin-kanban、plugin-report、plugin-view)却看不出缺失,让那条假 FAIL 更像一份可信的完整报告。

## 改动

**门禁语义:FAIL 必须带着数字。**

- 评论步骤改用 `!cancelled()` 而不是 `always()`。被取消的运行不再发任何评论 —— 取代它的那次运行几十秒后就会给出真实结论。
- 只有「测量到了**且**超标」才渲染 FAIL:渲染器要求 `budget_status` 是 `pass`/`fail`,**并且** gzip 大小、预算、入口文件名三项都在。真实超标必然带着这三个数字,这正是 issue 里点出的可判别信号。
- 「没测到」改发一条中性说明,正文明确写 **This is not a budget violation**,并列出 Build packages / Budget check 两步的 outcome 与失败原因。

**让生产者声明结果,而不是让消费者从「空」去猜。**

- `budget` 步骤原本有两条退出路径(dist 目录不存在、找不到 JS 文件)什么 output 都不写。现在它们显式写 `budget_status=error` 和一条 `budget_message`。消费者读到的是一个**声明过的结果**,而不是靠空字符串反推。同理,渲染器用的是显式白名单 `MEASURED_STATUSES`,而不是 `status !== 'pass'` 那个取反 —— 正是那个取反把「没有数据」变成了「FAIL」。

**半截报告。**

- `Generate package size report` 改成 `if: !cancelled() && steps.build_packages.outcome == 'success'`,只在包全部构建完成后才生成。生成不出来时评论里会写明「没有体积报告」,而不是静默省略 —— 因为一份被截断的报告读起来和完整的一模一样。

**渲染逻辑搬出 YAML。**

- 新增 `scripts/render-budget-comment.mjs`,评论步骤改为 `node scripts/render-budget-comment.mjs > budget-comment.md`,step outputs 经 `env:` 传入而不是插值进 JS 字符串字面量。这个 bug **本身就是**一个渲染 bug,而内联在 `script:` 块里的逻辑没有任何测试能覆盖它。现在它由 `scripts/__tests__/render-budget-comment.test.ts` 覆盖(17 个用例),其中 6 个是钉住工作流本身的 pin test(禁止 `always()`、`!cancelled()` 的三处、报告的构建门、env 契约、`budget_status` 的三种取值)。

## 每条退出路径的预期行为

| 场景 | Build packages | budget_status | 体积报告 | PR 评论 |
|---|---|---|---|---|
| 运行被取消(连推两次) | 部分完成 | 缺失(步骤没跑) | 跳过 | **不发评论** |
| 包构建失败 | failure | 缺失(步骤 skipped) | 跳过 | ℹ️ not measured |
| console 构建失败 | success | 缺失(步骤 skipped) | 生成 | ℹ️ not measured + 完整报告 |
| dist 目录不存在 | success | `error` | 生成 | ℹ️ not measured + 原因 |
| dist 里没有 JS | success | `error` | 生成 | ℹ️ not measured + 原因 |
| 未超预算 | success | `pass` | 生成 | ✅ PASS + 实测数字 |
| **超预算** | success | `fail` | 生成 | ❌ **FAIL + 实测数字**(行为不变) |

## 验证

**1. YAML 可解析,步骤条件符合预期**

```
YAML PARSE: OK, steps = 12
- Build packages [id=build_packages]
- Check console performance budget [id=budget]
- Generate package size report [id=size-report]  if: ${{ !cancelled() && steps.build_packages.outcome == 'success' }}
- Render performance budget comment [id=render_comment]  if: ${{ github.event_name == 'pull_request' && !cancelled() }}
- Comment PR with results  if: ${{ github.event_name == 'pull_request' && !cancelled() }}
```

**2. 把 `budget` 步骤的 shell **原样**从 YAML 里抽出来执行,逐条验证 output**

```
== PATH A: dist 目录不存在 ==        exit=1   budget_status=error
                                             budget_message=Build output not found at apps/console/dist/assets
== PATH B: dist 存在但没有 JS ==      exit=1   budget_status=error
                                             budget_message=No JS files found in apps/console/dist/assets
== PATH C: 未超预算 ==                exit=0   gzip_kb=40.1 budget_kb=350
                                             entry_file=index-abc123.js  budget_status=pass
== PATH D: 超预算 ==                  exit=1   gzip_kb=701.8 budget_kb=350
                                             entry_file=index-over.js    budget_status=fail
```

**3. 把 PATH D 的 output 原样喂给渲染器(端到端):真实超标信号完全保留**

```
## ❌ Console Performance Budget

| Metric | Value | Budget |
|--------|-------|--------|
| Main entry (gzip) | **701.8 KB** | 350 KB |
| Entry file | `index-over.js` | — |
| Status | **FAIL** | — |
```

**4. 取消 / 未测量路径:不再有 ❌,也不再有 FAIL**

```
## ℹ️ Console Performance Budget — not measured

This run did not produce a console bundle to measure, so there is no pass/fail verdict.

**This is not a budget violation.** Nothing was measured — the numbers a real violation would carry are simply absent.

| Step | Outcome |
|------|---------|
| Build packages | `failure` |
| Check console performance budget | `skipped` |
```

**5. 测试与静态检查**

```
$ pnpm exec vitest run --project unit scripts/__tests__/render-budget-comment.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ pnpm exec vitest run --project unit          # 确认 vitest.config.mts 的 include 改动没有影响其它文件
 Test Files  332 passed (332)
      Tests  4657 passed | 1 skipped (4658)

$ pnpm exec tsc --noEmit --ignoreConfig --strict ... scripts/__tests__/render-budget-comment.test.ts
 (无输出,0 错误)

$ pnpm exec eslint scripts/render-budget-comment.mjs scripts/__tests__/render-budget-comment.test.ts
 ESLINT_EXIT=0

$ node scripts/check-changeset-fixed.mjs
 ✅  All workspace packages are in the changeset fixed group.
```

注:本 PR 只改动 `.github/**`、`scripts/**`、`vitest.config.mts` 和 docs,不匹配 `performance-budget.yml` 自己的 paths 过滤器(`packages/**`、`apps/console/**`、`pnpm-lock.yaml`),所以这个工作流**不会在本 PR 上运行**。这也正是为什么渲染逻辑被搬进了可单测的文件,而不是留在 YAML 里靠 CI 碰运气。

## 关于 changeset

按 AGENTS.md §9「纯 bug 修复不需要 changeset」,且本次改动不触及任何已发布包的源码(只有 CI 工作流、仓库级 CI 脚本、vitest 配置和文档),没有版本需要 bump。仓库里唯一的 changeset 门禁 `scripts/check-changeset-fixed.mjs` 校验的是 fixed group 成员资格,不要求每个 PR 都带 changeset,已通过。

## 顺带发现(未在本 PR 修)

- #3197:`content/docs/guide/ci-cd-pipeline.md` 把 console 主入口预算写成 60 KB(实际 350 KB),记录了一个已不存在的 `size-check.yml`,并把三档「建议值」标成了 Enforced limits。按 Prime Directive #10 单独立 issue,未夹带进本 PR。本 PR 只改了同一节里描述 PR 评论行为的那条 bullet —— 那正是本次改掉的行为。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA)_