### PR TITLE
docs(changeset): 将 popup-copy-english-i18n 的语言包数量由 eleven 更正为 ten

### DIFF
--- a/.changeset/popup-copy-english-i18n.md
+++ b/.changeset/popup-copy-english-i18n.md
@@ -8,7 +8,7 @@ ships hard-coded bilingual Chinese/English copy (objectui#3321, AGENTS.md
 Commandment #-1): the pre-opened SSO spinner tab (title + body) and the
 popup-blocked toast (title, description, action label) are now localized
 through new `console.serverAction.*` keys in `@object-ui/i18n`, added at full
-parity across all eleven locale packs.
+parity across all ten locale packs.
 
 `createConsoleServerActionHandler` gains an optional i18next-style `t` option
 (`t(key, englishDefault)`) — the wrapper is a plain function, so the translate


### PR DESCRIPTION
Fixes #3351

## 问题

`.changeset/popup-copy-english-i18n.md` 第 11 行称新增的 `console.serverAction.*` 键在 "all **eleven** locale packs" 达成完整 parity，但仓库实际只有 **十个** 语言包。

## 证据

- `packages/i18n/src/locales/` 下的 locale 文件共十个：`en`、`zh`、`ja`、`ko`、`de`、`fr`、`es`、`pt`、`ru`、`ar`（`index.ts` 为聚合入口，不是语言包）。
- `packages/i18n/src/__tests__/all-locales-key-parity.test.ts:53` 将 `OTHER_LOCALES` 定义为 `builtInLocales` 中除 `en` 以外的键，第 60 行把它的长度**固定断言**为 9：`expect(OTHER_LOCALES).toHaveLength(9)`。9 + `en` = 10。

数字写错的这份 changeset 会被编译进 **v17.0.0-rc.4** 的公开 release notes，因此在发版前更正，避免错误数量进入对外文档。

## 改动

仅第 11 行 `eleven` → `ten`，一个单词：

```diff
-parity across all eleven locale packs.
+parity across all ten locale packs.
```

不涉及任何代码、测试或其他文件；PR #3350 的正文与 `content/docs/releases/` 均未触碰。

## 验证

| 命令 | 结果 |
| --- | --- |
| `node scripts/check-changeset-fixed.mjs` | exit 0 — `All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | exit 0 — ``No changeset declares a `major` bump.`` |
| `node scripts/check-control-bytes.mjs` | exit 0 — `OK (scanned 3690 tracked text file(s); skipped 85 binary)` |

方向预判与实际一致：本次仅改 changeset 散文，**不应有任何测试发生变化**，因此未跑测试套件——该改动不进入任何构建产物或运行时代码路径，跑测试无法提供关于这一个词的任何信号。

改动后 `grep -n "eleven\|ten"` 只剩第 11 行的 `ten` 与第 19 行 `written` 中的子串匹配（后者为原有文本，非回归）。

无需追加 changeset：本 PR 修改的就是 changeset 本身。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_