### PR TITLE
test(app-shell): 把 MetadataRedirectStub 同步回宿主实现,并用整链断言钉住转录真实性 (#3661)

### DIFF
--- a/packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx
@@ -35,9 +35,9 @@
  * redirect in the no-app branch that the with-app branch already declares, and
  * the alias lands on a route the no-app branch has had all along. No navigation
  * URL changes, and the alias keeps its single canonical destination. The
- * assertions below pin the resulting *pathname*, so a future change that made
- * `component/metadata/resource` render a second copy of the page instead of
- * redirecting would turn this file red.
+ * assertions below pin the resulting *pathname* AND the redirect chain that
+ * produced it, so both a `component/metadata/resource` that grew a second copy
+ * of the page and a silently changed number of hops turn this file red.
  *
  * ## Scope of the stubs
  *
@@ -47,11 +47,30 @@
  *
  * `systemRoutesStub` below transcribes the host fragment from
  * `apps/console/src/AppContent.tsx` (`systemRoutes` + its `MetadataRedirect`).
- * app-shell cannot import from `apps/` — different Vitest project, and the
- * redirect is a module-private function — so the rewrite is copied verbatim,
- * including its `prefix` regex, and this comment is the pointer back to the
- * original. It is the `sys-objects` leg of the chain: without it that URL's
- * two-hop route to the same dead end is invisible here.
+ * app-shell cannot import from `apps/` — a different Vitest project — so the
+ * rewrite is copied verbatim, including its `prefix` regex, and this comment is
+ * the pointer back to the original. It is the `sys-objects` leg of the chain:
+ * without it that URL's route into this branch is invisible here.
+ *
+ * ## Why the chain, not just the endpoint (objectui#3661)
+ *
+ * A transcription can go stale, and this one did. objectui#3658 re-pointed the
+ * host straight at the canonical routes; the copy here kept emitting the
+ * deprecated alias, so the `sys-objects` case went on measuring a two-hop chain
+ * that production had stopped producing. Nothing went red — the assertions
+ * pinned only the final pathname, and that is identical either way. Green, for
+ * a reason that no longer had anything to do with the code under test.
+ *
+ * So `renderConsoleAt` now returns every location the router settles on, and
+ * all four redirect cases assert that list exactly. A stub that drifts back
+ * onto the alias grows a third entry and fails, naming the alias in the diff.
+ * That is the only mechanism in this file capable of noticing.
+ *
+ * Measured, both directions. Re-pointing the stub at the alias fails exactly
+ * the two host-rewrite cases, and each diff adds exactly one line — the alias,
+ * in the middle, with the first and last entries untouched. That is the drift's
+ * whole signature, and precisely why an endpoint-only assertion could not see
+ * it.
  */
 
 import '@testing-library/jest-dom/vitest';
@@ -150,28 +169,52 @@ vi.mock('@object-ui/react', async (importOriginal) => ({
 
 import { AppContent } from '../AppContent';
 
-/** Reports the live URL so a redirect chain is visible as a URL, not just a screen. */
-function LocationProbe() {
+/**
+ * Reports the live URL so a redirect chain is visible as a URL, not just a
+ * screen, and records every distinct location the router settles on.
+ * `<Navigate replace>` re-renders the tree once per hop, so a one-hop rewrite
+ * shows up as two entries and a two-hop one as three — the difference this
+ * file's `sys-objects` case is about (objectui#3661).
+ */
+function LocationProbe({ sink }: { sink: string[] }) {
   const location = useLocation();
+  const here = `${location.pathname}${location.search}`;
+  if (sink[sink.length - 1] !== here) sink.push(here);
   return <div data-testid="pathname">{location.pathname}</div>;
 }
 
 /**
- * VERBATIM transcription of `apps/console/src/AppContent.tsx`'s `MetadataRedirect`
- * (the `system/metadata/*` legs of its `systemRoutes` fragment). Keep the regex
- * and the target construction identical to the original — this stub is what makes
- * the `sys-objects` hop measurable from inside app-shell.
+ * VERBATIM transcription of `apps/console/src/AppContent.tsx`'s
+ * `MetadataRedirect` (the `system/metadata/*` legs of its `systemRoutes`
+ * fragment), as it stands after objectui#3658 landed in `7883c0250`. Keep the
+ * regex and the target construction identical to the original — this stub is
+ * what makes the `sys-objects` hop measurable from inside app-shell.
+ *
+ * "Identical to the original" is a claim this file has to keep earning. Between
+ * `7883c0250` and objectui#3661 it was false: the host had been re-pointed at
+ * the canonical `…/metadata/:type` and this copy still built the deprecated
+ * `…/component/metadata/resource?type=:type`, so the `sys-objects` case
+ * measured a chain production no longer had. Re-syncing the copy is only half
+ * the repair; the other half is that the chain assertions below can now catch
+ * the next drift instead of staying green through it.
+ *
+ * Transcribed rather than imported because app-shell and `apps/console` are
+ * separate Vitest projects. objectui#3658 did `export` the host's `systemRoutes`
+ * (its own test imports the real fragment), so the module-private half of the
+ * original reason is gone — but the cross-project half stands, and whether the
+ * import is feasible at all is unmeasured. Until someone measures it, this stays
+ * a copy, and the copy stays pinned by the chain.
  */
 function MetadataRedirectStub() {
   const { metadataType, itemName } = useParams<{ metadataType?: string; itemName?: string }>();
   const location = useLocation();
   const prefix = location.pathname.replace(/\/(system\/)?metadata(\/.*)?$/, '');
-  const base = `${prefix}/component/metadata/resource`;
+  const base = `${prefix}/metadata`;
   const target = !metadataType
-    ? `${prefix}/component/metadata/directory`
+    ? base
     : itemName
-      ? `${base}/${itemName}?type=${metadataType}`
-      : `${base}?type=${metadataType}`;
+      ? `${base}/${encodeURIComponent(metadataType)}/${itemName}`
+      : `${base}/${encodeURIComponent(metadataType)}`;
   return <Navigate to={target} replace />;
 }
 
@@ -193,11 +236,17 @@ const systemRoutesStub = (
 /**
  * The reference host's route tree, reduced to the parts that decide this
  * question. Mirrors `apps/console/src/App.tsx`.
+ *
+ * Returns the redirect chain (see `LocationProbe`). It fills as the router
+ * navigates, so read it AFTER the `await findBy…` that lets the hops settle —
+ * the metadata-admin pages sit behind `React.lazy`, so nothing is final on the
+ * synchronous return.
  */
 function renderConsoleAt(initialUrl: string) {
-  return render(
+  const chain: string[] = [];
+  render(
     <MemoryRouter initialEntries={[initialUrl]}>
-      <LocationProbe />
+      <LocationProbe sink={chain} />
       <Routes>
         <Route path="/apps/:appName/*" element={<AppContent extraRoutesNoApp={systemRoutesStub} />} />
         <Route path="/" element={<div data-testid="root-landing">landing</div>} />
@@ -206,6 +255,7 @@ function renderConsoleAt(initialUrl: string) {
       </Routes>
     </MemoryRouter>,
   );
+  return chain;
 }
 
 const pathname = () => screen.getByTestId('pathname').textContent;
@@ -219,7 +269,12 @@ describe('AppContent — zero-app component/metadata destinations (objectui#3610
     // The white screen this issue is about. The URL passes `isMetadataRoute`
     // (substring `/metadata`) and so enters the no-`activeApp` branch, which
     // used to declare nothing matching `component/…` and had no catch-all.
-    renderConsoleAt('/apps/setup/component/metadata/resource?type=datasource');
+    //
+    // Unlike the two host-rewrite cases below, the alias here is the ENTRY, not
+    // an intermediate stop — the zero-app fallback sidebar's `sys-datasources`
+    // item still points straight at this spelling, so this chain is one this
+    // deployment really produces.
+    const chain = renderConsoleAt('/apps/setup/component/metadata/resource?type=datasource');
 
     const page = await screen.findByTestId('metadata-resource-list-page');
     expect(page).toBeInTheDocument();
@@ -229,34 +284,73 @@ describe('AppContent — zero-app component/metadata destinations (objectui#3610
     // The direction of the hop — `component/metadata/resource` is the ALIAS,
     // `metadata/:type` is canonical. Asserting the screen alone would stay
     // green if the alias grew a second copy of the page.
+    expect(chain).toEqual([
+      '/apps/setup/component/metadata/resource?type=datasource',
+      '/apps/setup/metadata/datasource',
+    ]);
     expect(pathname()).toBe('/apps/setup/metadata/datasource');
     // Not the "no apps configured" screen, and not bounced to the host landing.
     expect(screen.queryByTestId('create-first-app-btn')).not.toBeInTheDocument();
     expect(screen.queryByTestId('root-landing')).not.toBeInTheDocument();
   });
 
-  it('sys-objects: the /apps/setup/system/metadata/object detour reaches the same resource page', async () => {
+  it('sys-objects: /apps/setup/system/metadata/object reaches this branch\'s metadata/:type in ONE hop', async () => {
     // The non-obvious half, pinned on its own because it would regress
     // silently: this URL is rewritten by the HOST (`MetadataRedirect`) onto the
-    // legacy alias, which the shell then rewrites onto the canonical route.
-    // Three route tables, two redirects, zero apps.
-    renderConsoleAt('/apps/setup/system/metadata/object');
+    // canonical route, which the zero-app branch declares itself. Two route
+    // tables, one redirect, zero apps.
+    //
+    // It used to be two redirects — the host aimed at the legacy alias and the
+    // shell forwarded that on. objectui#3658 removed the middle stop; this case
+    // now measures what production actually does, and objectui#3661 is what it
+    // cost to notice that it had stopped doing so (the endpoint never moved, so
+    // nothing failed).
+    const chain = renderConsoleAt('/apps/setup/system/metadata/object');
 
     const page = await screen.findByTestId('metadata-resource-list-page');
     expect(page).toBeInTheDocument();
     expect(page).toHaveTextContent('object');
+    // Two entries, i.e. a single `<Navigate>`. The alias is not merely absent
+    // from the end of the chain — it is absent from the chain.
+    expect(chain).toEqual(['/apps/setup/system/metadata/object', '/apps/setup/metadata/object']);
+    expect(chain.some((entry) => entry.includes('component/metadata'))).toBe(false);
     expect(pathname()).toBe('/apps/setup/metadata/object');
     expect(screen.queryByTestId('root-landing')).not.toBeInTheDocument();
   });
 
-  it('the typeless legacy directory alias reaches the metadata directory', async () => {
+  it('the typeless host arm reaches the metadata directory in ONE hop', async () => {
     // `system/metadata` with no `:metadataType` takes `MetadataRedirect`'s other
-    // arm, onto `component/metadata/directory` — the second alias the with-app
-    // branch declares, and the second blank screen without it.
-    renderConsoleAt('/apps/setup/system/metadata');
+    // arm. That arm used to aim at `component/metadata/directory` — the second
+    // alias, and the second blank screen without it — and since objectui#3658
+    // aims at the canonical directory route directly.
+    const chain = renderConsoleAt('/apps/setup/system/metadata');
 
     expect(await screen.findByTestId('metadata-directory-page')).toBeInTheDocument();
+    expect(chain).toEqual(['/apps/setup/system/metadata', '/apps/setup/metadata']);
+    expect(chain.some((entry) => entry.includes('component/metadata'))).toBe(false);
     expect(pathname()).toBe('/apps/setup/metadata');
+  });
+
+  it('the legacy directory alias still resolves when entered directly', async () => {
+    // Coverage this file would otherwise have LOST to objectui#3661. The
+    // zero-app branch declares `component/metadata/directory` (objectui#3610);
+    // until #3658 the only thing that ever exercised it was the host stub's
+    // typeless arm, hopping through it on the way to `metadata`. Now that the
+    // host goes direct, that route has no other visitor: `pseudoRouteSegments`
+    // enters the directory alias only under `/apps/ghost/…`, which resolves to
+    // the DEFAULT app and therefore exercises the with-app branch's copy of the
+    // declaration, not this one.
+    //
+    // Bookmarks and `SystemHubPage`'s "Metadata" card still emit this URL, so
+    // the alias is live input, not a museum piece — entered directly here,
+    // exactly as `sys-datasources` above enters the resource alias.
+    const chain = renderConsoleAt('/apps/setup/component/metadata/directory');
+
+    expect(await screen.findByTestId('metadata-directory-page')).toBeInTheDocument();
+    expect(chain).toEqual(['/apps/setup/component/metadata/directory', '/apps/setup/metadata']);
+    expect(pathname()).toBe('/apps/setup/metadata');
+    expect(screen.queryByTestId('create-first-app-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('root-landing')).not.toBeInTheDocument();
   });
 
   it('an unmatched URL inside this branch renders "not found" instead of a blank screen', async () => {


### PR DESCRIPTION
Fixes #3661

## 前提复核(先证实,再动手)

issue 正文的行号与断言在最新 `origin/main`(`fe4d4da37`,含 `7883c0250`)上**逐条命中**,前提成立:

- `packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx:159-176` 的 `MetadataRedirectStub` docblock 自称 *"VERBATIM transcription … Keep the regex and the target construction identical to the original"*,而 target 构造仍是别名拼法;
- `apps/console/src/AppContent.tsx` 的 `MetadataRedirect` 自 `7883c0250` 起已改为直接构造 `…/metadata/:type[/:name]`;
- 二者确实已经不一致。

## 失真是**实测**出来的,不是从 diff 推出来的

动手前先给 `LocationProbe` 加了链记录,原样跑了一遍旧 stub,把三条链打了出来:

| 用例 | 旧 stub 下实测的链 | 跳数 |
|---|---|---|
| `sys-datasources` | `[component/metadata/resource?type=datasource, metadata/datasource]` | 1 |
| `sys-objects` | `[system/metadata/object, **component/metadata/resource?type=object**, metadata/object]` | **2** |
| typeless directory | `[system/metadata, **component/metadata/directory**, metadata]` | **2** |

两点比 issue 正文多出来的事实:

1. 链记录器**确实能看到中间站**(否则后面的逆向验证就是个空壳,红也红得没有意义);
2. 失真的不止 `sys-objects` **一条** —— typeless directory 那条同样在测一条生产中已不存在的两跳链。issue 只点名了前者。

## 改了什么

### 1. stub 同步(逐字转录恢复为真)

```
-  const base = `${prefix}/component/metadata/resource`;
+  const base = `${prefix}/metadata`;
   const target = !metadataType
-    ? `${prefix}/component/metadata/directory`
+    ? base
     : itemName
-      ? `${base}/${itemName}?type=${metadataType}`
-      : `${base}?type=${metadataType}`;
+      ? `${base}/${encodeURIComponent(metadataType)}/${itemName}`
+      : `${base}/${encodeURIComponent(metadataType)}`;
```

机器比对过:同步后 stub 函数体与宿主 `MetadataRedirect` 函数体**可执行代码逐字节一致**,唯一差异是宿主多带的三行注释(那三行 stub 改前也没有)。

docblock 改为注明转录对象路径、出处 commit(`7883c0250` / #3658),并明说「逐字」是一句**需要持续兑现**的声明 —— 它在 `7883c0250` 到 #3661 之间就是假的。

### 2. 整链断言(本单的防复发部分)

`LocationProbe` 升级为链记录器,`renderConsoleAt` 返回整条链,四条重定向用例改为 `toEqual` 整个数组。

这是必要的:旧断言只钉最终 pathname,而**一跳与两跳的终点逐字节相同**,所以 stub 失真时没有任何断言会红。整链断言是这个文件里唯一能发现这件事的机制。

### 3. 补一条用例,接住会被本 PR 删掉的覆盖

零应用分支的 `component/metadata/directory`(app-shell `AppContent.tsx:659`,#3610 加的)在改前的**唯一**运行者就是 stub 的 typeless 臂 —— 顺路经过。stub 改直达后,该路由在全仓将失去所有覆盖:`pseudoRouteSegments.test.tsx:299` 虽然直接进入该别名,但走的是 `/apps/ghost/…`,会回退到默认 app,跑的是**带 app 分支**那份声明,不是零应用分支这份。

所以补了一条直接进入的用例(手法与既有的 `sys-datasources` 一致 —— 别名作为入口而非中间站)。`SystemHubPage` 的 "Metadata" 卡片与书签今天仍在产出这个 URL,它是活输入。

## 推断兑现(issue 里那条**未实测**的推断)

#3639 的记录者标注了「方向 1 改完后该用例大概率仍绿,但**这一条我没有跑过**」。实测结论:**推断成立,仍绿。**

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

理由与记录者写的一致:零应用分支本来就声明了 `metadata` 与 `metadata/:type`,断言的落点 `/apps/setup/metadata/object` 逐字未变,变的只有到达它的路径(两跳变一跳)。

## 逆向验证(先预测,后运行)

**预测**:只把 stub 的 target 构造回退成别名(docblock 与断言保持不动),应当**恰好两条**用例转红 —— `sys-objects` 与 typeless host arm;`sys-datasources` 与新补的 directory 用例应当**保持绿**,因为它们自己就以别名为入口,stub 不在它们的路径上。红的形态应为链多出一个中间条目。

实跑:

```
 × sys-objects: /apps/setup/system/metadata/object reaches this branch's metadata/:type in ONE hop
 × the typeless host arm reaches the metadata directory in ONE hop
 Test Files  1 failed (1)
      Tests  2 failed | 5 passed (7)
```

两条,且 diff 各只多出**一行**:

```
  [
    "/apps/setup/system/metadata/object",
+   "/apps/setup/component/metadata/resource?type=object",
    "/apps/setup/metadata/object",
  ]

  [
    "/apps/setup/system/metadata",
+   "/apps/setup/component/metadata/directory",
    "/apps/setup/metadata",
  ]
```

方向与预测一致,无反转。

顺带,这两张 diff 本身就是**本单为什么会静默发生**的直接证据:两条链的**首尾条目完全没动**,只有中间多了一站。旧的「只断终点」断言在结构上就不可能红。

## 门禁

```
pnpm exec vitest run packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx
  → Test Files 1 passed / Tests 7 passed(改前 6 passed)

pnpm exec vitest run packages/app-shell/src/console/__tests__
  → Test Files 6 passed (6) / Tests 64 passed (64)

pnpm --workspace-concurrency=2 --filter @object-ui/app-shell type-check   → 通过(tsc --noEmit && tsc -p tsconfig.typetests.json)
pnpm exec eslint <该文件>                                                  → exit 0
node scripts/check-control-bytes.mjs                                      → OK(3669 个文本文件)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' <该文件>                          → 无
```

`type-check` 前先跑了 `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`(新 worktree 未构建依赖会报一片 `Cannot find module '@object-ui/*'`,AGENTS.md §9 陈旧产物陷阱的镜像)。

## changeset

**不写**,判断依据:本 PR 只改一个测试文件,零生产代码改动,对包的发布物与运行时行为没有任何影响,不属于用户可见变更。

## 越界发现(只报不改)

- **#3669** —— `AppContent.pseudoRouteSegments.test.tsx:218-233` 有**第二份** `MetadataRedirectStub`,同样自称逐字转录、同样在 #3658 后仍走别名,同样有两条用例在测已不存在的两跳链。同机制同来源,但**不同文件**,而本单的文件面被明确限定为单文件,故立单未改。已打 `finding`、未打 `pm:queue`(测试是绿的,无用户可撞),未认领。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_