### PR TITLE
fix(runner): 站内导航保留 query string,`?api=` 不再被抹掉

### DIFF
--- a/.changeset/runner-preserve-query-on-navigate.md
+++ b/.changeset/runner-preserve-query-on-navigate.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/runner': patch
+---
+
+Runner in-app navigation now carries the current query string across to the pushed URL instead of `pushState`-ing a bare path. Opening the Runner with `?api=<base>` and clicking a sidebar entry no longer drops the parameter from the address bar, so reloading or sharing the resulting URL still reaches the same backend rather than silently falling back to the (normally empty) `LocalBundleLoader` and rendering `Page not found`. The whole query string is preserved, not just `api` — `@object-ui/core`'s `?__debug…` flags survive navigation for the same reason. A navigation target that spells out its own query keeps it and wins on collision, with the remaining current parameters merged in behind it (#3578).

--- a/content/docs/utilities/runner.mdx
+++ b/content/docs/utilities/runner.mdx
@@ -134,11 +134,15 @@ browser path plus `.json`, with `/` rewritten to `/index` first.
   into `null`. The Runner then shows `Page not found: <path>` for a page, and for a
   failed `app.json` it drops the app chrome (header/sidebar) and renders the page on
   its own. The HTTP status never reaches the UI — read it from the Network tab.
-- **Read once, at mount.** The parameter is captured in a `useMemo` with an empty
-  dependency list. In-app navigation calls `history.pushState` with the bare path, so
-  the address bar loses `?api=…` after the first click; the loader already created
-  keeps serving that session, but reloading or sharing the resulting URL falls back to
-  the local bundle.
+- **Read once, at mount — and it survives navigation.** The parameter is captured in
+  a `useMemo` with an empty dependency list, so editing `?api=…` in the address bar
+  does nothing to the running session until you reload. In-app navigation pushes the
+  target path with the current query string carried over, so `?api=…` stays in the
+  address bar after a sidebar click, and reloading or sharing that URL reaches the
+  same backend. The whole query string rides along, not just `api` — that also keeps
+  `@object-ui/core`'s `?__debug…` flags alive across navigation. A navigation target
+  that spells out its own query keeps it and wins on collision; the remaining current
+  parameters are merged in behind it.
 - `NetworkLoader`'s own default base is `/api` (`constructor(baseUrl: string = '/api')`).
   That default only applies when the class is constructed directly in code — the
   Runner always passes it the query-parameter value.

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -88,8 +88,10 @@ Without the parameter, `LocalBundleLoader` resolves `src/app-data/app.json` and
 git-ignored and absent from a fresh checkout, so every load returns `null` until you
 copy or symlink your own metadata directory into it.
 
-Full details — route resolution order, error handling, and the caveat that in-app
-navigation drops `?api=` from the address bar — are in the
+In-app navigation carries the query string across, so `?api=…` stays in the address
+bar and the URL you copy or reload reaches the same backend.
+
+Full details — route resolution order and error handling — are in the
 [Metadata Loading](https://www.objectui.org/docs/utilities/runner#metadata-loading)
 section of the docs.
 

--- a/packages/runner/src/App.navigation.test.tsx
+++ b/packages/runner/src/App.navigation.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * In-app navigation must carry the URL's query string with it (objectui#3578).
+ *
+ * The Runner keeps two families of settings in the query string, and both are
+ * addressable state under ADR-0054 C3 (shared, and expected back after a
+ * reload):
+ *
+ * - `?api=<base>` — the metadata API base, read once at mount by `App.tsx`'s
+ *   loader `useMemo`.
+ * - `?__debug`, `?__debug_schema`, … — `@object-ui/core`'s debug flags, read
+ *   from `window.location.search` by `parseDebugFlags` / `useDebugMode` in the
+ *   tree the Runner renders.
+ *
+ * `handleNavigate` used to `pushState` a bare path, which dropped every one of
+ * them from the address bar on the first sidebar click. The already-memoised
+ * loader kept serving that session, so the loss was invisible until F5 (or a
+ * colleague opening the copied URL) fell back to the empty `LocalBundleLoader`
+ * and rendered `Page not found`.
+ *
+ * These assertions drive the real component so they are meaningful against the
+ * unmodified source — see the PR body for the recorded red run.
+ *
+ * The metadata loader is stubbed because `src/app-data/` is git-ignored and
+ * absent from a fresh checkout: `loadAppConfig` returns an app document with a
+ * sidebar menu (the reported repro path), and `loadPage` returns `null` so the
+ * main area falls to the built-in 404 block instead of the ComponentRegistry
+ * (which would make this a `dom-heavy` test for no added coverage).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('./lib/MetadataLoader', () => {
+  const APP_CONFIG = {
+    name: 'runner_demo_app',
+    title: 'Runner Demo',
+    layout: 'sidebar',
+    menu: [
+      { label: 'Customers', path: '/customers' },
+      // A nav target that declares its own query. No metadata in this repo
+      // spells one today, but plain concatenation would turn it into the
+      // malformed `/orders?tab=open?api=…`, so the merge branch is pinned.
+      { label: 'Open orders', path: '/orders?tab=open' },
+    ],
+  };
+  class StubLoader {
+    async loadAppConfig() {
+      return APP_CONFIG;
+    }
+    async loadPage() {
+      return null;
+    }
+  }
+  return { LocalBundleLoader: StubLoader, NetworkLoader: StubLoader };
+});
+
+// Static, module-scope import: `App.tsx` pulls in `@object-ui/components` and
+// the two plugin packages for their registration side effects, and that cost
+// must not land inside a test's timeout budget (AGENTS.md §测试纪律).
+import RunnerApp from './App';
+
+const API_BASE = 'https://backend.example.com/api';
+
+/** Click a sidebar entry and return the URL string handed to `pushState`. */
+async function navigateVia(label: string): Promise<string> {
+  const pushState = vi.spyOn(window.history, 'pushState');
+  try {
+    const link = await screen.findByRole('link', { name: label });
+    // `act` around the click so the page reload the navigation kicks off
+    // settles inside it, instead of updating state after the test returns.
+    await act(async () => {
+      fireEvent.click(link);
+    });
+    expect(pushState).toHaveBeenCalledTimes(1);
+    return String(pushState.mock.calls[0][2]);
+  } finally {
+    pushState.mockRestore();
+  }
+}
+
+describe('RunnerApp in-app navigation', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('carries `?api=` across a sidebar navigation so reload and share still work', async () => {
+    window.history.replaceState({}, '', `/?api=${API_BASE}`);
+
+    render(<RunnerApp />);
+    const pushed = await navigateVia('Customers');
+
+    expect(pushed).toBe(`/customers?api=${API_BASE}`);
+    expect(window.location.pathname).toBe('/customers');
+    // What a reload would read back.
+    expect(new URLSearchParams(window.location.search).get('api')).toBe(API_BASE);
+  });
+
+  it('carries the WHOLE query string, not just `api`', async () => {
+    // `__debug_schema` is `@object-ui/core`'s debug flag (parseDebugFlags), the
+    // Runner's second query-string consumer.
+    window.history.replaceState({}, '', `/?api=${API_BASE}&__debug_schema=&lang=de`);
+
+    render(<RunnerApp />);
+    const pushed = await navigateVia('Customers');
+
+    expect(pushed).toBe(`/customers?api=${API_BASE}&__debug_schema=&lang=de`);
+  });
+
+  it('appends no stray `?` when the URL has no query string', async () => {
+    window.history.replaceState({}, '', '/');
+
+    render(<RunnerApp />);
+    const pushed = await navigateVia('Customers');
+
+    expect(pushed).toBe('/customers');
+    expect(pushed).not.toContain('?');
+    expect(window.location.search).toBe('');
+  });
+
+  it('merges into a target that declares its own query instead of concatenating', async () => {
+    window.history.replaceState({}, '', `/?api=${API_BASE}`);
+
+    render(<RunnerApp />);
+    const pushed = await navigateVia('Open orders');
+
+    // The target's own `tab` is kept and the preserved `api` is merged in
+    // behind it. This branch rebuilds the query through `URLSearchParams`, so
+    // the value comes out canonically percent-encoded rather than verbatim —
+    // a different spelling of the same parameter, not a different parameter.
+    expect(pushed).toBe('/orders?tab=open&api=https%3A%2F%2Fbackend.example.com%2Fapi');
+    expect(new URLSearchParams(window.location.search).get('api')).toBe(API_BASE);
+    // Never the malformed shape a bare `to + location.search` would produce.
+    expect(pushed.match(/\?/g)).toHaveLength(1);
+  });
+});

--- a/packages/runner/src/App.tsx
+++ b/packages/runner/src/App.tsx
@@ -19,6 +19,50 @@ import { LayoutRenderer } from './LayoutRenderer';
 import { LocalBundleLoader, NetworkLoader, MetadataLoader } from './lib/MetadataLoader';
 
 /**
+ * Build the URL an in-app navigation to `to` should push, carrying the query
+ * string that is currently in the address bar along with it (objectui#3578).
+ *
+ * The Runner keeps addressable state (ADR-0054 C3) in the query string, and
+ * more than one kind of it: `?api=<base>` selects the metadata loader below,
+ * and `@object-ui/core`'s `?__debug…` flags are read straight off
+ * `window.location.search` by the tree this app renders. Preserving the whole
+ * string rather than re-emitting a single known parameter keeps both working —
+ * and keeps working for whatever else starts reading the query later.
+ *
+ * `to` normally is a bare path from the app's navigation metadata, in which
+ * case the current query string is carried over verbatim (no re-encoding, so
+ * the address bar keeps exactly what the user typed). A target that declares
+ * its own query keeps it and wins on collision; the remaining current
+ * parameters are merged in behind it, so the result is never the malformed
+ * `path?a=1?b=2` that plain concatenation would produce. That merge rebuilds
+ * the query through `URLSearchParams`, so values come out canonically
+ * percent-encoded — the same parameters, spelled the standard way.
+ */
+function withPreservedQuery(to: string, currentSearch: string): string {
+  if (!currentSearch || currentSearch === '?') return to;
+
+  const hashIndex = to.indexOf('#');
+  const hash = hashIndex === -1 ? '' : to.slice(hashIndex);
+  const pathAndQuery = hashIndex === -1 ? to : to.slice(0, hashIndex);
+  const queryIndex = pathAndQuery.indexOf('?');
+
+  if (queryIndex === -1) {
+    const search = currentSearch.startsWith('?') ? currentSearch : `?${currentSearch}`;
+    return `${pathAndQuery}${search}${hash}`;
+  }
+
+  const merged = new URLSearchParams(pathAndQuery.slice(queryIndex + 1));
+  // Snapshot the target's own keys first: appending while testing `merged.has`
+  // would swallow the second value of a repeated preserved parameter.
+  const ownKeys = new Set(merged.keys());
+  for (const [key, value] of new URLSearchParams(currentSearch)) {
+    if (!ownKeys.has(key)) merged.append(key, value);
+  }
+  const search = merged.toString();
+  return `${pathAndQuery.slice(0, queryIndex)}${search ? `?${search}` : ''}${hash}`;
+}
+
+/**
  * Root component of the standalone SDUI runner: loads an app config plus the
  * page for the current path and hands both to `<SchemaRenderer>`.
  *
@@ -71,7 +115,9 @@ export default function RunnerApp() {
 
   // --- 2. Route Handling ---
   const handleNavigate = useCallback((to: string) => {
-    window.history.pushState({}, '', to);
+    // The route is `to`; the query string rides along so that reloading or
+    // sharing the resulting URL still resolves the same backend (#3578).
+    window.history.pushState({}, '', withPreservedQuery(to, window.location.search));
     setCurrentPath(to);
     window.scrollTo(0, 0);
   }, []);

--- a/packages/runner/tsconfig.test.json
+++ b/packages/runner/tsconfig.test.json
@@ -12,7 +12,12 @@
     // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` and
     // `@objectstack/spec` resolve through the workspace dependency's built
     // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
-    "paths": {}
+    "paths": {},
+    // Same ambient types as `tsconfig.json`. A test that imports `App.tsx`
+    // pulls `lib/MetadataLoader.ts` into this program, and that file calls
+    // `import.meta.glob` — declared by `vite/client`, which the root config
+    // this extends does not carry (it is not a Vite app).
+    "types": ["vite/client"]
   },
   "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Fixes #3578

## 问题

`packages/runner/src/App.tsx` 的 `handleNavigate` 原先是 `window.history.pushState({}, '', to)` —— `to` 是侧栏导航项给的**裸路径**,于是地址栏上的 query string 在第一次点击后就没了。

loader 被 `useMemo(..., [])` memo 住,所以**当前会话**看起来一切正常;真正的代价在会话之外:

- **F5** → `params.get('api')` 读到 null → 退回 `LocalBundleLoader`,而 `src/app-data/` 在正常安装里是空的(gitignore),于是页面变成 `Page not found`。
- **复制地址栏分享** → 对方拿到的是不带后端的 URL。

而且失败现场不指认根因:没有任何提示说「API 基址丢了」,控制台只打印 `📦 Using Local Bundle Loader`。

## 裁定与做法

按 ADR-0054 C3「可寻址状态放 URL」——「当前指向哪个后端」是典型的可寻址状态(会被分享、刷新后期待还在)——采用方向 1:**导航时把当前 query string 一并带走**。

### 保留整个 query,还是只保留 `api`?先量了再定

| 参数 | 谁读的 | file:line |
| --- | --- | --- |
| `api` | runner 自己 | `packages/runner/src/App.tsx:45-46`(`git grep` 在 `packages/runner/src` 下的**唯一**一处 query 读取) |
| `__debug` / `__debug_schema` / `__debug_perf` / `__debug_data` / `__debug_expr` / `__debug_events` / `__debug_registry` | runner **渲染的树**里的依赖包 | `packages/core/src/utils/debug.ts:39-50`(`parseDebugFlags`)、`packages/core/src/utils/debug.ts:86`(`isDebugEnabled`)、`packages/react/src/hooks/useDebugMode.ts:51` |

所以 `api` **不是**今天唯一有语义的参数 —— runner 依赖 `@object-ui/react` / `@object-ui/core`,那套 debug 开关同样直接读 `window.location.search`,同样被裸路径 pushState 抹掉。**只搬 `api` 会把第二类参数留在原地继续丢**,是同一种静默丢失,只是爆炸半径小一点。故保留**整个** query string —— 也最少惊讶,并且以后谁再开始读 query 都自动受益。

### 改在哪

只改 `handleNavigate` 一处。读取侧**经测量无需改动**:`currentPath` 的初值(`App.tsx:39`)和 popstate handler(`App.tsx:80`)都只读 `location.pathname`,不受 query 影响;loader 的 `useMemo` 依旧是挂载时读一次 —— 本 PR 修的正是「刷新时它还能读到」。

新增的 `withPreservedQuery(to, currentSearch)`:

- 常见情形(`to` 是裸路径):把当前 query string **原样**接上,不做重编码,地址栏保持用户输入的样子。
- 无 query 时:原样返回 `to`,**不会**多出一个空的 `?`。
- `to` 自带 query:它自己的参数保留且同名优先,其余当前参数并在其后 —— 绝不拼出 `path?a=1?b=2` 这种畸形 URL(这条分支会经 `URLSearchParams` 重建,值按标准做百分号编码,是同一批参数的规范拼法)。

## 测试

新增 `packages/runner/src/App.navigation.test.tsx`,4 条,**驱动真实组件**(stub 掉 loader,因为 `src/app-data/` 是 gitignore 的),所以对未修改的源码也有意义。

**反向验证(先预测方向,再跑)**:预测 3 红 1 绿 —— 三条「保留」断言在旧代码下必红,而「无 query 时不多加 `?`」那条在旧代码下必**绿**(裸路径天然满足它),它防的是新逻辑过度施加,不是回归探测器。在**未修改**的 `App.tsx` 上实跑,与预测完全一致:

```
 ❯ |dom| packages/runner/src/App.navigation.test.tsx (4 tests | 3 failed)
     × carries `?api=` across a sidebar navigation …
        Expected: "/customers?api=https://backend.example.com/api"
        Received: "/customers"
     × carries the WHOLE query string, not just `api` …
     × merges into a target that declares its own query …
        Expected: "/orders?tab=open&api=…"   Received: "/orders?tab=open"
  Tests  3 failed | 1 passed (4)
```

改完后全绿:

```
$ pnpm exec vitest run packages/runner --maxWorkers=2
 Test Files  3 passed (3)
      Tests  13 passed (13)

$ pnpm --workspace-concurrency=2 --filter '@object-ui/runner' type-check
> tsc --noEmit && tsc -p tsconfig.test.json
(exit 0)

$ pnpm --workspace-concurrency=2 --filter '@object-ui/runner' lint
✖ 23 problems (0 errors, 23 warnings)   # 全部既有;App.tsx 那条 React Compiler 警告是原有的 `useMemo`,只是行号被上移的 helper 顶下去了

$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3631 tracked text file(s); skipped 85 binary)
```

## 文档同步

PR #3581 本小时刚把这个行为如实写成注意事项;修复落地后那段话就变成在描述一个**已修复的缺陷**,故一并改掉:

- `content/docs/utilities/runner.mdx` —— 「Read once, at mount」那条 caveat 重写为新行为(query 跟着走、刷新/分享可用;整串 query 而不只是 `api`;目标自带 query 时的合并规则)。「挂载时读一次」这半句仍然属实(不刷新地改地址栏不生效),予以保留。
- `packages/runner/README.md:91-92` —— 同一句缺陷描述在包 README 里还有一份(「the caveat that in-app navigation drops `?api=` from the address bar」),同步改掉。**这一处超出了派单的文件面**(派单只点了 mdx),但它和 mdx 那句是同一个事实的两份拷贝,留着就是在同一个 PR 里发布一句已知为假的话。请 review 时确认;要退回随时可以只 revert 这两行。

## 越界说明

`packages/runner/tsconfig.test.json` 加了一行 `"types": ["vite/client"]`。原因不是顺手清理:新测试是 runner 第一个 `import` `App.tsx` 的测试,把 `src/lib/MetadataLoader.ts` 拉进了 `tsconfig.test.json` 的 program,而该文件用了 `import.meta.glob`;`tsconfig.test.json` extends 的是**根** tsconfig(不是 Vite 应用,不带 `vite/client`),于是 `tsc -p tsconfig.test.json` 报 3 条 `TS2339: Property 'glob' does not exist on type 'ImportMeta'`。这是本 PR 引入的,不是既有问题(把新测试文件挪走后 `type-check` 立刻 exit 0,已实测)—— 修法与 `packages/{layout,plugin-calendar,plugin-report,types}/tsconfig.test.json` 既有的 `types` 声明同一形状。

## Changeset

`.changeset/runner-preserve-query-on-navigate.md` —— `@object-ui/runner`: patch(用户可见行为修复)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_