### PR TITLE
fix(runner): 把 vite 别名表补成工作区 import 的完整传递闭包

### DIFF
--- a/.changeset/runner-vite-alias-transitive-closure.md
+++ b/.changeset/runner-vite-alias-transitive-closure.md
@@ -1,0 +1,29 @@
+---
+"@object-ui/runner": patch
+---
+
+Complete `packages/runner/vite.config.ts`'s workspace alias table to the full
+transitive import closure, so `@object-ui/runner` boots and builds from the
+monorepo sources without a prior `pnpm -w build` (objectui#3575).
+
+The table aliased 7 `@object-ui/*` specifiers to `packages/*/src`, but those
+`src` trees import 8 more workspace packages that were not aliased. Those fell
+back to Node resolution and landed on `packages/<pkg>/dist`, which does not
+exist in a fresh install-only checkout — so the "From Source" flow documented in
+`content/docs/utilities/runner.mdx` (`pnpm install` then `pnpm dev`, no build
+step) failed with "Failed to run dependency scan" and served HTTP 500 for every
+module on the chain. `pnpm --filter @object-ui/runner build` failed the same way.
+
+Newly aliased: `i18n`, `sdui-parser`, `react-runtime`, `fields`, `plugin-detail`
+(first layer), `providers` and `permissions` (only reachable once the first layer
+resolves to src), and `data-objectstack` (a type-only import that esbuild erases,
+so the dependency scan never reported it).
+
+This is user-visible in the published artifact, because the alias table is not
+scoped by `command` and therefore applies to `vite build` as well. Bundling the
+newly aliased packages from src stops the per-icon `lucide-react/dynamic.mjs`
+chunks from being inlined, so the build now emits ~1.7k lazy icon micro-chunks
+like `apps/console` does. `build.modulePreload` is disabled to match console, so
+those chunks are not all preloaded on first paint: the measured initial eager
+payload drops from 4231003 to 591795 bytes, while total `dist` size grows about
+5.5% because the previously inlined icons are now separate files.

--- a/packages/runner/vite.config.ts
+++ b/packages/runner/vite.config.ts
@@ -25,6 +25,50 @@ export default defineConfig({
       "@app": path.resolve(__dirname, "./src/app-data"),
 
       // ⚡️ DX: Map imports to source code for Hot Module Replacement
+      //
+      // This table IS the mechanism that lets runner boot straight from the
+      // monorepo sources with NO `pnpm -w build` first — exactly what
+      // `content/docs/utilities/runner.mdx` "From Source" documents
+      // (`pnpm install` → `pnpm dev`). Any `@object-ui/*` specifier NOT listed
+      // here falls back to Node resolution and lands on `packages/<pkg>/dist`,
+      // which does not exist in a fresh install-only checkout — Vite then
+      // reports "Failed to run dependency scan" and serves HTTP 500 for every
+      // module on that import chain (objectui#3575).
+      //
+      // ⚠️ INVARIANT — the table must be the *transitive* closure, not just
+      // runner's own direct imports: every `@object-ui/*` specifier imported
+      // anywhere under the `src` of a package that is itself aliased here must
+      // also be aliased. Adding only the directly-missing packages just moves
+      // the hole one layer down (that is how #3575 happened: `plugin-kanban`
+      // was aliased, but the `fields` / `plugin-detail` it imports were not).
+      //
+      // Re-derive the closure — run from the repo root and re-run until it
+      // prints nothing; every package you add brings its own src into the
+      // sweep, so this reaches a fixpoint by iteration:
+      //
+      //   comm -13 \
+      //     <(grep -oP '"\K@object-ui/[a-z0-9-]+(?=":)' packages/runner/vite.config.ts | sort -u) \
+      //     <(grep -rhP "(?<![@\w])(?:from|import)\s*\(?\s*['\"]@object-ui/" \
+      //         packages/runner/src \
+      //         $(grep -oP 'packages/\K[a-z0-9-]+(?=/src")' packages/runner/vite.config.ts \
+      //           | sort -u | sed 's|^|packages/|;s|$|/src|') 2>/dev/null \
+      //       | grep -vP '^\s*(\*|//)' \
+      //       | grep -oP "['\"]\K@object-ui/[a-z0-9-]+" | sort -u)
+      //
+      // Anything it prints is a package importable from the aliased sources but
+      // missing below — add it, then run again. Notes on the filters, each of
+      // which suppresses a real false positive in this repo:
+      //   - the `(?<![@\w])` lookbehind skips CSS `@import`, so doc comments
+      //     quoting `@import '@object-ui/app-shell/styles.css'` are not hits;
+      //     a real CSS `@import` of a workspace package must be swept for
+      //     separately (there are none today);
+      //   - `grep -vP '^\s*(\*|//)'` drops JSDoc/line-comment examples such as
+      //     `* () => import('@object-ui/plugin-grid')` in react/LazyPluginLoader
+      //     and core/registry/Registry.ts, which are documentation, not edges;
+      //   - `2>/dev/null` tolerates a table entry whose package dir no longer
+      //     exists (`data-objectql` is such a leftover — objectui#3593).
+      // Type-only imports are invisible to Vite's esbuild dependency scan but
+      // still belong in the table — see `data-objectstack` below.
       "@object-ui/components": path.resolve(__dirname, "../../packages/components/src"),
       "@object-ui/react": path.resolve(__dirname, "../../packages/react/src"),
       "@object-ui/core": path.resolve(__dirname, "../../packages/core/src"),
@@ -32,6 +76,27 @@ export default defineConfig({
       "@object-ui/data-objectql": path.resolve(__dirname, "../../packages/data-objectql/src"),
       "@object-ui/plugin-kanban": path.resolve(__dirname, "../../packages/plugin-kanban/src"),
       "@object-ui/plugin-charts": path.resolve(__dirname, "../../packages/plugin-charts/src"),
+
+      // Reached transitively through the packages above — see the closure note.
+      // `@object-ui/i18n`          <- react/src/index.ts, components/src/lib/close-label.tsx
+      "@object-ui/i18n": path.resolve(__dirname, "../../packages/i18n/src"),
+      // `@object-ui/sdui-parser`   <- components/src/renderers/layout/page.tsx
+      "@object-ui/sdui-parser": path.resolve(__dirname, "../../packages/sdui-parser/src"),
+      // `@object-ui/react-runtime` <- components/src/renderers/layout/react-page.tsx
+      "@object-ui/react-runtime": path.resolve(__dirname, "../../packages/react-runtime/src"),
+      // `@object-ui/fields`        <- plugin-kanban/src/ObjectKanban.tsx
+      "@object-ui/fields": path.resolve(__dirname, "../../packages/fields/src"),
+      // `@object-ui/plugin-detail` <- plugin-kanban/src/ObjectKanban.tsx
+      "@object-ui/plugin-detail": path.resolve(__dirname, "../../packages/plugin-detail/src"),
+      // `@object-ui/providers`     <- fields/src/widgets/{FileField,ImageField}.tsx (2nd layer)
+      "@object-ui/providers": path.resolve(__dirname, "../../packages/providers/src"),
+      // `@object-ui/permissions`   <- plugin-detail/src/DetailView.tsx et al. (2nd layer)
+      "@object-ui/permissions": path.resolve(__dirname, "../../packages/permissions/src"),
+      // `@object-ui/data-objectstack` <- react/src/context/AppShellContext.tsx, `import type`
+      // only. esbuild erases it, so Vite's dependency scan never flags it — it is
+      // in the closure by the invariant above, and aliased so that the day the
+      // import turns into a value import the dev server does not break.
+      "@object-ui/data-objectstack": path.resolve(__dirname, "../../packages/data-objectstack/src"),
     },
   },
 })

--- a/packages/runner/vite.config.ts
+++ b/packages/runner/vite.config.ts
@@ -99,4 +99,25 @@ export default defineConfig({
       "@object-ui/data-objectstack": path.resolve(__dirname, "../../packages/data-objectstack/src"),
     },
   },
+  build: {
+    // The alias table above is NOT scoped by `command`, so it applies to
+    // `vite build` too. That is deliberate and matches apps/console: resolving
+    // the plugin packages to src keeps the ComponentRegistry singleton
+    // single-instanced, which importing their prebuilt dist/ bundles does not
+    // guarantee (duplicate registries surface as "Unknown component type").
+    //
+    // Measured consequence of completing the table (objectui#3575): once
+    // `@object-ui/fields` & co. are bundled from src, the per-icon chunks that
+    // `components/src/lib/lazy-icon.tsx` creates via `lucide-react/dynamic.mjs`
+    // stop being inlined — this build goes from 10 assets to 1776, ~1761 of
+    // them sub-2KB icon micro-chunks. That is exactly the shape apps/console
+    // has ("1700+ icon chunks", see its build config).
+    //
+    // Vite's default `modulePreload: true` then emits a preload link for every
+    // one of them: index.html measured 546 B -> 145 KB with 1765
+    // `rel="modulepreload"` links, so the browser eagerly fetches all the icon
+    // chunks on first paint and the lazy split becomes a pessimisation.
+    // apps/console disables it for this exact reason; runner needs the same.
+    modulePreload: false,
+  },
 })


### PR DESCRIPTION
Fixes #3575

## 问题

`packages/runner/vite.config.ts` 只把 7 个 `@object-ui/*` specifier 别名到 `packages/*/src`,但这些包的 `src` 自己又 import 了另外一批工作区包。没进别名表的 specifier 退回 Node 解析、落到 `packages/PKG/dist` —— 而 `dist` 只在构建之后存在。于是在只跑过 `pnpm install` 的干净 checkout 里,`content/docs/utilities/runner.mdx` 的 "From Source"(install → dev,**没有** build 步骤)必然失败。

按 PM 分诊裁定走**方向 1**:别名表就是本仓已选定的「runner 在 monorepo 内不依赖 dist 即跑」机制,表不完整是该机制自身不变量的破缺。不动发布依赖面(方向 2),不让文档为机制的洞背锅(方向 3)。

## 闭包计算(不是只补第一层)

从 `packages/runner/src` 出发,穿过每个被别名包的 `src`,迭代到不动点。扫描前先剥掉注释 —— 本仓源码里大量在文档注释中引用 `@object-ui/...`,不剥注释会把 `app-shell` / `plugin-grid` / `plugin-map` 等误判进来(实测三处均为注释)。

闭包共 14 个包,其中 6 个已在表内(components / core / react / types / plugin-kanban / plugin-charts),**新增 8 个**:

| 新增包 | 首次被谁拉进来 | 层 |
|---|---|---|
| `@object-ui/i18n` | `react/src/index.ts`、`components/src/lib/close-label.tsx` | 1 |
| `@object-ui/sdui-parser` | `components/src/renderers/layout/page.tsx` | 1 |
| `@object-ui/react-runtime` | `components/src/renderers/layout/react-page.tsx` | 1 |
| `@object-ui/fields` | `plugin-kanban/src/ObjectKanban.tsx` | 1 |
| `@object-ui/plugin-detail` | `plugin-kanban/src/ObjectKanban.tsx` | 1 |
| `@object-ui/providers` | `fields/src/widgets/FileField.tsx`、`ImageField.tsx` | **2** |
| `@object-ui/permissions` | `plugin-detail/src/DetailView.tsx` 等 6 个文件 | **2** |
| `@object-ui/data-objectstack` | `react/src/context/AppShellContext.tsx` | 类型级 |

- **第 2 层**(`providers` / `permissions`)只有在第 1 层解析到 src 之后才可达 —— issue 里列的 5 个是第一层,只补它们会把洞往下挪一层。
- **`data-objectstack`** 是 `import type`,esbuild 会抹除,所以依赖扫描**从来不报它**;它按不变量属于闭包,提前别名,免得哪天该 import 变成值导入时 dev server 才炸。
- 无深路径子导入(`@object-ui/x/y`),无工作区包的真实 CSS `@import` —— 三处疑似命中经核实全在注释里。

## 表旁留了可复跑的闭包重导命令

一条 `comm -13` 单行命令,拿别名表自身当输入,再跑一遍即可确认是否还有缺口。已实测:

- 当前表下输出为空(到达不动点);
- 人为把 `fields` / `i18n` 两条从表里去掉,能准确报出这两个缺口。

注释里逐条写明三个过滤器各自压掉的**真实**误报(`@import` 文档注释、JSDoc 里的 `import()` 示例、以及指向已不存在目录的表项)。

## 验证(方向在跑之前先定)

干净 worktree,只 `pnpm install`,**不** build,自选空闲端口 `--strictPort`。

**BEFORE(预测红,实测红)**

```
(!) Failed to run dependency scan. Skipping dependency pre-bundling. Error: The following dependencies are imported but could not be resolved:
  @object-ui/i18n (imported by .../packages/components/src/lib/close-label.tsx)
  @object-ui/fields (imported by .../packages/plugin-kanban/src/ObjectKanban.tsx)
  @object-ui/plugin-detail (imported by .../packages/plugin-kanban/src/ObjectKanban.tsx)
  @object-ui/sdui-parser (imported by .../packages/components/src/renderers/layout/page.tsx)
  @object-ui/react-runtime (imported by .../packages/components/src/renderers/layout/react-page.tsx)
```

issue 里那条 `@fs` 探针连同另外 5 个文件全部 500:`Failed to resolve import "@object-ui/i18n" from "../components/src/renderers/basic/elements.tsx"`。

**顺带测到:`pnpm --filter @object-ui/runner build` 在同样状态下也是失败的** —— 这个洞不止影响 dev:

```
Error: [vite]: Rolldown failed to resolve import "@object-ui/i18n" from ".../packages/react/src/index.ts".
```

**AFTER(预测绿,实测绿)**

依赖扫描零 unresolved(日志里 `could not be resolved` / `Failed to run dependency scan` 出现 0 次)。没有停在点探针上 —— 直接从 `/src/main.tsx` 沿 vite 改写后的 import URL **爬了整张模块图**:

```
crawled 2381 modules from /src/main.tsx
workspace packages served FROM SRC (13): components, core, fields, i18n, permissions,
  plugin-charts, plugin-detail, plugin-kanban, providers, react, react-runtime, sdui-parser, types
served from dist / node_modules/@object-ui (0): (none)

NON-200 responses: 0
```

13 而非 14,差的正是类型级的 `data-objectstack`(被 esbuild 抹除,本就不进模块图)—— 与分析自洽。issue 原探针 `elements.tsx` 500 → **200**。

`@object-ui/react` 是 `@object-ui/react-runtime` 的前缀,但 rollup alias 要求匹配 `pattern + "/"`,故未被吞掉 —— `react-page.tsx` 与 `react-runtime/src/index.ts` 均 200,已实测钉住。

**未跑无头浏览器**:容器内没装 playwright 浏览器(`~/.cache/ms-playwright` 不存在),所以**没有**白屏/渲染截图这一层,只有 HTTP 模块图这一层。

## 构建路径的影响 + changeset 决策

别名表**没有**按 `command` 分档,因此同样作用于 `vite build`。这是刻意的,与 `apps/console` 一致(其注释写明:插件包解析到 src 才能保证 ComponentRegistry 单例,从各自 dist 引入则不保证,否则会出 "Unknown component type")。

把依赖都构建好(等价 CI 状态)后对比:

| | BEFORE | AFTER(仅补别名) | FINAL(+ `modulePreload: false`) |
|---|---|---|---|
| build | ✅ | ✅ | ✅ |
| asset 数 | 10 | 1776 | 1776 |
| index.html | 546 B | 145595 B | **542 B** |
| `rel="modulepreload"` 条数 | 1 | **1765** | **0** |
| 首屏急切载荷 | 4231003 B | — | **591795 B(-86%)** |
| dist 总大小 | 5064294 B | 5670299 B | 5343175 B(+5.5%) |

`@object-ui/fields` 等从 src 打包后,`components/src/lib/lazy-icon.tsx` 经 `lucide-react/dynamic.mjs` 产生的逐图标 chunk 不再被内联,产物变成约 1761 个 2KB 以下的图标微 chunk。**这与 console 的形状一致** —— console 的 build 配置注释里就写着 "1700+ icon chunks"。

但 vite 默认 `modulePreload: true` 会给每个 chunk 发一条 preload,首屏就把图标全拉下来,懒加载反成劣化。console 正是为此关掉它,**runner 同样需要**,故本 PR 一并关掉;这是本次改动**自身引入**的回归,不是顺手修的无关问题。关掉后首屏急切载荷从 4.2 MB 降到 0.59 MB。

产物可见变化(runner 已发布,`files` 含 `dist`),故**补了 patch changeset** —— 与派单里「若影响发布产物解析则需 patch changeset」的判据一致。

## 其它

- `pnpm --filter @object-ui/runner type-check` / `lint` / `test`:全绿(9 tests passed;lint 23 条既有 warning、0 error)。`node scripts/check-control-bytes.mjs` OK,并对改动文件另做了控制字符自扫。
- 注意 `vite.config.ts` **不在** runner 的 tsc program 里(`include: ["src"]`),所以 type-check 覆盖不到本文件;真正的验收证据是上面的 dev/build 实测。
- 表里 `@object-ui/data-objectql` 指向的 `packages/data-objectql/` **目录并不存在**,且该 specifier 全仓仅此一处引用。属同一张表**另一个方向**的破缺,是独立缺陷,**本 PR 未动**,已按 Prime Directive #10 另开 #3593(observation-class,休眠:无人 import,故今天不影响任何人)。本 PR 的重导命令用 `2>/dev/null` 容忍它并在注释里点名了该单。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_