### PR TITLE
chore(deps): 删除未接线的 prettier devDependency (#3657)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "jsdom": "^30.0.1",
     "msw": "^2.15.0",
     "playwright": "^1.62.1",
-    "prettier": "^3.9.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-router-dom": "^7.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ importers:
       playwright:
         specifier: ^1.62.1
         version: 1.62.1
-      prettier:
-        specifier: ^3.9.6
-        version: 3.9.6
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -9582,11 +9579,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.9.6:
-    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -18551,8 +18543,6 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
-
-  prettier@3.9.6: {}
 
   pretty-format@27.5.1:
     dependencies:


### PR DESCRIPTION
Fixes #3657

按 issue 分诊裁决走 **enforce-or-remove → remove**:删掉根 `package.json` 里那条从未接线的 `prettier@^3.9.6`。

## 一、四类接线复测(基线 `origin/main` @ `278f57c36`,全部零命中)

复测在**全新 worktree、`pnpm install` 之前**执行,树里还没有 `node_modules`,所以下面每条 grep 天然不含依赖噪声。

| # | 接线面 | 复测命令 | 结果 |
| --- | --- | --- | --- |
| 1 | 配置文件 | `find . -iname '.prettierrc*' -o -iname 'prettier.config.*' -o -iname '.prettierignore' -o -iname '.editorconfig'` | **0**(仓根与任意子目录均无) |
| 2 | workflow | `grep -rn -i prettier .github/` | **0**(覆盖全部 16 个 workflow) |
| 3 | eslint | `grep -n -i prettier eslint.config.js` + `grep -rn -i prettier eslint-rules/` | **0**(无 `eslint-config-prettier` / `eslint-plugin-prettier`) |
| 4 | package.json | 全仓 46 个 `package.json` 逐个 `grep -n -i prettier` | **仅 1 处**:根 `package.json:95` 依赖声明本身。无 `prettier` 配置键,无任何 script 调用 |

补测了 issue 未列举的相邻接线面,同样为空:`.vscode/settings.json`、`.vscode/extensions.json`、`.husky/`、`lint-staged` / `husky` / `simple-git-hooks` / `pre-commit` 键,以及 `pnpm-workspace.yaml`、`turbo.json`。根 scripts 里也没有 `format` 一类的入口。

**全仓 grep 的一处订正**:排除 `node_modules` 与 `pnpm-lock.yaml` 后,提到 prettier 的文件其实是两个而非一个 —— 除依赖声明外,还有 `packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.tsx:194`。那里是英文形容词(“not a prettier view of a rule that cannot be saved”),与工具无关,不构成接线。

结论:四类接线全零,remove 的前提成立。

## 二、陷阱现场(未改动树上复现)

先证明文件与 `origin/main` 逐字节相同,再跑 `--check`:

```
$ git diff --stat origin/main -- scripts/check-doc-links.mjs
(空 —— 与 origin/main 逐字节相同)

$ pnpm exec prettier --check scripts/check-doc-links.mjs
Checking formatting...
[warn] scripts/check-doc-links.mjs
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
exit=1
```

零改动的树上 `exit=1`。因为没有配置,用的是 prettier 默认值(双引号、`printWidth: 80`),而本仓是单引号、行宽更宽。`--write` 会把它改成:

```
- import { readdirSync, readFileSync, statSync } from 'node:fs';
+ import { readdirSync, readFileSync, statSync } from "node:fs";
- const DOCS_ROUTE_PREFIX = '/docs';
+ const DOCS_ROUTE_PREFIX = "/docs";
```

规模复核(issue 报的 389 / 1646 **逐字复现**):

| 文件 | `diff \| wc -l`(issue 口径) | 仅计变更行 |
| --- | --- | --- |
| `scripts/check-doc-links.mjs` | **389** | 287 |
| `scripts/__tests__/check-doc-links.test.ts` | **1646** | 1198 |

两个数字的差别只是口径(前者含 `---` 分隔行与 `NNNcNNN` 块头),不是 main 漂移;issue 的测量可原样复现。

## 三、lockfile diff 摘要

`pnpm install` 报 `Packages: -1` / `devDependencies: - prettier 3.9.6`。lockfile 净删 11 行、增 0 行,三个 hunk 全部是 `prettier@3.9.6`:

1. `importers` 根条目(specifier + version),-3 行
2. `packages:` 的 `prettier@3.9.6` 解析块,-5 行
3. `snapshots:` 的 `prettier@3.9.6: {}`,-2 行

**`prettier@2.8.8` 原样保留**(它是 `@changesets/write` 与 `@changesets/apply-release-plan` 的传递依赖 —— changesets 自带一份 prettier 用来格式化 changeset 文件,与本仓格式化无关)。除此之外无任何解析漂移。

## 四、逆向验证:预测被推翻,如实记录

**预测**:删除后 `pnpm exec prettier --version` 应失败(不可解析)。
**实测**:**没有失败**,反而成功并报 `3.8.1`。

原因是 `pnpm exec` 在仓内找不到时会继续沿 PATH 兜底,而本容器镜像里装了一份全局 prettier:

```
$ command -v prettier
/opt/node22/bin/prettier          ->  /opt/node22/lib/node_modules/prettier/bin/prettier.cjs (3.8.1)
```

仓内这一份确实删干净了,证据是**版本号变了**:删除前 `pnpm exec prettier --version` 答 `3.9.6`(即被删的那条),删除后答 `3.8.1`(镜像全局那份);同时 `node_modules/.bin/prettier` 已不存在,lockfile 里 `grep 'prettier@3'` 零命中。

由此得到一个必须写明的**残留结论**:在装有全局 prettier 的环境里,**光删依赖并不能消灭这个假红陷阱** —— `pnpm exec prettier --check` 依然会落到全局那份上,依然对未改动内容报 `exit=1`(已实测复现)。本 PR 达成的是「仓库不再声明一条没人用的依赖」,而不是「陷阱物理消失」。补上 issue 里的三号方案(在 AGENTS.md 写明本仓不以 prettier 做格式门禁)才能真正闭合;已另开 finding 记录,不在本 PR 文件面内。

## 五、门禁

| 门禁 | 结果 |
| --- | --- |
| `pnpm exec vitest run --project unit scripts/ --maxWorkers=2` | **18 files / 337 tests passed**(含读取根 `package.json` 的 `package-files-exist`、`workspace-peer-dependency-edges`,证明无隐藏依赖) |
| `pnpm run check:control-bytes` | **OK**(3680 个跟踪文本文件) |
| 改动文件控制字符自扫 | clean |

## 六、若将来要重新引入 prettier(enforce 路)

本次走 remove 的依据是「测量已死」:四类接线全零、文档零提及、零 CI 影响。日后要装回来,不能只加回依赖 —— 那样只会把同一个假红再放一遍。enforce 路必须三件套一次到位:

1. **配置**:与现有风格一致的 `.prettierrc`(`singleQuote: true` 等)+ `.prettierignore`;
2. **接线**:挂进 `lint` 脚本与 CI workflow,让它真的会红/会拦;
3. **一次性全仓格式化基线**:单独一个 PR 把全仓格式化到位,与任何功能改动隔离,之后的 diff 才干净。

三者缺一都会退回今天这个状态:一条装不上用场的依赖 + 一个会骗人的 `--check`。

## 七、changeset

无。纯工具链 devDependency 移除,不进任何发布物,39 个包的产物与 API 零变化;按 AGENTS.md「功能改进需 changeset、纯修复不需要」的口径,此项两者皆非且零发布影响,故不写。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_