### PR TITLE
docs(ci): live-e2e allowlist 改为指向 package.json,不再手抄 spec 名单

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,12 +1,14 @@
 # Live E2E — the console driven against a REAL ObjectStack backend (#2835).
 #
-# What runs: an allowlist of e2e/live specs (screen-flow, action-modal,
-# master-detail — `pnpm test:e2e:live:ci`) against `objectstack dev` booted
-# from PUBLISHED @objectstack/* packages serving the showcase app. Every PR
-# therefore smoke-tests "this console x the released backend" — the class of
-# bug only a real browser against a real backend can catch (framework#3528:
-# a lazily-loaded widget's suspension unwound to the host's route boundary
-# and tore down the flow dialog; zero unit test could see it).
+# What runs: an allowlist of e2e/live specs (the list is whatever the
+# `test:e2e:live:ci` script in package.json names — that script is the single
+# source of truth; do not re-enumerate the specs here, a hand-copied list
+# drifts on every promotion) against `objectstack dev` booted from PUBLISHED
+# @objectstack/* packages serving the showcase app. Every PR therefore
+# smoke-tests "this console x the released backend" — the class of bug only
+# a real browser against a real backend can catch (framework#3528: a
+# lazily-loaded widget's suspension unwound to the host's route boundary and
+# tore down the flow dialog; zero unit test could see it).
 #
 # ⚠️ INFORMATIONAL, NON-REQUIRED lane — `continue-on-error: true` keeps a
 # failure here from failing the workflow run, so it never blocks a merge and

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -230,11 +230,16 @@ is informational and never ejects a PR from the merge queue. Do not add it to re
 (and do not remove `continue-on-error`) until the nightly record proves the lane stable; see the
 header comment in the workflow file (#2835).
 
-What it does: runs the allowlisted live specs (`pnpm test:e2e:live:ci` — screen-flow,
-action-modal, master-detail) against a real `objectstack dev` backend booted from **published**
-`@objectstack/*` packages serving the showcase app, catching the class of bug only a real
-browser against a real backend can see. Failures still surface as a red step plus an uploaded
-Playwright report and job summary.
+What it does: runs an allowlist of the live specs (`pnpm test:e2e:live:ci`) against a real
+`objectstack dev` backend booted from **published** `@objectstack/*` packages serving the
+showcase app, catching the class of bug only a real browser against a real backend can see.
+Failures still surface as a red step plus an uploaded Playwright report and job summary.
+
+**Which specs are in the allowlist:** whatever the `test:e2e:live:ci` script in `package.json`
+names — that script is the single source of truth, and this page deliberately does not repeat
+the list. The lane grows the allowlist a few proven specs at a time (see the workflow's header
+comment), so every promotion would stale a hand-copied enumeration here; it already did
+(objectui#3488).
 
 Backend pins live in `e2e/live/ci/backend.env` and must match the `@objectstack/spec` version in
 `pnpm-lock.yaml` — bump both in the same PR, or the run proves nothing.


### PR DESCRIPTION
Fixes #3488

## 问题

allowlist 的唯一真身是 `package.json` 的 `test:e2e:live:ci` 脚本,它现在是 **四个** spec:

```
"test:e2e:live:ci": "playwright test --config=playwright.live.config.ts screen-flow.spec.ts action-modal.spec.ts master-detail.spec.ts saved-view-filter.spec.ts"
```

这份名单被按 spec 名逐个手抄在另外两处,两处都停留在 PR #3487 之前的**三个**:

| 文件 | 现状(改前) |
| --- | --- |
| `.github/workflows/live-e2e.yml:3-4`(头部注释) | `an allowlist of e2e/live specs (screen-flow, action-modal, master-detail — ...)` |
| `content/docs/guide/ci-cd-pipeline.md:233-234` | `runs the allowlisted live specs (pnpm test:e2e:live:ci — screen-flow, action-modal, master-detail)` |

这不是一次性失误,而是**结构性**的:`live-e2e.yml` 自己的政策就是 "a few at a time" 地长这份名单(见其 "Growing the allowlist" 段),名单被设计为**会反复变更**;逐名手抄等于给每次晋级都埋一次静默漂移。而 workflow 头部注释恰好是下一个 agent 判断"这条 lane 到底跑了什么"的第一手材料。

## 改动:去枚举,改指路

按 issue 分诊结论走"最省事"方向 —— 两处都删掉逐名枚举,改成指向 `package.json`,漂移源直接消失。

**未加对齐脚本**(issue 里的另一个方向,已被分诊排除):为一条 `continue-on-error: true` 的非门禁 lane 的注释新增一道 CI 门禁,成本不划算。这里换来的是"没有第二份名单可以漂移",而不是"用门禁看住第二份名单"。

`.github/workflows/live-e2e.yml` —— **仅头部注释**,job / steps / env 一字未动:

```
# What runs: an allowlist of e2e/live specs (the list is whatever the
# `test:e2e:live:ci` script in package.json names — that script is the single
# source of truth; do not re-enumerate the specs here, a hand-copied list
# drifts on every promotion) against `objectstack dev` booted from PUBLISHED
```

`content/docs/guide/ci-cd-pipeline.md` —— 仅 `## Live E2E` 段:"What it does" 段去掉括号里的三个名字,另起一段 **Which specs are in the allowlist** 写清名单以脚本为准、以及为什么这里不复制。两处都保留了原有的行文风格(YAML 注释 ~74 列硬换行;markdown 段落宽度不变)。

## 验证

方向**先预测再跑**:这是注释 + 散文改动,**不应有任何测试改变方向**。为了证明"没有东西在门禁这份名单"(也就是 issue 的前提),before / after 都跑了一遍:

| 阶段 | 命令 | 结果 |
| --- | --- | --- |
| 改后 | `pnpm exec vitest run scripts/ --maxWorkers=2` | ✅ `Test Files 14 passed (14)` / `Tests 204 passed (204)` |
| 改后 | `pnpm docs:check-links` | ✅ `Docs links are valid.` exit 0 |
| 改后 | `node scripts/check-control-bytes.mjs` | ✅ `OK (scanned 3686 tracked text file(s); skipped 85 binary)` |
| **改前**(`git checkout origin/main -- <两个文件>` 还原) | 同上 vitest | ✅ 204 passed —— 与改后同向 |
| **改前** | 同上 `docs:check-links` | ✅ exit 0 |

改前一并绿,正是本 issue 的前提得到确认:**没有任何测试读这份枚举**,所以它才能悄悄漂移三个 spec 的量而 CI 全程无感。`scripts/__tests__/ci-cd-pipeline-doc.test.ts` 钉的是这一页的别的性质(workflow 清单双向、ci.yml job 表、size 预算数字),不含 live-e2e 的 spec 名单 —— 改后它依然全绿,说明本改动没有踩到它任何一条断言(尤其是"页面不得出现不存在的 `*.yml` 文件名":本 PR 未新增任何 `.yml` 提及)。

另外:YAML 改的是注释,仍用 `yaml.safe_load` 实解了一遍确认结构未变 —— `jobs: ['live-e2e']`,`steps: 15`,`continue-on-error: True`,`env` 三项原样。被改文件也做了超出门禁扫描面的控制字符自查(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,无命中)。

## 无 changeset

按仓库门禁的实际要求判断,而不是猜:`check-changeset-fixed.mjs` 只查 `fixed` 组成员资格,**不**检查 PR 是否附带 changeset(这一页第 68 行自己就是这么写的);`check-changeset-no-major.mjs` 只在有 changeset 且标了 `major` 时报错。本改动是 CI 注释 + 文档页,不属于任何已发布包,对用户不可见。

## ⚠️ Type Check 预计红(与本 PR 无关)

本分支基于 `origin/main` f995a452d,该提交上 `pnpm type-check:scripts` 已经是红的:

```
scripts/__tests__/check-doc-links.test.ts(7,1): error TS2578: Unused '@ts-expect-error' directive.
```

即 #3504,止血 PR #3505 尚未合入。本 PR 一个 `.ts` 文件都没碰,红的不是这次改动;#3505 落地后 update branch 即恢复。

## 范围外发现(未改)

`.changeset/live-e2e-lane.md:29` 是第三处出现三个 spec 名的地方:

```
- **Allowlist start**: only `screen-flow`, `action-modal` and `master-detail`
  run (`pnpm test:e2e:live:ci`) —— grow the list a few proven specs at a time
```

**故意不动**:它措辞是 **"Allowlist start"**,描述的是这条 lane **落地当时**的状态,是历史陈述而非对当前名单的断言,写下时正确、现在依然正确;而且 changeset 是某个 PR 的定稿记录,不该被后来的 PR 追改。已在给 PM 的报告里记一笔。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_