### PR TITLE
fix(i18n): ListView / ObjectGrid 记录详情浮层标题改为入键,不再自拼英文 (#3426)

### DIFF
--- a/.changeset/overlay-caller-titles-i18n-3426.md
+++ b/.changeset/overlay-caller-titles-i18n-3426.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/plugin-list': patch
+'@object-ui/plugin-grid': patch
+'@object-ui/i18n': patch
+---
+
+Localize the record-detail overlay heading that `ListView` and `ObjectGrid`
+build themselves (objectui#3426)
+
+#3423 gave `NavigationOverlay`'s `resolvedTitle` an i18n default
+(`detail.recordDetail`), but two hosts never let that default run: they
+string-built an English heading in TypeScript and passed it as the `title`
+prop, so a zh/ja/de session got a fully localized drawer with one English
+heading on it.
+
+- `packages/plugin-list/src/ListView.tsx` — `` `${schema.label} Detail` ``
+- `packages/plugin-grid/src/ObjectGrid.tsx` — the same template, plus a bare
+  `'Record Detail'` literal for the no-label case
+
+Both are user-reachable, not dead defaults. `list-view` / `object-grid` are
+public page blocks and `navigation` is an authorable key on their schema, so a
+page that authors `navigation: { mode: 'drawer' }` opens exactly this overlay
+on row click. (`app-shell`'s `ObjectView` does suppress it — it passes its own
+`onRowClick`, which takes priority inside `useNavigationOverlay`, and renders
+its own overlay — but that is one host overriding a public block, not proof the
+branch is unreachable.)
+
+## What changed
+
+Both call sites now key their heading instead of concatenating it:
+
+- a new `detail.recordDetailWithLabel` (`'{{label}} Detail'`) carries the
+  object label through interpolation, so a pack whose qualifier trails the noun
+  (`de`) or that needs a possessive particle (`ja`/`zh`) can write its own
+  arrangement rather than inherit English word order;
+- the no-label branch reuses `detail.recordDetail` — the very key the overlay
+  itself defaults to — so one heading on one control cannot drift into two
+  translations.
+
+The new key is added to all ten locale packs and to each plugin's English
+defaults map (`LIST_DEFAULT_TRANSLATIONS` / `GRID_DEFAULT_TRANSLATIONS`), which
+is what `createSafeTranslation` falls back to with no `I18nProvider` mounted.
+
+English output is byte-identical in every branch (`Contacts Detail` /
+`Contacts Detail` / `Record Detail`), with and without a provider — pinned by a
+provider-less test file per plugin, kept separate because `initReactI18next`
+registers its instance as a module global that outlives `cleanup()`.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -757,6 +757,7 @@ const ar = {
     reactionCount: "{{emoji}} {{count}} تفاعلات",
     reactionCountOne: "{{emoji}} {{count}} تفاعل",
     recordDetail: "تفاصيل السجل",
+    recordDetailWithLabel: "تفاصيل {{label}}",
     openAsFullPage: "فتح كصفحة كاملة",
     recordDetailOverlay: "طبقة تفاصيل السجل الخاصة بـ {{title}}.",
     addToFavorites: "إضافة إلى المفضلة",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -755,6 +755,7 @@ const de = {
     reactionCount: "{{emoji}} {{count}} Reaktionen",
     reactionCountOne: "{{emoji}} {{count}} Reaktion",
     recordDetail: "Datensatzdetails",
+    recordDetailWithLabel: "{{label}}-Details",
     openAsFullPage: "Als ganze Seite öffnen",
     recordDetailOverlay: "Detail-Overlay des Datensatzes für {{title}}.",
     addToFavorites: "Zu Favoriten hinzufügen",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -831,6 +831,15 @@ const en = {
     // name; `recordDetailOverlay` is the sr-only description on the
     // Sheet/Dialog when the host supplies none.
     recordDetail: 'Record Detail',
+    // Same heading, but for the hosts that DO know which object they are
+    // showing (objectui#3426): `ListView` / `ObjectGrid` used to string-build
+    // `` `${label} Detail` `` in TypeScript and hand it to the overlay's
+    // `title` prop, so `recordDetail` above never got a chance to apply and a
+    // non-English session read one English heading. Interpolating keeps the
+    // object label in the heading without freezing English word order — a pack
+    // whose qualifier trails the noun (de: a hyphenated compound) or that needs
+    // a possessive particle (ja/zh) writes its own arrangement here.
+    recordDetailWithLabel: '{{label}} Detail',
     openAsFullPage: 'Open as full page',
     recordDetailOverlay: 'Record detail overlay for {{title}}.',
     addToFavorites: 'Add to favorites',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -760,6 +760,7 @@ const es = {
     reactionCount: "{{emoji}} {{count}} reacciones",
     reactionCountOne: "{{emoji}} {{count}} reacción",
     recordDetail: "Detalle del registro",
+    recordDetailWithLabel: "Detalle de {{label}}",
     openAsFullPage: "Abrir como página completa",
     recordDetailOverlay: "Capa de detalle del registro para {{title}}.",
     addToFavorites: "Añadir a favoritos",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -757,6 +757,7 @@ const fr = {
     reactionCount: "{{emoji}} {{count}} réactions",
     reactionCountOne: "{{emoji}} {{count}} réaction",
     recordDetail: "Détail de l'enregistrement",
+    recordDetailWithLabel: "Détail — {{label}}",
     openAsFullPage: "Ouvrir en pleine page",
     recordDetailOverlay: "Panneau de détail de l'enregistrement pour {{title}}.",
     addToFavorites: "Ajouter aux favoris",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -755,6 +755,7 @@ const ja = {
     reactionCount: "{{emoji}} {{count}} 件のリアクション",
     reactionCountOne: "{{emoji}} {{count}} 件のリアクション",
     recordDetail: "レコード詳細",
+    recordDetailWithLabel: "{{label}}の詳細",
     openAsFullPage: "フルページで開く",
     recordDetailOverlay: "{{title}} のレコード詳細オーバーレイ。",
     addToFavorites: "お気に入りに追加",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -755,6 +755,7 @@ const ko = {
     reactionCount: "{{emoji}} 반응 {{count}}개",
     reactionCountOne: "{{emoji}} 반응 {{count}}개",
     recordDetail: "레코드 세부 정보",
+    recordDetailWithLabel: "{{label}} 세부 정보",
     openAsFullPage: "전체 페이지로 열기",
     recordDetailOverlay: "{{title}}의 레코드 세부 정보 오버레이입니다.",
     addToFavorites: "즐겨찾기에 추가",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -757,6 +757,7 @@ const pt = {
     reactionCount: "{{emoji}} {{count}} reações",
     reactionCountOne: "{{emoji}} {{count}} reação",
     recordDetail: "Detalhe do registro",
+    recordDetailWithLabel: "Detalhe de {{label}}",
     openAsFullPage: "Abrir como página inteira",
     recordDetailOverlay: "Sobreposição de detalhe do registro para {{title}}.",
     addToFavorites: "Adicionar aos favoritos",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -757,6 +757,7 @@ const ru = {
     reactionCount: "{{emoji}} {{count}} реакций",
     reactionCountOne: "{{emoji}} {{count}} реакция",
     recordDetail: "Сведения о записи",
+    recordDetailWithLabel: "Сведения: {{label}}",
     openAsFullPage: "Открыть на всю страницу",
     recordDetailOverlay: "Наложение со сведениями о записи для {{title}}.",
     addToFavorites: "Добавить в избранное",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -805,6 +805,7 @@ const zh = {
     reactionCount: '{{emoji}} {{count}} 个回应',
     reactionCountOne: '{{emoji}} {{count}} 个回应',
     recordDetail: '记录详情',
+    recordDetailWithLabel: '{{label}}详情',
     openAsFullPage: '以完整页面打开',
     recordDetailOverlay: '{{title}} 的记录详情浮层。',
     addToFavorites: '添加到收藏',

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -131,6 +131,15 @@ const GRID_DEFAULT_TRANSLATIONS: Record<string, string> = {
   // Reused by the grouped-view pager (falls back here when no I18nProvider).
   'table.rowsPerPage': 'Rows per page',
   'table.pageInfo': 'Page {{current}} of {{total}}',
+  // Heading of the record-detail overlay this grid opens on row click
+  // (objectui#3426). Borrowed from the `detail.*` namespace rather than minted
+  // as `grid.recordDetail`: `NavigationOverlay` already resolves
+  // `detail.recordDetail` for hosts that pass no title, and one heading on one
+  // control should not get two translations that can drift apart. Both entries
+  // must exist HERE too — a provider-less host (a standalone grid, this
+  // package's own tests) never reaches the locale packs.
+  'detail.recordDetail': 'Record Detail',
+  'detail.recordDetailWithLabel': '{{label}} Detail',
 };
 
 /**
@@ -2277,12 +2286,27 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     })),
   });
 
-  // Build record detail title
+  // Build record detail title.
+  //
+  // Keyed, not string-built (objectui#3426). This value is handed to
+  // `NavigationOverlay`'s `title` prop, which means the overlay's own
+  // `detail.recordDetail` default never applies here — whatever this computes
+  // IS the visible heading of the drawer/modal/split/popover. Interpolating
+  // the label through `detail.recordDetailWithLabel` instead of splicing it
+  // into an English template lets each pack choose its own word order; the
+  // no-label branch reuses the overlay's own key rather than a twin.
+  //
+  // English output is unchanged in all three branches (`Contacts Detail` /
+  // `Contacts Detail` / `Record Detail`), including with no `I18nProvider`
+  // mounted — `createSafeTranslation`'s fallback interpolates `{{label}}` from
+  // `GRID_DEFAULT_TRANSLATIONS`.
   const detailTitle = schema.label
-    ? `${schema.label} Detail`
+    ? t('detail.recordDetailWithLabel', { label: schema.label })
     : schema.objectName
-      ? `${schema.objectName.charAt(0).toUpperCase() + schema.objectName.slice(1)} Detail`
-      : 'Record Detail';
+      ? t('detail.recordDetailWithLabel', {
+          label: schema.objectName.charAt(0).toUpperCase() + schema.objectName.slice(1),
+        })
+      : t('detail.recordDetail');
 
   // Form-based record detail renderer (replaces simple key-value dump).
   // Hoisted above the mobile card-view's early return (below) so both the

--- a/packages/plugin-grid/src/__tests__/ObjectGrid.overlayTitleI18n.test.tsx
+++ b/packages/plugin-grid/src/__tests__/ObjectGrid.overlayTitleI18n.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ObjectGrid`'s record-detail overlay heading speaks the session locale —
+ * objectui#3426.
+ *
+ * ── Why this path is user-reachable (the issue left it unverified) ─────────
+ * `object-grid` / `grid` are PUBLIC page blocks (`packages/core/src/registry/
+ * public-blocks.ts`) and `navigation` is an authorable key on the grid schema
+ * (`ViewNavigationConfig`, aligned with `@objectstack/spec ListView.navigation`).
+ * `useNavigationOverlay` turns `mode: 'drawer' | 'modal' | 'split' | 'popover'`
+ * into `isOverlay`, and `ObjectGrid` wires `navigation.handleClick` onto every
+ * row. So any page metadata that drops a grid block with an overlay navigation
+ * mode gets this drawer — no console/app-shell involvement.
+ *
+ * The one host that DOES suppress it is `app-shell`'s `ObjectView`, which
+ * passes its own `onRowClick` (that takes full priority inside
+ * `useNavigationOverlay`) and renders its own overlay. That is a host override,
+ * not proof the branch is dead: `ObjectView` is one consumer of a public block.
+ *
+ * ── Direction of these assertions ─────────────────────────────────────────
+ * The non-English cases (zh / ja / de) were RED before the change — the drawer
+ * was titled by a TypeScript template literal (`` `${schema.label} Detail` ``),
+ * so a zh session read "Contacts Detail" — and are GREEN after. The `en` cases
+ * were GREEN before AND after: they pin that routing the heading through `t()`
+ * did not change a single byte of what an English session sees, in all three
+ * branches (label / objectName / neither).
+ *
+ * The provider-less fallback is asserted in
+ * `ObjectGrid.overlayTitleNoProviderFallback.test.tsx` — it cannot live in this
+ * file, because `createI18n` registers its instance as react-i18next's
+ * module-global default and that registration survives `cleanup()`; a
+ * "no provider" render in this file would silently resolve against whichever
+ * locale a previous test mounted.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+import { ObjectGrid } from '../ObjectGrid';
+
+registerAllFields();
+
+const rows = [
+  { id: '1', name: 'Alice' },
+  { id: '2', name: 'Bob' },
+];
+
+function renderGridIn(language: string, schemaExtra: Record<string, unknown>) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <ActionProvider>
+        <ObjectGrid
+          schema={{
+            type: 'object-grid',
+            objectName: 'contacts',
+            columns: [{ field: 'name', label: 'Name' }],
+            data: { provider: 'value', items: rows },
+            navigation: { mode: 'drawer' },
+            ...schemaExtra,
+          } as never}
+        />
+      </ActionProvider>
+    </I18nProvider>,
+  );
+}
+
+/** Open the detail overlay the way a user does: click a row. */
+async function openOverlay() {
+  const cell = await screen.findByText('Alice');
+  fireEvent.click(cell);
+  await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+}
+
+afterEach(() => cleanup());
+
+describe('ObjectGrid record-detail overlay heading (objectui#3426)', () => {
+  it('renders the authored label in English under an en session', async () => {
+    renderGridIn('en', { label: 'Contacts' });
+    await openOverlay();
+
+    expect(screen.getByText('Contacts Detail')).toBeInTheDocument();
+  });
+
+  it('renders the zh bundle value under a zh session', async () => {
+    renderGridIn('zh', { label: '联系人' });
+    await openOverlay();
+
+    expect(screen.getByText('联系人详情')).toBeInTheDocument();
+    // The whole point of the issue: no English leaks into a zh drawer.
+    expect(screen.queryByText('联系人 Detail')).toBeNull();
+  });
+
+  it('renders the ja bundle value under a ja session', async () => {
+    renderGridIn('ja', { label: '取引先' });
+    await openOverlay();
+
+    expect(screen.getByText('取引先の詳細')).toBeInTheDocument();
+  });
+
+  it('renders the de bundle value under a de session', async () => {
+    renderGridIn('de', { label: 'Kontakte' });
+    await openOverlay();
+
+    expect(screen.getByText('Kontakte-Details')).toBeInTheDocument();
+  });
+
+  /**
+   * Second branch: no `label`, so the heading is built from the capitalized
+   * `objectName`. Same key, same interpolation — this exists because the
+   * branch is separately spelled in the source and a partial fix would leave
+   * it English.
+   */
+  it('falls back to the capitalized objectName through the same key', async () => {
+    renderGridIn('zh', {});
+    await openOverlay();
+
+    expect(screen.getByText('Contacts详情')).toBeInTheDocument();
+  });
+
+  /**
+   * Third branch: neither label nor objectName — reuses `detail.recordDetail`,
+   * the very key `NavigationOverlay` defaults to. Pins that the two headings
+   * cannot drift into two different translations of one control.
+   */
+  it('reuses detail.recordDetail when the schema names nothing', async () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <ActionProvider>
+          <ObjectGrid
+            schema={{
+              type: 'object-grid',
+              columns: [{ field: 'name', label: 'Name' }],
+              data: { provider: 'value', items: rows },
+              navigation: { mode: 'drawer' },
+            } as never}
+          />
+        </ActionProvider>
+      </I18nProvider>,
+    );
+    await openOverlay();
+
+    expect(screen.getByText('记录详情')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-grid/src/__tests__/ObjectGrid.overlayTitleNoProviderFallback.test.tsx
+++ b/packages/plugin-grid/src/__tests__/ObjectGrid.overlayTitleNoProviderFallback.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ObjectGrid`'s record-detail overlay heading still resolves to ENGLISH, and
+ * to the SAME BYTES as before, when no `I18nProvider` is mounted —
+ * objectui#3426.
+ *
+ * This is not a nice-to-have. Routing a literal through `t()` without a working
+ * default is exactly how a provider-less consumer breaks, and it breaks in a
+ * suite that is not this one: `object-grid` is a public page block, so any host
+ * that renders schema without mounting a provider (this package's own tests,
+ * the preview gallery, an embedding app) reads whatever the defaults map says.
+ * The English defaults live in `GRID_DEFAULT_TRANSLATIONS` (`ObjectGrid.tsx`) —
+ * that map is what `createSafeTranslation` falls back to when its `grid.actions`
+ * probe comes back unresolved.
+ *
+ * The byte-identity matters beyond aesthetics: the heading is `Contacts Detail`
+ * before the change and `Contacts Detail` after, so e2e specs and host tests
+ * that address this chrome by its English name keep addressing it.
+ *
+ * Direction: this file was GREEN before the change and is GREEN after. It pins
+ * the FALLBACK, not the fix — the fix is asserted in
+ * `ObjectGrid.overlayTitleI18n.test.tsx`. A missing map entry would have turned
+ * it red by rendering the raw key `detail.recordDetailWithLabel`, which is
+ * precisely the regression it exists to catch.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, and `initReactI18next`
+ * registers that instance as **react-i18next's module-global default**. The
+ * registration survives unmount and `cleanup()`. So the moment any test in a
+ * file mounts `<I18nProvider config={{ defaultLanguage: 'zh' }}>`, every later
+ * "no provider" render in that same file silently resolves against the Chinese
+ * instance — a green-looking file that asserts nothing about the fallback.
+ *
+ * Vitest's `dom` project runs with `isolate: true`, so a file that never mounts
+ * a provider gets a genuinely clean global. Keep it that way: **do not import
+ * or mount `I18nProvider` here.**
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+import { ObjectGrid } from '../ObjectGrid';
+
+registerAllFields();
+
+const rows = [
+  { id: '1', name: 'Alice' },
+  { id: '2', name: 'Bob' },
+];
+
+function renderGrid(schemaExtra: Record<string, unknown>) {
+  return render(
+    <ActionProvider>
+      <ObjectGrid
+        schema={{
+          type: 'object-grid',
+          columns: [{ field: 'name', label: 'Name' }],
+          data: { provider: 'value', items: rows },
+          navigation: { mode: 'drawer' },
+          ...schemaExtra,
+        } as never}
+      />
+    </ActionProvider>,
+  );
+}
+
+async function openOverlay() {
+  const cell = await screen.findByText('Alice');
+  fireEvent.click(cell);
+  await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+}
+
+afterEach(() => cleanup());
+
+describe('ObjectGrid overlay heading — English fallback with no provider (objectui#3426)', () => {
+  it('interpolates the authored label in English, never the raw key', async () => {
+    renderGrid({ objectName: 'contacts', label: 'Contacts' });
+    await openOverlay();
+
+    expect(screen.getByText('Contacts Detail')).toBeInTheDocument();
+    expect(screen.queryByText('detail.recordDetailWithLabel')).toBeNull();
+  });
+
+  it('capitalizes objectName in English when no label is authored', async () => {
+    renderGrid({ objectName: 'contacts' });
+    await openOverlay();
+
+    expect(screen.getByText('Contacts Detail')).toBeInTheDocument();
+  });
+
+  it('falls back to the bare English heading when the schema names nothing', async () => {
+    renderGrid({});
+    await openOverlay();
+
+    expect(screen.getByText('Record Detail')).toBeInTheDocument();
+    expect(screen.queryByText('detail.recordDetail')).toBeNull();
+  });
+});

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -409,6 +409,15 @@ const LIST_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'grid.toolbar.densityCycleShortHint': 'Click to cycle',
   'list.viewSettings': 'View settings',
   'list.viewSettingsHint': 'Grouping, color, density, and visible fields.',
+  // Heading of the record-detail overlay this view opens when a child view's
+  // row is clicked (objectui#3426). Borrowed from the `detail.*` namespace
+  // rather than minted as `list.recordDetail`: `NavigationOverlay` already
+  // resolves `detail.recordDetail` for hosts that pass no title, and one
+  // heading on one control should not get two translations that can drift
+  // apart. Both entries must exist HERE too — a provider-less host (a
+  // standalone list, this package's own tests) never reaches the locale packs.
+  'detail.recordDetail': 'Record Detail',
+  'detail.recordDetailWithLabel': '{{label}} Detail',
 };
 
 /**
@@ -1407,6 +1416,28 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     onNavigate: schema.onNavigate,
     onRowClick,
   });
+
+  // Heading of the record-detail overlay rendered at the bottom of this file.
+  //
+  // Keyed, not string-built (objectui#3426). This value is handed to
+  // `NavigationOverlay`'s `title` prop, which means the overlay's own
+  // `detail.recordDetail` default never applies here — whatever this computes
+  // IS the visible heading of the drawer/modal/split/popover. Interpolating
+  // the label through `detail.recordDetailWithLabel` instead of splicing it
+  // into an English template lets each pack choose its own word order; the
+  // no-label branch reuses the overlay's own key rather than a twin.
+  //
+  // English output is unchanged in all three branches (`Contacts Detail` /
+  // `Contacts Detail` / `Record Detail`), including with no `I18nProvider`
+  // mounted — `createSafeTranslation`'s fallback interpolates `{{label}}` from
+  // `LIST_DEFAULT_TRANSLATIONS`.
+  const detailTitle = schema.label
+    ? t('detail.recordDetailWithLabel', { label: schema.label })
+    : schema.objectName
+      ? t('detail.recordDetailWithLabel', {
+          label: schema.objectName.charAt(0).toUpperCase() + schema.objectName.slice(1),
+        })
+      : t('detail.recordDetail');
 
   // Field-level permission gate. Filter unreadable columns from the
   // field list BEFORE any downstream column construction so they also
@@ -2847,13 +2878,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       {navigation.isOverlay && (
         <NavigationOverlay
           {...navigation}
-          title={
-            schema.label
-              ? `${schema.label} Detail`
-              : schema.objectName
-                ? `${schema.objectName.charAt(0).toUpperCase() + schema.objectName.slice(1)} Detail`
-                : 'Record Detail'
-          }
+          title={detailTitle}
         >
           {(record) => (
             <div className="space-y-3">

--- a/packages/plugin-list/src/__tests__/ListView.overlayTitleI18n.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.overlayTitleI18n.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ListView`'s record-detail overlay heading speaks the session locale —
+ * objectui#3426.
+ *
+ * ── Why this path is user-reachable (the issue left it unverified) ─────────
+ * `list-view` / `list` are PUBLIC page blocks (`packages/core/src/registry/
+ * public-blocks.ts`) and `navigation` is an authorable key on the list schema
+ * (`ViewNavigationConfig`, aligned with `@objectstack/spec ListView.navigation`).
+ * `useNavigationOverlay` turns `mode: 'drawer' | 'modal' | 'split' | 'popover'`
+ * into `isOverlay`; `ListView` forwards `navigation.handleClick` to whichever
+ * child view it renders (`viewComponentSchema.onRowClick`) and owns the overlay
+ * itself. So any page metadata that drops a list block with an overlay
+ * navigation mode gets this drawer — no console/app-shell involvement.
+ *
+ * The one host that DOES suppress it is `app-shell`'s `ObjectView`, which
+ * passes its own `onRowClick` (that takes full priority inside
+ * `useNavigationOverlay`) and renders its own overlay. That is a host override,
+ * not proof the branch is dead: `ObjectView` is one consumer of a public block.
+ *
+ * The child view is stubbed (same pattern as `ListView.test.tsx`'s inline-edit
+ * spy) so the row click under test is ListView's OWN `onRowClick` contract with
+ * its child, not a re-test of `ObjectGrid`'s row rendering — `plugin-list` does
+ * not depend on `plugin-grid`.
+ *
+ * ── Direction of these assertions ─────────────────────────────────────────
+ * The non-English cases (zh / ja / de) were RED before the change — the drawer
+ * was titled by a TypeScript template literal (`` `${schema.label} Detail` ``),
+ * so a zh session read "Contacts Detail" — and are GREEN after. The `en` case
+ * was GREEN before AND after: it pins that routing the heading through `t()`
+ * did not change a single byte of what an English session sees.
+ *
+ * The provider-less fallback is asserted in
+ * `ListView.overlayTitleNoProviderFallback.test.tsx` — it cannot live in this
+ * file, because `createI18n` registers its instance as react-i18next's
+ * module-global default and that registration survives `cleanup()`.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { SchemaRendererProvider } from '@object-ui/react';
+import { ListView } from '../ListView';
+import type { ListViewSchema } from '@object-ui/types';
+
+const rows = [{ id: '1', name: 'Alice' }];
+
+const mockDataSource = {
+  find: vi.fn().mockResolvedValue(rows),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+let prevObjectGrid: ReturnType<typeof ComponentRegistry.get>;
+
+beforeAll(() => {
+  prevObjectGrid = ComponentRegistry.get('object-grid');
+  // Minimal stand-in for the real grid: exposes the row-click affordance
+  // ListView hands every child view, and nothing else.
+  ComponentRegistry.register('object-grid', (props: never) => {
+    const onRowClick = (props as { onRowClick?: (r: unknown) => void }).onRowClick;
+    return (
+      <button type="button" data-testid="stub-row" onClick={() => onRowClick?.(rows[0])}>
+        row
+      </button>
+    );
+  });
+});
+
+afterAll(() => {
+  if (prevObjectGrid) ComponentRegistry.register('object-grid', prevObjectGrid);
+  else ComponentRegistry.unregister('object-grid');
+});
+
+afterEach(() => cleanup());
+
+function renderListIn(language: string, schemaExtra: Partial<ListViewSchema>) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <SchemaRendererProvider dataSource={mockDataSource}>
+        <ListView
+          schema={{
+            type: 'list-view',
+            objectName: 'contacts',
+            viewType: 'grid',
+            fields: ['name'],
+            navigation: { mode: 'drawer' },
+            ...schemaExtra,
+          } as ListViewSchema}
+          dataSource={mockDataSource}
+        />
+      </SchemaRendererProvider>
+    </I18nProvider>,
+  );
+}
+
+/** Open the detail overlay the way a user does: click a row in the child view. */
+async function openOverlay() {
+  fireEvent.click(await screen.findByTestId('stub-row'));
+  await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+}
+
+describe('ListView record-detail overlay heading (objectui#3426)', () => {
+  it('renders the authored label in English under an en session', async () => {
+    renderListIn('en', { label: 'Contacts' });
+    await openOverlay();
+
+    expect(screen.getByText('Contacts Detail')).toBeInTheDocument();
+  });
+
+  it('renders the zh bundle value under a zh session', async () => {
+    renderListIn('zh', { label: '联系人' });
+    await openOverlay();
+
+    expect(screen.getByText('联系人详情')).toBeInTheDocument();
+    // The whole point of the issue: no English leaks into a zh drawer.
+    expect(screen.queryByText('联系人 Detail')).toBeNull();
+  });
+
+  it('renders the ja bundle value under a ja session', async () => {
+    renderListIn('ja', { label: '取引先' });
+    await openOverlay();
+
+    expect(screen.getByText('取引先の詳細')).toBeInTheDocument();
+  });
+
+  it('renders the de bundle value under a de session', async () => {
+    renderListIn('de', { label: 'Kontakte' });
+    await openOverlay();
+
+    expect(screen.getByText('Kontakte-Details')).toBeInTheDocument();
+  });
+
+  /**
+   * Second branch: no `label`, so the heading is built from the capitalized
+   * `objectName`. Same key, same interpolation — this exists because the
+   * branch is separately spelled in the source and a partial fix would leave
+   * it English.
+   */
+  it('falls back to the capitalized objectName through the same key', async () => {
+    renderListIn('zh', {});
+    await openOverlay();
+
+    expect(screen.getByText('Contacts详情')).toBeInTheDocument();
+  });
+
+  /**
+   * Third branch: neither label nor objectName — reuses `detail.recordDetail`,
+   * the very key `NavigationOverlay` defaults to. Pins that the two headings
+   * cannot drift into two different translations of one control.
+   *
+   * Rows come from inline `data` here: with no `objectName` there is nothing
+   * for the data-source fetch to query, so the view would paint its empty
+   * state and render no child view at all.
+   */
+  it('reuses detail.recordDetail when the schema names nothing', async () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <SchemaRendererProvider dataSource={mockDataSource}>
+          <ListView
+            schema={{
+              type: 'list-view',
+              viewType: 'grid',
+              fields: ['name'],
+              data: { provider: 'value', items: rows },
+              navigation: { mode: 'drawer' },
+            } as unknown as ListViewSchema}
+            dataSource={mockDataSource}
+          />
+        </SchemaRendererProvider>
+      </I18nProvider>,
+    );
+    await openOverlay();
+
+    expect(screen.getByText('记录详情')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-list/src/__tests__/ListView.overlayTitleNoProviderFallback.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.overlayTitleNoProviderFallback.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ListView`'s record-detail overlay heading still resolves to ENGLISH, and to
+ * the SAME BYTES as before, when no `I18nProvider` is mounted — objectui#3426.
+ *
+ * This is not a nice-to-have. Routing a literal through `t()` without a working
+ * default is exactly how a provider-less consumer breaks, and it breaks in a
+ * suite that is not this one: `list-view` is a public page block, so any host
+ * that renders schema without mounting a provider (this package's own tests,
+ * the preview gallery, an embedding app) reads whatever the defaults map says.
+ * The English defaults live in `LIST_DEFAULT_TRANSLATIONS` (`ListView.tsx`) —
+ * that map is what `createSafeTranslation` falls back to when its
+ * `list.recordCount` probe comes back unresolved.
+ *
+ * The byte-identity matters beyond aesthetics: the heading is `Contacts Detail`
+ * before the change and `Contacts Detail` after, so e2e specs and host tests
+ * that address this chrome by its English name keep addressing it.
+ *
+ * Direction: this file was GREEN before the change and is GREEN after. It pins
+ * the FALLBACK, not the fix — the fix is asserted in
+ * `ListView.overlayTitleI18n.test.tsx`. A missing map entry would have turned
+ * it red by rendering the raw key `detail.recordDetailWithLabel`, which is
+ * precisely the regression it exists to catch.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, and `initReactI18next`
+ * registers that instance as **react-i18next's module-global default**. The
+ * registration survives unmount and `cleanup()`. So the moment any test in a
+ * file mounts `<I18nProvider config={{ defaultLanguage: 'zh' }}>`, every later
+ * "no provider" render in that same file silently resolves against the Chinese
+ * instance — a green-looking file that asserts nothing about the fallback.
+ *
+ * Vitest's `dom` project runs with `isolate: true`, so a file that never mounts
+ * a provider gets a genuinely clean global. Keep it that way: **do not import
+ * or mount `I18nProvider` here.**
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRendererProvider } from '@object-ui/react';
+import { ListView } from '../ListView';
+import type { ListViewSchema } from '@object-ui/types';
+
+const rows = [{ id: '1', name: 'Alice' }];
+
+const mockDataSource = {
+  find: vi.fn().mockResolvedValue(rows),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+let prevObjectGrid: ReturnType<typeof ComponentRegistry.get>;
+
+beforeAll(() => {
+  prevObjectGrid = ComponentRegistry.get('object-grid');
+  ComponentRegistry.register('object-grid', (props: never) => {
+    const onRowClick = (props as { onRowClick?: (r: unknown) => void }).onRowClick;
+    return (
+      <button type="button" data-testid="stub-row" onClick={() => onRowClick?.(rows[0])}>
+        row
+      </button>
+    );
+  });
+});
+
+afterAll(() => {
+  if (prevObjectGrid) ComponentRegistry.register('object-grid', prevObjectGrid);
+  else ComponentRegistry.unregister('object-grid');
+});
+
+afterEach(() => cleanup());
+
+function renderList(schemaExtra: Record<string, unknown>) {
+  return render(
+    <SchemaRendererProvider dataSource={mockDataSource}>
+      <ListView
+        schema={{
+          type: 'list-view',
+          viewType: 'grid',
+          fields: ['name'],
+          data: { provider: 'value', items: rows },
+          navigation: { mode: 'drawer' },
+          ...schemaExtra,
+        } as unknown as ListViewSchema}
+        dataSource={mockDataSource}
+      />
+    </SchemaRendererProvider>,
+  );
+}
+
+async function openOverlay() {
+  fireEvent.click(await screen.findByTestId('stub-row'));
+  await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+}
+
+describe('ListView overlay heading — English fallback with no provider (objectui#3426)', () => {
+  it('interpolates the authored label in English, never the raw key', async () => {
+    renderList({ objectName: 'contacts', label: 'Contacts' });
+    await openOverlay();
+
+    expect(screen.getByText('Contacts Detail')).toBeInTheDocument();
+    expect(screen.queryByText('detail.recordDetailWithLabel')).toBeNull();
+  });
+
+  it('capitalizes objectName in English when no label is authored', async () => {
+    renderList({ objectName: 'contacts' });
+    await openOverlay();
+
+    expect(screen.getByText('Contacts Detail')).toBeInTheDocument();
+  });
+
+  it('falls back to the bare English heading when the schema names nothing', async () => {
+    renderList({});
+    await openOverlay();
+
+    expect(screen.getByText('Record Detail')).toBeInTheDocument();
+    expect(screen.queryByText('detail.recordDetail')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #3426

PR #3423 给 `NavigationOverlay` 的 `resolvedTitle` 接上了 i18n 默认值(`detail.recordDetail`),但两个调用方在传入侧自拼英文标题、直接塞进 `title` prop —— 默认值根本轮不到生效。结果是:一个 zh/ja/de 会话拿到一个通体本地化的抽屉,顶上却挂着唯一一句英文标题。

- `packages/plugin-list/src/ListView.tsx` —— `` `${schema.label} Detail` ``
- `packages/plugin-grid/src/ObjectGrid.tsx` —— 同样的模板串,外加无 label 时的裸字面量 `'Record Detail'`

## 前提核验:这两条路径确实用户可达

Issue 明确把可达性留给实现者判定,这是核验结论(证据均在 `origin/main`):

- `list-view` / `object-grid` 是**公开页面块**(`packages/core/src/registry/public-blocks.ts`),`navigation` 是它们 schema 上的**可编写键**(`ViewNavigationConfig`,对齐 `@objectstack/spec ListView.navigation`)。
- `useNavigationOverlay` 把 `mode: 'drawer' | 'modal' | 'split' | 'popover'` 翻成 `isOverlay`;两个插件都把 `navigation.handleClick` 接到行点击上,并各自渲染 `NavigationOverlay`。
- 所以任何页面元数据只要写下 `navigation: { mode: 'drawer' }`,点行就会开出这个浮层 —— 不经过 console/app-shell。

唯一会**压制**它的宿主是 app-shell 的 `ObjectView`:它传自己的 `onRowClick`(在 `useNavigationOverlay` 里具有最高优先级,直接 return),并渲染自己的 `NavigationOverlay`。那是一个宿主对公开块的覆盖,不能反推分支是死的。

新增的四个测试文件就是这条可达性的可执行证据:它们完全按用户路径打开浮层(点行 → 断言标题),没有任何对内部状态的直接操作。

## 改法(调用方入键,不给消费方加宽容)

两处都改成从 key 取标题,而不是拼字符串:

- 新键 `detail.recordDetailWithLabel`(en: `'{{label}} Detail'`)用插值携带对象标签,这样限定词后置的语种(de 用连字符复合词)或需要领属助词的语种(ja/zh)可以自己排语序,而不是被英文语序焊死;
- 无 label 的分支**复用** `detail.recordDetail` —— 正是浮层自身的默认键 —— 而不是另铸一个孪生键,避免同一个控件上的同一句话分裂成两份会各自漂移的译文。

新键补进**全部十个语言包**,并且同时补进两个插件各自的英文兜底表(`LIST_DEFAULT_TRANSLATIONS` / `GRID_DEFAULT_TRANSLATIONS`)—— 那才是没有挂 `I18nProvider` 时 `createSafeTranslation` 真正读的东西。

## 英文输出逐字节不变

三个分支都不变:`Contacts Detail` / `Contacts Detail` / `Record Detail`,挂 provider 与不挂 provider 皆然(兜底路径里 `createSafeTranslation` 自己会替换 `{{label}}`)。既有 e2e 用英文名寻址这块 chrome 的写法照旧可用。

## 验证方向(先预判,再运行)

| 用例 | 改前 | 改后 |
|---|---|---|
| zh / ja / de(挂 provider) | RED | GREEN |
| en(挂 provider) | GREEN | GREEN(钉住字节不变) |
| 无 provider 兜底 | GREEN | GREEN(钉的是兜底,不是修复) |

反向核验实测(用 `git checkout origin/main --` 取回原始源文件后重跑,再还原):

```
ObjectGrid.overlayTitleI18n.test.tsx     Tests  5 failed | 1 passed (6)
ListView.overlayTitleI18n.test.tsx
  + ListView.overlayTitleNoProviderFallback.test.tsx
                                         Tests  5 failed | 4 passed (9)
```

两次唯一活下来的绿色用例,都正是 `en` 那条 —— 与预判完全一致。

正向全量(仓根,`flock` + `--maxWorkers=2`):

```
pnpm exec vitest run packages/i18n packages/plugin-grid packages/plugin-list
 Test Files  96 passed (96)
      Tests  987 passed (987)
```

`all-locales-key-parity`(含 placeholder 形状比对)覆盖了新键,已在上面这 987 条里绿。

type-check / lint:

```
pnpm --workspace-concurrency=2 --filter @object-ui/plugin-grid --filter @object-ui/plugin-list --filter @object-ui/i18n type-check   → Done ×3
pnpm --workspace-concurrency=2 --filter … lint   → 0 errors(仅存量 warning)
node scripts/check-control-bytes.mjs → OK (3648 tracked text files)
```

远端 CI 已全绿(17 项 success / skipped,含 Test 四个分片、Type Check、Lint、Control Byte Scan、Changeset Bump Policy 与 Fixed Group Check)。

## 关于「为什么兜底测试要单独一个文件」

`createI18n` 会 `instance.use(initReactI18next)`,而 `initReactI18next` 把该实例注册成 react-i18next 的**模块级全局默认**,这个注册在 unmount 和 `cleanup()` 之后依然存活。所以只要同一文件里有任何一个用例挂过 `I18nProvider`(哪怕 `defaultLanguage` 是 zh 且早已卸载),后面所有「不挂 provider」的渲染都会静悄悄地落到那个中文实例上 —— 看起来是绿的,其实什么都没断言。沿用 plugin-detail 在 objectstack#5733 立下的同一处理(两个文件、文件头写清原因)。

## 越界未改(已记录为 out-of-scope)

同一类缺陷在本 PR 文件围栏之外还有三处,均未在此 PR 触碰,已单独立为 #3459(未指派、未打标,待 PM triage):`plugin-kanban/src/ObjectKanban.tsx`(``${objectName} Detail`` 加 `'Card Details'`)、`plugin-tree/src/ObjectTree.tsx`(`title` 直接给字面量 `"Record Details"`)、`plugin-view/src/ObjectView.tsx`(``${objectLabel} Detail``)。
