### PR TITLE
fix(data-objectstack): 把 queryDataset(selection) 直接声明为 spec 的 DatasetSelection

### DIFF
--- a/.changeset/dataset-selection-spec-type-3613.md
+++ b/.changeset/dataset-selection-spec-type-3613.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+data-objectstack: type `queryDataset(selection)` as the spec's `DatasetSelection` instead of a hand-written copy
+
+The adapter restated the selection contract inline, field by field, and the copy
+had drifted three ways from the pinned `@objectstack/spec@17.0.0-rc.5`:
+
+- **`compareTo.dimension` was required.** It has been optional since
+  objectstack#5011, *because the executor resolves it*: exactly one time
+  dimension carrying a `dateRange` is the one shifted, and zero or several
+  raises a loud error naming the candidates. Requiring it made the compiler
+  demand from every typed caller precisely the consumer-side dimension guess
+  that change forbids — trading a loud executor error for a silently wrong
+  comparison window. No runtime path hit this yet (the dashboard's
+  `DatasetWidget` passes `selection` as `unknown`), but a declaration is a live
+  instruction to anyone calling this client from TypeScript.
+- **`timeDimensions` was widened to `unknown[]`**, erasing the very entry shape
+  the executor's resolution reads (`{ dimension, granularity?, dateRange? }`),
+  and **`runtimeFilter` to `Record<string, unknown>`**, erasing the
+  `$and`/`$or`/`$not` vocabulary the server parses.
+- **`dateGranularity` was missing entirely** — the copy had simply stopped at
+  whatever the contract looked like the day it was written, so a typed caller
+  could not bucket a trend by month at all.
+
+The parameter is now the spec type by reference, so there is nothing left to
+re-sync. The fix is the removal of the dialect rather than a correction to it:
+restating a contract owned elsewhere creates a second de-facto dialect of it, and
+drift is then only a matter of time (AGENTS.md #0/#0.1). `queryDataset.test.ts`
+pins structural identity with `DatasetSelection` plus each of the three drifts
+individually, checked by this package's `tsc --noEmit`; a runtime test pins that
+a dimension-less `compareTo` reaches the server untouched, so the adapter can
+never start guessing on the executor's behalf.
+
+The response type is deliberately left alone — it is the REST envelope
+(`object` / `dimensionFields` / `drillRawRows`), not a restatement of
+`AnalyticsResult`.

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -8,6 +8,7 @@
 
 import { ObjectStackClient, type QueryOptions as ObjectStackQueryOptions } from '@objectstack/client';
 import type { DroppedFieldsEvent } from '@objectstack/spec/data';
+import type { DatasetSelection } from '@objectstack/spec/contracts';
 import type {
   DataSource,
   BatchTransactionOperation,
@@ -3190,25 +3191,21 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * silently returning wrong numbers.
    *
    * @param dataset - An inline dataset definition (draft) OR a saved dataset name.
-   * @param selection - Dimension/measure names to project + runtime directives.
+   * @param selection - The spec's {@link DatasetSelection} — dimension/measure
+   *   names to project plus runtime directives. This parameter IS the spec type
+   *   by reference, never a local restatement of it (objectui#3613): a hand
+   *   copy of a contract is a second dialect of it, and the copy this replaced
+   *   had already drifted three ways from `@objectstack/spec` — it required
+   *   `compareTo.dimension` (optional since objectstack#5011, and resolved by
+   *   the EXECUTOR, so requiring it pushed callers into exactly the
+   *   consumer-side dimension guess AGENTS.md #0.1 forbids), it widened
+   *   `timeDimensions` to `unknown[]` and `runtimeFilter` to
+   *   `Record<string, unknown>`, and it had never grown `dateGranularity` at
+   *   all. Pinned in `queryDataset.test.ts`.
    */
   async queryDataset(
     dataset: Record<string, unknown> | string,
-    selection: {
-      dimensions?: string[];
-      measures: string[];
-      runtimeFilter?: Record<string, unknown>;
-      timeDimensions?: unknown[];
-      compareTo?: { kind: 'previousPeriod' | 'previousYear'; dimension: string };
-      order?: Record<string, 'asc' | 'desc'>;
-      limit?: number;
-      offset?: number;
-      timezone?: string;
-      /** Marginal-aggregate groupings (e.g. `[rows, [colDim], []]`) — server
-       *  computes each subtotal with the measure's TRUE aggregate (never client
-       *  re-derived). `[]` is the grand total. */
-      totals?: { groupings: string[][] };
-    },
+    selection: DatasetSelection,
   ): Promise<{
     rows: Array<Record<string, unknown>>;
     /** Column metadata: a display `label` (dimensions and measures), and a

--- a/packages/data-objectstack/src/queryDataset.test.ts
+++ b/packages/data-objectstack/src/queryDataset.test.ts
@@ -7,6 +7,11 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type {
+  AnalyticsQuery as SpecAnalyticsQuery,
+  DatasetCompareTo as SpecDatasetCompareTo,
+  DatasetSelection as SpecDatasetSelection,
+} from '@objectstack/spec/contracts';
 import {
   ObjectStackAdapter,
   clearSharedDiscoveryCache,
@@ -128,5 +133,124 @@ describe('ObjectStackAdapter.queryDataset', () => {
       expect(isAnalyticsNotInstalledError(err)).toBe(false);
       expect(String(err.message)).toContain('relationship not declared');
     });
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* objectui#3613 — the `selection` parameter IS the spec type, not a copy.      */
+/*                                                                             */
+/* Compile-time pins. A violation is a `tsc --noEmit` error, not a runtime      */
+/* failure: this package's tsconfig.json includes its whole `src/**` (tests     */
+/* included), so these are checked by `pnpm --filter @object-ui/data-objectstack*/
+/* type-check` with no separate tsconfig.typetests.json — the same property     */
+/* spec-symbol-batch6.test.ts documents and relies on.                          */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
+
+/** The declared type of `queryDataset`'s second parameter, read off the method. */
+type SelectionParam = Parameters<ObjectStackAdapter['queryDataset']>[1];
+
+describe('queryDataset(selection) is @objectstack/spec DatasetSelection itself', () => {
+  it('is pinned at compile time', () => {
+    type _SpecNotAny = Assert<Equal<IsAny<SpecDatasetSelection>, false>>;
+
+    // THE pin. `Equal` rather than a two-way `extends` on purpose: a
+    // restatement that merely *overlaps* the contract satisfies mutual
+    // assignability in the drifted direction too (a required `dimension` is
+    // still assignable TO an optional one). Structural identity is the only
+    // assertion a hand copy cannot pass while drifting.
+    type _IsTheSpecType = Assert<Equal<SelectionParam, SpecDatasetSelection>>;
+
+    expect(true).toBe(true);
+  });
+
+  // The three drifts the deleted copy had accumulated, named individually so a
+  // future reader learns what a restatement costs — not just that one existed.
+  it('pins compareTo as the spec DatasetCompareTo, with dimension OPTIONAL', () => {
+    type CompareTo = NonNullable<SelectionParam['compareTo']>;
+    type _IsSpecCompareTo = Assert<Equal<CompareTo, SpecDatasetCompareTo>>;
+
+    // objectstack#5011 made `dimension` optional BECAUSE the executor resolves
+    // it (exactly one dated time dimension → that one; zero or several → a loud
+    // error listing the candidates). The copy declared it required, so the
+    // compiler demanded from every typed caller precisely the consumer-side
+    // dimension guess that change forbids — turning a loud executor error into
+    // a silently wrong comparison window.
+    type _DimensionOptional = Assert<Equal<CompareTo['dimension'], string | undefined>>;
+    type _DimensionWasNotRequired = Assert<Equal<Equal<CompareTo['dimension'], string>, false>>;
+    // …and the shape with no `dimension` at all is a legal authoring surface.
+    type _KindOnlyIsValid = Assert<
+      { kind: 'previousPeriod' } extends CompareTo ? true : false
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  it('pins timeDimensions at the spec shape, not `unknown[]`', () => {
+    type _IsSpecTimeDimensions = Assert<
+      Equal<SelectionParam['timeDimensions'], SpecAnalyticsQuery['timeDimensions']>
+    >;
+    type _NotUnknownArray = Assert<
+      Equal<Equal<SelectionParam['timeDimensions'], unknown[] | undefined>, false>
+    >;
+    // The entry shape the executor's compareTo resolution reads (`dateRange`
+    // present ⇒ shiftable) — invisible through `unknown[]`.
+    type Entry = NonNullable<SelectionParam['timeDimensions']>[number];
+    type _EntryHasDimension = Assert<Equal<Entry['dimension'], string>>;
+    type _EntryHasDateRange = Assert<HasKey<Entry, 'dateRange'>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('pins runtimeFilter as a FilterCondition and carries dateGranularity', () => {
+    // The copy widened `runtimeFilter` to `Record<string, unknown>`, which
+    // erases the `$and`/`$or`/`$not` vocabulary the server parses.
+    type _RuntimeFilterNarrowed = Assert<
+      Equal<Equal<SelectionParam['runtimeFilter'], Record<string, unknown> | undefined>, false>
+    >;
+    type _RuntimeFilterKnowsLogicalOps = Assert<
+      HasKey<NonNullable<SelectionParam['runtimeFilter']>, '$and'>
+    >;
+
+    // `dateGranularity` (framework#3588) is the drift nobody had noticed: the
+    // copy never grew the key, so a typed caller could not bucket a trend by
+    // month at all. A restatement does not only drift on the fields it has — it
+    // also stops at whatever the contract looked like the day it was written.
+    type _HasDateGranularity = Assert<HasKey<SelectionParam, 'dateGranularity'>>;
+    type _DateGranularityEnum = Assert<
+      Equal<
+        SelectionParam['dateGranularity'],
+        'day' | 'week' | 'month' | 'quarter' | 'year' | undefined
+      >
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  // The runtime half of the same fact: the adapter must forward `compareTo`
+  // VERBATIM. If it ever "helpfully" filled a `dimension` in to satisfy its own
+  // old declaration, the executor would stop resolving and every caller's
+  // comparison window would depend on the adapter's guess.
+  it('forwards a dimension-less compareTo to the server untouched', async () => {
+    const { fetchImpl, calls } = makeFetch({ ok: true, body: { rows: [], fields: [] } });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+    await adapter.queryDataset('sales', {
+      dimensions: ['region'],
+      measures: ['revenue'],
+      timeDimensions: [{ dimension: 'closedAt', granularity: 'month', dateRange: ['2026-01-01', '2026-03-31'] }],
+      compareTo: { kind: 'previousPeriod' },
+    });
+
+    const post = calls.find((c) => c.url.includes('/analytics/dataset/query'))!;
+    const sent = JSON.parse(post.init.body);
+    expect(sent.selection.compareTo).toEqual({ kind: 'previousPeriod' });
+    expect(sent.selection.compareTo).not.toHaveProperty('dimension');
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3613

## 前提核验(issue 只是线索)

在 `origin/main` @ `28364bd` 上逐条核过,**前提成立**:

- `packages/data-objectstack/src/index.ts:3202` 确实仍是 `compareTo?: { kind: 'previousPeriod' | 'previousYear'; dimension: string }` —— `dimension` **必填**。
- `packages/data-objectstack/package.json` pin 的是 `@objectstack/spec@^17.0.0-rc.5`,lockfile 解析到 `17.0.0-rc.5`(注意:共享 checkout 当前分支的 lockfile 还停在 rc.2,所以这一条必须按 `origin/main` 读)。
- rc.5 里 `DatasetCompareTo.dimension` 确为可选,注释原文:`**Optional since #5011, resolved by the EXECUTOR — not by any consumer.**`

一处与 issue 正文的**出入**,已按裁定 1「READ the pinned spec package first」核实后照实处理:issue 说该类型在 `contracts/analytics-service.ts`,但发布出来的包里**没有** `src/contracts/`(源码只部分随包)。实际导出名与入口是 `DatasetSelection` / `DatasetCompareTo`,从 **`@objectstack/spec/contracts`** 子路径导出(本包 `spec-symbol-batch6.test.ts` 已在用这个子路径)。名字与 issue 一致,入口按实际的写。

## 改了什么

手写的 `selection` 内联类型换成对 spec 类型的**直接引用**:

```ts
import type { DatasetSelection } from '@objectstack/spec/contracts';

async queryDataset(
  dataset: Record< string, unknown > | string,
  selection: DatasetSelection,
): Promise< { … } >
```

删掉的那份副本一共漂了**三处**(裁定 2 的 `timeDimensions` 只是其中之一):

| 字段 | 删掉的副本 | spec rc.5 |
|---|---|---|
| `compareTo` | `{ kind; dimension: string }`(必填) | `DatasetCompareTo`,`dimension?` |
| `timeDimensions` | `unknown[]` | `AnalyticsQuery['timeDimensions']` |
| `runtimeFilter` | `Record< string, unknown >` | `FilterCondition` |
| `dateGranularity` | **整个键都没有** | `'day'｜'week'｜'month'｜'quarter'｜'year'` |

前两项 issue 点到了。后两项是核验时才浮出来的:`runtimeFilter` 放宽成 `Record< string, unknown >` 抹掉了服务端要解析的 `$and`/`$or`/`$not` 词汇;而 `dateGranularity`(framework#3588)是**副本从来没长出来过**的键 —— 这条最能说明问题:**重述一份契约不只会在它有的字段上漂移,它还会停在写它那天的样子**。这也正是 issue 自己的结论(「重述一份就是给同一契约开第二份方言」),所以这里做的是**消灭方言**而不是重新同步一遍。

为什么这不是纸面问题:`dimension` 必填等于让编译器向每个按类型调用的作者索要一个**执行器本该自己决议**的维度 —— 恰好是 objectstack#5011 与 AGENTS.md #0.1 明令禁止的消费端猜维度,把「零个/多个候选时响亮报错并列出候选」换成一个安静的错窗口。今天没有运行时路径撞上(`DatasetWidget` 走 `selection: unknown`),但类型声明不是 dormant code。

## 钉子(裁定 4)

加在 `queryDataset.test.ts`(与既有运行时用例同处),沿用本包 `spec-symbol-batch6.test.ts` 的 `Assert`/`Equal`/`HasKey` idiom:

- **主钉**:`Assert< Equal< Parameters< ObjectStackAdapter['queryDataset'] >[1], SpecDatasetSelection > >` —— 用 `Equal` 而非双向 `extends` 是刻意的:必填的 `dimension` **仍然**可赋给可选的,双向 `extends` 在漂移方向上也是绿的,结构恒等才是手写副本漂移时过不去的那一条。
- 三处漂移各自单独钉一条(附注释说明该漂移的代价),外加一条运行时用例:`compareTo: { kind: 'previousPeriod' }`(不带 dimension)必须**原样**送到服务端。这一条守的是 adapter 永远不会替执行器"帮忙"补一个 dimension。

**key-vs-value:** 这里守的是 `compareTo` 省略 `dimension` 是否为**合法的授权/编写形状**(一个 key/shape 事实),所以用编译期可赋值性断言;真正的 value 判决(哪个维度被平移)在执行器,本仓无从断言。

## 反向验证 —— 方向是先预测再跑的

**预测:把旧内联方言塞回去 → `type-check` 变红,而 `vitest` 保持绿。** 因为 vitest 不做类型检查,而那条运行时透传断言测的是 JSON 序列化,类型声明动不了它。这个钉子的承重门是 `tsc --noEmit`,**不是** vitest —— 写在这里免得后来的人误以为跑一遍 vitest 就守住了。

两个方向都如预测:

`type-check` 红,13 条错误,每条都对得上一处具名漂移:

```
src/queryDataset.test.ts(168,34): error TS2344: Type 'false' does not satisfy the constraint 'true'.   # 主钉 _IsTheSpecType
src/queryDataset.test.ts(185,38): error TS2344: Type 'false' does not satisfy the constraint 'true'.   # _DimensionOptional
src/queryDataset.test.ts(205,50): error TS2339: Property 'dimension' does not exist on type 'unknown'. # timeDimensions 退化成 unknown[]
src/queryDataset.test.ts(228,24): error TS2339: Property 'dateGranularity' does not exist on type '{ … }'.
src/queryDataset.test.ts(248,7):  error TS2741: Property 'dimension' is missing in type '{ kind: "previousPeriod"; }' but required in type '{ kind: …; dimension: string; }'.
```

vitest 同时仍是绿的(`Test Files 1 passed (1) / Tests 12 passed (12)`),与预测一致。随后已复原。

## 消费者核查(裁定 3)

`queryDataset` **不在** `@object-ui/types` 的 `DataSource` 接口上,只在本包具体类上,所以类型面只有直接调用方会碰到。全仓调用点三处,**全部**经 `any`/局部 `unknown` 取值,因此没有类型耦合:

- `packages/plugin-charts/src/ObjectChart.tsx:452` —— `ds: any`
- `packages/app-shell/…/previews/DatasetPreview.tsx:73` —— 自行 cast 成 `(d: unknown, s: unknown) => …`
- `packages/app-shell/…/previews/ReportPreview.tsx` —— 同上

`--filter "...@object-ui/data-objectstack" type-check`(本包 + 33 个下游)**全绿,exit 0,零 error**,无需任何消费端改动 —— 文件面因此严格停在 `packages/data-objectstack/`。

（首轮跑出的 `Cannot find module '@object-ui/data-objectstack'` 是新 worktree 没建产物的 §9 陷阱镜像,先 `--filter "...@object-ui/data-objectstack..." build` 后即消失,不是本改动引起。)

## 验证

```
pnpm --filter @object-ui/data-objectstack type-check          # tsc --noEmit,绿
pnpm --filter "...@object-ui/data-objectstack" type-check     # 34 个包全绿,exit 0
pnpm exec vitest run packages/data-objectstack/               # 23 files / 347 tests passed
pnpm --filter @object-ui/data-objectstack lint                # 0 errors(310 warnings 均为既存 no-explicit-any)
node scripts/check-control-bytes.mjs                          # OK(3690 files)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' <改动文件>           # 无控制字节
node scripts/check-changeset-no-major.mjs                     # OK
```

Changeset:`.changeset/dataset-selection-spec-type-3613.md`,`patch`(公开类型面被修正),英文正文。

## 刻意没做的事

- **返回类型没动。** 它是 REST 信封(多 `object` / `dimensionFields` / `drillRawRows`,又不含 `sql`),**不是** `AnalyticsResult` 的重述,换掉它是判断题而非机械替换。但它的 `fields[]` 有同族漂移(漏了 `percentScale`,而 objectui#3136 明令渲染端必须按它缩放),已按 PD #10 单开 **#3752**(未认领、未打标,连两个方案与倾向一并写在里面),不并入本 PR。
- **没有 re-export `DatasetSelection`。** 从本包再导出一次就是给同一类型开第二条命名路径 —— 正是本 PR 要消灭的东西;调用方直接从 `@objectstack/spec/contracts` 取。
- **没碰 `DatasetWidget` / pivot 代码**(裁定 5,#3614 分单),也没碰 `content/docs/releases/`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_