### PR TITLE
fix(fields): 内嵌子表 date 列回显存量 ISO 值 (#3566)

### DIFF
--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -113,6 +113,62 @@ describe('GridField / LineItemsField — editable line items', () => {
     expect(onChange).toHaveBeenCalledWith([{ description: 'Taxi', amount: 42.5 }]);
   });
 
+  /**
+   * objectui#3566 — the sub-grid face of #3127. `<input type="date">` accepts
+   * exactly `YYYY-MM-DD` and rejects every other shape SILENTLY: the attribute
+   * still lands in the DOM, so the value looks present in the markup, while
+   * `.value` reads back `''` and the cell paints its empty placeholder. Since
+   * the API hands back `2026-06-17T00:00:00.000Z` for a `date` field, every
+   * date cell in an inline child grid rendered blank on a row that has a value.
+   * Asserting `.value` (never `getAttribute('value')`) is the only way to see
+   * this bug at all.
+   */
+  describe('date columns echo the stored value (#3566)', () => {
+    const dateField = {
+      columns: [
+        { field: 'description', label: 'Description', type: 'text' as const },
+        { field: 'incurred_on', label: 'Incurred On', type: 'date' as const },
+      ],
+    } as any;
+
+    // Both spellings the API may hand back for a `date` field. The bare form
+    // must survive VERBATIM — re-parsing it as UTC midnight and reading local
+    // calendar components back out would move it to the 16th anywhere west of
+    // Greenwich, which is the off-by-one this fix must not introduce.
+    it.each(['2026-06-17', '2026-06-17T00:00:00.000Z'])(
+      'shows the stored calendar day for %s instead of an empty cell',
+      (stored) => {
+        render(
+          <GridField value={[{ description: 'Taxi', incurred_on: stored }]} onChange={() => {}} field={dateField} />,
+        );
+        const cell = screen.getAllByLabelText('Incurred On')[0] as HTMLInputElement;
+        expect(cell.type).toBe('date');
+        expect(cell.value).toBe('2026-06-17');
+      },
+    );
+
+    it('leaves an empty date cell empty', () => {
+      render(<GridField value={[{ description: 'Taxi', incurred_on: null }]} onChange={() => {}} field={dateField} />);
+      expect((screen.getAllByLabelText('Incurred On')[0] as HTMLInputElement).value).toBe('');
+    });
+
+    it('writes back the control\'s own YYYY-MM-DD, unchanged by the read fix', () => {
+      // No paired conversion on the write side: `onChange` hands over exactly
+      // what `<input type="date">` produces, matching DateField's contract. A
+      // conversion here would put read and write on different bases.
+      const onChange = vi.fn();
+      render(
+        <GridField
+          value={[{ description: 'Taxi', incurred_on: '2026-06-17T00:00:00.000Z' }]}
+          onChange={onChange}
+          field={dateField}
+        />,
+      );
+      fireEvent.change(screen.getAllByLabelText('Incurred On')[0], { target: { value: '2026-06-18' } });
+      expect(onChange).toHaveBeenCalledWith([{ description: 'Taxi', incurred_on: '2026-06-18' }]);
+    });
+  });
+
   describe('trailing ghost row (start-with-one + auto-append)', () => {
     it('renders a trailing empty row so an empty grid still has one input line', () => {
       render(<GridField value={[]} onChange={() => {}} field={field} />);

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -19,6 +19,7 @@ import { Plus, Trash2, SlidersHorizontal, Maximize2, Copy, GripVertical } from '
 import { resolveFieldRuleState } from '@object-ui/core';
 import { LookupField } from './LookupField';
 import { FileCell } from './FileField';
+import { toDateInputValue } from './nativeDateValue';
 
 /**
  * GridField / LineItemsField — editable child-grid ("line items") widget.
@@ -760,7 +761,13 @@ export function GridField({
           type={c.type === 'date' ? 'date' : isNumeric(c.type) ? 'number' : 'text'}
           step={isNumeric(c.type) ? c.step ?? 'any' : undefined}
           aria-label={c.label || c.field}
-          value={val != null ? String(val) : ''}
+          // A `date` cell holding the API's ISO shape (`2026-06-17T00:00:00.000Z`)
+          // is SILENTLY rejected by `<input type="date">` — the attribute lands in
+          // the DOM but `input.value` reads back `''` and the cell paints empty
+          // (objectui#3566, the sub-grid face of #3127). The write-back shape is
+          // unchanged: the control's own plain `YYYY-MM-DD`, so no paired
+          // conversion is needed on the `onChange` side.
+          value={c.type === 'date' ? toDateInputValue(val) : val != null ? String(val) : ''}
           onChange={(e) => setCell(rowIdx, c, e.target.value)}
           disabled={locked}
         />


### PR DESCRIPTION
Fixes #3566

#3127 的同族缺口，落在子表面上。

## 缺陷

`GridField` 自己手搓单元格输入，不走 `DateField`，所以 #3127 的修复够不着它。`date` 列拿到 API 的 ISO 形状时，`String(val)` 把它原样喂进 `<input type="date">`：

```js
el.getAttribute('value')  // "2026-06-17T00:00:00.000Z"  ← 记录里的值
el.value                  // ""                          ← 用户看到的
```

该控件只接受 `YYYY-MM-DD`，其余形状**静默拒收** —— 属性照样落进 DOM，`input.value` 读回空串，于是**有值的行画出空占位**。

## 改法

复用 #3127 落地的 `toDateInputValue`，**不新增第二个日期归一化 helper**：

```tsx
value={c.type === 'date' ? toDateInputValue(val) : val != null ? String(val) : ''}
```

它对开头是 `YYYY-MM-DD` 的串原样透传，避免 date-only 被 `new Date()` 按 UTC 午夜解析后、再读本地日期分量而在格林威治以西整体差一天。

**写回侧刻意不配对**：`onChange` 仍交出控件自己的 plain `YYYY-MM-DD` —— 与 `DateField` 同一约定，读写保持同一基准。

## 验证

**单测**（先证伪）：把修复行还原后，新测以本缺陷的精确症状失败 ——

```
FAIL packages/fields/src/widgets/GridField.test.tsx > date columns echo the stored value (#3566)
AssertionError: expected '' to be '2026-06-17'
```

恢复后 `pnpm exec vitest run packages/fields/` → **64 files / 973 tests passed**；连同消费方 `plugin-form/` 合跑 36 files / 380 tests passed。新增 4 条：ISO 与裸日期两种形状都渲染 `2026-06-17`、空值保持空、写回仍是 plain `YYYY-MM-DD`。

**真机**（framework showcase + 本分支 console dev，对象 `showcase_expense_line` 的 `incurred_on`，走 `inlineEdit: 'grid'` 的内嵌子表）：

| EXP-2003 编辑表单的 Incurred On 单元格 | `attr` | `.value` |
|---|---|---|
| 还原修复行（对照组） | `2026-06-17T00:00:00.000Z` | **`""`** ← 复现缺陷 |
| 本分支 | `2026-06-17` | **`2026/06/17`** ✅ |

- **差一天已显式排除**：本地时区 PDT（UTC−7），若按 UTC 午夜重解析会显示 06/16 —— 没有位移。
- **写回往返**：单元格改成 `2026-06-20` 保存 → 后端与 sqlite 原始行均为 `2026-06-20`，相邻未触碰行仍是 `2026-06-18`（未被重新提交或改坏）。

> 取证说明：该后端对 `date` 字段读写两侧都会规整成 `YYYY-MM-DD`（绕过 API 直写 sqlite 亦然），stock seed 复现不了本缺陷；因此用一个改写代理把文档所载的 ISO 形状真正放上线来驱动真实 UI。对照组 `datetime` 字段接口原样回 `2026-08-07T16:39:20.389Z`。上游夹具缺口已报 objectstack-ai/objectstack#6328（未擅改其 seed 数据）。

## 范围

无 changeset（AGENTS.md §9：纯 bug 修复不写）。

同族但**故意未修**、已拆出 #3569：`deriveMasterDetail.ts` 把 `datetime`/`time` 折叠成 `date` 列，导致 datetime 子表字段的时间分量在写回时被静默丢弃；只读展示面（`displayText()`、只读表的 `String(...)`）同源。两者的修复都要先解开类型折叠并跨 `plugin-form`，在此之前 `GridField` 无从分辨该显示「日」还是「日+时间」，按日渲染会把 datetime 的时间从展示里抹掉。**本 PR 不会让 #3569 更差**：datetime 列由「空白」变为「显示日历日」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
