### PR TITLE
fix(app-shell): key the record feed state by objectName:recordId (#3268)

### DIFF
--- a/.changeset/record-feed-keyed-by-record.md
+++ b/.changeset/record-feed-keyed-by-record.md
@@ -1,0 +1,55 @@
+---
+"@object-ui/app-shell": patch
+---
+
+The record discussion panel no longer shows the PREVIOUS record's comments and
+activity (objectui#3268).
+
+FROM: clicking from record A to record B in a list left A's comments and
+activity rows on B's discussion panel, with B's own rows merged in alongside
+them. TO: each record's panel shows that record's feed and nothing else, and a
+record that is still being fetched shows the loading row rather than the
+record the user just came from.
+
+This was cross-record data display, not a cosmetic glitch. `RecordDetailView`
+is deliberately NOT remounted between records — no mount site passes a `key=`
+(`console/AppContent.tsx`, and the `ObjectView` / `ObjectDataPage` /
+`InterfaceListPage` drawers just swap `recordIdOverride`), per objectui#2269
+"refresh data, don't rebuild UI" — so its feed state survived the navigation,
+and both reads (`sys_comment`, `sys_activity`) merged into it BY ROW ID. A's
+rows and B's rows have different ids, so the merge could not dedupe them away
+and nothing anywhere reset the list.
+
+It also suppressed the fix objectui#3209 had just shipped. On record→record
+navigation `feedLoading` did flip true, but `RecordActivityTimeline`'s branch
+is `loading && filtered.length === 0` (objectui#3205, deliberate: a refresh
+must not turn an on-screen feed into a spinner) and the leftover rows kept
+`filtered` non-empty — so the panel rendered the previous record's content
+where a loading state belonged. The two issues only add up to a working
+feature together.
+
+The feed state is now keyed by `objectName:recordId` — the same key
+objectui#3209 introduced in this file for the loading flag, and the very
+`thread_id` the rows carry server-side. The render reads only the current
+key's slice, so "empty for a new record" FALLS OUT of reading a key that has
+no slice; there is no `setFeedItems([])` racing the fetch that fills it. A
+response that lands after the user has navigated away is written under the key
+its effect closed over, so it updates the record it was fetched for and can
+never bleed into the record now on screen — the same guarantee `settledFeedKey`
+already gave the loading flag. One idiom in this file, not two.
+
+Keying rather than clearing is what keeps OPTIMISTIC rows safe. A comment the
+user has just posted but that has not come back from the server lives only in
+this state, and it now rides in its own record's slice: navigating away and
+back finds it again, and it never appears on another record's panel. Nothing
+deletes a slice, so returning to a record shows its rows immediately while the
+re-read confirms them (objectui#3205 again), and the re-read folds the
+persisted copy onto the optimistic row by id — same id, because that is the id
+it was created under — so there is no duplicate when it lands. The same
+scoping applies to threaded replies and reaction toggles.
+
+No tolerance was added at the consumer. `RecordActivityTimeline` still keeps
+`loading && filtered.length === 0` exactly as objectui#3205 wrote it; once the
+feed's lifecycle is correct that condition is right on its own. Weakening it
+would have been treating the symptom at the consumer, which is what
+objectui#3165 / #3205 / #3209 all deliberately avoided.

--- a/packages/app-shell/src/views/RecordDetailView.feedRecordScope.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.feedRecordScope.test.tsx
@@ -1,0 +1,436 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * RecordDetailView — the discussion feed belongs to ONE record (objectui#3268).
+ *
+ * `RecordDetailView` is not remounted when the user moves from record A to
+ * record B: no mount site passes a `key=` (`console/AppContent.tsx`, and the
+ * `ObjectView` / `ObjectDataPage` / `InterfaceListPage` drawers just swap
+ * `recordIdOverride`) — deliberately, per #2269 "refresh data, don't rebuild
+ * UI". The feed state therefore SURVIVES the navigation, and until this fix it
+ * was a single flat `FeedItem[]` that both reads merged into by row id. A's
+ * comments and activity stayed on B's discussion panel with B's own rows merged
+ * in alongside; different ids, so the merge could not dedupe them away. That is
+ * cross-record data display, not a cosmetic glitch.
+ *
+ * It also SUPPRESSED #3209's loading signal on exactly this path: `feedLoading`
+ * does flip true when the key changes, but `RecordActivityTimeline`'s branch is
+ * `loading && filtered.length === 0` (#3205 — a refresh must not turn an
+ * on-screen feed into a spinner), and the leftover rows kept `filtered`
+ * non-empty. So the user saw the PREVIOUS record's content where a loading
+ * state belonged. Both are asserted here, on the rendered outcome.
+ *
+ * The subtle half is the OPTIMISTIC rows — a comment the user just posted that
+ * has not come back from the server yet. "Empty for a new record" must fall out
+ * of reading the current record's slice, never from a clearing `setState` that
+ * would race the post. The round-trip test at the bottom pins that: post on A,
+ * go to B (it must not follow), come back to A (it must still be there, exactly
+ * once even after the re-read returns the persisted copy).
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MetadataCtx } from '@object-ui/react';
+// The panel's own English fallbacks — the copy actually rendered when no
+// I18nProvider is mounted. Selecting through them keeps this file pinned to
+// the composer/empty-state semantics rather than to a literal string.
+import { DETAIL_DEFAULT_TRANSLATIONS } from '@object-ui/plugin-detail';
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => ({ viewers: [], others: [] }),
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// Orthogonal chrome — stubbed so the only asynchrony in this file is the feed.
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+import { RecordDetailView } from './RecordDetailView';
+
+const EMPTY_COMMENTS = DETAIL_DEFAULT_TRANSLATIONS['detail.noCommentsYet'];
+const COMMENT_PLACEHOLDER = DETAIL_DEFAULT_TRANSLATIONS['detail.leaveCommentPlaceholder'];
+const SUBMIT_COMMENT = DETAIL_DEFAULT_TRANSLATIONS['detail.submitComment'];
+const OBJECT_NAME = 'crm_account';
+const REC_A = 'rec-A';
+const REC_B = 'rec-B';
+
+/** The body text each record's seeded comment carries — deliberately names the
+ *  record it belongs to, so a leak is legible in the failure message. */
+const commentFor = (recordId: string) => `comment for ${OBJECT_NAME}:${recordId}`;
+const activityFor = (recordId: string) => `activity for ${OBJECT_NAME}:${recordId}`;
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'Account',
+    managedBy: 'platform',
+    fields: {
+      id: { type: 'text', label: 'Id' },
+      name: { type: 'text', label: 'Name' },
+    },
+  },
+];
+
+/** A promise that never settles — "the fetch for this record is still in flight". */
+const pending = () => new Promise(() => {});
+
+interface Seed {
+  /** Records whose feed reads never settle, i.e. still loading. */
+  pendingRecords?: string[];
+  /** recordId → seeded sys_comment rows (bodies only need `body` + `created_at`). */
+  comments?: Record<string, Array<Record<string, any>>>;
+  /** recordId → seeded sys_activity rows. */
+  activities?: Record<string, Array<Record<string, any>>>;
+}
+
+/**
+ * A per-record fake backend. `sys_comment` is filtered by `thread_id`
+ * (`${objectName}:${recordId}`) and `sys_activity` by `record_id`, exactly as
+ * the view queries them — so a read can only ever return the rows of the
+ * record it asked about. Everything the view writes through `create` lands in
+ * the same store, which is what lets the round-trip test observe a posted
+ * comment coming BACK from the server on the return visit.
+ */
+function makeDataSource(seed: Seed = {}) {
+  const commentsByThread = new Map<string, Array<Record<string, any>>>();
+  for (const [recordId, rows] of Object.entries(seed.comments ?? {})) {
+    commentsByThread.set(`${OBJECT_NAME}:${recordId}`, [...rows]);
+  }
+  const activitiesByRecord = new Map<string, Array<Record<string, any>>>();
+  for (const [recordId, rows] of Object.entries(seed.activities ?? {})) {
+    activitiesByRecord.set(recordId, [...rows]);
+  }
+  const isPending = (recordId: unknown) =>
+    !!recordId && (seed.pendingRecords ?? []).includes(String(recordId));
+
+  const find = vi.fn((objectName: string, query?: any) => {
+    if (objectName === 'sys_comment') {
+      const threadId = String(query?.$filter?.thread_id ?? '');
+      const recordId = threadId.slice(threadId.indexOf(':') + 1);
+      if (isPending(recordId)) return pending();
+      return Promise.resolve({ data: commentsByThread.get(threadId) ?? [] });
+    }
+    if (objectName === 'sys_activity') {
+      const recordId = query?.$filter?.record_id;
+      if (isPending(recordId)) return pending();
+      return Promise.resolve({ data: activitiesByRecord.get(String(recordId)) ?? [] });
+    }
+    // Mention directory, related lists… answer empty immediately.
+    return Promise.resolve({ data: [] });
+  });
+
+  const create = vi.fn(async (objectName: string, row: any) => {
+    if (objectName === 'sys_comment') {
+      const list = commentsByThread.get(row.thread_id) ?? [];
+      list.push(row);
+      commentsByThread.set(row.thread_id, list);
+    }
+    return row;
+  });
+
+  return {
+    find,
+    create,
+    findOne: vi.fn(async (_objectName: string, recordId: string) => ({
+      id: recordId,
+      name: `Record ${recordId}`,
+    })),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+/**
+ * An AUTHORED record page with no discussion slot — this is what turns on the
+ * host's bottom auto-append, the `RecordChatterPanel` that carries the comment
+ * composer (`showCommentInput: true`). The optimistic round-trip test needs a
+ * real composer to post through, rather than reaching for the callback prop.
+ */
+const AUTHORED_PAGE_WITHOUT_DISCUSSION = {
+  name: 'account_record_page',
+  type: 'record',
+  pageType: 'record',
+  object: OBJECT_NAME,
+  regions: [{ name: 'main', components: [{ type: 'page:header', title: 'Account' }] }],
+};
+
+function makeMetadata(pages: any[]) {
+  return {
+    objects: OBJECTS,
+    pages,
+    loading: false,
+    error: null,
+    refresh: async () => {},
+    invalidate: () => {},
+    ensureType: async () => pages,
+    getItem: async () => null,
+    getItemsByType: (type: string) => (type === 'page' ? pages : []),
+  } as any;
+}
+
+/**
+ * The tree, parameterised by record id ONLY. Element type and position are
+ * identical across calls, so `rerender` reconciles onto the SAME
+ * `RecordDetailView` instance — i.e. it reproduces the real navigation, where
+ * nothing remounts and the feed state survives. Re-rendering a fresh `render()`
+ * instead would remount and hide the bug entirely.
+ */
+function tree(dataSource: any, recordId: string, pages: any[] = []) {
+  return (
+    <MemoryRouter initialEntries={[`/app/demo/${OBJECT_NAME}/${recordId}`]}>
+      <MetadataCtx.Provider value={makeMetadata(pages)}>
+        <RecordDetailView
+          dataSource={dataSource}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={recordId}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  // Unrelated chrome (approvals, favourites…) reaches for the platform API; in
+  // jsdom that is a real socket. Answer it locally.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('RecordDetailView — the feed does not follow the user to the next record (#3268)', () => {
+  it('drops record A’s comment when the view navigates to record B', async () => {
+    // The defect, verbatim from the issue: A’s comment stayed on B’s panel.
+    const dataSource = makeDataSource({
+      comments: {
+        [REC_A]: [{ id: 'c-a', author_name: 'Grace', body: commentFor(REC_A), created_at: '2026-01-02T00:00:00.000Z' }],
+        [REC_B]: [{ id: 'c-b', author_name: 'Grace', body: commentFor(REC_B), created_at: '2026-01-03T00:00:00.000Z' }],
+      },
+    });
+
+    const { rerender } = render(tree(dataSource, REC_A));
+    expect(await screen.findByText(commentFor(REC_A))).toBeTruthy();
+
+    rerender(tree(dataSource, REC_B));
+
+    expect(await screen.findByText(commentFor(REC_B))).toBeTruthy();
+    expect(screen.queryByText(commentFor(REC_A))).toBeNull();
+  });
+
+  it('drops record A’s ACTIVITY rows too, not just its comments', async () => {
+    // The two reads merge into the feed independently; scoping one and not the
+    // other would still leak half the previous record onto the panel.
+    const dataSource = makeDataSource({
+      activities: {
+        [REC_A]: [{ id: 'a-a', type: 'updated', actor_name: 'Grace', summary: activityFor(REC_A), timestamp: '2026-01-02T00:00:00.000Z' }],
+        [REC_B]: [{ id: 'a-b', type: 'updated', actor_name: 'Grace', summary: activityFor(REC_B), timestamp: '2026-01-03T00:00:00.000Z' }],
+      },
+    });
+
+    const { rerender } = render(tree(dataSource, REC_A));
+    expect(await screen.findByText(activityFor(REC_A))).toBeTruthy();
+
+    rerender(tree(dataSource, REC_B));
+
+    expect(await screen.findByText(activityFor(REC_B))).toBeTruthy();
+    expect(screen.queryByText(activityFor(REC_A))).toBeNull();
+  });
+
+  it('shows the LOADING state on record→record navigation, not the previous record (#3209 reaches this path)', async () => {
+    // #3209 made `feedLoading` flip true here already, but the timeline’s
+    // branch is `loading && filtered.length === 0` (#3205, deliberate), so the
+    // leftover rows kept `filtered` non-empty and the spinner never rendered —
+    // the user was shown A’s content while B was being fetched. This is the
+    // assertion that the two fixes only add up together.
+    const dataSource = makeDataSource({
+      comments: {
+        [REC_A]: [{ id: 'c-a', author_name: 'Grace', body: commentFor(REC_A), created_at: '2026-01-02T00:00:00.000Z' }],
+      },
+      pendingRecords: [REC_B],
+    });
+
+    const { rerender } = render(tree(dataSource, REC_A));
+    expect(await screen.findByText(commentFor(REC_A))).toBeTruthy();
+    expect(screen.queryByTestId('activity-loading')).toBeNull();
+
+    rerender(tree(dataSource, REC_B));
+
+    expect(await screen.findByTestId('activity-loading')).toBeTruthy();
+    expect(screen.queryByText(commentFor(REC_A))).toBeNull();
+    // …and it is not claiming B has no comments while it is still asking.
+    expect(screen.queryByText(EMPTY_COMMENTS)).toBeNull();
+  });
+
+  it('settles record B onto its own empty state when B genuinely has no feed', async () => {
+    // The other half of "empty for a new record": it must be reached by
+    // READING B’s (absent) slice, and it must still settle — not spin forever.
+    const dataSource = makeDataSource({
+      comments: {
+        [REC_A]: [{ id: 'c-a', author_name: 'Grace', body: commentFor(REC_A), created_at: '2026-01-02T00:00:00.000Z' }],
+      },
+    });
+
+    const { rerender } = render(tree(dataSource, REC_A));
+    expect(await screen.findByText(commentFor(REC_A))).toBeTruthy();
+
+    rerender(tree(dataSource, REC_B));
+
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByText(commentFor(REC_A))).toBeNull();
+    await waitFor(() => expect(screen.queryByTestId('activity-loading')).toBeNull());
+  });
+
+  it('does not let a SLOW response for the record just left overwrite the record now on screen', async () => {
+    // The response is written under the key its effect closed over, so a read
+    // for A that lands after the user moved to B updates A’s slice — never
+    // the panel showing B. Same guarantee `settledFeedKey` gives the loading
+    // flag; one idiom, not two.
+    let releaseA: (value: any) => void = () => {};
+    const slowA = new Promise((resolve) => { releaseA = resolve; });
+    const base = makeDataSource({
+      comments: {
+        [REC_B]: [{ id: 'c-b', author_name: 'Grace', body: commentFor(REC_B), created_at: '2026-01-03T00:00:00.000Z' }],
+      },
+    });
+    const inner = base.find;
+    base.find = vi.fn((objectName: string, query?: any) => {
+      if (objectName === 'sys_comment' && String(query?.$filter?.thread_id ?? '').endsWith(REC_A)) {
+        return slowA;
+      }
+      return inner(objectName, query);
+    });
+
+    const { rerender } = render(tree(base, REC_A));
+    await screen.findByTestId('activity-loading');
+
+    rerender(tree(base, REC_B));
+    expect(await screen.findByText(commentFor(REC_B))).toBeTruthy();
+
+    // A finally answers — long after the user left it.
+    releaseA({
+      data: [{ id: 'c-a', author_name: 'Grace', body: commentFor(REC_A), created_at: '2026-01-02T00:00:00.000Z' }],
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(screen.queryByText(commentFor(REC_A))).toBeNull();
+    expect(screen.getByText(commentFor(REC_B))).toBeTruthy();
+  });
+});
+
+describe('RecordDetailView — optimistic comments ride with their own record (#3268)', () => {
+  /** Post a comment through the real composer on the auto-appended panel. */
+  async function postComment(text: string) {
+    const box = await screen.findByPlaceholderText(COMMENT_PLACEHOLDER);
+    fireEvent.change(box, { target: { value: text } });
+    fireEvent.click(screen.getByTitle(SUBMIT_COMMENT));
+  }
+
+  it('keeps a just-posted comment on its own record across a navigation round-trip', async () => {
+    // The one genuinely subtle requirement: "empty for a new record" must be a
+    // consequence of reading the current record’s slice, so a comment that has
+    // been posted but not yet come back from the server cannot be collateral.
+    const dataSource = makeDataSource({});
+
+    const { rerender } = render(tree(dataSource, REC_A, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    await screen.findByText(EMPTY_COMMENTS);
+
+    await postComment('optimistic on A');
+    expect(await screen.findByText('optimistic on A')).toBeTruthy();
+
+    // …it must not follow the user to B…
+    rerender(tree(dataSource, REC_B, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByText('optimistic on A')).toBeNull();
+
+    // …and it must still be on A when the user comes back, exactly once: the
+    // re-read now returns the persisted copy under the SAME id the optimistic
+    // row was created with, so the union-by-id merge folds them together.
+    rerender(tree(dataSource, REC_A, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    await waitFor(() => expect(screen.getAllByText('optimistic on A')).toHaveLength(1));
+  });
+
+  it('keeps an unpersisted comment when the write never lands', async () => {
+    // Same round-trip with a `create` that rejects (offline, 403…). The view
+    // swallows the failure by design; the local row is all the user has, and
+    // navigating away and back must not be what destroys it.
+    const dataSource = makeDataSource({});
+    dataSource.create = vi.fn(async () => { throw new Error('503 offline'); });
+
+    const { rerender } = render(tree(dataSource, REC_A, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    await screen.findByText(EMPTY_COMMENTS);
+
+    await postComment('never persisted');
+    expect(await screen.findByText('never persisted')).toBeTruthy();
+
+    rerender(tree(dataSource, REC_B, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    expect(await screen.findByText(EMPTY_COMMENTS)).toBeTruthy();
+    expect(screen.queryByText('never persisted')).toBeNull();
+
+    rerender(tree(dataSource, REC_A, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    await waitFor(() => expect(screen.getAllByText('never persisted')).toHaveLength(1));
+  });
+
+  it('files the optimistic comment under the record it was written on, not the one visited next', async () => {
+    // Posting on A then on B must give each panel exactly its own row.
+    const dataSource = makeDataSource({});
+
+    const { rerender } = render(tree(dataSource, REC_A, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    await screen.findByText(EMPTY_COMMENTS);
+    await postComment('written on A');
+    await screen.findByText('written on A');
+
+    rerender(tree(dataSource, REC_B, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    await screen.findByText(EMPTY_COMMENTS);
+    await postComment('written on B');
+    await screen.findByText('written on B');
+
+    expect(screen.queryByText('written on A')).toBeNull();
+    expect(dataSource.create).toHaveBeenCalledWith(
+      'sys_comment',
+      expect.objectContaining({ thread_id: `${OBJECT_NAME}:${REC_B}`, body: 'written on B' }),
+    );
+
+    rerender(tree(dataSource, REC_A, [AUTHORED_PAGE_WITHOUT_DISCUSSION]));
+    await waitFor(() => expect(screen.getAllByText('written on A')).toHaveLength(1));
+    expect(screen.queryByText('written on B')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -131,6 +131,36 @@ function isSecondaryField(fieldName: string, fieldDef: any): boolean {
 }
 
 /**
+ * The discussion feed of a record that has none. A module-level constant, not
+ * a fresh `[]` per render: `feedItems` is handed straight to
+ * `DiscussionContextProvider` / `RecordChatterPanel` as a prop, so a new array
+ * identity every render would defeat every memo downstream of it. Read-only by
+ * convention — every write path below produces a NEW array.
+ */
+const EMPTY_FEED: FeedItem[] = [];
+
+/**
+ * Union two feed slices by row id, oldest first.
+ *
+ * Both reads that fill the feed (`sys_comment`, `sys_activity`) land through
+ * here, and so does the re-read that follows a navigation back to a record we
+ * already have rows for. Union-by-id (rather than replace) is what lets an
+ * OPTIMISTIC row — a comment the user just posted, written with the same id it
+ * was `create`d under — survive the refetch: if the row has persisted the
+ * server copy wins on the same key (no duplicate), and if it has not, the local
+ * row is still there.
+ */
+function mergeFeedRows(prev: readonly FeedItem[], incoming: readonly FeedItem[]): FeedItem[] {
+  const byId = new Map<string, FeedItem>();
+  for (const item of [...prev, ...incoming]) byId.set(String(item.id), item);
+  return Array.from(byId.values()).sort((a, b) => {
+    const ta = a.createdAt ? Date.parse(a.createdAt) : 0;
+    const tb = b.createdAt ? Date.parse(b.createdAt) : 0;
+    return ta - tb;
+  });
+}
+
+/**
  * Which system record-header affordances the record page may offer for this
  * object — the primary `sys_edit` CTA (which also gates the record-body
  * inline-edit session) and the `sys_delete` overflow item.
@@ -296,7 +326,9 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   const { isFavorite, toggleFavorite, refreshLabel: refreshFavoriteLabel } = useFavorites();
   const { addRecentItem } = useRecentItems();
   const [isLoading, setIsLoading] = useState(true);
-  const [feedItems, setFeedItems] = useState<FeedItem[]>([]);
+  // The discussion feed, stored PER RECORD (objectui#3268). See the
+  // `feedRecordKey` block below for why this is a map and not a `FeedItem[]`.
+  const [feedItemsByRecord, setFeedItemsByRecord] = useState<Record<string, FeedItem[]>>({});
   const [mentionSuggestions, setMentionSuggestions] = useState<
     Array<{ id: string; label: string; avatarUrl?: string }>
   >([]);
@@ -1363,10 +1395,36 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // render of a record already read as loading, with no reset effect.
   // `record:activity` derives its own flag the same way (`canSelfFetch &&
   // fetched === null`) — one idiom, not two.
+  //
+  // ── Feed STATE is keyed by the same key (objectui#3268) ─────────────────
+  //
+  // `feedRecordKey` is the identity of the record a feed row belongs to — the
+  // very `thread_id` the rows are stored under server-side. Every write into
+  // the feed, fetched or optimistic, goes into that record's slice, and the
+  // render reads only the CURRENT key's slice. This view is not remounted
+  // between records (no `key=` at any mount site — `console/AppContent.tsx`
+  // and the `ObjectView` / `ObjectDataPage` / `InterfaceListPage` drawers just
+  // swap `recordIdOverride`, deliberately: #2269 "refresh data, don't rebuild
+  // UI"), and both reads below merge by row id — so with one flat `FeedItem[]`
+  // record A's comments and activity stayed on record B's panel with B's rows
+  // merged in alongside (different ids, so the merge could not dedupe them).
+  //
+  // Keying rather than clearing is the point:
+  //   • "empty for a new record" FALLS OUT of reading a key with no slice —
+  //     there is no `setFeedItems([])` racing the fetch that filled it;
+  //   • a response that lands AFTER the user navigated away is written under
+  //     the key its effect closed over, so it can never bleed into the record
+  //     now on screen (the same guarantee `settledFeedKey` gives the loading
+  //     flag — one idiom in this file, not two);
+  //   • ⛔ optimistic rows (a comment posted but not yet persisted) ride in
+  //     their own record's slice, so navigating away and back does not drop
+  //     them. Nothing here ever deletes a slice; that is deliberate, and it is
+  //     also why coming back to a record shows its rows immediately instead of
+  //     a spinner while the re-read confirms them (#3205).
+  const feedRecordKey = objectName && pureRecordId ? `${objectName}:${pureRecordId}` : null;
+  const feedItems = (feedRecordKey ? feedItemsByRecord[feedRecordKey] : undefined) ?? EMPTY_FEED;
   const feedFetchKey =
-    dataSource && objectName && pureRecordId && (feedsEnabled || activitiesEnabled)
-      ? `${objectName}:${pureRecordId}`
-      : null;
+    dataSource && feedRecordKey && (feedsEnabled || activitiesEnabled) ? feedRecordKey : null;
   const [settledFeedKey, setSettledFeedKey] = useState<string | null>(null);
   const feedLoading = feedFetchKey !== null && settledFeedKey !== feedFetchKey;
 
@@ -1427,15 +1485,13 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           parentId: c.parent_id ?? undefined,
           reactions: parseReactions(c.reactions),
         }));
-        setFeedItems(prev => {
-          const byId = new Map<string, FeedItem>();
-          for (const item of [...prev, ...mapped]) byId.set(String(item.id), item);
-          return Array.from(byId.values()).sort((a, b) => {
-            const ta = a.createdAt ? Date.parse(a.createdAt) : 0;
-            const tb = b.createdAt ? Date.parse(b.createdAt) : 0;
-            return ta - tb;
-          });
-        });
+        // Into THIS record's slice — `threadId` is the key the effect closed
+        // over, so a response that arrives after the user navigated away
+        // updates the record it was fetched for, never the one on screen.
+        setFeedItemsByRecord(prev => ({
+          ...prev,
+          [threadId]: mergeFeedRows(prev[threadId] ?? EMPTY_FEED, mapped),
+        }));
       })
       .catch(() => {}));
 
@@ -1503,20 +1559,13 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           } as FeedItem);
         }
         if (!mapped.length) return;
-        setFeedItems(prev => {
-          // Merge by id (timeline events are append-only); sort by
-          // createdAt ascending so the activity panel reads as a
-          // chronological narrative.
-          const byId = new Map<string, FeedItem>();
-          for (const item of [...prev, ...mapped]) {
-            byId.set(String(item.id), item);
-          }
-          return Array.from(byId.values()).sort((a, b) => {
-            const ta = a.createdAt ? Date.parse(a.createdAt) : 0;
-            const tb = b.createdAt ? Date.parse(b.createdAt) : 0;
-            return ta - tb;
-          });
-        });
+        // Merge by id into THIS record's slice (timeline events are
+        // append-only); `mergeFeedRows` sorts by createdAt ascending so the
+        // activity panel reads as a chronological narrative.
+        setFeedItemsByRecord(prev => ({
+          ...prev,
+          [threadId]: mergeFeedRows(prev[threadId] ?? EMPTY_FEED, mapped),
+        }));
       })
       .catch(() => {}));
 
@@ -1556,7 +1605,17 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         body: text,
         createdAt: new Date().toISOString(),
       };
-      setFeedItems(prev => [...prev, newItem]);
+      // The optimistic row goes into the slice of the record it was written
+      // ON, under the same key its `thread_id` will carry (objectui#3268) —
+      // so navigating away and back finds it again, and it never shows up on
+      // another record's panel. The re-read merges the persisted copy onto it
+      // by id, so there is no duplicate when it lands.
+      if (feedRecordKey) {
+        setFeedItemsByRecord(prev => ({
+          ...prev,
+          [feedRecordKey]: [...(prev[feedRecordKey] ?? EMPTY_FEED), newItem],
+        }));
+      }
       // Persist to backend (M10.10: snake_case fields per sys_comment schema)
       if (dataSource) {
         const threadId = `${objectName}:${pureRecordId}`;
@@ -1573,7 +1632,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         }).catch(() => {});
       }
     },
-    [currentUser, dataSource, objectName, pureRecordId, mentionSuggestions],
+    [currentUser, dataSource, objectName, pureRecordId, feedRecordKey, mentionSuggestions],
   );
 
   const handleAddReply = useCallback(
@@ -1587,15 +1646,23 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         createdAt: new Date().toISOString(),
         parentId,
       };
-      setFeedItems(prev => {
-        const updated = [...prev, newItem];
-        // Increment replyCount on parent
-        return updated.map(item =>
-          item.id === parentId
-            ? { ...item, replyCount: (item.replyCount ?? 0) + 1 }
-            : item
-        );
-      });
+      // Same record-scoped optimistic write as `handleAddComment` — the reply
+      // and the parent's bumped `replyCount` both belong to THIS record's
+      // slice (objectui#3268).
+      if (feedRecordKey) {
+        setFeedItemsByRecord(prev => {
+          const updated = [...(prev[feedRecordKey] ?? EMPTY_FEED), newItem];
+          return {
+            ...prev,
+            // Increment replyCount on parent
+            [feedRecordKey]: updated.map(item =>
+              item.id === parentId
+                ? { ...item, replyCount: (item.replyCount ?? 0) + 1 }
+                : item
+            ),
+          };
+        });
+      }
       if (dataSource) {
         const threadId = `${objectName}:${pureRecordId}`;
         const mentionIds = extractMentions(text, mentionSuggestions);
@@ -1612,60 +1679,67 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         }).catch(() => {});
       }
     },
-    [currentUser, dataSource, objectName, pureRecordId, mentionSuggestions],
+    [currentUser, dataSource, objectName, pureRecordId, feedRecordKey, mentionSuggestions],
   );
 
   const handleToggleReaction = useCallback(
     (itemId: string | number, emoji: string) => {
-      setFeedItems(prev => prev.map(item => {
-        if (item.id !== itemId) return item;
-        const reactions = [...(item.reactions ?? [])];
-        const idx = reactions.findIndex(r => r.emoji === emoji);
-        if (idx >= 0) {
-          const r = reactions[idx];
-          if (r.reacted) {
-            // Remove user's reaction
-            if (r.count <= 1) {
-              reactions.splice(idx, 1);
+      if (!feedRecordKey) return;
+      // Reactions are toggled from the panel of the record on screen, so they
+      // apply to that record's slice only (objectui#3268) — an id collision
+      // with a row cached for another record cannot reach across.
+      setFeedItemsByRecord(prevByRecord => ({
+        ...prevByRecord,
+        [feedRecordKey]: (prevByRecord[feedRecordKey] ?? EMPTY_FEED).map(item => {
+          if (item.id !== itemId) return item;
+          const reactions = [...(item.reactions ?? [])];
+          const idx = reactions.findIndex(r => r.emoji === emoji);
+          if (idx >= 0) {
+            const r = reactions[idx];
+            if (r.reacted) {
+              // Remove user's reaction
+              if (r.count <= 1) {
+                reactions.splice(idx, 1);
+              } else {
+                reactions[idx] = { ...r, count: r.count - 1, reacted: false };
+              }
             } else {
-              reactions[idx] = { ...r, count: r.count - 1, reacted: false };
+              reactions[idx] = { ...r, count: r.count + 1, reacted: true };
             }
           } else {
-            reactions[idx] = { ...r, count: r.count + 1, reacted: true };
+            reactions.push({ emoji, count: 1, reacted: true });
           }
-        } else {
-          reactions.push({ emoji, count: 1, reacted: true });
-        }
-        const updated = { ...item, reactions };
-        // Persist reactions to backend as JSON. The schema stores
-        // `reactions` as a textarea JSON string of `{ emoji: userIds[] }`,
-        // so we rebuild the canonical shape from the optimistic local
-        // state before writing back. A failed update silently keeps the
-        // optimistic UI change (best-effort, surfaced by RUM if needed).
-        if (dataSource) {
-          const userId = currentUser.id;
-          const remoteShape: Record<string, string[]> = {};
-          for (const r of reactions) {
-            // We don't have the original user-id list locally, so we
-            // approximate by emitting the signed-in user when they are
-            // the (only known) reactor. This is an over-simplification
-            // for single-user pilot installs and will be replaced by a
-            // proper backend reaction endpoint in M11.
-            const ids: string[] = [];
-            if (r.reacted) ids.push(userId);
-            // Pad with a synthetic marker so count is preserved across
-            // refreshes from other clients (best-effort).
-            while (ids.length < r.count) ids.push('__other__');
-            remoteShape[r.emoji] = ids;
+          const updated = { ...item, reactions };
+          // Persist reactions to backend as JSON. The schema stores
+          // `reactions` as a textarea JSON string of `{ emoji: userIds[] }`,
+          // so we rebuild the canonical shape from the optimistic local
+          // state before writing back. A failed update silently keeps the
+          // optimistic UI change (best-effort, surfaced by RUM if needed).
+          if (dataSource) {
+            const userId = currentUser.id;
+            const remoteShape: Record<string, string[]> = {};
+            for (const r of reactions) {
+              // We don't have the original user-id list locally, so we
+              // approximate by emitting the signed-in user when they are
+              // the (only known) reactor. This is an over-simplification
+              // for single-user pilot installs and will be replaced by a
+              // proper backend reaction endpoint in M11.
+              const ids: string[] = [];
+              if (r.reacted) ids.push(userId);
+              // Pad with a synthetic marker so count is preserved across
+              // refreshes from other clients (best-effort).
+              while (ids.length < r.count) ids.push('__other__');
+              remoteShape[r.emoji] = ids;
+            }
+            dataSource.update('sys_comment', String(itemId), {
+              reactions: JSON.stringify(remoteShape),
+            }).catch(() => {});
           }
-          dataSource.update('sys_comment', String(itemId), {
-            reactions: JSON.stringify(remoteShape),
-          }).catch(() => {});
-        }
-        return updated;
+          return updated;
+        }),
       }));
     },
-    [currentUser.id, dataSource],
+    [currentUser.id, dataSource, feedRecordKey],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3268

## 问题

从记录 A 点到记录 B,**A 的评论和活动会留在 B 的讨论面板上**,B 自己的行归并进来排在一起。这是串数据,不是视觉瑕疵 —— 讨论区显示了另一条记录的内容。

成因是三件事叠在一起:

1. `RecordDetailView` 在记录间**不会重挂载** —— 任何挂载点都没有 `key=`(`console/AppContent.tsx`,以及 `ObjectView` / `ObjectDataPage` / `InterfaceListPage` 的抽屉只是换 `recordIdOverride`)。这是**有意为之**(#2269「refresh data, don't rebuild UI」:bump key 会毁掉 scroll、折叠区、tab、在途行内编辑),所以 feed 状态会跨记录存活;
2. 两处取数回填都是**按行 id 归并到 prev**;
3. 全文件没有任何一处把它重置回 `[]`。

A 的行和 B 的行 id 不同,所以 Map 去重不掉。

它还**压掉了 #3209 刚修好的东西**:记录间导航时 `feedLoading` 确实会转 true,但 `RecordActivityTimeline` 的分支是 `loading && filtered.length === 0`(#3205 有意为之 —— 刷新不该把已在屏的 feed 变成 spinner),残留行让 `filtered` 非空,于是渲染的是**上一条记录的内容**而不是加载态。两单合起来才是一个能用的功能。

## 改法:按 `objectName:recordId` 键存,不加清空的 setState

feed 状态从一个扁平的 `FeedItem[]` 改成按记录键存的 map。这把钥匙就是 #3209(PR #3270)在**同一个文件**里为 loading 标志引入的那把,也正是这些行在服务端携带的 `thread_id`:

```ts
const feedRecordKey = objectName && pureRecordId ? `${objectName}:${pureRecordId}` : null;
const feedItems = (feedRecordKey ? feedItemsByRecord[feedRecordKey] : undefined) ?? EMPTY_FEED;
const feedFetchKey =
  dataSource && feedRecordKey && (feedsEnabled || activitiesEnabled) ? feedRecordKey : null;
```

渲染只读当前键那一份,于是:

- **「换记录后是空的」是读取一个没有切片的键的自然结果**,而不是一次与取数竞速的 `setFeedItems([])`;
- **迟到的响应写进它的 effect 闭包捕获的那把键**(两处回填都用 `threadId`),所以一条为 A 发出、在用户已经走到 B 之后才回来的读,更新的是 A 的切片,永远碰不到屏幕上的 B —— 这与 `settledFeedKey` 给 loading 标志的保证是同一条,本文件里**一种写法而不是两种**(主令 #12)。

## ⛔ 乐观行怎么保证不丢(本单唯一微妙处)

`handleAddComment` / `handleAddReply` / `handleToggleReaction` 往 feed 里塞的本地行,是用户刚发出、尚未落库的评论 —— 它**只存在于这份 state 里**,清空就是真的删掉了用户的输入。按键存正是保住它的原因,链条是这样闭合的:

1. **写进它所属记录的切片。** 三个 handler 都改成写 `feedItemsByRecord[feedRecordKey]`,`feedRecordKey` 与 `dataSource.create('sys_comment', { thread_id })` 用的是同一个表达式,所以乐观行和它将来的持久化副本从一开始就归在同一把键下。`feedRecordKey` 进了三个 `useCallback` 的依赖数组,`handleToggleReaction` 另加了 `if (!feedRecordKey) return` 的守卫。
2. **离开记录不会删任何切片。** 这里没有任何删除路径 —— 换记录只是去读另一把键。所以走开再回来,乐观行还在。
3. **回来时不会变成重复行。** 回到该记录时 effect 重新取数,`mergeFeedRows` 是**按 id 求并**:落库副本和乐观行用的是同一个 id(`create` 时显式传的 `newItem.id`),于是在同一个 key 上合成一行;若还没落库(或 `create` 失败被 `.catch` 吞掉),本地行照样留着。

顺带的好处:因为切片不删,回到看过的记录会立刻显示它的行、再由重读确认,而不是先闪一个 spinner —— 这正是 #3205 那条 `loading && filtered.length === 0` 想要的行为。

## 测试

新增 `packages/app-shell/src/views/RecordDetailView.feedRecordScope.test.tsx`(8 条),沿用 #3209 的装置,并且**用 `rerender` 复用同一棵树** —— 元素类型与位置不变,React 会复用同一个 `RecordDetailView` 实例,这才是真实导航(重新 `render()` 会重挂载,把 bug 藏掉)。断言一律落在渲染结果上,不断言「传了某个 prop」。

- **原缺陷复现**(issue 正文那段的模板):`recordIdOverride="rec-A"` → 出现 A 的评论 → rerender 到 `rec-B` → 出现 B 的评论,且**断言 A 的评论已经不在**;
- 活动行(`sys_activity`)同样不许残留 —— 两处回填是独立的,只修一处仍会漏半个记录;
- **换记录时加载态可见**:A 已结算并显示评论 → 切到读数挂起的 B → 出现 `activity-loading`,且 A 的评论不在、也没有过早断言 B「没有评论」(即 #3209 在这条路径上生效);
- B 确实没有 feed 时落到它**自己**的空态,而不是 spin 到死;
- 迟到响应:为 A 发出的读在用户走到 B 之后才 resolve,不许覆盖屏幕上的 B;
- **乐观行往返**(经真实 composer 发评论,不是直接调回调):在 A 发一条 → 切到 B(**不许跟过去**)→ 切回 A(**还在,且只有一条** —— 重读拿回的落库副本按 id 合并掉了);
- `create` 一直失败(离线/403)时,往返之后本地行依然在;
- 在 A 发一条、在 B 发一条,各自只出现在自己的面板上,且 `create` 收到的 `thread_id` 是 B 的。

### mutation 验证(退回归并写法,证明测试转红)

只把**状态**的键退回扁平(`feedRecordKey` 恒为 `'FLAT'`,两处回填写 `['FLAT']`),`feedFetchKey` 保持按记录键 —— 即精确还原修复前的状态,不动 #3209:

```
❯ packages/app-shell/src/views/RecordDetailView.feedRecordScope.test.tsx (8 tests | 8 failed)
  × drops record A's comment when the view navigates to record B 324ms
  × drops record A's ACTIVITY rows too, not just its comments 183ms
  × shows the LOADING state on record→record navigation, not the previous record (#3209 reaches this path)
  × settles record B onto its own empty state when B genuinely has no feed
  × does not let a SLOW response for the record just left overwrite the record now on screen
  × keeps a just-posted comment on its own record across a navigation round-trip
  × keeps an unpersisted comment when the write never lands
  × files the optimistic comment under the record it was written on, not the one visited next

AssertionError: expected < p …(1) >< /p > to be null            ← A 的评论还在 B 的面板上
TestingLibraryElementError: Unable to find an element by: [data-testid="activity-loading"]   ← 加载态被残留行压掉

 Test Files  1 failed | 1 passed (2)
      Tests  8 failed | 11 passed (19)
```

`RecordDetailView.feedLoading.test.tsx`(#3209 的 11 条)在 mutation 下**全绿** —— 说明这组新测试钉的正好是本单的缺陷,没有和 #3209 重叠。

### 绿的证据

```
$ pnpm --filter @object-ui/app-shell test
 Test Files  20 passed (20)
      Tests  183 passed (183)

$ pnpm --filter @object-ui/app-shell type-check
> tsc --noEmit && tsc -p tsconfig.typetests.json      (无输出 = 通过)

$ pnpm --filter @object-ui/app-shell lint
✖ 2125 problems (0 errors, 2125 warnings)
# RecordDetailView.tsx:改前 122 warnings / 改后 122 warnings,0 errors —— 未新增

$ node scripts/check-changeset-no-major.mjs
✅  No changeset declares a `major` bump.
```

## scope

只动了 `packages/app-shell/src/views/RecordDetailView.tsx`(+ 新测试 + changeset)。

**`packages/plugin-detail` 一行没动。** `loading && filtered.length === 0` 是 #3205 刻意写的,feed 生命周期修对之后它自己就是对的 —— 放宽它属于在消费端治标,而 #3165 / #3205 / #3209 一路都在刻意避免这件事。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_