### PR TITLE
docs(examples): 修复 hello-world README 指向已删除示例的两条死链

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -28,6 +28,6 @@ pnpm install
 
 ## Learn more
 
-- [CRM Example](../crm/) — full-featured reference app
-- [Todo Example](../todo/) — ObjectStack protocol basics
+- [BYO Backend Console](../byo-backend-console/) — add ObjectUI to an existing product with your own REST/GraphQL backend (~100 lines: custom `DataSource` + router)
+- [Console Starter](../console-starter/) — fork it to stand up a brand-new ObjectStack console, with the full plugin set already wired
 - [Schema Catalog](../schema-catalog/) — canonical JSON schemas used across docs & tests


### PR DESCRIPTION
Fixes #3486

## 背景

`examples/hello-world/README.md` 的 "Learn more" 三条里有两条是死链:`../crm/` 与 `../todo/` 指向的目录已在 12b287d8b(2026-05-02,`refactor: remove example Todo application and related files`)随 CRM/Todo 示例一并删除。hello-world 是入门示例,读者读完的第一跳就是这一节 —— 三条里两条 404。第三条 `../schema-catalog/` 仍有效。

## 改动

只改 `examples/hello-world/README.md` 一个文件,只改 "Learn more" 三行:

- 删掉 `../crm/`、`../todo/` 两条;
- 按 `examples/README.md` 的 "Rule of thumb" 进阶路径补上现存的两个可运行示例(顺序即该路径顺序:hello-world 之后 → 接入已有产品 → 从零起 console);
- `../schema-catalog/` 原样保留。

描述不臆造,逐条取自仓库内既有材料:

| 新增条目 | 描述出处 |
|---|---|
| `../byo-backend-console/` | 其 README(`~100 lines`、自定义 `DataSource` + router、mock REST 而非 ObjectStack)与 `examples/README.md` 表格行("embed ObjectUI into your own app and connect it to your own REST/GraphQL backend") |
| `../console-starter/` | 该目录**没有 README**,故取 `package.json` 的 `description`("Opinionated, fork-ready console template built on @object-ui/app-shell with the full plugin set wired up.")与 `examples/README.md` 表格行 |

## 验证

按 PR #3485 的做法,对改后文件做离线相对链接解析(把每个相对 href 落到文件系统上):

改前(`git show origin/main:examples/hello-world/README.md`):

```
File-not-found  ----  [CRM Example](../crm/)
File-not-found  ----  [Todo Example](../todo/)
OK    dir   [Schema Catalog](../schema-catalog/)
relative links checked: 3
File-not-found: 2
```

改后:

```
OK    dir   [BYO Backend Console](../byo-backend-console/)
OK    dir   [Console Starter](../console-starter/)
OK    dir   [Schema Catalog](../schema-catalog/)
relative links checked: 3
File-not-found: 0
```

方向是事先定好的:死链修复应当"改前红、改后绿",实际即如此。

其余检查:

- markdown 代码围栏配平:4 行围栏 = 2 对(12/18、22/27),均在本次改动之外;
- 控制字节自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` → 无命中,`file` 报 `Unicode text, UTF-8 text`;
- `pnpm check:control-bytes` → `OK (scanned 3674 tracked text file(s); skipped 85 binary)`;
- `pnpm docs:check-links` → `Docs links are valid.`(说明:该 gate 只走 `content/docs` 且只校验 `/docs` 开头的路由,`examples/**/README.md` 的相对链接根本不在其扫描面内 —— 这正是这两条死链能存活三个月的原因,已另行记录,不在本 PR 处理)

docs-only,无 changeset。`ROADMAP.md` / `CHANGELOG.md` 的历史记录未动;`content/docs` 的同类死链归 #3490,本 PR 不碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_