### PR TITLE
fix(app-shell): AppSidebar / UnifiedSidebar 区域切换器采用派生可见性（#3319）

### DIFF
--- a/.changeset/app-shell-sidebars-derived-area-visibility.md
+++ b/.changeset/app-shell-sidebars-derived-area-visibility.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`AppSidebar` and `UnifiedSidebar` area switchers now adopt the derived area
+visibility introduced for `AppSchemaRenderer` in objectui#3311, closing the
+same visible-but-empty gap in the console shells (objectui#3319).
+
+Both sidebars inlined their own area switcher without any area-level
+filtering, so an area whose navigation items were **all** gated away
+(`visible` expression, `requiredPermissions`, `requiresObject` /
+`requiresService` capability gates) still appeared in the switcher and
+rendered an empty navigation — and a fully gated *first* area was even
+auto-activated, landing the user on an empty sidebar.
+
+## What changed
+
+- **Shared predicate, not a second implementation.** Both switchers now call
+  `hasVisibleNavigationItems` from `@object-ui/layout` — the exact guards
+  `NavigationRenderer` applies per item — so the switcher can never disagree
+  with the rendered navigation. In `UnifiedSidebar`, `action` items count as
+  content (it wires `onAction`, framework#4509); in `AppSidebar` they do not
+  (it wires none).
+- **The active area is elected among visible areas only**: first visible by
+  default, re-elected when the active area is gated away, and a gating change
+  that merely *reveals* an area never steals the user's current selection.
+- `areas: any[]` tightened to `NavigationArea[]` in both components.
+
+No authorable area-level key is introduced — visibility stays derived, per
+the objectui#3311 ruling.

--- a/packages/app-shell/src/layout/AppSidebar.tsx
+++ b/packages/app-shell/src/layout/AppSidebar.tsx
@@ -53,8 +53,8 @@ import {
   Home,
   ListTree,
 } from 'lucide-react';
-import { NavigationRenderer, resolveHref, resolveActiveNavItem } from '@object-ui/layout';
-import type { NavigationItem } from '@object-ui/types';
+import { NavigationRenderer, resolveHref, resolveActiveNavItem, hasVisibleNavigationItems } from '@object-ui/layout';
+import type { NavigationArea, NavigationItem } from '@object-ui/types';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useExpressionContext, evaluateVisibility } from '../providers/ExpressionProvider';
 import { useAuth, useIsWorkspaceAdmin, getUserInitials } from '@object-ui/auth';
@@ -191,45 +191,6 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
   // Navigation pin persistence via localStorage
   const { togglePin, applyPins } = useNavPins();
 
-  // Area management — track selected area when app defines areas
-  const areas: any[] = activeApp?.areas || [];
-  const [activeAreaId, setActiveAreaId] = React.useState<string | null>(
-    () => areas.length > 0 ? areas[0].id : null,
-  );
-
-  // Reset area when app changes or areas become available
-  React.useEffect(() => {
-    if (areas.length > 0) {
-      setActiveAreaId(prev => areas.some((a: any) => a.id === prev) ? prev : areas[0].id);
-    } else {
-      setActiveAreaId(null);
-    }
-  }, [activeAppName, areas.length]);
-
-  // Resolve navigation items: area navigation > flat navigation > empty
-  const activeArea = areas.find((a: any) => a.id === activeAreaId);
-  const resolvedNavigation: NavigationItem[] = activeArea?.navigation || activeApp?.navigation || [];
-
-  // App-level context selectors (e.g. Studio's package scope). Their
-  // values are injected into nav items as `{<id>}` template vars.
-  const { contextValues, element: contextSelectorsUI } = useAppContextSelectors(
-    activeAppName,
-    activeApp?.contextSelectors,
-    t,
-  );
-
-  // Apply saved order and pin state to navigation items
-  const processedNavigation = React.useMemo(() => {
-    const ordered = applyOrder(resolvedNavigation);
-    return applyPins(ordered);
-  }, [resolvedNavigation, applyOrder, applyPins]);
-
-  // Search filter state for sidebar navigation
-  const [navSearchQuery, setNavSearchQuery] = React.useState('');
-
-  // Recent section collapsed by default
-  const [recentExpanded, setRecentExpanded] = React.useState(false);
-
   // Visibility evaluation from Console expression context
   const { evaluator } = useExpressionContext();
   const evalVis = React.useCallback(
@@ -276,6 +237,71 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
     },
     [registeredObjectNames],
   );
+
+  // Area management — track selected area when app defines areas.
+  //
+  // Area visibility is DERIVED from the items inside (objectui#3311 /
+  // objectui#3319): the switcher offers an area iff at least one of its
+  // navigation items survives the same item-level guards NavigationRenderer
+  // applies (`visible`, `requiredPermissions`, runtime capabilities,
+  // action-dispatcher presence). The active area is elected among the
+  // VISIBLE areas only, so the user is never landed in — or stranded on —
+  // an area that renders nothing. Same derivation as `AppSchemaRenderer`
+  // (@object-ui/layout); the predicate is shared, not re-implemented.
+  const areas: NavigationArea[] = activeApp?.areas || [];
+  const visibleAreas = areas.filter((area) =>
+    hasVisibleNavigationItems(area.navigation, {
+      evaluateVisibility: evalVis,
+      checkPermission: checkPerm,
+      checkCapability: checkCap,
+      // This sidebar wires no `onAction` on its NavigationRenderer, so
+      // `action` items never render here and cannot carry an area's
+      // visibility either (framework#4509).
+      hasActionHandler: false,
+    }),
+  );
+  const [activeAreaId, setActiveAreaId] = React.useState<string | null>(
+    () => visibleAreas.length > 0 ? visibleAreas[0].id : null,
+  );
+
+  const visibleAreaIds = visibleAreas.map((a) => a.id).join(',');
+
+  // Re-elect when the app changes or the visible-area set changes. Keeping
+  // `prev` whenever it is still visible means merely REVEALING a new area
+  // never steals the user's current selection.
+  React.useEffect(() => {
+    if (visibleAreas.length > 0) {
+      setActiveAreaId(prev => visibleAreas.some((a) => a.id === prev) ? prev : visibleAreas[0].id);
+    } else {
+      setActiveAreaId(null);
+    }
+  }, [activeAppName, visibleAreaIds]);
+
+  // Resolve navigation items: area navigation > flat navigation > empty.
+  // The render-time `?? visibleAreas[0]` fallback covers the frame between
+  // a gating change hiding the active area and the effect above re-electing.
+  const activeArea = visibleAreas.find((a) => a.id === activeAreaId) ?? visibleAreas[0];
+  const resolvedNavigation: NavigationItem[] = activeArea?.navigation || activeApp?.navigation || [];
+
+  // App-level context selectors (e.g. Studio's package scope). Their
+  // values are injected into nav items as `{<id>}` template vars.
+  const { contextValues, element: contextSelectorsUI } = useAppContextSelectors(
+    activeAppName,
+    activeApp?.contextSelectors,
+    t,
+  );
+
+  // Apply saved order and pin state to navigation items
+  const processedNavigation = React.useMemo(() => {
+    const ordered = applyOrder(resolvedNavigation);
+    return applyPins(ordered);
+  }, [resolvedNavigation, applyOrder, applyPins]);
+
+  // Search filter state for sidebar navigation
+  const [navSearchQuery, setNavSearchQuery] = React.useState('');
+
+  // Recent section collapsed by default
+  const [recentExpanded, setRecentExpanded] = React.useState(false);
 
   const basePath = activeApp ? `/apps/${appRouteSegment(activeApp) ?? activeAppName}` : '';
 
@@ -435,8 +461,9 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
       <SidebarContent>
          {activeApp ? (
            <>
-           {/* Area Switcher — shown when app defines areas */}
-           {areas.length > 1 && (
+           {/* Area Switcher — offered only when MULTIPLE areas are visible;
+               area visibility is derived from the items inside (#3319) */}
+           {visibleAreas.length > 1 && (
              <SidebarGroup>
                <SidebarGroupLabel className="flex items-center gap-1.5">
                  <Layers className="h-3.5 w-3.5" />
@@ -444,9 +471,9 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
                </SidebarGroupLabel>
                <SidebarGroupContent>
                  <SidebarMenu>
-                   {areas.map((area: any) => {
+                   {visibleAreas.map((area) => {
                      const AreaIcon = getIcon(area.icon);
-                     const isActiveArea = area.id === activeAreaId;
+                     const isActiveArea = area.id === activeArea?.id;
                      return (
                        <SidebarMenuItem key={area.id}>
                          <SidebarMenuButton

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -38,8 +38,8 @@ import {
   Home,
   Layers,
 } from 'lucide-react';
-import { NavigationRenderer } from '@object-ui/layout';
-import type { NavigationItem } from '@object-ui/types';
+import { NavigationRenderer, hasVisibleNavigationItems } from '@object-ui/layout';
+import type { NavigationArea, NavigationItem } from '@object-ui/types';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useExpressionContext, evaluateVisibility } from '../providers/ExpressionProvider';
 import { usePermissions } from '@object-ui/permissions';
@@ -197,22 +197,97 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
   const { applyOrder, handleReorder } = useNavOrder(activeApp?.name || 'home');
   const { togglePin, applyPins } = useNavPins();
 
-  // Area management
-  const areas: any[] = activeApp?.areas || [];
-  const [activeAreaId, setActiveAreaId] = React.useState<string | null>(
-    () => areas.length > 0 ? areas[0].id : null,
+  // Visibility evaluation
+  const { evaluator } = useExpressionContext();
+  const evalVis = React.useCallback(
+    (expr: string | boolean | undefined) => evaluateVisibility(expr, evaluator),
+    [evaluator],
   );
 
+  // Permission check for nav `requiredPermissions` entries.
+  //
+  // Two authored forms:
+  //  - `object:action` → object CRUD gate.
+  //  - bare name → an ADR-0066 system capability, checked against the union of
+  //    the user's permission-set `systemPermissions` (from /me/permissions) —
+  //    the SAME subset rule the server applies to `AppSchema.requiredPermissions`.
+  //    This used to be misread as `can(<name>, 'read')` only, so a nav item
+  //    requiring a capability was hidden even from users whose permission set
+  //    granted it (admins included) — `requiredPermissions` degenerated into a
+  //    "hide from everyone" switch. The object-read fallback stays for nav
+  //    items that gate on a plain object name.
+  const { can, hasCapabilities } = usePermissions();
+  const checkPerm = React.useCallback(
+    (permissions: string[]) => permissions.every((perm: string) => {
+      const parts = perm.split(':');
+      if (parts.length >= 2) {
+        return can(parts[0], parts[1] as any);
+      }
+      return hasCapabilities([perm]) || can(perm, 'read');
+    }),
+    [can, hasCapabilities],
+  );
+
+  // Runtime capability gate: hide nav items targeting objects/services
+  // not registered in this runtime (e.g. cloud-only `sys_app`).
+  const registeredObjectNames = React.useMemo(
+    () => new Set<string>((metadataObjects || []).map((o: any) => o?.name).filter(Boolean)),
+    [metadataObjects],
+  );
+  const checkCap = React.useCallback(
+    (kind: 'object' | 'service', name: string): boolean => {
+      if (kind === 'object') {
+        if (registeredObjectNames.size === 0) return true;
+        return registeredObjectNames.has(name);
+      }
+      return true;
+    },
+    [registeredObjectNames],
+  );
+
+  // Area management.
+  //
+  // Area visibility is DERIVED from the items inside (objectui#3311 /
+  // objectui#3319): the switcher offers an area iff at least one of its
+  // navigation items survives the same item-level guards NavigationRenderer
+  // applies (`visible`, `requiredPermissions`, runtime capabilities,
+  // action-dispatcher presence). The active area is elected among the
+  // VISIBLE areas only, so the user is never landed in — or stranded on —
+  // an area that renders nothing. Same derivation as `AppSchemaRenderer`
+  // (@object-ui/layout); the predicate is shared, not re-implemented.
+  const areas: NavigationArea[] = activeApp?.areas || [];
+  const visibleAreas = areas.filter((area) =>
+    hasVisibleNavigationItems(area.navigation, {
+      evaluateVisibility: evalVis,
+      checkPermission: checkPerm,
+      checkCapability: checkCap,
+      // This sidebar always wires `onAction={dispatchNavAction}` on its
+      // NavigationRenderer (framework#4509), so `action` items render and
+      // count as area content.
+      hasActionHandler: !!dispatchNavAction,
+    }),
+  );
+  const [activeAreaId, setActiveAreaId] = React.useState<string | null>(
+    () => visibleAreas.length > 0 ? visibleAreas[0].id : null,
+  );
+
+  const visibleAreaIds = visibleAreas.map((a) => a.id).join(',');
+
+  // Re-elect when the app changes or the visible-area set changes. Keeping
+  // `prev` whenever it is still visible means merely REVEALING a new area
+  // never steals the user's current selection.
   React.useEffect(() => {
-    if (areas.length > 0) {
-      setActiveAreaId(prev => areas.some((a: any) => a.id === prev) ? prev : areas[0].id);
+    if (visibleAreas.length > 0) {
+      setActiveAreaId(prev => visibleAreas.some((a) => a.id === prev) ? prev : visibleAreas[0].id);
     } else {
       setActiveAreaId(null);
     }
-  }, [activeApp?.name, areas.length]);
+  }, [activeApp?.name, visibleAreaIds]);
 
-  // Resolve navigation items
-  const activeArea = areas.find((a: any) => a.id === activeAreaId);
+  // Resolve navigation items. The render-time `?? visibleAreas[0]` fallback
+  // covers the frame between a gating change hiding the active area and the
+  // effect above re-electing.
+  const activeArea = visibleAreas.find((a) => a.id === activeAreaId) ?? visibleAreas[0];
   const appNavigation: NavigationItem[] = activeArea?.navigation || activeApp?.navigation || [];
 
   // App-level context selectors (e.g. Studio's package scope). Their
@@ -310,54 +385,6 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
   // Recent section collapsed by default
   const [recentExpanded, setRecentExpanded] = React.useState(false);
 
-  // Visibility evaluation
-  const { evaluator } = useExpressionContext();
-  const evalVis = React.useCallback(
-    (expr: string | boolean | undefined) => evaluateVisibility(expr, evaluator),
-    [evaluator],
-  );
-
-  // Permission check for nav `requiredPermissions` entries.
-  //
-  // Two authored forms:
-  //  - `object:action` → object CRUD gate.
-  //  - bare name → an ADR-0066 system capability, checked against the union of
-  //    the user's permission-set `systemPermissions` (from /me/permissions) —
-  //    the SAME subset rule the server applies to `AppSchema.requiredPermissions`.
-  //    This used to be misread as `can(<name>, 'read')` only, so a nav item
-  //    requiring a capability was hidden even from users whose permission set
-  //    granted it (admins included) — `requiredPermissions` degenerated into a
-  //    "hide from everyone" switch. The object-read fallback stays for nav
-  //    items that gate on a plain object name.
-  const { can, hasCapabilities } = usePermissions();
-  const checkPerm = React.useCallback(
-    (permissions: string[]) => permissions.every((perm: string) => {
-      const parts = perm.split(':');
-      if (parts.length >= 2) {
-        return can(parts[0], parts[1] as any);
-      }
-      return hasCapabilities([perm]) || can(perm, 'read');
-    }),
-    [can, hasCapabilities],
-  );
-
-  // Runtime capability gate: hide nav items targeting objects/services
-  // not registered in this runtime (e.g. cloud-only `sys_app`).
-  const registeredObjectNames = React.useMemo(
-    () => new Set<string>((metadataObjects || []).map((o: any) => o?.name).filter(Boolean)),
-    [metadataObjects],
-  );
-  const checkCap = React.useCallback(
-    (kind: 'object' | 'service', name: string): boolean => {
-      if (kind === 'object') {
-        if (registeredObjectNames.size === 0) return true;
-        return registeredObjectNames.has(name);
-      }
-      return true;
-    },
-    [registeredObjectNames],
-  );
-
   const isStudioHomeActive = isStudioApp && location.pathname.replace(/\/+$/, '') === basePath;
 
   return (
@@ -420,8 +447,9 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
             </SidebarGroup>
           )}
 
-          {/* Area Switcher */}
-           {areas.length > 1 && (
+          {/* Area Switcher — offered only when MULTIPLE areas are visible;
+              area visibility is derived from the items inside (#3319) */}
+           {visibleAreas.length > 1 && (
              <SidebarGroup>
                <SidebarGroupLabel className="flex items-center gap-1.5">
                  <Layers className="h-3.5 w-3.5" />
@@ -429,9 +457,9 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
                </SidebarGroupLabel>
                <SidebarGroupContent>
                  <SidebarMenu>
-                   {areas.map((area: any) => {
+                   {visibleAreas.map((area) => {
                      const AreaIcon = getIcon(area.icon);
-                     const isActiveArea = area.id === activeAreaId;
+                     const isActiveArea = area.id === activeArea?.id;
                      return (
                        <SidebarMenuItem key={area.id}>
                          <SidebarMenuButton

--- a/packages/app-shell/src/layout/__tests__/AppSidebar.derivedAreaVisibility.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/AppSidebar.derivedAreaVisibility.test.tsx
@@ -1,0 +1,245 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * AppSidebar — derived area visibility (objectui#3319).
+ *
+ * The inline area switcher must follow the same derivation the layout
+ * package's `AppSchemaRenderer` adopted in #3311: an area appears in the
+ * switcher iff `hasVisibleNavigationItems` (shared predicate from
+ * `@object-ui/layout`, NOT a local copy) finds at least one item that
+ * survives the item-level guards, and the ACTIVE area is elected among the
+ * visible areas only. No authorable area-level key is involved.
+ *
+ * NB (lesson from #3322): a gated fixture is only load-bearing when it sits
+ * in the area that would otherwise be ACTIVE — the first/active area is the
+ * only one whose navigation actually renders, so gating an item elsewhere
+ * asserts nothing.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { NavigationArea } from '@object-ui/types';
+
+// ---------------------------------------------------------------------------
+// Mocks — providers and console-only chrome. @object-ui/components and
+// @object-ui/layout stay REAL so the shared predicate and the item-level
+// guards inside NavigationRenderer are actually exercised.
+// ---------------------------------------------------------------------------
+
+// Partial mock: @object-ui/components also imports from @object-ui/i18n
+// (createSafeTranslation), so the rest of the module must stay real.
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+    viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
+    dashboardLabel: ({ label }: { label?: string }) => label,
+    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
+  }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: null, signOut: vi.fn(), isAuthEnabled: false, activeOrganization: null }),
+  useIsWorkspaceAdmin: () => false,
+  getUserInitials: () => 'U',
+}));
+
+// Mutable permission state — swapped per test, re-read on every render.
+let permissionsState: {
+  can: (objectName: string, action: string) => boolean;
+  hasCapabilities: (caps: string[]) => boolean;
+};
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => permissionsState,
+}));
+
+let metadataState: { apps: unknown[]; objects: unknown[] };
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => metadataState,
+}));
+
+vi.mock('../../providers/ExpressionProvider', () => ({
+  useExpressionContext: () => ({ evaluator: null }),
+  // Mirrors the real evaluateVisibility's literal handling — enough for
+  // fixtures gating with `visible: false`.
+  evaluateVisibility: (expr: unknown) => expr !== false && expr !== 'false',
+}));
+
+vi.mock('../../utils', () => ({
+  resolveI18nLabel: (label: unknown) => (typeof label === 'string' ? label : ''),
+  matchAppBySegment: (apps: Array<{ name?: string }>, segment?: string) =>
+    apps.find((a) => a?.name === segment),
+  appRouteSegment: (app: { name?: string }) => app?.name,
+}));
+
+// Lazy lucide DynamicIcon would suspend mid-test; a null icon is enough here.
+vi.mock('../../utils/getIcon', () => ({ getIcon: () => () => null }));
+
+vi.mock('../../hooks/useRecentItems', () => ({ useRecentItems: () => ({ recentItems: [] }) }));
+vi.mock('../../hooks/useFavorites', () => ({
+  useFavorites: () => ({ favorites: [], removeFavorite: vi.fn() }),
+}));
+vi.mock('../../hooks/useNavPins', () => ({
+  useNavPins: () => ({ togglePin: vi.fn(), applyPins: (items: unknown) => items }),
+}));
+vi.mock('../ContextSelectors', () => ({
+  useAppContextSelectors: () => ({ contextValues: {}, element: null }),
+}));
+
+import { SidebarProvider } from '@object-ui/components';
+import { AppSidebar } from '../AppSidebar';
+
+// ---------------------------------------------------------------------------
+// Fixtures — labels are pairwise distinct so a hit is unambiguous.
+// ---------------------------------------------------------------------------
+
+const salesArea: NavigationArea = {
+  id: 'area-sales',
+  label: 'Sales',
+  navigation: [{ id: 'a1', type: 'object', label: 'Opportunities', objectName: 'opportunity' }],
+};
+
+const serviceArea: NavigationArea = {
+  id: 'area-service',
+  label: 'Service',
+  navigation: [{ id: 'a2', type: 'object', label: 'Cases', objectName: 'case' }],
+};
+
+const marketingArea: NavigationArea = {
+  id: 'area-marketing',
+  label: 'Marketing',
+  navigation: [{ id: 'a3', type: 'object', label: 'Campaigns', objectName: 'campaign' }],
+};
+
+const gatedSales: NavigationArea = {
+  ...salesArea,
+  navigation: [{ ...salesArea.navigation[0], visible: false }],
+};
+
+function sidebarUi(areas: NavigationArea[]) {
+  metadataState = {
+    apps: [{ name: 'crm', label: 'CRM', active: true, areas }],
+    objects: [],
+  };
+  return (
+    <MemoryRouter initialEntries={['/apps/crm']}>
+      <SidebarProvider>
+        <AppSidebar activeAppName="crm" onAppChange={() => {}} />
+      </SidebarProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  permissionsState = { can: () => true, hasCapabilities: () => true };
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AppSidebar derived area visibility (#3319)', () => {
+  it('keeps every area in the switcher when every area has a visible item', () => {
+    render(sidebarUi([salesArea, serviceArea, marketingArea]));
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+    // First area is active — only its navigation renders.
+    expect(screen.getByText('Opportunities')).toBeInTheDocument();
+    expect(screen.queryByText('Cases')).not.toBeInTheDocument();
+
+    // Switching among visible areas still works.
+    fireEvent.click(screen.getByText('Marketing'));
+    expect(screen.getByText('Campaigns')).toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+
+  it('keeps a PARTIALLY gated area visible and active, hiding only the gated item', () => {
+    const partialSales: NavigationArea = {
+      ...salesArea,
+      navigation: [
+        { ...salesArea.navigation[0], visible: false },
+        { id: 'a1b', type: 'object', label: 'Quotes', objectName: 'quote' },
+      ],
+    };
+    render(sidebarUi([partialSales, serviceArea]));
+    // The area survives (it still has a visible item) and stays active…
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Quotes')).toBeInTheDocument();
+    // …but the gated ITEM does not render (real NavigationRenderer guard).
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+
+  it('hides an area whose items are ALL gated and elects the first VISIBLE area', () => {
+    render(sidebarUi([gatedSales, serviceArea, marketingArea]));
+    // The fully gated area is not offered in the switcher…
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+    // …and never auto-activated: the first VISIBLE area's navigation renders.
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+
+  it('hides the switcher entirely when only one area remains visible', () => {
+    render(sidebarUi([gatedSales, serviceArea]));
+    // One visible area = nothing to switch between: no switcher rows at all,
+    // but the visible area's navigation still renders.
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.queryByText('Service')).not.toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+  });
+
+  it('renders no switcher and no area navigation when every area is fully gated', () => {
+    render(
+      sidebarUi([
+        gatedSales,
+        { ...serviceArea, navigation: [{ ...serviceArea.navigation[0], visible: false }] },
+      ]),
+    );
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.queryByText('Service')).not.toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cases')).not.toBeInTheDocument();
+  });
+
+  it('re-elects when the ACTIVE area is gated away, and a mere reveal does not steal the selection', () => {
+    const adminSales: NavigationArea = {
+      ...salesArea,
+      navigation: [{ ...salesArea.navigation[0], requiredPermissions: ['sales:admin'] }],
+    };
+    const areas = [adminSales, serviceArea, marketingArea];
+
+    const view = render(sidebarUi(areas));
+    // Permission granted: Sales is visible and active.
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Opportunities')).toBeInTheDocument();
+
+    // Permission revoked (`object:action` form → can('sales','admin') false):
+    // Sales derives hidden, drops out of the switcher, and the sidebar
+    // re-elects the first visible area.
+    permissionsState = {
+      can: (objectName, action) => !(objectName === 'sales' && action === 'admin'),
+      hasCapabilities: () => true,
+    };
+    view.rerender(sidebarUi(areas));
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+
+    // Permission granted again: Sales REAPPEARS in the switcher, but the
+    // user's current selection is not yanked away — Service stays active.
+    permissionsState = { can: () => true, hasCapabilities: () => true };
+    view.rerender(sidebarUi(areas));
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/layout/__tests__/UnifiedSidebar.derivedAreaVisibility.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/UnifiedSidebar.derivedAreaVisibility.test.tsx
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * UnifiedSidebar — derived area visibility (objectui#3319).
+ *
+ * Same contract as the AppSidebar suite: the inline area switcher adopts the
+ * #3311 derivation via the SHARED `hasVisibleNavigationItems` predicate from
+ * `@object-ui/layout` — an area is offered iff something inside it renders,
+ * and the active area is elected among the visible areas only.
+ *
+ * One behavior is specific to this sidebar: it wires
+ * `onAction={dispatchNavAction}` (framework#4509), so an `action` nav item IS
+ * content and can carry its area's visibility (`hasActionHandler: true`).
+ *
+ * NB (lesson from #3322): a gated fixture is only load-bearing when it sits
+ * in the area that would otherwise be ACTIVE.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { NavigationArea } from '@object-ui/types';
+
+// ---------------------------------------------------------------------------
+// Mocks — providers and console-only chrome. @object-ui/components and
+// @object-ui/layout stay REAL so the shared predicate and the item-level
+// guards inside NavigationRenderer are actually exercised.
+// ---------------------------------------------------------------------------
+
+// Partial mock: @object-ui/components also imports from @object-ui/i18n
+// (createSafeTranslation), so the rest of the module must stay real.
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+    viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
+    dashboardLabel: ({ label }: { label?: string }) => label,
+    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
+  }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: null, activeOrganization: null }),
+  useIsWorkspaceAdmin: () => false,
+}));
+
+// Mutable permission state — swapped per test, re-read on every render.
+let permissionsState: {
+  can: (objectName: string, action: string) => boolean;
+  hasCapabilities: (caps: string[]) => boolean;
+};
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => permissionsState,
+}));
+
+let metadataState: { apps: unknown[]; objects: unknown[] };
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => metadataState,
+}));
+
+vi.mock('../../providers/ExpressionProvider', () => ({
+  useExpressionContext: () => ({ evaluator: null }),
+  // Mirrors the real evaluateVisibility's literal handling — enough for
+  // fixtures gating with `visible: false`.
+  evaluateVisibility: (expr: unknown) => expr !== false && expr !== 'false',
+}));
+
+vi.mock('../../utils', () => ({
+  resolveI18nLabel: (label: unknown) => (typeof label === 'string' ? label : ''),
+  matchAppBySegment: (apps: Array<{ name?: string }>, segment?: string) =>
+    apps.find((a) => a?.name === segment),
+  appRouteSegment: (app: { name?: string }) => app?.name,
+}));
+
+// Lazy lucide DynamicIcon would suspend mid-test; a null icon is enough here.
+vi.mock('../../utils/getIcon', () => ({ getIcon: () => () => null }));
+
+vi.mock('../../hooks/useRecentItems', () => ({ useRecentItems: () => ({ recentItems: [] }) }));
+vi.mock('../../hooks/useFavorites', () => ({
+  useFavorites: () => ({ favorites: [], removeFavorite: vi.fn() }),
+}));
+vi.mock('../../hooks/useNavPins', () => ({
+  useNavPins: () => ({ togglePin: vi.fn(), applyPins: (items: unknown) => items }),
+}));
+const dispatchNavAction = vi.fn();
+vi.mock('../../hooks/useNavActionDispatch', () => ({
+  useNavActionDispatch: () => dispatchNavAction,
+}));
+vi.mock('../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ context: 'app', currentAppName: 'crm' }),
+}));
+vi.mock('../ContextSelectors', () => ({
+  useAppContextSelectors: () => ({ contextValues: {}, element: null }),
+}));
+vi.mock('../LocalizedSidebarTrigger', () => ({
+  LocalizedSidebarTrigger: () => null,
+}));
+
+import { SidebarProvider } from '@object-ui/components';
+import { UnifiedSidebar } from '../UnifiedSidebar';
+
+// ---------------------------------------------------------------------------
+// Fixtures — labels are pairwise distinct so a hit is unambiguous.
+// ---------------------------------------------------------------------------
+
+const salesArea: NavigationArea = {
+  id: 'area-sales',
+  label: 'Sales',
+  navigation: [{ id: 'a1', type: 'object', label: 'Opportunities', objectName: 'opportunity' }],
+};
+
+const serviceArea: NavigationArea = {
+  id: 'area-service',
+  label: 'Service',
+  navigation: [{ id: 'a2', type: 'object', label: 'Cases', objectName: 'case' }],
+};
+
+const marketingArea: NavigationArea = {
+  id: 'area-marketing',
+  label: 'Marketing',
+  navigation: [{ id: 'a3', type: 'object', label: 'Campaigns', objectName: 'campaign' }],
+};
+
+const gatedSales: NavigationArea = {
+  ...salesArea,
+  navigation: [{ ...salesArea.navigation[0], visible: false }],
+};
+
+function sidebarUi(areas: NavigationArea[]) {
+  metadataState = {
+    apps: [{ name: 'crm', label: 'CRM', active: true, areas }],
+    objects: [],
+  };
+  return (
+    <MemoryRouter initialEntries={['/apps/crm']}>
+      <SidebarProvider>
+        <UnifiedSidebar activeAppName="crm" />
+      </SidebarProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  permissionsState = { can: () => true, hasCapabilities: () => true };
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UnifiedSidebar derived area visibility (#3319)', () => {
+  it('keeps every area in the switcher when every area has a visible item', () => {
+    render(sidebarUi([salesArea, serviceArea, marketingArea]));
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+    // First area is active — only its navigation renders.
+    expect(screen.getByText('Opportunities')).toBeInTheDocument();
+    expect(screen.queryByText('Cases')).not.toBeInTheDocument();
+
+    // Switching among visible areas still works.
+    fireEvent.click(screen.getByText('Marketing'));
+    expect(screen.getByText('Campaigns')).toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+
+  it('keeps a PARTIALLY gated area visible and active, hiding only the gated item', () => {
+    const partialSales: NavigationArea = {
+      ...salesArea,
+      navigation: [
+        { ...salesArea.navigation[0], visible: false },
+        { id: 'a1b', type: 'object', label: 'Quotes', objectName: 'quote' },
+      ],
+    };
+    render(sidebarUi([partialSales, serviceArea]));
+    // The area survives (it still has a visible item) and stays active…
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Quotes')).toBeInTheDocument();
+    // …but the gated ITEM does not render (real NavigationRenderer guard).
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+
+  it('hides an area whose items are ALL gated and elects the first VISIBLE area', () => {
+    render(sidebarUi([gatedSales, serviceArea, marketingArea]));
+    // The fully gated area is not offered in the switcher…
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+    // …and never auto-activated: the first VISIBLE area's navigation renders.
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+
+  it('hides the switcher entirely when only one area remains visible', () => {
+    render(sidebarUi([gatedSales, serviceArea]));
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.queryByText('Service')).not.toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+  });
+
+  it('renders no switcher and no area navigation when every area is fully gated', () => {
+    render(
+      sidebarUi([
+        gatedSales,
+        { ...serviceArea, navigation: [{ ...serviceArea.navigation[0], visible: false }] },
+      ]),
+    );
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.queryByText('Service')).not.toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cases')).not.toBeInTheDocument();
+  });
+
+  it('counts an action item as area content — this sidebar wires a dispatcher (framework#4509)', () => {
+    const actionsArea: NavigationArea = {
+      id: 'area-actions',
+      label: 'Actions',
+      navigation: [
+        { id: 'act1', type: 'action', label: 'Run Sync', actionDef: { actionName: 'sync' } } as never,
+      ],
+    };
+    render(sidebarUi([actionsArea, serviceArea]));
+    // The action-only area is visible AND active (it is first): the switcher
+    // offers both areas. With no dispatcher this area would derive hidden.
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Run Sync')).toBeInTheDocument();
+  });
+
+  it('re-elects when the ACTIVE area is gated away, and a mere reveal does not steal the selection', () => {
+    const adminSales: NavigationArea = {
+      ...salesArea,
+      navigation: [{ ...salesArea.navigation[0], requiredPermissions: ['sales:admin'] }],
+    };
+    const areas = [adminSales, serviceArea, marketingArea];
+
+    const view = render(sidebarUi(areas));
+    // Permission granted: Sales is visible and active.
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Opportunities')).toBeInTheDocument();
+
+    // Permission revoked (`object:action` form → can('sales','admin') false):
+    // Sales derives hidden, drops out of the switcher, and the sidebar
+    // re-elects the first visible area.
+    permissionsState = {
+      can: (objectName, action) => !(objectName === 'sales' && action === 'admin'),
+      hasCapabilities: () => true,
+    };
+    view.rerender(sidebarUi(areas));
+    expect(screen.queryByText('Sales')).not.toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+
+    // Permission granted again: Sales REAPPEARS in the switcher, but the
+    // user's current selection is not yanked away — Service stays active.
+    permissionsState = { can: () => true, hasCapabilities: () => true };
+    view.rerender(sidebarUi(areas));
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('Cases')).toBeInTheDocument();
+    expect(screen.queryByText('Opportunities')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #3319

## 问题

`packages/app-shell` 的 `AppSidebar` 与 `UnifiedSidebar` 各自内联了一份区域切换器，均无 area 级过滤：某区域内 item 全被 gate（`visible` 表达式 / `requiredPermissions` / `requiresObject` / `requiresService`）时，区域仍出现在切换器里，点进去是空的；若第一个区域全被 gate，用户还会被默认落在空区域上。与 #3311 修掉的 `AppSchemaRenderer` 问题同型。

## 修法（按 issue 评论中的 PM 裁决逐条）

1. **复用共享谓词，不写第二份判定** — 两处切换器均改为调用 `@object-ui/layout` 已导出的 `hasVisibleNavigationItems`：区域可见 iff 其中至少一个 item 能通过 `NavigationRenderer` 逐条应用的 item 级守卫，切换器与实际渲染永不打架。差异只在 dispatcher：`UnifiedSidebar` 接了 `onAction={dispatchNavAction}`（framework#4509），`action` 项计为内容（`hasActionHandler: !!dispatchNavAction`）；`AppSidebar` 未接 `onAction`，`action` 项不承重（`hasActionHandler: false`）。
2. **活动区域只在可见区域中选举** — 默认首个可见区域；当前活动区域被 gate 掉后重新选举；仅「揭示新区域」不夺用户当前选择（effect 中 `prev` 仍可见即保留）。渲染期另有 `?? visibleAreas[0]` 兜底，覆盖 gating 变化与 effect 重选举之间的那一帧。
3. **空区域（本无 item）按 #3322 口径隐藏** — 派生口径天然一致：无可见 item 即隐藏。
4. **`areas: any[]` 收紧为 `NavigationArea[]`**（两处）。
5. **不引入任何 authorable key** — enforce-or-remove 之后不复活 area 级声明式 gating。

顺带把两组件中 `evalVis` / `checkPerm` / `checkCap` 的定义位置上移到区域管理之前（谓词需要它们），逻辑未改动。

## 测试

新增两个测试文件（真实 `@object-ui/layout` + `@object-ui/components`，仅 mock console providers），两组件各自覆盖：

| 场景 | AppSidebar | UnifiedSidebar |
|---|---|---|
| 全可见：全部区域在列，首区域激活，可切换 | ✅ | ✅ |
| 部分 gate：区域保留且激活，仅被 gate 的 item 不渲染 | ✅ | ✅ |
| 全 gate：区域从切换器消失，选举跳过它落到首个可见区域 | ✅ | ✅ |
| 仅剩一个可见区域：整个切换器隐藏 | ✅ | ✅ |
| 全部区域被 gate：无切换器、无区域导航 | ✅ | ✅ |
| 活动区域被 gate 后重选举；仅揭示不夺选 | ✅ | ✅ |
| `action` 项计为区域内容（本侧接了 dispatcher） | —（未接） | ✅ |

**破坏验证实录**（改坏 → 红 → 还原 → 绿，每次只改一处）：

| 变异 | 预期失败的测试 | 实测 |
|---|---|---|
| AppSidebar 切换器改回 `areas`（无派生过滤） | 全 gate 隐藏 / 单区域隐藏切换器 / 全 gate 无导航 / 重选举 | 4 失败，其余绿 |
| AppSidebar 选举无视 gating（init/effect/activeArea 用 `areas`） | 选举跳过 / 单区域 / 重选举 | 3 失败，其余绿 |
| AppSidebar effect 永远选第一个可见（夺选） | 仅揭示不夺选 | 1 失败，其余绿 |
| UnifiedSidebar 切换器改回 `areas` | 同 AppSidebar 第一条 | 4 失败，其余绿 |
| UnifiedSidebar `hasActionHandler: false` | action 项承重测试 | 1 失败，其余绿 |

**验证命令（仓根，均 flock 串行 + heap 上限）**：

- `pnpm exec vitest run packages/app-shell/src/layout/__tests__/AppSidebar.derivedAreaVisibility.test.tsx packages/app-shell/src/layout/__tests__/UnifiedSidebar.derivedAreaVisibility.test.tsx` → **2 files / 13 tests 全绿**
- `pnpm exec vitest run --maxWorkers=2 packages/app-shell` → **269 files / 2328 passed, 1 skipped**
- `turbo run build --filter=@object-ui/app-shell` → 29 tasks successful（app-shell tsc 干净）
- `turbo run type-check --filter=!@object-ui/site` → **77 tasks successful**
- `turbo run lint --filter=@object-ui/app-shell` → **0 errors**（2131 条既有 warning 为存量基线）
- ⚠️ **仓根全量 vitest 本地未能跑完：容器今日三次重启，全量验证任务三次被杀（PM 裁定不再重跑本地全量），交由本 PR 的 CI 把关。** 以上 scoped 结果（含 app-shell 全包 269 文件）均为重启前真实产出。

## Changeset

`.changeset/app-shell-sidebars-derived-area-visibility.md` — `@object-ui/app-shell: patch`（fixed group，无 major）。未触碰 `content/docs/releases/`。

## 相关

- #3311（裁决与 layout 侧实现）/ #3322（同型修法与测试结构参考）
- #3315（rc.2 跟随退役的 pin-bump）
- framework#4509（action 项无 dispatcher 则不渲染）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa