### PR TITLE
fix(app-shell): flow 设计器不再给 wait 种子写入 spec 17 已退役的 waitEventConfig.onTimeout (#3316)

### DIFF
--- a/.changeset/flow-wait-seed-drops-retired-ontimeout.md
+++ b/.changeset/flow-wait-seed-drops-retired-ontimeout.md
@@ -1,0 +1,42 @@
+---
+"@object-ui/app-shell": patch
+---
+
+The flow designer no longer seeds new `wait` nodes with the retired
+`waitEventConfig.onTimeout` (objectui#3316).
+
+FROM: `defaultNodeExtras('wait')` returned
+`{ waitEventConfig: { eventType: 'timer', onTimeout: 'fail' } }`, and the
+one-click revision loop (`addReviseLoop`) wrote `onTimeout: 'fail'` onto the
+`wait` node it creates. TO: both seed only the event flavor — `{ eventType:
+'timer' }` and `{ eventType: 'signal', signalName: 'revision' }`. The author
+fills in `timerDuration`.
+
+**This is a behaviour fix, not a cleanup.** `waitEventConfig.onTimeout` was
+retired in `@objectstack/spec` 17 (framework#4158) via `retiredKey()`, i.e.
+`z.never().optional()` — it is not a silently-stripped extra but a hard
+`FlowNodeSchema.parse()` error carrying its own prescription ("It had no
+readers at all … Delete the key."). Every `wait` node dragged out of the
+palette, inserted on an edge, or created by the revision-loop button therefore
+carried a key the loader rejects, so publishing a flow the author had merely
+assembled returned 422. The other half of the same retirement had already
+landed here — the label overrides came out of `i18n.ts` and the two fields came
+out of the hand-written node form (`inspectors/flow-node-config.ts`) — but the
+block that *produces* the key was missed.
+
+A new `flow-canvas-seeds.spec-parse.test.tsx` pins the invariant for the next
+retirement: every seeded node shape (all `NODE_PALETTE` types plus `start` /
+`end` / `http_request` / `boundary_event`) is run through the spec's own
+`FlowNodeSchema`, and the revision-loop node is captured from a real button
+click and parsed the same way. Two deliberately different criteria: the strict
+sibling blocks (`waitEventConfig` / `connectorConfig` / `boundaryConfig`) get a
+full-parse verdict plus an explicit `[REMOVED]`-tombstone check that names the
+offending seed key; the `config`-rooted seeds (`approval` / `notify` / `http`)
+— invisible to `FlowNodeSchema`, whose `config` is a permissive record, and
+deliberately partial, since the author still supplies notify's `title` and
+http's `url` — are checked key-level against the spec's published
+`ApprovalNodeConfigSchema` / `NotifyConfigSchema` / `HttpConfigSchema`.
+
+No other `defaultNodeExtras` branch was affected: the remaining seeds
+(`connector_action` / `boundary_event` / `approval` / `notify` / `http` /
+`script` / `start`) were each checked against the spec and are clean.

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowCanvas.tsx
@@ -364,7 +364,9 @@ export function FlowCanvas({
         type: 'wait',
         label: tr('engine.flowCanvas.awaitingRevision', locale),
         // Signal-flavored wait: the submitter's resubmit signal resumes the run.
-        waitEventConfig: { eventType: 'signal', signalName: 'revision', onTimeout: 'fail' },
+        // No `onTimeout` — retired in spec 17 (framework#4158); writing it makes
+        // `FlowNodeSchema.parse()` reject the node this button just created.
+        waitEventConfig: { eventType: 'signal', signalName: 'revision' },
       };
       const existingEdgeIds = edges.map((e) => e.id).filter(Boolean) as string[];
       const reviseId = uniqueId('edge', existingEdgeIds);

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-parts.tsx
@@ -376,13 +376,23 @@ export function defaultNodeLabel(type: string, locale?: string): string {
  * Spec-valid seed fields for a newly created node, so structured blocks start
  * in a valid-ish shape (e.g. a wait node already has a timer eventType) rather
  * than an empty intermediate state. Returns extra node props to spread in.
+ *
+ * Every branch here must survive `FlowNodeSchema.parse()` on the installed
+ * `@objectstack/spec` — a seed the loader rejects makes the designer's own
+ * output unpublishable the moment the author saves. Pinned by
+ * `flow-canvas-seeds.spec-parse.test.tsx` (#3316).
  */
 export function defaultNodeExtras(type: string): Record<string, unknown> {
   switch (type) {
     case 'start':
       return {};
     case 'wait':
-      return { waitEventConfig: { eventType: 'timer', onTimeout: 'fail' } };
+      // No `onTimeout`: retired in spec 17 (framework#4158) as a `retiredKey()`
+      // tombstone, so writing it is a hard `FlowNodeSchema` error, not a
+      // silently-stripped extra. A wait node has no timeout — it resumes when
+      // its timer elapses or its signal arrives. The author fills in
+      // `timerDuration`.
+      return { waitEventConfig: { eventType: 'timer' } };
     case 'connector_action':
       return { connectorConfig: { connectorId: '', actionId: '', input: {} } };
     case 'boundary_event':

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * **Every node shape the flow designer SEEDS must survive the spec's own
+ * loader** (#3316).
+ *
+ * The designer does not only render authored metadata — it *produces* it. Two
+ * places mint a brand-new node before the author has touched anything:
+ *
+ * 1. `defaultNodeExtras()` (`flow-canvas-parts.tsx`), spread into every node
+ *    added from the palette or inserted on an edge (`FlowCanvas` `addNode` /
+ *    `insertOnEdge`).
+ * 2. `addReviseLoop()` (`FlowCanvas.tsx`), the one-click ADR-0044 revision
+ *    loop, which writes its `wait` node inline.
+ *
+ * When a spec property is retired via `retiredKey()` (`z.never().optional()`)
+ * a seed still writing it is not "an extra key that gets stripped" — it is a
+ * hard `FlowNodeSchema.parse()` error, so the designer emits metadata its own
+ * runtime refuses and publish 422s on a flow the author never edited. That is
+ * exactly what `waitEventConfig.onTimeout` did between spec 17 (framework
+ * #4158) and #3316: the label overrides for the retired keys were dropped from
+ * `i18n.ts`, and the hand-written form dropped the fields
+ * (`inspectors/flow-node-config.ts`), but the two *seed* sites kept writing
+ * `onTimeout: 'fail'`.
+ *
+ * This file is the ratchet that makes the NEXT retirement land red here
+ * instead of at publish time. It renders (rather than staying a pure `.test.ts`
+ * in the cheap `unit` project) because the second producer only exists inside
+ * a React callback — and keeping both producers in one file is the point: the
+ * #3316 failure mode was fixing the visible consumer and missing the other.
+ *
+ * **Two criteria, deliberately different** (key-vs-value reachability):
+ *
+ * - The spec-structured sibling blocks (`waitEventConfig` / `connectorConfig` /
+ *   `boundaryConfig`) are strict objects and their seeds are complete, so the
+ *   assertion is full `safeParse` green on the whole node — a *value* verdict.
+ * - The `config`-rooted seeds (`approval` / `notify` / `http`) are invisible to
+ *   `FlowNodeSchema`, whose `config` is a permissive `z.record()`; and they are
+ *   deliberately PARTIAL (an author still supplies notify's `title`, http's
+ *   `url`), so demanding full parse green would assert something the seed never
+ *   promised. Their assertion is therefore key-level: every seeded key must be
+ *   a live, declared key of the spec's published node-config Zod — never a
+ *   `[REMOVED]` tombstone.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import * as Automation from '@objectstack/spec/automation';
+import { FlowCanvas } from './FlowCanvas';
+import { NODE_PALETTE, defaultNodeExtras, defaultNodeLabel } from './flow-canvas-parts';
+
+afterEach(cleanup);
+
+interface ZodIssue {
+  path: PropertyKey[];
+  message: string;
+}
+interface ZodLike {
+  shape?: Record<string, { description?: string } | undefined>;
+  unwrap?: () => ZodLike;
+  safeParse: (value: unknown) => { success: boolean; error?: { issues: ZodIssue[] } };
+}
+
+const spec = Automation as unknown as Record<string, ZodLike | undefined>;
+const FlowNodeSchema = spec.FlowNodeSchema!;
+
+/** Unwrap `.optional()` / `.default()` wrappers down to the object schema. */
+function unwrapped(schema: ZodLike | undefined): ZodLike | undefined {
+  let cur = schema;
+  for (let i = 0; cur && !cur.shape && typeof cur.unwrap === 'function' && i < 5; i++) {
+    cur = cur.unwrap();
+  }
+  return cur;
+}
+
+/**
+ * Keys a Zod object schema declares as LIVE authoring surface. `retiredKey()`
+ * tombstones stay in the shape so their rejection can carry the upgrade
+ * prescription (spec `shared/retired-key.ts` marks them `[REMOVED]`), but they
+ * are not authorable — the same filter `flow-node-config.spec-reconciliation`
+ * uses, for the same reason: counting them would false-pass exactly this drift.
+ */
+function liveKeys(schema: ZodLike | undefined): string[] {
+  const shape = unwrapped(schema)?.shape;
+  expect(shape, 'expected a Zod object schema exposing .shape').toBeDefined();
+  return Object.keys(shape ?? {})
+    .filter((k) => {
+      const description = shape![k]?.description;
+      return !(typeof description === 'string' && description.startsWith('[REMOVED]'));
+    })
+    .sort();
+}
+
+/** Tombstoned (retired) keys of a Zod object schema — never authorable. */
+function retiredKeys(schema: ZodLike | undefined): string[] {
+  const shape = unwrapped(schema)?.shape ?? {};
+  return Object.keys(shape)
+    .filter((k) => {
+      const description = shape[k]?.description;
+      return typeof description === 'string' && description.startsWith('[REMOVED]');
+    })
+    .sort();
+}
+
+/** Readable `safeParse` failure — the spec's own prescription, verbatim. */
+function explain(result: { success: boolean; error?: { issues: ZodIssue[] } }): string {
+  if (result.success) return 'ok';
+  return (result.error?.issues ?? [])
+    .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+    .join('\n');
+}
+
+/**
+ * Node types whose seeds this file covers: everything the palette offers, plus
+ * the `defaultNodeExtras` branches reachable from outside it (`start` / `end`
+ * bootstrap nodes, the `http_request` alias, `boundary_event` attached by the
+ * boundary affordance). Driven off `NODE_PALETTE` so a palette entry added
+ * without a spec-valid seed fails here rather than at publish.
+ */
+const SEEDED_TYPES: string[] = [
+  ...new Set([...NODE_PALETTE.map((p) => p.type), 'start', 'end', 'http_request', 'boundary_event']),
+];
+
+describe('designer node seeds ↔ spec FlowNodeSchema (#3316)', () => {
+  it.each(SEEDED_TYPES)(
+    '`%s`: a freshly added node parses as a spec FlowNode',
+    (type) => {
+      // Exactly what `FlowCanvas.addNode` builds before the author edits it.
+      const node = { id: 'node_1', type, label: defaultNodeLabel(type), ...defaultNodeExtras(type) };
+      const result = FlowNodeSchema.safeParse(node);
+      expect(result.success, `${type} seed rejected by FlowNodeSchema:\n${explain(result)}`).toBe(true);
+    },
+  );
+
+  it('seeds no key the spec has retired in a structured sibling block', () => {
+    // The direct #3316 ratchet, with a message that names the offender: the
+    // next `retiredKey()` on one of these blocks fails HERE, pointing at the
+    // seed, rather than as an opaque `invalid_type: never` at publish time.
+    const BLOCKS = ['waitEventConfig', 'connectorConfig', 'boundaryConfig'] as const;
+    const offenders: string[] = [];
+    for (const type of SEEDED_TYPES) {
+      const extras = defaultNodeExtras(type) as Record<string, unknown>;
+      for (const block of BLOCKS) {
+        const seeded = extras[block];
+        if (!seeded || typeof seeded !== 'object') continue;
+        const retired = retiredKeys(FlowNodeSchema.shape?.[block] as ZodLike | undefined);
+        const live = liveKeys(FlowNodeSchema.shape?.[block] as ZodLike | undefined);
+        for (const key of Object.keys(seeded as Record<string, unknown>)) {
+          if (retired.includes(key)) offenders.push(`${type}.${block}.${key} (retired in spec)`);
+          else if (!live.includes(key)) offenders.push(`${type}.${block}.${key} (not declared by spec)`);
+        }
+      }
+    }
+    expect(offenders, 'designer seeds writing non-authorable keys').toEqual([]);
+  });
+
+  it('`wait` seeds only the timer flavor — no retired timeout keys', () => {
+    // Pinned by name because this is the shape #3316 found in the field: the
+    // wait node has NO timeout (framework#4158), it resumes when its timer
+    // elapses or its signal arrives. `timerDuration` is the author's to fill.
+    expect(defaultNodeExtras('wait')).toEqual({ waitEventConfig: { eventType: 'timer' } });
+  });
+
+  it('the config-rooted seeds write only live keys of the spec node-config Zods', () => {
+    // Key-level, not full-parse: these seeds are deliberately partial (notify
+    // has no `title` yet, http no `url`) and `FlowNodeSchema.config` is a
+    // permissive record that cannot see them at all.
+    const CASES: ReadonlyArray<{ type: string; schema: string }> = [
+      { type: 'approval', schema: 'ApprovalNodeConfigSchema' },
+      { type: 'notify', schema: 'NotifyConfigSchema' },
+      { type: 'http', schema: 'HttpConfigSchema' },
+      { type: 'http_request', schema: 'HttpConfigSchema' },
+    ];
+    for (const { type, schema } of CASES) {
+      const zod = spec[schema];
+      // Feature-detected: a spec that predates the export skips rather than
+      // false-passing (it arms itself on the next `@objectstack/spec` bump).
+      if (!zod) continue;
+      const seeded = Object.keys((defaultNodeExtras(type).config ?? {}) as Record<string, unknown>);
+      expect(seeded.length, `${type}: expected a config-rooted seed`).toBeGreaterThan(0);
+      const live = liveKeys(zod);
+      expect(
+        seeded.filter((k) => !live.includes(k)),
+        `${type}: seeded config keys that ${schema} does not declare as live`,
+      ).toEqual([]);
+    }
+  });
+});
+
+describe('FlowCanvas one-click revision loop ↔ spec FlowNodeSchema (#3316)', () => {
+  it('the wait node the revision-loop button creates parses as a spec FlowNode', () => {
+    const patches: Array<Record<string, unknown>> = [];
+    render(
+      <FlowCanvas
+        nodes={[{ id: 'appr', type: 'approval', label: 'Manager approval' }]}
+        edges={[]}
+        editable
+        designMode
+        selectedId={null}
+        onSelect={() => {}}
+        onPatch={(partial) => patches.push(partial)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add revision loop' }));
+
+    expect(patches, 'the revision-loop button must emit one patch').toHaveLength(1);
+    const nodes = patches[0]!.nodes as Array<Record<string, unknown>>;
+    const waitNode = nodes.find((n) => n.type === 'wait');
+    expect(waitNode, 'the patch must add a wait node').toBeDefined();
+
+    const result = FlowNodeSchema.safeParse(waitNode);
+    expect(
+      result.success,
+      `revision-loop wait node rejected by FlowNodeSchema:\n${explain(result)}`,
+    ).toBe(true);
+    // The signal flavor is the point of the affordance — assert it survived.
+    expect(waitNode!.waitEventConfig).toEqual({ eventType: 'signal', signalName: 'revision' });
+  });
+});


### PR DESCRIPTION
Fixes #3316

## 前提核验(origin/main @ 68b6a28)

议题正文的两处快照已随 #3294 漂移,故一律以 `origin/main` 为准复核,**前提成立**:

- `previews/flow-canvas-parts.tsx:385` `defaultNodeExtras('wait')` 仍返回 `{ eventType: 'timer', onTimeout: 'fail' }`;
- `previews/FlowCanvas.tsx:367`(一键退回修订环)现为 `{ eventType: 'signal', signalName: 'revision', onTimeout: 'fail' }` —— 与正文快照不同,但**同样带着 `onTimeout`**。

对本仓 pin 的 `@objectstack/spec@17.0.0-rc.2` 实测,`waitEventConfig.onTimeout` 确为 `retiredKey()` 墓碑(即 `z.never().optional()`),不是被静默剥离而是 `FlowNodeSchema.parse()` 的硬错误:

```
current seed  { eventType: 'timer', onTimeout: 'fail' }                         -> REJECTED
  waitEventConfig.onTimeout: `waitEventConfig.onTimeout` was removed in
  @objectstack/spec 17 (#4158). It had no readers at all … Delete the key.
proposed seed { eventType: 'timer' }                                            -> ACCEPTED
revise seed   { eventType: 'signal', signalName: 'revision', onTimeout: 'fail' } -> REJECTED
revise fixed  { eventType: 'signal', signalName: 'revision' }                    -> ACCEPTED
```

即:设计器**自己产出的形状**过不了 spec 的加载校验 —— 作者只是从面板拖出一个 wait 节点、或点一次「添加退回修订环」,尚未编辑任何字段,保存/发布即 422。

## 改动

1. `defaultNodeExtras('wait')` 改为 `{ waitEventConfig: { eventType: 'timer' } }`(`timerDuration` 由作者填,表单里已是 text 字段)。
2. `FlowCanvas.addReviseLoop` 的 wait 节点改为 `{ eventType: 'signal', signalName: 'revision' }`。
3. 新增防回归测试 `previews/flow-canvas-seeds.spec-parse.test.tsx`。

同一次退役的另外两个消费点在本仓**早已跟上**(`i18n.ts:3519` 删了标签覆盖、`inspectors/flow-node-config.ts:766` 删了表单字段),漏的正是**产出**这个键的那一块 —— 本 PR 补齐的就是这一半。

## 防回归测试的两条判据(刻意不同)

- **严格兄弟块**(`waitEventConfig` / `connectorConfig` / `boundaryConfig`):种子形状完整,判据是整节点 `FlowNodeSchema.safeParse` 全绿(值判定);另加一条按名点名的 `[REMOVED]` 墓碑断言,让下一次退役**直接报出是哪个种子写了哪个键**,而不是抛一个 `invalid_type: never`。
- **`config` 根的种子**(`approval` / `notify` / `http`):`FlowNodeSchema.config` 是宽松的 `z.record()`,根本看不见它们;且这些种子**故意是残缺的**(notify 的 `title`、http 的 `url` 留给作者填),要求整解析全绿等于断言一件种子从未承诺的事。故判据下沉到键级 —— 每个种子键必须是 spec 已发布的 `ApprovalNodeConfigSchema` / `NotifyConfigSchema` / `HttpConfigSchema` 的**在生键**(非墓碑)。

覆盖面按**生产者**而非文件划:`NODE_PALETTE` 全部类型 + `start` / `end` / `http_request` / `boundary_event`,加上从**真实按钮点击**捕获的退回修订环节点(该节点写在 React 回调里,没有可直接调用的导出;两个生产者放同一文件正是因为 #3316 的失效形状就是「只改了看得见的那个」)。

## 议题建议第 3 点的核验结论:无第二例

`defaultNodeExtras` 其余分支逐一对 spec 跑过,**均通过**,没有第二个退役键,因此无 out-of-scope finding:

```
start OK · connector_action OK · boundary_event OK · approval OK
notify OK · http OK · http_request OK · script OK · wait FAIL(本 PR 修)
```

顺带核实:议题建议第 1 点括注「`timerDuration` 接受裸数字作为毫秒」在本仓 pin 的 spec 下,该字段类型是 `z.string()`,裸数字 `60000` 被拒、字符串 `'60000'` 通过 —— 与 `flow-node-config.ts` 注释里「`timeoutMs: 60000` 与 `timerDuration: '60000'` 是同一个 wait」一致。本 PR 不种 `timerDuration`,不受影响,记录于此以免下一位读者踩空。

## 验证

**反向验证(先定方向再跑)。** 预判:把 `onTimeout: 'fail'` 原样塞回两个种子点,应是**标准红向** —— 墓碑键按「是否存在」直接判定,不经 `??` 链,故既非计数翻转也非反转。实跑与预判一致,4 条红,每条都点名了 offender:

```
× `wait`: a freshly added node parses as a spec FlowNode
    waitEventConfig.onTimeout: `waitEventConfig.onTimeout` was removed in
    @objectstack/spec 17 (#4158) … Delete the key.
× seeds no key the spec has retired in a structured sibling block
    + "wait.waitEventConfig.onTimeout (retired in spec)"
× `wait` seeds only the timer flavor — no retired timeout keys
    +     "onTimeout": "fail",
× the wait node the revision-loop button creates parses as a spec FlowNode
Tests  4 failed | 21 passed (25)
```

恢复修复后复绿(输出里可见文件名,确认新测试真的跑了,规避 #3288 的静默路径过滤):

```
✓ |dom| …/previews/flow-canvas-seeds.spec-parse.test.tsx  (25 tests)
Test Files  1 passed (1)        Tests  25 passed (25)

vitest run packages/app-shell
Test Files  275 passed (275)    Tests  2406 passed | 1 skipped (2407)

pnpm --filter @object-ui/app-shell type-check  -> exit 0
pnpm --filter @object-ui/app-shell lint        -> 0 errors(2160 warnings,仓库既有基线,与 #3360 记录的数字一致)
node scripts/check-changeset-no-major.mjs      -> No changeset declares a `major` bump.
```

**消费半径扫描**:全仓(含 e2e / examples / apps)grep `onTimeout`,除注释与 CHANGELOG 外无任何 fixture 仍拼写该键 —— `apps/console/src/preview-samples.ts` 早已删除它,并有 `preview-samples-spec-valid.test.ts` 按任意深度封禁退役键。无陈旧 fixture 需要改口。

已含 changeset(`@object-ui/app-shell` patch)。未触碰 `content/docs/releases/`。文件面严格限于议题划定范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_