### PR TITLE
ci(docs): check-doc-links 提升为无路径过滤的独立 workflow，纯 docs PR 也拦得住断链 (#3448)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,30 +320,18 @@ jobs:
           node-version: '22.x'
           cache: 'pnpm'
 
-      # `scripts/check-doc-links.mjs` existed and worked, but nothing under
-      # `.github/` ever called it, so it had never run in CI — it exited 1 on an
-      # untouched `main` for a broken link that had been sitting there (#3213,
-      # #3292). It resolves every `/docs/...` markdown link against
-      # `content/docs/` on the filesystem: no install and no network, so it runs
-      # here — after Node is set up, before the expensive install + site build —
-      # and a bad link fails in seconds instead of after a full Next.js build.
-      #
-      # KNOWN GAP — read before assuming docs links are fully gated: `ci.yml`
-      # lists `content/**` and `'**/*.md'` under `paths-ignore`, and GitHub has
-      # no per-job path filter, so a docs-ONLY pull request never starts this
-      # workflow and is never link-checked. This step therefore covers pull
-      # requests that touch docs alongside code, plus pushes to `main` — not the
-      # pure-docs pull request, which is the likeliest way to break a link.
-      #
-      # `control-bytes.yml` hit this same wall and answered it by being its own
-      # workflow with no path filters, for a gate that likewise needs no install
-      # and no network; its header explains the reasoning, and
-      # `scripts/__tests__/check-control-bytes.test.ts` pins it. Moving this
-      # check to that shape is the known fix, but it changes CI triggering
-      # policy, so it is left to the maintainer — tracked in #3448.
-      - name: Check docs links
-        if: steps.docs-changes.outputs.should_run == 'true'
-        run: node scripts/check-doc-links.mjs
+      # The docs *link* check is deliberately NOT here any more — do not add it
+      # back. `node scripts/check-doc-links.mjs` ran in this job from #3213 /
+      # #3292 (PR #3450) until #3448 promoted it to its own workflow,
+      # `docs-links.yml`, with no path filters. The reason is this workflow's own
+      # `paths-ignore`: it lists `content/**` and `'**/*.md'`, and GitHub has no
+      # per-job path filter, so a docs-ONLY pull request never started `ci.yml`
+      # at all and the link check never saw the class of PR most likely to break
+      # a link. It is removed rather than kept in both places: the standalone
+      # workflow's trigger set is a strict superset of this job's, so a copy here
+      # could only ever add a second red check for the same broken link, and a
+      # second place to forget. `scripts/__tests__/docs-links-workflow.test.ts`
+      # pins the gate to exactly one home.
 
       - name: Turbo Cache
         if: steps.docs-changes.outputs.should_run == 'true'

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -1,0 +1,61 @@
+name: Docs Links
+
+# Why this is its own workflow instead of a step in `ci.yml`'s `docs` job, which
+# is where this check lived when it first reached CI (#3213 / #3292, PR #3450):
+# `ci.yml` lists `'**/*.md'`, `content/**`, `docs/**` and `apps/site/**` under
+# `paths-ignore`, and GitHub has no per-job path filter. The published site is
+# built from `content/docs/**`, so a docs-ONLY pull request matched every ignore
+# pattern, started no workflow at all, and was never link-checked — while a
+# docs-only PR is the likeliest way an internal link breaks in the first place.
+# The step therefore only ever saw PRs that touched docs *alongside code*, plus
+# pushes to `main`; a broken link could land through a pure-docs PR and only turn
+# `main` red later, under an unrelated author (#3448).
+#
+# `control-bytes.yml` hit the same wall and its header names the consequence: a
+# gate that cannot see a markdown-only PR "rebuilds the hole it exists to close".
+# `changeset-guard.yml` is the second instance of the shape in this repo.
+#
+# Hence: no `paths` and no `paths-ignore` here, deliberately.
+# `scripts/__tests__/docs-links-workflow.test.ts` fails if either is ever added.
+# A `paths: content/**` filter would look tighter and buy nothing measurable: the
+# whole run is a checkout plus one `node` call — no install, no network, a few
+# seconds — and the filter would be a second, drift-prone copy of the script's
+# own scan surface. Keep it that way if you add checks here.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: docs-links-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docs-links:
+    name: Internal Docs Link Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.x'
+
+      # Resolves every relative / `/docs/...` markdown link found in
+      # `content/docs/**` against the files actually on disk. Reads the checkout
+      # and nothing else, so no install is required. External URLs are a
+      # different problem with a different tool — Lychee, in `check-links.yml`,
+      # which is manual-dispatch only and scans `docs/` rather than
+      # `content/docs/` (#3449).
+      - name: Check internal docs links
+        run: node scripts/check-doc-links.mjs

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -27,6 +27,7 @@ one has its own section below.
 | `lint.yml` | Lint | Push / PR to `main`, `develop`; manual | **Yes** — ESLint **errors** only |
 | `changeset-guard.yml` | Changeset Bump Policy | PR / push touching `.changeset/**` | **Yes** |
 | `control-bytes.yml` | Control Byte Scan | Push / PR to `main`, `develop` — **no path filter**; manual | **Yes** |
+| `docs-links.yml` | Internal Docs Link Check | Push / PR to `main`, `develop` — **no path filter**; manual | **Yes** |
 | `performance-budget.yml` | Bundle Analysis | Push / PR touching `packages/**`, `apps/console/**`, `pnpm-lock.yaml` | **Yes** — the console entry gzip budget |
 | `live-e2e.yml` | Live E2E (informational) | PR to `main`, `develop` (code paths); nightly cron `30 6 * * *`; manual | No — informational lane, `continue-on-error` |
 | `labeler.yml` | Auto Label PRs | PR `opened`, `synchronize`, `reopened` | No |
@@ -39,13 +40,16 @@ one has its own section below.
 | `shadcn-check.yml` | Check Shadcn Components | Weekly cron `0 9 * * 1`; manual | n/a |
 | `check-links.yml` | Check Links | Manual dispatch only | n/a |
 
-Two path-filter facts explain most "why did nothing run on my PR?" questions:
+The path filters explain most "why did nothing run on my PR?" questions:
 
 - `ci.yml` and `lint.yml` both list `**/*.md`, `content/**`, `docs/**` and `.changeset/**` under
   `paths-ignore` (`ci.yml` also ignores `apps/site/**`). A docs-only or changeset-only PR starts
   neither of them.
 - `changeset-guard.yml` carries the inverse filter — it runs *only* when `.changeset/**` changes,
   which is precisely why it is a separate workflow instead of a job inside `ci.yml`.
+- `control-bytes.yml` and `docs-links.yml` carry **no** filter of any kind, which is equally
+  deliberate: both guard markdown, and a gate that a markdown-only PR cannot start is no gate on
+  the change most likely to trip it. Both cost a checkout plus one `node` call.
 
 ## Core CI Workflow (`ci.yml`)
 
@@ -61,7 +65,7 @@ Seven jobs, all parallel — there are no `needs:` edges between them:
 | `test` | Test (shard N/4) | `pnpm test --shard=N/4` across a 4-runner matrix with `fail-fast: false`, so every shard reports its own failures. No coverage instrumentation — v8 adds 40–100% overhead. | **Pull requests only** |
 | `test-coverage` | Test (coverage) | One unsharded `pnpm test:coverage`, uploaded to Codecov. Nothing blocks on it, which is why it is not sharded. | **Push only** |
 | `e2e` | Build & E2E | Builds the console with `vite build` (`VITE_BASE_PATH=/console/`), verifies the artifact, then `pnpm test:e2e --project=chromium`. Uploads the Playwright report on failure. | Every run |
-| `docs` | Build Docs | `scripts/check-doc-links.mjs` (resolves every `/docs/...` markdown link against `content/docs/` — no install, no network), then `turbo run build --filter='@object-ui/site'`. On a PR it first diffs against the base and skips both when nothing under `apps/site/` or `content/` changed. | Every run (steps themselves conditional) |
+| `docs` | Build Docs | `turbo run build --filter='@object-ui/site'`. On a PR it first diffs against the base and skips the build when nothing under `apps/site/` or `content/` changed. It does **not** check docs links any more — that moved to `docs-links.yml` (#3448), because this workflow's `paths-ignore` hides exactly the docs-only PRs a link check needs to see. | Every run (build itself conditional) |
 | `dev-server` | Dev-server fixture build | `pnpm --filter @object-ui/dev-server build` — guards `apps/dev-server`'s `objectstack.config.ts` against fixture / `@objectstack/spec` drift. | Every run |
 
 Uses: Node 22.x, pnpm via `corepack`, `actions/cache` over `.turbo/cache`.
@@ -213,6 +217,45 @@ Playwright report and job summary.
 Backend pins live in `e2e/live/ci/backend.env` and must match the `@objectstack/spec` version in
 `pnpm-lock.yaml` — bump both in the same PR, or the run proves nothing.
 
+## Internal Docs Links (`docs-links.yml`)
+
+**Triggers:** Push and PR to `main`/`develop`, plus manual dispatch — with **no path filter at
+all**, which is the point of the workflow. It appears in the checks list as **Internal Docs Link
+Check**.
+
+Runs `scripts/check-doc-links.mjs`, which walks every `.md` / `.mdx` file under `content/docs/` and
+resolves each internal markdown link against the files actually on disk (`/docs/foo` must have a
+`foo.md`, `foo.mdx` or `foo/index.md*` under `content/docs/`). External `http(s)` and `mailto:`
+links and bare `#anchors` are skipped — those belong to Lychee, below. No install, no build, no
+network: a checkout and one `node` call.
+
+**Why it blocks a merge.** A broken internal link is a 404 on the published site, and nothing else
+in CI sees it: the site build succeeds with a dead link in it. The script itself is older than its
+gate — it existed, worked, and was wired to nothing under `.github/`, so it had never run in CI at
+all, and `main` sat with a broken link it would have caught (objectui#3213, objectui#3292).
+
+**Why it is a separate workflow.** This is the second instance of the lesson `control-bytes.yml`
+records, and it was found by the PR that first put this check into CI. That PR added it as a step
+in `ci.yml`'s `docs` job — where it could never see the PRs that matter. `ci.yml` lists
+`'**/*.md'`, `content/**`, `docs/**` and `apps/site/**` under `paths-ignore`, GitHub's
+`paths-ignore` skips the *whole workflow* when every changed file matches, and GitHub has no
+per-job path filter. So a **docs-only** PR — the likeliest way an internal link breaks — started no
+workflow at all, and the check only ever ran on PRs that touched docs alongside code, plus pushes
+to `main`. A bad link could merge through a pure-docs PR and turn `main` red later under an
+unrelated author (objectui#3448).
+
+The step was **removed** from `ci.yml` in the same change rather than left in place. This
+workflow's trigger set is a strict superset of that job's, so keeping both would only add a second
+red check for one broken link, and a second place to forget.
+`scripts/__tests__/docs-links-workflow.test.ts` pins all of it: the workflow must exist, must gate
+pull requests, must carry neither `paths` nor `paths-ignore`, and must remain the only workflow
+that runs the script.
+
+**If it fails:** it prints every offending `file -> href`. Either the link is misspelled, or the
+page it points at has moved or been renamed — fix the link, or restore the target. Links are
+checked as *routes*, so `/docs/guide/foo` is what belongs in the markdown, not
+`content/docs/guide/foo.md`. Run it locally with `pnpm docs:check-links`.
+
 ## Link Checking (`check-links.yml`)
 
 **Trigger:** Manual workflow dispatch (`workflow_dispatch`).
@@ -221,17 +264,17 @@ There are **two** link checkers, and they cover different things (objectui#3213)
 
 | | Covers | Network | Runs |
 |---|---|---|---|
-| `scripts/check-doc-links.mjs` | **Internal** `/docs/...` routes, resolved against `content/docs/` | No | In `ci.yml`'s `docs` job — see the job table above |
+| `scripts/check-doc-links.mjs` | **Internal** `/docs/...` routes, resolved against `content/docs/` | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
 | Lychee (this workflow) | **External** URLs in `docs/` and `README.md` | Yes | Manual dispatch only |
 
 Note the asymmetry in what Lychee scans: `docs/` holds internal material (ADRs, audits,
 architecture notes), while the published site is built from `content/docs/`. Lychee therefore does
 not currently see the site's own pages.
 
-Two known gaps are tracked rather than silently lived with: `ci.yml` lists `content/**` under
-`paths-ignore` and GitHub has no per-job path filter, so a **docs-only** PR does not start `ci.yml`
-and is not link-checked (objectui#3448); and Lychee's scan scope predates the move to
-`content/docs/` (objectui#3449).
+One known gap remains tracked rather than silently lived with: Lychee's scan scope predates the
+move to `content/docs/` (objectui#3449), so **external** URLs on the published site's own pages are
+checked by nothing. The gap that used to sit beside it — docs-only PRs never being link-checked,
+because `ci.yml` ignores `content/**` — is closed: that check is now `docs-links.yml` (objectui#3448).
 
 Uses [Lychee](https://github.com/lycheeverse/lychee) with configuration from `lychee.toml`:
 - Scans markdown files in `docs/` and `README.md`

--- a/scripts/__tests__/docs-links-workflow.test.ts
+++ b/scripts/__tests__/docs-links-workflow.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3448 — the wiring test for `scripts/check-doc-links.mjs`.
+ *
+ * The script is older than its gate. It existed, worked, and nothing under
+ * `.github/` called it, so it had never run in CI at all and `main` carried a
+ * broken link it would have caught (#3213, #3292). PR #3450 fixed that by adding
+ * it as a step in `ci.yml`'s `docs` job — and rebuilt half the hole in the
+ * process: `ci.yml` lists every markdown path, plus `content/**`, `docs/**` and
+ * `apps/site/**`, under `paths-ignore`; `paths-ignore` skips the *entire*
+ * workflow when every changed file matches it, and GitHub has no per-job path
+ * filter. A docs-only PR therefore started no workflow, so the one class of
+ * change most likely to break an internal link was the one class the link check
+ * could never see.
+ *
+ * `control-bytes.yml` hit this exact wall first and its header states the
+ * consequence: a gate that cannot see a markdown-only PR "rebuilds the hole it
+ * exists to close". `changeset-guard.yml` is the second instance. This is the
+ * third, and the test below is what keeps it from regressing — the failure mode
+ * is silent by construction, because a path-filtered gate looks green and
+ * configured while simply never running.
+ *
+ * The last assertion pins the de-duplication decision, not just the shape: the
+ * check has exactly ONE home. Re-adding a copy to a path-filtered workflow is
+ * the specific mistake that would restore the illusion of coverage.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowDir = path.join(repoRoot, '.github/workflows');
+const workflowPath = path.join(workflowDir, 'docs-links.yml');
+const SCRIPT = 'scripts/check-doc-links.mjs';
+
+/**
+ * A workflow's YAML with whole-line comments removed.
+ *
+ * Required, not cosmetic: `ci.yml` still *names* the script in the comment that
+ * explains why the step was removed, and this workflow's own header discusses
+ * `paths` / `paths-ignore` in prose. A scan that counted those would report a
+ * duplicate gate and a path filter that neither file has.
+ */
+function withoutComments(yaml: string): string {
+  return yaml
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+}
+
+const workflowFiles = fs.readdirSync(workflowDir).filter((f) => f.endsWith('.yml'));
+
+describe('docs-links.yml — the internal link gate is reachable', () => {
+  it('exists at all', () => {
+    expect(fs.existsSync(workflowPath), 'a check nothing runs is not a gate').toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, SCRIPT)), `${SCRIPT} must exist for the workflow to run it`).toBe(true);
+  });
+
+  it('runs the link checker', () => {
+    expect(withoutComments(fs.readFileSync(workflowPath, 'utf8'))).toMatch(
+      new RegExp(`run:\\s*node\\s+${SCRIPT.replace(/[.]/g, '\\.')}`),
+    );
+  });
+
+  it('gates pull requests, not just pushes', () => {
+    const yaml = withoutComments(fs.readFileSync(workflowPath, 'utf8'));
+    expect(yaml).toMatch(/^\s*pull_request:/m);
+    expect(yaml).toMatch(/^\s*push:/m);
+  });
+
+  it('carries NO path filter of any kind', () => {
+    // The whole reason this is its own workflow. `paths-ignore` would recreate
+    // #3448 verbatim; a `paths: content/**` filter would look tighter and buy
+    // nothing — the run is a checkout plus one `node` call, and the filter would
+    // be a second copy of the script's scan surface, free to drift from it.
+    const yaml = withoutComments(fs.readFileSync(workflowPath, 'utf8'));
+    expect(yaml).not.toMatch(/paths-ignore:/);
+    expect(yaml).not.toMatch(/^\s+paths:/m);
+  });
+
+  it('is the only workflow that runs the link checker', () => {
+    // Not tidiness: a second copy living in a path-filtered workflow is exactly
+    // how a gate ends up looking covered while the docs-only PR still slips
+    // past. One gate, one home — and one place to fix when it needs changing.
+    const runners = workflowFiles.filter((f) =>
+      withoutComments(fs.readFileSync(path.join(workflowDir, f), 'utf8')).includes(SCRIPT),
+    );
+    expect(runners).toEqual(['docs-links.yml']);
+  });
+
+  it('every workflow that runs it is one a docs-only PR can start', () => {
+    // States the invariant rather than the file name, so it still holds if the
+    // gate is ever moved or renamed: whoever runs this check must be startable
+    // by a PR that touches nothing but markdown.
+    expect(workflowFiles.length, 'the workflow directory scan returned implausibly few files').toBeGreaterThan(5);
+
+    for (const file of workflowFiles) {
+      const yaml = withoutComments(fs.readFileSync(path.join(workflowDir, file), 'utf8'));
+      if (!yaml.includes(SCRIPT)) continue;
+      expect(yaml, `${file} runs ${SCRIPT} behind a paths-ignore — a docs-only PR would not start it`).not.toMatch(
+        /paths-ignore:/,
+      );
+      expect(yaml, `${file} runs ${SCRIPT} behind a paths filter — see objectui#3448`).not.toMatch(/^\s+paths:/m);
+    }
+  });
+
+  it('is runnable locally under the name the docs give', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    expect(pkg.scripts['docs:check-links']).toBe(`node ${SCRIPT}`);
+  });
+});


### PR DESCRIPTION
Fixes #3448

按 PM 裁定采**方案 A**：把 `node scripts/check-doc-links.mjs` 提升为独立 workflow，**无任何路径过滤**，镜像 `control-bytes.yml` 的形状（触发集、最小 checkout、头注解释为什么不能加过滤）。裁定与「形式上偏离维护者 08-03 对 #3213 的『加进 ci.yml 的 docs 任务』原话」的理由已在单上论证：https://github.com/objectstack-ai/objectui/issues/3448#issuecomment-5200799272 —— 那个裁决作出时结构洞尚未被发现，其**意图**（内链断裂 = 硬门禁）在字面落法下对纯 docs PR 恰好失效。

## 问题（已在 origin/main 上复核）

`ci.yml` 的 `paths-ignore` 两处都列着 `'**/*.md'`、`content/**`、`docs/**`、`apps/site/**`；站点文档全在 `content/docs/**`。GitHub 的语义是「改动文件全部命中即整个 workflow 不启动」，且没有 per-job path filter —— 所以**只改文档的 PR 根本不启动 ci.yml**，#3450 加的那一步自然也不跑。它此前只覆盖「文档+代码」混合 PR 与 push 到 main。

## 改动

- **新增 `.github/workflows/docs-links.yml`**：`push` / `pull_request` to `main`+`develop` 加 `workflow_dispatch`，**既无 `paths` 也无 `paths-ignore`**；checkout + setup-node + 一行 `node scripts/check-doc-links.mjs`。无 install、无网络、几秒钟。头注写清为什么路径过滤在这里是错的（`paths: content/**` 看着更紧，实则只是脚本扫描面的第二份副本，会各自漂移）。
- **从 `ci.yml` 的 `docs` job 删掉重复步骤** —— 这一处按最小重复原则由实现者定，我选**删**：新 workflow 的触发集是该 job 的**严格超集**（同样的 main/develop，且无过滤），保留只会为同一条坏链多出一个红勾、多一处会忘记同步的副本。原地留注释说明它去哪了、为什么别加回来；那段已失效的 `KNOWN GAP` 注释一并删除（留着就是假话）。
- **新增 `scripts/__tests__/docs-links-workflow.test.ts`**：workflow 必须存在、必须门禁 PR、必须既无 `paths` 也无 `paths-ignore`、必须是**唯一**跑该脚本的 workflow。最后一条钉的是去重决策本身——把副本加回某个带路径过滤的 workflow，正是会重新制造「看着有覆盖、实则纯 docs PR 照样溜过去」的那个具体错误。扫描前先剥掉整行注释：`ci.yml` 的说明注释里仍提到脚本名，不剥会误报重复门禁。

## ⚠️ 越界说明：`content/docs/guide/ci-cd-pipeline.md`

派单文件面把 `content/docs/**` 列为禁止面。这一条我**越了界**，因为它不是顺手改文档，而是**既有门禁的机械要求**：`scripts/__tests__/ci-cd-pipeline-doc.test.ts` 读 `.github/workflows/` 目录，任一 workflow 在该页没有点名标题就红。先加 workflow、不改文档，实测：

```
AssertionError: These workflows exist in .github/workflows/ but no heading in
content/docs/guide/ci-cd-pipeline.md names them:
  - docs-links.yml
```

该页自己的「Adding a New Workflow」也写着「Give it a section on this page in the same PR. Not a convention — a test.」。改动限于四处必要更正：清单表一行、新章节、ci.yml 任务表里 `docs` 行的更正（它不再跑链接检查）、Link Checking 章节里 #3448 那个「已知缺口」的收口（#3449 那个仍在）。如维护者认为该越界不可接受，我可以拆出去，但那样本 PR 必然是红的。

**与在飞 PR #3456 的交叉**：#3456（#3451）同样在改这个文件与 `ci-cd-pipeline-doc.test.ts`。两边不冲突的部分：它改 `ci.yml` 行与 `dev-server` 幽灵行，我加 `docs-links.yml` 行与新章节；**可能冲突的一处**是任务表里 `docs` 行——我改了它的内容，而它紧邻 #3456 删掉的 `dev-server` 行。两处修改都是有意的，谁后合谁 rebase 时按此说明取并集即可。#3456 不动 `ci.yml`，故 workflow 侧零交叉。

## 验证

- `python yaml.safe_load` 两个 workflow 均解析通过；`docs-links.yml` 的触发集实测为 `{'pull_request': {'branches': ['main','develop']}, 'push': {'branches': ['main','develop']}, 'workflow_dispatch': None}` —— **没有任何 paths 键**。
- `node scripts/check-doc-links.mjs` → `Docs links are valid.` (exit 0)
- `pnpm exec vitest run scripts/`（仓库根，规范调用）→ **9 files / 127 tests passed**
- `node scripts/check-control-bytes.mjs` → OK（3648 文件）；另对本 PR 四个文件做了越出门禁的自扫 `grep -naP`，无命中。
- **反向验证（方向先判后跑，两次均如期）**：把删掉的步骤加回 `ci.yml` → 新测试两处红（`is the only workflow that runs the link checker` 实得 `['ci.yml','docs-links.yml']`；`every workflow that runs it is one a docs-only PR can start` 点名 ci.yml 的 paths-ignore）。给 `docs-links.yml` 加 `paths: content/**` → `carries NO path filter of any kind` 红。

**诚实的覆盖面说明**：本 PR 改的是 `.github/**`，所以它自己既会启动 ci.yml、也会启动新 workflow —— 绿灯只证明「workflow 能在 PR 上跑通」，**证明不了**「纯 docs PR 会启动它」，后者只能由将来某个只改 markdown 的 PR 实证。能在此刻担保它的，是配置本身：`on.pull_request` 只有 `branches`，没有 `paths`/`paths-ignore` 两个键中的任何一个（YAML 解析结果如上），而 GitHub 只在存在过滤键时才做路径判断。这一条同时由上面那条测试机械看守。

## 未做的事

- **无 changeset**：纯 CI 配置，不影响任何包的产物（先例 #3437 / #3450）。
- **`scripts/` 的 type-check 覆盖（单上相邻观察）→ 建议拆单，不顺路**。理由不是错误多（实测 `tsc --noEmit --strict` 跑 `scripts/**/*.ts` 只有 3 个报错，且全是 `.mjs`/`.js` 无声明文件的 TS7016 与一处随之失效的 TS2578），而是**落点全在本 PR 之外**：(1) 它需要 install（typescript + @types/node + vitest 类型），而新 workflow 的全部设计前提是「无 install、无网络、几秒」，还被我的测试钉住了——把 tsc 塞进去等于让纯 docs PR 去等一次完整安装，与 `paths-ignore` 想省的正是同一笔开销；正确的家是 `ci.yml` 的 `type-check` job（那里已有 install 与 turbo 缓存）。(2) 需要为 `scripts/` 决定一个 tsconfig（并入根 include？独立 tsconfig？）并与 `check-type-check-coverage.mjs`（按 **包** 判定覆盖，而 `scripts/` 不是包）对齐。(3) 选定的 `allowJs`/`checkJs` 会机械地改变现有测试里 `@ts-expect-error` 的成立与否，从而必须改动既有测试文件——其中 `ci-cd-pipeline-doc.test.ts` 正被 #3456 占用。三处都在本单文件面之外，硬塞进来就是替维护者做架构决定。查重未能完成：GitHub 搜索/列表 API 对本账号已限流（`API rate limit already exceeded`），与 #3451 的 dev 撞的是同一堵墙，故按 #4949 纪律**不盲目立单**，留给 PM 立（该观察已记在 #3448 评论里，不会丢）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_