### PR TITLE
fix(scripts): 删除 check-doc-links 测试中已失效的 @ts-expect-error(修复净 main 上的 TS2578)

### DIFF
--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -4,7 +4,6 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// @ts-expect-error — plain-JS CI helper, intentionally untyped
 import { collectBrokenLinks, routeExists, stripCode } from '../check-doc-links.mjs';
 
 /**


### PR DESCRIPTION
Fixes #3504

## 症状

净 `origin/main`(f995a452d)上 `pnpm type-check:scripts` 红:

```
scripts/__tests__/check-doc-links.test.ts(7,1): error TS2578: Unused '@ts-expect-error' directive.
 ELIFECYCLE  Command failed with exit code 2.
```

CI 的 `type-check` job 跑的就是这条命令,因此**当前所有开着的 PR 的 Type Check 全部误红** —— 红的不是它们的改动。

## 成因:两个各自绿的 PR 合并后的语义冲突

这是典型的 semantic conflict:两个 PR 在文本上毫不相干、各自 CI 全绿,合并结果为红。

1. **PR #3489(449227d71)** 新增 `scripts/__tests__/check-doc-links.test.ts`,导入行上带
   `@ts-expect-error — plain-JS CI helper, intentionally untyped`。
   **写下时是正确的**:彼时仓库里没有任何 tsc program `include` 了 `scripts/`(根 `tsconfig.json` 只含 `packages`/`examples`/`apps`),该 `.mjs` 导入确实无类型可用,压制注释既无害也无人检验。

2. **PR #3498(f995a452d)** 引入 `tsconfig.scripts.json`,首次把 `scripts/**/*.ts` 纳入类型检查,并且经过实测选择了 `allowJs: true`(见该文件内的长篇注释)。`allowJs` 让 `.mjs` 助手的类型**从助手自身推断**得到,于是所有这类压制注释在同一瞬间集体变成 Unused。#3498 已经修掉了它 base 上的 **5 处**同类。

3. #3489 的这**第 6 处**恰好落在 #3498 开分支与合并之间的窗口里 —— 对 #3498 不可见,而 #3489 那边根本没有任何东西 type-check 它。两边 CI 都绿,merge base 之后才红。

换句话说:压制注释没有"错",是它脚下的地基(类型门的覆盖面)变了。

## 改动

只删掉那一行,不动其它任何东西:

```diff
-// @ts-expect-error — plain-JS CI helper, intentionally untyped
 import { collectBrokenLinks, routeExists, stripCode } from '../check-doc-links.mjs';
```

一个文件,一行,`1 file changed, 1 deletion(-)`。无 changeset —— 改动在 `scripts/` 下的 CI 测试文件里,不是任何已发布包的一部分,对用户不可见。

## 验证

**先在净 `origin/main`(未做任何改动、`git status` 干净)上复现**,再改,再复跑:

| 阶段 | 命令 | 结果 |
| --- | --- | --- |
| 改动前(净 main) | `pnpm type-check:scripts` | ❌ exit 2,`TS2578` at (7,1) |
| 改动后 | `pnpm type-check:scripts` | ✅ exit 0,无输出 |
| 改动后 | `pnpm exec vitest run scripts/__tests__/check-doc-links.test.ts --maxWorkers=2` | ✅ `Test Files 1 passed (1)` / `Tests 22 passed (22)` |
| 改动后 | `node scripts/check-control-bytes.mjs` | ✅ `OK (scanned 3686 tracked text file(s); skipped 85 binary)` |

**运行期行为从不依赖该指令**:`@ts-expect-error` 是纯 tsc 编译期构造,vitest 经 esbuild 转译时把它当普通注释剥离,对 `collectBrokenLinks` / `routeExists` / `stripCode` 的实际导入与执行零影响。所以这里 22 个用例保持全绿是**预期方向**,而不是"测试没覆盖到"的空绿 —— 真正把这次改动钉住的是 `type-check:scripts` 由红转绿这一条。

另在被改文件上做了超出门禁扫描面的控制字符自查(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,无命中;`file` 报 UTF-8 text)。

## 后续(不在本 PR 范围)

本 PR 是止血,刻意只删这一行。这类"新类型门上线 + 并行 PR 在窗口期落地旧式压制"的碰撞会重演;是否需要一条更结构化的防线(例如让 #3498 那类覆盖面扩张 PR 在合入前对 `origin/main` 最新态复跑一次,或把 `type-check:scripts` 纳入 merge queue 的必需检查),留给维护者判断,未在此另开 issue。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_