### PR TITLE
fix(plugin-detail,types): `record:highlights` 尊重条目上声明的 `readonly`,不再让表头 chip 覆写平台维护的列

### DIFF
--- a/.changeset/highlights-entry-readonly.md
+++ b/.changeset/highlights-entry-readonly.md
@@ -1,0 +1,6 @@
+---
+'@object-ui/plugin-detail': patch
+'@object-ui/types': patch
+---
+
+`record:highlights` now honours a `readonly: true` on an authored field entry, so a header chip for a platform-owned column no longer offers inline edit. `HeaderHighlight`'s editability gate already consulted `field.readonly`, but the renderer rebuilt each entry from a fixed `{name,label,icon,type}` list and dropped `readonly` one layer before that check, so the gate could never fire from authored metadata — a hook-maintained rollup or approval-written grade could be overwritten by hand from the detail-page header strip and stayed wrong until an unrelated write re-fired the computation. `readonly` is now a declared key on `HighlightField` and on the `RecordHighlightsComponentProps.fields[]` entry union, mirroring `DetailViewField.readonly` (objectstack#5077).

--- a/packages/plugin-detail/src/HeaderHighlight.tsx
+++ b/packages/plugin-detail/src/HeaderHighlight.tsx
@@ -104,7 +104,7 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
             // object metadata), and immutable system/audit fields never edit.
             const isComputed = TEXTUAL_REF_FALLBACK_TYPES.has(resolvedType as string);
             const isReadonly =
-              (field as any).readonly === true || objectDefField?.readonly === true;
+              field.readonly === true || objectDefField?.readonly === true;
             const isSystem = NON_EDITABLE_SYSTEM_FIELDS.has(field.name);
             const fieldEditable = !isComputed && !isReadonly && !isSystem;
             const canInlineEditField = canEdit && fieldEditable;

--- a/packages/plugin-detail/src/__tests__/RecordHighlightsRenderer.readonly.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordHighlightsRenderer.readonly.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectstack#5077 — a `record:highlights` chip must not offer inline edit for a
+ * column the platform owns.
+ *
+ * Downstream (yinlianghui/hotcrm-heimao#61) a hook-maintained rollup was
+ * overwritten by hand from the header strip and stayed corrupted until an
+ * unrelated child-row touch re-fired the rollup. Such a column cannot be marked
+ * `readonly` on the OBJECT — `stripReadonlyFields` would drop the hook's own
+ * write-back too — so the declaration has to live on the highlight entry.
+ *
+ * `HeaderHighlight`'s gate always read `field.readonly`; the renderer's entry
+ * normalization rebuilt each entry from `{name,label,icon,type}` and dropped
+ * `readonly` one layer earlier, so the gate could never fire from authored
+ * metadata. These tests pin the whole authored-metadata → chip path, not just
+ * the gate in isolation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider, InlineEditProvider } from '@object-ui/react';
+import { RecordHighlightsRenderer } from '../renderers/record-highlights';
+
+const objectSchema = {
+  fields: {
+    // Hook-maintained rollup. Declared a plain `number` on the object on
+    // purpose: the object CANNOT carry `readonly: true` without killing the
+    // cross-object hook that writes it.
+    supply_share: { type: 'number' },
+    owner: { type: 'text' },
+  },
+};
+
+const data = { supply_share: 28.57, owner: 'Alice' };
+
+const renderStrip = (fields: unknown[]) =>
+  render(
+    <InlineEditProvider canEdit>
+      <RecordContextProvider
+        objectName="crm_account"
+        recordId="A1"
+        data={data}
+        objectSchema={objectSchema}
+      >
+        <RecordHighlightsRenderer schema={{ fields } as any} />
+      </RecordContextProvider>
+    </InlineEditProvider>,
+  );
+
+/**
+ * The chip's inline-edit affordance: a hover pencil button plus the
+ * `cursor-pointer` double-click target. Both are rendered iff
+ * `canInlineEditField`, so either one answers "is this chip editable".
+ */
+const hasInlineEditAffordance = (container: HTMLElement) =>
+  screen.queryAllByRole('button').length > 0 ||
+  container.innerHTML.includes('cursor-pointer');
+
+describe('record:highlights — authored `readonly` reaches the editability gate (#5077)', () => {
+  it('renders a bare string entry as editable (control)', () => {
+    const { container } = renderStrip(['owner']);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(hasInlineEditAffordance(container)).toBe(true);
+  });
+
+  it('renders an object entry WITHOUT `readonly` as editable (control)', () => {
+    const { container } = renderStrip([{ name: 'supply_share', label: 'Supply Share' }]);
+    expect(hasInlineEditAffordance(container)).toBe(true);
+  });
+
+  it('renders `{ name, readonly: true }` as NON-editable', () => {
+    const { container } = renderStrip([{ name: 'supply_share', readonly: true }]);
+    // Value still displayed — the point of a highlight is being seen; this is a
+    // lock, not a redaction (`redactFields` is the remove-the-chip knob).
+    expect(screen.getByText(/28\.57/)).toBeInTheDocument();
+    expect(hasInlineEditAffordance(container)).toBe(false);
+  });
+
+  it('keeps `readonly` per-entry — one locked chip does not lock its siblings', () => {
+    const { container } = renderStrip([
+      { name: 'supply_share', readonly: true },
+      { name: 'owner' },
+    ]);
+    // The editable sibling still has exactly one pencil.
+    expect(screen.queryAllByRole('button')).toHaveLength(1);
+    expect(container.innerHTML).toContain('cursor-pointer');
+  });
+
+  it('treats only `readonly: true` as a lock — a falsy value stays editable', () => {
+    const { container } = renderStrip([{ name: 'supply_share', readonly: false }]);
+    expect(hasInlineEditAffordance(container)).toBe(true);
+  });
+});
+
+/**
+ * The second half of #5077: an authored computed `type` must reach the SAME
+ * gate the display-renderer selection reads. `TEXTUAL_REF_FALLBACK_TYPES`
+ * (formula / summary / rollup / auto_number) is the computed-type set.
+ *
+ * This already held at HEAD — `resolvedType = field.type || objectDefField.type`
+ * feeds both consumers — so these are pin tests: they fail loudly if the gate
+ * and the renderer selection are ever given separate type resolutions again.
+ */
+describe('record:highlights — authored computed `type` disables inline edit (#5077)', () => {
+  for (const type of ['formula', 'summary', 'rollup', 'auto_number']) {
+    it(`renders an authored \`type: '${type}'\` entry as NON-editable`, () => {
+      const { container } = renderStrip([{ name: 'supply_share', type }]);
+      expect(hasInlineEditAffordance(container)).toBe(false);
+    });
+  }
+
+  it('still honours a computed type declared only on the object', () => {
+    const { container } = render(
+      <InlineEditProvider canEdit>
+        <RecordContextProvider
+          objectName="crm_account"
+          recordId="A1"
+          data={data}
+          objectSchema={{ fields: { supply_share: { type: 'rollup' } } }}
+        >
+          <RecordHighlightsRenderer schema={{ fields: ['supply_share'] } as any} />
+        </RecordContextProvider>
+      </InlineEditProvider>,
+    );
+    expect(hasInlineEditAffordance(container)).toBe(false);
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-highlights.tsx
+++ b/packages/plugin-detail/src/renderers/record-highlights.tsx
@@ -50,9 +50,25 @@ export const RecordHighlightsRenderer: React.FC<RecordHighlightsRendererProps> =
     required.every((p) => perms.can(objectName, p as any));
 
   const rawFields: any[] = Array.isArray(schema.fields) ? schema.fields : [];
-  // Normalize: spec accepts either bare strings or { name, label?, icon?, type? }
+  // Normalize: accepts either bare strings or { name, label?, icon?, type?, readonly? }.
+  //
+  // `readonly` is copied through deliberately: HeaderHighlight's editability
+  // gate has always consulted `field.readonly`, but this map used to rebuild
+  // each entry from a fixed four-key list, so an authored `readonly: true` was
+  // dropped one layer BEFORE the check that would honour it and the gate could
+  // never fire from authored metadata (objectstack#5077). Rebuilding key-by-key
+  // rather than spreading keeps the entry shape closed — an undeclared key is
+  // still not silently forwarded to the strip.
   const normalized = rawFields.map((f) =>
-    typeof f === 'string' ? { name: f } : { name: f?.name, label: f?.label, icon: f?.icon, type: f?.type },
+    typeof f === 'string'
+      ? { name: f }
+      : {
+          name: f?.name,
+          label: f?.label,
+          icon: f?.icon,
+          type: f?.type,
+          readonly: f?.readonly === true,
+        },
   ).filter((f) => typeof f.name === 'string' && f.name.length > 0);
 
   const enforceFLS = (schema as any).enforceFieldSecurity === true;

--- a/packages/types/src/record-components.ts
+++ b/packages/types/src/record-components.ts
@@ -66,8 +66,18 @@ export interface RecordDetailsComponentProps {
  * Aligned with @objectstack/spec RecordHighlightsProps.
  */
 export interface RecordHighlightsComponentProps {
-  /** Fields to display as highlights — bare names or {name,label?,icon?,type?} for inline overrides */
-  fields: Array<string | { name: string; label?: string; icon?: string; type?: string }>;
+  /**
+   * Fields to display as highlights — bare names or
+   * `{name,label?,icon?,type?,readonly?}` for inline overrides.
+   *
+   * `readonly: true` suppresses the chip's inline-edit affordance
+   * (objectstack#5077) without touching the object field, which is what
+   * hook-maintained columns need: marking the object field `readonly` would
+   * also strip the hook's own write-back.
+   */
+  fields: Array<
+    string | { name: string; label?: string; icon?: string; type?: string; readonly?: boolean }
+  >;
   /** Layout mode for highlights display */
   layout?: 'horizontal' | 'vertical' | 'grid';
   /** ARIA accessibility attributes */

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -134,6 +134,20 @@ export interface HighlightField {
   type?: DetailViewField['type'];
   /** Optional icon */
   icon?: string;
+  /**
+   * Whether the chip is read-only — no inline-edit affordance, ever.
+   *
+   * Mirrors `DetailViewField.readonly` so the highlights strip and the details
+   * body take the same declaration. The strip's editability gate has always
+   * read this key; it is declared here so it is a typed part of the surface
+   * rather than an `any` cast (objectstack#5077).
+   *
+   * Use it for columns whose value is owned by the platform rather than the
+   * user — hook-maintained rollups, approval-written grades — where marking
+   * the OBJECT field `readonly` is not an option because that would also strip
+   * the hook's own write-back.
+   */
+  readonly?: boolean;
 }
 
 /**


### PR DESCRIPTION
修复 objectstack-ai/objectstack#5077(跨仓,故不用裸 `Fixes #`)。下游追踪:yinlianghui/hotcrm-heimao#61。

**这个 PR 是草稿,且是有意不完整的** —— 见下方"需要维护者决策的两点"。objectui 侧的这一半在任何一种决策下都是必需的,先落地以便决策有具体的东西可依附。

## 问题

详情页表头 chip 由 `record:highlights` 渲染,支持双击行内编辑。`HeaderHighlight` 的可编辑性门 **一直** 读 `field.readonly`:

```ts
const isReadonly = field.readonly === true || objectDefField?.readonly === true;
```

但 `RecordHighlightsRenderer` 的条目归一化把每个条目按固定四键重建:

```ts
typeof f === 'string' ? { name: f } : { name: f?.name, label: f?.label, icon: f?.icon, type: f?.type }
```

`readonly` 在那个检查的 **上一层** 就被丢掉了,所以这个门永远无法从作者写的元数据触发 —— 只有 `schemaField.readonly` 能触发,而那条路对本 issue 的场景是死路:把对象字段标 `readonly` 会连带让跨对象 hook 自己的回写被 `stripReadonlyFields` 剥掉(objectstack-ai/objectstack#2948)。

结果:hook 维护的汇总列(rollup、审批回写的等级)在表头 chip 上可以被任何人手工改掉。实测的破坏是持久的 —— 值一直错到某次不相关的子行改动重新触发 rollup 为止。

## 改动

- `packages/plugin-detail/src/renderers/record-highlights.tsx` —— 归一化时带上 `readonly`。仍然逐键重建而不是展开对象,条目形状保持封闭,未声明的键依旧不会被静默转发。
- `packages/types/src/views.ts` / `record-components.ts` —— 把 `readonly?: boolean` 声明到 `HighlightField` 和 `RecordHighlightsComponentProps.fields[]` 条目联合类型上,与 `DetailViewField.readonly` 对齐。
- `packages/plugin-detail/src/HeaderHighlight.tsx` —— 既然 `readonly` 已是声明键,去掉门里的 `(field as any)` 断言。

`redactFields` / `enforceFieldSecurity` 未动:那两个是**移除** chip,而这里要的是锁定一个"存在的意义就是被看见"的值。

## 与 issue 评论的实测偏差(重要)

2026-08-04 的浏览器实测评论提出的"建议 2"说:可编辑性门解析有效 type 的来源与显示渲染器不同,所以作者写的 `type: 'formula'` 到不了门上。**在 HEAD 上这一条不成立。** 编辑前我先跑了探针测量:

```
resolvedType = field.type || objectDefField?.type   // 门和显示渲染器选择读的是同一个值
```

作者写的 `type: 'formula' | 'summary' | 'rollup' | 'auto_number'` **已经**能正确禁用行内编辑。所以本 PR 里那 8 个 type 相关的用例是**回归钉**(pin tests),不是修复 —— 一旦将来有人再把门和渲染器选择拆成两套 type 解析,它们会立刻失败。

评论里"两个消费者对同一个字段意见不一致"的直觉是对的,只是方向反了:真正的洞是作者写的**显示** type 会 *放宽* 门。已另行归档,见下。

## 需要维护者决策的两点(均已作为未指派 issue 归档)

1. **objectstack-ai/objectstack#5176 —— spec 没有声明 `readonly`。** `RecordHighlightsField` 是恰好 `{name,label?,icon?,type?}` 四键,非 `.strict()`,所以 `RecordHighlightsProps.parse()` 会**静默剥掉** `readonly`(已实测)。今天本 PR 能端到端生效,只是因为 `ComponentPropsMap` 目前在加载路径上没有消费者、`PageComponentSchema.properties` 是 `z.record(z.string(), z.unknown())` 原样透传。协议 15 已经把三个 UI schema 翻成 `.strict()`(ADR-0089 D3a),方向很明确;等 props map 真的接入校验那天,作者写的 `readonly` 要么静默消失(chip 悄悄恢复可编辑,本 issue 的破坏原样回来,且没有任何诊断),要么直接 parse 报错。按 AGENTS.md #0.1,渲染器读一个 spec 未声明的键正是要避免的"宽容消费者"。建议在 spec 声明该键,并同步进 block `inputs` → `sdui.manifest.json`,让 AI 作者读得到。
2. **objectstack-ai/objectui#3355 —— 作者写的显示 `type` 会放宽计算字段的编辑门。** 对象声明 `score: { type: 'formula' }`,作者为了排版写 `{ name: 'score', type: 'number' }`,chip 就变成可编辑(实测)。`DetailSection` 有完全相同的形状,所以要改必须两处一起改,否则又会出现 `fieldEnrichment.ts` 当初就是为了消除的漂移。这正是上游 app 的真实配置(他们为绕过 objectstack-ai/objectstack#5066 给一个 rollup 写了 `type: 'number'`),也就是说实测到的那次数据破坏走的是**这条**路径。建议改成"只收窄不放宽"。

两点都超出本单范围(本单 = 实测评论的建议 1 + 2),故未在此 PR 内修改。

## 验证

```
npx vitest run packages/plugin-detail packages/types --maxWorkers=2
  Test Files  69 passed (69)
       Tests  773 passed (773)

pnpm --filter @object-ui/plugin-detail --filter @object-ui/types run type-check
  packages/types type-check: Done
  packages/plugin-detail type-check: Done

npx eslint <5 个改动文件>
  ✖ 33 problems (0 errors, 33 warnings)     # warning 全部是改动行之外既有的 any/unused
```

新增用例 10 个(`RecordHighlightsRenderer.readonly.test.tsx`),覆盖作者元数据 → chip 的整条路径而非孤立的门。已验证其防回归有效性 —— 临时撤掉归一化里的那一行后:

```
 × renders `{ name, readonly: true }` as NON-editable
 × keeps `readonly` per-entry — one locked chip does not lock its siblings
 Tests  2 failed | 8 passed (10)
```

恰好是依赖修复的 2 个失败,8 个 type 钉用例照常通过 —— 与"建议 2 在 HEAD 上已成立"的测量互相印证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ehu85kbvMcrNTUJjwxvLJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ehu85kbvMcrNTUJjwxvLJ9)_