### PR TITLE
fix(framework): 可见性谓词求值失败去静默——每谓词 warn 一次带源文本与原因 (#5149)

### DIFF
--- a/.changeset/predicate-eval-failures-warn-once.md
+++ b/.changeset/predicate-eval-failures-warn-once.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/core": patch
+"@object-ui/components": patch
+"@object-ui/plugin-form": patch
+"@object-ui/app-shell": patch
+---
+
+Conditional-rule predicates that fail to evaluate are no longer silent
+(objectstack#5149, appeal 2). `evalFieldPredicate` — the canonical funnel for
+`visibleWhen` / `readonlyWhen` / `requiredWhen`, view-level `visibleOn`, legacy
+`condition`, per-option `visibleWhen`, screen-field predicates and list
+conditional formatting — now logs **one `console.warn` per predicate text**
+when evaluation fails (parse error, unbound identifier, engine fault), carrying
+the predicate source, the engine's failure reason, and the field/rule locator
+the call site provides. Renderer call sites thread that locator
+(`visibleWhen of field 'amount'`), so a broken predicate identifies itself in
+the browser console instead of being indistinguishable from an absent one.
+
+Verdicts are unchanged: evaluation still fails open to the caller's safe
+default (flipping that default is objectstack#5149 appeal 1, tracked
+separately). Fault-probing callers (`evalRowPredicate`'s fail-closed path,
+`ExpressionEvaluator`'s `throwOnError`) opt out via the new
+`diagnostic.warn: false` and keep their own single diagnostic, so no broken
+predicate ever warns twice.

--- a/content/docs/guide/metadata-diagnostics.md
+++ b/content/docs/guide/metadata-diagnostics.md
@@ -155,6 +155,17 @@ result type** (only a proven-Number formula is offered as a dataset
 measure), while the draft-wide pass surfaces a broken formula on any field
 under its `fields.<field>.expression` path.
 
+A predicate that slips past authoring is still not silent at **runtime**:
+when a conditional rule (`visibleWhen` / `readonlyWhen` / `requiredWhen`,
+view-level `visibleOn`, per-option `visibleWhen`, list conditional
+formatting) fails to evaluate, the renderer applies the rule's safe default
+(fail-open — a broken predicate never hides a field or blocks a submit) and
+logs **one `console.warn` per predicate** with the predicate source, the
+engine's failure reason, and the field it was attached to. A rule that never
+fires while its field stays visible is the classic symptom — open the
+browser console and the broken predicate identifies itself (most often a
+bare field name where `record.<field>` was meant).
+
 ### 4. Governance overview page
 
 `/apps/<app>/metadata/_diagnostics` — a single sortable table of every

--- a/docs/adr/0036-field-conditional-rules.md
+++ b/docs/adr/0036-field-conditional-rules.md
@@ -103,6 +103,22 @@ merged record.
 visibility (don't hide content on error), `false` for required/readonly (don't
 block submit or lock a field on error) — the same posture as the server.
 
+**Amendment (objectstack#5149, appeal 2).** Fail-open is now **loud**: a
+predicate that cannot be evaluated (parse error, unbound identifier, engine
+fault) logs one `console.warn` per predicate text — with the source, the
+engine's failure reason, and the caller's locator (`visibleWhen of field
+'amount'`) when the call site provides one — and then still returns the
+fallback. Previously the failure was swallowed, which made a broken predicate
+indistinguishable from an absent one (the exact bug class objectstack#5149
+documents: two live inert predicates in one app, one shipped for months).
+Callers that deliberately probe for faults by evaluating twice with both
+fallbacks (`evalRowPredicate`'s fail-closed path, `ExpressionEvaluator`'s
+`throwOnError`) pass `warn: false` and surface their own diagnostic, so each
+broken predicate produces exactly one warning. The fail-open *default itself*
+is unchanged — flipping it is objectstack#5149 appeal 1, deliberately left
+undecided; this diagnostic exists partly to measure how often real apps hit
+the failure path before that call is made.
+
 ## Showcase
 
 `showcase_invoice` demonstrates all three:

--- a/packages/app-shell/src/views/ScreenView.tsx
+++ b/packages/app-shell/src/views/ScreenView.tsx
@@ -95,7 +95,11 @@ export function visibleScreenFields(
 ): ScreenFieldSpec[] {
   const scope = screenPredicateScope(screen, values);
   return screenFields(screen).filter((f) =>
-    f.visibleWhen ? evalFieldPredicate(f.visibleWhen, scope, true, undefined, scope) : true,
+    f.visibleWhen
+      ? evalFieldPredicate(f.visibleWhen, scope, true, undefined, scope, {
+          context: `visibleWhen of screen field '${f.name}'`,
+        })
+      : true,
   );
 }
 

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -668,12 +668,17 @@ ComponentRegistry.register('form',
           },
           ruleRecord,
           { required: !!f.required, readonly: (f as any).readonly === true },
+          undefined,
+          undefined,
+          `field '${name}'`,
         );
         // View-level FormField.visibleOn hides the field the same way a
         // field-level visibleWhen does (#2212) — fold it into the verdict.
         const viewVisible =
           (f as any).visibleOn == null ||
-          evalFieldPredicate((f as any).visibleOn, ruleRecord, true);
+          evalFieldPredicate((f as any).visibleOn, ruleRecord, true, undefined, undefined, {
+            context: `visibleOn of field '${name}'`,
+          });
         // A hidden field shows no errors at all; an un-required field clears
         // only its *required* error (keep legitimate format/min/etc. errors).
         const errType = (errs[name] as { type?: string } | undefined)?.type;
@@ -1220,7 +1225,12 @@ ComponentRegistry.register('form',
       // the server. Fail-open (a broken predicate shows the field),
       // matching the CEL rules below.
       const legacyConditionCel = legacyConditionToCel(condition);
-      if (legacyConditionCel && !evalFieldPredicate(legacyConditionCel, ruleRecord, true)) {
+      if (
+        legacyConditionCel &&
+        !evalFieldPredicate(legacyConditionCel, ruleRecord, true, undefined, undefined, {
+          context: `condition of field '${name}'`,
+        })
+      ) {
         return null;
       }
 
@@ -1233,6 +1243,9 @@ ComponentRegistry.register('form',
         { visibleWhen, readonlyWhen, requiredWhen },
         ruleRecord,
         { required: staticRequired, readonly: staticReadonly === true },
+        undefined,
+        undefined,
+        `field '${name}'`,
       );
       if (!ruleState.visible) return null;
 
@@ -1240,8 +1253,14 @@ ComponentRegistry.register('form',
       // authored on the form view (not the object field). Same
       // canonical CEL engine and record scope as visibleWhen; both
       // the bare-string and `{ dialect, source }` wire shapes are
-      // accepted, and a broken predicate fails open (#2212).
-      if (visibleOn != null && !evalFieldPredicate(visibleOn, ruleRecord, true)) {
+      // accepted, and a broken predicate fails open — loudly since
+      // #5149 (#2212).
+      if (
+        visibleOn != null &&
+        !evalFieldPredicate(visibleOn, ruleRecord, true, undefined, undefined, {
+          context: `visibleOn of field '${name}'`,
+        })
+      ) {
         return null;
       }
       const required = ruleState.required;

--- a/packages/core/src/evaluator/ExpressionEvaluator.ts
+++ b/packages/core/src/evaluator/ExpressionEvaluator.ts
@@ -293,8 +293,10 @@ export class ExpressionEvaluator {
     // Fail-closed callers need to tell a genuine `false` from a fault. The
     // canonical helper fails soft to the fallback, so a value that tracks the
     // fallback in BOTH runs means the predicate faulted — then we throw.
-    const asTrue = evalFieldPredicate(source, record, true, undefined, bag);
-    const asFalse = evalFieldPredicate(source, record, false, undefined, bag);
+    // `warn: false`: the throw below IS this path's diagnostic; without it one
+    // broken predicate would log AND throw (#5149).
+    const asTrue = evalFieldPredicate(source, record, true, undefined, bag, { warn: false });
+    const asFalse = evalFieldPredicate(source, record, false, undefined, bag, { warn: false });
     if (asTrue !== asFalse) {
       throw new Error(`CEL predicate failed to evaluate: ${source}`);
     }

--- a/packages/core/src/evaluator/__tests__/fieldRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/fieldRules.test.ts
@@ -6,8 +6,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ExpressionEngine } from '@objectstack/formula';
 import { evalFieldPredicate, resolveFieldRuleState } from '../fieldRules';
+
+/** Run `fn` with `console.warn` muted (the loud fail-open of #5149 is pinned
+ * in its own describe below; these legacy value-contract tests only care about
+ * the returned verdicts). */
+function muted<T>(fn: () => T): T {
+  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    return fn();
+  } finally {
+    spy.mockRestore();
+  }
+}
 
 describe('evalFieldPredicate', () => {
   it('evaluates a bare-string CEL predicate as TRUE', () => {
@@ -32,8 +45,10 @@ describe('evalFieldPredicate', () => {
 
   it('fails open to the fallback on a broken predicate', () => {
     // Unparseable / type-faulting CEL must not throw — it returns fallback.
-    expect(evalFieldPredicate('record.status ===', { status: 'paid' }, false)).toBe(false);
-    expect(evalFieldPredicate('record.status ===', { status: 'paid' }, true)).toBe(true);
+    muted(() => {
+      expect(evalFieldPredicate('record.status ===', { status: 'paid' }, false)).toBe(false);
+      expect(evalFieldPredicate('record.status ===', { status: 'paid' }, true)).toBe(true);
+    });
   });
 
   it('fails open when a referenced field is MISSING from the record (CEL "No such key")', () => {
@@ -41,8 +56,10 @@ describe('evalFieldPredicate', () => {
     // predicate referencing an absent field must fall back, not surface the
     // fault — the renderer seeds declared fields to null to avoid this, but the
     // helper must be safe on its own.
-    expect(evalFieldPredicate("record.status == 'paid'", {}, true)).toBe(true);
-    expect(evalFieldPredicate("record.status == 'paid'", {}, false)).toBe(false);
+    muted(() => {
+      expect(evalFieldPredicate("record.status == 'paid'", {}, true)).toBe(true);
+      expect(evalFieldPredicate("record.status == 'paid'", {}, false)).toBe(false);
+    });
     // Present-but-null compares cleanly to a real boolean (no fault).
     expect(evalFieldPredicate("record.status == 'paid'", { status: null }, true)).toBe(false);
   });
@@ -60,7 +77,9 @@ describe('evalFieldPredicate', () => {
       }),
     ).toBe(true);
     // Without the scope, `parent` is unbound → fault → fallback.
-    expect(evalFieldPredicate("parent.status == 'paid'", { quantity: 2 }, false)).toBe(false);
+    muted(() => {
+      expect(evalFieldPredicate("parent.status == 'paid'", { quantity: 2 }, false)).toBe(false);
+    });
   });
 
   it('exposes previous.* for transition predicates', () => {
@@ -130,7 +149,97 @@ describe('resolveFieldRuleState', () => {
   });
 
   it('fails open: broken visibleWhen keeps the field visible', () => {
-    const s = resolveFieldRuleState({ visibleWhen: 'record.status ===' }, { status: 'x' }, {});
+    const s = muted(() => resolveFieldRuleState({ visibleWhen: 'record.status ===' }, { status: 'x' }, {}));
     expect(s.visible).toBe(true);
+  });
+});
+
+describe('failure diagnostics — loud fail-open (objectstack#5149, appeal 2)', () => {
+  // Every test uses a UNIQUE predicate text: the once-per-predicate dedupe is
+  // module-level on purpose (it must survive re-renders), so a text reused
+  // across tests would have spent its one warning in the earlier test.
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => warn.mockRestore());
+
+  it('warns exactly once for an unbound identifier — with source text, reason, and the applied default', () => {
+    const pred = "totally_unbound_5149 == 'x'";
+    expect(evalFieldPredicate(pred, { a: 1 }, true)).toBe(true);
+    // Re-render / re-evaluation of the same predicate text: no second warning.
+    expect(evalFieldPredicate(pred, { a: 1 }, true)).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = String(warn.mock.calls[0][0]);
+    expect(msg).toContain('failed to evaluate');
+    expect(msg).toContain(JSON.stringify(pred)); // the predicate source text
+    expect(msg).toContain('Reason: ['); // the engine's failure kind + message
+    expect(msg).toContain('(true)'); // which safe default was applied
+  });
+
+  it('warns once for a syntax error, and the returned value still tracks the fallback', () => {
+    const pred = 'record.amount_5149 >< 3';
+    expect(evalFieldPredicate(pred, { amount_5149: 1 }, true)).toBe(true);
+    expect(evalFieldPredicate(pred, { amount_5149: 1 }, false)).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain(JSON.stringify(pred));
+  });
+
+  it('does not warn for a healthy, absent, or blank predicate', () => {
+    expect(evalFieldPredicate("record.ok_5149 == 'y'", { ok_5149: 'y' }, false)).toBe(true);
+    expect(evalFieldPredicate(undefined, {}, true)).toBe(true);
+    expect(evalFieldPredicate(null, {}, false)).toBe(false);
+    expect(evalFieldPredicate('   ', {}, true)).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a genuine FALSE verdict is not a failure and does not warn', () => {
+    expect(evalFieldPredicate("record.ok2_5149 == 'y'", { ok2_5149: 'n' }, true)).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('`warn: false` suppresses the diagnostic for fault-probing callers', () => {
+    const pred = "probe_only_5149 == 'x'";
+    expect(evalFieldPredicate(pred, {}, true, undefined, undefined, { warn: false })).toBe(true);
+    expect(evalFieldPredicate(pred, {}, false, undefined, undefined, { warn: false })).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('includes the caller-provided context locator', () => {
+    const pred = "ctx_unbound_5149 == 'x'";
+    evalFieldPredicate(pred, {}, true, undefined, undefined, {
+      context: "visibleOn of field 'amount'",
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain("(visibleOn of field 'amount')");
+  });
+
+  it('resolveFieldRuleState reports the rule kind and the field locator', () => {
+    const s = resolveFieldRuleState(
+      { visibleWhen: 'rule_ctx_5149 ===' },
+      { status: 'x' },
+      {},
+      undefined,
+      undefined,
+      "field 'amount'",
+    );
+    // Fail-open default unchanged — #5149 appeal 1 is deliberately NOT here.
+    expect(s.visible).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain("(visibleWhen of field 'amount')");
+  });
+
+  it('warns once when the engine THROWS (defensive catch), tagging the reason as [throw]', () => {
+    const spy = vi.spyOn(ExpressionEngine, 'evaluate').mockImplementation(() => {
+      throw new Error('engine exploded');
+    });
+    try {
+      expect(evalFieldPredicate('record.throw_5149 == 1', { throw_5149: 1 }, true)).toBe(true);
+      expect(evalFieldPredicate('record.throw_5149 == 1', { throw_5149: 1 }, true)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('[throw] engine exploded');
   });
 });

--- a/packages/core/src/evaluator/__tests__/listConditional.test.ts
+++ b/packages/core/src/evaluator/__tests__/listConditional.test.ts
@@ -66,9 +66,18 @@ describe('evalRowPredicate', () => {
     expect(evalRowPredicate('   ', { a: 1 }, { fallback: true })).toBe(true);
   });
 
-  it('fails to the fallback on a broken predicate', () => {
-    expect(evalRowPredicate('record.status ==', { status: 'x' }, { fallback: false })).toBe(false);
-    expect(evalRowPredicate('record.status ==', { status: 'x' }, { fallback: true })).toBe(true);
+  it('fails to the fallback on a broken predicate — loudly, once (#5149)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(evalRowPredicate('record.status ==', { status: 'x' }, { fallback: false })).toBe(false);
+      expect(evalRowPredicate('record.status ==', { status: 'x' }, { fallback: true })).toBe(true);
+      // The single-eval fast path is no longer silent: the canonical helper
+      // itself warned — once, despite two evaluations of the same text.
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain('failed to evaluate');
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   describe('legacy-dialect routing', () => {
@@ -217,11 +226,20 @@ describe('resolveConditionalFormatting', () => {
     ).toEqual({ backgroundColor: 'override', fontWeight: 'bold', color: 'blue' });
   });
 
-  it('a rule whose field is missing from the record fails soft (no style)', () => {
-    expect(
-      resolveConditionalFormatting({ other: 1 }, [
-        { field: 'status', operator: 'equals', value: 'active', backgroundColor: 'x' },
-      ]),
-    ).toEqual({});
+  it('a rule whose field is missing from the record fails soft (no style) — warning once with the rule locator (#5149)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(
+        resolveConditionalFormatting({ other: 1 }, [
+          { field: 'status', operator: 'equals', value: 'active', backgroundColor: 'x' },
+        ]),
+      ).toEqual({});
+      // The formatting fast path threads its label into the canonical
+      // helper's one-time warning, so the broken rule is locatable.
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain('(conditionalFormatting[0])');
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/core/src/evaluator/fieldRules.ts
+++ b/packages/core/src/evaluator/fieldRules.ts
@@ -25,6 +25,17 @@
  * block submit) and *fail-open* for readonly (a broken predicate leaves the
  * field editable) — matching the server, which logs and allows the change
  * through.
+ *
+ * Fail-open is **loud**, not silent (objectstack#5149): a predicate that
+ * cannot be evaluated — parse error, unbound identifier, engine fault — logs
+ * one `console.warn` per predicate text with the source and the failure
+ * reason, then still returns the caller's fallback. Without the warning a
+ * broken predicate is indistinguishable from an absent one, so
+ * conditional-visibility bugs survive inspection indefinitely. This is the
+ * client half of the server's "log and allow" convention (`readonlyWhen for
+ * 'x' failed to evaluate — change allowed through`). The *default* stays
+ * fail-open on purpose — flipping it is a shipped-behavior change tracked
+ * separately in objectstack#5149 (appeal 1, undecided).
  */
 import { ExpressionEngine } from '@objectstack/formula';
 import type { Expression } from '@objectstack/spec';
@@ -36,6 +47,50 @@ export type FieldRulePredicate = string | { dialect?: string; source: string };
 function toExpression(pred: FieldRulePredicate): Expression {
   if (typeof pred === 'string') return { dialect: 'cel', source: pred };
   return { dialect: (pred.dialect ?? 'cel') as Expression['dialect'], source: pred.source };
+}
+
+/** Diagnostic options for {@link evalFieldPredicate} evaluation failures. */
+export interface FieldPredicateDiagnostic {
+  /**
+   * Human-readable locator included in the one-time failure warning — e.g.
+   * `"visibleWhen of field 'amount'"`. Pass whatever the call site knows; the
+   * predicate source text and failure reason are always included.
+   */
+  context?: string;
+  /**
+   * Set `false` when the caller deliberately probes for faults (evaluating
+   * twice with both fallbacks) and surfaces its own diagnostic — prevents two
+   * warnings for one broken predicate. Defaults to `true`.
+   */
+  warn?: boolean;
+}
+
+const warnedPredicates = new Set<string>();
+
+/**
+ * One-time warning for a predicate that could not be evaluated. Deduped per
+ * predicate TEXT (dialect + source): a broken predicate is re-evaluated on
+ * every render/keystroke, and the point is one loud line, not a scrolling
+ * wall. The dedupe key is JSON-encoded — never a control-character separator
+ * (objectstack#5450 made a sibling of this file binary to grep that way).
+ */
+function warnPredicateFailure(
+  expr: Expression,
+  fallback: boolean,
+  reason: string,
+  context?: string,
+): void {
+  const key = JSON.stringify([expr.dialect, expr.source]);
+  if (warnedPredicates.has(key)) return;
+  warnedPredicates.add(key);
+  console.warn(
+    '[object-ui] A conditional predicate failed to evaluate' +
+      (context ? ` (${context})` : '') +
+      ` and was treated as its safe default (${String(fallback)}): ` +
+      JSON.stringify(expr.source) +
+      `. Reason: ${reason}. ` +
+      "Values are bound under 'record.' (e.g. record.status) — check the field names and CEL syntax.",
+  );
 }
 
 /**
@@ -52,6 +107,10 @@ function toExpression(pred: FieldRulePredicate): Expression {
  *                  e.g. `{ parent }` so an inline line-item cell can reference
  *                  its header (`parent.status == 'paid'`) as well as its own
  *                  row (`record.quantity`). Bound via the engine's `extra`.
+ * @param diagnostic  Failure-warning options: a `context` locator for the
+ *                  one-time warning, and `warn: false` for callers that probe
+ *                  for faults and report them themselves. The returned value
+ *                  is unaffected either way.
  */
 export function evalFieldPredicate(
   pred: FieldRulePredicate | undefined | null,
@@ -59,17 +118,41 @@ export function evalFieldPredicate(
   fallback: boolean,
   previous?: Record<string, unknown>,
   scope?: Record<string, unknown>,
+  diagnostic?: FieldPredicateDiagnostic,
 ): boolean {
   if (pred == null || (typeof pred === 'string' && !pred.trim())) return fallback;
+  const expr = toExpression(pred);
   try {
-    const res = ExpressionEngine.evaluate<boolean>(toExpression(pred), {
+    const res = ExpressionEngine.evaluate<boolean>(expr, {
       record,
       previous,
       ...(scope ? { extra: scope } : {}),
     });
-    if (!res.ok) return fallback;
+    if (!res.ok) {
+      // Parse error, type error, unbound identifier, engine fault … — every
+      // not-ok verdict resolves to the fallback, but never silently (#5149).
+      if (diagnostic?.warn !== false) {
+        warnPredicateFailure(
+          expr,
+          fallback,
+          `[${res.error.kind}] ${res.error.message}`,
+          diagnostic?.context,
+        );
+      }
+      return fallback;
+    }
     return res.value === true;
-  } catch {
+  } catch (err) {
+    // The engine contract is "never throws"; this guard is for anything that
+    // slips past it. Same loud fail-open as the not-ok branch.
+    if (diagnostic?.warn !== false) {
+      warnPredicateFailure(
+        expr,
+        fallback,
+        `[throw] ${err instanceof Error ? err.message : String(err)}`,
+        diagnostic?.context,
+      );
+    }
     return fallback;
   }
 }
@@ -80,6 +163,11 @@ export function evalFieldPredicate(
  * present, *overrides* the static flag. A static `true` is never weakened by a
  * `false` predicate result for required/readonly — but `visibleWhen` is
  * authoritative when present (so a field can be conditionally shown/hidden).
+ *
+ * @param fieldContext  Optional locator for failure warnings — e.g.
+ *                      `"field 'amount'"`. The warning then reads
+ *                      `visibleWhen of field 'amount' …`; without it, the rule
+ *                      kind alone is reported.
  */
 export function resolveFieldRuleState(
   rules: {
@@ -91,22 +179,27 @@ export function resolveFieldRuleState(
   statics: { required?: boolean; readonly?: boolean },
   previous?: Record<string, unknown>,
   scope?: Record<string, unknown>,
+  fieldContext?: string,
 ): { visible: boolean; readonly: boolean; required: boolean } {
+  const diag = (rule: string): FieldPredicateDiagnostic => ({
+    context: fieldContext ? `${rule} of ${fieldContext}` : rule,
+  });
+
   const visible =
     rules.visibleWhen != null
-      ? evalFieldPredicate(rules.visibleWhen, record, true, previous, scope)
+      ? evalFieldPredicate(rules.visibleWhen, record, true, previous, scope, diag('visibleWhen'))
       : true;
 
   const readonly =
     statics.readonly === true ||
     (rules.readonlyWhen != null
-      ? evalFieldPredicate(rules.readonlyWhen, record, false, previous, scope)
+      ? evalFieldPredicate(rules.readonlyWhen, record, false, previous, scope, diag('readonlyWhen'))
       : false);
 
   const required =
     statics.required === true ||
     (rules.requiredWhen != null
-      ? evalFieldPredicate(rules.requiredWhen, record, false, previous, scope)
+      ? evalFieldPredicate(rules.requiredWhen, record, false, previous, scope, diag('requiredWhen'))
       : false);
 
   return { visible, readonly, required };

--- a/packages/core/src/evaluator/listConditional.ts
+++ b/packages/core/src/evaluator/listConditional.ts
@@ -108,8 +108,11 @@ function evalCel(
   // fallback for BOTH `true` and `false`, the predicate faulted (a genuine
   // verdict is independent of the fallback). This reuses the canonical helper
   // verbatim — no second engine — so CEL semantics never drift from B2.
-  const asTrue = evalFieldPredicate(pred, record, true, undefined, scope);
-  const asFalse = evalFieldPredicate(pred, record, false, undefined, scope);
+  // `warn: false`: this caller reports the fault itself (the labelled
+  // `warnEvalError` in `evalRowPredicate`) — one warning per broken predicate,
+  // not two (#5149).
+  const asTrue = evalFieldPredicate(pred, record, true, undefined, scope, { warn: false });
+  const asFalse = evalFieldPredicate(pred, record, false, undefined, scope, { warn: false });
   if (asTrue !== asFalse) return { ok: false, value: false };
   return { ok: true, value: asTrue };
 }
@@ -166,10 +169,13 @@ export function evalRowPredicate(
   }
 
   // CEL path. The fault-aware `evalCel` costs two evaluations (to tell a fault
-  // from a genuine `false`), so only pay it when a caller wants the warning —
-  // the formatting hot path takes the single-eval fast route.
+  // from a genuine `false`), so only pay it when a caller wants the labelled
+  // fail-closed warning — the formatting hot path takes the single-eval fast
+  // route. Since #5149 the fast route is no longer silent either: the
+  // canonical helper itself warns once per broken predicate (with `opts.label`
+  // as the locator when given).
   if (!opts.warnOnError) {
-    return evalFieldPredicate(pred, rowObj, fallback, undefined, scope);
+    return evalFieldPredicate(pred, rowObj, fallback, undefined, scope, { context: opts.label });
   }
   const verdict = evalCel(pred, rowObj, scope);
   if (!verdict.ok) {

--- a/packages/core/src/evaluator/optionRules.ts
+++ b/packages/core/src/evaluator/optionRules.ts
@@ -98,7 +98,11 @@ export function resolveVisibleOptions<T extends OptionLike>(
 ): T[] {
   if (!options || options.length === 0) return [];
   return options.filter((o) =>
-    o?.visibleWhen == null ? true : evalFieldPredicate(o.visibleWhen, record, true, undefined, scope),
+    o?.visibleWhen == null
+      ? true
+      : evalFieldPredicate(o.visibleWhen, record, true, undefined, scope, {
+          context: `visibleWhen of option '${String(o.value)}'`,
+        }),
   );
 }
 

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -354,6 +354,9 @@ export const WizardForm: React.FC<WizardFormProps> = ({
             },
             record,
             { required: !!field.required, readonly: (field as any).readonly === true },
+            undefined,
+            undefined,
+            `field '${name}'`,
           );
           // View-level FormField.visibleOn hides the field the same way a
           // field-level visibleWhen does — fold it into the verdict exactly
@@ -362,7 +365,9 @@ export const WizardForm: React.FC<WizardFormProps> = ({
           // receives the ADR-0089 canonical view-level `visibleWhen` spelling.
           const viewVisible =
             (field as any).visibleOn == null ||
-            evalFieldPredicate((field as any).visibleOn, record, true);
+            evalFieldPredicate((field as any).visibleOn, record, true, undefined, undefined, {
+              context: `visibleOn of field '${name}'`,
+            });
           // A hidden or read-only field is not the user's to fill in.
           if (!viewVisible || !state.visible || state.readonly || !state.required) continue;
           if (!isEmptyValue(record[name])) continue;


### PR DESCRIPTION
Refs objectstack-ai/objectstack#5149(⛔ 非 Fixes——诉求 1 仍在决策箱,本 PR 不关闭该 issue)

按维护者半裁(2026-08-06 10:39Z)落地已放行半边:诉求 2(求值失败去静默)+ 诉求 4(`record.` 绑定文档验收)。

## 改了什么(诉求 2)

issue 摘的混淆产物 `function A(e,t,n,r,i)` 即 `@object-ui/core` 的 `evalFieldPredicate`(`packages/core/src/evaluator/fieldRules.ts`)。三种失败形状——表达式 parse 失败、`ExpressionEngine.evaluate` 返回 not-ok、防御性 catch 捕获 throw——现在都:

- `console.warn` 恰好一次(模块级按「谓词文本」去重,dialect+source 为键,JSON 编码——不用控制字符分隔,objectstack#5450 教训),内容含:谓词源文本、引擎失败原因(`[kind] message`)、调用点提供的定位信息(如 `visibleWhen of field 'amount'`)、实际采用的默认值;
- **返回值一丝不变**:仍返回调用方传入的默认(可见性 true / readonly-required false)。fail-open 默认值本身 ⛔ 未动——那是诉求 1,维护者单独拍板;本诊断落地正是给 1 的拍板提供命中面数据。

定位信息线程化(有多少上下文给多少):

- `resolveFieldRuleState` 新增可选 `fieldContext`,warn 报 `visibleWhen/readonlyWhen/requiredWhen of field 'x'`;
- form.tsx 渲染门与 error-clearing effect、WizardForm 必填门、ScreenView 屏幕字段、optionRules 选项级、listConditional 格式化 fast path(带 `conditionalFormatting[i]` 标签)全部传入定位;
- 故障探测型调用方(`evalRowPredicate` fail-closed 路径、`ExpressionEvaluator.throwOnError`——两处都是双求值探测)传 `warn: false`,保留自己原有的单条诊断:每个坏谓词全局恰好一条 warn,listConditional 既有计数断言不破。

措辞对齐服务端「log and allow」惯例(`readonlyWhen for 'x' failed to evaluate — change allowed through`)与仓内既有 `warnEvalError` 风格(`[object-ui]` 前缀、Set 去重、`JSON.stringify` 源文本)。文档同步:ADR-0036 增补 Amendment、`content/docs/guide/metadata-diagnostics.md` 增补运行时诊断段。

## 测试(全部实跑)

- 新增 8 条 pin(fieldRules.test.ts「failure diagnostics」describe):坏谓词(unbound identifier / 语法错误)warn 恰好一次且含源文本+原因+默认值;同文本重复求值不再 warn;好/空/null 谓词零 warn;真 FALSE 不 warn;`warn: false` 抑制;context 定位;`resolveFieldRuleState` 规则种类+字段定位;引擎 throw 形状(`[throw]`);
- listConditional 两条既有测试升级为断言新行为(fast path 一条 warn、格式化规则带定位),warnOnError 探测路径既有计数断言原样通过;
- 逆向验证(先定方向再跑):仅回退 fieldRules.ts 源码改动、保留测试 ⇒ 预测恰好 7 条 warn 断言变红、39 条值契约保持绿——实测严丝合缝(5 红 fieldRules + 2 红 listConditional,39 绿),已恢复;
- `pnpm exec vitest run packages/core/ packages/components/ packages/plugin-form/` ⇒ 187 files / 2418 tests 全绿;
- `pnpm exec vitest run packages/app-shell/src/views/` ⇒ 180 files / 1585 tests 全绿(1 skipped 既有);
- `turbo run type-check lint`(core / components / plugin-form / app-shell)⇒ 36/36 任务成功;
- `node scripts/check-control-bytes.mjs` ⇒ OK。

## 诉求 4 验收(文档半边——判定:已存在,零改动)

裁决指向的 describe 在 objectstack 仓 `packages/spec/src/ui/view.zod.ts`(origin/main)已完整:

- **:1407-1413**(JSDoc)与 **:1414**(describe):明确「Root: `record`+`current_user` (runtime forms) or `data` (metadata forms)」,示例即 `record.` 前缀写法(`record.priority == 'urgent'`);
- **:1505-1508**:FormSection 级同样声明;
- 无任何诱导裸标识符的示例(Repro 1 根源)。按最小改动原则不另开 objectstack PR。

## 范围红线(照裁决)

- ⛔ fail-open 默认值未动(诉求 1 在决策箱,求值失败仍返回既有默认);
- ⛔ 无构建期 lint(诉求 3 已另立 objectstack#6128 归 devx);
- ⛔ 未触碰 objectstack 仓 packages/console/dist(本 PR 全部在 objectui 源码)。

## Changeset

`.changeset/predicate-eval-failures-warn-once.md`——四包 patch(行为不变、纯诊断增强)。

---
_Generated by [Claude Code](https://claude.ai/code/session_015a5qkLzpGXhLL2F5gvJ7dD)_