### PR TITLE
ci(docs): fail OPEN when the Build Docs path gate cannot compute its diff (#3723)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,12 @@ jobs:
       #
       # A failure inside this step means RUN, never SKIP. objectstack#4928 named
       # that the filter contract, after a filter job that skipped when it could
-      # not tell produced a fully green, zero-gate pull request; the `|| echo ""`
-      # in the `docs` job below is the fail-CLOSED spelling and is why that job's
-      # own gate is reported separately (see the PR).
+      # not tell produced a fully green, zero-gate pull request. Every gate in
+      # this workflow is spelled that way — including the `docs` job below, whose
+      # capture swallowed its own failure into an empty result until
+      # objectui#3723. `scripts/__tests__/merge-queue-reporting.test.ts` holds
+      # every `CHANGED=$(git diff …)` in this file and in `lint.yml` to the
+      # fail-open form, so a new gate cannot be added in the closed spelling.
       - name: Decide whether this change needs a full run
         id: relevant
         run: |
@@ -552,27 +555,46 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      # Fails OPEN: if the diff cannot be computed the job builds the site,
+      # rather than reporting green having built nothing (objectstack#4928).
+      # Until objectui#3723 this step swallowed a failed `git diff` into an empty
+      # result (`2>/dev/null || echo ""`), which is indistinguishable from
+      # "nothing docs-related changed" — a checkout that did not fetch deep
+      # enough, a transient git failure or a malformed sha skipped the whole
+      # site build and the job still reported success. Measured against a
+      # fixture repository: on an unreachable base sha the old spelling yielded
+      # `should_run=false`, this one yields `true`; on a reachable base sha both
+      # agree, so which pull requests pay for a site build is unchanged.
       - name: Check for docs changes
         id: docs-changes
         run: |
           # `!= pull_request` covers `push` and `merge_group` alike
           # (objectui#3523). A queue build has no `github.event.pull_request`,
-          # so the else-branch below would diff an empty revision range and
-          # skip the site build on the last check before `main`.
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          # so the diff below would run on an empty revision range — and that
+          # case is NOT caught by failing open: git reads a bare `...` as
+          # `HEAD...HEAD` and exits 0 with no output (measured), so it would
+          # skip the site build on the last check before `main`. This early
+          # return is what covers it.
+          if [ "${{ github.event_name }}" != 'pull_request' ]; then
+            echo 'should_run=true' >> "$GITHUB_OUTPUT"
+            echo 'Not a pull request: push is filtered at the trigger, and a merge_group build is the last validation before main. Building the site.'
+            exit 0
+          fi
+          if ! CHANGED=$(git diff --name-only \
+            '${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}' -- \
+            'apps/site/' \
+            'content/'); then
+            echo 'should_run=true' >> "$GITHUB_OUTPUT"
+            echo 'Could not diff against the merge base. Building the site rather than skipping silently.'
+            exit 0
+          fi
+          if [ -n "$CHANGED" ]; then
+            echo 'should_run=true' >> "$GITHUB_OUTPUT"
+            echo 'Docs-related files changed:'
+            echo "$CHANGED"
           else
-            # Check if docs-related files changed in this PR
-            CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} -- \
-              'apps/site/' 'content/' 2>/dev/null || echo "")
-            if [ -n "$CHANGED" ]; then
-              echo "should_run=true" >> "$GITHUB_OUTPUT"
-              echo "Docs-related files changed:"
-              echo "$CHANGED"
-            else
-              echo "should_run=false" >> "$GITHUB_OUTPUT"
-              echo "No docs-related files changed, skipping build"
-            fi
+            echo 'should_run=false' >> "$GITHUB_OUTPUT"
+            echo 'No docs-related files changed. Skipping the steps below; this check still reports.'
           fi
 
       - name: Enable Corepack

--- a/scripts/__tests__/merge-queue-reporting.test.ts
+++ b/scripts/__tests__/merge-queue-reporting.test.ts
@@ -111,6 +111,42 @@ const quotedEntries = (block: string): string[] =>
 const excludePathspecs = (yaml: string): string[] =>
   [...yaml.matchAll(/':\(exclude,glob\)([^']+)'/g)].map((m) => m[1]);
 
+/**
+ * Every line capturing a `git diff` into `CHANGED` — one per gate, trimmed.
+ *
+ * Lines rather than whole commands, because the fail-open decision is made
+ * entirely by how the capture OPENS: `if ! CHANGED=$(…` is what turns a nonzero
+ * `git diff` into `should_run=true`. A capture continued over further lines
+ * (every one of these is) still contributes exactly one entry, so the count is
+ * the number of gates.
+ *
+ * Callers must strip comments first (`withoutComments`) — both workflows now
+ * discuss this exact shape in prose, and counting the prose would report gates
+ * no job has.
+ */
+const diffCaptureLines = (yaml: string): string[] =>
+  yaml
+    .split('\n')
+    .filter((line) => /CHANGED=\$\(\s*git diff/.test(line))
+    .map((line) => line.trim());
+
+/**
+ * `file -> the jobs whose diff capture must fail open`.
+ *
+ * Hand-maintained for the same reason as `MUST_SUBSCRIBE_MERGE_GROUP`, and used
+ * only as a FLOOR: the assertion below checks the shape of every capture it
+ * finds, so a sixth gate is covered the moment it is written, while the floor is
+ * what makes DELETING one red. Without it, the shape check would pass an empty
+ * list — green because nothing was produced, not because anything is right.
+ */
+const FAIL_OPEN_GATES = new Map<string, readonly string[]>([
+  // `type-check`, `test` and `e2e` share `id: relevant` (objectui#3523 / PR
+  // #3722); `docs` has its own `id: docs-changes` and predates them (#3450),
+  // which is how it kept the fail-CLOSED spelling until objectui#3723.
+  ['ci.yml', ['type-check', 'test', 'e2e', 'docs']],
+  ['lint.yml', ['lint']],
+]);
+
 describe('every requirable context reports on a merge-queue build (#3523 step 1)', () => {
   it('subscribes merge_group in each workflow that produces one', () => {
     const missing = [...MUST_SUBSCRIBE_MERGE_GROUP.keys()].filter(
@@ -242,24 +278,66 @@ describe('every context reports on every pull request (#3523 step 2)', () => {
     }
   });
 
-  it('fails OPEN: a gate that cannot compute the diff runs everything', () => {
+  it('fails OPEN: EVERY gate that cannot compute the diff runs everything', () => {
     // The direction matters more than the code. objectstack#4928 named this the
     // filter contract after the opposite spelling — a diff whose failure was
     // swallowed into an empty result — produced a fully green pull request with
-    // no job having run and no red signal anywhere. `ci.yml`'s older `docs` gate
-    // still uses that fail-CLOSED spelling (`|| echo ""`); the gates added by
-    // objectui#3523 must not copy it.
+    // no job having run and no red signal anywhere.
+    //
+    // This assertion used to be a single `toMatch` per FILE, which is why it
+    // reported green while `ci.yml`'s `docs` gate was still fail-CLOSED
+    // (objectui#3723): the three gates PR #3722 added satisfied the regex on
+    // ci.yml's behalf, and a whole-file match cannot tell four captures from
+    // three plus a swallow. It is now per CAPTURE, so each gate answers for
+    // itself and a fifth spelled the closed way cannot hide behind the others.
     for (const file of FILTER_MOVED_INTO_JOBS) {
-      const yaml = read(file);
-      const gates = [...yaml.matchAll(/^\s*id: relevant$/gm)];
-      expect(gates.length, `${file} must still carry at least one \`id: relevant\` gate`).toBeGreaterThan(0);
+      const expected = FAIL_OPEN_GATES.get(file) ?? [];
+      const captures = diffCaptureLines(withoutComments(read(file)));
 
       expect(
-        yaml,
-        `${file}'s short-circuit swallows a failed \`git diff\` into an empty result, which reads ` +
-          `as "nothing relevant changed" and skips every gate. When the filter cannot tell, it ` +
-          `must RUN (objectstack#4928).`,
-      ).toMatch(/if ! CHANGED=\$\(git diff --name-only/);
+        captures.length,
+        `${file} declares ${captures.length} \`CHANGED=$(git diff …)\` captures, fewer than the ` +
+          `${expected.length} gates that must have one (${expected.join(', ')}). A gate whose diff ` +
+          `capture is gone either no longer filters at all, or filters by some other means this ` +
+          `test cannot check the direction of — and with none left, the shape assertion below ` +
+          `passes an empty list (objectui#3523, objectui#3723).`,
+      ).toBeGreaterThanOrEqual(expected.length);
+
+      const failClosed = captures.filter((line) => !line.startsWith('if ! CHANGED=$(git diff'));
+      expect(
+        failClosed,
+        `${file} captures a \`git diff\` without letting its failure mean RUN:\n` +
+          failClosed.map((line) => `  - ${line}`).join('\n') +
+          `\n\nEvery gate must open its capture as \`if ! CHANGED=$(git diff …); then\` and treat ` +
+          `the failure branch as should_run=true. Swallowing the failure instead — the ` +
+          `\`2>/dev/null || echo ""\` this file's \`docs\` job used until objectui#3723 — makes ` +
+          `"the diff could not be computed" indistinguishable from "nothing changed", so a ` +
+          `shallow checkout or a malformed sha skips the job's real work and still reports ` +
+          `success. When the filter cannot tell, it must RUN (objectstack#4928).`,
+      ).toEqual([]);
+    }
+  });
+
+  it('fails OPEN in effect, not only in shape: no gate swallows its diff failure', () => {
+    // `if !` is necessary but not sufficient. `if ! CHANGED=$(git diff … || echo
+    // "")` reads as fail-open and is not: `|| echo ""` makes the command succeed
+    // whatever git did, so the failure branch becomes unreachable and the gate is
+    // fail-CLOSED again with the safe spelling wrapped around it. Same for
+    // `2>/dev/null`, which additionally deletes git's own explanation of what
+    // went wrong from the run log — the one diagnostic a future reader gets.
+    for (const file of FILTER_MOVED_INTO_JOBS) {
+      const code = withoutComments(read(file));
+      for (const [shape, why] of [
+        [/\|\|\s*echo\s*""/, '`|| echo ""` makes the capture succeed even when git failed'],
+        [/2>\s*\/dev\/null/, '`2>/dev/null` hides why git failed'],
+      ] as const) {
+        expect(
+          code,
+          `${file} still contains ${why}. Both halves of the fail-CLOSED spelling objectui#3723 ` +
+            `removed must stay out: the gate's failure branch has to be reachable, and the run ` +
+            `log has to say what happened (objectstack#4928).`,
+        ).not.toMatch(shape);
+      }
     }
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3723

## 问题

`ci.yml` 的 `docs` job(`Build Docs`)用这一句决定要不要构建站点:

```sh
CHANGED=$(git diff --name-only BASE...HEAD -- 'apps/site/' 'content/' 2>/dev/null || echo "")
```

`2>/dev/null || echo ""` 把两件完全不同的事压成同一个空串:

- **diff 成功、`apps/site/` 与 `content/` 下确实没变** —— 该跳过,正确;
- **diff 根本算不出来** —— checkout 拉得不够深、git 偶发失败、sha 畸形 —— 同样得到空串,于是**整个站点构建被跳过,而 job 依然报 success**:没有红步骤,没有警告,summary 里也没有任何痕迹。check 说文档构建过了,实际什么都没构建。

objectstack#4928 把这条命名为 **filter 契约**:filter 拿不准的时候必须 RUN。PR #3722 给本 workflow 新加的四个门禁(`type-check` / `test` / `e2e` / `lint`)全是 fail-open 拼法,这一处成了唯一的例外。

## 改法(`.github/workflows/ci.yml`,docs job 一步)

捕获改成与那四个门禁**同一个**形状:`if ! CHANGED=$(git diff …); then should_run=true; exit 0; fi`,revision range 加单引号(畸形 sha 会作为**一个**参数递给 git 被拒,而不是被词法拆开),并沿用它们的说明性注释形状。

验证方式不是手抄一遍逻辑,而是**把这一步真实的 `run:` 脚本从解析后的 YAML 里取出来**、替换 `${{ … }}` 后在 fixture 仓库里执行:

| 场景 | 旧拼法 | 新拼法 |
|---|---|---|
| base sha 不可达(浅 checkout / 畸形 sha) | `should_run=false`(静默全跳) | `should_run=true`(Could not diff against the merge base) |
| 文档有改动,base 可达 | `true` | `true` |
| 只有代码改动,base 可达 | `false` | `false` |
| `merge_group` 队列构建 | `true` | `true` |
| push 到 main | `true` | `true` |

也就是说:**哪些 PR 需要付一次站点构建的代价没有变**,只有"算不出来"这一格从静默跳过翻成了运行。

测量中另外确认了两件事,都已写进步骤注释:

1. **fail-open 并不能覆盖空 revision range。** 没有 `github.event.pull_request` payload 时,range 会插值成一个裸的 `...`,git 把它读成 `HEAD...HEAD`,**exit 0 且无输出**(已实测)—— 所以覆盖队列与 push 两条 lane 的是 #3722 加的 `!= 'pull_request'` 提前返回,不是 diff 本身。这一条本来容易被当成冗余删掉。
2. **`2>/dev/null` 与 `|| echo ""` 一起删。** 它把 git 自己对失败原因的说明从 run log 里抹掉了,而那是"构建为什么被跳过"的读者唯一能拿到的诊断。

顺带修掉 `type-check` job 里那段注释:它原本写着"下面 `docs` job 的 `|| echo ""` 是 fail-CLOSED 拼法",本 PR 之后这句话就是错的——同一个文件里留一句与代码相反的断言,比不写更糟。

## 钉面(`scripts/__tests__/merge-queue-reporting.test.ts`)

原来的 fail-open 断言是**按文件**的一条 `toMatch`,所以它看不见 `docs` 这一处:ci.yml 里三个 fail-open 捕获替 `docs` 门禁满足了正则,整份文件带着缺陷仍然全绿(实测:改前的树上 10/10 通过)。现在改成**按捕获**:

- `ci.yml` / `lint.yml` 里每一处 `CHANGED=$(git diff …)`(先剥注释——两个 workflow 现在都在正文里讨论这个形状)都必须以 `if ! ` 开头;新加的第六个门禁写成 closed 拼法会立刻红,不需要有人记得来改这个测试;
- 每个文件配一个**下界**(ci.yml 4 个:`type-check` / `test` / `e2e` / `docs`;lint.yml 1 个:`lint`),否则"删掉某个门禁的捕获"会让上面那条断言拿到空列表——**因为什么都没产出而绿**,不是因为逻辑对;
- 另加一条:门禁里不得出现 `|| echo ""` 或 `2>/dev/null`。`if ! CHANGED=$(git diff … || echo "")` 形状上是 fail-open,实际不是——`|| echo ""` 让命令无论 git 如何都成功,失败分支不可达,等于把安全拼法套在 fail-closed 外面。

### 反向验证(方向先预测,后测量)

预测:把 ci.yml 的拼法回退到 origin/main,**恰好 2 条测试变红,9 条仍绿**(捕获**数量**仍是 4,下界那条应当保持绿)。实测一致:

```
Tests  2 failed | 9 passed (11)

FAIL  fails OPEN: EVERY gate that cannot compute the diff runs everything
AssertionError: ci.yml captures a `git diff` without letting its failure mean RUN:
  - CHANGED=$(git diff --name-only ${{ … }}...${{ … }} -- \

FAIL  fails OPEN in effect, not only in shape: no gate swallows its diff failure
AssertionError: ci.yml still contains `|| echo ""` makes the capture succeed even when git failed.
```

## 门禁

```
pnpm exec vitest run scripts/__tests__/merge-queue-reporting.test.ts  →  11 passed (11)
pnpm exec vitest run scripts/                                          →  20 files, 362 passed (362)
pnpm type-check:scripts                                                →  exit 0
node scripts/check-control-bytes.mjs                                   →  OK (3691 tracked text files)
```

`scripts/` 全跑是刻意的:`ci-cd-pipeline-doc.test.ts` 也读 `.github/workflows/`(按 job 与按命令两个方向钉 `content/docs/guide/ci-cd-pipeline.md` 的表格),本改动没有增删任何 first-party 命令,它保持绿。仓库里没有 workflow linter(`package.json` 与 `.github/workflows/` 均无 actionlint),所以 YAML 的合法性由上面那个"解析 YAML 取出 `run:` 再执行"的模拟顺带覆盖。

`content/docs/guide/ci-cd-pipeline.md` **不需要改**:它第 116 行本来就写着 "The gate fails **open** — if the diff cannot be computed the job runs everything",而那一段同时点了 `docs` job 的名。本 PR 之前这句话对 `docs` 是过度声明,之后才真正成立。

**无 changeset**:纯 CI 配置,无已发布包的行为变化——与 #3722 及它之前三个 `ci.yml` 提交(#3659 / #3547 / #3550)的先例一致。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_