### PR TITLE
fix(app-shell): sys-objects 的三个生产端直发规范 metadata 路由,不再绕 system/metadata 别名 (#3739)

### DIFF
--- a/.changeset/nav-sys-objects-canonical-route-3739.md
+++ b/.changeset/nav-sys-objects-canonical-route-3739.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Point the `sys-objects` navigation entries at the canonical metadata-admin route instead of the `system/metadata/object` alias, removing a redirect hop from each click (objectui#3739).
+
+`AppSidebar.systemFallbackNavigation`, `UnifiedSidebar.homeNavigation` and `console/home/QuickActions` all spelled this target `/apps/setup/system/metadata/object`. That is not a page: `apps/console`'s host fragment declares `system/metadata/:metadataType` with `MetadataRedirect` as its element, which immediately navigates on to `/apps/setup/metadata/object` — the engine's real route (`metadata/:type`, `MetadataResourceListPage`). Every click therefore paid a redundant hop plus a re-render to reach a destination the navigation could name directly. All three now name it.
+
+This is the same defect objectui#3660 fixed for `sys-datasources`, declared on the line immediately below `sys-objects` in both sidebar arrays. It was missed there because the two entries reached their aliases through different route tables — `sys-datasources` through app-shell's own `component/metadata/resource` alias, `sys-objects` through the host's `system/metadata/:type` rewrite.
+
+The landing page is unchanged, byte for byte: the new URL is exactly what the alias hop was already computing (`object` percent-encodes to itself, and no producer carried a query or hash). Only the intermediate hop is gone. Of the three producers, the two sidebars are live; `QuickActions` has no JSX call site today, so its change is a guard against the dead link returning with the component.
+
+The alias routes stay declared and untouched: bookmarks and external links still arrive on them and are still forwarded.

--- a/packages/app-shell/src/console/home/QuickActions.tsx
+++ b/packages/app-shell/src/console/home/QuickActions.tsx
@@ -36,7 +36,14 @@ export function QuickActions() {
       label: t('home.quickActions.manageObjects', { defaultValue: 'Manage Objects' }),
       description: t('home.quickActions.manageObjectsDesc', { defaultValue: 'Configure data models' }),
       icon: Database,
-      href: '/apps/setup/system/metadata/object',
+      // #3739 — the metadata-admin engine's CANONICAL route, not the legacy
+      // `…/system/metadata/object` alias this card used to carry. That alias is
+      // not a page: `apps/console`'s host fragment serves it with
+      // `MetadataRedirect`, a bare `<Navigate>` onto the URL below, so every
+      // click paid a redundant hop plus a re-render. Same defect and same
+      // remedy as #3660's `sys-datasources` entry in both sidebars. The alias
+      // routes stay for bookmarks and external links.
+      href: '/apps/setup/metadata/object',
       iconBg: 'bg-gradient-to-br from-violet-500/15 to-purple-500/10 ring-violet-500/20',
       iconText: 'text-violet-600 dark:text-violet-400',
       hoverBorder: 'hover:border-violet-500/40',

--- a/packages/app-shell/src/console/home/__tests__/QuickActions.settingsTarget.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/QuickActions.settingsTarget.test.tsx
@@ -24,6 +24,25 @@
  * Configured" empty state's own URL on a zero-app deployment. The card's
  * sibling ("Manage Objects") already spelled `/apps/setup/system/...`, which is
  * what made this one the odd entry out.
+ *
+ * ## The "Manage Objects" card (objectui#3739)
+ *
+ * That sibling's `/apps/setup/system/...` prefix is what made it the anchor for
+ * #3611 — and it was the wrong URL for a different reason, unnoticed at the
+ * time. `…/system/metadata/object` is not a page: `apps/console`'s host fragment
+ * serves it with `MetadataRedirect`, a bare `<Navigate>` onto
+ * `/apps/setup/metadata/object`, so the card bought a redundant hop plus a
+ * re-render. It is the third of the three producers #3739 re-points; the other
+ * two are the `sys-objects` entries in both sidebars
+ * (`layout/__tests__/systemNavSettingsTarget.test.tsx`).
+ *
+ * So the third case below is REWRITTEN, not extended: it used to assert this
+ * card as the untouched consistency anchor, and that premise is what #3739
+ * falsified. It now pins the canonical target — the same discipline as the
+ * sidebar suites, which replace the old shape rather than keeping the bug and
+ * the fix side by side. Whether that URL resolves in one hop is a property of
+ * the URL rather than of this producer, and is measured in
+ * `layout/__tests__/systemNavObjectsHop.test.tsx`.
  */
 
 import '@testing-library/jest-dom/vitest';
@@ -59,6 +78,9 @@ function renderQuickActions() {
 }
 
 const SYSTEM_HUB = '/apps/setup/system';
+
+/** Where the metadata-admin engine really serves the object list (objectui#3739). */
+const OBJECTS_TARGET = '/apps/setup/metadata/object';
 
 describe('QuickActions system-settings card (objectui#3611, dormant)', () => {
   it('DORMANCY PRECONDITION: nothing renders this component, so the fix is a guard, not a user-visible change', async () => {
@@ -99,12 +121,23 @@ describe('QuickActions system-settings card (objectui#3611, dormant)', () => {
     expect(screen.getByTestId('landing')).toHaveTextContent(SYSTEM_HUB);
   });
 
-  it('REGRESSION: the sibling card that was already hub-scoped is unchanged', async () => {
+  it('the Manage Objects card targets the canonical metadata route, not the system alias (objectui#3739)', async () => {
+    // Replaces #3611's "the sibling is unchanged" anchor. That assertion was
+    // true of the URL and wrong about it: `…/system/metadata/object` is an alias
+    // the host only forwards, so pinning it froze the extra hop in place.
     const user = userEvent.setup();
     renderQuickActions();
 
     await user.click(screen.getByTestId('quick-action-manage-objects'));
 
-    expect(screen.getByTestId('landing')).toHaveTextContent(`${SYSTEM_HUB}/metadata/object`);
+    expect(screen.getByTestId('landing')).toHaveTextContent(OBJECTS_TARGET);
+    // `toHaveTextContent` matches on substring, and neither spelling contains
+    // the other (`/apps/setup/system/metadata/object` has the extra segment in
+    // the MIDDLE), so the assertion above already separates them. This second
+    // one adds nothing to the logic and is kept for the diff: a revert then
+    // fails naming the alias, instead of reporting two similar-looking paths.
+    expect(screen.getByTestId('landing')).not.toHaveTextContent(
+      `${SYSTEM_HUB}/metadata/object`,
+    );
   });
 });

--- a/packages/app-shell/src/layout/AppSidebar.tsx
+++ b/packages/app-shell/src/layout/AppSidebar.tsx
@@ -316,7 +316,12 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
   // `/apps/setup` renders `AppContent`'s "No Apps Configured" empty state (its
   // `isSystemRoute` guard needs a `/system` segment), so the cluster's head entry
   // was a dead link in the one situation the cluster exists for. Every sibling
-  // below already spells `/apps/setup/system/...`.
+  // below already spelled `/apps/setup/system/...` — the two metadata-admin
+  // entries excepted, and only since: they name the engine's canonical
+  // `/apps/setup/metadata/:type` routes (#3660, #3739), because for THOSE two
+  // the `system/...` spelling is a redirect rather than a page. Consistency of
+  // prefix is not the invariant here; naming the route that actually renders
+  // is.
   const systemFallbackNavigation: NavigationItem[] = React.useMemo(() => {
     const items: NavigationItem[] = [
       { id: 'sys-settings', label: t('layout.systemNav.systemSettings', { defaultValue: 'System Settings' }), type: 'url' as const, url: '/apps/setup/system', icon: 'settings' },
@@ -326,7 +331,17 @@ export function AppSidebar({ activeAppName, onAppChange }: { activeAppName: stri
       items.push({ id: 'sys-marketplace', label: t('layout.systemNav.appMarketplace', { defaultValue: 'App Marketplace' }), type: 'url' as const, url: '/apps/setup/system/marketplace', icon: 'store' });
     }
     items.push(
-      { id: 'sys-objects', label: t('layout.systemNav.objectManager', { defaultValue: 'Object Manager' }), type: 'url' as const, url: '/apps/setup/system/metadata/object', icon: 'database' },
+      // #3739 — `sys-objects` names the metadata-admin engine's CANONICAL route
+      // `/apps/setup/metadata/object`, not the legacy
+      // `…/system/metadata/object` alias it used to carry. That alias is not a
+      // page either: `apps/console`'s host fragment declares it as
+      // `MetadataRedirect`, which `<Navigate>`s onto exactly the URL spelled
+      // here, so every click paid a redundant hop plus a re-render — the same
+      // defect #3660 fixed one line below, on the entry immediately after this
+      // one, and the same remedy. The alias routes stay declared in the host
+      // (bookmarks and external links still arrive on them) — we simply stop
+      // aiming our own navigation at them.
+      { id: 'sys-objects', label: t('layout.systemNav.objectManager', { defaultValue: 'Object Manager' }), type: 'url' as const, url: '/apps/setup/metadata/object', icon: 'database' },
       // #3660 — `sys-datasources` names the metadata-admin engine's CANONICAL
       // route `/apps/setup/metadata/datasource`, not the legacy
       // `…/component/metadata/resource?type=datasource` alias it used to carry.

--- a/packages/app-shell/src/layout/UnifiedSidebar.tsx
+++ b/packages/app-shell/src/layout/UnifiedSidebar.tsx
@@ -327,12 +327,22 @@ export function UnifiedSidebar({ activeAppName }: UnifiedSidebarProps) {
       // `/system` form resolves in BOTH branches (`extraRoutesNoApp` with no
       // active app, `extraRoutes` once one exists), so an app-bearing deployment
       // now reaches the hub here instead of whatever app `/apps/setup` fell back
-      // to. Every sibling below already spells `/apps/setup/system/...`.
+      // to. Every sibling below already spelled `/apps/setup/system/...` — the
+      // two metadata-admin entries excepted, and only since: they name the
+      // engine's canonical `/apps/setup/metadata/:type` routes (#3660, #3739),
+      // because for THOSE two the `system/...` spelling is a redirect rather
+      // than a page.
       const adminItems: NavigationItem[] = [
         { id: 'sys-settings', label: t('layout.systemNav.systemSettings', { defaultValue: 'System Settings' }), type: 'url' as const, url: '/apps/setup/system', icon: 'settings' },
         { id: 'sys-apps', label: t('layout.systemNav.applications', { defaultValue: 'Applications' }), type: 'url' as const, url: '/apps/setup/system/apps', icon: 'layout-grid' },
         { id: 'sys-marketplace', label: t('layout.systemNav.appMarketplace', { defaultValue: 'App Marketplace' }), type: 'url' as const, url: '/apps/setup/system/marketplace', icon: 'store' },
-        { id: 'sys-objects', label: t('layout.systemNav.objectManager', { defaultValue: 'Object Manager' }), type: 'url' as const, url: '/apps/setup/system/metadata/object', icon: 'database' },
+        // #3739 — canonical `…/metadata/object`, not the legacy
+        // `…/system/metadata/object` alias. See the twin entry in
+        // `AppSidebar.systemFallbackNavigation` for the full note: the alias is
+        // served by `apps/console`'s `MetadataRedirect`, a bare `<Navigate>`
+        // onto this very URL, so pointing here removes a hop without moving the
+        // landing page. The alias routes themselves are untouched.
+        { id: 'sys-objects', label: t('layout.systemNav.objectManager', { defaultValue: 'Object Manager' }), type: 'url' as const, url: '/apps/setup/metadata/object', icon: 'database' },
         // #3660 — canonical `…/metadata/datasource`, not the legacy
         // `…/component/metadata/resource?type=datasource` alias. See the twin
         // entry in `AppSidebar.systemFallbackNavigation` for the full note: the

--- a/packages/app-shell/src/layout/__tests__/systemNavObjectsHop.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/systemNavObjectsHop.test.tsx
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The `sys-objects` entry both sidebars carry arrives at the canonical
+ * metadata-admin route with ZERO redirects (objectui#3739).
+ *
+ * ## What was wrong
+ *
+ * `AppSidebar.systemFallbackNavigation` and `UnifiedSidebar.homeNavigation` each
+ * hold their own literal for this entry, and both spelled it
+ * `/apps/setup/system/metadata/object`. That is not a page: `apps/console`'s host
+ * fragment declares `system/metadata/:metadataType` with `MetadataRedirect` as
+ * its element, which immediately `<Navigate>`s onto
+ * `/apps/setup/metadata/object`. Every click therefore paid a redundant hop plus
+ * a re-render to reach a URL the nav item could name itself.
+ *
+ * This is the same defect objectui#3660 fixed for `sys-datasources` — declared on
+ * the line immediately BELOW this entry in both arrays — and it was missed there,
+ * because the two entries reach their aliases through different route tables:
+ * `sys-datasources` went through app-shell's own `component/metadata/resource`
+ * alias, `sys-objects` through the host's `system/metadata/:type` rewrite. Same
+ * cost, different producer of the hop, so the grep that found one did not find
+ * the other. The third producer of this URL, `console/home/QuickActions`, is
+ * pinned in `console/home/__tests__/QuickActions.settingsTarget.test.tsx`.
+ *
+ * ## What this file measures, and how it differs from the sibling pins
+ *
+ * `systemNavSettingsTarget.test.tsx` asserts the URL each entry CARRIES — a
+ * string equality on an `href`. This file asks the next question: what that URL
+ * costs to resolve. `ChainRecorder` records every distinct location the router
+ * settles on, so a direct arrival is a one-entry chain and an alias arrival is
+ * two. Endpoint-only assertions cannot tell those apart — both finish at
+ * `/apps/setup/metadata/object`, which is exactly why the detour survived #3660
+ * and #3611 (the latter even pinned the alias spelling as its consistency
+ * anchor). `systemNavDatasourcesHop.test.tsx` is this file's twin for the entry
+ * one line below; the two are kept separate because the alias route being
+ * mirrored, and the file it is transcribed from, differ.
+ *
+ * The href is READ OUT of a real sidebar render rather than typed in here, so the
+ * producer under test is the component's own literal. Both sidebars are driven,
+ * because both hold a copy.
+ *
+ * ## The alias mirror below, and what rests on its fidelity
+ *
+ * `AliasMetadataRedirect` mirrors `MetadataRedirect` from
+ * `apps/console/src/AppContent.tsx` — transcribed, not imported, because
+ * `apps/console` is a different Vitest project (the same reason, and the same
+ * transcription, as `console/__tests__/AppContent.noAppComponentRoutes.test.tsx`
+ * and `AppContent.pseudoRouteSegments.test.tsx`; keep the regex and the target
+ * construction identical to the original).
+ *
+ * Nothing this file ASSERTS depends on that mirror being faithful: the green
+ * expectation is `chain` equals `[canonical URL]`, which holds iff the sidebar's
+ * URL matches a canonical route directly. The mirror only shapes what the FAILURE
+ * looks like — with it, restoring either literal produces a two-entry chain whose
+ * first entry is the alias, i.e. the extra hop printed literally in the diff
+ * rather than merely implied. The real host route's own behaviour is pinned
+ * against the real route table in `apps/console`'s
+ * `__tests__/AppContent.legacyRedirects.test.tsx`, and end-to-end through
+ * app-shell's route tree in `console/__tests__/AppContent.noAppComponentRoutes.test.tsx`.
+ *
+ * ## Scope
+ *
+ * Where the sidebars AIM. The alias routes are untouched and stay reachable for
+ * bookmarks and external links; nothing here asks for their removal, and the
+ * CONTROL case below pins that they still work.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate, useLocation, useParams } from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Mocks — providers and console-only chrome, matching the sibling sidebar
+// suites (`systemNavDatasourcesHop.test.tsx`, `systemNavSettingsTarget.test.tsx`).
+// `react-router-dom` stays REAL: the chain measurement below IS the router.
+// ---------------------------------------------------------------------------
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+    viewLabel: (_o: string, _v: string, fallback?: string) => fallback,
+    dashboardLabel: ({ label }: { label?: string }) => label,
+    navGroupLabel: (_a: string, _g: string, fallback?: string) => fallback,
+  }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: null, signOut: vi.fn(), isAuthEnabled: false, activeOrganization: null }),
+  useIsWorkspaceAdmin: () => true,
+  getUserInitials: () => 'U',
+}));
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({ can: () => true, hasCapabilities: () => true }),
+}));
+
+/** The zero-app deployment `systemFallbackNavigation` exists for. */
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: [], objects: [] }),
+}));
+
+vi.mock('../../providers/ExpressionProvider', () => ({
+  useExpressionContext: () => ({ evaluator: null }),
+  evaluateVisibility: (expr: unknown) => expr !== false && expr !== 'false',
+}));
+
+vi.mock('../../utils', () => ({
+  resolveI18nLabel: (label: unknown) => (typeof label === 'string' ? label : ''),
+  matchAppBySegment: (apps: Array<{ name?: string }>, segment?: string) =>
+    apps.find((a) => a?.name === segment),
+  appRouteSegment: (app: { name?: string }) => app?.name,
+}));
+
+vi.mock('../../utils/getIcon', () => ({ getIcon: () => () => null }));
+vi.mock('@object-ui/components', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getLazyIcon: () => () => null,
+}));
+
+vi.mock('../../hooks/useRecentItems', () => ({ useRecentItems: () => ({ recentItems: [] }) }));
+vi.mock('../../hooks/useFavorites', () => ({
+  useFavorites: () => ({ favorites: [], removeFavorite: vi.fn() }),
+}));
+vi.mock('../../hooks/useNavPins', () => ({
+  useNavPins: () => ({ togglePin: vi.fn(), applyPins: (items: unknown) => items }),
+}));
+vi.mock('../../hooks/useNavActionDispatch', () => ({
+  useNavActionDispatch: () => vi.fn(),
+}));
+vi.mock('../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ context: 'home', currentAppName: undefined }),
+}));
+vi.mock('../ContextSelectors', () => ({
+  useAppContextSelectors: () => ({ contextValues: {}, element: null }),
+  contextSelectorQueryKey: (id: string) => (id === 'active_package' ? 'package' : id),
+  STUDIO_PACKAGE_SELECTOR_ID: 'active_package',
+}));
+vi.mock('../LocalizedSidebarTrigger', () => ({
+  LocalizedSidebarTrigger: () => null,
+}));
+
+import { SidebarProvider } from '@object-ui/components';
+import { AppSidebar } from '../AppSidebar';
+import { UnifiedSidebar } from '../UnifiedSidebar';
+
+/** Where the metadata-admin engine really serves the object list. */
+const CANONICAL = '/apps/setup/metadata/object';
+
+/** The legacy spelling both entries used to carry — an alias, not a page. */
+const ALIAS = '/apps/setup/system/metadata/object';
+
+/**
+ * Records every distinct location the router settles on: one entry means the URL
+ * matched a real route on arrival, two means it was forwarded once.
+ */
+function ChainRecorder({ sink }: { sink: string[] }) {
+  const location = useLocation();
+  const here = `${location.pathname}${location.search}`;
+  if (sink[sink.length - 1] !== here) sink.push(here);
+  return null;
+}
+
+/** Terminal probe: reports which route matched and with which params. */
+function Probe({ id }: { id: string }) {
+  const params = useParams();
+  return <div data-testid={id}>{JSON.stringify(params)}</div>;
+}
+
+/**
+ * Mirror of `MetadataRedirect` from `apps/console/src/AppContent.tsx` — the
+ * `system/metadata/*` legs of its `systemRoutes` fragment. Present so a restored
+ * alias literal shows up as a real extra hop rather than as a dead end; see this
+ * file's header on what does and does not rest on its fidelity.
+ */
+function AliasMetadataRedirect() {
+  const { metadataType, itemName } = useParams<{ metadataType?: string; itemName?: string }>();
+  const location = useLocation();
+  const prefix = location.pathname.replace(/\/(system\/)?metadata(\/.*)?$/, '');
+  const base = `${prefix}/metadata`;
+  const target = !metadataType
+    ? base
+    : itemName
+      ? `${base}/${encodeURIComponent(metadataType)}/${itemName}`
+      : `${base}/${encodeURIComponent(metadataType)}`;
+  return <Navigate to={target} replace />;
+}
+
+/** Renders a sidebar, reads the entry's href, then unmounts it. */
+function objectsHrefFrom(ui: React.ReactElement, at: string): string {
+  const view = render(
+    <MemoryRouter initialEntries={[at]}>
+      <SidebarProvider>{ui}</SidebarProvider>
+    </MemoryRouter>,
+  );
+  const href = screen.getByRole('link', { name: 'Object Manager' }).getAttribute('href');
+  view.unmount();
+  expect(href).toBeTruthy();
+  return href as string;
+}
+
+/** Drops the emitted URL into a router that knows both spellings. */
+function chainFor(url: string): string[] {
+  const chain: string[] = [];
+  render(
+    <MemoryRouter initialEntries={[url]}>
+      <ChainRecorder sink={chain} />
+      <Routes>
+        <Route path="/apps/:appName">
+          <Route path="metadata" element={<Probe id="canonical-directory" />} />
+          <Route path="metadata/:type" element={<Probe id="canonical-list" />} />
+          <Route path="system/metadata" element={<AliasMetadataRedirect />} />
+          <Route path="system/metadata/:metadataType" element={<AliasMetadataRedirect />} />
+        </Route>
+        <Route path="*" element={<Probe id="unmatched" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  return chain;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('sidebar sys-objects reaches the canonical route directly (objectui#3739)', () => {
+  it('AppSidebar: the zero-app fallback cluster arrives with NO redirect', () => {
+    const href = objectsHrefFrom(
+      <AppSidebar activeAppName="setup" onAppChange={() => {}} />,
+      '/apps/setup',
+    );
+
+    // Precondition: with zero apps this really is the fallback cluster, so the
+    // href just read is the one `systemFallbackNavigation` declares.
+    expect(href).toBe(CANONICAL);
+
+    const chain = chainFor(href);
+
+    // One entry = matched on arrival. Before the fix this was two, the alias
+    // first.
+    expect(chain).toEqual([CANONICAL]);
+    expect(screen.getByTestId('canonical-list')).toHaveTextContent('"type":"object"');
+    expect(chain.some((entry) => entry.includes('system/metadata'))).toBe(false);
+  });
+
+  it('UnifiedSidebar: the /home Administration cluster arrives with NO redirect', () => {
+    const href = objectsHrefFrom(<UnifiedSidebar activeAppName="" />, '/home');
+
+    expect(href).toBe(CANONICAL);
+
+    const chain = chainFor(href);
+
+    expect(chain).toEqual([CANONICAL]);
+    expect(screen.getByTestId('canonical-list')).toHaveTextContent('"type":"object"');
+    expect(chain.some((entry) => entry.includes('system/metadata'))).toBe(false);
+  });
+
+  it('CONTROL: the alias still resolves, and doing so costs the hop the entries used to pay', () => {
+    // The alias is deliberately KEPT (bookmarks, external links), so its
+    // continued reachability is part of the contract, not collateral. This also
+    // proves the two assertions above are not vacuous: the probe table really
+    // does forward this spelling, so a sidebar that still emitted it would be
+    // measured at two entries rather than silently falling to `unmatched`.
+    const chain = chainFor(ALIAS);
+
+    expect(chain).toEqual([ALIAS, CANONICAL]);
+    expect(screen.getByTestId('canonical-list')).toHaveTextContent('"type":"object"');
+  });
+});

--- a/packages/app-shell/src/layout/__tests__/systemNavSettingsTarget.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/systemNavSettingsTarget.test.tsx
@@ -56,6 +56,23 @@
  * as above: replace the old shape, do not keep it alongside). The AppSidebar
  * test below gained the matching assertion at the same time — that sidebar
  * carries its own copy of the literal and had none.
+ *
+ * ## The `Object Manager` entry (objectui#3739)
+ *
+ * #3660 re-pointed `sys-datasources` and stopped there; `sys-objects`, the entry
+ * declared on the line immediately ABOVE it in both sidebars, kept spelling
+ * `/apps/setup/system/metadata/object`. That is a legacy alias too — served by
+ * `apps/console`'s `MetadataRedirect`, which `<Navigate>`s onto
+ * `/apps/setup/metadata/object` — so the same redundant hop survived on the
+ * neighbouring click target. Both literals now name the destination, and the
+ * expectation here is REWRITTEN rather than kept alongside, exactly as the
+ * `Datasources` note above describes.
+ *
+ * Note what this file does NOT claim: that the URL resolves in one hop. That is
+ * a property of the URL, not of the producer, and is measured once per family in
+ * `systemNavDatasourcesHop.test.tsx` / `systemNavObjectsHop.test.tsx`. Here the
+ * assertion is string equality on the href each sidebar emits — which is the
+ * half that can drift per copy, since each sidebar holds its own literal.
  */
 
 import '@testing-library/jest-dom/vitest';
@@ -173,6 +190,15 @@ const SYSTEM_HUB = '/apps/setup/system';
 const DATASOURCES_TARGET = '/apps/setup/metadata/datasource';
 
 /**
+ * `Object Manager` names the same engine's canonical route (objectui#3739). This
+ * entry used to read `${SYSTEM_HUB}/metadata/object` — an alias served by
+ * `apps/console`'s `MetadataRedirect`, a bare `<Navigate>` onto the URL below.
+ * Replaced here rather than kept alongside, for the reason spelled out in this
+ * file's header: the repo pins the fix, not both the bug and the fix.
+ */
+const OBJECTS_TARGET = '/apps/setup/metadata/object';
+
+/**
  * Every entry of the `/home` Administration cluster, in declaration order.
  * Asserted whole rather than by sample: the defect was that the group's
  * children were never visited at all, so "some of them render" is not the
@@ -182,7 +208,7 @@ const ADMINISTRATION_ENTRIES: ReadonlyArray<readonly [string, string]> = [
   ['System Settings', SYSTEM_HUB],
   ['Applications', `${SYSTEM_HUB}/apps`],
   ['App Marketplace', `${SYSTEM_HUB}/marketplace`],
-  ['Object Manager', `${SYSTEM_HUB}/metadata/object`],
+  ['Object Manager', OBJECTS_TARGET],
   ['Datasources', DATASOURCES_TARGET],
   ['Users', `${SYSTEM_HUB}/users`],
   ['Organizations', `${SYSTEM_HUB}/organizations`],
@@ -244,6 +270,20 @@ describe('sidebar system-settings target (objectui#3590)', () => {
     expect(screen.getByRole('link', { name: 'Datasources' })).toHaveAttribute(
       'href',
       DATASOURCES_TARGET,
+    );
+
+    // objectui#3739 — `sys-objects`, the twin one line above `sys-datasources`
+    // in this same array. Pinned in both sidebars for the same reason: two
+    // independent literals, either of which can drift back to the alias alone.
+    expect(screen.getByRole('link', { name: 'Object Manager' })).toHaveAttribute(
+      'href',
+      OBJECTS_TARGET,
+    );
+    // The alias spelling by name, so a revert is named in the diff rather than
+    // showing up as an unexplained string difference.
+    expect(screen.getByRole('link', { name: 'Object Manager' })).not.toHaveAttribute(
+      'href',
+      `${SYSTEM_HUB}/metadata/object`,
     );
   });
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3739

## 前提核验(issue body 只是线索)

在 `origin/main` @ `8ad6070fb` 上逐条复核,三处调用点全部仍在发 legacy 别名,premise 成立:

```
packages/app-shell/src/layout/AppSidebar.tsx:329      url:  '/apps/setup/system/metadata/object'
packages/app-shell/src/layout/UnifiedSidebar.tsx:335  url:  '/apps/setup/system/metadata/object'
packages/app-shell/src/console/home/QuickActions.tsx:39  href: '/apps/setup/system/metadata/object'
```

规范目标也核到了:`packages/app-shell/src/console/AppContent.tsx:641` 的 `metadata/:type` → `MetadataResourceListPage`,两个分支都声明。别名一侧由 `apps/console/src/AppContent.tsx:189-191` 的 `system/metadata/:metadataType` → `MetadataRedirect` 服务,它就是一个 `Navigate`,目标恰好是本 PR 写进导航项的那个 URL。另外确认在途无人改动这三个文件(PR #3728 今天只碰了 apps/console 的 AppContent)。

## 改了什么

三处生产端一律改指 `/apps/setup/metadata/object`,并按 #3660 在同一数组下一行留下的注释形状、逐文件沿用该文件既有注释习惯,各写一段判词。

落地页面逐字节不变 —— 新 URL 就是别名跳转本来算出来的那个(`object` 百分号编码即自身,三处都不带 query/hash);消失的只有中间那一跳和随之而来的 re-render。**别名路由一行未动**,书签与外链继续能到,只是我们自己的导航不再往里喂流量。

顺手修掉一句被本次改动证伪的旧注释:两个侧边栏 #3590 段末的「Every sibling below already spells `/apps/setup/system/...`」。它在 #3660 之后对 `sys-datasources` 已经不成立,本 PR 让它对 `sys-objects` 也不成立 —— 留着会诱导下一个 agent 为了「前缀一致」把 URL 改回去,所以改写为「这两个 metadata-admin 条目名的是引擎的规范路由;此处的不变量不是前缀一致,而是名字指向真正渲染的那条路由」。

## 测试

按这一族已有的模式加/改,分两层:

- **新增** `packages/app-shell/src/layout/__tests__/systemNavObjectsHop.test.tsx` —— `systemNavDatasourcesHop.test.tsx` 的孪生件,量的是**跳数**而非终点:href 从两个侧边栏的真实渲染里读出来,丢进同时认识规范路由与别名的 router,`ChainRecorder` 记录每一个落点,一条 = 直达。两个文件分开放,因为要镜像的别名路由不同(本文件镜像 `apps/console` 的 `MetadataRedirect`,与 `AppContent.noAppComponentRoutes.test.tsx` 同源同做法)。第三个 case 是 CONTROL:别名依然能解析,且解析要付那一跳 —— 别名可用是契约的一部分,不是附带损害;它同时证明前两条断言不空转。
- **改写** `systemNavSettingsTarget.test.tsx`:`ADMINISTRATION_ENTRIES` 的 `Object Manager` 换成规范 URL,并给 AppSidebar 那一半补上同形状断言(两个侧边栏各持一份字面量,只钉一份就能单边漂回去 —— 这正是 #3660 给 `Datasources` 补断言的理由)。
- **改写** `QuickActions.settingsTarget.test.tsx` 第三个 case。它原本叫「REGRESSION: the sibling card that was already hub-scoped is unchanged」,钉的正是我要改的那个字面量 —— 这个前提就是本 issue 证伪的东西,所以整条重写而非并存(沿用该族「只钉修好的形状,不同时钉 bug 和 fix」的纪律)。

三处都按 #3660/#3609 的做法**替换**旧期望,不与旧形状并存。

### 反向验证(先预测,再运行)

预测:只把三处生产端 URL 改回别名、测试不动,应有 9 条中 5 条转红 —— hop 文件两条 sidebar case、settings-target 文件 AppSidebar 与九条目循环、QuickActions 的 manage-objects;CONTROL、dormancy、system-settings、non-admin 四条保持绿。并预测 hop 文件会**先**死在 `expect(href).toBe(CANONICAL)` 这个前置断言上,因此那条「两跳链」并不会出现在 diff 里。

实测与预测逐条吻合:

```
 ❯ systemNavObjectsHop.test.tsx (3 tests | 2 failed)
     × AppSidebar: the zero-app fallback cluster arrives with NO redirect
     × UnifiedSidebar: the /home Administration cluster arrives with NO redirect
 ❯ systemNavSettingsTarget.test.tsx (3 tests | 2 failed)
 ❯ QuickActions.settingsTarget.test.tsx (3 tests | 1 failed)
AssertionError: expected '/apps/setup/system/metadata/object' to be '/apps/setup/metadata/object'
 ❯ systemNavObjectsHop.test.tsx:241:18
 Test Files  3 failed (3)
      Tests  5 failed | 4 passed (9)
```

随后 `git checkout --` 复原,工作树干净。

### 消费半径全量(不止改动包)

一条被改的 URL 在哪里被消费就在哪里可能碎,所以按调用面而非按包跑:app-shell 的 `layout/__tests__`、`console/__tests__`、`console/home/__tests__`,加上 `apps/console` 的别名钉(`AppContent.legacyRedirects.test.tsx`)与 #3660 的 System Hub 卡片钉。

```
 Test Files  26 passed (26)
      Tests  160 passed (160)
```

`apps/console` 的 legacyRedirects 测试**一行未动**,并且照旧全绿 —— 本 PR 只重指内部生产端,别名本身必须继续为外部到访服务。

其余门禁:`@object-ui/app-shell` 的 `type-check` 干净;`eslint` 对六个改动文件 0 error(新测试文件单跑 0 findings);`check-control-bytes` OK,并对改动文件另跑了一次手工控制字节扫描(gate 的盲区正是这类字节藏身处)。

## Changeset

`.changeset/nav-sys-objects-canonical-route-3739.md`,`@object-ui/app-shell: patch`。里面如实写了:三个生产端中两个侧边栏是活的,`QuickActions` 今天没有任何 JSX 调用点(其自身测试里有一条 dormancy 前置断言在钉这件事),所以那一处是「哪天有人把它挂回 /home,死链不会跟着回来」的守卫,而非用户可见变化。

## 范围

只碰 issue 点名的三个文件与它们的测试。发现了一处越界项已另行开 issue 记录(见下方评论),没有在本 PR 里动:`AppContent.noAppComponentRoutes.test.tsx` / `AppContent.pseudoRouteSegments.test.tsx` 的头注释把这两个条目当作**现在**还在发别名的生产端来枚举 —— #3660 之后 `sys-datasources` 那一行已经陈旧,本 PR 让 `sys-objects` 那一行也陈旧。两处测试**断言**本身都是从 URL 直接进入、量别名路由的行为,别名保留,因此仍然正确、仍然全绿;陈旧的只有叙述。参照 #3660 把同类注释改写单独立为 #3666 的先例,归为独立 issue。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_