### PR TITLE
docs(packages): 退役 36 个包 README 里已死的 release-metadata §Compatibility 生成块

### DIFF
--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -613,8 +613,6 @@ pins (20) each have an independent cap. See the guide below for details.
 See [User-Scoped State Persistence](../../content/docs/guide/user-state-persistence.md)
 for the adapter contract, backend schema, and how to plug in your own backend.
 
-<!-- release-metadata:v3.3.0 -->
-
 ## Command palette (⌘K)
 
 `<ConsoleShell>` mounts a global ⌘K command palette for cross-app navigation and
@@ -770,15 +768,6 @@ import { PreviewBadge, getPlatformStage } from '@object-ui/app-shell';
 ```
 
 Labels are localized under `topbar.stage.*` (`@object-ui/i18n`).
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
 
 ## Links
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -207,17 +207,6 @@ function MyComponent() {
 
 > **⚠️ Security:** Preview mode should **never** be used in production environments.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/auth)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -132,14 +132,6 @@ await serve('app.json', { port: '3000', host: 'localhost' });
 await init('my-app', { template: 'dashboard' });
 ```
 
-## Compatibility
-
-- **Node.js** ≥ 18
-- **TypeScript** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`** ^3.3.0
-- **`@objectstack/client`** ^3.3.0
-- **Tailwind CSS** ≥ 3.4
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/utilities/cli)

--- a/packages/collaboration/README.md
+++ b/packages/collaboration/README.md
@@ -116,17 +116,6 @@ Threaded comment component with @mentions:
 />
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/collaboration)

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -211,17 +211,6 @@ registerRenderer('custom-button', CustomButton)
 
 See [full documentation](https://objectui.org/docs/components) for detailed API reference.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/components)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -143,16 +143,6 @@ This allows the core types and logic to be used in:
 
 See [full documentation](https://objectui.org/docs/api) for detailed API reference.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/guide/architecture)

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -83,16 +83,6 @@ pnpm create @object-ui/plugin my-plugin --description "My awesome plugin" --auth
    pnpm test
    ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/guide/plugin-development)

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -470,16 +470,6 @@ dataSource.clearCache();
 dataSource.invalidateCache('users');
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/guide/data-source)

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -115,17 +115,6 @@ Client-side hiding is UX only — gate authorization-sensitive values on the
 server too. See
 [`content/docs/fields/select.mdx`](../../content/docs/fields/select.mdx).
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/guide/fields)

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -136,17 +136,6 @@ isRTL('ar'); // true
 isRTL('en'); // false
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/i18n)

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -121,17 +121,6 @@ All components accept `className` prop for Tailwind customization:
 
 For detailed API documentation, visit the [Object UI Documentation](https://www.objectui.org/docs/layout/app-shell).
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/guide/layout)

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -127,17 +127,6 @@ const manifest = generatePWAManifest({ name: 'My App', themeColor: '#000' });
 registerServiceWorker({ cacheStrategy: 'network-first' });
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/mobile)

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -121,17 +121,6 @@ const store = createPermissionStore(permissionConfig);
 store.check('read', 'orders'); // true | false
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/permissions)

--- a/packages/plugin-ai/README.md
+++ b/packages/plugin-ai/README.md
@@ -120,17 +120,6 @@ Components auto-register with `ComponentRegistry`:
 }
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-ai)

--- a/packages/plugin-calendar/README.md
+++ b/packages/plugin-calendar/README.md
@@ -254,17 +254,6 @@ const schema: CalendarViewSchema = {
 };
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-calendar)

--- a/packages/plugin-charts/README.md
+++ b/packages/plugin-charts/README.md
@@ -120,17 +120,6 @@ By using lazy loading, the main application bundle stays lean:
 
 This results in significantly faster initial page loads for applications that don't use charts on every page.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-charts)

--- a/packages/plugin-chatbot/README.md
+++ b/packages/plugin-chatbot/README.md
@@ -211,17 +211,6 @@ const aiSchema = {
 | Stop/Reload | Stop cancels timer | Stop interrupts stream |
 | Backend | None required | service-ai (IAIService) |
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-chatbot)

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -386,17 +386,6 @@ file system, …) per the protocol-agnostic architecture rule.
 > dashboards. If you still want a browser-local cache for a demo, do it
 > in the parent inside `onSchemaChange`.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-dashboard)

--- a/packages/plugin-designer/README.md
+++ b/packages/plugin-designer/README.md
@@ -129,17 +129,6 @@ const { zoom, pan, resetView } = useCanvasPanZoom();
 import { ConfirmDialog, Minimap, PropertyEditor, VersionHistory } from '@object-ui/plugin-designer';
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-designer)

--- a/packages/plugin-detail/README.md
+++ b/packages/plugin-detail/README.md
@@ -240,17 +240,6 @@ shared draft (`InlineEditProvider` from `@object-ui/react`), committed by
   gate `InlineEditProvider.canEdit` when the record is approval-locked, so a
   locked record hides its edit affordances instead of rejecting at Save.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-detail)

--- a/packages/plugin-editor/README.md
+++ b/packages/plugin-editor/README.md
@@ -105,17 +105,6 @@ pnpm build
 # The package will generate proper ESM and UMD builds with lazy loading preserved
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-editor)

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -357,17 +357,6 @@ The plugin includes these field components:
 - Date picker
 - File upload
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-form)

--- a/packages/plugin-gantt/README.md
+++ b/packages/plugin-gantt/README.md
@@ -422,17 +422,6 @@ const gantt: GanttSchema = {
 };
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-gantt)

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -406,17 +406,6 @@ const grid: GridSchema = {
 };
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-grid)

--- a/packages/plugin-kanban/README.md
+++ b/packages/plugin-kanban/README.md
@@ -169,17 +169,6 @@ const schema = {
 };
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-kanban)

--- a/packages/plugin-list/README.md
+++ b/packages/plugin-list/README.md
@@ -204,17 +204,6 @@ that label (see `getSortValue` in `@object-ui/core`).
 
 The ListView automatically persists the user's view type preference in localStorage using the key `listview-{objectName}-view`.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-list)

--- a/packages/plugin-map/README.md
+++ b/packages/plugin-map/README.md
@@ -271,17 +271,6 @@ const schema = {
 };
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-map)

--- a/packages/plugin-markdown/README.md
+++ b/packages/plugin-markdown/README.md
@@ -110,17 +110,6 @@ pnpm build
 # The package will generate proper ESM and UMD builds with lazy loading preserved
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-markdown)

--- a/packages/plugin-report/README.md
+++ b/packages/plugin-report/README.md
@@ -276,17 +276,6 @@ columns: [
 Legacy `renderAs: 'badge'` + `colorMap` is still honoured for plain
 string columns.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-report)

--- a/packages/plugin-timeline/README.md
+++ b/packages/plugin-timeline/README.md
@@ -75,17 +75,6 @@ const schema = {
 };
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-timeline)

--- a/packages/plugin-view/README.md
+++ b/packages/plugin-view/README.md
@@ -344,17 +344,6 @@ const userView: ObjectViewSchema = {
 };
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/plugins/plugin-view)

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -66,17 +66,6 @@ function App() {
 }
 ```
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/providers)

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -227,17 +227,6 @@ leaves the surface on its own anchor), `visibleNotificationStack` (`maxVisible` 
 
 See [full documentation](https://objectui.org/docs/core/schema-renderer) for detailed API reference.
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **React:** 18.x or 19.x
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/core/schema-renderer)

--- a/packages/runner/README.md
+++ b/packages/runner/README.md
@@ -169,16 +169,6 @@ that do configure it are:
 
 For detailed documentation, visit the [Object UI Documentation](https://www.objectui.org/docs/utilities/runner).
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/utilities/runner)

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -301,16 +301,6 @@ We follow these constraints for this package:
 3. **Comprehensive JSDoc** - Every property documented
 4. **Protocol first** - Types define the contract
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^15.1.1
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/api/schema-reference)

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -218,16 +218,6 @@ Built with:
 
 </div>
 
-<!-- release-metadata:v3.3.0 -->
-
-## Compatibility
-
-- **Node.js:** ≥ 18
-- **TypeScript:** ≥ 5.0 (strict mode)
-- **`@objectstack/spec`:** ^3.3.0
-- **`@objectstack/client`:** ^3.3.0
-- **Tailwind CSS:** ≥ 3.4 (for packages with UI)
-
 ## Links
 
 - 📚 [Documentation](https://www.objectui.org/docs/utilities/vscode-extension)


### PR DESCRIPTION
Fixes #3645

## 背景:生成器已死,块被冻结在 v3.3.0

标记行 `release-metadata:v3.3.0`(HTML 注释形式)曾由发布期生成器写入,该生成器已不存在。PM 两仓实测我已独立复现:

```
$ git grep -l "release-metadata"      # objectui
→ 仅命中 35 个 packages/*/README.md 自身;scripts/、.github/、其余全仓零引用
$ (objectstack 仓)                     → 全仓零命中
```

没有任何工具会再生成或覆盖这个块 —— 所以 issue 正文「手改会被下次发版覆盖」的顾虑不成立,而块里的每一行都从 v3.3.0 起被冻结,仓库却一路走到了 17.x。

一条正交证据:`packages/app-shell/README.md` 的标记行孤悬在第 616 行,与它本该界定的 §Compatibility(第 774 行)相隔 158 行,中间被插进了 `## Command palette` 等新章节。活的生成器会重新锚定或整块覆盖,不会容忍这种漂移。

## 形态实测:PM 预设的「标记行 + 标题 + 5 行 bullet」有四处不成立

| # | 差异 | 实测 | 处置 |
|---|---|---|---|
| 1 | `packages/cli/README.md` 有完整 §Compatibility 块但**无标记行**,且冒号在粗体外(`- **Node.js** ≥ 18`)、Tailwind 行无 `(for packages with UI)` 后缀 | 同一缺陷的另一种拼写 | **纳入**,文件面 35 → 36(见下「裁决二」) |
| 2 | 29/36 个块是 **6 行** bullet,多一行 `- **React:** 18.x or 19.x`;仅 cli / core / create-plugin / data-objectstack / runner / types / vscode-extension 这 7 个是 5 行 | 六行,不是五行 | **一并删**(见下「裁决一」) |
| 3 | `packages/types/README.md` 的 spec 行是 `^15.1.1`,**不是** `^3.3.0` | 「35 个逐字相同」不成立:该行被手改过一次,且仍然陈旧 | 同样删(处置是删版本宣称,与它宣称哪个版本无关) |
| 4 | `packages/app-shell/README.md` 标记行与块相隔 158 行 | 标记与块已解耦 | 两处独立删除 |

另有 2 个包(`plugin-tree`、`react-runtime`)本就没有这个块,**未触碰**。

## engines 实测(enforce-or-remove 的输入)

```
39 个 packages/*/package.json 中声明 engines 的:1 个
  vscode-extension → {"vscode":"^1.85.0"}     ← VS Code 引擎,与 Node 无关
即:39 个包全部没有 engines.node

根 package.json → engines: {"node":">=22","pnpm":">=9"}   ← 全仓唯一可执行的 Node 下限
apps/* 、examples/*                                        → 全部无 engines
```

这正是 issue 派发时预留的「测量给出别的形态(如根 package.json 有 engines)」分支:真相存在,但在**根**而非包,且由 pnpm 在安装期强制。

## 六行逐行处置依据 —— 全部失真,不止 issue 指出的两行

| README 宣称 | 仓库真相 | 强制点 | 判定 |
|---|---|---|---|
| `@objectstack/spec` ^3.3.0 | 27 个包锁 `^17.0.0-rc.5`,**零**包锁 ^3.3.0 | package.json dependencies | 差一个大版本区间 → 删 |
| `@objectstack/client` ^3.3.0 | 全仓**只有 1 个**包(`data-objectstack`)依赖它 | package.json dependencies | 36 个印这行的 README 里 35 个是幽灵行 → 删 |
| Node.js ≥ 18 | 根 `engines.node` 为 `">=22"` | 根 package.json,pnpm 安装期强制 | 直接矛盾,已漂移过一次 → 删 |
| TypeScript ≥ 5.0 (strict mode) | 全仓 39 处 typescript 声明均为 `^6.0.3` | 无 | 差一个大版本,且无处可核实 → 删 |
| Tailwind CSS ≥ 3.4 | 实为 `^4.3.3`(6 处)/ `^4.2.1`(1 处) | 无 | 差一个大版本;`(for packages with UI)` 的括号本身就承认它不逐包为真 → 删 |
| React 18.x or 19.x | 28 个 UI 包 peer 为 `^18.0.0 \|\| ^19.0.0`,但 **`plugin-report` 只有 `^18.0.0`** | package.json peerDependencies,包管理器安装期强制 | 手抄 peerDependencies 且**已漂移** → 删(见「裁决一」) |

**一律不改写为 rc.5 / >=22 / ^6 / ^4。** 按仓规「版本号入散文即漂移保证 —— 删」:重写等于把同一台漂移机器重新上膛,下个 major 又错一遍。真相已在 `package.json`(engines / peerDependencies / dependencies)里,由包管理器在安装期强制,读者违反会拿到硬错误而不是一份陈旧文档。

六行全删 → §Compatibility 整节空掉 → **连标题一起删**,不留空节。

## 两处越出字面裁决的取舍,已由 PM 裁 A

- **裁决一(React 行)**:该行落在被裁决的生成块区域内、属同一缺陷类(手抄 peerDependencies 的版本号入散文),且 `plugin-report` 已证明它不是例外。保留它会让 29 个文件留下**只剩一条 bullet** 的 §Compatibility 节 —— 此时标题反而更误导(读作「这就是全部兼容性约束」却已不含 Node/TS)。PM 裁 **A:一并删**。
- **裁决二(文件面 35 → 36)**:issue 的「35」是按标记行计数,按**缺陷**计数是 36。PM 给出的验收判据「`grep -rn 'release-metadata|\^3\.3\.0' packages/*/README.md` 零命中」只有覆盖 `cli` 才可能满足。PM 裁 **A:判据优先于估数**。

## 改动形状:纯删除,算术对得上

```
36 files changed, 387 deletions(-), 0 insertions(+)
```

逐类核对:

```
29 个 6-bullet 带标记 × 11 行 = 319
 6 个 5-bullet 带标记 × 10 行 =  60
 1 个 cli 5-bullet 无标记      =   8
                          合计 = 387   ✅ 与 diffstat 一致
```

(每块 = 标记 2 行【标记行 + 空行】 + 标题 2 行【标题 + 空行】 + N 行 bullet + 1 行尾随空行。)

被删行去重后**只有六种**:标记行、`## Compatibility` 标题、空行、以及五类兼容 bullet —— 无任何其他内容。§Links 等其他节(#3649 刚修过)、任何 package.json 均**未触碰**;暂存区 36 个文件全部匹配 `^packages/[^/]*/README\.md$`,越界文件数 0。

## 门禁

| 门禁 | 修前 | 修后 |
|---|---|---|
| `node scripts/check-doc-links.mjs` | `Links are valid across 7 scan roots.` exit=0 | `Links are valid across 7 scan roots.` exit=0 |
| `node scripts/check-control-bytes.mjs` | — | `OK (scanned 3674 tracked text file(s); skipped 85 binary)` exit=0 |
| 对 36 个改动文件自扫 `[\x00-\x08\x0b\x0c\x0e-\x1f]` | — | 命中 0 行 |

doc-links **前后同绿**是预期方向,不是空绿:`scripts/check-doc-links.mjs:395` 的 `{ path: 'packages/*/README.md', rule: 'disk' }` 是第 7 个扫描根,门禁确实读到了这 36 个文件;本改动删除的行不含任何 markdown 链接语法,链接面按构造不变。据实记录为同绿,不套「前红后绿」的模板。

验收判据计数:

```
修前:release-metadata 命中 35 文件 / ^3.3.0 命中 36 文件 / §Compatibility 36 节 / 合并 grep 106 行
修后:0 / 0 / 0 / 0        ✅ 判据满足
```

## changeset:不加(写明判断)

README.md 确在 `files` 内、属发布物内容,但:

1. **仓内先例一致不加** —— 实测三个最近的包 README 类 PR,合并提交的 `.changeset/` 文件数均为 **0**:#3644(runner README 措辞)、#3662(plugin-tree LICENSE)、#3649(7 个包 README + 新门禁)。
2. AGENTS.md 的门槛是「功能改进需 changeset,纯修复不需要」;本单是删除失真文档,**无 API/行为变更**。
3. fixed 组 39 包联动,一次文档删除会把全组推版。

附带提示:本 PR 全部是 `*.md`,`ci.yml` / `lint.yml` 的 `paths-ignore` 含 `**/*.md`,预期这两个 workflow 显示 **skipping** —— 按 AGENTS.md 那是跳过、不是失败。

## 未在本 PR 修的越界发现(已另立单)

- 站点文档侧同源失真宣称(`content/docs/utilities/cli.mdx:283`)
- `plugin-report` 的 peerDependencies.react 与其余 28 个 UI 包不一致
- release-metadata 生成器已死的观察记录


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_