### PR TITLE
fix(fields)!: FieldWidgetComponentProps 不再声称拥有全部键 (#3221)

### DIFF
--- a/.changeset/field-widget-props-closed-contract.md
+++ b/.changeset/field-widget-props-closed-contract.md
@@ -1,0 +1,50 @@
+---
+"@object-ui/fields": minor
+---
+
+`FieldWidgetComponentProps` stops claiming to have every key (objectui#3221).
+
+**Breaking for widget authors**: the exported `FieldWidgetComponentProps` no
+longer ends in `[key: string]: any`. FROM: any prop name at all type-checked and
+read as `any`. TO: the type declares a closed set — the controlled-input
+contract (`value` / `onChange` / `field` / `readonly` / `disabled` /
+`className` / `errorMessage` / `onUploadingChange`), the host plumbing a
+renderer forwards (`schema`, `dataSource`, `dependentValues`, `dependsOn`,
+`emptyHint`, `compact`, `onSelectRecord`, `onCreateNew`), and DOM pass-through
+(`id`, `name`, `autoFocus`, `tabIndex`, `onBlur`/`onFocus`/`onClick`, every
+`aria-*`, and `data-*` via a template-literal key). A custom widget reading
+anything else now fails `tsc`; the fix is to read it off `field` (the metadata)
+or to add the key here with its producer named.
+
+Scored `minor`, not `major`, per this repo's fixed-group rule — objectui's major
+tracks `@objectstack`, so breaking changes of our own ship as minor with the
+semantics spelled out (see AGENTS.md §版本号策略). The practical blast radius is
+small: every call site in this monorepo — `plugin-detail`'s inline editor,
+`plugin-grid`'s cell editor, `app-shell`'s metadata inspectors, the form
+renderer — compiles unchanged, because the closed set was derived from them.
+
+Why it mattered: an index signature is the objectstack#4075 mechanism — **a type
+that claims to have every key can never be reported as missing one**. Three
+things followed, and all three are now fixed:
+
+- `props.required` and `props.error`, both declared by the spec's
+  `FieldWidgetPropsSchema` and both absent here, were legal reads typed `any`
+  and `undefined` at runtime forever. They are compile errors now, which is what
+  makes the `error` / `errorMessage` divergence (objectui#3222) decidable by the
+  compiler instead of by a symbol guard. This change deliberately does **not**
+  resolve that divergence — only make it visible.
+- A misspelled prop (`readOnly` for `readonly`, `onchange` for `onChange`)
+  compiled and silently did nothing.
+- Any structural / parity comparison against the type was useless *in
+  principle*, which is why objectui#3161's batch-7 symbol guard was the only
+  detector that could see the collision at all.
+
+Also cleaned up inside the package: ~20 `(props as any).x` reads of keys the
+type now declares (`compact`, `dataSource`, `disabled`, `name`, `id`,
+`onCreateNew`, `onSelectRecord`, `contextRecord`, `dependentValues`) read
+through the type instead — leaving them would have kept the "a typo compiles"
+half of the defect alive at exactly the sites that matter. The three batch-7
+tripwires that existed to go red on this change
+(`_IndexSignatureStillThere` / `_RequiredSilentlyReadsAsAny` /
+`_ErrorSilentlyReadsAsAny`) are replaced by their inverse, so re-widening the
+type fails a test rather than passing one.

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -184,6 +184,8 @@ export function FieldEditWidget({
   const resolved = field?.type ? resolveInlineEditType(field.type) : undefined;
   const Widget = resolved ? EDIT_WIDGETS[resolved] : undefined;
   if (!Widget) return null;
+  // `compact` is a declared widget prop (objectui#3221 closed this type), so
+  // the spread no longer needs an `any` escape hatch to get past it.
   const compactProps = resolved && COMPACT_EDIT_TYPES.has(resolved) ? { compact: true } : {};
-  return <Widget field={field} value={value} onChange={onChange} readonly={readonly} {...(compactProps as any)} />;
+  return <Widget field={field} value={value} onChange={onChange} readonly={readonly} {...compactProps} />;
 }

--- a/packages/fields/src/__tests__/spec-symbol-batch7.test.ts
+++ b/packages/fields/src/__tests__/spec-symbol-batch7.test.ts
@@ -22,8 +22,9 @@
  *  - `FieldWidgetProps` is now `FieldWidgetComponentProps`. The spec owns that
  *    name for the DECLARED widget-plugin props contract; this package's is the
  *    React interface its widgets implement. The pins record the divergence that
- *    made re-exporting impossible, and the index signature that made the
- *    divergence invisible.
+ *    made re-exporting impossible — and, since objectui#3221 closed the type,
+ *    that the divergence is now *visible* rather than swallowed by a
+ *    `[key: string]: any` index signature.
  *
  * The other direction — "the spec must not start owning the NEW names" — is not
  * asserted here because `scripts/check-spec-symbol-derivation.mjs` already
@@ -87,19 +88,24 @@ describe('FieldWidgetComponentProps is the RENDERED layer of the spec contract',
     type _SpecNamesItError = Assert<HasKey<SpecFieldWidgetProps, 'error'>>;
     type _LocalNamesItErrorMessage = Assert<HasKey<FieldWidgetComponentProps, 'errorMessage'>>;
 
-    // …and the reason nobody noticed. The index signature answers `any` for
-    // every key this type does not declare, so BOTH of the spec's keys already
-    // "exist" here — `props.required` and `props.error` are legal reads that
-    // give `any` and are always `undefined` at runtime. No compiler check and
-    // no structural comparison can report a key as missing from a type that
-    // claims to have every key (objectstack#4075). That is what makes a parity
-    // test useless for this symbol and the guard the only detector.
-    //
-    // These three assertions exist to be DELETED by objectui#3221, which
-    // removes the index signature; when that lands they go red on purpose.
-    type _IndexSignatureStillThere = Assert<Extends<string, keyof FieldWidgetComponentProps>>;
-    type _RequiredSilentlyReadsAsAny = Assert<IsAny<FieldWidgetComponentProps['required']>>;
-    type _ErrorSilentlyReadsAsAny = Assert<IsAny<FieldWidgetComponentProps['error']>>;
+    // …and the reason nobody noticed used to sit right here: three pins
+    // asserting that `[key: string]: any` was still present, and that
+    // `props.required` / `props.error` therefore read as `any`. objectui#3221
+    // removed that index signature, so those pins have gone red on purpose and
+    // are gone with it. What replaces them is the inverse claim — the type is
+    // now CLOSED, so the two keys the spec declares and this one does not can
+    // finally be reported as missing. That is what makes objectui#3222 (the
+    // `error` / `errorMessage` divergence) decidable by the compiler instead of
+    // by a symbol guard.
+    type _NoStringIndexSignature = Assert<Equal<Extends<string, keyof FieldWidgetComponentProps>, false>>;
+    type _RequiredIsAbsent = Assert<Equal<HasKey<FieldWidgetComponentProps, 'required'>, false>>;
+    type _ErrorIsAbsent = Assert<Equal<HasKey<FieldWidgetComponentProps, 'error'>, false>>;
+
+    // `data-*` stays open (it is open in HTML too), but as a template-literal
+    // key — the distinction that keeps `keyof` finite above. A pin, because
+    // widening it back to `[key: string]` would silently restore the defect
+    // while every assertion here still read as "closed".
+    type _DataAttributesStayOpen = Assert<Extends<'data-testid', keyof FieldWidgetComponentProps>>;
 
     expect(true).toBe(true);
   });

--- a/packages/fields/src/__tests__/widget-props-contract.test.tsx
+++ b/packages/fields/src/__tests__/widget-props-contract.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FieldWidgetComponentProps` is a CLOSED contract (objectui#3221).
+ *
+ * It used to end in `[key: string]: any`, which made every check over it
+ * vacuous: a type claiming to have every key can never be reported as missing
+ * one (objectstack#4075). Three consequences, one test each below:
+ *
+ *  1. a key the type does not declare is a compile error, not a silent `any`
+ *     — which is what makes the `error` / `errorMessage` divergence
+ *     (objectui#3222) decidable by the compiler at all;
+ *  2. a MISSPELLED prop (`readOnly` for `readonly`) is rejected;
+ *  3. the pass-through keys hosts genuinely forward still type-check, and
+ *     still reach the rendered control at runtime — closing the type must not
+ *     have been paid for by dropping real behaviour.
+ *
+ * (1) and (2) are compile-time: a violation fails `pnpm --filter
+ * @object-ui/fields type-check`, not this run. `@ts-expect-error` inverts
+ * that — the line fails to compile if the error it expects ever STOPS
+ * happening, i.e. if the index signature comes back.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { TextField } from '../widgets/TextField';
+import { BooleanField } from '../widgets/BooleanField';
+import type { FieldWidgetComponentProps } from '../widgets/types';
+import type { FieldMetadata } from '@object-ui/types';
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Extends<A, B> = [A] extends [B] ? true : false;
+
+const field = { name: 'title', label: 'Title', type: 'text' } as unknown as FieldMetadata;
+
+describe('FieldWidgetComponentProps is closed (objectui#3221)', () => {
+  it('has no `[key: string]` index signature', () => {
+    // The single assertion the whole change turns on. While the index
+    // signature existed this was `true`, and every check below was vacuous.
+    type _NotOpen = Assert<Equal<Extends<string, keyof FieldWidgetComponentProps>, false>>;
+    expect(true).toBe(true);
+  });
+
+  it('rejects keys it does not declare', () => {
+    const props = {} as FieldWidgetComponentProps<string>;
+
+    // The spec's `FieldWidgetPropsSchema` declares both; this type declares
+    // neither. Reading them used to give `any` and `undefined` forever.
+    // Whether to ADD them is objectui#3222 — deliberately not decided here.
+    // @ts-expect-error `required` is not part of this contract
+    void props.required;
+    // @ts-expect-error `error` is not part of this contract — this type's slot is `errorMessage`
+    void props.error;
+
+    // …and the class of bug the index signature hid best: a typo.
+    // @ts-expect-error the prop is `readonly`, not React's DOM `readOnly`
+    void props.readOnly;
+    // @ts-expect-error the prop is `onChange`
+    void props.onchange;
+
+    expect(true).toBe(true);
+  });
+
+  it('still accepts the pass-through keys hosts actually forward', () => {
+    // Closing the type is only correct if the real call sites still compile.
+    // Each key here has a named producer: the form renderer, the inline-edit
+    // host, or the line-item grid. Deleting one from the type breaks this.
+    const passThrough: FieldWidgetComponentProps<string> = {
+      value: '',
+      onChange: () => {},
+      field,
+      // form renderer (`renderFieldComponent`)
+      schema: field,
+      dataSource: {},
+      dependentValues: { country: 'cn' },
+      dependsOn: ['country'],
+      emptyHint: 'Select country first',
+      name: 'title',
+      // inline-edit hosts / line-item grid
+      compact: true,
+      autoFocus: true,
+      onSelectRecord: () => {},
+      onCreateNew: () => {},
+      // DOM / a11y
+      id: 'title-input',
+      'aria-label': 'Title',
+      'data-testid': 'field-title',
+    };
+    expect(passThrough.compact).toBe(true);
+  });
+});
+
+describe('closing the type kept the pass-through behaviour', () => {
+  it('forwards a11y and data attributes to the rendered input', () => {
+    render(
+      <TextField
+        value="hello"
+        onChange={() => {}}
+        field={field}
+        aria-label="Title"
+        data-testid="title-input"
+      />,
+    );
+    const input = screen.getByTestId('title-input');
+    expect(input).toHaveAttribute('aria-label', 'Title');
+    expect(input).toHaveValue('hello');
+  });
+
+  it('forwards `disabled` — a declared key, not an index-signature accident', () => {
+    render(
+      <BooleanField
+        value={false}
+        onChange={() => {}}
+        field={{ name: 'active', label: 'Active', type: 'boolean' } as unknown as FieldMetadata}
+        disabled
+        data-testid="active-switch"
+      />,
+    );
+    expect(screen.getByTestId('active-switch')).toBeDisabled();
+  });
+});

--- a/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
+++ b/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
@@ -90,8 +90,8 @@ export function CapabilityMultiSelectField({
   const { t } = useFieldTranslation();
   const ctx = React.useContext(SchemaRendererContext);
   const dataSource: DataSource | null =
-    (props as any).dataSource ?? (ctx as any)?.dataSource ?? null;
-  const disabled = (props as any).disabled as boolean | undefined;
+    (props.dataSource as any) ?? (ctx as any)?.dataSource ?? null;
+  const disabled = props.disabled;
 
   const [caps, setCaps] = React.useState<Capability[] | null>(null);
 

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -35,7 +35,7 @@ export function CheckboxesField({
   const rawOptions: Option[] = config?.options || [];
   const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
   const groupId = useId();
-  const fieldName = (props as any).name || config?.name || (props as any).id || '';
+  const fieldName = props.name || config?.name || props.id || '';
 
   const dependsOn = config?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
@@ -107,7 +107,7 @@ export function CheckboxesField({
               id={id}
               checked={selected.includes(value)}
               onCheckedChange={(checked) => toggle(value, !!checked)}
-              disabled={(props as any).disabled}
+              disabled={props.disabled}
               data-testid={`checkboxes-option-${value}`}
             />
             <Label htmlFor={id} className="font-normal">{opt.label}</Label>

--- a/packages/fields/src/widgets/FilterConditionField.tsx
+++ b/packages/fields/src/widgets/FilterConditionField.tsx
@@ -301,7 +301,7 @@ export function FilterConditionField({
 }: FieldWidgetComponentProps<string | object>) {
   const ctx = React.useContext(SchemaRendererContext);
   const { t } = useFieldTranslation();
-  const dataSource: any = (props as any).dataSource ?? (ctx as any)?.dataSource ?? null;
+  const dataSource: any = props.dataSource ?? (ctx as any)?.dataSource ?? null;
   const dependentValues: Record<string, any> = (props as any).dependentValues ?? {};
   const objectName = String(dependentValues.object_name ?? '');
 

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -327,7 +327,7 @@ export function GridField({
   const cfg = (field || (props as any).schema || {}) as any;
   const allColumns: GridColumn[] = cfg.columns || [];
   const rows: Row[] = Array.isArray(value) ? value : [];
-  const contextRecord = (props as any).contextRecord as Record<string, unknown> | undefined;
+  const contextRecord = props.contextRecord;
 
   // Per-cell CEL rule state (B2 in grids). A column with no readonlyWhen/
   // requiredWhen resolves to its static flags (cheap fast-path — no engine

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -280,13 +280,13 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   }, [fieldMeta?.depends_on, fieldMeta?.dependsOn]);
 
   // Resolve dependent field values from explicit prop or SchemaRendererContext.data
-  const dependentValuesProp = (props as any).dependentValues as Record<string, any> | undefined;
+  const dependentValuesProp = props.dependentValues;
 
   // Resolve DataSource: explicit prop > field-level > wrapper field > SchemaRendererContext > none
   const ctx = useContext(SchemaRendererContext);
   const contextDataSource = ctx?.dataSource ?? null;
   const dataSource: DataSource | null =
-    (props as any).dataSource ?? lookupField?.dataSource ?? fieldMeta?.dataSource ?? contextDataSource;
+    (props.dataSource as DataSource | null | undefined) ?? lookupField?.dataSource ?? fieldMeta?.dataSource ?? contextDataSource;
 
   /** Resolve dependent values from the explicit prop (preferred), the form-data
    *  context provided by @object-ui/react, or finally `ctx.data` (record scope). */
@@ -369,7 +369,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
 
   // Optional create-new callback
   const onCreateNew: ((searchQuery: string) => void) | undefined =
-    (props as any).onCreateNew ?? lookupField?.onCreateNew;
+    props.onCreateNew ?? lookupField?.onCreateNew;
 
   // State for the full Record Picker dialog (Level 2)
   const [isPickerOpen, setIsPickerOpen] = useState(false);
@@ -657,7 +657,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   // auto-fill sibling fields from it — e.g. a line-item grid copying a product's
   // unit_price/description when the item is chosen. When provided (single
   // select), it drives the update and the host owns the resulting value change.
-  const onSelectRecord = (props as any).onSelectRecord as ((record: LookupOption) => void) | undefined;
+  const onSelectRecord = props.onSelectRecord;
 
   const handleSelect = useCallback(
     (option: LookupOption) => {
@@ -906,7 +906,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   // Compact mode (e.g. inside a line-item grid cell): show the selected value
   // INSIDE a borderless trigger on a single line — no chip stacked above a
   // separate "Select…" button (which double-stacks and wastes the row height).
-  const compact = !!(props as any).compact;
+  const compact = !!props.compact;
   const singleSelectedLabel = selectedOptions[0]?.label || selectedOptions[0]?.[displayField];
 
   // Shared field trigger — the anchor for either the inline PeoplePicker
@@ -920,8 +920,8 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
         compact && 'h-8 rounded-none border-0 bg-transparent px-2 shadow-none focus-visible:ring-1 focus-visible:ring-ring/60',
       )}
       type="button"
-      disabled={dependenciesMissing || (props as any).disabled}
-      data-testid={dependenciesMissing ? 'lookup-trigger-gated' : (((props as any).name || lookupField?.name) ? `lookup-trigger-${(props as any).name || lookupField.name}` : 'lookup-trigger')}
+      disabled={dependenciesMissing || props.disabled}
+      data-testid={dependenciesMissing ? 'lookup-trigger-gated' : ((props.name || lookupField?.name) ? `lookup-trigger-${props.name || lookupField.name}` : 'lookup-trigger')}
       title={dependenciesMissing
         ? t('lookup.selectFirst', { fields: dependsOn.map(d => d.field).join(', ') })
         : undefined}
@@ -1214,7 +1214,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
           type="button"
           // Gated exactly like the main trigger (#2215) — pre-fix this button
           // opened the full unscoped table while the dependency was missing.
-          disabled={dependenciesMissing || (props as any).disabled}
+          disabled={dependenciesMissing || props.disabled}
           onClick={() => setIsPickerOpen(true)}
           aria-label={t('lookup.browseAll')}
           title={dependenciesMissing

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -36,7 +36,7 @@ export function MultiSelectField({
   const config = (field || schema) as any;
   const rawOptions: Option[] = config?.options || [];
   const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
-  const fieldName = (props as any).name || config?.name || (props as any).id || '';
+  const fieldName = props.name || config?.name || props.id || '';
 
   const dependsOn = config?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
@@ -107,7 +107,7 @@ export function MultiSelectField({
             type="button"
             key={value}
             onClick={() => toggle(value)}
-            disabled={(props as any).disabled}
+            disabled={props.disabled}
             aria-pressed={active}
             data-testid={`multiselect-option-${opt.value}`}
             className={cn(

--- a/packages/fields/src/widgets/ObjectRefField.tsx
+++ b/packages/fields/src/widgets/ObjectRefField.tsx
@@ -35,8 +35,8 @@ export function ObjectRefField({
 }: FieldWidgetComponentProps<string>) {
   const ctx = React.useContext(SchemaRendererContext);
   const { t } = useFieldTranslation();
-  const dataSource: any = (props as any).dataSource ?? (ctx as any)?.dataSource ?? null;
-  const disabled = (props as any).disabled as boolean | undefined;
+  const dataSource: any = props.dataSource ?? (ctx as any)?.dataSource ?? null;
+  const disabled = props.disabled;
 
   const [objects, setObjects] = React.useState<ObjectHeader[] | null>(null);
 

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -34,7 +34,7 @@ export function RadioField({
   const config = (field || schema) as any;
   const rawOptions: Option[] = config?.options || [];
   const groupId = useId();
-  const fieldName = (props as any).name || config?.name || (props as any).id || '';
+  const fieldName = props.name || config?.name || props.id || '';
 
   const dependsOn = config?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
@@ -81,7 +81,7 @@ export function RadioField({
     <RadioGroup
       value={value ?? ''}
       onValueChange={onChange}
-      disabled={(props as any).disabled}
+      disabled={props.disabled}
       className={className}
     >
       {options.map((opt) => {

--- a/packages/fields/src/widgets/RecipientPickerField.tsx
+++ b/packages/fields/src/widgets/RecipientPickerField.tsx
@@ -57,8 +57,8 @@ export function RecipientPickerField({
 }: FieldWidgetComponentProps<string>) {
   const ctx = React.useContext(SchemaRendererContext);
   const { t } = useFieldTranslation();
-  const dataSource: any = (props as any).dataSource ?? (ctx as any)?.dataSource ?? null;
-  const disabled = (props as any).disabled as boolean | undefined;
+  const dataSource: any = props.dataSource ?? (ctx as any)?.dataSource ?? null;
+  const disabled = props.disabled;
   const dependentValues: Record<string, any> = (props as any).dependentValues ?? {};
   const recipientType = String(dependentValues.recipient_type ?? '');
   const mapping = TYPE_TO_OBJECT[recipientType];

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -67,7 +67,7 @@ function SingleSelectField({
   // driven by synthetic DOM events, so e2e must target the trigger/options by a
   // deterministic testid keyed on the field name. `props.name` is the
   // react-hook-form field name spread in by the form renderer (FormField).
-  const fieldName = (props as any).name || (config as any)?.name || props.id || '';
+  const fieldName = props.name || (config as any)?.name || props.id || '';
 
   const dependsOn = (config as any)?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions(

--- a/packages/fields/src/widgets/TagsField.tsx
+++ b/packages/fields/src/widgets/TagsField.tsx
@@ -58,7 +58,7 @@ export function TagsField({ value, onChange, field, readonly, className, ...prop
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={onKeyDown}
         onBlur={() => addTag(draft)}
-        disabled={(props as any).disabled}
+        disabled={props.disabled}
         placeholder={tags.length === 0 ? '输入后回车添加…' : ''}
         className="h-7 flex-1 border-0 bg-transparent p-0 px-1 shadow-none focus-visible:ring-0 min-w-[8ch]"
       />

--- a/packages/fields/src/widgets/types.ts
+++ b/packages/fields/src/widgets/types.ts
@@ -1,4 +1,5 @@
-import { FieldMetadata } from '@object-ui/types';
+import type { AriaAttributes, FocusEventHandler, MouseEventHandler } from 'react';
+import type { DependsOnInput, FieldMetadata } from '@object-ui/types';
 
 /**
  * Props every field widget in this package receives at RUNTIME.
@@ -16,24 +17,41 @@ import { FieldMetadata } from '@object-ui/types';
  * The two are NOT interchangeable, and the divergence is not cosmetic: the
  * spec's contract names the error slot `error`, this one names it
  * `errorMessage`, so a widget written to the spec's declared props renders no
- * validation message here and nothing reports it. That divergence is recorded,
- * not resolved, by this rename — see the tripwire in
- * `__tests__/spec-symbol-batch7.test.tsx`.
+ * validation message here. That divergence is tracked in objectui#3222 and is
+ * deliberately NOT resolved here — but it is now *visible*: reading
+ * `props.error` or `props.required` off this type is a compile error rather
+ * than a silent `any`.
  *
- * `[key: string]: any` below is load-bearing for the widgets' `...props`
- * spreads, and it is also why the drift above was invisible: the index
- * signature answers `any` for every key this type does not declare, so
- * `props.required` and `props.error` are legal reads that are always
- * `undefined` — a type that claims to have every key can never be reported as
- * missing one (the objectstack#4075 mechanism; only the symbol guard can see a
- * collision like this, a parity test cannot in principle). Removing it is a
- * separate change with a real blast radius: objectui#3221.
+ * ## Why there is no `[key: string]: any` (objectui#3221)
+ *
+ * This type used to end in an index signature, "load-bearing" for the widgets'
+ * `...props` spreads. It was also why every drift above was invisible: **a type
+ * that claims to have every key can never be reported as missing one** (the
+ * objectstack#4075 mechanism). `props.required` and `props.error` were legal
+ * reads typed `any` and always `undefined` at runtime; a misspelled prop
+ * (`readOnly` for `readonly`, `onchange` for `onChange`) compiled; and any
+ * structural/parity comparison against the type was useless *in principle*,
+ * which is why the batch-7 symbol guard was the only detector that could see
+ * the collision at all.
+ *
+ * It is replaced by the CLOSED set below: the controlled-input contract, the
+ * host plumbing the form renderer genuinely forwards, and a DOM pass-through
+ * allowance. `data-*` is an open family by design (it is open in HTML too) and
+ * is expressed as a template-literal index signature, which — unlike
+ * `[key: string]` — leaves `keyof` finite, so an undeclared prop still fails.
+ *
+ * Adding a key here is a contract change: say who produces it and who reads it.
  */
 export type FieldWidgetComponentProps<T = any> = {
+  /* ── The controlled-input contract every widget implements ─────────────── */
+
   value: T;
   onChange: (val: T) => void;
-  // Use a looser type for field to avoid complex circular dependencies for now
-  field: FieldMetadata; 
+  /**
+   * The field's metadata. Deliberately the looser `@object-ui/types` shape
+   * rather than the spec's, to avoid a circular dependency for now.
+   */
+  field: FieldMetadata;
   readonly?: boolean;
   disabled?: boolean;
   className?: string;
@@ -44,5 +62,81 @@ export type FieldWidgetComponentProps<T = any> = {
    * widgets ignore it.
    */
   onUploadingChange?: (uploading: boolean) => void;
-  [key: string]: any;
-}
+
+  /* ── Host plumbing: what a rendering host actually forwards ─────────────── */
+
+  /**
+   * The raw authored node the widget was rendered from. Two hosts supply it:
+   * `SchemaRenderer` (`<Component schema={schema} {...schema} />`) and the
+   * form renderer's `renderFieldComponent` (`schema={props.field || ...}`),
+   * which is why ~25 widgets read `field || schema` for their config.
+   *
+   * This is a second carrier for what `field` already means, i.e. a de-facto
+   * second contract (AGENTS.md #0.1) — declared here so it is at least
+   * visible; converging the two is tracked separately.
+   */
+  schema?: FieldMetadata | Record<string, unknown>;
+  /**
+   * DataSource for widgets that query records (lookup / user / object-ref /
+   * recipient-picker / grid). Injected by the form renderer for the field
+   * types that need it, and passed directly by inline-edit hosts. Option
+   * widgets destructure it purely to keep it off their DOM spread.
+   *
+   * Left structural (`unknown`): `@object-ui/fields` must not depend on a
+   * concrete adapter — every consumer narrows it itself.
+   */
+  dataSource?: unknown;
+  /**
+   * Live sibling-field values driving cascading / role-gated options and
+   * dependent lookups (ADR-0058, #2215/#2284). The form renderer passes the
+   * in-progress record; widgets fall back to `SchemaRendererContext`.
+   */
+  dependentValues?: Record<string, unknown>;
+  /**
+   * Controlling field(s) that gate this field's option list. Normally declared
+   * on the field metadata; accepted as a prop so a host can drive the gate for
+   * a field it synthesised. Field metadata wins when both are present.
+   */
+  dependsOn?: DependsOnInput;
+  /**
+   * Hint shown when a dependency-gated option list is still waiting on its
+   * controlling field. Forwarded by the form renderer; the option widgets in
+   * this package currently discard it and render their own message instead.
+   */
+  emptyHint?: string;
+  /**
+   * Render as a single-line, borderless control for a grid cell (the inline
+   * editor and the line-item grid set it) instead of the full form layout.
+   */
+  compact?: boolean;
+  /**
+   * Receive the FULL selected record rather than just its id, so a host can
+   * auto-fill sibling fields from it (a line-item grid copying a product's
+   * price). When provided, the host owns the resulting value change.
+   */
+  onSelectRecord?: (record: Record<string, any>) => void;
+  /**
+   * Offer a "create new" affordance in a record picker, carrying whatever the
+   * user had typed. Also declarable on the field metadata.
+   */
+  onCreateNew?: (searchQuery: string) => void;
+
+  /* ── DOM pass-through: what `...props` may legitimately reach an input ──── */
+
+  id?: string;
+  /** react-hook-form's field name, spread in by the form renderer. */
+  name?: string;
+  autoFocus?: boolean;
+  tabIndex?: number;
+  onBlur?: FocusEventHandler<HTMLElement>;
+  onFocus?: FocusEventHandler<HTMLElement>;
+  onClick?: MouseEventHandler<HTMLElement>;
+} & AriaAttributes & {
+  /**
+   * Arbitrary `data-*` attributes (test ids, analytics hooks). Open by design,
+   * but a template-literal key — `keyof` stays finite, so this does NOT
+   * reintroduce the index signature objectui#3221 removed: `props.required`
+   * is still an error, `props['data-testid']` is still fine.
+   */
+  [dataAttribute: `data-${string}`]: string | number | boolean | undefined;
+};


### PR DESCRIPTION
Fixes #3221

`packages/fields/src/widgets/types.ts` 里的 `[key: string]: any` 是 objectstack#4075 的机制:**一个声称拥有全部键的类型,永远不可能被报告「缺了某个键」**。本 PR 把它换成一个从真实调用点推导出来的**封闭**类型。

## 三个后果,逐条关掉

| 现象 | 之前 | 现在 |
|---|---|---|
| `props.required` / `props.error`(spec 的 `FieldWidgetPropsSchema` 声明、本地没有) | 合法读取,类型 `any`,运行时恒 `undefined` | 编译错误 |
| 拼错 prop(`readOnly` vs `readonly`、`onchange`) | 编译通过、静默失效 | 编译错误 |
| 对该类型做结构/parity 比较 | **原理上无效**,批次 7 的符号守卫是唯一探测器 | 可比较了 |

## 新类型怎么定的:先读调用点,再写类型

Issue 给了两个候选。`& React.HTMLAttributes< HTMLElement >` 被排除,原因是实测的:它声明的 `onChange?: FormEventHandler` 与本契约的 `onChange: (val: T) => void` 在交集下冲突(`strictFunctionTypes` 逆变,赋值不成立),且不覆盖 `data-*`,更不覆盖 `schema` / `dataSource` / `dependentValues` 这些真正在传的键。

于是走「显式声明」。**候选集不是猜的**:先只删索引签名、跑 `tsc`,让编译器把真实缺口列出来,再逐条判断该不该存在。分三组:

- **受控输入契约**(原有):`value` / `onChange` / `field` / `readonly` / `disabled` / `className` / `errorMessage` / `onUploadingChange`
- **宿主管道**(表单渲染器 `renderFieldComponent` 与内联编辑宿主确实转发的):`schema`、`dataSource`、`dependentValues`、`dependsOn`、`emptyHint`、`compact`、`onSelectRecord`、`onCreateNew`
- **DOM 透传**:`id`、`name`、`autoFocus`、`tabIndex`、`onBlur`/`onFocus`/`onClick`、全部 `aria-*`(`React.AriaAttributes`,闭集),以及 `data-*`

`data-*` 用**模板字面量索引签名**而不是 `[key: string]`。这是关键区别:模板键让 `keyof` 保持有限,所以 `props['data-testid']` 合法、`props.required` 依然报错 —— 开放的只是 HTML 本来就开放的那一族。

**爆炸半径实测很小**:全仓 `turbo run type-check` 78/78 绿,`plugin-detail` 内联编辑器、`plugin-grid` 单元格编辑器、`app-shell` 的 metadata inspectors、表单渲染器全部**零改动**通过 —— 因为封闭集就是从它们身上推出来的。

## 顺带:让读取侧也说实话

约 20 处 `(props as any).x` 改为直接读类型(`compact`、`dataSource`、`disabled`、`name`、`id`、`onCreateNew`、`onSelectRecord`、`contextRecord`、`dependentValues`)。留着它们等于保留了「拼错也能编译」那一半缺陷,而且恰恰留在最要命的位置上。

未动的是 `(field || (props as any).schema)` 这类**元数据配置读取**(约 25 处)—— 它们后面紧跟 `as any`,收紧收益低、风险高,且属于 `field`/`schema` 双载体问题,不在本 issue 范围内。

## 批次 7 的三条钉扎

`_IndexSignatureStillThere` / `_RequiredSilentlyReadsAsAny` / `_ErrorSilentlyReadsAsAny` 就是为本次改动写的、会在删除索引签名时报红的钉扎(#3224 已合并)。它们按预期删除了 —— 但没有留空,而是换成**反向断言**(类型现在是封闭的、两个键确实缺失),再加一条 `data-*` 仍开放的钉扎。这样把类型重新放宽回 `[key: string]` 会**失败一个测试**,而不是悄悄通过。

新增 `packages/fields/src/__tests__/widget-props-contract.test.tsx`:用 `@ts-expect-error` 钉住四类拒绝(`required`、`error`、`readOnly`、`onchange`),用一个正向字面量钉住每个透传键仍被接受(过度收紧会报红),再用两个渲染断言证明 `aria-*` / `data-*` / `disabled` 真的还能到达控件 —— 封闭类型不能是靠丢掉真实行为换来的。

## 范围边界:没有碰 #3222

**没有**把 `errorMessage` 改名为 `error`,**没有**新增 `required`。本 PR 只让类型说实话,好让 #3222 变成编译器可判定的问题。

按要求汇报:**移除索引签名后,`error`/`errorMessage` 的分歧没有在任何地方产生类型错误**(全仓 typecheck 全绿)。查证下来原因比「命名分歧」更尖锐,这条直接关系到 #3222 的选型,已同步评论到该 issue:

> **全仓没有任何宿主向 field widget 传 `errorMessage`。** 表单渲染器用独立的 `< FormMessage />` 渲染校验信息,从不转发这个 prop。读它的 7 个 widget(`Email`/`Currency`/`Url`/`RichText`/`Percent`/`TextArea`/`Phone`)拿它算 `aria-invalid={!!errorMessage}`,而它恒为 `undefined` —— 所以这 7 个 widget 的 `aria-invalid` 永远是 `false`。

也就是说这个槽位不只是**名字**和 spec 不一致,它在**两种拼写下都是死的**。#3222 的决策因此不只是改名,而是「谁来生产它」。

> 注:上一版正文里 `< FormMessage />` 被 GitHub 的正文消毒器当成 HTML 标签吞掉了(`<` 紧跟字母)。此处及后续一律在 `<` 后留一个空格。

## 验证

```
pnpm --filter @object-ui/fields type-check   → exit 0
npx turbo run type-check --concurrency=2     → 78 successful, 78 total
npx turbo run build --filter=!@object-ui/site → 43 successful, 43 total
npx vitest run packages/fields/ (根配置)      → 38 files / 483 tests passed
pnpm --filter @object-ui/fields lint          → 0 errors
node scripts/check-spec-symbol-derivation.mjs → exit 0(未修改该脚本)
node scripts/check-changeset-fixed.mjs        → exit 0
```

## 顺带发现(已另开 issue,不在本 PR 修)

- #3231 —— 表单渲染器计算的 `emptyHint` 被四个选项 widget 全部丢弃,用户看到的是硬编码英文(绕过 i18n)。
- #3232 —— `TextAreaField` 读取的 `mobileFullscreen` 全仓无人生产,注释却声称「宿主表单传入」。

两条都是同一类:索引签名在时,「读了但没人写」根本不可能被看见。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRJtkgUAaVG11FsJQbvZWA