### PR TITLE
fix(plugin-report): 放宽 react/react-dom peer 到 ^18.0.0 || ^19.0.0,对齐其余 29 个包 (#3690)

### DIFF
--- a/.changeset/plugin-report-react-19-peer-3690.md
+++ b/.changeset/plugin-report-react-19-peer-3690.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/plugin-report': patch
+---
+
+Accept React 19 in `@object-ui/plugin-report`'s peer range, the last UI package still declaring React 18 alone (objectui#3690).
+
+`peerDependencies.react` and `peerDependencies.react-dom` widen from `^18.0.0` to `^18.0.0 || ^19.0.0`, matching the other 29 packages in the fixed version group. With npm 7+ resolving peers strictly, a React 19 consumer installing this published package hit an `ERESOLVE` on first install while every sibling installed clean — and the package's own README already documented the wider range, so the manifest was the half that was wrong.
+
+The narrow range was never a constraint anyone stated. `packages/plugin-report/package.json` was hand-authored on 2026-02-06 (`1e557cbda`), by which point nineteen sibling packages already carried `^18.0.0 || ^19.0.0` and every package created afterwards was born with it; the one other package born narrow, `plugin-dashboard`, was corrected on 2026-05-08 (`d2b6ecec6`) in a build fix that touched only itself. No commit in the file's 172-commit history ever revisited the peer line, and no commit message mentions a React 18 requirement.
+
+Nothing in the package needs React 18. Its entire React surface is `React.FC`, `useState`, `useEffect`, `useMemo`, `useReducer`, `useContext`, `Fragment`, `ComponentType`, `CSSProperties` and `ReactNode` — all unchanged in React 19 — with zero uses of anything React 19 removed (`ReactDOM.render`, `unmountComponentAtNode`, `findDOMNode`, legacy context, string refs, `defaultProps` / `propTypes` on function components, `createFactory`, `useFormState`, `react-dom/test-utils`). `react-dom` is not imported by the source at all; it appears only as a UMD global name in the Vite externals config. The workspace pins `react` to 19.2.8 via a root `pnpm.overrides`, so this package's 78 tests have been running against React 19 the whole time it declared it did not support it.

--- a/packages/plugin-report/package.json
+++ b/packages/plugin-report/package.json
@@ -39,8 +39,8 @@
     "tailwind-merge": "^3.6.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@objectstack/spec": "^17.0.0-rc.5",

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -44,12 +44,19 @@ import { fileURLToPath } from 'node:url';
  *
  *   221 files scanned, 38 literals matched, 11 structurally exempt, 27 inventoried.
  *
- * Of the 27, NINE are measurably wrong today and are recorded as `stale` below —
- * including `@objectstack/spec ^4.0.4` in the architecture overview's layer diagram,
- * thirteen majors behind the `^17.0.0-rc.5` every manifest declares. None is fixed
- * here: objectui#3697 is a test-only task and every repair is a docs edit. They are
- * filed separately; inventorying a known-false line with `kind: 'stale'` records the
- * debt instead of blessing it, and still stops a tenth from joining them silently.
+ * Of the 27, NINE were measurably wrong when this file landed and were recorded as
+ * `stale` below — including `@objectstack/spec ^4.0.4` in the architecture overview's
+ * layer diagram, thirteen majors behind the `^17.0.0-rc.5` every manifest declares.
+ * None was fixed here: objectui#3697 is a test-only task and every repair is a docs
+ * edit. They are filed separately; inventorying a known-false line with `kind: 'stale'`
+ * records the debt instead of blessing it, and still stops a tenth from joining them
+ * silently.
+ *
+ * EIGHT remain. objectui#3690 paid off the first: `plugin-report/README.md` was the one
+ * entry where the README was RIGHT and the manifest lagged it, so widening that package
+ * peerDependencies to `^18.0.0 || ^19.0.0` turned the claim true without touching a
+ * single character of prose. Its entry is now a plain `restatement`. That direction —
+ * fix the anchor, not the sentence — is the cheapest way an entry ever leaves this list.
  *
  * ## Fences are SCANNED — the opposite of `check-doc-links.mjs`, on purpose
  *
@@ -325,10 +332,12 @@ const keyOf = (c: Pick<Claim, 'file' | 'claim'>): string => `${c.file} :: ${c.cl
  *                  can tell us when it stops being true.
  * `stale`        - measured WRONG at the time of writing. Recorded, not blessed.
  *
- * Nine of the 27 are `stale`. None is fixed here: objectui#3697 is a test-only task and
- * every one of them is a docs edit. They are filed separately. Inventorying a
- * known-false line records the debt where the next reader will trip over it, and the
- * ratchet still stops a tenth from joining them unnoticed.
+ * Nine of the 27 were `stale` when this file landed; EIGHT are today (objectui#3690
+ * cleared `plugin-report/README.md` by widening the manifest the README already
+ * described). None was fixed here: objectui#3697 is a test-only task and every one of
+ * them is a docs edit. They are filed separately. Inventorying a known-false line
+ * records the debt where the next reader will trip over it, and the ratchet still stops
+ * a tenth from joining them unnoticed.
  */
 type ClaimKind = 'anchored' | 'restatement' | 'sample' | 'unanchored' | 'stale';
 
@@ -440,6 +449,7 @@ const KNOWN_CLAIMS: KnownClaim[] = [
   { file: 'packages/permissions/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/plugin-ai/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/plugin-designer/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
+  { file: 'packages/plugin-report/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   { file: 'packages/react/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   {
     file: 'packages/react-runtime/README.md',
@@ -452,12 +462,6 @@ const KNOWN_CLAIMS: KnownClaim[] = [
     claim: 'react' + TICK + ' >= 18.0.0',
     kind: 'stale',
     why: 'Claims ">= 18.0.0", which admits React 20; the manifest peer is ^18.0.0 || ^19.0.0 and rejects it. The README is broader than what npm will install.',
-  },
-  {
-    file: 'packages/plugin-report/README.md',
-    claim: PEER_18_19,
-    kind: 'stale',
-    why: 'Claims ^18.0.0 || ^19.0.0 while this package peerDependencies.react is ^18.0.0 alone — the sole UI package without React 19, first noticed as an out-of-scope finding in PR #3688.',
   },
   {
     file: 'packages/plugin-chatbot/README.md',


### PR DESCRIPTION
Fixes #3690

`@object-ui/plugin-report` 的 `peerDependencies.react` / `react-dom` 从 `^18.0.0` 放宽到 `^18.0.0 || ^19.0.0`,与固定版本组里其余 29 个包对齐。npm 7+ 严格解析 peer,React 19 使用者装这个已发布包(17.3.0)会在首次 install 撞 `ERESOLVE`,而 29 个兄弟包全部装得干净。该包 README 早就写着放宽后的范围 —— **错的一直是清单这一侧**。

PM 裁决的三探针在动手之前逐一实测,全过。**这类改动的「验证」就是探针本身**:peer 范围是发布元数据,不进任何代码路径,不存在「改前红、改后绿」的断言可写。下面据实写探针输出,不造模板红绿。

---

## 探针一 · git 历史 —— 过,但机制与派发预设的不同

派发预设的形状是「28 个兄弟包批量加 `|| ^19.0.0`,plugin-report 早于该批量且被漏改」。**这个批量提交不存在。** 据实报账:

仓库是 shallow clone(211 commits,graft 点 `30ac2e1ee` 把每个文件都显示成 new file),必须 `git fetch --unshallow`(7516 commits)才能看清。展开后:

```
$ git log --follow --diff-filter=A -- packages/plugin-report/package.json
1e557cbda  Fri Feb 6 15:25:02 2026 +0800  Jack
feat(plugin-report): add ReportRenderer and ReportViewer components ...

$ git show 1e557cbda:packages/plugin-report/package.json → peerDependencies.react = "^18.0.0"
```

宽范围不是某次批量补的,而是**仓库从 2026-01-14 起的出生约定**,逐包在创建时写入。在 plugin-report 创建的那个切点上量所有包:

```
$ # 在 1e557cbda 处逐包读 peerDependencies.react
19 个包  ^18.0.0 || ^19.0.0   (react, components, layout, fields, plugin-grid, plugin-form,
                               plugin-view, plugin-kanban, plugin-markdown, plugin-charts,
                               plugin-editor, plugin-detail, plugin-list, plugin-map,
                               plugin-calendar, plugin-gantt, plugin-chatbot, plugin-timeline,
                               plugin-aggrid)
 2 个包  ^18.0.0              plugin-report(刚创建)、plugin-dashboard
```

**创建于 plugin-report 之后的每一个包都是出生即宽** —— 相隔仅两三天的也一样:

```
i18n            2026-02-08  bd3deb60f  ^18.0.0 || ^19.0.0
mobile          2026-02-09  8eb0ccbfc  ^18.0.0 || ^19.0.0
permissions     2026-02-09  49ddc8b6a  ^18.0.0 || ^19.0.0
plugin-ai       2026-02-09  b46dc0c1d  ^18.0.0 || ^19.0.0
plugin-designer 2026-02-09  a18302190  ^18.0.0 || ^19.0.0
auth            2026-02-10  7c2e3cd9c  ^18.0.0 || ^19.0.0
collaboration   2026-02-12  bfed0c107  ^18.0.0 || ^19.0.0
app-shell       2026-04-14  b55f88da9  ^18.0.0 || ^19.0.0
providers       2026-04-14  b55f88da9  ^18.0.0 || ^19.0.0
plugin-tree     2026-06-22  4eb9cb6ac  ^18.0.0 || ^19.0.0
```

另一个出生即窄的 `plugin-dashboard` 在 2026-05-08 被 `d2b6ecec6`(`fix(build): externalize all bare imports in library builds`)改正:

```
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
```

那次**只碰了 plugin-dashboard 一个 package.json**(`git show --name-only d2b6ecec6 | grep package.json` 只有一行),是定点修,不是批量 —— 所以 plugin-report 没被捎上。

逐包扫「出生即宽 / 后来变宽」,**plugin-report 是唯一一个声明了 react peer 却从未拿到宽字符串的包**;它 172 次提交的历史里没有任何一次动过 peer 行,创建提交的正文(六条 bullet,讲 ReportRenderer/ReportViewer/ReportBuilder/测试/注册/构建配置)也没有一个字提到 React 版本约束。

**方向判定:过。** 探针要回答的是「窄范围是不是被记录过的刻意约束」,答案是否 —— 它是一份手写 package.json 偏离了当时已成立的约定,此后无人回访。机制与预设不同,结论同向,故按裁决继续;预设错的那一半在此如实写明。

## 探针二 · API 面 —— 过,零命中

```
$ grep -rnE 'ReactDOM\.(render|hydrate)\b|unmountComponentAtNode|findDOMNode|createFactory|childContextTypes|contextTypes|getChildContext|defaultProps|propTypes|PropTypes|useFormState|react-test-renderer|react-dom/test-utils|unstable_batchedUpdates|renderToNodeStream|renderToStaticNodeStream' src/
(零命中)

$ grep -rnE 'ref="[^"]+"' src/                      # string refs        → 零命中
$ grep -rnE 'extends (React\.)?(Component|PureComponent)|componentWillMount|componentWillReceiveProps|componentWillUpdate' src/   → 零命中
$ grep -rnE 'useRef\(\)' src/                        # 19 的类型要求实参 → 零命中
```

正向清点该包用到的全部 React 面(4087 行,10 个源文件):

```
$ grep -rhoE 'React\.[A-Za-z]+' src/ | sort | uniq -c | sort -rn
      4 React.FC          2 React.useEffect     2 React.Fragment
      2 React.ComponentType   2 React.CSSProperties
      1 React.useState    1 React.useReducer    1 React.useMemo
      1 React.useContext  1 React.ReactNode
```

全部在 React 19 未变。`React.FC` 我故意放进了 grep 当近似项:它**不是** 19 移除的 API(变的是 `@types/react` 里 `FC` 不再隐含 `children`),而该包自己的 devDependencies 就是 `@types/react: 19.2.18`,已在 19 的类型面上编译。

附带量到:**`react-dom` 在源码里从未被 import**,只作为 UMD 全局名出现在 `vite.config.ts:46` 的 externals(`'react-dom': 'ReactDOM'`)。已另立观察级 finding,本 PR 仍按裁决同步放宽它 —— 保持固定组内一致优先于顺手裁剪 peer。

## 探针三 · 经验证据 —— 过

根 `package.json` 的 `pnpm.overrides` 把整个 workspace 钉在 19.2.8:

```json
"overrides": { "react": "19.2.8", "react-dom": "19.2.8",
               "@types/react": "19.2.18", "@types/react-dom": "19.2.4" }
```

plugin-report 自己没有 `devDependencies.react`,实测它解析到的就是这一份:

```
$ node -e "require.resolve('react/package.json',{paths:['packages/plugin-report/src']})"
node_modules/.pnpm/react@19.2.8/node_modules/react/package.json     version = 19.2.8
```

**改动之前**跑基线(此时清单仍写 `^18.0.0`):

```
$ pnpm exec vitest run packages/plugin-report/ --maxWorkers=2
 Test Files  6 passed (6)
      Tests  78 passed (78)
```

也就是说这 78 个测试**一直在 React 19 下跑**,而清单一直声明它不支持 19。实证兼容。

---

## 改动面

| 文件 | 动作 |
|---|---|
| `packages/plugin-report/package.json` | `react` / `react-dom` peer → `^18.0.0 \|\| ^19.0.0` |
| `scripts/__tests__/doc-version-claims.test.ts` | plugin-report 那一行 `kind: 'stale'` → `restatement`,并把头注里的「NINE stale」修成八 |
| `.changeset/plugin-report-react-19-peer-3690.md` | patch(peer 放宽属用户可见);未声明 `major`,合仓规 |

**README 一个字都没改,这是对的。** `packages/plugin-report/README.md:24-25` 本来就写着

```
- `react` ^18.0.0 || ^19.0.0
- `react-dom` ^18.0.0 || ^19.0.0
```

正如 #3711 在本单下的追评所判:**是清单落后于 README**,清单改对之后 README 自动为真。这也是九条 stale 债里最便宜的一条 —— 修锚点,不改句子。

**`pnpm-lock.yaml` 零 delta,这是构造性的,不是漏跑。** 跑了 `pnpm install --lockfile-only`,结果与 `origin/main` 逐字节相同。原因可机械核验:pnpm lockfile 的 `importers` 段对 workspace 包只记 `dependencies` / `devDependencies`,**从不记 `peerDependencies`** ——

```
$ # packages/plugin-report importer 块内的 key
dependencies, devDependencies
$ # importers 段里 'peerDependencies:' 的出现次数
0
```

所以 workspace 包改 peer 范围**按构造**不产生 lockfile 变化。据实写明,免得下一个读者以为这步被跳过了。

**ledger 并行注记(#3708 在途也动同一文件)。** 已复核在途 PR:#3708 与 #3709 目前**都没有开着的 PR**(仓内在途 PR 只有 #3691 / #3598 / #3580,均不碰此文件)。因此我只动了 `packages/plugin-report/README.md` 那**一行**,`architecture-overview` / `architecture.md` / `create-plugin.mdx` 的六条 stale 行原样保留,留给 #3708 / #3709。头注的 stale 计数我从九改成八 —— 那两单落地时会各自再减,数字在同一句里,是行级冲突,取并集即可。

## 测试

```
$ pnpm exec vitest run packages/plugin-report/ scripts/__tests__/doc-version-claims.test.ts --maxWorkers=2
 Test Files  7 passed (7)
      Tests  84 passed (84)          # plugin-report 6 文件 78 测试 + ledger 1 文件 6 测试

$ pnpm exec vitest run scripts/ --maxWorkers=2          # 整个 scripts 面,确认没打断邻居
 Test Files  19 passed (19)
      Tests  351 passed (351)

$ pnpm run type-check:scripts        # 覆盖被我改的那个 ledger 测试文件
 exit=0

$ node scripts/check-control-bytes.mjs
 ✅ OK (scanned 3684 tracked text file(s); skipped 85 binary)

$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' 本 PR 三个文件
 exit=1(零控制字节)
```

**一处如实交代:`pnpm --filter @object-ui/plugin-report type-check` 在本 worktree 未跑绿**,报的是

```
src/ReportViewer.tsx(12,104): error TS2307: Cannot find module '@object-ui/types' ...
src/index.tsx(9,35):          error TS2307: Cannot find module '@object-ui/core' ...
```

这是新建 worktree 里 workspace 依赖没 build 的既有状态,**不是本改动引起**,两点可证:(1) 实测 `packages/fields/dist`、`packages/components/dist`、`packages/react/dist`、`packages/plugin-grid/dist` 在本 worktree 里不存在,`tsc` 走 package `types` → `dist/index.d.ts` 因而解析不到,vitest 走源码 alias 所以照绿;(2) 本 PR 的 diff 只有一个 `peerDependencies` 块(`tsc` 从不读它)和一个 `scripts/` 测试文件(`type-check:scripts` 已 exit=0),结构上不可能产生 workspace 模块的 TS2307。补齐它需要 `pnpm --filter '@object-ui/plugin-report^...' build`,我在容器里发起该构建时被打断,未重试。CI 每次全新安装并按拓扑先 build 依赖,会覆盖这一格 —— 但我不把它记成我跑绿的,请以远端为准。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_