### PR TITLE
fix(a11y): 用真 label 命名 InlineCreateRelated 的 Link 页签搜索框 (#3381)

### DIFF
--- a/.changeset/link-tab-search-accessible-name.md
+++ b/.changeset/link-tab-search-accessible-name.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+Give `InlineCreateRelated`'s "Link Existing" search box a real accessible name (objectui#3381 — the neighbouring defect found while implementing #3341/PR #3380, and left out of that PR's scope fence as a different class).
+
+The box carried a `placeholder` and nothing else: no `<label>`, no `aria-label`, no `aria-labelledby`. Its accessible name therefore fell through to the placeholder, which is the last resort in HTML-AAM and fails in two ways — the name a browser derives from it is the one thing that disappears the moment the user types, and the fallback is not implemented uniformly (`dom-accessibility-api` has no placeholder step at all, so under test the control computed to the empty string while a browser would have said "Search Contact…").
+
+The fix is a visually hidden `<label htmlFor>` pointing at a `React.useId`-namespaced input id — the same shape #3341 left on the create tab, rather than an `aria-label`, so the accessible name stays a real label element instead of a detached string that can drift from the visible copy. The label text and the placeholder are now derived from one expression (the placeholder only adds the ellipsis), and the id uses a hyphenated `link-search` segment so it cannot collide with a create-tab field literally named `search`. The decorative magnifier is explicitly `aria-hidden` — lucide already defaults childless icons to that, but spelling it out keeps the intent local and independent of the icon library's defaults.
+
+No props, spec or rendered-copy change: the placeholder string is byte-identical to before.

--- a/packages/plugin-detail/src/InlineCreateRelated.tsx
+++ b/packages/plugin-detail/src/InlineCreateRelated.tsx
@@ -78,6 +78,24 @@ export const InlineCreateRelated: React.FC<InlineCreateRelatedProps> = ({
     [instanceId],
   );
 
+  /**
+   * The link-tab search box (objectui#3381). Same namespacing rationale as
+   * `fieldDomId`; the hyphenated `link-search` segment cannot collide with a
+   * `fieldDomId(...)` suffix, which is a metadata field name (`[a-z0-9_]+`).
+   */
+  const searchInputId = `inline-create-${instanceId}-link-search`;
+  /**
+   * Single source for the search box's name: the visible-to-AT `<label>` below
+   * and the placeholder are the SAME string (the placeholder only adds the
+   * ellipsis). Before #3381 there was no label at all, so the accessible name
+   * fell through to the placeholder — the last resort in HTML-AAM, which (a)
+   * is what a real browser shows only until the user types, and (b) is not
+   * implemented at all by `dom-accessibility-api`, so under test the control
+   * had NO name. Keeping both strings on one expression is what stops the
+   * label and the placeholder from drifting apart later.
+   */
+  const searchLabel = `Search ${objectName}`;
+
   const filteredResults = React.useMemo(() => {
     if (!searchQuery.trim()) return searchResults;
     const query = searchQuery.toLowerCase();
@@ -276,9 +294,27 @@ export const InlineCreateRelated: React.FC<InlineCreateRelatedProps> = ({
           {onLinkRecord && (
             <TabsContent value="link" className="space-y-3 mt-0">
               <div className="relative">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                {/* Visually hidden rather than `aria-label` (objectui#3381):
+                    the accessible name stays a real label element, on the same
+                    expression as the placeholder, so the two cannot drift the
+                    way a detached `aria-label` string does. `sr-only` is the
+                    repo's existing shape for a search box whose name is carried
+                    by the magnifier icon visually (see app-shell's
+                    SearchResultsPage). */}
+                <label htmlFor={searchInputId} className="sr-only">
+                  {searchLabel}
+                </label>
+                {/* Decorative: the name is on the label above. lucide-react
+                    already defaults childless, a11y-prop-less icons to
+                    `aria-hidden`, but that is a dependency default — spelling
+                    it out keeps the intent local and survives an icon-lib bump. */}
+                <Search
+                  aria-hidden="true"
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground"
+                />
                 <Input
-                  placeholder={`Search ${objectName}…`}
+                  id={searchInputId}
+                  placeholder={`${searchLabel}…`}
                   value={searchQuery}
                   onChange={(e) => handleSearchChange(e.target.value)}
                   className="h-8 text-sm pl-8"

--- a/packages/plugin-detail/src/__tests__/InlineCreateRelated.linkSearchLabel.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineCreateRelated.linkSearchLabel.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * InlineCreateRelated — the LINK tab's search box needs a real accessible name
+ * (objectui#3381).
+ *
+ * Third of the family, and a different class from both predecessors:
+ *   - #3299 — the required STATE never reached the a11y tree;
+ *   - #3341 — a label EXISTED but was never associated with its control;
+ *   - this one — the search box had NO label of any kind (no `<label>`, no
+ *     `aria-label`, no `aria-labelledby`), so its accessible name fell through
+ *     to the placeholder.
+ *
+ * Why placeholder-as-name is the bug and not merely a style nit:
+ *   - it is the LAST resort in HTML-AAM, and the visible hint it names is gone
+ *     the moment the user types the first character;
+ *   - the fallback is not implemented uniformly. `dom-accessibility-api` (what
+ *     jest-dom's `toHaveAccessibleName` computes with) has no placeholder step
+ *     at all, so pre-fix this control computed to the EMPTY string here while a
+ *     real browser would have said "Search Contact…".
+ *
+ * Both halves are pinned below: the name must be the label, and — the split
+ * between a real label and a placeholder standing in for one — it must survive
+ * the user typing. The label text is deliberately `Search Contact` while the
+ * placeholder is `Search Contact…`; the trailing ellipsis makes the two
+ * distinguishable, so "the name is not just the placeholder read back" is
+ * assertable in EITHER implementation, including one that does fall back.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { InlineCreateRelated } from '../InlineCreateRelated';
+
+afterEach(cleanup);
+
+const records = [
+  { id: '1', label: 'Northwind Traders', description: 'Customer' },
+  { id: '2', label: 'Contoso Ltd', description: 'Partner' },
+];
+
+/** Mount and open the link tab (the collapsed state renders only buttons). */
+function openLink(objectName = 'Contact') {
+  const utils = render(
+    <InlineCreateRelated
+      objectName={objectName}
+      relationshipField="account_id"
+      fields={[{ name: 'name', label: 'Name', type: 'string' }]}
+      onCreateRecord={vi.fn()}
+      onLinkRecord={vi.fn()}
+      existingRecords={records}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Link Existing/ }));
+  return utils;
+}
+
+describe('InlineCreateRelated — link-tab search box accessible name (objectui#3381)', () => {
+  it('resolves a label to the search input, so getByLabelText finds the control', () => {
+    openLink();
+
+    const search = screen.getByLabelText('Search Contact');
+    expect(search.tagName).toBe('INPUT');
+    // Located independently by the pre-fix identity of this box — its
+    // placeholder — to prove both queries land on the same element.
+    expect(search).toBe(screen.getByPlaceholderText('Search Contact…'));
+  });
+
+  it('gives the search input the LABEL as its accessible name', () => {
+    openLink();
+
+    // Pre-fix this computed to '' in this harness (see the file header).
+    const search = screen.getByPlaceholderText('Search Contact…');
+    expect(search).toHaveAccessibleName('Search Contact');
+  });
+
+  it('keeps the accessible name AFTER the user types, when the placeholder is gone', () => {
+    // The dividing line between a real label and placeholder-as-label: a
+    // browser stops showing the placeholder at the first keystroke, so a name
+    // sourced from it is a name that disappears exactly when the user is
+    // deepest in the interaction.
+    openLink();
+
+    const search = screen.getByPlaceholderText('Search Contact…') as HTMLInputElement;
+    fireEvent.change(search, { target: { value: 'North' } });
+
+    expect(search.value).toBe('North');
+    expect(search).toHaveAccessibleName('Search Contact');
+    // …and the box is live, i.e. this is the real search control, not a
+    // look-alike: the non-matching record is filtered out.
+    expect(screen.getByText('Northwind Traders')).toBeInTheDocument();
+    expect(screen.queryByText('Contoso Ltd')).not.toBeInTheDocument();
+  });
+
+  it('does not source the name from the placeholder', () => {
+    // Implementation-independent form of the assertion above: even where the
+    // placeholder fallback DOES exist (real browsers), the computed name must
+    // not be the placeholder string.
+    openLink();
+
+    const search = screen.getByLabelText('Search Contact');
+    expect(search.getAttribute('placeholder')).toBe('Search Contact…');
+    expect(search).not.toHaveAccessibleName('Search Contact…');
+  });
+
+  it('tracks objectName in both the label and the placeholder', () => {
+    // Both strings come off one expression; this pins that they stay in sync.
+    openLink('Opportunity');
+
+    const search = screen.getByLabelText('Search Opportunity');
+    expect(search).toHaveAttribute('placeholder', 'Search Opportunity…');
+    expect(search).toHaveAccessibleName('Search Opportunity');
+  });
+
+  it('registers the label on the input via the DOM `labels` collection', () => {
+    // The association a browser uses for BOTH the accessible name and
+    // click-to-focus — asserted structurally, as in the #3341 suite (jsdom /
+    // happy-dom do not move focus on a label click).
+    openLink();
+
+    const search = screen.getByLabelText('Search Contact') as HTMLInputElement;
+    expect(search.labels).not.toBeNull();
+    expect(Array.from(search.labels!)).toHaveLength(1);
+    expect(search.labels![0].getAttribute('for')).toBe(search.id);
+    expect(search.labels![0]).toHaveTextContent('Search Contact');
+  });
+
+  it('mints a per-instance id so two related lists on one page do not collide', () => {
+    // Same regression #3341 guarded for the create tab: a constant id would
+    // make every `<label for>` on the page resolve to the FIRST search box.
+    render(
+      <div>
+        <div data-testid="list-a">
+          <InlineCreateRelated
+            objectName="Contact"
+            relationshipField="account_id"
+            fields={[]}
+            onLinkRecord={vi.fn()}
+            existingRecords={records}
+          />
+        </div>
+        <div data-testid="list-b">
+          <InlineCreateRelated
+            objectName="Contact"
+            relationshipField="opportunity_id"
+            fields={[]}
+            onLinkRecord={vi.fn()}
+            existingRecords={records}
+          />
+        </div>
+      </div>,
+    );
+    const [triggerA, triggerB] = screen.getAllByRole('button', { name: /Link Existing/ });
+    fireEvent.click(triggerA);
+    fireEvent.click(triggerB);
+
+    const boxes = screen.getAllByLabelText('Search Contact');
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].id).toBeTruthy();
+    expect(boxes[1].id).toBeTruthy();
+    expect(boxes[0].id).not.toBe(boxes[1].id);
+
+    const a = within(screen.getByTestId('list-a')).getByLabelText('Search Contact');
+    const b = within(screen.getByTestId('list-b')).getByLabelText('Search Contact');
+    expect(a).not.toBe(b);
+  });
+
+  it('does not collide with a create-tab field literally named "search"', () => {
+    // `fieldDomId` suffixes the instance id with the metadata field name, so a
+    // field called `search` lands on `…-search`. The search box uses the
+    // hyphenated `link-search` segment for exactly this reason — the two ids
+    // are minted from the same instance id and must still differ.
+    render(
+      <InlineCreateRelated
+        objectName="Contact"
+        relationshipField="account_id"
+        fields={[{ name: 'search', label: 'Search term', type: 'string' }]}
+        onCreateRecord={vi.fn()}
+        onLinkRecord={vi.fn()}
+        existingRecords={records}
+      />,
+    );
+    // Read the create-tab id first: Radix unmounts the inactive tab's content,
+    // so the two inputs are never in the DOM at the same moment.
+    fireEvent.click(screen.getByRole('button', { name: /New Contact/ }));
+    const fieldId = screen.getByLabelText('Search term').id;
+    // Radix activates a tab on mousedown, not click (@radix-ui/react-tabs
+    // 1.1.x) — a bare `click` leaves the create tab selected.
+    fireEvent.mouseDown(screen.getByRole('tab', { name: /Link Existing/ }), { button: 0 });
+    const searchId = screen.getByLabelText('Search Contact').id;
+
+    expect(fieldId).toBeTruthy();
+    expect(searchId).toBeTruthy();
+    expect(searchId).not.toBe(fieldId);
+  });
+
+  it('leaves the decorative magnifier out of the a11y tree', () => {
+    openLink();
+
+    // Scoped to the search box's own wrapper — the card renders other icons
+    // (close, tab triggers) that this test is not about.
+    const search = screen.getByLabelText('Search Contact');
+    const icon = search.closest('div')!.querySelector('svg');
+    expect(icon).not.toBeNull();
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+});


### PR DESCRIPTION
Fixes #3381

## 前提复核(对 origin/main 2409e1d04)

issue 成立,行号已按 PR #3380 之后的现状复核:`packages/plugin-detail/src/InlineCreateRelated.tsx` 的 Link 页签搜索框在 **L279-L285**(正文写的是 ~L253-260,PR #3380 把它推后了约 26 行)。该 Input 确实**没有任何 label**(无 label 元素、无 `aria-label`、无 `aria-labelledby`),而同文件 Create 页签在 #3380 之后已经是「label 文本即可访问名」——正文描述的「唯独此处例外」属实。

## 改了什么

按 PM 裁定取**视觉隐藏 label + `htmlFor`/`React.useId`**(否决 `aria-label`):

- 新增 `searchLabel = \`Search ${objectName}\``,**label 文本与 placeholder 同一表达式**(placeholder 只多一个省略号)。这正是不用 `aria-label` 的理由:可访问名留在真实 label 元素上、且与可见文案同源,不会各自漂移。
- 新增 `searchInputId = \`inline-create-${instanceId}-link-search\``。`instanceId` 复用 #3341 引入的 `React.useId`(一个详情页每个相关列表挂一个该组件)。用带连字符的 `link-search` 段是为了和 `fieldDomId(...)` 的后缀(元数据字段名,惯例 `[a-z0-9_]+`)**不可能**撞上——包括一个字面叫 `search` 的字段。
- Search 装饰图标**按 PM 要求核了现状**:lucide-react 1.25.0 对「无 children 且无 a11y prop」的图标默认就加 `aria-hidden="true"`(`dist/cjs/lucide-react.js:92`),即现状已经是隐藏的。仍然显式补上——这是依赖的默认值而非我们的声明,写出来意图留在本地、也不随图标库升级改变。见「反向验证」里对这一条的诚实标注。
- **零新 i18n 键**:该 placeholder 本身的英文硬编码属另一族,未展开(既有 `detail.searchRecords` 文案是 `Search records…`,与本框的 `Search {objectName}…` 不同源,消费它反而会把 label 和 placeholder 拆开,与本单方向相反)。渲染文案**逐字节未变**。

## 测试

新增 `packages/plugin-detail/src/__tests__/InlineCreateRelated.linkSearchLabel.test.tsx`(9 条)。除常规的 `getByLabelText` / `toHaveAccessibleName` / `labels` 集合 / 每实例 id 不撞车外,两条专门钉验收里那个「分水岭」:

- **输入之后**(`fireEvent.change` 写入 `North`,真实浏览器里 placeholder 已不显示)可访问名仍是 `Search Contact`,并顺带断言该框确实是活的搜索框(过滤掉了不匹配的记录);
- **可访问名 ≠ placeholder**:label 是 `Search Contact`、placeholder 是 `Search Contact…`,末尾省略号让两者可区分,因此「名字不是把 placeholder 读回来」这一点在**任何**实现下都可断言——包括真会做 placeholder 兜底的浏览器。这一条正面解决了正文提到的「兜底跨实现不一致」。

命令与结果(仓根跑,已确认输出里点名了本文件;`--reporter=verbose`):

```
pnpm exec vitest run --maxWorkers=2 --reporter=verbose packages/plugin-detail/src/__tests__/InlineCreateRelated.linkSearchLabel.test.tsx
 ✓ |dom| packages/plugin-detail/src/__tests__/InlineCreateRelated.linkSearchLabel.test.tsx > … (9 条全绿)
 Test Files  1 passed (1)
      Tests  9 passed (9)

pnpm exec vitest run --maxWorkers=2 packages/plugin-detail/
 Test Files  48 passed (48)
      Tests  435 passed (435)

pnpm --workspace-concurrency=2 --filter @object-ui/plugin-detail type-check   → 通过(无输出)
pnpm exec eslint <两个改动文件>  → 0 errors(2 个既有的 no-explicit-any warning,在未改动的 L43/L62)
node scripts/check-control-bytes.mjs → OK(3605 个文件)
```

## 反向验证(方向事先声明,两个方向都记下)

**预期主方向:把源码改回 origin/main → 新测试转红。** 实测 9 条全红,`toHaveAccessibleName` 的 Received 是**空串**:

```
Expected element to have accessible name:
  Search Contact
Received:
            ← 空
→ Unable to find a label with the text of: Search Contact
```

这正好复现了 issue 正文的测量结论:`dom-accessibility-api` 不实现 placeholder 兜底,所以测试环境下修前的可访问名是空串(真实浏览器才会兜到 `Search Contact…`)。

**一条要诚实标注的例外:「装饰图标不进 a11y 树」这条并不由本 PR 的显式 `aria-hidden` 支撑。** 单独做了定向反验——保留 label 修复、只删掉 Search 上显式的 `aria-hidden`——该条**仍然绿**(lucide 的默认值兜住了)。也就是说这条断言钉的是**结果**(图标不被朗读),不是我们新加的那个属性;它的价值在于将来图标库换掉/改默认时会报警。全量反验里它也变红,但那只是因为前置的 `getByLabelText` 先失败,不构成独立证据。

另外首版里「字段名叫 `search` 不撞车」那条,在修前是**空绿**(修前搜索框根本没有 id,id 集合平凡地不重复)——已按「替换整条 fixture」的做法改成读取两个页签各自的真实 id 再比对,修前会因为 `getByLabelText` 找不到而红。顺带记一笔:Radix Tabs 1.1.x 的 tab 是 `mousedown` 激活的,`fireEvent.click` 切不过去(测试里已写明)。

## 范围

严格限于 `packages/plugin-detail/src/InlineCreateRelated.tsx` + 新增测试 + changeset(patch,仅 `@object-ui/plugin-detail`)。消费半径已扫:该组件只在 `packages/plugin-detail/src/index.tsx` 导出,仓内没有别的 fixture/测试按 placeholder 定位这个框。未改 props/spec/渲染文案。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_