### PR TITLE
fix(app-shell)!: converge flow node geometry to spec `FlowNode.position` (#3172)

### DIFF
--- a/.changeset/flow-node-geometry-is-spec-position.md
+++ b/.changeset/flow-node-geometry-is-spec-position.md
@@ -1,0 +1,38 @@
+---
+"@object-ui/app-shell": minor
+---
+
+The flow designer writes node geometry as the spec's `FlowNode.position`, not its
+own `ui: { x, y }` (objectui#3172).
+
+FROM: dragging, adding-at-a-point and insert-on-edge each wrote `node.ui = {x, y}`
+— a fourth-generation local spelling of a concept `@objectstack/spec` has modelled
+as `FlowNode.position` all along. TO: all three write `position: { x, y }`, and the
+canvas migrates on write: a stored flow's legacy `ui` is lifted onto `position` and
+the key removed in the first patch the canvas emits, geometry-related or not.
+
+**This is a behaviour fix, not a rename.** `FlowNodeSchema` has been `.strict()`
+since objectstack#4001, so `ui` is an `unrecognized_keys` error: the live client
+validation flagged the draft on every keystroke and the server rejected the save
+with a 422. In other words, dragging a node made the flow unsavable — the
+convergence is what makes the designer's most basic gesture round-trip again. A
+test now parses `{ …node, ui: {x, y} }` through the spec's own schema and asserts
+the rejection, so the claim is executed rather than argued.
+
+Reading is backwards-compatible: `manualPosition()` prefers `position` and falls
+back to a legacy `ui`, so a flow stored before this change still opens with its
+nodes exactly where the author left them (pinned by a test that lays out both
+spellings and compares the maps). The fallback is a migration path, not a second
+contract — nothing writes `ui`, and the canvas strips it at its input boundary, so
+no patch can re-emit it.
+
+The geometry type is now derived from the spec by reference
+(`FlowNodePosition = NonNullable< SpecFlowNode['position'] >`), and
+`spec-symbol-parity.test.ts` pins the equality in both directions — including that
+both coordinates are required, so a half-position stays unrepresentable. The
+shape-copy in `FlowPreview.tsx` is gone; it reads the canvas's own node type, the
+way it already read the canvas's edge type.
+
+Breaking for anyone reading `node.ui` off a flow draft: after the author's first
+edit the key is gone and the coordinates live under `node.position`. Nothing in
+this repo or the engine read it — it was a designer-local key the schema rejected.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -332,10 +332,15 @@ Salesforce Flow Builder) instead of a flat step list. It is **dependency-free**
 }
 ```
 
-- **Layout** — nodes without a `ui` hint are placed by a deterministic layered
+- **Layout** — nodes without a `position` are placed by a deterministic layered
   auto-layout (cycle-guarded), so a flow always renders cleanly even before any
-  manual positioning. Dragging a node persists its position to `node.ui.{x,y}`;
+  manual positioning. Dragging a node persists its position to the spec's
+  `node.position.{x,y}` (`FlowNode.position` — `x` and `y` both required);
   positions degrade gracefully (they are layout hints, not required data).
+  Flows stored with the designer's retired `node.ui.{x,y}` spelling still render
+  pinned, and the canvas lifts them onto `position` in the first patch it emits
+  (objectui#3172) — `FlowNodeSchema` is `.strict()`, so a draft that still
+  carries `ui` fails client-side validation and is rejected on save with a 422.
 - **Edges** — branch semantics (`condition`, `label`, `isDefault`) are rendered
   as labels on the connectors and preserved when a node is inserted on an edge.
 

--- a/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
+++ b/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
@@ -65,14 +65,24 @@ import { resolve, dirname } from 'node:path';
 
 import { isAggregatedViewContainer } from '../views/metadata-admin/view-item-normalize';
 
+import { FlowNodeSchema } from '@objectstack/spec/automation';
+
 import type { ScreenSpec } from '../views/ScreenView';
 import type { DecisionOutputDef } from '../utils/decisionOutputParams';
 import type { ObjectFieldGroup } from '../views/metadata-admin/previews/object-fields-io';
 import type {
+  FlowNodePosition,
+  FlowDesignerNode,
+} from '../views/metadata-admin/previews/flow-canvas-layout';
+import type {
   ScreenSpec as SpecScreenSpec,
   ScreenFieldSpec as SpecScreenFieldSpec,
 } from '@objectstack/spec/contracts';
-import type { DecisionOutputDef as SpecDecisionOutputDef } from '@objectstack/spec/automation';
+import type {
+  DecisionOutputDef as SpecDecisionOutputDef,
+  FlowNode as SpecFlowNode,
+  FlowNodeParsed as SpecFlowNodeParsed,
+} from '@objectstack/spec/automation';
 
 /** Every name `@objectstack/spec` exports from any subpath — types AND values. */
 function specExportNames(): Set<string> {
@@ -206,9 +216,10 @@ describe('re-exported values are the spec binding itself', () => {
 });
 
 /* -------------------------------------------------------------------------- */
-/* Structural derivations — the three symbols that are neither a plain          */
-/* re-export nor a rename. Each pins its ONE documented divergence, so the      */
-/* divergence cannot silently grow and cannot silently outlive its reason.      */
+/* Structural derivations — the symbols that are neither a plain re-export nor  */
+/* a rename. Each pins its ONE documented divergence, so the divergence cannot  */
+/* silently grow and cannot silently outlive its reason. `FlowNodePosition`     */
+/* (objectui#3172) pins the opposite: a derivation with NO divergence at all.   */
 /* -------------------------------------------------------------------------- */
 
 /**
@@ -279,6 +290,64 @@ describe('DecisionOutputDef is the spec type, with no local divergence left', ()
     >;
 
     expect(true).toBe(true);
+  });
+});
+
+/**
+ * The flow designer's node GEOMETRY is the spec's `FlowNode.position`, taken by
+ * reference (objectui#3172). This is the positive half of the pin above: the
+ * canvas's node type is deliberately NOT the spec's node (it holds mid-edit
+ * state the spec cannot represent), but its geometry has no such excuse — it is
+ * the same object, so it is the same type.
+ *
+ * The runtime half asserts what makes this a behaviour fix and not a rename: the
+ * spec's node schema is `.strict()`, so the designer's retired `ui: { x, y }`
+ * spelling is REJECTED (`unrecognized_keys` in the live client validation, 422
+ * on save). If that ever stops being true, the migration in
+ * `withCanonicalGeometry` is no longer load-bearing and should be re-argued.
+ */
+describe('flow node geometry IS the spec `FlowNode.position` (#3172)', () => {
+  it('is pinned at compile time', () => {
+    type _NotAny = Assert<Equal<IsAny<SpecFlowNode>, false>>;
+    type _LocalNotAny = Assert<Equal<IsAny<FlowNodePosition>, false>>;
+
+    // The local geometry type IS the spec's `position`, not a copy that agrees.
+    type _IsSpecPosition = Assert<Equal<FlowNodePosition, NonNullable<SpecFlowNode['position']>>>;
+    // `position` carries no `.default()`, so authoring and parsed agree — the
+    // z.input/z.infer trap that bites `ObjectFieldGroup` cannot bite here.
+    type _InputEqualsParsed = Assert<
+      Equal<NonNullable<SpecFlowNode['position']>, NonNullable<SpecFlowNodeParsed['position']>>
+    >;
+    // Both coordinates required: a half-position is not representable.
+    type _BothRequired = Assert<Equal<FlowNodePosition, { x: number; y: number }>>;
+    type _HalfIsNotAPosition = Assert<Equal<Extends<{ x: number }, FlowNodePosition>, false>>;
+
+    // …and the designer's node carries exactly that key, optional exactly as the
+    // spec's is (an un-dragged node is auto-laid, in both vocabularies).
+    type _NodeCarriesSpecPosition = Assert<
+      Equal<FlowDesignerNode['position'], SpecFlowNode['position']>
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  it('the spec still spells it `position` with both coordinates required', () => {
+    const base = { id: 'n1', type: 'script', label: 'Do the thing' };
+    expect(FlowNodeSchema.safeParse({ ...base, position: { x: 12, y: 34 } }).success).toBe(true);
+    expect(FlowNodeSchema.safeParse({ ...base, position: { x: 12 } }).success).toBe(false);
+    // No position at all is fine — the designer auto-lays those out.
+    expect(FlowNodeSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('the spec REJECTS the designer’s retired `ui` spelling (the 422 gate)', () => {
+    const parsed = FlowNodeSchema.safeParse({
+      id: 'n1',
+      type: 'script',
+      label: 'Do the thing',
+      ui: { x: 12, y: 34 },
+    });
+    expect(parsed.success).toBe(false);
+    expect(JSON.stringify(parsed.error?.issues)).toContain('unrecognized_keys');
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.test.tsx
@@ -344,3 +344,124 @@ describe('FlowCanvas — nested-node selection on the inline canvas (#2670 Phase
     expect(onSelectNested).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * objectui#3172 — node geometry is the spec's `FlowNode.position`.
+ *
+ * `FlowNodeSchema` is `.strict()` (objectstack#4001), so the designer's retired
+ * `ui: { x, y }` spelling is not a cosmetic divergence: a draft carrying it is
+ * flagged by the live client validation and rejected on save with a 422. These
+ * tests therefore assert BOTH halves of the fix — every write path emits
+ * `position`, and no patch may carry `ui` anywhere, including the legacy nodes a
+ * patch merely passes through (migrate-on-write).
+ *
+ * The compiler cannot help here: `FlowDesignerNode` has an index signature, so
+ * `ui: {…}` type-checks. These assertions are the guard.
+ */
+describe('FlowCanvas — geometry writes are spec-canonical `position` (#3172)', () => {
+  /** A stored flow from before the convergence: node `b` is pinned via `ui`. */
+  const LEGACY_NODES = [
+    { id: 'a', type: 'start', label: 'Start' },
+    { id: 'b', type: 'script', label: 'Do the thing', ui: { x: 400, y: 120 } },
+  ];
+  const LEGACY_EDGES = [{ source: 'a', target: 'b' }];
+
+  const patchedNodes = (onPatch: ReturnType<typeof vi.fn>): Array<Record<string, unknown>> => {
+    expect(onPatch).toHaveBeenCalledTimes(1);
+    const patch = onPatch.mock.calls[0][0] as { nodes?: Array<Record<string, unknown>> };
+    expect(Array.isArray(patch.nodes)).toBe(true);
+    return patch.nodes!;
+  };
+
+  /** No node in the patch may carry the retired key — the strict-schema gate. */
+  const expectNoLegacyKey = (nodes: Array<Record<string, unknown>>) => {
+    for (const n of nodes) expect(Object.keys(n)).not.toContain('ui');
+  };
+
+  const dragCard = (container: HTMLElement, id: string, dx: number, dy: number) => {
+    const card = container.querySelector(`[data-node-id="${id}"] [role="button"]`) as HTMLElement;
+    expect(card).not.toBeNull();
+    fireEvent.pointerDown(card, { button: 0, clientX: 0, clientY: 0 });
+    fireEvent.pointerMove(card, { clientX: dx, clientY: dy });
+    fireEvent.pointerUp(card, { clientX: dx, clientY: dy });
+  };
+
+  const renderCanvas = (
+    onPatch: ReturnType<typeof vi.fn>,
+    { nodes = LEGACY_NODES, selectedId = null }: { nodes?: typeof LEGACY_NODES; selectedId?: string | null } = {},
+  ) =>
+    render(
+      <FlowCanvas
+        nodes={nodes}
+        edges={LEGACY_EDGES}
+        editable
+        designMode
+        selectedId={selectedId}
+        onSelect={() => {}}
+        onPatch={onPatch}
+      />,
+    );
+
+  it('renders a legacy `ui`-pinned node at its stored point (compat read)', () => {
+    const { container } = renderCanvas(vi.fn());
+    const card = container.querySelector('[data-node-id="b"]') as HTMLElement;
+    expect(card.style.left).toBe('400px');
+    expect(card.style.top).toBe('120px');
+  });
+
+  it('drag → the dragged node gets `position`, and no node keeps `ui`', () => {
+    const onPatch = vi.fn();
+    const { container } = renderCanvas(onPatch);
+    dragCard(container, 'b', 30, 20);
+    const nodes = patchedNodes(onPatch);
+    const dragged = nodes.find((n) => n.id === 'b')!;
+    // Dropped 30/20 px from its stored (400, 120) pin — committed as `position`.
+    expect(dragged.position).toEqual({ x: 430, y: 140 });
+    expectNoLegacyKey(nodes);
+  });
+
+  it('drag of ANOTHER node still heals the legacy one (migrate-on-write)', () => {
+    const onPatch = vi.fn();
+    const { container } = renderCanvas(onPatch);
+    dragCard(container, 'a', 25, 25);
+    const nodes = patchedNodes(onPatch);
+    // The untouched legacy node is lifted onto `position` at the same point…
+    expect(nodes.find((n) => n.id === 'b')!.position).toEqual({ x: 400, y: 120 });
+    // …and the dragged node carries a fresh finite position.
+    const moved = nodes.find((n) => n.id === 'a')!.position as { x: number; y: number };
+    expect(Number.isFinite(moved.x) && Number.isFinite(moved.y)).toBe(true);
+    expectNoLegacyKey(nodes);
+  });
+
+  it('insert-on-edge → the new node is pinned via `position`', () => {
+    const onPatch = vi.fn();
+    renderCanvas(onPatch);
+    fireEvent.click(screen.getByRole('button', { name: 'Insert node here' }));
+    const nodes = patchedNodes(onPatch);
+    expect(nodes).toHaveLength(3);
+    const inserted = nodes[2].position as { x: number; y: number };
+    expect(Number.isFinite(inserted.x) && Number.isFinite(inserted.y)).toBe(true);
+    expectNoLegacyKey(nodes);
+  });
+
+  it('append (+ handle) → new node is auto-laid, legacy node still healed', () => {
+    const onPatch = vi.fn();
+    renderCanvas(onPatch);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add connected node' })[0]);
+    const nodes = patchedNodes(onPatch);
+    expect(nodes).toHaveLength(3);
+    // An appended node is deliberately unpinned (the layered layout slots it).
+    expect(nodes[2].position).toBeUndefined();
+    expect(nodes.find((n) => n.id === 'b')!.position).toEqual({ x: 400, y: 120 });
+    expectNoLegacyKey(nodes);
+  });
+
+  it('a patch that is not about geometry at all is still `ui`-free (delete)', () => {
+    const onPatch = vi.fn();
+    renderCanvas(onPatch, { selectedId: 'a' });
+    fireEvent.keyDown(screen.getByRole('application', { name: 'Flow canvas' }), { key: 'Delete' });
+    const nodes = patchedNodes(onPatch);
+    expect(nodes.map((n) => n.id)).toEqual(['b']);
+    expectNoLegacyKey(nodes);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -8,7 +8,8 @@
  * Shadcn cards over an SVG edge layer, laid out top-to-bottom by a
  * deterministic layered algorithm (`flow-canvas-layout`). Authors can:
  *
- *   - drag to reposition nodes (committed to `node.ui = {x,y}` on drop),
+ *   - drag to reposition nodes (committed to the spec's `node.position = {x,y}`
+ *     on drop — objectui#3172),
  *   - add nodes from a palette (toolbar or a node's bottom "+" handle),
  *   - insert a node on an edge ("+" at the edge midpoint splits A→B),
  *   - delete the selected node (Delete/Backspace) with full edge cleanup,
@@ -41,6 +42,7 @@ import {
   edgeKey,
   conditionText,
   extractRegions,
+  withCanonicalGeometry,
   type FlowDesignerNode,
   type FlowDesignerEdge,
   type Point,
@@ -127,7 +129,7 @@ export interface FlowCanvasProps {
 }
 
 export function FlowCanvas({
-  nodes,
+  nodes: storedNodes,
   edges,
   editable,
   designMode,
@@ -148,6 +150,14 @@ export function FlowCanvas({
   onSelectNested,
   onPatch,
 }: FlowCanvasProps) {
+  // objectui#3172 — the ONE geometry boundary: nodes enter the canvas with the
+  // retired `ui: {x,y}` spelling already lifted onto the spec's `position`, so
+  // every patch below is built from canonical nodes and no write path can
+  // re-emit `ui` (the compiler cannot catch that for us — `FlowDesignerNode`
+  // has an index signature). Same reference when nothing needed migrating, so
+  // the memos keyed on `nodes` are unaffected.
+  const nodes = React.useMemo(() => withCanonicalGeometry(storedNodes), [storedNodes]);
+
   const viewportRef = React.useRef<HTMLDivElement>(null);
   const [zoom, setZoom] = React.useState(1);
   const [pan, setPan] = React.useState<Point>({ x: 0, y: 0 });
@@ -243,7 +253,7 @@ export function FlowCanvas({
       const idx = nodes.findIndex((n) => n.id === id);
       if (idx < 0) return;
       const node = nodes[idx];
-      const nextNode: FlowDesignerNode = { ...node, ui: { ...(node.ui ?? {}), x, y } };
+      const nextNode: FlowDesignerNode = { ...node, position: { x, y } };
       onPatch({ nodes: spliceArray(nodes, idx, nextNode) });
     },
     [nodes, onPatch],
@@ -260,7 +270,13 @@ export function FlowCanvas({
       // spaces it horizontally among siblings — pinning it directly under the
       // parent (the old behavior) made every sibling stack on the same spot.
       const at = opts?.at;
-      const newNode: FlowDesignerNode = { id, type, label, ...defaultNodeExtras(type), ...(at ? { ui: { x: at.x, y: at.y } } : {}) };
+      const newNode: FlowDesignerNode = {
+        id,
+        type,
+        label,
+        ...defaultNodeExtras(type),
+        ...(at ? { position: { x: at.x, y: at.y } } : {}),
+      };
       const nextNodes = appendArray(nodes, newNode);
       const patch: Record<string, unknown> = { nodes: nextNodes };
       if (opts?.from) {
@@ -313,7 +329,7 @@ export function FlowCanvas({
         type,
         label: defaultNodeLabel(type, locale),
         ...defaultNodeExtras(type),
-        ui: { x: at.x, y: at.y },
+        position: { x: at.x, y: at.y },
       };
       // A→N inherits the original edge's branch semantics; N→B is plain.
       const firstSegment: FlowDesignerEdge = { ...edge, target: id };

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -37,30 +37,24 @@ import { uniqueId, appendArray } from '../inspectors/_shared';
 import { t as tr, translateFlowMeta } from '../i18n';
 import { FlowCanvas } from './FlowCanvas';
 import { defaultNodeLabel } from './flow-canvas-parts';
-import { edgeKey, type FlowDesignerEdge } from './flow-canvas-layout';
+import { edgeKey, type FlowDesignerEdge, type FlowDesignerNode } from './flow-canvas-layout';
 import { NESTED_NODE_KIND, parseNestedNodeId, encodeNestedNodeId } from '../inspectors/flow-nested-selection';
 import { FlowSimulatorPanel } from './FlowSimulatorPanel';
 import { FlowRunsPanel } from './FlowRunsPanel';
 import { ProblemsPanel } from './ProblemsPanel';
 import { buildFlowProblems, deriveInvalidElements, type FlowProblem } from './flow-problems';
 
-interface FlowNode {
-  id: string;
-  type: string;
-  label?: string;
-  config?: Record<string, unknown>;
-  ui?: { x?: number; y?: number };
-  [k: string]: unknown;
-}
-
 /**
- * This preview reads the draft's edges and hands them straight to
- * {@link FlowCanvas}, so it reads them as the canvas's own type rather than
- * restating the shape. It used to restate it — including a `condition` typed
- * `string | { source?: string }`, an envelope the spec's `FlowEdgeSchema`
- * rejects for want of `dialect`. Two copies of one shape is how the wrong one
- * survives being fixed (objectui#3202).
+ * This preview reads the draft's nodes and edges and hands them straight to
+ * {@link FlowCanvas}, so it reads them as the canvas's own types rather than
+ * restating the shapes. It used to restate both — the edge including a
+ * `condition` typed `string | { source?: string }`, an envelope the spec's
+ * `FlowEdgeSchema` rejects for want of `dialect`; the node including a
+ * `ui?: { x?: number; y?: number }` geometry key the spec's `.strict()`
+ * `FlowNodeSchema` rejects outright (objectui#3172). Two copies of one shape is
+ * how the wrong one survives being fixed (objectui#3202).
  */
+type FlowNode = FlowDesignerNode;
 type FlowEdge = FlowDesignerEdge;
 
 interface FlowVariable {

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.test.ts
@@ -11,6 +11,9 @@ import {
   backEdgeLabelAnchor,
   bottomAnchor,
   extractRegions,
+  hasManualPosition,
+  manualPosition,
+  withCanonicalGeometry,
   NODE_W,
   NODE_H,
   V_GAP,
@@ -187,7 +190,16 @@ describe('computeLayoutWithGeometry — constant-height invariance (the regressi
       ],
     },
     {
-      name: 'manual ui position',
+      name: 'manual position (spec-canonical)',
+      nodes: [
+        { id: 's', type: 'start' },
+        { id: 'pin', type: 'script', position: { x: 400, y: 10 } },
+        { id: 'e', type: 'end' },
+      ],
+      edges: [{ source: 's', target: 'pin' }, { source: 'pin', target: 'e' }],
+    },
+    {
+      name: 'manual position (legacy `ui`, read-compat)',
       nodes: [
         { id: 's', type: 'start' },
         { id: 'pin', type: 'script', ui: { x: 400, y: 10 } },
@@ -248,7 +260,7 @@ describe('computeLayoutWithGeometry — cumulative variable-height offsets (#267
   it('a manually-pinned tall node does not push auto rows (accepted-overlap rule)', () => {
     const nodes: FlowDesignerNode[] = [
       { id: 's', type: 'start' },
-      { id: 'pin', type: 'loop', ui: { x: 400, y: 10 } },
+      { id: 'pin', type: 'loop', position: { x: 400, y: 10 } },
       { id: 'e', type: 'end' },
     ];
     const edges: FlowDesignerEdge[] = [{ source: 's', target: 'pin' }, { source: 'pin', target: 'e' }];
@@ -263,5 +275,103 @@ describe('computeLayoutWithGeometry — cumulative variable-height offsets (#267
 describe('bottomAnchor with explicit height (#2670)', () => {
   it('anchors at the true bottom of a tall card', () => {
     expect(bottomAnchor({ x: 10, y: 20 }, 200)).toEqual({ x: 10 + NODE_W / 2, y: 220 });
+  });
+});
+
+// ── objectui#3172: node geometry IS the spec's `FlowNode.position` ───────────
+
+describe('manualPosition — `position` is canonical, `ui` is legacy read-only', () => {
+  it('reads the spec-canonical `position`', () => {
+    expect(manualPosition({ id: 'n', type: 'script', position: { x: 12, y: 34 } })).toEqual({ x: 12, y: 34 });
+  });
+
+  it('falls back to a legacy `ui` so stored flows still open pinned', () => {
+    expect(manualPosition({ id: 'n', type: 'script', ui: { x: 12, y: 34 } })).toEqual({ x: 12, y: 34 });
+  });
+
+  it('prefers `position` when a legacy node carries both', () => {
+    expect(
+      manualPosition({ id: 'n', type: 'script', position: { x: 1, y: 2 }, ui: { x: 90, y: 90 } }),
+    ).toEqual({ x: 1, y: 2 });
+  });
+
+  it('is null unless BOTH coordinates are finite (either spelling)', () => {
+    expect(manualPosition({ id: 'n', type: 'script' })).toBeNull();
+    expect(manualPosition({ id: 'n', type: 'script', ui: { x: 400 } })).toBeNull();
+    expect(manualPosition({ id: 'n', type: 'script', ui: { y: 400 } })).toBeNull();
+    expect(manualPosition({ id: 'n', type: 'script', position: { x: NaN, y: 1 } })).toBeNull();
+    // A half-position must not shadow a usable legacy one either.
+    expect(
+      manualPosition({ id: 'n', type: 'script', position: { x: 5 } as never, ui: { x: 7, y: 8 } }),
+    ).toEqual({ x: 7, y: 8 });
+    expect(hasManualPosition({ id: 'n', type: 'script', ui: { x: 400 } })).toBe(false);
+    expect(hasManualPosition({ id: 'n', type: 'script', position: { x: 4, y: 0 } })).toBe(true);
+  });
+
+  it('pins a legacy node at exactly the same point as the canonical spelling', () => {
+    const edges: FlowDesignerEdge[] = [{ source: 's', target: 'pin' }];
+    const legacy = computeLayout(
+      [{ id: 's', type: 'start' }, { id: 'pin', type: 'script', ui: { x: 400, y: 10 } }],
+      edges,
+    );
+    const canonical = computeLayout(
+      [{ id: 's', type: 'start' }, { id: 'pin', type: 'script', position: { x: 400, y: 10 } }],
+      edges,
+    );
+    expect(legacy.get('pin')).toEqual({ x: 400, y: 10 });
+    expect(legacy).toEqual(canonical);
+  });
+});
+
+describe('withCanonicalGeometry — migrate-on-write (the strict-schema gate)', () => {
+  it('lifts a legacy `ui` onto `position` and drops the `ui` key', () => {
+    const out = withCanonicalGeometry([{ id: 'n', type: 'script', ui: { x: 7, y: 9 } }]);
+    expect(out[0]).toEqual({ id: 'n', type: 'script', position: { x: 7, y: 9 } });
+    expect('ui' in out[0]).toBe(false);
+  });
+
+  it('keeps an existing `position` and still drops a stale `ui`', () => {
+    const out = withCanonicalGeometry([
+      { id: 'n', type: 'script', position: { x: 1, y: 2 }, ui: { x: 90, y: 90 } },
+    ]);
+    expect(out[0].position).toEqual({ x: 1, y: 2 });
+    expect('ui' in out[0]).toBe(false);
+  });
+
+  it('drops an unusable `ui` without inventing a position', () => {
+    const out = withCanonicalGeometry([{ id: 'n', type: 'script', ui: { x: 5 } }]);
+    expect(out[0]).toEqual({ id: 'n', type: 'script' });
+  });
+
+  it('preserves every other key, including ones the canvas does not understand', () => {
+    const out = withCanonicalGeometry([
+      {
+        id: 'n',
+        type: 'http',
+        label: 'Call',
+        config: { url: 'https://x' },
+        connectorConfig: { connectorId: 'c', actionId: 'a' },
+        ui: { x: 3, y: 4 },
+      },
+    ]);
+    expect(out[0]).toEqual({
+      id: 'n',
+      type: 'http',
+      label: 'Call',
+      config: { url: 'https://x' },
+      connectorConfig: { connectorId: 'c', actionId: 'a' },
+      position: { x: 3, y: 4 },
+    });
+  });
+
+  it('returns the SAME array when nothing needs migrating (memo identity)', () => {
+    const nodes: FlowDesignerNode[] = [
+      { id: 's', type: 'start' },
+      { id: 'n', type: 'script', position: { x: 1, y: 2 } },
+    ];
+    expect(withCanonicalGeometry(nodes)).toBe(nodes);
+    // …and it is idempotent: migrating twice is migrating once.
+    const once = withCanonicalGeometry([{ id: 'n', type: 'script', ui: { x: 7, y: 9 } }]);
+    expect(withCanonicalGeometry(once)).toBe(once);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-layout.ts
@@ -11,15 +11,39 @@
  * Salesforce Flow Builder). Origin is the top-left of the diagram bounding
  * box after normalization, so every node sits at x >= PADDING, y >= PADDING.
  *
- * "Dependency-free" means no RUNTIME dependency: the one import below is a
- * `import type`, erased at compile time, and it is here precisely so the
+ * "Dependency-free" means no RUNTIME dependency: the imports below are
+ * `import type`, erased at compile time, and they are here precisely so the
  * designer's edge guard cannot drift from the spec's expression envelope
- * (see {@link FlowDesignerEdge}).
+ * (see {@link FlowDesignerEdge}) and its node geometry cannot drift from the
+ * spec's `FlowNode.position` (see {@link FlowNodePosition}).
  */
 
 import type { ExpressionInput } from '@objectstack/spec/shared';
+import type { FlowNode as SpecFlowNode } from '@objectstack/spec/automation';
 
-export interface FlowNodeUI {
+/**
+ * Canvas geometry of a node — **the spec's own `FlowNode.position`**, taken by
+ * reference rather than restated (objectui#3172).
+ *
+ * `{ x: number; y: number }`, both REQUIRED: a half-coordinate is not a
+ * position, and the spec's node schema rejects one. Derived from the spec's
+ * authoring type so the two cannot drift; `__tests__/spec-symbol-parity.test.ts`
+ * pins the equality in both directions.
+ */
+export type FlowNodePosition = NonNullable<SpecFlowNode['position']>;
+
+/**
+ * The designer's pre-objectui#3172 geometry spelling, kept for READING stored
+ * flows only.
+ *
+ * @deprecated Never write this. `FlowSchema`'s node is `.strict()`
+ * (objectstack#4001), so a node carrying `ui` is rejected by client-side
+ * validation and by the server with a 422 — this spelling could not round-trip
+ * even before it was retired. {@link withCanonicalGeometry} lifts it onto
+ * {@link FlowNodePosition} at the canvas boundary, so a stored flow heals on the
+ * author's first edit.
+ */
+export interface LegacyFlowNodeUI {
   x?: number;
   y?: number;
 }
@@ -48,23 +72,29 @@ export interface FlowNodeUI {
  * every missing member (objectstack#4075) — which is precisely why the NAME had
  * to stop claiming they are the same thing.
  *
- * KNOWN DIVERGENCE, left alone deliberately: this designer persists geometry as
- * `ui: { x, y }` while the spec already models it twice
- * (`FlowNode.position`, and `FlowCanvasNode`). Three spellings of one concept
- * is a real defect, but reconciling it changes what gets written to metadata —
- * a behaviour change that does not belong in a symbol burn-down. See the PR
- * description; filed as a follow-up.
+ * Geometry is NOT a layer difference and no longer diverges: the canvas writes
+ * the spec's own `position` (objectui#3172). The designer's old `ui: { x, y }`
+ * spelling is read-only legacy — see {@link LegacyFlowNodeUI} and
+ * {@link withCanonicalGeometry}. (`@objectstack/spec/studio`'s `FlowCanvasNode`
+ * is a third name but not a third geometry: it is the visual overlay keyed BY
+ * node id, with no consumer in this repo.)
  *
  * `__tests__/spec-symbol-parity.test.ts` pins that the spec owns neither
- * `FlowDesignerNode` nor `FlowDesignerEdge`.
+ * `FlowDesignerNode` nor `FlowDesignerEdge`, and that `position` here IS the
+ * spec's.
  */
 export interface FlowDesignerNode {
   id: string;
   type: string;
   label?: string;
   config?: Record<string, unknown>;
-  /** UI-only layout hint persisted via onPatch; ignored by the runtime. */
-  ui?: FlowNodeUI;
+  /**
+   * Canvas position, spec-canonical (`FlowNode.position`). Optional because an
+   * un-dragged node is placed by the auto-layout, exactly as in the spec.
+   */
+  position?: FlowNodePosition;
+  /** @deprecated Read-only legacy geometry — see {@link LegacyFlowNodeUI}. */
+  ui?: LegacyFlowNodeUI;
   [k: string]: unknown;
 }
 
@@ -124,9 +154,59 @@ function isFiniteNum(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v);
 }
 
+/**
+ * The persisted manual position of a node — **the** reader for node geometry.
+ *
+ * Spec-canonical `position` first; the retired `ui: { x, y }` spelling is read
+ * ONLY as a fallback so a flow stored before objectui#3172 still opens with its
+ * nodes where the author left them. Nothing writes `ui` any more, and
+ * {@link withCanonicalGeometry} strips it at the canvas boundary, so the
+ * fallback is a migration path and not a second contract.
+ *
+ * Both coordinates must be finite — a half or NaN coordinate is not a position
+ * (and the spec's node schema rejects one), so such a node is auto-laid out
+ * instead of being pinned at a garbage point.
+ */
+export function manualPosition(node: FlowDesignerNode): FlowNodePosition | null {
+  const p = node.position;
+  if (isFiniteNum(p?.x) && isFiniteNum(p?.y)) return { x: p.x, y: p.y };
+  const legacy = node.ui;
+  if (isFiniteNum(legacy?.x) && isFiniteNum(legacy?.y)) return { x: legacy.x, y: legacy.y };
+  return null;
+}
+
 /** A node carries a persisted manual position when both x and y are finite. */
 export function hasManualPosition(node: FlowDesignerNode): boolean {
-  return isFiniteNum(node.ui?.x) && isFiniteNum(node.ui?.y);
+  return manualPosition(node) !== null;
+}
+
+/**
+ * Migrate-on-write boundary (objectui#3172): return `nodes` with every legacy
+ * `ui: { x, y }` lifted onto the spec's `position` and the `ui` key REMOVED.
+ *
+ * The canvas runs its own `nodes` prop through this, so every patch it emits is
+ * built from already-canonical nodes and can never re-emit `ui` — including the
+ * patches that have nothing to do with geometry (delete, revise loop). That
+ * matters because a draft carrying `ui` is unsavable, not merely untidy:
+ * `FlowSchema`'s node is `.strict()` (objectstack#4001), so the key surfaces as
+ * `unrecognized_keys` in the live client validation and as a 422 on save. A
+ * stored flow therefore heals on the author's first edit.
+ *
+ * A node whose legacy `ui` is unusable (missing or non-finite coordinate) loses
+ * the key without gaining a position: it was never rendered as pinned, and
+ * keeping it would keep the draft unsavable.
+ *
+ * Returns the SAME array reference when nothing needed migrating, so callers can
+ * use it inside a `useMemo` without invalidating downstream memos every render.
+ */
+export function withCanonicalGeometry(nodes: FlowDesignerNode[]): FlowDesignerNode[] {
+  if (!nodes.some((n) => n && 'ui' in n)) return nodes;
+  return nodes.map((n) => {
+    if (!n || !('ui' in n)) return n;
+    const { ui: _legacy, ...rest } = n;
+    const p = manualPosition(n);
+    return p ? { ...rest, position: p } : rest;
+  });
 }
 
 /**
@@ -208,17 +288,18 @@ export interface FlowLayoutGeometry {
  * - Nodes never reached from a root are dropped into a trailing layer so the
  *   author still sees them.
  * - Within a layer, nodes keep their original `nodes[]` order (stable).
- * - A node with a persisted `ui` position overrides its computed slot, but is
- *   still included in the returned map so callers can size the canvas.
+ * - A node with a persisted manual position ({@link manualPosition}) overrides
+ *   its computed slot, but is still included in the returned map so callers can
+ *   size the canvas.
  *
  * #2670: cards are no longer necessarily {@link NODE_H} tall — an expanded
  * `loop`/`parallel`/`try_catch` container grows to embed its region(s), so
  * layer spacing is **cumulative**: each layer starts below the tallest
  * (auto-laid) card of the previous one. With the default constant `heightOf`
  * the output is IDENTICAL to the historical fixed-pitch layout (pinned by
- * tests). Manual-`ui` nodes are excluded from a row's height (they don't render
- * in their computed slot; counting them would open phantom gaps) — so a pinned
- * node sitting at/below an expanded container can overlap it. Accepted
+ * tests). Manually-positioned nodes are excluded from a row's height (they don't
+ * render in their computed slot; counting them would open phantom gaps) — so a
+ * pinned node sitting at/below an expanded container can overlap it. Accepted
  * limitation: the author can drag it clear.
  */
 export function computeLayoutWithGeometry(
@@ -316,8 +397,8 @@ export function computeLayoutWithGeometry(
     ids.forEach((id, i) => {
       positions.set(id, { x: startX + i * (NODE_W + H_GAP), y });
       const n = byId.get(id);
-      // Manual-`ui` nodes don't render in this slot — exclude from the row
-      // height so they can't open phantom gaps (see JSDoc caveat).
+      // Manually-positioned nodes don't render in this slot — exclude from the
+      // row height so they can't open phantom gaps (see JSDoc caveat).
       if (n && !hasManualPosition(n)) {
         rowMaxHeight = Math.max(rowMaxHeight, heights.get(id) ?? NODE_H);
       }
@@ -344,8 +425,9 @@ export function computeLayoutWithGeometry(
 
   // Apply persisted manual overrides on top of the normalized frame.
   for (const n of nodes) {
-    if (hasManualPosition(n)) {
-      positions.set(n.id, { x: Math.max(0, n.ui!.x!), y: Math.max(0, n.ui!.y!) });
+    const manual = manualPosition(n);
+    if (manual) {
+      positions.set(n.id, { x: Math.max(0, manual.x), y: Math.max(0, manual.y) });
     }
   }
 


### PR DESCRIPTION
## 这是什么

按维护者裁决（2026-08-03）与 PM 审计报告，把流程设计器的节点几何收敛到 spec 已声明的 `FlowNode.position`，退役 objectui 本地拼写 `ui: {x, y}`。改动面全部落在 `@object-ui/app-shell`；`packages/spec`、objectstack 仓、`plugin-designer`、`types/react/components/fields`（#3233 在飞）**零改动**。

**它同时是一个行为修复，不只是改名。** spec 17 的 `FlowNodeSchema` 自 objectstack#4001 起是 `.strict()`，`ui` 会产出 `unrecognized_keys`：客户端实时校验飘红、服务端保存 422。也就是说**今天在设计器里拖一个节点，这份 flow 就存不进去**。审计里这条是静态推导，本 PR 把它跑成了断言（见下「实机验证」）。

## 触点清销（对照审计的 5 文件 ~15 处）

写侧 3 处 —— 一律产出 `position`，永不写 `ui`：
- [x] `FlowCanvas.tsx` `persistPosition`（拖拽落点）
- [x] `FlowCanvas.tsx` `addNode`（带 `at` 的新增）
- [x] `FlowCanvas.tsx` `insertOnEdge`（边上插入）

读侧 2 处 —— `position` 优先、`ui` 仅作遗留回退，保留「x/y 同时有限」判据：
- [x] `flow-canvas-layout.ts` `hasManualPosition`（现委托给新的单一读点 `manualPosition()`）
- [x] `flow-canvas-layout.ts` 布局覆盖（`positions.set(...)`，同时去掉了 `n.ui!.x!` 那对非空断言）

类型 3 处 —— 几何按引用派生自 spec，不再手写形状：
- [x] `FlowNodeUI` → `FlowNodePosition = NonNullable< SpecFlowNode['position'] >`（`import type`，仍是零运行时依赖）
- [x] `FlowDesignerNode` 挂载 `position?: FlowNodePosition`；`ui?: LegacyFlowNodeUI` 保留但标 `@deprecated` 只读
- [x] `FlowPreview.tsx:52` 的形状拷贝消灭，改 `type FlowNode = FlowDesignerNode`（与它早已这么做的 edge 对齐）

夹具 / 文档：
- [x] `flow-canvas-layout.test.ts` 两条夹具改 `position`，并**新增**一条同点位的 legacy `ui` 夹具（兼容读继续被覆盖）
- [x] `README.md` 布局段落改写；`FlowCanvas.tsx` 头注释改写
- [x] changeset（`minor`，按 AGENTS.md「changeset 不声明 major，破坏性语义写正文」）

## 不变量与证明

1. **写侧只出 `position`** —— 三条写路径各一条回归测试。
2. **离开设计器的 draft 必须 `ui`-free** —— 抬升点选在**画布输入边界**（`FlowCanvas` 用 `withCanonicalGeometry(storedNodes)` 归一后再 `useMemo`），而不是塞进 `persistPosition`。理由：`FlowCanvas` 有 **5** 条会重发 `nodes` 数组的 patch 路径（拖拽、新增、边插入、revise loop、删除），只补写侧会漏掉后两条——它们不写几何，却会把遗留 `ui` 原样带回 draft，闸门照样 422。归一在入口，则**任何**现有或将来的 patch 都从已规范化的数组构造，结构上不可能再发出 `ui`。测试里专门有一条「删除节点也 `ui`-free」钉住这一点。
3. **读侧兼容旧数据** —— `manualPosition()` 是唯一读点：`position` 优先、`ui` 回退；一条测试把两种拼写各布一次局并比对整张 map 相等。
4. **几何类型 ≡ spec** —— `spec-symbol-parity.test.ts` 新增正向 parity（编译期：与 `NonNullable< SpecFlowNode['position'] >` 互等、input 与 parsed 一致、x/y 均必填、半个坐标不可表示；运行期：spec 仍拼作 `position` 且拒收 `ui`）。既有的 `FlowCanvasNode` / `FlowCanvasEdge` 反向防撞 pin **原样保留**。
5. **索引签名兜底** —— `FlowDesignerNode` 带 `[k: string]: unknown`，编译器抓不到漏掉的 `ui` 读写点，因此收工做了全仓 grep：写形态 `ui: { x|y|... }` 在**生产代码中零命中**（仅剩注释与故意造遗留数据的测试夹具）；读形态 `ui?.x` / `ui.y` 零命中，唯一的 `node.ui` 读点就是 `manualPosition()` 里那条有文档的遗留回退。

## 验证

- 单测：`pnpm exec vitest run` 三个受影响文件 → **80 passed**；app-shell 全量 → **266 files / 2311 passed / 1 skipped**。
- `turbo run type-check --filter=@object-ui/app-shell` 通过（含 `tsconfig.typetests.json`，编译期断言真的被编译）；lint **0 errors**（新增告警仅 `_legacy` 解构丢弃一处，与本包既有 `_`-前缀写法一致）。
- **每条新测试都做了 sabotage 验证**（改坏见红、还原见绿）：把 `persistPosition` 改回写 `ui` → 2 红；绕过入口归一 → 5 红；删掉 legacy 读回退 → 9 红；抬升时不删 `ui` 键 → 10 红；破坏同引用返回 → 1 红；把 spec 拒收断言喂合法节点 → 1 红；把 `FlowNodePosition` 改成 `{ x: number; y?: number }` → typetests 4 处 `TS2344` 报红。还原后 80/80 绿。

### 实机验证（浏览器，无后端）

用仓内 `verify` 技能的 preview gallery（Playwright 驱动，console dev server 起在自选端口 5197，用完按 PID 关掉，临时插桩已 `git checkout` 还原）：把 flow 样本的 `find` 节点临时种成 `ui: {x: 520, y: 40}`，实测：

- 遗留节点渲染在钉位：`left: 520px / top: 40px`（兼容读活着）。
- 拖动另一个节点 `start` 后，真实 patch 载荷为
  `[{"id":"start","position":{"x":290,"y":88}},{"id":"find","position":{"x":520,"y":40}}, …]`，
  `JSON.stringify(patch).includes('"ui"') === false` —— 遗留节点在同一个 patch 里自愈了。
- 拖后的节点停在落点（说明写进去的 `position` 又被读了回来，不是靠自动布局巧合）。
- **闸门实测**：设计器产出的这份 draft `FlowSchema.safeParse(draft).success === true`；把同一份 draft 换回 `ui` 拼写则 `REJECTED`，issue 正是审计里那条
  `{"code":"unrecognized_keys","keys":["ui"],"path":["nodes",0]}`。审计中「今天拖一个节点就存不进去」的静态推导由此变成执行过的证据。

**未实机覆盖的部分**：真实后端 `POST /metadata` 的 422 未走真机（本次验证不带后端），但服务端用的就是同一份 `FlowSchema`，上面的 `safeParse` 即该链路的判定函数；真实环境**存量数据**的规模仓内无法回答（仓内 examples/fixtures 既无 `ui` 也无 `position`），不过因为 strict 闸门，带 `ui` 的行今天本就写不进去，存量面大概率接近空集。

## 范围外发现

无（本次没有踩到与本单无关的缺陷，故未新开 issue）。

Closes #3172

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_