### PR TITLE
fix(plugin-form,types): carry `mobile_fullscreen` on the field metadata, where widgets actually read (#3245)

### DIFF
--- a/.changeset/mobile-fullscreen-rides-the-field-metadata.md
+++ b/.changeset/mobile-fullscreen-rides-the-field-metadata.md
@@ -1,0 +1,46 @@
+---
+"@object-ui/plugin-form": minor
+"@object-ui/types": minor
+---
+
+`mobile.fullscreenLongText` finally reaches auto-generated long-text fields, and
+`mobile_fullscreen` gets one declared carrier (objectui#3245).
+
+FROM: `ObjectForm` stamped the flag onto the FormField itself
+(`{ ...f, mobile_fullscreen: true }`). TO: it stamps the flag onto the object the
+form renderer will actually forward to the widget as `field` — `f.field || f`,
+resolved exactly the way `renderFieldComponent` resolves it.
+
+**The flag's only legal carrier is the field metadata, and its only producer is
+`ObjectForm`.** That convention was already what the widget side assumed after
+objectui#3232/#3233 (`TextAreaField` reads `field.mobile_fullscreen` and nothing
+else, and `field` is the single metadata carrier); the producer was writing to a
+different object, so for auto-generated fields the two never met.
+
+What was broken, end to end: `ObjectForm` builds an auto-generated field as
+`type: 'field:textarea'` **and** stashes the object-field metadata on `.field`.
+The renderer forwards `field: field.field || field`, so the widget received the
+raw metadata — which never carried the flag — while the FormField-level copy was
+dropped by `stripRegisteredFieldProps`. Every entry point into `TextAreaField`
+therefore read `undefined` and the expand affordance never rendered. Only the
+hand-authored `customFields` path (no `.field` to shadow the FormField) ever
+worked, i.e. the feature was dead on the path virtually every form takes. Unit
+tests on both ends passed the whole time, because the break lived in the seam
+between them; this release adds the feature's first integration coverage — real
+`ObjectForm` → real form renderer → real `TextAreaField`, no mocks — which fails
+against the old producer and passes against the new one.
+
+`mobile_fullscreen` is now declared on `@object-ui/types`' `BaseFieldMetadata`,
+hence on every member of the `FieldMetadata` union that
+`FieldWidgetComponentProps.field` resolves to. It is deliberately **not** an
+`@objectstack/spec` property: nobody authors it on a field definition, it is a
+projection of the form-level `ObjectFormSchema.mobile.fullscreenLongText` setting
+onto the field metadata at render time. Declaring it removes the last untyped
+end of the chain — the producer's `as FormField` cast is gone — so the two sides
+can now disagree out loud instead of silently.
+
+The hand-authored `customFields` path keeps working unchanged, and keeps its own
+metadata: the flag is stamped on the FormField only when there is no `.field` to
+carry it. Synthesizing a `field` object in that case would light the affordance
+up while quietly replacing the field's `rows` / `placeholder` with defaults — the
+regression test pins that too.

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -1040,13 +1040,33 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
   // ----- Mobile UX (round 3) -----
   // 1) Propagate fullscreen-textarea opt-in to each textarea field so the
   //    field widget can render its expand affordance + dialog.
+  //
+  //    `mobile_fullscreen` is a PROJECTION of this form-level setting onto the
+  //    field metadata — this component is its one and only producer, and the
+  //    flag has one and only one legal carrier: the object the form renderer
+  //    forwards to the widget as `field`. That object is `f.field || f`
+  //    (`renderFieldComponent` in `@object-ui/components`): the stashed
+  //    object-field metadata when there is one, else the FormField itself.
+  //
+  //    Stamping it on `f` unconditionally was the objectui#3245 break. For an
+  //    AUTO-GENERATED field `.field` exists, so the widget was handed the raw
+  //    metadata (flag-free) while the FormField-level copy was dropped by
+  //    `stripRegisteredFieldProps` — every generated form silently lost the
+  //    feature, and only the hand-authored `customFields` path (no `.field`)
+  //    ever worked. Resolving the carrier the same way the renderer does keeps
+  //    both paths on ONE key in ONE place (objectui#3232 / #3233): no widget
+  //    reads a second spelling, so a flag written anywhere else stays dead
+  //    instead of being quietly caught by a fallback.
   const mobileOpts = schema.mobile;
   const fieldsWithMobile = mobileOpts?.fullscreenLongText
     ? autoLayoutResult.fields.map((f) => {
         const t = f.type as string | undefined;
         const isTextarea = t === 'textarea' || t === 'field:textarea' ||
           t === 'string-multiline' || t === 'field:markdown' || t === 'field:html';
-        return isTextarea ? ({ ...f, mobile_fullscreen: true } as FormField) : f;
+        if (!isTextarea) return f;
+        return f.field
+          ? { ...f, field: { ...f.field, mobile_fullscreen: true } }
+          : { ...f, mobile_fullscreen: true };
       })
     : autoLayoutResult.fields;
 

--- a/packages/plugin-form/src/__tests__/ObjectForm.mobileFullscreen.test.tsx
+++ b/packages/plugin-form/src/__tests__/ObjectForm.mobileFullscreen.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * End-to-end pin for `ObjectFormSchema.mobile.fullscreenLongText`
+ * (objectui#3245) — the ONLY integration coverage this feature has.
+ *
+ * Everything below is real: the real `ObjectForm` (the flag's single
+ * producer), the real form renderer in `@object-ui/components`, the real
+ * registry, and the real `TextAreaField` from `@object-ui/fields`. Nothing is
+ * mocked but the data source, because the bug this file exists to prevent
+ * lived exactly in the SEAMS between those four — each end looked correct on
+ * its own and the flag fell through the join:
+ *
+ *   1. `ObjectForm` auto-generates a FormField with `type: 'field:textarea'`
+ *      and stashes the object-field metadata on `field`;
+ *   2. it stamped `mobile_fullscreen` onto the FormField ITSELF;
+ *   3. the form renderer forwards `field: field.field || field` — for an
+ *      auto-generated field `.field` exists, so the widget received the raw
+ *      metadata, WITHOUT the flag;
+ *   4. the FormField-level copy was then dropped by
+ *      `stripRegisteredFieldProps`.
+ *
+ * Result: the flag reached `TextAreaField` only on the hand-authored
+ * `customFields` path (no `.field` to shadow the FormField), i.e. never on the
+ * path virtually every form actually takes. Unit tests on both ends passed
+ * throughout. The fix stamps the flag onto the metadata carrier the renderer
+ * will forward — `f.field || f` — so there stays exactly ONE carrier
+ * (objectui#3233) and it is the one the widget reads.
+ *
+ * `registerAllFields` registers each widget as a `React.lazy`, so the
+ * assertions sit behind a dynamic-import boundary — the shape AGENTS.md's test
+ * discipline says must be warmed at MODULE SCOPE (never in a `beforeAll`,
+ * whose 10s budget is narrower than the timeout it would replace) so the cold
+ * transform is billed to the import phase, which no test/hook timeout bounds.
+ * Here the barrel import below IS that warm-up: `@object-ui/fields`'s entry
+ * statically imports and re-exports `./widgets/TextAreaField`, the very
+ * specifier the lazy loader uses, so by the time a test renders, the widget
+ * module is already in the ESM cache and `React.lazy` resolves off it instead
+ * of racing RTL's 1000ms `findBy` budget against a cold Vite transform.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { registerAllFields } from '@object-ui/fields';
+import type { ObjectFormSchema } from '@object-ui/types';
+import { ObjectForm } from '../ObjectForm';
+
+registerAllFields();
+
+const objectSchema = {
+  name: 'issue_note',
+  label: 'Issue Note',
+  fields: {
+    body: { type: 'textarea', label: 'Body' },
+  },
+};
+
+function makeDataSource() {
+  return {
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    findOne: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    find: vi.fn().mockResolvedValue([]),
+  } as any;
+}
+
+function renderForm(schema: Partial<ObjectFormSchema>) {
+  return render(
+    <ObjectForm
+      schema={
+        {
+          type: 'object-form',
+          objectName: 'issue_note',
+          mode: 'create',
+          ...schema,
+        } as ObjectFormSchema
+      }
+      dataSource={makeDataSource()}
+    />,
+  );
+}
+
+describe('ObjectForm mobile.fullscreenLongText → TextAreaField (objectui#3245)', () => {
+  it('reaches the widget for an AUTO-GENERATED long-text field', async () => {
+    // The path almost every form takes: no `customFields`, so `ObjectForm`
+    // builds the FormField from the object schema and stashes the metadata on
+    // `.field`. This assertion was RED before the producer-side fix.
+    renderForm({ mobile: { fullscreenLongText: true } });
+
+    expect(await screen.findByTestId('textarea-fullscreen-toggle')).toBeInTheDocument();
+  });
+
+  it('still reaches the widget for a HAND-AUTHORED customFields long-text field, without displacing its other metadata', async () => {
+    // Control for the fix: a hand-authored `customFields` entry carries no
+    // `.field` metadata object, so `field.field || field` resolves to the
+    // FormField ITSELF — that is the carrier, and the flag has to land on it.
+    // This chain works today and must keep working.
+    //
+    // The extra metadata below is what makes this a real control rather than a
+    // restatement of the test above. Stamping `field: { ...f.field, flag }`
+    // UNCONDITIONALLY also lights the affordance up here — by conjuring a
+    // metadata object out of `undefined` that contains nothing but the flag.
+    // The renderer would then forward that stub as the widget's `field`, and
+    // `rows` / `placeholder` (which `TextAreaField` reads off the metadata, not
+    // off its props) would silently revert to their defaults. Asserting them
+    // here is what makes that shortcut fail instead of pass.
+    renderForm({
+      mobile: { fullscreenLongText: true },
+      customFields: [
+        { name: 'body', label: 'Body', type: 'field:textarea', rows: 9, placeholder: 'Say more' },
+      ],
+    });
+
+    expect(await screen.findByTestId('textarea-fullscreen-toggle')).toBeInTheDocument();
+
+    const textarea = screen.getByPlaceholderText('Say more');
+    expect(textarea).toHaveAttribute('rows', '9');
+  });
+
+  it('does NOT render the affordance when the form did not opt in', async () => {
+    // Negative control: without `mobile.fullscreenLongText` there is no
+    // producer, so no carrier may conjure the flag.
+    renderForm({});
+
+    // Wait for the textarea itself so we are asserting on a SETTLED form, not
+    // on a widget that simply has not resolved yet.
+    expect(await screen.findByRole('textbox')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('textarea-fullscreen-toggle')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/types/src/__tests__/field-metadata-mobile-fullscreen.test.ts
+++ b/packages/types/src/__tests__/field-metadata-mobile-fullscreen.test.ts
@@ -1,0 +1,97 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `mobile_fullscreen` has exactly ONE legal carrier: the field metadata
+ * (objectui#3245).
+ *
+ * The flag is a projection of the form-level
+ * `ObjectFormSchema.mobile.fullscreenLongText` setting, produced by `ObjectForm`
+ * (`@object-ui/plugin-form`) and read by `TextAreaField` (`@object-ui/fields`)
+ * off `FieldWidgetComponentProps.field` — whose type is the `FieldMetadata`
+ * union pinned below. It is deliberately NOT an `@objectstack/spec` property:
+ * nobody authors it on an object's field definition, the form runtime stamps it.
+ *
+ * Declaring it is the point. While it was undeclared, the producer stamped it
+ * onto the FormField through an `as FormField` cast and the consumer read it
+ * through an `as any` — two untyped ends that could not disagree out loud, and
+ * for the whole of the feature's life they DID disagree: the form renderer
+ * forwards `field: field.field || field`, so an auto-generated field handed the
+ * widget its raw metadata (flag-free) while `stripRegisteredFieldProps` dropped
+ * the prop copy. Every generated form silently lost the affordance, and no type
+ * anywhere could report it.
+ *
+ * The compile-time pins are the load-bearing part: `tsc -p tsconfig.test.json`
+ * (chained off this package's `type-check`) is what runs them. Deleting the
+ * declaration — or moving it off the base every `FieldMetadata` member extends —
+ * is a compile error, not a silently passing test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { BaseFieldMetadata, FieldMetadata, TextareaFieldMetadata } from '../index';
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins — compiled by tsconfig.test.json, chained off type-check. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+describe('FieldMetadata.mobile_fullscreen (objectui#3245)', () => {
+  it('is declared on the metadata base as an optional boolean', () => {
+    // Keeps the pins below from passing vacuously: an `any`-typed property
+    // would satisfy nothing while looking green.
+    type _NotAny = Assert<Equal<IsAny<BaseFieldMetadata['mobile_fullscreen']>, false>>;
+
+    // Optional boolean — never required (no form is obliged to project it) and
+    // never widened.
+    type _OptionalBoolean = Assert<
+      Equal<BaseFieldMetadata['mobile_fullscreen'], boolean | undefined>
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  it('is readable off the FieldMetadata union without narrowing first', () => {
+    // `FieldMetadata` is what `FieldWidgetComponentProps.field` resolves to,
+    // and `TextAreaField` reads the flag there. Declaring it on a single union
+    // member instead would make that read a compile error and push the next
+    // author straight back to the `as any` this issue exists to remove.
+    type _ReadableOffTheUnion = Assert<
+      Equal<FieldMetadata['mobile_fullscreen'], boolean | undefined>
+    >;
+
+    // The long-text members inherit it like any other base property.
+    type _TextareaInheritsIt = Assert<
+      Equal<TextareaFieldMetadata['mobile_fullscreen'], boolean | undefined>
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  it('is assignable on a long-text field metadata object', () => {
+    // The exact shape `ObjectForm` produces: the stashed object-field metadata
+    // with the projected flag folded in.
+    const stamped: TextareaFieldMetadata = {
+      name: 'body',
+      type: 'textarea',
+      label: 'Body',
+      mobile_fullscreen: true,
+    };
+
+    expect(stamped.mobile_fullscreen).toBe(true);
+  });
+
+  it('is absent, not false, when the form did not opt in', () => {
+    const plain: TextareaFieldMetadata = { name: 'body', type: 'textarea' };
+
+    expect(plain.mobile_fullscreen).toBeUndefined();
+    expect('mobile_fullscreen' in plain).toBe(false);
+  });
+});

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -68,6 +68,31 @@ export interface BaseFieldMetadata {
   system?: boolean;
 
   /**
+   * Render a long-text field with a fullscreen-edit affordance (an "expand"
+   * button opening a full-height dialog) — the mobile UX for a textarea that
+   * would otherwise be a 4-row box wedged between other fields.
+   *
+   * **Not authored metadata, and deliberately NOT in `@objectstack/spec`.**
+   * It is a PROJECTION of the FORM-level setting
+   * `ObjectFormSchema.mobile.fullscreenLongText` onto the field metadata,
+   * with exactly one producer: `ObjectForm` (`@object-ui/plugin-form`) stamps
+   * it onto each long-text field's metadata carrier while building the form.
+   * Writing it on an object's field definition is meaningless — nothing
+   * publishes it and nothing else produces it.
+   *
+   * **Consumer**: `TextAreaField` (`@object-ui/fields`), which reads it off
+   * `field` and nowhere else — `field` being the single metadata carrier since
+   * objectui#3233. It is declared here, on the type
+   * `FieldWidgetComponentProps.field` resolves to, so that the one legal
+   * location for the flag is a typed one rather than an untyped pun: before
+   * objectui#3245 it was stamped onto the FormField instead, where the form
+   * renderer's `field: field.field || field` forwarding could not see it and
+   * `stripRegisteredFieldProps` stripped the prop copy — so every
+   * auto-generated form silently lost the feature.
+   */
+  mobile_fullscreen?: boolean;
+
+  /**
    * Placeholder text
    */
   placeholder?: string;


### PR DESCRIPTION
Closes #3245

按 2026-08-03 维护者裁决走 **方案 A**：生产者把 flag 盖到元数据载体上；`mobile_fullscreen` **不进** `@objectstack/spec`，只在 `@object-ui/types` 的 widget 侧字段元数据类型上声明。方案 B（新增宿主 prop 契约）未采纳。

## 前置核对

基线含 #3233（PR #3296，`packages/fields/src/withFieldCarrier.tsx` 已在 `origin/main`）。issue 正文的六步断链在现状下**逐条复核仍然成立**（行号已漂移，以下为现状行号）：

| 步骤 | 现状位置 | 事实 |
|---|---|---|
| 1 | `ObjectForm.tsx:567` | 自动生成字段 `type: mapFieldTypeToFormType(field.type)` → `field:textarea` |
| 2 | `ObjectForm.tsx:584` | 同时 `field: field` 把原始元数据挂到 `.field` 槽 |
| 3 | `ObjectForm.tsx:1049` | mobile 步骤 `({ ...f, mobile_fullscreen: true } as FormField)` —— 盖在 FormField 自己身上 |
| 4 | `form.tsx:1826-1837` | `field:textarea` 不在 `BUILTIN_FIELD_TYPES`，走已注册 widget 分支 |
| 5 | `form.tsx:1372` | 转发 `field: field.field || field` —— 第 2 步让 `.field` 存在，第 3 步的 flag 在这里被丢掉 |
| 6 | `form.tsx:275-289` | `stripRegisteredFieldProps` 显式剔除 `mobile_fullscreen` prop |

结论未变：**自动生成字段拿不到 flag，手写 `customFields` 拿得到**——而自动生成是绝大多数表单的路径。

## 断链证明（先红后绿）

按裁决指定的顺序，**先补集成用例钉住现状**。用例全链路真实：真 `ObjectForm` → 真 form 渲染器 → 真注册表 → 真 `TextAreaField`，除 dataSource 外无 mock。这个特性此前**零集成覆盖**，两端的单测各自全绿，正是它断了这么久没人发现的原因。

改生产者**之前**（红）：

```
 × ... > reaches the widget for an AUTO-GENERATED long-text field 1043ms
 ✓ ... > still reaches the widget for a HAND-AUTHORED customFields long-text field
 ✓ ... > does NOT render the affordance when the form did not opt in
 Tests  1 failed | 2 passed (3)
```

改生产者**之后**（绿）：

```
 ✓ ... > reaches the widget for an AUTO-GENERATED long-text field 79ms
 ✓ ... > still reaches the widget for a HAND-AUTHORED customFields long-text field, without displacing its other metadata 14ms
 ✓ ... > does NOT render the affordance when the form did not opt in 28ms
 Tests  3 passed (3)
```

## 改动

**生产者（`packages/plugin-form/src/ObjectForm.tsx`）** —— flag 盖到「渲染器将要转发为 `field` 的那个对象」上，即用渲染器自己的解析方式 `f.field || f` 解析载体：

```ts
if (!isTextarea) return f;
return f.field
  ? { ...f, field: { ...f.field, mobile_fullscreen: true } }
  : { ...f, mobile_fullscreen: true };
```

`as FormField` 硬转随之消失（`FormField.field` 本就声明为 `Record< string, any >`，无需强转）。

**类型（`packages/types/src/field-types.ts`）** —— `mobile_fullscreen?: boolean` 声明在 `BaseFieldMetadata` 上，因而落在 `FieldWidgetComponentProps.field` 所解析到的整个 `FieldMetadata` 联合上。注释写明：它是表单级 `ObjectFormSchema.mobile.fullscreenLongText` 向字段元数据的**投影**，生产者唯一（`ObjectForm`），消费者唯一（`TextAreaField` 读 `field`，#3233 之后没有第二个载体），**不是可书写元数据、不进 `@objectstack/spec`**。

声明在 base 而非单个 `TextareaFieldMetadata` 成员上，是因为 `TextAreaField` 拿到的是**未收窄的联合**——声明在单个成员上会让那次读取变成编译错误，把下一个作者直接推回 `as any`，也就是这个 issue 要消灭的东西。

## 为什么保留「无 `.field` 时盖在 FormField 上」这一支

不是防御性冗余，而是被测试逼出来的。无条件写成 `{ ...f, field: { ...f.field, flag } }` 时，**手写 `customFields` 的对照用例照样绿**——因为它从 `undefined` 凭空造出一个只含 flag 的元数据对象，flag 确实到达了 widget。但渲染器随后会把这个 stub 当作 `field` 转发，而 `TextAreaField` 的 `rows` / `placeholder` 是**从元数据读的、不是从 props 读的**，于是它们静默退回默认值。

所以对照用例被加强为同时断言 `rows="9"` 与 `placeholder`，这条捷径才会失败而不是通过。

## Sabotage 验证（每条新断言逐一验证）

| # | 破坏 | 结果 |
|---|---|---|
| S1 | 还原为改前写法（只盖 FormField） | 仅「AUTO-GENERATED」红 ✅ |
| S2 | 去掉无 `.field` 分支（无条件盖元数据） | 仅「HAND-AUTHORED customFields」红 ✅ |
| S3 | 忽略 `mobile.fullscreenLongText` 开关 | 仅「did NOT render」红 ✅ |
| S4 | 删掉 `BaseFieldMetadata` 上的声明 | `tsc -p tsconfig.test.json` 报 6 处 TS2339/TS2353 ✅ |

S2 是加强对照用例前**没能**红的那一条——先失败、再据此补强断言。

## 验证

```
pnpm exec vitest run packages/plugin-form packages/types packages/fields --maxWorkers=2
  Test Files  101 passed (101)
       Tests  1225 passed (1225)

turbo run type-check --filter @object-ui/types --filter @object-ui/plugin-form \
                     --filter @object-ui/fields --filter @object-ui/components
  Tasks: 15 successful, 15 total

turbo run lint --filter @object-ui/types --filter @object-ui/plugin-form
  0 errors（类型断言的 unused-var warning 与既有 page-node-type-contract.test.ts 完全同形）

node scripts/check-changeset-no-major.mjs
  ✅ No changeset declares a `major` bump.
```

changeset：`minor`（additive 类型声明 + 行为修复），正文写明「flag 的唯一合法载体是字段元数据，生产者是 ObjectForm」。

## 范围

只改 `packages/plugin-form` + `packages/types` + 测试。**未触碰** `packages/components` / `packages/fields` 源码（#3233 收敛态是只读依赖，#3290 正在并行改 `form.tsx`），spec 零改动，`content/docs/releases/` 未碰。

顺带发现的相邻缺陷已另开 unassigned issue，不在本 PR 修。


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_