### PR TITLE
refactor(types,react,components,fields)!: converge the widget metadata carrier to `field`, retiring `schema` (#3233)

### DIFF
--- a/.changeset/field-widget-single-metadata-carrier.md
+++ b/.changeset/field-widget-single-metadata-carrier.md
@@ -1,0 +1,74 @@
+---
+"@object-ui/fields": minor
+"@object-ui/components": minor
+---
+
+**BREAKING (v17)** — field widgets receive their metadata on ONE key, `field`.
+`schema` is removed from the widget contract (objectui#3233).
+
+## What changed
+
+`schema` was a second carrier for what `field` already means. Two producers fed
+it: `SchemaRenderer` passed the authored node as `schema`, and the form
+renderer's `renderFieldComponent` passed `schema={props.field || props.schema ||
+props}` *alongside* `field`. The predictable result was ~30 widgets resolving
+their config as `field || schema` — one concept, two spellings, a de-facto
+second contract (AGENTS.md #0.1).
+
+- `FieldWidgetComponentProps` no longer declares `schema`. Reading
+  `props.schema` is now a compile error, not a silent `any`.
+- Both producers converged. The form renderer passes `field` only. The SDUI node
+  → `field` translation happens exactly once, in a new registration adapter
+  (`withFieldCarrier`), which every built-in field widget is registered through.
+- All `field || schema` reads in `@object-ui/fields` are now plain `field` reads.
+
+## Migrating a widget you wrote
+
+**Reading the metadata** — replace the fallback with the single key:
+
+```diff
+-const config = field || (props as any).schema;
++const config = field;
+```
+
+**Registering a widget** — if your widget can be rendered from a schema node
+(anything `SchemaRenderer` dispatches, not just forms), wrap it once so it still
+gets `field`:
+
+```diff
++import { withFieldCarrier } from '@object-ui/fields';
++
+-ComponentRegistry.register('color', ColorField, { namespace: 'field' });
++ComponentRegistry.register('color', withFieldCarrier(ColorField), { namespace: 'field' });
+```
+
+`withFieldCarrier` forwards the node **by reference** — nothing is copied,
+narrowed or renamed — and consumes `schema` so it cannot reach the DOM through a
+widget's `...props` spread.
+
+A third-party widget that still reads `props.schema` and is **not** re-registered
+through the adapter will read `undefined` in v17 and silently render an empty /
+default state. That is the deliberate cost of a major boundary: one contract
+beats N dialects, and a widget that picks the wrong spelling should fail at
+compile time rather than work under one host and not another.
+
+## What did NOT change
+
+- **Host metadata (SDUI JSON) is untouched.** No authored schema changes; this is
+  a change to how widgets are *written*, not to what apps declare.
+- **`schema` is still the universal SDUI prop** every registered component
+  receives from `SchemaRenderer` (`element:*`, `page:*`, grids, reports). Only
+  the *field-widget* contract retired it. In particular `renderFieldComponent`
+  still passes `schema` when a form field type resolves to a plain component
+  through the bare-name fallback (e.g. `type: 'text'` reaching the display text
+  widget) — that component's contract is the node, and dropping it there would
+  render `undefined.className`.
+
+## Payload equivalence
+
+Every path that used to deliver a payload through `schema` now delivers the
+identical object through `field`, and both halves are pinned by tests asserting
+**object identity**, not shape:
+
+- form path — `packages/components/src/renderers/form/__tests__/form-field-carrier.test.tsx`
+- SDUI path — `packages/fields/src/__tests__/field-carrier-sdui.test.tsx`

--- a/content/docs/guide/plugin-development.md
+++ b/content/docs/guide/plugin-development.md
@@ -195,6 +195,33 @@ The validation slot is named `error`, matching `FieldWidgetPropsSchema` in
 `@objectstack/spec/ui` — the published contract a widget is written against.
 The form renderer supplies it from the active validation message.
 
+### `field` is the only metadata carrier (v17, breaking)
+
+Before v17 a widget could receive its metadata under **either** `field` or
+`schema`, depending on which host rendered it, so widgets written in that era
+resolve their config as `field || schema`. `schema` has been removed from
+`FieldWidgetComponentProps` in v17: **read `props.field`, full stop.** Reading
+`props.schema` now yields `undefined`.
+
+`schema` itself is not going anywhere — it is the universal SDUI node
+`SchemaRenderer` hands to *every* registered component (`element:*`, `page:*`,
+grids, reports). That is precisely why a **field widget** needs an adapter when
+it is rendered from a schema node instead of from a form. Wrap it once, at
+registration, and the widget only ever implements one contract:
+
+```tsx
+import { ComponentRegistry } from '@object-ui/core';
+import { withFieldCarrier } from '@object-ui/fields';
+
+ComponentRegistry.register('color', withFieldCarrier(ColorPickerField), {
+  namespace: 'field',
+});
+```
+
+`withFieldCarrier` forwards the node by reference (nothing is copied or
+dropped) and consumes `schema` so it never reaches the DOM. Every built-in
+field widget is registered through it.
+
 ### Who renders what
 
 The widget and the form renderer split validation display, and the split is
@@ -268,9 +295,10 @@ Register it as a field widget:
 ```tsx
 // src/index.tsx
 import { ComponentRegistry } from '@object-ui/core';
+import { withFieldCarrier } from '@object-ui/fields';
 import { ColorPickerField } from './ColorPickerField';
 
-ComponentRegistry.register('field-color', ColorPickerField, {
+ComponentRegistry.register('field-color', withFieldCarrier(ColorPickerField), {
   namespace: 'plugin-board',
   label: 'Color Picker',
   category: 'field',

--- a/packages/components/src/renderers/form/__tests__/form-field-carrier.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-field-carrier.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The form renderer delivers field metadata on ONE key — objectui#3233.
+ *
+ * `renderFieldComponent` used to hand every registered widget the metadata
+ * TWICE:
+ *
+ *     <RegisteredComponent schema={props.field || props.schema || props}
+ *                          {...registeredProps} />   // …which also has `field`
+ *
+ * `props.field` is set unconditionally at the only call site (`field.field ||
+ * field`), so the two fallback terms were unreachable and `schema` was always
+ * the *same object* as `field`. The cost was not a wrong payload, it was a
+ * second spelling: ~30 widgets resolved their config as `field || schema`, and
+ * every new widget author had to learn which one their host used.
+ *
+ * v17 retires `schema` from `FieldWidgetComponentProps`. That is only safe if
+ * every payload that used to arrive through `schema` now arrives through
+ * `field` UNCHANGED — "swap the key, don't drop the cargo". These tests pin
+ * exactly that, by object identity rather than by shape: a structural
+ * comparison would still pass if the renderer started handing widgets a
+ * reconstructed copy, and a copy breaks the widgets that compare metadata
+ * identity across renders.
+ *
+ * The sibling half of the invariant — the SDUI path through `SchemaRenderer` —
+ * is pinned in `packages/fields/src/__tests__/field-carrier-sdui.test.tsx`.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/**
+ * Props the probe was rendered with, captured per render.
+ *
+ * A holder object rather than a bare module variable: `react-hooks/globals`
+ * forbids REASSIGNING an outer binding from a component body, and mutating a
+ * property of a stable object is the repo's usual shape for a probe.
+ */
+const captured: { props: Record<string, any> | null } = { props: null };
+
+/**
+ * Stands in for a registered field widget (`@object-ui/components` tests never
+ * load `@object-ui/fields`). It records its props instead of resolving them, so
+ * the assertions can talk about the KEY and the object identity — which is what
+ * the convergence is about — rather than about rendered output.
+ */
+function CarrierProbe(props: any) {
+  captured.props = props;
+  return <input data-testid={`probe-${props.name}`} value={(props.value as string) ?? ''} readOnly />;
+}
+
+beforeAll(() => {
+  ComponentRegistry.register('carrierprobe', CarrierProbe, { namespace: 'field' });
+}, 30000);
+
+beforeEach(() => {
+  captured.props = null;
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        defaultValues,
+        fields,
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+describe('form renderer — `field` is the single metadata carrier (objectui#3233)', () => {
+  it('delivers the metadata object the widget used to read through `schema`', () => {
+    // `.field` is the declared metadata slot (#3090). This object is what
+    // `schema={props.field || …}` resolved to before the convergence, so
+    // identity here IS the payload-equivalence proof for this path.
+    const metadata = {
+      name: 'title',
+      label: 'Title',
+      type: 'carrierprobe',
+      placeholder: 'Name the task',
+      options: [{ label: 'A', value: 'a' }],
+    };
+
+    renderForm([{ name: 'title', label: 'Title', type: 'carrierprobe', field: metadata }], {
+      title: 'hi',
+    });
+
+    expect(screen.getByTestId('probe-title')).toBeInTheDocument();
+    expect(captured.props).not.toBeNull();
+    // Same object, not a reconstruction.
+    expect(captured.props!.field).toBe(metadata);
+  });
+
+  it('falls back to the form-field config itself when no `.field` metadata was stashed', () => {
+    // Standalone forms author the config inline. The old producer resolved
+    // `props.field` to `field.field || field` — the config object — and passed
+    // THAT as `schema`. It must now arrive as `field`, same object.
+    const config: Record<string, any> = {
+      name: 'nickname',
+      label: 'Nickname',
+      type: 'carrierprobe',
+      placeholder: 'What do we call you?',
+    };
+
+    renderForm([config], { nickname: '' });
+
+    expect(captured.props).not.toBeNull();
+    expect(captured.props!.field).toBe(config);
+    expect(captured.props!.field.placeholder).toBe('What do we call you?');
+  });
+
+  it('does not pass a `schema` key at all', () => {
+    // Key ABSENCE, not `undefined`: a widget must not be able to resolve
+    // `field || schema` and get anything, or the second contract survives in
+    // practice while the type claims it is gone.
+    renderForm([{ name: 'title', label: 'Title', type: 'carrierprobe' }], { title: '' });
+
+    expect(captured.props).not.toBeNull();
+    expect('schema' in captured.props!).toBe(false);
+  });
+
+  it('cannot have the carrier resurrected by an authored `schema` key on the field', () => {
+    // A form field carrying its own `schema` key must not reach the widget:
+    // that would re-create the second carrier through metadata rather than
+    // through code, and (because widgets spread leftovers onto the DOM) spill
+    // an object into the markup.
+    const decoy = { name: 'decoy', label: 'Decoy', type: 'carrierprobe' };
+
+    renderForm(
+      [{ name: 'title', label: 'Title', type: 'carrierprobe', schema: decoy }],
+      { title: '' },
+    );
+
+    expect(captured.props).not.toBeNull();
+    expect('schema' in captured.props!).toBe(false);
+    expect(captured.props!.field).not.toBe(decoy);
+    expect(captured.props!.field.name).toBe('title');
+  });
+});
+
+describe('form renderer — retiring the carrier did NOT touch the SDUI `schema` contract', () => {
+  it('still passes `schema` to a plain component reached by the bare-name fallback', () => {
+    // The load-bearing distinction, and the one a "just delete `schema`"
+    // refactor gets wrong: `renderFieldComponent`'s registry lookup can answer
+    // with two different KINDS of component.
+    //
+    //  - a `field:<type>` entry is a field widget — `field` only, since v17;
+    //  - the bare-name fallback is an ordinary SDUI component (the display
+    //    `text` widget, `alert`, `badge` …), whose contract is the universal
+    //    `schema` node. That key is NOT retired, and dropping it here rendered
+    //    `undefined.className` for every form field that resolves this way
+    //    (caught by `form-write-error-message.test.tsx`, whose fields are
+    //    `type: 'text'` with `@object-ui/fields` not loaded).
+    //
+    // So this asserts the INVERSE of the tests above, on purpose.
+    ComponentRegistry.register('plaindisplay', CarrierProbe);
+
+    renderForm([{ name: 'note', label: 'Note', type: 'plaindisplay' }], { note: '' });
+
+    expect(captured.props).not.toBeNull();
+    expect(captured.props!.schema).toBeTruthy();
+    expect(captured.props!.schema.name).toBe('note');
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -283,6 +283,10 @@ function stripRegisteredFieldProps(type: string, props: RenderFieldProps): Rende
     fullscreen: _fullscreen,
     dependentValues,
     emptyHint,
+    // Retired from the widget contract in v17 (objectui#3233): `field` is the
+    // single metadata carrier. The strip stays so an authored form field that
+    // happens to carry a `schema` key cannot resurrect the second carrier —
+    // or spill an object onto the DOM through a widget's `...props` spread.
     schema: _schema,
     ...fieldProps
   } = props;
@@ -1807,15 +1811,52 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
   //    available (e.g. so { type: 'text' } in a form schema resolves to the
   //    text input field, not the display text widget that shares the same
   //    short name in the global registry).
-  const RegisteredComponent = !BUILTIN_FIELD_TYPES.has(type)
-    ? ((!type.includes(':') && ComponentRegistry.get(`field:${type}`)) ||
-      ComponentRegistry.get(type))
+  //
+  //    Which entry answered decides which CONTRACT the resolved component
+  //    implements, so the lookups are kept apart rather than folded into one
+  //    `||` chain (objectui#3233):
+  //
+  //      - a `field:` entry is a FIELD WIDGET — `FieldWidgetComponentProps`,
+  //        whose metadata carrier is `field` and nothing else since v17;
+  //      - the bare-name fallback is a plain SDUI COMPONENT (the display
+  //        `text` widget, `alert`, `badge` …). Its contract is the universal
+  //        `schema` node every registered component receives from
+  //        `SchemaRenderer`. That key is NOT retired and must still be passed,
+  //        or such a field renders `undefined.className`.
+  const namespacedWidget = !BUILTIN_FIELD_TYPES.has(type) && !type.includes(':')
+    ? ComponentRegistry.get(`field:${type}`)
     : undefined;
+  const RegisteredComponent = !BUILTIN_FIELD_TYPES.has(type)
+    ? (namespacedWidget || ComponentRegistry.get(type))
+    : undefined;
+  // A colon-qualified type resolves directly, and is a field widget only when
+  // it names the `field` namespace (`type: 'field:textarea'`).
+  const isFieldWidget = !!namespacedWidget || type.startsWith('field:');
 
   if (RegisteredComponent) {
     const registeredProps = stripRegisteredFieldProps(type, props);
-    const fieldSchema = props.field || props.schema || props;
-    return <RegisteredComponent schema={fieldSchema} {...registeredProps} />;
+
+    if (isFieldWidget) {
+      // `field` is the single metadata carrier (objectui#3233). It rides in
+      // `registeredProps` untouched — the caller always sets it (`field.field
+      // || field`, i.e. the raw metadata object, never undefined) and
+      // `stripRegisteredFieldProps` keeps it.
+      //
+      // This used to ALSO pass `schema={props.field || props.schema || props}`,
+      // a second key carrying the *same* object: `props.field` is truthy at the
+      // only call site, so the two chain terms after it were unreachable and
+      // `schema` was always `=== props.field`. Widgets therefore resolved
+      // `field || schema` to `field` on this path every time — which is why
+      // dropping the key here changes no payload, only the number of spellings
+      // a widget author has to know.
+      return <RegisteredComponent {...registeredProps} />;
+    }
+
+    // Non-field component reached through the bare-name fallback: `schema` is
+    // ITS contract, not the retired field-widget carrier, so the original
+    // resolution is preserved verbatim.
+    const nodeSchema = props.field || props.schema || props;
+    return <RegisteredComponent schema={nodeSchema} {...registeredProps} />;
   }
 
   const { inputType, options = [], placeholder, readonly, emptyHint, ...fieldProps } = props;

--- a/packages/fields/src/__tests__/field-carrier-sdui.test.tsx
+++ b/packages/fields/src/__tests__/field-carrier-sdui.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The SDUI path delivers field metadata on ONE key — objectui#3233.
+ *
+ * `SchemaRenderer` hands every registered component the authored node as
+ * `schema`. That key is the universal SDUI contract (`element:*`, `page:*`,
+ * `object-grid`, `ReportRenderer` …) and is NOT retired. What was retired is
+ * `schema` on the *field-widget* contract: a widget used to receive the node
+ * under `schema` here and the metadata under `field` from the form renderer,
+ * which is why ~30 widgets resolved their config as `field || schema`.
+ *
+ * The translation now happens once, at the registration seam
+ * (`withFieldCarrier`), so downstream `field` is the only carrier. That is only
+ * correct if the node reaches the widget UNCHANGED — "swap the key, don't drop
+ * the cargo". The first test proves it by OBJECT IDENTITY: a spy sits where the
+ * registry entry sits, records the object `SchemaRenderer` passed as `schema`,
+ * and the widget's `field` must be that exact object. (Identity against the
+ * authored literal would be wrong to assert — `SchemaRenderer` shallow-copies
+ * the node while evaluating expressions, so the object it delivers is its own.)
+ *
+ * The last test pins that the REAL registration path goes through the adapter
+ * at all: an adapter nobody applied would leave every SDUI-hosted widget
+ * reading `undefined`, which is exactly the silent failure this convergence is
+ * accused of risking.
+ *
+ * The sibling half of the invariant — the form path through
+ * `renderFieldComponent` — is pinned in `packages/components/src/renderers/
+ * form/__tests__/form-field-carrier.test.tsx`.
+ */
+
+import React, { Suspense } from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+
+import { withFieldCarrier } from '../withFieldCarrier';
+import { registerField } from '../index';
+// Module scope, not a hook: `registerField('boolean')` registers
+// `React.lazy(() => import('./widgets/BooleanField'))`, and under a saturated
+// transform pipeline a first `import()` can outlive RTL's 1000ms budget. The
+// specifier matches `fieldWidgetMap`'s exactly, so ESM's cache makes that
+// factory resolve immediately (AGENTS.md 测试纪律 / objectui#3010).
+import '../widgets/BooleanField';
+
+/**
+ * Capture holder, not bare module variables: `react-hooks/globals` forbids
+ * REASSIGNING an outer binding from a component body, which is what a probe
+ * has to do. Mutating a property of a stable object is the repo's usual shape
+ * for this (see plugin-detail's `RelatedList` probes).
+ */
+const captured: { props: Record<string, any> | null; node: unknown } = {
+  props: null,
+  node: null,
+};
+
+function CarrierProbe(props: any) {
+  captured.props = props;
+  return <div data-testid="carrier-probe">{props.field?.label ?? 'NO FIELD'}</div>;
+}
+
+const AdaptedProbe = withFieldCarrier(CarrierProbe);
+
+/**
+ * Sits exactly where the registry entry sits, so it sees the host's props
+ * verbatim, then forwards them to the adapter under test. This is what makes
+ * the identity assertion possible: `captured.node` and the widget's `field`
+ * are observed within a single render pass.
+ */
+function CarrierSpy(props: any) {
+  captured.node = props.schema;
+  return <AdaptedProbe {...props} />;
+}
+
+beforeEach(() => {
+  captured.props = null;
+  captured.node = null;
+  ComponentRegistry.register('carrierprobe', CarrierSpy, {
+    namespace: 'field',
+    skipFallback: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('SDUI path — the authored node arrives as `field` (objectui#3233)', () => {
+  it('hands the widget the very object it used to read through `schema`', () => {
+    const node = {
+      type: 'field:carrierprobe',
+      name: 'city',
+      label: 'City',
+      placeholder: 'Where?',
+      options: [{ label: 'Beijing', value: 'bj' }],
+    };
+
+    render(<SchemaRenderer schema={node as any} />);
+
+    expect(screen.getByTestId('carrier-probe')).toHaveTextContent('City');
+    expect(captured.props).not.toBeNull();
+    expect(captured.node).toBeTruthy();
+    // The payload-equivalence proof: same object, by reference. A
+    // reconstruction would still render "City" while quietly dropping whatever
+    // the copy did not know to carry.
+    expect(captured.props!.field).toBe(captured.node);
+    // …and it really is the whole authored node, not a narrowed projection.
+    expect(captured.props!.field.name).toBe('city');
+    expect(captured.props!.field.placeholder).toBe('Where?');
+    expect(captured.props!.field.options).toEqual([{ label: 'Beijing', value: 'bj' }]);
+  });
+
+  it('consumes `schema` rather than forwarding it to the widget', () => {
+    // Key ABSENCE, not `undefined`. Two reasons it must not be forwarded: a
+    // widget could resolve `field || schema` again (the second contract
+    // survives in practice while the type claims it is gone), and widgets
+    // spread their leftover props onto DOM nodes, where an object-valued
+    // `schema` attribute is a React warning.
+    render(
+      <SchemaRenderer schema={{ type: 'field:carrierprobe', name: 'city', label: 'City' } as any} />,
+    );
+
+    expect(captured.props).not.toBeNull();
+    expect('schema' in captured.props!).toBe(false);
+  });
+
+  it('lets an explicit `field` win when a host supplies both', () => {
+    // The form renderer passes `field` (resolved metadata) and never `schema`.
+    // If some host ever passed both, the resolved metadata is the better
+    // answer — the raw node is the fallback, not the override.
+    const node = { type: 'field:carrierprobe', name: 'from-node', label: 'From node' };
+    const metadata = { name: 'from-field', label: 'From field' };
+
+    render(<AdaptedProbe schema={node} field={metadata} />);
+
+    expect(captured.props!.field).toBe(metadata);
+  });
+
+  it('applies the adapter on the REAL registration path (`registerField`)', async () => {
+    // The seam is only worth anything if `registerField` goes through it.
+    // `BooleanField` reads `widget` / `name` off its metadata carrier and
+    // nowhere else: `widget: 'checkbox'` selects the Checkbox over the Switch,
+    // and `name` becomes the control's id. Both are node keys, so seeing them
+    // honoured here proves the node reached `field` end to end — through the
+    // real registry entry, the real SchemaRenderer, and the real widget.
+    registerField('boolean');
+
+    render(
+      <Suspense fallback={<div>loading</div>}>
+        <SchemaRenderer
+          schema={
+            { type: 'field:boolean', name: 'is_active', label: 'Active', widget: 'checkbox' } as any
+          }
+        />
+      </Suspense>,
+    );
+
+    const control = await screen.findByRole('checkbox');
+    expect(control).toHaveAttribute('id', 'is_active');
+  });
+});

--- a/packages/fields/src/__tests__/widget-props-contract.test.tsx
+++ b/packages/fields/src/__tests__/widget-props-contract.test.tsx
@@ -69,6 +69,14 @@ describe('FieldWidgetComponentProps is closed (objectui#3221)', () => {
     // @ts-expect-error the prop is `onChange`
     void props.onchange;
 
+    // The second metadata carrier is gone (objectui#3233). `schema` was a
+    // DECLARED key here through #3221 — one concept under two spellings, which
+    // is how ~30 widgets ended up resolving `field || schema`. v17 converged it
+    // at the producers, so reading it is now a compile error rather than a
+    // silent second contract for the next widget author to discover.
+    // @ts-expect-error `schema` was retired from the widget contract in v17
+    void props.schema;
+
     expect(true).toBe(true);
   });
 
@@ -79,9 +87,11 @@ describe('FieldWidgetComponentProps is closed (objectui#3221)', () => {
     const passThrough: FieldWidgetComponentProps<string> = {
       value: '',
       onChange: () => {},
+      // The single metadata carrier (objectui#3233) — every host produces this
+      // one key: the form renderer (`renderFieldComponent`), the inline-edit
+      // hosts, and the registry adapter that maps `SchemaRenderer`'s SDUI node
+      // onto it.
       field,
-      // form renderer (`renderFieldComponent`)
-      schema: field,
       dataSource: {},
       dependentValues: { country: 'cn' },
       dependsOn: ['country'],

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -14,6 +14,7 @@ import { Badge, Avatar, AvatarImage, AvatarFallback, Button, Checkbox, EmptyValu
 import { Check, X, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import { SchemaRendererContext as _SchemaRendererContext } from '@object-ui/react';
+import { withFieldCarrier } from './withFieldCarrier';
 
 // Module-level cache so multiple renderers fetching the same lookup ID
 // only trigger one network call. Keyed by `${objectName}:${id}`.
@@ -2277,9 +2278,12 @@ export function registerField(fieldType: string): void {
   
   // Create lazy component
   const LazyFieldWidget = React.lazy(loader);
-  
-  // Register with field namespace - NO WRAPPER to allow form renderer to control label/layout
-  ComponentRegistry.register(fieldType, LazyFieldWidget, {
+
+  // Register with field namespace. No LAYOUT wrapper — the form renderer owns
+  // label/description/spacing. The only thing wrapped is the metadata carrier:
+  // `withFieldCarrier` maps `SchemaRenderer`'s `schema` node onto `field`
+  // (objectui#3233) and renders nothing of its own.
+  ComponentRegistry.register(fieldType, withFieldCarrier(LazyFieldWidget), {
     namespace: 'field',
     skipFallback: FIELD_TYPES_SKIP_FALLBACK.has(fieldType),
   });
@@ -2353,7 +2357,7 @@ export function registerFields() {
   // field type. Registered WITHOUT createFieldRenderer: it is a fully-controlled
   // widget (value/onChange from RHF), so the wrapper's extra label + local value
   // buffer would only duplicate the form's FormLabel and desync the value.
-  ComponentRegistry.register('capability-multiselect', CapabilityMultiSelectField, { namespace: 'field', skipFallback: true });
+  ComponentRegistry.register('capability-multiselect', withFieldCarrier(CapabilityMultiSelectField), { namespace: 'field', skipFallback: true });
   // master_detail = child-side FK lookup (single value, typically required). See
   // fieldWidgetMap above for rationale.
   ComponentRegistry.register('master_detail', createFieldRenderer(LookupField), { namespace: 'field' });
@@ -2450,6 +2454,12 @@ export * from './widgets/MultiSelectField';
 export * from './widgets/RadioField';
 export * from './widgets/CheckboxesField';
 export * from './widgets/TagsField';
+
+// The SDUI-node → `field` adapter every registration here goes through
+// (objectui#3233). Exported so a widget registered OUTSIDE this repo can reach
+// the same single-carrier guarantee instead of re-growing a `field || schema`
+// read of its own.
+export { withFieldCarrier } from './withFieldCarrier';
 
 // Initialize registry
 registerAllFields();

--- a/packages/fields/src/widgets/AvatarField.tsx
+++ b/packages/fields/src/widgets/AvatarField.tsx
@@ -11,7 +11,7 @@ export function AvatarField({ value, onChange, field, readonly, ...props }: Fiel
   const [isHovered, setIsHovered] = React.useState(false);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   
-  const avatarField = (field || (props as any).schema) as any;
+  const avatarField = field as any;
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];

--- a/packages/fields/src/widgets/BooleanField.tsx
+++ b/packages/fields/src/widgets/BooleanField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Renders as Switch or Checkbox based on field widget configuration
  */
 export function BooleanField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<boolean>) {
-  const config = (field || (props as any).schema) as any;
+  const config = field as any;
   // Use simple type assertion for arbitrary custom properties not in BaseFieldMetadata
   const widget = config?.widget;
   // Generate unique ID using React's useId hook - must be before early returns (rules of hooks)

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -25,14 +25,13 @@ export function CheckboxesField({
   field,
   readonly,
   className,
-  schema,
   dependentValues,
   dependsOn: dependsOnProp,
   emptyHint,
   dataSource: _dataSource,
   ...props
 }: FieldWidgetComponentProps<string[]>) {
-  const config = (field || schema) as any;
+  const config = field as any;
   const rawOptions: Option[] = config?.options || [];
   const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
   const groupId = useId();

--- a/packages/fields/src/widgets/CodeField.tsx
+++ b/packages/fields/src/widgets/CodeField.tsx
@@ -8,7 +8,7 @@ import { FieldWidgetComponentProps } from './types';
  * For advanced code editing, use the @object-ui/plugin-editor component
  */
 export function CodeField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
-  const config = field || (props as any).schema;
+  const config = field;
   // Get code-specific configuration from field metadata
   const language = (config as any)?.language ?? 'javascript';
 

--- a/packages/fields/src/widgets/ColorField.tsx
+++ b/packages/fields/src/widgets/ColorField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Supports hex color values (e.g., #ff0000)
  */
 export function ColorField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
-  const colorField = (field || (props as any).schema) as any;
+  const colorField = field as any;
 
   if (readonly) {
     return (

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -37,7 +37,7 @@ const CURRENCY_SYMBOLS: Record<string, string> = {
 };
 
 export function CurrencyField({ value, onChange, field, readonly, error, className, ...props }: FieldWidgetComponentProps<number>) {
-  const currencyField = (field || (props as any).schema) as any;
+  const currencyField = field as any;
   // Shared precedence: field currency → currencyConfig → tenant default (ADR-0053).
   const { currency: tenantCurrency } = useLocalization();
   const currency: string | undefined = resolveFieldCurrency(currencyField, tenantCurrency);

--- a/packages/fields/src/widgets/EmailField.tsx
+++ b/packages/fields/src/widgets/EmailField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Renders as a clickable mailto link when readonly, standard email input otherwise
  */
 export function EmailField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
-  const config = field || (props as any).schema;
+  const config = field;
   if (readonly) {
     if (!value) return <EmptyValue />;
     return (

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -119,7 +119,7 @@ export function FileField({ value, onChange, field, readonly, onUploadingChange,
   const { t } = useObjectTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
   const cameraRef = useRef<HTMLInputElement>(null);
-  const fileField = (field || (props as any).schema) as any;
+  const fileField = field as any;
   const multiple = fileField?.multiple || false;
   const accept = fileField?.accept ? fileField.accept.join(',') : undefined;
   const maxSize = fileField?.maxSize as number | undefined; // bytes

--- a/packages/fields/src/widgets/FormulaField.tsx
+++ b/packages/fields/src/widgets/FormulaField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Values are computed on the backend and cannot be edited
  */
 export function FormulaField({ value, field, ...props }: FieldWidgetComponentProps<any>) {
-  const formulaField = (field || (props as any).schema) as any;
+  const formulaField = field as any;
   const returnType = formulaField?.return_type || 'text';
 
   if (value == null) {

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -324,7 +324,7 @@ export function GridField({
    *  the header (`parent.status == 'paid'`). Supplied by MasterDetailForm. */
   contextRecord?: Record<string, unknown>;
 }) {
-  const cfg = (field || (props as any).schema || {}) as any;
+  const cfg = (field || {}) as any;
   const allColumns: GridColumn[] = cfg.columns || [];
   const rows: Row[] = Array.isArray(value) ? value : [];
   const contextRecord = props.contextRecord;

--- a/packages/fields/src/widgets/ImageField.tsx
+++ b/packages/fields/src/widgets/ImageField.tsx
@@ -26,7 +26,7 @@ const ImageCropperDialog = lazy(() =>
  */
 export function ImageField({ value, onChange, field, readonly, onUploadingChange, ...props }: FieldWidgetComponentProps<any>) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const imageField = (field || (props as any).schema) as any;
+  const imageField = field as any;
   const multiple = imageField?.multiple || false;
   const accept = imageField?.accept ? imageField.accept.join(',') : 'image/*';
   /**

--- a/packages/fields/src/widgets/LocationField.tsx
+++ b/packages/fields/src/widgets/LocationField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Stores location as { latitude, longitude } object and displays as comma-separated pair
  */
 export function LocationField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<any>) {
-  const config = field || (props as any).schema;
+  const config = field;
   // Location is stored as { latitude, longitude } object
   // For display, convert to "latitude, longitude" string format
   const displayValue = value && typeof value === 'object' 

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -215,7 +215,7 @@ export function LookupField({ value, onChange, field, readonly, ...props }: Fiel
   const [activeIndex, setActiveIndex] = useState(-1);
   const listRef = useRef<HTMLDivElement>(null);
 
-  const lookupField = (field || (props as any).schema) as any;
+  const lookupField = field as any;
 
   // When rendered via createFieldRenderer wrapper the actual objectSchema field
   // metadata (reference_to, display_field, etc.) lives at lookupField.field.

--- a/packages/fields/src/widgets/MasterDetailField.tsx
+++ b/packages/fields/src/widgets/MasterDetailField.tsx
@@ -25,7 +25,7 @@ export function MasterDetailField({
   ...props 
 }: FieldWidgetComponentProps<MasterDetailValue[]>) {
   const items = value || [];
-  const config = field || (props as any).schema;
+  const config = field;
 
   const handleAdd = () => {
     // This would typically open a dialog to select/create related records

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -27,14 +27,13 @@ export function MultiSelectField({
   field,
   readonly,
   className,
-  schema,
   dependentValues,
   dependsOn: dependsOnProp,
   emptyHint,
   dataSource: _dataSource,
   ...props
 }: FieldWidgetComponentProps<string[]>) {
-  const config = (field || schema) as any;
+  const config = field as any;
   const rawOptions: Option[] = config?.options || [];
   const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
   const fieldName = props.name || config?.name || props.id || '';

--- a/packages/fields/src/widgets/NumberField.tsx
+++ b/packages/fields/src/widgets/NumberField.tsx
@@ -12,7 +12,7 @@ export function NumberField({ value, onChange, field, readonly, ...props }: Fiel
     return value == null ? <EmptyValue /> : <span className="text-sm">{value}</span>;
   }
 
-  const numberField = (field || (props as any).schema) as NumberFieldMetadata;
+  const numberField = field as NumberFieldMetadata;
   // Step follows `scale` (decimal places), not `precision` (total digit count):
   // a decimal(10, 0) column has 0 decimal places, so the input should step by 1
   // (`scale: 0` is a valid declaration — hence the typeof check, not truthiness).

--- a/packages/fields/src/widgets/ObjectField.tsx
+++ b/packages/fields/src/widgets/ObjectField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Allows editing structured JSON data
  */
 export function ObjectField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<any>) {
-  const config = field || (props as any).schema;
+  const config = field;
   
   // Initialize string state based on value
   const getInitialJsonString = () => {

--- a/packages/fields/src/widgets/PasswordField.tsx
+++ b/packages/fields/src/widgets/PasswordField.tsx
@@ -10,7 +10,7 @@ import { FieldWidgetComponentProps } from './types';
  */
 export function PasswordField({ value, onChange, field, readonly, className, ...props }: FieldWidgetComponentProps<string>) {
   const [showPassword, setShowPassword] = useState(false);
-  const config = field || (props as any).schema;
+  const config = field;
 
   if (readonly) {
     return <span className="text-sm">••••••••</span>;

--- a/packages/fields/src/widgets/PercentField.tsx
+++ b/packages/fields/src/widgets/PercentField.tsx
@@ -8,7 +8,7 @@ import { FieldWidgetComponentProps } from './types';
  * Includes a slider for interactive control.
  */
 export function PercentField({ value, onChange, field, readonly, error, className, ...props }: FieldWidgetComponentProps<number>) {
-  const percentField = (field || (props as any).schema) as any;
+  const percentField = field as any;
   const precision = percentField?.precision ?? 2;
 
   // Convention detection. A field declaring `max > 1` (e.g. `max: 100`) stores

--- a/packages/fields/src/widgets/PhoneField.tsx
+++ b/packages/fields/src/widgets/PhoneField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Renders as a clickable tel link when readonly, standard phone input otherwise
  */
 export function PhoneField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
-  const config = field || (props as any).schema;
+  const config = field;
   if (readonly) {
     if (!value) return <EmptyValue />;
     return (

--- a/packages/fields/src/widgets/QRCodeField.tsx
+++ b/packages/fields/src/widgets/QRCodeField.tsx
@@ -9,7 +9,7 @@ import { FieldWidgetComponentProps } from './types';
  */
 export function QRCodeField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
   const [showQR, setShowQR] = React.useState(false);
-  const config = field || (props as any).schema;
+  const config = field;
 
   // Simple QR code generation using an external library would be ideal
   // For now, we'll use a service API approach or placeholder

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -25,14 +25,13 @@ export function RadioField({
   field,
   readonly,
   className,
-  schema,
   dependentValues,
   dependsOn: dependsOnProp,
   emptyHint,
   dataSource: _dataSource,
   ...props
 }: FieldWidgetComponentProps<string>) {
-  const config = (field || schema) as any;
+  const config = field as any;
   const rawOptions: Option[] = config?.options || [];
   const groupId = useId();
   const fieldName = props.name || config?.name || props.id || '';

--- a/packages/fields/src/widgets/RatingField.tsx
+++ b/packages/fields/src/widgets/RatingField.tsx
@@ -9,7 +9,7 @@ import { FieldWidgetComponentProps } from './types';
  */
 export function RatingField({ value, onChange, field, readonly, className, ...props }: FieldWidgetComponentProps<number>) {
   // Get rating-specific configuration from field metadata
-  const ratingField = (field || (props as any).schema) as any;
+  const ratingField = field as any;
   const max = ratingField?.max ?? 5;
   const currentValue = value ?? 0;
 

--- a/packages/fields/src/widgets/RichTextField.tsx
+++ b/packages/fields/src/widgets/RichTextField.tsx
@@ -20,7 +20,7 @@ export function RichTextField({ value, onChange, field, readonly, error, ...prop
     );
   }
 
-  const richField = (field || (props as any).schema) as any;
+  const richField = field as any;
   const rows = richField?.rows || 8;
   const format = richField?.format || 'markdown'; // 'markdown' or 'html'
 

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -31,7 +31,7 @@ import { useCascadingOptions } from './useCascadingOptions';
  * in lockstep.
  */
 export function SelectField(props: FieldWidgetComponentProps<any>) {
-  const config = (props.field || (props as any).schema) as SelectFieldMetadata | undefined;
+  const config = props.field as SelectFieldMetadata | undefined;
   if ((config as any)?.multiple) {
     return <MultiSelectField {...props} />;
   }
@@ -54,14 +54,13 @@ function SingleSelectField({
   onChange,
   field,
   readonly,
-  schema,
   dependentValues,
   dependsOn: dependsOnProp,
   emptyHint,
   dataSource: _dataSource,
   ...props
 }: FieldWidgetComponentProps<string>) {
-  const config = (field || schema) as SelectFieldMetadata;
+  const config = field as SelectFieldMetadata;
   const rawOptions = config?.options || [];
   const { t } = useFieldTranslation();
   // Stable hook for automation/e2e — react-hook-form + Radix Select cannot be

--- a/packages/fields/src/widgets/SliderField.tsx
+++ b/packages/fields/src/widgets/SliderField.tsx
@@ -8,7 +8,7 @@ import { FieldWidgetComponentProps } from './types';
  */
 export function SliderField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<number>) {
   // Get slider-specific configuration from field metadata
-  const sliderField = (field || (props as any).schema) as any;
+  const sliderField = field as any;
   const min = sliderField?.min ?? 0;
   const max = sliderField?.max ?? 100;
   const step = sliderField?.step ?? 1;

--- a/packages/fields/src/widgets/SummaryField.tsx
+++ b/packages/fields/src/widgets/SummaryField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Values are aggregated from related records and cannot be edited
  */
 export function SummaryField({ value, field, ...props }: FieldWidgetComponentProps<any>) {
-  const summaryField = (field || (props as any).schema) as any;
+  const summaryField = field as any;
   const summaryType = summaryField?.summary_type || 'count';
 
   if (value == null) {

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -22,9 +22,10 @@ import { FieldWidgetComponentProps } from './types';
  *
  * That flag has exactly one producer: `ObjectForm` stamps it onto every
  * long-text field when `ObjectFormSchema.mobile.fullscreenLongText` is set
- * (`plugin-form/src/ObjectForm.tsx`). It reaches this widget on `field`, or
- * on `schema` when the host is `SchemaRenderer` — the same pair every widget
- * here resolves as `field || schema` (see `FieldWidgetComponentProps.schema`).
+ * (`plugin-form/src/ObjectForm.tsx`). It reaches this widget on `field` — the
+ * single metadata carrier since objectui#3233. A `SchemaRenderer`-hosted node
+ * arrives there too: the registry adapter (`withFieldCarrier`) maps the SDUI
+ * `schema` node onto `field` before the widget sees it.
  *
  * There is deliberately NO widget-prop override. A `mobileFullscreen`
  * (camelCase) prop was read here and written by nobody in the repo, and the
@@ -50,16 +51,15 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
     );
   }
 
-  const textareaField = (field || (props as any).schema) as any;
+  const textareaField = field as any;
   const rows = textareaField?.rows || 4;
   // Spec FieldSchema declares camelCase `maxLength`; `max_length` is the legacy
   // objectui spelling. Dual-read (framework#1878 §3 recheck) — without this a
   // spec-authored maxLength gave neither the textarea cap nor the counter.
   const maxLength = textareaField?.maxLength ?? textareaField?.max_length;
   // Mobile fullscreen opt-in travels on the field metadata and nowhere else.
-  // `textareaField` already resolves the two carriers a host may use for that
-  // metadata (`field`, else `schema`), so this is a single read — a misspelled
-  // flag now has no read path to quietly catch it.
+  // That metadata has exactly one carrier (`field`, objectui#3233), so this is
+  // a single read — a misspelled flag has no read path to quietly catch it.
   const showFullscreenButton = Boolean(textareaField?.mobile_fullscreen);
 
   const openFullscreen = () => { setDraft(value ?? ''); setFullscreenOpen(true); };

--- a/packages/fields/src/widgets/TextField.tsx
+++ b/packages/fields/src/widgets/TextField.tsx
@@ -8,7 +8,7 @@ import { FieldWidgetComponentProps } from './types';
  * Automatically renders as a textarea when rows are configured in field metadata
  */
 export function TextField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
-  const fieldData = field || (props as any).schema;
+  const fieldData = field;
 
   if (readonly) {
     return <span className="text-sm">{value || <EmptyValue />}</span>;

--- a/packages/fields/src/widgets/UrlField.tsx
+++ b/packages/fields/src/widgets/UrlField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Validates URLs to only render http/https links for security
  */
 export function UrlField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
-  const config = field || (props as any).schema;
+  const config = field;
   if (readonly) {
     if (!value) return <EmptyValue />;
     

--- a/packages/fields/src/widgets/UserField.tsx
+++ b/packages/fields/src/widgets/UserField.tsx
@@ -30,7 +30,7 @@ function withBannedFilter(filters?: any[]): any[] {
 }
 
 export function UserField(props: FieldWidgetComponentProps<any>) {
-  const raw = (props.field || (props as any).schema) as any;
+  const raw = props.field as any;
 
   // The objectSchema field metadata may live directly on `field`, or nested at
   // `field.field` when rendered via the createFieldRenderer wrapper — mirror the

--- a/packages/fields/src/widgets/VectorField.tsx
+++ b/packages/fields/src/widgets/VectorField.tsx
@@ -7,7 +7,7 @@ import { FieldWidgetComponentProps } from './types';
  * Shows vector embeddings in a read-only format
  */
 export function VectorField({ value, field, ...props }: FieldWidgetComponentProps<number[]>) {
-  const vectorField = (field || (props as any).schema) as any;
+  const vectorField = field as any;
   const dimensions = vectorField?.dimensions || (Array.isArray(value) ? value.length : 0);
 
   if (!value || !Array.isArray(value)) {

--- a/packages/fields/src/widgets/__tests__/TextAreaField.mobileFullscreen.test.tsx
+++ b/packages/fields/src/widgets/__tests__/TextAreaField.mobileFullscreen.test.tsx
@@ -91,21 +91,32 @@ describe('TextAreaField mobile fullscreen — the metadata flag is the only sour
     expect(onChange).toHaveBeenCalledWith('hello from fullscreen');
   });
 
-  it('reads the flag off `schema` when the host supplies no `field`', () => {
-    // `SchemaRenderer` passes the authored node as `schema`; the widget
-    // resolves its config as `field || schema`, which is why deleting the
-    // separate `schema.mobile_fullscreen` read lost nothing. `field` is
-    // required by the type, so the cast reproduces the runtime shape only.
-    render(
-      <TextAreaField
-        value=""
-        onChange={() => {}}
-        field={undefined as unknown as FieldMetadata}
-        schema={fieldMeta({ mobile_fullscreen: true })}
-      />,
-    );
+  it('no longer reads the flag off a `schema` prop (objectui#3233)', () => {
+    // This used to be the second carrier: `SchemaRenderer` passed the authored
+    // node as `schema` and the widget resolved `field || schema`. v17 converged
+    // that at the producer — the registry adapter (`withFieldCarrier`) maps the
+    // SDUI node onto `field` before any widget sees it, so the widget has one
+    // read. A host that still passes `schema` is now inert AND loud: a compile
+    // error on the closed props type, and no affordance at runtime.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const legacyHostProps = {
+        schema: fieldMeta({ mobile_fullscreen: true }),
+      } as unknown as Partial<FieldWidgetComponentProps<string>>;
 
-    expect(screen.getByTestId('textarea-fullscreen-toggle')).toBeInTheDocument();
+      render(
+        <TextAreaField
+          value=""
+          onChange={() => {}}
+          field={fieldMeta()}
+          {...legacyHostProps}
+        />,
+      );
+
+      expect(screen.queryByTestId('textarea-fullscreen-toggle')).not.toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('renders no affordance when the metadata does not opt in', () => {
@@ -127,6 +138,10 @@ describe('TextAreaField mobile fullscreen — the retired prop spellings', () =>
     void props.mobileFullscreen;
     // @ts-expect-error `mobile_fullscreen` is a metadata key, not a widget prop
     void props.mobile_fullscreen;
+    // …and the retired second METADATA carrier (objectui#3233). The flag has
+    // one source and that source now has one carrier.
+    // @ts-expect-error `schema` was retired from the widget contract in v17
+    void props.schema;
 
     expect(true).toBe(true);
   });

--- a/packages/fields/src/widgets/types.ts
+++ b/packages/fields/src/widgets/types.ts
@@ -54,6 +54,22 @@ import type { DependsOnInput, FieldMetadata } from '@object-ui/types';
  * is expressed as a template-literal index signature, which — unlike
  * `[key: string]` — leaves `keyof` finite, so an undeclared prop still fails.
  *
+ * ## Why there is no `schema` (objectui#3233)
+ *
+ * `schema` used to be declared here as a SECOND carrier for what `field`
+ * already means — `SchemaRenderer` handed the SDUI node down as `schema`, the
+ * form renderer forwarded `schema={props.field || props.schema || props}`
+ * *alongside* `field`, and ~30 widgets resolved their config as
+ * `field || schema`. One concept, two keys, two producers: exactly the
+ * consumer-side tolerance AGENTS.md #0.1 forbids, and exactly the shape that
+ * lets an AI-written widget pick the wrong spelling and still "work" under one
+ * host while reading `undefined` under another.
+ *
+ * v17 converged it at the PRODUCERS. `field` is the only carrier a widget ever
+ * sees; the SDUI node → `field` translation happens once, in this package's
+ * registry adapter (`withFieldCarrier`), not ~30 times in the widgets. Reading
+ * `props.schema` is now a compile error rather than a silent second contract.
+ *
  * Adding a key here is a contract change: say who produces it and who reads it.
  */
 export type FieldWidgetComponentProps<T = any> = {
@@ -62,8 +78,17 @@ export type FieldWidgetComponentProps<T = any> = {
   value: T;
   onChange: (val: T) => void;
   /**
-   * The field's metadata. Deliberately the looser `@object-ui/types` shape
-   * rather than the spec's, to avoid a circular dependency for now.
+   * The field's metadata, and the SINGLE carrier for it (objectui#3233).
+   *
+   * Deliberately the looser `@object-ui/types` shape rather than the spec's,
+   * to avoid a circular dependency for now.
+   *
+   * Every host produces it: the form renderer's `renderFieldComponent`, the
+   * inline-edit hosts (`FieldEditWidget`), `ActionParamDialog` /
+   * `BulkActionDialog`, and — since #3233 — the registry adapter that adapts
+   * `SchemaRenderer`'s SDUI node onto this contract (`withFieldCarrier` in
+   * `packages/fields/src/withFieldCarrier.tsx`). A widget reads `props.field`
+   * and nothing else; there is no second key to check.
    */
   field: FieldMetadata;
   readonly?: boolean;
@@ -94,17 +119,6 @@ export type FieldWidgetComponentProps<T = any> = {
 
   /* ── Host plumbing: what a rendering host actually forwards ─────────────── */
 
-  /**
-   * The raw authored node the widget was rendered from. Two hosts supply it:
-   * `SchemaRenderer` (`<Component schema={schema} {...schema} />`) and the
-   * form renderer's `renderFieldComponent` (`schema={props.field || ...}`),
-   * which is why ~25 widgets read `field || schema` for their config.
-   *
-   * This is a second carrier for what `field` already means, i.e. a de-facto
-   * second contract (AGENTS.md #0.1) — declared here so it is at least
-   * visible; converging the two is tracked separately.
-   */
-  schema?: FieldMetadata | Record<string, unknown>;
   /**
    * DataSource for widgets that query records (lookup / user / object-ref /
    * recipient-picker / grid). Injected by the form renderer for the field

--- a/packages/fields/src/withFieldCarrier.tsx
+++ b/packages/fields/src/withFieldCarrier.tsx
@@ -1,0 +1,75 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+/**
+ * Adapt `SchemaRenderer`'s SDUI carrier onto the field-widget contract —
+ * objectui#3233, the producer-side half of retiring `schema` from
+ * {@link import('./widgets/types').FieldWidgetComponentProps}.
+ *
+ * ## Why this exists
+ *
+ * Two kinds of host render a registered field widget, and they name the
+ * metadata differently *for good reason*:
+ *
+ *  - the **form renderer** (`renderFieldComponent` in
+ *    `@object-ui/components`), the inline-edit hosts (`FieldEditWidget`) and
+ *    the action dialogs pass **`field`** — the field metadata they already
+ *    hold;
+ *  - **`SchemaRenderer`** (`@object-ui/react`) passes **`schema`** — the
+ *    authored node. That key is the UNIVERSAL SDUI contract *every* registered
+ *    component receives (`element:*`, `page:*`, `object-grid`,
+ *    `ReportRenderer` …). It is not being retired and must not be: it is what
+ *    the renderer means by "the node you were rendered from".
+ *
+ * What WAS wrong is that both keys reached the widget, so ~30 widgets resolved
+ * their config as `field || schema` — one concept under two spellings, a second
+ * de-facto contract on the widget side (AGENTS.md #0.1) and precisely the shape
+ * that lets an AI-written widget pick one spelling and appear to work under one
+ * host while reading `undefined` under the other.
+ *
+ * The translation belongs at the seam, exactly once: here. Downstream `field`
+ * is the only carrier, and a widget reading `props.schema` no longer compiles.
+ *
+ * ## Guarantee
+ *
+ * Payload-preserving by construction: the node is forwarded **by reference**,
+ * so a widget's `field` is the very object it used to read through `schema`.
+ * `field` wins when a host supplies both (the form path always does, and it
+ * holds the resolved metadata rather than the raw node).
+ *
+ * `schema` is *consumed* here rather than forwarded — with the key gone from
+ * the contract, passing it on would only reach the DOM as a stray attribute
+ * through a widget's `...props` spread.
+ *
+ * ## For widget authors outside this repo
+ *
+ * Registering a widget raw means `SchemaRenderer` hands it `schema` and no
+ * `field`. Wrap it once at registration and the widget only ever implements
+ * `FieldWidgetComponentProps`:
+ *
+ * ```tsx
+ * import { withFieldCarrier } from '@object-ui/fields';
+ *
+ * ComponentRegistry.register('color', withFieldCarrier(ColorPickerField), {
+ *   namespace: 'field',
+ * });
+ * ```
+ */
+export function withFieldCarrier<P extends object>(
+  FieldWidget: React.ComponentType<P>,
+): React.FC<Record<string, any>> {
+  const FieldCarrierAdapter: React.FC<Record<string, any>> = ({ schema, field, ...props }) => (
+    <FieldWidget {...(props as unknown as P)} field={field ?? schema} />
+  );
+  FieldCarrierAdapter.displayName = `FieldCarrier(${
+    (FieldWidget as any).displayName || (FieldWidget as any).name || 'Component'
+  })`;
+  return FieldCarrierAdapter;
+}

--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -266,11 +266,36 @@ The slot is named `error` because that is what `FieldWidgetPropsSchema` in
 `@objectstack/spec/ui` — the published widget contract — calls it.
 
 The type is **closed**: it also declares the host plumbing and DOM/ARIA
-pass-through keys the renderer forwards (`schema`, `dataSource`,
-`dependentValues`, `dependsOn`, `emptyHint`, `compact`, `id`, `name`,
-`aria-*`, `data-*`), and nothing else. A key it does not declare is a compile
-error rather than a silent `any`, so a typo like `readOnly` for `readonly` is
-caught at build time instead of being quietly `undefined` at runtime.
+pass-through keys the renderer forwards (`dataSource`, `dependentValues`,
+`dependsOn`, `emptyHint`, `compact`, `id`, `name`, `aria-*`, `data-*`), and
+nothing else. A key it does not declare is a compile error rather than a silent
+`any`, so a typo like `readOnly` for `readonly` is caught at build time instead
+of being quietly `undefined` at runtime.
+
+### `field` is the only metadata carrier (v17, breaking)
+
+Before v17 a widget could receive its metadata under **either** `field` or
+`schema`, so widgets in the wild resolve their config as `field || schema`.
+`schema` is gone from the widget contract in v17 — read `props.field`, full
+stop.
+
+`schema` still exists everywhere else: it is the universal SDUI node
+`SchemaRenderer` hands to *every* registered component. That is exactly why a
+field widget needs an adapter when it is rendered from a schema node rather
+than from a form. Wrap it once, at registration:
+
+```tsx
+import { ComponentRegistry } from '@object-ui/core';
+import { withFieldCarrier } from '@object-ui/fields';
+
+ComponentRegistry.register('color', withFieldCarrier(ColorField), {
+  namespace: 'field',
+});
+```
+
+`withFieldCarrier` maps the node onto `field` (by reference — nothing is
+copied or dropped) and consumes `schema`, so the widget only ever implements
+one contract. All built-in field widgets are registered through it.
 
 Two things are deliberately **not** props, because each has exactly one author
 in the form renderer: the validation message TEXT (`<FormMessage/>`) and the


### PR DESCRIPTION
Closes #3233

按 2026-08-03 维护者裁决走**路线 B 直接落 v17**：生产者侧收敛到 `field`，从 widget 契约删除 `schema`，删掉全部消费端 `field || schema` 容忍。不做弃用期。

## 前提核对（实施前）

| 前提 | 结论 |
|---|---|
| `FieldWidgetComponentProps` 上 `schema` 仍是已声明键 | ✅ 成立（`packages/fields/src/widgets/types.ts`，#3221/PR #3230 封口的那版） |
| `field \|\| schema` 读法仍存在 | ✅ 成立，**32 处**（issue 估「约 25 处」；主流写法是 `field \|\| (props as any).schema`，只有 4 处写成字面 `field \|\| schema`，所以按字面量 grep 会严重低估） |

## 两条生产者路径

### 1. 表单路径 —— `renderFieldComponent`（`packages/components/src/renderers/form/form.tsx`）

原状 `schema={props.field || props.schema || props}` 与 `field` **同时**下发。唯一调用点无条件设 `field: field.field || field`（永远真值），所以链上后两项不可达，`schema` 恒 `=== props.field`。改为只传 `field`。

**但这里有一个 issue 未提及、且必须区分的事实**（本单最大的一个坑，被 `form-write-error-message.test.tsx` 抓了个正着）：`renderFieldComponent` 的注册表查找会命中**两类不同的组件**——

- `field:<type>` 命中 → **field widget**，契约是 `FieldWidgetComponentProps`，载体 `field`；
- 裸名兜底命中 → **普通 SDUI 组件**（展示型 `text`、`alert`、`badge` …），契约是 `SchemaRenderer` 给每个注册组件的**通用 `schema` 节点**。这个键**不在本次退役范围内**。

无差别删掉 `schema` 会让后一类渲染成 `undefined.className` 直接崩。所以查找被拆成两步并显式判定 `isFieldWidget`，只在 field widget 分支省略 `schema`，兜底分支**逐字保留**原解析。这条区分本身有专门测试钉住（见下）。

### 2. SDUI 路径 —— 注册适配器（`packages/fields/src/withFieldCarrier.tsx`，新增）

`SchemaRenderer` **没有** field-widget 专用分支：它给所有注册组件统一传 `schema`。而 `registerField()` 是把 widget **裸注册**进 `field:<type>`（及裸名），所以 SDUI 节点走到 widget 时只有 `schema` 没有 `field` —— 这才是那 32 处 `field || schema` 里 `schema` 分支的真实来源。

翻译点收在唯一的接缝上：`withFieldCarrier`，`registerField()` / `capability-multiselect` 全部经它注册。它**按引用**转发节点（不拷贝、不裁剪、不改名），并**吃掉** `schema`（契约里没有这个键了，继续转发只会随 widget 的 `...props` 展开变成 DOM 上的野属性）。

`withFieldCarrier` **已导出**为公共 API —— 这是仓外 widget 作者的迁移工具：裸注册的第三方 widget 在 SDUI 路径上拿不到 `field`，若不给它这个适配器，它们只能自己重新长出一个 `(props as any).schema` 读法，等于把刚删掉的容忍原样搬到仓外。⚠️ 这是本 PR 唯一的 API 面新增，若维护者认为超出授权范围，可以只回退这一处导出（内部仍需要该函数）。

## 载荷等价性证明

不变量：**过去经 `schema` 送达的每条载荷，必须以 `field` 送达完全相同的对象**。两条路径各有一个按**对象同一性**（不是结构相等）断言的测试 —— 结构相等在渲染器改为下发重建副本时依然会绿，而副本会打断按 metadata 引用做记忆化的 widget。

| 路径 | 文件 | 证明方式 |
|---|---|---|
| 表单 | `packages/components/src/renderers/form/__tests__/form-field-carrier.test.tsx` | 探针 widget 断言 `props.field` **`toBe`** 作者写下的那个 metadata 对象（含 `.field` 已声明槽与无 `.field` 的内联 config 两种形态） |
| SDUI | `packages/fields/src/__tests__/field-carrier-sdui.test.tsx` | 一个 spy 坐在注册表条目的位置，记录 `SchemaRenderer` 实际传下来的 `schema` 对象，再转发给被测适配器；断言 widget 的 `field` **`toBe`** 那个对象（不能对作者字面量断言 —— `SchemaRenderer` 求值时会浅拷贝节点） |

另外钉住的：

- 两条路径都断言 `'schema' in props === false`（**键缺失**，不是 `undefined` —— 否则 `field || schema` 在实践中依然可解，类型说没了而运行时还在）；
- 表单字段自带 `schema:` 键也无法把第二载体从元数据侧复活；
- **裸名兜底分支仍然收到 `schema`**（上面那条区分的反向断言）；
- `registerField()` **真的**过了适配器 —— 用真 `SchemaRenderer` + 真 `BooleanField` 端到端跑：节点上的 `widget: 'checkbox'` / `name` 只能经载体到达，能选中 Checkbox 而非 Switch 且 id 正确，就证明节点完整落到了 `field`；
- `props.schema` 现在是编译错误（`widget-props-contract.test.tsx` / `TextAreaField.mobileFullscreen.test.tsx` 各加一条 `@ts-expect-error`）。

**每条新增/改动的测试都做了 sabotage 验证**（改坏源码或断言 → 看它红 → 还原 → 看它绿），共 6 次：还原旧的双传（2 条红）、把 `field` 改成下发副本（2 条红）、适配器改为转发 `schema`（1 条红）、适配器改为下发副本（1 条红）、`registerField` 跳过适配器（1 条红，症状正是「渲染成 Switch，找不到 checkbox」——即本次收敛被指控的静默失效）、`isFieldWidget` 恒真（1 条红）。

## 迁移（面向 widget 作者，宿主元数据不受影响）

SDUI JSON / 对象元数据**零改动**。变的只是 widget 的**编写契约**：

```diff
-const config = field || (props as any).schema;
+const config = field;
```

```diff
+import { withFieldCarrier } from '@object-ui/fields';
+
-ComponentRegistry.register('color', ColorField, { namespace: 'field' });
+ComponentRegistry.register('color', withFieldCarrier(ColorField), { namespace: 'field' });
```

仓外 widget 若继续读 `props.schema` 且未经适配器重新注册，在 v17 会读到 `undefined` 并静默渲染空态 —— 该风险维护者已知并接受，缓解是大版本边界 + 变更集里的高声量迁移说明。

## 变更集

`.changeset/field-widget-single-metadata-carrier.md`，含完整迁移说明。

⚠️ **标 `minor` 而非 `major`**，尽管这是破坏性变更：AGENTS.md「版本号策略」明令 objectui 的 changeset 不得声明 `major`（fixed 组任一 major 会把 39 个包整体推上 18，脱离 `@objectstack` 的节奏），破坏性语义写在正文里。这一条由 `scripts/check-changeset-no-major.mjs` + `changeset-guard.yml` 机械强制；本地两个 guard 均已跑过通过。

## 文档

`content/docs/guide/plugin-development.md` 与 `skills/objectui/guides/plugin-development.md`：删掉 `schema` 作为已声明 pass-through 键的说法，新增「`field` 是唯一载体（v17，breaking）」小节 + `withFieldCarrier` 注册示例。未触碰 `content/docs/releases/`。

## 验证

| 项 | 结果 |
|---|---|
| `vitest run packages/fields packages/components` | **111 files / 1052 tests passed** |
| `vitest run packages/plugin-form packages/plugin-grid packages/plugin-detail packages/react` | **151 files / 1489 tests passed** |
| `vitest run packages/app-shell packages/plugin-designer packages/sdui-parser packages/plugin-report` | **279 files / 2404 passed, 1 skipped** |
| `vitest run packages/core packages/layout packages/mobile packages/plugin-dashboard packages/plugin-list packages/plugin-kanban packages/plugin-calendar packages/providers packages/runner packages/i18n` | **143 files / 2137 passed, 24 skipped** |
| `turbo run type-check`（fields / components / react / plugin-form / app-shell） | **33 tasks successful** |
| `turbo run lint`（fields / components / react） | **0 errors**（warning 数与基线一致） |
| `turbo run build`（fields / components） | **10 tasks successful** |
| changeset guards | 两个都通过 |

测试一律从仓根用 `pnpm exec vitest run <paths>` 跑（#3288：`pnpm --filter <pkg> test -- --run <paths>` 会静默忽略路径过滤）。

## 范围外发现

- **#3295** —— `pnpm docs:check-links` 在干净的 `main` 上就报一条坏链接（`content/docs/core/enhanced-actions.mdx → /docs/components/form`），且该脚本**没有挂进任何 workflow**。已 `git stash` 验证与本 PR 无关，单独开 issue（未指派），未并入。

未触碰 #3291（`toDomProps`）与 #3290（`aria-required`）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_