### PR TITLE
fix(console): make 8 more preview samples parse against @objectstack/spec

### DIFF
--- a/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
+++ b/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
@@ -5,7 +5,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * `preview-samples.ts` ↔ `@objectstack/spec` conformance (objectui#3257).
+ * `preview-samples.ts` ↔ `@objectstack/spec` conformance (objectui#3257, #3266).
  *
  * The preview gallery's samples are not test fixtures — they are the drafts the
  * metadata designers render, i.e. the worked EXAMPLE an author sees for each
@@ -47,7 +47,11 @@
  * `datasources` are; `views`, `jobs`, `emailTemplates` are not). For the
  * non-strict ones an unknown or retired key is stripped rather than rejected,
  * so a PASS there proves the sample is structurally sound, NOT that it is free
- * of retired keys. The guard is exactly as strict as the spec is.
+ * of retired keys. The guard is exactly as strict as the spec is. `RETIRED_KEYS`
+ * below covers the named retirements regardless, which is the only reason the
+ * `tool` / `report` rows mean anything: `report` reached SPEC_CLEAN by binding a
+ * dataset, and its stripped pre-9.0 `object` / `groupBy` keys would not have
+ * failed anything on their own.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -89,6 +93,15 @@ const SPEC_CLEAN = [
   'permission',
   'position',
   'email_template',
+  // Promoted from KNOWN_STALE by objectui#3266.
+  'action',
+  'agent',
+  'skill',
+  'flow',
+  'report',
+  'validation',
+  'datasource',
+  'app',
 ] as const;
 
 /**
@@ -96,26 +109,29 @@ const SPEC_CLEAN = [
  * is the first thing a reader of that sample would copy and get rejected for.
  *
  * This list is a ledger, not an excuse: the reverse assertion below fails if an
- * entry starts passing, so it can only ever shrink. Fixing them is objectui#3266
- * — deliberately not done here, because several are not mechanical (see that
- * issue: `object.fields` array-vs-record is a shape `readFields()` supports on
- * PURPOSE, and rewriting the `dashboard` sample changes what the gallery
- * renders, which is the shared browser-verification harness).
+ * entry starts passing, so it can only ever shrink. objectui#3266 emptied out
+ * the mechanically-fixable half of it (`action`, `agent`, `skill`, `flow`,
+ * `report`, `validation`, `datasource`, `app` — all now in SPEC_CLEAN above).
+ *
+ * What remains is NOT "not got to yet" — each of these four needs a decision
+ * that does not belong in this file, and the reason is recorded with it. A
+ * sample only leaves this ledger by being FIXED; relaxing the guard, exempting
+ * a schema, or moving a row into NO_AUTHORING_SCHEMA to buy a green run would
+ * delete the only thing keeping the gallery's examples honest.
  */
 const KNOWN_STALE: Record<string, string> = {
+  // Not a typo in the sample: `packages/app-shell/.../object-fields-io.ts`
+  // `readFields()` branches on `shape: 'array' | 'record'` and round-trips
+  // whichever the draft used, so this sample is what covers the array branch in
+  // the gallery. Rewriting it to a record would drop that coverage while
+  // leaving the designer still able to author a shape ObjectSchema rejects,
+  // which is the actual question (AGENTS.md #0.1) — and it is an app-shell
+  // question, not a preview-samples one.
   object: '`fields` is an array; ObjectSchema wants a record keyed by field name',
   page: 'page components carry `props`, which PageComponentSchema rejects (ADR-0089 D3a)',
-  report: '`columns` are objects; ReportSchema wants column-name strings',
   dashboard: 'widgets miss `dataset`/`values` and use retired `value`/`format`; `chart` is not a widget type',
-  app: 'navigation items miss the `type` discriminator; `landing` was removed (objectstack#4001)',
-  action: 'RETIRED `bulkEnabled` (objectstack#3896); `type`/`variant`/`locations` use pre-17 enum values',
-  flow: 'RETIRED `waitEventConfig.onTimeout` (objectstack#4158); `type: scheduled` invalid; edges need `id`',
-  agent: 'RETIRED `tools` (objectstack#3894, use `skills`) and `knowledge` (objectstack#3896)',
-  skill: 'RETIRED `triggerPhrases` (objectstack#3896); `triggerConditions` needs field/operator/value',
-  datasource: '`type`/`isDefault` rejected; `ssl` and `capabilities` are objects; `healthCheck.interval` is `intervalMs`',
-  validation: "`events` uses pre-17 `beforeInsert`/`beforeUpdate`; the enum is `insert`/`update`",
   translation:
-    'the `translations` collection is Array< Record< locale, TranslationData > >, but this sample is the metadata-RECORD form (name/label/locale/data) the console edits — so this row is a mapping mismatch, not necessarily a stale sample. Resolve in objectui#3266 before guarding it.',
+    'the `translations` collection is Array< Record< locale, TranslationData > >, but this sample is the metadata-RECORD form (name/label/locale/data) the console edits — so this row is a mapping mismatch, not necessarily a stale sample. Settle which contract the sample targets before guarding it.',
 };
 
 /**
@@ -127,6 +143,37 @@ const NO_AUTHORING_SCHEMA: Record<string, string> = {
   workflow: 'no `workflows` collection and no WorkflowSchema in spec 17',
   approval: 'no `approvals` collection; spec only has ApprovalNodeConfigSchema (a flow node)',
 };
+
+/**
+ * Retired keys that must never reappear in a sample, with the adjudication that
+ * removed each one. A preview or inspector that still READS one of these is not
+ * a reason to re-add it — that reader is the bug (see objectui#3236 / PR #3258,
+ * where `ToolPreview` stopped rendering its three).
+ */
+const RETIRED_KEYS: Array<[type: string, key: string, adjudication: string]> = [
+  ['tool', 'category', 'objectstack#3896'],
+  ['tool', 'active', 'objectstack#3715 / ADR-0033 §2'],
+  ['tool', 'requiresConfirmation', 'objectstack#3896'],
+  ['action', 'bulkEnabled', 'objectstack#3896'],
+  ['agent', 'tools', 'objectstack#3894 — use `skills`'],
+  ['agent', 'knowledge', 'objectstack#3896'],
+  ['skill', 'triggerPhrases', 'objectstack#3896'],
+  ['flow', 'onTimeout', 'objectstack#4158'],
+  ['app', 'landing', 'objectstack#4001 — use `homePageId`'],
+];
+
+/** Every key name appearing anywhere in `value`, at any depth. */
+function keyNamesIn(value: unknown, out = new Set<string>()): Set<string> {
+  if (Array.isArray(value)) {
+    for (const item of value) keyNamesIn(item, out);
+  } else if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      out.add(key);
+      keyNamesIn(child, out);
+    }
+  }
+  return out;
+}
 
 /** Issues the spec raises for one sample, scoped to that sample's own path. */
 function issuesFor(type: string): { path: string; message: string }[] {
@@ -196,14 +243,18 @@ describe('preview-samples conform to @objectstack/spec', () => {
     },
   );
 
-  // The specific regression objectui#3257 fixed, pinned by name. The list above
-  // would catch these via `tool`'s membership in SPEC_CLEAN, but only as a
-  // generic "sample is invalid"; naming them keeps the retirement legible to
-  // whoever is tempted to re-add one.
-  it.each(['category', 'active', 'requiresConfirmation'])(
-    'tool sample does not resurrect retired key `%s`',
-    (key) => {
-      expect(SAMPLES.tool).not.toHaveProperty(key);
+  // The specific retirements objectui#3257 and objectui#3266 cleared, pinned by
+  // name. SPEC_CLEAN already catches a re-added key (every one of these schemas
+  // rejects it BY NAME via `retiredKey()`), but only as a generic "sample is
+  // invalid"; naming them keeps each retirement legible — with its adjudication
+  // — to whoever is tempted to put one back because a preview still reads it.
+  //
+  // Matched at ANY depth, not just top level: `waitEventConfig.onTimeout` lives
+  // on a flow node, and a retired key is no less retired for being nested.
+  it.each(RETIRED_KEYS)(
+    '%s sample does not resurrect retired key `%s` (%s)',
+    (type, key) => {
+      expect([...keyNamesIn(SAMPLES[type])]).not.toContain(key);
     },
   );
 });

--- a/apps/console/src/preview-samples.ts
+++ b/apps/console/src/preview-samples.ts
@@ -57,33 +57,45 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     ],
   },
 
+  // ADR-0021 single form: a report binds a semantic-layer `dataset` and selects
+  // its measures (`values`) grouped by dimensions (`rows`, plus `columns`
+  // across for a matrix). The inline-query form this sample used
+  // (`object` + `columns: [{ field, label }]` + `groupBy`) was removed in the
+  // 9.0 cutover — `ReportSchema` is non-strict, so `object`/`groupBy` were
+  // silently stripped and the draft then failed for having no `dataset`.
   report: {
     name: 'orders_by_status',
     label: 'Orders by Status',
-    object: 'sales_order',
-    columns: [
-      { field: 'name', label: 'Order' },
-      { field: 'status', label: 'Status' },
-      { field: 'amount', label: 'Amount' },
-    ],
-    groupBy: ['status'],
+    type: 'summary',
+    dataset: 'sales_orders',
+    rows: ['status'],
+    values: ['order_count', 'total_amount'],
+    order: [{ by: 'total_amount', direction: 'desc' }],
   },
 
+  // Navigation is a DISCRIMINATED UNION on `type`, and every branch is
+  // `.strict()`: an app does not route by hand-written `path`, it names the
+  // metadata record to open (`objectName` / `pageName` / `dashboardName` /
+  // `url`) and the shell builds the route. `id` is required so a nav entry can
+  // be addressed — by a patch, and by `homePageId`, which replaced the removed
+  // top-level `landing` route (objectstack#4001).
   app: {
     name: 'crm',
     label: 'CRM',
     icon: 'briefcase',
-    landing: '/apps/crm/home',
+    homePageId: 'home',
     navigation: [
-      { label: 'Home', path: '/apps/crm/home', kind: 'page' },
-      { label: 'Accounts', object: 'account', path: '/apps/crm/accounts' },
-      { label: 'Sales Orders', object: 'sales_order', path: '/apps/crm/orders' },
-      { label: 'Dashboard', dashboard: 'sales_overview', path: '/apps/crm/dashboard' },
+      { id: 'home', type: 'page', label: 'Home', pageName: 'crm_welcome' },
+      { id: 'accounts', type: 'object', label: 'Accounts', objectName: 'account' },
+      { id: 'orders', type: 'object', label: 'Sales Orders', objectName: 'sales_order', viewName: 'open_orders' },
+      { id: 'dashboard', type: 'dashboard', label: 'Dashboard', dashboardName: 'sales_overview' },
       {
+        id: 'admin',
+        type: 'group',
         label: 'Admin',
         children: [
-          { label: 'Settings', path: '/apps/crm/settings', kind: 'page' },
-          { label: 'Docs', path: 'https://docs.example.com' },
+          { id: 'settings', type: 'page', label: 'Settings', pageName: 'crm_settings' },
+          { id: 'docs', type: 'url', label: 'Docs', url: 'https://docs.example.com', target: '_blank' },
         ],
       },
     ],
@@ -92,14 +104,22 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
   action: {
     name: 'close_order',
     label: 'Close Order',
-    type: 'server',
+    // `server` was never an ActionType — the server-side form is `script` with
+    // a `target` naming a registered bundle function (a `script` action without
+    // `body` or `target` is rejected: it would register no handler at all).
+    type: 'script',
+    target: 'closeOrder',
     objectName: 'sales_order',
     icon: 'check',
-    variant: 'default',
-    locations: ['record', 'list'],
+    variant: 'primary',
+    // Spec-17 placement vocabulary; the pre-17 `record`/`list` shorthands are
+    // not in the enum (and the ActionPreview placement mock renders nothing
+    // for them, so the "Where it appears" section was empty).
+    locations: ['record_header', 'list_toolbar'],
     confirmText: 'Close this order? This cannot be undone.',
     successMessage: 'Order closed.',
-    bulkEnabled: true,
+    // No `bulkEnabled`: RETIRED in spec 17 (objectstack#3896). The multi-select
+    // toolbar is driven by the LIST VIEW's `bulkActions`, never by this flag.
     refreshAfter: true,
   },
 
@@ -109,9 +129,13 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     status: 'active',
     version: 2,
     runAs: 'system',
-    type: 'scheduled',
+    // FlowType enum is `autolaunched | record_change | schedule | screen | api`
+    // — the start node below is a cron trigger, so `schedule` (not `scheduled`).
+    type: 'schedule',
+    // FlowVariableSchema is `.strict()` over name/type/isInput/isOutput — a
+    // `description` here is rejected, not merely ignored.
     variables: [
-      { name: 'daysBefore', type: 'number', isInput: true, description: 'Lead time in days' },
+      { name: 'daysBefore', type: 'number', isInput: true },
       { name: 'contract', type: 'object', isInput: true },
       { name: 'reminded', type: 'boolean', isOutput: true },
     ],
@@ -141,7 +165,10 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
       { id: 'guard', type: 'try_catch', label: 'Push with retry', config: { errorVariable: '$error', try: { nodes: [ { id: 'push', type: 'http_request', label: 'Push to CRM', config: { method: 'POST', url: 'https://api.example.com/v1/tasks' } } ], edges: [] }, catch: { nodes: [ { id: 'record_failure', type: 'update_record', label: 'Flag Sync Failure', config: { objectName: 'contract', fields: { reminded: false } } } ], edges: [] } } },
       { id: 'check', type: 'decision', label: 'Within reminder window?', config: { conditions: [ { label: 'Within window', expression: 'daysToExpiry <= daysBefore' }, { label: 'Else', expression: 'true' } ] } },
       { id: 'email', type: 'connector_action', label: 'Send renewal email', connectorConfig: { connectorId: 'email', actionId: 'send', input: { to: 'owner.email', template: 'renewal_reminder' } } },
-      { id: 'wait', type: 'wait', label: 'Wait 3 days', waitEventConfig: { eventType: 'timer', timerDuration: 'P3D', onTimeout: 'continue' } },
+      // No `waitEventConfig.onTimeout`: RETIRED in spec 17 (objectstack#4158).
+      // It had no readers — a wait node resumes only when its timer elapses or
+      // its signal arrives; there is no timeout branch to configure.
+      { id: 'wait', type: 'wait', label: 'Wait 3 days', waitEventConfig: { eventType: 'timer', timerDuration: 'P3D' } },
       { id: 'task', type: 'create_record', label: 'Create CSM follow-up', config: { objectName: 'task', fields: { subject: 'Renewal follow-up', priority: 'high' } } },
       { id: 'skip', type: 'update_record', label: 'Mark as not due', config: { objectName: 'contract', filter: { id: '{contractId}' }, fields: { reminded: false } } },
       { id: 'review', type: 'screen', label: 'CSM review', config: { fields: [ { name: 'discount', label: 'Discount %', type: 'number', required: false }, { name: 'note', label: 'Note', type: 'text', required: true, visibleWhen: 'discount > 0' } ] } },
@@ -149,21 +176,24 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
       { id: 'enrich', type: 'script', label: 'Score (code)', config: { script: "variables.score = 42;\nreturn variables;", outputVariables: ['score'] } },
       { id: 'end', type: 'end', label: 'End', config: { outcome: 'success' } },
     ],
+    // `FlowEdgeSchema.id` is REQUIRED — the canvas already keys off it when
+    // present (splitting an edge, adding a back-edge), and an id-less edge
+    // cannot be addressed by a patch.
     edges: [
-      { source: 'start', target: 'find' },
-      { source: 'find', target: 'each_contract' },
-      { source: 'each_contract', target: 'fan_out' },
-      { source: 'fan_out', target: 'guard' },
-      { source: 'guard', target: 'check' },
-      { source: 'check', target: 'email', condition: 'daysToExpiry <= daysBefore' },
-      { source: 'check', target: 'skip', isDefault: true },
-      { source: 'email', target: 'wait' },
-      { source: 'wait', target: 'task' },
-      { source: 'task', target: 'review' },
-      { source: 'review', target: 'notify' },
-      { source: 'notify', target: 'enrich' },
-      { source: 'enrich', target: 'end' },
-      { source: 'skip', target: 'end' },
+      { id: 'e_start_find', source: 'start', target: 'find' },
+      { id: 'e_find_each', source: 'find', target: 'each_contract' },
+      { id: 'e_each_fan_out', source: 'each_contract', target: 'fan_out' },
+      { id: 'e_fan_out_guard', source: 'fan_out', target: 'guard' },
+      { id: 'e_guard_check', source: 'guard', target: 'check' },
+      { id: 'e_check_email', source: 'check', target: 'email', condition: 'daysToExpiry <= daysBefore' },
+      { id: 'e_check_skip', source: 'check', target: 'skip', isDefault: true },
+      { id: 'e_email_wait', source: 'email', target: 'wait' },
+      { id: 'e_wait_task', source: 'wait', target: 'task' },
+      { id: 'e_task_review', source: 'task', target: 'review' },
+      { id: 'e_review_notify', source: 'review', target: 'notify' },
+      { id: 'e_notify_enrich', source: 'notify', target: 'enrich' },
+      { id: 'e_enrich_end', source: 'enrich', target: 'end' },
+      { id: 'e_skip_end', source: 'skip', target: 'end' },
     ],
   },
 
@@ -220,12 +250,11 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     model: { provider: 'openai', model: 'gpt-4o', temperature: 0.4, maxTokens: 2048 },
     instructions:
       'You are a helpful sales assistant. Answer questions about accounts and orders, and draft follow-up emails. Always cite the record you used.',
+    // An agent reaches exactly the tools its surface-compatible skills declare
+    // (ADR-0064). No `tools` (RETIRED, objectstack#3894 — put the reference in
+    // a skill instead) and no `knowledge` (RETIRED, objectstack#3896 — it never
+    // scoped retrieval; describe intended grounding in `instructions`).
     skills: ['summarize_account', 'draft_email'],
-    tools: [
-      { type: 'objectql', name: 'query_orders' },
-      { type: 'http', name: 'lookup_company' },
-    ],
-    knowledge: { sources: [{ name: 'sales_playbook', type: 'index' }] },
   },
 
   tool: {
@@ -252,8 +281,11 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     active: true,
     instructions: 'Write a concise, friendly follow-up email referencing the order.',
     tools: ['lookup_company'],
-    triggerPhrases: ['draft an email', 'follow up'],
-    triggerConditions: [{ expression: "record.status == 'Open'" }],
+    // No `triggerPhrases`: RETIRED in spec 17 (objectstack#3896) — phrases were
+    // never matched against the user's message. Activation is `triggerConditions`
+    // (an AND of context field/operator/value) intersected with the agent's
+    // `skills[]`, so routing intent belongs here.
+    triggerConditions: [{ field: 'objectName', operator: 'eq', value: 'sales_order' }],
   },
 
   permission: {
@@ -280,15 +312,19 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     name: 'warehouse',
     label: 'Analytics Warehouse',
     description: 'Read-only Postgres replica for reporting.',
+    // `DatasourceSchema` is `.strict()`: `type` is the `driver` (already set
+    // below) and `isDefault` is not a datasource key at all — routing is
+    // declared at stack level via `datasourceMapping`. Both were rejected.
     driver: 'postgres',
-    type: 'sql',
     active: true,
-    isDefault: false,
-    ssl: true,
+    // `ssl` and `capabilities` are config OBJECTS, not a boolean / token list.
+    ssl: { enabled: true, rejectUnauthorized: true },
     config: { host: 'db.internal', port: 5432, database: 'analytics' },
     pool: { min: 2, max: 10 },
-    capabilities: ['read', 'aggregate'],
-    healthCheck: { enabled: true, interval: 60 },
+    capabilities: { readOnly: true, queryAggregations: true },
+    // `interval` → `intervalMs`, and the unit is MILLISECONDS: the old `60`
+    // was read as 60ms once the key was spelled correctly, not 60 seconds.
+    healthCheck: { enabled: true, intervalMs: 60000 },
   },
 
   validation: {
@@ -302,7 +338,10 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     condition: 'amount > 0',
     expression: 'amount > 0',
     message: 'Order amount must be greater than zero.',
-    events: ['beforeInsert', 'beforeUpdate'],
+    // The enum is the WRITE CONTEXT (`insert` / `update`), not a lifecycle-hook
+    // name: the rule evaluator only runs on the insert/update write path, so
+    // the pre-17 `beforeInsert`/`beforeUpdate` spellings are rejected.
+    events: ['insert', 'update'],
     priority: 10,
   },
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3266

预览画廊里的样例不是测试夹具,是每种元数据类型给作者(多数情况下是模型)照抄的那份**范例**。范例过期不会只错一次,它会扩散。objectui#3257 / PR #3269 建好了度量它的守卫;本 PR 把那份 `KNOWN_STALE` 台账里**机械可修的那一半清空**。

- 修好并提升进 `SPEC_CLEAN`:**8 个**(`action`、`agent`、`skill`、`flow`、`report`、`validation`、`datasource`、`app`)
- 按派发要求留在台账里、附理由:**4 个**(`object`、`page`、`dashboard`、`translation`)
- 守卫的判定标准**一处未放宽**:没有豁免、没有挪进 `NO_AUTHORING_SCHEMA`、没有降低严格度。退役键的钉定测试反而被**加强**了(见下)。

---

## 一、4 个带已退役键的(与 #3257 同性质、同裁决依据)

| 样例 | 改动 | 依据 |
|---|---|---|
| `action` | 删 `bulkEnabled`;`type: 'server'` → `'script'` 并补 `target: 'closeOrder'`;`variant: 'default'` → `'primary'`;`locations: ['record','list']` → `['record_header','list_toolbar']` | objectstack#3896 |
| `agent` | 删 `tools`、`knowledge` | objectstack#3894 / #3896 |
| `skill` | 删 `triggerPhrases`;`triggerConditions` 改写成真正参与路由的 `field/operator/value` 形态 | objectstack#3896 |
| `flow` | 删 `waitEventConfig.onTimeout`;`type: 'scheduled'` → `'schedule'`;删 `variables[].description`(`FlowVariableSchema` 是 `.strict()`);13 条 edge 补上必需的 `id` | objectstack#4158 |

`action` 补 `target` 不是自由发挥:`ActionSchema` 有一条 refine —— `type: 'script'` 而既无 `body` 又无 `target` 会被拒(那是 #2169 的「注册不上 handler、运行时才炸」)。原样例 `type: 'server'` 表达的就是服务端处理器,`script` + 具名 `target` 是它在 17 里的写法。

## 二、4 个形态漂移

- **`report`** —— 本单原描述是「`columns` 改成列名字符串」,**实际不止**:ADR-0021 单一形态下报表必须绑 `dataset` + `values`。样例用的是 9.0 之前的内联查询(`object` + `columns: [{field,label}]` + `groupBy`),`ReportSchema` 非 `.strict()` 会把 `object`/`groupBy` 静默剥掉,然后因为「没有 dataset」失败 —— 只改列名字符串修不好。已重写为 `dataset: 'sales_orders'` / `rows: ['status']` / `values: ['order_count','total_amount']` / `order`。
- **`validation`** —— `events` 是**写入上下文**(`insert`/`update`),不是生命周期钩子名。
- **`datasource`** —— `type`/`isDefault` 不是 datasource 的键(路由在 stack 级的 `datasourceMapping`);`ssl`、`capabilities` 是配置**对象**;`interval` → `intervalMs`,且单位是毫秒(原来的 `60` 拼对键之后是 60ms,不是 60 秒)。
- **`app`** —— navigation 是按 `type` 的判别联合且每支 `.strict()`:app 不用手写 `path` 路由,而是点名要打开的元数据记录(`objectName` / `pageName` / `dashboardName` / `url`),路由由 shell 推导;`id` 必填;`landing` 已被 objectstack#4001 移除,替代是 `homePageId`(它是 nav item 的 **id**,不是路由字符串)。顺带让样例互相引用起来(`crm_welcome` 页、`open_orders` 视图、`sales_overview` 仪表盘)。

## 三、⚠️ 画廊(共用浏览器验证台)的可见变化,逐条

以下都是在 `preview-gallery.html?only=<type>` 上**实测**的改前 → 改后,不是推断。

| designer | 改前 | 改后 |
|---|---|---|
| **action** | `type: server` / `variant: default`,Locations 显示 `record` `list`,On click 显示 **"No handler bound yet."**,「WHERE IT APPEARS」标题下**一片空白**(placement mock 认不出 `record`/`list`) | `type: script` / `variant: primary`,Locations 显示 `record_header` `list_toolbar`,On click 显示 "Run named script closeOrder",「WHERE IT APPEARS」**真的画出** record_header 与 list_toolbar 两块占位模拟 —— 本 PR 里画廊**变丰富**的一处 |
| **agent** | TOOLS 区显示 `query_orders (OBJECTQL)` / `lookup_company (HTTP)`,并有 `KNOWLEDGE (RAG): sales_playbook` 区块 | TOOLS 显示空态提示 "No direct tools (skills can provide them)",KNOWLEDGE 区块消失。SKILLS 芯片不变 |
| **skill** | 有 `TRIGGER PHRASES (2)` 区块("draft an email" / "follow up");trigger condition 一行显示 `record.status == 'Open'` | TRIGGER PHRASES 区块消失;trigger condition 显示 `COND \| sales_order`(渲染器只读 `expression ?? value`,看不见 field/operator —— 已另立单) |
| **flow** | 顶栏 `Trigger: scheduled` | 顶栏 `Trigger: schedule`。**画布节点/连线渲染完全不变**(edge 的 `id` 只影响 React key,原本回落 `${source}-${target}-${i}`) |
| **report** | 空态卡片 "Bind a dataset to preview this report" | 走 dataset 绑定分支,显示内联错误 **"This data source does not support dataset queries."**(画廊无后端;页头本来就写着 view/dashboard/report 需要活的 data adapter)。**这是本 PR 里画廊唯一变「难看」的一处** —— 但任何 spec 合规的报表都必须绑 dataset,所以修 `report` 就一定会走到这条分支;换来的是验证台从此覆盖的是真实设计器走的那条路,而不是空态 |
| **validation** | `on beforeInsert, beforeUpdate` | `on insert, update` |
| **datasource** | SSL 区显示 `enabled: true`;Health Check 显示 `interval: 60`;有 `CAPABILITIES: read / aggregate` 区块 | SSL 区显示 `enabled: true` + `rejectUnauthorized`;Health Check 显示 `intervalMs: 60000`;**CAPABILITIES 区块消失**(渲染器 `Array.isArray(d.capabilities)` 只认数组,对象形态读不到 —— 已另立单) |
| **app** | 每项下面有一行路径(`/apps/crm/accounts` 等);`Dashboard` 的 kind 徽标是 `dashboard`;顶部 `Landing: /apps/crm/home` | 路径行消失(spec 里没有 `path`);`Dashboard` 徽标退化成 `item`;顶部 `Landing: /`(渲染器不读 `homePageId`)。层级、分组、外链项照常 |

`object` / `page` / `dashboard` / `translation` / `view` / `job` / `tool` / `permission` / `position` / `email_template` / `workflow` / `approval` 的样例**一个字没动**,画廊对应的卡片与 main 完全一致。

**其中 agent / skill / datasource / app 的「变少」不是本 PR 造成的退化,而是暴露出来的既有问题**:那几块内容原本是靠**不合规的样例**喂出来的 —— 渲染器在读 spec 现在明确拒收的键。按 AGENTS.md #0.1(修生产者、不在消费者加宽容回退)和 objectui#3236 / PR #3258 的先例,该修的是渲染器,那在 `packages/app-shell`,不在本轮 scope fence(`apps/console`)内,已另立 **#3275**。

## 四、守卫本体的改动(只增不减)

- `SPEC_CLEAN` 增加 8 项;`KNOWN_STALE` 只剩 4 项,每项理由保留并写清「为什么需要先裁决」而不是「还没轮到」。
- 台账注释明确写上:样例只能靠**被修好**离开台账;为了买一次绿而放宽守卫、豁免 schema 或把行挪进 `NO_AUTHORING_SCHEMA`,会把这个文件唯一的价值删掉。
- 退役键钉定测试从「只钉 `tool` 的 3 个键」扩成 `RETIRED_KEYS` 表(9 条,每条带裁决出处),并且改为**任意深度**匹配 —— `waitEventConfig.onTimeout` 挂在 flow 节点上,原来的 `not.toHaveProperty` 够不着。这是加强,不是放宽。
- 文件头补上一句 LIMIT 的推论:`report` 是靠绑 dataset 才进的 `SPEC_CLEAN`,它被剥掉的 `object`/`groupBy` 自己不会让任何断言失败 —— 这正是 `RETIRED_KEYS` 存在的理由。

## 五、留在台账里的 4 个,以及理由

| 样例 | 为什么不动 |
|---|---|
| `object` | `fields` 的数组形态是 `packages/app-shell/.../object-fields-io.ts` 的 `readFields()` **有意支持**的分支(它按 `shape: 'array' \| 'record'` 分流并原样保留)。改成 record 会让画廊不再覆盖 array 那条路,而真正该裁的是「设计器要不要继续编辑一个 `ObjectSchema` 拒收的形态」(AGENTS.md #0.1)—— 那是 app-shell 那头的决定 |
| `page` | region 里的 component 带 `props`,`PageComponentSchema` 按 ADR-0089 D3a 拒收;改法会改变画廊渲染结果,需先裁决 |
| `dashboard` | widget 缺 `dataset`/`values`、带已退役的 `value`/`format`、`chart` 不是合法 widget type;同样改变渲染结果 |
| `translation` | `ObjectStackSchema.translations` 是 `Array< Record< locale, TranslationData > >`,而样例是 console 实际在编辑的**元数据记录**形态。更像是**映射选错**而不是样例过期 —— 先定这个样例到底对应哪个契约,再动 |

## 六、changeset

**不需要**,#3269 的判断依然成立并已复核:`apps/console/vite.config.ts` **没有** `rollupOptions.input`,默认入口只有 `index.html`,`preview-gallery.html` 及其引用的 `preview-samples.ts` 不是生产构建输入(文件头也自述 DEV-ONLY)。另外 AGENTS.md 明确「纯 bug 修复不需要 changeset」,本 PR 两条都占。

## 七、验证

```
$ pnpm --filter @object-ui/console test
 Test Files  20 passed (20)
      Tests  183 passed (183)

$ vitest run src/__tests__/preview-samples-spec-valid.test.ts
 Test Files  1 passed (1)
      Tests  30 passed (30)      # 含 8 条新的 SPEC_CLEAN、4 条仍如实失败、9 条退役键钉定

$ eslint src/preview-samples.ts src/__tests__/preview-samples-spec-valid.test.ts
 (exit 0)
```

`pnpm --filter @object-ui/console type-check` 在本地 worktree 报 306 个 `Cannot find module '@object-ui/*'` —— 这是工作区包未构建导致的既有状态,**改动前后逐字一致(306 → 306),且没有一条落在本 PR 改的两个文件上**(CI 先构建,不会命中)。

浏览器验证走 `verify` skill(自建 :5233 vite,收工按 PID 停,未碰 :3000/:5180),上表每一行都是实测。

## 八、越界发现(Prime Directive #10,均未指派、不在本 PR 修)

- **#3275** —— `AgentPreview`/`SkillPreview`/`AppPreview`/`DatasourcePreview` 仍在读 spec 已拒收的键(`tools`/`knowledge`/`triggerPhrases`/`landing`/`path`/`capabilities` 数组形态),即上表里「变少」的那几处的根因。
- **#3276** —— `validation` 样例的 `condition: 'amount > 0'` 语义**写反了**(spec 契约是「condition 为 TRUE 表示校验失败」),另有 `expression`/`object`(以及 `skill` 的 `type`)是会被静默剥掉的键。本 PR 只按派发范围改了 `events`,没有动这些。


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_