### PR TITLE
feat(layout): area 可见性派生自 item 可见性,补掉退役留下的「可见但空」回归 (#3311)

### DIFF
--- a/.changeset/area-visibility-derived-from-items.md
+++ b/.changeset/area-visibility-derived-from-items.md
@@ -1,0 +1,41 @@
+---
+"@object-ui/layout": minor
+---
+
+`AppSchemaRenderer` now derives area visibility from the items inside the
+area, closing the visible-but-empty regression the spec 17.0.0 area-key
+retirement left behind (objectui#3311, option C of the recorded ruling).
+
+Spec 17.0.0 retired the authorable area-level `visible` /
+`requiredPermissions` (`AREA_VISIBLE_RETIRED` /
+`AREA_REQUIRED_PERMISSIONS_RETIRED`) — an area is a layout grouping, not an
+access boundary — and objectui followed in #3315 by deleting the area
+switcher's filter. Correct on the contract, but it changed the navigation
+surface: an area whose items are **all** gated away used to disappear from
+the switcher and instead rendered as a selectable, empty area.
+
+## What changed
+
+- **Area visibility is now derived, not authored.** An area appears in the
+  switcher iff at least one of its navigation items survives the exact
+  item-level guards `NavigationRenderer` applies: the `visible` expression,
+  `requiredPermissions`, the `requiresObject` / `requiresService` runtime
+  capability gates, and — for `action` items — the presence of an `onAction`
+  dispatcher (framework#4509: without one they are not rendered, so they
+  cannot carry an area either). Separators never count; a `group` counts only
+  through its children.
+- **The active area is elected among visible areas only.** A fully gated
+  first area is no longer auto-activated, and when a gating change hides the
+  currently active area the shell re-elects the first visible one. A gating
+  change that merely *reveals* an area never yanks the user away from where
+  they are.
+- **An area with no items at all derives the same way**: no visible item →
+  hidden. (Boundary recorded in objectui#3311.)
+- New export `hasVisibleNavigationItems(items, options)` from
+  `@object-ui/layout` — the predicate behind the derivation, usable by other
+  shells that render their own area switchers.
+
+No authorable key is involved anywhere: the platform's `.strict()` area
+object still rejects the retired keys, and the derivation — computed from the
+same guards that decide what renders — cannot disagree with the rendered
+navigation, so there is nothing for a metadata author to get wrong.

--- a/packages/layout/src/AppSchemaRenderer.tsx
+++ b/packages/layout/src/AppSchemaRenderer.tsx
@@ -41,6 +41,7 @@ import { menuItemToNavigationItem } from '@object-ui/types';
 import { AppShell, type AppShellBranding } from './AppShell';
 import {
   NavigationRenderer,
+  hasVisibleNavigationItems,
   resolveIcon,
   resolveLabel,
   type VisibilityEvaluator,
@@ -121,17 +122,24 @@ export interface AppSchemaRendererProps {
 // ---------------------------------------------------------------------------
 
 /**
- * Areas are NOT gated here any more. `@objectstack/spec` 17.0.0 retired
- * `visible` and `requiredPermissions` at area level
- * (`AREA_VISIBLE_RETIRED` / `AREA_REQUIRED_PERMISSIONS_RETIRED`): an area is a
- * layout grouping, not an access boundary, so gating belongs on the navigation
- * ITEM — which `NavigationRenderer` still enforces, via the same `evalVis` /
- * `checkPerm` this component used to apply one level up. The spec's area object
- * is `.strict()`, so no v17-valid app can carry the retired keys and this
- * filter had become unreachable for every app the platform accepts.
+ * Renders the switcher for the areas the current user can still see.
  *
- * Consequence worth knowing: an area whose items are all gated away now renders
- * as a visible-but-empty area rather than disappearing from the switcher.
+ * Areas carry no authorable gate of their own: `@objectstack/spec` 17.0.0
+ * retired `visible` and `requiredPermissions` at area level
+ * (`AREA_VISIBLE_RETIRED` / `AREA_REQUIRED_PERMISSIONS_RETIRED`) — an area is
+ * a layout grouping, not an access boundary, so gating belongs on the
+ * navigation ITEM, which `NavigationRenderer` still enforces via the same
+ * `evalVis` / `checkPerm` this component used to apply one level up. The
+ * spec's area object is `.strict()`, so no v17-valid app can carry the
+ * retired keys.
+ *
+ * Area visibility is instead DERIVED (objectui#3311): `AppSchemaRenderer`
+ * lists an area here iff `hasVisibleNavigationItems` finds at least one item
+ * in it that survives the item-level guards. An area whose items are all
+ * gated away disappears from the switcher — the same UX the retired keys used
+ * to produce — without resurrecting any authorable key for the platform's
+ * strict schema to reject. An area with no items at all derives the same way
+ * (no visible item → hidden).
  */
 function AreaSwitcher({
   areas,
@@ -272,6 +280,7 @@ function InternalSidebar({
   sidebarHeader,
   sidebarFooter,
   sidebarExtra,
+  visibleAreas,
   activeAreaId,
   setActiveAreaId,
   resolvedNavigation,
@@ -290,6 +299,8 @@ function InternalSidebar({
   sidebarHeader?: React.ReactNode;
   sidebarFooter?: React.ReactNode;
   sidebarExtra?: React.ReactNode;
+  /** Areas with at least one visible item — derived, not authored (#3311). */
+  visibleAreas: NavigationArea[];
   activeAreaId: string | null;
   setActiveAreaId: (id: string) => void;
   resolvedNavigation: NavigationItem[];
@@ -300,7 +311,6 @@ function InternalSidebar({
   onReorder?: (reorderedItems: NavigationItem[]) => void;
 }) {
   const Icon = resolveIcon(schema.logo);
-  const areas = schema.areas ?? [];
   const [searchQuery, setSearchQuery] = useState('');
 
   return (
@@ -349,10 +359,11 @@ function InternalSidebar({
       </SidebarHeader>
 
       <SidebarContent>
-        {/* Area Switcher */}
-        {areas.length > 1 && activeAreaId && (
+        {/* Area Switcher — only areas with a visible item, and only when
+            there is more than one of them left to switch between (#3311) */}
+        {visibleAreas.length > 1 && activeAreaId && (
           <AreaSwitcher
-            areas={areas}
+            areas={visibleAreas}
             activeAreaId={activeAreaId}
             onAreaChange={setActiveAreaId}
           />
@@ -393,7 +404,9 @@ function InternalSidebar({
  * Responsibilities:
  * - Reads `name`, `title`, `description`, `logo`, `favicon` for branding
  * - Renders sidebar navigation from `navigation` or `areas[].navigation`
- * - Area switcher when multiple `areas` are defined
+ * - Area switcher when multiple areas are VISIBLE — area visibility is
+ *   derived from the items inside, not authored (objectui#3311): an area
+ *   whose items are all gated away is hidden and never auto-activated
  * - Mobile modes: `drawer` (sheet overlay, default), `bottom_nav` (fixed
  *   bottom bar), `hamburger` (collapsed sidebar)
  * - Evaluates `visible` expressions and `requiredPermissions` on every item
@@ -448,24 +461,46 @@ export function AppSchemaRenderer({
   const flatNavigation = schema.navigation ?? legacyNavigation;
 
   // --- Area management ---
+  //
+  // Area visibility is DERIVED from the items inside (objectui#3311): an area
+  // is visible iff at least one of its navigation items survives the same
+  // item-level guards `NavigationRenderer` applies (`visible`,
+  // `requiredPermissions`, runtime capabilities, action-dispatcher presence).
+  // Spec 17.0.0 retired the authorable area-level keys; this derivation
+  // restores the "fully gated area disappears" UX without any authorable key.
+  // The active area is elected among the VISIBLE areas only, so the user is
+  // never landed in — or stranded on — an area that renders nothing.
   const areas = schema.areas ?? [];
+  const visibleAreas = areas.filter((area) =>
+    hasVisibleNavigationItems(area.navigation, {
+      evaluateVisibility: evalVis,
+      checkPermission: checkPerm,
+      checkCapability: checkCap,
+      hasActionHandler: !!onAction,
+    }),
+  );
   const [activeAreaId, setActiveAreaId] = useState<string | null>(
-    () => areas.length > 0 ? areas[0].id : null,
+    () => visibleAreas.length > 0 ? visibleAreas[0].id : null,
   );
 
-  const areaIds = areas.map((a) => a.id).join(',');
+  const visibleAreaIds = visibleAreas.map((a) => a.id).join(',');
 
   useEffect(() => {
-    if (areas.length > 0) {
+    if (visibleAreas.length > 0) {
       setActiveAreaId((prev) =>
-        areas.some((a) => a.id === prev) ? prev : areas[0].id,
+        visibleAreas.some((a) => a.id === prev) ? prev : visibleAreas[0].id,
       );
     } else {
       setActiveAreaId(null);
     }
-  }, [schema.name, areaIds]);
+  }, [schema.name, visibleAreaIds]);
 
-  const activeArea = areas.find((a) => a.id === activeAreaId);
+  // Resolve the EFFECTIVE active area at render time rather than trusting the
+  // state: when a gating change hides the currently active area, the effect
+  // above re-elects on the next tick — this fallback keeps the in-between
+  // frame from rendering the hidden area's (empty) navigation.
+  const activeArea =
+    visibleAreas.find((a) => a.id === activeAreaId) ?? visibleAreas[0];
   const resolvedNavigation: NavigationItem[] = activeArea?.navigation ?? flatNavigation;
 
   // --- Branding ---
@@ -487,7 +522,8 @@ export function AppSchemaRenderer({
       sidebarHeader={sidebarHeader}
       sidebarFooter={sidebarFooter}
       sidebarExtra={sidebarExtra}
-      activeAreaId={activeAreaId}
+      visibleAreas={visibleAreas}
+      activeAreaId={activeArea?.id ?? null}
       setActiveAreaId={setActiveAreaId}
       resolvedNavigation={resolvedNavigation}
       enableSearch={enableSearch}

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -343,6 +343,80 @@ const defaultPermission: PermissionChecker = () => true;
 const defaultCapability: CapabilityChecker = () => true;
 
 // ---------------------------------------------------------------------------
+// Derived area visibility (objectui#3311)
+// ---------------------------------------------------------------------------
+
+/** Guard callbacks for {@link hasVisibleNavigationItems}. */
+export interface NavigationVisibilityOptions {
+  /** Evaluator for item `visible` expressions. Defaults to always-visible. */
+  evaluateVisibility?: VisibilityEvaluator;
+  /** Checker for item `requiredPermissions`. Defaults to always-permitted. */
+  checkPermission?: PermissionChecker;
+  /** Checker for `requiresObject` / `requiresService`. Defaults to pass. */
+  checkCapability?: CapabilityChecker;
+  /**
+   * Whether the host wires an `onAction` dispatcher. Without one, `action`
+   * items are not rendered at all (framework#4509 — a nav entry that looks
+   * clickable and silently does nothing is worse than an absent one), so
+   * they cannot carry an area's visibility either. Defaults to `false`,
+   * matching a renderer with no `onAction` prop.
+   */
+  hasActionHandler?: boolean;
+}
+
+/**
+ * Whether a navigation tree contains at least one item that would actually
+ * render under the given guards — the exact guards `NavigationItemRenderer`
+ * applies per item: the `visible` expression, `requiredPermissions`, the
+ * `requiresObject` / `requiresService` runtime-capability gates, and (for
+ * `action` items) the presence of an action dispatcher.
+ *
+ * Non-content nodes never count: a `separator` is a visual divider, and a
+ * `group` counts only through its children — a group whose children are all
+ * gated away contributes nothing a user can navigate to.
+ *
+ * This is the predicate behind DERIVED area visibility (objectui#3311).
+ * `@objectstack/spec` 17.0.0 retired the authorable area-level `visible` /
+ * `requiredPermissions` (`AREA_VISIBLE_RETIRED` /
+ * `AREA_REQUIRED_PERMISSIONS_RETIRED`): an area is a layout grouping, not an
+ * access boundary. What replaces those keys is not a new key but this
+ * derivation: an area is visible iff something inside it is. Because it is
+ * computed from the same guards that decide what renders, it can never
+ * disagree with the rendered navigation — and there is nothing for a
+ * metadata author to get wrong. An area with no items at all derives the
+ * same way (no visible item → hidden).
+ */
+export function hasVisibleNavigationItems(
+  items: NavigationItem[],
+  options: NavigationVisibilityOptions = {},
+): boolean {
+  const {
+    evaluateVisibility = defaultVisibility,
+    checkPermission = defaultPermission,
+    checkCapability = defaultCapability,
+    hasActionHandler = false,
+  } = options;
+
+  for (const item of items) {
+    // Same guard order as NavigationItemRenderer.
+    if (!evaluateVisibility(item.visible)) continue;
+    if (item.requiredPermissions?.length && !checkPermission(item.requiredPermissions)) continue;
+    if (item.requiresObject && !checkCapability('object', item.requiresObject)) continue;
+    if (item.requiresService && !checkCapability('service', item.requiresService)) continue;
+
+    if (item.type === 'separator') continue;
+    if (item.type === 'group') {
+      if (hasVisibleNavigationItems(item.children ?? [], options)) return true;
+      continue;
+    }
+    if (item.type === 'action' && !hasActionHandler) continue;
+
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // Internal helper: resolve href from NavigationItem
 // ---------------------------------------------------------------------------
 

--- a/packages/layout/src/__tests__/AppSchemaRenderer.test.tsx
+++ b/packages/layout/src/__tests__/AppSchemaRenderer.test.tsx
@@ -12,6 +12,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { AppComponentSchema, NavigationItem, NavigationArea } from '@object-ui/types';
 import { AppSchemaRenderer } from '../AppSchemaRenderer';
+import { hasVisibleNavigationItems } from '../NavigationRenderer';
 
 /** Wrap component in MemoryRouter */
 function renderApp(
@@ -67,6 +68,15 @@ const serviceArea: NavigationArea = {
   icon: 'Headphones',
   navigation: [
     { id: 'a2', type: 'object', label: 'Cases', icon: 'Inbox', objectName: 'case' },
+  ],
+};
+
+const marketingArea: NavigationArea = {
+  id: 'area-marketing',
+  label: 'Marketing',
+  icon: 'Megaphone',
+  navigation: [
+    { id: 'a3', type: 'object', label: 'Campaigns', icon: 'Send', objectName: 'campaign' },
   ],
 };
 
@@ -189,15 +199,20 @@ describe('AppSchemaRenderer', () => {
   // `visible` / `requiredPermissions` were retired at AREA level
   // (`AREA_VISIBLE_RETIRED` / `AREA_REQUIRED_PERMISSIONS_RETIRED`): an area is a
   // layout grouping, not an access boundary. These two tests used to assert the
-  // area itself was hidden; they now assert the capability still exists one
-  // level down, which is where the spec moved it. Losing the gate entirely —
-  // rather than relocating it — is the regression worth catching, so the
-  // item-level assertions below are deliberately the same scenarios.
+  // area itself was hidden; after #3315 they asserted the capability still
+  // exists one level down, which is where the spec moved it. Losing the gate
+  // entirely — rather than relocating it — is the regression worth catching.
+  //
+  // Since #3311 the gated item needs a VISIBLE sibling here: an area whose
+  // items are ALL gated is now derived-hidden and never activated (see the
+  // "derived area visibility" block below), which would make a lone-gated-item
+  // assertion vacuous. A partially gated area stays visible and active, which
+  // is exactly what keeps "the ITEM is gated, the area is not" load-bearing.
 
-  // NB: the gated item must live in the FIRST area — that is the one the
-  // switcher activates by default, so it is the only area whose navigation is
-  // actually rendered. Gating an item in a non-active area asserts nothing:
-  // it is absent either way.
+  // NB: the gated item must live in the ACTIVE area — the first VISIBLE area
+  // is the one the switcher activates by default, so it is the only area whose
+  // navigation is actually rendered. Gating an item in a non-active area
+  // asserts nothing: it is absent either way.
 
   it('gates the navigation ITEM by visibility, not the area', () => {
     const schema: AppComponentSchema = {
@@ -207,7 +222,10 @@ describe('AppSchemaRenderer', () => {
       areas: [
         {
           ...salesArea,
-          navigation: [{ ...salesArea.navigation[0], visible: false }],
+          navigation: [
+            { ...salesArea.navigation[0], visible: false },
+            { id: 'a1b', type: 'object', label: 'Quotes', objectName: 'quote' },
+          ],
         },
         serviceArea,
       ],
@@ -215,8 +233,10 @@ describe('AppSchemaRenderer', () => {
     renderApp(schema, {
       evaluateVisibility: (expr) => expr !== false,
     });
-    // The area still appears in the switcher…
+    // The partially gated area still appears in the switcher, stays active,
+    // and renders its visible item…
     expect(screen.getByText('Sales')).toBeTruthy();
+    expect(screen.getByText('Quotes')).toBeTruthy();
     // …but the item it gates does not render.
     expect(screen.queryByText('Opportunities')).toBeNull();
   });
@@ -231,6 +251,7 @@ describe('AppSchemaRenderer', () => {
           ...salesArea,
           navigation: [
             { ...salesArea.navigation[0], requiredPermissions: ['sales:admin'] },
+            { id: 'a1b', type: 'object', label: 'Quotes', objectName: 'quote' },
           ],
         },
         serviceArea,
@@ -240,7 +261,250 @@ describe('AppSchemaRenderer', () => {
       checkPermission: (perms) => !perms.includes('sales:admin'),
     });
     expect(screen.getByText('Sales')).toBeTruthy();
+    expect(screen.getByText('Quotes')).toBeTruthy();
     expect(screen.queryByText('Opportunities')).toBeNull();
+  });
+
+  // --- Derived area visibility (#3311) ---
+  //
+  // Spec 17.0.0 retired the authorable area-level `visible` /
+  // `requiredPermissions`; #3315 followed suit, which left an area whose items
+  // are ALL gated rendering as visible-but-empty in the switcher. Per the
+  // #3311 ruling (option C), area visibility is now DERIVED from the items
+  // inside — the same item-level guards NavigationRenderer applies — so a
+  // fully gated area disappears again, with no authorable key involved. An
+  // area with no items at all derives the same way: nothing visible → hidden.
+
+  describe('derived area visibility (#3311)', () => {
+    const gatedSales: NavigationArea = {
+      ...salesArea,
+      navigation: [{ ...salesArea.navigation[0], visible: false }],
+    };
+
+    it('keeps every area in the switcher when every area has a visible item', () => {
+      renderApp({ type: 'app', name: 'crm', title: 'CRM', areas: [salesArea, serviceArea, marketingArea] });
+      expect(screen.getByText('Sales')).toBeTruthy();
+      expect(screen.getByText('Service')).toBeTruthy();
+      expect(screen.getByText('Marketing')).toBeTruthy();
+      // First area is active.
+      expect(screen.getByText('Opportunities')).toBeTruthy();
+    });
+
+    it('hides an area whose items are ALL gated and activates the first visible area', () => {
+      renderApp(
+        { type: 'app', name: 'crm', title: 'CRM', areas: [gatedSales, serviceArea, marketingArea] },
+        { evaluateVisibility: (expr) => expr !== false },
+      );
+      // The fully gated area is not offered in the switcher…
+      expect(screen.queryByText('Sales')).toBeNull();
+      expect(screen.getByText('Service')).toBeTruthy();
+      expect(screen.getByText('Marketing')).toBeTruthy();
+      // …and it is never auto-activated: the first VISIBLE area's navigation
+      // renders instead of a visible-but-empty Sales area.
+      expect(screen.getByText('Cases')).toBeTruthy();
+      expect(screen.queryByText('Opportunities')).toBeNull();
+    });
+
+    it('hides an area whose items all fail their permission checks', () => {
+      const adminSales: NavigationArea = {
+        ...salesArea,
+        navigation: [
+          { ...salesArea.navigation[0], requiredPermissions: ['sales:admin'] },
+        ],
+      };
+      renderApp(
+        { type: 'app', name: 'crm', title: 'CRM', areas: [adminSales, serviceArea, marketingArea] },
+        { checkPermission: (perms) => !perms.includes('sales:admin') },
+      );
+      expect(screen.queryByText('Sales')).toBeNull();
+      expect(screen.getByText('Service')).toBeTruthy();
+      expect(screen.getByText('Cases')).toBeTruthy();
+    });
+
+    it('hides the switcher entirely when only one area remains visible', () => {
+      renderApp(
+        { type: 'app', name: 'crm', title: 'CRM', areas: [gatedSales, serviceArea] },
+        { evaluateVisibility: (expr) => expr !== false },
+      );
+      // One visible area = nothing to switch between: no switcher at all,
+      // so neither area label renders — but the visible area's nav does.
+      expect(screen.queryByText('Sales')).toBeNull();
+      expect(screen.queryByText('Service')).toBeNull();
+      expect(screen.getByText('Cases')).toBeTruthy();
+    });
+
+    it('renders no switcher and no area navigation when every area is fully gated', () => {
+      renderApp(
+        {
+          type: 'app',
+          name: 'crm',
+          title: 'CRM',
+          areas: [
+            gatedSales,
+            { ...serviceArea, navigation: [{ ...serviceArea.navigation[0], visible: false }] },
+          ],
+        },
+        { evaluateVisibility: (expr) => expr !== false },
+      );
+      expect(screen.queryByText('Sales')).toBeNull();
+      expect(screen.queryByText('Service')).toBeNull();
+      expect(screen.queryByText('Opportunities')).toBeNull();
+      expect(screen.queryByText('Cases')).toBeNull();
+      // The shell itself still renders.
+      expect(screen.getByTestId('page-content')).toBeTruthy();
+    });
+
+    it('treats an area with no items at all like a fully gated one (hidden)', () => {
+      // Boundary decision recorded in #3311: an empty area derives exactly
+      // like an all-gated one — no visible item, no entry in the switcher.
+      const emptyArea: NavigationArea = { id: 'area-empty', label: 'Empty', navigation: [] };
+      renderApp({ type: 'app', name: 'crm', title: 'CRM', areas: [emptyArea, salesArea, serviceArea] });
+      expect(screen.queryByText('Empty')).toBeNull();
+      expect(screen.getByText('Sales')).toBeTruthy();
+      expect(screen.getByText('Service')).toBeTruthy();
+      // Active area skips the empty one.
+      expect(screen.getByText('Opportunities')).toBeTruthy();
+    });
+
+    it('derives through groups: an area whose groups have no visible child is hidden', () => {
+      const groupedGated: NavigationArea = {
+        id: 'area-grouped',
+        label: 'Grouped',
+        navigation: [
+          {
+            id: 'grp',
+            type: 'group',
+            label: 'Tools',
+            children: [
+              { id: 'grp-1', type: 'object', label: 'Hidden Tool', objectName: 'tool', visible: false },
+            ],
+          },
+        ],
+      };
+      renderApp(
+        { type: 'app', name: 'crm', title: 'CRM', areas: [groupedGated, serviceArea, marketingArea] },
+        { evaluateVisibility: (expr) => expr !== false },
+      );
+      expect(screen.queryByText('Grouped')).toBeNull();
+      expect(screen.getByText('Service')).toBeTruthy();
+      expect(screen.getByText('Cases')).toBeTruthy();
+    });
+
+    it('re-derives when gating changes: revoking a permission hides the active area and re-elects', () => {
+      const adminSales: NavigationArea = {
+        ...salesArea,
+        navigation: [
+          { ...salesArea.navigation[0], requiredPermissions: ['sales:admin'] },
+        ],
+      };
+      const schema: AppComponentSchema = {
+        type: 'app',
+        name: 'crm',
+        title: 'CRM',
+        areas: [adminSales, serviceArea, marketingArea],
+      };
+      const ui = (checkPermission: (perms: string[]) => boolean) => (
+        <MemoryRouter initialEntries={['/']}>
+          <AppSchemaRenderer schema={schema} basePath="/apps/crm" checkPermission={checkPermission}>
+            <div data-testid="page-content">Page Content</div>
+          </AppSchemaRenderer>
+        </MemoryRouter>
+      );
+      const view = render(ui(() => true));
+      // Permission granted: Sales is visible and active.
+      expect(screen.getByText('Sales')).toBeTruthy();
+      expect(screen.getByText('Opportunities')).toBeTruthy();
+
+      // Permission revoked: Sales derives hidden, drops out of the switcher,
+      // and the shell re-elects the first visible area.
+      view.rerender(ui((perms) => !perms.includes('sales:admin')));
+      expect(screen.queryByText('Sales')).toBeNull();
+      expect(screen.queryByText('Opportunities')).toBeNull();
+      expect(screen.getByText('Cases')).toBeTruthy();
+
+      // Permission granted again: Sales reappears in the switcher, but the
+      // user's current area is NOT yanked away — Service stays active.
+      view.rerender(ui(() => true));
+      expect(screen.getByText('Sales')).toBeTruthy();
+      expect(screen.getByText('Cases')).toBeTruthy();
+      expect(screen.queryByText('Opportunities')).toBeNull();
+    });
+  });
+
+  // --- hasVisibleNavigationItems (the predicate behind #3311) ---
+
+  describe('hasVisibleNavigationItems', () => {
+    it('returns false for an empty tree', () => {
+      expect(hasVisibleNavigationItems([])).toBe(false);
+    });
+
+    it('ignores separators — a divider is not content', () => {
+      expect(
+        hasVisibleNavigationItems([{ id: 's1', type: 'separator', label: '' }]),
+      ).toBe(false);
+    });
+
+    it('counts an action item only when the host wires a dispatcher (framework#4509)', () => {
+      const items: NavigationItem[] = [
+        {
+          id: 'act1',
+          type: 'action',
+          label: 'Export',
+          actionDef: { actionName: 'export_data' },
+        },
+      ];
+      expect(hasVisibleNavigationItems(items)).toBe(false);
+      expect(hasVisibleNavigationItems(items, { hasActionHandler: true })).toBe(true);
+    });
+
+    it('applies the runtime capability gates (requiresObject / requiresService)', () => {
+      const items: NavigationItem[] = [
+        { id: 'n1', type: 'object', label: 'Apps', objectName: 'sys_app', requiresObject: 'sys_app' },
+      ];
+      expect(
+        hasVisibleNavigationItems(items, { checkCapability: () => false }),
+      ).toBe(false);
+      expect(
+        hasVisibleNavigationItems(items, { checkCapability: () => true }),
+      ).toBe(true);
+    });
+
+    it('applies a group\'s own guards before recursing into its children', () => {
+      const items: NavigationItem[] = [
+        {
+          id: 'grp',
+          type: 'group',
+          label: 'Admin',
+          requiredPermissions: ['admin'],
+          children: [
+            { id: 'grp-1', type: 'object', label: 'Users', objectName: 'user' },
+          ],
+        },
+      ];
+      // The child is visible, but the group itself is gated → nothing counts.
+      expect(
+        hasVisibleNavigationItems(items, { checkPermission: () => false }),
+      ).toBe(false);
+      expect(
+        hasVisibleNavigationItems(items, { checkPermission: () => true }),
+      ).toBe(true);
+    });
+
+    it('does not count a group with no visible child', () => {
+      const items: NavigationItem[] = [
+        {
+          id: 'grp',
+          type: 'group',
+          label: 'Tools',
+          children: [
+            { id: 'grp-1', type: 'object', label: 'Hidden', objectName: 'tool', visible: false },
+          ],
+        },
+      ];
+      expect(
+        hasVisibleNavigationItems(items, { evaluateVisibility: (expr) => expr !== false }),
+      ).toBe(false);
+    });
   });
 
   // --- Mobile bottom_nav mode ---

--- a/packages/types/src/app.ts
+++ b/packages/types/src/app.ts
@@ -301,7 +301,12 @@ export interface NavigationItem {
  * `AppSchemaRenderer`'s area switcher filtered areas by `visible` and
  * `requiredPermissions`. That filter is gone, and the gating it did now happens
  * one level down in `NavigationRenderer`, which is where the spec moved it.
- * The premise mismatch is recorded in objectui#3311.
+ * The premise mismatch is recorded in objectui#3311. Per that issue's ruling,
+ * area visibility is now DERIVED rather than authored: `AppSchemaRenderer`
+ * hides an area from the switcher when none of its items survive the
+ * item-level guards (`hasVisibleNavigationItems` in `@object-ui/layout`), so
+ * the pre-17 "fully gated area disappears" UX is back without any authorable
+ * area-level key.
  *
  * One key is pinned locally, for a reason that outlives a spec release:
  *


### PR DESCRIPTION
Fixes #3311

按 #3311 裁决实施**选项 C**:area 可见性**派生**自「区域内是否存在至少一个可见 item」,不新增、不复活任何 authorable key。

## 背景

spec 17.0.0 退役了 area 级 `visible` / `requiredPermissions`(`AREA_VISIBLE_RETIRED` / `AREA_REQUIRED_PERMISSIONS_RETIRED`),#3315 跟随退役删掉了 `AreaSwitcher` 的过滤。契约上正确,但留下行为回归:某区域内 item **全部**被 gate 掉时,以前整块区域从切换器消失,退役后渲染成「可见但空」的区域,且第一个区域全被 gate 时用户还会被默认落在空区域上。

## 实现

- **新增 `hasVisibleNavigationItems(items, options)`**(`packages/layout/src/NavigationRenderer.tsx`,导出):判定一棵导航树里是否存在至少一个「真的会渲染」的 item。守卫逐条对齐 `NavigationItemRenderer` 的 item 级判定:`visible` 表达式(`evaluateVisibility`)、`requiredPermissions`(`checkPermission`)、`requiresObject` / `requiresService`(`checkCapability`)、以及 action 项的 dispatcher 存在性(framework#4509:无 `onAction` 则不渲染,自然也不能撑起一个区域)。separator 不算内容;group 只经由子项计数,且 group 自身守卫先于递归生效。
- **`AppSchemaRenderer` 用该谓词过滤区域**:`AreaSwitcher` 只列出可见区域;只剩一个可见区域时不再显示切换器(与退役前 `visibleAreas.length <= 1` 的语义一致)。
- **活动区域只在可见区域中选举**:初值取第一个可见区域;gating 变化把当前活动区域藏掉时重新选举第一个可见区域;仅仅「新增可见」的变化不会把用户从当前区域拽走。渲染时按有效区域取导航(state 由 effect 同步),避免过渡帧渲染被隐藏区域的空导航。
- 派生规则由渲染守卫直接计算,**不可能与实际渲染结果不一致**,元数据作者无从写错 —— 这正是裁决里「把曾经的 authorable 门变成一条不可能说谎的派生规则」。

### 边界:空区域(本来就没有 item 的 area)

裁决评论定义为「派生自区域内是否存在可见 item」——空区域没有任何 item,自然没有可见 item,**按与全被 gate 一致处理(隐藏)**,已在 issue 认领评论标注、测试 `treats an area with no items at all like a fully gated one` 钉住。**请维护者复核这一边界**;若希望空区域仍显示,只需把谓词入口改为对 `navigation.length === 0` 提前返回 true,一处改动。

### #3315 两条 item 级断言的语义更新(需要说明)

`AppSchemaRenderer.test.tsx` 里 #3315 落的 `gates the navigation ITEM by visibility/permission, not the area` 原断言「区域仍出现在切换器」——其场景恰是「区域内唯一 item 被 gate」,与本 PR 的派生规则**语义相反**(那正是要修的回归)。两条测试已改为**部分被 gate** 的区域(被 gate 的 item + 一个可见兄弟 item):区域保持可见且激活、可见 item 渲染、被 gate 的 item 不渲染 —— item 级 gate 断言依旧承重,「全被 gate 则区域隐藏」由新测试块覆盖。types 侧 #3315 的退役钉子(`page-nav-misc-spec-parity.test.ts` 等)未动、全绿。

## 验证

| 场景 | 测试 | 结果 |
|---|---|---|
| 全部区域可见 | `keeps every area in the switcher when every area has a visible item` | ✅ |
| 部分被 gate(区域显示) | 两条改写后的 `gates the navigation ITEM …` | ✅ |
| 全被 gate(visibility) → 区域隐藏 + 跳过默认激活 | `hides an area whose items are ALL gated and activates the first visible area` | ✅ |
| 全被 gate(permission) → 区域隐藏 | `hides an area whose items all fail their permission checks` | ✅ |
| 只剩一个可见区域 → 不显示切换器 | `hides the switcher entirely when only one area remains visible` | ✅ |
| 所有区域全被 gate → 无切换器、无区域导航 | `renders no switcher and no area navigation when every area is fully gated` | ✅ |
| 空区域(边界) | `treats an area with no items at all like a fully gated one (hidden)` | ✅ |
| group 递归派生 | `derives through groups …` | ✅ |
| gating 条件变化 → 重新选举 / 不拽走用户 | `re-derives when gating changes …` | ✅ |
| 谓词单测(separator / action dispatcher / capability / group 守卫) | `hasVisibleNavigationItems` describe 块 6 条 | ✅ |

### 破坏验证(改坏 → 红 → 还原 → 绿)

- **变异 1**:`hasVisibleNavigationItems` 恒返回 `true`(派生失效)→ **13 条断言红**(7 条派生行为 + 6 条谓词单测)→ 还原后 47/47 绿。
- **变异 2**:活动区域选举全部改回 `areas`(退役后的旧行为)→ **6 条断言红**(区域隐藏 + 重新选举各条)→ 还原后 47/47 绿。
- 注:仅改坏渲染期兜底(state 选举保留)时断言不红 —— state 选举与渲染期兜底对**稳态** DOM 冗余,兜底防的是 effect 提交前的过渡帧(真实浏览器里 effect 在 paint 后运行),故保留。

### 全量

- `pnpm exec vitest run packages/layout packages/types`:32 文件 / 477 测试全绿(含 #3315 退役钉子与 parity 测试)。
- `pnpm build`:43/43;`turbo run type-check lint`:123/123;仓根全量 `vitest run`:**872 文件 passed(1 skipped)/ 10321 测试 passed(25 skipped)**。
- changeset:`.changeset/area-visibility-derived-from-items.md`(`@object-ui/layout` minor,fixed group、无 major),`changeset:check` 通过;未触碰 `content/docs/releases/`。

## Out of scope

- #3319:app-shell 的 `AppSidebar` / `UnifiedSidebar` 内联区域切换器同样未派生(从来没有过 area 过滤,非 #3315 回归)——已单独立单,建议直接采用本 PR 导出的谓词。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_