### PR TITLE
ci(docs): 把 check-doc-links 接进 CI,并修好它一直在报的那条坏链 (#3213, #3292)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,31 @@ jobs:
           node-version: '22.x'
           cache: 'pnpm'
 
+      # `scripts/check-doc-links.mjs` existed and worked, but nothing under
+      # `.github/` ever called it, so it had never run in CI — it exited 1 on an
+      # untouched `main` for a broken link that had been sitting there (#3213,
+      # #3292). It resolves every `/docs/...` markdown link against
+      # `content/docs/` on the filesystem: no install and no network, so it runs
+      # here — after Node is set up, before the expensive install + site build —
+      # and a bad link fails in seconds instead of after a full Next.js build.
+      #
+      # KNOWN GAP — read before assuming docs links are fully gated: `ci.yml`
+      # lists `content/**` and `'**/*.md'` under `paths-ignore`, and GitHub has
+      # no per-job path filter, so a docs-ONLY pull request never starts this
+      # workflow and is never link-checked. This step therefore covers pull
+      # requests that touch docs alongside code, plus pushes to `main` — not the
+      # pure-docs pull request, which is the likeliest way to break a link.
+      #
+      # `control-bytes.yml` hit this same wall and answered it by being its own
+      # workflow with no path filters, for a gate that likewise needs no install
+      # and no network; its header explains the reasoning, and
+      # `scripts/__tests__/check-control-bytes.test.ts` pins it. Moving this
+      # check to that shape is the known fix, but it changes CI triggering
+      # policy, so it is left to the maintainer — tracked in #3448.
+      - name: Check docs links
+        if: steps.docs-changes.outputs.should_run == 'true'
+        run: node scripts/check-doc-links.mjs
+
       - name: Turbo Cache
         if: steps.docs-changes.outputs.should_run == 'true'
         uses: actions/cache@v6

--- a/content/docs/core/enhanced-actions.mdx
+++ b/content/docs/core/enhanced-actions.mdx
@@ -483,5 +483,5 @@ Enhanced Actions are ideal for:
 ## Related
 
 - [Building a CRUD App](/docs/guide/building-crud-app) - CRUD operations with actions
-- [Form](/docs/components/form) - Form submission actions
+- [Form](/docs/components/form/form) - Form submission actions
 - [Data Source](/docs/guide/data-source) - API integration

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -61,7 +61,7 @@ Seven jobs, all parallel — there are no `needs:` edges between them:
 | `test` | Test (shard N/4) | `pnpm test --shard=N/4` across a 4-runner matrix with `fail-fast: false`, so every shard reports its own failures. No coverage instrumentation — v8 adds 40–100% overhead. | **Pull requests only** |
 | `test-coverage` | Test (coverage) | One unsharded `pnpm test:coverage`, uploaded to Codecov. Nothing blocks on it, which is why it is not sharded. | **Push only** |
 | `e2e` | Build & E2E | Builds the console with `vite build` (`VITE_BASE_PATH=/console/`), verifies the artifact, then `pnpm test:e2e --project=chromium`. Uploads the Playwright report on failure. | Every run |
-| `docs` | Build Docs | `turbo run build --filter='@object-ui/site'`. On a PR it first diffs against the base and skips the build when nothing under `apps/site/` or `content/` changed. | Every run (build itself conditional) |
+| `docs` | Build Docs | `scripts/check-doc-links.mjs` (resolves every `/docs/...` markdown link against `content/docs/` — no install, no network), then `turbo run build --filter='@object-ui/site'`. On a PR it first diffs against the base and skips both when nothing under `apps/site/` or `content/` changed. | Every run (steps themselves conditional) |
 | `dev-server` | Dev-server fixture build | `pnpm --filter @object-ui/dev-server build` — guards `apps/dev-server`'s `objectstack.config.ts` against fixture / `@objectstack/spec` drift. | Every run |
 
 Uses: Node 22.x, pnpm via `corepack`, `actions/cache` over `.turbo/cache`.
@@ -216,6 +216,22 @@ Backend pins live in `e2e/live/ci/backend.env` and must match the `@objectstack/
 ## Link Checking (`check-links.yml`)
 
 **Trigger:** Manual workflow dispatch (`workflow_dispatch`).
+
+There are **two** link checkers, and they cover different things (objectui#3213):
+
+| | Covers | Network | Runs |
+|---|---|---|---|
+| `scripts/check-doc-links.mjs` | **Internal** `/docs/...` routes, resolved against `content/docs/` | No | In `ci.yml`'s `docs` job — see the job table above |
+| Lychee (this workflow) | **External** URLs in `docs/` and `README.md` | Yes | Manual dispatch only |
+
+Note the asymmetry in what Lychee scans: `docs/` holds internal material (ADRs, audits,
+architecture notes), while the published site is built from `content/docs/`. Lychee therefore does
+not currently see the site's own pages.
+
+Two known gaps are tracked rather than silently lived with: `ci.yml` lists `content/**` under
+`paths-ignore` and GitHub has no per-job path filter, so a **docs-only** PR does not start `ci.yml`
+and is not link-checked (objectui#3448); and Lychee's scan scope predates the move to
+`content/docs/` (objectui#3449).
 
 Uses [Lychee](https://github.com/lycheeverse/lychee) with configuration from `lychee.toml`:
 - Scans markdown files in `docs/` and `README.md`


### PR DESCRIPTION
Fixes #3213
Fixes #3292

## 前提复核(在未改动的 origin/main 上)

三条前提全部复现,均成立:

```
$ node scripts/check-doc-links.mjs
Found 1 broken docs link:
- content/docs/core/enhanced-actions.mdx -> /docs/components/form
EXIT=1

$ grep -rn "check-doc-links" .github/ package.json scripts/
package.json:42:    "docs:check-links": "node scripts/check-doc-links.mjs",     # 仅此一处,.github/ 下零调用
```

`check-links.yml` 的 `on:` 也确认只剩 `workflow_dispatch`(`push` / `pull_request` 被注释掉)。
即:一个能跑的检查器没人跑,另一个只能手动 —— 能力声明了但没被执行。

## 改动一:坏链改指 `/docs/components/form/form`(选 retarget,不补 index 页)

维护者裁决给了两个选项(补 `components/form` 索引页 / 改指 `/docs/components/form/form`,实施侧择优)。**选 retarget**,四条证据都指向它:

1. **本仓约定就是分类目录不设 index。** `content/docs/components/` 下 9 个分类目录(basic、complex、data-display、disclosure、feedback、form、layout、navigation、overlay)**全部 0 个 index 文件**。补一个会是 components 树里唯一的例外。
2. **站点自己就是这么链分类的。** `content/docs/components/index.md` 里写的是 `### [Form Components](/docs/components/form/button)`、`### [Basic Components](/docs/components/basic/text)` —— 一律用代表页,从不链裸分类路由。
3. **`form/meta.json` 显式列出 pages 且不含 index**,补页还得同步改 meta.json,进一步偏离约定。
4. **读者意图对得上。** 原句是 `- [Form](/docs/components/form) - Form submission actions`,讲的是表单**提交**;`content/docs/components/form/form.mdx` 的 frontmatter 正是 `title: "Form"` / `description: "Form container with validation and submission handling"`。是它,不是 `button`。

路由存在性也已核对:`apps/site/source.config.ts` 的 `dir: '../../content/docs'` + `apps/site/lib/source.ts` 的 `baseUrl: '/docs'`,故 `content/docs/components/form/form.mdx` 即 `/docs/components/form/form`。

```diff
-- [Form](/docs/components/form) - Form submission actions
++ [Form](/docs/components/form/form) - Form submission actions
```

## 改动二:`ci.yml` 的 docs job 加一步 `Check docs links`

按裁决「A 进 PR 门禁」。位置放在 `Setup Node.js` 之后、`Turbo Cache` / `Install dependencies` / `Build Site` 之前:

```yaml
- name: Check docs links
  if: steps.docs-changes.outputs.should_run == 'true'
  run: node scripts/check-doc-links.mjs
```

- 脚本零依赖、零网络(只对 `content/docs/` 做 `existsSync` 解析),**不需要 install**,几秒跑完 —— 契合 ci.yml 既有的「便宜的结构性检查放 install 之前」写法(参考 `Verify type-check coverage` 那一步的注释)。
- 沿用该 job 的 `should_run` 条件,与其余步骤风格一致,也避免因别人留下的坏链把无关 PR 判红。

## 改动三:同步 `content/docs/guide/ci-cd-pipeline.md`

commandment #2(docs-driven)。该页的 `ci.yml` job 表格原文只写了 `turbo run build`,加了门禁就不再准确,已同步;并在 Link Checking 一节补一张对照表,写清两个检查器的分工(站内路由 / 外链、走不走网络、在哪跑)与两个已知缺口 —— 免得读者从这一页得出「文档链接已被完全守住」的结论。

> 说明:该页还有一处**既存**漂移(写「Seven jobs」并列了一个 `ci.yml` 里并不存在的 `dev-server` job,实际 6 个)。**本 PR 没有顺手改**,已另立 #3451。

## ⚠️ 已知缺口(**请勿据此认为文档链接已被完全守住**)—— 已记为 #3448

`ci.yml` 的 `on:` 在 `push` 和 `pull_request` 两处都带 `paths-ignore`,其中含 `content/**` 与 `'**/*.md'`;GitHub 的 `paths-ignore` 是「改动文件全部命中则整个 workflow 不启动」,而且**没有 per-job path filter**。

于是:

| PR / push 类型 | 本步骤是否运行 |
|---|---|
| 纯 docs PR(只改 `content/**`) | ❌ workflow 根本不启动 |
| docs + 代码混合 PR | ✅ |
| push 到 `main`(含非忽略路径) | ✅ |

**最可能改坏链接的那类 PR(纯 docs)恰恰不被覆盖。**

仓库里已有针对同一堵墙的正确答案 —— `control-bytes.yml` 的文件头:

> Why this is its own workflow instead of a job in `ci.yml` or `lint.yml`: both of those list `'**/*.md'`, `content/**`, `docs/**` and `.changeset/**` under `paths-ignore`, and GitHub has no per-job path filter. (…) a gate that cannot see a markdown-only PR rebuilds the hole it exists to close.

`check-doc-links.mjs` 与 control-bytes 属于完全相同的类别(守 markdown/content、零 install、零网络)。**推荐后续按 #3448 的方案 A 把它挪成独立 workflow。** 本 PR 没有自行这么做:裁决明确写的是「加进 ci.yml 的 docs 任务」,且改 workflow 触发策略属于 CI 成本决策,应由维护者拍板。缺口已写进该步骤上方的注释,不留给下一个人踩。

## check-links.yml(Lychee):维持 workflow_dispatch,**有意未加 cron** —— 已记为 #3449

裁决说 cron 可选、有疑虑就跳过。这里有实证疑虑:Lychee 扫的是 `docs/**/*.md(x)` + `README.md`,而站点文档在 `content/docs/**`。

```
$ find docs -name '*.md' -o -name '*.mdx' | wc -l
15          # ARCHITECTURE.md、adr/、audits/ 等内部资料
$ find content/docs -name '*.md' -o -name '*.mdx' | wc -l
183         # 实际发布的站点文档
```

范围修正之前加 cron,只会按时产出一份「检查了内部 ADR、没检查站点文档」的绿报告 —— 加噪声不加覆盖,还会让人误以为已发布文档的外链有人守。建议先修范围再谈 cron。

## 验证

**反向验证(方向预判:恢复坏链 → 检查器转红)。** 预判与实测一致:

```
# 改前(pristine origin/main)
$ node scripts/check-doc-links.mjs
Found 1 broken docs link:
- content/docs/core/enhanced-actions.mdx -> /docs/components/form
EXIT=1

# 改后
$ node scripts/check-doc-links.mjs
Docs links are valid.
EXIT=0
```

**新步骤在本 PR 上真实跑过,且是 executed 而非 skipped** —— 取 Build Docs job 的 steps(commit `3c83a59`):

```
6  Setup Node.js       success
7  Check docs links    success     05:24:45 -> 05:24:45
8  Turbo Cache         success
...
10 Build Site          success
Job "Build Docs": conclusion = success
```

(skipped 的步骤 conclusion 会是 `skipped`,这里是 `success`,所以确实执行了。本 PR 能触发 `ci.yml` 是因为它改了 `.github/workflows/ci.yml`,该路径不在 `paths-ignore` 里;`docs-changes` 又因 `content/` 有改动而置 `should_run=true`。)

其余:

- **ci.yml YAML 解析通过**(容器内无 actionlint,改用 `python3 -c "yaml.safe_load(...)"`);docs job 步骤顺序为 `Checkout code → Check for docs changes → Enable Corepack → Verify pnpm version → Setup Node.js → Check docs links → Turbo Cache → Install dependencies → Build Site`。
- **钉住被改文档的测试**:`pnpm exec vitest run scripts/__tests__/ --maxWorkers=2` → `8 passed (8) / 120 passed (120)`,其中 `ci-cd-pipeline-doc.test.ts` 9 条全绿(它正是钉 `ci-cd-pipeline.md` 的那个文件)。
- **控制字节自查**:`node scripts/check-control-bytes.mjs` → `OK (scanned 3640 tracked text file(s); skipped 85 binary)`;另对三个改动文件单独 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` → 无命中。
- `Build Docs` 已在本 PR 上完整构建站点(556 静态页)成功,顺带验证改后的链接在真实路由下成立。

## 说明

- **未加 changeset**:docs + CI,无用户可见的包变更(沿用 #3437 / #3443 先例)。
- **未改 `scripts/check-doc-links.mjs`**:任务是把它接上,不是重写它。
- 顺带发现一律按纪律立为独立 issue,未在本 PR 夹带修复:#3448(门禁缺口)、#3449(Lychee 扫描范围漂移)、#3451(job 表格既存漂移)。
