### PR TITLE
docs(ROADMAP): 按 #3673/#3699 落地后的现实改写 P1.12.2 与 Permission Management 两段 (#3700)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -822,21 +822,21 @@ ObjectUI is a universal Server-Driven UI (SDUI) engine built on React + Tailwind
 - [x] Navigate to Create App / Edit App pages
 - [x] Navigate to app home
 
-**Permission Management Page (`/system/permissions`):**
-- [x] CRUD grid for `sys_permission` object
-- [x] Search/filter permissions
-- [x] Admin-only create/delete controls
+**Permission Management Page (`/system/permissions`):** _(Retired — the page was deleted; the successor surface is pending maintainer decision, see #3655)_
+- [x] CRUD grid for `sys_permission` object — shipped, then deleted when `apps/console` was slimmed for third-party customisation. `sys_permission` is not a framework object name: plugin-security registers `sys_capability` (the definition registry) and `sys_permission_set` (the grant container)
+- [x] Search/filter permissions — went with the page
+- [x] Admin-only create/delete controls — went with the page
 
-**ObjectView-Driven System Pages (P1.12.2):**
-- [x] Shared `SystemObjectViewPage` component using `ObjectView` from `@object-ui/plugin-view`
-- [x] User Management (`/system/users`) driven by `sys_user` metadata via ObjectView
-- [x] Organization Management (`/system/organizations`) driven by `sys_org` metadata via ObjectView
-- [x] Role Management (`/system/roles`) driven by `sys_role` metadata via ObjectView
-- [x] Permission Management (`/system/permissions`) driven by `sys_permission` metadata via ObjectView
-- [x] Audit Log (`/system/audit-log`) driven by `sys_audit_log` metadata via ObjectView (read-only)
-- [x] Admin-only CRUD operations controlled via ObjectView `operations` config
-- [x] Automatic search, sort, filter, pagination from ObjectView capabilities
-- [x] 22 system page tests passing
+**ObjectView-Driven System Pages (P1.12.2):** _(Retired — the console's wrapper pages are gone; these objects are contributed by framework plugins and reached through the Setup app's generic object route)_
+- [x] Shared `SystemObjectViewPage` component, and the hand-copied `systemObjects` definitions behind it — deleted as dead code once nothing in the repo referenced them (PR #3699)
+- [x] User Management (`/system/users`) — page gone; the URL survives as a redirect onto the framework's `sys_user` object route (PR #3673)
+- [x] Organization Management (`/system/organizations`) — page gone; the URL redirects to `sys_organization` (PR #3673). The `sys_org` named here was never a framework object
+- [x] Role Management (`/system/roles`) — page gone; the URL redirects to `sys_position` (PR #3673), ADR-0090 D3 having renamed `sys_role` → `sys_position`
+- [ ] Permission Management (`/system/permissions`) — no route is declared for it. The framework splits this surface into `sys_capability` and `sys_permission_set`, so binding the URL to either would pick for the maintainer; left undeclared pending that decision, see #3655
+- [x] Audit Log (`/system/audit-log`) — the route still resolves, but to `AuditLogPage`, a standalone read-only page that queries `sys_audit_log` over REST and renders its own table, filters, pagination and detail sheet; ObjectView is not involved
+- [x] Admin-only CRUD operations — were the `operations` config on `SystemObjectViewPage`'s own schema, and went with the component (PR #3699)
+- [x] Automatic search, sort, filter, pagination — likewise; what serves these objects today is the framework's Setup app route, not this repo's
+- [x] System page test suite — retired with the pages; `pages/system/__tests__/` now covers `SystemHubPage` only
 
 **Sidebar & Navigation Updates:**
 - [x] Settings button → `/system/` hub (was `/system/profile`)


### PR DESCRIPTION
Fixes #3700

纯文档改动,只动 `ROADMAP.md` 一个文件的两段(:825-839),零代码、零行为变化。无 changeset —— 根文档不是发布包,用户可见产物零 delta。

> 注:正文不写尖括号加字母的形式(GitHub 正文消毒器会把它当 HTML 标签在存储时剥掉),路由一律写成 `/apps/setup/:objectName`。

## 先定惯例,再改字(派发单要求)

issue #3700 把取舍留给了维护者:「ROADMAP 是历史账本还是当前真相快照」。**不必问 —— 这个文件自己已经答过三次**,普查 `ROADMAP.md` 其它段落对「已推翻/已退场」项的处理,惯例是一致的:

| 位置 | 现有写法 | 形态 |
|---|---|---|
| :152 | `**ViewDesigner:** _(Removed — replaced by ViewConfigPanel)_` | 子标题挂斜体退场注,**下面的 `[x]` 历史项保留** |
| :157 | `- [x] Removed: ViewDesigner replaced by ViewConfigPanel …` | 退场本身作为一条 `[x]` 记账 |
| :1046 | `- [x] Tab-drag UX retired in favour of Manage Views dialog (commit 3371239c)` | `[x]` + 「retired in favour of X」+ 裸引用 |
| :997 | `- [x] Auto-redirect … — removed; object now uses metadata pipeline` | `[x]` + 破折号 + 当前形态 |
| :82 | `… the client-side @object-ui/tenant package was removed as dead surface, #2564` | 保留已删符号名 + 裸 issue 号 |

即:**历史账本 + 就地标注**,条目不删、不打删除线,文字改写成「当前形态」并挂一个**裸文本**引用(`(PR #771)` / `(Issue #719)` / `(commit …)` 这三种,全文只有 6 处 markdown 链接,issue 链接仅 1 处)。本 PR 照此办理 —— 因此**没有新增任何链接**,check-doc-links 的扫描面不受影响。

## 九项逐条核实(全部对 `origin/main` @ `b19f54f39` 实测)

| # | 原文(:831-839) | 实测现状 | 证据 |
|---|---|---|---|
| 1 | Shared `SystemObjectViewPage` component using ObjectView | 文件已删 | `pages/system/` 下已无该文件;全仓 grep 两个符号,排除 ROADMAP/CHANGELOG 后**零命中**(PR #3699) |
| 2 | `/system/users` driven by `sys_user` … via ObjectView | 路由是重定向,不是页面 | `AppContent.tsx:203` `SystemObjectRedirect objectName="sys_user"`(PR #3673) |
| 3 | `/system/organizations` driven by `sys_org` | 重定向到 `sys_organization`;`sys_org` 不存在 | `AppContent.tsx:204`;`grep -rlw sys_org ../objectstack/packages/` = **0 个文件** |
| 4 | `/system/roles` driven by `sys_role` | 重定向到 `sys_position`;无 `sys_role` 对象 | `AppContent.tsx:205`;`sys_role` 的 18 处命中全在 CHANGELOG 与改名说明里,无对象定义;`packages/spec/PROTOCOL_MAP.md:104` 写明 ADR-0090 改名 |
| 5 | `/system/permissions` driven by `sys_permission` | **该路由未声明**;`sys_permission` 不是框架对象名 | `AppContent.tsx:191-201` 的注释写明「absent on purpose」;`grep -rlw sys_permission packages/` 唯一命中是 `sys-capability.object.ts` 的 docblock,内容正是「不叫 sys_permission」 |
| 6 | `/system/audit-log` … via ObjectView (read-only) | 路由在,但页面是独立手写的 | `AuditLogPage.tsx` 436 行:`:152` `fetch(${API_BASE}/data/sys_audit_log?…)`,手写 `$filter`/`$orderby`/`$top`/`$skip`(`:144-150`)、手写 Table(`:296`)与 Sheet 详情;不经 ObjectView |
| 7 | Admin-only CRUD via ObjectView `operations` config | 随组件消失 | 该 `operations`/`canMutate = !readOnly && isAdmin` 就长在被删的 `SystemObjectViewPage` 里(PR #3699) |
| 8 | Automatic search/sort/filter/pagination from ObjectView | 同上 | 同上 |
| 9 | 22 system page tests passing | 该套测试不存在 | `pages/system/__tests__/` 现只有 `SystemHubPage.counts.test.tsx` 与 `SystemHubPage.metadataCards.test.tsx` |

同源漂移的 :825-828 **Permission Management Page** 段(`sys_permission` CRUD grid / search-filter / admin-only create-delete):该页与该路由均已不存在,对象名亦非框架真名 —— 依据同上第 5、7 条。

**九条无一仍然成立,issue 前提完全属实。**

## 前后对照

改前(:830-839,九个 `[x]` 全部失实):

```
**ObjectView-Driven System Pages (P1.12.2):**
- [x] Shared `SystemObjectViewPage` component using `ObjectView` from `@object-ui/plugin-view`
- [x] User Management (`/system/users`) driven by `sys_user` metadata via ObjectView
- [x] Organization Management (`/system/organizations`) driven by `sys_org` metadata via ObjectView
- [x] Role Management (`/system/roles`) driven by `sys_role` metadata via ObjectView
- [x] Permission Management (`/system/permissions`) driven by `sys_permission` metadata via ObjectView
- [x] Audit Log (`/system/audit-log`) driven by `sys_audit_log` metadata via ObjectView (read-only)
- [x] Admin-only CRUD operations controlled via ObjectView `operations` config
- [x] Automatic search, sort, filter, pagination from ObjectView capabilities
- [x] 22 system page tests passing
```

改后(子标题挂退场注,九条逐一改写为「当前形态 + 落地 PR」):

```
**ObjectView-Driven System Pages (P1.12.2):** _(Retired — the console's wrapper pages are gone; these objects are contributed by framework plugins and reached through the Setup app's generic object route)_
- [x] Shared `SystemObjectViewPage` component, and the hand-copied `systemObjects` definitions behind it — deleted as dead code once nothing in the repo referenced them (PR #3699)
- [x] User Management (`/system/users`) — page gone; the URL survives as a redirect onto the framework's `sys_user` object route (PR #3673)
- [x] Organization Management (`/system/organizations`) — page gone; the URL redirects to `sys_organization` (PR #3673). The `sys_org` named here was never a framework object
- [x] Role Management (`/system/roles`) — page gone; the URL redirects to `sys_position` (PR #3673), ADR-0090 D3 having renamed `sys_role` → `sys_position`
- [ ] Permission Management (`/system/permissions`) — no route is declared for it. The framework splits this surface into `sys_capability` and `sys_permission_set`, so binding the URL to either would pick for the maintainer; left undeclared pending that decision, see #3655
- [x] Audit Log (`/system/audit-log`) — the route still resolves, but to `AuditLogPage`, a standalone read-only page that queries `sys_audit_log` over REST and renders its own table, filters, pagination and detail sheet; ObjectView is not involved
- [x] Admin-only CRUD operations — were the `operations` config on `SystemObjectViewPage`'s own schema, and went with the component (PR #3699)
- [x] Automatic search, sort, filter, pagination — likewise; what serves these objects today is the framework's Setup app route, not this repo's
- [x] System page test suite — retired with the pages; `pages/system/__tests__/` now covers `SystemHubPage` only
```

Permission Management Page 段同法:子标题加 `_(Retired — the page was deleted; the successor surface is pending maintainer decision, see #3655)_`,三条改写为「当年交付过 → 随 console 瘦身一并删除」,并就地把对象名纠正为 `sys_capability` / `sys_permission_set`。

### 两处刻意的取舍

- **第 5 条唯一改成 `- [ ]`(未勾选)。** 它不是「做完了又退场」,而是一个**尚未定案的缺口**:框架把这个面拆成 `sys_capability` 与 `sys_permission_set` 两个 Setup 条目,PR #3673 已按有界授权停手,留给 #3655 裁决。⛔ 本 PR **不预判 A/B/C** —— 只陈述「未声明路由」这个事实与拆分现状,措辞为中性的 pending maintainer decision, see #3655。全文 89 处 `- [ ]`,未勾选项是本文件的常规形态。
- **第 9 条不写新数字。** 原文的 `22` 正是烂掉的那种硬编码计数;改写成「`pages/system/__tests__/` now covers `SystemHubPage` only」,不再种一个下周就会再次失真的数。

## 措辞纪律(遵 #3656:不复植失真特征词)

#3656 的规矩是:承载错误机制的特征词改完要 grep 归零,而不是换个说法把它留着。本 PR 逐条量了:

| 特征词 | 改前 | 改后 |
|---|---|---|
| `driven by … metadata` | 5 | **0** |
| `via ObjectView` | 6 | **0** |
| `from ObjectView capabilities` | 1 | **0** |
| `22 system page tests` | 1 | **0** |

第一版草稿里 `via ObjectView` 只降到 1(第 7 条把它留在了**主语**位置,读起来仍像在陈述现行机制),已改写成过去式主语「were the `operations` config on …」后才真正归零 —— 如实记下,因为这正是 #3656 那个 `carries no continue-on-error` 教训的同型。

**刻意保留**的两个符号名(不是复植,而是纠错):`SystemObjectViewPage`(:831)与 `sys_org`(:833)。二者都紧跟「已删除 / 从来就不是框架对象」的判词,下一个 grep 到它们的 agent 读到的是结论而非诱饵 —— 这与 :82 保留 `@object-ui/tenant`、:152 保留 `ViewDesigner` 的既有惯例一致。

## 验证

改动不含代码,本仓无任何测试或脚本读取 `ROADMAP.md` 的正文(`scripts/__tests__/check-doc-links.test.ts` 里的 ROADMAP 是**内存里合成的 fixture**,见 `:778` / `:812`,与真实文件无关),故**没有可跑绿的单元测试** —— 如实写明,不凑数。真正管这块的是 doc-links 门禁,`ROADMAP.md` 是它第 5 个扫描根(`check-doc-links.mjs:397`,`rule: 'disk'`):

```
改前 baseline: node scripts/check-doc-links.mjs   → Links are valid across 7 scan roots.   EXIT=0
改后:          node scripts/check-doc-links.mjs   → Links are valid across 7 scan roots.   EXIT=0
```

**阳性对照(先预测,后运行)** —— 前后同为绿,必须先证明「门禁确实看了我改的那几行」,否则绿是「没看」而不是「没问题」。预测:往第 831 行(本 PR 改写过的行)注入一个死链,门禁应转红并点名 `ROADMAP.md:831`。实测吻合:

```
- [example-relative] ROADMAP.md:831 -> ./docs/adr/9999-does-not-exist.md
EXIT=1
```

随后还原,门禁复绿(`EXIT=0`),`grep -c 9999 ROADMAP.md` = 0,工作树干净。

控制字符:

```
node scripts/check-control-bytes.mjs → OK (scanned 3680 tracked text file(s); skipped 85 binary)   EXIT=0
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' ROADMAP.md → 无输出(exit 1)
```

## 围栏

- ⛔ **`CHANGELOG.md:595` 未动** —— 它是史实记录,记的是「当时确实做了这件事」,不该被改写。
- ⛔ `content/docs/releases/` 未动;无 changeset。
- ⛔ 代码零改动,`AppContent.tsx` / `AuditLogPage.tsx` 只读不写。
- `git diff` 只有一个 hunk:`@@ -825,15 +825,15 @@`,15 增 15 删,全部落在这两段内。

## 越界发现(只报不改)

同一个 `### P1.12` 章节里还有**两处同源漂移**,落在派发单给的两段之外,按纪律不在本 PR 修改,已**单独立单 #3704**(观察类,`finding`,未认领):

- `ROADMAP.md:857` —— `- [x] /system/permissions → PermissionManagementPage`,该路由与该页面均已不存在(依据同上第 5 条)。
- `ROADMAP.md:871` —— `- [x] 11 new tests (SystemHubPage, AppManagementPage, PermissionManagementPage)`,其中 `PermissionManagementPage` 的测试随页面一并消失。

本 PR 增删各 15 行、行号不移位,故 #3704 里记的 :857 / :871 在本 PR 合并后依然成立。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_