### PR TITLE
fix(console): emit maplibre's sibling worker beside its chunk (#3297)

### DIFF
--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
 import { viteCryptoStub } from '../../scripts/vite-crypto-stub';
+import { viteMaplibreWorker } from '../../scripts/vite-maplibre-worker';
 import { compression } from 'vite-plugin-compression2';
 import { visualizer } from 'rollup-plugin-visualizer';
 
@@ -172,6 +173,11 @@ export default defineConfig({
     react(),
     // Inject <link rel="modulepreload"> for critical chunks
     preloadCriticalChunks(),
+    // maplibre-gl loads its worker as a sibling of its own chunk URL — an
+    // edge no bundler can see — so the worker (and the shared module it
+    // imports) must be copied into assets/ or every map page 404s
+    // (objectui#3297). Asserts on drift; never silently skips.
+    viteMaplibreWorker(),
     // Dev-only plugin: serve runtime assets (product logo/favicon) from the
     // host project's runtime/assets directory so branding URLs configured
     // via OS_LOGO_URL / OS_FAVICON_URL resolve without a fragile symlink.

--- a/scripts/__tests__/vite-maplibre-worker.test.ts
+++ b/scripts/__tests__/vite-maplibre-worker.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+import {
+  MAPLIBRE_DEV_WORKER_ENTRY,
+  MAPLIBRE_WORKER_ENTRY,
+  auditWorkerReferences,
+  collectRelativeImports,
+  collectWorkerAssets,
+  collectWorkerReferences,
+  findMaplibreDistDir,
+} from '../vite-maplibre-worker';
+
+/**
+ * objectui#3297: maplibre-gl resolves its worker as a sibling of its own script
+ * URL (`new URL('./maplibre-gl-worker.mjs', import.meta.url)`), which no bundler
+ * can follow. Vite bundled maplibre into `assets/maplibre-gl-<hash>.js` and
+ * emitted nothing beside it, so `/_console/assets/maplibre-gl-worker.mjs` 404'd
+ * in every deployment.
+ *
+ * The copy step is only half the fix; the other half is that it must keep
+ * describing maplibre. These tests pin the drift audit that fails the BUILD
+ * when a maplibre upgrade renames the worker or changes its dist layout —
+ * the failure mode the original bug had no signal for at all.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('findMaplibreDistDir', () => {
+  it('derives the dist dir from any module id inside it', () => {
+    expect(
+      findMaplibreDistDir('/repo/packages/plugin-map/node_modules/maplibre-gl/dist/maplibre-gl.mjs'),
+    ).toBe('/repo/packages/plugin-map/node_modules/maplibre-gl/dist');
+    // CSS, or any other dist file, answers the same question.
+    expect(findMaplibreDistDir('/repo/node_modules/maplibre-gl/dist/maplibre-gl.css')).toBe(
+      '/repo/node_modules/maplibre-gl/dist',
+    );
+  });
+
+  it('ignores the query suffix Vite appends to module ids', () => {
+    expect(findMaplibreDistDir('/repo/node_modules/maplibre-gl/dist/maplibre-gl.css?used')).toBe(
+      '/repo/node_modules/maplibre-gl/dist',
+    );
+  });
+
+  it('returns null for unrelated modules', () => {
+    expect(findMaplibreDistDir('/repo/packages/plugin-map/src/MapRenderer.tsx')).toBeNull();
+    // A lookalike outside maplibre's own dist must not answer.
+    expect(findMaplibreDistDir('/repo/node_modules/react-map-gl/dist/maplibre.js')).toBeNull();
+  });
+});
+
+describe('collectWorkerReferences', () => {
+  it('finds both branches of maplibre’s minified worker-name ternary', () => {
+    // Verbatim from the built chunk quoted in objectui#3297.
+    const chunk =
+      'function di(){let e=import.meta.url;if(!/^https?:/.test(e))return``;' +
+      'let t=e.endsWith(`-dev.mjs`)?`maplibre-gl-worker-dev.mjs`:`maplibre-gl-worker.mjs`;' +
+      'return new URL(`./${t}`,e).href}';
+    expect(collectWorkerReferences(chunk)).toEqual([
+      MAPLIBRE_DEV_WORKER_ENTRY,
+      MAPLIBRE_WORKER_ENTRY,
+    ]);
+  });
+
+  it('picks up a renamed worker rather than silently matching nothing', () => {
+    expect(collectWorkerReferences('new URL(`./maplibre-gl-worker.v2.mjs`,e)')).toEqual([
+      'maplibre-gl-worker.v2.mjs',
+    ]);
+  });
+
+  it('returns nothing for a chunk with no worker reference', () => {
+    expect(collectWorkerReferences('export const a = 1;')).toEqual([]);
+  });
+});
+
+describe('collectRelativeImports', () => {
+  it('reads minified static imports, side-effect imports and re-exports', () => {
+    const code = [
+      'import{$ as e,Ai as t}from"./maplibre-gl-shared.mjs";',
+      "import'./side-effect.mjs';",
+      'export{a}from"./re-export.mjs";',
+      'const lazy=await import("./dynamic.mjs");',
+    ].join('\n');
+    expect(collectRelativeImports(code)).toEqual([
+      './dynamic.mjs',
+      './maplibre-gl-shared.mjs',
+      './re-export.mjs',
+      './side-effect.mjs',
+    ]);
+  });
+
+  it('ignores bare specifiers — only siblings need copying', () => {
+    expect(collectRelativeImports('import x from "maplibre-gl";')).toEqual([]);
+  });
+});
+
+describe('collectWorkerAssets', () => {
+  const fakeDist: Record<string, string> = {
+    'maplibre-gl-worker.mjs': 'import{a}from"./maplibre-gl-shared.mjs";export default a;',
+    'maplibre-gl-shared.mjs': 'export const a=1;',
+  };
+  const read = (dist: Record<string, string>) => (name: string) => dist[name] ?? null;
+
+  it('walks the worker’s sibling closure — the worker alone is not enough', () => {
+    const assets = collectWorkerAssets(MAPLIBRE_WORKER_ENTRY, read(fakeDist));
+    expect([...assets.keys()]).toEqual(['maplibre-gl-worker.mjs', 'maplibre-gl-shared.mjs']);
+    expect(assets.get('maplibre-gl-shared.mjs')).toBe('export const a=1;');
+  });
+
+  it('throws when the worker itself is gone (an upgrade renamed it)', () => {
+    expect(() => collectWorkerAssets(MAPLIBRE_WORKER_ENTRY, () => null)).toThrow(
+      /maplibre-gl-worker\.mjs' does not exist/,
+    );
+  });
+
+  it('throws when a sibling the worker imports is missing', () => {
+    const broken = { 'maplibre-gl-worker.mjs': fakeDist['maplibre-gl-worker.mjs'] };
+    expect(() => collectWorkerAssets(MAPLIBRE_WORKER_ENTRY, read(broken))).toThrow(
+      /maplibre-gl-shared\.mjs' does not exist/,
+    );
+  });
+
+  it('throws when the dist layout stops being flat', () => {
+    const nested = {
+      'maplibre-gl-worker.mjs': 'import"./sub/shared.mjs";',
+      'sub/shared.mjs': 'export const a=1;',
+    };
+    // A nested path would land outside assetsDir at a URL maplibre's worker
+    // cannot reach — fail the build instead of shipping a half-copy.
+    expect(() => collectWorkerAssets(MAPLIBRE_WORKER_ENTRY, read(nested))).toThrow(
+      /not a flat sibling/,
+    );
+  });
+
+  it('terminates on a circular sibling graph', () => {
+    const circular = {
+      'maplibre-gl-worker.mjs': 'import"./maplibre-gl-shared.mjs";',
+      'maplibre-gl-shared.mjs': 'import"./maplibre-gl-worker.mjs";export const a=1;',
+    };
+    expect([...collectWorkerAssets(MAPLIBRE_WORKER_ENTRY, read(circular)).keys()]).toEqual([
+      'maplibre-gl-worker.mjs',
+      'maplibre-gl-shared.mjs',
+    ]);
+  });
+});
+
+describe('auditWorkerReferences', () => {
+  const emitted = [MAPLIBRE_WORKER_ENTRY, 'maplibre-gl-shared.mjs'];
+
+  it('passes when the bundle asks only for what the build emitted', () => {
+    expect(auditWorkerReferences([MAPLIBRE_WORKER_ENTRY], emitted)).toBeNull();
+  });
+
+  it('tolerates the -dev branch, which a hashed chunk can never select', () => {
+    expect(
+      auditWorkerReferences([MAPLIBRE_DEV_WORKER_ENTRY, MAPLIBRE_WORKER_ENTRY], emitted),
+    ).toBeNull();
+  });
+
+  it('fails when an upgrade renames the worker the bundle requests', () => {
+    const message = auditWorkerReferences(['maplibre-gl-worker.v2.mjs'], emitted);
+    expect(message).toMatch(/does not emit: maplibre-gl-worker\.v2\.mjs/);
+  });
+
+  it('fails when the bundle stops referencing a sibling worker at all', () => {
+    // Either maplibre changed mechanism or chunking hid it; both need a human.
+    expect(auditWorkerReferences([], emitted)).toMatch(/No 'maplibre-gl-worker\*\.mjs' reference/);
+  });
+});
+
+describe('the installed maplibre-gl still matches these assumptions', () => {
+  // Reading the real dist keeps the constants above honest: an upgrade that
+  // renames the worker or drops the sibling convention turns this red in
+  // `pnpm test`, not in a browser tab.
+  const distDir = (() => {
+    try {
+      const require_ = createRequire(path.join(repoRoot, 'packages/plugin-map/package.json'));
+      return path.dirname(require_.resolve('maplibre-gl/dist/maplibre-gl.mjs'));
+    } catch {
+      return null;
+    }
+  })();
+
+  it('resolves maplibre-gl from the package that depends on it', () => {
+    expect(distDir).not.toBeNull();
+  });
+
+  it('computes its worker URL as a sibling of its own script URL', () => {
+    const entry = fs.readFileSync(path.join(distDir!, 'maplibre-gl.mjs'), 'utf8');
+    expect(collectWorkerReferences(entry)).toContain(MAPLIBRE_WORKER_ENTRY);
+    expect(entry).toContain('import.meta.url');
+  });
+
+  it('ships a worker whose sibling closure is on disk beside it', () => {
+    const assets = collectWorkerAssets(MAPLIBRE_WORKER_ENTRY, (name) => {
+      const file = path.join(distDir!, name);
+      return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : null;
+    });
+    // The worker is a *module* worker: shipping it without the shared module
+    // it imports would trade the 404 in #3297 for a 404 one hop deeper.
+    expect([...assets.keys()]).toContain('maplibre-gl-shared.mjs');
+    expect(auditWorkerReferences([MAPLIBRE_WORKER_ENTRY], [...assets.keys()])).toBeNull();
+  });
+});

--- a/scripts/vite-maplibre-worker.ts
+++ b/scripts/vite-maplibre-worker.ts
@@ -180,8 +180,9 @@ export function viteMaplibreWorker(): Plugin {
 
   return {
     name: 'maplibre-sibling-worker',
-    // `pre` so the resolveId hook below sees bare specifiers before Vite's own
-    // resolver rewrites them to a pre-bundled dep.
+    // `pre` so the resolveId hook below runs before Vite's core resolver
+    // answers the specifier — once a plugin resolves an id, later plugins'
+    // resolveId hooks never see it.
     enforce: 'pre',
 
     configResolved(config: ResolvedConfig) {

--- a/scripts/vite-maplibre-worker.ts
+++ b/scripts/vite-maplibre-worker.ts
@@ -1,0 +1,308 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+// Hook parameters are annotated explicitly throughout: Vite types each hook as
+// `ObjectHook<Fn>` (a function-or-object union), and TypeScript cannot
+// contextually infer parameters across such a union — same reason
+// `scripts/vite-crypto-stub.ts` spells its types out.
+import type { Plugin, ResolvedConfig, Rollup, ViteDevServer } from 'vite';
+
+/**
+ * maplibre-gl loads its web worker as a **sibling of its own script URL** —
+ * it never imports it, so no bundler can see the edge:
+ *
+ * ```js
+ * // maplibre-gl/dist/maplibre-gl.mjs
+ * let e = import.meta.url;
+ * let t = e.endsWith(`-dev.mjs`) ? `maplibre-gl-worker-dev.mjs` : `maplibre-gl-worker.mjs`;
+ * return new URL(`./${t}`, e).href;
+ * ```
+ *
+ * Vite bundles maplibre into a hashed chunk under `assets/` and emits nothing
+ * beside it, so at runtime that URL resolves to `<base>/assets/maplibre-gl-worker.mjs`
+ * and 404s in every deployment (objectui#3297).
+ *
+ * This plugin closes the gap by copying maplibre's worker — and everything the
+ * worker itself imports, which is a second sibling file (`maplibre-gl-shared.mjs`),
+ * not just the worker — into the build's `assetsDir`, where the runtime looks.
+ *
+ * It is deliberately assertive rather than best-effort. A maplibre upgrade that
+ * renames the worker, drops the sibling convention, or moves its dist layout
+ * must fail the BUILD, loudly, instead of shipping a 404 that only a browser
+ * tab reveals — the same "no silent drift" posture `scripts/build-console.sh`
+ * takes with its `CONSOLE_BUNDLE_CANARY`.
+ *
+ * **Dev has the same hole, one directory over.** `optimizeDeps` pre-bundles
+ * maplibre into `node_modules/.vite/deps/maplibre-gl-<hash>.js`, so the sibling
+ * URL becomes `/node_modules/.vite/deps/maplibre-gl-worker.mjs` — equally
+ * absent (measured: 404). The dev server therefore serves the same files out of
+ * maplibre's real dist directory, so `pnpm dev` and a built console behave alike.
+ */
+
+/** Worker basename maplibre computes for a non-`-dev` script URL. */
+export const MAPLIBRE_WORKER_ENTRY = 'maplibre-gl-worker.mjs';
+
+/**
+ * The other half of maplibre's ternary. It is picked only when the *loading*
+ * script's URL ends in `-dev.mjs` (maplibre's own unminified distribution).
+ * A Vite chunk is `assets/maplibre-gl-<hash>.js`, so this branch is
+ * unreachable here — the name is whitelisted by the drift audit, not emitted.
+ */
+export const MAPLIBRE_DEV_WORKER_ENTRY = 'maplibre-gl-worker-dev.mjs';
+
+/** Every `maplibre-gl-worker*.mjs` literal a bundled chunk may compute. */
+const WORKER_REFERENCE_RE = /maplibre-gl-worker[A-Za-z0-9._-]*\.mjs/g;
+
+/** `from"./x.mjs"`, `import"./x.mjs"`, `import("./x.mjs")` — ESM, minified or not. */
+const RELATIVE_IMPORT_RE = /(?:\bfrom|\bimport)\s*\(?\s*["'](\.[^"']*)["']/g;
+
+/** `…/maplibre-gl/dist` out of any module id inside maplibre's dist directory. */
+const MAPLIBRE_DIST_RE = /^(.*[\\/]maplibre-gl[\\/]dist)[\\/][^\\/]+$/;
+
+/**
+ * The directory maplibre's dist files live in, derived from a module id that
+ * rollup actually pulled into this build — so the copied worker is by
+ * construction the same version as the bundled main-thread code, with no
+ * second resolution (and no chance of resolving a different hoisted copy).
+ */
+export function findMaplibreDistDir(moduleId: string): string | null {
+  // Substring pre-filter: this runs per module in a build with thousands.
+  if (!moduleId.includes('maplibre-gl')) return null;
+  const match = MAPLIBRE_DIST_RE.exec(moduleId.split('?')[0]);
+  return match ? match[1] : null;
+}
+
+/** Unique, sorted worker basenames referenced by bundled code. */
+export function collectWorkerReferences(code: string): string[] {
+  // Same reason: the audit reads every chunk, and only one mentions the worker.
+  if (!code.includes('maplibre-gl-worker')) return [];
+  return [...new Set(code.match(WORKER_REFERENCE_RE) ?? [])].sort();
+}
+
+/** Unique, sorted relative specifiers statically imported by a module. */
+export function collectRelativeImports(code: string): string[] {
+  const found = new Set<string>();
+  for (const [, specifier] of code.matchAll(RELATIVE_IMPORT_RE)) found.add(specifier);
+  return [...found].sort();
+}
+
+/**
+ * Walk the worker's sibling-import closure. maplibre's worker is a *module*
+ * worker whose first line imports `./maplibre-gl-shared.mjs`; emitting the
+ * worker alone would trade a 404 on the worker for a 404 on its dependency.
+ *
+ * @param read returns a dist file's source, or null when it does not exist.
+ * @returns basename -> source, in discovery order.
+ * @throws when a referenced sibling is missing on disk (a broken/renamed dist).
+ */
+export function collectWorkerAssets(
+  entry: string,
+  read: (basename: string) => string | null,
+): Map<string, string> {
+  const assets = new Map<string, string>();
+  const queue = [entry];
+  const seenFrom = new Map<string, string>([[entry, "maplibre's runtime worker URL"]]);
+
+  while (queue.length > 0) {
+    const basename = queue.shift()!;
+    if (assets.has(basename)) continue;
+    const source = read(basename);
+    if (source === null) {
+      throw new Error(
+        `maplibre dist file '${basename}' does not exist (required by ${seenFrom.get(basename)}).`,
+      );
+    }
+    assets.set(basename, source);
+    for (const specifier of collectRelativeImports(source)) {
+      const next = path.posix.normalize(specifier);
+      if (next.includes('/')) {
+        throw new Error(
+          `maplibre worker asset '${basename}' imports '${specifier}', which is not a flat sibling — ` +
+            `the dist layout changed and this plugin's copy step no longer describes it.`,
+        );
+      }
+      if (!seenFrom.has(next)) seenFrom.set(next, `'${basename}'`);
+      queue.push(next);
+    }
+  }
+  return assets;
+}
+
+/**
+ * Drift audit: what the bundle asks for at runtime must be exactly what the
+ * build put on disk. Returns a failure message, or null when they agree.
+ */
+export function auditWorkerReferences(referenced: string[], emitted: string[]): string | null {
+  if (referenced.length === 0) {
+    return (
+      `No 'maplibre-gl-worker*.mjs' reference found in any built chunk.\n` +
+      `  maplibre no longer resolves its worker as a sibling of its own script URL, so the\n` +
+      `  files this plugin copies are either dead weight or landing under the wrong name.\n` +
+      `  Re-read maplibre's worker loading code, then update or delete this plugin.`
+    );
+  }
+  const known = new Set([...emitted, MAPLIBRE_DEV_WORKER_ENTRY]);
+  const unsatisfied = referenced.filter((name) => !known.has(name));
+  if (unsatisfied.length > 0) {
+    return (
+      `Built chunks request maplibre worker(s) this build does not emit: ${unsatisfied.join(', ')}.\n` +
+      `  Emitted: ${emitted.join(', ') || '(none)'}.\n` +
+      `  A maplibre upgrade renamed the worker — update MAPLIBRE_WORKER_ENTRY in\n` +
+      `  scripts/vite-maplibre-worker.ts to match, or the console 404s at runtime.`
+    );
+  }
+  return null;
+}
+
+/** A dev request for `maplibre-gl-worker.mjs` / `maplibre-gl-shared.mjs` / … */
+const MAPLIBRE_SIBLING_RE = /^maplibre-gl-[A-Za-z0-9._-]*\.mjs$/;
+
+/**
+ * The slice of a rollup output entry the drift audit reads. Spelled out locally
+ * because `scripts/` sits outside every package that depends on Vite, so Vite's
+ * own types are not resolvable from here (the same is true of
+ * `vite-crypto-stub.ts`) — and an audit that silently degrades to `any` is
+ * exactly the kind of quiet failure this plugin exists to prevent.
+ */
+type BundleEntry = { type: 'chunk'; code: string } | { type: 'asset' };
+
+/**
+ * Copy maplibre-gl's worker (and its sibling imports) into the build's
+ * `assetsDir`, serve the same files in dev, and fail the build if the bundle's
+ * own worker URL stops matching what was copied.
+ */
+export function viteMaplibreWorker(): Plugin {
+  let maplibreDistDir: string | null = null;
+  let assetsDir = 'assets';
+  let outDir = 'dist';
+  let emitted: string[] = [];
+
+  return {
+    name: 'maplibre-sibling-worker',
+    // `pre` so the resolveId hook below sees bare specifiers before Vite's own
+    // resolver rewrites them to a pre-bundled dep.
+    enforce: 'pre',
+
+    configResolved(config: ResolvedConfig) {
+      assetsDir = config.build.assetsDir;
+      outDir = path.resolve(config.root, config.build.outDir);
+    },
+
+    // Locating maplibre's dist directory takes two hooks, because dev and build
+    // move maplibre through different pipelines:
+    //
+    // - build: every bundled module passes through `transform`, so the dist
+    //   path arrives for free — and is by construction the copy rollup bundled.
+    // - dev: maplibre is served from `optimizeDeps`' pre-bundle and never
+    //   reaches `transform`. Resolve it with Node's own resolver instead,
+    //   anchored at the importer that pulled maplibre in — pnpm-correct, no
+    //   hardcoded node_modules layout, and (unlike `this.resolve`) it answers
+    //   with the file on disk rather than a `.vite/deps/` pre-bundle, and does
+    //   not make the optimizer bundle a new dep as a side effect.
+    //
+    // Any `maplibre-gl…` specifier is a usable anchor, not just the bare one:
+    // plugin-map imports `react-map-gl/maplibre` plus maplibre's stylesheet, so
+    // the bare specifier appears only inside an already-bundled dep, where no
+    // plugin hook can see it.
+    resolveId(source: string, importer: string | undefined) {
+      if (maplibreDistDir || !importer || !path.isAbsolute(importer)) return null;
+      if (source !== 'maplibre-gl' && !source.startsWith('maplibre-gl/')) return null;
+      try {
+        const worker = createRequire(importer).resolve(`maplibre-gl/dist/${MAPLIBRE_WORKER_ENTRY}`);
+        maplibreDistDir = findMaplibreDistDir(worker);
+      } catch {
+        // Not resolvable from here; the build path still has `transform`, and
+        // `generateBundle` fails loudly if nothing ever answered.
+      }
+      return null; // never claim the id — resolution continues untouched
+    },
+
+    transform(_code: string, id: string) {
+      if (!maplibreDistDir) maplibreDistDir = findMaplibreDistDir(id);
+      return null;
+    },
+
+    // Dev: answer the sibling URL maplibre computes next to its pre-bundled
+    // dep with the real file from maplibre's dist. Narrow by construction —
+    // it only ever serves a file that exists in that directory.
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use((req: IncomingMessage, res: ServerResponse, next: () => void) => {
+        const pathname = (req.url ?? '').split('?')[0];
+        const basename = pathname.slice(pathname.lastIndexOf('/') + 1);
+        if (!maplibreDistDir || !MAPLIBRE_SIBLING_RE.test(basename)) return next();
+        const file = path.join(maplibreDistDir, basename);
+        if (!file.startsWith(maplibreDistDir) || !fs.existsSync(file)) return next();
+        res.setHeader('Content-Type', 'text/javascript; charset=utf-8');
+        res.statusCode = 200;
+        res.end(fs.readFileSync(file));
+      });
+    },
+
+    generateBundle(_options: Rollup.NormalizedOutputOptions, bundle: Rollup.OutputBundle) {
+      const referenced = new Set<string>();
+      for (const output of Object.values(bundle) as BundleEntry[]) {
+        if (output.type !== 'chunk') continue;
+        for (const name of collectWorkerReferences(output.code)) referenced.add(name);
+      }
+
+      if (!maplibreDistDir) {
+        this.error(
+          `maplibre-gl was not found in this build.\n` +
+            `  This plugin exists to ship maplibre's sibling worker (objectui#3297); if the map\n` +
+            `  plugin was intentionally dropped from the console, remove viteMaplibreWorker()\n` +
+            `  from apps/console/vite.config.ts in the same change.`,
+        );
+        return;
+      }
+
+      let assets: Map<string, string>;
+      try {
+        assets = collectWorkerAssets(MAPLIBRE_WORKER_ENTRY, (basename) => {
+          const file = path.join(maplibreDistDir!, basename);
+          return fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : null;
+        });
+      } catch (error) {
+        this.error(
+          `${(error as Error).message}\n` +
+            `  Looked in ${maplibreDistDir}. maplibre's dist layout changed — update\n` +
+            `  scripts/vite-maplibre-worker.ts rather than letting the console 404 at runtime.`,
+        );
+        return;
+      }
+
+      emitted = [...assets.keys()];
+      const drift = auditWorkerReferences([...referenced].sort(), emitted);
+      if (drift) {
+        this.error(drift);
+        return;
+      }
+
+      for (const [basename, source] of assets) {
+        this.emitFile({
+          type: 'asset',
+          // Verbatim name, in assetsDir: maplibre computes this URL as a
+          // literal sibling of its own chunk, so it can be neither hashed
+          // nor placed anywhere else.
+          fileName: path.posix.join(assetsDir, basename),
+          source,
+        });
+      }
+    },
+
+    // Canary: emitFile can be undone by a later plugin or an output option.
+    // Assert against the real filesystem, after the write.
+    writeBundle() {
+      const missing = emitted.filter(
+        (basename) => !fs.existsSync(path.join(outDir, assetsDir, basename)),
+      );
+      if (missing.length > 0) {
+        this.error(
+          `maplibre worker asset(s) missing from the build output: ${missing.join(', ')}.\n` +
+            `  Expected them in ${path.join(outDir, assetsDir)} — something dropped the emitted\n` +
+            `  files, and every map page would 404 at runtime.`,
+        );
+      }
+    },
+  };
+}


### PR DESCRIPTION
Closes #3297

## 问题

`maplibre-gl` 把 worker 当作**自身脚本 URL 的兄弟文件**来解析，而不是 import 它，所以打包器看不到这条边（issue 中已给出构建产物摘录）：

```js
// maplibre-gl/dist/maplibre-gl.mjs
let e = import.meta.url;
let t = e.endsWith(`-dev.mjs`) ? `maplibre-gl-worker-dev.mjs` : `maplibre-gl-worker.mjs`;
return new URL(`./${t}`, e).href;
```

vite 把 maplibre 打成 `assets/maplibre-gl-[hash].js` 后旁边什么都不产出，于是运行时算出的
`/_console/assets/maplibre-gl-worker.mjs` 在**所有部署**里都是 404。

## 改动

新增 `scripts/vite-maplibre-worker.ts`（放在 `scripts/` 里，与既有的 `vite-crypto-stub.ts` 同一处），
在 `apps/console/vite.config.ts` 里接入。

**1. issue 只说了一半 —— worker 自己还有一个兄弟依赖。** maplibre 的 worker 是 *module worker*，
第一行就 `import "./maplibre-gl-shared.mjs"`（479 KB）。只拷 worker 只会把 404 往里挪一跳，
所以本 PR 拷的是 worker 的**兄弟闭包**：读 worker 源码，跟着它的相对 import 递归收集，
一并 emit 进 `assetsDir`。maplibre 以后拆出更多兄弟文件也会自动跟上。

**2. 落点。** 文件名不可哈希、不可换目录 —— 运行时算的是字面量兄弟路径。
源文件目录取自 rollup **本次真的打进去的那个模块 id**（`transform` 钩子），
所以拷出来的 worker 与主线程代码天然同版本，不存在二次解析选到另一份 hoist 副本的可能。

**3. 构建断言（参照 `scripts/build-console.sh` 的 `CONSOLE_BUNDLE_CANARY` 姿势）。**
三道，全部让构建**红**而不是运行时 404：

| 断言 | 触发条件 |
|---|---|
| dist 文件缺失 | maplibre 升级改名/改布局，要拷的文件不在了 |
| 引用漂移审计 | 产物 chunk 里请求的 worker 名不在本次 emit 的集合中 |
| 写盘后 canary | emit 被后续插件/配置吃掉，文件没真正落到 `dist/assets` |

## dev 模式（本单要求核对的第三点）

**结论：dev 原本也是坏的，同一机制、隔壁目录，已一并修。**

`optimizeDeps` 会把 maplibre 预打包到 `node_modules/.vite/deps/maplibre-gl-[hash].js`，
`import.meta.url` 未被改写，于是兄弟 URL 变成 `/node_modules/.vite/deps/maplibre-gl-worker.mjs`
—— 同样不存在。实测（修复前，console dev server）：

```
GET /node_modules/.vite/deps/maplibre-gl-ByR7Wvy-.js   200
GET /node_modules/.vite/deps/maplibre-gl-worker.mjs    404
GET /node_modules/.vite/deps/maplibre-gl-shared.mjs    404
```

因此插件同时挂了一个 dev 中间件，把这些请求用 maplibre 真实 dist 里的文件应答。
它只会应答**确实存在于 maplibre dist 里**的文件名，其余一律 `next()`。修复后：

```
GET /node_modules/.vite/deps/maplibre-gl-worker.mjs    200  text/javascript; charset=utf-8  19108
GET /node_modules/.vite/deps/maplibre-gl-shared.mjs    200  text/javascript; charset=utf-8  479327
GET /node_modules/.vite/deps/maplibre-gl-nope.mjs      404   ← 不会凭空造文件
```

## 验证

**构建产物**（`pnpm --filter @object-ui/console build`，绿）：

```
assets/maplibre-gl-DXuUDjK2.js     ← issue 里那个 chunk，hash 一致
assets/maplibre-gl-shared.mjs
assets/maplibre-gl-worker.mjs
```

**按 maplibre 自己的逻辑复算 URL**（从 preview 实际下发的 chunk 里正则取出那个三目表达式再算一遍）：

```
ternary found in served chunk: [ 'maplibre-gl-worker-dev.mjs', 'maplibre-gl-worker.mjs' ]
runtime-computed worker URL:   http://localhost:5399/assets/maplibre-gl-worker.mjs   -> 200, 19108 B
worker -> sibling import:      http://localhost:5399/assets/maplibre-gl-shared.mjs   -> 200, 479055 B
```

**issue 里那条一模一样的 URL**（`vite preview --base /_console/`）：

```
GET /_console/assets/maplibre-gl-worker.mjs  ->  HTTP=200  Content-Type=text/javascript  bytes=19108
GET /_console/assets/maplibre-gl-shared.mjs  ->  HTTP=200  Content-Type=text/javascript  bytes=479327
```

**sabotage（三道断言逐条验红，均 EXIT=1）**：

1. 把 worker 名改成 maplibre 没有的文件 →
   `maplibre dist file 'maplibre-gl-worker-v7.mjs' does not exist (required by maplibre's runtime worker URL).`
2. 改成拷一个存在但产物并不请求的文件 →
   `Built chunks request maplibre worker(s) this build does not emit: maplibre-gl-worker.mjs. Emitted: maplibre-gl-shared.mjs.`
3. 直接禁掉拷贝步骤 →
   `maplibre worker asset(s) missing from the build output: maplibre-gl-worker.mjs, maplibre-gl-shared.mjs.`

**测试 / 类型 / lint**：

```
vitest --project unit           359 files / 4933 passed        （含新增 20 条）
@object-ui/console test          20 files /  183 passed
@object-ui/console type-check    tsc --noEmit, 0 error
@object-ui/plugin-map type-check tsc --noEmit, 0 error
eslint（三个改动文件）             0 problem
```

新增的 20 条单测钉住了漂移审计的各个分支，并且会**读真实安装的 maplibre**：升级后
worker 改名或不再是兄弟约定，`pnpm test` 直接红，不用等到浏览器里才发现。

## ⚠️ 验证边界（如实标注）

- **tile 实际渲染未验证。** 本环境 egress 受限（`demotiles.maplibre.org` 打不通），
  容器内也没有可用浏览器（playwright 装了但没下载 browser），所以无法真的把地图画出来。
  验证到的是「产物存在 + 运行时算出的 URL 200 + MIME 正确 + worker 自身依赖也 200」。
- 因此 issue 里那个**严重度问题仍未确认**：worker 404 时 maplibre 究竟是主线程回退（只是慢）
  还是彻底不出图。有外网环境时值得复看一眼。不过这不影响本 PR 的正确性 ——
  第一方资产在自家产物里缺失，无论如何都该补。

## changeset

**未加**，依据两条：AGENTS.md「纯 bug 修复不需要 changeset」；以及仓库现行做法 ——
近期 `fix(console):` 三个 PR 均未附 changeset，而改动发布库包的
`fix(components)/fix(fields)/fix(app-shell)` 都附了。console 进部署走的是 framework 侧
`.objectui-sha` pin + `scripts/build-console.sh` 重新构建，不依赖 npm 版本号。
若维护者希望本次走版本发布，我再补一个（按仓规标 `minor`，绝不标 `major`）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_