### PR TITLE
fix(plugin-detail): 声明的展示 `type` 只能收窄内联编辑,永远不得放宽 (#3355)

### DIFF
--- a/.changeset/detail-authored-type-narrow-only-editability.md
+++ b/.changeset/detail-authored-type-narrow-only-editability.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+Behavior change — **an authored display `type` can NARROW inline editability, but never WIDEN it** (objectui#3355).
+
+Both detail-surface editability gates (`HeaderHighlight`, the `record:highlights` strip; `DetailSection`, the details body) used to resolve ONE effective type with display precedence — `viewFieldType || objectFieldType`. An authored non-computed `type` therefore ERASED the object's `formula` / `summary` / `rollup` / `auto_number` declaration from the gate's view, and a machine-owned column became inline-editable.
+
+The gate now reads the two types separately and takes their UNION: a field is non-editable if the authored entry type **or** the object field's type is computed. Renderer/editor selection keeps the old precedence, so nothing about the display changes — only who may write.
+
+What flips:
+
+- `{ name: 'supply_share', type: 'number' }` authored over an object field declared `rollup` (or `formula` / `summary` / `auto_number`) — a display override written to fix formatting — no longer offers a pencil / double-click editor. This is the shipped configuration behind objectstack-ai/objectstack#5077: a hook-maintained rollup was overwritten by hand from the header strip and stayed corrupted until an unrelated child-row touch re-fired it (downstream yinlianghui/hotcrm-heimao#61).
+- Narrowing is unchanged: an authored `type: 'formula'` still locks a plain object column.
+- Fields with no authored computed type over a plain object column stay editable, and the entry-level `readonly` declaration from objectui#3356 is still honored.
+
+The object schema is authoritative about what is machine-computed; a presentation override has no business granting write access. The rule now lives in ONE shared helper, `isComputedFieldType` in `fieldEnrichment.ts` — beside `enrichDetailField`, the module both hosts already share — with the computed-type set moved there too (still re-exported as `TEXTUAL_REF_FALLBACK_TYPES`), so the strip and the body cannot drift apart again.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -33,8 +33,8 @@ import { useDetailTranslation } from './useDetailTranslation';
 import { useSafeFieldLabel } from '@object-ui/react';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
 import { NON_EDITABLE_SYSTEM_FIELDS } from './systemFields';
-import { InlineFieldInput, TEXTUAL_REF_FALLBACK_TYPES } from './InlineFieldInput';
-import { enrichDetailField } from './fieldEnrichment';
+import { InlineFieldInput } from './InlineFieldInput';
+import { enrichDetailField, isComputedFieldType } from './fieldEnrichment';
 
 /**
  * Section-header icon. `fieldGroups[].icon` declares a Lucide name (spec),
@@ -224,8 +224,12 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     // fields explicitly flagged `readonly` are never editable. `onEnterInlineEdit`
     // is only threaded when the record itself is inline-editable, so its presence
     // carries the object-lifecycle + permission gate.
-    const inlineEditType = enrichedField.type || field.type;
-    const isComputedField = TEXTUAL_REF_FALLBACK_TYPES.has(inlineEditType as string);
+    // Read the authored view type and the object type SEPARATELY — the gate is
+    // the UNION of the two, so an authored display `type` (which still drives
+    // renderer/editor selection through `enrichedField.type`) can narrow
+    // editability but never widen it (objectui#3355). Shared with
+    // HeaderHighlight via `isComputedFieldType` so the two can't drift.
+    const isComputedField = isComputedFieldType(field.type, objectDefField?.type);
     // Honor the OBJECT metadata's read-only flag too — the enrichment above
     // intentionally doesn't copy `readonly` into enrichedField, so read it
     // straight off objectDefField (covers formula / non-updateable fields the

--- a/packages/plugin-detail/src/HeaderHighlight.tsx
+++ b/packages/plugin-detail/src/HeaderHighlight.tsx
@@ -19,8 +19,8 @@ import type { HighlightField } from '@object-ui/types';
 import { getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
 import { useSafeFieldLabel, useInlineEdit } from '@object-ui/react';
 import { Check, X, Pencil } from 'lucide-react';
-import { InlineFieldInput, TEXTUAL_REF_FALLBACK_TYPES } from './InlineFieldInput';
-import { enrichDetailField } from './fieldEnrichment';
+import { InlineFieldInput } from './InlineFieldInput';
+import { enrichDetailField, isComputedFieldType } from './fieldEnrichment';
 import { NON_EDITABLE_SYSTEM_FIELDS } from './systemFields';
 import { useDetailTranslation } from './useDetailTranslation';
 
@@ -98,11 +98,17 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
             const draftVal = inline?.draft?.[field.name];
             const value = draftVal !== undefined ? draftVal : rawValue;
 
-            // Field-level editability gate — mirrors DetailSection so the strip
-            // and the body agree on which highlights are editable. Computed
-            // types (formula/summary/rollup/auto_number), `readonly` (view OR
-            // object metadata), and immutable system/audit fields never edit.
-            const isComputed = TEXTUAL_REF_FALLBACK_TYPES.has(resolvedType as string);
+            // Field-level editability gate — shares `isComputedFieldType` with
+            // DetailSection so the strip and the body agree on which highlights
+            // are editable. Computed types (formula/summary/rollup/auto_number),
+            // `readonly` (view OR object metadata), and immutable system/audit
+            // fields never edit.
+            //
+            // The gate takes the authored type and the object type SEPARATELY,
+            // not `resolvedType` — an authored display `type` can narrow
+            // editability but never widen it (objectui#3355). `resolvedType`
+            // keeps its display precedence for renderer selection just below.
+            const isComputed = isComputedFieldType(field.type, objectDefField?.type);
             const isReadonly =
               field.readonly === true || objectDefField?.readonly === true;
             const isSystem = NON_EDITABLE_SYSTEM_FIELDS.has(field.name);

--- a/packages/plugin-detail/src/InlineFieldInput.tsx
+++ b/packages/plugin-detail/src/InlineFieldInput.tsx
@@ -23,16 +23,19 @@ import {
   coerceToSafeValue,
 } from '@object-ui/fields';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
+import { TEXTUAL_REF_FALLBACK_TYPES } from './fieldEnrichment';
 
 /**
  * Field types that carry a `reference_to` for relational metadata but are NOT
  * edited via the lookup picker (they have their own dedicated inputs/renderers).
- * Used so the inline-edit branch doesn't hijack them into a record picker.
+ * Used below so the inline-edit branch doesn't hijack them into a record picker.
  *
- * Exported because `DetailSection`'s per-field editability gate keys off the
- * same set (a computed field is never editable), so the two must not drift.
+ * The set itself moved to `fieldEnrichment` (objectui#3355) — the module both
+ * hosts' editability gates already share — so this renderer fallback and those
+ * gates read the ONE definition of "machine-computed". Re-exported here to keep
+ * the package's public name unchanged.
  */
-export const TEXTUAL_REF_FALLBACK_TYPES = new Set(['formula', 'summary', 'rollup', 'auto_number']);
+export { TEXTUAL_REF_FALLBACK_TYPES };
 
 /**
  * Extract the id a reference widget expects from a value that may already be

--- a/packages/plugin-detail/src/__tests__/inlineEditTypeNarrowing.test.tsx
+++ b/packages/plugin-detail/src/__tests__/inlineEditTypeNarrowing.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3355 — an authored display `type` may NARROW inline-edit, never WIDEN it.
+ *
+ * Both editability gates used to resolve ONE effective type with display
+ * precedence (`viewFieldType || objectFieldType`), so an authored non-computed
+ * type erased the object's `formula` / `summary` / `rollup` / `auto_number`
+ * declaration from the gate's view and handed the user an editor for a
+ * machine-owned column.
+ *
+ * That is the shipped configuration of the app that reported
+ * objectstack-ai/objectstack#5077: `{ name: 'supply_share', type: 'number' }`
+ * — authored purely to fix formatting (objectstack#5066) — over a
+ * hook-maintained ROLLUP. The rollup was overwritten by hand from the header
+ * strip and stayed corrupted until an unrelated child-row touch re-fired it
+ * (downstream yinlianghui/hotcrm-heimao#61).
+ *
+ * The gate is now the UNION of the two types (`isComputedFieldType`), shared by
+ * the highlights strip and the details body so they cannot drift. Renderer
+ * selection keeps the old precedence — nothing about the display changes.
+ */
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider, InlineEditProvider } from '@object-ui/react';
+import type { DetailViewSection } from '@object-ui/types';
+import { RecordHighlightsRenderer } from '../renderers/record-highlights';
+import { DetailSection } from '../DetailSection';
+import { isComputedFieldType } from '../fieldEnrichment';
+
+const COMPUTED_TYPES = ['formula', 'summary', 'rollup', 'auto_number'] as const;
+
+const data = { supply_share: 28.57, owner: 'Alice' };
+
+beforeAll(() => {
+  // Desktop layout — the mobile branch renders its own read-only row shape.
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+});
+
+// ---------------------------------------------------------------------------
+// `record:highlights` — the header strip
+// ---------------------------------------------------------------------------
+
+const renderStrip = (fields: unknown[], objectSchema: Record<string, any>) =>
+  render(
+    <InlineEditProvider canEdit>
+      <RecordContextProvider
+        objectName="crm_account"
+        recordId="A1"
+        data={data}
+        objectSchema={objectSchema}
+      >
+        <RecordHighlightsRenderer schema={{ fields } as any} />
+      </RecordContextProvider>
+    </InlineEditProvider>,
+  );
+
+/**
+ * The chip's inline-edit affordance: the hover pencil button plus the
+ * `cursor-pointer` double-click target — both rendered iff the chip is
+ * editable, so either one answers the question.
+ */
+const hasInlineEditAffordance = (container: HTMLElement) =>
+  screen.queryAllByRole('button').length > 0 ||
+  container.innerHTML.includes('cursor-pointer');
+
+describe('record:highlights — an authored `type` cannot widen editability (#3355)', () => {
+  it("locks the reporter's exact config: `{ name: 'supply_share', type: 'number' }` over a rollup", () => {
+    const { container } = renderStrip([{ name: 'supply_share', type: 'number' }], {
+      fields: { supply_share: { type: 'rollup' } },
+    });
+    expect(hasInlineEditAffordance(container)).toBe(false);
+  });
+
+  it('still renders the value through the authored type — the lock is not a redaction', () => {
+    renderStrip([{ name: 'supply_share', type: 'number' }], {
+      fields: { supply_share: { type: 'rollup' } },
+    });
+    expect(screen.getByText(/28\.57/)).toBeInTheDocument();
+  });
+
+  for (const objectType of COMPUTED_TYPES) {
+    it(`locks an authored \`type: 'number'\` over an object \`${objectType}\` field`, () => {
+      const { container } = renderStrip([{ name: 'supply_share', type: 'number' }], {
+        fields: { supply_share: { type: objectType } },
+      });
+      expect(hasInlineEditAffordance(container)).toBe(false);
+    });
+  }
+
+  it("narrowing still works — authored `type: 'formula'` locks a plain object field", () => {
+    const { container } = renderStrip([{ name: 'supply_share', type: 'formula' }], {
+      fields: { supply_share: { type: 'number' } },
+    });
+    expect(hasInlineEditAffordance(container)).toBe(false);
+  });
+
+  it('leaves an authored non-computed type over a plain field editable (control)', () => {
+    const { container } = renderStrip([{ name: 'supply_share', type: 'number' }], {
+      fields: { supply_share: { type: 'number' } },
+    });
+    expect(hasInlineEditAffordance(container)).toBe(true);
+  });
+
+  it('leaves a bare entry over a plain field editable (control)', () => {
+    const { container } = renderStrip(['owner'], { fields: { owner: { type: 'text' } } });
+    expect(hasInlineEditAffordance(container)).toBe(true);
+  });
+
+  it('still honours an entry-level `readonly: true` (#3356 regression guard)', () => {
+    const { container } = renderStrip(
+      [{ name: 'supply_share', type: 'number', readonly: true }],
+      { fields: { supply_share: { type: 'number' } } },
+    );
+    expect(hasInlineEditAffordance(container)).toBe(false);
+  });
+
+  it('locks only the offending chip — a sibling plain field stays editable', () => {
+    renderStrip(
+      [
+        { name: 'supply_share', type: 'number' },
+        { name: 'owner' },
+      ],
+      { fields: { supply_share: { type: 'rollup' }, owner: { type: 'text' } } },
+    );
+    expect(screen.queryAllByRole('button')).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `DetailSection` — the details body (same gate, second surface)
+// ---------------------------------------------------------------------------
+
+const renderSection = (
+  field: Record<string, any>,
+  objectSchema: Record<string, any>,
+  { isEditing = false }: { isEditing?: boolean } = {},
+) =>
+  render(
+    <DetailSection
+      section={{ fields: [field] } as unknown as DetailViewSection}
+      data={data}
+      objectSchema={objectSchema}
+      isEditing={isEditing}
+      onEnterInlineEdit={vi.fn()}
+    />,
+  );
+
+/** Read mode: the hover pencil is rendered iff the row is inline-editable. */
+const hasPencil = () => screen.queryAllByLabelText('Double-click to edit').length > 0;
+
+describe('DetailSection — an authored `type` cannot widen editability (#3355)', () => {
+  it("locks the reporter's exact config: `{ name: 'supply_share', type: 'number' }` over a rollup", () => {
+    renderSection({ name: 'supply_share', type: 'number' }, {
+      fields: { supply_share: { type: 'rollup' } },
+    });
+    expect(hasPencil()).toBe(false);
+  });
+
+  it('renders no editor for that field even with the section in edit mode', () => {
+    renderSection(
+      { name: 'supply_share', type: 'number' },
+      { fields: { supply_share: { type: 'rollup' } } },
+      { isEditing: true },
+    );
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+    // The value is still shown, formatted by the authored `number` type.
+    expect(screen.getByText(/28\.57/)).toBeInTheDocument();
+  });
+
+  for (const objectType of COMPUTED_TYPES) {
+    it(`locks an authored \`type: 'number'\` over an object \`${objectType}\` field`, () => {
+      renderSection(
+        { name: 'supply_share', type: 'number' },
+        { fields: { supply_share: { type: objectType } } },
+        { isEditing: true },
+      );
+      expect(screen.queryByRole('spinbutton')).toBeNull();
+    });
+  }
+
+  it("narrowing still works — authored `type: 'formula'` locks a plain object field", () => {
+    renderSection(
+      { name: 'owner', type: 'formula' },
+      { fields: { owner: { type: 'text' } } },
+      { isEditing: true },
+    );
+    expect(screen.queryByDisplayValue('Alice')).toBeNull();
+    expect(hasPencil()).toBe(false);
+  });
+
+  it('leaves an authored non-computed type over a plain field editable (control)', () => {
+    renderSection(
+      { name: 'supply_share', type: 'number' },
+      { fields: { supply_share: { type: 'number' } } },
+      { isEditing: true },
+    );
+    expect(screen.getByRole('spinbutton')).toHaveValue(28.57);
+  });
+
+  it('leaves a plain field with no authored type editable (control)', () => {
+    renderSection({ name: 'owner' }, { fields: { owner: { type: 'text' } } });
+    expect(hasPencil()).toBe(true);
+  });
+
+  it('still honours `readonly` on the view field and on the object metadata', () => {
+    renderSection({ name: 'owner', readonly: true }, { fields: { owner: { type: 'text' } } });
+    expect(hasPencil()).toBe(false);
+
+    renderSection({ name: 'owner' }, { fields: { owner: { type: 'text', readonly: true } } });
+    expect(hasPencil()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The shared helper itself — one definition both gates call.
+// ---------------------------------------------------------------------------
+
+describe('isComputedFieldType — union, not precedence (#3355)', () => {
+  it('is true when EITHER side is computed', () => {
+    expect(isComputedFieldType('number', 'rollup')).toBe(true);
+    expect(isComputedFieldType('formula', 'number')).toBe(true);
+    expect(isComputedFieldType(undefined, 'auto_number')).toBe(true);
+    expect(isComputedFieldType('summary', undefined)).toBe(true);
+  });
+
+  it('is false when neither side is computed', () => {
+    expect(isComputedFieldType('number', 'number')).toBe(false);
+    expect(isComputedFieldType(undefined, undefined)).toBe(false);
+    expect(isComputedFieldType('text', null)).toBe(false);
+  });
+});

--- a/packages/plugin-detail/src/fieldEnrichment.ts
+++ b/packages/plugin-detail/src/fieldEnrichment.ts
@@ -7,6 +7,60 @@
  */
 
 /**
+ * Field types the PLATFORM computes — the value is machine-owned and no user
+ * write is legitimate. They carry a `reference_to` for relational metadata but
+ * have no editor of their own.
+ *
+ * One set, three readers, so they cannot drift: `InlineFieldInput` renders them
+ * as text instead of hijacking them into a record picker, and both editability
+ * gates (`DetailSection`, `HeaderHighlight`) treat them as never inline-editable.
+ * It lives beside `enrichDetailField` — deciding whether a column is
+ * machine-computed is part of resolving a detail field's shape out of the view
+ * entry plus the object schema, not the private business of any one component.
+ * Re-exported from `InlineFieldInput` under its historical name.
+ */
+export const TEXTUAL_REF_FALLBACK_TYPES = new Set([
+  'formula',
+  'summary',
+  'rollup',
+  'auto_number',
+]);
+
+/**
+ * Is this field machine-computed, given the type authored on the view entry and
+ * the type declared on the object schema?
+ *
+ * **Narrow-only — the answer is the UNION of the two.** Either type being
+ * computed locks the field. An authored `type` is a DISPLAY override: it picks
+ * the cell renderer and the editor, and that selection keeps its usual
+ * precedence (`viewFieldType || objectFieldType`) everywhere else. It can
+ * therefore only ever *narrow* editability, never widen it.
+ *
+ * Before objectui#3355 both gates resolved a single effective type with that
+ * same display precedence, so an authored non-computed type ERASED the object's
+ * computed declaration from the gate's view. The app that reported
+ * objectstack-ai/objectstack#5077 ships `{ name: 'supply_share', type: 'number' }`
+ * — a display override worked around objectstack#5066 — over a hook-maintained
+ * ROLLUP, and the header chip became inline-editable: a user overwrote the
+ * computed value by hand and it stayed corrupted until an unrelated child-row
+ * touch re-fired the rollup (downstream yinlianghui/hotcrm-heimao#61).
+ *
+ * The object schema is authoritative about what is machine-owned; a
+ * presentation override has no business granting write access. Narrowing still
+ * works — an authored `type: 'formula'` locks a plain object column, which is
+ * how a view declares "this column is computed elsewhere".
+ */
+export function isComputedFieldType(
+  viewFieldType: unknown,
+  objectFieldType: unknown,
+): boolean {
+  return (
+    TEXTUAL_REF_FALLBACK_TYPES.has(viewFieldType as string) ||
+    TEXTUAL_REF_FALLBACK_TYPES.has(objectFieldType as string)
+  );
+}
+
+/**
  * Object-metadata keys carried onto a detail-view field so the read cell and
  * the inline editor see the SAME resolved field shape the object form does.
  *


### PR DESCRIPTION
Fixes #3355

关联:objectstack-ai/objectstack#5077(上游一家的现场)、下游 yinlianghui/hotcrm-heimao#61(被手工覆写的 rollup)、objectui#3356(同一条链上的 `readonly` 修复,已合并)。

## 问题

两个同形的可编辑性门(`HeaderHighlight` 表头高亮条、`DetailSection` 详情正文)此前都把「有效类型」收敛成**一个**值,用的是展示优先级 `viewFieldType || objectFieldType`。于是作者写在视图条目上的**展示** `type` 会**替换**掉对象字段的类型,把对象上 `formula` / `summary` / `rollup` / `auto_number` 的声明从门的视野里**抹掉**,平台维护的列因此变成可内联编辑。

这不是假想:报 objectstack#5077 的那家 app 就是这么发的 —— 为了绕过 objectstack#5066 的展示格式问题,他们在条目上写了 `{ name: 'supply_share', type: 'number' }`,而 `supply_share` 是 hook 维护的 rollup。表头 chip 于是可写,值被手工覆写后一直错着,直到一次无关的子行变更重新触发 rollup 才被纠正。

## 修法(issue 里的 Option A,维护者 2026-08-04 定调)

门改成取两个类型的**并集**:**authored 条目类型 或 对象字段类型**任一为计算类型,即不可编辑。渲染器/编辑器的选择**保持原有优先级不变**,所以展示效果一点不变 —— 变的只是「谁能写」。

规则一句话:**声明的展示 `type` 只能收窄可编辑性,永远不得放宽。** 对象 schema 才是「这一列是否由机器维护」的权威;展示层的覆写没有资格授予写权限。收窄仍然有效 —— 在普通列上写 `type: 'formula'` 依旧能锁死它。

## 共享而非镜像

新增 `isComputedFieldType(viewFieldType, objectFieldType)`,放在 `packages/plugin-detail/src/fieldEnrichment.ts` —— 正是两个宿主已经共享、且当初就是为了阻止这类 drift 而建的模块(issue 正文点名了这一点)。计算类型集合 `TEXTUAL_REF_FALLBACK_TYPES` 一并挪到那里(`InlineFieldInput` 原样 re-export,**包的公开导出名不变**),这样「渲染回退」和「两个可编辑性门」读的是同一份定义,不可能再各修各的。

改动文件:

- `packages/plugin-detail/src/fieldEnrichment.ts` —— 集合 + 新 helper(带完整的来龙去脉注释)。
- `packages/plugin-detail/src/HeaderHighlight.tsx` —— 门改用 helper,传 `field.type` 与 `objectDefField?.type` 两个值;`resolvedType` 仍留给渲染器选择用。
- `packages/plugin-detail/src/DetailSection.tsx` —— 同上,替掉原来塌缩过的 `inlineEditType`。
- `packages/plugin-detail/src/InlineFieldInput.tsx` —— 改为从 `fieldEnrichment` 导入并 re-export 集合。
- `packages/plugin-detail/src/__tests__/inlineEditTypeNarrowing.test.tsx` —— 新增 23 个用例。
- `.changeset/detail-authored-type-narrow-only-editability.md` —— patch,正文写明这是行为变更及规则本身。

## 验证

新测试覆盖两个组件:报告者的原配置(`{ name: 'supply_share', type: 'number' }` 压在 rollup 上,单列一条用例)、四种计算类型的对象字段配 authored `number`、收窄仍生效(普通列上 authored `formula`)、普通列对照组、以及 #3356 的 `readonly` 回归守卫。把 helper 临时改回 #3355 之前的优先级逻辑跑一遍,**23 条中 13 条变红**(两个组件都有),确认它们是真守卫而不是摆设。

```
pnpm exec vitest run packages/plugin-detail/src/__tests__/inlineEditTypeNarrowing.test.tsx
  Test Files  1 passed (1)       Tests  23 passed (23)

pnpm exec vitest run packages/plugin-detail/       (整包)
  Test Files  43 passed (43)     Tests  408 passed (408)

pnpm exec turbo run type-check --filter=@object-ui/plugin-detail
  Tasks: 12 successful, 12 total

pnpm exec turbo run lint --filter=@object-ui/plugin-detail
  0 errors, 683 warnings(全部为既有基线;新增文件只有测试里惯例性的 `as any` 警告)

node scripts/check-changeset-no-major.mjs   ->   No changeset declares a `major` bump.
```

## 兼容性说明

任何今天**依赖**「用展示 `type` 覆写把计算列变成可编辑」的页面,行为会变。issue 作者与我都构造不出这属于合理诉求而非潜在 bug 的场景 —— 这种写入要么被服务端弹回,要么落库并污染数据。需要显式表达「这个 chip 可读不可写」的场景,用 objectui#3356 落地的条目级 `readonly` 键。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ehu85kbvMcrNTUJjwxvLJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ehu85kbvMcrNTUJjwxvLJ9)_