### PR TITLE
fix(console): drop retired ToolSchema keys from the tool preview sample (#3257)

### DIFF
--- a/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
+++ b/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
@@ -1,0 +1,209 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `preview-samples.ts` ↔ `@objectstack/spec` conformance (objectui#3257).
+ *
+ * The preview gallery's samples are not test fixtures — they are the drafts the
+ * metadata designers render, i.e. the worked EXAMPLE an author sees for each
+ * metadata type. The implicit promise of an example is "copy this and it
+ * works". Nothing was checking that promise, and it had already broken: the
+ * `tool` sample declared `category` / `active` / `requiresConfirmation`, three
+ * keys `ToolSchema` had been retired and now rejects BY NAME (objectstack#3896,
+ * objectstack#3715 / ADR-0033 §2). Anyone copying it — a human, and far more
+ * often a model generating metadata — produced a tool definition that
+ * `ToolSchema.parse()` refuses outright. A bad example does not fail once; it
+ * propagates.
+ *
+ * Nothing in the gallery validates a draft (previews render whatever they are
+ * handed), so a sample can rot silently through any number of spec releases.
+ * This test is the missing feedback loop: it makes a sample going stale a CI
+ * failure instead of a lesson taught to the next author.
+ *
+ * HOW IT VALIDATES — samples are embedded in a whole stack:
+ *
+ *   ObjectStackSchema.safeParse({ tools: [SAMPLES.tool] })
+ *
+ * rather than reached through a hand-picked `XxxSchema` export. Two reasons,
+ * both learned the hard way while writing this:
+ *
+ *  1. `ObjectStackSchema` IS the authoring contract — the shape an author may
+ *     publish. Guessing the schema by name gets it wrong: the obvious pick for
+ *     `email_template` is `EmailTemplateSchema`, which is the runtime send
+ *     payload (`id` / `body` / `bodyType`); the authorable record is actually
+ *     `EmailTemplateDefinitionSchema` (`name` / `label` / `subject` /
+ *     `bodyHtml`). Reading the collection cannot pick the wrong one.
+ *  2. It needs no Zod internals. Unwrapping `optional > array > …` by hand via
+ *     `._def` would silently mis-resolve (or worse, vacuously pass) the day Zod
+ *     changes its internals. Here the wrapper does the unwrapping, so this test
+ *     asks precisely the question that matters: would this sample survive being
+ *     published in a real stack?
+ *
+ * LIMIT — worth knowing before trusting a pass. Only some element schemas are
+ * `.strict()` (`tools`, `apps`, `flows`, `permissions`, `positions`,
+ * `datasources` are; `views`, `jobs`, `emailTemplates` are not). For the
+ * non-strict ones an unknown or retired key is stripped rather than rejected,
+ * so a PASS there proves the sample is structurally sound, NOT that it is free
+ * of retired keys. The guard is exactly as strict as the spec is.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectStackSchema } from '@objectstack/spec';
+import { SAMPLES } from '../preview-samples';
+
+/**
+ * Sample type → the `ObjectStackSchema` collection that carries it. Only
+ * top-level collections appear here; `validation` is nested and handled below.
+ */
+const STACK_COLLECTION: Record<string, string> = {
+  object: 'objects',
+  page: 'pages',
+  view: 'views',
+  dashboard: 'dashboards',
+  report: 'reports',
+  app: 'apps',
+  action: 'actions',
+  flow: 'flows',
+  job: 'jobs',
+  agent: 'agents',
+  tool: 'tools',
+  skill: 'skills',
+  permission: 'permissions',
+  position: 'positions',
+  datasource: 'datasources',
+  email_template: 'emailTemplates',
+  translation: 'translations',
+};
+
+/**
+ * Samples that MUST parse. This is the guard: any of these going stale — a
+ * retired key re-added, a shape drifting from the spec — fails CI here.
+ */
+const SPEC_CLEAN = [
+  'view',
+  'job',
+  'tool',
+  'permission',
+  'position',
+  'email_template',
+] as const;
+
+/**
+ * Samples that map to a real spec collection and DO NOT parse today. Each entry
+ * is the first thing a reader of that sample would copy and get rejected for.
+ *
+ * This list is a ledger, not an excuse: the reverse assertion below fails if an
+ * entry starts passing, so it can only ever shrink. Fixing them is objectui#3266
+ * — deliberately not done here, because several are not mechanical (see that
+ * issue: `object.fields` array-vs-record is a shape `readFields()` supports on
+ * PURPOSE, and rewriting the `dashboard` sample changes what the gallery
+ * renders, which is the shared browser-verification harness).
+ */
+const KNOWN_STALE: Record<string, string> = {
+  object: '`fields` is an array; ObjectSchema wants a record keyed by field name',
+  page: 'page components carry `props`, which PageComponentSchema rejects (ADR-0089 D3a)',
+  report: '`columns` are objects; ReportSchema wants column-name strings',
+  dashboard: 'widgets miss `dataset`/`values` and use retired `value`/`format`; `chart` is not a widget type',
+  app: 'navigation items miss the `type` discriminator; `landing` was removed (objectstack#4001)',
+  action: 'RETIRED `bulkEnabled` (objectstack#3896); `type`/`variant`/`locations` use pre-17 enum values',
+  flow: 'RETIRED `waitEventConfig.onTimeout` (objectstack#4158); `type: scheduled` invalid; edges need `id`',
+  agent: 'RETIRED `tools` (objectstack#3894, use `skills`) and `knowledge` (objectstack#3896)',
+  skill: 'RETIRED `triggerPhrases` (objectstack#3896); `triggerConditions` needs field/operator/value',
+  datasource: '`type`/`isDefault` rejected; `ssl` and `capabilities` are objects; `healthCheck.interval` is `intervalMs`',
+  validation: "`events` uses pre-17 `beforeInsert`/`beforeUpdate`; the enum is `insert`/`update`",
+  translation:
+    'the `translations` collection is Array< Record< locale, TranslationData > >, but this sample is the metadata-RECORD form (name/label/locale/data) the console edits — so this row is a mapping mismatch, not necessarily a stale sample. Resolve in objectui#3266 before guarding it.',
+};
+
+/**
+ * Samples with no authoring schema in `@objectstack/spec` at all — nothing to
+ * validate against, so they are exempt by documented fact rather than by
+ * omission. The assertion below re-checks that fact every run.
+ */
+const NO_AUTHORING_SCHEMA: Record<string, string> = {
+  workflow: 'no `workflows` collection and no WorkflowSchema in spec 17',
+  approval: 'no `approvals` collection; spec only has ApprovalNodeConfigSchema (a flow node)',
+};
+
+/** Issues the spec raises for one sample, scoped to that sample's own path. */
+function issuesFor(type: string): { path: string; message: string }[] {
+  const sample = SAMPLES[type];
+
+  // `validation` is not a top-level collection — it lives on an object as
+  // `validations[]`, so it is embedded in a minimal host object. That host is
+  // itself valid, so every issue reported below belongs to the sample.
+  const [stack, prefix] =
+    type === 'validation'
+      ? [
+          {
+            objects: [
+              {
+                name: 'sales_order',
+                label: 'Sales Order',
+                fields: { amount: { type: 'currency', label: 'Amount' } },
+                validations: [sample],
+              },
+            ],
+          },
+          'objects.0.validations',
+        ]
+      : [{ [STACK_COLLECTION[type]]: [sample] }, STACK_COLLECTION[type]];
+
+  const result = ObjectStackSchema.safeParse(stack);
+  if (result.success) return [];
+  return result.error.issues
+    .filter((issue) => issue.path.join('.').startsWith(prefix))
+    .map((issue) => ({ path: issue.path.join('.'), message: issue.message }));
+}
+
+describe('preview-samples conform to @objectstack/spec', () => {
+  // Without this, a sample added to the gallery tomorrow would be validated by
+  // nothing and no test would notice — the exact failure mode this file exists
+  // to end. Classification is mandatory, so adding a sample forces a decision.
+  it('classifies every sample exactly once', () => {
+    const classified = [
+      ...SPEC_CLEAN,
+      ...Object.keys(KNOWN_STALE),
+      ...Object.keys(NO_AUTHORING_SCHEMA),
+    ];
+    expect([...classified].sort()).toEqual([...new Set(classified)].sort());
+    expect(classified.sort()).toEqual(Object.keys(SAMPLES).sort());
+  });
+
+  it.each(SPEC_CLEAN)('%s sample is valid metadata', (type) => {
+    expect(issuesFor(type)).toEqual([]);
+  });
+
+  // Reverse assertion (same shape as objectui#3212): a ledger nobody re-checks
+  // becomes a dumping ground. If a quarantined sample starts parsing — because
+  // someone fixed it, or the spec relaxed — this fails and demands it be
+  // promoted, so the list can only shrink.
+  it.each(Object.keys(KNOWN_STALE))(
+    '%s sample still fails as recorded (promote it to SPEC_CLEAN once fixed)',
+    (type) => {
+      expect(issuesFor(type).length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(Object.keys(NO_AUTHORING_SCHEMA))(
+    '%s still has no collection in the spec',
+    (type) => {
+      // If spec grows one, this fails — map the sample and guard it.
+      expect(Object.keys(ObjectStackSchema.shape)).not.toContain(`${type}s`);
+    },
+  );
+
+  // The specific regression objectui#3257 fixed, pinned by name. The list above
+  // would catch these via `tool`'s membership in SPEC_CLEAN, but only as a
+  // generic "sample is invalid"; naming them keeps the retirement legible to
+  // whoever is tempted to re-add one.
+  it.each(['category', 'active', 'requiresConfirmation'])(
+    'tool sample does not resurrect retired key `%s`',
+    (key) => {
+      expect(SAMPLES.tool).not.toHaveProperty(key);
+    },
+  );
+});

--- a/apps/console/src/preview-samples.ts
+++ b/apps/console/src/preview-samples.ts
@@ -231,11 +231,8 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
   tool: {
     name: 'query_orders',
     label: 'Query Orders',
-    category: 'data',
     description: 'Run a parameterized ObjectQL query against sales orders.',
-    active: true,
     objectName: 'sales_order',
-    requiresConfirmation: false,
     parameters: {
       type: 'object',
       required: ['status'],


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3257

## 改了什么

`apps/console/src/preview-samples.ts` 的 `tool` 样例删掉三行:`category` / `active` / `requiresConfirmation`。样例其余部分(`name` / `label` / `description` / `objectName` / `parameters` / `outputSchema`)全部保留 —— 实测这份删完之后 **`ToolSchema` 直接 ACCEPT**。

另外新增一条机器守卫 `apps/console/src/__tests__/preview-samples-spec-valid.test.ts`,把「样例过期」从静默腐烂变成 CI 报红。

## 为什么这不只是清理

这份样例不是测试夹具,是**设计器预览画廊里给作者看的范本**。范本的隐含承诺是「照抄就能用」,而它已经违约了:三个键都被 `.strict()` 的 `ToolSchema` **逐个具名拒收**,谁照抄谁就得到一份 `ToolSchema.parse()` 当场拒绝的元数据。这正是 AI 生成元数据最容易照抄并放大的位置 —— 坏范本不是错一次,是持续传播。

和 #3236 是同一次三仓扫描的两半,但危害形态不同:#3236 是「UI 宣传了不存在的能力」,本单是「**范本在教人写错**」。#3236 之后 `ToolPreview` 也不再渲染这三个徽标,这三行成了纯噪音。

## 守卫怎么写的(这是本 PR 的大头)

校验方式是**把样例塞进一整个 stack**,交给 `ObjectStackSchema.safeParse()`:

```ts
ObjectStackSchema.safeParse({ tools: [SAMPLES.tool] })
```

而不是去 import 一个手挑的 `XxxSchema`。两个理由,都是写的过程中踩出来的:

1. **`ObjectStackSchema` 本身就是作者契约** —— 作者能发布的形态。按名字猜 schema 会猜错:`email_template` 最顺手的那个 `EmailTemplateSchema` 其实是**运行时发信载荷**(`id` / `body` / `bodyType`),真正可编写的记录是 `EmailTemplateDefinitionSchema`(`name` / `label` / `subject` / `bodyHtml`)。读集合不可能挑错。
2. **不碰任何 Zod 内部**。手写 `._def` 去剥 `optional > array > …` 迟早会在 Zod 换版本时静默解错(或者更糟:空过)。让 wrapper 自己剥,这条测试问的就恰好是那个该问的问题 —— **这份样例如果被作者发布进真实 stack,会怎样?**

守卫分四层:

| 断言 | 作用 |
|---|---|
| `classifies every sample exactly once` | 每个样例必须落在 `SPEC_CLEAN` / `KNOWN_STALE` / `NO_AUTHORING_SCHEMA` 之一。**明天新加的样例逃不掉分类**,否则报红 |
| `%s sample is valid metadata` | 6 个干净样例必须过 `.parse()`(含本次修好的 `tool`) |
| `%s sample still fails as recorded` | **反向断言**(与 #3212 同思路):台账里的样例一旦开始通过就报红,要求提升到 `SPEC_CLEAN` —— 台账只会缩短,不会变成垃圾堆 |
| `tool sample does not resurrect retired key %s` | 三个键按名钉死,让「别再加回来」对读代码的人可见 |

### 破坏性验证(sabotage)

把 `category: 'data'` 和 `requiresConfirmation: false` 加回样例后重跑,三层同时报红:

```
FAIL  tool sample is valid metadata
AssertionError: expected [ { path: 'tools.0', …(1) } ] to deeply equal []

FAIL  tool sample does not resurrect retired key `category`
AssertionError: expected { name: 'query_orders', …(7) } to not have property "category"
- Expected: undefined
+ Received: "data"

FAIL  tool sample does not resurrect retired key `requiresConfirmation`

 Tests  3 failed | 21 passed (24)
```

已还原,当前 24/24 绿。

## 顺带核对了同文件其它全部 19 个样例(派发要求第 2 点)

结论:**`tool` 不是唯一一个** —— 20 个样例里 12 个当前过不了 `.parse()`,其中 4 个带的是和本单完全同型的**已退役键**(`action.bulkEnabled`、`agent.tools`/`agent.knowledge`、`skill.triggerPhrases`、`flow.waitEventConfig.onTimeout`)。

- ✅ **合法(6)**:`view`、`job`、`tool`(本 PR 修完)、`permission`、`position`、`email_template`
- ❌ **过不了(12)**:`object`、`page`、`report`、`dashboard`、`app`、`action`、`flow`、`agent`、`skill`、`datasource`、`validation`、`translation`
- ⚪ **spec 里根本没有对应 schema(2)**:`workflow`、`approval`(spec 只有 `ApprovalNodeConfigSchema`,那是 flow 节点配置)

**这 12 个本 PR 没修**,而是进了测试里的 `KNOWN_STALE` 台账(每条写明具体原因),并立了 objectui#3266 跟踪。没顺手修的理由不是偷懒:

1. `object.fields` 的**数组形态是 app-shell 有意支持的**,不是笔误 —— `previews/object-fields-io.ts` 的 `readFields()` 显式分支 `shape: 'array' | 'record'` 并原样保留。把样例改成 record 会让画廊**不再覆盖 array 那条分支**;真正该先裁决的是这个双形态要不要留(AGENTS.md #0.1 的典型场景),而不是先改样例。
2. 改 `dashboard` / `app` / `flow` 样例会**改变画廊渲染出来的东西**,而预览画廊是本仓共用的浏览器验证台,并行 agent 正拿它验证别的改动。
3. 本单 scope fence 是 `apps/console` 的 `tool` 样例 + 审计 + 守卫;PD#3 要求越界发现另立单。

`translation` 那条要特别说明:`ObjectStackSchema.translations` 是 `Array< Record< locale, TranslationData > >`,而 console 这份样例是 `{ name, label, locale, language, description, data }` 的元数据记录形态 —— 更可能是**映射选错**而非样例过期,已在测试注释和 #3266 里如实标注,没有硬套。

## 守卫的强度上限(如实记录,别过度信任)

守卫有多严取决于 spec 有多严:`tools` / `apps` / `flows` / `permissions` / `positions` / `datasources` 的元素 schema 是 `.strict()`,而 `views` / `jobs` / `emailTemplates` **不是** —— 后者把未知键悄悄剥掉而不报错。也就是说这三类样例即便混进一个已退役的键,守卫照样绿。这一点写在测试文件头部,免得后来者误以为「绿 = 没有退役键」。这是 spec 仓的事(objectstack#4001 / #3896 同一条线),已记在 #3266 备查。

## 为什么没有 changeset

`preview-samples.ts` 文件头就写着 DEV-ONLY;实测 `apps/console/vite.config.ts` **没有 `input:` 配置**,Vite 默认只以 `index.html` 为入口,`preview-gallery.html` 不是生产构建入口 —— 这份样例根本进不了发布的 `dist`,对 `@object-ui/console` 的消费者不可见。加上 AGENTS.md §9「纯 bug 修复不需要 changeset」,故不加。

## 验证

```
pnpm --filter @object-ui/console type-check   → 0 errors(先 turbo build 了 34 个依赖包)
pnpm --filter @object-ui/console test         → Test Files 20 passed (20) / Tests 177 passed (177)
pnpm --filter @object-ui/console lint         → 0 errors(187 条既有 warning,两个改动文件一条都没有)
```

## 相关

- objectui#3257(本单)
- objectui#3266(其余 12 个过期样例,本 PR 新立)
- objectui#3236 / PR #3258(`ToolPreview` 侧的同型残留)
- objectstack#3896(`category` / `active` 审计关闭)、objectstack#3715 / ADR-0033 §2(`requiresConfirmation` 退役)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_