### PR TITLE
fix(console): 把 system/permissions 与 Permissions 计数一并接到 sys_permission_set,收尾 #3655 第五腿

### DIFF
--- a/.changeset/system-hub-permissions-leg-3655.md
+++ b/.changeset/system-hub-permissions-leg-3655.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/console': patch
+---
+
+Point System Hub's Permissions card — both its link and its count — at `sys_permission_set`, closing the last of the five `system/*` navigation targets (objectui#3655).
+
+Four of those URLs became redirects in an earlier change; `system/permissions` was deliberately held back, and so was the count beside it, because the framework splits what this console calls "Permissions" into two Setup entries and picking one would have silently bound every click, bookmark and badge to a surface nobody chose:
+
+- `sys_capability` — ADR-0066 layer 1, the definition registry of "what can be done". Its own docblock notes it is what the ADR "loosely floats" as `sys_permission`, which is the name the retired page and the count query both used, so lineage pointed here.
+- `sys_permission_set` — ADR-0066 layer 2, the grant container the permissions docs call "the only capability container" (object CRUD, field security, access depth, system capabilities), so function pointed here.
+
+It is decided as `sys_permission_set`: the card reads "Manage permission rules and assignments", and rules-and-assignments is layer 2 — a capability is what a permission set references by name, not what an administrator is assigned. Two user-visible consequences:
+
+- `/apps/:app/system/permissions` now forwards in one hop to `/apps/:app/sys_permission_set` instead of being rewritten to `…/system/record/permissions` and rendering a record detail page for an object literally named `system` — a dead link that read as a backend fault.
+- The Permissions card's badge shows the real number of permission sets. It previously counted `sys_permission`, an object the framework does not register; the adapter absorbs that `404` into an empty page on purpose, so the card printed a confident `0` no administrator could tell apart from "there really are none".
+
+Recorded as a transitional alias. Retiring this hand-written card wall along with the hub (already `@deprecated` in favour of the metadata-driven navigation) remains open and does not conflict — a redirect keeps old bookmarks resolving either way.

--- a/apps/console/src/AppContent.tsx
+++ b/apps/console/src/AppContent.tsx
@@ -102,11 +102,11 @@ function MetadataRedirect() {
 }
 
 /**
- * Forwards the retired `system/{users,organizations,roles,positions}` console
- * pages onto the canonical object routes served by the generic
+ * Forwards the retired `system/{users,organizations,roles,positions,permissions}`
+ * console pages onto the canonical object routes served by the generic
  * `…/:objectName` route in `@object-ui/app-shell` (objectui#3655).
  *
- * These four were real routes until `apps/console` was slimmed for third-party
+ * These five were real routes until `apps/console` was slimmed for third-party
  * customisation (cccdf84d7): "Delete bespoke /system/* wrapper pages
  * (User/Role/Permission/Audit/Org) … these objects are now contributed by
  * framework plugins (plugin-auth, -security, -audit) into the Setup app
@@ -134,9 +134,11 @@ function MetadataRedirect() {
  *                                       and the hub's "Positions" are the same
  *                                       surface under old/new vocabulary)
  *   positions     -> sys_position      (`nav_positions`)
- *
- * `system/permissions` is deliberately NOT redirected here — see the route
- * block below.
+ *   permissions   -> sys_permission_set(`nav_permission_sets`; this one was
+ *                                       held back in PR #3673 and is resolved
+ *                                       by objectui#3655's decision A — the
+ *                                       reasoning is recorded at the route
+ *                                       block below)
  *
  * Same shape as `ObjectRedirect` / `MetadataRedirect` above (a legacy URL is
  * translated, the page is not resurrected), including their treatment of
@@ -188,22 +190,40 @@ export const systemRoutes = (
     <Route path="system/metadata/:metadataType" element={<MetadataRedirect />} />
     <Route path="system/metadata/:metadataType/:itemName" element={<MetadataRedirect />} />
     {/* Legacy URL redirects → the framework-owned system objects (objectui#3655).
-        `system/permissions` is absent on purpose: unlike the four above it has
-        no single measured equivalent. The framework splits what this console
-        calls "Permissions" into TWO Setup entries — `sys_capability`
-        (Capabilities: the definition registry, and the object whose own
-        docblock says it is what the ADR "loosely floats" as `sys_permission`,
-        which is the name the retired page and `SystemHubPage`'s count query
-        both use) and `sys_permission_set` (Permission Sets: the grant
-        container, which is what "Manage permission rules and assignments" and
-        admin CRUD describe). Picking one silently sends every future click and
-        bookmark to a surface the maintainer never chose, so it is left to be
-        decided rather than guessed; the test file pins its unchanged landing so
-        the gap stays visible instead of reading as an oversight. */}
+        All five resolve now. `system/permissions` was the one held back in PR
+        #3673: the framework splits what this console calls "Permissions" into
+        TWO Setup entries, and picking one on a hunch would have bound every
+        future click and bookmark to a surface nobody chose.
+
+          `sys_capability`     (nav "Capabilities") — ADR-0066 layer 1, the
+            DEFINITION registry of "what can be done". Its own docblock says it
+            is what the ADR "loosely floats" as `sys_permission` — the name the
+            retired page used — so LINEAGE points here.
+          `sys_permission_set` (nav "Permission Sets") — ADR-0066 layer 2, the
+            grant/assignment container the permissions docs call "the only
+            capability container" (object CRUD + field security + access depth
+            + system capabilities). FUNCTION points here.
+
+        Decided as A, `sys_permission_set` (objectui#3655): the card that emits
+        this URL reads "Manage permission rules and assignments", and
+        rules-and-assignments is layer 2 — the definition catalog is what you
+        reference BY NAME from a set, not what you assign. Deliberately a
+        transitional alias: option C (retiring this bespoke card wall together
+        with the hub, already `@deprecated`) stays open and does not conflict,
+        because a redirect keeps old bookmarks resolving either way.
+
+        One correction worth leaving here, since it circulated while this was
+        open: the "capabilities are platform-locked, permission sets are the
+        admin-CRUD one" reading does NOT survive a re-read of the framework.
+        BOTH objects are `managedBy: 'config'` with `protection.lock:
+        'no-overlay'`, and both docblocks say the lock is on the SCHEMA while
+        tenants/admins may add rows. The layer-1 / layer-2 split above is the
+        distinction that actually holds. */}
     <Route path="system/users" element={<SystemObjectRedirect objectName="sys_user" />} />
     <Route path="system/organizations" element={<SystemObjectRedirect objectName="sys_organization" />} />
     <Route path="system/roles" element={<SystemObjectRedirect objectName="sys_position" />} />
     <Route path="system/positions" element={<SystemObjectRedirect objectName="sys_position" />} />
+    <Route path="system/permissions" element={<SystemObjectRedirect objectName="sys_permission_set" />} />
   </>
 );
 

--- a/apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx
+++ b/apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx
@@ -39,11 +39,11 @@
  *
  * `ChainRecorder` records every location the router settles on, so "one hop" is
  * an assertion rather than an inference; the pre-fix landings above are
- * reachable by deleting the four `system/*` routes from `systemRoutes` (the
+ * reachable by deleting the five `system/*` routes from `systemRoutes` (the
  * `object-view` probes go red and the chain returns to `Page not found` /
  * `…/system/record/<word>`).
  *
- * ## Two branches, and the `permissions` gap
+ * ## Two branches
  *
  * `AppContent` has two route tables and this host passes the same fragment to
  * both. With an active app the redirect target resolves (`:objectName` renders
@@ -52,10 +52,24 @@
  * and pinned below rather than asserted away, because a deployment with no apps
  * in its metadata also has no `sys_user` to show.
  *
- * `system/permissions` is deliberately still broken: the framework splits this
- * console's "Permissions" into `sys_capability` and `sys_permission_set` and
- * nothing in the issue picks one. Its unchanged landing is pinned so the gap is
- * visible, and so whichever mapping is chosen has to come here to change it.
+ * ## The `permissions` leg, closed
+ *
+ * Four of the five landed in PR #3673. `system/permissions` was held back and
+ * its broken landing PINNED, because the framework splits this console's
+ * "Permissions" into two Setup entries (`sys_capability`, ADR-0066 layer 1 —
+ * the definition registry; `sys_permission_set`, layer 2 — the grant container
+ * the permissions docs call "the only capability container") and guessing would
+ * have bound every click and bookmark to a surface nobody chose. objectui#3655
+ * decided it as `sys_permission_set`: the card that emits this URL says "Manage
+ * permission rules and assignments", which is layer 2. Those pins are therefore
+ * REPLACED here, not merely kept passing — that was their stated purpose.
+ *
+ * What the pins measured beyond the gap itself — that an undeclared segment
+ * fails in two different ways depending on its LENGTH — is still true and still
+ * measured, now on a hypothetical pair that is undeclared in both branches
+ * (`system/teams`, 5 chars, and `system/workgroups`, 10). Re-pointing them was
+ * the alternative to letting the length asymmetry lose its only coverage the
+ * moment its last real specimen got a route.
  */
 
 import '@testing-library/jest-dom/vitest';
@@ -214,16 +228,18 @@ beforeEach(() => {
 
 describe('system-hub entries reach the framework system objects (objectui#3655)', () => {
   /**
-   * The four whose equivalent the framework names unambiguously. `roles` and
-   * `positions` converge on ONE object on purpose: ADR-0090 D3 renamed
-   * `sys_role` -> `sys_position`, so the sidebar's "Roles" and the hub's
-   * "Positions" are the same surface in old and new vocabulary.
+   * All five. `roles` and `positions` converge on ONE object on purpose:
+   * ADR-0090 D3 renamed `sys_role` -> `sys_position`, so the sidebar's "Roles"
+   * and the hub's "Positions" are the same surface in old and new vocabulary.
+   * `permissions` -> `sys_permission_set` is objectui#3655's decision A (see
+   * the file docblock); it landed one PR after the other four.
    */
   it.each([
     ['/apps/setup/system/users', '/apps/setup/sys_user', 'sys_user'],
     ['/apps/setup/system/organizations', '/apps/setup/sys_organization', 'sys_organization'],
     ['/apps/setup/system/roles', '/apps/setup/sys_position', 'sys_position'],
     ['/apps/setup/system/positions', '/apps/setup/sys_position', 'sys_position'],
+    ['/apps/setup/system/permissions', '/apps/setup/sys_permission_set', 'sys_permission_set'],
   ])('%s reaches %s in ONE hop', async (url, target, objectName) => {
     renderConsoleAt(url);
 
@@ -253,34 +269,34 @@ describe('system-hub entries reach the framework system objects (objectui#3655)'
   });
 
   /**
-   * MEASUREMENT — deliberately unresolved. "Permissions" has TWO candidate
-   * equivalents in the framework (`sys_capability`, the definition registry and
-   * the object its own docblock identifies as the ADR's `sys_permission`; and
-   * `sys_permission_set`, the grant container the permissions docs call "the
-   * only capability container"). Choosing one here would silently commit every
-   * click and bookmark to a surface nobody picked, so this leg keeps its
-   * pre-fix landing until the mapping is decided. This assertion is expected to
-   * be REPLACED, not merely to keep passing.
+   * MEASUREMENT — the length-dependent split this issue is really about, kept
+   * alive now that its last real specimen has a route. `permissions` used to
+   * stand here: 11 chars, judged a record id, rewritten to
+   * `…/system/record/permissions` and rendered as a record of an object
+   * literally named `system`. That pin was written to be REPLACED once the
+   * mapping was decided (objectui#3655 → `sys_permission_set`), and the one-hop
+   * case above is its replacement.
+   *
+   * The asymmetry itself outlives it, so it is re-pinned on a hypothetical pair
+   * that is undeclared in both route tables: `workgroups` (10 chars) here and
+   * `teams` (5) below — the same concept spelled two lengths, producing two
+   * unrelated failure screens. Nothing here asks for `looksLikeRecordId` to
+   * change; that is a separate question. The point is that the next reader
+   * still finds it measured against the shipped routes rather than described.
    */
-  it('MEASUREMENT: system/permissions still lands on a record of the object `system`', async () => {
-    renderConsoleAt('/apps/setup/system/permissions');
+  it('MEASUREMENT: an undeclared LONG system segment lands on a record of the object `system`', async () => {
+    renderConsoleAt('/apps/setup/system/workgroups');
 
     const probe = await screen.findByTestId('record-detail-view');
     expect(probe).toHaveTextContent('"objectName":"system"');
-    expect(probe).toHaveTextContent('"recordId":"permissions"');
+    expect(probe).toHaveTextContent('"recordId":"workgroups"');
     expect(chain).toEqual([
-      '/apps/setup/system/permissions',
-      '/apps/setup/system/record/permissions',
+      '/apps/setup/system/workgroups',
+      '/apps/setup/system/record/workgroups',
     ]);
   });
 
-  /**
-   * MEASUREMENT — the length-dependent split this issue is really about, taken
-   * on the one URL the fix does not cover. `permissions` (11 chars) is judged a
-   * record id; a hypothetical 5-char sibling would not be. Nothing here asks
-   * for `looksLikeRecordId` to change — it is a separate question — but the
-   * asymmetry is recorded so the next reader does not have to rediscover it.
-   */
+  /** MEASUREMENT — the short half of the pair described just above. */
   it('MEASUREMENT: an undeclared SHORT system segment still reaches Page not found', async () => {
     renderConsoleAt('/apps/setup/system/teams');
 
@@ -310,6 +326,7 @@ describe('zero-app branch — measured, not asserted away (objectui#3655)', () =
     ['/apps/setup/system/organizations', '/apps/setup/sys_organization'],
     ['/apps/setup/system/roles', '/apps/setup/sys_position'],
     ['/apps/setup/system/positions', '/apps/setup/sys_position'],
+    ['/apps/setup/system/permissions', '/apps/setup/sys_permission_set'],
   ])('%s still redirects, and the target is the no-apps empty state', async (url, target) => {
     metadataApps = [];
     renderConsoleAt(url);
@@ -319,12 +336,22 @@ describe('zero-app branch — measured, not asserted away (objectui#3655)', () =
     expect(screen.queryByTestId('object-view')).not.toBeInTheDocument();
   });
 
+  /**
+   * MEASUREMENT — same re-pointing as the with-app half. This case used to run
+   * on `system/permissions`, which is now declared and so redirects here too
+   * (the row added above). Its subject was never that URL, though: it is that
+   * on a zero-app deployment even a LONG undeclared word reaches
+   * `RouteNotFound` and never a record page, because `ShorthandRecordRedirect`
+   * is not declared in this branch at all — i.e. the length split measured in
+   * the with-app describe does not exist here. `workgroups` (10 chars) keeps
+   * that fact pinned on a segment that is still undeclared.
+   */
   it('MEASUREMENT: with no apps, an undeclared system URL reaches Page not found, never a record page', async () => {
     metadataApps = [];
-    renderConsoleAt('/apps/setup/system/permissions');
+    renderConsoleAt('/apps/setup/system/workgroups');
 
     expect(await screen.findByText('Page not found')).toBeInTheDocument();
     expect(screen.queryByTestId('record-detail-view')).not.toBeInTheDocument();
-    expect(chain).toEqual(['/apps/setup/system/permissions']);
+    expect(chain).toEqual(['/apps/setup/system/workgroups']);
   });
 });

--- a/apps/console/src/pages/system/SystemHubPage.tsx
+++ b/apps/console/src/pages/system/SystemHubPage.tsx
@@ -101,22 +101,25 @@ export function SystemHubPage() {
       // it only covers non-404 rejections.
       //
       // Verified against the framework's object registry:
-      //   sys_user         packages/platform-objects/src/identity/sys-user.object.ts
-      //   sys_organization packages/platform-objects/src/identity/sys-organization.object.ts
-      //   sys_position     packages/plugins/plugin-security/src/objects/sys-position.object.ts
-      //   sys_audit_log    packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts
+      //   sys_user           packages/platform-objects/src/identity/sys-user.object.ts
+      //   sys_organization   packages/platform-objects/src/identity/sys-organization.object.ts
+      //   sys_position       packages/plugins/plugin-security/src/objects/sys-position.object.ts
+      //   sys_permission_set packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts
+      //   sys_audit_log      packages/plugins/plugin-audit/src/objects/sys-audit-log.object.ts
       //
-      // `sys_permission` is the one exception and is deliberately left alone.
-      // The framework has no such object; it splits that surface into
-      // `sys_capability` (lineage — its docblock names itself "not
-      // sys_permission as the ADR loosely floats") and `sys_permission_set`
-      // (function — the admin-managed grant container). Both would render, so
-      // picking one here would silently commit this card to a surface the
-      // maintainer has not chosen; that call is pending on objectui#3655
-      // (A: sys_permission_set / B: sys_capability / C: retire this bespoke
-      // card with the hub itself, which is already `@deprecated` above). Until
-      // it lands the Permissions count stays a known-wrong `0` — pinned by a
-      // MEASUREMENT case in this page's test rather than quietly re-aimed.
+      // Permissions used to ask for `sys_permission`, which the framework does
+      // NOT register, so this card read a known-wrong `0` on every deployment
+      // (objectui#3670 left it pinned rather than re-aimed). The framework
+      // splits that surface in two — `sys_capability` (ADR-0066 layer 1, the
+      // definition registry, and the object whose docblock says it is what the
+      // ADR "loosely floats" as `sys_permission`) and `sys_permission_set`
+      // (ADR-0066 layer 2, the grant container the permissions docs call "the
+      // only capability container"). Both exist, so either would have rendered
+      // a plausible number and quietly decided which surface this card means.
+      // objectui#3655 decided it: `sys_permission_set`, because the card says
+      // "Manage permission rules and assignments" and rules-and-assignments is
+      // layer 2. The same decision aimed this page's `system/permissions` link
+      // at that object, so badge and destination now describe one thing.
       //
       // TODO: Replace with count-specific API endpoint when available
       //
@@ -136,13 +139,15 @@ export function SystemHubPage() {
       //
       // A 404 still does not reach here and still renders `0`: the adapter
       // resolves unregistered objects as an empty page on purpose (see above).
-      // That is its contract, not a failure — the one card still riding on it
-      // is Permissions, which is objectui#3655's decision to close.
+      // That is its contract, not a failure. No card rides on it by mistake any
+      // more — every name below is registered — but a deployment that does not
+      // install a plugin (e.g. plugin-security, which owns `sys_position` and
+      // `sys_permission_set`) still gets `0` rather than "unavailable".
       const [usersRes, orgsRes, positionsRes, permsRes, logsRes] = await Promise.all([
         dataSource.find('sys_user').catch(() => null),
         dataSource.find('sys_organization').catch(() => null),
         dataSource.find('sys_position').catch(() => null),
-        dataSource.find('sys_permission').catch(() => null),
+        dataSource.find('sys_permission_set').catch(() => null),
         dataSource.find('sys_audit_log').catch(() => null),
       ]);
       setCounts({

--- a/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
+++ b/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
@@ -14,16 +14,20 @@
  * none" — on a single-org deployment where `sys_organization` always has at
  * least one row.
  *
- * This file therefore asserts two different things, and the difference is the
- * point:
- *   - Organizations is FIXED — the count now travels through `sys_organization`
- *     and shows the real number.
- *   - Permissions is only PINNED — the query still says `sys_permission`, an
- *     object the framework does not have, so that card still reads 0. Which
- *     object it should read is a maintainer decision open on objectui#3655
- *     (A `sys_permission_set` / B `sys_capability` / C retire the card). The
- *     MEASUREMENT cases below hold that gap visible instead of letting it read
- *     like an oversight.
+ * Both halves are now FIXED, one issue apart:
+ *   - Organizations travels through `sys_organization` (objectui#3670).
+ *   - Permissions travelled through `sys_permission`, an object the framework
+ *     does not register, so that card read a confident `0` on every deployment.
+ *     PR #3680 pinned it rather than re-aiming it, because the framework splits
+ *     that surface in two and picking one is a product decision: `sys_capability`
+ *     (ADR-0066 layer 1, the definition registry — and the object whose docblock
+ *     says it is what the ADR "loosely floats" as `sys_permission`) versus
+ *     `sys_permission_set` (layer 2, the grant container the permissions docs
+ *     call "the only capability container"). objectui#3655 decided it as
+ *     `sys_permission_set`, matching the card's own copy ("Manage permission
+ *     rules and assignments") and the destination its link now redirects to.
+ *     The MEASUREMENT that held that gap open is REPLACED below — which is what
+ *     it was written for — not left to keep passing on a stale expectation.
  *
  * jsdom integration test — no backend. The adapter is stubbed at its real
  * contract boundary (see the `find` stub: unknown object RESOLVES empty, it
@@ -40,8 +44,15 @@
  * class the adapter does not absorb) leaves that card's count `null`, and the
  * badge's existing `count !== null` branch drops the badge. The MEASUREMENT
  * case that pinned the old collapse-into-0 was rewritten there, as its own
- * comment asked for; the other two MEASUREMENTs still pin objectui#3655's gap
- * and are untouched.
+ * comment asked for.
+ *
+ * That block keeps asserting Permissions as a NEIGHBOUR — the card that must
+ * still show its real number while another card's lookup fails — so its
+ * expectation moved from `0 permissions` to `5 permissions` when objectui#3655
+ * re-aimed the query. Its three-row matrix case also needed a fresh specimen
+ * for "unregistered object": there is no longer a misspelled name to supply
+ * one, so it drops `sys_permission_set` from the fixture registry, i.e. a
+ * deployment without plugin-security. Both are noted at their call sites.
  */
 
 import '@testing-library/jest-dom/vitest';
@@ -66,7 +77,9 @@ const { state, ADAPTER, FRAMEWORK_OBJECT_NAMES } = vi.hoisted(() => {
    *
    * `sys_org` and `sys_permission` are absent on purpose: a repo-wide grep for
    * either as an object name returns zero hits in the framework, which is
-   * exactly what makes them unqueryable.
+   * exactly what makes them unqueryable. Neither is asked for any more — the
+   * audit case below asserts that the set of queried-but-unregistered names is
+   * now EMPTY.
    */
   const FRAMEWORK_OBJECT_NAMES = [
     'sys_user',
@@ -190,15 +203,15 @@ const COUNTED_CARDS: ReadonlyArray<readonly [string, string]> = [
 ];
 
 /**
- * The object names the page asks for, in call order — including
- * `sys_permission`, which the framework does not register (objectui#3655) and
- * so is absent from the fixture registry above.
+ * The object names the page asks for, in call order. Every one of them is a
+ * name the framework registers — see `FRAMEWORK_OBJECT_NAMES` and the audit
+ * case that ties the two lists together.
  */
 const QUERIED_OBJECT_NAMES = [
   'sys_user',
   'sys_organization',
   'sys_position',
-  'sys_permission',
+  'sys_permission_set',
   'sys_audit_log',
 ];
 
@@ -221,7 +234,7 @@ describe('System Hub card counts — object names (objectui#3670)', () => {
     expect(within(screen.getByTestId('hub-card-audit-log')).getByText('6 entries')).toBeInTheDocument();
   });
 
-  it('asks for exactly five names, and only one of them is missing from the framework', async () => {
+  it('asks for exactly five names, every one of them registered by the framework', async () => {
     renderHub();
     // Settle on a card this audit does not judge, so a wrong name shows up as a
     // diff on the call list below rather than as a missing badge elsewhere.
@@ -231,50 +244,59 @@ describe('System Hub card counts — object names (objectui#3670)', () => {
       'sys_user',
       'sys_organization',
       'sys_position',
-      'sys_permission',
+      'sys_permission_set',
       'sys_audit_log',
     ]);
-    // The whole audit in one assertion: after this change the only name the
-    // framework does not register is the one parked on objectui#3655.
-    expect(state.calls.filter((name) => !FRAMEWORK_OBJECT_NAMES.includes(name))).toEqual([
-      'sys_permission',
-    ]);
+    // The whole audit in one assertion. It read `['sys_permission']` while
+    // objectui#3655 was open and `['sys_org', 'sys_permission']` before
+    // objectui#3670; with the permissions leg decided, no card asks for a name
+    // the framework does not have.
+    expect(state.calls.filter((name) => !FRAMEWORK_OBJECT_NAMES.includes(name))).toEqual([]);
+  });
+
+  it('counts Permissions through sys_permission_set, the container the card describes', async () => {
+    renderHub();
+
+    // The replacement for "MEASUREMENT: Permissions still reads 0 while both
+    // candidate objects hold rows", which pinned the pre-decision landing and
+    // said in so many words that it was written to be rewritten. Same fixture:
+    // `sys_permission_set` (5 rows) and `sys_capability` (7 rows) both exist,
+    // so the badge's number identifies WHICH one the page chose — a fixture
+    // where only one had rows would let either name pass. 5, not 7, and not the
+    // `0` that `sys_permission` produced.
+    expect(await badge('hub-card-permissions', '5 permissions')).toBeInTheDocument();
+    expect(state.calls).toContain('sys_permission_set');
+    expect(state.calls).not.toContain('sys_permission');
+    // Layer 1 stays unqueried: capabilities are what a permission set
+    // REFERENCES by name, not what an admin is assigned (ADR-0066).
+    expect(state.calls).not.toContain('sys_capability');
   });
 
   // ── MEASUREMENT ────────────────────────────────────────────────────────────
-  // The two cases below pin the CURRENT behaviour, not the desired one. They
-  // exist so the remaining gap is visible in the suite instead of being read as
-  // a missed line, and so whoever resolves objectui#3655 has a failing anchor
-  // to rewrite rather than a silent pass.
+  // The case below pins CURRENT behaviour that no open issue is fixing, so it
+  // is a measurement rather than an acceptance: it records a consequence of the
+  // adapter's absorb-the-404 contract, which this page does not own.
   //
-  // There were three. The third — "a non-404 failure is collapsed into 0 as
-  // well, with no error affordance" — named objectui#3679 as the work that
-  // would rewrite it, and that work is done: it now lives in the next describe
-  // block with its expectation inverted. These two stay measurements because
-  // objectui#3655 is still open.
-
-  it('MEASUREMENT: Permissions still reads 0 while both candidate objects hold rows', async () => {
-    renderHub();
-
-    // `sys_capability` (7 rows) and `sys_permission_set` (5 rows) both exist in
-    // this fixture, and the card shows neither — it asks for `sys_permission`,
-    // which the framework does not have. Aiming it at either candidate here
-    // would decide objectui#3655's A/B/C on the maintainer's behalf, so the
-    // query is deliberately untouched. When that decision lands, THIS is the
-    // case to rewrite (expected: `7 permissions` for B, `5 permissions` for A,
-    // or the card gone entirely for C).
-    expect(await badge('hub-card-permissions', '0 permissions')).toBeInTheDocument();
-    expect(state.calls).toContain('sys_permission');
-    expect(state.calls).not.toContain('sys_capability');
-    expect(state.calls).not.toContain('sys_permission_set');
-  });
+  // There were three others. "A non-404 failure is collapsed into 0 as well"
+  // was rewritten by objectui#3679 (next describe block). The two that held
+  // objectui#3655's permissions gap open are gone with the gap: one became the
+  // `5 permissions` case above, the other is this one, re-pointed — see below.
 
   it('MEASUREMENT: an unregistered object and a genuinely empty one render the identical badge', async () => {
-    // `sys_audit_log` exists but has no rows; `sys_permission` does not exist
-    // at all. Two different facts, one indistinguishable pixel — this is why
-    // the wrong name survived so long, and it is unchanged by this PR (fixing
-    // it means changing the error handling, a separate class of work).
+    // Two different facts, one indistinguishable pixel. This is why a wrong
+    // object name survived so long, and nothing here fixes it — the 404 is
+    // absorbed inside the adapter by design, so telling the two apart would
+    // mean changing that contract, not this page.
+    //
+    // It used to be demonstrated with `sys_permission`, a name that existed
+    // nowhere. Now that all five names are real, the unregistered case needs a
+    // real occasion, and there is one: `sys_permission_set` belongs to
+    // plugin-security, so a deployment that does not install that plugin has no
+    // such object. Dropping it from the fixture registry models exactly that —
+    // and the card is indistinguishable from the genuinely empty audit log
+    // beside it.
     state.registry.sys_audit_log = [];
+    delete state.registry.sys_permission_set;
     renderHub();
 
     expect(await badge('hub-card-audit-log', '0 entries')).toBeInTheDocument();
@@ -323,20 +345,28 @@ describe('System Hub card counts — a lookup that failed is not a `0` (objectui
       '2 organizations',
     );
     expect(countBadge('hub-card-positions', 'positions')).toHaveTextContent('4 positions');
+    // `5 permissions` since objectui#3655 aimed this card at
+    // `sys_permission_set`; it read `0` here while the query still named the
+    // unregistered `sys_permission`.
     expect(countBadge('hub-card-permissions', 'permissions')).toHaveTextContent(
-      '0 permissions',
+      '5 permissions',
     );
   });
 
   it('keeps `0` for the two things that really are zero, and blanks only the failure', async () => {
     // All three rows of the issue's behaviour matrix in one render. Only the
     // third moves; the first two are the adapter's contract and stay as they
-    // are (whether Permissions should be riding on row two at all is
-    // objectui#3655, not this change):
-    //   sys_audit_log   registered, genuinely empty  -> `0 entries`
-    //   sys_permission  unregistered, adapter resolves empty -> `0 permissions`
-    //   sys_position    403, adapter rethrows        -> no badge
+    // are:
+    //   sys_audit_log       registered, genuinely empty          -> `0 entries`
+    //   sys_permission_set  unregistered, adapter resolves empty -> `0 permissions`
+    //   sys_position        403, adapter rethrows                -> no badge
+    //
+    // Row two used to ride on `sys_permission`, a name the framework never had
+    // (objectui#3655 has since aimed the card at `sys_permission_set`). It now
+    // rides on a deployment without plugin-security, which owns that object —
+    // the row still needs a specimen, and this is the honest one.
     state.registry.sys_audit_log = [];
+    delete state.registry.sys_permission_set;
     state.failures.sys_position = Object.assign(new Error('Forbidden'), { status: 403 });
     renderHub();
 


### PR DESCRIPTION
Fixes #3655

第五条也是最后一条腿。按 #3655 的 PM 裁决(维护者已授权代裁,[裁决评论](https://github.com/objectstack-ai/objectui/issues/3655#issuecomment-5223378738))落地 **A —— `sys_permission_set`**;C(卡片墙连同 hub 退场)保留为独立产品项,不阻塞,本 PR 未替它做任何事。

## 先复核前提(逐条对 `origin/main` @ `36bf20235` 与框架 `../objectstack` @ `b4872a868`)

裁决的**结论**成立,但它引用的一条论据不成立 —— 照实写在这里,并已写进代码注释,免得下一个读者继承它:

| 复核项 | 结果 |
|---|---|
| `sys_permission_set` 是框架注册的对象 | ✅ `packages/plugins/plugin-security/src/objects/sys-permission-set.object.ts:16` `name: 'sys_permission_set'` |
| Setup 导航有对应条目 | ✅ `security-plugin.ts:445` `{ id: 'nav_permission_sets', type: 'object', label: 'Permission Sets', objectName: 'sys_permission_set', icon: 'lock' }`,contribute 进 `app: 'setup'` / `group_access_control` |
| `sys_permission`(不含 `_set`)仍然不是对象 | ✅ 框架全仓精确 grep 零命中 |
| 文档称 permission set 为「the only capability container」 | ✅ `content/docs/permissions/permissions-matrix.mdx:64` 等四处;`administrator-guide.mdx:25` 展开为「object CRUD、field security、access depth、system capabilities」 |
| ⚠️ 裁决理由 1 的「B 是 managedBy:'config' + no-overlay 的平台锁定注册表,A 是带管理员 CRUD 的授予容器」 | ❌ **不成立**。**两个都是** `managedBy: 'config'` + `protection.lock: 'no-overlay'`(`sys-permission-set.object.ts:21,24-25` / `sys-capability.object.ts:32,35-36`),且两个 docblock 都写明锁的是 **schema**、租户/管理员可以加行(capability 那句原文:「The platform/packages DEFINE capabilities; admins EXTEND them in Setup」)。「对 B 做管理员增删没有意义」不成立。 |

**结论没有因此改变,换了一条更硬的论据**:ADR-0066 的三层分离 —— capability(层 1,「能做什么」的定义目录)/ assignment(层 2)/ requirement(层 3)。`sys_capability` 是层 1,`sys_permission_set` 是层 2;卡片文案「Manage permission rules and assignments」正是层 2,而层 1 是 permission set **按 name 引用**的东西,不是被授予的东西。这条写进了 `AppContent.tsx` 的路由块注释,连同上面那条订正。

当前 main 上 permissions 腿的三处现状也逐条复核成立:`AppContent.tsx` 的「absent on purpose」注释、`systemHubRoutes.test.tsx` 钉住的未变落点、`counts.test.tsx` 钉住的恒 0。

## 五腿终局表(实测落点,有应用分支)

| URL | 本 PR 前 | 本 PR 后 | 落地于 |
|---|---|---|---|
| `system/users` | `RouteNotFound`(5 字) | 一跳 `…/sys_user` | #3673 |
| `system/organizations` | 改写为 `…/system/record/organizations`,`RecordDetailView` 收到 `objectName:"system"` | 一跳 `…/sys_organization` | #3673 |
| `system/roles` | `RouteNotFound`(5 字) | 一跳 `…/sys_position` | #3673 |
| `system/positions` | 改写为 `…/system/record/positions` | 一跳 `…/sys_position` | #3673 |
| **`system/permissions`** | **改写为 `…/system/record/permissions`,记录页对象名 `system`** | **一跳 `…/sys_permission_set`** | **本 PR** |

计数侧同步:`dataSource.find('sys_permission')` → `'sys_permission_set'`。#3680 已把 Organizations 从 `sys_org` 改到 `sys_organization`,`sys_permission` 是当时唯一留着的错名;本 PR 之后**五个名字全部是框架注册的名字**,这一点由那条 audit 用例的一行断言机械保证(见下)。

## 钉翻转对照(替换不并存,#3609 纪律)

派发单点了两处必翻。实测另有六处断言钉在同一条被改的肢体上 —— 逐条判定处置,不批量重拼:

| # | 位置 | 原钉 | 处置 | 为什么是这个处置 |
|---|---|---|---|---|
| 1 | `systemHubRoutes.test.tsx` MEASUREMENT | `system/permissions still lands on a record of the object system` | **整条替换**:并入主 `it.each` 的一跳直达断言(第 5 行) | 原注释自述「expected to be REPLACED, not merely to keep passing」 |
| 2 | `counts.test.tsx` MEASUREMENT | `Permissions still reads 0 while both candidate objects hold rows` | **整条替换**:`5 permissions` 真实计数 + 不查 `sys_permission` / 不查 `sys_capability` | 同上;fixture 里 permission_set 5 行、capability 7 行都非零,所以徽章上的**数字本身**指认选了哪一个 —— 只有一个有行的 fixture 会让两个名字都过 |
| 3 | `systemHubRoutes.test.tsx` 零应用 `it.each` | 四行 | **补第五行** `permissions → sys_permission_set` | 本宿主把同一 fragment 同时传给 `extraRoutes` 与 `extraRoutesNoApp`,新路由在两个分支都生效 |
| 4 | `systemHubRoutes.test.tsx` 零应用 MEASUREMENT | 以 `system/permissions` 断言「无应用时落 Page not found、绝不落记录页」 | **改指 `system/workgroups`** | 它钉的事实不是那个 URL,而是「零应用分支压根没有 `ShorthandRecordRedirect`,长词也不会变记录页」。permissions 一旦声明就必红,而事实仍然成立 —— 需要一个仍未声明的长词 |
| 5 | `systemHubRoutes.test.tsx` 长度分叉 MEASUREMENT | 「`permissions`(11 字)被判成 record id」由 #1 那条兼任 | **新增 `system/workgroups` 一条**接手 | #1 被替换后,「长词 → 记录页」这一侧会失去唯一覆盖。`teams`(5)/`workgroups`(10) 是同一概念的两种长度、两块不同的失败屏 —— 比原来用真缺口 URL 当标本更稳 |
| 6 | `counts.test.tsx` MEASUREMENT「未注册对象与真空对象徽章相同」+ #3679 的三行矩阵用例 | 都用 `sys_permission`(压根不存在的名字)当「未注册」标本 | **补声明式改写**:改成 `delete state.registry.sys_permission_set`,即**没装 plugin-security 的部署** | 五个名字全部变成真名后,页面再没有拼错的名字可以当标本;但「未注册」这一行事实仍属适配器契约(吞 404 → 与真空同形),需要一个真实的发生场合,而没装该插件就是 |
| 7 | `counts.test.tsx` #3679 的邻卡隔离用例 | 邻卡 permissions 断言 `0 permissions` | **改字面量** `5 permissions` | 它断言的是「答复成功的邻卡保住真实数字」;permissions 现在就是一张会答复的卡 |
| 8 | `counts.test.tsx` audit 用例 | 调用清单含 `sys_permission`;`filter(不在框架里)` 期望 `['sys_permission']` | **改为** `sys_permission_set` / 期望 `[]` | 这一行现在是整份审计最强的信号:**零个**查询名字缺席于框架 |

`QUERIED_OBJECT_NAMES`(#3679 的全失败用例用它装失败)同步改名,否则会给一个页面不再查询的名字装失败,而真实的 `sys_permission_set` 照常答复 —— 那条用例会以假红的方式报出来。

其余断言一行未改。

## 逆向验证(两个扰动,方向都先写死后运行)

### 扰动 A —— 删掉新增那行路由声明(保留计数改名)

**预测:`2 failed | 22 passed`。** 红的只应是两条 permissions 落点(有应用一跳、零应用空状态),方向是**回到旧落点**;而 4/5 两条 `workgroups` MEASUREMENT、其余四腿、以及 counts 全 9 条**都不该动** —— 它们不经过这行路由。这点照实预测,不假装 MEASUREMENT 会跟着红。

**实测逐条吻合**,失败现场直接打印出修前的屏幕:

```
× /apps/setup/system/permissions reaches /apps/setup/sys_permission_set in ONE hop
× /apps/setup/system/permissions still redirects, and the target is the no-apps empty state

TestingLibraryElementError: Unable to find an element by: [data-testid="object-view"]
  {"appName":"setup","*":"system/record/permissions","objectName":"system","recordId":"permissions"}
TestingLibraryElementError: Unable to find an element by: [data-testid="create-first-app-btn"]

Tests  2 failed | 22 passed (24)
```

### 扰动 B —— 计数名退回 `sys_permission`(保留路由)

方向与 A 不同,单独预测。**预测:`4 failed | 20 passed`** —— audit 用例(调用清单 diff)、新的 `5 permissions` 用例、#3679 邻卡隔离用例(permissions 邻卡回 0)、#3679 全失败用例(失败装在页面不再查询的名字上,`sys_permission` 照常 resolve 空 → 徽章 `0 permissions` 冒出来)。

**并且明确预测两条 `0 permissions` 用例保持绿,而且是「因为什么都没产生所以绿」**:上表 #6 的两条把 `sys_permission_set` 从 registry 里删掉当「未注册」标本,而退回后查的 `sys_permission` 同样未注册 —— 两种错法在这条 fixture 上同形。这不是覆盖,是这条钉子的已知盲区,写在这里而不是留给下一个读者。

**实测逐条吻合:**

```
× asks for exactly five names, every one of them registered by the framework
× counts Permissions through sys_permission_set, the container the card describes
× blanks only the card that failed and leaves its neighbours their real counts
× shows no counts at all when every lookup fails, and still renders the hub

AssertionError: expected [ Array(5) ] to deeply equal [ Array(5) ]
-   "sys_permission_set",
+   "sys_permission",
TestingLibraryElementError: Unable to find an element with the text: 5 permissions
AssertionError: expected div …(1)/div to be null
+ Received:  permissions

Tests  4 failed | 20 passed (24)
```

#3679 落的错误态断言不受两个扰动影响的部分(500 单卡致盲、三行矩阵)全程绿,回归无扰动。

## 测试

从**仓库根**跑(AGENTS.md §怎么跑测试),重活走共享 flock + `--max-old-space-size=4096` + `--maxWorkers=2`:

- `pnpm exec vitest run --project '@object-ui/console'` → **27 files / 247 tests passed**(#3686 记录的 245 + 本 PR 净增 2:systemHubRoutes 13 → 15,counts 9 → 9)
- 两个改动测试文件单跑 → `2 files / 24 tests passed`
- `pnpm --workspace-concurrency=2 --filter @object-ui/console type-check` → 通过(新树里先 `--filter '@object-ui/console^...' build` 建好依赖)
- `pnpm --workspace-concurrency=2 --filter @object-ui/console lint` → **0 errors / 190 warnings**,与 #3673 / #3680 / #3686 记录的数目一致,本次零新增
- `node scripts/check-control-bytes.mjs` → OK(3684 个文件);`check-changeset-no-major.mjs` / `check-changeset-fixed.mjs` → OK
- 越过门禁的自扫:改动五个文件 `grep -naP` 控制字符类零命中(changeset 是新文件,门禁只扫已跟踪文件,故必须自扫)

**消费半径清扫**:全仓 `system/permissions` 的产出者与断言者只有本 PR 这四个文件(`SystemHubPage.tsx:246` 的 href + 路由 + 两个测试);`packages/**` 零命中,两个 sidebar 不产出 permissions 条目(#3655 正文即如此:这一条只由 System Hub 卡片产出)。`hub-card-permissions` testid 全仓只有 `counts.test.tsx` 断言。`sys_permission_set` 在本仓此前零引用。

## 文件面

- `apps/console/src/AppContent.tsx` —— 一行路由声明 + 把「absent on purpose」注释换成裁决记录(含上面那条论据订正)
- `apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx` —— 钉翻转 #1/#3/#4/#5
- `apps/console/src/pages/system/SystemHubPage.tsx` —— 一行对象名 + 注释按事实更新
- `apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx` —— 钉翻转 #2/#6/#7/#8
- `.changeset/system-hub-permissions-leg-3655.md` —— patch(用户可见:Permissions 入口可达 + 计数真实)

⛔ 未触碰:`ROADMAP.md`(#3704 在途)、doc-version-claims ledger(#3708 在途)、两个 sidebar 文件、`ShorthandRecordRedirect` / `looksLikeRecordId` 的判定逻辑、`packages/app-shell` 的任何路由声明、`sys_capability` 相关的任何东西。

## 遗留(只报不改)

- 徽章文案:卡片 `countLabel` 仍是 `permissions`,而计数现在是 permission **set** 的行数(fixture 下读作「5 permissions」)。这是裁决 A 明确接受的过渡期语义(卡片自述「Manage permission rules and assignments」,permission set 正是那个容器),终局由 C 一并带走,故未改文案、未另立单 —— 若 PM 认为该单独跟踪,请裁。
- `ROADMAP.md` 里 permissions 腿的中性表述在 #3704 落地后应按本 PR 的新现实更新;本 PR 按派发要求未碰该文件。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_