### PR TITLE
fix(app-shell): ToolPreview 不再渲染已退役的 ToolSchema 标记徽标 (#3236)

### DIFF
--- a/.changeset/toolpreview-drop-retired-flag-pills.md
+++ b/.changeset/toolpreview-drop-retired-flag-pills.md
@@ -1,0 +1,39 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`ToolPreview` stops advertising retired `ToolSchema` flags (objectui#3236).
+
+The metadata-admin tool preview painted a header strip of flag pills read
+straight off the raw draft: `Requires confirmation`, `Active` / `Disabled`,
+`built-in`, and the `category` tag. All four keys have been removed from
+`@objectstack/spec`'s `ToolSchema` — `requiresConfirmation` in the 16.x line
+(objectstack#3715, ADR-0033 §2) and `category` / `active` / `builtIn` in
+17.0.0 (objectstack#3896 audit close-out). The schema is `.strict()` and now
+rejects each by name with an upgrade prescription, so no newly authored tool
+can carry them; verified against the `@objectstack/spec@17.0.0-rc.1` this repo
+depends on.
+
+New metadata could not reach these pills — but rows stored before the removals
+still carry the keys, and for those the preview kept rendering. That is the
+harmful direction, not a cosmetic one:
+
+- `Requires confirmation` advertised a safety pause that no execution path has
+  ever performed. Nothing read the key — not the LLM tool set (a tool reaches
+  the model as name/description/parameters only), not `ToolRegistry.execute`,
+  not `POST /ai/tools/:name/execute`. A reviewer reading the preview saw a
+  destructive tool marked as gated when it was not. The real gate is
+  `action.ai.requiresConfirmation`, which the HITL approval queue reads.
+- `Disabled` claimed a tool had been withdrawn while `ToolRegistry.getAll()`
+  kept handing it to the LLM and the execute route kept running it.
+
+Same shape as objectui#2962: a UI badge advertising a capability the runtime
+does not have. The pills are gone; the surviving header strip shows label,
+machine name and the `objectName` pill (`objectName` is still a live spec key),
+and nothing else in the preview changed — parameters table, example LLM call
+and output schema are untouched.
+
+New tests feed the preview a stale draft that still carries all four retired
+keys and assert none of them renders, so the pills cannot grow back: the names
+survive in the spec's tombstone guidance, which gives the next reader a
+plausible-looking reason to "restore" them.

--- a/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.test.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ToolPreview must not advertise retired `ToolSchema` flags (objectui#3236).
+ *
+ * `tool.requiresConfirmation` (objectstack#3715, ADR-0033 §2) and
+ * `tool.category` / `tool.active` / `tool.builtIn` (objectstack#3896 audit
+ * close-out) were removed from `@objectstack/spec`. `ToolSchema` is now
+ * `.strict()` and rejects each by name, so no *new* tool metadata can carry
+ * them — but stored rows authored before the removal still do, and the
+ * preview kept reading them off the raw draft and painting pills.
+ *
+ * That is the objectui#2962 shape: a UI badge advertising a capability the
+ * runtime never had. `Requires confirmation` promised a pause that no
+ * execution path performs (the real gate is `action.ai.requiresConfirmation`
+ * plus the HITL approval queue), and `Disabled` claimed a withdrawal while
+ * `ToolRegistry.getAll()` kept handing the tool to the LLM and
+ * `POST /ai/tools/:name/execute` kept running it.
+ *
+ * These tests feed the preview a STALE draft that still carries all four keys
+ * and assert nothing renders from them. They are the pin that stops the pills
+ * growing back: the names survive in the spec's tombstone guidance, so the
+ * next reader has a plausible reason to "restore" them.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ToolPreview } from './ToolPreview';
+
+afterEach(cleanup);
+
+/** A draft as an author wrote it *before* the spec removals — every retired key present. */
+const STALE_DRAFT = {
+  name: 'delete_all_orders',
+  label: 'Delete All Orders',
+  description: 'Permanently removes every order matching the filter.',
+  category: 'data',
+  active: false,
+  builtIn: true,
+  requiresConfirmation: true,
+  objectName: 'sales_order',
+  parameters: {
+    type: 'object',
+    required: ['status'],
+    properties: {
+      status: { type: 'string', description: 'Filter by status' },
+    },
+  },
+} satisfies Record<string, unknown>;
+
+function renderPreview(draft: Record<string, unknown>) {
+  return render(
+    <ToolPreview {...({ type: 'tool', name: 'delete_all_orders' } as never)} draft={draft} />,
+  );
+}
+
+describe('ToolPreview does not render retired ToolSchema flags', () => {
+  it('renders no confirmation badge for a stale draft with requiresConfirmation: true', () => {
+    renderPreview(STALE_DRAFT);
+    // The badge claimed a safety pause that no execution path has ever
+    // performed — never show it, whatever the stored row says.
+    expect(screen.queryByText(/requires confirmation/i)).toBeNull();
+    expect(screen.queryByText(/confirm/i)).toBeNull();
+  });
+
+  it('renders no Active/Disabled badge — `active` withdrew nothing', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText(/^Disabled$/)).toBeNull();
+    expect(screen.queryByText(/^Active$/)).toBeNull();
+  });
+
+  it('renders no built-in or category badge', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText(/built-in/i)).toBeNull();
+    expect(screen.queryByText(/^data$/)).toBeNull();
+  });
+
+  it('an `active: true` draft gets no badge either — the key is gone, not inverted', () => {
+    renderPreview({ ...STALE_DRAFT, active: true, requiresConfirmation: false, builtIn: false });
+    expect(screen.queryByText(/^Active$/)).toBeNull();
+    expect(screen.queryByText(/requires confirmation/i)).toBeNull();
+  });
+});
+
+describe('ToolPreview still renders everything the spec accepts', () => {
+  it('keeps label, machine name, description and the live objectName pill', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.getByText('Delete All Orders')).toBeTruthy();
+    expect(screen.getByText('delete_all_orders')).toBeTruthy();
+    expect(
+      screen.getByText('Permanently removes every order matching the filter.'),
+    ).toBeTruthy();
+    // `objectName` is NOT residue — ToolSchema still accepts it.
+    expect(screen.getByText('sales_order')).toBeTruthy();
+  });
+
+  it('still renders the parameters table and the example LLM call', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.getByText('Input Parameters')).toBeTruthy();
+    expect(screen.getByText('status')).toBeTruthy();
+    expect(screen.getByText('Example LLM Call')).toBeTruthy();
+  });
+
+  it('drops the pill row entirely when objectName is absent', () => {
+    const noObject: Record<string, unknown> = { ...STALE_DRAFT };
+    delete noObject.objectName;
+    renderPreview(noObject);
+    expect(screen.queryByText('sales_order')).toBeNull();
+    expect(screen.getByText('Delete All Orders')).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.tsx
@@ -6,8 +6,7 @@
  * AI tools are LLM-callable functions whose contract is a JSON Schema
  * in `parameters`. The preview renders:
  *
- *   1. A header strip: machine name, category, target object, flags
- *      (active, requiresConfirmation, builtIn).
+ *   1. A header strip: machine name, label, target object.
  *   2. The description verbatim (this is what the LLM reads to decide
  *      when to call the tool, so authors must be able to skim it).
  *   3. An **input parameters** table extracted from the JSON Schema:
@@ -21,19 +20,30 @@
  * permission checks, and live datasource access that the preview
  * sandbox doesn't provide. Authors get an `Open in API Console` link
  * for end-to-end testing.
+ *
+ * NO FLAG PILLS — deliberate (objectstack#3715 / #3896, objectui#3236).
+ * The header strip used to render `requiresConfirmation`, `active`,
+ * `builtIn` and `category`. All four were removed from the spec's
+ * `ToolSchema`, which is now `.strict()` and rejects them by name with an
+ * upgrade prescription, so no new tool metadata can carry them. Rendering
+ * them for stale stored rows was worse than useless: `Requires
+ * confirmation` advertised a safety pause no execution path has ever
+ * performed (a real gate is `action.ai.requiresConfirmation` + the HITL
+ * approval queue), and `Disabled` claimed a tool had been withdrawn while
+ * the registry kept handing it to the LLM. Do not re-add a pill for any
+ * of these names — the "stale draft" tests in `ToolPreview.test.tsx` fail
+ * if you do. Any new pill must correspond to a key the spec still accepts
+ * AND a behavior the runtime actually performs.
  */
 
 import * as React from 'react';
 import {
-  AlertTriangle,
   Box,
   CheckCircle2,
   ChevronRight,
   Database,
   ExternalLink,
   FileJson,
-  Power,
-  Tag,
   Wrench,
 } from 'lucide-react';
 import type { MetadataPreviewProps } from '../preview-registry';
@@ -96,11 +106,7 @@ export function ToolPreview({ name, draft }: MetadataPreviewProps) {
   const toolName = String(d.name ?? name ?? '');
   const label = String(d.label ?? toolName);
   const description = String(d.description ?? '');
-  const category = (d.category as string | undefined) || undefined;
   const objectName = (d.objectName as string | undefined) || undefined;
-  const requiresConfirmation = !!d.requiresConfirmation;
-  const active = d.active !== false;
-  const builtIn = !!d.builtIn;
 
   const parameters = (d.parameters ?? {}) as JsonSchema;
   const outputSchema = (d.outputSchema ?? undefined) as JsonSchema | undefined;
@@ -161,15 +167,11 @@ export function ToolPreview({ name, draft }: MetadataPreviewProps) {
                   <span className="text-sm font-medium truncate">{label}</span>
                   <span className="font-mono text-[10px] text-muted-foreground">{toolName}</span>
                 </div>
-                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
-                  {category && <Pill icon={Tag} label={category} />}
-                  {objectName && <Pill icon={Database} label={objectName} mono />}
-                  <Pill icon={Power} label={active ? 'Active' : 'Disabled'} tone={active ? 'green' : 'gray'} />
-                  {requiresConfirmation && (
-                    <Pill icon={AlertTriangle} label="Requires confirmation" tone="amber" />
-                  )}
-                  {builtIn && <Pill label="built-in" />}
-                </div>
+                {objectName && (
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+                    <Pill icon={Database} label={objectName} mono />
+                  </div>
+                )}
               </div>
             </div>
             {description && (
@@ -295,27 +297,23 @@ function Empty({ children }: { children: React.ReactNode }) {
   return <div className="text-xs text-muted-foreground italic">{children}</div>;
 }
 
+// `tone` ('green' for Active, 'amber' for Requires confirmation) went away with
+// the flag pills themselves — the surviving caller is the neutral object-name
+// pill. A tone vocabulary kept alive with no caller is how the removed pills
+// grow back.
 function Pill({
   icon: Icon,
   label,
-  tone = 'gray',
   mono = false,
 }: {
   icon?: React.ComponentType<{ className?: string }>;
   label: string;
-  tone?: 'gray' | 'green' | 'amber';
   mono?: boolean;
 }) {
-  const cls =
-    tone === 'green'
-      ? 'text-emerald-700'
-      : tone === 'amber'
-        ? 'text-amber-700'
-        : 'text-foreground';
   return (
     <span className="inline-flex items-center gap-1">
       {Icon && <Icon className="h-3 w-3 text-muted-foreground" />}
-      <span className={`${cls} ${mono ? 'font-mono' : ''}`}>{label}</span>
+      <span className={`text-foreground ${mono ? 'font-mono' : ''}`}>{label}</span>
     </span>
   );
 }


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3236

## 改了什么

`packages/app-shell/src/views/metadata-admin/previews/ToolPreview.tsx` 的头部条原先直接从 raw draft 上读四个键、每个画一枚 pill。四个键全部已从 `@objectstack/spec` 的 `ToolSchema` 移除,现已删除:

| 键 | 原渲染 | 退役出处 |
|---|---|---|
| `requiresConfirmation` | `Requires confirmation`(琥珀色 + 警告图标) | objectstack#3715 / ADR-0033 §2(16.x 线) |
| `active` | `Active` / `Disabled` | objectstack#3896(17.0.0 审计关闭) |
| `builtIn` | `built-in` | objectstack#3896 |
| `category` | 分类标签 pill | objectstack#3896 |

保留的头部条内容:label、机器名、以及 `objectName` pill(`objectName` 仍是 spec 认的键)。参数表、Example LLM Call、Output Schema 一律未动。`Pill` 的 `tone`(`green`/`amber`)词汇随徽标一起删掉 —— 删完已无调用者,留着正是徽标长回来的入口。

## `active` / `builtIn` 的核实结论(issue 要求先核实再动)

**已核实,确属同型残留,一并清理。** 不是照着 issue 猜的,是对着本仓实际安装的 `@objectstack/spec@17.0.0-rc.1` 跑出来的:

```
ToolSchema present: true
requiresConfirmation  => REJECTED: Unrecognized key(s) on the tool definition: `requiresConfirmation`. …
active                => REJECTED: Unrecognized key(s) on the tool definition: `active`. …
builtIn               => REJECTED: Unrecognized key(s) on the tool definition: `builtIn`. …
category              => REJECTED: Unrecognized key(s) on the tool definition: `category`. …
permissions           => REJECTED: Unrecognized key(s) on the tool definition: `permissions`. …
objectName+outputSchema => ACCEPTED
```

spec 源码里的注释也把这四个并列写死了:「`category`、`permissions`、`active` 和 `builtIn` 由 2026-07 #3896 安全审计关闭一并移除」。

**顺带发现:`category` 也是同型残留**(issue 只点了 `active`/`builtIn`)。它由同一次 #3896 移除、在同一条头部条上渲染,是同一次核实查出来的,因此一并删,单独在这里说明。`permissions` 本预览从未读取,无需处理。

## 为什么这不是"少画个徽标"的小事

spec 已 `.strict()` 具名拒收,所以**新**元数据带不进来 —— 但退役前入库的**陈旧存量行**仍带着这些键,预览照亮不误。危害方向是明确的:

- `Requires confirmation` 在宣传一个**从未存在的安全暂停**。没有任何执行路径读过它 —— 不是 LLM tool set(工具只以 name/description/parameters 到达模型)、不是 `ToolRegistry.execute`、不是 `POST /ai/tools/:name/execute`。审阅者看到一个破坏性工具被标成"有确认门",而它并没有。真正的门是 `action.ai.requiresConfirmation` + HITL 审批队列。
- `Disabled` 宣称工具已被撤下,而 `ToolRegistry.getAll()` 仍在把它交给 LLM、execute 路由仍在跑它。

即 objectui#2962 的同型形状:**一个 UI 徽标宣传运行时并不兑现的能力**。

## 测试(objectui#3236 要求的钉子)

新增 `packages/app-shell/src/views/metadata-admin/previews/ToolPreview.test.tsx`:喂一个**仍带全部四个退役键**的陈旧 draft(`requiresConfirmation: true`、`active: false`、`builtIn: true`、`category: 'data'`),断言一枚都不渲染;另有正向断言,保证 label / 机器名 / description / `objectName` pill / 参数表 / Example LLM Call 都还在。

**反向验证做了**:把徽标分支临时加回去,断言确实会红(不是永远为真的空断言):

```
FAIL |dom| ToolPreview.test.tsx > renders no confirmation badge for a stale draft with requiresConfirmation: true
AssertionError: expected < span class="text-foreground "> < /span> to be null
- Expected: null
+ Received: < span class="text-foreground "> Requires confirmation < /span>
 ❯ ToolPreview.test.tsx:62:58
…
 Test Files  1 failed (1)
      Tests  3 failed | 4 passed (7)
```

删掉徽标后:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

同目录/同视图回归(root config,含全部 metadata-admin 测试):

```
pnpm vitest run packages/app-shell/src/views/metadata-admin --maxWorkers=2
 Test Files  118 passed (118)
      Tests  1045 passed | 1 skipped (1046)
```

```
pnpm --filter @object-ui/app-shell test     → 19 files / 153 tests passed
pnpm --filter @object-ui/app-shell type-check → 通过(tsc --noEmit && tsc -p tsconfig.typetests.json)
eslint(两个改动文件)                        → 0 error(2 条既有 react-hooks/exhaustive-deps warning,与本次改动无关)
```

## Changeset

已加 `.changeset/toolpreview-drop-retired-flag-pills.md`(`@object-ui/app-shell: patch`)。判断依据:虽然是纯删代码,但**用户可见** —— admin 预览里几枚徽标消失了(其中 `Active` 是以前无条件渲染的),审阅 tool 元数据的人会直接看到差别,该进 release notes。按 AGENTS.md 版本策略不声明 `major`;`check-changeset-no-major.mjs` 与 `check-changeset-fixed.mjs` 均已本地跑过通过。

## 范围外发现

`apps/console/src/preview-samples.ts` 的 `tool` 样例仍带 `category` / `active` / `requiresConfirmation` 三个已退役键 —— 同型残留,但在 `apps/console` 而非本次 scope fence(`packages/app-shell`)内,**未在本 PR 改动**,已另开 objectstack-ai/objectui#3257 记录。

除此之外,全仓扫描(`packages/` `apps/` `content/` `examples/` `e2e/`)已无其他 `requiresConfirmation` / tool `builtIn` 残留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_