### PR TITLE
fix(console): System Hub 计数失败回落 null 而非冒充 0,单卡隔离 (#3679)

### DIFF
--- a/.changeset/system-hub-count-error-state-3679.md
+++ b/.changeset/system-hub-count-error-state-3679.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/console': patch
+---
+
+System Hub: a card count that failed to load no longer renders as `0`
+
+Each count on the System Hub fetched one object and caught its own failure with
+an empty page, so a 500, a 401, a 403 or a dropped connection all produced the
+same confident `0` as a table that really is empty — no error, no retry, and no
+way to tell the two apart. The most reachable case was a permission denial on a
+single object: an administrator who may open the hub but cannot read
+`sys_audit_log` was shown "0 entries" rather than being told anything at all.
+
+A failed lookup now leaves that card's count unknown, and the badge — which
+already renders only for a known count — is omitted, so the card shows no
+number instead of a wrong one. The catch stays on each call rather than around
+the batch, so one object's failure blanks only its own card and the cards beside
+it keep the real numbers they received.
+
+Unchanged: an object the backend does not have still counts `0`. The adapter
+resolves an unregistered object as an empty page by design (callers read empty
+as "feature unavailable"), so that never was an error and is not treated as one
+here.

--- a/apps/console/src/pages/system/SystemHubPage.tsx
+++ b/apps/console/src/pages/system/SystemHubPage.tsx
@@ -55,6 +55,21 @@ interface HubCard {
   adminOnly?: boolean;
 }
 
+/**
+ * One card's count from one `find` result: the row count when the lookup
+ * succeeded, `null` when it did not.
+ *
+ * `null` is not a formatting preference — it is the only shape this page has
+ * for "we do not know". The badge renders on `count !== null`, so an unknown
+ * count shows no badge at all, while `0` is a claim: the backend answered, and
+ * the answer was none. Collapsing a failed lookup into `0` prints a number
+ * nothing ever confirmed, and a 500 / 401 / 403 / offline then looks exactly
+ * like an empty table (objectui#3679).
+ */
+function countOrUnknown(result: { data?: unknown[] } | null): number | null {
+  return result === null ? null : (result.data?.length ?? 0);
+}
+
 export function SystemHubPage() {
   const navigate = useNavigate();
   const { appName } = useParams();
@@ -104,22 +119,46 @@ export function SystemHubPage() {
       // MEASUREMENT case in this page's test rather than quietly re-aimed.
       //
       // TODO: Replace with count-specific API endpoint when available
+      //
+      // Each `.catch` resolves to `null`, NOT to an empty page. What these
+      // catches actually cover is the class the adapter does NOT absorb: it
+      // rethrows everything that is not a 404, so a 500 / 401 / 403 / offline
+      // / timeout lands here. Answering that with `{ data: [] }` used to print
+      // a confident `0` — the same pixel as "there really are none", with no
+      // error, no retry and no way for an administrator to tell the two apart
+      // (objectui#3679). `null` flows into `counts` and the badge's existing
+      // `count !== null` branch simply omits the badge.
+      //
+      // Per call rather than once around the `Promise.all`, because the most
+      // reachable failure is a permission denial on ONE object — an admin who
+      // may open this hub but cannot read `sys_audit_log` should lose that
+      // card's number only, not the four beside it that answered fine.
+      //
+      // A 404 still does not reach here and still renders `0`: the adapter
+      // resolves unregistered objects as an empty page on purpose (see above).
+      // That is its contract, not a failure — the one card still riding on it
+      // is Permissions, which is objectui#3655's decision to close.
       const [usersRes, orgsRes, positionsRes, permsRes, logsRes] = await Promise.all([
-        dataSource.find('sys_user').catch(() => ({ data: [] })),
-        dataSource.find('sys_organization').catch(() => ({ data: [] })),
-        dataSource.find('sys_position').catch(() => ({ data: [] })),
-        dataSource.find('sys_permission').catch(() => ({ data: [] })),
-        dataSource.find('sys_audit_log').catch(() => ({ data: [] })),
+        dataSource.find('sys_user').catch(() => null),
+        dataSource.find('sys_organization').catch(() => null),
+        dataSource.find('sys_position').catch(() => null),
+        dataSource.find('sys_permission').catch(() => null),
+        dataSource.find('sys_audit_log').catch(() => null),
       ]);
       setCounts({
-        users: usersRes.data?.length ?? 0,
-        orgs: orgsRes.data?.length ?? 0,
-        positions: positionsRes.data?.length ?? 0,
-        permissions: permsRes.data?.length ?? 0,
-        auditLogs: logsRes.data?.length ?? 0,
+        users: countOrUnknown(usersRes),
+        orgs: countOrUnknown(orgsRes),
+        positions: countOrUnknown(positionsRes),
+        permissions: countOrUnknown(permsRes),
+        auditLogs: countOrUnknown(logsRes),
       });
     } catch {
-      // Keep nulls on failure
+      // Keep nulls on failure. Only a SYNCHRONOUS throw from `dataSource.find`
+      // can arrive here: the `.catch`es above are attached to the returned
+      // promises, so nothing makes `Promise.all` reject. That is why this
+      // branch is not where the fix went — leaving the counts untouched only
+      // says "unknown" because they are still `null`, and `setCounts` above is
+      // the only place a lookup's outcome is ever written.
     } finally {
       setLoading(false);
     }

--- a/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
+++ b/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
@@ -31,11 +31,22 @@
  * `SystemHubPage` itself is the real component, as in the sibling
  * `SystemHubPage.metadataCards.test.tsx` — a transcribed copy of the card list
  * is precisely how a wrong name survives.
+ *
+ * ── objectui#3679 ──────────────────────────────────────────────────────────
+ * A second describe block was added below for the other half of the same
+ * pixel. The names above decide WHICH object is counted; the error handling
+ * decides whether a count that never arrived is allowed to be spelled `0`. It
+ * no longer is: a non-404 rejection (500 / 401 / 403 / offline — the only
+ * class the adapter does not absorb) leaves that card's count `null`, and the
+ * badge's existing `count !== null` branch drops the badge. The MEASUREMENT
+ * case that pinned the old collapse-into-0 was rewritten there, as its own
+ * comment asked for; the other two MEASUREMENTs still pin objectui#3655's gap
+ * and are untouched.
  */
 
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, within, cleanup } from '@testing-library/react';
+import { render, screen, within, cleanup, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 // Hoisted so the vi.mock factories below can close over them, and so the
@@ -143,6 +154,54 @@ async function badge(cardTestId: string, text: string) {
   return within(card).findByText(text);
 }
 
+/**
+ * A card's count badge, or `null` when the card shows none — which is how this
+ * page says "unknown" (the badge renders only on `count !== null`).
+ *
+ * Anchored `^…$` on purpose: the card's title and description carry the same
+ * label word ("Manage system users and accounts"), so an unanchored match
+ * would find text on a card that has no badge at all.
+ */
+function countBadge(cardTestId: string, label: string) {
+  return within(screen.getByTestId(cardTestId)).queryByText(
+    new RegExp(`^\\d+\\s+${label}$`),
+  );
+}
+
+/**
+ * Settles the fetch when NO badge is expected to appear, so awaiting one is not
+ * an option. `fetchCounts` clears `loading` in its `finally`, so the spinner
+ * going away is the single anchor that holds whether the calls resolved,
+ * rejected, or threw synchronously.
+ */
+async function settleWithoutBadges() {
+  await waitFor(() =>
+    expect(screen.queryByText('Loading statistics...')).not.toBeInTheDocument(),
+  );
+}
+
+/** Every card that carries a count, as [testid, countLabel]. */
+const COUNTED_CARDS: ReadonlyArray<readonly [string, string]> = [
+  ['hub-card-users', 'users'],
+  ['hub-card-organizations', 'organizations'],
+  ['hub-card-positions', 'positions'],
+  ['hub-card-permissions', 'permissions'],
+  ['hub-card-audit-log', 'entries'],
+];
+
+/**
+ * The object names the page asks for, in call order — including
+ * `sys_permission`, which the framework does not register (objectui#3655) and
+ * so is absent from the fixture registry above.
+ */
+const QUERIED_OBJECT_NAMES = [
+  'sys_user',
+  'sys_organization',
+  'sys_position',
+  'sys_permission',
+  'sys_audit_log',
+];
+
 describe('System Hub card counts — object names (objectui#3670)', () => {
   it('counts Organizations through sys_organization, the name the framework registers', async () => {
     renderHub();
@@ -183,10 +242,16 @@ describe('System Hub card counts — object names (objectui#3670)', () => {
   });
 
   // ── MEASUREMENT ────────────────────────────────────────────────────────────
-  // The three cases below pin the CURRENT behaviour, not the desired one. They
+  // The two cases below pin the CURRENT behaviour, not the desired one. They
   // exist so the remaining gap is visible in the suite instead of being read as
   // a missed line, and so whoever resolves objectui#3655 has a failing anchor
   // to rewrite rather than a silent pass.
+  //
+  // There were three. The third — "a non-404 failure is collapsed into 0 as
+  // well, with no error affordance" — named objectui#3679 as the work that
+  // would rewrite it, and that work is done: it now lives in the next describe
+  // block with its expectation inverted. These two stay measurements because
+  // objectui#3655 is still open.
 
   it('MEASUREMENT: Permissions still reads 0 while both candidate objects hold rows', async () => {
     renderHub();
@@ -216,20 +281,96 @@ describe('System Hub card counts — object names (objectui#3670)', () => {
     expect(within(screen.getByTestId('hub-card-permissions')).getByText('0 permissions')).toBeInTheDocument();
   });
 
-  it('MEASUREMENT: a non-404 failure is collapsed into 0 as well, with no error affordance', async () => {
-    // The 404 never reaches the page's `.catch` — the adapter ate it upstream.
-    // What that `.catch` really covers is this: a 500 (or 401 / 403 / offline)
-    // on ONE object, rendered as a confident `0` on that card while its
-    // neighbours show real numbers. Recorded here only; changing the error
-    // handling is a separate class of work, filed as objectui#3679.
+});
+
+describe('System Hub card counts — a lookup that failed is not a `0` (objectui#3679)', () => {
+  it('a 500 on one object blanks that card instead of collapsing it into 0', async () => {
+    // This is the rewrite of PR #3680's third MEASUREMENT ("a non-404 failure
+    // is collapsed into 0 as well, with no error affordance") — same fixture,
+    // inverted expectation. The 404 never reaches the page's `.catch`; the
+    // adapter ate it upstream. What that `.catch` really covers is this.
     state.failures.sys_user = Object.assign(new Error('Internal Server Error'), {
       status: 500,
     });
     renderHub();
 
-    expect(await badge('hub-card-users', '0 users')).toBeInTheDocument();
-    // The per-call `.catch` also keeps `Promise.all` from rejecting, so the
-    // other four cards still resolve — including the one this PR fixed.
-    expect(within(screen.getByTestId('hub-card-organizations')).getByText('2 organizations')).toBeInTheDocument();
+    // Organizations answered, so the whole wall has settled once its badge is
+    // up — all five counts land in one `setCounts`.
+    expect(await badge('hub-card-organizations', '2 organizations')).toBeInTheDocument();
+    expect(countBadge('hub-card-users', 'users')).toBeNull();
+    // Spelled out, because `0 users` is the exact string this issue is about.
+    expect(screen.queryByText('0 users')).not.toBeInTheDocument();
   });
+
+  it('blanks only the card that failed and leaves its neighbours their real counts', async () => {
+    // The issue's most reachable scenario, and the one an administrator is
+    // most likely to act on: someone who may open the hub but has no read
+    // permission on `sys_audit_log`. The backend answers 403, the adapter
+    // rethrows (it absorbs 404s only), and this card used to read "0 entries"
+    // — an audit log that looks empty to the person auditing it.
+    state.failures.sys_audit_log = Object.assign(new Error('Forbidden'), {
+      status: 403,
+    });
+    renderHub();
+
+    await badge('hub-card-users', '3 users');
+    expect(countBadge('hub-card-audit-log', 'entries')).toBeNull();
+    // Single-card isolation — the reason the `.catch` stayed on each call
+    // instead of moving out around the `Promise.all`. The other four answered,
+    // so they still show their numbers.
+    expect(countBadge('hub-card-users', 'users')).toHaveTextContent('3 users');
+    expect(countBadge('hub-card-organizations', 'organizations')).toHaveTextContent(
+      '2 organizations',
+    );
+    expect(countBadge('hub-card-positions', 'positions')).toHaveTextContent('4 positions');
+    expect(countBadge('hub-card-permissions', 'permissions')).toHaveTextContent(
+      '0 permissions',
+    );
+  });
+
+  it('keeps `0` for the two things that really are zero, and blanks only the failure', async () => {
+    // All three rows of the issue's behaviour matrix in one render. Only the
+    // third moves; the first two are the adapter's contract and stay as they
+    // are (whether Permissions should be riding on row two at all is
+    // objectui#3655, not this change):
+    //   sys_audit_log   registered, genuinely empty  -> `0 entries`
+    //   sys_permission  unregistered, adapter resolves empty -> `0 permissions`
+    //   sys_position    403, adapter rethrows        -> no badge
+    state.registry.sys_audit_log = [];
+    state.failures.sys_position = Object.assign(new Error('Forbidden'), { status: 403 });
+    renderHub();
+
+    await badge('hub-card-users', '3 users');
+    expect(countBadge('hub-card-audit-log', 'entries')).toHaveTextContent('0 entries');
+    expect(countBadge('hub-card-permissions', 'permissions')).toHaveTextContent(
+      '0 permissions',
+    );
+    expect(countBadge('hub-card-positions', 'positions')).toBeNull();
+  });
+
+  it('shows no counts at all when every lookup fails, and still renders the hub', async () => {
+    // Offline, or the backend down. Every counted card loses its badge rather
+    // than reporting a system with nothing in it; the cards that never carried
+    // a count are unaffected and every link still works.
+    for (const objectName of QUERIED_OBJECT_NAMES) {
+      state.failures[objectName] = Object.assign(new Error('Failed to fetch'), {
+        status: 0,
+      });
+    }
+    renderHub();
+
+    await settleWithoutBadges();
+    for (const [testId, label] of COUNTED_CARDS) {
+      expect(countBadge(testId, label)).toBeNull();
+    }
+    expect(screen.getByTestId('hub-card-settings')).toBeInTheDocument();
+  });
+
+  // No case is written for `fetchCounts`'s OUTER `catch`. It is reachable only
+  // by a synchronous throw from `dataSource.find` (the per-call `.catch`es keep
+  // `Promise.all` from ever rejecting), and on that path the counts are still
+  // at their initial `null` — so an assertion that "no card shows a number"
+  // would pass whatever the outer catch did, including nothing. It would be
+  // green for an empty reason rather than because the page is right, so the
+  // fix stayed where the outcome is actually written, and so did the tests.
 });


### PR DESCRIPTION
Fixes #3679

## 先复核前提(#3680 的三行矩阵,逐条对 `origin/main` @ `074ec53d6` 重测)

issue 的三条论断全部成立,没有一条过期:

1. **404 到不了页面这一层**。`packages/data-objectstack/src/index.ts:1147` 的 `is404Error(err)` 命中后把资源记进 `missingResources` 并 `return { data: [], total: 0 }`(`find()` 开头 `:1117` 还有一条同名短路),给的是 resolve 不是 reject。**这是契约,本 PR 一个字节没碰。**
2. **逐 promise 的 `.catch(() =` `({ data: [] }))` 实际覆盖的只有非 404**:适配器对非 404 一律 `throw err`(`:1152`)。
3. **外层 `catch { /* Keep nulls on failure */ }` 确实进不去**:每个 promise 自带 `.catch`,`Promise.all` 不可能 reject。

另外核实了 issue 没说、但决定「复活什么」的一条:**`null` 的渲染分支是活的,不是死的**。徽章写作 `{card.count !== null && (Badge…)}`,而 Applications / Metadata / Settings / Profile 等卡片本来就是 `count: null` 且不显示徽章 —— 也就是说「不显示徽章 = 不知道」这个形态**页面现在就在用**,本 PR 只是让错误态也走进去,没有发明任何新 UI。(若这条不成立,派发要求停手报告;它成立。)

## 修法:逐 promise 回 `null`,而不是让外层接手

派发把两条路留给实测取舍,**实测结论:外层接手做不到逐卡,必须逐 promise**。

外层 catch 是**全军覆没式**的 —— 一个 reject 就让五张卡全部回 `null`。而 issue 点名的最易复现场景恰恰是**单个对象**上的权限拒绝:一个能进 System Hub、但对 `sys_audit_log` 没有读权限的管理员。让 Audit Log 那张卡失去数字是对的;顺带把 Users / Organizations / Positions 三张**已经答复成功**的卡的真实数字一起抹掉,是把一个局部故障放大成全局故障。所以 `.catch` 留在每个调用上,只是把返回值从「空页」换成 `null`。

这不是推理,是量出来的 —— 见下方逆向验证的**扰动 B**。

```ts
dataSource.find('sys_user').catch(() => null),   // 原:.catch(() => ({ data: [] }))
…
users: countOrUnknown(usersRes),                 // 原:usersRes.data?.length ?? 0
```

```ts
function countOrUnknown(result: { data?: unknown[] } | null): number | null {
  return result === null ? null : (result.data?.length ?? 0);
}
```

`0` 是一个**主张**(后端答复了,答案是「没有」);`null` 是唯一能说「不知道」的形态。

## 修前后行为矩阵

| 后端实际发生的事 | 适配器 | 页面 | 修前屏幕 | 修后屏幕 |
|---|---|---|---|---|
| 对象不存在(404 OBJECT_NOT_FOUND) | 吃掉,resolve 空 | `.catch` 未触发 | `0` | `0`(**不变** —— 契约,不是错误) |
| 对象存在但确实没有记录 | resolve 空 | `.catch` 未触发 | `0` | `0`(**不变**) |
| 500 / 401 / 403 / 断网 / 超时(单个对象) | rethrow | `.catch` → `null` | 该卡 `0`,邻卡正常 | **该卡无徽章**,邻卡数字不受影响 |
| 同上,但五个全失败 | rethrow | 五个 `.catch` → `null` | 五张全 `0` | **五张全无徽章** |

第一、二行是 #3655 / #3670-permissions 的账,⛔ 未碰;#3680 落的 Permissions 恒 0 的 MEASUREMENT 钉子原样保留。

## 外层那个 catch:照实说,没动它,也没为它写测试

派发允许「删逐 promise catch 让外层接手」,上面已说明为什么不走。剩下的问题是外层 catch 本身要不要一并改成显式 `setCounts(全 null)`。**没改**,理由是能被诚实钉住的只有它现在的样子:

- 它唯一的入口是 `dataSource.find` **同步**抛出(`.catch` 挂在返回的 promise 上,rejection 到不了外层)。
- 走到那条路时,counts 还停在初始的全 `null` —— 所以「所有卡都没有数字」这条断言**无论外层 catch 做什么都会绿**,包括什么都不做。那是「因为什么都没产生所以绿」,不是「因为逻辑对所以绿」。
- 唯一能区分的场景是**重取**(前一轮成功的数字残留在屏上)。而 `fetchCounts` 以 `dataSource` 记忆化,`AdapterProvider` 的 adapter 每次挂载只产生一次身份变化(`useState(externalAdapter ?? null)` → effect 里 `setAdapter`,依赖 `[externalAdapter]`),所以今天这条路根本走不到,想钉住它得改掉测试里「adapter 是稳定单例」的脚手架。

所以修的是**结果被写下的那一处**(`setCounts`),测试也钉在那里;外层 catch 只把注释订正为它真实的可达条件。测试文件里留了一段说明,免得下一个读者以为这里漏了一条用例。

## 逆向验证(两个扰动,方向都先预测后运行)

### 扰动 A —— 把逐 promise 的 `.catch` 退回 `({ data: [] })`(即复现缺陷)

**预测:4 红 | 9 绿**(本文件 4 红 5 绿 + metadataCards 4 绿)。红的应是新增那 4 条错误态用例,方向是**又见确定的 0**;而这 4 条用例内部的「邻卡仍显示真实数字」「真实空集仍是 0」那些断言在两个方向下都绿 —— 它们钉的是不该动的东西,不是这次改动的证据,这点照实预测,不假装它们会跟着红。

**实测:`Tests 4 failed | 5 passed (9)`,逐条吻合。** 失败现场直接把缺陷打印出来:

```
× a 500 on one object blanks that card instead of collapsing it into 0
× blanks only the card that failed and leaves its neighbours their real counts
× keeps `0` for the two things that really are zero, and blanks only the failure
× shows no counts at all when every lookup fails, and still renders the hub

AssertionError: expected div …(1)/div to be null
+ Received:
  0
   
  users
```

### 扰动 B —— 删掉逐 promise 的 `.catch`,让外层接手(派发点名的另一条修法)

这一扰动才是「逐 promise vs 外层」的实测取舍,方向和 A **不同**,所以单独预测:

**预测:3 红 | 6 绿**,且红法不是断言 diff 而是**等待锚超时** —— 前三条用例都以一张「答复成功」的邻卡徽章作为 settle 锚(`2 organizations` / `3 users`),外层接手后这些邻卡连同失败的那张一起没了数字,锚永远等不到。第 4 条(五个全失败)两种形态下结果相同,应保持**绿**。

**实测:`Tests 3 failed | 6 passed (9)`,逐条吻合:**

```
× a 500 on one object blanks that card …            1058ms
× blanks only the card that failed …                1031ms
× keeps `0` for the two things that really are zero … 1037ms

TestingLibraryElementError: Unable to find an element with the text: 2 organizations
TestingLibraryElementError: Unable to find an element with the text: 3 users
```

「答复成功的邻卡失去了它的数字」正是选择逐 promise 的理由,现在是量出来的。

## 测试

`SystemHubPage.counts.test.tsx` 新增 4 条(#3680 落的 6 条中,5 条原样未动):

| 用例 | 钉住什么 |
|---|---|
| `a 500 on one object blanks that card instead of collapsing it into 0` | #3680 第三条 MEASUREMENT 的**重写**(同 fixture,期望反转) |
| `blanks only the card that failed and leaves its neighbours their real counts` | **硬验收**:`sys_audit_log` 403 → 该卡无徽章;其余四张仍是 `3 users` / `2 organizations` / `4 positions` / `0 permissions`(单卡隔离) |
| `keeps 0 for the two things that really are zero, and blanks only the failure` | 三行矩阵同屏:真实空集 `0 entries`、未注册对象 `0 permissions`、403 无徽章 |
| `shows no counts at all when every lookup fails, and still renders the hub` | 断网:五张全无徽章,页面照常渲染,链接仍可用 |

**关于那条被重写的 MEASUREMENT**:派发写的是测试「只加不改」,但 #3680 落的 6 条里有一条 —— `MEASUREMENT: a non-404 failure is collapsed into 0 as well, with no error affordance` —— 钉的正是本单要修的行为,它自己的注释也写明「changing the error handling is a separate class of work, filed as objectui#3679」。留着它必红,故按其原意重写(同 fixture、期望反转、迁进新 describe),并在原 MEASUREMENT 段落注明「原本三条,第三条已完成并搬走」。另外两条 MEASUREMENT 钉的是 #3655 的缺口,**未动**。

从仓库根跑,重活走共享 flock + `--max-old-space-size=4096` + `--maxWorkers=2`:

- `pnpm exec vitest run --project '@object-ui/console'` → **27 files / 245 tests passed**(#3680 记录的 242 + 新增 4 - 重写 1)
- `pnpm --workspace-concurrency=2 --filter @object-ui/console type-check` → 通过(新树里先 `--filter '@object-ui/console^...' build` 建好依赖)
- `pnpm --workspace-concurrency=2 --filter @object-ui/console lint` → **0 errors / 190 warnings**,与 #3680 记录的数目一致。`SystemHubPage.tsx` 上那条 `react-hooks` 告警(`useEffect` 里同步 setState)**是既有的** —— 已把该文件切回 `origin/main` 版本单跑 lint 复核,同一条告警在同一行、总数同为 190,本次零新增。
- `node scripts/check-control-bytes.mjs` → OK;`check-changeset-no-major.mjs` / `check-changeset-fixed.mjs` → OK
- 改动文件另做了越过门禁的自扫:`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 零命中

**消费半径清扫**:全仓 `hub-card-*` testid 的产出者只有 `SystemHubPage`(本文件)与无关的 `DeveloperHubPage`;同目录 `SystemHubPage.metadataCards.test.tsx` 不断言计数,已随全量跑绿。计数徽章文案(`0 users` 等)在 `packages/**` 的唯一命中是 `AssignedUsersSection.tsx` 里的一句注释,与本页无关。

## 文件面

- `apps/console/src/pages/system/SystemHubPage.tsx` —— 五个 `.catch` 回 `null` + `countOrUnknown` 辅助函数 + 说明为什么是逐 promise、为什么 404 不走这里、外层 catch 真实可达条件
- `apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx` —— 新增 describe(4 条)+ 重写上述那条 MEASUREMENT
- `.changeset/system-hub-count-error-state-3679.md` —— patch(用户可见:错误态不再冒充 `0`)

⛔ 未触碰:`packages/data-objectstack` 的 `missingResources` / `is404Error` 设计、卡片 `href`、Permissions 的对象名与其 MEASUREMENT 钉、其他任何文件。

## 越界发现(只报不改,已单独立单、未认领)

- **#3685** —— 修后「无徽章」与「这张卡本来就没有计数」(Settings / Profile / AI Approvals 等)以及加载中三态在屏幕上仍然同形,403 的管理员得到的是沉默而不是「你没有权限」。issue #3679 正文的修法方向 1 里那句「必要时补一句错误文案」正是它,本单派发面明确划在界外(「复活现存设计,不发明新 UI」),故另立。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_