### PR TITLE
feat(fields): RichTextField honors `mobile_fullscreen` with a fullscreen editing dialog (#3301)

### DIFF
--- a/.changeset/richtext-honors-mobile-fullscreen.md
+++ b/.changeset/richtext-honors-mobile-fullscreen.md
@@ -1,0 +1,49 @@
+---
+"@object-ui/fields": minor
+"@object-ui/plugin-form": minor
+---
+
+`RichTextField` honours `mobile_fullscreen`, so `mobile.fullscreenLongText` is
+finally true of rich text too (objectui#3301).
+
+`ObjectFormSchema.mobile.fullscreenLongText` has always been documented as
+"textarea/rich-text get an expand button", and `ObjectForm` has always stamped
+`mobile_fullscreen` onto `field:markdown` / `field:html` fields to deliver it.
+Both of those types resolve to `RichTextField`, and that widget never read the
+flag: a producer with no consumer. Turning the setting on gave a phone user an
+expand affordance on their textareas and nothing at all on their markdown or
+HTML fields, with nothing anywhere reporting that half the feature was inert.
+
+FROM: `RichTextField` ignored the flag entirely (`grep fullscreen` over that
+file returned nothing). TO: it reads `field.mobile_fullscreen` — the same single
+metadata carrier `TextAreaField` reads, and nowhere else — and renders the same
+expand affordance and full-height editing dialog.
+
+**The affordance now has one implementation, not two.** One form-level setting
+should produce one behaviour, so the expand button, the dialog and the
+draft/commit semantics moved into a shared `FullscreenFieldEditor` that both
+widgets render; only the EDITOR is per-widget. A second hand-written copy of
+that state machine would be the same defect this release fixes, with an extra
+step — it drifts, and nothing reports the drift. The rich-text dialog hosts the
+widget's real editing surface (same format indicator, same editor), not a bare
+textarea, so whatever that editor grows into, both positions get it at once.
+
+Behaviour is identical across the two widgets and unchanged for
+`TextAreaField`: the dialog seeds its draft from the committed value at open
+time, keeps typing local (a react-hook-form field is not marked dirty by an
+edit the user may still cancel), commits once on "Done", and discards on
+"Cancel". Test ids follow the existing convention per widget —
+`richtext-fullscreen-toggle` / `-dialog` / `-input` / `-save` alongside the
+`textarea-*` ones, since a single form can contain both.
+
+There is deliberately no prop spelling of the flag and no `??` fallback chain in
+either widget. The field metadata is the one carrier (objectui#3233), so a
+misspelled or misplaced flag stays inert and visible rather than being quietly
+caught by a tolerant consumer.
+
+Also removes a dead type from the producer: `ObjectForm` stamped the flag on
+`'string-multiline'`, a string that `grep -rn` finds exactly once across both
+this repo and `objectstack` — that line itself. No producer emitted it, no
+registry key matched it, no widget read it. The remaining four stamped types
+(`textarea`, `field:textarea`, `field:markdown`, `field:html`) each have a real
+reader.

--- a/packages/fields/src/widgets/FullscreenFieldEditor.tsx
+++ b/packages/fields/src/widgets/FullscreenFieldEditor.tsx
@@ -1,0 +1,160 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useState } from 'react';
+import {
+  cn,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Button,
+} from '@object-ui/components';
+import { Maximize2, Check, X } from 'lucide-react';
+
+/**
+ * The fullscreen-edit affordance shared by every long-text widget: the "expand"
+ * button plus the full-height dialog it opens.
+ *
+ * ## Why this is shared rather than copied
+ *
+ * `ObjectFormSchema.mobile.fullscreenLongText` is ONE form-level promise, and
+ * `ObjectForm` projects it onto EVERY long-text field as `mobile_fullscreen`
+ * (`field:textarea` → `TextAreaField`, `field:markdown` / `field:html` →
+ * `RichTextField`). A user who turns the setting on gets one behaviour, so the
+ * behaviour has one implementation. objectui#3301 is what the other
+ * arrangement costs: the flag reached `RichTextField` for as long as the
+ * feature has existed and that widget simply never read it, so half the
+ * documented promise ("textarea/rich-text get an expand button") silently did
+ * nothing. A second hand-written copy of the state machine is the same failure
+ * with an extra step — it drifts, and nothing reports the drift.
+ *
+ * What is genuinely per-widget is the EDITOR, so that is the only thing
+ * injected: `children` renders it against the draft. Everything a user can
+ * observe about the *interaction* — when the affordance appears, that the
+ * dialog seeds from the committed value, that typing stays local until "Done",
+ * that "Cancel" discards — lives here, once.
+ *
+ * ## Draft semantics (unchanged from the original `TextAreaField` behaviour)
+ *
+ * The dialog edits a LOCAL draft seeded from `value` at open time and commits
+ * once, on "Done". It deliberately does not stream every keystroke to the host:
+ * these widgets sit in a react-hook-form field, and per-keystroke `onChange`
+ * during a modal edit would mark the form dirty (and fire validation) for an
+ * edit the user may still cancel. "Cancel" therefore needs no undo — nothing
+ * was written.
+ *
+ * ## `testIdPrefix`
+ *
+ * Each host passes its own (`textarea`, `richtext`), yielding the same
+ * convention with a per-widget namespace: `<prefix>-fullscreen-toggle` /
+ * `-dialog` / `-save`. One form can contain both a textarea and a markdown
+ * field, so a single shared id would make a test unable to say which widget it
+ * had found. The editor's own test id belongs to `children` for the same
+ * reason.
+ *
+ * Focus management, `Esc`, the overlay and the close button are Radix's, via
+ * the repo's `Dialog` (`@object-ui/components`) — deliberately not re-answered
+ * here.
+ */
+export interface FullscreenFieldEditorProps {
+  /**
+   * The committed value. Seeds the draft each time the dialog opens — read at
+   * open time, not held, so a value that changes underneath while the dialog is
+   * closed is picked up on the next open.
+   */
+  value: string;
+  /** Called once with the draft when the user confirms. */
+  onCommit: (next: string) => void;
+  /** Field label — the dialog title and part of the toggle's accessible name. */
+  label?: string;
+  /** Namespace for this widget's fullscreen test ids. See above. */
+  testIdPrefix: string;
+  /**
+   * The editor itself, rendered inside the dialog body against the draft. The
+   * host passes the SAME editor it renders inline, so "fullscreen" is a size
+   * change rather than a second, poorer editing surface.
+   */
+  children: (draft: string, setDraft: (next: string) => void) => React.ReactNode;
+  /** Optional footer status for the draft (e.g. a character counter). */
+  footer?: (draft: string) => React.ReactNode;
+  /**
+   * Extra classes for the toggle button. It is absolutely positioned by
+   * default and expects a `relative` ancestor; a host whose layout has a
+   * better home for it can re-place it here.
+   */
+  toggleClassName?: string;
+}
+
+export function FullscreenFieldEditor({
+  value,
+  onCommit,
+  label,
+  testIdPrefix,
+  children,
+  footer,
+  toggleClassName,
+}: FullscreenFieldEditorProps) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(value ?? '');
+
+  const openFullscreen = () => {
+    setDraft(value ?? '');
+    setOpen(true);
+  };
+  const cancelFullscreen = () => setOpen(false);
+  const commitFullscreen = () => {
+    onCommit(draft);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openFullscreen}
+        className={cn(
+          'absolute top-1.5 right-1.5 inline-flex items-center justify-center size-7 rounded-md bg-background/80 text-muted-foreground hover:text-foreground hover:bg-background border shadow-sm transition-colors',
+          toggleClassName,
+        )}
+        aria-label={`Edit ${label ?? 'text'} fullscreen`}
+        data-testid={`${testIdPrefix}-fullscreen-toggle`}
+      >
+        <Maximize2 className="size-3.5" />
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="sm:max-w-3xl h-[100dvh] sm:h-[80vh] max-h-[100dvh] sm:max-h-[80vh] flex flex-col p-0 gap-0"
+          data-testid={`${testIdPrefix}-fullscreen-dialog`}
+        >
+          <DialogHeader className="p-4 border-b">
+            <DialogTitle className="text-base">{label ?? 'Edit text'}</DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 min-h-0 p-4">{children(draft, setDraft)}</div>
+          <DialogFooter className="p-3 border-t flex-row justify-between sm:justify-end gap-2">
+            {footer?.(draft)}
+            <div className="flex gap-2 ml-auto">
+              <Button type="button" variant="ghost" onClick={cancelFullscreen}>
+                <X className="size-4 mr-1" /> Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={commitFullscreen}
+                data-testid={`${testIdPrefix}-fullscreen-save`}
+              >
+                <Check className="size-4 mr-1" /> Done
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/fields/src/widgets/RichTextField.tsx
+++ b/packages/fields/src/widgets/RichTextField.tsx
@@ -1,18 +1,112 @@
 import React from 'react';
-import { Textarea, EmptyValue } from '@object-ui/components';
+import { cn, Textarea, EmptyValue } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/react';
+import { FullscreenFieldEditor } from './FullscreenFieldEditor';
 import { FieldWidgetComponentProps } from './types';
+
+/**
+ * The rich-text editing surface, rendered by `RichTextField` in BOTH positions:
+ * inline in the form, and inside the fullscreen dialog.
+ *
+ * Sharing it is the point of objectui#3301's acceptance criterion "the dialog
+ * holds the real editor". Had the dialog inlined a bare `<Textarea>` instead,
+ * the two surfaces would already disagree (no format indicator) and would keep
+ * disagreeing every time this widget gains an affordance — whatever the editor
+ * grows into (a toolbar, a TipTap/Lexical instance, a preview toggle), both
+ * positions get it at once because there is only one of them.
+ *
+ * `fullHeight` is the only difference between the two renderings: inline the
+ * textarea is `rows`-sized, in the dialog it fills the available height.
+ */
+function RichTextEditorSurface({
+  value,
+  onChange,
+  formatLabel,
+  hint,
+  placeholder,
+  rows,
+  disabled,
+  error,
+  className,
+  fullHeight,
+  autoFocus,
+  textareaTestId,
+  overlay,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  formatLabel: string;
+  hint: string;
+  placeholder?: string;
+  rows?: number;
+  disabled?: boolean;
+  error?: string;
+  className?: string;
+  fullHeight?: boolean;
+  autoFocus?: boolean;
+  textareaTestId?: string;
+  /** Absolutely-positioned children over the textarea (the expand affordance). */
+  overlay?: React.ReactNode;
+}) {
+  return (
+    <div className={cn('space-y-2', fullHeight && 'flex flex-col h-full')}>
+      <div className="flex items-center justify-between text-xs text-gray-500">
+        <span>{formatLabel}</span>
+        <span className="italic">{hint}</span>
+      </div>
+      <div className={cn('relative', fullHeight && 'flex-1 min-h-0')}>
+        <Textarea
+          value={value || ''}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          autoFocus={autoFocus}
+          rows={fullHeight ? undefined : rows}
+          // `text-base` in the dialog for the same reason `TextAreaField` uses
+          // it there: sub-16px inputs make iOS Safari zoom on focus, which is
+          // exactly wrong for a surface the user opened to get more room.
+          className={cn(
+            'font-mono',
+            fullHeight ? 'text-base h-full min-h-full resize-none' : 'text-sm',
+            className,
+          )}
+          aria-invalid={!!error}
+          data-testid={textareaTestId}
+        />
+        {overlay}
+      </div>
+    </div>
+  );
+}
 
 /**
  * Rich text field with markdown/HTML support
  * For now, this is a simple textarea. A full implementation would use
  * a rich text editor like TipTap, Lexical, or Slate.
+ *
+ * Reached by forms as `field:markdown` and `field:html`; both resolve here.
+ *
+ * ## Fullscreen editing (objectui#3301)
+ *
+ * `ObjectForm` stamps `mobile_fullscreen` onto the metadata of every long-text
+ * field — textarea AND rich-text — when `ObjectFormSchema.mobile
+ * .fullscreenLongText` is set, and `ObjectFormSchema.mobile`'s own JSDoc has
+ * always promised "textarea/rich-text get an expand button". This widget never
+ * read the flag, so for `field:markdown` / `field:html` that promise did
+ * nothing at all: the producer stamped, and no consumer existed.
+ *
+ * The flag is read off `field` and nowhere else — the single metadata carrier
+ * since objectui#3233 — matching `TextAreaField` read for read, so a
+ * misspelled flag stays inert in both widgets rather than being caught by a
+ * tolerant fallback in one of them. The affordance and dialog themselves come
+ * from the shared `FullscreenFieldEditor`, so one form-level setting keeps
+ * producing one behaviour across both widgets.
  */
 export function RichTextField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   const { t } = useObjectTranslation();
   if (readonly) {
     return (
-      <div 
+      <div
         className="text-sm prose prose-sm max-w-none"
       >
         {value || <EmptyValue />}
@@ -23,27 +117,52 @@ export function RichTextField({ value, onChange, field, readonly, error, ...prop
   const richField = field as any;
   const rows = richField?.rows || 8;
   const format = richField?.format || 'markdown'; // 'markdown' or 'html'
+  // Same single read as `TextAreaField`: the field metadata is the only
+  // carrier, and this widget is the second consumer the flag always had.
+  const showFullscreenButton = Boolean(richField?.mobile_fullscreen);
+
+  // Resolved once and handed to BOTH renderings of the editor, so the dialog
+  // cannot drift into showing different copy than the inline surface.
+  const formatLabel = t('fields.richText.format', { format, defaultValue: `Format: ${format}` });
+  const hint = t('fields.richText.basicEditorHint', { defaultValue: 'Rich text editor (basic)' });
+  const placeholder =
+    richField?.placeholder ||
+    t('fields.richText.placeholder', { defaultValue: 'Enter text...' });
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs text-gray-500">
-        <span>{t('fields.richText.format', { format, defaultValue: `Format: ${format}` })}</span>
-        <span className="italic">
-          {t('fields.richText.basicEditorHint', { defaultValue: 'Rich text editor (basic)' })}
-        </span>
-      </div>
-      <Textarea
-        value={value || ''}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={
-          richField?.placeholder ||
-          t('fields.richText.placeholder', { defaultValue: 'Enter text...' })
-        }
-        disabled={readonly || props.disabled}
-        rows={rows}
-        className={`font-mono text-sm ${props.className || ''}`}
-        aria-invalid={!!error}
-      />
-    </div>
+    <RichTextEditorSurface
+      value={value}
+      onChange={onChange}
+      formatLabel={formatLabel}
+      hint={hint}
+      placeholder={placeholder}
+      rows={rows}
+      disabled={readonly || props.disabled}
+      error={error}
+      className={props.className}
+      overlay={
+        showFullscreenButton && (
+          <FullscreenFieldEditor
+            value={value ?? ''}
+            onCommit={onChange}
+            label={richField?.label}
+            testIdPrefix="richtext"
+          >
+            {(draft, setDraft) => (
+              <RichTextEditorSurface
+                value={draft}
+                onChange={setDraft}
+                formatLabel={formatLabel}
+                hint={hint}
+                placeholder={placeholder}
+                autoFocus
+                fullHeight
+                textareaTestId="richtext-fullscreen-input"
+              />
+            )}
+          </FullscreenFieldEditor>
+        )
+      }
+    />
   );
 }

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -1,15 +1,6 @@
-import React, { useState } from 'react';
-import {
-  Textarea,
-  EmptyValue,
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-  Button,
-} from '@object-ui/components';
-import { Maximize2, Check, X } from 'lucide-react';
+import React from 'react';
+import { Textarea, EmptyValue } from '@object-ui/components';
+import { FullscreenFieldEditor } from './FullscreenFieldEditor';
 import { FieldWidgetComponentProps } from './types';
 
 /**
@@ -27,6 +18,12 @@ import { FieldWidgetComponentProps } from './types';
  * arrives there too: the registry adapter (`withFieldCarrier`) maps the SDUI
  * `schema` node onto `field` before the widget sees it.
  *
+ * The affordance, the dialog and the draft/commit semantics live in the shared
+ * `FullscreenFieldEditor` — the same producer stamps the same flag on
+ * rich-text fields, and `RichTextField` renders it from there too
+ * (objectui#3301). Only the EDITOR differs per widget; here it is a
+ * full-height `Textarea`.
+ *
  * There is deliberately NO widget-prop override. A `mobileFullscreen`
  * (camelCase) prop was read here and written by nobody in the repo, and the
  * snake_case `mobile_fullscreen` prop cannot arrive either: the form renderer
@@ -39,10 +36,6 @@ import { FieldWidgetComponentProps } from './types';
  * `FieldWidgetComponentProps`, stop stripping it, and have a host pass it.
  */
 export function TextAreaField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
-  // Hooks must run before any early return (readonly) to keep hook order stable.
-  const [fullscreenOpen, setFullscreenOpen] = useState(false);
-  const [draft, setDraft] = useState(value ?? '');
-
   if (readonly) {
     return (
       <div className="text-sm whitespace-pre-wrap">
@@ -62,10 +55,6 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
   // a single read — a misspelled flag has no read path to quietly catch it.
   const showFullscreenButton = Boolean(textareaField?.mobile_fullscreen);
 
-  const openFullscreen = () => { setDraft(value ?? ''); setFullscreenOpen(true); };
-  const cancelFullscreen = () => setFullscreenOpen(false);
-  const commitFullscreen = () => { onChange(draft); setFullscreenOpen(false); };
-
   const { inputType, ...domProps } = props as any;
 
   return (
@@ -81,17 +70,6 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
         aria-invalid={!!error}
         className={domProps.className}
       />
-      {showFullscreenButton && (
-        <button
-          type="button"
-          onClick={openFullscreen}
-          className="absolute top-1.5 right-1.5 inline-flex items-center justify-center size-7 rounded-md bg-background/80 text-muted-foreground hover:text-foreground hover:bg-background border shadow-sm transition-colors"
-          aria-label={`Edit ${textareaField?.label ?? 'text'} fullscreen`}
-          data-testid="textarea-fullscreen-toggle"
-        >
-          <Maximize2 className="size-3.5" />
-        </button>
-      )}
       {maxLength && (
         <div
           className="absolute bottom-2 right-2 text-xs text-gray-400"
@@ -103,44 +81,31 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
       )}
 
       {showFullscreenButton && (
-        <Dialog open={fullscreenOpen} onOpenChange={setFullscreenOpen}>
-          <DialogContent
-            className="sm:max-w-3xl h-[100dvh] sm:h-[80vh] max-h-[100dvh] sm:max-h-[80vh] flex flex-col p-0 gap-0"
-            data-testid="textarea-fullscreen-dialog"
-          >
-            <DialogHeader className="p-4 border-b">
-              <DialogTitle className="text-base">
-                {textareaField?.label ?? 'Edit text'}
-              </DialogTitle>
-            </DialogHeader>
-            <div className="flex-1 min-h-0 p-4">
-              <Textarea
-                autoFocus
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                maxLength={maxLength}
-                placeholder={textareaField?.placeholder}
-                className="h-full min-h-full resize-none text-base"
-                data-testid="textarea-fullscreen-input"
-              />
-            </div>
-            <DialogFooter className="p-3 border-t flex-row justify-between sm:justify-end gap-2">
-              {maxLength && (
-                <span className="text-xs text-muted-foreground self-center">
-                  {draft.length}/{maxLength}
-                </span>
-              )}
-              <div className="flex gap-2 ml-auto">
-                <Button type="button" variant="ghost" onClick={cancelFullscreen}>
-                  <X className="size-4 mr-1" /> Cancel
-                </Button>
-                <Button type="button" onClick={commitFullscreen} data-testid="textarea-fullscreen-save">
-                  <Check className="size-4 mr-1" /> Done
-                </Button>
-              </div>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <FullscreenFieldEditor
+          value={value ?? ''}
+          onCommit={onChange}
+          label={textareaField?.label}
+          testIdPrefix="textarea"
+          footer={(draft) =>
+            maxLength ? (
+              <span className="text-xs text-muted-foreground self-center">
+                {draft.length}/{maxLength}
+              </span>
+            ) : null
+          }
+        >
+          {(draft, setDraft) => (
+            <Textarea
+              autoFocus
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              maxLength={maxLength}
+              placeholder={textareaField?.placeholder}
+              className="h-full min-h-full resize-none text-base"
+              data-testid="textarea-fullscreen-input"
+            />
+          )}
+        </FullscreenFieldEditor>
       )}
     </div>
   );

--- a/packages/fields/src/widgets/__tests__/RichTextField.mobileFullscreen.test.tsx
+++ b/packages/fields/src/widgets/__tests__/RichTextField.mobileFullscreen.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RichTextField` honours `mobile_fullscreen` (objectui#3301).
+ *
+ * `ObjectFormSchema.mobile.fullscreenLongText` has always promised, in its own
+ * JSDoc, that "textarea/rich-text get an expand button", and `ObjectForm` has
+ * always stamped `mobile_fullscreen` onto `field:markdown` / `field:html`
+ * fields to deliver it. This widget — the one both of those types resolve to —
+ * simply never read the flag. Producer present, consumer absent: the flag
+ * arrived at the widget and nothing happened, with nothing anywhere reporting
+ * that half the documented feature was inert.
+ *
+ * So the assertions below are about the READ and the interaction it drives.
+ * The sibling file `TextAreaField.mobileFullscreen.test.tsx` pins the same
+ * contract for the other widget; both now go through the shared
+ * `FullscreenFieldEditor`, and the pair is what keeps one form-level setting
+ * producing one behaviour. Divergence in either widget fails one of the two.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { RichTextField } from '../RichTextField';
+import type { FieldWidgetComponentProps } from '../types';
+import type { FieldMetadata } from '@object-ui/types';
+
+const fieldMeta = (extra: Record<string, unknown> = {}) =>
+  ({
+    name: 'notes',
+    label: 'Notes',
+    type: 'markdown',
+    ...extra,
+  }) as unknown as FieldMetadata;
+
+describe('RichTextField mobile fullscreen — the metadata flag is the only source', () => {
+  it('renders the expand affordance when the field metadata sets mobile_fullscreen', () => {
+    render(
+      <RichTextField
+        value="# hello"
+        onChange={() => {}}
+        field={fieldMeta({ mobile_fullscreen: true })}
+      />,
+    );
+
+    expect(screen.getByTestId('richtext-fullscreen-toggle')).toBeInTheDocument();
+  });
+
+  it('renders no affordance when the metadata does not opt in', () => {
+    render(<RichTextField value="# hello" onChange={() => {}} field={fieldMeta()} />);
+
+    expect(screen.queryByTestId('richtext-fullscreen-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('richtext-fullscreen-dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the fullscreen dialog and commits the edited draft', () => {
+    const onChange = vi.fn();
+    render(
+      <RichTextField
+        value="# hello"
+        onChange={onChange}
+        field={fieldMeta({ mobile_fullscreen: true })}
+      />,
+    );
+
+    // Closed until the affordance is used — the dialog is not just mounted.
+    expect(screen.queryByTestId('richtext-fullscreen-dialog')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('richtext-fullscreen-toggle'));
+    expect(screen.getByTestId('richtext-fullscreen-dialog')).toBeInTheDocument();
+
+    const dialogInput = screen.getByTestId('richtext-fullscreen-input');
+    expect(dialogInput).toHaveValue('# hello');
+
+    fireEvent.change(dialogInput, { target: { value: '# hello from fullscreen' } });
+    // The draft is local until "Done" — the host is not notified per keystroke,
+    // so a react-hook-form field is not marked dirty by an edit the user may
+    // still cancel.
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('richtext-fullscreen-save'));
+    expect(onChange).toHaveBeenCalledWith('# hello from fullscreen');
+  });
+
+  it('discards the draft on Cancel', () => {
+    const onChange = vi.fn();
+    render(
+      <RichTextField
+        value="# hello"
+        onChange={onChange}
+        field={fieldMeta({ mobile_fullscreen: true })}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('richtext-fullscreen-toggle'));
+    fireEvent.change(screen.getByTestId('richtext-fullscreen-input'), {
+      target: { value: 'thrown away' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('richtext-fullscreen-dialog')).not.toBeInTheDocument();
+
+    // …and re-opening seeds from the COMMITTED value, not from the abandoned
+    // draft. Holding the draft across opens would silently resurrect an edit
+    // the user explicitly cancelled.
+    fireEvent.click(screen.getByTestId('richtext-fullscreen-toggle'));
+    expect(screen.getByTestId('richtext-fullscreen-input')).toHaveValue('# hello');
+  });
+
+  it('puts the REAL editor in the dialog, not a degraded copy of it', () => {
+    // The acceptance criterion that the dialog holds the rich editor itself:
+    // the same surface renders in both positions (same format indicator, same
+    // editor), so whatever this widget's editor grows into, the fullscreen
+    // view gets it too rather than drifting into a bare textarea.
+    render(
+      <RichTextField
+        value=""
+        onChange={() => {}}
+        field={fieldMeta({ mobile_fullscreen: true, format: 'html', placeholder: 'Write HTML' })}
+      />,
+    );
+
+    expect(screen.getAllByText('Format: html')).toHaveLength(1);
+
+    fireEvent.click(screen.getByTestId('richtext-fullscreen-toggle'));
+
+    // Inline + dialog: the indicator and the placeholder are present twice.
+    expect(screen.getAllByText('Format: html')).toHaveLength(2);
+    expect(screen.getAllByPlaceholderText('Write HTML')).toHaveLength(2);
+    expect(screen.getByTestId('richtext-fullscreen-input')).toBeEnabled();
+  });
+
+  it('titles the dialog and the affordance with the field label', () => {
+    render(
+      <RichTextField
+        value=""
+        onChange={() => {}}
+        field={fieldMeta({ mobile_fullscreen: true, label: 'Release notes' })}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Edit Release notes fullscreen' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('richtext-fullscreen-toggle'));
+    expect(screen.getByRole('heading', { name: 'Release notes' })).toBeInTheDocument();
+  });
+
+  it('renders no affordance at all in readonly mode', () => {
+    render(
+      <RichTextField
+        value="# hello"
+        onChange={() => {}}
+        readonly
+        field={fieldMeta({ mobile_fullscreen: true })}
+      />,
+    );
+
+    expect(screen.queryByTestId('richtext-fullscreen-toggle')).not.toBeInTheDocument();
+  });
+});
+
+describe('RichTextField mobile fullscreen — no second carrier', () => {
+  it('ignores the flag on prop spellings a host might invent', () => {
+    // Same convergence `TextAreaField` went through in objectui#3232/#3233:
+    // the metadata is the ONE carrier. A host passing the flag as a prop must
+    // get nothing — a tolerant `??` chain here is exactly where a misspelled
+    // AI-authored flag would hide and look supported.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const hostProps = {
+        mobileFullscreen: true,
+        mobile_fullscreen: true,
+        schema: fieldMeta({ mobile_fullscreen: true }),
+      } as unknown as Partial<FieldWidgetComponentProps<string>>;
+
+      render(
+        <RichTextField value="" onChange={() => {}} field={fieldMeta()} {...hostProps} />,
+      );
+
+      expect(screen.queryByTestId('richtext-fullscreen-toggle')).not.toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -1057,12 +1057,27 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
   //    both paths on ONE key in ONE place (objectui#3232 / #3233): no widget
   //    reads a second spelling, so a flag written anywhere else stays dead
   //    instead of being quietly caught by a fallback.
+  //
+  //    Every type below has a READER, which is what makes the stamp mean
+  //    something (objectui#3301): `textarea` is the form renderer's built-in
+  //    branch, `field:textarea` is `TextAreaField`, and `field:markdown` /
+  //    `field:html` both resolve to `RichTextField` — which now reads the flag
+  //    too, so `ObjectFormSchema.mobile`'s documented "textarea/rich-text get
+  //    an expand button" is finally true of rich text as well.
+  //
+  //    A sixth type, `'string-multiline'`, was stamped here until #3301 and is
+  //    gone: `grep -rn "string-multiline"` across BOTH this repo and
+  //    `objectstack` (excluding node_modules/dist) returned exactly one hit —
+  //    this line. No producer emitted it, no registry key matched it, and no
+  //    widget read it, so the branch could only ever be false. Stamping types
+  //    nobody produces is how a flag comes to look supported while doing
+  //    nothing; a type belongs here once something can actually render it.
   const mobileOpts = schema.mobile;
   const fieldsWithMobile = mobileOpts?.fullscreenLongText
     ? autoLayoutResult.fields.map((f) => {
         const t = f.type as string | undefined;
         const isTextarea = t === 'textarea' || t === 'field:textarea' ||
-          t === 'string-multiline' || t === 'field:markdown' || t === 'field:html';
+          t === 'field:markdown' || t === 'field:html';
         if (!isTextarea) return f;
         return f.field
           ? { ...f, field: { ...f.field, mobile_fullscreen: true } }

--- a/packages/plugin-form/src/__tests__/ObjectForm.mobileFullscreen.test.tsx
+++ b/packages/plugin-form/src/__tests__/ObjectForm.mobileFullscreen.test.tsx
@@ -8,7 +8,8 @@
 
 /**
  * End-to-end pin for `ObjectFormSchema.mobile.fullscreenLongText`
- * (objectui#3245) — the ONLY integration coverage this feature has.
+ * (objectui#3245, extended to rich text in objectui#3301) — the ONLY
+ * integration coverage this feature has.
  *
  * Everything below is real: the real `ObjectForm` (the flag's single
  * producer), the real form renderer in `@object-ui/components`, the real
@@ -45,7 +46,7 @@
  * of racing RTL's 1000ms `findBy` budget against a cold Vite transform.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { registerAllFields } from '@object-ui/fields';
 import type { ObjectFormSchema } from '@object-ui/types';
@@ -61,9 +62,34 @@ const objectSchema = {
   },
 };
 
-function makeDataSource() {
+/**
+ * The rich-text half of the same promise (objectui#3301). `markdown` and
+ * `html` both map to `field:markdown` / `field:html` (`mapFieldTypeToFormType`)
+ * and both resolve to `RichTextField`, which — until #3301 — never read the
+ * flag `ObjectForm` had been stamping on them all along.
+ */
+const richTextObjectSchema = {
+  name: 'release_note',
+  label: 'Release Note',
+  fields: {
+    summary: { type: 'markdown', label: 'Summary' },
+    changelog: { type: 'html', label: 'Changelog' },
+  },
+};
+
+/** A form holding BOTH widget families, to pin that one setting drives both. */
+const mixedObjectSchema = {
+  name: 'mixed_note',
+  label: 'Mixed Note',
+  fields: {
+    body: { type: 'textarea', label: 'Body' },
+    summary: { type: 'markdown', label: 'Summary' },
+  },
+};
+
+function makeDataSource(schema: object = objectSchema) {
   return {
-    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    getObjectSchema: vi.fn().mockResolvedValue(schema),
     findOne: vi.fn(),
     insert: vi.fn(),
     update: vi.fn(),
@@ -71,20 +97,32 @@ function makeDataSource() {
   } as any;
 }
 
-function renderForm(schema: Partial<ObjectFormSchema>) {
+function renderForm(
+  schema: Partial<ObjectFormSchema>,
+  object: { name: string } & Record<string, unknown> = objectSchema,
+) {
   return render(
     <ObjectForm
       schema={
         {
           type: 'object-form',
-          objectName: 'issue_note',
+          objectName: object.name,
           mode: 'create',
           ...schema,
         } as ObjectFormSchema
       }
-      dataSource={makeDataSource()}
+      dataSource={makeDataSource(object)}
     />,
   );
+}
+
+/** The widget's INLINE control, as opposed to the one inside its dialog. */
+function inlineControl(fieldName: string): HTMLTextAreaElement {
+  const el = document.querySelector<HTMLTextAreaElement>(
+    `[data-field="${fieldName}"] textarea`,
+  );
+  if (!el) throw new Error(`no control rendered for field "${fieldName}"`);
+  return el;
 }
 
 describe('ObjectForm mobile.fullscreenLongText → TextAreaField (objectui#3245)', () => {
@@ -135,5 +173,76 @@ describe('ObjectForm mobile.fullscreenLongText → TextAreaField (objectui#3245)
     await waitFor(() => {
       expect(screen.queryByTestId('textarea-fullscreen-toggle')).not.toBeInTheDocument();
     });
+  });
+});
+
+/**
+ * The other half of the same setting (objectui#3301).
+ *
+ * `mobile.fullscreenLongText` is documented as "textarea/rich-text get an
+ * expand button", and `ObjectForm` has always stamped `mobile_fullscreen` onto
+ * `field:markdown` / `field:html` too. `RichTextField` never read it, so the
+ * rich-text half of that sentence had been inert since it was written — a
+ * producer with no consumer, which no unit test on either end can see. These
+ * assertions are RED against the pre-#3301 widget.
+ */
+describe('ObjectForm mobile.fullscreenLongText → RichTextField (objectui#3301)', () => {
+  it('reaches the widget for an AUTO-GENERATED field:markdown / field:html field', async () => {
+    renderForm({ mobile: { fullscreenLongText: true } }, richTextObjectSchema);
+
+    // Both rich-text types resolve to the same widget, and both are stamped.
+    await waitFor(() => {
+      expect(screen.getAllByTestId('richtext-fullscreen-toggle')).toHaveLength(2);
+    });
+  });
+
+  it('does NOT render the affordance when the form did not opt in', async () => {
+    renderForm({}, richTextObjectSchema);
+
+    // Settle on the rendered widget before asserting an absence.
+    await waitFor(() => expect(inlineControl('summary')).toBeInTheDocument());
+    await waitFor(() => {
+      expect(screen.queryByTestId('richtext-fullscreen-toggle')).not.toBeInTheDocument();
+    });
+  });
+
+  it('commits a fullscreen edit back into the form state', async () => {
+    // The acceptance criterion end to end: edit inside the dialog, close it,
+    // and the react-hook-form value is updated — observed through the INLINE
+    // control, which re-renders from form state. A widget that committed to a
+    // local buffer instead (or lost the value on unmount) fails here while
+    // every isolated unit test still passes.
+    renderForm(
+      {
+        mobile: { fullscreenLongText: true },
+        customFields: [{ name: 'summary', label: 'Summary', type: 'field:markdown' }],
+      },
+      richTextObjectSchema,
+    );
+
+    const toggle = await screen.findByTestId('richtext-fullscreen-toggle');
+    fireEvent.click(toggle);
+
+    fireEvent.change(screen.getByTestId('richtext-fullscreen-input'), {
+      target: { value: '## Shipped' },
+    });
+    fireEvent.click(screen.getByTestId('richtext-fullscreen-save'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('richtext-fullscreen-dialog')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(inlineControl('summary')).toHaveValue('## Shipped');
+    });
+  });
+
+  it('drives BOTH widget families from the one form-level setting', async () => {
+    // The regression this whole issue is about: the setting is form-level, so
+    // a form containing a textarea AND a markdown field must light up both.
+    // Before #3301 only the textarea did, from the very same stamp.
+    renderForm({ mobile: { fullscreenLongText: true } }, mixedObjectSchema);
+
+    expect(await screen.findByTestId('textarea-fullscreen-toggle')).toBeInTheDocument();
+    expect(await screen.findByTestId('richtext-fullscreen-toggle')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #3301

按 2026-08-03 的维护者裁决走 **A 路：兑现承诺，不收窄**。`mobile.fullscreenLongText` 对 `field:markdown` / `field:html` 从「盖了没人读」变成真的能用。

## 缺陷复核（premise check，全部确证）

| 断言 | 复核结果 |
|---|---|
| `RichTextField` 不读 flag | 确证。修改前 `grep -n "fullscreen\|mobile_" packages/fields/src/widgets/RichTextField.tsx` 零命中 |
| `field:markdown` / `field:html` 都落到 `RichTextField` | 确证（`packages/fields/src/index.tsx:2349,2353`，两处 `createFieldRenderer(RichTextField)`） |
| `string-multiline` 无人产出 | 确证。**本仓 + `objectstack` 兄弟仓**（排除 `node_modules`/`dist`/`.git`）全类型 grep，全仓合计 **1 处命中**，就是判定式那一行本身 |

## 改了什么

**读取（唯一载体）**：`RichTextField` 读 `field.mobile_fullscreen`，**只此一处**。没有新 prop、没有第二载体、没有 `??` 兜底链——与 `TextAreaField` 逐字同构。拼错的 flag 在两个 widget 里都保持 inert，不会被某一侧的宽容消费悄悄接住（AGENTS #0.1）。

**复用决策：抽出共享件**。展开按钮 + 对话框 + draft/commit 状态机进入新的 `packages/fields/src/widgets/FullscreenFieldEditor.tsx`，两个 widget 共用；**per-widget 的只有编辑器本身**（`children` 注入）。

判断依据：`fullscreenLongText` 是**一个表单级设置**，用户打开它期待**一种行为**。手写第二份状态机就是本 issue 的缺陷再来一遍（只是多绕一步）——它会漂移，而且没有任何东西会报告漂移。抽出来之后这一点是**机械可验的**：见下方 sabotage C，改坏共享件的 commit 一处，`TextAreaField` 与 `RichTextField` 的测试**同时**变红。

**对话框里是真编辑器**：`RichTextEditorSurface` 内联与全屏两处渲染同一份（同 format 指示、同编辑器），`fullHeight` 是唯一差异。若对话框内联一个裸 `Textarea`，两个界面**当场**就已经不一致（少了 format 指示），且这个 widget 每长出一个 affordance 就再不一致一次。

> ⚠️ 一句实话：本 widget 今天的「富编辑器」就是一个 mono `Textarea` + format 指示行，**没有工具栏可接**（源码注释自陈 "A full implementation would use TipTap, Lexical, or Slate"）。所以本 PR 兑现的是「全屏里是这个 widget 真正的编辑面，不是降级副本」，而不是凭空发明一条工具栏——后者会是没有验收标准的 scope creep。等编辑器升级时，两处一起升级。

**`string-multiline` 死分支删除**：证据见上表，`ObjectForm` 判定式里附了注释说明依据。剩下 4 个 type 每个都有真实 reader。无既有测试引用该字串，故无测试需要调整。

**行为一致性**：draft 在打开时从已提交值播种、输入期间保持本地（RHF 不会因用户可能取消的编辑被标脏）、"Done" 提交一次、"Cancel" 丢弃。testid 沿用既有约定但按 widget 命名空间（`richtext-fullscreen-toggle` / `-dialog` / `-input` / `-save`）——一个表单里可以同时有 textarea 和 markdown 字段，共用一个 id 会让测试说不清自己找到的是谁。焦点管理 / `Esc` / overlay 沿用仓内 `Dialog`（Radix），未另行作答。

## 验证证据

### Sabotage（每条：改坏见红、还原见绿）

| # | 破坏点 | 结果 |
|---|---|---|
| A | `RichTextField` 停止读 flag（还原到 #3301 之前） | **8 红**（全部 rich-text 正向断言），负向控制保持绿 |
| B | 对话框内换成裸 `Textarea`（降级副本） | **恰好 1 红** — `puts the REAL editor in the dialog`（`expected [ span ] to have a length of 2 but got 1`） |
| C | 共享件的 commit 不回传 draft | **3 红，跨两个 widget** — `RichTextField` + **`TextAreaField`** 的 commit 测试 + 集成链的表单状态测试 → 证明复用是真共享 |
| D | 共享件打开时不重新播种 draft | **恰好 1 红** — `discards the draft on Cancel` |
| E | 生产侧去掉 `fullscreenLongText` 开关（无条件盖章） | **2 红** — `TextAreaField` 与 `RichTextField` 两条负向控制 |

### 测试

```
pnpm exec vitest run packages/fields packages/plugin-form --maxWorkers=2
 Test Files  76 passed (76)
      Tests  855 passed (855)
```

新增/扩展：
- `packages/fields/src/widgets/__tests__/RichTextField.mobileFullscreen.test.tsx`（新，8 例）— 含 readonly 不出 affordance、Cancel 丢弃且重开从已提交值播种、无第二载体。
- `packages/plugin-form/src/__tests__/ObjectForm.mobileFullscreen.test.tsx`（扩展，+4 例）— 镜像 #3300 范式，真 `ObjectForm` → 真渲染器 → 真 `RichTextField`，除 dataSource 外无 mock：自动生成的 `field:markdown` + `field:html` 双双出现 affordance；未开启则不出现；**对话框内编辑 → 关闭 → 通过内联控件观察到 react-hook-form 状态已更新**；textarea + markdown 混合表单由同一个设置同时点亮两族 widget。
- `TextAreaField` 既有测试**未做任何修改**，全绿（回归不变）。

```
turbo run type-check --filter @object-ui/fields --filter @object-ui/plugin-form
 Tasks:    13 successful, 13 total

turbo run lint --filter @object-ui/fields --filter @object-ui/plugin-form
 Tasks:    2 successful, 2 total     (0 errors；warnings 均为既有 `field as any` 等既存形态)
```

`FullscreenFieldEditor.tsx` 零 lint warning。changeset：`@object-ui/fields` + `@object-ui/plugin-form` **minor**（`pnpm changeset:check` 双绿）。

## 需要维护者裁决的一处（**未擅自修改**）

`packages/types/src/field-types.ts` 中 `mobile_fullscreen` 的 JSDoc 现在**过时**了：

```
* **Consumer**: `TextAreaField` (`@object-ui/fields`), which reads it off …
```

本 PR 之后消费者是**两个**。`packages/types` 在本单的范围栅栏外（指示要求「停下回报而不是直接改」），所以这行注释**原样保留**，请裁决是否另开一个 2 行 docs PR 补上 `RichTextField`。留着不改的代价正是本 issue 那类 declared-vs-actual 漂移，只不过方向反了：声明比实现**窄**。

（`packages/types/src/objectql.ts:1265` 那句 `fullscreenLongText: true, // textarea/rich-text get an "expand" button` **不必改**——本 PR 之后它第一次成为事实。）

## 未做

- 浏览器 dogfood 未做（本单证据等级为测试级；集成链已无 mock 地跑通真渲染器）。
- 未动 `apps/console`、`packages/components`、`packages/types`、`packages/spec`、`content/docs/releases/`。
- issue 里提到的 `TextAreaField.tsx` `as any` 消费侧洞：未处理，issue 自陈「不必然与上面同单处理」，且彻底修复需先决定 widget 如何收窄 `FieldMetadata` 联合。
