### PR TITLE
fix(app-shell): 唯一候选规则 — union 只剩一个成员读过值时,给出它的具名诊断

### DIFF
--- a/.changeset/lucky-pugs-shave.md
+++ b/.changeset/lucky-pugs-shave.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/app-shell": patch
+---
+
+metadata-admin: name the offending key when only one union member ever read the value
+
+A union with no discriminant reports its failure as one collapsed issue, and the
+member diagnostics that would name the problem are buried inside it. PR #3677
+started unpacking those for `config.columns` by reading the value's own content,
+but deliberately declined every union where some member had rejected the value's
+type outright — which left `config.sort` (`string | ColumnSort[]`) collapsed even
+though only one of its two members had read the value at all.
+
+When exactly one member accepted the value's type, naming it is a fact rather
+than a preference: it is the only member whose complaint can be about what the
+author wrote. So `sort: [{ field: 'n', order: 'bogus' }]` now reports
+`config.sort.0.order` with the spec's own `expected one of "asc" | "desc"`
+instead of `config.sort` / `Invalid input`, and the same holds for a sort row
+that is not an object, a `columns[].summary` written as a bad enum string, a form
+`sections[].fields[]` entry missing its `field`, and an array `filter[].value`
+whose offending element is now addressed directly.
+
+Where two or more members read the value, or where none did, nothing changes:
+the previous message is kept rather than inventing a preference between members
+that objected equally. Both gates — create and edit — continue to report
+identically, and validation verdicts are untouched: the accept/reject decision is
+still made by the one gate, and this only changes how an already-failed draft is
+presented.

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -117,7 +117,7 @@ function viewSchemaForDraft(item: ZodLikeSchema, container: ZodLikeSchema): ZodL
 }
 
 /**
- * ── Union-failure diagnostics for the `view` gates (objectui#3606, #3626) ──
+ * ── Union-failure diagnostics for the `view` gates (objectui#3606, #3626, #3678) ──
  *
  * PRESENTATION ONLY. Nothing below can change a verdict: it runs strictly
  * inside the final issue→`SchemaFormIssue` mapping, after `ok` has already been
@@ -125,9 +125,11 @@ function viewSchemaForDraft(item: ZodLikeSchema, container: ZodLikeSchema): ZodL
  * on create) and after every issue filter has run. Same input set, same `ok`;
  * only the rendered `path`/`message` move.
  *
- * Two rules live here, one per union depth. This first block is the ROOT rule
- * (#3606, edit gate only — neither authoring schema has a union at its root);
- * the NESTED rule for `config.columns` follows below (#3626, both gates).
+ * Three rules live here. This first block is the ROOT rule (#3606, edit gate
+ * only — neither authoring schema has a union at its root); the two NESTED
+ * rules follow below — the content rule for `config.columns` (#3626) and the
+ * sole-candidate rule (#3678). The two nested rules read disjoint cells of one
+ * partition; `nestedUnionMemberIndex` states and proves that.
  *
  * The edit gate is `z.preprocess(stripViewConsoleDecorations, z.union([…]))`.
  * Zod reports a union failure as a SINGLE root issue — `code: 'invalid_union'`,
@@ -207,7 +209,12 @@ function viewUnionMemberIndex(draft: unknown): number {
  * its own relative root) is not a candidate: it never looked at the contents,
  * so contents cannot be evidence for it. That single categorical test — asked
  * of each group on its own, never group-vs-group — is what keeps `sort`,
- * `filter[].value`, `gantt.tooltipFields[]` and the rest untouched.
+ * `filter[].value`, `gantt.tooltipFields[]` and the rest out of THIS rule.
+ * (It kept them collapsed entirely until #3678, which reads the same test as a
+ * census and answers the unions where it leaves exactly one member standing.
+ * The narrowing above is unchanged and still load-bearing: delete the
+ * `groups.some(memberRejectedNodeType)` line and the content rule elects the
+ * plain-`string` member for `sort: ['name']` again.)
  *
  * Boundaries, all measured rather than assumed:
  *
@@ -235,8 +242,20 @@ const ARRAY_VARIANT_MEMBERS = { ofStrings: 0, ofObjects: 1 } as const;
 
 /**
  * Did this member reject the value's TYPE at the union node itself, without
- * ever looking at its contents? Asked of one group in isolation — it filters
- * which unions the content rule may speak about, it does not pick a winner.
+ * ever looking at its contents? Asked of one group in isolation — never
+ * group-vs-group — so it is a categorical fact about one member, not a ranking.
+ *
+ * This single test is the basis of BOTH nested rules (see
+ * `nestedUnionMemberIndex`): #3626 uses it to decide which unions the content
+ * rule may speak about, #3678 counts it to find a union with exactly one
+ * candidate. A member that answers `true` here never read the value, so nothing
+ * about the value can be evidence for or against it.
+ *
+ * Measured caveat, deliberately kept: only `invalid_type` counts. An enum
+ * member handed an object answers `invalid_value`, not `invalid_type` — so
+ * `columns[0].summary` (`enum | {type, field}`) reads as TWO candidates for an
+ * object value and stays in the content rule's cell, which declines it. That is
+ * why the `summary` descent boundary #3626 pinned is unchanged by #3678.
  */
 function memberRejectedNodeType(group: ZodLikeIssue[]): boolean {
   return group.some((i) => i.code === 'invalid_type' && (i.path ?? []).length === 0);
@@ -275,6 +294,97 @@ function arrayVariantMemberIndex(groups: ZodLikeIssue[][], value: unknown): numb
 }
 
 /**
+ * ── NESTED unions: the sole-candidate rule (objectui#3678) ──
+ *
+ * #3626's narrowing left a gap, and #3678 is that gap: when the categorical
+ * test above leaves EXACTLY ONE member standing, naming it is not a heuristic
+ * and not a preference — it is the only member that ever read the value, so it
+ * is the only member whose complaint can be about what the author wrote. The
+ * other members objected to the value's TYPE and stopped there; showing their
+ * complaints would describe a shape the author never chose.
+ *
+ * `config.sort` (`string | ColumnSort[]`) is the case that motivated it. For
+ * `sort: [{field: 'n', order: 'bogus'}]` the plain-`string` member rejects the
+ * array outright and the `ColumnSort[]` member reports
+ * `[0].order` / `Invalid option: expected one of "asc"|"desc"` — the spec's own
+ * guided message (#4001), which until now was thrown away and rendered as
+ * `config.sort` / `Invalid input`.
+ *
+ * This rule does NOT index members positionally: the index is derived from the
+ * census of the groups the failing gate itself produced, so a spec-side reorder
+ * of a union's members cannot mis-select. What a spec change CAN do is move a
+ * union between cells — adding a third `sort` member that also accepts arrays
+ * would take the census from one candidate to two and collapse the node back to
+ * `Invalid input`. That is why the #3678 anchors pin exact paths + messages:
+ * the loss shows up as a red test rather than as a quietly worse message.
+ *
+ * Reach, measured over the `view` family rather than assumed — this is WIDER
+ * than issue #3678 estimated. #3678's "范围" paragraph expected only
+ * scalar-or-array two-member unions such as `sort` to be reachable, and read
+ * `filter[].value` / `sections[].fields[]` as rejecting wholesale. They do
+ * reject wholesale for a scalar value, but not for an ARRAY value, where the
+ * array member is the sole candidate:
+ *
+ *   `filter[0].value: [{}]`        → `config.filter.0.value.0` (was `…value`)
+ *   `sections[0].fields: [{}]`     → `config.sections.0.fields.0.field`
+ *   `columns[0].summary: 'bogus'`  → same path, now the enum's option list
+ *
+ * All three are strict improvements — a nearer path, or a named expectation
+ * instead of `Invalid input` — and each is pinned below. Two of them supersede
+ * NARROWING pins #3626 wrote (see the test file's #3678 block); those pins were
+ * asserting that no rule spoke there, which is exactly what this rule changes.
+ */
+function soleTypeAcceptingMember(groups: ZodLikeIssue[][]): number | null {
+  let sole: number | null = null;
+  for (let i = 0; i < groups.length; i++) {
+    if (memberRejectedNodeType(groups[i])) continue;
+    if (sole !== null) return null; // two or more candidates — ambiguous, not ours
+    sole = i;
+  }
+  return sole; // stays `null` when every member rejected the type
+}
+
+/**
+ * The two NESTED rules, and the relationship between them.
+ *
+ * Census the members with `memberRejectedNodeType` and let `k` be how many
+ * ACCEPTED the value's type. That single number partitions every nested union
+ * into three cells, and the two rules live in different ones:
+ *
+ *   k === 1                 → #3678 names the sole candidate.
+ *   k === groups.length      → every member read the value, so the value's own
+ *     (i.e. k === 0 rejected)  CONTENT decides — #3626's `array<A> | array<B>`
+ *                              rule, which declines unless the union really is
+ *                              of that shape.
+ *   otherwise (k === 0, or  → no rule. Nothing about the value distinguishes
+ *    0 < k < groups.length     the members, and #3626 already ruled that
+ *    with k !== 1)             inventing a preference is not ours to do.
+ *
+ * So they cannot both want to select: `k === 1` and `k === groups.length`
+ * coincide only at `groups.length === 1`, a one-member "union" the schema does
+ * not produce — and even there both rules agree on index 0, since #3626's rule
+ * requires `groups.length === 2` and returns `null`. The content rule is NOT a
+ * special case of the sole-candidate rule and the sole-candidate rule is NOT a
+ * fallback for it; they answer different questions in disjoint cells. #3678's
+ * dispatch asked for this to be measured before implementing, and it was: the
+ * census in the test block below covers every nested union shape the `view`
+ * family produces, and no shape lands in two cells.
+ *
+ * Order below is therefore unobservable while both guards hold — and it is
+ * written content-first ON PURPOSE, so that #3626's narrowing guard stays the
+ * thing that fails when it is removed. Deleting
+ * `if (groups.some(memberRejectedNodeType)) return null;` from
+ * `arrayVariantMemberIndex` still resurrects the exact `sort` mis-selection
+ * #3626 measured, and the #3678 sort anchor goes red on it. Hoisting that guard
+ * into this function would have made it dead code.
+ */
+function nestedUnionMemberIndex(groups: ZodLikeIssue[][], value: unknown): number | null {
+  const byContent = arrayVariantMemberIndex(groups, value);
+  if (byContent !== null) return byContent;
+  return soleTypeAcceptingMember(groups);
+}
+
+/**
  * Pick the union member whose issues should be shown for one `invalid_union`,
  * or `null` for "nothing better than the union node's own message".
  *
@@ -294,7 +404,7 @@ function selectViewUnionGroup(
   const index =
     absPath.length === 0
       ? viewUnionMemberIndex(draft)
-      : arrayVariantMemberIndex(groups, valueAtPath(draft, absPath));
+      : nestedUnionMemberIndex(groups, valueAtPath(draft, absPath));
   if (index === null) return null;
   const group = groups[index];
   if (!Array.isArray(group) || group.length === 0) return null;
@@ -312,12 +422,20 @@ function selectViewUnionGroup(
  * finite tree and only ever yields a non-empty group, so this terminates and a
  * rejected draft always renders at least one issue.
  *
- * There is no depth counter: the array-variant rule declines every union whose
- * node value is not an array, which is what actually bounds the descent. In the
- * measured schema that is exactly one nested level — e.g. a bad
- * `columns[0].summary` (`enum | {type, field}`, an object value) stops there and
- * keeps its own message, now correctly addressed to `config.columns.0.summary`
- * rather than to `config.columns`.
+ * There is no depth counter, and #3678 is why there must not be one: the
+ * descent is bounded by the rules having nothing to say, not by a level count.
+ * A union whose members ALL rejected the value's type ends it — nothing
+ * distinguishes them — and so does one where two or more members read the value
+ * but the content rule declines. Measured examples of each bound:
+ *
+ *  - `columns[0].summary` (`enum | {type, field}`) handed an OBJECT: both
+ *    members read it, the content rule declines a non-array, descent stops with
+ *    Zod's own message now addressed to `config.columns.0.summary`.
+ *  - `filter[0].value: [{}]` descends TWO levels — the array member is the sole
+ *    candidate, and the element union beneath it is rejected by every member —
+ *    ending at `config.filter.0.value.0`. Before #3678 the claim here was "in
+ *    the measured schema that is exactly one nested level"; that was true only
+ *    while the content rule was the only nested rule, and it is now false.
  */
 function expandViewIssues(
   issues: ZodLikeIssue[],

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.viewDiagnostics.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.viewDiagnostics.test.ts
@@ -412,15 +412,37 @@ describe('view nested union — `config.columns` diagnostics (objectui#3626)', (
     // received array" — true, and the wrong thing to tell someone who correctly
     // wrote an array. A member that rejected the node's TYPE outright never
     // looked at the contents, so the contents are not evidence for it, and the
-    // union is left alone. Remove that guard and this goes red.
+    // CONTENT rule is left out of it. Remove that guard and this goes red.
+    //
+    // RE-PINNED BY #3678, and the claim above is unchanged: what this test
+    // guards is that the plain-`string` member is never the one selected. The
+    // expected value moved because a DIFFERENT rule — the sole-candidate rule —
+    // now speaks here, and it selects the OTHER member, the one that actually
+    // read the array. The forbidden mis-selection is asserted directly below so
+    // the guard cannot pass vacuously: if #3626's narrowing guard is deleted,
+    // the content rule elects `string[]` first and both assertions go red.
     const issues = await bothGates({
       ...AUTHORABLE_ITEM,
       config: { ...(AUTHORABLE_ITEM.config as Record<string, unknown>), sort: ['name'] },
     });
-    expect(issues).toEqual([{ path: 'config.sort', message: 'Invalid input' }]);
+    expect(issues).toEqual([
+      { path: 'config.sort.0', message: 'Invalid input: expected object, received string' },
+    ]);
+    expect(issues.map((i) => i.message).join('\n')).not.toContain(
+      'expected string, received array',
+    );
   });
 
   it('does NOT answer for a filter value union (five members, not two)', async () => {
+    // The CONTENT rule needs exactly two members, and this union has five, so
+    // it still declines — the claim this test was written for.
+    //
+    // RE-PINNED BY #3678: for an ARRAY value, four of the five members reject
+    // the type outright and the array member is the sole candidate, so the
+    // sole-candidate rule descends one level to the offending element. It then
+    // STOPS: the element's own union (`string | number`) is rejected by every
+    // member, nothing distinguishes them, and Zod's message is kept. The result
+    // is a nearer path with the same message — `…value.0` rather than `…value`.
     const issues = await bothGates({
       ...AUTHORABLE_ITEM,
       config: {
@@ -428,7 +450,7 @@ describe('view nested union — `config.columns` diagnostics (objectui#3626)', (
         filter: [{ field: 'f', operator: 'in', value: [{}] }],
       },
     });
-    expect(issues).toEqual([{ path: 'config.filter.0.value', message: 'Invalid input' }]);
+    expect(issues).toEqual([{ path: 'config.filter.0.value.0', message: 'Invalid input' }]);
   });
 
   // ── Boundaries: what the content cannot elect ────────────────────────────
@@ -498,6 +520,291 @@ describe('view verdict parity — `columns` bodies (objectui#3626)', () => {
     { label: 'mixed list', body: withColumns([{ field: 'a' }, 'b']), ok: false },
     { label: 'columns elected by nothing', body: withColumns([42]), ok: false },
     { label: 'columns not an array', body: withColumns('nope'), ok: false },
+  ];
+
+  for (const c of CASES) {
+    it(`${c.label}: edit=${c.ok ? 'ok' : 'not ok'}`, async () => {
+      const edited = await validateMetadataDraft('view', c.body, undefined, EDIT);
+      expect(edited.ok, `edit: ${JSON.stringify(edited.issues)}`).toBe(c.ok);
+      expect(edited.issues.length === 0).toBe(c.ok);
+    });
+  }
+});
+
+/**
+ * ── NESTED union diagnostics: the SOLE-CANDIDATE rule (objectui#3678) ──
+ *
+ * #3626 narrowed its content rule so it could not speak for `config.sort`, and
+ * said what that left behind: when a union's members are censused by the
+ * categorical test — did this member reject the value's TYPE at the node
+ * itself, without ever reading it? — and EXACTLY ONE member is left standing,
+ * naming that member is not a guess. It is the only member that read the value,
+ * so it is the only one whose complaint can be about what the author wrote.
+ *
+ * Measured before implementing, on @objectstack/spec 17.0.0-rc.5:
+ *
+ *   sort: [{field:'n', order:'bogus'}]  member[0] `string`        rejected the type
+ *                                       member[1] `ColumnSort[]`  [0].order Invalid option
+ *
+ * so the diagnostic that reached the user was `config.sort` / `Invalid input`
+ * while the spec's own guided message sat one level down, unread.
+ *
+ * ── How this rule relates to #3626's content rule ────────────────────────────
+ *
+ * They are DISJOINT, not layered, and the dispatch for #3678 asked for that to
+ * be measured rather than asserted. Let `k` be how many members accepted the
+ * value's type. `k` partitions every nested union:
+ *
+ *   k === 1                → #3678 names the sole candidate.
+ *   k === members.length   → every member read the value, so the value's own
+ *                            CONTENT decides (#3626), which further declines
+ *                            unless the union is `array<A> | array<B>`.
+ *   otherwise              → no rule; the union keeps Zod's message.
+ *
+ * `k === 1` and `k === members.length` can only coincide at a one-member union,
+ * which this schema does not produce — and #3626's rule requires exactly two
+ * members anyway. The census below walks every nested-union shape the `view`
+ * family produces and pins that no shape lands in two cells, so there is no
+ * priority question to answer.
+ *
+ * Three kinds of claim are pinned here:
+ *
+ *  - CANARY — the sole candidate's exact `path` + `message`. This rule does not
+ *    index members positionally, so a reorder cannot hurt it; what CAN hurt it
+ *    is a spec change to the member SET (a third `sort` member that also accepts
+ *    arrays would take `k` from 1 to 2 and collapse the node back). These turn
+ *    red on that instead of quietly reverting to `Invalid input`.
+ *  - DISJOINTNESS — the two rules never both select, asserted over the census.
+ *  - MAINTAINED — the cells where this rule must stay silent (`k === 0`, and
+ *    `k >= 2` where the content rule declines) still read exactly as #3626 left
+ *    them.
+ */
+describe('view nested union — the sole-candidate rule (objectui#3678)', () => {
+  const AUTHORABLE_ITEM: Record<string, unknown> = { ...STORED_ITEM };
+  delete AUTHORABLE_ITEM.isPinned;
+
+  const withConfig = (extra: Record<string, unknown>) => ({
+    ...AUTHORABLE_ITEM,
+    config: { ...(AUTHORABLE_ITEM.config as Record<string, unknown>), ...extra },
+  });
+
+  /** Every case here must read identically through both gates. */
+  const bothGates = async (body: unknown) => {
+    const created = await validateMetadataDraft('view', body, undefined, { mode: 'create' });
+    const edited = await validateMetadataDraft('view', body, undefined, EDIT);
+    expect(created.ok).toBe(false);
+    expect(edited.ok).toBe(false);
+    expect(edited.issues).toEqual(created.issues);
+    return created.issues;
+  };
+
+  // ── CANARY ───────────────────────────────────────────────────────────────
+
+  it('CANARY: a bad `order` on a sort row reports the key and the allowed options', async () => {
+    // THE case #3678 was filed on. Before: `config.sort` / `Invalid input`.
+    const issues = await bothGates(withConfig({ sort: [{ field: 'n', order: 'bogus' }] }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe('config.sort.0.order');
+    expect(issues[0].message).toContain('Invalid option');
+    expect(issues[0].message).toContain('"asc"');
+    expect(issues[0].message).toContain('"desc"');
+  });
+
+  it('CANARY: a non-object element in a sort list is addressed to that element', async () => {
+    // The `string` member rejected the array outright, so `ColumnSort[]` is the
+    // sole candidate and index 0 is where it broke. Measured, against the
+    // dispatch's guess that BOTH members would reject `[42]`: they do not — the
+    // array member accepts the type and complains about the element.
+    const issues = await bothGates(withConfig({ sort: [42] }));
+    expect(issues).toEqual([
+      { path: 'config.sort.0', message: 'Invalid input: expected object, received number' },
+    ]);
+  });
+
+  it('CANARY: every issue of the sole candidate is shown, and only that member’s', async () => {
+    // `sort: [{}]` is missing `field` AND has no valid `order`. Both belong to
+    // the selected member; the rejected member's "expected string, received
+    // array" is not among them.
+    const issues = await bothGates(withConfig({ sort: [{}] }));
+    expect(issues.map((i) => i.path)).toEqual(['config.sort.0.field', 'config.sort.0.order']);
+    const messages = issues.map((i) => i.message).join('\n');
+    // Positive anchor FIRST — a collapsed `Invalid input` contains no forbidden
+    // substring either, so the negative alone would pass vacuously (#3606's
+    // lesson, and #3626 hit the same trap).
+    expect(messages).toContain('expected string, received undefined');
+    expect(messages).not.toContain('expected string, received array');
+  });
+
+  it('CANARY: the same union under the aggregated container reports `list.sort.…`', async () => {
+    // Prefix composition on the other route: top-level on create, one level
+    // down inside the selected root member on edit.
+    const issues = await bothGates({
+      ...CONTAINER,
+      list: { type: 'grid', columns: ['name'], sort: [{ field: 'n', order: 'bogus' }] },
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe('list.sort.0.order');
+    expect(issues[0].message).toContain('Invalid option');
+  });
+
+  it('CANARY: a scalar union member left standing names the options it wanted', async () => {
+    // `columns[0].summary` is `enum | {type, field}`. Handed a STRING the object
+    // member rejects the type, leaving the enum as sole candidate — so the path
+    // is unchanged and the MESSAGE stops being `Invalid input`. (Handed an
+    // OBJECT, k is 2 and this stays collapsed — pinned in the #3626 block.)
+    const issues = await bothGates(withConfig({ columns: [{ field: 'a', summary: 'bogus' }] }));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe('config.columns.0.summary');
+    expect(issues[0].message).toContain('Invalid option');
+    expect(issues[0].message).toContain('"count"');
+  });
+
+  it('descends more than one level when each level has a sole candidate', async () => {
+    // `sections[].fields[]` is `string | FormField`. This is the reach #3678's
+    // own scope paragraph did not expect: it read this union as rejecting
+    // wholesale, which it does for a scalar element but not for an object one.
+    const issues = await bothGates({
+      ...AUTHORABLE_ITEM,
+      viewKind: 'form',
+      config: { type: 'simple', sections: [{ fields: [{}] }] },
+    });
+    expect(issues).toEqual([
+      {
+        path: 'config.sections.0.fields.0.field',
+        message: 'Invalid input: expected string, received undefined',
+      },
+    ]);
+  });
+
+  // ── MAINTAINED: the cells this rule must stay out of ─────────────────────
+
+  it('k === 0 — every member rejected the type, so the collapse is kept', async () => {
+    // `sort: 42` is neither a string nor an array. Nothing distinguishes the
+    // members, and #3626 already ruled that inventing a preference is not ours.
+    expect(await bothGates(withConfig({ sort: 42 }))).toEqual([
+      { path: 'config.sort', message: 'Invalid input' },
+    ]);
+  });
+
+  it('k >= 2 — two members read the value, so this rule stays silent', async () => {
+    // `columns: [42]` — BOTH members accepted the array type, so there is no
+    // sole candidate; the content rule then declines because `42` elects
+    // neither variant, and the node keeps its own message. This is the
+    // uniqueness requirement doing its job: drop it and take "the first member
+    // that accepted" instead, and this reports `config.columns.0` /
+    // "expected string, received number" — a preference nobody expressed.
+    expect(await bothGates(withConfig({ columns: [42] }))).toEqual([
+      { path: 'config.columns', message: 'Invalid input' },
+    ]);
+  });
+
+  it('every nested union shape lands in exactly ONE rule’s cell — census', async () => {
+    // The `k` partition is an argument about the code; this is the measurement
+    // that stands behind it. For each shape: the nested union under test
+    // (`unionAt`), where the diagnostic actually lands (`reportedAt`), and which
+    // cell that implies.
+    //
+    // The cells are observable from outside, but NOT — as this test first
+    // assumed and was corrected by running it — through the path alone. A rule
+    // that spoke shows up as a nearer path OR as a named message, and each can
+    // happen without the other:
+    //
+    //   selected member's issue is DEEPER  → path moves   (`sort` → `…sort.0.order`)
+    //   selected member's issue is AT the  → path stays, message stops being
+    //     union node (a scalar member)       `Invalid input` (`summary: 'bogus'`)
+    //   descent ends in a `none` cell      → path moves, message stays
+    //     one level further down             (`filter[].value: [{}]`)
+    //
+    // So the honest test of "did a rule speak" is the disjunction, and `none`
+    // is exactly its negation: the address is still the union node AND the
+    // message is still the node's own `Invalid input`.
+    //
+    // What makes this a disjointness measurement rather than a list: the two
+    // rules would collide only if a k=2 union were also selected as a sole
+    // candidate. The `columns` rows are the k=2 population — three of them, two
+    // where the content rule speaks and one where nothing does — and none of
+    // them reports the "first member that accepted" address (`config.columns.0`
+    // / "expected string, received number" for `[42]`) that a collision would
+    // produce. The `k >= 2` test above pins that single case directly.
+    const CENSUS: Array<{
+      label: string;
+      body: unknown;
+      unionAt: string;
+      reportedAt: string;
+      cell: 'sole' | 'content' | 'none';
+      collapsedMessage: boolean;
+    }> = [
+      { label: 'sort: bad order', body: withConfig({ sort: [{ field: 'n', order: 'bogus' }] }), unionAt: 'config.sort', reportedAt: 'config.sort.0.order', cell: 'sole', collapsedMessage: false },
+      { label: 'sort: of field names', body: withConfig({ sort: ['name'] }), unionAt: 'config.sort', reportedAt: 'config.sort.0', cell: 'sole', collapsedMessage: false },
+      { label: 'sort: of numbers', body: withConfig({ sort: [42] }), unionAt: 'config.sort', reportedAt: 'config.sort.0', cell: 'sole', collapsedMessage: false },
+      { label: 'sort: a bare number', body: withConfig({ sort: 42 }), unionAt: 'config.sort', reportedAt: 'config.sort', cell: 'none', collapsedMessage: true },
+      { label: 'columns: bad key type', body: withConfig({ columns: [{ field: 123 }] }), unionAt: 'config.columns', reportedAt: 'config.columns.0.field', cell: 'content', collapsedMessage: false },
+      { label: 'columns: stray element', body: withConfig({ columns: ['a', 42] }), unionAt: 'config.columns', reportedAt: 'config.columns.1', cell: 'content', collapsedMessage: false },
+      { label: 'columns: elected by nothing', body: withConfig({ columns: [42] }), unionAt: 'config.columns', reportedAt: 'config.columns', cell: 'none', collapsedMessage: true },
+      { label: 'columns: not an array', body: withConfig({ columns: 'nope' }), unionAt: 'config.columns', reportedAt: 'config.columns', cell: 'none', collapsedMessage: true },
+      { label: 'summary: a bad enum string', body: withConfig({ columns: [{ field: 'a', summary: 'bogus' }] }), unionAt: 'config.columns.0.summary', reportedAt: 'config.columns.0.summary', cell: 'sole', collapsedMessage: false },
+      { label: 'summary: an object', body: withConfig({ columns: [{ field: 'a', summary: { type: 'bogus' } }] }), unionAt: 'config.columns.0.summary', reportedAt: 'config.columns.0.summary', cell: 'none', collapsedMessage: true },
+      { label: 'filter value: an array', body: withConfig({ filter: [{ field: 'f', operator: 'in', value: [{}] }] }), unionAt: 'config.filter.0.value', reportedAt: 'config.filter.0.value.0', cell: 'sole', collapsedMessage: true },
+      { label: 'filter value: an object', body: withConfig({ filter: [{ field: 'f', operator: 'equals', value: {} }] }), unionAt: 'config.filter.0.value', reportedAt: 'config.filter.0.value', cell: 'none', collapsedMessage: true },
+    ];
+    for (const c of CENSUS) {
+      const issues = await bothGates(c.body);
+      expect(issues.map((i) => i.path), c.label).toEqual([c.reportedAt]);
+      expect(issues[0].message === 'Invalid input', c.label).toBe(c.collapsedMessage);
+      // The address never leaves the union node's subtree, whatever spoke.
+      expect(
+        c.reportedAt === c.unionAt || c.reportedAt.startsWith(`${c.unionAt}.`),
+        c.label,
+      ).toBe(true);
+      const spoke = c.reportedAt !== c.unionAt || issues[0].message !== 'Invalid input';
+      expect(spoke, c.label).toBe(c.cell !== 'none');
+    }
+  });
+
+  it('a rule speaking is NOT the same as the message improving — both directions', async () => {
+    // Two rows of the census move in only one of the two observables each, and
+    // asserting the wrong one is how a pin passes for a reason that is not the
+    // reason it claims. Written out so the next reader does not re-derive it.
+
+    // Path moves, message does NOT. The sole-candidate rule named the element
+    // that broke the list, but the element's own union is rejected by every
+    // member, so the descent ends in a `none` cell and `Invalid input` is all
+    // there is left to show.
+    expect(
+      await bothGates(withConfig({ filter: [{ field: 'f', operator: 'in', value: [{}] }] })),
+    ).toEqual([{ path: 'config.filter.0.value.0', message: 'Invalid input' }]);
+
+    // Message moves, path does NOT. The sole candidate is the ENUM member,
+    // whose issue sits AT the union node, so the address is unchanged and the
+    // entire gain is that the user is told which options exist.
+    const summary = await bothGates(withConfig({ columns: [{ field: 'a', summary: 'bogus' }] }));
+    expect(summary.map((i) => i.path)).toEqual(['config.columns.0.summary']);
+    expect(summary[0].message).not.toBe('Invalid input');
+    expect(summary[0].message).toContain('Invalid option');
+  });
+});
+
+/**
+ * PARITY, sole-candidate layer — the verdict cannot move, for the structural
+ * reason #3606 and #3626 already pinned: the expansion runs inside the
+ * issue→form-issue mapping, downstream of `ok`. Green before this change and
+ * green after; that is the point of it, not a weakness of it.
+ */
+describe('view verdict parity — sole-candidate bodies (objectui#3678)', () => {
+  const withConfig = (extra: Record<string, unknown>) => ({
+    ...STORED_ITEM,
+    config: { ...(STORED_ITEM.config as Record<string, unknown>), ...extra },
+  });
+
+  const CASES: Array<{ label: string; body: unknown; ok: boolean }> = [
+    { label: 'sort as a field name', body: withConfig({ sort: 'name' }), ok: true },
+    { label: 'sort as an empty array', body: withConfig({ sort: [] }), ok: true },
+    { label: 'sort as column sorts', body: withConfig({ sort: [{ field: 'n', order: 'asc' }] }), ok: true },
+    { label: 'sort with a bad order', body: withConfig({ sort: [{ field: 'n', order: 'bogus' }] }), ok: false },
+    { label: 'sort of field names', body: withConfig({ sort: ['name'] }), ok: false },
+    { label: 'sort of numbers', body: withConfig({ sort: [42] }), ok: false },
+    { label: 'sort as a number', body: withConfig({ sort: 42 }), ok: false },
+    { label: 'summary as a bad enum', body: withConfig({ columns: [{ field: 'a', summary: 'bogus' }] }), ok: false },
   ];
 
   for (const c of CASES) {


### PR DESCRIPTION
Fixes #3678

## 问题

PR #3677 把嵌套 union 的失败诊断按**值的内容**展开(`config.columns`),并**刻意收窄**:在 union 节点上直接拒绝了值的类型的成员,压根没读过值,内容就不能作为它的证据 —— 于是它不是候选。这条收窄是必要的,`config.sort`(`string | ColumnSort[]`)就是它挡住的那个邻居。

收窄之后留下一个空档,就是本单:当这条范畴判定过后**恰好只剩一个**成员时,选它**不是启发式**。它是唯一读过这个值的成员,因此是唯一一个抱怨可能关于「作者写了什么」的成员;其余成员在类型上就停住了,展示它们等于描述一个作者从未选择的形状。

实测(`@objectstack/spec`,修前):

```
[invalid_union] path=["config","sort"] msg="Invalid input"
  member[0] (string)        [invalid_type]  path=[]           "expected string, received array"   ← 没读过值
  member[1] (ColumnSort[])  [invalid_value] path=[0,"order"]  "Invalid option: expected one of …" ← 唯一候选
```

spec 自己写的那句引导消息(#4001)就在下面一层,被丢掉了。

## 两条嵌套规则的关系(本单要求先测量再实现)

**不是优先级关系,是同一个划分的两个不相交格子。** 设 `k` = 接受了值的类型的成员数(即范畴判定不成立的成员数):

| `k` | 谁说话 | 为什么 |
|---|---|---|
| `k === 1` | **唯一候选(#3678)** | 只有它读过值 —— 无歧义 |
| `k === 成员总数` | **内容判别(#3677)** | 全体都读过值,于是由值自身的内容决定;它进一步要求 union 真是「A 的数组 或 B 的数组」,否则弃权 |
| 其余(`k === 0`,或 k 在 2 与成员总数之间且两端不取) | 无人 | 没有任何东西区分这些成员,#3677 已裁「不发明偏好」 |

`k === 1` 与 `k === 成员总数` 只在单成员 union 上重合,而该 schema 不产生单成员 union;何况内容判别本就要求恰好两个成员。**所以不存在两规则都想选的形状** —— 这正是派发单要求「先测量有无冲突形状」的那一步,测量结果见下面的普查表:12 个形状,每个只落进一个格子。

代码里两条规则**并列**而不是嵌套,顺序写成内容判别在前**是刻意的**:这样 #3677 的收窄条款仍然是「删掉它就红」的那一行(删掉后 `sort: ['name']` 会被内容判别选中 `string` 成员,复现 #3677 测到的误选)。如果把范畴判定上提到划分函数里统一做,#3677 那行就成了死代码。

## 测量:每个嵌套 union 落在哪个格子

`unionAt` = 被测 union 节点,`reportedAt` = 诊断最终落在哪里。

| 形状 | unionAt | k | 格子 | 修后 reportedAt |
|---|---|---|---|---|
| `sort: [{field:'n',order:'bogus'}]` | config.sort | 1 | 唯一候选 | `config.sort.0.order` |
| `sort: ['name']` | config.sort | 1 | 唯一候选 | `config.sort.0` |
| `sort: [42]` | config.sort | 1 | 唯一候选 | `config.sort.0` |
| `sort: 42` | config.sort | 0 | 无 | `config.sort`(不变) |
| `columns: [{field:123}]` | config.columns | 2/2 | 内容判别 | `config.columns.0.field`(#3677 已有) |
| `columns: ['a',42]` | config.columns | 2/2 | 内容判别 | `config.columns.1`(#3677 已有) |
| `columns: [42]` | config.columns | 2/2 | 内容判别弃权 | `config.columns`(不变) |
| `columns: 'nope'` | config.columns | 0 | 无 | `config.columns`(不变) |
| `columns[0].summary: 'bogus'` | …0.summary | 1 | 唯一候选 | `…0.summary`(路径不变,消息变具名) |
| `columns[0].summary: {type:'bogus'}` | …0.summary | 2/2 | 内容判别弃权 | `…0.summary`(不变) |
| `filter[0].value: [{}]` | …0.value | 1/5 | 唯一候选 | `config.filter.0.value.0` |
| `filter[0].value: {}` | …0.value | 0/5 | 无 | `config.filter.0.value`(不变) |

**一个被测量纠正的直觉**:「规则说话了」不等于「消息变好了」,两个可观测量可以各自单独移动 ——

- 路径动、消息不动:`filter[].value: [{}]` 下降到出错的那个元素,但元素自己的 union 被全体成员拒绝(`k === 0`),于是止步,`Invalid input` 就是仅剩能显示的东西。
- 消息动、路径不动:`summary: 'bogus'` 选中的是 enum 成员,它的 issue 就在 union 节点上,于是地址不变,全部收益是「告诉作者有哪些选项」。

这条最初把普查断言写错了(只断言路径下降),跑出来才发现。现在断言写成析取,并单独钉了两个方向。

## 修前 / 修后(两条门逐一实测,逐字节相同)

| body | 修前 | 修后 |
|---|---|---|
| `sort: [{field:'n',order:'bogus'}]` | `config.sort` / `Invalid input` | `config.sort.0.order` / `Invalid option: expected one of "asc"｜"desc"` |
| `sort: ['name']` | `config.sort` / `Invalid input` | `config.sort.0` / `expected object, received string` |
| `sort: [42]` | `config.sort` / `Invalid input` | `config.sort.0` / `expected object, received number` |
| `sort: [{}]` | `config.sort` / `Invalid input` | `config.sort.0.field` + `config.sort.0.order`(选中成员的全部 issue) |
| 容器 `list.sort: [{order:'bogus'}]` | `list.sort` / `Invalid input` | `list.sort.0.order` / `Invalid option …` |
| `columns[0].summary: 'bogus'` | `config.columns.0.summary` / `Invalid input` | 同路径 / `Invalid option: expected one of "none"｜"count"｜…` |
| `sections[0].fields: [{}]` | `config.sections.0.fields.0` / `Invalid input` | `config.sections.0.fields.0.field` / `expected string, received undefined` |
| `filter[0].value: [{}]` | `config.filter.0.value` / `Invalid input` | `config.filter.0.value.0` / `Invalid input`(路径更近) |
| `sort: 42`、`columns: [42]`、`columns: 'nope'`、`summary: {type:'bogus'}` | — | **不变** |

## ⚠️ 与 #3677 既有测试的冲突:2 条 NARROWING 钉子被取代(派发单的「只加不改」在此不成立)

派发单要求「既有 38 条一行不改只加」。**测量证明这条约束与本单授权的规则不相容**,如实报告而不是绕开:

1. `does NOT answer for config.sort`(`sort: ['name']`)—— issue #3678 正文的对照表**逐字要求**这一行变成 `config.sort.0` / `expected object, received string`。
2. `does NOT answer for a filter value union`(`value: [{}]`)—— issue 的「范围」段落**估计错了**:它把 `filter[].value` 读成「值类型不匹配时全体拒绝」。对**标量**值确实如此(`value: {}` → k=0,不变),但对**数组**值,5 个成员里恰好数组成员接受,`k === 1`,唯一候选成立。

两条都按「fixture 三分诊」里的**整体替换**处理,并保留各自原本守的那个 claim:

- `sort` 那条守的是「**绝不能选中 `string` 成员**」。新钉子仍然证明这一点(误选会读作 `expected string, received array`),并且**直接加了这句负断言**,所以它不会空过。#3677 的收窄条款依然是删掉就红的那一行 —— 见下面的扰动 (c)。
- `filter` 那条守的是「内容判别对五成员 union 不说话」。它**依然不说话**(内容判别要求恰好两个成员);说话的是另一条规则,注释里写清了这层区别。

**可逆的杠杆**:若维护者认为 `filter[].value` 不该被本规则触及,唯一的收窄方式是给唯一候选规则加 `groups.length === 2` 的元数限制。**不建议**:「唯一候选」与成员个数无关,为了保住一条旧钉子而加一条无原则的特例,正是本仓一贯拒绝的形状。但它是一行,随时可加。

## 逆向验证(先写预测,后运行;三个扰动)

预测全文落盘在实现之前。

**扰动 (a) —— 还原实现**(`nestedUnionMemberIndex` 退回只调内容判别)。预测:所有唯一候选锚点 + 两条重钉的 NARROWING 红;`k === 0` / `k >= 2` 两条「维持」锚点与全部 parity 钉子**两向皆绿**(它们钉的是「不变」)。实际:

```
Tests  10 failed | 46 passed (56)
  × does NOT answer for `config.sort` …
  × does NOT answer for a filter value union …
  × CANARY: a bad `order` on a sort row …      (以及其余 6 条 #3678 锚点)
```

`k === 0`、`k >= 2` 两条如预测未红 —— **如实注明**:它们是防回归的那一半,不是「修前红修后绿」的那一半。

**扰动 (b) —— 「验证验证器」,只扰动唯一性条款**(把「恰好一个」改成「第一个接受的」)。预测**方向不是**「新锚点红」—— 内容判别先跑,`columns` 里它说得上话的形状不受影响,受影响的恰是它**弃权**的那些,于是红的应该是 **#3677 自己的两条钉子**。实际:

```
Tests  4 failed | 52 passed (56)
  × a first element that elects NEITHER variant keeps the union's own message   ← #3626 的
  × stops at the next union down, but addressed to it rather than to `columns`  ← #3626 的
  × k >= 2 — two members read the value, so this rule stays silent
  × every nested union shape lands in exactly ONE rule's cell — census
```

方向与预测一致。这证明唯一性条款守的是 #3677 的「不发明偏好」边界,而不只是它自己的锚点 —— 少了它,`columns: [42]` 会报 `config.columns.0` / `expected string, received number`,`summary: {type:'bogus'}` 会报 enum 的 `Invalid option`。

**扰动 (c) —— #3677 的收窄条款是否变成死代码**:删掉 `if (groups.some(memberRejectedNodeType)) return null;`。预测:`sort: ['name']` 被内容判别选中 `string` 成员,重新报 `expected string, received array`,重新钉的 sort 测试红。实际:

```
Tests  2 failed | 54 passed (56)
  × does NOT answer for `config.sort` — one member never accepted the array
  × every nested union shape lands in exactly ONE rule's cell — census
```

该条款仍然是活的,没有因为本单变成死代码 —— 这也是把两条规则并列、而不是把范畴判定上提的原因。

## 判定奇偶

展开仍在 issue → `SchemaFormIssue` 的**映射内部**、`ok` 判定之后、所有既有过滤器之后。判定不是「测出来没变」,而是**结构上不可能变**。照 #3624/#3677 的手法加了 8 条 parity pin,它们**修前修后都绿** —— 这正是它们的意义,不是它们的弱点。

## 测试

`clientValidation.viewDiagnostics.test.ts`:新增 10 条(6 CANARY + 2 维持 + 1 普查 + 1 双向可观测量)+ 8 条 parity pin;**改动 2 条**(上述被取代的 NARROWING 钉子),其余 36 条一行未动。

```
vitest run packages/app-shell/src/views/metadata-admin/   →  Test Files 128 passed (128)
                                                             Tests 1225 passed | 1 skipped (1226)
pnpm --filter @object-ui/app-shell type-check             →  exit=0(tsc --noEmit + typetests)
eslint(两个改动文件)                                       →  clean
node scripts/check-control-bytes.mjs                      →  OK (3681 files)
node scripts/check-spec-symbol-derivation.mjs             →  OK
```

## 已知残留(不在本单范围)

- 范畴判定只认 `invalid_type`:enum 成员被喂非枚举值时答的是 `invalid_value`,于是被算作「读过值」的候选。`summary: {type:'bogus'}` 因此维持 k=2 而塌陷,若判定放宽到「任何在 union 节点自身整体拒绝该值的 issue」则 k=1 可下降。属观测类,单独记录,不在本单改。
- 全体一致提升(#3626 的方向 1)未做。
- contract-first 的正解仍是 spec 侧给出判别入口(objectstack#6391)。本仓这三条局部规则是不跨仓的兜底,定位与 #3626 一致。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_