### PR TITLE
fix(components): #3344 Combobox trigger 显式声明 type="button"，绝不提交外层表单

### DIFF
--- a/.changeset/combobox-trigger-never-submits-forms.md
+++ b/.changeset/combobox-trigger-never-submits-forms.md
@@ -1,0 +1,12 @@
+---
+"@object-ui/components": patch
+---
+
+The Combobox trigger now declares `type="button"` explicitly, so it can never
+submit an enclosing `<form>` (objectui#3344). The current Radix
+`PopoverTrigger` happens to supply `type="button"` through its Slot, but that
+form-safety guarantee was an upstream implementation detail — it is now a
+locally declared, regression-tested contract, matching the explicit style of
+LookupField / MultiSelectField / RatingField. The default sits before the
+trigger pass-through spread (objectui#3318), so a consumer who explicitly
+passes `type` (e.g. `type="submit"`) still wins.

--- a/packages/components/src/__tests__/combobox-trigger-type.test.tsx
+++ b/packages/components/src/__tests__/combobox-trigger-type.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3344 — the combobox trigger must not submit an enclosing form.
+ *
+ * An HTML <button> defaults to `type="submit"` inside a <form>, and Radix's
+ * PopoverTrigger does not preventDefault on click — so a Combobox rendered
+ * inside an object form (object-ref / recipient-picker field widgets)
+ * submitted the form on every click of its dropdown trigger. The trigger now
+ * declares `type="button"`, placed BEFORE the #3318 pass-through spread so a
+ * consumer who explicitly passes `type` (e.g. `type="submit"`) still wins.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Combobox } from '../custom/combobox';
+
+const OPTIONS = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+];
+
+describe('Combobox trigger inside a form', () => {
+  it('defaults to type="button" and does not submit the form on click', () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <Combobox options={OPTIONS} value="" onValueChange={vi.fn()} />
+      </form>,
+    );
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('type', 'button');
+    fireEvent.click(trigger);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('still opens the popover when clicked inside a form', () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <Combobox options={OPTIONS} value="" onValueChange={vi.fn()} />
+      </form>,
+    );
+    const trigger = screen.getByRole('combobox');
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('lets an explicit type="submit" override the default (#3318 pass-through ordering)', () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <Combobox options={OPTIONS} value="" onValueChange={vi.fn()} type="submit" />
+      </form>,
+    );
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('type', 'submit');
+    fireEvent.click(trigger);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/components/src/custom/combobox.tsx
+++ b/packages/components/src/custom/combobox.tsx
@@ -71,6 +71,14 @@ export function Combobox({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          // Inside a <form> a bare <button> defaults to type="submit", so an
+          // untyped trigger would submit the enclosing object form on every
+          // click (objectui#3344). Radix's PopoverTrigger happens to supply
+          // type="button" via its Slot today, but that is an upstream
+          // implementation detail — declare the contract locally, like
+          // LookupField / MultiSelectField / RatingField do. Placed BEFORE the
+          // pass-through spread so an explicit consumer `type` still wins.
+          type="button"
           // Before this component's own props, which stay authoritative for
           // the combobox contract (role, aria-expanded, className, disabled).
           {...triggerProps}


### PR DESCRIPTION
Fixes #3344

## 修复内容

按 PM 裁决（#3344 认领评论）：给 `packages/components/src/custom/combobox.tsx` 的 trigger Button 加一行 `type="button"`，且放在 #3318 引入的 pass-through spread（`{...triggerProps}`）**之前** —— 消费方显式传 `type`（如 `type="submit"`）时覆盖仍然生效。附带回归测试钉住两个方向的契约。

## ⚠️ 实测发现：bug 在当前 main 上不能复现（请 PM/维护者知悉）

写好回归测试后先对**未修复**的源码跑（破坏验证的红腿），3 个用例**全绿** —— 追查发现当前安装的 `@radix-ui/react-popover@1.1.23` 的 `PopoverTrigger` 本身就渲染 `type: "button"`（在其 props spread 之前），经 `asChild` 的 Slot 合并落到我们的 Button 上。issue 的前提「Radix PopoverTrigger 不设 type」对该版本**不成立**：

- 缺省场景:trigger 在 DOM 上已有 `type="button"`，form 内点击**不会**提交（实测断言通过）；
- 覆盖场景:消费方经 pass-through 传 `type="submit"` 时，子元素 prop 压过 Slot prop，覆盖本来就生效。

因此本 PR 的实际性质是**防御性加固 + 契约钉住**：form 安全此前只由上游实现细节保证（Radix 换版本/重构掉 asChild 即失守），现在升格为本地显式声明、有回归测试把守的契约 —— 与 LookupField / MultiSelectField / RatingField 的显式写法对齐。是否要把 #3344 重新归类（bug → 加固），请 PM 定夺。

## 验证表

| 步骤 | 命令 | 结果 |
|---|---|---|
| 新回归测试 + 既有 combobox 测试 | `pnpm exec vitest run packages/components/src/__tests__/combobox-trigger-type.test.tsx packages/components/src/__tests__/combobox-long-label.test.tsx --maxWorkers=2` | ✅ 2 files / 7 tests passed |
| 类型检查 | `pnpm exec turbo run type-check --filter=@object-ui/components` | ✅ 8 tasks successful |
| 全量 components 包测试 | 见 PR 后续评论/CI | push-first,交由 CI 把关 |

## 破坏验证实录

- **Leg A（裁决原样：仅去掉新增行 = 回到 main 现状）**→ 测试**仍绿**。这不是测试没牙，而正是「不能复现」的证据:Radix 1.1.23 兜底提供了 `type="button"`。
- **Leg B（teeth check：spread 后强制 `type={undefined}`，模拟上游无兜底且本地无声明）**→ **2 red**（缺省用例 `toHaveAttribute('type', 'button')` 失败；覆盖用例 `type="submit"` 属性断言失败）→ 还原 → 绿。证明回归测试确实把守该契约。
- **行为断言非空转**:覆盖用例在修复前即验证 happy-dom 点击 submit 型按钮真的触发 form submit（`onSubmit` 被调用 1 次），故缺省用例的 `not.toHaveBeenCalled()` 是有效行为断言，不是恒真。

## Changeset

`@object-ui/components` **patch**（fixed group,未声明 major）。未触碰 `content/docs/releases/`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVPjPzmmAJ2Ngtvgg5MSRa)_