### PR TITLE
fix(i18n): 语言选择写入 localStorage 并在启动时恢复,刷新不再退回 en

### DIFF
--- a/.changeset/locale-choice-survives-reload.md
+++ b/.changeset/locale-choice-survives-reload.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/i18n': minor
+---
+
+The console language choice now survives a reload. `I18nProvider` writes every language change to `localStorage` (`objectui-locale`, exported as `LOCALE_STORAGE_KEY`) and boots the next session in that language, so switching to 中文/日本語/… is no longer reverted to `en` by the next F5 or new tab (objectstack#5406).
+
+Bootstrap precedence is **stored choice → browser language → `defaultLanguage`**: an explicit choice outranks browser detection, and a stored value the app no longer offers is ignored and purged rather than locking the UI to a locale with no translations. The restore lands in the instance's bootstrap language, so `<html lang>` — and therefore the `Accept-Language` header on the first wave of API calls — is already correct on the first render.
+
+New public surface on `@object-ui/i18n`: `persistLanguage` (default `true`; set `false` for fixed-language previews/demos), `LOCALE_STORAGE_KEY`, and `readStoredLanguage()` for apps that bootstrap their own i18next instance.

--- a/packages/app-shell/src/layout/__tests__/LocaleSwitcher.persistence.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/LocaleSwitcher.persistence.test.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * LocaleSwitcher — the console's language choice survives a reload
+ * (objectstack#5406).
+ *
+ * The bug was reported against this exact surface (avatar menu → Preferences →
+ * Language): the switch localized the UI immediately and was gone on the next
+ * F5. The persistence itself lives in `@object-ui/i18n`'s provider; this test
+ * covers the console path end to end, so a future switcher that bypasses the
+ * i18n context (calling into some other API) turns red here instead of
+ * silently reverting to `en` again.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { I18nProvider, LOCALE_STORAGE_KEY } from '@object-ui/i18n';
+
+// Passthrough dropdown primitives — the open/close choreography is Radix's
+// business; what matters here is what a click on a language item leaves behind.
+vi.mock('@object-ui/components', () => ({
+  Button: (p: any) => <button {...p} />,
+  DropdownMenu: (p: any) => <div>{p.children}</div>,
+  DropdownMenuTrigger: (p: any) => <div>{p.children}</div>,
+  DropdownMenuContent: (p: any) => <div>{p.children}</div>,
+  DropdownMenuItem: ({ onClick, children }: any) => <div onClick={onClick}>{children}</div>,
+}));
+vi.mock('lucide-react', () => ({ Globe: () => <span /> }));
+
+import { LocaleSwitcher } from '../LocaleSwitcher';
+
+/** A page load: a fresh provider building a fresh i18next instance. */
+function load() {
+  return render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <LocaleSwitcher />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('LocaleSwitcher persistence', () => {
+  it('remembers the picked language across a reload', async () => {
+    const first = load();
+    // English before the switch — the switcher's own sr-only label localizes.
+    expect(screen.getByText('Language')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('中文'));
+
+    await waitFor(() => expect(screen.getByText('语言')).toBeInTheDocument());
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh');
+
+    first.unmount();
+
+    // Reload: nothing carries over but localStorage.
+    load();
+    expect(screen.getByText('语言')).toBeInTheDocument();
+    expect(screen.queryByText('Language')).not.toBeInTheDocument();
+  });
+});

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -61,6 +61,32 @@ Wraps your application with i18n context:
 </I18nProvider>
 ```
 
+#### Language persistence
+
+The active language is a **user preference**, so it survives a reload: every
+language change is written to `localStorage` under `objectui-locale`
+(`LOCALE_STORAGE_KEY`), and the provider boots the next session in that
+language.
+
+Precedence at bootstrap: **stored choice → browser language → `defaultLanguage`**.
+An explicit choice outranks browser detection — otherwise a user who picked 中文
+on a `ja` browser would be handed `ja` back on every reload. A stored value the
+app no longer offers (not a built-in pack, not in `config.resources`) is ignored
+*and purged*, so a stale entry can never lock the UI to a locale with no
+translations.
+
+```tsx
+// Fixed-language surfaces (previews, demos, screenshot harnesses) opt out —
+// they neither restore nor write the preference.
+<I18nProvider config={{ defaultLanguage: 'en' }} persistLanguage={false}>
+  <Preview />
+</I18nProvider>
+```
+
+Bringing your own `instance`? Then its bootstrap language is yours to choose —
+read the preference with `readStoredLanguage()` and pass it to `createI18n`.
+Switching through such an instance is still persisted.
+
 ### useObjectTranslation
 
 Hook for translations and language management:

--- a/packages/i18n/src/__tests__/locale-persistence-ssr.test.ts
+++ b/packages/i18n/src/__tests__/locale-persistence-ssr.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Language-preference storage under SSR (objectstack#5406).
+ *
+ * This file is deliberately `.test.ts` so it lands in the `unit` project's
+ * **node** environment — there is no `window` here for real, no stub involved.
+ * That is the shape of a server render, and reading a preference must degrade
+ * to "nothing stored" rather than throw and take the render down.
+ */
+import { describe, it, expect } from 'vitest';
+import { LOCALE_STORAGE_KEY, readStoredLanguage } from '../provider';
+
+describe('readStoredLanguage without a window (SSR)', () => {
+  it('has no window in this environment', () => {
+    expect(typeof window).toBe('undefined');
+  });
+
+  it('returns null instead of throwing', () => {
+    expect(() => readStoredLanguage()).not.toThrow();
+    expect(readStoredLanguage()).toBeNull();
+  });
+
+  it('exposes a stable storage key', () => {
+    // The key is part of the package's public surface: apps clear it on sign
+    // out and read it when they bootstrap their own i18next instance.
+    expect(LOCALE_STORAGE_KEY).toBe('objectui-locale');
+  });
+});

--- a/packages/i18n/src/__tests__/provider-locale-persistence.test.tsx
+++ b/packages/i18n/src/__tests__/provider-locale-persistence.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * I18nProvider — the language choice survives a reload (objectstack#5406).
+ *
+ * Before this, switching the console language took effect immediately and was
+ * never written anywhere: the next page load (or a new tab) reverted the whole
+ * UI to `en`, which made every non-`en` locale demo-only.
+ *
+ * A "reload" here is an unmount + a fresh `I18nProvider` mount — the provider
+ * builds a new i18next instance, exactly as a page load does, so anything the
+ * new instance knows had to come out of storage.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider, useObjectTranslation, LOCALE_STORAGE_KEY, readStoredLanguage } from '../provider';
+
+/** Mount a provider and expose the translation context, as a page load would. */
+function mount(props: Partial<React.ComponentProps<typeof I18nProvider>> = {}) {
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(I18nProvider, { ...props, children });
+  return renderHook(() => useObjectTranslation(), { wrapper });
+}
+
+/** Pin the browser language so detection is deterministic (and contestable). */
+function stubBrowserLanguage(lang: string) {
+  Object.defineProperty(window.navigator, 'language', { value: lang, configurable: true });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  stubBrowserLanguage('en-US');
+});
+
+describe('language preference persistence', () => {
+  it('writes the chosen language to localStorage on switch', async () => {
+    const { result } = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBeNull();
+
+    await act(async () => {
+      await result.current.changeLanguage('zh');
+    });
+
+    await waitFor(() => expect(result.current.language).toBe('zh'));
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh');
+  });
+
+  it('restores the stored language across a reload — on the FIRST render', async () => {
+    const first = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+    await act(async () => {
+      await first.result.current.changeLanguage('zh');
+    });
+    first.unmount();
+
+    // Reload: a brand-new provider + instance, same storage.
+    const second = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+
+    // Asserted without waitFor on purpose: the restore must land in the
+    // bootstrap language, not as an async correction after an English first
+    // paint. `<html lang>` seeds Accept-Language on every API call (#1319), so
+    // a late switch would fetch server-resolved labels in the wrong locale.
+    expect(second.result.current.language).toBe('zh');
+    expect(second.result.current.t('common.save')).toBe('保存');
+    await waitFor(() => expect(document.documentElement.lang).toBe('zh'));
+  });
+
+  it('persists a switch made directly on the i18next instance', async () => {
+    const { result } = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+
+    // A switcher reaching for react-i18next's own API instead of the context
+    // must not silently lose the preference.
+    await act(async () => {
+      await result.current.i18n.changeLanguage('ja');
+    });
+
+    await waitFor(() => expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('ja'));
+  });
+
+  it('an explicit stored choice outranks browser detection', () => {
+    stubBrowserLanguage('ja-JP');
+
+    // Baseline: with nothing stored, detection wins over `defaultLanguage`.
+    const detected = mount({ config: { defaultLanguage: 'en' } });
+    expect(detected.result.current.language).toBe('ja');
+    detected.unmount();
+
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'zh');
+
+    const restored = mount({ config: { defaultLanguage: 'en' } });
+    expect(restored.result.current.language).toBe('zh');
+  });
+
+  it('restores an RTL locale with its direction intact', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'ar');
+
+    const { result } = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+
+    expect(result.current.language).toBe('ar');
+    expect(result.current.direction).toBe('rtl');
+  });
+
+  it('honours a stored language supplied only through config.resources', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'th');
+
+    const { result } = mount({
+      config: {
+        defaultLanguage: 'en',
+        detectBrowserLanguage: false,
+        resources: { th: { common: { save: 'บันทึก' } } },
+      },
+    });
+
+    expect(result.current.language).toBe('th');
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('th');
+  });
+
+  it('drops AND purges a stored language the app no longer offers', () => {
+    // The app shipped `th` yesterday and dropped it today: a leftover entry
+    // must not lock the UI to a locale with no translations.
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'th');
+
+    const { result } = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+
+    expect(result.current.language).toBe('en');
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('ignores a junk value that only exists on Object.prototype', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'constructor');
+
+    const { result } = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+
+    expect(result.current.language).toBe('en');
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('persistLanguage={false} neither restores nor writes', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'zh');
+
+    const { result } = mount({
+      config: { defaultLanguage: 'en', detectBrowserLanguage: false },
+      persistLanguage: false,
+    });
+    expect(result.current.language).toBe('en');
+
+    await act(async () => {
+      await result.current.changeLanguage('ja');
+    });
+
+    await waitFor(() => expect(result.current.language).toBe('ja'));
+    // The pre-existing preference is left exactly as it was, not overwritten.
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('zh');
+  });
+
+  it('survives storage being blocked (Safari private mode / partitioned iframe)', async () => {
+    // Not a spy on Storage.prototype: the runner may swap `localStorage` for a
+    // plain in-memory object (vitest.setup.base.ts), which no prototype spy
+    // would reach. Replace the property itself so the throw is unavoidable.
+    const real = window.localStorage;
+    const throws = () => { throw new Error('SecurityError: storage is disabled'); };
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: { getItem: throws, setItem: throws, removeItem: throws, clear: throws, key: throws, length: 0 },
+    });
+
+    try {
+      const { result } = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+      expect(result.current.language).toBe('en');
+
+      await act(async () => {
+        await result.current.changeLanguage('zh');
+      });
+
+      // The switch still applies for this session; only its persistence is lost.
+      await waitFor(() => expect(result.current.language).toBe('zh'));
+    } finally {
+      Object.defineProperty(window, 'localStorage', { configurable: true, value: real });
+    }
+  });
+
+  it('readStoredLanguage reads back what the provider wrote', async () => {
+    const { result } = mount({ config: { defaultLanguage: 'en', detectBrowserLanguage: false } });
+
+    await act(async () => {
+      await result.current.changeLanguage('de');
+    });
+
+    await waitFor(() => expect(readStoredLanguage()).toBe('de'));
+  });
+});

--- a/packages/i18n/src/__tests__/provider.test.tsx
+++ b/packages/i18n/src/__tests__/provider.test.tsx
@@ -1,8 +1,17 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import { I18nProvider, useObjectTranslation, useI18nContext } from '../provider';
 import { createI18n } from '../i18n';
+
+// Each test below is written as a fresh browser: the provider now remembers the
+// language across mounts (objectstack#5406), so the `changeLanguage` test would
+// otherwise hand its `zh` to every test after it — including the ones asserting
+// a config-supplied bootstrap language. Persistence itself is covered in
+// `provider-locale-persistence.test.tsx`.
+beforeEach(() => {
+  window.localStorage.clear();
+});
 
 describe('I18nProvider', () => {
   it('creates i18n instance from config', () => {

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -35,7 +35,16 @@
 export { createI18n, getDirection, getAvailableLanguages, type I18nConfig, type TranslationKeys } from './i18n';
 
 // React integration
-export { I18nProvider, useObjectTranslation, useI18nContext, type I18nProviderProps } from './provider';
+export {
+  I18nProvider,
+  useObjectTranslation,
+  useI18nContext,
+  // Language-preference persistence: the key the provider writes, and the
+  // reader apps that bring their own i18next instance need to honour it.
+  LOCALE_STORAGE_KEY,
+  readStoredLanguage,
+  type I18nProviderProps,
+} from './provider';
 
 // Safe translation hook factory
 export { createSafeTranslation, useSafeTranslate } from './useSafeTranslation';

--- a/packages/i18n/src/provider.tsx
+++ b/packages/i18n/src/provider.tsx
@@ -7,6 +7,101 @@ import React, { createContext, useContext, useEffect, useMemo, useRef, useState 
 import { I18nextProvider, useTranslation } from 'react-i18next';
 import type { i18n as I18nInstance } from 'i18next';
 import { createI18n, getDirection, type I18nConfig } from './i18n';
+import { builtInLocales } from './locales/index';
+
+/**
+ * `localStorage` key holding the user's explicit language choice.
+ *
+ * Follows the console's existing preference-key convention
+ * (`objectui-favorites`, `objectui-recent-items`), and sits beside the theme
+ * preference the same avatar menu writes — a language switch is a preference,
+ * not ephemeral UI state, so it belongs in storage (AGENTS.md §5 #8).
+ *
+ * Exported so an app that builds its own i18next instance (and therefore owns
+ * its bootstrap language — see {@link I18nProviderProps.instance}) can honour
+ * the same preference, and so a sign-out flow can clear it.
+ */
+export const LOCALE_STORAGE_KEY = 'objectui-locale';
+
+/**
+ * Read the persisted language choice, or `null` when nothing is stored.
+ *
+ * Defensive by design: `localStorage` does not exist under SSR and *throws* on
+ * access in Safari private mode / partitioned iframes. A language preference is
+ * never worth taking the app down for, so every failure degrades to "nothing
+ * stored".
+ */
+export function readStoredLanguage(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(LOCALE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredLanguage(lang: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, lang);
+  } catch {
+    // Storage blocked or full — the switch still applies for this session.
+  }
+}
+
+function clearStoredLanguage(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(LOCALE_STORAGE_KEY);
+  } catch {
+    // Nothing readable means nothing to purge.
+  }
+}
+
+/**
+ * Languages `createI18n(config)` will know about: the built-in packs plus any
+ * extra `config.resources`.
+ *
+ * `hasOwnProperty` rather than `in`: a junk stored value like `constructor`
+ * would pass an `in` check against the locale map's prototype.
+ */
+function isKnownLanguage(lang: string, config?: I18nConfig): boolean {
+  const own = Object.prototype.hasOwnProperty;
+  return own.call(builtInLocales, lang) || Boolean(config?.resources && own.call(config.resources, lang));
+}
+
+/**
+ * Resolve the bootstrap config for a provider-owned i18next instance, applying
+ * a stored language choice when there is a usable one.
+ *
+ * Applied at instance creation rather than through a post-mount
+ * `changeLanguage`, because the very first render must already be in the right
+ * locale: `<html lang>` seeds the `Accept-Language` header on every API call
+ * (`createAuthenticatedFetch`, issue #1319), so a late switch would fetch the
+ * first wave of server-resolved metadata labels in the wrong language and then
+ * have to remount to fix it.
+ *
+ * A stored choice outranks browser detection (which itself outranks
+ * `defaultLanguage` in `createI18n`) — otherwise a user who picked 中文 on a
+ * `ja` browser would be handed `ja` back on every reload, and the preference
+ * would be unusable for exactly the users who need it.
+ *
+ * A stored value the app no longer offers is dropped *and purged*, so one stale
+ * entry can never lock the UI to a locale that has no translations.
+ */
+function resolveBootstrapConfig(
+  config: I18nConfig | undefined,
+  persist: boolean,
+): I18nConfig | undefined {
+  if (!persist) return config;
+  const stored = readStoredLanguage();
+  if (!stored) return config;
+  if (!isKnownLanguage(stored, config)) {
+    clearStoredLanguage();
+    return config;
+  }
+  return { ...config, defaultLanguage: stored, detectBrowserLanguage: false };
+}
 
 interface I18nContextValue {
   /** Current language code */
@@ -44,6 +139,26 @@ export interface I18nProviderProps {
    * ```
    */
   loadLanguage?: (lang: string) => Promise<Record<string, unknown>>;
+  /**
+   * Remember the active language in `localStorage` ({@link LOCALE_STORAGE_KEY})
+   * and restore it on the next mount. Default: `true`.
+   *
+   * Every language change on the instance is persisted — whether it came from
+   * this provider's `changeLanguage`, a switcher calling
+   * `i18n.changeLanguage()` directly, or app code — because the promise the UI
+   * makes ("this is my language now") must not depend on which API the caller
+   * reached for.
+   *
+   * The *restore* half only applies to an instance this provider creates: when
+   * you pass your own {@link I18nProviderProps.instance}, its bootstrap
+   * language is yours to choose (call {@link readStoredLanguage} if you want
+   * the same preference honoured).
+   *
+   * Set `false` for surfaces that must stay on a fixed language regardless of
+   * what the user picked elsewhere on the origin — previews, demos, screenshot
+   * harnesses.
+   */
+  persistLanguage?: boolean;
   /** Children to render */
   children: React.ReactNode;
 }
@@ -58,10 +173,16 @@ export interface I18nProviderProps {
  * </I18nProvider>
  * ```
  */
-export function I18nProvider({ config, instance: externalInstance, loadLanguage, children }: I18nProviderProps) {
+export function I18nProvider({
+  config,
+  instance: externalInstance,
+  loadLanguage,
+  persistLanguage = true,
+  children,
+}: I18nProviderProps) {
   const i18nInstance = useMemo(
-    () => externalInstance || createI18n(config),
-    [externalInstance, config],
+    () => externalInstance || createI18n(resolveBootstrapConfig(config, persistLanguage)),
+    [externalInstance, config, persistLanguage],
   );
 
   const [language, setLanguage] = useState(i18nInstance.language || 'en');
@@ -74,6 +195,13 @@ export function I18nProvider({ config, instance: externalInstance, loadLanguage,
   useEffect(() => {
     const handleLanguageChanged = (lng: string) => {
       setLanguage(lng);
+      // Remember the choice. This is the single choke point every switch runs
+      // through — i18next fires `languageChanged` for the context's
+      // `changeLanguage` and for a direct `i18n.changeLanguage()` alike — so no
+      // switcher can be wired in a way that silently forgets the preference.
+      // Bootstrap does NOT fire this event, so restoring a stored language
+      // never re-writes it.
+      if (persistLanguage) writeStoredLanguage(lng);
       // Update document direction for RTL support
       if (typeof document !== 'undefined') {
         document.documentElement.dir = getDirection(lng);
@@ -98,7 +226,7 @@ export function I18nProvider({ config, instance: externalInstance, loadLanguage,
     return () => {
       i18nInstance.off('languageChanged', handleLanguageChanged);
     };
-  }, [i18nInstance]);
+  }, [i18nInstance, persistLanguage]);
 
   // Load app-specific translations for the initial language on mount
   useEffect(() => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5406

## 问题

控制台切换语言(头像菜单 → Preferences → Language)只改动内存里的 i18next 实例:`packages/i18n/src/provider.tsx` 与 `packages/app-shell/src/layout/LocaleSwitcher.tsx` 全无持久化写入。任何一次刷新或新开标签页都会重建 provider,UI 整个退回 `en` —— 非 `en` 语言只能演示,无法真正使用。前提已在 `origin/main` 复核成立(i18n 面零 localStorage 命中)。

## 方案(PM 裁定:localStorage 持久化 + 启动时恢复)

- **写入点是 provider 的 `languageChanged` 监听,不是 LocaleSwitcher 的点击回调。** i18next 对「context 的 changeLanguage」和「直接调 i18n.changeLanguage()」都会触发该事件,所以这是唯一收口点 —— 换任何一种写法的切换器都不会漏写偏好。bootstrap 不触发该事件,因此「恢复」不会反过来重写存储。据此 `LocaleSwitcher.tsx` 本身无需改动(只补了一条端到端测试)。
- **恢复发生在实例创建时**(进 `createI18n` 的入参),而不是挂载后再 `changeLanguage`。provider 依据实例语言设置 html 的 lang 属性,`createAuthenticatedFetch` 又拿它拼 `Accept-Language`(#1319):晚一步切换会让首屏那批服务端解析的标签用错语言取回,再靠 remount 补救。
- **优先级:已存选择 → 浏览器语言 → `defaultLanguage`。** 显式选择必须压过浏览器探测,否则「在 ja 浏览器上选了中文」的用户每次刷新都会被塞回 ja,偏好对最需要它的人反而失效。
- **脏值静默回退并清理。** 存的语言若不在「内置语言包 + `config.resources`」内(app 换了 locale 集),回退默认语言并**删除**该键,一条陈旧记录不会把 UI 锁死在没有翻译的 locale 上。判定用 `hasOwnProperty` 而非 `in`,免得 `constructor` 这类垃圾值蒙混过关。
- **防御式访问。** SSR 无 window;Safari 隐私模式 / 分区 iframe 下访问 localStorage 直接抛错。读写一律 try/catch 降级 —— 语言偏好不值得让应用崩掉,存不下时本次会话的切换照样生效。

新增公开面(`@object-ui/i18n`):`persistLanguage`(默认 `true`;预览、demo、截图夹具等固定语言场景传 `false`,既不恢复也不写入)、`LOCALE_STORAGE_KEY`(`objectui-locale`,循 `objectui-favorites` / `objectui-recent-items` 一族命名)、`readStoredLanguage()`(自带 i18next 实例的 app 用它沿用同一偏好;这类 app 的 bootstrap 语言仍归自己决定)。

## 反向验证(方向先定,再跑)

预判:两条肢都是常规「红」方向 —— 新测试钉的是此前根本不存在的行为,不存在 #5018 那种反转。逐条关掉后实测与预判集合完全一致:

- 关掉**恢复**一肢:`7 failed | 5 passed` —— 红的是跨重载恢复、优先级压过浏览器探测、RTL 恢复、`config.resources` locale、脏值清理(语言回退这半截仍绿,清理那半截红)、垃圾值清理,以及 LocaleSwitcher 的重载断言;写入类断言全绿。
- 关掉**写入**一肢:`5 failed | 7 passed` —— 红的是切换写入、跨重载恢复(无可恢复之物)、直接调实例 API 的写入、`readStoredLanguage` 回读,以及 LocaleSwitcher;手工塞存储的那批恢复用例全绿。

## 测试

- 新增 `packages/i18n/src/__tests__/provider-locale-persistence.test.tsx`(11 例):切换写入、重载恢复且**落在首帧**(不是异步补正)、直接调 `i18n.changeLanguage` 也持久化、显式选择压过浏览器探测(先用无存储的基线钉出探测确实赢过 `defaultLanguage`)、RTL 方向、`config.resources` 提供的 locale、脏值/垃圾值回退并清理、`persistLanguage={false}` 两头都不动、存储被禁时不崩。
- 新增 `packages/i18n/src/__tests__/locale-persistence-ssr.test.ts`:刻意用 `.test.ts` 落进 `unit` 项目的 **node** 环境 —— 这里真的没有 window,不靠 stub,SSR 读取必须返回 null 而非抛错。
- 新增 `packages/app-shell/src/layout/__tests__/LocaleSwitcher.persistence.test.tsx`:issue 报告的那条路径端到端 —— 点 中文 → 写入 → 重载后 UI 仍是中文。将来若有人把切换器改到绕过 i18n context 的 API 上,这里会红,而不是又悄悄退回 `en`。
- 改 `packages/i18n/src/__tests__/provider.test.tsx`:加 `beforeEach` 清 localStorage。持久化默认开启后,那条 `changeLanguage` 用例会把 `zh` 递给它后面的每个用例(包括断言 config 指定 bootstrap 语言的 ar 用例)—— 每条用例都该是一次全新的浏览器。

命令与结果(全部持容器验证锁跑):

- `pnpm exec vitest run --maxWorkers=2 --reporter=verbose` 四个相关文件 → `Test Files 4 passed (4) / Tests 25 passed (25)`,输出里逐条列出文件名(本仓 `--filter ... test -- --run path` 会静默忽略路径过滤,故走根 vitest)。
- `pnpm exec vitest run --maxWorkers=2 packages/i18n` → `19 passed / 171 passed`。
- `pnpm exec vitest run --maxWorkers=2 packages/app-shell` → `275 passed / 2382 passed | 1 skipped`(含 metadata-admin 那条直接切实例语言的 studio-locale 用例)。
- `pnpm exec vitest run --maxWorkers=2 apps/console` → `20 passed / 184 passed`。
- `pnpm --filter @object-ui/i18n type-check`、`pnpm --filter @object-ui/app-shell type-check`(先 `pnpm --workspace-concurrency=2 --filter "@object-ui/app-shell^..." build` 备齐依赖 d.ts)→ 均通过。
- 改动文件 `eslint` → 0 error(仅测试 mock 的 `any` 与 provider 早已存在的 fast-refresh / exhaustive-deps 警告)。
- `pnpm changeset:check` → fixed 组齐全、无 `major` 声明。

## 影响半径

持久化默认开启,意味着所有 `I18nProvider` 消费方(预览画廊、各 plugin demo)也会跟随同源下用户选过的语言;需要固定语言的表面传 `persistLanguage={false}` 即可。已按「规则的消费半径」而非「改动的包」清点:全仓仅 3 个测试文件调用过 `changeLanguage`,其中 2 个经由 provider(已处理/已复跑),另一个在 `packages/i18n` 内部直接操作实例;app-shell、console 两个项目全量跑绿。

顺带的文档:`packages/i18n/README.md` 补了一节「Language persistence」(优先级、脏值语义、`persistLanguage` 与自带实例的用法)。

## 顺手记下、未在本 PR 修的

- objectstack-ai/objectstack#5418:语言菜单是硬编码的十个码,从不询问 app 实际发布了哪些 locale(`GET /api/v1/i18n/locales` 是好用的)。本 PR 的脏值校验边界(内置包 + `config.resources`)今天正确,恰恰因为菜单只给这十个;菜单一旦扩到 app 真实 locale 列表,校验必须同步扩,否则「用户选的 app locale 活不过刷新」会成为下一个同款 bug。
- objectstack-ai/objectstack#5419:`/auth/me/localization` 已经把租户侧 `locale` 取回来了,却只喂给货币/数字格式化,从不参与 UI 语言 —— 新设备首次登录仍是浏览器语言或 `en`。这是契约问题(优先级、存哪、写入端点都缺),按 PM 的裁定另立,不在本 PR 猜。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_