### PR TITLE
fix(app-shell): 零应用分支补 component/metadata 别名路由与 catch-all (#3610)

### DIFF
--- a/.changeset/no-app-component-metadata-routes-3610.md
+++ b/.changeset/no-app-component-metadata-routes-3610.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Make the zero-app console's "Object Manager" / "Datasources" entries resolve, and give that branch a not-found screen instead of a blank one (objectui#3610).
+
+On a deployment with no published apps, the system fallback navigation sends `sys-datasources` to `/apps/setup/component/metadata/resource?type=datasource` and `sys-objects` to `/apps/setup/system/metadata/object` (rewritten by the console host onto the same legacy alias). `isMetadataRoute` is a substring test on `/metadata`, so both URLs pass the "No Apps Configured" guard and enter `AppContent`'s no-`activeApp` route table — which declared no `component/…` route at all and, unlike the with-`activeApp` table, carried no trailing catch-all. A `<Routes>` with no match renders `null`, so an admin building their first object got a fully blank screen: no 404, no error, no empty state.
+
+Both halves are fixed on the routing side, with no navigation URL changed. The two legacy metadata aliases (`component/metadata/directory`, `component/metadata/resource/*`) are now declared in the no-`activeApp` branch too, mirroring the with-`activeApp` branch — they are redirects, not a second copy of the page, so they forward onto the canonical `metadata/:type` routes that branch already declared. And the branch now ends in the same `path="*"` → "Page not found" screen the with-app branch has always had, so the next unresolved URL in a zero-app console is reportable rather than invisible.

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -629,7 +629,29 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
           <Route path="metadata/:type/new" element={<MetadataResourceEditPage createMode />} />
           <Route path="metadata/:type/:name" element={<MetadataResourceEditPage />} />
           <Route path="metadata/:type/:name/history" element={<MetadataResourceHistoryPage />} />
+          {/* #3610 — the legacy metadata aliases, mirrored from the with-app
+              branch below. They are NOT a second copy of the page: both render
+              `LegacyMetadataRedirect`, which forwards onto the canonical
+              `metadata/:type…` routes declared just above. Declaring them here
+              is what makes the zero-app console's own fallback navigation work:
+              `sys-datasources` points straight at
+              `…/component/metadata/resource?type=datasource`, and `sys-objects`
+              arrives via the host's `system/metadata/:type` → same alias
+              rewrite. Both pass `isMetadataRoute` (a substring test on
+              `/metadata`) and so land in THIS branch, which declared no
+              `component/…` route at all — every one of them rendered a blank
+              screen. Kept as a mirror rather than re-pointed navigation because
+              the alias already has exactly one canonical destination; adding a
+              zero-app-only spelling would create a second. */}
+          <Route path="component/metadata/directory" element={<LegacyMetadataRedirect mode="directory" />} />
+          <Route path="component/metadata/resource/*" element={<LegacyMetadataRedirect mode="resource" />} />
           {extraRoutesNoApp}
+          {/* #3610 — same catch-all the with-app branch has carried all along.
+              A `<Routes>` with no match renders `null`, i.e. a blank page that
+              is indistinguishable from a crash: no 404, no error, nothing to
+              report. This branch is the one a zero-app deployment lives in, so
+              it is precisely where an unresolved URL most needs to say so. */}
+          <Route path="*" element={<RouteNotFound />} />
         </Routes>
       </Suspense>
     );

--- a/packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Zero-app console: the `component/metadata/*` destinations must resolve, and
+ * anything unmatched must say so (objectui#3610).
+ *
+ * ## The defect
+ *
+ * With zero published apps, the system fallback sidebar offers two entries that
+ * both land inside `AppContent`'s no-`activeApp` branch:
+ *
+ *     sys-datasources -> /apps/setup/component/metadata/resource?type=datasource
+ *     sys-objects     -> /apps/setup/system/metadata/object
+ *
+ * `isMetadataRoute` is a substring test (`pathname.includes('/metadata')`), so
+ * both URLs pass the "no apps configured" guard and enter the no-`activeApp`
+ * `<Routes>`. That branch declared `create-app`, `system/marketplace*` and
+ * `metadata*` only — no `component/…` at all — and, unlike the with-`activeApp`
+ * branch, no trailing `path="*"`. A `<Routes>` with no match renders `null`:
+ * a fully blank screen, no 404, no error, no empty state.
+ *
+ * ## Which spelling is canonical — MEASURED, and the opposite of the guess
+ *
+ * The dispatch presumed `component/metadata/resource?type=` was the canonical
+ * shape (because `apps/console`'s `MetadataRedirect` rewrites *into* it). It is
+ * not. In the with-`activeApp` branch `component/metadata/resource/*` is not a
+ * page at all — it is declared under the comment *"Legacy: old metadata routes
+ * built before the REST-style nesting landed. Redirect to the new
+ * /metadata/:type/... shape"* and renders `LegacyMetadataRedirect`
+ * (`console/AppContent.tsx`). The canonical spelling is `metadata/:type`, which
+ * both branches already declare as the real `MetadataResourceListPage`.
+ *
+ * So the two spellings are NOT two pages: one is an alias that 302s to the
+ * other. That makes the fix a pure mirror — declare the same legacy-alias
+ * redirect in the no-app branch that the with-app branch already declares, and
+ * the alias lands on a route the no-app branch has had all along. No navigation
+ * URL changes, and the alias keeps its single canonical destination. The
+ * assertions below pin the resulting *pathname*, so a future change that made
+ * `component/metadata/resource` render a second copy of the page instead of
+ * redirecting would turn this file red.
+ *
+ * ## Scope of the stubs
+ *
+ * This file measures ROUTING — which route matches, which URL results, what
+ * ends up on screen. The metadata-admin pages and the designer are stubbed;
+ * their internals are other files' subject.
+ *
+ * `systemRoutesStub` below transcribes the host fragment from
+ * `apps/console/src/AppContent.tsx` (`systemRoutes` + its `MetadataRedirect`).
+ * app-shell cannot import from `apps/` — different Vitest project, and the
+ * redirect is a module-private function — so the rewrite is copied verbatim,
+ * including its `prefix` regex, and this comment is the pointer back to the
+ * original. It is the `sys-objects` leg of the chain: without it that URL's
+ * two-hop route to the same dead end is invisible here.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Mocks — everything that takes part in the routing decision (AppContent's
+// guards, its nested <Routes>, react-router's matching) stays real.
+// ---------------------------------------------------------------------------
+
+// The metadata-admin pages sit behind `React.lazy(() => import('../views/metadata-admin'))`.
+// Stubbing the module keeps the assertions off the transform pipeline entirely
+// (AGENTS.md §测试纪律: never let an unbounded module load race a bounded
+// `findBy` window). The list page echoes its `:type` param so the assertions can
+// tell "the right resource page" from "a resource page".
+vi.mock('../../views/metadata-admin', () => ({
+  MetadataDirectoryPage: () => <div data-testid="metadata-directory-page">directory</div>,
+  StudioHomePage: () => <div data-testid="studio-home-page">studio</div>,
+  MetadataResourceListPage: () => {
+    const { type } = useParams<{ type?: string }>();
+    return <div data-testid="metadata-resource-list-page">{type}</div>;
+  },
+  MetadataResourceEditPage: () => <div data-testid="metadata-resource-edit-page" />,
+  MetadataResourceHistoryPage: () => <div data-testid="metadata-resource-history-page" />,
+  MetadataDiagnosticsPage: () => <div data-testid="metadata-diagnostics-page" />,
+}));
+
+vi.mock('@object-ui/plugin-designer', () => ({
+  CreateAppPage: () => <div data-testid="create-app-page">create app</div>,
+  EditAppPage: () => <div data-testid="edit-app-page" />,
+  DashboardDesignPage: () => <div data-testid="dashboard-design-page" />,
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+  }),
+}));
+
+vi.mock('@object-ui/auth', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAuth: () => ({
+    user: null,
+    getAuthConfig: async () => ({ features: {} }),
+    activeOrganization: null,
+  }),
+  useIsWorkspaceAdmin: () => false,
+}));
+
+const dataSourceStub = {
+  onConnectionStateChange: () => () => {},
+  getConnectionState: () => 'connected',
+};
+vi.mock('../../providers/AdapterProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => dataSourceStub,
+}));
+
+/** The zero-app deployment this whole branch exists for. */
+const refreshMetadata = vi.fn(async () => {});
+vi.mock('../../providers/MetadataProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useMetadata: () => ({
+    apps: [],
+    objects: [],
+    loading: false,
+    // `undefined` — no bucket preloading to await, so the shell is ready on
+    // first render (mirrors a host that ships metadata eagerly).
+    ensureType: undefined,
+    error: null,
+    refresh: refreshMetadata,
+  }),
+}));
+
+const actionRunnerStub = { registerHandler: vi.fn(), getContext: () => ({}) };
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useActionRunner: () => ({ execute: vi.fn(), runner: actionRunnerStub }),
+  useGlobalUndo: () => {},
+  useMutationInvalidationBridge: () => {},
+}));
+
+import { AppContent } from '../AppContent';
+
+/** Reports the live URL so a redirect chain is visible as a URL, not just a screen. */
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="pathname">{location.pathname}</div>;
+}
+
+/**
+ * VERBATIM transcription of `apps/console/src/AppContent.tsx`'s `MetadataRedirect`
+ * (the `system/metadata/*` legs of its `systemRoutes` fragment). Keep the regex
+ * and the target construction identical to the original — this stub is what makes
+ * the `sys-objects` hop measurable from inside app-shell.
+ */
+function MetadataRedirectStub() {
+  const { metadataType, itemName } = useParams<{ metadataType?: string; itemName?: string }>();
+  const location = useLocation();
+  const prefix = location.pathname.replace(/\/(system\/)?metadata(\/.*)?$/, '');
+  const base = `${prefix}/component/metadata/resource`;
+  const target = !metadataType
+    ? `${prefix}/component/metadata/directory`
+    : itemName
+      ? `${base}/${itemName}?type=${metadataType}`
+      : `${base}?type=${metadataType}`;
+  return <Navigate to={target} replace />;
+}
+
+/**
+ * The host's `extraRoutesNoApp` fragment, reduced to the entries this file
+ * depends on. `apps/console/src/AppContent.tsx` passes the SAME fragment to both
+ * `extraRoutes` and `extraRoutesNoApp`; with zero apps only the latter is
+ * reachable.
+ */
+const systemRoutesStub = (
+  <>
+    <Route path="system" element={<div data-testid="system-hub-page">system hub</div>} />
+    <Route path="system/metadata" element={<MetadataRedirectStub />} />
+    <Route path="system/metadata/:metadataType" element={<MetadataRedirectStub />} />
+    <Route path="system/metadata/:metadataType/:itemName" element={<MetadataRedirectStub />} />
+  </>
+);
+
+/**
+ * The reference host's route tree, reduced to the parts that decide this
+ * question. Mirrors `apps/console/src/App.tsx`.
+ */
+function renderConsoleAt(initialUrl: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/apps/:appName/*" element={<AppContent extraRoutesNoApp={systemRoutesStub} />} />
+        <Route path="/" element={<div data-testid="root-landing">landing</div>} />
+        <Route path="/home" element={<div data-testid="home-launcher">home</div>} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const pathname = () => screen.getByTestId('pathname').textContent;
+
+describe('AppContent — zero-app component/metadata destinations (objectui#3610)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sys-datasources: /apps/setup/component/metadata/resource?type=datasource renders the resource page', async () => {
+    // The white screen this issue is about. The URL passes `isMetadataRoute`
+    // (substring `/metadata`) and so enters the no-`activeApp` branch, which
+    // used to declare nothing matching `component/…` and had no catch-all.
+    renderConsoleAt('/apps/setup/component/metadata/resource?type=datasource');
+
+    const page = await screen.findByTestId('metadata-resource-list-page');
+    expect(page).toBeInTheDocument();
+    // Which page: the `type` search param must survive the alias hop as the
+    // canonical path segment.
+    expect(page).toHaveTextContent('datasource');
+    // The direction of the hop — `component/metadata/resource` is the ALIAS,
+    // `metadata/:type` is canonical. Asserting the screen alone would stay
+    // green if the alias grew a second copy of the page.
+    expect(pathname()).toBe('/apps/setup/metadata/datasource');
+    // Not the "no apps configured" screen, and not bounced to the host landing.
+    expect(screen.queryByTestId('create-first-app-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('root-landing')).not.toBeInTheDocument();
+  });
+
+  it('sys-objects: the /apps/setup/system/metadata/object detour reaches the same resource page', async () => {
+    // The non-obvious half, pinned on its own because it would regress
+    // silently: this URL is rewritten by the HOST (`MetadataRedirect`) onto the
+    // legacy alias, which the shell then rewrites onto the canonical route.
+    // Three route tables, two redirects, zero apps.
+    renderConsoleAt('/apps/setup/system/metadata/object');
+
+    const page = await screen.findByTestId('metadata-resource-list-page');
+    expect(page).toBeInTheDocument();
+    expect(page).toHaveTextContent('object');
+    expect(pathname()).toBe('/apps/setup/metadata/object');
+    expect(screen.queryByTestId('root-landing')).not.toBeInTheDocument();
+  });
+
+  it('the typeless legacy directory alias reaches the metadata directory', async () => {
+    // `system/metadata` with no `:metadataType` takes `MetadataRedirect`'s other
+    // arm, onto `component/metadata/directory` — the second alias the with-app
+    // branch declares, and the second blank screen without it.
+    renderConsoleAt('/apps/setup/system/metadata');
+
+    expect(await screen.findByTestId('metadata-directory-page')).toBeInTheDocument();
+    expect(pathname()).toBe('/apps/setup/metadata');
+  });
+
+  it('an unmatched URL inside this branch renders "not found" instead of a blank screen', async () => {
+    // The general fix. `/system` flips `isSystemRoute`, so this enters the
+    // branch; nothing declares `system/no-such-page`. Before the catch-all,
+    // `<Routes>` rendered `null` — an indistinguishable-from-crashed blank page.
+    renderConsoleAt('/apps/setup/system/no-such-page');
+
+    expect(await screen.findByText('Page not found')).toBeInTheDocument();
+    expect(pathname()).toBe('/apps/setup/system/no-such-page');
+    // A 404, not a bounce and not the empty state.
+    expect(screen.queryByTestId('root-landing')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('create-first-app-btn')).not.toBeInTheDocument();
+  });
+
+  it('an unmatched component/metadata/* spelling gets the same "not found"', async () => {
+    // The alias routes are narrow on purpose (`directory`, `resource/*`) — a
+    // near-miss must be reportable rather than blank.
+    renderConsoleAt('/apps/setup/component/metadata/nonsense');
+
+    expect(await screen.findByText('Page not found')).toBeInTheDocument();
+    expect(pathname()).toBe('/apps/setup/component/metadata/nonsense');
+  });
+
+  it('MEASUREMENT: /apps/setup/no-such-page never reaches this branch — it is the no-apps empty state', async () => {
+    // Correction to the acceptance criterion's example URL. A path with no
+    // `/system`, no `/metadata` and no `create-app` fails all three flags the
+    // branch is gated on, so the `!activeApp` guard above it wins and shows
+    // "no apps configured". The catch-all added here is NOT what such a URL
+    // hits, and this pins that boundary so the two screens don't get conflated.
+    renderConsoleAt('/apps/setup/no-such-page');
+
+    expect(await screen.findByTestId('create-first-app-btn')).toBeInTheDocument();
+    expect(screen.queryByText('Page not found')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/console/__tests__/AppContent.noAppsCta.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.noAppsCta.test.tsx
@@ -46,8 +46,10 @@
  * relative form is depth-dependent: right at `/apps/setup`, but from
  * `/apps/setup/sys_inbox_message` it builds
  * `/apps/setup/sys_inbox_message/create-app`, which matches no route inside the
- * no-active-app `<Routes>` and renders a BLANK screen. The two CTA tests below
- * cover both depths precisely so that trap stays pinned.
+ * no-active-app `<Routes>` — a BLANK screen when this was written, and since
+ * objectui#3610 gave that branch a catch-all, a "page not found" screen. Either
+ * way it is not the designer. The two CTA tests below cover both depths
+ * precisely so that trap stays pinned.
  *
  * The fix therefore builds the app-scoped URL `/apps/<segment>/create-app` —
  * the platform's canonical app URL contract (ADR-0048, `utils/appRoute.ts`),
@@ -240,8 +242,9 @@ describe('AppContent — no-apps empty state CTA (objectui#3573)', () => {
     // `isSystemRoute`, i.e. the switch that mounts `extraRoutesNoApp` — so the
     // splat segment must not leak into the target either (a relative `system`
     // would build `/apps/setup/sys_inbox_message/system` here: still
-    // `isSystemRoute`, but matching no route inside that branch — which has no
-    // catch-all — and therefore rendering blank).
+    // `isSystemRoute`, but matching no route inside that branch — blank before
+    // objectui#3610, "page not found" after it, and the system hub in neither
+    // case, which is what the assertion below actually distinguishes).
     renderConsoleAt('/apps/setup/sys_inbox_message');
     fireEvent.click(await screen.findByTestId('go-to-settings-btn'));
 


### PR DESCRIPTION
Fixes #3610

## 现象与成因

零应用部署下,系统兜底侧栏的两项点下去是纯白屏 —— 没有 404、没有报错、没有空态:

- `sys-datasources` → `/apps/setup/component/metadata/resource?type=datasource`
- `sys-objects` → `/apps/setup/system/metadata/object`,由 console 宿主的 `MetadataRedirect` 改写成上面同一条 URL

`AppContent.tsx:185` 的 `isMetadataRoute` 是对 `/metadata` 的子串判断,两条 URL 都为真,于是越过 `:568` 的「No Apps Configured」守卫,进入 `:616` 的无-activeApp 路由表。该表只声明 `create-app`、`system/marketplace*`、`metadata*` 与宿主传入的 `extraRoutesNoApp`,**没有任何 `component/*`**;而且末尾**没有 catch-all**(全文件 `path="*"` 只有一处,在有-activeApp 分支的 `:775`)。无匹配的路由表渲染 `null` = 白屏。

## 两种拼法的关系(实测,与派发预设相反)

派发单假设 `component/metadata/resource?type=` 才是规范拼法(理由是宿主的 `MetadataRedirect` 往它改写)。**实测结论正好相反:**

- `AppContent.tsx:753-754`(有-activeApp 分支)把这两条 `component/metadata/*` 声明为 `LegacyMetadataRedirect`,上方注释原文:*"Legacy: old metadata routes built before the REST-style nesting landed. Redirect to the new /metadata/:type/... shape."*
- `LegacyMetadataRedirect` 自己的 docblock(`:927-933`)写的是同一件事:把 *pre-refactor* 的 `component/metadata/resource/:name?type=:type` 翻译成 *new REST-style* 的 `metadata/:type/:name`。

所以**两种拼法不是同一页面的两个入口,而是一个别名指向一个页面**:`metadata/:type` 才是规范拼法(两个分支都把它声明为真正的 `MetadataResourceListPage`),`component/metadata/resource` 是旧别名 —— 在有-app 分支里它根本不渲染页面,只做 302。

这个结论**不改修法,只改叙述**:「镜像有-app 分支的 `component/metadata` 形态、渲染同一组件」落地下来就是把同样两条 `LegacyMetadataRedirect` 声明进无-app 分支,而它们转向的 `metadata/:type` 该分支本来就有。这也正是契约优先的选择:**别名保持唯一的规范落点**,不为零应用另造一个拼法。导航 URL 一个没改。

## 改动

`packages/app-shell/src/console/AppContent.tsx`,只动无-activeApp 分支(+22 行,全部为新增):

1. 补 `component/metadata/directory` 与 `component/metadata/resource/*` 两条别名路由,element 与有-app 分支完全一致。
2. 分支末尾补 `path="*"` → `RouteNotFound`,与有-app 分支的 `:775` 对齐 —— 让这一类缺陷从「白屏不可报告」变成「可读的没找到」。

零应用下的完整链路(测试逐条钉住):

| 入口 URL | 链路 | 落点 |
| --- | --- | --- |
| `/apps/setup/component/metadata/resource?type=datasource` | 别名 302 | `/apps/setup/metadata/datasource` 资源列表页 |
| `/apps/setup/system/metadata/object` | 宿主 `MetadataRedirect` → `…/component/metadata/resource?type=object` → 别名 302 | `/apps/setup/metadata/object` 资源列表页 |
| `/apps/setup/system/metadata` | 宿主 → `…/component/metadata/directory` → 别名 302 | `/apps/setup/metadata` 目录页 |
| `/apps/setup/system/no-such-page` | catch-all | RouteNotFound(原白屏) |

`sys-objects` 那条绕行链穿过**三张路由表、两次重定向**,是最不显眼、最会静默回归的一条,按分诊裁定单独钉了一条测试。

## 逆向验证(先预测后运行)

**预测**:新测试保留、`AppContent.tsx` 停在 `origin/main` 状态 → 五条新断言全红,方向是**查无元素**(白屏),而不是渲染错误。

**实测吻合** —— `Tests 5 failed | 1 passed (6)`。失败现场的 DOM dump 里 body 只剩测试自己的 `pathname` 探针,一个业务节点都没有,这是白屏的字面证据:

```
TestingLibraryElementError: Unable to find an element with the text: Page not found.
body
  div
    div data-testid="pathname"
      /apps/setup/system/no-such-page
```

第 6 条预期即为绿 —— 它是边界测量,不是回归钉子,见下一节。

## 一处验收口径修正

验收条目里的「访问 `/apps/setup/no-such-page` → 渲染 RouteNotFound」**这条 URL 选错了**:它不含 `/system`、不含 `/metadata`、也不以 `/create-app` 结尾,三个开关全不亮,所以它压根进不了这个分支 —— `:568` 的守卫先命中,渲染的是「No Apps Configured」空态(既有行为,`AppContent.noAppsCta.test.tsx` 已有同族钉子)。真正需要 catch-all 的,是**进得了分支却匹配不上**的 URL,例如 `/apps/setup/system/no-such-page`。测试按后者写,并把前者作为边界单独钉了一条 MEASUREMENT 用例,免得这两块屏日后被混为一谈。

## 测试

新增 `packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx`(6 条)。宿主的 `MetadataRedirect` 是 `apps/console` 的模块私有函数、且属于另一个 vitest project,app-shell 无法 import,因此在测试里**逐字转写**了它的 `prefix` 正则与 target 构造,并在文件头注明出处 —— 没有它,`sys-objects` 那一跳在 app-shell 内不可测量。

```
pnpm exec vitest run packages/app-shell/  →  Test Files 288 passed (288) / Tests 2516 passed | 1 skipped (2517)
pnpm exec vitest run apps/console/        →  Test Files  23 passed  (23) / Tests  212 passed (212)
pnpm --filter @object-ui/app-shell type-check  →  clean
node scripts/check-control-bytes.mjs      →  OK (3650 tracked text files)
eslint(三个改动文件)                      →  0 errors(37 warnings 均为既有 no-explicit-any)
```

有-activeApp 分支零改动,现有测试全绿。

## 范围

只碰 `AppContent.tsx` 的无-app 分支、其测试与 changeset。**未碰** `UnifiedSidebar.tsx`(在途 #3609)、`AppSidebar.tsx`(#3611)、`ConsoleShell.tsx`、`QuickActions.tsx`、`apps/console/**` —— 导航侧 URL 一个未改。

顺带把 `AppContent.noAppsCta.test.tsx` 里两处「该分支没有 catch-all,因此渲染空白」的注释改写为现状(断言未动)—— 本 PR 正是让那句话过期的改动。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_