### PR TITLE
docs(runner): 删掉 README 两处虚构能力面(createRunner/runner.config.js),修正 404 文档链接 (#3576)

### DIFF
--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -10,17 +10,22 @@ Universal Object UI Application Runner - A standalone development server and run
 - **Development Ready** - Built-in Vite development server
 - **Production Build** - Optimized build for deployment
 
-## Installation
+## Running the Runner
+
+The runner is an application, not a library: `package.json` declares no `main`,
+`module`, `exports` or `types`, so there is nothing to `import` from
+`@object-ui/runner`. You run it from a checkout of this repository:
 
 ```bash
-pnpm add @object-ui/runner
+git clone https://github.com/objectstack-ai/objectui.git
+cd objectui
+pnpm install
+
+# Start the dev server on http://localhost:5173
+pnpm --filter @object-ui/runner dev
 ```
 
-## Usage
-
-### As a Development Tool
-
-The runner is primarily used for schema development and testing:
+Inside `packages/runner`, the same scripts are available directly:
 
 ```bash
 # Start development server
@@ -31,22 +36,6 @@ pnpm build
 
 # Preview production build
 pnpm preview
-```
-
-### Programmatic Usage
-
-You can also use the runner as a library in your projects:
-
-```typescript
-import { createRunner } from '@object-ui/runner';
-
-const runner = createRunner({
-  schema: mySchema,
-  plugins: ['kanban', 'charts'],
-  theme: 'light'
-});
-
-runner.mount('#app');
 ```
 
 ## Pre-installed Plugins
@@ -97,19 +86,14 @@ section of the docs.
 
 ## Configuration
 
-Create a `runner.config.js` file to customize the runner:
+There is no runner config file and no runner environment variables. The two surfaces
+that do configure it are:
 
-```javascript
-export default {
-  port: 3000,
-  host: 'localhost',
-  plugins: ['kanban', 'charts'],
-  theme: {
-    primaryColor: '#3b82f6',
-    darkMode: true
-  }
-};
-```
+- **`vite.config.ts`** — build options and the workspace alias table that lets the runner
+  boot straight from the monorepo sources. The dev server takes Vite's own defaults
+  (port 5173); change them with Vite's flags, e.g. `pnpm dev --port 3000`.
+- **The `api` query parameter** — the metadata base URL, described under
+  [Metadata Loading](#metadata-loading) above.
 
 ## Development Workflow
 
@@ -162,9 +146,9 @@ export default {
 }
 ```
 
-## API Reference
+## Documentation
 
-For detailed documentation, visit the [Object UI Documentation](https://www.objectui.org/docs/runner).
+For detailed documentation, visit the [Object UI Documentation](https://www.objectui.org/docs/utilities/runner).
 
 <!-- release-metadata:v3.3.0 -->
 


### PR DESCRIPTION
Fixes #3576

按 #3533 的口径(文档不许描述实现里不存在的能力)清掉 `packages/runner/README.md` 的两个虚构能力面,并修正一条 404 的文档链接。改动只落在这一个文件。

## 三处处置与零命中证据

**1. §Programmatic Usage(原 41-50 行)—— 整节删除,并把上方 §Installation 改写成 runner 的真实用法。**

```
$ git grep -n "createRunner" -- .
packages/runner/README.md:41:import { createRunner } from '@object-ui/runner';
packages/runner/README.md:43:const runner = createRunner({
```

全仓仅此两行,且 `packages/runner/package.json` 没有 `main` / `module` / `exports` / `types` 任何一个字段(`files` 只有 `dist` / `README.md` / `CHANGELOG.md` / `LICENSE`),所以 `import ... from '@object-ui/runner'` 无从解析 —— 这个包是 `index.html` + `src/main.tsx` 的 Vite 应用,不是库。

选了 issue 给的第二个选项(改写为真实用法)而不是纯删,原因是纯删会留下一个孤儿:上方 `## Installation` 教的 `pnpm add @object-ui/runner` 只在"可 import"的前提下才成立,而 issue 正文已把它点名为同一处虚构的连带面("因此也是误导:装了也没有可 import 的入口")。现在合并为一节 `## Running the Runner`,与 `content/docs/utilities/runner.mdx` 的同名小节口径一致(clone → `pnpm install` → `pnpm --filter @object-ui/runner dev`),原来的 `pnpm dev` / `build` / `preview` 三条命令原样保留在下半段。删掉 `### Programmatic Usage` 后 `### As a Development Tool` 成了唯一的三级标题,一并拍平。

**2. §Configuration(原 98-112 行)—— `runner.config.js` 删除,改写为真实的两个配置面。**

```
$ git grep -n "runner\.config" -- .
packages/runner/README.md:100:Create a `runner.config.js` file to customize the runner:
```

同样零代码引用(含未跟踪文件的全盘 grep 也只有这一行)。改写后指向实测存在的两处:`vite.config.ts`(构建选项 + 让 runner 直接从 monorepo 源码启动的别名表;dev server 用 Vite 默认端口 5173,靠 Vite 自己的 flag 改)与 `?api=` 查询参数(指回本 README 已有的 §Metadata Loading 锚点,不重复叙述)。这与 #3594 刚落的 §Metadata Loading 那句"it reads no environment variables and no config file"互相印证;#3538 此前已清掉环境变量那一面,这是最后一处虚构配置面。

**3. §API Reference 的链接(原 167 行)—— `/docs/runner` → `/docs/utilities/runner`。**

```
$ git grep -n "objectui.org/docs/runner" -- .   # 改动前:packages/runner/README.md:167
```

路由核对(人工,理由见下):`content/docs/runner.*` 不存在;`content/docs/utilities/runner.mdx` 存在,且 `content/docs/utilities/meta.json` 的 `pages` 里列了 `runner`,`content/docs/meta.json` 的 `pages` 里列了 `utilities`。同一 README 底部 `## Links` 的 Documentation 一条本来就是这个 URL,`package.json` 的 `homepage` 也是 —— 现在三处一致。

顺带把标题 `## API Reference` 改成 `## Documentation`:这一节的正文本来就是"detailed documentation",而本 PR 刚刚确认这个包没有可引用的 API,留着 API Reference 是被删掉那套"库"叙事的最后残留。这是本 PR 唯一一处超出三条 issue 字面的改动,单独在此声明。

改动后三条 grep 全部零命中:

```
$ git grep -n "createRunner" -- .        -> (无输出)
$ git grep -n "runner\.config" -- .      -> (无输出)
$ git grep -n "objectui.org/docs/runner" -- .  -> (无输出)
```

## 全文一致性核对

今天有三个 PR 动过这个文件(#3581 / #3594,以及本 PR),所以通读了改后全文:开头第 3 行"standalone development server and runtime"、§Features 的"Built-in Vite development server"与新的 §Running the Runner 同调,全篇不再有"可 import 的库"这一叙事;新 §Configuration 与 §Metadata Loading 不冲突也不重复;`#metadata-loading` 锚点对应 `## Metadata Loading` 标题,有效。另确认没有任何文件链接到本 README 的旧锚点(`git grep "runner/README\|#programmatic-usage\|#as-a-development-tool"` 只命中 CHANGELOG 里一句无关文字),所以拍平标题不会打断站内链接。

通读时发现 §Development Workflow 第 1 步"Create a schema file (JSON or TypeScript)"与 §Metadata Loading 不符(两个 loader 都只认 JSON:`import.meta.glob('../app-data/**/*.json')` 与 `fetch(base + '/pages/x.json')`)。**不在本 issue 的三条范围内,未在本 PR 修改**,已另开 issue 记录。

## 验证

```
$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3641 tracked text file(s); skipped 85 binary).

$ node scripts/check-doc-links.mjs
Links are valid across 3 scan roots.

$ pnpm exec vitest run scripts/ --maxWorkers=2
 Test Files  16 passed (16)
      Tests  275 passed (275)

$ node scripts/check-changeset-fixed.mjs      # CI 的 changeset-check
✅  All workspace packages are in the changeset fixed group.
$ node scripts/check-changeset-no-major.mjs   # changeset-guard
✅  No changeset declares a `major` bump.

$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' packages/runner/README.md   # 门禁之外自查
(无命中;file(1) 报 UTF-8 text)
```

⚠️ **链接门禁看不见这条修复,证据只能是上面的人工路由核对。** 两层原因,都实测过:`scripts/check-doc-links.mjs` 的 `SCAN_ROOTS` 只有 `content/docs` / `examples` / 根 `README.md`,`packages/**/README.md` 不在其中;而且即使在其中也没用 —— `judgeHref()` 在 `check-doc-links.mjs:552` 对任何带 scheme 的 href 直接 `return null`,唯一例外是 `SELF_REPO_BLOB_RE`(本仓 github blob/tree URL),站内绝对地址 `https://www.objectui.org/docs/...` 从不做路由校验。所以 `docs:check-links` 那句绿是"没扫到",不是"扫过且通过"。这个盲区在别的包 README 上已经兑现成 9 处死链,已另开 issue。

## Changeset

**无。** 按 #3581 的先例(同样是 `packages/runner/README.md` + docs 的纯文档 PR,无 changeset)。核对过没有门禁反对:CI 的 `changeset-check` 跑的是 `check-changeset-fixed.mjs`(校验所有包在 fixed group 里,不要求每个 PR 带 changeset),`changeset-guard` 跑的是 `check-changeset-no-major.mjs`(只拦 major),两条本地都绿。README 确实进 npm tarball(`files` 含 `README.md`),但改的是纯错误叙述,没有版本语义。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_