### PR TITLE
fix(fields): 注册路径的全屏长文本对话框接上 i18n(#3404)

### DIFF
--- a/.changeset/fullscreen-field-editor-i18n.md
+++ b/.changeset/fullscreen-field-editor-i18n.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/fields': patch
+---
+
+fix(fields): translate the registered path's fullscreen long-text dialog (objectui#3404)
+
+`FullscreenFieldEditor` — the expand button and dialog that `TextAreaField`
+(`field:textarea`) and `RichTextField` (`field:markdown` / `field:html`) render
+when `ObjectFormSchema.mobile.fullscreenLongText` is on — shipped four English
+literals: the toggle's accessible name (`Edit {label} fullscreen`), the title
+fallback `Edit text`, `Cancel` and `Done`.
+
+No translation was missing. `form.fullscreen.*` and `common.cancel` have shipped
+in all ten locale packs since objectui#3272 translated the built-in branch; this
+path simply never consumed them. The result was visible inside a SINGLE form: a
+zh session saw 「取消 / 完成」 on a built-in-rendered long-text field and
+`Cancel / Done` on a registered-widget one.
+
+All four now consume those existing keys — **no new keys, no locale-pack
+change**. The dialog also gained the sr-only `form.fullscreen.description` the
+built-in branch already carries, so it has an accessible description
+(`aria-describedby`) instead of none.
+
+Copy resolves through `useFieldTranslation()` (`createSafeTranslation`), as the
+built-in branch does, whose English defaults are byte-identical to the literals
+they replace — so widgets rendered with no `I18nProvider` (standalone/embedded
+hosts) render exactly what they did before rather than raw i18n keys.

--- a/packages/fields/src/widgets/FullscreenFieldEditor.tsx
+++ b/packages/fields/src/widgets/FullscreenFieldEditor.tsx
@@ -11,12 +11,14 @@ import {
   cn,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
   Button,
 } from '@object-ui/components';
 import { Maximize2, Check, X } from 'lucide-react';
+import { useFieldTranslation } from './useFieldTranslation';
 
 /**
  * The fullscreen-edit affordance shared by every long-text widget: the "expand"
@@ -99,6 +101,27 @@ import { Maximize2, Check, X } from 'lucide-react';
  * had found. The editor's own test id belongs to `children` for the same
  * reason.
  *
+ * ## Copy (objectui#3404)
+ *
+ * Every string here goes through `useFieldTranslation()` and consumes the
+ * EXISTING `form.fullscreen.*` / `common.cancel` keys — the same ones the
+ * built-in branch consumes since objectui#3272. Nothing was missing from the
+ * ten locale packs; this path simply never read them, so a zh session opened a
+ * dialog reading `Cancel` / `Done` while a long-text field rendered by the
+ * built-in branch **in the same form** read 「取消 / 完成」.
+ *
+ * Sharing the keys rather than minting `fields.fullscreen.*` twins is the
+ * point: one form-level setting (`mobile.fullscreenLongText`) projects onto
+ * both render paths, so two copies of this copy could only drift.
+ *
+ * `useFieldTranslation` (not bare `useObjectTranslation`) because this widget
+ * is rendered without an `I18nProvider` by standalone/embedded hosts and by
+ * every bare-render test in this package. Measured before the change: with no
+ * provider mounted `useObjectTranslation().t('common.cancel')` returns
+ * `"common.cancel"` — the raw key — and the `{{label}}` interpolation collapses
+ * entirely. The safe hook's English defaults are byte-identical to the literals
+ * they replaced, so the provider-less rendering is unchanged.
+ *
  * Focus management, `Esc`, the overlay and the close button are Radix's, via
  * the repo's `Dialog` (`@object-ui/components`) — deliberately not re-answered
  * here.
@@ -165,6 +188,7 @@ export function FullscreenFieldEditor({
   footer,
   toggleClassName,
 }: FullscreenFieldEditorProps) {
+  const { t } = useFieldTranslation();
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState(value ?? '');
 
@@ -194,7 +218,9 @@ export function FullscreenFieldEditor({
           'disabled:opacity-50 disabled:pointer-events-none',
           toggleClassName,
         )}
-        aria-label={`Edit ${label ?? 'text'} fullscreen`}
+        aria-label={t('form.fullscreen.toggle', {
+          label: label ?? t('form.fullscreen.textFallback'),
+        })}
         data-testid={`${testIdPrefix}-fullscreen-toggle`}
       >
         <Maximize2 className="size-3.5" />
@@ -206,14 +232,27 @@ export function FullscreenFieldEditor({
           data-testid={`${testIdPrefix}-fullscreen-dialog`}
         >
           <DialogHeader className="p-4 border-b">
-            <DialogTitle className="text-base">{label ?? 'Edit text'}</DialogTitle>
+            <DialogTitle className="text-base">{label ?? t('form.fullscreen.title')}</DialogTitle>
+            {/*
+              Parity with the built-in branch (`form.tsx`), which has carried
+              this sr-only line since #3272. Without it Radix reports no
+              `descriptionPresent` and omits `aria-describedby` altogether, so
+              the registered path's dialog had no accessible description while
+              the identical built-in one did — and `form.fullscreen.description`
+              was a key with no consumer here. (The missing-Description console
+              warning older Radix versions emitted is NOT why: @radix-ui/react-dialog
+              1.1.23 contains no `console.*` call at all, verified before adding this.)
+            */}
+            <DialogDescription className="sr-only">
+              {t('form.fullscreen.description')}
+            </DialogDescription>
           </DialogHeader>
           <div className="flex-1 min-h-0 p-4">{children(draft, setDraft, disabled)}</div>
           <DialogFooter className="p-3 border-t flex-row justify-between sm:justify-end gap-2">
             {footer?.(draft)}
             <div className="flex gap-2 ml-auto">
               <Button type="button" variant="ghost" onClick={cancelFullscreen}>
-                <X className="size-4 mr-1" /> Cancel
+                <X className="size-4 mr-1" /> {t('common.cancel')}
               </Button>
               <Button
                 type="button"
@@ -221,7 +260,7 @@ export function FullscreenFieldEditor({
                 disabled={disabled}
                 data-testid={`${testIdPrefix}-fullscreen-save`}
               >
-                <Check className="size-4 mr-1" /> Done
+                <Check className="size-4 mr-1" /> {t('form.fullscreen.done')}
               </Button>
             </div>
           </DialogFooter>

--- a/packages/fields/src/widgets/__tests__/FullscreenFieldEditor.i18n.test.tsx
+++ b/packages/fields/src/widgets/__tests__/FullscreenFieldEditor.i18n.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The REGISTERED path's fullscreen long-text dialog speaks the session locale —
+ * objectui#3404.
+ *
+ * This is the second half of objectui#3272. That issue translated the built-in
+ * branch (`FullscreenTextarea` in `components/src/renderers/form/form.tsx`,
+ * pinned next door in `form-fullscreen-textarea-i18n.test.tsx`); the shared
+ * `FullscreenFieldEditor` that `TextAreaField` and `RichTextField` render was
+ * left with four English literals — the toggle's accessible name
+ * (`Edit ${label} fullscreen`), the title fallback `Edit text`, `Cancel` and
+ * `Done`.
+ *
+ * Nothing about the keys was missing: `form.fullscreen.*` and `common.cancel`
+ * have shipped in all ten locale packs since #3272. This path simply never
+ * consumed them, so the defect was visible INSIDE A SINGLE FORM: with
+ * `ObjectFormSchema.mobile.fullscreenLongText` on, `ObjectForm` stamps
+ * `mobile_fullscreen` onto every long-text field, and a zh session got
+ * 「取消 / 完成」 from a built-in-rendered field and `Cancel / Done` from a
+ * registered-widget one.
+ *
+ * ## What the cases assert, and why in this shape
+ *
+ * - **Both widgets.** `TextAreaField` (`field:textarea`) and `RichTextField`
+ *   (`field:markdown` / `field:html`) are the two hosts, and the copy lives in
+ *   the component they share. Covering one would leave a regression that broke
+ *   only the other's props path (`label`, `testIdPrefix`) unreported.
+ * - **`en` is a NO-OP pin, not a defect reproducer.** The four literals were
+ *   byte-identical to the `en` pack, so the English cases below were green
+ *   before this change too. They are here to prove the swap did not alter the
+ *   English rendering — the direction that only a positive assertion can see.
+ * - **Non-`en` positive AND English-literal negative, together.** A re-inlined
+ *   literal rendered next to a translated sibling still satisfies a
+ *   positive-only assertion. `ja` joins `zh` because the toggle's name is
+ *   INTERPOLATED (`{{label}}` + a translated generic noun) and the two packs
+ *   put the noun on opposite sides — a build that dropped the interpolation
+ *   passes a zh-only check by luck.
+ * - **Un-labelled fixtures for the generic copy.** `form.fullscreen.title` and
+ *   `form.fullscreen.textFallback` are reachable only when the field has no
+ *   `label` (a labelled field titles the dialog with its own label, in the
+ *   author's language, on both paths). The labelled stack is pinned separately
+ *   at the bottom, where what matters is that `{{label}}` is interpolated into
+ *   translated surroundings rather than concatenated in English.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+
+import { TextAreaField } from '../TextAreaField';
+import { RichTextField } from '../RichTextField';
+import type { FieldMetadata } from '@object-ui/types';
+
+/**
+ * No `label` — the one authoring stack the generic copy is written for. The
+ * flag is spelled `mobile_fullscreen`, the single carrier `ObjectForm`
+ * produces (#3233/#3301).
+ */
+const textareaField = (extra: Record<string, unknown> = {}) =>
+  ({ name: 'notes', type: 'textarea', mobile_fullscreen: true, ...extra }) as unknown as FieldMetadata;
+
+const markdownField = (extra: Record<string, unknown> = {}) =>
+  ({ name: 'notes', type: 'markdown', mobile_fullscreen: true, ...extra }) as unknown as FieldMetadata;
+
+function renderIn(language: string, element: React.ReactElement) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      {element}
+    </I18nProvider>,
+  );
+}
+
+/** Open the dialog and hand back the trigger, so its name can be asserted too. */
+function openFullscreen(prefix: 'textarea' | 'richtext') {
+  const toggle = screen.getByTestId(`${prefix}-fullscreen-toggle`);
+  fireEvent.click(toggle);
+  return toggle;
+}
+
+describe('TextAreaField fullscreen dialog is translated (objectui#3404)', () => {
+  it('renders the English copy under an en provider', () => {
+    renderIn('en', <TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    const toggle = openFullscreen('textarea');
+
+    // Byte-identical to the literals this replaced, so `en` is a no-op change.
+    expect(toggle).toHaveAttribute('aria-label', 'Edit text fullscreen');
+    expect(screen.getByText('Edit text')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+  });
+
+  it('renders the whole dialog in Chinese under a zh provider', () => {
+    renderIn('zh', <TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    const toggle = openFullscreen('textarea');
+
+    expect(toggle).toHaveAttribute('aria-label', '全屏编辑文本');
+    expect(screen.getByText('编辑文本')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '取消' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '完成' })).toBeInTheDocument();
+
+    // The four literals, asserted absent. `Edit text` is matched loosely
+    // because it was BOTH the dialog title and part of the trigger's name.
+    expect(screen.queryByText(/edit text/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
+    expect(toggle.getAttribute('aria-label')).not.toMatch(/fullscreen/i);
+  });
+
+  it('renders the whole dialog in Japanese under a ja provider', () => {
+    renderIn('ja', <TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    const toggle = openFullscreen('textarea');
+
+    expect(toggle).toHaveAttribute('aria-label', 'テキストを全画面で編集');
+    expect(screen.getByText('テキストを編集')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '完了' })).toBeInTheDocument();
+
+    expect(screen.queryByText(/edit text/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
+  });
+});
+
+describe('RichTextField fullscreen dialog is translated (objectui#3404)', () => {
+  // The second host of the SAME component. The copy is shared, the props path
+  // into it (`label`, `testIdPrefix`) is not.
+  it('renders the English copy under an en provider', () => {
+    renderIn('en', <RichTextField value="# hello" onChange={vi.fn()} field={markdownField()} />);
+    const toggle = openFullscreen('richtext');
+
+    expect(toggle).toHaveAttribute('aria-label', 'Edit text fullscreen');
+    expect(screen.getByText('Edit text')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+  });
+
+  it('renders the whole dialog in Chinese under a zh provider', () => {
+    renderIn('zh', <RichTextField value="# hello" onChange={vi.fn()} field={markdownField()} />);
+    const toggle = openFullscreen('richtext');
+
+    expect(toggle).toHaveAttribute('aria-label', '全屏编辑文本');
+    expect(screen.getByText('编辑文本')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '取消' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '完成' })).toBeInTheDocument();
+
+    expect(screen.queryByText(/edit text/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Done' })).not.toBeInTheDocument();
+    expect(toggle.getAttribute('aria-label')).not.toMatch(/fullscreen/i);
+  });
+});
+
+describe('fullscreen dialog copy — the field label is interpolated, not concatenated (objectui#3404)', () => {
+  it("titles the dialog with the author's label and interpolates it into the trigger name", () => {
+    // A labelled field keeps its own label as the title on both paths — what
+    // must be translated around it is the trigger's sentence. `Edit Notes
+    // fullscreen` was the literal; zh wraps the label instead of prefixing it.
+    renderIn(
+      'zh',
+      <TextAreaField value="hello" onChange={vi.fn()} field={textareaField({ label: 'Notes' })} />,
+    );
+    const toggle = openFullscreen('textarea');
+
+    expect(toggle).toHaveAttribute('aria-label', '全屏编辑Notes');
+    expect(screen.getByText('Notes')).toBeInTheDocument();
+    expect(toggle.getAttribute('aria-label')).not.toMatch(/^Edit /);
+  });
+
+  it('still commits the draft — translating the footer did not unwire it', () => {
+    // "Done" lost its literal child. This pins that the click handler still
+    // rides on the translated button and not on some node that merely used to
+    // carry the old text.
+    const onChange = vi.fn();
+    renderIn('zh', <TextAreaField value="hello" onChange={onChange} field={textareaField()} />);
+    openFullscreen('textarea');
+
+    fireEvent.change(screen.getByTestId('textarea-fullscreen-input'), {
+      target: { value: 'hello from fullscreen' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '完成' }));
+
+    expect(onChange).toHaveBeenCalledWith('hello from fullscreen');
+    expect(screen.queryByTestId('textarea-fullscreen-dialog')).not.toBeInTheDocument();
+  });
+
+  it('still discards the draft on the translated Cancel', () => {
+    const onChange = vi.fn();
+    renderIn('zh', <TextAreaField value="hello" onChange={onChange} field={textareaField()} />);
+    openFullscreen('textarea');
+
+    fireEvent.change(screen.getByTestId('textarea-fullscreen-input'), {
+      target: { value: 'discarded' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('textarea-fullscreen-dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('fullscreen dialog has an accessible description (objectui#3404)', () => {
+  /**
+   * The issue listed this as an unverified aside. What was measured: Radix
+   * only sets `aria-describedby` when a `Dialog.Description` is present
+   * (`descriptionPresent ? descriptionId : undefined`), so before this change
+   * the registered path's dialog had NO accessible description while the
+   * byte-identical built-in one did, and `form.fullscreen.description` was a
+   * key with no consumer on this path.
+   *
+   * Explicitly NOT justified by a console warning: `@radix-ui/react-dialog`
+   * 1.1.23 (the pinned version) contains no `console.*` call at all — the
+   * missing-Description warning older versions emitted is gone upstream, and
+   * no warning fired in the baseline run.
+   */
+  it('wires aria-describedby to the translated sr-only description', () => {
+    renderIn('zh', <TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    openFullscreen('textarea');
+
+    const dialog = screen.getByTestId('textarea-fullscreen-dialog');
+    const describedBy = dialog.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    const description = document.getElementById(describedBy!);
+    expect(description).not.toBeNull();
+    expect(description).toHaveTextContent('编辑完整的文本内容，然后保存或取消更改。');
+  });
+
+  it('renders the English description under an en provider', () => {
+    renderIn('en', <TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    openFullscreen('textarea');
+
+    expect(
+      screen.getByText('Edit the full text value, then save or cancel your changes.'),
+    ).toBeInTheDocument();
+  });
+});
+
+// The provider-LESS leg lives in `FullscreenFieldEditor.no-provider.test.tsx`.
+// It cannot share this file: mounting `I18nProvider` installs its instance as
+// react-i18next's GLOBAL default, so after any case above there is no
+// "no provider" state left in this module graph to observe. See that file's
+// header — it was measured, not assumed.

--- a/packages/fields/src/widgets/__tests__/FullscreenFieldEditor.no-provider.test.tsx
+++ b/packages/fields/src/widgets/__tests__/FullscreenFieldEditor.no-provider.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The shared fullscreen long-text dialog with NO `I18nProvider` mounted
+ * (objectui#3404) — standalone/embedded hosts, and most of this package's own
+ * bare-render tests.
+ *
+ * ## Why this leg decided the implementation
+ *
+ * Routing the copy through i18n must not turn it into raw keys where nothing
+ * is configured. MEASURED on the pre-change tree with a probe rendering bare
+ * `useObjectTranslation()` and no provider:
+ *
+ *     {"cancel":"common.cancel","done":"form.fullscreen.done",
+ *      "title":"form.fullscreen.title","toggle":"form.fullscreen.toggle"}
+ *
+ * Raw keys on every one, and the `{{label}}` interpolation gone entirely —
+ * strictly WORSE than the English literals being replaced. So
+ * `FullscreenFieldEditor` consumes `useFieldTranslation()`
+ * (`createSafeTranslation` + English defaults, the same shape the built-in
+ * branch has used since objectui#3272) rather than the bare hook, and the
+ * defaults are byte-identical to the old literals so this rendering is
+ * unchanged.
+ *
+ * ## Why a separate FILE and not another `describe`
+ *
+ * Mounting `I18nProvider` calls `initReactI18next`, which installs that
+ * instance as react-i18next's GLOBAL default. Once any sibling case has done
+ * so there is no "no provider" state left in the module graph, and these
+ * assertions would pass by reading that leaked instance instead of the
+ * fallback — green for the wrong reason. That is not a hypothetical: these
+ * cases were FIRST written inside `FullscreenFieldEditor.i18n.test.tsx`, and
+ * the reverse check (swap `useFieldTranslation` back to bare
+ * `useObjectTranslation`, expect red) left them GREEN there while it correctly
+ * turned `RichTextField.mobileFullscreen.test.tsx` red. Split out, the same
+ * swap turns them red — which is what makes them a pin.
+ *
+ * Same split, same reason as `TagsField.placeholder.no-provider.test.tsx` and
+ * `OptionsEmptyState.no-provider.test.tsx`; vitest's per-file isolation is
+ * what makes the observation honest.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { TextAreaField } from '../TextAreaField';
+import type { FieldMetadata } from '@object-ui/types';
+
+const textareaField = (extra: Record<string, unknown> = {}) =>
+  ({ name: 'notes', type: 'textarea', mobile_fullscreen: true, ...extra }) as unknown as FieldMetadata;
+
+function openFullscreen() {
+  const toggle = screen.getByTestId('textarea-fullscreen-toggle');
+  fireEvent.click(toggle);
+  return toggle;
+}
+
+describe('fullscreen dialog copy — English fallback survives with no i18n configured (objectui#3404)', () => {
+  it('renders the English defaults, not raw keys', () => {
+    render(<TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    const toggle = openFullscreen();
+
+    // Byte-identical to the literals this change replaced.
+    expect(toggle).toHaveAttribute('aria-label', 'Edit text fullscreen');
+    expect(screen.getByText('Edit text')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+
+    // The measured failure mode, stated directly — a raw key reaching a user.
+    expect(document.body.textContent).not.toMatch(/form\.fullscreen\./);
+    expect(document.body.textContent).not.toMatch(/common\.cancel/);
+  });
+
+  it('still interpolates the field label into the trigger name', () => {
+    // `createSafeTranslation`'s fallback does its own `{{k}}` replacement.
+    // Bare `useObjectTranslation` returns `form.fullscreen.toggle` verbatim
+    // here, label dropped.
+    render(
+      <TextAreaField value="hello" onChange={vi.fn()} field={textareaField({ label: 'Notes' })} />,
+    );
+
+    expect(openFullscreen()).toHaveAttribute('aria-label', 'Edit Notes fullscreen');
+  });
+
+  it('the code-shipped defaults carry no CJK (Commandment #-1)', () => {
+    // With no provider mounted, whatever renders here came from CODE
+    // (FIELD_DEFAULTS). Escaped ranges on purpose: a literal CJK class would
+    // itself violate the commandment this asserts (same shape as
+    // `TagsField.placeholder.no-provider.test.tsx`).
+    render(<TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    openFullscreen();
+
+    expect(screen.getByTestId('textarea-fullscreen-dialog').textContent).not.toMatch(
+      /[\u3000-\u30ff\u4e00-\u9fff]/,
+    );
+  });
+
+  it('still gives the dialog an accessible description', () => {
+    render(<TextAreaField value="hello" onChange={vi.fn()} field={textareaField()} />);
+    openFullscreen();
+
+    const describedBy = screen
+      .getByTestId('textarea-fullscreen-dialog')
+      .getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent(
+      'Edit the full text value, then save or cancel your changes.',
+    );
+  });
+});

--- a/packages/fields/src/widgets/useFieldTranslation.ts
+++ b/packages/fields/src/widgets/useFieldTranslation.ts
@@ -78,6 +78,36 @@ const FIELD_DEFAULTS: Record<string, string> = {
   // objectui#3342 — the tags widget's input hint. Used only when the field
   // author declared no `placeholder` of their own (author declaration wins).
   'fields.tags.placeholder': 'Type and press Enter to add…',
+  // objectui#3404 — the shared fullscreen long-text dialog
+  // (`FullscreenFieldEditor`, reached from `TextAreaField` and
+  // `RichTextField` when `mobile_fullscreen` is set).
+  //
+  // Deliberately the SAME `form.fullscreen.*` / `common.cancel` keys the
+  // built-in branch consumes (`FullscreenTextarea` in
+  // `components/src/renderers/form/form.tsx`, objectui#3272) rather than
+  // `fields.fullscreen.*` twins. One form-level setting
+  // (`ObjectFormSchema.mobile.fullscreenLongText`) projects onto BOTH render
+  // paths inside a single form, so a second copy of this copy is guaranteed
+  // drift — the shape #3231/#3263 had to undo — and would mean editing ten
+  // locale packs to say what they already say. `common.cancel` is already
+  // declared above and is reused here for exactly that reason.
+  //
+  // The values are byte-identical to the English literals they replaced, so
+  // a widget rendered with no I18nProvider (standalone/embedded hosts, and
+  // every bare-render test in this package) shows what it always did instead
+  // of a raw key. Measured before the change: with no provider mounted, bare
+  // `useObjectTranslation().t` returns the key itself
+  // (`common.cancel` → "common.cancel"), which is why this goes through
+  // `createSafeTranslation` like the built-in branch does.
+  'form.fullscreen.title': 'Edit text',
+  'form.fullscreen.description': 'Edit the full text value, then save or cancel your changes.',
+  'form.fullscreen.done': 'Done',
+  // Kept as ONE interpolated sentence with a translated generic noun standing
+  // in for a missing label — the literal's own shape
+  // (`Edit ${label ?? 'text'} fullscreen`). A second, label-less sentence key
+  // would need ten new pack entries to say the same thing.
+  'form.fullscreen.toggle': 'Edit {{label}} fullscreen',
+  'form.fullscreen.textFallback': 'text',
   // objectui#2600 B5 — capability picker scope group headers.
   'capability.group.platform': 'Platform',
   'capability.group.org': 'Organization',


### PR DESCRIPTION
Fixes #3404

## 问题

`packages/fields/src/widgets/FullscreenFieldEditor.tsx` 四处英文字面量:展开按钮的可访问名(`Edit ${label ?? 'text'} fullscreen`)、标题兜底 `Edit text`、`Cancel`、`Done`。

**键一个都不缺** —— `form.fullscreen.*` 与 `common.cancel` 自 #3272 给内置分支做国际化起就在十个语言包里齐全,只是这条路径从没消费。可达性也不是理论上的:`mobile.fullscreenLongText` 打开后 `ObjectForm` 给每个长文本字段盖 `mobile_fullscreen`,于是**同一张表单内**,内置分支渲染的字段显示「取消 / 完成」,注册 widget 渲染的显示 Cancel / Done。

## 改动

四处全部改为消费**既有**键,**零新增键、十个语言包一行未动**。另补上内置分支早已有的 sr-only `form.fullscreen.description`,详见下。

**关键实现选择:走 `useFieldTranslation()` 而不是 issue 正文提到的裸 `useObjectTranslation`。** 这一点是实测决定的,不是偏好。本包 widget 会被独立/嵌入宿主以及本包绝大多数测试**不带 `I18nProvider`** 裸渲染,而在改动前的树上实测裸 hook 在无 provider 时返回的是原始键:

```
{"cancel":"common.cancel","done":"form.fullscreen.done",
 "title":"form.fullscreen.title","toggle":"form.fullscreen.toggle"}
```

`{{label}}` 插值也整个塌掉 —— 比它要替换的英文字面量**更差**。`useFieldTranslation`(`createSafeTranslation`)正是内置分支自 #3272 起用的形状,其英文兜底与原字面量逐字节相同,因此无 provider 的渲染结果完全不变。相应地,英文兜底项加在了本包既有的 `FIELD_DEFAULTS`(`useFieldTranslation.ts`)里 —— 那是代码内的英文兜底表,不是语言包,**仍是零新增 i18n 键**;`common.cancel` 本就在表内,直接复用。

## 「顺带观察」的 DialogDescription:补了,但理由与 issue 猜测的不同

issue 猜测可能触发 Radix 的 missing-Description 警告。**实测该警告不存在**:锁定的 `@radix-ui/react-dialog@1.1.23` 整个文件里一个 `console.*` 调用都没有,上游已移除该警告,baseline 跑也确实没有任何告警输出。

补它的真实理由是另外两条:Radix 仅在存在 Description 时才设置 `aria-describedby`(`descriptionPresent ? descriptionId : undefined`),所以改动前这条路径的对话框**根本没有可访问描述**,而逐像素相同的内置对话框有;且 `form.fullscreen.description` 在此路径上是个无消费者的键 —— 与本 issue 主体是同一处漂移。同文件、零新键。

## 测试

新增两个文件,合计 14 例,textarea 与 richtext 两个 widget 各覆盖:

- `__tests__/FullscreenFieldEditor.i18n.test.tsx` —— en 正向(与旧字面量逐字节相同,证明 en 是 no-op)、zh/ja 正向 + **英文字面量反向断言**(只做正向断言的话,重新内联的字面量挨着翻译过的兄弟节点照样能过);ja 是因为 toggle 名是插值的、两个包把通用名词放在句子两端,只测 zh 会蒙混过关。另含 label 插值、`aria-describedby`、以及提交/取消仍然接线正常。
- `__tests__/FullscreenFieldEditor.no-provider.test.tsx` —— 无 provider 的那条腿,含 Commandment #-1 的无 CJK 断言。

**为什么无 provider 那几例必须单独成文件(这是本 PR 返工过的一处):** 它们最初写在 i18n 文件里。反向验证(把 `useFieldTranslation` 换回裸 `useObjectTranslation`,预期变红)时它们**依然全绿**,而同一次实验正确地把 `RichTextField.mobileFullscreen.test.tsx` 弄红了。原因是 `I18nProvider` 会调用 `initReactI18next`,把实例装成 react-i18next 的**全局默认**;同文件内只要有一例挂过 provider,就再也没有「无 provider」状态可观测 —— 那几例是靠读泄漏的全局实例而绿的,属于「因为什么都没发生而通过」的假绿。拆成独立文件后,同样的替换实验让它们如实变红(`aria-label="form.fullscreen.toggle"`),这才算真的钉住。同样的拆分理由见 `TagsField.placeholder.no-provider.test.tsx`。

### 反向验证方向

- **主改动:** 预期红 → 实测红。改动前跑新 i18n 套件:`Tests 6 failed | 2 passed`,失败的正是 zh/ja 各例(`Received: aria-label="Edit text fullscreen"`);通过的 2 例是两个 `en` 用例 —— 它们**改动前后都绿**,因为字面量与 en 包逐字节相同。这一点如实记录:en 用例是 no-op 保护,不是缺陷复现器。
- **实现选择:** 换回裸 hook → 4 例红,报出 `aria-label="form.fullscreen.toggle"` 原始键,其中一例是**既有的** `RichTextField.mobileFullscreen.test.tsx`(它按 `'Edit Release notes fullscreen'` 查按钮)。

### 命令与结果

从**仓根**跑(包内跑会假绿 / 路径过滤被吞,见 #3288/#3378),并以文件名核对确实执行:

```
npx vitest run --maxWorkers=2 packages/fields packages/plugin-form \
  packages/components/src/renderers/form packages/i18n
  → Test Files 139 passed (139) / Tests 1552 passed (1552)

pnpm --filter @object-ui/fields type-check   → 干净(需先 build 依赖图)
pnpm check:control-bytes                     → OK(3598 个文件)
eslint(4 个改动文件)                          → 0 问题
```

按消费半径而非编辑包扫了 fixture:`packages/plugin-form/src/__tests__/ObjectForm.mobileFullscreen.test.tsx` 在 `packages/fields` 之外也消费这个组件,已纳入上面的运行范围;`packages/i18n` 的语言包 parity 套件一并跑过,确认没有包漂移。

## 范围

严格限定在 `FullscreenFieldEditor.tsx` + 测试 + changeset(patch),外加 `useFieldTranslation.ts` 里的英文兜底项 —— 那是让本次改动**不产生回归**所必需的最小外扩(理由见上),且不属于裁定禁止的 form.tsx / 语言包 / TextAreaField / RichTextField 任何一项。未碰 form.tsx,未碰任何 locale 文件,未改两个宿主 widget。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_