### PR TITLE
test(types): move the sole `PageNodeSchema['type']` pin into the package that owns the type (#3227)

### DIFF
--- a/packages/layout/src/__tests__/spec-symbol-batch7.test.ts
+++ b/packages/layout/src/__tests__/spec-symbol-batch7.test.ts
@@ -17,8 +17,9 @@
  *  - `PageHeaderProps` → `PageHeaderComponentProps`, the name
  *    `@object-ui/app-shell` already settled on for its own header props
  *    (objectui#3169). Reused deliberately: one concept, one name, even across
- *    two packages that each draw their own header. Still exported, still
- *    guarded below.
+ *    two packages that each draw their own header. Still exported by this
+ *    package, still guarded below — that is the whole of what this file now
+ *    covers.
  *  - `Page` → `PageNodeRenderer` → **deleted** (objectui#3223, ADR-0049
  *    enforce-or-remove). The rename was correct and did not go far enough: the
  *    renderer was registered nowhere and called from nowhere — the `page` key
@@ -26,13 +27,15 @@
  *    actively discourages re-registering it — so all the export did was tell
  *    the next reader that `@object-ui/layout` is where page rendering lives.
  *
- * What survives that deletion is the LAYER SPLIT it was renamed for, pinned
- * below: the spec's `Page` is the authored page DOCUMENT, `@object-ui/types`'s
- * `PageNodeSchema` is the SDUI NODE discriminated by `type: 'page'`, and the
- * two are not interchangeable. Those pins are load-bearing beyond the deleted
- * component — `type: 'page'` is the wire key `PageRenderer` is registered
- * under, and this is the only place in the repo that pins it — so they are
- * kept here rather than deleted along with their former subject.
+ * The LAYER SPLIT that second rename was made for outlived the component, and
+ * used to be pinned here: the spec's `Page` is the authored page DOCUMENT,
+ * `@object-ui/types`'s `PageNodeSchema` is the SDUI NODE discriminated by
+ * `type: 'page'`. Those pins have moved to
+ * `packages/types/src/__tests__/page-node-type-contract.test.ts`
+ * (objectui#3227) — they are still the repo's only guard on that contract, but
+ * they belong with the package that declares the type, not with a deleted
+ * renderer in a package that no longer references `PageNodeSchema` at all.
+ * **Do not re-add them here; extend them there.**
  *
  * Each `import type` below is load-bearing: if the spec retires one of these
  * names, this file stops compiling, and the rename's justification is up for
@@ -45,8 +48,7 @@ import { describe, it, expect } from 'vitest';
 // `PageHeaderProps` is a zod SCHEMA in the spec, not a type — which is the
 // collision in one line: the spec's is a validator for authored JSON, this
 // package's was a React props interface.
-import type { Page as SpecPage, PageHeaderProps as SpecPageHeaderPropsSchema } from '@objectstack/spec/ui';
-import type { PageNodeSchema } from '@object-ui/types';
+import type { PageHeaderProps as SpecPageHeaderPropsSchema } from '@objectstack/spec/ui';
 
 import { PageHeader } from '../PageHeader';
 import type { PageHeaderComponentProps } from '../PageHeader';
@@ -71,9 +73,8 @@ type HasKey<T, K extends string> = K extends keyof T ? true : false;
 /** What `PageHeaderProps.parse()` returns — the authored node, normalised. */
 type SpecParsedHeader = (typeof SpecPageHeaderPropsSchema)['_zod']['output'];
 
-describe('the spec names still mean the authored layer', () => {
+describe('the spec name still means the authored layer', () => {
   it('is pinned at compile time', () => {
-    type _PageIsReal = Assert<Equal<IsAny<SpecPage>, false>>;
     type _HeaderIsReal = Assert<Equal<IsAny<SpecParsedHeader>, false>>;
 
     // The spec's is the AUTHORED node: `breadcrumb` is a required boolean once
@@ -84,17 +85,6 @@ describe('the spec names still mean the authored layer', () => {
     type _RenderedIsNotAuthored = Assert<Equal<Extends<PageHeaderComponentProps, SpecParsedHeader>, false>>;
     type _AuthoredHasBreadcrumb = Assert<HasKey<SpecParsedHeader, 'breadcrumb'>>;
     type _RenderedHasSchemaNode = Assert<HasKey<PageHeaderComponentProps, 'schema'>>;
-
-    // `Page` in the spec is the page DOCUMENT (`name` + `label` identify it);
-    // the SDUI node is `PageNodeSchema`, tagged `type: 'page'`. Two layers, two
-    // names — pinned here even though objectui#3223 deleted this package's
-    // page-node renderer, because `type: 'page'` is the registry key
-    // `@object-ui/components`'s `PageRenderer` answers to, and nowhere else in
-    // the repo pins it. Collapse these two types back together and the next
-    // renderer named after the wrong layer compiles clean.
-    type _DocumentIsNotNode = Assert<Equal<Equal<SpecPage, PageNodeSchema>, false>>;
-    type _DocumentIsIdentified = Assert<HasKey<SpecPage, 'name'>>;
-    type _NodeIsATaggedNode = Assert<Equal<PageNodeSchema['type'], 'page'>>;
 
     expect(true).toBe(true);
   });

--- a/packages/types/src/__tests__/page-node-type-contract.test.ts
+++ b/packages/types/src/__tests__/page-node-type-contract.test.ts
@@ -1,0 +1,99 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `PageNodeSchema` ↔ `@objectstack/spec` page-layer contract.
+ *
+ * Two pins, one contract: the authored page DOCUMENT and the SDUI page NODE are
+ * different types at different layers, and the node's discriminant is exactly
+ * `'page'`.
+ *
+ *  - `Page` in `@objectstack/spec/ui` is the page DOCUMENT — the authored
+ *    metadata record, identified by `name`.
+ *  - {@link PageNodeSchema} here is the SDUI NODE the renderer walks, tagged
+ *    `type: 'page'`. That tag is not decoration: it is the `ComponentRegistry`
+ *    key `@object-ui/components` registers `PageRenderer` under
+ *    (`packages/components/src/renderers/layout/page.tsx`) — the WIRE key every
+ *    producer of page metadata emits. Change it and authored JSON silently
+ *    stops resolving to a renderer at runtime; nothing else in the repo
+ *    complains at build time.
+ *
+ * Collapse the two types back together and the next renderer named after the
+ * wrong layer compiles clean.
+ *
+ * ## Do not delete or relax these pins
+ *
+ * This is the ONLY place in the repo that pins `PageNodeSchema['type']` to
+ * exactly `'page'`. `p1-spec-alignment.test.ts` writes
+ * `const page: PageNodeSchema = { type: 'page', … }`, which looks equivalent
+ * and is not: assignability only proves `'page'` is *admitted*, so widening the
+ * discriminant to `string` — or to any union that still contains `'page'` —
+ * leaves every one of those green. Only `Equal<…>` fails on a widening, which
+ * is why `Equal` here must never be softened to `Extends`.
+ *
+ * ## Why this file, and not `packages/layout`
+ *
+ * These pins were written in
+ * `packages/layout/src/__tests__/spec-symbol-batch7.test.ts` (objectui#3161,
+ * objectstack#4115 ledger batch 7) and deliberately survived the deletion of
+ * that package's `PageNodeRenderer` (objectui#3223): the component died, the
+ * wire contract did not. They moved here (objectui#3227) because that left the
+ * repo's only guard on this contract sitting in a package that no longer
+ * references `PageNodeSchema` at all — where it read as debris from a finished
+ * refactor, and deleting it would have gone unnoticed by every test. This
+ * package declares the type, so it owns the pin.
+ *
+ * The `import type` of the spec's `Page` is load-bearing in the other
+ * direction too: if the spec retires that name, this file stops compiling and
+ * the layer split is re-triaged instead of quietly outliving its subject.
+ *
+ * ## These assertions are compile-time only
+ *
+ * They mean something here only because this package actually type-checks its
+ * tests. `tsconfig.json` excludes test files (they must not emit into `dist`)
+ * and `tsconfig.test.json` picks them back up, chained off the package's
+ * `type-check` script. Vitest alone would NOT catch a broken pin — it strips
+ * types without checking them (objectstack#4642). If this package ever stops
+ * running `tsc -p tsconfig.test.json`, everything below silently becomes a
+ * comment.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Page as SpecPage } from '@objectstack/spec/ui';
+// Imported through the package entrypoint, not `../layout`: the barrel is the
+// surface `@object-ui/components` and every other consumer sees.
+import type { PageNodeSchema } from '../index';
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins — compiled by tsconfig.test.json, chained off type-check. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type HasKey<T, K extends string> = K extends keyof T ? true : false;
+
+describe('the authored page document and the SDUI page node stay two types', () => {
+  it('is pinned at compile time', () => {
+    // Keeps the pins below from passing vacuously: `Equal<any, X>` is `false`
+    // and `keyof any` admits every key, so an `any` `SpecPage` would satisfy
+    // both of them while checking nothing at all.
+    type _PageIsReal = Assert<Equal<IsAny<SpecPage>, false>>;
+
+    // The spec's `Page` is the page DOCUMENT (`name` identifies it); the SDUI
+    // node is `PageNodeSchema`, tagged `type: 'page'`. Two layers, two names.
+    type _DocumentIsNotNode = Assert<Equal<Equal<SpecPage, PageNodeSchema>, false>>;
+    type _DocumentIsIdentified = Assert<HasKey<SpecPage, 'name'>>;
+
+    // The wire key `PageRenderer` is registered under. Exact equality, not
+    // assignability — see the file header.
+    type _NodeIsATaggedNode = Assert<Equal<PageNodeSchema['type'], 'page'>>;
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -520,6 +520,15 @@ export interface PageNodeRegion {
  * Page layout component
  * Top-level container for a page route.
  * Aligned with @objectstack/spec PageSchema
+ *
+ * This is the SDUI NODE, not the authored page DOCUMENT — the spec's `Page`
+ * is that, and the two are deliberately different types (same layer split as
+ * {@link PageNodeRegion}).
+ *
+ * Tripwire: `__tests__/page-node-type-contract.test.ts`, which pins
+ * `type` to exactly `'page'` — the `ComponentRegistry` key
+ * `@object-ui/components` registers `PageRenderer` under, i.e. the wire key
+ * authored metadata carries. Nothing else in the repo pins it.
  */
 export interface PageNodeSchema extends BaseSchema {
   type: 'page';


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3227

## 做了什么

把全仓唯一一条钉住 SDUI 页面节点判别式的编译期断言,从 `packages/layout` 搬到了声明该类型的 `packages/types`。

新家:`packages/types/src/__tests__/page-node-type-contract.test.ts`(新文件,名字说的是它现在的职责,不是某一批已完成的改名)。

搬过去的是**两条**,不是一条 —— issue 只点名了后者,但它们是同一份契约的两面(**页面 DOCUMENT 不是页面 NODE**),把其中一条留在一个两个类型都不引用的包里没有意义:

```ts
type _DocumentIsNotNode = Assert< Equal< Equal< SpecPage, PageNodeSchema >, false > >;
type _NodeIsATaggedNode = Assert< Equal< PageNodeSchema['type'], 'page' > >;
```

连带搬走的还有它们的两条支撑断言:`_DocumentIsIdentified`(`HasKey< SpecPage, 'name' >`)和 `_PageIsReal`(`IsAny< SpecPage >` 为 false)。后者不是装饰 —— `Equal< any, X >` 是 `false`、`keyof any` 又接受任何键,所以 `SpecPage` 一旦退化成 `any`,上面两条会**双双空转通过**。

**断言本身一个字没改**,仍然是 `Equal<…>` 而不是 `Extends<…>`(理由见下)。

原文件 `packages/layout/src/__tests__/spec-symbol-batch7.test.ts` 现在只覆盖 batch 7 真正活下来的那个符号(`PageHeaderProps` → `PageHeaderComponentProps`),头注释按新事实重写了一遍,并留下指向新家的指针 + 「不要搬回来,要扩展就去那边扩展」。

另外给 `PageNodeSchema` 的类型声明加了一行 `Tripwire:` 反向指针(沿用同文件里 `PageNodeRegion` 已有的写法),让守卫从它守的类型出发就能找到 —— 这正是本 issue 抱怨的「守卫本身没有守卫」。

## 新家的断言是**真的**在跑 —— 用破坏实验证明,不是靠推断

issue 的要害是「一条覆盖消失了没有任何东西会报红」,而 objectstack#4642 记过这个仓库家族的前科:`tsconfig.json` 排除 `*.test.ts`、vitest 又不开 `typecheck`,于是编译期断言住进一个没人 type-check 的文件里就等于注释。所以搬家之前先查了落点。

`packages/types` 是**有**这道链路的:

- `tsconfig.json` 排除测试(它们不能 emit 进 `dist`);
- `tsconfig.test.json` 把它们接回来(`include: src/**/*.test.ts`);
- `package.json` 的 `type-check` = `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`;
- CI `ci.yml` 跑 `pnpm type-check`,外加 `scripts/check-type-check-coverage.mjs` 保证没有包漏掉这个脚本。

然后**真的把它钉的东西掰断**验证(两次都已还原):

**实验 A —— 直接改判别式** `type: 'page'` → `'page-node'`:

```
src/__tests__/p1-spec-alignment.test.ts(425,9): error TS2322: Type '"page"' is not assignable to type '"page-node"'.
src/__tests__/p1-spec-alignment.test.ts(447,7): error TS2322: Type '"page"' is not assignable to type '"page-node"'.
src/__tests__/p1-spec-alignment.test.ts(597,7): error TS2322: Type '"page"' is not assignable to type '"page-node"'.
src/__tests__/page-node-type-contract.test.ts(95,38): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

**实验 B —— 放宽成** `type: 'page' | 'page-node'`(运行时后果更坏:producer 可以合法发出一个注册表里根本没有的键,而类型层面全绿):

```
src/__tests__/page-node-type-contract.test.ts(95,38): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

整个包**只有一条错误,就是搬过来的这条**。

## 顺带回答 issue 的「别处是否已有等价覆盖」

issue 说「我查的时候没有」,要求核实后再决定要不要合并两处。核实结论:**没有等价覆盖,不合并**。

`p1-spec-alignment.test.ts` 里有三处 `const page: PageNodeSchema = { type: 'page', … }`,看着像等价物,其实不是 —— 那是**可赋值性**,只证明 `'page'` 被*接受*。实验 B 就是这件事的证据:判别式一放宽,那三处**全绿**,只有 `Equal<…>` 这条会红。

这也正是**为什么这条断言不能被「顺手放宽」成 `Extends`** —— 放宽之后它就退化成 `p1-spec-alignment` 已有的那种检查,等于自己把自己删掉。新文件的头注释把这一段写进去了,给下一个动它的人。

## 关于 changeset:本 PR 不加,理由如下

按 AGENTS.md「功能改进需写 changeset;纯 bug 修复不需要」,这次两头都不是 —— 没有运行时代码、没有公开 API、没有类型面变化:

- 两个测试文件的增删改;
- `packages/types/src/layout.ts` 只动了**文档注释**(那行 `Tripwire:` 指针),`PageNodeSchema` 的结构一字未改。

消费者编译所依赖的 `dist` 完全不变。(`@object-ui/types` 的 `files` 确实包含 `src`,所以新测试文件会进 npm tarball —— 但该包 `src/__tests__/` 下**所有**测试文件本来就在里面,这是既有现状,不是本 PR 新增的暴露面。)

## 验证

```
$ pnpm --filter @object-ui/types type-check
> tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json
（无输出 = 通过）

$ npx turbo run type-check lint --filter=@object-ui/types --filter=@object-ui/layout
 Tasks:    12 successful, 12 total
（lint 0 errors;warnings 全部是既有的 no-explicit-any / 断言别名未使用,与 layout 原文件同型)

$ npx vitest run packages/types packages/layout
 Test Files  30 passed (30)
      Tests  449 passed (449)
```

`packages/layout` 的 `page-node-renderer-stays-deleted.test.ts` 仍然绿:它的 `MAY_MENTION` 白名单里有 `spec-symbol-batch7.test.ts`,而该文件头注释里仍然合法地提到 `PageNodeRenderer`。

改动范围严格限制在 `packages/layout` 与 `packages/types`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_