### PR TITLE
fix(fields): 编辑弹窗 datetime/date 字段回显存量值

### DIFF
--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -343,4 +343,46 @@ describe('serializeParamValues', () => {
     });
     expect(out).toEqual({ attachments: 'f_1', comment: 'keep me' });
   });
+
+  // `DateTimeField` became ISO-canonical on both sides in objectui#3127 (a
+  // record's stored value arrives as an ISO instant, which the native control
+  // silently rejects, so read and write must share one basis). Action params
+  // have no stored value, so the endpoint contract stays the control's own
+  // zone-less local wall clock — converted back HERE rather than by weakening
+  // the widget, which would put the record form back on two bases.
+  describe('datetime params (objectui#3127 / contract pinned by #2714)', () => {
+    const dtParam = (name: string): ActionParamDef =>
+      ({ name, label: name, type: 'datetime' } as ActionParamDef);
+
+    it('converts the widget ISO instant back to the local wall clock it POSTs', () => {
+      const iso = new Date(2026, 6, 20, 14, 30).toISOString();
+      expect(serializeParamValues([dtParam('when')], { when: iso })).toEqual({
+        when: '2026-07-20T14:30',
+      });
+    });
+
+    it('leaves an already zone-less value untouched', () => {
+      expect(serializeParamValues([dtParam('when')], { when: '2026-07-20T14:30' })).toEqual({
+        when: '2026-07-20T14:30',
+      });
+    });
+
+    it('leaves an empty / absent datetime alone', () => {
+      expect(serializeParamValues([dtParam('when')], { when: '' })).toEqual({ when: '' });
+      expect(serializeParamValues([dtParam('when')], { other: 1 })).toEqual({ other: 1 });
+    });
+
+    it('keeps an unparseable value rather than blanking it', () => {
+      expect(serializeParamValues([dtParam('when')], { when: 'not-a-date' })).toEqual({
+        when: 'not-a-date',
+      });
+    });
+
+    it('does not touch a plain date param', () => {
+      const dateParam = { name: 'day', label: 'day', type: 'date' } as ActionParamDef;
+      expect(serializeParamValues([dateParam], { day: '2026-07-20' })).toEqual({
+        day: '2026-07-20',
+      });
+    });
+  });
 });

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -32,7 +32,7 @@ import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionParamDef } from '@object-ui/core';
 import { ExpressionEvaluator } from '@object-ui/core';
 import { usePredicateScope } from '@object-ui/react';
-import { getLazyFieldWidget, fileIdOf } from '@object-ui/fields';
+import { getLazyFieldWidget, fileIdOf, toDateTimeInputValue } from '@object-ui/fields';
 import { paramToField } from '../utils/paramToField';
 
 export interface ParamDialogState {
@@ -84,26 +84,44 @@ export function filterVisibleParams(
  * is visible rather than silently POSTing `undefined`. Every non-upload value is
  * returned as-is. Pure + exported so the mapping is unit-testable without the
  * dialog render tree.
+ *
+ * `datetime` params are converted back to the control's zone-less local wall
+ * clock (`YYYY-MM-DDTHH:mm`) — the shape this endpoint contract pins (#2714).
+ * `DateTimeField` is ISO-canonical on both sides since objectui#3127: it has to
+ * be, because a record's stored value arrives as an ISO instant and the control
+ * silently rejects that shape, so read and write must share one basis or a
+ * UTC+8 user picking 08:33 would store `08:33Z`. Action params have no stored
+ * value to read, so that widget-level basis is invisible here — but its ISO
+ * output would still reach endpoints that were built against the naive string.
+ * Converting at this boundary keeps the widget coherent AND the wire shape
+ * byte-identical; moving action params onto ISO is a contract change of its own
+ * and belongs in its own ticket, not in a display-bug fix.
  */
 export function serializeParamValues(
   params: ActionParamDef[],
   values: Record<string, any>,
 ): Record<string, any> {
-  const uploadNames = new Set(
-    params
-      .filter((p) => {
-        const t = paramToField(p).type;
-        return t === 'file' || t === 'image';
-      })
-      .map((p) => p.name),
-  );
-  if (uploadNames.size === 0) return values;
+  const uploadNames = new Set<string>();
+  const datetimeNames = new Set<string>();
+  for (const p of params) {
+    const t = paramToField(p).type;
+    if (t === 'file' || t === 'image') uploadNames.add(p.name);
+    else if (t === 'datetime') datetimeNames.add(p.name);
+  }
+  if (uploadNames.size === 0 && datetimeNames.size === 0) return values;
   const toId = (item: any) => fileIdOf(item) ?? item;
   const out: Record<string, any> = { ...values };
   for (const name of uploadNames) {
     const v = out[name];
     if (v == null) continue;
     out[name] = Array.isArray(v) ? v.map(toId) : toId(v);
+  }
+  for (const name of datetimeNames) {
+    const v = out[name];
+    if (v == null || v === '') continue;
+    // An unconvertible value is left intact rather than blanked — the same
+    // failure-visible rule the upload branch above follows.
+    out[name] = toDateTimeInputValue(v) || v;
   }
   return out;
 }

--- a/packages/fields/src/datetime-widgets.test.tsx
+++ b/packages/fields/src/datetime-widgets.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { DateField } from './widgets/DateField';
@@ -54,10 +55,15 @@ describe('Date/Time Widgets', () => {
         });
 
         it('calls onChange when value changes', () => {
-            const { container } = render(<DateTimeField {...baseProps} />);
+            const onChange = vi.fn();
+            const { container } = render(<DateTimeField {...baseProps} onChange={onChange} />);
             const input = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
             fireEvent.change(input, { target: { value: '2023-01-01T12:00' } });
-            expect(baseProps.onChange).toHaveBeenCalledWith('2023-01-01T12:00');
+            // The control speaks zone-less local wall clock; form state holds
+            // ISO, the shape the API hands back and `toDateTimeInputValue`
+            // reads (objectui#3127). Storing the naive string instead would put
+            // read and write on different timezone bases.
+            expect(onChange).toHaveBeenCalledWith(new Date('2023-01-01T12:00').toISOString());
         });
 
         it('renders formatted datetime in readonly mode', () => {
@@ -68,6 +74,92 @@ describe('Date/Time Widgets', () => {
                 return content.includes(date.toLocaleDateString());
             });
             expect(span).toBeInTheDocument();
+        });
+    });
+
+    /**
+     * objectui#3127 — the record's stored ISO value reached the native control
+     * verbatim, and `<input type="date">` / `<input type="datetime-local">`
+     * reject anything but their one exact shape SILENTLY: the attribute lands
+     * in the DOM, `.value` reads back `''`, and the user sees an empty box on a
+     * field that has a value. `.value` (not `getAttribute('value')`) is
+     * therefore the only assertion that can see this bug at all.
+     */
+    describe('existing values round-trip through the native controls (#3127)', () => {
+        // The seeded showcase value. Whole minutes and no sub-second part, so
+        // the control (which has minute resolution) can represent it exactly
+        // and the round trip below is lossless in every timezone.
+        const storedIso = '2026-06-17T14:30:00.000Z';
+
+        it('DateTimeField shows a stored ISO instant instead of an empty box', () => {
+            const { container } = render(<DateTimeField {...baseProps} value={storedIso} />);
+            const input = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
+
+            expect(input.value).not.toBe('');
+            expect(input.value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+            // The shown wall clock denotes the SAME instant as the record —
+            // asserted this way so the test holds in every timezone, which a
+            // hardcoded "2026-06-17T22:30" would not.
+            expect(new Date(input.value).getTime()).toBe(new Date(storedIso).getTime());
+        });
+
+        it('DateTimeField writes back on the same basis it reads', () => {
+            // Read and write must share one timezone basis. Displaying local
+            // while storing the naive local string is the worse bug: the value
+            // would silently drift by the viewer's offset on every edit.
+            const onChange = vi.fn();
+            const { container } = render(
+                <DateTimeField {...baseProps} onChange={onChange} value={storedIso} />
+            );
+            const input = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
+
+            fireEvent.change(input, { target: { value: '2026-06-18T09:15' } });
+
+            const written = onChange.mock.calls[0][0];
+            // Zone-QUALIFIED, which the control's own output is not. Storing
+            // the raw `2026-06-18T09:15` is what puts the write on a different
+            // basis from the read: the server has no way to know whose 09:15
+            // it is, and resolves it to a different instant than the one the
+            // user picked.
+            expect(written).toMatch(/(Z|[+-]\d{2}:\d{2})$/);
+            expect(new Date(written).getTime()).toBe(new Date('2026-06-18T09:15').getTime());
+        });
+
+        it('DateTimeField returning to the shown minute restores the exact stored value', () => {
+            // Guards the drift this fix could otherwise introduce: if the two
+            // conversions disagreed by the viewer's UTC offset, navigating away
+            // from a value and back would land somewhere else, and every open →
+            // fiddle → undo would quietly move the record.
+            // Held in real state, because a `vi.fn()` onChange would leave the
+            // control pinned to its initial prop and React would swallow the
+            // second edit as a no-op — the test would pass without exercising
+            // anything.
+            const seen: string[] = [];
+            const Host = () => {
+                const [v, setV] = React.useState<string>(storedIso);
+                seen.push(v);
+                return <DateTimeField {...baseProps} value={v} onChange={setV as any} />;
+            };
+            const { container } = render(<Host />);
+            const input = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
+            const shown = input.value;
+
+            fireEvent.change(input, { target: { value: '2026-06-18T09:15' } });
+            fireEvent.change(input, { target: { value: shown } });
+
+            expect(seen[seen.length - 1]).toBe(storedIso);
+        });
+
+        it('DateField shows the stored calendar day, ISO-shaped or not', () => {
+            // Both spellings the API may hand back for a `date` field. The day
+            // must survive verbatim — re-parsing the bare form as UTC midnight
+            // would move it to the 16th west of Greenwich.
+            for (const stored of ['2026-06-17', '2026-06-17T00:00:00.000Z']) {
+                const { container, unmount } = render(<DateField {...baseProps} value={stored} />);
+                const input = container.querySelector('input[type="date"]') as HTMLInputElement;
+                expect(input.value).toBe('2026-06-17');
+                unmount();
+            }
         });
     });
 

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -2499,5 +2499,18 @@ export { withFieldCarrier } from './withFieldCarrier';
 export { toDomProps } from './widgets/toDomProps';
 export type { DomProps } from './widgets/toDomProps';
 
+// The native date/time control value adapters (objectui#3127). `DateTimeField`
+// is ISO-canonical on BOTH sides — it takes the record's ISO instant and hands
+// an ISO instant back — so a caller whose own endpoint contract is the control's
+// zone-less local wall clock (`ActionParamDialog`'s `datetime` param, pinned by
+// #2714) needs `toDateTimeInputValue` to convert at its serialization boundary.
+// Exported rather than duplicated so the two surfaces cannot drift on what the
+// local wall clock of an instant is.
+export {
+  toDateInputValue,
+  toDateTimeInputValue,
+  fromDateTimeInputValue,
+} from './widgets/nativeDateValue';
+
 // Initialize registry
 registerAllFields();

--- a/packages/fields/src/widgets/DateField.tsx
+++ b/packages/fields/src/widgets/DateField.tsx
@@ -3,6 +3,7 @@ import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { openNativePicker } from './openNativePicker';
+import { toDateInputValue } from './nativeDateValue';
 
 /**
  * DateField - Date picker input widget
@@ -19,7 +20,10 @@ export function DateField({ value, onChange, field, readonly, ...props }: FieldW
     <Input
       {...domProps}
       type="date"
-      value={value || ''}
+      // An API that hands back `2026-06-17T00:00:00.000Z` for a `date` field
+      // would leave this control empty too (objectui#3127). The written-back
+      // shape is unchanged: the control's own plain `YYYY-MM-DD`.
+      value={toDateInputValue(value)}
       onChange={(e) => onChange(e.target.value)}
       onClick={(e) => {
         openNativePicker(e.currentTarget);

--- a/packages/fields/src/widgets/DateTimeField.tsx
+++ b/packages/fields/src/widgets/DateTimeField.tsx
@@ -3,6 +3,7 @@ import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { openNativePicker } from './openNativePicker';
+import { toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue';
 
 /**
  * DateTimeField - Combined date and time picker widget
@@ -25,8 +26,11 @@ export function DateTimeField({ value, onChange, field, readonly, ...props }: Fi
     <Input
       {...domProps}
       type="datetime-local"
-      value={value || ''}
-      onChange={(e) => onChange(e.target.value)}
+      // The record's value is ISO-8601 (`…T14:30:00.000Z`), which this control
+      // rejects outright — it renders empty and the user reads that as a lost
+      // value (objectui#3127). Convert in, and back out on the same basis.
+      value={toDateTimeInputValue(value)}
+      onChange={(e) => onChange(fromDateTimeInputValue(e.target.value))}
       onClick={(e) => {
         openNativePicker(e.currentTarget);
         domProps.onClick?.(e);

--- a/packages/fields/src/widgets/nativeDateValue.test.ts
+++ b/packages/fields/src/widgets/nativeDateValue.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  toDateInputValue,
+  toDateTimeInputValue,
+  fromDateTimeInputValue,
+} from './nativeDateValue';
+
+/**
+ * These assertions are deliberately written to hold in EVERY timezone, because
+ * the bug they pin (objectui#3127) is a timezone-shaped one and a test that
+ * only passes in UTC would go green on CI while the defect it guards is live
+ * for every user east or west of it.
+ *
+ * The trick: never hardcode the expected wall clock. Assert the SHAPE the
+ * native control demands, and assert that reading that shape back (as local
+ * time, which is how both the browser and `new Date` read a zone-less
+ * datetime) lands on the same INSTANT we started from.
+ */
+
+const localInstantOf = (bare: string) => new Date(bare).getTime();
+
+describe('toDateInputValue', () => {
+  it('keeps a leading YYYY-MM-DD verbatim, in any timezone', () => {
+    // Re-parsing would read this as UTC midnight and hand back the 16th
+    // anywhere west of Greenwich. The calendar day is the value here.
+    expect(toDateInputValue('2026-06-17')).toBe('2026-06-17');
+    expect(toDateInputValue('2026-06-17T14:30:00.000Z')).toBe('2026-06-17');
+  });
+
+  it('formats a Date to the local calendar day', () => {
+    const d = new Date(2026, 5, 17, 23, 59);
+    expect(toDateInputValue(d)).toBe('2026-06-17');
+  });
+
+  it('maps empty and unparseable input to an empty control', () => {
+    expect(toDateInputValue(null)).toBe('');
+    expect(toDateInputValue(undefined)).toBe('');
+    expect(toDateInputValue('')).toBe('');
+    expect(toDateInputValue('not a date')).toBe('');
+  });
+});
+
+describe('toDateTimeInputValue', () => {
+  it('renders a UTC ISO instant as a local wall clock the control accepts', () => {
+    const iso = '2026-06-17T14:30:00.000Z';
+    const shown = toDateTimeInputValue(iso);
+
+    // 1. The shape `datetime-local` demands — the whole point of #3127.
+    expect(shown).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    // 2. …denoting the SAME instant the record holds.
+    expect(localInstantOf(shown)).toBe(new Date(iso).getTime());
+  });
+
+  it('truncates an already-local datetime to minutes without re-parsing it', () => {
+    expect(toDateTimeInputValue('2026-06-17T14:30')).toBe('2026-06-17T14:30');
+    expect(toDateTimeInputValue('2026-06-17T14:30:59')).toBe('2026-06-17T14:30');
+    expect(toDateTimeInputValue('2026-06-17T14:30:59.123')).toBe('2026-06-17T14:30');
+  });
+
+  it('maps empty and unparseable input to an empty control', () => {
+    expect(toDateTimeInputValue(null)).toBe('');
+    expect(toDateTimeInputValue(undefined)).toBe('');
+    expect(toDateTimeInputValue('')).toBe('');
+    expect(toDateTimeInputValue('not a date')).toBe('');
+  });
+});
+
+describe('fromDateTimeInputValue', () => {
+  it('reads the control back on the same basis it was written', () => {
+    const local = '2026-06-17T14:30';
+    const stored = fromDateTimeInputValue(local);
+
+    expect(stored).toMatch(/Z$/);
+    expect(new Date(stored).getTime()).toBe(localInstantOf(local));
+  });
+
+  it('round-trips an ISO instant through the control unchanged', () => {
+    // The invariant that makes the read/write pair safe: opening an editor and
+    // re-picking the same minute must not move the record.
+    const iso = '2026-06-17T14:30:00.000Z';
+    expect(fromDateTimeInputValue(toDateTimeInputValue(iso))).toBe(iso);
+  });
+
+  it('returns an unparseable value untouched rather than blanking it', () => {
+    expect(fromDateTimeInputValue('garbage')).toBe('garbage');
+    expect(fromDateTimeInputValue('')).toBe('');
+  });
+});

--- a/packages/fields/src/widgets/nativeDateValue.ts
+++ b/packages/fields/src/widgets/nativeDateValue.ts
@@ -1,0 +1,112 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Value adapters for the native date/time controls (objectui#3127).
+ *
+ * ## The defect these close
+ *
+ * `<input type="date">` accepts exactly `YYYY-MM-DD` and
+ * `<input type="datetime-local">` exactly `YYYY-MM-DDTHH:mm[:ss]` — a **local
+ * wall clock with no zone suffix**. Anything else is not "coerced" or
+ * "warned about": the browser SILENTLY rejects it. The attribute still lands
+ * in the DOM, so the value looks present to anyone inspecting markup, while
+ * `input.value` reads back `""` and the control paints its empty placeholder:
+ *
+ * ```js
+ * el.getAttribute('value')  // "2026-08-16T00:33:00.000Z"  ← the record's value
+ * el.value                  // ""                          ← what the user sees
+ * ```
+ *
+ * Records come back from the API as full ISO-8601 (`…T00:33:00.000Z`) — which
+ * is precisely one of those rejected shapes. So EVERY datetime field in an
+ * edit dialog rendered blank while holding a real value, and users read that
+ * as "the date was lost" and retyped it (which is the only way the display bug
+ * could turn into a data change).
+ *
+ * ## Why a round trip, and not just a formatter
+ *
+ * Formatting on the way IN without converting on the way OUT would be the
+ * worse bug: the control would then be read as UTC but written back as a naive
+ * local string, so a user in UTC+8 who picked "08:33" would store 08:33Z and
+ * see 16:33 on the detail page. Read basis and write basis must be the same
+ * one, so `toDateTimeInputValue` / `fromDateTimeInputValue` are a pair and are
+ * used as a pair.
+ *
+ * ## Shape kept in form state
+ *
+ * `datetime` round-trips through ISO — the shape the API hands us and the one
+ * display/format code already assumes. `date` stays a plain `YYYY-MM-DD`
+ * string, matching what the inline cell editor in `@object-ui/components`
+ * (`data-table.tsx`) and `@object-ui/plugin-detail`'s `InlineFieldInput`
+ * already do. Untouched fields are never re-emitted, so a form that opens and
+ * closes without an edit still submits nothing for them.
+ */
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * Stored value → `<input type="date">` value (`YYYY-MM-DD`).
+ *
+ * A leading `YYYY-MM-DD` is passed through VERBATIM rather than re-parsed: a
+ * date-only string is parsed as UTC midnight by `new Date()`, so reading local
+ * calendar components back out of it shifts the day by one everywhere west of
+ * Greenwich. `2026-06-17` must stay June 17th in every zone.
+ */
+export function toDateInputValue(value: unknown): string {
+  if (value == null || value === '') return '';
+  if (typeof value === 'string') {
+    const m = value.match(/^(\d{4}-\d{2}-\d{2})/);
+    if (m) return m[1];
+  }
+  const d = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(d.getTime())) return '';
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+/**
+ * Stored value → `<input type="datetime-local">` value (`YYYY-MM-DDTHH:mm`),
+ * expressed in the viewer's local wall clock — the same instant the detail
+ * page shows, so opening the editor never appears to move the time.
+ *
+ * A value that is ALREADY a zone-less local datetime is truncated to minutes
+ * in place instead of being round-tripped through `Date`, which would
+ * reinterpret it and then re-render it, twice risking an off-by-a-zone shift.
+ */
+export function toDateTimeInputValue(value: unknown): string {
+  if (value == null || value === '') return '';
+  if (typeof value === 'string') {
+    const local = value.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})(?::\d{2}(?:\.\d+)?)?$/);
+    if (local) return `${local[1]}T${local[2]}`;
+  }
+  const d = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(d.getTime())) return '';
+  return (
+    `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}` +
+    `T${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+  );
+}
+
+/**
+ * `<input type="datetime-local">` value → stored value (ISO-8601, UTC).
+ *
+ * The control hands us a zone-less local wall clock; `new Date()` reads that
+ * form as local time, which is the inverse of what `toDateTimeInputValue`
+ * wrote — the pair is what keeps read and write on one basis.
+ *
+ * An unparseable string is returned untouched rather than blanked: dropping a
+ * value the user can see in the box would be a data loss dressed up as a fix.
+ */
+export function fromDateTimeInputValue(value: string): string {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toISOString();
+}


### PR DESCRIPTION
Fixes #3127（EHR #864）

## 缺陷

`<input type="datetime-local">` 只接受**不带时区后缀的本地墙钟** `YYYY-MM-DDTHH:mm`。记录从 API 回来是完整 ISO-8601（`2026-06-17T14:30:00.000Z`）——正好是被拒的形状之一，而浏览器**静默拒收**：属性照样落进 DOM，`input.value` 读回空串，控件画出空占位。

```js
el.getAttribute('value')  // "2026-06-17T14:30:00.000Z"  ← 记录里的值
el.value                  // ""                           ← 用户看到的
```

所以每个 datetime 字段在编辑弹窗里都是空框却握着真实值，用户当成「日期丢了」去重新输入 —— 这才是显示 bug 变成数据改动的唯一路径。

`DateField` 在拿到 ISO 形状的 `date` 值时有同一个缺口。

## 改法

新增 `packages/fields/src/widgets/nativeDateValue.ts`，**成对**转换：

- `toDateTimeInputValue` / `fromDateTimeInputValue` —— 读写必须同基准。只做「读」那一半会更糟：控件按 UTC 读、却按裸本地串写，UTC+8 用户选 08:33 会存成 `08:33Z`，详情页显示 16:33。
- `toDateInputValue` —— 开头是 `YYYY-MM-DD` 就**原样透传**，不重新 parse：date-only 串被 `new Date()` 按 UTC 午夜解析，再读本地日期分量会让格林威治以西的所有时区**整体差一天**。

表单状态里的形状不变：`datetime` 走 ISO（API 给的、显示/格式化代码已假定的那个），`date` 保持 plain `YYYY-MM-DD`（与 `data-table.tsx` 内联单元格编辑器、`plugin-detail` 的 `InlineFieldInput` 一致）。

## 验证

**真机**：framework showcase 后端 + 本分支 console dev，对象 `showcase_field_zoo` / 记录 `Specimen — Full`（种子 `f_datetime = 2026-06-17T14:30:00Z`）。浏览器时区 `America/Los_Angeles`。

| | 本分支 | 对照组（预构建 console，无修复） |
|---|---|---|
| `attr` | `2026-06-17T07:30` | `2026-06-17T14:30:00.000Z` |
| `.value` | **`2026-06-17T07:30`** ✅ | **`""`** ← 复现缺陷 |

对照组里 `f_date` 是正常的，只有 datetime 空 —— 说明测法本身有效，差异确实来自本次改动。

**写回**：弹窗里改成本地 `2026-06-18 09:15` 保存 → PATCH body `f_datetime = "2026-06-18T16:15:00.000Z"`（带 Z 的 ISO，非裸本地串），落库一致，详情页显示 `2026/6/18 上午9:15`，无漂移。`f_date` 全程保持 plain `2026-06-17`。

**单测**：`nativeDateValue.test.ts` + `datetime-widgets.test.tsx` 共 **23/23 绿**，`TZ` 取 `Asia/Shanghai` / `America/Los_Angeles` / `UTC` 三次都绿；把两个 widget 还原回 HEAD 时 **5 条转红**（测试确实抓得住这个缺陷）。

## 说明

- 纯 bug 修复，按 AGENTS.md 不带 changeset。
- 排查中读码确认了一处**同族缺口，未并进本单**：`packages/fields/src/widgets/GridField.tsx:763` 子表 date 列是 `value={val != null ? String(val) : ''}` 配 `type="date"`，ISO 形状的值会同样空掉。另立 issue 跟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
