### PR TITLE
fix(console): 宿主重定向直发规范 metadata 路由,不再绕已废弃的 component/metadata 别名 (#3639)

### DIFF
--- a/.changeset/host-redirect-canonical-metadata-3639.md
+++ b/.changeset/host-redirect-canonical-metadata-3639.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/console': patch
+'@object-ui/app-shell': patch
+---
+
+Send the console host's legacy URL redirects straight to the canonical metadata-admin routes instead of routing them through the deprecated `component/metadata/resource` alias (objectui#3639).
+
+`apps/console`'s `ObjectRedirect` and `MetadataRedirect` rewrote `system/objects[/:name]` and `system/metadata[/:type[/:name]]` onto `…/component/metadata/resource[/:name]?type=:type`. app-shell declares that spelling as a legacy *alias*, not a page: its route element is `LegacyMetadataRedirect`, which immediately navigates on to `…/metadata/:type[/:name]`. Every one of those URLs therefore took two `<Navigate>` hops (plus a re-render) to reach a destination the host could name directly — and it was this indirection that carried `sys-objects` into the zero-app blank screen fixed in objectui#3610, since the alias was the leg that branch did not recognise.
+
+Both redirects now construct `…/metadata/:type[/:name]` (and `…/metadata` for the typeless directory arm) themselves. The endpoints are unchanged, byte for byte, including the alias hop's own percent-encoding of `:type` and its verbatim pass-through of `:name`; only the intermediate hop is gone. The alias routes stay declared exactly as they were — bookmarks, external links and the setup left-nav still arrive on them and are still forwarded — this change only stops the console feeding its own traffic through them.
+
+Also corrects four docblocks that described the alias as "the engine route", in `apps/console`'s two redirects and in app-shell's `datasource` resource registration and page. That wording is not merely stale: the objectui#3610 dispatch read this chain and concluded `component/metadata/resource` was the canonical spelling, which is the exact opposite of what the route table says.

--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -45,43 +45,68 @@ const DocsLayout = lazy(() => import('./pages/DocsLayout'));
 // available to every host (including framework/console).
 
 /**
- * Forwards legacy `system/objects/:objectName` URLs to the metadata-admin
- * engine's edit route, preserving the active-app prefix. The engine route is
- * `…/component/metadata/resource/<name>?type=object`.
+ * Forwards legacy `system/objects[/:objectName]` URLs to the metadata-admin
+ * engine, preserving the active-app prefix. The engine routes are the
+ * REST-style `…/metadata/object/:name` (edit) and `…/metadata/object` (list),
+ * declared by `DefaultAppContent` in `@object-ui/app-shell`.
+ *
+ * NOT `…/component/metadata/resource/:name?type=object` (objectui#3639).
+ * That spelling pre-dates the REST-style nesting and is no longer a page at
+ * all: app-shell declares it as a legacy *alias* whose element is
+ * `LegacyMetadataRedirect`, i.e. a second `<Navigate>` onto precisely the
+ * target built below. Emitting it here bought a redundant hop and, worse,
+ * documented the alias as if it were canonical. The alias route itself stays
+ * (bookmarks and external links still land on it) — we simply stop feeding it
+ * from our own code.
  */
 function ObjectRedirect() {
   const { objectName } = useParams<{ objectName?: string }>();
   const location = useLocation();
   const prefix = location.pathname.replace(/\/(system\/)?objects(\/.*)?$/, '');
   const target = objectName
-    ? `${prefix}/component/metadata/resource/${objectName}?type=object`
-    : `${prefix}/component/metadata/resource?type=object`;
+    ? `${prefix}/metadata/object/${objectName}`
+    : `${prefix}/metadata/object`;
   return <Navigate to={target} replace />;
 }
 
 /**
- * Forwards legacy `system/metadata/:metadataType[/:itemName]` URLs to the
- * metadata-admin engine. The legacy page-based editor was removed once the
- * server's `/api/v1/meta` endpoint started emitting JSON Schema per type,
- * letting the engine render every type generically.
+ * Forwards legacy `system/metadata[/:metadataType[/:itemName]]` URLs to the
+ * metadata-admin engine's own REST-style routes: `…/metadata` (directory),
+ * `…/metadata/:type` (one type's list), `…/metadata/:type/:name` (one item).
+ * The legacy page-based editor was removed once the server's `/api/v1/meta`
+ * endpoint started emitting JSON Schema per type, letting the engine render
+ * every type generically.
+ *
+ * Those really are the engine's routes now — unlike the `component/metadata/…`
+ * spelling this used to emit, which is itself a legacy alias that only
+ * `<Navigate>`s onto the same destinations (objectui#3639). Two notes on
+ * staying byte-identical to what that alias hop produced: `:type` is
+ * percent-encoded (the alias carried it through `?type=` and the alias hop
+ * encoded it back into the path), while `:name` is passed through verbatim
+ * (the alias hop forwarded its path tail untouched).
  */
 function MetadataRedirect() {
   const { metadataType, itemName } = useParams<{ metadataType?: string; itemName?: string }>();
   const location = useLocation();
   // Strip an optional leading `system/` too — legacy nav uses
-  // `…/system/metadata/:type`, and the engine route lives at the app root
-  // (`…/component/metadata/resource`), not under `system/`.
+  // `…/system/metadata/:type`, and the engine routes live at the app root
+  // (`…/metadata/…`), not under `system/`.
   const prefix = location.pathname.replace(/\/(system\/)?metadata(\/.*)?$/, '');
-  const base = `${prefix}/component/metadata/resource`;
+  const base = `${prefix}/metadata`;
   const target = !metadataType
-    ? `${prefix}/component/metadata/directory`
+    ? base
     : itemName
-      ? `${base}/${itemName}?type=${metadataType}`
-      : `${base}?type=${metadataType}`;
+      ? `${base}/${encodeURIComponent(metadataType)}/${itemName}`
+      : `${base}/${encodeURIComponent(metadataType)}`;
   return <Navigate to={target} replace />;
 }
 
-const systemRoutes = (
+// Exported for `__tests__/AppContent.legacyRedirects.test.tsx`, which mounts
+// this exact fragment in a bare `MemoryRouter` to measure the redirect chain.
+// Transcribing the routes into the test instead would let the copy drift from
+// the original — which is precisely how the `component/metadata/resource`
+// spelling survived here long after it stopped being canonical (objectui#3639).
+export const systemRoutes = (
   <>
     <Route path="system" element={<Suspense fallback={<LoadingScreen />}><SystemHubPage /></Suspense>} />
     <Route path="system/apps" element={<Suspense fallback={<LoadingScreen />}><AppManagementPage /></Suspense>} />

--- a/apps/console/src/__tests__/AppContent.legacyRedirects.test.tsx
+++ b/apps/console/src/__tests__/AppContent.legacyRedirects.test.tsx
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The console host's legacy URL redirects land on the CANONICAL metadata-admin
+ * routes in one hop, never on the deprecated alias (objectui#3639).
+ *
+ * ## What was wrong
+ *
+ * `ObjectRedirect` and `MetadataRedirect` rewrote onto
+ * `…/component/metadata/resource[/:name]?type=:type`. app-shell declares that
+ * spelling as a legacy *alias* — its route element is `LegacyMetadataRedirect`,
+ * which immediately `<Navigate>`s onto `…/metadata/:type[/:name]`. So every
+ * `system/metadata/*` and `system/objects/*` URL took two hops to a place the
+ * host could name directly, and both docblocks called the alias "the engine
+ * route", which is how the #3610 dispatch came to believe `component/…` was
+ * canonical (it is the opposite).
+ *
+ * ## What these tests measure
+ *
+ * `ChainRecorder` records every distinct location the router settles on, so the
+ * assertion is about the *chain*, not only its endpoint. Endpoint-only
+ * assertions cannot tell a one-hop rewrite from a two-hop one — both finish at
+ * `…/metadata/object` — which is exactly the property this issue is about.
+ *
+ * The route table below declares the canonical routes AND the alias routes as
+ * terminal probes. That is what makes the direction falsifiable: restore either
+ * redirect's old target and the alias probe renders, the canonical probe does
+ * not, and the recorded chain ends on `component/metadata/resource`.
+ *
+ * `systemRoutes` is imported from the module under test rather than transcribed
+ * here on purpose. app-shell's own `AppContent.noAppComponentRoutes.test.tsx`
+ * had to copy `MetadataRedirect` (it cannot import across Vitest projects) and
+ * annotated the copy "keep identical to the original" — a copy is exactly what
+ * this file must not become.
+ *
+ * ## Scope
+ *
+ * This measures the HOST's rewrite only. What app-shell then does with the
+ * alias (`LegacyMetadataRedirect`) is pinned by app-shell's own tests; the
+ * alias route is deliberately kept alive for bookmarks and external links, and
+ * nothing here asks for its removal.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation, useParams } from 'react-router-dom';
+
+import { systemRoutes } from '../AppContent';
+
+/**
+ * Records every distinct location the router settles on. `<Navigate replace>`
+ * re-renders the tree once per hop, so a two-hop chain shows up as three
+ * entries and a one-hop chain as two.
+ */
+function ChainRecorder({ sink }: { sink: string[] }) {
+  const location = useLocation();
+  const here = `${location.pathname}${location.search}`;
+  if (sink[sink.length - 1] !== here) sink.push(here);
+  return null;
+}
+
+/** Terminal probe: reports which route matched and with which params. */
+function Probe({ id }: { id: string }) {
+  const params = useParams();
+  return <div data-testid={id}>{JSON.stringify(params)}</div>;
+}
+
+/**
+ * The destinations both spellings compete for. `metadata/*` mirrors app-shell's
+ * canonical metadata-admin routes; `component/metadata/*` mirrors the legacy
+ * aliases it declares alongside them. Here both are terminal — this file asks
+ * *which one the host aims at*, not what the alias does afterwards.
+ */
+function renderAt(url: string): string[] {
+  const chain: string[] = [];
+  render(
+    <MemoryRouter initialEntries={[url]}>
+      <ChainRecorder sink={chain} />
+      <Routes>
+        <Route path="/apps/:appName">
+          {systemRoutes}
+          <Route path="metadata" element={<Probe id="canonical-directory" />} />
+          <Route path="metadata/:type" element={<Probe id="canonical-list" />} />
+          <Route path="metadata/:type/:name" element={<Probe id="canonical-item" />} />
+          <Route path="component/metadata/directory" element={<Probe id="alias-directory" />} />
+          <Route path="component/metadata/resource/*" element={<Probe id="alias-resource" />} />
+          <Route path="component/metadata/resource" element={<Probe id="alias-resource" />} />
+        </Route>
+        <Route path="*" element={<Probe id="unmatched" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return chain;
+}
+
+/** No alias route may appear anywhere in the chain, not merely at its end. */
+function expectNoAliasAnywhere(chain: string[]) {
+  expect(chain.some((entry) => entry.includes('component/metadata'))).toBe(false);
+  expect(screen.queryByTestId('alias-resource')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('alias-directory')).not.toBeInTheDocument();
+}
+
+describe('console host legacy redirects → canonical metadata routes (objectui#3639)', () => {
+  it('system/metadata/:type reaches metadata/:type in ONE hop', () => {
+    const chain = renderAt('/apps/x/system/metadata/object');
+
+    // The whole point: two entries, i.e. a single `<Navigate>`. Before the fix
+    // this was three, with the alias in the middle.
+    expect(chain).toEqual(['/apps/x/system/metadata/object', '/apps/x/metadata/object']);
+    expect(screen.getByTestId('canonical-list')).toHaveTextContent('"type":"object"');
+    expectNoAliasAnywhere(chain);
+  });
+
+  it('system/metadata/:type/:name reaches metadata/:type/:name in ONE hop', () => {
+    const chain = renderAt('/apps/x/system/metadata/object/account');
+
+    expect(chain).toEqual([
+      '/apps/x/system/metadata/object/account',
+      '/apps/x/metadata/object/account',
+    ]);
+    const probe = screen.getByTestId('canonical-item');
+    expect(probe).toHaveTextContent('"type":"object"');
+    expect(probe).toHaveTextContent('"name":"account"');
+    expectNoAliasAnywhere(chain);
+  });
+
+  it('bare system/metadata reaches the metadata directory in ONE hop', () => {
+    // The typeless arm used to aim at `component/metadata/directory`, the
+    // second alias — a different route from the resource one, same detour.
+    const chain = renderAt('/apps/x/system/metadata');
+
+    expect(chain).toEqual(['/apps/x/system/metadata', '/apps/x/metadata']);
+    expect(screen.getByTestId('canonical-directory')).toBeInTheDocument();
+    expectNoAliasAnywhere(chain);
+  });
+
+  it('system/objects/:objectName reaches metadata/object/:name in ONE hop', () => {
+    const chain = renderAt('/apps/x/system/objects/account');
+
+    expect(chain).toEqual(['/apps/x/system/objects/account', '/apps/x/metadata/object/account']);
+    const probe = screen.getByTestId('canonical-item');
+    expect(probe).toHaveTextContent('"type":"object"');
+    expect(probe).toHaveTextContent('"name":"account"');
+    expectNoAliasAnywhere(chain);
+  });
+
+  it('bare system/objects reaches the object list in ONE hop', () => {
+    const chain = renderAt('/apps/x/system/objects');
+
+    expect(chain).toEqual(['/apps/x/system/objects', '/apps/x/metadata/object']);
+    expect(screen.getByTestId('canonical-list')).toHaveTextContent('"type":"object"');
+    expectNoAliasAnywhere(chain);
+  });
+
+  it('the app prefix is preserved, not just stripped to the root', () => {
+    // `prefix` is cut with a regex off `location.pathname`; a mistake there is
+    // invisible in the single-segment cases above.
+    const chain = renderAt('/apps/my-app/system/metadata/datasource');
+
+    expect(chain).toEqual([
+      '/apps/my-app/system/metadata/datasource',
+      '/apps/my-app/metadata/datasource',
+    ]);
+    expectNoAliasAnywhere(chain);
+  });
+
+  it('MEASUREMENT: the endpoint is byte-identical to what the old two-hop produced', () => {
+    // Equivalence, not improvement: `LegacyMetadataRedirect` dropped
+    // `location.search` on its resource arm and the host never forwarded the
+    // incoming query either, so the old chain also arrived with a bare path.
+    // Preserving query/hash would be a real behaviour change and is NOT part of
+    // this issue — pinned here so a future reader can see the omission was
+    // measured rather than overlooked.
+    const chain = renderAt('/apps/x/system/metadata/object?keep=me#frag');
+
+    expect(chain[chain.length - 1]).toBe('/apps/x/metadata/object');
+    expect(chain).toHaveLength(2);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/datasource/DatasourceResourcePage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/datasource/DatasourceResourcePage.tsx
@@ -3,8 +3,13 @@
 /**
  * DatasourceResourcePage — the `datasource` metadata type's custom ListPage,
  * registered into the metadata-admin engine (`registerMetadataResource`) and
- * reached via the engine route `…/component/metadata/resource?type=datasource`
- * (and the setup left-nav "Datasources" item → `system/metadata/datasource`).
+ * reached via the engine route `…/metadata/datasource`.
+ *
+ * Two legacy spellings still arrive here, both as redirects onto that engine
+ * route rather than routes of their own (objectui#3639): the setup left-nav
+ * "Datasources" item points at `…/component/metadata/resource?type=datasource`
+ * (rewritten by `LegacyMetadataRedirect`), and the console host forwards
+ * `…/system/metadata/datasource` (rewritten by its own `MetadataRedirect`).
  *
  * datasource is a *side-effectful* metadata type: its records are managed by
  * the framework `datasource-admin` service (secret encryption + connection-pool

--- a/packages/app-shell/src/views/metadata-admin/datasource/register.ts
+++ b/packages/app-shell/src/views/metadata-admin/datasource/register.ts
@@ -5,9 +5,13 @@
  * metadata-admin engine. datasource is a *side-effectful* type (secret +
  * connection pool + introspection), so it ships a bespoke ListPage that talks
  * to the framework `datasource-admin` REST — but it lives inside the engine
- * (engine route + registry slot + shell), reachable from the setup left-nav
- * "Datasources" item and the `…/component/metadata/resource?type=datasource`
- * route, instead of a separate hand-written System page.
+ * (engine route + registry slot + shell), reachable at the engine route
+ * `…/metadata/datasource`, instead of a separate hand-written System page.
+ *
+ * The setup left-nav "Datasources" item still points at the older
+ * `…/component/metadata/resource?type=datasource` spelling. That is a legacy
+ * *alias*, not this engine route: it renders `LegacyMetadataRedirect`, which
+ * 302s onto `…/metadata/datasource` (objectui#3639).
  */
 
 import { registerMetadataResource } from '../registry';


### PR DESCRIPTION
Fixes #3639

## 前提复核(先证实,再动手)

issue 正文的行号在最新 `origin/main`(`54dd7ec1`)上**逐条命中**,前提成立:`apps/console/src/AppContent.tsx` 的 `ObjectRedirect`(:47-51 docblock / :52-60 实现)与 `MetadataRedirect`(:62-67 / :68-82)确实仍在改写到 `component/metadata/resource`,而 `packages/app-shell/src/console/AppContent.tsx` 把这个拼法声明为 `LegacyMetadataRedirect`(:775-776 有应用分支、:646-647 零应用分支),规范落点是 `metadata/:type[/:name]`。

## 改了什么

两个宿主重定向直接构造规范目标,不再喂别名:

| 入口 URL | 改前(两跳) | 改后(一跳) |
|---|---|---|
| `system/objects` | `component/metadata/resource?type=object` → `metadata/object` | `metadata/object` |
| `system/objects/:objectName` | `component/metadata/resource/:name?type=object` → `metadata/object/:name` | `metadata/object/:name` |
| `system/metadata` | `component/metadata/directory` → `metadata` | `metadata` |
| `system/metadata/:type` | `component/metadata/resource?type=:type` → `metadata/:type` | `metadata/:type` |
| `system/metadata/:type/:name` | `component/metadata/resource/:name?type=:type` → `metadata/:type/:name` | `metadata/:type/:name` |

**落点与旧的两跳逐字节等价**,这是刻意对齐 `LegacyMetadataRedirect` 的翻译逻辑得到的,不是巧合:

- `:type` 做 `encodeURIComponent` —— 别名跳自己就是这么做的(它从 `?type=` 读出再编码进 path)。旧写法把 `metadataType` 裸拼进 query,遇到含 `&` 的类型名会被 `URLSearchParams` 截断;现写法不会。对现实中的类型名(`object` / `datasource` …)两者恒等。
- `:name` / `:objectName` 原样透传 —— 别名跳把 path 尾巴原样接上,没有编码。保持一致,不顺手"修"。
- **query 与 hash 照旧丢弃** —— 别名跳的 resource 分支本来就不转发 `location.search`,宿主也从不转发入参 query,所以旧链路同样是光秃秃的 path 落地。保留这个行为并**专门写了一条测量用例钉住**,免得下一个读者以为是漏掉的。

另外订正四段把别名说成 "the engine route" 的 docblock:`apps/console` 两处 + `datasource/register.ts:9` + `DatasourceResourcePage.tsx:6`(裁决第 5 条)。这不是文字洁癖 —— #3610 的派发单正是顺着这句话推出"`component/...` 才是规范拼法"的,与路由表恰好相反。

## 生产端枚举(issue 的 ⚠️ 要求)

全仓 grep `component/metadata`,按**生成** / **声明接收** / **测试钉形态** / **注释**分类:

| 位置 | 类别 | 本 PR 处置 |
|---|---|---|
| `apps/console/src/AppContent.tsx:57-58`(ObjectRedirect) | 生产端 | ✅ 改 |
| `apps/console/src/AppContent.tsx:75-80`(MetadataRedirect) | 生产端 | ✅ 改 |
| `apps/console/src/pages/system/SystemHubPage.tsx:118`("Metadata" 卡片 → `directory`) | **生产端(第三处)** | 围栏外 → 立单 |
| `apps/console/src/pages/system/SystemHubPage.tsx:126`("Datasources" 卡片 → `resource?type=datasource`) | **生产端(第四处)** | 围栏外 → 立单 |
| `packages/app-shell/src/layout/AppSidebar.tsx:330`(`sys-datasources`) | **生产端(第五处)** | 围栏外(⛔ app-shell) → 立单 |
| `packages/app-shell/src/layout/UnifiedSidebar.tsx:336`(`sys-datasources`) | **生产端(第六处)** | 围栏外 → 立单 |
| `packages/app-shell/src/console/AppContent.tsx:646-647 / 775-776` | 路由声明(接收) | 不动(裁决第 3 条) |
| `packages/app-shell/src/console/AppContent.tsx:951-952`(`LegacyMetadataRedirect` docblock) | 声明侧文档 | 不动 —— 它的表述本来就是对的 |
| `packages/app-shell/src/layout/__tests__/systemNavSettingsTarget.test.tsx:162` | 测试钉形态 | 不动 |
| `packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx:169-171` | 测试内 `MetadataRedirect` **逐字转录副本** | 不动 → 立单(见下) |
| `packages/app-shell/src/services/componentRegistry.ts:28` | 注释(注册表键→路径**约定**的举例,非 URL 生产) | 不动 |
| `packages/app-shell/src/views/metadata-admin/ResourceRouter.tsx:63` | 注释(休眠分发器自述,属遮蔽议题) | 不动(另行分诊) |
| `datasource/register.ts:9`、`DatasourceResourcePage.tsx:6` | 注释 | ✅ 订正(裁决第 5 条) |

一共 **6 处生产端**,本 PR 修其中 2 处(围栏内),另 4 处按"越界即停"立单。它们与本 PR 的两处是同一机制(导航直接指向别名 → 多一跳),但分布在 `apps/console` 的 SystemHub 卡片与 `packages/app-shell` 的两个 sidebar,修法应当一次性统一决定,而不是拆成两半。

## 测试

新增 `apps/console/src/__tests__/AppContent.legacyRedirects.test.tsx`(7 例)。关键点是它**导入生产代码的 `systemRoutes` fragment**(为此把它 `export` 出来),而不是把路由抄一遍 —— 抄一份正是 `component/metadata/resource` 这个拼法能在此处存活这么久的原因。

`ChainRecorder` 记录路由**每一次**停靠的位置,所以断言针对的是**整条链**而非只有终点:只看终点无法区分一跳与两跳(都是 `metadata/object` 收尾),而一跳与否恰恰就是本单的全部内容。路由表里同时声明了规范路由与别名路由(都作为终端探针),这让方向可证伪。

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

### 逆向验证(先预测,后运行)

**预测的方向:红,且失败现场应指认"中间/落点仍是别名"。** 只回退两处 target 构造(docblock 与测试保持不动)后实跑:

```
 × system/metadata/:type reaches metadata/:type in ONE hop
 × system/metadata/:type/:name reaches metadata/:type/:name in ONE hop
 × bare system/metadata reaches the metadata directory in ONE hop
 × system/objects/:objectName reaches metadata/object/:name in ONE hop
 × bare system/objects reaches the object list in ONE hop
 × the app prefix is preserved, not just stripped to the root
 × MEASUREMENT: the endpoint is byte-identical to what the old two-hop produced
 Test Files  1 failed (1)
      Tests  7 failed (7)
```

七条全红,且每条 diff 都直接打印出别名:

```
+   "/apps/x/component/metadata/resource?type=object"
+   "/apps/x/component/metadata/resource/account?type=object"
+   "/apps/x/component/metadata/directory"
+   "/apps/my-app/component/metadata/resource?type=datasource"
```

方向与预测一致,无反转。

### 别名仍可达(裁决第 3 条的回归证据)

别名路由一行未动,证据是 `packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx` 全绿 —— 它直接以 `/apps/setup/component/metadata/resource?type=datasource` 起步并断言落到 `/apps/setup/metadata/datasource`:

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

顺带一提:该文件里那份 `MetadataRedirectStub` 是 `apps/console` `MetadataRedirect` 的逐字转录(注释明写 "keep identical to the original")。本 PR 之后它**不再逐字**,而且它的 `sys-objects` 用例现在测的是一条生产中已不存在的链路 —— 绿是因为 stub 自己仍走别名,不是因为生产代码走。属于"该整例替换而非重拼"的那一类,已立单,**未在此 PR 内改**(围栏外,且 #3638 在途于同一组件的测试面)。

### 其余门禁

```
pnpm vitest run --project "@object-ui/console"          → 24 files / 219 tests passed
pnpm vitest run packages/app-shell                      → 292 files / 2545 passed, 1 skipped
pnpm --filter @object-ui/console --filter @object-ui/app-shell type-check → Done / Done
pnpm --filter @object-ui/console lint                   → 0 errors(190 条既有 warning)
pnpm --filter @object-ui/app-shell lint                 → 0 errors(2205 条既有 warning)
node scripts/check-control-bytes.mjs                    → OK(3661 个文本文件)
```

`type-check` 首跑报了一片 `Cannot find module '@object-ui/*'` —— 是新 worktree 未构建依赖所致(AGENTS.md §9 陈旧产物陷阱的镜像),`pnpm --filter '@object-ui/app-shell^...' build` 之后即全绿,与本改动无关。

## 遮蔽关系测量(裁决第 6 条:只测量不动)

react-router 打分(静态段 10 / 动态段 3 / splat -2,`initialScore = 段数 + splat 罚分`):

| 路由 | 计算 | 得分 |
|---|---|---|
| `component/metadata/resource/*` | `4 - 2 + 10 + 10 + 10` | **32** |
| `component/:ns/:name/*` | `4 - 2 + 10 + 3 + 3` | **18** |

**修前 = 修后,完全没变。** 本 PR 的 diff 里 `packages/app-shell/src/console/AppContent.tsx` 零改动(改的只有 `datasource/` 下两个注释),路由声明、顺序、打分一行未动;打分是同一个 `Routes` 内的静态属性,与谁往这些 URL 发流量无关。所以注册表组件 `metadata:resource` 依旧被恒压,`MetadataResourceRouter` 依旧休眠。

本 PR 唯一改变的是**流量**:`apps/console` 不再把 `system/metadata/*` 与 `system/objects/*` 送进别名。别名仍由 sidebar 的 `sys-datasources`、SystemHub 两张卡片以及书签/外链喂着(见上面的枚举表),所以别名远未变成死路 —— 这也是保留它的理由本身。

一并确认 issue 评论区那条"不要以为 datasource 定制页也死了":`ResourceListPage.tsx:98-104` 的规范列表页自己查注册表(`getMetadataResource(type)?.ListPage`),所以 `metadata/datasource` 渲染的仍是 `DatasourceResourcePage`。休眠的只有 `MetadataResourceRouter` 这一层分发器。其处置(删除 vs 保留)按裁决另行分诊,本 PR 不碰。

## changeset

写了。判断依据:`.changeset/config.json` 的 `ignore` 只有 `@object-ui/example-*` 与 `@object-ui/site`,`@object-ui/console`(即 `apps/console`,`private` 未设、version 17.3.0)与 `@object-ui/app-shell` 都在 39 包 `fixed` 组内,会随组发布,因此**需要** changeset。按仓规标 `patch`,绝不标 `major`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_