### PR TITLE
fix(page): one page, one h1 — page:header owns the title on every page type (#3434)

### DIFF
--- a/.changeset/page-single-h1-3434.md
+++ b/.changeset/page-single-h1-3434.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/components': patch
+---
+
+`PageRenderer` no longer renders its own `<h1>` when the page authors a titled `page:header`, so a page has exactly one level-1 heading. Every non-record page used to render the page `title`/`label` as an `h1` *and* let the `page:header` block render a second one — on the showcase master-detail page both said "New Project + Tasks", producing a broken document outline, a page title a screen reader announces twice, and the same string printed twice on screen. Record pages already delegated the whole title block to `page:header`; that rule now holds for `app` / `home` / `utility` pages too, and it is what the live e2e was reporting as a Playwright strict-mode violation (`getByRole('heading', { name })` resolving to 2 elements, objectui#3434).
+
+Delegation is deliberately conservative: only a `page:header` whose title renders literal text takes the heading over. A header with no title — or one whose title interpolates to nothing (e.g. `title: '{name}'` with no record in scope) — renders no heading of its own, so the page keeps its implicit `h1` rather than ending up with none. The page-level `description` is unaffected; it is the page's own prose, not a duplicate of the header `subtitle`.
+
+Author-visible effect: on a page carrying both a `label` and a titled `page:header`, only the header's title is shown (e.g. app-crm's welcome page shows "Welcome to the CRM", not also "CRM Welcome"). Pages without a `page:header` are unchanged.

--- a/packages/components/src/__tests__/page-single-h1.test.tsx
+++ b/packages/components/src/__tests__/page-single-h1.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * "One page, one h1" — accessibility contract for PageRenderer (objectui#3434).
+ *
+ * Two components can render the page's title: PageRenderer's own implicit
+ * heading (from `title`/`label`) and the authored `page:header` block. Before
+ * this guard they BOTH rendered on every non-record page, so the showcase
+ * master-detail page shipped two `heading level 1` nodes with the identical
+ * accessible name — a broken document outline, a title a screen reader
+ * announces twice, and the same string printed twice on screen. The live e2e
+ * caught it as a Playwright strict-mode violation:
+ * `getByRole('heading', { name: 'New Project + Tasks' })` resolved to 2
+ * elements, taking `e2e/live/master-detail.spec.ts` down in `beforeEach`.
+ *
+ * The assertions below are written against the ACCESSIBLE TREE (`getAllByRole`
+ * with an explicit level), not against class names, so they pin the fact the
+ * e2e locator actually depends on. The negative controls matter as much as the
+ * positive one: delegating the heading must never leave a page with ZERO `h1`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActionProvider } from '@object-ui/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Module scope, not a hook: registers PageRenderer (`app`/`home`/`record`/…)
+// and `page:header`. A cold `await import()` inside a hook is billed to
+// `hookTimeout` and races the assertions (AGENTS.md §测试纪律, objectui#3010).
+import '../renderers';
+
+/** The showcase master-detail page, reduced to the parts that render headings. */
+function masterDetailPage(headerProps: Record<string, unknown> | null, extra?: Record<string, unknown>) {
+  return {
+    type: 'app',
+    pageType: 'app',
+    name: 'showcase_project_workspace',
+    // Spec pages carry `label`; PageRenderer dual-reads it as the page title.
+    label: 'New Project + Tasks',
+    template: 'default',
+    regions: [
+      ...(headerProps
+        ? [{ name: 'header', width: 'full', components: [{ type: 'page:header', properties: headerProps }] }]
+        : []),
+      {
+        name: 'main',
+        width: 'large',
+        components: [{ type: 'element:text', properties: { text: 'body' } }],
+      },
+    ],
+    ...extra,
+  } as any;
+}
+
+function renderPage(schema: any) {
+  return render(
+    <ActionProvider>
+      <SchemaRenderer schema={schema} />
+    </ActionProvider>,
+  );
+}
+
+describe('PageRenderer — one page, one h1 (objectui#3434)', () => {
+  it('renders exactly ONE h1 when a titled page:header carries the same name', () => {
+    renderPage(
+      masterDetailPage({
+        title: 'New Project + Tasks',
+        subtitle: 'Master-detail entry — fill the project, add its tasks inline, and save them together.',
+      }),
+    );
+
+    // The exact locator the live e2e uses. Before the fix this threw
+    // "found multiple elements"; Playwright reported the same as a strict-mode
+    // violation resolving to 2 elements.
+    expect(screen.getByRole('heading', { name: 'New Project + Tasks' })).toBeTruthy();
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    // The surviving h1 is the authored header's, and the header keeps its subtitle.
+    expect(screen.getByRole('heading', { level: 1 }).closest('header')).not.toBeNull();
+    expect(screen.getByText(/Master-detail entry/)).toBeTruthy();
+  });
+
+  it('drops the implicit title even when the page:header names the page differently', () => {
+    // app-crm welcome.page.ts: label 'CRM Welcome' + header 'Welcome to the CRM'.
+    renderPage({ ...masterDetailPage({ title: 'Welcome to the CRM' }), label: 'CRM Welcome' });
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Welcome to the CRM');
+    expect(screen.queryByText('CRM Welcome')).toBeNull();
+  });
+
+  it('still renders the implicit h1 when the page authors NO page:header', () => {
+    renderPage(masterDetailPage(null));
+
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe('New Project + Tasks');
+  });
+
+  it('still renders the implicit h1 when the page:header has no title of its own', () => {
+    // Negative control against a zero-h1 page: PageHeaderRenderer's bare branch
+    // renders `{explicitTitle && <h1>}`, so an untitled header contributes no
+    // heading at all and the page's own title must stay.
+    renderPage(masterDetailPage({ subtitle: 'Just a subtitle' }));
+
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe('New Project + Tasks');
+  });
+
+  it('still renders the implicit h1 when the header title interpolates to nothing', () => {
+    // `title: '{name}'` with no record in scope → `interpolate()` blanks it →
+    // no header heading. Suppressing ours here would leave the page headingless.
+    renderPage(masterDetailPage({ title: '{name}' }));
+
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe('New Project + Tasks');
+  });
+
+  it('honours an inline-translation map as a real header title', () => {
+    renderPage(masterDetailPage({ title: { en: 'Get in touch', 'zh-CN': '联系我们' } }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Get in touch');
+  });
+
+  it('keeps the page description when the header takes over the heading', () => {
+    // `description` is the page's own prose, not a duplicate of the header
+    // `subtitle` — delegating the h1 must not delete unrelated content.
+    renderPage(masterDetailPage({ title: 'New Project + Tasks' }, { description: 'Page-level prose.' }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByText('Page-level prose.')).toBeTruthy();
+  });
+
+  it('record pages keep delegating the whole title block (unchanged)', () => {
+    renderPage({
+      ...masterDetailPage({ title: 'New Project + Tasks' }),
+      type: 'record',
+      pageType: 'record',
+      description: 'record prose',
+    });
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.queryByText('record prose')).toBeNull();
+  });
+});

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -84,6 +84,85 @@ function getRemainingRegions(regions: PageNodeRegion[] | undefined, exclude: str
 }
 
 // ---------------------------------------------------------------------------
+// "One page, one h1" — who owns the page heading (objectui#3434)
+// ---------------------------------------------------------------------------
+
+/**
+ * `page:header` is registered `skipFallback: true`, so this is the ONLY node
+ * type that resolves to PageHeaderRenderer — no bare `header` alias to match.
+ */
+const PAGE_HEADER_TYPE = 'page:header';
+
+/** Text a header title contributes once `{token}` interpolation is stripped. */
+function literalTitleText(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') {
+    // `interpolate()` (containers.tsx) replaces `{field}` with the record value
+    // and blanks it when there is none, so only the literal remainder is text
+    // we can promise will be on screen.
+    return value.replace(/\{[a-zA-Z0-9_.]+\}/g, '').replace(/\s+/g, ' ').trim();
+  }
+  if (typeof value === 'object') {
+    // Inline translation map (`pickLocalized`): any non-empty translation
+    // means the header will render a heading in some language.
+    return Object.values(value as Record<string, unknown>)
+      .map((v) => literalTitleText(v))
+      .find((s) => s !== '') ?? '';
+  }
+  return String(value);
+}
+
+/** Does this node render a `page:header` heading of its own? */
+function isTitledPageHeader(node: any): boolean {
+  if (node?.type !== PAGE_HEADER_TYPE) return false;
+  // Spec bridge may inline `properties.*` onto the node or preserve the bag —
+  // PageHeaderRenderer reads both, so this must too.
+  return literalTitleText(node?.title ?? node?.properties?.title) !== '';
+}
+
+/** Depth-bounded walk over the component shapes a page can nest. */
+function containsTitledPageHeader(nodes: unknown, depth = 0): boolean {
+  if (!Array.isArray(nodes) || depth > 6) return false;
+  return nodes.some(
+    (n: any) =>
+      !!n &&
+      typeof n === 'object' &&
+      (isTitledPageHeader(n) ||
+        containsTitledPageHeader(n.components, depth + 1) ||
+        containsTitledPageHeader(n.children, depth + 1) ||
+        containsTitledPageHeader(n.body, depth + 1)),
+  );
+}
+
+/**
+ * Does the page delegate its `<h1>` to an authored `page:header`?
+ *
+ * A document has exactly ONE `h1`. When an author drops a `page:header` into a
+ * region, THAT component is the page's title renderer — the record chip on
+ * record pages, a bare `<h1>` everywhere else — so PageRenderer must not emit a
+ * second one. It used to, for every non-record page type: the showcase
+ * master-detail page rendered its `label` as an `h1` AND its `page:header`
+ * title as another `h1` with the same name, which is a broken document outline,
+ * a title a screen reader announces twice, and a visible duplicate on screen
+ * (objectui#3434 — a live e2e `getByRole('heading', { name })` resolved to 2
+ * elements). Record pages already delegated the whole title block; this is the
+ * same rule stated for every page type.
+ *
+ * Deliberately conservative — only a header whose title renders literal text
+ * counts. `page:header` drops an empty title (and one that interpolates to
+ * nothing, e.g. `title: '{name}'` with no record in scope), so suppressing ours
+ * against a header that renders no heading would leave the page with NO `h1`.
+ */
+function pageHeaderOwnsTitle(schema: PageNodeSchema): boolean {
+  const regionNodes = (schema.regions ?? []).flatMap((r: any) => r?.components ?? []);
+  return (
+    containsTitledPageHeader(regionNodes) ||
+    containsTitledPageHeader((schema as any).body) ||
+    containsTitledPageHeader((schema as any).children)
+  );
+}
+
+// ---------------------------------------------------------------------------
 // RegionContent — renders all components inside a single region
 // ---------------------------------------------------------------------------
 
@@ -513,6 +592,18 @@ export const PageRenderer: React.FC<{
   );
   const maxWidthClass = fullBleed ? 'max-w-none' : getPageMaxWidth(pageType);
 
+  // Who renders the page's single `<h1>` (objectui#3434). Record pages always
+  // delegate to `page:header`; every other page type delegates too as soon as
+  // the author put a titled `page:header` in a region.
+  const headerOwnsTitle = React.useMemo(
+    () => pageType === 'record' || pageHeaderOwnsTitle(schema),
+    [schema, pageType],
+  );
+  const showPageTitle = !!pageTitle && !headerOwnsTitle;
+  // The description is the page's own prose, not a duplicate of the header's
+  // `subtitle`, so delegating the heading does not delete it.
+  const showPageDescription = !!schema.description && pageType !== 'record';
+
   const pageContent = (
     <div
       className={cn(
@@ -526,19 +617,21 @@ export const PageRenderer: React.FC<{
       {...pageProps}
     >
       <div className={cn(fullBleed ? 'space-y-6' : 'mx-auto space-y-6', maxWidthClass)}>
-        {/* Page header — suppressed on record pages (the page:header component
-            in the header region renders the record-bound title instead).
+        {/* Implicit page title — the fallback heading for a page that does NOT
+            author its own `page:header`. Suppressed whenever that component
+            owns the h1 (always on record pages, and on any page carrying a
+            titled `page:header`), so the document never has two `h1`.
             `title` is the objectui spelling; the spec's PageNodeSchema declares
             `label` (required), so dual-read it — mirrors the fallback
             DashboardRenderer already uses (framework#1878 §3 recheck). */}
-        {pageType !== 'record' && (pageTitle || schema.description) && (
+        {(showPageTitle || showPageDescription) && (
           <div className="space-y-2">
-            {pageTitle && (
+            {showPageTitle && (
               <h1 className="text-3xl font-bold tracking-tight text-foreground">
                 {pageTitle}
               </h1>
             )}
-            {schema.description && (
+            {showPageDescription && (
               <p className="text-muted-foreground">{schema.description}</p>
             )}
           </div>


### PR DESCRIPTION
Fixes #3434

## 结论:是**渲染侧**的缺陷,spec 一行未改

issue 里两种可能(测试定位器过宽 vs. 应用侧重复渲染两个 h1),按 PM 的裁决用**无障碍树证据**判定 —— 证据指向渲染侧,`e2e/live/master-detail.spec.ts` 是一个诚实的探针,原样保留。

## 无障碍树证据

失败页面是 framework 侧的 `examples/app-showcase/src/ui/pages/project-workspace.page.ts`:

```
label: 'New Project + Tasks',        // 页面级标题
type:  'app',
regions: [{ name: 'header', components: [
  { type: 'page:header', properties: { title: 'New Project + Tasks', subtitle: '…' } },
]}, …]
```

两个渲染器同时输出 level-1 标题,**名字完全相同**:

1. `packages/components/src/renderers/layout/page.tsx:613`(改动前)——
   `pageType !== 'record' && (pageTitle || schema.description)` 时渲染
   `class="text-3xl font-bold tracking-tight text-foreground"` 的页面级标题。
   `PageView.tsx:131` 把 spec 的 `type: 'app'` 映射成 `pageType`,所以这条对 app/home/utility 页恒成立;`pageTitle = schema.title ?? schema.label` 取到 `label`。
2. `packages/components/src/renderers/layout/containers.tsx:1359` —— `page:header` 的非 record 分支(`hasRecord === false`,create 模式下没有 RecordContext 数据)在 `header` 元素里渲染 `class="text-2xl font-semibold tracking-tight"` 的标题。

在新增的 DOM 测试里逐字复现了 live 现场:

```
TestingLibraryElementError: Found multiple elements with the role "heading"
and name "New Project + Tasks"

  h1 class="text-3xl font-bold tracking-tight text-foreground"
  h1 class="text-2xl font-semibold tracking-tight"
```

—— 与 run 31069352699 的 strict mode violation 是同一对元素。**不是条件互斥、也不是服务不同 region 的设计形状**:两者同时出现在同一个文档、同一个页面上下文里,同名。一个文档两个 level-1 标题 = 文档大纲被打断、读屏把页面标题念两遍;当两个字符串相同时(showcase master-detail、app-showcase `my-work`)屏幕上还直接看到重复的一行。这在 showcase/crm 里共影响 5 个已授权页面(`my-work` / `contact-form` / `page-variables` / `project-workspace` / crm `welcome`)。

## 修法

`page.tsx` 里原本就写着设计意图:

> Page header — suppressed on record pages (**the `page:header` component in the header region renders the record-bound title instead**)

也就是说「作者写了 `page:header`,标题就归它渲染」这条规则**本来就存在**,只是抑制条件被写死成 `pageType === 'record'`,漏掉了其余页面类型。本 PR 把它补成完整的规则:

- 页面 regions/body/children 里存在**带标题**的 `page:header` → PageRenderer 不再输出自己的隐式标题;record 页行为完全不变。
- 判定刻意保守 —— 只有「标题会渲染出字面文本」的 header 才接管:`page:header` 会丢弃空标题、以及插值后为空的标题(如无 record 在作用域时的 `title: '{name}'`,`interpolate()` 把 `{field}` 置空)。否则抑制我们自己的标题会让页面**一个 level-1 标题都没有**,那是把一个 a11y 缺陷换成另一个。
- 页面级 `description` 不受影响:它是页面自己的正文,不是 header `subtitle` 的副本,交出标题不等于删掉别的内容。

作者可见的行为变化:同时声明 `label` 与带标题 `page:header` 的页面,只显示 header 的标题(如 crm 只剩 "Welcome to the CRM",不再额外显示 "CRM Welcome")。没有 `page:header` 的页面完全不变。

## 验证

新增 `packages/components/src/__tests__/page-single-h1.test.tsx` —— 断言写在**无障碍树**上(`getAllByRole('heading', { level: 1 })`),而不是 class name,钉的正是 e2e 定位器依赖的那个事实。

**反向验证(方向按预期,先预测后执行)**:预测「把 `page.tsx` 还原成 origin/main → 4 条正向用例转红,4 条负向对照保持绿」。实测一致:

```
$ git checkout origin/main -- packages/components/src/renderers/layout/page.tsx
$ pnpm exec vitest run packages/components/src/__tests__/page-single-h1.test.tsx
 × renders exactly ONE h1 when a titled page:header carries the same name
 × drops the implicit title even when the page:header names the page differently
 × honours an inline-translation map as a real header title
 × keeps the page description when the header takes over the heading
AssertionError: expected [ h1, h1 ] to have a length of 1 but got 2
 Tests  4 failed | 4 passed (8)
```

负向对照(「无 page:header」「header 无标题」「header 标题插值为空」「record 页」)前后都绿 —— 它们是防「零个 h1」的那一半,不能被这次改动带红,也不能因为改动而空过。

其余(均从仓根跑,`flock` 串行 + `NODE_OPTIONS=--max-old-space-size=4096`):

| 命令 | 结果 |
|---|---|
| `pnpm exec vitest run packages/components/src/__tests__/page-single-h1.test.tsx` | Test Files 1 passed / **Tests 8 passed** |
| `pnpm exec vitest run packages/components` | Test Files 88 passed / **Tests 646 passed** |
| `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/previews packages/app-shell/src/utils/__tests__/pageSchemaIntrospect.test.ts packages/layout packages/plugin-detail/src/synth` | Test Files 40 passed / **Tests 579 passed** |
| `pnpm --filter @object-ui/components type-check` | 通过 |
| `pnpm --filter @object-ui/components lint` | 0 errors(801 warnings,全部为既有) |
| `node scripts/check-control-bytes.mjs` / `check-changeset-no-major.mjs` / `check-changeset-fixed.mjs` | 通过 |

**消费半径排查**:按「规则被谁消费」而不是「改了哪个包」扫了一遍 —— `page:header` 的其他消费方(app-shell metadata-admin previews、`pageSchemaIntrospect`、`plugin-detail` 的 `buildDefaultPageSchema`、`packages/layout` 的 authorable-keys、console `public-contract`)以及 `e2e/` 下所有 spec,均无断言依赖「页面级 `h1` 与 header 同时存在」。`e2e/live/showcase-smoke.spec.ts` 只断 `main` 有内容,不用 heading 定位器。

真正的验收是本 PR 上 live-e2e lane 的实跑(期望 4/4 绿),会在 run 完成后回读并补充。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_