### PR TITLE
refactor(types,core)!: retire the inert `validation` action-param key (#3201)

### DIFF
--- a/.changeset/retire-action-param-validation.md
+++ b/.changeset/retire-action-param-validation.md
@@ -1,0 +1,48 @@
+---
+"@object-ui/types": minor
+"@object-ui/core": minor
+---
+
+Retire `validation` from the action-param contract — it was declared on both
+halves, read by neither, and rejected outright by the server (objectui#3201).
+
+FROM: `validation?: string` was declared on the AUTHORING type
+(`@object-ui/types`' `ActionParam`) and on the RESOLVED type (`@object-ui/core`'s
+`ActionParamDef`). TO: it is declared on neither.
+
+**Breaking for anyone who declared it — but it never did anything.** This is
+marked `minor`, not `major`, per the repo's version-alignment policy (objectui's
+major tracks `@objectstack`'s, so objectui's own breaking changes ship as `minor`
+with the breaking semantics spelled out here).
+
+**Migration: delete it.** If you authored `validation: '...'` on an action param,
+it never took effect, and publishing that metadata to the server is a hard parse
+failure — so any metadata that reached production either never carried the key or
+never parsed. Removing it changes no runtime behaviour; it only moves the error
+from "silent no-op, then rejected at publish" to a `tsc` error at the keystroke.
+
+Why it could not work as authored:
+
+- `ActionParamSchema` in `@objectstack/spec/ui` is `.strict()` and does not list
+  `validation`, so an authored key is a PARSE REJECTION on the server:
+  `Unrecognized key(s) on this action param: \`validation\``. Meanwhile `tsc`
+  against the public type accepted it — the type vouched for a key the platform
+  itself refuses.
+- Nothing read it on the resolved side either: it was never a key of
+  `resolveActionParams()`'s `RawActionParam`, the runtime field metadata a
+  field-backed param inherits from carries no `validation` to source one from,
+  and `paramToField()` never mapped it — so it could not reach the field widgets,
+  whose rules `buildValidationRules()` builds from `required` / `minLength` /
+  `maxLength` / `pattern`.
+
+Removed rather than implemented, on ADR-0049 enforce-or-remove. Giving it meaning
+would mean first deciding what an "expression" is here (CEL? a formula? a regex?)
+and adding it to `@objectstack/spec`, which is where such a capability has to
+start — not accreted renderer-side around a key the contract does not have.
+
+This also retires the last named exception in objectui#3174's drift guard
+(`packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts`), which carried
+`validation` as the one key `ActionParam` added on top of the spec's set. The
+rule it pins — **the authoring type declares exactly the spec's authorable
+keys** — is now literal: the guard asserts the local-only key set is empty, so
+any future addition fails the build instead of being waved through.

--- a/packages/app-shell/src/utils/resolveActionParams.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.ts
@@ -5,9 +5,15 @@
  * Action params (`packages/spec/src/ui/action.zod.ts ActionParamSchema`) may
  * either be declared inline (`{ name, label, type, ... }`) or reference an
  * existing object field via `{ field, objectOverride? }`. Field-backed
- * params inherit label (i18n via `fieldLabel()`), type, options, validation,
- * placeholder, and help text from the object's field definition. Inline
- * properties on a field-backed param act as overrides.
+ * params inherit label (i18n via `fieldLabel()`), type, options, placeholder,
+ * and help text from the object's field definition. Inline properties on a
+ * field-backed param act as overrides.
+ *
+ * NOT validation: this comment used to claim it, but no `validation` was ever
+ * inherited — `RuntimeField` below has no such key to read one from, and the
+ * `ActionParamDef` it would have landed on no longer declares one either
+ * (objectui#3201). A param's constraints reach the widgets through
+ * `paramToField()` as `required` / `minLength` / `maxLength` / `pattern`.
  *
  * The resolver flattens each param to the runtime `ActionParamDef` shape
  * expected by `ActionParamDialog`, so the dialog itself stays agnostic to

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -413,6 +413,19 @@ export type ResultDialogHandler = (
 /**
  * ActionParam definition accepted by the runner.
  * Compatible with @objectstack/spec ActionParam.
+ *
+ * The RESOLVED shape — what `resolveActionParams()` emits and `ActionParamDialog`
+ * reads, after a field-backed param's `{ field }` reference has been inlined.
+ * The AUTHORING counterpart is `@object-ui/types`' `ActionParam` (objectui#3174).
+ *
+ * `validation?: string` used to sit here too, and was removed by objectui#3201:
+ * no producer ever wrote it (it was never a key of `resolveActionParams()`'s
+ * `RawActionParam`, and the runtime field metadata a field-backed param inherits
+ * from carries no `validation` either) and no consumer ever read it —
+ * `paramToField()` did not map it, so it never reached the field widgets, whose
+ * rules `buildValidationRules()` builds from `required` / `minLength` /
+ * `maxLength` / `pattern`. Declaring it on the resolved side only invited the
+ * authoring side to declare it back.
  */
 export interface ActionParamDef {
   name: string;
@@ -423,7 +436,6 @@ export interface ActionParamDef {
   defaultValue?: unknown;
   helpText?: string;
   placeholder?: string;
-  validation?: string;
   /**
    * Visibility predicate (CEL) evaluated against the same scope as action
    * `visible` (`current_user` / `app` / `data` / `features`). When it evaluates

--- a/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
+++ b/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
@@ -367,21 +367,43 @@ describe('ActionParam declares ONLY authorable keys (objectui#3174)', () => {
     expect(authored.reference).toBe('account');
   });
 
-  it('adds exactly ONE key to the spec set — `validation` (objectui#3201)', () => {
-    // INVERTED PIN, both directions. Forward: no key may join `validation`
-    // without this failing, which is the rule objectui#3174 leaves behind —
-    // the authoring type declares exactly the spec's authorable keys, so a
+  it('adds NO key to the spec set — the exception is gone (objectui#3201)', () => {
+    // The rule objectui#3174 left behind, now with nothing carved out of it:
+    // the authoring type declares EXACTLY the spec's authorable keys, so a
     // capability the resolved shape has and this one lacks is a spec change or
-    // a field-backed param, never a key added here. Reverse: `validation` is
-    // itself inert and rejected by the spec's `.strict()` parse (objectui#3201),
-    // so the day it is retired this line stops compiling and the exception is
-    // deleted rather than inherited.
-    const theOneException: LocalOnlyParamKey = 'validation';
-    type NothingElseIsLocal = Exclude<LocalOnlyParamKey, 'validation'> extends never ? true : false;
-    const nothingElse: NothingElseIsLocal = true;
+    // a field-backed param, never a key added here.
+    //
+    // This used to read `const theOneException: LocalOnlyParamKey = 'validation'`
+    // — an inverted pin whose reverse direction said "the day `validation` is
+    // retired this line stops compiling and the exception is deleted rather
+    // than inherited". objectui#3201 retired it (declared on both halves of the
+    // contract, read by neither, and a hard `.strict()` parse rejection on the
+    // server), so the exception is deleted, not re-pointed at some other key.
+    //
+    // `[T] extends [never]` deliberately, not a naked `T extends never`: the
+    // naked form distributes and evaluates to `never` — not `true` — for the
+    // empty union, which is exactly the case being asserted, so it would fail
+    // to compile the moment it started being satisfied. The tuple wrapper
+    // defeats distribution and lets `never` be tested as a value.
+    type NoLocalOnlyKeys = [LocalOnlyParamKey] extends [never] ? true : false;
+    const noLocalOnlyKeys: NoLocalOnlyKeys = true;
+    expect(noLocalOnlyKeys).toBe(true);
 
-    expect(theOneException).toBe('validation');
-    expect(nothingElse).toBe(true);
+    // Forward direction, made runtime-visible: adding any key not in the spec's
+    // set has to fail here, so the assertion above cannot quietly become
+    // vacuous. `type` is the one key `ActionParam` restates, and it restates a
+    // key the spec already declares (a NARROWING to `ResolvableParamFieldType`),
+    // so it is not local-only and does not belong in this set either.
+    const localOnlyKeys: LocalOnlyParamKey[] = [];
+    expect(localOnlyKeys).toEqual([]);
+
+    // And the retired key specifically is no longer authorable: an authored
+    // `validation` is now the `tsc` error it always should have been, matching
+    // the server, which answers it with
+    // "Unrecognized key(s) on this action param: `validation`".
+    // @ts-expect-error retired by objectui#3201 — inert, and rejected by `ActionParamSchema`
+    const retired: ActionParam = { name: 'p', validation: 'value > 0' };
+    expect(retired.name).toBe('p');
   });
 });
 

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -264,6 +264,8 @@ export type ResolvableParamFieldType = ActionParamFieldType | ObjectUiLocalParam
  * ONE key is pinned locally: `type` takes {@link ResolvableParamFieldType} —
  * the spec vocabulary plus objectui's declared legacy spellings
  * (`checkbox` / `reference` / `datetime-local`), which the dialog resolves.
+ * `type` is a NARROWING of a key the spec already declares, not an addition:
+ * the interface adds no key of its own (objectui#3201 retired the last one).
  *
  * **Authoring ≠ resolved — the resolved-side keys are NOT declared here**
  * (objectui#3174). This interface used to add the whole picker group on top of
@@ -296,6 +298,20 @@ export type ResolvableParamFieldType = ActionParamFieldType | ObjectUiLocalParam
  * shape has and the authoring shape lacks is either a spec change or a
  * field-backed param — never a key added here.
  *
+ * That rule is now literal, with no named exception. `validation?: string` was
+ * carried here as the one key this interface added on top of the spec's set,
+ * and objectui#3201 retired it: `ActionParamSchema` is `.strict()` and does not
+ * list it, so an authored `validation` was a hard PARSE REJECTION on the server
+ * (`Unrecognized key(s) on this action param`) while `tsc` accepted it happily;
+ * and nothing ever read it — `resolveActionParams()` never had it on
+ * `RawActionParam`, `paramToField()` never mapped it, and `buildValidationRules()`
+ * in `@object-ui/fields` builds rules from `required` / `minLength` /
+ * `maxLength` / `pattern` field metadata with no `validation` branch. It was
+ * removed rather than implemented (ADR-0049 enforce-or-remove): giving it
+ * meaning would mean first deciding what an "expression" is here (CEL? formula?
+ * regex?) and adding it to `@objectstack/spec`, which is where such a capability
+ * would have to start.
+ *
  * `label` and `options[].label` are NOT pinned, though the comment above used
  * to justify them as a widening: "labels take the spec's `I18nLabel` (a string
  * or a per-locale record)". In spec 17 `I18nLabelSchema` is `z.ZodString` —
@@ -319,26 +335,6 @@ export interface ActionParam
    * {@link ActionParamFieldType} in new metadata.
    */
   type?: ResolvableParamFieldType;
-
-  /**
-   * Validation expression.
-   *
-   * NOT a spec key — `ActionParamSchema` is `.strict()`, so the server rejects
-   * it — and nothing reads it: `resolveActionParams()` never copies it onto the
-   * resolved param, and `paramToField()` never maps it into the field the
-   * widgets consume (form validation is built from `required` / `minLength` /
-   * `maxLength` / `pattern` field metadata instead). It is the same
-   * declared-but-inert shape objectui#3174 removed the picker group for, minus
-   * the second spelling, and is left standing only because retiring it is its
-   * own decision with its own blast radius — tracked as objectui#3201.
-   *
-   * The drift guard names it as the ONE key this interface adds to the spec's
-   * set, so it cannot be joined by a second without that being a decision.
-   *
-   * @deprecated Inert — declared, never read, and rejected by the server's
-   * param parser. Do not author it.
-   */
-  validation?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3201

按 PM 裁定走**选项 1(移除)**,不新增 spec 能力(选项 2 已否决,未触碰 `packages/spec`)。

## 问题

`validation?: string` 同时声明在 action-param 契约的**两半**上,两边都没人读,而服务端直接拒收:

- 作者侧 —— `@object-ui/types` 的 `ActionParam`(`packages/types/src/ui-action.ts`)
- 解析后 —— `@object-ui/core` 的 `ActionParamDef`(`packages/core/src/actions/ActionRunner.ts`)

`@objectstack/spec/ui` 的 `ActionParamSchema` 是 `.strict()` 且 `ACTION_PARAM_KEYS` 不含它,所以作者写下它就是一次**硬解析拒绝**,而 `tsc` 对着公共类型却照单全收。本 PR 实测确认:

```
parse { name, label, validation } success? false
ERROR: code "unrecognized_keys", keys ["validation"],
  message "Unrecognized key(s) on this action param: `validation`. …"
parse without validation success? true
```

这正是「类型说合法、运行时当场拒收」的 ADR-0049 enforce-or-remove 目标形态。

## resolved 侧确实无消费者(逐一核实)

单子的判断成立,并且比单子说的还要彻底:

- `RawActionParam`(`resolveActionParams.ts`)**根本没有** `validation` 这个键;
- `RuntimeField` 也**没有** `validation`,所以 field-backed param 从来无从继承;
- `paramToField()` / `ActionParamDialog`(app-shell 与 components 两处)/ `paramValueShape.ts` / `useConsoleActionRuntime.tsx` / `MetadataTypeActions.tsx` —— 全部 `grep -c validation` 为 **0**;
- 仓内唯一的 `def.validation` 读取在 `packages/plugin-detail/src/RecordDetailDrawer.tsx:252`,读的是 `schemaFields[name]` 这个**对象字段 schema**,与 action param 无关。

一处顺带纠正:`resolveActionParams.ts` 模块注释原先声称 field-backed param 会从字段继承 `validation` —— 这是**错的**(`RuntimeField` 上没有该键)。仅改注释,无逻辑改动;留着它会在移除之后继续教错同一件事。

## 漂移守卫回到「无例外」

`packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts` 原先把 `validation` 作为唯一具名例外携带,其注释自己预言过「retired 那天这行会编译失败,例外应被删除而不是被继承」—— 现在正是那天。

新断言不再有任何例外:

```ts
type NoLocalOnlyKeys = [ LocalOnlyParamKey ] extends [ never ] ? true : false;
```

刻意用 `[ T ] extends [ never ]` 的**元组包裹**形式,而非裸的 `T extends never`:裸形式会分配(distribute),对空联合求值得到 `never` 而非 `true`,恰好在断言开始被满足的那一刻编译失败。另加一条 `@ts-expect-error` 钉死「作者写 `validation` 现在就是 `tsc` 错误」。

`type` 不构成例外:它是对 spec **已声明**键的**收窄**(`ResolvableParamFieldType`),不是新增键。

## Sabotage 验证(守卫必须能红)

**A —— 任意新增本地键**(`sabotageOnlyKey?: string`):

```
src/__tests__/page-nav-misc-spec-parity.test.ts(389,11): error TS2322: Type 'true' is not assignable to type 'false'.
Exit status 2
```

**B —— 把 `validation` 原样加回**,两条断言同时红:

```
src/__tests__/page-nav-misc-spec-parity.test.ts(389,11): error TS2322: Type 'true' is not assignable to type 'false'.
src/__tests__/page-nav-misc-spec-parity.test.ts(404,5): error TS2578: Unused '@ts-expect-error' directive.
REAL EXIT CODE: 2
```

还原后 `REAL EXIT CODE: 0`。

注意守卫的真实执行者是 `tsc -p tsconfig.test.json`(`packages/types` 的 `type-check` 第三趟)—— 包自身的 `tsconfig.json` 把 `**/*.test.ts` 排除在外,`build` 不覆盖测试文件,vitest 也不评估 `@ts-expect-error`。

## 验证

- `pnpm --filter @object-ui/types --filter @object-ui/core type-check` → 退出码 **0**(types 三趟全过,含 `tsconfig.test.json`)
- `pnpm exec vitest run packages/types packages/core/src/actions packages/app-shell/src/utils --maxWorkers=2` → **55 文件 / 914 用例全绿**,退出码 0
- `node scripts/check-changeset-no-major.mjs` → `✅ No changeset declares a 'major' bump.`
- eslint 四个改动文件 → **0 errors**,warning 数与 `origin/main` 基线持平(未新增)
- 以上均在 rebase 到最新 `origin/main`(含 #3282)之后重跑过

## Changeset

两个已发布类型移除键,按仓库版本策略标 **`minor`**(不是 `major` —— fixed 组任一 major 会把 39 个包推离 `@objectstack` 的节奏),正文写清 FROM → TO 与迁移指引:**若你声明过 `validation`,它从未生效且会被服务端拒收,删掉即可**。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_