### PR TITLE
fix(app-shell): derive each context selector's URL scope key from its id

### DIFF
--- a/.changeset/context-selector-per-selector-scope-key.md
+++ b/.changeset/context-selector-per-selector-scope-key.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`useAppContextSelectors` now derives each context selector's URL scope key from its own `id` instead of hardcoding the literal `package` query key. `App.contextSelectors` is an array and `AppContextSelectorSchema.id` is documented as the nav template var the selected value is published under — but the shell spelled `package` on all five read/write sites, so a second declared selector mirrored the first: switching either one wrote the same query key, and every `contextValues[id]` read it back. An app declaring `active_package` + `active_env` parsed clean, rendered two dropdowns, and fed both template vars one shared value (#3500).
+
+Studio's shipped `?package=` links are unaffected. The `active_package` selector keeps that exact key through a single grandfathered entry (`contextSelectorQueryKey`), because it is not this renderer's key to rename: ~15 Studio nav items declare `params: { package: '{active_package}' }` in `@objectstack/platform-objects`, six Studio surfaces read `?package` straight off the query string, and bookmarked URLs already carry it. Existing URLs are byte-identical before and after; only newly declared selectors get `?<id>=`. `UnifiedSidebar`'s Studio home link now reads and re-emits the scope through the same derivation rather than assuming the literal key. Two selectors colliding on one key warn in dev.
+
+The `persist` under-enforcement reported in the same issue (`'query' | 'session' | 'none'` are not distinguished) is deliberately untouched here — it is a spec-side enforce-or-remove ruling tracked separately.

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -12,6 +12,10 @@
  * Selecting an option therefore transparently scopes every child nav
  * item — no per-item wiring required.
  *
+ * The active value also lives in the URL query string, under a key derived
+ * per selector by {@link contextSelectorQueryKey} — see that helper for the
+ * one grandfathered key (`active_package` → `?package=`) and its sunset.
+ *
  * @module
  */
 
@@ -45,6 +49,57 @@ export interface ContextSelectorDef {
 interface Option { value: string; label: string }
 
 const ALL_SENTINEL = '__all__';
+
+/** Selector id used by the built-in Studio app's package scope. */
+export const STUDIO_PACKAGE_SELECTOR_ID = 'active_package';
+
+/**
+ * URL scope keys that shipped BEFORE the key was derived per selector
+ * (objectui#3500). Grandfathered by selector id, read and write alike.
+ *
+ * Exactly one entry, and it must stay that way: Studio's `active_package`
+ * selector keeps owning `?package=`. That key is a live contract with three
+ * parties this file does not own —
+ *
+ *  1. bookmarked / shared Studio URLs already carrying `?package=…`;
+ *  2. six Studio surfaces that read `?package` straight off the query string
+ *     (`StudioHomePage`, `DirectoryPage`, `ResourceListPage`,
+ *     `ResourceEditPage` ×2, `AiChatPage`);
+ *  3. Studio's own nav metadata in `@objectstack/platform-objects`, which
+ *     declares `params: { package: '{active_package}' }` on ~15 nav items —
+ *     i.e. the destination query key is chosen by the APP metadata, not by
+ *     this renderer, and renaming here alone would desync the two halves.
+ *
+ * So this is a migration, not a rename: the pre-existing selector keeps its
+ * key, while every NEWLY declared selector gets `?<id>=` from day one — which
+ * is the whole point of the fix (a second selector no longer mirrors the
+ * first). Do not add entries here; a new selector that "wants" a shorter key
+ * is asking for a spec-side `queryKey`, not a renderer-side alias.
+ *
+ * Sunset: delete the entry (and this table) once either
+ *  (a) `AppContextSelectorSchema` gains an explicit query-key field so the app
+ *      author declares it, or
+ *  (b) Studio's nav metadata and the six reader surfaces above move to
+ *      `?active_package=`,
+ * at which point the plain `id` derivation needs no exception.
+ */
+// A Map, not an object literal: selector ids are snake_case identifiers, and
+// `constructor` / `valueOf` are legal snake_case — an object lookup would walk
+// the prototype and hand back a function as the "query key".
+const LEGACY_SCOPE_QUERY_KEYS: ReadonlyMap<string, string> = new Map([
+  [STUDIO_PACKAGE_SELECTOR_ID, 'package'],
+]);
+
+/**
+ * The URL query key that carries a context selector's active value.
+ *
+ * Derived from the selector's `id`, so each selector owns an independent
+ * key — `AppContextSelectorSchema` promises the selected value is exposed
+ * per `id`, and a shared key made every declared selector mirror the first.
+ */
+export function contextSelectorQueryKey(selectorId: string): string {
+  return LEGACY_SCOPE_QUERY_KEYS.get(selectorId) ?? selectorId;
+}
 
 /** Read a (possibly dotted) property path off a row, e.g. `manifest.id`. */
 function getByPath(row: any, key: string): unknown {
@@ -160,10 +215,11 @@ export function useAppContextSelectors(
     let changed = false;
     for (const sel of list) {
       if (sel.persist === 'none') continue;
-      if (p.get('package')) continue;
+      const key = contextSelectorQueryKey(sel.id);
+      if (p.get(key)) continue;
       try {
         const saved = sessionStorage.getItem(`objectui-ctx-${appName}-${sel.id}`);
-        if (saved) { p.set('package', saved); changed = true; }
+        if (saved) { p.set(key, saved); changed = true; }
       } catch { /* storage disabled */ }
     }
     if (changed) {
@@ -179,14 +235,38 @@ export function useAppContextSelectors(
       else sessionStorage.removeItem(key);
     } catch { /* storage disabled */ }
 
-    // Reflect the scope onto the current page immediately. Metadata
-    // surfaces read the `package` query param as the conventional filter
-    // key; nav links pick it up via the `{active_package}` template var.
+    // Reflect the scope onto the current page immediately, under THIS
+    // selector's own query key — writing a shared key made a second selector
+    // clobber the first's scope. Studio's `active_package` still resolves to
+    // `package`, the key its metadata surfaces and nav links already use.
     const next = new URLSearchParams(location.search);
-    if (value) next.set('package', value);
-    else next.delete('package');
+    const key = contextSelectorQueryKey(sel.id);
+    if (value) next.set(key, value);
+    else next.delete(key);
     navigate({ pathname: location.pathname, search: next.toString() }, { replace: true });
   }, [appName, location.pathname, location.search, navigate]);
+
+  // Two selectors resolving to the same query key would silently reintroduce
+  // the mirroring this fix removes, and the symptom (both template vars hold
+  // one value) reads as a data bug rather than an authoring one. Say so out
+  // loud in dev — the renderer cannot reject metadata, only complain.
+  React.useEffect(() => {
+    if (process.env.NODE_ENV === 'production') return;
+    const owners = new Map<string, string>();
+    for (const sel of list) {
+      const key = contextSelectorQueryKey(sel.id);
+      const owner = owners.get(key);
+      if (owner) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[ObjectUI] contextSelectors "${owner}" and "${sel.id}" both map to the URL `
+          + `scope key "?${key}=" — their values will mirror each other. Rename one id.`,
+        );
+      } else {
+        owners.set(key, sel.id);
+      }
+    }
+  }, [list]);
 
   const contextValues: Record<string, string> = {};
   for (const sel of list) {
@@ -194,7 +274,7 @@ export function useAppContextSelectors(
     try {
       saved = sessionStorage.getItem(`objectui-ctx-${appName}-${sel.id}`) ?? '';
     } catch { /* storage disabled */ }
-    contextValues[sel.id] = (params.get('package') ?? saved) || (sel.allValue ?? '');
+    contextValues[sel.id] = (params.get(contextSelectorQueryKey(sel.id)) ?? saved) || (sel.allValue ?? '');
   }
 
   const element = list.length === 0 ? null : (

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -54,7 +54,11 @@ import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 // i18n lookup — `{ns}.apps.{name}.label` resolves to the translated label
 // loaded from /api/v1/i18n/translations/:locale.
 import { useNavigationContext } from '../context/NavigationContext';
-import { useAppContextSelectors } from './ContextSelectors';
+import {
+  useAppContextSelectors,
+  contextSelectorQueryKey,
+  STUDIO_PACKAGE_SELECTOR_ID,
+} from './ContextSelectors';
 import { LocalizedSidebarTrigger } from './LocalizedSidebarTrigger';
 
 // ---------------------------------------------------------------------------
@@ -340,11 +344,18 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
   const navigationItems = context === 'home' ? homeNavigation : appNavigation;
   const basePath = context === 'app' && activeApp ? `/apps/${appRouteSegment(activeApp)}` : '';
   const isStudioApp = context === 'app' && activeApp?.name === 'studio';
+  // Studio's home link carries the active package scope. Read (and re-emit)
+  // it through the SAME per-selector key derivation the selector writes with,
+  // instead of assuming the literal `package` key — for `active_package` the
+  // derivation resolves to `package`, so existing links are byte-identical,
+  // and the two halves can no longer drift apart (objectui#3500).
+  const studioScopeKey = contextSelectorQueryKey(STUDIO_PACKAGE_SELECTOR_ID);
+  const studioScopeValue = contextValues[STUDIO_PACKAGE_SELECTOR_ID];
   const studioHomeSearch = React.useMemo(() => {
     if (!isStudioApp) return '';
-    const packageId = new URLSearchParams(location.search).get('package') || contextValues.active_package;
-    return packageId ? `?package=${encodeURIComponent(packageId)}` : '';
-  }, [contextValues.active_package, isStudioApp, location.search]);
+    const packageId = new URLSearchParams(location.search).get(studioScopeKey) || studioScopeValue;
+    return packageId ? `?${studioScopeKey}=${encodeURIComponent(packageId)}` : '';
+  }, [studioScopeValue, isStudioApp, location.search, studioScopeKey]);
 
   const studioNavigationItems = React.useMemo(() => {
     if (context !== 'app' || activeApp?.name !== 'studio') return navigationItems;

--- a/packages/app-shell/src/layout/__tests__/ContextSelectors.scopeKey.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ContextSelectors.scopeKey.test.tsx
@@ -1,0 +1,259 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Context selectors own ONE URL scope key EACH (objectui#3500).
+ *
+ * `AppContextSelectorSchema` is an array and its `id` is documented as the
+ * nav template var the selected value is published under — so declaring two
+ * selectors must yield two independent scopes. The shell used to hardcode the
+ * literal `package` query key on both the read and the write side, so a second
+ * selector mirrored the first: switching either wrote the same key, and every
+ * `contextValues[id]` read it back. Parse-clean metadata, two rendered
+ * dropdowns, one silently shared value.
+ *
+ * No fixture in this repo had ever declared a second selector, which is why
+ * the hole was invisible to the suite — hence the ≥2-selector cases below.
+ *
+ * The legacy-compat case is a REGRESSION PIN, not a behaviour change: Studio's
+ * `active_package` selector deliberately keeps `?package=`, because that key
+ * is also spelled by ~15 Studio nav items in `@objectstack/platform-objects`
+ * (`params: { package: '{active_package}' }`) and read directly by six Studio
+ * pages. It was green before this change and must stay green after it.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import type { NavigationItem } from '@object-ui/types';
+
+// Radix's Select is not driveable in happy-dom (pointer capture), and the
+// choreography is not what is under test — the query key the selection lands
+// on is. Swap the primitives for a flat list of buttons that call
+// `onValueChange` directly. `getLazyIcon` is kept because NavigationRenderer
+// (imported below for the template assertion) names it.
+vi.mock('@object-ui/components', async () => {
+  const R = await import('react');
+  const PickCtx = R.createContext<(value: string) => void>(() => {});
+  return {
+    getLazyIcon: () => () => null,
+    Select: ({ value, onValueChange, children }: any) => (
+      <PickCtx.Provider value={onValueChange}>
+        <div data-current={value ?? ''}>{children}</div>
+      </PickCtx.Provider>
+    ),
+    SelectTrigger: ({ children, 'aria-label': label }: any) => (
+      <div role="combobox" aria-label={label}>{children}</div>
+    ),
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectItem: ({ value, children }: any) => {
+      const pick = R.useContext(PickCtx);
+      return (
+        <button type="button" data-testid={`opt-${value}`} onClick={() => pick(value)}>
+          {children}
+        </button>
+      );
+    },
+    SelectValue: () => null,
+  };
+});
+
+import { resolveHref } from '@object-ui/layout/NavigationRenderer';
+import {
+  useAppContextSelectors,
+  contextSelectorQueryKey,
+  STUDIO_PACKAGE_SELECTOR_ID,
+  type ContextSelectorDef,
+} from '../ContextSelectors';
+
+const PACKAGES_ENDPOINT = '/api/v1/packages';
+const ENVS_ENDPOINT = '/api/v1/environments';
+
+/** Option rows per endpoint; labels sort so `options[0]` is predictable. */
+const ROWS: Record<string, Array<{ id: string; name: string }>> = {
+  [PACKAGES_ENDPOINT]: [
+    { id: 'billing', name: 'Billing' },
+    { id: 'crm_core', name: 'CRM Core' },
+  ],
+  [ENVS_ENDPOINT]: [
+    { id: 'prod', name: 'Production' },
+    { id: 'staging', name: 'Staging' },
+  ],
+};
+
+// Stable module-level refs: `useAppContextSelectors` keys effects off the
+// selector array, so a fresh array per render would re-run them needlessly.
+const STUDIO_ONLY: ContextSelectorDef[] = [
+  { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT } },
+];
+
+const TWO_SELECTORS: ContextSelectorDef[] = [
+  { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT } },
+  { id: 'active_env', label: 'Environment', optionsSource: { endpoint: ENVS_ENDPOINT } },
+];
+
+/** Latest render's hook output plus the router's query string. */
+let snapshot: { contextValues: Record<string, string>; search: string };
+
+function Probe({ selectors }: { selectors: ContextSelectorDef[] }) {
+  const location = useLocation();
+  const { contextValues, element } = useAppContextSelectors('studio', selectors);
+  // Published from an effect, not during render: the hook re-navigates from
+  // its own effects, so only a committed render is a meaningful sample.
+  React.useEffect(() => {
+    snapshot = { contextValues, search: location.search };
+  });
+  return <>{element}</>;
+}
+
+function mount(selectors: ContextSelectorDef[], url: string) {
+  snapshot = { contextValues: {}, search: '' };
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Probe selectors={selectors} />
+    </MemoryRouter>,
+  );
+}
+
+/** The options for every declared selector have resolved and rendered. */
+async function optionsReady(...testIds: string[]) {
+  await waitFor(() => {
+    for (const id of testIds) expect(screen.getByTestId(id)).toBeInTheDocument();
+  });
+}
+
+function query() {
+  return new URLSearchParams(snapshot.search);
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => ROWS[String(url)] ?? [],
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('contextSelectorQueryKey', () => {
+  it('derives the scope key from the selector id', () => {
+    expect(contextSelectorQueryKey('active_env')).toBe('active_env');
+    expect(contextSelectorQueryKey('tenant')).toBe('tenant');
+    // Snake_case ids that collide with Object.prototype must not resolve to a
+    // prototype member — the legacy table is a Map for exactly this reason.
+    expect(contextSelectorQueryKey('constructor')).toBe('constructor');
+    expect(contextSelectorQueryKey('value_of')).toBe('value_of');
+  });
+
+  it('grandfathers the shipped `?package=` key for `active_package`', () => {
+    expect(contextSelectorQueryKey(STUDIO_PACKAGE_SELECTOR_ID)).toBe('package');
+  });
+});
+
+describe('useAppContextSelectors — one URL scope key per selector', () => {
+  it('reads every selector value from its own query key', async () => {
+    mount(TWO_SELECTORS, '/apps/studio?package=crm_core&active_env=prod');
+    await optionsReady('opt-crm_core', 'opt-prod');
+
+    expect(snapshot.contextValues).toEqual({
+      active_package: 'crm_core',
+      active_env: 'prod',
+    });
+  });
+
+  it('switching one selector leaves the other scope untouched', async () => {
+    mount(TWO_SELECTORS, '/apps/studio?package=crm_core&active_env=prod');
+    await optionsReady('opt-crm_core', 'opt-staging');
+
+    fireEvent.click(screen.getByTestId('opt-staging'));
+
+    await waitFor(() => expect(snapshot.contextValues.active_env).toBe('staging'));
+    // The package scope is the one that used to get clobbered.
+    expect(snapshot.contextValues.active_package).toBe('crm_core');
+    expect(query().get('package')).toBe('crm_core');
+    expect(query().get('active_env')).toBe('staging');
+    // The per-selector sessionStorage half was already correct; keep it pinned
+    // so the URL/session halves cannot drift apart again.
+    expect(sessionStorage.getItem('objectui-ctx-studio-active_env')).toBe('staging');
+    expect(sessionStorage.getItem('objectui-ctx-studio-active_package')).toBeNull();
+  });
+
+  it('re-applies each remembered scope under its own key', async () => {
+    sessionStorage.setItem('objectui-ctx-studio-active_package', 'crm_core');
+    sessionStorage.setItem('objectui-ctx-studio-active_env', 'prod');
+
+    mount(TWO_SELECTORS, '/apps/studio');
+
+    await waitFor(() => {
+      expect(query().get('package')).toBe('crm_core');
+      expect(query().get('active_env')).toBe('prod');
+    });
+    expect(snapshot.contextValues).toEqual({
+      active_package: 'crm_core',
+      active_env: 'prod',
+    });
+  });
+
+  it('publishes distinct nav template vars per selector id', async () => {
+    mount(TWO_SELECTORS, '/apps/studio?package=crm_core&active_env=prod');
+    await optionsReady('opt-crm_core', 'opt-prod');
+
+    const ctx = { contextValues: snapshot.contextValues };
+    const item = (params: Record<string, string>): NavigationItem => ({
+      id: 'nav_comp',
+      type: 'component',
+      label: 'Comp',
+      componentRef: 'metadata:resource',
+      params,
+    } as NavigationItem);
+
+    expect(
+      resolveHref(item({ type: 'object', package: '{active_package}' }), '/apps/studio', ctx).href,
+    ).toBe('/apps/studio/metadata/object?package=crm_core');
+    expect(
+      resolveHref(item({ type: 'object', env: '{active_env}' }), '/apps/studio', ctx).href,
+    ).toBe('/apps/studio/metadata/object?env=prod');
+  });
+
+  it('warns when two selectors collide on one scope key', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // `package` and `active_package` both resolve to `?package=` — the one
+    // collision the legacy table can still produce. Silent mirroring is what
+    // this whole fix removes, so say it out loud instead.
+    const colliding: ContextSelectorDef[] = [
+      { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT } },
+      { id: 'package', label: 'Package (again)', optionsSource: { endpoint: PACKAGES_ENDPOINT } },
+    ];
+    mount(colliding, '/apps/studio?package=crm_core');
+
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('both map to the URL scope key "?package="')),
+    );
+    warn.mockRestore();
+  });
+});
+
+describe('useAppContextSelectors — legacy `?package=` compat (regression pin)', () => {
+  it('reads and writes the shipped `?package=` key, never `?active_package=`', async () => {
+    mount(STUDIO_ONLY, '/apps/studio?package=crm_core');
+    await optionsReady('opt-billing', 'opt-crm_core');
+
+    // Read side: an existing bookmark keeps resolving the template var.
+    expect(snapshot.contextValues.active_package).toBe('crm_core');
+
+    // Write side: switching still lands on `?package=`, which is what the six
+    // Studio reader surfaces and the app's own nav metadata spell.
+    fireEvent.click(screen.getByTestId('opt-billing'));
+
+    await waitFor(() => expect(query().get('package')).toBe('billing'));
+    expect(query().has('active_package')).toBe(false);
+    expect(snapshot.contextValues.active_package).toBe('billing');
+  });
+});

--- a/packages/app-shell/src/layout/__tests__/UnifiedSidebar.derivedAreaVisibility.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/UnifiedSidebar.derivedAreaVisibility.test.tsx
@@ -94,8 +94,13 @@ vi.mock('../../hooks/useNavActionDispatch', () => ({
 vi.mock('../../context/NavigationContext', () => ({
   useNavigationContext: () => ({ context: 'app', currentAppName: 'crm' }),
 }));
+// The sidebar also imports the per-selector scope-key derivation (#3500) to
+// build Studio's home link; keep those exports on the mock or the module is
+// missing them at import time.
 vi.mock('../ContextSelectors', () => ({
   useAppContextSelectors: () => ({ contextValues: {}, element: null }),
+  contextSelectorQueryKey: (id: string) => (id === 'active_package' ? 'package' : id),
+  STUDIO_PACKAGE_SELECTOR_ID: 'active_package',
 }));
 vi.mock('../LocalizedSidebarTrigger', () => ({
   LocalizedSidebarTrigger: () => null,


### PR DESCRIPTION
Fixes #3500

只做**①半**(URL 作用域键)。②半 `persist` 三取值的 enforce-or-remove 裁决在 objectstack#5994,**本 PR 完全不碰** `persist` 逻辑(`if (sel.persist === 'none') continue;` 一行未动),两半由两个座位串行落地。

## 问题

`useAppContextSelectors` 把 URL 作用域键写死成字面量 `package`,五处读写全都是它。而 `AppContextSelectorSchema` 是数组、`id` 的 `.describe` 明说「选中值按 `id` 暴露为导航模板变量」。于是声明第二个 selector 时:切换任意一个都写同一个 query key,每个 `contextValues[id]` 又都从同一个 key 读回 —— 元数据 parse 通过、渲染出两个下拉、两个模板变量拿到同一个值。

`sessionStorage` 那一半本来就是按 selector 分开的(`objectui-ctx-${appName}-${sel.id}`),所以两半是错位的。

## 改法

新增 `contextSelectorQueryKey(id)`,按 selector 的 `id` 派生 query key,**读写两侧一致**地替换掉全部五处硬编码(重新施加已记住的作用域 2 处、写入选中值 2 处、读回当前值 1 处)。

## 兼容路径:这是迁移,不是改名

Studio 现有的 `?package=` 链接**逐字节不变**。`active_package` 通过 `LEGACY_SCOPE_QUERY_KEYS` 里**唯一一条**祖父条目继续拥有 `package` 这个键 —— 因为这个键根本不归本文件命名,它是与三方的活契约:

1. 已经流传在外的 `?package=…` Studio 书签/分享链接;
2. 六个 Studio 界面直接从 query string 读 `?package`:`StudioHomePage:165`、`DirectoryPage:114`、`ResourceListPage:174`、`ResourceEditPage:259` 与 `:1076`、`AiChatPage:737`(全部在 file fence 之外,本 PR 一行未动);
3. `@objectstack/platform-objects` 的 `studio.app.ts` 里约 15 个导航项声明了 `params: { package: '{active_package}' }` —— **目的地的 query key 是由 app 元数据选的,不是由这个渲染器选的**。只在这边改名,两半立刻错位。

所以取舍是:**已存在的 selector 保留原键,此后新声明的 selector 从第一天起就拿到自己的 `?` + `id` + `=`** —— 这正是本次修复的全部意义。表里不再加第二条:新 selector 想要一个更短的键,那是 spec 侧该有一个 `queryKey` 字段,而不是渲染器侧再加别名(AGENTS #0.1)。

**日落条件**(写进了代码注释):满足以下任一条即删除该条目及整张表 ——
(a) `AppContextSelectorSchema` 增加显式的 query-key 字段,由 app 作者声明;或
(b) Studio 的导航元数据与上面六个读取面一并迁到 `?active_package=`。
届时纯 `id` 派生不再需要任何例外。

`UnifiedSidebar.tsx:345` 的 `?package` 直读也走同一套派生(`contextSelectorQueryKey(STUDIO_PACKAGE_SELECTOR_ID)`),读和回写都用派生出来的键 —— 对 `active_package` 结果仍是 `package`,链接逐字节相同,但两半从此不可能各自漂移。

额外:两个 selector 派生出同一个键时(唯一可能的形状是同时声明 `active_package` 与 `package`)dev 环境 `console.warn` 告警 —— 静默镜像正是本次要消灭的症状,渲染器拒绝不了元数据,至少要出声。祖父表用 `Map` 而非对象字面量:`constructor` / `value_of` 都是合法的 snake_case id,对象查找会走原型链把函数当成 query key 返回。

## 测试与反向验证(方向**先预测后运行**)

新增 `packages/app-shell/src/layout/__tests__/ContextSelectors.scopeKey.test.tsx` —— 此前仓库里**没有任何用例声明第二个 selector**,这个洞在测试里同样不可见。

反向验证方式:把两个源文件 `git checkout origin/main --` 还原,只补上两个新导出的临时 shim(五处硬编码保持 origin/main 原样),跑同一个测试文件:

| 用例 | 预测 | origin/main 实测 |
|:--|:--|:--|
| 每个 selector 从自己的 key 读值 | RED | RED — `active_env` 收到 `crm_core`(镜像了第一个) |
| 切换一个 selector 不动另一个的作用域 | RED | RED — `active_package` 被写成 `staging` |
| 按各自的 key 重新施加已记住的作用域 | RED | RED — `active_env` 参数为 `null` |
| 每个 id 发布互不相同的导航模板变量 | RED | RED — 解析出 `?env=crm_core` 而非 `?env=prod` |
| 两个 selector 撞键时告警 | RED(新诊断) | RED — `warn` 调用 0 次 |
| `contextSelectorQueryKey` 单元(2 条) | GREEN | GREEN |
| **legacy `?package=` 兼容(读+写)** | **GREEN,改前改后都绿** | **GREEN** |

最后一条按模板会被写成「改前红」,但那是**不诚实**的:兼容路径的正确性恰恰在于它**没有**改变行为 —— 它是一条**回归钉**,防的是日后有人「顺手清理」掉祖父条目,不是本次的行为变更。这里如实标注。

打完补丁后同一文件 8/8 全绿。

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

### 消费方逐一交代(`git grep -n "contextValues|get('package')|set('package')"`)

| 命中 | 处置 |
|:--|:--|
| `ContextSelectors.tsx` 五处硬编码 | **改** —— 全部走 `contextSelectorQueryKey` |
| `UnifiedSidebar.tsx:345/347` | **改** —— 同一套派生;`:300/:514` 的 `contextValues` 消费不变 |
| `AppSidebar.tsx:288/421/532` | 不动 —— 本来就按 `sel.id` 透传给 `templateContext`,现在拿到的值才是对的 |
| `NavigationRenderer.tsx:441/456` | 不动 —— `contextValues?.[name]` 本来就按变量名(= selector id)查,问题从来在生产侧 |
| `StudioHomePage:165` / `DirectoryPage:114` / `ResourceListPage:174` / `ResourceEditPage:259,1076` / `AiChatPage:737` | 不动 —— 兼容路径保证 `?package` 语义不变;越界即停 |
| `UnifiedSidebar.derivedAreaVisibility.test.tsx:97` 的 `vi.mock('../ContextSelectors')` | **改** —— 只导出了 `useAppContextSelectors`,新导入的两个符号会让整个 suite 在 import 期炸掉(实测 7 red),补齐 mock |
| `AppSidebar.derivedAreaVisibility.test.tsx:91` 的同名 mock | 不动 —— `AppSidebar` 没有导入新符号,mock 仍然成立 |
| `packages/layout/.../resolveHref.test.ts:275` | 不动 —— 钉的是 `{active_package}` 的模板解析,不受影响 |

### 验证命令

```
pnpm exec vitest run packages/app-shell/src/layout        -> 12 files / 66 tests passed
pnpm exec vitest run packages/app-shell                   -> 284 files / 2478 passed, 1 skipped
pnpm --filter @object-ui/app-shell type-check             -> clean
pnpm exec eslint (四个改动文件)                          -> 0 errors
```

(全新 worktree 里先跑了 `pnpm --filter '@object-ui/app-shell^...' build`,否则 type-check 会报一片 `Cannot find module '@object-ui/*'` 的假红。)

Changeset:`.changeset/context-selector-per-selector-scope-key.md`(patch,`@object-ui/app-shell`)。未触碰 `content/docs/releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_