### PR TITLE
fix(types,app-shell)!: `reference` 是 action param 唯一可作者化的 picker 目标 (#3174)

### DIFF
--- a/.changeset/action-param-reference-is-the-authorable-spelling.md
+++ b/.changeset/action-param-reference-is-the-authorable-spelling.md
@@ -1,0 +1,55 @@
+---
+"@object-ui/types": minor
+"@object-ui/app-shell": minor
+---
+
+`reference` is the one authorable action-param picker target (objectui#3174).
+
+**Breaking for authoring**: `ActionParam` in `@object-ui/types` no longer
+declares the nine resolved-side picker keys — `referenceTo`, `displayField`,
+`idField`, `descriptionField`, `titleFormat`, `lookupColumns`, `lookupFilters`,
+`lookupPageSize`, `dependsOn`. FROM: `{ name: 'account_id', type: 'lookup',
+referenceTo: 'account' }` type-checked. TO: `{ name: 'account_id', type:
+'lookup', reference: 'account' }` — or make the param field-backed
+(`{ field: 'account_id' }`) and it inherits the whole picker group from the
+object field.
+
+The two halves of one contract disagreed about a spelling, and the type was the
+half that was wrong. `resolveActionParams()` reads the spec's `reference` for an
+inline `lookup`/`master_detail` target and nothing else; it EMITS
+`ActionParamDef.referenceTo`, the resolved spelling. The public authoring type
+declared the resolved spelling "for parity with the resolved shape", so an
+author who followed it got a param whose picker target was dropped in the
+resolver and a dialog that degraded to a plain record-id text input — asking a
+human to paste a UUID. The dev warning that fired then told them to declare
+`reference`, a key the type did not have.
+
+`reference` wins because the platform had already decided: `ActionParamSchema` in
+`@objectstack/spec` is `.strict()`, lists `referenceTo` **by name** in its
+alias map, and answers it with "use `reference`". So an authored `referenceTo`
+was never storable — it was a hard parse rejection on the server while `tsc`
+waved it through. Resolving it in objectui instead would have made the renderer
+accept metadata the platform itself refuses, and such a param would work in a
+locally-authored TS action and fail at publish; removing the declaration moves
+the failure to where it can be fixed, at the authoring keystroke.
+
+- **`@object-ui/types`**: the nine keys are gone, and the rule they violated is
+  now pinned — `ActionParam` declares *exactly* the spec's authorable key set.
+  The drift guard names the single exception (`validation`, inert and rejected
+  by the same `.strict()` parse — filed as objectui#3201) so a second one cannot
+  appear without being a decision.
+- **`@object-ui/app-shell`**: `resolveActionParams()` names any resolved-only
+  key it finds on an authored param in a dev-mode warning, with the
+  prescription (`referenceTo` → "use `reference`"; the rest → "make the param
+  field-backed"). It still does **not** read them. This covers the gap `tsc`
+  cannot gate — params authored in plain JS, loaded from JSON, or synthesised
+  at runtime — so the mistake is loud where it is made rather than surfacing
+  downstream as `paramToField()`'s "no reference target" warning naming a key
+  the author never wrote.
+
+The internal pipeline keeps its two spellings on purpose (authoring `reference`
+→ `ActionParamDef.referenceTo` → the field's `reference_to`); what is pinned now
+is that the public entry and the public exit agree. The end-to-end test authors
+through the published `ActionParam` and follows one param to `reference_to` —
+every previous test authored the resolver's own local input interface, which is
+why the resolver only ever agreed with itself and the mismatch survived.

--- a/packages/app-shell/src/utils/resolveActionParams.test.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.test.ts
@@ -16,8 +16,15 @@
  * in both the raw-string and the spec-normalised `{ dialect, source }` envelope
  * forms, and across inline / field-backed / missing-field branches.
  */
-import { describe, it, expect } from 'vitest';
-import { resolveActionParams, type ResolveActionParamsContext, type RawActionParam } from './resolveActionParams';
+import { describe, it, expect, vi } from 'vitest';
+import type { ActionParam } from '@object-ui/types';
+import {
+  RESOLVED_ONLY_PARAM_KEYS,
+  resolveActionParams,
+  type ResolveActionParamsContext,
+  type RawActionParam,
+} from './resolveActionParams';
+import { paramToField } from './paramToField';
 
 const ctx = (over: Partial<ResolveActionParamsContext> = {}): ResolveActionParamsContext => ({
   objectName: 'sys_user',
@@ -191,5 +198,163 @@ describe('resolveActionParams — inline lookup reference target (#3405)', () =>
 
   it('leaves referenceTo undefined for a non-picker inline param', () => {
     expect(resolveActionParams([{ name: 'note', type: 'textarea' }], lookupCtx())[0].referenceTo).toBeUndefined();
+  });
+});
+
+/**
+ * objectui#3174 — the gate the previous suite could not be.
+ *
+ * Every test above authors a `RawActionParam`, this file's own local input
+ * interface. That is exactly why the defect survived: the resolver agreed with
+ * itself, while `@object-ui/types`' public `ActionParam` — the type a host app
+ * actually writes against — declared `referenceTo` and (before objectui#3156)
+ * not `reference`. An author who followed the published type got a param whose
+ * picker target was dropped here and a dev warning downstream naming a key the
+ * type did not have.
+ *
+ * So these tests author through the PUBLIC type and follow one param all the
+ * way to the field the widgets consume: `ActionParam` → `resolveActionParams()`
+ * → `ActionParamDef` → `paramToField()` → `reference_to`. The internal pipeline
+ * keeps its two spellings (authoring `reference`, resolved `referenceTo`) — the
+ * point is not that they match, it is that the public entry and the public exit
+ * do.
+ */
+describe('resolveActionParams — authored through the public ActionParam type (objectui#3174)', () => {
+  const authoringCtx = () =>
+    ctx({
+      objectName: 'quality_dispatch',
+      objects: [
+        {
+          name: 'quality_dispatch',
+          fields: {
+            inspector: {
+              type: 'lookup',
+              label: 'Inspector',
+              reference_to: 'sys_user',
+              display_field: 'name',
+              id_field: 'id',
+            },
+          },
+        },
+      ],
+    });
+
+  /** Public authoring shape → the field object `ActionParamDialog` renders. */
+  const authorToField = (authored: ActionParam) =>
+    paramToField(resolveActionParams([authored], authoringCtx())[0]);
+
+  it('an inline `reference` reaches the picker as `reference_to`', () => {
+    const authored: ActionParam = {
+      name: 'account_id',
+      label: 'Account',
+      type: 'lookup',
+      reference: 'account',
+    };
+    expect(authorToField(authored)).toMatchObject({
+      name: 'account_id',
+      type: 'lookup',
+      reference_to: 'account',
+    });
+  });
+
+  it('a field-backed param inherits the whole picker group', () => {
+    const authored: ActionParam = { field: 'inspector' };
+    expect(authorToField(authored)).toMatchObject({
+      type: 'lookup',
+      reference_to: 'sys_user',
+      display_field: 'name',
+      id_field: 'id',
+    });
+  });
+
+  it('`master_detail` reaches the picker too — both LOOKUP_WIDGET_TYPES', () => {
+    const authored: ActionParam = { name: 'parent_id', type: 'master_detail', reference: 'account' };
+    expect(authorToField(authored)).toMatchObject({
+      type: 'master_detail',
+      reference_to: 'account',
+    });
+  });
+
+  it('never silently degrades: no dev warning on the authorable spelling', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const authored: ActionParam = { name: 'account_id', type: 'lookup', reference: 'account' };
+      authorToField(authored);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('names `referenceTo` at the resolver instead of dropping it silently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // The exact shape objectui#3174 reported. `tsc` rejects it against the
+      // public type now (pinned in @object-ui/types'
+      // `page-nav-misc-spec-parity.test.ts`); this covers the JS / JSON /
+      // synthesised paths `tsc` does not gate. It stays REFUSED, not resolved:
+      // `ActionParamSchema` is `.strict()`, so honouring it here would render a
+      // picker for metadata the server will not store.
+      const offSpec = { name: 'account_id', type: 'lookup', referenceTo: 'account' };
+      const field = authorToField(offSpec as unknown as ActionParam);
+
+      const messages = warn.mock.calls.map((c) => String(c[0]));
+      const named = messages.filter((m) => m.includes('`referenceTo`'));
+      expect(named).toHaveLength(1);
+      expect(named[0]).toContain('account_id');
+      expect(named[0]).toContain('Use `reference` instead');
+
+      // Still degrades — the metadata is genuinely unusable — but loudly, and
+      // the downstream warning now prescribes a key the author can write.
+      expect(field.reference_to).toBeUndefined();
+      expect(field.type).toBe('text');
+      expect(messages.some((m) => m.includes('degrades to a plain record-id text input'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('names every resolved-only key an author may reach for', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (const key of Object.keys(RESOLVED_ONLY_PARAM_KEYS)) {
+        warn.mockClear();
+        resolveActionParams([{ name: 'p', [key]: 'x' } as RawActionParam], authoringCtx());
+        const named = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes(`\`${key}\``));
+        expect(named, `expected a dev warning naming \`${key}\``).toHaveLength(1);
+      }
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('says nothing for a param that only uses authorable keys', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const authored: ActionParam = {
+        name: 'comment',
+        label: 'Comment',
+        type: 'textarea',
+        required: true,
+        placeholder: 'Why?',
+        helpText: 'Shown to the approver',
+        defaultFromRow: true,
+        visible: 'features.phoneNumber',
+      };
+      resolveActionParams([authored], authoringCtx());
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('the public authoring type is accepted by this resolver (type-level)', () => {
+    // The structural half of the fix: whatever `@object-ui/types` says an
+    // author may write has to be readable here. `RawActionParam` is a local
+    // restatement, and the two drifting apart is objectui#3174's mechanism —
+    // this assignment is what fails when they do.
+    const authored: ActionParam = { name: 'account_id', type: 'lookup', reference: 'account' };
+    const raw: RawActionParam = authored;
+    expect(raw.reference).toBe('account');
   });
 });

--- a/packages/app-shell/src/utils/resolveActionParams.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.ts
@@ -12,6 +12,16 @@
  * The resolver flattens each param to the runtime `ActionParamDef` shape
  * expected by `ActionParamDialog`, so the dialog itself stays agnostic to
  * field references.
+ *
+ * AUTHORING vs RESOLVED is the load-bearing distinction here, and the two
+ * vocabularies are not interchangeable (objectui#3174). What an author may
+ * write is exactly the spec's `ActionParamSchema` key set — mirrored by
+ * `@object-ui/types`' `ActionParam` and by {@link RawActionParam} below. What
+ * this function EMITS is `@object-ui/core`'s `ActionParamDef`, whose picker
+ * group (`referenceTo`, `displayField`, …) exists only after resolution.
+ * Authoring a resolved-side key is a mistake in every direction — `tsc`
+ * rejects it, the server's `.strict()` parse rejects it, and this resolver
+ * names it via {@link RESOLVED_ONLY_PARAM_KEYS} rather than reading it.
  */
 import type { ActionParamDef } from '@object-ui/core';
 
@@ -59,6 +69,68 @@ export interface RawActionParam {
    * Absent = always visible.
    */
   visible?: string | { dialect?: string; source?: string };
+}
+
+/**
+ * Keys of the RESOLVED `ActionParamDef` that are not authorable on a raw param,
+ * mapped to the prescription an author needs (objectui#3174).
+ *
+ * They are deliberately ABSENT from `RawActionParam` above rather than declared
+ * and ignored: the whole defect this table exists for is that
+ * `@object-ui/types`' public `ActionParam` declared them "for parity with the
+ * resolved shape", so `{ name: 'account_id', type: 'lookup', referenceTo:
+ * 'account' }` type-checked, lost its picker target here, and rendered as a
+ * plain record-id text box. `ActionParamSchema` in `@objectstack/spec` is
+ * `.strict()` and rejects every one of them at parse time — `referenceTo` by
+ * name, with `reference` as the suggestion — so resolving them here would make
+ * objectui accept metadata the platform itself refuses to store. That is a
+ * second de-facto contract, not a kindness (AGENTS.md "contract-first"): such a
+ * param would work in a locally-authored TS action and fail at publish.
+ *
+ * So the disposition is: recognise, name, and refuse — never silently drop, and
+ * never quietly honour.
+ */
+export const RESOLVED_ONLY_PARAM_KEYS: Readonly<Record<string, string>> = (() => {
+  const fromField =
+    'It is inherited from the referenced field — make the param field-backed '
+    + "(`{ field: '<lookup_field>' }`) to pick it up.";
+  return {
+    referenceTo:
+      "Use `reference` instead — `reference: '<object>'` is the spec's spelling for an inline "
+      + 'picker target, and the only one this resolver reads.',
+    displayField: fromField,
+    idField: fromField,
+    descriptionField: fromField,
+    titleFormat: fromField,
+    lookupColumns: fromField,
+    lookupFilters: fromField,
+    lookupPageSize: fromField,
+    dependsOn: fromField,
+  };
+})();
+
+/**
+ * Dev-mode guard: name any resolved-only key an author put on a raw param.
+ *
+ * `tsc` already rejects these against `@object-ui/types`' `ActionParam`, and the
+ * server rejects them at parse. This covers the gap between the two — params
+ * authored in plain JS, loaded from JSON, or synthesised at runtime — so the
+ * mistake is loud wherever it enters, instead of surfacing downstream as
+ * `paramToField()`'s "no reference target" warning naming a key the author never
+ * wrote (which is how objectui#3174 read from the author's seat).
+ */
+function warnResolvedOnlyKeys(param: RawActionParam): void {
+  if (process.env.NODE_ENV === 'production') return;
+  const raw = param as unknown as Record<string, unknown>;
+  for (const key of Object.keys(RESOLVED_ONLY_PARAM_KEYS)) {
+    if (raw[key] === undefined) continue;
+    console.warn(
+      `[resolveActionParams] Param "${param.name ?? param.field ?? '(unnamed)'}" declares \`${key}\`, `
+        + 'which is not an authorable action-param key: it belongs to the RESOLVED `ActionParamDef`, '
+        + "`@objectstack/spec`'s `ActionParamSchema` rejects it at parse time, and this resolver ignores it. "
+        + RESOLVED_ONLY_PARAM_KEYS[key],
+    );
+  }
 }
 
 /** Field metadata as exposed by `useMetadata().objects[].fields`. */
@@ -156,6 +228,11 @@ export function resolveActionParam(
   param: RawActionParam,
   ctx: ResolveActionParamsContext,
 ): ActionParamDef {
+  // Off-spec resolved-side keys are named here, at the authoring boundary,
+  // before anything downstream can mistake the resulting gap for partial
+  // metadata (objectui#3174).
+  warnResolvedOnlyKeys(param);
+
   /** Row-context default: when `defaultFromRow` and a row is present, the
    *  param's defaultValue is the row's value at the field key (or `name`). */
   const rowKey = param.field ?? param.name;

--- a/packages/app-shell/src/utils/resolveActionParams.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.ts
@@ -72,6 +72,36 @@ export interface RawActionParam {
 }
 
 /**
+ * The param's handle in the action payload — `name` wins, defaulting to the
+ * field it binds.
+ *
+ * One of the two identity reads this module makes, and the reason both are
+ * named functions rather than open-coded alternations: they are two LAYERS, not
+ * two spellings of one (objectui#3104's inventory says so for this exact file).
+ * Reading them through a single reader each is what keeps that distinction
+ * legible — and keeps a third, accidental precedence from appearing the next
+ * time someone needs a param's identity.
+ *
+ * NOT `columnIdentity()` from `@object-ui/core`: that reader is canonical-first
+ * (`field` beats `name`) because a list COLUMN's identity is the object field it
+ * shows. A param is the opposite — it is a slot in the payload that may bind a
+ * field — so borrowing the column reader here would silently invert the
+ * precedence and rename every field-backed param that also names itself.
+ */
+function paramName(param: RawActionParam): string | undefined {
+  return param.name ?? param.field;
+}
+
+/**
+ * The key a `defaultFromRow` param reads off the row record — `field` wins here,
+ * because row data is keyed by OBJECT FIELD. The mirror image of
+ * {@link paramName}, deliberately: same two keys, opposite question.
+ */
+function rowValueKey(param: RawActionParam): string | undefined {
+  return param.field ?? param.name;
+}
+
+/**
  * Keys of the RESOLVED `ActionParamDef` that are not authorable on a raw param,
  * mapped to the prescription an author needs (objectui#3174).
  *
@@ -125,7 +155,7 @@ function warnResolvedOnlyKeys(param: RawActionParam): void {
   for (const key of Object.keys(RESOLVED_ONLY_PARAM_KEYS)) {
     if (raw[key] === undefined) continue;
     console.warn(
-      `[resolveActionParams] Param "${param.name ?? param.field ?? '(unnamed)'}" declares \`${key}\`, `
+      `[resolveActionParams] Param "${paramName(param) ?? '(unnamed)'}" declares \`${key}\`, `
         + 'which is not an authorable action-param key: it belongs to the RESOLVED `ActionParamDef`, '
         + "`@objectstack/spec`'s `ActionParamSchema` rejects it at parse time, and this resolver ignores it. "
         + RESOLVED_ONLY_PARAM_KEYS[key],
@@ -234,8 +264,8 @@ export function resolveActionParam(
   warnResolvedOnlyKeys(param);
 
   /** Row-context default: when `defaultFromRow` and a row is present, the
-   *  param's defaultValue is the row's value at the field key (or `name`). */
-  const rowKey = param.field ?? param.name;
+   *  param's defaultValue is the row's value at {@link rowValueKey}. */
+  const rowKey = rowValueKey(param);
   const rowDefault =
     param.defaultFromRow && ctx.row && rowKey != null && Object.prototype.hasOwnProperty.call(ctx.row, rowKey)
       ? ctx.row[rowKey]
@@ -272,7 +302,7 @@ export function resolveActionParam(
     // action remains usable in environments where the metadata cache is
     // partial (e.g. tests).
     return {
-      name: param.name ?? param.field,
+      name: paramName(param) ?? param.field,
       label: param.label ?? ctx.fieldLabel(ownerName, param.field, param.field),
       type: param.type ?? 'text',
       required: param.required ?? false,
@@ -317,7 +347,7 @@ export function resolveActionParam(
     : {};
 
   return {
-    name: param.name ?? param.field,
+    name: paramName(param) ?? param.field,
     label: resolvedLabel,
     type: resolvedType,
     required: param.required ?? field.required ?? false,

--- a/packages/app-shell/tsconfig.typetests.json
+++ b/packages/app-shell/tsconfig.typetests.json
@@ -44,5 +44,16 @@
   },
   // Explicit list, not a glob. Every entry is a file whose type assertions are
   // the point of the file.
-  "include": ["src/__tests__/spec-symbol-parity.test.ts"]
+  //
+  // `utils/resolveActionParams.test.ts` earns its place through objectui#3174:
+  // its last block authors params through `@object-ui/types`' PUBLIC
+  // `ActionParam` and follows one to the field the widgets consume. The reason
+  // that defect went unseen for so long is that every other test in the file
+  // authors the resolver's OWN local `RawActionParam`, so the resolver only
+  // ever agreed with itself — an `ActionParam` annotation that no `tsc` run
+  // reads would reproduce exactly that blind spot.
+  "include": [
+    "src/__tests__/spec-symbol-parity.test.ts",
+    "src/utils/resolveActionParams.test.ts"
+  ]
 }

--- a/packages/core/src/utils/__tests__/column-identity.ratchet.test.ts
+++ b/packages/core/src/utils/__tests__/column-identity.ratchet.test.ts
@@ -35,12 +35,12 @@
  *
  * objectui#3104 PR3 asked for the eslint option to be evaluated on its
  * false-positive rate before adopting it. It was, and the answer is decisive:
- * with the family at zero, **all 12 remaining scanner hits are legitimate** —
+ * with the family at zero, **all 11 remaining scanner hits are legitimate** —
  * two-layer joins where both precedences are correct, the form cluster #3090
  * settled the other way, and display fallbacks that merely share the key names.
  * A syntactic rule matching `.field ?? .name` cannot tell any of those from a
  * real dual read, because the distinction is what the keys MEAN in that layer,
- * not how the expression is spelled. Adopting it would mean 12 inline disables
+ * not how the expression is spelled. Adopting it would mean 11 inline disables
  * on correct code — which trains the next author to reach for the disable, the
  * precise reflex that lets a real one through.
  *
@@ -122,11 +122,11 @@ interface Entry {
 const INVENTORY: Record<string, Entry> = {
   // ── the column-identity family: EMPTY (was 24 in PR1; 22 after re-triage) ──
 
-  // ── two layers, not two spellings (6) ────────────────────────────────────
+  // ── two layers, not two spellings (5) ────────────────────────────────────
   'app-shell/src/utils/resolveActionParams.ts': {
-    count: 3,
+    count: 2,
     verdict: 'two-layer',
-    why: 'BOTH orders appear here and both are right: `field ?? name` picks the key to read off the ROW (row data is keyed by object field), `name ?? field` names the PARAM in the action payload, defaulting to the field it binds. Two concepts, not two spellings.',
+    why: 'BOTH orders appear here and both are right: `field ?? name` picks the key to read off the ROW (row data is keyed by object field), `name ?? field` names the PARAM in the action payload, defaulting to the field it binds. Two concepts, not two spellings. Lowered 3 -> 2 in objectui#3174: each order is now exactly ONE named reader (`rowValueKey` / `paramName`) that every call site in the file goes through, so the count is the number of CONCEPTS here rather than the number of times they were open-coded. Deliberately NOT converged onto `columnIdentity()`: that reader is canonical-first because a column IS the object field it shows, whereas a param merely BINDS one, so borrowing it would invert the param-name precedence and rename every field-backed param that also names itself.',
   },
   'core/src/utils/dashboard-filters.ts': {
     count: 1,
@@ -259,7 +259,9 @@ describe('column identity dual-read ratchet (#3104)', () => {
     // settled decisions, and `unrelated` is scanner residue recorded so it
     // cannot hide a real one.
     expect(sum((e) => e.verdict === 'column-identity')).toBe(0);
-    expect(sum(() => true)).toBe(12);
+    // 12 at #3104 PR2; 11 since objectui#3174 routed `resolveActionParams`'
+    // two orders through one named reader each.
+    expect(sum(() => true)).toBe(11);
   });
 
   it('records a precedence for every read left in the family', () => {

--- a/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
+++ b/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
@@ -37,8 +37,10 @@ import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import ts from 'typescript';
+import type { z } from 'zod';
 import { NavigationAreaSchema as SpecNavigationAreaSchema } from '@objectstack/spec/ui';
 import type {
+  ActionParamSchema as SpecActionParamSchema,
   I18nLabel as SpecI18nLabel,
   NavigationArea as SpecNavigationArea,
   Theme as SpecTheme,
@@ -300,6 +302,86 @@ describe('ActionParam derives from the spec ActionParamSchema input', () => {
   it('still expresses the field-backed form (framework#4074)', () => {
     const fieldBacked: ActionParam = { field: 'status' };
     expect(fieldBacked.field).toBe('status');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ActionParam — authoring keys ONLY (objectui#3174)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The keys an author may write on a param, straight off the spec. `z.input`
+ * because `ActionParamSchema` ends in a `.transform()` and this is the
+ * pre-parse, as-written side (objectui#3169).
+ */
+type SpecAuthorableParamKey = keyof z.input<typeof SpecActionParamSchema>;
+
+/** Every key `ActionParam` adds on top of the spec's set. */
+type LocalOnlyParamKey = Exclude<keyof ActionParam, SpecAuthorableParamKey>;
+
+describe('ActionParam declares ONLY authorable keys (objectui#3174)', () => {
+  it('does not declare the resolved-side picker group', () => {
+    // These nine live on `@object-ui/core`'s RESOLVED `ActionParamDef`, which
+    // `resolveActionParams()` EMITS. Declaring them on the authoring type made
+    // `{ type: 'lookup', referenceTo: 'account' }` compile, lose its picker
+    // target in the resolver, and render as a record-id text box — while the
+    // dialog's own warning told the author to use `reference`, a key this type
+    // did not have. `ActionParamSchema` is `.strict()`, so the server rejects
+    // every one of them at parse time too; the type was the half that lied.
+    const authored: ActionParam = {
+      name: 'account_id',
+      type: 'lookup',
+      // @ts-expect-error `referenceTo` is resolved-side; author `reference`
+      referenceTo: 'account',
+    };
+    expect(authored.name).toBe('account_id');
+
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withDisplayField: ActionParam = { name: 'p', displayField: 'name' };
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withIdField: ActionParam = { name: 'p', idField: 'id' };
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withDescriptionField: ActionParam = { name: 'p', descriptionField: 'email' };
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withTitleFormat: ActionParam = { name: 'p', titleFormat: '{name}' };
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withLookupColumns: ActionParam = { name: 'p', lookupColumns: [] };
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withLookupFilters: ActionParam = { name: 'p', lookupFilters: [] };
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withLookupPageSize: ActionParam = { name: 'p', lookupPageSize: 20 };
+    // @ts-expect-error inherited from the referenced field, not authored
+    const withDependsOn: ActionParam = { name: 'p', dependsOn: [] };
+
+    expect([
+      withDisplayField, withIdField, withDescriptionField, withTitleFormat,
+      withLookupColumns, withLookupFilters, withLookupPageSize, withDependsOn,
+    ]).toHaveLength(8);
+  });
+
+  it('keeps `reference` as the one authorable picker spelling', () => {
+    // The positive half of the pin above: what the resolver reads must stay
+    // writable, or the removal would have closed the capability instead of
+    // pointing at it.
+    const authored: ActionParam = { name: 'account_id', type: 'lookup', reference: 'account' };
+    expect(authored.reference).toBe('account');
+  });
+
+  it('adds exactly ONE key to the spec set — `validation` (objectui#3201)', () => {
+    // INVERTED PIN, both directions. Forward: no key may join `validation`
+    // without this failing, which is the rule objectui#3174 leaves behind —
+    // the authoring type declares exactly the spec's authorable keys, so a
+    // capability the resolved shape has and this one lacks is a spec change or
+    // a field-backed param, never a key added here. Reverse: `validation` is
+    // itself inert and rejected by the spec's `.strict()` parse (objectui#3201),
+    // so the day it is retired this line stops compiling and the exception is
+    // deleted rather than inherited.
+    const theOneException: LocalOnlyParamKey = 'validation';
+    type NothingElseIsLocal = Exclude<LocalOnlyParamKey, 'validation'> extends never ? true : false;
+    const nothingElse: NothingElseIsLocal = true;
+
+    expect(theOneException).toBe('validation');
+    expect(nothingElse).toBe(true);
   });
 });
 

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -226,19 +226,17 @@ export type ResolvableParamFieldType = ActionParamFieldType | ObjectUiLocalParam
 /**
  * Action parameter definition (ObjectStack Spec v2.0.1)
  *
- * Mirrors `@object-ui/core`'s `ActionParamDef` — the shape `ActionParamDialog`
- * actually consumes — so a host app authoring against this package can express
- * every param capability objectui renders. Before #4074 it declared 9 of the 22
- * fields `ActionParamDef` carries, so the widget config below (`multiple`,
- * upload `accept`/`maxSize`, and the whole lookup-picker group that
- * `paramToField.ts` maps into the shared field renderer, ADR-0059) was
- * unrepresentable in the public type while being fully implemented.
+ * The AUTHORING shape of an action param: what a host app WRITES. It is not a
+ * mirror of `@object-ui/core`'s `ActionParamDef`, which is what the dialog
+ * READS after `resolveActionParams()` has inlined the field reference — see the
+ * "authoring ≠ resolved" note below, and objectui#3174 for what conflating them
+ * cost.
  *
- * This is the AUTHORING shape, aligned with the spec's `ActionParamSchema`
- * input (#4074 steps 2–3): `name` / `label` / `type` are optional because the
- * `field` reference form supplies them from an existing object field. The
- * RESOLVED shape the dialog consumes — after `resolveActionParams()` in
- * `@object-ui/app-shell` inlines the field reference — is `@object-ui/core`'s
+ * It is aligned with the spec's `ActionParamSchema` input (#4074 steps 2–3):
+ * `name` / `label` / `type` are optional because the `field` reference form
+ * supplies them from an existing object field. The RESOLVED shape the dialog
+ * consumes — after `resolveActionParams()` in `@object-ui/app-shell` inlines
+ * the field reference — is `@object-ui/core`'s
  * `ActionParamDef`, which keeps `name`/`label`/`type` required. Authoring and
  * resolved are different types on purpose; conflating them is what made a
  * spec-valid `{ field: 'status' }` param a type error here for as long as this
@@ -267,6 +265,37 @@ export type ResolvableParamFieldType = ActionParamFieldType | ObjectUiLocalParam
  * the spec vocabulary plus objectui's declared legacy spellings
  * (`checkbox` / `reference` / `datetime-local`), which the dialog resolves.
  *
+ * **Authoring ≠ resolved — the resolved-side keys are NOT declared here**
+ * (objectui#3174). This interface used to add the whole picker group on top of
+ * the spec's keys — `referenceTo`, `displayField`, `idField`,
+ * `descriptionField`, `titleFormat`, `lookupColumns`, `lookupFilters`,
+ * `lookupPageSize`, `dependsOn` — "for parity with the resolved shape". None of
+ * them is authorable:
+ *
+ *  - `ActionParamSchema` is `.strict()`, so every one of them is a hard PARSE
+ *    REJECTION on the server; `referenceTo` is even listed by name in the
+ *    schema's alias map, which answers it with "use `reference`".
+ *  - `resolveActionParams()` never read any of them. It reads the spec's
+ *    `reference` for an inline picker target and inherits the rest from the
+ *    referenced object field.
+ *
+ * So `{ name: 'account_id', type: 'lookup', referenceTo: 'account' }` type-
+ * checked, lost its picker target on the way through the resolver, and rendered
+ * as a plain record-id text box — while the dev warning that fired told the
+ * author to declare `reference`, a key this type did not have. Declaring the
+ * resolved spelling here is what made that a *silent* authoring error instead
+ * of a compile error, so it is gone: `reference` is the one authorable
+ * spelling, and the eight remaining picker keys come from the field a
+ * field-backed param names (`{ field: 'account_id' }`). An authored
+ * `referenceTo` now fails `tsc` here, and — for the JS/JSON authoring paths
+ * `tsc` does not gate — `resolveActionParams()` names it in a dev warning
+ * rather than dropping it silently.
+ *
+ * The rule this leaves behind, pinned by the drift guard: **this interface
+ * declares exactly the spec's authorable keys.** A capability the resolved
+ * shape has and the authoring shape lacks is either a spec change or a
+ * field-backed param — never a key added here.
+ *
  * `label` and `options[].label` are NOT pinned, though the comment above used
  * to justify them as a widening: "labels take the spec's `I18nLabel` (a string
  * or a per-locale record)". In spec 17 `I18nLabelSchema` is `z.ZodString` —
@@ -291,50 +320,25 @@ export interface ActionParam
    */
   type?: ResolvableParamFieldType;
 
-  /** Validation expression */
-  validation?: string;
-
-  // ── Resolved-side picker config (shared form field-widget renderer,
-  // ADR-0059) ───────────────────────────────────────────────────────────
-  // `ActionParamDialog` renders every param through the same field widgets the
-  // object form uses. These keys are the picker config `paramToField.ts` reads
-  // off `@object-ui/core`'s RESOLVED `ActionParamDef`; `resolveActionParams()`
-  // fills them from the referenced object field (or, for `referenceTo`, from
-  // the spec's inline `reference` above). They are declared here for parity
-  // with the resolved shape — an authored param that sets them directly is not
-  // read today, which is objectui#3174.
-
   /**
-   * Reference target object for `lookup`/`master_detail` params.
+   * Validation expression.
    *
-   * Authoring an inline picker target uses the spec's `reference` (above);
-   * this is the resolved spelling `ActionParamDef` carries (objectui#3174).
+   * NOT a spec key — `ActionParamSchema` is `.strict()`, so the server rejects
+   * it — and nothing reads it: `resolveActionParams()` never copies it onto the
+   * resolved param, and `paramToField()` never maps it into the field the
+   * widgets consume (form validation is built from `required` / `minLength` /
+   * `maxLength` / `pattern` field metadata instead). It is the same
+   * declared-but-inert shape objectui#3174 removed the picker group for, minus
+   * the second spelling, and is left standing only because retiring it is its
+   * own decision with its own blast radius — tracked as objectui#3201.
+   *
+   * The drift guard names it as the ONE key this interface adds to the spec's
+   * set, so it cannot be joined by a second without that being a decision.
+   *
+   * @deprecated Inert — declared, never read, and rejected by the server's
+   * param parser. Do not author it.
    */
-  referenceTo?: string;
-
-  /** Field on the referenced object to display in the picker. */
-  displayField?: string;
-
-  /** Field on the referenced object holding its id. */
-  idField?: string;
-
-  /** Field on the referenced object to show as secondary text. */
-  descriptionField?: string;
-
-  /** Template composing the picker's row title. */
-  titleFormat?: string;
-
-  /** Columns shown in the lookup picker's table. */
-  lookupColumns?: unknown[];
-
-  /** Filters constraining the lookup picker's query. */
-  lookupFilters?: unknown[];
-
-  /** Page size for the lookup picker's query. */
-  lookupPageSize?: number;
-
-  /** Params this one's options depend on (cascading selects). */
-  dependsOn?: unknown[];
+  validation?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #3174

## 问题

一个概念、两种拼法，分别落在 `resolveActionParams()` 的两侧：

- **作者侧** —— `resolveActionParams()` 只读 spec 的 `reference`,用于内联 `lookup` / `master_detail` 的 picker 目标。
- **解析侧** —— 它产出的是 `@object-ui/core` 的 `ActionParamDef.referenceTo`,再由 `paramToField()` 映射成字段的 `reference_to`。

而宿主应用真正编写的公共类型 `@object-ui/types` 的 `ActionParam`,声明的却是**解析侧**的 `referenceTo`(注释写着"for parity with the resolved shape")。于是照公共类型写下 `{ name: 'account_id', type: 'lookup', referenceTo: 'account' }` 的作者:类型检查通过 → picker 目标在 resolver 里被丢弃 → 对话框降级成一个要人手工粘贴 UUID 的文本框 → 随后弹出的 dev 警告让他去声明 `reference`,一个这个类型上根本不存在的键。契约的两半对拼法各执一词,而**错的那一半是类型**。

## 为什么是 `reference` 赢,以及为什么不做 `??` 兜底

平台其实早就裁决过了。`@objectstack/spec` 的 `ActionParamSchema` 是 `.strict()` 的,并且在它的近义键别名表里**点名**列出了 `referenceto`,给出的答案就是 `reference`:

```
const ACTION_PARAM_KEY_ALIASES = {
  referenceto: 'reference',
  ...
};
```

也就是说,作者写下的 `referenceTo` 从来就存不进去 —— 它在服务端是一次硬性 parse 拒绝,只是 `tsc` 把它放行了。既然如此,在 objectui 侧加一个 `param.reference ?? param.referenceTo` 就是**最坏的选项**:那会让渲染器接受平台自己拒收的元数据,这样的 param 在本地 TS 里写着能用,一发布就失败,同时也正是 AGENTS.md contract-first 明令禁止的"消费端宽容"——AI 生成的元数据错误恰恰藏在这类兜底里并繁殖。所以按 PM 的裁决取"不再声明"这一支:把失败搬到作者敲键盘的那一刻。

本次**不需要**改动 `@objectstack/spec` 的公开契约(升级红线未触发):spec 的形状已经是对的,要改的只是 objectui 这一侧的声明与运行时。

## 改动

**`@object-ui/types`** —— 从作者侧的 `ActionParam` 上移除九个解析侧 picker 键:`referenceTo`、`displayField`、`idField`、`descriptionField`、`titleFormat`、`lookupColumns`、`lookupFilters`、`lookupPageSize`、`dependsOn`。它们没有一个是可作者化的:`.strict()` 全部拒收,resolver 一个都不读。内联 picker 目标写 `reference`;其余八个由字段反查而来 —— 把 param 写成 field-backed 的 `{ field: 'account_id' }` 即可整组继承。

同时把这条规则**钉住**:该接口声明的键集恰好等于 spec 的可作者化键集。守卫点名了唯一的例外 `validation`(同样 inert、同样被 `.strict()` 拒收,已另开 #3201 记录),所以第二个本地键不可能在没人做决定的情况下混进来。

**`@object-ui/app-shell`** —— `resolveActionParams()` 在 dev 模式下**点名**任何出现在作者侧 param 上的解析侧键,并给出处方(`referenceTo` → 改用 `reference`;其余 → 改成 field-backed)。它**仍然不读**这些键。这一层补的是 `tsc` 管不到的缝:纯 JS 编写、从 JSON 载入、或运行时合成的 param —— 让错误在它产生的位置就响,而不是在下游变成 `paramToField()` 那句"没有 reference target"、点名一个作者从没写过的键。

## 验收

判据是"作者照公共类型写,不可能再静默降级成记录 ID 文本框":

- 写 `referenceTo` → `tsc` 直接报错(在 `@object-ui/types` 的漂移守卫里用 `@ts-expect-error` 钉住)。
- 绕过 `tsc` 写进来 → resolver 点名警告 + 下游降级警告,两条都指向可写的 `reference`。二者都不是静默。

内部管线的两种拼法(作者 `reference` → `ActionParamDef.referenceTo` → 字段 `reference_to`)按 PM 裁决保持不变;钉住的是**公共入口与公共出口一致**。

## 测试

新增的端到端用例通过**公共 `ActionParam` 类型**编写 param,一路跟到 widget 真正消费的字段对象:`ActionParam` → `resolveActionParams()` → `ActionParamDef` → `paramToField()` → `reference_to`。这正是 issue 指出的缺口 —— 此前每一个用例写的都是 resolver 自己的本地 `RawActionParam`,所以 resolver 永远只跟自己达成一致,错配才得以存活。该文件同时加入了 `tsconfig.typetests.json`,否则那些 `ActionParam` 标注没有任何 `tsc` 会读,等于复刻同一个盲区。

```
$ npx vitest run --maxWorkers=2 packages/types packages/app-shell
 Test Files  277 passed (277)
      Tests  2542 passed | 1 skipped (2543)

$ npx turbo run type-check --concurrency=2
 Tasks:    78 successful, 78 total

$ node scripts/check-type-check-coverage.mjs
 ✅  type-check coverage: 43/45 via `type-check` … 
 ✅  test type-check coverage: 21/36 packages compile their tests … 4 with a narrow type-assertion project.

$ node scripts/check-changeset-fixed.mjs   →  ✅
$ node scripts/check-spec-symbol-derivation.mjs  →  ✅
$ npx turbo run lint --filter=@object-ui/types --filter=@object-ui/app-shell
 2 successful, 0 errors
```

## 顺带记录(未在本 PR 修)

- #3201 —— `ActionParam.validation` / `ActionParamDef.validation` 同属"声明了、没人读、且被 spec parser 拒收"的形状,退役它是独立决定,已单开 issue,并在守卫里作为唯一具名例外挂账。

Changeset:`.changeset/action-param-reference-is-the-authorable-spelling.md`(两个包各 minor;对作者是破坏性变更,已在文中写明迁移方式)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA)_