### PR TITLE
fix(app-shell): point the remaining four Settings senders at /apps/setup/system (#3611)

### DIFF
--- a/.changeset/remaining-setup-links-3611.md
+++ b/.changeset/remaining-setup-links-3611.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Point the four remaining "Settings" senders at the system hub `/apps/setup/system` instead of the bare `/apps/setup` (objectui#3611).
+
+Same root cause as objectui#3590, which fixed the three call sites inside its declared file surface: `AppContent` mounts the system hub only under `isSystemRoute`, which keys on a `/system` path segment, so on a zero-app deployment the bare `/apps/setup` *is* the "No Apps Configured" empty state's own URL and every entry spelling it looped in place.
+
+Three of the four are live defects, all reachable on a zero-app deployment today:
+
+- `AppSidebar`'s no-active-app sidebar header (`system-sidebar-header`) — the sharpest of them, since it renders *only* when there is no active app, i.e. it was unreachable except in exactly the state where its target was broken.
+- `AppSidebar`'s user-menu "Settings" entry.
+- `SystemRedirect`'s bare `/system` legacy bookmark. This forwarder was already half right — every *suffixed* bookmark (`/system/users`) was correctly rewritten to `/apps/setup/system/users`, and only the bare one dropped the `system` segment. The bare branch now agrees with the suffixed branch beside it; no new logic.
+
+The fourth, `QuickActions`' "System Settings" card, is dormant — the component has zero JSX call sites repo-wide, so no user can reach it today. It is corrected in the same pass so the dead link cannot return with the component if it is ever remounted.

--- a/packages/app-shell/src/console/ConsoleShell.tsx
+++ b/packages/app-shell/src/console/ConsoleShell.tsx
@@ -370,11 +370,17 @@ export function RootRedirect() {
 
 /**
  * SystemRedirect — forwards legacy /system/* URLs to the canonical
- * /apps/setup/* location so bookmarks keep working. Suffix is preserved.
+ * /apps/setup/system/* location so bookmarks keep working. Suffix is preserved.
+ *
+ * #3611 — the bare `/system` bookmark used to land on the bare `/apps/setup`,
+ * which on a zero-app deployment is the "No Apps Configured" empty state's own
+ * URL. Every suffixed bookmark was already forwarded to `/apps/setup/system…`;
+ * the bare one now agrees with them instead of dropping the `system` segment
+ * that makes the hub mount at all.
  */
 export function SystemRedirect() {
   const location = useLocation();
   const suffix = location.pathname.replace(/^\/system/, '');
-  const target = suffix ? `/apps/setup/system${suffix}` : '/apps/setup';
+  const target = suffix ? `/apps/setup/system${suffix}` : '/apps/setup/system';
   return <Navigate to={`${target}${location.search}${location.hash}`} replace />;
 }

--- a/packages/app-shell/src/console/__tests__/systemRedirectTarget.test.tsx
+++ b/packages/app-shell/src/console/__tests__/systemRedirectTarget.test.tsx
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `SystemRedirect` — the legacy `/system*` bookmark forwarder (objectui#3611).
+ *
+ * ## The defect: the component disagreed with itself
+ *
+ * The forwarder was already HALF right. It built its target as
+ *
+ *     suffix ? `/apps/setup/system${suffix}` : '/apps/setup'
+ *
+ * so every SUFFIXED legacy bookmark (`/system/users`) was correctly forwarded
+ * to `/apps/setup/system/users`, while the BARE `/system` bookmark dropped the
+ * `system` segment entirely and landed on `/apps/setup`.
+ *
+ * That segment is not decoration: `AppContent` mounts the system hub only when
+ * `isSystemRoute` (`pathname.includes('/system')`) holds, so on a zero-app
+ * deployment the bare `/apps/setup` falls through to the "No Apps Configured"
+ * empty state — it is that empty state's own URL. The fix makes the bare branch
+ * agree with the suffixed branch beside it; it adds no new logic.
+ *
+ * ## Route shape
+ *
+ * The route below is spelled exactly as the real consumers spell it
+ * (`apps/console/src/App.tsx`, `examples/console-starter/src/App.tsx`):
+ * `<Route path="/system/*" />`. The splat also matches the bare `/system`, with
+ * an empty splat — which is precisely how the defective branch was reachable.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+
+import { SystemRedirect } from '../ConsoleShell';
+
+/** Reports where the redirect actually landed, including search and hash. */
+function Landing() {
+  const { pathname, search, hash } = useLocation();
+  return <div data-testid="landing">{`${pathname}${search}${hash}`}</div>;
+}
+
+function landedFrom(entry: string): string {
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        {/* The one route declaration every console consumer ships. */}
+        <Route path="/system/*" element={<SystemRedirect />} />
+        <Route path="*" element={<Landing />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return screen.getByTestId('landing').textContent ?? '';
+}
+
+describe('SystemRedirect legacy bookmark forwarding (objectui#3611)', () => {
+  it('THE FIX: the bare /system bookmark lands on the system hub, not the empty state URL', () => {
+    expect(landedFrom('/system')).toBe('/apps/setup/system');
+  });
+
+  it('REGRESSION: suffixed bookmarks — the half that was already correct — are unchanged', () => {
+    expect(landedFrom('/system/users')).toBe('/apps/setup/system/users');
+  });
+
+  it('REGRESSION: a deep suffix keeps every segment', () => {
+    expect(landedFrom('/system/metadata/object')).toBe('/apps/setup/system/metadata/object');
+  });
+
+  it('preserves search and hash on the bare bookmark too', () => {
+    // The bare branch is the one that changed, so its query/hash carry-over is
+    // worth pinning explicitly rather than inferring it from the suffixed case.
+    expect(landedFrom('/system?tab=general#audit')).toBe('/apps/setup/system?tab=general#audit');
+  });
+});

--- a/packages/app-shell/src/console/home/QuickActions.tsx
+++ b/packages/app-shell/src/console/home/QuickActions.tsx
@@ -46,7 +46,9 @@ export function QuickActions() {
       label: t('home.quickActions.systemSettings', { defaultValue: 'System Settings' }),
       description: t('home.quickActions.systemSettingsDesc', { defaultValue: 'Configure your workspace' }),
       icon: Settings,
-      href: '/apps/setup',
+      // #3611 — the system hub, not the bare `/apps/setup` (which is the
+      // "No Apps Configured" empty state's own URL on a zero-app deployment).
+      href: '/apps/setup/system',
       iconBg: 'bg-gradient-to-br from-emerald-500/15 to-teal-500/10 ring-emerald-500/20',
       iconText: 'text-emerald-600 dark:text-emerald-400',
       hoverBorder: 'hover:border-emerald-500/40',

--- a/packages/app-shell/src/console/home/__tests__/QuickActions.settingsTarget.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/QuickActions.settingsTarget.test.tsx
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `QuickActions` — "System Settings" card target (objectui#3611).
+ *
+ * ## This one is DORMANT, and the test says so on purpose
+ *
+ * Unlike the other three sites #3611 fixes, no user can reach this card today:
+ * `QuickActions` has zero JSX call sites repo-wide. It is exported from
+ * `console/home/index.ts` and rendered by nobody (`HomePage` builds its own
+ * tiles). So there is no user-visible behavior change here and nothing to
+ * verify through a mounted page.
+ *
+ * It was fixed anyway, in the same pass, for one reason: the day someone
+ * remounts this component on `/home`, the dead link comes back with it. This
+ * file is the guard that makes that reappearance impossible — it renders the
+ * component DIRECTLY (the honest scope for dormant code) rather than pretending
+ * a route reaches it.
+ *
+ * ## The target
+ *
+ * Same root cause as its three live siblings: `AppContent` mounts the system
+ * hub only on `isSystemRoute`, so a bare `/apps/setup` is the "No Apps
+ * Configured" empty state's own URL on a zero-app deployment. The card's
+ * sibling ("Manage Objects") already spelled `/apps/setup/system/...`, which is
+ * what made this one the odd entry out.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+}));
+
+import { QuickActions } from '../QuickActions';
+
+/** Reports where a card's navigate() actually put the router. */
+function Landing() {
+  const { pathname } = useLocation();
+  return <div data-testid="landing">{pathname}</div>;
+}
+
+function renderQuickActions() {
+  render(
+    <MemoryRouter initialEntries={['/home']}>
+      <QuickActions />
+      <Routes>
+        <Route path="*" element={<Landing />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const SYSTEM_HUB = '/apps/setup/system';
+
+describe('QuickActions system-settings card (objectui#3611, dormant)', () => {
+  it('DORMANCY PRECONDITION: nothing renders this component, so the fix is a guard, not a user-visible change', async () => {
+    // Recorded as an assertion rather than prose so it goes red the day the
+    // component is remounted — at which point the pin below stops being a
+    // guard and becomes a live-path test, and this file should be re-read.
+    const { readFileSync, readdirSync, statSync } = await import('node:fs');
+    const path = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    // .../src/console/home/__tests__ -> .../src
+    const srcRoot = path.resolve(here, '../../..');
+
+    const callSites: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (/\.tsx$/.test(entry.name) && !/\.(test|spec)\.tsx$/.test(entry.name)) {
+          if (/<QuickActions\b/.test(readFileSync(full, 'utf8'))) callSites.push(full);
+        }
+      }
+    };
+    if (statSync(srcRoot).isDirectory()) walk(srcRoot);
+
+    expect(callSites).toEqual([]);
+  });
+
+  it('the System Settings card targets the system hub, not the bare setup URL', async () => {
+    const user = userEvent.setup();
+    renderQuickActions();
+
+    await user.click(screen.getByTestId('quick-action-system-settings'));
+
+    expect(screen.getByTestId('landing')).toHaveTextContent(SYSTEM_HUB);
+  });
+
+  it('REGRESSION: the sibling card that was already hub-scoped is unchanged', async () => {
+    const user = userEvent.setup();
+    renderQuickActions();
+
+    await user.click(screen.getByTestId('quick-action-manage-objects'));
+
+    expect(screen.getByTestId('landing')).toHaveTextContent(`${SYSTEM_HUB}/metadata/object`);
+  });
+});

--- a/packages/app-shell/src/layout/AppSidebar.tsx
+++ b/packages/app-shell/src/layout/AppSidebar.tsx
@@ -451,7 +451,14 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
             /* No-app fallback header */
             <SidebarMenuButton
               size="lg"
-              onClick={() => navigate('/apps/setup')}
+              /* #3611 — the system hub is `/apps/setup/system`, not the bare
+                 `/apps/setup`. This header renders ONLY when `activeApp` is
+                 falsy, i.e. exactly on the zero-app deployment where
+                 `/apps/setup` is the "No Apps Configured" empty state's own
+                 URL — so the bare target sent the user back to the screen
+                 they were already looking at. Same fix as the `sys-settings`
+                 entry above (#3590). */
+              onClick={() => navigate('/apps/setup/system')}
               data-testid="system-sidebar-header"
             >
               <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
@@ -680,8 +687,12 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuGroup>
+                  {/* #3611 — "Settings" means the system hub. The bare
+                      `/apps/setup` resolves to the "No Apps Configured" empty
+                      state on a zero-app deployment, so this entry looped in
+                      place there. */}
                   <DropdownMenuItem
-                    onClick={() => navigate('/apps/setup')}
+                    onClick={() => navigate('/apps/setup/system')}
                   >
                     <Settings className="mr-2 h-4 w-4" />
                     {t('user.settings', { defaultValue: 'Settings' })}

--- a/packages/app-shell/src/layout/__tests__/appSidebarSettingsTargets.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/appSidebarSettingsTargets.test.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * AppSidebar's two IMPERATIVE "Settings" senders — must target the system HUB
+ * (objectui#3611).
+ *
+ * ## Why these two are separate from the ones #3590 fixed
+ *
+ * #3590 / PR #3608 retargeted the `sys-settings` NAV ENTRY (a declarative
+ * `url:` on a navigation item, asserted as an `href` in
+ * `systemNavSettingsTarget.test.tsx`) and the empty state's CTA. The two sites
+ * pinned here are neither: they are `onClick={() => navigate(...)}` handlers,
+ * so they carry no `href` and no navigation item to inspect. They were outside
+ * #3590's declared file surface and stayed on the bare URL.
+ *
+ * ## The defect
+ *
+ * `AppContent` mounts the system hub only when `isSystemRoute`
+ * (`pathname.includes('/system')`) holds. A bare `/apps/setup` therefore falls
+ * into the `!activeApp && !isCreateAppRoute && !isSystemRoute && !isMetadataRoute`
+ * guard and renders the "No Apps Configured" empty state — on a zero-app
+ * deployment `/apps/setup` IS that empty state's own URL. Both senders below
+ * spelled it, so both looped in place.
+ *
+ * `system-sidebar-header` is the sharpest of the two: it renders ONLY in the
+ * `activeApp` falsy branch, i.e. it is unreachable EXCEPT in exactly the state
+ * where its old target was broken. The user-menu entry renders in every
+ * deployment but is only *broken* in the zero-app one.
+ *
+ * ## What is asserted, and what is not
+ *
+ * These assert the URL each handler SENDS. What that URL then resolves to is
+ * `AppContent`'s question and is pinned end-to-end (click -> mounted hub) in
+ * `console/__tests__/AppContent.noAppsCta.test.tsx`.
+ *
+ * The dropdown primitives are replaced with passthroughs (same technique, and
+ * same reason, as `WorkspaceSwitcher.test.tsx`): the subject here is the
+ * constant the handler closes over, not Radix's open/close choreography, and
+ * jsdom + Radix's modal `pointer-events: none` makes driving the real menu a
+ * source of flake unrelated to anything this file is measuring.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Mocks — providers and console-only chrome, matching the sibling sidebar
+// suites. `@object-ui/layout` stays REAL so the fallback nav cluster below is
+// the one AppSidebar's own render path emits.
+// ---------------------------------------------------------------------------
+
+/** The imperative target under test. `MemoryRouter`/`Link`/`useLocation` stay real. */
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNavigate: () => navigate,
+}));
+
+// Passthrough dropdown primitives so the footer menu's items render without
+// interaction. Everything else in @object-ui/components (Sidebar*, Avatar) is
+// the real implementation.
+vi.mock('@object-ui/components', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  DropdownMenu: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuLabel: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+  }) => (
+    <div role="menuitem" onClick={onClick}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+    viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
+    dashboardLabel: ({ label }: { label?: string }) => label,
+    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
+  }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', name: 'Ada', email: 'ada@example.com' },
+    signOut: vi.fn(),
+    isAuthEnabled: false,
+    activeOrganization: null,
+  }),
+  useIsWorkspaceAdmin: () => true,
+  getUserInitials: () => 'U',
+}));
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({ can: () => true, hasCapabilities: () => true }),
+}));
+
+/** The zero-app deployment both senders exist for. */
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: [], objects: [] }),
+}));
+
+vi.mock('../../providers/ExpressionProvider', () => ({
+  useExpressionContext: () => ({ evaluator: null }),
+  evaluateVisibility: (expr: unknown) => expr !== false && expr !== 'false',
+}));
+
+vi.mock('../../utils', () => ({
+  resolveI18nLabel: (label: unknown) => (typeof label === 'string' ? label : ''),
+  matchAppBySegment: (apps: Array<{ name?: string }>, segment?: string) =>
+    apps.find((a) => a?.name === segment),
+  appRouteSegment: (app: { name?: string }) => app?.name,
+}));
+
+// Lazy lucide DynamicIcon would suspend mid-test; a null icon keeps each link's
+// accessible name equal to its label text.
+vi.mock('../../utils/getIcon', () => ({ getIcon: () => () => null }));
+
+vi.mock('../../hooks/useRecentItems', () => ({ useRecentItems: () => ({ recentItems: [] }) }));
+vi.mock('../../hooks/useFavorites', () => ({
+  useFavorites: () => ({ favorites: [], removeFavorite: vi.fn() }),
+}));
+vi.mock('../../hooks/useNavPins', () => ({
+  useNavPins: () => ({ togglePin: vi.fn(), applyPins: (items: unknown) => items }),
+}));
+vi.mock('../../hooks/useNavActionDispatch', () => ({
+  useNavActionDispatch: () => vi.fn(),
+}));
+vi.mock('../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ context: 'app', currentAppName: 'setup' }),
+}));
+vi.mock('../ContextSelectors', () => ({
+  useAppContextSelectors: () => ({ contextValues: {}, element: null }),
+  contextSelectorQueryKey: (id: string) => (id === 'active_package' ? 'package' : id),
+  STUDIO_PACKAGE_SELECTOR_ID: 'active_package',
+}));
+vi.mock('../LocalizedSidebarTrigger', () => ({
+  LocalizedSidebarTrigger: () => null,
+}));
+
+import { SidebarProvider } from '@object-ui/components';
+import { AppSidebar } from '../AppSidebar';
+
+/** The system hub — the reachable target, and what every sibling entry prefixes. */
+const SYSTEM_HUB = '/apps/setup/system';
+/** The empty state's OWN url — what both senders used to spell. */
+const BARE_SETUP = '/apps/setup';
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter initialEntries={[BARE_SETUP]}>
+      <SidebarProvider>
+        <AppSidebar activeAppName="setup" onAppChange={() => {}} />
+      </SidebarProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  navigate.mockClear();
+});
+
+describe('AppSidebar imperative Settings senders (objectui#3611)', () => {
+  it('the no-app sidebar header sends to the system hub, not back to the empty state', async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    // Precondition: with zero apps this really is the no-active-app branch —
+    // otherwise the header under test would not be on screen at all and the
+    // assertion below would be vacuous.
+    expect(screen.getByTestId('system-fallback-nav')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('system-sidebar-header'));
+
+    expect(navigate).toHaveBeenCalledWith(SYSTEM_HUB);
+    // The regression: bare `/apps/setup` re-renders the very empty state this
+    // header is drawn on top of.
+    expect(navigate).not.toHaveBeenCalledWith(BARE_SETUP);
+  });
+
+  it('the user-menu Settings entry sends to the system hub', async () => {
+    const user = userEvent.setup();
+    renderSidebar();
+
+    // `Settings` is an exact match — it does not collide with the fallback
+    // cluster's `System Settings` link.
+    await user.click(screen.getByRole('menuitem', { name: 'Settings' }));
+
+    expect(navigate).toHaveBeenCalledWith(SYSTEM_HUB);
+    expect(navigate).not.toHaveBeenCalledWith(BARE_SETUP);
+  });
+
+  it('REGRESSION: the sibling app-switcher entry that was already hub-scoped is unchanged', () => {
+    renderSidebar();
+
+    // `sys-settings`, corrected by #3590, is the anchor that made these two the
+    // odd ones out. It is a declarative `url:` (an href), not a navigate() —
+    // which is exactly why #3590's sweep did not reach the two above.
+    expect(screen.getByRole('link', { name: 'System Settings' })).toHaveAttribute(
+      'href',
+      SYSTEM_HUB,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #3611

## 背景

#3590 / PR #3608 已修掉其文件面内的三个调用点。本单是它明确声明的**剩余部分**:同一根因、同一取值,但落在 #3590 的文件面之外。

根因:`AppContent` 只在 `isSystemRoute`(`pathname.includes('/system')`)成立时挂载系统枢纽。裸 `/apps/setup` 因此匹配不到除 `isSetupRoute` 外的任何伪路由,落回 `!activeApp && …` 守卫 —— 在零应用部署下,它**就是**「No Apps Configured」空态自己的 URL。凡是拼这个裸 URL 的入口,在那里都原地打转。

PM 裁决:「System Settings」语义恒等于系统枢纽,四处统一 `/apps/setup/system`(该 URL 在有/无 activeApp 两个分支下都可解析:分别经 `extraRoutes` 与 `extraRoutesNoApp`)。常量替换,无行为分叉。

## 四处前后对照(3 活 1 眠)

| # | 文件:行 | 入口 | before | after | 分类 |
|---|---|---|---|---|---|
| 1 | `layout/AppSidebar.tsx:461` | 无应用侧栏头 `system-sidebar-header` | `navigate('/apps/setup')` | `navigate('/apps/setup/system')` | **活** |
| 2 | `layout/AppSidebar.tsx:695` | 用户菜单 `user.settings`「Settings」 | `navigate('/apps/setup')` | `navigate('/apps/setup/system')` | **活** |
| 3 | `console/ConsoleShell.tsx:384` | `SystemRedirect` 裸 `/system` 旧书签 | `suffix ? '/apps/setup/system' + suffix : '/apps/setup'` | `… : '/apps/setup/system'` | **活** |
| 4 | `console/home/QuickActions.tsx:51` | `id: 'system-settings'`「System Settings」卡片 | `href: '/apps/setup'` | `href: '/apps/setup/system'` | **眠** |

### 三个「活」缺陷

零应用部署下今天真实可达。其中 `system-sidebar-header` 最尖锐:它**只**在 `activeApp` 为假时渲染 —— 也就是说,除了「其目标恰好失效」的那个状态,它根本无法被触达。

`SystemRedirect` 值得单独一句:它本来就**有一半是对的** —— 带后缀的旧书签(`/system/users`)一直被正确改写成 `/apps/setup/system/users`,只有**裸** `/system` 丢掉了那个 `system` 段。本 PR 让裸分支与它旁边的带后缀分支自洽,**不加任何新逻辑**。

### 一个「眠」代码

`QuickActions` 全仓**零 JSX 调用点**(仅由 `console/home/index.ts` 导出,无人渲染),今天没有用户能碰到它,因此这一处**没有用户可见的行为变化**。仍在本次一并改掉:成本为零,而代价是 —— 只要有人把它挂回 HomePage,这条死链就会跟着一起回来。对应测试**直接渲染该组件**(休眠代码的诚实作用域),并把「零调用点」这一前提本身写成断言:有人挂回时它会变红,提示重读该文件。

## 测试

新增三个测试文件:

- `layout/__tests__/appSidebarSettingsTargets.test.tsx` —— 站点 1、2
- `console/__tests__/systemRedirectTarget.test.tsx` —— 站点 3
- `console/home/__tests__/QuickActions.settingsTarget.test.tsx` —— 站点 4

`SystemRedirect` 的测试按真实消费者(`apps/console/src/App.tsx`、`examples/console-starter/src/App.tsx`)的写法声明路由 `path="/system/*"` —— splat 同样匹配裸 `/system`(空 splat),这正是那条缺陷分支的可达路径。

命令与结果(仓根,canonical invocation):

```
pnpm exec vitest run --maxWorkers=2 packages/app-shell/src/layout packages/app-shell/src/console
  Test Files  44 passed (44)
       Tests  225 passed (225)

pnpm --workspace-concurrency=2 --filter @object-ui/app-shell type-check   → EXIT=0
pnpm check:control-bytes   → OK (scanned 3656 tracked text file(s))
pnpm changeset:check       → OK (fixed group ✓,no major ✓)
```

## 逆向验证(先预测方向,后运行)

保留三个新测试文件、把三个源文件回退到 `origin/main`,**逐条**预测方向后再跑:

| 断言 | 预测 | 实测 |
|---|---|---|
| AppSidebar 侧栏头 → 枢纽 | 红 | 红 |
| AppSidebar 用户菜单 → 枢纽 | 红 | 红 |
| AppSidebar 回归:`sys-settings` href(#3590 已修,本 PR 未动) | 绿 | 绿 |
| SystemRedirect 裸 `/system` → 枢纽 | 红 | 红 |
| SystemRedirect 回归:带后缀 / 深后缀(本来就对的那一半) | 绿 ×2 | 绿 ×2 |
| SystemRedirect 裸 + query/hash | 红 | 红 |
| QuickActions 休眠前提(零调用点) | 绿 | 绿 |
| QuickActions「System Settings」卡片 → 枢纽 | 红 | 红 |
| QuickActions 回归:兄弟卡片 | 绿 | 绿 |

逐条方向**全部命中**:标红的 5 条正是失败的 5 条,标绿的 5 条全部通过(`Tests 5 failed | 5 passed (10)`)。失败文本即预期形状:

```
AssertionError: expected '/apps/setup' to be '/apps/setup/system'
AssertionError: expected '/apps/setup?tab=general#audit' to be '/apps/setup/system?tab=general#audit'
```

一处如实记录:我在汇总时把表头总数写成了「4 红 / 6 绿」,逐行预测实为 5 红 / 5 绿 —— 是我自己的加总笔误,逐条方向本身没有错。按「模板是工具而非事实」如实记下,不粉饰。

## 与在途单的隔离

- **未触碰** `layout/__tests__/systemNavSettingsTarget.test.tsx`(正被在途 #3609 翻转)、`UnifiedSidebar.tsx`(#3609)、`AppContent.tsx`(#3610)。与两个在途单**零文件相交**。
- `AppContent.tsx:187` 的 `isSetupRoute` 是**路由匹配器**而非导航目标,按规则不动 —— 裸 `/apps/setup` 在那里出现是正确的。
- 消费半径已扫:`system-sidebar-header` / `quick-action-*` 在源码、测试、e2e、docs 中除本 PR 新增测试外无其他引用。

## 变更集

`.changeset/remaining-setup-links-3611.md`(`@object-ui/app-shell: patch`)—— 用户可见:零应用部署下侧栏头、用户菜单与旧 `/system` 书签的 Settings 入口不再原地打转。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_