### PR TITLE
fix(ci): 把 live-e2e 的 runner.temp 移出 job 级 env,修掉全分支 startup failure

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -57,8 +57,16 @@ jobs:
     # Non-blocking by construction — see the header comment before touching.
     continue-on-error: true
 
+    # ⚠️ Do NOT add a `runner.*` expression to this job-level `env:` block.
+    # The `runner` context does not exist yet when job-level env is evaluated
+    # (GitHub's "contexts availability" table allows only github / needs /
+    # strategy / matrix / vars / secrets / inputs here). One `${{ runner.temp }}`
+    # in this block fails the whole FILE at validation time — 0 jobs, 0s,
+    # "startup failure" — and `continue-on-error` cannot soften it because no
+    # job is ever created. Need a runner path? Use the `$RUNNER_TEMP`
+    # environment variable inside a `run:` step, or a step-level `env:` /
+    # `with:` (both may read `runner`). See the LIVE_BACKEND_DIR step below.
     env:
-      LIVE_BACKEND_DIR: ${{ runner.temp }}/live-backend
       LIVE_BACKEND_PORT: '4010'
       LIVE_API_URL: http://localhost:4010
       LIVE_APP_URL: http://localhost:5190
@@ -91,6 +99,12 @@ jobs:
           key: live-backend-${{ runner.os }}-${{ hashFiles('e2e/live/ci/backend.env') }}
 
       - name: Start ObjectStack backend (published packages)
+        # Step-level env — `runner` IS available here (unlike job-level env).
+        # Must resolve to the same path as the cache step's `path:` above and
+        # the artifact upload's `path:` below, or the cache silently stops
+        # hitting; keep the three in sync.
+        env:
+          LIVE_BACKEND_DIR: ${{ runner.temp }}/live-backend
         run: bash e2e/live/ci/start-backend.sh
 
       - name: Build console


### PR DESCRIPTION
Fixes #3425

## 根因

`.github/workflows/live-e2e.yml` 第 61 行,在 **job 级 `env:`** 里读了 `runner` 上下文:

```yaml
    env:
      LIVE_BACKEND_DIR: ${{ runner.temp }}/live-backend
```

job 级 `env:` 求值时 `runner` 上下文尚不存在。actionlint v1.7.7 对 origin/main 原文件的判定(exit 1):

```
.github/workflows/live-e2e.yml:61:29: context "runner" is not allowed here.
available contexts are "github", "inputs", "matrix", "needs", "secrets",
"strategy", "vars". [expression]
```

关键在于:这是**整份 workflow 文件校验失败**,而不是某个 step 失败。GitHub 还没能解析 `on:` 就先判定文件非法,于是对每一次 push 都记一条 0 job / 0s 的 startup failure —— 包括 `gh-readonly-queue/*` 合并队列分支,把每个 PR 和每次 main push 的 checks 列表都染红一格。

## 两个推论

1. **`continue-on-error: true` 救不了它。** 那是 job 级属性,而这里根本没有任何 job 被创建,红色出在 workflow 启动阶段。
2. **该 lane 自 #3325 落地起从未跑起来过一次。** 按 `pull_request` 事件过滤,这个 workflow 的历史 run 数是 **0**;它从未声明过 push 触发器,所有 182 个 run 编号全部是 push 上的 startup failure 噪声。换句话说,它一次都没有真正冒烟测试过「console x 真后端」—— 这比「红噪声」本身更值得记一笔。

## 改动

- job 级 `env:` 只保留三个字面量常量。
- `LIVE_BACKEND_DIR` 下沉到唯一消费它的 `Start ObjectStack backend` step 的 **step 级 `env:`** —— 该处读 `runner` 是合法的。
- cache 的 `path:`/`key:` 与 artifact 上传的 `path:` 本就写在 `with:` 里、一直合法,未动。
- job 级 `env:` 上方补了一段告警注释,写明此处为什么不能出现 `runner.*`,避免下一个人挪回去。

## 验证(方向在运行前先行预测)

| 对象 | actionlint v1.7.7 |
|---|---|
| origin/main 原文件 | 报 L61 `runner` 上下文错误,exit 1 |
| 本 PR | 无告警,exit 0 |
| 全量 `.github/workflows/*.yml` | exit 0 —— live-e2e.yml 是仓库里唯一一份校验不过的 workflow,与 issue 观察到的「只有这一格红」吻合 |

**push 事件的预期方向值得说清楚:** 修好后本分支的「0 红」**不是**靠 job 跑绿拿到的,而是靠**这条 run 不再存在** —— 文件合法后 GitHub 能正确解析 `on:`,而其中并没有 `push:`。实测本分支 push 后 live-e2e 的 run 数为 `0`(对比:修复前每个分支每次 push 都会多出一条 startup failure)。真正会产出 job 的,是本 PR 的 `pull_request` 事件 run。

纯 CI bug 修复、不触及任何已发布包,按 AGENTS.md:151 不需要 changeset。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_