### PR TITLE
fix(i18n): key ObjectView 的 create/edit/view 表单标题 (#3462)

### DIFF
--- a/.changeset/object-view-form-title-i18n-3462.md
+++ b/.changeset/object-view-form-title-i18n-3462.md
@@ -1,0 +1,66 @@
+---
+'@object-ui/plugin-view': patch
+'@object-ui/i18n': patch
+---
+
+Localize the create / edit / view form title `ObjectView` builds itself
+(objectui#3462)
+
+The same family as #3426 / PR #3457 and #3459 / PR #3464, one call site further
+in. `ObjectView.getFormTitle()` string-built its three verbs in TypeScript:
+
+    case 'create': return `Create ${objectLabel}`;
+    case 'edit':   return `Edit ${objectLabel}`;
+    case 'view':   return `View ${objectLabel}`;
+
+so a Chinese session whose object is labelled 联系人 read a drawer headed
+**"View 联系人"** — an English verb glued onto a localized label. All three
+consumers are visible chrome: `renderDrawerForm`'s `DrawerTitle`,
+`renderModalForm`'s `DialogTitle`, and the `title` prop handed to
+`NavigationOverlay` in the `popover` branch (a host-supplied `title` displaces
+the overlay's own `resolvedTitle` default, so it is what the user sees).
+
+The bar to reach it is lower than #3459's split panel: `ObjectViewSchema.layout`
+already defaults to `'drawer'`, and `navigation` is a declared authorable input
+on the registered `object-view` block whose `mode` union carries `drawer`,
+`modal` and `popover`. A row click under any of them sets `formMode: 'view'` and
+opens the container. `app-shell`'s wrapper pinning `layout: 'page'` is one host
+overriding a registered block, not proof the branch is dead.
+
+## What changed
+
+The three verb branches resolve `form.createTitle` / `form.editTitle` /
+`form.viewTitle`.
+
+**No new key family was minted.** `form.createTitle` (`'Create {{object}}'`) and
+`form.editTitle` (`'Edit {{object}}'`) already ship in all ten packs and are
+already how `app-shell` heads the PAGE-mode record form
+(`RecordFormPage.tsx`, `AppContent.tsx`). The drawer / modal / popover titles are
+the same heading on a different surface, so they resolve the same keys — a
+parallel per-plugin family would have guaranteed the two spellings drift, which
+is what the sibling issues were about. Only the third verb had no sibling:
+`form.viewTitle` is added to all ten packs, following each pack's existing
+arrangement for its create/edit twins rather than a translated-verb-plus-label
+concatenation (de puts the verb last, ja/zh use particles and no space).
+
+`VIEW_DEFAULT_TRANSLATIONS` in `ObjectView.tsx` gains the three English entries,
+which is what `createSafeTranslation` falls back to with no `I18nProvider`
+mounted.
+
+Two branches stay literal on purpose and are pinned by tests: `schema.form.title`
+(the author wrote a title, so the author's title wins, in every locale) and the
+`default` branch (bare object label, no verb to translate).
+
+## Visible English change
+
+None. Every branch is byte-identical in English — `Create Contacts`,
+`Edit Contacts`, `View Contacts` — with and without a provider, so e2e specs and
+host tests that address this chrome by its English name keep addressing it. The
+provider-less path has its own test file, kept separate because
+`initReactI18next` registers its instance as a module global that outlives
+`cleanup()`.
+
+The toolbar's create BUTTON keeps resolving `console.objectView.new`
+("New" / 新建) and was deliberately not reused for the heading: a button verb and
+a title are different contexts, and folding them together is how the next drift
+of this shape would start.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -132,6 +132,7 @@ const ar = {
     stepOf: "الخطوة {{current}} من {{total}}",
     createTitle: "إنشاء {{object}}",
     editTitle: "تعديل {{object}}",
+    viewTitle: "عرض {{object}}",
     saveRecord: "حفظ السجل",
     create: "إنشاء",
     update: "تحديث",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -132,6 +132,7 @@ const de = {
     stepOf: "Schritt {{current}} von {{total}}",
     createTitle: "{{object}} erstellen",
     editTitle: "{{object}} bearbeiten",
+    viewTitle: "{{object}} anzeigen",
     saveRecord: "Datensatz speichern",
     create: "Erstellen",
     update: "Aktualisieren",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -145,6 +145,7 @@ const en = {
     stepOf: 'Step {{current}} of {{total}}',
     createTitle: 'Create {{object}}',
     editTitle: 'Edit {{object}}',
+    viewTitle: 'View {{object}}',
     saveRecord: 'Save',
     create: 'Create',
     update: 'Update',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -137,6 +137,7 @@ const es = {
     stepOf: "Paso {{current}} de {{total}}",
     createTitle: "Crear {{object}}",
     editTitle: "Editar {{object}}",
+    viewTitle: "Ver {{object}}",
     saveRecord: "Guardar registro",
     create: "Crear",
     update: "Actualizar",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -132,6 +132,7 @@ const fr = {
     stepOf: "Étape {{current}} sur {{total}}",
     createTitle: "Créer {{object}}",
     editTitle: "Modifier {{object}}",
+    viewTitle: "Afficher {{object}}",
     saveRecord: "Enregistrer",
     create: "Créer",
     update: "Mettre à jour",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -132,6 +132,7 @@ const ja = {
     stepOf: "ステップ {{current}} / {{total}}",
     createTitle: "{{object}}を作成",
     editTitle: "{{object}}を編集",
+    viewTitle: "{{object}}を表示",
     saveRecord: "レコードを保存",
     create: "作成",
     update: "更新",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -132,6 +132,7 @@ const ko = {
     stepOf: "{{total}}단계 중 {{current}}단계",
     createTitle: "{{object}} 생성",
     editTitle: "{{object}} 편집",
+    viewTitle: "{{object}} 보기",
     saveRecord: "레코드 저장",
     create: "생성",
     update: "업데이트",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -132,6 +132,7 @@ const pt = {
     stepOf: "Etapa {{current}} de {{total}}",
     createTitle: "Criar {{object}}",
     editTitle: "Editar {{object}}",
+    viewTitle: "Ver {{object}}",
     saveRecord: "Salvar registro",
     create: "Criar",
     update: "Atualizar",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -132,6 +132,7 @@ const ru = {
     stepOf: "Шаг {{current}} из {{total}}",
     createTitle: "Создать {{object}}",
     editTitle: "Редактировать {{object}}",
+    viewTitle: "Просмотреть {{object}}",
     saveRecord: "Сохранить запись",
     create: "Создать",
     update: "Обновить",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -137,6 +137,7 @@ const zh = {
     stepOf: '第{{current}}步，共{{total}}步',
     createTitle: '新建{{object}}',
     editTitle: '编辑{{object}}',
+    viewTitle: '查看{{object}}',
     saveRecord: '保存',
     create: '创建',
     update: '更新',

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -85,23 +85,47 @@ function useCreateVerb(): string {
 }
 
 /**
- * English fallback for the split-mode record-detail heading (objectui#3459,
- * following #3426's shape).
+ * English fallbacks for the headings this view resolves through `t()`
+ * (objectui#3459 for the split-mode record-detail heading, objectui#3462 for
+ * the create/edit/view form titles — both following #3426's shape).
  *
- * Borrowed from the `detail.*` namespace rather than minted as
- * `view.recordDetail`: `NavigationOverlay` — the very component this heading is
- * handed to — already resolves that namespace, as do `ListView` / `ObjectGrid`
- * / `ObjectKanban` / `ObjectTree`, and one heading on one control should not
- * get several translations that can drift apart. The entry must exist HERE too
- * — a provider-less host never reaches the locale packs, and
- * `createSafeTranslation`'s fallback is what interpolates `{{label}}`.
+ * Every entry must exist HERE as well as in the locale packs: a provider-less
+ * host never reaches the packs, and `createSafeTranslation`'s fallback is what
+ * interpolates the placeholder.
  *
- * It doubles as the probe key: under a provider `t()` returns the pack's
- * template (≠ the key) so the real translator is used; with no provider the key
- * comes back unchanged and this map supplies the English.
+ * ── Why these keys, and not new ones ──────────────────────────────────────
+ * `detail.recordDetailWithLabel` is borrowed from the `detail.*` namespace
+ * rather than minted as `view.recordDetail`: `NavigationOverlay` — the very
+ * component that heading is handed to — already resolves that namespace, as do
+ * `ListView` / `ObjectGrid` / `ObjectKanban` / `ObjectTree`, and one heading on
+ * one control should not get several translations that can drift apart.
+ *
+ * `form.createTitle` / `form.editTitle` are reused for the same reason, and are
+ * not new: all ten packs already carry them, and `app-shell` already heads the
+ * PAGE-mode record form with exactly these (`RecordFormPage.tsx`,
+ * `AppContent.tsx`). The drawer / modal / popover titles below are the same
+ * heading on a different surface, so they resolve the same keys — minting a
+ * parallel `console.objectView.*` family would have guaranteed the two spellings
+ * drift (zh already distinguishes 新建 from 创建). Only the third verb,
+ * `form.viewTitle`, had no sibling; it was added to all ten packs.
+ *
+ * Note the placeholder is `{{object}}`, not `{{label}}` — that is the variable
+ * the existing `form.*Title` family declares, and the pack-vs-en placeholder
+ * parity guard compares placeholder sets per key.
+ *
+ * `detail.recordDetailWithLabel` doubles as the probe key: under a provider
+ * `t()` returns the pack's template (≠ the key) so the real translator is used;
+ * with no provider the key comes back unchanged and this map supplies the
+ * English.
  */
 const VIEW_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'detail.recordDetailWithLabel': '{{label}} Detail',
+  // Byte-for-byte the strings `getFormTitle` used to build with a template
+  // literal, so an English session and every e2e spec that addresses this
+  // chrome by name see no change at all.
+  'form.createTitle': 'Create {{object}}',
+  'form.editTitle': 'Edit {{object}}',
+  'form.viewTitle': 'View {{object}}',
 };
 
 const useObjectViewTranslation = createSafeTranslation(
@@ -271,10 +295,11 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
   onViewAction,
 }) => {
   const createVerb = useCreateVerb();
-  // Heading of the split-mode record-detail panel (see the split branch far
-  // below). Declared with the other top-level hooks so it stays above every
-  // conditional return — rules-of-hooks.
-  const { t: tDetail } = useObjectViewTranslation();
+  // Headings this view owns: the split-mode record-detail panel (see the split
+  // branch far below) and the create/edit/view form titles (`getFormTitle`).
+  // Declared with the other top-level hooks so it stays above every conditional
+  // return — rules-of-hooks.
+  const { t: tView } = useObjectViewTranslation();
   const [objectSchema, setObjectSchema] = useState<Record<string, unknown> | null>(null);
   // Assigned in the render body (not in an effect) so the fetchData effect always
   // reads the latest objectSchema without needing it as a dependency. This matches
@@ -872,14 +897,26 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
     };
   };
 
-  // Get form title based on mode
+  // Get form title based on mode.
+  //
+  // objectui#3462: the three verbs used to be string-built (`` `View ${label}` ``),
+  // so a zh session reading a drawer opened by a row click was headed
+  // "View 联系人" — an English verb glued onto a localized label. They resolve
+  // `form.{create,edit,view}Title` now, which is the SAME key family `app-shell`
+  // already uses for the page-mode record form, so the four surfaces cannot
+  // drift. German compounds and ja/zh particle order all sit inside the
+  // template, which is why this is a key and not a verb lookup + concatenation.
+  //
+  // Two branches stay literal on purpose:
+  //   - `schema.form?.title` — the author wrote a title, so use the author's.
+  //   - `default` — returns the object label alone, no verb to translate.
   const getFormTitle = (): string => {
     if (schema.form?.title) return schema.form.title;
     const objectLabel = (objectSchema?.label as string) || schema.objectName;
     switch (formMode) {
-      case 'create': return `Create ${objectLabel}`;
-      case 'edit': return `Edit ${objectLabel}`;
-      case 'view': return `View ${objectLabel}`;
+      case 'create': return tView('form.createTitle', { object: objectLabel });
+      case 'edit': return tView('form.editTitle', { object: objectLabel });
+      case 'view': return tView('form.viewTitle', { object: objectLabel });
       default: return objectLabel;
     }
   };
@@ -1188,7 +1225,7 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
                  choose its own word order (de hyphenates, ja/zh need a
                  possessive particle). English output is byte-identical
                  (`Contacts Detail`), with or without an `I18nProvider`. */
-              title={tDetail('detail.recordDetailWithLabel', { label: objectLabel })}
+              title={tView('detail.recordDetailWithLabel', { label: objectLabel })}
               mainContent={<div className="h-full overflow-auto">{renderContent()}</div>}
             >
               {renderOverlayDetail}

--- a/packages/plugin-view/src/__tests__/ObjectView.formTitleI18n.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.formTitleI18n.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ObjectView`'s create / edit / view form title speaks the session locale —
+ * objectui#3462 (the #3426 / #3459 family).
+ *
+ * ── What was wrong ────────────────────────────────────────────────────────
+ * `getFormTitle()` string-built the three verbs:
+ *
+ *     case 'view': return `View ${objectLabel}`;
+ *
+ * so a Chinese session whose object is labelled 联系人 read a drawer headed
+ * **"View 联系人"** — an English verb glued onto a localized label. The filer
+ * reproduced exactly that. All three consumers of `getFormTitle()` are visible
+ * chrome: `renderDrawerForm`'s `DrawerTitle`, `renderModalForm`'s
+ * `DialogTitle`, and the `title` prop handed to `NavigationOverlay` in the
+ * `popover` branch (a host-supplied `title` displaces the overlay's own
+ * `resolvedTitle` default, so this is the string the user sees).
+ *
+ * ── Why this path is user-reachable ───────────────────────────────────────
+ * `object-view` / `view` are registered renderer types
+ * (`packages/plugin-view/src/index.tsx`) and `navigation` is a DECLARED
+ * authorable input on that registration, typed as `ViewNavigationConfig` whose
+ * `mode` union includes `'drawer'`, `'modal'` and `'popover'`. `handleRowClick`
+ * turns a click under any of those into `setFormMode('view')` +
+ * `setIsFormOpen(true)`, and `formLayout` maps the same mode to the container
+ * that renders the heading. The toolbar's create button (`handleCreate`) and the
+ * grid's row-edit action (`handleEdit`) reach the other two modes. The bar is
+ * even lower than #3459's split branch: `ObjectViewSchema.layout` already
+ * defaults to `'drawer'`. `app-shell`'s wrapper pinning `layout: 'page'` is one
+ * host overriding a registered block, not proof the branch is dead.
+ *
+ * ── Direction of these assertions (decided before running them) ───────────
+ *   - zh / de / ja cases, all three verbs: **RED before, GREEN after.** Before
+ *     the change they rendered "Create 联系人" / "Create Kontakte" etc.
+ *   - **de is the load-bearing case**: German puts the verb AFTER the object
+ *     ("Kontakte anzeigen"), which a `` `Verb ${label}` `` concatenation cannot
+ *     produce at any value of the verb. It is the assertion that a future
+ *     "just translate the verb and concatenate" regression cannot satisfy.
+ *   - en cases: **GREEN before AND after.** They pin that routing the title
+ *     through `t()` did not move a single byte of what an English session sees,
+ *     so e2e specs and host tests addressing this chrome by its English name
+ *     keep addressing it.
+ *   - the `schema.form.title` override: **GREEN before AND after.** The author
+ *     wrote a title, so the author's title is used — that branch is deliberately
+ *     untouched and this pins it.
+ *
+ * The provider-less fallback is asserted in
+ * `ObjectView.formTitleNoProviderFallback.test.tsx` — it cannot live in this
+ * file, because `createI18n` registers its instance as react-i18next's
+ * module-global default and that registration survives `cleanup()`; a
+ * "no provider" render here would silently resolve against whichever locale a
+ * previous test mounted.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+import type { DataSource, ObjectViewSchema } from '@object-ui/types';
+import { ObjectView } from '../ObjectView';
+
+// Mock @object-ui/react to avoid circular dependency issues (same shape as
+// ObjectView.test.tsx — the bus exports are imported at module-eval time by the
+// real @object-ui/components, so a strict mock must expose them).
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
+  return {
+    SchemaRenderer: ({ schema }: any) => (
+      <div data-testid="schema-renderer" data-schema-type={schema?.type}>
+        {schema?.type}
+      </div>
+    ),
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+
+// Grid stub exposing the two row affordances this test drives: a row click
+// (-> formMode 'view') and the row edit action (-> formMode 'edit').
+vi.mock('@object-ui/plugin-grid', () => ({
+  ObjectGrid: ({ schema, onRowClick, onEdit }: any) => (
+    <div data-testid="object-grid" data-object={schema?.objectName}>
+      <button data-testid="grid-row" onClick={() => onRowClick?.({ id: '1', name: 'Test' })}>
+        Row 1
+      </button>
+      <button data-testid="grid-edit" onClick={() => onEdit?.({ id: '1', name: 'Test' })}>
+        Edit row 1
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@object-ui/plugin-form', () => ({
+  ObjectForm: ({ schema }: any) => (
+    <div data-testid="object-form" data-mode={schema?.mode}>
+      Form ({schema?.mode})
+    </div>
+  ),
+}));
+
+function dataSourceLabelled(label: string): DataSource {
+  return {
+    find: vi.fn().mockResolvedValue({ data: [{ id: '1', name: 'Test' }], total: 1 }),
+    findOne: vi.fn().mockResolvedValue({ id: '1', name: 'Test' }),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'contacts',
+      label,
+      fields: { name: { label: 'Name', type: 'text' } },
+    }),
+  } as unknown as DataSource;
+}
+
+function renderViewIn(
+  language: string,
+  label: string,
+  schemaOverrides: Partial<ObjectViewSchema> = {},
+) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <ObjectView
+        schema={{
+          type: 'object-view',
+          objectName: 'contacts',
+          navigation: { mode: 'drawer' },
+          ...schemaOverrides,
+        } as never}
+        dataSource={dataSourceLabelled(label)}
+      />
+    </I18nProvider>,
+  );
+}
+
+/** Row click under drawer/modal/popover navigation -> formMode 'view'. */
+const openView = () => fireEvent.click(screen.getByTestId('grid-row'));
+/** Row edit action -> formMode 'edit'. */
+const openEdit = () => fireEvent.click(screen.getByTestId('grid-edit'));
+/**
+ * Toolbar create button -> formMode 'create'. Addressed by its own localized
+ * verb (`console.objectView.new`), which is deliberately NOT the title key:
+ * the button says "New" / 新建 while the title says "Create" / 新建... — reusing
+ * the button verb for the heading is the drift this issue's sibling warned
+ * about, and naming it here keeps the two visibly separate.
+ */
+const openCreate = (createVerb: string) =>
+  fireEvent.click(screen.getByRole('button', { name: createVerb }));
+
+/** The object label the fixtures use, per locale. */
+const LABEL = { en: 'Contacts', zh: '联系人', de: 'Kontakte', ja: '取引先' } as const;
+
+afterEach(() => cleanup());
+
+describe('ObjectView form title — view mode, drawer (objectui#3462)', () => {
+  it('renders the English title unchanged under an en session', async () => {
+    renderViewIn('en', LABEL.en);
+    openView();
+
+    await waitFor(() => expect(screen.getByText('View Contacts')).toBeInTheDocument());
+  });
+
+  it('renders the zh bundle arrangement under a zh session', async () => {
+    renderViewIn('zh', LABEL.zh);
+    openView();
+
+    // The filer's exact repro: a zh drawer used to be headed "View 联系人".
+    await waitFor(() => expect(screen.getByText('查看联系人')).toBeInTheDocument());
+    expect(screen.queryByText('View 联系人')).toBeNull();
+  });
+
+  it('renders the de bundle arrangement — verb AFTER the label', async () => {
+    renderViewIn('de', LABEL.de);
+    openView();
+
+    await waitFor(() => expect(screen.getByText('Kontakte anzeigen')).toBeInTheDocument());
+    expect(screen.queryByText('View Kontakte')).toBeNull();
+  });
+
+  it('renders the ja bundle arrangement under a ja session', async () => {
+    renderViewIn('ja', LABEL.ja);
+    openView();
+
+    await waitFor(() => expect(screen.getByText('取引先を表示')).toBeInTheDocument());
+  });
+});
+
+describe('ObjectView form title — edit mode, drawer (objectui#3462)', () => {
+  it('renders the English title unchanged under an en session', async () => {
+    renderViewIn('en', LABEL.en);
+    openEdit();
+
+    await waitFor(() => expect(screen.getByText('Edit Contacts')).toBeInTheDocument());
+  });
+
+  it('renders the zh bundle arrangement under a zh session', async () => {
+    renderViewIn('zh', LABEL.zh);
+    openEdit();
+
+    await waitFor(() => expect(screen.getByText('编辑联系人')).toBeInTheDocument());
+    expect(screen.queryByText('Edit 联系人')).toBeNull();
+  });
+
+  it('renders the de bundle arrangement — verb AFTER the label', async () => {
+    renderViewIn('de', LABEL.de);
+    openEdit();
+
+    await waitFor(() => expect(screen.getByText('Kontakte bearbeiten')).toBeInTheDocument());
+    expect(screen.queryByText('Edit Kontakte')).toBeNull();
+  });
+});
+
+describe('ObjectView form title — create mode, drawer (objectui#3462)', () => {
+  it('renders the English title unchanged under an en session', async () => {
+    renderViewIn('en', LABEL.en);
+    openCreate('New');
+
+    await waitFor(() => expect(screen.getByText('Create Contacts')).toBeInTheDocument());
+  });
+
+  it('renders the zh bundle arrangement under a zh session', async () => {
+    renderViewIn('zh', LABEL.zh);
+    openCreate('新建');
+
+    await waitFor(() => expect(screen.getByText('新建联系人')).toBeInTheDocument());
+    expect(screen.queryByText('Create 联系人')).toBeNull();
+  });
+
+  it('renders the de bundle arrangement — verb AFTER the label', async () => {
+    renderViewIn('de', LABEL.de);
+    openCreate('Neu');
+
+    await waitFor(() => expect(screen.getByText('Kontakte erstellen')).toBeInTheDocument());
+    expect(screen.queryByText('Create Kontakte')).toBeNull();
+  });
+});
+
+describe('ObjectView form title — the other two consumption sites (objectui#3462)', () => {
+  it('localizes the modal DialogTitle', async () => {
+    renderViewIn('zh', LABEL.zh, { navigation: { mode: 'modal' } } as never);
+    openView();
+
+    await waitFor(() => expect(screen.getByText('查看联系人')).toBeInTheDocument());
+    expect(screen.queryByText('View 联系人')).toBeNull();
+  });
+
+  it('localizes the title handed to NavigationOverlay in popover mode', async () => {
+    renderViewIn('zh', LABEL.zh, { navigation: { mode: 'popover' } } as never);
+    openView();
+
+    await waitFor(() => expect(screen.getByText('查看联系人')).toBeInTheDocument());
+    expect(screen.queryByText('View 联系人')).toBeNull();
+  });
+});
+
+describe('ObjectView form title — branches that stay literal (objectui#3462)', () => {
+  it('uses the authored schema.form.title verbatim, untranslated', async () => {
+    renderViewIn('zh', LABEL.zh, { form: { title: 'My Own Heading' } } as never);
+    openView();
+
+    // The author wrote a title, so the author's title wins — in every locale.
+    await waitFor(() => expect(screen.getByText('My Own Heading')).toBeInTheDocument());
+    expect(screen.queryByText('查看联系人')).toBeNull();
+  });
+});

--- a/packages/plugin-view/src/__tests__/ObjectView.formTitleNoProviderFallback.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.formTitleNoProviderFallback.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ObjectView`'s create / edit / view form title still resolves to ENGLISH, and
+ * to the SAME BYTES as before, when no `I18nProvider` is mounted —
+ * objectui#3462.
+ *
+ * This is not a nice-to-have. Routing a literal through `t()` without a working
+ * default is exactly how a provider-less consumer breaks, and it breaks in a
+ * suite that is not this one: `object-view` renders wherever its type is
+ * registered, so any host that renders schema without mounting a provider (this
+ * package's own tests, the preview gallery, an embedding app) reads whatever the
+ * defaults map says. The English defaults live in `VIEW_DEFAULT_TRANSLATIONS`
+ * (`ObjectView.tsx`) — that map is what `createSafeTranslation` falls back to
+ * when its `detail.recordDetailWithLabel` probe comes back unresolved, and it is
+ * what interpolates `{{object}}`.
+ *
+ * The byte-identity matters beyond aesthetics: the heading is `View Contacts`
+ * before the change and `View Contacts` after, so e2e specs and host tests that
+ * address this chrome by its English name keep addressing it.
+ *
+ * Direction: this file was GREEN before the change and is GREEN after. It pins
+ * the FALLBACK, not the fix — the fix is asserted in
+ * `ObjectView.formTitleI18n.test.tsx`. A missing map entry would turn it red by
+ * rendering the raw key `form.viewTitle`, which is precisely the regression it
+ * exists to catch.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, and `initReactI18next`
+ * registers that instance as **react-i18next's module-global default**. The
+ * registration survives unmount and `cleanup()`. So the moment any test in a
+ * file mounts `<I18nProvider config={{ defaultLanguage: 'zh' }}>`, every later
+ * "no provider" render in that same file silently resolves against the Chinese
+ * instance — a green-looking file that asserts nothing about the fallback.
+ *
+ * Vitest's `dom` project runs with `isolate: true`, so a file that never mounts
+ * a provider gets a genuinely clean global. Keep it that way: **do not import
+ * or mount `I18nProvider` here.**
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { DataSource } from '@object-ui/types';
+import { ObjectView } from '../ObjectView';
+
+vi.mock('@object-ui/react', async () => {
+  const React = await import('react');
+  return {
+    SchemaRenderer: ({ schema }: any) => (
+      <div data-testid="schema-renderer" data-schema-type={schema?.type}>
+        {schema?.type}
+      </div>
+    ),
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+
+vi.mock('@object-ui/plugin-grid', () => ({
+  ObjectGrid: ({ schema, onRowClick, onEdit }: any) => (
+    <div data-testid="object-grid" data-object={schema?.objectName}>
+      <button data-testid="grid-row" onClick={() => onRowClick?.({ id: '1', name: 'Test' })}>
+        Row 1
+      </button>
+      <button data-testid="grid-edit" onClick={() => onEdit?.({ id: '1', name: 'Test' })}>
+        Edit row 1
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@object-ui/plugin-form', () => ({
+  ObjectForm: ({ schema }: any) => (
+    <div data-testid="object-form" data-mode={schema?.mode}>
+      Form ({schema?.mode})
+    </div>
+  ),
+}));
+
+function dataSourceLabelled(label?: string): DataSource {
+  return {
+    find: vi.fn().mockResolvedValue({ data: [{ id: '1', name: 'Test' }], total: 1 }),
+    findOne: vi.fn().mockResolvedValue({ id: '1', name: 'Test' }),
+    create: vi.fn().mockResolvedValue({}),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'contacts',
+      ...(label ? { label } : {}),
+      fields: { name: { label: 'Name', type: 'text' } },
+    }),
+  } as unknown as DataSource;
+}
+
+function renderView(label?: string) {
+  return render(
+    <ObjectView
+      schema={{
+        type: 'object-view',
+        objectName: 'contacts',
+        navigation: { mode: 'drawer' },
+      } as never}
+      dataSource={dataSourceLabelled(label)}
+    />,
+  );
+}
+
+const openView = () => fireEvent.click(screen.getByTestId('grid-row'));
+const openEdit = () => fireEvent.click(screen.getByTestId('grid-edit'));
+const openCreate = () => fireEvent.click(screen.getByRole('button', { name: 'New' }));
+
+afterEach(() => cleanup());
+
+describe('ObjectView form title — English fallback with no provider (objectui#3462)', () => {
+  it('heads a view-mode drawer "View {label}", never the raw key', async () => {
+    renderView('Contacts');
+    openView();
+
+    await waitFor(() => expect(screen.getByText('View Contacts')).toBeInTheDocument());
+    expect(screen.queryByText('form.viewTitle')).toBeNull();
+  });
+
+  it('heads an edit-mode drawer "Edit {label}", never the raw key', async () => {
+    renderView('Contacts');
+    openEdit();
+
+    await waitFor(() => expect(screen.getByText('Edit Contacts')).toBeInTheDocument());
+    expect(screen.queryByText('form.editTitle')).toBeNull();
+  });
+
+  it('heads a create-mode drawer "Create {label}", never the raw key', async () => {
+    renderView('Contacts');
+    openCreate();
+
+    await waitFor(() => expect(screen.getByText('Create Contacts')).toBeInTheDocument());
+    expect(screen.queryByText('form.createTitle')).toBeNull();
+  });
+
+  it('falls back to the objectName when the object declares no label', async () => {
+    renderView();
+    openView();
+
+    await waitFor(() => expect(screen.getByText('View contacts')).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
Fixes #3462

#3426 / PR #3457 与 #3459 / PR #3464 同族的又一个调用点。

## 前提复核(先于实现)

在 `origin/main` (84bd39e77) 上确认 issue 前提**仍然成立**:`getFormTitle()`(行号已漂到 903)仍在用模板字符串自拼三个英文动词,三个消费点也都还读它 —— `renderDrawerForm` 的 `DrawerTitle`(937)、`renderModalForm` 的 `DialogTitle`(954)、popover 分支传给 `NavigationOverlay` 的 `title` prop(1276)。

```ts
case 'create': return `Create ${objectLabel}`;
case 'edit':   return `Edit ${objectLabel}`;
case 'view':   return `View ${objectLabel}`;
```

zh 会话打开抽屉读到的是 **"View 联系人"** —— 英文动词贴在本地化标签前。这不是推断:反向验证时把 `ObjectView.tsx` 还原成 main 的版本再跑新测试,渲染出的 DOM 里字面量出现了 `View 联系人` / `Create 联系人` / `Edit 联系人`,与报告人的复现完全一致。

可达性门槛比 #3459 的 split 分支还低:`ObjectViewSchema.layout` 默认即 `'drawer'`,而 `navigation` 是 `object-view` 注册块上已声明的可编写输入,其 `mode` 联合类型含 `drawer` / `modal` / `popover`;任一模式下点行即 `setFormMode('view')` 并打开容器。app-shell 包装器钉 `layout: 'page'` 是宿主覆盖已注册块,不能证明分支已死。

## 改法:复用既有 key 家族,而不是新造

按 PM 裁定「先在十个语言包里找现成的 `Create/Edit/View` 形状的 key,找不到再造 `console.objectView.*`」—— **找到了**:

- `form.createTitle` = `Create {{object}}`
- `form.editTitle` = `Edit {{object}}`

这两个 key 十包全有,而且 app-shell 的 **page 模式**记录表单标题用的正是它们(`RecordFormPage.tsx:131-132`、`AppContent.tsx:787-788`)。抽屉 / 弹窗 / 浮层的标题只是同一个标题的另一个承载面,所以解析同一组 key;另造一套 `console.objectView.*` 只会保证两处拼写迟早漂开(zh 本身就区分 新建 与 创建),而这恰是本系列 issue 要治的病。

只有第三个动词没有兄弟,新增 `form.viewTitle` 到十个语言包,按各包 create/edit 双胞胎的既有语序排布,而非「翻译动词再拼标签」:

| 包 | createTitle(既有) | editTitle(既有) | **viewTitle(新增)** |
| --- | --- | --- | --- |
| en | `Create {{object}}` | `Edit {{object}}` | `View {{object}}` |
| zh | `新建{{object}}` | `编辑{{object}}` | `查看{{object}}` |
| de | `{{object}} erstellen` | `{{object}} bearbeiten` | `{{object}} anzeigen` |
| ja | `{{object}}を作成` | `{{object}}を編集` | `{{object}}を表示` |
| ko | `{{object}} 생성` | `{{object}} 편집` | `{{object}} 보기` |
| fr | `Créer {{object}}` | `Modifier {{object}}` | `Afficher {{object}}` |
| es | `Crear {{object}}` | `Editar {{object}}` | `Ver {{object}}` |
| pt | `Criar {{object}}` | `Editar {{object}}` | `Ver {{object}}` |
| ru | `Создать {{object}}` | `Редактировать {{object}}` | `Просмотреть {{object}}` |
| ar | `إنشاء {{object}}` | `تعديل {{object}}` | `عرض {{object}}` |

`VIEW_DEFAULT_TRANSLATIONS`(#3464 在本文件建好的兜底表)补上三条英文,供无 `I18nProvider` 的宿主使用。

**两个分支刻意保持原样**,并各有测试钉住:`schema.form?.title` 覆盖(作者写了标题就用作者的,任何语言下都是)、以及 `default` 分支(只回标签,没有动词可译)。

工具栏那个「新建」**按钮**仍解析 `console.objectView.new`,刻意没有拿来当标题:按钮动词与标题是两种语境,把它们并成一个 key 正是下一次同形漂移的起点。

## 与 PM 裁定的一处偏差(需知会)

插值变量是 `{{object}}` 而非派发单里写的 `{{label}}`。这是复用既有 `form.*Title` 家族的机械后果 —— 该家族声明的就是 `{{object}}`,而 `all-locales-key-parity` 的占位符守卫是按 key 逐个比对占位符集合的;给 `viewTitle` 单独用 `{{label}}` 会让它与两个兄弟不一致。若维护者更希望另起 `console.objectView.*` 家族,改回来的成本很小,但代价是与 app-shell 的 page 模式标题分家。

## 测试

新增两个文件,分文件的理由沿用 #3464:`createI18n` 会把实例注册成 react-i18next 的**模块级全局默认**,该注册在 `cleanup()` 后仍在,所以「无 provider」断言必须独占一个文件。

- `ObjectView.formTitleI18n.test.tsx` —— 13 例,三个动词 × en/zh/de(+ view 的 ja),外加 modal `DialogTitle`、popover `NavigationOverlay` 两个消费点,以及 `schema.form.title` 覆盖。
- `ObjectView.formTitleNoProviderFallback.test.tsx` —— 4 例,无 provider 时三个动词的英文兜底 + 无 label 时回落到 `objectName`。

**de 是承重断言**:德语动词在标签**之后**(`Kontakte anzeigen`),任何「翻译动词再拼接」的写法在任何动词取值下都产不出这个语序 —— 将来若有人把 key 退化成动词查表,这条会红。

### 反向验证(方向在跑之前就定好了)

预测:zh/de/ja 各动词 —— 改前红、改后绿;en、无 provider、`form.title` 覆盖 —— 两侧皆绿(逐字节钉死)。

用 `git checkout origin/main -- packages/plugin-view/src/ObjectView.tsx` 还原实现、保留新测试与语言包后实测:

```
 Test Files  1 failed | 1 passed (2)
      Tests  9 failed | 8 passed (17)
```

9 条红的全部且仅为 zh/de/ja 用例(view/edit/create 三态 + modal + popover);8 条绿的是 3 条 en + 1 条 `form.title` 覆盖 + 4 条无 provider 兜底。**方向与预测完全一致**。恢复实现后 17/17 全绿。

### 完整跑批(仓库根,flock 串行,`--maxWorkers=2`)

```
npx vitest run --maxWorkers=2 packages/plugin-view packages/i18n
 Test Files  32 passed (32)
      Tests  363 passed (363)
```

含 `all-locales-key-parity.test.ts`(十包 key 与占位符全量对齐)。

```
turbo run type-check --filter=@object-ui/plugin-view --filter=@object-ui/i18n
 Tasks:    16 successful, 16 total

turbo run lint --filter=@object-ui/plugin-view --filter=@object-ui/i18n
 ✖ 138 problems (0 errors, 138 warnings)   ← 全为既有 warning
```

### 消费半径清扫

按规则用 key 的消费半径而非改动包来扫 fixture:全仓 grep 旧标题字面量(`View Contacts` 等)与 `getFormTitle`,除本 PR 自己的测试外,没有任何 e2e spec 或宿主测试按旧英文串寻址这块 chrome —— 英文输出逐字节不变,所以本来也无需改动。

### 字节自查

`node scripts/check-control-bytes.mjs` 通过(扫 3668 个文件);另按规则做了超出闸门的自查 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,改动文件全部干净。

Changeset:`.changeset/object-view-form-title-i18n-3462.md`(`@object-ui/plugin-view` + `@object-ui/i18n`,均为 patch)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_