### PR TITLE
docs(ci): 删掉 ci.yml 任务表里的幽灵 dev-server 行，并给任务表加双向 pin (#3451)

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -23,7 +23,7 @@ one has its own section below.
 
 | Workflow file | Appears as | Runs on | Blocks a PR? |
 |---|---|---|---|
-| `ci.yml` | CI | Push / PR to `main`, `develop` | **Yes** — 6 of its 7 jobs run on PRs |
+| `ci.yml` | CI | Push / PR to `main`, `develop` | **Yes** — every job but `test-coverage` (push only) runs on PRs |
 | `lint.yml` | Lint | Push / PR to `main`, `develop`; manual | **Yes** — ESLint **errors** only |
 | `changeset-guard.yml` | Changeset Bump Policy | PR / push touching `.changeset/**` | **Yes** |
 | `control-bytes.yml` | Control Byte Scan | Push / PR to `main`, `develop` — **no path filter**; manual | **Yes** |
@@ -52,7 +52,12 @@ Two path-filter facts explain most "why did nothing run on my PR?" questions:
 **Triggers:** Push and PR to `main` and `develop`, unless the change touches only `**/*.md`,
 `content/**`, `docs/**`, `apps/site/**` or `.changeset/**` (`paths-ignore`).
 
-Seven jobs, all parallel — there are no `needs:` edges between them:
+Every job runs in parallel — there are no `needs:` edges between them. As with the workflow
+inventory above, this page states **no job count**: the table *is* the list, and
+`scripts/__tests__/ci-cd-pipeline-doc.test.ts` pins its first column against `ci.yml`'s `jobs:`
+keys in both directions, so a job added or removed without touching this table is a red test.
+(This section used to open with a hard-coded count and list a seventh job, `dev-server`, that had
+been deleted three months earlier — [#3451](https://github.com/objectstack-ai/objectui/issues/3451).)
 
 | Job key | Appears as | What it runs | When |
 |---|---|---|---|
@@ -62,20 +67,37 @@ Seven jobs, all parallel — there are no `needs:` edges between them:
 | `test-coverage` | Test (coverage) | One unsharded `pnpm test:coverage`, uploaded to Codecov. Nothing blocks on it, which is why it is not sharded. | **Push only** |
 | `e2e` | Build & E2E | Builds the console with `vite build` (`VITE_BASE_PATH=/console/`), verifies the artifact, then `pnpm test:e2e --project=chromium`. Uploads the Playwright report on failure. | Every run |
 | `docs` | Build Docs | `scripts/check-doc-links.mjs` (resolves every `/docs/...` markdown link against `content/docs/` — no install, no network), then `turbo run build --filter='@object-ui/site'`. On a PR it first diffs against the base and skips both when nothing under `apps/site/` or `content/` changed. | Every run (steps themselves conditional) |
-| `dev-server` | Dev-server fixture build | `pnpm --filter @object-ui/dev-server build` — guards `apps/dev-server`'s `objectstack.config.ts` against fixture / `@objectstack/spec` drift. | Every run |
 
 Uses: Node 22.x, pnpm via `corepack`, `actions/cache` over `.turbo/cache`.
 
 ### What is *not* in `ci.yml`
 
-Two jobs this page used to list have never existed under those names, and looking for them in
-`ci.yml` is a dead end:
+Three job names this page has carried at one time or another are absent from `ci.yml`, and looking
+for them there is a dead end:
 
-- **Lint** is not a `ci.yml` job. ESLint runs in its own workflow, `lint.yml` (next section), and
-  shows up as a separate **Lint** check on the PR.
-- **Build Core** does not exist. `ci.yml` builds only the console SPA that Playwright consumes;
-  building the packages and measuring their size belongs to the Bundle Analysis workflow
+- **Lint** is not a `ci.yml` job, and never was. ESLint runs in its own workflow, `lint.yml` (next
+  section), and shows up as a separate **Lint** check on the PR.
+- **Build Core** does not exist, and never did. `ci.yml` builds only the console SPA that Playwright
+  consumes; building the packages and measuring their size belongs to the Bundle Analysis workflow
   (`performance-budget.yml`), as the comment on the `e2e` job states.
+- **Dev-server fixture build** (`dev-server`) is the one that *did* exist, and it is the cautionary
+  tale behind the pin above. It was added on 2026-05-24 to run
+  `pnpm --filter @object-ui/dev-server build` against an in-repo `apps/dev-server`. That app was
+  removed two days later, on 2026-05-26 — after which the filter matched no package and the job
+  exited 0 without building anything. It stayed green by vacuity for over two months; was then
+  *documented in that state* by
+  [#3253](https://github.com/objectstack-ai/objectui/pull/3253) on 2026-08-03, whose table row
+  claimed a fixture-drift guard that had not run since May; and was finally deleted from `ci.yml`
+  by [#3325](https://github.com/objectstack-ai/objectui/pull/3325) on 2026-08-04, which left the
+  row behind ([#3451](https://github.com/objectstack-ai/objectui/issues/3451)). **Today there is no
+  `apps/dev-server` and no such job** — nothing in the repository is being left unguarded by its
+  absence. The intent it was meant to serve, proving this console still works against a real
+  `@objectstack` backend, is carried by `live-e2e.yml`, informationally.
+
+  Both halves of that history are the reason the job table is pinned. A row can be wrong because
+  the job was deleted under it, and a row can be wrong the day it is written, because the job it
+  describes was already doing nothing. Understating a gate is annoying; advertising a guardrail CI
+  does not have is worse than no doc, because people trust it and stop checking.
 
 ## Lint (`lint.yml`)
 

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -186,3 +186,192 @@ describe('ci-cd-pipeline.md — workflow inventory', () => {
     expect(workflowFiles).not.toContain('size-check.yml');
   });
 });
+
+/**
+ * objectui#3451: the same drift as #3197/#3212, one table lower down and pointing
+ * the dangerous way. The `## Core CI Workflow (ci.yml)` section opened with "Seven
+ * jobs, all parallel" and its table's seventh row described a `dev-server` job —
+ * "guards `apps/dev-server`'s `objectstack.config.ts` against fixture /
+ * `@objectstack/spec` drift", running "Every run".
+ *
+ * The history matters, because the row was wrong in two different ways and only the
+ * second is the one you would guess:
+ *
+ *   2026-05-24  `apps/dev-server` lands, and with it the `dev-server` job.
+ *   2026-05-26  `apps/dev-server` is removed. The job stays. `--filter
+ *               @object-ui/dev-server` now matches no package and exits 0 —
+ *               green by vacuity, for the next 69 days.
+ *   2026-08-03  #3253 (fixing #3212) rewrites this very table and *adds* the
+ *               `dev-server` row, describing a fixture-drift guard that had not
+ *               built anything since May. The row was false the day it was written.
+ *   2026-08-04  #3325 deletes the vacuous job from `ci.yml`, leaving the row.
+ *   2026-08-06  #3451.
+ *
+ * So this is not only "the YAML moved and the prose lagged". #3253 pinned the
+ * *workflow* inventory in both directions and left the *job* table unpinned, and the
+ * table drifted within a day. #3197's comment names the direction: understating a
+ * gate is annoying, advertising a guardrail the CI does not have is worse than no
+ * doc.
+ *
+ * The count and the table are pinned together because fixing either one alone fixes
+ * a snapshot, not the drift. Add or remove a job in `ci.yml` without editing this
+ * page and the first test below fails, naming the job in each direction.
+ *
+ * What this still cannot catch is the 2026-05-26 shape: a job that exists in YAML
+ * and does nothing. No amount of doc-to-YAML pinning sees that — only reading what
+ * the job runs does.
+ */
+describe('ci-cd-pipeline.md — ci.yml job table', () => {
+  const ciWorkflow = fs.readFileSync(path.join(workflowDir, 'ci.yml'), 'utf8');
+
+  /**
+   * Job keys from `ci.yml`, in file order.
+   *
+   * Scoped to the `jobs:` mapping, because top-level `on:` has two-space children
+   * of its own (`push:`, `pull_request:`) that a whole-file scan would read as
+   * jobs. Inside `jobs:` the only two-space lines are the job keys themselves:
+   * job-level keys sit at four, step bodies deeper still, and every block scalar
+   * (`run: |`) is indented past its key, so nothing else can reach column 2.
+   */
+  function ciJobKeys(): string[] {
+    const start = ciWorkflow.search(/^jobs:[ \t]*$/m);
+    expect(start, 'ci.yml must still have a top-level `jobs:` mapping').toBeGreaterThan(-1);
+    const body = ciWorkflow.slice(start + 'jobs:'.length);
+    // `jobs:` is the last top-level key today; stop at the next one regardless.
+    const end = body.search(/^[A-Za-z]/m);
+    const scoped = end === -1 ? body : body.slice(0, end);
+    return [...scoped.matchAll(/^ {2}([a-z0-9][a-z0-9-]*):[ \t]*$/gm)].map((m) => m[1]);
+  }
+
+  /** The `name:` each job reports itself under in the checks list, keyed by job key. */
+  function ciJobNames(): Map<string, string> {
+    const names = new Map<string, string>();
+    const start = ciWorkflow.search(/^jobs:[ \t]*$/m);
+    const body = ciWorkflow.slice(start);
+    for (const key of ciJobKeys()) {
+      const at = body.search(new RegExp(`^ {2}${key}:[ \\t]*$`, 'm'));
+      const after = body.slice(at);
+      const name = after.match(/^ {4}name:[ \t]*(.+?)[ \t]*$/m)?.[1];
+      if (name) names.set(key, name.replace(/^['"]|['"]$/g, ''));
+    }
+    return names;
+  }
+
+  /** The `## Core CI Workflow (ci.yml)` section, up to the next `##` heading. */
+  function coreCiSection(): string {
+    const start = doc.indexOf('## Core CI Workflow (`ci.yml`)');
+    expect(start, 'the page must still have a "## Core CI Workflow (`ci.yml`)" section').toBeGreaterThan(-1);
+    const rest = doc.slice(start + 2);
+    const next = rest.search(/^## /m);
+    return next === -1 ? rest : rest.slice(0, next);
+  }
+
+  const JOB_TABLE_HEADER = '| Job key | Appears as | What it runs | When |';
+
+  /** First column of the job table, in page order. */
+  function docJobRows(): { key: string; appearsAs: string }[] {
+    const section = coreCiSection();
+    const at = section.indexOf(JOB_TABLE_HEADER);
+    expect(at, `the job table must keep the header \`${JOB_TABLE_HEADER}\``).toBeGreaterThan(-1);
+    const lines = section.slice(at).split('\n').slice(1);
+    const rows: { key: string; appearsAs: string }[] = [];
+    for (const line of lines) {
+      if (!line.startsWith('|')) break;
+      if (/^\|[\s|:-]+\|$/.test(line)) continue; // separator
+      const cells = line.split('|').slice(1, -1).map((c) => c.trim());
+      rows.push({ key: cells[0].replace(/`/g, '').trim(), appearsAs: cells[1] ?? '' });
+    }
+    return rows;
+  }
+
+  it('lists exactly the jobs ci.yml defines — in both directions', () => {
+    const fromWorkflow = ciJobKeys();
+    // A parser that silently matched nothing would make this test vacuously green,
+    // which is the failure mode the removed `dev-server` job itself demonstrated.
+    expect(fromWorkflow.length, 'the ci.yml `jobs:` parse returned implausibly few keys').toBeGreaterThan(3);
+
+    const fromDoc = docJobRows().map((r) => r.key);
+    expect(fromDoc.length, 'the job table parse returned implausibly few rows').toBeGreaterThan(3);
+
+    const phantom = fromDoc.filter((k) => !fromWorkflow.includes(k));
+    const missing = fromWorkflow.filter((k) => !fromDoc.includes(k));
+
+    expect(
+      phantom,
+      `content/docs/guide/ci-cd-pipeline.md's job table has rows for jobs that are NOT in ` +
+        `.github/workflows/ci.yml:\n` +
+        phantom.map((k) => `  - ${k}`).join('\n') +
+        `\n\nDelete the row. A page that advertises a guard CI does not run is worse than no ` +
+        `page — objectui#3451: the \`dev-server\` row survived three months after #3325 deleted ` +
+        `the job, telling contributors their objectstack.config.ts had drift protection it did not.`,
+    ).toEqual([]);
+
+    expect(
+      missing,
+      `.github/workflows/ci.yml defines jobs with no row in the job table of ` +
+        `content/docs/guide/ci-cd-pipeline.md:\n` +
+        missing.map((k) => `  - ${k}`).join('\n') +
+        `\n\nAdd a row (job key, the \`name:\` it appears as in the checks list, what it runs, and ` +
+        `when) — an undocumented job is a check contributors get blocked by without knowing it exists.`,
+    ).toEqual([]);
+  });
+
+  it('quotes each job under the name ci.yml gives it', () => {
+    // `${{ ... }}` is left as a wildcard: `test` is a matrix job whose name is
+    // `Test (shard ${{ matrix.shard }}/4)` and the page sensibly writes `N` for the
+    // shard index. Everything outside the expressions must match literally.
+    const names = ciJobNames();
+    expect(names.size, 'every ci.yml job should declare a `name:`').toBe(ciJobKeys().length);
+
+    for (const { key, appearsAs } of docJobRows()) {
+      const declared = names.get(key);
+      if (!declared) continue; // key mismatch is the previous test's failure to report
+      const pattern = new RegExp(
+        `^${declared
+          .split(/\$\{\{[^}]*\}\}/)
+          .map((lit) => lit.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('.+')}$`,
+      );
+      expect(
+        appearsAs,
+        `the job table's "Appears as" for \`${key}\` must match ci.yml's \`name: ${declared}\``,
+      ).toMatch(pattern);
+    }
+  });
+
+  it('states no job count, so the number cannot drift away from the table', () => {
+    // The #3212 lesson applied one section down: a hand-maintained count drifts by
+    // construction and a stale one still reads as authoritative. "Seven jobs, all
+    // parallel" outlived the seventh job by three months.
+    const section = coreCiSection();
+    const counted = section.match(
+      /\b(?:one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|\d+)[ \t]+(?:parallel[ \t]+)?jobs\b/i,
+    );
+    expect(
+      counted?.[0],
+      `the Core CI section must not hard-code how many jobs ci.yml has (found "${counted?.[0]}") — ` +
+        `the table is the list. See the same decision for the workflow count at the top of the page.`,
+    ).toBeUndefined();
+  });
+
+  it('is telling the truth: no CI job builds the retired dev-server fixture', () => {
+    // The inverse pin. The page now states outright that there is *no* guard on
+    // `objectstack.config.ts` / `@objectstack/spec` drift. If anyone restores such a
+    // job, this fails and points at the paragraph that denies it exists.
+    expect(ciJobKeys()).not.toContain('dev-server');
+    expect(
+      ciWorkflow,
+      'a dev-server fixture build is back in ci.yml — update the "What is not in `ci.yml`" ' +
+        'section, which currently tells readers no such guard exists',
+    ).not.toMatch(/@object-ui\/dev-server/);
+    // Reflow-tolerant, and asserted as a boolean so a failure prints the reason
+    // rather than diffing the entire page into the terminal.
+    expect(
+      /Today there is no `apps\/dev-server` and no such job/.test(doc.replace(/\s+/g, ' ')),
+      'the "What is not in `ci.yml`" section must keep stating outright that neither the ' +
+        '`dev-server` job nor `apps/dev-server` exists. The table pin above catches a restored ' +
+        'job with no row; this catches a restored job whose row was added while this paragraph ' +
+        'still denies it (objectui#3451).',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #3451

## 查史结论：是被删的，但比 issue 假设的更糟

issue 问「是被删了还是从未落地」。答案是**被删了**——但查完历史后，这一行的问题不只是「YAML 变了、散文没跟上」，它在写下来的当天就已经是假的。

| 日期 | 事件 |
|---|---|
| 2026-05-24 | `apps/dev-server` 落地（`895ab27f5`），`dev-server` job 同日加入 ci.yml（`3fb31a5da`，「ci: guard the dev-server fixture build」） |
| 2026-05-26 | **`apps/dev-server` 被移除**（`f2a03a5f8`「Remove in-repo dev-server, require external ObjectStack instance」）。job 保留下来，`pnpm --filter @object-ui/dev-server build` 自此匹配不到任何包、静默 exit 0 —— **空转绿 69 天** |
| 2026-08-03 | #3253（修 #3212）重写这张任务表，并「补齐」了 `dev-server` 行。它描述的是一个自 5 月起就没构建过任何东西的守卫 —— 这一行在被写下的当天就是假的 |
| 2026-08-04 | #3325 从 ci.yml 删掉这个空转 job（其 PR 正文原话：「该 job 长期『空转绿』」），**留下了文档里的这一行** |
| 2026-08-06 | #3451 |

值得单独记一笔的是：#3253 正是那个「给 workflow 清单补上反向断言」的 PR。它把 **workflow 清单**钉成了双向，却没有钉 **job 表**——于是 job 表在一天之内就漂了。这就是本 PR 补的那个洞。

**是否要把这个守卫加回来：不需要，也没有缺口。** `apps/dev-server` 本身已经不在树中，所以「守护 apps/dev-server 的 objectstack.config.ts」今天没有对象可守；#3325 的裁决明确写了其意图由新的 `live-e2e.yml` lane 承接（而且换成了真后端）。因此本 PR 没有任何 CI 成本方面的升级项，纯粹是文档追平现实。

## 改了什么

**1. `content/docs/guide/ci-cd-pipeline.md`**

- 删掉 `dev-server` 表格行。
- 「Seven jobs, all parallel」→ 不写死数字。这不是自创，是沿用**本页对 workflow 计数已经做过的同一决定**（#3212：手工维护的计数必然漂移，过期的数字仍然读起来像权威）。改为说明表格本身就是清单，并指向钉住它的测试。
- inventory 表里的「**Yes** — 6 of its 7 jobs run on PRs」同样含一个会漂的数字，改为按 job 名表述：「every job but `test-coverage` (push only) runs on PRs」。
- 「What is *not* in `ci.yml`」一节补记 `dev-server` 的完整来龙去脉，并明确写出**今天既没有 `apps/dev-server` 也没有该 job**，以及其意图由 `live-e2e.yml` 承接。原来那两条（Lint / Build Core）措辞相应补上「never was / never did」以区分——三者中只有 dev-server 是真存在过的。

**2. `scripts/__tests__/ci-cd-pipeline-doc.test.ts`** —— 新增 4 条断言（止血的那部分）

| 断言 | 钉住什么 |
|---|---|
| `lists exactly the jobs ci.yml defines — in both directions` | 任务表首列 ↔ ci.yml `jobs:` keys，两个方向各自给出可执行的失败信息 |
| `quotes each job under the name ci.yml gives it` | 「Appears as」列 ↔ ci.yml 的 `name:`。`${{ ... }}` 按通配处理，因为 `test` 是矩阵 job（`Test (shard ${{ matrix.shard }}/4)`，页面合理地写 `N`），表达式之外必须逐字相符 |
| `states no job count, so the number cannot drift away from the table` | 本节不得再写死 job 数量 |
| `is telling the truth: no CI job builds the retired dev-server fixture` | 反向 pin：若有人把 job 加回来，「今天没有这个 job」那段话就成了假话 |

`jobs:` 的解析被**限定在 `jobs:` 映射之内**：顶层 `on:` 自己就有两空格缩进的子键（`push:` / `pull_request:`），全文件扫描会把它们读成 job。这一点连同「为什么 `jobs:` 块内除 job key 外没有别的东西能到第 2 列」都写在了代码注释里。另有一条 `length > 3` 的自检，防止解析器静默匹配为空而让测试真空变绿——这恰恰是被删的那个 job 自己演示过的失效方式。

## 验证

**反向验证（方向先预测，后运行）。** 预测：新断言在 origin/main 的文档上**红**，修完**绿**。实测三条红（第四条 `Appears as` 在 main 上是绿的，因为 `dev-server` 在 ci.yml 里没有对应 `name:`，代码里显式 `continue` 把 key 不匹配留给上一条断言报——这是有意设计，不是漏网）：

```
FAIL  ci-cd-pipeline.md — ci.yml job table > lists exactly the jobs ci.yml defines — in both directions
  content/docs/guide/ci-cd-pipeline.md's job table has rows for jobs that are NOT in
  .github/workflows/ci.yml:
    - dev-server
  - []
  + [ "dev-server" ]

FAIL  ... > states no job count, so the number cannot drift away from the table
  the Core CI section must not hard-code how many jobs ci.yml has (found "Seven jobs")

FAIL  ... > is telling the truth: no CI job builds the retired dev-server fixture

 Tests  3 failed | 10 passed (13)
```

修完（仓根全量 `scripts/__tests__/`）：

```
 Test Files  8 passed (8)
      Tests  124 passed (124)
```

**Sabotage 验证（证明每条断言都不是真空绿），改动均已还原：**

- 临时删掉 `docs` 行 → 反方向红：``.github/workflows/ci.yml defines jobs with no row in the job table ... - docs``
- 临时把 `Build & E2E` 改成 `Build and E2E` → ``the job table's "Appears as" for `e2e` must match ci.yml's `name: Build & E2E`: expected 'Build and E2E' to match /^Build & E2E$/``
- 「不写死数字」那条在开发中真的抓到了我自己：初稿的散文里引用了旧措辞原文，被判红后改为不含该字面量的表述。

**其它闸门：**

| 项 | 结果 |
|---|---|
| `node scripts/check-doc-links.mjs` | ✅ `Docs links are valid.` |
| `node scripts/check-control-bytes.mjs` | ✅ `OK (scanned 3648 tracked text file(s); skipped 85 binary)` |
| 控制字节自查（超出闸门范围，`grep -naP` C0 区间） | ✅ 两个文件均无 |
| `tsc --noEmit --strict`（针对该测试文件） | ✅ exit 0 |
| `eslint scripts/__tests__/ci-cd-pipeline-doc.test.ts` | ✅ exit 0 |

**关于 CI：** 本 PR 是纯文档 + 测试改动，而 `ci.yml` 把 `content/**` 和 `**/*.md` 放在 `paths-ignore` 里——所以 `docs` job（以及整个 ci.yml）**很可能不会在这个 PR 上运行**。这正是 #3448 追踪的那个洞。上面所有结论均以本地实跑为准，特此声明。

## 范围

- 改动文件仅两个：`content/docs/guide/ci-cd-pipeline.md`、`scripts/__tests__/ci-cd-pipeline-doc.test.ts`。
- **未触碰 `.github/workflows/`**（按裁决，workflow 改动归 #3448）。
- 未加 changeset：纯文档 + 测试，不改变任何已发布包的行为（先例 #3443 / #3437 / #3253）。

## 顺带记录（不在本 PR 范围，也不建议在本 PR 修）

`scripts/` 不在根 `tsconfig.json` 的 `include`（只有 `packages` / `examples` / `apps`），也不是任何 workspace 包，因此 `turbo run type-check` 覆盖不到 `scripts/__tests__/*.ts`——这些测试文件的类型错误在 CI 里没有闸门。本 PR 用直接跑 `tsc` 的方式自行补了这一次，但这是个结构性缺口。是否值得单独立 issue，请 PM 定夺（我未擅自开单，因为它更像 #3448 那一类 CI 覆盖面问题，可能应挂在既有条目下）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_