### PR TITLE
fix(a11y): 给两处表单控件补上 label→control 关联 (#3341)

### DIFF
--- a/.changeset/label-control-association-two-sites.md
+++ b/.changeset/label-control-association-two-sites.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/components': patch
+'@object-ui/plugin-detail': patch
+---
+
+Associate the label with its control at the two form surfaces where the two were never programmatically connected (objectui#3341 — found while implementing #3299/PR #3340, and deliberately left out of that PR's scope fence as a different class of defect).
+
+`aria-required` reaching the control (#3299) only fixes the required *state*; at these two sites the control's accessible *name* was still wrong, because the label pointed at nothing:
+
+- `@object-ui/plugin-detail` — `InlineCreateRelated`'s create-tab fields rendered a `<label>` with no `htmlFor` beside an `<Input>` with no `id`, and the two were siblings rather than wrapper/child. The field label was unreachable for assistive tech, and clicking the label did not focus the input. The ids are namespaced with `React.useId`, because `field.name` alone is unique only within one instance and a detail page mounts one of these per related list.
+- `@object-ui/components` — the custom `ActionParamDialog`'s `select` branch rendered `<Label htmlFor={param.name}>` but never put the matching `id` on its Radix `SelectTrigger`, so the reference dangled. The textarea / number / date / text branches already set `id={param.name}`; select was the only one that did not.
+
+`SelectTrigger` renders a `<button role="combobox">`, and `button` is a labelable element, so the plain `htmlFor`/`id` pair is the correct association there — no `aria-labelledby` required. No spec change and no widget-props contract change.

--- a/packages/components/src/__tests__/action-param-dialog-label-association.test.tsx
+++ b/packages/components/src/__tests__/action-param-dialog-label-association.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ActionParamDialog (components/custom) — the `select` branch's `htmlFor` must
+ * point at a control that actually exists (objectui#3341).
+ *
+ * Every branch renders `<Label htmlFor={param.name}>`, and textarea / number /
+ * date / text all set the matching `id={param.name}` on their `Input` /
+ * `Textarea`. The `select` branch did not: its control is a Radix
+ * `SelectTrigger`, which carried no `id`, so the label referenced a
+ * non-existent target and its text never reached the combobox — the one branch
+ * where the label was decorative.
+ *
+ * Measured pre-fix accessible name in this harness: the EMPTY string.
+ * `dom-accessibility-api` implements no `placeholder` fallback, so the
+ * observable failure is an unnamed combobox rather than one named "Select...".
+ * Either way the name was not the label, which is what these tests pin.
+ *
+ * `SelectTrigger` renders a `<button role="combobox">`, and `button` is a
+ * labelable element, so a plain `htmlFor`/`id` pair is the correct association
+ * here — no `aria-labelledby` needed (Radix sets none on the trigger).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { ActionParamDef } from '@object-ui/core';
+import { ActionParamDialog } from '../custom/action-param-dialog';
+
+afterEach(cleanup);
+
+function openDialog(params: ActionParamDef[]) {
+  return render(
+    <ActionParamDialog
+      params={params}
+      open
+      onSubmit={vi.fn()}
+      onCancel={vi.fn()}
+    />,
+  );
+}
+
+const def = (over: Partial<ActionParamDef>): ActionParamDef =>
+  ({ name: 'p1', label: 'Param One', type: 'text', ...over } as ActionParamDef);
+
+const selectParam = (over: Partial<ActionParamDef> = {}): ActionParamDef =>
+  def({
+    name: 'env',
+    label: 'Environment',
+    type: 'select',
+    options: [
+      { label: 'Production', value: 'prod' },
+      { label: 'Staging', value: 'stage' },
+    ],
+    ...over,
+  });
+
+describe('custom ActionParamDialog — select branch label→control association (objectui#3341)', () => {
+  it('gives the SelectTrigger the id its Label already pointed at', () => {
+    openDialog([selectParam()]);
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('id', 'env');
+
+    // The pre-fix state in one assertion: the label's target did not resolve.
+    const label = document.querySelector('label[for="env"]');
+    expect(label).not.toBeNull();
+    expect(document.getElementById('env')).toBe(trigger);
+  });
+
+  it('resolves the label to the combobox, so getByLabelText finds it', () => {
+    openDialog([selectParam()]);
+
+    // Optional param → the label's textContent is exactly "Environment".
+    // (RTL's label-text query reads raw textContent and does NOT honour
+    // `aria-hidden`, so a required param's label would read "Environment*";
+    // the required case is asserted on the accessible name below, where the
+    // `*` is correctly excluded.)
+    expect(screen.getByLabelText('Environment')).toBe(screen.getByRole('combobox'));
+  });
+
+  it('names the combobox from the LABEL, even with a placeholder present', () => {
+    openDialog([selectParam({ placeholder: 'Pick an environment' })]);
+
+    // Pre-fix this computed to '' because the label association did not
+    // resolve (see the file header).
+    expect(screen.getByRole('combobox')).toHaveAccessibleName('Environment');
+  });
+
+  it('keeps the required `*` out of the combobox accessible name', () => {
+    openDialog([selectParam({ required: true })]);
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAccessibleName('Environment');
+    // The #3299 state channel is untouched by this change.
+    expect(trigger).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('leaves the other branches label-associated exactly as before', () => {
+    // Fence: the select fix must not regress the branches that were already
+    // correct — all five typed branches now name themselves from their label.
+    openDialog([
+      def({ name: 'title', label: 'Title', type: 'text' }),
+      def({ name: 'reason', label: 'Reason', type: 'textarea' }),
+      def({ name: 'count', label: 'Count', type: 'number' }),
+      def({ name: 'due', label: 'Due', type: 'date' }),
+      selectParam(),
+    ]);
+
+    for (const [name, label] of [
+      ['title', 'Title'],
+      ['reason', 'Reason'],
+      ['count', 'Count'],
+      ['due', 'Due'],
+      ['env', 'Environment'],
+    ] as const) {
+      const control = document.getElementById(name);
+      expect(control, `no control rendered with id="${name}"`).not.toBeNull();
+      expect(control).toHaveAccessibleName(label);
+      expect(screen.getByLabelText(label)).toBe(control);
+    }
+  });
+});

--- a/packages/components/src/custom/action-param-dialog.tsx
+++ b/packages/components/src/custom/action-param-dialog.tsx
@@ -189,11 +189,11 @@ export const ActionParamDialog: React.FC<ActionParamDialogProps> = ({
               {/* The trigger IS the focusable combobox control, so both the
                   state and the `id` belong on it (the Radix root renders no
                   element of its own). Without the `id` the sibling
-                  `<Label htmlFor={param.name}>` pointed at nothing, and the
-                  combobox took its accessible name from the placeholder
-                  instead of the label — every other branch already sets it
-                  (objectui#3341). `button` is a labelable element, so the
-                  plain `htmlFor` association is enough here. */}
+                  `<Label htmlFor={param.name}>` pointed at nothing, so the
+                  label text never reached the combobox's accessible name —
+                  every other branch already sets the `id` (objectui#3341).
+                  `button` is a labelable element, so the plain `htmlFor`
+                  association is enough here; no `aria-labelledby` needed. */}
               <SelectTrigger id={param.name} aria-required={ariaRequired}>
                 <SelectValue placeholder={param.placeholder || 'Select...'} />
               </SelectTrigger>

--- a/packages/components/src/custom/action-param-dialog.tsx
+++ b/packages/components/src/custom/action-param-dialog.tsx
@@ -186,9 +186,15 @@ export const ActionParamDialog: React.FC<ActionParamDialogProps> = ({
               value={value || ''}
               onValueChange={(val) => handleChange(param.name, val)}
             >
-              {/* The trigger IS the focusable combobox control, so the state
-                  belongs on it (the Radix root renders no element of its own). */}
-              <SelectTrigger aria-required={ariaRequired}>
+              {/* The trigger IS the focusable combobox control, so both the
+                  state and the `id` belong on it (the Radix root renders no
+                  element of its own). Without the `id` the sibling
+                  `<Label htmlFor={param.name}>` pointed at nothing, and the
+                  combobox took its accessible name from the placeholder
+                  instead of the label — every other branch already sets it
+                  (objectui#3341). `button` is a labelable element, so the
+                  plain `htmlFor` association is enough here. */}
+              <SelectTrigger id={param.name} aria-required={ariaRequired}>
                 <SelectValue placeholder={param.placeholder || 'Select...'} />
               </SelectTrigger>
               <SelectContent>

--- a/packages/plugin-detail/src/InlineCreateRelated.tsx
+++ b/packages/plugin-detail/src/InlineCreateRelated.tsx
@@ -220,10 +220,12 @@ export const InlineCreateRelated: React.FC<InlineCreateRelatedProps> = ({
                 <div key={field.name}>
                   <label
                     // Programmatic label→control association (objectui#3341).
-                    // Without it the input's accessible name fell back to the
-                    // placeholder ("Enter name") and the label text — the real
-                    // field name — never reached assistive tech; clicking the
-                    // label also failed to focus the input.
+                    // Without it the label text — the real field name — never
+                    // reached the input's accessible name (a browser fell back
+                    // to the placeholder, "Enter name"; the jsdom accname
+                    // implementation has no placeholder fallback and produced
+                    // an empty name — see the test header). Clicking the label
+                    // also failed to focus the input.
                     htmlFor={fieldDomId(field.name)}
                     className="text-xs font-medium text-muted-foreground mb-1 block"
                   >

--- a/packages/plugin-detail/src/InlineCreateRelated.tsx
+++ b/packages/plugin-detail/src/InlineCreateRelated.tsx
@@ -65,6 +65,19 @@ export const InlineCreateRelated: React.FC<InlineCreateRelatedProps> = ({
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [isSearching, setIsSearching] = React.useState(false);
 
+  /**
+   * Namespace for the create-tab input ids (objectui#3341). `field.name` alone
+   * is unique only WITHIN one instance — a detail page renders one of these per
+   * related list, so two lists both offering a `name` field would emit
+   * duplicate ids and `<label for>` would resolve to whichever came first.
+   * `React.useId` supplies the per-instance half.
+   */
+  const instanceId = React.useId();
+  const fieldDomId = React.useCallback(
+    (fieldName: string) => `inline-create-${instanceId}-${fieldName}`,
+    [instanceId],
+  );
+
   const filteredResults = React.useMemo(() => {
     if (!searchQuery.trim()) return searchResults;
     const query = searchQuery.toLowerCase();
@@ -205,7 +218,15 @@ export const InlineCreateRelated: React.FC<InlineCreateRelatedProps> = ({
             <TabsContent value="create" className="space-y-3 mt-0">
               {fields.map((field) => (
                 <div key={field.name}>
-                  <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  <label
+                    // Programmatic label→control association (objectui#3341).
+                    // Without it the input's accessible name fell back to the
+                    // placeholder ("Enter name") and the label text — the real
+                    // field name — never reached assistive tech; clicking the
+                    // label also failed to focus the input.
+                    htmlFor={fieldDomId(field.name)}
+                    className="text-xs font-medium text-muted-foreground mb-1 block"
+                  >
                     {field.label}
                     {/* Visual-only (objectui#3299): the required STATE is
                         announced via `aria-required` on the input below. */}
@@ -214,6 +235,7 @@ export const InlineCreateRelated: React.FC<InlineCreateRelatedProps> = ({
                     )}
                   </label>
                   <Input
+                    id={fieldDomId(field.name)}
                     // State channel for required (objectui#3299) — not the native
                     // `required` attribute, per the #3290 ruling (it would arm the
                     // browser's constraint-validation UI alongside this form's own

--- a/packages/plugin-detail/src/__tests__/InlineCreateRelated.labelAssociation.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineCreateRelated.labelAssociation.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * InlineCreateRelated — the create-tab `<label>` must be programmatically
+ * associated with its `<Input>` (objectui#3341).
+ *
+ * Sibling-but-different-class defect to #3299: that one fixed "the required
+ * STATE never reaches the a11y tree". This one is "the label and the control
+ * were never connected at all" — pre-fix the `<label>` carried no `htmlFor`,
+ * the `<Input>` no `id`, and they were siblings rather than wrapper/child. The
+ * consequences were both machine-visible and user-visible:
+ *
+ *   - the label text never reached the input's accessible name, and
+ *   - clicking the label did not focus the input.
+ *
+ * Measured pre-fix accessible name in this harness: the EMPTY string.
+ * `dom-accessibility-api` implements no `placeholder` fallback (a real browser
+ * would fall back to "Enter name" per HTML-AAM), so the observable failure
+ * here is an unnamed control rather than a mis-named one. Either way the label
+ * was not the name, which is what these tests pin.
+ *
+ * The ids are namespaced with `React.useId` because `field.name` alone is only
+ * unique within ONE instance, and a detail page mounts one of these per related
+ * list.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { InlineCreateRelated } from '../InlineCreateRelated';
+import type { RelatedFieldDefinition } from '../InlineCreateRelated';
+
+afterEach(cleanup);
+
+const fields: RelatedFieldDefinition[] = [
+  { name: 'name', label: 'Name', type: 'string', required: true },
+  { name: 'notes', label: 'Notes', type: 'string' },
+];
+
+/** Mount with the create tab open (the collapsed state renders only buttons). */
+function openCreate(objectName = 'Contact') {
+  const utils = render(
+    <InlineCreateRelated
+      objectName={objectName}
+      relationshipField="account_id"
+      fields={fields}
+      onCreateRecord={vi.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(`New ${objectName}`) }));
+  return utils;
+}
+
+describe('InlineCreateRelated — label→control association (objectui#3341)', () => {
+  it('resolves the label to the input, so getByLabelText finds the control', () => {
+    openCreate();
+
+    // `Notes` is the OPTIONAL field, so its label text is exactly "Notes".
+    // (For a required field the label's textContent also contains the visual
+    // `*`; RTL's label-text query reads raw textContent and — unlike the
+    // accessible-name computation — does NOT honour `aria-hidden`. That is why
+    // the exact-string case uses the optional field; the required field is
+    // asserted below on the computed accessible name, where the `*` is
+    // correctly excluded.)
+    const notes = screen.getByLabelText('Notes');
+    expect(notes.tagName).toBe('INPUT');
+    expect(notes).toBe(screen.getByPlaceholderText('Enter notes'));
+  });
+
+  it('gives the input the LABEL as its accessible name', () => {
+    openCreate();
+
+    // Located by placeholder deliberately: that is the pre-fix identity of
+    // these inputs, and it is independent of the association under test.
+    // Pre-fix both of these computed to '' (see the file header).
+    expect(screen.getByPlaceholderText('Enter name')).toHaveAccessibleName('Name');
+    expect(screen.getByPlaceholderText('Enter notes')).toHaveAccessibleName('Notes');
+  });
+
+  it('keeps the visual `*` out of the required field\'s accessible name', () => {
+    openCreate();
+
+    // #3299 made the asterisk `aria-hidden`; now that the label actually feeds
+    // the accessible name, that matters — otherwise this would read "Name *".
+    const name = screen.getByPlaceholderText('Enter name');
+    expect(name).toHaveAccessibleName('Name');
+    expect(name).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('points htmlFor at an id that really exists on the input', () => {
+    const { container } = openCreate();
+
+    const label = container.querySelector('label[for]');
+    expect(label).not.toBeNull();
+    const target = document.getElementById(label!.getAttribute('for')!);
+    expect(target).not.toBeNull();
+    expect(target!.tagName).toBe('INPUT');
+  });
+
+  it('mints per-instance ids so two related lists on one page do not collide', () => {
+    // The regression this guards: ids derived from `field.name` alone would be
+    // identical across instances, and every `<label for="name">` on the page
+    // would resolve to the FIRST input — clicking the second list's label would
+    // focus the first list's box.
+    render(
+      <div>
+        <div data-testid="list-contact">
+          <InlineCreateRelated
+            objectName="Contact"
+            relationshipField="account_id"
+            fields={fields}
+            onCreateRecord={vi.fn()}
+          />
+        </div>
+        <div data-testid="list-task">
+          <InlineCreateRelated
+            objectName="Task"
+            relationshipField="account_id"
+            fields={fields}
+            onCreateRecord={vi.fn()}
+          />
+        </div>
+      </div>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /New Contact/ }));
+    fireEvent.click(screen.getByRole('button', { name: /New Task/ }));
+
+    const inputs = screen.getAllByLabelText('Notes');
+    expect(inputs).toHaveLength(2);
+    const ids = inputs.map((el) => el.id);
+    expect(ids[0]).toBeTruthy();
+    expect(ids[1]).toBeTruthy();
+    expect(ids[0]).not.toBe(ids[1]);
+
+    // …and each list's label resolves to the input inside its OWN subtree,
+    // which is precisely what a shared `id="notes"` would have broken.
+    const contact = within(screen.getByTestId('list-contact')).getByLabelText('Notes');
+    const task = within(screen.getByTestId('list-task')).getByLabelText('Notes');
+    expect(contact).not.toBe(task);
+    expect(new Set([contact.id, task.id]).size).toBe(2);
+  });
+
+  it('registers the label on the input via the DOM `labels` collection', () => {
+    // The association browsers use for BOTH the accessible name and
+    // click-to-focus. Asserted structurally rather than by clicking the label:
+    // jsdom forwards a label click to the control's activation behaviour but
+    // does not move focus, so a `toHaveFocus()` assertion here would be
+    // testing jsdom, not this component.
+    openCreate();
+
+    const notes = screen.getByLabelText('Notes') as HTMLInputElement;
+    expect(notes.labels).not.toBeNull();
+    expect(Array.from(notes.labels!)).toHaveLength(1);
+    expect(notes.labels![0].getAttribute('for')).toBe(notes.id);
+    expect(notes.labels![0]).toHaveTextContent('Notes');
+  });
+});


### PR DESCRIPTION
Fixes #3341

两处表单控件的 label 与控件之间**根本没有程序化关联**,导致控件的可访问名错误或缺失。这与 #3299(PR #3340)修的「必填状态不进 a11y 树」是**相邻但不同类**的缺陷:即便 `aria-required` 已经到位,可访问名仍然是错的。

## 前置核对(对当前 origin/main)

两处缺陷**均仍然成立**,行号已按合并后代码重新核对:

- `packages/plugin-detail/src/InlineCreateRelated.tsx` L208-L227:label 元素无 `htmlFor`,相邻的 Input 无 `id`,两者也不是包裹关系。
- `packages/components/src/custom/action-param-dialog.tsx` select 分支 L181-L193:`Label htmlFor={param.name}` 指向的 id 从未被渲染出来 —— 该分支的控件是 Radix SelectTrigger,没有设 `id`。其余 textarea / number / date / text 分支的 Input / Textarea 都设了 `id={param.name}`,只有 select 漏了。

## 修法

- **InlineCreateRelated**:label 加 `htmlFor`、Input 加 `id`。id 用 `React.useId` 做前缀命名空间(`inline-create-{uid}-{fieldName}`)—— `field.name` 只在**单个实例内**唯一,而一个详情页每个相关列表挂一个该组件,两个列表都提供 `name` 字段时裸用 `field.name` 会产生重复 id,`htmlFor` 会一律解析到第一个输入框。
- **custom action-param-dialog**:SelectTrigger 加 `id={param.name}`,让本就存在的 `htmlFor` 落到实处。SelectTrigger 渲染的是 `role="combobox"` 的 button,而 button 属于 labelable element,因此普通的 `htmlFor` / `id` 配对就是这里的正确关联方式,**不需要** `aria-labelledby`(Radix 也没有在 trigger 上设 `aria-labelledby`,那个是 SelectItem 用的)。

未动 spec,未动 widget props 契约。

## 测试

新增 11 条断言,两处各一个测试文件,覆盖验收口径:`getByLabelText` 命中控件 + `toHaveAccessibleName` 等于 label 文本。

**反向验证(方向为事前预测的「常规红」)**:把两处 `htmlFor`/`id` 还原成修复前的样子,**11 条全红**;恢复后全绿。失败信息正是缺陷本身 —— `Found a label with the text of: Notes, however no form control was found associated to that label`。

一处**与工单正文不符、按实测如实记录**的细节:工单说可访问名「退化到 placeholder(Enter name)」。实测在本测试环境下修复前的可访问名是**空字符串**,不是 placeholder —— `dom-accessibility-api` 根本没有实现 placeholder 兜底(两个版本里 `placeholder` 出现次数均为 0),真实浏览器才会按 HTML-AAM 兜底到 placeholder。两种情况下「可访问名不是 label」这个结论一致,测试钉的也是这一条;但测试头注释里写的是实测到的空字符串,而不是照抄工单的 placeholder 说法。

另外两条口径已在注释中写明,避免后来者踩坑:

- 精确字符串的 `getByLabelText` 用的是**非必填**字段。RTL 的 label-text 查询读的是原始 `textContent`,**不**尊重 `aria-hidden`,所以必填字段的 label 文本是 `Name*`;必填字段改为在**计算出的可访问名**上断言(那里 `*` 被正确排除)。这两个通道的差异是真实存在的,不是测试瑕疵。
- 「点击 label 聚焦输入框」改为断言 DOM 的 `labels` 集合。jsdom 会把 label 上的点击转发给控件的 activation behaviour,但**不移动焦点**,写 `toHaveFocus()` 等于在测 jsdom 而不是本组件。

```
pnpm exec vitest run packages/plugin-detail packages/components --maxWorkers=2
 Test Files  118 passed (118)
      Tests  965 passed (965)

turbo run type-check --filter=@object-ui/components --filter=@object-ui/plugin-detail
 Tasks:    13 successful, 13 total

turbo run lint --filter=@object-ui/components --filter=@object-ui/plugin-detail
 ✖ 760 problems (0 errors, 760 warnings)   # 全部为既有 warning
```

消费半径已扫过:两个组件除各自的测试与 barrel 导出外,没有其他包的 fixture 引用,不存在跨包 fixture 需要一并改。

已附 changeset(patch;按仓库约定不声明 major)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_