### PR TITLE
feat(scripts): check-doc-links 扫描面第四扩 packages/*/README.md,并付清入场价的 11 条死链 (#3622)

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -252,8 +252,8 @@ Check**.
 
 Runs `scripts/check-doc-links.mjs`, which walks every `.md` / `.mdx` file in the surfaces listed in
 its `SCAN_ROOTS` — `content/docs/`, `examples/`, the root `README.md`, `CONTRIBUTING.md`,
-`ROADMAP.md` and the internal `docs/` tree — and asks of each internal markdown link whether its
-target is really there.
+`ROADMAP.md`, the internal `docs/` tree and every package `README.md` — and asks of each internal
+markdown link whether its target is really there.
 
 **Two rules, because the two groups are read through different machinery** (objectui#3536). For
 `content/docs/` the question is the one a site reader cares about, **does the site serve this URL?**
@@ -282,16 +282,31 @@ rather than special-casing any surface. Measured before landing: 11 across the s
 dead. Prefer the origin-less form (`/docs/guide/plugins`) in new prose: it survives a domain change,
 and both spellings are now checked identically.
 
-Every other surface — `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs/` — is read
-on **GitHub**, not served by the site, so a relative href there names a path on disk and is checked
-for existence only: a directory (`./packages/core`) or a non-markdown file (`./vite.config.ts`) is a
-perfectly good target, and there is no collection to escape. A leading `/` is rejected outright:
-GitHub resolves it against `github.com`, not against this repository. Applying the `content/docs/`
-rules to these files instead would reject 111 links that render correctly today.
+Every other surface — `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs/` and the
+package READMEs — is read on **GitHub** (and, for the package READMEs, on **npm**), not served by
+the site, so a relative href there names a path on disk and is checked for existence only: a
+directory (`./packages/core`) or a non-markdown file (`./vite.config.ts`) is a perfectly good
+target, and there is no collection to escape. A leading `/` is rejected outright: GitHub resolves it
+against `github.com`, not against this repository. Applying the `content/docs/` rules to these files
+instead would reject 186 links that render correctly today.
 
-The last three surfaces are objectui#3572. They cost one `SCAN_ROOTS` row each and no new rule,
-because "read on GitHub" already had one; their own backlog — three dead links — was cleared first
-and separately (objectui#3545), so the rows landed on a green tree.
+`CONTRIBUTING.md`, `ROADMAP.md` and `docs/` are objectui#3572. They cost one `SCAN_ROOTS` row each
+and no new rule, because "read on GitHub" already had one; their own backlog — three dead links —
+was cleared first and separately (objectui#3545), so the rows landed on a green tree.
+
+The package READMEs are objectui#3622, and the same shape: **one row, its backlog paid first**. That
+backlog was 11 dead links in seven packages — three `/api/<pkg>` routes the site has never served,
+four site URLs naming three `content/docs/` directories that have no index page (so fumadocs
+generates no route for them), a `/docs/types` tree that does not exist, an `/examples` route that
+does not either, and two disk paths that were simply absent. Each was repointed at a real page, or
+replaced with the repository URL that does exist, before the row went in. The row is also the table's only wildcard: `packages/*/README.md` stands for
+one file per package directory (38 of the 39 today), and only the README — a package's
+`CHANGELOG.md`, `TESTING.md` and its own `docs/` tree stay unscanned.
+
+**Package READMEs must keep the origin on site links.** Inside `content/docs/` the origin-less
+`/docs/guide/plugins` is preferred; in a README it would be wrong, because GitHub and npm both
+resolve a leading `/` against their own host, not against this site. Write
+`https://www.objectui.org/docs/guide/plugins` there — it is checked exactly as strictly.
 
 **One boundary, stated because it is easy to mistake for coverage:** links written inside a code
 fence are invisible to this check. `stripCode()` blanks fenced blocks and inline spans before
@@ -350,7 +365,7 @@ There are **two** link checkers, and they cover different things (objectui#3213)
 
 | | Covers | Network | Runs |
 |---|---|---|---|
-| `scripts/check-doc-links.mjs` | **Internal** links in `content/docs/` (relative hrefs, `/docs/...` routes, every other site-absolute href against `apps/site`), in `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md` and `docs/` (as paths on disk), plus this repo's own `blob/main/` and `tree/main/` GitHub URLs and this site's own `objectui.org` URLs everywhere — **except** anything inside a code fence | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
+| `scripts/check-doc-links.mjs` | **Internal** links in `content/docs/` (relative hrefs, `/docs/...` routes, every other site-absolute href against `apps/site`), in `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs/` and every package `README.md` (as paths on disk), plus this repo's own `blob/main/` and `tree/main/` GitHub URLs and this site's own `objectui.org` URLs everywhere — **except** anything inside a code fence | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
 | Lychee (this workflow) | **External** URLs, plus **relative** in-repo file links, in `content/docs/`, `docs/` and `README.md` | Yes | Weekly cron and manual dispatch |
 
 Lychee sweeps **both** documentation trees: `content/docs/` (the 183 pages the site publishes) and

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -27,7 +27,7 @@ pnpm shadcn:check
 pnpm shadcn:update button --backup
 ```
 
-**📚 See [SHADCN_SYNC.md](../../docs/SHADCN_SYNC.md) for the complete guide.**
+**📚 See [README_SHADCN_SYNC.md](./README_SHADCN_SYNC.md) for the complete guide.**
 
 ## Installation
 
@@ -209,7 +209,7 @@ registerRenderer('custom-button', CustomButton)
 
 ## API Reference
 
-See [full documentation](https://objectui.org/api/components) for detailed API reference.
+See [full documentation](https://objectui.org/docs/components) for detailed API reference.
 
 <!-- release-metadata:v3.3.0 -->
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -141,7 +141,7 @@ This allows the core types and logic to be used in:
 
 ## API Reference
 
-See [full documentation](https://objectui.org/api/core) for detailed API reference.
+See [full documentation](https://objectui.org/docs/api) for detailed API reference.
 
 <!-- release-metadata:v3.3.0 -->
 
@@ -155,7 +155,7 @@ See [full documentation](https://objectui.org/api/core) for detailed API referen
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/core)
+- 📚 [Documentation](https://www.objectui.org/docs/guide/architecture)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/core)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -128,7 +128,7 @@ server too. See
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/fields)
+- 📚 [Documentation](https://www.objectui.org/docs/guide/fields)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/fields)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -119,7 +119,7 @@ All components accept `className` prop for Tailwind customization:
 
 ## API Reference
 
-For detailed API documentation, visit the [Object UI Documentation](https://www.objectui.org/docs/layout).
+For detailed API documentation, visit the [Object UI Documentation](https://www.objectui.org/docs/layout/app-shell).
 
 <!-- release-metadata:v3.3.0 -->
 
@@ -134,7 +134,7 @@ For detailed API documentation, visit the [Object UI Documentation](https://www.
 
 ## Links
 
-- 📚 [Documentation](https://www.objectui.org/docs/layout)
+- 📚 [Documentation](https://www.objectui.org/docs/guide/layout)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/layout)
 - 📝 [Changelog](./CHANGELOG.md)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -225,7 +225,7 @@ leaves the surface on its own anchor), `visibleNotificationStack` (`maxVisible` 
 
 ## API Reference
 
-See [full documentation](https://objectui.org/api/react) for detailed API reference.
+See [full documentation](https://objectui.org/docs/core/schema-renderer) for detailed API reference.
 
 <!-- release-metadata:v3.3.0 -->
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -326,6 +326,6 @@ MIT
 
 ## Links
 
-- [Documentation](https://objectui.org/docs/types)
+- [Documentation](https://objectui.org/docs/api/schema-reference)
 - [GitHub](https://github.com/objectstack-ai/objectui)
 - [NPM](https://www.npmjs.com/package/@object-ui/types)

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -187,7 +187,7 @@ pnpm publish
 - [Object UI Documentation](https://www.objectui.org)
 - [Schema Reference](https://www.objectui.org/docs/api/schema-reference)
 - [Component Library](https://www.objectui.org/docs/components)
-- [Examples](https://www.objectui.org/examples)
+- [Examples](https://github.com/objectstack-ai/objectui/tree/main/examples)
 
 ## 🤝 Contributing
 
@@ -239,4 +239,4 @@ Built with:
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+MIT — see [LICENSE](https://github.com/objectstack-ai/objectui/blob/main/LICENSE).

--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -81,10 +81,15 @@ import {
  * fail if either is.
  *
  * That card's OTHER half — adding the package READMEs to SCAN_ROOTS — was
- * deliberately not bought, because measuring it first turned up 11 more dead
- * links in packages the card never touched (objectui#3622). Nothing here pins
- * a `packages/**` row for that reason; when its backlog is paid, the SCAN_ROOTS
- * assertions below are what will need extending.
+ * deliberately not bought at the time, because measuring it first turned up 11
+ * more dead links in packages the card never touched. objectui#3622 paid those
+ * 11 and added the row, and the last describe pins it. Two things there are
+ * worth reading before editing it: the scan root carries the table's only
+ * wildcard segment, so `collectFiles` has an expansion step whose failure mode
+ * is a surface that silently expands to nothing — which is why the row's floor
+ * is pinned on DECIDABLE HREFS and not only on file count — and the fixture
+ * pair that keeps the row on the `disk` rule, since a package README is read on
+ * npm and GitHub and never served by the site.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -386,6 +391,7 @@ describe('the repo it guards', () => {
       'CONTRIBUTING.md',
       'ROADMAP.md',
       'docs',
+      'packages/*/README.md',
     ]);
     expect(scanned['README.md']).toBe(1);
     expect(scanned['CONTRIBUTING.md']).toBe(1);
@@ -393,6 +399,11 @@ describe('the repo it guards', () => {
     expect(scanned['examples']).toBeGreaterThanOrEqual(4);
     expect(scanned['docs']).toBeGreaterThanOrEqual(15);
     expect(scanned['content/docs']).toBeGreaterThanOrEqual(100);
+    // objectui#3622. 38 of the 39 package directories carry a README today
+    // (`sdui-parser` does not), and this row is the only one whose path needs
+    // expanding before anything is opened — so a floor here is also the floor
+    // under `expandWildcard()`.
+    expect(scanned['packages/*/README.md']).toBeGreaterThanOrEqual(35);
   });
 
   it('pairs each scan root with the link semantics that root actually has', () => {
@@ -403,6 +414,10 @@ describe('the repo it guards', () => {
     // objectui#3572 added the last three, all `disk` — they are read on GitHub
     // like the first two. The table is the whole configuration surface, so it
     // is pinned whole: a row silently changing rule would re-judge a tree.
+    //
+    // objectui#3622 added the package READMEs, `disk` for the same reason and
+    // one more: they are read on **npm** as well, where a leading `/` is no
+    // more this repo's root than it is on github.com.
     expect(SCAN_ROOTS).toEqual([
       { path: 'content/docs', rule: 'docs' },
       { path: 'examples', rule: 'disk' },
@@ -410,6 +425,7 @@ describe('the repo it guards', () => {
       { path: 'CONTRIBUTING.md', rule: 'disk' },
       { path: 'ROADMAP.md', rule: 'disk' },
       { path: 'docs', rule: 'disk' },
+      { path: 'packages/*/README.md', rule: 'disk' },
     ]);
   });
 
@@ -1136,10 +1152,14 @@ describe("this site's own absolute URLs are resolved as internal routes — obje
     // `siteAbsoluteRoute()` returned null for everything. This pins that the
     // URLs are really there and really reaching the check.
     //
-    // Measured on main: 11 of them, of which 6 sit inside `content/docs`
-    // itself — the fact that makes this a general fix rather than a package
-    // README one — and 3 carry a `/docs/...` path, so the strict branch above
-    // is genuinely exercised by real content and not only by fixtures.
+    // Measured on main when #3603 landed: 11 of them, of which 6 sit inside
+    // `content/docs` itself — the fact that makes this a general fix rather
+    // than a package README one — and 3 carry a `/docs/...` path, so the strict
+    // branch above is genuinely exercised by real content and not only by
+    // fixtures. objectui#3622 took the total to 58 by adding a surface that
+    // writes 47 of them; the floors below stay at #3603's measurement, since
+    // they exist to pin THAT card's minimum and the new root has its own floor
+    // in the last describe.
     const seen: { root: string; route: string }[] = [];
     for (const root of SCAN_ROOTS as { path: string }[]) {
       for (const file of collectFiles(path.join(repoRoot, root.path)) as string[]) {
@@ -1153,5 +1173,141 @@ describe("this site's own absolute URLs are resolved as internal routes — obje
     expect(seen.length).toBeGreaterThanOrEqual(11);
     expect(seen.filter((item) => item.root === 'content/docs').length).toBeGreaterThanOrEqual(6);
     expect(seen.filter((item) => item.route.startsWith('/docs')).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('packages/*/README.md joined the disk surface — objectui#3622', () => {
+  it('reports the four shapes the 11 dead links really had', () => {
+    // One fixture carrying all four, each next to a live control of the same
+    // shape — so no verdict here can be right for the wrong reason:
+    //
+    //   /api/core            a route prefix the router has never had (#3490's class)
+    //   /docs/core           a REAL directory with no index page, so not a route
+    //   ../../docs/SHA…      a disk path that has never existed
+    //   ./LICENSE            a disk path this package really does not have
+    //
+    // The middle one is the one objectui#3603's own verification script scored
+    // green, by accepting a bare directory as a fumadocs candidate. The fixture
+    // materialises `content/docs/core/schema-renderer.mdx` so the directory is
+    // genuinely there and only the missing index decides the verdict.
+    expect(
+      rejections({
+        ...SITE_FIXTURE,
+        'content/docs/core/schema-renderer.mdx': '# SchemaRenderer',
+        'packages/core/README.md': [
+          '[api](https://objectui.org/api/core)',
+          '[group](https://www.objectui.org/docs/core)',
+          '[renderer](https://www.objectui.org/docs/core/schema-renderer)',
+          '[sync](../../docs/SHADCN_SYNC.md)',
+          '[changelog](./CHANGELOG.md)',
+          '[licence](./LICENSE)',
+        ].join('\n\n'),
+        'packages/core/CHANGELOG.md': '# Changelog',
+      }),
+    ).toEqual([
+      ['https://objectui.org/api/core', 'site-absolute-url'],
+      ['https://www.objectui.org/docs/core', 'site-absolute-url'],
+      ['../../docs/SHADCN_SYNC.md', 'example-relative'],
+      ['./LICENSE', 'example-relative'],
+    ]);
+  });
+
+  it('expands the wildcard to one path per package directory, sorted', () => {
+    // The row is the table's only wildcard, so this is where `expandWildcard()`
+    // is pinned: one path per directory, a package without a README dropped
+    // (`sdui-parser` on main), and a stable order so the report does not depend
+    // on the filesystem's.
+    const repo = repoWith({
+      'packages/gamma/README.md': '# Gamma',
+      'packages/alpha/README.md': '# Alpha',
+      'packages/beta/index.ts': 'export {}',
+    });
+
+    expect(
+      collectFiles(path.join(repo, 'packages/*/README.md')).map((file: string) => path.relative(repo, file)),
+    ).toEqual([path.join('packages', 'alpha', 'README.md'), path.join('packages', 'gamma', 'README.md')]);
+  });
+
+  it('takes only the README — a package CHANGELOG or TESTING.md stays unscanned', () => {
+    // The boundary this row deliberately stops at, pinned as a decision rather
+    // than left to be discovered as coverage that was never there. The README's
+    // OWN dead link is the control: an expectation of "nothing from the other
+    // two files" would hold just as well if the row had been dropped entirely.
+    expect(
+      rejections({
+        'packages/core/README.md': '[fine](./CHANGELOG.md) and [gone](./NOWHERE.md)',
+        'packages/core/CHANGELOG.md': '[also gone](./NOWHERE.md)',
+        'packages/core/TESTING.md': '[also gone](./NOWHERE.md)',
+        'packages/core/docs/FilterBuilder.md': '[also gone](./NOWHERE.md)',
+      }),
+    ).toEqual([['./NOWHERE.md', 'example-relative']]);
+  });
+
+  it('does not treat a dependency tree under packages/ as a package', () => {
+    // `packages/node_modules` is a directory like any other to a wildcard, and
+    // its READMEs are not ours. Same exclusion the tree walk already applies.
+    expect(
+      rejections({
+        'packages/core/README.md': '[gone](./NOWHERE.md)',
+        'packages/node_modules/README.md': '[gone](./NOWHERE.md)',
+      }),
+    ).toEqual([['./NOWHERE.md', 'example-relative']]);
+  });
+
+  it('keeps the docs rules off package READMEs — the contrast pair', () => {
+    // A package README is read on npm and on GitHub, never served by the site,
+    // so it takes the `disk` rule. Two hrefs make that visible in both
+    // directions: a link INTO content/docs is fine from a README (there is no
+    // collection to escape) and rejected from inside content/docs, while the
+    // extensionless spelling the docs rule accepts is a 404 on GitHub.
+    const repo = repoWith({
+      ...SITE_FIXTURE,
+      'content/docs/guide/a.md': '[readme](../../../packages/core/README.md)',
+      'content/docs/fields/lookup.mdx': '# Lookup',
+      'packages/core/README.md': '[lookup](../../content/docs/fields/lookup.mdx) and [bare](../../content/docs/fields/lookup)',
+    });
+
+    expect(scan(repo).map((item) => [path.relative(repo, item.file), item.href, item.reason])).toEqual([
+      [path.join('content', 'docs', 'guide', 'a.md'), '../../../packages/core/README.md', 'escapes-collection'],
+      [path.join('packages', 'core', 'README.md'), '../../content/docs/fields/lookup', 'example-relative'],
+    ]);
+  });
+
+  it('refuses a wildcard that is not a whole path segment, rather than matching nothing', () => {
+    // The failure mode a glob row has and a plain path does not: a pattern that
+    // expands to zero paths is a surface silently dropped, and every test above
+    // stays green about a tree nobody opened. Loud beats quiet, as with the
+    // missing route table in `routeExists()`.
+    const repo = repoWith({ 'packages/plugin-charts/README.md': '# Charts' });
+
+    expect(() => collectFiles(path.join(repo, 'packages/plugin-*/README.md'))).toThrow(/whole path segment/);
+  });
+
+  it('really judges the links these READMEs carry — the floor under the green', () => {
+    // The anti-vacuous-green floor for this row, and the reason it counts HREFS
+    // rather than files: the file count above proves the wildcard expanded, but
+    // a surface of 38 files carrying nothing this gate can decide would still
+    // leave the repo-wide green meaning "checked nothing". Measured when the row
+    // landed: 200 decidable hrefs across the 38 READMEs, 47 of them site-absolute
+    // URLs — the shape 9 of the 11 dead links had.
+    // The root is read out of SCAN_ROOTS rather than spelled again here, so
+    // deleting the row takes this floor with it instead of leaving a green test
+    // measuring a surface the gate no longer scans.
+    const root = (SCAN_ROOTS as { path: string }[]).find((item) => item.path.startsWith('packages/'));
+    expect(root).toBeDefined();
+
+    const decidable: string[] = [];
+    const siteAbsolute: string[] = [];
+    for (const file of collectFiles(path.join(repoRoot, root!.path)) as string[]) {
+      for (const match of stripCode(fs.readFileSync(file, 'utf8')).matchAll(/\[[^\]]+\]\(([^)]+)\)/g)) {
+        const href = match[1].trim();
+        const decidableScheme = siteAbsoluteRoute(href) !== null || selfRepoPath(href) !== null;
+        if (siteAbsoluteRoute(href) !== null) siteAbsolute.push(href);
+        if (decidableScheme || !/^(?:#|[a-zA-Z][a-zA-Z0-9+.-]*:)/.test(href)) decidable.push(href);
+      }
+    }
+
+    expect(decidable.length).toBeGreaterThanOrEqual(150);
+    expect(siteAbsolute.length).toBeGreaterThanOrEqual(40);
   });
 });

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -273,16 +273,19 @@
  * closes the comment. It is described in prose here and written out only in the
  * table below, which is code.)
  *
- * The price was **11 more** dead links, none of them among #3603's 9 — they sit
- * in seven packages, five of which that card never opened, and the other two on
- * lines it did not touch: `/api/core`, `/api/react`,
- * `/api/components` (no such routes — the class #3490 swept), `/docs/core`,
- * `/docs/fields`, `/docs/layout` (real directories with no index page, so no
- * route), `/docs/types` and `/examples` (neither exists), plus two disk paths
- * that were simply absent (a `docs/SHADCN_SYNC.md` that has never existed, and
- * a per-package `LICENSE` that `packages/vscode-extension` does not have).
- * Each was resolved to a real page, or dropped where none exists, in the same
- * PR as this row — so the row arrives on a green tree, the #3572 shape.
+ * The price was **11 more** dead links, none of them among #3603's 9. They sit
+ * in seven packages: five that card never opened, plus two where it had already
+ * fixed a different line. `/api/core`, `/api/react` and `/api/components` (no
+ * such routes — the class #3490 swept); `/docs/core`, `/docs/fields` and
+ * `/docs/layout`, twice (real directories with no index page, so no route);
+ * `/docs/types` and `/examples` (neither exists); and two disk paths that were
+ * simply absent (a `docs/SHADCN_SYNC.md` that has never existed, and a
+ * per-package `LICENSE` that `packages/vscode-extension` does not have).
+ *
+ * All eleven were repointed at a page or path that does exist, in the same PR as
+ * this row — none had to be dropped, unlike #3603's 9, where 6 assumed a whole
+ * `/docs/packages/...` namespace that was never written. So the row arrives on a
+ * green tree, the #3572 shape.
  *
  * Three of those deserve naming, because objectui#3603's own verification
  * script scored them GREEN: it accepted a bare DIRECTORY as a fumadocs

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -223,11 +223,10 @@
  * link. A gate for prose *about* links inside fences would need to tell an
  * illustrative route from an executable one, which is a different gate.
  *
- * ### Still not bought
- *
- * `QUICK_REFERENCE.md`, `AGENTS.md`, `CLAUDE.md` and `CHANGELOG.md` remain
- * unscanned. Same one-row price, same caveat — measure the surface first, pay
- * its backlog separately, then add the row.
+ * (A "Still not bought" list closed this section, naming `QUICK_REFERENCE.md`,
+ * `AGENTS.md`, `CLAUDE.md` and `CHANGELOG.md`. It has moved to the end of the
+ * objectui#3622 section below, which is the current one; those four are still
+ * on it.)
  *
  * ## Why this file changed again (objectui#3603)
  *
@@ -261,33 +260,58 @@
  * dead. The #3572 shape again — the check arrives green, its backlog already
  * paid.
  *
- * ### Measured and NOT bought: the package READMEs (objectui#3622)
+ * ## Why this file changed again (objectui#3622): the package READMEs, bought
  *
- * objectui#3603 asked for a second half: growing the scan surface by the 38
- * package READMEs, which is where the 9 dead links that prompted it lived.
- * Those 9 are fixed by hand in the same PR. The scan row is **not** added, and
- * the reason is this file's own rule from #3572 — measure the surface, pay its
- * backlog separately, then add the row.
+ * The section that stood here was headed "Measured and NOT bought". It recorded
+ * the price of objectui#3603's other half — growing the scan surface by the 38
+ * package READMEs, which is where the 9 dead links that prompted that card lived
+ * — and refused to add the row until that price was paid, per this file's rule
+ * from #3572. It is paid, so the row is in the table above.
  *
- * (Note for whoever writes that row: a glob naming each package README cannot
- * be spelled inside this block comment, because the star-slash in it closes the
- * comment. Say it in prose here, or move the note outside.)
+ * (Note kept for whoever edits that row: a glob naming each package README
+ * cannot be spelled inside this block comment, because the star-slash in it
+ * closes the comment. It is described in prose here and written out only in the
+ * table below, which is code.)
  *
- * The surface was measured, and its backlog is not the 9. With the resolution
- * above in place, a `disk`-rule row covering those 38 files
- * reports **11 more** dead links in five packages that card never touched:
- * `/api/core`, `/api/react`, `/api/components` (no such routes — the class
- * #3490 swept), `/docs/core`, `/docs/fields`, `/docs/layout` (real directories
- * with no index page, so no route), `/docs/types` and `/examples` (neither
- * exists), plus two disk paths that are simply absent
- * (`../../docs/SHADCN_SYNC.md`, `./LICENSE`).
+ * The price was **11 more** dead links, none of them among #3603's 9 — they sit
+ * in seven packages, five of which that card never opened, and the other two on
+ * lines it did not touch: `/api/core`, `/api/react`,
+ * `/api/components` (no such routes — the class #3490 swept), `/docs/core`,
+ * `/docs/fields`, `/docs/layout` (real directories with no index page, so no
+ * route), `/docs/types` and `/examples` (neither exists), plus two disk paths
+ * that were simply absent (a `docs/SHADCN_SYNC.md` that has never existed, and
+ * a per-package `LICENSE` that `packages/vscode-extension` does not have).
+ * Each was resolved to a real page, or dropped where none exists, in the same
+ * PR as this row — so the row arrives on a green tree, the #3572 shape.
  *
  * Three of those deserve naming, because objectui#3603's own verification
  * script scored them GREEN: it accepted a bare DIRECTORY as a fumadocs
  * candidate. This gate does not, and is right not to — `routeCandidates()` has
  * no such spelling, and the pinned test "rejects a relative link to a directory
  * that has no index page" is that decision. `content/docs/core/` really has no
- * index page, so `/docs/core` really does 404. The class is 20 links, not 9.
+ * index page, so `/docs/core` really does 404. The class was 20 links, not 9.
+ *
+ * **The rule is `disk`, and that is not a coin toss.** A package README is read
+ * on npm and on GitHub, never served by the site, so its relative hrefs are
+ * paths on disk exactly like `examples/`, the root `README.md`,
+ * `CONTRIBUTING.md`, `ROADMAP.md` and `docs/`: `./CHANGELOG.md` is a file next
+ * to it, not a route. The same reading forbids the origin-less `/docs/...`
+ * spelling this file prefers inside `content/docs` — GitHub and npm resolve a
+ * leading `/` against their own host — which is why the site links repaired
+ * above all keep the `https://[www.]objectui.org/...` origin, and are still
+ * checked as strictly as the origin-less form (see the section above).
+ *
+ * The one thing the row does need is a wildcard segment in the scan-root path,
+ * since the surface is one file per package directory rather than a tree.
+ * `expandWildcard()` is that, and no more than that.
+ *
+ * ### Still not bought
+ *
+ * `QUICK_REFERENCE.md`, `AGENTS.md`, `CLAUDE.md` and `CHANGELOG.md` remain
+ * unscanned, along with the non-README markdown inside packages (`CHANGELOG.md`,
+ * `TESTING.md`, `MIGRATION.md`, per-package `docs/` trees). Same one-row price,
+ * same caveat — measure the surface first, pay its backlog separately, then add
+ * the row.
  *
  * ## Code spans are stripped before scanning
  *
@@ -346,11 +370,17 @@ const UNSCANNED_DIRS = new Set(['node_modules', 'dist', 'build', '.next', '.turb
  *
  * The split is the point (objectui#3536). See the header for why applying the
  * docs rules to the second group would reject links that render perfectly well:
- * over today's `disk` surface it would reject 111 links that all render.
+ * over today's `disk` surface it would reject 186 links that all render — 111
+ * of them before objectui#3622 widened that surface, 75 in the package READMEs
+ * it added.
  *
  * Adding a surface is one row. Adding one that is read on GitHub needs no new
  * rule class at all — which is why objectui#3572 could take the last three for
- * the price of the table entry.
+ * the price of the table entry, and objectui#3622 the package READMEs.
+ *
+ * A row's `path` is a directory to walk, a single markdown file, or a pattern
+ * whose one wildcard SEGMENT stands for every directory at that level — see
+ * `expandWildcard()` below, which is all the glob syntax this table has.
  */
 export const SCAN_ROOTS = [
   { path: 'content/docs', rule: 'docs' },
@@ -359,6 +389,7 @@ export const SCAN_ROOTS = [
   { path: 'CONTRIBUTING.md', rule: 'disk' },
   { path: 'ROADMAP.md', rule: 'disk' },
   { path: 'docs', rule: 'disk' },
+  { path: 'packages/*/README.md', rule: 'disk' },
 ];
 
 const blank = (text) => text.replace(/[^\n]/g, ' ');
@@ -383,8 +414,49 @@ export function walk(dir, files = []) {
   return files;
 }
 
-/** One scan root, which may be a directory to walk or a single markdown file. */
+/**
+ * Expands the leftmost wildcard segment of a scan root into one path per
+ * directory at that level, sorted so the scan order — and therefore the report
+ * order — does not depend on the filesystem's (objectui#3622). `collectFiles`
+ * recurses, so a later wildcard segment expands on the next pass.
+ *
+ * Deliberately not a glob library: a whole segment that is exactly `*`, and
+ * nothing else. Anything richer THROWS rather than quietly matching nothing,
+ * because a scan root that expands to zero paths is a surface silently dropped
+ * — the one failure mode this gate must not have (same stance as the missing
+ * route table in `routeExists()`).
+ */
+function expandWildcard(pattern) {
+  const segments = pattern.split(path.sep);
+  const index = segments.findIndex((segment) => segment.includes('*'));
+  if (segments[index] !== '*') {
+    throw new Error(
+      `A SCAN_ROOTS path may only use a wildcard as a whole path segment, and got "${pattern}". ` +
+        'Widen the row to the directory above, or add the paths one row each.',
+    );
+  }
+
+  const parent = segments.slice(0, index).join(path.sep);
+  const rest = segments.slice(index + 1);
+  let entries;
+  try {
+    entries = readdirSync(parent, { withFileTypes: true });
+  } catch {
+    return []; // the parent is not here — same contract as a missing scan root
+  }
+
+  return entries
+    .filter((entry) => entry.isDirectory() && !UNSCANNED_DIRS.has(entry.name))
+    .map((entry) => [parent, entry.name, ...rest].join(path.sep))
+    .sort();
+}
+
+/**
+ * One scan root, which may be a directory to walk, a single markdown file, or a
+ * wildcard pattern standing for one path per directory at that level.
+ */
 export function collectFiles(root) {
+  if (root.includes('*')) return expandWildcard(root).flatMap((expanded) => collectFiles(expanded));
   try {
     if (statSync(root).isFile()) return /\.(md|mdx)$/.test(root) ? [root] : [];
   } catch {
@@ -765,7 +837,7 @@ const HINTS = {
     ' (the "Package README" form used throughout content/docs/plugins/).',
   'example-relative':
     'Outside content/docs (examples/**, README.md, CONTRIBUTING.md, ROADMAP.md,' +
-    ' docs/**) a relative link is a' +
+    ' docs/** and each package README) a relative link is a' +
     ' PATH IN THIS REPO, resolved by GitHub against the linking file — so it' +
     ' must name something that exists and lives inside the repository. A' +
     ' directory or a non-markdown file is fine; an extensionless spelling of a' +


### PR DESCRIPTION
Fixes #3622
Fixes #3603

先量后付的第四次。红账先清零,再加扫描行——门禁首跑对真仓即绿,而这 11 条正是它的验收语料。父单 #3603 的门禁第 1 层至此落地,两半合齐。

## 一、11 条红账处置表(逐条独立查证,全部改指,零删除)

| # | 位置 | 原 href | 处置 | 依据(逐条实测) |
| --- | --- | --- | --- | --- |
| 1 | `packages/components/README.md:30` | `../../docs/SHADCN_SYNC.md` | 改指 `./README_SHADCN_SYNC.md` | `find . -name SHADCN_SYNC.md` 全仓零命中,该文件从未存在;真正的完整指南是同包的 `README_SHADCN_SYNC.md`(278 行,`pnpm shadcn:check` / `shadcn:update` 全在其中),且 `shadcn-components.json` 也在同目录 |
| 2 | `packages/components/README.md:212` | `https://objectui.org/api/components` | 改指 `https://objectui.org/docs/components` | `apps/site/app/api` 下只有 `search/route.ts`,`/api/components` 无路由;`content/docs/components/index.md` 是 Component Gallery,正是该包的组件参考。#3629 给 vscode-extension 的「Component Library」用的就是这一页 |
| 3 | `packages/core/README.md:144` | `https://objectui.org/api/core` | 改指 `https://objectui.org/docs/api` | 同上无路由;`content/docs/api/index.md` 标题即 "API Reference",自述 "Comprehensive reference documentation for all ObjectUI types, schemas, and APIs",与该节标题 `## API Reference` 对位 |
| 4 | `packages/core/README.md:158` | `https://www.objectui.org/docs/core` | 改指 `https://www.objectui.org/docs/guide/architecture` | `content/docs/core/` 只有 5 个 `.mdx`,**无 index 页**,fumadocs 不生成路由;`guide/architecture.md` 的 §Package Structure 有 `#### @object-ui/core` 一节逐包说明角色与边界 |
| 5 | `packages/fields/README.md:131` | `https://www.objectui.org/docs/fields` | 改指 `https://www.objectui.org/docs/guide/fields` | `content/docs/fields/` 26 个字段页,无 index;`guide/fields.md` 标题 "Field Registry",正文首句即 "The `@object-ui/fields` package serves as the Universal Language for rendering values" |
| 6 | `packages/layout/README.md:122` | `https://www.objectui.org/docs/layout` | 改指 `https://www.objectui.org/docs/layout/app-shell` | `content/docs/layout/` 无 index;该行在 `## API Reference` 下、紧跟一段 `AppShell` 示例,`layout/app-shell.mdx` 就是这个组件的 API 页 |
| 7 | `packages/layout/README.md:137` | `https://www.objectui.org/docs/layout` | 改指 `https://www.objectui.org/docs/guide/layout` | 同上无 index;该行在 `## Links` 的「Documentation」位,`guide/layout.md` 标题 "Layout System",逐个介绍 AppShell / Page / PageHeader / SidebarNav——是包总览而非单组件页,故与第 6 条取不同目标 |
| 8 | `packages/react/README.md:228` | `https://objectui.org/api/react` | 改指 `https://objectui.org/docs/core/schema-renderer` | 无 `/api/react` 路由(#3490 已扫过同款);`core/schema-renderer.mdx` 是该包主导出 SchemaRenderer 的参考页。与 #3629 给同包 `:243` 选的目标相同——**这一处重复是有意留下的**:站点没有按包组织的 API 页(#3490 的结论),这就是 react 最贴近的真实参考页 |
| 9 | `packages/types/README.md:329` | `https://objectui.org/docs/types` | 改指 `https://objectui.org/docs/api/schema-reference` | `content/docs/types` 整个目录不存在;`api/schema-reference.md` 开篇写着 "**Import:** All types are available from `@object-ui/types`",就是这个包的内容 |
| 10 | `packages/vscode-extension/README.md:190` | `https://www.objectui.org/examples` | 改指 `https://github.com/objectstack-ai/objectui/tree/main/examples` | `/examples` 不是站点路由(#3490 已确认);`examples/` 目录真实存在,且 `content/docs/utilities/vscode-extension.mdx:489` 这条同名链接用的正是这个 URL,仓内另有 3 处同款写法 |
| 11 | `packages/vscode-extension/README.md:242` | `./LICENSE` | 改指 `https://github.com/objectstack-ai/objectui/blob/main/LICENSE` | 39 个包里 35 个有 LICENSE 文件,该包没有;仓根有。该 README 第 237 行给 CONTRIBUTING.md 用的就是 `blob/main/` 形态,与之统一。⚠️ 未改成补 LICENSE 文件——那是打包策略,已另开 #3647 |

**没有删除任何一行。** #3603/#3629 的口径是「查不到真实页才删」;这 11 条逐条都找到了实测存在的对位页面,所以全部改指。这也是它与 #3629(9 条里删 6 改 3)的差别:那 6 条假设的是一整个不存在的 `/docs/packages/PKG` 命名空间,本单这 11 条各自都有真实归属。

改指后全部保留 `https://[www.]objectui.org/...` 的 origin,不写成 origin-less 的 `/docs/...`:包 README 在 GitHub 与 npm 上被读,那里开头的 `/` 会被解析到它们自己的域名。这一点已写进头注释与 `ci-cd-pipeline.md`,避免下一个人按 `content/docs` 的偏好「顺手改正」。

## 二、扫描行

```
{ path: 'packages/*/README.md', rule: 'disk' },
```

`disk` 规则,不新增规则类:包 README 在 npm 与 GitHub 被阅读,相对链接是磁盘路径语义(`./CHANGELOG.md` 是身边的文件而非路由),与 `examples/**`、`README.md`、`CONTRIBUTING.md`、`ROADMAP.md`、`docs/**` 完全同类。理由与「必须保留 origin」的推论一并写进头注释。

这是表里**唯一带通配符**的一行,所以 `collectFiles()` 增加了 `expandWildcard()`:只认**整段**的 `*`,再复杂的写法直接抛错,而不是静默匹配零个路径——扫描面被悄悄丢掉是这个门禁唯一不能有的失效模式(与 `routeExists()` 缺路由表时抛错同一立场)。

头注释的 "Measured and NOT bought" 一节改写为已购入,并把 #3572 那份过期的 "Still not bought" 清单挪到当前位置(那四个文件仍在单上,另加包内非 README 的 markdown)。⚠️ 注释里仍未原样写出 glob——星号加斜杠会提前闭合块注释(#3629 踩过),只用散文描述,真正的 glob 只出现在下方的数据表里(那是代码)。

顺带更新了两处随扫描面漂移的实测数字:「把 docs 规则套到 disk 面会误杀多少条」由 111 改为 186。**111 是用本次同一套方法独立复算出来的**(examples 21 + README 40 + CONTRIBUTING 0 + ROADMAP 3 + docs 47 = 111,与文件里记的数字一致),包 README 贡献新增的 75 条。

## 三、逆向验证(方向先定后跑)

这是「扩扫描面」类改动,方向是常规的**加行则多报**,不是 #5018/#5046 那种反转或计数下降的情形——先写下预测再跑:

| 步骤 | 预测 | 实测 |
| --- | --- | --- |
| 真仓首跑,11 条已清、扫描行已加 | 绿 | ✅ `Links are valid across 7 scan roots.`(exit 0) |
| 在 `packages/core/README.md` 植入两条死链(相对磁盘路径 + 站内绝对 URL 各一) | 红,且恰好是这 2 条 | ✅ `Found 2 broken links`,`[example-relative] ./NO_SUCH_FILE.md` + `[site-absolute-url] .../docs/no-such-page`,exit 1 |
| **仅撤掉扫描行**,植入的死链原地留着 | 绿——证明是这一行在干活,不是别的根顺带扫到了 | ✅ `Links are valid across 6 scan roots.`(exit 0) |
| 还原两者 | 绿,7 根 | ✅ `Links are valid across 7 scan roots.` |

测试层做了同一件事(撤掉扫描行跑测试):

| 预测 | 实测 |
| --- | --- |
| 依赖扫描面的用例转红 | ✅ 7 条红:`really scans every surface`、`pairs each scan root`,以及 #3622 describe 里的 4 条(四种死链形状 / 只收 README / 排除 node_modules / disk 与 docs 对照对)+ 「floor under the green」 |
| 两条直接调 `collectFiles()`、不经 SCAN_ROOTS 的用例保持绿 | ✅ 恰好这 2 条绿(通配符展开、非整段通配符抛错) |

「floor under the green」原本也直接写死路径、撤行后不会红,已改成从 `SCAN_ROOTS` 里取那一行——现在删行会连它一起带红,而不是留下一条对着门禁已不再扫描的目录做测量的绿测试。

## 四、测试

- `SCAN_ROOTS` 的 `toEqual` pin 与逐根 count 表按新行扩写(新根文件数下限 35,今日 38——39 个包里 `sdui-parser` 没有 README)。
- **新根另加「可判定 href 数」下限**,这是本次的反空绿主力:文件数只能证明通配符展开了,证明不了这批文件里有东西可判。实测 38 个 README 共 294 条链接、其中 **200 条可判定**(47 条是站内绝对 URL,即 11 条死链里 9 条的形状),下限写 150 / 40。
- 新增 7 条用例:四种死链形状同框(每种旁边配一条同形状的活链作对照,任一条判对判错都会响)、通配符展开与排序、只收 README 的边界(包内 `CHANGELOG.md` / `TESTING.md` / `docs/` 不扫,用 README 自己的死链作控制项防止空绿)、`packages/node_modules` 排除、disk 与 docs 规则的双向对照对、非整段通配符抛错。

```
npx vitest run scripts/__tests__/check-doc-links.test.ts
  Test Files  1 passed (1)   Tests  82 passed (82)

npx vitest run scripts/__tests__/          # 全量
  Test Files  16 passed (16)  Tests  300 passed (300)

pnpm type-check:scripts                     # tsc -p tsconfig.scripts.json,无输出
npx eslint scripts/check-doc-links.mjs scripts/__tests__/check-doc-links.test.ts   # 无输出
node scripts/check-control-bytes.mjs
  ✅ OK (scanned 3655 tracked text file(s); skipped 85 binary)
```

另按仓规自查了控制字节(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 扫本 PR 全部改动文件,零命中)。

## 五、不加 changeset

改的是包 README 的链接与 CI 脚本,不触发任何包的版本发布,与 #3589 / #3629 仓例一致(#3629 的部分验收评论第 5 条已确认接受)。

## 六、范围外发现(已另开,未在本 PR 修)

- **#3647** — `@object-ui/plugin-tree` 的 `package.json` `files` 点名要打包 `LICENSE`,但该文件不存在;npm 对 `files` 里缺失的条目静默跳过,所以已发布的 tarball 都没有它自己声明要带的许可证文本。发现于逐包核对第 11 条时。
- **#3648**(`finding` 标签,观察类) — `judgeHref()` 里有一段 4 行注释被逐字复制了两遍(PR #3629 引入),纯注释、零行为影响,按围栏未顺手改。

## 七、未做,且是有意的

`content/docs/` 下 `core` / `fields` / `layout` / `rfcs` 四个目录缺 index 页(侧边栏这四个分组标题本身不可点)。给它们补 index 页会让第 4/5/6/7 条链接原地复活,但那是内容创作,#3622 正文与 PM 认领评论都判在本卡之外,留给分诊池。本 PR 按「链接侧处置」的裁决,把这四条改指到实测存在的真实页。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_