### PR TITLE
fix(console): make vite/vitest configs loadable by `configLoader: 'native'`

### DIFF
--- a/apps/console/tsconfig.node.json
+++ b/apps/console/tsconfig.node.json
@@ -17,6 +17,18 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
+    /* `vite.config.ts` imports `../../scripts/vite-*.ts` with explicit `.ts`
+       extensions, because Vite's `configLoader: 'native'` hands the config to
+       Node's ESM loader, which does no extension guessing (objectui#3384).
+       TypeScript needs `allowImportingTsExtensions` to accept that spelling —
+       `moduleResolution: bundler` takes `./x` and `./x.js`, but NOT `./x.ts`.
+       That option demands one of `noEmit` / `emitDeclarationOnly` /
+       `rewriteRelativeImportExtensions`. `noEmit` is barred here for the reason
+       spelled out above (TS6310, referenced by `tsconfig.json`), and rewriting
+       extensions in output nobody reads would be pointless — so declarations
+       only. They still land in the cache `outDir`; the `.js` was never used. */
+    "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
     "strict": true
   },
   /* `../../scripts/vite-*.ts` are the repo-level Vite plugins vite.config.ts

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -7,8 +7,14 @@ import type { Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
-import { viteCryptoStub } from '../../scripts/vite-crypto-stub';
-import { viteMaplibreWorker } from '../../scripts/vite-maplibre-worker';
+// Relative specifiers carry their real file extension, and `__dirname` is
+// spelled `import.meta.dirname` throughout this file, so the config stays
+// loadable by Vite's `configLoader: 'native'` — which imports this file with
+// Node's own ESM loader. Node does no extension guessing and defines no
+// `__dirname` in ESM, so the pre-Vite-8 spellings would fail outright the day
+// `native` becomes the default loader (objectui#3384).
+import { viteCryptoStub } from '../../scripts/vite-crypto-stub.ts';
+import { viteMaplibreWorker } from '../../scripts/vite-maplibre-worker.ts';
 import { compression } from 'vite-plugin-compression2';
 import { visualizer } from 'rollup-plugin-visualizer';
 
@@ -53,7 +59,7 @@ function preloadCriticalChunks(): Plugin {
  * Non-blocking — silently skips when the directory doesn't exist.
  */
 function serveRuntimeAssets(): Plugin {
-  const ASSETS_DIR = path.resolve(__dirname, '../../../../runtime/assets');
+  const ASSETS_DIR = path.resolve(import.meta.dirname, '../../../../runtime/assets');
   const MIME: Record<string, string> = {
     '.png': 'image/png', '.svg': 'image/svg+xml', '.jpg': 'image/jpeg',
     '.jpeg': 'image/jpeg', '.ico': 'image/x-icon', '.webp': 'image/webp',
@@ -108,42 +114,42 @@ const isCI = !!(process.env.VERCEL || process.env.CI);
 // Workspace src/ aliases — gives instant HMR in dev and ensures correct
 // side-effect resolution (plugin registrations) in production builds.
 const workspaceAliases: Record<string, string> = {
-  '@object-ui/components': path.resolve(__dirname, '../../packages/components/src'),
-  '@object-ui/core': path.resolve(__dirname, '../../packages/core/src'),
-  '@object-ui/react-runtime': path.resolve(__dirname, '../../packages/react-runtime/src'),
-  '@object-ui/sdui-parser': path.resolve(__dirname, '../../packages/sdui-parser/src'),
-  '@object-ui/fields': path.resolve(__dirname, '../../packages/fields/src'),
-  '@object-ui/layout': path.resolve(__dirname, '../../packages/layout/src'),
-  '@object-ui/plugin-dashboard': path.resolve(__dirname, '../../packages/plugin-dashboard/src'),
-  '@object-ui/plugin-report': path.resolve(__dirname, '../../packages/plugin-report/src'),
-  '@object-ui/plugin-form': path.resolve(__dirname, '../../packages/plugin-form/src'),
-  '@object-ui/plugin-grid': path.resolve(__dirname, '../../packages/plugin-grid/src'),
-  '@object-ui/react': path.resolve(__dirname, '../../packages/react/src'),
-  '@object-ui/types': path.resolve(__dirname, '../../packages/types/src'),
-  '@object-ui/data-objectstack': path.resolve(__dirname, '../../packages/data-objectstack/src'),
-  '@object-ui/auth': path.resolve(__dirname, '../../packages/auth/src'),
-  '@object-ui/permissions': path.resolve(__dirname, '../../packages/permissions/src'),
-  '@object-ui/providers': path.resolve(__dirname, '../../packages/providers/src'),
-  '@object-ui/collaboration': path.resolve(__dirname, '../../packages/collaboration/src'),
-  '@object-ui/i18n': path.resolve(__dirname, '../../packages/i18n/src'),
-  '@object-ui/mobile': path.resolve(__dirname, '../../packages/mobile/src'),
-  '@object-ui/app-shell': path.resolve(__dirname, '../../packages/app-shell/src'),
+  '@object-ui/components': path.resolve(import.meta.dirname, '../../packages/components/src'),
+  '@object-ui/core': path.resolve(import.meta.dirname, '../../packages/core/src'),
+  '@object-ui/react-runtime': path.resolve(import.meta.dirname, '../../packages/react-runtime/src'),
+  '@object-ui/sdui-parser': path.resolve(import.meta.dirname, '../../packages/sdui-parser/src'),
+  '@object-ui/fields': path.resolve(import.meta.dirname, '../../packages/fields/src'),
+  '@object-ui/layout': path.resolve(import.meta.dirname, '../../packages/layout/src'),
+  '@object-ui/plugin-dashboard': path.resolve(import.meta.dirname, '../../packages/plugin-dashboard/src'),
+  '@object-ui/plugin-report': path.resolve(import.meta.dirname, '../../packages/plugin-report/src'),
+  '@object-ui/plugin-form': path.resolve(import.meta.dirname, '../../packages/plugin-form/src'),
+  '@object-ui/plugin-grid': path.resolve(import.meta.dirname, '../../packages/plugin-grid/src'),
+  '@object-ui/react': path.resolve(import.meta.dirname, '../../packages/react/src'),
+  '@object-ui/types': path.resolve(import.meta.dirname, '../../packages/types/src'),
+  '@object-ui/data-objectstack': path.resolve(import.meta.dirname, '../../packages/data-objectstack/src'),
+  '@object-ui/auth': path.resolve(import.meta.dirname, '../../packages/auth/src'),
+  '@object-ui/permissions': path.resolve(import.meta.dirname, '../../packages/permissions/src'),
+  '@object-ui/providers': path.resolve(import.meta.dirname, '../../packages/providers/src'),
+  '@object-ui/collaboration': path.resolve(import.meta.dirname, '../../packages/collaboration/src'),
+  '@object-ui/i18n': path.resolve(import.meta.dirname, '../../packages/i18n/src'),
+  '@object-ui/mobile': path.resolve(import.meta.dirname, '../../packages/mobile/src'),
+  '@object-ui/app-shell': path.resolve(import.meta.dirname, '../../packages/app-shell/src'),
 
   // Plugin Aliases
-  '@object-ui/plugin-calendar': path.resolve(__dirname, '../../packages/plugin-calendar/src'),
-  '@object-ui/plugin-charts': path.resolve(__dirname, '../../packages/plugin-charts/src'),
-  '@object-ui/plugin-chatbot': path.resolve(__dirname, '../../packages/plugin-chatbot/src'),
-  '@object-ui/plugin-detail': path.resolve(__dirname, '../../packages/plugin-detail/src'),
-  '@object-ui/plugin-editor': path.resolve(__dirname, '../../packages/plugin-editor/src'),
-  '@object-ui/plugin-gantt': path.resolve(__dirname, '../../packages/plugin-gantt/src'),
-  '@object-ui/plugin-kanban': path.resolve(__dirname, '../../packages/plugin-kanban/src'),
-  '@object-ui/plugin-list': path.resolve(__dirname, '../../packages/plugin-list/src'),
-  '@object-ui/plugin-map': path.resolve(__dirname, '../../packages/plugin-map/src'),
-  '@object-ui/plugin-markdown': path.resolve(__dirname, '../../packages/plugin-markdown/src'),
-  '@object-ui/plugin-timeline': path.resolve(__dirname, '../../packages/plugin-timeline/src'),
-  '@object-ui/plugin-tree': path.resolve(__dirname, '../../packages/plugin-tree/src'),
-  '@object-ui/plugin-view': path.resolve(__dirname, '../../packages/plugin-view/src'),
-  '@object-ui/plugin-designer': path.resolve(__dirname, '../../packages/plugin-designer/src'),
+  '@object-ui/plugin-calendar': path.resolve(import.meta.dirname, '../../packages/plugin-calendar/src'),
+  '@object-ui/plugin-charts': path.resolve(import.meta.dirname, '../../packages/plugin-charts/src'),
+  '@object-ui/plugin-chatbot': path.resolve(import.meta.dirname, '../../packages/plugin-chatbot/src'),
+  '@object-ui/plugin-detail': path.resolve(import.meta.dirname, '../../packages/plugin-detail/src'),
+  '@object-ui/plugin-editor': path.resolve(import.meta.dirname, '../../packages/plugin-editor/src'),
+  '@object-ui/plugin-gantt': path.resolve(import.meta.dirname, '../../packages/plugin-gantt/src'),
+  '@object-ui/plugin-kanban': path.resolve(import.meta.dirname, '../../packages/plugin-kanban/src'),
+  '@object-ui/plugin-list': path.resolve(import.meta.dirname, '../../packages/plugin-list/src'),
+  '@object-ui/plugin-map': path.resolve(import.meta.dirname, '../../packages/plugin-map/src'),
+  '@object-ui/plugin-markdown': path.resolve(import.meta.dirname, '../../packages/plugin-markdown/src'),
+  '@object-ui/plugin-timeline': path.resolve(import.meta.dirname, '../../packages/plugin-timeline/src'),
+  '@object-ui/plugin-tree': path.resolve(import.meta.dirname, '../../packages/plugin-tree/src'),
+  '@object-ui/plugin-view': path.resolve(import.meta.dirname, '../../packages/plugin-view/src'),
+  '@object-ui/plugin-designer': path.resolve(import.meta.dirname, '../../packages/plugin-designer/src'),
 };
 
 // Opt-in override of the installed `@objectstack/client`. The published client
@@ -314,7 +320,7 @@ export default defineConfig({
     port: 5180,
     // Widen the fs allow-list only when an out-of-tree client override is set
     // (see OBJECTSTACK_CLIENT_DIST above); otherwise keep Vite's defaults.
-    ...(clientFsAllow.length ? { fs: { allow: [path.resolve(__dirname, '../..'), ...clientFsAllow] } } : {}),
+    ...(clientFsAllow.length ? { fs: { allow: [path.resolve(import.meta.dirname, '../..'), ...clientFsAllow] } } : {}),
     proxy: {
       '/api': { target: process.env.DEV_PROXY_TARGET || 'http://localhost:3000', changeOrigin: true },
     },

--- a/apps/console/vitest.config.ts
+++ b/apps/console/vitest.config.ts
@@ -1,7 +1,11 @@
 import path from 'path';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import rootConfig from '../../vitest.config.mts';
-import viteConfig from './vite.config';
+// The `.ts` extension and `import.meta.dirname` below are load-bearing, not
+// style: Vite's `configLoader: 'native'` hands this file to Node's own ESM
+// loader, which neither guesses extensions nor defines `__dirname`
+// (objectui#3384).
+import viteConfig from './vite.config.ts';
 
 export default mergeConfig(
   mergeConfig(rootConfig, viteConfig),
@@ -10,7 +14,7 @@ export default mergeConfig(
       // The root config no longer sets global setupFiles (they moved into the
       // per-project `unit`/`dom` split). Console tests render components, so
       // they need the DOM setup explicitly.
-      setupFiles: [path.resolve(__dirname, '../../vitest.setup.dom.tsx')],
+      setupFiles: [path.resolve(import.meta.dirname, '../../vitest.setup.dom.tsx')],
     },
   })
 );


### PR DESCRIPTION
Fixes #3384

## 背景

Vite 8 每次加载 console 配置都会打印同一个 5 行告警块:两个配置文件用到了 `configLoader: 'native'` 不支持的特性。今天只是告警(默认的 `bundle` loader 替它们做了补丁),但 Vite 把默认值翻过去的那一天,console 的 dev / build / vitest 会**同时**在「加载配置」这一步挂掉 —— 而且扣扳机的会是一次毫不相关的依赖升级。

## 改动

三个文件,两个提交:

**`apps/console/vite.config.ts` / `apps/console/vitest.config.ts`**

1. `__dirname` → `import.meta.dirname`:**36 处**(vite.config.ts)+ 1 处(vitest.config.ts)。
2. 三个相对 specifier 补上真实扩展名 `.ts`:`./vite.config`、`../../scripts/vite-crypto-stub`、`../../scripts/vite-maplibre-worker`。Node 的 ESM 解析器不做扩展名猜测。

`scripts/vite-*.ts` 本身没有改动 —— 扩展名只写在**导入方**。

**`apps/console/tsconfig.node.json`**(两行,见下方「type-check 门」一节)

3. `allowImportingTsExtensions` + `emitDeclarationOnly` —— 让 #3305 那道门接受显式 `.ts` specifier。

### 告警只报了 5 条,真实站点是 39 个

Vite 对同一文件的同一类问题**只报第一处**。「5 个告警」严重低估了工作量:vite.config.ts 里有 36 处 `__dirname`,告警只点名了第 56 行那一处。这不是洁癖,反向验证在下面。

## 验证

### 告警块前后对照(同一条命令 `pnpm exec vitest list apps/console/`)

改动前:

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vitest.config.ts:13:33). Use `import.meta.dirname` instead
  - import "./vite.config" without a file extension (vitest.config.ts:4:24). Add the file extension
  - `__dirname` (vite.config.ts:56:35). Use `import.meta.dirname` instead
  - import "../../scripts/vite-crypto-stub" without a file extension (vite.config.ts:10:32). Add the file extension
  - import "../../scripts/vite-maplibre-worker" without a file extension (vite.config.ts:11:36). Add the file extension
```

改动后:告警块消失,输出直接从测试清单开始。`vitest run` 的完整输出里同样一条都没有。

### 两个 loader 下配置解析完全一致(`resolveConfig`,command 为 build)

```
bundle  -> root: /apps/console | plugins: 46 | alias@object-ui/core: /packages/core/src
native  -> root: /apps/console | plugins: 46 | alias@object-ui/core: /packages/core/src
```

说明 `import.meta.dirname` 算出的绝对路径与原来的 `__dirname` 一致。

### 反向验证(预测方向:改前红 / 改后绿 —— 结果符合)

把两个文件退回 origin/main,再用 `configLoader: 'native'` 加载:

```
NATIVE FAILED: ERR_MODULE_NOT_FOUND | Cannot find module '.../scripts/vite-crypto-stub' imported from .../apps/console/vite.config.ts
NATIVE FAILED: ERR_MODULE_NOT_FOUND | Cannot find module '.../apps/console/vite.config'  imported from .../apps/console/vitest.config.ts
```

注意:模块解析先失败,把 `__dirname` 那一半**掩盖**掉了。于是单独隔离 —— 扩展名保持修好,只把 36 处里的 1 处改回 `__dirname`:

```
NATIVE FAILED: ReferenceError | __dirname is not defined in ES module scope
```

漏掉任意一处 `__dirname` 都足以让整个配置加载失败,所以必须全改。

### 测试

- `pnpm exec vitest run apps/console/ --maxWorkers=2`(仓库根):`Test Files  23 passed (23)` / `Tests  211 passed (211)`
- `tsc -b apps/console/tsconfig.node.json --force`:exit 0,工作树零 litter,产物仍全部落在原有的 `outDir`(`node_modules/.cache/tsc/console-node`),且只有 `.d.ts`、没有 `.js`
- `eslint vite.config.ts vitest.config.ts`:干净
- 控制字符自检 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`:干净

## type-check 门:为什么要动 `tsconfig.node.json`

`.ts` 扩展名会让 #3305 那道门(`apps/console` 的 `tsc -b tsconfig.node.json --force`,CI 的 type-check job 会跑到)报错,而且**只**报这两条:

```
vite.config.ts(16,32): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
vite.config.ts(17,36): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
```

issue 正文里「`moduleResolution: bundler` accepts both spellings」这一句不成立:bundler 接受 `./x` 和 `./x.js`,但 `./x.ts` 必须开 `allowImportingTsExtensions`。而 `.ts` 是唯一能被 Node 原生 ESM 解析的写法(`./x.js` 在磁盘上不存在),所以绕不过去。

补丁就是两行:

```diff
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
+    "emitDeclarationOnly": true,
     "strict": true
```

`emitDeclarationOnly` 这个搭档不是随便挑的,三个候选实测过:

- **`noEmit`** —— 不行。`allowImportingTsExtensions` 必须搭配 `noEmit` / `emitDeclarationOnly` / `rewriteRelativeImportExtensions` 之一(否则 TS5096),但 `noEmit` 会让 `type-check` 的前半段 `tsc --noEmit` 挂掉:`tsconfig.json(28,18): error TS6310: Referenced project '.../tsconfig.node.json' may not disable emit.` —— 正是 `tsconfig.node.json` 自己注释里写明的那条约束。
- **`rewriteRelativeImportExtensions`** —— 能过,但它给一份反正要丢掉的产物加上了 `.ts` → `.js` 改写语义,没有意义。
- **`emitDeclarationOnly`** —— 选它。composite 工程本来就需要声明产物,而那份 `.js` 从来没人用;它满足 TS6310(没有禁用 emit),又把丢弃的输出减到最小,和该文件「存在只为被类型检查」的既有设计一致。

> 更正:本 PR 首版正文里贴过一份**错误**的 tsconfig 补丁(重写整个文件、删掉 `outDir`/`rootDir`、并加 `noEmit`)。那是照着一份 stale 的工作副本(共享 checkout 停在 68b6a2855)推出来的,套用会重新引入 #3305 修掉的产物 litter 并触发 TS6310。已作废,以最终落地的这两行为准。

## 为什么没有显式钉 `configLoader: 'native'`

issue 里那条 optional 建议**做不到** —— 不是版本兼容问题,是结构问题:`configLoader` 是 `InlineConfig` 的字段,不在 `UserConfig` 上。它是 `loadConfigFromFile(...)` 的**入参** —— 「用哪种方式读这个配置文件」,在配置文件被读出来之前就已经消费掉了。写在 `vite.config.ts` 里的键不可能影响读它自己的那一步。Vitest 侧同样:它的 `configLoader` 类型注释原文是 "Override vite config's configLoader **from CLI**"。

因此钉死只能落在**调用处**(`apps/console/package.json` 的 `dev`/`build` 加 `vite --configLoader native`;或根 `test` 脚本加 `vitest run --configLoader native` —— 后者会把 native 强加给**所有** project 配置,波及面远超本 issue)。两者都超出本 issue 范围,PM 已据此撤回该要求。

兼容性本身是验证过的、绿的:本 PR 之后 `apps/console/vite.config.ts`、`apps/console/vitest.config.ts`、根 `vitest.config.mts` 三者在 `configLoader: 'native'` 下都能正常加载 —— 真要钉,随时可以钉,只是得换个文件落地。

另外:告警块清零本身就是回归绊线 —— 之前 5 条常驻噪音里再多一条没人看得见,现在任何新引入的不兼容写法都是干净输出里唯一的那条告警。

## Changeset

没加。`@object-ui/console` 确实是发布包(在 fixed 组内,非 private),但本次只改开发期配置文件,不进 `dist/`,对使用者零可见变化 —— 按 AGENTS.md「纯 bug 修复不需要 changeset」处理。

## 顺手记录的 finding

#3476(observation 类,未排期):`apps/console/vitest.config.ts` 不在任何 tsc program 里(两个 console tsconfig 的 `include` 都没覆盖它),以及 `tsconfig.node.json` 的 `include` 列了一个不存在的 `vitest.setup.ts`。与本 PR 独立成立。
