### PR TITLE
docs(ci): stop hand-maintaining a repo-wide warning count in two places (#3274)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,15 @@ name: Lint
 # setting any `object-ui/*` rule to `error`, or if this workflow stops gating
 # pull requests.
 #
-# `--max-warnings` is deliberately not set: the 7,724 warnings repo-wide are 81%
-# `no-explicit-any`, plus React Compiler rules the config downgrades on purpose.
-# This gate is about errors.
+# `--max-warnings` is deliberately not set: warnings repo-wide run into the
+# thousands, dominated by `no-explicit-any` plus React Compiler rules the config
+# downgrades on purpose — known historical debt, not a signal. This gate is
+# about errors. No exact figure here, for the reason above: this paragraph used
+# to carry a hand-maintained warning count and percentage that nothing
+# recomputed and nothing alarmed on as they aged (#3274), and
+# `scripts/check-lint-coverage.mjs` held a copy of the same number that would
+# have gone stale on its own clock. The order of magnitude is the whole
+# argument; the integer never was.
 on:
   push:
     branches: [main, develop]

--- a/scripts/check-lint-coverage.mjs
+++ b/scripts/check-lint-coverage.mjs
@@ -27,7 +27,11 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // Packages with outstanding ESLint *errors*, so they cannot carry a `lint`
 // script without turning CI red. Warnings do not matter here — ESLint only
 // fails on errors unless `--max-warnings` is set, and it deliberately is not
-// (7,724 warnings repo-wide are dominated by `no-explicit-any`; see #2923).
+// (warnings repo-wide run into the thousands, dominated by `no-explicit-any`;
+// see #2923). No exact count on purpose: this line and the matching paragraph
+// in `.github/workflows/lint.yml` used to quote the same hand-maintained
+// figure, which every added `any` aged and nothing ever recomputed — two copies
+// free to drift apart, and apart from reality (#3274).
 //
 // Every entry is real debt: fix the errors, add `"lint": "eslint ."`, then
 // delete the entry.


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3274

## 问题

`.github/workflows/lint.yml` 第三段注释和 `scripts/check-lint-coverage.mjs:30` 各存了一份**同一个手工维护的数字**,用来论证「`--max-warnings` 故意不设」:

```
the 7,724 warnings repo-wide are 81% `no-explicit-any`
(7,724 warnings repo-wide are dominated by `no-explicit-any`; see #2923)
```

这和 #3261(PR #3273)修掉的是同一个缺陷类,只是漂移得更快:仓库里每加一个 `any`、每新增一个包,`7,724` 和 `81%` 就更旧一点,**没有任何东西会在它变旧时报警**。而且两份副本会各自独立地旧掉 —— 已经具备了 #3212 那种「同一个事实多个数字」的全部条件。

按 issue 的判断,这里修的**不是「它今天是错的」**(没有证据说它错,本 PR 也没去跑全仓 ESLint 核对 —— 核对只会把同一个时钟重新上一遍发条),而是**「它注定会错」**。

## 改动

两处都改成只讲量级、不点精确整数的写法,论证一字未失(它本来就只需要「warning 是一笔已知的、成千上万条的历史欠账,主体是 `no-explicit-any` 和被刻意降级的 React Compiler 规则,所以这道门禁只管 error」):

- `.github/workflows/lint.yml` — `warnings repo-wide run into the thousands, dominated by ...`,并写明为何不再点数字、以及另一份副本在哪。
- `scripts/check-lint-coverage.mjs` — 同样去数字,并反向指回 `lint.yml`,两处互相说明。

**两处必须同一个 PR 一起改**:只改一处,会把「两份一致但过期」变成「两份互相矛盾」,比现状更糟。

顺带确认:`content/docs/guide/ci-cd-pipeline.md` 早就是去数字写法(`the repository carries thousands of warnings (overwhelmingly no-explicit-any ...)`),本 PR 的措辞与它对齐,不需要改。全仓 `grep 7,724|7724|81%` 除这两处外只剩向量样例数据里的巧合匹配。

## 刻意**不**加断言钉住这个数字

与 #3261 相反的取舍,原因是成本差了几个数量级:#3261 的守卫是纯文本 + 读已求值的 flat config,毫秒级;而钉住 warning 数意味着在测试里跑**全仓 ESLint**(分钟级),并且此后任何地方新增一个 `any` 都会让一个不相干的测试变红。这条门禁本身就是「只管 error」,再引入一个对 warning 数量敏感的机械门禁与它的立意直接矛盾。

## 测试

```
$ node scripts/check-lint-coverage.mjs
✅  lint coverage: 45/45 packages linted, 0 with outstanding errors (0 total).
EXIT=0

$ pnpm exec vitest run scripts/__tests__
 Test Files  5 passed (5)
      Tests  41 passed (41)
```

其中 `scripts/__tests__/lint-workflow.test.ts`(#3273 新增,断言这段注释不得再手工点数)5 项全过 —— 新措辞里的 `thousands` 不是它匹配的基数词,`#3274` 这类 issue 号也不落在 `object-ui`/`ratchet` 的邻域内。另外用 js-yaml 复核了 `lint.yml` 仍能解析(`top keys: name, on, concurrency, permissions, jobs`;`triggers: push, pull_request, workflow_dispatch`)—— 改的是 `on:` 之上的注释,但这个文件的正确性就是它能被 Actions 读懂。

## 无 changeset

只改了一条 CI workflow 的注释和一个仓库内部脚本的注释,**不发布任何东西**,也没有任何用户可见行为变化;按 AGENTS.md「功能改进才写 changeset」这里不需要。(顺带:`lint.yml`/`ci.yml` 都把 `.changeset/**` 放进了 `paths-ignore`。)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_