### PR TITLE
fix(tsconfig): 根 tsconfig.node.json 加 noEmit,堵住全仓排放

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,33 @@
+// Editor / reference config only. NO script runs this project — not
+// package.json, not turbo.json, not CI. (`apps/console/tsconfig.node.json` is a
+// DIFFERENT file of the same name; that one IS built, by the console's
+// `type-check`. Don't let a grep hit there convince you this one has a runner.)
+//
+// `noEmit` below is load-bearing, not cruft — DO NOT REMOVE IT. This file
+// declares no `include`, so it compiles the ENTIRE repository, and
+// `tsconfig.base.json` turns on `declaration` / `declarationMap` / `sourceMap`
+// with NO `outDir`. So one stray `tsc -p tsconfig.node.json` used to write
+// ~5,850 `.js` / `.d.ts` / `.map` files next to every source across
+// `packages/`, `apps/`, `examples/`, `scripts/` and the repo root, none of them
+// gitignored. During objectui#3515 a throwaway `git add -A` then swallowed
+// 402,729 insertions across 5,838 files — and worse, the emitted `.js` carry
+// JSX (they came from `.tsx` inputs) and rolldown resolves `src/lib/utils.js`
+// in preference to `src/lib/utils.tsx`, so `@object-ui/components:build` failed
+// with 165 "Unexpected JSX expression" errors that read like "your change broke
+// the build" while having nothing to do with any change. objectui#3549.
+//
+// Legal here because this project is standalone: nothing `references` it, so
+// TS6310 does not apply. Same argument `tsconfig.scripts.json` and
+// `tsconfig.vitest-setup.json` each make for themselves.
+//
+// Note this changes EMIT only, not checking. The project still reports its
+// pre-existing ~23.9k errors; that backlog is deliberately out of scope here
+// (objectui#3515 rejected "widen the root config and give it a runner" for
+// exactly that reason).
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2020"]
+    "lib": ["ES2020"],
+    "noEmit": true
   }
 }


### PR DESCRIPTION
Fixes #3549

## 问题

根 `tsconfig.node.json` 既没有 `include`(默认编译整个仓库),又从 `tsconfig.base.json` 继承了 `declaration` / `declarationMap` / `sourceMap` 且没有 `outDir`。任何一次 `tsc -p tsconfig.node.json` 都会在**每个源文件旁边**写出 `.js` / `.d.ts` / `.map`,而且这些形状全部不在 `.gitignore` 里。

objectui#3515 已经实测踩爆过一次:一条随手的 `git add -A` 吞进 402,729 行插入;更糟的是排放出的 `.js` 带 JSX(来自 `.tsx` 输入),rolldown 会优先解析 `src/lib/utils.js` 而不是 `src/lib/utils.tsx`,于是 `@object-ui/components:build` 报出 165 个 "Unexpected JSX expression",读起来像"你的改动弄坏了构建",实际与任何改动无关。

## 修法

取最小静态防线:给 `compilerOptions` 加 `"noEmit": true`,并补一段文件头注释说明来由(避免下一个编辑者当作冗余删掉)。

选这条路而不是 `.gitignore` 退路,是因为**前置排查确认没有任何东西依赖它的 emit**。全仓 `tsconfig.node.json` 的引用共 8 处,逐条落定:

| 位置 | 指向 | 处置 |
|---|---|---|
| `apps/console/package.json:48` (`tsc -b tsconfig.node.json --force`) | cwd 是 `apps/console`,解析到 **`apps/console/tsconfig.node.json`** | 同名不同文件,不受影响 |
| `apps/console/tsconfig.json:28` (`references: ./tsconfig.node.json`) | 同上,相对 `apps/console/` | 同名不同文件,不受影响 |
| `tsconfig.vitest-setup.json:14` | 散文注释,提到根文件 | 仅描述,无执行;且该描述("无 include、无 script 运行它")改后依然成立 |
| `tsconfig.vitest-setup.json:89`、`tsconfig.scripts.json:15`、`tsconfig.scripts.json:96` | 散文注释,提到 `apps/console` 那个 | 仅描述 |
| `scripts/__tests__/vitest-setup-type-check.test.ts:17`、`:143` | 散文注释 / 错误提示字符串 | 无任何断言读取根文件内容 |
| `turbo.json:26`、`.github/labeler.yml:80` (`tsconfig*.json`) | 缓存 input glob / 打标签 glob | 非执行;仅使 turbo hash 变化一次 |

另外确认:根 `tsconfig.json` 没有 `references` 数组,全仓所有 package 配置 `extends` 的都是 `../../tsconfig.json`,**没有任何工程 `extends` 或 `references` 根 `tsconfig.node.json`** —— 所以 TS6310(被引用工程不得 `noEmit`)不适用。`tsconfig.scripts.json` 与 `tsconfig.vitest-setup.json` 各自也是同一个论证(两者都是 standalone + `noEmit: true`)。

## 逆向验证

方向是**先预测后跑**的。修前预测:排放物出现;修后预测:退出码记录、零新文件落盘、诊断数不变。

| | BEFORE(origin/main) | AFTER(本 PR) |
|---|---|---|
| `git status --porcelain` 条目 | **5,850**(全部 `??` 未跟踪) | **0**(只剩被改的 `tsconfig.node.json` 本身) |
| `git clean -dn` | 5,850 | 0 |
| tsc 退出码 | 1 | 2 |
| 诊断数 | 23,903 | 23,902 |

排放物构成:1,435 个 `.js`、1,434 个 `.ts`(即 `.d.ts`)、2,979 个 `.map`,加 1 个 `.mjs` / 1 个 `.mts`。抽查 issue 点名的四个路径,`git check-ignore` 全部 **NOT ignored**,与 issue 的表格一致。

**两个数字与我的预测不符,都查清了,而且两个都是"修好了"的证据,不是回归:**

1. **退出码 1 → 2 不是变坏。** tsc 的约定是:`1` = 报了错但**仍生成了输出**,`2` = 报了错且**没有生成任何输出**。退到 2 正是 emit 停止的机器可读确认。
2. **少掉的那 1 条诊断是 emit-only 诊断。** 逐行 diff 后只有一条消失、**零条新增**:

   ```
   packages/components/src/__tests__/test-utils.tsx(16,17): error TS2883:
   The inferred type of 'renderComponent' cannot be named without a reference to ...
   ```

   TS2883 只在 TypeScript **必须写出 `.d.ts`** 却无法可移植地命名推断类型时才产生。关掉 emit 就不再写声明,该诊断自然不产生。也就是说:本 PR 只动 emit、不动检查,而唯一变化的诊断恰好属于 emit 本身。既有的 ~23.9k 错误原样保留(那份积压按 objectui#3515 的裁定不在本次范围内;issue 记录的 21,616 是当时的数,随 main 漂到了 23.9k)。

同时确认 `TS5053`(`declaration` 与 `noEmit` 并用)与 `TS6310` 均**未**出现 —— TS 6.0.3 下二者可共存。

## 门禁

| 命令 | 结果 |
|---|---|
| `pnpm type-check:scripts` | EXIT=0 |
| `pnpm type-check:vitest-setup` | EXIT=0 |
| `pnpm check:control-bytes` | OK(扫描 3,631 个跟踪文本文件) |
| `pnpm type-check:coverage` | EXIT=0 |
| `vitest run scripts/__tests__/{vitest-setup-type-check,scripts-type-check}.test.ts` | 2 files / **19 tests passed** |

`type-check:vitest-setup` 在全新 worktree 里初跑是红的(4 条 TS2882,`@object-ui/components` / `fields` / `plugin-dashboard` / `plugin-grid` 找不到声明)。这是 CI 注释写明的 `^build` 前置缺失,**不是本改动引起**:把本 PR 的改动撤回到未修改的 `origin/main` 再跑,得到**逐字相同的 4 条**;补建这四个包及其依赖后,该门禁 EXIT=0。

## 备注

- 无 changeset:根开发配置,不面向用户。
- 未触碰 `content/docs/releases/`。
- 排放物清理过程严格避开了本 issue 描述的陷阱:全程在独立 worktree 内,`git clean -fdn` 先预演(5,850 条,零 `node_modules` 命中)再执行,清理后 `git status --porcelain` 与 `git clean -dn` 双双归零;**没有用过 `git add -A`**。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_