### PR TITLE
fix(console): 把已退场的 system/{users,organizations,roles,positions} 四条 URL 声明为重定向,直达框架系统对象 (#3655)

### DIFF
--- a/.changeset/system-hub-routes-3655.md
+++ b/.changeset/system-hub-routes-3655.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/console': patch
+---
+
+Declare the retired `system/{users,organizations,roles,positions}` console URLs as redirects onto the framework-owned system objects (objectui#3655).
+
+`SystemHubPage`'s cards and both sidebars' `sys-*` cluster emit five `/apps/setup/system/…` targets. Four of them were real routes until `apps/console` was slimmed for third-party customisation, which deleted the bespoke wrapper pages because "these objects are now contributed by framework plugins … and resolved via the generic `/apps/setup/<object_name>` route" — but the producers were never retargeted and nothing redeclared the URLs. All five fell through to app-shell's tail, where the failure they got depended on how long the word was, because `ShorthandRecordRedirect` treats any URL-safe segment of 6+ characters as a record id:
+
+- `users` (5) and `roles` (5) rendered "Page not found".
+- `organizations` (13) and `positions` (9) were rewritten to `…/system/record/<word>` and rendered a record detail page for an object literally named `system` — the worse of the two, because it reads as a backend/data problem rather than a dead link.
+
+Each now forwards in one hop to the object the framework's own Setup navigation names: `sys_user`, `sys_organization` (the list entry — the record-scoped one needs a runtime `{current_org_id}` a static redirect cannot resolve), and `sys_position` for both `roles` and `positions` (ADR-0090 D3 renamed `sys_role` to `sys_position`, so the sidebar's "Roles" and the hub's "Positions" are one surface in two vocabularies). Same shape as the `system/objects` and `system/metadata` redirects beside them: the URL is translated, the deleted page is not resurrected, and the navigation producers are untouched.
+
+`system/permissions` is deliberately left as it was. The framework splits what this console calls "Permissions" into two Setup entries — `sys_capability` and `sys_permission_set` — and picking one here would silently commit every click and bookmark to a surface nobody chose. Its unchanged landing is pinned in the tests so the gap stays visible.

--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -101,6 +101,56 @@ function MetadataRedirect() {
   return <Navigate to={target} replace />;
 }
 
+/**
+ * Forwards the retired `system/{users,organizations,roles,positions}` console
+ * pages onto the canonical object routes served by the generic
+ * `…/:objectName` route in `@object-ui/app-shell` (objectui#3655).
+ *
+ * These four were real routes until `apps/console` was slimmed for third-party
+ * customisation (cccdf84d7): "Delete bespoke /system/* wrapper pages
+ * (User/Role/Permission/Audit/Org) … these objects are now contributed by
+ * framework plugins (plugin-auth, -security, -audit) into the Setup app
+ * navigation and resolved via the generic /apps/setup/<object_name> route."
+ * The pages went; the URLs did not — `SystemHubPage`'s cards and both sidebars'
+ * `sys-*` cluster still emit them, and so do bookmarks. Nothing declared them
+ * afterwards, so they fell through to app-shell's tail and produced TWO
+ * different failures depending on the word's length (`looksLikeRecordId`
+ * requires 6+ chars): `users` / `roles` reached `RouteNotFound`, while
+ * `organizations` / `positions` were rewritten to
+ * `…/system/record/<word>` and rendered `RecordDetailView` for an
+ * object literally named `system`. Both landings are measured in
+ * `__tests__/AppContent.systemHubRoutes.test.tsx`.
+ *
+ * The object names are the framework's, not this repo's — read off
+ * `platform-objects`' Setup-app navigation contributions and plugin-security's:
+ *
+ *   users         -> sys_user          (`nav_users`)
+ *   organizations -> sys_organization  (`nav_organizations`, the LIST — the
+ *                                       record-scoped `nav_organization`
+ *                                       needs a runtime `{current_org_id}`
+ *                                       that a static redirect cannot resolve)
+ *   roles         -> sys_position      (ADR-0090 D3 renamed `sys_role` ->
+ *                                       `sys_position`; the sidebar's "Roles"
+ *                                       and the hub's "Positions" are the same
+ *                                       surface under old/new vocabulary)
+ *   positions     -> sys_position      (`nav_positions`)
+ *
+ * `system/permissions` is deliberately NOT redirected here — see the route
+ * block below.
+ *
+ * Same shape as `ObjectRedirect` / `MetadataRedirect` above (a legacy URL is
+ * translated, the page is not resurrected), including their treatment of
+ * `location.search` / `location.hash`: neither is forwarded. None of these
+ * URLs has ever carried one.
+ */
+function SystemObjectRedirect({ objectName }: { objectName: string }) {
+  const location = useLocation();
+  // The matched path is always `<prefix>/system/<one segment>`; anchoring at
+  // the end keeps an app segment that happens to be spelled `system` intact.
+  const prefix = location.pathname.replace(/\/system\/[^/]+\/?$/, '');
+  return <Navigate to={`${prefix}/${objectName}`} replace />;
+}
+
 // Exported for `__tests__/AppContent.legacyRedirects.test.tsx`, which mounts
 // this exact fragment in a bare `MemoryRouter` to measure the redirect chain.
 // Transcribing the routes into the test instead would let the copy drift from
@@ -137,6 +187,23 @@ export const systemRoutes = (
     <Route path="system/metadata" element={<MetadataRedirect />} />
     <Route path="system/metadata/:metadataType" element={<MetadataRedirect />} />
     <Route path="system/metadata/:metadataType/:itemName" element={<MetadataRedirect />} />
+    {/* Legacy URL redirects → the framework-owned system objects (objectui#3655).
+        `system/permissions` is absent on purpose: unlike the four above it has
+        no single measured equivalent. The framework splits what this console
+        calls "Permissions" into TWO Setup entries — `sys_capability`
+        (Capabilities: the definition registry, and the object whose own
+        docblock says it is what the ADR "loosely floats" as `sys_permission`,
+        which is the name the retired page and `SystemHubPage`'s count query
+        both use) and `sys_permission_set` (Permission Sets: the grant
+        container, which is what "Manage permission rules and assignments" and
+        admin CRUD describe). Picking one silently sends every future click and
+        bookmark to a surface the maintainer never chose, so it is left to be
+        decided rather than guessed; the test file pins its unchanged landing so
+        the gap stays visible instead of reading as an oversight. */}
+    <Route path="system/users" element={<SystemObjectRedirect objectName="sys_user" />} />
+    <Route path="system/organizations" element={<SystemObjectRedirect objectName="sys_organization" />} />
+    <Route path="system/roles" element={<SystemObjectRedirect objectName="sys_position" />} />
+    <Route path="system/positions" element={<SystemObjectRedirect objectName="sys_position" />} />
   </>
 );
 

--- a/apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx
+++ b/apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx
@@ -1,0 +1,330 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The System Hub / system-navigation entries under `/apps/:app/system/…` reach
+ * the framework-owned system objects instead of failing (objectui#3655).
+ *
+ * ## What was wrong
+ *
+ * `SystemHubPage`'s cards and both sidebars' `sys-*` cluster emit five
+ * `/apps/setup/system/{users,organizations,roles,positions,permissions}` URLs.
+ * They were real routes until `apps/console` was slimmed for third-party
+ * customisation (cccdf84d7), which deleted the bespoke wrapper pages on the
+ * grounds that "these objects are now contributed by framework plugins … and
+ * resolved via the generic /apps/setup/<object_name> route". The producers were
+ * never retargeted and nothing redeclared the URLs, so all five fell through to
+ * app-shell's tail — where the failure they got depended on how long the word
+ * was, because `ShorthandRecordRedirect`'s `looksLikeRecordId` treats any
+ * URL-safe segment of 6+ chars as a record id:
+ *
+ *   users (5), roles (5)                       -> RouteNotFound, "Page not found"
+ *   organizations (13), positions (9),         -> rewritten to
+ *   permissions (11)                              `…/system/record/<word>` and
+ *                                                 rendered as a record of an
+ *                                                 object literally named `system`
+ *
+ * Same cluster, same click, two unrelated failure screens — and the second is
+ * the worse one, because a record page for a nonexistent object reads as a
+ * backend/data problem rather than a dead link.
+ *
+ * ## What this file measures
+ *
+ * It renders app-shell's REAL `AppContent` (`DefaultAppContent`) with this
+ * host's REAL `systemRoutes` fragment, so the tail routes under test —
+ * `:objectName`, `:objectName/record/:recordId`, `ShorthandRecordRedirect`,
+ * `RouteNotFound` — are the shipped ones, not a transcription. That matters
+ * here more than usual: the defect IS the interaction between this fragment and
+ * that tail, and a hand-copied tail would be free to agree with whatever the
+ * fragment does.
+ *
+ * `ChainRecorder` records every location the router settles on, so "one hop" is
+ * an assertion rather than an inference; the pre-fix landings above are
+ * reachable by deleting the four `system/*` routes from `systemRoutes` (the
+ * `object-view` probes go red and the chain returns to `Page not found` /
+ * `…/system/record/<word>`).
+ *
+ * ## Two branches, and the `permissions` gap
+ *
+ * `AppContent` has two route tables and this host passes the same fragment to
+ * both. With an active app the redirect target resolves (`:objectName` renders
+ * `ObjectView`); on a zero-app deployment there is no `:objectName` route at
+ * all, so the target lands on the "No Apps Configured" empty state — measured
+ * and pinned below rather than asserted away, because a deployment with no apps
+ * in its metadata also has no `sys_user` to show.
+ *
+ * `system/permissions` is deliberately still broken: the framework splits this
+ * console's "Permissions" into `sys_capability` and `sys_permission_set` and
+ * nothing in the issue picks one. Its unchanged landing is pinned so the gap is
+ * visible, and so whichever mapping is chosen has to come here to change it.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom';
+
+// AGENTS.md §测试纪律 — the lazily-imported page modules are stubbed so no
+// unbounded `import()` races a bounded assertion window. The paths are
+// relative to app-shell's OWN source tree (`@object-ui/app-shell` is aliased to
+// `packages/app-shell/src` by `apps/console/vite.config.ts`), which is what
+// makes these resolve to the same module ids app-shell imports internally.
+vi.mock('../../../../packages/app-shell/src/views/metadata-admin', () => ({
+  MetadataDirectoryPage: () => <div data-testid="metadata-directory-page">directory</div>,
+  StudioHomePage: () => <div data-testid="studio-home-page">studio</div>,
+  MetadataResourceListPage: () => {
+    const { type } = useParams<{ type?: string }>();
+    return <div data-testid="metadata-resource-list-page">{type}</div>;
+  },
+  MetadataResourceEditPage: () => <div data-testid="metadata-resource-edit-page" />,
+  MetadataResourceHistoryPage: () => <div data-testid="metadata-resource-history-page" />,
+  MetadataDiagnosticsPage: () => <div data-testid="metadata-diagnostics-page" />,
+  MetadataResourceRouter: () => <div data-testid="metadata-resource-router" />,
+  registerMetadataResource: () => {},
+}));
+
+vi.mock('../../../../packages/app-shell/src/console/marketplace/MarketplacePage', () => ({
+  MarketplacePage: () => <div data-testid="marketplace-page">marketplace</div>,
+}));
+vi.mock('../../../../packages/app-shell/src/console/marketplace/MarketplaceInstalledPage', () => ({
+  MarketplaceInstalledPage: () => <div data-testid="marketplace-installed-page" />,
+}));
+vi.mock('../../../../packages/app-shell/src/console/marketplace/MarketplacePackagePage', () => ({
+  MarketplacePackagePage: () => <div data-testid="marketplace-package-page" />,
+}));
+
+vi.mock('@object-ui/plugin-designer', () => ({
+  CreateAppPage: () => <div data-testid="create-app-page">create app</div>,
+  EditAppPage: () => <div data-testid="edit-app-page" />,
+  DashboardDesignPage: () => <div data-testid="dashboard-design-page" />,
+}));
+
+vi.mock('../../../../packages/app-shell/src/layout/ConsoleLayout', () => ({
+  ConsoleLayout: ({ activeAppName, children }: { activeAppName?: string; children?: React.ReactNode }) => (
+    <div data-testid="console-layout" data-active-app={activeAppName}>
+      {children}
+    </div>
+  ),
+}));
+vi.mock('../../../../packages/app-shell/src/chrome/CommandPalette', () => ({ CommandPalette: () => null }));
+vi.mock('../../../../packages/app-shell/src/chrome/KeyboardShortcutsDialog', () => ({ KeyboardShortcutsDialog: () => null }));
+vi.mock('../../../../packages/app-shell/src/chrome/OnboardingWalkthrough', () => ({ OnboardingWalkthrough: () => null }));
+
+/** Echoes `:objectName` — this is the probe the whole fix is measured against. */
+vi.mock('../../../../packages/app-shell/src/views/ObjectView', () => ({
+  ObjectView: () => {
+    const { objectName } = useParams<{ objectName?: string }>();
+    return <div data-testid="object-view">{objectName}</div>;
+  },
+}));
+
+/** Echoes every param, so "a record page for the object `system`" is a fact. */
+vi.mock('../../../../packages/app-shell/src/views/RecordDetailView', () => ({
+  RecordDetailView: () => {
+    const params = useParams();
+    return <div data-testid="record-detail-view">{JSON.stringify(params)}</div>;
+  },
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+  }),
+}));
+
+vi.mock('@object-ui/auth', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAuth: () => ({
+    user: null,
+    getAuthConfig: async () => ({ features: {} }),
+    activeOrganization: null,
+  }),
+  useIsWorkspaceAdmin: () => false,
+}));
+
+const dataSourceStub = {
+  onConnectionStateChange: () => () => {},
+  getConnectionState: () => 'connected',
+};
+vi.mock('../../../../packages/app-shell/src/providers/AdapterProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => dataSourceStub,
+}));
+
+/**
+ * `setup` is a real app in any framework deployment (it ships in
+ * `@objectstack/platform-objects`), which is why the with-app branch is the one
+ * a user normally reaches these URLs in.
+ */
+const APPS = [{ name: 'setup', label: 'Setup', isDefault: true, navigation: [] }];
+let metadataApps: unknown[] = APPS;
+vi.mock('../../../../packages/app-shell/src/providers/MetadataProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useMetadata: () => ({
+    apps: metadataApps,
+    objects: [],
+    loading: false,
+    ensureType: undefined,
+    error: null,
+    refresh: vi.fn(async () => {}),
+  }),
+}));
+
+import { DefaultAppContent } from '@object-ui/app-shell';
+import { systemRoutes } from '../AppContent';
+
+/**
+ * Records every distinct location the router settles on. `<Navigate replace>`
+ * re-renders once per hop, so a one-hop rewrite shows up as exactly two
+ * entries.
+ */
+const chain: string[] = [];
+function ChainRecorder() {
+  const location = useLocation();
+  const here = location.pathname;
+  if (chain[chain.length - 1] !== here) chain.push(here);
+  return null;
+}
+
+function renderConsoleAt(initialUrl: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <ChainRecorder />
+      <Routes>
+        <Route
+          path="/apps/:appName/*"
+          element={<DefaultAppContent extraRoutes={systemRoutes} extraRoutesNoApp={systemRoutes} />}
+        />
+        <Route path="/" element={<div data-testid="root-landing">landing</div>} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  metadataApps = APPS;
+  chain.length = 0;
+});
+
+describe('system-hub entries reach the framework system objects (objectui#3655)', () => {
+  /**
+   * The four whose equivalent the framework names unambiguously. `roles` and
+   * `positions` converge on ONE object on purpose: ADR-0090 D3 renamed
+   * `sys_role` -> `sys_position`, so the sidebar's "Roles" and the hub's
+   * "Positions" are the same surface in old and new vocabulary.
+   */
+  it.each([
+    ['/apps/setup/system/users', '/apps/setup/sys_user', 'sys_user'],
+    ['/apps/setup/system/organizations', '/apps/setup/sys_organization', 'sys_organization'],
+    ['/apps/setup/system/roles', '/apps/setup/sys_position', 'sys_position'],
+    ['/apps/setup/system/positions', '/apps/setup/sys_position', 'sys_position'],
+  ])('%s reaches %s in ONE hop', async (url, target, objectName) => {
+    renderConsoleAt(url);
+
+    expect(await screen.findByTestId('object-view')).toHaveTextContent(objectName);
+    // Two entries = a single `<Navigate>`. Before the fix `users` never left
+    // its own URL (it rendered `RouteNotFound` in place) and `organizations` /
+    // `positions` moved to `…/system/record/<word>` instead.
+    expect(chain).toEqual([url, target]);
+    expect(screen.queryByTestId('record-detail-view')).not.toBeInTheDocument();
+    expect(screen.queryByText('Page not found')).not.toBeInTheDocument();
+  });
+
+  it('preserves the app prefix rather than stripping to the root', () => {
+    // `prefix` is cut with a regex off `location.pathname`; every case above
+    // uses the same two-segment prefix, so a mistake there is invisible in them.
+    renderConsoleAt('/apps/my-app/system/users');
+
+    expect(chain).toEqual(['/apps/my-app/system/users', '/apps/my-app/sys_user']);
+  });
+
+  it('an app segment spelled `system` survives the rewrite', () => {
+    // The regex is end-anchored precisely so the LAST `/system/<seg>` is the
+    // one removed. An unanchored cut would leave `/apps` here.
+    renderConsoleAt('/apps/system/system/users');
+
+    expect(chain).toEqual(['/apps/system/system/users', '/apps/system/sys_user']);
+  });
+
+  /**
+   * MEASUREMENT — deliberately unresolved. "Permissions" has TWO candidate
+   * equivalents in the framework (`sys_capability`, the definition registry and
+   * the object its own docblock identifies as the ADR's `sys_permission`; and
+   * `sys_permission_set`, the grant container the permissions docs call "the
+   * only capability container"). Choosing one here would silently commit every
+   * click and bookmark to a surface nobody picked, so this leg keeps its
+   * pre-fix landing until the mapping is decided. This assertion is expected to
+   * be REPLACED, not merely to keep passing.
+   */
+  it('MEASUREMENT: system/permissions still lands on a record of the object `system`', async () => {
+    renderConsoleAt('/apps/setup/system/permissions');
+
+    const probe = await screen.findByTestId('record-detail-view');
+    expect(probe).toHaveTextContent('"objectName":"system"');
+    expect(probe).toHaveTextContent('"recordId":"permissions"');
+    expect(chain).toEqual([
+      '/apps/setup/system/permissions',
+      '/apps/setup/system/record/permissions',
+    ]);
+  });
+
+  /**
+   * MEASUREMENT — the length-dependent split this issue is really about, taken
+   * on the one URL the fix does not cover. `permissions` (11 chars) is judged a
+   * record id; a hypothetical 5-char sibling would not be. Nothing here asks
+   * for `looksLikeRecordId` to change — it is a separate question — but the
+   * asymmetry is recorded so the next reader does not have to rediscover it.
+   */
+  it('MEASUREMENT: an undeclared SHORT system segment still reaches Page not found', async () => {
+    renderConsoleAt('/apps/setup/system/teams');
+
+    expect(await screen.findByText('Page not found')).toBeInTheDocument();
+    expect(chain).toEqual(['/apps/setup/system/teams']);
+  });
+});
+
+describe('zero-app branch — measured, not asserted away (objectui#3655)', () => {
+  /**
+   * The sidebars' `sys-*` cluster renders ONLY when there is no active app, so
+   * this is the branch its Users / Organizations / Roles entries are clicked
+   * in. `AppContent`'s no-active-app route table declares no `:objectName`
+   * route, so the redirect target leaves the pseudo-route family
+   * (`isSystemRoute` keys on a `system` path segment) and falls into the "No
+   * Apps Configured" guard.
+   *
+   * That is the honest end state, not a regression hidden by a stub: a
+   * deployment whose metadata carries zero apps also carries no `sys_user` to
+   * render. What changes is only WHICH dead end is reached — previously all
+   * five landed on `RouteNotFound` here, because `ShorthandRecordRedirect` is
+   * not declared in this branch either (i.e. the length-dependent split above
+   * does NOT exist on a zero-app deployment).
+   */
+  it.each([
+    ['/apps/setup/system/users', '/apps/setup/sys_user'],
+    ['/apps/setup/system/organizations', '/apps/setup/sys_organization'],
+    ['/apps/setup/system/roles', '/apps/setup/sys_position'],
+    ['/apps/setup/system/positions', '/apps/setup/sys_position'],
+  ])('%s still redirects, and the target is the no-apps empty state', async (url, target) => {
+    metadataApps = [];
+    renderConsoleAt(url);
+
+    expect(await screen.findByTestId('create-first-app-btn')).toBeInTheDocument();
+    expect(chain).toEqual([url, target]);
+    expect(screen.queryByTestId('object-view')).not.toBeInTheDocument();
+  });
+
+  it('MEASUREMENT: with no apps, an undeclared system URL reaches Page not found, never a record page', async () => {
+    metadataApps = [];
+    renderConsoleAt('/apps/setup/system/permissions');
+
+    expect(await screen.findByText('Page not found')).toBeInTheDocument();
+    expect(screen.queryByTestId('record-detail-view')).not.toBeInTheDocument();
+    expect(chain).toEqual(['/apps/setup/system/permissions']);
+  });
+});


### PR DESCRIPTION
Fixes-part-of #3655(4/5:users/organizations/roles/positions 四条已交付;第五条 permissions 腿按有界授权停手,等维护者在 #3655 裁决 A/B/C 后另行落地 — 详见下文「为什么 permissions 留着不动」)

> 注:正文刻意不写 `Route` 的尖括号形式 —— GitHub 的正文消毒器会把「尖括号 + 字母」当成 HTML 标签在存储时剥掉。本 PR 首版正是在两处栽了这个跟头(存回来一读就发现是两个空反引号),现已改用无尖括号写法。

## 先复核:issue 结论成立,且比正文更细

issue 的结论来自静态路由表推导,派发单要求先做**路由级实测复核**。本 PR 的测试文件挂载 app-shell **真实的** `AppContent`(`DefaultAppContent`)+ 本宿主**真实的** `systemRoutes` fragment,五条 URL 逐条渲染。这一点在这里比平时更要紧:缺陷本身就是「本 fragment 与 app-shell 尾部路由的相互作用」,手抄一份尾部路由等于让它自动同意 fragment 的任何行为。

实测落点(**有应用**分支,即 System Hub 卡片正常可达的那条):

| URL | 修前落点(实测) | 修后落点(实测) |
|---|---|---|
| `/apps/setup/system/users` | `RouteNotFound` — "Page not found" | 一跳 -> `/apps/setup/sys_user`,`ObjectView` 渲染 `sys_user` |
| `/apps/setup/system/organizations` | 重写为 `/apps/setup/system/record/organizations`,`RecordDetailView` 收到 `objectName: "system"` / `recordId: "organizations"` | 一跳 -> `/apps/setup/sys_organization` |
| `/apps/setup/system/roles` | `RouteNotFound` — "Page not found" | 一跳 -> `/apps/setup/sys_position` |
| `/apps/setup/system/positions` | 重写为 `…/system/record/positions`,`RecordDetailView` 收到 `objectName: "system"` / `recordId: "positions"` | 一跳 -> `/apps/setup/sys_position` |
| `/apps/setup/system/permissions` | 重写为 `…/system/record/permissions`,`RecordDetailView` 收到 `objectName: "system"` / `recordId: "permissions"` | **未变**(见下「为什么 permissions 留着」) |

与 issue 正文的两处**修正**,均以实测为准:

1. **零应用分支根本没有那条长度分叉。** issue 说「三个跳进不存在对象 `system` 的记录页」,这只在**有应用**分支成立。`AppContent` 的无 activeApp 路由表里既没有 `:objectName/:maybeRecordId` 也没有 `:objectName/record/:recordId`,所以 `ShorthandRecordRedirect` 压根不参与 —— 零应用下**五条全部**落 `RouteNotFound`。这条很关键,因为两个 sidebar 的 `sys-*` 簇**只在 activeApp 为假时渲染**(`AppSidebar.tsx` 自己的注释),也就是说 sidebar 那三条入口平时走的正是这个分支。
2. **`looksLikeRecordId` 的过宽判定只作记录、不改动**(派发单要求)。本 PR 一行都没碰它;它造成的长度分叉现象在测试里以 MEASUREMENT 形态钉住(`system/teams` 这类短词仍落 404),供后续单据引用。

## 处置分支:(b) 路由侧重定向,不动导航文件

派发单给了三个分支,实测把它定死在 (b):

- **不是 (a)「已有页面组件未接线」。** `apps/console/src/pages/system/` 下确有 `SystemObjectViewPage.tsx` + `systemObjects.ts`,但它们自 cccdf84d7 起**全仓零引用**,且其中的对象名(`sys_org`、`sys_permission`)在框架里根本不存在 —— 接回去只会渲染出空的 ObjectView。已另立 #3672(观察类)记录。
- **是 (b)「有 metadata 驱动的等价物」。** cccdf84d7 删掉这五个页面时把去向写在提交信息里:「these objects are now contributed by framework plugins (plugin-auth, -security, -audit) into the Setup app navigation and resolved via the generic /apps/setup/`{object_name}` route」。等价物就是 Setup 应用导航里的 `type:'object'` 条目,`resolveHref` 把它解析成 `{basePath}/{objectName}`。
- 派发单对导航文件挂了 ⛔(`SystemHubPage.tsx` / `AppSidebar.tsx` / `UnifiedSidebar.tsx` 正被 #3660 修改),故只交**路由侧**能做的部分:声明轻量重定向。这与它们上方 `system/objects` / `system/metadata` 两组重定向是**同一形态**(翻译 URL、不复活页面),#3660 正文亦已裁定「别名路由本身仍应保留 —— 书签与外链需要它」。

目标对象名逐条取自框架源码,不是猜的:

| 入口 | 目标对象 | 依据 |
|---|---|---|
| users | `sys_user` | `setup-nav.contributions.ts` 的 `nav_users` |
| organizations | `sys_organization` | `nav_organizations`(**列表**那条)。另一条 `nav_organization` 带 `recordId: '{current_org_id}'`,需要运行期会话值,静态重定向解析不了,故取列表 |
| roles | `sys_position` | ADR-0090 D3 把 `sys_role` 改名为 `sys_position`;sidebar 的 "Roles" 与 Hub 的 "Positions" 是同一个面的新旧两种叫法。全仓无 `sys_role` 对象 |
| positions | `sys_position` | plugin-security 的 `nav_positions` |

## 为什么 permissions 留着不动

框架把本 console 叫作 "Permissions" 的东西拆成了**两个** Setup 条目,证据两边都硬:

- **`sys_capability`**(导航标签 "Capabilities")—— 其对象 docblock 明写「Named `sys_capability` (not `sys_permission` as the ADR loosely floats)」,而 `sys_permission` 正是被删掉的那个页面、以及 `SystemHubPage` 计数查询今天仍在用的名字。血缘指向它。
- **`sys_permission_set`**(导航标签 "Permission Sets")—— 权限文档称其为「the only capability container」,是带管理员 CRUD 的授予容器,和卡片描述「Manage permission rules and assignments」以及它在 Positions 旁边的位置对得上。功能指向它。而 `sys_capability` 是 `managedBy: 'config'` + `protection.lock: 'no-overlay'` 的平台锁定注册表,对它做管理员增删本就没有意义。

任选其一都会把此后每一次点击与每一个书签**静默**绑到一个维护者没有选过的面上 —— 这正是「消费端宽容」最典型的藏错处。派发单的 (b) 分支写明「redirect 目标以等价物实测为准」,而实测给出的是**两个**都能渲染的等价物,该条无法定案,故按「停手报告」处理:这一腿保持原样,并在测试里把它**未变的落点**钉住,让缺口显式可见、而不是读起来像漏掉了一条。裁决落地后,改的就是那条钉子。

## 零应用分支:测量,不是掩盖

重定向对两个分支同时生效(本宿主把同一个 fragment 传给 `extraRoutes` 与 `extraRoutesNoApp`)。零应用下目标 `/apps/setup/sys_user` 不含 `system` / `metadata` 路径段,于是离开伪路由家族,落到「No Apps Configured」空状态。

这是**诚实的终点而非被 stub 掩盖的回归**:metadata 里一个 app 都没有的部署,同样没有 `sys_user` 可渲染。变的只是**换了一个死胡同** —— 修前这里五条全是 `RouteNotFound`。测试里以专门一组用例钉住这个事实,而不是把它断言掉。

## 逆向验证(先预测,后运行)

预测:删掉那四行 `path="system/…"` 的路由声明后,四条一跳断言与四条零应用断言应转红,落点回到修前的两类;而三条 MEASUREMENT 断言(permissions 记录页、短词 404、零应用 permissions 404)**不应受影响**,因为它们不依赖这四条路由。

实测:`13 passed` -> **`10 failed / 3 passed`**,失败清单与预测逐条吻合,失败现场直接打印出两类旧落点:

```
× /apps/setup/system/users reaches /apps/setup/sys_user in ONE hop
× /apps/setup/system/organizations reaches /apps/setup/sys_organization in ONE hop
× /apps/setup/system/roles reaches /apps/setup/sys_position in ONE hop
× /apps/setup/system/positions reaches /apps/setup/sys_position in ONE hop
× preserves the app prefix rather than stripping to the root
× an app segment spelled `system` survives the rewrite
× (4x) … still redirects, and the target is the no-apps empty state

TestingLibraryElementError: Unable to find an element by: [data-testid="object-view"]
  data-testid="record-detail-view"
  {"appName":"setup","*":"system/record/organizations","objectName":"system","recordId":"organizations"}
AssertionError: expected [ '/apps/my-app/system/users' ] to deeply equal [ '/apps/my-app/system/users', …(1) ]
-   "/apps/my-app/sys_user",
```

## 测试

从仓库根跑,重活走共享 flock + `--max-old-space-size=4096` + `--maxWorkers=2`:

- `pnpm exec vitest run --project '@object-ui/console'` -> **25 files / 232 tests passed**
- `pnpm exec vitest run packages/app-shell/src/console packages/app-shell/src/layout` -> **46 files / 268 tests passed**(消费半径清扫:`systemRedirectTarget.test.tsx:62` 是全仓唯一另一处提到 `/system/users` 的断言,它测的是 `SystemRedirect` 的**改写产物**,发生在本 PR 的路由之前,故不受影响 —— 已跑绿确认)
- `pnpm --workspace-concurrency=2 --filter @object-ui/console type-check` -> 通过(新树里先 `--filter '@object-ui/console^...' build` 建好依赖)
- `pnpm --workspace-concurrency=2 --filter @object-ui/console lint` -> **0 errors**(190 warnings 全为既有 `no-explicit-any`;`AppContent.tsx` 唯一那条 `react-refresh/only-export-components` 来自既有的 `systemRoutes` 导出,非本次新增)
- `node scripts/check-control-bytes.mjs` -> OK;`node scripts/check-changeset-no-major.mjs` -> OK

## 文件面

- `apps/console/src/AppContent.tsx` —— 新增 `SystemObjectRedirect` + 四行路由声明
- `apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx` —— 新增
- `.changeset/system-hub-routes-3655.md` —— patch

⛔ 未触碰:`SystemHubPage.tsx` / `AppSidebar.tsx` / `UnifiedSidebar.tsx`(#3660 在途)、`ShorthandRecordRedirect` 的判定逻辑、`packages/app-shell` 的任何路由声明。

## 越界发现(只报不改,均已单独立单、未认领)

- **#3670** —— `SystemHubPage` 的计数查的是框架里不存在的 `sys_org` / `sys_permission`,`.catch` 吞掉 404,Organizations 与 Permissions 两张卡片**永远显示 0**,与「确实没有」无法区分。真实缺陷,未打 `finding`,留给分诊。
- **#3672** —— `SystemObjectViewPage.tsx` + `systemObjects.ts` 自 2026-04 起全仓零引用,且内嵌对象名已与框架脱节。观察类,已打 `finding`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt