### PR TITLE
fix(console): declare `type: 'home'` on the page preview sample (#3454)

### DIFF
--- a/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
+++ b/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
@@ -224,6 +224,18 @@ function issuesFor(type: string): { path: string; message: string }[] {
     .map((issue) => ({ path: issue.path.join('.'), message: issue.message }));
 }
 
+/**
+ * The `page` sample as the spec actually MATERIALISES it — i.e. after defaults
+ * are applied, not as authored. Parsing is the only way to see a defaulted key:
+ * reading `SAMPLES.page.type` shows what the author wrote, which is precisely
+ * the blind spot objectui#3454 was filed for.
+ */
+function parsedPage(): Record<string, unknown> {
+  const result = ObjectStackSchema.safeParse({ pages: [SAMPLES.page] });
+  if (!result.success) throw new Error('page sample no longer parses');
+  return (result.data as { pages: Record<string, unknown>[] }).pages[0];
+}
+
 describe('preview-samples conform to @objectstack/spec', () => {
   // Without this, a sample added to the gallery tomorrow would be validated by
   // nothing and no test would notice — the exact failure mode this file exists
@@ -240,6 +252,33 @@ describe('preview-samples conform to @objectstack/spec', () => {
 
   it.each(SPEC_CLEAN)('%s sample is valid metadata', (type) => {
     expect(issuesFor(type)).toEqual([]);
+  });
+
+  /**
+   * objectui#3454 — the page sample must declare the page KIND it is used as.
+   *
+   * Being valid is not the same as meaning what it says. `PageSchema.type` is
+   * `PageTypeSchema.default('record')`, so a page that omits `type` parses
+   * clean and MATERIALISES as a record page — one bound to no object, since
+   * `object` is optional. This sample is not a record page: the `app` sample in
+   * the same file routes it as the CRM's landing entry
+   * (`navigation[0] = { id: 'home', type: 'page', pageName: 'crm_welcome' }`),
+   * and its content is a welcome header with quick links.
+   *
+   * The mismatch is invisible in the gallery, which renders the UNPARSED draft
+   * — so nothing would ever have gone red over it. It matters because these
+   * samples are the worked example an author (increasingly, a model generating
+   * metadata) copies: a landing page silently defaulting to `record` is wrong
+   * semantics propagating from the file that exists to demonstrate right ones.
+   *
+   * Asserted on the PARSED value, not the authored literal, because the defect
+   * lives in the default: only the parse distinguishes "declared `home`" from
+   * "omitted, therefore `record`". Deleting the sample's `type` line turns this
+   * red with the received value `'record'`.
+   */
+  it('page sample declares `home`, the kind the app sample routes it as', () => {
+    expect(parsedPage().type).toBe('home');
+    expect(SAMPLES.page.type).toBe('home');
   });
 
   // Reverse assertion (same shape as objectui#3212): a ledger nobody re-checks

--- a/apps/console/src/preview-samples.ts
+++ b/apps/console/src/preview-samples.ts
@@ -49,6 +49,18 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
   page: {
     name: 'crm_welcome',
     label: 'CRM Welcome',
+    // Declared, NOT defaulted (objectui#3454). `PageSchema.type` is
+    // `PageTypeSchema.default('record')`, so omitting it does not mean
+    // "unspecified" — it materialises this welcome screen as a RECORD page
+    // bound to no object (`object` is optional, so nothing complains). The app
+    // sample below routes this very page as the CRM's landing entry
+    // (`navigation[0]` = `{ id: 'home', type: 'page', pageName: 'crm_welcome' }`),
+    // so `home` is the kind it is actually used as. Spelling it out is what
+    // makes the sample mean what it demonstrates: the gallery renders the
+    // unparsed draft and would never have shown the difference, but these
+    // samples are copied — increasingly by models generating metadata — and a
+    // landing page that silently defaults to `record` propagates as such.
+    type: 'home',
     regions: [
       {
         name: 'main',


### PR DESCRIPTION
Fixes #3454

## 问题

`apps/console/src/preview-samples.ts` 的 `page` 样例只声明了 `name` / `label` / `regions`,没有声明 `type`。而 spec 的 `PageSchema.type` 是 `PageTypeSchema.default('record')`(`page.zod.ts:413`),所以「不写」并不等于「未指定」——它会**落成 `record` 页**;又因为 `object` 是可选的,这个 record 页没有任何对象绑定,校验也不会报错。

但同一个文件里的 `app` 样例,正是把这个页面当**首页**用的:

`navigation[0]` = `{ id: 'home', type: 'page', pageName: 'crm_welcome' }`

即:样例演示的语义(首页)与它解析后的语义(无绑定的记录页)是矛盾的。

## 为什么之前没有任何测试变红

gallery 渲染的是**未解析的 draft**(`draft.type` 为 undefined);而 `preview-samples-registry-resolvable.test.ts` 只遍历 `regions[].components`,不读根节点的 `type`。这个缺陷正好落在两条既有防线之间。它值得修,是因为这些样例是作者(越来越多是生成元数据的模型)照抄的范例——错误语义会被复制、传播。

## 改动

一行 `type: 'home'`,加一段说明「为什么必须显式声明」的注释。`home` 在 `PageTypeSchema` 中(`page.zod.ts:232`),且已注册渲染器(`packages/components/src/renderers/layout/page.tsx:700`,与 `page` 共用 `PageRenderer`)。

## 这一行有实际作用,不只是「更规范」

运行时 `PageView.tsx:129-131` 会把 spec 的 `type` 桥接到渲染器真正读的 `pageType`:

```
type: (page as any).type || 'page',
pageType: (page as any).type,
```

该处注释写明:没有这个映射,"every page fell back to `pageType: 'record'`, so non-record pages got the record max-width, a wrong `data-page-type` and a suppressed header"。也就是说,原样例演示的恰恰是这个映射要避免的坏状态;补上后,它发布到真实应用、从 home 导航打开时,会真正走 `HomePageLayout`。

## 验证

反向验证(先预测方向,再执行):先加 pin、不改样例 → 应当变红,且 received 恰为 `'record'`。实际输出:

```
AssertionError: expected 'record' to be 'home'
Expected: "home"
Received: "record"
```

补上 `type: 'home'` 后:

- `preview-samples-spec-valid.test.ts` + `preview-samples-registry-resolvable.test.ts`:35 passed
- `apps/console` 全量:23 files / 212 tests passed
- `type-check --filter=@object-ui/console`:35 tasks successful
- `check-control-bytes`:OK

浏览器验证(scoped verify skill,gallery `?only=page`):改动前后**截图 md5 完全一致**(`8fde30b4...`),DOM 采集逐项相同,无 "Unknown component type" 兜底框。零视觉差异的原因比「draft 路径忽略 type」更具体:design 模式下 `PagePreview` 走的是 `PageBlockCanvas`,根本不经过 `PageRenderer`(所以 DOM 里没有 `data-page-type`);即便走 `SchemaRenderer`,`'home'` 与原先注入的 `'page'` 也都解析到同一个 `PageRenderer`,而布局分支读的是 `pageType`(预览路径并不设置它)。

## 未改动 / 无新 finding

spec 的 `type`(页面种类)与 objectui 节点 `pageType` 的命名冲突,是 `packages/types/src/zod/layout.zod.ts:296` 已明确记录的既有取舍,且运行时已由 `PageView` 桥接,因此不另开 finding。

按 #3453 先例,dev-only 样例不加 changeset。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_