### PR TITLE
fix(app-shell): RecordDetailView modal 分派报告不可解析 target，删除死路 server 回退 (#3320)

### DIFF
--- a/.changeset/modal-dead-fallthrough-record-page.md
+++ b/.changeset/modal-dead-fallthrough-record-page.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+RecordDetailView's `type:'modal'` dispatch no longer falls back to the server-side action handler when the target resolves to neither a page nor an object. That fallthrough could never succeed — the framework rejects `type:'modal'` over REST with a 400 (`headlessActionTypeError`) — so it only converted an authoring mistake into a confusing round-trip. The record page now reports the same descriptive authoring error as the shared console runtime (objectstack#3959), naming the action, the dud target, and the way out (`type:'script'` with `params`).

--- a/packages/app-shell/src/views/RecordDetailView.modalDispatch.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.modalDispatch.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RecordDetailView — `type: 'modal'` dispatch is CLIENT-SIDE ONLY
+ * (objectstack#3959 / objectui#3320).
+ *
+ * The record page wires its own `modal` handler into its `<ActionProvider>`,
+ * shadowing the shared console runtime for every action on the record surface.
+ * objectstack#3959 removed the "fall back to the server-side handler" branch
+ * from `useConsoleActionRuntime.modalActionHandler` — the framework's
+ * `headlessActionTypeError` rejects `type: 'modal'` over REST with a 400, so
+ * the fallthrough could never succeed and only converted an authoring mistake
+ * (a target naming no page) into a confusing round-trip. This copy kept the
+ * pre-#3959 shape, so the SAME dud modal action reported a descriptive
+ * authoring error on a list page and an opaque 400 on the record page.
+ *
+ * This file is the RecordDetailView-side counterpart of
+ * `useConsoleActionRuntime.test.tsx`'s "reports an unresolvable target instead
+ * of POSTing to /actions": it exercises the handler set the view REALLY hands
+ * to its ActionProvider (captured via a pass-through wrapper), so re-adding the
+ * fallthrough — `return serverActionHandler(action)` — turns it red.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const authFetchSpy = vi.fn(async () =>
+  new Response(JSON.stringify({ data: [] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }),
+);
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => authFetchSpy,
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => [],
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// The dialogs / flow runner are orthogonal chrome; stubbing them keeps this
+// file about the modal dispatch (same posture as the feed-signal tests).
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+// The client modal transport is stubbed for the same reason as in
+// useConsoleActionRuntime.test.tsx — importing it for real drags in
+// <ModalForm> and the whole plugin-form graph. `resolveTargetSpy` stands in
+// for the page/object lookup so each case below chooses whether the target
+// resolves; its real resolution rules are covered in
+// useActionModal.resolve.test.tsx.
+const modalHandlerSpy = vi.fn(async () => ({ success: true }));
+const resolveTargetSpy = vi.fn(async (_schema: any): Promise<any> => null);
+vi.mock('../hooks/useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: modalHandlerSpy,
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: resolveTargetSpy,
+  }),
+}));
+
+// The server-side dispatch the dead fallthrough used to reach. Returns
+// success so a re-added `return serverActionHandler(action)` flips BOTH the
+// not-called assertion AND the `success: false` assertion below.
+const serverActionSpy = vi.fn(async () => ({ success: true }));
+vi.mock('../utils/consoleServerAction', () => ({
+  createConsoleServerActionHandler: () => serverActionSpy,
+}));
+
+// Capture the handler set each <ActionProvider> receives while KEEPING the
+// real provider (children still get a working action context). The record
+// page's own set is the only one carrying `approval`, so the capture below
+// selects it even if a nested surface mounts a provider of its own. The page
+// body itself is orthogonal here — SchemaRenderer is stubbed so the file
+// stays about the wiring, not the render tree.
+const capturedHandlers: Array<Record<string, (action: any) => Promise<any>>> = [];
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    ActionProvider: (props: any) => {
+      capturedHandlers.push(props.handlers);
+      return React.createElement(actual.ActionProvider as any, props);
+    },
+    SchemaRenderer: () => null,
+  };
+});
+
+import { MetadataCtx } from '@object-ui/react';
+import { RecordDetailView } from './RecordDetailView';
+
+const OBJECT_NAME = 'crm_call';
+const RECORD_ID = 'rec-call-1';
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'Call',
+    fields: {
+      id: { type: 'text', label: 'Id' },
+      name: { type: 'text', label: 'Name' },
+    },
+  },
+];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => ({ id: RECORD_ID, name: 'Intro call' })),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+const METADATA = {
+  objects: OBJECTS,
+  pages: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invalidate: () => {},
+  ensureType: async () => [],
+  getItem: async () => null,
+  getItemsByType: () => [],
+} as any;
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={[`/app/demo/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={METADATA}>
+        <RecordDetailView
+          dataSource={makeDataSource()}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={RECORD_ID}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+}
+
+/** The record page's OWN handler set — the only provider carrying `approval`. */
+function recordPageHandlers() {
+  return [...capturedHandlers].reverse().find((h) => h && 'approval' in h);
+}
+
+/** Render the view and hand back its ActionProvider handlers, spies cleared. */
+async function mountAndCaptureHandlers() {
+  renderDetail();
+  await waitFor(() => expect(recordPageHandlers()).toBeTruthy());
+  const handlers = recordPageHandlers()!;
+  // Anything the mount itself fetched is not the dispatch under test.
+  authFetchSpy.mockClear();
+  serverActionSpy.mockClear();
+  resolveTargetSpy.mockClear();
+  modalHandlerSpy.mockClear();
+  return handlers;
+}
+
+beforeEach(() => {
+  cleanup();
+  capturedHandlers.length = 0;
+  authFetchSpy.mockClear();
+  serverActionSpy.mockClear();
+  modalHandlerSpy.mockClear();
+  resolveTargetSpy.mockReset();
+  resolveTargetSpy.mockResolvedValue(null);
+  // Unrelated chrome on this view (approvals, favourites, …) reaches for the
+  // platform API; in jsdom that is a real socket. Answer it locally so the
+  // only asynchrony left is the record load the capture waits on.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("RecordDetailView modal dispatch — CLIENT-SIDE ONLY (objectstack#3959 / objectui#3320)", () => {
+  it('opens the resolved target client-side and never POSTs to /actions', async () => {
+    const handlers = await mountAndCaptureHandlers();
+    resolveTargetSpy.mockResolvedValue({ content: { name: 'log_call', type: 'utility' } });
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.modal({ name: 'log_call', type: 'modal', target: 'log_call' });
+    });
+
+    expect(resolveTargetSpy).toHaveBeenCalledWith('log_call');
+    expect(modalHandlerSpy).toHaveBeenCalledWith({ content: { name: 'log_call', type: 'utility' } });
+    expect(serverActionSpy).not.toHaveBeenCalled();
+    expect(authFetchSpy).not.toHaveBeenCalled();
+    expect(r).toMatchObject({ success: true });
+  });
+
+  // The RecordDetailView-side counterpart of useConsoleActionRuntime.test.tsx's
+  // case of the same name. Until objectui#3320 this handler fell back to
+  // `serverActionHandler(action)`, POSTing the modal to /actions — which the
+  // framework rejects with a 400 (headlessActionTypeError) — while the shared
+  // runtime already reported the authoring error (objectstack#3959).
+  it('reports an unresolvable target instead of POSTing to /actions', async () => {
+    const handlers = await mountAndCaptureHandlers();
+    resolveTargetSpy.mockResolvedValue(null);
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.modal({
+        name: 'log_call', type: 'modal', target: 'log_call', params: { subject: 'Intro' },
+      });
+    });
+
+    expect(modalHandlerSpy).not.toHaveBeenCalled();
+    expect(serverActionSpy).not.toHaveBeenCalled();
+    expect(authFetchSpy).not.toHaveBeenCalled();
+    expect(r.success).toBe(false);
+    // The message must name the action, the dud target, and the way out —
+    // the same copy the shared runtime reports, so the two surfaces cannot
+    // drift apart silently again.
+    expect(String(r.error)).toContain('log_call');
+    expect(String(r.error)).toMatch(/type:'script' with params/);
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -831,19 +831,35 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
 
   /**
    * `type: 'modal'` dispatch — same rule as the shared console runtime (see
-   * `useConsoleActionRuntime.modalActionHandler`): open `target` as a page (or
-   * an object form) when it names one, else fall through to the action's
-   * server-side handler. Registering it as a handler rather than relying on the
-   * runner's built-in `executeModal` is what gives the record page that server
-   * fallback, so a modal action bound to `engine.registerAction(...)` completes
-   * here exactly as it does on a list page.
+   * `useConsoleActionRuntime.modalActionHandler`): CLIENT-SIDE ONLY. The
+   * action's `target` names the page (or object form) to open; rendering it is
+   * the whole of what a modal action does.
+   *
+   * [objectstack#3959 / objectui#3320] This used to fall through to
+   * `serverActionHandler` when the target resolved to neither a page nor an
+   * object, "so a modal action bound to `engine.registerAction(...)` completes
+   * here exactly as it does on a list page". It never ran: the framework's
+   * `headlessActionTypeError` rejects `type: 'modal'` over REST with a 400,
+   * because a modal has no server dispatch — the fallthrough only converted an
+   * authoring mistake (a target naming no page) into a confusing round-trip.
+   * objectstack#3959 removed it from the shared runtime; this copy kept the
+   * pre-#3959 shape until objectui#3320. An unresolvable target is now
+   * reported as what it is. To collect input and then run server-side, declare
+   * `type: 'script'` with `params`: the runner collects the same dialog and
+   * the handler runs with those values.
    */
   const modalActionHandler = useCallback(async (action: ActionDef) => {
     const schema = (action as any).modal ?? action.target ?? (action as any).params?.schema;
     const descriptor = schema != null ? await resolveModalTarget(schema) : null;
     if (descriptor) return modalHandler(descriptor);
-    return serverActionHandler(action);
-  }, [resolveModalTarget, modalHandler, serverActionHandler]);
+    return {
+      success: false,
+      error:
+        `Action "${action.name}" is type:'modal' but its target ` +
+        `${schema != null ? `"${String(schema)}" ` : ''}names no page or object to open. ` +
+        `Point it at a page, or use type:'script' with params to collect input and run a handler.`,
+    };
+  }, [resolveModalTarget, modalHandler]);
 
   // ─── Approvals ─────────────────────────────────────────────────────
   // Since ADR-0019 an approval is a flow node: the flow opens the request,


### PR DESCRIPTION
Fixes #3320

## 变更说明

按 PM 裁决采用方案 a（最小修法）：在 `RecordDetailView.modalActionHandler` 镜像 objectstack#3959 在共享 console runtime 中的行为与错误文案。基于 #3324（#2904 dispatcher 收敛）之后的新形状。

- **删除死路回退**：`type:'modal'` 的 target 既解析不到 page 也解析不到 object 时，原实现回退 `serverActionHandler(action)` POST 到 `/actions/...`。该路径永远不可能成功——framework 的 `headlessActionTypeError` 对 REST 上的 `type:'modal'` 一律 400——只会把一个 authoring 错误变成一次令人困惑的往返。现在与共享 runtime 一样返回描述性错误（指名 action、失效的 target、以及出路：`type:'script'` + `params`），错误文案与 `useConsoleActionRuntime.modalActionHandler` 逐字一致，两个 surface 不再漂移。
- **docblock 修正**：原注释声称 "same rule as the shared console runtime"（自 objectstack#3959 起已不为真），重写为镜像共享 runtime 的注释并记录本次收敛（objectstack#3959 / objectui#3320）。`serverActionHandler` 本身保留（仍是 `script` handler）。
- **新增测试** `RecordDetailView.modalDispatch.test.tsx`：`useConsoleActionRuntime.test.tsx` 中 "reports an unresolvable target instead of POSTing to /actions" 的 RecordDetailView 侧对应测试。测试捕获视图真实传给自己 ActionProvider 的 handlers（pass-through 包装、保留真 Provider，按唯一携带 `approval` 的那组选取），断言：不可解析 target → 不调 modalHandler、不调 server dispatch、不发 fetch、返回 `success: false` 且文案含 action 名与 `type:'script' with params`；可解析 target → 客户端打开、绝不 POST。
- **changeset**：`@object-ui/app-shell` patch（fixed group，非 major）。

方案 b（把 modal 分派上提进共享包装）未采用：需要新增导出面且净改动超过 30 行预裁上限，且会在刚合并的 #2904 表面上引入二次扰动。

未触碰 popup/SSO 文案（#3321 地盘）与 `content/docs/releases/`。

## 验证

| 项 | 命令 | 结果 |
|---|---|---|
| 新测试 | `pnpm exec vitest run packages/app-shell/src/views/RecordDetailView.modalDispatch.test.tsx` | 1 file / 2 passed |
| 邻域套件（runtime + RecordDetailView 全部测试文件，共 7 个） | `pnpm exec vitest run …` | 7 files / 90 passed |
| app-shell 全量 | `pnpm exec vitest run packages/app-shell --maxWorkers=2` | 268 files / 2317 passed, 1 skipped |
| 类型检查 | `pnpm --filter @object-ui/app-shell type-check` | 通过（先构建依赖包） |

### 破坏验证实录

把死路回退加回（`return serverActionHandler(action)`）后运行新测试：

```
× reports an unresolvable target instead of POSTing to /actions
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
    251|     expect(serverActionSpy).not.toHaveBeenCalled();
Tests  1 failed | 1 passed (2)
```

还原后 2 passed。红点恰好落在「server dispatch 被调用」的断言上，证明该测试锁住的正是本 bug。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_