### PR TITLE
docs(console): 清掉 objectstack.config.ts 幽灵、重写已死的建应用入口、诚实框定 Routing 表

### DIFF
--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -24,6 +24,6 @@
     /* Testing */
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src", "dev", "objectstack.config.ts"],
+  "include": ["src", "dev"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/content/docs/guide/console-architecture.md
+++ b/content/docs/guide/console-architecture.md
@@ -18,10 +18,12 @@ from a path.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  objectstack.config.ts                                  │
-│  (defineStack → apps, objects, views)                   │
+│  ObjectStack server  (owns apps, objects, views)        │
+│  • metadata is authored and stored server-side          │
+│  • the console reads it over HTTP — it has no local     │
+│    metadata file of its own                             │
 └────────────────────┬────────────────────────────────────┘
-                     │ ObjectStack server  (HTTP, VITE_SERVER_URL)
+                     │ HTTP  (base URL from VITE_SERVER_URL)
                      ▼
 ┌─────────────────────────────────────────────────────────┐
 │  ObjectStackAdapter  (@object-ui/data-objectstack)      │
@@ -52,14 +54,49 @@ from a path.
 └─────────────────────────────────────────────────────────┘
 ```
 
+### What the console boots from
+
+The console has **no metadata file of its own** — nothing in `apps/console` declares apps,
+objects or views. Everything above the adapter is fetched. Its entire local configuration is
+one build-time Vite variable:
+
+- **`VITE_SERVER_URL`** — the only setting that picks a backend. It seeds both the adapter's
+  `baseUrl` and the runtime-config fetch. Empty means same origin, which is what a server that
+  serves the console itself wants.
+- **Server-pushed runtime config** — before React mounts, the entry point resolves
+  `/api/v1/runtime/config` (branding, feature flags, cloud URL) through `@object-ui/app-shell`,
+  so first paint already shows operator branding instead of the static defaults.
+- **Discovery + metadata** — `AdapterProvider` (`@object-ui/app-shell`) constructs the
+  `ObjectStackAdapter`, `connect()`s it (one `/api/v1/discovery` probe, cached per base URL),
+  and the metadata provider pulls apps, objects and views from the server's metadata API on
+  demand.
+
+Apps and objects **are** authored declaratively — but in the ObjectStack **server** project
+(`objectstack.config.ts` there, or through Studio), not in this repo. The console is a pure
+consumer of whatever that server publishes; see
+[ObjectOS Integration](/docs/guide/objectos-integration) for the server-side shape.
+
 ## Routing
 
 Routing is React Router DOM v7. `apps/console` mounts the per-app subtree at
 `/apps/:appName/*`; the routes below are declared inside it by the console shell
 (`@object-ui/app-shell`). Every component in the table is exported by `@object-ui/app-shell`,
 except `CreateAppPage` / `EditAppPage`, which are lazy-loaded from `@object-ui/plugin-designer`.
-These are the object-facing routes — the shell declares more (record create/edit, the metadata
-admin subtree), and `apps/console` adds the unauthenticated auth surfaces outside this subtree.
+
+**The table below is a curated subset, not an inventory.** It covers the object-facing routes
+— the ones you need to understand how metadata becomes a page. The real tree is several times
+larger and is declared in exactly two places, which are the source of truth when you need the
+full list:
+
+- the **console's own route tree** (`apps/console`) — the unauthenticated auth surfaces
+  (login, register, password reset, verify-email, setup, OAuth consent, invitations), plus
+  home, Studio, AI, organizations, docs and the shared/public record pages;
+- the **shell's app-content route tree** (`@object-ui/app-shell`) — everything under
+  `/apps/:appName/*`: record create and edit, dashboards, pages, reports, search, the
+  marketplace, and the whole metadata-admin subtree.
+
+Read those two route trees in the source rather than trusting a hand-copied table to stay
+current.
 
 | Route Pattern | Component | Purpose |
 |---------------|-----------|---------|
@@ -126,10 +163,20 @@ routes.
 - **Create App** — `CreateAppPage` at `/apps/:appName/create-app`. Passes metadata objects as `availableObjects`, handles `onComplete` (converts draft via `wizardDraftToAppSchema()`, navigates to new app), `onCancel` (navigate back), and `onSaveDraft` (localStorage persistence).
 - **Edit App** — `EditAppPage` at `/apps/:appName/edit-app/:editAppName`. Loads existing app config as `initialDraft` and updates on completion.
 
-**Entry Points:**
-- Sidebar app switcher → "Add App" / "Edit App" buttons
-- CommandPalette (⌘+K) → "Create New App" command in Actions group
-- Empty state CTA → "Create Your First App" button when no apps are configured
+**How users get there.** Manual app creation is **deprecated in favour of the AI-first
+builder**, and the menu entries that used to launch it are gone. Today:
+
+- **Build with AI** — the primary path. The console home (`/home`) offers it whenever the
+  server reports a deployed build agent, and it opens the AI build surface rather than the
+  4-step wizard.
+- **Studio** — the authoring surface for a package and the apps inside it (`/studio`, and the
+  design surface per package). This is where app structure is edited by hand now.
+- **The wizard routes themselves** — `create-app` / `edit-app/:editAppName` stay mounted and
+  reachable as direct (legacy) deep links, which is why the pages above still ship.
+
+Do not re-document the old sidebar / command-palette entries: the "Add App" and "Edit App"
+items exist only in `AppSidebar`, which the console no longer mounts (`ConsoleLayout` renders
+`UnifiedSidebar`), and the command palette never registered a create-app command.
 
 ### 5. Branding
 

--- a/content/docs/guide/console.md
+++ b/content/docs/guide/console.md
@@ -21,7 +21,7 @@ The console opens at **http://localhost:5180** (the port is fixed in `apps/conso
 
 | Feature | Description |
 |---------|-------------|
-| **Multi-App Switcher** | Switch between apps defined in `objectstack.config.ts`. |
+| **Multi-App Switcher** | Switch between the apps discovered from the connected server. |
 | **Dynamic Navigation** | Sidebar renders from the app's `navigation` tree (objects, groups, URLs, pages). |
 | **Object Views** | List / Grid / Kanban / Calendar — backed by `@object-ui/plugin-view`. |
 | **CRUD Dialogs** | Create & edit records via schema-driven forms. |
@@ -54,37 +54,25 @@ published from the top-bar **Publish** flow.
 
 ## Configuration
 
-The console reads its configuration from `objectstack.config.ts`:
+**The console has no configuration file.** It declares no apps, objects or views of its own —
+it renders whatever the server it is pointed at publishes. There are only two inputs:
 
-```ts
-import { defineStack } from '@objectstack/spec';
-import { ObjectSchema, App, Field } from '@objectstack/spec';
+**1. `VITE_SERVER_URL` — which backend to talk to.** A build-time Vite variable, and the only
+setting the console itself owns. It seeds the data adapter's base URL and the runtime-config
+fetch; `apps/console/.env.development` defaults it to `http://localhost:3000`, and an empty
+value means same origin. See [Running with a Real Backend](#running-with-a-real-backend).
 
-export default defineStack({
-  apps: [
-    App.create({
-      name: 'crm',
-      label: 'CRM',
-      icon: 'briefcase',
-      navigation: [
-        { type: 'object', objectName: 'contacts', label: 'Contacts', icon: 'users' },
-        { type: 'object', objectName: 'deals', label: 'Deals', icon: 'dollar-sign' },
-      ],
-      branding: { primaryColor: '#3B82F6' },
-    }),
-  ],
-  objects: [
-    ObjectSchema.create({
-      name: 'contacts',
-      label: 'Contacts',
-      fields: [
-        Field.text('name', { label: 'Name', required: true }),
-        Field.email('email', { label: 'Email' }),
-      ],
-    }),
-  ],
-});
-```
+**2. Server-pushed runtime config — everything else.** Before React mounts, the console
+resolves `/api/v1/runtime/config` from that server and applies it: product branding, feature
+flags (marketplace, AI Studio, SSO, custom domain), and the cloud URL. Operators configure
+these on the **server**, not in the SPA, which is why changing them needs no console rebuild.
+
+Apps, objects and views themselves are metadata fetched over HTTP — discovered at connect
+time and loaded on demand. To change what the console shows, change the metadata on the
+server: author it in the ObjectStack server project (`objectstack.config.ts` lives **there**,
+not here) or edit and publish it from Studio. See
+[ObjectOS Integration](/docs/guide/objectos-integration) for the server-side configuration
+shape.
 
 ## Running with a Real Backend
 


### PR DESCRIPTION
Fixes #3543

在 #3544 / #3539 合并后的主干(`b785a77b3`)上逐条复核了三项前提再动手,复核详情见 [issue 上的复核评论](https://github.com/objectstack-ai/objectui/issues/3543#issuecomment-5218129417)。**一条前提已过期,一条归因需修正,其余成立。**

## (一)`objectstack.config.ts` 幽灵 —— 两页一次清

console 没有任何本地元数据/配置文件,但两页都在教一个:数据流图顶框写着 `objectstack.config.ts (defineStack → apps, objects, views)`,console.md 的 `## Configuration` 还配了整段 `defineStack` 示例。该文件 `git ls-files` 零命中。

**关键修正**:这个文件名并非全无所指 —— 它是 ObjectStack **服务端项目**的配置文件(见 `objectos-integration.mdx`,以及 i18n 里 manifest 冲突提示「请先从 objectstack.config.ts 中移除」)。所以两页都不写成「此文件不存在」,而是写成「它不属于 console」,并指向服务端。

替换成实测到的真实启动输入(按角色写,不按路径):

| 输入 | 实测锚点 |
|---|---|
| `VITE_SERVER_URL` —— 唯一由 console 自己拥有的设置 | `apps/console/src/main.tsx:63`、`.env.development`;喂给 adapter 的 `baseUrl` 与 runtime-config 取数 |
| 服务端下发的 runtime config(品牌、功能开关、cloud URL) | `main.tsx` 挂载前 `initRuntimeConfig(SERVER_BASE)` → `runtime-config.ts:160` → `GET /api/v1/runtime/config` |
| discovery + 元数据(apps/objects/views) | `AdapterProvider.tsx:62-80` 造 `ObjectStackAdapter({ baseUrl: VITE_SERVER_URL })` 并 `connect()`(一次 `/api/v1/discovery`,按 baseUrl 缓存),再由 MetadataProvider 按需拉取 |

**越界一处,请复核**:文件面写的是 console.md「仅 Configuration 段」,但实测发现同一页 `console.md:24` 的 Key Features 表里还有**第三处同源幽灵**(「Switch between apps defined in `objectstack.config.ts`」)。只清 Configuration 段会让这一页自相矛盾 —— 正是本单要求「两页一起改」所要避免的失败模式,只是缩到了一页之内。因此一并修正(单行、同缺陷类、同文件),在此显式声明。

`apps/console/tsconfig.json` 的死 include 条目一并删除。

## (二)§4 Entry Points —— 三条入口全部不通

| 文档原列入口 | 实测 |
|---|---|
| Sidebar app switcher → Add App / Edit App | `add-app-btn` / `edit-app-btn` 仍在 `AppSidebar.tsx:395,401`,但 `ConsoleLayout` 只挂 `UnifiedSidebar` —— **组件整体无挂载点** |
| CommandPalette → Create New App | `createApp` / `create-app` / `Create New App` 在 `CommandPalette.tsx` 均**零命中**,该命令从未注册 |
| Empty state CTA → Create Your First App | 渲染点是**活的**(`AppContent.tsx:577`),但跳转目标断链 —— 另见下文 |

**归因修正**:原单引用 `AppSidebar.tsx` 的「Entry point removed」注释作为 sidebar 入口被撤的依据。实测该注释在 `AppSidebar.tsx:326-328`,位于**系统导航项列表**的 `items.push(...)` 内,管辖的是那份系统导航,并不管 395/401 行的应用切换器下拉菜单(其代码仍在)。两条事实指向同一结论(入口不可达),但真实原因是**组件没被挂载**,不是「入口已从组件里删掉」。文档按后者口径写。

改写后按 AppSidebar 注释的产品口径给出真实路径:AI-first builder(`/home` 的 Build with AI,依服务端是否部署 build agent 而定)、Studio,以及作为 legacy deep link 保留的 wizard 路由。空态 CTA **未**写进新的入口清单,因为它在 console 里是断的(见下)。

## (三)Routing 表 —— 选「诚实框定」,不逐条补全

原单点名的「a simple flat route structure」一句**已在 #3544 中消失**,这半条前提已过期。剩余的「表不全」成立并已量化:

- shell `packages/app-shell/src/console/AppContent.tsx`:47 个 `Route`(34 个去重路径)
- `apps/console/src/App.tsx`:42 个 `Route`(38 个去重路径)
- 文档表:**7 行**

逐条补全等于把 70+ 条路由手抄进 markdown,下次改路由必然立刻过期。按 #3539「删手抄、指真源」先例,**明确选择诚实框定**:声明该表是 object-facing 的**精选子集而非清单**,并点名两处真源路由树各自负责什么。表内 7 行已逐条复核,全部存在且路径正确,予以保留(它们是「元数据如何变成页面」的最小可读集)。

## 验证

预测:三项门禁改动前后都应为绿(纯文档 + 一条惰性 tsconfig 条目);tsconfig 那条的**预期方向是「什么都不动」**,这与常见的「把删掉的分支放回去看它变红」相反 —— 该条目是 glob-less 且匹配不到文件的字面量,tsc 静默忽略,所以「无变化」本身就是它可安全删除的证据。实测与预测一致:

```
node scripts/check-doc-links.mjs      → exit 0  (Links are valid across 3 scan roots.)
node scripts/check-control-bytes.mjs  → exit 0  (OK; scanned 3631 tracked text file(s))
pnpm --filter @object-ui/console type-check → exit 0
pnpm exec vitest run scripts/ --maxWorkers=2 → exit 0  (16 files, 275 tests passed)
```

**tsconfig 惰性性质的反向验证**(先预测后跑):把幽灵条目放回一个临时 tsconfig,对比 `tsc --listFilesOnly` 的文件清单 —— 预测「完全相同」,实测 **472 行 vs 472 行,diff 为空**。该 include 条目确实不影响任何编译输入。

两页改后通读:彼此一致(同一套 VITE_SERVER_URL + 服务端下发配置 + HTTP 取元数据的说法,且都指向 objectos-integration 讲服务端形态),与 #3532 / #3539 / #3544 的既有措辞一致。

无 changeset:纯文档 + dev-only 的 tsconfig include 清理,无用户可见运行时变更(`changeset-guard` 只由 `.changeset/**` 触发,`ci.yml`/`lint.yml` 把 `**/*.md` 列入 paths-ignore)。未触碰 `content/docs/releases/`。

## 越界发现(只报不改)

已另立 **#3573**:空态「Create Your First App」CTA 在 `apps/console` 里断链 —— `AppContent.tsx:577` 走 `navigate('/create-app')`(绝对路径),而 `App.tsx` 根路由树没有 `/create-app`,末尾 `path="*"` 把它重定向回 `/`。因此文档原列三个入口**实际三个都不通**(原单判断为「至少两个」)。属代码侧缺陷,不在本单文件面内。

原单记录的 observation-class「`AppSidebar` 仍导出但无挂载点」按分诊要求**未修、未另立单**,继续留在 #3543 里待下轮定去留。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_