### PR TITLE
fix(plugin-report): 透视表 bucket id / cell key 改用 JSON 编码,维度值不再串桶串格 (objectstack#5665)

### DIFF
--- a/.changeset/olive-poets-shave.md
+++ b/.changeset/olive-poets-shave.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/plugin-report': patch
+'@object-ui/plugin-dashboard': patch
+'@object-ui/core': patch
+---
+
+Fix matrix report cells showing another bucket's numbers when dimension values run together.
+
+The cross-tab in `DatasetReportRenderer` built its bucket ids by joining dimension values with the EMPTY string, so adjacent values had no boundary at all: `"x"` + `"yz"` and `"xy"` + `"z"` were the same bucket on both axes, and the later row silently overwrote the earlier one. Its cell key then joined the two bucket ids with a plain space, while dimension values contain spaces constantly ("New York", "In Progress"), so `"New"` × `"York Q1"` and `"New York"` × `"Q1"` also met in one key. A merged bucket showed a different row's measure, the overwritten row's value was unreachable, the per-row and per-column subtotals matched the wrong header, and drill-through followed the same wrong index into another record's list — none of it with an error.
+
+Bucket ids and cell keys are now encoded with `JSON.stringify`, which carries the boundary in its own quoting rather than in a character the data is assumed never to contain. All four lookups in the renderer (row headers, column headers, row subtotals, column subtotals) share the one encoder, so they agree by construction.
+
+The encoders moved to `@object-ui/core` as `pivotBucketId` / `pivotCellKey` and are now shared with the dashboard `DatasetWidget`, which carried the same defect and fixed it separately: two packages each hand-rolling the same key is why one fix left the other broken. The dashboard keeps its existing exports and behaviour.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,10 @@ export * from './utils/merge-filters.js';
 export * from './utils/compare-to.js';
 export * from './utils/chart-series.js';
 export * from './utils/dataset-format.js';
+// Pivot lookup-key encoders, shared by every cross-tab renderer so the
+// dashboard widget and the report renderer key their buckets identically
+// (objectstack#5473 / objectstack#5665).
+export * from './utils/dataset-pivot.js';
 export * from './utils/record-title.js';
 export * from './utils/export-filename.js';
 export * from './utils/reference-keys.js';

--- a/packages/core/src/utils/dataset-pivot.ts
+++ b/packages/core/src/utils/dataset-pivot.ts
@@ -1,0 +1,60 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * dataset-pivot — the lookup-key encoders every cross-tab over a semantic-layer
+ * `queryDataset` result shares (ADR-0021).
+ *
+ * A pivot keys three lookups off dimension-value tuples: the DOWN bucket, the
+ * ACROSS bucket, and the cell where the two meet. Every one of them used to be
+ * spelled by concatenating values with a character the data was ASSUMED never
+ * to contain — an empty string, a plain space, U+0001 — and each assumption
+ * failed on ordinary data: `"x"` + `"yz"` and `"xy"` + `"z"` are one id under an
+ * empty join, and `"New"` × `"York Q1"` and `"New York"` × `"Q1"` are one cell
+ * key under a space join. The later row silently overwrote the earlier one, so
+ * the cell showed a different row's measure, the overwritten row's value was
+ * unreachable, and drill-through followed the same wrong index into the wrong
+ * records — all without an error (objectstack#5473, objectstack#5665).
+ *
+ * `JSON.stringify` carries the boundary in its own quoting rather than in a
+ * character the values must avoid, so these are unambiguous for ANY value a
+ * dimension can hold. The ids are opaque lookup keys, never displayed — visible
+ * text comes from the separately-formatted labels.
+ *
+ * Both encoders live here, in `@object-ui/core`, because the same pivot is
+ * rendered by two packages (`plugin-dashboard`'s `DatasetWidget` and
+ * `plugin-report`'s `DatasetReportRenderer`). Each having written its own is
+ * exactly why both carried the defect and why fixing one left the other broken.
+ * The same rule applies WITHIN a renderer: the cell index and the subtotal
+ * lookups key the same buckets, so they must all call these — a second
+ * hand-rolled encoding of the same id agrees with the first only for the
+ * dimension counts someone happened to test, which is what kept the original
+ * bug invisible.
+ *
+ * Pure (no React / i18n), like its `dataset-format` neighbour.
+ *
+ * Known residual, tracked separately in objectstack#5666: callers encode a
+ * null/undefined dimension value as a placeholder string, so it still collides
+ * with a value that literally equals that placeholder. That is a property of
+ * the placeholder, not of the encoding below.
+ */
+
+/**
+ * Encode a pivot BUCKET id from its dimension values.
+ *
+ * Axis-neutral on purpose: a DOWN bucket and an ACROSS bucket are the same kind
+ * of thing (a dimension-value tuple), and a cross-tab with multiple across
+ * dimensions collides on that axis just as readily as on the down axis.
+ */
+export const pivotBucketId = (dimensionValues: string[]): string => JSON.stringify(dimensionValues);
+
+/**
+ * Encode the cell key for a (down bucket, across bucket) pair — the key of the
+ * map a renderer reads to place a measure and to resolve a drill-through.
+ */
+export const pivotCellKey = (rowId: string, colId: string): string => JSON.stringify([rowId, colId]);

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -39,6 +39,15 @@ import {
   formatDimensionValue,
   buildDatasetFieldHelpers,
   buildDatasetDrillFilter,
+  // The pivot key encoders now live in `@object-ui/core` so this widget and the
+  // report renderer's cross-tab share ONE implementation — each having written
+  // its own is why the same collision had to be fixed twice (objectstack#5473,
+  // objectstack#5665). Aliased to the local name: `pivotRowId` reads right here
+  // (this widget only ever encodes DOWN buckets — its across axis is a single
+  // dimension), while the shared helper is axis-neutral because the report's
+  // cross-tab keys multi-dimension ACROSS buckets with it too.
+  pivotBucketId as pivotRowId,
+  pivotCellKey,
   type DatasetResultField,
   type DatasetDrillRange,
 } from '@object-ui/core';
@@ -64,36 +73,17 @@ interface DatasetCapableSource {
 export const buildDrillFilter = buildDatasetDrillFilter;
 
 /**
- * Encode a pivot ROW bucket id from its dimension values.
- *
- * `JSON.stringify` of the value array — not a delimiter character — carries the
- * boundary between two values, so the id is unambiguous for ANY value a
- * dimension can hold. The previous encodings both relied on a character the
- * values were assumed never to contain, which is exactly how two different
- * rows collapsed into one bucket (objectstack#5473; same treatment as the
- * include key in objectui#3388 and the warning-dedupe key in objectstack#5450).
+ * The pivot key encoders, re-exported for back-compat; the implementations now
+ * live in `@object-ui/core` (`pivotBucketId` / `pivotCellKey`) so this widget
+ * and the report renderer's cross-tab key their buckets identically. See that
+ * module for why both are `JSON.stringify` rather than a delimiter character,
+ * and for the null-placeholder residual tracked in objectstack#5666.
  *
  * Every consumer of a row id — the cell index below AND the row-total lookup in
- * the cross-tab renderer — must build its key with this function; a second,
- * hand-rolled encoding of the same id is what made the old bug invisible.
- *
- * Known residual, tracked separately in objectstack#5666: a null/undefined
- * dimension value is encoded as the placeholder character below, so it still
- * collides with a value that literally equals that placeholder.
+ * the cross-tab renderer — must build its key with these; a second, hand-rolled
+ * encoding of the same id is what made the old bug invisible.
  */
-export const pivotRowId = (dimensionValues: string[]): string => JSON.stringify(dimensionValues);
-
-/**
- * Encode the `cellIndex` key for a (row bucket, column bucket) pair.
- *
- * Was `${rowId} ${colId}` — a plain space, while dimension values contain
- * spaces all the time ("New York", "In Progress"). Two rows whose ids met at a
- * different point of the same string ("New" + "York Q1" vs "New York" + "Q1")
- * produced ONE key: the later row silently overwrote the earlier one, the cell
- * showed another row's measure, and drill-through followed the same wrong
- * index. `JSON.stringify` of the pair has no such boundary (objectstack#5473).
- */
-export const pivotCellKey = (rowId: string, colId: string): string => JSON.stringify([rowId, colId]);
+export { pivotRowId, pivotCellKey };
 
 /**
  * Pivot flat dataset rows into a cross-tab: `rowDims` go DOWN, `colDim` spreads

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -64,6 +64,8 @@ import {
   formatDimensionValue,
   buildDatasetFieldHelpers,
   buildDatasetDrillFilter,
+  pivotBucketId,
+  pivotCellKey,
   type DatasetResultField,
   type DatasetDrillRange,
 } from '@object-ui/core';
@@ -738,9 +740,19 @@ function DatasetReportChart({
   );
 }
 
-/** Stable bucket id for a dimension-value tuple. */
+/**
+ * Stable bucket id for a dimension-value tuple — the id every lookup in the
+ * cross-tab below is keyed by (row headers, column headers, and both subtotal
+ * maps), so they all agree by construction.
+ *
+ * The values go through `pivotBucketId` (shared with the dashboard's pivot)
+ * rather than being concatenated: this used to `join('')`, which left NO
+ * boundary at all between adjacent values, so `'x'` + `'yz'` and `'xy'` + `'z'`
+ * were one bucket and the later row overwrote the earlier one
+ * (objectstack#5665; objectstack#5473 is the same defect in the dashboard).
+ */
 function bucketId(dims: string[], row: Row): string {
-  return dims.map((d) => String(row[d] ?? '∅')).join('');
+  return pivotBucketId(dims.map((d) => String(row[d] ?? '∅')));
 }
 
 function bucketLabel(dims: string[], row: Row): string {
@@ -816,7 +828,11 @@ function DatasetMatrixTable({
         for (const d of columnsAcross) key[d] = r[d];
         colHeaders.push({ id: cid, label: bucketLabel(columnsAcross, r), key });
       }
-      cells.set(`${rid} ${cid}`, { row: r, index });
+      // Keyed by pivotCellKey, not `${rid} ${cid}`: a plain space is a boundary
+      // only while no dimension value contains one, and they do constantly
+      // ("New York", "In Progress"). `index` is also what drill-through reads
+      // `drillRawRows` by, so a merged key drilled to the wrong records too.
+      cells.set(pivotCellKey(rid, cid), { row: r, index });
     });
     return { rowHeaders, colHeaders, cells };
   }, [state, rows, columnsAcross]);
@@ -903,7 +919,7 @@ function DatasetMatrixTable({
                 </td>
               ))}
               {cellCols.map((cc) => {
-                const entry = pivot.cells.get(`${rh.id} ${cc.col.id}`);
+                const entry = pivot.cells.get(pivotCellKey(rh.id, cc.col.id));
                 const value = entry?.row[cc.measure];
                 const clickable = canDrill && entry != null;
                 return (

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -787,3 +787,171 @@ describe('DatasetReportRenderer', () => {
     expect(screen.getByText(/does not support dataset queries/i)).toBeInTheDocument();
   });
 });
+
+/**
+ * Matrix bucket / cell-key encoding (objectstack#5665).
+ *
+ * The cross-tab keys three lookups off dimension-value tuples: the DOWN bucket,
+ * the ACROSS bucket, and the (row, column) cell that meets them. All three were
+ * spelled by concatenation — the bucket id joined its values with the EMPTY
+ * string, the cell key joined the two bucket ids with a PLAIN SPACE — so a
+ * boundary existed only where the data happened not to reach across it. Two
+ * different buckets then produced ONE key: the later row silently overwrote the
+ * earlier one, the cell showed another row's measure, the overwritten row was
+ * unreachable, and drill-through followed the same wrong index into the wrong
+ * records. Same defect as the dashboard widget's (objectstack#5473).
+ *
+ * These cases assert BEHAVIOUR — which bucket renders which measure, which raw
+ * record a cell drills to — not key spelling. The pre-existing pivot cases use
+ * one row dimension and space-free values, where an empty separator is
+ * indistinguishable from a correct one, which is why they stayed green
+ * throughout.
+ */
+describe('DatasetReportRenderer — matrix bucket encoding (objectstack#5665)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /** Data rows of the rendered cross-tab, as text — the totals row excluded. */
+  const matrixBodyRows = (): string[][] =>
+    [...screen.getByTestId('dataset-matrix').querySelectorAll('tbody tr')]
+      .filter((tr) => tr.getAttribute('data-testid') !== 'matrix-total-row')
+      .map((tr) => [...tr.querySelectorAll('td')].map((td) => td.textContent ?? ''));
+
+  it('keeps two DOWN buckets whose values concatenate identically apart ("x"+"yz" vs "xy"+"z")', async () => {
+    // The empty join gave these two rows one id, "xyz". Nothing about the values
+    // is exotic — any two adjacent dimensions can spell each other's boundary.
+    const src = makeSource({
+      sales: [
+        { region: 'x', segment: 'yz', priority: 'High', amount: 1 },
+        { region: 'xy', segment: 'z', priority: 'High', amount: 2 },
+      ],
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'sales', rows: ['region', 'segment'], columns: ['priority'], values: ['amount'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    expect(matrixBodyRows()).toEqual([
+      ['x', 'yz', '1'],
+      ['xy', 'z', '2'],
+    ]);
+  });
+
+  it('keeps two ACROSS buckets whose values concatenate identically apart', async () => {
+    // The across axis runs through the same encoder, so it collides the same
+    // way: "Q"+"1x" and "Q1"+"x" both spelled "Q1x", collapsing two columns into
+    // one and making the first bucket's measure unreachable.
+    const src = makeSource({
+      sales: {
+        rows: [
+          { region: 'East', quarter: 'Q', channel: '1x', amount: 1 },
+          { region: 'East', quarter: 'Q1', channel: 'x', amount: 2 },
+        ],
+        totals: [
+          { dimensions: ['quarter', 'channel'], rows: [{ quarter: 'Q', channel: '1x', amount: 10 }, { quarter: 'Q1', channel: 'x', amount: 20 }] },
+        ],
+      },
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'sales', rows: ['region'], columns: ['quarter', 'channel'], values: ['amount'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    expect(screen.getByRole('columnheader', { name: 'Q / 1x' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Q1 / x' })).toBeInTheDocument();
+    expect(matrixBodyRows()).toEqual([['East', '1', '2']]);
+    // Column subtotals key the across buckets with the SAME encoder, so they
+    // must land under their own column rather than share one.
+    expect(screen.getByTestId('matrix-total-row').textContent).toContain('10');
+    expect(screen.getByTestId('matrix-total-row').textContent).toContain('20');
+  });
+
+  it('does not merge cells when a dimension value contains a space ("New" × "York Q1" vs "New York" × "Q1")', async () => {
+    // The space-joined cell key spelled both pairs "New York Q1" — and values
+    // with spaces are the norm, not the exception ("New York", "In Progress").
+    const src = makeSource({
+      sales: [
+        { region: 'New', quarter: 'York Q1', amount: 111 },
+        { region: 'New York', quarter: 'Q1', amount: 222 },
+      ],
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'sales', rows: ['region'], columns: ['quarter'], values: ['amount'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    // Each bucket pair holds its own measure; the two absent pairs render '—'.
+    expect(matrixBodyRows()).toEqual([
+      ['New', '111', '—'],
+      ['New York', '—', '222'],
+    ]);
+  });
+
+  it('drills a colliding cell to ITS raw record, not the one that overwrote it', async () => {
+    // The cell entry carries the flat row INDEX that drill-through reads
+    // `drillRawRows` by, so a merged key drilled to another row's records with
+    // no error — the quiet half of the same bug.
+    const src = makeSource({
+      sales: {
+        rows: [
+          { region: 'New', quarter: 'York Q1', amount: 111 },
+          { region: 'New York', quarter: 'Q1', amount: 222 },
+        ],
+        object: 'opportunity',
+        dimensionFields: { region: 'billing_state', quarter: 'close_quarter' },
+        drillRawRows: [
+          { region: 'NEW', quarter: 'YORK-Q1' },
+          { region: 'NEW-YORK', quarter: 'Q1' },
+        ],
+      },
+    });
+    const onDrill = vi.fn();
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'sales', rows: ['region'], columns: ['quarter'], values: ['amount'] }}
+        dataSource={src}
+        onDrill={onDrill}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    // First clickable cell = row "New" × column "York Q1" (flat row 0).
+    fireEvent.click(screen.getAllByTestId('dataset-drill-cell')[0]);
+    expect(onDrill).toHaveBeenCalledWith(expect.objectContaining({
+      groupKey: { region: 'New', quarter: 'York Q1' },
+      objectFilter: { billing_state: 'NEW', close_quarter: 'YORK-Q1' },
+    }));
+  });
+
+  it('matches per-row subtotals to multi-dimension row buckets', async () => {
+    // `rowTotalById` keys the server's subtotal rows with the same encoder as
+    // the row headers, so the collision reached the Total column too: two
+    // subtotals under one id, one of them unreachable.
+    const src = makeSource({
+      sales: {
+        rows: [
+          { region: 'x', segment: 'yz', priority: 'High', amount: 1 },
+          { region: 'xy', segment: 'z', priority: 'High', amount: 2 },
+        ],
+        totals: [
+          { dimensions: ['region', 'segment'], rows: [{ region: 'x', segment: 'yz', amount: 1 }, { region: 'xy', segment: 'z', amount: 2 }] },
+          { dimensions: ['priority'], rows: [{ priority: 'High', amount: 3 }] },
+          { dimensions: [], rows: [{ amount: 3 }] },
+        ],
+      },
+    });
+    render(
+      <DatasetReportRenderer
+        report={{ name: 'm', type: 'matrix', dataset: 'sales', rows: ['region', 'segment'], columns: ['priority'], values: ['amount'] }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('dataset-matrix')).toBeInTheDocument());
+    expect(screen.getAllByTestId('matrix-row-total').map((el) => el.textContent)).toEqual(['1', '2']);
+    expect(screen.getByTestId('matrix-grand-total')).toHaveTextContent('3');
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5665

## 问题

`packages/plugin-report/src/DatasetReportRenderer.tsx` 的 matrix 交叉表把三类查找都建在「维度值拼接」上,两处拼接各自有缺陷:

1. **`bucketId` 用真空串 `join('')`** —— 相邻维度值之间**一个边界字符都没有**。`bucketId(['region','segment'], …)` 对 `x` + `yz` 与 `xy` + `z` 同样产出 `xyz`。这条同时作用在**行轴和列轴**上(`rid` / `cid` 都走它),两个不同的桶合并成一个,后写覆盖先写。
2. **cell key 用普通空格拼 `rid`/`cid`** —— 与 #3414 在 dashboard 修掉的完全同形。维度值含空格是常态(`New York` / `In Progress`),于是 `New` × `York Q1` 与 `New York` × `Q1` 落进同一个 key。

合并后的桶显示的是**另一行的度量**,被覆盖那行的值取不到;`cells` 的 value 还带 `index`,而 drill-through 正是用它读 `drillRawRows`,所以**点开的是另一条记录的列表**。全程无任何报错。

## 修法(与 PR #3414 同形,整体换)

`bucketId` 改走 `JSON.stringify`:边界由 JSON 自身的引号承载,不再依赖「数据不会包含的字符」。

本渲染器有**四处**查找共用这一个 encoder —— 行表头、列表头、行小计 `rowTotalById`、列小计 `colTotalById` —— 所以**整体换**:任何一处留在旧拼法,就会把 #3414 刚在 dashboard 侧修掉的「表头与小计各用一套编码」重新引进来。cell key 的 `set` 与 `get` 两处也一并换成 `pivotCellKey`。

## 共享 helper(按 PM 裁定核了依赖拓扑)

`plugin-report` 与 `plugin-dashboard` 都 `workspace:*` 依赖 `@object-ui/core`,且已有先例 —— `buildDatasetDrillFilter` 正是为「两边 drill 行为一致」抽过去的。方向干净,因此:

- 新增 `packages/core/src/utils/dataset-pivot.ts`,导出 `pivotBucketId` / `pivotCellKey`;
- `DatasetWidget.tsx` **仅**改 import(`pivotBucketId as pivotRowId`)+ 删本地 helper,导出面、调用点、行为一律不动,#3414 的用例全部复跑通过;
- 核心命名取 `pivotBucketId` 而非 `pivotRowId`:report 侧**列轴**也用它编码(dashboard 的 across 只有单维度,行轴才拼多值),叫 row 会在 `cid` 处误导。dashboard 侧用别名保留其原有本地名,不扩大改动面。

两个包各写一份同样的 key,正是同一个碰撞被发现两次、修两次的根因;现在只有一份实现。

## 用例(钉行为,不钉 key 拼法)

新增 5 例,覆盖 issue 与 PM 点名的每一族:

| 用例 | 修前 | 修后 |
|---|---|---|
| 行轴 `x`+`yz` vs `xy`+`z` | 塌成一行,显示 `2` | 两行,各显示 `1` / `2` |
| 列轴 `Q`+`1x` vs `Q1`+`x`(含列小计) | 塌成一列 | 两列,小计各归各位 |
| 空格碰撞 `New` × `York Q1` vs `New York` × `Q1` | 行 `New` 显示 `222` | 显示 `111`,缺失格为 `—` |
| drill 命中 | `objectFilter` = `NEW-YORK` / `Q1`(**另一行**) | `NEW` / `YORK-Q1` |
| 多维行小计匹配 | 只剩 1 个小计 | `['1','2']` |

**反向验证方向(修前红 / 修后绿,预先判定并复现)**:先只加用例、不动实现,5 例全红,且失败形态与预测逐条吻合 —— drill 那例直接打出 `billing_state: "NEW-YORK"`,即「钻到另一行」的实证。同文件既有 36 例始终绿:它们的 pivot fixture 行/列各只有一个维度、值不含空格,此时空串分隔与正确分隔**不可区分**,所以两个缺陷从未被跑到。

## 消费半径清扫

- `grep` 全仓已无 `` `${a} ${b}` `` 形态的 map key;`.join('')` 的其余命中都是图标名/首字母拼接,不是桶 id。
- `plugin-dashboard/PivotTable.tsx` 用嵌套对象 `bucket[r][c]`、单行单列字段,不属此类,无需改动。

## 验证

- `vitest run packages/plugin-report/.../DatasetReportRenderer.test.tsx packages/plugin-dashboard/.../DatasetWidget.test.tsx` → **88 passed (2 files)**
- `type-check`:`@object-ui/core` / `plugin-report`(含 `tsconfig.test.json`)/ `plugin-dashboard` 全部 Done
- `pnpm check:control-bytes` OK,并对本 PR 全部改动文件做了越过 gate 的自扫(含 `0x01` 等 gate 不扫的字节),无命中

## 已知残留(不在本 PR 范围)

null/undefined 维度值仍编码为占位符 `∅`,与字面等于该占位符的值相撞 —— 这是占位符的性质而非编码的,已由 objectstack#5666 单独跟踪,`dataset-pivot.ts` 的注释里指了过去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_