### PR TITLE
fix(plugin-detail): 取数中的活动 feed 显示加载态,而不是"暂无活动" (#3205)

### DIFF
--- a/.changeset/activity-timeline-loading-state.md
+++ b/.changeset/activity-timeline-loading-state.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/plugin-detail": patch
+---
+
+A fetching activity feed says "loading", not "No activity recorded" (objectui#3205).
+
+`RecordActivityTimeline` declared a `loading` prop and destructured it straight
+into `_loading`, so nothing in the component ever read it. For the whole
+duration of a feed fetch the panel therefore rendered the empty state — "No
+activity recorded" — and then contradicted itself when the rows landed. The
+empty copy is a factual claim about the record; it may only be made once the
+fetch that would fill the feed has settled.
+
+The timeline now branches on `loading` **before** the empty branch and renders a
+spinner row (`role="status"`, `aria-live="polite"`) while the feed is in flight.
+`collapseWhenEmpty` does not suppress it: that flag is about the empty state
+("collapse when there are no items"), and mid-fetch it is not yet known whether
+there are items.
+
+The guard is `loading && filtered.length === 0`, not `loading` alone — a refresh
+or a "Load more" round-trip keeps the rows already on screen instead of blanking
+them (that button carries its own spinner).
+
+No prop or signature changed: the fix is that the declared prop is now read.
+`record:activity` has computed a live `loading` since objectui#3165 (true during
+its self-fetch) and `RecordChatterPanel` already forwarded it in both positions,
+so the whole chain now shows a loading state end to end.

--- a/packages/plugin-detail/src/RecordActivityTimeline.tsx
+++ b/packages/plugin-detail/src/RecordActivityTimeline.tsx
@@ -51,7 +51,9 @@ export interface RecordActivityTimelineProps {
   hasMore?: boolean;
   /** Called when user wants to load more items */
   onLoadMore?: () => void | Promise<void>;
-  /** Loading state */
+  /** Whether the feed is still being fetched. While true and nothing is on
+   *  screen yet, the timeline shows a loading row instead of the empty state
+   *  — "still fetching" is not "no activity" (objectui#3205). */
   loading?: boolean;
   /** Called when a comment is submitted */
   onAddComment?: (text: string, attachments?: Attachment[]) => void | Promise<void>;
@@ -172,7 +174,7 @@ export const RecordActivityTimeline: React.FC<RecordActivityTimelineProps> = ({
   onFilterChange,
   hasMore = false,
   onLoadMore,
-  loading: _loading = false,
+  loading = false,
   onAddComment,
   onAddReply,
   onToggleReaction,
@@ -370,8 +372,30 @@ export const RecordActivityTimeline: React.FC<RecordActivityTimelineProps> = ({
           />
         )}
 
-        {/* Timeline */}
-        {filtered.length === 0 ? (
+        {/* Timeline.
+            The loading branch comes FIRST because "still fetching" and "no
+            activity" are different answers, and only one of them is true
+            while the feed is in flight (objectui#3205). Until this branch
+            existed the panel spent every fetch asserting the record had no
+            activity, then contradicted itself when the rows arrived.
+            `collapseWhenEmpty` does not suppress it: that flag is about the
+            EMPTY state ("collapse when there are no items"), and during a
+            fetch we do not yet know whether there are items.
+            Note the guard is `filtered.length === 0`, not `loading` alone —
+            a refresh or a "Load more" round-trip must not blank a feed that
+            is already on screen (that would lose the reader's position, and
+            "Load more" carries its own spinner). */}
+        {loading && filtered.length === 0 ? (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="activity-loading"
+            className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground"
+          >
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>{t('detail.loading')}</span>
+          </div>
+        ) : filtered.length === 0 ? (
           collapseWhenEmpty ? null : (
             <DataEmptyState
               title={emptyLabel ?? t('detail.noActivity')}

--- a/packages/plugin-detail/src/__tests__/RecordActivityTimeline.loading.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordActivityTimeline.loading.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * "Fetching" is not "empty" (objectui#3205).
+ *
+ * `RecordActivityTimeline` declared a `loading` prop and destructured it into
+ * `_loading`, so nothing in the file ever read it: for the whole duration of a
+ * feed fetch the panel rendered `DataEmptyState` — "No activity recorded" — and
+ * then contradicted itself when the rows landed. The empty copy is a factual
+ * claim about the record; it may only be made once the fetch that would fill
+ * the feed has settled.
+ *
+ * The three layers of the chain are pinned separately, because the bug lived
+ * at exactly one of them while the other two were already correct:
+ *   1. the timeline reads the prop at all;
+ *   2. `RecordChatterPanel` forwards it (both positions — sidebar and inline);
+ *   3. `record:activity` computes a live one (#3165) and the block therefore
+ *      shows the loading row, not the empty copy, while its own fetch is in
+ *      flight.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { RecordContextProvider } from '@object-ui/react';
+import type { FeedItem } from '@object-ui/types';
+import { RecordActivityTimeline } from '../RecordActivityTimeline';
+import { RecordChatterPanel } from '../RecordChatterPanel';
+import { RecordActivityRenderer } from '../renderers/record-activity';
+
+const EMPTY_ACTIVITY = 'No activity recorded';
+const EMPTY_COMMENTS = 'No comments yet';
+const LOADING = 'Loading...';
+
+const ITEMS: FeedItem[] = [
+  {
+    id: 'act-1',
+    type: 'comment',
+    actor: 'Ada',
+    body: 'Already on screen',
+    createdAt: '2026-01-02T00:00:00.000Z',
+  },
+];
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('RecordActivityTimeline — loading is read, not discarded', () => {
+  it('shows a loading row instead of the empty state while the feed is fetching', () => {
+    render(<RecordActivityTimeline items={[]} loading />);
+
+    expect(screen.getByTestId('activity-loading')).toBeTruthy();
+    expect(screen.getByRole('status')).toBeTruthy();
+    expect(screen.getByText(LOADING)).toBeTruthy();
+    // The regression itself: no "this record has no activity" claim mid-fetch.
+    expect(screen.queryByText(EMPTY_ACTIVITY)).toBeNull();
+  });
+
+  it('shows the empty state once loading has settled with no items', () => {
+    render(<RecordActivityTimeline items={[]} loading={false} />);
+
+    expect(screen.getByText(EMPTY_ACTIVITY)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('defaults to the empty state when no host passes `loading` at all', () => {
+    render(<RecordActivityTimeline items={[]} />);
+
+    expect(screen.getByText(EMPTY_ACTIVITY)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('honours a custom `emptyLabel` only after the fetch settles', () => {
+    const view = render(
+      <RecordActivityTimeline items={[]} loading emptyLabel={EMPTY_COMMENTS} />,
+    );
+    expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+
+    view.rerender(
+      <RecordActivityTimeline items={[]} loading={false} emptyLabel={EMPTY_COMMENTS} />,
+    );
+    expect(screen.getByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('keeps a feed that is already on screen instead of blanking it on refresh', () => {
+    // A refresh / "Load more" round-trip must not replace the rows the reader
+    // is looking at with a spinner — hence the branch is `loading && empty`,
+    // not `loading` alone. ("Load more" carries its own spinner.)
+    render(<RecordActivityTimeline items={ITEMS} loading />);
+
+    expect(screen.getByText('Already on screen')).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+    expect(screen.queryByText(EMPTY_ACTIVITY)).toBeNull();
+  });
+
+  it('still suppresses the empty copy while loading when collapseWhenEmpty is set', () => {
+    // `collapseWhenEmpty` is about the EMPTY state ("collapse when there are
+    // no items"); mid-fetch we do not yet know whether there are items, so the
+    // loading row is what a host asking to collapse-when-empty gets.
+    render(<RecordActivityTimeline items={[]} loading collapseWhenEmpty />);
+
+    expect(screen.getByTestId('activity-loading')).toBeTruthy();
+    expect(screen.queryByText(EMPTY_ACTIVITY)).toBeNull();
+  });
+
+  it('does not mistake a filtered-out feed for a fetch in flight', () => {
+    // Items exist but the active filter excludes them: that is genuinely
+    // empty, not loading.
+    render(
+      <RecordActivityTimeline items={ITEMS} filterMode="tasks_only" loading={false} />,
+    );
+
+    expect(screen.getByText(EMPTY_ACTIVITY)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+});
+
+describe('RecordChatterPanel — the loading pass-through holds end to end', () => {
+  it.each(['right', 'left', 'bottom'] as const)(
+    'forwards loading to the embedded timeline (position: %s)',
+    (position) => {
+      render(
+        <RecordChatterPanel items={[]} config={{ position }} loading />,
+      );
+
+      expect(screen.getByTestId('activity-loading')).toBeTruthy();
+      // The panel overrides the empty copy with its own label — neither
+      // wording may appear mid-fetch.
+      expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+      expect(screen.queryByText(EMPTY_ACTIVITY)).toBeNull();
+    },
+  );
+
+  it('falls through to the panel empty copy once loading settles', () => {
+    render(
+      <RecordChatterPanel items={[]} config={{ position: 'bottom' }} loading={false} />,
+    );
+
+    expect(screen.getByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+});
+
+describe('record:activity — the self-fetch shows loading, never the empty copy', () => {
+  it('renders the loading row while the sys_activity fetch is in flight', async () => {
+    let resolveFind: (value: unknown) => void = () => {};
+    const pending = new Promise((resolve) => {
+      resolveFind = resolve;
+    });
+    const dataSource = { find: vi.fn().mockReturnValue(pending) } as any;
+
+    render(
+      <RecordContextProvider
+        objectName="crm_account"
+        recordId="rec-alpha"
+        data={{ id: 'rec-alpha', name: 'Alpha' }}
+        dataSource={dataSource}
+      >
+        <RecordActivityRenderer schema={{} as any} />
+      </RecordContextProvider>,
+    );
+
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(screen.getByTestId('activity-loading')).toBeTruthy();
+    expect(screen.queryByText(EMPTY_ACTIVITY)).toBeNull();
+
+    resolveFind({
+      data: [
+        {
+          id: 'act-1',
+          type: 'updated',
+          summary: 'Stage: draft to qualified',
+          timestamp: '2026-01-02T00:00:00.000Z',
+          actor_name: 'Grace',
+        },
+      ],
+    });
+
+    expect(await screen.findByText('Stage: draft to qualified')).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+    expect(screen.queryByText(EMPTY_ACTIVITY)).toBeNull();
+  });
+
+  it('shows the empty copy once a fetch settles with no rows', async () => {
+    const dataSource = { find: vi.fn().mockResolvedValue({ data: [] }) } as any;
+
+    render(
+      <RecordContextProvider
+        objectName="crm_account"
+        recordId="rec-alpha"
+        data={{ id: 'rec-alpha', name: 'Alpha' }}
+        dataSource={dataSource}
+      >
+        <RecordActivityRenderer schema={{} as any} />
+      </RecordContextProvider>,
+    );
+
+    expect(await screen.findByText(EMPTY_ACTIVITY)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #3205

## 问题

`RecordActivityTimeline` 的 props 声明了 `loading`,解构时却直接改名丢弃(`loading: _loading = false`),整个文件没有第二处引用。于是 feed 取数的那段时间,面板渲染的是空态 `DataEmptyState`(默认文案 "No activity recorded")——一句关于这条记录的**事实断言**——然后数据到了再自打脸。

空态文案只有在"本该填满 feed 的那次取数已经 settle"之后才是真的。

## 改法

在 `filtered.length === 0` 分支**之前**加 loading 分支,复用文件里已导入的 `Loader2`(`Load more` 用的就是它)。下面的 JSX 标签为绕开 GitHub body 的标签清洗,每个 `<` 后面多留了一个空格:

```tsx
{loading && filtered.length === 0 ? (
  < div role="status" aria-live="polite" data-testid="activity-loading" … >
    < Loader2 className="h-4 w-4 animate-spin" / >
    < span >{t('detail.loading')}< /span >
  < /div >
) : filtered.length === 0 ? (
  /* 空态,原样 */
) : (
  /* 时间线,原样 */
)}
```

两处判断细节,都写在代码注释里:

- **守卫是 `loading && filtered.length === 0`,不是单看 `loading`**。刷新或 "Load more" 的往返期间,已经在屏幕上的行不能被 spinner 顶掉(那会丢掉读者的位置,而且 "Load more" 按钮本身已经有自己的 spinner)。
- **`collapseWhenEmpty` 不抑制 loading 行**。那个 flag 说的是**空态**("没有 items 时折叠"),而取数中我们还不知道有没有 items——"取数中 ≠ 空"正是本 issue 的分界线。

没有新增/修改任何 prop 或签名,也没有新 i18n key(`detail.loading` 已存在):这个修复的全部内容就是"声明了的 prop 终于有人读"。

## 链路确认(端到端)

- `record:activity`:#3165 已经把 `loading` 真实算出来(自取数期间 `fetched === null` 或 `selfLoading` 为 true)并 `loading={loading}` 传下来 —— 信号是活的,本 PR 接上最后一段;
- `RecordChatterPanel`:两处调用(sidebar 与 inline)都已透传 `loading`,已用测试钉住;
- **但**再往上一跳没有信号源:`RecordDetailView` 与 `renderers/record-chatter.tsx` 从不给面板/context 传 `loading`,`feedItems` 的两个 `find` 期间没有任何 loading state。这属于本 issue 之外的宿主侧缺口,已按 Prime Directive #10 单独立 issue:**#3209**(未指派)。

## 测试

新增 `packages/plugin-detail/src/__tests__/RecordActivityTimeline.loading.test.tsx`,按三层分别钉住(bug 只在其中一层,另两层本来就是对的):

1. 组件层:取数中渲染 loading 行且**不**渲染空态文案;settle 后(以及宿主根本不传 `loading` 时)恢复空态;自定义 `emptyLabel` 同理;已有 items 时刷新不清屏;`collapseWhenEmpty` 下依然不出空态文案;被 filter 过滤空 ≠ loading;
2. 面板层:`RecordChatterPanel` 三种 position(`right`/`left`/`bottom`)都把 `loading` 透传到内嵌 timeline,`No comments yet` 与 `No activity recorded` 两种文案都不出现;
3. block 层:`record:activity` 自取数在飞期间显示 loading 行,resolve 后显示行、loading 行消失;空结果 settle 后显示空态。

反向验证过这些断言确实钉住了 bug:临时把新分支条件短路成 `false` 后,13 个用例里 **7 个失败**(正是跨三层的那 7 个),恢复后全绿。

```
pnpm exec vitest run --maxWorkers=2 packages/plugin-detail
 Test Files  37 passed (37)
      Tests  358 passed (358)

pnpm exec turbo run type-check --filter=@object-ui/plugin-detail  → tsc --noEmit 退出 0
eslint(改动的两个文件)                                          → 0 errors
```

## Changeset

`.changeset/activity-timeline-loading-state.md`(`@object-ui/plugin-detail: patch`)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA