### PR TITLE
feat(plugin-detail): `record:activity` 接上取数路径,11 个声明的输入不再是空 feed 上的摆设 (#3165)

### DIFF
--- a/.changeset/record-activity-feed-has-a-source.md
+++ b/.changeset/record-activity-feed-has-a-source.md
@@ -1,0 +1,59 @@
+---
+"@object-ui/plugin-detail": minor
+---
+
+`record:activity` fetches a feed instead of rendering a permanently empty one (objectui#3165).
+
+The block published eleven inputs — `types`, `filterMode`, `showFilterToggle`,
+`limit`, `showCompleted`, `unifiedTimeline`, `showCommentInput`,
+`enableMentions`, `enableReactions`, `enableThreading`,
+`showSubscriptionToggle` — every one of them a filter or an affordance over a
+feed that could not have content on any path. `RecordActivityRenderer` called
+`useRecordContext()`, discarded the result and rendered
+`<RecordActivityTimeline items={[]}>` with the empty array hard-coded; the
+timeline takes `items` as a prop and never fetched; no host supplied any
+(`buildDefaultPageSchema` emits `{ type: 'record:activity' }` with no props at
+all). Declared, published to `sdui.manifest.json`, inert at runtime —
+objectstack#4413's shape, three blocks over.
+
+**The feed now has three sources, in precedence order.** `items` on the node
+(the convention `record:history` uses for `entries`); a mounted
+`DiscussionContext`, which the console's record page fills with the merged
+`sys_comment` + `sys_activity` feed and the write handlers; otherwise a
+**self-fetch** of `sys_activity` scoped to the bound record
+(`{ object_name, record_id }`, newest first, `limit` rows per page, "Load more"
+re-reading a wider window). The third path is what makes the block
+drop-anywhere — hand-authored inside a `page:tabs`, with no host feeding it —
+and it mirrors the read `record:history` already had. Rows map to feed items
+exactly as the console's record page maps them, so both surfaces agree about
+what a row is.
+
+**The read-side inputs now filter.** `types` is an allow-list over feed item
+types (unrecognised entries ignored; an all-typo list is treated as unset
+rather than emptying the feed). `limit` is a page size and caps the scoped
+read. `showCompleted` (spec default `false`) hides completed activities.
+`unifiedTimeline: false` un-mixes field changes from the comment stream — the
+panel becomes a discussion feed and field changes stay in `record:history`.
+`filterMode` seeds which slice the dropdown opens on and falls back to `all`
+on an unrecognised value instead of leaving a `<Select>` matching nothing.
+
+**The write-side switches are wired to the host's handlers.**
+`showCommentInput`, `enableThreading`, `enableReactions` and `enableMentions`
+read `onAddComment` / `onAddReply` / `onToggleReaction` /
+`mentionSuggestions` off `DiscussionContext` — the same standing
+`record:discussion` has. With no host mounted the feed stays read-only and no
+composer is rendered, rather than showing one that silently drops what you
+type.
+
+**`showSubscriptionToggle` is recorded as a known gap, not quietly left
+looking configurable.** The bell needs a `RecordSubscription` value and
+somewhere to persist it, and the platform has no record-subscription object to
+read or write one from. Its input description now says `NOT IMPLEMENTED` (that
+text ships to `sdui.manifest.json`, so an author meets it before writing the
+prop), the docs repeat it, and a test pins it inert so the note has to be
+deleted the day a backend for it lands.
+
+`apps/console`'s record-reach probe (objectui#3149 layer 3a) asserted the old
+behaviour from its `NO_RECORD_REACH` ledger in both directions; that entry is
+deleted, and the probe now reports `record:activity` as responding to the bound
+record.

--- a/apps/console/src/__tests__/record-block-record-reach.test.tsx
+++ b/apps/console/src/__tests__/record-block-record-reach.test.tsx
@@ -66,7 +66,10 @@
  * ledgered below with the host path NAMED and a file:line to check it against,
  * because "host-fed" is only a reason while a host actually feeds it — the day
  * no host does, "host-fed" is the same excuse objectstack#4413 shipped behind.
- * One entry in the ledger is exactly that case today.
+ * One entry in the ledger was exactly that case when this file landed:
+ * `record:activity`, whose feed no host fed and whose renderer hard-coded
+ * `items={[]}`. objectui#3165 gave it a scoped `sys_activity` read and the
+ * entry went with it — the ledger's two-way assertion is what forced that.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -436,43 +439,25 @@ const EXPECTED_CANDIDATES = [
  * reason and the place to check it. Entries are DEBT, not acceptance — an entry
  * whose block starts responding to the record fails this test until deleted.
  *
- * Two of these three are host-fed by design and the host really does feed them.
- * The third is the one this probe was written to find.
+ * Both entries are host-fed by design and the host really does feed them.
+ *
+ * A third entry — `record:activity`, the one this probe was written to find —
+ * was deleted by objectui#3165, which gave the block the scoped `sys_activity`
+ * read it had been declaring eleven filters over. It reaches now, so the ledger
+ * cannot carry it: the assertion below is two-way and goes red on a block that
+ * responds to the record while still listed here. That is the whole point of
+ * writing the ledger as an assertion rather than a skip.
  */
 const NO_RECORD_REACH: Readonly<Record<string, string>> = {
-  // ── objectstack#4413's shape, alive today ──────────────────────────────────
-  // `record:activity` renders an activity feed that structurally cannot have
-  // activities. `RecordActivityRenderer` calls `useRecordContext()` and
-  // DISCARDS the result, then renders `<RecordActivityTimeline items={[]}>`
-  // with the empty array hard-coded; `RecordActivityTimeline` takes `items` as
-  // a prop and never fetches. Its own file header says "Real data wiring
-  // (sys_activity / sys_comment polling) lives inside that component" — it does
-  // not, and that sentence is the whole defect in one line.
-  //
-  // Nor is a host feeding it: `buildDefaultPageSchema` emits the node with NO
-  // props at all (`{ type: 'record:activity' }`), and the `showActivity` option
-  // that would emit it is never set true anywhere outside that builder's own
-  // tests. Meanwhile the registration declares ELEVEN inputs — types,
-  // filterMode, limit, showCompleted, unifiedTimeline, enableReactions,
-  // enableThreading, … — every one of them a filter or affordance over a feed
-  // that is always empty. Declared, published to `sdui.manifest.json`, nothing
-  // behind it: objectstack#4413 exactly, three blocks over.
-  //
-  // Ledgered rather than fixed here because the fix is a feature (a scoped
-  // `sys_activity` read, mirroring the one `record:history` already has) rather
-  // than the missing-bridge one-liner objectui#3144 turned out to be. Tracked
-  // in objectui#3165.
-  'record:activity':
-    'renders `items={[]}` hard-coded and no host supplies items — the feed is always empty on every path (objectui#3165)',
-
   // ── Host-fed, and the host really does feed them ──────────────────────────
   // Feed items come from DiscussionContext, which the page host mounts
   // (app-shell RecordDetailView wraps the record body in
   // <DiscussionContextProvider>). The block is a presenter, not a fetcher, so
-  // mounted without that provider it correctly shows an empty feed. Unlike
-  // `record:activity` above, the provider and its data are real — which is the
-  // difference between a reason and an excuse, and why entries here have to
-  // name the path instead of just saying "host-fed".
+  // mounted without that provider it correctly shows an empty feed. The
+  // provider and its data are real — which is the difference between a reason
+  // and an excuse, and why entries here have to name the path instead of just
+  // saying "host-fed". (`record:activity` used to sit here on a claim of the
+  // same shape with no host behind it; #3165 is what that cost to establish.)
   'record:discussion':
     'feed items come from DiscussionContext, mounted by the page host (app-shell RecordDetailView); presenter, not fetcher',
 

--- a/content/docs/plugins/plugin-detail.mdx
+++ b/content/docs/plugins/plugin-detail.mdx
@@ -160,6 +160,72 @@ const feedItems: FeedItem[] = comments.map(c => ({
 - **Positioning**: Panel can be placed at `bottom`, `right`, or `left` of the record view
 - **Collapsible**: Optional collapse/expand with configurable default state
 
+## The `record:activity` block
+
+`RecordActivityTimeline` is a presenter: you hand it `items`. The SDUI block
+`record:activity` is the schema-authored form of the same panel, and it finds
+its own feed. Drop it anywhere inside a record page:
+
+```json
+{
+  "type": "page:tabs",
+  "items": [
+    {
+      "label": "Activity",
+      "value": "activity",
+      "children": [
+        { "type": "record:activity", "limit": 20, "showCompleted": false }
+      ]
+    }
+  ]
+}
+```
+
+### Where the feed comes from
+
+Three sources, in precedence order:
+
+1. **`items` on the node** — a host that already owns the feed passes it in
+   (the same convention `record:history` uses for `entries`).
+2. **A mounted discussion context** — the console's record page wraps the
+   record body in one, carrying the merged `sys_comment` + `sys_activity` feed
+   *and* the comment / reply / reaction handlers. When it is present the block
+   presents that feed instead of fetching a second, poorer copy.
+3. **Self-fetch** — otherwise the block reads `sys_activity` scoped to the
+   record it is bound to (`object_name` + `record_id`), newest first, `limit`
+   rows per page. This is what makes it work on a hand-authored record page
+   with no host feeding it.
+
+`sys_activity` rows map to feed items the same way the console's record page
+maps them, so both surfaces agree about what a row is:
+`created` / `updated` / `deleted` / `assigned` / `shared` → `field_change`,
+`completed` → `task`, `system` → `system`. `commented` / `mentioned` are
+skipped (their content lives in `sys_comment`), and `login` / `logout` are
+account events, not record activity.
+
+### Which inputs do what
+
+| Input | Effect | Needs |
+|---|---|---|
+| `types` | Allow-list of feed item types. Unrecognised entries are ignored; a list of nothing but typos is treated as unset rather than emptying the feed. | — |
+| `filterMode` | Which slice the filter dropdown opens on (`all` / `comments_only` / `changes_only` / `tasks_only`). The user can still change it. An unrecognised value falls back to `all`. | — |
+| `showFilterToggle` | Shows/hides that dropdown. | — |
+| `limit` | Items per page; also caps the scoped `sys_activity` read. "Load more" grows the window by this much and re-reads. | — |
+| `showCompleted` | Include completed activities (`sys_activity.type = 'completed'`, which surfaces as a `task` item). Off by default, per spec. | — |
+| `unifiedTimeline` | Default `true` mixes field changes and comments in one timeline (Airtable style). `false` un-mixes them: the panel becomes a discussion stream and field changes stay in `record:history`. | — |
+| `showCommentInput` | Shows the composer. | A host discussion context to persist the comment. Without one the feed is read-only and no composer is rendered. |
+| `enableMentions` | Offers @-mention autocomplete in the composer. `false` withholds the suggestions. | The host context's user list. |
+| `enableReactions` | Shows emoji reactions on feed items. Existing reactions still render without a host; toggling one needs the host handler. | A host `onToggleReaction`. |
+| `enableThreading` | Groups replies under their parent comment. Posting a reply needs the host handler. | A host `onAddReply`. |
+| `showSubscriptionToggle` | **Not implemented.** | — |
+
+> **Known gap — `showSubscriptionToggle`.** It renders nothing, whatever you set
+> it to. The bell needs a `RecordSubscription` value and somewhere to persist
+> it, and the platform has no record-subscription object to read or write one
+> from. The input stays declared only because `@objectstack/spec` declares it —
+> it is recorded as a known gap here and in the block's registration rather than
+> left looking configurable (objectui#3165).
+
 ## Schema API
 
 ### RecordChatterPanel Config

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -299,18 +299,49 @@ ComponentRegistry.register('activity', RecordActivityRenderer, {
   icon: 'Activity',
   // Mirrors RecordActivityComponentProps (@object-ui/types), itself aligned
   // with @objectstack/spec RecordActivityProps.
+  //
+  // Every description below says what the input DOES and, where it depends on
+  // something the block does not own, what it needs — because this text is
+  // what ships to `sdui.manifest.json` and is therefore what an AI author
+  // reads before writing the block. objectui#3165: all eleven of these used to
+  // be filters and affordances over a feed the renderer hard-coded to `[]`, so
+  // they read as configurable and did nothing. The read-side six are live on
+  // every path now; the write-side four are live wherever a host mounts a
+  // DiscussionContext (record detail pages do); `showSubscriptionToggle` is a
+  // declared-but-inert GAP and says so here rather than looking configurable.
   inputs: [
-    { name: 'types', type: 'array', label: 'Activity Types', description: 'Activity types to display (e.g. task, event, call, comment)' },
-    { name: 'filterMode', type: 'string', label: 'Filter Mode', description: 'How the type filter combines with the feed query' },
-    { name: 'showFilterToggle', type: 'boolean', label: 'Show Filter Toggle', description: 'Expose the activity-type filter UI' },
-    { name: 'limit', type: 'number', label: 'Limit', description: 'Maximum activities to display' },
-    { name: 'showCompleted', type: 'boolean', label: 'Show Completed', description: 'Include completed/resolved activities' },
-    { name: 'unifiedTimeline', type: 'boolean', label: 'Unified Timeline', description: 'Merge all activity types into one timeline' },
-    { name: 'showCommentInput', type: 'boolean', label: 'Show Comment Input' },
-    { name: 'enableMentions', type: 'boolean', label: 'Enable @mentions' },
-    { name: 'enableReactions', type: 'boolean', label: 'Enable Reactions' },
-    { name: 'enableThreading', type: 'boolean', label: 'Enable Threaded Replies' },
-    { name: 'showSubscriptionToggle', type: 'boolean', label: 'Show Subscribe Toggle' },
+    { name: 'types', type: 'array', label: 'Activity Types', description: 'Allow-list of feed item types to show (comment, field_change, task, event, email, call, note, file, record_create, record_delete, approval, sharing, system). Omit for all; unrecognised entries are ignored.' },
+    {
+      name: 'filterMode',
+      type: 'enum',
+      label: 'Filter Mode',
+      enum: ['all', 'comments_only', 'changes_only', 'tasks_only'],
+      defaultValue: 'all',
+      description: 'Filter the timeline dropdown starts on. The user can still change it; an unrecognised value falls back to "all".',
+    },
+    { name: 'showFilterToggle', type: 'boolean', label: 'Show Filter Toggle', defaultValue: true, description: 'Expose the activity-type filter dropdown in the panel header' },
+    { name: 'limit', type: 'number', label: 'Limit', defaultValue: 20, description: 'Items per page. Also caps the scoped sys_activity read; "Load more" grows the window by this much.' },
+    { name: 'showCompleted', type: 'boolean', label: 'Show Completed', defaultValue: false, description: 'Include completed activities (sys_activity type "completed", which surfaces as a task item). Off by default.' },
+    { name: 'unifiedTimeline', type: 'boolean', label: 'Unified Timeline', defaultValue: true, description: 'Mix field changes and comments in one timeline (Airtable style). Off keeps the panel a discussion stream — field changes stay in record:history.' },
+    { name: 'showCommentInput', type: 'boolean', label: 'Show Comment Input', defaultValue: true, description: 'Show the composer. Requires a host discussion context to persist the comment (record detail pages provide one); without it the feed is read-only.' },
+    { name: 'enableMentions', type: 'boolean', label: 'Enable @mentions', defaultValue: true, description: 'Offer @-mention autocomplete in the composer, from the host discussion context\'s user list. Off withholds the suggestions.' },
+    { name: 'enableReactions', type: 'boolean', label: 'Enable Reactions', defaultValue: false, description: 'Show emoji reactions on feed items. Toggling one requires a host discussion context; without it existing reactions still render, read-only.' },
+    { name: 'enableThreading', type: 'boolean', label: 'Enable Threaded Replies', defaultValue: false, description: 'Group replies under their parent comment. Posting a reply requires a host discussion context.' },
+    {
+      name: 'showSubscriptionToggle',
+      type: 'boolean',
+      label: 'Show Subscribe Toggle',
+      // No `defaultValue`: the spec defaults it true and this renderer treats
+      // it as false, and pinning either number here would advertise a default
+      // for something that has no behaviour to default to.
+      // KNOWN GAP (objectui#3165). Declared because @objectstack/spec declares
+      // it, and left visible rather than quietly dropped so the two
+      // declarations stay in parity — but it renders nothing: the bell needs a
+      // RecordSubscription plus a persist handler, and the platform has no
+      // record-subscription object to read or write one. Saying so here is the
+      // difference between a documented gap and objectstack#4413's shape.
+      description: 'NOT IMPLEMENTED — no record-subscription backend exists yet, so this renders nothing whatever it is set to. Declared for spec parity only (objectui#3165).',
+    },
   ],
 });
 

--- a/packages/plugin-detail/src/renderers/__tests__/record-activity.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-activity.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:activity` — the feed has a source, and the bound record decides it
+ * (objectui#3165).
+ *
+ * Before #3165 the renderer called `useRecordContext()`, threw the result away
+ * and rendered `<RecordActivityTimeline items={[]}>` with the empty array
+ * hard-coded — so every one of its eleven declared inputs was a filter or an
+ * affordance over a feed that was structurally empty. `apps/console`'s
+ * record-reach probe caught that behaviourally (two different records,
+ * byte-identical DOM, zero data calls) and ledgered it; this suite is the
+ * unit-level statement of the same property, plus the precedence rules the fix
+ * introduced.
+ *
+ * What is asserted, in the order it matters:
+ *   1. with nothing but a record context, the block FETCHES, scoped to that
+ *      record — the property whose absence was the bug;
+ *   2. the declared read-side inputs change what is rendered;
+ *   3. a host that owns the feed (`items`, or a mounted DiscussionContext)
+ *      wins, and the block does not fetch a second copy;
+ *   4. the write-path switches are wired to that host's handlers, so
+ *      `showCommentInput` / `enableMentions` are real switches rather than
+ *      decoration;
+ *   5. `showSubscriptionToggle` is pinned as the ONE documented gap — asserted
+ *      inert on purpose, so the day a subscription backend exists this test
+ *      fails and the "NOT IMPLEMENTED" note at the registration site has to be
+ *      deleted with it.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import { RecordContextProvider, DiscussionContextProvider } from '@object-ui/react';
+import type { FeedItem } from '@object-ui/types';
+import { RecordActivityRenderer } from '../record-activity';
+
+const COMPOSER_PLACEHOLDER = 'Leave a comment… (Ctrl+Enter to submit)';
+const EMPTY_FEED = 'No activity recorded';
+
+/** Rows as `sys_activity` returns them for one record. */
+const ROWS = [
+  {
+    id: 'act-1',
+    type: 'updated',
+    summary: 'Stage: draft to qualified',
+    timestamp: '2026-01-02T00:00:00.000Z',
+    actor_name: 'Grace',
+  },
+  {
+    id: 'act-2',
+    type: 'commented',
+    summary: 'lives in sys_comment, not here',
+    timestamp: '2026-01-03T00:00:00.000Z',
+    actor_name: 'Ada',
+  },
+  {
+    id: 'act-3',
+    type: 'completed',
+    summary: 'Follow-up call closed',
+    timestamp: '2026-01-04T00:00:00.000Z',
+    actor_name: 'Ada',
+  },
+  {
+    id: 'act-4',
+    type: 'system',
+    summary: 'Assignment rule ran',
+    timestamp: '2026-01-05T00:00:00.000Z',
+  },
+];
+
+const makeDataSource = (rows: unknown[] = ROWS) =>
+  ({ find: vi.fn().mockResolvedValue({ data: rows }) }) as any;
+
+const mountBound = (
+  schema: Record<string, unknown>,
+  dataSource: any,
+  wrap: (node: React.ReactNode) => React.ReactNode = (n) => n,
+  recordId = 'rec-alpha',
+) =>
+  render(
+    <RecordContextProvider
+      objectName="crm_account"
+      recordId={recordId}
+      data={{ id: recordId, name: 'Alpha' }}
+      dataSource={dataSource}
+    >
+      {wrap(<RecordActivityRenderer schema={schema as any} />)}
+    </RecordContextProvider>,
+  );
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('record:activity — self-fetch scoped to the bound record', () => {
+  it('reads sys_activity for THIS record when no host owns the feed', async () => {
+    const dataSource = makeDataSource();
+    mountBound({}, dataSource);
+
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    const [object, query] = dataSource.find.mock.calls[0];
+    expect(object).toBe('sys_activity');
+    expect(query.$filter).toEqual({ object_name: 'crm_account', record_id: 'rec-alpha' });
+    // Newest first, one row past the window so "Load more" can be honest.
+    expect(query.$orderby).toEqual({ timestamp: 'desc' });
+    expect(query.$top).toBe(21); // spec default limit 20, +1
+
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.getByText('Assignment rule ran')).toBeTruthy();
+  });
+
+  it('re-scopes the fetch when the bound record changes', async () => {
+    const dataSource = makeDataSource();
+    const view = mountBound({}, dataSource);
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(dataSource.find.mock.calls[0][1].$filter.record_id).toBe('rec-alpha');
+
+    view.rerender(
+      <RecordContextProvider
+        objectName="crm_account"
+        recordId="rec-bravo"
+        data={{ id: 'rec-bravo', name: 'Bravo' }}
+        dataSource={dataSource}
+      >
+        <RecordActivityRenderer schema={{} as any} />
+      </RecordContextProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        dataSource.find.mock.calls.some((c: any[]) => c[1]?.$filter?.record_id === 'rec-bravo'),
+      ).toBe(true),
+    );
+  });
+
+  it('skips the comment/mention rows — their content lives in sys_comment', async () => {
+    mountBound({ showCompleted: true }, makeDataSource());
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.queryByText('lives in sys_comment, not here')).toBeNull();
+  });
+
+  it('fetches nothing and renders an empty feed with no record bound', async () => {
+    render(<RecordActivityRenderer schema={{} as any} />);
+    await waitFor(() => expect(screen.getByText(EMPTY_FEED)).toBeTruthy());
+  });
+
+  it('treats a missing sys_activity table as "no activity", not an error', async () => {
+    const dataSource = { find: vi.fn().mockRejectedValue(new Error('404 not provisioned')) } as any;
+    mountBound({}, dataSource);
+    expect(await screen.findByText(EMPTY_FEED)).toBeTruthy();
+  });
+});
+
+describe('record:activity — the declared read-side inputs change what is rendered', () => {
+  it('hides completed activities by default and shows them on request', async () => {
+    const view = mountBound({}, makeDataSource());
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.queryByText('Follow-up call closed')).toBeNull();
+    view.unmount();
+
+    mountBound({ showCompleted: true }, makeDataSource());
+    expect(await screen.findByText('Follow-up call closed')).toBeTruthy();
+  });
+
+  it('types narrows the feed to the listed feed item types', async () => {
+    mountBound({ types: ['system'] }, makeDataSource());
+    expect(await screen.findByText('Assignment rule ran')).toBeTruthy();
+    expect(screen.queryByText('Stage: draft to qualified')).toBeNull();
+  });
+
+  it('unifiedTimeline:false un-mixes field changes out of the stream', async () => {
+    mountBound({ unifiedTimeline: false }, makeDataSource());
+    expect(await screen.findByText('Assignment rule ran')).toBeTruthy();
+    expect(screen.queryByText('Stage: draft to qualified')).toBeNull();
+  });
+
+  it('limit caps the scoped read and the rendered page, and offers to grow it', async () => {
+    const dataSource = makeDataSource();
+    mountBound({ limit: 1, showCompleted: true }, dataSource);
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(dataSource.find.mock.calls[0][1].$top).toBe(2); // limit + 1
+
+    // Only the newest surviving item is on the first page.
+    expect(await screen.findByText('Assignment rule ran')).toBeTruthy();
+    expect(screen.queryByText('Follow-up call closed')).toBeNull();
+
+    // "Load more" grows the window by `limit` — and re-asks for a window that
+    // size, rather than paging client-side over rows it never fetched.
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(await screen.findByText('Follow-up call closed')).toBeTruthy();
+    await waitFor(() =>
+      expect(dataSource.find.mock.calls.some((c: any[]) => c[1]?.$top === 3)).toBe(true),
+    );
+  });
+
+  it('filterMode seeds which slice of the feed the panel opens on', async () => {
+    mountBound({ filterMode: 'changes_only' }, makeDataSource());
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.queryByText('Assignment rule ran')).toBeNull();
+  });
+
+  it('an unrecognised filterMode falls back to "all" rather than a filter nothing matches', async () => {
+    // objectui#3151's posture: an unknown filter token is skipped, never turned
+    // into a predicate that can only ever be empty.
+    mountBound({ filterMode: 'not_a_mode' }, makeDataSource());
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.getByText('Assignment rule ran')).toBeTruthy();
+  });
+
+  it('showFilterToggle:false removes the filter dropdown', async () => {
+    const view = mountBound({}, makeDataSource());
+    expect(await screen.findByLabelText('Filter activity')).toBeTruthy();
+    view.unmount();
+
+    mountBound({ showFilterToggle: false }, makeDataSource());
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.queryByLabelText('Filter activity')).toBeNull();
+  });
+});
+
+const HOST_ITEMS: FeedItem[] = [
+  {
+    id: 'h1',
+    type: 'comment',
+    actor: 'Ada',
+    body: 'host supplied',
+    createdAt: '2026-02-01T00:00:00.000Z',
+  },
+];
+
+describe('record:activity — a host that owns the feed wins', () => {
+  it('presents `items` from the node and does not fetch', async () => {
+    const dataSource = makeDataSource();
+    mountBound({ items: HOST_ITEMS }, dataSource);
+    expect(await screen.findByText('host supplied')).toBeTruthy();
+    expect(dataSource.find).not.toHaveBeenCalled();
+  });
+
+  it('reads `properties.items` too — the spec bridge preserves the raw bag', async () => {
+    const dataSource = makeDataSource();
+    mountBound({ properties: { items: HOST_ITEMS } }, dataSource);
+    expect(await screen.findByText('host supplied')).toBeTruthy();
+    expect(dataSource.find).not.toHaveBeenCalled();
+  });
+
+  it('presents a mounted DiscussionContext feed and does not fetch a second copy', async () => {
+    const dataSource = makeDataSource();
+    mountBound({}, dataSource, (node) => (
+      <DiscussionContextProvider items={HOST_ITEMS as any}>{node}</DiscussionContextProvider>
+    ));
+    expect(await screen.findByText('host supplied')).toBeTruthy();
+    expect(dataSource.find).not.toHaveBeenCalled();
+  });
+
+  it('still applies the declared filters to a host feed', async () => {
+    mountBound({ types: ['task'] }, makeDataSource(), (node) => (
+      <DiscussionContextProvider items={HOST_ITEMS as any}>{node}</DiscussionContextProvider>
+    ));
+    await waitFor(() => expect(screen.getByText(EMPTY_FEED)).toBeTruthy());
+  });
+});
+
+describe('record:activity — the write-path switches are wired to the host handlers', () => {
+  const withHost =
+    (extra: Record<string, unknown> = {}) =>
+    (node: React.ReactNode) => (
+      <DiscussionContextProvider items={HOST_ITEMS as any} onAddComment={vi.fn()} {...(extra as any)}>
+        {node}
+      </DiscussionContextProvider>
+    );
+
+  it('showCommentInput renders the composer once a host supplies onAddComment', async () => {
+    mountBound({}, makeDataSource(), withHost());
+    expect(await screen.findByPlaceholderText(COMPOSER_PLACEHOLDER)).toBeTruthy();
+  });
+
+  it('showCommentInput:false hides it even when the host CAN persist a comment', async () => {
+    mountBound({ showCommentInput: false }, makeDataSource(), withHost());
+    expect(await screen.findByText('host supplied')).toBeTruthy();
+    expect(screen.queryByPlaceholderText(COMPOSER_PLACEHOLDER)).toBeNull();
+  });
+
+  it('with no host handler the feed stays read-only — no composer to mislead the author', async () => {
+    mountBound({ showCommentInput: true }, makeDataSource());
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.queryByPlaceholderText(COMPOSER_PLACEHOLDER)).toBeNull();
+  });
+
+  it('enableMentions passes the host suggestions through, and false withholds them', async () => {
+    const mentionSuggestions = [{ id: 'u1', label: 'Ada Lovelace' }];
+
+    const on = mountBound({}, makeDataSource(), withHost({ mentionSuggestions }));
+    const composerOn = await screen.findByPlaceholderText(COMPOSER_PLACEHOLDER);
+    fireEvent.change(composerOn, { target: { value: '@' } });
+    expect(await screen.findByText('Ada Lovelace')).toBeTruthy();
+    on.unmount();
+
+    mountBound({ enableMentions: false }, makeDataSource(), withHost({ mentionSuggestions }));
+    const composerOff = await screen.findByPlaceholderText(COMPOSER_PLACEHOLDER);
+    fireEvent.change(composerOff, { target: { value: '@' } });
+    expect(screen.queryByText('Ada Lovelace')).toBeNull();
+  });
+});
+
+describe('record:activity — showSubscriptionToggle is the one documented gap', () => {
+  it('renders nothing whatever it is set to, because no subscription backend exists', async () => {
+    mountBound({ showSubscriptionToggle: true }, makeDataSource());
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    // The bell would carry one of these aria-labels. Neither can appear: the
+    // timeline needs a RecordSubscription value AND a persist handler, and the
+    // platform has no object to read or write one from. Pinned so that the day
+    // that backend lands, this test fails and the "NOT IMPLEMENTED" note on the
+    // input declaration must be deleted with it (objectui#3165).
+    expect(screen.queryByLabelText('Subscribe to notifications')).toBeNull();
+    expect(screen.queryByLabelText('Unsubscribe from notifications')).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/recordActivityFeed.test.ts
+++ b/packages/plugin-detail/src/renderers/__tests__/recordActivityFeed.test.ts
@@ -1,0 +1,208 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:activity` — the declared filters actually filter (objectui#3165).
+ *
+ * These assert the pure half directly: the `sys_activity` → `FeedItem` map and
+ * `applyFeedConfig`. Asserting them here rather than only through the DOM is
+ * deliberate — the defect #3165 fixes was that `types` / `limit` /
+ * `showCompleted` / `unifiedTimeline` were DECLARED inputs with nothing behind
+ * them, and "the panel rendered something" is exactly the evidence that stayed
+ * green while that was true.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FeedFilterMode as SpecFilterMode, FeedItemType as SpecFeedItemType } from '@objectstack/spec/data';
+import type { FeedItem } from '@object-ui/types';
+import {
+  ACTIVITY_TYPE_TO_FEED_TYPE,
+  DEFAULT_ACTIVITY_LIMIT,
+  activityRowToFeedItem,
+  activityTimestamp,
+  applyFeedConfig,
+  mergeFeedItems,
+  normalizeFeedTypes,
+  normalizeFilterMode,
+  normalizeLimit,
+} from '../recordActivityFeed';
+
+const item = (over: Partial<FeedItem> & Pick<FeedItem, 'id' | 'type'>): FeedItem => ({
+  actor: 'Ada',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('sys_activity row → FeedItem', () => {
+  it('maps every activity type the platform writes, and only to spec feed types', () => {
+    // The keys are `sys_activity.type`'s select options (plugin-audit
+    // sys-activity.object.ts). Pinned as a set so a new activity type added
+    // upstream shows up here as a decision rather than silently rendering
+    // nothing.
+    expect(Object.keys(ACTIVITY_TYPE_TO_FEED_TYPE).sort()).toEqual([
+      'assigned', 'commented', 'completed', 'created', 'deleted',
+      'login', 'logout', 'mentioned', 'shared', 'system', 'updated',
+    ]);
+    for (const mapped of Object.values(ACTIVITY_TYPE_TO_FEED_TYPE)) {
+      if (mapped) expect(SpecFeedItemType.options).toContain(mapped);
+    }
+  });
+
+  it('drops the rows that are not record activity', () => {
+    for (const type of ['commented', 'mentioned', 'login', 'logout']) {
+      expect(activityRowToFeedItem({ id: '1', type }, 'System')).toBeNull();
+    }
+  });
+
+  it('carries actor, summary and the ADR-0052 source pointer onto the feed item', () => {
+    const mapped = activityRowToFeedItem(
+      {
+        id: 'act-1',
+        type: 'updated',
+        summary: 'Stage: draft → qualified',
+        timestamp: '2026-03-04T05:06:07.000Z',
+        actor_name: 'Grace',
+        actor_avatar_url: 'https://example.test/g.png',
+        source_object: 'sys_email',
+        source_id: 'email-9',
+      },
+      'System',
+    );
+    expect(mapped).toEqual({
+      id: 'act-1',
+      type: 'field_change',
+      actor: 'Grace',
+      actorAvatarUrl: 'https://example.test/g.png',
+      body: 'Stage: draft → qualified',
+      createdAt: '2026-03-04T05:06:07.000Z',
+      sourceObject: 'sys_email',
+      sourceId: 'email-9',
+    });
+  });
+
+  it('falls back to the system actor label when the row has no actor', () => {
+    expect(activityRowToFeedItem({ id: 'a', type: 'system' }, '系统')?.actor).toBe('系统');
+  });
+
+  it('falls back to created_at when the driver leaked the literal NOW() default', () => {
+    expect(activityTimestamp({ timestamp: 'NOW()', created_at: '2026-02-02T00:00:00.000Z' }))
+      .toBe('2026-02-02T00:00:00.000Z');
+    expect(activityTimestamp({ timestamp: null, created_at: '2026-02-03T00:00:00.000Z' }))
+      .toBe('2026-02-03T00:00:00.000Z');
+  });
+});
+
+describe('input normalisation reads its vocabulary from the spec', () => {
+  it('accepts every FeedFilterMode the spec declares, and only those', () => {
+    for (const mode of SpecFilterMode.options) {
+      expect(normalizeFilterMode(mode)).toBe(mode);
+    }
+    // An unrecognised value is SKIPPED, not passed through — a <Select> handed
+    // a value with no matching item renders blank (objectui#3151's posture).
+    expect(normalizeFilterMode('x')).toBe('all');
+    expect(normalizeFilterMode(undefined)).toBe('all');
+    expect(normalizeFilterMode(7)).toBe('all');
+  });
+
+  it('keeps only spec feed types in `types`, and treats an all-garbage list as unset', () => {
+    expect(normalizeFeedTypes(['comment', 'not_a_type', 'task'])).toEqual(['comment', 'task']);
+    expect(normalizeFeedTypes(['not_a_type'])).toBeUndefined();
+    expect(normalizeFeedTypes('comment')).toBeUndefined();
+    expect(normalizeFeedTypes(undefined)).toBeUndefined();
+  });
+
+  it('coerces `limit` to a positive integer, defaulting to the spec default', () => {
+    expect(normalizeLimit(5)).toBe(5);
+    expect(normalizeLimit('5')).toBe(5);
+    expect(normalizeLimit(0)).toBe(DEFAULT_ACTIVITY_LIMIT);
+    expect(normalizeLimit(-3)).toBe(DEFAULT_ACTIVITY_LIMIT);
+    expect(normalizeLimit(undefined)).toBe(DEFAULT_ACTIVITY_LIMIT);
+    expect(normalizeLimit('lots')).toBe(DEFAULT_ACTIVITY_LIMIT);
+    expect(DEFAULT_ACTIVITY_LIMIT).toBe(20); // @objectstack/spec RecordActivityProps.limit
+  });
+});
+
+describe('applyFeedConfig — the declared inputs change what is rendered', () => {
+  const feed: FeedItem[] = [
+    item({ id: 'c1', type: 'comment', createdAt: '2026-01-01T00:00:00.000Z' }),
+    item({ id: 'f1', type: 'field_change', createdAt: '2026-01-02T00:00:00.000Z' }),
+    item({ id: 't1', type: 'task', createdAt: '2026-01-03T00:00:00.000Z' }),
+    item({ id: 's1', type: 'system', createdAt: '2026-01-04T00:00:00.000Z' }),
+  ];
+  const ids = (f: { items: FeedItem[] }) => f.items.map((i) => i.id);
+
+  it('shows everything but completed activities by default (spec: showCompleted=false)', () => {
+    expect(ids(applyFeedConfig(feed, {}, 50))).toEqual(['c1', 'f1', 's1']);
+  });
+
+  it('showCompleted:true admits the completed activities', () => {
+    expect(ids(applyFeedConfig(feed, { showCompleted: true }, 50))).toEqual(['c1', 'f1', 't1', 's1']);
+  });
+
+  it('unifiedTimeline:false un-mixes field changes from the comment stream', () => {
+    expect(ids(applyFeedConfig(feed, { unifiedTimeline: false, showCompleted: true }, 50)))
+      .toEqual(['c1', 't1', 's1']);
+    // …and true is the spec default, i.e. mixed.
+    expect(ids(applyFeedConfig(feed, { unifiedTimeline: true, showCompleted: true }, 50)))
+      .toEqual(['c1', 'f1', 't1', 's1']);
+  });
+
+  it('types is an allow-list over feed item types', () => {
+    expect(ids(applyFeedConfig(feed, { types: ['comment'] }, 50))).toEqual(['c1']);
+    expect(ids(applyFeedConfig(feed, { types: ['comment', 'system'] }, 50))).toEqual(['c1', 's1']);
+  });
+
+  it('a `types` list of nothing but typos does not silently empty the feed', () => {
+    expect(ids(applyFeedConfig(feed, { types: ['commnet'] }, 50))).toEqual(['c1', 'f1', 's1']);
+  });
+
+  it('limit pages the feed newest-first and reports hasMore', () => {
+    const page = applyFeedConfig(feed, { showCompleted: true }, 2);
+    // Chronological render order, but the PAGE is the newest two.
+    expect(ids(page)).toEqual(['t1', 's1']);
+    expect(page.total).toBe(4);
+    expect(page.hasMore).toBe(true);
+
+    const all = applyFeedConfig(feed, { showCompleted: true }, 4);
+    expect(all.hasMore).toBe(false);
+  });
+
+  it('counts the page AFTER filtering, so limit means "items the author sees"', () => {
+    // 3 comments + 3 field changes; with field changes excluded a limit of 3
+    // must yield all three comments, not "3 of the 6 raw rows".
+    const mixed: FeedItem[] = [
+      item({ id: 'c1', type: 'comment', createdAt: '2026-01-01T00:00:00.000Z' }),
+      item({ id: 'f1', type: 'field_change', createdAt: '2026-01-02T00:00:00.000Z' }),
+      item({ id: 'c2', type: 'comment', createdAt: '2026-01-03T00:00:00.000Z' }),
+      item({ id: 'f2', type: 'field_change', createdAt: '2026-01-04T00:00:00.000Z' }),
+      item({ id: 'c3', type: 'comment', createdAt: '2026-01-05T00:00:00.000Z' }),
+      item({ id: 'f3', type: 'field_change', createdAt: '2026-01-06T00:00:00.000Z' }),
+    ];
+    const page = applyFeedConfig(mixed, { unifiedTimeline: false }, 3);
+    expect(ids(page)).toEqual(['c1', 'c2', 'c3']);
+    expect(page.hasMore).toBe(false);
+  });
+
+  it('never mutates the feed it was handed', () => {
+    const source = feed.slice();
+    applyFeedConfig(source, { types: ['comment'] }, 1);
+    expect(source).toHaveLength(4);
+  });
+});
+
+describe('mergeFeedItems', () => {
+  it('de-duplicates by id and sorts chronologically', () => {
+    const merged = mergeFeedItems(
+      [item({ id: 'b', type: 'comment', createdAt: '2026-01-02T00:00:00.000Z' })],
+      [
+        item({ id: 'a', type: 'comment', createdAt: '2026-01-01T00:00:00.000Z' }),
+        item({ id: 'b', type: 'comment', createdAt: '2026-01-02T00:00:00.000Z', body: 'newer' }),
+      ],
+    );
+    expect(merged.map((i) => i.id)).toEqual(['a', 'b']);
+    expect(merged[1].body).toBe('newer');
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-activity.tsx
+++ b/packages/plugin-detail/src/renderers/record-activity.tsx
@@ -5,17 +5,71 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * `record:activity` — unified activity feed (tasks, events, calls, comments)
- * scoped to the current record. Delegates to the existing
- * RecordActivityTimeline. Real data wiring (sys_activity / sys_comment
- * polling) lives inside that component; here we just pass the schema as
- * `config` and a placeholder empty feed for static rendering.
+ * `record:activity` — unified activity feed (field changes, tasks, system
+ * events, comments) scoped to the current record.
+ *
+ * ## Where the feed comes from (objectui#3165)
+ *
+ * Three sources, in precedence order:
+ *
+ *  1. `items` on the node — a host that already owns the feed passes it in,
+ *     exactly as `record:history` takes `entries`;
+ *  2. `DiscussionContext` — mounted by the page host (app-shell
+ *     `RecordDetailView`) with the merged `sys_comment` + `sys_activity` feed
+ *     AND the comment / reply / reaction handlers. When it is present the
+ *     block presents the host's feed rather than fetching a second, poorer
+ *     copy of it;
+ *  3. SELF-FETCH from `sys_activity`, scoped to the bound record off
+ *     `useRecordContext`. This is what makes the block drop-anywhere — inside
+ *     a `page:tabs` on a hand-authored record page, with no host feeding it —
+ *     and it mirrors the path `record:history` already has.
+ *
+ * Until #3165 there was no source at all: the renderer called
+ * `useRecordContext()`, discarded the result and rendered
+ * `<RecordActivityTimeline items={[]}>` with the empty array hard-coded, while
+ * the registration declared eleven inputs that were all filters and
+ * affordances over that permanently-empty feed. That is objectstack#4413's
+ * shape — declared, published to `sdui.manifest.json`, inert at runtime — and
+ * `apps/console/src/__tests__/record-block-record-reach.test.tsx` carried it in
+ * its `NO_RECORD_REACH` ledger until this file grew a data path.
+ *
+ * ## Which declared inputs are live, and where
+ *
+ * READ side, live on every path (the filters themselves live in
+ * `recordActivityFeed.ts`, where they can be asserted without a DOM):
+ *   `types` · `limit` · `showCompleted` · `unifiedTimeline` · `filterMode` ·
+ *   `showFilterToggle`
+ *
+ * WRITE side, live exactly when a host `DiscussionContext` supplies the
+ * matching handler — the same standing `record:discussion` has, and the reason
+ * the wiring below reads them off that context instead of inventing a private
+ * one (this package has no access to the current user, so it cannot author a
+ * `sys_comment` row on its own):
+ *   `showCommentInput` (needs `onAddComment`) · `enableThreading` (replies
+ *   need `onAddReply`) · `enableReactions` (needs `onToggleReaction`) ·
+ *   `enableMentions` (withholds the @-autocomplete suggestions when off)
+ *
+ * KNOWN GAP, stated at the registration site and in the docs so an author
+ * reading the manifest meets it before writing it:
+ *   `showSubscriptionToggle` — the bell needs a `RecordSubscription` and a
+ *   persist handler, and the platform has no record-subscription backend to
+ *   read or write one (no `sys_*` object for it exists). Declared because
+ *   `@objectstack/spec` declares it; inert until that backend does.
  */
 
 import React from 'react';
-import { useRecordContext } from '@object-ui/react';
-import type { RecordActivityComponentProps } from '@object-ui/types';
-import { RecordActivityTimeline } from '../RecordActivityTimeline';
+import { useRecordContext, useDiscussionContext } from '@object-ui/react';
+import { useSafeTranslate } from '@object-ui/i18n';
+import type { FeedItem, RecordActivityComponentProps } from '@object-ui/types';
+import { RecordActivityTimeline, type FeedFilterMode } from '../RecordActivityTimeline';
+import {
+  activityRowToFeedItem,
+  applyFeedConfig,
+  mergeFeedItems,
+  normalizeFilterMode,
+  normalizeLimit,
+  type SysActivityRow,
+} from './recordActivityFeed';
 
 const splitDesigner = (props: Record<string, any>) => {
   const { 'data-obj-id': id, 'data-obj-type': type, style, ...rest } = props || {};
@@ -23,7 +77,15 @@ const splitDesigner = (props: Record<string, any>) => {
 };
 
 export interface RecordActivityRendererProps {
-  schema?: RecordActivityComponentProps & Record<string, any>;
+  schema?: RecordActivityComponentProps & {
+    /** Host-supplied feed. When present the block presents it instead of
+     *  fetching — the `record:history` `entries` convention. */
+    items?: FeedItem[];
+    /** Host-supplied loading flag, paired with `items`. */
+    loading?: boolean;
+    properties?: Record<string, any>;
+    [k: string]: any;
+  };
   className?: string;
   [k: string]: any;
 }
@@ -33,14 +95,159 @@ export const RecordActivityRenderer: React.FC<RecordActivityRendererProps> = ({
   className,
   ...props
 }) => {
-  useRecordContext();
   const { designer } = splitDesigner(props);
+  const ctx = useRecordContext() as any;
+  const discussion = useDiscussionContext();
+  const tt = useSafeTranslate();
+
+  // The spec bridge inlines `properties.*` onto the node but also preserves the
+  // raw bag. Read from either location, same as `record:history`.
+  const bag = (schema.properties ?? {}) as Record<string, any>;
+  const read = (key: string) => (schema as any)[key] ?? bag[key];
+
+  const limit = normalizeLimit(read('limit'));
+  const defaultFilterMode = normalizeFilterMode(read('filterMode'));
+  const types = read('types');
+  const showCompleted = read('showCompleted');
+  const unifiedTimeline = read('unifiedTimeline');
+
+  /** Only the declared inputs, normalized — never the whole node. */
+  const config: RecordActivityComponentProps = {
+    types,
+    filterMode: defaultFilterMode,
+    showFilterToggle: read('showFilterToggle'),
+    limit,
+    showCompleted,
+    unifiedTimeline,
+    showCommentInput: read('showCommentInput'),
+    enableMentions: read('enableMentions'),
+    enableReactions: read('enableReactions'),
+    enableThreading: read('enableThreading'),
+    showSubscriptionToggle: read('showSubscriptionToggle'),
+  };
+
+  const hostItems: FeedItem[] | undefined = Array.isArray(schema.items)
+    ? (schema.items as FeedItem[])
+    : Array.isArray(bag.items)
+      ? (bag.items as FeedItem[])
+      : undefined;
+  const hostLoading: boolean | undefined = schema.loading ?? bag.loading;
+
+  const objectName: string | undefined = ctx?.objectName;
+  const recordId = ctx?.data?.id ?? ctx?.data?._id ?? ctx?.recordId;
+  // `RecordContextValue.dataSource` is typed `string` (a datasource id) while
+  // every host passes the object; `record:history` / `record:reference_rail`
+  // cast the same way. Matching the runtime beats matching the declaration.
+  const dataSource = ctx?.dataSource as any;
+
+  // Self-fetch only when nobody else owns the feed. A mounted DiscussionContext
+  // has already merged `sys_comment` + `sys_activity` for this record; fetching
+  // again would duplicate the round-trip and render a strictly poorer feed.
+  const canSelfFetch =
+    hostItems === undefined &&
+    !discussion &&
+    typeof dataSource?.find === 'function' &&
+    !!objectName &&
+    recordId != null;
+
+  // Page window. Starts at `limit` and grows by `limit` per "Load more", so the
+  // authored `limit` is a page size (the spec's wording) rather than a hard cap.
+  //
+  // The extra PAGES are the state, not the resulting size: re-authoring `limit`
+  // then flows through without an effect that resets a second copy of it (and
+  // without the cascading render that pattern costs).
+  const [extraPages, setExtraPages] = React.useState(0);
+  const pageSize = limit * (extraPages + 1);
+
+  const [fetched, setFetched] = React.useState<FeedItem[] | null>(null);
+  // Whether the server had rows beyond the window. Tracked separately from the
+  // post-filter count because the filters run AFTER the fetch: a page whose
+  // rows were all filtered out still has more rows behind it, and "Load more"
+  // has to stay offered or the feed silently truncates.
+  const [fetchedHasMore, setFetchedHasMore] = React.useState(false);
+  const [selfLoading, setSelfLoading] = React.useState(false);
+
+  const systemActorLabel = tt('detail.systemActor', 'System');
+
+  React.useEffect(() => {
+    if (!canSelfFetch) return;
+    let cancelled = false;
+    setSelfLoading(true);
+    Promise.resolve(
+      dataSource.find('sys_activity', {
+        $filter: { object_name: objectName, record_id: recordId },
+        $orderby: { timestamp: 'desc' },
+        // One row past the window so "Load more" can be offered honestly.
+        $top: Math.max(1, pageSize) + 1,
+      }),
+    )
+      .then((res: any) => {
+        if (cancelled) return;
+        const raw: unknown = res?.data ?? res?.records ?? [];
+        const rows: SysActivityRow[] = Array.isArray(raw) ? (raw as SysActivityRow[]) : [];
+        const mapped: FeedItem[] = [];
+        for (const row of rows) {
+          const item = activityRowToFeedItem(row, systemActorLabel);
+          if (item) mapped.push(item);
+        }
+        setFetchedHasMore(rows.length > Math.max(1, pageSize));
+        setFetched(mergeFeedItems(mapped));
+      })
+      .catch(() => {
+        // `sys_activity` is system-owned and optional: a 404 on a deployment
+        // without the audit plugin is "no activity", not an error to surface.
+        if (!cancelled) {
+          setFetched([]);
+          setFetchedHasMore(false);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setSelfLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [canSelfFetch, dataSource, objectName, recordId, pageSize, systemActorLabel]);
+
+  const discussionItems = discussion?.items as FeedItem[] | undefined;
+  const applied = React.useMemo(() => {
+    const sourceItems: FeedItem[] = hostItems ?? discussionItems ?? fetched ?? [];
+    return applyFeedConfig(sourceItems, { types, showCompleted, unifiedTimeline }, pageSize);
+  }, [hostItems, discussionItems, fetched, types, showCompleted, unifiedTimeline, pageSize]);
+  const items = applied.items;
+  const hasMore = applied.hasMore || (canSelfFetch && fetchedHasMore);
+
+  const loading =
+    hostLoading ?? discussion?.loading ?? (canSelfFetch && fetched === null ? true : selfLoading);
+
+  // The timeline takes `filterMode` as a CONTROLLED prop, so the authored
+  // `filterMode` becomes the initial state here and the dropdown stays usable —
+  // passing it straight through would freeze the dropdown on the authored value.
+  const [filterMode, setFilterMode] = React.useState<FeedFilterMode>(defaultFilterMode);
+  React.useEffect(() => { setFilterMode(defaultFilterMode); }, [defaultFilterMode]);
+
+  const handleLoadMore = React.useCallback(() => {
+    setExtraPages((n) => n + 1);
+  }, []);
+
+  // Write path: whatever the host's DiscussionContext provides, nothing more.
+  // `enableMentions: false` withholds the suggestion list, which is what turns
+  // the composer's @-autocomplete off.
+  const mentionsEnabled = config.enableMentions !== false;
 
   return (
     <div className={className} {...designer}>
       <RecordActivityTimeline
-        items={[] as any}
-        config={schema as any}
+        items={items}
+        config={config}
+        loading={loading}
+        filterMode={filterMode}
+        onFilterChange={setFilterMode}
+        hasMore={hasMore}
+        onLoadMore={handleLoadMore}
+        onAddComment={discussion?.onAddComment as any}
+        onAddReply={discussion?.onAddReply as any}
+        onToggleReaction={discussion?.onToggleReaction as any}
+        mentionSuggestions={mentionsEnabled ? (discussion?.mentionSuggestions as any) : undefined}
+        onUploadAttachments={discussion?.onUploadAttachments as any}
       />
     </div>
   );

--- a/packages/plugin-detail/src/renderers/recordActivityFeed.ts
+++ b/packages/plugin-detail/src/renderers/recordActivityFeed.ts
@@ -1,0 +1,251 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:activity` — the pure half (objectui#3165).
+ *
+ * Two things live here, both testable without a DOM:
+ *
+ *  1. the `sys_activity` row → {@link FeedItem} map the block's self-fetch
+ *     uses (the same map `RecordDetailView` applies to the rows it merges
+ *     into its own feed — one shape for one table);
+ *  2. {@link applyFeedConfig}, the filter/pagination pipeline that turns the
+ *     block's DECLARED inputs (`types` / `showCompleted` / `unifiedTimeline`
+ *     / `limit`) into observable behaviour.
+ *
+ * (2) exists as its own function on purpose. Before #3165 every one of those
+ * inputs was a filter over a feed that was hard-coded empty — declared,
+ * published to `sdui.manifest.json`, inert (objectstack#4413's shape). Making
+ * them filter *whatever items the block has* — host-supplied or self-fetched —
+ * is what stops the declaration from lying, and keeping the rule in one pure
+ * function is what lets a test assert it directly rather than through a DOM.
+ *
+ * Enum membership is read from `@objectstack/spec` at runtime, never re-typed
+ * here: a hand copy of a spec enum is how `FEED_TYPE_ICONS` lost six of the
+ * thirteen feed types (objectstack#4115).
+ */
+
+import { FeedFilterMode as FeedFilterModeEnum, FeedItemType as FeedItemTypeEnum } from '@objectstack/spec/data';
+import type { FeedItem, FeedItemType } from '@object-ui/types';
+import type { FeedFilterMode } from '../RecordActivityTimeline';
+
+const FILTER_MODE_VALUES: readonly string[] = FeedFilterModeEnum.options;
+const FEED_ITEM_TYPE_VALUES: readonly string[] = FeedItemTypeEnum.options;
+
+/** Spec default for `RecordActivityProps.limit`. */
+export const DEFAULT_ACTIVITY_LIMIT = 20;
+
+/**
+ * `sys_activity.type` → `FeedItem.type`.
+ *
+ * Identical to the map `RecordDetailView` uses when it merges `sys_activity`
+ * into the discussion feed, deliberately: one table, one reading. Two renderers
+ * that disagree about what a `created` row IS would put the same record's
+ * history under two different icons depending on which block an author reached
+ * for, so the richer `record_create` / `record_delete` / `sharing` feed types
+ * the spec offers are NOT used here — adopting them is a change to that shared
+ * map, not to this block.
+ *
+ * `commented` / `mentioned` map to nothing because their content lives in
+ * `sys_comment` (with reactions and threading attached) — a host that has both
+ * merges the comment rows, and the block on its own has no comment write path
+ * to pair them with. `login` / `logout` are account events, not record
+ * activity.
+ */
+export const ACTIVITY_TYPE_TO_FEED_TYPE: Readonly<Record<string, FeedItemType | undefined>> = {
+  created: 'field_change',
+  updated: 'field_change',
+  deleted: 'field_change',
+  assigned: 'field_change',
+  shared: 'field_change',
+  system: 'system',
+  completed: 'task',
+  commented: undefined,
+  mentioned: undefined,
+  login: undefined,
+  logout: undefined,
+};
+
+/**
+ * The feed types a COMPLETED activity produces.
+ *
+ * `showCompleted` (spec default `false`) is stated over feed types rather than
+ * over `sys_activity.type` so that one rule covers both paths — the block's own
+ * read AND a feed a host hands it, which arrives already mapped. It is exact
+ * today because `completed` is the only activity type that means "this
+ * finished" and the only one that maps to `task` (see
+ * {@link ACTIVITY_TYPE_TO_FEED_TYPE}, pinned in the tests). A future producer
+ * that emits OPEN tasks makes this coarse, and would need a completion marker
+ * on `FeedItem` before `showCompleted` could stay honest.
+ */
+const COMPLETED_FEED_TYPES = new Set<string>(['task']);
+
+/** A row as `sys_activity` returns it. Loose on purpose: the block reads a
+ *  system table it does not own, and an unknown column is not an error. */
+export interface SysActivityRow {
+  id?: string | number;
+  type?: string;
+  summary?: string | null;
+  timestamp?: string | null;
+  created_at?: string | null;
+  actor_name?: string | null;
+  actor_avatar_url?: string | null;
+  source_object?: string | null;
+  source_id?: string | number | null;
+  [k: string]: unknown;
+}
+
+/**
+ * Coerce an authored `filterMode` to a value the timeline understands.
+ *
+ * Unknown values fall back to `'all'` rather than being passed through: a
+ * `<Select>` handed a value with no matching item renders blank and the
+ * dropdown reads as broken. Same posture as objectui#3151 — an unrecognised
+ * filter token is skipped, never turned into a filter that can't match.
+ */
+export function normalizeFilterMode(value: unknown): FeedFilterMode {
+  return typeof value === 'string' && FILTER_MODE_VALUES.includes(value)
+    ? (value as FeedFilterMode)
+    : 'all';
+}
+
+/** Keep only the `types` entries the spec actually defines. */
+export function normalizeFeedTypes(value: unknown): FeedItemType[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const kept = value.filter(
+    (v): v is FeedItemType => typeof v === 'string' && FEED_ITEM_TYPE_VALUES.includes(v),
+  );
+  return kept.length > 0 ? kept : undefined;
+}
+
+/** Coerce `limit` to a positive integer, falling back to the spec default. */
+export function normalizeLimit(value: unknown): number {
+  const n = Math.floor(Number(value));
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_ACTIVITY_LIMIT;
+}
+
+/**
+ * Timestamp of a `sys_activity` row.
+ *
+ * Prefers the explicit `timestamp` column but tolerates older rows where the
+ * driver leaked the literal default `"NOW()"` — `created_at` is always a real
+ * ISO date. Copied from `RecordDetailView`'s merge for the same reason the
+ * type map is: same rows, same quirk.
+ */
+export function activityTimestamp(row: SysActivityRow): string {
+  const when = row.timestamp;
+  if (!when || when === 'NOW()' || Number.isNaN(Date.parse(String(when)))) {
+    return String(row.created_at ?? '');
+  }
+  return String(when);
+}
+
+/**
+ * One `sys_activity` row → one {@link FeedItem}, or `null` when the row is not
+ * record activity (see {@link ACTIVITY_TYPE_TO_FEED_TYPE}).
+ */
+export function activityRowToFeedItem(
+  row: SysActivityRow,
+  systemActorLabel: string,
+): FeedItem | null {
+  const feedType = ACTIVITY_TYPE_TO_FEED_TYPE[String(row?.type)];
+  if (!feedType) return null;
+  return {
+    id: row.id as string | number,
+    type: feedType,
+    actor: row.actor_name ?? systemActorLabel,
+    actorAvatarUrl: row.actor_avatar_url ?? undefined,
+    body: row.summary ?? '',
+    createdAt: activityTimestamp(row),
+    // ADR-0052 ActivityPointer: drill from the one-line summary to the rich
+    // source record (a `sys_email` row, a call/meeting task, …).
+    sourceObject: row.source_object ?? undefined,
+    sourceId: (row.source_id ?? undefined) as string | number | undefined,
+  };
+}
+
+/** The subset of `RecordActivityProps` that decides which items survive. */
+export interface FeedConfigFilters {
+  types?: unknown;
+  showCompleted?: unknown;
+  unifiedTimeline?: unknown;
+  limit?: unknown;
+}
+
+export interface AppliedFeed {
+  /** Items to render, newest last (chronological, as the timeline reads). */
+  items: FeedItem[];
+  /** How many items the filters kept before `limit` trimmed the page. */
+  total: number;
+  /** True when `total` exceeds the current page — drives "Load more". */
+  hasMore: boolean;
+}
+
+/**
+ * Apply the block's declared filters to a feed, whatever its source.
+ *
+ * Order matters and is asserted: structural exclusions first
+ * (`unifiedTimeline`, `showCompleted`), then the explicit `types` allow-list,
+ * then pagination — so `limit` counts items the author can actually see.
+ *
+ * `pageSize` is the effective window (`limit` on first render, grown by
+ * "Load more"); it is separate from `config.limit` so paging does not have to
+ * rewrite the authored config.
+ */
+export function applyFeedConfig(
+  items: readonly FeedItem[],
+  config: FeedConfigFilters,
+  pageSize: number,
+): AppliedFeed {
+  let kept = items.slice();
+
+  // `unifiedTimeline: false` — do not mix field changes into the comment
+  // stream. The spec's own wording for the default is "Mix field changes and
+  // comments in one timeline (Airtable style)", so switching it off is
+  // precisely the un-mixing: the panel becomes a discussion stream and the
+  // record's field history stays in `record:history`, where it has its own
+  // block.
+  if (config.unifiedTimeline === false) {
+    kept = kept.filter((i) => i.type !== 'field_change');
+  }
+
+  // `showCompleted` — spec default false, i.e. completed activities are hidden
+  // unless asked for. See COMPLETED_FEED_TYPES for why this reads as a feed
+  // type here.
+  if (config.showCompleted !== true) {
+    kept = kept.filter((i) => !COMPLETED_FEED_TYPES.has(i.type));
+  }
+
+  // `types` — an explicit allow-list of feed item types. Unknown entries are
+  // dropped by normalizeFeedTypes; an all-unknown list is treated as "not
+  // configured" rather than "show nothing", so a typo cannot empty the feed
+  // silently.
+  const types = normalizeFeedTypes(config.types);
+  if (types) {
+    const allowed = new Set<string>(types);
+    kept = kept.filter((i) => allowed.has(i.type));
+  }
+
+  const total = kept.length;
+  const size = Math.max(1, Math.floor(pageSize) || DEFAULT_ACTIVITY_LIMIT);
+  // Newest first when trimming a page, chronological when rendering: the feed
+  // reads oldest→newest, so a page of `size` is the LAST `size` items.
+  const page = total > size ? kept.slice(total - size) : kept;
+  return { items: page, total, hasMore: total > size };
+}
+
+/** Sort a feed chronologically and de-duplicate by id (feeds are append-only). */
+export function mergeFeedItems(...groups: readonly FeedItem[][]): FeedItem[] {
+  const byId = new Map<string, FeedItem>();
+  for (const group of groups) {
+    for (const item of group) byId.set(String(item.id), item);
+  }
+  return Array.from(byId.values()).sort((a, b) => {
+    const ta = a.createdAt ? Date.parse(a.createdAt) : 0;
+    const tb = b.createdAt ? Date.parse(b.createdAt) : 0;
+    return (Number.isNaN(ta) ? 0 : ta) - (Number.isNaN(tb) ? 0 : tb);
+  });
+}


### PR DESCRIPTION
Fixes #3165

## 问题

`record:activity` 注册时声明了 11 个输入(`types` / `filterMode` / `showFilterToggle` / `limit` / `showCompleted` / `unifiedTimeline` / `showCommentInput` / `enableMentions` / `enableReactions` / `enableThreading` / `showSubscriptionToggle`),全部是同一个 feed 上的过滤器和开关——而那个 feed 在任何路径上都恒为空:`RecordActivityRenderer` 调了 `useRecordContext()` 却丢掉结果,渲染时把 `RecordActivityTimeline` 的 `items` 写死成空数组;底层组件的 `items` 是 prop,自己从不取数;也没有宿主在喂它(`buildDefaultPageSchema` 发出的节点不带任何 props)。声明了、发布进 `sdui.manifest.json`、运行时什么都没有——objectstack#4413 的形状。

## 修法

### 读路径:三个来源,按优先级

1. **节点上的 `items`** —— 宿主已经拥有 feed 时直接传进来(与 `record:history` 的 `entries` 同一约定);
2. **已挂载的 `DiscussionContext`** —— app-shell `RecordDetailView` 在这里放了合并好的 `sys_comment` + `sys_activity` feed **以及**写路径 handler。有它就呈现宿主的 feed,不再自己去取一份更差的副本;
3. **自取数** —— 否则从 `sys_activity` 按当前记录取(`{ object_name, record_id }`,`timestamp desc`,每页 `limit` 行,"Load more" 重新取更宽的窗口)。这条正是让 block 可以随处放置(手写 `page:tabs` 里、没有宿主喂)的那条,镜像 `record:history` 已有的路径。

行到 `FeedItem` 的映射与 `RecordDetailView` 完全一致(`created`/`updated`/`deleted`/`assigned`/`shared` → `field_change`,`completed` → `task`,`system` → `system`;`commented`/`mentioned` 跳过,内容在 `sys_comment`;`login`/`logout` 不是记录活动),两个界面对"一行是什么"不会出现两种读法。

### 读侧输入真正参与过滤

过滤规则集中在新的纯模块 `recordActivityFeed.ts`,不带 DOM 也能断言——因为这个 issue 的缺陷正是"声明了没人读",而"面板渲染出了东西"恰恰是那段时间里一直绿着的证据。

- `types`:feed item 类型白名单。无法识别的条目忽略;整份都是错拼时按"没配"处理,而不是把 feed 清空。
- `limit`:每页条数,同时限制 `sys_activity` 的取数窗口。
- `showCompleted`:spec 默认 `false`,即默认隐藏已完成活动。
- `unifiedTimeline`:`false` 时把字段变更从评论流里拆出去(spec 对默认值的原话是 "Mix field changes and comments in one timeline",取反即为不混),面板变成纯讨论流,字段历史留在 `record:history`。
- `filterMode`:决定下拉框初始停在哪一档,用户仍可切换;无法识别的值回落到 `all`,而不是留一个匹配不到任何项的 Select(与 #3151 的处置一致)。
- `showFilterToggle`:显隐该下拉框。

### 写侧开关接到宿主的 handler

`showCommentInput` / `enableThreading` / `enableReactions` / `enableMentions` 从 `DiscussionContext` 读 `onAddComment` / `onAddReply` / `onToggleReaction` / `mentionSuggestions`——与 `record:discussion` 同样的站位。**没有宿主时 feed 保持只读、不渲染输入框**,而不是给一个打了字就被丢掉的编辑器。(本包拿不到当前用户,无法自行写 `sys_comment`,所以写路径只能走宿主。)

### `showSubscriptionToggle`:明确记为已知空档

铃铛需要一个 `RecordSubscription` 值和落库的地方,而平台根本没有记录订阅的后端对象可读可写。因此:

- 输入声明的 description 改成 `NOT IMPLEMENTED — no record-subscription backend exists yet…`,**这段文字会进 `sdui.manifest.json`**,AI 作者在写这个 prop 之前就会读到;
- 文档同样写明;
- 一条测试把它钉成"渲染不出任何东西",等哪天订阅后端落地,这条测试会红,注册处那句 NOT IMPLEMENTED 必须跟着删。

不留成"看起来能配"——那正是本 issue 的成因。

### 台账销账

`apps/console/src/__tests__/record-block-record-reach.test.tsx` 的 `NO_RECORD_REACH` 条目已删除。台账是双向断言的,现在探针把 `record:activity` 报成 "responds to the bound record"。

## 验证

```
$ pnpm exec vitest run packages/plugin-detail --maxWorkers=2
 Test Files  36 passed (36)
      Tests  345 passed (345)

$ pnpm exec vitest run packages/plugin-detail/src/renderers/__tests__/record-activity.test.tsx \
    packages/plugin-detail/src/renderers/__tests__/recordActivityFeed.test.ts
 Test Files  2 passed (2)
      Tests  38 passed (38)          # 新增:21 渲染器 + 17 纯规则

$ pnpm exec vitest run apps/console/src/__tests__/record-block-record-reach.test.tsx --reporter=verbose
 ✓ record:* blocks — the bound record reaches the output (objectui#3149) > record:activity responds to the bound record 1640ms
 ✓ record:* blocks — the bound record reaches the output (objectui#3149) > record:discussion is unmoved by the bound record (ledgered) 1595ms
 Test Files  1 passed (1)
      Tests  13 passed (13)

$ pnpm exec vitest run apps/console/src/__tests__/public-contract.test.ts \
    apps/console/src/__tests__/public-block-binding-reach.test.tsx \
    packages/core/src/registry packages/types/src/__tests__/p1-spec-alignment.test.ts
 Test Files  7 passed (7)
      Tests  156 passed (156)

$ cd packages/plugin-detail && npx tsc --noEmit
TYPECHECK_OK
```

> 注:`turbo run type-check --filter=@object-ui/plugin-detail` 会报 `Cannot find module '@object-ui/permissions'` —— 这是既有的依赖图缺口(该包在 `peerDependencies` 里但不在 `devDependencies`,`^build` 因此不构建它),与本次改动无关;先构建 `@object-ui/permissions` 后 `tsc --noEmit` 干净通过。

## 变更文件

- `packages/plugin-detail/src/renderers/record-activity.tsx` —— 取数 + 优先级 + 开关接线
- `packages/plugin-detail/src/renderers/recordActivityFeed.ts`(新)—— 行映射与过滤管线(纯函数)
- `packages/plugin-detail/src/index.tsx` —— 输入声明:补默认值、`filterMode` 收成 enum、每条 description 说清依赖什么,`showSubscriptionToggle` 标 NOT IMPLEMENTED
- `apps/console/src/__tests__/record-block-record-reach.test.tsx` —— 销台账
- `content/docs/plugins/plugin-detail.mdx` —— 新增 `record:activity` block 一节
- `.changeset/record-activity-feed-has-a-source.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA