### PR TITLE
fix(plugin-tree): 补上 package.json files 已声明、但仓库里不存在的 LICENSE (#3647)

### DIFF
--- a/packages/plugin-tree/LICENSE
+++ b/packages/plugin-tree/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ObjectQL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Fixes #3647

## 问题

`@object-ui/plugin-tree` 的 `package.json` 在 `files` 里点名要打包 `LICENSE`,但 `packages/plugin-tree/LICENSE` 根本不存在。npm 对 `files` 里缺失的条目是**静默跳过**的 —— 不报错、不警告,于是 `npm publish` 与 CI 一路绿灯,而每一个已发布的 tarball 都没有它自己 manifest 承诺要带的 MIT 许可证文本。

在 origin/main 上实测 39 个包(38 个可发布 + 1 个 private),plugin-tree 是**唯一**「声明了 LICENSE 却没有该文件」的包:

| 包 | `private` | `files` 是否含 LICENSE | 文件是否存在 |
| --- | --- | --- | --- |
| `plugin-tree` | false | ✅ 声明了 | ❌ 缺失 ← 本 PR |
| `react-runtime` / `sdui-parser` | false | ❌ 未声明(`files` 只有 `dist`) | ❌ |
| `vscode-extension` | true(不发 npm) | 无 `files` | ❌ |
| 其余 35 个 | false | ✅ | ✅ |

`react-runtime` / `sdui-parser` 属于打包**策略**问题(要不要给所有已发布包补 LICENSE),issue 正文已把它与本单分开,本 PR 不碰。

## 改动

只新增一个文件:`packages/plugin-tree/LICENSE`。

内容是仓根 `LICENSE` 的**逐字节副本**。先实测过一致性 —— 根 LICENSE 与 35 个兄弟包的 LICENSE 共 36 份,在 git 里是**同一个 blob**:

```
$ git ls-tree -r origin/main | grep -E 'LICENSE$' | awk '{print $3}' | sort | uniq -c
     36 cf2ca28574caca42deafdee0ea935fc2e2823427
```

即连 copyright 行(`Copyright (c) 2024 ObjectQL`)在内完全一致,不存在「多数形态 / 少数形态」的分歧。新增文件的 blob 哈希同为 `cf2ca28574caca42deafdee0ea935fc2e2823427`。

## 验收:`npm pack --dry-run` 前后对照

验收标准不是「文件存在」,而是**它确实进入 tarball 清单**。在 `packages/plugin-tree/` 下实测:

**修改前**(预测:清单无 LICENSE — 命中):

```
npm notice Tarball Contents
npm notice 21.9kB CHANGELOG.md
npm notice 1.7kB README.md
npm notice 1.9kB package.json
npm notice total files: 3
```

**修改后**(预测:LICENSE 进入清单 — 命中):

```
npm notice Tarball Contents
npm notice 21.9kB CHANGELOG.md
npm notice 1.1kB LICENSE
npm notice 1.7kB README.md
npm notice 1.9kB package.json
npm notice total files: 4
```

`total files` 3 → 4,`unpacked size` 25.5 kB → 26.5 kB。

两点说明,免得清单读起来有歧义:

1. **清单里没有 `dist/`**,是因为这是一棵全新 worktree、该包尚未构建。这不影响本次验收 —— npm 对 LICENSE 的收录与 `dist` 是否存在互相独立。
2. 作为对照,同样未构建的兄弟包 `plugin-timeline` 跑同一条命令,清单里是有 `1.1kB LICENSE` 的 —— 证明差异来自文件本身的有无,而不是命令或环境。

补充一条 npm 语义:`LICENSE` 属于 npm **无视 `files` 也总是收录**的文件之一,所以 `files` 里那条 `"LICENSE"` 声明本身是冗余但无害的;真正的修复就是把文件补上,不需要动 `package.json`(本 PR 也确实没动)。

## 关于 changeset:判定为不加,依据如下

1. **仓规明文**:AGENTS.md 第 151 行 —— 「功能改进(feature)需写 changeset;纯 bug 修复不需要」。本 PR 是纯打包缺陷修复。
2. **直接先例**:PR #3649(修 #3622)改了 7 个已发布包的 `README.md`,README 同样在各包 `files` 里、同样改变 tarball 内容,该 PR **未加 changeset**。
3. **修复不会被搁浅**:`.changeset/config.json` 把 39 个包放在同一个 `fixed` 组,任何一个 changeset 都会带着 plugin-tree 一起 bump 并重新发布。当前已有 16 个待发 changeset,下一次发版本就会把这份 LICENSE 带上 npm —— 不需要本 PR 自带 changeset 来触发。
4. 反过来,为补一个文件而新增 changeset,会让 39 个包整组 bump 一个版本,收益与代价不成比例。

历史上唯一一个新增 `packages/*/LICENSE` 的提交是仓库初始导入(`30ac2e1`,一次性加入全部文件),不构成单包补 LICENSE 的先例。

## 顺带发现(未在本 PR 处理,已另行开单)

- plugin-tree 的 `README.md` 是 38 个已发布包里唯一没有 `## License` 小节的 —— 也正因如此,#3622/#3649 那轮针对 `packages/*/README.md` 的死链扫描发现不了这个缺失(它连指向 `./LICENSE` 的链接都没有,自然没有死链可查)。
- 仓库没有任何门禁校验「`files` 里声明的条目在磁盘上真实存在」或「已发布包都带 LICENSE」。这正是本缺陷能长期静默存在的原因。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_