### PR TITLE
fix(app-shell): 检查器读写 `{ dialect, source }` 表达式信封 (#3218)

### DIFF
--- a/.changeset/hook-inspector-reads-the-expression-envelope.md
+++ b/.changeset/hook-inspector-reads-the-expression-envelope.md
@@ -1,0 +1,62 @@
+---
+"@object-ui/app-shell": minor
+---
+
+Inspectors read AND write the `{ dialect, source }` expression envelope (objectui#3218).
+
+The Hook inspector's "Run only when (optional CEL)" box rendered **empty** for a
+hook that had a guard. `HookSchema.condition` is `ExpressionInputSchema` — the
+same `ZodPipe` as `FlowEdgeSchema.condition` — so parsing `condition: 'amount > 10'`
+**rewrites it into** `{ dialect: 'cel', source: 'amount > 10' }`. The envelope is
+what a persisted hook carries; the inspector read `typeof draft.condition ===
+'string'` and fell through to `''`.
+
+An empty box is not a cosmetic defect here. `ConditionBuilder.emit` compiles only
+the rows currently on screen, so the author's next edit **replaced** a guard they
+were never shown (clearing it committed `condition: undefined`). Opening the
+panel is safe on its own — `onCommit` fires only on a real edit — but the empty
+box is what induces that edit.
+
+**Read.** Every one of these surfaces now goes through `conditionText`, the one
+reader objectui#3216 settled on, via a shared `expressionSource` /
+`writeExpressionSource` pair. No new `typeof c === 'string'` was written.
+
+**Write.** `source` was the only key the commit path preserved — everything else
+in the envelope was discarded, because the commit sent a bare string and the
+spec's pipe hardcodes `dialect: 'cel'`. Editing one character of a
+`dialect: 'cron'` or `dialect: 'template'` guard silently moved it to a different
+evaluation engine, and dropped `ast` and ADR-0089 `meta` (`rationale` /
+`generatedBy` — the keys AI-authored metadata fills and nobody restores by hand).
+An edit now:
+
+| key | behaviour |
+|:--|:--|
+| `dialect` | **preserved** |
+| `meta` | **preserved** |
+| `source` | replaced |
+| `ast` | **discarded** — it was compiled from the OLD source, so keeping it would leave the engine evaluating the old guard while the UI shows the new one. `objectstack compile` refills it, and `ExpressionSchema`'s `source \|\| ast` refinement still holds. |
+
+With no prior envelope to preserve, the commit stays the bare-string shorthand —
+which the spec's pipe normalizes to exactly `{ dialect: 'cel', source }`, so
+nothing is lost and plain-`string` predicate fields keep round-tripping as
+strings.
+
+Four surfaces were in this family, not one:
+
+- **Hook inspector** — `condition` (the reported defect).
+- **Action inspector** — `visible` and `disabled` (`boolean | ExpressionInput`),
+  same empty-box read.
+- **The generic SchemaForm condition widget** — every predicate-named field
+  (`visible` / `hidden` / `disabled` / `condition` / `predicate` / `*When`) routes
+  here, and it did `String(value)`: an envelope reached the editor as the literal
+  text `[object Object]`.
+- **Object validations panel** — the rule `condition`, plus a third narrow read
+  in the type switcher that dropped a persisted guard on the floor and left the
+  skeleton's never-firing `'false'` in its place. `ValidationRuleDraft.condition`
+  is now `ExpressionInput` instead of `string`.
+
+The flow-edge inspector's **write** is fixed the same way; objectui#3216 had
+converged only its read.
+
+Fixtures in the new tests are authored input fed through `HookSchema.parse` — no
+envelope is hand-written — so they cannot drift from the spec.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
@@ -50,6 +50,7 @@ import { useObjectOptions } from '../previews/useObjectOptions';
 import { useObjectFields } from '../previews/useObjectFields';
 import { useMetaOptions } from '../previews/useMetaOptions';
 import { ConditionBuilder } from './ConditionBuilder';
+import { expressionSource, writeExpressionSource } from './expression-envelope';
 import { IconPickerWidget } from '../widgets';
 
 /* ─────────────── constants ─────────────── */
@@ -464,8 +465,11 @@ export function ActionDefaultInspector({
       {/* 6 ─ Conditions */}
       <div className="border-t pt-3 space-y-3">
         <SectionHeader title="Conditions" hint="No-code predicates over the record / user / ctx (compiled to CEL)." />
-        <ConditionBuilder label="Visible when" value={typeof draft.visible === 'string' ? (draft.visible as string) : ''} onCommit={(v) => onPatch({ visible: v || undefined })} objectName={objectName} disabled={readOnly} />
-        <ConditionBuilder label="Disabled when" value={typeof draft.disabled === 'string' ? (draft.disabled as string) : ''} onCommit={(v) => onPatch({ disabled: v || undefined })} objectName={objectName} disabled={readOnly} />
+        {/* Both are `ExpressionInputSchema` in the spec (`disabled` as
+            `boolean | ExpressionInput`), so a persisted action carries the
+            ADR-0089 envelope — same read/write pair as the hook guard (#3218). */}
+        <ConditionBuilder label="Visible when" value={expressionSource(draft.visible)} onCommit={(v) => onPatch({ visible: writeExpressionSource(draft.visible, v) })} objectName={objectName} disabled={readOnly} />
+        <ConditionBuilder label="Disabled when" value={expressionSource(draft.disabled)} onCommit={(v) => onPatch({ disabled: writeExpressionSource(draft.disabled, v) })} objectName={objectName} disabled={readOnly} />
       </div>
 
       {/* 7 ─ AI exposure */}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowEdgeInspector.tsx
@@ -32,6 +32,7 @@ import { validateExpressionClient } from './expression-validate';
 import { useFlowScope } from './useFlowScope';
 import { VariableTextInput } from './VariableTextInput';
 import { findUnknownRefs, scopeRoots, describeUnknownRefs } from './flow-ref-check';
+import { writeExpressionSource } from './expression-envelope';
 import type { ExpressionInput } from '@objectstack/spec/shared';
 
 /**
@@ -232,11 +233,16 @@ export function FlowEdgeInspector({ selection, draft, onPatch, onClearSelection,
       />
       <div className="space-y-1">
         <Label className="text-xs text-muted-foreground">{t('engine.inspector.flowEdge.condition', locale)}</Label>
+        {/* #3216 converged the READ on `conditionText`; the write stayed a
+            bare string, which the spec's pipe would have re-stamped as
+            `dialect: 'cel'` — silently swapping the engine of a `cron` /
+            `template` guard and dropping its `ast` / `meta`. Same rule as the
+            hook guard now (#3218). */}
         <VariableTextInput
           mode="expression"
           mono
           value={conditionText(edge.condition) ?? ''}
-          onValueChange={(v) => patchEdge({ condition: v || undefined })}
+          onValueChange={(v) => patchEdge({ condition: writeExpressionSource(edge.condition, v) })}
           groups={scopeGroups}
           placeholder={t('engine.inspector.flowEdge.conditionHint', locale)}
           disabled={readOnly || isDefault}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.condition.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.condition.test.tsx
@@ -1,0 +1,172 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#3218 — the Hook inspector's "Run only when" guard must read AND
+ * write the ADR-0089 expression envelope.
+ *
+ * `HookSchema.condition` is `ExpressionInputSchema`, the same pipe
+ * `FlowEdgeSchema.condition` uses: a bare authored string is NORMALIZED at
+ * parse time into `{ dialect: 'cel', source }`, so the envelope is what a
+ * persisted hook actually carries. The inspector used to read
+ * `typeof draft.condition === 'string'`, so a persisted guard rendered EMPTY —
+ * and because `ConditionBuilder.emit` compiles only the rows currently on
+ * screen, the author's next edit REPLACED a guard they were never shown.
+ *
+ * FIXTURE DISCIPLINE (objectui#3216's method): no envelope is hand-written
+ * here. Every fixture is the AUTHORED input fed through `HookSchema.parse`, so
+ * a fixture cannot drift from the spec — if the spec stops normalizing, these
+ * tests change shape with it instead of quietly testing a shape nothing emits.
+ *
+ * The write rule (issue ruling, option B) is what the edit cases pin:
+ *
+ *   | key       | when `source` is edited                                |
+ *   |:----------|:-------------------------------------------------------|
+ *   | `dialect` | PRESERVED (only a value with no prior envelope is 'cel')|
+ *   | `meta`    | PRESERVED (ADR-0089 rationale / generatedBy)            |
+ *   | `source`  | replaced                                               |
+ *   | `ast`     | DISCARDED — derived from the OLD source                |
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { HookSchema } from '@objectstack/spec/data';
+import { HookDefaultInspector } from './HookDefaultInspector';
+
+afterEach(cleanup);
+
+/**
+ * Author a hook the way a user does, parse it with the spec, and hand the
+ * RESULT to the inspector — exactly what the metadata editor loads.
+ */
+function hookDraft(condition: unknown): Record<string, unknown> {
+  return HookSchema.parse({
+    name: 'guard_hook',
+    // '*' keeps ConditionBuilder in raw/no-catalog mode: the guard's read and
+    // write are what is under test, not the field picker's network fetch.
+    object: '*',
+    events: ['beforeInsert'],
+    handler: 'guard_fn',
+    condition,
+  }) as unknown as Record<string, unknown>;
+}
+
+function renderInspector(draft: Record<string, unknown>, onPatch = vi.fn()) {
+  render(
+    <HookDefaultInspector
+      type="hook"
+      name="guard_hook"
+      draft={draft}
+      onPatch={onPatch}
+      readOnly={false}
+      locale={'en-US' as never}
+    />,
+  );
+  return onPatch;
+}
+
+/** The no-code builder's value box for the single parsed row. */
+const rowValueInput = () => screen.getByPlaceholderText('value') as HTMLInputElement;
+/**
+ * The raw-expression editor. CelPredicateField renders a combobox TEXTAREA
+ * (autocomplete host); the panel's Radix selects are combobox buttons.
+ */
+const rawEditor = () =>
+  screen.getAllByRole('combobox').find((el) => el.tagName === 'TEXTAREA') as HTMLTextAreaElement;
+
+describe('HookDefaultInspector — condition envelope (#3218)', () => {
+  it('renders the `source` of an envelope condition instead of an empty box', () => {
+    const draft = hookDraft('amount > 10');
+    // Pin what the platform actually stores, so this test fails loudly if the
+    // spec ever stops normalizing rather than passing on a stale assumption.
+    expect(draft.condition).toEqual({ dialect: 'cel', source: 'amount > 10' });
+
+    renderInspector(draft);
+
+    // The guard is visible: the no-code builder adopted `amount > 10`, so its
+    // value box carries `10` and the compiled preview echoes the whole guard.
+    expect(rowValueInput().value).toBe('10');
+    expect(screen.getByText('amount > 10')).toBeInTheDocument();
+  });
+
+  it('preserves `dialect` and `meta` verbatim across an edit', () => {
+    const draft = hookDraft({
+      dialect: 'cel',
+      source: 'amount > 10',
+      meta: { rationale: 'Only large deals need approval', generatedBy: 'agent:deal-guard' },
+    });
+    const onPatch = renderInspector(draft);
+
+    fireEvent.change(rowValueInput(), { target: { value: '20' } });
+
+    expect(onPatch).toHaveBeenCalledWith({
+      condition: {
+        dialect: 'cel',
+        source: 'amount > 20',
+        meta: { rationale: 'Only large deals need approval', generatedBy: 'agent:deal-guard' },
+      },
+    });
+  });
+
+  it('DISCARDS a stale `ast` on edit (it was compiled from the old source)', () => {
+    const draft = hookDraft({
+      dialect: 'cel',
+      source: 'amount > 10',
+      ast: { op: '>', left: 'amount', right: 10 },
+    });
+    expect((draft.condition as Record<string, unknown>).ast).toBeDefined();
+
+    const onPatch = renderInspector(draft);
+    fireEvent.change(rowValueInput(), { target: { value: '20' } });
+
+    const patched = onPatch.mock.calls.at(-1)![0].condition as Record<string, unknown>;
+    expect(patched.source).toBe('amount > 20');
+    // Keeping it would leave the engine evaluating the OLD guard while the UI
+    // shows the new one. `objectstack compile` refills it.
+    expect(patched).not.toHaveProperty('ast');
+    // Dropping `ast` is safe: `source` is present, so ExpressionSchema's
+    // "one of source | ast" refinement still holds.
+    expect(HookSchema.parse({ ...draft, condition: patched }).condition).toEqual({
+      dialect: 'cel',
+      source: 'amount > 20',
+    });
+  });
+
+  it('keeps a `template` guard on the template dialect (the A/B dividing line)', () => {
+    const draft = hookDraft({ dialect: 'template', source: 'Hello {{record.name}}' });
+    const onPatch = renderInspector(draft);
+
+    // Not simple-CEL, so the builder opens the raw expression editor — which
+    // is also proof the envelope's `source` reached the control.
+    expect(rawEditor().value).toBe('Hello {{record.name}}');
+
+    fireEvent.change(rawEditor(), { target: { value: 'Hello {{record.title}}' } });
+
+    // Committing a bare string here (option A) would have let the spec's pipe
+    // rewrite this guard to `dialect: 'cel'` — a different evaluation engine
+    // for an author who believes they only retyped the text.
+    expect(onPatch).toHaveBeenCalledWith({
+      condition: { dialect: 'template', source: 'Hello {{record.title}}' },
+    });
+  });
+
+  it('still clears the guard to `undefined` when the author empties it', () => {
+    const draft = hookDraft('amount > 10');
+    const onPatch = renderInspector(draft);
+
+    fireEvent.click(screen.getByLabelText('Remove condition'));
+
+    expect(onPatch).toHaveBeenCalledWith({ condition: undefined });
+  });
+
+  it('writes the bare-string shorthand when there was no prior envelope', () => {
+    // A hook authored without a guard: nothing to preserve, so the shorthand
+    // (which the spec's pipe normalizes to `dialect: 'cel'`) is what is sent.
+    const draft = hookDraft(undefined);
+    expect(draft.condition).toBeUndefined();
+
+    const onPatch = renderInspector(draft);
+    fireEvent.click(screen.getByText('Add condition'));
+    // A subject-less row compiles to '', i.e. still no guard.
+    expect(onPatch).toHaveBeenLastCalledWith({ condition: undefined });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.tsx
@@ -37,6 +37,7 @@ import {
 } from './_shared';
 import { useObjectOptions } from '../previews/useObjectOptions';
 import { ConditionBuilder } from './ConditionBuilder';
+import { expressionSource, writeExpressionSource } from './expression-envelope';
 
 /* ─────────────── constants ─────────────── */
 
@@ -251,10 +252,14 @@ export function HookDefaultInspector({
             <InspectorCheckboxField label="Run asynchronously (after commit)" value={draft.async === true} onCommit={(v) => onPatch({ async: v })} disabled={readOnly} />
           </div>
         </div>
+        {/* `HookSchema.condition` is `ExpressionInputSchema`: a persisted hook
+            carries the ADR-0089 envelope, not the authored string. Read and
+            write it through the shared pair so the guard is visible and an
+            edit cannot rewrite its dialect or drop its `meta` (#3218). */}
         <ConditionBuilder
           label="Run only when (optional CEL)"
-          value={typeof draft.condition === 'string' ? (draft.condition as string) : ''}
-          onCommit={(v) => onPatch({ condition: v || undefined })}
+          value={expressionSource(draft.condition)}
+          onCommit={(v) => onPatch({ condition: writeExpressionSource(draft.condition, v) })}
           objectName={conditionObject}
           disabled={readOnly}
         />

--- a/packages/app-shell/src/views/metadata-admin/inspectors/expression-envelope.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/expression-envelope.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#3218 — the ONE read/write pair every inspector uses for an
+ * ADR-0089 expression-shaped metadata value.
+ *
+ * The read delegates to `conditionText` (objectui#3216's single reader) so this
+ * module adds no new spelling of "how an expression is read". What it adds is
+ * the WRITE, which #3216 never had to answer: an inspector edits `source`, and
+ * everything else in the envelope must survive that edit.
+ *
+ * Fixtures are authored input fed through `HookSchema.parse` — never
+ * hand-written envelopes — so they cannot drift from the spec.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HookSchema } from '@objectstack/spec/data';
+import { expressionSource, writeExpressionSource } from './expression-envelope';
+
+/** The `condition` a hook actually carries once the spec has parsed it. */
+function storedCondition(authored: unknown): unknown {
+  return HookSchema.parse({
+    name: 'guard_hook',
+    object: 'lead',
+    events: ['beforeInsert'],
+    handler: 'guard_fn',
+    condition: authored,
+  }).condition;
+}
+
+describe('expressionSource — read (#3218)', () => {
+  it('reads the envelope the spec normalizes an authored string into', () => {
+    const stored = storedCondition('amount > 10');
+    expect(stored).toEqual({ dialect: 'cel', source: 'amount > 10' });
+    // The defect: this used to be '' because the read was bare-string-only,
+    // so the author saw "no condition" on a hook that had one.
+    expect(expressionSource(stored)).toBe('amount > 10');
+  });
+
+  it('reads a bare string unchanged (pre-parse drafts)', () => {
+    expect(expressionSource('amount > 10')).toBe('amount > 10');
+  });
+
+  it('reads nothing readable as the empty string', () => {
+    expect(expressionSource(undefined)).toBe('');
+    expect(expressionSource(null)).toBe('');
+    // `disabled` is `boolean | ExpressionInput` on an action — a boolean is
+    // not an expression and must not be stringified into the editor.
+    expect(expressionSource(true)).toBe('');
+    // An AST-only envelope (spec phase M9.2) has no readable source YET;
+    // `conditionText` says so rather than inventing text.
+    expect(expressionSource(storedCondition({ dialect: 'cel', ast: { op: 'gt' } }))).toBe('');
+    // Never `[object Object]` — the generic SchemaForm condition widget used
+    // to `String(value)` an envelope straight into the editor.
+    expect(expressionSource({ dialect: 'cel', source: 'a > 1' })).not.toContain('object Object');
+  });
+});
+
+describe('writeExpressionSource — write (#3218, ruling option B)', () => {
+  it('preserves `dialect` and `meta`, replaces `source`', () => {
+    const stored = storedCondition({
+      dialect: 'cel',
+      source: 'amount > 10',
+      meta: { rationale: 'large deals only', generatedBy: 'agent:deal-guard' },
+    });
+    expect(writeExpressionSource(stored, 'amount > 20')).toEqual({
+      dialect: 'cel',
+      source: 'amount > 20',
+      meta: { rationale: 'large deals only', generatedBy: 'agent:deal-guard' },
+    });
+  });
+
+  it('keeps a non-cel dialect (the A/B dividing line)', () => {
+    for (const dialect of ['template', 'cron'] as const) {
+      const stored = storedCondition({ dialect, source: 'a' });
+      expect(writeExpressionSource(stored, 'b')).toEqual({ dialect, source: 'b' });
+    }
+  });
+
+  it('DISCARDS `ast` — it is derived from the old source', () => {
+    const stored = storedCondition({
+      dialect: 'cel',
+      source: 'amount > 10',
+      ast: { op: '>', left: 'amount', right: 10 },
+      meta: { generatedBy: 'agent:deal-guard' },
+    });
+    const next = writeExpressionSource(stored, 'amount > 20') as Record<string, unknown>;
+    expect(next).not.toHaveProperty('ast');
+    expect(next).toEqual({
+      dialect: 'cel',
+      source: 'amount > 20',
+      meta: { generatedBy: 'agent:deal-guard' },
+    });
+    // Still spec-valid: ExpressionSchema's refine only needs one of source|ast.
+    expect(
+      HookSchema.parse({
+        name: 'guard_hook', object: 'lead', events: ['beforeInsert'], handler: 'guard_fn',
+        condition: next,
+      }).condition,
+    ).toEqual(next);
+  });
+
+  it('falls back to the bare-string shorthand when there is no prior envelope', () => {
+    // The shorthand IS `dialect: 'cel'` — the spec's pipe normalizes it — so
+    // nothing is lost, and a plain-string field is not handed an object.
+    expect(writeExpressionSource(undefined, 'amount > 10')).toBe('amount > 10');
+    expect(writeExpressionSource('amount > 5', 'amount > 10')).toBe('amount > 10');
+    expect(writeExpressionSource(true, 'amount > 10')).toBe('amount > 10');
+    // An object with no `dialect` is not a valid envelope; treat it as absent
+    // rather than propagating a shape the spec rejects.
+    expect(writeExpressionSource({ source: 'amount > 5' }, 'amount > 10')).toBe('amount > 10');
+  });
+
+  it('clears to `undefined` on an empty source, envelope or not', () => {
+    expect(writeExpressionSource(storedCondition('amount > 10'), '')).toBeUndefined();
+    expect(writeExpressionSource('amount > 10', '')).toBeUndefined();
+    expect(writeExpressionSource(undefined, '')).toBeUndefined();
+  });
+
+  it('does not mutate the draft it was given', () => {
+    const stored = storedCondition({ dialect: 'cel', source: 'amount > 10', ast: { op: 'gt' } });
+    const snapshot = JSON.parse(JSON.stringify(stored));
+    writeExpressionSource(stored, 'amount > 20');
+    expect(stored).toEqual(snapshot);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/expression-envelope.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/expression-envelope.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * expression-envelope — how an inspector READS and WRITES an ADR-0089
+ * expression-shaped metadata value (`hook.condition`, `action.visible` /
+ * `action.disabled`, `validation.condition`, every `*When` predicate …).
+ *
+ * All of those are `ExpressionInputSchema` in `@objectstack/spec`: a bare
+ * authored string is NORMALIZED at parse time into `{ dialect: 'cel', source }`,
+ * so the ENVELOPE — not the string — is what a persisted artifact carries.
+ *
+ * ## Read
+ *
+ * {@link expressionSource} does not decide anything; it delegates to
+ * `conditionText`, the ONE reader objectui#3216 settled on. Adding a second
+ * `typeof c === 'string'` here is precisely the bug class #3216 closed
+ * (four hand-rolled readers, two of which reported a spec-canonical envelope as
+ * "no condition"), so this file deliberately owns no read logic of its own.
+ *
+ * ## Write
+ *
+ * #3216 never had to answer the write side. objectui#3218 did, and the ruling
+ * on that issue is binding — editing `source` must not silently destroy the
+ * rest of the envelope:
+ *
+ * | key       | when `source` is edited                                       |
+ * |:----------|:--------------------------------------------------------------|
+ * | `dialect` | **preserved** — see below                                     |
+ * | `meta`    | **preserved** (ADR-0089 `rationale` / `generatedBy`)          |
+ * | `source`  | replaced with the edited text                                 |
+ * | `ast`     | **discarded** — it was compiled from the OLD source           |
+ *
+ * `dialect` is the load-bearing one. The rejected alternative was "commit a
+ * bare string and let the spec's pipe normalize it", but that pipe hardcodes
+ * `dialect: 'cel'`: a `cron` or `template` guard would come back as `cel` —
+ * the author believes they retyped an expression and has in fact swapped the
+ * evaluation engine. Silent, and it passes schema validation.
+ *
+ * `ast` must go rather than ride along: keeping a stale AST means the engine
+ * evaluates the OLD guard while the UI shows the new source (spec phase M9.2+,
+ * where `ast` becomes the authoritative build output). Dropping it still
+ * satisfies `ExpressionSchema`'s `source || ast` refinement, because `source`
+ * is present; `objectstack compile` refills it.
+ *
+ * With no prior envelope to preserve there is nothing to lose, so the write
+ * emits the bare-string shorthand — which the spec's pipe normalizes to
+ * exactly `{ dialect: 'cel', source }`. That also keeps this helper safe for
+ * the generic SchemaForm condition widget, which serves plain-`string`
+ * predicate fields as well as `ExpressionInput` ones: the shape it was handed
+ * is the shape it hands back.
+ */
+
+import type { ExpressionInput } from '@objectstack/spec/shared';
+import { conditionText } from '../previews/flow-canvas-layout';
+
+/** The object arm of `ExpressionInput` — the envelope itself. */
+type ExpressionEnvelope = Exclude<ExpressionInput, string>;
+
+/**
+ * The editable source text of an expression-shaped value, for a control that
+ * takes a `string` (`ConditionBuilder`, `VariableTextInput`).
+ *
+ * Empty means "nothing readable": absent, a boolean (`action.disabled` is
+ * `boolean | ExpressionInput`), or an AST-only envelope that has no `source`
+ * yet — never a stringified object.
+ */
+export function expressionSource(value: unknown): string {
+  return conditionText(value as ExpressionInput | undefined) ?? '';
+}
+
+/** The prior value as an envelope, or `undefined` when there is none to preserve. */
+function priorEnvelope(value: unknown): ExpressionEnvelope | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  // `dialect` is what makes it an envelope: the spec requires it, and a
+  // `{ source }`-only object is a shape the spec rejects, not one to propagate.
+  const candidate = value as Partial<ExpressionEnvelope>;
+  return typeof candidate.dialect === 'string' ? (value as ExpressionEnvelope) : undefined;
+}
+
+/**
+ * Write an edited `source` back into `previous`, per the table above.
+ *
+ * @param previous the draft's current value for this key — the envelope whose
+ *                 `dialect` / `meta` must survive the edit
+ * @param source   the edited text; empty clears the value (`undefined`)
+ */
+export function writeExpressionSource(
+  previous: unknown,
+  source: string,
+): ExpressionInput | undefined {
+  if (!source) return undefined;
+  const prior = priorEnvelope(previous);
+  if (!prior) return source;
+  const next: ExpressionEnvelope = { ...prior, source };
+  // Derived from the OLD source — never carried across an edit.
+  delete next.ast;
+  return next;
+}

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -46,6 +46,7 @@ import { iconNames } from 'lucide-react/dynamic.mjs';
 import { useMetadataLocale, t, tFormat } from './i18n';
 import { ColorVariantPicker } from './color-variant-field';
 import { ConditionBuilder } from './inspectors/ConditionBuilder';
+import { expressionSource, writeExpressionSource } from './inspectors/expression-envelope';
 
 export interface WidgetContext {
   /** Names of all object metadata records (for `ref:object`). */
@@ -1810,11 +1811,21 @@ function ColorPickerWidget({ value, onChange, readOnly, schema, fieldSpec }: Wid
 /* condition — no-code CEL predicate builder (visible / hidden / disabled / …) */
 /* -------------------------------------------------------------------------- */
 
+/**
+ * `SchemaForm` routes every predicate-named field here (`visible` / `hidden` /
+ * `disabled` / `condition` / `predicate` / `*When`), and most of those are
+ * `ExpressionInputSchema` in the spec — so the value arriving is usually the
+ * ADR-0089 envelope, not a string. `String(value)` put a literal
+ * `[object Object]` in the editor and the commit wrote a bare string back over
+ * the envelope; both go through the shared read/write pair now (#3218). The
+ * pair is shape-preserving, so the plain-`string` predicate fields this widget
+ * also serves keep round-tripping as strings.
+ */
 function ConditionWidget({ value, onChange, readOnly, context }: WidgetProps) {
   return (
     <ConditionBuilder
-      value={value == null ? '' : String(value)}
-      onCommit={(cel) => onChange(cel || undefined)}
+      value={expressionSource(value)}
+      onCommit={(cel) => onChange(writeExpressionSource(value, cel))}
       fields={context?.objectFields}
       disabled={readOnly}
     />

--- a/packages/app-shell/src/views/studio-design/ObjectValidationsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectValidationsPanel.tsx
@@ -36,8 +36,10 @@ import React from 'react';
 import { Plus, Trash2, ShieldAlert, ChevronDown } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@object-ui/components';
 import { ConditionBuilder } from '../metadata-admin/inspectors/ConditionBuilder';
+import { expressionSource, writeExpressionSource } from '../metadata-admin/inspectors/expression-envelope';
 import { readFields } from '../metadata-admin/previews/object-fields-io';
 import { t, useMetadataLocale } from '../metadata-admin/i18n';
+import type { ExpressionInput } from '@objectstack/spec/shared';
 
 type RuleType = 'script' | 'cross_field' | 'state_machine' | 'format' | 'json_schema' | 'conditional';
 
@@ -47,7 +49,14 @@ interface ValidationRuleDraft {
   label?: string;
   description?: string;
   message?: string;
-  condition?: string;
+  /**
+   * `ExpressionInput`, not `string`: the spec's validation-rule `condition` is
+   * `ExpressionInputSchema`, so a rule loaded off a saved object carries the
+   * ADR-0089 envelope. Typing it `string` was the same over-narrow local
+   * mirror #3202 / #3216 closed elsewhere, and it made the guard render empty
+   * here (#3218).
+   */
+  condition?: ExpressionInput;
   severity?: 'error' | 'warning' | 'info';
   active?: boolean;
   events?: string[];
@@ -299,8 +308,8 @@ function RuleTypeFields({
         {t('engine.studio.rules.celPost', locale)}
       </span>
       <ConditionBuilder
-        value={typeof rule.condition === 'string' ? rule.condition : ''}
-        onCommit={(cel) => patch({ condition: cel })}
+        value={expressionSource(rule.condition)}
+        onCommit={(cel) => patch({ condition: writeExpressionSource(rule.condition, cel) })}
         fields={fields}
         disabled={disabled}
       />
@@ -475,10 +484,13 @@ export function ObjectValidationsPanel({
     const cur = rules.find((r) => r.name === name);
     if (!cur) return;
     const next = makeSkeleton(nextType, name, firstField);
-    // carry a CEL condition across the types that share one
+    // Carry a CEL condition across the types that share one — envelope
+    // INCLUDED. A `typeof === 'string'` test here dropped a persisted guard on
+    // the floor and left the skeleton's never-firing `'false'` in its place
+    // (#3218). Carried verbatim: no `source` was edited, so `ast` stays valid.
     if (
       (nextType === 'script' || nextType === 'cross_field' || nextType === 'conditional') &&
-      typeof cur.condition === 'string'
+      expressionSource(cur.condition)
     ) {
       next.condition = cur.condition;
     }


### PR DESCRIPTION
Fixes #3218

## 缺陷

`HookSchema.condition` 用的是 `ExpressionInputSchema`(和 `FlowEdgeSchema.condition` 同一个 pipe),裸字符串在 **parse 时**被规范化成 `{ dialect: 'cel', source }` —— 信封才是平台自己产出的形状。Hook 检查器只认裸字符串,于是「Run only when (optional CEL)」渲染为**空**。

空框不是外观问题:`ConditionBuilder` 的 `emit` 只编译**当前 UI 里的行**,所以作者在这个看起来空的构建器里下一次编辑,提交的是**替换**掉那条他从没看见过的守卫(清空则提交 `condition: undefined`)。仅仅打开面板是安全的(`onCommit` 只在真实编辑时触发),但诱导那次编辑的正是这个空框。

## 读侧:走既有的那**一个**读法

全部经 `conditionText`(#3216 沉淀下来的唯一读法),包在共享的 `expressionSource` / `writeExpressionSource` 里。**没有写出第四份 `typeof c === 'string'`** —— `previews/flow-canvas-layout.ts` 未被改动,只被读取。

## 写侧:按本单裁决(选项 B),含 `ast` 必须丢弃那一条

原先提交路径唯一保住的键就是 `source`;其余全丢,因为它发的是裸字符串,而 spec 的 pipe 把 `dialect` **硬编码**成 `cel`。也就是说,改一个 `dialect: 'cron'` / `dialect: 'template'` 守卫的一个字符,就把它换到了另一个求值引擎上,并顺手丢掉 `ast` 与 ADR-0089 的 `meta`(`rationale` / `generatedBy` —— AI 作者最常填、也最没人会手工补回来的那份)。

现在编辑 `source` 时:

| 键 | 行为 |
|:--|:--|
| `dialect` | **保留** |
| `meta` | **保留** |
| `source` | 替换 |
| `ast` | **丢弃** —— 它是**旧 source** 的派生物。留着就是「引擎按旧 AST 求值,界面显示新 source」,比原缺陷更难查;`objectstack compile` 会重新填,且 `source` 在,`ExpressionSchema` 的 `source \|\| ast` refine 仍满足。 |

**没有原信封可保留时**(值缺失、裸字符串、或 `action.disabled` 上的布尔),提交仍是裸字符串简写 —— spec 的 pipe 把它规范化成的正是 `{ dialect: 'cel', source }`,一分不少。这条同时让同一个 helper 对**普通 `string` 谓词字段**也安全:给什么形状,还什么形状。这一点是有意为之,因为通用 SchemaForm 条件控件同时服务这两类字段。

## 普查结果:同族有四处,不止一处

| 位置 | 症状 |
|:--|:--|
| `inspectors/HookDefaultInspector.tsx` | `condition` —— 本单报告的缺陷 |
| `inspectors/ActionDefaultInspector.tsx` | `visible` / `disabled`(spec 是 `boolean \| ExpressionInput`),同样的空框读法 |
| `widgets.tsx` 的 `ConditionWidget` | `SchemaForm` 把**每一个**谓词名字段(`visible` / `hidden` / `disabled` / `condition` / `predicate` / `*When`)都路由到这里,而它做的是 `String(value)` —— 信封进到编辑器里是字面量 `[object Object]`,比空框更糟 |
| `studio-design/ObjectValidationsPanel.tsx` | 规则 `condition`;另外**类型切换器里还有第三份窄读法**(`typeof cur.condition === 'string'`),信封守卫会被直接丢掉、留下骨架里那条永不命中的 `'false'`。`ValidationRuleDraft.condition` 的本地类型由 `string` 改为 `ExpressionInput` |

外加 `inspectors/FlowEdgeInspector.tsx`:#3216 只收敛了它的**读**,**写**仍是裸字符串,是上面那条 dialect 改写的同一个口子,一并按同一规则修掉。

**未改动** `inspectors/PageBlockInspector.tsx` 的 `hidden`。它不是本族:`PageComponentSchema` 是 `.strict()` 且根本没有 `hidden` 这个键(canonical 是 `visibleWhen`)。那是另一个真缺陷,已按 Prime Directive #10 单独立单:#3229。

## 测试(先写,改前失败)

新增两个文件,**固件一律不手写信封** —— 按 #3216 的做法把作者输入喂给 `HookSchema.parse` 再断言,固件因此不可能与 spec 漂移。

- `inspectors/HookDefaultInspector.condition.test.tsx` —— 真渲染检查器:① 信封条件显示出 `source`;② 编辑后 `dialect` / `meta` 原样保留;③ 原来带 `ast` 的,编辑后 `ast` 没了(并再跑一次 `HookSchema.parse` 证明结果仍然合法);④ `dialect: 'template'` 的条件编辑后**仍是 template**(A/B 分界线);外加清空仍提交 `undefined`。
- `inspectors/expression-envelope.test.ts` —— 共享读写对的单元测试(其余调用点靠这一份契约覆盖),含 `cron`、AST-only 信封、布尔 `disabled`、不可变性。

改前:`5 failed | 1 passed`,失败原因正是守卫渲染为空(找不到条件行、找不到删除按钮、raw 编辑器值为空串)。改后 `15 passed`;`packages/app-shell` 全量 `257 files / 2203 tests` 通过,`type-check` 与 `lint`(0 errors)通过。
