### PR TITLE
test(app-shell): 测量 `invalid_value` 的范畴定性 — 两种定性各有形状受损,不放宽,钉住两个方向

### DIFF
--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -251,11 +251,40 @@ const ARRAY_VARIANT_MEMBERS = { ofStrings: 0, ofObjects: 1 } as const;
  * candidate. A member that answers `true` here never read the value, so nothing
  * about the value can be evidence for or against it.
  *
- * Measured caveat, deliberately kept: only `invalid_type` counts. An enum
- * member handed an object answers `invalid_value`, not `invalid_type` — so
- * `columns[0].summary` (`enum | {type, field}`) reads as TWO candidates for an
- * object value and stays in the content rule's cell, which declines it. That is
- * why the `summary` descent boundary #3626 pinned is unchanged by #3678.
+ * Only `invalid_type` counts, and objectui#3694 MEASURED that this is the right
+ * line rather than an implementation detail that leaked into the semantics.
+ *
+ * Zod answers `invalid_value` — not `invalid_type` — whenever an enum or a
+ * literal rejects, whatever the input's type. Across the whole `view` family
+ * exactly two union sites ever produce `invalid_value` at a member's own root:
+ * `columns[].summary` (`enum | {type, field}`) and `sections[].columns`
+ * (`enum | 1 | 2 | 3 | 4`). Widening this predicate to count `invalid_value`
+ * as a node-level rejection was measured over 51 shapes and is NOT an
+ * improvement — it is a TRADE on one union:
+ *
+ *   summary is an OBJECT (`{type:'bogus'}`, `{}`, `{type,field}`)
+ *     today k=2 → collapsed `…summary` / `Invalid input`
+ *     widened k=1 → `…summary.type` / the option list          ← 5 shapes GAINED
+ *   summary is a non-enum SCALAR (`42`, `true`, `null`, `[]`, `['count']`, …)
+ *     today k=1 → the enum is the sole candidate, `…summary` / the option list
+ *     widened k=0 → `…summary` / `Invalid input`               ← 8 shapes LOST
+ *
+ * The loss includes the #3678 CANARY `summary: 'bogus'`. A type-aware variant
+ * (categorical only when no allowed literal shares the value's `typeof`) was
+ * measured too and merely re-cuts the same trade: 6 gained, 6 lost. So neither
+ * qualification of `invalid_value` dominates, and #3694 declined both. Both
+ * directions are pinned in the test file's #3694 block, so an attempt to widen
+ * this predicate goes red on the shapes it would damage instead of shipping
+ * them silently — four of them are pinned nowhere else.
+ *
+ * Measured with the same run: widening cannot move the CONTENT rule's reach at
+ * all. That rule needs two members AND a non-empty array value, and at the one
+ * shape satisfying both (`summary: ['count']`) the object member answers
+ * `invalid_type`, so `groups.some(memberRejectedNodeType)` is already true and
+ * stays true. The whole question lives in the sole-candidate rule.
+ *
+ * The contract-first fix remains spec-side (objectstack#6391): a union that
+ * declares its own discriminant needs none of this census.
  */
 function memberRejectedNodeType(group: ZodLikeIssue[]): boolean {
   return group.some((i) => i.code === 'invalid_type' && (i.path ?? []).length === 0);

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.viewDiagnostics.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.viewDiagnostics.test.ts
@@ -815,3 +815,199 @@ describe('view verdict parity — sole-candidate bodies (objectui#3678)', () => 
     });
   }
 });
+
+/**
+ * ── What `invalid_value` at a member's own root means (objectui#3694) ──
+ *
+ * The categorical test both nested rules stand on counts only `invalid_type`.
+ * #3694 asked whether that is the rule's meaning or an implementation detail:
+ * Zod answers `invalid_value` whenever an ENUM or a LITERAL rejects, whatever
+ * the input's type, so an enum member handed an object is counted as a
+ * candidate even though it never looked inside either.
+ *
+ * Measured over 51 shapes, the whole `view` family produces `invalid_value` at
+ * a member's own root at exactly TWO union sites — `columns[].summary`
+ * (`enum | {type, field}`) and `sections[].columns` (`enum | 1 | 2 | 3 | 4`) —
+ * and re-qualifying it is a TRADE on the first of them, not an improvement:
+ * the object-valued shapes gain a named `…summary.type`, the scalar-valued
+ * shapes lose the enum's option list and collapse to `Invalid input`. #3694
+ * therefore changed no behaviour. This block is the measurement made durable.
+ *
+ * These pins are green today and are meant to STAY green — they are the
+ * regression half, not the red-before/green-after half. Their job is that the
+ * next attempt to widen the predicate goes red on the shapes it would damage.
+ * Verified by perturbation, results in the PR body: widening to
+ * `invalid_type || invalid_value` reddens 4 tests, and the type-aware variant
+ * reddens 2 — and WITHOUT this block four of the damaged shapes
+ * (`summary: 42 | true | null | ['count']`) were pinned nowhere at all.
+ *
+ * Pinning the currently-collapsed shapes too is deliberate and is NOT an
+ * endorsement of the collapse: it is what makes adopting any future relaxation
+ * a visible, deliberate replacement of these expectations rather than a quiet
+ * drift. The contract-first fix stays spec-side (objectstack#6391).
+ */
+describe('view nested union — the `invalid_value` qualification, measured (objectui#3694)', () => {
+  const AUTHORABLE_ITEM: Record<string, unknown> = { ...STORED_ITEM };
+  delete AUTHORABLE_ITEM.isPinned;
+
+  const withConfig = (extra: Record<string, unknown>) => ({
+    ...AUTHORABLE_ITEM,
+    config: { ...(AUTHORABLE_ITEM.config as Record<string, unknown>), ...extra },
+  });
+  const withSummary = (summary: unknown) => withConfig({ columns: [{ field: 'a', summary }] });
+
+  const bothGates = async (body: unknown) => {
+    const created = await validateMetadataDraft('view', body, undefined, { mode: 'create' });
+    const edited = await validateMetadataDraft('view', body, undefined, EDIT);
+    expect(created.ok).toBe(false);
+    expect(edited.ok).toBe(false);
+    expect(edited.issues).toEqual(created.issues);
+    return created.issues;
+  };
+
+  // ── The shapes a widened predicate would SILENCE ─────────────────────────
+
+  it('an enum member left standing survives every non-enum value, not just a string', async () => {
+    // `summary: 'bogus'` — the one shape #3678 pinned — is not special. For a
+    // number, a boolean, `null` and an array alike the OBJECT member answers
+    // `invalid_type` at its own root while the ENUM answers `invalid_value`, so
+    // k stays 1 and the enum's option list is what the author is shown.
+    //
+    // Count `invalid_value` as a node-level rejection and every one of these
+    // goes to k=0 and collapses. Four of them are pinned in no other test, so
+    // this assertion is the only thing standing between that change and four
+    // silent regressions.
+    for (const value of [42, true, null, [], ['count'], [{ type: 'count' }]]) {
+      const label = JSON.stringify(value);
+      const issues = await bothGates(withSummary(value));
+      expect(issues.map((i) => i.path), label).toEqual(['config.columns.0.summary']);
+      // Positive anchor FIRST: a collapsed `Invalid input` satisfies no
+      // `toContain`, so the negative alone would pass vacuously.
+      expect(issues[0].message, label).toContain('Invalid option');
+      expect(issues[0].message, label).toContain('"count_unique"');
+      expect(issues[0].message, label).not.toBe('Invalid input');
+    }
+  });
+
+  it('the same holds on the container and `listViews` routes', async () => {
+    // Prefix composition is a different route on each gate; the census must not
+    // be route-dependent.
+    const viaContainer = await bothGates({
+      ...CONTAINER,
+      list: { type: 'grid', columns: [{ field: 'a', summary: 42 }] },
+    });
+    expect(viaContainer.map((i) => i.path)).toEqual(['list.columns.0.summary']);
+    expect(viaContainer[0].message).toContain('Invalid option');
+
+    const viaListViews = await bothGates({
+      ...CONTAINER,
+      listViews: { v1: { type: 'grid', columns: [{ field: 'a', summary: 'bogus' }] } },
+    });
+    expect(viaListViews.map((i) => i.path)).toEqual(['listViews.v1.columns.0.summary']);
+    expect(viaListViews[0].message).toContain('Invalid option');
+  });
+
+  // ── The shapes a widened predicate would IMPROVE (pinned as they stand) ──
+
+  it('an OBJECT summary keeps TWO candidates, so the node stays collapsed', async () => {
+    // These are the shapes #3694 was filed on and the ones any relaxation
+    // would gain: the enum answers `invalid_value` at the root (counted as a
+    // candidate) and the object member reports at `['type']`, so k=2 and no
+    // cell claims the node. `{type:'bogus'}` is already pinned by #3626's
+    // descent-boundary test; the other two were pinned nowhere.
+    for (const value of [{}, { type: 'bogus', field: 'x' }]) {
+      const label = JSON.stringify(value);
+      expect(await bothGates(withSummary(value)), label).toEqual([
+        { path: 'config.columns.0.summary', message: 'Invalid input' },
+      ]);
+    }
+  });
+
+  it('the object-summary collapse is the same on the container and `listViews` routes', async () => {
+    expect(
+      await bothGates({
+        ...CONTAINER,
+        list: { type: 'grid', columns: [{ field: 'a', summary: { type: 'bogus' } }] },
+      }),
+    ).toEqual([{ path: 'list.columns.0.summary', message: 'Invalid input' }]);
+
+    expect(
+      await bothGates({
+        ...CONTAINER,
+        listViews: { v1: { type: 'grid', columns: [{ field: 'a', summary: { type: 'bogus' } }] } },
+      }),
+    ).toEqual([{ path: 'listViews.v1.columns.0.summary', message: 'Invalid input' }]);
+  });
+
+  // ── The OTHER `invalid_value` site, and why it never moves ───────────────
+
+  it('`sections[].columns` — all five members answer `invalid_value`, and no cell claims it either way', async () => {
+    // `enum('1'|'2'|'3'|'4') | 1 | 2 | 3 | 4`. Every member rejects the value
+    // as a whole, so today k=5 (the content rule's cell, which declines a
+    // five-member union) and under a widened predicate k=0 (the empty cell).
+    // Different cell, same silence — which is why the second `invalid_value`
+    // site contributes nothing to the trade above. Measured, not assumed.
+    for (const value of ['bogus', 7, {}, null]) {
+      const label = JSON.stringify(value);
+      expect(
+        await bothGates({
+          ...AUTHORABLE_ITEM,
+          viewKind: 'form',
+          config: { type: 'simple', sections: [{ fields: ['a'], columns: value }] },
+        }),
+        label,
+      ).toEqual([{ path: 'config.sections.0.columns', message: 'Invalid input' }]);
+    }
+  });
+
+  // ── The content rule cannot be reached by this question ──────────────────
+
+  it('the CONTENT rule’s reach cannot move — its one candidate shape still declines', async () => {
+    // #3694 worried that re-qualifying the shared predicate would move BOTH
+    // rules. Measured: it cannot. The content rule needs exactly two members
+    // AND a non-empty array value, and `summary: ['count']` is the only shape
+    // in the family meeting both at an `invalid_value` site. There the OBJECT
+    // member answers `invalid_type`, so the narrowing guard is already true and
+    // a widened predicate can only keep it true. The node is answered by the
+    // sole-candidate rule (the enum), never by the content rule — which would
+    // have reported the OBJECT member's "expected object, received array".
+    const issues = await bothGates(withSummary(['count']));
+    expect(issues.map((i) => i.path)).toEqual(['config.columns.0.summary']);
+    expect(issues[0].message).toContain('Invalid option');
+    expect(issues.map((i) => i.message).join('\n')).not.toContain('received array');
+  });
+});
+
+/**
+ * PARITY, #3694 layer. #3694 changed no behaviour at all, so this is doubly a
+ * regression pin — but the bodies above are new to this file and the verdict
+ * they produce is worth stating outright rather than leaving implied.
+ */
+describe('view verdict parity — `invalid_value` bodies (objectui#3694)', () => {
+  const withSummary = (summary: unknown) => ({
+    ...STORED_ITEM,
+    config: {
+      ...(STORED_ITEM.config as Record<string, unknown>),
+      columns: [{ field: 'a', summary }],
+    },
+  });
+
+  const CASES: Array<{ label: string; body: unknown; ok: boolean }> = [
+    { label: 'summary as a valid enum', body: withSummary('count'), ok: true },
+    { label: 'summary as a valid object', body: withSummary({ type: 'sum' }), ok: true },
+    { label: 'summary as a number', body: withSummary(42), ok: false },
+    { label: 'summary as a boolean', body: withSummary(true), ok: false },
+    { label: 'summary as null', body: withSummary(null), ok: false },
+    { label: 'summary as an array', body: withSummary(['count']), ok: false },
+    { label: 'summary as an empty object', body: withSummary({}), ok: false },
+    { label: 'summary as an object with a bad type', body: withSummary({ type: 'bogus', field: 'x' }), ok: false },
+  ];
+
+  for (const c of CASES) {
+    it(`${c.label}: edit=${c.ok ? 'ok' : 'not ok'}`, async () => {
+      const edited = await validateMetadataDraft('view', c.body, undefined, EDIT);
+      expect(edited.ok, `edit: ${JSON.stringify(edited.issues)}`).toBe(c.ok);
+      expect(edited.issues.length === 0).toBe(c.ok);
+    });
+  }
+});


### PR DESCRIPTION
Fixes #3694

## 结论先说:测量后**不放宽**,行为零改动

#3694 问的是:范畴判定只认 `invalid_type`,这是规则的**本意**,还是实现细节漏进了语义?

测量答案:**两种定性各有形状受损,不存在「全面改善」的再定性**。于是本 PR 不动任何判定逻辑,只把测量**钉成回归防线** + 更新注释。判定门、38+ 既有钉子、两条规则的划分全部原样。

## 测量面:整个 `view` 家族里,这个问题只够得着一个 union

先把 `ViewMetadataSchema` / `ViewItemSchema` / `ViewSchema` 的 Zod 树走了一遍,21 个无判别式嵌套 union。其中**成员在自身相对根上答 `invalid_value` 的只有两处**:

| union | 成员 | 探针下的 k |
|---|---|---|
| `columns[].summary` | `enum ｜ {type, field}` | 随值而变 —— **全部变化都在这里** |
| `sections[].columns` | `enum ｜ 1 ｜ 2 ｜ 3 ｜ 4` | 五个成员**全部**答 `invalid_value` |

`sections[].columns` 两种定性下都不说话(今天 k=5 落进内容判别的格子、被五成员限制挡下;放宽后 k=0 落进空格子)—— **换了格子,同样沉默**,对结论零贡献。已钉。

## 两种定性逐形状对照(51 个探针,只列有变化的)

A = 今天(`invalid_value` 视作「读过值的候选」);B = 放宽(`invalid_value` 视作类型层拒绝)。

| 形状 | A(今天) | B(放宽) | 方向 |
|---|---|---|---|
| `summary: {type:'bogus'}` | `…summary` / `Invalid input` | `…summary.type` / 具名选项 | **改善** |
| `summary: {}` | `…summary` / `Invalid input` | `…summary.type` / 具名选项 | **改善** |
| `summary: {type:'bogus', field:'x'}` | `…summary` / `Invalid input` | `…summary.type` / 具名选项 | **改善** |
| 容器 `list.…summary: {type:'bogus'}` | 同上塌陷 | 同上具名 | **改善** |
| `listViews.v1.…summary: {type:'bogus'}` | 同上塌陷 | 同上具名 | **改善** |
| `summary: 'bogus'` | `…summary` / **具名选项** | `…summary` / `Invalid input` | **退化** ⚠️ |
| `summary: 42` | `…summary` / **具名选项** | `Invalid input` | **退化** |
| `summary: true` | `…summary` / **具名选项** | `Invalid input` | **退化** |
| `summary: null` | `…summary` / **具名选项** | `Invalid input` | **退化** |
| `summary: []` | `…summary` / **具名选项** | `Invalid input` | **退化** |
| `summary: ['count']` | `…summary` / **具名选项** | `Invalid input` | **退化** |
| `summary: [{type:'count'}]` | `…summary` / **具名选项** | `Invalid input` | **退化** |
| `listViews.…summary: 'bogus'` | `…summary` / **具名选项** | `Invalid input` | **退化** |
| 其余 38 个探针 | — | — | 不变 |

**5 改善 / 8 退化。** 带 ⚠️ 的那行是 PR #3693 自己的 CANARY(`CANARY: a scalar union member left standing names the options it wanted`)—— 放宽会把一条已合并的钉子改红,方向是**回归**而不是验证。

### 派发单第 2 条的逐处核对:新激活处**没有误选**

放宽让 k 从 2 降到 1 的 5 处,选中的都是 `{type, field}` 成员 —— 作者写的就是对象,这正是作者意图的成员。**误选零处**。B 的伤害**全部来自「去激活」**(k 从 1 降到 0),不是来自选错。这一点值得单独记下:它说明放宽的方向不算错,错的是它同时砍掉了枚举成员本来提供的那条好消息。

### 还测了第三种谓词(类型感知),同样不合格

`invalid_value` 只有在**没有任何允许字面量与该值 `typeof` 相同**时才算类型层拒绝(枚举值都是字符串 → 喂对象/数字属于「压根没机会」;喂字符串属于「真读过」)。结果只是把同一笔交易重新切了一刀:**6 改善 / 6 退化** —— 它救回了 `summary: 'bogus'`,还多赚一个 `sections[].columns: 'bogus'`,但 `42 / true / null / ['count']` 照样塌陷。

## 内容判别的适用面:测出来**动不了**

#3694 正文担心「放宽会同时改变两条规则的适用范围」。实测:**不会**。内容判别要求恰好两个成员**且**值是非空数组,全家族同时满足这两条又落在 `invalid_value` 站点的形状只有 `summary: ['count']` 一个;那里对象成员答的是 `invalid_type`,`groups.some(memberRejectedNodeType)` **今天就已经为真**,放宽只会让它更真。整个问题活在唯一候选规则里。已钉。

## 逆向验证(先写预测,后运行;三个扰动)

预测全文落盘于实现之前。**注意方向不是常规的「还原实现→新钉子红」** —— 本 PR 不改行为,所以扰动的是**被否决的那两个谓词**,预测它们红出各自会损坏的形状。

先在**加钉之前**跑(56 条),验证既有套件能看见多少:

| 扰动 | 预测 | 实际 |
|---|---|---|
| B(`invalid_type ｜｜ invalid_value`) | 4 红 | **4 failed / 52 passed** ✅ |
| C(类型感知) | 2 红 | **2 failed / 54 passed** ✅ |
| D(见下) | 2 红 | **2 failed / 54 passed** ✅ |

再在**加钉之后**跑(70 条):

| 扰动 | 预测 | 实际 | 红的性质 |
|---|---|---|---|
| B | 9 红 | **9 failed / 61 passed** ✅ | 含 5 条真回归 |
| C | 8 红 | **8 failed / 62 passed** ✅ | 含真回归 |
| D | 4 红 | **4 failed / 66 passed** ✅ | **全部是「钉住现状塌陷」的钉子,零回归** |

三次预测逐条命中,连红的测试名都一致。

**加钉的价值就在这个差值里**:加钉前,C 的四个退化形状(`summary: 42 / true / null / ['count']`)**在整个仓库里一条钉子都没有** —— 类型感知谓词本可以带着四条静默回归合进来,套件不会吭一声。

## 顺带测到的一件事:存在**严格改善**的谓词,但它不是「再定性 `invalid_value`」

上表的 D 是「证据深度」谓词:先取**在值内部报过位置**(相对 path 非空)的成员,恰好一个就选它;一个都没有时,回落到今天的普查。

- 它**从不去激活**(可证:内部报位置的成员必然没有根上的 `invalid_type`,故 D 的候选集是 A 的子集,|tier1|=1 时 A 的 k≥1)。实测 51 形状:**5 改善 / 0 退化**。
- 但它**根本不看 issue 的 code** —— 它回答的是另一个问题(「谁报进了值内部」),而不是派发单授权的「`invalid_value` 算不算读过值」。

它同时把唯一候选规则的**理据**从「只有一个成员读过值」悄悄换成「只有一个成员报进了值内部」,两者恰好在 enum-vs-object 上分叉。#3626 / #3677 两次把「不发明偏好」写进代码注释,这一步是否要迈,是**维护者的设计裁决**,不该由本单的有界授权顺手做掉。因此:**测量、记录、不实施**,留给 #3694 后续或 objectstack#6391 一并裁。上表 D 那一行也已经把代价说清楚了 —— 若采纳,要红的是 4 条「钉住现状」的钉子,按 fixture 三分诊做**整体替换**,零回归。

## 判定奇偶

本 PR **一行判定逻辑都没动**,`clientValidation.ts` 的 diff 是纯注释。奇偶不是「测出来没变」,是 diff 层面不可能变。另加 8 条 parity pin(修前修后都绿 —— 这正是它们的意义)。

## 测试

`clientValidation.viewDiagnostics.test.ts` **只加不改**(196 增 / 0 删,`git diff --numstat` 为证),新增 14 条:6 条测量钉 + 8 条 parity。

```
vitest run packages/app-shell/src/views/metadata-admin/  →  Test Files 128 passed (128)
                                                            Tests 1239 passed | 1 skipped (1240)
pnpm --filter @object-ui/app-shell type-check             →  exit=0(tsc --noEmit + typetests)
eslint(两个改动文件)                                       →  clean
node scripts/check-control-bytes.mjs                      →  OK (3682 files)
grep -naP 自查(网关盲区 0x01-0x1f)                          →  clean
```

新鲜 worktree 里先 `pnpm --filter '@object-ui/app-shell^...' build` 再 type-check —— 否则报的是缺 `@object-ui/react` 之类的假红。

## 不做的事 / 残留

- **不加 changeset**:零行为改动,非用户可见。
- 全体一致提升(#3626 方向 1)未做。
- contract-first 的正解仍在 spec 侧(objectstack#6391):union 自带判别式的话,这套普查连同 #3626 / #3678 / #3694 三条局部规则一起退休。本 PR 的注释把这句话留在了谓词旁边。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_