### PR TITLE
fix(app-shell): flow 分支编辑器新建的边带上 `id`(#3202)

### DIFF
--- a/.changeset/flow-branch-edges-carry-an-id.md
+++ b/.changeset/flow-branch-edges-carry-an-id.md
@@ -1,0 +1,54 @@
+---
+"@object-ui/app-shell": minor
+---
+
+Flow branch editor: an edge it creates carries an `id` (objectui#3202).
+
+The Branches editor on a Decision node creates an out-edge when a branch names a
+Target it has no edge for. That edge shipped with no `id`, while
+`FlowEdgeSchema.id` in `@objectstack/spec` is a required `z.string()` — so the
+designer drew an edge, its own live draft validation (`clientValidation.ts`,
+which parses the draft with `FlowSchema`) immediately flagged
+`edges.N.id: Invalid input: expected string, received undefined`, and saving it
+was a 422 from the server's parse of the same schema. The author had done
+nothing wrong and there is no UI anywhere that can supply a missing edge id.
+
+Created edges now get `uniqueId('edge', …)` — the same minter every other
+edge-creating path in this designer already used (`FlowCanvas`'s `addNode`,
+`insertOnEdge`, and the ADR-0044 revise loop). Ids are drawn from the ids
+already in the flow **plus the ones minted earlier in the same commit**, since
+one apply can create several edges at once and must not mint a number twice.
+
+The gate that would have caught it is now in place: every edge produced by
+`applyDecisionBranches` / `syncDecisionEdgesByOrder`, across create, update,
+retarget, detach and legacy by-order scenarios, must pass
+`FlowEdgeSchema.safeParse`. These functions' output is a **committed** state
+that goes straight to `onPatch` → draft → save, so "the designer's own output is
+spec-legal" is the contract, not a nicety.
+
+**Type change (minor, public):** `FlowDesignerEdge.condition` in
+`views/metadata-admin/previews/flow-canvas-layout` is now the spec's
+`ExpressionInput` — a bare CEL string, or the ADR-0089 envelope whose `dialect`
+discriminant is **required**. It was `string | { source?: string }`, which
+described an envelope the server rejects and that nothing in this repo has ever
+produced. Code that assigned a `dialect`-less `{ source }` to an edge condition
+no longer compiles; such a condition was already refused at save, so this only
+moves the failure to where it can be fixed. The type is **imported** from
+`@objectstack/spec` rather than restated, so the mirror cannot go stale, and it
+is pinned by compile-time assertions in a project CI actually type-checks
+(`tsconfig.typetests.json`). The two other places that restated the same
+over-wide shape follow: `FlowEdgeInspector` (which only ever commits the
+bare-string form) and `FlowPreview`, whose duplicate declaration is deleted in
+favour of the canvas's own type.
+
+Why the type is part of a bug fix: that over-wide read type already cost a wrong
+defect diagnosis — objectui#3171 was filed against the phantom `{ source }`
+envelope and does not reproduce, while the real spec-rejected shape the designer
+emits was this missing `id`. A type that cannot describe a shape the spec
+rejects cannot send the next reader down that road either.
+
+`uniqueId` also moves from `inspectors/_shared.tsx` to `inspectors/unique-id.ts`
+(re-exported from `_shared`, so every existing import is unchanged) so that pure
+reconciliation modules can share the one minter without dragging React and the
+`@object-ui/components` barrel into their unit tests — measured at 7.4s of
+module load versus 63ms.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
@@ -32,12 +32,24 @@ import { validateExpressionClient } from './expression-validate';
 import { useFlowScope } from './useFlowScope';
 import { VariableTextInput } from './VariableTextInput';
 import { findUnknownRefs, scopeRoots, describeUnknownRefs } from './flow-ref-check';
+import type { ExpressionInput } from '@objectstack/spec/shared';
 
+/**
+ * The selected edge as this panel reads it out of the draft.
+ *
+ * `condition` is the spec's `ExpressionInput`: a bare CEL string, or the
+ * ADR-0089 envelope whose `dialect` discriminant is REQUIRED. It used to be
+ * typed `string | { source?: string }` — an envelope the server's own
+ * `FlowEdgeSchema` rejects. Nothing here ever wrote that shape (this panel only
+ * ever commits the bare-string form, see `patchEdge` below), but the type said
+ * it could, which is how objectui#3171 came to be filed against a defect that
+ * does not reproduce. Mirroring the spec keeps the read side honest (#3202).
+ */
 interface FlowEdge {
   id?: string;
   source: string;
   target: string;
-  condition?: string | { source?: string };
+  condition?: ExpressionInput;
   type?: string;
   label?: string;
   isDefault?: boolean;

--- a/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
@@ -337,17 +337,9 @@ export function moveArray<T>(arr: T[] | undefined, from: number, to: number): T[
 }
 
 /**
- * Generate a snake_case id that doesn't collide with `existing`. Used
- * by Add helpers that need a stable identifier (Flow nodes, App nav,
- * Dashboard widgets) before the user fills in a meaningful name.
- *
- *   uniqueId('node', ['node_1', 'node_3']) -> 'node_2'
+ * The designer's id minter. Its body moved to `./unique-id` (a module with no
+ * React in it) so pure reconciliation modules can share this one minter without
+ * pulling the components barrel into their unit tests — see that file. Re-
+ * exported here because every existing call site imports it from `_shared`.
  */
-export function uniqueId(prefix: string, existing: ReadonlyArray<string | undefined | null>): string {
-  const taken = new Set(existing.filter((x): x is string => typeof x === 'string'));
-  for (let i = 1; i < 10_000; i++) {
-    const candidate = `${prefix}_${i}`;
-    if (!taken.has(candidate)) return candidate;
-  }
-  return `${prefix}_${Date.now()}`;
-}
+export { uniqueId } from './unique-id';

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { FlowEdgeSchema } from '@objectstack/spec/automation';
 import {
   applyDecisionBranches,
   syncDecisionEdgesByOrder,
@@ -73,9 +74,30 @@ describe('applyDecisionBranches — commit reconciliation (#1942)', () => {
       [],
     );
     expect(edges).toEqual([
-      { source: DEC, target: 'n_yes', label: 'Yes', condition: 'amount > 10' },
-      { source: DEC, target: 'n_no', label: 'Else', isDefault: true },
+      { id: 'edge_1', source: DEC, target: 'n_yes', label: 'Yes', condition: 'amount > 10' },
+      { id: 'edge_2', source: DEC, target: 'n_no', label: 'Else', isDefault: true },
     ]);
+  });
+
+  it('mints ids around the ones the flow already uses — and around its own, within one commit (#3202)', () => {
+    // `edge_1` belongs to another node's edge, `edge_2` to this decision's own
+    // (claimed by branch A); the two created edges must dodge both AND each
+    // other — the taken-id set has to grow as this single commit mints.
+    const existing = [
+      { id: 'edge_1', source: 'other', target: 'n0' },
+      edge({ id: 'edge_2', target: 'n1', condition: 'a' }),
+    ];
+    const { edges } = applyDecisionBranches(
+      DEC,
+      [
+        { label: 'A', expression: 'a', target: 'n1' },
+        { label: 'B', expression: 'b', target: 'n2' },
+        { label: 'C', expression: 'c', target: 'n3' },
+      ],
+      existing,
+    );
+    expect(edges.map((e) => e.id)).toEqual(['edge_1', 'edge_2', 'edge_3', 'edge_4']);
+    expect(new Set(edges.map((e) => e.id)).size).toBe(edges.length);
   });
 
   it('updates the existing edge in place, carrying condition/label/default', () => {
@@ -203,5 +225,149 @@ describe('syncDecisionEdgesByOrder — legacy #1927 mirror', () => {
   it('an empty expression clears both guard and default flag', () => {
     const out = syncDecisionEdgesByOrder(DEC, [{ label: 'A' }], [edge({ target: 'n1', condition: 'x', isDefault: true })]);
     expect(out).toEqual([{ source: DEC, target: 'n1', label: 'A' }]);
+  });
+});
+
+/**
+ * The gate (objectui#3202, the one #3171 asked for — pointed at the shape that
+ * actually fails).
+ *
+ * Both reconcilers below produce a COMMITTED edge list: it goes to `onPatch` →
+ * draft → save, is live-validated against `FlowSchema` in `clientValidation.ts`,
+ * and is parsed by the server with this very schema. So "the designer's own
+ * output is spec-legal" is not a nicety, it is the contract — and it is
+ * checkable in one line, which is why it is checked on EVERY edge of EVERY
+ * scenario rather than spot-checked.
+ *
+ * What it caught when written: `applyDecisionBranches` created branch edges with
+ * no `id`, while `FlowEdgeSchema.id` is a required `z.string()` — the designer
+ * drawing an edge it then marks red in its own draft validation, for an author
+ * who did nothing wrong and has no UI to supply the missing id.
+ *
+ * Reading a failure: the INPUT edges of every case are spec-clean, so an issue
+ * reported here is one these functions minted or mangled, never one they were
+ * handed. (`FlowEdgeSchema` is `.strict()`, so a stray extra key on an input
+ * fixture would fail as loudly — keep them spec-shaped.)
+ */
+describe('spec gate — every produced edge satisfies FlowEdgeSchema (#3202)', () => {
+  /** Every schema violation across an edge list, addressed for the failure message. */
+  const violations = (edges: DecisionEdge[]): string[] =>
+    edges.flatMap((e, i) => {
+      const parsed = FlowEdgeSchema.safeParse(e);
+      return parsed.success
+        ? []
+        : parsed.error.issues.map((iss) => `edges[${i}].${iss.path.join('.') || '(root)'}: ${iss.message}`);
+    });
+
+  const CASES: Array<{ name: string; produce: () => DecisionEdge[] }> = [
+    {
+      name: 'applyDecisionBranches — creates every edge from scratch (the #3202 repro)',
+      produce: () =>
+        applyDecisionBranches(
+          DEC,
+          [
+            { label: 'Yes', expression: 'amount > 10', target: 'n_yes' },
+            { label: 'Maybe', expression: 'amount > 5', target: 'n_maybe' },
+            { label: 'Else', expression: 'true', target: 'n_no' },
+          ],
+          [],
+        ).edges,
+    },
+    {
+      name: 'applyDecisionBranches — created default edge (no condition, isDefault)',
+      produce: () => applyDecisionBranches(DEC, [{ label: 'Else', expression: 'true', target: 'n_no' }], []).edges,
+    },
+    {
+      name: 'applyDecisionBranches — mixes creation with update-in-place and retarget',
+      produce: () =>
+        applyDecisionBranches(
+          DEC,
+          [
+            { label: 'A', expression: 'a', target: 'n9' },
+            { label: 'B', expression: 'b', target: 'n2' },
+          ],
+          [{ id: 'edge_1', source: DEC, target: 'n1', condition: 'a', label: 'A' }],
+        ).edges,
+    },
+    {
+      name: 'applyDecisionBranches — detaches a cleared branch, keeps unbound edges',
+      produce: () =>
+        applyDecisionBranches(
+          DEC,
+          [
+            { label: 'A', expression: 'a' },
+            { label: 'Else', expression: 'true', target: 'n2' },
+          ],
+          [
+            { id: 'edge_1', source: DEC, target: 'n1', condition: 'a' },
+            { id: 'edge_2', source: DEC, target: 'n2', isDefault: true },
+            { id: 'edge_3', source: DEC, target: 'n_err', type: 'fault' },
+          ],
+        ).edges,
+    },
+    {
+      name: 'applyDecisionBranches — carries an authored { dialect, source } envelope through',
+      produce: () =>
+        applyDecisionBranches(
+          DEC,
+          [{ label: 'Hot', expression: 'score > 90', target: 'n1' }],
+          [{ id: 'edge_1', source: DEC, target: 'n1', condition: { dialect: 'cel', source: 'score > 90' } }],
+        ).edges,
+    },
+    {
+      name: 'applyDecisionBranches — falls back to the by-order mirror (no targets)',
+      produce: () =>
+        applyDecisionBranches(
+          DEC,
+          [
+            { label: 'A', expression: 'a' },
+            { label: 'Else', expression: 'true' },
+          ],
+          [
+            { id: 'edge_1', source: DEC, target: 'n1' },
+            { id: 'edge_2', source: DEC, target: 'n2' },
+          ],
+        ).edges,
+    },
+    {
+      name: 'syncDecisionEdgesByOrder — stamps guards onto existing edges',
+      produce: () =>
+        syncDecisionEdgesByOrder(
+          DEC,
+          [
+            { label: 'A', expression: 'a' },
+            { label: 'Else', expression: 'true' },
+          ],
+          [
+            { id: 'edge_1', source: DEC, target: 'n_err', type: 'fault' },
+            { id: 'edge_2', source: DEC, target: 'n1' },
+            { id: 'edge_3', source: DEC, target: 'n2', condition: 'stale', isDefault: false },
+            { id: 'edge_4', source: DEC, target: 'n3', type: 'back' },
+          ],
+        ),
+    },
+    {
+      name: 'syncDecisionEdgesByOrder — clears guard and default flag on an empty expression',
+      produce: () =>
+        syncDecisionEdgesByOrder(
+          DEC,
+          [{ label: 'A' }],
+          [{ id: 'edge_1', source: DEC, target: 'n1', condition: 'x', isDefault: true }],
+        ),
+    },
+  ];
+
+  it.each(CASES)('$name', ({ produce }) => {
+    const edges = produce();
+    expect(edges.length).toBeGreaterThan(0);
+    expect(violations(edges)).toEqual([]);
+  });
+
+  it('would have failed before the fix — an id-less edge is a schema violation, not a warning', () => {
+    // Pins WHY the gate above bites: this is exactly the edge the old
+    // `applyDecisionBranches` pushed, and the schema rejects it outright.
+    expect(violations([{ source: DEC, target: 'n_yes', label: 'Yes', condition: 'amount > 10' }])).toEqual([
+      'edges[0].id: Invalid input: expected string, received undefined',
+    ]);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-decision-edges.ts
@@ -32,13 +32,14 @@
  * the `isDefault` edge; otherwise match by condition text, then by label.
  */
 
-import { conditionText } from '../previews/flow-canvas-layout';
+import { conditionText, type FlowDesignerEdge } from '../previews/flow-canvas-layout';
+import { uniqueId } from './unique-id';
 
 export interface DecisionEdge {
   id?: string;
   source: string;
   target: string;
-  /** CEL guard — a bare string or the spec's `{ dialect, source }` shape. */
+  /** CEL guard — a bare string or the spec's `{ dialect, source }` envelope. */
   condition?: unknown;
   label?: string;
   isDefault?: boolean;
@@ -48,7 +49,7 @@ export interface DecisionEdge {
 
 /** `conditionText` narrowed for the loose `unknown` condition this module carries. */
 const condText = (c: unknown): string | undefined =>
-  conditionText(c as string | { source?: string } | undefined);
+  conditionText(c as FlowDesignerEdge['condition']);
 
 /** A branch row as committed by the editor (freeform per the spec config). */
 export type DecisionBranch = Record<string, unknown>;
@@ -183,6 +184,17 @@ export function withBranchTargets(
  * AND binding, exact target, binding alone (a retarget keeps the edge's
  * identity and extra keys) — unmatched targeted branches create a fresh edge,
  * and a target-less branch detaches (removes) the edge still bound to it.
+ *
+ * Every created edge carries an `id` (objectui#3202). This output is a
+ * COMMITTED state — it goes straight to `onPatch` → draft → save — and the
+ * spec's `FlowEdgeSchema.id` is required, so an id-less edge here is one the
+ * designer draws, marks red in its own live draft validation, and then has the
+ * server reject with a 422, for an author who did nothing wrong. Ids come from
+ * `uniqueId('edge', …)`, the same helper every other edge-creating path in this
+ * designer uses (`FlowCanvas.addNode` / `insertOnEdge` / the revise loop), over
+ * the ids already in the flow PLUS the ones minted earlier in this same commit
+ * — a multi-branch apply creates several edges at once and must not mint the
+ * same id twice.
  */
 export function applyDecisionBranches(
   decisionId: string,
@@ -224,6 +236,9 @@ export function applyDecisionBranches(
   const updated = new Map<number, DecisionEdge>();
   const created: DecisionEdge[] = [];
   const removed = new Set<number>();
+  // Ids already spoken for: every edge in the flow (not just this decision's —
+  // an id is unique per flow), grown with each id minted below.
+  const takenEdgeIds: Array<string | undefined> = edges.map((e) => e.id);
   branches.forEach((b, bi) => {
     const target = branchTarget(b);
     if (target === '') {
@@ -237,8 +252,13 @@ export function applyDecisionBranches(
       return;
     }
     const ei = pairing.get(bi);
-    if (ei !== undefined) updated.set(ei, mirrorBranchOntoEdge({ ...edges[ei], target }, b));
-    else created.push(mirrorBranchOntoEdge({ source: decisionId, target }, b));
+    if (ei !== undefined) {
+      updated.set(ei, mirrorBranchOntoEdge({ ...edges[ei], target }, b));
+      return;
+    }
+    const id = uniqueId('edge', takenEdgeIds);
+    takenEdgeIds.push(id);
+    created.push(mirrorBranchOntoEdge({ id, source: decisionId, target }, b));
   });
 
   const nextEdges = edges

--- a/packages/app-shell/src/views/metadata-admin/inspectors/unique-id.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/unique-id.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `uniqueId` — the designer's one id minter, in a module with no React in it.
+ *
+ * It lives here rather than in `_shared.tsx` (which still re-exports it, so
+ * every existing `from './_shared'` import is untouched) because the id
+ * convention is needed by PURE reconciliation modules too — `flow-decision-edges`
+ * mints edge ids on commit (objectui#3202). Importing it from `_shared.tsx`
+ * would drag React, lucide, and the whole `@object-ui/components` barrel into
+ * those modules' node-environment unit tests: measured at 7.4s of module load
+ * versus 63ms, for a helper that is fifteen lines of string arithmetic.
+ *
+ * One minter, not two: a second local id generator is how two paths end up
+ * disagreeing about what a fresh id looks like.
+ */
+
+/**
+ * Generate a snake_case id that doesn't collide with `existing`. Used
+ * by Add helpers that need a stable identifier (Flow nodes, Flow edges, App
+ * nav, Dashboard widgets) before the user fills in a meaningful name.
+ *
+ *   uniqueId('node', ['node_1', 'node_3']) -> 'node_2'
+ *
+ * `existing` tolerates holes (`undefined` / `null`) so callers can pass a raw
+ * `items.map((i) => i.id)` without pre-filtering.
+ */
+export function uniqueId(prefix: string, existing: ReadonlyArray<string | undefined | null>): string {
+  const taken = new Set(existing.filter((x): x is string => typeof x === 'string'));
+  for (let i = 1; i < 10_000; i++) {
+    const candidate = `${prefix}_${i}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${prefix}_${Date.now()}`;
+}

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -37,7 +37,7 @@ import { uniqueId, appendArray } from '../inspectors/_shared';
 import { t as tr, translateFlowMeta } from '../i18n';
 import { FlowCanvas } from './FlowCanvas';
 import { defaultNodeLabel } from './flow-canvas-parts';
-import { edgeKey } from './flow-canvas-layout';
+import { edgeKey, type FlowDesignerEdge } from './flow-canvas-layout';
 import { NESTED_NODE_KIND, parseNestedNodeId, encodeNestedNodeId } from '../inspectors/flow-nested-selection';
 import { FlowSimulatorPanel } from './FlowSimulatorPanel';
 import { FlowRunsPanel } from './FlowRunsPanel';
@@ -53,15 +53,15 @@ interface FlowNode {
   [k: string]: unknown;
 }
 
-interface FlowEdge {
-  id?: string;
-  source: string;
-  target: string;
-  condition?: string | { source?: string };
-  type?: string;
-  label?: string;
-  isDefault?: boolean;
-}
+/**
+ * This preview reads the draft's edges and hands them straight to
+ * {@link FlowCanvas}, so it reads them as the canvas's own type rather than
+ * restating the shape. It used to restate it — including a `condition` typed
+ * `string | { source?: string }`, an envelope the spec's `FlowEdgeSchema`
+ * rejects for want of `dialect`. Two copies of one shape is how the wrong one
+ * survives being fixed (objectui#3202).
+ */
+type FlowEdge = FlowDesignerEdge;
 
 interface FlowVariable {
   name: string;

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
@@ -10,7 +10,14 @@
  * Coordinate system: top-to-bottom flowchart (mirrors Power Automate /
  * Salesforce Flow Builder). Origin is the top-left of the diagram bounding
  * box after normalization, so every node sits at x >= PADDING, y >= PADDING.
+ *
+ * "Dependency-free" means no RUNTIME dependency: the one import below is a
+ * `import type`, erased at compile time, and it is here precisely so the
+ * designer's edge guard cannot drift from the spec's expression envelope
+ * (see {@link FlowDesignerEdge}).
  */
+
+import type { ExpressionInput } from '@objectstack/spec/shared';
 
 export interface FlowNodeUI {
   x?: number;
@@ -66,21 +73,34 @@ export interface FlowDesignerNode {
  * {@link FlowDesignerNode} for why this is not `@objectstack/spec/automation`'s
  * `FlowEdge`.
  *
- * Two concrete reasons it cannot simply BE the spec's edge: an edge being drawn
- * has no `id` until it is committed (the spec requires one), and this
- * `condition` shape (`string | { source?: string }`) omits the ADR-0089
- * expression envelope's REQUIRED `dialect` discriminant.
+ * The ONE remaining reason it cannot simply BE the spec's edge is `id`: an edge
+ * being DRAWN has no id until it is committed, while the spec requires one.
+ * That is a real mid-edit state (the same layer difference {@link
+ * FlowDesignerNode} describes), and it is the only member here that is wider
+ * than the spec's. It licenses nothing downstream: every edge that reaches a
+ * COMMIT carries an id — objectui#3202 closed the last producer that shipped
+ * one without (`applyDecisionBranches`, whose output goes straight to
+ * `onPatch` → draft → save).
  *
- * That second one is a genuine finding rather than a layering difference: the
- * inspector can build a condition object the server's own `FlowEdgeSchema`
- * would reject. Recorded as a follow-up rather than fixed here, because
- * changing the emitted envelope is a behaviour change — see the PR description.
+ * `condition` used to be spelled `string | { source?: string }`, which dropped
+ * the ADR-0089 expression envelope's REQUIRED `dialect` discriminant. That was
+ * never a layer difference — it was an over-wide READ type describing a shape
+ * the server's own `FlowEdgeSchema` rejects and that nothing in this repo has
+ * ever produced. Its cost was a wrong defect diagnosis (objectui#3171 was filed
+ * against that phantom envelope and does not reproduce). It now mirrors the
+ * spec by IMPORTING `ExpressionInput` rather than restating it, so the mirror
+ * cannot go stale: a type that can no longer describe a spec-rejected condition
+ * cannot mislead the next reader into filing against one either.
+ *
+ * `type` stays `string` deliberately (the spec's is a four-value enum): the
+ * canvas round-trips whatever an authored flow carries, and the inspector's
+ * type picker is what constrains the values an author can write.
  */
 export interface FlowDesignerEdge {
   id?: string;
   source: string;
   target: string;
-  condition?: string | { source?: string };
+  condition?: ExpressionInput;
   type?: string;
   label?: string;
   isDefault?: boolean;

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-designer-edge.types.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-designer-edge.types.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `FlowDesignerEdge.condition` is the spec's expression envelope — pinned at
+ * compile time (objectui#3202).
+ *
+ * The designer's edge guard used to be typed `string | { source?: string }`,
+ * which describes an envelope WITHOUT the ADR-0089 `dialect` discriminant — a
+ * shape the server's own `FlowEdgeSchema` rejects, and one nothing in this repo
+ * has ever produced. An over-wide read type costs something even when no
+ * runtime path exercises it: objectui#3171 was filed as a defect against that
+ * phantom envelope, investigated, and does not reproduce. A type that cannot
+ * DESCRIBE a spec-rejected condition cannot send the next reader down that road
+ * either — which is only true for as long as somebody checks, hence this file.
+ *
+ * The assertions below are the file's entire point, so it is listed in
+ * `packages/app-shell/tsconfig.typetests.json`. Without that listing they would
+ * be commentary: the package's build tsconfig excludes `**\/*.test.ts`, and
+ * vitest erases types before running (objectui#3181 — the same trap
+ * `src/__tests__/spec-symbol-parity.test.ts` documents in its header). The
+ * runtime case at the bottom is real too: it walks an envelope through
+ * `conditionText`, the reader every consumer of this type goes through.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { conditionText, type FlowDesignerEdge } from './flow-canvas-layout';
+import type { ExpressionInput } from '@objectstack/spec/shared';
+
+type Assert<T extends true> = T;
+type Extends<A, B> = [A] extends [B] ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+type Condition = NonNullable<FlowDesignerEdge['condition']>;
+
+describe('FlowDesignerEdge.condition mirrors the spec ExpressionInput', () => {
+  it('is pinned at compile time', () => {
+    // Guard against the probe lying: were either side `any`, every
+    // assignability assertion below would pass while proving nothing
+    // (objectstack#4171 is exactly that failure mode for other symbols).
+    type _SpecNotAny = Assert<Equal<IsAny<ExpressionInput>, false>>;
+    type _LocalNotAny = Assert<Equal<IsAny<Condition>, false>>;
+
+    // Not "compatible with" — the SAME type. Restating the envelope locally is
+    // how the two drift apart again.
+    type _IsExactlyTheSpecType = Assert<Equal<Condition, ExpressionInput>>;
+
+    // The authored shorthand (a bare CEL string) stays authorable…
+    type _StringIsACondition = Assert<Extends<string, Condition>>;
+    // …and the full envelope with its REQUIRED discriminant.
+    type _EnvelopeIsACondition = Assert<Extends<{ dialect: 'cel'; source: string }, Condition>>;
+
+    // The regression itself: a `dialect`-less envelope is no longer expressible.
+    // `FlowEdgeSchema` rejects it, so this type must too.
+    type _DialectlessRejected = Assert<Equal<Extends<{ source: string }, Condition>, false>>;
+    // And `dialect` is closed over the spec's three dialects (`js` was retired
+    // in objectstack#3278) — a free-form string is not a dialect.
+    type _DialectIsClosed = Assert<Equal<Extends<{ dialect: 'sql'; source: string }, Condition>, false>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('reads both spellings at runtime, which is why both must type-check', () => {
+    const bare: FlowDesignerEdge = { source: 'a', target: 'b', condition: 'amount > 10' };
+    const envelope: FlowDesignerEdge = {
+      source: 'a',
+      target: 'b',
+      condition: { dialect: 'cel', source: 'amount > 10' },
+    };
+    expect(conditionText(bare.condition)).toBe('amount > 10');
+    expect(conditionText(envelope.condition)).toBe('amount > 10');
+    // An envelope carrying only a compiled `ast` has no readable source yet
+    // (spec phase M9.2) — the reader says so instead of inventing text.
+    expect(conditionText({ dialect: 'cel', ast: { op: 'gt' } })).toBeUndefined();
+  });
+});

--- a/packages/app-shell/tsconfig.typetests.json
+++ b/packages/app-shell/tsconfig.typetests.json
@@ -52,8 +52,16 @@
   // authors the resolver's OWN local `RawActionParam`, so the resolver only
   // ever agreed with itself — an `ActionParam` annotation that no `tsc` run
   // reads would reproduce exactly that blind spot.
+  //
+  // `views/metadata-admin/previews/flow-designer-edge.types.test.ts` earns its
+  // place through objectui#3202: it pins the flow designer's edge guard to the
+  // spec's `ExpressionInput`, and what it guards against — an envelope missing
+  // the required `dialect` — is a TYPE-level regression only. No runtime path
+  // observes it (the inspector commits bare strings), so unchecked assertions
+  // would leave that tightening declared and unenforced.
   "include": [
     "src/__tests__/spec-symbol-parity.test.ts",
-    "src/utils/resolveActionParams.test.ts"
+    "src/utils/resolveActionParams.test.ts",
+    "src/views/metadata-admin/previews/flow-designer-edge.types.test.ts"
   ]
 }


### PR DESCRIPTION
Fixes #3202

按 issue 上 PM 的裁决交付三件,外加两处在编译期被迫暴露出来的同形状复制。

## 1. 补 `id`(真正的缺陷)

`applyDecisionBranches` 在「某分支填了 Target、但没有可复用的出边」时**新建**一条边,而新建的边不带 `id`;spec 的 `FlowEdgeSchema.id` 是必填 `z.string()`。后果不是静默:`clientValidation.ts` 用 `FlowSchema` 实时校验草稿,作者会立刻看到设计器自己画出来的边被自己标红(`edges.N.id: Invalid input: expected string, received undefined`),保存则被服务端 422 挡下 —— 而作者没做错任何事,UI 里也没有任何地方能补这个 id。

改法沿用仓内既有约定:`uniqueId('edge', …)`(`FlowCanvas` 的 `addNode` / `insertOnEdge` / ADR-0044 revise 回路一直在用)。取号集合 = **整个 flow 已有的边 id** + **本次提交中先前已铸出的 id** —— 一次 apply 可能新建多条边,不累积就会撞号。这一条单列了用例:`edge_1` 被别的节点占着、`edge_2` 被本决策自己的边占着,新建两条必须躲开这两者**以及彼此**。

## 2. 闸门(#3171 正文要的那条,指向真正失败的形状)

`applyDecisionBranches` / `syncDecisionEdgesByOrder` 产出的**每一条**边,在 create / update / retarget / detach / 遗留 by-order 五类场景下都必须通过 `FlowEdgeSchema.safeParse`。这两个函数的输出是**已提交**状态(直接 `onPatch` → draft → 保存),所以「设计器自己的产物合 spec」是契约而非讲究。

闸门确实咬得住:把补 id 那行改回原样后,5 个测试立刻红,报的正是 `edges[N].id: Invalid input: expected string, received undefined`。测试里另有一条把这个失败形状本身钉住,说明闸门为什么会咬。所有用例的**输入**边都是 spec 干净的(`FlowEdgeSchema` 是 `.strict()`),所以这里报出来的问题必然是这两个函数铸出来或改坏的,不会是它们收到的。

## 3. 收紧本地读类型

`FlowDesignerEdge.condition` 从 `string | { source?: string }` 收紧为 spec 的 `ExpressionInput`(裸 CEL 字符串,或 ADR-0089 信封 —— `dialect` 判别式**必填**)。

一处刻意的做法:**import 而不是重写一遍**。裁决里给的形状是 `string | { dialect: ExpressionDialect; source?: string; ast?: unknown }`,但 spec 的对象分支还带一个可选的 `meta`;照抄会让本地类型比 spec **更窄**,一个合法的、带 `meta` 的存量条件就变成描述不出来的形状 —— 那是把「类型撒谎」换了个方向而已。直接 `import type { ExpressionInput }` 两边都对,而且镜像不会随 spec 演进而过期。

这是公共类型变更,按仓库版本政策发 **minor**(changeset 里写明了 breaking 语义)。

**为什么类型收紧属于一个 bug 修复**:这个过宽的类型已经导致过一次错误的缺陷判定 —— #3171 是冲着那个并不存在的 `{ source }` 信封去的,而设计器真正吐出的、spec 会拒的形状是这里缺的 `id`。描述不出「spec 会拒绝的形状」的类型,才不会把下一个读代码的人带到同一条岔路上。

收紧只在类型层面可观测(inspector 只写裸字符串),所以断言必须真的被编译,否则就是「声明了但没执行」。新增的 `flow-designer-edge.types.test.ts` 列进了 `tsconfig.typetests.json`(CI 的 Type Check 会跑)—— 把其中一条断言反过来写,`tsc` 立刻报 `TS2344: Type 'false' does not satisfy the constraint 'true'`。

## 越界的两处(编译器逼出来的,不是顺手扩大范围)

- **`FlowEdgeInspector`**:同形状的第二份声明,裁决里已经点名要一并处理。
- **`FlowPreview`**:同形状的**第三份**,收紧后 `tsc` 直接报错(它把边原样交给 `FlowCanvas`)。这一份是逐字复制的 `FlowDesignerEdge`,所以删掉复制、直接 `type FlowEdge = FlowDesignerEdge` —— 一个形状留两份副本,正是错的那份能躲过修复活下来的方式。
- **`uniqueId` 挪到无 React 的模块**(`inspectors/unique-id.ts`,`_shared` 继续 re-export,所有既有 import 不变):`flow-decision-edges.ts` 是纯模块,从 `_shared.tsx` 引用会把 React / lucide / 整个 `@object-ui/components` barrel 拖进它的 node 环境单测 —— 实测模块加载 **7.4s vs 63ms**。不铸第二个 id 生成器(两个生成器就是两条路对「新 id 长什么样」各执一词的开始),也不让纯模块变重。

## 验证

- `vitest run packages/app-shell packages/core` → **316 个测试文件全绿,3550 passed | 1 skipped**(按施工提醒,`packages/core` 的跨包棘轮一并跑了)。
- `pnpm --filter @object-ui/app-shell type-check`(`tsc --noEmit` + `tsc -p tsconfig.typetests.json`)→ 通过。
- `pnpm --filter @object-ui/app-shell lint` → 0 errors(仅存量 warning)。
- `pnpm type-check:coverage` / `pnpm check:spec-symbols` / `pnpm changeset:check` → 全部通过。

**不在本条范围**:#3172(节点几何 `ui:{x,y}` vs `position`)未触碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA)_