### PR TITLE
docs(ci): stop lint.yml's header comment hand-counting the object-ui error rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,21 @@
 name: Lint
 
 # Until #2923 this workflow was `workflow_dispatch`-only, so ESLint had never
-# gated a PR. That mattered more than it looked: `eslint.config.js` sets three
-# `object-ui/*` rules to `error` *specifically* so a new violation fails CI
-# (ADR-0054 Phase 5, #2879, and the objectql.ts ratchet), and each author
-# pre-cleaned the existing sites so the rule would lint clean. All three
-# ratchets were inert because nothing ran them.
+# gated a PR. That mattered more than it looked: every `object-ui/*` rule that
+# `eslint.config.js` sets to `error` is a ratchet — added *specifically* so a
+# new violation fails CI, with its existing sites pre-cleaned first so the rule
+# lints clean on the day it lands. While nothing ran them, every one of them was
+# inert.
+#
+# `eslint.config.js` is the single list of those rules, and this comment
+# deliberately neither counts them nor names them: it used to hand-count, and
+# the count was stale by the time anyone read it (#3261). A hand-copied
+# enumeration drifts by construction, and a stale one still reads as
+# authoritative — `content/docs/guide/ci-cd-pipeline.md` avoids the number for
+# the same reason. `scripts/__tests__/lint-workflow.test.ts` holds that in
+# place: it fails if a count or a rule name reappears here, if the config stops
+# setting any `object-ui/*` rule to `error`, or if this workflow stops gating
+# pull requests.
 #
 # `--max-warnings` is deliberately not set: the 7,724 warnings repo-wide are 81%
 # `no-explicit-any`, plus React Compiler rules the config downgrades on purpose.

--- a/scripts/__tests__/lint-workflow.test.ts
+++ b/scripts/__tests__/lint-workflow.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3261: the header comment in `.github/workflows/lint.yml` said
+ * `eslint.config.js` sets *three* `object-ui/*` rules to `error` and named the
+ * three sources they came from. The config had four. The parenthesised list of
+ * sources was short by one for the same reason.
+ *
+ * Miscounting is the visible symptom, not the defect. That comment is the only
+ * written explanation of why `lint.yml` exists at all — it records that those
+ * `error` ratchets sat inert for months because the workflow was
+ * `workflow_dispatch`-only until #2923. The next person adding an `error`-level
+ * rule reads it to decide what this gate covers, and a stale enumeration reads
+ * exactly as authoritative as a fresh one: it will tell them their new rule is
+ * outside the gate (or inside it) with equal confidence, and be wrong.
+ *
+ * A hand-copied enumeration drifts by construction; #3212 measured the same
+ * page's workflow count at 11 in the doc, 12 in the issue and 13 in reality on
+ * a single day. So the comment no longer counts or names anything, and this
+ * file is what keeps it that way — plus it pins the two claims the comment
+ * still makes, so the prose cannot quietly become fiction:
+ *
+ *   1. the enumeration does not come back (the #3261 regression itself);
+ *   2. `eslint.config.js` really does set `object-ui/*` rules to `error`,
+ *      otherwise the comment describes a gate that no longer has anything to
+ *      gate;
+ *   3. this workflow really does run on pull requests, otherwise those rules
+ *      are inert again exactly as they were before #2923 — and the comment
+ *      would be describing the bug as history while it is live.
+ *
+ * Deliberately NOT asserted: that a *list* of the rules somewhere matches the
+ * config. Keeping such a list is the thing this issue removed — the generic
+ * phrasing ("the rules `eslint.config.js` sets to `error`") is always true, so
+ * the only honest list is the config itself.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowPath = path.join(repoRoot, '.github/workflows/lint.yml');
+const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+type FlatConfigEntry = { rules?: Record<string, unknown>; files?: string[] };
+
+/**
+ * The resolved flat config, imported rather than text-scanned: severity is
+ * authored four different ways (`'error'`, `2`, `['error', {…}]`, `[2, {…}]`)
+ * and the `object-ui/*` rules live in four separate config objects with
+ * different `files` scopes. Reading the evaluated array is the only way to get
+ * the same answer ESLint would.
+ *
+ * At module scope, not in `beforeAll` — AGENTS.md's testing discipline, and
+ * `object-ui/no-dynamic-import-in-test-hook` mechanically enforces it: the cost
+ * of loading typescript-eslint and the local plugin belongs to the import
+ * phase, where no test or hook timeout applies.
+ */
+const eslintConfig = ((await import('../../eslint.config.js')) as { default: FlatConfigEntry[] })
+  .default;
+
+const severityOf = (value: unknown): unknown => (Array.isArray(value) ? value[0] : value);
+
+const objectUiErrorRules = eslintConfig
+  .flatMap((entry) => Object.entries(entry?.rules ?? {}))
+  .filter(([name, value]) => {
+    const severity = severityOf(value);
+    return name.startsWith('object-ui/') && (severity === 'error' || severity === 2);
+  })
+  .map(([name]) => name);
+
+/**
+ * The `# …` prose block between `name:` and `on:` — the comment this issue is
+ * about. Scoped so the assertions below read the explanation, not the YAML.
+ */
+function headerComment(): string {
+  const start = workflow.indexOf('\n#');
+  const end = workflow.indexOf('\non:');
+  expect(start, 'lint.yml must still carry a header comment above `on:`').toBeGreaterThan(-1);
+  expect(end, 'lint.yml must still have a top-level `on:` block').toBeGreaterThan(start);
+  return workflow.slice(start, end);
+}
+
+/**
+ * The header comment as one continuous line: `#` markers stripped and wrapping
+ * undone. Matching the raw block instead would miss the exact sentence that
+ * caused #3261 — "sets three" ended a line and "`object-ui/*` rules" began the
+ * next one, so any pattern spanning the two has to survive a `\n# ` in the
+ * middle. Comment prose re-wraps whenever a word is edited, so the assertions
+ * below must not depend on where the lines happen to break.
+ */
+function unwrappedHeaderComment(): string {
+  return headerComment()
+    .replace(/^[ \t]*#[ \t]?/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * The `on:` block, from the top-level `on:` key to the next top-level key.
+ * Trigger claims have to be read here and not from the whole file, where the
+ * word `pull_request` also appears in `concurrency`/`github.ref` expressions.
+ */
+function onBlock(): string {
+  const start = workflow.indexOf('\non:');
+  const rest = workflow.slice(start + 1);
+  const next = rest.search(/\n[a-z_]+:/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe('lint.yml header comment — objectui#3261', () => {
+  it('never hand-counts the object-ui/* rules again', () => {
+    const comment = unwrappedHeaderComment();
+
+    // `three \`object-ui/*\` rules`, `all four ratchets`, `4 object-ui rules`…
+    const counted = [
+      ...comment.matchAll(
+        /\b(one|two|three|four|five|six|seven|eight|nine|ten|\d+)\b[^.]{0,20}?(`?object-ui|ratchet)/gi,
+      ),
+    ].map((m) => m[0]);
+
+    expect(
+      counted,
+      `lint.yml's header comment counts the \`object-ui/*\` error rules again:\n` +
+        counted.map((c) => `  - ${JSON.stringify(c)}`).join('\n') +
+        `\n\nDon't. The count was wrong within weeks last time (objectui#3261: the ` +
+        `comment said three, the config had four) and a stale count still reads as ` +
+        `authoritative to the next person deciding what this gate covers. Say "the ` +
+        `\`object-ui/*\` rules \`eslint.config.js\` sets to \`error\`" instead — always ` +
+        `true, never maintained. content/docs/guide/ci-cd-pipeline.md phrases it that ` +
+        `way for the same reason.`,
+    ).toEqual([]);
+  });
+
+  it('never enumerates them by name either', () => {
+    // Same defect one level down: naming the rules is a list that has to be
+    // maintained in lockstep with the config, and nothing makes anyone do it.
+    const named = objectUiErrorRules.filter((rule) => workflow.includes(rule));
+
+    expect(
+      named,
+      `lint.yml names specific \`object-ui/*\` rules:\n` +
+        named.map((r) => `  - ${r}`).join('\n') +
+        `\n\nThat list is a second copy of eslint.config.js and will drift from it ` +
+        `(objectui#3261). The workflow explains why the gate exists; eslint.config.js ` +
+        `is where the rules are, with each rule's own comment giving its ADR/issue.`,
+    ).toEqual([]);
+  });
+});
+
+describe('lint.yml header comment — the claims it still makes', () => {
+  it("eslint.config.js really does set object-ui/* rules to `error`", () => {
+    // The comment's premise. If every ratchet is downgraded or deleted, this
+    // fails — which is the moment the comment has to be rewritten rather than
+    // left describing a gate with nothing behind it.
+    expect(
+      objectUiErrorRules,
+      `No \`object-ui/*\` rule is set to \`error\` in eslint.config.js, but lint.yml's ` +
+        `header comment is built entirely on the premise that some are. Either a ` +
+        `severity was downgraded by accident, or the ratchets are genuinely gone and ` +
+        `that comment now needs rewriting (objectui#3261).`,
+    ).not.toEqual([]);
+  });
+
+  it('still runs on pull requests, so those rules are not inert again (#2923)', () => {
+    const on = onBlock();
+
+    expect(
+      on,
+      `lint.yml no longer triggers on \`pull_request\`. That is exactly the state ` +
+        `#2923 fixed: every \`object-ui/*\` rule \`eslint.config.js\` sets to \`error\` ` +
+        `goes silently inert, because the only thing that runs them on a PR is this ` +
+        `workflow. The header comment describes that as history — keep it history.`,
+    ).toMatch(/^\s{2}pull_request:/m);
+  });
+
+  it('does not paths-ignore the TypeScript sources those rules lint', () => {
+    // A narrow tripwire, not a glob engine (the repo has no glob matcher at the
+    // root, and vendoring one for this would cost more than it protects). The
+    // realistic way to un-gate the ratchets without touching the triggers above
+    // is adding a TypeScript pattern to `paths-ignore`; today's entries are all
+    // markdown, `content/**`, `docs/**` and `.changeset/**`.
+    const ignored = [...onBlock().matchAll(/^\s*-\s*'([^']+)'/gm)].map((m) => m[1]);
+
+    expect(ignored.length, 'lint.yml must still declare `paths-ignore` entries').toBeGreaterThan(0);
+
+    const swallowsSource = ignored.filter((pattern) => /\.tsx?$/.test(pattern));
+    expect(
+      swallowsSource,
+      `lint.yml skips TypeScript changes:\n` +
+        swallowsSource.map((p) => `  - ${p}`).join('\n') +
+        `\n\nEvery \`object-ui/*\` rule \`eslint.config.js\` sets to \`error\` only gates ` +
+        `a PR because this workflow lints the .ts/.tsx it touches. Excluding them is the ` +
+        `pre-#2923 inert state with extra steps.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3261

`.github/workflows/lint.yml` 的头部注释写着 `eslint.config.js` 把**三条** `object-ui/*` 规则设成 `error`,实际是**四条**;括号里点名的三个来源(ADR-0054 Phase 5、#2879、objectql.ts ratchet)同样漏了一个(`no-dynamic-import-in-test-hook` / #3010、#3021)。

复核结果(`origin/main` @ `e0f23ca`,直接读求值后的 flat config,而不是扫文本):

| eslint.config.js 行 | 规则 | `files` 作用域 |
|---|---|---|
| 59 | `no-synthetic-event-trigger` | `**/*.{ts,tsx}` |
| 65 | `no-try-catch-around-hook` | `**/*.{ts,tsx}` |
| 98 | `no-dynamic-import-in-test-hook` | `**/*.test.{ts,tsx}`、`**/__tests__/**` |
| 111 | `no-inline-spec-config` | `packages/types/src/objectql.ts` |

## 为什么不是把「三」改成「四」

数错一个数是症状,不是缺陷。这条注释是 `lint.yml` 存在理由的**唯一**书面说明 —— 它记录着「这些 `error` ratchet 曾因 workflow 是 `workflow_dispatch`-only 而全部空转,直到 #2923」。下一个要加 `error` 级规则的人照它判断这道门禁管到哪儿,而**过期的枚举读起来和新鲜的一样权威**:它会同样自信地告诉那个人「你的新规则不在覆盖范围内」(或者反过来),然后是错的。

#3212 在同一天量过同一页:工作流数量文档写 11、issue 写 12、实际 13 —— 手工维护的枚举**按构造必然漂移**。三改四只是把下一次漂移推迟到第五条规则落地那天。

所以注释改成既不点数也不点名,与 `content/docs/guide/ci-cd-pipeline.md` 已经采用的写法(「the rules `eslint.config.js` sets to `error`」)对齐,不再维护第二份副本。

## 但清单确实有价值 —— 所以加了守卫

本单和 PM 都要求先评估「加断言把清单钉在 `eslint.config.js` 上」。评估结论:**把清单钉住可行,但清单本身不该保留**。

`eslint.config.js` 已经是那份清单,而且每条规则**在自己旁边**写了 ADR/issue 出处;在 workflow YAML 里再抄一份,只是制造一个必须与配置同步、却没有任何机制强迫谁去同步的第二副本。真正值得机器守住的不是「有几条」,而是这条注释**还在做的那几个断言**。于是 `scripts/__tests__/lint-workflow.test.ts`(与 #3212 的反向断言、#3207 的 peer-edge 守卫、#3257 的样例守卫同一路数)钉住:

1. 枚举不会回来 —— 注释里不得再出现数量词或规则名(#3261 本身的回归守卫);
2. `eslint.config.js` 确实还有 `object-ui/*` 规则设成 `error` —— 否则注释描述的是一道背后空无一物的门禁,该重写了;
3. 这个 workflow 确实还在 `pull_request` 上跑,且没把 `.ts`/`.tsx` 放进 `paths-ignore` —— 否则那些规则就**又**空转了,和 #2923 修掉的状态一模一样,而注释还在把它当历史讲。

规则集合是 `import` 求值后的 flat config 读出来的,不是正则扫文本:severity 有 `'error'` / `2` / `['error', {…}]` 等多种写法,四条规则又分散在四个 `files` 作用域不同的 config 对象里,只有读求值结果才能得到和 ESLint 一致的答案。

## 破坏性验证(每例改完即还原)

| 用例 | 结果 |
|---|---|
| 基线 | 5 passed |
| A1 数量词写回注释(同一行) | `× never hand-counts the object-ui/* rules again` |
| A2 数量词**跨注释换行**(#3261 原始形态) | `× never hand-counts the object-ui/* rules again` |
| B 注释里点名规则 | `× never enumerates them by name either` |
| C 四条规则全降为 `warn` | ``× eslint.config.js really does set object-ui/* rules to `error` `` |
| D 去掉 `pull_request` 触发器 | `× still runs on pull requests, so those rules are not inert again (#2923)` |
| E `paths-ignore` 加 `'**/*.tsx'` | `× does not paths-ignore the TypeScript sources those rules lint` |
| **F 新增第五条 `error` 规则** | **5 passed —— 保持绿灯** |

F 是这套设计的关键性质,不是遗漏:加规则**不该**要求任何人再去改一句 workflow 散文。如果走「保留枚举 + 断言钉住」那条路,F 会变红,把「编辑注释」变成每个加规则的人都要做的杂务 —— 而一个只能靠改散文来修的失败断言,教会大家的是把守卫当噪音。

A2 值得单说:第一版正则用 `[^.\n]` 连接数量词与 `object-ui`,**漏掉了 #3261 的原始形态** —— 原注释里 "sets three" 结束一行、"`object-ui/*` rules" 开始下一行。破坏性验证抓到了这一点,现已改为先把注释去掉 `#` 前缀、展平换行再匹配。

## 未加 changeset

改动是一条 CI workflow 注释 + 一个仓库内部守卫测试,不触及任何已发布包的行为或 API,没有用户可见的东西发出去。按 AGENTS.md「纯 bug 修复不需要 changeset」,这里连发布代码都不是;加了只会在 release notes 里多一行无意义条目。

## 边界

只改了 `.github/workflows/lint.yml` 的注释,新增一个测试文件。**未改**任何 workflow 的实际行为,**未改** `eslint.config.js` 的规则等级。

`npx eslint scripts/__tests__/lint-workflow.test.ts` 干净退出;`vitest run --project unit scripts/ eslint-rules/` 9 个文件 / 85 个测试全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_