### PR TITLE
test(app-shell): 同步 pseudoRouteSegments 里的第二份 MetadataRedirectStub,并用整链断言钉住 (#3669)

### DIFF
--- a/packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx
@@ -78,6 +78,23 @@
  * app-shell cannot import from `apps/` — different Vitest project, and the
  * redirect is module-private — so the rewrite is copied verbatim, including its
  * `prefix` regex, and this comment is the pointer back to the original.
+ *
+ * ## Why the two host-rewrite cases assert the chain (objectui#3669)
+ *
+ * A transcription can go stale, and this one did. objectui#3658 re-pointed the
+ * host straight at the canonical metadata routes; the copy below kept emitting
+ * the deprecated `component/metadata/resource` alias, so both `system/metadata`
+ * cases went on measuring a two-hop chain production had stopped producing.
+ * Nothing went red — they pinned only the endpoint (or only the testid), and
+ * the endpoint is byte-identical whether the alias sits in the middle or not.
+ *
+ * So `renderConsoleAt` returns every location the router settles on, and the
+ * two cases fed by the stub assert that list exactly. A copy that drifts back
+ * onto the alias grows a middle entry and fails, naming the alias in the diff.
+ * The rest of the file is untouched by this: every other URL below reaches its
+ * page without passing through the stub, and pinning their endpoints is the
+ * right assertion for what they are about (which guard wins, which app's shell
+ * rendered) — the hop count is not part of their claim.
  */
 
 import '@testing-library/jest-dom/vitest';
@@ -209,27 +226,57 @@ vi.mock('../../providers/MetadataProvider', async (importOriginal) => ({
 
 import { AppContent } from '../AppContent';
 
-/** Reports the live URL so a redirect chain is visible as a URL, not just a screen. */
-function LocationProbe() {
+/**
+ * Reports the live URL so a redirect chain is visible as a URL, not just a
+ * screen, and records every distinct location the router settles on.
+ * `<Navigate replace>` re-renders the tree once per hop, so a one-hop rewrite
+ * shows up as two entries and a two-hop one as three — the difference the two
+ * host-rewrite cases below are about (objectui#3669).
+ */
+function LocationProbe({ sink }: { sink: string[] }) {
   const location = useLocation();
+  const here = `${location.pathname}${location.search}`;
+  if (sink[sink.length - 1] !== here) sink.push(here);
   return <div data-testid="pathname">{location.pathname}</div>;
 }
 
 /**
  * VERBATIM transcription of `apps/console/src/AppContent.tsx`'s
- * `MetadataRedirect` — the `system/metadata/*` legs of `systemRoutes`. Keep the
- * regex and the target construction identical to the original.
+ * `MetadataRedirect` — the `system/metadata/*` legs of `systemRoutes` — as it
+ * stands after objectui#3658 landed in `7883c0250`. Keep the regex and the
+ * target construction identical to the original.
+ *
+ * "Identical to the original" is a claim this file has to keep earning, and
+ * between `7883c0250` and objectui#3669 it was false. The host was re-pointed
+ * at the canonical `…/metadata/:type`; this copy went on building the
+ * deprecated `…/component/metadata/resource?type=:type`, so the two cases fed
+ * by it measured a two-hop chain production had stopped producing. Nothing
+ * failed: the assertions pinned only the final pathname, which is identical
+ * whether the alias is in the middle or not. Green, for a reason that had come
+ * unhooked from the code under test.
+ *
+ * That is why the two cases below now assert the whole chain rather than the
+ * endpoint. A copy that drifts back onto the alias grows a middle entry and
+ * fails, naming the alias in the diff — the only mechanism in this file able to
+ * notice the drift at all. (The same repair, on the same day, for the same
+ * reason as objectui#3661 / PR #3671, which found the twin of this stub in
+ * `AppContent.noAppComponentRoutes.test.tsx`.)
+ *
+ * Transcribed rather than imported because app-shell and `apps/console` are
+ * separate Vitest projects and `MetadataRedirect` itself is module-private —
+ * objectui#3658 exported the surrounding `systemRoutes` fragment, but not this
+ * function. So it stays a copy, and the copy stays pinned by the chain.
  */
 function MetadataRedirectStub() {
   const { metadataType, itemName } = useParams<{ metadataType?: string; itemName?: string }>();
   const location = useLocation();
   const prefix = location.pathname.replace(/\/(system\/)?metadata(\/.*)?$/, '');
-  const base = `${prefix}/component/metadata/resource`;
+  const base = `${prefix}/metadata`;
   const target = !metadataType
-    ? `${prefix}/component/metadata/directory`
+    ? base
     : itemName
-      ? `${base}/${itemName}?type=${metadataType}`
-      : `${base}?type=${metadataType}`;
+      ? `${base}/${encodeURIComponent(metadataType)}/${itemName}`
+      : `${base}/${encodeURIComponent(metadataType)}`;
   return <Navigate to={target} replace />;
 }
 
@@ -251,11 +298,19 @@ const systemRoutesStub = (
   </>
 );
 
-/** The reference host's route tree — mirrors `apps/console/src/App.tsx`. */
+/**
+ * The reference host's route tree — mirrors `apps/console/src/App.tsx`.
+ *
+ * Returns the redirect chain (see `LocationProbe`). It fills as the router
+ * navigates, so read it AFTER the `await findBy…` that lets the hops settle —
+ * the metadata-admin pages sit behind `React.lazy`, so nothing is final on the
+ * synchronous return.
+ */
 function renderConsoleAt(initialUrl: string) {
-  return render(
+  const chain: string[] = [];
+  render(
     <MemoryRouter initialEntries={[initialUrl]}>
-      <LocationProbe />
+      <LocationProbe sink={chain} />
       <Routes>
         <Route
           path="/apps/:appName/*"
@@ -267,6 +322,7 @@ function renderConsoleAt(initialUrl: string) {
       </Routes>
     </MemoryRouter>,
   );
+  return chain;
 }
 
 const pathname = () => screen.getByTestId('pathname').textContent;
@@ -295,10 +351,15 @@ describe('AppContent pseudo-routes — live input surface stays special (objectu
     ['/apps/ghost/metadata/object/sys_user', 'metadata-resource-edit-page', '/apps/ghost/metadata/object/sys_user'],
     // The legacy aliases redirect onto the canonical `metadata/:type` route
     // (declared in this same branch) — the pathname pins the hop's direction.
+    // These two ENTER the alias directly, so they are unaffected by the host
+    // stub going direct (objectui#3669), and they are what keeps the with-app
+    // branch's `component/metadata/*` declarations covered now that nothing
+    // passes through them on the way somewhere else.
     ['/apps/ghost/component/metadata/resource?type=datasource', 'metadata-resource-list-page', '/apps/ghost/metadata/datasource'],
     ['/apps/ghost/component/metadata/directory', 'metadata-directory-page', '/apps/ghost/metadata'],
-    // Two-hop: host rewrite (`system/metadata/:type`) -> shell alias -> canonical.
-    ['/apps/ghost/system/metadata/object', 'metadata-resource-list-page', '/apps/ghost/metadata/object'],
+    // The host rewrite (`system/metadata/:type`) is its own `it` below — it is
+    // the one URL here whose hop COUNT is part of the claim, and a shared
+    // `it.each` body can only pin the endpoint.
     // Control — `isCreateAppRoute` is an `endsWith` test and is NOT changed.
     ['/apps/ghost/create-app', 'create-app-page', '/apps/ghost/create-app'],
   ])('unresolved app segment keeps the default-app fallback for %s', async (url, testid, expected) => {
@@ -312,13 +373,37 @@ describe('AppContent pseudo-routes — live input surface stays special (objectu
     expect(screen.queryByTestId('app-not-available-retry')).not.toBeInTheDocument();
   });
 
+  it('unresolved app segment: the host rewrite reaches canonical metadata/:type in ONE hop', async () => {
+    // Lifted out of the table above so the hop COUNT can be asserted, not just
+    // the endpoint. The host's `MetadataRedirect` rewrites this URL onto the
+    // canonical `metadata/:type` that the shell declares itself: two route
+    // tables, one redirect.
+    //
+    // It used to be two — the host aimed at `component/metadata/resource?type=`
+    // and the shell forwarded that on to the same place. objectui#3658 removed
+    // the middle stop, and this case went on measuring it anyway, because the
+    // stub above had not been re-synced and the endpoint is byte-identical
+    // either way. objectui#3669 is what that cost to notice.
+    const chain = renderConsoleAt('/apps/ghost/system/metadata/object');
+
+    expect(await screen.findByTestId('metadata-resource-list-page')).toBeInTheDocument();
+    // Two entries, i.e. a single `<Navigate>`. The alias is not merely absent
+    // from the end of the chain — it is absent from the chain.
+    expect(chain).toEqual(['/apps/ghost/system/metadata/object', '/apps/ghost/metadata/object']);
+    expect(chain.some((entry) => entry.includes('component/metadata'))).toBe(false);
+    expect(pathname()).toBe('/apps/ghost/metadata/object');
+    // Same two guarantees the table's body makes: the DEFAULT app's shell, and
+    // no "App not available".
+    expect(screen.getByTestId('console-layout')).toHaveAttribute('data-active-app', 'crm');
+    expect(screen.queryByTestId('app-not-available-retry')).not.toBeInTheDocument();
+  });
+
   /**
    * `/apps/setup/*` rides `isSetupRoute`, untouched by this change — pinned as
    * the boundary of the two flags, not as their coverage.
    */
   it.each([
     ['/apps/setup/system', 'system-hub-page'],
-    ['/apps/setup/system/metadata/object', 'metadata-resource-list-page'],
     ['/apps/setup/component/metadata/resource?type=datasource', 'metadata-resource-list-page'],
     ['/apps/setup/developer', 'developer-hub-page'],
     ['/apps/setup/docs', 'docs-page'],
@@ -326,6 +411,19 @@ describe('AppContent pseudo-routes — live input surface stays special (objectu
     renderConsoleAt(url);
 
     expect(await screen.findByTestId(testid)).toBeInTheDocument();
+    expect(screen.getByTestId('console-layout')).toHaveAttribute('data-active-app', 'crm');
+  });
+
+  it('the /apps/setup family is unaffected: the host rewrite still lands in ONE hop', async () => {
+    // The `setup` twin of the case above, lifted out of the table for the same
+    // reason. `isSetupRoute` decides this URL rather than `isMetadataRoute`,
+    // but the chain through the host stub is the same one, and it was stale in
+    // the same way.
+    const chain = renderConsoleAt('/apps/setup/system/metadata/object');
+
+    expect(await screen.findByTestId('metadata-resource-list-page')).toBeInTheDocument();
+    expect(chain).toEqual(['/apps/setup/system/metadata/object', '/apps/setup/metadata/object']);
+    expect(chain.some((entry) => entry.includes('component/metadata'))).toBe(false);
     expect(screen.getByTestId('console-layout')).toHaveAttribute('data-active-app', 'crm');
   });
 


### PR DESCRIPTION
Fixes #3669

## 前提复核(先证实,再动手)

issue 正文在最新 `origin/main`(`e98702190`,已含 PR #3671)上逐条命中,前提成立:

- `packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx:218-233` 的第二份 `MetadataRedirectStub`,docblock 自称 *"VERBATIM transcription … Keep the regex and the target construction identical to the original"*,target 构造仍是别名拼法;
- 宿主 `apps/console/src/AppContent.tsx:88-102` 的 `MetadataRedirect` 自 `7883c0250`(PR #3658)起已改为直接构造 `…/metadata/:type[/:name]`;
- 二者确实已经不一致。

前置条件也实测过:PR #3671(第一份 stub 的同步,本单的直接模板)已落 main(`e98702190`),手法照抄。

## 失真是**实测**出来的

动手前先只给 `LocationProbe` 加链记录、**不动 stub**,把五条链打了出来(用一条必失败的断言让 vitest 把实际数组打进 diff — 该仓 reporter 吞 `console.log`):

| 用例 | 旧 stub 下实测的链 | 跳数 |
|---|---|---|
| `/apps/ghost/system/metadata/object` | `[system/metadata/object, **component/metadata/resource?type=object**, metadata/object]` | **2** |
| `/apps/setup/system/metadata/object` | `[system/metadata/object, **component/metadata/resource?type=object**, metadata/object]` | **2** |
| `/apps/ghost/component/metadata/resource?type=datasource` | `[component/metadata/resource?type=datasource, metadata/datasource]` | 1 |
| `/apps/ghost/component/metadata/directory` | `[component/metadata/directory, metadata]` | 1 |
| `/apps/setup/component/metadata/resource?type=datasource` | `[component/metadata/resource?type=datasource, metadata/datasource]` | 1 |

两点确认:链记录器**确实能看到中间站**(否则后面的逆向验证就是空壳);issue 点名的两条**都**在测两跳链,且中间站正是已废弃的别名。

顺带一条比 issue 正文多出来的事实:本文件里 stub 的**另外两条臂从未被执行过** —— 没有任何用例走 `system/metadata`(typeless)或 `system/metadata/:type/:name`,所以只有 `metadataType && !itemName` 这一条臂在跑,跑了两次。

## 改了什么

### 1. stub 同步(逐字转录恢复为真)

```
-  const base = `${prefix}/component/metadata/resource`;
+  const base = `${prefix}/metadata`;
   const target = !metadataType
-    ? `${prefix}/component/metadata/directory`
+    ? base
     : itemName
-      ? `${base}/${itemName}?type=${metadataType}`
-      : `${base}?type=${metadataType}`;
+      ? `${base}/${encodeURIComponent(metadataType)}/${itemName}`
+      : `${base}/${encodeURIComponent(metadataType)}`;
```

机器比对过(剥掉注释后 `diff`):同步后 stub 函数体与宿主 `MetadataRedirect` 函数体**可执行代码逐字节一致**,唯一差异是宿主多带的三行注释(那三行 stub 改前也没有)。

docblock 改为注明转录对象、出处 commit(`7883c0250` / #3658),并明说「逐字」是一句**需要持续兑现**的声明 —— 它在 `7883c0250` 到本单之间就是假的。

### 2. 整链断言(防复发)

`LocationProbe` 升级为链记录器,`renderConsoleAt` 返回整条链。这是必要的:旧断言只钉最终 pathname(setup 那条连 pathname 都不钉,只钉 testid),而**一跳与两跳的终点逐字节相同**,所以 stub 失真时没有任何断言会红。

### 3. 两条受影响用例提为独立 `it`

两条都原本是 `it.each` 表里的行,而共享的表体只能钉终点,钉不了跳数。所以把这两行提出来,写成独立 `it` 并断言整条链 —— **原有断言一条不少地保留**(`data-active-app` 为 `crm`、无 `app-not-available-retry`、pathname),再加上整链与「链中不含 `component/metadata`」。

表里其余 11 行 + 4 行、以及 #3638 落的近似段族断言**一行未动**(见 diff:全文件只有这两行被移除)。

## 覆盖清点

stub 改直达后,这两条用例不再顺路经过 with-app 分支的 `component/metadata/resource/*`(`packages/app-shell/src/console/AppContent.tsx:792`)。清点结果:**没有任何路由因此失去全仓唯一覆盖,不需要补用例。**

| 路由声明 | 分支 | 改后仍由谁覆盖 |
|---|---|---|
| `AppContent.tsx:792` `component/metadata/resource/*` | with-app | 本文件 `:337`(`/apps/ghost/…?type=datasource`)与 setup 家族表(`/apps/setup/…?type=datasource`)—— 两条都**直接进入**别名,不经 stub |
| `AppContent.tsx:791` `component/metadata/directory` | with-app | 本文件 `:338`(`/apps/ghost/component/metadata/directory`),直接进入;且该路由**本就没有**经过 stub 的覆盖 —— stub 的 typeless 臂在本文件从未被执行 |
| `AppContent.tsx:663` `component/metadata/resource/*` | 零应用 | 本文件零应用 describe 里的 `/apps/setup/…?type=datasource`(`metadataApps = []`) |
| `AppContent.tsx:662` `component/metadata/directory` | 零应用 | PR #3671 已补的直接进入用例(`AppContent.noAppComponentRoutes.test.tsx`) |

这与 #3661 的处境不同,原因 issue 的 ⚠️ 说对了:那边零应用分支的 directory 别名**只有** stub 的 typeless 臂在跑,所以 #3671 必须补一条接住;本文件对应的别名覆盖全部来自**直接进入**的用例,stub 是否途经它们都不影响。

## 逆向验证(先预测,后运行)

**预测**:只把 stub 的 target 构造回退成别名(docblock 与断言保持不动),应当**恰好两条**用例转红 —— 即新提出的两条 host-rewrite 用例;红的形态应为链**正中**多出一个别名条目、**首尾条目不变**,同时两条 `component/metadata` 缺席断言翻为 true。其余 34 条(含输入面回归表与近似段族)应全程绿。方向为常规「红」,不存在反转 —— 整链断言是数组逐位相等,长度一变必红。

实跑,与预测**逐条一致**:

```
 × unresolved app segment: the host rewrite reaches canonical metadata/:type in ONE hop
 × the /apps/setup family is unaffected: the host rewrite still lands in ONE hop
 Test Files  1 failed (1)
      Tests  2 failed | 34 passed (36)
```

两张 diff 各只多出**一行**:

```
  [
    "/apps/ghost/system/metadata/object",
+   "/apps/ghost/component/metadata/resource?type=object",
    "/apps/ghost/metadata/object",
  ]

  [
    "/apps/setup/system/metadata/object",
+   "/apps/setup/component/metadata/resource?type=object",
    "/apps/setup/metadata/object",
  ]
```

这两张 diff 本身就是**本单为什么会静默发生**的直接证据:两条链的**首尾条目完全没动**,只有中间多了一站。旧的「只断终点」断言在结构上就不可能红。

## 门禁

```
pnpm exec vitest run …/AppContent.pseudoRouteSegments.test.tsx
  → Test Files 1 passed / Tests 36 passed(改前亦 36 —— 表里去掉 2 行,提出 2 条独立用例)

pnpm exec vitest run packages/app-shell/src/console/__tests__
  → Test Files 6 passed (6) / Tests 64 passed (64)

pnpm --workspace-concurrency=2 --filter @object-ui/app-shell type-check   → 通过(tsc --noEmit && tsc -p tsconfig.typetests.json)
pnpm exec eslint 该文件                                                    → exit 0
node scripts/check-control-bytes.mjs                                       → OK(3672 个文本文件)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' 该文件                            → 无
```

`type-check` 前先跑了 `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`(新 worktree 未构建依赖会报一片 `Cannot find module '@object-ui/*'`,AGENTS.md §9 陈旧产物陷阱的镜像)。

## changeset

**不写**:本 PR 只改一个测试文件,零生产代码改动,对包的发布物与运行时行为没有任何影响,不属于用户可见变更(与 PR #3671 同判)。

## 越界发现

无。本次未发现新的越界问题。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_