### PR TITLE
test(plugin-calendar): partial-mock @object-ui/react so both vitest configs agree (#3219)

### DIFF
--- a/packages/plugin-calendar/src/registration.test.tsx
+++ b/packages/plugin-calendar/src/registration.test.tsx
@@ -1,18 +1,43 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import * as ObjectUIReact from '@object-ui/react';
 import { ObjectCalendarRenderer } from './index';
 
-// Mock dependencies
-vi.mock('@object-ui/react', async () => {
-  const React = await import('react');
-  return {
-    useSchemaContext: vi.fn(() => ({ dataSource: { type: 'mock-datasource' } })),
-    SchemaRendererContext: React.createContext(null),
-  };
-});
+// Partial mock — override ONLY what this test controls, keep every other real
+// export (objectui#3219).
+//
+// A whole-module `vi.mock('@object-ui/react', () => ({ ... }))` used to list
+// just `useSchemaContext` + `SchemaRendererContext`. That made the file's
+// result depend on HOW the module graph resolved, so the two vitest configs in
+// this repo disagreed about it:
+//
+//   - root `vitest.config.mts` (what CI runs): this file is in `heavyDomTests`,
+//     and `vitest.setup.dom.tsx` eagerly imports `@object-ui/components`. That
+//     evaluates `components/src/hooks/related-count-store.ts` — which imports
+//     `subscribeDataChanges` from `@object-ui/react` — against the REAL module
+//     before the mock applies. Green, by accident.
+//   - `packages/plugin-calendar/vitest.config.ts` (what `pnpm --filter … test`
+//     and `turbo run test` run): no such setup, so `@object-ui/components` is
+//     first evaluated inside the mocked graph. Vitest 4 hard-errors on a
+//     missing export instead of silently yielding `undefined`, so the suite
+//     failed to load at all: `No "subscribeDataChanges" export is defined on
+//     the "@object-ui/react" mock`.
+//
+// Spreading `importOriginal()` removes the sensitivity: the mock is a superset
+// of the real module under either resolution, so a transitive consumer can
+// never trip over an export this test never intended to replace. Adding a new
+// `@object-ui/react` export can no longer break this file.
+vi.mock(import('@object-ui/react'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  // Only the pieces this test drives:
+  useSchemaContext: vi.fn(() => ({ dataSource: { type: 'mock-datasource' } })),
+}));
 
-// Mock the implementation
+// Mock the implementation. Deliberate whole-module replacement of a LOCAL
+// module: stubbing `ObjectCalendar` is the isolation boundary this test is
+// about, and `./ObjectCalendar`'s only runtime export is the component itself
+// (`ObjectCalendarProps` is type-only and erased at runtime).
 vi.mock('./ObjectCalendar', () => ({
   ObjectCalendar: ({ dataSource, data, loading }: any) => (
     <div data-testid="calendar-mock">
@@ -41,5 +66,28 @@ describe('Plugin Calendar Registration', () => {
     const el = screen.getByTestId('calendar-mock');
     expect(el).toHaveTextContent('Data: [{"id":1,"name":"Event A"}]');
     expect(el).toHaveTextContent('Loading: false');
+  });
+
+  // Regression guard for objectui#3219 — keep this test.
+  //
+  // It pins the exact invariant whose absence made the root config and the
+  // package config disagree about this file: the `@object-ui/react` mock must
+  // expose every export the real module has. When that holds, no transitive
+  // importer of `@object-ui/react` can hit a missing export, so the file
+  // behaves identically no matter which config resolved the module (source via
+  // the root alias, or `dist` via the package config) and no matter whether a
+  // setup file happened to pre-load the consumer first.
+  //
+  // Deliberately compares export SETS rather than naming `subscribeDataChanges`:
+  // naming the one export that broke would just re-arm the same trap for the
+  // next export somebody adds.
+  it('mocks @object-ui/react as a superset of the real module (pins both run paths to the same result)', async () => {
+    const actual = await vi.importActual<typeof ObjectUIReact>('@object-ui/react');
+
+    const missing = Object.keys(actual)
+      .filter((name) => !(name in ObjectUIReact))
+      .sort();
+
+    expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3219

按 PM 在认领评论里的裁定,本 PR 只做两件事:把 `registration.test.tsx` 改成 `importOriginal` 的部分 mock,并补一条断言钉住**这个文件**在两条运行路径下结论一致。全仓 17 个包的 vitest 配置治理**不在本单**,已另立 #3240。

## 根因(实测坐实,不是推测)

同一份 `packages/plugin-calendar/src/registration.test.tsx`,两套配置结论相反:

| 路径 | 实际执行 | 修复前 |
|:--|:--|:--|
| CI(根 `vitest.config.mts`,`vitest run --shard=N/4`) | `@object-ui/*` alias 到**源码** | **绿** |
| `pnpm --filter @object-ui/plugin-calendar test` / `turbo run test`(包内 `vitest.config.ts`) | 无 alias,解析到 **`dist`** | **红** |

原来的写法是整模块替换,只列了 `useSchemaContext` + `SchemaRendererContext`。真正 import `subscribeDataChanges` 的不是 plugin-calendar 自己,而是**传递依赖** `@object-ui/components` 的 `src/hooks/related-count-store.ts`。

关键的一层:**根配置那一侧的"绿"是偶然的**。该文件在根配置的 `heavyDomTests` 名单里,`vitest.setup.dom.tsx` 会**预先** `import '@object-ui/components'`,于是 `related-count-store.ts` 在 `vi.mock` 生效**之前**就已按真实模块求值完毕;包配置没有这个 setup,`@object-ui/components` 首次求值发生在被 mock 的图里,vitest 4 对整模块 mock 的缺失导出是硬报错(不再静默给 `undefined`),于是整份文件加载失败。

所以分叉有**两个叠加变量**:alias 解析目标(源码 vs `dist`),以及 setupFiles 是否预热了消费者模块。

## 修法

改用 `importOriginal` 的部分 mock,只覆盖这份测试真正要控制的 `useSchemaContext`:

```ts
vi.mock(import('@object-ui/react'), async (importOriginal) => ({
  ...(await importOriginal()),
  useSchemaContext: vi.fn(() => ({ dataSource: { type: 'mock-datasource' } })),
}));
```

这样 mock 在**任一**解析路径下都是真实模块的超集,传递依赖不可能再撞上一个本测试从未打算替换的导出。`SchemaRendererContext` 不必再手写——原模块的那个会被 spread 进来。

`vi.mock('./ObjectCalendar', …)` 保持整模块替换:那是本测试**刻意**的隔离边界(且该模块唯一的运行时导出就是组件本身,`ObjectCalendarProps` 是类型、运行时已擦除)。

## 防回归断言

新增一条断言,钉的正是"分叉"本身的不变式——mock 必须是真实模块的**超集**:

```ts
const actual = await vi.importActual< typeof ObjectUIReact >('@object-ui/react');
const missing = Object.keys(actual).filter((name) => !(name in ObjectUIReact)).sort();
expect(missing).toEqual([]);
```

刻意比较**导出集合**而不是点名 `subscribeDataChanges`:点名只会把同一个陷阱推迟到下一个新增导出(这正是原 issue 指出的问题)。该不变式成立时,任何传递 importer 都不会遇到缺失导出,于是文件在哪套配置下解析、setup 有没有预热消费者,结论都一样。

## 验证

**修复前**,包路径(issue 报告的那条):

```
FAIL  src/registration.test.tsx [ src/registration.test.tsx ]
Error: [vitest] No "subscribeDataChanges" export is defined on the "@object-ui/react" mock.
 ❯ src/CalendarView.tsx:13:1
 Test Files  1 failed (1) /  Tests  no tests
```

**修复后,两条路径一致**:

```
$ pnpm --filter @object-ui/plugin-calendar exec vitest run src/registration.test.tsx
 Test Files  1 passed (1) /  Tests  3 passed (3)

$ pnpm exec vitest run --project dom-heavy packages/plugin-calendar/src/registration.test.tsx
 Test Files  1 passed (1) /  Tests  3 passed (3)
```

包全量:`Test Files  3 passed (3)` / `Tests  16 passed (16)`(原为 `1 failed | 2 passed`)。`type-check` 通过,`lint` 0 error。

**断言的反向验证**(把整模块 mock 改回去,断言留着):

```
# 根路径 —— 即原缺陷"看不见"的那条,现在也红了:
AssertionError: expected [ 'ActionCtxReact', …(125) ] to deeply equal []
+   "subscribeDataChanges",
      Tests  1 failed | 2 passed (3)

# 包路径:
Error: [vitest] No "subscribeDataChanges" export is defined on the "@object-ui/react" mock.
 Test Files  1 failed (1) /  Tests  no tests
```

两条路径同红同绿,断言确实拦得住。

## 关于 changeset

**未加**,理由:本 PR 只改动一个 `*.test.tsx`,不进 `dist`(包的 `files` 只发 `dist`/README/CHANGELOG),对使用者零可见变化。按 AGENTS.md「功能改进需写 changeset;纯 bug 修复不需要」,测试基础设施修复比纯 bugfix 更靠内。加了反而会让 `fixed` 组 39 个包为一次测试改动整体升版。如维护者认为仍需登记,我补一条 `patch` 即可。

## 越界发现

- **#3240**:全仓 17 个包各自带 `vitest.config.ts` 与根 `vitest.config.mts` 的分叉治理(评论里"删掉本地配置比修好它更彻底"那条方向)。已按 Prime Directive #10 **不认领**立单,正文写明本 PR 坐实的分叉机制、17 个包清单,以及动手前必须先回答的问题「哪些包真的需要本地配置」。未在本 PR 处理:那是跨 17 个包的配置面重构,会与本轮在飞单大面积撞文件。
- 原 issue 附带的 `plugin-gantt` `ELIFECYCLE` 未追:issue 自述是并发/内存漂移,与本条不是一回事。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_