### PR TITLE
fix(plugin-detail): field:permission-facet-link 注册套上 withFieldCarrier（#3307）

### DIFF
--- a/.changeset/permission-facet-link-field-carrier.md
+++ b/.changeset/permission-facet-link-field-carrier.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/plugin-detail": patch
+---
+
+`field:permission-facet-link` now registers through `withFieldCarrier` — the
+repo's only raw `field:` registration bypassed the single-metadata-carrier seam
+(objectui#3233), so under the SDUI path (`SchemaRenderer` passes `schema`,
+never `field`) the widget read `field === undefined` and silently rendered an
+anonymous facet summary (`field?.name` empty, no facet branch selected). The
+form and inline-edit hosts were unaffected — they pass `field` directly, which
+the carrier forwards unchanged. Fixes objectui#3307.

--- a/packages/plugin-detail/src/__tests__/PermissionFacetLink.sduiCarrier.test.tsx
+++ b/packages/plugin-detail/src/__tests__/PermissionFacetLink.sduiCarrier.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression for objectui#3307 — `field:permission-facet-link` was the only
+ * `field:` registration in the repo that bypassed `withFieldCarrier`.
+ *
+ * `SchemaRenderer` (the SDUI path) hands every registered component the
+ * authored node as `schema` and never passes `field`; the form and inline-edit
+ * hosts pass `field`. Since objectui#3233 the field-widget contract carries
+ * metadata on `field` ONLY, and the translation happens once at the
+ * registration seam via `withFieldCarrier`. A raw registration therefore works
+ * under the form hosts but reads `field === undefined` under SDUI — the widget
+ * renders, silently, an anonymous summary (`field?.name` empty, no facet
+ * branch selected). Exactly the failure class the carrier exists to prevent.
+ *
+ * The behavioral test below goes through the REAL registration (imported from
+ * `../index`), the real `SchemaRenderer`, and the real widget. The asserted
+ * text is data (capability names), not translation copy, so the test does not
+ * depend on i18n configuration. Removing `withFieldCarrier` from the
+ * registration makes it fail: `field?.name` falls to `''`, the widget takes
+ * the anonymous default branch, and renders the bare count "2" instead of the
+ * capability chips.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+
+// Module scope, not a hook (AGENTS.md 测试纪律 / objectui#3010): importing the
+// package index executes its registration side-effects, so the entry under
+// test is the very one production resolves.
+import '../index';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('field:permission-facet-link — SDUI path delivers `field` (objectui#3307)', () => {
+  it('converges the authored node onto `field` (field?.name non-empty end to end)', () => {
+    // The SDUI shape: `schema` only — no `field` anywhere in these props.
+    render(
+      <MemoryRouter>
+        <SchemaRenderer
+          schema={
+            {
+              type: 'field:permission-facet-link',
+              name: 'system_permissions',
+              label: 'System Permissions',
+              value: ['manage_users', 'view_reports'],
+            } as any
+          }
+        />
+      </MemoryRouter>,
+    );
+
+    // The capability-chip branch renders IFF `field?.name === 'system_permissions'`,
+    // i.e. the authored node reached the widget as `field`. The chip labels are
+    // the facet's own data.
+    expect(screen.getByText('manage_users')).toBeInTheDocument();
+    expect(screen.getByText('view_reports')).toBeInTheDocument();
+    // …and NOT the anonymous default-branch summary (bare count "2") that a
+    // raw registration produced when `field?.name` came up empty.
+    expect(screen.queryByText('2')).toBeNull();
+  });
+
+  it('is registered through the carrier adapter, not raw', () => {
+    // Cheap seam pin: the registry entry itself is the `withFieldCarrier`
+    // wrapper. The behavioral test above is the authority; this one makes a
+    // future raw re-registration fail with an unmistakable message.
+    const entry = ComponentRegistry.get('field:permission-facet-link') as
+      | { displayName?: string }
+      | undefined;
+    expect(entry).toBeTruthy();
+    expect(entry?.displayName).toMatch(/^FieldCarrier\(/);
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import { ComponentRegistry, type ComponentInput } from '@object-ui/core';
+import { withFieldCarrier } from '@object-ui/fields';
 import { DetailView } from './DetailView';
 import { DetailSection } from './DetailSection';
 import { DetailTabs } from './DetailTabs';
@@ -456,7 +457,13 @@ ComponentRegistry.register('alert', RecordAlertRenderer, {
 // the record form and inline edit resolve `field:permission-facet-link`; the
 // detail read path special-cases it in DetailSection. Setup never edits these
 // facets — they are designed in Studio's structured editors.
-ComponentRegistry.register('permission-facet-link', PermissionFacetLink, {
+//
+// `withFieldCarrier` is MANDATORY on every `field:` registration (objectui#3233
+// / #3307): `SchemaRenderer` hands the authored node over as `schema`, and the
+// adapter converges it onto `field` — the field-widget contract's only
+// metadata carrier. Registered raw, the widget reads `field === undefined`
+// under the SDUI path and silently renders an anonymous summary.
+ComponentRegistry.register('permission-facet-link', withFieldCarrier(PermissionFacetLink), {
   namespace: 'field',
   skipFallback: true,
 });


### PR DESCRIPTION
Fixes #3307

## 问题

`packages/plugin-detail/src/index.tsx` 把 `PermissionFacetLink` **裸注册**进 `field:` 命名空间——全仓唯一一处绕过 `withFieldCarrier`（objectui#3233 / PR #3296）的 field 注册。SDUI 路径下 `SchemaRenderer` 只传 `schema` 不传 `field`，widget 读 `props.field` 拿到 `undefined`，于是 `field?.name` 为空、facet 分支全部落空，静默渲染出一个匿名摘要——不报错、不警告，正是单载体收敛要防的那类静默失效。表单宿主与内联编辑宿主本来就传 `field`，不受影响（carrier 对显式 `field` 原样放行）。

## 修法（按 PM 裁决的最小修法）

- 注册处套上 `withFieldCarrier`，与 `packages/fields/src/index.tsx` 注册循环的用法一致；注册点注释写明这是 `field:` 注册的强制封口。
- 回归测试 `PermissionFacetLink.sduiCarrier.test.tsx`：走**真实注册项 + 真实 SchemaRenderer + 真实 widget**，SDUI 形状（只传 `schema`）下断言 capability chips（`manage_users` / `view_reports`,facet 自身的数据而非翻译文案）渲染出来——该分支当且仅当 `field?.name === 'system_permissions'` 才会命中，即 `field?.name` 非空端到端成立；并断言不落到匿名默认分支（裸计数 `2`）。另钉住注册项本身就是 carrier 适配器（`displayName` 前缀）。
- changeset：`@object-ui/plugin-detail` patch（fixed 组,无 major）。

## 验证

| 项 | 命令 | 结果 |
|---|---|---|
| 新回归测试 | `pnpm exec vitest run packages/plugin-detail/src/__tests__/PermissionFacetLink.sduiCarrier.test.tsx` | ✅ 2 passed |
| **破坏验证** | 摘掉 `withFieldCarrier` 后重跑同一文件 | ❌ 2 failed（`getByText('manage_users')` 找不到——widget 落入匿名分支;registry 项 `displayName` 为 `undefined`）;套回后 ✅ 2 passed |
| 类型检查 | `pnpm exec turbo run type-check --filter=@object-ui/plugin-detail` | ✅ 12 tasks successful |
| 面上测试 | `pnpm exec vitest run packages/plugin-detail packages/fields/src/__tests__/field-carrier-sdui.test.tsx packages/components/src/renderers/form/__tests__/form-field-carrier.test.tsx --maxWorkers=2` | ✅ 42 files / 380 tests passed |

## 后续指引（本单不做）

#3307 里提出的结构性加固——收口 `field:` 注册表面（例如只暴露内置 carrier 的 `registerField()`,让绕过在结构上不可能）——按 PM 裁决另立单裁决,本 PR 不做。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_