### PR TITLE
fix(plugin-list): gallery cover 按 file 值形状解析,而非把字段值当 URL 字符串

### DIFF
--- a/.changeset/gallery-cover-file-value-shape.md
+++ b/.changeset/gallery-cover-file-value-shape.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-list': patch
+---
+
+Gallery covers now resolve the `coverField` value through its **file value
+shape** instead of assuming the field value *is* a URL string, so an
+ADR-0104-conforming `image` value renders a cover again (objectui#3317).
+
+Since ADR-0104 D3 wave 2 the stored value of a `file`/`image`/`avatar`/
+`video`/`audio` field is an opaque `sys_file` id, which the read path expands
+in place into `{ id, name, size, mimeType, url }`. `ObjectGallery` read the
+value twice — `hasAnyCover` tested `typeof value === 'string'`, and each card
+did `item[coverField] as string` — so against a spec-correct object value the
+cover area collapsed for the whole gallery, and the card underneath it built
+an `<img src="[object Object]">`. The only values that ever rendered were the
+inline `data:` URIs and external links ADR-0104 retired, which is why this
+stayed invisible.
+
+## What changed
+
+- Both reads now share one `resolveCoverUrl`, so the "does anything have a
+  cover?" predicate and the per-card render can no longer disagree — that
+  disagreement is what collapsed the area for records that did have a cover.
+- Shape handling is delegated to `readFileValues` from `@object-ui/fields`,
+  the platform's existing single arbiter of file value shapes, rather than
+  re-derived in the gallery. It accepts the expanded `{ url }` object, a
+  legacy bare URL string (still valid during the dual-mode window), and a
+  still-bare `sys_file` id — which resolves to the stable
+  `/api/v1/storage/files/:id` endpoint instead of reaching `<img src>` as a
+  raw opaque token. A value carrying no resolvable URL yields no cover, which
+  collapses the area rather than emitting a broken `src`.
+- A `multiple` file field's first entry is used as the cover.
+
+The sibling paths that thread `coverField`/`imageField` around
+(`ListView`, `app-shell/ObjectView`, `plugin-view/ObjectView`) pass the field
+**name**, not the value, and needed no change.

--- a/packages/plugin-list/src/ObjectGallery.tsx
+++ b/packages/plugin-list/src/ObjectGallery.tsx
@@ -12,7 +12,7 @@ import { ComponentRegistry, buildExpandFields, getRecordDisplayName } from '@obj
 import { cn, Card, CardContent, NavigationOverlay } from '@object-ui/components';
 import type { GalleryConfig, ViewNavigationConfig, GroupingConfig } from '@object-ui/types';
 import { ChevronRight, ChevronDown } from 'lucide-react';
-import { getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
+import { getCellRenderer, resolveCellRendererType, readFileValues } from '@object-ui/fields';
 
 export interface ObjectGalleryProps {
     schema: {
@@ -187,6 +187,40 @@ const GalleryIconTile: React.FC<{
     );
 };
 
+/**
+ * The cover image URL for one record, whatever shape its file value arrived in.
+ *
+ * ADR-0104 D3 wave 2 made the **stored** value of a `file`/`image`/`avatar`/
+ * `video`/`audio` field an opaque `sys_file` id, which the read path expands
+ * in place into `{ id, name, size, mimeType, url }`. So a spec-correct cover
+ * reaches this component as an **object**, and the old `item[coverField] as
+ * string` read resolved to no usable URL for every conforming record: the only
+ * values that ever rendered a cover were the inline `data:` URIs and external
+ * links ADR-0104 retired (objectui#3317).
+ *
+ * Shape handling is delegated to `readFileValues` — the platform's single
+ * arbiter of file value shapes (`@object-ui/fields`, `widgets/file-value`) —
+ * rather than re-derived here, so the gallery cover, the `image` cell renderer
+ * and the edit-form widgets can never disagree about what a value means. It
+ * accepts the expanded object, a legacy bare URL string (still valid during the
+ * dual-mode window), and a still-bare `sys_file` id, which it resolves to the
+ * stable `/files/:id` download endpoint rather than dropping — a bare reference
+ * is what the read path leaves behind when it did not expand, and that endpoint
+ * is directly usable as an `<img src>`. A value carrying no resolvable URL at
+ * all yields `undefined`, which collapses the cover area instead of emitting a
+ * broken `<img src>`.
+ *
+ * A `multiple` file field arrives as an array; its first entry is the cover.
+ */
+const resolveCoverUrl = (
+    item: Record<string, unknown> | undefined,
+    coverField: string,
+): string | undefined => {
+    const raw = item?.[coverField];
+    if (raw == null || raw === '') return undefined;
+    return readFileValues(raw)[0]?.url;
+};
+
 export const ObjectGallery: React.FC<ObjectGalleryProps> = (props) => {
     const { schema } = props;
     const context = useContext(SchemaRendererContext);
@@ -326,8 +360,12 @@ export const ObjectGallery: React.FC<ObjectGalleryProps> = (props) => {
     // an explicit one but no populated values) render with a giant empty
     // letter-placeholder block that dwarfs the actual content. By collapsing
     // it when there's nothing to show, the cards become information-dense.
+    // Resolved through the very same `resolveCoverUrl` each card renders with:
+    // when this predicate and the per-card read disagree about what counts as a
+    // cover, the area collapses for values that would have rendered fine (the
+    // objectui#3317 failure — a string-only test against an expanded object).
     const hasAnyCover = useMemo(
-        () => items.some((it) => typeof (it as any)[coverField] === 'string' && !!(it as any)[coverField]),
+        () => items.some((it) => !!resolveCoverUrl(it, coverField)),
         [items, coverField],
     );
     // Show the cover area only when at least one record has a non-empty
@@ -449,7 +487,7 @@ export const ObjectGallery: React.FC<ObjectGalleryProps> = (props) => {
                 ? String(item[titleField])
                 : undefined;
         const title = explicitTitle ?? getRecordDisplayName(objectDef, item);
-        const imageUrl = item[coverField] as string | undefined;
+        const imageUrl = resolveCoverUrl(item, coverField);
         const placeholder = pickPlaceholderGradient(String(id) + '|' + title);
 
         const cardClass = cn(

--- a/packages/plugin-list/src/__tests__/ObjectGallery.coverValue.test.tsx
+++ b/packages/plugin-list/src/__tests__/ObjectGallery.coverValue.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Regression test: the gallery cover must be resolved through the file
+ * **value shape**, not by assuming the field value *is* a URL string
+ * (objectui#3317).
+ *
+ * Since ADR-0104 D3 wave 2 a `file`/`image`/`avatar`/`video`/`audio` field
+ * stores an opaque `sys_file` id and the read path expands it in place to
+ * `{ id, name, size, mimeType, url }`. The gallery's two reads —
+ * `hasAnyCover` and the per-card `imageUrl` — both did
+ * `typeof v === 'string'` / `v as string`, so for a spec-correct value the
+ * cover area collapsed for the whole gallery and the card emitted
+ * `<img src="[object Object]">`. The only values that rendered were the
+ * inline `data:` URIs and external links ADR-0104 retired.
+ *
+ * Both reads now share one `resolveCoverUrl`, which delegates to
+ * `readFileValues` from `@object-ui/fields` — the platform's single arbiter
+ * of file value shapes. These tests pin all three shapes plus the
+ * area-collapse regression.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ObjectGallery } from '../ObjectGallery';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+const objectSchema = {
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    cover: { type: 'image', label: 'Cover' },
+  },
+};
+
+const renderGallery = (data: Record<string, unknown>[]) => {
+  const dataSource = {
+    find: vi.fn().mockResolvedValue(data),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+  };
+  return render(
+    <SchemaRendererProvider dataSource={dataSource as any}>
+      <ObjectGallery
+        schema={{
+          objectName: 'showcase_task',
+          gallery: { titleField: 'name', coverField: 'cover' },
+        }}
+      />
+    </SchemaRendererProvider>,
+  );
+};
+
+/**
+ * The cover image a user actually sees.
+ *
+ * `GalleryCover` always mounts its wrapper and toggles the `hidden`
+ * attribute, so "the cover area collapsed" is not the same DOM fact as "no
+ * `<img>` was built" — before the fix the card mounted an `<img>` with a
+ * garbage `src` *inside* the hidden wrapper. Filtering on the `hidden`
+ * ancestor is what makes these assertions describe the rendered result
+ * rather than the component's internal bookkeeping.
+ */
+const visibleCoverImg = (container: HTMLElement): HTMLImageElement | null =>
+  Array.from(container.querySelectorAll('img')).find((el) => !el.closest('[hidden]')) ?? null;
+
+describe('ObjectGallery — coverField value shapes (objectui#3317)', () => {
+  it('renders the cover from the expanded read form ({ url }) — the ADR-0104 shape', async () => {
+    const { container } = renderGallery([
+      {
+        id: 't1',
+        name: 'Task A',
+        cover: {
+          id: 'fileAAA111',
+          name: 'cover.png',
+          size: 2048,
+          mimeType: 'image/png',
+          url: '/api/v1/storage/files/fileAAA111',
+        },
+      },
+    ]);
+    await waitFor(() => expect(screen.getByText('Task A')).toBeInTheDocument());
+
+    const img = await waitFor(() => {
+      const found = visibleCoverImg(container);
+      expect(found).not.toBeNull();
+      return found as HTMLImageElement;
+    });
+    expect(img.getAttribute('src')).toBe('/api/v1/storage/files/fileAAA111');
+    // The old string-only read cast the object straight into `src`.
+    expect(img.getAttribute('src')).not.toBe('[object Object]');
+  });
+
+  it('renders a legacy bare URL string (still valid during the dual-mode window)', async () => {
+    const { container } = renderGallery([
+      { id: 't2', name: 'Task B', cover: 'https://cdn.example.com/b.png' },
+    ]);
+    await waitFor(() => expect(screen.getByText('Task B')).toBeInTheDocument());
+
+    const img = await waitFor(() => {
+      const found = visibleCoverImg(container);
+      expect(found).not.toBeNull();
+      return found as HTMLImageElement;
+    });
+    expect(img.getAttribute('src')).toBe('https://cdn.example.com/b.png');
+  });
+
+  it('resolves an unexpanded `sys_file` id to the stable endpoint instead of a broken src', async () => {
+    // NOTE ON DIRECTION: objectui#3317 suggested treating a bare id as "no
+    // cover". That suggestion predates `@object-ui/fields`'s `file-value`
+    // module, which already decided this platform-wide: a bare reference
+    // resolves to `/api/v1/storage/files/:id`, the stable endpoint that
+    // 302-redirects to a freshly-signed URL and is directly usable as an
+    // `<img src>`. The issue's actual requirement — never emit a broken
+    // `src` — is met strictly better by resolving than by hiding, and
+    // forking a narrower rule here would put the gallery at odds with the
+    // `image` cell renderer and the edit-form widgets reading the same value.
+    const { container } = renderGallery([{ id: 't3', name: 'Task C', cover: 'fileCCC333' }]);
+    await waitFor(() => expect(screen.getByText('Task C')).toBeInTheDocument());
+
+    const img = await waitFor(() => {
+      const found = visibleCoverImg(container);
+      expect(found).not.toBeNull();
+      return found as HTMLImageElement;
+    });
+    expect(img.getAttribute('src')).toBe('/api/v1/storage/files/fileCCC333');
+    // The raw opaque token must never reach `src` — that is the broken src.
+    expect(img.getAttribute('src')).not.toBe('fileCCC333');
+  });
+
+  it('treats a value carrying no resolvable URL as no cover', async () => {
+    // An object with neither `url` nor an id resolves to nothing; the cover
+    // area collapses rather than mounting an `<img>` with a garbage src.
+    const { container } = renderGallery([
+      { id: 't4', name: 'Task D', cover: { name: 'orphan.png' } },
+      { id: 't5', name: 'Task E', cover: null },
+      { id: 't6', name: 'Task F', cover: '' },
+    ]);
+    await waitFor(() => expect(screen.getByText('Task D')).toBeInTheDocument());
+
+    expect(visibleCoverImg(container)).toBeNull();
+    // Nothing anywhere in the gallery may carry the stringified object.
+    expect(container.innerHTML).not.toContain('[object Object]');
+  });
+
+  it('keeps the cover area open when covers are expanded objects (hasAnyCover shares the resolver)', async () => {
+    // The area-collapse regression in its purest form: every populated cover
+    // is an object, so the old `typeof === 'string'` predicate reported
+    // "no covers anywhere" and hid the area for the whole gallery — including
+    // the records that did have one.
+    const { container } = renderGallery([
+      { id: 't7', name: 'Task G', cover: null },
+      {
+        id: 't8',
+        name: 'Task H',
+        cover: { id: 'fileHHH888', name: 'h.png', mimeType: 'image/png', url: '/api/v1/storage/files/fileHHH888' },
+      },
+    ]);
+    await waitFor(() => expect(screen.getByText('Task H')).toBeInTheDocument());
+
+    const img = await waitFor(() => {
+      const found = visibleCoverImg(container);
+      expect(found).not.toBeNull();
+      return found as HTMLImageElement;
+    });
+    expect(img.getAttribute('src')).toBe('/api/v1/storage/files/fileHHH888');
+    // The card without a cover still renders, sharing the now-open area.
+    expect(screen.getByText('Task G')).toBeInTheDocument();
+  });
+
+  it('uses the first entry of a `multiple` file field as the cover', async () => {
+    const { container } = renderGallery([
+      {
+        id: 't9',
+        name: 'Task I',
+        cover: [
+          { id: 'fileIII111', name: 'first.png', mimeType: 'image/png', url: '/api/v1/storage/files/fileIII111' },
+          { id: 'fileIII222', name: 'second.png', mimeType: 'image/png', url: '/api/v1/storage/files/fileIII222' },
+        ],
+      },
+    ]);
+    await waitFor(() => expect(screen.getByText('Task I')).toBeInTheDocument());
+
+    const img = await waitFor(() => {
+      const found = visibleCoverImg(container);
+      expect(found).not.toBeNull();
+      return found as HTMLImageElement;
+    });
+    expect(img.getAttribute('src')).toBe('/api/v1/storage/files/fileIII111');
+  });
+});


### PR DESCRIPTION
Fixes #3317

## 前提核验(对 `origin/main` @ 68b6a28)

Issue 前提成立,行号按 PM 提示核对无误:

- `packages/plugin-list/src/ObjectGallery.tsx:330` — `hasAnyCover` 用 `typeof (it as any)[coverField] === 'string'`
- `packages/plugin-list/src/ObjectGallery.tsx:452` — `const imageUrl = item[coverField] as string | undefined;`

ADR-0104 D3 wave 2 之后,`file`/`image`/`avatar`/`video`/`audio` 字段的**存储**值是不透明的 `sys_file` id,读路径会就地展开成 `{ id, name, size, mimeType, url }`。于是符合规范的值到达客户端时是**对象**:`hasAnyCover` 恒为 `false`,整个画廊的封面区塌陷;而其下的卡片仍会构造出一个 src 属性等于字符串 `[object Object]` 的 img 元素。唯一还能渲染的值,正是 ADR-0104 已经淘汰的内联 `data:` URI 与外链 —— 这也是它长期不可见的原因。

## 改动

两处读取现在共用同一个 `resolveCoverUrl`。「有没有封面」的判定与单卡渲染再也不会各说各话 —— 那种分歧正是让**确实有封面**的记录也一起塌陷的原因。

形状处理**委托**给 `@object-ui/fields` 的 `readFileValues`,而不是在画廊里重新推导一套。

### 落点说明:没有新建共享模块

派单允许在合适的包里抽出共享解析器,但**它已经存在**:`packages/fields/src/widgets/file-value.ts`,经 `packages/fields/src/index.tsx` 的 `export * from './widgets/file-value'` 公开导出,是平台既有的 file 值形状唯一仲裁者(`FileField` / `ImageField` / image cell renderer 都读它)。`plugin-list` 本就 peer-depend `@object-ui/fields`,且 `ObjectGallery.tsx` 本就从中 import —— 依赖方向已经成立,本 PR 只是加了一个 import 名。新造一个平行解析器反而会制造第二套真相。

## ⚠️ 一处与 issue 建议的偏离(请复核)

Issue 建议「把未展开的不透明 id 视为 no cover」。该建议早于 `file-value` 模块,而后者已在平台层面定了调:裸引用解析到稳定端点 `/api/v1/storage/files/:id`,该端点 302 重定向到新签发的短时 URL,可直接作为 img 元素的 src 使用。

Issue 的**真实诉求**是「不要产生坏 src」—— 解析比隐藏更好地满足了它,而且在画廊里 fork 一条更窄的规则,会让画廊与读同一个值的 image cell renderer、编辑态控件互相矛盾。故本 PR **解析**而非隐藏,并把这个方向明确钉进了测试注释。真正的 no-cover 是「值不携带任何可解析 URL」(如只有 `{ name }` 的对象),该用例单独覆盖。

## 测试

新增 `packages/plugin-list/src/__tests__/ObjectGallery.coverValue.test.tsx`(6 例):expanded `{ url }` 对象 / legacy 裸字符串 / 未展开 id → 稳定端点 / 无可解析 URL → 塌陷且不出现 `[object Object]` / `hasAnyCover` 共用解析器的塌陷回归 / `multiple` 取首项。

**反向验证**(先定方向再跑):把两处读取改回字符串假定 —— 预测 5 红 1 绿,实测一致。唯一仍绿的是 legacy 裸字符串,因为那本就是修复前唯一能工作的形态(它是保持性守卫,不是回归捕手)。不透明 id 用例报 `expected 'fileCCC333' to be '/api/v1/storage/files/fileCCC333'`,坐实原始 token 确实曾进入 `src`。

```
Test Files  20 passed (20)
     Tests  290 passed (290)
```

`type-check` 通过;`lint` 0 errors(335 条既有 warning)。

## 兄弟路径:核对后无需改动

`ListView.tsx:1319/1570`、`app-shell/ObjectView.tsx:1547/1548`、`plugin-view/ObjectView.tsx:696` 传递的都是字段**名**,不是字段**值**,不存在同类 string 假定。按规则消费半径也扫了其它包的 fixture(`types` / `react` / `app-shell` 的 gallery 用例),全部是字段名配置 parity,无值形状 fixture。

未触碰 `app-shell/src/views/metadata-admin/**`。
