### PR TITLE
fix(fields): 记录选择器筛选面板的 select 筛选项改从引用对象 schema 取 options (#3336)

### DIFF
--- a/.changeset/record-picker-filter-select-options.md
+++ b/.changeset/record-picker-filter-select-options.md
@@ -1,0 +1,19 @@
+---
+"@object-ui/fields": patch
+---
+
+The lookup "Browse all records" Record Picker's filter panel now offers the
+options a `select` field declares in its schema (objectui#3336). `LookupField`
+turns each typed picker column into a filter column, and those carried no
+`options` — so the filter panel's dropdown opened EMPTY and the column could
+not be filtered at all, even though the same column's table cells had rendered
+the authored option labels since objectui#3333.
+
+`RecordPickerDialog` now fills a `select` filter column's missing `options`
+from `fieldsMeta` (the referenced object's schema `fields` map) through the
+same resolver — and the same i18n option translation — the table cells use, so
+the filter dropdown and the cells can never disagree about what an option is
+called. Explicitly authored filter `options` still win (including the ones
+auto-derived from an `in`/`notIn` `lookup_filters` entry), and a select field
+whose schema declares no options keeps an empty dropdown: no options are
+synthesised from the loaded page's raw stored values.

--- a/packages/fields/src/widgets/RecordPickerDialog.filterOptions.test.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.filterOptions.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Record Picker FILTER PANEL — select filter inputs carry the schema's options
+ * (#3336).
+ *
+ * #3333 fixed the picker's table CELLS: they now format through the referenced
+ * object's schema `fields` map (`fieldsMeta`) plus the shared i18n option
+ * translation, so a `select` column renders the authored option label instead
+ * of title-casing the raw stored value.
+ *
+ * The filter panel is the other face of the same widget and was still broken.
+ * `LookupField` turns each typed picker column into a `RecordPickerFilterColumn`
+ * (`{ field, label, type: 'select' }`) with no `options`, and the panel's select
+ * input renders `col.options?.map(...)` — so the dropdown opened EMPTY and the
+ * column could not be filtered at all.
+ *
+ * ## What these cases assert, and in which direction
+ *
+ * - **The two reproducers (`renderFilterBar` slot + built-in panel DOM) were
+ *   RED before the fix**: `options` was `undefined` and the dropdown rendered
+ *   zero `option` roles.
+ * - **The parity case is the load-bearing one.** It asserts the filter option
+ *   label and the table cell for the SAME field are the same translated string,
+ *   under an `I18nProvider` that translates `fieldOptions.<obj>.<field>.<value>`.
+ *   That is what pins "one source" rather than "two derivations that happen to
+ *   agree today" — a second, filter-only derivation reading `meta.options`
+ *   directly would satisfy the label assertions but not this one.
+ * - **Two cases are deliberate NO-OP pins, green before and after** (called out
+ *   individually below): a schema field with no `options` still yields an empty
+ *   dropdown (the fix adds no consumer-side leniency — no options synthesised
+ *   from the loaded page's raw values), and explicitly authored filter options
+ *   keep winning over the schema (including the `in`-operator options
+ *   auto-derived from `lookupFilters`). They guard the precedence and the
+ *   non-leniency the fix chose, not a defect it repaired.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { I18nProvider } from '@object-ui/i18n';
+import { RecordPickerDialog } from './RecordPickerDialog';
+import type { RecordPickerFilterBarProps } from './RecordPickerDialog';
+import { LookupField } from './LookupField';
+import { getCellRenderer } from '../index';
+
+// Radix Select opens on pointer events happy-dom/jsdom do not implement.
+beforeAll(() => {
+  class MockPointerEvent extends Event {
+    button: number;
+    ctrlKey: boolean;
+    pointerType: string;
+    constructor(type: string, props: any = {}) {
+      super(type, props);
+      this.button = props.button ?? 0;
+      this.ctrlKey = props.ctrlKey ?? false;
+      this.pointerType = props.pointerType ?? 'mouse';
+    }
+  }
+  (window as any).PointerEvent = MockPointerEvent;
+  (HTMLElement.prototype as any).hasPointerCapture = vi.fn();
+  (HTMLElement.prototype as any).releasePointerCapture = vi.fn();
+  (HTMLElement.prototype as any).scrollIntoView = vi.fn();
+});
+
+const projects = [
+  { id: 'p1', name: 'Line A retooling', project_phase: 'manufacturing' },
+];
+
+/** The referenced object's schema `fields` map, as `getObjectSchema` returns it. */
+const projectFields = {
+  name: { type: 'text', label: 'Name' },
+  project_phase: {
+    type: 'select',
+    label: 'Project Phase',
+    options: [
+      { label: '01 Initiation', value: 'initiation' },
+      { label: '03 Manufacturing', value: 'manufacturing' },
+    ],
+  },
+  // A select field the metadata author never gave options to.
+  risk_level: { type: 'select', label: 'Risk Level' },
+};
+
+function makeDataSource() {
+  const find = vi.fn(async () => ({ data: projects, total: projects.length }));
+  const getObjectSchema = vi.fn(async () => ({
+    name: 'projects',
+    fields: projectFields,
+    highlightFields: ['name', 'project_phase'],
+  }));
+  return { find, getObjectSchema } as any;
+}
+
+const phaseFilterColumn = { field: 'project_phase', label: 'Project Phase', type: 'select' as const };
+
+/**
+ * Open the built-in filter panel and return the first select trigger in it.
+ *
+ * The toggle is reached structurally (first button in the filter bar) rather
+ * than by its accessible name: one case below mounts a `zh` I18nProvider, and
+ * `initReactI18next` makes that instance the default for provider-less renders
+ * afterwards — so a `/filters/i` name match would pass or fail depending on
+ * test order, not on the behaviour under test.
+ *
+ * `findBy…`: the filter bar only exists once the filter columns are resolved,
+ * which in the LookupField path waits on the referenced object's schema fetch.
+ */
+async function openFilterSelect(): Promise<Element> {
+  const bar = await screen.findByTestId('record-picker-filter-bar');
+  fireEvent.click(bar.querySelector('button')!);
+  const panel = await screen.findByTestId('record-picker-filter-panel');
+  const trigger = panel.querySelector('[role="combobox"]');
+  expect(trigger).toBeTruthy();
+  await act(async () => {
+    fireEvent.pointerDown(trigger!, { button: 0 });
+  });
+  return trigger!;
+}
+
+describe('RecordPickerDialog filter panel — select options come from the schema (#3336)', () => {
+  it('hands the filter bar a select column carrying the schema field options', async () => {
+    let captured: RecordPickerFilterBarProps | null = null;
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={() => {}}
+        dataSource={makeDataSource()}
+        objectName="projects"
+        columns={[{ field: 'project_phase', label: 'Project Phase', type: 'select' }]}
+        onSelect={() => {}}
+        cellRenderer={getCellRenderer}
+        fieldsMeta={projectFields}
+        filterColumns={[phaseFilterColumn]}
+        renderFilterBar={(p) => {
+          captured = p;
+          return <div data-testid="external-filter-bar" />;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(captured).not.toBeNull());
+    // Pre-fix this was `undefined` — the panel had nothing to render.
+    expect(captured!.filterColumns[0].options).toEqual([
+      { label: '01 Initiation', value: 'initiation' },
+      { label: '03 Manufacturing', value: 'manufacturing' },
+    ]);
+  });
+
+  it('renders the schema options in the built-in filter panel dropdown', async () => {
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={() => {}}
+        dataSource={makeDataSource()}
+        objectName="projects"
+        columns={[
+          { field: 'name', label: 'Name', type: 'text' },
+          { field: 'project_phase', label: 'Project Phase', type: 'select' },
+        ]}
+        onSelect={() => {}}
+        cellRenderer={getCellRenderer}
+        fieldsMeta={projectFields}
+        filterColumns={[phaseFilterColumn]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('Line A retooling')).toBeInTheDocument());
+    await openFilterSelect();
+
+    // Pre-fix: SelectContent was empty, so neither option role existed.
+    expect(await screen.findByRole('option', { name: '03 Manufacturing' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: '01 Initiation' })).toBeTruthy();
+  });
+
+  it('filters on the picked option value', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={() => {}}
+        dataSource={ds}
+        objectName="projects"
+        columns={[{ field: 'project_phase', label: 'Project Phase', type: 'select' }]}
+        onSelect={() => {}}
+        cellRenderer={getCellRenderer}
+        fieldsMeta={projectFields}
+        filterColumns={[phaseFilterColumn]}
+      />,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    await openFilterSelect();
+
+    const option = await screen.findByRole('option', { name: '03 Manufacturing' });
+    await act(async () => {
+      fireEvent.click(option);
+    });
+
+    await waitFor(() => {
+      const lastParams = ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+      expect(lastParams.$filter).toMatchObject({ project_phase: 'manufacturing' });
+    });
+  });
+
+  /**
+   * The load-bearing case: ONE source for both faces of the widget. The filter
+   * option label and the table cell for the same field must be the same
+   * translated string — a filter-only re-derivation that skipped the shared
+   * i18n option path would show the authored English here.
+   */
+  it('translates filter option labels through the same i18n path as the cells', async () => {
+    let captured: RecordPickerFilterBarProps | null = null;
+    render(
+      <I18nProvider
+        config={{
+          defaultLanguage: 'zh',
+          detectBrowserLanguage: false,
+          resources: {
+            zh: {
+              demo: {
+                fields: { projects_zh: { project_phase: '项目阶段' } },
+                fieldOptions: {
+                  projects_zh: {
+                    project_phase: {
+                      initiation: '01 立项',
+                      manufacturing: '03 制造',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }}
+      >
+        {/* A dedicated object name: the bundle above stays registered on the
+            default i18next instance for later renders, and keying it to
+            `projects_zh` keeps it from translating the other cases' options. */}
+        <RecordPickerDialog
+          open
+          onOpenChange={() => {}}
+          dataSource={makeDataSource()}
+          objectName="projects_zh"
+          columns={[{ field: 'project_phase', label: 'Project Phase', type: 'select' }]}
+          onSelect={() => {}}
+          cellRenderer={getCellRenderer}
+          fieldsMeta={projectFields}
+          filterColumns={[phaseFilterColumn]}
+          renderFilterBar={(p) => {
+            captured = p;
+            return <div data-testid="external-filter-bar" />;
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    // The cell already resolved the translated label after #3333 …
+    await waitFor(() => expect(screen.getByText('03 制造')).toBeInTheDocument());
+    // … and the filter option for the same field now says exactly the same thing.
+    await waitFor(() => expect(captured).not.toBeNull());
+    const labels = captured!.filterColumns[0].options?.map(o => o.label);
+    expect(labels).toEqual(['01 立项', '03 制造']);
+    expect(labels).not.toContain('03 Manufacturing');
+  });
+
+  /**
+   * NO-OP PIN (green before and after). A select field the author gave no
+   * options keeps an empty dropdown: the fix derives options from the schema
+   * and adds no consumer-side leniency — it never invents entries from the
+   * loaded page's raw stored values, which would hide the metadata gap behind
+   * a list that changes per page.
+   */
+  it('leaves a select filter optionless when the schema field declares none', async () => {
+    let captured: RecordPickerFilterBarProps | null = null;
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={() => {}}
+        dataSource={makeDataSource()}
+        objectName="projects"
+        columns={[{ field: 'name', label: 'Name', type: 'text' }]}
+        onSelect={() => {}}
+        cellRenderer={getCellRenderer}
+        fieldsMeta={projectFields}
+        filterColumns={[{ field: 'risk_level', label: 'Risk Level', type: 'select' }]}
+        renderFilterBar={(p) => {
+          captured = p;
+          return <div data-testid="external-filter-bar" />;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.filterColumns[0].options).toBeUndefined();
+  });
+
+  /**
+   * NO-OP PIN (green before and after). Authored filter options are the more
+   * specific statement and keep winning — including the `in`-operator options
+   * `lookupFilters` auto-derivation builds, which must not be replaced by the
+   * schema's full option set (that would widen a deliberately narrowed list).
+   */
+  it('keeps explicitly authored filter options over the schema ones', async () => {
+    let captured: RecordPickerFilterBarProps | null = null;
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={() => {}}
+        dataSource={makeDataSource()}
+        objectName="projects"
+        onSelect={() => {}}
+        cellRenderer={getCellRenderer}
+        fieldsMeta={projectFields}
+        lookupFilters={[{ field: 'project_phase', operator: 'in', value: ['manufacturing'] }]}
+        renderFilterBar={(p) => {
+          captured = p;
+          return <div data-testid="external-filter-bar" />;
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(captured).not.toBeNull());
+    expect(captured!.filterColumns[0].options).toEqual([
+      { label: 'manufacturing', value: 'manufacturing' },
+    ]);
+  });
+});
+
+describe('LookupField → picker filter panel wiring (#3336)', () => {
+  const lookup = {
+    name: 'project',
+    label: 'Project',
+    type: 'lookup',
+    reference_to: 'projects',
+    reference_field: 'name',
+  } as any;
+
+  it('offers the referenced object schema options in the derived select filter', async () => {
+    render(
+      <LookupField
+        field={lookup}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={makeDataSource()}
+      />,
+    );
+
+    // Open the "Browse all records" picker.
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId('browse-all-records'));
+    });
+    await waitFor(() => expect(screen.getByTestId('record-picker-dialog')).toBeInTheDocument());
+
+    // `project_phase` reaches the filter bar because it is a typed picker column
+    // derived from `highlightFields`; its options come from the same schema.
+    await openFilterSelect();
+    expect(await screen.findByRole('option', { name: '03 Manufacturing' })).toBeTruthy();
+  });
+});

--- a/packages/fields/src/widgets/RecordPickerDialog.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.tsx
@@ -186,6 +186,41 @@ export function lookupFiltersToRecord(
 }
 
 /**
+ * A select option as the object schema declares it — `{ value, label }` plus
+ * whatever the renderer also reads (`color`, …), which the i18n translation
+ * carries through untouched.
+ */
+type SchemaOption = { value: any; label: string; [key: string]: any };
+
+/**
+ * Resolve a field's select options from the referenced object's schema field
+ * definition (`fieldsMeta[field]`), translated through the shared i18n option
+ * path.
+ *
+ * This is the SINGLE source for both surfaces that need option labels: the
+ * table cells (#3333) and the filter panel's select inputs (#3336) — so a
+ * picker column and the filter input for that same column can never disagree
+ * about what an option is called.
+ *
+ * Returns `undefined` when the schema field declares no options: a select
+ * field with no authored options genuinely has nothing to offer, and
+ * synthesising entries from the loaded page's raw stored values would paper
+ * over the metadata gap with a list that changes per page.
+ */
+function resolveSchemaOptions(
+  meta: { options?: unknown } | undefined,
+  objectName: string,
+  fieldName: string,
+  translateOptions: (o: string, f: string, opts: SchemaOption[]) => SchemaOption[],
+): SchemaOption[] | undefined {
+  const raw = meta?.options;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const options = raw as SchemaOption[];
+  if (!objectName) return options;
+  return translateOptions(objectName, fieldName, options);
+}
+
+/**
  * Convert user-entered filter bar values into a $filter Record.
  * Each key is a field name, each value the user-entered value.
  * Empty/null values are ignored.
@@ -288,6 +323,11 @@ export interface RecordPickerDialogProps {
    * title-casing the raw stored value instead of resolving the option label
    * (#3333: `manufacturing` rendered as "Manufacturing" instead of the
    * authored option label).
+   *
+   * The filter bar reads the same map: a `select` filter column with no
+   * authored `options` takes them from the schema field here, so the filter
+   * panel's dropdown offers exactly the options the table cells render
+   * (#3336 — it used to open empty, leaving the field unfilterable).
    */
   fieldsMeta?: Record<string, any>;
 
@@ -415,9 +455,8 @@ export function RecordPickerDialog({
       const descriptor: any = meta
         ? { ...meta, name: col.field, type }
         : { name: col.field, type };
-      if (Array.isArray(descriptor.options) && objectName) {
-        descriptor.options = translateOptions(objectName, col.field, descriptor.options);
-      }
+      const options = resolveSchemaOptions(meta, objectName, col.field, translateOptions);
+      if (options) descriptor.options = options;
       map[col.field] = descriptor;
     }
     return map;
@@ -425,7 +464,7 @@ export function RecordPickerDialog({
 
   // Auto-generate filter columns from lookupFilters when no explicit filterColumns given.
   // Each LookupFilterDef becomes a filterable field with inferred type.
-  const effectiveFilterColumns = useMemo<RecordPickerFilterColumn[] | undefined>(() => {
+  const baseFilterColumns = useMemo<RecordPickerFilterColumn[] | undefined>(() => {
     if (filterColumns && filterColumns.length > 0) return filterColumns;
     // Auto-derive from lookupFilters: each filter entry becomes a filterable field
     if (lookupFilters && lookupFilters.length > 0) {
@@ -462,6 +501,28 @@ export function RecordPickerDialog({
     }
     return undefined;
   }, [filterColumns, lookupFilters]);
+
+  // Filter columns as the filter bar consumes them: every `select` filter
+  // carries the options its schema field declares. The filter panel's Select reads
+  // `col.options` — a derived select column (LookupField turns each typed picker
+  // column into a filter column) carries none, so the dropdown opened empty and
+  // the field could not be filtered at all (#3336).
+  //
+  // The options come from `fieldsMeta` through `resolveSchemaOptions`, i.e. the
+  // SAME schema source + i18n translation the table cells use (#3333) — not a
+  // second derivation that could drift from the cells. An explicitly authored
+  // `options` list on the filter column always wins (it is the more specific
+  // statement), and a schema field with no options stays optionless: an empty
+  // dropdown for THAT field is the honest rendering of missing metadata.
+  const effectiveFilterColumns = useMemo<RecordPickerFilterColumn[] | undefined>(() => {
+    if (!baseFilterColumns) return undefined;
+    return baseFilterColumns.map(col => {
+      if (col.type !== 'select') return col;
+      if (col.options && col.options.length > 0) return col;
+      const options = resolveSchemaOptions(fieldsMeta?.[col.field], objectName, col.field, translateOptions);
+      return options ? { ...col, options } : col;
+    });
+  }, [baseFilterColumns, fieldsMeta, objectName, translateOptions]);
 
   // Merge base lookup_filters with user filter bar values. The hard
   // `baseFilter` constraint (dependent-lookup chain, #2215) is spread LAST so


### PR DESCRIPTION
Fixes #3336

## 问题

lookup「浏览全部记录」记录选择器的筛选面板里,由 typed picker column 派生出来的 `select` 筛选项不带 `options`,筛选面板的 `renderFilterInput` 渲染的是 `col.options?.map(...)`,于是 SelectContent 为空 —— 下拉展开什么都没有,这一列根本无法筛选。

同一列的**表格单元格**自 #3333 起已经能解析选项 label(走 `fieldsMeta` + 共享 i18n option 翻译),所以这是同一个控件的另一面:单元格对了,筛选输入框还是空的。

## 定位复核(issue body 只是线索,逐条对 origin/main 核过)

- `packages/fields/src/widgets/LookupField.tsx:376-386` `filterColumns` useMemo 仍然只 push `{ field, label, type }`,不带 options —— 成立;
- `packages/fields/src/widgets/RecordPickerDialog.tsx` `renderFilterInput` 的 select 分支仍是 `col.options?.map(...)` —— 成立;
- #3333 的富化确实在:`LookupField.tsx:1280` 已经把 `fieldsMeta={refObjectSchema?.fields}` 传给了 dialog,dialog 里有 `columnFieldDescriptors` 走 `translateOptions` —— 可复用,成立。

## 改法

把选项解析抽成 `resolveSchemaOptions(meta, objectName, fieldName, translateOptions)`,**单元格描述符和筛选列共用同一个 resolver**:

- 单元格路径(#3333)行为不变,只是改为调用同一个函数;
- 筛选列在 `select` 且自身没有 options 时,从 `fieldsMeta[col.field].options` 取,并过同一条 i18n option 翻译路径。

因此筛选下拉与表格单元格不可能对同一个选项给出不同的名字 —— 这是本 PR 的关键取舍:**没有**在 `LookupField` 里再写一份"筛选专用"的派生逻辑(那样两边会各自漂移),`LookupField` 本次零改动。

刻意保留的两条边界(都有测试钉住):

1. **显式 options 优先**:筛选列自带 options(包括 `lookup_filters` 的 `in`/`notIn` 自动派生出来的那一份)不会被 schema 的全量选项覆盖 —— 那会把作者刻意收窄的列表重新放宽;
2. **不做消费端兜底**:schema 里本来就没有 options 的 select 字段,下拉仍然是空的。不会拿当前这一页记录里出现过的裸值现编选项(那样列表会随翻页变化,还会把元数据缺口盖住)。

## 测试与反向验证(方向是先预判、后运行的)

新增 `packages/fields/src/widgets/RecordPickerDialog.filterOptions.test.tsx`(7 例)。把修改 stash 掉、只留测试跑了一遍,方向与预判完全一致:

- 预判 RED → 实测 RED(5 例):`renderFilterBar` 拿到的筛选列带 schema options、内置筛选面板下拉里出现两个 option、选中后 `$filter` 落到 `project_phase: 'manufacturing'`、i18n 平价用例、以及 LookupField → 筛选面板的端到端串联。失败信息分别是 `expected undefined to deeply equal [ …(2) ]` 和 `Unable to find role="option" and name "03 Manufacturing"`。
- 预判 GREEN(no-op pin)→ 实测 GREEN(2 例):schema 无 options 时保持空下拉、显式 options 优先。这两例修复前后都绿,它们钉的是本 PR 选择的"不兜底/优先级",不是被修复的缺陷 —— 报告里也是这么写的,没有当成 RED 邀功。

其中 i18n 平价用例是最吃重的一例:在 zh provider 下断言**筛选项 label 与同字段单元格是同一个被翻译过的字符串**。一份只读 `meta.options`、绕过 i18n 的"筛选专用"派生能通过前面几例,但过不了这一例。

命令与结果(均在 worktree 仓库根跑 vitest,已确认目标文件名出现在 verbose 输出里):

- `npx vitest run --maxWorkers=2 packages/fields --reporter=dot` → `Test Files 60 passed (60) / Tests 924 passed (924)`
- `npx vitest run --maxWorkers=2 packages/plugin-detail packages/app-shell/.../AccessExplainPanel.test.tsx packages/app-shell/.../AssignedUsersSection.test.tsx` → `Test Files 52 passed (52) / Tests 453 passed (453)`(按"规则消费半径"扫的下游:RelatedList / AccessExplainPanel / AssignedUsersSection 都是 RecordPickerDialog 的调用方)
- `pnpm --workspace-concurrency=2 --filter @object-ui/fields type-check` → 通过(先 `pnpm --filter '@object-ui/fields^...' build` 建好依赖 dist,否则是假红)
- `node scripts/check-control-bytes.mjs` → OK;`eslint` 改动文件 → 0 errors

已附 changeset(`.changeset/record-picker-filter-select-options.md`,patch)。未触碰 `content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_