### PR TITLE
fix(console): System Hub 的 Organizations 计数改查框架真名 sys_organization,Permissions 半只钉不修 (#3670)

### DIFF
--- a/.changeset/system-hub-org-count-3670.md
+++ b/.changeset/system-hub-org-count-3670.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/console': patch
+---
+
+Count System Hub's Organizations card through `sys_organization`, the object the framework actually registers — it asked for `sys_org`, which does not exist, so the card read `0` on every deployment (objectui#3670).
+
+The failure was silent by construction. A missing object answers `404 OBJECT_NOT_FOUND`, and `ObjectStackAdapter.find()` absorbs that on purpose — it caches the name in `missingResources` and resolves `{ data: [], total: 0 }` so callers can treat an uninstalled collection as "no rows". The hub renders `data.length`, so a name the framework never had produced a perfectly ordinary `0`, indistinguishable from a workspace that genuinely has no organizations — which no single-org deployment ever is, since `sys_organization` always holds at least one row. The `.catch` on each call never even saw the 404; it only ever covered non-404 rejections.
+
+The other three counted names were checked against the framework's object registry and are correct as spelled: `sys_user`, `sys_position`, `sys_audit_log`.
+
+The Permissions card is **not** fixed here and still reads `0`. Its query names `sys_permission`, which the framework also does not have — it splits that surface into `sys_capability` (lineage: its own docblock says "named `sys_capability`, not `sys_permission`") and `sys_permission_set` (function: the admin-managed grant container). Both would render, so choosing one would silently bind the card to a surface nobody picked; that decision is open on objectui#3655. Until it lands the gap is held visible by a MEASUREMENT case in the page's test rather than quietly re-aimed.

--- a/apps/console/src/pages/system/SystemHubPage.tsx
+++ b/apps/console/src/pages/system/SystemHubPage.tsx
@@ -75,10 +75,38 @@ export function SystemHubPage() {
     if (!dataSource) return;
     setLoading(true);
     try {
+      // Every name below must be one the framework actually registers. A name
+      // it does NOT register is not a loud failure here: the backend answers
+      // `404 OBJECT_NOT_FOUND` and `ObjectStackAdapter.find()` absorbs that on
+      // purpose (`packages/data-objectstack/src/index.ts` — it caches the
+      // resource in `missingResources` and resolves `{ data: [], total: 0 }`),
+      // so a misspelled object renders a perfectly plausible `0` that no
+      // administrator can tell apart from "there really are none"
+      // (objectui#3670). The `.catch` on each call never even sees that case;
+      // it only covers non-404 rejections.
+      //
+      // Verified against the framework's object registry:
+      //   sys_user         packages/platform-objects/src/identity/sys-user.object.ts
+      //   sys_organization packages/platform-objects/src/identity/sys-organization.object.ts
+      //   sys_position     packages/plugins/plugin-security/src/objects/sys-position.object.ts
+      //   sys_audit_log    packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts
+      //
+      // `sys_permission` is the one exception and is deliberately left alone.
+      // The framework has no such object; it splits that surface into
+      // `sys_capability` (lineage — its docblock names itself "not
+      // sys_permission as the ADR loosely floats") and `sys_permission_set`
+      // (function — the admin-managed grant container). Both would render, so
+      // picking one here would silently commit this card to a surface the
+      // maintainer has not chosen; that call is pending on objectui#3655
+      // (A: sys_permission_set / B: sys_capability / C: retire this bespoke
+      // card with the hub itself, which is already `@deprecated` above). Until
+      // it lands the Permissions count stays a known-wrong `0` — pinned by a
+      // MEASUREMENT case in this page's test rather than quietly re-aimed.
+      //
       // TODO: Replace with count-specific API endpoint when available
       const [usersRes, orgsRes, positionsRes, permsRes, logsRes] = await Promise.all([
         dataSource.find('sys_user').catch(() => ({ data: [] })),
-        dataSource.find('sys_org').catch(() => ({ data: [] })),
+        dataSource.find('sys_organization').catch(() => ({ data: [] })),
         dataSource.find('sys_position').catch(() => ({ data: [] })),
         dataSource.find('sys_permission').catch(() => ({ data: [] })),
         dataSource.find('sys_audit_log').catch(() => ({ data: [] })),

--- a/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
+++ b/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * System Hub — the card counts must query object names the framework actually
+ * registers (objectui#3670).
+ *
+ * The hub fetches one full list per card and renders `data.length` as the
+ * count. Two of the five names it asked for did not exist in the framework at
+ * all, and the failure mode was silent rather than loud: the backend answers a
+ * missing object with `404 OBJECT_NOT_FOUND`, and `ObjectStackAdapter.find()`
+ * deliberately absorbs that into `{ data: [], total: 0 }` (it caches the name
+ * in `missingResources` so later calls short-circuit). So the card rendered a
+ * confident `0` that no administrator could tell apart from "there really are
+ * none" — on a single-org deployment where `sys_organization` always has at
+ * least one row.
+ *
+ * This file therefore asserts two different things, and the difference is the
+ * point:
+ *   - Organizations is FIXED — the count now travels through `sys_organization`
+ *     and shows the real number.
+ *   - Permissions is only PINNED — the query still says `sys_permission`, an
+ *     object the framework does not have, so that card still reads 0. Which
+ *     object it should read is a maintainer decision open on objectui#3655
+ *     (A `sys_permission_set` / B `sys_capability` / C retire the card). The
+ *     MEASUREMENT cases below hold that gap visible instead of letting it read
+ *     like an oversight.
+ *
+ * jsdom integration test — no backend. The adapter is stubbed at its real
+ * contract boundary (see the `find` stub: unknown object RESOLVES empty, it
+ * does not reject), so the tests exercise the same silence the bug hid behind.
+ * `SystemHubPage` itself is the real component, as in the sibling
+ * `SystemHubPage.metadataCards.test.tsx` — a transcribed copy of the card list
+ * is precisely how a wrong name survives.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+// Hoisted so the vi.mock factories below can close over them, and so the
+// adapter is a STABLE singleton — a fresh object per render re-runs the page's
+// fetch effect (`fetchCounts` is memoized on `dataSource`).
+const { state, ADAPTER, FRAMEWORK_OBJECT_NAMES } = vi.hoisted(() => {
+  /**
+   * Object names the framework registers, each verified in the `objectstack`
+   * checkout at the baseline of this change:
+   *
+   *   sys_user            packages/platform-objects/src/identity/sys-user.object.ts
+   *   sys_organization    packages/platform-objects/src/identity/sys-organization.object.ts
+   *   sys_position        packages/plugins/plugin-security/src/objects/sys-position.object.ts
+   *   sys_capability      packages/plugins/plugin-security/src/objects/sys-capability.object.ts
+   *   sys_permission_set  packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
+   *   sys_audit_log       packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts
+   *
+   * `sys_org` and `sys_permission` are absent on purpose: a repo-wide grep for
+   * either as an object name returns zero hits in the framework, which is
+   * exactly what makes them unqueryable.
+   */
+  const FRAMEWORK_OBJECT_NAMES = [
+    'sys_user',
+    'sys_organization',
+    'sys_position',
+    'sys_capability',
+    'sys_permission_set',
+    'sys_audit_log',
+  ];
+
+  const state = {
+    /** Every object name the page asked for, in call order. */
+    calls: [] as string[],
+    /** Registered object -> its rows. A name absent here is unregistered. */
+    registry: {} as Record<string, unknown[]>,
+    /** Object -> a NON-404 failure the real adapter would rethrow. */
+    failures: {} as Record<string, Error>,
+  };
+
+  const ADAPTER = {
+    /**
+     * Mirrors `ObjectStackAdapter.find()` at its contract boundary:
+     *   - registered name        -> `{ data: rows, total }`
+     *   - UNregistered name      -> `{ data: [], total: 0 }`. The 404 is
+     *     absorbed inside the adapter; callers never see a rejection, so the
+     *     page's own `.catch` is not what hides a wrong object name.
+     *   - non-404 failure (500 / 401 / network) -> REJECTS. That is the class
+     *     the page's `.catch` actually swallows.
+     */
+    find: async (objectName: string) => {
+      state.calls.push(objectName);
+      const failure = state.failures[objectName];
+      if (failure) throw failure;
+      const rows = Object.prototype.hasOwnProperty.call(state.registry, objectName)
+        ? state.registry[objectName]
+        : [];
+      return { data: rows, total: rows.length };
+    },
+  };
+
+  return { state, ADAPTER, FRAMEWORK_OBJECT_NAMES };
+});
+
+vi.mock('@object-ui/app-shell', () => ({ useAdapter: () => ADAPTER }));
+vi.mock('@object-ui/auth', () => ({ useIsWorkspaceAdmin: () => true }));
+
+// Imported AFTER the mocks so the page picks them up.
+import { SystemHubPage } from '../SystemHubPage';
+
+const rows = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `r${i}` }));
+
+beforeEach(() => {
+  state.calls.length = 0;
+  state.failures = {};
+  // A deployment where every framework object holds a distinct, non-zero row
+  // count — so any `0` on screen is a defect, never an accident of fixtures.
+  state.registry = {
+    sys_user: rows(3),
+    sys_organization: rows(2),
+    sys_position: rows(4),
+    sys_capability: rows(7),
+    sys_permission_set: rows(5),
+    sys_audit_log: rows(6),
+  };
+});
+afterEach(cleanup);
+
+/** Mounts the hub under a route that supplies `:appName` (basePath `/apps/setup`). */
+function renderHub() {
+  render(
+    <MemoryRouter initialEntries={['/apps/setup/system']}>
+      <Routes>
+        <Route path="/apps/:appName/system" element={<SystemHubPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Awaits one card's count badge. All five counts land in a single `setCounts`,
+ * so awaiting any one of them settles the whole wall.
+ */
+async function badge(cardTestId: string, text: string) {
+  const card = await screen.findByTestId(cardTestId);
+  return within(card).findByText(text);
+}
+
+describe('System Hub card counts — object names (objectui#3670)', () => {
+  it('counts Organizations through sys_organization, the name the framework registers', async () => {
+    renderHub();
+
+    // Before the fix this read `0 organizations`: `sys_org` is not a framework
+    // object, so the query 404'd and the adapter turned that into an empty page.
+    expect(await badge('hub-card-organizations', '2 organizations')).toBeInTheDocument();
+    expect(state.calls).toContain('sys_organization');
+    expect(state.calls).not.toContain('sys_org');
+  });
+
+  it('leaves the three already-correct names alone', async () => {
+    renderHub();
+
+    expect(await badge('hub-card-users', '3 users')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hub-card-positions')).getByText('4 positions')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hub-card-audit-log')).getByText('6 entries')).toBeInTheDocument();
+  });
+
+  it('asks for exactly five names, and only one of them is missing from the framework', async () => {
+    renderHub();
+    // Settle on a card this audit does not judge, so a wrong name shows up as a
+    // diff on the call list below rather than as a missing badge elsewhere.
+    await badge('hub-card-users', '3 users');
+
+    expect(state.calls).toEqual([
+      'sys_user',
+      'sys_organization',
+      'sys_position',
+      'sys_permission',
+      'sys_audit_log',
+    ]);
+    // The whole audit in one assertion: after this change the only name the
+    // framework does not register is the one parked on objectui#3655.
+    expect(state.calls.filter((name) => !FRAMEWORK_OBJECT_NAMES.includes(name))).toEqual([
+      'sys_permission',
+    ]);
+  });
+
+  // ── MEASUREMENT ────────────────────────────────────────────────────────────
+  // The three cases below pin the CURRENT behaviour, not the desired one. They
+  // exist so the remaining gap is visible in the suite instead of being read as
+  // a missed line, and so whoever resolves objectui#3655 has a failing anchor
+  // to rewrite rather than a silent pass.
+
+  it('MEASUREMENT: Permissions still reads 0 while both candidate objects hold rows', async () => {
+    renderHub();
+
+    // `sys_capability` (7 rows) and `sys_permission_set` (5 rows) both exist in
+    // this fixture, and the card shows neither — it asks for `sys_permission`,
+    // which the framework does not have. Aiming it at either candidate here
+    // would decide objectui#3655's A/B/C on the maintainer's behalf, so the
+    // query is deliberately untouched. When that decision lands, THIS is the
+    // case to rewrite (expected: `7 permissions` for B, `5 permissions` for A,
+    // or the card gone entirely for C).
+    expect(await badge('hub-card-permissions', '0 permissions')).toBeInTheDocument();
+    expect(state.calls).toContain('sys_permission');
+    expect(state.calls).not.toContain('sys_capability');
+    expect(state.calls).not.toContain('sys_permission_set');
+  });
+
+  it('MEASUREMENT: an unregistered object and a genuinely empty one render the identical badge', async () => {
+    // `sys_audit_log` exists but has no rows; `sys_permission` does not exist
+    // at all. Two different facts, one indistinguishable pixel — this is why
+    // the wrong name survived so long, and it is unchanged by this PR (fixing
+    // it means changing the error handling, a separate class of work).
+    state.registry.sys_audit_log = [];
+    renderHub();
+
+    expect(await badge('hub-card-audit-log', '0 entries')).toBeInTheDocument();
+    expect(within(screen.getByTestId('hub-card-permissions')).getByText('0 permissions')).toBeInTheDocument();
+  });
+
+  it('MEASUREMENT: a non-404 failure is collapsed into 0 as well, with no error affordance', async () => {
+    // The 404 never reaches the page's `.catch` — the adapter ate it upstream.
+    // What that `.catch` really covers is this: a 500 (or 401 / 403 / offline)
+    // on ONE object, rendered as a confident `0` on that card while its
+    // neighbours show real numbers. Recorded here only; changing the error
+    // handling is a separate class of work, filed as objectui#3679.
+    state.failures.sys_user = Object.assign(new Error('Internal Server Error'), {
+      status: 500,
+    });
+    renderHub();
+
+    expect(await badge('hub-card-users', '0 users')).toBeInTheDocument();
+    // The per-call `.catch` also keeps `Promise.all` from rejecting, so the
+    // other four cards still resolve — including the one this PR fixed.
+    expect(within(screen.getByTestId('hub-card-organizations')).getByText('2 organizations')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes-part-of #3670(Organizations 半已交付;Permissions 半按有界授权停手,等维护者在 #3655 裁决 A/B/C 后另行落地 —— 详见下文「为什么 Permissions 留着不动」)

## 先复核:issue 的症状成立,机制归因需订正

issue 说「`.catch` 吞掉 404,所以计数落成 0」。**症状完全成立,机制不是这样** —— 这条不是措辞挑剔,它决定了本 PR 该改哪一行、不该改哪一行:

- 对象不存在时后端答 `404` + `code: 'OBJECT_NOT_FOUND'`,而 `ObjectStackAdapter.find()` **自己**先吃掉了它:`packages/data-objectstack/src/index.ts` 里 `is404Error(err)` 命中后把资源记进 `missingResources`(后续同名调用直接短路)并 `return { data: [], total: 0 }`。这是有意设计,注释原话是 callers treat empty data as "feature unavailable"。
- 也就是说 404 **从来没到达**页面那一层的 `.catch`;它给的是 resolve 不是 reject。页面拿到一页空数据,`data.length` 得 0,渲染出一个完全正常的徽章。

结论不变而且更刺眼:**错名的失败是静默的,不是被 `.catch` 掩盖的**,靠加错误处理也不会让它变响 —— 唯一的修法就是把名字改对。因此本 PR 只改名字,`.catch` 一个字节没动(那是另一个类,见文末 #3679)。

## 对象名核实表(逐个对框架源码核对,不是猜的)

框架侧 checkout `../objectstack` @ `b4872a868`;计数处五个名字全量列出,不只 issue 点名的两个:

| 卡片 | 查询用的对象名 | 框架里有没有 | 依据 | 处置 |
|---|---|---|---|---|
| Users | `sys_user` | 有 | `packages/platform-objects/src/identity/sys-user.object.ts:17` | 不动 |
| Organizations | `sys_org` | **没有** | 全仓 grep 作为对象名零命中;真名 `sys_organization`,`packages/platform-objects/src/identity/sys-organization.object.ts:14` | **改为 `sys_organization`** |
| Positions | `sys_position` | 有 | `packages/plugins/plugin-security/src/objects/sys-position.object.ts:16` | 不动 |
| Permissions | `sys_permission` | **没有** | 全仓精确 grep(不含 `_set`)只命中 `sys-capability.object.ts:20` 的一句注释,无对象定义 | **不动,只钉** |
| Audit Log | `sys_audit_log` | 有 | `packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts:17` | 不动 |

没有第三个错名。issue 对 `sys_user` / `sys_position` 正确的判断经核实成立,并把它没点名的 `sys_audit_log` 一并核过。

Organizations 这一条的现实后果:单组织部署里 `sys_organization` 至少有一行,所以那张卡片显示的 `0` **在任何部署上都是错的**,而且长得和「还没建组织」一模一样。

## 为什么 Permissions 留着不动

框架把这张卡片叫的东西拆成了两个对象,两边证据都硬(考证出自已合并的 PR #3673,本 PR 未推翻):

- **`sys_capability`** —— 其 docblock 明写「Named `sys_capability` (not `sys_permission` as the ADR loosely floats)」,而 `sys_permission` 正是这里今天在用的名字。**血缘**指向它。
- **`sys_permission_set`** —— 权限文档称其为唯一的 capability 容器,是带管理员 CRUD 的授予容器,和卡片描述 "Manage permission rules and assignments" 对得上。**功能**指向它。

任选其一,此后每一个看到这个数字的人都会以为平台确认了这就是「Permissions」——一个维护者没有做过的选择被一次改名静默定型。#3655 已把它挂上 `needs-user-decision`,三选一是 A `sys_permission_set` / B `sys_capability` / C 连同这张 bespoke 卡片一起退场(`SystemHubPage` 自己的 docblock 已标 `@deprecated`)。裁决落地前,这张卡片继续读 0 —— 但这个缺口现在在测试里**显式钉住**,不再读起来像漏了一行。

## `.catch` 行为矩阵(只测量,不修)

同一个 `0` 背后有三种语义完全不同的事,修前修后都不可分:

| 后端实际发生的事 | 适配器 | 页面 `.catch` | 屏幕 | 本 PR 前 | 本 PR 后 |
|---|---|---|---|---|---|
| 对象不存在(404 OBJECT_NOT_FOUND) | 吃掉,resolve 空 | 未触发 | `0` | Organizations + Permissions 两张 | 只剩 Permissions 一张 |
| 对象存在但确实没有记录 | resolve 空 | 未触发 | `0` | 同 | 同(不变) |
| 500 / 401 / 403 / 断网 | rethrow | **吃掉** | `0` | 同 | 同(不变) |

第三行是这个 `.catch` **实际**覆盖的唯一一类,和 issue 的归因正相反。它没被本 PR 碰,只被测量并另立 #3679。顺带记录:`fetchCounts` 外层那个 `catch { /* Keep nulls on failure */ }` 因为每个 promise 自带 `.catch` 已不可能被 `Promise.all` 触发,那条「保留 null 不显示徽章」的降级路径实际是死的 —— 而它恰好是唯一能把「不知道」和「0」区分开的形态。这一条也写进了 #3679。

## 逆向验证(先预测,后运行)

预测:把对象名回退成 `sys_org` 后,**3 红 3 绿**。红的应是——(1) Organizations 计数用例(查询发向 `sys_org`,fixture 里没有这个对象,适配器 resolve 空 → 徽章回到 `0 organizations`);(2) 对象名审计用例(调用清单第二项变成 `sys_org`,「框架不认识的名字」从 1 个变 2 个);(3) 非 404 失败的 MEASUREMENT 用例 —— 它顺带断言了邻居卡片仍显示真实计数 `2 organizations`,所以也会跟着红,这条要照实预测而不是假装它无关。绿的应是另外三条:三个正确名字的用例、Permissions 恒 0 的钉子、「空对象与不存在对象徽章相同」的钉子 —— 它们都不经过 Organizations 的计数。

实测:`6 passed` -&gt; **`3 failed | 3 passed`**,失败清单与预测逐条吻合,失败现场直接打印出修前的屏幕与调用清单:

```
× counts Organizations through sys_organization, the name the framework registers
× asks for exactly five names, and only one of them is missing from the framework
× MEASUREMENT: a non-404 failure is collapsed into 0 as well, with no error affordance

TestingLibraryElementError: Unable to find an element with the text: 2 organizations
  data-testid="hub-card-organizations"
  ...
      0
       
      organizations

AssertionError: expected [ 'sys_user', 'sys_org', …(3) ] to deeply equal [ Array(5) ]
-   "sys_organization",
+   "sys_org",
```

（把审计用例的等待锚从 Organizations 卡片换到 Users 卡片,就是为了让它红在调用清单的 diff 上,而不是红在别处的徽章上。）

## 测试

从仓库根跑,重活走共享 flock + `--max-old-space-size=4096` + `--maxWorkers=2`:

- `pnpm exec vitest run --project '@object-ui/console'` -&gt; **27 files / 242 tests passed**
- `pnpm --workspace-concurrency=2 --filter @object-ui/console type-check` -&gt; 通过(新树里先 `--filter '@object-ui/console^...' build` 建好依赖)
- `pnpm --workspace-concurrency=2 --filter @object-ui/console lint` -&gt; **0 errors**(190 warnings 全为既有 `no-explicit-any`,与 PR #3673 记录的数目一致;本次两个文件零告警)
- `node scripts/check-control-bytes.mjs` -&gt; OK;`node scripts/check-changeset-no-major.mjs` -&gt; OK

消费半径清扫:`SystemHubPage` 只在 `apps/console` 内被引用(`AppContent.tsx` 的路由声明 + `pages/settings/SettingsHub.tsx`),`packages/**` 里对它的五处提及**全是注释**,无 import;全仓 `hub-card-*` testid 的另一处产出者是 `DeveloperHubPage`,与本文件无关。同目录既有的 `SystemHubPage.metadataCards.test.tsx`(#3660 落的)不断言计数,已跑绿确认不受影响。

## 文件面

- `apps/console/src/pages/system/SystemHubPage.tsx` —— 一行对象名 + 一段说明为什么这里的错名是静默的、以及 Permissions 为什么留着
- `apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx` —— 新增(与既有的 metadataCards 测试同目录同形态:真组件 + 真 `@object-ui/components`,只 mock `useAdapter` / `useIsWorkspaceAdmin`)。适配器 stub 按**真实契约**建模:不存在的对象 **resolve 空**而不是 reject,所以测试跑在和缺陷同一种静默里
- `.changeset/system-hub-org-count-3670.md` —— patch

⛔ 未触碰:卡片 `href`(#3668 刚落)、`AppContent`、`.catch` / 错误处理、框架侧任何对象定义、以及同目录里 #3672 记录的孤儿文件 `systemObjects.ts`(它内嵌的对象定义同样写着 `sys_org` / `sys_permission`,但全仓零引用,属于那一单)。

## 越界发现(只报不改,已单独立单、未认领)

- **#3679** —— 页面这一层的 `.catch(() =&gt; ({ data: [] }))` 把 500 / 401 / 403 / 断网都渲染成一个确定的 `0`(而 404 根本到不了它);外层那个「保留 null」的降级 catch 实际是死路径。含上面那张行为矩阵与 #3670 正文机制归因的订正。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_