### PR TITLE
docs(runner): 删掉 Best Practices 里复活的环境变量配置面 (#3617)

### DIFF
--- a/content/docs/utilities/runner.mdx
+++ b/content/docs/utilities/runner.mdx
@@ -488,20 +488,7 @@ src/app-data/
         └── accounts.json    # route "/crm/accounts"
 ```
 
-### 2. Environment Configuration
-
-Use environment variables for configuration:
-
-```typescript
-const config = {
-  apiUrl: import.meta.env.VITE_API_URL,
-  features: {
-    analytics: import.meta.env.VITE_ENABLE_ANALYTICS === 'true',
-  },
-}
-```
-
-### 3. Error Boundaries
+### 2. Error Boundaries
 
 Wrap components in error boundaries:
 


### PR DESCRIPTION
Fixes #3617

## 问题

`content/docs/utilities/runner.mdx` 的 `## Best Practices` 下,`### 2. Environment Configuration` 教读者用环境变量配置 Runner:

````markdown
### 2. Environment Configuration

Use environment variables for configuration:

```typescript
const config = {
  apiUrl: import.meta.env.VITE_API_URL,
  features: {
    analytics: import.meta.env.VITE_ENABLE_ANALYTICS === 'true',
  },
}
```
````

**实现侧不支持这个说法。** 核查范围是整个包(不只 `src`):

```
$ grep -rnE "import.meta.env|process.env|loadEnv|VITE_" packages/runner
(无输出,exit 1)
```

而同一页上方 `## Metadata Loading` 的 :95 写着**相反**的话:

> This is the Runner's only API base URL setting — it reads no environment variables and no config file

两句在同一页、相隔约 400 行,读者按哪句做都算「照文档做」。

## 这是 #3538 的漏网

#3538(`039d2d077`,Fixes #3533)以「文档不许描述不存在的能力」为由把本页的 `## Environment Variables` **整节**删除 —— 但只删了那一节,这处 Best Practices 小节把同一个不存在的配置面又讲了一遍。被删那节写的是 `VITE_API_URL` + `VITE_APP_TITLE`,与本处的 `VITE_API_URL` 是同一条。

## 处置

按 #3538 的口径**整节删除**,而不是换个变量名续命 —— Runner 没有任何配置面可以承接它,唯一的配置入口是 `?api=` 查询参数,已由 `## Metadata Loading` 一节完整覆盖。

`:95` 那句保留原样:修后全页对「Runner 读不读环境变量」只剩一个声音。

### 编号顺延前后对照

| | 修前 | 修后 |
| --- | --- | --- |
| 1 | `### 1. One File per Page` | `### 1. One File per Page`(不动) |
| 2 | `### 2. Environment Configuration` | **删除** |
| 3 | `### 3. Error Boundaries` | `### 2. Error Boundaries` |

`### 1.` 已由 #3616 从 `Modular Schemas` 改写为 `One File per Page`,本 PR 以最新 `main`(`0e4ea07b2`)重锚定,按内容定位而非行号。

## 验证(先预测后验证,四条全中)

| 预测 | 结果 |
| --- | --- |
| 修后 `grep -n 'VITE_\|import.meta.env\|process.env' content/docs/utilities/runner.mdx` 0 命中(修前 2 命中) | ✅ 修前 2(:497 / :499),修后 exit 1 零命中 |
| `:95` 的 "reads no environment variables" 原样保留 | ✅ `95:setting — it reads no environment variables and no config file:` |
| `node scripts/check-doc-links.mjs` 修前修后都绿 | ✅ 两次均 `Links are valid across 6 scan roots.` exit 0 |
| `node scripts/check-control-bytes.mjs` 绿 + 改动文件自扫干净 | ✅ `OK (scanned 3654 tracked text file(s); skipped 85 binary)`;`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 零命中 |

另核:全仓无任何位置引用被删小节的锚点 `#2-environment-configuration`(`grep -rni` 零命中),故 doc-links 修前修后同绿不是「没扫到」。本 PR 只删不增链接。

`content/**`-only 的 PR 会跳过 `ci.yml` / `lint.yml`(两者的 `paths-ignore` 都含 `content/**`),真正会跑的门禁正是上表后两条 —— `docs-links.yml` 与 `control-bytes.yml`。

## 范围

- **单文件**:`content/docs/utilities/runner.mdx`,单个 diff hunk(`@@ -491,14 +491 @@`)。
- ⛔ 未碰同页 `### Add Custom Routes`(:409,那是 #3618,同文件互斥,等本单落 main 另派)。
- ⛔ 未碰 `packages/runner/README.md`(#3620 在途)。
- **无 changeset**:改动只在站点文档 `content/`,不涉及任何已发布包的行为;`@object-ui/site` 本就在 `.changeset/config.json` 的 `ignore` 列表内。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_