### PR TITLE
fix(react-runtime,sdui-parser,console): 补上三包声明了 MIT 却从未随包发布的许可证文本,并加门禁封死该类 (#3696, #3702)

### DIFF
--- a/apps/console/LICENSE
+++ b/apps/console/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ObjectQL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-runtime/LICENSE
+++ b/packages/react-runtime/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ObjectQL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdui-parser/LICENSE
+++ b/packages/sdui-parser/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ObjectQL
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/__tests__/package-files-exist.test.ts
+++ b/scripts/__tests__/package-files-exist.test.ts
@@ -415,8 +415,9 @@ function licenseTextFiles(pkg: WorkspacePackage): string[] {
 /**
  * Whether a package owes license text. Split out from the filter below so the
  * truth table can be asserted directly: two of its four cases have no specimen
- * in the tree today, and an unexercised predicate limb is how objectui#4984's
- * family of dead rules started.
+ * in the tree today (every non-private package declares a license), and a
+ * predicate limb no test ever walks is one a later edit can invert with nothing
+ * turning red.
  */
 function owesLicenseText(pkg: Pick<WorkspacePackage, 'private' | 'license'>): boolean {
   return !pkg.private && pkg.license !== undefined && pkg.license.trim() !== '';

--- a/scripts/__tests__/package-files-exist.test.ts
+++ b/scripts/__tests__/package-files-exist.test.ts
@@ -85,6 +85,8 @@ interface WorkspacePackage {
   private: boolean;
   files: string[] | undefined;
   hasBuildScript: boolean;
+  /** The `license` field verbatim, or undefined when the manifest omits it. */
+  license: string | undefined;
 }
 
 /**
@@ -147,6 +149,7 @@ function readWorkspacePackages(): WorkspacePackage[] {
         private: Boolean(json.private),
         files: Array.isArray(json.files) ? json.files : undefined,
         hasBuildScript: Boolean(json.scripts?.build),
+        license: typeof json.license === 'string' ? json.license : undefined,
       });
     }
   }
@@ -346,5 +349,213 @@ describe('package.json `files` entries exist on disk (objectui#3663)', () => {
       '@object-ui/plugin-tree lists "LICENSE" in `files`; PR #3662 added packages/plugin-tree/LICENSE ' +
         'because every published tarball had been shipping without it. npm will not complain if it goes missing again.',
     ).toBe(true);
+  });
+});
+
+/**
+ * objectui#3696: the guard above can only ask whether a path a package
+ * PROMISED in `files` is real. A package that never made the promise is
+ * invisible to it — and the license text is exactly the file nobody promises,
+ * because npm ships it whether you list it or not.
+ *
+ * ## Why `files` is the wrong place to look for this one
+ *
+ * npm keeps a small set of paths it packs REGARDLESS of `files`:
+ * `package.json`, `README*`, `LICENSE*`/`LICENCE*`, `COPYING*`, and the `main`
+ * entry. Measured on `packages/sdui-parser` (which declares `files: ["dist"]`)
+ * by renaming one file and re-running `npm pack --dry-run`:
+ *
+ *   LICENSE / License / LICENCE / LICENSE.md / LICENSE.txt -> packed
+ *   copying                                                -> packed
+ *   NOTICE / CHANGELOG.md / NOTALICENSE                     -> NOT packed
+ *
+ * So `files: ["dist"]` never excluded the license text, and adding `"LICENSE"`
+ * to `files` would not have included it. `@object-ui/react-runtime` and
+ * `@object-ui/sdui-parser` shipped every version of themselves declaring
+ * `"license": "MIT"` with no MIT text and no copyright notice in the tarball,
+ * for one reason only: the file was not on disk. That is what this guard reads.
+ *
+ * ## The predicate
+ *
+ * `!private && license` — the two conditions that together turn "MIT" from a
+ * label into an obligation. A private package makes no distribution and owes no
+ * text (`object-ui`, the vscode-extension, is exactly that case and is excluded
+ * on purpose). A package declaring no license at all is a different defect that
+ * this guard deliberately does not invent a verdict about.
+ *
+ * The population is DERIVED from the same workspace scan as the guard above, so
+ * a 40th package is covered the day it is added rather than the day someone
+ * repeats the by-hand census. objectui#3647 and objectui#3696 were both found
+ * by a human diffing every package by hand; twice in one week is the argument
+ * for a gate, not for more care.
+ */
+
+/**
+ * Spellings that count as license text. The `licen[cs]e` family from npm's
+ * always-packed set above, with an optional extension.
+ *
+ * `COPYING` is packed by npm too but is deliberately NOT accepted: every one of
+ * this repo's 38 license files is spelled `LICENSE`, and a guard that silently
+ * blesses a spelling the repo does not use would report success over a
+ * convention drift. Landing a `COPYING` should turn this red and be widened
+ * here on purpose.
+ */
+const LICENSE_TEXT_RE = /^licen[cs]e(\.[^.]+)?$/i;
+
+/** Every license-text file in a package directory, by name. */
+function licenseTextFiles(pkg: WorkspacePackage): string[] {
+  const dir = path.join(repoRoot, pkg.dir);
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((name) => LICENSE_TEXT_RE.test(name))
+    .sort();
+}
+
+/**
+ * Whether a package owes license text. Split out from the filter below so the
+ * truth table can be asserted directly: two of its four cases have no specimen
+ * in the tree today, and an unexercised predicate limb is how objectui#4984's
+ * family of dead rules started.
+ */
+function owesLicenseText(pkg: Pick<WorkspacePackage, 'private' | 'license'>): boolean {
+  return !pkg.private && pkg.license !== undefined && pkg.license.trim() !== '';
+}
+
+const owingPackages = packages.filter(owesLicenseText);
+const withoutLicenseText = owingPackages.filter((p) => licenseTextFiles(p).length === 0);
+
+/**
+ * Packages that owed license text and did not have it when this guard landed,
+ * measured on main@3e601773e.
+ *
+ * A RATCHET in the same shape as {@link KNOWN_MISSING}: a NEW offender fails
+ * without consulting this map, and an entry here that is no longer offending
+ * fails too, so it can only shrink.
+ *
+ * `apps/console` (`@object-ui/console`) is the one entry. It is published for
+ * real — `publishConfig.access: "public"`, versioned 17.3.0 with the rest, in
+ * the `.changeset/config.json` `fixed` group — and it has the identical defect
+ * to the two packages objectui#3696 fixed. It is baselined rather than fixed
+ * because objectui#3696 scoped itself to `packages/*` by name; objectui#3702
+ * carries it, and fixing it means copying the root LICENSE and deleting the
+ * line below.
+ */
+const KNOWN_LICENSE_TEXT_MISSING: Record<string, { issue: string }> = {
+  'apps/console': { issue: 'objectui#3702' },
+};
+
+describe('published packages that declare a license ship its text (objectui#3696)', () => {
+  it('discovers the packages that owe license text (guard cannot pass by finding nothing)', () => {
+    // Same anti-vacuity floor as the guard above, sitting just under the 39
+    // measured on main@3e601773e. A predicate that quietly matches nothing —
+    // a renamed `license` field, a lost workspace root, a `private` default
+    // flipped — would otherwise report success over an empty set.
+    expect(owingPackages.length).toBeGreaterThanOrEqual(38);
+
+    // The two packages objectui#3696 fixed must be in scope BY NAME. If either
+    // drops out of the population, this guard has stopped watching the exact
+    // spot that motivated it, and the pin below would pass on a package nobody
+    // is checking any more.
+    const names = owingPackages.map((p) => p.name);
+    expect(names, '@object-ui/react-runtime must still be required to ship license text').toContain(
+      '@object-ui/react-runtime',
+    );
+    expect(names, '@object-ui/sdui-parser must still be required to ship license text').toContain(
+      '@object-ui/sdui-parser',
+    );
+  });
+
+  it('every package that declares a license has the text on disk', () => {
+    const violations = withoutLicenseText
+      .filter((p) => !Object.hasOwn(KNOWN_LICENSE_TEXT_MISSING, p.dir))
+      .map((p) => `${p.name} (${p.dir}) declares "license": "${p.license}" but has no LICENSE file`);
+
+    expect(
+      violations,
+      [
+        'A published package claims a license in package.json and ships no license text.',
+        'The MIT terms require the licence and copyright notice to travel WITH the distribution,',
+        'so the published tarball does not actually grant what its own manifest advertises',
+        '(objectui#3647/#3696).',
+        '',
+        'npm packs LICENSE regardless of `files`, so the fix is the file itself, never a `files` entry:',
+        '  cp LICENSE <package-dir>/LICENSE      # all 38 are byte-identical, blob cf2ca285',
+        '',
+        'If the package should NOT be published, mark it `"private": true` instead — that is the',
+        'other true direction, and it is why `object-ui` (the vscode-extension) is not listed here.',
+        '',
+        ...violations,
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('the objectui#3696 license baseline only shrinks', () => {
+    // The other half of the ratchet, kept separate from the objectui#3663 one
+    // above so a stale entry names its own defect class.
+    const stillMissing = new Set(withoutLicenseText.map((p) => p.dir));
+    const stale = Object.keys(KNOWN_LICENSE_TEXT_MISSING).filter((dir) => !stillMissing.has(dir));
+
+    expect(
+      stale,
+      [
+        'A KNOWN_LICENSE_TEXT_MISSING entry is stale: the package now ships license text, or it',
+        'stopped owing any (it went `private`, or dropped its `license` field). Either way the',
+        'defect is gone — delete its line from KNOWN_LICENSE_TEXT_MISSING to bank the progress.',
+        '',
+        ...stale.map((dir) => `${dir} (${KNOWN_LICENSE_TEXT_MISSING[dir].issue})`),
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('pins the two packages fixed in objectui#3696', () => {
+    // The general assertion covers these, but naming them means a revert points
+    // straight at the issue that explains why the files have to be there —
+    // and, unlike the general assertion, this cannot be satisfied by adding a
+    // baseline line.
+    for (const dir of ['packages/react-runtime', 'packages/sdui-parser']) {
+      expect(
+        fs.existsSync(path.join(repoRoot, dir, 'LICENSE')),
+        `${dir}/LICENSE is required: the package declares "license": "MIT" and npm packs the file ` +
+          'regardless of `files`, so deleting it silently resumes publishing MIT-labelled tarballs ' +
+          'with no MIT text (objectui#3696).',
+      ).toBe(true);
+    }
+  });
+
+  it('requires license text only from packages that publish AND declare a license', () => {
+    // The predicate's truth table, asserted directly. Two of these four rows
+    // have no specimen in the tree today — every non-private package declares a
+    // license — so without this they would be untested logic that a later edit
+    // could invert with nothing turning red.
+    expect(owesLicenseText({ private: false, license: 'MIT' }), 'published + declared -> owes').toBe(true);
+    expect(owesLicenseText({ private: true, license: 'MIT' }), 'private -> makes no distribution').toBe(false);
+    expect(owesLicenseText({ private: false, license: undefined }), 'no claim -> nothing to honour').toBe(false);
+    expect(owesLicenseText({ private: false, license: '  ' }), 'blank claim is not a claim').toBe(false);
+  });
+
+  it('excludes private packages, and that exclusion is not vacuous', () => {
+    // The `private` limb only means something while some private package would
+    // otherwise be reported. Asserting the specimen set is NON-EMPTY first is
+    // what keeps this from becoming a test that passes because it examines
+    // nothing — today it is `object-ui` (packages/vscode-extension), which
+    // declares "MIT" and has no LICENSE file.
+    const privateOwingIfPublished = packages.filter(
+      (p) => p.private && p.license !== undefined && licenseTextFiles(p).length === 0,
+    );
+
+    expect(
+      privateOwingIfPublished.map((p) => p.name),
+      'No private package declares a license without shipping its text any more, so this boundary ' +
+        'case now proves nothing. Either pick a live specimen or delete this test — do not leave it ' +
+        'green over an empty set.',
+    ).not.toEqual([]);
+
+    const reported = new Set(withoutLicenseText.map((p) => p.name));
+    for (const pkg of privateOwingIfPublished) {
+      expect(reported.has(pkg.name), `${pkg.name} is private and must not be required to ship license text`).toBe(
+        false,
+      );
+    }
   });
 });

--- a/scripts/__tests__/package-files-exist.test.ts
+++ b/scripts/__tests__/package-files-exist.test.ts
@@ -434,17 +434,18 @@ const withoutLicenseText = owingPackages.filter((p) => licenseTextFiles(p).lengt
  * without consulting this map, and an entry here that is no longer offending
  * fails too, so it can only shrink.
  *
- * `apps/console` (`@object-ui/console`) is the one entry. It is published for
- * real — `publishConfig.access: "public"`, versioned 17.3.0 with the rest, in
- * the `.changeset/config.json` `fixed` group — and it has the identical defect
- * to the two packages objectui#3696 fixed. It is baselined rather than fixed
- * because objectui#3696 scoped itself to `packages/*` by name; objectui#3702
- * carries it, and fixing it means copying the root LICENSE and deleting the
- * line below.
+ * Currently empty, which is the intended resting state — the ratchet still
+ * fails on any NEW offender. It was written carrying one entry,
+ * `apps/console` (`@object-ui/console`): published for real
+ * (`publishConfig.access: "public"`, versioned 17.3.0 with the rest, in the
+ * `.changeset/config.json` `fixed` group) with the identical defect to the two
+ * packages objectui#3696 fixed, but outside that issue's `packages/*` scope, so
+ * it was booked to objectui#3702 instead of fixed silently. Triage folded
+ * objectui#3702 into the same PR, the root LICENSE was copied to
+ * `apps/console/LICENSE`, and the entry was banked — the ratchet reported it
+ * stale first, naming the cause (`it now ships license text (LICENSE)`).
  */
-const KNOWN_LICENSE_TEXT_MISSING: Record<string, { issue: string }> = {
-  'apps/console': { issue: 'objectui#3702' },
-};
+const KNOWN_LICENSE_TEXT_MISSING: Record<string, { issue: string }> = {};
 
 describe('published packages that declare a license ship its text (objectui#3696)', () => {
   it('discovers the packages that owe license text (guard cannot pass by finding nothing)', () => {
@@ -530,17 +531,25 @@ describe('published packages that declare a license ship its text (objectui#3696
     ).toEqual([]);
   });
 
-  it('pins the two packages fixed in objectui#3696', () => {
+  it('pins the three packages fixed in objectui#3696 / objectui#3702', () => {
     // The general assertion covers these, but naming them means a revert points
     // straight at the issue that explains why the files have to be there —
     // and, unlike the general assertion, this cannot be satisfied by adding a
     // baseline line.
-    for (const dir of ['packages/react-runtime', 'packages/sdui-parser']) {
+    const fixed: Record<string, string> = {
+      'packages/react-runtime': 'objectui#3696',
+      'packages/sdui-parser': 'objectui#3696',
+      // Found by re-running objectui#3696's census over ALL FOUR workspace
+      // roots instead of `packages/*` alone, which is how it was missed twice.
+      'apps/console': 'objectui#3702',
+    };
+
+    for (const [dir, issue] of Object.entries(fixed)) {
       expect(
         fs.existsSync(path.join(repoRoot, dir, 'LICENSE')),
         `${dir}/LICENSE is required: the package declares "license": "MIT" and npm packs the file ` +
           'regardless of `files`, so deleting it silently resumes publishing MIT-labelled tarballs ' +
-          'with no MIT text (objectui#3696).',
+          `with no MIT text (${issue}).`,
       ).toBe(true);
     }
   });

--- a/scripts/__tests__/package-files-exist.test.ts
+++ b/scripts/__tests__/package-files-exist.test.ts
@@ -497,14 +497,35 @@ describe('published packages that declare a license ship its text (objectui#3696
     const stillMissing = new Set(withoutLicenseText.map((p) => p.dir));
     const stale = Object.keys(KNOWN_LICENSE_TEXT_MISSING).filter((dir) => !stillMissing.has(dir));
 
+    // WHY an entry stopped being a live defect, reported per entry rather than
+    // assumed — the convention objectui#3701 established for the baseline
+    // above, and for the same reason. An entry leaves this baseline by four
+    // routes and only the FIRST means someone added the licence: the other
+    // three mean the package stopped owing one, which is a different fact with
+    // a different reviewer response. Derived from the same data the predicate
+    // reads, so it cannot drift from the verdict it explains.
+    const causeOf = (dir: string): string => {
+      const pkg = packages.find((p) => p.dir === dir);
+      if (!pkg)
+        return 'no package sits at that path any more: it was moved or removed from the workspace, or this baseline key never matched one';
+      const texts = licenseTextFiles(pkg);
+      if (texts.length > 0) return `it now ships license text (${texts.join(', ')})`;
+      if (pkg.private) return 'it is now `private`, so it distributes nothing and owes no text';
+      return 'it no longer declares a `license` field, so there is no claim left to honour';
+    };
+
     expect(
       stale,
       [
-        'A KNOWN_LICENSE_TEXT_MISSING entry is stale: the package now ships license text, or it',
-        'stopped owing any (it went `private`, or dropped its `license` field). Either way the',
-        'defect is gone — delete its line from KNOWN_LICENSE_TEXT_MISSING to bank the progress.',
+        'A KNOWN_LICENSE_TEXT_MISSING entry no longer describes a live defect.',
+        'Delete its line from KNOWN_LICENSE_TEXT_MISSING to bank the progress — that is the',
+        'right move under every cause below.',
         '',
-        ...stale.map((dir) => `${dir} (${KNOWN_LICENSE_TEXT_MISSING[dir].issue})`),
+        'The cause is reported per entry rather than assumed, because only one of the four',
+        'routes out of this baseline means the licence was actually added; do not read a stale',
+        'line as proof that the package now ships its terms.',
+        '',
+        ...stale.map((dir) => `${dir} (${KNOWN_LICENSE_TEXT_MISSING[dir].issue}) — ${causeOf(dir)}`),
       ].join('\n'),
     ).toEqual([]);
   });


### PR DESCRIPTION
Fixes #3696
Fixes #3702

裁 B(补文件 + 门禁),外加分诊裁定并入的 #3702。4 个文件:三份新 LICENSE,外加 `scripts/__tests__/package-files-exist.test.ts` 的新增断言块。**未动任何 `package.json`**,未动 `files` 字段。

## 前提复核(在 origin/main 上先证后改)

| 事实 | 结果 |
| --- | --- |
| 两包 `license` 字段 | 均为 `"MIT"` |
| 两包 `private` | 均无该键(即会发布) |
| 两包 `files` | 均为 `["dist"]` |
| 两包 LICENSE 文件 | **均不存在** |
| `sdui-parser` README | 不存在(38 个已发布包里唯一) |

issue 正文的前提全部复现。

### 既有 LICENSE 仍是单 blob —— 但份数与派发口径差 1

```
$ git ls-tree -r origin/main | grep -E 'LICENSE$' | awk '{print $3}' | sort | uniq -c
     37 cf2ca28574caca42deafdee0ea935fc2e2823427
```

派发说「36 个」,实测 **37**。差额不是分歧:37 = 仓根 1 份 + 包级 36 份,而包级的第 36 份正是 PR #3662 刚补的 `plugin-tree`。#3662 正文写的「36 份」是在它自己落地**之前**测的(1 + 35)。形态结论不变 —— 连 copyright 行在内完全一致,不存在多数/少数形态之分。

本 PR 新增的三份 blob 同为 `cf2ca285…`,各 1065 字节:

```
$ cmp LICENSE packages/react-runtime/LICENSE && cmp LICENSE packages/sdui-parser/LICENSE && cmp LICENSE apps/console/LICENSE   # 均无输出
$ git hash-object LICENSE packages/{react-runtime,sdui-parser,plugin-grid}/LICENSE apps/console/LICENSE
cf2ca28574caca42deafdee0ea935fc2e2823427     x5
```

## 为什么修法是补文件而不是改 `files` —— 在本仓实测过,不是照抄语义

npm 有一份**无视 `files` 恒定打包**的清单。在 `packages/sdui-parser`(`files: ["dist"]`)上逐个改名跑 `npm pack --dry-run`,带对照组:

| 文件名 | 是否进 tarball |
| --- | --- |
| `LICENSE` / `License` / `LICENCE` / `LICENSE.md` / `LICENSE.txt` | ✅ 收录 |
| `copying` | ✅ 收录 |
| `NOTICE` | ❌ |
| `CHANGELOG.md` | ❌ |
| `NOTALICENSE`(对照组) | ❌ |

对照组不收录,证明这个探针是有鉴别力的,不是「什么都收」。

同一机制在**未改动的** `react-runtime` 上有现成佐证:它的 `files` 只有 `dist`,而 `README.md` 照样进了 tarball(见下方「修改前」清单)—— 恒定清单压过 `files` 这件事在本仓当场可见,LICENSE 走的是同一条路。

所以给 `files` 加 `"LICENSE"` 是无效操作,本 PR 不动 `package.json`。

## 验收:`npm pack --dry-run` 三个包前后对照

**`@object-ui/react-runtime`**

```
修改前                              修改后
npm notice Tarball Contents        npm notice Tarball Contents
                                   npm notice 1.1kB LICENSE      ← 新增
npm notice 4.7kB README.md         npm notice 4.7kB README.md
npm notice 847B  package.json      npm notice 847B  package.json
npm notice unpacked size: 5.6 kB   npm notice unpacked size: 6.7 kB
npm notice total files: 2          npm notice total files: 3
```

**`@object-ui/sdui-parser`**

```
修改前                              修改后
npm notice Tarball Contents        npm notice Tarball Contents
                                   npm notice 1.1kB LICENSE      ← 新增
npm notice 1.0kB package.json      npm notice 1.0kB package.json
npm notice unpacked size: 1.0 kB   npm notice unpacked size: 2.1 kB
npm notice total files: 1          npm notice total files: 2
```

**`@object-ui/console`(#3702 并入部分)**

```
修改前                              修改后
npm notice Tarball Contents        npm notice Tarball Contents
                                   npm notice 1.1kB LICENSE      ← 新增
npm notice 5.8kB README.md         npm notice 5.8kB README.md
npm notice 4.0kB package.json      npm notice 4.0kB package.json
npm notice 1.9kB plugin.ts         npm notice 1.9kB plugin.ts
npm notice unpacked size: 11.6 kB  npm notice unpacked size: 12.7 kB
npm notice total files: 3          npm notice total files: 4
```

`apps/console` 的 `files` 保持 `["dist","plugin.ts","plugin.js","plugin.d.ts","README.md"]` **一字未改**,LICENSE 照样进清单 —— 这本身又是恒定清单语义的一次独立复现。

两点说明,免得清单读起来有歧义(沿用 #3662 的写法):

1. **清单里没有 `dist/`**,因为这是全新 worktree、包尚未构建。不影响验收 —— npm 对 LICENSE 的收录与 `dist` 是否存在互相独立。
2. **对照**:同样未构建的兄弟包 `plugin-timeline` 跑同一条命令,清单里本来就有 `1.1kB LICENSE`(4 个文件)。差异来自文件本身的有无,不是命令或环境。

## 新门禁

`scripts/__tests__/package-files-exist.test.ts` 末尾新增独立 describe:**凡非 `private` 且声明了 `license` 字段的包,必须有许可证文本**。

判据 `!private && license` 从**同一份工作区扫描派生**,不是硬编码包名单 —— 第 40 个包加进来的当天就被覆盖。#3647 与 #3696 连着两次都是靠人肉逐包普查发现的,缺的是门禁不是细心;而 #3702 正是这道门禁在自己落地当天抓出来的第三例。

许可证文件名接受 `/^licen[cs]e(\.[^.]+)?$/i`。上表实测的 `COPYING` **故意不接受**:全仓 39 份都拼作 `LICENSE`,一道悄悄放行仓库不用的拼法的门禁,等于在约定漂移上报成功。真落一个 `COPYING` 应当转红并在此处有意放宽。

### 反空绿(四重)

1. **人口下限**:`owingPackages.length >= 38`(实测 39)。`license` 字段被改名、工作区根丢失、`private` 默认翻转,都会让谓词悄悄匹配到空集。
2. **点名钉扎**:三个包必须**按名字**各带自己的 issue 号留在树上。这条比通用断言强 —— 它**不能靠往基线里加一行来满足**。
3. **谓词真值表直接断言**:`owesLicenseText` 的四行里有**两行今天在树上没有标本**(全部 39 个非 private 包都声明了 license)。不断言的话,那两肢就是无人行经的逻辑,后来的改动可以把它反转而**不转红**。
4. **边界非空自证**:「private 不被要求」这一条,先断言「存在至少一个 private 且声明 license 却无文本的包」**非空**,再断言它们不被点名。今天的标本是 `object-ui`(vscode-extension)。标本消失时该测试会红并明说「要么换标本要么删掉,别留一个在空集上绿的测试」。

## 逆向验证:均先写预测再跑

**A. 删掉 `packages/react-runtime/LICENSE`** — 预测:通用断言点名 + 点名钉扎,共 2 红。**命中**:

```
× every package that declares a license has the text on disk
× pins the three packages fixed in objectui#3696 / objectui#3702
@object-ui/react-runtime (packages/react-runtime) declares "license": "MIT" but has no LICENSE file
 Tests  2 failed | 9 passed (11)
```

**B. 边界演示 —— 同时删掉 LICENSE 与 `license` 字段。** 这里的预期方向**不是**「更红」,而是**通用断言转绿**:没有声明就没有义务。预测:通用断言绿,而点名钉扎与人口点名转红,总数仍是 2 红但**失败集合不同**。**命中**:

```
× discovers the packages that owe license text (guard cannot pass by finding nothing)
    @object-ui/react-runtime must still be required to ship license text
× pins the three packages fixed in objectui#3696 / objectui#3702
 Tests  2 failed | 9 passed (11)
```

`every package that declares a license has the text on disk` 这一条**确实转绿了** —— 谓词的 `license` 那一肢是承重的。同时这组输出说明门禁是**分层**的:删掉 `license` 字段并不能悄悄把一个已知发布物豁免掉,点名钉扎照样红。这一点值得写下来,因为「删字段即脱身」正是这类门禁最容易被绕开的方式。

**C. 棘轮四条成因分支** — 对齐 #3701 约定后逐一实测,四条全部按预测点名,每次均 `1 failed | 10 passed`:

| 路径 | 制造方式 | 实测输出 |
| --- | --- | --- |
| 1 补上文件(**唯一**意味着许可证真被补上) | `cp LICENSE apps/console/LICENSE` | `— it now ships license text (LICENSE)` |
| 2 改为 private | `private: true` | `— it is now \`private\`, so it distributes nothing and owes no text` |
| 3 撤掉 license 字段 | `delete j.license` | `— it no longer declares a \`license\` field, so there is no claim left to honour` |
| 4 基线键无对应包 | 临时加 `packages/BOGUS-never-existed` | `— no package sits at that path any more: it was moved or removed from the workspace, or this baseline key never matched one` |

## 分诊裁定:#3702 已并入本 PR

原先 `apps/console` 是挂账在基线里的第三例。分诊裁定就地一并修,故本 PR 现同时 `Fixes #3702`。

### 为什么它是第三例

按四个工作区根(`packages/*`、`examples/*`、`apps/*`、`docs`)重测,非 private 且声明 license 的包是 **39** 个,缺许可证文本的是 **3** 个 —— issue #3696 正文的「38 / 2」只展开了 `packages/*`,这正是它被两次普查漏掉的原因。

`@object-ui/console` 确是发布物:`publishConfig.access: "public"`、版本 17.3.0 与其余同线、列在 `.changeset/config.json` 的 `fixed` 组里、有 `prepublishOnly`。缺陷与另外两个**完全同形**。

### 并入过程(棘轮两步,输出留档)

**第 (a) 步 —— 先补文件,`KNOWN_LICENSE_TEXT_MISSING` 仍留着那一行。** 预测:棘轮转红报陈旧,并按逐条成因命中**第一条**。**命中**:

```
× the objectui#3696 license baseline only shrinks
AssertionError: A KNOWN_LICENSE_TEXT_MISSING entry no longer describes a live defect.
Delete its line from KNOWN_LICENSE_TEXT_MISSING to bank the progress — that is the
right move under every cause below.

The cause is reported per entry rather than assumed, because only one of the four
routes out of this baseline means the licence was actually added; do not read a stale
line as proof that the package now ships its terms.

apps/console (objectui#3702) — it now ships license text (LICENSE)
 Tests  1 failed | 10 passed (11)
```

这是本 PR 原正文里逆向验证 C 的**现实版** —— 当时是人为建文件演示的方向,这次是真修。

**第 (b) 步 —— 清空基线。** 预测:11 全绿。**命中**:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

### 修完之后留下的是覆盖,不是沉默

基线清空后「没有违规」这件事本身可能是空绿,所以补了一次:删掉 `apps/console/LICENSE`(此时**已无基线可豁免**)。预测 2 红。**命中**:

```
× every package that declares a license has the text on disk
× pins the three packages fixed in objectui#3696 / objectui#3702
@object-ui/console (apps/console) declares "license": "MIT" but has no LICENSE file
apps/console/LICENSE is required: … (objectui#3702)
 Tests  2 failed | 9 passed (11)
```

### 一处文件面披露:改了基线上方的文档注释

该注释以**现在时**逐条描述我正要删掉的那个条目(「`apps/console` is the one entry …」)。基线清空后这段话会变成一份「描述一个并不存在的条目」的声明 —— 与本 PR 正在消除的失真**完全同一类**,只是从 `package.json` 搬进了注释。已改写为历史记录(#3687 对同一情形的同一处理)。**棘轮机理段原文一字未动**,其下所有断言逻辑未动。

## 与 #3701 / #3674 的关系

#3701(修 #3674)在本 PR 开出后落到 main,同文件。冲突用不落地的探针先证过,**不是靠猜**:

```
$ git merge-tree --write-tree origin/claude/issue-3696-license-text-gate origin/main
36cdb15a35c7ddd566df24a293445f08be3fc90f      # exit 0 = 干净
```

与原正文预判一致(#3701 改 305–317 行一带,本 PR 第三个 hunk 最早上下文行 327,零交叠),**技术上不需要 rebase**。仍做了 rebase 以便 CI 跑在含 #3701 的树上;该 rebase 需要 force-push,已单独报备并获接受(见评论)。最后这次 #3702 的并入提交是**普通 fast-forward 推送,未 force**。

顺带把本 PR 的 license 棘轮也对齐了 #3701 立下的约定:成因**逐条实测上报**,不由消息硬编码假定(上表 C 的四条即此)。

## 关于 changeset:判定为不加

按 #3662 确立、#3687/#3695 沿用的框架:

1. **仓规明文**:AGENTS.md 第 151 行 —— 功能改进需写 changeset,纯 bug 修复不需要。本 PR 是打包缺陷修复 + 一道门禁。
2. **直接同类先例**:**PR #3662 是完全同一种变化**(给一个已发布包新增 LICENSE、确实改变 tarball 内容),判定不加。本 PR 只是把同一动作做在另外三个包上,没有理由反向判。
3. **修复不会被搁浅**:`.changeset/config.json` 把 39 个包放在同一个 `fixed` 组(`@object-ui/console` 也在其中),任何一个 changeset 都会带着这三个包一起 bump 重发;为补三个文件而单独推整组一个版本,收益与代价不成比例。

## 验证

```
$ pnpm exec vitest run scripts/__tests__/package-files-exist.test.ts --maxWorkers=2
 Test Files  1 passed (1)
      Tests  11 passed (11)

$ pnpm exec vitest run scripts/__tests__/ --maxWorkers=2        # 全量 scripts 门禁套件
 Test Files  18 passed (18)
      Tests  345 passed (345)

$ pnpm type-check:scripts                                        # tsc -p tsconfig.scripts.json
 exit 0
$ npx eslint scripts/__tests__/package-files-exist.test.ts
 exit 0
$ node scripts/check-control-bytes.mjs
 ✅  check-control-bytes: OK (scanned 3682 tracked text file(s); skipped 85 binary)
```

控制字符另做超出门禁扫描面的自查:对改动文件 `grep -naP` 扫 `\x00`-`\x08` / `\x0b` / `\x0c` / `\x0e`-`\x1f` **无命中**;并逐码点统计零宽与不可见字符(U+200B/200C/200D/FEFF/2028/2029/00A0)计数**均为 0**。

### 两处过程自查(实测中差点带进 PR 的东西)

1. **探针副作用**:「改名跑 `npm pack`」里有一步是 `mv LICENSE CHANGELOG.md`,它**覆盖掉了** `packages/sdui-parser/CHANGELOG.md` 真实内容,改回来时又把它删掉了。是提交前的 `git status` 抓到的(` D packages/sdui-parser/CHANGELOG.md`),已 `git checkout --` 还原并与 origin/main 逐字节比对为空 diff。
2. **悬空引用**:新块注释里原写了 `objectui#4984`,但本仓编号在 3700 一带,该号**不存在** —— 那是另一个仓的同族教训被误标成本仓引用。追加提交 `430c0db87` 已把它改成直接讲清道理。新块现存的引用(`#3647` / `#3663` / `#3696` / `#3701` / `#3702`)均为本仓真实条目。

## 文件面

| 文件 | 变化 |
| --- | --- |
| `packages/react-runtime/LICENSE` | 新增(1065 字节,blob `cf2ca285…`) |
| `packages/sdui-parser/LICENSE` | 新增(同上) |
| `apps/console/LICENSE` | 新增(同上,#3702 并入) |
| `scripts/__tests__/package-files-exist.test.ts` | 新增断言块 + 棘轮成因分句 + 基线清空 |

未动任何 `package.json`,未动 `files` 字段,未动 `content/docs/releases/`,未改 assignee。`sdui-parser` 缺 README 一事属 #3647/#3664 划出的「打包策略」,本 PR 不主张、不处理。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_
