### PR TITLE
fix(i18n): 组织写入目标徽标在十种语言下都渲染译文,而不是英文兜底

### DIFF
--- a/.changeset/create-target-org-translated-3517.md
+++ b/.changeset/create-target-org-translated-3517.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/i18n': patch
+'@object-ui/app-shell': patch
+---
+
+The group-tenancy write-target badge is now translated in all ten locales (objectui#3517)
+
+`form.createTargetOrg` — the ADR-0105 badge `RecordFormPage` shows in create mode
+to name the organization a new record will land in — was defined in **no** locale
+pack, not even `en`. i18next therefore genuinely missed the key and rendered the
+call site's inline `defaultValue`, so the badge read English `Creates in <org>` in
+all ten languages: a Chinese console creating a record on an org-walled object
+showed `Creates in 某某组织`.
+
+`all-locales-key-parity.test.ts` could not see this. It asserts that every pack
+defines every **`en`** key, so a key `en` itself lacks is outside the comparison —
+ten packs missing it identically kept parity fully green.
+
+## What changed
+
+- `createTargetOrg` is backfilled into `en` as `Creates in {{org}}`, which makes
+  the parity gate demand it from the other nine; each is translated to its pack's
+  existing `form`-section tone rather than copied or machine-filled.
+- The inline `defaultValue` in `RecordFormPage.tsx` is deleted, finishing what
+  objectui#3469 started — that key was the file's last remaining exception, and
+  every `t()` on the page now passes bare. Declared = enforced: the packs are the
+  single source of this copy, and a missing key must surface (raw key + dev
+  missing-key warning) instead of being papered over at the call site.
+- The two exception-pinning tests objectui#3516 left behind invert. `form.createTargetOrg`
+  joins the `BARE_KEYS` list (pinned present in all ten packs), and the render
+  assertion now checks the badge against the **pack** copy in both `en` and `zh` —
+  the deleted English default could not satisfy the Chinese assertion, so the
+  badge fails loudly if the packs ever stop driving it.

--- a/packages/app-shell/src/views/RecordFormPage.i18n.test.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.i18n.test.tsx
@@ -18,7 +18,10 @@
  * `New {object}` while the pack says `Create {{object}}`. The day the key was
  * renamed or dropped, the page title would have silently changed verb with
  * every test still green. #3469 deleted them (declared = enforced), leaving
- * exactly one deliberate exception documented below.
+ * exactly one deliberate exception — `form.createTargetOrg`, the only key the
+ * packs genuinely lacked. #3517 backfilled it into all ten, deleted that last
+ * default, and inverted the exception's pin (final describe below), so the
+ * rule now holds for every `t()` on the page with no carve-out.
  *
  * Direction note — a "put the deleted limb back and watch this go red"
  * reverse-verification is IMPOSSIBLE for this change, by construction: with
@@ -214,6 +217,10 @@ describe('the keys RecordFormPage passes bare are defined in every pack (#3469)'
     'form.createSuccess',
     'form.updateSuccess',
     'form.saveRecord',
+    // Joined this list in #3517. It was the file's one exception — defined in
+    // NO pack, not even `en` — until the backfill; the describe below pins the
+    // rendered badge now that it resolves like every other key here.
+    'form.createTargetOrg',
     'common.back',
     'common.cancel',
   ] as const;
@@ -233,28 +240,42 @@ describe('the keys RecordFormPage passes bare are defined in every pack (#3469)'
   });
 });
 
-describe('form.createTargetOrg keeps its fallback — the one LOAD-BEARING default (#3469)', () => {
-  // Ledger entry, not decoration. Unlike every key above, this one is defined
-  // in NO pack (not even `en`), so i18next genuinely misses and the inline
-  // `defaultValue` is what renders. It was therefore NOT deleted by #3469.
-  // When the key is backfilled into `en` (parity carries it to the other
-  // nine), delete the inline default in the same change — this test says so.
-  it('is absent from all ten packs, which is why the inline default survives', () => {
-    const defining = Object.entries(builtInLocales)
-      .filter(([, pack]) => typeof (pack as any)?.form?.createTargetOrg === 'string')
-      .map(([lang]) => lang);
-    expect(
-      defining,
-      'form.createTargetOrg is now translated — backfill done, so remove the inline defaultValue in RecordFormPage.tsx',
-    ).toEqual([]);
-  });
-
-  it('renders the fallback copy, so deleting it would put a raw key on screen', async () => {
+describe('the ADR-0105 write-target badge resolves from the locale packs (#3517)', () => {
+  // This describe used to pin the OPPOSITE fact. `form.createTargetOrg` was
+  // the file's one load-bearing `defaultValue`: defined in NO pack — not even
+  // `en` — so i18next genuinely missed and the inline default rendered, which
+  // is why the badge read English `Creates in <org>` in all ten locales
+  // (#3517). #3469 kept that default deliberately and left an assertion here
+  // that would go red the moment any pack defined the key, instructing the
+  // backfill to delete it. The backfill landed, so the assertion has served
+  // its purpose and inverts: the key is now an ordinary member of BARE_KEYS
+  // above (pinned present in all ten packs) and what needs pinning is that the
+  // BADGE reads the pack copy.
+  const badgeIn = async (language: string) => {
     authState.activeOrganization = { name: 'Acme Inc' };
     getAuthConfig.mockResolvedValue({ features: { tenancyPosture: 'group' } });
-    renderPage('create');
-    const badge = await screen.findByTestId('record-form-write-target-org');
+    renderPage('create', { language });
+    return screen.findByTestId('record-form-write-target-org');
+  };
+
+  it('renders the en pack copy, never a raw key', async () => {
+    const badge = await badgeIn('en');
     expect(badge).toHaveTextContent('Creates in Acme Inc');
+    // A missing key would surface the key itself — the failure mode the
+    // deleted `defaultValue` used to hide.
     expect(badge).not.toHaveTextContent('form.createTargetOrg');
+  });
+
+  it('follows the active locale — the deleted English default could not produce this', async () => {
+    // Same proof the title describe uses, and the point of the whole issue:
+    // under `zh` the badge is Chinese. The removed default was a hardcoded
+    // `Creates in ${org}`, so it could never satisfy this assertion — if the
+    // packs ever stop driving this badge, it fails loudly instead of quietly
+    // reverting to English.
+    const badge = await badgeIn('zh');
+    expect(badge).toHaveTextContent(
+      String(builtInLocales.zh.form.createTargetOrg).replace('{{org}}', 'Acme Inc'),
+    );
+    expect(badge).toHaveTextContent('创建到Acme Inc');
   });
 });

--- a/packages/app-shell/src/views/RecordFormPage.tsx
+++ b/packages/app-shell/src/views/RecordFormPage.tsx
@@ -135,8 +135,10 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
   // would have silently changed verb with every test still green (#3469).
   // Declared = enforced: the packs are the single source of this copy, and a
   // missing key must surface (raw key + dev missing-key warning), not be
-  // papered over at the call site. The one deliberate exception in this file
-  // is `form.createTargetOrg` below — see the note there.
+  // papered over at the call site. This now holds for EVERY `t()` in the file:
+  // `form.createTargetOrg` was the last exception (#3469 kept its default
+  // because the key existed in no pack, not even `en`) and #3517 backfilled it
+  // into all ten, so the write-target badge is translated and passes bare too.
   const pageTitle =
     mode === 'create'
       ? t('form.createTitle', { object: label })
@@ -314,18 +316,7 @@ export function RecordFormPage({ mode }: RecordFormPageProps) {
                 data-testid="record-form-write-target-org"
               >
                 <Building2 className="h-3.5 w-3.5 shrink-0" />
-                {/* The one LOAD-BEARING `defaultValue` in this file (#3469):
-                    unlike every other key here, `form.createTargetOrg` is
-                    defined in NO locale pack — not even `en` — so i18next
-                    genuinely misses and this default is what renders. Removing
-                    it would put the raw key on screen. It is also why the badge
-                    is English-only in all ten locales. Backfilling the key into
-                    `en` (the parity test then carries it to the other nine) is
-                    the real fix; delete this default in the same change. */}
-                {t('form.createTargetOrg', {
-                  org: activeOrganization.name,
-                  defaultValue: `Creates in ${activeOrganization.name}`,
-                })}
+                {t('form.createTargetOrg', { org: activeOrganization.name })}
               </span>
             )}
         </header>

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -133,6 +133,7 @@ const ar = {
     createTitle: "إنشاء {{object}}",
     editTitle: "تعديل {{object}}",
     viewTitle: "عرض {{object}}",
+    createTargetOrg: "الإنشاء في {{org}}",
     saveRecord: "حفظ السجل",
     create: "إنشاء",
     update: "تحديث",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -133,6 +133,7 @@ const de = {
     createTitle: "{{object}} erstellen",
     editTitle: "{{object}} bearbeiten",
     viewTitle: "{{object}} anzeigen",
+    createTargetOrg: "Wird in {{org}} erstellt",
     saveRecord: "Datensatz speichern",
     create: "Erstellen",
     update: "Aktualisieren",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -146,6 +146,7 @@ const en = {
     createTitle: 'Create {{object}}',
     editTitle: 'Edit {{object}}',
     viewTitle: 'View {{object}}',
+    createTargetOrg: 'Creates in {{org}}',
     saveRecord: 'Save',
     create: 'Create',
     update: 'Update',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -138,6 +138,7 @@ const es = {
     createTitle: "Crear {{object}}",
     editTitle: "Editar {{object}}",
     viewTitle: "Ver {{object}}",
+    createTargetOrg: "Se crea en {{org}}",
     saveRecord: "Guardar registro",
     create: "Crear",
     update: "Actualizar",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -133,6 +133,7 @@ const fr = {
     createTitle: "Créer {{object}}",
     editTitle: "Modifier {{object}}",
     viewTitle: "Afficher {{object}}",
+    createTargetOrg: "Création dans {{org}}",
     saveRecord: "Enregistrer",
     create: "Créer",
     update: "Mettre à jour",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -133,6 +133,7 @@ const ja = {
     createTitle: "{{object}}を作成",
     editTitle: "{{object}}を編集",
     viewTitle: "{{object}}を表示",
+    createTargetOrg: "作成先: {{org}}",
     saveRecord: "レコードを保存",
     create: "作成",
     update: "更新",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -133,6 +133,7 @@ const ko = {
     createTitle: "{{object}} 생성",
     editTitle: "{{object}} 편집",
     viewTitle: "{{object}} 보기",
+    createTargetOrg: "{{org}}에 생성",
     saveRecord: "레코드 저장",
     create: "생성",
     update: "업데이트",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -133,6 +133,7 @@ const pt = {
     createTitle: "Criar {{object}}",
     editTitle: "Editar {{object}}",
     viewTitle: "Ver {{object}}",
+    createTargetOrg: "Criação em {{org}}",
     saveRecord: "Salvar registro",
     create: "Criar",
     update: "Atualizar",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -133,6 +133,7 @@ const ru = {
     createTitle: "Создать {{object}}",
     editTitle: "Редактировать {{object}}",
     viewTitle: "Просмотреть {{object}}",
+    createTargetOrg: "Создаётся в {{org}}",
     saveRecord: "Сохранить запись",
     create: "Создать",
     update: "Обновить",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -138,6 +138,7 @@ const zh = {
     createTitle: '新建{{object}}',
     editTitle: '编辑{{object}}',
     viewTitle: '查看{{object}}',
+    createTargetOrg: '创建到{{org}}',
     saveRecord: '保存',
     create: '创建',
     update: '更新',


### PR DESCRIPTION
Fixes #3517

`form.createTargetOrg`(ADR-0105 集团租户「写入目标」徽标,`RecordFormPage` create 模式渲染)**在十个语言包里一个都没有定义,连 `en` 都没有**。i18next 是真的 miss,渲染出来的是调用点的内联 `defaultValue`,所以该徽标在十种语言下全是英文 —— 中文控制台在组织隔离对象上新建记录时,头部会出现一句 `Creates in 某某组织`。

`all-locales-key-parity.test.ts` 看不见这条:它断言的是「每个包定义了 **`en`** 的每个 key」,`en` 自己没有的 key 不在比较范围内,十个包一致地缺失反而让 parity 完全绿。

## 改了什么

1. **`en.ts` 回填** `createTargetOrg: 'Creates in {{org}}'`,parity 门禁随即要求其余九包跟上。
2. **九个语言实译**,按各包既有 `form` 段的语气与词汇,不是机翻占位、也不是英文复制(逐条理由见下表)。
3. **删掉 `RecordFormPage.tsx` 的内联 `defaultValue`** 及其说明注释 —— 这是 #3469 留下的最后一条例外,现在该文件每一处 `t()` 都是裸调用。Declared = enforced:语言包是这份文案的唯一来源,key 缺失必须显形(裸 key + dev missing-key 告警),而不是在调用点糊过去。
4. **反转 #3516 留下的两条例外钉扎**:`form.createTargetOrg` 并入 `BARE_KEYS`(钉住十包都有),渲染断言改为按**语言包**取值,并按该文件既有的写法**同时断言 zh** —— 被删掉的英文默认值无论如何都满足不了中文断言。

## 九个语言的取词依据

| 包 | 译文 | 依据 |
|---|---|---|
| zh | `创建到{{org}}` | 与 `新建{{object}}` 一致,插值前后不加空格;「创建到」表达写入方向 |
| ja | `作成先: {{org}}` | 沿用 `相手の保存時刻: {{time}}` 的「名词 + 半角冒号 + 值」徽标句式;`作成先` 正是写入目标 |
| ko | `{{org}}에 생성` | 与 `{{object}} 생성` 同词(생성);조사 `에` 不随收音变化,插值安全 |
| de | `Wird in {{org}} erstellt` | 与 `{{object}} erstellen` 同词根,被动现在时对应 "Creates in" |
| fr | `Création dans {{org}}` | 名词式,避免与按钮态 `Créer {{object}}` 混淆 |
| es | `Se crea en {{org}}` | 自反被动,西语 UI 常见("se crea en / se guarda en") |
| pt | `Criação em {{org}}` | 名词式;刻意**不用** `Criado em`,它会与日期字段「Criado em 某日期」歧义 |
| ru | `Создаётся в {{org}}` | 与 `Создать {{object}}` 同词根;用 ё,与该包 `несохранённые`/`обновлён` 的正字法一致 |
| ar | `الإنشاء في {{org}}` | 与 `إنشاء {{object}}` 同词根;占位符置于句末,与该包 `تحرير {{label}}`、`الخطوة {{current}} من {{total}}` 的 RTL 语序一致 |

## 测试方向(先预测再跑)

- **改动前(fresh main)**:两条例外钉扎绿(它们断言「缺失」)—— 实测 36 passed。
- **仅做第 1 步(只改 `en.ts`)——刻意跑的中间态**:parity 红 + 例外钉扎红,共 **10 failed**。九条形如(以 `ar` 为例,zh/ja/ko/de/fr/es/pt/ru 同形):

  ```
  ar is missing 1 key(s): expected [ 'form.createTargetOrg' ] to deeply equal []
  ```

  外加例外钉扎打出它自己写好的指令:

  ```
  form.createTargetOrg is now translated — backfill done, so remove the inline
  defaultValue in RecordFormPage.tsx: expected [ 'en' ] to deeply equal []
  ```

  两道门禁都确实会响。
- **全部改完**:全绿。

**反向验证的方向是「无变化」,不是「变红」,这里如实记录**:把 `RecordFormPage.tsx` 从 origin/main 检出(把 `defaultValue` 装回去),测试文件 **17 passed 依旧全绿** —— 因为 key 现在能从语言包解析,i18next 根本不会去看 `defaultValue`,它又变回死代码。这正是本 issue 描述的缺陷形态(没有测试能看见的死分支),所以真正的红色方向是上面那个中间态,而不是「把删掉的肢体装回去」。

## 验证

```
pnpm exec vitest run packages/i18n packages/app-shell
  Test Files  305 passed (305)
       Tests  2732 passed | 1 skipped (2733)

pnpm --filter @object-ui/i18n type-check       # tsc --noEmit,无输出
pnpm --filter @object-ui/app-shell type-check  # tsc --noEmit && tsc -p tsconfig.typetests.json,无输出
node scripts/check-control-bytes.mjs           # OK(3690 个文本文件)
```

Changeset:`.changeset/create-target-org-translated-3517.md`,`@object-ui/i18n` 与 `@object-ui/app-shell` 各一条 patch。未触碰 `content/docs/releases/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)