### PR TITLE
docs(skills): 把 console-development.md 三处表/节里 13 个符号的路径钉回真实位置 (#3730)

### DIFF
--- a/skills/objectui/guides/console-development.md
+++ b/skills/objectui/guides/console-development.md
@@ -243,7 +243,9 @@ export function buildObjectDetailPageSchema(objectName: string, item?: any): Pag
 
 ### Registered custom widgets
 
-`apps/console/src/components/schema/registerObjectDetailWidgets.ts` registers:
+`apps/console/src/components/schema/registerObjectDetailWidgets.ts` registers seven types
+(its own docblock lists the same seven — count the `ComponentRegistry.register()` calls if
+this table and the file ever disagree):
 
 | Widget type | Component | Purpose |
 |------------|-----------|---------|
@@ -251,6 +253,7 @@ export function buildObjectDetailPageSchema(objectName: string, item?: any): Pag
 | `object-properties` | `ObjectPropertiesWidget` | Object config form (name, label, icon, etc.) |
 | `object-field-designer` | `ObjectFieldDesignerWidget` | Interactive field CRUD |
 | `object-relationships` | `ObjectRelationshipsWidget` | Relationships & foreign keys |
+| `object-keys` | `ObjectKeysWidget` | Key fields card — unique, `id`, and external-id fields |
 | `object-data-experience` | `ObjectDataExperienceWidget` | Data experience config |
 | `object-data-preview` | `ObjectDataPreviewWidget` | Data preview table |
 
@@ -307,7 +310,8 @@ registerMetadataResource({
 
 ### UnifiedSidebar
 
-`apps/console/src/components/UnifiedSidebar.tsx` — Airtable-style contextual sidebar:
+`packages/app-shell/src/layout/UnifiedSidebar.tsx` (same directory as `ConsoleLayout.tsx`)
+— Airtable-style contextual sidebar:
 
 - **Persistent** across all routes (embedded in AppShell)
 - **Context-aware**: shows different items based on `NavigationContext` (`'home'` vs `'app'`)
@@ -315,7 +319,7 @@ registerMetadataResource({
 
 ### NavigationContext
 
-`apps/console/src/context/NavigationContext.tsx`:
+`packages/app-shell/src/context/NavigationContext.tsx`:
 
 ```typescript
 type NavigationContextType = 'home' | 'app';
@@ -389,15 +393,21 @@ system/users                        -> SystemObjectRedirect -> …/sys_user
 system/organizations                -> SystemObjectRedirect -> …/sys_organization
 system/roles                        -> SystemObjectRedirect -> …/sys_position
 system/positions                    -> SystemObjectRedirect -> …/sys_position
+system/permissions                  -> SystemObjectRedirect -> …/sys_permission_set
 ```
 
-Four redirects, not five. `system/permissions` is **deliberately absent** as of
-`origin/main`: the framework splits what this console called "Permissions" into
-`sys_capability` (the definition registry) and `sys_permission_set` (the grant container),
-so PR #3673 declined to guess and pinned the unchanged landing in a test instead. The
-maintainer has since ruled **A — `sys_permission_set`** on objectui#3655; that redirect is
-queued but **not yet on `main`**, so today the URL still falls through to app-shell's tail
-route. Check `apps/console/src/AppContent.tsx` before quoting this list.
+All five legs resolve on `origin/main`. `system/permissions` was the last one declared, and
+its history is worth knowing before you touch it: the framework splits what this console
+called "Permissions" into `sys_capability` (ADR-0066 layer 1, the definition registry of
+"what can be done") and `sys_permission_set` (layer 2, the grant container), so PR #3673
+declined to guess and pinned the then-unchanged landing in a test instead. The maintainer
+ruled **A — `sys_permission_set`** on objectui#3655 and PR #3728 declared the route. The
+target is layer 2 because the hub card that emits the URL promises "permission rules and
+assignments", and a definition catalog is what a set references by name, not what you
+assign. The route block in `apps/console/src/AppContent.tsx` carries that reasoning in full
+(including one reading of the two objects that does *not* survive a re-read of the
+framework) — read it there rather than re-deriving it, and re-read this list against the
+file if you are about to add a sixth leg.
 
 Two traps worth internalising, both paid for in objectui#3639 / #3655:
 
@@ -413,26 +423,40 @@ Two traps worth internalising, both paid for in objectui#3639 / #3655:
 
 ## Key contexts
 
+All five live in `@object-ui/app-shell`; there is no `apps/console/src/context/` directory
+at all. app-shell keeps **two** sibling directories, `context/` and `providers/`, and these
+five are split across both — so the prefix differs per row. Check the row; do not shift one
+prefix across the table.
+
 | Context | Location | Purpose |
 |---------|----------|---------|
-| `AdapterProvider` | `context/AdapterProvider.tsx` | ObjectStackAdapter lifecycle, connection management |
-| `MetadataProvider` | `context/MetadataProvider.tsx` | Apps, objects, dashboards, reports from API |
-| `NavigationContext` | `context/NavigationContext.tsx` | Home vs App sidebar context |
-| `FavoritesProvider` | `context/FavoritesProvider.tsx` | User's starred/pinned items |
-| `ExpressionProvider` | `context/ExpressionProvider.tsx` | Expression evaluator instance |
+| `AdapterProvider` | `packages/app-shell/src/providers/AdapterProvider.tsx` | ObjectStackAdapter lifecycle, connection management |
+| `MetadataProvider` | `packages/app-shell/src/providers/MetadataProvider.tsx` | Apps, objects, dashboards, reports from API |
+| `NavigationContext` | `packages/app-shell/src/context/NavigationContext.tsx` | Home vs App sidebar context |
+| `FavoritesProvider` | `packages/app-shell/src/context/FavoritesProvider.tsx` | User's starred/pinned items |
+| `ExpressionProvider` | `packages/app-shell/src/providers/ExpressionProvider.tsx` | Expression evaluator instance |
+
+`MetadataProvider` is the one name with two hits in the repo. The console's is the
+app-shell file above — it is what `ConsoleShell` / `ConnectedShell` mount and what
+`@object-ui/app-shell` re-exports. `packages/providers/src/MetadataProvider.tsx` is an
+unrelated, much smaller generic provider (static metadata or one fetch); nothing in the
+console path uses it.
 
 ## Key hooks
 
+`useBranding` is the **only** file in `apps/console/src/hooks/`. The other seven live in
+`@object-ui/app-shell`, so the first row's prefix does not generalise to the rest.
+
 | Hook | Location | Purpose |
 |------|----------|---------|
-| `useBranding` | `hooks/useBranding.ts` | AppShell brand colors/logo |
-| `useFavorites` | `hooks/useFavorites.ts` | Starred items state |
-| `useMetadataService` | `hooks/useMetadataService.ts` | CRUD operations on metadata |
-| `useNavPins` | `hooks/useNavPins.ts` | Pinned navigation items |
-| `useNavigationSync` | `hooks/useNavigationSync.ts` | URL ↔ navigation context sync |
-| `useObjectActions` | `hooks/useObjectActions.ts` | Custom actions on objects |
-| `useRecentItems` | `hooks/useRecentItems.ts` | MRU tracking |
-| `useResponsiveSidebar` | `hooks/useResponsiveSidebar.ts` | Sidebar collapse on mobile |
+| `useBranding` | `apps/console/src/hooks/useBranding.ts` | AppShell brand colors/logo |
+| `useFavorites` | `packages/app-shell/src/hooks/useFavorites.ts` | Starred items state |
+| `useMetadataService` | `packages/app-shell/src/hooks/useMetadataService.ts` | CRUD operations on metadata |
+| `useNavPins` | `packages/app-shell/src/hooks/useNavPins.ts` | Pinned navigation items |
+| `useNavigationSync` | `packages/app-shell/src/hooks/useNavigationSync.ts` | URL ↔ navigation context sync |
+| `useObjectActions` | `packages/app-shell/src/hooks/useObjectActions.ts` | Custom actions on objects |
+| `useRecentItems` | `packages/app-shell/src/hooks/useRecentItems.ts` | MRU tracking |
+| `useResponsiveSidebar` | `packages/app-shell/src/hooks/useResponsiveSidebar.ts` | Sidebar collapse on mobile |
 
 ## Common console development patterns
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3730

单文件改动：`skills/objectui/guides/console-development.md`。四项路径订正 + 一处授权搭改。
所有替换后的 Location 都由本分支自己在 `origin/main` 上跑 `find`/`ls` 逐条核过，未照抄卡片
（卡片自己也提醒过这个映射不是整体平移一层前缀）。基线 `origin/main` @ `4e93e40d7`（PR #3729
刚重写过本文件，卡内行号已失效，全部按内容锚定）。

## 一、Key contexts 表（5 行全改）

`apps/console/src/context/` 这个目录整个不存在。五个符号都在 `@object-ui/app-shell`，但
app-shell 内部有 `context/` 与 `providers/` 两个平级目录，五个符号分散在两边 —— 所以表头
新增一句说明「按行核前缀，不要整表平移」，避免下一位读者把它当成统一前缀。

| Context | 改后 Location |
|---|---|
| `AdapterProvider` | `packages/app-shell/src/providers/AdapterProvider.tsx` |
| `MetadataProvider` | `packages/app-shell/src/providers/MetadataProvider.tsx` |
| `NavigationContext` | `packages/app-shell/src/context/NavigationContext.tsx` |
| `FavoritesProvider` | `packages/app-shell/src/context/FavoritesProvider.tsx` |
| `ExpressionProvider` | `packages/app-shell/src/providers/ExpressionProvider.tsx` |

`MetadataProvider` 是全仓唯一重名的一个，表后加了一句消歧：console 用的是 app-shell 那个
（`ConsoleShell` / `ConnectedShell` 挂载它、`@object-ui/app-shell` 再导出它，已核 import
与 barrel），`packages/providers/src/MetadataProvider.tsx` 是另一个无关的通用 provider。

## 二、Key hooks 表（8 行里改 7 行）

`useBranding` 是 `apps/console/src/hooks/` 里**唯一**一个文件，也恰好是表里唯一正确的一行；
其余七个都在 `packages/app-shell/src/hooks/`。同样加了一句说明，免得第一行的前缀被外推。

## 三、UnifiedSidebar / NavigationContext 两个小节的开篇路径

- `### UnifiedSidebar`：`apps/console/src/components/UnifiedSidebar.tsx` 改为
  `packages/app-shell/src/layout/UnifiedSidebar.tsx`（并注明与 `ConsoleLayout.tsx` 同目录）。
  行为描述（persistent / context-aware / app switcher）按派发单只钉路径，未动。
- `### NavigationContext`：同小节群里还有第二处同类死路径
  `apps/console/src/context/NavigationContext.tsx`，与 Key contexts 表第三行是同一个符号、
  同一个不存在的目录，一并改为 `packages/app-shell/src/context/NavigationContext.tsx`。
  留着它等于把卡片自己列为错误的那个字符串原样留在文件里，故一并订正并在此单列说明。

改完全文只剩一处 `apps/console/src/context/` 字样，且是新写的否定句（「这个目录并不存在」），
是故意的。

## 四、Registered custom widgets 表补第七行

`registerObjectDetailWidgets.ts` 实际 `ComponentRegistry.register()` 七次，表里只列了六个，
缺 `object-keys` / `ObjectKeysWidget`。补上该行（用途按 `ObjectKeysWidget` 实现描述：unique /
`id` / external-id 字段），并把表头的 "registers" 写成 "registers seven types"，附一句「表与文件
不一致时数 register 调用」。此处原有的文件路径是对的，未动。

## 五、【授权搭改，单列】permissions 重定向段落已过期

派发单授权的同文件搭改。原文写着该重定向「queued but **not yet on `main`**，所以今天 URL 仍会
落到 app-shell 的 tail route」—— PR #3728（commit `cc95c2c31`）今天已合入 main，这句话现在是假的。
已核 `origin/main` 的 `apps/console/src/AppContent.tsx`：

```
system/permissions -> SystemObjectRedirect objectName="sys_permission_set"
```

改动两处：

1. 上方路由清单补第五条 `system/permissions -> SystemObjectRedirect -> …/sys_permission_set`。
2. 段落重写：删掉 "Four redirects, not five" 与 "not yet on main" / tail-route 兜底的描述，改成
   「五条腿在 `origin/main` 上都能解析」，保留 ADR-0066 layer 1 / layer 2 的由来（为什么最终选
   `sys_permission_set` 而不是 `sys_capability`），并把自查指针从「引用前先看一眼」改成「理由在
   AppContent.tsx 的路由注释里写全了，去那里读，别自己重推；要加第六条腿时再对一遍清单」。

## 与卡片事实的一处偏差（不影响本单前提）

卡片（及本 guide 顶部的注记）把这批符号的成因记为 commit `cccdf84d7`（console 瘦身）。
实测这 13 个符号都不是在 `cccdf84d7` 里搬走的：

- `AdapterProvider` / `MetadataProvider` / `ExpressionProvider` —— app-shell 副本由
  `c1e105793`（04-21）加入，console 副本由 `28ffe4033`（04-22）删除，两者都**早于** `cccdf84d7`。
- `NavigationContext` / `FavoritesProvider` / `UnifiedSidebar` / 七个 hooks —— app-shell 副本的
  加入与 console 副本的删除都发生在 `b279d80d6`（04-23），**晚于** `cccdf84d7` 一天。

即「路径全错」这个承重前提成立（已逐条复核），只是归因写错了。因此本 PR 的两处新写引言**不**
提任何成因 commit，只陈述今天的位置事实；顶部注记的归因不在本单文件面授权范围内（派发单明确
不动目录树与 Retired-names 锚点），另立 finding 记账。

## 验证

改动是纯 markdown 文档，无代码面、无可写的单元测试；相应地跑的是门禁 + 磁盘存在性断言：

- `node scripts/check-control-bytes.mjs` → `OK (scanned 3686 tracked text file(s))`
- 控制字节自查（超出门禁扫描面）：`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 本文件 → 无命中
- CJK 自查：本文件 0 行 CJK（英文正文约定未破）
- `node scripts/check-doc-links.mjs` → `Links are valid across 7 scan roots.`
  （注：`SCAN_ROOTS` 不含 `skills/`，本文件不在该门禁覆盖面内，跑它只为确认未连带破坏）
- 卡片的复核脚本原样重跑，结论与卡片一致：`apps/console/src/` 无 `context` 项、
  `apps/console/src/hooks/` 只有 `useBranding.ts`、`apps/console/src/components/` 无
  `UnifiedSidebar.tsx`、register 调用数 = 7
- 全文回归断言：抽出文件里所有反引号包裹的仓内路径逐个 `existsSync`，34 条命中 33 条存在，
  唯一「不存在」的就是第三节末尾说明的那句故意否定句
- 未改 `skills/objectui/evals/console-development.json`：已确认该 eval 不 pin 任何被我改动的
  字符串（`must_contain` 只要求出现 `UnifiedSidebar` 这个词，改动后仍在）

## Changeset

无。已核同类先例：PR #3729（`4e93e40d7`，本文件今日的重写）、`c19ddf027`、`91e03f466` 三个
skills-only 的 `docs(skills)` 提交都没有 `.changeset/` 条目 —— `skills/` 不是发布包，按仓内约定
不需要。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_