### PR TITLE
test(plugin-kanban): 在模块作用域预载 KanbanImpl,把 lazy chunk 移出 findBy 预算 (#3465)

### DIFF
--- a/packages/plugin-kanban/src/KanbanRenderer.uncolumned.test.tsx
+++ b/packages/plugin-kanban/src/KanbanRenderer.uncolumned.test.tsx
@@ -17,6 +17,19 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { KanbanRenderer } from './index';
 
+// Pay the board's lazy chunk at import time, not inside a `findBy` budget
+// (AGENTS.md §测试纪律). `KanbanRenderer` renders
+// `React.lazy(() => import('./KanbanImpl'))` behind a Suspense boundary, and
+// both assertions below sit AFTER that boundary — the card has to be on screen
+// before it can be found. Importing `./index` alone does NOT warm it: that only
+// registers the lazy factory, it never executes the dynamic import. Under full
+// CI parallelism a first `import()` has been measured at ~976ms against RTL's
+// 1000ms default, so without this the suite would race the module loader. The
+// specifier must stay byte-identical to the one in `./index` — ESM caches by
+// resolved specifier, which is what makes the component's own lazy factory
+// resolve immediately.
+import './KanbanImpl';
+
 const columns = [
   { id: 'todo', title: 'To Do' },
   { id: 'in_progress', title: 'In Progress' },


### PR DESCRIPTION
Fixes #3465

## 问题

`packages/plugin-kanban/src/KanbanRenderer.uncolumned.test.tsx` 的两条断言
(`findByText('Orphaned card')` 与 `findByText('Matches')`)都落在 `React.lazy`
边界之后,而文件顶部只 `import { KanbanRenderer } from './index'`。

关键点:**import './index' 并不会预热 KanbanImpl**。已核对 `./index` 的静态图:

- `index.tsx:15` 只静态 import `./ObjectKanban`
- `ObjectKanban.tsx:24` 又反向 import 回 `./index`,另加 `./types`
- 全图没有任何一条静态边到达 `KanbanImpl`

`KanbanImpl` 唯一的可达路径是 `index.tsx:124` 的
`React.lazy(() => import('./KanbanImpl'))` —— 它只是**登记**了工厂,不执行导入。
于是首次 `import('./KanbanImpl')` 发生在 Suspense resolve 期间,即被计入 RTL
`findBy` 的 **1000ms 有界窗口**。AGENTS.md §测试纪律 记录过满并行下一次首包
`import()` 实测可达 976ms(占该预算 97.6%),这就是 latent flake 的根因。

`heavyDomTests` 成员身份帮不上忙:`vitest.setup.dom.tsx` 只预载
components / fields / plugin-dashboard / plugin-grid,没有 plugin-kanban;
何况即便有,`./index` 也不会 warm 到 `KanbanImpl`。

## 改动

按 §测试纪律,在模块作用域直接 `import './KanbanImpl';` 并附一行注释说明原因,
写法沿用 PR #3464 的两个姊妹文件(`ObjectKanban.overlayTitleI18n.test.tsx`、
`ObjectKanban.overlayTitleNoProviderFallback.test.tsx`)。成本进入 import 阶段,
**不受任何 test/hook 超时约束**。

specifier 与 `index.tsx:124` 完全一致(两个文件同在 `packages/plugin-kanban/src/`,
`./KanbanImpl` 解析到同一个绝对模块 id)—— ESM 按解析后的 specifier 缓存,这样组件
自己的 lazy 工厂才会立刻 resolve。

**没有用 `beforeAll`**:它受更窄的 `hookTimeout`(10s)约束,且已被
`object-ui/no-dynamic-import-in-test-hook` 机械禁止。

单文件 +13 行(1 个 import + 注释),纯测试改动,无 changeset。

## 验证 —— 计时是 null result,如实报告

派发单预期「after 首个测试更快」。**实测并非如此,这里如实记录**:本改动移除的是
一场竞态,不是一条失败断言,而空闲容器复现不出 CI 满并行的饱和管线条件。

首个测试耗时(`--reporter=verbose`,repo root,`--maxWorkers=2`):

| 条件 | before | after |
| --- | --- | --- |
| 单文件(warm,3 次) | 356 / 359 / 372ms | 355 / 355 / 356ms |
| plugin-kanban 全量套件 | 386ms | 384ms |

差异在噪声范围内,`import` / `tests` 阶段拆分同样看不出成本迁移
(before import 656-724ms、tests 385-395ms;after import 625-669ms、tests 379-386ms)。
清掉 `node_modules/.vite` 冷跑也没拉开差距。

原因是:空闲容器上这次 `import()` 只要几十 ms,而首个测试的 ~355ms 主要是
React + happy-dom 真实渲染看板(dnd-kit 初始化、列与卡片),预载并不消除这部分。
976ms 那个数字来自全仓 ~300 个 DOM 文件并行时饱和的 transform 管线,8 个文件、
`--maxWorkers=2` 的包级套件复现不出来。

所以本 PR 的依据是**结构性的**(上面的静态图追踪证明 lazy 边界确实横在断言之前),
而不是本地计时差。可观察到的旁证是 before 跑的文件内落差:首个测试 ~370ms、
第二个 ~25ms —— 首次加载的成本确实压在第一条 `findBy` 上。

其余检查(均在 `flock /tmp/os-heavy-verify.lock` 下,`--max-old-space-size=4096`):

- 目标文件 before 与 after **均绿**(各 3 次,2 passed)
- `pnpm exec vitest run packages/plugin-kanban/` before/after 均 **8 files / 39 tests passed**
- `pnpm exec eslint` 该文件:0 error 0 warning;`--print-config` 确认
  `object-ui/no-dynamic-import-in-test-hook` 在该路径上确实生效
- `pnpm --filter @object-ui/plugin-kanban type-check`:exit 0
  (先 `pnpm --filter '@object-ui/plugin-kanban^...' build` —— 新 worktree 未建依赖
  时的 TS2307 是 stale-artefact 陷阱,与本改动无关)
- `pnpm check:control-bytes`:OK(3673 个文件);另做越界自扫
  `grep -naP` 无匹配,`file` 报 UTF-8 text

未改动其他 kanban 测试文件:`registration.test.tsx` 的断言在边界之前(它 mock 掉
`./ObjectKanban` 并同步 `getByTestId`),`cardPredicateScope.test.tsx` 已有对
`./KanbanImpl` 的静态 import。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_