### PR TITLE
docs(plugin-tree): add the `## License` section the other 36 published READMEs carry (#3664)

### DIFF
--- a/packages/plugin-tree/README.md
+++ b/packages/plugin-tree/README.md
@@ -44,3 +44,7 @@ It registers two component types via the `ComponentRegistry`:
 
 Records whose parent is missing (or points outside the result set) are kept as
 roots, so nothing is silently dropped.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
Fixes #3664

`packages/plugin-tree/README.md` 是 38 个已发布包里唯一「有 README 却没有 `## License` 小节」的。本 PR 补上该节,单文件 4 行新增。

## 前提复核(origin/main)

派发时 main 已前进到 `be9cd38ac`,其中 `4747344da`(#3688)刚重写过 36 个包 README,所以普查是在**当前 origin/main** 上重跑的,不是照抄 issue 正文的旧数:

- 已发布(非 private)包:**38**
- 有 README 的:**37**(`sdui-parser` 无 README —— 属 #3647 划出去的打包策略问题,不在本单范围)
- 37 个里有 `## License` 的:**36**;`plugin-tree` 是唯一遗漏

issue 正文写的是「37 个已发布包的 README 都有」,实际应为 36(38 减去无 README 的 sdui-parser、再减去 plugin-tree 本身)。差 1 是计数口径,不影响结论。

## 兄弟包形态普查(36 个)

**正文措辞**分布:

| 形态 | 数量 | 包 |
| --- | --- | --- |
| `MIT — see [LICENSE](./LICENSE).` | **32** | 绝大多数 |
| `MIT` | 2 | types, react-runtime |
| `MIT © ObjectStack Inc.` | 1 | plugin-timeline |
| `MIT © ObjectStack Inc.` + 第三方声明 | 1 | plugin-chatbot |

**位置**分布:末节 **34/36**(例外:plugin-view、types,其后还有别的小节)。

**其他格式约定**(逐字核对):标题前无 `---` 分隔线(0/36)、标题前后各一空行、文件末尾恰好一个换行、破折号是真 em dash U+2014 而非连字符。

取多数形态,与 `packages/plugin-grid/README.md` 的 License 节做了**逐字节相等**断言(`a === b` 为 true),位置放文末。该 README 其余内容一字未动。

**与 issue 建议的出入(已在 commit 里写明)**:issue 正文建议照抄 `plugin-timeline`,但该形态是 1/36 的少数派,且**完全不含 `./LICENSE` 链接**。多数形态既是仓库惯例,又能给链接门禁留下可校验的对象 —— 按派发口径取了多数形态。

## 门禁前后

`scripts/check-doc-links.mjs` 第 7 个扫描根 `packages/*/README.md`(`disk` 规则)把相对 href 当作仓库内路径解析,所以新增的 `./LICENSE` 会被机械校验,指向 PR #3662 落地的文件。

| 时点 | 结果 |
| --- | --- |
| 修改前(基线) | `Links are valid across 7 scan roots.` exit 0 |
| 修改后 | `Links are valid across 7 scan roots.` exit 0 |

绿→绿本身不构成证明,所以补了一次**反向验证(先定方向再跑)**:预测「若门禁真的扫这条链接,临时删掉 LICENSE 必须转红并点名该 href;若仍绿则说明链接未被检查、修后绿是空的」。实测与预测一致:

```
Found 1 broken link (1 distinct target):
- [example-relative] packages/plugin-tree/README.md:50 -> ./LICENSE
```

exit 1;恢复文件后重回 exit 0,`git status` 确认 LICENSE 按原样还原(1065 字节,未进入 diff)。这条链接因此是**承重**的,修后绿是「LICENSE 文件确实存在」的机械证明。

顺带印证了 issue 的那个观察:#3622/#3649 那轮死链清扫扫不到 plugin-tree 缺 LICENSE,正因为它的 README 一条链接都没有 —— 无链可死。现在这个盲区补上了。

CI 覆盖确认:`docs-links.yml` 的触发是 `pull_request: branches: [main]` 且**无 paths 过滤**,所以纯 markdown 的 PR 照样会跑到这道门禁(`ci.yml`/`lint.yml` 把 `**/*.md` 列进 paths-ignore,不会启动)。另跑了 `scripts/check-control-bytes.mjs`:`OK (scanned 3682 tracked text file(s))` exit 0。

## 无 changeset(判断依据)

文档改动,且有两条直接先例:

- **PR #3662** —— 给**同一个包**加 `LICENSE` 文件(同样随 tarball 发布,`files` 含它),0 个 changeset;
- **PR #3688** —— 改 36 个包 README,0 个 changeset。

AGENTS.md 的口径也是「功能改进需写 changeset,纯修复不需要」。故不加。

## 文件面

`packages/plugin-tree/README.md` 单文件,+4 行 / -0 行。未动 `content/docs/releases/`,未改 assignee。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_