### PR TITLE
docs: 清偿门禁记账里的 8 处版本失真 — 无锚宣称删版本指真相、脚手架记录对齐生成器、有锚重述收窄到清单 (#3708, #3709, #3710)

### DIFF
--- a/content/docs/guide/architecture-overview.md
+++ b/content/docs/guide/architecture-overview.md
@@ -13,7 +13,7 @@ ObjectUI enforces a strict separation across three layers. Each layer has clear 
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  Layer 1: @objectstack/spec ^4.0.4 (The Protocol)                  │
+│  Layer 1: @objectstack/spec (The Protocol)                         │
 │  Pure TypeScript type definitions — 12 export modules               │
 │  ❌ No runtime code. No React. No dependencies.                    │
 └──────────────────────────────┬──────────────────────────────────────┘
@@ -32,7 +32,7 @@ ObjectUI enforces a strict separation across three layers. Each layer has clear 
 
 ### Layer 1 — `@objectstack/spec` (The Protocol)
 
-The upstream JSON specification for all ObjectStack products. ObjectUI **imports** these types but never redefines them. Located externally; consumed as `@objectstack/spec ^4.0.0`.
+The upstream JSON specification for all ObjectStack products. ObjectUI **imports** these types but never redefines them. Located externally and consumed as `@objectstack/spec`; the range each package installs is declared in that package's own `package.json`, under `dependencies`.
 
 ### Layer 2 — `@object-ui/types` (The Bridge)
 

--- a/content/docs/guide/architecture.md
+++ b/content/docs/guide/architecture.md
@@ -314,7 +314,7 @@ import { cn } from '@/lib/utils'
 
 ## Type Safety
 
-ObjectUI is built with **TypeScript 5.0+** in strict mode:
+ObjectUI is built with **TypeScript** in strict mode:
 
 ```typescript
 import type { ComponentSchema, ButtonSchema } from '@object-ui/types'

--- a/content/docs/utilities/create-plugin.mdx
+++ b/content/docs/utilities/create-plugin.mdx
@@ -133,28 +133,22 @@ export interface AwesomeComponentProps {
 
 ### `package.json`
 
-Pre-configured with all necessary settings:
+Pre-configured with all necessary settings: the package identity (`name`, `version`,
+`type`, `license`, `description`), the build entry points (`main`, `module`, `types` and
+an `exports` map covering both the ES and the UMD bundle), and its `scripts`.
 
-```json
-{
-  "name": "@object-ui/plugin-awesome",
-  "version": "0.1.0",
-  "description": "An awesome plugin for ObjectUI",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": ["dist"],
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
-    "test": "vitest"
-  },
-  "peerDependencies": {
-    "@object-ui/core": "^0.3.0",
-    "@object-ui/components": "^0.3.0",
-    "react": "^18.0.0"
-  }
-}
-```
+It also writes three dependency groups:
+
+- `dependencies` — four `@object-ui` workspace packages plus an icon library, written as
+  workspace links rather than as published version ranges. Note the field: the generator
+  puts these under **`dependencies`**, not under `peerDependencies`.
+- `peerDependencies` — `react` and `react-dom`, left for the host application to supply.
+- `devDependencies` — what the generated Vite build and its tests need.
+
+Do not transcribe version ranges out of this page into a hand-written manifest. They are
+written by one template — the manifest literal in
+[`packages/create-plugin/src/index.ts`](https://github.com/objectstack-ai/objectui/blob/main/packages/create-plugin/src/index.ts) —
+and reading them there is the only way to see what your scaffold will actually contain.
 
 ## Development Workflow
 

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -17,9 +17,9 @@ pnpm add @object-ui/layout
 ```
 
 **Peer Dependencies:**
-- `react` >= 18.0.0
-- `react-dom` >= 18.0.0
-- `react-router-dom` >= 6.0.0
+- `react` ^18.0.0 || ^19.0.0
+- `react-dom` ^18.0.0 || ^19.0.0
+- `react-router-dom` ^6.0.0 || ^7.0.0
 
 ## Components
 

--- a/packages/plugin-chatbot/README.md
+++ b/packages/plugin-chatbot/README.md
@@ -55,7 +55,7 @@ function App() {
 ### AI Streaming Mode (service-ai)
 
 When `api` is set in the schema, the chatbot connects to a backend SSE endpoint
-using `@ai-sdk/react` v3 (Vercel UI Message Stream protocol) for streaming,
+using `@ai-sdk/react` v4 (Vercel UI Message Stream protocol) for streaming,
 tool-calling, and production-grade chat:
 
 ```tsx

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -44,12 +44,21 @@ import { fileURLToPath } from 'node:url';
  *
  *   221 files scanned, 38 literals matched, 11 structurally exempt, 27 inventoried.
  *
- * Of the 27, NINE are measurably wrong today and are recorded as `stale` below —
+ * Of the 27, NINE were measurably wrong at that cut and were recorded as `stale` —
  * including `@objectstack/spec ^4.0.4` in the architecture overview's layer diagram,
- * thirteen majors behind the `^17.0.0-rc.5` every manifest declares. None is fixed
- * here: objectui#3697 is a test-only task and every repair is a docs edit. They are
- * filed separately; inventorying a known-false line with `kind: 'stale'` records the
- * debt instead of blessing it, and still stops a tenth from joining them silently.
+ * thirteen majors behind the `^17.0.0-rc.5` every manifest declares. None was fixed by
+ * objectui#3697 itself: that was a test-only task and every repair is a docs edit, so
+ * they were filed separately. Inventorying a known-false line with `kind: 'stale'`
+ * recorded the debt instead of blessing it, and still stopped a tenth from joining
+ * them silently.
+ *
+ * EIGHT of those nine have since been paid off — objectui#3708 (the two spec claims and
+ * the TypeScript one), #3709 (the three scaffolder-output lines) and #3710 (layout's
+ * peer line and plugin-chatbot's `@ai-sdk/react` major). Their entries left this file in
+ * the same change, which is the downward half of the ratchet doing its job rather than
+ * a courtesy. One `stale` entry remains, `packages/plugin-report/README.md`, and it is
+ * the one repair that belongs on the MANIFEST side: objectui#3690 widens the package's
+ * `peerDependencies.react`, after which the README is correct without being touched.
  *
  * ## Fences are SCANNED — the opposite of `check-doc-links.mjs`, on purpose
  *
@@ -63,13 +72,16 @@ import { fileURLToPath } from 'node:url';
  * be designed out. This gate has one, so a false positive costs a single line saying
  * "illustrative sample, not a claim" — while a miss costs the whole #3645 family again.
  * The measurement makes the trade concrete: stripping fences drops 12 of the 38 hits,
- * and among the dropped are two of the worst live defects —
+ * and among the dropped were the two worst defects the census found — both of them
+ * since repaired, which is the argument's strongest evidence rather than a reason to
+ * delete it. A fence-stripping gate would have reported green over both of these:
  *
- *   - `architecture-overview.md:16`, the layer diagram, states `@objectstack/spec ^4.0.4`
- *     inside an ASCII box (a fence), 13 majors stale;
- *   - `create-plugin.mdx:152` documents the scaffolder's output as pinning
- *     `@object-ui/core` `^0.3.0`, when `packages/create-plugin/src/index.ts:143` actually
- *     writes `workspace:*` dependencies and no such peer at all.
+ *   - `architecture-overview.md`, the layer diagram, stated `@objectstack/spec ^4.0.4`
+ *     inside an ASCII box (a fence), 13 majors stale — fixed by objectui#3708;
+ *   - `create-plugin.mdx` documented the scaffolder's output as pinning
+ *     `@object-ui/core` `^0.3.0`, when the manifest literal in
+ *     `packages/create-plugin/src/index.ts` actually writes workspace-link dependencies
+ *     and no such peer at all — fixed by objectui#3709.
  *
  * So: scan fences, absorb the samples in the inventory. The residual hole is stated
  * rather than implied — a version literal in a file OUTSIDE the two scan roots is
@@ -313,10 +325,14 @@ const keyOf = (c: Pick<Claim, 'file' | 'claim'>): string => `${c.file} :: ${c.cl
  *
  * `anchored`     - true today AND checkable against a machine-readable truth in this
  *                  tree, so a reviewer can re-verify it in one command.
- * `restatement`  - a package README restating its OWN package.json. Formally a subclass
- *                  of `anchored`, kept separate because it is the largest class (11 of
- *                  27) and the one already drifting: this is where a gate that pinned
- *                  README to manifest would pay off next.
+ * `restatement`  - a README restating its OWN package.json. Formally a subclass of
+ *                  `anchored`, kept separate because it is the largest class (12 of 21)
+ *                  and the one that had already drifted: the two drifted members were
+ *                  repaired by objectui#3710 and re-filed here as restatements. Note
+ *                  what this class does and does not buy — the equality it names is
+ *                  re-verified by a HUMAN reading the manifest, not by this gate, which
+ *                  only asks whether a literal was recorded at all. Pinning README to
+ *                  manifest mechanically is still the payoff this class is pointing at.
  * `sample`       - illustrative or template content. NOT an assertion about this
  *                  repository's versions: a changelog a plugin renders as demo data, or
  *                  a package.json skeleton the reader owns after copying it.
@@ -325,10 +341,11 @@ const keyOf = (c: Pick<Claim, 'file' | 'claim'>): string => `${c.file} :: ${c.cl
  *                  can tell us when it stops being true.
  * `stale`        - measured WRONG at the time of writing. Recorded, not blessed.
  *
- * Nine of the 27 are `stale`. None is fixed here: objectui#3697 is a test-only task and
- * every one of them is a docs edit. They are filed separately. Inventorying a
- * known-false line records the debt where the next reader will trip over it, and the
- * ratchet still stops a tenth from joining them unnoticed.
+ * Nine of the 27 were `stale` at the census. Eight have been paid off (objectui#3708,
+ * #3709, #3710) and their entries deleted in the same change; ONE remains, and it is
+ * the one whose repair is a manifest edit rather than a docs edit (objectui#3690).
+ * Inventorying a known-false line records the debt where the next reader will trip over
+ * it, and the ratchet still stops a tenth from joining them unnoticed.
  */
 type ClaimKind = 'anchored' | 'restatement' | 'sample' | 'unanchored' | 'stale';
 
@@ -339,31 +356,18 @@ interface KnownClaim {
   why: string;
 }
 
-/** The peer-dependency line 9 package READMEs carry, verbatim from their manifests. */
+/**
+ * The peer-dependency line 10 package READMEs carry verbatim from their manifests —
+ * `layout` joined them in objectui#3710, which narrowed its over-promising `>=` spelling
+ * to the range its manifest actually declares. An eleventh README, `plugin-report`,
+ * carries the same line WITHOUT the manifest to back it; that one stays `stale` below.
+ */
 const PEER_18_19 = 'react' + TICK + ' ^18.0.0';
 const PEER_RESTATEMENT_OK =
   'Restates this package peerDependencies.react verbatim; re-verify with a one-line read of the manifest.';
 
 const KNOWN_CLAIMS: KnownClaim[] = [
   // --- content/docs ------------------------------------------------------------
-  {
-    file: 'content/docs/guide/architecture-overview.md',
-    claim: '@objectstack/spec ^4.0.4',
-    kind: 'stale',
-    why: 'The layer diagram pins spec ^4.0.4; all 29 manifests declare ^17.0.0-rc.5. Thirteen majors stale, and inside a fence, which is why fences are scanned here.',
-  },
-  {
-    file: 'content/docs/guide/architecture-overview.md',
-    claim: '@objectstack/spec ^4.0.0',
-    kind: 'stale',
-    why: 'Same page, prose this time ("consumed as @objectstack/spec ^4.0.0"); the truth is ^17.0.0-rc.5 in every packages manifest.',
-  },
-  {
-    file: 'content/docs/guide/architecture.md',
-    claim: 'TypeScript 5.0',
-    kind: 'stale',
-    why: 'Says "built with TypeScript 5.0+ in strict mode"; all 34 typescript declarations in this repo are ^6.0.3. One major behind.',
-  },
   {
     file: 'content/docs/guide/ci-cd-pipeline.md',
     claim: 'Node 22.x',
@@ -412,30 +416,13 @@ const KNOWN_CLAIMS: KnownClaim[] = [
     kind: 'sample',
     why: 'Second row of the same fake changelog demo string.',
   },
-  {
-    file: 'content/docs/utilities/create-plugin.mdx',
-    claim: '@object-ui/core": "^0.3.0',
-    kind: 'stale',
-    why: 'Documents the scaffolder output as a ^0.3.0 peer, but packages/create-plugin/src/index.ts writes @object-ui/core as a workspace:* DEPENDENCY and no such peer exists. Wrong version and wrong field.',
-  },
-  {
-    file: 'content/docs/utilities/create-plugin.mdx',
-    claim: '@object-ui/components": "^0.3.0',
-    kind: 'stale',
-    why: 'Same block, same defect: the scaffolder emits @object-ui/components as workspace:* under dependencies, never as a ^0.3.0 peer.',
-  },
-  {
-    file: 'content/docs/utilities/create-plugin.mdx',
-    claim: 'react": "^18.0.0',
-    kind: 'stale',
-    why: 'The scaffolder writes react ^18.0.0 || ^19.0.0 (and a react-dom peer this block omits entirely), so the documented output understates what it generates.',
-  },
 
   // --- packages/<name>/README.md ----------------------------------------------
   { file: 'packages/auth/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/collaboration/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/components/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/i18n/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
+  { file: 'packages/layout/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/mobile/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/permissions/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/plugin-ai/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
@@ -448,12 +435,6 @@ const KNOWN_CLAIMS: KnownClaim[] = [
     why: 'Restates this package peerDependencies.react, which is literally ">=18" — the one README whose looser spelling is the manifest spelling.',
   },
   {
-    file: 'packages/layout/README.md',
-    claim: 'react' + TICK + ' >= 18.0.0',
-    kind: 'stale',
-    why: 'Claims ">= 18.0.0", which admits React 20; the manifest peer is ^18.0.0 || ^19.0.0 and rejects it. The README is broader than what npm will install.',
-  },
-  {
     file: 'packages/plugin-report/README.md',
     claim: PEER_18_19,
     kind: 'stale',
@@ -461,9 +442,9 @@ const KNOWN_CLAIMS: KnownClaim[] = [
   },
   {
     file: 'packages/plugin-chatbot/README.md',
-    claim: '@ai-sdk/react' + TICK + ' v3',
-    kind: 'stale',
-    why: 'Prose says the streaming mode uses @ai-sdk/react v3; the manifest dependency is ^4.0.47. A whole major behind, and the only third-party version claim in the corpus.',
+    claim: '@ai-sdk/react' + TICK + ' v4',
+    kind: 'restatement',
+    why: 'Names the major of this package own dependencies["@ai-sdk/react"], which is ^4.0.47. Kept rather than deleted because the reader follows it to the streaming protocol docs; re-verify with a one-line read of the manifest.',
   },
 ];
 


### PR DESCRIPTION
Fixes #3708
Fixes #3709
Fixes #3710

清偿 PR #3711 门禁记账的 9 处失真里属这三单的 **8 处**(第 9 处 `plugin-report/README.md:24` 的修法在清单侧,归 #3690,本 PR 一字未动)。6 文件,+69 / -94。

## 前提复核:三单全部成立,行号也没漂

在 `origin/main`(切点 `36bf20235`,即 PR #3711 的合并点)逐处核过,8 处宣称全在,与 ledger 记的一致。两个反读也复现:29 个 `packages` 清单全部 `@objectstack/spec: ^17.0.0-rc.5`,34 处 `typescript` 全部 `^6.0.3` —— 均匀,不存在「部分包还在旧大版本」这种能救散文的读法。

## 处置按失真性质分三类,不套统一口径

裁决要求分类执行,实测下来三类的**处置方向确实不同**,记在这里免得读成不一致。

### 一、无锚宣称(#3708 三处)—— 删版本号,指真相

照 #3645 / PR #3688 立下的仓规:版本号入散文即漂移保证,**一律不改写成 `rc.5` / `^6`**,重写等于把同一台漂移机器重新上膛。

`content/docs/guide/architecture-overview.md`,三层架构 ASCII 图内(围栏里,这正是 #3711 决定扫描围栏而非抹掉围栏的实测依据之一):

```
- │  Layer 1: @objectstack/spec ^4.0.4 (The Protocol)                  │
+ │  Layer 1: @objectstack/spec (The Protocol)                         │
```

删掉 7 个字符、补回 7 个空格,该行长度保持 70 不变(方框本就因宽字形而各行不等宽,`:18` 是 69 —— 这个既有偏差不是本 PR 引入的,也没被本 PR 改动)。

同页散文:

```
- Located externally; consumed as `@objectstack/spec ^4.0.0`.
+ Located externally and consumed as `@objectstack/spec`; the range each package
+ installs is declared in that package's own `package.json`, under `dependencies`.
```

照 PR #3698 处理 Node 行的办法:真相存在(每个包清单的 `dependencies`)、由包管理器安装期强制,所以保留句子、把值改成指针,而不是整句删掉。

`content/docs/guide/architecture.md:317`:

```
- ObjectUI is built with **TypeScript 5.0+** in strict mode:
+ ObjectUI is built with **TypeScript** in strict mode:
```

这一处**不加指针**,与上一处不同处置,理由据实:这句话的主语是 strict mode 而不是编译器版本;而 TypeScript 的声明是贡献者工具链事实(34 处 devDependencies),不是消费者约束(包发 `.d.ts`),指过去会让读者以为那是安装要求。PR #3688 对同一条宣称的处置也是直接删版本(「差一个大版本,且无处可核实」)。

### 二、脚手架记录(#3709)—— 对齐真实生成形态,不再逐字复制

先按裁决实测当前生成形态(truth = `packages/create-plugin/src/index.ts` 的 manifest 字面量),**测出的不符远多于 ledger 记的三行**:文档那份 `package.json` 还多报了一个 `files` 字段、少报了 `type` / `license` / `module` / `exports` / `dependencies` / `devDependencies`,`main` 也写错(文档 `dist/index.js`,实为 `dist/index.umd.cjs`)。

处置取「改写为无版本形态」而非「入 ledger」,以该页上下文取舍,理由:这一页**没有任何门禁或测试守着**,而它已经证明了自己会漂;把一份逐字复制的 manifest 记成 `restatement`,等于宣告一个无人强制的等式。改为描述真实形态 + 指向生成器模板本身:

```
- ```json
- {
-   "name": "@object-ui/plugin-awesome",
-   ...
-   "peerDependencies": {
-     "@object-ui/core": "^0.3.0",
-     "@object-ui/components": "^0.3.0",
-     "react": "^18.0.0"
-   }
- }
- ```
+ Pre-configured with all necessary settings: the package identity (...), the build
+ entry points (...), and its `scripts`.
+
+ It also writes three dependency groups:
+
+ - `dependencies` — four `@object-ui` workspace packages plus an icon library, written
+   as workspace links rather than as published version ranges. Note the field: the
+   generator puts these under **`dependencies`**, not under `peerDependencies`.
+ - `peerDependencies` — `react` and `react-dom`, ...
+ - `devDependencies` — what the generated Vite build and its tests need.
+
+ Do not transcribe version ranges out of this page into a hand-written manifest. ...
```

「字段错」这一半因此被正面写进散文(**dependencies**,不是 peer)—— 这是读者照做会坏的根因,删掉数字并不会让它自己消失。

### 三、有锚重述(#3710)—— 对齐清单,不删

与前两类**方向相反**:这一族有同包 `package.json` 作锚,分诊已裁 B(保留并钉住),所以处置是收窄到与清单逐字一致,而不是删版本号。

`packages/layout/README.md` —— 分诊追评把同一块里的另外两行也并入本单(README 承诺 `>=`,清单其实拒绝更高大版本,方向是**过度承诺**,读者照装会拿到 peer 冲突):

```
- - `react` >= 18.0.0
- - `react-dom` >= 18.0.0
- - `react-router-dom` >= 6.0.0
+ - `react` ^18.0.0 || ^19.0.0
+ - `react-dom` ^18.0.0 || ^19.0.0
+ - `react-router-dom` ^6.0.0 || ^7.0.0
```

三行现在与 `packages/layout/package.json` 的 `peerDependencies` **逐字相等**,已用脚本核对(三行全 MATCH)。

`packages/plugin-chatbot/README.md:58`:

```
- using `@ai-sdk/react` v3 (Vercel UI Message Stream protocol) for streaming,
+ using `@ai-sdk/react` v4 (Vercel UI Message Stream protocol) for streaming,
```

清单是 `^4.0.47`,取其主版本。**保留而不删**的理由:全语料唯一一处指名协议来源的宣称,读者据它去查协议文档;删掉即失去该信息。这里刻意**不**改写成不带点也不带符号的裸「4」—— 那个拼写门禁的 `VERSION` 正则匹配不到(它自己的头注已写明这个已知召回缺口),写成裸大版本等于绕过门禁,所以写 `v4` 并入 ledger。

## ledger 清偿:27 -> 21 条,`stale` 9 -> 1

| kind | 修前 | 修后 |
|---|---|---|
| `anchored` | 1 | 1 |
| `restatement` | 11 | 12 |
| `sample` | 5 | 5 |
| `unanchored` | 2 | 2 |
| `stale` | **9** | **1** |
| 合计 | 27 | 21 |

- 6 条**删除**(三处 architecture + 三处 create-plugin):宣称本身没了;
- `layout` 从独立 `stale` 条目**并入按字母排序的 peer 一行式组**(即裁决说的「照抄既有 9 包形态」),`claim` 键随之变成 `PEER_18_19`;
- `plugin-chatbot` 改判 `restatement`,`why` 里写明锚是 `dependencies["@ai-sdk/react"]` 与保留而非删除的理由;
- 剩下的唯一 `stale` 是 `plugin-report`,归 #3690。

## 棘轮两步(照 #3703 手法):方向先预测,后跑

裁决要求「清前红报陈旧点名、清后绿」。两步都先写下预测再跑,**且预测精确到条数与条目名**。

### 步骤一 —— 文档已改、ledger 未动

预测:两条测试变红。「no entry may outlive the claim」点名 **8** 条(6 条被删的 + 2 条 claim 文本变了的);「records every version literal」点名 **2** 条新宣称;并且 **`react-dom` / `react-router-dom` 两行不会出现** —— 依据不是猜:`packages/auth/README.md` 同款 `react-dom` 行今天就在树上而 ledger 里没有它的条目,main 却是绿的,所以那个拼写正则匹配不到。

实测,与预测逐条相符:

```
 ❯ scripts/__tests__/doc-version-claims.test.ts (6 tests | 2 failed)
   × records every version literal on the scanned surfaces
   × keeps the inventory honest - no entry may outlive the claim it excuses

AssertionError: KNOWN_CLAIMS names version claims that are no longer in the tree:
  - content/docs/guide/architecture-overview.md :: @objectstack/spec ^4.0.4
  - content/docs/guide/architecture-overview.md :: @objectstack/spec ^4.0.0
  - content/docs/guide/architecture.md :: TypeScript 5.0
  - content/docs/utilities/create-plugin.mdx :: @object-ui/core": "^0.3.0
  - content/docs/utilities/create-plugin.mdx :: @object-ui/components": "^0.3.0
  - content/docs/utilities/create-plugin.mdx :: react": "^18.0.0
  - packages/layout/README.md :: react` >= 18.0.0
  - packages/plugin-chatbot/README.md :: @ai-sdk/react` v3

AssertionError: These doc surfaces state a version and nothing in this repository can tell whether it is still true:
  - packages/layout/README.md:20  "react` ^18.0.0"
  - packages/plugin-chatbot/README.md:58  "@ai-sdk/react` v4"

 Tests  2 failed | 4 passed (6)
```

8 条、2 条,`react-dom` / `react-router-dom` 均未出现。这一步是本 PR 唯一能证明「ledger 缩短不是走形式」的证据:清偿前它确实以「条目所指的宣称已不在树上」变红,并把 8 条逐条点名。

### 步骤二 —— ledger 同步收缩

预测:6/6 绿。

```
$ pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts
   Test Files  1 passed (1) ;  Tests  6 passed (6)
```

## 反向验证:新增的那条自仓链接确实被门禁读到

`create-plugin.mdx` 新增了一条 `blob/main/` 自仓链接,正落在 `check-doc-links.mjs` §2 的可判定形状里。**预测:把路径改成不存在的,门禁必须变红并点名该行** —— 只有红了,修后的绿才是真覆盖(同 PR #3698 的做法)。

```
$ node scripts/check-doc-links.mjs        # 路径改坏后
- [self-repo-url] content/docs/utilities/create-plugin.mdx:150 -> .../packages/create-plugin/src/index.ts.NOPE
broken-path exit=1                        ← 与预测同向:红
restored   exit=0                         ← 还原后(文件 sha256 与改坏前逐字节相同)
```

## 措辞遵 #3656:先量后改,并检查有没有重新上膛

| 文件 | 判据 | 修前 | 修后 |
|---|---|---|---|
| architecture-overview.md | `^4.0.4` | 1 | **0** |
| architecture-overview.md | `^4.0.0` | 1 | **0** |
| architecture-overview.md | 重新上膛 `rc.5\|17.0.0` | 0 | **0** |
| architecture.md | `TypeScript 5.0` | 1 | **0** |
| architecture.md | 重新上膛 `^6.0.3\|TypeScript 6` | 0 | **0** |
| create-plugin.mdx | `^0.3.0` | 2 | **0** |
| create-plugin.mdx | `"react": "^18.0.0"` | 1 | **0** |
| create-plugin.mdx | 重新上膛 `workspace:*\|^0.563\|^19.0.0` | 0 | **0** |
| layout/README.md | `>= 18.0.0` | 2 | **0** |
| layout/README.md | `>= 6.0.0` | 1 | **0** |
| plugin-chatbot/README.md | `` ai-sdk/react` v3 `` | 1 | **0** |
| plugin-chatbot/README.md | `` ai-sdk/react` v4 `` | 0 | **1** |

最后一行是**故意不为零**的:#3710 那一族有锚,处置是对齐而不是删除,所以它必须留下一个字面量并进 ledger。三类处置方向不同,这张表如实反映,不强行凑成「全部归零」。

## 门禁

```
$ pnpm exec vitest run scripts/                     # 整个 scripts 面,确认没打断邻居
   Test Files  19 passed (19) ;  Tests  351 passed (351)

$ pnpm run type-check:scripts                       exit=0
$ pnpm exec eslint scripts/__tests__/doc-version-claims.test.ts   exit=0
$ node scripts/check-doc-links.mjs                  Links are valid across 7 scan roots. exit=0
$ node scripts/check-control-bytes.mjs              OK (scanned 3684 tracked text file(s); skipped 85 binary) exit=0
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' (6 个改动文件)      0 命中
```

`scripts/` 的 351 与 PR #3711 正文记的 345 不同,据实说明:那是它合并前在自己分支上量的数;本 PR 的 diff 只碰 19 个测试文件里的 1 个,该文件测试数前后都是 6,未增未减。

CI 预期(按 #3722 / #3523 step 2 落地后的**真实机制**写,不照抄旧口径):`ci.yml` / `lint.yml` 在 `pull_request` 上**已经没有 trigger 级 `paths-ignore`** 了 —— 那份排除表被移进 job 内的 "Decide whether this change needs a full run" 步骤(`push` 那份保留,因为没人评判推到 main 的提交)。所以本 PR **不会**显示成 workflow skipping,而是照跑、由该步骤判定。排除表是 `**/*.md` / `content/**` / `docs/**` / `apps/site/**` / `.changeset/**`;我这 6 个文件里 5 个被排除(`create-plugin.mdx` 是靠 `content/**` 命中,不是靠 `**/*.md` —— 它是 `.mdx`),但 `scripts/__tests__/doc-version-claims.test.ts` 不在排除表内,于是 `should_run=true`,**跑全量**。

结论方向与 PR #3688 / #3698 那两次的旧口径同(会真的跑),但机制不同:这条我在开 PR 后按 `origin/main` 的当前 workflow 重读过一遍才写,原稿把过滤描述成 trigger 级的,已按实际机制改写 —— 在一个专门清偿失真宣称的 PR 里留一句失真的机制描述,是本 PR 自己要防的那件事。

## 超出 `KNOWN_CLAIMS` 行的那部分改动,单独交代

派发文件面把该测试文件限定在「`KNOWN_CLAIMS` 行」。我另改了同文件的**四处头注**,理由是不改会让这个文件自己变成它要防的东西:

- 「NINE are measurably wrong **today** … None is fixed here」—— 清偿后这句直接为假,改为记录「9 条中 8 条已由 #3708/#3709/#3710 清偿,剩 1 条在清单侧(#3690)」;
- 围栏论证里「among the dropped are two of the worst **live** defects」点名的两处正是本 PR 修掉的 —— 保留举例(它们是该设计取舍的证据)但改为过去时并注明已修,论证反而更强:门禁当初看见它们,正因为扫了围栏;
- `restatement` 类注里的「largest class (11 of 27) … already drifting」计数与状态都变了,改为 12 of 21,并**补写一句这个类买到了什么、没买到什么**:它声称的逐字相等由人复核,门禁只问「有没有登记」;
- `PEER_18_19` 常量注「9 package READMEs」-> 10(layout 加入),并写明第 11 个 `plugin-report` 是无清单支撑的那条。

## changeset:不加(写明判断)

- `content/docs/**` 不在任何包的 `files` 里,只被 `apps/site` 消费,不是发布物;
- `scripts/__tests__/**` 不发布;
- 两个 `README.md` 确在发布物内,但本改动是修正失真文档,**无 API / 行为变更**,且仓内先例一致不加(#3688 改 36 个包 README、#3644、#3662、#3649 的合并提交 `.changeset/` 文件数均为 0);
- fixed 组联动,一次文档修正会把全组推版。

## 围栏

- `packages/plugin-report/README.md` **一字未动**(#3690 另裁,方向相反 —— 那处该改的是清单);
- `content/docs/guide/release-notes.md` 未动(版本标题下的历史叙述,结构性豁免);
- `content/docs/releases/` 未动;任何 `package.json` 未动;
- 暂存区文件数 **6**,与派发文件面逐一对应,越界文件 0。

## 越界发现(只记录、不顺手修)

- **#3715** —— `create-plugin.mdx` 该页**其余部分**同样描述了一个不存在的脚手架:6 个提示词(实为 3)、产物目录 `my-awesome-plugin/`(实为 `packages/plugin-NAME/`)、`npm run dev`(生成的 scripts 没有 dev,照做报 Missing script)、整节虚构的 `.create-plugin.config.js`、Version `0.3.1`(清单为 `17.3.0`)、依赖写 Inquirer / Ora(实为 commander / prompts)。全部落在本单 ledger 三行与裁决 truth 窗口(`index.ts` 的 dependencies / peerDependencies 两段)之外,且大多不含版本字面量、门禁看不见,故不在本 PR 越界修。**本 PR 因此刻意没有改写该页 §2 的 `npm run dev`**,也没在新散文里枚举 `scripts` 的具体名字 —— 那会把 #3715 的范围拖进来。
- **#3716** —— `create-plugin` 生成的插件跑不了自己的测试:模板写入 `test` 脚本与一个 test 文件,却没在生成的 devDependencies 里声明 `@testing-library/react` 与 `jest-dom`,vite 配置也没有 test 段/jsdom 环境。产物首次 `npm test` 即红。
- **#3717** —— #3710 分诊裁的 B 只落地了一半:两处已对齐并改判 `restatement`,但**那条断言没加**(派发文件面把本文件限定在 `KNOWN_CLAIMS` 行)。今天 12 条 `restatement` 声称的「与自家清单逐字一致」由人复核,棘轮两个方向都不响 —— #3690 正是这个形状的活样本。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt