### PR TITLE
fix(app-shell): 伪路由开关改按路径段判断,拼错 app 名不再静默渲染别的 app (#3638)

### DIFF
--- a/.changeset/pseudo-route-segment-flags-3638.md
+++ b/.changeset/pseudo-route-segment-flags-3638.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Match the built-in pseudo-routes on whole path segments, so a mistyped app name can no longer render a different app (objectui#3638).
+
+`AppContent` decides whether a URL is a built-in pseudo-route (`create-app`, `system/*`, `metadata/*`, `setup`) before it decides which app to render, and two of those switches were substring tests: `pathname.includes('/system')` and `pathname.includes('/metadata')`. Both are true for any segment that merely *starts* with the word — `system_log`, `system_setting`, `systems`, `metadata_import`, `metadata-export`. `isSpecialRoute` feeds `requestedAppMissing`, so visiting `/apps/<mistyped-app>/system_log` marked the URL as a pseudo-route, suppressed the "App not available" guard, fell back to the default app and rendered **that** app's shell with `system_log` taken as its object name — the exact "must NOT silently render a DIFFERENT app" case the fallback's own comment exists to prevent, with no indication that the requested app does not exist.
+
+The two flags now test path *segments* (`pathname.split('/').includes('system' | 'metadata')`); `isCreateAppRoute`'s `endsWith('/create-app')` is unchanged. Every real pseudo-route spells the word as a whole segment — `system/marketplace{,/installed,/:packageId}`, the host's `system/{apps,profile,approvals,ai-approvals,audit-log,settings,objects,metadata/…}`, `metadata/{,_diagnostics,:type,…}` and the legacy `component/metadata/{directory,resource/*}` aliases — so all of them stay special, including in the zero-app branch that keys on these flags directly (objectui#3590 / #3610). Knock-on, in a zero-app console only: a `system`-prefixed near-miss such as `/apps/setup/system_log` now reaches the same "No Apps Configured" screen every other unresolved URL there reaches, instead of the pseudo-route branch's "Page not found".

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -180,9 +180,22 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
   // Built-in pseudo-routes under /apps/* that are NOT metadata apps (create-app,
   // system/*, metadata/*, setup). They must keep working — and may fall back to
   // a default app — regardless of whether the segment resolves to an app.
+  // #3638 — `system` / `metadata` are matched as whole path SEGMENTS, not as
+  // substrings. `pathname.includes('/system')` was also true for any segment
+  // that merely STARTS with `system` (`system_log`, `system_setting`,
+  // `systems`), and likewise for `metadata` (`metadata_import`, …). That made
+  // `isSpecialRoute` true for an ordinary `/apps/:app/:objectName` URL whose
+  // object name happened to start that way — which suppressed
+  // `requestedAppMissing` below and let a MISTYPED app name silently render a
+  // DIFFERENT app (the exact failure the comment on the fallback describes).
+  // Every real pseudo-route spells them as full segments — `system/marketplace`,
+  // `system/metadata/:type`, `metadata/:type`, `component/metadata/resource` —
+  // so the segment test keeps all of them true (pinned in
+  // `__tests__/AppContent.pseudoRouteSegments.test.tsx`).
+  const pathSegments = location.pathname.split('/');
   const isCreateAppRoute = location.pathname.endsWith('/create-app');
-  const isSystemRoute = location.pathname.includes('/system');
-  const isMetadataRoute = location.pathname.includes('/metadata');
+  const isSystemRoute = pathSegments.includes('system');
+  const isMetadataRoute = pathSegments.includes('metadata');
   const isSetupRoute =
     location.pathname === '/apps/setup' || location.pathname.startsWith('/apps/setup/');
   const isSpecialRoute = isCreateAppRoute || isSystemRoute || isMetadataRoute || isSetupRoute;
@@ -637,8 +650,8 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
               `sys-datasources` points straight at
               `…/component/metadata/resource?type=datasource`, and `sys-objects`
               arrives via the host's `system/metadata/:type` → same alias
-              rewrite. Both pass `isMetadataRoute` (a substring test on
-              `/metadata`) and so land in THIS branch, which declared no
+              rewrite. Both pass `isMetadataRoute` (a `metadata` path segment —
+              a substring test until #3638) and so land in THIS branch, which declared no
               `component/…` route at all — every one of them rendered a blank
               screen. Kept as a mirror rather than re-pointed navigation because
               the alias already has exactly one canonical destination; adding a

--- a/packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx
@@ -1,0 +1,434 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The built-in pseudo-route switches must be SEGMENT tests, not substring
+ * tests (objectui#3638).
+ *
+ * ## The defect
+ *
+ * `AppContent` decides whether a URL is one of the built-in pseudo-routes
+ * (`create-app`, `system/*`, `metadata/*`, `setup`) before it decides which app
+ * to render. Two of those switches were substring tests:
+ *
+ *     const isSystemRoute   = location.pathname.includes('/system');
+ *     const isMetadataRoute = location.pathname.includes('/metadata');
+ *
+ * `includes('/system')` is true for any segment that merely STARTS with
+ * `system` — `system_log`, `system_setting`, `systems` — and likewise for
+ * `metadata` (`metadata_import`, `metadata-export`). `isSpecialRoute` feeds
+ * `requestedAppMissing`, so a mistyped app name plus such a segment made the
+ * "App not available" guard not fire, and the shell fell back to rendering the
+ * DEFAULT app's chrome with the near-miss segment taken as its `:objectName` —
+ * exactly what the comment above the fallback exists to prevent ("A normal
+ * unmatched appName must NOT silently render a DIFFERENT app").
+ *
+ * ## Measure before tightening
+ *
+ * The looseness is load-bearing for real URLs today, so this file pins the live
+ * input surface FIRST — every shape below was read off a route declaration or a
+ * navigation target, not guessed:
+ *
+ *   route tables    console/AppContent.tsx     `system/marketplace{,/installed,/:packageId}`
+ *                                              `metadata{,/_diagnostics,/:type,/:type/new,
+ *                                               /:type/:name,/:type/:name/history}`
+ *                                              `component/metadata/{directory,resource/*}`
+ *   host extraRoutes apps/console/AppContent    `system`, `system/{apps,profile,approvals,
+ *                                               ai-approvals,audit-log,settings,
+ *                                               settings/:namespace,objects,objects/:objectName,
+ *                                               metadata,metadata/:type,metadata/:type/:name}`
+ *                                              (`developer/*` and `docs/*` are in the same
+ *                                               fragment but flip NO flag — pinned below)
+ *   navigation      AppSidebar / UnifiedSidebar `/apps/setup/system{,/apps,/marketplace,
+ *                                               /metadata/object,/users,/organizations,
+ *                                               /roles,/settings}`
+ *                                              `/apps/setup/component/metadata/resource?type=`
+ *                   QuickActions / HomePage /   `/apps/setup/system/{metadata/object,marketplace,
+ *                   InboxPopover                approvals}`
+ *                   SystemRedirect (#3637)      bare `/system` -> `/apps/setup/system`
+ *
+ * In EVERY one of them `system` / `metadata` is a whole path segment, so a
+ * segment test keeps all of them true. That is the claim this file's first two
+ * describes exist to falsify.
+ *
+ * ## Where the two flags are actually load-bearing
+ *
+ * Not everywhere they are true. With a MATCHED app the flags change nothing
+ * (`activeApp` is the matched app either way). They decide behaviour in exactly
+ * two situations, and both are covered below:
+ *
+ *   1. the app segment does NOT resolve (stale bookmark, mistyped name) — the
+ *      flags choose between the default-app fallback and "App not available";
+ *   2. there is NO active app at all (a fresh, zero-app deployment) — the
+ *      guards at the `!activeApp` branches key on `isSystemRoute` /
+ *      `isMetadataRoute` directly (objectui#3590 / #3610).
+ *
+ * `/apps/setup/*` is a third family, but it rides `isSetupRoute`, which this
+ * change does not touch; it is pinned here only as a boundary.
+ *
+ * ## Scope of the stubs
+ *
+ * This file measures ROUTING — which guard wins, which route matches, what ends
+ * up on screen. Pages, the console chrome and the designer are stubbed; their
+ * internals are other files' subject. `ConsoleLayout` is stubbed as a probe that
+ * echoes `activeAppName`, which is what makes "silently rendered a DIFFERENT
+ * app" an assertable fact rather than an inference.
+ *
+ * `systemRoutesStub` transcribes the host fragment from
+ * `apps/console/src/AppContent.tsx` (`systemRoutes` + its `MetadataRedirect`).
+ * app-shell cannot import from `apps/` — different Vitest project, and the
+ * redirect is module-private — so the rewrite is copied verbatim, including its
+ * `prefix` regex, and this comment is the pointer back to the original.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useParams,
+} from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Mocks — everything that takes part in the routing decision (AppContent's
+// guards, its nested <Routes>, react-router's matching) stays real.
+// ---------------------------------------------------------------------------
+
+// AGENTS.md §测试纪律 — the lazy page modules are stubbed so no unbounded
+// `import()` races a bounded `findBy` window.
+vi.mock('../../views/metadata-admin', () => ({
+  MetadataDirectoryPage: () => <div data-testid="metadata-directory-page">directory</div>,
+  StudioHomePage: () => <div data-testid="studio-home-page">studio</div>,
+  MetadataResourceListPage: () => {
+    const { type } = useParams<{ type?: string }>();
+    return <div data-testid="metadata-resource-list-page">{type}</div>;
+  },
+  MetadataResourceEditPage: () => <div data-testid="metadata-resource-edit-page" />,
+  MetadataResourceHistoryPage: () => <div data-testid="metadata-resource-history-page" />,
+  MetadataDiagnosticsPage: () => <div data-testid="metadata-diagnostics-page" />,
+}));
+
+vi.mock('../marketplace/MarketplacePage', () => ({
+  MarketplacePage: () => <div data-testid="marketplace-page">marketplace</div>,
+}));
+vi.mock('../marketplace/MarketplaceInstalledPage', () => ({
+  MarketplaceInstalledPage: () => <div data-testid="marketplace-installed-page" />,
+}));
+vi.mock('../marketplace/MarketplacePackagePage', () => ({
+  MarketplacePackagePage: () => <div data-testid="marketplace-package-page" />,
+}));
+
+vi.mock('@object-ui/plugin-designer', () => ({
+  CreateAppPage: () => <div data-testid="create-app-page">create app</div>,
+  EditAppPage: () => <div data-testid="edit-app-page" />,
+  DashboardDesignPage: () => <div data-testid="dashboard-design-page" />,
+}));
+
+/**
+ * The probe that makes the bug visible: it reports WHICH app's shell rendered.
+ * The real `ConsoleLayout` drags in the whole console chrome (sidebar, header,
+ * chat dock) — none of it part of this question.
+ */
+vi.mock('../../layout/ConsoleLayout', () => ({
+  ConsoleLayout: ({ activeAppName, children }: { activeAppName?: string; children?: React.ReactNode }) => (
+    <div data-testid="console-layout" data-active-app={activeAppName}>
+      {children}
+    </div>
+  ),
+}));
+vi.mock('../../chrome/CommandPalette', () => ({ CommandPalette: () => null }));
+vi.mock('../../chrome/KeyboardShortcutsDialog', () => ({ KeyboardShortcutsDialog: () => null }));
+vi.mock('../../chrome/OnboardingWalkthrough', () => ({ OnboardingWalkthrough: () => null }));
+
+/** Echoes `:objectName` — the near-miss segment is taken as an object name. */
+vi.mock('../../views/ObjectView', () => ({
+  ObjectView: () => {
+    const { objectName } = useParams<{ objectName?: string }>();
+    return <div data-testid="object-view">{objectName}</div>;
+  },
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+  }),
+}));
+
+vi.mock('@object-ui/auth', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAuth: () => ({
+    user: null,
+    getAuthConfig: async () => ({ features: {} }),
+    activeOrganization: null,
+  }),
+  useIsWorkspaceAdmin: () => false,
+}));
+
+const dataSourceStub = {
+  onConnectionStateChange: () => () => {},
+  getConnectionState: () => 'connected',
+};
+vi.mock('../../providers/AdapterProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => dataSourceStub,
+}));
+
+/**
+ * Two published apps, one of them the default. The default is what a broken
+ * `requestedAppMissing` falls back to, so `crm` is the app that must NEVER
+ * appear for a `/apps/<mistyped>/…` URL.
+ */
+const APPS = [
+  { name: 'crm', label: 'CRM', isDefault: true, navigation: [] },
+  { name: 'sales', label: 'Sales', navigation: [] },
+];
+
+const refreshMetadata = vi.fn(async () => {});
+let metadataApps: unknown[] = APPS;
+vi.mock('../../providers/MetadataProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useMetadata: () => ({
+    apps: metadataApps,
+    objects: [],
+    loading: false,
+    // `undefined` — no bucket preloading to await, so the shell is ready on
+    // first render (mirrors a host that ships metadata eagerly).
+    ensureType: undefined,
+    error: null,
+    refresh: refreshMetadata,
+  }),
+}));
+
+import { AppContent } from '../AppContent';
+
+/** Reports the live URL so a redirect chain is visible as a URL, not just a screen. */
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="pathname">{location.pathname}</div>;
+}
+
+/**
+ * VERBATIM transcription of `apps/console/src/AppContent.tsx`'s
+ * `MetadataRedirect` — the `system/metadata/*` legs of `systemRoutes`. Keep the
+ * regex and the target construction identical to the original.
+ */
+function MetadataRedirectStub() {
+  const { metadataType, itemName } = useParams<{ metadataType?: string; itemName?: string }>();
+  const location = useLocation();
+  const prefix = location.pathname.replace(/\/(system\/)?metadata(\/.*)?$/, '');
+  const base = `${prefix}/component/metadata/resource`;
+  const target = !metadataType
+    ? `${prefix}/component/metadata/directory`
+    : itemName
+      ? `${base}/${itemName}?type=${metadataType}`
+      : `${base}?type=${metadataType}`;
+  return <Navigate to={target} replace />;
+}
+
+/**
+ * The host's fragment, reduced to the entries this file depends on.
+ * `apps/console/src/AppContent.tsx` passes the SAME fragment to both
+ * `extraRoutes` and `extraRoutesNoApp`, so both are wired below.
+ */
+const systemRoutesStub = (
+  <>
+    <Route path="system" element={<div data-testid="system-hub-page">system hub</div>} />
+    <Route path="system/settings" element={<div data-testid="system-settings-page">settings</div>} />
+    <Route path="system/audit-log" element={<div data-testid="system-audit-log-page">audit</div>} />
+    <Route path="system/metadata" element={<MetadataRedirectStub />} />
+    <Route path="system/metadata/:metadataType" element={<MetadataRedirectStub />} />
+    <Route path="system/metadata/:metadataType/:itemName" element={<MetadataRedirectStub />} />
+    <Route path="developer" element={<div data-testid="developer-hub-page">developer</div>} />
+    <Route path="docs" element={<div data-testid="docs-page">docs</div>} />
+  </>
+);
+
+/** The reference host's route tree — mirrors `apps/console/src/App.tsx`. */
+function renderConsoleAt(initialUrl: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <LocationProbe />
+      <Routes>
+        <Route
+          path="/apps/:appName/*"
+          element={<AppContent extraRoutes={systemRoutesStub} extraRoutesNoApp={systemRoutesStub} />}
+        />
+        <Route path="/" element={<div data-testid="root-landing">landing</div>} />
+        <Route path="/home" element={<div data-testid="home-launcher">home</div>} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const pathname = () => screen.getByTestId('pathname').textContent;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  metadataApps = APPS;
+});
+
+describe('AppContent pseudo-routes — live input surface stays special (objectui#3638)', () => {
+  /**
+   * Situation 1: the app segment does not resolve. This is where the flags
+   * decide, and it is the shape a stale bookmark or a renamed/uninstalled app
+   * produces. Every URL here must keep falling back to the default app.
+   */
+  it.each([
+    // [url, page testid, resulting pathname]
+    ['/apps/ghost/system/marketplace', 'marketplace-page', '/apps/ghost/system/marketplace'],
+    ['/apps/ghost/system/marketplace/installed', 'marketplace-installed-page', '/apps/ghost/system/marketplace/installed'],
+    ['/apps/ghost/system/marketplace/acme.crm', 'marketplace-package-page', '/apps/ghost/system/marketplace/acme.crm'],
+    ['/apps/ghost/system', 'system-hub-page', '/apps/ghost/system'],
+    ['/apps/ghost/system/settings', 'system-settings-page', '/apps/ghost/system/settings'],
+    ['/apps/ghost/system/audit-log', 'system-audit-log-page', '/apps/ghost/system/audit-log'],
+    ['/apps/ghost/metadata', 'metadata-directory-page', '/apps/ghost/metadata'],
+    ['/apps/ghost/metadata/_diagnostics', 'metadata-diagnostics-page', '/apps/ghost/metadata/_diagnostics'],
+    ['/apps/ghost/metadata/object/sys_user', 'metadata-resource-edit-page', '/apps/ghost/metadata/object/sys_user'],
+    // The legacy aliases redirect onto the canonical `metadata/:type` route
+    // (declared in this same branch) — the pathname pins the hop's direction.
+    ['/apps/ghost/component/metadata/resource?type=datasource', 'metadata-resource-list-page', '/apps/ghost/metadata/datasource'],
+    ['/apps/ghost/component/metadata/directory', 'metadata-directory-page', '/apps/ghost/metadata'],
+    // Two-hop: host rewrite (`system/metadata/:type`) -> shell alias -> canonical.
+    ['/apps/ghost/system/metadata/object', 'metadata-resource-list-page', '/apps/ghost/metadata/object'],
+    // Control — `isCreateAppRoute` is an `endsWith` test and is NOT changed.
+    ['/apps/ghost/create-app', 'create-app-page', '/apps/ghost/create-app'],
+  ])('unresolved app segment keeps the default-app fallback for %s', async (url, testid, expected) => {
+    renderConsoleAt(url);
+
+    expect(await screen.findByTestId(testid)).toBeInTheDocument();
+    expect(pathname()).toBe(expected);
+    // It fell back to the DEFAULT app, which is the documented behaviour for a
+    // pseudo-route (and the whole reason the flags exist).
+    expect(screen.getByTestId('console-layout')).toHaveAttribute('data-active-app', 'crm');
+    expect(screen.queryByTestId('app-not-available-retry')).not.toBeInTheDocument();
+  });
+
+  /**
+   * `/apps/setup/*` rides `isSetupRoute`, untouched by this change — pinned as
+   * the boundary of the two flags, not as their coverage.
+   */
+  it.each([
+    ['/apps/setup/system', 'system-hub-page'],
+    ['/apps/setup/system/metadata/object', 'metadata-resource-list-page'],
+    ['/apps/setup/component/metadata/resource?type=datasource', 'metadata-resource-list-page'],
+    ['/apps/setup/developer', 'developer-hub-page'],
+    ['/apps/setup/docs', 'docs-page'],
+  ])('the /apps/setup family is unaffected: %s', async (url, testid) => {
+    renderConsoleAt(url);
+
+    expect(await screen.findByTestId(testid)).toBeInTheDocument();
+    expect(screen.getByTestId('console-layout')).toHaveAttribute('data-active-app', 'crm');
+  });
+
+  /** A matched app resolves on its own — the flags change nothing here. */
+  it.each([
+    ['/apps/crm/system/marketplace', 'marketplace-page'],
+    ['/apps/crm/metadata/object', 'metadata-resource-list-page'],
+    ['/apps/sales/system/settings', 'system-settings-page'],
+  ])('a matched app segment renders its own shell: %s', async (url, testid) => {
+    renderConsoleAt(url);
+
+    expect(await screen.findByTestId(testid)).toBeInTheDocument();
+    const expectedApp = url.split('/')[2];
+    expect(screen.getByTestId('console-layout')).toHaveAttribute('data-active-app', expectedApp);
+  });
+});
+
+describe('AppContent pseudo-routes — zero-app deployment (objectui#3638)', () => {
+  /**
+   * Situation 2: with no active app the `!activeApp` guards key on
+   * `isSystemRoute` / `isMetadataRoute` directly — this is the branch
+   * objectui#3590 and #3610 built. A flag that stopped firing here would send
+   * these URLs to the "no apps configured" screen instead.
+   */
+  it.each([
+    ['/apps/setup/system', 'system-hub-page'],
+    ['/apps/setup/system/marketplace', 'marketplace-page'],
+    ['/apps/setup/metadata', 'metadata-directory-page'],
+    ['/apps/setup/metadata/object', 'metadata-resource-list-page'],
+    ['/apps/setup/component/metadata/resource?type=datasource', 'metadata-resource-list-page'],
+    ['/apps/setup/create-app', 'create-app-page'],
+  ])('with zero apps %s still reaches the pseudo-route branch', async (url, testid) => {
+    metadataApps = [];
+    renderConsoleAt(url);
+
+    expect(await screen.findByTestId(testid)).toBeInTheDocument();
+    // Not the "no apps configured" empty state, and not a bounce to the host.
+    expect(screen.queryByTestId('create-first-app-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('root-landing')).not.toBeInTheDocument();
+  });
+});
+
+describe('AppContent pseudo-routes — a near-miss segment no longer hijacks another app (objectui#3638)', () => {
+  /**
+   * The defect itself. Each segment merely STARTS with `system` / `metadata`;
+   * none of them is a pseudo-route. Before the fix `isSpecialRoute` was true,
+   * `requestedAppMissing` was therefore false, and the shell rendered the
+   * DEFAULT app (`crm`) with the segment as its `:objectName`.
+   */
+  it.each([
+    '/apps/ghost/system_log',
+    '/apps/ghost/system_setting',
+    '/apps/ghost/systems',
+    '/apps/ghost/metadata_import',
+    '/apps/ghost/metadata_log',
+    '/apps/ghost/metadata-export',
+  ])('%s reports "App not available" instead of rendering the default app', async (url) => {
+    renderConsoleAt(url);
+
+    expect(await screen.findByTestId('app-not-available-retry')).toBeInTheDocument();
+    expect(screen.getByText('App not available')).toBeInTheDocument();
+    // The three things that must NOT be on screen: another app's chrome, that
+    // app's object page for the near-miss segment, and the misleading
+    // "no apps configured" screen (there ARE apps).
+    expect(screen.queryByTestId('console-layout')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('object-view')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('create-first-app-btn')).not.toBeInTheDocument();
+    // The URL is left alone — no silent rewrite onto the wrong app.
+    expect(pathname()).toBe(url);
+  });
+
+  it('a deeper near-miss URL is judged the same way', async () => {
+    // `system_log/record/abc` — the near-miss is still the first segment, and
+    // the substring test was equally true for the whole path.
+    renderConsoleAt('/apps/ghost/system_log/record/abc123');
+
+    expect(await screen.findByTestId('app-not-available-retry')).toBeInTheDocument();
+    expect(screen.queryByTestId('console-layout')).not.toBeInTheDocument();
+  });
+
+  it('a near-miss under a REAL app still renders that app (the flags are not a filter)', async () => {
+    // Guard against over-tightening: `system_log` under an app that exists is
+    // an ordinary object route and must keep working. `requestedAppMissing`
+    // never applied here — `matchedApp` is set — and this pins that the change
+    // did not turn the flags into a segment allow-list.
+    renderConsoleAt('/apps/crm/system_log');
+
+    expect(await screen.findByTestId('object-view')).toHaveTextContent('system_log');
+    expect(screen.getByTestId('console-layout')).toHaveAttribute('data-active-app', 'crm');
+  });
+
+  it('MEASUREMENT: with ZERO apps a near-miss URL now takes the "no apps configured" screen', async () => {
+    // Knock-on, recorded rather than designed. In a zero-app deployment
+    // `/apps/setup/system_log` used to slip into the pseudo-route branch and
+    // hit its catch-all ("Page not found"); a segment test drops it into the
+    // `!activeApp` guard above, i.e. the same screen
+    // `/apps/setup/no-such-page` has always produced (pinned in
+    // AppContent.noAppComponentRoutes.test.tsx). Both screens are honest; the
+    // change is that a `system`-prefixed typo is no longer a special case.
+    metadataApps = [];
+    renderConsoleAt('/apps/setup/system_log');
+
+    expect(await screen.findByTestId('create-first-app-btn')).toBeInTheDocument();
+    expect(screen.queryByText('Page not found')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #3638

## 问题

`AppContent` 在决定「渲染哪个 app」之前先判断 URL 是不是内建伪路由。三个开关里有两个是**子串**判断:

```
const isSystemRoute   = location.pathname.includes('/system');
const isMetadataRoute = location.pathname.includes('/metadata');
```

`includes('/system')` 对任何**以 `system` 开头的段**都为真(`system_log` / `system_setting` / `systems`),`metadata` 同理(`metadata_import` / `metadata-export`)。`isSpecialRoute` 喂给 `requestedAppMissing`,于是 `/apps/{拼错的app名}/system_log`:

1. `matchedApp` 为 undefined;
2. `isSystemRoute` 被 `system_log` 误命中 → `isSpecialRoute` 为真;
3. `requestedAppMissing` 因此为 false,「App not available」守卫不触发;
4. `activeApp` 回退成**默认 app**,渲染它的 shell,并把 `system_log` 当作该 app 下的 `:objectName`。

用户看到的是**另一个 app 的界面**,没有任何提示说所请求的 app 不存在 —— 正是 fallback 上方那段注释("A normal unmatched appName must NOT silently render a DIFFERENT app")要防的事。

## 改法

切**路径段**判断,不是正则:

```
const pathSegments = location.pathname.split('/');
const isCreateAppRoute = location.pathname.endsWith('/create-app');   // 不动
const isSystemRoute = pathSegments.includes('system');
const isMetadataRoute = pathSegments.includes('metadata');
```

选段判断而不是 `/\/system(\/|$)/` 的理由:本文件相邻的 `isSetupRoute` 已经是 `=== / startsWith` 的字面量比较风格,全文件没有第二处路由正则;段判断读起来即是「某一段就叫 system」,与 issue 里三条伪路由的语义一字对应。`isCreateAppRoute` 的 `endsWith` **未改动**(它判的是末段,本来就没有这个歧义)。

顺带把 no-app 分支里一句已经过时的注释("a substring test on `/metadata`")改写为段判断的说法。

## 先量后收:今天依赖宽松判断的真实输入面

以**路由声明 + 导航目标**为准枚举(grep `path=` / `navigate(` / `url:` / `href:`),不臆测。逐条都写成了「收紧后仍为真」的回归断言:

| # | 输入 | 来源(file) | `system`/`metadata` 是否整段 | 收紧后 |
|---|---|---|---|---|
| 1 | `/apps/{app}/system/marketplace{,/installed,/:packageId}` | `console/AppContent.tsx` 路由表(两个分支都声明) | 是 | 仍为真 ✅ |
| 2 | `/apps/{app}/metadata{,/_diagnostics,/:type,/:type/new,/:type/:name,/:type/:name/history}` | `console/AppContent.tsx` 路由表 | 是 | 仍为真 ✅ |
| 3 | `/apps/{app}/component/metadata/{directory,resource/*}`(#3610 的别名,`?type=` 在 query 上不参与判断) | `console/AppContent.tsx` 两个分支 | 是(第 3 段) | 仍为真 ✅ |
| 4 | `/apps/{app}/system`、`system/{apps,profile,approvals,ai-approvals,audit-log,settings,settings/:namespace}` | 宿主 `apps/console/src/AppContent.tsx` 的 `extraRoutes` | 是 | 仍为真 ✅ |
| 5 | `/apps/{app}/system/{objects,objects/:objectName,metadata,metadata/:type,metadata/:type/:itemName}`(legacy → 引擎的两跳重写) | 同上 `systemRoutes` + `MetadataRedirect` | 是 | 仍为真 ✅ |
| 6 | 侧栏 `sys-*` 簇:`/apps/setup/system{,/apps,/marketplace,/users,/organizations,/roles,/settings}`、`/apps/setup/system/metadata/object`、`/apps/setup/component/metadata/resource?type=datasource` | `AppSidebar.tsx` / `UnifiedSidebar.tsx` | 是 | 仍为真 ✅ |
| 7 | `QuickActions` / `HomePage` / `InboxPopover`:`/apps/setup/system/{metadata/object,marketplace,approvals}` | 各自文件 | 是 | 仍为真 ✅ |
| 8 | 裸 `/system` 书签经 `SystemRedirect`(#3637)落到 `/apps/setup/system` | `console/SystemRedirect` | 是 | 仍为真 ✅ |
| 9 | 宿主 `extraRoutes` 的 `developer{,/api-console,/flow-runs,/public-forms,/integrations}`、`docs{,/:slug,/:slug/:name}` | `apps/console/src/AppContent.tsx` | **不含** system/metadata,今天就不翻这两个 flag | 不受影响(已钉) |
| 10 | `/apps/setup{,/**}` 整族 | `isSetupRoute` | 走 `isSetupRoute`,与本 PR 无关 | 不受影响(已钉) |

**结论:今天没有任何一条活路由把 `system` / `metadata` 写成段的前缀**,所以段判断不黑洞任何一条。第 9、10 行是边界,专门钉住「本 PR 没有顺手改它们」。

### 两个 flag 到底在哪里承重

不是「为真的地方」都承重。**app 段能匹配上时两个 flag 什么都不改变**(`activeApp` 已由 `matchedApp` 决定)。它们只在两种情形下决定行为,测试两种都覆盖:

- **A. app 段解析不到**(书签失效 / 拼错):flag 决定「回退默认 app」还是「App not available」;
- **B. 完全没有 active app**(零应用部署):`:568` 与 `:616` 两个 `!activeApp` 守卫**直接**读 `isSystemRoute` / `isMetadataRoute`(#3590 / #3610 建的那条分支)。

## 消费面行为矩阵(行号以本 PR 基线实测)

`isSpecialRoute` 的消费点:`:198`(activeApp 回退)、`:207`(`requestedAppMissing`);`requestedAppMissing` 再被 `:527`(preview 空态)与 `:547`(App not available)消费;`:568`(零应用空态)与 `:616`(零应用伪路由分支)直接读两个 flag。

| 输入 | apps | 修前 flag | 修前屏幕 | 修后 flag | 修后屏幕 |
|---|---|---|---|---|---|
| `/apps/ghost/system_log` | 有(crm 默认) | isSystemRoute=true | **crm 的 shell + ObjectView(system_log)** ← bug | false | 「App not available」(`:547`) |
| `/apps/ghost/metadata_import` | 有 | isMetadataRoute=true | **crm 的 shell + ObjectView** ← bug | false | 「App not available」(`:547`) |
| `/apps/ghost/system_log/record/abc123` | 有 | true | crm 的 shell | false | 「App not available」 |
| `/apps/crm/system_log`(app 存在) | 有 | true | crm + ObjectView(system_log) | false | **不变** — crm + ObjectView(`matchedApp` 命中,flag 不参与) |
| `/apps/ghost/system/marketplace` 等表 1–7 全部 | 有 | true | 回退默认 app 渲染该伪路由 | true | **不变** |
| 表 1–7 全部 | 零 | true | `:616` 伪路由分支 | true | **不变** |
| `/apps/setup/system_log` | 零 | isSystemRoute=true | `:616` 分支的 catch-all →「Page not found」 | false | 「No Apps Configured」(`:568`) ← 见下 |

最后一行是**实测出来的连带变化,不是设计目标**:零应用下 `/apps/setup/system_log` 这种「以 system 开头的臆造 URL」从 404 变成空态。两块屏幕都不撒谎,变化在于 `system` 前缀的错字不再是特例 —— 它现在和 `/apps/setup/no-such-page` 落到同一块屏幕(那条已被 `AppContent.noAppComponentRoutes.test.tsx` 的 MEASUREMENT 用例钉住)。已在新测试里以 `MEASUREMENT:` 用例原样钉住并写明原委。

## 逆向验证(先预测,后跑)

预测写在改代码之前:

- **P1/P2(红)**:近似段族(`system_log` / `system_setting` / `systems` / `metadata_import` / `metadata_log` / `metadata-export` + 深层 `system_log/record/abc123`)7 条断言在**未改动的 main 上必须红**,且红的形态是「渲染了 crm 的 shell」,不是别的。
- **P3(绿)**:表 1–10 的回归断言在**未改动的 main 上必须全绿** —— 它们编码的是今天的行为,若有一条红,说明我把输入面量错了。
- **P4(红→绿)**:零应用连带那条在 main 上红(修前是 Page not found)、修后绿。
- **P5**:改后 app-shell 全量绿(#3630/#3636/#3637 刚落的测试都在)。

跑出来与预测一致。**修前**(未改 `AppContent.tsx`,只加测试):

```
Tests  8 failed | 28 passed (36)
```

8 红正是 P1/P2 的 7 条 + P4 的 1 条;28 绿正是 P3 的全部回归断言。修前失败现场直接把 bug 的形态打印了出来 —— `/apps/ghost/system_log` 渲染的是:

```
data-active-app="crm"
data-testid="console-layout"
  ...
  data-testid="object-view"   (内容: system_log)
```

**修后**:

```
Tests  36 passed (36)
```

## 测试证据

```
$ pnpm exec vitest run packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx
 Test Files  1 passed (1)
      Tests  36 passed (36)

$ pnpm exec vitest run packages/app-shell            # 全量
 Test Files  293 passed (293)
      Tests  2581 passed | 1 skipped (2582)

$ pnpm exec vitest run apps/console                  # 宿主(extraRoutes 的声明方)
 Test Files  23 passed (23)
      Tests  212 passed (212)

$ pnpm --filter @object-ui/app-shell type-check      # 先 build 依赖(全新 worktree)
 (无输出,通过)

$ pnpm --filter @object-ui/app-shell lint
 ✖ 2205 problems (0 errors, 2205 warnings)           # 全部为既存 warning;新增文件 eslint 零输出

$ node scripts/check-control-bytes.mjs
 ✅ OK (scanned 3661 tracked text file(s))
```

新测试文件按「消费半径」扫过:两个 flag 只在 `AppContent` 内被读,但它们服务的路由由**宿主** `apps/console` 声明,所以宿主那 23 个测试文件也跑了一遍。

## 文件面

- `packages/app-shell/src/console/AppContent.tsx` — 两行判断 + 注释
- `packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx` — 新增(36 条)
- `.changeset/pseudo-route-segment-flags-3638.md` — patch

未改动:`#3636` 的 `AppContent.noAppComponentRoutes.test.tsx`、`#3573`/`#3590` 的 `AppContent.noAppsCta.test.tsx`(只读不改,两者全绿)、导航侧文件、locale 包、`content/docs/releases/`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_