### PR TITLE
fix(layout): `page-header` 的 registration `inputs` 不再宣告 `description`

### DIFF
--- a/.changeset/page-header-inputs-declare-subtitle.md
+++ b/.changeset/page-header-inputs-declare-subtitle.md
@@ -1,0 +1,39 @@
+---
+"@object-ui/layout": patch
+---
+
+The legacy `page-header` alias stops advertising `description` as an authorable
+key (objectui#3226).
+
+FROM: `registerLayout()` declared `inputs: [title, description]`. TO:
+`inputs: [title, subtitle]` — the key `@objectstack/spec/ui`'s `PageHeaderProps`
+declares, and the one the canonical `page:header` renderer in
+`@object-ui/components` already declares.
+
+`inputs` is a DECLARATION surface, not documentation: the designer builds its
+property palette from it, and the framework's `check:react-declaration-parity`
+diffs it against the spec schemas. Declaring `description` therefore did not
+merely tolerate a legacy spelling — it published a second dialect for the one
+concept the protocol calls `subtitle`, and told authors (an AI author most
+readily, since the registry is what it reads to learn the shape) that the
+non-spec key was legal. Metadata that took the offer renders a subtitle under
+`page-header` and silently loses it under `page:header`: same JSON, two results,
+which is the outcome a single contract exists to prevent.
+
+No runtime behaviour changes. `PageHeader` still reads `subtitle ?? description`,
+deliberately: this alias exists for out-of-repo consumer schemas, so "no in-repo
+author writes `description`" (verified — zero hits) is not evidence that nobody
+does, and dropping the read today would delete an external page's second line
+while its title kept rendering, the least reportable failure mode there is. That
+read is retired together with an ADR-0087 D2 conversion entry
+(`page-header-subtitle-alias`, `description` → `subtitle` rewritten at load
+time), which lives in the framework repo and is tracked separately. Narrowing the
+declaration did not need to wait on it and breaks no consumer; leaving the
+declaration wrong in the meantime keeps minting the metadata the conversion would
+then have to absorb.
+
+New tests pin both halves so neither can drift back: the registration may not
+declare `description`, must declare `subtitle`, and — checked against the spec's
+own shape rather than a hand-written allowlist — may declare nothing
+`@objectstack/spec` does not; while the runtime fallback is pinned as a sequencing
+guard, to be deleted in the same change that lands the conversion entry.

--- a/packages/layout/src/__tests__/page-header-authorable-keys.test.tsx
+++ b/packages/layout/src/__tests__/page-header-authorable-keys.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `page-header` alias declares only keys `@objectstack/spec` declares
+ * (objectui#3226).
+ *
+ * The legacy kebab key `page-header` and the canonical protocol key
+ * `page:header` (in `@object-ui/components`) render the same concept, but this
+ * one used to DECLARE a different authorable key for the secondary line:
+ * `description`, where the spec's `PageHeaderProps` — and therefore
+ * `page:header` — declares `subtitle`. That is not a tolerated legacy spelling,
+ * it is a second dialect published on the declaration surface: `inputs` is what
+ * the designer offers as fields and what the framework's
+ * `check:react-declaration-parity` diffs against the spec schemas, so an author
+ * (especially an AI one) was being TOLD `description` was legal. Metadata that
+ * took the offer renders a subtitle under `page-header` and silently loses it
+ * under `page:header` — the same JSON, two results, which is the failure mode
+ * one contract exists to prevent.
+ *
+ * The cross-check below is deliberately derived from the spec's own shape
+ * rather than a hand-written allowlist: a future input added here that the spec
+ * does not declare fails for the same reason `description` did, without anyone
+ * having to remember this issue.
+ *
+ * SEQUENCING — read before "finishing the job". `PageHeader.tsx` still READS
+ * `subtitle ?? description` at runtime, and the last test in this file pins
+ * that on purpose. The alias exists precisely for out-of-repo consumer schemas,
+ * so "no in-repo author writes `description`" (true, verified) says nothing
+ * about whether anyone does; dropping the read today would delete an external
+ * page's second line while its title kept rendering — the least reportable
+ * failure there is. The read goes away together with the ADR-0087 D2 conversion
+ * entry `page-header-subtitle-alias` (`description` → `subtitle` rewritten at
+ * load time), which lives in the framework repo. Narrowing the DECLARATION did
+ * not need to wait on it and changes no runtime behaviour; deleting the READ
+ * does. When that conversion lands, delete the fallback AND the last test here
+ * in one change.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PageHeaderProps as SpecPageHeaderProps } from '@objectstack/spec/ui';
+
+import { registerLayout, PageHeader } from '../index';
+
+/** Authorable keys of the spec node this renderer serves. */
+const specKeys = new Set(Object.keys(SpecPageHeaderProps.shape));
+
+const declaredInputNames = (type: string, namespace?: string): string[] => {
+  const config = ComponentRegistry.getConfig(type, namespace);
+  if (!config) throw new Error(`"${namespace ? `${namespace}:${type}` : type}" is not registered`);
+  return (config.inputs ?? []).map((input) => input.name);
+};
+
+beforeAll(() => {
+  registerLayout();
+});
+
+describe('the `page-header` registration declares the spec key, not a dialect', () => {
+  it('is registered under the bare key and its namespace', () => {
+    expect(ComponentRegistry.getConfig('page-header')).toBeTruthy();
+    expect(ComponentRegistry.getConfig('page-header', 'layout')).toBeTruthy();
+  });
+
+  // The one assertion this issue is about: whatever else changes, the
+  // declaration surface must never advertise `description` again.
+  it.each([
+    ['page-header', undefined],
+    ['page-header', 'layout'],
+  ])('does not advertise `description` on %s (namespace: %s)', (type, namespace) => {
+    expect(declaredInputNames(type, namespace)).not.toContain('description');
+  });
+
+  it('declares `subtitle` — the spec key for the secondary line', () => {
+    expect(declaredInputNames('page-header')).toContain('subtitle');
+    expect(specKeys.has('subtitle')).toBe(true);
+    // …and the spec has no `description` at all, which is the whole reason the
+    // old declaration was wrong rather than merely redundant.
+    expect(specKeys.has('description')).toBe(false);
+  });
+
+  it('declares nothing `@objectstack/spec` does not', () => {
+    const offSpec = declaredInputNames('page-header').filter((name) => !specKeys.has(name));
+    expect(offSpec).toEqual([]);
+  });
+});
+
+describe('the runtime `description` fallback stays until the conversion entry lands', () => {
+  // NOT an endorsement of the alias — a guard on the ORDER. Removing this read
+  // before `page-header-subtitle-alias` exists is the deletion route that was
+  // considered and rejected: external schemas authored with `description` would
+  // lose their subtitle silently. Delete this test in the same change that
+  // deletes the fallback, once the conversion rewrites the key upstream.
+  it('still renders a legacy `description` as the secondary line', () => {
+    render(<PageHeader title="Customer Details" description="View and edit customer information" />);
+    expect(screen.getByText('View and edit customer information')).toBeTruthy();
+  });
+
+  it('lets the spec key win when both are present', () => {
+    render(<PageHeader title="Customer Details" subtitle="From the spec" description="From the alias" />);
+    expect(screen.getByText('From the spec')).toBeTruthy();
+    expect(screen.queryByText('From the alias')).toBeNull();
+  });
+});

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -27,13 +27,33 @@ export function registerLayout() {
   // namespace. We intentionally do NOT re-register `page:header` here —
   // doing so would (depending on package load order) clobber the
   // record-aware renderer in components with this thinner one.
+  //
+  // `inputs` declares the AUTHORABLE surface, and it must name the same keys
+  // the spec does — the designer and the framework's
+  // `check:react-declaration-parity` read this list and treat everything in it
+  // as a legal input (objectui#3226). `@objectstack/spec/ui`'s
+  // `PageHeaderProps` declares `subtitle`; it has no `description`. This list
+  // used to declare `description`, so the alias did not merely tolerate a
+  // legacy spelling — it ADVERTISED a second dialect for the one concept
+  // `page:header` calls `subtitle`, and metadata authored against it renders
+  // a subtitle here and nothing at all under the canonical key.
+  //
+  // The runtime `subtitle ?? description` fallback in `PageHeader.tsx` stays
+  // for now ON PURPOSE: this alias exists for out-of-repo consumer schemas, so
+  // "no in-repo author writes `description`" is not evidence that nobody does,
+  // and dropping the read would silently delete their second line. That read
+  // is retired together with an ADR-0087 D2 conversion entry
+  // (`page-header-subtitle-alias`, `description` → `subtitle` at load time),
+  // which lives in the framework repo. Narrowing the DECLARATION is
+  // unconditional and independent of that: it breaks no consumer, and it stops
+  // the registry from teaching the wrong key in the meantime.
   ComponentRegistry.register('page-header', PageHeader, {
       namespace: 'layout',
       label: 'Page Header',
       category: 'Layout',
       inputs: [
-          { name: 'title', type: 'string' },
-          { name: 'description', type: 'string' }
+          { name: 'title', type: 'string', label: 'Title' },
+          { name: 'subtitle', type: 'string', label: 'Subtitle' }
       ]
   });
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3226

## ⚠️ 本 PR 只做原 issue 的**一半**(objectui 本地那一半)

按 issue 上两条 PM 裁定(`#3226` 的 comment):本单走**路线 B(ADR-0087 D2 conversion 条目)而非直接删除**,而 conversion 机制在 **objectstack** 仓,不在这里。因此本 PR 的范围被明确收窄为**无条件成立、且跨仓依赖为零**的那一半:

> 原 issue 原文:「两种路线都要求 `inputs` 不再宣告 `description` —— 这一点无论哪条路都成立。」

**本 PR 做的**:`registerLayout()` 里 `page-header` 的 `inputs` 从 `[title, description]` 收窄为 `[title, subtitle]`。

**本 PR 刻意不做的**:不删 `PageHeader.tsx` 的 `subtitle ?? description`,不删 `description` prop。**这两项被本 PR 的测试主动钉住了**(见下),删它们等于走回被否决的删除路线。

**剩余部分(阻塞在上游)**:conversion 条目 `page-header-subtitle-alias`(`description` → `subtitle`,加载时改写成 canonical 键)+ 随后删除消费端裸 `??` 与 `description` prop。这部分归主 backlog PM,在 objectstack 立单;本单挂 `Blocked-by`。

---

## 为什么这一半可以现在就做,而且必须现在做

`inputs` 是**声明面**,不是文档。设计器用它生成属性面板,framework 的 `check:react-declaration-parity` 拿它跟 spec schema 对差。所以宣告 `description` 不是「容忍一个遗留拼写」,而是**对外发布了第二套方言**,并且在**教**作者(尤其是读 registry 学形状的 AI 作者)写一个 spec 里根本不存在的键:

- `@objectstack/spec/ui` 的 `PageHeaderProps` 的 shape 是 `title / subtitle / icon / breadcrumb / actions / aria` —— **没有** `description`(已实测)。
- canonical 的 `page:header`(`@object-ui/components` `containers.tsx`)声明的是 `subtitle`。
- 于是同一份 metadata:写 `description` 在 `page-header` 下渲染出副标题,换到 `page:header` 下**静默丢失**。同一份 JSON,两个结果 —— 这正是「单一契约」要消灭的东西。

收窄声明面**不改变任何运行时行为**(`??` 还在),因此对仓外消费者**零破坏**;而把声明面留在错的状态,只会持续生产出将来 conversion 层还得去吸收的错误 metadata。

## 为什么运行时的 `??` 现在不能删

这个别名存在的**全部理由**就是仓外的消费者 schema(佐证:`registerLayout()` 在本仓**没有任何调用点**,它纯粹是 `@object-ui/layout` 对外的公开导出)。所以「仓内 grep 零命中」(我复核过,确实为零)**不构成**「没人在写」的证据。按删除路线走,外部写 `description` 的页面会**静默丢副标题** —— 标题照常渲染,只是第二行没了,是最难被报障的失效形态。

## 预警的门禁冲突:核实过,**不存在**

PM 预警了 `check:react-declaration-parity` 可能校验「声明的 inputs ↔ 组件实际读取的 props」。查了 framework 侧实现,**不会冲突**,两个独立理由:

1. 它比对的是**两份声明**(spec zod props vs registry `inputs`),其文件头明确写着「It never looks at a renderer」。组件读不读 `description` 完全不在它视野内。
2. 它的 ratchet 只对 **NEW registry-only inputs**(registry 声明了而 spec 没有的)报警。`description` 恰恰就是一个 registry-only input,**删掉它只会减少 divergence,不可能触发 ratchet**。
3. 另外,它的覆盖面是 `REACT_BLOCKS`(`ObjectForm` / `ListView` / `ObjectChart` / `Block`),baseline 里也只有这三个 block;`page-header` 根本不在其中。

## 测试:两半都钉住

新增 `packages/layout/src/__tests__/page-header-authorable-keys.test.tsx`(7 个用例):

- 声明面:`page-header` 与 `layout:page-header` 两个键都**不得**含 `description`;**必须**含 `subtitle`;并且 —— 这条是**从 spec 自己的 shape 推出来的,不是手写白名单** —— 声明的每一个 input 都必须是 `PageHeaderProps` 的键。将来再往这里加一个 spec 没有的 input,会因为和 `description` 完全相同的理由变红,不需要谁记得这个 issue。
- 顺序守卫:运行时仍把 legacy `description` 渲染成副标题、且 `subtitle` 在两者都在时胜出 —— 这**不是**为别名背书,而是钉住**顺序**:在 conversion 条目落地前删掉这个读取,就是被否决的删除路线。注释里写明:conversion 落地时,**同一个 commit 里**删掉 fallback 和这两个用例。

## 验证

```
pnpm exec vitest run --maxWorkers=2 packages/layout
  Test Files  6 passed (6)
       Tests  78 passed (78)

pnpm exec turbo run type-check --filter=@object-ui/layout --concurrency=2
  Tasks:    9 successful, 9 total

pnpm --filter @object-ui/layout lint     → 0 errors(42 warnings,全部为既有)
pnpm run check:spec-symbols              → ✅ 1192 files scanned
pnpm run changeset:check                 → ✅ fixed group ok / no `major`
```

## Changeset

有 —— `patch`(`@object-ui/layout`)。虽然运行时行为不变,但**声明面是对外发布的**:设计器属性面板会从 "Description" 变成 "Subtitle",生成的 `sdui.manifest.json` 也随之改变,对使用设计器的人是可见的。按 AGENTS.md 未标 `major`。

---

## 顺带发现(未在本 PR 修,已另开 issue)

文档里同样在教 `description`,而且比 `inputs` 教得更直接 —— 但它在 `content/docs/`,超出本单的 `packages/layout` 范围,且牵扯到别的 doc drift(`breadcrumbs` 这个 prop 组件根本不读),不适合搭车:

- `content/docs/guide/layout.md`「PageHeader Component」的 authored JSON 示例写 `"type": "page-header"` + `"description"`,Schema API 块声明 `description?: string`
- `content/docs/layout/page-header.mdx`「Component Props」块列 `description?: string`,且完全没提 `subtitle`

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_