### PR TITLE
fix(i18n): fallback interpolation replaces all placeholder occurrences

### DIFF
--- a/.changeset/safe-translation-fallback-replace-all.md
+++ b/.changeset/safe-translation-fallback-replace-all.md
@@ -1,0 +1,25 @@
+---
+"@object-ui/i18n": patch
+---
+
+`createSafeTranslation`'s no-provider fallback interpolation now replaces **all**
+occurrences of each placeholder, matching i18next semantics on the provider path.
+
+The fallback used `value.replace('{{k}}', String(v))`, and `String.prototype.replace`
+with a string needle substitutes only the *first* match. A default string repeating a
+placeholder — `'Selected {{count}} of {{count}} items'`, natural in many locales and
+sometimes required by RTL / agglutinative word order — therefore leaked literal braces
+to users on hosts with no `I18nProvider` mounted (standalone / embedded renderers),
+while the same string interpolated correctly once a provider was present. A silent
+semantic fork, in exactly the environments we observe least.
+
+The replacement is `value.split(needle).join(String(v))` rather than `replaceAll`:
+both `replace` and `replaceAll` interpret `$&`, `` $` ``, `$'` and `$$` in the
+*replacement* string, which i18next does not. Values here are runtime data (record
+labels, search terms), so that second divergence was reachable today — a label
+containing `$&` was mangled on the fallback path. split/join is literal on both sides
+and needs no regex escaping of the placeholder name.
+
+Key resolution (`defaults[key] || key`), the `String(v)` coercion, and the
+leave-it-literal behaviour for a placeholder with no matching option are unchanged.
+Fixes objectui#3418.

--- a/packages/i18n/src/__tests__/useSafeTranslation.test.tsx
+++ b/packages/i18n/src/__tests__/useSafeTranslation.test.tsx
@@ -11,6 +11,11 @@ import { createSafeTranslation, useSafeTranslate } from '../useSafeTranslation';
 const DEFAULTS = {
   'detail.test': 'Test Anchor',
   'detail.greeting': 'Hello {{name}}',
+  // objectui#3418: the same placeholder twice in one sentence — natural in
+  // many locales ("已选 {{count}} 项,共 {{count}} 项"), and the shape the
+  // fallback used to interpolate only once.
+  'detail.selection': 'Selected {{count}} of {{count}} items',
+  'detail.pair': '{{a}}/{{b}} — {{a}} again, {{b}} again',
 };
 
 describe('createSafeTranslation (no I18nProvider)', () => {
@@ -21,6 +26,69 @@ describe('createSafeTranslation (no I18nProvider)', () => {
     expect(result.current.t('detail.test')).toBe('Test Anchor');
     // Unknown keys pass through as-is (historical contract).
     expect(result.current.t('detail.missing')).toBe('detail.missing');
+  });
+
+  // objectui#3418 — the fallback interpolator must agree with i18next, the
+  // engine that serves the *provider* path. Every assertion below was checked
+  // against a real i18next instance configured the way `createI18n` configures
+  // it (`interpolation: { escapeValue: false }`); the expected strings are
+  // i18next's own output, not a guess.
+  describe('interpolation matches i18next semantics', () => {
+    const useT = createSafeTranslation(DEFAULTS, 'detail.test');
+
+    it('replaces EVERY occurrence of a repeated placeholder', () => {
+      const { result } = renderHook(() => useT());
+      // Was 'Selected 3 of {{count}} items' while the fallback used
+      // `String.prototype.replace` with a string needle (first match only),
+      // leaking literal braces to users on provider-less hosts.
+      expect(result.current.t('detail.selection', { count: 3 })).toBe(
+        'Selected 3 of 3 items',
+      );
+      // Counts are interpolated as strings elsewhere in this repo too — the
+      // `String(v)` coercion must keep serving both spellings identically.
+      expect(result.current.t('detail.selection', { count: '3' })).toBe(
+        'Selected 3 of 3 items',
+      );
+    });
+
+    it('replaces every occurrence of each of several repeated placeholders', () => {
+      const { result } = renderHook(() => useT());
+      expect(result.current.t('detail.pair', { a: 'A', b: 'B' })).toBe(
+        'A/B — A again, B again',
+      );
+    });
+
+    it('still replaces a single occurrence exactly once', () => {
+      const { result } = renderHook(() => useT());
+      expect(result.current.t('detail.greeting', { name: 'Ada' })).toBe('Hello Ada');
+    });
+
+    it('leaves a placeholder literal when no matching option is supplied', () => {
+      const { result } = renderHook(() => useT());
+      // Unchanged behaviour, pinned so the widened replace scope cannot start
+      // inventing empty strings. i18next does the same.
+      expect(result.current.t('detail.greeting')).toBe('Hello {{name}}');
+      expect(result.current.t('detail.greeting', {})).toBe('Hello {{name}}');
+      expect(result.current.t('detail.greeting', { other: 'x' })).toBe('Hello {{name}}');
+      expect(result.current.t('detail.selection', { unrelated: 1 })).toBe(
+        'Selected {{count}} of {{count}} items',
+      );
+    });
+
+    it('treats the interpolated value literally, including $-patterns', () => {
+      const { result } = renderHook(() => useT());
+      // `replace`/`replaceAll` interpret `$&`, `` $` ``, `$'` and `$$` in the
+      // *replacement* string; i18next does not, and neither does split/join.
+      // A record label carrying one of these is reachable today, unlike the
+      // repeated-placeholder case.
+      expect(result.current.t('detail.greeting', { name: '$& raw' })).toBe(
+        'Hello $& raw',
+      );
+      expect(result.current.t('detail.greeting', { name: 'a$`b' })).toBe('Hello a$`b');
+      expect(result.current.t('detail.selection', { count: '$$' })).toBe(
+        'Selected $$ of $$ items',
+      );
+    });
   });
 
   it('returns a STABLE fallback t across renders (memo-dep friendly)', () => {

--- a/packages/i18n/src/__tests__/useSafeTranslation.test.tsx
+++ b/packages/i18n/src/__tests__/useSafeTranslation.test.tsx
@@ -12,8 +12,8 @@ const DEFAULTS = {
   'detail.test': 'Test Anchor',
   'detail.greeting': 'Hello {{name}}',
   // objectui#3418: the same placeholder twice in one sentence — natural in
-  // many locales ("已选 {{count}} 项,共 {{count}} 项"), and the shape the
-  // fallback used to interpolate only once.
+  // many locales, and sometimes forced by RTL / agglutinative word order.
+  // This is the shape the fallback used to interpolate only once.
   'detail.selection': 'Selected {{count}} of {{count}} items',
   'detail.pair': '{{a}}/{{b}} — {{a}} again, {{b}} again',
 };

--- a/packages/i18n/src/useSafeTranslation.ts
+++ b/packages/i18n/src/useSafeTranslation.ts
@@ -21,7 +21,23 @@ export function createSafeTranslation(
     let value = defaults[key] || key;
     if (options) {
       for (const [k, v] of Object.entries(options)) {
-        value = value.replace(`{{${k}}}`, String(v));
+        // `split(needle).join(value)` — deliberately not `replace`, and not
+        // `replaceAll` either (objectui#3418). This path must agree with
+        // i18next, which serves the *provider* path; any divergence is a
+        // silent fork that only shows up on provider-less hosts, where we are
+        // least likely to see it:
+        //   1. `replace` with a string needle substitutes only the FIRST
+        //      occurrence. i18next substitutes every one, so a sentence that
+        //      repeats a placeholder ("Selected {{count}} of {{count}} items"
+        //      — natural in many locales, and often required by RTL /
+        //      agglutinative word order) leaked literal braces to users.
+        //   2. `replace` AND `replaceAll` both interpret `$&`, `` $` ``, `$'`
+        //      and `$$` in the *replacement* string. i18next does not. Values
+        //      here are runtime data — record labels, search terms — so this
+        //      one is reachable today, unlike (1).
+        // split/join is literal on both sides, which is exactly i18next's
+        // behaviour, and needs no regex escaping of the placeholder name.
+        value = value.split(`{{${k}}}`).join(String(v));
       }
     }
     return value;


### PR DESCRIPTION
Fixes #3418

## 问题

`createSafeTranslation` 的无 provider 回退插值用的是 `value.replace('{{k}}', String(v))`。`String.prototype.replace` 传字符串 needle 时**只替换第一次出现**;而挂了 provider 的路径走 i18next 自己的插值,**替换全部出现**。

于是任何一条在同一句里重复用同一个占位符的默认文案(`Selected {{count}} of {{count}} items` —— 在很多语言里都很自然,RTL / 黏着语为了语序还经常必须这么写),在没有挂 `I18nProvider` 的宿主(独立 / 嵌入式渲染)上会把第二次及以后的 `{{k}}` 原样吐给用户。不抛错、不打日志,专挑我们最看不到的运行环境 —— 一条**静默的语义分叉**。

## 改法

`value.split(needle).join(String(v))`,一行。

裁定见 issue:**修插值语义,不加守卫**。为绕开实现 bug 去限制文案作者能写的句式,是把 bug 固化成契约;语义修齐后,重复占位符在两条路径上同样合法。

**为什么是 split/join 而不是 `replaceAll`**:`replace` 和 `replaceAll` 都会解释**替换串**里的 `$&`、`$'`、`$$` 和反引号形式,i18next 不会。这里插进去的是运行时数据(记录 label、搜索词),所以这第二条分叉**今天就够得着** —— 一个名字里带 `$&` 的记录在回退路径上会被改坏(`'Hello {{name}}'` + `'$& raw'` 旧实现给出 `'Hello {{name}} raw'`)。split/join 两侧都是字面量,顺带也省掉了占位符名的正则转义。

`defaults[key] || key` 的取值、`String(v)` 强转、以及「没有对应 option 时占位符保持字面量」的行为,全部原样保留。

## 前提核验

- 一行 `replace` 在 `origin/main` 上确实还活着 —— 前提 live。
- issue 说的「休眠」也仍然成立:扫过 `packages/` + `apps/` 全部单行字符串字面量,**0 条**重复使用同一个占位符。所以 (1) 类分叉今天没有触发点,(2) 类(`$` 替换模式)有。

## 测试

新增断言的**期望值不是猜的** —— 每一条都先在一个按 `createI18n` 同样配置(`interpolation: { escapeValue: false }`)的真实 i18next 实例上跑过,测里写的就是 i18next 自己的输出:

| 输入 | i18next | 旧回退 | 新回退 |
|---|---|---|---|
| `selection` + `{count: 3}` | `Selected 3 of 3 items` | `Selected 3 of {{count}} items` | ✅ 一致 |
| `pair` + `{a:'A', b:'B'}` | `A/B — A again, B again` | `A/B — {{a}} again, {{b}} again` | ✅ 一致 |
| `greeting` + `{name:'$& raw'}` | `Hello $& raw` | `Hello {{name}} raw` | ✅ 一致 |
| `greeting` + `{other:'x'}` | `Hello {{name}}` | 同 | ✅ 不变 |
| `greeting`(无 options) | `Hello {{name}}` | 同 | ✅ 不变 |

**反向验证(先定方向再跑)**:预测「两条重复占位符用例 + `$` 模式用例 RED,其余 GREEN」。测试先写、源码未动时跑:

```
Tests  3 failed | 5 passed (8)
AssertionError: expected 'Selected 3 of {{count}} items' to be 'Selected 3 of 3 items'
AssertionError: expected 'A/B — {{a}} again, {{b}} again' to be 'A/B — A again, B again'
AssertionError: expected 'Hello {{name}} raw' to be 'Hello $& raw'
```

与预测逐条吻合。改完后 `Tests 8 passed (8)`。

**消费半径清扫**(这条规则跑在哪就要扫到哪,不是只扫被改的包):`createSafeTranslation` 有 ~15 个包在用,root vitest 把 `@object-ui/i18n` alias 到 src,所以下游 no-provider 测试直接吃到这次改动。

```
pnpm exec vitest run packages/i18n                    → 22 files / 261 tests passed
pnpm exec vitest run <18 个下游 no-provider 测试文件>   → 18 files / 100 tests passed
pnpm --filter @object-ui/i18n type-check              → exit 0
pnpm --filter @object-ui/i18n lint                    → 0 errors(28 条既有 warning,均不在本次改的文件里)
node scripts/check-control-bytes.mjs                  → OK
node scripts/check-changeset-no-major.mjs             → OK
```

下游那 100 条断言没有一条方向翻转,与前提核验一致:仓库里既没有重复占位符的文案,也没有把 `$` 替换模式当值插进 `t()` 的地方。

Changeset:`.changeset/safe-translation-fallback-replace-all.md`(`@object-ui/i18n` patch)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_