### PR TITLE
fix(docs,scripts): 清掉 9 条包 README 死链,并让链接门禁认站内绝对 URL (#3603)

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -266,6 +266,22 @@ Four checks, by href shape:
 | absolute `/docs/...` | `content/docs/` as a **route** | no `foo.md`, `foo.mdx` or `foo/index.md*` backs it — a `.md`/`.mdx` suffix always fails, since that URL 404s whatever is on disk |
 | any other absolute (`/spec/...`, `/img/...`) | the **site itself**: route segments enumerated from `apps/site/app`, plus static files under `apps/site/public` | no route pattern or static file matches |
 
+**Two href shapes are checked on _every_ surface, both rules included**, because they look external
+but are decidable offline:
+
+| Href shape | Resolved against | Rejected when |
+|---|---|---|
+| this repo's own `https://github.com/objectstack-ai/objectui/(blob\|tree)/main/...` (objectui#3536) | the path in the working tree | that path is not in the checkout. Only `main` and only this repo — other refs and repos cannot be answered offline |
+| this site's own `https://[www.]objectui.org/...` (objectui#3603) | the origin is stripped, and what remains goes through the two absolute rows above, unchanged | the resulting route does not resolve — so `…/docs/guide/foo.md` fails for exactly the reason `/docs/guide/foo.md` does |
+
+The second one had been invisible since the beginning: `judgeHref()` skipped every href carrying a
+scheme, so a route written with the site's own origin was never checked while the identical
+origin-less route was checked strictly. That blind spot was never confined to package READMEs —
+`content/docs/` writes 6 such URLs itself — which is why the fix strips the origin in `judgeHref()`
+rather than special-casing any surface. Measured before landing: 11 across the scanned tree, zero
+dead. Prefer the origin-less form (`/docs/guide/plugins`) in new prose: it survives a domain change,
+and both spellings are now checked identically.
+
 Every other surface — `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs/` — is read
 on **GitHub**, not served by the site, so a relative href there names a path on disk and is checked
 for existence only: a directory (`./packages/core`) or a non-markdown file (`./vite.config.ts`) is a
@@ -334,7 +350,7 @@ There are **two** link checkers, and they cover different things (objectui#3213)
 
 | | Covers | Network | Runs |
 |---|---|---|---|
-| `scripts/check-doc-links.mjs` | **Internal** links in `content/docs/` (relative hrefs, `/docs/...` routes, every other site-absolute href against `apps/site`), in `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md` and `docs/` (as paths on disk), plus this repo's own `blob/main/` and `tree/main/` GitHub URLs everywhere — **except** anything inside a code fence | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
+| `scripts/check-doc-links.mjs` | **Internal** links in `content/docs/` (relative hrefs, `/docs/...` routes, every other site-absolute href against `apps/site`), in `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md` and `docs/` (as paths on disk), plus this repo's own `blob/main/` and `tree/main/` GitHub URLs and this site's own `objectui.org` URLs everywhere — **except** anything inside a code fence | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
 | Lychee (this workflow) | **External** URLs, plus **relative** in-repo file links, in `content/docs/`, `docs/` and `README.md` | Yes | Weekly cron and manual dispatch |
 
 Lychee sweeps **both** documentation trees: `content/docs/` (the 183 pages the site publishes) and

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -220,7 +220,6 @@ function MyComponent() {
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/packages/auth)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/auth)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/collaboration/README.md
+++ b/packages/collaboration/README.md
@@ -129,7 +129,6 @@ Threaded comment component with @mentions:
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/packages/collaboration)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/collaboration)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -149,7 +149,6 @@ isRTL('en'); // false
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/packages/i18n)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/i18n)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -140,7 +140,6 @@ registerServiceWorker({ cacheStrategy: 'network-first' });
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/packages/mobile)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/mobile)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -134,7 +134,6 @@ store.check('read', 'orders'); // true | false
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/packages/permissions)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/permissions)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -79,7 +79,6 @@ function App() {
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/packages/providers)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/providers)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -240,7 +240,7 @@ See [full documentation](https://objectui.org/api/react) for detailed API refere
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/packages/react)
+- 📚 [Documentation](https://www.objectui.org/docs/core/schema-renderer)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/react)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -185,8 +185,8 @@ pnpm publish
 ## 📚 Documentation
 
 - [Object UI Documentation](https://www.objectui.org)
-- [Schema Reference](https://www.objectui.org/docs/protocol/overview)
-- [Component Library](https://www.objectui.org/docs/api/components)
+- [Schema Reference](https://www.objectui.org/docs/api/schema-reference)
+- [Component Library](https://www.objectui.org/docs/components)
 - [Examples](https://www.objectui.org/examples)
 
 ## 🤝 Contributing

--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -1070,7 +1070,7 @@ describe("this site's own absolute URLs are resolved as internal routes — obje
     ).toEqual(['https://www.objectui.org/examples']);
   });
 
-  it('checks the shape in the disk surfaces too, not only content/docs', () => {
+  it('checks site URLs in the disk surfaces too, not only content/docs', () => {
     // One rejection from EACH tree, for the reason the fence test spells out:
     // an expectation naming only the content/docs one would hold just as well
     // if the check never ran on the disk rule, and would prove nothing.
@@ -1103,7 +1103,7 @@ describe("this site's own absolute URLs are resolved as internal routes — obje
     ).toEqual([]);
   });
 
-  it('ignores the fragment and the query — anchors are out of scope', () => {
+  it('ignores the fragment and the query on a site URL — anchors are out of scope', () => {
     expect(
       brokenHrefs({
         'guide/a.md': [

--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -12,6 +12,7 @@ import {
   diskPathExists,
   routeExists,
   selfRepoPath,
+  siteAbsoluteRoute,
   siteUrlExists,
   stripCode,
 } from '../check-doc-links.mjs';
@@ -68,6 +69,22 @@ import {
  * the FENCE BOUNDARY — `stripCode()` hides a link inside a code fence from this
  * gate, dead or not, and that limit is pinned as a decision rather than left to
  * be discovered as coverage that was never there (#3570 is the live instance).
+ *
+ * objectui#3603 closed the second half of the by-scheme skip, and the last
+ * describe pins it: a URL on this project's OWN site
+ * (`https://www.objectui.org/docs/...`) is an internal route wearing an origin,
+ * and `judgeHref()` waved every one of them through. It is now stripped to an
+ * absolute site path and handed to the same `routeExists()` — so the tests that
+ * matter most there are the INHERITANCE ones: a `.md` extension is rejected
+ * because the `/docs` branch is strict, and a non-`/docs` path is judged by the
+ * `apps/site` route table. Neither behaviour is re-implemented, and these tests
+ * fail if either is.
+ *
+ * That card's OTHER half — adding the package READMEs to SCAN_ROOTS — was
+ * deliberately not bought, because measuring it first turned up 11 more dead
+ * links in packages the card never touched (objectui#3622). Nothing here pins
+ * a `packages/**` row for that reason; when its backlog is paid, the SCAN_ROOTS
+ * assertions below are what will need extending.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -938,9 +955,10 @@ describe("this repo's own GitHub blob/tree URLs are resolved offline — objectu
 });
 
 describe('every failure carries the reason that rejected it', () => {
-  it('labels all seven checks distinctly', () => {
-    // The #3490 test of the same name, extended with objectui#3536's three.
-    // Every reason here must have a HINTS entry — the next test pins that.
+  it('labels all eight checks distinctly', () => {
+    // The #3490 test of the same name, extended with objectui#3536's three and
+    // objectui#3603's one. Every reason here must have a HINTS entry — the next
+    // test pins that.
     const repo = repoWith({
       ...SITE_FIXTURE,
       'content/docs/guide/a.md': [
@@ -949,6 +967,7 @@ describe('every failure carries the reason that rejected it', () => {
         '[docs](/docs/guide/a.md)',
         '[rel](./nowhere.md)',
         '[self](https://github.com/objectstack-ai/objectui/blob/main/packages/gone/README.md)',
+        '[origin](https://www.objectui.org/docs/guide/gone)',
       ].join('\n\n'),
       'examples/README.md': '[disk](./nowhere.md) and [abs](/packages/core)',
     });
@@ -959,6 +978,7 @@ describe('every failure carries the reason that rejected it', () => {
       'docs-route',
       'relative',
       'self-repo-url',
+      'site-absolute-url',
       'example-relative',
       'example-absolute',
     ]);
@@ -980,7 +1000,158 @@ describe('every failure carries the reason that rejected it', () => {
       'example-relative',
       'relative',
       'self-repo-url',
+      'site-absolute-url',
       'site-route',
     ]);
+  });
+});
+
+describe("this site's own absolute URLs are resolved as internal routes — objectui#3603", () => {
+  it('reports the shape all 9 package-README links had: a full site URL to no page', () => {
+    // The assertion that dies if `if (EXTERNAL_HREF_RE.test(href)) return null;`
+    // is ever allowed to reach a site-absolute URL again. `/docs/packages/*` is
+    // the namespace 7 package READMEs invented; it has never existed.
+    expect(
+      brokenHrefs({
+        'guide/a.md': '[docs](https://www.objectui.org/docs/packages/auth)',
+      }),
+    ).toEqual(['https://www.objectui.org/docs/packages/auth']);
+  });
+
+  it('accepts the same URL once it names a real page', () => {
+    expect(
+      brokenHrefs({
+        'guide/a.md': '[renderer](https://www.objectui.org/docs/core/schema-renderer)',
+        'core/schema-renderer.mdx': '# SchemaRenderer',
+      }),
+    ).toEqual([]);
+  });
+
+  it('judges both host spellings — this tree really carries www and bare', () => {
+    // 109 `www.objectui.org` against 9 bare `objectui.org` on main. Accepting
+    // only the majority spelling would leave the other 9 in the blind spot the
+    // whole change exists to close.
+    expect(
+      brokenHrefs({
+        'guide/a.md': [
+          '[www dead](https://www.objectui.org/docs/gone)',
+          '[bare dead](https://objectui.org/docs/gone)',
+          '[www live](https://www.objectui.org/docs/guide/a)',
+          '[bare live](https://objectui.org/docs/guide/a)',
+        ].join('\n\n'),
+      }),
+    ).toEqual(['https://www.objectui.org/docs/gone', 'https://objectui.org/docs/gone']);
+  });
+
+  it('INHERITS /docs strictness — an extension 404s here exactly as it does origin-less', () => {
+    // The test that proves the origin is stripped and the rest handed to the
+    // existing `routeExists()`, rather than judged by some new parallel path.
+    // `guide/b.md` is materialised: only the strict `/docs` branch rejects it.
+    expect(
+      brokenHrefs({
+        'guide/a.md': '[b](https://www.objectui.org/docs/guide/b.md)',
+        'guide/b.md': '# B',
+      }),
+    ).toEqual(['https://www.objectui.org/docs/guide/b.md']);
+  });
+
+  it('INHERITS the apps/site route table for non-/docs paths', () => {
+    // `/playground` and `/` are real routes in the site fixture; `/examples` is
+    // the prefix #3490 proved has never been one. Same table, same verdicts.
+    expect(
+      brokenHrefs({
+        'guide/a.md': [
+          '[examples](https://www.objectui.org/examples)',
+          '[playground](https://www.objectui.org/playground)',
+          '[home](https://www.objectui.org)',
+          '[home slash](https://www.objectui.org/)',
+        ].join('\n\n'),
+      }),
+    ).toEqual(['https://www.objectui.org/examples']);
+  });
+
+  it('checks the shape in the disk surfaces too, not only content/docs', () => {
+    // One rejection from EACH tree, for the reason the fence test spells out:
+    // an expectation naming only the content/docs one would hold just as well
+    // if the check never ran on the disk rule, and would prove nothing.
+    const repo = repoWith({
+      ...SITE_FIXTURE,
+      'content/docs/guide/a.md': '[gone](https://www.objectui.org/docs/gone)',
+      'README.md': '[gone](https://objectui.org/docs/gone)',
+      'examples/hello-world/README.md': '[live](https://www.objectui.org/docs/guide/a)',
+    });
+
+    expect(scan(repo).map((item) => [path.relative(repo, item.file), item.reason])).toEqual([
+      [path.join('content', 'docs', 'guide', 'a.md'), 'site-absolute-url'],
+      ['README.md', 'site-absolute-url'],
+    ]);
+  });
+
+  it('leaves every other origin alone, a lookalike host included', () => {
+    // The regex is anchored at both ends precisely so `objectui.org.example.com`
+    // cannot borrow this repo's route table — it is somebody else's host, and
+    // resolving it here would invent 404s that are not ours to report.
+    expect(
+      brokenHrefs({
+        'guide/a.md': [
+          '[lookalike](https://objectui.org.example.com/docs/gone)',
+          '[prefixed](https://notobjectui.org/docs/gone)',
+          '[other](https://example.com/docs/gone)',
+          '[docs of another](https://react.dev/docs/gone)',
+        ].join('\n\n'),
+      }),
+    ).toEqual([]);
+  });
+
+  it('ignores the fragment and the query — anchors are out of scope', () => {
+    expect(
+      brokenHrefs({
+        'guide/a.md': [
+          '[live](https://www.objectui.org/docs/guide/a#install)',
+          '[live q](https://www.objectui.org/docs/guide/a?x=1)',
+          '[dead](https://www.objectui.org/docs/gone#install)',
+        ].join('\n\n'),
+      }),
+    ).toEqual(['https://www.objectui.org/docs/gone#install']);
+  });
+
+  it('exposes siteAbsoluteRoute: the path it extracts, and the shapes it declines', () => {
+    expect(siteAbsoluteRoute('https://www.objectui.org/docs/guide/plugins')).toBe('/docs/guide/plugins');
+    expect(siteAbsoluteRoute('https://objectui.org/api/core')).toBe('/api/core');
+    expect(siteAbsoluteRoute('http://objectui.org/docs')).toBe('/docs');
+    // No path at all is the site ROOT, not the empty string — `routeExists()`
+    // reads '' as a pure in-page anchor and would wave it through.
+    expect(siteAbsoluteRoute('https://www.objectui.org')).toBe('/');
+    expect(siteAbsoluteRoute('https://www.objectui.org/docs/guide/a#x')).toBe('/docs/guide/a');
+    expect(siteAbsoluteRoute('https://objectui.org.example.com/docs')).toBeNull();
+    expect(siteAbsoluteRoute('https://example.com/docs')).toBeNull();
+    expect(siteAbsoluteRoute('/docs/guide/plugins')).toBeNull();
+  });
+
+  it('really judges the site-absolute URLs this repo carries — the floor under the green', () => {
+    // objectui#3603's anti-vacuous-green assertion, and the one this change
+    // needs most. Unlike #3536 and #3572 this card added NO scan root, so the
+    // repo-wide "no broken internal links" test above stays green whether or
+    // not the new resolution runs at all — it would pass just as well if
+    // `siteAbsoluteRoute()` returned null for everything. This pins that the
+    // URLs are really there and really reaching the check.
+    //
+    // Measured on main: 11 of them, of which 6 sit inside `content/docs`
+    // itself — the fact that makes this a general fix rather than a package
+    // README one — and 3 carry a `/docs/...` path, so the strict branch above
+    // is genuinely exercised by real content and not only by fixtures.
+    const seen: { root: string; route: string }[] = [];
+    for (const root of SCAN_ROOTS as { path: string }[]) {
+      for (const file of collectFiles(path.join(repoRoot, root.path)) as string[]) {
+        for (const match of stripCode(fs.readFileSync(file, 'utf8')).matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
+          const route = siteAbsoluteRoute(match[1].trim());
+          if (route !== null) seen.push({ root: root.path, route });
+        }
+      }
+    }
+
+    expect(seen.length).toBeGreaterThanOrEqual(11);
+    expect(seen.filter((item) => item.root === 'content/docs').length).toBeGreaterThanOrEqual(6);
+    expect(seen.filter((item) => item.route.startsWith('/docs')).length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -229,6 +229,66 @@
  * unscanned. Same one-row price, same caveat — measure the surface first, pay
  * its backlog separately, then add the row.
  *
+ * ## Why this file changed again (objectui#3603)
+ *
+ * A second scheme-bearing shape that is decidable here, and the exact mirror of
+ * the self-repo blob URLs above: **this site's own absolute URLs**.
+ *
+ * `judgeHref()` skipped every href carrying a scheme (`EXTERNAL_HREF_RE`), with
+ * `SELF_REPO_BLOB_RE` as the single exception. So
+ * `https://www.objectui.org/docs/guide/plugins` — a route on the very site this
+ * repo publishes, whose whole route table is already enumerated above to serve
+ * the `/docs/...` and `/...` branches — was never resolved, while the identical
+ * route written `/docs/guide/plugins` was checked strictly. The origin is the
+ * only difference between the two, and it is the one part of a URL this script
+ * can be certain about.
+ *
+ * **Not a package-README special case, and deliberately not written as one.**
+ * The blind spot lives in `judgeHref()`, so it was never confined to any
+ * surface: `content/docs` carries 6 site-absolute URLs of its own and the root
+ * `README.md` 5, and all 11 were unchecked until now. Stripping the origin and
+ * handing the rest to `routeExists()` fixes the class everywhere at once, which
+ * is also why it needs no new rule and no new scan root.
+ *
+ * Both host spellings are live in this tree (`www.objectui.org` and bare
+ * `objectui.org`), so both are accepted; every other origin stays external and
+ * remains lychee's problem. Because what survives the strip is an ordinary
+ * absolute site path, it inherits BOTH branches of `routeExists()` unchanged —
+ * `/docs` strictness included. `https://www.objectui.org/docs/guide/plugins.md`
+ * is rejected for precisely the reason `/docs/guide/plugins.md` is.
+ *
+ * Measured before landing: 11 site-absolute URLs across today's surfaces, zero
+ * dead. The #3572 shape again — the check arrives green, its backlog already
+ * paid.
+ *
+ * ### Measured and NOT bought: the package READMEs (objectui#3622)
+ *
+ * objectui#3603 asked for a second half: growing the scan surface by the 38
+ * package READMEs, which is where the 9 dead links that prompted it lived.
+ * Those 9 are fixed by hand in the same PR. The scan row is **not** added, and
+ * the reason is this file's own rule from #3572 — measure the surface, pay its
+ * backlog separately, then add the row.
+ *
+ * (Note for whoever writes that row: a glob naming each package README cannot
+ * be spelled inside this block comment, because the star-slash in it closes the
+ * comment. Say it in prose here, or move the note outside.)
+ *
+ * The surface was measured, and its backlog is not the 9. With the resolution
+ * above in place, a `disk`-rule row covering those 38 files
+ * reports **11 more** dead links in five packages that card never touched:
+ * `/api/core`, `/api/react`, `/api/components` (no such routes — the class
+ * #3490 swept), `/docs/core`, `/docs/fields`, `/docs/layout` (real directories
+ * with no index page, so no route), `/docs/types` and `/examples` (neither
+ * exists), plus two disk paths that are simply absent
+ * (`../../docs/SHADCN_SYNC.md`, `./LICENSE`).
+ *
+ * Three of those deserve naming, because objectui#3603's own verification
+ * script scored them GREEN: it accepted a bare DIRECTORY as a fumadocs
+ * candidate. This gate does not, and is right not to — `routeCandidates()` has
+ * no such spelling, and the pinned test "rejects a relative link to a directory
+ * that has no index page" is that decision. `content/docs/core/` really has no
+ * index page, so `/docs/core` really does 404. The class is 20 links, not 9.
+ *
  * ## Code spans are stripped before scanning
  *
  * Required, not tidiness. Extending the scan to relative hrefs turns markdown's
@@ -265,6 +325,15 @@ const ROUTE_ENTRY_RE = /^(?:page|route)\.(?:js|jsx|ts|tsx|md|mdx)$/;
  * treats owner and repo that way; the captured path is used as written.
  */
 const SELF_REPO_BLOB_RE = /^https:\/\/github\.com\/objectstack-ai\/objectui\/(?:blob|tree)\/main\/(.+)$/i;
+/**
+ * This site's own origin — the second decidable scheme-bearing shape
+ * (objectui#3603). Both host spellings are in use in this tree, and the site
+ * serves the same routes under each. Anchored at both ends so a lookalike host
+ * (`objectui.org.example.com`) cannot match; the captured group is the absolute
+ * site path, which `routeExists()` then judges exactly as if it had been
+ * written without the origin.
+ */
+const SITE_ORIGIN_RE = /^https?:\/\/(?:www\.)?objectui\.org(\/[^\s]*)?$/i;
 /** Never markdown sources of ours, and huge — walking them wastes the scan. */
 const UNSCANNED_DIRS = new Set(['node_modules', 'dist', 'build', '.next', '.turbo', '.git']);
 
@@ -399,6 +468,23 @@ function hrefPath(href) {
 export function selfRepoPath(href) {
   const match = SELF_REPO_BLOB_RE.exec(hrefPath(href));
   return match ? match[1].replace(/\/+$/, '') : null;
+}
+
+/**
+ * The absolute site path a site-absolute URL names, or `null` if this href is
+ * not one (objectui#3603). The fragment and query are stripped — anchors are
+ * out of scope here for the same reason they are for `selfRepoPath` — but the
+ * path is NOT decoded: `routeExists()` does that itself, and decoding twice
+ * would corrupt a legitimately escaped `%25`.
+ *
+ * `https://www.objectui.org` with no path at all names the site root, so it
+ * resolves to `/` rather than to the empty string (which `routeExists()` reads
+ * as a pure in-page anchor and waves through).
+ */
+export function siteAbsoluteRoute(href) {
+  const match = SITE_ORIGIN_RE.exec(href.split('#')[0].split('?')[0].trim());
+  if (!match) return null;
+  return match[1] || '/';
 }
 
 /**
@@ -592,13 +678,25 @@ function classifyBrokenDisk(href) {
  * @returns {string | null} the failing check's name, or `null` when it resolves
  */
 function judgeHref(href, context) {
-  // The self-repo URL check runs FIRST and in every rule: it is the one
-  // external-looking shape this script can decide, so it must be reached
-  // before the by-scheme skip below waves it through (objectui#3536).
+  // The two external-LOOKING shapes this script can actually decide run FIRST,
+  // and in every rule: both must be reached before the by-scheme skip below
+  // waves them through (objectui#3536, objectui#3603).
   const selfPath = selfRepoPath(href);
   if (selfPath !== null) {
     const target = path.resolve(context.repoRoot, selfPath);
     return isInside(context.repoRoot, target) && pathExists(target) ? null : 'self-repo-url';
+  }
+  // A URL on this site is an internal route wearing an origin. Strip the origin
+  // and judge what is left with the same `routeExists()` every absolute href
+  // goes through — so `/docs` strictness and the `apps/site` route table apply
+  // here too, on every surface, `content/docs` included.
+  // A URL on this site is an internal route wearing an origin. Strip the origin
+  // and judge what is left with the same `routeExists()` every absolute href
+  // goes through — so `/docs` strictness and the `apps/site` route table apply
+  // here too, on every surface, `content/docs` included.
+  const siteRoute = siteAbsoluteRoute(href);
+  if (siteRoute !== null) {
+    return routeExists(siteRoute, context) ? null : 'site-absolute-url';
   }
   if (EXTERNAL_HREF_RE.test(href)) return null;
 
@@ -678,6 +776,13 @@ const HINTS = {
     ' https://github.com/packages/core. Write the repo path relative to the' +
     ' file (`./packages/core`), or, if a github.com URL really was meant,' +
     ' write it in full with the scheme.',
+  'site-absolute-url':
+    'A `https://www.objectui.org/...` URL is a route on this project OWN site,' +
+    ' so the origin is stripped and the rest is checked exactly like the' +
+    ' equivalent absolute href — this one does not resolve. Fix the route, or' +
+    ' drop the link if no such page exists. Inside content/docs prefer the' +
+    ' origin-less form (`/docs/guide/plugins`): it survives a domain change,' +
+    ' and both spellings are checked identically.',
   'self-repo-url':
     'A `https://github.com/objectstack-ai/objectui/(blob|tree)/main/...` URL' +
     ' points into this repository, so its path is checked against the working' +


### PR DESCRIPTION
Fixes-part-of #3603

分段交付。**内容半件全交**;**门禁半件只交第 2 层**(`judgeHref` 解析站内绝对 URL),第 1 层(`SCAN_ROOTS` 追加包 README)按实测结论回队列,单独开在 #3622 —— 理由在第四节,是本 PR 最需要复核的判断。

PM 裁决要求的前置实测已做:`git log origin/main` 确认 **#3589 已落 main**(`6632114bc`,`SCAN_ROOTS` 打印 6 roots),worktree 基线即含它,门禁半件不与任何在途 PR 同文件。

---

## 一、内容半件:9 条逐条处置

按 fumadocs 候选拼写(`x.mdx` / `x.md` / `x/index.mdx` / `x/index.md`)在 `content/docs` 下逐个查证。查不到对应文档页的删该行(指向不存在的页面比不给链接更糟,分诊已确认此 fallback);查到的改指真实页。

| 位置 | 原链接 | 处置 | 依据 |
| --- | --- | --- | --- |
| `packages/auth/README.md:223` | `/docs/packages/auth` | **删行** | 全库无 `@object-ui/auth` 的文档页;`AuthProvider` / `AuthGuard` 在 `content/docs` 零命中。`blocks/authentication.mdx` 是「Authentication Blocks」登录表单 block 图库,与本包(Provider、守卫、token)不是一个主题,指过去会误导 |
| `packages/collaboration/README.md:132` | `/docs/packages/collaboration` | **删行** | 无文档页;`LiveCursors` / `PresenceAvatars` 零命中 |
| `packages/i18n/README.md:152` | `/docs/packages/i18n` | **删行** | 无文档页;`useObjectTranslation` 仅在 `guide/public-forms.md` 顺带出现,`I18nProvider` 仅在 architecture-overview / troubleshooting 顺带出现,都不是 i18n 的文档页 |
| `packages/mobile/README.md:143` | `/docs/packages/mobile` | **删行** | 无文档页;`useBreakpoint` / `MobileProvider` 零命中 |
| `packages/permissions/README.md:137` | `/docs/packages/permissions` | **删行** | 无文档页;`PermissionGuard` / `usePermissions` 零命中 |
| `packages/providers/README.md:82` | `/docs/packages/providers` | **删行** | 无文档页 |
| `packages/react/README.md:243` | `/docs/packages/react` | **改指 `/docs/core/schema-renderer`** | issue 提示「react 的文档可能在 `content/docs/core/` 一带」,查证属实:`core/schema-renderer.mdx` 标题 "SchemaRenderer"、描述 "Core component for rendering JSON schemas into React components",正是本包 README 开篇自述的头号导出 |
| `packages/vscode-extension/README.md:188` | `/docs/protocol/overview` | **改指 `/docs/api/schema-reference`** | 该行标签就是 "Schema Reference",`api/schema-reference.md` 标题正是 "Schema Type Reference" |
| `packages/vscode-extension/README.md:189` | `/docs/api/components` | **改指 `/docs/components`** | 该行标签是 "Component Library",`components/index.md` 标题正是 "Component Gallery"(`packages/components/README.md` 早已用这条路由) |

6 删 3 改。删掉的那 6 行所在的 `## Links` 尾块保留其余 5 条(npm / Changelog / Issues / Contributing / Roadmap),README 正文本身就是这些包当前的文档。

> **顺带说明**:这 7 个包共同假设了一个不存在的 `/docs/packages/*` 命名空间。删链接只是止血,真正的修法是把这些页面写出来;这属另一件事,已在 #3622 末尾记录供分诊判断是否另开。

复核脚本(issue 正文同款,改为对工作树跑)输出:`dead links: 0`。

## 二、门禁半件第 2 层:站内绝对 URL 解回站内路由

`judgeHref()` 此前对任何带 scheme 的 href 直接 `return null`,唯一例外是 `SELF_REPO_BLOB_RE`。于是 `https://www.objectui.org/docs/guide/plugins` 从不校验,而**同一条路由**写成 `/docs/guide/plugins` 则严格校验 —— 两者只差一个 origin,而 origin 恰恰是这个脚本唯一能确定的部分。

实现是通用的,**不特判包 README**:剥掉 origin,把剩下的绝对站内路径原样交给同一个 `routeExists()`。因此两个分支都原样继承 —— `/docs` 的严格性(`.../docs/guide/foo.md` 被拒的理由与 `/docs/guide/foo.md` 完全相同)与 `apps/site` 路由表(`/examples` 无路由则拒)。这一点在测试里是两条 `INHERITS ...` 断言,实现若改成"另起一套判断"它们会红。

两种 host 拼写都认(本仓 `www.objectui.org` 与裸 `objectui.org` 都在用);正则两端锚定,`objectui.org.example.com` 这种仿冒 host 不会误借本仓路由表(有专门一条测试)。

**落地前实测:全部扫描面共 11 条站内绝对 URL,零死链** —— 与 #3589 同形状(门禁到货即绿),对照 #3479(16 个死目标)/ #3490(18 个)那种「门禁与欠账同时到货」。其中 **6 条就在 `content/docs` 自己**,这正是分诊说的「这一层对所有扫描面都成立」—— 不是包 README 专属问题。

### 反空绿

本次**没有新增扫描根**,所以既有的仓库级 "has no broken internal links" 断言即使解析层完全不干活也照样绿。为此新增一条计数下限:实测 11 条(其中 `content/docs` 贡献 6 条、带 `/docs` 路径 3 条)必须真的被 `siteAbsoluteRoute()` 认出来,否则上面那条绿毫无意义。这是本 PR 最重要的一条测试。

新增/改写:8 条新 case,既有 `labels all seven checks distinctly` 扩成 eight、HINTS 键表扩成 8 键。

## 三、逆向验证(方向先定,后跑)

预测方向为**常规方向(改前绿 / 改后红)**,理由:这是对一个**此前被 `EXTERNAL_HREF_RE` 无条件跳过**的形状新增的检查 —— 既不存在 canonical-first 的 `??` 链(故不属 inverted 家族),新判定喂的也是谓词而非计数(故不属「诊断变多」家族)。

| 步骤 | 状态 | 预测 | 实测 |
| --- | --- | --- | --- |
| 1 | 在 `content/docs/index.md` 与根 `README.md` 各植入一条死的站内绝对 URL,解析层**在** | 红,reason 为 `site-absolute-url`,两个面各一条 | ✅ `Found 2 broken links` —— `[site-absolute-url] content/docs/index.md:89` + `[site-absolute-url] README.md:518`,hint 正常打印 |
| 2 | 保留植入,**撤掉** `judgeHref` 里的解析分支 | 绿(证明是新层在干活,不是既有检查顺手抓到的) | ✅ `Links are valid across 6 scan roots.` exit=0 —— 两条死链被静默放行,正是改前行为 |
| 3 | 撤掉解析分支的状态下跑测试 | 新测试应大面积红 | ✅ 7 failed / 68 passed(accept 侧与纯函数用例本就该继续绿) |
| 4 | 全部还原 | 绿,且工作树只剩本 PR 的文件 | ✅ `Links are valid across 6 scan roots.`,`git status` 干净 |

## 四、⚠️ 门禁半件第 1 层没有做 —— 请优先复核这一节

PM 的预测是「内容半件清干净后,门禁首跑对真仓应为绿」。**这个预测对第 2 层成立,对第 1 层被实测证伪**,所以我停在文件面边界上,没有硬凑。

在 9 条已清干净之后,把 `disk` 规则的包 README 扫描根加上去,**仍会红 11 条**,分布在本单文件面之外的 5 个包(components / core / fields / layout / types),外加 react、vscode-extension 各一条**不同的行**:`/api/core`、`/api/react`、`/api/components`(无此路由)、`/docs/core`、`/docs/fields`、`/docs/layout`(真目录但无 index 页,故无路由)、`/docs/types`、`/examples`(均不存在),以及两条磁盘路径 `../../docs/SHADCN_SYNC.md`、`./LICENSE`(文件不在)。

其中 `/docs/core`、`/docs/fields`、`/docs/layout` 值得单独点名:**issue 正文的复核脚本把它们判成了绿**,因为那段脚本把**裸目录**也算作 fumadocs 候选(候选数组的最后一项 `rel`)。门禁不这么算,而且它是对的 —— `routeCandidates()` 只有四种拼写,既有 pin 测试 `rejects a relative link to a directory that has no index page` 就是这条规则。实测 `content/docs/` 下 `core` / `fields` / `layout` / `rfcs` 确实没有 index 页。**所以这一类的真实规模是 20 条,不是 9 条。**

按本文件头注释自 #3572 起写死的规矩 ——「先量扫描面,单独付清红账,再加那一行」—— 红账应单独付,故第 1 层连同它的 11 条欠账开在 **#3622**(已挂为 #3603 的子 issue,自动进派发池)。头注释里新增了一节 "Measured and NOT bought",把这个测量结果和 issue 编号写死,避免下一个人不量就加行、撞上一片意外的红。

### 文件面偏差(1 个文件,主动声明)

`content/docs/guide/ci-cd-pipeline.md` 不在派发单列出的文件面里,但本 PR 改了它:该页用一张表逐条描述这个门禁判定哪些 href 形状,原文写「Four checks, by href shape」,我的改动使其变成事实错误。#3589 改同一处行为时也同步改了这个文件(它是那次 diff 的三个文件之一),AGENTS.md 准则 #2「docs 不反映代码就不算完成」也指向同一结论。改动限于新增跨扫描面两形状的说明表 + 一处覆盖面描述,未动其它内容;已确认无在途 PR 触碰该文件。若判定越界,可要求我拆出。

## 五、验证

```
$ node scripts/check-doc-links.mjs
Links are valid across 6 scan roots.

$ pnpm vitest run scripts/__tests__/check-doc-links.test.ts --maxWorkers=2
 Test Files  1 passed (1)
      Tests  75 passed (75)

$ pnpm vitest run scripts/__tests__/ --maxWorkers=2
 Test Files  16 passed (16)
      Tests  293 passed (293)

$ pnpm type-check:scripts
exit=0

$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3650 tracked text file(s); skipped 85 binary)
```

消费半径清点:`check-doc-links` 的消费方为 `docs-links.yml` / `ci.yml` / `check-links.yml`、`CONTRIBUTING.md`、`content/docs/guide/ci-cd-pipeline.md`、`lychee.toml` 与 3 个测试文件,全部跑过或核对过。`CONTRIBUTING.md` 明确写着「read them there instead of trusting a list copied into prose」,无需同步。

**changeset:不加**,与仓例一致 —— #3602(纯 README 死链修复)与 #3589(纯门禁脚本 + 测试)都没有 changeset。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_