### PR TITLE
test(filter-parity): 给两处 spec 词表减法加排除项存活棘轮 (#3628)

### DIFF
--- a/packages/data-objectstack/src/filter-operator-ast-parity.test.ts
+++ b/packages/data-objectstack/src/filter-operator-ast-parity.test.ts
@@ -30,6 +30,10 @@ import { FILTER_OPERATOR_ALIASES } from './index';
 /**
  * View operators this adapter is not the bridge for — the value-shape ones the
  * view layer resolves to a null comparison before an operator is ever emitted.
+ *
+ * Every token here must still be a member of `VIEW_FILTER_OPERATORS` — the
+ * ratchet below enforces it. Subtracting a name the spec has retired excuses
+ * nothing and must be deleted rather than left as a dead subtraction (#3628).
  */
 const NOT_THIS_ADAPTERS_JOB = new Set(['is_empty', 'is_not_empty']);
 
@@ -37,6 +41,33 @@ describe('FILTER_OPERATOR_ALIASES lands inside the spec AST vocabulary', () => {
   it('reads both vocabularies from the spec', () => {
     expect(VIEW_FILTER_OPERATORS.length).toBeGreaterThan(0);
     expect(VALID_AST_OPERATORS.size).toBeGreaterThan(0);
+  });
+
+  // The exclusion ratchet (#3628). The coverage sweep further down subtracts a
+  // hand-written set from a spec-derived vocabulary, and that subtraction only
+  // excuses something while the spec still lists the subtracted tokens. Once
+  // upstream retires or renames one, the sweep stays green (it is still total
+  // over what remains) but the row becomes dead weight, and its comment goes on
+  // telling the next reader that the view layer resolves this one to a null
+  // comparison — about an operator no author can declare any more. That is the
+  // shape that rotted 37 of 82 deny-list entries in #3601 with nothing to report
+  // it: a hand-written list beside a spec-derived vocabulary and no assertion
+  // that its members still exist in that vocabulary.
+  //
+  // Collected rather than asserted per entry on purpose (same call as PR #3623):
+  // vocabulary retirements land as whole families, and failing on the first entry
+  // would hide the rest.
+  it('every NOT_THIS_ADAPTERS_JOB token is still in the spec view vocabulary', () => {
+    const vocabulary = new Set<string>(VIEW_FILTER_OPERATORS);
+    const retired = [...NOT_THIS_ADAPTERS_JOB].filter((op) => !vocabulary.has(op));
+    expect(
+      retired,
+      `VIEW_FILTER_OPERATORS no longer lists these NOT_THIS_ADAPTERS_JOB tokens: `
+        + `${retired.join(', ')}. The spec has retired them, so subtracting them from `
+        + 'the coverage sweep below excuses nothing — delete each from the set (with '
+        + 'the comment claiming the view layer resolves it) rather than leaving a dead '
+        + 'subtraction',
+    ).toEqual([]);
   });
 
   it('every alias target is an operator the AST gate accepts', () => {

--- a/packages/plugin-list/src/__tests__/filter-operator-ast-parity.test.ts
+++ b/packages/plugin-list/src/__tests__/filter-operator-ast-parity.test.ts
@@ -31,7 +31,13 @@ import { VALID_AST_OPERATORS, isFilterAST } from '@objectstack/spec/data';
 import { VIEW_FILTER_OPERATORS, VIEW_FILTER_OPERATOR_ALIASES } from '@objectstack/spec/ui';
 import { mapOperator, normalizeFilterCondition } from '../ListView';
 
-/** Operators this bridge deliberately resolves without reaching the AST gate. */
+/**
+ * Operators this bridge deliberately resolves without reaching the AST gate.
+ *
+ * Every token here must still be a member of `VIEW_FILTER_OPERATORS` — the
+ * ratchet below enforces it. Subtracting a name the spec has retired excuses
+ * nothing and must be deleted rather than left as a dead subtraction (#3628).
+ */
 const HANDLED_BEFORE_MAPPING = new Set([
   // convertFilterGroupToAST rewrites these to `[field, '=' | '!=', null]`
   // before mapOperator is consulted, so they never need an AST spelling.
@@ -43,6 +49,31 @@ describe('mapOperator bridges the spec view vocabulary onto the AST vocabulary',
     // Guards every assertion below against silently passing on an empty list.
     expect(VIEW_FILTER_OPERATORS.length).toBeGreaterThan(0);
     expect(VALID_AST_OPERATORS.size).toBeGreaterThan(0);
+  });
+
+  // The exclusion ratchet (#3628). The sweep below subtracts a hand-written set
+  // from a spec-derived vocabulary, and that subtraction only excuses something
+  // while the spec still lists the subtracted tokens. Once upstream retires or
+  // renames one, the sweep stays green (it is still total over what remains) but
+  // the row becomes dead weight, and its comment goes on telling the next reader
+  // that "the view layer rewrites this first" about an operator no author can
+  // declare any more. That is the shape that rotted 37 of 82 deny-list entries in
+  // #3601 with nothing to report it — a hand-written list beside a spec-derived
+  // vocabulary and no assertion that its members still exist in that vocabulary.
+  //
+  // Collected rather than asserted per entry on purpose (same call as PR #3623):
+  // vocabulary retirements land as whole families, and failing on the first entry
+  // would hide the rest.
+  it('every HANDLED_BEFORE_MAPPING token is still in the spec view vocabulary', () => {
+    const vocabulary = new Set<string>(VIEW_FILTER_OPERATORS);
+    const retired = [...HANDLED_BEFORE_MAPPING].filter((op) => !vocabulary.has(op));
+    expect(
+      retired,
+      `VIEW_FILTER_OPERATORS no longer lists these HANDLED_BEFORE_MAPPING tokens: `
+        + `${retired.join(', ')}. The spec has retired them, so subtracting them from `
+        + 'the sweep below excuses nothing — delete each from the set (with the comment '
+        + 'claiming the view layer rewrites it) rather than leaving a dead subtraction',
+    ).toEqual([]);
   });
 
   const bridged = VIEW_FILTER_OPERATORS.filter((op) => !HANDLED_BEFORE_MAPPING.has(op));


### PR DESCRIPTION
Fixes #3628

与 #3601 / PR #3623 同一手法的**预防性**棘轮:两处 filter-operator 平价测试各自从 spec 派生的 `VIEW_FILTER_OPERATORS` 里减去一个手写排除集,却没有任何一条断言被减的 token 仍然是那份词表的成员。各加一条存活断言。

## 问题形状

- `packages/plugin-list/src/__tests__/filter-operator-ast-parity.test.ts` —— `HANDLED_BEFORE_MAPPING`
- `packages/data-objectstack/src/filter-operator-ast-parity.test.ts` —— `NOT_THIS_ADAPTERS_JOB`

两处减的都是 `is_empty` / `is_not_empty`,排除理由都成立(视图层在 `mapOperator` / 适配器被问到之前就把它们改写成 null 比较)。缺的是排除项**自身**的存活断言。

上游一旦把这两个 token 退役或改名,减法就变成一次**空减法**:平价扫描依然全绿(它对剩下的 token 仍然是完整的),但排除行成了死重,注释还会继续对下一位读者宣称「视图层会先改写这一个」—— 而那时已经没有作者能声明这个 operator 了。这正是 #3601 里 82 条拒绝名单烂掉 37 条的同一个形状:**一份手写清单挂在 spec 派生的词表旁边,却没有一条断言清单成员仍然存在于那份词表**。

## 测量(在本分支 worktree 重测,非照抄 issue 正文)

worktree 装的是 lockfile 解析的 `@objectstack/spec@17.0.0-rc.5`:

```
spec version: 17.0.0-rc.5
VIEW_FILTER_OPERATORS count: 19
is_empty       LIVE in spec
is_not_empty   LIVE in spec
```

与 issue 正文一致:**19 项词表,两条今天都还在,排除当前是有效的** —— 这条是预防性的,不是已兑现的腐化,没有任何现存排除项需要删除。

## 实现取舍

```ts
it('every HANDLED_BEFORE_MAPPING token is still in the spec view vocabulary', () => {
  const vocabulary = new Set< string >(VIEW_FILTER_OPERATORS);
  const retired = [...HANDLED_BEFORE_MAPPING].filter((op) => !vocabulary.has(op));
  expect(retired, `VIEW_FILTER_OPERATORS no longer lists these … tokens: ${retired.join(', ')}…`)
    .toEqual([]);
});
```

- **收集后一次性断言,而非逐条 `toBe(true)`**(照抄 PR #3623 的设计取舍):词表退役是整族落地的,逐条断言会停在第一条、藏住其余。失败信息点名死项,并提示「spec 已退役,请把它从排除集删除」而不是留一次死减法。
- **用 `new Set< string >(VIEW_FILTER_OPERATORS)` 而不是 issue 正文建议的 `VIEW_FILTER_OPERATORS.includes(op)`**:`VIEW_FILTER_OPERATORS` 在 spec 的 d.ts 里是 `readonly ["equals", …]` 字面量元组,`.includes()` 只接受该字面量联合,传 `Set< string >` 迭代出的 `string` 会是 TS 错误。`Set` 查表既过了类型也是 O(1)。
- 两个文件的**既有断言一行未改**,只加了新 `it` 与排除集 doc 注释里指向棘轮的一句。

## 逆向验证(先预测后运行,两个方向都如预测)

在两个排除集里临时塞一个词表从未有过的 token `never_existed_op`:

| | 预测 | 实测 |
| :-- | :-- | :-- |
| **修前**(未改的两个文件) | 绿 —— 排除集只被当作减数用,一个不在词表里的成员什么都匹配不到 | ✅ 绿:`Test Files 2 passed (2)`,`Tests 42 passed (42)` |
| **修后**(本 PR) | 红,且点名该 token;其余断言仍绿 | ✅ 红:`Test Files 2 failed (2)`,`Tests 2 failed / 42 passed (44)` |

修后那一轮的失败输出(两个文件对称,摘 plugin-list 一条):

```
FAIL |unit| packages/plugin-list/src/__tests__/filter-operator-ast-parity.test.ts >
  mapOperator bridges the spec view vocabulary onto the AST vocabulary >
  every HANDLED_BEFORE_MAPPING token is still in the spec view vocabulary
AssertionError: VIEW_FILTER_OPERATORS no longer lists these HANDLED_BEFORE_MAPPING
tokens: never_existed_op. The spec has retired them, so subtracting them from the
sweep below excuses nothing — delete each from the set …
  expected [ 'never_existed_op' ] to deeply equal []
```

修前那一轮绿就是恒真缺陷的现场演示:两条排除行这些年一直处在「没人能发现它失效」的状态。验证后假 token 已还原,提交里不含它(见 diff)。

## 验证

```
$ npx vitest run packages/plugin-list/…/filter-operator-ast-parity.test.ts \
                 packages/data-objectstack/src/filter-operator-ast-parity.test.ts --maxWorkers=2
 Test Files  2 passed (2)
      Tests  44 passed (44)          # 42 + 2 条新棘轮

$ npx vitest run packages/plugin-list packages/data-objectstack --maxWorkers=2
 Test Files  46 passed (46)
      Tests  706 passed (706)

$ pnpm --workspace-concurrency=2 --filter @object-ui/plugin-list --filter @object-ui/data-objectstack type-check
packages/data-objectstack type-check: Done
packages/plugin-list type-check: Done

$ npx eslint <两个测试文件>        # exit 0,无告警
$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3655 tracked text file(s); skipped 85 binary).
```

首轮 type-check 因新 worktree 未构建依赖而报 `Cannot find module '@object-ui/components'`(AGENTS.md §9 那个陷阱),先跑 `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-list^...' --filter '@object-ui/data-objectstack^...' build` 后即通过 —— 与本改动无关。

**无 changeset**:测试-only 改动,不触碰任何包的公开面、运行时行为或类型导出 —— 按仓例(changeset 用于 user-visible 变更)无需 changeset,同 PR #3623 先例。

**文件面**:两个测试文件,+63 −1。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt