### PR TITLE
docs: 删除 runner 不存在的环境变量配置面,修正前端示例的 process.env 读法

### DIFF
--- a/content/docs/guide/objectos-integration.mdx
+++ b/content/docs/guide/objectos-integration.mdx
@@ -403,7 +403,7 @@ start();
 ```typescript
 // frontend/src/config.ts
 export const config = {
-  apiBaseUrl: process.env.VITE_API_URL || 'http://localhost:3000/api'
+  apiBaseUrl: import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
 };
 
 // frontend/src/index.tsx

--- a/content/docs/utilities/runner.mdx
+++ b/content/docs/utilities/runner.mdx
@@ -313,22 +313,6 @@ Run tests:
 pnpm test
 ```
 
-## Environment Variables
-
-Configure the runner with environment variables:
-
-```bash
-# .env
-VITE_API_URL=http://localhost:3000
-VITE_APP_TITLE="ObjectUI Runner"
-```
-
-Use in code:
-
-```typescript
-const apiUrl = import.meta.env.VITE_API_URL
-```
-
 ## Package Information
 
 **Package Name:** `@object-ui/runner`  


### PR DESCRIPTION
Fixes #3533

两处文档教的环境变量用法与实现不符,按 #3527 / #3532 的口径处理。

## 一、`content/docs/utilities/runner.mdx` —— 整节删除 "Environment Variables"

前提已复核通过,且核查范围比原单更宽(整个包,不只是 `src`):

    $ grep -rn "import.meta.env|process.env|loadEnv|VITE_" packages/runner --exclude-dir=node_modules --exclude-dir=dist
    (无输出)

    $ grep -rn "VITE_APP_TITLE" -I . --exclude-dir=node_modules --exclude-dir=.git
    content/docs/utilities/runner.mdx:323        ← 全仓仅此一处,即只活在这份文档里

    $ grep -rn "VITE_API_URL" packages/ apps/ examples/ scripts/ | grep -v node_modules
    (无输出)

`@object-ui/runner` 一个环境变量都不读,所以「Configure the runner with environment variables」这一整节教的两个变量都不会生效。失败形态与 #3527 相同:**读者照做、配了、没有任何报错、也没有任何效果**。文档不许描述不存在的能力,因此**整节删除**,不换变量名续命。

删除后衔接干净:`### pnpm test` 的代码块之后直接是 `## Package Information`,没有孤立的引导语或空行。也没有任何锚点悬空 —— 全仓对 `#environment-variables` 的引用为零(`grep -rn "#environment-variables" -I .` 无输出),`content/docs/utilities/meta.json` 只列页面不列标题,不受影响。

## 二、`content/docs/guide/objectos-integration.mdx:406` —— `process.env` 改 `import.meta.env`

该示例注释明写是 `frontend/src/config.ts`,而 Vite 不向浏览器包注入 `process`,原样照抄会直接 `process is not defined`(或恒为 undefined,静默退回硬编码的兜底地址)。

变量名 `VITE_API_URL` 本身是**读者自己应用里的自定义变量**(不是 ObjectUI 的契约),是对的 —— 本 PR 只改读取方式,不动变量名。

## 三、经核定「正确、未改动」的一处

`content/docs/guide/building-crud-app.md:306` 用 `import.meta.env.VITE_API_URL` 读读者自定义变量,拼法正确,属正常示例,按分诊裁定**未改动**。

## 验证

事前预测 → 实测,全部相符:

| 检查 | 预测 | 实测 |
|---|---|---|
| `grep -rn "VITE_APP_TITLE" content/` | 0 | 0(exit 1) |
| `grep -rn "process\.env\.VITE" content/` | 0 | 0(exit 1) |
| `node scripts/check-doc-links.mjs` | exit 0 | `Docs links are valid.` exit 0 |
| `node scripts/check-control-bytes.mjs` | OK | `OK (scanned 3695 tracked text file(s); skipped 85 binary)` |
| `pnpm exec vitest run scripts/ --maxWorkers=2` | 保持绿 | `Test Files 14 passed (14) / Tests 216 passed (216)` |

**关于 vitest 这一项需要说明清楚**:`scripts/__tests__/` 测的是各个检查脚本**自身**,没有任何一个文件引用 `runner.mdx` / `objectos-integration` / `VITE_`(`grep -rln "runner\.mdx|objectos-integration|VITE_" scripts/` 无输出)。所以这 216 个测试是**回归兜底**,并没有真正覆盖本 PR 改的内容;真正把本次改动跑过一遍的是 `check-doc-links.mjs` 与 `check-control-bytes.mjs`(它们扫真实的 `content/` 树)。据实写明,不把它记成「测试验证了本改动」。

另外对两个被改文件做了超出 gate 的控制字符自查(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`),无命中。

无 changeset:纯 content 文档改动,依 #3532 先例。

## 越界发现(已另立单,本 PR 不实现)

**#3537** —— runner **真实**的 API 基址配置面是 URL 查询参数 `api`(`packages/runner/src/App.tsx:43-57`:带 `api` 参数走 `NetworkLoader`,缺省走 `LocalBundleLoader`),而这个真实能力在全仓文档里**零处记载**。与本单互为镜像:本单是「文档教了实现里没有的东西」,#3537 是「实现里有的东西文档一个字没写」。删掉这节错误的环境变量说明之后,该页关于 API 基址的指引为零 —— 删除仍然是对的,但由此暴露的文档缺口另单处理。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_