### PR TITLE
fix(plugin-detail): 把记录详情抽屉拖拽手柄的硬编码英文接入 i18n (objectstack#5733)

### DIFF
--- a/.changeset/detail-drawer-resize-handle-i18n-5733.md
+++ b/.changeset/detail-drawer-resize-handle-i18n-5733.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+Localize `RecordDetailDrawer`'s drag-resize handle (objectstack#5733)
+
+`packages/plugin-detail/src/RecordDetailDrawer.tsx` carried a byte-identical twin
+of the literal objectstack#5506 removed from `NavigationOverlay`: a
+`role="separator"` drag handle on the drawer's left edge with a hardcoded
+`aria-label="Resize drawer"`. #5506's sweep fenced on `packages/components`, so
+this second copy survived it.
+
+The handle has no visible label, so that string IS the control as far as a
+screen reader is concerned — a zh/ja/de session got one English announcement in
+an otherwise localized drawer. It is not a dormant branch either: `resizable`
+defaults to `true`, and the drawer is what plugin-kanban / plugin-calendar /
+plugin-gantt open on row, card and event click.
+
+It now reads `t('common.resizeDrawer')` — deliberately the SAME key #5506 gave
+the other handle (already present in all ten locale packs) rather than a new
+`detail.resizeDrawer` twin, so one control rendered from two packages cannot end
+up with two translations that drift apart.
+
+`common.resizeDrawer` is also added to `DETAIL_DEFAULT_TRANSLATIONS`, the map
+`createSafeTranslation` falls back to when no `I18nProvider` is mounted. Without
+that entry the name would degrade to the raw key for every provider-less host —
+which is the regression the accompanying no-provider test pins.

--- a/packages/plugin-detail/src/RecordDetailDrawer.tsx
+++ b/packages/plugin-detail/src/RecordDetailDrawer.tsx
@@ -269,12 +269,15 @@ export function RecordDetailDrawer({
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
         {/* Drag handle on the left edge — only rendered on >= sm screens
-            where pointer-resize is meaningful. */}
+            where pointer-resize is meaningful. The handle carries no visible
+            label, so its `aria-label` IS the control to a screen reader —
+            hence it comes from the locale pack, not a literal
+            (objectstack#5733, twin of #5506's NavigationOverlay handle). */}
         {resizable && (
           <div
             role="separator"
             aria-orientation="vertical"
-            aria-label="Resize drawer"
+            aria-label={t('common.resizeDrawer')}
             onPointerDown={handleResizePointerDown}
             className="hidden sm:block absolute left-0 top-0 h-full w-1.5 cursor-col-resize select-none bg-transparent hover:bg-primary/30 active:bg-primary/50 transition-colors z-10"
           />

--- a/packages/plugin-detail/src/__tests__/RecordDetailDrawer.resizeHandleI18n.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordDetailDrawer.resizeHandleI18n.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RecordDetailDrawer`'s drag-resize handle speaks the session locale —
+ * objectstack#5733.
+ *
+ * The literal removed here was a **byte-identical twin** of the one #5506
+ * removed from `NavigationOverlay` (`packages/components/src/custom/
+ * navigation-overlay.tsx`): same control (a drag-resize handle on a record
+ * drawer's left edge), same shape (`role="separator"`, `aria-orientation=
+ * "vertical"`, no visible label), same defect (a zh/ja/de session got one
+ * English string in an otherwise localized drawer). #5506's file fence did not
+ * reach `packages/plugin-detail`, so this copy survived that sweep.
+ *
+ * It reuses #5506's key, `common.resizeDrawer` — already in all ten packs —
+ * rather than minting a `detail.resizeDrawer` twin: one control rendered from
+ * two packages should not get two translations that can drift apart.
+ *
+ * The handle carries no visible label, so its `aria-label` IS the control as
+ * far as a screen reader is concerned. `resizable` defaults to `true`, so this
+ * is the drawer the console renders, not a dormant branch.
+ *
+ * ── Direction of these assertions ─────────────────────────────────────────
+ * The non-English cases (zh / de / ja) were RED before the change — the handle
+ * announced "Resize drawer" in every locale — and are GREEN after. The `en`
+ * case was GREEN before AND after: it pins that routing the name through `t()`
+ * did not change what an English session hears. The provider-less fallback is
+ * asserted in `RecordDetailDrawer.resizeHandleNoProviderFallback.test.tsx` —
+ * it cannot live in this file; see that file's header for why.
+ *
+ * `DetailView` / `InlineEditSaveBar` are mocked (same as
+ * `RecordDetailDrawer.capability.test.tsx`) so the only `role="separator"` in
+ * the tree is the handle under test, and the drawer body's data fetching stays
+ * out of an assertion about chrome.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { RecordDetailDrawer } from '../RecordDetailDrawer';
+
+vi.mock('../DetailView', () => ({
+  DetailView: () => <div data-testid="dv-probe" />,
+}));
+
+vi.mock('../InlineEditSaveBar', () => ({
+  InlineEditSaveBar: () => null,
+}));
+
+function renderDrawerIn(
+  language: string,
+  extra: Partial<React.ComponentProps<typeof RecordDetailDrawer>> = {},
+) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <RecordDetailDrawer
+        open
+        onClose={() => {}}
+        title="Task Details"
+        record={{ id: '1', name: 'Hello' }}
+        objectName="tasks"
+        recordId="1"
+        {...extra}
+      />
+    </I18nProvider>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe('RecordDetailDrawer drag-resize handle — accessible name (objectstack#5733)', () => {
+  it('still reads English under an en session', () => {
+    renderDrawerIn('en');
+
+    expect(screen.getByRole('separator').getAttribute('aria-label')).toBe('Resize drawer');
+  });
+
+  it('reads the zh bundle value under a zh session', () => {
+    renderDrawerIn('zh');
+
+    expect(screen.getByRole('separator').getAttribute('aria-label')).toBe('调整面板宽度');
+    // The whole point of the issue: no English leaks into a zh drawer.
+    expect(screen.queryByLabelText('Resize drawer')).toBeNull();
+  });
+
+  it('reads the de bundle value under a de session', () => {
+    renderDrawerIn('de');
+
+    expect(screen.getByRole('separator').getAttribute('aria-label')).toBe('Panelbreite anpassen');
+  });
+
+  it('reads the ja bundle value under a ja session', () => {
+    renderDrawerIn('ja');
+
+    expect(screen.getByRole('separator').getAttribute('aria-label')).toBe('パネル幅を調整');
+  });
+
+  /**
+   * The handle is gated on `resizable`, so a host that turns resizing off must
+   * render no separator at all — in any locale. Without this the locale
+   * assertions above could pass against an empty tree if the gate ever broke
+   * open in the other direction.
+   */
+  it('renders no handle at all when the host disables resizing', () => {
+    renderDrawerIn('zh', { resizable: false });
+
+    expect(screen.queryByRole('separator')).toBeNull();
+    expect(screen.queryByLabelText('调整面板宽度')).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RecordDetailDrawer.resizeHandleNoProviderFallback.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordDetailDrawer.resizeHandleNoProviderFallback.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RecordDetailDrawer`'s resize-handle name still resolves to ENGLISH when no
+ * `I18nProvider` is mounted — objectstack#5733.
+ *
+ * This is not a nice-to-have. Routing a literal through `t()` without a working
+ * default is exactly how a provider-less consumer breaks, and it breaks in a
+ * suite that is not this one. `RecordDetailDrawer` is embedded by
+ * `plugin-kanban`'s `ObjectKanban` and `plugin-calendar`'s `ObjectCalendar`
+ * (and mocked out by `plugin-gantt`'s), none of which wrap it in an
+ * `I18nProvider`; the same goes for any host app that never mounts one. The
+ * English default lives in `DETAIL_DEFAULT_TRANSLATIONS`
+ * (`useDetailTranslation.ts`) — that map is what `createSafeTranslation` falls
+ * back to when its `detail.back` probe comes back unresolved.
+ *
+ * Direction: this file was GREEN before the change and is GREEN after. It pins
+ * the FALLBACK, not the fix — the fix is asserted in
+ * `RecordDetailDrawer.resizeHandleI18n.test.tsx`. A missing map entry would
+ * have turned it red by rendering the raw key `common.resizeDrawer`, which is
+ * precisely the regression it exists to catch.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, and `initReactI18next`
+ * registers that instance as **react-i18next's module-global default**. The
+ * registration survives unmount and `cleanup()`. So the moment any test in a
+ * file mounts `<I18nProvider config={{ defaultLanguage: 'de' }}>`, every later
+ * "no provider" render in that same file silently resolves against the German
+ * instance — a green-looking file that asserts nothing about the fallback, or a
+ * confusing red where the drawer announces "Panelbreite anpassen" under a test
+ * that mounted no provider at all.
+ *
+ * Vitest's `dom` project runs with `isolate: true`, so a file that never mounts
+ * a provider gets a genuinely clean global. Keep it that way: **do not import
+ * or mount `I18nProvider` here.**
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { RecordDetailDrawer } from '../RecordDetailDrawer';
+
+vi.mock('../DetailView', () => ({
+  DetailView: () => <div data-testid="dv-probe" />,
+}));
+
+vi.mock('../InlineEditSaveBar', () => ({
+  InlineEditSaveBar: () => null,
+}));
+
+afterEach(() => cleanup());
+
+describe('RecordDetailDrawer resize handle — English fallback with no provider (objectstack#5733)', () => {
+  it('names the drag handle in English, never the raw key', () => {
+    render(
+      <RecordDetailDrawer
+        open
+        onClose={() => {}}
+        title="Task Details"
+        record={{ id: '1', name: 'Hello' }}
+        objectName="tasks"
+        recordId="1"
+      />,
+    );
+
+    const handle = screen.getByRole('separator');
+    expect(handle.getAttribute('aria-label')).toBe('Resize drawer');
+    // A missing DETAIL_DEFAULT_TRANSLATIONS entry surfaces as the raw key,
+    // because createSafeTranslation's fallback is `defaults[key] || key`.
+    expect(handle.getAttribute('aria-label')).not.toBe('common.resizeDrawer');
+    expect(screen.getByLabelText('Resize drawer')).toBeTruthy();
+  });
+});

--- a/packages/plugin-detail/src/useDetailTranslation.ts
+++ b/packages/plugin-detail/src/useDetailTranslation.ts
@@ -27,6 +27,13 @@ export const createSafeTranslationHook = createSafeTranslation;
  * Used as fallback when no I18nProvider is available.
  */
 export const DETAIL_DEFAULT_TRANSLATIONS: Record<string, string> = {
+  // objectstack#5733 — RecordDetailDrawer's drag-resize handle. The only
+  // `common.*` key in this map, deliberately: it is the SAME key #5506 gave
+  // NavigationOverlay's identical handle (`common.resizeDrawer`, already in
+  // all ten packs), and one control should not get two spellings just because
+  // it is rendered from two packages. Adding a `detail.resizeDrawer` twin
+  // would fork the translation and drift the two handles apart.
+  'common.resizeDrawer': 'Resize drawer',
   'detail.back': 'Back',
   'detail.edit': 'Edit',
   'detail.editInline': 'Edit',


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5733

## 问题

`packages/plugin-detail/src/RecordDetailDrawer.tsx:277` 带着一个 `aria-label="Resize drawer"` 硬编码字面量,与 objectstack#5506(objectui #3423)刚从 `packages/components/src/custom/navigation-overlay.tsx` 移除的那个**逐字节相同**。#5506 的改动范围只圈了 `packages/components`,`packages/plugin-detail` 不在其中,这份副本因此漏网。

两处是同一个控件形态:抽屉左边缘的拖拽调宽手柄,`role="separator"` + `aria-orientation="vertical"`,**没有任何可见标签**——所以这个字符串对读屏软件而言"就是"这个控件本身。结果是 zh / ja / de 会话在一个整体已本地化的抽屉里,只有这一处念英文。

也不是死代码:`resizable` 默认为 `true`,plugin-kanban 的 `ObjectKanban`、plugin-calendar 的 `ObjectCalendar` 点开的就是它(plugin-gantt 在测试里把它 mock 掉)。

## 前提核验(基于 origin/main@5dd012776)

Issue 只是线索,三条前提逐条在 `origin/main` 上验过:

- 字面量仍在 `RecordDetailDrawer.tsx:277`,且是该文件里唯一的 `aria-label`。
- `common.resizeDrawer` 已在**十个语言包全部落地**(#3423 已合入):en `Resize drawer` / zh `调整面板宽度` / de `Panelbreite anpassen` / ja `パネル幅を調整` / ar es fr ko pt ru。
- `useDetailTranslation.ts` 的 `DETAIL_DEFAULT_TRANSLATIONS` 存在,`RecordDetailDrawer.tsx:136` 已经拿到 `t`(第 321 行在用),无需新接线。

顺带确认探针 key `detail.back` 在 en/zh/de/ja 包里都在——挂了 provider 时 `createSafeTranslation` 才会走真 `t`,`common.resizeDrawer` 才解析得到语言包的值。

## 改动

两行实质改动:

1. `RecordDetailDrawer.tsx` —— 字面量换成 `t('common.resizeDrawer')`。
2. `useDetailTranslation.ts` —— 往 `DETAIL_DEFAULT_TRANSLATIONS` 加一条 `'common.resizeDrawer': 'Resize drawer'`。

**刻意复用 #5506 的同一个 key,而不是新造 `detail.resizeDrawer` 孪生 key。** 这是本 PR 唯一一处有取舍的地方:它让 `DETAIL_DEFAULT_TRANSLATIONS` 出现了第一个 `common.*` 条目(其余全是 `detail.*`)。但同一个控件从两个包渲染,不该拿到两份会各自漂移的翻译;新造 key 还要再动十个语言包(而 `packages/i18n` 本来就不该由这个 PR 碰)。代码里留了注释说明这一条。

那条 defaults 是无 provider 时的回退表——缺了它,所有没挂 I18nProvider 的宿主会退化成显示原始 key `common.resizeDrawer`。

## 测试(两个文件,方向先预测后运行)

**这不是一个"全红转全绿"的改动,三个方向分开说清楚:**

| 用例 | 改前 | 改后 |
|---|---|---|
| zh / de / ja 会话下手柄读语言包的值 | **RED** | GREEN |
| en 会话下仍读 `Resize drawer` | GREEN | GREEN |
| 无 provider 时回退英文 | GREEN | GREEN |

后两行是**如实记录**:它们钉的是"回退没被改坏",不是这次修复本身。`en` 一行证明把名字接进 `t()` 没有改变英文会话听到的内容;无 provider 一行钉的是 defaults 表——少了那条会渲染出原始 key 而变红,那正是它存在的理由。

反向验证真跑了:把两处源码改动 stash 掉、只留新测试,得到

```
× reads the zh bundle value under a zh session
  → expected 'Resize drawer' to be '调整面板宽度'
× reads the de bundle value under a de session
  → expected 'Resize drawer' to be 'Panelbreite anpassen'
× reads the ja bundle value under a ja session
  → expected 'Resize drawer' to be 'パネル幅を調整'
Test Files  1 failed | 1 passed (2)
     Tests  3 failed | 3 passed (6)
```

与预测完全一致。

**为什么是两个文件而不是一个 describe:** `createI18n` 会调 `instance.use(initReactI18next)`,把该实例注册成 react-i18next 的**模块级全局默认**,这个注册在 unmount 和 `cleanup()` 之后依然存在。所以只要文件里有任何一个用例挂过 provider,同文件里之后所有"无 provider"渲染都会静默地解析到那个实例上——要么绿得毫无意义,要么红得莫名其妙。无 provider 的断言因此单独成文件,且该文件**不 import provider**;vitest 的 `dom` project 是 `isolate: true`,能保证它拿到干净的全局。这一条在文件头注释里写死了。

两个文件都把 `DetailView` / `InlineEditSaveBar` mock 掉(沿用同目录 `RecordDetailDrawer.capability.test.tsx` 的做法),这样树里唯一的 `role="separator"` 就是被测手柄。另外补了一个 `resizable: false` 的用例——否则上面几条 locale 断言在"手柄整个不渲染"的情况下也可能因为查不到东西而误绿。

## 消费半径排查

按规则的调用方而不是按改动的包来扫:`grep` 全仓 `Resize drawer` / `resizeDrawer` / `role="separator"` 断言,`RecordDetailDrawer` 的三个宿主包(kanban / calendar / gantt)的 fixture 与 spec 里,**没有**任何一处按英文名寻址这个抽屉的手柄。`packages/components` 下命中的三处都是 NavigationOverlay 自己的测试,是另一个组件。

## 验证输出

```
# 全量 plugin-detail 套件(含两个新文件)
Test Files  52 passed (52)
     Tests  450 passed (450)

# 两个新文件确实跑到了(verbose 里核对过文件名)
✓ .../RecordDetailDrawer.resizeHandleI18n.test.tsx  (5 个用例)
✓ .../RecordDetailDrawer.resizeHandleNoProviderFallback.test.tsx  (1 个用例)

# type-check(先 build 了依赖图,否则新 worktree 里 tsc 解析不到 @object-ui/* 声明)
pnpm --workspace-concurrency=2 --filter @object-ui/plugin-detail type-check  → 通过

# 门禁
node scripts/check-control-bytes.mjs   ✅ OK (3622 tracked text files)
node scripts/check-changeset-no-major.mjs  ✅
node scripts/check-changeset-fixed.mjs     ✅
eslint(四个改动文件)  0 errors(8 个 warning 全在未触碰的既有行上)
```

另按字节纪律对五个改动文件做了门禁之外的自查(`grep -naP` 扫控制字符),无命中。

changeset 按 #3423 的先例补了一个(patch,`@object-ui/plugin-detail`),因为这是十个 locale 下用户可见的可访问名变化。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_