### PR TITLE
docs(ci): ci-cd-pipeline.md 描述真实存在的体积门禁,并把数字钉到工作流上

### DIFF
--- a/.changeset/ci-cd-pipeline-doc-matches-the-workflow.md
+++ b/.changeset/ci-cd-pipeline-doc-matches-the-workflow.md
@@ -1,0 +1,36 @@
+---
+---
+
+docs: the CI/CD pipeline page describes the bundle-size gates that actually exist
+
+Release-nothing: rewrites `content/docs/guide/ci-cd-pipeline.md` and adds a test
+under `scripts/__tests__/`; no package code changes.
+
+Three claims on that page had drifted away from `.github/workflows/`
+(objectui#3197):
+
+- The console budget was documented as **60 KB** gzip while
+  `performance-budget.yml` enforces `MAX_ENTRY_GZIP_KB=350` — off by 5.8x, and
+  in the direction that matters: at 28.1 KB the entry chunk read as half a
+  budget away from breaching, when it is using 8% of it. Anyone sizing a
+  dependency against this page was reading a ceiling that does not exist.
+- A `size-check.yml` workflow had its own section, triggers and limits table.
+  No such file is in `.github/workflows/`, and `git log --all` finds none ever:
+  the package size report it described has always been a step inside
+  `performance-budget.yml`.
+- That step's 50 / 100 / 150 KB tiers were printed under an **Enforced limits**
+  heading. The step `echo`s them into the markdown report as explanatory text —
+  no comparison, no `exit 1`. Nothing goes red when a package exceeds them.
+
+The last one is the reason this is a bug rather than staleness. A documented
+guardrail that is not implemented is worse than no documentation: it is trusted
+in exactly the moment it fails. The tiers are now labelled advisory in the table
+itself, next to the one limit that really is enforced.
+
+Retyping 350 would have set up the next drift, so the number is pinned instead:
+`scripts/__tests__/ci-cd-pipeline-doc.test.ts` reads `MAX_ENTRY_GZIP_KB` out of
+the workflow, the three tiers out of the `echo` lines, and the workflow
+filenames out of the page's prose, and fails when the page and the YAML
+disagree — including in the direction nobody thinks to check: if the size report
+ever grows a real comparison, the test fails and sends whoever added it back to
+the "advisory only" wording.

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -14,12 +14,12 @@ ObjectUI uses **11 GitHub Actions workflows** to automate testing, quality check
 │                     Push / PR to main/develop                   │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│  ┌──────────┐  ┌──────────────┐  ┌──────────────┐             │
-│  │  ci.yml   │  │ size-check   │  │ performance- │             │
-│  │ (test,    │  │   .yml       │  │ budget.yml   │             │
-│  │  lint,    │  │              │  │              │             │
-│  │  build)   │  │              │  │              │             │
-│  └──────────┘  └──────────────┘  └──────────────┘             │
+│  ┌──────────┐  ┌──────────────┐                                 │
+│  │  ci.yml  │  │ performance- │                                 │
+│  │ (test,   │  │ budget.yml   │                                 │
+│  │  lint,   │  │ (bundle size)│                                 │
+│  │  build)  │  │              │                                 │
+│  └──────────┘  └──────────────┘                                 │
 │                                                                 │
 │  ┌──────────────┐                                              │
 │  │  labeler.yml │                                              │
@@ -75,31 +75,50 @@ Uses: Node 22, pnpm (via `corepack`), Turbo remote caching.
 ## Performance Budget (`performance-budget.yml`)
 
 **Triggers:** Push and PR when changes touch `packages/`, `apps/console/`, or `pnpm-lock.yaml`.
+Its display name in the checks list is **Bundle Analysis**.
 
-**Enforced limits:**
+### Enforced limit
 
-| Bundle | Max gzip size |
-|--------|---------------|
-| Console main entry | 60 KB |
+Exactly one bundle-size number in this repository is enforced — this one:
+
+| Bundle | Max gzip size | Enforced |
+|--------|---------------|----------|
+| Console main entry (`apps/console/dist/assets/index-*.js`) | **350 KB** (`MAX_ENTRY_GZIP_KB`) | Yes — the step exits non-zero when the entry chunk exceeds it |
+
+> The 350 KB above is **pinned to the workflow**, not retyped from memory:
+> `scripts/__tests__/ci-cd-pipeline-doc.test.ts` reads `MAX_ENTRY_GZIP_KB` out of
+> `.github/workflows/performance-budget.yml` and fails `pnpm test` if this page
+> disagrees with it. Change one and you must change the other — the number cannot
+> drift silently again ([#3197](https://github.com/objectstack-ai/objectui/issues/3197)).
 
 - Builds the console app and measures bundle sizes.
 - Posts a PR comment with the budget report and pass/fail status — but **only when the bundle was actually measured**. A run that was cancelled (a second push supersedes the first via `cancel-in-progress`) posts nothing, and a run whose build never produced a bundle posts a neutral "not measured" note instead of a verdict. A `FAIL` verdict therefore always carries the measured size that exceeded the budget.
-- The package size report is generated only from a complete package build, so it is never truncated into a report that looks complete.
+- The comment is rendered by `scripts/render-budget-comment.mjs` (unit-tested), not by logic inlined in YAML.
 
-## Size Check (`size-check.yml`)
+### Package size report — advisory, not a gate
 
-**Triggers:** Push to `main`/`develop` with changes in `packages/`.
+The same workflow's `Generate package size report` step writes a markdown table of every
+`packages/*/dist/*.js` file with its raw and gzipped size, and that table is appended to the
+PR comment. The report is generated only from a **complete** package build, so it is never a
+truncated table that looks complete.
 
-**Enforced limits:**
+The step **never compares a measured size against a limit and never exits non-zero** — it
+`echo`s the three tiers below into the report as explanatory text. They are guidance for
+reviewers; exceeding any of them turns no check red and blocks no merge:
 
-| Package Category | Max Size |
-|------------------|----------|
-| Core (`@object-ui/core`) | 50 KB |
-| Components (`@object-ui/components`) | 100 KB |
-| Plugins (`@object-ui/plugin-*`) | 150 KB each |
+| Package category | Advisory target (gzip) | Enforced |
+|------------------|------------------------|----------|
+| Core packages | < 50 KB | **No** — advisory only |
+| Component packages | < 100 KB | **No** — advisory only |
+| Plugin packages | < 150 KB | **No** — advisory only |
 
-- Generates a markdown table with raw and gzipped sizes for each package.
-- Posts the size report as a PR comment.
+> **There is no separate size-check workflow**, and there never has been one in this
+> repository — the package size report has always been a step inside
+> `performance-budget.yml`. This page used to document one as its own workflow file,
+> enforcing the three tiers above; both claims were false, which is worse than no
+> documentation because it advertises a guardrail that does not exist. If you want
+> these tiers enforced, add the comparison to the workflow — do not describe it as
+> enforced here.
 
 ## Link Checking (`check-links.yml`)
 

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3197: `content/docs/guide/ci-cd-pipeline.md` described a bundle-size
+ * regime that had not existed for a long time — a 60 KB console budget against a
+ * workflow that enforces 350 KB (5.8x off), a `size-check.yml` workflow that has
+ * never existed in this repository, and three package-size tiers printed under an
+ * **Enforced limits** heading even though the step that emits them compares
+ * nothing and never exits non-zero.
+ *
+ * Prose cannot be trusted to stay in sync with YAML by review alone — the number
+ * had already drifted once and would drift again. So the doc is pinned to the
+ * workflow here: change `MAX_ENTRY_GZIP_KB` (or the advisory tiers, or the set of
+ * workflows the page names) without updating the page and this test fails.
+ *
+ * The dangerous direction is deliberately covered twice. A doc that *understates*
+ * a gate is annoying; a doc that advertises a guardrail the CI does not have is
+ * worse than no doc, because people make size decisions believing something will
+ * stop them. Hence the last block: if anyone ever makes the size report actually
+ * enforce those tiers, this test fails and points at the page that calls them
+ * advisory.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const docPath = path.join(repoRoot, 'content/docs/guide/ci-cd-pipeline.md');
+const workflowPath = path.join(repoRoot, '.github/workflows/performance-budget.yml');
+const workflowDir = path.join(repoRoot, '.github/workflows');
+
+const doc = fs.readFileSync(docPath, 'utf8');
+const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+/**
+ * The `Generate package size report` step body, from its `- name:` line up to the
+ * next step at the same indentation. Scoping matters: the *budget* step legitimately
+ * exits non-zero, and asserting over the whole file would conflate the two.
+ */
+function sizeReportStep(): string {
+  const start = workflow.indexOf('      - name: Generate package size report');
+  expect(start, 'the size-report step must still be named "Generate package size report"').toBeGreaterThan(-1);
+  const rest = workflow.slice(start + 1);
+  const next = rest.indexOf('\n      - name: ');
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe('ci-cd-pipeline.md — enforced console budget', () => {
+  it('quotes the same MAX_ENTRY_GZIP_KB the workflow enforces', () => {
+    const fromWorkflow = workflow.match(/^\s*MAX_ENTRY_GZIP_KB=(\d+)\s*$/m)?.[1];
+    expect(fromWorkflow, 'MAX_ENTRY_GZIP_KB must still be assigned a literal in the workflow').toBeDefined();
+
+    // The doc row that names the constant — the number lives next to it so the
+    // two can never be read apart.
+    const docRow = doc.split('\n').find((line) => line.includes('MAX_ENTRY_GZIP_KB') && line.startsWith('|'));
+    expect(docRow, 'the doc must have a table row naming MAX_ENTRY_GZIP_KB').toBeDefined();
+
+    const fromDoc = docRow!.match(/\*\*(\d+) KB\*\*/)?.[1];
+    expect(
+      fromDoc,
+      `ci-cd-pipeline.md must state the console entry budget as "**${fromWorkflow} KB**"`,
+    ).toBe(fromWorkflow);
+  });
+
+  it('does not leave the superseded 60 KB figure anywhere on the page', () => {
+    expect(doc).not.toMatch(/\b60 ?KB\b/);
+  });
+});
+
+describe('ci-cd-pipeline.md — advisory package size tiers', () => {
+  // `- ✅ Core packages should be < 50KB gzipped`, ×3.
+  const tiersFromWorkflow = [...workflow.matchAll(/should be < (\d+)KB gzipped/g)].map((m) => m[1]);
+  // `| Core packages | < 50 KB | **No** — advisory only |`
+  const advisoryRows = doc.split('\n').filter((line) => /^\|.*\|\s*<\s*\d+ KB\s*\|/.test(line));
+
+  it('lists the same three tiers the workflow echoes into the report', () => {
+    expect(tiersFromWorkflow).toEqual(['50', '100', '150']);
+    expect(advisoryRows.map((row) => row.match(/<\s*(\d+) KB/)![1])).toEqual(tiersFromWorkflow);
+  });
+
+  it('marks every tier as NOT enforced', () => {
+    expect(advisoryRows).toHaveLength(3);
+    for (const row of advisoryRows) {
+      expect(row, `advisory tier row must say it is not enforced: ${row}`).toMatch(/\*\*No\*\*/);
+    }
+    expect(doc).toMatch(/### Package size report — advisory, not a gate/);
+  });
+
+  it('is telling the truth: the size-report step compares nothing and cannot fail', () => {
+    // The inverse pin. If someone turns the tiers into a real gate, this fails —
+    // which is the moment the "advisory only" wording above must be rewritten.
+    const step = sizeReportStep();
+    expect(step).not.toMatch(/\bexit 1\b/);
+    expect(step).not.toMatch(/\b(50|100|150)\b\s*\)?\s*(?:\]\]|\))?\s*(?:&&|\|\||;|then)/);
+    expect(step).not.toMatch(/-(gt|lt|ge|le)\s/);
+  });
+});
+
+describe('ci-cd-pipeline.md — workflow inventory', () => {
+  const workflowFiles = new Set(fs.readdirSync(workflowDir).filter((f) => f.endsWith('.yml')));
+
+  it('never names a workflow file that does not exist', () => {
+    // Fenced blocks are excluded: the ASCII overview box wraps filenames across
+    // lines (`performance-` / `budget.yml`), which no filename scan can read.
+    const prose = doc.replace(/```[\s\S]*?```/g, '');
+    // Skip path-qualified mentions (`.github/labeler.yml` is the labeler *config*,
+    // not the workflow of the same name).
+    const named = new Set([...prose.matchAll(/(?<![\w/.-])([a-z0-9][a-z0-9-]*\.yml)\b/g)].map((m) => m[1]));
+
+    expect(named.size).toBeGreaterThan(5);
+    for (const name of named) {
+      expect(workflowFiles, `ci-cd-pipeline.md documents ${name}, which is not in .github/workflows/`).toContain(name);
+    }
+  });
+
+  it('does not resurrect the never-existent size-check.yml', () => {
+    // Checked over the whole file, fences included — the stale claim lived in the
+    // ASCII overview box as well as in its own section. (The page may still say
+    // the words "size-check" while denying that such a workflow exists; what it
+    // must never do again is name the file.)
+    expect(doc).not.toMatch(/size-check\.yml/);
+    expect(workflowFiles).not.toContain('size-check.yml');
+  });
+});


### PR DESCRIPTION
Fixes #3197

仅文档 + 一个新测试文件。**没有改动任何工作流行为** —— `#3152` 今天刚改过 `performance-budget.yml`,本分支基于刚拉取的 `origin/main`(`dd06bcd`),描述的是它当前的行为。

## 改了什么

`content/docs/guide/ci-cd-pipeline.md` 里描述 bundle 体积门禁的两节,三处事实错误全部修掉:

| # | 原文 | 实际 | 处理 |
|---|------|------|------|
| 1 | Console 主入口预算 **60 KB** | `MAX_ENTRY_GZIP_KB=350` | 改成 350 KB,**并钉住**(见下) |
| 2 | 有独立一节记录 `size-check.yml` | `.github/workflows/` 下没有这个文件,`git log --all` 也查不到它曾经存在 | 删掉该节 + ASCII 总览图里的方框;包体积报告并入 Performance Budget 一节 |
| 3 | 50/100/150 KB 三档列在 **Enforced limits** 下 | 那一步只是把三行 `echo` 进 markdown 报告,没有比较、没有 `exit 1` | 独立子节「advisory, not a gate」,表格逐行标注 **No — advisory only** |

第 3 条才是这算 bug 而不只是过期的原因:**声明了却没强制的护栏比没有护栏更糟**,因为它恰好在失效的那一刻被信任。现在三档与真正强制的那一条并排,一眼能分辨哪个会让检查变红。

顺带把 `performance-budget.yml` 在 checks 列表里的显示名(**Bundle Analysis**)写进去 —— 按文档标题去 checks 里找 "Performance Budget" 是找不到的。

## 关于 PM 裁决里的「优先做成机制,而不是又抄一遍数字」

重新抄一遍 350 只会埋下第三次漂移,所以做成了机制。仓库里现成的钩子就够用:`scripts/__tests__/` 已经有一个 `performance-budget.yml contract` 测试块(#3152 留下的),把工作流事实钉在 vitest 的 `unit` project 里,而该 project 由 `ci.yml` 的 Test 任务分片跑 —— 已经是 PR 门禁。所以新增 `scripts/__tests__/ci-cd-pipeline-doc.test.ts` 沿用同一条路,不引入任何新工具、新脚本、新 CI 步骤。

它从**源头**读、从文档读、然后比对:

- `MAX_ENTRY_GZIP_KB` ← 工作流;`**350 KB**` ← 文档中提到该常量的那一行表格
- 三档 ← 工作流里 `should be < NNNKB gzipped` 的 `echo` 行;`< NN KB` ← 文档 advisory 表格
- 文档正文里提到的每个 `*.yml` ← 必须真实存在于 `.github/workflows/`(总览图在 fenced block 里,ASCII 方框会把文件名折行,故排除)

以及**反方向**的一条,这条是我认为最值得留的:`Generate package size report` 那一步现在被断言「不含 `exit 1`、不含数值比较」。哪天有人把三档变成真门禁,这条测试会失败 —— 失败信息会把加逻辑的人送回「advisory only」那段措辞前。没有它,文档只是**声称**那三档不强制;有了它,这句声称本身也是被检验的。

### 变异测试(四个方向都验过会红)

| 变异 | 结果 |
|---|---|
| 文档改回 60 KB | `× quotes the same MAX_ENTRY_GZIP_KB the workflow enforces` — `must state the console entry budget as "**350 KB**": expected '60' to be '350'` |
| 工作流常量改成 500,文档不动 | `must state the console entry budget as "**500 KB**": expected '350' to be '500'` |
| 文档重新加回 `size-check.yml` 一节 | `ci-cd-pipeline.md documents size-check.yml, which is not in .github/workflows/` |
| 给 size report 步骤加上 `if [ "$gzip_kb" -gt 150 ]; then exit 1; fi` | `× is telling the truth: the size-report step compares nothing and cannot fail` |

四次变异后均已 `git checkout --` 还原,分支里没有残留。

## 验证

- `npx vitest run --project unit` → **338 files / 4777 passed | 1 skipped**(新增 7 条断言在内)
- 新测试文件单独 `tsc --noEmit --strict`(scripts/ 不在任何 tsconfig 的 include 里,与既有同目录测试一致)→ 无输出
- `npx eslint scripts/__tests__/ci-cd-pipeline-doc.test.ts` → exit 0
- 用站点同款 MDX 编译器(`@mdx-js/mdx` + `remark-gfm`)编译改动后的 `.md` → OK,27337 chars(表格里的 `< 50 KB` 等尖括号安全)
- `node scripts/check-changeset-fixed.mjs` → `✅ All workspace packages are in the changeset fixed group.`

Changeset 为 release-nothing(空 frontmatter),沿用 `.changeset/root-screenshot-dash-flag-ignore.md` 的先例。

## 越界发现(已另立 issue,未夹带进本 PR)

见下方评论中链接的两个 issue —— 同一页面还有别处与实际不符(工作流清单数字 / `ci.yml` 的任务列表),以及一个与本页无关的文档链接检查问题。按 Prime Directive #10 单独记录。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA)_