### PR TITLE
docs(runner): 删掉 runner.mdx 的幽灵目录与「内置示例 schema」断言,重写 Package Information

### DIFF
--- a/content/docs/utilities/runner.mdx
+++ b/content/docs/utilities/runner.mdx
@@ -56,17 +56,14 @@ The Runner includes these plugins by default:
 - **@object-ui/plugin-kanban** - Kanban board with drag-and-drop
 - **@object-ui/plugin-charts** - Data visualization charts
 
-### Example Schemas
+### Metadata — Supplied by You
 
-The Runner includes example schemas demonstrating:
-
-- Dashboard layouts
-- Data tables and grids
-- Form validation
-- Kanban boards
-- Chart visualizations
-- Calendar views
-- Timeline displays
+The Runner ships **no** metadata of its own: the package contains no `.json` schema
+files, so a fresh checkout renders nothing until you give it something to render. The
+two ways to do that are covered under [Metadata Loading](#metadata-loading) — drop JSON
+into `src/app-data/` (git-ignored, yours to create), or point the Runner at a backend
+with `?api=<base>`. With neither in place, `/` shows the built-in `No index page found.`
+placeholder.
 
 ### Development Tools
 
@@ -75,22 +72,19 @@ The Runner includes example schemas demonstrating:
 - **React DevTools** - Inspect component tree
 - **Network Inspector** - Monitor API calls
 
-## Directory Structure
+## Where the Code Lives
 
-```
-packages/runner/
-├── src/
-│   ├── App.tsx              # Main application
-│   ├── main.tsx             # Entry point
-│   ├── schemas/             # Example schemas
-│   │   ├── dashboard.json
-│   │   ├── kanban.json
-│   │   └── charts.json
-│   └── components/          # Custom components
-├── public/                  # Static assets
-├── package.json
-└── vite.config.ts
-```
+`packages/runner/src` is small and holds no metadata. `main.tsx` mounts the root
+component; `App.tsx` is that root — it picks the metadata loader from the `api` query
+parameter, imports the pre-installed plugins, handles routing, and hands the loaded page
+to `<SchemaRenderer>`. `lib/MetadataLoader.ts` holds both loaders (`LocalBundleLoader`
+and `NetworkLoader`), and `LayoutRenderer.tsx` draws the app chrome around the page.
+Everything you actually see rendered comes from `@object-ui/react`, `@object-ui/components`
+and the `@object-ui/plugin-*` packages, not from this one.
+
+The one directory worth knowing about is **`src/app-data/`** — the metadata the Runner
+renders. It is git-ignored and absent from a fresh checkout; you create it. See
+[Metadata Loading](#metadata-loading) for its layout and resolution order.
 
 ## Configuration
 
@@ -222,10 +216,13 @@ Test new plugins in a full application context:
 // src/main.tsx
 import '@object-ui/plugin-myplugin'
 
-// src/schemas/test.json
+// src/app-data/pages/index.json — the page served at "/"
 {
-  "type": "my-component",
-  "message": "Testing my plugin"
+  "type": "page",
+  "title": "Plugin test",
+  "body": [
+    { "type": "my-component", "message": "Testing my plugin" }
+  ]
 }
 ```
 
@@ -234,7 +231,7 @@ import '@object-ui/plugin-myplugin'
 Experiment with complex schemas:
 
 ```bash
-# Edit schemas in src/schemas/
+# Edit the JSON under src/app-data/
 # Changes are reflected immediately
 ```
 
@@ -265,7 +262,11 @@ pnpm dev --host
 # http://your-ip:5173
 ```
 
-## Example Schemas
+## Schemas to Start From
+
+These live here in the docs, not in the package — copy one, wrap it in a page document
+(`{ "type": "page", "body": [ … ] }`), and save it as `src/app-data/pages/index.json`, or
+serve it from your own backend and load it with `?api=<base>`.
 
 ### Dashboard Example
 
@@ -385,9 +386,11 @@ pnpm test
 
 ## Package Information
 
-**Package Name:** `@object-ui/runner`  
-**Version:** 0.3.1  
-**Type:** Application (not published to npm)  
+**Package Name:** `@object-ui/runner` — published on npm, see the
+[npm page](https://www.npmjs.com/package/@object-ui/runner) for the current version  
+**Type:** Application, not a library. `package.json` declares no `main`, `module`,
+`exports` or `types`, so there is nothing to `import` from it — you run it from a
+checkout of this repository, as shown above.  
 **License:** MIT
 
 ## Dependencies
@@ -425,7 +428,8 @@ function App() {
 
 ### Add Custom Components
 
-Create in `src/components/`:
+The package ships no components of its own, so create the file wherever you like under
+`src/` — this example uses a `components/` directory you add yourself:
 
 ```typescript
 // src/components/MyComponent.tsx
@@ -445,16 +449,23 @@ ComponentRegistry.register('my-component', MyComponent)
 
 ### Add Custom Schemas
 
-Add to `src/schemas/`:
+Add a page document to `src/app-data/pages/`. The file name is the route: this one is
+served at `/my-page`.
 
 ```json
-// src/schemas/my-page.json
+// src/app-data/pages/my-page.json
 {
-  "type": "div",
-  "className": "p-8",
-  "children": [
+  "type": "page",
+  "title": "My Page",
+  "body": [
     {
-      "type": "my-component"
+      "type": "div",
+      "className": "p-8",
+      "children": [
+        {
+          "type": "my-component"
+        }
+      ]
     }
   ]
 }
@@ -462,16 +473,19 @@ Add to `src/schemas/`:
 
 ## Best Practices
 
-### 1. Modular Schemas
+### 1. One File per Page
 
-Keep schemas in separate files:
+The loader globs `src/app-data/`, so a page is a file and nested routes are nested
+directories — no index or barrel file to maintain:
 
 ```
-src/schemas/
-├── dashboard.json
-├── kanban.json
-├── charts.json
-└── index.ts
+src/app-data/
+├── app.json                 # app document: branding, navigation
+└── pages/
+    ├── index.json           # route "/"
+    ├── customers.json       # route "/customers"
+    └── crm/
+        └── accounts.json    # route "/crm/accounts"
 ```
 
 ### 2. Environment Configuration


### PR DESCRIPTION
Fixes #3577

三类结构性虚构，均对 `origin/main`（切点 `622c23082`）逐条复核后处理。**范围是整页 8 处锚点**，不是正文列的 3 处 —— 分诊评论已经指出 `src/schemas/` 还在 `:221/:233/:444/:447/:466` 复现，只修 `Directory Structure` 会让全页继续自相矛盾。切点上行号比分诊时整体 +4（#3594 落地所致），锚点全部存活。

## 1. 幽灵目录（Directory Structure ＋ 全部复现处）

实测 `packages/runner/src` 下只有 `App.tsx`、`LayoutRenderer.tsx`、`main.tsx`、`index.css`、`lib/`、测试文件 —— **没有** `schemas/`、**没有** `components/`，包根也**没有** `public/`。

按 #3534/#3539 先例（删手抄目录树、指真源）整块删掉 `## Directory Structure`，换成 `## Where the Code Lives` 一段实测过的 prose；承重信息落在唯一真实的元数据目录 `src/app-data/` 上（`.gitignore` 排除、新检出下不存在），布局与解析顺序交给本页自己的 `## Metadata Loading`（#3581 补的那节，本单以它为准）承接，不重复贴一份会漂移的抄本。

其余 5 处引用一并按 Metadata Loading 的真实契约改写为 `src/app-data/pages/*.json`。页文档形状取自 `App.tsx` 兜底页的 `{ "type": "page", "title", "body": [] }`，与本页表格里「the page document (`PageNodeSchema`)」一致，不是我新编的形状。

## 2.「内置示例 schema」

这个包一个 schema 文件都不带：承载它们的 `src/app-data/` 就写在 `packages/runner/.gitignore:1`；缺该目录时 `LocalBundleLoader` 的三个 `import.meta.glob` 编译为 `{}`，`/` 渲染内置兜底 `No index page found.`。

- `What's Included` 下那节列了七类「Runner 包含的示例 schema」→ 整节改写为读者实际要做的事（往 `src/app-data/` 放 JSON，或用 `?api=` 指后端）。
- 下方 `## Example Schemas` → 改题 `## Schemas to Start From`，加一句说明：这些例子活在文档里、不在包里，复制后包成页文档存为 `src/app-data/pages/index.json`。

## 3. Package Information

- `**Version:** 0.3.1` **直接删除**，不改成 17.3.0 —— `@object-ui/runner` 在 `.changeset/config.json` 的 `fixed` 组里随 39 包同发，手抄版本号必然再次漂移（分诊亦明确背书删除）。当前版本改为指向 npm 页。
- `**Type:** Application (not published to npm)` 与实测相反：`package.json` 是 `"private": false` + `publishConfig.access: "public"`，registry 上 `dist-tags.latest` = `17.3.0`。改为不随版本漂移的措辞：**已发布**，但它是应用不是库 —— `package.json` 不声明 `main` / `module` / `exports` / `types`，没有可 import 的东西。这与 PR #3602 刚给 `packages/runner/README.md` 定下的说法一致。

## 逐锚点处置（8 处）

| 切点行 | 内容 | 处置 |
| --- | --- | --- |
| 59 | `### Example Schemas`（七类清单） | 改写为 `### Metadata — Supplied by You` |
| 85 | 目录树里的 `schemas/` | 整块删除（含 `components/`、`public/`） |
| 90 | 目录树里的 `public/` | 同上 |
| 225 | `// src/schemas/test.json` | → `src/app-data/pages/index.json`，包成页文档 |
| 237 | `# Edit schemas in src/schemas/` | → `# Edit the JSON under src/app-data/` |
| 268 | `## Example Schemas` | 改题 + 加来源说明 |
| 389/390 | `Version:` / `Type:` | 删版本行；发布状态重写 |
| 448/451 | `Add to src/schemas/` | → `src/app-data/pages/my-page.json`，并说明文件名即路由 |
| 470 | Best Practices 的 `src/schemas/` 树 | → 真实的 `src/app-data/` 布局（取自 loader 的三个 glob） |

**一处刻意保留的 survivor**：`Add Custom Components` 里的 `// src/components/MyComponent.tsx`。那是让读者自己建的文件（下方注册片段的相对 import 必须与它对齐），且已在上一句明写「包里不带组件，这个目录你自己加」，不再是「它存在」的断言。

## 验证（先给预测，再跑）

命令一律在 worktree 根、目标文件为 `content/docs/utilities/runner.mdx`：

```
grep -n "src/schemas" <该文件>      → 0 命中（预测 0）✅
grep -n "src/components" <该文件>   → 1 命中，即上面那处 justified survivor ✅
node scripts/check-doc-links.mjs    → Links are valid across 3 scan roots. exit=0（改前改后同）✅
node scripts/check-control-bytes.mjs → OK (scanned 3641 tracked text files) ✅
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' <该文件> → 无命中（exit 1）✅
pnpm exec vitest run scripts/ --maxWorkers=2 → 16 files / 275 tests passed ✅
```

新增链接只有外部 npm 页（门禁按 `EXTERNAL_HREF_RE` 跳过，已用 registry API 单独核实包真实存在，`dist-tags.latest = 17.3.0`）与两个纯页内锚点 `#metadata-loading`（`routeExists` 对空 path 直接返回 true），因此门禁读数不变符合预期。**扫描根计数仍是 3**，未见 #3589 改动的影响。

（附带一条实测：本 PR 正文首版里那几个尖括号占位符被 GitHub 的正文清洗器按 HTML 标签吞掉了，回读才发现 —— 已改成中文占位。写 PR 正文时避开「`<`+字母」这个组合仍然必要。）

## 未修（越界，另行开单）

通读全页发现、**不在本单范围**、已按 Prime Directive #10 单独开 issue：Features 的「All official plugins included」（实际只有 kanban + charts）、Best Practices 的环境变量小节（#3538 删了 `## Environment Variables` 整节却漏了它，且与本页「reads no environment variables」直接打架）、`Add Custom Routes` 的 `react-router-dom`（runner 不依赖它，路由是手写 `history.pushState` + `popstate`）。#3604 是 `packages/runner/README.md` 的另一件事，本 PR 未触碰。

内容文档，不需要 changeset。未触碰 `content/docs/releases/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt
