### PR TITLE
docs(ROADMAP): P1.12/P1.16 的 MetadataManagerPage 铺与 Total 计数按现实改写 (#3712)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -855,21 +855,21 @@ ObjectUI is a universal Server-Driven UI (SDUI) engine built on React + Tailwind
 - [x] `/system/` → SystemHubPage
 - [x] `/system/apps` → AppManagementPage
 - [ ] `/system/permissions` — no route is declared at this URL; the `PermissionManagementPage` it named was deleted when `apps/console` was slimmed for third-party customisation (commit cccdf84d), and the successor surface is pending maintainer decision, see #3655
-- [x] `/system/metadata/:metadataType` → MetadataManagerPage (generic, registry-driven)
+- [x] `/system/metadata/:metadataType` — the URL still resolves, but as a legacy alias: its route element is `MetadataRedirect` (`apps/console/src/AppContent.tsx`), which forwards in one hop to the metadata-admin engine's own `metadata/:type`. The `MetadataManagerPage` named here has zero files and zero references under `apps/console/src/`; the generic, registry-driven list that route lands on is `MetadataResourceListPage` (`packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx`), mounted by `packages/app-shell/src/console/AppContent.tsx` (#3639)
 
 **Unified Metadata Management (P1.12.3):**
 - [x] Metadata type registry (`config/metadataTypeRegistry.ts`) — centralized config for all metadata types
-- [x] Generic `MetadataManagerPage` for listing/managing items of any registered type
+- [x] Generic `MetadataManagerPage` for listing/managing items of any registered type — shipped, then deleted when `apps/console` was slimmed for third-party customisation. The generic list is now `MetadataResourceListPage` (`packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx`), driven by the engine's own `MetadataResourceRegistry` (`registry.ts` in that directory) rather than by a console-side config, and it covers every registered metadata type from one shell
 - [x] SystemHubPage auto-generates metadata type cards from registry (dashboard, page, report)
 - [x] Dynamic `/system/metadata/:metadataType` routes in all route contexts
 - [x] Generic `MetadataService` methods: `getItems()`, `saveMetadataItem()`, `deleteMetadataItem()`
 - [x] Types with custom pages (`app`, `object`) link to existing dedicated routes
 - [x] Legacy routes preserved — no breaking changes
-- [x] 40+ new tests (registry, MetadataManagerPage, MetadataService generic, SystemHubPage registry)
+- [x] New tests for the registry-driven metadata surface — no total is carried here, because none of the four suites named survives in that form: the `MetadataManagerPage` and `config/metadataTypeRegistry.ts` suites went with the code they covered, `MetadataService` has no test file in the tree at all, and `SystemHubPage`'s remaining suites test its two hand-written cards, not registry-generated ones. What covers this surface today is the metadata-admin engine's own tests under `packages/app-shell/src/views/metadata-admin/`, plus the console's hub-card and legacy-redirect suites under `apps/console/src/`
 
 **Tests:**
 - [x] New tests for the system pages — of the three suites named here, only `SystemHubPage`'s is still in the tree; nothing tests `AppManagementPage` today, and `PermissionManagementPage` has no tests because the page itself is gone (commit cccdf84d)
-- [x] Total: 20 system page tests passing
+- [x] The system page suites that remain are green — no total is carried here: "system page tests" has no fixed referent, the suites being split across `apps/console` and `packages/app-shell`, and the count this line used to state matched neither the narrow reading (`apps/console/src/pages/system/__tests__/`) nor the wide one (that directory plus the console's system-hub route suite). Measure the group you mean instead of trusting a number written down once, see #3712
 
 ### P1.13 Airtable Grid/List UX Optimization ✅
 
@@ -996,8 +996,8 @@ Enterprise-grade visual designers for managing object definitions and configurin
 **MetadataDetailPage & Provider Enhancements:**
 - [x] Auto-redirect for custom page types (object → `/system/objects/:name`) — removed; object now uses metadata pipeline
 - [x] `getItemsByType(type)` method on MetadataProvider for dynamic registry access
-- [x] Object type merged into MetadataManagerPage pipeline — `ObjectManagerPage` removed, replaced by `ObjectManagerListAdapter` via `listComponent` extension point
-- [x] `listComponent` extension point on MetadataTypeConfig for injecting custom list UIs
+- [x] Object type merged into the generic metadata pipeline — `ObjectManagerPage` removed (only stale docblock mentions of it remain, in the two `utils/metadataConverters.ts`). Neither vehicle named here survived the move onto the metadata-admin engine: `ObjectManagerListAdapter` has zero hits, and `object` needs no custom list at all — it is listed by the engine's generic shell, configured by `registerMetadataResource({ type: 'object', … })` in `packages/app-shell/src/services/builtinComponents.tsx`
+- [x] Per-type override slot for injecting a custom list UI — `listComponent` on `MetadataTypeConfig` went with that console-side registry (both names have zero hits today). The engine's equivalent is `ListPage` on `MetadataResourceConfig` (`packages/app-shell/src/views/metadata-admin/registry.ts`), which bypasses the generic shell for one type; `datasource` is the only type overriding it
 - [x] All entry points (sidebar, QuickActions, hub cards) unified to `/system/metadata/object`
 
 **Technical Debt Cleanup:**


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3712

基线 `origin/main` @ `4e93e40d7`(单据写的 `36bf20235` 已走远,分诊复核点 `0cf8f0f7` 亦已走远;四行的行号与内容在本取点仍逐字命中,详见下表)。仅改 `ROADMAP.md` 一个文件,6 增 6 删。

## 一、前提复核(逐条,按裁定「读它引用的代码,别猜」)

| ROADMAP 行 | 原文断言 | 本取点实测 |
|---|---|---|
| :858 | `/system/metadata/:metadataType` → MetadataManagerPage | 该 URL 的 route element 是 `MetadataRedirect`(`apps/console/src/AppContent.tsx:190`),一跳转到引擎自己的 `metadata/:type`;`MetadataManagerPage` 在 `apps/console/src/` 下**零文件零引用**(控制探针 `MetadataRedirect` 同路径 6 命中,扫描面正常) |
| :862 | Generic `MetadataManagerPage` 列出任意已注册类型 | 通用列表现为 `MetadataResourceListPage`(`packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx`),由引擎自己的 `MetadataResourceRegistry`(同目录 `registry.ts`)驱动,挂载在 `packages/app-shell/src/console/AppContent.tsx:641` |
| :868 | 40+ new tests(registry / MetadataManagerPage / MetadataService generic / SystemHubPage registry) | 四套**无一以该形态存活**:`MetadataManagerPage` 与 `config/metadataTypeRegistry.ts` 随代码同去(两者均零命中);`MetadataService*test*` 全仓零文件;`SystemHubPage` 现存两套测的是它**手写的两张卡**(`SystemHubPage.tsx:174-189` 注明 per-type 卡片已随引擎自动列举而移除),不是注册表生成的卡 |
| :872 | Total: 20 system page tests passing | 窄读 `pages/system/__tests__/` = 9 + 4 = **13**,宽读併入 `AppContent.systemHubRoutes` 的 5 = **18**,皆非 20 —— 单据的两个数字均复现 |
| :999 | ObjectManagerPage 被 `ObjectManagerListAdapter` 经 `listComponent` 取代 | `ObjectManagerPage` 确已删除(仅两处 `utils/metadataConverters.ts` 的陈旧 docblock 提及);但 `ObjectManagerListAdapter`、`listComponent`、`MetadataTypeConfig`、`MetadataDetailPage`、`pageSchemaFactory` **全仓零命中**。`object` 今天由引擎通用外壳列出,配置见 `packages/app-shell/src/services/builtinComponents.tsx:60` 的 `registerMetadataResource({ type: 'object', … })`,**不需要任何自定义列表组件** |

结论:单据前提**成立**,且比标题所述更宽——:999 的两个「载体」名字都不存在,不只是换了实现。

## 二、越界一行,已声明:连改紧邻的 :1000

裁定的围栏是 `:858 / :862 / :868 / :999`。但 :1000 原文 `listComponent extension point on MetadataTypeConfig for injecting custom list UIs` 与 :999 是**同一句话的后半**、同一个零命中符号;只改 :999 会让它紧接着自相矛盾 —— 正是裁定第 1 条列为不可接受的形态。故一并改写,并在此明示越界范围为 ROADMAP.md 内 1 行。引擎侧的等价插槽是 `MetadataResourceConfig.ListPage`(`packages/app-shell/src/views/metadata-admin/registry.ts:116`),今天只有 `datasource` 覆写它(`datasource/register.ts:30`)。

## 三、:872 不种新计数

按裁定第 2 条与 :871 / PR #3705 先例:改写为不含硬编码数字的表述,并把「指称本身没定义」这件事写进条目本身、提示读者按需自行度量。**没有写入 13,也没有写入 18** —— 种下 13 只是把同一个陷阱重新上膛。

## 四、手法(#3700 / PR #3705,裁定第 3 条)

条目一律**不删**;`[x]` 保留(里程碑确实以另一形态交付过,同 :866 audit-log 一行的处理);错误名保留作**纠错锚**、判词紧跟其后(同 PR #3714 对 `PermissionManagementPage` 的处理),便于日后 grep;引用只挂**裸文本编号**(`#3639`、`#3712`),不加 markdown 链接;全程零新增硬编码计数。

## 五、门禁(裁定第 4 条,含版本号 prose 规则)

- `node scripts/check-control-bytes.mjs` → `OK (scanned 3686 tracked text file(s))`;另做超出门禁的自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' ROADMAP.md` → 无命中,`file ROADMAP.md` 仍报 UTF-8 text。
- `node scripts/check-doc-links.mjs` → `Links are valid across 7 scan roots.`。`ROADMAP.md` **在**该门禁的 disk 面上(`scripts/check-doc-links.mjs:397`),故本次改写只用裸文本编号、不新增任何链接。
- 版本号 prose 门禁:`scripts/__tests__/doc-version-claims.test.ts:112` 的 `SCAN_ROOTS = ['content/docs', 'packages/*/README.md']` —— **`ROADMAP.md` 不在其扫描面上**(即该门禁自述的「residual hole」)。仍按规则**未写入任何版本号字面量**,并实跑该测试确认绿:`doc-version-claims.test.ts` + `check-doc-links.test.ts` → `Test Files 2 passed / Tests 88 passed`。
- 被 :872 指称的套件实跑:`apps/console/src/pages/system/__tests__` + `AppContent.systemHubRoutes` + `AppContent.legacyRedirects` → `Test Files 4 passed / Tests 35 passed`。

## 六、Changeset:无

对齐 PR #3714 与 PR #3705 —— 两者的 `--stat` 均只含 `ROADMAP.md`、无 `.changeset/` 条目。`ROADMAP.md` 是根级文档、不属任何发布包,无用户可见的包变更。`check-changeset-fixed.mjs` / `check-changeset-no-major.mjs` 均绿。

## 七、围栏外的残余(只报不改,另立单)

同两节里**不属** MetadataManagerPage / listComponent 这一族的失实条目未动:P1.12.3 的 :861(`config/metadataTypeRegistry.ts` 零命中)、:863(注册表生成卡片)、:864(动态路由现为 legacy alias)、:866(`object` 已无专属路由);:1001(入口统一到 `/system/metadata/object`);以及 P1.16 的 **Metadata Manager Grid Mode** 整块 :987-:990(`listMode`、`MetadataGrid` 全仓零命中)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_