### PR TITLE
docs(guide): 删掉 console-architecture 里不存在的 MSW Mock Mode,并按包归属校正组件

### DIFF
--- a/content/docs/guide/console-architecture.md
+++ b/content/docs/guide/console-architecture.md
@@ -5,7 +5,14 @@ description: Internal architecture of the ObjectStack Console — data flow, rou
 
 # Console Architecture
 
-This document describes the internal architecture of the Console app (`apps/console`).
+This document describes the internal architecture of the Console SPA.
+
+`apps/console` is a thin host: it owns the Vite build, the outermost route tree, and plugin
+registration. Almost everything named below is a **component exported by a package**, not a file
+under `apps/console` — the shell (providers, layout, object and record views) ships from
+`@object-ui/app-shell`, view rendering from `@object-ui/plugin-view`, and the app wizard from
+`@object-ui/plugin-designer`. Packages are named where it matters; import from the package, never
+from a path.
 
 ## Data Flow
 
@@ -14,7 +21,7 @@ This document describes the internal architecture of the Console app (`apps/cons
 │  objectstack.config.ts                                  │
 │  (defineStack → apps, objects, views)                   │
 └────────────────────┬────────────────────────────────────┘
-                     │ MSW / Real Server
+                     │ ObjectStack server  (HTTP, VITE_SERVER_URL)
                      ▼
 ┌─────────────────────────────────────────────────────────┐
 │  ObjectStackAdapter  (@object-ui/data-objectstack)      │
@@ -25,20 +32,20 @@ This document describes the internal architecture of the Console app (`apps/cons
                      │ DataSource interface
                      ▼
 ┌─────────────────────────────────────────────────────────┐
-│  SchemaRendererProvider  (@object-ui/react)              │
+│  SchemaRendererProvider  (@object-ui/react)             │
 │  • provides dataSource + registry to all children       │
 └────────────────────┬────────────────────────────────────┘
                      │ React Context
                      ▼
 ┌─────────────────────────────────────────────────────────┐
-│  App.tsx                                                │
+│  Console shell  (@object-ui/app-shell)                  │
 │  ├── ExpressionProvider  (user, app, evaluator)         │
 │  ├── ConsoleLayout                                      │
 │  │   ├── AppShell (@object-ui/layout)                   │
 │  │   │   └── useAppShellBranding (CSS vars)             │
-│  │   ├── AppSidebar (navigation tree)                   │
+│  │   ├── sidebar nav (app switcher + nav tree)          │
 │  │   └── AppHeader (breadcrumbs, status)                │
-│  └── Routes                                             │
+│  └── Routes (mounted by apps/console at /apps/:appName) │
 │      ├── /apps/:appName/:objectName  → ObjectView       │
 │      ├── /apps/:appName/:objectName/record/:id → Detail │
 │      └── /apps/:appName  → Home Page                    │
@@ -47,7 +54,12 @@ This document describes the internal architecture of the Console app (`apps/cons
 
 ## Routing
 
-The console uses React Router DOM v7 with a simple flat route structure:
+Routing is React Router DOM v7. `apps/console` mounts the per-app subtree at
+`/apps/:appName/*`; the routes below are declared inside it by the console shell
+(`@object-ui/app-shell`). Every component in the table is exported by `@object-ui/app-shell`,
+except `CreateAppPage` / `EditAppPage`, which are lazy-loaded from `@object-ui/plugin-designer`.
+These are the object-facing routes — the shell declares more (record create/edit, the metadata
+admin subtree), and `apps/console` adds the unauthenticated auth surfaces outside this subtree.
 
 | Route Pattern | Component | Purpose |
 |---------------|-----------|---------|
@@ -73,7 +85,7 @@ Navigation items can be conditionally hidden using expressions:
 }
 ```
 
-The `ExpressionProvider` wraps the layout and provides an `ExpressionEvaluator` that resolves `${}` templates against context variables (`user`, `app`, `data`).
+`ExpressionProvider` (`@object-ui/app-shell`) wraps the layout and provides an `ExpressionEvaluator` that resolves `${}` templates against context variables (`user`, `app`, `data`).
 
 ### 2. Action System
 
@@ -98,21 +110,24 @@ The `ActionRunner` supports:
 
 ### 3. Plugin ObjectView Delegation
 
-The console's `ObjectView` is a **thin wrapper** around `@object-ui/plugin-view`'s `ObjectView`:
+The shell's `ObjectView` — the one exported by `@object-ui/app-shell` and bound to the routes
+above — is a **thin wrapper** around `@object-ui/plugin-view`'s `ObjectView`:
 
 - Resolves views from the object definition's `list_views`
 - Passes a `renderListView` callback for multi-view rendering (kanban, calendar, chart)
-- Handles console-specific concerns: URL routing, MetadataInspector, record detail Sheet
+- Handles shell-level concerns: URL routing, MetadataInspector, record detail overlay
 
 ### 4. App Creation & Editing
 
-The console integrates the `AppCreationWizard` from `@object-ui/plugin-designer` for creating and editing apps:
+App creation and editing are owned end to end by `@object-ui/plugin-designer`: it exports both
+route pages and the `AppCreationWizard` they render. The console shell only lazy-loads them onto
+routes.
 
 - **Create App** — `CreateAppPage` at `/apps/:appName/create-app`. Passes metadata objects as `availableObjects`, handles `onComplete` (converts draft via `wizardDraftToAppSchema()`, navigates to new app), `onCancel` (navigate back), and `onSaveDraft` (localStorage persistence).
 - **Edit App** — `EditAppPage` at `/apps/:appName/edit-app/:editAppName`. Loads existing app config as `initialDraft` and updates on completion.
 
 **Entry Points:**
-- AppSidebar app switcher → "Add App" / "Edit App" buttons
+- Sidebar app switcher → "Add App" / "Edit App" buttons
 - CommandPalette (⌘+K) → "Create New App" command in Actions group
 - Empty state CTA → "Create Your First App" button when no apps are configured
 
@@ -131,13 +146,12 @@ Per-app branding is applied via `AppShell`'s `branding` prop:
 
 This sets CSS custom properties (`--brand-primary`, `--brand-primary-hsl`, etc.) on the document root.
 
-## MSW Mock Mode
+## Development Mode
 
-In development, the console uses MSW (Mock Service Worker) to simulate an ObjectStack backend:
+There is **no bundled mock backend** — offline development is not a thing here. In dev exactly as
+in production, `ObjectStackAdapter` talks over HTTP to a live ObjectStack server at
+`VITE_SERVER_URL`, and everything above the adapter in the data flow depends on that call
+succeeding: no server, no discovery, no apps in the sidebar.
 
-1. `objectstack.config.ts` defines apps and objects via `@objectstack/spec`
-2. `@objectstack/runtime` boots an `ObjectKernel` with `MSWPlugin`
-3. MSW intercepts `/api/v1/*` requests and serves in-memory data
-4. The `ObjectStackAdapter` connects to this mock server transparently
-
-This allows full offline development without a real backend.
+See [Console App → Quick Start](/docs/guide/console#quick-start) for the dev server port, the
+default `VITE_SERVER_URL`, and how to point the console at a different backend.


### PR DESCRIPTION
Fixes #3540

只动一个文件:`content/docs/guide/console-architecture.md`。

## 一、`MSW Mock Mode` 整节删除(前提已在 origin/main `a2c8f2a29` 上重新实测)

| 实测项 | 结果 |
|---|---|
| `git grep -niE "mswplugin\|msw" -- apps/console/` | 源码与 `package.json` **零命中**(只剩 `.gitignore` 的一行注释、`CHANGELOG.md` 的历史条目,以及不在本单面内的 `apps/console/docs/deployment.md`) |
| `apps/console/src/mocks/` | 目录不存在 |
| `2b7435b76` | `refactor: remove MSW mock server setup and related configurations` —— 确系那次删除 |

即整节属于「文档描述不存在的能力」,且与 #3532 刚改写的 `console.md:18`("There is no bundled mock backend")当场矛盾 —— 而 `console.md` 的 See Also 正把读者往这一页送。与 #3532 同口径:整节删除。

顺带澄清一个容易误判的信号:`msw` 仍是 `packages/plugin-form` / `packages/plugin-grid` 的 devDependency(单测里拦请求用),与「console 自带 mock 后端」无关,所以 `pnpm install` 输出里出现的 `msw@2.15.0` 不构成反证。

**替代内容**(按单里的要求,一句话 + 指路,不重复 console.md):新开一节 `## Development Mode`,说明没有内置 mock 后端、dev 与生产一样由 `ObjectStackAdapter` 经 `VITE_SERVER_URL` 连活服务器、服务器不在则 discovery 失败因而侧边栏空,然后链到 `console.md` 的 Quick Start。

数据流图里同源的边标注 `MSW / Real Server` 一并改成真实的 `ObjectStack server  (HTTP, VITE_SERVER_URL)`。

## 二、组件归属按 role/package 口径校正(逐项在 origin/main 上重新 `git grep -l`,未继承 #3539 的表)

| 组件 | 实测导出方 |
|---|---|
| `ExpressionProvider` | `@object-ui/app-shell` |
| `ConsoleLayout` / `AppSidebar` / `AppHeader` | `@object-ui/app-shell` |
| `ObjectView` / `RecordDetailView` / `ObjectDataPage` | `@object-ui/app-shell` |
| `CreateAppPage` / `EditAppPage` / `AppCreationWizard` | `@object-ui/plugin-designer` |
| `AppShell` / `useAppShellBranding` | `@object-ui/layout` —— 图里原本的标注**是对的**,保留未动 |

⛔ 按单里的禁令,没有把任何文件路径写进正文。具体改法:

- **开篇**加一段总述,一次性说清 `apps/console` 只是薄壳(拥有 Vite 构建、最外层路由树、插件注册),其余点名的东西都是**包导出的组件**而非 `apps/console` 下的文件 —— 后文因而不必逐句重复归属。
- **数据流图**:`App.tsx` 那格改成 `Console shell  (@object-ui/app-shell)`;`Routes` 一行注明由 `apps/console` 挂在 `/apps/:appName`(实测 `App.tsx:348` 的 `path="/apps/:appName/*"`,内层路由在 app-shell 的 `AppContent` 里声明)。
- **Routing 节**:点明表内组件除 `CreateAppPage` / `EditAppPage` 由 plugin-designer 懒加载外,其余均由 app-shell 导出。
- **§3**:`The console's ObjectView is a thin wrapper...` 的主语改成 shell 导出的那个 `ObjectView`(该 wrapper 在 app-shell,不在 console;其文件头注释原文就是 "Thin wrapper around the plugin-view ObjectView",claim 本身成立,错的只是归属)。
- **§4**:改成 plugin-designer 端到端拥有(路由页与 `AppCreationWizard` 都由它导出),console shell 只负责懒加载挂路由。

### 一处有意的偏离:`AppSidebar` 改用角色措辞

图里原 `AppSidebar (navigation tree)` 没有改成「`AppSidebar`,来自 app-shell」,而是改成角色措辞 `sidebar nav (app switcher + nav tree)`。理由:`AppSidebar` 确实在 app-shell,但 `ConsoleLayout` 已经改挂 `UnifiedSidebar`(`ConsoleLayout.tsx` 只 import 后者),在描述活组合的图里直接点名 `AppSidebar` 等于写下一句可证伪的话。单里给的口径本就是 role/package,角色措辞两头都不吃亏。该组件的挂载漂移已并入 #3543 报告。

## 附带

修了 `SchemaRendererProvider` 那格的一格错位(纯空格,零内容变更)—— 那一格宽 60、上下框线宽 59,渲染出来是歪的,而这张图本 PR 正在编辑。

## 越界发现:只报不改,已立 #3543

同页另有三处过期陈述,均不属于本单的两类缺陷面,按 `越界即停` **没有在本 PR 里改**:

1. 数据流图顶格的 `objectstack.config.ts` —— 全仓 `git ls-files` 零命中。**特别注意**:`console.md` 的 `## Configuration` 节同源,只改这一页会让两页当场矛盾,而「两页一致」正是本单的验收条件,所以必须两页同修 → 出面。
2. `§4` 的 Entry Points 三条已死/存疑(`AppSidebar` 的 Add App 菜单已不可达,且其注释写明 "Manual Create App is deprecated in favour of the AI-first builder ... Entry point removed";CommandPalette 里 `create-app` 零命中)。
3. Routing 表不全(shell 另有 `:objectName/new`、`record/:recordId/edit`、`metadata/*`;console 另有整棵 auth 路由)。本 PR 只加了一句兜底说明这些是 object-facing 路由,未逐条补全。

## 验证(预测先写,再跑)

| 命令 | 预测 | 实际 |
|---|---|---|
| `node scripts/check-doc-links.mjs` | exit 0(改前基线即 0;新增链接 `/docs/guide/console#quick-start` 的目标页与锚点都在) | ✅ `Docs links are valid.` exit 0 |
| `pnpm exec vitest run scripts/ --maxWorkers=2` | **保持绿**(`scripts/` 下对本页零引用,没有任何测试 pin 这页内容) | ✅ `Test Files 14 passed (14) / Tests 216 passed (216)` |
| `node scripts/check-control-bytes.mjs` | OK | ✅ `OK (scanned 3695 tracked text file(s))` |
| `grep -rn "MSW\|msw" content/docs/guide/console-architecture.md` | 零命中 | ✅ 零命中 |
| `grep -naP` 自扫控制字节(超出 gate 扫描面) | 干净 | ✅ 干净 |

重活按纪律走了 `flock /tmp/os-heavy-verify.lock` + `NODE_OPTIONS=--max-old-space-size=4096`。

内容文档,无用户可见的代码变更 → 不加 changeset;`content/docs/releases/` 未触碰。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt