### PR TITLE
docs(guide): 删掉 console.md 已整体过期的 Folder Structure 目录树

### DIFF
--- a/content/docs/guide/console.md
+++ b/content/docs/guide/console.md
@@ -97,29 +97,11 @@ export default defineStack({
    Leave it empty (`VITE_SERVER_URL=`) to use the same origin — the right setting when an ObjectStack server serves the console itself.
 2. The console will use the ObjectStack client to discover metadata and perform CRUD operations against the server.
 
-## Folder Structure
+## Where the Code Lives
 
-```
-apps/console/
-  src/
-    App.tsx                    # Root component + routing
-    dataSource.ts              # ObjectStackAdapter wrapper
-    components/
-      AppHeader.tsx            # Top navbar (breadcrumbs, connection status)
-      AppSidebar.tsx           # Left sidebar (app switcher, navigation tree)
-      CommandPalette.tsx       # ⌘+K command bar
-      ConsoleLayout.tsx        # AppShell wrapper
-      ObjectView.tsx           # Object list view (wraps plugin-view)
-      RecordDetailView.tsx     # Single-record detail view
-    pages/
-      CreateAppPage.tsx        # App creation wizard page
-      EditAppPage.tsx          # Edit existing app page
-    context/
-      ExpressionProvider.tsx   # Expression evaluation context
-    hooks/
-      useBranding.ts           # Delegates to @object-ui/layout
-      useObjectActions.ts      # CRUD action handlers
-```
+Most of what you see in the console does not live in `apps/console`. The shell and layout, sidebar, header, command palette, object list and record detail views all ship from **`packages/app-shell`** (`@object-ui/app-shell`), so any host application can mount the same experience; the heavier view surfaces (grid, kanban, calendar, charts, designer) come from the `@object-ui/plugin-*` packages.
+
+`apps/console` is the assembly layer on top: it owns the route tree, registers the plugin set, wires the backend connection, and adds the surfaces specific to this app (auth pages, the docs portal, system and settings pages). So when you want to change something you *see* in the console, look in `packages/app-shell` first.
 
 ## See Also
 


### PR DESCRIPTION
Fixes #3534

## 背景

`content/docs/guide/console.md` 的 "Folder Structure" 代码块自称描述 `apps/console/`,但已整体漂移。PR #3532 只删了其中 MSW 那两行,结构性漂移未动。

## 复核实测(基于 origin/main `a2c8f2a29`,已含 #3532 的 `8c44bb661`)

原块共 11 个叶子条目,**只有 3 个还对得上**:`App.tsx`、`dataSource.ts`、`hooks/useBranding.ts`。其余:

| 文档里写的 | 实际位置 |
|---|---|
| `components/AppHeader.tsx` | `packages/app-shell/src/layout/AppHeader.tsx` |
| `components/AppSidebar.tsx` | `packages/app-shell/src/layout/AppSidebar.tsx` |
| `components/CommandPalette.tsx` | `packages/app-shell/src/chrome/CommandPalette.tsx` |
| `components/ConsoleLayout.tsx` | `packages/app-shell/src/layout/ConsoleLayout.tsx` |
| `components/ObjectView.tsx` | `packages/app-shell/src/views/ObjectView.tsx` |
| `components/RecordDetailView.tsx` | `packages/app-shell/src/views/RecordDetailView.tsx` |
| `context/ExpressionProvider.tsx` | `packages/app-shell/src/providers/ExpressionProvider.tsx`(`apps/console/src/context/` 这个目录不存在) |
| `hooks/useObjectActions.ts` | `packages/app-shell/src/hooks/useObjectActions.ts` |
| `pages/CreateAppPage.tsx` | `packages/plugin-designer/src/pages/CreateAppPage.tsx` |
| `pages/EditAppPage.tsx` | `packages/plugin-designer/src/pages/EditAppPage.tsx` |

比 issue 记的还多两处:`useObjectActions.ts` 也迁走了,而 `CreateAppPage`/`EditAppPage` 去的是 **`plugin-designer`** 而不是 app-shell —— 所以新 prose 没有把「全都在 app-shell」写死。

## 改法(PM 裁定,与 #3488 先例同构)

不逐项重写目录树:手写的目录树是注定再次漂移的手抄本,逐项重写只是把下一次漂移推迟到下一次重构。整块删掉,换成一段 prose,只保留唯一承重的那条信息 —— **console 的绝大多数视图/布局在 `packages/app-shell`,`apps/console` 只是装配层**。

新 prose 的每条断言都有源码依据,不是继承来的:

- 「任何宿主应用都能挂载同一套体验」← `apps/console/src/AppContent.tsx` 自己的注释:*"The full inner-SPA shell (ConsoleLayout, CommandPalette, ObjectView etc.) lives in @object-ui/app-shell as DefaultAppContent … third-party hosts that don't need those routes use DefaultAppContent directly."*
- 「owns the route tree」← `apps/console/src/App.tsx` 注释:*"Owns the full route tree including unauthenticated auth surfaces…"*
- 「registers the plugin set」← `apps/console/src/register-plugins.ts`:*"Console plugin registration — the SDUI block layer."*
- 「wires the backend connection」← `dataSource.ts` 转出 `ObjectStackAdapter`,配合本文上一节的 `VITE_SERVER_URL`
- 「console 专属界面(auth / docs portal / system / settings)」← 实测 `apps/console/src/pages/{auth,system,settings}/`、`pages/Docs*.tsx`

## 关于链接:没有重复贴 URL

裁定要求指向 `/docs/guide/console-architecture`。该链接**已经**是紧随其后的 "See Also" 第一条 —— 新段落是 See Also 之前的最后一节,两行之隔再贴一次同一个 URL 是可见的冗余。因此段落以「先去 `packages/app-shell` 找」这条可执行结论收尾,深入阅读交给既有的 See Also 条目承接,See Also 一字未动。

## 验证

- `node scripts/check-doc-links.mjs` → `Docs links are valid.`,exit 0
- `pnpm exec vitest run scripts/ --maxWorkers=2` → **14 passed (14) / 216 passed (216)**。跑前预测「保持绿」:没有任何测试读 `console.md` 的正文(`check-doc-links.test.ts` 是在临时目录里造合成仓库,不读真实 guide 文件);实测与预测一致。
- `node scripts/check-control-bytes.mjs` → OK(3695 个文本文件),另对本文件单独 `grep -naP` 自检控制字节,干净。
- 全文通读:与 #3532 刚改过的 Quick Start 不冲突(未触及 mock backend / `VITE_SERVER_URL` 的说法),与上方 Key Features 表里的 Command Palette 等条目一致。
- `#folder-structure` 锚点全仓无引用,删标题不会产生死链。

纯 content 文档改动,按仓库约定不加 changeset;未触碰 `content/docs/releases/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_