### PR TITLE
docs(readme): 用真实的 examples 目录替换 4 个已删除的示例条目

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,34 +54,29 @@ One schema, many view types — dashboards, Gantt schedules, kanban boards, cale
 
 ## Examples
 
-ObjectStack examples that demonstrate different features and use cases:
+Everything under [`examples/`](examples) — in learning order. The
+[examples catalog](examples/README.md) has the full "which one should I use?" table.
 
-- **[examples/crm](examples/crm)** - Full-featured CRM application with dashboards, multiple views (Grid, Kanban, Map, Gantt), and custom server implementation.
-- **[examples/todo](examples/todo)** - Simple task management app demonstrating basic ObjectStack configuration and field types.
-- **[examples/kitchen-sink](examples/kitchen-sink)** - Comprehensive component catalog showing all available field types, dashboard widgets, and view types.
-- **[examples/msw-todo](examples/msw-todo)** - Frontend-first development example using MSW (Mock Service Worker) to run ObjectStack in the browser.
+- **[examples/hello-world](examples/hello-world)** - The smallest JSON → UI demo: one `schema.json` (a `Page` holding a `Card` with text and a button) rendered by `<SchemaRenderer>` from a single `App.tsx`. Start here to see how a `type` resolves against the component registry.
 - **[examples/byo-backend-console](examples/byo-backend-console)** ⭐ - Minimal custom console in ~100 lines showing third-party integration without full console infrastructure. Uses `@object-ui/app-shell` and `@object-ui/providers` with custom routing and a mock REST adapter (BYO backend).
 - **[examples/console-starter](examples/console-starter)** - Opinionated, fork-ready console template with the full plugin set (grid, kanban, dashboard, designer, charts, …) wired up against an ObjectStack backend. Use this as the starting point when you want a complete console rather than a minimal integration.
+- **[examples/schema-catalog](examples/schema-catalog)** - Not a runnable app — the canonical JSON schema catalog that is the single source of truth for the schemas shipped elsewhere: the docs site renders them via `<SchemaExample id="…" />`, a smoke test mounts every entry, and AI agents use it as a few-shot corpus.
 
-### Running Examples as API Servers
-
-All examples (except msw-todo) can be run as API servers using `@objectstack/cli`:
+### Running an example
 
 ```bash
 # From the monorepo root
-pnpm run serve:crm          # Start CRM example on http://localhost:3000
-pnpm run serve:todo         # Start Todo example on http://localhost:3000
-pnpm run serve:kitchen-sink # Start Kitchen Sink example on http://localhost:3000
+pnpm install
+pnpm -w build
 
-# Or from individual example directories
-cd examples/crm
-pnpm run serve
+# Vite dev server — byo-backend-console or console-starter
+cd examples/console-starter
+pnpm dev
 ```
 
-Each server provides:
-- GraphQL API endpoint: `http://localhost:3000/graphql`
-- REST API endpoints based on object definitions
-- Sample data loaded from the configuration manifest
+`hello-world` ships no dev server: copy its `App.tsx` and `schema.json` into your own
+Vite/Next.js app. `schema-catalog` is a data package — its smoke test mounts every
+schema in it (`pnpm --filter @object-ui/example-schema-catalog test`).
 
 ## 📦 For React Developers
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,18 +15,28 @@ Runnable examples that show how to consume ObjectUI in different scenarios. Pick
 > - Adding ObjectUI to an existing product / different backend → `byo-backend-console`.
 > - Standing up a brand-new ObjectStack console → fork `console-starter`.
 
+### Also under `examples/`
+
+| Directory | What it is |
+|---|---|
+| [`schema-catalog/`](./schema-catalog) | **Not a runnable app** — a data package (`@object-ui/example-schema-catalog`) holding the canonical JSON schemas consumed by the docs site (`<SchemaExample id="…" />`), by the smoke test that mounts every entry, and by AI agents as a few-shot corpus. See [its README](./schema-catalog/README.md) for how to add one. |
+
 ## Running an example
 
-From the monorepo root:
+`byo-backend-console` and `console-starter` are Vite apps. From the monorepo root:
 
 ```bash
 pnpm install
 pnpm -w build
-cd examples/<name>
+cd examples/console-starter   # or byo-backend-console
 pnpm dev
 ```
 
-Each example exposes its own dev server port (see its README).
+Each exposes its own dev server port (see its README).
+
+The other two directories are not dev servers: `hello-world` is a snippet to drop into
+your own Vite/Next.js app, and `schema-catalog` is a data package verified with
+`pnpm --filter @object-ui/example-schema-catalog test`.
 
 ## Adding a new example
 


### PR DESCRIPTION
Fixes #3480

README.md:59-62 以肯定语气推荐了四个不存在的示例目录。按 issue 要求,先查清「去向」再决定修法。

## 每个目录的历史判定

四个都是 **被删**,不是移仓,也不是计划未建。证据是同一个提交:

| 目录 | 曾经的包名 | 判定 | 证据 |
|---|---|---|---|
| `examples/crm` | `@object-ui/example-crm` | 被删 | 在 `12b287d8b` 中删除(72 个文件) |
| `examples/todo` | `@object-ui/example-todo` | 被删 | 同一提交(10 个文件) |
| `examples/kitchen-sink` | `@object-ui/example-kitchen-sink` | 被删 | 同一提交(8 个文件) |
| `examples/msw-todo` | `@object-ui/example-msw-todo` | 被删 | 同一提交(21 个文件) |

提交 `12b287d8b` — *"refactor: remove example Todo application and related files"*(Jack Zhuang, 2026-05-02)。关键的三点:

1. `git show --diff-filter=A --name-only 12b287d8b` 输出为空 —— 该提交**没有新增任何目录**,所以不存在「移到别处」。
2. `git show --name-only 12b287d8b | grep '^README.md$'` 计数为 0 —— **没有同步更新 README**,这正是漂移的来源。
3. 仓库内已无任何 ref 还持有这四个目录(遍历 `refs/remotes` + `refs/heads` 逐个 `git cat-file -e` 均未命中)。

**排除「移仓」的交叉验证:** 兄弟仓库 `objectstack` 确实有 `examples/app-crm`、`examples/app-todo`,但它们的首个提交是 `1a758d042`(2026-02-03),**早于本仓库删除动作三个月**,且包名为 `@objectstack/example-*`、入口是 `objectstack.config.ts` —— 那是后端 metadata 示例,与这里被删的 `@object-ui/example-*` 前端示例是各自独立的东西,不是迁移目的地。`kitchen-sink` / `msw-todo` 在 `objectstack` 现存目录中也没有对应物。因此**不改绝对链接,直接删除四条**。

## 改动

**README.md**

- 删除四条幽灵条目;补上真实存在却从未被提及的 `hello-world` 与 `schema-catalog`,描述全部取自它们各自的 README 与 package.json(未作臆测)。
- 删除整节 "Running Examples as API Servers"。该节**已完全失效**,不只是提到了被删示例:
  - 根 `package.json` 中不存在任何 `serve:*` 脚本(`serve:crm` / `serve:todo` / `serve:kitchen-sink` 全是死命令);
  - 现存四个示例**没有一个**声明 `serve` 脚本(`byo-backend-console`、`console-starter` 是 `dev/build/lint/type-check/preview`;`hello-world` 只有 `lint`;`schema-catalog` 是 `build/test/...`);
  - 因此 "Each server provides: GraphQL API endpoint..." 描述的服务端形态在本仓库已不存在。
  - 替换为真实可用的 Vite dev 流程。

**examples/README.md**(issue 要求一并对齐)

- 该文件**没有**幽灵条目,但漏了 `schema-catalog`。补上 —— 它自己的 README 明确写着"不是可运行应用,是 data package + smoke tests",所以单列一节,而不是塞进 "Runnable examples" 表格里谎称可运行。
- 修正 `cd examples/[示例名] && pnpm dev` 这条通用说明:对 `hello-world`(无 dev 脚本)和 `schema-catalog`(data package)都不成立。

## 验证

lychee 二进制在本环境不可用(未安装,`npx lychee` 亦无),因此写了一个等价的离线检查器复现它那一类 File-not-found 判定,并**先声明预期方向再运行**:origin/main 的 README.md 应恰好报 4 个错(59-62 行),examples/README.md 应本来就是 0 —— 实测与预期一致。

```
=== BEFORE(origin/main 内容,按真实仓库树解析)===
  [ERROR] README.md:59 -> examples/crm (File not found)
  [ERROR] README.md:60 -> examples/todo (File not found)
  [ERROR] README.md:61 -> examples/kitchen-sink (File not found)
  [ERROR] README.md:62 -> examples/msw-todo (File not found)
  checked 40 relative file link(s) — FAIL: 4 File-not-found error(s)

  examples/README.md: checked 3 — OK: 0 File-not-found errors

=== AFTER ===
  checked 45 relative file link(s) across 2 file(s)
  OK: 0 File-not-found errors
```

其余检查:

- `node scripts/check-doc-links.mjs` → `Docs links are valid.`(注:该脚本只扫 `content/docs/`,不覆盖 README,故为回归确认而非本改动的证据)
- `pnpm check:control-bytes` → `OK (scanned 3673 tracked text file(s); skipped 85 binary)`
- 控制字节自查:`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' README.md examples/README.md` → 无命中
- markdown 结构:README.md 36 个 fence 标记(平衡)、examples/README.md 2 个(平衡);表格列数一致(5/5/5 与 2/2/2)

无 changeset —— 纯文档改动。

## 范围外发现(未在本 PR 修改)

`examples/hello-world/README.md:31-32` 同样指向被删目录(`../crm/`、`../todo/`),但该文件不在本次派发的文件围栏内,已另行记录。`content/docs/**` 下的同类链接由另一个派发负责。`ROADMAP.md` 与 `CHANGELOG.md` 中的提及属历史记录,不应改动。