### PR TITLE
fix(console): un-invert the validation sample's condition and drop 4 silently-stripped keys

### DIFF
--- a/apps/console/src/preview-samples.ts
+++ b/apps/console/src/preview-samples.ts
@@ -276,7 +276,10 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
   skill: {
     name: 'draft_email',
     label: 'Draft Email',
-    type: 'prompt',
+    // No `type`: `SkillSchema` has no such key, so `type: 'prompt'` parsed and was
+    // then silently dropped. The key that classifies a skill is `surface`
+    // (`ask` | `build` | `both`, default `ask`, ADR-0063 §3) — it gates which agents
+    // may bind the skill, and there is no 'prompt' among its values.
     description: 'Draft a follow-up email from a record context.',
     active: true,
     instructions: 'Write a concise, friendly follow-up email referencing the order.',
@@ -327,16 +330,30 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     healthCheck: { enabled: true, intervalMs: 60000 },
   },
 
+  // `condition` is the FAILURE predicate, not the invariant: `ScriptValidationSchema`
+  // documents it as "Predicate (CEL). If TRUE, validation fails." So the rule that
+  // enforces "amount must be positive" reads `amount <= 0` — the illegal case, the
+  // same direction as the spec's own examples (`record.amount < 0`,
+  // `discount_percent > 0.40`). The pre-#3276 sample said `amount > 0`, which parses
+  // fine and means the exact opposite of its name and message: it would have rejected
+  // every valid order and passed every invalid one. Nothing catches this — a spec
+  // guard can only ask whether a draft parses, never whether it means what it says —
+  // so the direction has to be right here, in the example people copy.
   validation: {
     name: 'amount_positive',
     label: 'Amount Must Be Positive',
-    object: 'sales_order',
     active: true,
     severity: 'error',
+    // A script rule carries ONLY `condition`. `expression` is not a key on any
+    // validation branch; `object` isn't either (a rule lives in its host object's
+    // `validations[]`, which IS its scope); and `field` exists on the
+    // state_machine / format / json_schema branches, not this one. All three parsed
+    // (the branch is not `.strict()`) and were then silently dropped. To point the
+    // error at a specific field instead of the whole record, the spec's construct is
+    // `type: 'cross_field'` with `fields: ['amount']` — same evaluation path, and
+    // `fields[0]` labels which field the violation attaches to.
     type: 'script',
-    field: 'amount',
-    condition: 'amount > 0',
-    expression: 'amount > 0',
+    condition: 'amount <= 0',
     message: 'Order amount must be greater than zero.',
     // The enum is the WRITE CONTEXT (`insert` / `update`), not a lifecycle-hook
     // name: the rule evaluator only runs on the insert/update write path, so


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3276

## 1. `condition` 的方向(主要问题)

先按 dispatch 的要求**核了契约**再动手。`node_modules/@objectstack/spec/src/data/validation.zod.ts:119`:

```
condition: ExpressionInputSchema.describe('Predicate (CEL). If TRUE, validation fails. e.g. P`record.amount < 0`'),
```

确认无误:`condition` 是**失败谓词**,不是不变式。同文件顶部的 Salesforce 对照也是同一方向 —— `condition: 'discount_percent > 0.40'` 配 message「Discount cannot exceed 40%」,写的都是**非法**的情形。

样例原本是 `condition: 'amount > 0'`,配 `name: 'amount_positive'` 和 message「Order amount must be greater than zero.」—— 按契约,它会在金额**为正**时判定失败,把每一条合法订单拦下、把每一条非法订单放行,和自己的名字与消息**正好相反**。改为 `'amount <= 0'`。

这类错误 #3257 的守卫结构上抓不到(它只问「能不能 parse」),而危害恰恰更大:parse 不过的样例会被修,语义反了的样例会被**照抄** —— 抄的人通常是模型。

## 2. 四个会被静默剥掉的键

`validation` 各分支与 `SkillSchema` 都不是 `.strict()`,所以这些键 parse 能过、解析结果里却不存在:

| 键 | 为什么不存在 |
|---|---|
| `validation.object` | 规则挂在宿主对象的 `validations[]` 上,宿主**就是**它的作用域 |
| `validation.field` | 只存在于 `state_machine` / `format` / `json_schema` 三支,`script` 没有 |
| `validation.expression` | **任何**一支 validation 分支上都没有这个键 |
| `skill.type` | `SkillSchema` 用 `surface`(`ask`/`build`/`both`)分类,没有 `type`,更没有 `'prompt'` |

`field` 是 issue 正文没列的第三个 —— 它是我按 dispatch 第 3 条机械审计所有样例时找出来的(见下)。它今天**已经**被剥掉,所以删除它在运行时零变化;只是不再教作者写一个没用的键。要把错误指到某个字段,spec 的正解是 `type: 'cross_field'` + `fields: ['amount']`(同一条求值路径,`fields[0]` 决定违规挂在哪个字段上)—— 这一点已写进文件注释。

按 ⚠️ 提示,这四个键**没有**加进 `RETIRED_KEYS`:它们不是被退役的键,是在这些 schema 上**从来没存在过**的键,两件事不能混。

## 3. 全样例审计(dispatch 第 3 条)

把每个样例按守卫测试的方式嵌进 `ObjectStackSchema`,`safeParse` 后逐层比对输入/输出的 key 集合,输入有、输出没有的即为被剥掉的键。修完之后 `validation` 与 `skill` 归零;其余发现**不在本 PR 修**,已按 Prime Directive #10 立为未指派 issue:

- **#3280** —— `view`(`name`/`label`/`object`/`list.object`,`ViewSchema` 是个没有身份键的容器)、`job`(`concurrency`,以及拼错的 `timeoutMs`,真键是 `timeout`)、`email_template`(`from` 应为 `fromOverride`;`to` 是发送期入参,不是授权期元数据)。另附「静默剥键」机械检查的建议 —— 并说明它是**结构性**检查,不是本 issue 拒掉的那种语义断言。
- **#3281** —— `ValidationPreview.tsx` 读 `celText(d.condition) ?? celText(d.expression)`(给一个从来不存在的键做别名回退,AGENTS.md #0.1),还有个 spec 里已被明确裁掉的 `case 'unique'` 分支。这是 #3275 那张表漏掉的第五个 preview,同在 `packages/app-shell`,不在本 PR 的 scope fence 内。

按 issue 第 3 条与 dispatch 的 ⛔,**没有**往 `preview-samples-spec-valid.test.ts` 里加任何语义断言。

## 验证

```
$ pnpm exec vitest run src/__tests__/preview-samples-spec-valid.test.ts --maxWorkers=2
 Test Files  1 passed (1)
      Tests  30 passed (30)

$ pnpm --filter @object-ui/console test -- --maxWorkers=2
 Test Files  20 passed (20)
      Tests  183 passed (183)
```

`validation` 与 `skill` 都留在 `SPEC_CLEAN` 里,守卫全绿。

`type-check`:本 worktree 里 `pnpm --filter @object-ui/console type-check` 报 `TS2307: Cannot find module '@object-ui/types'` 等 —— 工作区包未构建所致,**与本改动无关**:`git stash` 后在干净树上重跑,报错完全相同(CI 会先构建)。改动文件单独过 tsc 干净:

```
$ pnpm exec tsc --noEmit --ignoreConfig --strict --target es2020 --moduleResolution bundler --module esnext src/preview-samples.ts
ISOLATED TYPECHECK: preview-samples.ts CLEAN (exit 0)
```

预览渲染的实际影响(已读 `ValidationPreview.tsx` 确认,无崩溃):`object` 芯片不再显示(规则本来就没有 `object`);`field` 只在非 `script` 分支被读,本样例零变化;`condition` 照常渲染。

## 不加 changeset(已复核)

`preview-samples.ts` 仅被 `preview-gallery.tsx` 引用,后者仅由 `preview-gallery.html` 引入;`apps/console/vite.config.ts` 里**没有** `rollupOptions.input`(grep `input:` 命中 0 次),因此 Vite 的构建入口只有默认的 `index.html`,`preview-gallery.html` 不是构建输入。发布物 `files: ["dist", …]` 中的 `dist` 由该构建产出,样例不会进入 —— 对用户不可见。#3269 / #3277 的判断成立。


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_