### PR TITLE
refactor(app-shell): 删除 RecordFormPage 中不可达的 i18n defaultValue 兜底

### DIFF
--- a/.changeset/record-form-page-dead-i18n-defaultvalue-3469.md
+++ b/.changeset/record-form-page-dead-i18n-defaultvalue-3469.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`RecordFormPage` no longer passes an inline `defaultValue` to the seven `t()`
+lookups whose keys are defined in all ten locale packs (`form.createTitle`,
+`form.editTitle`, `form.createSuccess`, `form.updateSuccess`,
+`form.saveRecord`, `common.back`, `common.cancel`). Rendered copy is
+unchanged in every locale — those branches were unreachable, because
+`all-locales-key-parity.test.ts` pins the keys as present, so i18next always
+resolved the pack value and never consulted the fallback (objectui#3469).
+
+What the dead fallbacks *did* do is carry a second, unwatched English
+spelling of the same string. `form.createTitle`'s default read
+`New {object}` while the pack says `Create {{object}}` — a different verb for
+one title at one call site. Had the key ever been renamed or dropped, the page
+title would have silently changed from "Create Contacts" to "New Contacts"
+with the whole suite still green. Now a missing key surfaces as the raw key
+plus the dev missing-key warning, and a new
+`RecordFormPage.i18n.test.tsx` asserts both that the rendered copy is the pack
+copy (checked in `en` and `zh`, which no hardcoded English default could
+satisfy) and that every bare key really exists in all ten packs.
+
+One `defaultValue` in the file is deliberately kept: `form.createTargetOrg`
+(the group-tenancy write-target badge) is defined in **no** pack, not even
+`en`, so its fallback is what actually renders. It is now documented as the
+exception and pinned by a test that says to remove it when the key is
+backfilled.

--- a/packages/app-shell/src/views/RecordFormPage.i18n.test.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.i18n.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RecordFormPage — every user-visible string comes from the locale packs
+ * (objectui#3469).
+ *
+ * The page used to hand i18next an inline `defaultValue` on nearly every
+ * `t()` call. Those branches were unreachable: all ten packs define the keys
+ * and `all-locales-key-parity.test.ts` pins that permanently, so i18next
+ * always resolved the pack value. What the defaults DID do is carry a second,
+ * unwatched English spelling — `form.createTitle`'s default read
+ * `New {object}` while the pack says `Create {{object}}`. The day the key was
+ * renamed or dropped, the page title would have silently changed verb with
+ * every test still green. #3469 deleted them (declared = enforced), leaving
+ * exactly one deliberate exception documented below.
+ *
+ * Direction note — a "put the deleted limb back and watch this go red"
+ * reverse-verification is IMPOSSIBLE for this change, by construction: with
+ * the key present in the pack, i18next never consults `defaultValue`, so
+ * restoring `defaultValue: \`New ${label}\`` leaves every assertion here
+ * green. That is precisely the defect the issue reported (a dead branch no
+ * test could see). What this file pins instead is the invariant the deletion
+ * buys:
+ *
+ *   1. the rendered copy IS the pack copy (asserted in two locales, so a
+ *      hardcoded English default could not satisfy it), and
+ *   2. every key the page now passes bare is really defined in all ten packs
+ *      — so removing one turns this file red instead of silently swapping the
+ *      title's verb.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { I18nProvider, builtInLocales } from '@object-ui/i18n';
+import { RecordFormPage } from './RecordFormPage';
+
+const h = React.createElement;
+
+const { toastSuccess, formSchemas, getAuthConfig, authState } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  formSchemas: [] as any[],
+  getAuthConfig: vi.fn(async () => ({ features: {} as Record<string, unknown> })),
+  authState: { activeOrganization: null as { name: string } | null },
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: toastSuccess,
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', name: 'Ada', email: 'ada@example.com', role: 'admin' },
+    getAuthConfig,
+    get activeOrganization() {
+      return authState.activeOrganization;
+    },
+  }),
+}));
+
+// Stand-in for the real form: records the schema the page builds (so the
+// `submitText` / `cancelText` it translates are observable) and exposes a
+// button that fires `onSuccess`, which is what raises the toast under test.
+vi.mock('@object-ui/plugin-form', () => ({
+  ObjectForm: ({ schema }: any) => {
+    formSchemas.push(schema);
+    return h(
+      'div',
+      { 'data-testid': 'object-form' },
+      h('span', { 'data-testid': 'submit-text' }, schema.submitText),
+      h('span', { 'data-testid': 'cancel-text' }, schema.cancelText),
+      h(
+        'button',
+        { type: 'button', 'data-testid': 'fire-success', onClick: () => schema.onSuccess?.() },
+        'ok',
+      ),
+    );
+  },
+}));
+
+const metadataState = {
+  objects: [] as any[],
+  loading: false,
+};
+vi.mock('../providers/MetadataProvider', () => ({
+  useMetadata: () => metadataState,
+}));
+vi.mock('../providers/AdapterProvider', () => ({
+  useAdapter: () => null,
+}));
+
+/** Object whose `label` is what `useObjectLabel` falls back to (no app namespace loaded). */
+const CONTACTS = {
+  name: 'contacts',
+  label: 'Contacts',
+  fields: { name: { type: 'text' }, organization_id: { type: 'lookup' } },
+};
+
+function renderPage(
+  mode: 'create' | 'edit',
+  { language = 'en' }: { language?: string } = {},
+) {
+  const path =
+    mode === 'create'
+      ? '/apps/crm/contacts/new'
+      : '/apps/crm/contacts/record/r1/edit';
+  const route =
+    mode === 'create'
+      ? '/apps/:appName/:objectName/new'
+      : '/apps/:appName/:objectName/record/:recordId/edit';
+
+  return render(
+    h(
+      I18nProvider,
+      { config: { defaultLanguage: language, detectBrowserLanguage: false } },
+      h(
+        MemoryRouter,
+        { initialEntries: [path] },
+        h(
+          Routes,
+          null,
+          h(Route, { path: route, element: h(RecordFormPage, { mode }) }),
+        ),
+      ),
+    ),
+  );
+}
+
+const title = () => screen.getByTestId('record-form-page-title').textContent;
+
+beforeEach(() => {
+  metadataState.objects = [CONTACTS];
+  metadataState.loading = false;
+  authState.activeOrganization = null;
+  getAuthConfig.mockResolvedValue({ features: {} });
+  formSchemas.length = 0;
+  toastSuccess.mockClear();
+});
+afterEach(cleanup);
+
+describe('RecordFormPage title resolves from the locale packs (#3469)', () => {
+  it('create mode renders the pack spelling "Create X" — never the deleted "New X" default', () => {
+    renderPage('create');
+    expect(title()).toBe('Create Contacts');
+    // The verb the removed inline `defaultValue` carried. It never rendered
+    // before this change either; asserting its absence is what makes a
+    // re-introduced second spelling visible.
+    expect(screen.queryByText('New Contacts')).not.toBeInTheDocument();
+  });
+
+  it('edit mode renders the pack spelling "Edit X"', () => {
+    renderPage('edit');
+    expect(title()).toBe('Edit Contacts');
+  });
+
+  it('follows the active locale — a hardcoded English default could not produce this', () => {
+    // The strongest available proof that the PACK drives the title: under `zh`
+    // the title is Chinese. No inline English `defaultValue` can satisfy this
+    // assertion, so it fails loudly if the packs ever stop being consulted.
+    renderPage('create', { language: 'zh' });
+    expect(title()).toBe(String(builtInLocales.zh.form.createTitle).replace('{{object}}', 'Contacts'));
+    expect(title()).toBe('新建Contacts');
+  });
+});
+
+describe('RecordFormPage success toasts resolve from the locale packs (#3469)', () => {
+  it('create mode raises the pack `form.createSuccess`', async () => {
+    renderPage('create');
+    fireEvent.click(screen.getByTestId('fire-success'));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastSuccess).toHaveBeenCalledWith('Contacts created successfully');
+  });
+
+  it('edit mode raises the pack `form.updateSuccess`', async () => {
+    renderPage('edit');
+    fireEvent.click(screen.getByTestId('fire-success'));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastSuccess).toHaveBeenCalledWith('Contacts updated successfully');
+  });
+});
+
+describe('RecordFormPage chrome copy resolves from the locale packs (#3469)', () => {
+  it('form buttons and the back control read their pack values', () => {
+    renderPage('create');
+    expect(screen.getByTestId('submit-text')).toHaveTextContent('Save');
+    expect(screen.getByTestId('cancel-text')).toHaveTextContent('Cancel');
+    expect(screen.getByTestId('record-form-page-back')).toHaveAttribute('aria-label', 'Back');
+  });
+});
+
+describe('the keys RecordFormPage passes bare are defined in every pack (#3469)', () => {
+  // This is the guard the deleted `defaultValue`s used to suppress. Before
+  // #3469, dropping `form.createTitle` from the packs changed the page title
+  // from "Create X" to "New X" with the whole suite still green. Now a missing
+  // key would put the raw key on screen — and turns this red first.
+  const BARE_KEYS = [
+    'form.createTitle',
+    'form.editTitle',
+    'form.createSuccess',
+    'form.updateSuccess',
+    'form.saveRecord',
+    'common.back',
+    'common.cancel',
+  ] as const;
+
+  const at = (pack: unknown, dotted: string) =>
+    dotted.split('.').reduce<any>((n, p) => n?.[p], pack);
+
+  it.each(BARE_KEYS)('%s is a string in all ten packs', (key) => {
+    const missing = Object.entries(builtInLocales)
+      .filter(([, pack]) => typeof at(pack, key) !== 'string')
+      .map(([lang]) => lang);
+    expect(missing, `${key} missing from: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('the comparison really covers ten packs', () => {
+    expect(Object.keys(builtInLocales)).toHaveLength(10);
+  });
+});
+
+describe('form.createTargetOrg keeps its fallback — the one LOAD-BEARING default (#3469)', () => {
+  // Ledger entry, not decoration. Unlike every key above, this one is defined
+  // in NO pack (not even `en`), so i18next genuinely misses and the inline
+  // `defaultValue` is what renders. It was therefore NOT deleted by #3469.
+  // When the key is backfilled into `en` (parity carries it to the other
+  // nine), delete the inline default in the same change — this test says so.
+  it('is absent from all ten packs, which is why the inline default survives', () => {
+    const defining = Object.entries(builtInLocales)
+      .filter(([, pack]) => typeof (pack as any)?.form?.createTargetOrg === 'string')
+      .map(([lang]) => lang);
+    expect(
+      defining,
+      'form.createTargetOrg is now translated — backfill done, so remove the inline defaultValue in RecordFormPage.tsx',
+    ).toEqual([]);
+  });
+
+  it('renders the fallback copy, so deleting it would put a raw key on screen', async () => {
+    authState.activeOrganization = { name: 'Acme Inc' };
+    getAuthConfig.mockResolvedValue({ features: { tenancyPosture: 'group' } });
+    renderPage('create');
+    const badge = await screen.findByTestId('record-form-write-target-org');
+    expect(badge).toHaveTextContent('Creates in Acme Inc');
+    expect(badge).not.toHaveTextContent('form.createTargetOrg');
+  });
+});

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -126,22 +126,27 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
   }, [navigate, recordDetailUrl]);
 
   const label = objectDef ? objectLabel(objectDef as any) : objectName ?? '';
+  // No inline `defaultValue` on these lookups: every key below is defined in
+  // all ten locale packs and `all-locales-key-parity.test.ts` pins that
+  // permanently, so i18next always resolves the pack value and a fallback
+  // could never render. Worse, an inline default is a SECOND English spelling
+  // that drifts unwatched — `form.createTitle`'s was `New {object}` while the
+  // pack says `Create {{object}}`, so the day the key was renamed the title
+  // would have silently changed verb with every test still green (#3469).
+  // Declared = enforced: the packs are the single source of this copy, and a
+  // missing key must surface (raw key + dev missing-key warning), not be
+  // papered over at the call site. The one deliberate exception in this file
+  // is `form.createTargetOrg` below — see the note there.
   const pageTitle =
     mode === 'create'
-      ? t('form.createTitle', { object: label, defaultValue: `New ${label}` })
-      : t('form.editTitle', { object: label, defaultValue: `Edit ${label}` });
+      ? t('form.createTitle', { object: label })
+      : t('form.editTitle', { object: label });
 
   const handleSuccess = useCallback(() => {
     toast.success(
       mode === 'create'
-        ? t('form.createSuccess', {
-            object: label,
-            defaultValue: `${label} created successfully`,
-          })
-        : t('form.updateSuccess', {
-            object: label,
-            defaultValue: `${label} updated successfully`,
-          }),
+        ? t('form.createSuccess', { object: label })
+        : t('form.updateSuccess', { object: label }),
     );
     goBack();
   }, [mode, t, label, goBack]);
@@ -273,7 +278,7 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
             size="sm"
             onClick={goBack}
             data-testid="record-form-page-back"
-            aria-label={t('common.back', { defaultValue: 'Back' })}
+            aria-label={t('common.back')}
           >
             <ArrowLeft className="h-4 w-4" />
           </Button>
@@ -309,6 +314,14 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
                 data-testid="record-form-write-target-org"
               >
                 <Building2 className="h-3.5 w-3.5 shrink-0" />
+                {/* The one LOAD-BEARING `defaultValue` in this file (#3469):
+                    unlike every other key here, `form.createTargetOrg` is
+                    defined in NO locale pack — not even `en` — so i18next
+                    genuinely misses and this default is what renders. Removing
+                    it would put the raw key on screen. It is also why the badge
+                    is English-only in all ten locales. Backfilling the key into
+                    `en` (the parity test then carries it to the other nine) is
+                    the real fix; delete this default in the same change. */}
                 {t('form.createTargetOrg', {
                   org: activeOrganization.name,
                   defaultValue: `Creates in ${activeOrganization.name}`,
@@ -347,8 +360,8 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
                 onCancel: handleCancel,
                 showSubmit: true,
                 showCancel: true,
-                submitText: t('form.saveRecord', { defaultValue: 'Save' }),
-                cancelText: t('common.cancel', { defaultValue: 'Cancel' }),
+                submitText: t('form.saveRecord'),
+                cancelText: t('common.cancel'),
               }}
               dataSource={dataSource ?? undefined}
             />


### PR DESCRIPTION
Fixes #3469

采用 issue 分诊结论的 **B 向**:删掉死的 `defaultValue` 分支,而不是把它改成和语言包一致的拼法。与 #3470/#3483 的「declared = enforced、消费端不留容忍」先例一致。

## 改了什么

`packages/app-shell/src/views/RecordFormPage.tsx` 原本在 8 处 `t()` 调用上挂了内联 `defaultValue`。逐一评估后:

| key | 十个语言包 | 处置 |
|---|---|---|
| `form.createTitle` | 全部定义 | **删**(默认值曾是 `New ${label}`,包里是 `Create {{object}}`) |
| `form.editTitle` | 全部定义 | **删** |
| `form.createSuccess` | 全部定义 | **删** |
| `form.updateSuccess` | 全部定义 | **删** |
| `form.saveRecord` | 全部定义 | **删** |
| `common.back` | 全部定义 | **删** |
| `common.cancel` | 全部定义 | **删** |
| `form.createTargetOrg` | **一个包都没有,连 `en` 都没有** | **保留** — 这条兜底是真正承重的 |

删掉的七条,key 由 `all-locales-key-parity.test.ts` 永久钉住必然存在,i18next 永远解析得到包里的值,兜底分支不可能被渲染。它们真正的作用是给同一条文案带了**第二处没人看管的英文拼法**:`form.createTitle` 的默认值写的是 `New ${label}`,包里却是 `Create {{object}}`,同一个标题、同一个调用点、两个动词。哪天这个 key 被改名或删掉,页面标题就会从 `Create Contacts` 悄悄变成 `New Contacts`,而且没有任何测试会红。

保留的那一条已在代码里写清原委:`form.createTargetOrg` 在十个包里都没有定义,i18next 是真的 miss,兜底就是实际渲染出来的东西 —— 删了会把裸 key 摆到页面上。这也是该徽标在十种语言下都是英文的原因。把 key 回填进 `en`(parity 测试会带着其余九个包跟上)才是正解,届时在同一个改动里删掉这条兜底,新测试里有一条断言就是提醒这件事的。

## 行为不变的证据(以及反向验证的真实方向)

**「把删掉的分支放回去看测试变红」在这个改动上从构造上就不可能成立**,预测在跑之前就已写进测试文件头:key 在包里,i18next 根本不会去看 `defaultValue`,所以把 `defaultValue` 加回来,断言一条都不会动。这正是 issue 报告的那个缺陷本身 —— 一段没有任何测试能看见的死分支。所以这里如实记录三个方向的实测:

1. **不变方向(证明行为未变 / 分支确实是死的)**:`git checkout origin/main -- RecordFormPage.tsx` 把八处 `defaultValue` 全部放回,新测试文件 **16/16 依旧全绿**。
2. **反事实 A(旧代码,静默漂移)**:临时把 `form.createTitle` 从 `en` 包里删掉,旧代码渲染出 `PROBE_TITLE=[New Contacts]` —— 动词静默改变,没有任何测试信号。
3. **反事实 B(新代码,响亮失败)**:同样删掉该 key,新代码渲染出 `PROBE_TITLE=[form.createTitle]`(裸 key + dev missing-key 告警),且新增的覆盖率断言直接变红:`form.createTitle missing from: en`。

反事实用的语言包临时改动是一次性探针,已还原,未进入本 PR(`git status` 已核验)。

## 新增测试

`packages/app-shell/src/views/RecordFormPage.i18n.test.tsx`(16 个用例),钉住删除之后真正成立的不变式:

- 标题/toast/按钮文案渲染的就是包里的值,并且**在 `en` 和 `zh` 两种语言下各断言一次** —— 任何硬编码的英文默认值都无法同时满足这两条(`zh` 下标题是 `新建Contacts`)。
- 断言 `New Contacts` 不在页面上。
- 现在裸传的七个 key,逐个断言在**十个包里都是字符串**;少一个就红,而不是悄悄换个动词继续绿。
- `form.createTargetOrg` 的两条:一条钉住它当前在十个包里都不存在(所以兜底必须留),一条钉住徽标确实渲染出 `Creates in Acme Inc` 而不是裸 key。

## 验证

- `pnpm exec vitest run packages/app-shell/src/views/RecordFormPage.i18n.test.tsx packages/i18n/src/__tests__/all-locales-key-parity.test.ts` → 36 passed
- `pnpm exec vitest run packages/app-shell/src/views`(消费半径清扫)→ 180 files / 1585 passed
- `pnpm exec turbo run type-check --filter=@object-ui/app-shell` → 通过
- `pnpm exec eslint` 两个改动文件 → 0 error
- `node scripts/check-control-bytes.mjs` / `check-changeset-no-major.mjs` → 通过

## 顺带发现(未在本 PR 修改)

`form.createTargetOrg` 被组织租户徽标消费,却在十个语言包里全部缺失 —— 属于「组件引用了不存在的 key」这一类漂移,与本 issue 是两件事,已另行记录待 PM 分诊。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_