### PR TITLE
fix(app-shell): judge a stored `view` by the wire gate, not the authoring gate

### DIFF
--- a/.changeset/view-edit-wire-gate-5316.md
+++ b/.changeset/view-edit-wire-gate-5316.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin no longer false-rejects a stored `view` that has been pinned or
+reordered. The editor's live client-side validation judged BOTH the create and
+the edit draft with the AUTHORING schema (`ViewItemSchema` via
+`viewSchemaForDraft`). That is right for create and wrong for edit: the editor
+opens a body that came back out of `sys_metadata`, and the platform itself
+writes keys into stored view bodies — `isPinned` from the view switcher's pin
+action, `sortOrder` from the reorder write, and a per-row `id` that the console
+filter/sort builders stamp on `config.filter[]` for React. `updateView` GETs the
+stored item and PUTs `{ ...current, ...partial }`, and `saveMetaItem` persists
+the accepted body verbatim, so those keys are in storage by design.
+
+Before the authoring schemas were tightened these keys were silently stripped
+and the draft passed. Once the gate became strict, opening a pinned view in the
+editor reported unrecognized keys — while the SERVER accepted the very same body,
+because it validates against `ViewMetadataSchema`. The client was strictly
+stricter than the server; the direction was inverted.
+
+`validateMetadataDraft` now takes an optional `{ mode: 'create' | 'edit' }`.
+Create keeps the authoring gate unchanged. Edit is judged by
+`ViewMetadataSchema` — the schema the `view` metadata type registers, i.e. the
+same one the server runs — so the client and the server accept the same set by
+construction. `mode` defaults to `'create'`, the strict gate, so a caller that
+omits it can only ever over-report, never silently widen the door.
+
+The edit gate keeps its teeth: a wrong `config.type` and a container carrying an
+unknown key are both still rejected.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -419,7 +419,19 @@ function MetadataResourceEditPageImpl({
     const handle = window.setTimeout(() => {
       // Pass the live server schema so the client never flags fields the
       // running server now treats as optional (cross-repo spec-skew root-cure).
-      void validateMetadataDraft(type, draft, entry?.schema as { required?: unknown } | undefined).then((res) => {
+      //
+      // `mode` picks the gate (objectstack#5316): a create draft is AUTHORED
+      // here and judged by the strict authoring schema, while an edit draft is
+      // a body that came back out of storage and is judged by the same wire
+      // schema the server runs. Judging a stored body by the authoring schema
+      // made this editor reject bodies the server accepts — e.g. a view that
+      // had been pinned or reordered carries `isPinned` / `sortOrder`.
+      void validateMetadataDraft(
+        type,
+        draft,
+        entry?.schema as { required?: unknown } | undefined,
+        { mode: createMode ? 'create' : 'edit' },
+      ).then((res) => {
         if (cancelled) return;
         setIssues(res.issues);
       });
@@ -428,7 +440,7 @@ function MetadataResourceEditPageImpl({
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [type, draft, entry?.schema]);
+  }, [type, draft, entry?.schema, createMode]);
   // Issues to DISPLAY (banner + inline). Suppressed on a pristine create form
   // so a blank new item doesn't open covered in required-field errors.
   const displayIssues = React.useMemo(

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -31,7 +31,24 @@ type ZodLikeSchema = {
   };
 };
 
-type SchemaLoader = () => Promise<ZodLikeSchema | undefined>;
+/**
+ * Which door a draft came through — the two are validated by different gates
+ * (objectstack#5316).
+ *
+ *  - `create` — the draft is being AUTHORED in this admin. It is judged by the
+ *    authoring schema, which is the strict one: a key the authoring contract
+ *    does not declare is a mistake the author should see now.
+ *  - `edit` — the draft is a body that came back OUT of storage. It is judged by
+ *    the same WIRE schema the server's `saveMetaItem` runs, because the platform
+ *    itself writes keys into stored bodies that the authoring contract has no
+ *    reason to declare.
+ *
+ * Only `view` currently distinguishes the two; every other loader ignores the
+ * mode and returns the one schema it has always returned.
+ */
+export type DraftMode = 'create' | 'edit';
+
+type SchemaLoader = (mode: DraftMode) => Promise<ZodLikeSchema | undefined>;
 
 /**
  * The `view` metadata type has TWO spec-declared shapes, and the backend serves
@@ -98,8 +115,43 @@ const LOADERS: Record<string, SchemaLoader> = {
   analytics_cube: async () => (await import('@objectstack/spec/data')).CubeSchema as unknown as ZodLikeSchema,
 
   // ui
-  view: async () => {
-    const { ViewItemSchema, ViewSchema } = await import('@objectstack/spec/ui');
+  //
+  // `view` is the one type whose two doors need two gates (objectstack#5316).
+  //
+  // CREATE — the authoring gate, unchanged: `viewSchemaForDraft` dispatches on
+  // the record's own `viewKind` discriminant to `ViewItemSchema` (what
+  // `createBuildBody` emits) or `ViewSchema` (the container). #5074 made these
+  // strict on purpose and this admin's create path passes them cleanly.
+  //
+  // EDIT — the WIRE gate. The editor opens a body that came back out of
+  // `sys_metadata`, and a stored view body carries keys the PLATFORM wrote:
+  // `isPinned` (the view switcher's pin action, `ObjectView.tsx:882`),
+  // `sortOrder` (the reorder write, `ObjectView.tsx:931`), and — nested —
+  // the console filter/sort builders' per-row `id`. `updateView` GETs the
+  // stored item and PUTs `{ ...current, ...partial }`; `saveMetaItem` persists
+  // the accepted body verbatim (ADR-0005 §Validation). So the server ACCEPTS
+  // this body — it validates against `ViewMetadataSchema` — while the authoring
+  // gate rejects it. Judging a stored body by the authoring schema made the
+  // client strictly stricter than the server; that is the inversion #5316 fixes.
+  //
+  // Why `ViewMetadataSchema` and not the narrower `ViewItemWireSchema`, which
+  // also declares `isPinned`/`sortOrder`: two measured reasons.
+  //   1. It is the schema the `view` metadata type registers, i.e. literally
+  //      the one `saveMetaItem` runs — so client and server accept the same
+  //      set by construction rather than by a maintained resemblance.
+  //   2. `ViewItemWireSchema` covers only the ViewItem record. It rejects the
+  //      container and the flattened overlay, and — measurably — still rejects
+  //      `config.filter[].id` with `unrecognized_keys`, because that decoration
+  //      is stripped by `ViewMetadataSchema`'s `z.preprocess`, which runs ahead
+  //      of every union member and reaches nested blocks a member-level
+  //      `.strip()` cannot.
+  //
+  // NOT a "try both, pass if either passes" fallback: each mode has exactly ONE
+  // gate and a rejection is final. The last pins in
+  // `clientValidation.viewShapes.test.ts` guard that.
+  view: async (mode) => {
+    const { ViewItemSchema, ViewSchema, ViewMetadataSchema } = await import('@objectstack/spec/ui');
+    if (mode === 'edit') return ViewMetadataSchema as unknown as ZodLikeSchema;
     return viewSchemaForDraft(
       ViewItemSchema as unknown as ZodLikeSchema,
       ViewSchema as unknown as ZodLikeSchema,
@@ -247,22 +299,25 @@ async function validateObjectFieldRules(draft: unknown): Promise<SchemaFormIssue
   return issues;
 }
 
+// Keyed by mode AND type — `view` resolves to a different schema per mode, so
+// caching by type alone would hand the create gate whichever mode asked first.
 const SCHEMA_CACHE = new Map<string, ZodLikeSchema | null>();
 
-async function getSchemaForType(type: string): Promise<ZodLikeSchema | null> {
-  if (SCHEMA_CACHE.has(type)) return SCHEMA_CACHE.get(type) ?? null;
+async function getSchemaForType(type: string, mode: DraftMode): Promise<ZodLikeSchema | null> {
+  const key = `${mode}:${type}`;
+  if (SCHEMA_CACHE.has(key)) return SCHEMA_CACHE.get(key) ?? null;
   const loader = LOADERS[type];
   if (!loader) {
-    SCHEMA_CACHE.set(type, null);
+    SCHEMA_CACHE.set(key, null);
     return null;
   }
   try {
-    const schema = await loader();
+    const schema = await loader(mode);
     const value = (schema && typeof schema.safeParse === 'function') ? schema : null;
-    SCHEMA_CACHE.set(type, value);
+    SCHEMA_CACHE.set(key, value);
     return value;
   } catch {
-    SCHEMA_CACHE.set(type, null);
+    SCHEMA_CACHE.set(key, null);
     return null;
   }
 }
@@ -301,8 +356,16 @@ export async function validateMetadataDraft(
    * per-change shim (cf. `FORWARD_COMPAT_FLOW_NODE_TYPES`).
    */
   serverSchema?: { required?: unknown },
+  /**
+   * Which door the draft came through (objectstack#5316). Defaults to
+   * `'create'` — the AUTHORING gate, which is the strict one — so a call site
+   * that omits it can only ever over-report, never silently widen the door.
+   * Callers that open a STORED body must say `{ mode: 'edit' }`.
+   */
+  options?: { mode?: DraftMode },
 ): Promise<ValidateResult> {
-  const schema = await getSchemaForType(type);
+  const mode: DraftMode = options?.mode ?? 'create';
+  const schema = await getSchemaForType(type, mode);
   if (!schema) return { ok: true, issues: [] };
 
   // CEL lint for object field conditional rules — additive to the Zod shape

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.viewShapes.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.viewShapes.test.ts
@@ -25,7 +25,7 @@ import { describe, it, expect } from 'vitest';
 import { validateMetadataDraft } from './clientValidation';
 
 /** What `anchors.ts`'s `createBuildBody` emits for a default list view. */
-const VIEW_ITEM = {
+const VIEW_ITEM: Record<string, unknown> = {
   name: 'crm_lead.all_leads',
   object: 'crm_lead',
   viewKind: 'list',
@@ -77,5 +77,131 @@ describe('validateMetadataDraft("view") — both spec shapes (objectui#3312)', (
     });
     expect(res.ok).toBe(false);
     expect(res.issues.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Editing a STORED view body — the wire gate (objectstack#5316).
+ *
+ * The four pins above all describe the AUTHORING surface: what
+ * `createBuildBody` may emit. Editing is a different door. The editor opens a
+ * body that came back OUT of `sys_metadata`, and a stored body carries keys the
+ * platform itself wrote there:
+ *
+ *   - `isPinned`   — `ObjectView.tsx:882`, the view-switcher's pin action, via
+ *                    `dataSource.updateView(object, vid, { isPinned: true })`.
+ *   - `sortOrder`  — `ObjectView.tsx:931`, the reorder write.
+ *   - nested `id`  — the console filter/sort builder's stable React key
+ *                    (`VIEW_CONSOLE_ROW_DECORATIONS`), on `config.filter[]` rows.
+ *
+ * `updateView` GETs the stored item and PUTs `{ ...current, ...partial }`, and
+ * `saveMetaItem` persists the accepted body verbatim (ADR-0005 §Validation) — so
+ * these keys are in the stored body by design, not by accident.
+ *
+ * Before #5074 `ViewItemSchema` was strip and they were silently dropped. #5074
+ * tightened it into a real authoring gate, which is correct for CREATE and wrong
+ * for EDIT: the SERVER validates the very same body against `ViewMetadataSchema`
+ * and accepts it. The client was strictly stricter than the server — direction
+ * inverted. These pins fix the direction: create keeps the authoring gate, edit
+ * is judged by the same wire schema the server runs.
+ */
+describe('validateMetadataDraft("view") — stored bodies on the EDIT path (objectstack#5316)', () => {
+  /** A stored ViewItem that has been pinned via the view switcher. */
+  const PINNED = { ...VIEW_ITEM, isPinned: true };
+  /** A stored ViewItem that has been dragged into a new position. */
+  const REORDERED = { ...VIEW_ITEM, sortOrder: 3 };
+  /** Both round-trip keys, plus the console builder's nested row decoration. */
+  const PINNED_WITH_BUILDER_ROWS = {
+    ...VIEW_ITEM,
+    isPinned: true,
+    sortOrder: 3,
+    config: {
+      type: 'grid',
+      columns: [],
+      data: { provider: 'object', object: 'crm_lead' },
+      filter: [{ field: 'status', operator: 'equals', value: 'open', id: 'row-1' }],
+    },
+  };
+
+  it('accepts a stored view that was PINNED', async () => {
+    const res = await validateMetadataDraft('view', PINNED, undefined, { mode: 'edit' });
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts a stored view that was REORDERED', async () => {
+    const res = await validateMetadataDraft('view', REORDERED, undefined, { mode: 'edit' });
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  /**
+   * The nested case is why the gate must be `ViewMetadataSchema` and not the
+   * bare `ViewItemWireSchema`: the wire member declares `isPinned`/`sortOrder`
+   * at the TOP level, but only `ViewMetadataSchema`'s
+   * `z.preprocess(stripViewConsoleDecorations, …)` reaches `config.filter[].id`.
+   * A member-level `.strip()` cannot — the spec says so at the union's
+   * definition, and it is measurable: `ViewItemWireSchema` rejects this body
+   * with `config.filter.0: unrecognized_keys`.
+   */
+  it('accepts a stored view carrying nested console builder row ids', async () => {
+    const res = await validateMetadataDraft('view', PINNED_WITH_BUILDER_ROWS, undefined, {
+      mode: 'edit',
+    });
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts the aggregated container on the edit path too', async () => {
+    const res = await validateMetadataDraft('view', CONTAINER, undefined, { mode: 'edit' });
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  // ── The edit gate still has teeth ────────────────────────────────────────
+  // Widening the door for keys the platform WRITES must not widen it for a
+  // body that is actually wrong.
+
+  it('still REJECTS a stored view whose config is wrong', async () => {
+    const res = await validateMetadataDraft(
+      'view',
+      { ...PINNED, config: { type: 'not_a_real_layout', columns: [] } },
+      undefined,
+      { mode: 'edit' },
+    );
+    expect(res.ok).toBe(false);
+    expect(res.issues.length).toBeGreaterThan(0);
+  });
+
+  it('still REJECTS a container carrying an unknown key on the edit path', async () => {
+    const res = await validateMetadataDraft(
+      'view',
+      { ...CONTAINER, notAContainerKey: true },
+      undefined,
+      { mode: 'edit' },
+    );
+    expect(res.ok).toBe(false);
+    expect(res.issues.length).toBeGreaterThan(0);
+  });
+
+  // ── The CREATE path is untouched ─────────────────────────────────────────
+
+  it('keeps REJECTING the same stored keys on the CREATE path', async () => {
+    // `createBuildBody` has no business emitting `isPinned`: on the authoring
+    // surface these are still unrecognized, exactly as #5074 made them.
+    for (const body of [PINNED, REORDERED]) {
+      const res = await validateMetadataDraft('view', body, undefined, { mode: 'create' });
+      expect(res.ok, JSON.stringify(res.issues)).toBe(false);
+      expect(res.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('defaults to the CREATE gate when no mode is given', async () => {
+    // Default-strict: a call site that forgets `mode` gets the authoring gate,
+    // so an omission can only ever over-report — never silently widen the door.
+    const withMode = await validateMetadataDraft('view', PINNED, undefined, { mode: 'create' });
+    const withoutMode = await validateMetadataDraft('view', PINNED);
+    expect(withoutMode.ok).toBe(false);
+    expect(withoutMode.issues).toEqual(withMode.issues);
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5316

## 问题

`packages/app-shell/src/views/metadata-admin/clientValidation.ts` 的 `view` loader 把**创建**和**编辑**两条路都送进了授权门(`ViewItemSchema`,经 `viewSchemaForDraft`)。

创建路这样判是对的。编辑路不是 —— 编辑器打开的是一份从 `sys_metadata` 取回的 body,而 stored view body 里带着**平台自己写进去的**键:

| 键 | 谁写的 |
|---|---|
| `isPinned` | 视图切换器的 pin 动作(`ObjectView.tsx:882`) |
| `sortOrder` | 拖动重排的写入(`ObjectView.tsx:931`) |
| `config.filter[].id` | console 过滤器/排序构建器给每行盖的 React key |

`updateView` 先 GET 存储项再 PUT `{ ...current, ...partial }`,`saveMetaItem` 校验后原样落库(ADR-0005 §Validation)—— 这些键在库里是**设计如此**,不是脏数据。

objectstack#5074 把授权门收紧成真正的门之后(此前是 strip,这些键被静默丢弃),给某视图打过 pin 再进 metadata-admin 编辑器就会报未识别键 —— 而**服务端接受同一份 body**,因为它判的是 `ViewMetadataSchema`。客户端严于服务端,方向反了。

## 修法

`validateMetadataDraft` 增加可选第四参 `{ mode: 'create' | 'edit' }`:

- **创建**继续走授权门,一字未改;
- **编辑**走 `ViewMetadataSchema` —— `view` 元数据类型注册的那个 schema,也就是服务端 `saveMetaItem` 跑的同一个。客户端与服务端因此**按构造同集**,而不是靠人工维持相似。

`mode` 缺省为 `'create'`(严的那个门)。漏传只会**多报**,绝不会静默把门放宽 —— 这是刻意选的缺省方向。

唯一的生产调用点 `ResourceEditPage.tsx` 传 `{ mode: createMode ? 'create' : 'edit' }`;`createMode` 本就在该 effect 作用域内,没有新增状态,其余元数据类型的 loader 行为不变(签名多了个被忽略的参数)。

`SCHEMA_CACHE` 改为按 `mode:type` 作键 —— 否则 `view` 会把先到的那个 mode 的 schema 喂给另一个 mode。

## 为什么是 `ViewMetadataSchema` 而不是更窄的 `ViewItemWireSchema`

两者都在顶层声明了 `isPinned` / `sortOrder`,所以只看 issue 正文里那两个键**分不出高下**。实测把它们分开的是另外两条:

1. `ViewItemWireSchema` 只覆盖 ViewItem 记录,**拒绝容器**(编辑器确实会打开容器 —— 既有 pin 就钉着这条)。
2. 它仍会以 `config.filter.0: unrecognized_keys` **误拒**构建器写入的行 `id`。那条 decoration 由 `ViewMetadataSchema` 的 `z.preprocess(stripViewConsoleDecorations, …)` 剥除,而 preprocess 跑在所有 union 成员**之前**,够得到成员级 `.strip()` 够不到的嵌套块 —— spec 在 union 定义处自己写明了这一点。

也就是说:用 `ViewItemWireSchema` 只能修掉一半的误拒,嵌套那一半照旧。

## 不是 try-both 兜底

每个 mode 恰好一个门,拒绝即终局 —— 没有「换一个再试,过一个就算过」。`clientValidation.viewShapes.test.ts` 原有的后两条 pin 正是看守这个的,它们**原样保留且全绿**。

## 验证

**先复现,再修**。把编辑路的期望写成 pin,在**未改动**的 main 上跑,预测红:

```
Tests  3 failed | 9 passed (12)
```

红的正是三条编辑路接受性 pin,报错内容与 issue 描述逐字吻合:

```
config.filter.0 : Unrecognized key(s) on this filter rule: `id`.
                  … the write path removes it before validating.
(root)          : Unrecognized key(s) on this view item: `isPinned`, `sortOrder`.
                  … Pinning is per-user Studio state … the console writes it
                  through the `view` metadata API.
```

修后 `12 passed (12)`。

**反向验证**(先定方向再跑):把 `ViewMetadataSchema` 换成 `ViewItemWireSchema`,预测**恰好两条**变红 —— 嵌套 decoration 那条和容器那条,而 `isPinned`/`sortOrder` 两条**仍绿**(wire 成员在顶层声明了它们)。实跑 `2 failed | 10 passed`,与预测一致。这说明钉住 schema **选型**的是嵌套与容器那两条 pin,顶层那两个键单独无法区分两个候选。

全量:`packages/app-shell/src/views/metadata-admin` 共 `127 passed / 1169 tests`;`type-check` 干净;`lint` 0 error;`check-control-bytes` OK。

## 一条已测量的副作用(已单独立单,未在本 PR 处理)

`ViewMetadataSchema` 是个 union,Zod 对 union 失败只给一条根级 `invalid_union`,映射后成为 `path: ''` / `message: 'Invalid input'`。判定仍然正确(坏 body 照样被拒,pin 有钉),但编辑路失去了逐字段内联定位和 spec 专门撰写的引导消息。

这是修法的**代价**,不是 bug —— 更窄的候选已被上面两条实测排除,而消除它需要展开 union 的嵌套 errors 并解决「选哪个成员呈现」的取舍(启发式实测会误选),超出本单范围。已按发现纪律另开 objectstack-ai/objectui#3606 交分诊定级。

## 影响面

仅 Studio 客户端预校验。服务端不受影响。变更集:`patch @object-ui/app-shell`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_