### PR TITLE
fix(app-shell): 权限集编辑页系统能力胶囊墙加自身 max-height,对象权限矩阵不再被压到 0 高不可达 (#3332)

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.basics.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.basics.test.tsx
@@ -96,4 +96,19 @@ describe('PermissionMatrixEditPage — B1 first-screen collapse (objectui#2600)'
     expect(screen.getByTestId('cap-picker')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Add capability/i })).toBeNull();
   });
+
+  // objectui#3332 — a large capability chip wall (44+ grants → 20+ rows) is a
+  // non-shrinking sibling of the flex-1 object matrix; unbounded it squeezed
+  // the matrix to ~9px with no page scrollbar. The picker must sit inside a
+  // height-capped, internally-scrolling container so the matrix keeps the rest
+  // of the viewport.
+  it('caps the capability area with its own scroll so the matrix stays reachable (objectui#3332)', async () => {
+    await renderSet({
+      systemPermissions: Array.from({ length: 44 }, (_, i) => `navigation.item_${i}`),
+    });
+    const wrap = screen.getByTestId('capability-scroll');
+    expect(wrap).toContainElement(screen.getByTestId('cap-picker'));
+    expect(wrap.className).toContain('overflow-y-auto');
+    expect(wrap.className).toMatch(/max-h-/);
+  });
 });

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -775,15 +775,26 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
             <p className="text-xs text-muted-foreground mt-0.5 mb-2">
               {t('perm.field.systemCapabilitiesHelp')}
             </p>
-            <CapabilityMultiSelectField
-              value={JSON.stringify(draft.systemPermissions ?? [])}
-              onChange={(v: unknown) =>
-                setDraft((p) => ({ ...p, systemPermissions: parseCapabilityNames(v) }))
-              }
-              field={{ name: 'system_permissions' } as any}
-              dataSource={adapter as any}
-              readonly={!writable}
-            />
+            {/* objectui#3332 — the capability chip wall grows with the live
+                sys_capability registry (44+ nav capabilities → 20+ rows). It is
+                a non-shrinking sibling of the flex-1 matrix, so unbounded it
+                squeezes the object list to ~0px with no page scrollbar. Cap it
+                to a viewport share and scroll internally; the matrix keeps the
+                remaining height (per #2600 B1 the picker itself stays inline). */}
+            <div
+              data-testid="capability-scroll"
+              className="max-h-[30vh] overflow-y-auto overscroll-contain"
+            >
+              <CapabilityMultiSelectField
+                value={JSON.stringify(draft.systemPermissions ?? [])}
+                onChange={(v: unknown) =>
+                  setDraft((p) => ({ ...p, systemPermissions: parseCapabilityNames(v) }))
+                }
+                field={{ name: 'system_permissions' } as any}
+                dataSource={adapter as any}
+                readonly={!writable}
+              />
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3332

## 问题

Setup 权限集「权限配置」页(PermissionMatrixEditPage,Setup 元数据路由与 Studio 设计面共用)中,「系统能力」区的 CapabilityMultiSelectField 胶囊墙无界渲染。它在 overflow-hidden 的弹性列里是 flex-1 对象矩阵的不收缩兄弟节点:能力注册表一多(项目实测 44+ 个导航能力 → 20+ 行胶囊),矩阵滚动容器被压到 scrollHeight=7134 / clientHeight=9,整页又无滚动条,对象级 C/R/U/D 配置在 UI 上彻底不可达。

## 修复

采用 issue 给出的「能力区给自身 max-height」方案:胶囊墙包进 `max-h-[30vh] overflow-y-auto overscroll-contain` 容器,能力区最多占 30% 视口、内部自滚,矩阵拿回剩余全部高度。与 objectui#2600 B1 既有约定兼容——有授权时选择器仍免点击直出(该行为已有测试钉住,本次未动)。

## 测试

- 新增回归测试(PermissionMatrixEditor.basics.test.tsx):44 个能力授权时,选择器必须位于带 `overflow-y-auto` + `max-h-` 的滚动容器内;
- `pnpm vitest run packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor`:7 个测试文件 25 个用例全绿;
- `pnpm type-check`(app-shell)通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)