### PR TITLE
docs(skills): console-development.md 按 pages/system 现状重写,并同步 eval 的幽灵组件期望 (#3713)

### DIFF
--- a/skills/objectui/evals/console-development.json
+++ b/skills/objectui/evals/console-development.json
@@ -3,17 +3,20 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "I need to add a new 'Workflow' metadata type to the console admin panel. It should show in the system hub, have a list page with name/status/trigger columns, and a create dialog with name and trigger object fields.",
-      "expected_output": "Provides MetadataTypeRegistry configuration with columns, formFields, icon. Shows where to add the registration and how it automatically appears in SystemHubPage and MetadataManagerPage.",
+      "prompt": "I need to add a new 'Workflow' metadata type to the console admin panel. It should be reachable from the admin navigation, list items with name/status/trigger-object columns, and ask for name plus trigger object when creating one.",
+      "expected_output": "Explains that the metadata-admin engine already delivers list/create/edit/history once the type exists in the framework's spec and type registry, so the UI-side work is an optional registerMetadataResource() override supplying listColumns and createFields. Points at packages/app-shell/src/views/metadata-admin/registry.ts, and reaches the surface through the app's navigation rather than a bespoke card or page.",
       "files": [],
       "assertions": {
         "must_contain": [
-          "MetadataTypeRegistry",
-          "columns",
-          "formFields",
-          "SystemHubPage"
+          "registerMetadataResource",
+          "listColumns",
+          "createFields",
+          "metadata-admin",
+          "navigation"
         ],
         "must_not_contain": [
+          "registerMetadataType",
+          "pageSchemaFactory",
           "new standalone page",
           "/system/objects"
         ]
@@ -22,16 +25,18 @@
     {
       "id": 2,
       "prompt": "I want to create a custom detail page for the 'workflow' metadata type that has tabs for Settings, Steps, and History, similar to how object detail pages work.",
-      "expected_output": "Provides pageSchemaFactory function, custom widget components for each tab, registerWidgets file, and MetadataTypeRegistry wiring with pageSchemaFactory.",
+      "expected_output": "Provides a PageSchema factory, self-contained widget components for each tab registered in ComponentRegistry, and an EditPage component that renders the factory's schema through SchemaRenderer — wired to the type by registerMetadataResource({ type: 'workflow', EditPage }). Mirrors apps/console/src/schemas/objectDetailPageSchema.ts plus components/schema/registerObjectDetailWidgets.ts.",
       "files": [],
       "assertions": {
         "must_contain": [
-          "pageSchemaFactory",
-          "registerWidgets",
-          "MetadataDetailPage",
-          "tabs"
+          "ComponentRegistry",
+          "SchemaRenderer",
+          "EditPage",
+          "registerMetadataResource"
         ],
-        "must_not_contain": []
+        "must_not_contain": [
+          "pageSchemaFactory"
+        ]
       }
     },
     {

--- a/skills/objectui/guides/console-development.md
+++ b/skills/objectui/guides/console-development.md
@@ -1,11 +1,25 @@
 ---
 name: objectui-console-development
-description: Develop features for the Object UI Console application — the reference admin interface. Use this skill when the user works on apps/console code, adds admin pages, modifies the metadata management system, extends the MetadataTypeRegistry, creates schema-driven detail pages with PageSchema factories, modifies the UnifiedSidebar or navigation, works with ConsoleLayout/HomeLayout, builds system hub pages, or debugs console-specific routing. Also applies when the user mentions metadata types, object management, admin panel, system settings, app management, or console navigation patterns.
+description: Develop features for the Object UI Console application — the reference admin interface. Use this skill when the user works on apps/console code, adds admin pages, modifies the metadata management system, extends the metadata-admin resource registry, creates schema-driven detail pages with PageSchema factories, modifies the UnifiedSidebar or navigation, works with ConsoleLayout/HomeLayout, builds system hub pages, or debugs console-specific routing. Also applies when the user mentions metadata types, object management, admin panel, system settings, app management, or console navigation patterns.
 ---
 
 # ObjectUI Console Development
 
 Use this skill when working on the Console application (`apps/console/`), the reference admin interface for Object UI. The Console demonstrates schema-driven patterns at scale and serves as the blueprint for enterprise admin interfaces.
+
+> **`apps/console` is a reference assembly, not the engine.** Commit `cccdf84d7`
+> ("Slim apps/console for third-party customisation") moved the shell, the layouts,
+> the home pages, the navigation and the whole metadata admin into
+> `@object-ui/app-shell`, moved the designer pages into
+> `@object-ui/plugin-designer`, and left `apps/console` as a thin host that mostly
+> declares routes. Two consequences for anyone reading this guide:
+>
+> - **Look in `packages/app-shell` first.** Most symbols you want to change are
+>   there, not under `apps/console/src/`. Grep before you assume a path.
+> - **Third parties fork the template, not this app** — `examples/console-starter`
+>   wires `ConsoleShell` + host routes in ~100 LOC. Adding a surface to
+>   `apps/console` only benefits this repo's own deployment; adding it to
+>   `app-shell` (or to an app's `navigation[]` metadata) benefits every host.
 
 ## Console architecture overview
 
@@ -47,96 +61,152 @@ host app (see `guides/project-setup.md` → "Runtime & integration packages").
 
 ```
 apps/console/src/pages/
-├── home/                    # Workspace hub
-│   ├── HomeLayout.tsx       # Home shell (AppShell + sidebar, sets nav context)
-│   ├── HomePage.tsx         # Workspace dashboard
-│   ├── QuickActions.tsx     # Quick action buttons
-│   ├── RecentApps.tsx       # Recently-accessed apps
-│   └── AppCard.tsx          # App preview card
-├── system/                  # Admin panel
-│   ├── SystemHubPage.tsx    # Card-based admin hub
-│   ├── MetadataManagerPage.tsx  # Registry-driven list page
-│   ├── MetadataDetailPage.tsx   # Registry-driven detail page
-│   ├── AppManagementPage.tsx
-│   ├── UserManagementPage.tsx
-│   ├── RoleManagementPage.tsx
-│   └── PermissionManagementPage.tsx
-├── CreateAppPage.tsx
-├── EditAppPage.tsx
-├── PageDesignPage.tsx
-└── DashboardDesignPage.tsx
+├── auth/                        # Login, register, reset/set password, verify email,
+│                                #   OAuth consent, device auth, accept invitation
+├── developer/                   # DeveloperHubPage, ApiConsolePage, FlowRunsPage,
+│                                #   PublicFormsPage, IntegrationsPage
+├── settings/                    # SettingsHub + SettingsView (`system/settings/:namespace`)
+├── system/                      # Admin panel — exactly six pages
+│   ├── SystemHubPage.tsx        # Card-based admin hub (@deprecated — see below)
+│   ├── AppManagementPage.tsx    # App CRUD
+│   ├── ProfilePage.tsx          # Signed-in user's own profile
+│   ├── AuditLogPage.tsx         # Read-only audit trail (hand-written REST fetch,
+│   │                            #   deliberately not an ObjectView)
+│   ├── ApprovalsInboxPage.tsx   # Approvals awaiting the current user
+│   └── AiPendingActionsPage.tsx # AI-proposed actions awaiting confirmation
+├── DocsLayout.tsx / AppDocsIndex.tsx / DocsSlug.tsx / DocPage.tsx / BookPage.tsx
+│                                # ADR-0048 / ADR-0046 §6 — package docs reader
+└── SharedRecordPage.tsx         # Public share-link landing
 ```
 
-## Metadata Type Registry
+Where the rest went (all of it left `apps/console` in `cccdf84d7`):
 
-The registry at `apps/console/src/config/metadataTypeRegistry.ts` is the central configuration for all admin-managed entity types (app, dashboard, page, report, object, etc.).
+| Looking for | Today's home |
+|---|---|
+| `home/` (`HomeLayout`, `HomePage`, `QuickActions`, `RecentApps`, `AppCard`) | `packages/app-shell/src/console/home/` |
+| `CreateAppPage`, `EditAppPage`, `DashboardDesignPage` | `packages/plugin-designer/src/pages/` |
+| `UnifiedSidebar`, `ConsoleLayout` | `packages/app-shell/src/layout/` |
+| The registry-driven metadata pages | `packages/app-shell/src/views/metadata-admin/` (see next section) |
 
-### MetadataTypeConfig interface
+### Retired names — do not import these
+
+Earlier versions of this guide taught seven `pages/system/` files. Five of them are
+gone; searching for them wastes a lap, and writing code against them does not
+compile. Each is listed here **once**, with what replaced it:
+
+| Retired symbol | Verdict |
+|---|---|
+| `MetadataManagerPage` | **Deleted.** Registry-driven list is now `MetadataResourceListPage` in `packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx`. |
+| `MetadataDetailPage` | **Deleted.** Registry-driven editor is now `MetadataResourceEditPage` in `.../ResourceEditPage.tsx`. |
+| `UserManagementPage` | **Deleted** (`cccdf84d7`, whose message records where these objects went: "contributed by framework plugins (plugin-auth, -security, -audit) into the Setup app navigation"). The URL is now a redirect to `sys_user` — see "Routing patterns". |
+| `RoleManagementPage` | **Deleted** (`cccdf84d7`). ADR-0090 D3 renamed `sys_role` to `sys_position`; the URL redirects there. |
+| `PermissionManagementPage` | **Deleted** (`cccdf84d7`, 26 lines). Permissions are edited through `PermissionMatrixEditor`, registered as the `permission` type's `EditPage`. |
+| `config/metadataTypeRegistry.ts` | **Never existed under `apps/console/src/`.** The real registry is `packages/app-shell/src/views/metadata-admin/registry.ts`. |
+| `MetadataTypeConfig`, `registerMetadataType`, `getMetadataTypeConfig`, `pageSchemaFactory`, `listComponent`, `MetadataListComponentProps` | **No such API anywhere in the repo** (zero hits). The live equivalents are `MetadataResourceConfig`, `registerMetadataResource()`, `getMetadataResource()`, and the `ListPage` / `EditPage` / `CreatePage` component overrides. |
+
+## Metadata resource registry (metadata-admin engine)
+
+The registry lives in `@object-ui/app-shell`, not in the console:
+`packages/app-shell/src/views/metadata-admin/registry.ts`.
+
+The important inversion versus the old page-per-type design: the engine drives **all**
+metadata types from one `ListPage` / `EditPage` / `HistoryPage` shell, and the default
+form is generated from the JSONSchema the framework serves on `/api/v1/meta/types`. A
+type does not need a registry entry at all to be listable and editable. Registering one
+only **overrides** defaults.
+
+The contract for "add a new metadata type" is therefore mostly *not* a UI change:
+
+1. Define its Zod schema in the framework's `packages/spec/src/<domain>/`.
+2. Add it to the framework's `DEFAULT_METADATA_TYPE_REGISTRY`.
+3. Done — it appears in the Setup app's Metadata Directory with working
+   list / create / edit / history.
+
+### MetadataResourceConfig — the override surface
+
+Every field is optional. The ones you reach for most (see `registry.ts` for the full
+~30-field interface, which is documented field by field):
 
 ```typescript
-interface MetadataTypeConfig {
-  type: string;                    // API metadata category ('dashboard', 'page', 'object')
-  label: string;                   // Singular display name
-  pluralLabel: string;             // Plural display name
-  icon: string;                    // Lucide icon name
-  columns?: MetadataColumnDef[];   // Columns for list view
-  formFields?: MetadataFormFieldDef[]; // Fields for create/edit dialog
-  customRoute?: string;            // Override hub card link URL
-  pageSchemaFactory?: (name: string, item?: any) => PageSchema; // Schema-driven detail page
-  countSource?: 'metadata' | 'dataSource';  // Where to get item count
-  editable?: boolean;              // Enable CRUD (default: true)
-  listComponent?: React.ComponentType<MetadataListComponentProps>; // Custom list UI
+interface MetadataResourceConfig {
+  type: string;                       // 'view', 'flow', 'permission', …
+  label?: string;                     // falls back to the server label, then to `type`
+  description?: string;               // shown in the page hero
+  iconName?: string;                  // Lucide icon name
+  domain?: MetadataDomain;            // 'data' | 'ui' | 'automation' | 'security' | …
+  primaryKey?: string;                // default 'name'
+  identityField?: string;             // URL slug + body key; default 'name'
+  searchableFields?: string[];        // default ['name','label','description']
+  listColumns?: Array<{ key: string; label: string; width?: string;
+                        render?: (value: unknown, item: Record<string, unknown>) => ReactNode }>;
+  listFilter?: (item: Record<string, unknown>) => boolean;  // false hides the row
+  ListPage?: ComponentType<{ type: string }>;                 // bypass the generic list
+  EditPage?: ComponentType<{ type: string; name: string }>;    // bypass the generic editor
+  CreatePage?: ComponentType<{ type: string }>;                // bypass the generic create
+  createFields?: string[];            // which fields the create form asks for
+  createDerive?: CreateDeriveRule[];  // e.g. label -> name via 'slugify'
+  createDefaults?: Record<string, unknown>;   // shallow-merged into the PUT body
+  createBuildBody?: (draft: Record<string, unknown>) => Record<string, unknown>;
+  toDraft?: (item: Record<string, unknown>) => Record<string, unknown>;   // wire -> editor
+  fromDraft?: (draft: Record<string, unknown>) => Record<string, unknown>; // editor -> wire
+  defaultSchema?: Record<string, unknown>;    // used only when the server serves none
+  supportsHistory?: boolean;          // default true
+  anchors?: MetadataAnchor[];         // powers the parent's Related tab
 }
 ```
 
-### How MetadataManagerPage works
+Registration is idempotent and **merging**: calling `registerMetadataResource()` twice for
+the same `type` merges the new fields over the old, so a bespoke editor and the
+generic-engine defaults can be registered independently.
 
-Instead of hardcoding pages per type, `MetadataManagerPage` reads the registry config:
+### How MetadataResourceListPage works
 
-1. Gets `metadataType` from URL params
-2. Looks up `getMetadataTypeConfig(metadataType)`
-3. Uses `config.columns` to render the list table
-4. Uses `config.formFields` to render create/edit dialog
-5. If `config.listComponent` is set, renders that instead of the default grid
+`packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx`:
 
-### How MetadataDetailPage works
+1. Resolves `type` from the `type` prop, else from the `:type` route param.
+2. `getMetadataResource(type)` — if the entry has a `ListPage`, renders it and returns
+   (done before any other hook, so the hook count stays stable across type switches).
+3. Otherwise `resolveResourceConfig(type, serverEntry)` merges the registry entry with the
+   `/meta/types` row (server `label` / `description` / `domain` fill the gaps).
+4. Fetches `/meta/:type`, then filters by search (`searchableFields`), source/overlay, and
+   package scope — plus `listFilter` if the type declares one.
+5. Renders `listColumns`, falling back to columns inferred from `primaryKey`. Each row
+   links to its editor at `./:name?type=…`.
 
-1. Gets `metadataType` and `itemName` from URL params
-2. Looks up config from registry
-3. If `config.pageSchemaFactory` exists: generates PageSchema → renders via `SchemaRenderer`
-4. Otherwise: renders a generic detail card
+### How MetadataResourceEditPage works
 
-### Adding a new metadata type
+`.../ResourceEditPage.tsx`, one component for both edit and create (`createMode`):
+
+1. A registered `EditPage` (edit mode) or `CreatePage` (create mode) short-circuits
+   everything below — that is how `PermissionMatrixEditor` replaces the form for
+   `type: 'permission'`.
+2. Otherwise it picks a schema: `createSchema` in create mode, else the `/meta/types`
+   row's `schema`, else the registry's `defaultSchema`.
+3. Fetches the layered view (`?layers=true`) so code / overlay / effective are all
+   visible, and renders `SchemaForm` against that schema.
+4. Save → PUT. A `409 destructive_change` opens a confirmation dialog and retries with
+   `?force=true`. Reset overlay → DELETE. The References tab calls `client.references()`
+   so an admin sees the back-pointers before deleting.
+
+### Adding a registry override
 
 ```typescript
-// In metadataTypeRegistry.ts
-registerMetadataType({
-  type: 'workflow',
-  label: 'Workflow',
-  pluralLabel: 'Workflows',
-  icon: 'git-branch',
-  columns: [
-    { key: 'name', label: 'Name' },
-    { key: 'status', label: 'Status', width: '100px' },
-    { key: 'triggerObject', label: 'Object' },
+// packages/app-shell/src/services/builtinComponents.tsx
+registerMetadataResource({
+  type: 'permission',
+  label: 'Permission sets',
+  description: 'Object-level CRUD + VAMA + lifecycle permissions, and field-level R/W.',
+  domain: 'security',
+  EditPage: PermissionMatrixEditPage,   // bespoke grid replaces the generic AutoForm
+  searchableFields: ['name', 'label'],
+  listColumns: [
+    { key: 'name', label: 'Name', width: '30%' },
+    { key: 'label', label: 'Label', width: '30%' },
+    { key: 'managedBy', label: 'Source', width: '15%',
+      render: (v) => (v === 'package' ? 'Package' : 'Custom') },
   ],
-  formFields: [
-    { key: 'name', label: 'Name', type: 'text', required: true },
-    { key: 'triggerObject', label: 'Trigger Object', type: 'select', options: objectOptions },
-    { key: 'active', label: 'Active', type: 'boolean' },
-  ],
-  editable: true,
 });
 ```
-
-### MetadataFormFieldDef types
-
-Supported form field types:
-- `'text'` — text input
-- `'textarea'` — multiline text
-- `'select'` — dropdown with options
-- `'number'` — numeric input
-- `'boolean'` — Switch toggle (stored as `'true'`/`'false'` strings)
 
 ## Schema-driven detail pages (PageSchema)
 
@@ -144,7 +214,14 @@ Supported form field types:
 
 1. **Schema factory** generates a `PageSchema` from entity name/data
 2. **Custom widgets** are self-contained React components registered in `ComponentRegistry`
-3. **MetadataDetailPage** calls the factory and renders via `SchemaRenderer`
+3. **A registered `EditPage`** calls the factory and renders the result via `SchemaRenderer`
+
+> Measured status: the factory and its widgets exist and are registered
+> (`main.tsx` imports `registerObjectDetailWidgets`), but **nothing in the repo calls
+> `buildObjectDetailPageSchema()` today** — its only caller was the registry-driven
+> detail page retired above. Its own docblock records the intended wiring: "Render via
+> SchemaRenderer (e.g. inside a custom metadata-admin EditPage)." Treat the pattern
+> below as the recipe for a *new* bespoke editor, not as a description of a live route.
 
 ### Object detail page example
 
@@ -207,11 +284,21 @@ ComponentRegistry.register('my-detail-tabs', MyDetailTabsWidget, {
 });
 ```
 
-4. Wire into MetadataTypeRegistry:
+4. Wrap the factory in an `EditPage` component and register it as that type's override.
+   There is no declarative "give me a schema factory" hook — the registry takes a React
+   component, so the factory call happens inside it:
+
 ```typescript
-registerMetadataType({
+import { SchemaRenderer } from '@object-ui/react';
+import { registerMetadataResource } from '@object-ui/app-shell';
+
+function MyEntityEditPage({ name }: { type: string; name: string }) {
+  return <SchemaRenderer schema={buildMyDetailPageSchema(name)} />;
+}
+
+registerMetadataResource({
   type: 'my-entity',
-  pageSchemaFactory: buildMyDetailPageSchema,
+  EditPage: MyEntityEditPage,
   // ...
 });
 ```
@@ -259,33 +346,70 @@ function HomeLayout({ children }) {
 
 ### Routing patterns
 
-```typescript
-// apps/console/src/App.tsx routes (simplified)
-<Routes>
-  {/* Home */}
-  <Route path="/" element={<HomeLayout />}>
-    <Route index element={<HomePage />} />
-  </Route>
+Routes are split across two files, and that split is the thing to get right:
 
-  {/* App context */}
-  <Route path="/app/:appName" element={<ConsoleLayout />}>
-    <Route path="view/:viewName" element={<ViewPage />} />
-    <Route path="dashboard/:dashboardName" element={<DashboardView />} />
-    <Route path="record/:objectName/:recordId" element={<RecordDetailView />} />
-  </Route>
+- **`apps/console/src/App.tsx`** — the outer skeleton only (auth pages, `/home`,
+  `/organizations`, `/create-app`, `/apps/:appName/*`).
+- **`packages/app-shell/src/console/AppContent.tsx`** (`DefaultAppContent`) — everything
+  *inside* one app, including the metadata-admin engine's own routes. It declares two
+  route tables: one for when an app is active, one for the zero-app case
+  (`extraRoutesNoApp`).
+- **`apps/console/src/AppContent.tsx`** — a thin wrapper that passes a
+  `systemRoutes` JSX fragment into `DefaultAppContent`. Console-specific pages and
+  legacy-URL redirects live in that fragment; it is exported so tests mount the real
+  fragment instead of a hand-copied transcription.
 
-  {/* Admin */}
-  <Route path="/system" element={<ConsoleLayout />}>
-    <Route index element={<SystemHubPage />} />
-    <Route path="metadata/:metadataType" element={<MetadataManagerPage />} />
-    <Route path="metadata/:metadataType/:itemName" element={<MetadataDetailPage />} />
-  </Route>
+The engine's canonical metadata routes (declared by `DefaultAppContent`, relative to
+`/apps/:appName`):
 
-  {/* Legacy redirects */}
-  <Route path="/system/objects" element={<Navigate to="/system/metadata/object" />} />
-  <Route path="/system/objects/:name" element={<ObjectRedirect />} />
-</Routes>
 ```
+metadata                            -> MetadataDirectoryPage
+metadata/_diagnostics               -> MetadataDiagnosticsPage
+metadata/:type                      -> MetadataResourceListPage
+metadata/:type/new                  -> MetadataResourceEditPage (createMode)
+metadata/:type/:name                -> MetadataResourceEditPage
+metadata/:type/:name/history        -> MetadataResourceHistoryPage
+```
+
+The console's own fragment (`apps/console/src/AppContent.tsx`, abbreviated — read the file
+for the full list and its rationale comments):
+
+```
+system                              -> SystemHubPage
+system/apps | profile | approvals | ai-approvals | audit-log | settings[/:namespace]
+developer[/api-console | flow-runs | public-forms | integrations]
+docs[/:slug[/:name]]
+
+# Legacy URLs -> the metadata-admin engine (translate the URL, don't revive the page)
+system/objects[/:objectName]        -> ObjectRedirect      -> …/metadata/object[/:name]
+system/metadata[/:type[/:itemName]] -> MetadataRedirect    -> …/metadata[/:type[/:name]]
+
+# Legacy URLs -> framework-owned system objects (objectui#3655)
+system/users                        -> SystemObjectRedirect -> …/sys_user
+system/organizations                -> SystemObjectRedirect -> …/sys_organization
+system/roles                        -> SystemObjectRedirect -> …/sys_position
+system/positions                    -> SystemObjectRedirect -> …/sys_position
+```
+
+Four redirects, not five. `system/permissions` is **deliberately absent** as of
+`origin/main`: the framework splits what this console called "Permissions" into
+`sys_capability` (the definition registry) and `sys_permission_set` (the grant container),
+so PR #3673 declined to guess and pinned the unchanged landing in a test instead. The
+maintainer has since ruled **A — `sys_permission_set`** on objectui#3655; that redirect is
+queued but **not yet on `main`**, so today the URL still falls through to app-shell's tail
+route. Check `apps/console/src/AppContent.tsx` before quoting this list.
+
+Two traps worth internalising, both paid for in objectui#3639 / #3655:
+
+- The `component/metadata/resource/:name?type=…` spelling is a **legacy alias** whose
+  element is `LegacyMetadataRedirect` — a second `<Navigate>` onto the `metadata/:type…`
+  routes above. Never emit it from new code; it buys a redundant hop. It stays declared
+  only because bookmarks land on it.
+- An unmatched URL under `/apps/:appName/*` falls to app-shell's
+  `:objectName/:maybeRecordId` tail, where `looksLikeRecordId` treats any 6+ character
+  segment as a record id. A missing route therefore fails in two different ways depending
+  on word length: short words reach `RouteNotFound`, long ones render `RecordDetailView`
+  for a nonexistent object. If you add a nav target, declare its route in the same change.
 
 ## Key contexts
 
@@ -312,12 +436,32 @@ function HomeLayout({ children }) {
 
 ## Common console development patterns
 
-### Adding a new admin page
+### Adding a new admin surface
 
-1. Create the page component in `pages/system/`
-2. Add route in `App.tsx` under the `/system` route group
-3. Add card entry in `SystemHubPage.tsx` (icon, label, link)
-4. Optionally register as metadata type in registry
+**Default answer: don't write a page.** `SystemHubPage` carries an explicit
+`@deprecated` docblock — the hand-written card hub is superseded by the metadata-driven
+navigation, and it says so in terms worth quoting because they are the platform's
+position, not one file's preference:
+
+> ObjectStack is a metadata-driven platform: every administrable surface (objects,
+> metadata types such as `datasource`) is reached through an app's `navigation[]`
+> (defined in framework `packages/platform-objects/src/apps/*.app.ts`) and rendered by
+> the standard `UnifiedSidebar` → `NavigationRenderer`. New admin surfaces must be added
+> as nav items (`type:'object'` or `type:'component'` with
+> `componentRef:'metadata:resource'`), NOT as bespoke cards/pages here.
+
+So, in order of preference:
+
+1. **A metadata type** → register it in the framework's spec + type registry. The
+   metadata-admin engine gives you list / create / edit / history for free; add a
+   `registerMetadataResource()` entry only to override columns or swap in a bespoke editor.
+2. **An object** → contribute a `type:'object'` nav item from the owning framework plugin.
+3. **A genuinely bespoke React surface** → a `type:'component'` nav item with a
+   `componentRef` registered in `builtinComponents.tsx`.
+4. **Only if none of the above fits**: a page under `apps/console/src/pages/`, its route in
+   the `systemRoutes` fragment of `apps/console/src/AppContent.tsx`, and a test that
+   renders the URL. A page in this repo's host is invisible to every other host — see the
+   reference-assembly note at the top.
 
 ### Extending object management
 
@@ -348,10 +492,17 @@ function MyWidget({ schema }) {
 
 ## Common mistakes
 
-- Creating standalone pages instead of using MetadataTypeRegistry for admin entities.
+- Writing a standalone admin page instead of declaring a nav item / metadata type — see
+  "Adding a new admin surface".
+- Assuming a symbol lives under `apps/console/src/` because this guide's older revisions
+  said so. Grep first; most of it is in `packages/app-shell`.
 - Forgetting to set `NavigationContext` in custom layouts — sidebar shows wrong items.
-- Not registering custom widgets before MetadataDetailPage renders — SchemaRenderer produces fallback.
-- Using legacy routes (`/system/objects`) instead of unified metadata routes (`/system/metadata/object`).
+- Not registering custom widgets before the editor renders — `SchemaRenderer` falls back.
+- Emitting legacy URLs from new code (`/system/objects`, `component/metadata/resource/…`)
+  instead of the engine's canonical `…/metadata/:type[/:name]`. The legacy routes stay
+  declared for bookmarks; that is not a licence to generate them.
+- Adding a navigation target without declaring its route in the same change — the tail
+  route swallows it and fails differently depending on the word's length.
 - Modifying `src/ui/**/*.tsx` files directly — these are Shadcn upstream files that get overwritten by sync scripts.
 
 ## Debugging & Browser Simulation Strategy


### PR DESCRIPTION
Fixes #3713

按 PM 裁决**方向 1(按现状重写 + 同步 eval),吸收方向 3 的既定事实**执行。两文件,无源码改动。

> 注:正文刻意不写「尖括号 + 字母」的泛型/JSX 形式 —— GitHub 正文消毒器会在存储时把它当 HTML 标签剥掉(#3673 首版栽过)。泛型一律写成 `ComponentType< X >` 或改用花括号占位。

## 一、前提复核:issue 结论全部成立(`origin/main` @ `0cf8f0f70`)

7 页面表逐条 `find apps/console/src -name '{名}.tsx'`:

| guide 原文声称的文件 | 实测 | 本 PR 处置 |
|---|---|---|
| `SystemHubPage.tsx` | ✅ 存在 | 保留,补 `@deprecated` 判词 |
| `MetadataManagerPage.tsx` | ❌ 不存在 | 移入「Retired names」纠错锚 |
| `MetadataDetailPage.tsx` | ❌ 不存在 | 移入纠错锚 |
| `AppManagementPage.tsx` | ✅ 存在 | 保留 |
| `UserManagementPage.tsx` | ❌ 不存在 | 移入纠错锚 |
| `RoleManagementPage.tsx` | ❌ 不存在 | 移入纠错锚 |
| `PermissionManagementPage.tsx` | ❌ 不存在 | 移入纠错锚 |

`pages/system/` 现存 6 个,原 guide 一个都没提其中四个 —— 现已全部补入:`ProfilePage` / `AuditLogPage` / `ApprovalsInboxPage` / `AiPendingActionsPage`。

零命中复核(`packages` + `apps`,排除 node_modules):`MetadataManagerPage` 0、`MetadataDetailPage` 0、`metadataTypeRegistry` 0、`MetadataTypeConfig` 0、`registerMetadataType` 0、`getMetadataTypeConfig` 0、`pageSchemaFactory` 0、`listComponent` 0、`MetadataListComponentProps` 0。即 `:88` 的 `listComponent` 扩展点与整个 `MetadataTypeConfig` 接口都是幽灵。

**一处与 PR #3699 正文不符的史实,以本次实测为准**:#3699 说 `cccdf84d7` 不是 `main` 的祖先(当时 `main` 仅 203 个 commit)。今天 `origin/main` 有 **7517** 个 commit,`git merge-base --is-ancestor cccdf84d origin/main` 返回 **ANCESTOR**,`git log -1` 能读到完整提交信息。故本 PR 放心引用它 —— `apps/console/src/AppContent.tsx:110` 也已经在引。

## 二、「How MetadataManagerPage works」按真实机制改写(先实测,未照抄派发单)

派发单指出真身在 `packages/app-shell` 的 metadata-admin,要求先实测。实测结果比「registry 驱动」这句话更强,而且方向是**反的**:

- 真实注册表:`packages/app-shell/src/views/metadata-admin/registry.ts`,类型 `MetadataResourceConfig`,写入 `registerMetadataResource()`(幂等 + **合并**语义),读出 `getMetadataResource()` / `resolveResourceConfig()`。
- **关键反转**:旧 guide 教的是「注册表驱动的页面」;真实引擎是**一套 ListPage / EditPage / HistoryPage 通吃全部 27 个类型**,默认表单由框架 `/api/v1/meta/types` 返回的 JSONSchema 生成。**一个类型完全不注册也能列/建/改** —— 注册项只是**覆盖**默认值。旧文那种「不注册就没有页面」的心智模型,会让 agent 去写一堆本来不必写的东西。
- 五步流程按 `ResourceListPage.tsx` / `ResourceEditPage.tsx` 逐行改写(含 `ListPage` 覆盖必须在其它 hook 之前短路这一实现约束、`createSchema` -> 服务端 `schema` -> `defaultSchema` 的取值顺序、`409 destructive_change` 重试 `?force=true`)。
- 「Adding a new metadata type」的假 API 例子换成 `builtinComponents.tsx` 里 `type:'permission'` 的**真实**注册项(`EditPage: PermissionMatrixEditPage`)。

路由示例整节重写:两文件分工(`App.tsx` 外骨架 / app-shell `DefaultAppContent` 应用内 / `apps/console/src/AppContent.tsx` 的 `systemRoutes` fragment)、引擎自己的 `metadata/:type…` 六条正规路由、以及 `SystemObjectRedirect` 的**四条**腿。

## 三、#3655 permissions 腿:未落地,按「已裁 A 待落地」措辞写(避免抢跑)

动手前 `git log origin/main` 实测:`9961df297`(#3673,四条重定向)已在 main;**permissions 腿不在** —— `apps/console/src/AppContent.tsx` 现仍只有 users / organizations / roles / positions 四行,`:191-202` 的注释仍在解释为什么 permissions 故意缺席。故 guide 写作:

> Four redirects, not five. `system/permissions` is **deliberately absent** as of `origin/main` … The maintainer has since ruled **A — `sys_permission_set`** on objectui#3655; that redirect is queued but **not yet on `main`**, so today the URL still falls through to app-shell's tail route. Check `apps/console/src/AppContent.tsx` before quoting this list.

即:陈述现状 + 记录已裁方向 + 给出自查指令,`sys_permission_set` 落地后这段只需删掉「not yet」那半句,不会与在途 PR 打架。

## 四、参考装配定位(引 cccdf84d7)

开头新增引用块:cccdf84d7 把 shell / layout / home / 导航 / 整个 metadata admin 搬进 `@object-ui/app-shell`,designer 页搬进 `@object-ui/plugin-designer`,`apps/console` 只剩薄宿主。两条可执行推论:**先在 `packages/app-shell` 找**;**第三方 fork 的是模板不是本 app**。

模板路径以实测为准:cccdf84d7 建的是 `apps/console-starter`,今天在 **`examples/console-starter`**(`apps/` 下只有 `console` 与 `site`),故 guide 引后者。

## 五、eval 同步(本单的牙)

**先测量消费方式**:全仓 `scripts/` / `.github/` / `package.json` / `turbo.json` 对 `evals` 的引用 **零命中** —— 本仓**没有** eval runner,`skills/objectui/README.md` 只说这个形状「so the prompts can be run as machine-checkable regression tests」。故校验方式是:**逐字段人工核对 + 一个一次性核对脚本**(写在 scratchpad,未进提交),规则见下。

eval diff:

| 位置 | 改前 | 改后 | 理由 |
|---|---|---|---|
| eval 1 `expected_output` | 「…automatically appears in SystemHubPage and **MetadataManagerPage**」 | 讲引擎已自带 list/create/edit/history,UI 侧只是可选的 `registerMetadataResource()` 覆盖 | issue 正文点名的 `:7`,幽灵组件名被烤进期望答案 |
| eval 1 `must_contain` | `MetadataTypeRegistry`, `columns`, `formFields`, `SystemHubPage` | `registerMetadataResource`, `listColumns`, `createFields`, `metadata-admin`, `navigation` | `MetadataTypeRegistry` 零命中;`columns`/`formFields` 是幽灵接口的字段名;`SystemHubPage` 是 `@deprecated` 面,不该作为正确答案的必要条件 |
| eval 1 `must_not_contain` | `new standalone page`, `/system/objects` | 追加 `registerMetadataType`, `pageSchemaFactory` | 让**照旧指南生成的答案机械判错**,而不只是「不加分」 |
| eval 1 `prompt` | 「should show in the system hub」 | 「reachable from the admin navigation」 | 不把已废弃的卡片墙写进题面 |
| eval 2 `must_contain` | `pageSchemaFactory`, `registerWidgets`, `MetadataDetailPage`, `tabs` | `ComponentRegistry`, `SchemaRenderer`, `EditPage`, `registerMetadataResource` | 前三个全是零命中的幽灵。**额外发现**:`registerWidgets` 连**改前的 guide 里也不存在**(真实文件名是 `registerObjectDetailWidgets.ts`,不含该子串)—— 这条断言从来就无法从指南得到满足 |
| eval 2 `must_not_contain` | `[]` | `pageSchemaFactory` | 同上,补牙 |
| eval 3 | 未动 | 未动 | 实测 `NavigationContext` / `ConsoleLayout` / `HomeLayout` / `UnifiedSidebar` **四个符号今天都真实存在**,只是搬到了 `packages/app-shell`。eval 断言的是答案里的符号名,不是路径,故该 eval 未被这次漂移污染 —— 如实不动 |

**为什么 `MetadataManagerPage` / `MetadataDetailPage` 没进 `must_not_contain`**:一个**正确**答案完全可能顺口说一句「旧的 `MetadataDetailPage` 已删」,把它列成反模式会造成假红。改用正向断言把牙做足:照旧指南生成的答案会**同时**丢掉 `registerMetadataResource` / `EditPage`(must_contain 未满足)并命中 `pageSchemaFactory`(反模式),两条独立失败,已足够。这条取舍在此写明,免得下一个读者以为是漏了。

## 六、纠错锚 + grep 计数(改前先量,#3656 措辞纪律)

新增「### Retired names — do not import these」小节,每个被删名字**保留原名 + 紧跟判词与活体替代物**。#3656 的教训是「措辞会改变 grep 结果,要先预测」—— 这里方向与 #3656 **相反**:那次目标是 grep **归零**,这次刻意**不归零**,而是收敛到「只在纠错锚里出现一次」,好让 grep 这些名字的 agent 一定落到判词上。

改前 / 改后计数(guide 内出现次数):

| 名字 | 改前 | 改后 | 位置 |
|---|---|---|---|
| `MetadataManagerPage` | 4 | **1** | 纠错锚 |
| `MetadataDetailPage` | 5 | **1** | 纠错锚 |
| `UserManagementPage` | 1 | **1** | 纠错锚 |
| `RoleManagementPage` | 1 | **1** | 纠错锚 |
| `PermissionManagementPage` | 1 | **1** | 纠错锚 |
| `metadataTypeRegistry` | 2 | **1** | 纠错锚 |
| `MetadataTypeConfig` | 2 | **1** | 纠错锚 |
| `registerMetadataType` | 2 | **1** | 纠错锚 |
| `pageSchemaFactory` | 3 | **1** | 纠错锚 |
| `listComponent` | 2 | **1** | 纠错锚 |
| `MetadataListComponentProps` | 1 | **1** | 纠错锚 |

计数脚本的一处自身缺陷已修正并记录:`MetadataTypeConfig` 是 `getMetadataTypeConfig` 的**子串**,两者同在纠错锚同一行,裸计数会读成 2 —— 已在脚本里扣掉这层重叠,计的是「独立提及数」。

## 七、逆向验证(先预测,后运行)

**预测**:把 `origin/main` 的旧 guide + 旧 eval 放回去,核对脚本应**转红**,且红点必须落在(a) 旧 eval 的 must_contain 解析不到真实代码;(b) 纠错锚小节不存在;(c) 每个被删名字在锚外出现,次数应与上表「改前」列**逐条相等**;(d) 目录树名字集合 ≠ 真实文件集合。

**实测**(`git show origin/main:` 取回两文件,`apps`/`packages` 软链到本树):**23 项 FAIL**,逐条吻合:

```
FAIL  eval 2 must_contain "registerWidgets" appears in the guide
FAIL  eval 1 must_contain "MetadataTypeRegistry" resolves to real code (0 file(s))
FAIL  eval 2 must_contain "pageSchemaFactory" resolves to real code (0 file(s))
FAIL  eval 2 must_contain "MetadataDetailPage" resolves to real code (0 file(s))
FAIL  correction-anchor section exists
FAIL  retired "MetadataManagerPage": total=4 inAnchor=0 outsideAnchor=4 (want 1/1/0)
FAIL  retired "MetadataDetailPage": total=5 inAnchor=0 outsideAnchor=5 (want 1/1/0)
FAIL  retired "pageSchemaFactory": total=3 inAnchor=0 outsideAnchor=3 (want 1/1/0)
FAIL  pages/system/AiPendingActionsPage.tsx is listed in the guide tree
FAIL  tree names === real files
```

改后同一脚本:**ALL CHECKS PASSED**(87 项)。

## 八、门禁与 changeset 判断

- `node scripts/check-control-bytes.mjs` -> `OK (scanned 3684 tracked text file(s); skipped 85 binary)`
- 越过门禁盲区自扫两文件:`grep -naP` 控制字符类 -> 无命中(退出码 1)
- `JSON.parse(evals/console-development.json)` -> OK;与其余 10 个 eval 文件的键集合**逐一比对一致**(`skill_name,evals` / `id,prompt,expected_output,files,assertions` / `must_contain,must_not_contain`),`must_contain` 条数在 README 规定的 3–6 之间
- 英文单一性(SKILL.md 核心原则 0):两文件均无 CJK 字符,脚本已断言

**无 changeset,判断依据实测**:`skills/` 下**没有任何 package.json**;根 `package.json` 是 `private: true` 且**无 `files` 字段**;39 包固定版本组里没有任何包把 `skills` 列进 `files`。`skills-lock.json` 只是把 `objectui` 指到本地路径供 skills CLI 消费,不参与 npm 发布。即 skills/ **不是发布面**,本次改动对任何包产物零 delta。与 PR #3656(`scripts/` 非发布包 -> 无 changeset)同一判据。

## 九、围栏

- ⛔ **未碰** `apps/console` 任何源码、`ROADMAP.md`、`content/docs/releases/`。
- ⛔ **未碰** #3655 permissions 腿的文件面(`AppContent.tsx` / `SystemHubPage.tsx`)—— 与其在途 PR 零文件相交。
- 本 guide 的**其余章节**仍有同源(cccdf84d7)路径漂移,**不在本单文件面授权的处置清单内,故未改**,已另立单(见下)。

## 十、越界发现(只报不改)

立单时命中 GitHub API 速率限制,单号待补(内容如下,PM 可代立或本 session 稍后补立):

1. 同一 guide 的「Key contexts」「Key hooks」「UnifiedSidebar」三处仍把 5 + 7 + 1 个**真实存在**的符号指到 `apps/console/src/{context,hooks,components}/` —— `apps/console/src/context/` 这个目录**整个不存在**,`hooks/` 下只剩 `useBranding.ts`,`UnifiedSidebar.tsx` 在 `packages/app-shell/src/layout/`。符号活着、路径全死,与本单同源(cccdf84d7)但属不同章节,故未在本 PR 中改。另:「Registered custom widgets」表列 6 个,`registerObjectDetailWidgets.ts` 实注册 **7** 个(缺 `object-keys`)。
2. `apps/console/src/schemas/objectDetailPageSchema.ts` 的 `buildObjectDetailPageSchema()` 全仓**零调用者**(唯一调用者正是被删的 `MetadataDetailPage`),其 7 个 widget 仍由 `main.tsx` 注册。休眠代码,观察类(`finding`)。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_