### PR TITLE
fix(components): 表单内置 textarea 分支只读 mobile_fullscreen，删掉无生产者的 fullscreen 别名 (#3303)

### DIFF
--- a/.changeset/form-fullscreen-flag-one-spelling.md
+++ b/.changeset/form-fullscreen-flag-one-spelling.md
@@ -1,0 +1,44 @@
+---
+"@object-ui/components": patch
+---
+
+The form renderer's built-in `textarea` branch reads the fullscreen long-text
+flag on one spelling (objectui#3303).
+
+FROM: the branch resolved the affordance as `mobile_fullscreen || fullscreen`,
+and both prop strips (`stripRendererOnlyProps`, `stripRegisteredFieldProps`)
+carried a matching entry discarding a `fullscreen` key. TO: a single read of
+`mobile_fullscreen`, with no strip entry left for the alias.
+
+No runtime behaviour changes for anything that exists, because the second term
+was permanently `undefined`. `fullscreen` had **no producer**: a repo-wide grep
+plus `objectstack`'s `packages/spec` turns up only the unrelated
+feedback/loading overlay property of the same name, never a form field. The one
+real producer is `ObjectForm`, which stamps `mobile_fullscreen` onto long-text
+fields from `ObjectFormSchema.mobile.fullscreenLongText` — the same single
+carrier `TextAreaField` and `RichTextField` read.
+
+This closes the last member of the convergence run objectui#3232 / #3233 /
+#3245 / #3301 started. The changeset for #3232 named this branch explicitly as
+"a separate live path" still accepting two spellings; it is now single-read like
+the two widgets, so the same authored metadata behaves the same way whether a
+field type resolves to a registered widget or falls through to the built-in
+branch.
+
+Why a no-producer alias is worth removing rather than leaving as harmless
+insurance: it is not insurance, it is a contract that never held. The renderer
+advertised a spelling to whoever reads it next — very much including an AI
+writing form metadata — and that spelling silently does nothing, with no error
+and nowhere to look. That is the lenient consumer fallback AGENTS.md #0.1
+forbids, and the identical mechanism behind #3245 and #3301. Dropping the strip
+entries matters for the same reason: a key nobody produces should not get a
+dedicated discard, it should be in the ordinary unrecognised-key class, so a
+typo is as visible as any other typo instead of being quietly swallowed.
+
+Pinned by tests in both places the alias lived: the built-in branch renders the
+expand affordance for `mobile_fullscreen` and not for `fullscreen` (the
+canonical case is asserted alongside the alias case, so the negative cannot pass
+for the empty reason of the affordance having disappeared altogether), and the
+strips are shown to own `mobile_fullscreen` — stripped from the top-level props,
+delivered on `field` — while `fullscreen` is now indistinguishable from an
+arbitrary unknown key.

--- a/packages/components/src/renderers/form/__tests__/form-fullscreen-flag-single-spelling.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-fullscreen-flag-single-spelling.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The fullscreen long-text flag has exactly ONE spelling — objectui#3303.
+ *
+ * The built-in (unregistered) `textarea` branch used to read the flag as
+ * `mobile_fullscreen || fullscreen`, and `stripRendererOnlyProps` /
+ * `stripRegisteredFieldProps` each carried a matching entry that discarded a
+ * `fullscreen` key. That alias had **zero producers**: a repo-wide grep (plus
+ * `objectstack`'s `packages/spec`) turned up only the unrelated
+ * feedback/loading overlay property of the same name. `ObjectForm` — the one
+ * and only producer — stamps `mobile_fullscreen` (#3245/#3300), so the second
+ * term of the `||` was undefined from the day it was written.
+ *
+ * A no-producer alias is not "one more layer of safety", it is the lenient
+ * consumer fallback AGENTS.md #0.1 forbids: the next author (very much
+ * including an AI writing form metadata) reads `fullscreen` off the renderer,
+ * spells it that way, and gets silence — no dialog, no error, nowhere to look.
+ * That is the same mechanism as #3245 and #3301.
+ *
+ * What these tests pin, in the two places the alias lived:
+ *
+ *   1. the built-in branch honours `mobile_fullscreen` and ONLY that. The
+ *      canonical case is asserted alongside the alias case on purpose — a
+ *      lone "the alias renders no expand button" assertion would also pass if
+ *      the fullscreen affordance stopped rendering altogether, i.e. it would
+ *      be green for an empty reason.
+ *   2. the prop strips own `mobile_fullscreen` and no longer name
+ *      `fullscreen`, so a misspelled flag is now handled exactly like any
+ *      other unrecognised authored key rather than being quietly swallowed by
+ *      a dedicated discard entry.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: false, showCancel: false, fields }} />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('form renderer — built-in textarea reads one fullscreen spelling (objectui#3303)', () => {
+  it('renders the expand affordance for the canonical `mobile_fullscreen`', () => {
+    // The positive half. Without it the alias assertion below would be
+    // satisfied by a branch that renders no expand button for ANY input.
+    renderForm([{ name: 'notes', label: 'Notes', type: 'textarea', mobile_fullscreen: true }]);
+
+    expect(screen.getByTestId('form-textarea-fullscreen-toggle')).toBeInTheDocument();
+  });
+
+  it('still opens and commits through the dialog on the canonical spelling', () => {
+    // Narrowing the read must not disturb the surviving path: the draft model
+    // (edit → Done → value lands in form state) is what the flag is FOR.
+    renderForm([{ name: 'notes', label: 'Notes', type: 'textarea', mobile_fullscreen: true }]);
+
+    fireEvent.click(screen.getByTestId('form-textarea-fullscreen-toggle'));
+    fireEvent.change(screen.getByTestId('form-textarea-fullscreen-input'), {
+      target: { value: 'committed from the dialog' },
+    });
+    fireEvent.click(screen.getByTestId('form-textarea-fullscreen-save'));
+
+    expect(screen.queryByTestId('form-textarea-fullscreen-dialog')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Notes')).toHaveValue('committed from the dialog');
+  });
+
+  it('does NOT honour the producer-less `fullscreen` alias', () => {
+    // The nail. Before #3303 this field DID render the expand button and the
+    // dialog, through the `|| fullscreen` limb — which is precisely the
+    // problem: a spelling nothing in the repo produces nevertheless "worked"
+    // here, and nowhere else (`TextAreaField` / `RichTextField` are both
+    // single-read), so the same metadata behaved differently depending on
+    // whether the field type happened to resolve to a registered widget.
+    //
+    // React logs its usual "Received `true` for a non-boolean attribute"
+    // warning here now, because the key survives the strip and reaches the
+    // `<textarea>` like any other unrecognised prop. That noise is the point:
+    // the typo is visible instead of silent. It is not asserted on, since the
+    // exact wording belongs to React, not to this contract.
+    renderForm([{ name: 'notes', label: 'Notes', type: 'textarea', fullscreen: true }]);
+
+    expect(screen.queryByTestId('form-textarea-fullscreen-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('form-textarea-fullscreen-dialog')).not.toBeInTheDocument();
+    // A plain textarea, not "nothing rendered" — so the assertions above are
+    // about the affordance being absent, not about the field being absent.
+    expect(screen.getByLabelText('Notes').tagName).toBe('TEXTAREA');
+  });
+
+  it('renders a plain textarea when neither spelling is present', () => {
+    renderForm([{ name: 'notes', label: 'Notes', type: 'textarea' }]);
+
+    expect(screen.getByLabelText('Notes').tagName).toBe('TEXTAREA');
+    expect(screen.queryByTestId('form-textarea-fullscreen-toggle')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Props the probe was rendered with, captured per render.
+ *
+ * A holder object rather than a bare module variable: `react-hooks/globals`
+ * forbids REASSIGNING an outer binding from a component body, and mutating a
+ * property of a stable object is the repo's usual shape for a probe
+ * (see `form-field-carrier.test.tsx`).
+ */
+const captured: { props: Record<string, any> | null } = { props: null };
+
+/** Stands in for a registered field widget — `@object-ui/components` tests never load `@object-ui/fields`. */
+function StripProbe(props: any) {
+  captured.props = props;
+  return <input data-testid={`probe-${props.name}`} value={(props.value as string) ?? ''} readOnly />;
+}
+
+describe('form renderer — the prop strips own `mobile_fullscreen` only (objectui#3303)', () => {
+  beforeAll(() => {
+    ComponentRegistry.register('stripprobe', StripProbe, { namespace: 'field' });
+  }, 30000);
+
+  beforeEach(() => {
+    captured.props = null;
+  });
+
+  it('strips the canonical flag but leaves the alias in the ordinary unknown-key class', () => {
+    renderForm([
+      {
+        name: 'notes',
+        label: 'Notes',
+        type: 'stripprobe',
+        mobile_fullscreen: true,
+        fullscreen: true,
+        // A control key with no meaning to anyone. Whatever the renderer does
+        // with THIS is what an unrecognised key gets, and after #3303
+        // `fullscreen` is one of those.
+        not_a_real_flag: true,
+      },
+    ]);
+
+    const props = captured.props!;
+    expect(props).not.toBeNull();
+
+    // `mobile_fullscreen` is renderer-owned: it is stripped from the top-level
+    // props precisely so widgets cannot grow a second read of it. Its one legal
+    // carrier is `field` (objectui#3232/#3233/#3245).
+    expect(props.mobile_fullscreen).toBeUndefined();
+    expect(props.field.mobile_fullscreen).toBe(true);
+
+    // …and `fullscreen` is not renderer-owned at all any more. The assertion is
+    // NOT "widgets should receive `fullscreen`" — it is that the renderer has no
+    // dedicated entry for it, so it is indistinguishable from any other typo.
+    // Re-adding `fullscreen: _fullscreen` to either strip turns this red.
+    expect(props.fullscreen).toBe(props.not_a_real_flag);
+    expect(props.fullscreen).toBe(true);
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -256,7 +256,6 @@ function stripRendererOnlyProps<T extends Record<string, any>>(props: T): T {
     fieldContainerClass: _fieldContainerClass,
     mobileStickyActions: _mobileStickyActions,
     mobile_fullscreen: _mobileFullscreen,
-    fullscreen: _fullscreen,
     dependentValues: _dependentValues,
     dependsOn: _dependsOn,
     // objectstack#5407 — the sibling name→label map is for widgets that NAME a
@@ -318,7 +317,6 @@ function stripRegisteredFieldProps(type: string, props: RenderFieldProps): Rende
     fieldContainerClass: _fieldContainerClass,
     mobileStickyActions: _mobileStickyActions,
     mobile_fullscreen: _mobileFullscreen,
-    fullscreen: _fullscreen,
     dependentValues,
     dependsOnLabels,
     emptyHint,
@@ -2013,9 +2011,18 @@ function renderFieldComponent(type: string, props: RenderFieldProps) {
       );
 
     case 'textarea': {
-      const { mobile_fullscreen, fullscreen, label } = fieldProps as any;
+      // `mobile_fullscreen` is the flag's ONE spelling (objectui#3303). This
+      // branch used to read `mobile_fullscreen || fullscreen`; the second term
+      // had no producer anywhere in this repo or in `@objectstack/spec` — the
+      // only `fullscreen` properties that exist belong to the unrelated
+      // feedback/loading overlay — so it was undefined from the day it was
+      // written, while advertising a spelling that silently does nothing to
+      // whoever reads this file next (AGENTS.md #0.1). `ObjectForm` is the sole
+      // producer and it stamps `mobile_fullscreen` (#3245/#3300), which is also
+      // the single spelling `TextAreaField` and `RichTextField` read.
+      const { mobile_fullscreen, label } = fieldProps as any;
       const { label: _label, ...rest } = stripRendererOnlyProps(fieldProps);
-      if (mobile_fullscreen || fullscreen) {
+      if (mobile_fullscreen) {
         return (
           <FullscreenTextarea
             placeholder={placeholder}


### PR DESCRIPTION
Fixes #3303

## 做了什么

按 PM 裁定的 A 方案收敛：表单渲染器内置 `textarea` 分支只读 `mobile_fullscreen` 一种拼法。

1. `packages/components/src/renderers/form/form.tsx` 内置 `textarea` 分支：
   `mobile_fullscreen || fullscreen` → `mobile_fullscreen`。
2. 同文件 `stripRendererOnlyProps` 与 `stripRegisteredFieldProps` 各自丢弃
   `fullscreen` 键的那一条（别名的最后残留）一并删除。
3. 新增钉子测试
   `packages/components/src/renderers/form/__tests__/form-fullscreen-flag-single-spelling.test.tsx`。
4. changeset 一份（见下面「为什么补了 changeset」）。

## 前提复核（issue 行号基于 08-03 快照）

issue 写的是 `form.tsx:1945-1947`，而今天 #3392 刚改过同一文件。**已对当前
`origin/main`（4eeb932aa）复核，别名读取仍在**，只是行号漂到 2016-2018；两处 strip
条目漂到 259 / 321。前提成立。

「`fullscreen` 零生产者」也机械复核过：全仓 + 全扩展名 grep 一个裸 `fullscreen`
键，只剩两类无关命中 —— feedback/loading 遮罩的同名属性
（`packages/types/src/zod/feedback.zod.ts`、`renderers/feedback/loading.tsx`，
按裁定不碰），以及各 locale 文件里的 `fullscreen:` 词条命名空间。没有任何一处是表单字段。

## 为什么这不是「多一层保险」

`ObjectForm` 是唯一生产者，产出的键叫 `mobile_fullscreen`（#3245/#3300），也是
`TextAreaField` / `RichTextField` 单读的那一个。所以 `|| fullscreen` 从写下起恒为
undefined —— 它的代价不是取错值，而是**多了一种拼法**：下一个作者（尤其是写表单元数据的
AI）从渲染器里读到 `fullscreen`，照着写，静默无效、没有任何一处报错。这正是 AGENTS.md
0.1 禁止的消费侧宽容兜底，与 #3245、#3301 同一机制。

两处 strip 条目同理：一个没人产出的键不该享有**专门的丢弃条目**，它应该落回普通的
「不认识的键」那一类，这样拼错才和其它拼错一样可见，而不是被悄悄吞掉。

顺带说明，#3232 那份 changeset 当初明确把这个内置分支记为「另一条仍接受两种拼法的活路径」，
本 PR 就是把那条 forward reference 关掉，#3232/#3233/#3245/#3301 这一串收敛到此收口。

## 反向验证（方向是先定后跑的）

跑之前先记下预期：钉子里「金丝雀」用例（元数据只写 `fullscreen: true`）应当
**改前红、改后绿**；因为 fixture 故意不写规范键，`||` 的第二项才是决定项 —— 这不是
canonical-key-first 那种「改前后都红」的反转家族。

改前（未动源码，只加测试）实测：

```
 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

两条红的正是要钉的两条：别名用例渲染出了展开按钮（dump 里能看到
`lucide-maximize2` 的 button），strip 用例里 `props.fullscreen` 是 `undefined`
（说明当时确实有专门的丢弃条目）。**两条限肢都是活的**，不是空绿。

改后：

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## 钉子怎么写的

- **正例与反例成对**：只断言「别名不渲染展开按钮」是会**因为空的理由变绿**的 —— 全屏能力整个
  失效时它同样通过。所以同一 describe 里先钉住 `mobile_fullscreen` 确实渲染展开按钮、
  且开-改-Done 的 draft/commit 语义仍然完好。
- **strip 语义单独钉**：只钉内置分支的话，删掉两处 strip 条目是**零测试覆盖**的，后人原样加
  回去不会有任何东西变红。所以用一个探针 field widget 断言：`mobile_fullscreen` 仍被 strip
  掉（它只走 `field` 这一个载体），而 `fullscreen` 现在与一个随手编的 `not_a_real_flag`
  行为完全一致。断言写成两者相等，意思不是「widget 应该收到 `fullscreen`」，而是
  「渲染器不再为它保留专门条目」。

## 消费半径已扫

两个 strip 只在 form.tsx 的 `renderFieldComponent` 里被调用，但它们的下游是**所有**注册
字段 widget。按消费半径（不是按改动包）扫了 fixture：全仓没有任何 fixture 拼过表单字段级的
`fullscreen`，所以没有需要改拼写 / 补声明 / 整条替换的 fixture。

## 明确没做（按裁定）

- ⛔ `FullscreenTextarea` 第三份实现与 `packages/fields` 的 `FullscreenFieldEditor`
  合并 —— components 依赖 fields 方向反，需单独裁决。
- ⛔ #3393 的 label prop 问题（同落在这一行的解构上，串行下一单）。
- ⛔ feedback/loading 的同名无关属性。

## 为什么补了 changeset

PM 说纯收敛可免、由 dev 判。判下来是**补**：这一族（#3232/#3245/#3301）每一单都发了
changeset，且 #3232 那份正文里对本分支留了 forward reference，不补会让发布说明里这串收敛
断在半路。定为 `patch` / `@object-ui/components`；`check-changeset-no-major` 已过。

## 验证

- 新钉子 5/5 绿，并用 `--reporter=verbose` 按**文件名**确认确实跑到了（objectui#3288/#3378
  的路径过滤被吞陷阱）。
- 表单渲染器全目录 + 三个跨包 fullscreen 消费者（fields 的 TextAreaField / RichTextField、
  plugin-form 的 ObjectForm、types 的字段元数据）一起从仓根跑：
  `Test Files 31 passed (31) / Tests 153 passed (153)`。
- `turbo run type-check --filter=@object-ui/components`：8/8 successful。
- `turbo run lint --filter=@object-ui/components`：0 errors（770 条既有 warning 全在
  `src/ui/**` 免动区等无关文件；新测试文件只有 3 条 `no-explicit-any`，与同目录既有探针测试
  `form-field-carrier.test.tsx` 同款）。
- `pnpm check:control-bytes`：OK。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_