### PR TITLE
fix(docs): 非 /docs 绝对链接按站点路由校验,并修掉 18 条真实 404 (#3490)

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -246,10 +246,24 @@ all**, which is the point of the workflow. It appears in the checks list as **In
 Check**.
 
 Runs `scripts/check-doc-links.mjs`, which walks every `.md` / `.mdx` file under `content/docs/` and
-resolves each internal markdown link against the files actually on disk (`/docs/foo` must have a
-`foo.md`, `foo.mdx` or `foo/index.md*` under `content/docs/`). External `http(s)` and `mailto:`
-links and bare `#anchors` are skipped — those belong to Lychee, below. No install, no build, no
-network: a checkout and one `node` call.
+asks of each internal markdown link the only question a reader cares about — **does the site serve
+this URL?** Four checks, by href shape:
+
+| Href shape | Resolved against | Rejected when |
+|---|---|---|
+| relative (`../plugins/plugin-charts.mdx`) | the linking file's directory | the target file is missing… |
+| relative escaping the collection (`../../../packages/x/README.md`) | — | …**or** it resolves outside `content/docs/` (fumadocs can only resolve inside its page index, so the href reaches the browser verbatim — a 404 even though the file exists) |
+| absolute `/docs/...` | `content/docs/` as a **route** | no `foo.md`, `foo.mdx` or `foo/index.md*` backs it — a `.md`/`.mdx` suffix always fails, since that URL 404s whatever is on disk |
+| any other absolute (`/spec/...`, `/img/...`) | the **site itself**: route segments enumerated from `apps/site/app`, plus static files under `apps/site/public` | no route pattern or static file matches |
+
+External `http(s)` and `mailto:` links and bare `#anchors` are skipped — those belong to Lychee,
+below. No install, no build, no network: a checkout and one `node` call.
+
+The last two rows are objectui#3490. Reading `apps/site` widens the script's responsibility, and
+that is the deliberate purchase: it is the only way to catch a link to a route that does not exist,
+and 18 such 404s had accumulated while the check waved every non-`/docs` absolute href through. The
+cost is that a docs PR can now go red because `apps/site` moved under it — correct, but real. The
+header of the script argues the trade-off in full.
 
 **Why it blocks a merge.** A broken internal link is a 404 on the published site, and nothing else
 in CI sees it: the site build succeeds with a dead link in it. The script itself is older than its
@@ -287,7 +301,7 @@ There are **two** link checkers, and they cover different things (objectui#3213)
 
 | | Covers | Network | Runs |
 |---|---|---|---|
-| `scripts/check-doc-links.mjs` | **Internal** `/docs/...` routes, resolved against `content/docs/` | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
+| `scripts/check-doc-links.mjs` | **Internal** links in `content/docs/`: relative hrefs, `/docs/...` routes, and every other site-absolute href (against `apps/site`) | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
 | Lychee (this workflow) | **External** URLs, plus **relative** in-repo file links, in `content/docs/`, `docs/` and `README.md` | Yes | Weekly cron and manual dispatch |
 
 Lychee sweeps **both** documentation trees: `content/docs/` (the 183 pages the site publishes) and

--- a/content/docs/guide/component-registry.md
+++ b/content/docs/guide/component-registry.md
@@ -459,10 +459,10 @@ export { RatingComponent }
 
 - [Expression System](./expressions.md) - Learn about dynamic expressions
 - [Schema Rendering](./schema-rendering.md) - Understand the rendering engine
-- [Creating Custom Components](/spec/component-package.md) - Deep dive into component creation
+- [Custom Plugin Development](/docs/guide/plugin-development) - Deep dive into component creation
 
 ## Related Documentation
 
-- [Core API](/api/core) - Component registry API
-- [React API](/api/react) - React integration
-- [Component Specification](/spec/component.md) - Component metadata spec
+- [`@object-ui/core` README](https://github.com/objectstack-ai/objectui/tree/main/packages/core) - Component registry API
+- [`@object-ui/react` README](https://github.com/objectstack-ai/objectui/tree/main/packages/react) - React integration
+- [Schema Type Reference](/docs/api/schema-reference) - Component metadata reference

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -199,5 +199,5 @@ behaviour: probe `/batch` and fall back to the non-atomic emulation on
 `404`/`405`/`501`. Atomic cross-object saves are therefore guaranteed only
 against backends that advertise the capability; older ones still save, but
 best-effort. See the
-[adapter README](../../../packages/data-objectstack/README.md#cross-object-atomic-batch-batchtransaction)
+[adapter README](https://github.com/objectstack-ai/objectui/blob/main/packages/data-objectstack/README.md#cross-object-atomic-batch-batchtransaction)
 for the full capability table and minimum-backend note.

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -636,10 +636,10 @@ const data: UserData = { /* ... */ }
 
 - [Schema Rendering](./schema-rendering.md) - Learn the rendering engine
 - [Component Registry](./component-registry.md) - Understand components
-- [Protocol Overview](/protocol/overview) - Explore schema specifications
+- [Schema Overview](/docs/guide/schema-overview) - Explore schema specifications
 
 ## Related Documentation
 
-- [Core API](/api/core) - Expression evaluator API
-- [Form Protocol](/protocol/form) - Form-specific expressions
-- [View Protocol](/protocol/view) - Data view expressions
+- [`@object-ui/core` README](https://github.com/objectstack-ai/objectui/tree/main/packages/core) - Expression evaluator API
+- [Form Plugin](/docs/plugins/plugin-form) - Form-specific expressions
+- [View Plugin](/docs/plugins/plugin-view) - Data view expressions

--- a/content/docs/guide/fields.md
+++ b/content/docs/guide/fields.md
@@ -66,7 +66,7 @@ Once registered, you can simply use the new type in your JSON schema.
 
 ## Standard Fields
 
-Object UI comes with built-in support for the standard [ObjectStack Protocol](/protocol) types:
+Object UI comes with built-in support for the standard [ObjectStack Protocol](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) types:
 
 | Type | Description |
 |---|---|

--- a/content/docs/guide/objectos-integration.mdx
+++ b/content/docs/guide/objectos-integration.mdx
@@ -659,8 +659,8 @@ test('create contact workflow', async ({ page }) => {
 - [ObjectStack Documentation](https://docs.objectstack.ai)
 - [ObjectUI Components Reference](/docs/components)
 - [ObjectQL Schemas](/docs/api/schema-reference#objectql-schemas)
-- [Example: CRM Application](/examples/crm)
-- [Example: Kitchen Sink](/examples/kitchen-sink)
+- [Example: ObjectStack Console Starter](https://github.com/objectstack-ai/objectui/tree/main/examples/console-starter)
+- [Schema Catalog](/docs/guide/schema-catalog) - every schema rendered in these docs
 
 ## Support
 

--- a/content/docs/guide/plugins.md
+++ b/content/docs/guide/plugins.md
@@ -512,7 +512,7 @@ export function registerComponents() {
 
 - [Component Registry](./component-registry.md) - Understanding the registry
 - [Schema Rendering](./schema-rendering.md) - How schemas become UI
-- [Creating Components](/spec/component-package.md) - Component development
+- [Custom Plugin Development](/docs/guide/plugin-development) - Component development
 - **[Create Plugin Utility](/docs/utilities/create-plugin)** - Scaffold new plugins quickly
 - **[CLI Tool](/docs/utilities/cli)** - Test plugins with the CLI
 - **[All Utilities](/docs/utilities)** - Complete toolkit for development

--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -411,11 +411,11 @@ Always type your schemas for better IDE support and fewer runtime errors.
 
 - [Component Registry](./component-registry.md) - Learn about component registration
 - [Expression System](./expressions.md) - Master expressions
-- [Protocol Overview](/protocol/overview) - Explore all available schemas
+- [Schema Overview](/docs/guide/schema-overview) - Explore all available schemas
 
 ## Related Documentation
 
-- [Schema Specification](/spec/schema-rendering) - Technical specification
-- [Architecture](/spec/architecture) - System architecture
-- [Core API](/api/core) - Core package API reference
-- [React API](/api/react) - React package API reference
+- [SchemaRenderer](/docs/core/schema-renderer) - Technical reference for the renderer
+- [Architecture Overview](/docs/guide/architecture) - System architecture
+- [`@object-ui/core` README](https://github.com/objectstack-ai/objectui/tree/main/packages/core) - Core package API reference
+- [`@object-ui/react` README](https://github.com/objectstack-ai/objectui/tree/main/packages/react) - React package API reference

--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -4,8 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// @ts-expect-error — plain-JS CI helper, intentionally untyped
-import { collectBrokenLinks, routeExists, stripCode } from '../check-doc-links.mjs';
+import { collectBrokenLinks, collectSiteRoutes, routeExists, siteUrlExists, stripCode } from '../check-doc-links.mjs';
 
 /**
  * objectui#3479 — the behaviour test for `scripts/check-doc-links.mjs`.
@@ -28,13 +27,34 @@ import { collectBrokenLinks, routeExists, stripCode } from '../check-doc-links.m
  *
  * The A-class defect in #3479 is exactly the first shape violated: 13 links
  * spelled `../plugins/plugin-*.md` while every one of those files is `.mdx`.
+ *
+ * objectui#3490 removed the two waivers those checks were still built on — a
+ * non-`/docs` absolute href was waved through unchecked, and a relative href was
+ * judged purely as a path on disk. Both answered "does a file exist?" when the
+ * question is "does the site serve this URL?", and 18 live 404s had collected
+ * behind them. The gate now enumerates `apps/site/app` + `apps/site/public` as
+ * its truth source for absolute hrefs, and rejects relative hrefs that resolve
+ * out of the docs collection. The describes at the bottom pin both.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const tempRoots: string[] = [];
 
-/** Materialises `{ 'guide/a.md': '...' }` into a throwaway docs root. */
-function docsRootWith(files: Record<string, string>): string {
+/**
+ * The default site fixture: the shapes the real `apps/site/app` uses — a route
+ * group serving `/`, a plain segment, an optional catch-all, a nested route
+ * handler — plus one static file under `public/`.
+ */
+const SITE_FIXTURE: Record<string, string> = {
+  'apps/site/app/(home)/page.tsx': 'export default () => null',
+  'apps/site/app/playground/page.tsx': 'export default () => null',
+  'apps/site/app/docs/[[...slug]]/page.tsx': 'export default () => null',
+  'apps/site/app/api/search/route.ts': 'export const GET = () => null',
+  'apps/site/public/img/guide/shot.png': 'PNG',
+};
+
+/** Materialises `{ 'content/docs/guide/a.md': '...' }` into a throwaway repo. */
+function repoWith(files: Record<string, string>): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'check-doc-links-'));
   tempRoots.push(root);
   for (const [rel, contents] of Object.entries(files)) {
@@ -45,9 +65,21 @@ function docsRootWith(files: Record<string, string>): string {
   return root;
 }
 
+/** Docs-only sugar: keys are relative to `content/docs`, site fixture implied. */
+function docsRootWith(files: Record<string, string>): string {
+  const prefixed = Object.fromEntries(Object.entries(files).map(([rel, body]) => [`content/docs/${rel}`, body]));
+  return path.join(repoWith({ ...SITE_FIXTURE, ...prefixed }), 'content/docs');
+}
+
+function scan(repo: string): { file: string; href: string; line: number; reason: string }[] {
+  return collectBrokenLinks(path.join(repo, 'content/docs'), path.join(repo, 'apps/site'));
+}
+
 /** The hrefs reported broken, in file order. */
 function brokenHrefs(files: Record<string, string>): string[] {
-  return collectBrokenLinks(docsRootWith(files)).map((item: { href: string }) => item.href);
+  const docsRoot = docsRootWith(files);
+  const repo = path.resolve(docsRoot, '../..');
+  return scan(repo).map((item) => item.href);
 }
 
 afterAll(() => {
@@ -180,14 +212,16 @@ describe('absolute /docs hrefs stay strict — they are routes, not files', () =
     expect(brokenHrefs({ 'index.md': '[home](/docs)' })).toEqual([]);
   });
 
-  it('waves through site routes outside the docs collection', () => {
-    // `/api/core`, `/img/...`, `/spec/...` are not in this collection and cannot
-    // be resolved from `content/docs` alone.
+  it('is checked before the site-route table, so the /docs rule stays the strict one', () => {
+    // `/docs/[[...slug]]` is a real route in the site fixture, so the generic
+    // route matcher would accept `/docs/guide/b.md`. It must not get the chance:
+    // the extension makes it a 404, and the `/docs` branch above owns that call.
     expect(
       brokenHrefs({
-        'guide/a.md': '[api](/api/core) ![shot](/img/guide/x.png)',
+        'guide/a.md': '[b](/docs/guide/b.md)',
+        'guide/b.md': '# B',
       }),
-    ).toEqual([]);
+    ).toEqual(['/docs/guide/b.md']);
   });
 });
 
@@ -264,11 +298,7 @@ describe('the repo it guards', () => {
   it('has no broken internal docs links', () => {
     // The other half of objectui#3479: the extended check must land GREEN, not
     // arrive with a backlog it merely describes.
-    const broken = collectBrokenLinks(path.join(repoRoot, 'content/docs')) as {
-      file: string;
-      href: string;
-      line: number;
-    }[];
+    const broken = scan(repoRoot);
     const report = broken.map((b) => `${path.relative(repoRoot, b.file)}:${b.line} -> ${b.href}`);
     expect(report).toEqual([]);
   });
@@ -279,5 +309,155 @@ describe('the repo it guards', () => {
 
     expect(routeExists('../plugins/plugin-charts.mdx', { fromFile, docsRoot: root })).toBe(true);
     expect(routeExists('../plugins/plugin-charts.md', { fromFile, docsRoot: root })).toBe(false);
+  });
+
+  it('reads the real apps/site tree as its route truth source', () => {
+    // The coupling objectui#3490 deliberately bought, pinned against the actual
+    // site: the enumerator must understand this router's shapes (a `(home)`
+    // group serving `/`, dot-named literal segments, an optional catch-all) and
+    // must NOT invent the prefixes the 17 dead links assumed.
+    const site = collectSiteRoutes(path.join(repoRoot, 'apps/site'));
+
+    for (const served of ['/', '/playground', '/llms.txt', '/docs/guide/expressions', '/logo.svg']) {
+      expect([served, siteUrlExists(served, site)]).toEqual([served, true]);
+    }
+    for (const dead of ['/spec/component.md', '/protocol/overview', '/api/core', '/api/react', '/examples/crm']) {
+      expect([dead, siteUrlExists(dead, site)]).toEqual([dead, false]);
+    }
+  });
+});
+
+describe('absolute non-/docs hrefs are resolved against the site — objectui#3490 B-class', () => {
+  it('reports the shape all 17 dead links had: a prefix the router has no segment for', () => {
+    // The assertion that dies if `if (cleanHref.startsWith('/')) return true;`
+    // ever comes back. `/spec`, `/protocol`, `/examples` are not route segments
+    // in apps/site/app, and never were.
+    expect(
+      brokenHrefs({
+        'guide/a.md': [
+          '[spec](/spec/component-package.md)',
+          '[protocol](/protocol/overview)',
+          '[example](/examples/crm)',
+        ].join('\n\n'),
+      }),
+    ).toEqual(['/spec/component-package.md', '/protocol/overview', '/examples/crm']);
+  });
+
+  it('reports a sibling of a real segment — /api exists, /api/core does not', () => {
+    // The near-miss that makes prefix-allowlisting useless: the fixture has
+    // `app/api/search/route.ts`, so `/api` is a real path prefix. It is not a
+    // route, and neither is `/api/core`.
+    expect(
+      brokenHrefs({ 'guide/a.md': '[core](/api/core) and [search](/api/search)' }),
+    ).toEqual(['/api/core']);
+  });
+
+  it('accepts a static file under public/ — the 3 /img links in #3490 were fine', () => {
+    expect(brokenHrefs({ 'guide/a.md': '![shot](/img/guide/shot.png)' })).toEqual([]);
+  });
+
+  it('reports a public/ path that does not exist', () => {
+    expect(brokenHrefs({ 'guide/a.md': '![gone](/img/guide/missing.png)' })).toEqual(['/img/guide/missing.png']);
+  });
+
+  it('accepts a plain route and the site root, trailing slash or not', () => {
+    expect(brokenHrefs({ 'guide/a.md': '[p](/playground) [q](/playground/) [home](/)' })).toEqual([]);
+  });
+
+  it('refuses to judge an absolute href with no route table rather than waving it through', () => {
+    // A silent `true` here is exactly how the 18 accumulated. Callers that skip
+    // the truth source get an error, not a green.
+    const docsRoot = docsRootWith({ 'guide/a.md': '# A' });
+    expect(() => routeExists('/spec/component.md', { fromFile: path.join(docsRoot, 'guide/a.md'), docsRoot })).toThrow(
+      /site route table/,
+    );
+  });
+});
+
+describe('the route table follows Next.js segment semantics', () => {
+  function tableFor(files: Record<string, string>) {
+    return collectSiteRoutes(path.join(repoWith(files), 'apps/site'));
+  }
+
+  it('drops route groups, skips private and slot folders, and needs a page or route file', () => {
+    const site = tableFor({
+      'apps/site/app/(marketing)/pricing/page.tsx': 'x',
+      'apps/site/app/_internal/secret/page.tsx': 'x',
+      'apps/site/app/components/Thing.tsx': 'x',
+      'apps/site/app/feed/route.ts': 'x',
+    });
+
+    expect(siteUrlExists('/pricing', site)).toBe(true);
+    expect(siteUrlExists('/(marketing)/pricing', site)).toBe(false);
+    expect(siteUrlExists('/_internal/secret', site)).toBe(false);
+    expect(siteUrlExists('/components', site)).toBe(false);
+    expect(siteUrlExists('/feed', site)).toBe(true);
+  });
+
+  it('matches dynamic, catch-all and optional catch-all segments by arity', () => {
+    const site = tableFor({
+      'apps/site/app/blog/[slug]/page.tsx': 'x',
+      'apps/site/app/og/[...slug]/page.tsx': 'x',
+      'apps/site/app/wiki/[[...slug]]/page.tsx': 'x',
+    });
+
+    expect(siteUrlExists('/blog/hello', site)).toBe(true);
+    expect(siteUrlExists('/blog', site)).toBe(false);
+    expect(siteUrlExists('/blog/a/b', site)).toBe(false);
+
+    expect(siteUrlExists('/og/a', site)).toBe(true);
+    expect(siteUrlExists('/og/a/b', site)).toBe(true);
+    expect(siteUrlExists('/og', site)).toBe(false);
+
+    expect(siteUrlExists('/wiki', site)).toBe(true);
+    expect(siteUrlExists('/wiki/a/b', site)).toBe(true);
+  });
+});
+
+describe('relative hrefs may not leave the collection — objectui#3490 A-class', () => {
+  it('reports a link out of content/docs even though the file is really there', () => {
+    // `guide/data-source.md:202` pointed at `../../../packages/data-objectstack/
+    // README.md#...`. The file exists, so `lychee --offline` and the pre-#3490
+    // check both passed it; the site still 404s, because fumadocs can only
+    // resolve inside the docs page index. The fixture materialises the target,
+    // so this test fails if existence is ever allowed to decide the verdict.
+    const repo = repoWith({
+      ...SITE_FIXTURE,
+      'content/docs/guide/data-source.md': '[adapter README](../../../packages/data-objectstack/README.md#batch)',
+      'packages/data-objectstack/README.md': '# Adapter',
+    });
+
+    expect(fs.existsSync(path.join(repo, 'packages/data-objectstack/README.md'))).toBe(true);
+    expect(scan(repo).map((item) => [item.href, item.reason])).toEqual([
+      ['../../../packages/data-objectstack/README.md#batch', 'escapes-collection'],
+    ]);
+  });
+
+  it('still accepts relative links that stay inside the collection', () => {
+    expect(
+      brokenHrefs({
+        'guide/plugins.md': '[Charts](../plugins/plugin-charts.mdx) and [self](./plugins.md)',
+        'plugins/plugin-charts.mdx': '# Charts',
+      }),
+    ).toEqual([]);
+  });
+
+  it('labels each failure with the check that rejected it', () => {
+    const repo = repoWith({
+      ...SITE_FIXTURE,
+      'content/docs/guide/a.md': [
+        '[out](../../../elsewhere/README.md)',
+        '[site](/spec/component.md)',
+        '[docs](/docs/guide/a.md)',
+        '[rel](./nowhere.md)',
+      ].join('\n\n'),
+    });
+
+    expect(scan(repo).map((item) => item.reason)).toEqual([
+      'escapes-collection',
+      'site-route',
+      'docs-route',
+      'relative',
+    ]);
   });
 });

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -54,9 +54,53 @@
  * therefore kept strict: `/docs/guide/plugins.md` is NOT accepted just because
  * `guide/plugins.md` exists on disk, because that URL 404s on the site.
  *
- * Non-`/docs` absolute hrefs (`/spec/...`, `/api/...`, `/img/...`) are still
- * waved through: they are routes outside this collection and cannot be resolved
- * from `content/docs` alone.
+ * ## Why this file changed again (objectui#3490)
+ *
+ * The paragraph that used to sit here said non-`/docs` absolute hrefs
+ * (`/spec/...`, `/api/...`, `/img/...`) were "waved through: they are routes
+ * outside this collection and cannot be resolved from `content/docs` alone",
+ * and that a relative href was checked purely as a path on disk. Both waivers
+ * were load-bearing, and both were wrong in the same way: they made the gate's
+ * question "does a file exist?" when the only question that matters to a reader
+ * is "does the site serve this URL?". 18 live 404s had collected behind them —
+ * 17 absolute (`/spec/*`, `/protocol/*`, `/api/core`, `/api/react`,
+ * `/examples/*`) plus one relative link that resolved out of the collection
+ * entirely. `lychee --offline` scores all 18 green for the same reason.
+ *
+ * **The trade-off this makes explicit.** Answering "does the site serve it?"
+ * means the script can no longer read only `content/docs`: it now also reads
+ * `apps/site` — the App-Router segment tree under `apps/site/app` and the static
+ * files under `apps/site/public` — as its truth source for what URLs exist. That
+ * widens the script's responsibility (and couples a `content/` gate to an
+ * `apps/` layout), and it is a deliberate purchase, not an accident:
+ *
+ *   - Without it there is no gate at all on this class. #3479 is the evidence
+ *     that "no gate" means "it accumulates": 33 dead references before anyone
+ *     looked. The 18 here accumulated behind exactly the waiver being removed.
+ *   - The coupling is to *structure*, not to content. `apps/site/app` is
+ *     enumerated, never imported or executed, so a routing change is picked up
+ *     automatically — the truth source cannot drift from the router the way a
+ *     hand-maintained allowlist of prefixes would.
+ *   - The cost is real and worth naming: adding a route to the site is now the
+ *     thing that makes a docs link legal, so a docs PR can go red because
+ *     `apps/site` moved under it. That failure is *correct* (the link really
+ *     would 404), but it does mean the two trees are no longer independent.
+ *
+ * What is deliberately NOT bought here: `next.config.mjs` rewrites/redirects are
+ * not modelled (the one rewrite, `/docs/:path*.mdx`, sits under the stricter
+ * `/docs` branch above and never reaches this one), and the scan surface is
+ * still only `content/docs` — `examples/**` and the root `README.md` remain
+ * unscanned, tracked separately.
+ *
+ * **Relative hrefs may not leave the collection.** `../../../packages/foo/
+ * README.md` resolves on disk, so the pre-#3490 check passed it, but
+ * `source.resolveHref` can only look inside the docs page index; `packages/**`
+ * is not in it, so the href reaches the browser verbatim and the browser
+ * resolves it against the *page URL* — `/docs/guide/data-source` +
+ * `../../../packages/...` lands on `/packages/...`, which is not a route. Such a
+ * link is rejected with a pointer to the fix the repo already uses everywhere
+ * else: an absolute `https://github.com/objectstack-ai/objectui/blob/main/...`
+ * URL (the "Package README" form in `content/docs/plugins/*.mdx`).
  *
  * ## Code spans are stripped before scanning
  *
@@ -86,6 +130,8 @@ const FENCE_RE = /^\s*(`{3,}|~{3,})(.*)$/;
 const INLINE_CODE_RE = /(`+)[^`\n]*\1/g;
 /** Any URI scheme (`https:`, `mailto:`, `tel:`) — not ours to resolve. */
 const EXTERNAL_HREF_RE = /^(?:#|[a-zA-Z][a-zA-Z0-9+.-]*:)/;
+/** Files that turn an App-Router directory into a servable URL. */
+const ROUTE_ENTRY_RE = /^(?:page|route)\.(?:js|jsx|ts|tsx|md|mdx)$/;
 
 const blank = (text) => text.replace(/[^\n]/g, ' ');
 
@@ -149,12 +195,111 @@ function routeCandidates(base) {
 }
 
 /**
+ * Classifies one `apps/site/app` directory name as a URL segment.
+ *
+ * Next.js App Router, the four forms that matter here:
+ *   `(group)`      — organisational only, contributes no URL segment
+ *   `_private`     — never routable, subtree skipped
+ *   `[[...slug]]`  — optional catch-all, matches 0+ segments
+ *   `[...slug]`    — catch-all, matches 1+ segments
+ *   `[slug]`       — dynamic, matches exactly 1 segment
+ * anything else is a literal segment (`llms.txt` is a literal, dot included).
+ */
+function classifySegment(name) {
+  if (name.startsWith('_') || name.startsWith('@')) return { kind: 'skip' };
+  if (name.startsWith('(') && name.endsWith(')')) return { kind: 'group' };
+  if (name.startsWith('[[...') && name.endsWith(']]')) return { kind: 'optionalCatchAll' };
+  if (name.startsWith('[...') && name.endsWith(']')) return { kind: 'catchAll' };
+  if (name.startsWith('[') && name.endsWith(']')) return { kind: 'dynamic' };
+  return { kind: 'literal', value: name };
+}
+
+/**
+ * Enumerates every URL the site can serve, as a truth source for absolute
+ * hrefs: the App-Router segment tree under `<siteRoot>/app`, plus the static
+ * files under `<siteRoot>/public` (Next serves those from `/`).
+ *
+ * Structure only — nothing here is imported or executed, so the table tracks
+ * whatever the router currently is. See the header for why this script reads
+ * outside `content/docs` at all.
+ *
+ * @returns {{ routes: object[][], assets: Set<string> }}
+ */
+export function collectSiteRoutes(siteRoot) {
+  const routes = [];
+  const assets = new Set();
+
+  const walkApp = (dir, pattern) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    if (entries.some((entry) => entry.isFile() && ROUTE_ENTRY_RE.test(entry.name))) {
+      routes.push(pattern);
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const segment = classifySegment(entry.name);
+      if (segment.kind === 'skip') continue;
+      walkApp(path.join(dir, entry.name), segment.kind === 'group' ? pattern : [...pattern, segment]);
+    }
+  };
+
+  const walkPublic = (dir, prefix) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const child = `${prefix}/${entry.name}`;
+      if (entry.isDirectory()) walkPublic(path.join(dir, entry.name), child);
+      else assets.add(child);
+    }
+  };
+
+  walkApp(path.join(siteRoot, 'app'), []);
+  walkPublic(path.join(siteRoot, 'public'), '');
+
+  return { routes, assets };
+}
+
+/** Does `segments` match one route pattern? Catch-alls are terminal in Next. */
+function matchesPattern(segments, pattern) {
+  let index = 0;
+  for (let cursor = 0; cursor < pattern.length; cursor += 1) {
+    const part = pattern[cursor];
+    if (part.kind === 'literal' || part.kind === 'dynamic') {
+      if (index >= segments.length) return false;
+      if (part.kind === 'literal' && segments[index] !== part.value) return false;
+      index += 1;
+      continue;
+    }
+    // catch-all / optional catch-all: swallows the rest, so it must be last.
+    if (cursor !== pattern.length - 1) return false;
+    return segments.length - index >= (part.kind === 'catchAll' ? 1 : 0);
+  }
+  return index === segments.length;
+}
+
+/** Is `pathname` (an absolute site path) served by a route or a static file? */
+export function siteUrlExists(pathname, site) {
+  const normalized = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+  if (site.assets.has(normalized)) return true;
+  const segments = normalized.split('/').filter(Boolean);
+  return site.routes.some((pattern) => matchesPattern(segments, pattern));
+}
+
+/**
  * Resolves one href.
  *
  * @param {string} href       the raw href as authored
- * @param {{ fromFile: string, docsRoot: string }} context
+ * @param {{ fromFile: string, docsRoot: string, site?: { routes: object[][], assets: Set<string> } }} context
  */
-export function routeExists(href, { fromFile, docsRoot }) {
+export function routeExists(href, { fromFile, docsRoot, site }) {
   let cleanHref = href.split('#')[0].split('?')[0].trim();
   if (!cleanHref) return true; // pure in-page anchor or query
   try {
@@ -170,18 +315,50 @@ export function routeExists(href, { fromFile, docsRoot }) {
     return routeCandidates(routePath ? path.join(docsRoot, routePath) : docsRoot).some(isFile);
   }
 
-  // Site routes outside this docs collection — not resolvable from here.
-  if (cleanHref.startsWith('/')) return true;
+  // Site routes outside this docs collection — checked against the enumerated
+  // router + `public/` tree (objectui#3490). No table means the caller has not
+  // supplied a truth source; failing loudly beats silently waving 404s through,
+  // which is precisely how the 18 links in #3490 accumulated.
+  if (cleanHref.startsWith('/')) {
+    if (!site) {
+      throw new Error(
+        `routeExists() needs a site route table to judge the absolute href "${href}". ` +
+          'Pass `site: collectSiteRoutes(<repo>/apps/site)`.',
+      );
+    }
+    return siteUrlExists(cleanHref, site);
+  }
 
   const base = path.resolve(path.dirname(fromFile), cleanHref);
+  // A relative href must stay inside the collection: fumadocs' page index is
+  // the only thing that can resolve one, and it holds nothing else. Resolving
+  // on disk is not enough — `../../../packages/x/README.md` is a real file and
+  // still a 404 on the site. See the header.
+  if (base !== docsRoot && !base.startsWith(docsRoot + path.sep)) return false;
+
   // File form first (what fumadocs' `resolveHref` keys on), then the
   // extensionless-route spellings.
   return [base, ...routeCandidates(base)].some(isFile);
 }
 
-/** @returns {{ file: string, href: string, line: number }[]} */
-export function collectBrokenLinks(docsRoot) {
+/** Which of the four checks rejected this href — drives the hint printed below. */
+function classifyBroken(href, { fromFile, docsRoot }) {
+  const cleanHref = href.split('#')[0].split('?')[0].trim();
+  if (cleanHref === DOCS_ROUTE_PREFIX || cleanHref.startsWith(`${DOCS_ROUTE_PREFIX}/`)) return 'docs-route';
+  if (cleanHref.startsWith('/')) return 'site-route';
+  const base = path.resolve(path.dirname(fromFile), cleanHref);
+  if (base !== docsRoot && !base.startsWith(docsRoot + path.sep)) return 'escapes-collection';
+  return 'relative';
+}
+
+/**
+ * @param {string} docsRoot  the `content/docs` tree to scan
+ * @param {string} siteRoot  `apps/site` — truth source for absolute hrefs
+ * @returns {{ file: string, href: string, line: number, reason: string }[]}
+ */
+export function collectBrokenLinks(docsRoot, siteRoot) {
   const broken = [];
+  const site = collectSiteRoutes(siteRoot);
 
   for (const file of walk(docsRoot)) {
     const source = stripCode(readFileSync(file, 'utf8'));
@@ -191,12 +368,13 @@ export function collectBrokenLinks(docsRoot) {
     while ((match = MARKDOWN_LINK_RE.exec(source)) !== null) {
       const href = match[1].trim();
       if (EXTERNAL_HREF_RE.test(href)) continue;
-      if (routeExists(href, { fromFile: file, docsRoot })) continue;
+      if (routeExists(href, { fromFile: file, docsRoot, site })) continue;
 
       broken.push({
         file,
         href,
         line: source.slice(0, match.index).split('\n').length,
+        reason: classifyBroken(href, { fromFile: file, docsRoot }),
       });
     }
   }
@@ -209,9 +387,30 @@ export function collectBrokenLinks(docsRoot) {
 // as scripts/check-control-bytes.mjs.
 const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
+const HINTS = {
+  relative:
+    'Relative links must name the target FILE including its real extension' +
+    ' (`../plugins/plugin-charts.mdx`) — that is the key fumadocs indexes pages by.',
+  'docs-route':
+    'Absolute `/docs/...` links must be extensionless ROUTES' +
+    ' (`/docs/plugins/plugin-charts`); a `.md`/`.mdx` suffix 404s whatever is on disk.',
+  'site-route':
+    'Absolute non-`/docs` links must resolve to a real site URL — a route under' +
+    ' `apps/site/app` or a file under `apps/site/public`. There is no `/spec`,' +
+    ' `/protocol`, `/api/<pkg>` or `/examples` route: link the equivalent' +
+    ' `/docs/...` page, or an absolute `https://github.com/...` URL.',
+  'escapes-collection':
+    'A relative link may not leave `content/docs` — fumadocs can only resolve' +
+    ' hrefs inside the docs page index, so it reaches the browser verbatim and' +
+    ' 404s even though the file exists. Use an absolute' +
+    ' `https://github.com/objectstack-ai/objectui/blob/main/...` URL instead' +
+    ' (the "Package README" form used throughout content/docs/plugins/).',
+};
+
 if (invokedDirectly) {
   const docsRoot = path.resolve('content/docs');
-  const broken = collectBrokenLinks(docsRoot);
+  const siteRoot = path.resolve('apps/site');
+  const broken = collectBrokenLinks(docsRoot, siteRoot);
 
   if (broken.length > 0) {
     const targets = new Set(broken.map((item) => `${path.dirname(item.file)}|${item.href.split('#')[0]}`));
@@ -219,14 +418,12 @@ if (invokedDirectly) {
       `Found ${broken.length} broken docs link${broken.length === 1 ? '' : 's'} (${targets.size} distinct target${targets.size === 1 ? '' : 's'}):`,
     );
     for (const item of broken) {
-      console.error(`- ${path.relative(process.cwd(), item.file)}:${item.line} -> ${item.href}`);
+      console.error(`- [${item.reason}] ${path.relative(process.cwd(), item.file)}:${item.line} -> ${item.href}`);
     }
-    console.error(
-      '\nRelative links must name the target FILE including its real extension' +
-        ' (`../plugins/plugin-charts.mdx`); absolute `/docs/...` links must be' +
-        ' extensionless routes (`/docs/plugins/plugin-charts`). See the header of' +
-        ' scripts/check-doc-links.mjs.',
-    );
+    for (const reason of Object.keys(HINTS)) {
+      if (broken.some((item) => item.reason === reason)) console.error(`\n${reason}: ${HINTS[reason]}`);
+    }
+    console.error('\nSee the header of scripts/check-doc-links.mjs.');
     process.exit(1);
   }
 


### PR DESCRIPTION
Fixes #3490

## 前提复核(先证后改)

在 `origin/main`(f995a452d)上逐条复核 issue 的清单,**全部属实**:非 `/docs` 绝对 href 共 20 条 = 17 条死链 + 3 条 `/img/guide/dashboard-filters/*.png`(真实存在于 `apps/site/public/`,是好的);跑出 collection 的相对链接 1 条。`apps/site/app` 的路由段枚举结果与 issue 描述一字不差:

```
/            /api/search   /docs/[[...slug]]   /llms-full.txt
/llms.txt    /playground   /llms.mdx/docs/[[...slug]]   /og/docs/[...slug]
```

没有 `spec`、`protocol`、`examples`;`next.config.mjs` 只有 `/docs/:path*.mdx` 一条重写;无 `vercel.json`。

## 根因

门禁问的是「磁盘上有没有这个文件」,而唯一该问的是「站点服务不服务这个 URL」。两条豁免由此而来——非 `/docs` 绝对 href 直接放行,相对 href 只按磁盘路径判定。18 条真实 404 就积在这两条豁免后面,`lychee --offline` 判绿也是同一个原因。

## 门禁改动(方向 3,按 PM 裁定收敛)

1. **非 `/docs` 绝对 href** 按真值来源判定存在性:从 `apps/site/app` 枚举 App-Router 路由段(含 route group `(home)`、私有 `_foo`、动态 `[slug]`、catch-all `[...slug]`、可选 catch-all `[[...slug]]`),外加 `apps/site/public` 下的静态文件。
2. **跑出 collection 的相对链接**一律拒绝:fumadocs 的 `source.resolveHref` 只在 docs 页面索引里查,`packages/**` 不在其中,href 原样落到浏览器——文件真在磁盘上也照样 404。
3. 每条失败都带上**是哪一项检查拒的**(`relative` / `docs-route` / `site-route` / `escapes-collection`),各给各的修复提示。
4. `routeExists()` 拿不到路由表时**抛错**而不是放行绝对 href——静默 `true` 正是这 18 条积起来的方式。

### 职责扩大的取舍(脚本头部已写明)

脚本从「只读 `content/docs`」变成「也读 `apps/site`」。这是**有意购买**,不是顺手:

- 不这么做就**根本没有**针对这一类的门禁。#3479 已经证明「没门禁就会攒」(33 处死引用),这 18 条正是攒在被移除的那条豁免后面。
- 耦合的是**结构**不是内容:`apps/site/app` 只被枚举,从不 import、从不执行,路由变更自动被感知——不会像手维护的前缀白名单那样悄悄漂移。
- 成本要说明白:给站点加路由现在成了「让某条 docs 链接合法」的前提,于是一个 docs PR 可能因为 `apps/site` 在它脚下挪动而变红。这个失败是**正确的**(那条链接确实会 404),但两棵树从此不再互相独立。

**没有**买的:`next.config.mjs` 的 rewrite/redirect 不建模(唯一那条 `/docs/:path*.mdx` 落在更严格的 `/docs` 分支里,根本走不到这里);扫描面仍然只有 `content/docs`——`examples/**` 与根 `README.md` 按 PM 裁定留作后续单,不在本单扩。

## 逐条处置表(18 条)

`/docs/...` 页面有等价物的就指过去,没有的用 GitHub 绝对 URL(`content/docs/plugins/*.mdx` 的 "Package README" 已有先例)。

| # | 文件:行 | 原 href | 新目标 | 依据 |
|---|---|---|---|---|
| A | `guide/data-source.md:202` | `../../../packages/data-objectstack/README.md#cross-object-atomic-batch-batchtransaction` | `https://github.com/.../blob/main/packages/data-objectstack/README.md#cross-object-atomic-batch-batchtransaction` | A 类:跑出 collection。锚点就在该 README 里,照 `plugin-dashboard.mdx:222` 的 blob+锚点写法 |
| 1 | `guide/component-registry.md:462` | `/spec/component-package.md` | `/docs/guide/plugin-development` | "Custom Plugin Development" 就是讲从脚手架到发布地造组件/控件 |
| 2 | `guide/component-registry.md:466` | `/api/core` | `.../tree/main/packages/core` | 站上没有按包分的 API 路由;包 README 是真实的深度参考 |
| 3 | `guide/component-registry.md:467` | `/api/react` | `.../tree/main/packages/react` | 同上 |
| 4 | `guide/component-registry.md:468` | `/spec/component.md` | `/docs/api/schema-reference` | "Schema Type Reference" 即组件元数据参考 |
| 5 | `guide/expressions.md:639` | `/protocol/overview` | `/docs/guide/schema-overview` | "Schema Overview — 所有可用 schema 的总览" |
| 6 | `guide/expressions.md:643` | `/api/core` | `.../tree/main/packages/core` | 表达式求值器在 core 包 |
| 7 | `guide/expressions.md:644` | `/protocol/form` | `/docs/plugins/plugin-form` | |
| 8 | `guide/expressions.md:645` | `/protocol/view` | `/docs/plugins/plugin-view` | |
| 9 | `guide/fields.md:69` | `/protocol` | `objectstack/tree/main/packages/spec` | ObjectStack Protocol 就是 `@objectstack/spec` |
| 10 | `guide/objectos-integration.mdx:662` | `/examples/crm` | `.../tree/main/examples/console-starter` | 仓库里**没有** `examples/crm`;console-starter 才是接 ObjectStack 后端、插件全开的那个例子 |
| 11 | `guide/objectos-integration.mdx:663` | `/examples/kitchen-sink` | `/docs/guide/schema-catalog` | 同样不存在;Schema Catalog 才是「所有 schema 都在这」的那一页 |
| 12 | `guide/plugins.md:515` | `/spec/component-package.md` | `/docs/guide/plugin-development` | 同 #1 |
| 13 | `guide/schema-rendering.md:414` | `/protocol/overview` | `/docs/guide/schema-overview` | 同 #5 |
| 14 | `guide/schema-rendering.md:418` | `/spec/schema-rendering` | `/docs/core/schema-renderer` | 渲染器的技术参考页 |
| 15 | `guide/schema-rendering.md:419` | `/spec/architecture` | `/docs/guide/architecture` | "Architecture Overview" 现成就有 |
| 16 | `guide/schema-rendering.md:420` | `/api/core` | `.../tree/main/packages/core` | 同 #2 |
| 17 | `guide/schema-rendering.md:421` | `/api/react` | `.../tree/main/packages/react` | 同 #3 |

改标签的三处(#2/#3、#10、#11)是有意为之:链接文案写着 "CRM Application" 却指向 console-starter,本身就是另一个小谎。

同批的 3 条 `/img/guide/dashboard-filters/*.png` **不动**——它们本来就对,新检查把它们按 `public/` 静态资源判绿。

## 验证(先预测方向,再跑)

**预测:扩展后的门禁在未修改的 content 上应恰好报 18 条(17 `site-route` + 1 `escapes-collection`),且 3 条 `/img` 不得出现。** 实跑一致:

```
Found 18 broken docs links (13 distinct targets):
- [site-route] content/docs/guide/component-registry.md:462 -> /spec/component-package.md
  ... (17 条 site-route)
- [escapes-collection] content/docs/guide/data-source.md:202 -> ../../../packages/data-objectstack/README.md#...
EXIT=1
```

修完后 `node scripts/check-doc-links.mjs` → `Docs links are valid.`(exit 0)。

**反向验证。** 预测方向为「红」:把两条豁免原样接回去,新增的**拒绝类**断言应全部转红,而直接对 `collectSiteRoutes`/`siteUrlExists` 的单元测试不经过豁免、应保持绿。实跑与预测完全一致——`6 failed | 28 passed`,红的正是那 6 条拒绝类断言(3 条 site-route、1 条 public 缺失、1 条抛错、1 条 escapes-collection + reason 分类),路由表语义与真实 `apps/site` 那两个 describe 一条没红。

其他:

| 命令 | 结果 |
|---|---|
| `pnpm exec vitest run scripts/` | `Test Files 14 passed (14) / Tests 216 passed (216)`(本文件 22 → 34) |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm exec eslint` (改动的 mjs/ts) | 无输出 |
| `pnpm turbo run build --filter=@object-ui/site` | `Tasks: 28 successful, 28 total` — 文档照常编译 |
| `node scripts/check-control-bytes.mjs` | OK(另按 `[\x00-\x08\x0b\x0c\x0e-\x1f]` 自扫改动文件,无命中) |

## 两处需要 reviewer 注意的范围外沿

1. **`content/docs/guide/ci-cd-pipeline.md`**:该页第 248 行与第 290 行的表格格描述的正是本脚本的行为("resolved against the files actually on disk"、"**Internal** `/docs/...` routes"),被本次改动证伪。按 AGENTS.md #2(docs-driven)做了最小事实订正,没有做别的改动。
2. **删掉 `check-doc-links.test.ts` 第 7 行的 `@ts-expect-error`**:#3494 打开 `scripts/` 的 `allowJs` 推断后,#3489 带进来的这条指令变成 unused,而 unused 本身就是 tsc 报错——`main` 因此在 `pnpm type-check:scripts` 上**已经是红的**(与本 PR 无关,已由 PM 记为 #3504)。按 PM 协调只删这一行,不加替代注释,以便与热修 PR 无论谁先合都能干净合并。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_