### PR TITLE
fix(i18n): 八包按 en 当前的 read-only 语义重译 view.readonlyTooltip (#3625)

### DIFF
--- a/.changeset/view-readonly-tooltip-semantics-3625.md
+++ b/.changeset/view-readonly-tooltip-semantics-3625.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/i18n': patch
+---
+
+`view.readonlyTooltip` — the tooltip on a view tab's read-only lock — is
+retranslated in the eight packs (ja/ko/de/fr/es/pt/ru/ar) that still described
+the retired "duplicate to customize" workflow, so a Japanese, Korean, German,
+French, Spanish, Portuguese, Russian or Arabic session is told the view is
+defined in code and read-only, which is what `en` says and what the product
+does (#3625).
+
+This is the same stale sentence #3582 fixed one namespace over, but it hid
+behind a much better disguise. In #3582 the eight packs stored the **English**
+string, so two cheap criteria could see it: "value equals `en`" and "a
+non-Latin pack holds pure ASCII". Neither can see this key. Its eight values
+were **idiomatic translations** — real Japanese, real Cyrillic, real Arabic —
+of a sentence `en` itself had already abandoned. Nothing about their form was
+wrong; only their meaning was. Key sets were complete, so
+`all-locales-key-parity` was green; the key exists in `en`, so the call-site
+guard and its ratchet were green; the values are distinct and in their own
+scripts, so every heuristic #3582 sketched would have been green too. Eight
+locales spent those releases pointing users at a path the product no longer
+offers, with every gate reporting success.
+
+Each value is translated against `en`'s **current** meaning and built from
+words the same pack already uses — "read-only" from its own `view.readOnly` /
+`view.readonlyAriaLabel`, "defined in code" from
+`console.objectView.systemViewReadonly` / `cannotEditMetaView` — so the tooltip
+agrees with the copy beside it instead of introducing a ninth way to say
+read-only. Nothing is rewritten from the stale text.
+
+`en` and `zh` are unchanged, byte for byte, and no key is added or removed —
+the diff is eight values in eight files. A new
+`viewReadonlyTooltip-semantics-3625.test.ts` tests **meaning** rather than
+form, in both directions: no pack may name the duplicate/copy workflow in its
+own language, and every pack must positively carry all three pieces of the
+sentence ("system view", "defined in code", "read-only") so the negative check
+cannot pass on a gutted string. It also pins the `en` literal, so the next
+rewording of `en` fails in the PR that does the rewording rather than orphaning
+nine translations for another release — which is the invariant this family of
+defects has actually been missing.

--- a/packages/i18n/src/__tests__/viewReadonlyTooltip-semantics-3625.test.ts
+++ b/packages/i18n/src/__tests__/viewReadonlyTooltip-semantics-3625.test.ts
@@ -1,0 +1,192 @@
+/**
+ * `view.readonlyTooltip` carries `en`'s CURRENT read-only meaning in all ten
+ * packs — not the retired "duplicate to customize" workflow (objectui#3625).
+ *
+ * ## Why this needs its own criterion
+ *
+ * objectui#3582 was the same stale sentence in a neighbouring namespace, and
+ * two cheap criteria could see it: the eight packs stored the *English*
+ * string, so "value equals en" and "non-Latin pack holds pure ASCII" both
+ * fired. Neither can see this key. The eight values were **idiomatic
+ * translations** — ja in Japanese, ru in Cyrillic, ar in Arabic — of a
+ * sentence `en` had already abandoned. Nothing about their *form* was wrong;
+ * their *meaning* was. So the assertions below test meaning, in two
+ * directions at once:
+ *
+ *   - RETIRED: no pack may name the duplicate/copy workflow, in that pack's
+ *     own language (stems measured from the values that were actually there
+ *     before this fix, not guessed — es/pt spell it `duplique`, so the stem is
+ *     `dupliqu`; a `duplic` stem would have missed both).
+ *   - ANCHORS: every pack must positively carry all three pieces of `en`'s
+ *     sentence — "system view", "defined in code", "read-only". Without this
+ *     half the RETIRED check passes trivially on an empty or gutted string.
+ *
+ * ## What this file does NOT claim
+ *
+ * The distinctness and native-script checks below were **green before this
+ * fix too** — the eight stale values were already distinct, already in their
+ * own scripts. They are kept because they guard a different failure (pasting
+ * one language into another), not because they detect this defect. Saying so
+ * plainly is the point: the reason objectui#3625 survived objectui#3582's
+ * sweep is precisely that every form-level criterion was green.
+ *
+ * ## Scope, and why it is narrow
+ *
+ * The RETIRED scan is scoped to this one key on purpose, exactly as
+ * objectui#3582's file scoped its own. `view.duplicateView` ("Duplicar
+ * vista" in es) is a legitimate Duplicate-view action in the SAME namespace;
+ * a pack-wide stem scan would red on it. The stale-copy invariant is per-key
+ * by nature and cannot be generalised into a repo-wide gate — see
+ * objectui#3625's closing note on what the missing gate actually is
+ * ("when `en` is reworded, the nine translation packs follow in the same PR").
+ *
+ * Companion file: `objectView-value-language-3582.test.ts` pins
+ * `console.objectView.systemViewReadonly` / `.expandToPage`. It is left
+ * untouched — its comment already names this key as objectui#3625's, and
+ * keeping the two pin surfaces in separate files means a red tells you which
+ * of the two defects came back.
+ */
+import { describe, it, expect } from 'vitest';
+import { builtInLocales } from '../locales';
+
+const LANGS = Object.keys(builtInLocales);
+
+const tooltipOf = (lang: string) => (builtInLocales[lang] as any)?.view?.readonlyTooltip as string;
+const sysViewOf = (lang: string) =>
+  (builtInLocales[lang] as any)?.console?.objectView?.systemViewReadonly as string;
+
+/** `en`'s current copy, and the sentence it retired. Neither may appear elsewhere. */
+const EN_CURRENT = 'System view — defined in code, read-only.';
+const EN_RETIRED_SPELLINGS = [
+  'System view — duplicate to customize.',
+  'System view - duplicate to customize.',
+];
+
+/**
+ * The retired workflow, per pack, in that pack's own language. Every stem here
+ * was read off the value the pack actually held on `origin/main` before this
+ * fix; the ones for en/zh are defensive (those two were already correct).
+ */
+const RETIRED: Record<string, RegExp> = {
+  en: /duplicate|copy/i,
+  zh: /复制|复刻|拷贝/,
+  ja: /複製|コピー/,
+  ko: /복제|복사/,
+  de: /duplizier|kopier/i,
+  fr: /dupliqu|duplic|copi/i,
+  es: /dupliqu|duplic|copi/i,
+  pt: /dupliqu|duplic|copi/i,
+  ru: /копир|скопир/i,
+  ar: /نسخ|انسخ/,
+};
+
+/**
+ * The three semantic pieces of `en`'s sentence, in each pack's own words.
+ * Every term is lifted from a neighbouring key in the SAME pack — see the PR's
+ * sourcing table — so this doubles as a check that the translation stayed
+ * inside the vocabulary the pack already uses for these concepts.
+ */
+const ANCHORS: Record<string, { systemView: RegExp; inCode: RegExp; readOnly: RegExp }> = {
+  en: { systemView: /System view/i, inCode: /code/i, readOnly: /read-only/i },
+  zh: { systemView: /系统视图/, inCode: /代码/, readOnly: /只读/ },
+  ja: { systemView: /システムビュー/, inCode: /コード/, readOnly: /読み取り専用/ },
+  ko: { systemView: /시스템 보기/, inCode: /코드/, readOnly: /읽기 전용/ },
+  de: { systemView: /Systemansicht/i, inCode: /Code/i, readOnly: /schreibgeschützt/i },
+  fr: { systemView: /Vue système/i, inCode: /code/i, readOnly: /lecture seule/i },
+  es: { systemView: /Vista del sistema/i, inCode: /código/i, readOnly: /solo lectura/i },
+  pt: { systemView: /Exibição do sistema/i, inCode: /código/i, readOnly: /somente leitura/i },
+  ru: { systemView: /Системное представление/i, inCode: /код/i, readOnly: /чтени/i },
+  ar: { systemView: /عرض النظام/, inCode: /كود/, readOnly: /قراءة/ },
+};
+
+/** Packs where "is this value written in the pack's language?" is decidable. */
+const NATIVE_SCRIPT: Record<string, RegExp> = {
+  zh: /\p{Script=Han}/u,
+  ja: /\p{Script=Hiragana}|\p{Script=Katakana}|\p{Script=Han}/u,
+  ko: /\p{Script=Hangul}/u,
+  ru: /\p{Script=Cyrillic}/u,
+  ar: /\p{Script=Arabic}/u,
+};
+
+describe('view.readonlyTooltip semantic coverage (objectui#3625)', () => {
+  it('covers all ten built-in packs', () => {
+    expect(LANGS).toHaveLength(10);
+    expect(Object.keys(RETIRED).sort()).toEqual([...LANGS].sort());
+    expect(Object.keys(ANCHORS).sort()).toEqual([...LANGS].sort());
+  });
+
+  it.each(LANGS)('%s defines view.readonlyTooltip as a non-empty string', (lang) => {
+    const value = tooltipOf(lang);
+    expect(typeof value, `${lang}.view.readonlyTooltip`).toBe('string');
+    expect(value.trim().length, `${lang}.view.readonlyTooltip is empty`).toBeGreaterThan(0);
+  });
+
+  it('the en pack still says read-only — the meaning the nine were translated against', () => {
+    // The tripwire objectui#3625 was missing. `en` was reworded once already
+    // and nine packs kept the old sentence for releases. If this literal
+    // changes again this line goes red in the SAME PR that reworded it, which
+    // forces the nine to be revisited then rather than discovered later by
+    // someone reading a tooltip in Japanese.
+    expect(tooltipOf('en')).toBe(EN_CURRENT);
+  });
+
+  it('no pack but en serves any English spelling of the tooltip', () => {
+    // The objectui#3582 failure mode applied to this key: current copy pasted
+    // verbatim, or the retired English sentence resurrected.
+    const english = LANGS.filter(
+      (l) => l !== 'en' && [EN_CURRENT, ...EN_RETIRED_SPELLINGS].includes(tooltipOf(l)),
+    );
+    expect(english, `packs serving English: ${english.join(', ')}`).toEqual([]);
+  });
+
+  it('no pack names the retired duplicate-to-customize workflow', () => {
+    // THE assertion for objectui#3625. Red on all eight before the fix; the
+    // form-level checks in this file were green on all eight.
+    const leaked = LANGS.filter((l) => RETIRED[l].test(tooltipOf(l)));
+    expect(leaked, `packs still offering duplicate-to-customize: ${leaked.join(', ')}`).toEqual([]);
+  });
+
+  it.each(LANGS)('%s carries all three pieces of the read-only sentence', (lang) => {
+    // Guards the empty green: without this, deleting a value outright would
+    // satisfy the negative check above.
+    const value = tooltipOf(lang);
+    const { systemView, inCode, readOnly } = ANCHORS[lang];
+    expect(systemView.test(value), `${lang} tooltip lost "system view": ${value}`).toBe(true);
+    expect(inCode.test(value), `${lang} tooltip lost "defined in code": ${value}`).toBe(true);
+    expect(readOnly.test(value), `${lang} tooltip lost "read-only": ${value}`).toBe(true);
+  });
+
+  it.each(Object.keys(NATIVE_SCRIPT))('%s writes the tooltip in its own script', (lang) => {
+    // Green before this fix as well — the stale values were properly
+    // translated Japanese/Korean/Russian/Arabic. Kept as a guard against a
+    // future paste, not as evidence for objectui#3625.
+    expect(
+      NATIVE_SCRIPT[lang].test(tooltipOf(lang)),
+      `${lang} tooltip has no native script`,
+    ).toBe(true);
+  });
+
+  it('all ten packs differ from one another', () => {
+    // Also green before this fix (10/10 distinct even while eight were stale),
+    // for the same reason: eight idiomatic translations of a wrong sentence
+    // are still ten different strings. It guards cross-pack copy-paste only.
+    const values = LANGS.map(tooltipOf);
+    expect(new Set(values).size, 'view.readonlyTooltip has duplicate values across packs').toBe(
+      LANGS.length,
+    );
+  });
+
+  it('de is the only pack where this tooltip reads identically to console.objectView.systemViewReadonly', () => {
+    // A record of fact, not a rule. `en` distinguishes the two keys only by
+    // where the dash falls ("System view — defined in code, read-only." vs
+    // "System view defined in code — read-only."), which is a distinction most
+    // languages cannot carry. German lands on one sentence for both, and that
+    // is fine — objectui#3582's PR set the same precedent deliberately by
+    // aligning `console.objectView.expandToPage` byte-for-byte with
+    // `detail.openAsFullPage` in every pack. Pinned so that a future
+    // translation edit which changes WHICH packs collide surfaces for a human
+    // to look at; relax this line with a note if that happens legitimately.
+    const collide = LANGS.filter((l) => tooltipOf(l) === sysViewOf(l));
+    expect(collide).toEqual(['de']);
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -730,7 +730,7 @@ const ar = {
     defaultBadge: "افتراضي",
     tabActionsFor: "إجراءات العرض لـ {{name}}",
     readonlyAriaLabel: "عرض للقراءة فقط",
-    readonlyTooltip: "عرض النظام — انسخ للتخصيص.",
+    readonlyTooltip: "عرض النظام — معرَّف في الكود، للقراءة فقط.",
   },
   designer: {
     undo: 'Undo',

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -730,7 +730,7 @@ const de = {
     defaultBadge: "Standard",
     tabActionsFor: "Ansichtsaktionen für {{name}}",
     readonlyAriaLabel: "Schreibgeschützte Ansicht",
-    readonlyTooltip: "Systemansicht — zum Anpassen duplizieren.",
+    readonlyTooltip: "Systemansicht — im Code definiert, schreibgeschützt.",
   },
   designer: {
     undo: 'Undo',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -735,7 +735,7 @@ const es = {
     defaultBadge: "predeterminada",
     tabActionsFor: "Acciones de vista para {{name}}",
     readonlyAriaLabel: "Vista de solo lectura",
-    readonlyTooltip: "Vista del sistema — duplique para personalizar.",
+    readonlyTooltip: "Vista del sistema — definida en el código, solo lectura.",
   },
   designer: {
     undo: 'Undo',

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -730,7 +730,7 @@ const fr = {
     defaultBadge: "par défaut",
     tabActionsFor: "Actions de vue pour {{name}}",
     readonlyAriaLabel: "Vue en lecture seule",
-    readonlyTooltip: "Vue système — dupliquer pour personnaliser.",
+    readonlyTooltip: "Vue système — définie dans le code, en lecture seule.",
   },
   designer: {
     undo: 'Undo',

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -730,7 +730,7 @@ const ja = {
     defaultBadge: "デフォルト",
     tabActionsFor: "{{name}} のビュー操作",
     readonlyAriaLabel: "読み取り専用ビュー",
-    readonlyTooltip: "システムビュー — 複製してカスタマイズしてください。",
+    readonlyTooltip: "システムビュー — コードで定義され、読み取り専用です。",
   },
   designer: {
     undo: 'Undo',

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -730,7 +730,7 @@ const ko = {
     defaultBadge: "기본",
     tabActionsFor: "{{name}}의 보기 작업",
     readonlyAriaLabel: "읽기 전용 보기",
-    readonlyTooltip: "시스템 보기 — 사용자 지정하려면 복제하세요.",
+    readonlyTooltip: "시스템 보기 — 코드에 정의되어 있으며 읽기 전용입니다.",
   },
   designer: {
     undo: 'Undo',

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -730,7 +730,7 @@ const pt = {
     defaultBadge: "padrão",
     tabActionsFor: "Ações de exibição para {{name}}",
     readonlyAriaLabel: "Exibição somente leitura",
-    readonlyTooltip: "Exibição do sistema — duplique para personalizar.",
+    readonlyTooltip: "Exibição do sistema — definida no código, somente leitura.",
   },
   designer: {
     undo: 'Undo',

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -730,7 +730,7 @@ const ru = {
     defaultBadge: "по умолчанию",
     tabActionsFor: "Действия с представлением {{name}}",
     readonlyAriaLabel: "Представление только для чтения",
-    readonlyTooltip: "Системное представление — скопируйте для настройки.",
+    readonlyTooltip: "Системное представление — определено в коде, только для чтения.",
   },
   designer: {
     undo: 'Undo',


### PR DESCRIPTION
Fixes #3625

`view.readonlyTooltip`(视图页签只读锁的 tooltip,消费点唯一:`packages/plugin-view/src/ViewTabBar.tsx:489`)在 ja/ko/de/fr/es/pt/ru/ar 八个包里描述的是**产品已不提供**的「复制一份来自定义」路径。按 `en` **当前**的 read-only 语义整句重译八包。

`en` / `zh` **一字节未动**,**不增删任何 key**(八个包各 1 行,+8/-8 严格对称),**未碰** `ViewTabBar.tsx`、棘轮基线,**未改动** #3627 落地测试的任何既有断言。

## 前置测量:en/zh 现状(硬约束 1)

动笔前先证伪 issue 的前提。`en` 与 `zh` 都已经是 read-only 口径,因此本单只动八包:

| 包 | 值 | 语义 |
|---|---|---|
| en | `System view — defined in code, read-only.` | read-only,当前口径 ✅ |
| zh | `系统视图 — 由代码定义，只读。` | read-only,已对齐 ✅ |

## 为什么 #3627 的判据看不见这一条(这才是本单的重点)

#3582 是同一句废弃语义在隔壁命名空间,八包存的是**英文原文**,所以两条便宜判据都能抓:值等于 `en`、非拉丁包里出现纯 ASCII。**这个 key 两条都抓不到** —— 八个值是**地道译文**(ja 是日文、ru 是西里尔、ar 是阿拉伯文),只是译了一句 `en` 自己已经废弃的话。**形态全对,语义全错。**

实测:修前八包 **10/10 互不相同**、**五个非拉丁包全部通过本文字系统判据**、键集合完整。也就是说 `all-locales-key-parity`、调用点 key 守卫及其棘轮、#3582「建议 2」设想的那道 ASCII 门禁,**修前修后全绿**。

因此本单的断言按**语义**而非等值/形态设计,且**两个方向同时钉**。

## 八包新旧对照表

| 包 | 修前(废弃语义) | 修后(read-only) |
|---|---|---|
| ja | `システムビュー — 複製してカスタマイズしてください。` | `システムビュー — コードで定義され、読み取り専用です。` |
| ko | `시스템 보기 — 사용자 지정하려면 복제하세요.` | `시스템 보기 — 코드에 정의되어 있으며 읽기 전용입니다.` |
| de | `Systemansicht — zum Anpassen duplizieren.` | `Systemansicht — im Code definiert, schreibgeschützt.` |
| fr | `Vue système — dupliquer pour personnaliser.` | `Vue système — définie dans le code, en lecture seule.` |
| es | `Vista del sistema — duplique para personalizar.` | `Vista del sistema — definida en el código, solo lectura.` |
| pt | `Exibição do sistema — duplique para personalizar.` | `Exibição do sistema — definida no código, somente leitura.` |
| ru | `Системное представление — скопируйте для настройки.` | `Системное представление — определено в коде, только для чтения.` |
| ar | `عرض النظام — انسخ للتخصيص.` | `عرض النظام — معرَّف في الكود، للقراءة فقط.` |

## 译文溯源:每个词都指回同包既有 key,没有一句自创

照抄 #3627 的邻键溯源纪律。`en` 的句子是三段式(`System view` + `defined in code` + `read-only`),逐段取词:

| 语义段 | 取自(同包) |
|---|---|
| 「系统视图」 | 本 key 自己的前半句(八包这半句本来就是对的,只有后半句过期)+ `console.objectView.systemViewReadonly`(#3627 刚落) |
| 「由代码定义」 | `console.objectView.systemViewReadonly` / `console.objectView.cannotEditMetaView`(#3583 落的) |
| 「只读」 | `view.readOnly` / `view.readonlyAriaLabel`(与本 key 同命名空间、同一屏) |

标点与正式度随各包邻域,不自创:

- **破折号**:十个包本 key 修前就都用 `— `(含 en/zh),沿用。**es 这里用 `—` 而非 `:`** —— #3627 的冒号选择是 `console.objectView` 命名空间局部的(该命名空间 `cannotEditMetaView` / `filterOrNotSavable` 用冒号);而在 `view` 命名空间里,es 的同类 tooltip `view.subscribedTooltip`(`Suscrito — clic para cancelar suscripción`)和本 key 自己修前的值都用破折号。
- **逗号**:ja 用 `、`,zh 用 `，`,ar 用 `،`(该包 60 处在用),其余 ASCII `,`。
- **性数一致**,全部与同包 `systemViewReadonly` 保持同一选择:fr `Vue` 阴性 → `définie`;pt `Exibição` 阴性 → `definida`;es `Vista` 阴性 → `definida`;ru `представление` 中性 → `определено`;ar `عرض` 阳性 → `معرَّف`。
- **es 祈使语气**邻域现状是 usted —— 本句是陈述句,不涉及。

### de 的两处落到同一句,是有意接受的,不是疏漏

`en` 区分这两个 key 靠的只是破折号落点(`System view — defined in code, read-only.` 对 `System view defined in code — read-only.`),这个区分多数语言承载不了。#3627 为 de 的 `systemViewReadonly` 选的正是本 key 的破折号结构,于是德文两处重合。**不为造差异而改写译文** —— #3627 自己把 `console.objectView.expandToPage` 与 `detail.openAsFullPage` 在十个包里逐字节对齐,已经立下「同义即可同文」的先例。测试把「**只有 de** 重合」这个事实钉住,将来哪个包重合状况变了会浮出来给人看。

## 测试:与 #3627 的分工(硬约束 4)

**新开文件** `packages/i18n/src/__tests__/viewReadonlyTooltip-semantics-3625.test.ts`,**不改** `objectView-value-language-3582.test.ts` 一行。理由三条:

1. #3627 那个文件的 docblock 与模块级 helper(`objectViewOf` / `readonlyOf` / `EN_CURRENT`)整体锚定在 `console.objectView` 一个命名空间上,塞进第二个命名空间会让它自己的作用域声明失真;
2. 它的 `duplicate to customize` 扫描面**特意限定在那两个 key,并在注释里点名 #3625 是另一单** —— 分文件放,这句注释保持为真;
3. 两个钉子面各自独立后,**红灯能直接指认是哪一单回归了**。

### 扫描面同样必须窄(与 #3627 同理,但踩点不同)

废弃语义扫描**只限本 key**。同命名空间的 `view.duplicateView`(es 是 `Duplicar vista`)是**合法的**「复制视图」动作,含 `duplic` 词干 —— 包级词干扫描会误红它。这条不变量天生是 per-key 的,推不成仓级门禁。

### 禁用词干表按包内实际旧值测量修正

派发口径给的表里 es/pt 是 `duplic`,**实测旧值是 `duplique`**,`duplic` 并不是它的子串(`dupliqu` 才是),照抄会漏。实际落地的词干:

| 包 | 禁用词干(负向) | 正向锚点(三段全钉) |
|---|---|---|
| ja | `複製` / `コピー` | `システムビュー` + `コード` + `読み取り専用` |
| ko | `복제` / `복사` | `시스템 보기` + `코드` + `읽기 전용` |
| de | `duplizier` / `kopier` | `Systemansicht` + `Code` + `schreibgeschützt` |
| fr | `dupliqu` / `duplic` / `copi` | `Vue système` + `code` + `lecture seule` |
| es | `dupliqu` / `duplic` / `copi` | `Vista del sistema` + `código` + `solo lectura` |
| pt | `dupliqu` / `duplic` / `copi` | `Exibição do sistema` + `código` + `somente leitura` |
| ru | `копир` / `скопир` | `Системное представление` + `код` + `чтени` |
| ar | `نسخ` / `انسخ` | `عرض النظام` + `كود` + `قراءة` |

正向锚点是**防空绿**的那一半:只有负向断言的话,把值删空也能全绿。

另外钉了 `en` 字面量 —— `en` 下次改文案时,**在改文案的那个 PR 里**就红,而不是再放九个包漂一个版本。这才是这一族缺陷真正缺的那道不变量。

## 逆向验证(先预测,后运行)

预测:回退八包值 →

- **红**:`no pack names the retired…` 1 条(八包全命中词干)+ 正向锚点 8 条(ja/ko/de/fr/es/pt/ru/ar,en/zh 保持绿);
- **红,但方向是反的**:`de is the only pack…` —— 回退让 de **不再**与 `systemViewReadonly` 重合,断言是从 `['de']` 掉成 `[]`,与上面九条的红法相反;
- **绿(不翻转,如实记)**:互异断言、五条文字系统断言、`en` 钉子、英文字面量断言、非空断言 —— 因为八个废弃值本来就是互异的地道译文;
- `objectView-value-language-3582.test.ts` 全绿、`all-locales-key-parity` 全绿。

合计预测 10 红。实测完全吻合:

```
× no pack names the retired duplicate-to-customize workflow
    packs still offering duplicate-to-customize: ja, ko, de, fr, es, pt, ru, ar: expected [ 'ja', 'ko', 'de', 'fr', 'es', …(3) ] to deeply equal []
× ja carries all three pieces of the read-only sentence
    ja tooltip lost "defined in code": システムビュー — 複製してカスタマイズしてください。
× ko / de / fr / es / pt / ru / ar carries all three pieces …   (同款,共 8 条)
× de is the only pack where this tooltip reads identically to console.objectView.systemViewReadonly
    expected [] to deeply equal [ 'de' ]

 Test Files  1 failed | 2 passed (3)
      Tests  10 failed | 63 passed (73)
```

两个 passed 文件正是 `objectView-value-language-3582.test.ts` 与 `all-locales-key-parity.test.ts`。

**`all-locales-key-parity` 修前修后都绿是本 PR 的预期结论,不是缺陷** —— 它比的是键集合与占位符形状,本缺陷不动键集合、本 key 不带占位符。互异与文字系统判据同样不翻转,原因已在上面写明;它们保留是为了防「把一种语言粘进另一种」,不是本单的证据。**这一点如实写出来,而不是把它们包装成红。**

## 测试

```
# 新测试 + #3627 落地测试 + 键集合门禁
npx vitest run --maxWorkers=2 packages/i18n/src/__tests__/viewReadonlyTooltip-semantics-3625.test.ts \
                              packages/i18n/src/__tests__/objectView-value-language-3582.test.ts \
                              packages/i18n/src/__tests__/all-locales-key-parity.test.ts
  Test Files  3 passed (3) / Tests  73 passed (73)

# i18n 全量(#3627 落地时是 25 文件 / 326 测试,本单 +1 文件 / +31 测试)
npx vitest run --maxWorkers=2 packages/i18n/src/__tests__/
  Test Files  26 passed (26) / Tests  357 passed (357)

pnpm --workspace-concurrency=2 --filter @object-ui/i18n type-check
  tsc --noEmit → 通过(无输出)

node scripts/check-changeset-no-major.mjs  → ✅  No changeset declares a `major` bump.
node scripts/check-changeset-fixed.mjs     → ✅  All workspace packages are in the changeset fixed group.

eslint(9 个改动 .ts 文件)  → 0 errors,2 warnings(`as any`,与 #3627 落地的同目录测试同款)

控制字符自查:grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' (8 个包 + 测试 + changeset) → 无匹配
```

消费半径清扫:全仓 grep `readonlyTooltip` 与八句废弃文案字面量,除本 PR 改的八个包外,只有 `ViewTabBar.tsx:489`(唯一消费点,本 PR 不碰)与 #3627 测试里指向本单的那句注释、其 changeset 里的一处引用 —— **没有任何 fixture 或组件测试断言这八个旧值**,故无需改动包外测试。

## 范围

- 改:8 个语言包各 1 个值;新增 1 个测试文件 + 1 个 changeset(patch,`@object-ui/i18n`,用户可见:八语言视图页签 tooltip 语义修正)
- 未改:`en.ts` / `zh.ts`、`packages/plugin-view/src/ViewTabBar.tsx`、`objectView-value-language-3582.test.ts`、棘轮基线、任何组件代码

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_