### PR TITLE
test(types): 删除 37 条随 spec 退役而失效的 DROPPED_SCHEMA_EXPORTS,并加棘轮断言 (#3601)

### DIFF
--- a/packages/types/src/__tests__/spec-ui-schema-reexports.test.ts
+++ b/packages/types/src/__tests__/spec-ui-schema-reexports.test.ts
@@ -9,9 +9,11 @@
  * value re-exports; consumers needing the runtime validators import
  * `@objectstack/spec/ui` directly.
  *
- * Note: dual type+value names (`Dashboard`, `DensityMode`, `ThemeMode`, …)
- * are intentionally re-exported type-only — only `…Schema`-suffixed zod
- * values are governed by this contract.
+ * Note: dual type+value names (`Dashboard`, `ThemeMode`, …) are intentionally
+ * re-exported type-only — only `…Schema`-suffixed zod values are governed by
+ * this contract. (`DensityMode` used to head that list; objectstack#3494 /
+ * PR objectstack#3516 retired it from the spec, so it is no longer an example
+ * of anything — same rot the ratchet below now catches for the deny-list.)
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -28,30 +30,14 @@ const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
 /**
  * The public names dropped in #2561 (previously value-erased `export type`
  * re-exports of spec/ui zod schemas, listed under their exported alias).
+ *
+ * Every entry must still be a live `@objectstack/spec/ui` export — the ratchet
+ * below enforces it. A row for a name the spec has retired guards nothing
+ * (nothing can re-export a name upstream no longer publishes), so it must be
+ * deleted rather than left to dilute the real guards (#3601).
  */
 const DROPPED_SCHEMA_EXPORTS = [
-  // Drag and Drop
-  'DndConfigSchema',
-  'DragItemSchema',
-  'DropZoneSchema',
-  'DragConstraintSchema',
-  'DragHandleSchema',
-  'DropEffectSchema',
-  // Focus & Keyboard Navigation
-  'FocusManagementSchema',
-  'FocusTrapConfigSchema',
-  'KeyboardNavigationConfigSchema',
-  'KeyboardShortcutSchema',
-  // Animation & Motion
-  'ComponentAnimationSchema',
-  'AnimationTriggerSchema',
-  'MotionConfigSchema',
-  'TransitionConfigSchema',
-  'TransitionPresetSchema',
-  'EasingFunctionSchema',
   // Notifications
-  'NotificationSchema',
-  'NotificationConfigSchema',
   // `NotificationActionSchema` removed (objectui#3362 residue, closed out on
   // objectui#3363): objectstack#5015 / PR objectstack#5300 RETIRED
   // `NotificationAction` from the spec outright. A deny-list entry for a name
@@ -60,30 +46,12 @@ const DROPPED_SCHEMA_EXPORTS = [
   'NotificationPositionSchema',
   'NotificationSeveritySchema',
   'NotificationTypeSchema',
-  // Gestures & Touch
-  'SpecGestureConfigSchema',
-  'SpecGestureTypeSchema',
-  'SwipeGestureConfigSchema',
-  'SwipeDirectionSchema',
-  'PinchGestureConfigSchema',
-  'LongPressGestureConfigSchema',
-  'TouchInteractionSchema',
-  'TouchTargetConfigSchema',
-  // Offline & Sync
-  'SpecOfflineConfigSchema',
-  'OfflineCacheConfigSchema',
-  'OfflineStrategySchema',
-  'SyncConfigSchema',
-  'ConflictResolutionSchema',
-  'PersistStorageSchema',
-  'EvictionPolicySchema',
   // View Enhancements
   'ColumnSummarySchema',
   'GalleryConfigSchema',
   'GroupingConfigSchema',
   'RowColorConfigSchema',
   'RowHeightSchema',
-  'DensityModeSchema',
   'TimelineConfigSchema',
   'NavigationConfigSchema',
   'ViewSharingSchema',
@@ -120,12 +88,8 @@ const DROPPED_SCHEMA_EXPORTS = [
   'SpecPageRegionSchema',
   'SpecPageTypeSchema',
   'SpecPageVariableSchema',
-  // Performance & Page Transitions
-  'PerformanceConfigSchema',
-  'PageTransitionSchema',
   // Accessibility
   'AriaPropsSchema',
-  'WcagContrastLevelSchema',
   // I18n
   'I18nLabelSchema',
   'I18nObjectSchema',
@@ -141,7 +105,47 @@ const DROPPED_SCHEMA_EXPORTS = [
   'ThemeModeSchema',
 ];
 
+/**
+ * Resolves a deny-list entry to the name `@objectstack/spec/ui` actually
+ * publishes, or `undefined` if the spec no longer publishes it under any
+ * spelling. Entries are listed under their @object-ui/types export alias; the
+ * `Spec`-prefixed ones (`SpecPageSchema`) carry that prefix only to dodge a
+ * local collision, so the fallback strips it — the same aliasing the list's
+ * own doc comment describes.
+ */
+function resolveSpecName(entry: string): string | undefined {
+  const candidates = entry.startsWith('Spec')
+    ? [entry, entry.slice('Spec'.length)]
+    : [entry];
+  return candidates.find((candidate) => candidate in SpecUI);
+}
+
 describe('spec/ui …Schema re-exports (#2561, decision (a))', () => {
+  // The ratchet (#3601). A deny-list row only asserts something while the spec
+  // still publishes the name; once upstream retires it, nothing can re-export
+  // it and the row below passes as a tautology. That had already happened to
+  // 37 of 82 entries before anyone measured — objectstack#4988 / PR #5321 (32,
+  // the five interaction-config modules), #4610 (2), #3494 / PR #3516 (2),
+  // #3896 (1) — diluting the 45 rows that do guard something. This makes the
+  // next upstream retirement announce itself here instead of waiting for an
+  // audit to trip over it.
+  //
+  // Collected rather than asserted per entry on purpose: retirements land as
+  // whole families (32 names in one PR above), and failing on the first would
+  // hide the other 31.
+  it('every deny-list entry is still a live @objectstack/spec/ui export', () => {
+    const retired = DROPPED_SCHEMA_EXPORTS.filter(
+      (name) => resolveSpecName(name) === undefined,
+    );
+    expect(
+      retired,
+      `@objectstack/spec/ui no longer publishes these DROPPED_SCHEMA_EXPORTS ` +
+        `entries: ${retired.join(', ')}. Nothing can re-export a name the spec ` +
+        `has retired, so each of these rows asserts nothing — delete it from ` +
+        `the list and record the upstream retirement in your PR body`,
+    ).toEqual([]);
+  });
+
   it('does not runtime-export the dropped …Schema names', () => {
     for (const name of DROPPED_SCHEMA_EXPORTS) {
       expect(


### PR DESCRIPTION
Fixes #3601

按 PM 裁决的**方向 B**:删 37 条恒真条目 + 加一条棘轮断言,让「随 spec 退役而失效」从此自曝。

## 背景

`DROPPED_SCHEMA_EXPORTS` 是 #2561 决策 (a) 的拒绝名单:逐条断言 `@objectstack/spec/ui` 的 zod 校验器**不**从 `@object-ui/types` 导出。这条断言只在 spec **仍然发布该名**时才有意义 —— 上游一旦整个退役某个 def,没有任何东西能再导出它,该行退化为恒真,还会稀释真守卫的信噪比。

## 测量(在本分支重跑,非照抄 issue 正文)

worktree 装的是 lockfile 解析的 `@objectstack/spec@17.0.0-rc.5`,对 82 条逐条查 spec 是否仍发布该名(`Spec` 前缀条目按名单注释的既有语义回退到去前缀原名再查):

```
total: 82   INERT: 37   LIVE: 45
```

与 issue 正文的 37 条清单**逐条一致**,包括正文标为「待查」的 4 条 —— `DensityModeSchema` / `PerformanceConfigSchema` / `PageTransitionSchema` / `WcagContrastLevelSchema` 全部确认已退役。另做了近名探测(`Density` / `Performance` / `Transition` / `Wcag` / `Contrast` 在 204 个 spec/ui 导出里零命中),排除「改名而非退役」的可能。

45 条真守卫一条未动。

## 删除的 37 条,按退役来源分组

正文表格的分组有两处需要更正,已按上游退役测试的实际名单归位:

| 退役来源 | 条数 | 条目 |
| :-- | --: | :-- |
| objectstack#4988 / PR objectstack#5321 —— `ui/` 五个交互配置模块(touch / dnd / keyboard / animation / offline)整体退役 | 32 | `TouchTargetConfigSchema` `SpecGestureTypeSchema` `SwipeDirectionSchema` `SwipeGestureConfigSchema` `PinchGestureConfigSchema` `LongPressGestureConfigSchema` `SpecGestureConfigSchema` `TouchInteractionSchema` `TransitionPresetSchema` `EasingFunctionSchema` `TransitionConfigSchema` `AnimationTriggerSchema` `ComponentAnimationSchema` `PageTransitionSchema` `MotionConfigSchema` `DragHandleSchema` `DropEffectSchema` `DragConstraintSchema` `DropZoneSchema` `DragItemSchema` `DndConfigSchema` `FocusTrapConfigSchema` `KeyboardShortcutSchema` `FocusManagementSchema` `KeyboardNavigationConfigSchema` `OfflineStrategySchema` `ConflictResolutionSchema` `SyncConfigSchema` `PersistStorageSchema` `EvictionPolicySchema` `OfflineCacheConfigSchema` `SpecOfflineConfigSchema` |
| objectstack#4610 —— `NotificationAction` 的两个包装器,零消费者删除 | 2 | `NotificationSchema` `NotificationConfigSchema` |
| objectstack#3494 / PR objectstack#3516 —— Theme 侧仍然死掉的 aspirational config 清理 | 2 | `DensityModeSchema` `WcagContrastLevelSchema` |
| objectstack#3896 audit close-out —— `performance` 块每个承载者都是 authorable 且 inert | 1 | `PerformanceConfigSchema` |
| | **37** | |

两处更正:

- `PageTransitionSchema` 正文归在「其它/待查」,实际出自 `ui/animation.zod.ts`,属 #4988 那一组 —— 归位后该组正好 **32** 条,与上游 `interaction-config-retirement.test.ts` 自述的「32 emitted defs」对上。
- `NotificationSchema` / `NotificationConfigSchema` 正文归在 #4988 组,实际 notification 不在退役的五个模块内,出自更早的 #4610。

## 棘轮断言

手法同 PR #3568 给 `$icontains` 排除项加的「排除项不得超期」断言:

```ts
it('every deny-list entry is still a live @objectstack/spec/ui export', () => {
  const retired = DROPPED_SCHEMA_EXPORTS.filter(
    (name) => resolveSpecName(name) === undefined,
  );
  expect(retired, `…no longer publishes…: ${retired.join(', ')}…`).toEqual([]);
});
```

两处设计取舍:

- **收集后一次性断言,而非逐条 `toBe(true)`**:退役是整族落地的(上游一个 PR 就带走 32 条),逐条断言会停在第一条、藏住其余 31 条。
- **`Spec` 前缀回退是承重的,不是装饰**:45 条里有 **16** 条只能靠回退解析(`SpecPageSchema` → `PageSchema` 等),29 条直接命中。去掉回退这条断言会立刻误报那 16 条。

## 逆向验证(先预测后运行,两个方向都如预测)

在名单末尾临时塞一个 spec 从未有过的名字 `NeverExistedInSpecSchema`:

| | 预测 | 实测 |
| :-- | :-- | :-- |
| **修前**(未改的测试) | 绿 —— 唯一断言是 `name in Types === false`,对一个谁都不导出的名字恒真 | ✅ 绿,`Tests 3 passed (3)` |
| **修后**(本 PR) | 红,且点名该条;其余 3 条测试仍绿 | ✅ 1 failed / 3 passed(共 4),失败信息含 `no longer publishes these DROPPED_SCHEMA_EXPORTS entries: NeverExistedInSpecSchema` |

修后那一轮的完整失败输出:

```
FAIL packages/types/src/__tests__/spec-ui-schema-reexports.test.ts >
  spec/ui …Schema re-exports (#2561, decision (a)) >
  every deny-list entry is still a live @objectstack/spec/ui export
AssertionError: @objectstack/spec/ui no longer publishes these
DROPPED_SCHEMA_EXPORTS entries: NeverExistedInSpecSchema. …
  expected [ 'NeverExistedInSpecSchema' ] to deeply equal []

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

修前那一轮绿就是恒真缺陷的现场演示:被删的 37 条这些年一直是这个状态。验证后假名已还原。

## 顺带更正的一处注释

文件头注举「dual type+value 名」的例子是 `` `Dashboard`, `DensityMode`, `ThemeMode` `` —— 而 `DensityMode` 本身已被 objectstack#3494 / PR objectstack#3516 从 spec 退役(`Dashboard` / `ThemeMode` 仍在)。同一份文件里同一类腐化,仅注释改动,已在注释里点明出处。

## 验证

```
$ npx vitest run packages/types --maxWorkers=2
 Test Files  28 passed (28)
      Tests  383 passed (383)

$ pnpm --workspace-concurrency=2 --filter @object-ui/types type-check
> tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json
(通过,无输出)

$ npx eslint packages/types/src/__tests__/spec-ui-schema-reexports.test.ts
(exit 0,无告警)

$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3650 tracked text file(s); skipped 85 binary).
```

**无 changeset**:测试-only 改动,不触碰任何包的公开面、运行时行为或类型导出 —— 按仓例(changeset 用于 user-visible 变更)无需 changeset。

**文件面**:`packages/types/src/__tests__/spec-ui-schema-reexports.test.ts` 单文件,+50 −46。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt