### PR TITLE
fix(fields): field:select 把 aria-invalid/aria-describedby/aria-required 送达真实控件（Select trigger），并加全注册表守卫 (#3306)

### DIFF
--- a/.changeset/select-aria-reaches-the-trigger.md
+++ b/.changeset/select-aria-reaches-the-trigger.md
@@ -1,0 +1,29 @@
+---
+"@object-ui/fields": patch
+---
+
+`field:select` now announces its validation state to assistive tech: the
+widget's DOM pass-through lands on the Radix `SelectTrigger` — the focusable
+`<button role="combobox">` a user actually interacts with — instead of
+`Select.Root`, which renders no DOM element of its own and silently dropped
+every `aria-*` the form renderer delivered (objectui#3306).
+
+Before this, a required select that failed validation showed the red message
+while a screen reader was told nothing: `aria-invalid`, `aria-describedby`
+(the link to the message text) and `aria-required` (objectui#3290's state
+channel) all landed on Root and vanished. All three now reach the trigger,
+and the widget computes `aria-invalid` from the published `error` slot after
+the spread, the objectui#3222 discipline — a valid field explicitly says
+`aria-invalid="false"` rather than staying mute.
+
+Two keys deliberately stay on Root: `name` (Root forwards it to the hidden
+native `<select>` that takes part in form submission) and `disabled` (Root is
+the single authority that disables trigger, items and hidden select together).
+
+Guarding the whole class forward, a new registry-wide sweep
+(`widget-aria-invalid-registry-e2e.test.tsx`, the objectui#3291 leak-sweep
+paradigm) renders every registered field widget through the real form, drives
+a real validation failure, and asserts `aria-invalid="true"` appears inside
+the field's row. The 29 widget types measured not to deliver yet are pinned in
+a ratchet ledger (tracked in objectui#3318): fixing one turns its ledger row
+red until the entry is removed, so the ledger only ever shrinks.

--- a/packages/fields/src/__tests__/widget-aria-invalid-e2e.test.tsx
+++ b/packages/fields/src/__tests__/widget-aria-invalid-e2e.test.tsx
@@ -51,8 +51,14 @@ import { CurrencyField } from '../widgets/CurrencyField';
 import { PercentField } from '../widgets/PercentField';
 import { RichTextField } from '../widgets/RichTextField';
 import { TextField } from '../widgets/TextField';
+import { SelectField } from '../widgets/SelectField';
 
-/** The seven widgets that read the validation slot, by their form-path key. */
+/**
+ * The widgets that read the validation slot, by their form-path key: the seven
+ * from objectui#3222, plus `select` (objectui#3306) — the widget whose control
+ * is a Radix trigger rather than a native input, where every aria-* used to be
+ * swallowed by the non-DOM `Select.Root`.
+ */
 const WIDGETS = [
   ['email', EmailField],
   ['phone', PhoneField],
@@ -61,6 +67,7 @@ const WIDGETS = [
   ['currency', CurrencyField],
   ['percent', PercentField],
   ['markdown', RichTextField],
+  ['select', SelectField],
 ] as const;
 
 beforeAll(() => {
@@ -184,5 +191,75 @@ describe('field widgets announce an invalid field to AT (objectui#3222)', () => 
     fireEvent.change(controlOf('email'), { target: { value: 'a@example.com' } });
 
     await waitFor(() => expect(controlOf('email')).toHaveAttribute('aria-invalid', 'false'));
+  });
+});
+
+describe('field:select announces validation state on its TRIGGER (objectui#3306)', () => {
+  // Radix `Select.Root` renders no DOM element and silently drops every prop
+  // it does not recognise. The widget used to spread its DOM pass-through onto
+  // Root, so `aria-invalid` / `aria-describedby` / `aria-required` all
+  // vanished: a failed required select showed the red message while assistive
+  // tech was told nothing. The real control is the focusable
+  // `<button role="combobox">` the trigger renders — that is where every
+  // assertion below reads from, never a wrapper.
+  //
+  // `field:select` (not bare `select`) because `select` is a
+  // BUILTIN_FIELD_TYPE in the form renderer and never reaches the registry —
+  // same reason as `field:textarea` above.
+  const OPTIONS = [
+    { label: 'Alpha', value: 'alpha' },
+    { label: 'Beta', value: 'beta' },
+  ];
+
+  const selectField = {
+    name: 'choice',
+    label: 'Choice',
+    type: 'field:select',
+    required: true,
+    options: OPTIONS,
+  };
+
+  /** The trigger button, by role — fails loudly if it stops being a combobox. */
+  function trigger(): Element {
+    const el = document.querySelector('[data-field="choice"] [role="combobox"]');
+    if (!el) throw new Error('no select trigger rendered for field "choice"');
+    return el;
+  }
+
+  it('a required select is aria-invalid only AFTER validation fails, on the trigger', async () => {
+    renderForm(selectField, null);
+
+    // The explicit "false" half is load-bearing, same as the widgets above: a
+    // valid field SAYS it is valid rather than staying mute.
+    expect(trigger()).toHaveAttribute('aria-invalid', 'false');
+
+    submit();
+
+    // Prove the failure actually rendered before reading aria off it — an
+    // error variant that silently produces no error tests nothing.
+    await waitFor(() =>
+      expect(screen.getAllByText('Choice is required')).toHaveLength(1),
+    );
+    expect(trigger()).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('carries aria-required on the trigger — the state channel of objectui#3290', () => {
+    renderForm(selectField, null);
+
+    // Root would swallow it; the trigger is "the control" for a Radix select.
+    expect(trigger()).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('aria-describedby on the trigger references the rendered error message', async () => {
+    renderForm(selectField, null);
+
+    submit();
+
+    const message = await screen.findByText('Choice is required');
+    // The association is only real if the id chain closes: the trigger must
+    // point at the exact element carrying the message text.
+    expect(message.id).not.toBe('');
+    const describedBy = trigger().getAttribute('aria-describedby') ?? '';
+    expect(describedBy.split(/\s+/)).toContain(message.id);
   });
 });

--- a/packages/fields/src/__tests__/widget-aria-invalid-registry-e2e.test.tsx
+++ b/packages/fields/src/__tests__/widget-aria-invalid-registry-e2e.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * GATE: every registered field widget must announce a validation failure to
+ * assistive tech — `aria-invalid="true"` on some element inside its own form
+ * row (objectui#3306, the paradigm of objectui#3291's leak sweep).
+ *
+ * ## Why a registry-wide sweep
+ *
+ * This failure class recurs per widget: objectui#3222 fixed seven widgets that
+ * computed `aria-invalid` from a prop nobody produced; objectui#3290 fixed the
+ * `aria-required` state channel; objectui#3306 fixed `select`, whose Radix
+ * `Select.Root` — not being a DOM element — silently swallowed every `aria-*`
+ * the form renderer delivered. Each was invisible until someone happened to
+ * audit that one widget, because the per-widget tests only cover the widgets
+ * someone already fixed. This sweep covers the REGISTRY, so the next widget
+ * with a swallowed or missing `aria-invalid` fails here by name instead of
+ * shipping.
+ *
+ * ## The ratchet
+ *
+ * Widgets listed in {@link NOT_YET_DELIVERED} are known not to deliver the
+ * attribute today. They are asserted in the OPPOSITE direction — the sweep
+ * proves they still do NOT deliver — so fixing one turns its entry red and
+ * forces its removal from the ledger. The ledger can only shrink; a widget can
+ * never silently regress INTO it, and a fix can never silently go unrecorded.
+ * The remaining entries are tracked as follow-up work (see the ledger's doc
+ * comment); this file is the source of truth for what is left.
+ *
+ * ## Discipline inherited from the #3291 sweep
+ *
+ * - **An error variant that produces no error tests nothing** — every case
+ *   asserts the "is required" message rendered before it reads any aria. The
+ *   `required` check is a PRESENCE check (`null` is missing, `false`/`0` are
+ *   values — cloud#972), so `null` drives a real failure for every type.
+ * - **Popovers are not opened** (happy-dom lacks the pointer-capture APIs
+ *   Radix needs); the inline control every widget renders is the surface under
+ *   test, which is exactly where `aria-invalid` must sit.
+ * - Widgets are registered from STATIC imports wrapped in `withFieldCarrier`
+ *   (the real registration seam, objectui#3233), never `registerAllFields()`,
+ *   whose `React.lazy` loaders are this repo's known flake generator
+ *   (AGENTS.md 测试纪律 / objectui#3010).
+ */
+
+import type { ComponentType } from 'react';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { withFieldCarrier } from '../withFieldCarrier';
+import { FORM_FIELD_TYPES } from '../index';
+
+import { TextField } from '../widgets/TextField';
+import { TextAreaField } from '../widgets/TextAreaField';
+import { NumberField } from '../widgets/NumberField';
+import { BooleanField } from '../widgets/BooleanField';
+import { SelectField } from '../widgets/SelectField';
+import { DateField } from '../widgets/DateField';
+import { DateTimeField } from '../widgets/DateTimeField';
+import { TimeField } from '../widgets/TimeField';
+import { EmailField } from '../widgets/EmailField';
+import { PhoneField } from '../widgets/PhoneField';
+import { UrlField } from '../widgets/UrlField';
+import { MultiSelectField } from '../widgets/MultiSelectField';
+import { RadioField } from '../widgets/RadioField';
+import { CheckboxesField } from '../widgets/CheckboxesField';
+import { TagsField } from '../widgets/TagsField';
+import { CurrencyField } from '../widgets/CurrencyField';
+import { PercentField } from '../widgets/PercentField';
+import { PasswordField } from '../widgets/PasswordField';
+import { RichTextField } from '../widgets/RichTextField';
+import { LookupField } from '../widgets/LookupField';
+import { FileField } from '../widgets/FileField';
+import { ImageField } from '../widgets/ImageField';
+import { LocationField } from '../widgets/LocationField';
+import { FormulaField } from '../widgets/FormulaField';
+import { SummaryField } from '../widgets/SummaryField';
+import { AutoNumberField } from '../widgets/AutoNumberField';
+import { UserField } from '../widgets/UserField';
+import { ObjectField } from '../widgets/ObjectField';
+import { VectorField } from '../widgets/VectorField';
+import { GridField } from '../widgets/GridField';
+import { ColorField } from '../widgets/ColorField';
+import { SliderField } from '../widgets/SliderField';
+import { RatingField } from '../widgets/RatingField';
+import { CodeField } from '../widgets/CodeField';
+import { AvatarField } from '../widgets/AvatarField';
+import { AddressField } from '../widgets/AddressField';
+import { GeolocationField } from '../widgets/GeolocationField';
+import { SignatureField } from '../widgets/SignatureField';
+import { QRCodeField } from '../widgets/QRCodeField';
+import { ObjectRefField } from '../widgets/ObjectRefField';
+import { FilterConditionField } from '../widgets/FilterConditionField';
+import { RecipientPickerField } from '../widgets/RecipientPickerField';
+
+/** Same widget map as the #3291 sweep, so the parity check covers the registry. */
+const WIDGETS: Record<string, ComponentType<any>> = {
+  text: TextField,
+  textarea: TextAreaField,
+  number: NumberField,
+  boolean: BooleanField,
+  select: SelectField,
+  date: DateField,
+  datetime: DateTimeField,
+  time: TimeField,
+  email: EmailField,
+  phone: PhoneField,
+  url: UrlField,
+  multiselect: MultiSelectField,
+  radio: RadioField,
+  checkboxes: CheckboxesField,
+  tags: TagsField,
+  currency: CurrencyField,
+  percent: PercentField,
+  password: PasswordField,
+  markdown: RichTextField,
+  html: RichTextField,
+  richtext: RichTextField,
+  lookup: LookupField,
+  master_detail: LookupField,
+  file: FileField,
+  image: ImageField,
+  location: LocationField,
+  formula: FormulaField,
+  summary: SummaryField,
+  auto_number: AutoNumberField,
+  user: UserField,
+  owner: UserField,
+  object: ObjectField,
+  vector: VectorField,
+  grid: GridField,
+  color: ColorField,
+  slider: SliderField,
+  rating: RatingField,
+  code: CodeField,
+  avatar: AvatarField,
+  address: AddressField,
+  geolocation: GeolocationField,
+  signature: SignatureField,
+  qrcode: QRCodeField,
+  'object-ref': ObjectRefField,
+  'filter-condition': FilterConditionField,
+  'recipient-picker': RecipientPickerField,
+};
+
+/**
+ * THE RATCHET LEDGER — widget types MEASURED (by this very sweep, run with an
+ * empty ledger) not to put `aria-invalid` on any element of their row after a
+ * real validation failure. Every entry is a known accessibility gap tracked in
+ * objectui#3318, not an accepted state: the field shows its red message while
+ * assistive tech is told nothing.
+ *
+ * Mechanism, per widget: none of these forwards its DOM pass-through (which
+ * carries the `<FormControl>` Slot's `aria-invalid`) to the control it
+ * renders, nor computes one from the published `error` slot. `grid` is the
+ * one partial case — it has per-CELL `aria-invalid` for its own line-item
+ * validation, but a form-level failure does not drive it.
+ *
+ * Do NOT add to this list to make a new widget pass; fix the widget (the
+ * objectui#3222/#3306 pattern: spread `toDomProps(props)` onto the real
+ * focusable control — never a non-DOM Radix Root — then `aria-invalid=
+ * {!!error}` after the spread). An entry is removed by fixing the widget: the
+ * sweep asserts each entry still fails to deliver, so a fixed widget turns
+ * its own ledger row red until it is removed here. The ledger only shrinks.
+ */
+const NOT_YET_DELIVERED: ReadonlySet<string> = new Set([
+  'multiselect',
+  'radio',
+  'checkboxes',
+  'tags',
+  'lookup',
+  'master_detail',
+  'file',
+  'image',
+  'location',
+  'formula',
+  'summary',
+  'auto_number',
+  'user',
+  'owner',
+  'object',
+  'vector',
+  'grid',
+  'color',
+  'slider',
+  'rating',
+  'code',
+  'avatar',
+  'address',
+  'geolocation',
+  'signature',
+  'qrcode',
+  'object-ref',
+  'filter-condition',
+  'recipient-picker',
+]);
+
+/** Option widgets render an "unfillable" placeholder unless offered a list. */
+const OPTION_TYPES = new Set(['select', 'multiselect', 'radio', 'checkboxes', 'tags']);
+const OPTIONS = [
+  { label: 'Alpha', value: 'alpha' },
+  { label: 'Beta', value: 'beta' },
+];
+
+/** `null` is MISSING for the presence-check `required` (cloud#972). */
+const MISSING_VALUE = null;
+
+function fieldConfig(type: string) {
+  return {
+    name: 'f',
+    label: 'F',
+    type: `field:${type}`,
+    required: true,
+    ...(OPTION_TYPES.has(type) ? { options: OPTIONS } : {}),
+  };
+}
+
+function renderForm(field: Record<string, unknown>) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        defaultValues: { f: MISSING_VALUE },
+        fields: [field],
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+async function formRow(): Promise<Element> {
+  return waitFor(() => {
+    const row = document.querySelector('[data-field="f"]');
+    if (!row) throw new Error('field row never rendered');
+    return row;
+  });
+}
+
+/**
+ * Drive a REAL validation failure and prove it rendered before reading aria:
+ * submit, then wait for the "is required" message inside the row.
+ */
+async function failValidation(): Promise<Element> {
+  fireEvent.click(screen.getByRole('button', { name: /create/i }));
+  await waitFor(() => {
+    expect(document.querySelector('[data-field="f"]')?.textContent ?? '').toContain(
+      'is required',
+    );
+  });
+  return formRow();
+}
+
+beforeAll(() => {
+  for (const [type, Widget] of Object.entries(WIDGETS)) {
+    ComponentRegistry.register(type, withFieldCarrier(Widget) as any, {
+      namespace: 'field',
+      skipFallback: true,
+    });
+  }
+}, 60000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const ALL_TYPES = Object.keys(WIDGETS);
+const DELIVERING = ALL_TYPES.filter((type) => !NOT_YET_DELIVERED.has(type));
+const LEDGERED = ALL_TYPES.filter((type) => NOT_YET_DELIVERED.has(type));
+
+describe('every registered field widget announces a failed validation (objectui#3306)', () => {
+  it('covers every field type the form can render', () => {
+    expect(Object.keys(WIDGETS).sort()).toEqual([...FORM_FIELD_TYPES].sort());
+  });
+
+  it('the ledger only names types that exist', () => {
+    // A renamed/removed widget must not leave a stale ledger entry that would
+    // silently assert against nothing.
+    expect([...NOT_YET_DELIVERED].filter((type) => !(type in WIDGETS))).toEqual([]);
+  });
+
+  it.each(DELIVERING)(
+    'field:%s — carries aria-invalid inside its row after a real failure',
+    async (type) => {
+      renderForm(fieldConfig(type));
+      const row = await formRow();
+
+      // No premature alarm: a widget must not claim invalid before validation
+      // ran. (`aria-invalid="false"` is fine and expected — asserting on the
+      // "true" value keeps this half meaningful for widgets that stay silent
+      // until they fail.)
+      expect(row.querySelector('[aria-invalid="true"]')).toBeNull();
+
+      const after = await failValidation();
+      expect(
+        after.querySelector('[aria-invalid="true"]'),
+        `field:${type} rendered its "is required" message but no element in its row carries aria-invalid="true" — assistive tech is never told the field failed`,
+      ).not.toBeNull();
+    },
+  );
+
+  it.each(LEDGERED)(
+    'field:%s — KNOWN GAP: still does not deliver aria-invalid (fix it, then remove it from NOT_YET_DELIVERED)',
+    async (type) => {
+      renderForm(fieldConfig(type));
+      await formRow();
+
+      const after = await failValidation();
+      // The ratchet: the day this widget starts delivering, this assertion
+      // fails and the entry MUST be removed from the ledger above.
+      expect(
+        after.querySelector('[aria-invalid="true"]'),
+        `field:${type} now delivers aria-invalid — remove it from NOT_YET_DELIVERED so the sweep guards it forward`,
+      ).toBeNull();
+    },
+  );
+});

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -59,6 +59,7 @@ function SingleSelectField({
   onChange,
   field,
   readonly,
+  error,
   dependentValues,
   dependsOn: dependsOnProp,
   emptyHint,
@@ -113,20 +114,40 @@ function SingleSelectField({
     );
   }
 
+  // Radix `Select.Root` renders no DOM element of its own — anything it does
+  // not recognise (every `aria-*` / `data-*` a host hands this widget) is
+  // silently DROPPED, never reaching a real element. That is how a required
+  // select failed validation with the red message on screen while assistive
+  // tech was told nothing (objectui#3306): the form renderer's `aria-invalid`
+  // / `aria-describedby` / `aria-required` landed on Root and vanished. The
+  // DOM pass-through therefore goes to `SelectTrigger` — the focusable
+  // `<button role="combobox">` a user and their screen reader actually
+  // interact with — with two deliberate exceptions kept on Root:
+  //
+  // - `name`: the ONE whitelist key Root genuinely consumes — it forwards it
+  //   to the hidden native `<select>` that takes part in form submission.
+  //   On the trigger it would sit uselessly on a non-submitter `<button>`.
+  // - `disabled`: Root is the single authority (it disables trigger, item
+  //   interaction and the hidden select together); forwarding the raw prop to
+  //   the trigger as well would give the state a second, OR-merged author.
+  const { name: domName, disabled: _domDisabled, ...triggerDomProps } = toDomProps(props);
+
   return (
     <Select
-      // Radix `Select.Root` renders no element of its own and drops what it
-      // does not recognise, so this spread leaks nothing TODAY. It is closed
-      // anyway because that is an accident of the primitive, not a property of
-      // this widget: the structure is identical to the thirteen widgets that
-      // DID leak, and one refactor to a plain <select> starts it leaking too
-      // (objectui#3291).
-      {...toDomProps(props)}
+      name={domName}
       value={value}
       onValueChange={onChange}
       disabled={readonly || props.disabled}
     >
-      <SelectTrigger className={props.className} id={props.id} data-testid={fieldName ? `select-trigger-${fieldName}` : undefined}>
+      <SelectTrigger
+        {...triggerDomProps}
+        data-testid={fieldName ? `select-trigger-${fieldName}` : undefined}
+        // AFTER the spread so this widget's own computation wins, the #3222
+        // discipline: `error` is the published validation slot
+        // (`FieldWidgetPropsSchema`), and `!!undefined` must yield an explicit
+        // `"false"` — a valid field SAYS it is valid rather than staying mute.
+        aria-invalid={!!error}
+      >
         <SelectValue placeholder={config?.placeholder || t('common.selectOption')} />
       </SelectTrigger>
       <SelectContent position="popper">


### PR DESCRIPTION
Fixes #3306

## 问题

`field:select` 把 DOM pass-through（`{...toDomProps(props)}`）展开在 Radix `Select.Root` 上。`Select.Root` 自身不渲染任何 DOM 元素，不认识的 prop 一律静默丢弃——表单渲染器送下来的 `aria-invalid`、`aria-describedby`、`aria-required` 全部消失。实测：一个 `required` 的 select 提交失败后，红字错误信息视觉上正常显示，但真实控件（trigger）上没有任何 aria 状态——屏幕阅读器用户完全收不到「该字段处于错误状态」，也拿不到错误信息的关联。

这与 #3222（7 个 widget 的 `aria-invalid` 从未被算出）和 #3290（`aria-required` 声明了没送达）同属本仓视为一等缺陷的「declared ≠ delivered」失败类。

## 修复

`packages/fields/src/widgets/SelectField.tsx`（单选分支）：

- DOM pass-through 改为落在 **`SelectTrigger`** 上——真实可聚焦的 `<button role="combobox">`，用户与辅助技术实际交互的元素。`aria-invalid` / `aria-describedby` / `aria-required` / `data-*` / `id` / `className` / `tabIndex` / 焦点事件由此送达真实 DOM。
- 两个 key 刻意留在 Root 上：
  - `name`——Root 唯一真正消费的白名单 key（转发给参与原生表单提交的隐藏 `<select>`）；放到 trigger 上只会挂在一个非 submitter 的 `<button>` 上；
  - `disabled`——Root 是单一权威（同时禁用 trigger、选项交互与隐藏 select）；再转发给 trigger 会给这个状态第二个 OR 合并的作者。
- spread 之后显式写 `aria-invalid={!!error}`（#3222 纪律：`error` 是 spec `FieldWidgetPropsSchema` 的发布槽位；`!!undefined` 必须产出显式的 `"false"`——字段有效时明说有效，而不是沉默）。

**没有**放宽 `toDomProps`（白名单原样），**没有**在消费端加任何容错回退。

## 顺带核查（issue 要求的同结构扫描）

逐一核查了全部 46 个注册 widget 的 spread 落点：**只有 `SelectField` 把 DOM pass-through 展开到非 DOM 的 Radix Root 上**。Boolean/Date/DateTime/Time 等其余 `toDomProps` 使用者都落在真实 DOM 控件（`Input` / Radix Checkbox·Switch 的真实 `<button>`）上。

## 守卫（issue 要求的「不再逐个复发」）

新增全注册表 sweep `packages/fields/src/__tests__/widget-aria-invalid-registry-e2e.test.tsx`（范式同 #3291 的 DOM leak sweep）：

- 46 个注册类型 × 真实表单 + 真实 react-hook-form 校验失败（presence 语义 `required` + `null`，cloud#972），**先自证 "is required" 消息已渲染**再读 aria（无错误的错误变体什么都测不到）；
- 送达者断言行内存在 `aria-invalid="true"`，且失败前不存在（不许提前报警）；
- 实测 **29 个类型未送达**，登记进棘轮账本 `NOT_YET_DELIVERED` 并**按反方向断言**：修好任何一个，它的账本行变红、强制移出账本——账本只能收缩，新类型默认走正向断言，不能悄悄进账本。29 个缺口已作为独立未认领 issue 记录：#3318；
- 注册表 parity 断言 + 账本条目存在性断言（改名/删除的 widget 不能留下守空的账本行）。

同时把 `select` 补进既有 `widget-aria-invalid-e2e.test.tsx`（#3222 的守卫，当年漏掉 select 的那个），新增 3 条针对 trigger 的断言：`aria-invalid` 仅在失败后为 `"true"`（此前显式 `"false"`）、`aria-required` 在位、`aria-describedby` 的 id 链闭合到渲染出的错误信息元素。

## 破坏验证实录

| 步骤 | 操作 | 结果 |
|---|---|---|
| 改坏 | 把 spread 还原回 Root、trigger 去掉 aria-invalid | 3 条新断言全红（`3 failed \| 10 skipped`） |
| 还原 | `git checkout` 回修复态 | `13 passed` 全绿 |
| 守卫自证（正向） | 全注册表 sweep 以空账本首跑 | 29 个类型逐名红（每条失败信息点名 widget） |
| 守卫自证（棘轮） | 把已送达的 `text` 植入账本 | 其账本行红：`field:text now delivers aria-invalid — remove it from NOT_YET_DELIVERED` |

## 验证

| 检查 | 结果 |
|---|---|
| `vitest run widget-aria-invalid-e2e.test.tsx` | 13 passed |
| `vitest run widget-aria-invalid-registry-e2e.test.tsx` | 48 passed |
| `vitest run widget-dom-leak-e2e.test.tsx`（#3313 的 gate，46×5） | 233 passed |
| rebase（含 #3322）后 `vitest run packages/fields` 全包 | **46 文件 / 823 测试全绿**（含上述三个文件） |
| turbo type-check / lint / build + 仓根全量 vitest | 本容器两次重启未能在本地完成，**交由 PR CI 把关** |

改动仅涉 `packages/fields`（widget + 测试）与一个 changeset（`@object-ui/fields` patch，fixed group，无 major）。未触碰 `content/docs/releases/`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa