### PR TITLE
fix(app-shell): entitlement 成功包络严格只读 `data`，删除 3 处双方言容错 (#3352)

### DIFF
--- a/packages/app-shell/src/console/home/CloudOnboardingNext.tsx
+++ b/packages/app-shell/src/console/home/CloudOnboardingNext.tsx
@@ -83,8 +83,16 @@ function useProductionEnvState(warmUrl?: string): Resolved {
           credentials: 'include',
         });
         if (!res.ok) throw new Error(`entitlements ${res.status}`);
-        const json = await res.json().catch(() => null);
-        const data = (json?.data ?? json) as { hasProductionEnv?: boolean } | null;
+        // Strict envelope read: the control plane wraps every success body as
+        // `{ success, data }` (cloud#1046). A bare body is a producer contract
+        // violation, not a second accepted dialect — reading it would resolve
+        // `hasProductionEnv` to `false` from an absent field and strand a user
+        // who HAS a production env behind a wrong "create" CTA. Unresolvable
+        // ⇒ `unknown`, which degrades to both actions and always works.
+        const json = (await res.json().catch(() => null)) as
+          | { data?: { hasProductionEnv?: boolean } }
+          | null;
+        const data = json?.data;
         if (cancelled) return;
         if (!data || typeof data !== 'object') {
           setState({ phase: 'unknown' });

--- a/packages/app-shell/src/console/home/__tests__/CloudOnboardingNext.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/CloudOnboardingNext.test.tsx
@@ -93,6 +93,41 @@ describe('CloudOnboardingNext', () => {
     expect(screen.queryByText('Create your environment')).toBeNull();
   });
 
+  // Strict envelope pins (#3352): the control plane wraps success bodies as
+  // `{ success, data }`, so a BARE body is a producer contract violation and
+  // must NOT produce a usable summary. It resolves to `unknown` (both actions
+  // work) instead of being read field-by-field off the wrong shape.
+  it('does NOT read a bare (un-enveloped) body as a usable summary', async () => {
+    fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ hasProductionEnv: true }),
+    });
+    const { container } = renderOnboarding(<CloudOnboardingNext {...PROPS} />);
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-onboarding="unknown"]')).toBeTruthy(),
+    );
+    expect(container.querySelector('[data-onboarding="ready"]')).toBeNull();
+  });
+
+  it('never strands a user behind a wrong "create" CTA when the envelope is missing', async () => {
+    // The silent-degradation case the strict read exists to kill: an
+    // un-enveloped body whose `hasProductionEnv` reads as absent used to
+    // resolve to `ready:false` and show "Create your environment" to an org
+    // that already HAS a production env.
+    fetchImpl = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ hasProductionEnv: false }),
+    });
+    const { container } = renderOnboarding(<CloudOnboardingNext {...PROPS} />);
+
+    expect(await screen.findByText('Open Production')).toBeTruthy();
+    expect(screen.queryByText('Create your environment')).toBeNull();
+    expect(container.querySelector('[data-onboarding="unknown"]')).toBeTruthy();
+  });
+
   it('renders a non-CTA skeleton while the signal is still loading', async () => {
     let resolveFetch: (v: any) => void = () => {};
     fetchImpl = () => new Promise((r) => { resolveFetch = r; });

--- a/packages/app-shell/src/console/organizations/__tests__/provisionEnvironment.test.ts
+++ b/packages/app-shell/src/console/organizations/__tests__/provisionEnvironment.test.ts
@@ -58,6 +58,27 @@ describe('provisionProductionEnvironment', () => {
     expect(out).toEqual({ alreadyProvisioned: true });
   });
 
+  // Strict envelope pin (#3352): the control plane wraps success payloads as
+  // `{ success, data }`, so a BARE body is a producer contract violation — it
+  // must NOT be read as the provisioned environment. This used to fall through
+  // to `return body`, reporting a successful provision from a shape that never
+  // existed; now it throws into the caller's documented lazy-provision path.
+  it('does NOT read a bare (un-enveloped) 2xx body as the provisioned env', async () => {
+    authFetch.mockResolvedValue(res(200, { id: 'env-1', hostname: 'os-abc.localhost' }));
+
+    await expect(provisionProductionEnvironment({ organizationId: 'org-123' })).rejects.toThrow(
+      /envelope/i,
+    );
+  });
+
+  it('throws when a 2xx body carries the envelope but no data payload', async () => {
+    authFetch.mockResolvedValue(res(200, { success: true }));
+
+    await expect(provisionProductionEnvironment({ organizationId: 'org-123' })).rejects.toThrow(
+      /envelope/i,
+    );
+  });
+
   it('throws on a genuine failure so the caller can fall back to the lazy gate', async () => {
     authFetch.mockResolvedValue(res(500, { success: false }));
 

--- a/packages/app-shell/src/console/organizations/provisionEnvironment.ts
+++ b/packages/app-shell/src/console/organizations/provisionEnvironment.ts
@@ -48,7 +48,8 @@ export interface ProvisionedEnvironment {
  * switch has propagated. The env is named `Production` to match the
  * born-with-env convention used by the signup org.
  *
- * @throws on a genuine control-plane failure (5xx / network). A 403/409
+ * @throws on a genuine control-plane failure (5xx / network), or on a 2xx whose
+ *   body doesn't carry the contractual `{ success, data }` envelope. A 403/409
  *   "already has its production env" is NOT an error — it resolves to
  *   `{ alreadyProvisioned: true }`.
  */
@@ -73,12 +74,19 @@ export async function provisionProductionEnvironment(opts: {
     }
     throw new Error(`Failed to provision production environment (status ${res.status})`);
   }
-  // The control plane wraps payloads as `{ success, data }`; tolerate both.
-  const body = (await res.json().catch(() => ({}))) as
-    | { data?: ProvisionedEnvironment }
-    | ProvisionedEnvironment;
-  if (body && typeof body === 'object' && 'data' in body && body.data) {
-    return body.data;
+  // Strict envelope read: the control plane wraps every success payload as
+  // `{ success, data }` (cloud#1046), so `data` is the only place the created
+  // environment lives. A bare body is a producer contract violation, not a
+  // second accepted dialect — returning it (or an empty object) would report a
+  // successful provision carrying no env at all. Throwing routes it to the
+  // caller's documented failure path: the onboarding gate provisions lazily on
+  // first navigation.
+  const body = (await res.json().catch(() => null)) as { data?: ProvisionedEnvironment } | null;
+  const data = body?.data;
+  if (!data || typeof data !== 'object') {
+    throw new Error(
+      'Malformed control-plane response: expected a `{ success, data }` envelope from POST /cloud/environments',
+    );
   }
-  return (body as ProvisionedEnvironment) ?? {};
+  return data;
 }

--- a/packages/app-shell/src/environment/__tests__/useEnvironmentEntitlements.test.tsx
+++ b/packages/app-shell/src/environment/__tests__/useEnvironmentEntitlements.test.tsx
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * useEnvironmentEntitlements — the authoritative summary is read STRICTLY out
+ * of the control plane's `{ success, data }` envelope (#3352).
+ *
+ * The control plane wraps every success body as `{ success, data }` (cloud#1046)
+ * and `EnvironmentEntitlementsSummary` is declared as that `data` payload, so a
+ * bare body is a producer contract violation rather than a second accepted
+ * dialect. Reading one would hand back a summary whose every field is
+ * `undefined` — a silent `hasProductionEnv: false` that tells a user with a
+ * live production environment they have none. The strict read makes that shape
+ * produce NO summary, so the hook degrades to the row-derived fallback, which
+ * resolves the signal for real.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ activeOrganization: { id: 'org_1' } }),
+}));
+
+import { useEnvironmentEntitlements } from '../useEnvironmentEntitlements';
+
+/** Env rows for the derived fallback — this org DOES own a production env. */
+const PRODUCTION_ROWS = [{ id: 'env-1', environment_type: 'production', status: 'ready' }];
+
+function setup(opts: { json: unknown; ok?: boolean; rows?: unknown[] }) {
+  const authFetch = vi.fn().mockResolvedValue({
+    ok: opts.ok ?? true,
+    status: opts.ok === false ? 500 : 200,
+    json: async () => opts.json,
+  });
+  const dataSource = { find: vi.fn().mockResolvedValue(opts.rows ?? PRODUCTION_ROWS) };
+  const view = renderHook(() =>
+    useEnvironmentEntitlements({ enabled: true, dataSource, authFetch, apiBase: '' }),
+  );
+  return { view, authFetch, dataSource };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useEnvironmentEntitlements — envelope discipline', () => {
+  it('reads the summary out of the `{ success, data }` envelope', async () => {
+    const { view } = setup({
+      json: { success: true, data: { hasProductionEnv: true, plan: 'pro' } },
+    });
+
+    await waitFor(() => expect(view.result.current?.ready).toBe(true));
+    expect(view.result.current).toMatchObject({
+      source: 'summary',
+      hasProductionEnv: true,
+      plan: 'pro',
+    });
+  });
+
+  // The pin: a bare body must NOT produce a usable summary. Here the bare body
+  // claims `hasProductionEnv: false` while the org's rows show a real
+  // production env — so reading it would actively contradict reality. Strict
+  // read ⇒ no summary ⇒ the derived fallback resolves `true`.
+  it('does NOT read a bare (un-enveloped) body as a summary; falls back to rows', async () => {
+    const { view, dataSource } = setup({
+      json: { hasProductionEnv: false, plan: 'free' },
+    });
+
+    await waitFor(() => expect(view.result.current?.ready).toBe(true));
+    expect(view.result.current).toMatchObject({ source: 'derived', hasProductionEnv: true });
+    // `plan` only ever comes from the authoritative summary — the bare body's
+    // `free` must not leak into the state.
+    expect(view.result.current?.plan).toBeUndefined();
+    expect(dataSource.find).toHaveBeenCalledWith('sys_environment', expect.anything());
+  });
+
+  it('does NOT read an envelope whose `data` payload is missing', async () => {
+    const { view } = setup({ json: { success: true } });
+
+    await waitFor(() => expect(view.result.current?.ready).toBe(true));
+    expect(view.result.current).toMatchObject({ source: 'derived' });
+  });
+
+  it('still falls back to rows when the endpoint itself fails', async () => {
+    const { view } = setup({ ok: false, json: null });
+
+    await waitFor(() => expect(view.result.current?.ready).toBe(true));
+    expect(view.result.current).toMatchObject({ source: 'derived', hasProductionEnv: true });
+  });
+});

--- a/packages/app-shell/src/environment/useEnvironmentEntitlements.ts
+++ b/packages/app-shell/src/environment/useEnvironmentEntitlements.ts
@@ -7,7 +7,8 @@
  *      by the same helper the create guard uses). Gives plan + dev-create
  *      capability precisely, including the seat-scaled / subscription cases the
  *      client can't derive from rows.
- *   2. FALLBACK — when that endpoint is unavailable (older control plane / error),
+ *   2. FALLBACK — when that endpoint is unavailable (older control plane / error,
+ *      or a success body that doesn't carry the `{ success, data }` envelope),
  *      derive `hasProductionEnv` from the org's env rows via the data API (which
  *      is org-scoped on the control plane). This keeps the critical
  *      "set up your production environment" path working without a backend deploy;
@@ -72,8 +73,17 @@ export function useEnvironmentEntitlements(
           credentials: 'include',
         });
         if (!res.ok) return null;
-        const json = await res.json().catch(() => null);
-        const data = (json?.data ?? json) as EnvironmentEntitlementsSummary | undefined;
+        // Strict envelope read: the control plane wraps every success body as
+        // `{ success, data }` (cloud#1046), and `EnvironmentEntitlementsSummary`
+        // is declared as that `data` payload. A bare body is therefore a
+        // producer contract violation, not a second accepted dialect — reading
+        // it would yield a summary whose fields are all `undefined`, i.e. a
+        // silent `hasProductionEnv: false`. Returning null instead degrades to
+        // the `fromRows()` derivation, which resolves that signal for real.
+        const json = (await res.json().catch(() => null)) as
+          | { data?: EnvironmentEntitlementsSummary }
+          | null;
+        const data = json?.data;
         if (!data || typeof data !== 'object') return null;
         return {
           ready: true,


### PR DESCRIPTION
Fixes #3352

## 做了什么

控制面的成功响应按契约一律包成 `{ success, data }`，Console 侧却有 3 处读点「两种形状都收」。本 PR 把它们改成**严格只读 `data`**，拿不到就走各自**既有的**失败分支——逐处保留原语义，不统一成一种：

| 读点 | 原写法 | 改后拿不到 `data` 时 |
|:--|:--|:--|
| `environment/useEnvironmentEntitlements.ts` | `json?.data ?? json` | 返回 `null` → `fromRows()` 行派生回退 |
| `console/home/CloudOnboardingNext.tsx` | `json?.data ?? json` | `phase: 'unknown'` → 降级为两个按钮都给 |
| `console/organizations/provisionEnvironment.ts` | `'data' in body ? body.data : body` | 抛错 → 调用方既有的 lazy provision 兜底 |

## 为什么

这是 #3329（错误体半边，删 `entitlementErrorFields()` 的 `body?.error ?? body`）的**同族收尾**，方向一致：一种形状，严格读。

`??` 容错把一个事实上不存在的第二方言固化成了第二份事实契约，而且**失败是静默的**：一旦生产者漏包 `data`，裸 body 的字段全是 `undefined`，`hasProductionEnv` 直接读成 `false`——**一个明明有生产环境的用户会被告知「还没有生产环境」**，并被推到错误的 "Create your environment" CTA 上，没有任何一处会响。`provisionEnvironment` 那处更直接：原本会把裸 body（甚至 `{}`）当成功的 env 返回，报告一次「provision 成功」却什么都没带回来。

契约优先（AGENTS.md 准则 #0.1）：这类漏包是**生产者侧的 bug**，消费端的宽容只会把它藏起来。

## 契约核实（第 1 步）

cloud 仓不在本会话凭证范围内，改用 in-scope 证据链定案，三条互相印证：

1. **本仓内的契约声明**——`environment/entitlements.ts:181` 上的注释就写着 `EnvironmentEntitlementsSummary` 是 “GET /cloud/environment-entitlements → `data`”。summary 的宿主位置在类型声明层面本来就只有 `data` 一个，裸 body 分支从来没有 spec 依据。
2. **cloud#1046 已落地**——objectstack#4604 的 08-04 注销交班总账把 “#1046（两仓原子切换）” 列进已合入清单，并记 “错误信封收敛完成”。
3. **#3329 已按 strict 合入本仓**——其 PM 验收评论明确记录「无任何 `??` 跨形回退」，并把本单点名为「同一清理方向的下一单」。

线程内未发现任何相悖事实（例如「某端点未包信封」）。控制面是 SaaS 单版本部署，不存在 #3366 那种客户端跨代服务端存活的兼容窗口。

## 测试

三处各补了裸 body 的**负向 pin**，另新建了 `useEnvironmentEntitlements` 的测试文件（此前该 hook 无测试）。

反向验证**方向事先预判为「全红」，实测与预判一致**：把三条 `??` / `'data' in body` 限枝恢复成 `origin/main` 的写法后，6 条新 pin 全部转红，9 条既有/形状无关的测试保持绿：

```
× does NOT read a bare (un-enveloped) body as a summary; falls back to rows
× does NOT read an envelope whose `data` payload is missing
× does NOT read a bare (un-enveloped) 2xx body as the provisioned env
× throws when a 2xx body carries the envelope but no data payload
× does NOT read a bare (un-enveloped) body as a usable summary
× never strands a user behind a wrong "create" CTA when the envelope is missing
Test Files  3 failed (3)  |  Tests  6 failed | 9 passed (15)
```

恢复实现后：

- 三个受影响文件：`Test Files 3 passed (3) / Tests 15 passed (15)`
- app-shell 整包（走仓根 config）：`Test Files 276 passed (276) / Tests 2414 passed | 1 skipped (2415)`
- `type-check`（`tsc --noEmit` + typetests）：干净退出
- 六个改动文件 eslint：**0 errors**（11 条存量 warning，均在未触碰的行上）

其中 `useEnvironmentEntitlements` 那条 pin 特意让裸 body 声称 `hasProductionEnv: false`，而行数据里确有生产环境——严格读之后由行派生回退解析出 `true`，正好把「静默读错」这个后果本身钉住。

## 关于 changeset

**不带 changeset**。按仓库约定纯 bug 修复不需要；且在生产者遵守契约的前提下无用户可见行为变化——三处的失败分支都是既有路径，没有新增/改写任何 UI 文案。`provisionEnvironment` 新增的抛错被调用方 `CreateWorkspaceDialog` 既有的 `try/catch`（`console.warn` 后继续 `onCreated`）吞掉，不产生新的用户可见面。

## 范围

严格限于 issue 指定的 3 个读点 + 相应测试，未越界。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_