### PR TITLE
fix(ci): Lychee 扫站点文档 content/docs,并加上每周 cron (#3449)

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,7 +1,46 @@
 name: Check Links
 
+# Lychee is the EXTERNAL link checker. It makes real network requests and is
+# flaky by nature. Site-internal routes (`/docs/...`) are a different problem
+# with a different tool — `scripts/check-doc-links.mjs`, run by
+# `docs-links.yml`, which reads the checkout and nothing else and is therefore
+# the one that gates pull requests. The two are complementary, not redundant;
+# do not move either one's job onto the other.
+#
+# The scan scope below (`args`) was wrong until #3449: it listed only the
+# repo-root `docs/**`, which holds 15 INTERNAL documents (ADRs, audits), while
+# the 183 files the published site is built from live in `content/docs/**`
+# (`apps/site/source.config.ts`: `dir: '../../content/docs'`, baseUrl `/docs`).
+# This workflow had therefore never scanned a single published page — it was
+# green because of what it was not looking at.
+# `scripts/__tests__/check-links-workflow.test.ts` pins the scope to the
+# directory the site config itself declares: if the content tree moves again
+# that test turns red, instead of this workflow silently going blind a second
+# time.
+
 on:
   workflow_dispatch:
+
+  # Weekly sweep, Sundays at 04:17 UTC.
+  #
+  # The PR that fixed #3213 deliberately did NOT add a cron, and it was right to
+  # hold off: with the scope pointed at the wrong tree, a schedule only turns
+  # one false-green report into a periodically produced false-green report. Now
+  # that the scope is correct, #3213's ruling-B intent — a periodic sweep — is
+  # real, so the schedule lands in the same change that makes it meaningful.
+  #
+  # Timing: off the top of the hour, because GitHub's scheduled-workflow queue
+  # is most congested (and most delayed) at :00; Sunday because that is when the
+  # repo contends least for runners.
+  schedule:
+    - cron: '17 4 * * 0'
+
+  # ⛔ Do NOT enable the two triggers below — #3213's ruling B still stands.
+  # An external link check goes over the network: one 502, rate-limit or
+  # anti-scraping response from a third-party site turns an unrelated pull
+  # request red, and its author can do nothing about it. `schedule` +
+  # `workflow_dispatch` do not have that problem: this workflow blocks nobody,
+  # so flakiness costs a second look and nothing else.
   # push:
   #   branches:
   #     - main
@@ -17,11 +56,20 @@ jobs:
       - name: Check links with Lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          # Scan all markdown files in docs directory and README
+          # Both trees:
+          #   content/docs/** — the published site's documentation (the fumadocs
+          #     content source). Never scanned before #3449; the whole point.
+          #   docs/**, README.md — the repo-root internal material (ADRs,
+          #     audits). Their external links are worth sweeping too and cost
+          #     nothing extra, so they stay.
+          # Site-absolute routes (`/docs/...`) are NOT judged here — see the
+          # `root_dir` section of lychee.toml.
           args: |
             --verbose
             --no-progress
             --config lychee.toml
+            'content/docs/**/*.md'
+            'content/docs/**/*.mdx'
             'docs/**/*.md'
             'docs/**/*.mdx'
             'README.md'

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -55,7 +55,8 @@ jobs:
       # `content/docs/**` against the files actually on disk. Reads the checkout
       # and nothing else, so no install is required. External URLs are a
       # different problem with a different tool — Lychee, in `check-links.yml`,
-      # which is manual-dispatch only and scans `docs/` rather than
-      # `content/docs/` (#3449).
+      # which sweeps both `content/docs/` and `docs/` on a weekly cron and on
+      # demand, and deliberately gates nothing (#3449 fixed its scope; #3213
+      # decided it stays off pull requests).
       - name: Check internal docs links
         run: node scripts/check-doc-links.mjs

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -38,7 +38,7 @@ one has its own section below.
 | `changelog.yml` | Auto Changelog | GitHub Release published; manual | n/a |
 | `stale.yml` | Stale Issues & PRs | Daily cron `0 0 * * *`; manual | n/a |
 | `shadcn-check.yml` | Check Shadcn Components | Weekly cron `0 9 * * 1`; manual | n/a |
-| `check-links.yml` | Check Links | Manual dispatch only | n/a |
+| `check-links.yml` | Check Links | Weekly cron `17 4 * * 0`; manual | n/a — reports, never gates |
 
 The path filters explain most "why did nothing run on my PR?" questions:
 
@@ -280,29 +280,38 @@ checked as *routes*, so `/docs/guide/foo` is what belongs in the markdown, not
 
 ## Link Checking (`check-links.yml`)
 
-**Trigger:** Manual workflow dispatch (`workflow_dispatch`).
+**Trigger:** Weekly cron (`17 4 * * 0` — Sundays, off the top of the hour, when the scheduled-run
+queue is shortest) plus manual workflow dispatch.
 
 There are **two** link checkers, and they cover different things (objectui#3213):
 
 | | Covers | Network | Runs |
 |---|---|---|---|
 | `scripts/check-doc-links.mjs` | **Internal** `/docs/...` routes, resolved against `content/docs/` | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
-| Lychee (this workflow) | **External** URLs in `docs/` and `README.md` | Yes | Manual dispatch only |
+| Lychee (this workflow) | **External** URLs, plus **relative** in-repo file links, in `content/docs/`, `docs/` and `README.md` | Yes | Weekly cron and manual dispatch |
 
-Note the asymmetry in what Lychee scans: `docs/` holds internal material (ADRs, audits,
-architecture notes), while the published site is built from `content/docs/`. Lychee therefore does
-not currently see the site's own pages.
+Lychee sweeps **both** documentation trees: `content/docs/` (the 183 pages the site publishes) and
+the repo-root `docs/` (15 files of internal material — ADRs, audits, architecture notes) plus
+`README.md`. Until objectui#3449 it scanned only the latter, so no published page had ever been
+link-checked; the workflow was green about a tree almost nobody reads.
+`scripts/__tests__/check-links-workflow.test.ts` now derives the expected scope from
+`apps/site/source.config.ts`, so moving the content tree turns that test red instead of quietly
+blinding the sweep again.
 
-One known gap remains tracked rather than silently lived with: Lychee's scan scope predates the
-move to `content/docs/` (objectui#3449), so **external** URLs on the published site's own pages are
-checked by nothing. The gap that used to sit beside it — docs-only PRs never being link-checked,
-because `ci.yml` ignores `content/**` — is closed: that check is now `docs-links.yml` (objectui#3448).
+It is deliberately **not** a PR gate (objectui#3213). External link checking goes over the network,
+and one 502 or rate-limit from a third-party site would redden a pull request whose author can do
+nothing about it. The cron was added only once the scope was correct: a schedule pointed at the
+wrong tree just produces a false-green report on a timer.
 
 Uses [Lychee](https://github.com/lycheeverse/lychee) with configuration from `lychee.toml`:
-- Scans markdown files in `docs/` and `README.md`
+- Scans `content/docs/**/*.{md,mdx}`, `docs/**/*.{md,mdx}` and `README.md`
 - Max concurrency: 10, timeout: 20s, retries: 3
 - Excludes: localhost, example.com, Twitter/X, GitHub compare/commit URLs
-- Remaps internal `/docs/*` paths to `file://./docs/*` for local resolution
+- Skips **site-absolute** routes (`/docs/...`, `/api/...`): Lychee cannot resolve extensionless
+  fumadocs routes, and without handling it fails them while building the URI — before `exclude` is
+  even consulted. `root_dir` therefore resolves them into a sentinel namespace that is then
+  excluded wholesale. Judging those routes is `check-doc-links.mjs`'s job, and duplicating its
+  route-to-file mapping here would only create a second copy free to drift.
 
 ## Release Workflows
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,11 @@
 # Lychee configuration file for ObjectUI documentation link checking
-# This configuration enables checking internal fumadocs links by mapping
-# Next.js routes (e.g., /docs/guide) to filesystem paths (e.g., docs/guide.mdx)
+# (used by `.github/workflows/check-links.yml` — schedule + workflow_dispatch).
+#
+# Lychee checks two classes of link here: EXTERNAL URLs, and RELATIVE in-repo
+# file links (`docs/**` links into `../../packages/**` source files rely on
+# that). Site-ABSOLUTE routes — `/docs/...`, `/api/...`, `/protocol/...` — are
+# not its job; those belong to `scripts/check-doc-links.mjs`, run by
+# `docs-links.yml`. See the `root_dir` section below.
 
 # Maximum number of concurrent requests
 max_concurrency = 10
@@ -19,28 +24,60 @@ exclude = [
     # Local development URLs
     "http://localhost*",
     "https://localhost*",
-    
+
     # Example and placeholder URLs
     "https://example.com",
     "http://example.com",
-    
+
     # Social media (anti-scraping)
     "https://twitter.com*",
     "https://x.com*",
-    
+
     # GitHub specific patterns that may cause false positives
     "https://github.com/.*/compare/*",
     "https://github.com/.*/commit/*",
+
+    # Site-absolute routes, resolved into the sentinel namespace by `root_dir`
+    # below and skipped wholesale here. Rationale: see `root_dir`.
+    "^file:///__site-routes-not-on-disk__/",
 ]
 
-# Path remapping for fumadocs internal links
-# Maps Next.js routes to actual file paths
-# Format: ["pattern to match", "replacement"]
-remap = [
-    # Map /docs/* links to docs/ filesystem paths
-    # The file:// prefix tells lychee to check local files
-    "^/docs/(.*)$ file://./docs/$1"
-]
+# Why site-absolute routes (`/docs/...`) are handled this way
+#
+# When a local file contains an absolute-path link, Lychee without a `root_dir`
+# reports a HARD error:
+#   [ERROR] Cannot resolve root-relative link '/docs/plugins':
+#           To resolve root-relative links in local files, provide a root dir
+# and that failure happens while the URI is being constructed, BEFORE the
+# exclude filter runs — adding `^/docs` or `^/` to `exclude` is measurably a
+# no-op: the errors are still reported and the exit code is still 2.
+# `content/docs/**` contains 297 such links, so once #3449 widened the scan to
+# `content/docs`, leaving them unhandled would make this workflow red from its
+# very first run — trading a false-green report on the wrong tree for a
+# false-red one on the right tree, which is no better.
+#
+# So: `root_dir` resolves site-absolute routes into a sentinel namespace that
+# does not exist on disk, and the exclude entry above skips that namespace
+# entirely. `root_dir` must be an absolute path, and the repository's absolute
+# path differs between a local checkout and a runner, so it can only be a
+# repo-independent constant — the sentinel is forced by that constraint, not
+# chosen for cuteness. Expect one line of output per run:
+#   [WARN] Root dir '/__site-routes-not-on-disk__' does not exist
+# That is intended; the directory is not supposed to exist, and its name is the
+# explanation.
+#
+# Why not have Lychee resolve these routes properly instead: fumadocs routes
+# carry no extension (`/docs/guide/data-source` -> `content/docs/guide/
+# data-source.md`), so judging them needs a real route-to-file mapping. That
+# mapping already exists — `scripts/check-doc-links.mjs` — and a second copy
+# here would only be a second copy free to drift from the first.
+#
+# (This section replaced `remap = ["^/docs/(.*)$ file://./docs/$1"]`, which had
+#  never once fired: `remap` operates on an already-parsed URL, and `/docs/x`
+#  fails to parse before it ever reaches remapping. Its replacement target was
+#  wrong twice over anyway — no extension, and pointing at the internal `docs/`
+#  rather than the site's `content/docs/`.)
+root_dir = "/__site-routes-not-on-disk__"
 
 # Cache configuration
 # Don't use cache to ensure fresh results

--- a/scripts/__tests__/check-links-workflow.test.ts
+++ b/scripts/__tests__/check-links-workflow.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3449 — `check-links.yml` was pointed at the wrong tree.
+ *
+ * Its `args` listed `docs/**` and `README.md`. `docs/` is 15 files of INTERNAL
+ * material (ADRs, audit reports). The documentation the site actually publishes
+ * is the 183 files under `content/docs/**` — `apps/site/source.config.ts`
+ * declares `dir: '../../content/docs'` with baseUrl `/docs`. Not one published
+ * page had ever been scanned. The workflow was green about a tree nobody reads
+ * and silent about the tree everybody does, which is the same failure mode as
+ * #3448 / #3261 / #2879 in this repo: a gate that looks configured and simply
+ * never sees its subject.
+ *
+ * The scope is only half the fix, so this file pins both halves:
+ *
+ *  1. **Scope, derived not copied.** The assertions below do not hard-code
+ *     `content/docs`; they read the directory out of `apps/site/source.config.ts`
+ *     and require the workflow to cover every markdown file under it. A
+ *     hard-coded path would be a second copy of the site's layout, free to
+ *     drift from it — which is exactly how this bug was born. Move the content
+ *     tree again and this test goes red on the same day, instead of the
+ *     workflow going quietly blind for another year.
+ *
+ *  2. **The `root_dir` / `exclude` pair in `lychee.toml`.** Widening the scope
+ *     without it does not produce a working sweep, it produces 316 hard errors:
+ *     `content/docs` carries ~297 site-absolute links (`/docs/...`), and Lychee
+ *     fails those while CONSTRUCTING the URI — before `exclude` is consulted,
+ *     so an `^/docs` exclude pattern cannot suppress them. The two settings only
+ *     work together; removing either alone re-breaks the sweep, so neither may
+ *     leave without the other.
+ *
+ * Also pinned: the trigger set. `schedule` must exist (the periodic sweep
+ * #3213's ruling B intended, which was correctly withheld until the scope was
+ * right), and `push` / `pull_request` must NOT — an external link checker walks
+ * the network, and gating PRs on third-party uptime makes other people's work
+ * fail for reasons they cannot fix.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const workflowPath = path.join(repoRoot, '.github/workflows/check-links.yml');
+const lycheeConfigPath = path.join(repoRoot, 'lychee.toml');
+const siteConfigPath = path.join(repoRoot, 'apps/site/source.config.ts');
+
+/**
+ * The workflow YAML with whole-line comments removed.
+ *
+ * Required, not cosmetic: the header explains at length why `push` and
+ * `pull_request` stay disabled and names both of them, and the commented-out
+ * trigger block is itself part of the record. A scan that counted either would
+ * report triggers this workflow does not have.
+ */
+function withoutComments(yaml: string): string {
+  return yaml
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+}
+
+/** The quoted input patterns from the workflow's `args:` block. */
+function scannedPatterns(yaml: string): string[] {
+  return [...withoutComments(yaml).matchAll(/^\s*'([^']+)'\s*$/gm)].map((m) => m[1]);
+}
+
+/** Every `.md` / `.mdx` file below `dir`, as repo-relative paths. */
+function markdownFilesUnder(dir: string): string[] {
+  const absolute = path.join(repoRoot, dir);
+  if (!fs.existsSync(absolute)) return [];
+  const found: string[] = [];
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.mdx?$/.test(entry.name)) found.push(path.relative(repoRoot, full));
+    }
+  };
+  walk(absolute);
+  return found;
+}
+
+/**
+ * Files matched by one input pattern.
+ *
+ * Only the two shapes the workflow uses are supported — `<dir>/ ** / *.<ext>`
+ * and a literal path. Anything else is reported rather than silently counted as
+ * zero, because "matches nothing" is the very defect this file exists to catch.
+ */
+function filesMatching(pattern: string): string[] {
+  const glob = /^(.+)\/\*\*\/\*\.([a-z]+)$/.exec(pattern);
+  if (glob) {
+    const [, base, extension] = glob;
+    return markdownFilesUnder(base).filter((file) => file.endsWith(`.${extension}`));
+  }
+  if (/[*?[\]]/.test(pattern)) {
+    throw new Error(`unsupported glob shape in check-links.yml args: ${pattern}`);
+  }
+  return fs.existsSync(path.join(repoRoot, pattern)) ? [pattern] : [];
+}
+
+/** The docs directory the site itself declares, as a repo-relative path. */
+function declaredDocsDir(): string {
+  const source = fs.readFileSync(siteConfigPath, 'utf8');
+  const match = /\bdir:\s*'([^']+)'/.exec(source);
+  expect(match, `${siteConfigPath} no longer declares a docs \`dir\``).not.toBeNull();
+  const resolved = path.resolve(path.dirname(siteConfigPath), match![1]);
+  return path.relative(repoRoot, resolved);
+}
+
+const workflowYaml = () => fs.readFileSync(workflowPath, 'utf8');
+
+describe('check-links.yml — the external link sweep looks at the published docs', () => {
+  it('scans every markdown file the site is built from', () => {
+    // The #3449 assertion. Derived from the site config on purpose: see the
+    // header. `content/docs` is never spelled out here.
+    const docsDir = declaredDocsDir();
+    const published = markdownFilesUnder(docsDir);
+    expect(published.length, `no markdown found under the declared docs dir '${docsDir}'`).toBeGreaterThan(100);
+
+    const scanned = new Set(scannedPatterns(workflowYaml()).flatMap(filesMatching));
+    const missed = published.filter((file) => !scanned.has(file));
+    expect(missed.slice(0, 5), `${missed.length} published doc(s) are not covered by check-links.yml args`).toEqual([]);
+  });
+
+  it('still sweeps the repo-root internal docs and README', () => {
+    // Ruling on #3449: `docs/**` (ADRs, audits) and README keep their coverage.
+    // Widening to the published tree was never meant to narrow anything.
+    const scanned = new Set(scannedPatterns(workflowYaml()).flatMap(filesMatching));
+    const internal = markdownFilesUnder('docs');
+    expect(internal.length, "the repo-root internal docs tree is gone — re-read this workflow's scope").toBeGreaterThan(
+      0,
+    );
+
+    const missed = internal.filter((file) => !scanned.has(file));
+    expect(missed.slice(0, 5), `${missed.length} internal doc(s) are not covered by check-links.yml args`).toEqual([]);
+    expect(scanned.has('README.md')).toBe(true);
+  });
+
+  it('states its inputs in a shape this test can actually evaluate', () => {
+    // Coverage above is asserted per FILE, not per pattern, and that is
+    // deliberate: `docs/**/*.mdx` currently matches nothing (the internal tree
+    // is all `.md`) and should stay anyway, so that an internal `.mdx` landing
+    // tomorrow is swept rather than becoming a fresh blind spot. What must not
+    // happen is an args block this test cannot read — it would assert coverage
+    // over an empty pattern list and pass while checking nothing.
+    const patterns = scannedPatterns(workflowYaml());
+    expect(patterns.length, 'no input patterns found in the args block').toBeGreaterThan(2);
+    for (const pattern of patterns) expect(() => filesMatching(pattern)).not.toThrow();
+  });
+
+  it('runs on a schedule as well as on demand', () => {
+    const yaml = withoutComments(workflowYaml());
+    expect(yaml, 'the periodic sweep #3213 ruling B intended').toMatch(/^\s*schedule:/m);
+    expect(yaml).toMatch(/^\s*-\s*cron:\s*'[^']+'/m);
+    expect(yaml).toMatch(/^\s*workflow_dispatch:/m);
+  });
+
+  it('does not gate pull requests', () => {
+    // #3213 ruling B. Lychee goes over the network; a third-party 502 must not
+    // be able to redden somebody's unrelated PR. The commented-out block in the
+    // workflow stays commented — `withoutComments` is what makes this real.
+    const yaml = withoutComments(workflowYaml());
+    expect(yaml, 'external link checking must not become a PR gate — see #3213').not.toMatch(/^\s*pull_request:/m);
+    expect(yaml).not.toMatch(/^\s*push:/m);
+  });
+});
+
+describe('lychee.toml — site-absolute routes are skipped, not resolved', () => {
+  it('resolves site-absolute routes into a sentinel root and excludes it', () => {
+    // Both halves or neither: `root_dir` alone turns 297 unresolvable links into
+    // 297 "file not found" errors, and the exclude alone cannot fire at all,
+    // because the failure happens before filtering.
+    const config = fs.readFileSync(lycheeConfigPath, 'utf8');
+    const rootDir = /^\s*root_dir\s*=\s*"([^"]+)"/m.exec(config);
+    expect(rootDir, 'lychee.toml must set root_dir, or site-absolute links are hard errors').not.toBeNull();
+    expect(rootDir![1].startsWith('/'), 'root_dir must be an absolute path').toBe(true);
+    expect(fs.existsSync(rootDir![1]), 'root_dir is a sentinel namespace and must not exist on disk').toBe(false);
+    expect(config, `root_dir ${rootDir![1]} is set but never excluded`).toContain(`"^file://${rootDir![1]}/`);
+  });
+
+  it('carries no remap pretending to resolve fumadocs routes', () => {
+    // The removed `^/docs/(.*)$ file://./docs/$1` never fired (remap operates on
+    // a parsed URL; `/docs/x` fails to parse first) and pointed at the internal
+    // `docs/` tree besides. Route-to-file resolution has exactly one owner:
+    // scripts/check-doc-links.mjs.
+    const config = fs.readFileSync(lycheeConfigPath, 'utf8');
+    const active = config
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n');
+    expect(active, 'internal route resolution belongs to scripts/check-doc-links.mjs').not.toMatch(/^\s*remap\s*=/m);
+  });
+});


### PR DESCRIPTION
Fixes #3449

## 前提复核(origin/main)

issue 的前提成立,三条都当场复核过:

| 断言 | 复核结果 |
|---|---|
| `args` 只扫 `docs/**` + README | 成立 |
| 触发器只有 `workflow_dispatch` | 成立(push / pull_request 仍注释掉) |
| 文件数 183 vs 15 | 成立 —— `lychee --dump-inputs` 实测:`content/docs` 183、`docs/` 15、README 1 |

## 改了什么

### 1. 扫描范围:两棵树都扫(PM 裁决 ①)

`args` 增加 `content/docs/**/*.md` 与 `content/docs/**/*.mdx`,保留原有的 `docs/**` 与 `README.md`。输入文件数 **16 → 199**。

### 2. 每周 cron(PM 裁决 ②)

`schedule: - cron: '17 4 * * 0'`。避开整点(GitHub 的 schedule 队列在 :00 最挤、延迟最久),周日仓库最安静。`workflow_dispatch` 保留;**push / pull_request 继续注释掉** —— #3213 裁决 B 依然有效,注释块和理由一并留在文件里(理由原本没写,这次补上了)。

### 3. `lychee.toml`:这一步是必须的,不是顺手改的

只改范围会得到一个**从第一次运行起就全红**的 workflow。实测(新 args + origin/main 的 lychee.toml):

```
🔍 640 Total  🔗 207 Unique  ✅ 167 OK  🚫 353 Errors
其中 "Cannot resolve root-relative link" 316 条
```

`content/docs` 里有 297 处站内绝对链接(`/docs/...`)。Lychee 在**构造 URI 的阶段**就把它们判成硬错误,这早于 `exclude` 过滤 —— 所以往 `exclude` 里加 `^/docs` 或 `^/` 实测**完全无效**(错误照报、退出码照样是 2)。

处理方式:`root_dir` 先把站内绝对路由解析进一个磁盘上不存在的哨兵命名空间,再由 `exclude` 整段跳过。`root_dir` 必须是绝对路径,而仓库在本地和 runner 上的绝对路径不同,所以它只能是一个与仓库无关的常量 —— 哨兵是被这条约束逼出来的。

**没有**让 Lychee 去解析这些路由:fumadocs 路由没有扩展名(`/docs/guide/data-source` → `content/docs/guide/data-source.md`),判它需要一份真正的 路由→文件 映射,而那份映射已经存在 —— `scripts/check-doc-links.mjs`。在 `lychee.toml` 里再抄一份,只是多一份会各自漂移的副本。

顺带删掉了 `remap = ["^/docs/(.*)$ file://./docs/$1"]`:它**从未生效过**(remap 作用在已解析的 URL 上,而 `/docs/x` 在解析阶段就失败,压根走不到 remap),而且替换目标既少扩展名、指的又是内部的 `docs/` 而不是 `content/docs/`。

### 4. Pin 测试

`scripts/__tests__/check-links-workflow.test.ts`:范围**不是**硬编码 `content/docs`,而是从 `apps/site/source.config.ts` 的 `dir` 读出来,再要求 workflow 覆盖该目录下每一个 md/mdx。硬编码等于把站点布局又抄一份 —— 这个 bug 本来就是这么来的。content 再搬家一次,测试当天变红。同时钉住 `root_dir`/`exclude` 这一对(拆掉任何一半都会重新弄坏)、`schedule` 存在、以及 `pull_request`/`push` 不存在。

### 5. 文档

`content/docs/guide/ci-cd-pipeline.md` 原本把这件事写成"已知缺口,追踪在 #3449",还把已删除的 remap 写成现行配置;`docs-links.yml` 的注释说 Lychee "dispatch-only 且扫 docs/"。都已更新。

## 验证

本地下载了真的 lychee 0.24.2 跑的,不是纸面推演。

**范围(`--dump-inputs`,精确计数)**

```
total inputs: 199 | content/docs: 183 | docs/: 15 | README: 1
```

**反向验证 —— 方向是先预测再跑的,四条都按预测变红**

| 回退 | 预测 | 实际 |
|---|---|---|
| 只回退 args 范围 | 覆盖断言红 | `× scans every markdown file the site is built from` |
| 只回退 `lychee.toml` | 两条配置断言红 | `× resolves site-absolute routes …` `× carries no remap …` |
| 删掉 `schedule` | cron 断言红 | `× runs on a schedule as well as on demand` |
| 放开 `pull_request` | 门禁断言红 | `× does not gate pull requests` |

全部恢复后 `Tests 7 passed (7)`。

**测试 / 门禁**

```
pnpm exec vitest run scripts/          → Test Files 11 passed | Tests 151 passed (151)
actionlint check-links.yml docs-links.yml → clean
node scripts/check-doc-links.mjs       → Docs links are valid.
node scripts/check-control-bytes.mjs   → OK (3673 tracked text files)
pnpm exec eslint <新测试>               → exit 0
tsc --noEmit --strict <新测试>          → exit 0
YAML 解析:triggers = ["workflow_dispatch","schedule"],schedule = [{cron: "17 4 * * 0"}]
```

`scripts/` 不在任何 tsconfig 的 `include` 里(root tsconfig 只含 `packages`/`examples`/`apps`),所以仓库的 `type-check` 本来就不覆盖它 —— 上面那条 tsc 是我单独跑的,如实说明。

## ⚠️ 首次定时运行预期是红的,而且是**真红**

修好范围后离线跑一遍,还剩 37 个错误,全部是仓库内**相对**文件链接失效,与外链无关:

- **content/docs 16 个失效目标**(33 处引用):13 个是 `plugins/plugin-*.md` 但文件其实叫 `.mdx`;另有 `concepts/lazy-loading`、`guide/lazy-loading.md`、`guide/examples/server` 三个目标根本不存在。
- **README.md 4 个**(#3449 之前就在扫描范围内,即老范围下这个 workflow 跑起来也是红的):`examples/crm`、`examples/todo`、`examples/kitchen-sink`、`examples/msw-todo` —— 这四个 example 应用在仓库里不存在。

这些是**既有的内容缺陷**,不是本 PR 引入的,按 Prime Directive #10 另开 issue、不夹带进这个 PR 修。顺带暴露出一个门禁洞:`scripts/check-doc-links.mjs` 只校验 `/docs/...` 开头的 href,相对链接一律直接 return true —— 所以这 16 个失效链接一直没人管。同样另开 issue。

我特意**没有**加 `--fallback-extensions md,mdx`:它能把错误从 33 降到 6,但降下去的那 13 个正是 `.md` 写成 `.mdx` 的真缺陷(fumadocs 路由无扩展名,`.md` 后缀在站点上就是 404),等于用宽容的消费端把生产端的错误盖住。宁可报得难看,也不要报得好看但不真。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_