### PR TITLE
fix(fields): 全屏长文本编辑器的字数计数接入无障碍,计数 UI 收敛为一份共享组件 (#3417)

### DIFF
--- a/.changeset/textarea-fullscreen-character-count-a11y.md
+++ b/.changeset/textarea-fullscreen-character-count-a11y.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/fields': patch
+---
+
+`TextAreaField`'s fullscreen edit dialog now gives screen reader users the character count it has always shown sighted ones. The dialog's footer counter was a bare `{n}/{max}` span: no accessible name, nothing `aria-live`, and nothing tying it to the dialog's textarea — so browse mode read "5 slash 500" if it happened to sweep the footer, and focusing the input said nothing about the cap at all. The inline surface of the same field has carried a proper three-node counter since #3408, so the fullscreen branch was at zero for the same field, the same cap and the same user (#3417). It is reachable on any phone form with `ObjectFormSchema.mobile.fullscreenLongText` on, for every long-text field that declares a limit.
+
+The counting UI is now ONE shared `CharacterCount` component that both surfaces render, instead of two hand-written copies that could only drift. In the dialog it renders `aria-hidden` digits plus a visually-hidden description carrying `fields.textarea.characterCount`, wired to the dialog's textarea through `aria-describedby`, so focus reads "Character count: 12 of 500" once and the count follows the draft as it is edited. The description ids are per surface, because the dialog's draft and the committed value diverge as soon as the user types.
+
+The dialog deliberately gets NO live region: it is a modal opened to write at length, the description already delivers the cap on focus, and the inline surface's `aria-live` region stays mounted behind the overlay. The inline surface is unchanged — same DOM, same threshold-gated debounced announcements, same ten locale packs and the same English fallbacks with no `I18nProvider` mounted. No new i18n keys and no metadata change: the counter still renders exactly when the field declares `maxLength` (or the legacy `max_length`).

--- a/packages/fields/src/widgets/CharacterCount.tsx
+++ b/packages/fields/src/widgets/CharacterCount.tsx
@@ -1,0 +1,263 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useFieldTranslation } from './useFieldTranslation';
+
+/**
+ * The character counter a capped long-text field renders, in the GOV.UK
+ * character-count shape — extracted from `TextAreaField` so that widget's TWO
+ * editing surfaces (the inline textarea and the fullscreen dialog) render the
+ * SAME counting UI instead of two hand-written copies (objectui#3417).
+ *
+ * ## Why this is shared rather than copied
+ *
+ * objectui#3408 gave the inline counter three nodes — decorative digits, an
+ * accessible description, a gated status region. The fullscreen dialog's
+ * counter, passed to `FullscreenFieldEditor` as a `footer`, stayed what it had
+ * always been: a bare `{n}/{max}` `span` with no accessible name, no
+ * `aria-describedby` association with the dialog's textarea, and nothing
+ * `aria-live`. Same field, same cap, same user — and a screen reader in the
+ * fullscreen dialog got nothing at all, while browse mode read "5 slash 500".
+ *
+ * That is the failure mode this package keeps paying for (objectui#3301: the
+ * fullscreen flag reached `RichTextField` for as long as the feature existed
+ * and that widget never read it). A second hand-written copy of a counting UI
+ * is the same failure with an extra step: it drifts, and nothing reports the
+ * drift. So the counter has ONE implementation and each surface renders it.
+ *
+ * ## The three nodes, and why the third is a prop
+ *
+ * 1. the visible `{n}/{max}` digits, `aria-hidden` — a glance affordance;
+ * 2. a visually-hidden DESCRIPTION carrying the translated sentence. The host
+ *    owns {@link CharacterCountProps.descriptionId} and MUST name it in the
+ *    edited control's `aria-describedby`, which is what makes the sentence
+ *    reachable on focus rather than only in browse mode;
+ * 3. a visually-hidden `aria-live="polite"` STATUS region, silent until the
+ *    value is inside the last 10% / 20 characters of the cap and updated only
+ *    after the typist pauses.
+ *
+ * Node 3 is opt-in per surface ({@link CharacterCountProps.announceNearLimit}),
+ * required rather than defaulted, because "should this surface interrupt the
+ * user while they type?" is a real decision and neither answer should be
+ * reached by leaving a prop off. The fullscreen dialog answers no: it is a
+ * modal the user opened deliberately to write at length, the description
+ * already tells them the cap on focus, and the dialog's own textarea carries
+ * the same native `maxLength` stop as the inline one. The inline surface
+ * answers yes, unchanged from objectui#3408.
+ */
+
+/**
+ * How long the typist must pause before the counter's status region is allowed
+ * to change (objectui#3408). The GOV.UK Design System character-count component
+ * uses the same shape and the same order of magnitude.
+ *
+ * The number this replaces was effectively 0: the counter WAS the live region,
+ * so every keystroke re-rendered it and every re-render was an announcement.
+ * Measured on `origin/main`, zh session, `maxLength: 500`, typing a 52-character
+ * sentence one character at a time: 52 keystrokes produced 52 distinct
+ * announcements totalling 979 spoken characters — ~19x the text the user was
+ * trying to write, each one interrupting the screen reader's echo of what they
+ * had just typed.
+ */
+const COUNTER_STATUS_DEBOUNCE_MS = 1000;
+
+/** Announce inside the last 10% of the cap … */
+const COUNTER_STATUS_REMAINING_RATIO = 0.1;
+/** … or the last 20 characters — whichever the typist reaches FIRST. */
+const COUNTER_STATUS_MIN_REMAINING = 20;
+
+/**
+ * The remaining-character count at or below which the status region speaks.
+ *
+ * "10% remaining OR 20 characters remaining, whichever comes first" is a
+ * disjunction, and because `remaining` only ever counts DOWN as the user types,
+ * the branch that fires first is simply the LARGER of the two — hence `max`.
+ * A 500-character cap starts warning at 50 remaining; a 100-character cap at 20
+ * (10% of it would be 10, which the typist would reach later, not sooner).
+ *
+ * A cap smaller than {@link COUNTER_STATUS_MIN_REMAINING} is therefore "near
+ * the limit" from the first keystroke, which is correct: on a 10-character
+ * field every character genuinely is one of the last few. The debounce still
+ * bounds it to one announcement per pause.
+ */
+function counterStatusThreshold(maxLength: number): number {
+  return Math.max(
+    Math.ceil(maxLength * COUNTER_STATUS_REMAINING_RATIO),
+    COUNTER_STATUS_MIN_REMAINING,
+  );
+}
+
+export interface CharacterCountProps {
+  /**
+   * Length of the text this surface is counting. The inline surface passes the
+   * committed value's length; the fullscreen dialog passes the DRAFT's, which
+   * is the number that is true of what the user is looking at.
+   */
+  length: number;
+  /**
+   * The declared cap. Callers render this component only when the field
+   * declares one, so it is non-optional here — a counter with no cap to count
+   * against has nothing to say and must not be mounted at all (an unconditional
+   * live region in every long-text field is the objectui#3408 defect back
+   * again).
+   */
+  maxLength: number;
+  /**
+   * The description node's `id`, minted by the host from `useId()`.
+   *
+   * The host MUST also name it in the edited control's `aria-describedby` —
+   * this component renders the sentence, only the host knows which element is
+   * being described, and a description nothing references is a node no screen
+   * reader will ever reach. That association is asserted from the OUTSIDE (the
+   * tests resolve `aria-describedby` and concatenate the referenced nodes' text,
+   * exactly as an assistive technology does) rather than trusted here.
+   *
+   * Two surfaces of one widget therefore need two ids: the dialog's draft and
+   * the inline value diverge the moment the user types in the dialog, so one
+   * shared id would point both controls at whichever sentence rendered last.
+   */
+  descriptionId: string;
+  /**
+   * Render node 3, the threshold-gated debounced `aria-live` status region.
+   *
+   * Required on purpose — see the component doc above. `false` removes the
+   * region from the DOM entirely (not merely empties it), which is the only
+   * form of "no live region" a test can tell apart from "a live region that
+   * happens to be silent right now".
+   */
+  announceNearLimit: boolean;
+  /**
+   * Classes for the visible digits. Required because placement is entirely the
+   * surface's business — inline pins them to the textarea's bottom-right
+   * corner, the dialog lays them out as a footer item — and a default borrowed
+   * from either one would position the other wrongly while looking deliberate.
+   */
+  className: string;
+  /**
+   * `data-testid` for the visible digits, namespaced per surface
+   * (`textarea-character-count`, `textarea-fullscreen-character-count`) so a
+   * test that finds digits can say WHICH surface it found them on. Same
+   * convention, same reason, as `FullscreenFieldEditor`'s `testIdPrefix`.
+   */
+  testId: string;
+}
+
+export function CharacterCount({
+  length,
+  maxLength,
+  descriptionId,
+  announceNearLimit,
+  className,
+  testId,
+}: CharacterCountProps) {
+  const { t } = useFieldTranslation();
+
+  /**
+   * The counter sentence as a DESCRIPTION (objectui#3408). Reached through the
+   * edited control's `aria-describedby`, so focusing it says "12 characters,
+   * 500 max" once and then shuts up. Before this the cap was announced only as
+   * a side effect of typing — focus told a screen reader user nothing at all
+   * that a sighted user could read off the corner of the box.
+   */
+  const description = t('fields.textarea.characterCount', { count: length, max: maxLength });
+
+  /**
+   * The near-limit warning, gated. Silent for the whole comfortable middle of
+   * the field — a count nobody is close to is not news — and phrased as what
+   * is LEFT rather than what has been typed, because that is the number the
+   * user is about to act on. Over-long values (a cap lowered after the record
+   * was saved) clamp to 0: the textarea's own `maxLength` blocks further
+   * input, so "0 left" is the true actionable state, and the description above
+   * still carries the honest `503 of 500`.
+   *
+   * Short-circuited by `announceNearLimit` rather than only hidden at render
+   * time, so a surface that renders no status region also schedules no timer —
+   * a debounce firing into a region that does not exist is a state update with
+   * no consumer, and in tests an `act()` warning with no cause.
+   */
+  const pendingStatus =
+    announceNearLimit && maxLength - length <= counterStatusThreshold(maxLength)
+      ? t('fields.textarea.charactersRemaining', { count: Math.max(maxLength - length, 0) })
+      : '';
+
+  /**
+   * The last sentence a PAUSE settled on. Only ever written by the timer —
+   * never cleared synchronously — so this effect adds no cascading render on
+   * the keystrokes it is busy staying quiet through
+   * (`react-hooks/set-state-in-effect`).
+   */
+  const [settledStatus, setSettledStatus] = useState('');
+
+  useEffect(() => {
+    if (!pendingStatus) return;
+    const timer = setTimeout(() => setSettledStatus(pendingStatus), COUNTER_STATUS_DEBOUNCE_MS);
+    // Every keystroke cancels the previous pending announcement, so a typist
+    // who never pauses is never interrupted. The dependency is the SENTENCE,
+    // not the length: re-typing back to the same count produces the same string
+    // and therefore no DOM change and no second announcement.
+    return () => clearTimeout(timer);
+  }, [pendingStatus]);
+
+  /**
+   * Speak the settled sentence only while it is still TRUE — i.e. while it is
+   * the one the current value would produce. Everything else renders empty,
+   * which costs no speech (emptying a live region announces nothing), and that
+   * is what makes leaving the warning band silent IMMEDIATELY rather than a
+   * second later.
+   *
+   * The obvious alternative, `pendingStatus ? settledStatus : ''`, is wrong in
+   * one specific way: delete back out of the band and type into it again, and
+   * the region re-announces the STALE count from before the excursion a full
+   * second before the timer corrects it. Announcing a wrong number is worse
+   * than announcing a right one twice, which is the bounded, sub-second,
+   * correct-content cost of the comparison below. Pinned by `never
+   * re-announces the STALE count when the user types back into the band`.
+   */
+  const status = settledStatus === pendingStatus ? pendingStatus : '';
+
+  return (
+    <>
+      {/*
+        The VISIBLE counter, and visible ONLY (objectui#3408). It used to be
+        three things at once: the digits a sighted user glances at, the carrier
+        of the translated sentence (objectui#3406), and the live region itself —
+        so the sentence was re-announced on every single keystroke. Split into
+        the three nodes here, this one is decorative: `aria-hidden` keeps a
+        screen reader from reading "5 slash 200" on top of the description that
+        says it properly.
+      */}
+      <div className={className} aria-hidden="true" data-testid={testId}>
+        {length}/{maxLength}
+      </div>
+
+      {/*
+        The DESCRIPTION. Referenced by the edited control's `aria-describedby`,
+        never announced on its own — a screen reader reads it when focus lands
+        on the control and not again. Visually hidden because the digits above
+        already say it to the eye.
+      */}
+      <span id={descriptionId} className="sr-only">
+        {description}
+      </span>
+
+      {/*
+        The STATUS region, on the surfaces that opted in. Rendered
+        unconditionally there and starting EMPTY on purpose: a live region has
+        to be in the DOM before its content changes or the first change is not
+        announced at all. `aria-atomic` so the whole sentence is spoken rather
+        than the digits that differ from last time.
+      */}
+      {announceNearLimit && (
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
+          {status}
+        </span>
+      )}
+    </>
+  );
+}

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useId, useState } from 'react';
+import React, { useId } from 'react';
 import { Textarea, EmptyValue } from '@object-ui/components';
+import { CharacterCount } from './CharacterCount';
 import { FullscreenFieldEditor } from './FullscreenFieldEditor';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
-import { useFieldTranslation } from './useFieldTranslation';
 
 /**
  * TextAreaField - Multi-line text input widget
@@ -36,134 +36,49 @@ import { useFieldTranslation } from './useFieldTranslation';
  * silently-ignored prop, so the reads are gone (objectui#3232). If a host
  * override is ever genuinely needed, declare ONE key on
  * `FieldWidgetComponentProps`, stop stripping it, and have a host pass it.
- */
-
-/**
- * How long the typist must pause before the counter's status region is allowed
- * to change (objectui#3408). The GOV.UK Design System character-count component
- * uses the same shape and the same order of magnitude.
  *
- * The number this replaces was effectively 0: the counter WAS the live region,
- * so every keystroke re-rendered it and every re-render was an announcement.
- * Measured on `origin/main`, zh session, `maxLength: 500`, typing a 52-character
- * sentence one character at a time: 52 keystrokes produced 52 distinct
- * announcements totalling 979 spoken characters — ~19x the text the user was
- * trying to write, each one interrupting the screen reader's echo of what they
- * had just typed.
- */
-const COUNTER_STATUS_DEBOUNCE_MS = 1000;
-
-/** Announce inside the last 10% of the cap … */
-const COUNTER_STATUS_REMAINING_RATIO = 0.1;
-/** … or the last 20 characters — whichever the typist reaches FIRST. */
-const COUNTER_STATUS_MIN_REMAINING = 20;
-
-/**
- * The remaining-character count at or below which the status region speaks.
+ * ## The character counter (objectui#3408, shared across surfaces in #3417)
  *
- * "10% remaining OR 20 characters remaining, whichever comes first" is a
- * disjunction, and because `remaining` only ever counts DOWN as the user types,
- * the branch that fires first is simply the LARGER of the two — hence `max`.
- * A 500-character cap starts warning at 50 remaining; a 100-character cap at 20
- * (10% of it would be 10, which the typist would reach later, not sooner).
+ * Both editing surfaces below — the inline `<Textarea>` and the fullscreen
+ * dialog's — render the SAME `CharacterCount`, which owns the three-node
+ * GOV.UK shape (decorative digits / accessible description / gated status
+ * region) and the debounce and threshold behind it. Until #3417 the fullscreen
+ * footer had its own hand-written copy that was digits and nothing else, which
+ * is what a second copy of a UI always costs: it drifts, and nothing reports
+ * the drift.
  *
- * A cap smaller than {@link COUNTER_STATUS_MIN_REMAINING} is therefore "near
- * the limit" from the first keystroke, which is correct: on a 10-character
- * field every character genuinely is one of the last few. The debounce still
- * bounds it to one announcement per pause.
+ * This widget's remaining job is the part only it can do — mint the two
+ * description ids and name each one in the `aria-describedby` of the control
+ * it describes. The surfaces differ in exactly one behaviour, and it is
+ * declared rather than implied: `announceNearLimit`. Inline announces
+ * (unchanged since #3408); the fullscreen dialog does not.
  */
-function counterStatusThreshold(maxLength: number): number {
-  return Math.max(
-    Math.ceil(maxLength * COUNTER_STATUS_REMAINING_RATIO),
-    COUNTER_STATUS_MIN_REMAINING,
-  );
-}
 
 export function TextAreaField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
-  // Everything from here to the `readonly` early return is hook-order
-  // territory: a hook may not sit behind a conditional return. The readonly
-  // branch renders no counter, so these are no-ops there — but moving them
-  // down would desync hook order the moment a field toggles readonly. The
-  // derivations they read (`maxLength`, `length`) sit up here for the same
-  // reason, not because the readonly branch wants them.
-  const { t } = useFieldTranslation();
-
+  // `useId` sits above the `readonly` early return because a hook may not sit
+  // behind a conditional return: the readonly branch renders no counter, so
+  // the ids go unused there, but moving the call down would desync hook order
+  // the moment a field toggles readonly. `maxLength` is derived here for the
+  // same reason the ids are — proximity to the hook, not because the readonly
+  // branch wants it.
   const textareaField = field as any;
   // Spec FieldSchema declares camelCase `maxLength`; `max_length` is the legacy
   // objectui spelling. Dual-read (framework#1878 §3 recheck) — without this a
   // spec-authored maxLength gave neither the textarea cap nor the counter.
   const maxLength = textareaField?.maxLength ?? textareaField?.max_length;
-  const length = (value || '').length;
 
-  // Two ids off one `useId()`: the description a screen reader reads ONCE on
-  // focus, and the status region it hears only near the cap. Both derive from
-  // the widget instance, so two textareas on one form never collide.
+  /**
+   * Two description ids off one `useId()` — one per editing surface.
+   *
+   * They cannot be a single id. The dialog edits a LOCAL draft (see
+   * `FullscreenFieldEditor`), so the moment the user types in it the two
+   * surfaces are counting different strings; one shared id would point both
+   * textareas at whichever sentence rendered last. Both derive from the widget
+   * instance, so two textareas on one form never collide either.
+   */
   const instanceId = useId();
   const descriptionId = `${instanceId}-charcount`;
-
-  /**
-   * The counter sentence as a DESCRIPTION (objectui#3408). Reached through the
-   * textarea's `aria-describedby`, so focusing the field says "12 characters,
-   * 500 max" once and then shuts up. Before this the cap was announced only as
-   * a side effect of typing — focus told a screen reader user nothing at all
-   * that a sighted user could read off the corner of the box.
-   *
-   * Same key the visible counter's `aria-label` used to carry (objectui#3406,
-   * ten packs); it moved from a live region onto a description, it was not
-   * duplicated.
-   */
-  const description = maxLength
-    ? t('fields.textarea.characterCount', { count: length, max: maxLength })
-    : '';
-
-  /**
-   * The near-limit warning, gated. Silent for the whole comfortable middle of
-   * the field — a count nobody is close to is not news — and phrased as what
-   * is LEFT rather than what has been typed, because that is the number the
-   * user is about to act on. Over-long values (a cap lowered after the record
-   * was saved) clamp to 0: the textarea's own `maxLength` blocks further
-   * input, so "0 left" is the true actionable state, and the description above
-   * still carries the honest `503 of 500`.
-   */
-  const pendingStatus =
-    !readonly && maxLength && maxLength - length <= counterStatusThreshold(maxLength)
-      ? t('fields.textarea.charactersRemaining', { count: Math.max(maxLength - length, 0) })
-      : '';
-
-  /**
-   * The last sentence a PAUSE settled on. Only ever written by the timer —
-   * never cleared synchronously — so this effect adds no cascading render on
-   * the keystrokes it is busy staying quiet through
-   * (`react-hooks/set-state-in-effect`).
-   */
-  const [settledStatus, setSettledStatus] = useState('');
-
-  useEffect(() => {
-    if (!pendingStatus) return;
-    const timer = setTimeout(() => setSettledStatus(pendingStatus), COUNTER_STATUS_DEBOUNCE_MS);
-    // Every keystroke cancels the previous pending announcement, so a typist
-    // who never pauses is never interrupted. The dependency is the SENTENCE,
-    // not the length: re-typing back to the same count produces the same string
-    // and therefore no DOM change and no second announcement.
-    return () => clearTimeout(timer);
-  }, [pendingStatus]);
-
-  /**
-   * Speak the settled sentence only while it is still TRUE — i.e. while it is
-   * the one the current value would produce. Everything else renders empty,
-   * which costs no speech (emptying a live region announces nothing), and that
-   * is what makes leaving the warning band silent IMMEDIATELY rather than a
-   * second later.
-   *
-   * The obvious alternative, `pendingStatus ? settledStatus : ''`, is wrong in
-   * one specific way: delete back out of the band and type into it again, and
-   * the region re-announces the STALE count from before the excursion a full
-   * second before the timer corrects it. Announcing a wrong number is worse
-   * than announcing a right one twice, which is the bounded, sub-second,
-   * correct-content cost of the comparison below. Pinned by `never
-   * re-announces the STALE count when the user types back into the band`.
-   */
-  const status = settledStatus === pendingStatus ? pendingStatus : '';
+  const fullscreenDescriptionId = `${instanceId}-fullscreen-charcount`;
 
   if (readonly) {
     return (
@@ -213,45 +128,21 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
         className={domProps.className}
       />
       {maxLength && (
-        <>
-          {/*
-            The VISIBLE counter, and now visible ONLY (objectui#3408). It used
-            to be three things at once: the digits a sighted user glances at,
-            the carrier of the translated sentence (objectui#3406), and the
-            live region itself — so the sentence was re-announced on every
-            single keystroke. Split into the three nodes below, this one is
-            decorative: `aria-hidden` keeps a screen reader from reading
-            "5 slash 200" on top of the description that says it properly.
-          */}
-          <div
-            className="absolute bottom-2 right-2 text-xs text-gray-400"
-            aria-hidden="true"
-            data-testid="textarea-character-count"
-          >
-            {length}/{maxLength}
-          </div>
-
-          {/*
-            The DESCRIPTION. Referenced by the textarea's `aria-describedby`,
-            never announced on its own — a screen reader reads it when focus
-            lands on the field and not again. Visually hidden because the
-            digits above already say it to the eye.
-          */}
-          <span id={descriptionId} className="sr-only">
-            {description}
-          </span>
-
-          {/*
-            The STATUS region. Rendered unconditionally (whenever there is a
-            cap) and starting EMPTY on purpose: a live region has to be in the
-            DOM before its content changes or the first change is not announced
-            at all. `aria-atomic` so the whole sentence is spoken rather than
-            the digits that differ from last time.
-          */}
-          <span className="sr-only" aria-live="polite" aria-atomic="true">
-            {status}
-          </span>
-        </>
+        /*
+          The INLINE surface's counter. `announceNearLimit` because this is the
+          surface the user types into with the rest of the form around them —
+          the near-limit warning is the one thing worth interrupting for, and
+          it is threshold-gated and debounced so it interrupts about five times
+          over a run that fills a 500-character cap rather than 52.
+        */
+        <CharacterCount
+          length={(value || '').length}
+          maxLength={maxLength}
+          descriptionId={descriptionId}
+          announceNearLimit
+          className="absolute bottom-2 right-2 text-xs text-gray-400"
+          testId="textarea-character-count"
+        />
       )}
 
       {showFullscreenButton && (
@@ -261,11 +152,32 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
           label={textareaField?.label}
           testIdPrefix="textarea"
           disabled={disabled}
+          /*
+            The FULLSCREEN surface's counter (objectui#3417). This slot used to
+            render a bare `{n}/{max}` span: no accessible name, no association
+            with the dialog's textarea, nothing `aria-live`. A screen reader
+            heard "5 slash 500" if browse mode happened to sweep it and not one
+            word while the input had focus — the same field, the same cap, and
+            the inline surface three nodes richer since objectui#3408.
+
+            `announceNearLimit={false}` is the ruling on #3417, and it is a
+            choice about this SURFACE rather than a saving on effort: a
+            fullscreen modal is opened deliberately to write at length, the
+            description below already delivers the cap on focus, and the
+            dialog's textarea carries the same native `maxLength` stop. Adding
+            a second live region inside a modal would also put two of them in
+            one document, since the inline one stays mounted behind the overlay.
+          */
           footer={(draft) =>
             maxLength ? (
-              <span className="text-xs text-muted-foreground self-center">
-                {draft.length}/{maxLength}
-              </span>
+              <CharacterCount
+                length={draft.length}
+                maxLength={maxLength}
+                descriptionId={fullscreenDescriptionId}
+                announceNearLimit={false}
+                className="text-xs text-muted-foreground self-center"
+                testId="textarea-fullscreen-character-count"
+              />
             ) : null
           }
         >
@@ -277,6 +189,19 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
               disabled={editorDisabled}
               maxLength={maxLength}
               placeholder={textareaField?.placeholder}
+              /*
+                Assigned, not appended — and that is a statement about THIS
+                element, not a relaxation of the rule above. The inline control
+                composes because `<FormControl>` hands it an `aria-describedby`
+                through `domProps`; this one is constructed here from scratch,
+                `domProps` never reaches it, and the ids the host would have
+                supplied name nodes OUTSIDE the dialog, which Radix `aria-hidden`s
+                while the modal is open. There is nothing to preserve. Should
+                this editor ever be given host-supplied ids, compose them the
+                way `describedBy` above does rather than adding a second
+                assignment.
+              */
+              aria-describedby={maxLength ? fullscreenDescriptionId : undefined}
               className="h-full min-h-full resize-none text-base"
               data-testid="textarea-fullscreen-input"
             />

--- a/packages/fields/src/widgets/__tests__/TextAreaField.fullscreenCharacterCount.i18n.test.tsx
+++ b/packages/fields/src/widgets/__tests__/TextAreaField.fullscreenCharacterCount.i18n.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The fullscreen dialog's character-count description follows the session
+ * language — objectui#3417.
+ *
+ * The sentence is the SAME `fields.textarea.characterCount` key the inline
+ * surface has used since objectui#3406, and reusing it rather than minting a
+ * `fields.textarea.fullscreenCharacterCount` twin is the point: one form-level
+ * setting (`ObjectFormSchema.mobile.fullscreenLongText`) projects onto both
+ * surfaces of the same field, so two copies of this copy could only drift, and
+ * a twin would mean editing ten locale packs to say what they already say.
+ * (Same reasoning, same shape, as objectui#3404's decision to have
+ * `FullscreenFieldEditor` consume the existing `form.fullscreen.*` keys.)
+ *
+ * ## Why this needs its own cases at all
+ *
+ * `TextAreaField.characterCount.i18n.test.tsx` already pins the key and its ten
+ * packs — including the load-bearing `ja` word-order case, which no code-side
+ * concatenation can satisfy. What it cannot see is whether the FULLSCREEN
+ * surface routes through `t()` or re-inlines an English literal on the way to a
+ * node only a screen reader reads. A footer that renders
+ * `Character count: 5 of 500` in a zh session looks correct to everyone who
+ * could file the bug. So: a positive translated assertion AND the English
+ * literal asserted absent, on the fullscreen surface specifically.
+ *
+ * `ja` is carried over for the same reason it exists on the inline side — its
+ * pack puts the cap BEFORE the count, so an implementation that assembled the
+ * sentence from parts passes a zh-only check by luck and fails here.
+ *
+ * The provider-LESS leg lives in `TextAreaField.fullscreenCharacterCount.test.tsx`
+ * and cannot share this file: mounting `I18nProvider` installs its instance as
+ * react-i18next's GLOBAL default, so after any case below there is no "no
+ * provider" state left in this module graph to observe (measured in
+ * objectui#3404 — cases written inside the provider file stayed GREEN under a
+ * reverse check that correctly reddened a separate file).
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+
+import { TextAreaField } from '../TextAreaField';
+import type { FieldMetadata } from '@object-ui/types';
+
+const fieldMeta = (extra: Record<string, unknown> = {}) =>
+  ({
+    name: 'description',
+    label: 'Description',
+    type: 'textarea',
+    mobile_fullscreen: true,
+    ...extra,
+  }) as unknown as FieldMetadata;
+
+/**
+ * Render, open the dialog, and return the dialog textarea's accessible
+ * DESCRIPTION resolved the way an assistive technology resolves it — follow
+ * `aria-describedby`, concatenate the referenced nodes. Scoped to its own mount
+ * and unmounted before returning: every case here renders a different language,
+ * and a document-wide read after a second mount would report the FIRST one.
+ */
+const fullscreenDescription = (language: string, maxLength = 200, value = 'hello') => {
+  const { unmount } = render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <TextAreaField value={value} onChange={vi.fn()} field={fieldMeta({ maxLength })} />
+    </I18nProvider>,
+  );
+  fireEvent.click(screen.getByTestId('textarea-fullscreen-toggle'));
+
+  const input = screen.getByTestId('textarea-fullscreen-input');
+  const ids = (input.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+  const text = ids
+    .map((id) => document.getElementById(id)?.textContent ?? '')
+    .join(' ')
+    .trim();
+  const digits =
+    document.querySelector('[data-testid="textarea-fullscreen-character-count"]')?.textContent ??
+    null;
+
+  unmount();
+  return { text, digits };
+};
+
+describe('the fullscreen counter description is translated (objectui#3417)', () => {
+  it('renders the English sentence under an en provider', () => {
+    // A no-op pin: `FIELD_DEFAULTS` and the `en` pack are byte-identical, so
+    // this is here to prove routing through `t()` did not change English
+    // rendering. Only a positive assertion sees that direction.
+    const { text, digits } = fullscreenDescription('en');
+
+    expect(text).toBe('Character count: 5 of 200');
+    expect(digits).toBe('5/200');
+  });
+
+  it('renders the sentence in Chinese under a zh provider', () => {
+    const { text, digits } = fullscreenDescription('zh');
+
+    expect(text).toBe('已输入 5 个字符，最多 200 个');
+    // The literal, asserted absent — a re-inlined one would still satisfy the
+    // positive assertion on a sibling case, and in a screen-reader-only string
+    // nobody who can see it is affected.
+    expect(text).not.toMatch(/character count/i);
+    // The digits stay language-independent; only the description is keyed.
+    expect(digits).toBe('5/200');
+  });
+
+  it('renders the sentence in Japanese, with the cap interpolated BEFORE the count', () => {
+    // `{{max}}` precedes `{{count}}` in this pack. Code-side concatenation
+    // cannot produce this order — that is the point of the assertion.
+    const { text } = fullscreenDescription('ja');
+
+    expect(text).toBe('文字数: 200 文字中 5 文字');
+    expect(text.indexOf('200')).toBeLessThan(text.indexOf('5'));
+    expect(text).not.toMatch(/character count/i);
+  });
+
+  it('resolves the base key under ru, whose plural rules i18next consults first', () => {
+    // `count` sends i18next to `key_one` / `key_few` / … BEFORE the base key,
+    // and these packs declare the base key only. A raw key reaching a
+    // screen-reader-only string is invisible to everyone who could report it.
+    const { text } = fullscreenDescription('ru');
+
+    expect(text).toBe('Количество символов: 5 из 200');
+    expect(text).not.toContain('fields.textarea');
+  });
+
+  it('recomputes the sentence as the DRAFT changes, not the committed value', () => {
+    // Derived per render from the draft. A memo frozen at open time would keep
+    // describing the value the user opened the dialog with while the digits
+    // beside it moved on.
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <TextAreaField value="hello" onChange={vi.fn()} field={fieldMeta({ maxLength: 200 })} />
+      </I18nProvider>,
+    );
+    fireEvent.click(screen.getByTestId('textarea-fullscreen-toggle'));
+
+    const input = screen.getByTestId('textarea-fullscreen-input');
+    const describedText = () => {
+      const ids = (input.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+      return ids
+        .map((id) => document.getElementById(id)?.textContent ?? '')
+        .join(' ')
+        .trim();
+    };
+
+    expect(describedText()).toBe('已输入 5 个字符，最多 200 个');
+
+    fireEvent.change(input, { target: { value: 'hello world' } });
+
+    expect(describedText()).toBe('已输入 11 个字符，最多 200 个');
+  });
+});

--- a/packages/fields/src/widgets/__tests__/TextAreaField.fullscreenCharacterCount.test.tsx
+++ b/packages/fields/src/widgets/__tests__/TextAreaField.fullscreenCharacterCount.test.tsx
@@ -1,0 +1,346 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * What a screen reader can find out about the character cap INSIDE the
+ * fullscreen long-text dialog — objectui#3417.
+ *
+ * ## The state this replaces
+ *
+ * objectui#3408 gave the inline counter three nodes. The fullscreen dialog's
+ * counter, handed to `FullscreenFieldEditor` as a `footer`, stayed what it had
+ * been since the feature shipped:
+ *
+ * ```jsx
+ * footer={(draft) => maxLength
+ *   ? <span className="…">{draft.length}/{maxLength}</span>
+ *   : null}
+ * ```
+ *
+ * Digits, and nothing else. No accessible name, no `aria-describedby` tying it
+ * to the dialog's `textarea`, nothing `aria-live`. Browse mode read "5 slash
+ * 500" if it happened to sweep the footer; focusing the input said nothing at
+ * all. Same field, same cap, same user as the inline surface — and the
+ * fullscreen branch was at zero.
+ *
+ * Reachability is not exotic: `ObjectForm` stamps `mobile_fullscreen` onto
+ * EVERY long-text field when `ObjectFormSchema.mobile.fullscreenLongText` is
+ * set, so on a phone with that setting on, every capped long-text field in the
+ * form is this case.
+ *
+ * ## What is pinned here, and what is deliberately NOT
+ *
+ * The dialog gets two of the three nodes — `aria-hidden` digits and a
+ * visually-hidden DESCRIPTION reached through the textarea's
+ * `aria-describedby`. It gets NO live region, and that absence is asserted
+ * rather than left to chance (`no aria-live node inside the dialog`): a modal
+ * the user opened deliberately to write at length should not also interrupt
+ * them, the description already delivers the cap on focus, and the inline
+ * surface's live region stays mounted behind the overlay — a second one would
+ * put two in one document.
+ *
+ * That assertion is therefore GREEN on `origin/main` too, and is expected to
+ * be. It is not evidence of the fix; it is the pin that the fix did not
+ * overreach. The cases that change direction are the describedby/description
+ * ones, which are red on `origin/main` for the plainest possible reason —
+ * `aria-describedby` is absent and there is no description node to point at.
+ *
+ * ## Why this file mounts no `I18nProvider`
+ *
+ * Two reasons, and they are the same reason. Mounting `I18nProvider` calls
+ * `initReactI18next`, which installs that instance as react-i18next's GLOBAL
+ * default — after any sibling case has done so there is no "no provider" state
+ * left in this module graph to observe, which is why
+ * `TextAreaField.characterCount.no-provider.test.tsx` and
+ * `FullscreenFieldEditor.no-provider.test.tsx` are separate FILES rather than
+ * separate `describe`s. Keeping this file provider-less makes its English
+ * expectations a genuine assertion about the code-shipped `FIELD_DEFAULTS`
+ * fallback on the fullscreen path — a raw key surfacing in a
+ * screen-reader-only string is invisible to everyone who could report it. The
+ * locale leg lives in `TextAreaField.fullscreenCharacterCount.i18n.test.tsx`.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { TextAreaField } from '../TextAreaField';
+import type { FieldMetadata } from '@object-ui/types';
+
+const fieldMeta = (extra: Record<string, unknown> = {}) =>
+  ({
+    name: 'description',
+    label: 'Description',
+    type: 'textarea',
+    mobile_fullscreen: true,
+    ...extra,
+  }) as unknown as FieldMetadata;
+
+const dialog = () => screen.getByTestId('textarea-fullscreen-dialog');
+const fullscreenInput = () =>
+  screen.getByTestId('textarea-fullscreen-input') as HTMLTextAreaElement;
+const fullscreenCounter = () =>
+  document.querySelector('[data-testid="textarea-fullscreen-character-count"]');
+const inlineCounter = () => document.querySelector('[data-testid="textarea-character-count"]');
+
+/**
+ * Resolve an element's accessible DESCRIPTION the way an assistive technology
+ * does — follow `aria-describedby`, in order, and concatenate the referenced
+ * nodes' text. Asserting on this rather than on a node found by test id is
+ * what puts "the association actually works" under assertion: a description
+ * node nothing references is a node no screen reader will ever reach, and that
+ * is precisely the failure a footer-shaped counter invites.
+ */
+const describedText = (el: HTMLElement) => {
+  const ids = (el.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+  return ids
+    .map((id) => document.getElementById(id)?.textContent ?? '')
+    .join(' ')
+    .trim();
+};
+
+/** A host that owns the value, so a committed edit really changes it. */
+function Host({
+  initial = '',
+  maxLength,
+  metaExtra = {},
+}: {
+  initial?: string;
+  maxLength?: number;
+  metaExtra?: Record<string, unknown>;
+}) {
+  const [v, setV] = React.useState(initial);
+  return (
+    <TextAreaField value={v} onChange={setV} field={fieldMeta({ maxLength, ...metaExtra })} />
+  );
+}
+
+const openDialog = () => fireEvent.click(screen.getByTestId('textarea-fullscreen-toggle'));
+
+describe('the fullscreen dialog counter is reachable from the input (objectui#3417)', () => {
+  it('describes the dialog textarea, so focus announces the cap once', () => {
+    // Measured on `origin/main`: the dialog's textarea carried no
+    // `aria-describedby` at all, so this is the assertion that flips.
+    render(<Host maxLength={500} initial="hello" />);
+    openDialog();
+
+    expect(fullscreenInput()).toHaveAttribute('aria-describedby');
+    expect(describedText(fullscreenInput())).toBe('Character count: 5 of 500');
+  });
+
+  it('keeps the visible digits out of the accessibility tree', () => {
+    // The digits are a glance affordance. Unhidden they make a screen reader
+    // read "5 slash 500" on top of the description that says it in words —
+    // which is exactly what browse mode did on the old bare-span footer.
+    render(<Host maxLength={500} initial="hello" />);
+    openDialog();
+
+    expect(fullscreenCounter()).toHaveAttribute('aria-hidden', 'true');
+    expect(fullscreenCounter()).toHaveTextContent('5/500');
+    expect(fullscreenCounter()).not.toHaveAttribute('aria-live');
+  });
+
+  it('counts the DRAFT, in the digits and in the description together', () => {
+    // The dialog edits a local draft that is not written back until "Done"
+    // (`FullscreenFieldEditor`). A description sourced from the committed
+    // value instead would describe the field the user is no longer looking at,
+    // and would silently disagree with the digits beside it — so both are
+    // asserted from the same edit.
+    render(<Host maxLength={500} initial="hello" />);
+    openDialog();
+
+    fireEvent.change(fullscreenInput(), { target: { value: 'hello from fullscreen' } });
+
+    expect(fullscreenCounter()).toHaveTextContent('21/500');
+    expect(describedText(fullscreenInput())).toBe('Character count: 21 of 500');
+  });
+
+  it('substitutes both placeholders from the code-shipped fallback', () => {
+    // No provider is mounted, so whatever renders here came from
+    // `FIELD_DEFAULTS` via `createSafeTranslation`. The failure this guards is
+    // a raw key or an unsubstituted `{{max}}` reaching a screen-reader-only
+    // string, where nobody who can see it is affected and nobody affected can
+    // see it.
+    render(<Host maxLength={40} initial="hi" />);
+    openDialog();
+
+    expect(describedText(fullscreenInput())).toBe('Character count: 2 of 40');
+    expect(describedText(fullscreenInput())).not.toMatch(/fields\.textarea/);
+    expect(describedText(fullscreenInput())).not.toContain('{{');
+  });
+
+  it('announces zero for an empty draft rather than a hole in the sentence', () => {
+    // `0` is falsy — the one input length at which a truthiness-guarded
+    // interpolation drops the number and speaks "Character count:  of 40".
+    render(<Host maxLength={40} />);
+    openDialog();
+
+    expect(describedText(fullscreenInput())).toBe('Character count: 0 of 40');
+  });
+
+  it('the code-shipped default carries no CJK (Commandment #-1)', () => {
+    // Escaped ranges on purpose: a literal CJK character class would itself
+    // violate the commandment this asserts (same shape as
+    // `FullscreenFieldEditor.no-provider.test.tsx`).
+    render(<Host maxLength={200} initial="hello" />);
+    openDialog();
+
+    // The positive assertion FIRST, and not decoration: a negative match on a
+    // sentence that does not exist is satisfied by the empty string, so
+    // without this line the case is green on `origin/main` for the one reason
+    // that proves nothing.
+    expect(describedText(fullscreenInput())).toBe('Character count: 5 of 200');
+    expect(describedText(fullscreenInput())).not.toMatch(/[\u3000-\u30ff\u4e00-\u9fff]/);
+  });
+
+  it('reads the legacy snake_case max_length spelling here too', () => {
+    // The dual-read predates all of this (framework#1878 §3). Sharing the
+    // counting UI across surfaces must not narrow which spelling reaches the
+    // fullscreen one.
+    render(<Host metaExtra={{ max_length: 80 }} initial="hello" />);
+    openDialog();
+
+    expect(fullscreenCounter()).toHaveTextContent('5/80');
+    expect(describedText(fullscreenInput())).toBe('Character count: 5 of 80');
+  });
+});
+
+describe('the fullscreen dialog stays SILENT while typing (objectui#3417)', () => {
+  it('renders no aria-live node inside the dialog', () => {
+    // The ruling on #3417, pinned as an absence. GREEN on `origin/main` too —
+    // there was nothing accessible in that footer at all — so this case is not
+    // evidence of the fix, it is the guard against the fix overreaching into a
+    // second live region. `[aria-live]` unqualified, because "assertive"
+    // instead of "polite" would be worse, not compliant.
+    render(<Host maxLength={100} initial={'x'.repeat(95)} />);
+    openDialog();
+
+    // Deep inside the warning band (5 of 100 left): if a status region existed
+    // on this surface, this is the state that would fill it.
+    expect(dialog().querySelector('[aria-live]')).toBeNull();
+    expect(dialog().querySelector('[aria-atomic]')).toBeNull();
+  });
+
+  it('grows no live region as the draft crosses into the near-limit band', () => {
+    render(<Host maxLength={100} initial="short" />);
+    openDialog();
+
+    fireEvent.change(fullscreenInput(), { target: { value: 'x'.repeat(99) } });
+
+    expect(fullscreenCounter()).toHaveTextContent('99/100');
+    expect(dialog().querySelector('[aria-live]')).toBeNull();
+  });
+});
+
+describe('the two surfaces are wired independently (objectui#3417)', () => {
+  it('gives the inline and fullscreen descriptions distinct ids', () => {
+    // One shared id would point both textareas at whichever sentence rendered
+    // last — and the two diverge the moment the user types in the dialog,
+    // which is the whole reason the dialog holds a draft.
+    render(<Host maxLength={500} initial="hello" />);
+    const inline = screen.getAllByRole('textbox')[0] as HTMLTextAreaElement;
+    const inlineDescribedBy = inline.getAttribute('aria-describedby');
+    openDialog();
+    const fullscreenDescribedBy = fullscreenInput().getAttribute('aria-describedby');
+
+    // BOTH asserted present before they are compared. `not.toBe` alone is
+    // satisfied by `null !== 'some-id'`, which is exactly the `origin/main`
+    // state this case is supposed to reject — the trap of an assertion that
+    // passes because nothing was produced.
+    expect(inlineDescribedBy).not.toBeNull();
+    expect(fullscreenDescribedBy).not.toBeNull();
+    expect(fullscreenDescribedBy).not.toBe(inlineDescribedBy);
+    // And each resolves to its own sentence, not to the other's node.
+    expect(describedText(fullscreenInput())).toBe('Character count: 5 of 500');
+  });
+
+  it('leaves the inline description on the committed value while the draft moves', () => {
+    // The draft is local until "Done". Both descriptions are live at once (the
+    // inline one behind the overlay), so a shared source would make one of
+    // them a lie.
+    render(<Host maxLength={500} initial="hello" />);
+    const inline = screen.getAllByRole('textbox')[0] as HTMLTextAreaElement;
+    openDialog();
+
+    fireEvent.change(fullscreenInput(), { target: { value: 'hello from fullscreen' } });
+
+    expect(describedText(fullscreenInput())).toBe('Character count: 21 of 500');
+    expect(describedText(inline)).toBe('Character count: 5 of 500');
+    expect(inlineCounter()).toHaveTextContent('5/500');
+  });
+
+  it('lets the committed edit flow back to the inline counter on Done', () => {
+    // End to end, because a counter that describes a draft nobody commits
+    // would satisfy every assertion above.
+    render(<Host maxLength={500} initial="hello" />);
+    openDialog();
+
+    fireEvent.change(fullscreenInput(), { target: { value: 'hello from fullscreen' } });
+    fireEvent.click(screen.getByTestId('textarea-fullscreen-save'));
+
+    expect(inlineCounter()).toHaveTextContent('21/500');
+    const inline = screen.getAllByRole('textbox')[0] as HTMLTextAreaElement;
+    expect(describedText(inline)).toBe('Character count: 21 of 500');
+  });
+
+  it('keeps the inline surface at three nodes, live region included', () => {
+    // The extraction must not have cost the inline surface anything. Its own
+    // pins live in the objectui#3408 files and are untouched; this is the
+    // cross-check from the fullscreen side, taken with the dialog OPEN so that
+    // "there is one live region in the document, and it is the inline one" is
+    // asserted as a whole.
+    render(<Host maxLength={100} initial={'x'.repeat(95)} />);
+    openDialog();
+
+    const liveRegions = document.querySelectorAll('[aria-live="polite"]');
+    expect(liveRegions).toHaveLength(1);
+    expect(dialog().contains(liveRegions[0])).toBe(false);
+    expect(inlineCounter()).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+describe('a field with no cap gets no fullscreen counter (objectui#3417)', () => {
+  it('renders neither digits nor a description node', () => {
+    // `{maxLength && …}` on both surfaces. Sharing the component must not make
+    // either one unconditional.
+    render(<Host maxLength={undefined} />);
+    openDialog();
+
+    expect(fullscreenCounter()).toBeNull();
+    expect(inlineCounter()).toBeNull();
+  });
+
+  it('leaves the dialog textarea`s aria-describedby unset', () => {
+    // An `aria-describedby` naming an id that does not exist is worse than
+    // none: some assistive technologies fall back to reading the id string.
+    render(<Host maxLength={undefined} />);
+    openDialog();
+
+    expect(fullscreenInput()).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('renders no counter on either surface when the field is readonly', () => {
+    // The readonly branch early-returns a display before any of this is
+    // computed, so there is no dialog to open at all. Pinned as a
+    // non-regression of the hook hoist.
+    render(
+      <TextAreaField
+        value="hello"
+        onChange={vi.fn()}
+        readonly
+        field={fieldMeta({ maxLength: 500 })}
+      />,
+    );
+
+    expect(inlineCounter()).toBeNull();
+    expect(fullscreenCounter()).toBeNull();
+    expect(screen.queryByTestId('textarea-fullscreen-toggle')).not.toBeInTheDocument();
+    expect(document.querySelector('[aria-live="polite"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #3417

## 前提复核(先做,再动手)

在 `origin/main`(875c5fafb)上逐条核对了单子的前提,**成立**:

- `packages/fields/src/widgets/TextAreaField.tsx` 的 `footer` 回调仍然只渲染一串裸数字(`text-xs text-muted-foreground self-center` 的 span,内容 `{draft.length}/{maxLength}`):没有可访问名、没有 `aria-describedby` 把它和对话框里 `data-testid="textarea-fullscreen-input"` 的 textarea 关联起来、没有任何 `aria-live`。
- #3416 落地的内联三节点形制存在(`aria-hidden` 数字 + describedby 描述节点 + 阈值门控 debounce 的 polite 状态节点)。
- 可达性也复核过:`ObjectForm` 在 `ObjectFormSchema.mobile.fullscreenLongText` 打开时给每个长文本字段盖 `mobile_fullscreen`,手机端开了这个设置的表单里,每个带上限的长文本字段都命中。

顺带核了一件事,结论是**不必扩大范围**:`packages/components/src/renderers/form/form.tsx` 的内建分支(`form-textarea-fullscreen-*` 一套 test id)整个就没有字数计数(它只有 `validation.maxLength` 校验规则),所以不存在「第三份计数 UI 又漂了」的问题,没有额外要修的分叉。

## 做法(按裁定的 C 形 + B 行为)

新增 `packages/fields/src/widgets/CharacterCount.tsx`,从 #3416 的内联实现里抽出来,**两个编辑面共用这一份**,不再有分叉的手抄件。

- **内联面行为逐字节不变**:同样三个节点、同样的属性顺序、同样的 1s debounce 与「10% 或 20 字符,先到者为准」阈值。#3416 那三个测试文件**一行没改**,前后都绿 —— 这就是「行为没漂」的钉子。
- **全屏面**:`aria-hidden` 数字 + 视觉隐藏的描述节点,通过 `aria-describedby` 挂到对话框的 textarea 上;数字与描述都跟 **draft** 走(对话框是本地草稿,提交前和已保存值会分叉,所以两个面各自一个描述 id)。
- **全屏面不加 live region**:`announceNearLimit={false}`。理由写在代码注释里 —— 全屏是用户主动打开来长写的模态,描述节点已经在聚焦时把上限说清楚了,而内联那份 live region 在遮罩后面仍然挂着,再加一个就是同一份文档里两个 live region。这一条是**以「不存在」的形式断言**的,不是靠运气。

### 关于 `FullscreenFieldEditor` 的 footer 槽(裁定让我自己判断)

**保持 `footer` 是 ReactNode 回调,`FullscreenFieldEditor.tsx` 一个字没动。**

理由是「更小且诚实」:`TextAreaField` 同时拥有 footer 和 editor 两侧,是唯一能同时铸出 id 并把它写到 textarea 的 `aria-describedby` 上的地方,所以这条路只需要 3 行。反过来把 count 提升成一等能力,就要给 `children` 加第四个参数(描述 id)来把 id 递回宿主 —— 而另一个宿主 `RichTextField` 根本不传 footer,它会拿到一个永远忽略的参数。那正是这个包一直在删的形状(#3232/#3233:声明了没有生产者的 prop)。代价我也写进注释了:全屏 textarea 的 `aria-describedby` 是**赋值**而非追加,因为这个元素是 `TextAreaField` 自己从零构造的,`domProps` 根本到不了它,而宿主本会提供的那些 id 指向的是对话框**外面**的节点 —— 模态打开时被 Radix `aria-hidden` 掉了,追加进来只会指向读屏读不到的东西。内联那份仍然是**追加**(#3408 的规则原封不动)。

## i18n

**没有新键**,`packages/i18n` 一个字节没碰。复用 `fields.textarea.characterCount` / `fields.textarea.charactersRemaining` 及其 `FIELD_DEFAULTS` 兜底;`packages/i18n/src/__tests__/textarea-charactercount-locale-parity.test.ts` 照跑绿。

## 反向验证(方向是**跑之前**定好的)

用 `git checkout origin/main -- packages/fields/src/widgets/TextAreaField.tsx` 把源文件退回去(测试文件与新组件留着),跑同一组文件 —— 三个方向全部与预测一致:

| 断言 | 预测 | 实测 |
|---|---|---|
| 新的全屏 describedby / 描述 / 数字节点用例(共 15 条,含 i18n 文件 5 条) | before RED / after GREEN | ✅ 全部 RED → GREEN |
| `renders no aria-live node inside the dialog` | **两侧都 GREEN**(它钉的是裁定,不是修复的证据) | ✅ 两侧 GREEN |
| #3416 三个内联测试文件(共 39 条) | **两侧都 GREEN** | ✅ 两侧 GREEN |

一处要**如实说明的偏差**:`grows no live region as the draft crosses into the near-limit band` 我原本归在「钉裁定、两侧绿」那一组,实测 before 是 RED —— 因为它除了断言没有 live region,还断言了数字节点的 `99/100`,而 before 根本没有那个节点。它是混合用例,不是纯粹的裁定钉子;纯粹那条是上表第二行。

另有两条我在提交前**主动加固**过,因为它们在 before 会**因为「什么都没产出」而假绿**(PR #5046 记过的那个坑):

- `the code-shipped default carries no CJK` —— 空串天然满足「不含 CJK」,补了正向断言;
- `gives the inline and fullscreen descriptions distinct ids` —— `null !== 'some-id'` 天然满足 `not.toBe`,补了「两侧都非 null」。

加固后这两条也一并翻红了(见上表第一行的 15 条)。

## 测试

仓根跑 vitest,`--maxWorkers=2`,verbose 确认文件名:

- `packages/fields` 全量 + `plugin-form` 的全屏消费者:**63 files / 957 tests passed**
- `plugin-form/src/__tests__/ObjectForm.mobileFullscreen.test.tsx` 单跑:**1 file / 7 tests passed**
- `packages/components/src/renderers/form/__tests__/` + `packages/i18n` 的 charactercount parity:**31 files / 213 tests passed**
- `pnpm --filter @object-ui/fields type-check`(`tsc --noEmit`)通过;`lint` 0 errors(改动文件只剩 `field as any` 这条既有 warning);`build` 通过
- `node scripts/check-control-bytes.mjs` 通过,另按纪律对改动文件做了越过 gate 的自查(`grep -naP` 控制字符范围,无命中);测试里的 CJK 字符类写成 `u3000` 一类的转义序列而非裸字符

## 影响面清点

按规则的消费半径扫过,不只按被改的包:`textarea-character-count` / `CharacterCount` / `textarea-fullscreen-input` 的引用只落在 `packages/fields`(本 PR)、`packages/components` 内建分支(独立 test id 命名空间,无计数)、`packages/i18n` 的 parity 测试(未改键)三处,已全部跑过。

## 范围外发现

无。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_