### PR TITLE
ci(console): 把 vitest.config.ts 纳入 tsc program,并把根 vitest 配置算进 turbo 的 cache key

### DIFF
--- a/apps/console/tsconfig.node.json
+++ b/apps/console/tsconfig.node.json
@@ -34,6 +34,42 @@
   /* `../../scripts/vite-*.ts` are the repo-level Vite plugins vite.config.ts
      imports. They must be listed here or each one is a TS6307 ("not listed
      within the file list of project") — the error that kept this project red,
-     and therefore ungated. */
-  "include": ["vite.config.ts", "vitest.setup.ts", "../../scripts/vite-*.ts"]
+     and therefore ungated.
+
+     `vitest.config.ts` is listed for the same reason `vite.config.ts` is, and
+     until objectui#3476 it was in ZERO tsc programs. CI runs
+     `turbo run type-check`, i.e. per PACKAGE; the root `tsconfig.json` does
+     list `apps` in its `include`, but no script ever runs it — it is the
+     editor config. So the one console config that merges two config objects
+     (`rootConfig` and `viteConfig`), which is precisely the shape a
+     type-checker catches drift in, was the one an agent could break with no
+     gate noticing.
+
+     `../../vitest.config.mts` follows it in by necessity, not by wish:
+     `vitest.config.ts` imports it, and a composite project must list every
+     file in its program or that import is a TS6307 as well. Covering the
+     importer is impossible without it — and it is a bonus, since the root
+     Vitest config was in no gated program either. One caveat that comes with
+     it: its `@ts-expect-error` on the plain-JS `vitest-invocation-guard.mjs`
+     import stays CORRECT here only because this project leaves `allowJs` at
+     its default `false`. Turning `allowJs` on would make that directive unused
+     and this project red with TS2578 — see `tsconfig.scripts.json`, which
+     chose `allowJs: true` for `scripts/` and deliberately paid that price.
+
+     There is deliberately NO `vitest.setup.ts` entry. No such file has ever
+     existed in this directory, and a literal, glob-less `include` entry that
+     matches nothing is silently ignored by TypeScript — so it read as coverage
+     that was never there (objectui#3476). Repointing it at the setup file
+     `vitest.config.ts` actually uses (the repo-root `vitest.setup.dom.tsx`)
+     was measured and rejected: that file is handed to Vitest as a RUNTIME PATH
+     STRING, never imported, so this program has no type edge to it, and naming
+     it here drags `vitest.setup.base.ts` plus four `@object-ui` side-effect
+     imports into a Node build-config project that cannot resolve them
+     (one TS6307 + four TS2882). It belongs to a test-oriented program. */
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "../../vitest.config.mts",
+    "../../scripts/vite-*.ts"
+  ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -44,7 +44,8 @@
       "cache": true,
       "inputs": [
         "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/scripts/vite-*.ts"
+        "$TURBO_ROOT$/scripts/vite-*.ts",
+        "$TURBO_ROOT$/vitest.config.mts"
       ]
     },
     "clean": {


### PR DESCRIPTION
Fixes #3476

两个文件、两个提交:

| 提交 | 文件 | 作用 |
| --- | --- | --- |
| 342ca3d3c | `apps/console/tsconfig.node.json` | 只改 `include` —— 把 `vitest.config.ts` 纳入 program,删掉幽灵条目 `vitest.setup.ts` |
| b040f911e | `turbo.json` | 一行 —— 把 `$TURBO_ROOT$/vitest.config.mts` 加进 `type-check` 的 `inputs` |

**没有动任何编译选项**:PR #3475 留下的 `allowImportingTsExtensions` + `emitDeclarationOnly` 已经把 `.ts` / `.mts` 显式扩展名这一关过掉了,实测无需追加(见下方「flag 组合」)。

> **关于 `turbo.json`(第二个提交)的范围说明**
> 本 issue 派发时的文件面只有 `apps/console/tsconfig.node.json`。第一版 PR 因此**刻意没改** `turbo.json`,只把实测到的缓存空洞记录成 #3514 并在报告里升级为待决问题(方案 A:并入本 PR / 方案 B:另行派发)。
> PM 已裁决并**明确放宽文件面**,原文:
> > 「**Option A, approved now** —— the file fence is hereby WIDENED to include the one-line turbo.json change: add `$TURBO_ROOT$/vitest.config.mts` to the `type-check` task's `inputs`, symmetric with the existing `$TURBO_ROOT$/scripts/vite-*.ts` entry. Your reasoning is endorsed as-is: knowingly landing a half-armed gate is the exact failure class this repo has paid for three times, and the stale-green window of option B is avoidable for one line.」
> 故第二个提交在范围内。**#3514 不关闭**:PM 将其改写承载方案 C(把这类 `inputs` 从 tsconfig 的 `include` 推导出来、或加钉测试的长效解),本 PR 不动该 issue。

## 前提复核(先证伪,再动手)

issue 的两条论断都在 `origin/main`(f995a452d)上重新量过,**均成立**:

| 论断 | 复核结果 |
| --- | --- |
| `apps/console/vitest.config.ts` 不在任何 CI 会跑的 tsc program 里 | ✅ 两个 console tsconfig 均为 0 |
| `tsconfig.node.json` 的 include 列了不存在的 `vitest.setup.ts` | ✅ 该文件在 `apps/console/` 下从不存在 |
| CI 跑的是 per-package 的 `turbo run type-check`,根 `tsconfig.json` 只是编辑器配置 | ✅ 根 `package.json` 里 `type-check` 就是 `turbo run type-check`,**没有任何 script 跑根 `tsconfig.json`** |

补充一条 issue 没写、但顺手量到的:根 `tsconfig.json` 的 program 里其实**是**有 `apps/console/vitest.config.ts` 的(`include` 含 `apps`,且它非 composite 所以不报 TS6307)—— 但既然没有任何 script 运行它,这只是编辑器里的绿,不构成门禁。issue 的判断没有被这一点推翻。

## 改动一:`tsconfig.node.json` 的 include

```diff
-  "include": ["vite.config.ts", "vitest.setup.ts", "../../scripts/vite-*.ts"]
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "../../vitest.config.mts",
+    "../../scripts/vite-*.ts"
+  ]
```

### 为什么 `../../vitest.config.mts` 也得进来

不是顺手扩大范围,是**绕不过去**:`vitest.config.ts` 导入它,而 composite 工程必须列出 program 里的每一个文件。只加 `vitest.config.ts` 的中间态实测:

```
vitest.config.ts(3,24): error TS6307: File '.../vitest.config.mts' is not listed within the
file list of project '.../apps/console/tsconfig.node.json'.
```

跟注释里 `../../scripts/vite-*.ts` 是同一个形状、同一个理由,`rootDir: "../.."` 本来就是为它准备的。附带收益:根 Vitest 配置此前同样不在任何门禁 program 里,现在有了(下方有反向验证)。

**随之而来的一条约束**已写进注释:`vitest.config.mts` 里那句 `@ts-expect-error`(压制 plain-JS 的 `vitest-invocation-guard.mjs` 导入)在这里**保持正确,仅仅因为**本工程的 `allowJs` 是默认的 `false`。哪天有人把它打开,那条指令立刻变成 TS2578 —— 这不是假设,`tsconfig.scripts.json` 选了 `allowJs: true` 并为此付过 5 处的代价,而**此刻 main 上正红着的 #3504 就是第 6 处**。

### 幽灵条目:选择删除,而不是改指

`vitest.config.ts` 真正用的 setup 文件是仓库根的 `vitest.setup.dom.tsx`。但它是以**运行期路径字符串**交给 Vitest 的,不是 import:

```ts
setupFiles: [path.resolve(import.meta.dirname, '../../vitest.setup.dom.tsx')],
```

所以本 program 与它之间**没有任何类型边**,把它类型检查一遍并不校验本工程持有的任何契约。改指的代价也实测了 —— 它会把整个 DOM 测试 setup 图拖进一个 Node 构建配置工程:

```
../../vitest.setup.dom.tsx(15,8): error TS6307: vitest.setup.base.ts is not listed ...
../../vitest.setup.dom.tsx(38,8): error TS2882: side-effect import of '@object-ui/components'
../../vitest.setup.dom.tsx(39,8): error TS2882: side-effect import of '@object-ui/fields'
../../vitest.setup.dom.tsx(40,8): error TS2882: side-effect import of '@object-ui/plugin-dashboard'
../../vitest.setup.dom.tsx(41,8): error TS2882: side-effect import of '@object-ui/plugin-grid'
```

要弄绿就得让这个「只为被类型检查而存在」的配置工程去依赖整个 workspace 构建图。它属于某个面向测试的 program,不属于这里。故:删掉。

(顺带记录:`vitest.setup.dom.tsx` / `.base.ts` / `.dom-light.tsx` 目前确实**不在任何门禁 program** 里 —— 已单独立为 #3515,observation 类,超出本 PR 文件面。)

## 改动二:`turbo.json` 的 cache key

```diff
       "inputs": [
         "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/scripts/vite-*.ts"
+        "$TURBO_ROOT$/scripts/vite-*.ts",
+        "$TURBO_ROOT$/vitest.config.mts"
       ]
```

改动一让 console 的 `type-check` 多读了一个仓库根文件,而 `$TURBO_DEFAULT$` 只覆盖包目录内的文件、`globalDependencies` 未设置 —— 于是这个新增的 program 成员不进哈希,turbo 可以在它已经编译不过的情况下回放一条绿。已有的 `$TURBO_ROOT$/scripts/vite-*.ts` 正是为**同一 program 的另一个根级文件**加的,本行与之对称。

`turbo.json` 无注释先例(严格 JSON),故不加注释;理由写在 tsconfig 注释、commit message 与此处。

## 验证

### 覆盖面前后对照(issue 指定的那条命令)

```
$ cd apps/console && ../../node_modules/.bin/tsc -p tsconfig.node.json --noEmit --listFilesOnly \
    | grep -c 'apps/console/vitest.config.ts'
改动前: 0
改动后: 1
```

program 里的仓库文件(改动后,已滤掉 node_modules):

```
scripts/vite-crypto-stub.ts
scripts/vite-maplibre-worker.ts
apps/console/vite.config.ts
vitest.config.mts               ← 新增
apps/console/vitest.config.ts   ← 新增
```

### 反向验证 A:类型门真的能红(方向**先预测后运行**,两次都符合)

覆盖面这类改动,「文件名出现在列表里」不算证明 —— 证明是**门禁真的能红**。故种入真实类型错误,用 CI 的同一条 `type-check` 脚本跑两边:

| 种入位置 | tsconfig | 预测 | 实测 |
| --- | --- | --- | --- |
| `apps/console/vitest.config.ts` 的 `setupFiles: [42, ...]` | `origin/main` 的 | 绿(错误不可见) | ✅ exit 0,无输出 |
| 同上 | 本 PR 的 | 红 | ✅ exit 1,`vitest.config.ts(17,20): error TS2769 ... Type 'number' is not assignable to type 'string'` |
| 根 `vitest.config.mts` 的 `testTimeout: 'fifteen-seconds'` | `origin/main` 的 | 绿 | ✅ exit 0 |
| 同上 | 本 PR 的 | 红 | ✅ exit 1,`../../vitest.config.mts(114,5): error TS2769 ... Type 'string' is not assignable to type 'number'` |

### 反向验证 B:turbo 那一行真的在起作用(同一棵树、同一次会话内的 A/B)

先把缓存跑绿落盘,再在根 `vitest.config.mts` 种入同一个类型错误,只跑 console 这一个 filter:

| `type-check` 的 inputs | 预测 | 实测 |
| --- | --- | --- |
| 旧(`origin/main`) | cache HIT,回放绿 —— 即缺陷本身 | ✅ `cache hit, replaying logs 4214aa6ab3df0f18` / `Tasks: 35 successful` / `FULL TURBO` / **exit 0** |
| 新(本 PR) | cache MISS,重新执行并变红 | ✅ `cache miss, executing 648e8a0633f2bff7` / `Failed: @object-ui/console#type-check` / **exit 1**,输出 `../../vitest.config.mts(114,5): error TS2769` |

即:**修之前 turbo 会把一条绿盖在编译不过的 program 上;修之后同样的改动立刻转红。**

不只是本地现象,两条依据:
1. `.github/workflows/ci.yml` 用 `actions/cache` 持久化 `.turbo/cache`,暖缓存会跨 run 携带这条陈旧的绿;
2. 本容器里 turbo 把缓存解析到**共享主 checkout** 的 `/home/user/objectui/.turbo`(git worktree 共用 common dir),所以旧哈希 `4214aa6ab3df0f18` 在我的 worktree 删除重建之后仍然命中 —— 陈旧的绿会在并行 agent 的多个 worktree 之间旅行。

两次种入均已还原,`git status` 只剩预期的改动文件。

### 门禁

| 命令 | 结果 |
| --- | --- |
| `pnpm --filter @object-ui/console type-check`(= `tsc --noEmit && tsc -b tsconfig.node.json --force`) | ✅ exit 0 |
| `turbo run type-check --concurrency=2`(全仓,turbo.json 改后重跑) | ✅ `Tasks: 78 successful, 78 total`,exit 0(36 cached / 42 重新执行 —— 改 turbo.json 令全局哈希失效,符合预期) |
| `node scripts/check-type-check-coverage.mjs` | ✅ `43/45 via type-check ...` exit 0 |
| `pnpm exec vitest run apps/console/ --maxWorkers=2`(仓库根) | ✅ `Test Files 23 passed (23)` / `Tests 212 passed (212)` |
| `pnpm exec vitest list apps/console/`(仓库根) | ✅ exit 0,配置照常加载 |
| `node scripts/check-control-bytes.mjs` | ✅ `OK (scanned 3686 tracked text file(s))` |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自查两个被改文件 | ✅ 无命中 |
| `turbo.json` 严格 JSON 解析 | ✅ OK |
| 工作树 litter | ✅ 无,声明产物仍全部落在 `node_modules/.cache/tsc/console-node` |

## flag 组合:实测「不需要改」

issue 备注提示可能要处理 `allowImportingTsExtensions` 的搭档问题。实测结论是 **#3475 已经把这件事做完了**:`allowImportingTsExtensions: true` + `emitDeclarationOnly: true` 对 `./vite.config.ts` 与 `../../vitest.config.mts` 两种显式扩展名一并成立,本 PR **一个编译选项都没动**。`--noEmit` 与本工程 `emitDeclarationOnly` 在 TS 6.0.3 下用于 `--listFilesOnly` 量测也不冲突(exit 0),故 issue 给的验证命令原样可用。

## Type Check 会红,且不是本 PR 的锅

净 `origin/main`(f995a452d)上 `pnpm type-check:scripts` 目前就是红的:

```
scripts/__tests__/check-doc-links.test.ts(7,1): error TS2578: Unused '@ts-expect-error' directive.
```

即 #3504,止血 PR #3505 仍是 draft、未合。本 PR 不碰 `scripts/`,两个被改文件都不在 `tsconfig.scripts.json` 的 program(`scripts/**`)里,不可能是成因。

⚠️ 副作用:该步骤在 job 早期就 `exit 2`,**导致 CI 从未跑到 `pnpm type-check`** —— 也就是说本 PR 自己那道门在 CI 上没被执行过,上表的绿是本地实测的。#3505 落地后需 update branch 复跑一次,让 CI 真正验证。

## Changeset

未加。`@object-ui/console` 确实是发布包,但本次只改开发期 tsconfig 的 `include` 与 `turbo.json`(后者根本不是发布包),不进 `dist/`,对使用者零可见变化 —— 与 PR #3475 对同一文件的处理一致。`changeset:check` 两条守卫均绿。

## 关联

- #3476(本 PR 修复)
- #3514(turbo inputs 的长效解,PM 持有、改写为方案 C;本 PR 落地的是其中的一行止血)
- #3515(仓库根四个 `vitest.setup.*` 不在任何门禁 program,observation 类)
- #3475 / #3384(flag 组合的来源)、#3305(本 program 的成因)、#3494 / #3498(`scripts/` 的同形状)、#3504(live 的 `allowJs` / TS2578 交互)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_