### PR TITLE
fix(app-shell): previews 只读 spec 声明的键(#3275,合并 #3281)

### DIFF
--- a/.changeset/previews-read-only-spec-declared-keys.md
+++ b/.changeset/previews-read-only-spec-declared-keys.md
@@ -1,0 +1,76 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Five metadata designers stop rendering keys `@objectstack/spec` rejects, and start
+rendering the keys it declares (objectui#3275, objectui#3281).
+
+The previews and the console's sample drafts had been wrong TOGETHER, which is
+why the gallery looked healthy. objectui#3266 corrected the samples and the
+gallery immediately rendered LESS — agent's TOOLS and KNOWLEDGE blocks, skill's
+TRIGGER PHRASES, app's per-item row and `Dashboard` badge, and datasource's
+CAPABILITIES all vanished or degraded. Nothing had broken: those blocks were only
+ever lit up by metadata that cannot be saved. This is the renderer half of that
+finding, and the same fix objectui#3236 / PR #3258 made to `ToolPreview`.
+
+A preview that renders a rejected key does not just show something useless — it
+tells the author "this is correct" until publish refuses it. For AI-generated
+metadata that is where a stale key hides and multiplies, so every read below was
+deleted rather than kept behind a fallback (AGENTS.md #0.1).
+
+**Retired keys, deleted** — each is a `retiredKey()` tombstone rejected by name:
+`agent.tools` (objectstack#3894 — an agent reaches exactly the tools its skills
+declare, ADR-0064), `agent.knowledge` (objectstack#3896 — it never scoped
+retrieval), `skill.triggerPhrases` (objectstack#3896 — phrases were never matched
+against a user's message).
+
+**`AppPreview` / `AppNavCanvas`** — `AppSchema.navigation` is a discriminated
+union on `type` whose every branch is `.strict()`. Both surfaces ignored the
+discriminator: kind came from `it.object` / `it.dashboard`, the route from
+`it.path ?? it.href ?? it.route ?? it.url`, and the landing from
+`landingRoute ?? landing ?? defaultRoute ?? '/'`. Not one of those is a key
+(`landing` was removed in objectstack#4001), so the reading was exactly inverted —
+a valid app showed generic badges, no targets and an invented `Landing: /`. Now
+`type` is the badge, each branch's own key is the target
+(`objectName`/`pageName`/`dashboardName`/`url`/`reportName`/`componentRef`/
+`actionDef.actionName`), and the route comes from `resolveHref`, the shell's own
+nav → URL mapping that `useNavPins` and `SearchResultsPage` already share — so a
+link in the preview is the link the runtime follows. `homePageId` is rendered as
+the nav item **id** it is, resolved to the entry it selects; it is never printed
+as a path.
+
+**`DatasourcePreview`** — `capabilities` is a `DatasourceCapabilities` object of
+boolean flags, and the preview tested `Array.isArray`, lighting the block up only
+for the pre-17 token array the schema refuses. It now lists the flags set to
+`true`. The `driver ?? d.type` fallback is gone (the schema's own hint is
+`type` → `driver`), as is the `default` pill behind `isDefault ?? default` —
+routing is declared at stack level via `datasourceMapping`, never on the
+datasource.
+
+**`SkillPreview`** — the trigger-conditions table read `cond.expression ??
+cond.value` under a `cond.type` gutter, so a spec-valid condition rendered as
+`COND | sales_order` with the field it tests and the operator it applies both
+invisible. It is now three columns — `field` / `operator` / `value` — straight off
+`SkillTriggerConditionSchema`, and a row missing one of those required cells says
+so instead of rendering a blank that reads as fine.
+
+**`ValidationPreview`** (objectui#3281) — drew nine rule types where the union has
+six. `unique`, `async` and `custom` were removed by one paragraph of
+`validation.zod.ts`, because a rule must be a deterministic, synchronous,
+side-effect-free predicate over one record; each now redirects to the layer that
+does the job (a unique **index** — a SELECT-then-INSERT rule is racy, TOCTOU — a
+form-layer check, a lifecycle hook). Two alias fallbacks went with them:
+`condition ?? expression` and `pattern ?? regex`, where neither `expression` nor
+`pattern` has ever been a key on any branch — which is precisely why a bogus
+`expression` sat unnoticed in the console sample. Two branches were also simply
+wrong: `conditional` read `condition` instead of its `when` (a valid rule showed
+"No expression set", and its nested `then`/`otherwise` now render), and
+`json_schema` had no branch at all, so a valid rule displayed "Unknown rule type".
+
+`validation.object` is deliberately still read: `anchors.ts` registers a
+standalone `validation` resource matched by `anchorByField('object')`, so a
+standalone rule genuinely carries it. Not every key a union omits is residue.
+
+Verified in the preview gallery before and after, per designer; each preview also
+gains tests that feed a spec-valid draft and assert the block renders, then feed a
+stale draft carrying the retired key and assert nothing renders from it.

--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.test.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * AgentPreview must not render retired `AgentSchema` keys (objectui#3275).
+ *
+ * `agent.tools` (objectstack#3894) and `agent.knowledge` (objectstack#3896)
+ * are `retiredKey()` tombstones in `@objectstack/spec` 17 — `AgentSchema`
+ * rejects each BY NAME, so no draft carrying them can be saved. The preview
+ * nevertheless read both off the raw draft and painted a TOOLS chip strip and
+ * a `KNOWLEDGE (RAG)` block.
+ *
+ * That inverted the preview's whole purpose. The two shapes an author can
+ * write are (a) spec-valid, which rendered NOTHING in those blocks, and
+ * (b) retired, which rendered a full, healthy-looking summary right up until
+ * publish refused it. The designer was rewarding the unsaveable draft — the
+ * tolerant-consumer failure AGENTS.md #0.1 names, and the reason objectui#3266
+ * saw the gallery render LESS after its samples were corrected.
+ *
+ * These tests pin both directions: a VALID draft renders its capabilities, and
+ * a STALE draft renders nothing from the retired keys. The second half matters
+ * because the names survive in the spec's tombstone guidance, so a future
+ * reader has a plausible-looking reason to "restore" them.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { AgentPreview } from './AgentPreview';
+
+afterEach(cleanup);
+
+/** Parses clean against `ObjectStackSchema` — mirrors the gallery's sample. */
+const VALID_DRAFT = {
+  name: 'sales_copilot',
+  label: 'Sales Copilot',
+  role: 'Assistant for sales reps',
+  active: true,
+  model: { provider: 'openai', model: 'gpt-4o', temperature: 0.4, maxTokens: 2048 },
+  instructions: 'You are a helpful sales assistant.',
+  skills: ['summarize_account', 'draft_email'],
+} satisfies Record<string, unknown>;
+
+/** A draft as an author wrote it *before* the removals — both retired keys present. */
+const STALE_DRAFT = {
+  ...VALID_DRAFT,
+  tools: [
+    { type: 'objectql', name: 'query_orders' },
+    { type: 'http', name: 'lookup_company' },
+  ],
+  knowledge: { sources: [{ id: 'sales_playbook', type: 'vector' }] },
+} satisfies Record<string, unknown>;
+
+function renderPreview(draft: Record<string, unknown>) {
+  return render(
+    <AgentPreview {...({ type: 'agent', name: 'sales_copilot' } as never)} draft={draft} />,
+  );
+}
+
+describe('AgentPreview renders what a spec-valid agent declares', () => {
+  it('renders the skills chips — the whole of an agent capability surface', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('Capabilities')).toBeTruthy();
+    expect(screen.getByText('Skills')).toBeTruthy();
+    expect(screen.getByText('summarize_account')).toBeTruthy();
+    expect(screen.getByText('draft_email')).toBeTruthy();
+  });
+
+  it('keeps persona, model pills and instructions', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('Sales Copilot')).toBeTruthy();
+    expect(screen.getByText('sales_copilot')).toBeTruthy();
+    expect(screen.getByText('Assistant for sales reps')).toBeTruthy();
+    expect(screen.getByText('openai · gpt-4o')).toBeTruthy();
+    expect(screen.getByText('You are a helpful sales assistant.')).toBeTruthy();
+  });
+
+  it('says where tools come from, so the missing TOOLS block is not read as a gap', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText(/tools come from the attached skills/i)).toBeTruthy();
+  });
+
+  it('an agent with no skills gets an explicit empty state, not a blank', () => {
+    renderPreview({ ...VALID_DRAFT, skills: [] });
+    expect(screen.getByText(/no skills attached/i)).toBeTruthy();
+  });
+});
+
+describe('AgentPreview renders nothing from retired AgentSchema keys', () => {
+  it('paints no TOOLS block for a stale draft carrying `tools`', () => {
+    renderPreview(STALE_DRAFT);
+    // The chip-list heading is gone with the read...
+    expect(screen.queryByText('Tools')).toBeNull();
+    // ...and so is every tool name it used to advertise.
+    expect(screen.queryByText('query_orders')).toBeNull();
+    expect(screen.queryByText('lookup_company')).toBeNull();
+  });
+
+  it('paints no KNOWLEDGE (RAG) block for a stale draft carrying `knowledge`', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText(/knowledge/i)).toBeNull();
+    expect(screen.queryByText('sales_playbook')).toBeNull();
+  });
+
+  it('renders the stale draft exactly as if the retired keys were absent', () => {
+    const { container: stale } = renderPreview(STALE_DRAFT);
+    const staleHtml = stale.innerHTML;
+    cleanup();
+    const { container: valid } = renderPreview(VALID_DRAFT);
+    // The strongest form of "the key is not read": the two drafts differ only
+    // by `tools`/`knowledge`, so identical output proves neither reaches the DOM.
+    expect(staleHtml).toBe(valid.innerHTML);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
@@ -8,9 +8,19 @@
  *   • Persona header (avatar, label, role, active flag).
  *   • Model config (provider, model id, temperature, max tokens).
  *   • System prompt / instructions in a scrollable monospace block.
- *   • Skills + Tools as two collapsible chip lists.
- *   • Knowledge sources (RAG indices) when present.
+ *   • Skills as a chip list.
  *   • Planning + guardrails callouts.
+ *
+ * NOT shown — `agent.tools` and `agent.knowledge` (objectui#3275).
+ * Both are `retiredKey()` tombstones in `@objectstack/spec` 17
+ * (objectstack#3894 / #3896): `AgentSchema` rejects them BY NAME, so a
+ * draft carrying either cannot be saved. This preview used to read both
+ * and paint a TOOLS chip strip plus a `KNOWLEDGE (RAG)` block, which told
+ * the author their draft was fine right up until publish refused it —
+ * the tolerant-consumer shape AGENTS.md #0.1 forbids. An agent reaches
+ * exactly the tools its skills declare (ADR-0064), and grounding is
+ * described in `instructions`, so the Skills list below is the whole
+ * truth about what this agent can do.
  *
  * We intentionally do **not** wire a live chat into this preview:
  *   1. The draft may reference unsaved skills/tools the runtime can't
@@ -27,7 +37,6 @@ import {
   Activity,
   Bot,
   BrainCircuit,
-  Database,
   ExternalLink,
   Eye,
   EyeOff,
@@ -36,7 +45,6 @@ import {
   ScrollText,
   Shield,
   Sparkles,
-  Wrench,
 } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry';
@@ -49,11 +57,6 @@ interface ModelConfig {
   maxTokens?: number;
 }
 
-interface ToolRef {
-  type?: string;
-  name?: string;
-}
-
 export function AgentPreview({ name, draft }: MetadataPreviewProps) {
   const d = draft as Record<string, unknown>;
   const agentName = String(d.name ?? name ?? '');
@@ -64,14 +67,12 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
   const active = d.active !== false;
   const model = (d.model ?? {}) as ModelConfig;
   const skills: string[] = Array.isArray(d.skills) ? (d.skills as string[]) : [];
-  const tools: ToolRef[] = Array.isArray(d.tools) ? (d.tools as ToolRef[]) : [];
-  const knowledge = d.knowledge as Record<string, unknown> | undefined;
   const planning = d.planning as Record<string, unknown> | undefined;
   const memory = d.memory as Record<string, unknown> | undefined;
   const guardrails = d.guardrails as Record<string, unknown> | undefined;
   const permissions = Array.isArray(d.permissions) ? (d.permissions as string[]) : [];
 
-  if (!agentName && !instructions && skills.length === 0 && tools.length === 0) {
+  if (!agentName && !instructions && skills.length === 0) {
     return (
       <PreviewShell hint="agent">
         <PreviewMessage>Fill in label, role, and instructions in the Form tab to see the agent preview.</PreviewMessage>
@@ -136,34 +137,24 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
               )}
             </Section>
 
-            {/* Capabilities */}
-            <Section title="Capabilities" icon={Wrench}>
+            {/* Capabilities — skills only. `tools` is a retired tombstone
+                (objectstack#3894); an agent's reachable tool surface IS the
+                union of its skills' own `tools` (ADR-0064). */}
+            <Section title="Capabilities" icon={Sparkles}>
               <div className="space-y-2">
                 <ChipList
                   label="Skills"
-                  emptyHint="Attach skills (preferred)"
+                  emptyHint="No skills attached — this agent can reach no tools."
                   items={skills.map((s) => ({ key: s, label: s }))}
                   icon={Sparkles}
                   tone="violet"
                   mono
                 />
-                <ChipList
-                  label="Tools"
-                  emptyHint="No direct tools (skills can provide them)"
-                  items={tools.map((t, i) => ({ key: `${t.type ?? ''}:${t.name ?? i}`, label: t.name ?? String(t), hint: t.type }))}
-                  icon={Wrench}
-                  tone="blue"
-                  mono
-                />
+                <div className="text-[10px] text-muted-foreground">
+                  Tools come from the attached skills; grounding is described in the instructions.
+                </div>
               </div>
             </Section>
-
-            {/* Knowledge */}
-            {knowledge && Object.keys(knowledge).length > 0 && (
-              <Section title="Knowledge (RAG)" icon={Database}>
-                <KnowledgeSummary knowledge={knowledge} />
-              </Section>
-            )}
           </div>
 
           {/* Side rail: planning / memory / guardrails / permissions */}
@@ -207,36 +198,6 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
   );
 }
 
-function KnowledgeSummary({ knowledge }: { knowledge: Record<string, unknown> }) {
-  const sources = Array.isArray(knowledge.sources) ? (knowledge.sources as unknown[]) : [];
-  const indexes = Array.isArray(knowledge.indexes) ? (knowledge.indexes as unknown[]) : [];
-  const items = [...sources, ...indexes];
-  if (items.length === 0) {
-    const keys = Object.keys(knowledge);
-    return (
-      <div className="text-xs text-muted-foreground font-mono">
-        {keys.length ? keys.join(', ') : 'configured'}
-      </div>
-    );
-  }
-  return (
-    <ul className="rounded border bg-background divide-y text-xs">
-      {items.map((s, i) => {
-        const obj = (s ?? {}) as Record<string, unknown>;
-        const id = (obj.id ?? obj.name ?? `source ${i + 1}`) as string;
-        const kind = (obj.type ?? obj.kind ?? '') as string;
-        return (
-          <li key={i} className="flex items-center gap-2 px-2.5 py-1.5">
-            <Database className="h-3 w-3 text-muted-foreground" />
-            <span className="font-mono">{String(id)}</span>
-            {kind && <span className="text-[10px] uppercase text-muted-foreground">{kind}</span>}
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
 function Section({
   title,
   icon: Icon,
@@ -262,18 +223,13 @@ function Empty({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * Tone presets for capability chips — keep skills and tools visually
- * distinct at a glance. Full Tailwind class strings (JIT) with light +
- * dark variants.
+ * Tone preset for capability chips. Full Tailwind class strings (JIT)
+ * with light + dark variants.
  */
 const CHIP_TONE = {
   violet: {
     chip: 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300',
     icon: 'text-violet-500 dark:text-violet-400',
-  },
-  blue: {
-    chip: 'border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-900 dark:bg-blue-950/40 dark:text-blue-300',
-    icon: 'text-blue-500 dark:text-blue-400',
   },
 } as const;
 

--- a/packages/app-shell/src/views/metadata-admin/previews/AppNavCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AppNavCanvas.tsx
@@ -3,8 +3,13 @@
 /**
  * AppNavCanvas — form-canvas-style editor for an App's top-level
  * navigation tree. Each nav entry becomes a card with a drag handle,
- * a kind icon, an inline-rename label, the bound path, and a remove
- * affordance on hover. Drag-drop reorders within the root list.
+ * a kind icon, an inline-rename label, the metadata record it targets,
+ * and a remove affordance on hover. Drag-drop reorders within the root
+ * list.
+ *
+ * Kind and target are read from the spec's discriminated union — `type`
+ * plus that branch's own target key — never inferred from off-spec keys
+ * (objectui#3275).
  *
  * Nested children are rendered indented; cross-level moves and
  * adding child items are still handled by AppNavInspector (the
@@ -26,7 +31,10 @@ import {
   GripVertical,
   LayoutDashboard,
   Link as LinkIcon,
+  Minus,
+  MousePointerClick,
   Plus,
+  Puzzle,
   Trash2,
   type LucideIcon,
 } from 'lucide-react';
@@ -40,33 +48,30 @@ interface RawNav {
   id?: string;
   type?: string;
   label?: string;
-  title?: string;
-  name?: string;
-  path?: string;
-  href?: string;
-  route?: string;
-  url?: string;
-  kind?: string;
-  object?: string;
   objectName?: string;
-  page?: string;
   pageName?: string;
-  dashboard?: string;
-  report?: string;
+  dashboardName?: string;
+  reportName?: string;
+  url?: string;
+  componentRef?: string;
+  actionDef?: { actionName?: string };
   children?: RawNav[];
   [k: string]: unknown;
 }
 
-function inferKind(it: RawNav): string {
-  if (it.kind) return String(it.kind);
-  if (it.object || it.objectName) return 'object';
-  if (it.page || it.pageName) return 'page';
-  if (it.dashboard) return 'dashboard';
-  if (it.report) return 'report';
-  if (Array.isArray(it.children) && it.children.length) return 'group';
-  const path = it.path ?? it.href ?? it.route ?? it.url;
-  if (typeof path === 'string' && /^https?:/i.test(path)) return 'link';
-  return 'item';
+/**
+ * The nav item's kind IS its `type` discriminator (objectui#3275).
+ *
+ * This used to infer one from `it.object` / `it.dashboard` / a
+ * `path ?? href ?? route ?? url` chain and fall back to `'item'`. Since
+ * every branch of `AppSchema.navigation` is `.strict()`, none of those
+ * keys can appear on a saveable draft — so the inference only ever fired
+ * for metadata the spec rejects, and a spec-VALID app had every entry
+ * badged the meaningless `item`. Reading `type` is both simpler and the
+ * only reading that can be right.
+ */
+function navKind(it: RawNav): string {
+  return typeof it.type === 'string' && it.type ? it.type : 'untyped';
 }
 
 function kindIcon(kind: string): LucideIcon {
@@ -79,10 +84,16 @@ function kindIcon(kind: string): LucideIcon {
       return LayoutDashboard;
     case 'report':
       return BarChart3;
-    case 'link':
+    case 'url':
       return LinkIcon;
     case 'group':
       return Folder;
+    case 'action':
+      return MousePointerClick;
+    case 'component':
+      return Puzzle;
+    case 'separator':
+      return Minus;
     default:
       return Compass;
   }
@@ -115,7 +126,7 @@ const KIND_TONE: Record<string, KindTone> = {
     icon: 'text-amber-500',
     badge: 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300',
   },
-  link: {
+  url: {
     icon: 'text-indigo-500',
     badge: 'border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300',
   },
@@ -123,25 +134,65 @@ const KIND_TONE: Record<string, KindTone> = {
     icon: 'text-slate-500',
     badge: 'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300',
   },
-  item: {
-    icon: 'text-zinc-500',
-    badge: 'border-zinc-200 bg-zinc-50 text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400',
+  action: {
+    icon: 'text-rose-500',
+    badge: 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-300',
+  },
+  component: {
+    icon: 'text-cyan-500',
+    badge: 'border-cyan-200 bg-cyan-50 text-cyan-700 dark:border-cyan-900 dark:bg-cyan-950/40 dark:text-cyan-300',
+  },
+  separator: {
+    icon: 'text-zinc-400',
+    badge: 'border-zinc-200 bg-zinc-50 text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900/40 dark:text-zinc-400',
+  },
+  /**
+   * No `type` at all. Amber, not a neutral zinc: an untyped entry is not a
+   * benign "generic item", it is a draft `AppSchema` will reject for a
+   * missing discriminator, and the badge should read that way.
+   */
+  untyped: {
+    icon: 'text-amber-500',
+    badge: 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300',
   },
 };
 
 function kindTone(kind: string): KindTone {
-  return KIND_TONE[kind] ?? KIND_TONE.item;
+  return KIND_TONE[kind] ?? KIND_TONE.untyped;
 }
 
 function navLabel(it: RawNav, i: number): string {
-  const l = it.label ?? it.title ?? it.name ?? it.path;
+  // `label` only — `title` / `name` / `path` are not nav-item keys.
+  const l = it.label;
   if (typeof l === 'string' && l.trim()) return l.trim();
   return `Item ${i + 1}`;
 }
 
-function navPath(it: RawNav): string | undefined {
-  const p = it.path ?? it.href ?? it.route ?? it.url;
-  return typeof p === 'string' && p ? p : undefined;
+/**
+ * The metadata record this entry names, read from the key its own branch
+ * declares. Replaces a `path ?? href ?? route ?? url` chain in which only
+ * `url` was ever a real key — and only on `type: 'url'`.
+ */
+function navTarget(it: RawNav): string | undefined {
+  const pick = (v: unknown) => (typeof v === 'string' && v ? v : undefined);
+  switch (it.type) {
+    case 'object':
+      return pick(it.objectName);
+    case 'page':
+      return pick(it.pageName);
+    case 'dashboard':
+      return pick(it.dashboardName);
+    case 'report':
+      return pick(it.reportName);
+    case 'url':
+      return pick(it.url);
+    case 'component':
+      return pick(it.componentRef);
+    case 'action':
+      return pick(it.actionDef?.actionName);
+    default:
+      return undefined;
+  }
 }
 
 export interface AppNavCanvasProps {
@@ -405,10 +456,10 @@ function NavCard({
   onDropBefore: () => void;
 }) {
   const locale = useMetadataLocale();
-  const kind = inferKind(item);
+  const kind = navKind(item);
   const Icon = kindIcon(kind);
   const tone = kindTone(kind);
-  const path0 = navPath(item);
+  const target = navTarget(item);
   const [editing, setEditing] = React.useState(false);
   const [draft, setDraft] = React.useState(navLabel(item, index));
   const [hover, setHover] = React.useState(false);
@@ -502,9 +553,9 @@ function NavCard({
         <Badge variant="outline" className={cn('text-[10px] font-medium', tone.badge)}>
           {kind}
         </Badge>
-        {path0 && (
+        {target && (
           <code className="ml-0 text-[10px] text-muted-foreground truncate max-w-[10rem]">
-            {path0}
+            {target}
           </code>
         )}
         {canEdit && hover && !editing && (

--- a/packages/app-shell/src/views/metadata-admin/previews/AppPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AppPreview.test.tsx
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * AppPreview / AppNavCanvas vs `AppSchema` (objectui#3275).
+ *
+ * `AppSchema.navigation` is a DISCRIMINATED UNION on `type` whose every branch
+ * is `.strict()`. Both surfaces ignored that and guessed instead:
+ *
+ *   kind  ← `it.object` / `it.dashboard` / `it.report`  (none are keys)
+ *   route ← `it.path ?? it.href ?? it.route ?? it.url`  (only `url` is a key,
+ *                                                        only on `type: 'url'`)
+ *   home  ← `landingRoute ?? landing ?? defaultRoute ?? '/'`
+ *
+ * `landing` was removed outright in objectstack#4001; the rest were never
+ * declared anywhere. So a spec-VALID app rendered every entry as a generic
+ * badge with no target and an invented `Landing: /`, while a draft full of
+ * rejected keys rendered a complete-looking nav — which is why objectui#3266
+ * watched the app designer degrade the moment its sample was corrected.
+ *
+ * The route column now comes from `resolveHref`, the shell's own nav → URL
+ * mapping (`NavigationRenderer` documents it as the single source of truth,
+ * and `useNavPins` / `SearchResultsPage` already share it). A link shown in
+ * the preview is therefore the link the runtime will follow — the preview
+ * cannot drift from the shell because it is no longer guessing separately.
+ *
+ * `homePageId` is a nav item's **id**, not a route, so it is rendered as an id
+ * resolved against the tree — never as a path.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { AppPreview } from './AppPreview';
+
+afterEach(cleanup);
+
+/** Parses clean against `ObjectStackSchema` — mirrors the gallery's sample. */
+const VALID_DRAFT = {
+  name: 'crm',
+  label: 'CRM',
+  icon: 'briefcase',
+  homePageId: 'home',
+  navigation: [
+    { id: 'home', type: 'page', label: 'Home', pageName: 'crm_welcome' },
+    { id: 'accounts', type: 'object', label: 'Accounts', objectName: 'account' },
+    {
+      id: 'orders',
+      type: 'object',
+      label: 'Sales Orders',
+      objectName: 'sales_order',
+      viewName: 'open_orders',
+    },
+    { id: 'dashboard', type: 'dashboard', label: 'Dashboard', dashboardName: 'sales_overview' },
+    {
+      id: 'admin',
+      type: 'group',
+      label: 'Admin',
+      children: [
+        { id: 'docs', type: 'url', label: 'Docs', url: 'https://docs.example.com', target: '_blank' },
+      ],
+    },
+  ],
+} satisfies Record<string, unknown>;
+
+/** Pre-spec shape: hand-written routes, inferred kinds, removed `landing`. */
+const STALE_DRAFT = {
+  name: 'crm',
+  label: 'CRM',
+  landing: '/apps/crm/home',
+  nav: [
+    { label: 'Accounts', path: '/apps/crm/accounts', object: 'account' },
+    { label: 'Dashboard', path: '/apps/crm/dash', dashboard: 'sales_overview' },
+  ],
+} satisfies Record<string, unknown>;
+
+/** Read-only preview mode: no `onSelectionChange` ⇒ the NavRow list, not the canvas. */
+function renderPreview(draft: Record<string, unknown>) {
+  return render(<AppPreview {...({ type: 'app', name: 'crm' } as never)} draft={draft} />);
+}
+
+describe('AppPreview reads the navigation discriminated union', () => {
+  it('badges each entry with its `type`, including the dashboard entry', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('page')).toBeTruthy();
+    expect(screen.getAllByText('object')).toHaveLength(2);
+    // The badge objectui#3266 watched degrade from `dashboard` to a generic item.
+    expect(screen.getByText('dashboard')).toBeTruthy();
+    expect(screen.getByText('group')).toBeTruthy();
+    expect(screen.getByText('url')).toBeTruthy();
+  });
+
+  it('shows the metadata record each entry names', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('crm_welcome')).toBeTruthy();
+    expect(screen.getByText('account')).toBeTruthy();
+    expect(screen.getByText('sales_order')).toBeTruthy();
+    expect(screen.getByText('sales_overview')).toBeTruthy();
+  });
+
+  it('renders the route the shell will navigate to, via resolveHref', () => {
+    renderPreview(VALID_DRAFT);
+    // Derived, not authored: `viewName` becomes a /view/ segment and the
+    // dashboard entry becomes /dashboard/<name> — exactly what NavigationRenderer
+    // produces, so the preview cannot advertise a route the runtime won't serve.
+    expect(screen.getByText('/apps/crm/account')).toBeTruthy();
+    expect(screen.getByText('/apps/crm/sales_order/view/open_orders')).toBeTruthy();
+    expect(screen.getByText('/apps/crm/dashboard/sales_overview')).toBeTruthy();
+    expect(screen.getByText('/apps/crm/page/crm_welcome')).toBeTruthy();
+  });
+
+  it('renders a `url` entry with its own absolute URL, not an /apps/ prefix', () => {
+    renderPreview(VALID_DRAFT);
+    // Appears twice: once as the entry target, once as the resolved route —
+    // resolveHref returns an external url verbatim rather than prefixing it.
+    const hits = screen.getAllByText('https://docs.example.com');
+    expect(hits.length).toBeGreaterThan(0);
+    expect(screen.queryByText('/apps/crm/https://docs.example.com')).toBeNull();
+  });
+
+  it('flags an entry that has no `type` discriminator', () => {
+    renderPreview({
+      name: 'crm',
+      label: 'CRM',
+      navigation: [{ id: 'mystery', label: 'Mystery' }],
+    });
+    expect(screen.getByText('no type')).toBeTruthy();
+  });
+});
+
+describe('AppPreview renders homePageId as a nav item id', () => {
+  it('shows the id and the entry it selects', () => {
+    renderPreview(VALID_DRAFT);
+    const home = screen.getByText('home');
+    expect(home).toBeTruthy();
+    // Resolved to the entry's label — NOT rendered as a route.
+    expect(screen.getByText('→ Home')).toBeTruthy();
+  });
+
+  it('never renders homePageId as a path', () => {
+    const { container } = renderPreview(VALID_DRAFT);
+    expect(container.textContent).not.toContain('Landing: /home');
+    expect(container.textContent).not.toContain('/apps/crm/home');
+  });
+
+  it('says so when the id matches no navigation item', () => {
+    renderPreview({ ...VALID_DRAFT, homePageId: 'nope_missing' });
+    expect(screen.getByText(/no navigation item with this id/i)).toBeTruthy();
+  });
+
+  it('describes the real default when homePageId is absent', () => {
+    const noHome: Record<string, unknown> = { ...VALID_DRAFT };
+    delete noHome.homePageId;
+    renderPreview(noHome);
+    expect(screen.getByText(/opens the first navigation item/i)).toBeTruthy();
+  });
+});
+
+describe('AppPreview renders nothing from keys AppSchema rejects', () => {
+  it('does not render the removed `landing` as a route', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText('/apps/crm/home')).toBeNull();
+    expect(screen.getByText(/opens the first navigation item/i)).toBeTruthy();
+  });
+
+  it('does not infer a kind from `object` / `dashboard`', () => {
+    renderPreview(STALE_DRAFT);
+    // Both entries lack `type`; neither may borrow a kind from an off-spec key.
+    expect(screen.queryByText('object')).toBeNull();
+    expect(screen.queryByText('dashboard')).toBeNull();
+    expect(screen.getAllByText('no type')).toHaveLength(2);
+  });
+
+  it('does not render a hand-written `path` as the entry route', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText('/apps/crm/accounts')).toBeNull();
+    expect(screen.queryByText('/apps/crm/dash')).toBeNull();
+  });
+});
+
+describe('AppNavCanvas (design mode) reads the same union', () => {
+  /** Design mode: passing `editing` + `onSelectionChange` selects the canvas. */
+  function renderCanvas(draft: Record<string, unknown>) {
+    return render(
+      <AppPreview
+        {...({ type: 'app', name: 'crm' } as never)}
+        draft={draft}
+        editing
+        selection={null}
+        onSelectionChange={() => {}}
+      />,
+    );
+  }
+
+  it('badges the dashboard entry `dashboard`, not a generic item', () => {
+    renderCanvas(VALID_DRAFT);
+    expect(screen.getByText('dashboard')).toBeTruthy();
+    expect(screen.queryByText('item')).toBeNull();
+  });
+
+  it('shows each entry target from its own branch key', () => {
+    renderCanvas(VALID_DRAFT);
+    expect(screen.getByText('sales_overview')).toBeTruthy();
+    expect(screen.getByText('account')).toBeTruthy();
+    expect(screen.getByText('crm_welcome')).toBeTruthy();
+  });
+
+  it('badges an entry with no `type` as `untyped` rather than inventing one', () => {
+    renderCanvas({ name: 'crm', label: 'CRM', navigation: [{ id: 'x_y', label: 'Mystery', object: 'account' }] });
+    expect(screen.getByText('untyped')).toBeTruthy();
+    expect(screen.queryByText('object')).toBeNull();
+  });
+
+  it('labels an entry from `label` only, never from a `path`', () => {
+    renderCanvas({
+      name: 'crm',
+      label: 'CRM',
+      navigation: [{ id: 'a_b', type: 'object', path: '/apps/crm/accounts', objectName: 'account' }],
+    });
+    // No `label` ⇒ the positional fallback, not the off-spec path.
+    expect(screen.getByText('Item 1')).toBeTruthy();
+    expect(screen.queryByText('/apps/crm/accounts')).toBeNull();
+  });
+
+  it('keeps the group child visible under its parent', () => {
+    const { container } = renderCanvas(VALID_DRAFT);
+    expect(within(container).getByText('Docs')).toBeTruthy();
+    expect(within(container).getByText('https://docs.example.com')).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/AppPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AppPreview.tsx
@@ -2,55 +2,149 @@
 
 /**
  * AppPreview — visual summary of an App metadata record's nav and
- * landing route, since rendering a full nested AppShell inside the
+ * landing page, since rendering a full nested AppShell inside the
  * admin would be confusing (nav-within-nav).
  *
  * Shows:
- *   • App label/icon + landing route
- *   • Top-level navigation items (tabs/menu) as a clickable list —
- *     each link opens the runtime app in a new tab so authors can
- *     test the configured nav without leaving the editor.
+ *   • App label/icon + the landing nav item (`homePageId`)
+ *   • Top-level navigation items as a clickable list — each link opens
+ *     the runtime app in a new tab so authors can test the configured
+ *     nav without leaving the editor.
+ *
+ * READING THE NAV (rewritten in objectui#3275). `AppSchema.navigation` is
+ * a DISCRIMINATED UNION on `type` and every branch is `.strict()`. This
+ * file used to ignore that: it inferred a "kind" from `it.object` /
+ * `it.dashboard` and took a route from `it.path ?? it.href ?? it.route ??
+ * it.url`. Not one of `path` / `href` / `route` / `object` / `dashboard`
+ * is a key in any branch — the spec rejects them by name — while the keys
+ * that ARE declared (`objectName`, `pageName`, `dashboardName`, `url`)
+ * were never read. The result was exactly inverted: a spec-valid app
+ * rendered every entry as an unlabelled generic item with no target,
+ * and only an unsaveable one looked complete.
+ *
+ * An app does not route by hand-written path; it names the metadata
+ * record to open and the SHELL derives the URL. So the route column now
+ * comes from `resolveHref` — the shell's own nav → URL mapping, which
+ * `NavigationRenderer` documents as the single source of truth and which
+ * `useNavPins` / `SearchResultsPage` already share. A link shown here is
+ * therefore the link the user will actually follow, `recordId` /
+ * `filters` / `componentRef` semantics included.
  *
  * If the App schema doesn't follow the expected shape we degrade to
  * a "no preview" hint rather than throw.
  */
 
 import * as React from 'react';
-import { Compass, ExternalLink, LayoutDashboard, FileText, Database, BarChart3 } from 'lucide-react';
+import {
+  Compass,
+  ExternalLink,
+  Folder,
+  LayoutDashboard,
+  FileText,
+  Database,
+  BarChart3,
+  Link as LinkIcon,
+  Minus,
+  MousePointerClick,
+  Puzzle,
+} from 'lucide-react';
+import { resolveHref } from '@object-ui/layout';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell';
 import { AppNavCanvas } from './AppNavCanvas';
 
+/** The nine members of the spec's navigation union. */
+type NavKind =
+  | 'object'
+  | 'dashboard'
+  | 'page'
+  | 'url'
+  | 'report'
+  | 'action'
+  | 'component'
+  | 'group'
+  | 'separator';
+
+const NAV_KINDS: readonly string[] = [
+  'object', 'dashboard', 'page', 'url', 'report', 'action', 'component', 'group', 'separator',
+];
+
 interface NavItem {
+  id?: string;
   label: string;
-  path?: string;
-  kind?: 'object' | 'page' | 'dashboard' | 'report' | 'link' | 'group';
+  /** The discriminator, verbatim — never inferred. */
+  kind?: NavKind;
+  /** The metadata record this entry names (`objectName`, `pageName`, …). */
+  target?: string;
+  /** Route the shell will navigate to, from `resolveHref`. */
+  href?: string;
+  external?: boolean;
   children?: NavItem[];
 }
 
-function normalizeNav(raw: unknown): NavItem[] {
+/**
+ * The target a nav item names, read from the key its own branch declares.
+ * Returns undefined for branches that name nothing (`group`, `separator`).
+ */
+function navTarget(it: Record<string, unknown>, kind?: NavKind): string | undefined {
+  switch (kind) {
+    case 'object':
+      return typeof it.objectName === 'string' ? it.objectName : undefined;
+    case 'dashboard':
+      return typeof it.dashboardName === 'string' ? it.dashboardName : undefined;
+    case 'page':
+      return typeof it.pageName === 'string' ? it.pageName : undefined;
+    case 'report':
+      return typeof it.reportName === 'string' ? it.reportName : undefined;
+    case 'url':
+      return typeof it.url === 'string' ? it.url : undefined;
+    case 'component':
+      return typeof it.componentRef === 'string' ? it.componentRef : undefined;
+    case 'action': {
+      const def = it.actionDef as Record<string, unknown> | undefined;
+      return def && typeof def.actionName === 'string' ? def.actionName : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function normalizeNav(raw: unknown, appName: string): NavItem[] {
   if (!Array.isArray(raw)) return [];
   return raw
     .map((it: any): NavItem | null => {
       if (!it || typeof it !== 'object') return null;
-      const label = String(it.label ?? it.title ?? it.name ?? it.path ?? '').trim();
+      const kind: NavKind | undefined =
+        typeof it.type === 'string' && NAV_KINDS.includes(it.type) ? (it.type as NavKind) : undefined;
+      if (kind === 'separator') {
+        return { id: typeof it.id === 'string' ? it.id : undefined, label: '', kind };
+      }
+      const label = typeof it.label === 'string' ? it.label.trim() : '';
       if (!label && !it.children) return null;
-      const path: string | undefined = it.path ?? it.href ?? it.route ?? it.url ?? undefined;
-      // Best-effort kind inference for icon selection.
-      let kind: NavItem['kind'];
-      if (it.object || it.objectName) kind = 'object';
-      else if (it.page || it.pageName) kind = 'page';
-      else if (it.dashboard) kind = 'dashboard';
-      else if (it.report) kind = 'report';
-      else if (typeof path === 'string' && /^https?:/i.test(path)) kind = 'link';
-      else if (Array.isArray(it.children) && it.children.length) kind = 'group';
-      const children = Array.isArray(it.children) ? normalizeNav(it.children) : undefined;
-      return { label: label || '(unnamed)', path, kind, children };
+      const target = navTarget(it, kind);
+      // Delegate to the shell's own mapping so the preview cannot invent a
+      // route the runtime would not produce. Needs a `type`, so an item
+      // missing the discriminator gets no link — which is the truth.
+      let href: string | undefined;
+      let external = false;
+      if (kind && appName) {
+        try {
+          const r = resolveHref(it, `/apps/${encodeURIComponent(appName)}`);
+          if (r.href && r.href !== '#') {
+            href = r.href;
+            external = r.external;
+          }
+        } catch {
+          href = undefined;
+        }
+      }
+      const children = Array.isArray(it.children) ? normalizeNav(it.children, appName) : undefined;
+      return { id: typeof it.id === 'string' ? it.id : undefined, label: label || '(unnamed)', kind, target, href, external, children };
     })
     .filter((x): x is NavItem => x !== null);
 }
 
-function kindIcon(kind?: NavItem['kind']) {
+function kindIcon(kind?: NavKind) {
   switch (kind) {
     case 'object':
       return Database;
@@ -60,15 +154,42 @@ function kindIcon(kind?: NavItem['kind']) {
       return LayoutDashboard;
     case 'report':
       return BarChart3;
+    case 'url':
+      return LinkIcon;
+    case 'group':
+      return Folder;
+    case 'action':
+      return MousePointerClick;
+    case 'component':
+      return Puzzle;
+    case 'separator':
+      return Minus;
     default:
       return Compass;
   }
 }
 
+/** Depth-first lookup of a nav item by `id` — how `homePageId` addresses one. */
+function findNavItem(items: NavItem[], id: string): NavItem | undefined {
+  for (const it of items) {
+    if (it.id === id) return it;
+    if (it.children) {
+      const hit = findNavItem(it.children, id);
+      if (hit) return hit;
+    }
+  }
+  return undefined;
+}
+
 export function AppPreview({ name, draft, editing, selection, onSelectionChange, onPatch }: MetadataPreviewProps) {
   const appName = String((draft as any).name ?? name ?? '');
   const label = (draft as any).label ?? appName;
-  const landing = (draft as any).landingRoute ?? (draft as any).landing ?? (draft as any).defaultRoute ?? '/';
+  // `homePageId` is a nav item's **id**, not a route: it names which entry
+  // the app opens on (the shell resolves that entry's URL via resolveHref).
+  // The old `landingRoute ?? landing ?? defaultRoute ?? '/'` read three keys
+  // AppSchema has never declared — `landing` was removed outright in
+  // objectstack#4001 — so a valid app always showed the invented `Landing: /`.
+  const homePageId = typeof (draft as any).homePageId === 'string' ? (draft as any).homePageId : undefined;
   const { rootKey, navItems } = React.useMemo<{ rootKey: string | null; navItems: NavItem[] }>(() => {
     const candidates: Array<[string, unknown]> = [
       ['nav', (draft as any).nav],
@@ -78,10 +199,14 @@ export function AppPreview({ name, draft, editing, selection, onSelectionChange,
       ['menu', (draft as any).menu],
     ];
     for (const [k, c] of candidates) {
-      if (Array.isArray(c) && c.length) return { rootKey: k, navItems: normalizeNav(c) };
+      if (Array.isArray(c) && c.length) return { rootKey: k, navItems: normalizeNav(c, appName) };
     }
     return { rootKey: null, navItems: [] };
-  }, [draft]);
+  }, [draft, appName]);
+
+  // Resolve the landing id against the tree so the author sees WHICH entry
+  // it selects — and, when it matches nothing, that it selects none.
+  const homeItem = homePageId ? findNavItem(navItems, homePageId) : undefined;
 
   // For Add we need a root key even when empty — default to `navigation`,
   // the only root key the spec (AppSchema) actually accepts; `nav` /
@@ -120,7 +245,20 @@ export function AppPreview({ name, draft, editing, selection, onSelectionChange,
             <div className="text-sm font-medium text-foreground">{String(label)}</div>
             <div className="text-xs text-muted-foreground font-mono mt-0.5">{appName}</div>
             <div className="text-xs text-muted-foreground mt-1">
-              Landing: <code className="font-mono">{String(landing)}</code>
+              {homePageId ? (
+                <>
+                  Home: <code className="font-mono">{homePageId}</code>
+                  {homeItem ? (
+                    <span className="ml-1.5">→ {homeItem.label}</span>
+                  ) : (
+                    <span className="ml-1 text-amber-700">
+                      — no navigation item with this id
+                    </span>
+                  )}
+                </>
+              ) : (
+                <>Home: opens the first navigation item</>
+              )}
             </div>
           </div>
 
@@ -136,7 +274,7 @@ export function AppPreview({ name, draft, editing, selection, onSelectionChange,
             />
           ) : navItems.length === 0 ? (
             <PreviewMessage>
-              No top-level nav items. Add <code>nav</code> / <code>tabs</code> entries in the Form tab to populate the app's navigation.
+              No top-level nav items. Add <code>navigation</code> entries in the Form tab to populate the app's navigation.
             </PreviewMessage>
           ) : (
             <div className="border rounded divide-y">
@@ -144,7 +282,6 @@ export function AppPreview({ name, draft, editing, selection, onSelectionChange,
                 <NavRow
                   key={i}
                   item={item}
-                  appName={appName}
                   depth={0}
                   path={`${rootKey}[${i}]`}
                   onSelect={onSelect}
@@ -161,21 +298,19 @@ export function AppPreview({ name, draft, editing, selection, onSelectionChange,
 
 function NavRow({
   item,
-  appName,
   depth,
   path,
   onSelect,
   selectedId,
 }: {
   item: NavItem;
-  appName: string;
   depth: number;
   path: string;
   onSelect?: (path: string, item: NavItem) => void;
   selectedId: string | null;
 }) {
   const Icon = kindIcon(item.kind);
-  const url = buildUrl(appName, item.path);
+  const url = item.href;
   const selected = selectedId === path;
   return (
     <>
@@ -187,8 +322,18 @@ function NavRow({
         {/* eslint-disable-next-line react-hooks/static-components -- kindIcon returns a stable icon component from a static registry, not one created during render */}
         <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         <span className="font-medium truncate">{item.label}</span>
-        {item.kind && (
+        {item.kind ? (
           <span className="text-[10px] uppercase tracking-wider opacity-60">{item.kind}</span>
+        ) : (
+          <span
+            className="text-[10px] uppercase tracking-wider text-amber-700"
+            title="Every navigation item needs a `type` discriminator — this entry will be rejected on save."
+          >
+            no type
+          </span>
+        )}
+        {item.target && (
+          <span className="font-mono text-[10px] text-muted-foreground truncate">{item.target}</span>
         )}
         {url && (
           <a
@@ -198,7 +343,7 @@ function NavRow({
             onClick={(e) => e.stopPropagation()}
             className="ml-auto font-mono text-[10px] text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
           >
-            {item.path} <ExternalLink className="h-3 w-3" />
+            {url} <ExternalLink className="h-3 w-3" />
           </a>
         )}
       </div>
@@ -206,7 +351,6 @@ function NavRow({
         <NavRow
           key={i}
           item={c}
-          appName={appName}
           depth={depth + 1}
           path={`${path}.children[${i}]`}
           onSelect={onSelect}
@@ -217,11 +361,3 @@ function NavRow({
   );
 }
 
-function buildUrl(appName: string, path?: string): string | null {
-  if (!path) return null;
-  if (/^https?:/i.test(path)) return path;
-  if (!appName) return null;
-  // Treat path as relative to /apps/<appName>/ by default.
-  const trimmed = path.startsWith('/') ? path.slice(1) : path;
-  return `/apps/${encodeURIComponent(appName)}/${trimmed}`;
-}

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.test.tsx
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * DatasourcePreview vs `DatasourceSchema` (objectui#3275).
+ *
+ * `DatasourceSchema` is `.strict()`. Three reads in this preview were for keys
+ * it rejects outright, and each one made an unsaveable draft look correct:
+ *
+ *  • `capabilities` — a `DatasourceCapabilities` OBJECT of boolean flags. The
+ *    preview tested `Array.isArray(d.capabilities)`, which is exactly
+ *    backwards: it lit the CAPABILITIES block up only for the pre-17 token
+ *    array the schema refuses, and left it dark for the object form the schema
+ *    requires. objectui#3266 watched the block vanish the moment the sample was
+ *    corrected.
+ *  • `driver ?? d.type` — `type` is rejected with an explicit `type` → `driver`
+ *    alias hint, so the fallback taught the wrong spelling.
+ *  • `isDefault` / `default` — not datasource keys at all; routing is declared
+ *    at stack level via `datasourceMapping`.
+ *
+ * A preview that renders a rejected key is not being helpful; it is making the
+ * author's mistake invisible until publish (AGENTS.md #0.1).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+// The federation panel makes REST calls against a saved datasource; this test
+// is about which keys the preview reads, so stub it out.
+vi.mock('../external/ExternalDatasourcePanel', () => ({
+  ExternalDatasourcePanel: () => <div data-testid="mock-external-panel" />,
+}));
+
+import { DatasourcePreview } from './DatasourcePreview';
+
+afterEach(cleanup);
+
+/** Parses clean against `ObjectStackSchema` — mirrors the gallery's sample. */
+const VALID_DRAFT = {
+  name: 'warehouse',
+  label: 'Analytics Warehouse',
+  description: 'Read-only Postgres replica for reporting.',
+  driver: 'postgres',
+  active: true,
+  ssl: { enabled: true, rejectUnauthorized: true },
+  config: { host: 'db.internal', port: 5432, database: 'analytics' },
+  pool: { min: 2, max: 10 },
+  capabilities: { readOnly: true, queryAggregations: true },
+  healthCheck: { enabled: true, intervalMs: 60000 },
+} satisfies Record<string, unknown>;
+
+/** Pre-17 shape: array capabilities, `type` instead of `driver`, `isDefault`. */
+const STALE_DRAFT = {
+  name: 'warehouse',
+  label: 'Analytics Warehouse',
+  type: 'postgres',
+  isDefault: true,
+  config: { host: 'db.internal' },
+  capabilities: ['read', 'aggregate'],
+} satisfies Record<string, unknown>;
+
+function renderPreview(draft: Record<string, unknown>) {
+  return render(
+    <DatasourcePreview {...({ type: 'datasource', name: 'warehouse' } as never)} draft={draft} />,
+  );
+}
+
+describe('DatasourcePreview renders object-shaped capabilities', () => {
+  it('renders a chip for each capability the author set to true', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('Capabilities')).toBeTruthy();
+    expect(screen.getByText('readOnly')).toBeTruthy();
+    expect(screen.getByText('queryAggregations')).toBeTruthy();
+  });
+
+  it('omits flags left false — a default is not an assertion worth a chip', () => {
+    renderPreview({
+      ...VALID_DRAFT,
+      capabilities: { readOnly: true, joins: false, transactions: false },
+    });
+    expect(screen.getByText('readOnly')).toBeTruthy();
+    expect(screen.queryByText('joins')).toBeNull();
+    expect(screen.queryByText('transactions')).toBeNull();
+  });
+
+  it('renders no capabilities block when every flag is false', () => {
+    renderPreview({ ...VALID_DRAFT, capabilities: { readOnly: false } });
+    expect(screen.queryByText('Capabilities')).toBeNull();
+  });
+});
+
+describe('DatasourcePreview renders nothing from keys the spec rejects', () => {
+  it('renders no capabilities block for the array form', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText('Capabilities')).toBeNull();
+    expect(screen.queryByText('read')).toBeNull();
+    expect(screen.queryByText('aggregate')).toBeNull();
+  });
+
+  it('does not fall back to `type` for the driver pill', () => {
+    renderPreview(STALE_DRAFT);
+    // `postgres` was never written to `driver`, so the preview must not claim
+    // one — the alias hint belongs at save time, not as a silent rescue here.
+    expect(screen.queryByText('postgres')).toBeNull();
+    expect(screen.getByText('unknown')).toBeTruthy();
+  });
+
+  it('paints no `default` pill for `isDefault` / `default`', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText('default')).toBeNull();
+    cleanup();
+    renderPreview({ ...STALE_DRAFT, isDefault: undefined, default: true });
+    expect(screen.queryByText('default')).toBeNull();
+  });
+});
+
+describe('DatasourcePreview still renders everything the spec accepts', () => {
+  it('keeps label, name, driver, description and the redacted connection table', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('Analytics Warehouse')).toBeTruthy();
+    expect(screen.getByText('warehouse')).toBeTruthy();
+    expect(screen.getByText('postgres')).toBeTruthy();
+    expect(screen.getByText('Read-only Postgres replica for reporting.')).toBeTruthy();
+    expect(screen.getByText('db.internal')).toBeTruthy();
+  });
+
+  it('keeps the pool / ssl / health-check rail blocks', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('Pool')).toBeTruthy();
+    expect(screen.getByText('SSL')).toBeTruthy();
+    expect(screen.getByText('Health Check')).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.tsx
@@ -8,14 +8,24 @@
  * leak secrets". Concretely:
  *
  *   • Header: driver pill (postgres/mysql/mongo/…), name, label,
- *     active flag, default-flag.
+ *     active flag.
  *   • Connection card: a redacted config table where any key whose
  *     name matches /pass|secret|key|token|credential/i is replaced
  *     with `••••••` and a "redacted" badge. Other primitives render
  *     verbatim; nested objects render as their key count.
  *   • Pool, SSL, retry, health-check pills derived from optional
  *     sibling blocks.
- *   • Capabilities chip strip.
+ *   • Capabilities chip strip — the `DatasourceCapabilities` flags set to
+ *     `true`.
+ *
+ * Three reads were deleted in objectui#3275 because `DatasourceSchema` is
+ * `.strict()` and rejects every one of them, so each made an unsaveable
+ * draft look correct: `driver ?? d.type` (the alias hint is `type` →
+ * `driver`), the `default` pill behind `isDefault ?? default` (routing is
+ * declared at stack level via `datasourceMapping`, never on the
+ * datasource), and `Array.isArray(capabilities)` — which had it exactly
+ * backwards, lighting up only for the array form the schema refuses and
+ * staying dark for the object form it requires.
  *
  * A read-replica count pill used to sit in that strip. It is gone with
  * `datasource.readReplicas` itself (objectstack#4468): nothing in the
@@ -38,7 +48,6 @@ import {
   Power,
   RotateCcw,
   ShieldCheck,
-  Star,
 } from 'lucide-react';
 import type { MetadataPreviewProps } from '../preview-registry';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell';
@@ -55,6 +64,23 @@ function redactValue(v: unknown): string {
   return '••••••';
 }
 
+/**
+ * The capability names an author has switched ON.
+ *
+ * `DatasourceCapabilities` is a flat object of optional booleans, each
+ * defaulting to `false`. Only `true` is an assertion the author made, so
+ * only `true` earns a chip — listing the falses would bury the two facts
+ * that matter under nine that don't. A non-object (e.g. the pre-17 string
+ * array) yields nothing: the block staying empty IS the signal that the
+ * shape is wrong.
+ */
+function enabledCapabilities(raw: unknown): string[] {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return [];
+  return Object.entries(raw as Record<string, unknown>)
+    .filter(([, v]) => v === true)
+    .map(([k]) => k);
+}
+
 function renderValue(v: unknown): string {
   if (v == null) return '∅';
   if (typeof v === 'string') return v;
@@ -69,15 +95,25 @@ export function DatasourcePreview({ name, draft }: MetadataPreviewProps) {
   const dsName = String(d.name ?? name ?? '');
   const label = String(d.label ?? dsName);
   const description = (d.description as string | undefined) ?? '';
-  const driver = (d.driver as string | undefined) ?? (d.type as string | undefined) ?? 'unknown';
+  // `driver` only. `DatasourceSchema` is `.strict()` and rejects `type`
+  // outright (with a `type` → `driver` alias hint), so the old
+  // `?? d.type` fallback rendered a driver pill for a draft that cannot
+  // be saved — and, worse, made the wrong spelling look correct.
+  const driver = (d.driver as string | undefined) ?? 'unknown';
   const active = d.active !== false;
-  const isDefault = !!d.isDefault || !!d.default;
   const config = (d.config as Record<string, unknown> | undefined) ?? {};
   const pool = d.pool as Record<string, unknown> | undefined;
   const ssl = d.ssl as Record<string, unknown> | boolean | undefined;
   const retryPolicy = d.retryPolicy as Record<string, unknown> | undefined;
   const healthCheck = d.healthCheck as Record<string, unknown> | undefined;
-  const capabilities = Array.isArray(d.capabilities) ? (d.capabilities as string[]) : [];
+  // `capabilities` is a DatasourceCapabilities OBJECT of boolean flags
+  // (`{ readOnly, queryAggregations, joins, … }`), never a token array.
+  // Reading it with `Array.isArray` meant a spec-valid draft rendered NO
+  // capabilities block at all, while the old array form — which the schema
+  // rejects — was the only thing that lit it up. Show the flags the author
+  // turned ON; a flag left false is the schema's own default, not a
+  // statement worth a chip.
+  const capabilities = enabledCapabilities(d.capabilities);
 
   // External Datasource Federation (ADR-0015): a non-'managed' schemaMode
   // marks this datasource as federated. The panel keys off the *saved* item
@@ -118,7 +154,6 @@ export function DatasourcePreview({ name, draft }: MetadataPreviewProps) {
                     <HardDrive className="h-3 w-3 text-muted-foreground" /> {driver}
                   </span>
                   <Pill icon={Power} label={active ? 'Active' : 'Disabled'} tone={active ? 'green' : 'gray'} />
-                  {isDefault && <Pill icon={Star} label="default" tone="amber" />}
                 </div>
               </div>
             </div>

--- a/packages/app-shell/src/views/metadata-admin/previews/SkillPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/SkillPreview.test.tsx
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * SkillPreview vs `SkillSchema` (objectui#3275).
+ *
+ * Two defects of the same shape, both found by objectui#3266's browser pass:
+ *
+ *  1. `skill.triggerPhrases` is a `retiredKey()` tombstone in
+ *     `@objectstack/spec` 17 (objectstack#3896) — rejected BY NAME. The
+ *     preview read it and painted a `TRIGGER PHRASES (n)` block, which was
+ *     wrong twice over: the draft could not be saved, and the phrases were
+ *     never matched against a user's message even when they were legal.
+ *
+ *  2. The trigger-conditions table read `cond.expression ?? cond.value` under
+ *     a `cond.type` gutter. `SkillTriggerConditionSchema` is
+ *     `{ field, operator, value }` — all three REQUIRED — so a spec-VALID
+ *     condition rendered as `COND | sales_order`: the value alone, with the
+ *     field it tests and the operator it applies both invisible. The author
+ *     could not see what their skill actually triggers on.
+ *
+ * Together these are why a corrected sample made the gallery render less: the
+ * only draft that lit this preview up fully was one the spec refuses.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { SkillPreview } from './SkillPreview';
+
+afterEach(cleanup);
+
+/** Parses clean against `ObjectStackSchema` — mirrors the gallery's sample. */
+const VALID_DRAFT = {
+  name: 'draft_email',
+  label: 'Draft Email',
+  type: 'prompt',
+  description: 'Draft a follow-up email from a record context.',
+  active: true,
+  instructions: 'Write a concise, friendly follow-up email referencing the order.',
+  tools: ['lookup_company'],
+  triggerConditions: [{ field: 'objectName', operator: 'eq', value: 'sales_order' }],
+} satisfies Record<string, unknown>;
+
+/** Pre-removal shape: retired `triggerPhrases` plus the off-spec condition form. */
+const STALE_DRAFT = {
+  ...VALID_DRAFT,
+  triggerPhrases: ['draft an email', 'follow up with the customer'],
+  triggerConditions: [{ type: 'cel', expression: 'context.objectName == "sales_order"' }],
+} satisfies Record<string, unknown>;
+
+function renderPreview(draft: Record<string, unknown>) {
+  return render(
+    <SkillPreview {...({ type: 'skill', name: 'draft_email' } as never)} draft={draft} />,
+  );
+}
+
+describe('SkillPreview renders trigger conditions as field / operator / value', () => {
+  it('renders all three columns of a spec-valid condition', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('Trigger Conditions (1)')).toBeTruthy();
+    // Column headers — the two that used to have nowhere to render.
+    expect(screen.getByText('Field')).toBeTruthy();
+    expect(screen.getByText('Operator')).toBeTruthy();
+    expect(screen.getByText('Value')).toBeTruthy();
+    // ...and the row, which previously showed only `sales_order`.
+    const row = screen.getByText('objectName').closest('tr')!;
+    expect(within(row).getByText('eq')).toBeTruthy();
+    expect(within(row).getByText('sales_order')).toBeTruthy();
+  });
+
+  it('renders an `in` condition whose value is a string array', () => {
+    renderPreview({
+      ...VALID_DRAFT,
+      triggerConditions: [{ field: 'stage', operator: 'in', value: ['open', 'won'] }],
+    });
+    const row = screen.getByText('stage').closest('tr')!;
+    expect(within(row).getByText('in')).toBeTruthy();
+    expect(within(row).getByText('open, won')).toBeTruthy();
+  });
+
+  it('marks a missing required cell instead of rendering a blank that reads as fine', () => {
+    // `operator` is required — an author who omitted it must see that here,
+    // not discover it when the save is refused.
+    renderPreview({
+      ...VALID_DRAFT,
+      triggerConditions: [{ field: 'objectName', value: 'sales_order' }],
+    });
+    const row = screen.getByText('objectName').closest('tr')!;
+    expect(within(row).getByText('missing')).toBeTruthy();
+  });
+
+  it('spells out the AND semantics once there is more than one condition', () => {
+    renderPreview({
+      ...VALID_DRAFT,
+      triggerConditions: [
+        { field: 'objectName', operator: 'eq', value: 'sales_order' },
+        { field: 'stage', operator: 'neq', value: 'closed' },
+      ],
+    });
+    expect(screen.getByText(/all conditions must hold/i)).toBeTruthy();
+  });
+});
+
+describe('SkillPreview renders nothing from retired SkillSchema keys', () => {
+  it('paints no TRIGGER PHRASES block for a stale draft carrying `triggerPhrases`', () => {
+    renderPreview(STALE_DRAFT);
+    expect(screen.queryByText(/trigger phrases/i)).toBeNull();
+    expect(screen.queryByText('draft an email')).toBeNull();
+    expect(screen.queryByText('follow up with the customer')).toBeNull();
+  });
+
+  it('does not resurrect the off-spec condition shape through `expression`', () => {
+    renderPreview(STALE_DRAFT);
+    // `expression` / `type` are not condition keys — reading them was what let
+    // a non-conforming condition look rendered. The row now reports the three
+    // required cells as missing, which is the truth about this draft.
+    expect(screen.queryByText('context.objectName == "sales_order"')).toBeNull();
+    expect(screen.getAllByText('missing')).toHaveLength(3);
+  });
+});
+
+describe('SkillPreview still renders everything the spec accepts', () => {
+  it('keeps label, machine name, description, instructions and tools', () => {
+    renderPreview(VALID_DRAFT);
+    expect(screen.getByText('Draft Email')).toBeTruthy();
+    expect(screen.getByText('draft_email')).toBeTruthy();
+    expect(screen.getByText('Draft a follow-up email from a record context.')).toBeTruthy();
+    expect(screen.getByText(/write a concise, friendly follow-up email/i)).toBeTruthy();
+    expect(screen.getByText('Tools (1)')).toBeTruthy();
+    expect(screen.getByText('lookup_company')).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/SkillPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/SkillPreview.tsx
@@ -14,10 +14,23 @@
  *     it the way the LLM will.
  *   • Tools — chip list. Wildcards (`*`, `prefix.*`) get highlighted
  *     because they expand the agent's tool surface significantly.
- *   • Trigger phrases — the natural-language hints that route a user
- *     message into this skill.
- *   • Trigger conditions — CEL/structured conditions, rendered as a
- *     compact table.
+ *   • Trigger conditions — the AND-ed `{ field, operator, value }` triples
+ *     that gate activation, rendered as a three-column table.
+ *
+ * NOT shown — `skill.triggerPhrases` (objectui#3275). It is a
+ * `retiredKey()` tombstone in `@objectstack/spec` 17 (objectstack#3896):
+ * `SkillSchema` rejects it BY NAME, so a draft carrying it cannot be
+ * saved. The phrases were never matched against a user's message either,
+ * so the `TRIGGER PHRASES` block this preview used to paint advertised
+ * routing that no runtime performed — twice wrong. Activation is
+ * `triggerConditions` intersected with the agent's `skills[]`.
+ *
+ * The conditions table itself was the other half of the bug: it read
+ * `cond.expression ?? cond.value` with a `cond.type` gutter, none of
+ * which `SkillTriggerConditionSchema` declares. A spec-valid condition
+ * therefore rendered as a bare value with its `field` and `operator`
+ * invisible — `COND | sales_order` instead of `objectName eq
+ * sales_order`. Three columns, read straight off the schema's shape.
  */
 
 import * as React from 'react';
@@ -25,7 +38,6 @@ import {
   Asterisk,
   BookOpen,
   Filter,
-  MessagesSquare,
   Power,
   Sparkles,
   Wrench,
@@ -40,7 +52,6 @@ export function SkillPreview({ name, draft }: MetadataPreviewProps) {
   const description = (d.description as string | undefined) ?? '';
   const instructions = (d.instructions as string | undefined) ?? '';
   const tools = Array.isArray(d.tools) ? (d.tools as string[]) : [];
-  const triggerPhrases = Array.isArray(d.triggerPhrases) ? (d.triggerPhrases as string[]) : [];
   const triggerConditions = Array.isArray(d.triggerConditions)
     ? (d.triggerConditions as Array<Record<string, unknown>>)
     : [];
@@ -119,42 +130,42 @@ export function SkillPreview({ name, draft }: MetadataPreviewProps) {
             )}
           </Section>
 
-          {/* Trigger phrases */}
-          {triggerPhrases.length > 0 && (
-            <Section title={`Trigger Phrases (${triggerPhrases.length})`} icon={MessagesSquare}>
-              <ul className="rounded border bg-background divide-y text-xs">
-                {triggerPhrases.map((p, i) => (
-                  <li key={i} className="px-2.5 py-1.5">
-                    <span className="text-muted-foreground mr-2">"</span>
-                    {p}
-                    <span className="text-muted-foreground ml-2">"</span>
-                  </li>
-                ))}
-              </ul>
-            </Section>
-          )}
-
-          {/* Trigger conditions */}
+          {/* Trigger conditions — `{ field, operator, value }`, ANDed.
+              Every column comes from a key SkillTriggerConditionSchema
+              declares; nothing is inferred or defaulted. */}
           {triggerConditions.length > 0 && (
             <Section title={`Trigger Conditions (${triggerConditions.length})`} icon={Filter}>
               <div className="rounded border bg-background overflow-hidden">
                 <table className="w-full text-xs">
+                  <thead>
+                    <tr className="bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+                      <th className="px-2.5 py-1.5 font-medium">Field</th>
+                      <th className="px-2.5 py-1.5 font-medium">Operator</th>
+                      <th className="px-2.5 py-1.5 font-medium">Value</th>
+                    </tr>
+                  </thead>
                   <tbody className="divide-y">
                     {triggerConditions.map((cond, i) => (
-                      <tr key={i}>
-                        <td className="px-2.5 py-1.5 align-top w-24 text-muted-foreground text-[10px] uppercase">
-                          {(cond.type as string | undefined) ?? 'cond'}
+                      <tr key={i} className="align-top">
+                        <td className="px-2.5 py-1.5 font-mono break-all">
+                          {renderCell(cond.field)}
+                        </td>
+                        <td className="px-2.5 py-1.5 font-mono text-muted-foreground">
+                          {renderCell(cond.operator)}
                         </td>
                         <td className="px-2.5 py-1.5 font-mono break-all">
-                          {(cond.expression as string | undefined) ??
-                            (cond.value as string | undefined) ??
-                            JSON.stringify(cond)}
+                          {renderCell(cond.value)}
                         </td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
+              {triggerConditions.length > 1 && (
+                <div className="mt-1 text-[10px] text-muted-foreground">
+                  All conditions must hold (AND) for the skill to activate.
+                </div>
+              )}
             </Section>
           )}
 
@@ -166,6 +177,28 @@ export function SkillPreview({ name, draft }: MetadataPreviewProps) {
         </div>
       </PreviewErrorBoundary>
     </PreviewShell>
+  );
+}
+
+/**
+ * Render one trigger-condition cell.
+ *
+ * `SkillTriggerConditionSchema` declares all three of `field` / `operator` /
+ * `value` as REQUIRED (`value` is `string | string[]`), so an absent or
+ * wrongly-typed cell is a draft that will be rejected at publish. Say so in
+ * place rather than rendering an empty cell that reads as "fine" — the whole
+ * point of this preview is to surface the mistake while the author is still
+ * looking at it.
+ */
+function renderCell(v: unknown): React.ReactNode {
+  if (typeof v === 'string' && v !== '') return v;
+  if (Array.isArray(v) && v.every((x) => typeof x === 'string')) {
+    return (v as string[]).join(', ');
+  }
+  return (
+    <span className="text-amber-700" title="Required by SkillTriggerConditionSchema — this draft will be rejected on save.">
+      missing
+    </span>
   );
 }
 

--- a/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.test.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ValidationPreview vs `ValidationRuleSchema` (objectui#3281, folded into #3275).
+ *
+ * The union has exactly six members — `script`, `state_machine`, `format`,
+ * `cross_field`, `json_schema`, `conditional`. This preview drew nine, read two
+ * keys that have never existed on any branch, and had no branch at all for one
+ * member that does. Every one of those is the AGENTS.md #0.1 tolerant consumer:
+ *
+ *  • `condition ?? expression` — `expression` is not a retired key, it was
+ *    never a key. The fallback is precisely why a bogus `expression` sat
+ *    unnoticed in the console sample (objectui#3276): the preview rendered
+ *    either spelling, so nothing surfaced the mistake, while a real publish
+ *    strips the key and the rule silently enforces nothing.
+ *  • `pattern ?? regex` — same shape; only `regex` is declared.
+ *  • `unique` / `async` / `custom` — removed by one paragraph of
+ *    `validation.zod.ts` ("Deliberately NOT validation rules"), because a rule
+ *    must be a deterministic, synchronous, side-effect-free predicate over one
+ *    record. Uniqueness is a DB unique index (a SELECT-then-INSERT rule is
+ *    racy — TOCTOU). Drawing an editor for them advertised a rule type that
+ *    cannot be saved.
+ *  • `conditional` read `condition`; the branch's predicate is `when`, so a
+ *    VALID conditional rule displayed "No expression set".
+ *  • `json_schema` had no branch, so a VALID rule displayed "Unknown rule type".
+ *
+ * `object` is deliberately still read: `anchors.ts` registers a standalone
+ * `validation` resource matched by `anchorByField('object')`, so a standalone
+ * rule genuinely carries it. Not every key the union omits is residue.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ValidationPreview } from './ValidationPreview';
+
+afterEach(cleanup);
+
+const BASE = {
+  name: 'amount_positive',
+  label: 'Amount Must Be Positive',
+  message: 'Order amount must be greater than zero.',
+  severity: 'error',
+  active: true,
+  events: ['insert', 'update'],
+  priority: 10,
+} satisfies Record<string, unknown>;
+
+function renderPreview(draft: Record<string, unknown>) {
+  return render(
+    <ValidationPreview
+      {...({ type: 'validation', name: 'amount_positive' } as never)}
+      draft={draft}
+    />,
+  );
+}
+
+describe('ValidationPreview renders the condition of a spec-valid script rule', () => {
+  it('renders `condition` — the predicate that FAILS the record when true', () => {
+    renderPreview({ ...BASE, type: 'script', condition: 'record.amount <= 0' });
+    expect(screen.getByText('Condition')).toBeTruthy();
+    expect(screen.getByText('record.amount <= 0')).toBeTruthy();
+  });
+
+  it('renders a CEL object form (`{ source }`) as its source text', () => {
+    renderPreview({ ...BASE, type: 'script', condition: { source: 'record.amount <= 0' } });
+    expect(screen.getByText('record.amount <= 0')).toBeTruthy();
+  });
+
+  it('does NOT fall back to `expression` — a key no branch has ever declared', () => {
+    // The exact draft objectui#3276 found in the sample: a real `condition`
+    // plus a bogus `expression`. Only the declared key may render.
+    renderPreview({ ...BASE, type: 'script', expression: 'amount > 0' });
+    expect(screen.queryByText('amount > 0')).toBeNull();
+    expect(screen.getByText(/no expression set/i)).toBeTruthy();
+  });
+});
+
+describe('ValidationPreview renders removed rule types as a redirect, not an editor', () => {
+  it('tells a `unique` draft that uniqueness is an index, and draws no fields editor', () => {
+    renderPreview({
+      ...BASE,
+      type: 'unique',
+      fields: ['order_number'],
+      scope: 'record.org_id',
+    });
+    expect(screen.getByText(/cannot be saved/i)).toBeTruthy();
+    expect(screen.getByText(/unique.*index/i)).toBeTruthy();
+    // The old editor is gone: no field chips, no Scope block.
+    expect(screen.queryByText('order_number')).toBeNull();
+    expect(screen.queryByText('Scope')).toBeNull();
+    expect(screen.queryByText('record.org_id')).toBeNull();
+  });
+
+  it('redirects `async` to the form layer and renders no endpoint', () => {
+    renderPreview({ ...BASE, type: 'async', endpoint: 'https://api.example.com/check' });
+    expect(screen.queryByText('https://api.example.com/check')).toBeNull();
+    expect(screen.getByText(/form-layer concern/i)).toBeTruthy();
+  });
+
+  it('redirects `custom` to a lifecycle hook and renders no handler', () => {
+    renderPreview({ ...BASE, type: 'custom', handler: 'validateOrder' });
+    expect(screen.queryByText('validateOrder')).toBeNull();
+    expect(screen.getByText(/beforeInsert/i)).toBeTruthy();
+  });
+});
+
+describe('ValidationPreview renders the branches it previously got wrong', () => {
+  it('reads `when` (not `condition`) on a conditional rule and shows the nested rule', () => {
+    renderPreview({
+      ...BASE,
+      type: 'conditional',
+      when: "record.type == 'enterprise'",
+      then: {
+        type: 'script',
+        name: 'enterprise_min_amount',
+        condition: 'record.amount < 1000',
+        message: 'Enterprise orders start at 1000.',
+      },
+    });
+    expect(screen.getByText('When')).toBeTruthy();
+    expect(screen.getByText("record.type == 'enterprise'")).toBeTruthy();
+    expect(screen.getByText('Then apply')).toBeTruthy();
+    expect(screen.getByText('enterprise_min_amount')).toBeTruthy();
+    expect(screen.getByText('Enterprise orders start at 1000.')).toBeTruthy();
+  });
+
+  it('renders a json_schema rule instead of "Unknown rule type"', () => {
+    renderPreview({
+      ...BASE,
+      type: 'json_schema',
+      field: 'payload',
+      schema: { type: 'object', required: ['sku'] },
+    });
+    expect(screen.queryByText(/unknown rule type/i)).toBeNull();
+    expect(screen.getByText('JSON Schema on payload')).toBeTruthy();
+    expect(screen.getByText(/"required"/)).toBeTruthy();
+  });
+
+  it('reads `regex` and not `pattern` on a format rule', () => {
+    renderPreview({ ...BASE, type: 'format', field: 'email', regex: '^.+@.+$' });
+    expect(screen.getByText('^.+@.+$')).toBeTruthy();
+    cleanup();
+    // `pattern` is not a key — a rule carrying only it has no regex at all.
+    renderPreview({ ...BASE, type: 'format', field: 'email', pattern: '^.+@.+$' });
+    expect(screen.queryByText('^.+@.+$')).toBeNull();
+    expect(screen.getByText(/no format or regex set/i)).toBeTruthy();
+  });
+
+  it('shows a state machine transitions matrix and its initial states', () => {
+    renderPreview({
+      ...BASE,
+      type: 'state_machine',
+      field: 'status',
+      transitions: { draft: ['open'], open: ['closed'] },
+      initialStates: ['draft'],
+    });
+    expect(screen.getByText('Transitions on status')).toBeTruthy();
+    expect(screen.getByText('May be created in')).toBeTruthy();
+  });
+
+  it('keeps the cross_field branch rendering fields and condition', () => {
+    renderPreview({
+      ...BASE,
+      type: 'cross_field',
+      fields: ['start_date', 'end_date'],
+      condition: 'record.end_date < record.start_date',
+    });
+    expect(screen.getByText('start_date')).toBeTruthy();
+    expect(screen.getByText('record.end_date < record.start_date')).toBeTruthy();
+  });
+});
+
+describe('ValidationPreview still renders the shared envelope', () => {
+  it('keeps label, name, severity, message and the object pill', () => {
+    // `object` is NOT residue — standalone validations are anchored by it.
+    renderPreview({ ...BASE, type: 'script', object: 'sales_order', condition: 'record.amount <= 0' });
+    expect(screen.getByText('Amount Must Be Positive')).toBeTruthy();
+    expect(screen.getByText('amount_positive')).toBeTruthy();
+    expect(screen.getByText('Order amount must be greater than zero.')).toBeTruthy();
+    expect(screen.getByText('object: sales_order')).toBeTruthy();
+    expect(screen.getByText('error')).toBeTruthy();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.tsx
@@ -3,35 +3,54 @@
 /**
  * ValidationPreview — read-only summary of a Validation rule draft.
  *
- * Validation is a discriminated union by `type`:
- *   script · unique · state_machine · format · cross_field · async ·
- *   custom · conditional · plus the schema-style JSONValidationSchema.
- *
- * The preview shows a shared envelope (target, message, severity,
- * active, events, priority, tags) and then a type-specific body so
- * each rule shape gets the right vocabulary instead of a generic
- * "field dump":
+ * `ValidationRuleSchema` is a discriminated union on `type` with exactly
+ * SIX members, each rendered with its own vocabulary rather than a
+ * generic "field dump":
  *
  *   • script         → CEL condition block
- *   • unique         → unique fields + scope (CEL)
- *   • state_machine  → from→to transitions matrix
+ *   • state_machine  → from→to transitions matrix (+ initial states)
  *   • format         → regex / built-in format name
  *   • cross_field    → involved fields + cross-field condition
- *   • async          → endpoint URL + timeout
- *   • custom         → handler reference
- *   • conditional    → predicate + nested rule reference
+ *   • json_schema    → target field + JSON Schema
+ *   • conditional    → `when` predicate + nested `then` / `otherwise`
  *
- * Severity drives the accent color (error=red, warning=amber,
- * info=blue) the same way runtime UI surfaces it.
+ * The shared envelope (target, message, severity, active, events,
+ * priority, tags) is rendered above the type body. Severity drives the
+ * accent color (error=red, warning=amber, info=blue) the same way
+ * runtime UI surfaces it.
+ *
+ * WHAT THIS FILE DELIBERATELY NO LONGER RENDERS (objectui#3275/#3281).
+ * Three branches — `unique`, `async`, `custom` — were removed from the
+ * spec by one paragraph of `validation.zod.ts` ("Deliberately NOT
+ * validation rules"): a rule is a deterministic, synchronous,
+ * side-effect-free predicate over one record, and none of the three can
+ * be. Uniqueness is a DB unique index (a SELECT-then-INSERT rule is
+ * racy — TOCTOU); async/remote validation is a form-layer concern and an
+ * SSRF hazard on the write path; a custom handler is a `beforeInsert` /
+ * `beforeUpdate` lifecycle hook. Drawing those editors taught authors a
+ * rule type that can never be saved, so each now redirects to the layer
+ * that does the job correctly.
+ *
+ * Two alias fallbacks went with them: `condition ?? expression` and
+ * `pattern ?? regex`. Neither `expression` nor `pattern` has EVER been a
+ * key on any branch — they are not even retired keys, which would at
+ * least have been legal once. `expression` is exactly why a bogus key sat
+ * unnoticed in the console sample for so long (objectui#3276): the
+ * preview rendered either spelling, so nothing ever surfaced the
+ * mistake, while a publish strips the key and the rule silently does
+ * nothing. That is the second de-facto contract AGENTS.md #0.1 forbids.
+ *
+ * `object` is NOT residue and stays: `anchors.ts` registers a standalone
+ * `validation` resource matched by `anchorByField('object')`, so a
+ * standalone rule really does carry it.
  */
 
 import * as React from 'react';
 import {
   AlertTriangle,
   ArrowRight,
+  Braces,
   Code2,
-  Fingerprint,
-  Globe2,
   Info,
   Power,
   Regex,
@@ -168,37 +187,69 @@ export function ValidationPreview({ name, draft }: MetadataPreviewProps) {
   );
 }
 
+/**
+ * The three rule types the spec removed, each with the layer that owns
+ * the job instead. Rendered as a redirect, not as an editor: an author
+ * looking at a `unique` draft needs to know where uniqueness actually
+ * lives, not a prettier view of a rule that cannot be saved.
+ */
+const REMOVED_TYPES: Record<string, string> = {
+  unique:
+    'Uniqueness is a unique INDEX, not a validation rule: declare it on the object as '
+    + '`indexes: [{ fields: [...], unique: true }]` (or `unique: true` on the field). A '
+    + 'SELECT-then-INSERT rule is inherently racy (TOCTOU); a database constraint is not.',
+  async:
+    'Remote/async validation is a form-layer concern — on the server write path it is an '
+    + 'SSRF and latency hazard. Keep it in the form, or enforce the underlying invariant '
+    + 'with a unique index or a lifecycle hook.',
+  custom:
+    'Arbitrary validation code belongs in a `beforeInsert` / `beforeUpdate` lifecycle '
+    + 'hook — the typed, supported extension point.',
+};
+
 function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
+  const removed = REMOVED_TYPES[type];
+  if (removed) {
+    return (
+      <Section title="Not a validation rule" icon={ShieldAlert}>
+        <div className="rounded border border-amber-200 bg-amber-50 p-2.5 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+          <div className="font-medium">
+            <code className="font-mono">{type}</code> was removed from ValidationRuleSchema — this
+            rule cannot be saved.
+          </div>
+          <div className="mt-1">{removed}</div>
+        </div>
+      </Section>
+    );
+  }
+
   switch (type) {
     case 'script':
-    case 'conditional':
       return (
         <Section title="Condition" icon={Code2}>
-          <CelBlock value={celText(d.condition) ?? celText(d.expression)} />
+          {/* `condition` only. A CEL predicate that FAILS the record when
+              TRUE — never `expression`, which no branch has ever declared. */}
+          <CelBlock value={celText(d.condition)} />
         </Section>
       );
 
-    case 'unique': {
-      const fields = Array.isArray(d.fields) ? (d.fields as string[]) : [];
-      const scope = celText(d.scope) ?? celText(d.where);
+    case 'conditional': {
+      // `when` gates a nested `then` (and optional `otherwise`) — this used
+      // to be lumped in with `script` and read `condition`, a key the branch
+      // does not have, so a valid conditional rule showed "No expression set".
+      const nested = d.then as Record<string, unknown> | undefined;
+      const otherwise = d.otherwise as Record<string, unknown> | undefined;
       return (
         <>
-          <Section title={`Unique on ${fields.length} field${fields.length === 1 ? '' : 's'}`} icon={Fingerprint}>
-            <div className="flex flex-wrap gap-1">
-              {fields.length === 0 ? (
-                <span className="text-xs text-amber-700 dark:text-amber-400">no fields set</span>
-              ) : (
-                fields.map((f) => (
-                  <span key={f} className="rounded border bg-muted/40 px-1.5 py-0.5 text-[11px] font-mono">
-                    {f}
-                  </span>
-                ))
-              )}
-            </div>
+          <Section title="When" icon={Code2}>
+            <CelBlock value={celText(d.when)} />
           </Section>
-          {scope && (
-            <Section title="Scope" icon={Sigma}>
-              <CelBlock value={scope} />
+          <Section title="Then apply" icon={ShieldAlert}>
+            <NestedRule rule={nested} emptyHint="No nested rule set — this rule enforces nothing." />
+          </Section>
+          {otherwise && (
+            <Section title="Otherwise apply" icon={ShieldAlert}>
+              <NestedRule rule={otherwise} emptyHint="—" />
             </Section>
           )}
         </>
@@ -213,32 +264,51 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
           : {};
       const entries = Object.entries(transitionMap);
       const field = d.field as string | undefined;
+      const initialStates = Array.isArray(d.initialStates) ? (d.initialStates as string[]) : [];
       return (
-        <Section title={`Transitions${field ? ` on ${field}` : ''}`} icon={Workflow}>
-          {entries.length === 0 ? (
-            <div className="text-xs text-amber-700 dark:text-amber-400">No transitions declared.</div>
-          ) : (
-            <ul className="rounded border bg-background divide-y text-xs">
-              {entries.map(([from, tos]) => (
-                <li key={from} className="flex items-center gap-2 px-2.5 py-1.5">
-                  <span className="font-mono">{from}</span>
-                  <ArrowRight className="h-3 w-3 text-muted-foreground" />
-                  <span className="font-mono text-emerald-700 dark:text-emerald-400">
-                    {Array.isArray(tos) && tos.length > 0 ? tos.join(' | ') : '∅ (dead-end)'}
+        <>
+          <Section title={`Transitions${field ? ` on ${field}` : ''}`} icon={Workflow}>
+            {entries.length === 0 ? (
+              <div className="text-xs text-amber-700 dark:text-amber-400">No transitions declared.</div>
+            ) : (
+              <ul className="rounded border bg-background divide-y text-xs">
+                {entries.map(([from, tos]) => (
+                  <li key={from} className="flex items-center gap-2 px-2.5 py-1.5">
+                    <span className="font-mono">{from}</span>
+                    <ArrowRight className="h-3 w-3 text-muted-foreground" />
+                    <span className="font-mono text-emerald-700 dark:text-emerald-400">
+                      {Array.isArray(tos) && tos.length > 0 ? tos.join(' | ') : '∅ (dead-end)'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+          {/* `initialStates` gates which states a record may be CREATED in —
+              `transitions` only governs UPDATE, so without this a record can
+              be born mid-flow (objectstack#3165). */}
+          {initialStates.length > 0 && (
+            <Section title="May be created in" icon={Sigma}>
+              <div className="flex flex-wrap gap-1">
+                {initialStates.map((s) => (
+                  <span key={s} className="rounded border bg-muted/40 px-1.5 py-0.5 text-[11px] font-mono">
+                    {s}
                   </span>
-                </li>
-              ))}
-            </ul>
+                ))}
+              </div>
+            </Section>
           )}
-        </Section>
+        </>
       );
     }
 
     case 'format': {
-      const pattern = (d.pattern as string | undefined) ?? (d.regex as string | undefined);
+      // `regex` only — `pattern` is not a key on this branch (or any other).
+      const regex = d.regex as string | undefined;
       const format = d.format as string | undefined;
+      const field = d.field as string | undefined;
       return (
-        <Section title="Format" icon={Regex}>
+        <Section title={`Format${field ? ` on ${field}` : ''}`} icon={Regex}>
           <div className="rounded border bg-background p-2.5 text-xs space-y-1">
             {format && (
               <div>
@@ -246,13 +316,13 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
                 <code className="font-mono">{format}</code>
               </div>
             )}
-            {pattern && (
+            {regex && (
               <div>
-                <span className="text-muted-foreground">Pattern:</span>{' '}
-                <code className="font-mono break-all">{pattern}</code>
+                <span className="text-muted-foreground">Regex:</span>{' '}
+                <code className="font-mono break-all">{regex}</code>
               </div>
             )}
-            {!format && !pattern && <span className="text-amber-700 dark:text-amber-400">No format or regex set.</span>}
+            {!format && !regex && <span className="text-amber-700 dark:text-amber-400">No format or regex set.</span>}
           </div>
         </Section>
       );
@@ -280,32 +350,23 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
       );
     }
 
-    case 'async': {
-      const endpoint = (d.endpoint as string | undefined) ?? (d.url as string | undefined);
-      const timeout = d.timeoutMs as number | undefined;
-      const method = (d.method as string | undefined) ?? 'POST';
+    case 'json_schema': {
+      // The sixth union member. It had no branch at all, so a spec-valid
+      // json_schema rule fell through to "Unknown rule type" — the inverse
+      // of the same bug: valid metadata rendered as broken.
+      const field = d.field as string | undefined;
+      const schema = d.schema;
+      const json =
+        schema && typeof schema === 'object' ? JSON.stringify(schema, null, 2) : undefined;
       return (
-        <Section title="Async endpoint" icon={Globe2}>
-          <div className="rounded border bg-background p-2.5 text-xs space-y-1">
-            <div className="flex items-center gap-1.5">
-              <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono">{method}</span>
-              <code className="font-mono break-all">{endpoint ?? '—'}</code>
-            </div>
-            {timeout != null && (
-              <div className="text-muted-foreground">timeout: {timeout}ms</div>
-            )}
-          </div>
-        </Section>
-      );
-    }
-
-    case 'custom': {
-      const handler = (d.handler as string | undefined) ?? (d.function as string | undefined);
-      return (
-        <Section title="Custom handler" icon={Code2}>
-          <div className="rounded border bg-background px-2.5 py-1.5 text-xs">
-            {handler ? <code className="font-mono break-all">{handler}</code> : <span className="text-amber-700 dark:text-amber-400">No handler set.</span>}
-          </div>
+        <Section title={`JSON Schema${field ? ` on ${field}` : ''}`} icon={Braces}>
+          {json ? (
+            <pre className="m-0 rounded border bg-background p-2.5 text-xs font-mono overflow-auto max-h-[240px]">
+              {json}
+            </pre>
+          ) : (
+            <div className="text-xs text-amber-700 dark:text-amber-400">No JSON Schema set.</div>
+          )}
         </Section>
       );
     }
@@ -319,6 +380,45 @@ function TypeBody({ type, d }: { type: string; d: Record<string, unknown> }) {
         </Section>
       );
   }
+}
+
+/**
+ * A `conditional` rule's nested `then` / `otherwise` — itself a full
+ * ValidationRule. Summarised (type + message + its own predicate) rather
+ * than recursed, so a deeply nested rule cannot blow the preview up.
+ */
+function NestedRule({
+  rule,
+  emptyHint,
+}: {
+  rule: Record<string, unknown> | undefined;
+  emptyHint: string;
+}) {
+  if (!rule || typeof rule !== 'object') {
+    return <div className="text-xs text-amber-700 dark:text-amber-400">{emptyHint}</div>;
+  }
+  const nestedType = String(rule.type ?? '');
+  const predicate = celText(rule.condition) ?? celText(rule.when);
+  return (
+    <div className="rounded border bg-background p-2.5 text-xs space-y-1">
+      <div className="flex flex-wrap items-baseline gap-x-2">
+        <span className="rounded border bg-muted/40 px-1.5 py-0.5 text-[10px] font-mono">
+          {nestedType || 'no type'}
+        </span>
+        {typeof rule.name === 'string' && (
+          <span className="font-mono text-[10px] text-muted-foreground">{rule.name}</span>
+        )}
+      </div>
+      {typeof rule.message === 'string' && rule.message && (
+        <div className="text-foreground">{rule.message}</div>
+      )}
+      {predicate && (
+        <pre className="m-0 rounded border bg-muted/30 p-2 font-mono whitespace-pre-wrap break-words">
+          {predicate}
+        </pre>
+      )}
+    </div>
+  );
 }
 
 function CelBlock({ value }: { value: string | undefined }) {


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3275
Fixes objectstack-ai/objectui#3281

预览与样例此前是「一起错」才看起来正常。objectui#3266 把样例改对之后,画廊**反而少画了东西** —— 因为这些预览读的键 spec 现在明确拒收。本 PR 是那件事的渲染器另一半,做法照抄 objectui#3236 / PR #3258 对 `ToolPreview` 的同型修复。

预览渲染一个保存时会被拒的键,等于告诉作者「这样写是对的」,直到发布才被打脸 —— 对 AI 生成的元数据,这正是过期键藏身并扩散的地方。所以下面每一处读取都是**删掉**,而不是留个兜底(AGENTS.md #0.1)。

## 浏览器实测 before → after

方法与 #3266 相同:`apps/console` 预览画廊 + `?only=< type >` 隔离单个设计器,Playwright headless 抓取。**after 一次,把改动 `git stash` 后再抓一次 before**,所以下表是量出来的,不是推出来的。

| 设计器 | BEFORE(改动 stash 掉) | AFTER(本 PR) |
|---|---|---|
| **app** | `Landing: /` | `Home: home → Home`(id + 它选中的条目) |
| **app** | `Dashboard` 徽标 = `item` | `Dashboard` 徽标 = `dashboard` ✅ #3266 记录的那条 |
| **app** | `Docs` 徽标 = `link` | `Docs` 徽标 = `url`(spec 词汇) |
| **app** | 每项**无**目标行 | `crm_welcome` / `account` / `sales_order` / `sales_overview` / `https://docs.example.com` ✅ 路径行回来了 |
| **agent** | `TOOLS / No direct tools (skills can provide them)` 空态 | TOOLS 区块整体消失,改为一行说明:tools 来自已挂载的 skills |
| **skill** | `TRIGGER CONDITIONS (1)` → `COND \| sales_order` | `FIELD / OPERATOR / VALUE` → `objectName / eq / sales_order` ✅ |
| **datasource** | **没有** CAPABILITIES 区块 | `CAPABILITIES: readOnly, queryAggregations` ✅ #3266 记录的那条 |
| **validation** | `CONDITION: amount > 0` | 同上(无变化) |

> validation 这行**无差异是符合预期的**:当前样例带的是合法的 `condition`,而 `?? expression` 回退对它是死代码 —— 这恰恰是单子里说的「预览照样画得出来,于是没人发现 `expression` 是假的」。样例侧属 `apps/console`(#3276 的 scope fence),本 PR 不动;该分支的行为由单测覆盖。

内容与旧输出不同是正常的 —— 它现在来自 spec 合法的键;判据是**合规草稿渲染出有内容的区块,而不是空区块**。

## 改了什么

**删掉的退役键读取**(都是 `retiredKey()` 墓碑,按名字被拒):`agent.tools`(objectstack#3894,agent 能碰到的 tool 就是它 skills 声明的那些,ADR-0064)、`agent.knowledge`(objectstack#3896,从不 scope 检索)、`skill.triggerPhrases`(objectstack#3896,phrases 从未与用户消息匹配过)。

**`AppPreview` / `AppNavCanvas`** —— `AppSchema.navigation` 是按 `type` 的判别联合且每支 `.strict()`。两处都无视了判别键:kind 靠 `it.object` / `it.dashboard` 猜,路由靠 `it.path ?? it.href ?? it.route ?? it.url`,landing 靠 `landingRoute ?? landing ?? defaultRoute ?? '/'`。这些**一个都不是键**(`landing` 已被 objectstack#4001 移除),所以读法是完全反的。现在:`type` 即徽标;目标读各分支自己的键;路由交给 `resolveHref` —— shell 自己的 nav → URL 映射(`NavigationRenderer` 写明它是唯一真源,`useNavPins` / `SearchResultsPage` 已在共用),所以预览里的链接就是运行时会走的链接。`homePageId` 按它本来的样子渲染成 nav item 的 **id**,并解析出它选中的条目,**绝不当路径画**。

**`DatasourcePreview`** —— `capabilities` 是 `DatasourceCapabilities` 布尔标志**对象**,而预览判的是 `Array.isArray`,正好只对 schema 拒收的旧数组形态亮灯。改为列出置 `true` 的标志。同时删掉 `driver ?? d.type`(schema 的提示就是 `type` → `driver`)与 `isDefault ?? default` 的 default 芯片(路由在 stack 层的 `datasourceMapping` 声明,不在 datasource 上)。

**`SkillPreview`** —— trigger-conditions 表原本在 `cond.type` 栏下读 `cond.expression ?? cond.value`,于是合规条件只显示出 value 一列。改为三列 `field / operator / value`,直接对应 `SkillTriggerConditionSchema`;缺必填格时明说 `missing`,而不是留个看起来「正常」的空格。

**`ValidationPreview`**(#3281,PM 中途并入)—— 画了 9 个规则类型,而联合只有 6 个。`unique` / `async` / `custom` 被 `validation.zod.ts` 同一段话裁掉(规则必须是对单条记录的确定性、同步、无副作用谓词),三者现在各自指向真正负责的那一层(唯一性用 unique **索引** —— SELECT-then-INSERT 天生有 TOCTOU 竞态;async 属表单层;custom 属生命周期钩子)。随之删掉两个别名回退:`condition ?? expression`、`pattern ?? regex` —— `expression` 和 `pattern` **从来不是**任何分支的键。另有两支本来就读错了:`conditional` 读的是 `condition` 而非它的 `when`(合规规则显示「No expression set」,现在还会渲染嵌套的 `then` / `otherwise`),`json_schema` 压根没有分支(合规规则显示「Unknown rule type」)。

## 一个刻意**没有**删的读取

`validation.object` 保留。单子建议「确认没有别的调用方会传 object-scoped 草稿之后删掉」—— 确认结果是**有**:`anchors.ts` 注册了独立的 `validation` 资源,并以 `anchorByField('object')` 匹配,所以独立校验规则确实带这个键。联合没有的键,不等于都是残留。

## 验证

- `pnpm exec vitest run packages/app-shell/` → **264 files / 2272 passed, 1 skipped, 0 failed**
- `pnpm --filter @object-ui/app-shell type-check` → 干净通过(`tsc --noEmit` + typetests)
- `eslint` 改动的 11 个文件 → **0 errors**;warning 18 条,而 `origin/main` 上同样 6 个源文件的基线是 19 条 —— 没有新增 lint 债
- 每个改动的预览按 PR #3258 的 `ToolPreview.test.tsx` 模板补了断言:喂**合规**草稿断言区块渲染出来,喂带**退役键**的陈旧草稿断言不渲染(agent 那条更强:合规草稿与仅多带 `tools`/`knowledge` 的草稿 DOM 完全相同)
- 起的 vite dev server 已按记录的 PID 停掉,端口已释放

## ⚠️ 给维护者的一个上游提示(本 PR 没有据此改动)

本 PR 按**当前 pin 住的** `@objectstack/spec@17.0.0-rc.1` 实现 —— 在那个已发布版本里 `homePageId` 是合法的 `z.string().optional()`,且 objectui 自己的 `AppContent.resolveLandingRoute()` **确实在读它**。

但 objectstack `main`(尚未发布)已用 #4667 / ADR-0049 把 `app.homePageId` 也退役了,墓碑文案写的是「no shell ever read it」—— 这与 `AppContent.tsx:876` 的实际读取相矛盾。等 objectui 升到 spec 17.0.0 正式版时,要动的**不只是**这个预览,还有 `AppContent` 的落地路由解析。已在 `out_of_scope_findings` 记录,未在本 PR 处理(超出 scope fence,且需要维护者对「谁说了算」拍板)。

## 顺带记录(未在本 PR 修)

`AgentPreview` 侧栏读的 `d.permissions` 是合法键;`d.access` 在 spec 里是 `array`,预览未渲染它 —— 不是缺陷,只是没覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa