### PR TITLE
docs(ROADMAP): P1.12 Routes/Tests 两条 PermissionManagementPage 记录按现实改写 (#3704)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -854,7 +854,7 @@ ObjectUI is a universal Server-Driven UI (SDUI) engine built on React + Tailwind
 **Routes:**
 - [x] `/system/` → SystemHubPage
 - [x] `/system/apps` → AppManagementPage
-- [x] `/system/permissions` → PermissionManagementPage
+- [ ] `/system/permissions` — no route is declared at this URL; the `PermissionManagementPage` it named was deleted when `apps/console` was slimmed for third-party customisation (commit cccdf84d), and the successor surface is pending maintainer decision, see #3655
 - [x] `/system/metadata/:metadataType` → MetadataManagerPage (generic, registry-driven)
 
 **Unified Metadata Management (P1.12.3):**
@@ -868,7 +868,7 @@ ObjectUI is a universal Server-Driven UI (SDUI) engine built on React + Tailwind
 - [x] 40+ new tests (registry, MetadataManagerPage, MetadataService generic, SystemHubPage registry)
 
 **Tests:**
-- [x] 11 new tests (SystemHubPage, AppManagementPage, PermissionManagementPage)
+- [x] New tests for the system pages — of the three suites named here, only `SystemHubPage`'s is still in the tree; nothing tests `AppManagementPage` today, and `PermissionManagementPage` has no tests because the page itself is gone (commit cccdf84d)
 - [x] Total: 20 system page tests passing
 
 ### P1.13 Airtable Grid/List UX Optimization ✅


### PR DESCRIPTION
Fixes #3704

纯文档改动,只动 `ROADMAP.md` 的两行(:857 / :871),零代码、零行为变化。无 changeset —— 根文档不是发布包,用户可见产物零 delta。`git diff --stat` = `1 file changed, 2 insertions(+), 2 deletions(-)`,行号不移位。

## 前置实测

派发单要求先证 PR #3705 已落 main,并以内容锚定复核行号(#3705 是 15 增 15 删的中性改动,理应不移位):

```
git merge-base --is-ancestor 35e84b65f origin/main  → PR3705 commit IS ancestor of origin/main
grep -n 'PermissionManagementPage' ROADMAP.md       → 857 / 871   ✅ 与 issue 记载一致
```

基线 `origin/main` @ `36bf20235`(已含 PR #3705 与 PR #3711)。

## 前提复核(issue 是线索不是规格)

issue 的三条断言逐条对 `origin/main` 实测,**全部属实**:

| 断言 | 实测 | 证据 |
|---|---|---|
| `PermissionManagementPage` 组件不存在 | ✅ | `grep -rn` 于 `apps/` `packages/` = **EXIT=1 零命中**;`pages/system/` 现存 6 个页面,无此文件 |
| `/system/permissions` 路由不存在 | ✅ | `grep -n 'path="system/permissions"' AppContent.tsx` = **EXIT=1**;`:138` / `:191` 两处注释写明「deliberately NOT redirected」「absent on purpose」 |
| 相应测试随页面消失 | ✅ | 全仓 `*.test.tsx` grep `PermissionManagementPage` 零命中 |

额外查到 issue 未记的一条硬证据 —— **删除该页的 commit 有名有姓**:

```
git log --all --diff-filter=D -- '*PermissionManagementPage*'
→ cccdf84d7 Slim apps/console for third-party customisation
   .../src/pages/system/PermissionManagementPage.tsx | 26 ----------------------
```

这正好坐实了 #3705 已写在 `:826` 的那句「deleted when `apps/console` was slimmed for third-party customisation」,于是本 PR 把裸引用从泛指升级为可复核的 `(commit cccdf84d)`,合乎本文件 `:1046` `(commit 3371239c)` 的既有形态。

## 惯例:沿用 #3705 已确立的手法

#3705 已把这个文件对「已退场」项的处理考据清楚(`:152` / `:157` / `:1046` / `:997` / `:82`):**历史账本 + 就地批注** —— 条目不删、不打删除线,文字改写成「当前形态」并挂一个**裸文本**引用。本 PR 照办,因此**未新增任何 markdown 链接**(`git diff` 中新增行 grep `](...)`  = 零命中),check-doc-links 的扫描面不受影响。

## 前后对照

**`**Routes:**` 子块(:857)**

改前:

```
- [x] `/system/permissions` → PermissionManagementPage
```

改后:

```
- [ ] `/system/permissions` — no route is declared at this URL; the `PermissionManagementPage` it named was deleted when `apps/console` was slimmed for third-party customisation (commit cccdf84d), and the successor surface is pending maintainer decision, see #3655
```

**`**Tests:**` 子块(:871)**

改前:

```
- [x] 11 new tests (SystemHubPage, AppManagementPage, PermissionManagementPage)
```

改后:

```
- [x] New tests for the system pages — of the three suites named here, only `SystemHubPage`'s is still in the tree; nothing tests `AppManagementPage` today, and `PermissionManagementPage` has no tests because the page itself is gone (commit cccdf84d)
```

## 四处刻意的取舍

**1. :857 改成 `- [ ]`(未勾选),与 #3705 的 `:835` 对齐。** 它不是「做完了又退场」,而是一个**尚未定案的缺口**。更要紧的是内部一致性:#3705 已把 P1.12.2 里的同一条路由(`:835`)判为 `- [ ]`,若本 PR 让 `:857` 留在 `- [x]`,同一 `### P1.12` 章节里两条讲同一个 URL 的记录会自相矛盾。全文 89+ 处 `- [ ]`,未勾选是本文件的常规形态。

**2. ⛔ 不预判 #3655 的 A/B/C。** 措辞只陈述「未声明路由」这个事实并中性指向 #3655,**不点名** `sys_capability` / `sys_permission_set` 中的任何一个 —— 那两个名字在 `:826` / `:835` 已各出现一次,此处第三次复述既冗余又更易被读成倾向。

**3. 两个 `PermissionManagementPage` 作纠错锚保留,且判词紧跟其后。** 全文该词仍是 2 处(改前 2 → 改后 2),但两处的下一句都已是结论:`:857` 是「…**was deleted**…」,`:871` 是「…**has no tests because the page itself is gone**」。下一个 grep 到它的 agent 读到的是判词而非诱饵 —— 与 `:82` 保留 `@object-ui/tenant`、`:152` 保留 `ViewDesigner`、#3705 保留 `SystemObjectViewPage` / `sys_org` 同一手法。

**4. :871 不写新硬编码计数(照 #3705 第 9 项)。** 原文的 `11` 正是烂掉的那种数;改写后只说「三套里只剩 `SystemHubPage` 这一套还在树里」,不再种一个下周会再次失真的数字。

## 措辞纪律(遵 #3656:不复植承载错误机制的特征词)

| 特征词 | 改前 | 改后 |
|---|---|---|
| 路由活映射形态 `` `/system/permissions` `` + 箭头 | 1 | **0** |
| `11 new tests`(本围栏内) | 1 | **0** |
| `PermissionManagementPage`(纠错锚,刻意保留) | 2 | 2 |

第一版草稿把 `:857` 写成 `- [ ] /system/permissions → PermissionManagementPage — …`,箭头与组件名仍在**活映射位**,一眼扫过去仍像在陈述现行路由,纠正语只是尾随 —— 与 #3705 初稿把 `via ObjectView` 留在主语位是同型错误。改成把组件名降到从句(`the PermissionManagementPage it named was deleted`)后该形态才真正归零。如实记下。

> 注:`grep -c '11 new tests' ROADMAP.md` 改后仍为 2,是 `:489` 与 `:1778` 两条 —— 分别讲 DashboardDesignInteraction 与 getResponsiveSpanClass,与本漂移无关,亦在围栏外,未动。

## 验证

改动不含代码,本仓无任何测试或脚本读取 `ROADMAP.md` 的正文(`scripts/__tests__/check-doc-links.test.ts` 里的 ROADMAP 是**内存里合成的 fixture**,与真实文件无关),故**没有可跑绿的单元测试** —— 如实写明,不凑数。真正管这块的是 doc-links 门禁,`ROADMAP.md` 是它 `SCAN_ROOTS` 的第 5 个扫描根(`check-doc-links.mjs:397`,`rule: 'disk'`)。

```
改前 baseline: node scripts/check-doc-links.mjs → Links are valid across 7 scan roots.  EXIT=0
改后:          node scripts/check-doc-links.mjs → Links are valid across 7 scan roots.  EXIT=0
```

**阳性对照(先预测,后运行)** —— 前后同为绿,必须先证「门禁确实读了我改的那两行」,否则绿是「没看」而不是「没问题」。预测:分别往 **:857** 与 **:871**(本 PR 仅有的两条改动行)注入死链,门禁应各转红一次并**点名该行号**。两次实测均吻合:

```
注入 :857 → Found 1 broken link (1 distinct target):
            - [example-relative] ROADMAP.md:857 -> ./docs/adr/9999-does-not-exist.md    EXIT=1
还原      → Links are valid across 7 scan roots.                                        EXIT=0

注入 :871 → Found 1 broken link (1 distinct target):
            - [example-relative] ROADMAP.md:871 -> ./docs/adr/8888-nope.md              EXIT=1
还原      → Links are valid across 7 scan roots.                                        EXIT=0
```

还原后残留核查:`grep -c 9999` = 0、`grep -c 8888` = 0、`grep -c 'neg-control\|neg2'` = 0,`git status --short` 仅 `M ROADMAP.md`。

控制字符(门禁 + 门禁盲区自扫):

```
node scripts/check-control-bytes.mjs → OK (scanned 3684 tracked text file(s); skipped 85 binary)  EXIT=0
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' ROADMAP.md → 无输出(EXIT=1,干净)
```

> PR #3711 新加的版本字面量门禁扫描面是 `content/docs` 与各包 README,不含 `ROADMAP.md`;本 PR 亦未引入任何版本号,无交集。

## 围栏

- ⛔ `CHANGELOG.md` 未动 —— 史实记录,记的是「当时确实做了这件事」,不该被改写。
- ⛔ `content/docs/releases/` 未动;无 changeset。
- ⛔ 代码零改动,`AppContent.tsx` 只读不写。
- ⛔ **同在两个子块内、但与 PermissionManagementPage 无关的两条失实记录未动** —— 见下。

## 围栏内的两条「不动」,与理由

派发单把文件面给到「两行**及其所在子块**」,故下面两条虽在围栏内,仍**刻意不改**,已另立单:

- **`:858`** `- [x] /system/metadata/:metadataType → MetadataManagerPage` —— `MetadataManagerPage` 在 `apps/console/src/` 零文件零引用,该路由今天解析到 `MetadataRedirect`(`AppContent.tsx:188`)。**不搭车的理由**:它不是孤例,而是整片 P1.12.3 漂移的入口(`:862` / `:868` / `:999` 都仍把它当现役组件),单行修补会让 `:858` 与紧邻的 `:860-868` 自相矛盾,而 P1.12.3 段在围栏外。
- **`:872`** `- [x] Total: 20 system page tests passing` —— 实测窄读(`pages/system/__tests__/`)13 条、宽读(併入 `AppContent.systemHubRoutes.test.tsx`)18 条,**都不是 20**。**不搭车的理由**:「system page tests」这个指称本身没有定义(相关套件散在 `apps/console` 与 `packages/app-shell` 至少 7 个文件),要改先得裁定它指哪一组,或照 #3705 第 9 项干脆不写计数 —— 那是一次独立取舍,不该由本 PR 替维护者做。

两条与 `:857` / `:871` 的分野是清楚的:后者的判据是**同一个主语**(PermissionManagementPage),修补半径完全落在围栏内;前者是**另一个主语**,修补半径伸出围栏。

## 越界发现(只报不改)

- **#3712**(观察类,`finding`,未认领)—— 上述 `ROADMAP.md:858` / `:872` 两条残余漂移。
- **#3713**(具体缺陷,不打 `finding`,未认领)—— `skills/objectui/guides/console-development.md` 的目录树列出 7 个 `pages/system/` 页面,实测 **5 个不存在**(含本单主角 `PermissionManagementPage.tsx`),并有整节「How MetadataManagerPage works」教用一个零引用的组件;`skills/objectui/evals/console-development.json:7` 的 `expected_output` 已把该组件写进评测期望,即照 guide 生成的错代码会被 eval 判为「对」。消费者是 agent 而非读者,故未按观察类归档,严重度留给分诊。

立单前已就 `MetadataManagerPage` / `ROADMAP drift` / `P1.12.3` / `console-development.md` / `skills guide` 搜过本仓开放 issue,除 #3704 外无同源单。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt