### PR TITLE
docs(contributing): 按真实 root scripts 重写三条死的开发服务器命令 (#3596)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,14 +81,16 @@ git checkout -b feature/your-feature-name
 ### Running Development Servers
 
 ```bash
-# Run the visual designer demo
-pnpm designer
+# Run the console app — the main dev playground (app shell + the full plugin set,
+# including the visual designer, which mounts here rather than in a demo of its own)
+pnpm dev
 
-# Run the prototype example
-pnpm prototype
+# Run an example app (console-starter and byo-backend-console are the two that ship
+# a dev server; hello-world has none, and schema-catalog is a data package)
+pnpm --filter @object-ui/example-console-starter dev
 
-# Run documentation site
-pnpm docs:dev
+# Run the documentation site
+pnpm site:dev
 ```
 
 ### Building


### PR DESCRIPTION
Fixes #3596

`### Running Development Servers` 一节三条命令全部不可运行。本 PR 只改这一节的围栏内容,逐条以 root `package.json` 实测结果为准重写,没有发明命令。

## 前提复核(三条全部坐实)

分支点 `origin/main` @ `42ae5c62a`:

```
grep -n '"designer"|"prototype"|"docs:dev"|"site:dev"' package.json
26:    "site:dev": "pnpm --filter @object-ui/site dev",
```

四个名字里只有 `site:dev` 命中。`designer` / `prototype` / `docs:dev` 在 root scripts 里都不存在 —— 与单子正文一致。

## 逐条处置与证据

| 原命令 | 处置 | 实测证据 |
|---|---|---|
| `pnpm designer` | 换成 `pnpm dev` | `packages/plugin-designer` 的 scripts 只有 `build`/`clean`/`test`/`type-check`/`lint`,**没有 `dev`** —— 所以 `pnpm --filter @object-ui/plugin-designer dev` 这种形式跑不通,不能写。它是**库**不是 demo:`FieldDesigner` 由 `apps/console/src/components/schema/ObjectFieldDesignerWidget.tsx:15` 导入,经 `registerObjectDetailWidgets.ts:72` 注册为 `object-field-designer`。可视化设计器真正跑起来的地方就是 console,而 console 的 root script 是 `dev` |
| `pnpm prototype` | 换成 `pnpm --filter @object-ui/example-console-starter dev` | `grep -rn 'prototype' --include=package.json packages apps examples docs` → **零命中**,没有同名包、脚本或包名子串。无从建立等价关系(仓库历史是 shallow graft,161 commits,查不到这两个 script 曾经存在)。故不宣称 console-starter 就是当年的 prototype,只按「跑一个 example」这个真实需求写实测可用的入口 |
| `pnpm docs:dev` | 换成 `pnpm site:dev` | root script 实测存在:`site:dev` → `pnpm --filter @object-ui/site dev`。无歧义 |

新写的三条全部验证为**原则上可运行**(只验解析,未真的起服务):

```
root script dev        EXISTS => pnpm --filter @object-ui/console dev
root script site:dev   EXISTS => pnpm --filter @object-ui/site dev
example-console-starter dev => vite | name: @object-ui/example-console-starter
pnpm --filter @object-ui/example-console-starter exec pwd
  -> /home/user/objectui-issue-3596/examples/console-starter
```

example 那条的括号注释同样是实测的:有 `dev` 的 example 只有 `console-starter` 与 `byo-backend-console`;`hello-world` 没有、`schema-catalog` 是数据包 —— 与 `README.md:74-80` 的既有表述一致。

## 通读全节

改完把 `## Development Workflow` 整节读了一遍(Running Development Servers / Building / Testing / Linting)。相邻各节的命令全部实测存在:root 的 `build`/`test`/`test:watch`/`test:ui`/`test:coverage`/`lint` 均在;`cd packages/core && pnpm build` 与 `cd packages/react && pnpm lint` 两个包也都在且带对应 script。本节之外无需改动,**无新发现可立单**。

## 门禁(先预告再跑,三项全中)

```
node scripts/check-doc-links.mjs      Links are valid across 3 scan roots. (exit 0)
node scripts/check-control-bytes.mjs  OK (scanned 3643 tracked text file(s)) (exit 0)
grep -naP 控制字符自扫 CONTRIBUTING.md  clean(超出门禁扫描面的自查)
pnpm exec vitest run scripts/ --maxWorkers=2   16 files / 275 tests passed
```

**扫描面状态(如实报告,与派单预设相反)**:派单说「若 #3589 已合并,CONTRIBUTING.md 就在扫描面里」。**#3589 目前仍是 open、未合并**,所以我的分支点上 `SCAN_ROOTS` 仍是 `content/docs` / `examples` / `README.md` **三根**,门禁打印的正是 `across 3 scan roots` —— 这个数字与 #3589 自己那张逆向验证表第 4 行(撤掉三行 → `Links are valid across 3 scan roots.`)完全吻合,可互为佐证。

无论 #3589 是否落地,本改动都不会让该门禁变红:改动整块在 ```bash 围栏内,`stripCode()`(`check-doc-links.mjs:281`,调用点 `:577`)扫描前会把围栏抹掉;而且本次一条 markdown 链接都没有增删。#3589 也没有触碰 `CONTRIBUTING.md`,两边零冲突。

无 changeset:根目录贡献文档,非用户可见的产品变更。未触碰 `content/docs/releases/`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_