### PR TITLE
fix(cli,create-plugin): 删掉两包 files 里声明的 templates —— 该目录从未存在过 (#3665)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,6 @@
   },
   "files": [
     "dist",
-    "templates",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -9,7 +9,6 @@
   },
   "files": [
     "dist",
-    "templates",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/packages/create-plugin/src/index.ts
+++ b/packages/create-plugin/src/index.ts
@@ -12,10 +12,6 @@ import chalk from 'chalk';
 import prompts from 'prompts';
 import * as path from 'path';
 import fs from 'fs-extra';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const program = new Command();
 
@@ -110,9 +106,6 @@ async function createPlugin(pluginName?: string, options: PluginOptions = {}) {
   // Create directory structure
   fs.mkdirpSync(targetDir);
   fs.mkdirpSync(path.join(targetDir, 'src'));
-
-  // Get template directory
-  const templateDir = path.join(__dirname, '..', 'templates', 'plugin');
 
   // Template variables
   const vars = {

--- a/scripts/__tests__/package-files-exist.test.ts
+++ b/scripts/__tests__/package-files-exist.test.ts
@@ -67,22 +67,17 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * can only shrink. Fix one by deleting the stale `files` entry from the
  * package's `package.json` and deleting its line here.
  *
- * Both current entries are vestigial declarations, measured on
- * main@dae1ac41e: neither `templates` directory exists on disk, neither has
- * EVER existed in this repo's git history (an all-branch `git log
- * --diff-filter=A` over both paths returns nothing), and no build step or
- * workflow creates one. Both packages inline their templates instead —
- * `@object-ui/cli` as an
- * object literal in `src/commands/init.ts`, and `@object-ui/create-plugin` by
- * constructing the generated `package.json` in code, leaving
- * `src/index.ts`'s `templateDir` assigned and never read. So nothing is broken
- * for a user today; the manifests simply state something untrue, which is the
- * defect objectui#3663 is about.
+ * Currently empty, which is the intended resting state — the ratchet still
+ * fails on any NEW violation. It landed carrying two entries measured on
+ * main@dae1ac41e, `packages/cli/templates` and
+ * `packages/create-plugin/templates`: vestigial declarations for directories
+ * that never existed on disk, never existed anywhere in this repo's git
+ * history, and that no build step or workflow creates. Both packages inline
+ * their templates instead. objectui#3665 banked both by deleting the two
+ * `files` entries, and deleting a declaration retires a baseline line exactly
+ * as creating the file would.
  */
-const KNOWN_MISSING: Record<string, { issue: string }> = {
-  'packages/cli/templates': { issue: 'objectui#3665' },
-  'packages/create-plugin/templates': { issue: 'objectui#3665' },
-};
+const KNOWN_MISSING: Record<string, { issue: string }> = {};
 
 interface WorkspacePackage {
   name: string;


### PR DESCRIPTION
Fixes #3665

## 问题

`@object-ui/cli` 与 `@object-ui/create-plugin` 的 `package.json` 都在 `files` 里点名要打包 `templates`,而两个目录**都不存在,也从未存在过**。npm 对 `files` 里缺失的条目静默跳过 —— 不报错、不警告、退出码 0 —— 所以发布出去的 tarball 效果上是对的,失真的只有 manifest 本身:它声明要打包一个不存在、也永远不会存在的目录。这是 #3647(plugin-tree 声明 LICENSE 而文件不存在)的同一机制,方向相反 —— 那次的正确修法是补文件,这次是删声明。

## 前提复核(在 origin/main @ d2fd044b7 上实测,先证后改)

| 事实 | 命令 | 结果 |
| --- | --- | --- |
| 两处 `files` 确实含 `templates` | 读 package.json | 两包均为 `dist, templates, README.md, CHANGELOG.md, LICENSE` |
| 磁盘不存在 | `ls packages/{cli,create-plugin}/` | 无 templates 目录 |
| git 历史从未有过 | `git log --all --diff-filter=A -- 'packages/cli/templates/**' 'packages/create-plugin/templates/**'` | 空输出 |
| 未被 git-ignore(不是构建产物豁免) | `git check-ignore -v` 两路径 | exit 1(未命中任何规则) |
| 构建不会生成 | 两包 tsup.config.ts | 只声明 `entry` + `dts`,产物只进 `dist/` |
| cli 模板已内联 | `src/commands/init.ts:17` | `const templates = {` 对象字面量,由 `:381` 取用 |
| create-plugin 的 templateDir 是死变量 | 全包 grep `templateDir` | 只有 `src/index.ts:115` 一处,即其赋值本身 |

issue 正文的三条佐证全部复现,前提成立。

## 改动(4 个文件)

1. `packages/cli/package.json` —— 删 `files` 里的 `"templates"` 一行。
2. `packages/create-plugin/package.json` —— 同上。
3. `packages/create-plugin/src/index.ts` —— 删死变量 `templateDir`,以及**唯一存在意义就是算它**的 `fileURLToPath` import + `__filename` + `__dirname` 三行。
4. `scripts/__tests__/package-files-exist.test.ts` —— 清空 `KNOWN_MISSING` 的两条(#3667 为本单挂的账)。

### 关于 index.ts:201 残留的那个 `__dirname`

删完之后文件里仍能 grep 到一个 `__dirname`:

```
201:      entry: path.resolve(__dirname, 'src/index.tsx'),
```

它**不是**漏网的引用 —— 它落在 `const viteConfig = ` 开头的模板字符串**内部**,是要被逐字写进脚手架产物 `vite.config.ts` 的字面文本(该行没有 `${...}` 插值,`${pascalCaseName}` 才是插值)。它指的是**被生成的那个插件包**自己的 `__dirname`,与本模块无关。下面的构建产物 diff 是这一判断的机械佐证。

## 顺序验收:棘轮双向性的现场演示(先写下预测,再跑)

#3667 的逆向验证 C 钉住过一个反直觉方向:**修好一个缺陷会让套件转红,直到基线里那一行也被删掉**。本单正是被那半边棘轮逼出来的,所以分两步跑,两步输出都在这里。

### 第 (a) 步 —— 只删两个 `package.json` 的 `templates` 行,**不动** `KNOWN_MISSING`

**预测(动手前写下):** `1 failed | 4 passed`;红的是 `the objectui#3647 baseline only shrinks`,报陈旧并逐条点名;存在性断言保持绿(条目已不在 `files` 里,无可校验)。

**实测 —— 命中:**

```
 ❯ |unit| scripts/__tests__/package-files-exist.test.ts (5 tests | 1 failed) 13ms
     × the objectui#3647 baseline only shrinks 8ms

AssertionError: A KNOWN_MISSING entry is stale — the path now resolves, so the defect is fixed.
Delete its line from KNOWN_MISSING in this file to bank the progress.

packages/cli/templates (objectui#3665)
packages/create-plugin/templates (objectui#3665): expected [ 'packages/cli/templates', …(1) ] to deeply equal []

 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

### 第 (b) 步 —— 清空 `KNOWN_MISSING`

**预测:** 5 条全绿。

**实测 —— 命中:**

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### 一处必须写明的方向差异(否则下一个读者会被消息误导)

#3667 的 C 方向是**把路径建出来**让它 resolve;本单走的是**另一条**路径 —— 把声明删掉,于是该条目根本不再进入 `declared`,自然不在 `stillMissing` 里。终态判定相同(`stale`),但失败消息首行写死的是 `the path now resolves` —— 而此刻 `packages/cli/templates` **并没有** resolve,它依然不存在,只是不再被声明。补救指令(「删掉 KNOWN_MISSING 里那一行」)在两条路径下都正确,所以不会把人引向错误动作,但归因句与现场不符。**已另行开单 #3674 记录**(观察类,`finding` 标签);修它要改该文件的断言消息,超出本单文件面,故本 PR 不动。

## 零行为佐证一:`npm pack --dry-run` 受控 A/B

⚠️ 先说一次方法论上的自我纠正,免得清单读起来有歧义:最初的对照是「改前(未构建 worktree)vs 改后」,而中途为跑 cli 的 type-check 构建了依赖、cli 自己的测试又生成了 `dist/`,于是「改后」清单凭空多出 7 个 dist 文件 —— 那个差异来自构建,不来自本改动,该对照**已作废**。下面是重做的版本:**同一棵已构建的树上**,只把那一行加回去、再删掉,其余一切不动。

**`@object-ui/cli`** —— 带 `templates` 行 / 不带,清单逐字节相同,均 12 个文件:

```
Tarball Contents
32.5kB CHANGELOG.md
1.1kB LICENSE
3.4kB README.md
48.7kB dist/chunk-EV2DCI7W.js
74.4kB dist/chunk-EV2DCI7W.js.map
20B dist/cli.d.ts
42.6kB dist/cli.js
85.0kB dist/cli.js.map
685B dist/index.d.ts
116B dist/index.js
71B dist/index.js.map
1.8kB package.json
```

**`@object-ui/create-plugin`** —— 带 / 不带,同样相同,均 6 个文件:

```
Tarball Contents
6.4kB CHANGELOG.md
1.1kB LICENSE
2.3kB README.md
20B dist/index.d.ts
9.3kB dist/index.js
1.4kB package.json
```

`templates` 本来就打不进 tarball(npm 静默跳过),删掉声明对发布物的影响精确为零。

## 零行为佐证二:构建产物 diff(证明死变量删除对脚手架产物无影响)

`create-plugin` 没有测试文件,所以改用更硬的证据:把 `git show HEAD` 的旧源码与新源码分别 tsup 构建,diff 两份 `dist/index.js`。**全部差异恰好是被删的两处,一行不多:**

```diff
 import prompts from "prompts";
 import * as path from "path";
 import fs from "fs-extra";
-import { fileURLToPath } from "url";
-var __filename = fileURLToPath(import.meta.url);
-var __dirname = path.dirname(__filename);
 var program = new Command();
@@
   fs.mkdirpSync(targetDir);
   fs.mkdirpSync(path.join(targetDir, "src"));
-  const templateDir = path.join(__dirname, "..", "templates", "plugin");
   const vars = {
```

产物里**没有任何其他行发生变化** —— 包括那段生成 `vite.config.ts` 的模板字符串,它里面的 `__dirname` 原样保留,证实了上面「那是字面文本、不是引用」的判断。脚手架生成什么,一个字节都没变。

## 验证

```
$ pnpm exec vitest run scripts/__tests__/ --maxWorkers=2        # 全量 scripts 门禁套件
 Test Files  17 passed (17)
      Tests  305 passed (305)

$ pnpm exec vitest run packages/cli/ --maxWorkers=2
 Test Files  2 passed (2)
      Tests  38 passed (38)

$ pnpm --workspace-concurrency=2 --filter @object-ui/create-plugin type-check    # tsc --noEmit
 exit 0
$ pnpm --workspace-concurrency=2 --filter @object-ui/create-plugin lint          # eslint .
 exit 0

$ pnpm --workspace-concurrency=2 --filter @object-ui/cli type-check
 exit 0

$ pnpm type-check:scripts
 exit 0
$ npx eslint scripts/__tests__/package-files-exist.test.ts
 exit 0

$ node scripts/check-control-bytes.mjs
 ✅  check-control-bytes: OK (scanned 3672 tracked text file(s); skipped 85 binary).
```

`@object-ui/cli` 的 type-check **第一次是红的**,报 `Cannot find module '@object-ui/types/zod'` —— 这是全新 worktree 的陈旧产物陷阱(AGENTS.md §9 的同族),不是本改动。先跑 `pnpm --workspace-concurrency=2 --filter '@object-ui/cli^...' build` 把依赖构建出来后即转绿,如上。记在这里是因为它读起来非常像「你的改动弄坏了一个 import」。

另:除 `check-control-bytes` 外,对 4 个改动文件另做了一次超出门禁扫描面的自查 —— `grep -naP` 扫 `\x00`-`\x08` / `\x0b` / `\x0c` / `\x0e`-`\x1f` 无命中,并逐码点统计零宽与不可见字符(U+200B / U+FEFF / U+2028 等)计数均为 0。

## 文件面披露:改了 `KNOWN_MISSING` 上方的一段文档注释

派发的文件面是「清空 KNOWN_MISSING 两条,该文件其余**断言**一行不动」。**我没有动任何断言**,但改写了 `KNOWN_MISSING` 上方文档注释的最后一段,理由需要摆明:

那一段以**现在时**逐条描述我正要删掉的两个条目(`Both current entries are vestigial declarations, measured on main@dae1ac41e: neither templates directory exists...`)。map 清空后这段话会变成一份「描述两个并不存在的条目」的声明 —— 与本 PR 正在消除的失真**完全同一类**,只是从 `package.json` 搬到了注释里。

改写只做两件事:把已死的现在时描述换成历史记录,并补记「删声明与建文件同样使基线条目退休」(即上面那处方向差异)。**ratchet 机理与修复指引两段原文一字未动**,其下所有断言与逻辑一字未动。此项已向 PM 报备并获预先接受;若判定越界,单独回退这一段即可,不影响其余三个文件。

## 关于 changeset:判定为不加

按 #3662 确立的判断框架:

1. **仓规明文**:AGENTS.md 第 151 行 —— 功能改进(feature)需写 changeset,纯缺陷修复不需要。本 PR 是 manifest 失真订正加死代码清除。
2. **用户可见变化精确为零**:上面两份受控 A/B 证明两个包的 tarball 清单逐文件相同,构建产物 diff 证明脚手架行为字节不变。这比 #3662 的处境更弱 —— 那个 PR **确实改变了** tarball 内容(往里加了一份 LICENSE),尚且判定不加 changeset。
3. **代价不成比例**:`.changeset/config.json` 把 39 个包放在同一个 `fixed` 组,为一条 manifest 订正会把整组推一个版本。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_