### PR TITLE
fix(app-shell,plugin-detail): chatter 那条链补上 loading 信号源 (#3209)

### DIFF
--- a/.changeset/record-chatter-loading-signal.md
+++ b/.changeset/record-chatter-loading-signal.md
@@ -1,0 +1,49 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/plugin-detail": patch
+---
+
+The record discussion panel now says "loading" while it is loading, instead of
+"No comments yet" (objectui#3209).
+
+FROM: opening any record page showed the discussion/chatter panel asserting
+`No comments yet` for the whole first leg of the page, then contradicting
+itself when the comments appeared. TO: the panel shows the loading row until
+the feed has actually answered, and only then commits to "this record has no
+comments".
+
+objectui#3205 gave `RecordActivityTimeline` the render branch that prefers a
+loading row over the empty copy, and `RecordChatterPanel` already forwarded
+`loading` to it in both positions — but on the chatter chain **nothing
+produced the signal**, so that branch could never fire. `record:activity`
+computes its own flag and was visibly fixed by #3205; chatter was not. The
+four wiring points are one chain and are all closed here, because any one of
+them left open still ships the empty copy to some user:
+
+- `RecordDetailView` — the host that OWNS the feed fetch — now derives a
+  `feedLoading` flag from its two reads (`sys_comment` + `sys_activity`);
+- `<DiscussionContextProvider loading={feedLoading}>` publishes it (the field
+  was already declared on `DiscussionContextValue`, and already read by
+  `record:activity`);
+- the auto-appended `<RecordChatterPanel loading={feedLoading}>` — the panel
+  authored pages get when they place no discussion slot — receives it
+  directly;
+- the `record:chatter` / `record:discussion` renderer forwards
+  `loading={discussion?.loading}`, so a hand-placed block is on the same
+  chain as the synthesized one.
+
+The two reads run in parallel, so the flag closes over **both**: it clears on
+`Promise.allSettled`, and a REJECTED read counts as an answer. A deployment
+without the audit plugin 404s `sys_activity` and an object with
+`enable.feeds: false` 403s `sys_comment`; neither may pin the panel in a
+permanent spinner, which would be a worse bug than the one being fixed. The
+flag is keyed by `object:recordId` rather than being a plain boolean, so the
+first render of a record already reads as loading (no one-frame flash of the
+empty state) and navigating between records cannot show the previous record's
+settled answer.
+
+No tolerance was added at the consumer. The timeline still does not guess that
+"no items yet and just mounted" means loading — that guess is wrong the moment
+a record genuinely has no comments, and the signal belongs to whoever owns the
+fetch. Same shape as objectui#3165 / #3205: divergence converges at the
+producer.

--- a/packages/app-shell/src/views/RecordDetailView.feedLoading.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.feedLoading.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * RecordDetailView — the discussion feed's LOADING SIGNAL (objectui#3209).
+ *
+ * This view owns the two `find`s (`sys_comment` + `sys_activity`) that fill
+ * the discussion feed, so it is the only place that can tell the panel
+ * "still fetching". Until #3209 it never did: `feedItems` started `[]` and
+ * both fetches filled it asynchronously with no loading state anywhere, so
+ * `DiscussionContextProvider` and the auto-appended `RecordChatterPanel`
+ * both went out without `loading`. The user-visible result was the panel
+ * asserting "No comments yet" — a factual claim about the record — for the
+ * whole first leg of every record page, then contradicting itself when the
+ * rows arrived.
+ *
+ * #3205 fixed the RENDER BRANCH (the timeline reads `loading` at all); this
+ * file pins the SIGNAL that reaches it. Both are needed, so the assertions
+ * are on the rendered outcome — the loading row vs. the empty copy — never
+ * on "a prop was passed".
+ *
+ * TWO delivery paths reach a user, and this file exercises both, because the
+ * fix wires them separately and either one alone still ships the bug:
+ *   • the SYNTHESIZED page (no authored record page) bakes in a
+ *     `record:discussion` node, so the panel arrives through
+ *     `DiscussionContextProvider` → `record:chatter` renderer;
+ *   • an AUTHORED page that omits the discussion slot gets the host's
+ *     bottom auto-append, a `RecordChatterPanel` mounted directly with no
+ *     context hop in between.
+ *
+ * The three cases that matter, and why:
+ *   1. during the fetch → loading row, no empty copy;
+ *   2. after BOTH parallel reads settle with nothing → empty copy, no
+ *      spinner (one settled read is not an answer);
+ *   3. after a read REJECTS → still the empty copy. A rejected fetch is an
+ *      answer too; the alternative is a panel that spins forever, which is
+ *      strictly worse than the bug being fixed.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MetadataCtx } from '@object-ui/react';
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => ({ viewers: [], others: [] }),
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// The dialogs / flow runner are orthogonal chrome; stubbing them keeps this
+// file about the feed signal (same posture as useConsoleActionRuntime.test).
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+import { RecordDetailView } from './RecordDetailView';
+
+const EMPTY_COMMENTS = 'No comments yet';
+const OBJECT_NAME = 'crm_account';
+const RECORD_ID = 'rec-alpha';
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'Account',
+    managedBy: 'platform',
+    fields: {
+      id: { type: 'text', label: 'Id' },
+      name: { type: 'text', label: 'Name' },
+    },
+  },
+];
+
+/** A promise that never settles — "the fetch is still in flight". */
+const pending = () => new Promise(() => {});
+
+interface FeedResponses {
+  sys_comment: () => Promise<any>;
+  sys_activity: () => Promise<any>;
+}
+
+function makeDataSource(feed: FeedResponses) {
+  const find = vi.fn((objectName: string) => {
+    if (objectName === 'sys_comment') return feed.sys_comment();
+    if (objectName === 'sys_activity') return feed.sys_activity();
+    // Everything else this view probes (mention directory, related lists…)
+    // answers empty immediately so only the feed reads are in flight.
+    return Promise.resolve({ data: [] });
+  });
+  return {
+    find,
+    findOne: vi.fn(async () => ({ id: RECORD_ID, name: 'Alpha' })),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+/**
+ * An AUTHORED record page that places no discussion slot — this is what
+ * turns on the host's bottom auto-append (`showAutoDiscussion`). The
+ * synthesized default page always bakes in `record:discussion`, so without
+ * an authored page the auto-append branch is unreachable.
+ */
+const AUTHORED_PAGE_WITHOUT_DISCUSSION = {
+  name: 'account_record_page',
+  type: 'record',
+  pageType: 'record',
+  object: OBJECT_NAME,
+  regions: [{ name: 'main', components: [{ type: 'page:header', title: 'Account' }] }],
+};
+
+function makeMetadata(pages: any[]) {
+  return {
+    objects: OBJECTS,
+    pages,
+    loading: false,
+    error: null,
+    refresh: async () => {},
+    invalidate: () => {},
+    ensureType: async () => pages,
+    getItem: async () => null,
+    getItemsByType: (type: string) => (type === 'page' ? pages : []),
+  } as any;
+}
+
+function renderDetail(dataSource: any, pages: any[] = []) {
+  return render(
+    <MemoryRouter initialEntries={[`/app/demo/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={makeMetadata(pages)}>
+        <RecordDetailView
+          dataSource={dataSource}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={RECORD_ID}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  // Unrelated chrome on this view (approvals, favourites, …) reaches for the
+  // platform API. In jsdom that is a real socket to :3000 — noisy, slow and
+  // machine-dependent. Answering it locally keeps the only asynchrony in this
+  // file the two feed reads under test.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('RecordDetailView — the feed fetch produces a loading signal (#3209)', () => {
+  it('renders the discussion through the context path when the page is synthesized', async () => {
+    // Pins WHICH path the cases below exercise: the synthesized page bakes
+    // in `record:discussion`, so the host suppresses its auto-append and the
+    // panel arrives via DiscussionContext. If this ever flips, the auto-append
+    // case (further down) would be the one under test twice and the context
+    // hop would go uncovered without any test turning red.
+    const dataSource = makeDataSource({ sys_comment: pending, sys_activity: pending });
+
+    renderDetail(dataSource);
+
+    await screen.findByTestId('activity-loading');
+    expect(screen.getAllByTestId('activity-loading')).toHaveLength(1);
+  });
+
+  it('shows the loading row instead of "No comments yet" while both feed reads are in flight', async () => {
+    const dataSource = makeDataSource({
+      sys_comment: pending,
+      sys_activity: pending,
+    });
+
+    renderDetail(dataSource);
+
+    // The panel is on screen and the feed reads have started…
+    const loadingRow = await screen.findByTestId('activity-loading');
+    expect(loadingRow).toBeTruthy();
+    expect(dataSource.find).toHaveBeenCalledWith('sys_comment', expect.anything());
+    expect(dataSource.find).toHaveBeenCalledWith('sys_activity', expect.anything());
+    // …and the record is NOT being told it has no comments while we are
+    // still asking whether it does.
+    expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+  });
+
+  it('keeps the loading row while only ONE of the two parallel reads has settled', async () => {
+    // The two reads are independent promises. "Comments answered" is not
+    // "the feed answered" — leaving the loading state on the first settle
+    // would flash the empty copy right before the activity rows land.
+    const dataSource = makeDataSource({
+      sys_comment: () => Promise.resolve({ data: [] }),
+      sys_activity: pending,
+    });
+
+    renderDetail(dataSource);
+
+    await screen.findByTestId('activity-loading');
+    // Give the settled read several microtask/macrotask turns to (wrongly)
+    // clear the flag before asserting it is still set.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(screen.getByTestId('activity-loading')).toBeTruthy();
+    expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+  });
+
+  it('settles onto the empty copy once BOTH reads answer with nothing', async () => {
+    const dataSource = makeDataSource({
+      sys_comment: () => Promise.resolve({ data: [] }),
+      sys_activity: () => Promise.resolve({ data: [] }),
+    });
+
+    renderDetail(dataSource);
+
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('renders the fetched comment once it lands, with no loading row left behind', async () => {
+    const dataSource = makeDataSource({
+      sys_comment: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: 'c-1',
+              author_name: 'Grace',
+              body: 'First comment on the record',
+              created_at: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+        }),
+      sys_activity: () => Promise.resolve({ data: [] }),
+    });
+
+    renderDetail(dataSource);
+
+    expect(await screen.findByText('First comment on the record')).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+    expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+  });
+
+  // ── A rejected read is an ANSWER, not a permanent spinner ───────────────
+  it('leaves the loading state when a feed read REJECTS (both rejecting)', async () => {
+    // `sys_activity` 404s on any deployment without the audit plugin, and the
+    // view has always swallowed that with `.catch(() => {})`. The loading flag
+    // must be closed over the SETTLED set, not the fulfilled set — otherwise
+    // this fix would trade "wrongly says empty" for "spins forever", which is
+    // the worse bug.
+    const dataSource = makeDataSource({
+      sys_comment: () => Promise.reject(new Error('403 FEEDS_DISABLED')),
+      sys_activity: () => Promise.reject(new Error('404 sys_activity')),
+    });
+
+    renderDetail(dataSource);
+
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('leaves the loading state when only one read rejects and the other resolves empty', async () => {
+    const dataSource = makeDataSource({
+      sys_comment: () => Promise.resolve({ data: [] }),
+      sys_activity: () => Promise.reject(new Error('404 sys_activity')),
+    });
+
+    renderDetail(dataSource);
+
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('still renders the comments that DID arrive when the other read rejects', async () => {
+    const dataSource = makeDataSource({
+      sys_comment: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: 'c-1',
+              author_name: 'Grace',
+              body: 'Survived the failed activity read',
+              created_at: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+        }),
+      sys_activity: () => Promise.reject(new Error('404 sys_activity')),
+    });
+
+    renderDetail(dataSource);
+
+    expect(await screen.findByText('Survived the failed activity read')).toBeTruthy();
+    await waitFor(() => expect(screen.queryByTestId('activity-loading')).toBeNull());
+  });
+});
+
+describe('RecordDetailView — the auto-appended panel is on the same chain (#3209)', () => {
+  // An authored page that omits the discussion slot gets the host's
+  // bottom-of-page `RecordChatterPanel`, mounted DIRECTLY — no
+  // DiscussionContext hop, therefore its own `loading` wire. Missing it
+  // would leave every authored record page still showing "No comments yet"
+  // mid-fetch, with the context path green.
+  it('shows the loading row on an authored page whose discussion slot is auto-appended', async () => {
+    const dataSource = makeDataSource({ sys_comment: pending, sys_activity: pending });
+
+    renderDetail(dataSource, [AUTHORED_PAGE_WITHOUT_DISCUSSION]);
+
+    expect(await screen.findByTestId('activity-loading')).toBeTruthy();
+    expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+  });
+
+  it('settles onto the empty copy once both reads answer', async () => {
+    const dataSource = makeDataSource({
+      sys_comment: () => Promise.resolve({ data: [] }),
+      sys_activity: () => Promise.resolve({ data: [] }),
+    });
+
+    renderDetail(dataSource, [AUTHORED_PAGE_WITHOUT_DISCUSSION]);
+
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('leaves the loading state when both reads reject', async () => {
+    const dataSource = makeDataSource({
+      sys_comment: () => Promise.reject(new Error('403 FEEDS_DISABLED')),
+      sys_activity: () => Promise.reject(new Error('404 sys_activity')),
+    });
+
+    renderDetail(dataSource, [AUTHORED_PAGE_WITHOUT_DISCUSSION]);
+
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -1342,6 +1342,34 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     [user?.id, user?.name, user?.image, permissionsLoaded, systemPermissions],
   );
 
+  // ── Feed loading signal (objectui#3209) ──────────────────────────────────
+  //
+  // This view OWNS the discussion fetch (the two `find`s below are the only
+  // thing that can fill `feedItems`), so it is the only place that can say
+  // "still fetching". Until this existed nobody on the chain could: the
+  // panel spent every fetch asserting `No comments yet` — a factual claim
+  // about the record — and then contradicted itself when the rows landed.
+  // #3205 gave `RecordActivityTimeline` the loading render branch; this is
+  // the missing SIGNAL behind it. Same shape as #3165/#3205: produced by the
+  // host that owns the fetch, never guessed at the consumer (a "no items yet
+  // and just mounted" heuristic down in the timeline would be wrong the
+  // moment a record genuinely has no comments).
+  //
+  // Keyed rather than a plain boolean, deliberately. A `useState(false)` +
+  // `setFeedLoading(true)` inside the effect paints the empty state for the
+  // frame before the effect runs, and navigating to another record would show
+  // the PREVIOUS record's settled state until its effect re-fired. Deriving
+  // "the key I would fetch for ≠ the key I have settled" makes the very first
+  // render of a record already read as loading, with no reset effect.
+  // `record:activity` derives its own flag the same way (`canSelfFetch &&
+  // fetched === null`) — one idiom, not two.
+  const feedFetchKey =
+    dataSource && objectName && pureRecordId && (feedsEnabled || activitiesEnabled)
+      ? `${objectName}:${pureRecordId}`
+      : null;
+  const [settledFeedKey, setSettledFeedKey] = useState<string | null>(null);
+  const feedLoading = feedFetchKey !== null && settledFeedKey !== feedFetchKey;
+
   // Fetch comments from API.
   //
   // NOTE: Record-level presence ("who else is viewing this record") used to
@@ -1353,7 +1381,12 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // realtime / OCC plan.
   useEffect(() => {
     if (!dataSource || !objectName || !pureRecordId) return;
+    let cancelled = false;
     const threadId = `${objectName}:${pureRecordId}`;
+    // The two reads below run in PARALLEL and are collected here so the
+    // loading flag can close over BOTH of them — see the `allSettled` at the
+    // end of this effect.
+    const inFlight: Promise<unknown>[] = [];
 
     // M10.10: Fetch persisted comments from sys_comment. Field names
     // are snake_case to match the platform-objects schema
@@ -1380,7 +1413,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       }));
     };
 
-    if (feedsEnabled) dataSource.find('sys_comment', { $filter: { thread_id: threadId }, $orderby: { created_at: 'asc' } })
+    if (feedsEnabled) inFlight.push(dataSource.find('sys_comment', { $filter: { thread_id: threadId }, $orderby: { created_at: 'asc' } })
       .then((res: any) => {
         if (!res?.data?.length) return;
         const mapped: FeedItem[] = res.data.map((c: any) => ({
@@ -1404,7 +1437,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           });
         });
       })
-      .catch(() => {});
+      .catch(() => {}));
 
     // M10.11: Fetch sys_activity rows for this record and merge into the
     // timeline. plugin-audit's writers populate sys_activity on every
@@ -1438,7 +1471,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
       login:     undefined,
       logout:    undefined,
     };
-    if (activitiesEnabled) dataSource.find('sys_activity', {
+    if (activitiesEnabled) inFlight.push(dataSource.find('sys_activity', {
       $filter: { object_name: objectName, record_id: pureRecordId },
       $orderby: { timestamp: 'asc' },
       $top: 200,
@@ -1485,8 +1518,22 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           });
         });
       })
-      .catch(() => {});
-  }, [dataSource, objectName, pureRecordId, currentUser, feedsEnabled, activitiesEnabled]);
+      .catch(() => {}));
+
+    // The panel leaves the loading state exactly once, when BOTH reads have
+    // answered. `allSettled` over promises that already carry their own
+    // `.catch(() => {})` is what makes a FAILED read count as an answer: a
+    // 404 from `sys_activity` (deployment without the audit plugin) or a
+    // rejected `sys_comment` must land the panel on the empty state, never
+    // pin it in a permanent spinner. Keyed off `feedFetchKey` so a settle
+    // that arrives after the user has navigated to another record cannot
+    // clear the new record's loading state.
+    Promise.allSettled(inFlight).then(() => {
+      if (!cancelled) setSettledFeedKey(feedFetchKey);
+    });
+
+    return () => { cancelled = true; };
+  }, [dataSource, objectName, pureRecordId, currentUser, feedsEnabled, activitiesEnabled, feedFetchKey]);
 
   /**
    * Note: comment-mention → notification fan-out lives on the server
@@ -2082,6 +2129,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         <HighlightFieldsProvider>
         <DiscussionContextProvider
           items={feedItems as any}
+          loading={feedLoading}
           onAddComment={handleAddComment as any}
           onAddReply={handleAddReply as any}
           onToggleReaction={handleToggleReaction as any}
@@ -2163,6 +2211,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                       },
                     }}
                     items={feedItems}
+                    loading={feedLoading}
                     onAddComment={handleAddComment}
                     onAddReply={handleAddReply}
                     onToggleReaction={handleToggleReaction}

--- a/packages/plugin-detail/src/renderers/__tests__/record-chatter.loading.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-chatter.loading.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * `record:chatter` / `record:discussion` — the loading signal reaches the
+ * panel (objectui#3209).
+ *
+ * #3205 gave `RecordActivityTimeline` the branch that renders a loading row
+ * instead of the empty copy, and `RecordChatterPanel` already forwarded
+ * `loading` to it in both positions. The chain was still dead on this hop:
+ * this renderer passed `items` and every handler off `DiscussionContext` but
+ * dropped `loading`, even though `DiscussionContextValue` declares it and
+ * `record:activity` was already reading it. So a hand-placed
+ * `record:discussion` spent the host's whole feed fetch asserting
+ * "No comments yet" — a factual claim about the record, made before the
+ * fetch that would answer it had returned.
+ *
+ * The assertions are on what the USER sees (loading row vs. empty copy), not
+ * on "a prop was forwarded": the prop travelling and the render branch firing
+ * are two different facts, and only together are they the fix.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DiscussionContextProvider } from '@object-ui/react';
+import type { FeedItem } from '@object-ui/types';
+import { RecordChatterRenderer } from '../record-chatter';
+
+const EMPTY_COMMENTS = 'No comments yet';
+const LOADING = 'Loading...';
+
+const ITEMS: FeedItem[] = [
+  {
+    id: 'c-1',
+    type: 'comment',
+    actor: 'Ada',
+    body: 'Already on screen',
+    createdAt: '2026-01-02T00:00:00.000Z',
+  },
+];
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('record:chatter — the host loading signal reaches the rendered panel', () => {
+  it.each(['bottom', 'right', 'left'] as const)(
+    'renders the loading row, not the empty copy, while the host feed is fetching (position: %s)',
+    (position) => {
+      render(
+        <DiscussionContextProvider items={[]} loading>
+          <RecordChatterRenderer schema={{ position } as any} />
+        </DiscussionContextProvider>,
+      );
+
+      expect(screen.getByTestId('activity-loading')).toBeTruthy();
+      expect(screen.getByText(LOADING)).toBeTruthy();
+      // The regression itself: no "this record has no comments" claim while
+      // the host's fetch is still in flight.
+      expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+    },
+  );
+
+  it('falls through to the empty copy once the host fetch has settled with no items', () => {
+    render(
+      <DiscussionContextProvider items={[]} loading={false}>
+        <RecordChatterRenderer schema={{ position: 'bottom' } as any} />
+      </DiscussionContextProvider>,
+    );
+
+    expect(screen.getByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('shows the rows once they land, with no loading row left behind', () => {
+    const view = render(
+      <DiscussionContextProvider items={[]} loading>
+        <RecordChatterRenderer schema={{ position: 'bottom' } as any} />
+      </DiscussionContextProvider>,
+    );
+    expect(screen.getByTestId('activity-loading')).toBeTruthy();
+
+    view.rerender(
+      <DiscussionContextProvider items={ITEMS as any} loading={false}>
+        <RecordChatterRenderer schema={{ position: 'bottom' } as any} />
+      </DiscussionContextProvider>,
+    );
+
+    expect(screen.getByText('Already on screen')).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+    expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+  });
+
+  it('a host that never reports loading still gets the empty copy, not a spinner', () => {
+    // `loading` is optional on DiscussionContextValue: a host that owns no
+    // fetch (or a standalone preview) says nothing, and "nothing" means
+    // settled — the panel must not invent a loading state of its own.
+    render(
+      <DiscussionContextProvider items={[]}>
+        <RecordChatterRenderer schema={{ position: 'bottom' } as any} />
+      </DiscussionContextProvider>,
+    );
+
+    expect(screen.getByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+
+  it('renders the empty copy with no DiscussionContext at all', () => {
+    // Standalone previews mount the block with no host — it composes, and it
+    // does not hang on a spinner it has no way to clear.
+    render(<RecordChatterRenderer schema={{ position: 'bottom' } as any} />);
+
+    expect(screen.getByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-chatter.tsx
+++ b/packages/plugin-detail/src/renderers/record-chatter.tsx
@@ -56,6 +56,13 @@ export const RecordChatterRenderer: React.FC<RecordChatterRendererProps> = ({
       <RecordChatterPanel
         items={(discussion?.items as any) || []}
         config={config}
+        // The host that owns the fetch produces this (app-shell
+        // `RecordDetailView`); without it a hand-placed `record:chatter` /
+        // `record:discussion` spends the whole fetch claiming the record has
+        // no comments (objectui#3209 — #3205 added the render branch, this
+        // is the signal that reaches it). `record:activity` reads the same
+        // field off the same context; no second idiom.
+        loading={discussion?.loading}
         onAddComment={discussion?.onAddComment as any}
         onAddReply={discussion?.onAddReply as any}
         onToggleReaction={discussion?.onToggleReaction as any}


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3209

## 问题

记录详情页打开的头一段时间,讨论面板渲染的是 `No comments yet`(`emptyLabel`)——那是一句**关于这条记录的事实断言**,而此时用来回答这个问题的取数还没回来;行落地之后面板又自己打自己的脸。

#3205 已经把 `RecordActivityTimeline` 的渲染分支补上了(`loading && filtered.length === 0` 时渲染 loading 行而不是空态),`RecordChatterPanel` 的两处透传(sidebar / inline)本来也是好的。**缺的是信号源**:chatter 这条链上没有任何人算出 `loading`,所以那个分支永远不会被触发。`record:activity` 因为自己算了 `loading`,#3205 一合并就立刻可见;chatter 得等这一单。

## 改了什么(四个落点,一条链)

原单和派发说明都点明了:少接一处,就还有一条用户路径继续看到空态。四处全接:

1. **`packages/app-shell/src/views/RecordDetailView.tsx`** —— 真正**拥有取数**的宿主,从它自己的两个 `find`(`sys_comment` + `sys_activity`)算出 `feedLoading`;
2. `< DiscussionContextProvider loading={feedLoading} >` 把它发布出去(`DiscussionContextValue` 本来就声明了 `loading`,`record:activity` 也早就在读);
3. 自动追加的 `< RecordChatterPanel loading={feedLoading} >` —— 作者页面没摆讨论槽位时用户拿到的就是它,它不经过 context,得单独接;
4. **`packages/plugin-detail/src/renderers/record-chatter.tsx`** 补 `loading={discussion?.loading}`,让作者手工摆放的 `record:chatter` / `record:discussion` 和合成页走同一条链。

第 4 处是照 `renderers/record-activity.tsx` 抄的(它已经在读 `discussion?.loading`),没有发明第二种写法。

## 两个并行 promise 怎么收口的

两个 `find` 是**并行**的,所以标志位必须同时闭合在两条上:

```ts
const inFlight: Promise< unknown >[] = [];
if (feedsEnabled) inFlight.push(dataSource.find('sys_comment', …).then(…).catch(() => {}));
if (activitiesEnabled) inFlight.push(dataSource.find('sys_activity', …).then(…).catch(() => {}));

Promise.allSettled(inFlight).then(() => {
  if (!cancelled) setSettledFeedKey(feedFetchKey);
});
```

- **`allSettled`,不是 `all`** —— 而且是叠在原有的 `.catch(() => {})` 之上:**失败也是答案**。没装审计插件的部署 `sys_activity` 会 404,`enable.feeds: false` 的对象 `sys_comment` 会 403,任何一条都不能把面板永久钉成转圈——那比原来的 bug 更糟。
- 只有一条 settle 时**不能**转 false,否则活动行落地前会闪一下空态。

## 为什么用「键」而不是一个布尔

```ts
const feedFetchKey = dataSource && objectName && pureRecordId && (feedsEnabled || activitiesEnabled)
  ? `${objectName}:${pureRecordId}` : null;
const [settledFeedKey, setSettledFeedKey] = useState< string | null >(null);
const feedLoading = feedFetchKey !== null && settledFeedKey !== feedFetchKey;
```

`useState(false)` + effect 里 `setFeedLoading(true)` 会在 effect 跑之前先画一帧空态,而且换记录时会先显示**上一条记录**已经 settle 的状态。用「我要取的键 ≠ 我已 settle 的键」来推导,记录的**第一帧**就已经是 loading 态,也不需要额外的 reset effect。`record:activity` 用的是同一个思路(`canSelfFetch && fetched === null`)。

`.then()` 里带 `cancelled` 守卫,并按 `feedFetchKey` 落键:用户已经跳到下一条记录之后才回来的 settle,不会把新记录的 loading 态抹掉。

## 没有在消费端加兜底

timeline 里**没有**去猜「items 为空且刚挂载就算 loading」——那个猜测在记录真的没有评论时就是错的。信号由拥有取数的人产出,这是 #3165 / #3205 已经确立的形状,也是本轮 #3232 同一条仓规。

## 测试

断言的是**用户看到什么**(loading 行 vs 空态),不是「prop 传到了」——#3205 修的是渲染分支、本单修的是信号源,两者合起来才是用户可见的结果。

- `packages/app-shell/src/views/RecordDetailView.feedLoading.test.tsx`(新增,11 例)—— 真渲染 `RecordDetailView`,覆盖**两条投递路径**:合成页(内置 `record:discussion` 节点 → 走 DiscussionContext)与作者页(不摆讨论槽位 → 走自动追加)。含「两条都在飞」「只 settle 了一条」「两条都 settle 且为空」「行落地」「一条 reject」「两条都 reject」。
- `packages/plugin-detail/src/renderers/__tests__/record-chatter.loading.test.tsx`(新增,7 例)—— `record:chatter` 渲染器三种 position 全覆盖,外加「宿主不报 loading」「完全没有 DiscussionContext」两种不能自己造 spinner 的情况。

**Mutation 验证**(每一处接线单独摘掉,确认转红):

| 摘掉的东西 | 结果 |
|---|---|
| `< DiscussionContextProvider loading >` | 2 failed \| 5 passed |
| `record-chatter.tsx` 的 `loading={discussion?.loading}` | 6 failed \| 8 passed(两个文件都红) |
| 自动追加 panel 的 `loading={feedLoading}` | 1 failed \| 10 passed |
| `allSettled(inFlight)` → 只等第一条 | 1 failed \| 10 passed(「只 settle 了一条」转红) |
| `allSettled` → `all` 且去掉 `sys_activity` 的 `.catch` | 3 failed \| 8 passed(三个 reject 用例全红) |

**回归**:`packages/plugin-detail` 39 files / 369 tests 全绿;`packages/app-shell` 259 files / 2221 passed(1 skipped)全绿;两个包 `type-check` 通过,`lint` 0 error。

## 顺路发现,已单独立单

切换记录时 `feedItems` 从不清空(两处回填都是 `setFeedItems(prev => 按 id 归并)`,全文件没有一处重置回 `[]`,而 `RecordDetailView` 在路由下不重挂载),上一条记录的评论会留在下一条记录的面板上。已复现并作为 objectstack-ai/objectui#3268 立单,**未**在本 PR 里顺手修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_