### PR TITLE
docs(runner): 把 README 两处开放集合的插件措辞按实测闭合 (#3632)

### DIFF
--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -8,7 +8,7 @@ Universal Object UI Application Runner - A standalone development server and run
 - **No-Restart Edits** - Under `src/app-data/` the dev server picks metadata changes up
   without a restart, because that JSON is part of Vite's module graph; behind `?api=` it
   cannot, because Vite never sees your backend ([Metadata Loading](#metadata-loading))
-- **Plugin Support** - Pre-configured with popular plugins (Kanban, Charts, etc.)
+- **Plugin Support** - Pre-configured with the Kanban and Charts plugins
 - **Development Ready** - Built-in Vite development server
 - **Production Build** - Optimized build for deployment
 
@@ -42,11 +42,16 @@ pnpm preview
 
 ## Pre-installed Plugins
 
-The runner comes with these plugins pre-configured:
+The runner comes with these two plugins pre-configured, registered by the imports in
+`src/App.tsx`:
 
 - **@object-ui/plugin-kanban** - Kanban board components
 - **@object-ui/plugin-charts** - Chart visualization components
-- **Additional plugins can be added as needed**
+
+Adding any other plugin means editing the runner's own sources and rebuilding — a
+dependency in `package.json`, a registration import in `src/App.tsx`, and the
+`vite.config.ts` alias and `src/index.css` `@source` entries the two above have. There
+is no runtime plugin installation.
 
 ## Metadata Loading
 


### PR DESCRIPTION
Fixes #3632

## 前提复核(独立于 issue 正文)

切点 `fa3ba5bf1`。issue 正文的行号已漂(#3621 / #3634 改过同文件),按内容锚定复核,**两处缺陷都仍在**,实测预装集合与 issue 正文一致 —— 恰好两个,无差异:

| 实测面 | 结果 |
| --- | --- |
| `packages/runner/package.json` dependencies 的 `plugin-*` | 仅 `@object-ui/plugin-charts`、`@object-ui/plugin-kanban` |
| `packages/runner/src/App.tsx:14-15` 注册 import | 仅 `@object-ui/plugin-kanban`、`@object-ui/plugin-charts` |
| `packages/runner/src` 全量 `plugin-` grep | 另有 `index.css:13-14` 的 `@source`、`vite.config.ts:77-78` 的别名 —— 同样只覆盖这两个 |

行号漂移:§Features 该行 9 → 11,§Pre-installed Plugins 41-47 → 43-49。

## 前后对照

**§Features**

```diff
-- **Plugin Support** - Pre-configured with popular plugins (Kanban, Charts, etc.)
+- **Plugin Support** - Pre-configured with the Kanban and Charts plugins
```

括号里已经穷举了全部两个,末尾却缀 `etc.`,读起来是「还有更多没列」。一并去掉 `popular`:集合闭合之后,「popular plugins (Kanban, Charts)」仍读作「从更大集合里挑的几个热门的」,会把刚合上的口子重新撑开 —— 这个词与闭合措辞不相容,不是顺手润色。

**§Pre-installed Plugins**

```diff
-The runner comes with these plugins pre-configured:
+The runner comes with these two plugins pre-configured, registered by the imports in
+`src/App.tsx`:

 - **@object-ui/plugin-kanban** - Kanban board components
 - **@object-ui/plugin-charts** - Chart visualization components
-- **Additional plugins can be added as needed**
+
+Adding any other plugin means editing the runner's own sources and rebuilding — a
+dependency in `package.json`, a registration import in `src/App.tsx`, and the
+`vite.config.ts` alias and `src/index.css` `@source` entries the two above have. There
+is no runtime plugin installation.
```

第三条不是插件,却被排在一句「comes with these plugins pre-configured」引出的列表里、且和前两条一样加粗,形状上与两个真插件并列,扫读时会被当成第三个预装项。按 issue 建议降为列表下方的一句正文。

保留(而非删除)的措辞理由:该节读者的下一个问题必然是「那我怎么加别的插件」,留空反而会让人去猜一个不存在的运行时机制。这句话按实测写清真实代价,四个落点都已复核 —— `package.json` dependencies、`App.tsx:14-15`、`vite.config.ts:77-78`、`index.css:13-14`,现有两个插件在后两处各有条目。末句「There is no runtime plugin installation」把 issue 关心的那个误读直接堵死。

措辞上刻意说「the entries the two above have」(现有两个插件各有的条目)而不是「required」:vite 别名表的作用是让 runner 直接从 monorepo 源码启动(见 `vite.config.ts:42-43` 关于 #3575 的注释),把它写成硬性必需会是新的过度断言 —— 陈述现状而不越界断言。

## 验证(先预测后跑)

三条预测,全部命中:

1. **修后全文 `etc.` 零命中,§Pre-installed Plugins 列表恰两项**

```
$ grep -n 'etc\.' packages/runner/README.md      -> 无输出(exit 1)
$ awk '/^## Pre-installed Plugins/{f=1;next} /^## /{f=0} f' packages/runner/README.md | grep -c '^- '
2
```

2. **`docs:check-links` 修前修后皆绿**

```
修前: Links are valid across 6 scan roots.
修后: Links are valid across 6 scan roots.
```

关于扫描面(#3622 在途扩包 README 扫描面):**本切点上 `packages/**` 还不在扫描面内** —— `scripts/check-doc-links.mjs:355-362` 的 `SCAN_ROOTS` 是 `content/docs` / `examples` / `README.md` / `CONTRIBUTING.md` / `ROADMAP.md` / `docs` 六项,脚本自己在第 264 行写着「Measured and NOT bought: the package READMEs (objectui#3622)」。也就是说这道门禁目前根本没读到本文件,它的绿不构成对本改动的证明。真正的证据是链接零增删:`git show HEAD:packages/runner/README.md` 与工作区各 12 个 markdown 链接,两处改动都不含链接。#3622 落地后本文件进扫描面也不受影响。

3. **`check:control-bytes` 绿 + 自扫干净**

```
$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3661 tracked text file(s); skipped 85 binary).
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' packages/runner/README.md
(无输出, exit 1)
```

未跑 `pnpm test` / `type-check`:本 PR 是纯 README 文本改动,零代码行,runner 的 vitest 与 tsc 都不读 README —— 跑一遍只会在共用容器里烧内存换一个与本改动无关的绿。如实记录,不补造证据。

## 无 changeset

包 README 的事实订正,不改任何发布产物或公开 API,沿用 #3602 / #3621 / #3634 的先例。

## 越界发现(只报不改)

通读两节邻接,§Features 其余四条与 §Running the Runner、§Metadata Loading 均已复核属实(`dev: vite` / `build: vite build` 脚本存在;`package.json` 确实没有 `main` / `module` / `exports` / `types`)。同类新虚构:无。

另有一处非同类、非邻接的发现(生成块的版本漂移,波及 35 个包 README),已按仓规单独建 issue 归档,不在本 PR 修改。

⛔ 未碰 `content/docs/utilities/runner.mdx`(#3618 在途)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_