### PR TITLE
fix(app-shell): flow simulator evaluates a `{ dialect, source }` edge guard (#3216)

### DIFF
--- a/.changeset/flow-simulator-reads-the-expression-envelope.md
+++ b/.changeset/flow-simulator-reads-the-expression-envelope.md
@@ -1,0 +1,51 @@
+---
+"@object-ui/app-shell": minor
+---
+
+Flow simulator evaluates an edge guard stored as `{ dialect, source }` (objectui#3216).
+
+A decision's out-edge whose guard is the ADR-0089 expression envelope — say
+`{ dialect: 'cel', source: 'amount > 10' }` — was reported on the debug timeline
+as `Branch has no condition.` and skipped. With `amount = 20` the simulation fell
+through to the default branch (or dead-ended with "No branch matched"), while the
+engine takes that branch at run time. A designer-time debugger that shows a
+different route than the runtime is worse than no debugger, and it is the one
+thing the simulator's own contract forbids: *never silently simulate semantics
+that differ from the runtime*.
+
+The envelope is not an exotic spelling. `ExpressionInputSchema` in
+`@objectstack/spec` is a `ZodPipe`: parsing `condition: 'amount > 10'` **rewrites
+it into** `{ dialect: 'cel', source: 'amount > 10' }`, and `FlowEdgeSchema.condition`
+is that schema. So the shape the simulator could not read is the shape the
+platform itself produces for every authored guard.
+
+Two readers in `previews/simulator/` each hand-rolled `typeof c === 'string' ? c :
+undefined`, while every other consumer in this repo already accepted both
+spellings — `conditionText` (canvas labels, `FlowEdgeInspector`, the Branches↔edges
+reconciliation) and `validateExpressionClient` (the Problems panel). Both now go
+through `conditionText`, so "how an edge guard is read" has exactly one answer.
+Its JSDoc says so, because a fifth hand-rolled copy brings this class of bug
+straight back.
+
+Two behaviours change, both toward the runtime:
+
+- **Decision routing** — a branch guarded by an envelope is now evaluated, and
+  selected when true. The timeline shows the CEL source it ran instead of
+  "no condition". An envelope carrying only a compiled `ast` and no `source`
+  (spec phase M9.2) still reports "no condition": there is nothing to evaluate,
+  and the simulator says so rather than faking a result.
+- **Preflight diagnostics** — `validateFlowDraft` warns that a decision has no
+  default branch when *every* out-edge is guarded. A decision whose guards were
+  envelopes was silently exempt from that warning; it is exactly as able to
+  dead-end, so the warning now appears in the Problems panel and the canvas
+  banner for those flows too.
+
+**Type change:** `SimEdge.condition` is now the spec's `ExpressionInput`,
+**imported** rather than restated — the last copy of the restatement objectui#3202
+removed from `FlowDesignerEdge`. `string | { source?: string }` was wrong in both
+directions at once: too wide, since it describes a `dialect`-less envelope the
+server rejects; too narrow, since excess-property checking then refused the
+canonical envelope written as a literal (`'dialect' does not exist in type
+'{ source?: string }'`) — the one shape a persisted flow actually carries was the
+one shape you could not write down. Compile-time assertions pin it in
+`tsconfig.typetests.json`, the project CI actually type-checks.

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
@@ -457,7 +457,26 @@ export function edgeKey(edge: FlowDesignerEdge, index: number): string {
   return edge.id || `${edge.source}->${edge.target}#${index}`;
 }
 
-/** Human-readable condition text for an edge's optional guard. */
+/**
+ * The CEL source of an edge's optional guard — **the** reader for that field.
+ *
+ * Both authoring spellings resolve here: the bare string, and the ADR-0089
+ * envelope that the spec's `ExpressionInputSchema` normalizes every authored
+ * string INTO at parse time (so the envelope is what a persisted flow carries).
+ * An envelope with only a compiled `ast` and no `source` (spec phase M9.2) has
+ * no readable source yet, and says so rather than inventing text.
+ *
+ * Every consumer of `condition` goes through this function — canvas labels and
+ * the inspector, the Branches↔edges reconciliation in
+ * `inspectors/flow-decision-edges.ts`, AND the simulator (both its decision
+ * routing and its preflight diagnostics). That is deliberate and load-bearing:
+ * "how an edge guard is read" had four hand-rolled answers, two of which
+ * (`simulator/flow-simulator.ts`, `simulator/flow-sim-validate.ts`) accepted
+ * only the bare string and so reported a spec-canonical envelope as "no
+ * condition" — the simulator skipped a branch the engine takes (objectui#3216).
+ * Add a fifth spelling and that class of bug comes straight back; call this
+ * instead.
+ */
 export function conditionText(c: FlowDesignerEdge['condition']): string | undefined {
   if (!c) return undefined;
   if (typeof c === 'string') return c;

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-sim-edge.types.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-sim-edge.types.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `SimEdge.condition` is the spec's expression envelope — pinned at compile
+ * time (objectui#3216).
+ *
+ * This was the LAST copy of the restatement objectui#3202 removed from
+ * `FlowDesignerEdge`: `string | { source?: string }`, a spelling wrong in both
+ * directions at once. Too WIDE, because it describes an envelope with no
+ * `dialect` — a shape the server's `FlowEdgeSchema` rejects outright. Too
+ * NARROW, because excess-property checking then refuses the CANONICAL envelope
+ * written as a literal: `condition: { dialect: 'cel', source }` fails with
+ * "'dialect' does not exist in type '{ source?: string }'", so the one shape a
+ * persisted flow actually carries was the one shape you could not write down.
+ * Both errors come from the same act — writing the shape out by hand instead of
+ * importing it — and correcting it by hand only moves the drift to the next
+ * omitted member (`ast`, `meta`).
+ *
+ * The over-wide half is not academic: the simulator's readers took exactly the
+ * branch that type invited (`typeof c === 'string'`, everything else
+ * `undefined`) and skipped envelope guards the engine evaluates. The assertions
+ * below make the local type incapable of describing either error again.
+ *
+ * The assertions ARE the file, so it is listed in
+ * `packages/app-shell/tsconfig.typetests.json`: the package's build tsconfig
+ * excludes `**\/*.test.ts` and vitest erases types before running
+ * (objectui#3181), so unlisted they would be commentary, not a check.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ExpressionInput } from '@objectstack/spec/shared';
+import type { SimEdge } from '../flow-sim-types';
+import type { FlowDesignerEdge } from '../../flow-canvas-layout';
+
+type Assert< T extends true > = T;
+type Extends< A, B > = [A] extends [B] ? true : false;
+type IsAny< T > = 0 extends 1 & T ? true : false;
+type Equal< A, B > = (< T >() => T extends A ? 1 : 2) extends < T >() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+type Condition = NonNullable< SimEdge['condition'] >;
+
+describe('SimEdge.condition mirrors the spec ExpressionInput', () => {
+  it('is pinned at compile time', () => {
+    // Guard against the probe lying: were either side `any`, every
+    // assignability assertion below would pass while proving nothing.
+    type _SpecNotAny = Assert< Equal< IsAny< ExpressionInput >, false > >;
+    type _LocalNotAny = Assert< Equal< IsAny< Condition >, false > >;
+
+    // Not "compatible with" — the SAME type. Restating it is how they drift.
+    type _IsExactlyTheSpecType = Assert< Equal< Condition, ExpressionInput > >;
+
+    // …and therefore the same type the designer canvas carries, so an edge can
+    // cross from the canvas into the simulator with nothing to reconcile.
+    type _AgreesWithTheCanvas = Assert< Equal< Condition, NonNullable< FlowDesignerEdge['condition'] > > >;
+
+    // The authored shorthand (a bare CEL string) stays authorable…
+    type _StringIsACondition = Assert< Extends< string, Condition > >;
+    // …as does the envelope the spec canonicalises that string INTO — the form
+    // the two readers used to report as "no condition".
+    type _EnvelopeIsACondition = Assert< Extends< { dialect: 'cel'; source: string }, Condition > >;
+    // …including the optional authorship `meta` the old restatement dropped.
+    type _MetaIsACondition = Assert<
+      Extends< { dialect: 'cel'; source: string; meta: { generatedBy: string } }, Condition >
+    >;
+
+    // The over-wide half of the regression: a `dialect`-less envelope is no
+    // longer expressible. `FlowEdgeSchema` rejects it, so this type must too.
+    type _DialectlessRejected = Assert< Equal< Extends< { source: string }, Condition >, false > >;
+    // And `dialect` is closed over the spec's three dialects.
+    type _DialectIsClosed = Assert< Equal< Extends< { dialect: 'sql'; source: string }, Condition >, false > >;
+
+    expect(true).toBe(true);
+  });
+
+  it('accepts the canonical envelope written INLINE — the half `Extends` cannot see', () => {
+    // The assertions above compare types; this one exercises excess-property
+    // checking, which is where the old restatement failed in the NARROW
+    // direction. Under `{ source?: string }` both consts below are compile
+    // errors ("'dialect' does not exist in…"), which is why an edge fixture in
+    // this repo could never spell the shape the spec canonicalises guards into.
+    const guarded: SimEdge = {
+      source: 'd',
+      target: 'hi',
+      condition: { dialect: 'cel', source: 'amount > 10' },
+    };
+    // …including the optional authorship `meta` that a "corrected" restatement
+    // would be the next thing to drop.
+    const annotated: SimEdge = {
+      source: 'd',
+      target: 'hi',
+      condition: { dialect: 'cel', source: 'amount > 10', meta: { generatedBy: 'agent' } },
+    };
+    expect(guarded.condition).toBeTruthy();
+    expect(annotated.condition).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-sim-edge.types.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-sim-edge.types.test.ts
@@ -28,6 +28,8 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { FlowEdgeSchema } from '@objectstack/spec/automation';
+import type { z } from 'zod';
 import type { ExpressionInput } from '@objectstack/spec/shared';
 import type { SimEdge } from '../flow-sim-types';
 import type { FlowDesignerEdge } from '../../flow-canvas-layout';
@@ -40,6 +42,8 @@ type Equal< A, B > = (< T >() => T extends A ? 1 : 2) extends < T >() => T exten
   : false;
 
 type Condition = NonNullable< SimEdge['condition'] >;
+/** An edge as the server PERSISTS it — `FlowEdgeSchema`'s parsed output. */
+type PersistedEdge = z.infer< typeof FlowEdgeSchema >;
 
 describe('SimEdge.condition mirrors the spec ExpressionInput', () => {
   it('is pinned at compile time', () => {
@@ -70,6 +74,13 @@ describe('SimEdge.condition mirrors the spec ExpressionInput', () => {
     type _DialectlessRejected = Assert< Equal< Extends< { source: string }, Condition >, false > >;
     // And `dialect` is closed over the spec's three dialects.
     type _DialectIsClosed = Assert< Equal< Extends< { dialect: 'sql'; source: string }, Condition >, false > >;
+
+    // The whole point, stated end to end: an edge the SERVER hands back is a
+    // thing the simulator accepts, with no reconciliation and no cast. That is
+    // what objectui#3216 was not — the simulator's own input type described a
+    // guard shape the persisted edge never has.
+    type _PersistedEdgeNotAny = Assert< Equal< IsAny< PersistedEdge >, false > >;
+    type _PersistedEdgeIsASimEdge = Assert< Extends< PersistedEdge, SimEdge > >;
 
     expect(true).toBe(true);
   });

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { FlowEdgeSchema } from '@objectstack/spec/automation';
 import { FlowSimulator } from '../flow-simulator';
 import { validateFlowDraft, findCycle } from '../flow-sim-validate';
 import type { SimEdge, SimNode } from '../flow-sim-types';
@@ -11,6 +12,18 @@ const run = (nodes: SimNode[], edges: SimEdge[], seed = {}, mocks = {}) => {
   sim.runToEnd();
   return sim;
 };
+
+/**
+ * An edge as the PLATFORM persists it, not as a test hand-writes it: authoring
+ * input goes through `FlowEdgeSchema`, whose `ExpressionInput` pipe rewrites a
+ * bare guard string into the `{ dialect: 'cel', source }` envelope. So the
+ * envelope is not an exotic spelling the simulator may decline to support — it
+ * is THE canonical persisted form, and a fixture that spells it by hand could
+ * drift from what the spec actually emits. The `SimEdge` return annotation is
+ * load-bearing too: it is a compile-time proof that a spec-parsed edge is a
+ * thing the simulator accepts (objectui#3216).
+ */
+const specEdge = (e: Record<string, unknown>): SimEdge => FlowEdgeSchema.parse(e);
 
 describe('validateFlowDraft', () => {
   it('flags a missing entry node', () => {
@@ -462,5 +475,113 @@ describe('FlowSimulator', () => {
     const jStep = sim.state.steps.find((s) => s.nodeId === 'j')!;
     expect(jStep.status).toBe('skipped');
     expect(jStep.note).toMatch(/not modelled/i);
+  });
+});
+
+/**
+ * objectui#3216 — the simulator reads an edge guard through `conditionText`,
+ * the one reader every consumer of that field goes through.
+ *
+ * Both readers here (`flow-simulator.ts`'s decision routing and
+ * `flow-sim-validate.ts`'s diagnostics) used to accept only a bare string and
+ * return `undefined` for anything else. That made the simulator report
+ * `Branch has no condition.` for — and skip — a branch the ENGINE evaluates
+ * normally, i.e. it silently simulated semantics that differ from the runtime,
+ * which is the one thing the simulator's own contract forbids. The spelling it
+ * could not read is the spelling the platform itself produces (see
+ * {@link specEdge}), so this was never "the simulator supports the shorthand
+ * only"; it was a missing branch in two hand-rolled copies of one read.
+ */
+describe('decision guards in the spec expression envelope (#3216)', () => {
+  const NODES: SimNode[] = [
+    { id: 's', type: 'start' },
+    { id: 'd', type: 'decision' },
+    { id: 'hi', type: 'end' },
+    { id: 'lo', type: 'end' },
+  ];
+  const START: SimEdge = { id: 'e_s', source: 's', target: 'd' };
+
+  /** The decision's recorded evaluation of its out-edge to `target`. */
+  const edgeEval = (sim: FlowSimulator, target: string) => {
+    const step = sim.state.steps.find((x) => x.nodeId === 'd');
+    const found = (step?.edges ?? []).find((x) => x.target === target);
+    if (!found) throw new Error(`decision "d" recorded no evaluation for its edge to "${target}"`);
+    return found;
+  };
+
+  it('the spec canonicalises a bare guard INTO the envelope (premise of this suite)', () => {
+    const edge = specEdge({ id: 'e_hi', source: 'd', target: 'hi', condition: 'amount > 10' });
+    expect(edge.condition).toEqual({ dialect: 'cel', source: 'amount > 10' });
+  });
+
+  it('selects the branch whose envelope guard is true (the issue repro)', () => {
+    const guarded = specEdge({ id: 'e_hi', source: 'd', target: 'hi', condition: 'amount > 10' });
+    const sim = run(NODES, [START, guarded, { id: 'e_lo', source: 'd', target: 'lo', isDefault: true }], { amount: 20 });
+
+    expect(sim.state.visitedNodeIds).toContain('hi');
+    expect(sim.state.visitedNodeIds).not.toContain('lo');
+    const dStep = sim.state.steps.find((x) => x.nodeId === 'd');
+    expect(dStep?.edges?.find((x) => x.selected)?.target).toBe('hi');
+    // The timeline shows the guard it evaluated, not "Branch has no condition."
+    const hiEval = edgeEval(sim, 'hi');
+    expect(hiEval.condition).toBe('amount > 10');
+    expect(hiEval.error).toBeUndefined();
+  });
+
+  it('EVALUATES an envelope guard rather than treating it as always-true', () => {
+    const guarded = specEdge({ id: 'e_hi', source: 'd', target: 'hi', condition: 'amount > 10' });
+    const sim = run(NODES, [START, guarded, { id: 'e_lo', source: 'd', target: 'lo', isDefault: true }], { amount: 5 });
+
+    expect(sim.state.visitedNodeIds).toContain('lo');
+    expect(sim.state.visitedNodeIds).not.toContain('hi');
+    const hiEval = edgeEval(sim, 'hi');
+    // False for the right REASON: the guard ran and was false…
+    expect(hiEval.result).toBe(false);
+    expect(hiEval.condition).toBe('amount > 10');
+    // …not because the reader could not see a condition at all.
+    expect(hiEval.error).toBeUndefined();
+  });
+
+  it('still says "no condition" for an envelope with nothing readable to evaluate', () => {
+    // Spec phase M9.2 will emit `ast`-only envelopes. There is no CEL source to
+    // run, and the simulator's rule is to say so rather than fake a result —
+    // the fix widened the reader, it did not make every object a condition.
+    const astOnly: SimEdge = { id: 'e_hi', source: 'd', target: 'hi', condition: { dialect: 'cel', ast: { op: 'gt' } } };
+    const sim = run(NODES, [START, astOnly, { id: 'e_lo', source: 'd', target: 'lo', isDefault: true }], { amount: 20 });
+
+    const hiEval = edgeEval(sim, 'hi');
+    expect(hiEval.error).toBe('Branch has no condition.');
+    expect(sim.state.visitedNodeIds).toContain('lo');
+  });
+
+  it('reports a dead-ending envelope guard as false, not as an absent condition', () => {
+    const guarded = specEdge({ id: 'e_hi', source: 'd', target: 'hi', condition: 'amount > 10' });
+    const sim = run(NODES, [START, guarded], { amount: 5 });
+
+    expect(sim.state.status).toBe('error');
+    const hiEval = edgeEval(sim, 'hi');
+    expect(hiEval.error).toBeUndefined();
+    expect(hiEval.condition).toBe('amount > 10');
+  });
+
+  // The same under-read, one layer up: `validateFlowDraft` warns when a decision
+  // guards EVERY out-edge and has no default (it may dead-end). Reading only the
+  // bare string made a decision whose guards are envelopes silently exempt.
+  it('warns about a missing default when every guard is an envelope', () => {
+    const v = validateFlowDraft(NODES, [
+      START,
+      specEdge({ id: 'e_hi', source: 'd', target: 'hi', condition: 'amount > 10' }),
+      specEdge({ id: 'e_lo', source: 'd', target: 'lo', condition: 'amount <= 10' }),
+    ]);
+    expect(v.warnings.some((w) => w.nodeId === 'd' && /no default branch/.test(w.message))).toBe(true);
+  });
+
+  it('does not warn when one branch is unguarded (that branch cannot dead-end)', () => {
+    const v = validateFlowDraft(NODES, [
+      START,
+      specEdge({ id: 'e_hi', source: 'd', target: 'hi', condition: 'amount > 10' }),
+      { id: 'e_lo', source: 'd', target: 'lo' },
+    ]);
+    expect(v.warnings.some((w) => w.nodeId === 'd' && /no default branch/.test(w.message))).toBe(false);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/__tests__/flow-simulator.test.ts
@@ -19,9 +19,14 @@ const run = (nodes: SimNode[], edges: SimEdge[], seed = {}, mocks = {}) => {
  * bare guard string into the `{ dialect: 'cel', source }` envelope. So the
  * envelope is not an exotic spelling the simulator may decline to support — it
  * is THE canonical persisted form, and a fixture that spells it by hand could
- * drift from what the spec actually emits. The `SimEdge` return annotation is
- * load-bearing too: it is a compile-time proof that a spec-parsed edge is a
- * thing the simulator accepts (objectui#3216).
+ * drift from what the spec actually emits (objectui#3216).
+ *
+ * The `SimEdge` return annotation states the matching type-level claim, but do
+ * not read it as a proof: `tsc` never sees this file (the package tsconfig
+ * excludes `**\/*.test.ts`, and app-shell's test tree is still TEST_DEBT), and
+ * vitest erases types. The enforced version lives next door in
+ * `flow-sim-edge.types.test.ts`, which IS compiled — `PersistedEdge extends
+ * SimEdge`.
  */
 const specEdge = (e: Record<string, unknown>): SimEdge => FlowEdgeSchema.parse(e);
 

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-types.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-types.ts
@@ -14,6 +14,8 @@
  * "success".
  */
 
+import type { ExpressionInput } from '@objectstack/spec/shared';
+
 export interface SimNode {
   id: string;
   type: string;
@@ -27,7 +29,24 @@ export interface SimEdge {
   id?: string;
   source: string;
   target: string;
-  condition?: string | { source?: string };
+  /**
+   * Optional guard, in the spec's authoring shape: a bare CEL string, or the
+   * ADR-0089 envelope (`{ dialect, source }`) that `ExpressionInputSchema`
+   * normalizes every authored string INTO at parse time — so the envelope is
+   * the form a persisted flow actually carries, not an exotic alternative.
+   *
+   * Imported from the spec rather than restated. The local spelling used to be
+   * `string | { source?: string }`, and a restatement gets it wrong in BOTH
+   * directions at once: too WIDE, because it describes a `dialect`-less
+   * envelope that `FlowEdgeSchema` rejects outright; too NARROW, because
+   * excess-property checking then refuses the canonical envelope written as a
+   * literal (`dialect` "does not exist" on `{ source?: string }`). Correcting
+   * it by hand only moves the drift — the next spelling omits `ast` or `meta`.
+   * objectui#3202 removed the same restatement from `FlowDesignerEdge`; this
+   * was its last copy, and the reason the simulator could not read a guard the
+   * platform itself produces (objectui#3216).
+   */
+  condition?: ExpressionInput;
   isDefault?: boolean;
   label?: string;
   /**

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-sim-validate.ts
@@ -13,10 +13,8 @@
 
 import { ExpressionEvaluator } from '@object-ui/core';
 import type { Diagnostic, FlowValidation, SimEdge, SimNode } from './flow-sim-types';
+import { conditionText } from '../flow-canvas-layout';
 import { t as tr, tFormat } from '../../i18n';
-
-const edgeCondString = (c: SimEdge['condition']): string | undefined =>
-  typeof c === 'string' ? c : undefined;
 
 /** Evaluate a CEL condition, capturing (not swallowing) any failure. */
 export function evalCondition(
@@ -149,9 +147,14 @@ export function validateFlowDraft(nodes: SimNode[], edges: SimEdge[], locale?: s
     if (defaults.length > 1) {
       errors.push({ level: 'error', nodeId: n.id, message: tFormat('engine.flowValidate.decisionMultipleDefaults', locale, { id: n.id, count: defaults.length }) });
     }
+    // "Every branch is guarded" is read through `conditionText`, the same ONE
+    // reader the stepper routes on (objectui#3216) — a decision whose guards
+    // are stored as `{ dialect, source }` envelopes is exactly as capable of
+    // dead-ending as one written with bare strings, and used to be silently
+    // exempt from this warning.
     if (out.length === 0) {
       warnings.push({ level: 'warning', nodeId: n.id, message: tFormat('engine.flowValidate.decisionNoBranches', locale, { id: n.id }) });
-    } else if (defaults.length === 0 && out.every((e) => edgeCondString(e.condition))) {
+    } else if (defaults.length === 0 && out.every((e) => conditionText(e.condition))) {
       warnings.push({ level: 'warning', nodeId: n.id, message: tFormat('engine.flowValidate.decisionNoDefault', locale, { id: n.id }) });
     }
   }

--- a/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/simulator/flow-simulator.ts
@@ -26,6 +26,7 @@ import type {
   SimStepStatus,
 } from './flow-sim-types';
 import { evalCondition, validateFlowDraft } from './flow-sim-validate';
+import { conditionText } from '../flow-canvas-layout';
 
 const MAX_STEPS = 500;
 
@@ -43,7 +44,6 @@ const MOCKED_SIDE_EFFECT = new Set([
 const UNSUPPORTED = new Set(['join_gateway', 'subflow', 'boundary_event', 'parallel', 'try_catch']);
 
 const edgeId = (e: SimEdge, i: number): string => e.id || `${e.source}->${e.target}#${i}`;
-const condStr = (c: SimEdge['condition']): string | undefined => (typeof c === 'string' ? c : undefined);
 const str = (v: unknown): string | undefined => (typeof v === 'string' && v ? v : undefined);
 
 export class FlowSimulator {
@@ -276,9 +276,14 @@ export class FlowSimulator {
     let firstError: string | undefined;
 
     // Evaluate conditional edges in declared order; first truthy wins.
+    // The guard is read through `conditionText` — the ONE reader every consumer
+    // of an edge condition goes through — so both authoring spellings evaluate
+    // here exactly as the engine evaluates them (objectui#3216). Reading only
+    // the bare string used to report a spec-canonical `{ dialect, source }`
+    // envelope as "no condition" and skip a branch the runtime would take.
     for (const { e, i } of out) {
       if (e.isDefault) continue;
-      const cond = condStr(e.condition);
+      const cond = conditionText(e.condition);
       if (!cond) {
         evals.push({ edgeId: edgeId(e, i), target: e.target, result: false, selected: false, error: 'Branch has no condition.' });
         continue;

--- a/packages/app-shell/tsconfig.typetests.json
+++ b/packages/app-shell/tsconfig.typetests.json
@@ -59,9 +59,19 @@
   // the required `dialect` — is a TYPE-level regression only. No runtime path
   // observes it (the inspector commits bare strings), so unchecked assertions
   // would leave that tightening declared and unenforced.
+  //
+  // `views/metadata-admin/previews/simulator/__tests__/flow-sim-edge.types.test.ts`
+  // is the same pin on the SIMULATOR's edge (objectui#3216) — the last copy of
+  // that restatement. Its RUNTIME consequence is covered next door in
+  // `flow-simulator.test.ts` (the simulator skipped envelope guards); what
+  // stays type-only here is the other half of the same mistake, the direction
+  // in which the hand-written shape was too NARROW — excess-property checking
+  // rejected the canonical `{ dialect, source }` literal outright. No test that
+  // vitest runs can observe that, so unlisted it would be commentary.
   "include": [
     "src/__tests__/spec-symbol-parity.test.ts",
     "src/utils/resolveActionParams.test.ts",
-    "src/views/metadata-admin/previews/flow-designer-edge.types.test.ts"
+    "src/views/metadata-admin/previews/flow-designer-edge.types.test.ts",
+    "src/views/metadata-admin/previews/simulator/__tests__/flow-sim-edge.types.test.ts"
   ]
 }


### PR DESCRIPTION
Fixes #3216

## 缺陷

决策节点的一条出边,守卫存成 `{ dialect: 'cel', source: 'amount > 10' }` 时,模拟器在时间线上报 `Branch has no condition.` 并跳过这条分支;变量给 `amount = 20` 也会落到 default 分支或直接死路,而引擎在真实运行时会正常求值这条守卫。

根因是 `previews/simulator/` 里有**两份**手写的读法,都只认裸字符串:

- `flow-simulator.ts` 的 `condStr`
- `flow-sim-validate.ts` 的 `edgeCondString`

信封形式一律返回 `undefined`。

## 为什么信封不是"边角拼写"

`@objectstack/spec` 的 `ExpressionInputSchema` 是一个 `ZodPipe`:parse 时会把裸字符串**改写成** `{ dialect: 'cel', source }`,而 `FlowEdgeSchema.condition` 用的正是它。也就是说,模拟器读不了的那种拼写,恰恰是平台自己对每一条作者写下的守卫产出的那种。仓内其它读同一字段的地方(`conditionText`、`validateExpressionClient`)一直两种都认——漏掉一条分支的只有模拟器这两处。

一个设计时调试器给出的路线和运行时不一致,比没有调试器更糟;而"不静默模拟与运行时不同的语义"正是模拟器自己写在文件头上的契约。

## 改法:收敛到一个读法

两处都改走 `conditionText`(`previews/flow-canvas-layout.ts`),即画布标签、`FlowEdgeInspector`、`inspectors/flow-decision-edges.ts` 的分支匹配已经在走的那一个。**没有新增第三份手写读法**——本 PR 之后,"边守卫怎么读"在本仓只剩一个答案,并且把这一点写进了 `conditionText` 的 JSDoc(第五份手写拷贝会把这一类缺陷原样带回来)。

行为上有两处变化,方向都是向运行时靠拢:

1. **决策路由** —— 信封守卫会被求值,为真时选中该分支;时间线显示它实际执行的 CEL 源码,而不是 "no condition"。只带编译后 `ast`、没有 `source` 的信封(spec 阶段 M9.2)仍然报 "no condition":确实没有可求值的东西,如实说,而不是伪造一个结果。
2. **预检诊断** —— `validateFlowDraft` 的"决策没有 default 分支"警告原先要求每条出边都是裸字符串守卫,守卫是信封的决策被静默豁免。它一样会死路,所以现在问题面板和画布横幅对这类流程也会给出警告。

## 类型

`SimEdge.condition` 改为 `import type` 引入 spec 的 `ExpressionInput` —— 这是 #3202 从 `FlowDesignerEdge` 上摘掉的那份重述的最后一份拷贝。原来的 `string | { source?: string }` 两个方向同时是错的:

- **过宽**:它描述了一个没有 `dialect` 的信封,而服务端 `FlowEdgeSchema` 直接拒绝这种形状;
- **过窄**:正因为如此,多余属性检查会拒掉直接写成字面量的规范信封(`'dialect' does not exist in type '{ source?: string }'`)—— 持久化流程真正携带的那唯一一种形状,反倒是你写不出来的那一种。

所以是**导入**而不是重述:手工"修正"只会把漂移挪到下一个漏掉的成员(`ast`、`meta`)上。

## 测试

- `previews/simulator/__tests__/flow-simulator.test.ts` 新增 `decision guards in the spec expression envelope (#3216)`:边固件不再手写信封,而是把作者输入喂给 `FlowEdgeSchema.parse` —— 断言的就是平台自己产出的形状,固件无法与 spec 漂移。覆盖 issue 正文的复现、"确实求值而不是一律为真"、`ast`-only 信封仍报 no condition、以及 `flow-sim-validate` 少判的那条诊断。
- 新增 `previews/simulator/__tests__/flow-sim-edge.types.test.ts`,并登记进 `tsconfig.typetests.json`(CI 真的会编译的那个 project)。类型断言之外还有一条只有多余属性检查能观察到的:规范信封写成字面量必须能通过。
- **修复前**这些行为断言会失败(逐条验证过):

```
× selects the branch whose envelope guard is true (the issue repro)
    AssertionError: expected [ 's', 'd', 'lo' ] to include 'hi'
× EVALUATES an envelope guard rather than treating it as always-true
    AssertionError: expected undefined to be 'amount > 10'
× reports a dead-ending envelope guard as false, not as an absent condition
    AssertionError: expected 'Branch has no condition.' to be undefined
× warns about a missing default when every guard is an envelope
    AssertionError: expected false to be true
 Test Files  1 failed | 1 passed (2)
      Tests  4 failed | 29 passed (33)
```

  修复后 `Test Files 3 passed (3) / Tests 59 passed (59)`。类型 pin 同样是有效的:把 `flow-sim-types.ts` 回退到 main 后,`tsc -p tsconfig.typetests.json` 在 4 条断言上报 `TS2344: Type 'false' does not satisfy the constraint 'true'`。

## 验证

```
npx turbo run type-check --filter=@object-ui/app-shell --concurrency=2   # 29 tasks successful
npx vitest run --maxWorkers=2 packages/app-shell/src/views/metadata-admin/
#   Test Files 115 passed (115) / Tests 1023 passed | 1 skipped (1024)
npx eslint packages/app-shell/src/views/metadata-admin/previews/simulator  # 0 errors
node scripts/check-spec-symbol-derivation.mjs                              # ✅
```

已加 changeset(`@object-ui/app-shell: minor` —— 行为变更 + 公开类型收紧)。未触碰 `scripts/check-spec-symbol-derivation.mjs`(#3160 正在改该文件),也未触碰 `content/docs/releases/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA)_