### PR TITLE
fix(console): type-check tsconfig.node.json and wire it into the gate (#3305)

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -45,7 +45,7 @@
     "dev": "vite",
     "build:plugin": "tsc -p tsconfig.plugin.json",
     "build": "tsc && vite build && pnpm build:plugin",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -b tsconfig.node.json --force",
     "lint": "eslint .",
     "build:analyze": "pnpm build && echo 'Bundle analysis available at dist/stats.html'",
     "preview": "vite preview",

--- a/apps/console/tsconfig.node.json
+++ b/apps/console/tsconfig.node.json
@@ -1,11 +1,27 @@
 {
   "compilerOptions": {
     "composite": true,
+    /* This project exists to be type-checked, not to ship anything: its output
+       is thrown away. It cannot say `noEmit` — `tsconfig.json` references it,
+       and a referenced project that disables emit is TS6310 — so instead the
+       emit is aimed at a gitignored cache directory. Left at the default it
+       writes .js/.d.ts next to every input (apps/console/vite.config.js,
+       scripts/vite-*.d.ts, …), and that untracked litter is a large part of why
+       this project was never wired into a gate (objectui#3305). */
+    "outDir": "../../node_modules/.cache/tsc/console-node",
+    /* `composite` defaults `rootDir` to this file's own directory, which would
+       put `../../scripts/vite-*.ts` outside it (TS6059). The project genuinely
+       spans both, so name the repo root explicitly. */
+    "rootDir": "../..",
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "strict": true
   },
-  "include": ["vite.config.ts", "vitest.setup.ts"]
+  /* `../../scripts/vite-*.ts` are the repo-level Vite plugins vite.config.ts
+     imports. They must be listed here or each one is a TS6307 ("not listed
+     within the file list of project") — the error that kept this project red,
+     and therefore ungated. */
+  "include": ["vite.config.ts", "vitest.setup.ts", "../../scripts/vite-*.ts"]
 }

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -1,4 +1,8 @@
-import { defineConfig } from 'vite';
+// `defineConfig` comes from `vitest/config`, not `vite` — this file carries a
+// `test` block (consumed by `vitest.config.ts`, which merges this config), and
+// `vite`'s own `UserConfigExport` has no `test` property. Importing it from
+// `vite` left that whole block unchecked (objectui#3305).
+import { defineConfig } from 'vitest/config';
 import type { Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
@@ -185,13 +189,20 @@ export default defineConfig({
     // Gzip/Brotli compression & bundle visualizer are skipped on Vercel/CI to
     // reduce memory usage — Vercel's CDN compresses assets automatically.
     ...(!isCI ? [
+      // `algorithms` (plural, an array) is the key vite-plugin-compression2
+      // declares. The singular `algorithm` used here before was never read: it
+      // fell through to the plugin's default, which is BOTH
+      // `['gzip', 'brotliCompress']` — so each of these two instances was
+      // compressing every asset twice, and the `.gz`/`.br` pair that made the
+      // build look correct came from the default, not from these options
+      // (objectui#3305).
       compression({
-        algorithm: 'gzip',
+        algorithms: ['gzip'],
         exclude: [/\.(br)$/, /\.(gz)$/],
         threshold: 1024,
       }),
       compression({
-        algorithm: 'brotliCompress',
+        algorithms: ['brotliCompress'],
         exclude: [/\.(br)$/, /\.(gz)$/],
         threshold: 1024,
       }),

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "typedoc-plugin-markdown": "^4.12.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
+    "vite": "^8.2.0",
     "vite-plugin-compression2": "^2.5.3",
     "vitest": "^4.1.10",
     "vitest-axe": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       typescript-eslint:
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      vite:
+        specifier: ^8.2.0
+        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vite-plugin-compression2:
         specifier: ^2.5.3
         version: 2.5.3(rollup@4.62.2)

--- a/turbo.json
+++ b/turbo.json
@@ -41,7 +41,11 @@
     "type-check": {
       "dependsOn": ["^build"],
       "outputs": [],
-      "cache": true
+      "cache": true,
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/scripts/vite-*.ts"
+      ]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
Fixes #3305

## 复核:premise 成立,且错误已从 5 条涨到 7 条

Issue 的基线是 `f44d8727f`,当前 `origin/main`(`0554e889c`)重跑,7 条:

```
$ pnpm exec tsc -b apps/console/tsconfig.node.json --force
apps/console/vite.config.ts(6,32): error TS6307: File '.../scripts/vite-crypto-stub.ts' is not listed within the file list of project ...
apps/console/vite.config.ts(7,36): error TS6307: File '.../scripts/vite-maplibre-worker.ts' is not listed within the file list of project ...
apps/console/vite.config.ts(189,9): error TS2561: ... 'algorithm' does not exist in type 'ViteCompressionPluginOption'. Did you mean to write 'algorithms'?
apps/console/vite.config.ts(194,9): error TS2561: ... 同上
apps/console/vite.config.ts(292,3): error TS2769: ... 'test' does not exist in type 'UserConfigExport'.
scripts/vite-crypto-stub.ts(1,29): error TS2307: Cannot find module 'vite' or its corresponding type declarations.
scripts/vite-maplibre-worker.ts(9,68): error TS2307: Cannot find module 'vite' or its corresponding type declarations.
```

多出的 2 条来自 issue 提出后新落的 `scripts/vite-maplibre-worker.ts` —— 正好实证了 issue 里那句预判:「任何住在 `scripts/` 的共享 vite 插件都会继承这个问题」。没门禁的文件会持续吸附新错误。

## 一处需要更正 issue 的判断:`algorithm` 在运行时**也**是失效的

Issue 说「实证 build 仍产 .gz 与 .br,所以运行时认这个键,属类型/运行时错位」。读已安装的 `vite-plugin-compression2@2.5.3` 运行时源码,这个归因是错的:

```js
// node_modules/vite-plugin-compression2/dist/index.mjs
let { ..., algorithms: d = ["gzip", "brotliCompress"], ... } = n;
```

`algorithm`(单数)**根本不在解构列表里**,从头到尾没被读过。两份 `.gz`/`.br` 不是因为运行时认了这个键,而是因为它落到了默认值 —— 而默认值是**两个算法都做**。也就是说这两个 plugin 实例**各自都在做 gzip + brotli,每个产物被压了两遍**。旧 build 日志里 `dist/vite.svg.br` 连续出现两次就是这个重复的痕迹。

结论不变(该修),但性质不是「类型说错了、运行时是对的」,而是**两端都错,只是默认值恰好掩盖了它**。修完每个实例只做自己那一个算法,重复功耗消失。

## 三个问题的修法

1. **`algorithm` → `algorithms: [...]`**,以已安装插件声明的键为准。
2. **`scripts/vite-*.ts` 的类型解析路径** —— 选择「留在 `scripts/`,补声明」而不是搬走。理由:`scripts/` 是本仓刻意维护的仓库级 TS 代码位置(root `vitest.config.mts` 的 `unit` project 显式 include 了 `scripts/**/*.test.ts`,那里现有 6 个测试文件);而 root `package.json` 本来就替 console 声明着 `vite-plugin-compression2` 和 `rollup-plugin-visualizer`。所以补一条 root `vite` devDependency 是顺着既有约定走,搬文件反而要连带搬测试、动 root vitest 的 include。已核验 root 与 apps/console 解析到**同一份** `vite@8.2.0`(realpath 相同),`Plugin` 不会裂成两个类型。
3. **`defineConfig` 改从 `vitest/config` 导入** —— `vite.config.ts` 的 `test` 块确实是活的(`apps/console/vitest.config.ts` 用 `mergeConfig` 合了进去),而 `vitest.config.ts` 自己早就是从 `vitest/config` 导入的,这里只是对齐。

## 接线(本单主交付)—— 两层,少一层就是假绿

### 第一层:console 的 type-check 真的跑这个 project

```diff
-"type-check": "tsc --noEmit",
+"type-check": "tsc --noEmit && tsc -b tsconfig.node.json --force",
```

走 `apps/console/package.json` 的 `type-check`,即 CI `ci.yml` 里 `pnpm type-check` 的既有挂点,不新增 workflow。

**`--force` 是有承载作用的,不是保险丝。** 我第一版写的是不带 `--force` 的 `tsc -b`,反向验证第 4 例(删掉 root 的 `vite` 解析)时它**报了绿** —— build 模式的 up-to-date 检查认为项目没变就整个跳过了。只有输入文件变化时才重跑,依赖变化会假绿。加 `--force` 后同一例正确变红。

### 第二层:turbo 的缓存 key 必须覆盖 `scripts/vite-*.ts`

第一层写完后我去验第二层,发现**接了等于没接**。`type-check` 任务没声明 `inputs`,turbo 只按各 package 自己目录下的文件算 hash;而这道门禁读的 `scripts/vite-*.ts` 在仓库根、不属于任何 package。

实测(改动前):

```
# 把 scripts/vite-crypto-stub.ts 改出一个真实类型错误后
@object-ui/console:type-check: cache hit, replaying logs 9b56b04fee5b19cc   # 与改动前同一个 hash
TURBO_EXIT=0                                                                # 绿

# 同一棵树上直接跑这条脚本:
../../scripts/vite-crypto-stub.ts(33,7): error TS2322: Type 'string' is not assignable to type 'number'.
DIRECT_EXIT=1                                                               # 红
```

CI 是跨 run 恢复 turbo 缓存的(`restore-keys: turbo-${{ runner.os }}-type-check-`),所以这个假绿在 CI 上同样可达,不只是本地现象。

修法是给任务补 `inputs`(`$TURBO_DEFAULT$` 放第一位,不收窄任何既有行为):

```json
"inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/scripts/vite-*.ts"]
```

改动后同一实验:

```
改动前基线:  cache miss, executing b804f2284a20c21d   TURBO_EXIT=0
改坏 script:  cache miss, executing 14b3af20777c366d   TURBO_EXIT=1  + TS2322   # hash 变了,红了
恢复 script:  cache hit,  replaying b804f2284a20c21d   TURBO_EXIT=0
```

这是本 PR 唯一一处超出 issue 文件面的改动(`turbo.json` 一处 `inputs`),属于接线本身的必要组成 —— 不补这层,第一层的门禁在 CI 上可以被缓存整个跳过。

## 验证

**门禁绿:**
```
$ pnpm --filter @object-ui/console type-check
> tsc --noEmit && tsc -b tsconfig.node.json --force
EXIT=0        # 工作树无新增未跟踪文件
```

**反向验证(防再腐)—— 预期方向事先声明:门禁就是一个编译器直接编译这几个文件,不存在计数/反转的微妙情况,五例都应当变红:**

| 例 | 改动 | 结果 |
|---|---|---|
| 1 | `algorithms` 退回 `algorithm` | 红 · TS2561 x2 |
| 2 | `defineConfig` 退回从 `vite` 导入 | 红 · TS2769 |
| 3 | include 去掉 `../../scripts/vite-*.ts` | 红 · TS6307 x2 |
| 4 | 移除 root 的 `vite` 解析 | 红 · TS2307 x2 |
| 5 | 改坏 `scripts/vite-crypto-stub.ts`,经 `turbo run type-check` | 红 · TS2322(补 `inputs` 前是**绿**,见上) |

全部按预期变红,恢复后基线 `EXIT=0`。

**.gz/.br 双产物实证(PM 要求):** 分别用修前(`algorithm`)与修后(`algorithms`)各跑一次 `vite build`,对产物清单做 diff:

```
before: 898 files | after: 898 files
RESULT: artifact sets are BYTE-IDENTICAL (no diff)
  .gz count: 449
  .br count: 449
```

产物集合完全不变,双算法照常产出;变化的只是不再压两遍。

**测试:**
```
$ pnpm exec vitest run --project unit --maxWorkers=2 scripts/__tests__
  Test Files  6 passed (6)   Tests  61 passed (61)

$ cd apps/console && pnpm exec vitest run --maxWorkers=2
  Test Files  22 passed (22)  Tests  208 passed (208)

$ node scripts/check-type-check-coverage.mjs
  type-check coverage: 43/45 via `type-check`, ... 0 known-broken
$ node scripts/check-changeset-fixed.mjs && node scripts/check-changeset-no-major.mjs
  All workspace packages are in the changeset fixed group. / No changeset declares a `major` bump.
$ pnpm exec eslint vite.config.ts     # EXIT=0
```

## 实现细节:为什么不是 `noEmit`

`tsconfig.json` 引用了这个 project,而被引用的 project 不许 `noEmit`(TS6310,实测会把现有的 `tsc --noEmit` 一起打红)。保持默认又会在每个输入旁边吐 `.js`/`.d.ts`(`apps/console/vite.config.js`、`scripts/vite-*.d.ts`),这堆未跟踪垃圾本身就是它当初难以接进门禁的原因之一。因此 `outDir` 指向 gitignore 覆盖的 `node_modules/.cache/tsc/console-node`,并显式写 `rootDir: "../.."`(`composite` 会把 `rootDir` 默认成本文件所在目录,导致 `../../scripts/*.ts` 越界 TS6059)。

## 关于 changeset

**未附 changeset**,按 AGENTS.md「功能改进需写 changeset;纯 bug 修复不需要」。本 PR 无任何用户可见变化 —— 构建产物集合已实证逐字节相同,改动全部落在类型门禁与构建工具链上;而 objectui 是 39 包 fixed 组联动发布,为纯工具链改动推一次全组版本并不合适。如果维护者希望留一条发布记录,我再补一个 patch changeset。

## 附带发现(未在本 PR 修,已另开 issue)

- #3384 — console 的 vite/vitest 配置依赖 `configLoader: 'native'` 将要移除的能力(`__dirname`、无扩展名的相对 import),现在只是警告,Vite 下个 major 翻默认值时会变成配置加载失败。
- #3385 — `apps/console/tsconfig.node.json` 的 include 一直列着 `vitest.setup.ts`,但该文件不存在(console 的 setup 是 `../../vitest.setup.dom.tsx`)。死路径,无害,按最小改动原则未顺手删。
