### PR TITLE
fix(plugin-detail,plugin-list): add missing @object-ui/permissions dev edge so turbo `^build` reaches it

### DIFF
--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -49,6 +49,7 @@
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
     "@object-ui/fields": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@types/react": "19.2.17",

--- a/packages/plugin-list/package.json
+++ b/packages/plugin-list/package.json
@@ -52,6 +52,7 @@
     "@object-ui/fields": "workspace:*",
     "@object-ui/i18n": "workspace:*",
     "@object-ui/mobile": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0-rc.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1765,9 +1765,6 @@ importers:
       '@object-ui/i18n':
         specifier: workspace:*
         version: link:../i18n
-      '@object-ui/permissions':
-        specifier: workspace:^
-        version: link:../permissions
       '@objectstack/spec':
         specifier: ^17.0.0-rc.1
         version: 17.0.0-rc.1(ai@7.0.37(zod@4.4.3))
@@ -1790,6 +1787,9 @@ importers:
       '@object-ui/fields':
         specifier: workspace:*
         version: link:../fields
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react
@@ -2107,9 +2107,6 @@ importers:
 
   packages/plugin-list:
     dependencies:
-      '@object-ui/permissions':
-        specifier: workspace:^
-        version: link:../permissions
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.8)
@@ -2135,6 +2132,9 @@ importers:
       '@object-ui/mobile':
         specifier: workspace:*
         version: link:../mobile
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react

--- a/scripts/__tests__/workspace-peer-dependency-edges.test.ts
+++ b/scripts/__tests__/workspace-peer-dependency-edges.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3207: `turbo run type-check --filter=@object-ui/plugin-detail` failed
+ * on a clean worktree with six `TS2307: Cannot find module '@object-ui/permissions'`
+ * errors, plus the `TS7006 implicitly has an 'any' type` cascade that follows a
+ * failed import. `@object-ui/plugin-list` had the identical break.
+ *
+ * The cause is a build-graph hole, not a missing install. Both packages listed
+ * `@object-ui/permissions` in `peerDependencies` only. pnpm still symlinks such a
+ * peer into `node_modules` (the lockfile recorded it under the importer's
+ * `dependencies`), so the package *path* resolved fine — but turbo reads
+ * `package.json`, not the lockfile, and the `type-check` task's `dependsOn:
+ * ["^build"]` walks `dependencies`/`devDependencies` only. `permissions/dist`
+ * therefore never got built, and `tsc` found a directory with no type
+ * declarations in it.
+ *
+ * Why that is worth a guard rather than just a one-line fix: the full-repo
+ * `pnpm type-check` was GREEN the whole time, because some other package's build
+ * dragged `@object-ui/permissions` up as a side effect. CI could not see this.
+ * The only command that could was a scoped, per-package typecheck — precisely the
+ * command someone should run after touching one package — and it answered with a
+ * screenful of red that had nothing to do with their change. That is the worst
+ * possible failure mode: it trains people to ignore the output of the one check
+ * that would have caught their real mistake.
+ *
+ * So the invariant is enforced structurally instead of being restored by hand:
+ * a peer that lives in this workspace must also carry a `dependencies` or
+ * `devDependencies` edge, so turbo's `^` traversal can actually reach it. At the
+ * time of writing every one of the workspace's packages satisfies this, which is
+ * why there is no exemption list here and should not become one — an exemption
+ * would be indistinguishable from the bug this pins down.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+interface WorkspacePackage {
+  name: string;
+  dir: string;
+  json: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  };
+}
+
+/**
+ * The `packages:` globs from `pnpm-workspace.yaml`, read rather than hardcoded so
+ * a new workspace root is covered the day it is added.
+ *
+ * The parser deliberately understands only the two shapes the file actually uses
+ * (`dir/*` and a bare `dir`). Anything else throws instead of being skipped: a
+ * guard that silently stops looking at part of the workspace is worse than no
+ * guard, because it keeps reporting success over a shrinking surface.
+ */
+function workspaceGlobs(): string[] {
+  const yaml = fs.readFileSync(path.join(repoRoot, 'pnpm-workspace.yaml'), 'utf8');
+  const lines = yaml.split('\n');
+  const start = lines.findIndex((l) => /^packages:\s*$/.test(l));
+  expect(start, '`pnpm-workspace.yaml` must still declare a top-level `packages:` key').toBeGreaterThan(-1);
+
+  const globs: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    // A non-indented line ends the `packages:` block.
+    if (!/^\s/.test(line)) break;
+    const match = line.match(/^\s*-\s*['"]?([^'"#\s]+)['"]?\s*(#.*)?$/);
+    if (!match) throw new Error(`Unparsed entry in pnpm-workspace.yaml \`packages:\`: ${JSON.stringify(line)} — teach this guard the new syntax.`);
+    globs.push(match[1]);
+  }
+  return globs;
+}
+
+function readWorkspacePackages(): WorkspacePackage[] {
+  const found: WorkspacePackage[] = [];
+  for (const glob of workspaceGlobs()) {
+    let dirs: string[];
+    if (glob.endsWith('/*')) {
+      const parent = path.join(repoRoot, glob.slice(0, -2));
+      dirs = fs.existsSync(parent)
+        ? fs.readdirSync(parent).map((d) => path.join(parent, d)).filter((d) => fs.statSync(d).isDirectory())
+        : [];
+    } else if (!glob.includes('*')) {
+      dirs = [path.join(repoRoot, glob)];
+    } else {
+      throw new Error(`Unsupported workspace glob ${JSON.stringify(glob)} — teach this guard how to expand it.`);
+    }
+
+    for (const dir of dirs) {
+      const pkgPath = path.join(dir, 'package.json');
+      if (!fs.existsSync(pkgPath)) continue;
+      const json = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      if (!json.name) continue;
+      found.push({ name: json.name, dir: path.relative(repoRoot, dir), json });
+    }
+  }
+  return found;
+}
+
+const packages = readWorkspacePackages();
+const workspaceNames = new Set(packages.map((p) => p.name));
+
+describe('workspace peer dependencies are reachable by turbo `^build`', () => {
+  it('discovers the workspace (guard cannot pass by finding nothing)', () => {
+    // Without this, a broken parser or a moved directory would turn every
+    // assertion below into a vacuous pass over an empty list.
+    expect(packages.length).toBeGreaterThan(30);
+    expect(workspaceNames.has('@object-ui/plugin-detail')).toBe(true);
+    expect(workspaceNames.has('@object-ui/permissions')).toBe(true);
+  });
+
+  it('every workspace package that is a peer is also a dependency or devDependency', () => {
+    const violations: string[] = [];
+
+    for (const pkg of packages) {
+      const peers = Object.keys(pkg.json.peerDependencies ?? {});
+      const edges = new Set([
+        ...Object.keys(pkg.json.dependencies ?? {}),
+        ...Object.keys(pkg.json.devDependencies ?? {}),
+      ]);
+
+      for (const peer of peers) {
+        // Only workspace packages matter: turbo builds those, and only those
+        // need an edge for `^build` to reach them. An external peer such as
+        // `react` or `@objectstack/spec` comes from the registry already built.
+        if (!workspaceNames.has(peer)) continue;
+        if (edges.has(peer)) continue;
+        violations.push(`${pkg.name} (${pkg.dir}/package.json) declares "${peer}" in peerDependencies but has no dependencies/devDependencies edge for it`);
+      }
+    }
+
+    expect(
+      violations,
+      [
+        'A workspace peer without a dependencies/devDependencies edge is invisible to turbo.',
+        "The `type-check` task's `dependsOn: [\"^build\"]` walks dependencies/devDependencies only,",
+        'so that peer never gets built and a scoped `turbo run type-check --filter=<pkg>` fails with',
+        "TS2307 \"Cannot find module\" errors that have nothing to do with the change being tested.",
+        '',
+        'Fix: add the peer to devDependencies as "workspace:*" (see objectui#3207), then `pnpm install`.',
+        '',
+        ...violations,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('pins the two packages fixed in objectui#3207', () => {
+    // The general assertion above would catch a regression here too, but these
+    // two are named so a revert points straight at the issue that explains why.
+    for (const name of ['@object-ui/plugin-detail', '@object-ui/plugin-list']) {
+      const pkg = packages.find((p) => p.name === name);
+      expect(pkg, `${name} must exist in the workspace`).toBeDefined();
+      expect(
+        pkg!.json.devDependencies?.['@object-ui/permissions'],
+        `${name} imports @object-ui/permissions in its sources, so it needs the devDependencies edge that lets turbo build it`,
+      ).toBe('workspace:*');
+    }
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3207

## 问题

`@object-ui/permissions` 只出现在 `plugin-detail` / `plugin-list` 的 `peerDependencies`,不在 `dependencies` / `devDependencies`。turbo 的 `type-check` 任务 `dependsOn: ["^build"]`,而 `^` 只沿 dependencies/devDependencies 走,所以 `permissions/dist` 永远不会为这条命令构建出来。

值得强调的一点(原单没写,但它解释了为什么这是**构建图**问题而不是安装问题):**pnpm 其实已经把这个 peer 软链进了 `node_modules`** —— 改动前的 lockfile 里,`@object-ui/permissions` 被记在 importer 的 `dependencies` 下(`specifier: workspace:^`)。也就是说包的**路径**一直能解析,`tsc` 找得到那个目录,只是目录里没有 `.d.ts`,于是报 TS2307。turbo 读的是 `package.json`,不是 lockfile,两者不一致正是缺口所在。

## 缺口有两处

按「`peerDependencies` 里的工作区包未同时出现在 `dependencies`/`devDependencies`」逐个扫全工作区(46 个包,含 `apps/*` 与 `examples/*`),命中两个:

```
@object-ui/plugin-detail -> missing: @object-ui/permissions
@object-ui/plugin-list   -> missing: @object-ui/permissions
```

两处都改 `package.json` 且都会动 `pnpm-lock.yaml`,分两个 PR 必然互撞,所以一并修。

## 改动

1. 两个包的 `devDependencies` 各补一行 `"@object-ui/permissions": "workspace:*"`(与同文件其余 peer 的写法一致),`pnpm install` 重新生成 lockfile。
2. 新增 `scripts/__tests__/workspace-peer-dependency-edges.test.ts` —— 把这条不变量**机械化**,而不是手工修完就算。

## 关于那条 guard

原单的深层意思是:一个包改完后最该跑的那条 scoped typecheck,返回的却是一屏与改动无关的红。补一行依赖只恢复了今天的状态,挡不住下一个包再捅同样的窟窿 —— 所以补了 guard。

判据用的是「**这个 peer 是不是工作区里的包**」,而不是「名字是不是 `@object-ui/` 开头」。后者只是巧合,前者才是 turbo 真正在乎的东西(外部 peer 如 `react` / `@objectstack/spec` 从 registry 装来就是构建好的,不需要这条边)。

几个刻意的设计:

- **没有豁免名单**,现在也不该有 —— 修完之后全工作区 46 个包无一违反,而一条豁免和这个 bug 本身在形态上无法区分。
- **workspace 根从 `pnpm-workspace.yaml` 读**,不写死,新增工作区根当天就被覆盖到;解析器只认文件里实际用的两种写法,遇到看不懂的语法**抛错而不是跳过**(悄悄少看半个工作区的 guard 比没有 guard 更糟)。
- 有一条 `discovers the workspace` 断言兜底,防止解析器坏掉后所有断言在空列表上「真空通过」。
- 失败信息直接给出原因和修法,不用再去翻 issue。

它落在 `scripts/**/*.test.ts`,`vitest.config.mts` 的 `unit` project 已经覆盖这个 glob,所以随 `pnpm test` 自动跑,不需要另外改 workflow(少一处可能忘掉的接线)。全量耗时 272ms。

**反向验证过**:临时把 `plugin-detail` 那行 devDep 删掉,guard 如期变红并指名道姓;恢复后转绿。

## 关于 changeset(未加,理由如下)

按 AGENTS.md「纯 bug 修复不需要 changeset」,且这次改的只有 `devDependencies` —— 消费者安装依赖时**不会**装 devDependencies,`peerDependencies` / `dependencies` 一个字没动,发布物的行为零变化,属于仓库内构建图/DX 修复。加 changeset 会让 `fixed` 组 39 个包为一次消费者观察不到的改动集体 patch 发版。若维护者认为仍需留一条 changelog 记录,我可以补一个 `patch`。

## 验证

改动前(干净 worktree,`packages/permissions/dist` 不存在):

```
$ pnpm exec turbo run type-check --filter=@object-ui/plugin-detail
@object-ui/plugin-detail:type-check: src/DetailView.tsx(49,32): error TS2307: Cannot find module '@object-ui/permissions' or its corresponding type declarations.
@object-ui/plugin-detail:type-check: src/RelatedList.tsx(51,32): error TS2307: ...
@object-ui/plugin-detail:type-check: src/renderers/record-details.tsx(15,53): error TS2307: ...
@object-ui/plugin-detail:type-check: src/renderers/record-details.tsx(116,18): error TS7006: Parameter 'n' implicitly has an 'any' type.
@object-ui/plugin-detail:type-check: src/renderers/record-highlights.tsx(15,53): error TS2307: ...
@object-ui/plugin-detail:type-check: src/renderers/record-quick-actions.tsx(21,32): error TS2307: ...
@object-ui/plugin-detail:type-check: src/renderers/record-related-list.tsx(16,53): error TS2307: ...
@object-ui/plugin-detail:type-check: src/renderers/record-related-list.tsx(161,60): error TS7006: Parameter 'n' implicitly has an 'any' type.
Failed:    @object-ui/plugin-detail#type-check

$ pnpm exec turbo run type-check --filter=@object-ui/plugin-list
@object-ui/plugin-list:type-check: src/ListView.tsx(24,32): error TS2307: Cannot find module '@object-ui/permissions' or its corresponding type declarations.
Failed:    @object-ui/plugin-list#type-check
```

`plugin-list` 复现的是同一类失败(只有一处 import,所以只有一条),**不是**依赖边本来就完整。

改动后(先 `rm -rf packages/permissions/dist`,以证明是 turbo 自己把它构建出来的):

```
$ pnpm exec turbo run type-check --filter=@object-ui/plugin-detail
@object-ui/permissions:build: > @object-ui/permissions@17.2.0 build
@object-ui/permissions:build: > tsc
@object-ui/plugin-detail:type-check: > tsc --noEmit && tsc -p tsconfig.typetests.json
 Tasks:    12 successful, 12 total

$ pnpm exec turbo run type-check --filter=@object-ui/plugin-list
@object-ui/plugin-list:type-check: > tsc --noEmit && tsc -p tsconfig.typetests.json
 Tasks:    13 successful, 13 total
```

`@object-ui/permissions:build` 出现在依赖图里 —— 这正是原先缺失的那条边。

其余:

```
$ pnpm exec turbo run test --filter=@object-ui/plugin-detail --filter=@object-ui/plugin-list
@object-ui/plugin-detail:test:  Test Files  38 passed (38)
@object-ui/plugin-detail:test:       Tests  362 passed (362)
 Tasks:    14 successful, 14 total

$ pnpm exec vitest run --project unit scripts/
 Test Files  4 passed (4)
      Tests  34 passed (34)

$ pnpm exec eslint scripts/__tests__/workspace-peer-dependency-edges.test.ts
(exit 0)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_