### PR TITLE
fix(console): settings 客户端跟进 framework#3843 响应信封,配置板块整体恢复 (#3366)

### DIFF
--- a/.changeset/settings-client-reads-response-envelope.md
+++ b/.changeset/settings-client-reads-response-envelope.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/console': patch
+---
+
+Settings pages read the declared `{ success, data }` response envelope, so the
+whole Setup → Configuration section works again against a framework#3843 server
+(objectui#3366).
+
+`service-settings` moved all five `/api/settings` responses into the platform
+envelope and its changelog named the cost for callers that do not go through
+`@objectstack/client`: "Raw `fetch` callers must add one hop: `body.data`." The
+console's settings client is one of those callers and never took the hop, so on
+17.0.0-rc.3 it handed the envelope to the views:
+
+- every namespace page (localization, company, branding, auth, mail, sms,
+  storage, AI, knowledge base, feature flags, data lifecycle) hit
+  `Object.entries(payload.values)` on an object with no `values`, threw
+  `Cannot convert undefined or null to object`, and went to the error boundary;
+- the "All settings" hub read `manifests` off the envelope, got `undefined`,
+  and rendered "no settings are registered" while the server was answering 11
+  manifests — a soft failure that reads as a plugin bug;
+- a save's read-back merged nothing, leaving stale values under a success toast;
+- an action's verdict was not where the client looked, so its `message` and
+  `severity` were dropped and the toast read the bare HTTP status text.
+
+## What changed
+
+- `jsonOrThrow` unwraps the envelope with the exact predicate
+  `ObjectStackClient.unwrapResponse` uses — `success` is a boolean **and**
+  `data` is present. Requiring both is what keeps error envelopes
+  (`{ success: false, error }`) intact, so `err.payload.error` still feeds the
+  locked-key and per-field-rejection rendering from objectstack#4224. A body
+  with no boolean `success` is a pre-#3843 server and passes through untouched.
+- The action endpoint reads its verdict from the success envelope's `data`, and
+  on the reported-failure arm from `error.details`, where the route deliberately
+  parks the whole result so `message` / `severity` / `details` survive the 400.
+- Each endpoint now asserts the shape it promises and throws a named
+  `Malformed response from …` error instead of passing a wrong-shaped body on.
+  Both symptoms above were an unreadable body travelling onward as if it were
+  right; the views already have an error state, and a named error renders there.

--- a/apps/console/src/pages/settings/__tests__/SettingsView.envelope.test.tsx
+++ b/apps/console/src/pages/settings/__tests__/SettingsView.envelope.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The two screens objectui#3366 took down, driven end to end over a stubbed
+ * `fetch` — the REAL `./api` module, not a mock of it.
+ *
+ * The unit tests next door (`../api.envelope.test.ts`) pin the unwrap itself.
+ * This file exists because the unwrap is only interesting for what it stops
+ * happening on screen, and both symptoms were screen-level:
+ *
+ *   - `SettingsView` — `Object.entries(payload.values)` on an envelope threw
+ *     "Cannot convert undefined or null to object" out of a `useMemo`, which
+ *     the error boundary turned into a blank page for all 11 namespaces.
+ *   - `SettingsHub` — the same wrong body flowed through `r.manifests ?? []`
+ *     and rendered the empty state, telling an admin that no plugin had
+ *     registered any settings while the server was answering 11 manifests.
+ *
+ * Mocking `./api` would assert nothing about either: the bug WAS `./api`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { SettingsView } from '../SettingsView';
+import { SettingsHub } from '../SettingsHub';
+
+/** The `/api/settings/localization` payload, as the service produces it. */
+const LOCALIZATION = {
+  manifest: {
+    namespace: 'localization',
+    version: 1,
+    label: 'Localization',
+    description: 'Language, timezone and formats.',
+    specifiers: [
+      { type: 'text', key: 'timezone', label: 'Timezone', description: 'IANA zone id.' },
+      { type: 'text', key: 'language', label: 'Language' },
+    ],
+  },
+  values: {
+    timezone: { value: 'Asia/Shanghai', source: 'env', locked: true, lockedReason: 'locked-by-env' },
+    language: { value: 'zh-CN', source: 'default', locked: false },
+  },
+};
+
+const MANIFESTS = [
+  { namespace: 'localization', version: 1, label: 'Localization', category: 'Platform', specifiers: [] },
+  { namespace: 'branding', version: 1, label: 'Branding', category: 'Platform', specifiers: [] },
+];
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function ok(body: unknown): Response {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => body } as unknown as Response;
+}
+
+function renderView() {
+  return render(
+    <MemoryRouter initialEntries={['/settings/localization']}>
+      <Routes>
+        <Route path="/settings/:namespace" element={<SettingsView />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('SettingsView against a framework#3843 server', () => {
+  it('renders the namespace instead of throwing out of the values useMemo', async () => {
+    fetchMock.mockResolvedValue(ok({ success: true, data: LOCALIZATION }));
+    renderView();
+
+    // The page itself, and both fields with their resolved values.
+    expect(await screen.findByText('Localization')).toBeTruthy();
+    expect(screen.getByText('Timezone')).toBeTruthy();
+    expect(screen.getByDisplayValue('Asia/Shanghai')).toBeTruthy();
+    expect(screen.getByDisplayValue('zh-CN')).toBeTruthy();
+
+    // Provenance survives the hop too — `source: 'env'` is why this one is locked.
+    expect((screen.getByDisplayValue('Asia/Shanghai') as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it('renders the same page from a pre-#3843 server answering the bare payload', async () => {
+    fetchMock.mockResolvedValue(ok(LOCALIZATION));
+    renderView();
+    expect(await screen.findByText('Localization')).toBeTruthy();
+    expect(screen.getByDisplayValue('Asia/Shanghai')).toBeTruthy();
+  });
+
+  it('shows a readable error card when the body is a shape it cannot read', async () => {
+    // Not a white screen and not a wrong page: the view has an error state, and
+    // the client now fails into it by name rather than crashing the render.
+    fetchMock.mockResolvedValue(ok({ success: true }));
+    renderView();
+    expect(await screen.findByText(/Malformed response from GET \/api\/settings\/localization/)).toBeTruthy();
+  });
+});
+
+describe('SettingsHub against a framework#3843 server', () => {
+  it('lists the registered manifests instead of the "nothing is registered" empty state', async () => {
+    fetchMock.mockResolvedValue(ok({ success: true, data: { manifests: MANIFESTS } }));
+    render(
+      <MemoryRouter>
+        <SettingsHub />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Localization')).toBeTruthy();
+    expect(screen.getByText('Branding')).toBeTruthy();
+    // The empty-state copy that sent readers hunting a plugin registration bug.
+    expect(screen.queryByText(/console\.settingsHub\.empty/)).toBeNull();
+  });
+
+  it('a genuinely empty registry still renders the empty state', async () => {
+    // The fix must not turn "no manifests" into an error — only "unreadable body" is one.
+    fetchMock.mockResolvedValue(ok({ success: true, data: { manifests: [] } }));
+    render(
+      <MemoryRouter>
+        <SettingsHub />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.queryByText(/console\.settingsHub\.empty/)).toBeTruthy());
+  });
+});

--- a/apps/console/src/pages/settings/api.envelope.test.ts
+++ b/apps/console/src/pages/settings/api.envelope.test.ts
@@ -1,0 +1,303 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The settings client reads the declared response envelope (objectui#3366 /
+ * framework#3843).
+ *
+ * What this closes: `settings-routes.ts` moved all five `/api/settings`
+ * responses into `{ success, data }` and said what that costs raw `fetch`
+ * callers — "must add one hop: `body.data`". This module is a raw `fetch`
+ * caller and never took the hop, so on 17.0.0-rc.3 every namespace page handed
+ * the ENVELOPE to the view: `Object.entries(payload.values)` on an object with
+ * no `values` threw "Cannot convert undefined or null to object" and the whole
+ * page went to the error boundary. The hub failed more quietly and worse — its
+ * `r.manifests ?? []` turned the same mistake into "no settings are
+ * registered", which reads as a plugin bug rather than a client one.
+ *
+ * The bodies below are the real wire shapes of both generations, not tuned
+ * fixtures: the enveloped ones are what a #3843 server sends (the namespace one
+ * is quoted from the issue's rc.3 capture), the bare ones are what a server
+ * from before it sent. Both are asserted because the console ships as a
+ * versioned asset that outlives any single server build — and because a compat
+ * branch no test exercises is the branch someone deletes without knowing which
+ * server it was carrying.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getSettingsNamespace,
+  listSettingsManifests,
+  runSettingsAction,
+  saveSettingsNamespace,
+} from './api';
+
+/** A `Response` double — only the three members this client touches. */
+function jsonResponse(body: unknown, status = 200, statusText?: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: statusText ?? (status === 200 ? 'OK' : 'Bad Request'),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** A body that is not JSON at all — `res.json()` rejects. */
+function brokenResponse(status = 502, statusText = 'Bad Gateway'): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: async () => {
+      throw new SyntaxError('Unexpected token < in JSON at position 0');
+    },
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** The manifest list, as `service.listManifests` produces it. */
+const MANIFESTS = [
+  { namespace: 'localization', version: 1, label: 'Localization', specifiers: [] },
+  { namespace: 'branding', version: 1, label: 'Branding', specifiers: [] },
+];
+
+/** `GET /api/settings/localization` on rc.3, quoted from the issue. */
+const NAMESPACE_PAYLOAD = {
+  manifest: {
+    namespace: 'localization',
+    version: 1,
+    label: 'Localization',
+    specifiers: [{ type: 'select', key: 'timezone', label: 'Timezone' }],
+  },
+  values: {
+    timezone: { value: 'Asia/Shanghai', source: 'env', locked: true, lockedReason: 'locked-by-env' },
+  },
+};
+
+describe('GET /api/settings — the hub', () => {
+  it('unwraps the #3843 envelope, so the list is the manifests and not a fake empty state', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: { manifests: MANIFESTS } }));
+    const res = await listSettingsManifests();
+    // The exact read `SettingsHub` performs — `r.manifests ?? []` is what
+    // silently produced "no settings are registered" against the envelope.
+    expect(res.manifests).toHaveLength(2);
+    expect(res.manifests.map((m) => m.namespace)).toEqual(['localization', 'branding']);
+  });
+
+  it('still reads a pre-#3843 server answering the bare body', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ manifests: MANIFESTS }));
+    expect((await listSettingsManifests()).manifests).toHaveLength(2);
+  });
+
+  it('an empty registry is an empty list, not an error', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: { manifests: [] } }));
+    expect((await listSettingsManifests()).manifests).toEqual([]);
+  });
+
+  it('names a body it cannot read instead of degrading into "nothing is registered"', async () => {
+    // A 200 with neither shape — e.g. a third envelope generation, or a proxy
+    // answering something else entirely. The hub renders `err.message`.
+    fetchMock.mockResolvedValue(jsonResponse({ success: true }));
+    await expect(listSettingsManifests()).rejects.toThrow(/Malformed response from GET \/api\/settings.*manifests/);
+  });
+});
+
+describe('GET /api/settings/:namespace — the page that white-screened', () => {
+  it('unwraps the envelope, so the view gets `manifest` + `values`', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: NAMESPACE_PAYLOAD }));
+    const payload = await getSettingsNamespace('localization');
+    expect(payload.manifest.namespace).toBe('localization');
+    // The read that threw: `Object.entries(payload.values)` in SettingsView.
+    expect(() => Object.entries(payload.values)).not.toThrow();
+    expect(payload.values.timezone.value).toBe('Asia/Shanghai');
+    expect(payload.values.timezone.locked).toBe(true);
+  });
+
+  it('still reads a pre-#3843 server answering the bare payload', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(NAMESPACE_PAYLOAD));
+    const payload = await getSettingsNamespace('localization');
+    expect(payload.values.timezone.source).toBe('env');
+  });
+
+  it('encodes the namespace into the URL it asks for', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: NAMESPACE_PAYLOAD }));
+    await getSettingsNamespace('data lifecycle');
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/api/settings/data%20lifecycle');
+  });
+
+  it('rejects a shape it cannot read by name, rather than letting the view crash on it', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true }));
+    await expect(getSettingsNamespace('localization')).rejects.toThrow(
+      /Malformed response from GET \/api\/settings\/localization.*`manifest`, `values`/,
+    );
+  });
+});
+
+describe('PUT /api/settings/:namespace — the save read-back', () => {
+  const WRITTEN = { timezone: { value: 'UTC', source: 'tenant', locked: false } };
+
+  it('unwraps the envelope, so the saved values merge into the view', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ success: true, data: { values: WRITTEN } }));
+    const res = await saveSettingsNamespace('localization', { timezone: 'UTC' });
+    // `SettingsView` does `{ ...values, ...res.values }`; against the envelope
+    // that spread nothing and left the old value on screen under a success toast.
+    expect(res.values.timezone.value).toBe('UTC');
+  });
+
+  it('still reads a pre-#3843 server answering the bare `{ values }`', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ values: WRITTEN }));
+    expect((await saveSettingsNamespace('localization', { timezone: 'UTC' })).values.timezone.source).toBe('tenant');
+  });
+});
+
+describe('error responses are not unwrapped — `err.payload` keeps the envelope', () => {
+  /**
+   * A failure envelope carries a boolean `success` but no `data`, which is
+   * exactly why the predicate requires BOTH. Unwrapping it would have handed
+   * `undefined` to the view's `err.payload?.error` reads and quietly undone
+   * objectstack#4224's per-field rendering.
+   */
+  it('a 400 SETTINGS_VALIDATION keeps `error.details.fields` reachable', async () => {
+    const wire = {
+      success: false,
+      error: {
+        code: 'SETTINGS_VALIDATION',
+        message: "Settings for 'ai' are incomplete: gateway_model — …",
+        details: {
+          namespace: 'ai',
+          fields: [{ field: 'gateway_model', code: 'invalid_format', message: 'Use provider/model.' }],
+        },
+      },
+    };
+    fetchMock.mockResolvedValue(jsonResponse(wire, 400));
+
+    const err = await saveSettingsNamespace('ai', { gateway_model: 'gpt4o' }).then(
+      () => null,
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err.status).toBe(400);
+    expect(err.message).toContain('are incomplete');
+    // The whole body, envelope and all — this is what `extractFieldErrors` and
+    // `lockedKeyOf` are handed via `err.payload.error`.
+    expect(err.payload).toEqual(wire);
+    expect(err.payload.error.details.fields[0].field).toBe('gateway_model');
+  });
+
+  it('a 409 SETTINGS_LOCKED keeps the locked key where `lockedKeyOf` reads it', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          success: false,
+          error: {
+            code: 'SETTINGS_LOCKED',
+            message: "Setting 'branding.workspace_name' is locked (locked-by-env).",
+            details: { namespace: 'branding', key: 'workspace_name', reason: 'locked-by-env' },
+          },
+        },
+        409,
+        'Conflict',
+      ),
+    );
+    const err = await saveSettingsNamespace('branding', { workspace_name: 'X' }).then(
+      () => null,
+      (e) => e,
+    );
+    expect(err.status).toBe(409);
+    expect(err.payload.error.details.key).toBe('workspace_name');
+  });
+
+  it('a 404 UNKNOWN_NAMESPACE surfaces the server sentence, not "Not Found"', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { success: false, error: { code: 'UNKNOWN_NAMESPACE', message: "Unknown settings namespace 'nope'." } },
+        404,
+        'Not Found',
+      ),
+    );
+    await expect(getSettingsNamespace('nope')).rejects.toThrow("Unknown settings namespace 'nope'.");
+  });
+
+  it('falls back to the status text when the error body is not JSON', async () => {
+    fetchMock.mockResolvedValue(brokenResponse());
+    const err = await listSettingsManifests().then(
+      () => null,
+      (e) => e,
+    );
+    expect(err.message).toBe('Bad Gateway');
+    expect(err.status).toBe(502);
+  });
+});
+
+describe('POST /api/settings/:namespace/:actionId — the action verdict', () => {
+  it('reads the message out of the success envelope instead of losing it', async () => {
+    // Pre-fix this fell through to `{ ok: res.ok, message: statusText }`: the
+    // action ran, and the console said "OK" where the server had said what happened.
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: { ok: true, message: 'Test email sent to admin@objectos.ai.', severity: 'success' },
+      }),
+    );
+    const result = await runSettingsAction('email', 'send_test');
+    expect(result).toEqual({ ok: true, message: 'Test email sent to admin@objectos.ai.', severity: 'success' });
+  });
+
+  it('reads a reported failure out of `error.details`, keeping message and severity', async () => {
+    // The route parks the whole SettingsActionResult there precisely so these survive the 400.
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        {
+          success: false,
+          error: {
+            code: 'SETTINGS_ACTION_FAILED',
+            message: 'SMTP connection refused',
+            details: { ok: false, message: 'SMTP connection refused', severity: 'error', details: { port: 587 } },
+          },
+        },
+        400,
+      ),
+    );
+    const result = await runSettingsAction('email', 'send_test');
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe('SMTP connection refused');
+    expect(result.severity).toBe('error');
+    expect(result.details).toEqual({ port: 587 });
+  });
+
+  it('still reads a pre-#3843 server answering the bare result on both arms', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ ok: true, message: 'Sent.' }));
+    expect(await runSettingsAction('email', 'send_test')).toEqual({ ok: true, message: 'Sent.' });
+
+    fetchMock.mockResolvedValue(jsonResponse({ ok: false, message: 'Refused.' }, 400));
+    expect(await runSettingsAction('email', 'send_test')).toEqual({ ok: false, message: 'Refused.' });
+  });
+
+  it('a crash carries the server message with ok:false — there is no verdict to read', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { success: false, error: { code: 'INTERNAL_ERROR', message: 'Action failed' } },
+        500,
+        'Internal Server Error',
+      ),
+    );
+    expect(await runSettingsAction('email', 'send_test')).toEqual({ ok: false, message: 'Action failed' });
+  });
+
+  it('falls back to the status text when the body is not JSON', async () => {
+    fetchMock.mockResolvedValue(brokenResponse(504, 'Gateway Timeout'));
+    expect(await runSettingsAction('email', 'send_test')).toEqual({ ok: false, message: 'Gateway Timeout' });
+  });
+});

--- a/apps/console/src/pages/settings/api.ts
+++ b/apps/console/src/pages/settings/api.ts
@@ -12,15 +12,90 @@ import type {
 const SERVER_URL = (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, '');
 const BASE = `${SERVER_URL}/api/settings`;
 
+/**
+ * Unwrap the platform's declared success envelope, `{ success, data }`
+ * (framework#3843).
+ *
+ * All five `/api/settings` responses moved into that envelope when
+ * `settings-routes.ts` adopted `sendOk`/`sendError`; its changelog spelled out
+ * the consequence for callers that do not go through `@objectstack/client`:
+ * "Raw `fetch` callers must add one hop: `body.data`." This module is one of
+ * those callers and did not take the hop, so every namespace page read the
+ * envelope itself as the payload (objectui#3366).
+ *
+ * The predicate is character-for-character the one `ObjectStackClient
+ * .unwrapResponse` applies (`framework/packages/client/src/index.ts`), and it
+ * matters that it is that one and not something looser:
+ *
+ * - `'data' in body` is what keeps an ERROR envelope out of here. A failure is
+ *   `{ success: false, error: {…} }` — `success` is a boolean, but there is no
+ *   `data`, so the body is handed back whole and `jsonOrThrow` can still read
+ *   `error.message` / park the body on `err.payload` for `lockedKeyOf` and
+ *   `extractFieldErrors`.
+ * - A body WITHOUT a boolean `success` is a pre-#3843 server answering the bare
+ *   payload; it passes through untouched. The console ships as a versioned
+ *   asset that outlives any single server build, which is why both generations
+ *   are read rather than the old one being declared gone. Drop the passthrough
+ *   once the oldest supported server carries #3843 — the tests below name that
+ *   branch explicitly so deleting it is a red test, not a silent regression.
+ *
+ * This is deliberately a local copy rather than an import: the console talks to
+ * `/api/settings` with raw `fetch` and does not construct an `ObjectStackClient`,
+ * and `unwrapResponse` is private to it.
+ */
+function unwrapEnvelope(body: unknown): unknown {
+  if (
+    body !== null &&
+    typeof body === 'object' &&
+    typeof (body as { success?: unknown }).success === 'boolean' &&
+    'data' in body
+  ) {
+    return (body as { data: unknown }).data;
+  }
+  return body;
+}
+
+/**
+ * Fail loudly when the unwrapped body is not the shape this endpoint promises.
+ *
+ * Both symptoms of objectui#3366 came from a wrong-shaped body travelling
+ * onward as if it were right: `Object.entries(payload.values)` on the envelope
+ * threw `Cannot convert undefined or null to object` and the whole page went to
+ * the error boundary, while the hub's `r.manifests ?? []` turned the same
+ * mistake into "no settings are registered" — a lie that sends the reader off
+ * hunting a plugin bug. A named error at the boundary is both diagnosable and
+ * renderable: `SettingsView` and `SettingsHub` already have an error state.
+ *
+ * This is a strict check on the contract, not tolerance for a third shape: it
+ * accepts what #3843 declares and what the pre-#3843 server sent, and rejects
+ * everything else by name instead of guessing.
+ */
+function assertShape<T>(value: unknown, keys: Array<keyof T & string>, what: string): T {
+  const bag = value as Record<string, unknown> | null | undefined;
+  const missing = keys.filter(
+    (key) => !(bag && typeof bag === 'object') || bag[key] === null || bag[key] === undefined,
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Malformed response from ${what}: expected an object carrying ${missing
+        .map((key) => `\`${key}\``)
+        .join(', ')}.`,
+    );
+  }
+  return value as T;
+}
+
 async function jsonOrThrow<T>(res: Response): Promise<T> {
   if (!res.ok) {
     const detail = await res.json().catch(() => ({ error: { message: res.statusText } }));
     const err = new Error(detail?.error?.message ?? res.statusText) as Error & { status?: number; payload?: any };
     err.status = res.status;
+    // The raw body, NOT unwrapped: `err.payload.error` is what the view reads
+    // for the locked key and the per-field rejections (objectstack#4224).
     err.payload = detail;
     throw err;
   }
-  return res.json() as Promise<T>;
+  return unwrapEnvelope(await res.json()) as T;
 }
 
 const jsonHeaders = (): HeadersInit => ({
@@ -59,7 +134,8 @@ export function lockedKeyOf(apiError: unknown): string | undefined {
 
 export async function listSettingsManifests(): Promise<SettingsListResponse> {
   const res = await fetch(BASE, { credentials: 'include', headers: jsonHeaders() });
-  return jsonOrThrow<SettingsListResponse>(res);
+  const body = await jsonOrThrow<SettingsListResponse>(res);
+  return assertShape<SettingsListResponse>(body, ['manifests'], 'GET /api/settings');
 }
 
 export async function getSettingsNamespace(namespace: string): Promise<SettingsNamespacePayload> {
@@ -67,7 +143,12 @@ export async function getSettingsNamespace(namespace: string): Promise<SettingsN
     credentials: 'include',
     headers: jsonHeaders(),
   });
-  return jsonOrThrow<SettingsNamespacePayload>(res);
+  const body = await jsonOrThrow<SettingsNamespacePayload>(res);
+  return assertShape<SettingsNamespacePayload>(
+    body,
+    ['manifest', 'values'],
+    `GET /api/settings/${namespace}`,
+  );
 }
 
 export async function saveSettingsNamespace(
@@ -80,7 +161,15 @@ export async function saveSettingsNamespace(
     headers: jsonHeaders(),
     body: JSON.stringify(patch),
   });
-  return jsonOrThrow<{ values: SettingsNamespacePayload['values'] }>(res);
+  const body = await jsonOrThrow<{ values: SettingsNamespacePayload['values'] }>(res);
+  // The write's read-back is what the view merges into the on-screen values.
+  // Before the unwrap it was the envelope, so the merge spread nothing and a
+  // "saved" toast could sit above stale numbers (objectui#3366).
+  return assertShape<{ values: SettingsNamespacePayload['values'] }>(
+    body,
+    ['values'],
+    `PUT /api/settings/${namespace}`,
+  );
 }
 
 export async function runSettingsAction(
@@ -94,10 +183,39 @@ export async function runSettingsAction(
     headers: jsonHeaders(),
     body: JSON.stringify(payload ?? {}),
   });
-  // The action endpoint always returns SettingsActionResult JSON, even on 400.
-  const data = (await res.json().catch(() => ({ ok: false, message: res.statusText }))) as SettingsActionResult;
-  if (typeof data?.ok !== 'boolean') {
-    return { ok: res.ok, message: (data as any)?.error?.message ?? res.statusText };
-  }
-  return data;
+  // This endpoint answers a `SettingsActionResult` on both arms, but the two
+  // arms park it in different places (framework#3843, `settings-routes.ts`):
+  //
+  //   ok:true  → 200 `{ success: true,  data: SettingsActionResult }`
+  //   ok:false → 400 `{ success: false, error: { code: 'SETTINGS_ACTION_FAILED',
+  //                                               message, details: <result> } }`
+  //
+  // The route keeps the whole result under `error.details` precisely so the
+  // renderer's `message` / `severity` / `details` survive the 4xx. Reading them
+  // from there is following that contract, not guessing at an alias.
+  const body: unknown = await res.json().catch(() => null);
+
+  // Success arm — envelope, or the bare result from a pre-#3843 server.
+  const unwrapped = unwrapEnvelope(body);
+  if (isActionResult(unwrapped)) return unwrapped;
+
+  // Failure arm — the reported verdict, with its message and severity intact.
+  // Without this the console fell back to `{ ok: res.ok, message: statusText }`
+  // and rendered "Bad Request" where the action had said why.
+  const apiError = (body as { error?: { message?: unknown; details?: unknown } } | null)?.error;
+  if (isActionResult(apiError?.details)) return apiError.details;
+
+  // Neither: a crash (`INTERNAL_ERROR`), a 403, or a non-JSON body. Keep the
+  // server's sentence when there is one.
+  const message = typeof apiError?.message === 'string' ? apiError.message : res.statusText;
+  return { ok: res.ok, message };
+}
+
+/** A body that actually carries an action verdict — `ok` is the one required key. */
+function isActionResult(value: unknown): value is SettingsActionResult {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as { ok?: unknown }).ok === 'boolean'
+  );
 }

--- a/apps/console/src/pages/settings/api.ts
+++ b/apps/console/src/pages/settings/api.ts
@@ -36,8 +36,9 @@ const BASE = `${SERVER_URL}/api/settings`;
  *   payload; it passes through untouched. The console ships as a versioned
  *   asset that outlives any single server build, which is why both generations
  *   are read rather than the old one being declared gone. Drop the passthrough
- *   once the oldest supported server carries #3843 — the tests below name that
- *   branch explicitly so deleting it is a red test, not a silent regression.
+ *   once the oldest supported server carries #3843 — `api.envelope.test.ts`
+ *   drives that branch explicitly, so deleting it is a red test naming the
+ *   server generation it was carrying, not a silent regression.
  *
  * This is deliberately a local copy rather than an import: the console talks to
  * `/api/settings` with raw `fetch` and does not construct an `ObjectStackClient`,


### PR DESCRIPTION
Fixes #3366

## 问题

framework#3843 把 `service-settings` 的 5 个响应全部搬进平台声明信封 `{ success, data }`,其 changelog 明说了 raw fetch 调用方要付的代价:必须加一跳 `body.data`。console 的 settings 客户端正是 raw fetch 调用方,没跟进,于是把**信封本身**当 payload 交给了视图:

- 11 个命名空间页在 `Object.entries(payload.values)` 上抛 `Cannot convert undefined or null to object`,整页落到错误边界;
- 「全部设置」列表页的 `r.manifests ?? []` 把同一个坏 body 变成假空态「尚未注册任何设置」—— 比白屏更误导,会把排查方向带去「插件没注册」;
- 保存回读 merge 到空,成功 toast 之下值还是旧的;
- 动作(POST)的 verdict 不在客户端寻找的位置,`message` / `severity` 丢失,toast 只剩 HTTP status text。

前提已对 `origin/main` @ `68b6a28` 复核成立(`api.ts` 的 `jsonOrThrow` 直接 `return res.json()`;`SettingsView.tsx:97` 直取 `payload.values`),服务端一侧也已核对:`settings-routes.ts` 5 条路径全部走 `sendOk` / `sendError`。

## 改法

生产代码只动 `apps/console/src/pages/settings/api.ts` 一个文件 —— 视图未改,客户端修好后 `SettingsView` / `SettingsHub` 原样工作:

1. **`jsonOrThrow` 统一解包**,判定与 `ObjectStackClient.unwrapResponse` 逐字相同:`success` 是 boolean **且** 存在 `data`。两个条件都要,正是错误信封不被解包的原因 —— 失败体是 `{ success: false, error }`,没有 `data`,原样交回,`err.payload.error` 继续喂 objectstack#4224 的 locked key 与逐字段拒绝渲染。没有 boolean `success` 的 body 是 #3843 之前的服务端,原样透传。
2. **`runSettingsAction` 两臂各读各的**:成功臂从 `data` 取 verdict,上报失败臂从 `error.details` 取 —— 路由正是把整个 SettingsActionResult 放在那里,好让 message / severity / details 熬过 400。
3. **每个端点断言自己承诺的形状**,读不了就抛具名 `Malformed response from …`,而不是把坏 body 继续往下传。两个症状本质都是「读不了的 body 冒充读得了的往下走」;两个视图本来就有 error 态,具名错误落得进去。

契约优先的说明:这里的两代兼容不是在消费者侧加宽容别名,而是复用平台客户端自己的同一条判定 —— console 是带版本的静态资产,会跨服务端版本存活。旧形状分支被测试逐条钉住:等最老支持的服务端都带上 #3843,删掉它是一条红测试点名它在替哪代服务端兜底,而不是静默回归。

## 测试

新增 `api.envelope.test.ts`(19 例,单元)与 `__tests__/SettingsView.envelope.test.tsx`(5 例,过真实 `./api` + stub fetch 的两屏集成)。覆盖 PM 点名的三面:信封形正确解包、旧裸形仍兼容、错误响应(`success:false` / 非 2xx)不被解包逻辑吞掉。

```
apps/console: vitest run src/pages/settings   → Test Files 4 passed (4) | Tests 33 passed (33)
apps/console: vitest run (全量)               → Test Files 22 passed (22) | Tests 208 passed (208)
apps/console: tsc --noEmit                    → 0 errors
eslint src/pages/settings                     → 0 errors(10 条 warning 全部在未改动的既有行上)
scripts/check-changeset-{fixed,no-major}.mjs  → 均通过
```

**反向验证**(方向在跑之前先定:普通的「红」方向)。只把 `jsonOrThrow` 里那一跳解包退回 `return res.json()`:

```
Test Files  2 failed | 2 passed (4)
     Tests  8 failed | 25 passed (33)
```

8 条红全部是喂信封形 body 的用例(list / namespace / save 三处解包 + 两屏渲染),裸形、错误路径、动作三组 25 条保持绿 —— 动作那组本来就走自己的解包路径,不受这一跳影响,与预测一致。

再把形状断言一并停用(还原成本次修改之前的真实状态),集成测试复现的是 issue 里那条一模一样的浏览器崩溃栈:

```
TypeError: Cannot convert undefined or null to object
    at .../apps/console/src/pages/settings/SettingsView.tsx:97:33
```

也就是说这两个测试文件钉的是真 bug,不是绕着修改写的同义反复。

## 影响面清点

这个客户端的消费半径是封闭的:仅 `SettingsView` / `SettingsHub` / 同目录测试 import 它,仓内没有第二处 raw fetch 读 `/api/settings`。顺手核对了 console 另外两处直读顶层 body 的 raw fetch(`/auth/me/localization`、`/forms/:slug`),服务端确认这两条路由本就返回裸 body(未走 `sendOk`),不属同一族问题,无需改动、也无 finding 可报。

用户可见,已附 changeset(`@object-ui/console`: patch;按仓库约定不声明 major)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_