### PR TITLE
test(plugin-form): pin form section headings to the `_sections` convention (objectstack#5408)

### DIFF
--- a/packages/plugin-form/src/__tests__/sectionLabelI18n.test.tsx
+++ b/packages/plugin-form/src/__tests__/sectionLabelI18n.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Section headings on the create/edit form resolve the `_sections` translation
+ * convention — the SAME lookup the record detail page uses.
+ *
+ * Convention (per `@objectstack/spec` `ObjectTranslationDataSchema`):
+ *
+ *     {ns}.objects.{objectName}._sections.{sectionName}.label
+ *
+ * resolved by `useObjectLabel().sectionLabel(objectName, sectionName, fallback)`
+ * in `@object-ui/i18n`, falling back to the authored `label`.
+ *
+ * Both halves of the renderer call that one resolver:
+ *   - detail page — `packages/plugin-detail/src/renderers/record-details.tsx`
+ *     (`sectionLabel(objectName, s.name, rawTitle ?? s.name)`)
+ *   - this form    — `ObjectForm.tsx` (`tSec`), `ModalForm.tsx` (`sectionTitle`)
+ *
+ * The behaviour existed but was pinned by NO test on the form side, so nothing
+ * stopped the two halves from drifting apart again (objectstack#5408 was filed
+ * believing they already had). These tests pin the form half, the fallback, and
+ * — critically — that the KEY is the section's stable `name`, never a guess
+ * derived from its authored label.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, renderHook } from '@testing-library/react';
+import React from 'react';
+import { createI18n, I18nProvider, useObjectLabel } from '@object-ui/i18n';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectForm } from '../ObjectForm';
+
+registerAllFields();
+
+const objectSchema = {
+  name: 'crm_case',
+  fields: {
+    subject: { type: 'text', label: 'Subject' },
+    priority: { type: 'text', label: 'Priority' },
+  },
+};
+
+let dataSource: any;
+
+beforeEach(() => {
+  dataSource = {
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+});
+
+/**
+ * The runtime bundle shape `transformSpecTranslations` produces from authored
+ * `objects.<obj>._sections.<key>.label` entries — `_sections` is preserved
+ * verbatim under the object scope (pinned in
+ * `packages/i18n/src/__tests__/spec-translations.test.ts`).
+ *
+ * `case_info` is translated; `sla` deliberately is NOT, so every render below
+ * exercises the translated path and the authored-label fallback at once.
+ */
+const withSections = () =>
+  createI18n({
+    defaultLanguage: 'zh',
+    detectBrowserLanguage: false,
+    resources: {
+      zh: {
+        app: {
+          objects: {
+            crm_case: {
+              label: '服务案例',
+              _sections: { case_info: { label: '工单信息' } },
+            },
+          },
+          fields: { crm_case: { subject: '主题' } },
+        },
+      },
+    },
+  });
+
+/** Same object bundle, no `_sections` block at all. */
+const withoutSections = () =>
+  createI18n({
+    defaultLanguage: 'zh',
+    detectBrowserLanguage: false,
+    resources: {
+      zh: {
+        app: {
+          objects: { crm_case: { label: '服务案例' } },
+          fields: { crm_case: { subject: '主题' } },
+        },
+      },
+    },
+  });
+
+/** Sections authored the way the convention requires: a stable `name` + label. */
+const NAMED_SECTIONS = [
+  { name: 'case_info', label: 'Case Info', fields: ['subject'] },
+  { name: 'sla', label: 'SLA', fields: ['priority'] },
+];
+
+const renderForm = (instance: any, schema: Record<string, unknown>) =>
+  render(
+    <I18nProvider instance={instance}>
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          objectName: 'crm_case',
+          mode: 'create',
+          ...schema,
+        } as any}
+        dataSource={dataSource}
+      />
+    </I18nProvider>,
+  );
+
+const tabLabels = async () => {
+  await waitFor(() => expect(screen.getAllByRole('tab').length).toBeGreaterThan(0));
+  return screen.getAllByRole('tab').map((el) => el.textContent);
+};
+
+describe('form section headings resolve `_sections` (objectstack#5408)', () => {
+  it('page-mode tabbed form: the tab strip shows the translated heading', async () => {
+    renderForm(withSections(), { formType: 'tabbed', sections: NAMED_SECTIONS });
+    // `case_info` translated; `sla` has no key and keeps its authored label.
+    expect(await tabLabels()).toEqual(['工单信息', 'SLA']);
+  });
+
+  it('modal-hosted tabbed form: the tab strip shows the translated heading', async () => {
+    renderForm(withSections(), {
+      formType: 'modal',
+      open: true,
+      contentLayout: 'tabbed',
+      sections: NAMED_SECTIONS,
+    });
+    expect(await tabLabels()).toEqual(['工单信息', 'SLA']);
+  });
+
+  it('stacked (simple) sectioned form: the section divider heading is translated too', async () => {
+    // The non-tabbed grouping heading goes through the same resolver, so a
+    // `simple` form view's headings never diverge from its tabbed sibling.
+    renderForm(withSections(), { formType: 'simple', sections: NAMED_SECTIONS });
+    await waitFor(() => expect(screen.getByText('工单信息')).toBeTruthy());
+    expect(screen.getByText('SLA')).toBeTruthy();
+  });
+
+  it('falls back to the authored label when the bundle carries no `_sections`', async () => {
+    renderForm(withoutSections(), { formType: 'tabbed', sections: NAMED_SECTIONS });
+    expect(await tabLabels()).toEqual(['Case Info', 'SLA']);
+  });
+
+  it('resolves through the same `sectionLabel` call the detail page uses (parity)', async () => {
+    // Parity anchor: `useObjectLabel().sectionLabel` is the ONE resolver for
+    // this convention, and `record-details.tsx` calls it with this exact
+    // argument shape — `(objectName, section.name, authoredLabel)`. Asserting
+    // the rendered tab text equals what that call returns is what keeps the
+    // form half from drifting away from the detail half again.
+    const instance = withSections();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <I18nProvider instance={instance}>{children}</I18nProvider>
+    );
+    const { result } = renderHook(() => useObjectLabel(), { wrapper });
+    const viaResolver = NAMED_SECTIONS.map((s) =>
+      result.current.sectionLabel('crm_case', s.name, s.label),
+    );
+
+    renderForm(instance, { formType: 'tabbed', sections: NAMED_SECTIONS });
+    expect(await tabLabels()).toEqual(viaResolver);
+  });
+
+  it('keys off the section `name` only — a nameless section is not guessed at', async () => {
+    // Contract pin (AGENTS.md #0.1). A form view whose sections declare only a
+    // `label` gives the renderer no key: `_sections` is keyed by section NAME,
+    // so the authored English label is the correct output — the renderer must
+    // not slugify the label and go fishing for a second de-facto key. This is
+    // exactly the shape that produced the objectstack#5408 field report
+    // (hotcrm `src/views/case.view.ts` authors `{ label: 'Case' }` with no
+    // `name`, while its `_sections` bundle is keyed `basic`/`sla`/`resolution`)
+    // — a metadata gap at the producer, not a renderer gap.
+    const instance = createI18n({
+      defaultLanguage: 'zh',
+      detectBrowserLanguage: false,
+      resources: {
+        zh: {
+          app: {
+            objects: {
+              crm_case: {
+                label: '服务案例',
+                // Keyed plausibly-but-differently from the authored labels.
+                _sections: { case: { label: '工单信息' }, sla: { label: 'SLA 与优先级' } },
+              },
+            },
+            fields: { crm_case: { subject: '主题' } },
+          },
+        },
+      },
+    });
+    renderForm(instance, {
+      formType: 'tabbed',
+      sections: [
+        { label: 'Case', fields: ['subject'] },
+        { label: 'SLA', fields: ['priority'] },
+      ],
+    });
+    expect(await tabLabels()).toEqual(['Case', 'SLA']);
+  });
+});


### PR DESCRIPTION
Refs objectstack-ai/objectstack#5408(前提证伪,issue 由 PM 按证伪结论另行关闭 —— 见该单评论;本 PR 交付的是缺失的护栏测试,不是症状修复)

## 结论先行:issue 的前提在 `origin/main` 上不成立

objectstack#5408 断言「表单的 section tab strip 从不查 `_sections`,而 detail 页会查」。
对着 `origin/main` @ `68b6a28` 核验:**表单这一半早就接上了**,而且是和 detail 页
同一个解析器、同一个 key 约定 `objects.{objectName}._sections.{sectionName}.label`,
miss 时回退 authored label。三处独立调用点:

| 路径 | 调用点 |
|---|---|
| 页面态 tabbed / wizard / split / drawer / modal 分发 | `packages/plugin-form/src/ObjectForm.tsx:165-167`(`tSec`),5 个分支映射各调一次 |
| 模态内 tabbed + 堆叠 section + fieldGroups 派生 section | `packages/plugin-form/src/ModalForm.tsx:588`(`sectionTitle`)、`:684` |
| 非 tabbed 的分组标题(stacked section divider) | `packages/plugin-form/src/ObjectForm.tsx:966-968` |

detail 页那一半在 `packages/plugin-detail/src/renderers/record-details.tsx:199`,
调的是同一个 `useObjectLabel().sectionLabel(objectName, section.name, authoredLabel)`。
两半没有分岔。PM 补充里「plugin-form 全包零 `_sections` 命中」是 grep 了字面量
`_sections` 的结果 —— 解析发生在 `@object-ui/i18n` 的 `sectionLabel()` 内部,包里
自然搜不到这个字符串。

实测(见下方证据)zh-CN bundle 带 `_sections` 时,tab strip 渲染的就是译文。

## 现场那条 English tab strip 的真正成因:元数据缺 `name`

`_sections` 是**按 section 的 `name` 建索引**的。HotCRM 的
`src/views/case.view.ts` 里,`crm_case` 默认 form view 的三个 section 只写了
`label`,没有 `name`:

```ts
form: {
  type: 'tabbed',
  sections: [
    { label: 'Case',       columns: 2, fields: [...] },
    { label: 'SLA',        columns: 2, fields: [...] },
    { label: 'Resolution', columns: 1, fields: [...] },
  ],
}
```

—— 正是 issue 里报的那条 `Case / SLA / Resolution`。而同一个 object 的
`src/translations/zh-CN.ts` 的 `crm_case._sections` 键是
`info`/`status`/`description`(detail 页 `case_detail.page.ts` 的 section name,
所以 detail 页正常出译文)加 `basic`/`origin`/`sla`/`resolution`
(`case.object.ts` 的 `fieldGroups` 键)。form view 那三个 section 一个 `name`
都没有,渲染器**根本拿不到 key**,只能回退 authored label。

这是 producer 侧的元数据缺口,不是 renderer 缺口。按 AGENTS.md #0.1(contract-first),
不能在渲染器里把 label slug 化去猜第二套 key —— 那会把一个错误约定固化成第二份
事实契约。正确修法在下游元数据(给 form view 的 section 补 `name`)+ 平台侧加一道
门(objectstack#5417)。

## 那这个 PR 交付什么

真正缺的东西:**这套行为在 form 侧一条测试都没有**(plugin-form 全包搜不到一处
`sectionLabel` 的断言)。也就是说,让 issue 作者担心的「两半分岔」在今天是完全没有
护栏的 —— 谁把 `tSec` 改回 `s.label` 都不会红。本 PR 补的就是这道护栏,**不改一行
生产代码**。

六条钉子(`packages/plugin-form/src/__tests__/sectionLabelI18n.test.tsx`):

1. 页面态 tabbed:tab strip 出译文(`工单信息`),同一次渲染里未翻译的 `sla` 回退
   authored `SLA` —— 译文路径和回退路径一次覆盖。
2. 模态内 tabbed(`formType: 'modal'` + `contentLayout: 'tabbed'`):同上。
3. 非 tabbed 的 stacked sectioned form:section divider 标题同样出译文
   (PM 点名的「FormSection 标题」那一半)。
4. bundle 里完全没有 `_sections` 时,回退 authored label。
5. **parity 断言**:直接用 detail 页调的那个 `useObjectLabel().sectionLabel`、按
   `record-details.tsx` 的同款入参形状算出期望值,断言 tab strip 文本与之逐项相等。
   form 侧一旦绕开这个解析器就红。
6. **契约钉**:section 只有 `label` 没有 `name` 时,即使 bundle 里存在长得很像的键,
   渲染出来的就是 authored label —— 钉住「key 只认 `name`,渲染器不猜」,也就是上面
   HotCRM 那个 case 的最小复现。

## 验证

`pnpm --filter @object-ui/plugin-form test`(容器级 flock + `--maxWorkers=2`):

```
 Test Files  33 passed (33)
      Tests  322 passed (322)
```

33 = 原有 32 + 本 PR 新增 1,新文件确实进了这一轮(objectui#3288 的路径过滤坑,靠文件
计数而不是 `-- --run path` 确认)。单跑新文件 `6 passed (6)`。
`type-check` 退出 0;`lint` 0 errors(500 条既有 `no-explicit-any` warning,与本 PR 无关)。

**反向验证**(先定方向再跑):把生产代码改坏,看测试往哪边走。

- 只把 `ObjectForm.tsx` 的 `tSec` 改成 `s?.label` —— 预测**只红 2 条**(用例 1 和 5),
  用例 2、3 应当**仍绿**,因为模态与 stacked 两条路各自还有独立的解析调用
  (`ModalForm.sectionTitle` / `SimpleObjectForm`)会把 `name` 再解析一次。实测:
  `2 failed | 4 passed`,失败正是用例 1、5(`expected [ 'Case Info', 'SLA' ] to deeply
  equal [ '工单信息', 'SLA' ]`)。方向与预测一致。
- 再把 `ModalForm.tsx:588` 与 `ObjectForm.tsx:966-968` 两处一并改坏 —— 预测用例
  2、3 补红,用例 4、6 恒绿(它们不依赖解析器)。实测:`4 failed | 2 passed`,
  红的就是 1/2/3/5。

四条依赖解析器的用例全部可红,两条回退/契约钉在两次突变下都稳绿 —— 覆盖是活的,
不是「因为什么都没产出所以恰好通过」。改坏的文件已按原样还原,`git diff` 对生产代码为空。

无 changeset:纯测试,无用户可见变更。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_