### PR TITLE
fix(app-shell): expand `view` edit-gate union failures into per-field diagnostics

### DIFF
--- a/.changeset/sour-clouds-yawn.md
+++ b/.changeset/sour-clouds-yawn.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/app-shell": patch
+---
+
+metadata-admin: restore per-field diagnostics when editing an invalid stored `view`
+
+Editing a stored `view` is judged by the wire gate `ViewMetadataSchema`, which is a
+union. Zod reports a union failure as a single root issue — no path, message
+`Invalid input` — so every field-level diagnostic collapsed into one message that
+pointed at nothing: `SchemaForm` had no field to highlight and Monaco had no
+position to jump to, and the guided messages the spec writes for these rejections
+never reached the editor.
+
+Failures are now expanded to the union member the draft's own `viewKind`
+discriminant selects, so a bad stored view reports `config.type` with the list of
+valid layouts, a mis-typed filter reports `config.filter.0.operator`, and a
+container key that belongs to a single view gets the spec's full
+`defineView(...)` guidance back. Only the selected member's issues are shown, so
+the other members' rejections do not become noise.
+
+Validation verdicts are unchanged: the accept/reject decision is still made by the
+one gate, and this only changes how an already-failed draft is presented.

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -24,10 +24,30 @@ import type { SchemaFormIssue } from './SchemaForm';
 import { lintCelPredicate } from './celAuthoring';
 import { readFields } from './previews/object-fields-io';
 
+/**
+ * The structural slice of a Zod issue this module reads.
+ *
+ * `code` and `errors` are optional so the `ZodLikeSchema` contract stays
+ * satisfiable by anything shaped like a Zod schema; every real Zod 4 issue
+ * carries `code`, and only `invalid_union` carries `errors`.
+ */
+type ZodLikeIssue = {
+  path?: Array<string | number>;
+  message: string;
+  /** Zod 4 issue discriminator (`invalid_type`, `invalid_union`, …). */
+  code?: string;
+  /**
+   * Present only on `invalid_union`: ONE issue group per union member, in the
+   * union's own member order. Zod reports a union failure as a single root
+   * issue and buries every member's real diagnostics here.
+   */
+  errors?: ZodLikeIssue[][];
+};
+
 type ZodLikeSchema = {
   safeParse: (value: unknown) => {
     success: boolean;
-    error?: { issues: Array<{ path: Array<string | number>; message: string }> };
+    error?: { issues: ZodLikeIssue[] };
   };
 };
 
@@ -77,14 +97,100 @@ type SchemaLoader = (mode: DraftMode) => Promise<ZodLikeSchema | undefined>;
  * strictly against its own schema. Which of the two should be the single
  * authorable shape is a real open question, tracked in objectui#3312.
  */
+/**
+ * The `view` discriminant, in ONE place: `viewKind` is what makes a record a
+ * ViewItem rather than the aggregated container, and it is the same test
+ * `MetadataProvider.isViewItem()` applies on the read side.
+ *
+ * Both the create gate's schema dispatch (`viewSchemaForDraft`) and the edit
+ * gate's union-diagnostic selection (`viewUnionMemberIndex`) read it here, so
+ * the two can never drift apart into two different notions of "is a ViewItem".
+ */
+function isViewItemDraft(value: unknown): boolean {
+  return !!value && typeof value === 'object' && 'viewKind' in (value as object);
+}
+
 function viewSchemaForDraft(item: ZodLikeSchema, container: ZodLikeSchema): ZodLikeSchema {
   return {
-    safeParse: (value: unknown) => {
-      const isViewItem =
-        !!value && typeof value === 'object' && 'viewKind' in (value as object);
-      return (isViewItem ? item : container).safeParse(value);
-    },
+    safeParse: (value: unknown) => (isViewItemDraft(value) ? item : container).safeParse(value),
   };
+}
+
+/**
+ * ── Union-failure diagnostics for the `view` EDIT gate (objectui#3606) ──
+ *
+ * PRESENTATION ONLY. Nothing below can change a verdict: it runs strictly
+ * inside the final issue→`SchemaFormIssue` mapping, after `ok` has already been
+ * decided by the one gate (`ViewMetadataSchema`) and after every issue filter
+ * has run. Same input set, same `ok`; only the rendered `path`/`message` move.
+ *
+ * The edit gate is `z.preprocess(stripViewConsoleDecorations, z.union([…]))`.
+ * Zod reports a union failure as a SINGLE root issue — `code: 'invalid_union'`,
+ * `path: []`, `message: 'Invalid input'` — and buries each member's real
+ * diagnostics in `issue.errors`, one group per member, in member order. Mapping
+ * that root issue literally is what collapsed every field-level diagnostic on
+ * the edit path into one un-addressable "Invalid input": `SchemaForm` highlights
+ * by `path` and Monaco locates by `path`, so an empty path points at nothing,
+ * and the guided messages the spec wrote for these rejections (#4001) never
+ * reached the user.
+ *
+ * Selection is by the draft's OWN discriminant — the same `isViewItemDraft` the
+ * create gate dispatches on — never by a heuristic over the groups. "Fewest
+ * issues / deepest path" was measured and picks wrong: for a container carrying
+ * an unknown key, the ViewItem group reports a deeper `viewKind` discriminator
+ * error that is the wrong message entirely. We show ONLY the selected member's
+ * issues; showing all four would put "this is not a container" in front of
+ * someone editing a ViewItem.
+ *
+ * Measured member layout of `ViewMetadataSchema`'s union (@objectstack/spec
+ * 17.0.0-rc.5):
+ *
+ *   [0] `ViewItemWireSchema`  — the stored ViewItem record (itself a
+ *       discriminated union on `viewKind`; a valid discriminator resolves
+ *       straight through, so its issues arrive flat and field-addressed).
+ *   [1] the aggregated container — same shape as the exported `ViewSchema`.
+ *   [2] flattened list-view overlay.
+ *   [3] flattened form-view overlay.
+ *
+ * This indexes members POSITIONALLY, which couples to a spec-internal detail.
+ * That coupling is deliberate and it is guarded, not hoped for: reading the
+ * groups the failing gate itself produced is the only way the diagnostics
+ * cannot describe a schema other than the one that judged. The alternative —
+ * re-parsing with the exported member schemas — was measured and rejected: the
+ * container member is NOT the exported `ViewSchema` object (equal shape today,
+ * a resemblance maintained by hand), and a re-parse would also have to
+ * re-apply `stripViewConsoleDecorations` itself, reconstructing the spec's
+ * pipeline composition in a second place that can drift. The positional read
+ * is pinned by the CANARY tests in `clientValidation.viewDiagnostics.test.ts`:
+ * they assert the selected member's exact `path` + `message` for known bodies,
+ * so reordering, adding or removing a union member turns them red instead of
+ * silently mis-selecting.
+ */
+const VIEW_UNION_MEMBERS = { wireItem: 0, container: 1 } as const;
+
+function viewUnionMemberIndex(draft: unknown): number {
+  return isViewItemDraft(draft) ? VIEW_UNION_MEMBERS.wireItem : VIEW_UNION_MEMBERS.container;
+}
+
+/**
+ * Expand a ROOT union failure into the selected member's own issues, or return
+ * `null` to say "nothing better to show" — in which case the caller renders the
+ * root issue unchanged, exactly as before. It can never return an empty list,
+ * so a rejected draft always renders at least one issue.
+ *
+ * Root-only by design: a member issue's `path` is relative to the union node,
+ * and only at the root is that the same as the draft-absolute path `SchemaForm`
+ * needs. A union nested deeper (e.g. `config.columns`) keeps Zod's own message;
+ * it still carries a real path, so it is addressable — unlike the root case.
+ */
+function expandViewUnionIssue(issue: ZodLikeIssue, draft: unknown): ZodLikeIssue[] | null {
+  if (issue.code !== 'invalid_union') return null;
+  if ((issue.path ?? []).length !== 0) return null;
+  const groups = issue.errors;
+  if (!Array.isArray(groups)) return null;
+  const group = groups[viewUnionMemberIndex(draft)];
+  if (!Array.isArray(group) || group.length === 0) return null;
+  return group;
 }
 
 // Map metadata-type name → loader for that type's root Zod schema.
@@ -411,11 +517,18 @@ export async function validateMetadataDraft(
   }
   if (rawIssues.length === 0 && celIssues.length === 0) return { ok: true, issues: [] };
 
+  // Presentation only — see `expandViewUnionIssue`. `ok` is already `false`
+  // here and `rawIssues` is already final; this only decides what gets RENDERED
+  // for each of them, so the verdict cannot move (pinned by the parity test in
+  // `clientValidation.viewDiagnostics.test.ts`).
   const issues: SchemaFormIssue[] = [
-    ...rawIssues.map((i) => ({
-      path: (i.path ?? []).map((seg) => String(seg)).join('.'),
-      message: i.message,
-    })),
+    ...rawIssues.flatMap((i) => {
+      const expanded = type === 'view' ? expandViewUnionIssue(i, draft) : null;
+      return (expanded ?? [i]).map((issue) => ({
+        path: (issue.path ?? []).map((seg) => String(seg)).join('.'),
+        message: issue.message,
+      }));
+    }),
     ...celIssues,
   ];
   return { ok: false, issues };

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.viewDiagnostics.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.viewDiagnostics.test.ts
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Field-level diagnostics on the `view` EDIT path (objectui#3606).
+ *
+ * The edit gate is `ViewMetadataSchema` = `z.preprocess(strip, z.union([…]))`
+ * (objectstack#5316 / objectui#3607). Zod reports a union failure as ONE root
+ * issue — `path: []`, `message: 'Invalid input'` — with every member's real
+ * diagnostics buried in `issue.errors`. Mapping that root issue literally
+ * collapsed the whole edit path to a single un-addressable "Invalid input":
+ * `SchemaForm` highlights by `path`, Monaco locates by `path`, and the guided
+ * messages the spec wrote for these rejections (#4001) never reached the user.
+ *
+ * Two things are being pinned here, and they are different kinds of claim:
+ *
+ *  - CANARY — the union member selected by the draft's own discriminant
+ *    produces THESE exact paths and messages. The selection indexes members
+ *    positionally, which couples to a spec-internal detail; these assertions
+ *    are what makes a reorder / insertion / removal of a `ViewMetadataSchema`
+ *    union member fail loudly instead of silently mis-selecting.
+ *  - PARITY — the verdict (`ok`) is byte-identical to what the un-expanded
+ *    mapping produced. The expansion runs strictly inside the issue→form-issue
+ *    mapping, downstream of `ok`; only presentation moves. Note this half
+ *    CANNOT be red-before-green-after — it was green before the change and must
+ *    stay green. That is the point of it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateMetadataDraft } from './clientValidation';
+
+const EDIT = { mode: 'edit' } as const;
+
+/** A stored ViewItem: what `createBuildBody` emits plus the pin the view switcher wrote. */
+const STORED_ITEM: Record<string, unknown> = {
+  name: 'crm_lead.all_leads',
+  object: 'crm_lead',
+  viewKind: 'list',
+  label: 'All Leads',
+  isPinned: true,
+  config: {
+    type: 'grid',
+    columns: [],
+    data: { provider: 'object', object: 'crm_lead' },
+  },
+};
+
+/** A record that was never expanded into ViewItems. */
+const CONTAINER: Record<string, unknown> = {
+  name: 'crm_lead',
+  label: 'Lead views',
+  object: 'crm_lead',
+  list: { type: 'grid', columns: ['name'] },
+};
+
+describe('view edit path — union diagnostics are expanded to the selected member (objectui#3606)', () => {
+  // ── CANARY ───────────────────────────────────────────────────────────────
+  // Exact path + message of the member the discriminant selects. If the spec
+  // reorders `ViewMetadataSchema`'s union, the positional index in
+  // `clientValidation.ts` selects a different member and these go red.
+
+  it('CANARY: a stored ViewItem with a bad layout type reports `config.type`, not a bare root issue', async () => {
+    const res = await validateMetadataDraft(
+      'view',
+      { ...STORED_ITEM, config: { type: 'not_a_real_layout', columns: [] } },
+      undefined,
+      EDIT,
+    );
+    expect(res.ok).toBe(false);
+    // Before #3606 this was the single issue `{ path: '', message: 'Invalid input' }`.
+    expect(res.issues).toHaveLength(1);
+    expect(res.issues[0].path).toBe('config.type');
+    expect(res.issues[0].message).toContain('Invalid option');
+    expect(res.issues[0].message).toContain('"grid"');
+  });
+
+  it('CANARY: a stored container with an unknown key reports the spec-authored guidance', async () => {
+    const res = await validateMetadataDraft(
+      'view',
+      { ...CONTAINER, notAContainerKey: true },
+      undefined,
+      EDIT,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.issues).toHaveLength(1);
+    // The container member reports `unrecognized_keys` AT the object it applies
+    // to, so the root path is correct here — the message is what was lost.
+    expect(res.issues[0].path).toBe('');
+    expect(res.issues[0].message).toContain('Unrecognized key(s) on this view container');
+    expect(res.issues[0].message).toContain('notAContainerKey');
+  });
+
+  it('CANARY: a container key that belongs to a single view recovers the full `defineView` guidance', async () => {
+    // #3606's report quoted the container rejection as ending in
+    // "Wrap it: defineView({...})". Measured, that clause is not part of the
+    // generic message above — it is a PER-KEY hint the spec attaches only to
+    // keys that belong to a single view rather than to the container
+    // (`type` / `columns` / `data` / `viewKind` / `filters` / `sort`). This is
+    // the richest message the collapse was destroying, so it gets its own pin.
+    const res = await validateMetadataDraft('view', { ...CONTAINER, columns: ['name'] }, undefined, EDIT);
+    expect(res.ok).toBe(false);
+    expect(res.issues).toHaveLength(1);
+    expect(res.issues[0].message).toContain('belongs to a single VIEW, not to the container');
+    expect(res.issues[0].message).toContain('Wrap it: `defineView(');
+    expect(res.issues[0].message).toContain("The container's own keys are");
+  });
+
+  it('CANARY: a missing required field on a stored ViewItem is addressed to that field', async () => {
+    const draft = { ...STORED_ITEM };
+    delete draft.name;
+    const res = await validateMetadataDraft('view', draft, undefined, EDIT);
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toEqual(['name']);
+    expect(res.issues[0].message).toContain('expected string');
+  });
+
+  it('CANARY: a bad nested filter operator keeps its full array path', async () => {
+    const res = await validateMetadataDraft(
+      'view',
+      {
+        ...STORED_ITEM,
+        config: {
+          ...(STORED_ITEM.config as Record<string, unknown>),
+          filter: [{ field: 'status', operator: 'not_an_operator', value: 'open' }],
+        },
+      },
+      undefined,
+      EDIT,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toEqual(['config.filter.0.operator']);
+    expect(res.issues[0].message).toContain('Invalid option');
+  });
+
+  // ── Noise control ────────────────────────────────────────────────────────
+
+  it('shows ONLY the selected member — never the other members’ rejections', async () => {
+    // All four members reject this body. The three we did not select say things
+    // like "this is not a view container" / "expected undefined, received
+    // object", which would be pure noise to someone editing a ViewItem.
+    const res = await validateMetadataDraft(
+      'view',
+      { ...STORED_ITEM, config: { type: 'not_a_real_layout', columns: [] } },
+      undefined,
+      EDIT,
+    );
+    const messages = res.issues.map((i) => i.message).join('\n');
+    // Positive anchor FIRST: without it the negatives below pass vacuously
+    // against the collapsed "Invalid input", which contains no forbidden
+    // substring either — green because nothing is produced, not because the
+    // selection is right.
+    expect(messages).toContain('Invalid option');
+    expect(messages).not.toContain('view container');
+    expect(messages).not.toContain('expected undefined');
+  });
+
+  it('selects by the draft’s discriminant, not by "fewest issues / deepest path"', async () => {
+    // The heuristic picks wrong here, measurably: for this container the
+    // ViewItem member reports a DEEPER path (`viewKind`, discriminator
+    // mismatch) than the container member's root `unrecognized_keys` — and it
+    // is the wrong message. The discriminant has no `viewKind`, so the
+    // container member is selected regardless of group shape.
+    const res = await validateMetadataDraft(
+      'view',
+      { ...CONTAINER, notAContainerKey: true },
+      undefined,
+      EDIT,
+    );
+    const messages = res.issues.map((i) => i.message).join('\n');
+    // Positive anchor first, same reason as above.
+    expect(messages).toContain('Unrecognized key(s) on this view container');
+    expect(messages).not.toContain('Invalid discriminator value');
+  });
+
+  // ── Fallbacks: never lose a diagnostic ───────────────────────────────────
+
+  it('a rejected draft always renders at least one issue', async () => {
+    // Includes the residual case: `config.columns` fails a union that is nested
+    // BELOW the root, which this change deliberately does not expand (a nested
+    // member issue's path is relative to its own node, and there is no
+    // documented discriminant down there). It still carries a real path, so it
+    // is addressable — which the root case was not.
+    const bodies: unknown[] = [
+      { ...STORED_ITEM, config: { type: 'not_a_real_layout', columns: [] } },
+      { ...STORED_ITEM, viewKind: 'not_a_kind' },
+      {
+        ...STORED_ITEM,
+        config: { ...(STORED_ITEM.config as Record<string, unknown>), columns: [{ field: 123 }] },
+      },
+      { ...CONTAINER, notAContainerKey: true },
+      'not even an object',
+      null,
+    ];
+    for (const body of bodies) {
+      const res = await validateMetadataDraft('view', body, undefined, EDIT);
+      expect(res.ok, JSON.stringify(body)).toBe(false);
+      expect(res.issues.length, JSON.stringify(body)).toBeGreaterThan(0);
+    }
+  });
+
+  it('leaves non-union failures exactly as they were', async () => {
+    // `page` has a plain object schema — no union, so the mapping is untouched.
+    const res = await validateMetadataDraft('page', { name: 'p', type: 42 });
+    expect(res.ok).toBe(false);
+    expect(res.issues.length).toBeGreaterThan(0);
+    expect(res.issues.every((i) => i.message !== 'Invalid input')).toBe(true);
+  });
+});
+
+/**
+ * The CREATE path is judged by the authoring gates (`ViewItemSchema` /
+ * `ViewSchema`), neither of which is a root union — so the expansion is a
+ * structural no-op there. Pinned with exact values rather than argued.
+ */
+describe('view create path — unchanged by objectui#3606', () => {
+  it('reports the same field-level issue it always did', async () => {
+    const res = await validateMetadataDraft('view', {
+      name: 'crm_lead.all_leads',
+      object: 'crm_lead',
+      viewKind: 'list',
+      label: 'All Leads',
+      config: { type: 'not_a_real_layout', columns: [] },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues).toHaveLength(1);
+    expect(res.issues[0].path).toBe('config.type');
+    expect(res.issues[0].message).toContain('Invalid option');
+  });
+
+  it('still rejects platform-written keys on the authoring surface', async () => {
+    const res = await validateMetadataDraft('view', STORED_ITEM);
+    expect(res.ok).toBe(false);
+    expect(res.issues.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * PARITY — the verdict is decided by ONE gate and this change did not touch it.
+ *
+ * Read this as the anti-regression half of the pair above: whatever the
+ * diagnostics now say, `ok` for every shape × mode is what `ViewMetadataSchema`
+ * (edit) and the authoring gates (create) already decided. A `try both, pass if
+ * either passes` fallback — the thing #3606 explicitly is NOT — would show up
+ * here as an expectation flipping to `true`.
+ */
+describe('view verdict parity — presentation moved, judgement did not (objectui#3606)', () => {
+  const CASES: Array<{ label: string; body: unknown; edit: boolean; create: boolean }> = [
+    { label: 'clean stored ViewItem (pinned)', body: STORED_ITEM, edit: true, create: false },
+    {
+      label: 'stored ViewItem with nested console row ids',
+      body: {
+        ...STORED_ITEM,
+        sortOrder: 3,
+        config: {
+          ...(STORED_ITEM.config as Record<string, unknown>),
+          filter: [{ field: 'status', operator: 'equals', value: 'open', id: 'row-1' }],
+        },
+      },
+      edit: true,
+      create: false,
+    },
+    { label: 'aggregated container', body: CONTAINER, edit: true, create: true },
+    {
+      label: 'ViewItem with a bad layout type',
+      body: { ...STORED_ITEM, config: { type: 'not_a_real_layout', columns: [] } },
+      edit: false,
+      create: false,
+    },
+    {
+      label: 'container with an unknown key',
+      body: { ...CONTAINER, notAContainerKey: true },
+      edit: false,
+      create: false,
+    },
+    { label: 'ViewItem with an unknown viewKind', body: { ...STORED_ITEM, viewKind: 'nope' }, edit: false, create: false },
+    { label: 'not an object at all', body: 'nope', edit: false, create: false },
+  ];
+
+  for (const c of CASES) {
+    it(`${c.label}: edit=${c.edit ? 'ok' : 'not ok'}, create=${c.create ? 'ok' : 'not ok'}`, async () => {
+      const edited = await validateMetadataDraft('view', c.body, undefined, EDIT);
+      const created = await validateMetadataDraft('view', c.body, undefined, { mode: 'create' });
+      expect(edited.ok, `edit: ${JSON.stringify(edited.issues)}`).toBe(c.edit);
+      expect(created.ok, `create: ${JSON.stringify(created.issues)}`).toBe(c.create);
+      // ok and issues stay consistent in both directions.
+      expect(edited.issues.length === 0).toBe(c.edit);
+      expect(created.issues.length === 0).toBe(c.create);
+    });
+  }
+});


### PR DESCRIPTION
Fixes #3606

## 问题

#3607(objectstack#5316)把 `view` 编辑路切到 wire 门 `ViewMetadataSchema` —— 这是对的,它正是 `view` 元数据类型注册、服务端 `saveMetaItem` 所判的那个 schema。但它是 `z.preprocess(strip, z.union([...]))`,而 Zod 对 union 失败只产出**一条根级 issue**(`code: 'invalid_union'`,`path: []`,`message: 'Invalid input'`),四个成员各自的真实诊断埋在 `issue.errors` 里(每个成员一组,按成员序)。

`validateMetadataDraft` 的映射是逐字照搬那条根 issue,于是编辑路的逐字段诊断全部塌陷。`SchemaForm` 按 `path` 做内联高亮、Monaco 按 `path` 定位 —— 空 path 指向不了任何东西;spec 为这些拒绝**专门撰写**的引导消息(#4001 那批)在编辑路上完全看不到。

## 改动

失败之后,按 draft **自身的判别式**选定 union 成员,展开该成员的 issues。判别式复用创建路已有的 `viewKind` 判定,这次抽成单一的 `isViewItemDraft`,两条路不可能再各自漂移。

**只呈现选中成员的 issues** —— 四个成员全摆出来会把「这不是 view container」摆到正在编辑 ViewItem 的人脸上。issue 里提到的启发式选支(issue 数最少 / path 最深)已被一条测试钉死为错误做法。

## 实测:修前 / 修后

编辑路(`mode: 'edit'`),`@objectstack/spec` 17.0.0-rc.5:

| body | 修前 path | 修前 message | 修后 path | 修后 message |
|---|---|---|---|---|
| stored ViewItem,`config.type: 'not_a_real_layout'` | `` (空) | `Invalid input` | `config.type` | `Invalid option: expected one of "grid"｜"kanban"｜"gallery"｜…` |
| stored ViewItem,缺 `name` | `` (空) | `Invalid input` | `name` | `Invalid input: expected string, received undefined` |
| stored ViewItem,`config.filter[0].operator` 非法 | `` (空) | `Invalid input` | `config.filter.0.operator` | `Invalid option: expected one of "equals"｜"not_equals"｜…` |
| container 带未知键 `notAContainerKey` | `` (空) | `Invalid input` | `` (根,正确) | ``Unrecognized key(s) on this view container: `notAContainerKey`. Until #4001 closed these shapes an unknown key was dropped silently — …`` |
| container 带单视图键 `columns` | `` (空) | `Invalid input` | `` (根,正确) | 上一条 + 逐键提示:``• `columns` belongs to a single VIEW, not to the container. Wrap it: `defineView({ list: { type, data, columns, … } })`, or name it — … `` |

对 issue 正文的一处事实订正:正文把容器拒绝的消息引成 `Unrecognized key(s) on this view container: … Wrap it: defineView({...})`。实测这两截**不是同一条消息** —— `Wrap it: defineView(...)` 是 spec 只挂在**属于单个 view 的那批键**(`type`/`columns`/`data`/`viewKind`/`filters`/`sort`)上的逐键提示;`notAContainerKey` 这种普通未知键拿到的是不带该提示的通用消息。表格最后两行分别钉住这两种,避免以后有人照 issue 正文去断言而扑空。

## 判定奇偶性:只有呈现变了

展开逻辑跑在 issue → `SchemaFormIssue` 的**映射内部**,位置在 `ok` 判定之后、且在既有的 `serverRequired` / flow 前向兼容两个过滤器之后 —— 驱动 `ok` 的那组 raw issues 一个都没动。所以判定不是「测出来没变」,而是**结构上不可能变**。

这一点仍然写成了 pin(`view verdict parity` 一节):三种运行时形状 × 合法/非法 × 两种 mode,逐一断言 `ok`。它**修前修后都是绿的** —— 这正是它的意义,它是防回归的那一半,不是「修前红修后绿」的那一半。若有人日后把这里改成 try-both 兜底改判,这组期望会翻成 `true` 而爆掉。

`clientValidation.viewShapes.test.ts` 的现有 pin 一行未改,原样通过。创建路(`ViewItemSchema` / `ViewSchema`,都不是根 union)行为零变化,并按精确 path+message 钉住,而不是只靠论证。

## 为什么按成员序索引,而不是拿导出的成员 schema 重解一遍

两条都测量过:

- `ViewMetadataSchema` union 的 `options[0]` **就是**导出的 `ViewItemWireSchema`(同一个对象);但 `options[1]` **不是**导出的 `ViewSchema` —— 今天二者 shape 相同、行为相同,但那是**手工维持的相似**,正是 #5316 在本文件注释里明确拒绝依赖的东西。
- 重解一遍还必须自己再调一次 `stripViewConsoleDecorations`,把 spec 的 preprocess 组合在第二个地方复刻出来 —— 又一处会漂移的复制品(`config.filter[].id` 那条 false positive 就是这么来的)。

读「判定时那一次运行自己产出的」错误组,是唯一能保证**诊断不会描述另一个 schema**的做法。代价是耦合成员**顺序**(spec 内部细节),这个代价用 CANARY 测试兜住:它们断言选中成员的精确 path + message,spec 一旦重排/增删 union 成员,测试直接红,而不是静默误选。

## 已知残留(未修,不在本 issue 范围)

只展开**根**上的 union。成员 issue 的 `path` 相对于 union 节点,只有在根上它才等于 draft 绝对路径。更深处的嵌套 union(实测:`config.columns` 是 `string[] | ColumnDef[]`,无判别式)仍保留 Zod 自己的 `Invalid input` —— 但它带着真实 path `config.columns`,**是可定位的**,这与根上那条空 path 有本质区别。已在 `a rejected draft always renders at least one issue` 里覆盖到,不会静默丢诊断。

## 测试

新增 `packages/app-shell/src/views/metadata-admin/clientValidation.viewDiagnostics.test.ts`(18 条:5 CANARY + 2 噪音控制 + 2 兜底 + 2 创建路 + 7 判定奇偶)。

反向验证(先写预测再跑):还原实现后 **7 红**(5 CANARY + 2 噪音控制),打回实现后 **0 红**;11 条判定奇偶/创建路/兜底测试**两个方向都绿**。

有一处预测未命中,如实记录:两条噪音控制测试最初**修前也是绿的** —— 它们只有 `not.toContain(...)`,而塌陷后的 `Invalid input` 恰好也不含任何被禁子串,即「因为什么都没产出所以绿」。已各补一条正向锚点断言,补后两条都变成修前红、修后绿。

```
vitest run packages/app-shell/src/views/metadata-admin/   →  128 passed, 1187 passed | 1 skipped
pnpm --filter @object-ui/app-shell type-check             →  clean
eslint (两个改动文件)                                      →  clean
node scripts/check-control-bytes.mjs                      →  OK (3644 files)
node scripts/check-changeset-fixed.mjs / -no-major.mjs    →  OK
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_