### PR TITLE
fix(components): deliver `aria-required` to field controls (#3290)

### DIFF
--- a/.changeset/aria-required-reaches-the-control.md
+++ b/.changeset/aria-required-reaches-the-control.md
@@ -1,0 +1,54 @@
+---
+"@object-ui/components": patch
+---
+
+The required state now reaches the input control as `aria-required`, instead of
+existing only as part of the control's accessible name (objectui#3290).
+
+The form renderer has always computed a correct `required` — the static
+`required` flag merged with the `requiredWhen` CEL verdict — and then spent it
+on exactly one thing: the red asterisk in `<FormLabel>`. That asterisk carried
+`aria-label="required"`, so the only path from the computed state to assistive
+tech was `<label for>` folding it into the control's **accessible name**: the
+field was announced as "Title required".
+
+A state smuggled through a name is broken three ways:
+
+- it is read in name order rather than announced as a state, and "list the
+  required fields" style navigation cannot see it at all;
+- a field rendered without a `label` (compact layouts, inline grid editing)
+  draws no asterisk, so the signal disappears entirely;
+- `requiredWhen` makes required **dynamic**, and a state channel can express
+  the flip where a name cannot.
+
+## What changed
+
+- Every field control — built-in (`input` / `textarea` / `checkbox` / `switch` /
+  `select`) and registered widget alike — now receives `aria-required="true"`
+  when the field resolves required, and **no attribute at all** when it does
+  not. Absence rather than `aria-required="false"` is deliberate: it is what
+  the `requiredWhen`-turns-false case has to produce.
+- The red asterisk is now `aria-hidden="true"` and no longer carries
+  `aria-label="required"`. It renders exactly as before for sighted users; it
+  simply stops being announced, so the state is reported once (as a state) and
+  not twice.
+
+**No field widget needed a change.** `aria-required` is already declared and
+typed on the widget props contract (`FieldWidgetComponentProps &
+AriaAttributes`) and every widget forwards its leftover props to the control it
+renders, so all 48 widgets pick it up unmodified.
+
+Two non-changes, both deliberate:
+
+- **No native `required` attribute.** That would arm the browser's own
+  constraint-validation bubble alongside react-hook-form's `<FormMessage/>` —
+  two validators, two UIs, one field. `aria-required` reports the state without
+  triggering native validation.
+- **No `required` boolean in the widget props contract.** A boolean would give
+  the required marker a second author, and the next widget draws its own
+  asterisk next to the renderer's — the double-display failure objectui#3222
+  already declined for the validation message.
+
+If you select the asterisk in a test, it is now
+`span[data-required-marker]` — an explicit locator, rather than an
+accessibility attribute doubling as a test hook.

--- a/e2e/live/field-conditional-rules.spec.ts
+++ b/e2e/live/field-conditional-rules.spec.ts
@@ -17,11 +17,18 @@ import { selectOption } from './helpers';
  * Driving the Status select must reactively re-gate every dependent field.
  */
 
-/** True when the field's <label> carries the required asterisk. */
+/**
+ * True when the field's <label> carries the required asterisk.
+ *
+ * Selects on `data-required-marker`, not the marker's old `aria-label`
+ * (objectui#3290): the asterisk is now `aria-hidden` because the required STATE
+ * travels to the control as `aria-required` instead of being folded into its
+ * accessible name. The visual marker is unchanged — only its locator is.
+ */
 async function isRequired(dialog: Locator, labelText: string): Promise<boolean> {
   const marker = dialog
     .locator('label', { hasText: labelText })
-    .locator('span[aria-label="required"]');
+    .locator('span[data-required-marker]');
   return (await marker.count()) > 0;
 }
 

--- a/packages/components/src/renderers/form/__tests__/form-aria-required-delivery.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-aria-required-delivery.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The required STATE must reach the input control, not just the label
+ * (objectui#3290) — the third "declared ≠ delivered" gap in this renderer,
+ * after `error` (#3222) and `emptyHint` (#3231).
+ *
+ * The renderer has always computed a correct `required` (static `required`
+ * merged with the `requiredWhen` CEL verdict) and then spent it on exactly one
+ * thing: the red asterisk in `<FormLabel>`. That asterisk carried
+ * `aria-label="required"`, so the ONLY way the state reached assistive tech was
+ * by `<label for>` folding it into the control's ACCESSIBLE NAME — the field
+ * was read as "Title required". A state smuggled through a name is broken three
+ * ways:
+ *
+ *   1. it is announced in name order rather than as a state, and "list the
+ *      required fields" style navigation cannot see it at all;
+ *   2. a field rendered without a `label` (compact layouts, inline grid
+ *      editing) draws no asterisk, so the signal disappears completely;
+ *   3. `requiredWhen` makes required DYNAMIC — a state channel expresses the
+ *      flip, a name does not.
+ *
+ * The fix costs one host-side prop and zero widget changes: `aria-required` is
+ * already declared and typed on the widget props contract
+ * (`FieldWidgetComponentProps & AriaAttributes`) and every widget forwards its
+ * leftover props to the control it renders; neither strip function touches
+ * `aria-*`. That is exactly why #3222 refused to sink a `required` BOOLEAN into
+ * the widget contract — a boolean gives the asterisk a second author, and the
+ * next AI-written widget draws its own.
+ *
+ * Two things this deliberately does NOT do, both ruled on in the issue:
+ *   • the asterisk keeps rendering but is now `aria-hidden` — the state channel
+ *     is the single source, so nothing is announced twice;
+ *   • no native `required` attribute — that would arm the browser's own
+ *     constraint-validation bubble alongside react-hook-form's messages.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/**
+ * Stands in for a real field widget (`@object-ui/components` tests never load
+ * `@object-ui/fields`) and mirrors the mechanism the fix relies on: destructure
+ * the props it understands, spread the REST onto the control it renders. That
+ * spread is what carries `aria-required` to the DOM with no widget change.
+ *
+ * `data-aria-required-key` distinguishes "the renderer computed FALSE" from
+ * "a strip function ate the prop" — `emptyHint` (#3231) was lost to a strip,
+ * not to a missing computation, and key presence is the only thing that tells
+ * those two failure modes apart.
+ */
+function RequiredProbe(props: any) {
+  const { name, value, onChange, field: _field, error: _error, ...rest } = props;
+  return (
+    <input
+      data-testid={`probe-${name}`}
+      data-aria-required-key={'aria-required' in props ? 'yes' : 'no'}
+      name={name}
+      value={(value as string) ?? ''}
+      onChange={(e) => onChange?.(e.target.value)}
+      {...rest}
+    />
+  );
+}
+
+beforeAll(() => {
+  ComponentRegistry.register('reqprobe', RequiredProbe, { namespace: 'field' });
+}, 30000);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        defaultValues,
+        fields,
+      }}
+    />,
+  );
+}
+
+describe('form renderer — `aria-required` reaches the control (objectui#3290)', () => {
+  it('sets aria-required="true" on a BUILTIN control for a statically required field', () => {
+    renderForm([{ name: 'title', label: 'Title', type: 'input', required: true }], { title: '' });
+
+    expect(screen.getByLabelText(/title/i)).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('sets aria-required="true" on a REGISTERED widget for a statically required field', () => {
+    // The other half of the fork `renderFieldComponent` makes: registered
+    // widgets go through `stripRegisteredFieldProps`, builtins through
+    // `stripRendererOnlyProps`. Both must pass `aria-*` through, so both get a
+    // test — a strip added to one path only would otherwise land silently.
+    renderForm([{ name: 'title', label: 'Title', type: 'reqprobe', required: true }], { title: '' });
+
+    const probe = screen.getByTestId('probe-title');
+    expect(probe).toHaveAttribute('aria-required', 'true');
+    expect(probe).toHaveAttribute('data-aria-required-key', 'yes');
+  });
+
+  it('omits the attribute entirely on an optional field, rather than writing "false"', () => {
+    // `|| undefined`, not `String(required)`. `aria-required="false"` is legal
+    // but noisier than absence, and absence is what the `requiredWhen` FALSE
+    // case below has to produce — asserting it here pins the spelling.
+    renderForm(
+      [
+        { name: 'title', label: 'Title', type: 'input' },
+        { name: 'notes', label: 'Notes', type: 'reqprobe' },
+      ],
+      { title: '', notes: '' },
+    );
+
+    expect(screen.getByLabelText(/title/i)).not.toHaveAttribute('aria-required');
+    expect(screen.getByTestId('probe-notes')).not.toHaveAttribute('aria-required');
+  });
+
+  it('flips the attribute on and off as `requiredWhen` re-evaluates', async () => {
+    // The case a name-shaped signal cannot express at all. `requiredWhen` is
+    // the same CEL the server enforces, so the announced state has to track it
+    // reactively, not just at first paint.
+    renderForm(
+      [
+        { name: 'status', label: 'Status', type: 'input' },
+        {
+          name: 'paid_on',
+          label: 'Paid On',
+          type: 'input',
+          requiredWhen: "record.status == 'paid'",
+        },
+      ],
+      { status: 'draft', paid_on: '' },
+    );
+
+    const paidOn = () => screen.getByLabelText(/paid on/i);
+    expect(paidOn()).not.toHaveAttribute('aria-required');
+
+    fireEvent.change(screen.getByLabelText(/status/i), { target: { value: 'paid' } });
+    await waitFor(() => expect(paidOn()).toHaveAttribute('aria-required', 'true'));
+
+    fireEvent.change(screen.getByLabelText(/status/i), { target: { value: 'draft' } });
+    await waitFor(() => expect(paidOn()).not.toHaveAttribute('aria-required'));
+  });
+
+  it('reaches a required field that renders WITHOUT a label', () => {
+    // The failure mode that motivated the issue: no label ⇒ no asterisk ⇒
+    // under the old design the required signal did not exist at all. The state
+    // channel does not depend on a label being rendered.
+    renderForm([{ name: 'title', type: 'reqprobe', required: true }], { title: '' });
+
+    expect(screen.getByTestId('probe-title')).toHaveAttribute('aria-required', 'true');
+  });
+});
+
+describe('form renderer — the asterisk is visual only (objectui#3290)', () => {
+  it('keeps required OUT of the accessible name now that it is a state', () => {
+    // Asserted on the COMPUTED ACCESSIBLE NAME, not on markup: the regression
+    // being pinned is "assistive tech hears required twice", and only the name
+    // computation shows that. Pre-fix this read "Title required".
+    renderForm([{ name: 'title', label: 'Title', type: 'input', required: true }], { title: '' });
+
+    const input = screen.getByRole('textbox', { name: 'Title' });
+    expect(input).toHaveAccessibleName('Title');
+    expect(input).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('still renders the asterisk for sighted users, hidden from the a11y tree', () => {
+    const { container } = renderForm(
+      [{ name: 'title', label: 'Title', type: 'input', required: true }],
+      { title: '' },
+    );
+
+    const marker = container.querySelector('span[data-required-marker]');
+    expect(marker).not.toBeNull();
+    expect(marker).toHaveTextContent('*');
+    expect(marker).toHaveAttribute('aria-hidden', 'true');
+    // The old a11y-attribute-as-test-hook is gone; nothing should reintroduce
+    // it, or the double announcement comes back with it.
+    expect(marker).not.toHaveAttribute('aria-label');
+  });
+
+  it('renders no marker at all for an optional field', () => {
+    const { container } = renderForm([{ name: 'title', label: 'Title', type: 'input' }], {
+      title: '',
+    });
+
+    expect(container.querySelector('span[data-required-marker]')).toBeNull();
+  });
+});
+
+describe('form renderer — no native `required` (objectui#3290)', () => {
+  it('never sets the native attribute, on either render path', () => {
+    // Ruled out deliberately: a native `required` arms the browser's own
+    // validation bubble on top of react-hook-form's `<FormMessage/>` — two
+    // validators disagreeing about the same field. `aria-required` announces
+    // the state without triggering native constraint validation. This is a
+    // regression fence: the "obvious" follow-up to this fix is exactly the
+    // change that must not happen.
+    renderForm(
+      [
+        { name: 'title', label: 'Title', type: 'input', required: true },
+        { name: 'notes', label: 'Notes', type: 'reqprobe', required: true },
+      ],
+      { title: '', notes: '' },
+    );
+
+    // NOT `toBeRequired()` — jest-dom counts `aria-required="true"` as
+    // required, so that matcher can never distinguish the two channels and
+    // would pass no matter which one we shipped. The native attribute (and the
+    // `required` IDL property that arms constraint validation) is the thing
+    // under test, so assert on it directly.
+    const builtin = screen.getByLabelText(/title/i) as HTMLInputElement;
+    expect(builtin).toHaveAttribute('aria-required', 'true');
+    expect(builtin).not.toHaveAttribute('required');
+    expect(builtin.required).toBe(false);
+
+    const widget = screen.getByTestId('probe-notes') as HTMLInputElement;
+    expect(widget).toHaveAttribute('aria-required', 'true');
+    expect(widget).not.toHaveAttribute('required');
+    expect(widget.required).toBe(false);
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -1355,7 +1355,25 @@ ComponentRegistry.register('form',
                 <FormLabel className="text-xs font-normal text-muted-foreground">
                   {label}
                   {required && (
-                    <span className="text-destructive ml-1" aria-label="required">
+                    // Purely visual redundancy now that `aria-required` rides
+                    // on the control itself (objectui#3290). It used to carry
+                    // `aria-label="required"`, which made the asterisk part of
+                    // the control's accessible name; keeping both channels
+                    // would have assistive tech announce required TWICE — once
+                    // inside the name, once as the state. The state channel is
+                    // the correct single source, so the marker leaves the
+                    // accessibility tree entirely.
+                    //
+                    // `data-required-marker` is the stable locator for the
+                    // sighted-user affordance (ADR-0054 C4), replacing the
+                    // `aria-label` that end-to-end specs were selecting on —
+                    // a11y attributes must not double as test hooks, which is
+                    // how this one survived as long as it did.
+                    <span
+                      className="text-destructive ml-1"
+                      data-required-marker="true"
+                      aria-hidden="true"
+                    >
                       *
                     </span>
                   )}
@@ -1410,6 +1428,40 @@ ComponentRegistry.register('form',
                   // Undefined when the field is valid, so the key is simply
                   // absent from the DOM rather than rendering `error=""`.
                   error: fieldState.error?.message,
+                  // Required is a STATE, so it travels the state channel
+                  // (objectui#3290). Until now the resolved `required` (static
+                  // `required` + `requiredWhen` CEL) drove exactly one thing —
+                  // the red asterisk in `<FormLabel>` — which reached assistive
+                  // tech only by being folded into the control's ACCESSIBLE
+                  // NAME ("Title required"). Three ways that fails: a name is
+                  // read in name order rather than announced as a state, "list
+                  // the required fields" navigation cannot see it, and a field
+                  // rendered without a `label` (compact layouts, inline grid
+                  // editing) draws no asterisk at all, so the signal vanishes.
+                  //
+                  // No widget change is needed for this to land on the input:
+                  // `aria-required` is already declared and typed on the widget
+                  // props contract (`FieldWidgetComponentProps & AriaAttributes`)
+                  // and every widget forwards its leftover props to the control
+                  // it renders. The builtin branch is the same story — neither
+                  // `stripRegisteredFieldProps` nor `stripRendererOnlyProps`
+                  // touches `aria-*`. That is precisely why #3222 refused to
+                  // sink a `required` BOOLEAN into the widget contract: a
+                  // boolean gives the asterisk a second author and the next
+                  // AI-written widget draws its own, while `aria-required` goes
+                  // straight to the DOM with no new key to get wrong.
+                  //
+                  // `|| undefined` (not `String(required)`) so an optional
+                  // field carries NO attribute at all. `aria-required="false"`
+                  // is legal but semantically noisier than absence, and absence
+                  // is what the dynamic `requiredWhen` FALSE case must produce.
+                  //
+                  // Deliberately NOT the native `required` attribute: that
+                  // would arm the browser's own constraint-validation bubble
+                  // alongside react-hook-form's messages — two validators, two
+                  // UIs, one field. `aria-required` reports the state without
+                  // triggering native validation.
+                  'aria-required': required || undefined,
                 })}
               </FormControl>
               {description && (


### PR DESCRIPTION
Closes #3290

必填状态过去只以「可访问名的一部分」存在——表单渲染器算出的 `required`（静态 `required` + `requiredWhen` CEL）只驱动 `< FormLabel >` 里的红星，而那颗红星带着 `aria-label="required"`，于是状态经由 `< label for >` 关联被并进控件的**可访问名**，字段被读成「Title required」。把状态塞进名字有三处失效：按名字顺序朗读而非以状态播报、「只列必填项」这类导航看不见它、无 `label` 的字段（紧凑布局 / grid 内联编辑）根本不画星号因而信号彻底消失，且 `requiredWhen` 让必填是动态的——状态通道能表达翻转，名字不能。

> 注：本文中 `< FormLabel >` / `< FormControl >` 这类写法的尖括号后有意加了空格——GitHub 正文清洗器会把「`<` 紧跟字母」当 HTML 标签删掉（本 PR 初版正文已被吃掉三处，这是修正后的版本）。

## 裁决执行清单

| 裁决项 | 落实 |
|---|---|
| 宿主一处加 `'aria-required': required \|\| undefined` | ✅ `form.tsx` 转发进 widget 的 props（紧接 `error: fieldState.error?.message`） |
| 48 个 widget 零改动 | ✅ 未改任何 widget；另经实测复核（见下「前置核对」第 2 条） |
| 红星改 `aria-hidden="true"` | ✅ 同时移除 `aria-label="required"`，状态通道成为唯一来源 |
| **不**加原生 `required` | ✅ 并加了一条回归栅栏测试钉死它 |

## 前置核对（三条都是复核，不是假设）

1. **基线含 #3233（PR #3296）**——worktree 基于 `origin/main@6e794a19e`，`packages/fields/src/withFieldCarrier.tsx` 存在；`renderFieldComponent` 已是 field-widget / 裸名 SDUI 双路径的现状。
2. **两条分支都收到 `aria-required`**——`stripRendererOnlyProps` 与 `stripRegisteredFieldProps` 都是定长解构，`aria-*` 不在其中，因此原样透传。不止读代码：临时跑了一个**真 widget**（EmailField / PhoneField / UrlField / TextAreaField / CurrencyField / PercentField / TextField）穿真表单渲染器的检查，七个全部把 `aria-required="true"` 落到真实的 `input` / `textarea` 元素上，零 widget 改动。该临时文件已删除，未进提交。
3. **`< FormControl >` 确实不注入 `aria-required`**——`packages/components/src/ui/form.tsx` 里的 Radix `Slot` 只注入 `id` / `aria-describedby` / `aria-invalid`。（附带更正 issue 正文一处措辞：全仓 grep `aria-required` 并非 0 处，`plugin-form` 的 `EmbeddableForm` 和 console 的 `ProfilePage` 各有手写的一处；**表单渲染器这条路径**上确为 0，结论不变。）

## 为什么是 `|| undefined` 而不是 `String(required)`

非必填字段应当**完全没有该属性**，而不是 `aria-required="false"`。后者合法但语义更嘈杂，且 `requiredWhen` 翻成 FALSE 时必须产出的正是「属性消失」。测试里单独钉住了这个拼写。

## 测试

新增 `packages/components/src/renderers/form/__tests__/form-aria-required-delivery.test.tsx`（9 条）。每条都做了 sabotage 验证——改坏见红、还原见绿：

| Sabotage | 结果 |
|---|---|
| 删掉 `'aria-required'` 一行 | 6 红 |
| 改成 `String(required)` | 2 红（「非必填不带属性」+「requiredWhen 翻回时消失」） |
| 红星退回 `aria-label="required"` | 2 红（可访问名 + marker 断言） |
| 补上原生 `required` | 1 红 |
| 两个 strip 函数吃掉 `aria-required` | 6 红 |

覆盖：内置分支、注册 widget 分支、非必填属性缺席、`requiredWhen` 动态翻转、**无 label 的必填字段**（老设计下信号完全不存在的那个场景）、可访问名不再含 "required"（用 `toHaveAccessibleName`，不是 querySelector）、红星仍渲染但在 a11y 树外、无原生 `required`。

关于最后一条有个坑值得记：`toBeRequired()` **不能**用来断言「没有原生 required」——jest-dom 把 `aria-required="true"` 也算作 required，那个 matcher 无论修成哪样都会绿。改为直接断言原生属性缺席 + `el.required === false`。

## 顺带改到 `packages/components` 之外的一处（是本改动自身的调用点修复，非范围外顺手修）

`e2e/live/field-conditional-rules.spec.ts` 的 `isRequired()` helper 用 `span[aria-label="required"]` 定位红星——红星移出 a11y 树后这个选择器必然失效。红星因此获得 `data-required-marker="true"` 作为显式定位钩子（ADR-0054 C4 的稳定 locator 惯例），helper 改用它。a11y 属性不该兼任测试钩子，这正是这条 `aria-label` 能活这么久的原因。这是全仓唯一一处该选择器。

## 给邻接单的两条提示

- **#3272（form.tsx 硬编码英文）**：清单里的 `aria-label="required"` 字符串**已随本 PR 消失**——它现在是 `aria-hidden` 的纯视觉星号，不再有任何面向用户的文本需要翻译。届时请核对并从清单划掉。
- **`packages/fields/src/widgets/types.ts:29`** 有一句注释仍在描述旧行为（「`< FormLabel >` 里带 `aria-label="required"` 的 `*`」）。按本单范围栅栏未动 `packages/fields`；这是一处陈旧注释而非功能缺陷，留给维护者决定是单独收还是搭车下次改 fields 时顺手更正。

## changeset

已加 `.changeset/aria-required-reaches-the-control.md`（`@object-ui/components: patch`）。依据：AGENTS.md 说纯 bug 修复不必写，但本改动**用户可见**——每个必填控件多出一个 DOM 属性、可访问名从「Title required」变为「Title」——且移除 `aria-label="required"` 对任何按它选择的下游是破坏性的（本仓 e2e 就是活证）。定 `patch` 而非 `minor`：无 API、无 props 契约、无 schema 变更，红星对视力用户的呈现一模一样。若维护者认为 DOM/a11y 行为变更应按仓规的「自身破坏性变更也标 `minor`」处理，改一个字即可。

## 验证输出

```
pnpm exec vitest run packages/components/src/renderers/form/__tests__/ packages/components/src/__tests__/form-renderers.test.tsx
  Test Files  22 passed (22)
       Tests  138 passed (138)

pnpm exec vitest run packages/components          # 全量
  Test Files  69 passed (69)
       Tests  530 passed (530)

pnpm exec vitest run packages/fields/src/__tests__/widget-aria-invalid-e2e.test.tsx   # 跨包真 widget 集成
  Test Files  1 passed (1)
       Tests  10 passed (10)

pnpm --filter @object-ui/components type-check    # 通过，无输出
pnpm --filter @object-ui/components lint          # 0 errors（760 warnings 均为既有）
node scripts/check-changeset-no-major.mjs         # ✅ No changeset declares a `major` bump.
```

未动 `packages/spec`、任何 widget、`packages/fields` / `types` / `react`、`content/docs/releases/`。