### PR TITLE
docs(runner): 记录 `api` 查询参数这一真实的元数据加载配置面 (#3537)

### DIFF
--- a/content/docs/utilities/runner.mdx
+++ b/content/docs/utilities/runner.mdx
@@ -94,6 +94,72 @@ packages/runner/
 
 ## Configuration
 
+### Metadata Loading
+
+The Runner picks one of two metadata loaders when it mounts, from the `api` query
+parameter of the page URL (`src/App.tsx`). This is the Runner's only API base URL
+setting — it reads no environment variables and no config file:
+
+| URL | Loader | Where metadata comes from |
+| --- | --- | --- |
+| `http://localhost:5173/` | `LocalBundleLoader` | JSON bundled from `src/app-data/` at build time |
+| `http://localhost:5173/?api=/api` | `NetworkLoader` | `fetch`ed from the base URL you passed |
+
+The branch is `params.get('api')`, so an empty value (`?api=`) is falsy and still
+selects the local loader. Which strategy won is logged to the browser console —
+`📦 Using Local Bundle Loader` or `🔌 Using Network Loader: <base>`.
+
+#### Serving metadata over HTTP (`?api=<base>`)
+
+`NetworkLoader` uses the parameter value verbatim as a base URL and appends fixed
+paths to it, so a backend needs to serve exactly two kinds of JSON document:
+
+| Runner route | Request | Response |
+| --- | --- | --- |
+| _(any, once at startup)_ | `GET <base>/app.json` | the app document (`AppComponentSchema`) |
+| `/` | `GET <base>/pages/index.json` | the page document (`PageNodeSchema`) |
+| `/customers` | `GET <base>/pages/customers.json` | the page document |
+| `/crm/accounts` | `GET <base>/pages/crm/accounts.json` | the page document |
+
+Nested routes map straight through — the request path is `<base>/pages` plus the
+browser path plus `.json`, with `/` rewritten to `/index` first.
+
+- **Relative or absolute base.** `?api=/api` keeps the requests same-origin (pair it
+  with a dev-server proxy or a reverse proxy in front of the built bundle);
+  `?api=https://metadata.example.com/api` goes cross-origin, which needs CORS on the
+  backend. The loader calls `fetch` with no second argument, so it sends no
+  credentials and no custom headers — an endpoint behind cookie or bearer auth will
+  not work as-is.
+- **Failures are silent.** Any non-2xx status, or a network/parse error, is turned
+  into `null`. The Runner then shows `Page not found: <path>` for a page, and for a
+  failed `app.json` it drops the app chrome (header/sidebar) and renders the page on
+  its own. The HTTP status never reaches the UI — read it from the Network tab.
+- **Read once, at mount.** The parameter is captured in a `useMemo` with an empty
+  dependency list. In-app navigation calls `history.pushState` with the bare path, so
+  the address bar loses `?api=…` after the first click; the loader already created
+  keeps serving that session, but reloading or sharing the resulting URL falls back to
+  the local bundle.
+- `NetworkLoader`'s own default base is `/api` (`constructor(baseUrl: string = '/api')`).
+  That default only applies when the class is constructed directly in code — the
+  Runner always passes it the query-parameter value.
+
+#### Running from bundled JSON (no `api` parameter)
+
+`LocalBundleLoader` resolves metadata from `packages/runner/src/app-data/` through
+Vite's `import.meta.glob` — at build time, not over the network. It globs
+`app-data/app.json`, `app-data/pages/**/*.json` and `app-data/*.json`, and resolves a
+route by trying, in order:
+
+| Runner route | Files tried, in order |
+| --- | --- |
+| `/` | `pages/index.json`, `pages/index/index.json`, `index.json` |
+| `/customers` | `pages/customers.json`, `pages/customers/index.json` |
+
+`src/app-data/` is git-ignored (see `packages/runner/.gitignore`) and is **not** part
+of a fresh checkout — you supply it, by copying or symlinking your own metadata
+directory there. With that directory absent, the three globs compile to `{}`, every
+load returns `null`, and `/` renders the built-in `No index page found.` placeholder.
+
 ### `vite.config.ts`
 
 The Runner uses Vite for development and building:

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -57,27 +57,41 @@ The runner comes with these plugins pre-configured:
 - **@object-ui/plugin-charts** - Chart visualization components
 - **Additional plugins can be added as needed**
 
-## Schema Loading
+## Metadata Loading
 
-The runner can load schemas from various sources:
+The runner picks its metadata loader when it mounts, from the `api` query parameter of
+the page URL (`src/App.tsx`). This is its only API base URL setting — it reads no
+environment variables and no config file:
 
-```typescript
-// From JSON file
-const schema = await import('./my-schema.json');
+| URL | Loader | Where metadata comes from |
+| --- | --- | --- |
+| `http://localhost:5173/` | `LocalBundleLoader` | JSON bundled from `src/app-data/` at build time |
+| `http://localhost:5173/?api=/api` | `NetworkLoader` | `fetch`ed from the base URL you passed |
 
-// From JavaScript/TypeScript
-const schema = {
-  type: 'page',
-  title: 'My App',
-  body: {
-    type: 'card',
-    content: 'Hello World'
-  }
-};
+With `?api=<base>`, the value is used verbatim as a base URL and fixed paths are
+appended to it, so a backend only has to serve two kinds of JSON document:
 
-// From API endpoint
-const schema = await fetch('/api/schema').then(r => r.json());
+```text
+GET <base>/app.json                 # the app document, loaded once at startup
+GET <base>/pages/index.json         # route "/"
+GET <base>/pages/customers.json     # route "/customers"
+GET <base>/pages/crm/accounts.json  # route "/crm/accounts"
 ```
+
+A relative base (`?api=/api`) keeps the requests same-origin; an absolute one needs
+CORS on the backend. `fetch` is called with no options, so no credentials or custom
+headers are sent, and any non-2xx status or network error becomes `null` — which the
+runner renders as a 404 rather than surfacing the status.
+
+Without the parameter, `LocalBundleLoader` resolves `src/app-data/app.json` and
+`src/app-data/pages/**/*.json` through Vite's `import.meta.glob`. That directory is
+git-ignored and absent from a fresh checkout, so every load returns `null` until you
+copy or symlink your own metadata directory into it.
+
+Full details — route resolution order, error handling, and the caveat that in-app
+navigation drops `?api=` from the address bar — are in the
+[Metadata Loading](https://www.objectui.org/docs/utilities/runner#metadata-loading)
+section of the docs.
 
 ## Configuration
 


### PR DESCRIPTION
Fixes #3537

纯文档单:runner 有一个真实可用的 API 基址配置面(URL 查询参数 `api`),但全仓文档零处记载 —— 在 #3533 / PR #3538 删掉那节「不存在的环境变量」之后,该页关于 API 基址的指引降为零。不涉及任何实现改动。

## 前提复核(rule 6:issue 正文是线索不是规格)

对 `origin/main`(`b785a77b3`)逐条复核,issue 的前提**成立**,行号也仍然准确:

- `packages/runner/src/App.tsx:44-57` —— `const params = new URLSearchParams(window.location.search); const apiUrl = params.get('api');`,有值 → `new NetworkLoader(apiUrl)`,无值 → `new LocalBundleLoader()`。
- `packages/runner/src/lib/MetadataLoader.ts:75-103` —— `NetworkLoader`,`constructor(baseUrl: string = '/api')`,取 `${this.baseUrl}/app.json` 与 `${this.baseUrl}/pages${jsonPath}.json`(`path === '/'` 先改写成 `/index`)。
- PR #3538 已落地(`039d2d077`),原 "Environment Variables" 一节确已删除。

## 改了什么

**`content/docs/utilities/runner.mdx`** —— 在 `## Configuration` 下新增 `### Metadata Loading`,放在 `### vite.config.ts` **之前**(issue 的建议就是补在 Configuration 一节;而它是读者「我要把 runner 指向自己的后端」时第一眼扫的标题,排在 vite 配置前面比排在末尾更容易被找到)。内容:

- 两种加载策略的分流表;`params.get('api')` 是真值判断,所以 `?api=`(空值)仍然走本地加载器;控制台会打印命中了哪一种。
- `?api=` 走网络时后端要提供的四类请求(`app.json` + `pages/index.json` + `pages/customers.json` + `pages/crm/accounts.json`),嵌套路由直通。
- 相对基址(同源)与绝对基址(需要后端开 CORS);`fetch` 无第二参数 ⇒ 不带 cookie / 自定义头,cookie 或 bearer 鉴权的后端直接用不了。
- 失败静默:非 2xx 与网络/解析错误一律转成 `null`,页面显示 `Page not found`,`app.json` 失败则整个 app 外壳(头部/侧栏)消失,HTTP 状态码不进 UI。
- 参数只在挂载时读一次;站内跳转 `pushState` 裸路径会把 `?api=` 从地址栏抹掉(已另立单 #3578)。
- 缺省 `LocalBundleLoader` 的真实来源 `src/app-data/`(gitignore、新检出为空)与按序解析的文件顺序。

**`packages/runner/README.md`** —— 深度选择及理由:原 `## Schema Loading` 一节讲的是 runner 并不具备的通用加载方式(`await import('./my-schema.json')` / `fetch('/api/schema')`),与本单要补的**正是同一主题**;若在它旁边另起一节,README 会自相矛盾(一节说「可以从各种地方加载」,紧邻一节说「只有两种,由查询参数决定」)。所以改写该节为 `## Metadata Loading`,按 README 既有深度(每节 10–20 行 + 一个代码块 + 末尾指回文档)给出:分流表、后端要提供的请求清单、CORS/凭据/错误处理各一句,细节指回文档页的 `#metadata-loading` 锚点。README 里另外两处虚构能力(`createRunner()`、`runner.config.js`)与本主题无关,**未动**,已另立单 #3576。

## 实测(以及**没有**实测的部分)

这次**没有**在浏览器里跑通两种模式 —— 容器内没有安装 playwright 浏览器(`~/.cache/ms-playwright` 不存在),而且干净 worktree 里 runner 的 dev server 本身就因为别名缺口起不了页面(另立单 #3575)。按 #3524 的先例如实说明。以下是**实际跑了**的两项测量,文档里的 URL 形状与「缺目录时什么都加载不到」两条结论来自它们,不是读代码推断:

**1. `NetworkLoader` 的请求 URL** —— 用 esbuild 转译**真实源文件** `packages/runner/src/lib/MetadataLoader.ts`(与 Vite 相同的 TS→JS 步骤),桩掉 `fetch` 记录每一次请求:

```
--- explicit baseUrl: "https://backend.example.test/api" ---
loadAppConfig()          -> https://backend.example.test/api/app.json
loadPage("/")            -> https://backend.example.test/api/pages/index.json
loadPage("/customers")   -> https://backend.example.test/api/pages/customers.json
loadPage("/crm/accounts")-> https://backend.example.test/api/pages/crm/accounts.json
--- default baseUrl (no argument) ---
                            /api/app.json , /api/pages/index.json
--- 404 handling (res.ok === false) ---
loadPage("/missing") -> null
--- network error handling (fetch throws) ---
loadAppConfig() -> null
```

**2. `LocalBundleLoader` 的 glob 到底解析到什么** —— 起 runner 的 vite dev server(自选空闲端口 5387,用完按记下的 PID 收),直接取转译后的模块:

- 无 `src/app-data/`(= 仓库现状):

  ```js
  appGlob = Object.assign({}); pagesGlob = Object.assign({}); rootGlob = Object.assign({});
  ```

  三个 glob 全空 ⇒ 每次加载都返回 `null` ⇒ `/` 落到内置的 `No index page found.`。

- 把一个 `app.json` + `pages/index.json` + `pages/customers.json` + `pages/crm/accounts.json` 的目录软链成 `src/app-data/` 后重启:

  ```js
  appGlob  = Object.assign({"../app-data/app.json": () => import(...)});
  pagesGlob= Object.assign({"../app-data/pages/crm/accounts.json": ..., "../app-data/pages/customers.json": ..., "../app-data/pages/index.json": ...});
  ```

  即文档里写的键名与解析顺序确实是 Vite 编译期决定的。(该软链目录被 `.gitignore` 覆盖,`git status` 全程干净;测完已删除,dev server 已按 PID 停止,端口 5387 已释放。)

## 门禁(先预测后运行,均如预测)

| 命令 | 预测 | 实际 |
|---|---|---|
| `node scripts/check-doc-links.mjs` | 0(新增内容不含站内链接) | `Links are valid across 3 scan roots.` exit 0 |
| `pnpm exec vitest run scripts/ --maxWorkers=2`(flock + 4G 堆上限) | 保持绿 | `Test Files 16 passed (16) / Tests 275 passed (275)` |
| `node scripts/check-control-bytes.mjs` | OK | `✅ OK (scanned 3631 tracked text file(s))`;另自查 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 两文件均无命中 |

补充两项:

- **README 里的链接没有门禁覆盖**,只能人工核 —— `scripts/check-doc-links.mjs` 的 `SCAN_ROOTS` 是 `content/docs`、`examples`、根 `README.md`,`packages/*/README.md` 不在内。人工核了新增的那条 `https://www.objectui.org/docs/utilities/runner#metadata-loading`:页面文件 `content/docs/utilities/runner.mdx` 存在(路由与 `package.json` 的 `homepage`、README 底部 `## Links` 一致),锚点来自本 PR 新增的 `### Metadata Loading` 标题。(README 原有的 `/docs/runner` 那条是死链,不在本单范围,已另立单 #3576。)
- **MDX 能否解析**:用仓库内的 `@mdx-js/mdx@3.1.1` 编译改后的 `runner.mdx`(去掉 frontmatter),`compiled OK`;新增内容里所有 `<` 都在行内代码或围栏代码里,不会被当作 JSX 标签。表格用 GFM 管道语法,与 `content/docs` 下已有的 43 个页面一致。

## changeset:不加,依据如下

- `AGENTS.md:151`:「功能改进(feature)需写 changeset;纯 bug 修复不需要」—— 纯文档不在需要之列。
- 仓库没有「改了就必须有 changeset」的门禁:`scripts/check-changeset-fixed.mjs` 只校验 fixed 组成员齐全,`scripts/check-changeset-no-major.mjs` 只禁 major,都不要求 changeset 存在。(#3387 提议加这样一条门禁,**仍是 open**,且其触发面是 `packages/*/src/**`,本 PR 未触及。)
- 直接先例:同族的 PR #3538(`039d2d077`,纯文档、同一个 `runner.mdx`)未带 changeset。
- 已核实 `@object-ui/runner` 确实是发布包(`private: false`,`files` 含 `README.md`),所以这条不是「README 不发布所以无所谓」,而是「本仓约定文档改动不发 changeset」。

## 越界发现(全部另立单,本 PR 一处未改)

按 Prime Directive #10 逐条立单,均未指派:

- #3575 —— `packages/runner/vite.config.ts` 的别名表漏了 5 个源码实际 import 的工作区包,照 runner.mdx 的 "From Source"(install → dev,无构建步骤)走必然 500。与 #3528 同形态但严重度更高(那边文档已写明先构建,判为 `finding`;这边文档没写),故未打 `finding`,交 PM 定级。
- #3576 —— README 的 `createRunner()` 程序化 API 与 `runner.config.js` 都不存在(该包连 `main`/`exports` 都没有),外加 `/docs/runner` 死链。
- #3577 —— runner.mdx 另三处结构性陈述过期:`src/schemas`+`src/components` 目录、「内置示例 schema」、Package Information 的 `0.3.1` 与「not published to npm」(实际 `17.3.0`、`private: false`)。
- #3578 —— 站内导航把 `?api=` 从地址栏抹掉,刷新/分享即静默退回空的本地加载器(本 PR 已把该行为如实写成注意事项)。
- #3579 —— `scripts/start-app.mjs` 是死入口(无 `start:app` 脚本、默认目标不存在、没有 example 是 app-data 形状),标 `finding`。正因为它不能用,本 PR 的文档**没有**把它写成填充 `src/app-data/` 的办法,只说「由你自己复制或软链」。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_