### PR TITLE
fix(components): translate the built-in select branch's empty copy (#3263)

### DIFF
--- a/.changeset/builtin-select-empty-state-translated.md
+++ b/.changeset/builtin-select-empty-state-translated.md
@@ -1,0 +1,39 @@
+---
+"@object-ui/components": patch
+---
+
+The form renderer's built-in `select` branch stops saying "No options available"
+in English to non-English sessions (objectui#3263).
+
+FROM: the inline branch that renders a `type: 'select'` field — the one taken
+whenever the field is a `BUILTIN_FIELD_TYPES` member, i.e. before the `field:`
+registry is consulted — rendered `{emptyHint || 'No options available'}`. TO:
+`{emptyHint || t('fields.options.empty')}`, the same i18n key the registered
+option widgets fall back to (objectui#3231, all ten locale packs).
+
+This was the last hardcoded copy of that sentence in `form.tsx`, and the file was
+half-translated in a way a user could see inside one widget: the dependency-gate
+sentence next to it already went through `t()`
+(`fields.options.selectFirst`), so under a `zh` session a gated select read
+"请先选择Country" and the same select — one keystroke later, when the parent
+value matched no option — flipped to English.
+
+`fields.options.empty` is added to `useSafeFormTranslation`'s defaults map, the
+pattern `fields.options.selectFirst` already follows there, so a form rendered
+with no `I18nProvider` (standalone widget, test, embedded form) produces the
+byte-identical English string it produced before. Both halves are pinned by
+tests: the Chinese rendering in one file, the no-provider English fallback in
+another (mounting a provider installs it as react-i18next's global default,
+which would erase the state the second one observes).
+
+The box moved from an inline `<div>` into a small `BuiltinSelectEmptyState`
+component in the same file, because `renderFieldComponent` is a plain helper that
+early-returns on the registered-widget path — a hook called there would run
+conditionally. It forwards its rest props, since `<FormControl>` is a Radix
+`Slot` that supplies the control's `id` / `aria-describedby`; a test pins that
+the field's `<label for>` still resolves to this box.
+
+Deliberately NOT unified with `@object-ui/fields`' `OptionsEmptyState`: different
+package, different render path (inline branch vs. registry). What the two share
+is the i18n key, not a component — merging them would impose one path's markup
+and props on the other.

--- a/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-default.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-default.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The no-provider half of objectui#3263: routing the built-in `select` branch's
+ * empty copy through `t('fields.options.empty')` must not change what a form
+ * with NO `I18nProvider` renders — a standalone form, a test, an embedded
+ * widget. `createSafeTranslation`'s defaults map carries the same English
+ * sentence the branch used to hardcode, so the output stays byte-identical.
+ *
+ * Deliberately its own file: `I18nProvider` registers its instance as
+ * react-i18next's global default, so any module graph that mounts one (see
+ * `form-builtin-select-empty-i18n.test.tsx`) no longer has a "no provider"
+ * state to observe.
+ *
+ * The second assertion pins something the fix could plausibly have broken: the
+ * empty state moved from an inline `<div>` to a small component, and
+ * `<FormControl>` is a Radix `Slot` that hands the control its `id` — drop the
+ * rest props and the field's `<label for>` points at nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(<Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields }} />);
+}
+
+const unconfiguredSelect = [
+  { name: 'province', label: 'Province', type: 'select', options: [] },
+];
+
+describe('form renderer — built-in select empty state without an I18nProvider (objectui#3263)', () => {
+  it('falls back to the same English sentence it used to hardcode', () => {
+    renderForm(unconfiguredSelect);
+
+    expect(screen.getByText('No options available')).toBeInTheDocument();
+  });
+
+  it('is still the labelled form control, not a detached box', () => {
+    renderForm(unconfiguredSelect);
+
+    const box = screen.getByText('No options available');
+    const label = screen.getByText('Province');
+
+    expect(box.id).toBeTruthy();
+    expect(label).toHaveAttribute('for', box.id);
+    expect(box).toHaveAttribute('aria-describedby');
+  });
+});

--- a/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-i18n.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-i18n.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The built-in `select` branch's empty state is translated — objectui#3263.
+ *
+ * `type: 'select'` is a `BUILTIN_FIELD_TYPES` member, so a bare select never
+ * reaches the `field:` registry: it renders the form renderer's own inline
+ * branch. That branch had TWO empty sentences and only one of them spoke the
+ * user's language — the dependency gate went through `t()`
+ * (`fields.options.selectFirst`, objectui#3231) while the generic "nothing to
+ * offer" copy was a hardcoded English literal. Under a `zh` session a gated
+ * list read Chinese and an unconfigured one English, from the same widget.
+ *
+ * Both sentences are asserted here, in one locale, precisely because the defect
+ * was the SPLIT: pinning only the new key would let the pair drift apart again.
+ * The English no-provider fallback lives in
+ * `form-builtin-select-empty-default.test.tsx` — mounting `I18nProvider` here
+ * installs its instance as react-i18next's global default, so within this
+ * module graph there is no "no provider" state left to observe.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../../../renderers';
+
+function renderFormIn(language: string, fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields }} />
+    </I18nProvider>,
+  );
+}
+
+/** Nothing to offer at all — the branch's own empty copy (`fields.options.empty`). */
+const unconfiguredSelect = [
+  { name: 'province', label: 'Province', type: 'select', options: [] },
+];
+
+/** Waiting on its controlling field — the gate copy (`fields.options.selectFirst`). */
+const gatedSelect = [
+  { name: 'country', label: 'Country', type: 'input', defaultValue: '' },
+  {
+    name: 'province',
+    label: 'Province',
+    type: 'select',
+    dependsOn: 'country',
+    options: [
+      { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+      { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+    ],
+  },
+];
+
+describe('form renderer — built-in select empty state speaks the session locale (objectui#3263)', () => {
+  it('renders the unconfigured copy in Chinese under a zh provider', () => {
+    renderFormIn('zh', unconfiguredSelect);
+
+    expect(screen.getByText('暂无可选项')).toBeInTheDocument();
+    // The literal this replaced. Asserted negatively as well as positively:
+    // a re-inlined English string would still let the positive assertion pass
+    // if the box ever rendered both.
+    expect(screen.queryByText(/no options available/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the dependency-gate copy in Chinese from the same branch', () => {
+    renderFormIn('zh', gatedSelect);
+
+    // `Select {{fields}} first` with the controlling field's label interpolated.
+    expect(screen.getByText('请先选择Country')).toBeInTheDocument();
+    expect(screen.queryByText(/select .* first/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the gate and the empty copy in ONE language as the gate lifts', async () => {
+    // The transition the split used to expose: gated (Chinese) -> parent set,
+    // but this parent value matches no option, so the list is empty (used to
+    // flip to English mid-interaction, in the same widget, same session).
+    renderFormIn('zh', gatedSelect);
+
+    expect(screen.getByText('请先选择Country')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/country/i), { target: { value: 'jp' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('暂无可选项')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/no options available/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -113,6 +113,12 @@ const useSafeFormTranslation = createSafeTranslation(
     // objectui#3231 — the dependency-gate sentence (#2284). Shared with the
     // option widgets' own fallback so both sides render one wording.
     'fields.options.selectFirst': 'Select {{fields}} first',
+    // objectui#3263 — the built-in `select` branch's own empty copy. Same key
+    // as the option widgets' fallback (`packages/fields`), so an empty option
+    // list reads identically whichever render path produced it. The default
+    // here is what a form with no I18nProvider renders — byte-identical to the
+    // English literal this replaced.
+    'fields.options.empty': 'No options available',
     'validation.required': '{{field}} is required',
     'validation.minLength': '{{field}} must be at least {{min}} characters',
     'validation.maxLength': '{{field}} must be at most {{max}} characters',
@@ -1729,6 +1735,42 @@ function openNativePickerOnClick(inputType: string | undefined) {
   };
 }
 
+/**
+ * The built-in (unregistered) `select` branch's empty state — objectui#3263.
+ *
+ * A component rather than an inline `<div>` because the copy has to go through
+ * `useSafeFormTranslation()`, and `renderFieldComponent` below is a plain
+ * helper, not a component: it early-returns on the registered-widget path, so a
+ * hook called there would run conditionally (rules-of-hooks). Owning the box
+ * gives the hook a legitimate home without changing what the branch renders.
+ *
+ * The host's `emptyHint` still wins when it computed one (the #2284 dependency
+ * gate, already translated via `fields.options.selectFirst`); this only
+ * translates the branch's OWN fallback, which was the last hardcoded English
+ * copy of that sentence in this file.
+ *
+ * Deliberately NOT `packages/fields`' `OptionsEmptyState`: different package,
+ * different render path (this is the inline `BUILTIN_FIELD_TYPES` branch, that
+ * one the registry). What the two share is the i18n KEY, not a component —
+ * unifying them would impose one path's styling and props on the other.
+ *
+ * `...rest` is forwarded because `<FormControl>` is a Radix `Slot`: it hands the
+ * control its `id` / `aria-describedby` / `aria-invalid`, so dropping the rest
+ * props here would silently unlink the field's own label and error message.
+ */
+function BuiltinSelectEmptyState({
+  emptyHint,
+  className,
+  ...rest
+}: { emptyHint?: string } & React.HTMLAttributes<HTMLDivElement>) {
+  const { t } = useSafeFormTranslation();
+  return (
+    <div className={cn('text-sm text-muted-foreground', className)} {...rest}>
+      {emptyHint || t('fields.options.empty')}
+    </div>
+  );
+}
+
 function renderFieldComponent(type: string, props: RenderFieldProps) {
   // 1. Try to resolve specialized field widget from registry first.
   //    Form fields should always prefer the `field:<type>` namespace when
@@ -1838,11 +1880,7 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       // — surface that instead of the generic "no options" so the user knows to
       // pick the parent first rather than reading it as a broken widget.
       if (!options || options.length === 0) {
-        return (
-          <div className="text-sm text-muted-foreground">
-            {emptyHint || 'No options available'}
-          </div>
-        );
+        return <BuiltinSelectEmptyState emptyHint={emptyHint} />;
       }
 
       return (


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3263

## 问题

`packages/components/src/renderers/form/form.tsx` 的内建 `select` 分支(命中 `BUILTIN_FIELD_TYPES` 时的内联渲染,走不到 `field:` 注册表)渲染的是硬编码英文:

```
{emptyHint || 'No options available'}
```

而**紧挨着它**的门控提示早就走了 i18n(`t('fields.options.selectFirst')`,objectui#3231)。也就是说同一个 widget 在 zh 会话里会中途换语言:被 `dependsOn` 门控时读到「请先选择Country」,用户把父字段填成一个匹配不到任何选项的值之后,同一个框立刻变成英文 "No options available"。这是 #3231 scope fence 刻意留下的最后一块,不是遗漏。

## 改动

1. 分支改为 `t('fields.options.empty')` —— 与已注册选项 widget(`packages/fields` 的 `OptionsEmptyState`)回落时用的**同一个 key**,十个语言包里已就位,`packages/i18n` 不需要改。
2. 在 `useSafeFormTranslation` 的 defaults map 里补 `'fields.options.empty': 'No options available'` —— 与 `fields.options.selectFirst` 在那里的做法一致。**无 provider 时渲染结果逐字不变**,所以现有的英文断言(`form-cascading-select.test.tsx`、`plugin-form/selectOptions.test.tsx`)不需要动,也确实全绿。
3. 空状态从内联的 div 提成同文件里的小组件 `BuiltinSelectEmptyState`。原因:`renderFieldComponent` 是普通 helper 而非组件,它在「已注册 widget」那条路径上会提前 return,在那里调 hook 就是**条件调用**(rules-of-hooks)。组件里 `...rest` 会转发下去,因为 `FormControl` 是 Radix Slot,控件的 `id` / `aria-describedby` / `aria-invalid` 是它塞进来的 —— 丢掉 rest props 会让该字段的 label 指向一个不存在的 id,这一点有测试钉住。

## 边界(按 issue 与派发说明)

**没有**把内建分支和 `packages/fields` 的 `OptionsEmptyState` 统一成一个组件:不同包、不同渲染路径(内联分支 vs. 注册表),该共享的只有 i18n key,不是组件 —— 合并会把一条路径的 DOM 结构和 props 约束强加给另一条。

`packages/i18n` 未改动(两个 key 由 #3231 补齐,已核对 `en.ts` / `zh.ts`)。

## 测试

两个新文件,拆开是必须的:挂载 `I18nProvider` 会把它的实例注册成 react-i18next 的全局默认,同一模块图里就再也观察不到「无 provider」状态(与 `OptionsEmptyState.test.tsx` / `OptionsEmptyState.no-provider.test.tsx` 的拆法一致)。

- `form-builtin-select-empty-i18n.test.tsx` —— zh 下渲染「暂无可选项」;门控句渲染「请先选择Country」;以及门控解除后**两句话仍在同一种语言里**(这条正是原缺陷暴露的那个转换)。
- `form-builtin-select-empty-default.test.tsx` —— 无 provider 时回落到逐字相同的英文;以及空状态仍是被 label 关联的表单控件(label 的 `for` 等于该 div 的 `id`,且带 `aria-describedby`)。

```
pnpm exec vitest run --maxWorkers=2 packages/components/src/renderers/form/ \
  packages/plugin-form/src/selectOptions.test.tsx \
  packages/fields/src/widgets/OptionsEmptyState*.test.tsx
Test Files  21 passed (21)
     Tests  112 passed (112)

pnpm --filter @object-ui/components test    Test Files 20 passed / Tests 177 passed
pnpm --filter @object-ui/components type-check    通过
```

**变异验证**(把 `t('fields.options.empty')` 改回英文字面量后重跑):

```
Test Files  1 failed | 1 passed (2)
     Tests  2 failed | 3 passed (5)
```

失败现场的 DOM dump 里,zh provider 下那个 div 渲染的正是 `No options available`;顺带确认 `id="_r_4_-form-item"` 与 `aria-describedby` 仍然落在这个 div 上(即 rest props 转发是对的)。

Changeset:`.changeset/builtin-select-empty-state-translated.md`(patch,仅 `@object-ui/components`)—— 非英文会话不再在这里看到英文,属用户可见变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_