### PR TITLE
ci(shadcn): 按失败类别把 shadcn:check 的退出码路由进 issue 通道

### DIFF
--- a/.github/workflows/shadcn-check.yml
+++ b/.github/workflows/shadcn-check.yml
@@ -4,21 +4,29 @@ on:
   # Run weekly on Mondays at 9:00 AM UTC
   schedule:
     - cron: '0 9 * * 1'
-  
+
   # Allow manual trigger
   workflow_dispatch:
+
+# The reporting step below opens (or comments on) a tracking issue, which the
+# default token cannot do unless it is asked for. Declared explicitly so an
+# org-wide tightening of the default workflow permissions cannot silently turn
+# the only alarm channel this workflow has back into a no-op.
+permissions:
+  contents: read
+  issues: write
 
 jobs:
   check-components:
     name: Check for Shadcn Component Updates
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           submodules: true
-      
+
       - name: Enable Corepack
         run: corepack enable
 
@@ -30,10 +38,13 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'pnpm'
-      
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
+      # Left tolerant deliberately: `component-analysis.js` has exactly one
+      # non-zero exit (an unhandled crash in `main()`), so there is no verdict
+      # here to swallow — its output is advisory context for the report below.
       - name: Analyze components (offline)
         id: analyze
         run: |
@@ -41,15 +52,111 @@ jobs:
           pnpm shadcn:analyze > analysis.txt
           cat analysis.txt
         continue-on-error: true
-      
+
+      # `pnpm shadcn:check` has carried a REAL exit code since #3455: it exits
+      # non-zero for one reason only — a declared local patch that is missing
+      # from the file on disk, or that no longer re-applies to current upstream
+      # (`results.patchFailures > 0` in scripts/shadcn-sync.js). Ordinary drift
+      # (outdated/modified) and an unreachable registry both stay exit 0 by
+      # design, because that gate "must only ever accuse real drift".
+      #
+      # This step used to carry `continue-on-error: true`, which threw that code
+      # away wholesale — and because the reporting step was gated on `failure()`,
+      # which a tolerated step never produces, the issue-creation path below had
+      # never once run (objectstack#5805). The code is captured explicitly here
+      # instead, classified, and routed into that issue path: this workflow runs
+      # weekly on a schedule, and a red run on a page nobody opens is not an
+      # alarm — an issue in the triage queue is.
       - name: Check component status (online)
         id: check
+        shell: bash
         run: |
           echo "Checking component status against Shadcn registry..."
-          pnpm shadcn:check > check.txt
-          cat check.txt
-        continue-on-error: true
-      
+          set +e
+          pnpm shadcn:check 2>&1 | tee check.ansi.txt
+          status=${PIPESTATUS[0]}
+          set -e
+
+          # The script colours every line unconditionally (no TTY or NO_COLOR
+          # check), so the raw capture is dense with ANSI escapes. Strip them for
+          # the artifact and for the issue body. `\e` below is perl's own escape
+          # sequence — never write the byte itself into a repo file
+          # (objectstack#4890).
+          perl -pe 's/\e\[[0-9;]*[A-Za-z]//g' check.ansi.txt > check.txt
+          rm -f check.ansi.txt
+
+          # How many components the registry could not serve. Both shapes the
+          # script produces for that: a rejected fetch, and a response whose
+          # file content is unusable (proxy error page, egress block, schema
+          # change). Counted for reporting only — see the tolerance rule below.
+          registry_errors=$(grep -cE 'Registry returned no usable file content|Error fetching from registry:' check.txt || true)
+
+          # Three classes. Only the benign one is tolerated, so a failure mode
+          # nobody anticipated cannot fall through the same gap the swallowed
+          # exit code did:
+          #
+          #   patch   the patch gate's own verdict line is present. Upstream
+          #           moved an anchor the next `--update` must re-apply, or a
+          #           required edit vanished from the file on disk. ALARM.
+          #   ok      exit 0 and no such verdict. Includes an unreachable
+          #           registry, which the script reports per component and still
+          #           exits 0 — tolerated, per objectstack#5805.
+          #   broken  any other non-zero exit: the check could not run at all
+          #           (fatal error, bad invocation, tooling). ALARM — a check
+          #           that cannot report is not a passing check.
+          #
+          # The verdict line is tested BEFORE the exit code on purpose: the
+          # message is the evidence, the exit code is a policy that a later
+          # change to the script could revise without touching this workflow.
+          if grep -qF 'component(s) with declared local patch failures' check.txt; then
+            check_class=patch
+          elif [ "$status" -eq 0 ]; then
+            check_class=ok
+          else
+            check_class=broken
+          fi
+
+          alarm=false
+          if [ "$check_class" != 'ok' ]; then
+            alarm=true
+          fi
+
+          {
+            echo "exit_code=$status"
+            echo "class=$check_class"
+            echo "registry_errors=$registry_errors"
+            echo "alarm=$alarm"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Shadcn component check"
+            echo ""
+            echo "- \`pnpm shadcn:check\` exit code: \`$status\` (class: \`$check_class\`)"
+            echo "- components the registry could not serve: $registry_errors"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$check_class" in
+            patch)
+              echo "::error::Declared local patches are failing (exit $status). Opening/updating the tracking issue."
+              echo "- Verdict: a declared local patch failed. Tracking issue opened or updated." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            broken)
+              echo "::error::shadcn:check exited $status without a patch verdict — the check itself could not run. Opening/updating the tracking issue."
+              echo "- Verdict: the check could not run. Tracking issue opened or updated." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            ok)
+              if [ "$registry_errors" -gt 0 ]; then
+                # Tolerated, but never reported as a clean bill of health: with
+                # the registry unreachable the upstream-anchor half of the check
+                # did not execute, so this run proved nothing about upstream.
+                echo "::warning::$registry_errors component(s) could not be fetched from the registry, so the upstream-anchor check did not run. Tolerated by design — no issue opened."
+                echo "- Verdict: no patch failure, but the online half did not run (registry unreachable). Tolerated, no issue opened." >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "- Verdict: all declared local patches still apply to current upstream." >> "$GITHUB_STEP_SUMMARY"
+              fi
+              ;;
+          esac
+
       - name: Upload analysis results
         uses: actions/upload-artifact@v7
         if: always()
@@ -59,36 +166,70 @@ jobs:
             analysis.txt
             check.txt
           retention-days: 30
-      
-      - name: Create issue if components are outdated
-        if: failure()
+
+      # Deliberately NOT `continue-on-error`: this step is the alarm. If it
+      # cannot deliver (missing permission, API outage), the job must go red,
+      # because a silently broken alarm channel is the bug this workflow was
+      # just fixed for.
+      - name: Report check failure as an issue
+        if: steps.check.outputs.alarm == 'true'
         uses: actions/github-script@v9
+        env:
+          CHECK_CLASS: ${{ steps.check.outputs.class }}
+          CHECK_EXIT: ${{ steps.check.outputs.exit_code }}
+          REGISTRY_ERRORS: ${{ steps.check.outputs.registry_errors }}
         with:
           script: |
             const fs = require('fs');
-            
+
+            const checkClass = process.env.CHECK_CLASS;
+            const isPatchFailure = checkClass === 'patch';
+
+            const title = isPatchFailure
+              ? 'Shadcn sync: declared local patches are failing'
+              : 'Shadcn sync: the weekly component check could not run';
+
             let body = '## Shadcn Components Status Report\n\n';
-            body += 'The weekly component sync check has detected issues or updates.\n\n';
-            
+            if (isPatchFailure) {
+              body += 'The weekly component sync check found a **declared local patch failure**: ';
+              body += 'either a required edit is missing from the file on disk, or upstream moved ';
+              body += 'the anchor it is applied to, so the next `pnpm shadcn:update` would refuse ';
+              body += 'to write rather than drop it. Details in the check output below.\n\n';
+            } else {
+              body += 'The weekly component sync check **could not complete**: `pnpm shadcn:check` ';
+              body += 'exited `' + process.env.CHECK_EXIT + '` without reaching a patch verdict. ';
+              body += 'Until this is fixed the weekly upstream early-warning is not running.\n\n';
+            }
+            body += '- Exit code: `' + process.env.CHECK_EXIT + '` (class: `' + checkClass + '`)\n';
+            body += '- Components the registry could not serve: ' + process.env.REGISTRY_ERRORS + '\n';
+            body += '- Run: ' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo +
+              '/actions/runs/' + context.runId + '\n\n';
+
             if (fs.existsSync('analysis.txt')) {
               const analysis = fs.readFileSync('analysis.txt', 'utf8');
               body += '### Offline Analysis\n\n';
               body += '```\n' + analysis.substring(0, 5000) + '\n```\n\n';
             }
-            
+
             if (fs.existsSync('check.txt')) {
               const check = fs.readFileSync('check.txt', 'utf8');
               body += '### Online Check Results\n\n';
               body += '```\n' + check.substring(0, 5000) + '\n```\n\n';
             }
-            
+
             body += '### Next Steps\n\n';
-            body += '1. Review the analysis results above\n';
-            body += '2. Run `pnpm shadcn:analyze` locally for detailed information\n';
-            body += '3. Update components as needed with `pnpm shadcn:update <component>`\n';
-            body += '4. See [SHADCN_SYNC.md](../blob/main/docs/SHADCN_SYNC.md) for detailed guide\n\n';
+            if (isPatchFailure) {
+              body += '1. Read the `DECLARED LOCAL PATCHES` section above — it names the patch id, its tracking issue and the reason\n';
+              body += '2. Marker missing from disk: restore it with `pnpm shadcn:update <component>`\n';
+              body += '3. Anchor no longer found upstream: re-target `find`/`occurrences` in `scripts/shadcn-local-patches.mjs`\n';
+              body += '4. See [SHADCN_SYNC.md](../blob/main/docs/SHADCN_SYNC.md) for detailed guide\n\n';
+            } else {
+              body += '1. Open the workflow run linked above and read the failure\n';
+              body += '2. Reproduce locally with `pnpm shadcn:check`\n';
+              body += '3. See [SHADCN_SYNC.md](../blob/main/docs/SHADCN_SYNC.md) for detailed guide\n\n';
+            }
             body += '> This issue was automatically created by the Shadcn Components Check workflow.\n';
-            
+
             // Check if there's already an open issue
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -96,7 +237,7 @@ jobs:
               state: 'open',
               labels: 'shadcn-sync',
             });
-            
+
             if (issues.data.length > 0) {
               // Update existing issue
               await github.rest.issues.createComment({
@@ -110,7 +251,7 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: 'Shadcn Components Need Review',
+                title: title,
                 body: body,
                 labels: ['maintenance', 'shadcn-sync', 'dependencies'],
               });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5805

## 前提核验（在 origin/main 上逐条确认）

1. **退出码确实被吞。** `.github/workflows/shadcn-check.yml` 的 `check` 步骤带 `continue-on-error: true`,`pnpm shadcn:check` 的退出码原样丢弃。
2. **不只是"不标红"——告警通道从未跑过一次。** 下游那个"发现更新就开 issue"的步骤条件是 `if: failure()`。被 `continue-on-error` 容错的步骤 conclusion 记为 success,job 状态不变,`failure()` 永远为假。也就是说 workflow 后半段的建 issue 逻辑自写下起就是死代码。旁证:仓库里从来没有过带 `shadcn-sync` 标签的 issue(`label:shadcn-sync` 搜索结果 0 条)。
3. **退出码的真实语义(#3455 之后)。** `scripts/shadcn-sync.js` 的 `--check` 分支只有一个非零来源:

   ```
   if (results.patchFailures > 0) { ...; process.exitCode = 1; }
   ```

   `patchFailures` = `missingPatches`(磁盘上的文件丢了声明式补丁的 marker)与 `unappliablePatches`(上游挪走锚点,下次 `--update` 无法重施加)的**去重并集**。普通漂移(outdated / modified / UNDOCUMENTED)按设计保持退出 0。
4. **registry 不可达本来就不会非零。** `checkComponent` 的两条错误路径都只把组件标成 `status: 'error'`,并显式注释"gate 只能指控真实漂移"。所以"容忍 registry 不可达"不需要新写豁免——**它本来就已经是退出 0**,只要不再吞码即可。

前提成立,且比 issue 描述的更糟一档(建 issue 逻辑是死的)。

## 改了什么

只动 `.github/workflows/shadcn-check.yml`:

- `check` 步骤去掉 `continue-on-error`,改为显式捕获退出码(`set +e` + `PIPESTATUS[0]`),步骤自身仍恒定退出 0,**job 不会因为补丁失效变红**——按 PM 裁定:周任务红没人看,进 issue 才进分诊流。
- 三分类,顺序是"先看证据行,再看退出码":

  | 类别 | 判据 | 处置 |
  | --- | --- | --- |
  | `patch` | 输出含 `component(s) with declared local patch failures` | 走既有建/评论 issue 逻辑,标签不变 |
  | `ok` | 退出 0 且无上述判据(含 registry 不可达) | 容忍,不开 issue |
  | `broken` | 其余任何非零退出(致命错误、调用失败) | 也告警——跑不起来的检查不是通过的检查 |

  判据行优先于退出码是刻意的:消息是证据,退出码是脚本可以另行修订的策略。容忍面只覆盖**已识别的良性类别**,其余一律告警,免得再挖出一个和被吞退出码同形状的缝。
- 输出去掉 ANSI(脚本无条件上色),artifact 和 issue 正文因此可读;剥离用的是 perl 自己的转义写法,仓库文件里没有任何裸控制字节(objectstack#4890)。
- 补 `permissions: contents: read / issues: write`。这条路径从没跑过,谁也没验证过默认 token 建得了 issue;显式声明后,组织级收紧默认权限也不会把唯一的告警通道悄悄变回空操作。
- 建 issue 的步骤**故意不加** `continue-on-error`:它就是告警本身,送不出去必须让 job 红。
- `$GITHUB_STEP_SUMMARY` 写一段结论,`ok` 且有 registry 错误时另发 `::warning::`——容忍不等于报平安。

`analyze` 步骤保持原样:`component-analysis.js` 只有一处非零退出(未捕获崩溃),没有可吞的判决,它的输出是报告的辅助上下文。

## 干跑证据

从 YAML 里**解析出真正要发布的 `run` 块**,配合桩 `pnpm` 跑 5 个**真实产出**的 fixture(不是手写文本)。方向在运行前先写死:

| fixture 来源 | 退出码 | 预期 | 实测 outputs |
| --- | --- | --- | --- |
| 全量种入 cache,46 个组件 identical | 0 | ok,无告警 | `class=ok registry_errors=0 alarm=false`,无 annotation |
| 本容器直连 registry 失败(46 个 `Registry returned no usable file content`) | 0 | ok,容忍但发 warning | `class=ok registry_errors=46 alarm=false` + `::warning::` |
| /tmp 副本里删掉 sheet.tsx 的两个 marker | 1 | patch | `class=patch registry_errors=46 alarm=true` + `::error::` |
| 种入"上游把 Close 改成 Dismiss"的 cache,锚点找不到 | 1 | patch | `class=patch registry_errors=45 alarm=true` + `::error::` |
| 移走 manifest 触发 `Error loading manifest` | 1 | broken | `class=broken registry_errors=0 alarm=true` + `::error::` |

5 例全部与预判一致;`check.txt` 中残留 ESC 字节数 0,临时文件已清理。补丁失效的两类都是在 **/tmp 的一次性副本**里模拟的,repo 树与 `scripts/**` 未被触碰。

`github-script` 的 payload 也做了离线渲染(桩 `github`/`context`):新建分支 title 随类别变化、labels 仍是 `['maintenance','shadcn-sync','dependencies']`、去重查询仍按 `shadcn-sync` 标签找已开 issue 并改走 `createComment` —— 与原块行为一致。

YAML `yaml.safe_load` 通过;`bash -n` 通过;`node scripts/check-control-bytes.mjs` 通过,并额外做了越过该 gate 的自查(0x00-0x1f 与 0x7f 全扫)。本机没有 actionlint / shellcheck,这两项没跑。

**诚实的边界:**真实的定时运行只能由下周一的 cron 或一次手动 `workflow_dispatch` 证明——建议合并后手动触发一次,顺带验证 token 真的能建 issue。

## 已知限制(有意保留,未在本 PR 处理)

- registry 不可达时,"上游挪锚点"这一半根本没执行,本次运行其实什么也没证明。按裁定容忍,只发 warning + summary;是否对"连续 N 周不可达"告警需要跨运行状态,超出本单。
- job 没有 `timeout-minutes`:`--check` 是 46 次串行请求,挂住会静默烧满默认时限。与退出码无关,未在此改。

## 与 #5803 的关系

不依赖它。分类只读当前脚本已有的输出:`Error fetching from registry:` / `Registry returned no usable file content` / `component(s) with declared local patch failures`。已核对 #5803 在途分支未改动这三处字符串,它新增的 HTTP 状态码错误仍从 `fetchUrl` reject,落进同一条 `Error fetching from registry:` 消息里,分类不受影响。

CI-only,无 changeset。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_