### PR TITLE
fix(i18n,app-shell): 补齐 8 处无兜底裸 key 调用点的十语言包文案 (#3546 切片一)

### DIFF
--- a/.changeset/raw-key-call-sites-slice-one.md
+++ b/.changeset/raw-key-call-sites-slice-one.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/i18n': patch
+'@object-ui/app-shell': patch
+'@object-ui/plugin-detail': patch
+'@object-ui/plugin-gantt': patch
+'@object-ui/plugin-form': patch
+---
+
+The five locale keys behind #3546's eight no-fallback `t()` call sites are now defined in all ten packs, so the built-in-view toasts, the activity-timeline source link, the wizard's required-field toast and the Gantt refresh button's accessible name are translated instead of falling back to English — or, on two surfaces, to the key itself (part of #3546).
+
+`scripts/check-i18n-call-site-keys.mjs` measured 258 keys that a `t()` call site asks for and no pack defines. These five were the subset with no working inline default: `console.objectView.cannotEditMetaView`, `console.objectView.cannotDeleteMetaView`, `detail.viewSource`, `gantt.toolbar.refresh` and `wizard.missingRequired`. Adding a `defaultValue` is deliberately not the fix — that mechanism is what kept all 258 invisible for months.
+
+**Two of the eight sites really did render the raw key**, and both go through a binding with nothing in front of i18next. `ObjectView.tsx` calls `useObjectTranslation()` directly, so five toasts read `console.objectView.cannotEditMetaView` / `cannotDeleteMetaView` on screen; the `|| 'Built-in views cannot be renamed.'` guards next to them were dead on every path, because i18next answers a miss with the key itself and a non-empty string never falls through `||`. Those four unreachable English strings are removed rather than repaired: one key served four call sites (rename / pin / set-as-default / configure), so the pack copy covers any change to a built-in view instead of naming one operation. `RecordActivityTimeline.tsx` fails the same way for a subtler reason — `useDetailTranslation` is `createSafeTranslation(..., 'detail.back')`, and because `detail.back` does resolve, the probe hands back i18next's `t` for every key and bypasses the defaults map wholesale, so `detail.viewSource` reached the user verbatim.
+
+**The other two sites were not rendering a raw key**, contrary to the issue's description, and are fixed here as the milder "English in all ten languages" class. `wizard.missingRequired` is its own hook's probe key, so the probe failed and `createSafeTranslation` correctly served its English default. `gantt.toolbar.refresh` goes through `useGanttTranslation`, which deliberately does not use `createSafeTranslation` and falls back per key — so the refresh button's `aria-label` was "Refresh", in English, never the key. Screen-reader users heard an English word rather than an identifier; a `zh` session now hears 刷新.
+
+Regression cover is provider-mounted on purpose: with no `I18nProvider` the defaults maps answer every one of these keys and the assertions pass while the console is broken, which is precisely the false-green the issue documents. For the two sites whose English output was already correct, `en` cannot discriminate before from after — the `zh` assertions are the ones that pin the fix.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -851,7 +851,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
 
     const handleRenameView = useCallback(async (vid: string, newName: string) => {
         if (!isSavedView(vid)) {
-            toast.error(t('console.objectView.cannotEditMetaView') || 'Built-in views cannot be renamed.');
+            toast.error(t('console.objectView.cannotEditMetaView'));
             return;
         }
         try {
@@ -869,7 +869,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const handleDeleteView = useCallback(async (vid: string) => {
         if (!dataSource) return;
         if (!isSavedView(vid)) {
-            toast.error(t('console.objectView.cannotDeleteMetaView') || 'Built-in views cannot be deleted.');
+            toast.error(t('console.objectView.cannotDeleteMetaView'));
             return;
         }
         const targetView = views.find((v: any) => v.id === vid);
@@ -903,7 +903,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const handlePinView = useCallback(async (vid: string, pinned: boolean) => {
         if (!dataSource) return;
         if (!isSavedView(vid)) {
-            toast.error(t('console.objectView.cannotEditMetaView') || 'Built-in views cannot be pinned.');
+            toast.error(t('console.objectView.cannotEditMetaView'));
             return;
         }
         try {
@@ -919,10 +919,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const handleSetDefaultView = useCallback(async (vid: string) => {
         if (!dataSource) return;
         if (!isSavedView(vid)) {
-            toast.error(
-                t('console.objectView.cannotEditMetaView')
-                || 'System view — it cannot be set as a default.',
-            );
+            toast.error(t('console.objectView.cannotEditMetaView'));
             return;
         }
         try {
@@ -972,10 +969,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         // ViewConfigPanel against one would let the user save changes that
         // never persist.
         if (!isSavedView(vid)) {
-            toast.error(
-                t('console.objectView.cannotEditMetaView')
-                || 'System view — it cannot be edited.',
-            );
+            toast.error(t('console.objectView.cannotEditMetaView'));
             return;
         }
         if (vid !== activeViewId) handleViewChange(vid);

--- a/packages/i18n/src/__tests__/raw-key-call-sites-3546.test.tsx
+++ b/packages/i18n/src/__tests__/raw-key-call-sites-3546.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * The five keys behind objectui#3546's eight no-fallback `t()` call sites now
+ * resolve **from the locale packs, with a provider mounted**.
+ *
+ * ## Why a provider-mounted test, and why `zh` is the load-bearing half
+ *
+ * This is the trap #3546 documents. `createSafeTranslation` probes ONE
+ * `testKey`; if that key resolves, it hands the caller i18next's `t` for
+ * *every* key. So a key that lives only in a component's defaults map is
+ * served correctly in a provider-less unit test and degrades to the raw key in
+ * the real console. A green suite proves nothing unless a provider is mounted —
+ * hence `I18nProvider` here rather than `renderHook` on its own.
+ *
+ * `en` alone is not enough either, and for a second reason. Two of the eight
+ * sites were NOT rendering a raw key before the fix, because their fallback
+ * genuinely worked (measured, not assumed — see the PR body):
+ *
+ *   - `wizard.missingRequired` is its own hook's `testKey`, so the probe failed
+ *     and `createSafeTranslation` correctly served the English default.
+ *   - `gantt.toolbar.refresh` goes through `useGanttTranslation`, which does
+ *     per-key fallback and deliberately does NOT use `createSafeTranslation`.
+ *
+ * For those two the pre-fix `en` output was already "Please complete…" /
+ * "Refresh" — identical to the post-fix pack value. An `en`-only assertion
+ * would have been green before the fix and is therefore worthless as a guard.
+ * **`zh` is what discriminates**: before the packs were backfilled a `zh`
+ * session got the English default, and after it gets Chinese. Every assertion
+ * below that actually pins this fix is a `zh` one.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider, useObjectTranslation } from '../provider';
+import { createSafeTranslation } from '../useSafeTranslation';
+import { builtInLocales } from '../locales/index';
+
+/** The five keys this slice backfilled, with their call sites. */
+const KEYS = [
+  'console.objectView.cannotEditMetaView',
+  'console.objectView.cannotDeleteMetaView',
+  'detail.viewSource',
+  'gantt.toolbar.refresh',
+  'wizard.missingRequired',
+] as const;
+
+const LANGS = Object.keys(builtInLocales);
+
+const at = (pack: unknown, path: string): unknown =>
+  path.split('.').reduce<unknown>((n, k) => (n as Record<string, unknown> | undefined)?.[k], pack);
+
+const wrapperFor = (lang: string) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      I18nProvider,
+      { config: { defaultLanguage: lang, detectBrowserLanguage: false } },
+      children,
+    );
+  };
+
+beforeEach(() => {
+  // The provider remembers the language across mounts (objectstack#5406), so a
+  // stale `zh` would otherwise leak into the `en` cases below.
+  window.localStorage.clear();
+});
+
+describe('objectui#3546 slice one — the five raw-key call-site keys', () => {
+  it('covers all ten packs (guards the loop from silently emptying)', () => {
+    expect(LANGS).toHaveLength(10);
+    expect(KEYS).toHaveLength(5);
+  });
+
+  it.each(LANGS)('%s defines all five keys as non-empty strings', (lang) => {
+    for (const key of KEYS) {
+      const value = at(builtInLocales[lang], key);
+      expect(typeof value, `${lang}.${key}`).toBe('string');
+      expect((value as string).trim().length, `${lang}.${key} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every pack but en carries a real translation, not the English string', () => {
+    // The failure this catches is a backfill that copy-pastes `en` into the
+    // other nine packs: full key parity, ten packs green, and nine languages
+    // still reading English. `all-locales-key-parity` cannot see it.
+    const untranslated: string[] = [];
+    for (const lang of LANGS.filter((l) => l !== 'en')) {
+      for (const key of KEYS) {
+        if (at(builtInLocales[lang], key) === at(builtInLocales.en, key)) {
+          untranslated.push(`${lang}.${key}`);
+        }
+      }
+    }
+    expect(untranslated).toEqual([]);
+  });
+
+  describe("ObjectView's binding — plain useObjectTranslation, no defaults map", () => {
+    // ObjectView.tsx calls `useObjectTranslation()` directly, so a missing key
+    // reached the user verbatim: the toast literally read
+    // `console.objectView.cannotEditMetaView`. Nothing shadowed it, which is
+    // why these two are the sites the issue verified on the page.
+    it.each(['en', 'zh'])('%s resolves both meta-view toasts from the pack', (lang) => {
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor(lang) });
+      for (const key of [
+        'console.objectView.cannotEditMetaView',
+        'console.objectView.cannotDeleteMetaView',
+      ]) {
+        const value = result.current.t(key);
+        expect(value, `${lang}.${key} rendered the raw key`).not.toBe(key);
+        expect(value).toBe(at(builtInLocales[lang], key));
+      }
+    });
+
+    it('the zh toast is Chinese — the assertion that would fail without the packs', () => {
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor('zh') });
+      expect(result.current.t('console.objectView.cannotEditMetaView')).toBe(
+        '该视图为内置视图，由代码定义，无法修改。',
+      );
+      expect(result.current.t('console.objectView.cannotDeleteMetaView')).toBe(
+        '该视图为内置视图，由代码定义，无法删除。',
+      );
+    });
+  });
+
+  describe("WizardForm's binding — createSafeTranslation whose testKey IS the key", () => {
+    // `createSafeTranslation({...}, 'wizard.missingRequired')`. Before the
+    // backfill the probe failed (the key was in no pack), so the hook served
+    // its own English default to every language. Now the probe succeeds and
+    // i18next serves the pack — so `zh` finally gets Chinese.
+    const useWizardTranslation = createSafeTranslation(
+      { 'wizard.missingRequired': 'Please complete the required fields: {{fields}}' },
+      'wizard.missingRequired',
+    );
+
+    it('en interpolates {{fields}} from the pack', () => {
+      const { result } = renderHook(() => useWizardTranslation(), { wrapper: wrapperFor('en') });
+      expect(result.current.t('wizard.missingRequired', { fields: 'Name, Owner' })).toBe(
+        'Please complete the required fields: Name, Owner',
+      );
+    });
+
+    it('zh serves Chinese, NOT the hook default (the pre-fix behaviour)', () => {
+      const { result } = renderHook(() => useWizardTranslation(), { wrapper: wrapperFor('zh') });
+      const value = result.current.t('wizard.missingRequired', { fields: 'Name, Owner' });
+      expect(value).toBe('请填写以下必填字段：Name, Owner');
+      expect(value).not.toContain('Please complete');
+    });
+  });
+
+  describe("RecordActivityTimeline's binding — testKey resolves, so i18next wins", () => {
+    // `createSafeTranslation(DETAIL_DEFAULT_TRANSLATIONS, 'detail.back')`.
+    // `detail.back` HAS always been in the packs, so the probe succeeded, the
+    // defaults map was bypassed wholesale, and `detail.viewSource` — present
+    // in the map, absent from every pack — reached the user as a raw key.
+    const useDetailish = createSafeTranslation(
+      { 'detail.back': 'Back', 'detail.viewSource': 'View source' },
+      'detail.back',
+    );
+
+    it.each(['en', 'zh'])('%s resolves detail.viewSource from the pack', (lang) => {
+      const { result } = renderHook(() => useDetailish(), { wrapper: wrapperFor(lang) });
+      const value = result.current.t('detail.viewSource');
+      expect(value, `${lang} rendered the raw key`).not.toBe('detail.viewSource');
+      expect(value).toBe(at(builtInLocales[lang], 'detail.viewSource'));
+    });
+
+    it('zh is Chinese', () => {
+      const { result } = renderHook(() => useDetailish(), { wrapper: wrapperFor('zh') });
+      expect(result.current.t('detail.viewSource')).toBe('查看来源');
+    });
+  });
+
+  describe("GanttView's binding — per-key fallback, so English always rendered", () => {
+    // `useGanttTranslation` deliberately avoids `createSafeTranslation` and
+    // falls back per key, so `gantt.toolbar.refresh` rendered "Refresh", not
+    // the raw key — the aria-label was in English, never a key. The defect at
+    // this site is that ten languages could not translate it.
+    const perKey = (hostT: (k: string) => string, defaults: Record<string, string>) =>
+      (key: string) => {
+        const hostValue = hostT(key);
+        return typeof hostValue === 'string' && hostValue !== key ? hostValue : defaults[key] || key;
+      };
+
+    it.each(['en', 'zh'])('%s resolves the refresh aria-label from the pack', (lang) => {
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor(lang) });
+      const t = perKey(result.current.t, { 'gantt.toolbar.refresh': 'Refresh' });
+      expect(t('gantt.toolbar.refresh')).toBe(at(builtInLocales[lang], 'gantt.toolbar.refresh'));
+    });
+
+    it('zh reaches the pack instead of stopping at the bundled English default', () => {
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor('zh') });
+      // Pre-fix this returned 'Refresh': the pack missed the key, so the
+      // per-key fallback served the English default under a zh provider.
+      expect(result.current.t('gantt.toolbar.refresh')).toBe('刷新');
+    });
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -689,6 +689,7 @@ const ar = {
       exportPng: "تصدير بصيغة PNG",
       exportPdf: "تصدير PDF",
       saveLayout: "حفظ التخطيط",
+      refresh: "تحديث",
       undo: "تراجع",
       redo: "إعادة",
       prevPeriod: "الفترة السابقة",
@@ -846,6 +847,7 @@ const ar = {
     loadMore: "تحميل المزيد",
     edited: "(معدل)",
     via: "عبر {{source}}",
+    viewSource: "عرض المصدر",
     replyCount: "{{count}} رد",
     replyCountPlural: "{{count}} ردود",
     replyPlaceholder: "رد…",
@@ -1526,6 +1528,8 @@ const ar = {
       viewNameRequired: "أدخل مفتاحًا (أحرف إنجليزية صغيرة وأرقام وشرطة سفلية). لا يُملأ تلقائيًا للعناوين غير اللاتينية.",
       viewNameInvalid: "استخدم أحرفًا إنجليزية صغيرة وأرقامًا وشرطات سفلية؛ وابدأ بحرف أو شرطة سفلية.",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "هذا عرض مدمج معرَّف في الكود — لا يمكن تعديله.",
+      cannotDeleteMetaView: "هذا عرض مدمج معرَّف في الكود — لا يمكن حذفه.",
       expandToPage: 'Open as full page',
       objectNotFound: "الكائن غير موجود",
       objectNotFoundDescription: "الكائن \"{{objectName}}\" غير موجود في الإعدادات الحالية.",
@@ -3088,6 +3092,9 @@ const ar = {
     statusActive: "نشط",
     statusIdle: "خامل",
     statusAway: "غائب",
+  },
+  wizard: {
+    missingRequired: "يرجى إكمال الحقول المطلوبة: {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -689,6 +689,7 @@ const de = {
       exportPng: "Als PNG exportieren",
       exportPdf: "PDF exportieren",
       saveLayout: "Layout speichern",
+      refresh: "Aktualisieren",
       undo: "Rückgängig",
       redo: "Wiederholen",
       prevPeriod: "Vorherige Periode",
@@ -844,6 +845,7 @@ const de = {
     loadMore: "Mehr laden",
     edited: "(bearbeitet)",
     via: "über {{source}}",
+    viewSource: "Quelle anzeigen",
     replyCount: "{{count}} Antwort",
     replyCountPlural: "{{count}} Antworten",
     replyPlaceholder: "Antworten…",
@@ -1526,6 +1528,8 @@ const de = {
       viewNameRequired: "Geben Sie einen Schlüssel ein (Kleinbuchstaben, Ziffern, Unterstrich). Bei nicht-lateinischen Titeln wird er nicht automatisch gefüllt.",
       viewNameInvalid: "Verwenden Sie Kleinbuchstaben, Ziffern und Unterstriche; beginnen Sie mit einem Buchstaben oder Unterstrich.",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "Diese Ansicht ist integriert und im Code definiert – sie kann nicht geändert werden.",
+      cannotDeleteMetaView: "Diese Ansicht ist integriert und im Code definiert – sie kann nicht gelöscht werden.",
       expandToPage: 'Open as full page',
       objectNotFound: "Objekt nicht gefunden",
       objectNotFoundDescription: "Das Objekt „{{objectName}}\" existiert in der aktuellen Konfiguration nicht.",
@@ -3088,6 +3092,9 @@ const de = {
     statusActive: "aktiv",
     statusIdle: "inaktiv",
     statusAway: "abwesend",
+  },
+  wizard: {
+    missingRequired: "Bitte füllen Sie die Pflichtfelder aus: {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -664,6 +664,7 @@ const en = {
       exportPng: 'Export as PNG',
       exportPdf: 'Export PDF',
       saveLayout: 'Save layout',
+      refresh: 'Refresh',
       undo: 'Undo',
       redo: 'Redo',
     },
@@ -962,6 +963,7 @@ const en = {
     loadMore: 'Load more',
     edited: '(edited)',
     via: 'via {{source}}',
+    viewSource: 'View source',
     // Replies
     replyCount: '{{count}} reply',
     replyCountPlural: '{{count}} replies',
@@ -1754,6 +1756,11 @@ const en = {
       filterOrNotSavable: 'This filter uses OR between conditions, which a saved view cannot store yet. It still applies to this list — remove the OR grouping to save it to the view.',
       filterNestedNotSavable: 'This filter uses nested condition groups, which a saved view cannot store. Flatten it to a single list of conditions to save it to the view.',
       systemViewReadonly: 'System view defined in code — read-only.',
+      // ObjectView.tsx references ONE edit-denied key from four call sites
+      // (rename / pin / set-as-default / configure), so the copy has to cover
+      // any change to a built-in view rather than name one operation.
+      cannotEditMetaView: 'This view is built in and defined in code — it cannot be changed.',
+      cannotDeleteMetaView: 'This view is built in and defined in code — it cannot be deleted.',
       expandToPage: 'Open as full page',
       allRecords: 'All Records',
       exitDesignMode: 'Exit Design Mode',
@@ -3252,6 +3259,11 @@ const en = {
     statusActive: 'active',
     statusIdle: 'idle',
     statusAway: 'away',
+  },
+  // Multi-step form (plugin-form's WizardForm). `{{fields}}` is a
+  // comma-joined, already-truncated label list built at the call site.
+  wizard: {
+    missingRequired: 'Please complete the required fields: {{fields}}',
   },
 } as const;
 

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -694,6 +694,7 @@ const es = {
       exportPng: "Exportar como PNG",
       exportPdf: "Exportar PDF",
       saveLayout: "Guardar la disposición",
+      refresh: "Actualizar",
       undo: "Deshacer",
       redo: "Rehacer",
       prevPeriod: "Período anterior",
@@ -849,6 +850,7 @@ const es = {
     loadMore: "Cargar más",
     edited: "(editado)",
     via: "vía {{source}}",
+    viewSource: "Ver origen",
     replyCount: "{{count}} respuesta",
     replyCountPlural: "{{count}} respuestas",
     replyPlaceholder: "Responder…",
@@ -1531,6 +1533,8 @@ const es = {
       viewNameRequired: "Introduzca una clave (minúsculas, números, guion bajo). No se rellena automáticamente con títulos no latinos.",
       viewNameInvalid: "Use minúsculas, números y guiones bajos; empiece por una letra o un guion bajo.",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "Esta vista está integrada y definida en el código: no se puede modificar.",
+      cannotDeleteMetaView: "Esta vista está integrada y definida en el código: no se puede eliminar.",
       expandToPage: 'Open as full page',
       objectNotFound: "Objeto no encontrado",
       objectNotFoundDescription: "El objeto \"{{objectName}}\" no existe en la configuración actual.",
@@ -3093,6 +3097,9 @@ const es = {
     statusActive: "activo",
     statusIdle: "inactivo",
     statusAway: "ausente",
+  },
+  wizard: {
+    missingRequired: "Complete los campos obligatorios: {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -689,6 +689,7 @@ const fr = {
       exportPng: "Exporter en PNG",
       exportPdf: "Exporter en PDF",
       saveLayout: "Enregistrer la disposition",
+      refresh: "Actualiser",
       undo: "Annuler",
       redo: "Rétablir",
       prevPeriod: "Période précédente",
@@ -846,6 +847,7 @@ const fr = {
     loadMore: "Charger plus",
     edited: "(modifié)",
     via: "via {{source}}",
+    viewSource: "Voir la source",
     replyCount: "{{count}} réponse",
     replyCountPlural: "{{count}} réponses",
     replyPlaceholder: "Répondre…",
@@ -1526,6 +1528,8 @@ const fr = {
       viewNameRequired: "Saisissez une clé (minuscules, chiffres, tiret bas). Non remplie automatiquement pour les titres non latins.",
       viewNameInvalid: "Utilisez des minuscules, des chiffres et des tirets bas ; commencez par une lettre ou un tiret bas.",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "Cette vue est intégrée et définie dans le code — elle ne peut pas être modifiée.",
+      cannotDeleteMetaView: "Cette vue est intégrée et définie dans le code — elle ne peut pas être supprimée.",
       expandToPage: 'Open as full page',
       objectNotFound: "Objet introuvable",
       objectNotFoundDescription: "L'objet « {{objectName}} » n'existe pas dans la configuration actuelle.",
@@ -3088,6 +3092,9 @@ const fr = {
     statusActive: "actif",
     statusIdle: "inactif",
     statusAway: "absent",
+  },
+  wizard: {
+    missingRequired: "Veuillez renseigner les champs obligatoires : {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -689,6 +689,7 @@ const ja = {
       exportPng: "PNG で書き出す",
       exportPdf: "PDF で書き出す",
       saveLayout: "レイアウトを保存",
+      refresh: "更新",
       undo: "元に戻す",
       redo: "やり直す",
       prevPeriod: "前の期間",
@@ -855,6 +856,7 @@ const ja = {
     loadMore: "さらに読み込む",
     edited: "(編集済み)",
     via: "{{source}} 経由",
+    viewSource: "ソースを表示",
     replyCount: "{{count}} 件の返信",
     replyCountPlural: "{{count}} 件の返信",
     replyPlaceholder: "返信…",
@@ -1526,6 +1528,8 @@ const ja = {
       viewNameRequired: "キーを入力してください（英小文字、数字、アンダースコア）。ラテン文字以外のタイトルでは自動入力されません。",
       viewNameInvalid: "英小文字、数字、アンダースコアを使用し、先頭は文字かアンダースコアにしてください。",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "このビューはコードで定義された組み込みビューのため、変更できません。",
+      cannotDeleteMetaView: "このビューはコードで定義された組み込みビューのため、削除できません。",
       expandToPage: 'Open as full page',
       objectNotFound: "オブジェクトが見つかりません",
       objectNotFoundDescription: "オブジェクト「{{objectName}}」は現在の設定に存在しません。",
@@ -3088,6 +3092,9 @@ const ja = {
     statusActive: "アクティブ",
     statusIdle: "アイドル",
     statusAway: "離席中",
+  },
+  wizard: {
+    missingRequired: "必須項目を入力してください: {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -689,6 +689,7 @@ const ko = {
       exportPng: "PNG로 내보내기",
       exportPdf: "PDF로 내보내기",
       saveLayout: "레이아웃 저장",
+      refresh: "새로 고침",
       undo: "실행 취소",
       redo: "다시 실행",
       prevPeriod: "이전 기간",
@@ -844,6 +845,7 @@ const ko = {
     loadMore: "더 보기",
     edited: "(수정됨)",
     via: "{{source}} 통해",
+    viewSource: "원본 보기",
     replyCount: "답글 {{count}}개",
     replyCountPlural: "답글 {{count}}개",
     replyPlaceholder: "답글…",
@@ -1526,6 +1528,8 @@ const ko = {
       viewNameRequired: "키를 입력하세요(소문자, 숫자, 밑줄). 비라틴 문자 제목에서는 자동으로 채워지지 않습니다.",
       viewNameInvalid: "소문자, 숫자, 밑줄을 사용하고 문자 또는 밑줄로 시작하세요.",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "이 보기는 코드에 정의된 기본 제공 보기이므로 변경할 수 없습니다.",
+      cannotDeleteMetaView: "이 보기는 코드에 정의된 기본 제공 보기이므로 삭제할 수 없습니다.",
       expandToPage: 'Open as full page',
       objectNotFound: "객체를 찾을 수 없음",
       objectNotFoundDescription: "객체 \"{{objectName}}\"이(가) 현재 구성에 존재하지 않습니다.",
@@ -3088,6 +3092,9 @@ const ko = {
     statusActive: "활성",
     statusIdle: "유휴",
     statusAway: "자리 비움",
+  },
+  wizard: {
+    missingRequired: "필수 항목을 입력하세요: {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -689,6 +689,7 @@ const pt = {
       exportPng: "Exportar como PNG",
       exportPdf: "Exportar PDF",
       saveLayout: "Salvar o layout",
+      refresh: "Atualizar",
       undo: "Desfazer",
       redo: "Refazer",
       prevPeriod: "Período anterior",
@@ -846,6 +847,7 @@ const pt = {
     loadMore: "Carregar mais",
     edited: "(editado)",
     via: "via {{source}}",
+    viewSource: "Ver origem",
     replyCount: "{{count}} resposta",
     replyCountPlural: "{{count}} respostas",
     replyPlaceholder: "Responder…",
@@ -1526,6 +1528,8 @@ const pt = {
       viewNameRequired: "Informe uma chave (letras minúsculas, números, sublinhado). Não é preenchida automaticamente para títulos não latinos.",
       viewNameInvalid: "Use letras minúsculas, números e sublinhados; comece com uma letra ou sublinhado.",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "Esta exibição é integrada e definida no código — não é possível alterá-la.",
+      cannotDeleteMetaView: "Esta exibição é integrada e definida no código — não é possível excluí-la.",
       expandToPage: 'Open as full page',
       objectNotFound: "Objeto não encontrado",
       objectNotFoundDescription: "O objeto \"{{objectName}}\" não existe na configuração atual.",
@@ -3088,6 +3092,9 @@ const pt = {
     statusActive: "ativo",
     statusIdle: "inativo",
     statusAway: "ausente",
+  },
+  wizard: {
+    missingRequired: "Preencha os campos obrigatórios: {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -689,6 +689,7 @@ const ru = {
       exportPng: "Экспортировать в PNG",
       exportPdf: "Экспортировать в PDF",
       saveLayout: "Сохранить компоновку",
+      refresh: "Обновить",
       undo: "Отменить",
       redo: "Повторить",
       prevPeriod: "Предыдущий период",
@@ -857,6 +858,7 @@ const ru = {
     loadMore: "Загрузить ещё",
     edited: "(изменено)",
     via: "через {{source}}",
+    viewSource: "Показать источник",
     replyCount: "{{count}} ответ",
     replyCountPlural: "{{count}} ответов",
     replyPlaceholder: "Ответить…",
@@ -1526,6 +1528,8 @@ const ru = {
       viewNameRequired: "Введите ключ (строчные буквы, цифры, подчёркивание). Для нелатинских заголовков автозаполнение не работает.",
       viewNameInvalid: "Используйте строчные латинские буквы, цифры и подчёркивания; начните с буквы или подчёркивания.",
       systemViewReadonly: 'System view defined in code - duplicate to customize.',
+      cannotEditMetaView: "Это встроенное представление, определённое в коде, — изменить его нельзя.",
+      cannotDeleteMetaView: "Это встроенное представление, определённое в коде, — удалить его нельзя.",
       expandToPage: 'Open as full page',
       objectNotFound: "Объект не найден",
       objectNotFoundDescription: "Объект «{{objectName}}» не существует в текущей конфигурации.",
@@ -3088,6 +3092,9 @@ const ru = {
     statusActive: "активен",
     statusIdle: "бездействует",
     statusAway: "отошёл",
+  },
+  wizard: {
+    missingRequired: "Заполните обязательные поля: {{fields}}",
   },
 };
 

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -642,6 +642,7 @@ const zh = {
       exportPng: '导出 PNG',
       exportPdf: '导出 PDF',
       saveLayout: '保存布局',
+      refresh: '刷新',
       undo: '撤销',
       redo: '重做',
     },
@@ -928,6 +929,7 @@ const zh = {
     loadMore: '加载更多',
     edited: '(已编辑)',
     via: '通过 {{source}}',
+    viewSource: '查看来源',
     // Replies
     replyCount: '{{count}} 条回复',
     replyCountPlural: '{{count}} 条回复',
@@ -1702,6 +1704,8 @@ const zh = {
     },
     objectView: {
       systemViewReadonly: '系统视图由代码定义，只读。',
+      cannotEditMetaView: '该视图为内置视图，由代码定义，无法修改。',
+      cannotDeleteMetaView: '该视图为内置视图，由代码定义，无法删除。',
       expandToPage: '以完整页面打开',
       objectNotFound: '未找到对象',
       objectNotFoundDescription: '对象"{{objectName}}"在当前配置中不存在。',
@@ -3142,6 +3146,9 @@ const zh = {
     statusActive: '活跃',
     statusIdle: '空闲',
     statusAway: '离开',
+  },
+  wizard: {
+    missingRequired: '请填写以下必填字段：{{fields}}',
   },
 } as const;
 

--- a/packages/plugin-detail/src/__tests__/useDetailTranslation.viewSource.i18n.test.tsx
+++ b/packages/plugin-detail/src/__tests__/useDetailTranslation.viewSource.i18n.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * `detail.viewSource` — the activity-timeline "drill to source" link — resolves
+ * from the locale packs with a provider mounted (objectui#3546).
+ *
+ * ## Why this site really did render a raw key
+ *
+ * `useDetailTranslation` is `createSafeTranslation(DETAIL_DEFAULT_TRANSLATIONS,
+ * 'detail.back')`. That factory probes exactly ONE key: if `detail.back`
+ * resolves, it hands the caller i18next's `t` for **every** key and the
+ * defaults map is bypassed wholesale. `detail.back` has always been in the
+ * packs, so in the real console the probe succeeded — and `detail.viewSource`,
+ * present in the map but in none of the ten packs, reached the user verbatim
+ * as `detail.viewSource`.
+ *
+ * That is why the test mounts a provider. Without one the probe fails, the
+ * defaults map serves "View source", and the assertion passes while the
+ * console is broken — the exact false-green #3546 was filed about.
+ *
+ * The real hook and the real defaults map are imported (rather than a local
+ * stand-in) so this also fails if the map and the `en` pack ever drift apart.
+ */
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { I18nProvider } from '@object-ui/i18n';
+import { useDetailTranslation, DETAIL_DEFAULT_TRANSLATIONS } from '../useDetailTranslation';
+
+const wrapperFor = (lang: string) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <I18nProvider config={{ defaultLanguage: lang, detectBrowserLanguage: false }}>
+        {children}
+      </I18nProvider>
+    );
+  };
+
+beforeEach(() => {
+  // The provider persists the last language (objectstack#5406).
+  window.localStorage.clear();
+});
+
+describe('detail.viewSource under a mounted I18nProvider (objectui#3546)', () => {
+  it('en resolves to English — never the raw key', () => {
+    const { result } = renderHook(() => useDetailTranslation(), { wrapper: wrapperFor('en') });
+    const value = result.current.t('detail.viewSource');
+    // Pre-fix this assertion failed with the literal string 'detail.viewSource'.
+    expect(value).not.toBe('detail.viewSource');
+    expect(value).toBe('View source');
+  });
+
+  it('zh resolves to Chinese', () => {
+    const { result } = renderHook(() => useDetailTranslation(), { wrapper: wrapperFor('zh') });
+    expect(result.current.t('detail.viewSource')).toBe('查看来源');
+  });
+
+  it("the probe key still resolves — otherwise this file tests the fallback, not the packs", () => {
+    // If `detail.back` ever leaves the packs, `createSafeTranslation` starts
+    // serving the defaults map for everything and the two cases above would go
+    // green for the wrong reason (the provider-less false-green this issue is
+    // about). Pin the precondition explicitly.
+    const { result } = renderHook(() => useDetailTranslation(), { wrapper: wrapperFor('zh') });
+    expect(result.current.t('detail.back')).not.toBe('detail.back');
+    expect(result.current.t('detail.back')).not.toBe(DETAIL_DEFAULT_TRANSLATIONS['detail.back']);
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.refreshAriaLabel.i18n.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.refreshAriaLabel.i18n.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * The Gantt toolbar's refresh button gets a LOCALIZED accessible name
+ * (objectui#3546).
+ *
+ * The button renders only an icon, so `aria-label` is the entire accessible
+ * name — a screen-reader user has nothing else to go on. `gantt.toolbar.refresh`
+ * was in `GANTT_DEFAULT_TRANSLATIONS` but in none of the ten packs.
+ *
+ * ## What was actually broken here, and why this test is `zh`-shaped
+ *
+ * #3546 filed this site as "screen-reader users hear the raw key". It does not
+ * reproduce, and the reason is in `useGanttTranslation`: it deliberately does
+ * NOT use `createSafeTranslation` (which probes one testKey and then serves
+ * defaults for everything) and instead falls back **per key**. A key the host
+ * misses therefore lands on the bundled English default, not on the raw key —
+ * so the pre-fix accessible name was "Refresh", in English, in all ten
+ * languages.
+ *
+ * That makes an `en` assertion useless as a regression guard: "Refresh" was
+ * the answer before the backfill and after it. The `zh` case is the one that
+ * was red before and green now, so it is the one that pins the fix. The `en`
+ * case is kept only to prove the button is reachable and labelled at all.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { I18nProvider } from '@object-ui/i18n';
+import { GanttView, type GanttTask } from './GanttView';
+import { GANTT_DEFAULT_TRANSLATIONS } from './useGanttTranslation';
+
+const TASKS = (): GanttTask[] => [
+  {
+    id: 'a',
+    title: 'Task A',
+    start: new Date('2024-06-03T00:00:00.000Z'),
+    end: new Date('2024-06-13T00:00:00.000Z'),
+    progress: 0,
+  },
+];
+
+function renderWithLocale(lang: string) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: lang, detectBrowserLanguage: false }}>
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={TASKS()}
+          startDate={new Date('2024-06-01T00:00:00.000Z')}
+          endDate={new Date('2024-12-30T00:00:00.000Z')}
+          onRefresh={vi.fn()}
+        />
+      </div>
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+  // The provider persists the last language (objectstack#5406); without this
+  // the `zh` case would leak into the `en` one.
+  window.localStorage.clear();
+});
+
+describe('Gantt refresh button accessible name (objectui#3546)', () => {
+  it('is labelled in English under an en provider — never the raw key', () => {
+    const { getByTestId } = renderWithLocale('en');
+    const label = getByTestId('gantt-refresh').getAttribute('aria-label');
+    expect(label).toBe('Refresh');
+    expect(label).not.toBe('gantt.toolbar.refresh');
+  });
+
+  it('is labelled in Chinese under a zh provider (the pre-fix failure)', () => {
+    const { getByTestId } = renderWithLocale('zh');
+    const label = getByTestId('gantt-refresh').getAttribute('aria-label');
+    // Before the pack backfill this read 'Refresh': every pack missed the key,
+    // so `useGanttTranslation`'s per-key fallback served the bundled English
+    // default to a Chinese session.
+    expect(label).toBe('刷新');
+    expect(label).not.toBe(GANTT_DEFAULT_TRANSLATIONS['gantt.toolbar.refresh']);
+  });
+});

--- a/scripts/i18n-call-site-key-baseline.json
+++ b/scripts/i18n-call-site-key-baseline.json
@@ -90,8 +90,6 @@
     "console.notFound.back": { "issue": "objectui#3546" },
     "console.notFound.description": { "issue": "objectui#3546" },
     "console.notFound.title": { "issue": "objectui#3546" },
-    "console.objectView.cannotDeleteMetaView": { "issue": "objectui#3546" },
-    "console.objectView.cannotEditMetaView": { "issue": "objectui#3546" },
     "console.shortcuts.groups.aiChat": { "issue": "objectui#3546" },
     "console.shortcuts.newChat": { "issue": "objectui#3546" },
     "console.shortcuts.toggleChatsList": { "issue": "objectui#3546" },
@@ -100,11 +98,9 @@
     "detail.concurrentUpdateRecordLabel": { "issue": "objectui#3546" },
     "detail.deleted": { "issue": "objectui#3546" },
     "detail.historyEmpty": { "issue": "objectui#3546" },
-    "detail.viewSource": { "issue": "objectui#3546" },
     "empty.appNotAvailable": { "issue": "objectui#3546" },
     "empty.appNotAvailableDescription": { "issue": "objectui#3546" },
     "empty.interfacePageSourceMissing": { "issue": "objectui#3546" },
-    "gantt.toolbar.refresh": { "issue": "objectui#3546" },
     "home.pendingDrafts.capabilityWarn": { "issue": "objectui#3546" },
     "home.pendingDrafts.nothing": { "issue": "objectui#3546" },
     "home.pendingDrafts.probeWarn": { "issue": "objectui#3546" },
@@ -266,7 +262,6 @@
     "preview.unpublishedBar.publishFailed": { "issue": "objectui#3546" },
     "preview.unpublishedBar.published": { "issue": "objectui#3546" },
     "preview.unpublishedBar.publishing": { "issue": "objectui#3546" },
-    "wizard.missingRequired": { "issue": "objectui#3546" },
     "workspace.multiOrgDisabled": { "issue": "objectui#3546" }
   },
 


### PR DESCRIPTION
Fixes-part-of #3546

#3546 切片一。#3547 的守卫量出 258 个 `t()` 引用但十个包都没有的 key,本切片只处理其中**没有可用内联兜底**的 8 处调用点(工单正文标出的那一批),背后是 5 个 key。其余 250 个按命名空间的批次串行开,本 PR 不碰。

⛔ 没有新增任何 `defaultValue` —— 那正是让 258 个 key 藏了几个月的机制,工单明令禁止。

## ⚠️ 前置核实推翻了工单对其中 2 处的定性

按"工单是线索不是规格"的要求,动手前在 `origin/main` 上逐点实测了这 8 处**挂载 provider 后**的真实渲染值。结论是 **8 处里只有 6 处真的把 raw key 给了用户**,另外 2 处的兜底本来就是生效的:

| 调用点 | 绑定 | 修复前实测(挂 provider) | 工单说法 | 判定 |
|---|---|---|---|---|
| `ObjectView.tsx` ×5 | `useObjectTranslation()` 裸用 | `"console.objectView.cannotEditMetaView"` | raw key | ✅ 成立 |
| `RecordActivityTimeline.tsx` | `createSafeTranslation(…, 'detail.back')` | `"detail.viewSource"` | raw key | ✅ 成立 |
| `WizardForm.tsx` | `createSafeTranslation(…, 'wizard.missingRequired')` | `"Please complete the required fields: A, B"` | raw key | ❌ **不成立** |
| `GanttView.tsx` | `useGanttTranslation()` | `"Refresh"` | raw key,读屏用户听到 key | ❌ **不成立** |

两处不成立的原因各不相同,都在代码里写着:

- **WizardForm** 的 `testKey` 就是缺失的那个 key 本身。`createSafeTranslation` 的探针因此**正确地**判定"翻译未配置",交出 `fallbackT`,英文默认值照常渲染。
- **GanttView** 走的 `useGanttTranslation` **刻意不用** `createSafeTranslation` —— 它逐 key 兜底,源码注释明写理由(宿主字典常常译了通用 key、落下新 key,单 key 探针处理不了半译字典)。所以 host 未命中时落到 `GANTT_DEFAULT_TRANSLATIONS`,`aria-label` 是英文 `Refresh`,不是 key。工单把 `createSafeTranslation` 的语义安在了一个明确规避它的钩子上。

这 2 处仍然是缺陷,只是属于**较轻的 #3517 类**(英文照常渲染,十种语言译不了),不是"用户今天看得见裸 key"。分诊评论把 aria-label 那处当作"反对自己定级的最强论据",而它恰恰是被推翻的两处之一 —— 定级请据此重估。**修法不变**(5 个 key 一样要补),变的只是严重度。

## 改了什么

**1. 五个 key 回填十包**(`console.objectView.cannotEditMetaView` / `cannotDeleteMetaView`、`detail.viewSource`、`gantt.toolbar.refresh`、`wizard.missingRequired`)。

九包逐条按邻键的语气/词汇/标点惯例写,不是照抄:fr 用法语冒号前空格(`obligatoires : {{fields}}`,与邻键 `missingRequiredHint` 一致)、de 用该包惯用的 `–`、es 用冒号代破折号(该包 `filterOrNotSavable` 就是这么写的)、pt 沿用 `exibição`(与 `deleteViewTitle` 一致)、ko 用 `보기`、ru 保留 ё 正字法(`определённое`)、ar 占位符置尾、zh 全角标点且中英文间不加空格。

`detail.viewSource` / `gantt.toolbar.refresh` / `wizard.missingRequired` 的英文与各自组件 defaults map 里的字符串**逐字一致**,避免 provider 路径与无 provider 路径分叉。

**2. 删掉 ObjectView 五处死兜底。** 这五个 `|| '英文'` **在 key 缺失时也永远不触发** —— i18next 未命中返回 key 本身,是非空字符串,`||` 不会落下去。它们不是"兜底失效",是从写下那天起就不可达的代码。

一个额外事实值得记录:这**一个** key 服务四个调用点(重命名 / 置顶 / 设为默认 / 配置),四处死兜底写的是四句不同的英文。既然它们从未渲染过,本 PR 把包文案写成覆盖"对内置视图的任何修改"的一句,而不是挑其中一句。若维护者希望四种操作各有文案,那是拆 key 的独立改动。

**3. 棘轮基线精确减 5 条**,`missingKeys` 258 → 253,`missingPrefixes` 4 条未动(那 4 个整族缺失前缀属于后续切片)。

## 验证(方向都是跑之前先预测的)

**守卫** `node scripts/check-i18n-call-site-keys.mjs`:

| 指标 | 预测 | 实测 |
|---|---|---|
| 退出码 | 0 | 0 |
| 可解析调用点 | 2043 → 2051(+8) | 2043 → **2051** |
| en 包 key 数 | 2641 → 2646(+5) | 2641 → **2646** |
| 基线 `missingKeys` | 258 → 253(−5) | 258 → **253** |

**逆向验证 A —— 中间态(只补 en,九包回退)**,两个预测都精确命中:

- 平价测试对九个语言各报 `is missing 5 key(s)`,列出的正是本切片这 5 个;
- 棘轮**同时**转红,理由是"条目已修好却还留着":
  ```
  5 baseline entries are stale — the defect is gone, so the entry must go too
    missingKeys: console.objectView.cannotDeleteMetaView
    ...
  EXIT=1
  ```
  这正是棘轮该有的行为 —— 只补 en 不补包、或补完不删条目,都拦得住。

**逆向验证 B —— 新增的 zh 断言真的有鉴别力。** 从 zh 包单独摘掉 `gantt.toolbar.refresh` 后重跑新测:
```
× is labelled in Chinese under a zh provider (the pre-fix failure)
AssertionError: expected 'Refresh' to be '刷新'
```
红的方式本身就是上面那张表的直接证据:修复前 zh 会话拿到的是**英文默认值**,不是 raw key。同一文件的 en 用例保持绿 —— 这也说明**光靠 en 断言等于没断言**(那两处修复前后的 en 输出完全相同),真正钉住修复的是 zh 那半边。

**测试(仓库根 vitest)**

```
packages/i18n                                   23 files / 284 tests  ✅
packages/plugin-gantt + plugin-detail + plugin-form  124 files / 1124 tests  ✅
packages/app-shell                             285 files / 2492 passed, 1 skipped  ✅
```

`turbo run type-check`(i18n / app-shell / plugin-detail / plugin-gantt / plugin-form):**33 successful, 33 total**。
`pnpm check:control-bytes` ✅、`pnpm changeset:check` ✅。

## 新增测试为什么都挂 provider

工单记录的陷阱就是这个:不挂 provider 时 defaults map 会把这几个 key 全部答对,断言全绿而控制台是坏的。三个新文件都在 `I18nProvider` 下跑,并且都用**各调用点真实的绑定形态**:

- `packages/i18n/src/__tests__/raw-key-call-sites-3546.test.tsx` —— 5 个 key × 十包完整性 + en/zh 经三种真实绑定解析;含一条"九包不得与 en 逐字相同"的断言(防止回填时把英文复制九份:那样键平价全绿而九种语言仍是英文,现有门禁看不见)。ObjectView 的绑定就是裸 `useObjectTranslation`,中间没有任何一层,所以在绑定层断言是忠实的 —— 不必为读一句 toast 文案去渲染整个 ObjectView。
- `packages/plugin-gantt/src/GanttView.refreshAriaLabel.i18n.test.tsx` —— DOM 级,真渲染 `GanttView`,直接读刷新按钮的 `aria-label`(该按钮只有图标,`aria-label` 就是它的全部可访问名)。
- `packages/plugin-detail/src/__tests__/useDetailTranslation.viewSource.i18n.test.tsx` —— 用**真实**的 `useDetailTranslation` 与真实 defaults map,顺带能发现 map 与 en 包漂移;并显式钉住"探针 key `detail.back` 仍可解析"这个前提,否则上面两条会以错误的理由变绿。

## 顺带发现,未在本 PR 修改

已另立 **#3582**(未认领、未打标签,交分诊):`console.objectView` 的 `systemViewReadonly` 与 `expandToPage` 两个 key 在八个包里存的是英文原文,且前者存的还是一句 `en` 自己已经不用的**过期**文案(包里是 "duplicate to customize",en 现在是 "read-only")。键平价、#3547 守卫、棘轮三道全绿 —— 因为没有任何一道断言"包里的值是不是该语言"。与 #3546 的 258 个不同类(那是十包都没有 key,这是十包都有 key 但值是英文),故单独立单。

## 文件面

严格限定在切片一:4 个组件文件里只动了那 8 个调用点及其死兜底(实际只有 ObjectView 需要改代码,另外 3 处无死兜底构造)、十个语言包只加本切片的 5 个 key、基线只删 5 条。其余 250 个 key 的条目一条未动。已核实与 #3518 / #3548 零文件相交(两者均已合并且早于本分支起点)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_