### PR TITLE
fix(fields,components): 字段 widget 的校验槽位改用 spec 的 `error`,并接上生产者 (#3222)

### DIFF
--- a/.changeset/field-widget-error-slot-follows-spec.md
+++ b/.changeset/field-widget-error-slot-follows-spec.md
@@ -1,0 +1,86 @@
+---
+"@object-ui/fields": minor
+"@object-ui/components": minor
+---
+
+Field widgets are finally told when their field fails validation, and the props
+slot that carries it takes the name the published contract gives it
+(objectui#3222).
+
+**Breaking** for anyone implementing a field widget (see migration below). The
+repo version policy keeps this a `minor` — objectui's major tracks
+`@objectstack`'s — so read the bump as "breaking within objectui".
+
+## The a11y defect this fixes
+
+`@objectstack/spec/ui`'s `FieldWidgetPropsSchema` — the published contract that
+third-party and AI-authored field widgets are written against — has always
+declared `error?: string`. `@object-ui/fields` declared its own slot as
+`errorMessage`. That looked like a naming split; it was worse:
+
+```
+producers of `errorMessage` anywhere in packages/ + apps/ :  0
+reads of `errorMessage` in packages/fields/src            : 15  (7 widgets)
+reads of `props.error`                                    :  0
+```
+
+The slot was dead under BOTH spellings. No host ever passed it: the form
+renderer showed validation text through its own `<FormMessage/>` and never
+forwarded the prop. So `EmailField`, `CurrencyField`, `UrlField`,
+`RichTextField`, `PercentField`, `TextAreaField` and `PhoneField` each computed
+`aria-invalid={!!errorMessage}` from a value that was `undefined` forever —
+**`aria-invalid` had never once been set, and a screen reader was never told
+the field had failed validation.**
+
+Worse than "never set": `<FormControl>` is a Radix `Slot` that hands its child a
+CORRECT `aria-invalid`, but a widget's own attribute is written after the props
+spread, so it wins. Those seven widgets were actively overwriting the right
+answer with `false`.
+
+FROM: `renderFieldComponent` received no validation state, and the widget props
+type declared `errorMessage?: string`, which nothing produced.
+TO: the form renderer passes react-hook-form's `fieldState.error?.message` down
+as `error` when it renders a registered widget, and the props type declares
+`error?: string`. Both ends of the contract are live for the first time; a
+rename alone would only have swapped one dead key for another.
+
+## Migration for widget authors
+
+```diff
+-export function MyField({ value, onChange, field, readonly, errorMessage }: FieldWidgetComponentProps< string >) {
+-  return <Input value={value} aria-invalid={!!errorMessage} />;
++export function MyField({ value, onChange, field, readonly, error }: FieldWidgetComponentProps< string >) {
++  return <Input value={value} aria-invalid={!!error} />;
+```
+
+No alias is kept. `errorMessage` was retained nowhere on purpose — a tolerant
+second spelling is exactly the de-facto second contract AGENTS.md #0.1 forbids,
+and it is what would let a missed call site go quiet again. Because
+objectui#3221 had already removed the type's `[key: string]: any`, every missed
+site is a compile error rather than a silent `any`, so the compiler — not grep
+— validated this rename.
+
+## Responsibilities are split, not duplicated
+
+The widget consumes `error` **only** to drive `aria-invalid` on the control it
+renders (which only it can do — `aria-invalid` has to sit on the input element).
+The message TEXT stays with `<FormMessage/>` in the form renderer. A widget that
+also renders the text double-displays it, and the docs, the agent prompt and the
+tests all now say so.
+
+For the same reason `required` — also declared by the spec, also never delivered
+— is deliberately NOT lowered into widget props: the required marker has exactly
+one author, the renderer's `<FormLabel>`, and giving widgets the flag invites a
+second asterisk. The a11y state a widget could legitimately carry is
+`aria-required`, which needs no contract change at all (`AriaAttributes` is
+already part of the type and widgets already forward it).
+
+Builtin field types are unaffected: they render inside `<FormControl>`, whose
+Slot already supplies `aria-invalid`, so `error` is stripped there rather than
+leaking into the DOM as a stray attribute.
+
+Docs updated to match: `content/docs/guide/plugin-development.md`,
+`skills/objectui/guides/plugin-development.md` and
+`.github/prompts/component.prompt.md` — the last of which additionally used the
+spec's non-generic type alias as a generic (`FieldWidgetProps< number >`) and
+destructured a `mode` prop that exists on neither type.

--- a/.github/prompts/component.prompt.md
+++ b/.github/prompts/component.prompt.md
@@ -16,7 +16,7 @@
 
 2.  **Fields (@object-ui/fields):**
     *   Standard Input/Display widgets (Text, Number, Date, Select).
-    *   Must implement `FieldWidgetProps`.
+    *   Must implement `FieldWidgetComponentProps` (the package's own generic React interface — not the spec's non-generic `FieldWidgetProps` alias; see §2.A).
 
 3.  **Layouts & Patterns (@object-ui/layout):**
     *   Page structures (Sidebar, Header, AppLauncher).
@@ -35,15 +35,22 @@ You will be asked to build components in these 3 standard slots. Refer to `packa
 
 ### A. Field Widgets (`field:*`)
 Responsible for **Input** (Edit Mode) and **Display** (Read Mode) of a specific data type.
-*   **Contract:** Must implement `FieldWidgetProps` (Ref: `src/ui/widget.zod.ts`).
+*   **Contract:** Two layers with the same shape and DIFFERENT names — do not mix them up.
+    *   `FieldWidgetProps` (`@objectstack/spec/ui`, Ref: `src/ui/widget.zod.ts`) is the **declared** contract: a `z.infer` of `FieldWidgetPropsSchema`, so it is a plain **non-generic** type alias. Read it to learn what a widget receives.
+    *   `FieldWidgetComponentProps<T>` (`@object-ui/fields`) is the **implemented** React interface, and the one you actually import and parameterize when writing a widget in this repo.
     ```typescript
-    type FieldWidgetProps<T = any> = {
+    import type { FieldWidgetComponentProps } from '@object-ui/fields';
+
+    type FieldWidgetComponentProps<T = any> = {
       value: T;
       onChange: (val: T) => void;
-      field: FieldSchema; // Config
+      field: FieldMetadata; // Config
       readonly?: boolean;
+      disabled?: boolean;
+      error?: string;       // active validation message — see below
     }
     ```
+    The type is **closed**: a key it does not declare is a compile error, not a silent `any`.
 *   **Required Types (Ref: `src/data/field.zod.ts`):**
     *   **Textual:** `text` (Input), `textarea` (Multi-line), `password`, `email`, `url`, `phone`.
     *   **Rich Content:** `markdown` (Editor), `html` (WYSIWYG), `code` (Monaco/Ace).
@@ -168,24 +175,35 @@ Conversational and Generative UI components.
 ## 2. API Reference & Contracts
 
 ### A. Field Widget Implementation
-**Reference:** `@objectstack/spec` -> `dist/ui/widget.zod.d.ts`
+**Reference:** `packages/fields/src/widgets/types.ts` (implemented props), `@objectstack/spec` -> `dist/ui/widget.zod.d.ts` (declared contract)
+
+Import the **generic** `FieldWidgetComponentProps<T>` from `@object-ui/fields`.
+The spec's `FieldWidgetProps` is a non-generic alias — writing
+`FieldWidgetProps< number >` does not compile. There is no `mode` prop on
+either type; read-mode is `readonly`.
 
 ```typescript
-import { FieldWidgetProps } from '@objectstack/spec/ui';
+import type { FieldWidgetComponentProps } from '@object-ui/fields';
 
-export function RatingField({ 
-  value, 
-  onChange, 
-  field, 
-  mode 
-}: FieldWidgetProps<number>) {
-  
-  if (mode === 'read') {
+export function RatingField({
+  value,
+  onChange,
+  field,
+  readonly,
+  error,
+}: FieldWidgetComponentProps<number>) {
+
+  if (readonly) {
     return <span>{'★'.repeat(value || 0)}</span>;
   }
 
   return (
-    <div className="flex gap-1">
+    // `error` is the ACTIVE VALIDATION MESSAGE, supplied by the form renderer.
+    // Consume it as a boolean signal for a11y and nothing more: the message
+    // text is rendered by `<FormMessage/>` and the required marker by
+    // `<FormLabel>`, both in the form renderer. A widget that also prints the
+    // text double-displays it.
+    <div className="flex gap-1" role="radiogroup" aria-invalid={!!error}>
       {[1, 2, 3, 4, 5].map((star) => (
         <button 
           key={star}
@@ -240,7 +258,7 @@ export const widgetRegistry = {
 
 *   **Statelessness:** Widgets should rely on `props.value` and `props.onChange`. Avoid internal state unless necessary for transient UI interactions (like hover).
 *   **Schema Awareness:** The widget must respect schema options (e.g., `field.required`, `field.readonly`, `field.options`).
-*   **Validation:** Rendering logic should handle `props.errorMessage` gracefully.
+*   **Validation:** `props.error` is the active validation message. Use it for the a11y state (`aria-invalid={!!error}`) and nothing else — the host renders the message text and the required marker, so a widget that renders either shows it twice.
 *   **Accessibility:** Use standard ARIA roles and keyboard navigation (Shadcn UI/Radix primitives recommended).
 
 ---

--- a/content/docs/guide/plugin-development.md
+++ b/content/docs/guide/plugin-development.md
@@ -187,9 +187,29 @@ type FieldWidgetComponentProps<T = any> = {
   readonly?: boolean;
   disabled?: boolean;
   className?: string;
-  errorMessage?: string;
+  error?: string;
 };
 ```
+
+The validation slot is named `error`, matching `FieldWidgetPropsSchema` in
+`@objectstack/spec/ui` — the published contract a widget is written against.
+The form renderer supplies it from the active validation message.
+
+### Who renders what
+
+The widget and the form renderer split validation display, and the split is
+not optional:
+
+| Concern | Owner |
+|---|---|
+| `aria-invalid` on the input | **the widget** — only it renders the input element |
+| the required marker (`*`) | **the form renderer** (`<FormLabel>`) |
+| the message TEXT | **the form renderer** (`<FormMessage/>`) |
+
+So consume `error` as a **boolean signal** — `aria-invalid={!!error}` — and do
+not render the message yourself. The form already prints it below the control;
+a widget that prints it too shows the user the same sentence twice. For the
+same reason `required` is not in the props: the marker has one author.
 
 ### Example: Color Picker Field
 
@@ -205,7 +225,7 @@ export function ColorPickerField({
   field,
   readonly,
   disabled,
-  errorMessage,
+  error,
 }: FieldWidgetComponentProps<string>) {
   if (readonly) {
     return (
@@ -220,26 +240,24 @@ export function ColorPickerField({
   }
 
   return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center gap-2">
-        <input
-          type="color"
-          value={value || '#000000'}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          className="h-8 w-8 cursor-pointer rounded border-0 p-0"
-        />
-        <Input
-          value={value || ''}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={field?.placeholder || '#000000'}
-          disabled={disabled}
-          className="font-mono text-sm"
-        />
-      </div>
-      {errorMessage && (
-        <span className="text-xs text-destructive">{errorMessage}</span>
-      )}
+    <div className="flex items-center gap-2">
+      <input
+        type="color"
+        value={value || '#000000'}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="h-8 w-8 cursor-pointer rounded border-0 p-0"
+      />
+      <Input
+        value={value || ''}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={field?.placeholder || '#000000'}
+        disabled={disabled}
+        className="font-mono text-sm"
+        // The whole job of `error` here: tell assistive tech the field failed.
+        // The message text is rendered by the form, not by this widget.
+        aria-invalid={!!error}
+      />
     </div>
   );
 }

--- a/packages/components/src/renderers/form/__tests__/form-error-delivery.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-error-delivery.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The validation message must actually REACH a registered field widget
+ * (objectui#3222) — the producer half of "declared ≠ delivered", again.
+ *
+ * `@objectstack/spec/ui`'s `FieldWidgetPropsSchema` has declared `error?:
+ * string` on the field-widget props contract for as long as the contract has
+ * been published, and the protocol page teaches widgets to destructure it.
+ * objectui declared its own slot under a different name (`errorMessage`) —
+ * but the measured fact was sharper than a naming split:
+ *
+ *     producers of `errorMessage` anywhere in packages/ + apps/ :  0
+ *     reads of `errorMessage` in packages/fields/src            : 15
+ *     reads of `props.error`                                    :  0
+ *
+ * The slot was dead under BOTH spellings. This renderer showed validation text
+ * through its own `<FormMessage/>` and never forwarded the prop, so seven
+ * widgets computed `aria-invalid={!!errorMessage}` from a permanent
+ * `undefined`: `aria-invalid` was never once set, and a screen reader was
+ * never told the field had failed. Renaming alone would have swapped one dead
+ * key for another, so #3222 landed the rename together with THIS — the
+ * renderer producing `fieldState.error?.message` as `error`.
+ *
+ * Note what a widget must NOT do with it: render the text. `<FormMessage/>`
+ * below the control already owns the message; a widget that prints it too
+ * double-displays it. The widget's whole job here is `aria-invalid`, which has
+ * to live on the input element — and only the widget renders that element.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/**
+ * Stands in for a real field widget (`@object-ui/components` tests never load
+ * `@object-ui/fields`), and mirrors what the seven real ones do: compute
+ * `aria-invalid` from `error`, render no message text of its own.
+ *
+ * It deliberately does NOT spread its leftover props onto the input. That
+ * matters: `<FormControl>` is a Radix `Slot` and hands its child a correct
+ * `aria-invalid` already, so a probe that spread it would go green whether or
+ * not the renderer produced `error` — the assertion has to come from the prop.
+ * (In production the real widgets have the inverse problem: their own
+ * `aria-invalid` is written AFTER the spread, so it OVERRIDES the Slot's — a
+ * widget computing it from a prop nobody passed actively unsets the correct
+ * value. That is the defect this delivery closes.)
+ */
+function ErrorProbe(props: any) {
+  const { error, name, value, onChange } = props;
+  return (
+    <input
+      aria-label={name}
+      data-testid={`probe-${name}`}
+      data-has-error-key={'error' in props ? 'yes' : 'no'}
+      data-error={error === undefined ? 'NONE' : String(error)}
+      aria-invalid={!!error}
+      value={(value as string) ?? ''}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  );
+}
+
+beforeAll(() => {
+  ComponentRegistry.register('probe', ErrorProbe, { namespace: 'field' });
+}, 30000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}, onSubmit?: any) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues,
+        fields,
+        onSubmit: onSubmit ?? (() => {}),
+      }}
+    />,
+  );
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+describe('form renderer — `error` delivery to registered widgets (objectui#3222)', () => {
+  it('a registered widget marks its control aria-invalid when validation fails', async () => {
+    // THE test the issue makes a hard requirement. Before #3222 this asserted
+    // nothing that could ever be true: the prop had no producer, so the probe's
+    // `!!error` was `!!undefined` no matter how badly the field failed.
+    renderForm([{ name: 'title', label: 'Title', type: 'probe', required: true }], { title: '' });
+
+    const probe = screen.getByTestId('probe-title');
+    expect(probe).toHaveAttribute('aria-invalid', 'false');
+
+    submit();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-title')).toHaveAttribute('aria-invalid', 'true');
+    });
+    // …and it is the real message, not a boolean smuggled through — a widget
+    // may want it for `aria-errormessage` or a title attribute.
+    expect(screen.getByTestId('probe-title')).toHaveAttribute('data-error', 'Title is required');
+  });
+
+  it('delivers a field-authored message verbatim, not the generated one', async () => {
+    renderForm(
+      [
+        {
+          name: 'title',
+          label: 'Title',
+          type: 'probe',
+          required: true,
+          validation: { required: 'Give the task a name' },
+        },
+      ],
+      { title: '' },
+    );
+
+    submit();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-title')).toHaveAttribute('data-error', 'Give the task a name');
+    });
+  });
+
+  it('renders the message exactly ONCE — the widget drives a11y, `<FormMessage/>` owns the text', async () => {
+    // Scope item the ruling is explicit about: splitting the responsibility is
+    // the point. If a widget also printed `error`, the user would read the same
+    // sentence twice. The probe keeps it in an attribute, so exactly one node
+    // carries the text.
+    renderForm([{ name: 'title', label: 'Title', type: 'probe', required: true }], { title: '' });
+
+    submit();
+
+    await waitFor(() => expect(screen.getAllByText('Title is required')).toHaveLength(1));
+  });
+
+  it('withdraws the message once the field becomes valid again', async () => {
+    renderForm([{ name: 'title', label: 'Title', type: 'probe', required: true }], { title: '' });
+
+    submit();
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-title')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    fireEvent.change(screen.getByTestId('probe-title'), { target: { value: 'Write the report' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe-title')).toHaveAttribute('aria-invalid', 'false');
+    });
+    expect(screen.getByTestId('probe-title')).toHaveAttribute('data-error', 'NONE');
+  });
+
+  it('always passes the KEY, so a widget can tell "valid" from "not forwarded"', () => {
+    // `emptyHint` (objectui#3231) was lost to a strip, not to a missing
+    // computation — key presence is what distinguishes the two failure modes,
+    // and `stripRegisteredFieldProps` must never start eating this one.
+    renderForm([{ name: 'title', label: 'Title', type: 'probe' }], { title: 'ok' });
+
+    const probe = screen.getByTestId('probe-title');
+    expect(probe).toHaveAttribute('data-has-error-key', 'yes');
+    expect(probe).toHaveAttribute('data-error', 'NONE');
+  });
+});
+
+describe('form renderer — `error` is not leaked to the DOM by the builtin branch', () => {
+  it('a builtin control gets aria-invalid from <FormControl>, and no stray `error` attribute', async () => {
+    // Builtin types render their control directly inside `<FormControl>`, whose
+    // Slot already injects `aria-invalid`/`aria-describedby`. There is no widget
+    // to consume `error` there, so `stripRendererOnlyProps` drops it rather than
+    // spilling `error="Title is required"` into the markup.
+    renderForm([{ name: 'title', label: 'Title', type: 'input', required: true }], { title: '' });
+
+    submit();
+
+    const input = screen.getByLabelText(/title/i);
+    await waitFor(() => expect(input).toHaveAttribute('aria-invalid', 'true'));
+    expect(input).not.toHaveAttribute('error');
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -227,6 +227,13 @@ function stripRendererOnlyProps<T extends Record<string, any>>(props: T): T {
     dependentValues: _dependentValues,
     dependsOn: _dependsOn,
     emptyHint: _emptyHint,
+    // The validation message (objectui#3222) is for REGISTERED widgets, which
+    // need it to put `aria-invalid` on the control they render. The builtin
+    // branch below renders its control directly inside `<FormControl>`, whose
+    // Slot already injects `aria-invalid` / `aria-describedby` — so here the
+    // prop has no reader and would only reach the DOM as a stray `error="…"`
+    // attribute.
+    error: _error,
     ...domProps
   } = props;
 
@@ -1334,7 +1341,7 @@ ComponentRegistry.register('form',
           control={form.control}
           name={name}
           rules={rules}
-          render={({ field: formField }) => (
+          render={({ field: formField, fieldState }) => (
             <FormItem
               className={colSpanClass || undefined}
               data-testid={fieldTestId}
@@ -1381,6 +1388,24 @@ ComponentRegistry.register('form',
                   // form, not read a stale record snapshot. Forwarded to
                   // data-source widgets only (see stripRegisteredFieldProps).
                   dependentValues: ruleRecord,
+                  // The validation slot the widget props contract has declared
+                  // all along and nobody produced (objectui#3222). Spelled
+                  // `error` because that is what `@objectstack/spec/ui`'s
+                  // `FieldWidgetPropsSchema` calls it — the published contract
+                  // third-party / AI-authored widgets are written against.
+                  //
+                  // A widget consumes it for `aria-invalid` ONLY; the message
+                  // TEXT belongs to `<FormMessage/>` below. Both halves matter:
+                  // `aria-invalid` has to sit on the input element, which only
+                  // the widget renders, and `<FormControl>`'s Slot does hand a
+                  // correct `aria-invalid` down — but a widget that computes
+                  // its own from a prop nobody passed OVERRIDES that Slot value
+                  // with `false`. That is how seven widgets ended up never once
+                  // announcing an invalid field.
+                  //
+                  // Undefined when the field is valid, so the key is simply
+                  // absent from the DOM rather than rendering `error=""`.
+                  error: fieldState.error?.message,
                 })}
               </FormControl>
               {description && (
@@ -1714,6 +1739,11 @@ interface RenderFieldProps {
   onChange?: (value: any) => void;
   disabled?: boolean;
   readonly?: boolean;
+  /**
+   * Active validation message, forwarded to registered widgets under the name
+   * `@objectstack/spec/ui`'s `FieldWidgetPropsSchema` gives it (objectui#3222).
+   */
+  error?: string;
   [key: string]: any;
 }
 

--- a/packages/fields/src/__tests__/spec-symbol-batch7.test.ts
+++ b/packages/fields/src/__tests__/spec-symbol-batch7.test.ts
@@ -21,10 +21,10 @@
  *
  *  - `FieldWidgetProps` is now `FieldWidgetComponentProps`. The spec owns that
  *    name for the DECLARED widget-plugin props contract; this package's is the
- *    React interface its widgets implement. The pins record the divergence that
- *    made re-exporting impossible — and, since objectui#3221 closed the type,
- *    that the divergence is now *visible* rather than swallowed by a
- *    `[key: string]: any` index signature.
+ *    React interface its widgets implement. The pins record what still makes
+ *    re-exporting impossible (`field` is the far richer `FieldMetadata` here)
+ *    and, since objectui#3222, what no longer does: the validation slot is the
+ *    spec's `error` on both sides.
  *
  * The other direction — "the spec must not start owning the NEW names" — is not
  * asserted here because `scripts/check-spec-symbol-derivation.mjs` already
@@ -80,26 +80,40 @@ describe('FieldWidgetComponentProps is the RENDERED layer of the spec contract',
     // reason is up for re-triage (the plain name could come back).
     type _SpecIsReal = Assert<Equal<IsAny<SpecFieldWidgetProps>, false>>;
 
-    // The divergence that makes a re-export impossible AND is a live defect
-    // worth naming: the declared contract calls the validation-message slot
-    // `error`; every widget in this package reads `errorMessage`. A widget
-    // written against the spec's declared props renders no message here, and
-    // nothing reports it. Recorded, not fixed, by the rename — objectui#3222.
+    // The validation-message slot no longer diverges. objectui#3161 could only
+    // RECORD that the declared contract called it `error` while every widget
+    // here read `errorMessage`; objectui#3222 resolved it in the direction the
+    // contract points — this package adopted `error`, and the form renderer
+    // started producing it, so the name and the delivery landed together.
+    // Both sides are pinned: the spec still owns the name, and this package
+    // still spells it the same way.
     type _SpecNamesItError = Assert<HasKey<SpecFieldWidgetProps, 'error'>>;
-    type _LocalNamesItErrorMessage = Assert<HasKey<FieldWidgetComponentProps, 'errorMessage'>>;
+    type _LocalNamesItErrorToo = Assert<HasKey<FieldWidgetComponentProps, 'error'>>;
+    type _SameOptionalStringSlot = Assert<
+      Equal<FieldWidgetComponentProps['error'], SpecFieldWidgetProps['error']>
+    >;
+    // The old name is gone, not kept as an alias. An alias would be exactly the
+    // lenient second dialect AGENTS.md #0.1 forbids — and the reason a missed
+    // call site would have gone quiet again.
+    type _OldNameRetired = Assert<Equal<HasKey<FieldWidgetComponentProps, 'errorMessage'>, false>>;
 
     // …and the reason nobody noticed used to sit right here: three pins
     // asserting that `[key: string]: any` was still present, and that
     // `props.required` / `props.error` therefore read as `any`. objectui#3221
     // removed that index signature, so those pins have gone red on purpose and
     // are gone with it. What replaces them is the inverse claim — the type is
-    // now CLOSED, so the two keys the spec declares and this one does not can
-    // finally be reported as missing. That is what makes objectui#3222 (the
-    // `error` / `errorMessage` divergence) decidable by the compiler instead of
-    // by a symbol guard.
+    // now CLOSED, so a key the spec declares and this one does not can finally
+    // be reported as missing. That is what made objectui#3222's rename
+    // decidable by the compiler instead of by a symbol guard.
     type _NoStringIndexSignature = Assert<Equal<Extends<string, keyof FieldWidgetComponentProps>, false>>;
+    // `required` is the one key that stayed behind, and deliberately so
+    // (objectui#3222): the required marker has a single author — the form
+    // renderer's `<FormLabel>` — and lowering the flag into widget props gives
+    // it a second, i.e. the double-display failure that also keeps the
+    // validation TEXT out of the widget. The a11y state a widget could
+    // legitimately carry is `aria-required`, and `AriaAttributes` already
+    // supplies that key with no contract change at all.
     type _RequiredIsAbsent = Assert<Equal<HasKey<FieldWidgetComponentProps, 'required'>, false>>;
-    type _ErrorIsAbsent = Assert<Equal<HasKey<FieldWidgetComponentProps, 'error'>, false>>;
 
     // `data-*` stays open (it is open in HTML too), but as a template-literal
     // key — the distinction that keeps `keyof` finite above. A pin, because

--- a/packages/fields/src/__tests__/validation-feedback.test.tsx
+++ b/packages/fields/src/__tests__/validation-feedback.test.tsx
@@ -10,7 +10,16 @@
  * P3.2 Field Widget Polish - Validation Feedback
  *
  * Tests that field widgets consistently handle validation feedback:
- * errorMessage prop, aria-invalid attribute, and disabled states.
+ * `error` prop, aria-invalid attribute, and disabled states.
+ *
+ * The slot is `error` — the name `@objectstack/spec/ui`'s
+ * `FieldWidgetPropsSchema` gives it — since objectui#3222. These are the
+ * CONSUMER half only: they prove a widget handed a message marks its control
+ * invalid. That was true before #3222 too, under the name `errorMessage`, and
+ * it did not help anyone, because no host ever passed the prop. The PRODUCER
+ * half is `form-error-delivery.test.tsx` in `@object-ui/components` plus
+ * `widget-aria-invalid-e2e.test.tsx` next to this file; a rename alone would
+ * have swapped one dead key for another.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -32,23 +41,23 @@ const noop = vi.fn();
 
 describe('P3.2 Validation Feedback', () => {
   // ---------------------------------------------------------------
-  // aria-invalid on errorMessage
+  // aria-invalid on `error`
   // ---------------------------------------------------------------
   describe('aria-invalid attribute', () => {
-    it('EmailField sets aria-invalid when errorMessage provided', () => {
+    it('EmailField sets aria-invalid when `error` provided', () => {
       render(
         <EmailField
           value=""
           onChange={noop}
           field={{ type: 'email' } as any}
-          errorMessage="Invalid email"
+          error="Invalid email"
         />
       );
       const input = screen.getByRole('textbox');
       expect(input).toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('EmailField does not set aria-invalid without errorMessage', () => {
+    it('EmailField does not set aria-invalid without `error`', () => {
       render(
         <EmailField
           value=""
@@ -60,52 +69,52 @@ describe('P3.2 Validation Feedback', () => {
       expect(input).not.toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('UrlField sets aria-invalid when errorMessage provided', () => {
+    it('UrlField sets aria-invalid when `error` provided', () => {
       render(
         <UrlField
           value=""
           onChange={noop}
           field={{ type: 'url' } as any}
-          errorMessage="Invalid URL"
+          error="Invalid URL"
         />
       );
       const input = screen.getByDisplayValue('');
       expect(input).toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('PhoneField sets aria-invalid when errorMessage provided', () => {
+    it('PhoneField sets aria-invalid when `error` provided', () => {
       render(
         <PhoneField
           value=""
           onChange={noop}
           field={{ type: 'phone' } as any}
-          errorMessage="Invalid phone"
+          error="Invalid phone"
         />
       );
       const input = screen.getByRole('textbox');
       expect(input).toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('TextAreaField sets aria-invalid when errorMessage provided', () => {
+    it('TextAreaField sets aria-invalid when `error` provided', () => {
       render(
         <TextAreaField
           value=""
           onChange={noop}
           field={{ type: 'textarea' } as any}
-          errorMessage="Required"
+          error="Required"
         />
       );
       const textarea = screen.getByRole('textbox');
       expect(textarea).toHaveAttribute('aria-invalid', 'true');
     });
 
-    it('CurrencyField sets aria-invalid when errorMessage provided', () => {
+    it('CurrencyField sets aria-invalid when `error` provided', () => {
       render(
         <CurrencyField
           value={0}
           onChange={noop}
           field={{ type: 'currency' } as any}
-          errorMessage="Must be positive"
+          error="Must be positive"
         />
       );
       const input = screen.getByRole('spinbutton');

--- a/packages/fields/src/__tests__/widget-aria-invalid-e2e.test.tsx
+++ b/packages/fields/src/__tests__/widget-aria-invalid-e2e.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * End-to-end: a REAL widget, inside the REAL form renderer, announces an
+ * invalid field to assistive tech (objectui#3222).
+ *
+ * The two halves of this contract have unit tests of their own — the widgets
+ * mark themselves invalid when handed an `error`
+ * (`validation-feedback.test.tsx`), and the form renderer produces one
+ * (`form-error-delivery.test.tsx` in `@object-ui/components`). Neither alone
+ * would have caught the actual defect, because the defect was precisely that
+ * the two halves never met: the widgets read `errorMessage`, the spec's
+ * published contract said `error`, and NOTHING in `packages/` or `apps/`
+ * produced either. Seven widgets computed `aria-invalid={!!errorMessage}` from
+ * a value that was `undefined` forever, so `aria-invalid` had never once been
+ * set on a failing field.
+ *
+ * So this file joins them: real react-hook-form validation, real widget, one
+ * assertion per widget that the control is `aria-invalid="true"` after the
+ * failure and `"false"` before it. `aria-invalid="false"` up front is the load
+ * bearing half of each pair — `<FormControl>` is a Radix `Slot` that hands its
+ * child a correct `aria-invalid`, and the widget's own attribute is written
+ * AFTER the props spread, so it wins. A widget computing it from a prop nobody
+ * passes does not merely miss the signal, it OVERWRITES the correct one with
+ * `false`.
+ *
+ * The widgets are registered raw rather than through `registerAllFields()`,
+ * which wraps every loader in `React.lazy`: an unbounded module load inside a
+ * bounded `findBy`/`waitFor` window is the repo's known flake generator
+ * (AGENTS.md 测试纪律, objectui#3010). Same component, no Suspense boundary.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { EmailField } from '../widgets/EmailField';
+import { PhoneField } from '../widgets/PhoneField';
+import { UrlField } from '../widgets/UrlField';
+import { TextAreaField } from '../widgets/TextAreaField';
+import { CurrencyField } from '../widgets/CurrencyField';
+import { PercentField } from '../widgets/PercentField';
+import { RichTextField } from '../widgets/RichTextField';
+import { TextField } from '../widgets/TextField';
+
+/** The seven widgets that read the validation slot, by their form-path key. */
+const WIDGETS = [
+  ['email', EmailField],
+  ['phone', PhoneField],
+  ['url', UrlField],
+  ['textarea', TextAreaField],
+  ['currency', CurrencyField],
+  ['percent', PercentField],
+  ['markdown', RichTextField],
+] as const;
+
+beforeAll(() => {
+  for (const [type, Widget] of WIDGETS) {
+    ComponentRegistry.register(type, Widget as any, { namespace: 'field', skipFallback: true });
+  }
+}, 30000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(field: any, defaultValue: unknown) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues: { [field.name]: defaultValue },
+        fields: [field],
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+/**
+ * The control the widget rendered, located through the form row rather than by
+ * role — the seven widgets render `input[type=email|tel|url|number]` and
+ * `textarea` between them, and the point of the assertion is the ATTRIBUTE,
+ * not which element type carries it.
+ */
+function controlOf(name: string): Element {
+  const control = document.querySelector(
+    `[data-field="${name}"] input, [data-field="${name}"] textarea`,
+  );
+  if (!control) throw new Error(`no control rendered for field "${name}"`);
+  return control;
+}
+
+const submit = () => fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+describe('field widgets announce an invalid field to AT (objectui#3222)', () => {
+  // `field:textarea` because the bare `textarea` key is a BUILTIN_FIELD_TYPE in
+  // the form renderer and never reaches the registry — it is the prefixed id
+  // (`mapFieldTypeToFormType`) that resolves to this package's widget.
+  it.each([
+    ['email', 'email', ''],
+    ['phone', 'phone', ''],
+    ['url', 'url', ''],
+    ['field:textarea', 'notes', ''],
+    ['currency', 'amount', null],
+    ['percent', 'ratio', null],
+    ['markdown', 'body', ''],
+  ] as const)(
+    'a required %s field is aria-invalid only AFTER validation fails',
+    async (type, name, emptyValue) => {
+      renderForm({ name, label: name, type, required: true }, emptyValue);
+
+      // Before the submit there is no error, and the widget must say so —
+      // this is the half that a Slot-provided `aria-invalid` cannot fake.
+      expect(controlOf(name)).toHaveAttribute('aria-invalid', 'false');
+
+      submit();
+
+      await waitFor(() => {
+        expect(controlOf(name)).toHaveAttribute('aria-invalid', 'true');
+      });
+    },
+  );
+
+  it('the message itself is rendered once, by the form — not by the widget', async () => {
+    // Responsibility split (the ruling's scope item 3): the widget consumes
+    // `error` for `aria-invalid` ONLY. `<FormMessage/>` owns the text; a widget
+    // that printed it too would show the user the same sentence twice.
+    renderForm({ name: 'email', label: 'Email', type: 'email', required: true }, '');
+
+    submit();
+
+    await waitFor(() => expect(screen.getAllByText('Email is required')).toHaveLength(1));
+    // And the message is NOT inside the control the widget rendered.
+    expect(controlOf('email')).not.toHaveTextContent('Email is required');
+  });
+
+  it('a widget that does NOT read `error` is still marked invalid, by the Slot', async () => {
+    // The counterpart that makes the diagnosis precise: `TextField` never
+    // computed its own `aria-invalid`, so `<FormControl>`'s Slot value reached
+    // its input untouched and it announced invalid fields correctly all along.
+    // Only the seven widgets that DID compute one were broken — they wrote
+    // theirs after the props spread, so `!!undefined` won.
+    //
+    // Pinned because the obvious "cleanup" here is to stop forwarding `error`
+    // to widgets that do not declare a use for it. That cannot be known (a
+    // third-party widget is exactly the case the contract exists for), and
+    // withholding it would recreate declared-≠-delivered one widget at a time.
+    ComponentRegistry.register('plaintext', TextField as any, { namespace: 'field', skipFallback: true });
+    renderForm({ name: 'title', label: 'Title', type: 'plaintext', required: true }, '');
+
+    submit();
+
+    await waitFor(() => expect(controlOf('title')).toHaveAttribute('aria-invalid', 'true'));
+  });
+
+  it('clears the invalid state when the field becomes valid again', async () => {
+    renderForm({ name: 'email', label: 'Email', type: 'email', required: true }, '');
+
+    submit();
+    await waitFor(() => expect(controlOf('email')).toHaveAttribute('aria-invalid', 'true'));
+
+    fireEvent.change(controlOf('email'), { target: { value: 'a@example.com' } });
+
+    await waitFor(() => expect(controlOf('email')).toHaveAttribute('aria-invalid', 'false'));
+  });
+});

--- a/packages/fields/src/__tests__/widget-props-contract.test.tsx
+++ b/packages/fields/src/__tests__/widget-props-contract.test.tsx
@@ -14,8 +14,9 @@
  * one (objectstack#4075). Three consequences, one test each below:
  *
  *  1. a key the type does not declare is a compile error, not a silent `any`
- *     — which is what makes the `error` / `errorMessage` divergence
- *     (objectui#3222) decidable by the compiler at all;
+ *     — which is what let objectui#3222 rename the validation slot to the
+ *     spec's `error` with the compiler, not grep, proving no call site was
+ *     missed;
  *  2. a MISSPELLED prop (`readOnly` for `readonly`) is rejected;
  *  3. the pass-through keys hosts genuinely forward still type-check, and
  *     still reach the rendered control at runtime — closing the type must not
@@ -52,13 +53,15 @@ describe('FieldWidgetComponentProps is closed (objectui#3221)', () => {
   it('rejects keys it does not declare', () => {
     const props = {} as FieldWidgetComponentProps<string>;
 
-    // The spec's `FieldWidgetPropsSchema` declares both; this type declares
-    // neither. Reading them used to give `any` and `undefined` forever.
-    // Whether to ADD them is objectui#3222 — deliberately not decided here.
+    // `required` stays out on purpose (objectui#3222): the required marker has
+    // exactly one author, the form renderer's `<FormLabel>`, and handing the
+    // flag to widgets invites a second one. Its sibling `error` went the other
+    // way — the spec declares it, so the slot below adopted the spec's name and
+    // the form renderer now produces it.
     // @ts-expect-error `required` is not part of this contract
     void props.required;
-    // @ts-expect-error `error` is not part of this contract — this type's slot is `errorMessage`
-    void props.error;
+    const message: string | undefined = props.error;
+    void message;
 
     // …and the class of bug the index signature hid best: a typo.
     // @ts-expect-error the prop is `readonly`, not React's DOM `readOnly`

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -36,7 +36,7 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
   USD: '$',
 };
 
-export function CurrencyField({ value, onChange, field, readonly, errorMessage, className, ...props }: FieldWidgetComponentProps<number>) {
+export function CurrencyField({ value, onChange, field, readonly, error, className, ...props }: FieldWidgetComponentProps<number>) {
   const currencyField = (field || (props as any).schema) as any;
   // Shared precedence: field currency → currencyConfig → tenant default (ADR-0053).
   const { currency: tenantCurrency } = useLocalization();
@@ -87,7 +87,7 @@ export function CurrencyField({ value, onChange, field, readonly, errorMessage, 
         min={typeof currencyField?.min === 'number' ? currencyField.min : undefined}
         max={typeof currencyField?.max === 'number' ? currencyField.max : undefined}
         step={Math.pow(10, -precision).toFixed(precision)}
-        aria-invalid={!!errorMessage}
+        aria-invalid={!!error}
       />
     </div>
   );

--- a/packages/fields/src/widgets/EmailField.tsx
+++ b/packages/fields/src/widgets/EmailField.tsx
@@ -6,7 +6,7 @@ import { FieldWidgetComponentProps } from './types';
  * EmailField - Email address input with mailto link in readonly mode
  * Renders as a clickable mailto link when readonly, standard email input otherwise
  */
-export function EmailField({ value, onChange, field, readonly, errorMessage, ...props }: FieldWidgetComponentProps<string>) {
+export function EmailField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   const config = field || (props as any).schema;
   if (readonly) {
     if (!value) return <EmptyValue />;
@@ -31,7 +31,7 @@ export function EmailField({ value, onChange, field, readonly, errorMessage, ...
       onChange={(e) => onChange(e.target.value)}
       placeholder={config?.placeholder || 'email@example.com'}
       disabled={readonly || domProps.disabled}
-      aria-invalid={!!errorMessage}
+      aria-invalid={!!error}
     />
   );
 }

--- a/packages/fields/src/widgets/PercentField.tsx
+++ b/packages/fields/src/widgets/PercentField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Stores values as decimals (0-1) and displays as percentages (0-100%)
  * Includes a slider for interactive control.
  */
-export function PercentField({ value, onChange, field, readonly, errorMessage, className, ...props }: FieldWidgetComponentProps<number>) {
+export function PercentField({ value, onChange, field, readonly, error, className, ...props }: FieldWidgetComponentProps<number>) {
   const percentField = (field || (props as any).schema) as any;
   const precision = percentField?.precision ?? 2;
 
@@ -72,7 +72,7 @@ export function PercentField({ value, onChange, field, readonly, errorMessage, c
           disabled={readonly || props.disabled}
           className={`pr-8 ${className || ''}`}
           step={Math.pow(10, -precision).toFixed(precision)}
-          aria-invalid={!!errorMessage}
+          aria-invalid={!!error}
         />
         <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
           %

--- a/packages/fields/src/widgets/PhoneField.tsx
+++ b/packages/fields/src/widgets/PhoneField.tsx
@@ -6,7 +6,7 @@ import { FieldWidgetComponentProps } from './types';
  * PhoneField - Telephone number input with tel link in readonly mode
  * Renders as a clickable tel link when readonly, standard phone input otherwise
  */
-export function PhoneField({ value, onChange, field, readonly, errorMessage, ...props }: FieldWidgetComponentProps<string>) {
+export function PhoneField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   const config = field || (props as any).schema;
   if (readonly) {
     if (!value) return <EmptyValue />;
@@ -31,7 +31,7 @@ export function PhoneField({ value, onChange, field, readonly, errorMessage, ...
       onChange={(e) => onChange(e.target.value)}
       placeholder={config?.placeholder || '(555) 123-4567'}
       disabled={readonly || domProps.disabled}
-      aria-invalid={!!errorMessage}
+      aria-invalid={!!error}
     />
   );
 }

--- a/packages/fields/src/widgets/RichTextField.tsx
+++ b/packages/fields/src/widgets/RichTextField.tsx
@@ -8,7 +8,7 @@ import { FieldWidgetComponentProps } from './types';
  * For now, this is a simple textarea. A full implementation would use
  * a rich text editor like TipTap, Lexical, or Slate.
  */
-export function RichTextField({ value, onChange, field, readonly, errorMessage, ...props }: FieldWidgetComponentProps<string>) {
+export function RichTextField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   const { t } = useObjectTranslation();
   if (readonly) {
     return (
@@ -42,7 +42,7 @@ export function RichTextField({ value, onChange, field, readonly, errorMessage, 
         disabled={readonly || props.disabled}
         rows={rows}
         className={`font-mono text-sm ${props.className || ''}`}
-        aria-invalid={!!errorMessage}
+        aria-invalid={!!error}
       />
     </div>
   );

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -37,7 +37,7 @@ import { FieldWidgetComponentProps } from './types';
  * override is ever genuinely needed, declare ONE key on
  * `FieldWidgetComponentProps`, stop stripping it, and have a host pass it.
  */
-export function TextAreaField({ value, onChange, field, readonly, errorMessage, ...props }: FieldWidgetComponentProps<string>) {
+export function TextAreaField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   // Hooks must run before any early return (readonly) to keep hook order stable.
   const [fullscreenOpen, setFullscreenOpen] = useState(false);
   const [draft, setDraft] = useState(value ?? '');
@@ -78,7 +78,7 @@ export function TextAreaField({ value, onChange, field, readonly, errorMessage, 
         disabled={readonly || domProps.disabled}
         rows={rows}
         maxLength={maxLength}
-        aria-invalid={!!errorMessage}
+        aria-invalid={!!error}
         className={domProps.className}
       />
       {showFullscreenButton && (

--- a/packages/fields/src/widgets/UrlField.tsx
+++ b/packages/fields/src/widgets/UrlField.tsx
@@ -6,7 +6,7 @@ import { FieldWidgetComponentProps } from './types';
  * UrlField - URL input with clickable link in readonly mode
  * Validates URLs to only render http/https links for security
  */
-export function UrlField({ value, onChange, field, readonly, errorMessage, ...props }: FieldWidgetComponentProps<string>) {
+export function UrlField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   const config = field || (props as any).schema;
   if (readonly) {
     if (!value) return <EmptyValue />;
@@ -40,7 +40,7 @@ export function UrlField({ value, onChange, field, readonly, errorMessage, ...pr
       onChange={(e) => onChange(e.target.value)}
       placeholder={config?.placeholder || 'https://example.com'}
       disabled={readonly || domProps.disabled}
-      aria-invalid={!!errorMessage}
+      aria-invalid={!!error}
     />
   );
 }

--- a/packages/fields/src/widgets/types.ts
+++ b/packages/fields/src/widgets/types.ts
@@ -14,13 +14,27 @@ import type { DependsOnInput, FieldMetadata } from '@object-ui/types';
  * the widgets in this directory actually implement, against
  * `@object-ui/types`'s much richer `FieldMetadata`.
  *
- * The two are NOT interchangeable, and the divergence is not cosmetic: the
- * spec's contract names the error slot `error`, this one names it
- * `errorMessage`, so a widget written to the spec's declared props renders no
- * validation message here. That divergence is tracked in objectui#3222 and is
- * deliberately NOT resolved here — but it is now *visible*: reading
- * `props.error` or `props.required` off this type is a compile error rather
- * than a silent `any`.
+ * The two are NOT interchangeable, but they no longer disagree on the
+ * validation slot: this type used to call it `errorMessage` while the spec
+ * calls it `error`, so a widget written to the published contract read
+ * `undefined` forever. objectui#3222 resolved that in the direction the
+ * contract points — the slot below IS the spec's `error`, and the form
+ * renderer now produces it (see `error`'s own doc comment). Reading
+ * `props.required` off this type is still a compile error rather than a
+ * silent `any`; that key is deliberately NOT lowered here (see below).
+ *
+ * ## Why `required` is still absent, though the spec declares it
+ *
+ * The required MARKER is drawn exactly once, by the form renderer's
+ * `<FormLabel>` (the `*` with `aria-label="required"`, which the label
+ * association folds into the control's accessible name). Handing `required`
+ * to widgets would give that marker a second possible author, and the very
+ * next AI-written widget draws its own asterisk — the same double-display
+ * failure that keeps the validation TEXT out of the widget below. The a11y
+ * state a widget genuinely could carry is `aria-required` on the input, and
+ * that needs no new key at all: `AriaAttributes` is already part of this type
+ * and every widget already forwards it to its control. Tracked separately;
+ * do not add `required` here to "align" without that decision.
  *
  * ## Why there is no `[key: string]: any` (objectui#3221)
  *
@@ -55,7 +69,22 @@ export type FieldWidgetComponentProps<T = any> = {
   readonly?: boolean;
   disabled?: boolean;
   className?: string;
-  errorMessage?: string;
+  /**
+   * The active validation message for this field, named as
+   * `@objectstack/spec/ui`'s `FieldWidgetPropsSchema` names it (objectui#3222).
+   *
+   * **Producer**: the form renderer, from react-hook-form's
+   * `fieldState.error?.message` (`packages/components/src/renderers/form/
+   * form.tsx`). Before #3222 nothing in the repo produced it under EITHER
+   * spelling, so the seven widgets computing `aria-invalid={!!errorMessage}`
+   * were computing it from a permanent `undefined` — `aria-invalid` was never
+   * once set and a screen reader was never told the field had failed.
+   *
+   * **Consumer**: a widget reads this ONLY to drive `aria-invalid` on the
+   * control it renders. The message TEXT stays with the form renderer's
+   * `<FormMessage/>`; a widget that also renders it double-displays it.
+   */
+  error?: string;
   /**
    * Upload widgets (`file`/`image`) fire this when their in-progress state
    * flips, so a host can block submit until a presigned upload settles. Other

--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -230,20 +230,20 @@ export function ColorField({
   readonly,
   disabled,
   className,
-  errorMessage,
+  error,
 }: FieldWidgetComponentProps<string>) {
   return (
-    <div className={cn('space-y-1', className)}>
-      <Input
-        type="color"
-        value={value || '#000000'}
-        onChange={(e) => onChange(e.target.value)}
-        disabled={readonly || disabled}
-      />
-      {errorMessage && (
-        <p className="text-sm text-destructive">{errorMessage}</p>
-      )}
-    </div>
+    <Input
+      type="color"
+      className={className}
+      value={value || '#000000'}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={readonly || disabled}
+      // `error` drives the a11y state ONLY. The form renderer already prints
+      // the message below the control via `<FormMessage/>`; printing it here
+      // too shows the user the same sentence twice.
+      aria-invalid={!!error}
+    />
   );
 }
 ```
@@ -258,10 +258,24 @@ type FieldWidgetComponentProps<T = any> = {
   readonly?: boolean;           // Read-only mode
   disabled?: boolean;           // HTML disabled state
   className?: string;           // Tailwind CSS classes
-  errorMessage?: string;        // Validation error
-  [key: string]: any;           // Additional forwarded props
+  error?: string;               // Active validation message — drive `aria-invalid` with it
 };
 ```
+
+The slot is named `error` because that is what `FieldWidgetPropsSchema` in
+`@objectstack/spec/ui` — the published widget contract — calls it.
+
+The type is **closed**: it also declares the host plumbing and DOM/ARIA
+pass-through keys the renderer forwards (`schema`, `dataSource`,
+`dependentValues`, `dependsOn`, `emptyHint`, `compact`, `id`, `name`,
+`aria-*`, `data-*`), and nothing else. A key it does not declare is a compile
+error rather than a silent `any`, so a typo like `readOnly` for `readonly` is
+caught at build time instead of being quietly `undefined` at runtime.
+
+Two things are deliberately **not** props, because each has exactly one author
+in the form renderer: the validation message TEXT (`<FormMessage/>`) and the
+required marker (`<FormLabel>`). Rendering either inside a widget
+double-displays it.
 
 ## Package configuration
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3222

按 PM 裁定的**方向 1(objectui 跟随 spec)**,并且是「**改名 + 接上生产者**」两件一起。`packages/spec` 一个字未改。

> 说明:下文所有 JSX 组件名与标签都写成 `< FormControl >` 这样**尖括号后带一个空格**的形式 —— GitHub 的正文消毒器会把 `<` 紧跟字母当成 HTML 标签在**存储时**剥掉。本 PR 正文第一版就因此被吃掉了五处组件名。

## 这修的不是命名,是一个当下就存在的可访问性缺陷

issue 的实测把这单的性质改了:

```
全仓 packages/ + apps/ 中 errorMessage 的生产者:0 处
packages/fields/src 中 errorMessage 的读取  :15 处(7 个 widget)
读 props.error 的代码                        :0 处
```

**这个槽位在两种拼写下都是死的。** 后果比「纸面不一致」严重一档 —— 而且比 issue 里描述的还要糟:

`< FormControl >` 是 Radix `Slot`,它**本来就**把正确的 `aria-invalid` 递给子元素。但 widget 自己的 `aria-invalid={!!errorMessage}` 写在 `{...props}` 展开**之后**,所以它**覆盖**了 Slot 给的正确值。也就是说这 7 个 widget 不只是「没拿到信号」,而是**主动把对的值改写成了 `false`**。

变异验证时抓到的真实 DOM 就是这个现场 —— `aria-describedby` 已经指向了错误消息(表单知道这个字段挂了),而 `aria-invalid` 是 `false`:

```
< input
    aria-describedby="_r_0_-form-item-description _r_0_-form-item-message"
    aria-invalid="false"      ← widget 用 !!undefined 覆盖掉了 Slot 的 true
    type="email" name="email" value="" >
```

反证也成立:`TextField` 从不自己算 `aria-invalid`,Slot 的值原样到达,它**一直是对的**。坏的恰好只有那 7 个自己算的。这条已作为测试钉住。

## 改了什么

1. **表单渲染器开始生产这个 prop**(实质工作):渲染已注册 widget 时把 react-hook-form 的 `fieldState.error?.message` 作为 `error` 传下去。
2. **槽位采用 spec 的名字**:`errorMessage` → `error`,`FieldWidgetComponentProps` + 7 个 widget,**不保留别名**。#3221 已删索引签名,所以漏改点是编译错误 —— 改名的正确性由编译器验证,不是靠 grep。
3. **职责划清**:widget 只用 `error` 驱动 `aria-invalid`;校验文案仍由 `< FormMessage / >` 渲染。有测试钉住「文案只出现一次」。
4. **内置字段类型不接收 `error`**:它们直接渲染在 `< FormControl >` 里,Slot 已给 `aria-invalid`,这里没有读者,传下去只会变成 DOM 上一个多余的 `error="…"` 属性 —— 所以在 `stripRendererOnlyProps` 里剥掉。

## `required`:评估后**维持现状**,不下沉

按要求单独评估,结论是**不接**,理由不是「工作量大」:

- **必填标记今天只有一个作者** —— 渲染器的 `< FormLabel >`(那个带 `aria-label="required"` 的 `*`,label 关联会把它并进控件的可访问名)。把 flag 递给 widget 就等于给这个标记**第二个作者**,下一个 AI 写的 widget 很自然会自己画一个星号 —— 这正是本 PR 里让校验**文案**留在 `< FormMessage / >` 的同一个「双份显示」理由。两处应当同一结论。
- **它也不是拿到 `aria-required` 的必要条件**:`FieldWidgetComponentProps` 已经 `& AriaAttributes`,`aria-required` 本来就是这份契约里已声明、已类型化的键,而且每个 widget 都已经把剩余 props 转发到控件上。也就是说「让 required 状态到达 DOM」**不需要新增任何契约键**,更不需要 48 个 widget 各自记得把布尔翻译成属性。
- 所以「接 `required`」和「拿到 `aria-required`」是两件事,只有后者是 a11y 修复,而后者是一个独立的一行改动,不依赖本 PR。已另开 issue 记录,未指派。

结论:**接了会让契约更差(多一个双份显示的入口),不接也不妨碍真正的 a11y 目标。** 不为对齐而对齐。

## 测试

- `packages/components/src/renderers/form/__tests__/form-error-delivery.test.tsx` —— **生产者**半边(探针 widget 刻意**不**展开剩余 props,否则 Slot 的 `aria-invalid` 会让测试假绿)。
- `packages/fields/src/__tests__/widget-aria-invalid-e2e.test.tsx` —— **端到端**:真表单 + 真 widget + 真 react-hook-form 校验,7 个 widget 各一条「失败后 `aria-invalid` 为 true、失败前为 false」。
- 现有 `validation-feedback` / `widget-props-contract` / `spec-symbol-batch7` 的钉子随之翻面(`_ErrorIsAbsent` 撤销,新增 `_OldNameRetired` 钉住**没有**保留别名)。

**变异验证**(硬要求):撤掉 `error: fieldState.error?.message` 一行后,15 条里 **12 条转红**;恢复后 61 文件 / 615 测试全绿。

## 已知取舍

不读 `error` 的已注册 widget 会把它当剩余 prop 展开到 DOM,失败时留下 `error="T is required"` 属性(实测 **0 条 React 警告**,因为是全小写)。这是有意的:按 widget 类型做白名单会对第三方 widget 重建「声明了但没交付」,而契约恰恰是为它们存在的。同一个 DOM 上早就有更严重的一例(`schema="[object Object]"`),已另开 issue。

## 文档同步

- `content/docs/guide/plugin-development.md` / `skills/objectui/guides/plugin-development.md`:改名 + 新增「谁渲染什么」的职责表;顺带修掉 skill 里仍在教的 `[key: string]: any`(#3221 已删)。
- `.github/prompts/component.prompt.md`:除改名外修掉 issue 点名的另两处 —— 把 spec 的**非泛型**类型别名当泛型用(`FieldWidgetProps< number >`),以及解构一个两边都不存在的 `mode` prop。
- `content/docs/protocol/objectui/widget-contract.mdx` **在 objectstack 仓**,不在本仓 —— 已另开 issue 跟进(它的示例目前教 widget 自己渲染文案,按本 PR 的结论应改成只驱动 `aria-invalid`)。

Changeset:`minor`(按仓库版本策略,objectui 自身的破坏性变更也标 minor),正文含 FROM → TO 迁移指引。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa