### PR TITLE
refactor(dashboard): compareTo 收敛为 { kind, dimension? },并让 dataset 路径真的跑出对比

### DIFF
--- a/.changeset/compareto-kind-convergence.md
+++ b/.changeset/compareto-kind-convergence.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/core": patch
+"@object-ui/plugin-dashboard": patch
+"@object-ui/plugin-charts": patch
+---
+
+Converge dashboard widget `compareTo` on the executor's `{ kind, dimension? }` contract, and make the dataset path actually render a comparison
+
+`CompareToConfig` was a three-branch union (`'previousPeriod' | 'previousYear' | { offset }`). `@objectstack/spec` collapsed it to the shape the analytics executor already implements — `DatasetCompareTo`, a plain strict object `{ kind: 'previousPeriod' | 'previousYear'; dimension?: string }` (objectstack#5011) — so this renderer now reads that one shape:
+
+- `shiftFilterByCompareTo` / `compareToTrendLabelKey` dispatch on `compareTo.kind`. The `{ offset }` duration shift is gone: `{ offset: '1y' }` is `kind: 'previousYear'`, while `'7d'` / `'1M'` have no faithful target and are restated by the author on the widget's own `filter` plus `kind: 'previousPeriod'`. No trend label key is retired — the offset arm resolved to `vsPreviousPeriod`, which survives as the `previousPeriod` fallback.
+- `DatasetWidget` no longer discards part of `compareTo`. It used to forward only the object form because the two string forms had no meaning downstream; with one shape there is nothing to discard, and a stale string is now invalid metadata rejected where it is authored rather than silently reinterpreted here.
+- **The comparison now actually runs on the dataset path.** A widget states its window in its own `filter` (a date macro, or the dashboard date-range filter merged in), but the executor shifts a `timeDimensions` entry carrying a `dateRange` — so a dataset widget asking for a comparison got "compareTo needs a dated window to shift" and rendered none. When (and only when) a comparison is requested, the resolved filter's bounded date windows are lowered into `selection.timeDimensions[].dateRange` and moved out of `runtimeFilter` (a copy left behind would intersect the shifted window with the current one and empty every comparison column). Which dimension gets shifted stays the executor's decision: every window found is lowered under the name the author wrote, and zero or two candidates surfaces the executor's own error, listing them.
+- The `<measure>__compare` columns that come back are now shown: a delta + window label on KPI widgets, a comparison column on tables, and a `variant: 'comparison'` overlay series on charts — the same treatment and the same `dashboard.trend.*` labels the inline object-provider widgets already use.

--- a/packages/core/src/utils/__tests__/compare-to.test.ts
+++ b/packages/core/src/utils/__tests__/compare-to.test.ts
@@ -21,21 +21,21 @@ describe('shiftFilterByCompareTo', () => {
           $lte: '{current_quarter_end}',
         },
       };
-      const out = shiftFilterByCompareTo(filter, 'previousPeriod', now);
+      const out = shiftFilterByCompareTo(filter, { kind: 'previousPeriod' }, now);
       // Q2 2026 → Q1 2026 (2026-01-01 .. 2026-03-31)
       expect(out.created_at.$gte).toBe('2026-01-01');
       expect(out.created_at.$lte).toBe('2026-03-31');
     });
 
     it('substitutes today → yesterday', () => {
-      const out = shiftFilterByCompareTo({ at: '{today}' }, 'previousPeriod', now);
+      const out = shiftFilterByCompareTo({ at: '{today}' }, { kind: 'previousPeriod' }, now);
       expect(out.at).toBe('2026-05-24');
     });
 
     it('substitutes bare aliases (month_start / month_end)', () => {
       const out = shiftFilterByCompareTo(
         { d: { $gte: '{month_start}', $lte: '{month_end}' } },
-        'previousPeriod',
+        { kind: 'previousPeriod' },
         now,
       );
       // May 2026 → April 2026
@@ -44,7 +44,7 @@ describe('shiftFilterByCompareTo', () => {
     });
 
     it('passes filters with no date tokens through unchanged', () => {
-      const out = shiftFilterByCompareTo({ status: 'open' }, 'previousPeriod', now);
+      const out = shiftFilterByCompareTo({ status: 'open' }, { kind: 'previousPeriod' }, now);
       expect(out).toEqual({ status: 'open' });
     });
   });
@@ -54,67 +54,80 @@ describe('shiftFilterByCompareTo', () => {
       const filter = {
         d: { $gte: '{current_quarter_start}', $lte: '{current_quarter_end}' },
       };
-      const out = shiftFilterByCompareTo(filter, 'previousYear', now);
+      const out = shiftFilterByCompareTo(filter, { kind: 'previousYear' }, now);
       // Q2 2025 (2025-04-01 .. 2025-06-30)
       expect(out.d.$gte).toBe('2025-04-01');
       expect(out.d.$lte).toBe('2025-06-30');
     });
   });
 
-  describe('offset', () => {
-    it('shifts now by N days', () => {
-      const out = shiftFilterByCompareTo({ d: '{today}' }, { offset: '7d' }, now);
-      expect(out.d).toBe('2026-05-18');
+  // Replaces the retired `offset` block (objectstack#5011 removed that arm).
+  // Re-spelling those cases was not an option: they pinned the duration shift
+  // itself, so they would have gone green by producing nothing. What the
+  // converged shape needs pinned instead is that `dimension` — the one key the
+  // new object gained — stays the EXECUTOR's business: it names the dataset
+  // time dimension whose dateRange is shifted, and a renderer that let it reach
+  // its own filter shifting would be guessing at a window the executor owns.
+  describe('dimension is the executor’s, never read here', () => {
+    it('shifts identically with and without a dimension', () => {
+      const filter = { d: { $gte: '{current_month_start}', $lte: '{current_month_end}' } };
+      const bare = shiftFilterByCompareTo(filter, { kind: 'previousPeriod' }, now);
+      const named = shiftFilterByCompareTo(
+        filter,
+        { kind: 'previousPeriod', dimension: 'close_date' },
+        now,
+      );
+      expect(named).toEqual(bare);
+      expect(named.d.$gte).toBe('2026-04-01');
     });
-    it('shifts now by N weeks', () => {
-      const out = shiftFilterByCompareTo({ d: '{today}' }, { offset: '2w' }, now);
-      expect(out.d).toBe('2026-05-11');
-    });
-    it('shifts now by N months', () => {
-      const out = shiftFilterByCompareTo({ d: '{today}' }, { offset: '1M' }, now);
-      expect(out.d).toBe('2026-04-25');
-    });
-    it('shifts now by N years', () => {
-      const out = shiftFilterByCompareTo({ d: '{today}' }, { offset: '1y' }, now);
-      expect(out.d).toBe('2025-05-25');
-    });
-    it('falls back to current now when offset is malformed', () => {
-      const out = shiftFilterByCompareTo({ d: '{today}' }, { offset: 'garbage' }, now);
-      expect(out.d).toBe('2026-05-25');
+
+    it('never treats the dimension name as a filter key', () => {
+      const out = shiftFilterByCompareTo(
+        { status: 'open' },
+        { kind: 'previousYear', dimension: 'close_date' },
+        now,
+      );
+      expect(out).toEqual({ status: 'open' });
+      expect(out).not.toHaveProperty('close_date');
     });
   });
 });
 
 describe('compareToTrendLabelKey', () => {
   it('previousYear → vsLastYear regardless of filter', () => {
-    expect(compareToTrendLabelKey('previousYear', undefined)).toBe('vsLastYear');
-    expect(compareToTrendLabelKey('previousYear', { d: '{today}' })).toBe('vsLastYear');
+    expect(compareToTrendLabelKey({ kind: 'previousYear' }, undefined)).toBe('vsLastYear');
+    expect(compareToTrendLabelKey({ kind: 'previousYear' }, { d: '{today}' })).toBe('vsLastYear');
   });
 
-  it('offset → vsPreviousPeriod', () => {
-    expect(compareToTrendLabelKey({ offset: '7d' }, undefined)).toBe('vsPreviousPeriod');
+  it('derives the key from .kind alone — a dimension changes nothing', () => {
+    expect(
+      compareToTrendLabelKey({ kind: 'previousYear', dimension: 'close_date' }, { d: '{today}' }),
+    ).toBe('vsLastYear');
+    expect(
+      compareToTrendLabelKey({ kind: 'previousPeriod', dimension: 'close_date' }, { d: '{today}' }),
+    ).toBe('vsYesterday');
   });
 
   describe('previousPeriod token sniffing', () => {
     it('detects year', () => {
-      expect(compareToTrendLabelKey('previousPeriod', { d: '{current_year_start}' })).toBe('vsLastYear');
-      expect(compareToTrendLabelKey('previousPeriod', { d: '{year_start}' })).toBe('vsLastYear');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, { d: '{current_year_start}' })).toBe('vsLastYear');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, { d: '{year_start}' })).toBe('vsLastYear');
     });
     it('detects quarter', () => {
-      expect(compareToTrendLabelKey('previousPeriod', { d: '{current_quarter_end}' })).toBe('vsLastQuarter');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, { d: '{current_quarter_end}' })).toBe('vsLastQuarter');
     });
     it('detects month', () => {
-      expect(compareToTrendLabelKey('previousPeriod', { d: '{month_start}' })).toBe('vsLastMonth');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, { d: '{month_start}' })).toBe('vsLastMonth');
     });
     it('detects week', () => {
-      expect(compareToTrendLabelKey('previousPeriod', { d: '{current_week_start}' })).toBe('vsLastWeek');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, { d: '{current_week_start}' })).toBe('vsLastWeek');
     });
     it('detects today', () => {
-      expect(compareToTrendLabelKey('previousPeriod', { d: '{today}' })).toBe('vsYesterday');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, { d: '{today}' })).toBe('vsYesterday');
     });
     it('falls back to vsPreviousPeriod when no token matches', () => {
-      expect(compareToTrendLabelKey('previousPeriod', { status: 'open' })).toBe('vsPreviousPeriod');
-      expect(compareToTrendLabelKey('previousPeriod', undefined)).toBe('vsPreviousPeriod');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, { status: 'open' })).toBe('vsPreviousPeriod');
+      expect(compareToTrendLabelKey({ kind: 'previousPeriod' }, undefined)).toBe('vsPreviousPeriod');
     });
   });
 });

--- a/packages/core/src/utils/compare-to.ts
+++ b/packages/core/src/utils/compare-to.ts
@@ -11,19 +11,45 @@ import { resolveDateMacros } from './date-macros.js';
 /**
  * Period-over-period comparison config for dashboard widgets.
  *
- * - `'previousPeriod'` — substitute `current_*` / `today` date macro tokens
- *   with their `last_*` / `yesterday` counterparts (e.g. `current_quarter_start`
- *   → `last_quarter_start`). Best when the filter uses date macros.
- * - `'previousYear'` — re-resolve date macros against a `now` shifted back
- *   one calendar year (same week / month / quarter, one year earlier).
- * - `{ offset: '7d' | '4w' | '1M' | '1y' }` — re-resolve macros against a
- *   `now` shifted by the given duration. Units: `d` (day), `w` (week),
- *   `M` (month), `y` (year).
+ * Converged (objectstack#5011) onto the contract the analytics executor
+ * already implements — `DatasetSelection.compareTo`, i.e. `DatasetCompareTo`
+ * in `@objectstack/spec` (`contracts/analytics-service.ts`). This type is that
+ * contract's thin projection, so the same widget key means the same thing on
+ * the ADR-0021 dataset path and on this legacy inline object-provider path.
+ *
+ * - `kind: 'previousPeriod'` — the equal-length window immediately before the
+ *   current one. On the inline path that is done by substituting `current_*` /
+ *   `today` date macro tokens with their `last_*` / `yesterday` counterparts
+ *   (`current_quarter_start` → `last_quarter_start`), so it works best when the
+ *   filter is written with date macros.
+ * - `kind: 'previousYear'` — re-resolve the filter's date macros against a
+ *   `now` shifted back one calendar year (same week / month / quarter, one year
+ *   earlier).
+ * - `dimension` — OPTIONAL, and deliberately never read on this path. It names
+ *   the dataset time dimension whose `dateRange` the EXECUTOR shifts. That
+ *   resolution lives at the producer of the comparison so that every caller
+ *   gets the same answer or the same loud error; a renderer that guessed a
+ *   dimension would trade "loud error" for "quietly wrong window" — precisely
+ *   the failure class this convergence exists to end.
+ *
+ * **Design note — a plain strict object, NOT a union** (objectstack#5011,
+ * framework#5014). The retired shape was a three-branch union
+ * (`'previousPeriod' | 'previousYear' | { offset }`); zod collapses a failed
+ * union into a bare `Invalid input`, so the prescriptions written inside each
+ * arm never reached the author. One strict object keeps the rejection specific.
+ * It also leaves this renderer with exactly one contract to read — no second
+ * de-facto dialect to be tolerant about (AGENTS.md #0.1).
+ *
+ * The `{ offset: '7d' | '1M' | '1y' }` arm went with the union: `{ offset: '1y' }`
+ * IS `kind: 'previousYear'` (rewritten deterministically upstream), while
+ * `'7d'` / `'1M'` have no faithful target — an author restates that window on
+ * the widget's own `filter` and asks for `kind: 'previousPeriod'` (registered
+ * semantic migration `dashboard-widget-compareto-offset`).
  */
-export type CompareToConfig =
-  | 'previousPeriod'
-  | 'previousYear'
-  | { offset: string };
+export interface CompareToConfig {
+  kind: 'previousPeriod' | 'previousYear';
+  dimension?: string;
+}
 
 const CURRENT_TO_LAST_TOKENS: Record<string, string> = {
   current_week_start: 'last_week_start',
@@ -62,25 +88,11 @@ function substituteTokens<T>(value: T, map: Record<string, string>): T {
   return value;
 }
 
-function shiftNow(now: Date, offset: string): Date | null {
-  const m = offset.match(/^(\d+)([dwMy])$/);
-  if (!m) return null;
-  const n = parseInt(m[1], 10);
-  const unit = m[2];
-  const x = new Date(now);
-  if (unit === 'd') x.setDate(x.getDate() - n);
-  else if (unit === 'w') x.setDate(x.getDate() - n * 7);
-  else if (unit === 'M') x.setMonth(x.getMonth() - n);
-  else if (unit === 'y') x.setFullYear(x.getFullYear() - n);
-  else return null;
-  return x;
-}
-
 /**
- * Resolve a filter for a period-over-period comparison query.
+ * Resolve a filter for a period-over-period comparison query. Dispatches on
+ * `compareTo.kind` — the only discriminator the converged shape has:
  *
  * - `previousYear` — re-resolve date macros against a `now` shifted back by one year.
- * - `{ offset }` — re-resolve date macros against a `now` shifted by the given duration.
  * - `previousPeriod` — substitute `current_*` / `today` tokens with `last_*` / `yesterday`
  *   before resolving.
  */
@@ -89,7 +101,7 @@ export function shiftFilterByCompareTo<T = any>(
   compareTo: CompareToConfig,
   now: Date = new Date(),
 ): T {
-  if (compareTo === 'previousYear') {
+  if (compareTo.kind === 'previousYear') {
     const shifted = new Date(
       now.getFullYear() - 1,
       now.getMonth(),
@@ -98,11 +110,6 @@ export function shiftFilterByCompareTo<T = any>(
       now.getMinutes(),
       now.getSeconds(),
     );
-    return resolveDateMacros(filter, shifted);
-  }
-  if (typeof compareTo === 'object' && compareTo && 'offset' in compareTo) {
-    const shifted = shiftNow(now, compareTo.offset);
-    if (!shifted) return resolveDateMacros(filter, now);
     return resolveDateMacros(filter, shifted);
   }
   // previousPeriod
@@ -118,10 +125,7 @@ export function compareToTrendLabelKey(
   compareTo: CompareToConfig,
   filter?: unknown,
 ): string {
-  if (compareTo === 'previousYear') return 'vsLastYear';
-  if (typeof compareTo === 'object' && compareTo && 'offset' in compareTo) {
-    return 'vsPreviousPeriod';
-  }
+  if (compareTo.kind === 'previousYear') return 'vsLastYear';
   // previousPeriod — sniff the dominant token in the filter
   const json = filter ? JSON.stringify(filter) : '';
   if (/current_year_|year_start|year_end/.test(json)) return 'vsLastYear';

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -466,6 +466,10 @@ export const ObjectChart = (props: any) => {
           // — so both aggregate and find see real values and any drill-down
           // filter further down the line stays consistent.
           const resolvedFilter = resolveFilterPlaceholders(schema.filter, filterScope);
+          // `{ kind, dimension? }` since objectstack#5011. Nothing here reads the
+          // value apart from its presence: the ONE discriminator (`.kind`) is
+          // read where the shift is computed — `shiftFilterByCompareTo` — so
+          // this file has no second copy of the branch table to drift from it.
           const compareTo: CompareToConfig | undefined = (schema as any).compareTo;
           const wantsComparison = !!compareTo && supportsCompareTo(schema.chartType);
           // shiftFilterByCompareTo expects the raw filter (with date macros)

--- a/packages/plugin-charts/src/__tests__/ObjectChart.compareTo.test.tsx
+++ b/packages/plugin-charts/src/__tests__/ObjectChart.compareTo.test.tsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#3337 — the LEGACY inline object-provider chart path under the
+ * converged `compareTo` shape (`{ kind, dimension? }`, objectstack#5011).
+ *
+ * This path is where the retired three-branch union actually ran, so it is the
+ * one that has to keep working verbatim: the comparison window is fetched by
+ * shifting the widget's own filter, the previous-window values arrive under
+ * `<valueKey>__comparison`, and the overlay series is labelled from the same
+ * trend vocabulary the metric card uses.
+ *
+ * The window is a QUARTER so the two kinds disagree about both the window and
+ * the label — a year-scoped filter would let a `previousYear` that fell through
+ * to the previousPeriod branch pass anyway.
+ *
+ * Asserted at the schema handed to ChartRenderer — the seam the overlay is
+ * actually expressed in — rather than through Recharts' DOM, which draws
+ * nothing at jsdom's zero-size container.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+
+let lastSchema: any = null;
+
+vi.mock('../ChartRenderer', () => ({
+  ChartRenderer: (props: any) => {
+    lastSchema = props.schema;
+    return null;
+  },
+}));
+
+import { ObjectChart } from '../ObjectChart';
+
+afterEach(() => {
+  cleanup();
+  lastSchema = null;
+});
+
+const quarterStart = (d: Date) => new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1);
+const iso = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+const CURRENT_FROM = iso(quarterStart(new Date()));
+/** Same quarter, one year earlier — string surgery, independent of the shifter. */
+const PREVIOUS_YEAR_FROM = `${Number(CURRENT_FROM.slice(0, 4)) - 1}${CURRENT_FROM.slice(4)}`;
+
+/** 120 for the current window, 100 for whatever window the comparison asks for. */
+const makeSource = () => ({
+  aggregate: vi.fn(async (_object: string, q: any) => [
+    { stage: 'won', amount: String(q?.filter?.close_date?.$gte) === CURRENT_FROM ? 120 : 100 },
+  ]),
+});
+
+const comparisonFromOf = (src: { aggregate: any }) =>
+  src.aggregate.mock.calls
+    .map((c: any[]) => String(c[1].filter.close_date.$gte))
+    .find((from: string) => from !== CURRENT_FROM);
+
+const renderChart = (compareTo: unknown, dataSource: unknown) =>
+  render(
+    <ObjectChart
+      schema={{
+        objectName: 'deal',
+        chartType: 'bar',
+        aggregate: { field: 'amount', function: 'sum', groupBy: 'stage' },
+        filter: { close_date: { $gte: '{current_quarter_start}', $lte: '{current_quarter_end}' } },
+        xAxisKey: 'stage',
+        ...(compareTo ? { compareTo } : {}),
+      }}
+      dataSource={dataSource}
+    />,
+  );
+
+describe('ObjectChart — inline compareTo overlay under { kind }', () => {
+  it('previousYear fetches the same quarter one year back and overlays it', async () => {
+    const src = makeSource();
+    renderChart({ kind: 'previousYear' }, src);
+
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(2));
+    expect(comparisonFromOf(src)).toBe(PREVIOUS_YEAR_FROM);
+
+    await waitFor(() => expect(lastSchema?.series?.length).toBe(2));
+    expect(lastSchema.data[0]).toMatchObject({ amount: 120, amount__comparison: 100 });
+    expect(lastSchema.series[0]).toMatchObject({ dataKey: 'amount', variant: 'current' });
+    expect(lastSchema.series[1]).toMatchObject({ dataKey: 'amount__comparison', variant: 'comparison' });
+    // Label derived from `.kind`, not from the filter's quarter tokens.
+    expect(lastSchema.series[1].label).toBe('Previous year');
+  });
+
+  it('previousPeriod substitutes current_* tokens and labels by the filter’s window', async () => {
+    const src = makeSource();
+    renderChart({ kind: 'previousPeriod' }, src);
+
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(2));
+    // The PREVIOUS QUARTER — not the same quarter a year earlier.
+    expect(comparisonFromOf(src)).not.toBe(PREVIOUS_YEAR_FROM);
+    expect(String(comparisonFromOf(src)) < CURRENT_FROM).toBe(true);
+
+    await waitFor(() => expect(lastSchema?.series?.length).toBe(2));
+    expect(lastSchema.series[1].label).toBe('Previous quarter');
+  });
+
+  it('a dimension changes nothing here — it names a DATASET time dimension', async () => {
+    // `dimension` is the executor's input on the dataset path. The inline path
+    // shifts the widget's own filter, so carrying one must not alter the query.
+    const src = makeSource();
+    renderChart({ kind: 'previousYear', dimension: 'close_date' }, src);
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(2));
+    expect(comparisonFromOf(src)).toBe(PREVIOUS_YEAR_FROM);
+    await waitFor(() => expect(lastSchema?.series?.length).toBe(2));
+    expect(lastSchema.series[1]).toMatchObject({ dataKey: 'amount__comparison', variant: 'comparison' });
+  });
+
+  it('runs a single pass and adds no overlay without compareTo', async () => {
+    const src = makeSource();
+    renderChart(undefined, src);
+    await waitFor(() => expect(lastSchema).not.toBeNull());
+    expect(src.aggregate).toHaveBeenCalledTimes(1);
+    expect(lastSchema.data[0]).not.toHaveProperty('amount__comparison');
+  });
+});

--- a/packages/plugin-dashboard/SKILL.md
+++ b/packages/plugin-dashboard/SKILL.md
@@ -14,23 +14,52 @@ table, pivot, etc.) with drag/resize, drill-down, and async data binding.
 
 ## Period-over-period comparison (`compareTo`)
 
-Any dataset-bound widget (metric / gauge / chart) can opt into a
-period-over-period comparison by adding a `compareTo` field. The renderer
-issues a second dataset query against the comparison-period filter and:
+Any dataset-bound widget (metric / gauge / chart / table) can opt into a
+period-over-period comparison by adding a `compareTo` field. The dataset
+executor re-runs the same selection over the shifted window and attaches a
+`<measure>__compare` column to each row, which the widget shows as:
 
-- For **metric** & **gauge** widgets, computes a delta percentage and surfaces
-  it as a `trend` indicator (overrides any static `trend` prop).
+- For **metric** & **gauge** widgets, a delta percentage surfaced as a `trend`
+  indicator (overrides any static `trend` prop).
 - For **chart** widgets (line / area / bar / horizontal-bar / scatter / combo),
-  overlays a muted second series (dashed line, lower fill opacity). Pie,
-  donut, and funnel charts ignore `compareTo`.
+  a muted second series (dashed line, lower fill opacity). Pie, donut, and
+  funnel charts ignore `compareTo`.
+- For **table** widgets, a comparison column beside each compared measure.
 
-### Accepted values
+### Accepted value
 
-| Value | Meaning |
+`compareTo` is an object — the analytics executor's own contract
+(`DatasetSelection.compareTo`, objectstack#5011). It is a plain **strict**
+object, so an unknown key is rejected rather than ignored:
+
+```ts
+{ kind: 'previousPeriod' | 'previousYear', dimension?: string }
+```
+
+| Key | Meaning |
 |---|---|
-| `'previousPeriod'` | Substitute `current_*` / `today` date macro tokens with `last_*` / `yesterday` (e.g. `current_quarter_start` → `last_quarter_start`). Best when the filter uses date macros. |
-| `'previousYear'` | Re-resolve macros against a `now` shifted back one calendar year. |
-| `{ offset: '7d' \| '4w' \| '1M' \| '1y' }` | Re-resolve macros against `now` shifted by the given duration. Units: `d`, `w`, `M`, `y`. |
+| `kind: 'previousPeriod'` | The equal-length window immediately before the current one. On the inline (non-dataset) path this substitutes `current_*` / `today` date macro tokens with `last_*` / `yesterday` (e.g. `current_quarter_start` → `last_quarter_start`), so it works best when the filter uses date macros. |
+| `kind: 'previousYear'` | The same window shifted back one calendar year. |
+| `dimension` | Optional. Names the dataset time dimension whose window is shifted. **Omit it** unless the widget's window covers more than one date field — the executor resolves it, and says so loudly (listing the candidates) when there is not exactly one. |
+
+The earlier spellings are retired: the bare strings `"previousPeriod"` /
+`"previousYear"` are now `{ "kind": "previousPeriod" }` / `{ "kind":
+"previousYear" }`, and the `{ "offset": "…" }` form is gone. `{ offset: '1y' }`
+is `{ kind: 'previousYear' }`; `'7d'` / `'1M'` have no faithful equivalent —
+state that window on the widget's own `filter` and ask for
+`{ kind: 'previousPeriod' }`.
+
+### The window has to be a bounded date range
+
+A period-over-period comparison is only defined against a **bounded** window,
+so the widget's `filter` must date the measure with both ends —
+`{ "$gte": …, "$lte": … }` on a date field (a date-macro pair, or the
+dashboard's own date-range filter bound to that widget). The renderer lowers
+that window into the dataset query's time dimension for the executor to shift.
+
+A half-open `{ "$gte": … }`, an exclusive `$lt`, or no date condition at all
+leaves nothing to shift, and the widget surfaces the executor's error instead of
+rendering a comparison that silently isn't one.
 
 ### Trend label i18n
 
@@ -44,9 +73,10 @@ without per-card configuration:
 | `{current_month_*}` / `{month_*}` | `dashboard.trend.vsLastMonth` |
 | `{current_week_*}` / `{week_*}` | `dashboard.trend.vsLastWeek` |
 | `{today}` | `dashboard.trend.vsYesterday` |
-| anything else / `offset` | `dashboard.trend.vsPreviousPeriod` |
+| anything else | `dashboard.trend.vsPreviousPeriod` |
 
-`previousYear` always uses `vsLastYear` regardless of the filter shape.
+`kind: 'previousYear'` always uses `vsLastYear` regardless of the filter shape;
+the sniffing above applies to `kind: 'previousPeriod'`.
 
 ### Metric example
 
@@ -62,7 +92,7 @@ without per-card configuration:
       "$lte": "{current_quarter_end}"
     }
   },
-  "compareTo": "previousPeriod"
+  "compareTo": { "kind": "previousPeriod" }
 }
 ```
 
@@ -86,7 +116,7 @@ measure — its aggregate, field, format, and currency — is declared once on t
       "$lte": "{current_year_end}"
     }
   },
-  "compareTo": "previousYear"
+  "compareTo": { "kind": "previousYear" }
 }
 ```
 
@@ -95,21 +125,23 @@ Renders a line of monthly order counts for the current year with a dashed,
 points are aligned to current-period buckets by groupBy value when possible,
 otherwise by sorted index (the common case for time series).
 
-### Sliding offset example
+### Naming the dimension (only when the window is ambiguous)
 
 ```json
-{ "compareTo": { "offset": "7d" } }
+{ "compareTo": { "kind": "previousYear", "dimension": "created_at" } }
 ```
 
-Use when "this week vs last week" is more meaningful than "this calendar
-week vs last calendar week".
+Needed only when the widget's filter dates more than one field, so the executor
+cannot tell which window to shift. With a single dated field, omit `dimension`
+— hard-coding one that the dataset does not date is how a comparison ends up
+running over a window nobody asked for.
 
 ### When NOT to use `compareTo`
 
-- Filters that do not include any date macros — for `previousPeriod` /
-  `previousYear` the comparison filter would be identical to the current
-  filter, producing a meaningless 0% delta. Prefer `{ offset: '...' }` in
-  this case, or omit `compareTo` entirely.
+- Filters with no bounded date range — there is no window to shift, and the
+  widget reports that instead of rendering a comparison. Date the widget (a
+  date-macro `$gte`/`$lte` pair, or a dashboard date-range filter bound to it)
+  or omit `compareTo` entirely.
 - Pie / donut / funnel charts — comparison overlays are not visually
   meaningful and are silently ignored.
 

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -492,7 +492,11 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                         // animation to freeze at height 0 (#2756).
                         isAnimationActive: false,
                         drillDown: options.drillDown ?? defaultChartDrill(dispatch.chartType),
-                        compareTo: (widget as any).compareTo,
+                        // Passed through by value; its TYPE now comes from the
+                        // spec's converged `{ kind, dimension? }` (objectstack#5011),
+                        // which is what `CompareToConfig` projects — so the cast
+                        // that used to bridge the skew is gone.
+                        compareTo: widget.compareTo,
                         className: "h-[200px] sm:h-[250px] md:h-[300px]"
                     };
                 }

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -48,15 +48,16 @@ import {
   // cross-tab keys multi-dimension ACROSS buckets with it too.
   pivotBucketId as pivotRowId,
   pivotCellKey,
+  compareToTrendLabelKey,
   type CompareToConfig,
   type DatasetResultField,
   type DatasetDrillRange,
 } from '@object-ui/core';
 import { cn, Skeleton, ChartSkeleton, GridSkeleton } from '@object-ui/components';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
-import { BarChart3, AlertTriangle, Download } from 'lucide-react';
+import { BarChart3, AlertTriangle, Download, ArrowUpIcon, ArrowDownIcon, MinusIcon } from 'lucide-react';
 import { useFilterScope } from '@object-ui/react';
-import { resolveFilterPlaceholders } from './utils';
+import { resolveFilterPlaceholders, computeMetricDelta } from './utils';
 import { DrillDownDrawer } from './DrillDownDrawer';
 
 type Row = Record<string, unknown>;
@@ -150,6 +151,150 @@ function downloadCsv(filename: string, rows: Array<Array<string | number | null 
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+}
+
+/** Column the executor attaches a comparison window's value under. */
+const COMPARE_SUFFIX = '__compare';
+const compareColumn = (measure: string) => `${measure}${COMPARE_SUFFIX}`;
+
+/**
+ * English fallbacks for the `dashboard.trend.*` keys — the SAME vocabulary the
+ * inline `MetricWidget` / `ObjectMetricWidget` label their trend with, so a
+ * dataset-bound and an inline KPI comparing the same window read identically.
+ * No new key is introduced here.
+ */
+const TREND_LABEL_DEFAULTS: Record<string, string> = {
+  vsLastQuarter: 'vs last quarter',
+  vsLastMonth: 'vs last month',
+  vsLastWeek: 'vs last week',
+  vsLastYear: 'vs last year',
+  vsYesterday: 'vs yesterday',
+  vsPreviousPeriod: 'vs previous period',
+};
+
+/**
+ * ISO calendar date, optionally carrying a time part — `2026-01-15`,
+ * `2026-01-15T08:30:00Z`. Deliberately narrower than `Date.parse` (which also
+ * accepts `2026` and `March 5, 2026`); the same shape the dashboard filter
+ * layer already holds date values to (`core/utils/dashboard-filters.ts`).
+ */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(?:[T ][\d:.]+(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/** A `DatasetSelection.timeDimensions` entry stating a bounded window. */
+export interface DatasetTimeWindow {
+  dimension: string;
+  dateRange: [string, string];
+}
+
+/**
+ * A **bounded, closed** date window, or null. Exactly `{ $gte, $lte }` with two
+ * ISO-date bounds qualifies, and nothing else:
+ *
+ *  - `{ $gte: 1000 }` on an amount is a numeric range, not a window;
+ *  - `$gt` / `$lt` are EXCLUSIVE, and `dateRange` has no exclusive bound —
+ *    converting one would silently widen the window by a day;
+ *  - a half-open `{ $gte }` alone has no end to shift. A period-over-period
+ *    comparison is only defined against a bounded window, so leaving it in the
+ *    filter is what makes the executor say so out loud.
+ */
+function boundedDateWindow(value: unknown): [string, string] | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const keys = Object.keys(value as object);
+  if (keys.length !== 2 || !keys.includes('$gte') || !keys.includes('$lte')) return null;
+  const { $gte: from, $lte: to } = value as { $gte: unknown; $lte: unknown };
+  if (typeof from !== 'string' || typeof to !== 'string') return null;
+  if (!ISO_DATE_RE.test(from) || !ISO_DATE_RE.test(to)) return null;
+  return [from, to];
+}
+
+/**
+ * Split a RESOLVED runtime filter into the bounded date windows it states and
+ * the rest of the filter (objectui#3337 point 5).
+ *
+ * The executor shifts exactly one thing for a `compareTo`: a `timeDimensions`
+ * entry carrying a `dateRange`. A widget states its window in its own `filter`
+ * instead (a date macro, or the dashboard's date-range filter merged in by
+ * `DashboardRenderer`), which is why forwarding a structured `compareTo` alone
+ * still came back "compareTo needs a dated window to shift".
+ *
+ * Windows are **moved, not copied**: the comparison pass re-runs with the
+ * shifted `timeDimensions` but the SAME `runtimeFilter`, so a copy left behind
+ * would intersect the shifted window with the current one and every
+ * `<measure>__compare` column would come back empty.
+ *
+ * Only CONJUNCTIVE positions are walked — the top level and `$and` members. A
+ * window inside `$or` / `$not` is not a window the whole query runs in, so it
+ * stays in the filter untouched.
+ *
+ * **Which dimension gets shifted is not decided here.** Every window found is
+ * lowered under the name the author wrote. Zero of them, or two, is the
+ * executor's error to raise — it names the candidates (`resolveCompareDimension`).
+ * Guessing one renderer-side would trade a loud error for a quietly wrong
+ * window, which is the failure class objectstack#5011 set out to end.
+ */
+export function extractDateWindows(filter: unknown): {
+  windows: DatasetTimeWindow[];
+  rest: Record<string, unknown> | undefined;
+} {
+  // Insertion-ordered so the lowered windows (and any executor message listing
+  // them) are deterministic.
+  const ranges = new Map<string, [string, string]>();
+
+  const walk = (node: unknown): unknown => {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) return node;
+    const out: Record<string, unknown> = {};
+    let conjuncts: Record<string, unknown>[] | null = null;
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === '$and' && Array.isArray(value)) {
+        conjuncts = value
+          .map(walk)
+          .filter(
+            (c): c is Record<string, unknown> =>
+              !!c && typeof c === 'object' && !Array.isArray(c) && Object.keys(c).length > 0,
+          );
+        continue;
+      }
+      // Any other operator ($or, $not, …) is left whole, contents included.
+      if (key.startsWith('$')) {
+        out[key] = value;
+        continue;
+      }
+      const range = boundedDateWindow(value);
+      if (!range) {
+        out[key] = value;
+        continue;
+      }
+      const prev = ranges.get(key);
+      // Two conjunctive windows on ONE dimension are their intersection — plain
+      // arithmetic on the AND, not a heuristic. (The realistic pair: a widget
+      // that dates its own filter under a dashboard date-range filter bound to
+      // the same field.) Lexicographic comparison is chronological for ISO
+      // dates, whose fixed-width prefix orders bare dates and timestamps alike.
+      ranges.set(
+        key,
+        prev
+          ? [prev[0] > range[0] ? prev[0] : range[0], prev[1] < range[1] ? prev[1] : range[1]]
+          : range,
+      );
+    }
+    if (conjuncts && conjuncts.length > 0) out.$and = conjuncts;
+    return out;
+  };
+
+  const walked = walk(filter) as Record<string, unknown> | undefined;
+  let rest = walked && Object.keys(walked).length > 0 ? walked : undefined;
+  // `{ $and: [x] }` — a one-member conjunction left after its sibling was
+  // lowered — is just `x`. Unwrapped only at the top level and only when it is
+  // the sole key, so no sibling condition can be overwritten by the merge.
+  const only = rest && Object.keys(rest).length === 1 && Array.isArray(rest.$and) && rest.$and.length === 1
+    ? (rest.$and[0] as Record<string, unknown>)
+    : undefined;
+  if (only) rest = only;
+
+  return {
+    windows: Array.from(ranges, ([dimension, dateRange]) => ({ dimension, dateRange })),
+    rest,
+  };
 }
 
 /** Single-value KPI widget types — rendered as a number, not a chart. */
@@ -259,6 +404,21 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     [rawFilter, filterScope],
   );
 
+  // ── The comparison window (objectui#3337 point 5) ────────────────────────
+  // Lower the widget's already-resolved date window into the one place the
+  // executor can shift it — `selection.timeDimensions[].dateRange` — and only
+  // when a comparison is actually asked for. Without a comparison the window
+  // says exactly the same thing in `runtimeFilter`, and leaving every other
+  // widget's query byte-identical keeps this change to the path it is about.
+  // See `extractDateWindows` for why the windows are MOVED and why the choice
+  // of dimension is left to the executor.
+  const { windows: compareWindows, rest: selectionFilter } = useMemo(
+    () => (compareTo
+      ? extractDateWindows(runtimeFilter)
+      : { windows: [] as DatasetTimeWindow[], rest: runtimeFilter }),
+    [compareTo, runtimeFilter],
+  );
+
   const [state, setState] = useState<{ status: 'idle' | 'loading' | 'ok' | 'error'; rows: Row[]; fields?: DatasetResultField[]; object?: string; dimensionFields?: Record<string, string>; drillRawRows?: Array<Record<string, unknown>>; drillRanges?: Array<Record<string, DatasetDrillRange>>; totals?: DatasetTotals[]; error?: string }>({ status: 'idle', rows: [] });
   // Drill-through (ADR-0021 D2): the clicked bucket's record-list filter + title.
   const [drill, setDrill] = useState<{ filter: Record<string, unknown>; title: string } | null>(null);
@@ -299,7 +459,8 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     src.queryDataset(datasetName, {
       dimensions,
       measures: values,
-      ...(runtimeFilter ? { runtimeFilter } : {}),
+      ...(selectionFilter ? { runtimeFilter: selectionFilter } : {}),
+      ...(compareWindows.length > 0 ? { timeDimensions: compareWindows } : {}),
       ...(compareTo ? { compareTo } : {}),
       ...(totalsGroupings ? { totals: { groupings: totalsGroupings } } : {}),
       ...(dateGranularity ? { dateGranularity } : {}),
@@ -401,6 +562,25 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // shared with the report renderer via @object-ui/core.
   const { measureField, headerLabel } = buildDatasetFieldHelpers(state.fields, state.object, fieldLabel);
 
+  // --- Comparison overlay (objectui#3337) ---------------------------------
+  // The executor attaches a `<measure>__compare` column per measure once it has
+  // a window to shift. Showing it is the visible half of the comparison:
+  // forwarding `compareTo` and lowering the window only get the numbers INTO
+  // the result, and a widget that then drops them renders the very "silently no
+  // comparison" this issue is about. The comparison values carry the base
+  // measure's own format (they are the same measure over an earlier window).
+  const comparedValues = compareTo
+    ? values.filter((m) => state.rows.some((r) => r[compareColumn(m)] != null))
+    : [];
+  // Window label from the SAME `dashboard.trend.*` vocabulary the inline metric
+  // widget uses. `compareToTrendLabelKey` reads `compareTo.kind` and — for
+  // `previousPeriod` — the RAW filter's macro tokens, so "vs last quarter"
+  // survives the resolution that turned those tokens into dates.
+  const compareTrendKey = compareTo ? compareToTrendLabelKey(compareTo, rawFilter) : '';
+  const compareLabel = compareTo
+    ? tt(`dashboard.trend.${compareTrendKey}`, TREND_LABEL_DEFAULTS[compareTrendKey] ?? 'vs previous period')
+    : '';
+
   // --- Drill-through (shared by table/pivot AND chart) -------------------
   // Available when the server returned the dataset's base object + at least one
   // drillable dimension this widget groups by. Tables/pivots drill by row index;
@@ -431,9 +611,34 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   if (isMetric) {
     const f = measureField(values[0]);
     const value = state.rows[0]?.[values[0]] ?? 0;
+    // Period-over-period delta, computed from the SAME `computeMetricDelta` the
+    // inline KPI uses so both surfaces round and sign it identically.
+    const previous = state.rows[0]?.[compareColumn(values[0])];
+    const delta = comparedValues.includes(values[0])
+      ? computeMetricDelta(
+          typeof value === 'number' ? value : null,
+          typeof previous === 'number' ? previous : null,
+        )
+      : null;
     return (
       <div className="flex h-full w-full flex-col items-start justify-center gap-1 p-2">
         <span className="text-2xl font-semibold tabular-nums">{formatMeasure(value, f?.format, f?.currency, f?.percentScale)}</span>
+        {delta && (
+          <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground" data-testid="dataset-compare-trend">
+            <span className={cn(
+              'flex shrink-0 items-center font-medium',
+              delta.direction === 'up' && 'text-emerald-600 dark:text-emerald-400',
+              delta.direction === 'down' && 'text-rose-600 dark:text-rose-400',
+              delta.direction === 'neutral' && 'text-muted-foreground',
+            )}>
+              {delta.direction === 'up' && <ArrowUpIcon className="mr-1 h-3 w-3" />}
+              {delta.direction === 'down' && <ArrowDownIcon className="mr-1 h-3 w-3" />}
+              {delta.direction === 'neutral' && <MinusIcon className="mr-1 h-3 w-3" />}
+              {delta.value}%
+            </span>
+            <span className="min-w-0 truncate">{compareLabel}</span>
+          </div>
+        )}
         <span className="text-xs text-muted-foreground">{headerLabel(values[0])}</span>
       </div>
     );
@@ -447,9 +652,28 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     // CSV export — display-label headers + the underlying grouped rows (measures
     // kept numeric so the data round-trips into a spreadsheet). Shared by the flat
     // table and the cross-tab.
-    const exportColumns = [...dimensions, ...values];
+    // Measure columns, each followed by its comparison column when the executor
+    // attached one. `compareOf` names the base measure a comparison column
+    // belongs to — its format, and the label it is qualified with, both come
+    // from that measure (a comparison is the same measure over an earlier
+    // window). A measure literally named `<x>__compare` is still itself.
+    const compareOf = (column: string): string | undefined => {
+      if (values.includes(column) || !column.endsWith(COMPARE_SUFFIX)) return undefined;
+      const base = column.slice(0, -COMPARE_SUFFIX.length);
+      return values.includes(base) ? base : undefined;
+    };
+    const columnLabel = (column: string): string => {
+      const base = compareOf(column);
+      return base ? `${headerLabel(base)} · ${compareLabel}` : headerLabel(column);
+    };
+    const measureColumns = values.flatMap((m) =>
+      comparedValues.includes(m) ? [m, compareColumn(m)] : [m],
+    );
+    // The cross-tab does not spread comparison columns (that would key every
+    // cell by bucket × measure × window); its export stays the plain grid.
+    const exportColumns = [...dimensions, ...(isMatrix ? values : measureColumns)];
     const exportCsv = () => downloadCsv(String(widget?.title ?? datasetName ?? 'export'), [
-      exportColumns.map((c) => headerLabel(c)),
+      exportColumns.map((c) => columnLabel(c)),
       ...state.rows.map((r) => exportColumns.map((c) => {
         const v = r[c];
         return v == null ? '' : (typeof v === 'number' ? v : String(v));
@@ -566,14 +790,20 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     }
 
     // table (and a 1-dimension pivot) → a flat grouped table.
-    const columns = [...dimensions, ...values];
+    const columns = [...dimensions, ...measureColumns];
     return (
       <div className="relative h-full w-full overflow-auto p-1">{exportBtn}
         <table className="w-full text-xs">
           <thead className="bg-muted/40">
             <tr>
               {columns.map((c) => (
-                <th key={c} className="px-2 py-1.5 text-left font-medium whitespace-nowrap">{headerLabel(c)}</th>
+                <th
+                  key={c}
+                  className="px-2 py-1.5 text-left font-medium whitespace-nowrap"
+                  data-testid={compareOf(c) ? 'dataset-compare-column' : undefined}
+                >
+                  {columnLabel(c)}
+                </th>
               ))}
             </tr>
           </thead>
@@ -585,11 +815,17 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
                 data-testid={canDrill ? 'dataset-drill-row' : undefined}
                 onClick={canDrill ? () => openDrill(i, drillDims.map((d) => formatDimensionValue(row[d])).filter(Boolean).join(' / ')) : undefined}
               >
-                {columns.map((c) => (
-                  <td key={c} className="px-2 py-1 whitespace-nowrap tabular-nums">
-                    {values.includes(c) ? formatMeasure(row[c], measureField(c)?.format, measureField(c)?.currency, measureField(c)?.percentScale) : formatDimensionValue(row[c])}
-                  </td>
-                ))}
+                {columns.map((c) => {
+                  // A comparison column formats as the measure it compares.
+                  const measure = compareOf(c) ?? (values.includes(c) ? c : undefined);
+                  return (
+                    <td key={c} className="px-2 py-1 whitespace-nowrap tabular-nums">
+                      {measure
+                        ? formatMeasure(row[c], measureField(measure)?.format, measureField(measure)?.currency, measureField(measure)?.percentScale)
+                        : formatDimensionValue(row[c])}
+                    </td>
+                  );
+                })}
               </tr>
             ))}
           </tbody>
@@ -611,6 +847,25 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // ADR-0021 (#1759): shared helper — pivots a second dimension into grouped
   // series so multi-dimension dataset widgets match the chart-view renderer.
   const { data: chartData, xAxisKey, series } = buildChartSeries(chartRows, dimensions, values, state.fields);
+
+  // Comparison overlay — one extra series per compared measure, carrying the
+  // same `variant: 'comparison'` the inline chart's overlay uses (ObjectChart's
+  // augmentedSeries), so AdvancedChartImpl draws it muted/dashed here too.
+  // Skipped when buildChartSeries PIVOTED a second dimension into the series:
+  // those series are dimension VALUES, not measures, so there is no per-measure
+  // series a comparison could pair with (the `__compare` columns are still in
+  // the rows — nothing is lost, it just isn't drawn as an overlay).
+  const pivotedSeries = dimensions.length >= 2 && values.length === 1;
+  const comparisonSeries = pivotedSeries
+    ? []
+    : comparedValues.map((m) => ({
+        dataKey: compareColumn(m),
+        label: `${headerLabel(m)} · ${compareLabel}`,
+        variant: 'comparison' as const,
+      }));
+  const chartSeries = comparisonSeries.length > 0
+    ? [...series.map((s) => ({ ...s, variant: (s as { variant?: string }).variant ?? 'current' })), ...comparisonSeries]
+    : series;
 
   // Ordered-sequence charts (funnel/pyramid) need a DEFINED stage order.
   // `options.stageOrder` wins when the author states one explicitly; otherwise
@@ -662,7 +917,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
         // measurement churn, can freeze there — bars never draw until an unrelated
         // re-render (#2756, follow-up to #2727's ineffective settle re-mount).
         // Turning the tween off makes the first paint deterministic.
-        schema={{ type: 'chart', chartType, data: chartData, xAxisKey, series, isAnimationActive: false, ...(showLegend != null ? { showLegend } : {}), ...(categoryColors ? { categoryColors } : {}), ...(effectiveCategoryOrder ? { categoryOrder: effectiveCategoryOrder } : {}) } as any}
+        schema={{ type: 'chart', chartType, data: chartData, xAxisKey, series: chartSeries, isAnimationActive: false, ...(showLegend != null ? { showLegend } : {}), ...(categoryColors ? { categoryColors } : {}), ...(effectiveCategoryOrder ? { categoryOrder: effectiveCategoryOrder } : {}) } as any}
         onChartClick={chartDrill}
         onSegmentClick={chartDrill}
       />

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -48,6 +48,7 @@ import {
   // cross-tab keys multi-dimension ACROSS buckets with it too.
   pivotBucketId as pivotRowId,
   pivotCellKey,
+  type CompareToConfig,
   type DatasetResultField,
   type DatasetDrillRange,
 } from '@object-ui/core';
@@ -188,12 +189,16 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const datasetName = String(widget?.dataset ?? '');
   const dimensions: string[] = useMemo(() => (Array.isArray(widget?.dimensions) ? widget.dimensions.filter(Boolean) : []), [widget]);
   const values: string[] = useMemo(() => (Array.isArray(widget?.values) ? widget.values.filter(Boolean) : []), [widget]);
-  // Dataset `compareTo` must be the structured `{ kind, dimension }` shape (it
-  // needs a time dimension + dateRange). The legacy widget form is a bare string
-  // (`'previousPeriod'`) — forwarding it makes the executor throw "compareTo
-  // requires a timeDimension". Only pass the structured form; drop the legacy
-  // string (the base measure still renders; the comparison overlay is opt-in).
-  const compareTo = widget?.compareTo && typeof widget.compareTo === 'object' ? widget.compareTo : undefined;
+  // `widget.compareTo` IS the executor's contract since objectstack#5011 —
+  // `{ kind, dimension? }`, the same `DatasetCompareTo` the selection carries —
+  // so it forwards unchanged. It used to be a three-branch union whose two
+  // string arms had no meaning downstream and were dropped right here; the
+  // convergence deleted the arms instead of keeping the workaround, so there is
+  // no longer a widget form this path has to quietly discard. A stale string
+  // left in stored metadata is now INVALID metadata, rejected where it is
+  // authored/published — not laundered here into a different query
+  // (AGENTS.md #0.1).
+  const compareTo: CompareToConfig | undefined = widget?.compareTo;
   const widgetType = String(widget?.type ?? '');
   const isMetric = METRIC_TYPES.has(widgetType) || dimensions.length === 0;
   const isTable = widgetType === 'table' || widgetType === 'pivot';

--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -88,16 +88,19 @@ export interface ObjectMetricWidgetProps {
   /** Title for the drill-down panel; defaults to the metric label. */
   title?: string | { key?: string; defaultValue?: string };
   /**
-   * Period-over-period comparison configuration. When set, the widget
-   * issues a parallel aggregate for the comparison window and derives a
+   * Period-over-period comparison configuration — the executor's own
+   * `{ kind, dimension? }` contract since objectstack#5011. When set, the
+   * widget issues a parallel aggregate for the comparison window and derives a
    * trend (% delta + direction + i18n label like "vs last quarter").
    *
-   * - `'previousPeriod'`: same window length immediately before the current.
-   * - `'previousYear'`: same window shifted back one year.
-   * - `{ offset: '7d' }`: sliding window shifted back by N days/weeks.
+   * - `{ kind: 'previousPeriod' }`: same window length immediately before the current.
+   * - `{ kind: 'previousYear' }`: same window shifted back one year.
    *
-   * Has no effect when no `filter` (or no date filter) is provided — the
-   * shift uses the filter's date range to compute the comparison window.
+   * `dimension` is not read on this inline path — it names the dataset time
+   * dimension the EXECUTOR shifts, and this path shifts the widget's own
+   * `filter` instead. Has no effect when no `filter` (or no date filter) is
+   * provided — the shift uses the filter's date range to compute the
+   * comparison window.
    */
   compareTo?: CompareToConfig;
   /** Optional i18n translator used to localize the trend label. */
@@ -255,9 +258,9 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
       // a slow backend doesn't double the perceived load time.
       // Pass the RAW (unresolved) filter so `shiftFilterByCompareTo` can
       // substitute `{current_*}` tokens with their `{last_*}` counterparts
-      // (`previousPeriod`) or re-resolve macros against a shifted `now`
-      // (`previousYear` / `{offset}`). Passing the already-resolved filter
-      // would produce an identical query with no period shift.
+      // (`kind: 'previousPeriod'`) or re-resolve macros against a shifted `now`
+      // (`kind: 'previousYear'`). Passing the already-resolved filter would
+      // produce an identical query with no period shift.
       const comparisonFilter = compareTo
         ? shiftFilterByCompareTo(filter, compareTo)
         : null;

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.compareTo.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.compareTo.test.tsx
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#3337 point 5 — the one functional half of the `compareTo`
+ * convergence (objectstack#5011).
+ *
+ * Forwarding the structured `compareTo` is not enough on its own: the executor
+ * shifts a `timeDimensions` entry carrying a `dateRange`, and this widget only
+ * ever produced a `runtimeFilter`. A widget whose window lives in its own
+ * filter (a date macro, or the dashboard's date-range filter merged in) got
+ * "compareTo needs a dated window to shift" back and rendered no comparison.
+ *
+ * These tests pin the three halves of making it real: the window is LOWERED
+ * (and moved, not copied), the choice of dimension stays the EXECUTOR's, and
+ * the `<measure>__compare` columns the executor sends back are actually shown.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+
+let lastChartSchema: any = null;
+
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  SchemaRenderer: (props: any) => {
+    lastChartSchema = props.schema;
+    return null;
+  },
+}));
+
+import { DatasetWidget, extractDateWindows } from '../DatasetWidget';
+
+afterEach(() => {
+  cleanup();
+  lastChartSchema = null;
+});
+
+const makeSource = (impl: (d: string, s: any) => Promise<any>) => ({ queryDataset: vi.fn(impl) });
+const oneRow = async () => ({ rows: [{ revenue: 1 }] });
+const selectionOf = (src: { queryDataset: any }) => src.queryDataset.mock.calls[0][1];
+
+const Q2 = { close_date: { $gte: '2026-04-01', $lte: '2026-06-30' } };
+
+describe('extractDateWindows', () => {
+  it('lowers a bounded ISO window and removes it from the filter', () => {
+    const { windows, rest } = extractDateWindows({ ...Q2, stage: 'won' });
+    expect(windows).toEqual([{ dimension: 'close_date', dateRange: ['2026-04-01', '2026-06-30'] }]);
+    expect(rest).toEqual({ stage: 'won' });
+  });
+
+  it('returns no filter at all when the window was the whole filter', () => {
+    const { windows, rest } = extractDateWindows({ ...Q2 });
+    expect(windows).toHaveLength(1);
+    expect(rest).toBeUndefined();
+  });
+
+  // A `dateRange` is a DATE window. These four are not one, and quietly
+  // treating them as one is how a widget would end up shifting the wrong thing.
+  it('leaves a numeric range alone', () => {
+    const filter = { amount: { $gte: 1000, $lte: 5000 } };
+    expect(extractDateWindows(filter)).toEqual({ windows: [], rest: filter });
+  });
+
+  it('leaves an exclusive bound alone (dateRange has no exclusive bound)', () => {
+    const filter = { close_date: { $gte: '2026-04-01', $lt: '2026-07-01' } };
+    expect(extractDateWindows(filter)).toEqual({ windows: [], rest: filter });
+  });
+
+  it('leaves a half-open window alone (nothing bounded to shift)', () => {
+    const filter = { close_date: { $gte: '2026-04-01' } };
+    expect(extractDateWindows(filter)).toEqual({ windows: [], rest: filter });
+  });
+
+  it('leaves a window inside $or alone (it is not the window the query runs in)', () => {
+    const filter = { $or: [Q2, { stage: 'won' }] };
+    expect(extractDateWindows(filter)).toEqual({ windows: [], rest: filter });
+  });
+
+  it('walks $and members and unwraps the one-member conjunction left behind', () => {
+    // Exactly the shape DashboardRenderer's mergeFilters produces when a
+    // dashboard date-range filter is broadcast into a widget's own filter.
+    const { windows, rest } = extractDateWindows({ $and: [{ stage: 'won' }, Q2] });
+    expect(windows).toEqual([{ dimension: 'close_date', dateRange: ['2026-04-01', '2026-06-30'] }]);
+    expect(rest).toEqual({ stage: 'won' });
+  });
+
+  it('intersects two conjunctive windows on the SAME dimension', () => {
+    // Widget window (Q2) AND dashboard window (May) → May. Plain arithmetic on
+    // the AND — and it keeps the executor from being handed the same dimension
+    // twice and calling it ambiguous.
+    const { windows } = extractDateWindows({
+      $and: [Q2, { close_date: { $gte: '2026-05-01', $lte: '2026-05-31' } }],
+    });
+    expect(windows).toEqual([{ dimension: 'close_date', dateRange: ['2026-05-01', '2026-05-31'] }]);
+  });
+
+  it('keeps every dated dimension — picking one is the executor’s job', () => {
+    const { windows } = extractDateWindows({
+      close_date: { $gte: '2026-04-01', $lte: '2026-06-30' },
+      created_at: { $gte: '2026-01-01', $lte: '2026-12-31' },
+    });
+    expect(windows.map((w) => w.dimension)).toEqual(['close_date', 'created_at']);
+  });
+});
+
+describe('DatasetWidget — lowering the comparison window (#3337 point 5)', () => {
+  it('lowers the resolved date window into timeDimensions and MOVES it out of runtimeFilter', async () => {
+    const src = makeSource(oneRow);
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'metric', dataset: 'sales', values: ['revenue'],
+          filter: { ...Q2, stage: 'won' },
+          compareTo: { kind: 'previousPeriod' },
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    const selection = selectionOf(src);
+    expect(selection.timeDimensions).toEqual([
+      { dimension: 'close_date', dateRange: ['2026-04-01', '2026-06-30'] },
+    ]);
+    // MOVED, not copied. The comparison pass re-runs with the SHIFTED
+    // timeDimensions but the same runtimeFilter — a copy left here would
+    // intersect the shifted window with the current one and every
+    // `<measure>__compare` column would come back empty.
+    expect(selection.runtimeFilter).toEqual({ stage: 'won' });
+  });
+
+  it('resolves date macros before lowering them', async () => {
+    const src = makeSource(oneRow);
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'metric', dataset: 'sales', values: ['revenue'],
+          filter: { close_date: { $gte: '{current_quarter_start}', $lte: '{current_quarter_end}' } },
+          compareTo: { kind: 'previousPeriod' },
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    const [td] = selectionOf(src).timeDimensions;
+    expect(td.dimension).toBe('close_date');
+    // Concrete dates, not the macro tokens the executor would have to guess at.
+    expect(td.dateRange[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(td.dateRange[1]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('lowers nothing without compareTo — every other widget’s query is unchanged', async () => {
+    const src = makeSource(oneRow);
+    render(
+      <DatasetWidget
+        widget={{ type: 'metric', dataset: 'sales', values: ['revenue'], filter: { ...Q2 } }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect(selectionOf(src)).toEqual({
+      dimensions: [], measures: ['revenue'], runtimeFilter: Q2,
+    });
+  });
+
+  it('sends BOTH dated dimensions rather than picking one', async () => {
+    const src = makeSource(oneRow);
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'metric', dataset: 'sales', values: ['revenue'],
+          filter: { ...Q2, created_at: { $gte: '2026-01-01', $lte: '2026-12-31' } },
+          compareTo: { kind: 'previousYear' },
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(src.queryDataset).toHaveBeenCalled());
+    expect(selectionOf(src).timeDimensions).toHaveLength(2);
+    expect(selectionOf(src).compareTo).toEqual({ kind: 'previousYear' });
+  });
+
+  it('surfaces the executor’s ambiguity error un-swallowed', async () => {
+    // Verbatim from dataset-executor's resolveCompareDimension: the message
+    // names the candidates so the author can pick one. A renderer that guessed
+    // instead would have replaced this with a quietly wrong window.
+    const message =
+      '[dataset-executor] compareTo.dimension is ambiguous: 2 time dimensions carry a dateRange '
+      + '("close_date", "created_at"). Name the one to shift — '
+      + "compareTo: { kind: 'previousYear', dimension: 'close_date' }.";
+    const src = makeSource(async () => { throw new Error(message); });
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'metric', dataset: 'sales', values: ['revenue'],
+          filter: { ...Q2, created_at: { $gte: '2026-01-01', $lte: '2026-12-31' } },
+          compareTo: { kind: 'previousYear' },
+        }}
+        dataSource={src}
+      />,
+    );
+    expect(await screen.findByRole('alert')).toHaveTextContent(/ambiguous/);
+    expect(screen.getByRole('alert')).toHaveTextContent(/"close_date", "created_at"/);
+  });
+});
+
+describe('DatasetWidget — showing the comparison the executor returned', () => {
+  it('renders the KPI delta + window label from the __compare column', async () => {
+    const src = makeSource(async () => ({
+      rows: [{ revenue: 120, revenue__compare: 100 }],
+      fields: [{ name: 'revenue', type: 'number', label: 'Revenue' }, { name: 'revenue__compare', type: 'number' }],
+    }));
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'metric', dataset: 'sales', values: ['revenue'],
+          filter: { ...Q2 }, compareTo: { kind: 'previousYear' },
+        }}
+        dataSource={src}
+      />,
+    );
+    const trend = await screen.findByTestId('dataset-compare-trend');
+    expect(trend).toHaveTextContent('20%');
+    expect(trend).toHaveTextContent(/vs last year/i);
+  });
+
+  it('labels the window from the RAW filter’s macros, which resolution erased', async () => {
+    // `previousPeriod` derives its label by sniffing the filter's date macros.
+    // The resolved filter has none left — passing that instead would silently
+    // downgrade every label to the generic "vs previous period".
+    const src = makeSource(async () => ({ rows: [{ revenue: 120, revenue__compare: 100 }] }));
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'metric', dataset: 'sales', values: ['revenue'],
+          filter: { close_date: { $gte: '{current_quarter_start}', $lte: '{current_quarter_end}' } },
+          compareTo: { kind: 'previousPeriod' },
+        }}
+        dataSource={src}
+      />,
+    );
+    expect(await screen.findByTestId('dataset-compare-trend')).toHaveTextContent(/vs last quarter/i);
+  });
+
+  it('shows no trend when the executor attached no comparison', async () => {
+    const src = makeSource(async () => ({ rows: [{ revenue: 120 }] }));
+    render(
+      <DatasetWidget
+        widget={{ type: 'metric', dataset: 'sales', values: ['revenue'], filter: { ...Q2 }, compareTo: { kind: 'previousYear' } }}
+        dataSource={src}
+      />,
+    );
+    await screen.findByText('120');
+    expect(screen.queryByTestId('dataset-compare-trend')).not.toBeInTheDocument();
+  });
+
+  it('renders a comparison COLUMN in the table, formatted as its base measure', async () => {
+    const src = makeSource(async () => ({
+      rows: [
+        { stage: 'won', revenue: 120, revenue__compare: 100 },
+        { stage: 'lost', revenue: 20, revenue__compare: 40 },
+      ],
+      fields: [
+        { name: 'stage', type: 'string', label: 'Stage' },
+        { name: 'revenue', type: 'number', label: 'Revenue', format: '$0,0' },
+        { name: 'revenue__compare', type: 'number' },
+      ],
+    }));
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'table', dataset: 'sales', dimensions: ['stage'], values: ['revenue'],
+          filter: { ...Q2 }, compareTo: { kind: 'previousYear' },
+        }}
+        dataSource={src}
+      />,
+    );
+    const header = await screen.findByTestId('dataset-compare-column');
+    expect(header).toHaveTextContent(/Revenue/);
+    expect(header).toHaveTextContent(/vs last year/i);
+    // The comparison value carries the base measure's format — it is the same
+    // measure over an earlier window, so "$100", never a bare 100.
+    expect(screen.getByText('$100')).toBeInTheDocument();
+    expect(screen.getByText('$120')).toBeInTheDocument();
+  });
+
+  it('appends a comparison SERIES to the chart, marked for the overlay treatment', async () => {
+    const src = makeSource(async () => ({
+      rows: [
+        { stage: 'won', revenue: 120, revenue__compare: 100 },
+        { stage: 'lost', revenue: 20, revenue__compare: 40 },
+      ],
+      fields: [{ name: 'revenue', type: 'number', label: 'Revenue' }],
+    }));
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'],
+          filter: { ...Q2 }, compareTo: { kind: 'previousYear' },
+        }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(lastChartSchema).not.toBeNull());
+    expect(lastChartSchema.series).toHaveLength(2);
+    expect(lastChartSchema.series[0]).toMatchObject({ dataKey: 'revenue', variant: 'current' });
+    expect(lastChartSchema.series[1]).toMatchObject({
+      dataKey: 'revenue__compare',
+      variant: 'comparison',
+    });
+    expect(lastChartSchema.series[1].label).toMatch(/vs last year/i);
+  });
+
+  it('adds no comparison series when no __compare column came back', async () => {
+    const src = makeSource(async () => ({ rows: [{ stage: 'won', revenue: 120 }] }));
+    render(
+      <DatasetWidget
+        widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'], compareTo: { kind: 'previousYear' } }}
+        dataSource={src}
+      />,
+    );
+    await waitFor(() => expect(lastChartSchema).not.toBeNull());
+    expect(lastChartSchema.series).toHaveLength(1);
+    expect(lastChartSchema.series[0].variant).toBeUndefined();
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -100,15 +100,25 @@ describe('DatasetWidget', () => {
     await waitFor(() => expect(src.queryDataset).toHaveBeenCalledWith('sales', { dimensions: ['stage'], measures: ['revenue'] }));
   });
 
-  it('forwards a structured compareTo, but drops the legacy string form (which the executor cannot run)', async () => {
-    const structured = { kind: 'previousPeriod', dimension: 'close_date' };
+  // Replaces (does not amend) the assertion that pinned "structured forwarded,
+  // strings dropped". `compareTo` converged on the executor's own
+  // `{ kind, dimension? }` (objectstack#5011), so there is no second widget form
+  // left for this widget to discard — the whole value forwards, and the string
+  // spelling is now invalid METADATA, rejected where it is authored rather than
+  // laundered here.
+  it('forwards compareTo unchanged — the executor’s own { kind, dimension? } contract', async () => {
+    const withDimension = { kind: 'previousPeriod', dimension: 'close_date' };
     const src1 = makeSource(async () => ({ rows: [{ revenue: 1 }] }));
-    render(<DatasetWidget widget={{ type: 'metric', dataset: 'sales', values: ['revenue'], compareTo: structured }} dataSource={src1} />);
-    await waitFor(() => expect(src1.queryDataset).toHaveBeenCalledWith('sales', { dimensions: [], measures: ['revenue'], compareTo: structured }));
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'sales', values: ['revenue'], compareTo: withDimension }} dataSource={src1} />);
+    await waitFor(() => expect(src1.queryDataset).toHaveBeenCalledWith('sales', { dimensions: [], measures: ['revenue'], compareTo: withDimension }));
 
+    // `dimension` omitted — the executor resolves it (or fails loudly naming the
+    // candidates). The widget must NOT fill one in on its way past.
+    const bare = { kind: 'previousYear' };
     const src2 = makeSource(async () => ({ rows: [{ revenue: 1 }] }));
-    render(<DatasetWidget widget={{ type: 'metric', dataset: 'sales', values: ['revenue'], compareTo: 'previousPeriod' }} dataSource={src2} />);
-    await waitFor(() => expect(src2.queryDataset).toHaveBeenCalledWith('sales', { dimensions: [], measures: ['revenue'] }));
+    render(<DatasetWidget widget={{ type: 'metric', dataset: 'sales', values: ['revenue'], compareTo: bare }} dataSource={src2} />);
+    await waitFor(() => expect(src2.queryDataset).toHaveBeenCalledWith('sales', { dimensions: [], measures: ['revenue'], compareTo: bare }));
+    expect(src2.queryDataset.mock.calls[0][1].compareTo).not.toHaveProperty('dimension');
   });
 
   it('forwards the widget filter as runtimeFilter — a dataset-bound widget stays filtered (ADR-0021)', async () => {

--- a/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.compareTo.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.compareTo.test.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#3337 — the inline KPI half of the legacy `compareTo` path under the
+ * converged `{ kind, dimension? }` shape (objectstack#5011).
+ *
+ * The widget issues a second aggregate over the shifted window and derives the
+ * trend from the two values; the i18n label comes from `compareTo.kind` (plus,
+ * for `previousPeriod`, the filter's own macro vocabulary).
+ *
+ * The window is deliberately a QUARTER: the two kinds then disagree about both
+ * the window (`previousYear` = same quarter −1y, `previousPeriod` = the quarter
+ * before) and the label (`vs last year` / `vs last quarter`), so each case can
+ * only pass by reading `.kind`. A year-scoped filter would have let a
+ * `previousYear` that fell through to the previousPeriod branch pass anyway.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { ObjectMetricWidget } from '../ObjectMetricWidget';
+
+afterEach(cleanup);
+
+/** The current window's own bounds, resolved the same way the widget resolves them. */
+const quarterStart = (d: Date) => new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1);
+const iso = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+const CURRENT_FROM = iso(quarterStart(new Date()));
+/** Same quarter, one year earlier — string surgery, independent of the shifter. */
+const PREVIOUS_YEAR_FROM = `${Number(CURRENT_FROM.slice(0, 4)) - 1}${CURRENT_FROM.slice(4)}`;
+
+const makeSource = () => ({
+  aggregate: vi.fn(async (_object: string, q: any) => [
+    { amount_sum: String(q?.filter?.close_date?.$gte) === CURRENT_FROM ? 120 : 100 },
+  ]),
+});
+
+const comparisonFilterOf = (src: { aggregate: any }) => {
+  const call = src.aggregate.mock.calls.find(
+    (c: any[]) => String(c[1].filter.close_date.$gte) !== CURRENT_FROM,
+  );
+  return call?.[1].filter.close_date;
+};
+
+const renderWidget = (compareTo: unknown, dataSource: unknown) =>
+  render(
+    <ObjectMetricWidget
+      objectName="deal"
+      label="Revenue"
+      aggregate={{ field: 'amount', function: 'sum' }}
+      filter={{ close_date: { $gte: '{current_quarter_start}', $lte: '{current_quarter_end}' } }}
+      compareTo={compareTo as any}
+      dataSource={dataSource as any}
+    />,
+  );
+
+describe('ObjectMetricWidget — compareTo under { kind }', () => {
+  it('previousYear shifts the SAME quarter back one year and labels "vs last year"', async () => {
+    const src = makeSource();
+    renderWidget({ kind: 'previousYear' }, src);
+
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(2));
+    expect(comparisonFilterOf(src).$gte).toBe(PREVIOUS_YEAR_FROM);
+
+    // 120 vs 100 → +20%, labelled off `.kind` and NOT off the filter's quarter
+    // tokens (which is what the previousPeriod arm reads).
+    expect(await screen.findByText('20%')).toBeInTheDocument();
+    expect(await screen.findByText(/vs last year/i)).toBeInTheDocument();
+    expect(screen.queryByText(/vs last quarter/i)).not.toBeInTheDocument();
+  });
+
+  it('previousPeriod substitutes current_* → last_* and labels "vs last quarter"', async () => {
+    const src = makeSource();
+    renderWidget({ kind: 'previousPeriod' }, src);
+
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(2));
+    const cmp = comparisonFilterOf(src);
+    // The PREVIOUS QUARTER, which is not the same quarter a year earlier.
+    expect(cmp.$gte).not.toBe(PREVIOUS_YEAR_FROM);
+    expect(cmp.$lte < CURRENT_FROM).toBe(true);
+
+    expect(await screen.findByText('20%')).toBeInTheDocument();
+    expect(await screen.findByText(/vs last quarter/i)).toBeInTheDocument();
+  });
+
+  it('carries a dimension without letting it touch the query', async () => {
+    // `dimension` addresses a DATASET time dimension, resolved by the executor.
+    // This inline path shifts the widget's own filter, so it must be inert here.
+    const src = makeSource();
+    renderWidget({ kind: 'previousYear', dimension: 'close_date' }, src);
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(2));
+    for (const call of src.aggregate.mock.calls) {
+      expect(Object.keys(call[1].filter)).toEqual(['close_date']);
+    }
+    expect(comparisonFilterOf(src).$gte).toBe(PREVIOUS_YEAR_FROM);
+  });
+
+  it('runs a single pass and shows no trend without compareTo', async () => {
+    const src = makeSource();
+    renderWidget(undefined, src);
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/vs last/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #3337

上游 objectstack#5011 把 `DashboardWidgetSchema.compareTo` 从三分支联合收敛为执行器早已实现的那份契约(`DatasetCompareTo`,普通 strict object)。本仓是消费侧适配。前提已实测:pin 的 `@objectstack/spec` 解析到 **17.0.0-rc.5**,`node_modules` 里 `compareTo: z.ZodOptional&lt;z.ZodObject&lt;{ kind, dimension? }, $strict&gt;&gt;`,`DatasetCompareTo.dimension` 已是可选并注明由执行器决议。

两个 commit,按「改型」与「唯一的功能改动」分开:

## 1. `refactor`:类型收敛(正文 1-4、6-8 点)

- `CompareToConfig` → `{ kind: 'previousPeriod' | 'previousYear'; dimension?: string }`;`shiftFilterByCompareTo` / `compareToTrendLabelKey` 按 `.kind` 分派,`{ offset }` 的时长位移随分支删除。
- **无孤儿语言包 key**(按 PM 裁决只报不删,实测为零):offset 分支原本返回 `vsPreviousPeriod`,而它正是 `previousPeriod` 的兜底,六个 `dashboard.trend.*` 一个没少。本 PR 未触碰任何语言包文件。
- `DatasetWidget` 删掉 `typeof widget.compareTo === 'object'` 的字符串丢弃 workaround 及那句已不成立的注释,`widget.compareTo` 原样转发。遗留字符串在新形状下是**非法元数据**,应在作者/发布侧被拒,而不是在渲染器里改写成另一个查询(AGENTS.md #0.1)。
- `ObjectChart` / `ObjectMetricWidget` / `DashboardRenderer`:这三处**本来就没有整值判别** —— 它们只把值转发进两个 core helper,唯一的判别式在 helper 里。所以是类型与注释跟随,外加删掉 `DashboardRenderer` 里那个用来兜跨仓 skew 的 `as any`。这一点与 issue 正文的预期不同,如实说明。

## 2. `feat`:唯一的功能改动(正文第 5 点)

只做改型的话,dataset 路径只是**换个报错**继续坏:执行器要位移的是带 `dateRange` 的 `timeDimensions` 条目,而本组件只产出 `runtimeFilter`。所以在**且仅在**请求对比时,把已解析的日期窗口降进 `selection.timeDimensions[].dateRange`:

- **是搬走,不是复制。** 对比 pass 用位移后的 timeDimensions 但**同一份** `runtimeFilter`;留一份副本会让位移窗口与当前窗口取交集,每个 `__compare` 列都空。
- 只认**闭合有界**的 `{ $gte, $lte }` ISO 日期对。数值区间不是窗口;`$gt`/`$lt` 是开区间而 `dateRange` 没有开区间上界;半开的 `{ $gte }` 没有可位移的终点。三者都留在 filter 里 —— 这正是让执行器把话说出口的方式。
- 只走**合取**位置(顶层与 `$and`);`$or` 里的窗口不是整条查询所处的窗口。同一维度上的两个合取窗口取交集(AND 上的算术),顺带避免把同一个维度名递给执行器两次再被判为歧义。
- **不在渲染器侧挑维度**:每个窗口按作者写的字段名下沉;零个或多个由执行器报错并列出候选。渲染器自己猜维度 = 把「响亮报错」换成「安静的错窗口」,正是这次收敛要终结的失败类。

**验收里那句「真的渲染出对比列」需要的第二半**:本组件此前**根本不渲染** `__compare` 列(表格 `columns = [...dimensions, ...values]`、metric 只读 `values[0]`),所以就算对比成功也会被丢掉 —— 同一个「静默无对比」的另一个方向。现在 KPI 显示 delta + 窗口标签(复用 `computeMetricDelta` 与内联 metric 卡片同一套 `dashboard.trend.*`,不新增 key),表格多一列(按基础度量的 format 格式化,如 `revenue__compare` 显示 `$100`),图表多一条 `variant: 'comparison'` 覆盖序列(与 ObjectChart 的 overlay 同款)。交叉表(pivot ≥2 维)**有意不做**:把对比铺进 桶 × 度量 × 窗口 是另一个布局决策,已另开 finding 记录。

## 验证

- 全量 vitest(仓根,flock 串行 + `--maxWorkers=2`):`packages/core` `packages/plugin-dashboard` `packages/plugin-charts` → **110 files / 1817 tests passed**。
- `type-check` 三包全绿;改动文件 eslint **0 error**;`check-control-bytes` OK;changeset guard(无 `major`)OK。
- **逆向验证(先预测方向再跑)** —— 保留新测试、把 5 个源文件回退到 `origin/main`,结果与预测逐条吻合:
  - `compare-to.test.ts` **红 3 条**(previousYear 窗口 + 两条 label key):旧码用 `compareTo === 'previousYear'` 比字符串,`{ kind: 'previousYear' }` 落进 previousPeriod 分支。
  - `DatasetWidget.compareTo.test.tsx` **红 16/20**(旧码没有 `extractDateWindows`、不下沉窗口、不渲染对比);绿的 4 条全是「无 compareTo 时不变」的反向对照。
  - 内联两个文件各 **红 2/4**,红的恰是 previousYear 两条;previousPeriod 与无 compareTo 两条前后都绿 —— 那条分支本来就没改,如实记录。
  - ⚠️ **`DatasetWidget.test.tsx` 第 8 点的反转断言,对旧码是绿的**,不是红。派发单预设的 before-red 在这里不成立:旧守卫的判别式是 `typeof === 'object'`,而新形状的**每一个**取值都是 object。真正变化的是「字符串拼写不再由渲染器裁决」,它落回 schema 的具名拒绝(#5018 家族的倒置方向)。因此那条老断言是**整条替换**:原来钉的「字符串被丢弃」随着字符串形态一起消失,替换成「省略 `dimension` 时不得替作者补一个」。同理 core 测试里的 `offset` 块也是整条替换(re-spell 只会让它「因为什么都没产出」而绿),换成钉住 `dimension` 属于执行器、渲染器不读。
  - 内联路径新测试特意用**季度**窗口:previousYear 与 previousPeriod 在窗口和标签上都不同,若用年窗口,一个落错分支的 previousYear 也会蒙混过关。

## 越界说明(1 处,有意)

`packages/plugin-dashboard/SKILL.md` 不在派发单的文件围栏内,但它是本包面向 AI 作者的授权文档,原文三个 JSON 示例写的正是已退役拼写(`"compareTo": "previousPeriod"` / `{ "offset": "7d" }`)—— 留着会让 AI 持续产出被 strict schema 拒绝的元数据。按 AGENTS.md #2(docs-driven)一并更新,并补上「窗口必须有界」这条新的作者约束。与在途 #3546-s2(语言包)、#3584(CONTRIBUTING.md)无文件相交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_