### PR TITLE
fix(create-plugin): 把脚手架 build 侧 devDependencies 锚到仓内工具链,并把整张清单钉进 parity 测试

### DIFF
--- a/.changeset/create-plugin-build-deps-anchored-3742.md
+++ b/.changeset/create-plugin-build-deps-anchored-3742.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/create-plugin": patch
+---
+
+Anchor the scaffold's build-side `devDependencies` to this repo's real toolchain, and pin the whole generated manifest against drift
+
+A freshly scaffolded plugin declared a build stack one to two majors behind the one this monorepo actually builds and tests every in-tree plugin with: `vite ^7.3.1` against the repo's `^8.2.0`, `@vitejs/plugin-react ^4.2.1` against `^6.0.5`, `vite-plugin-dts ^4.5.4` against `^5.0.3`, `typescript ^5.9.3` against `^6.0.3`, `vitest ^4.0.18` against `^4.1.10`. Those five ranges were never sourced from anything — objectui#3716's end-to-end run of the generated artifact only ever exercised the versions installed in this repo, so the declared ranges were not the ones under test. All five now quote an in-repo anchor, the same way the three testing ranges already did.
+
+Two anchors, because the root manifest does not declare everything. `create-plugin` writes into `<cwd>/packages/plugin-<name>`, so a generated plugin is a literal sibling of `packages/plugin-*`; those manifests anchor the two build-only tools the root omits (`@vitejs/plugin-react`, `vite-plugin-dts`), and the root anchors the rest.
+
+The parity test now covers **every** entry of the generated `devDependencies` rather than the three testing ones, including a completeness check that fails when a dependency is added without naming its anchor — the five build ranges drifted precisely because nothing pinned them. It also asserts the two anchors agree wherever both declare a dependency, so which one is read cannot hide a drift.
+
+The generated `vite.config.ts` resolves its library entry from `import.meta.dirname` instead of `__dirname`. vite 8 still defines `__dirname` under its default `bundle` config loader but warns on it ("unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite ... Use `import.meta.dirname` instead"), and under `native` — which imports the config with Node's own ESM loader, where no `__dirname` exists — the generated config failed to load outright. `apps/console/vite.config.ts` was converted for the same reason in objectui#3384.
+
+Not a peer-dependency fix: `@vitejs/plugin-react ^4.2.1` resolved to 4.7.0, whose vite peer had widened to `^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0` and accepted the declared `vite ^7.3.1`, so the old manifest installed cleanly. The cost was a scaffold lagging its own monorepo, not a failing install.

--- a/packages/create-plugin/src/__tests__/templates.test.ts
+++ b/packages/create-plugin/src/__tests__/templates.test.ts
@@ -18,7 +18,7 @@
  *   generator actually writes.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { isBuiltin } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -69,6 +69,92 @@ function importedPackagesOf(source: string): string[] {
   return [...packages].sort();
 }
 
+type Manifest = {
+  devDependencies?: Record<string, string>;
+  dependencies?: Record<string, string>;
+};
+
+function readManifest(path: string): Manifest {
+  return JSON.parse(readFileSync(path, 'utf-8')) as Manifest;
+}
+
+/** The repo root `package.json` — anchor for every dependency it declares. */
+function rootManifest(): Manifest {
+  return readManifest(resolve(REPO_ROOT, 'package.json'));
+}
+
+/**
+ * `packages/plugin-*` manifests, as `package name -> manifest`.
+ *
+ * `create-plugin` writes into `<cwd>/packages/plugin-<name>`, so a generated
+ * plugin is a literal sibling of these — which makes them the faithful anchor
+ * for build dependencies the root manifest does not declare
+ * (`@vitejs/plugin-react`, `vite-plugin-dts`).
+ */
+function inRepoPluginManifests(): Record<string, Manifest> {
+  const packagesDir = resolve(REPO_ROOT, 'packages');
+  const manifests: Record<string, Manifest> = {};
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('plugin-')) continue;
+    const manifestPath = resolve(packagesDir, entry.name, 'package.json');
+    if (!existsSync(manifestPath)) continue;
+    manifests[entry.name] = readManifest(manifestPath);
+  }
+  return manifests;
+}
+
+/**
+ * Which in-repo manifest each generated devDependency range must quote.
+ *
+ * Anchoring is what keeps ONE range per dependency in this repo instead of one
+ * per file. `root` is preferred wherever the dependency exists there (that is
+ * the anchor objectui#3733 chose for the three testing entries); the two
+ * build-only tools the root does not declare are anchored to the in-repo plugin
+ * manifests the generated package sits beside.
+ *
+ * Every key of the generated `devDependencies` must appear here — the
+ * completeness test below fails on an unanchored addition, so this map cannot
+ * quietly go back to covering a subset (objectui#3742).
+ */
+const DEV_DEPENDENCY_ANCHORS: Record<string, 'root' | 'in-repo-plugins'> = {
+  '@testing-library/jest-dom': 'root',
+  '@testing-library/react': 'root',
+  '@vitejs/plugin-react': 'in-repo-plugins',
+  jsdom: 'root',
+  typescript: 'root',
+  vite: 'root',
+  'vite-plugin-dts': 'in-repo-plugins',
+  vitest: 'root'
+};
+
+/** The range `name` is declared at in the root manifest, if it is declared there. */
+function rootRangeOf(name: string): string | undefined {
+  const manifest = rootManifest();
+  return manifest.devDependencies?.[name] ?? manifest.dependencies?.[name];
+}
+
+/**
+ * The range every in-repo plugin declaring `name` agrees on.
+ *
+ * Returns the distinct ranges found, keyed by range, so a divergence names the
+ * offending manifests instead of just failing. A split here is itself a finding
+ * — this repo's rule is one range per dependency — so the parity test asserts
+ * unanimity rather than picking a winner.
+ */
+function inRepoPluginRangesOf(name: string): Record<string, string[]> {
+  const byRange: Record<string, string[]> = {};
+  for (const [pluginDir, manifest] of Object.entries(inRepoPluginManifests())) {
+    const range = manifest.devDependencies?.[name] ?? manifest.dependencies?.[name];
+    if (range === undefined) continue;
+    (byRange[range] ??= []).push(pluginDir);
+  }
+  return byRange;
+}
+
+function generatedDevDependencies(vars: PluginTemplateVars): Record<string, string> {
+  return (buildPackageJson(vars) as { devDependencies: Record<string, string> }).devDependencies;
+}
+
 function declaredDependencies(vars: PluginTemplateVars): Record<string, string> {
   const pkg = buildPackageJson(vars) as {
     dependencies: Record<string, string>;
@@ -94,24 +180,58 @@ describe('generated package.json', () => {
     );
   });
 
-  it('sources the testing ranges from this repo instead of inventing them', () => {
+  it('anchors every devDependency range, leaving none unpinned', () => {
+    // The completeness gate. objectui#3733 pinned only the three testing
+    // ranges, and the five build ranges beside them drifted one to two majors
+    // behind the repo's own toolchain unnoticed (objectui#3742). Adding a
+    // devDependency to the template without naming its anchor fails here.
+    const generated = generatedDevDependencies(VARS);
+    expect(Object.keys(generated).sort()).toEqual(Object.keys(DEV_DEPENDENCY_ANCHORS).sort());
+  });
+
+  it('sources every devDependency range from this repo instead of inventing them', () => {
     // These literals live in `.ts` source, outside the objectui#3711
     // version-claims gate's scan face, so this is the gate for them: the
     // template must quote the monorepo's own range for the same package.
-    // Bumping the root manifest and leaving the template behind is the drift
+    // Bumping an in-repo manifest and leaving the template behind is the drift
     // this test exists to catch — update `src/templates.ts` in the same PR.
-    const rootPkg = JSON.parse(readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf-8')) as {
-      devDependencies: Record<string, string>;
-    };
-    const generated = (
-      buildPackageJson(VARS) as { devDependencies: Record<string, string> }
-    ).devDependencies;
+    const generated = generatedDevDependencies(VARS);
 
-    for (const name of ['@testing-library/react', '@testing-library/jest-dom', 'jsdom']) {
-      expect(rootPkg.devDependencies[name], `${name} must exist in the root manifest`).toBeTruthy();
-      expect(generated[name], `${name} range must match the repo root`).toBe(
-        rootPkg.devDependencies[name]
-      );
+    for (const [name, anchor] of Object.entries(DEV_DEPENDENCY_ANCHORS)) {
+      if (anchor === 'root') {
+        const rootRange = rootRangeOf(name);
+        expect(rootRange, `${name} must exist in the root manifest`).toBeTruthy();
+        expect(generated[name], `${name} range must match the repo root`).toBe(rootRange);
+        continue;
+      }
+
+      const byRange = inRepoPluginRangesOf(name);
+      const ranges = Object.keys(byRange);
+      expect(
+        ranges.length,
+        `${name} must be declared by at least one packages/plugin-* manifest to anchor to`
+      ).toBeGreaterThan(0);
+      expect(
+        ranges.sort(),
+        `in-repo plugins disagree on ${name}: ${JSON.stringify(byRange)} — settle on one range first`
+      ).toHaveLength(1);
+      expect(generated[name], `${name} range must match packages/plugin-*`).toBe(ranges[0]);
+    }
+  });
+
+  it('keeps the two anchors consistent wherever both declare a dependency', () => {
+    // Makes the anchor CHOICE non-load-bearing: for anything declared both at
+    // the root and in the plugin manifests, the two must already agree, so
+    // reading one instead of the other cannot hide a drift.
+    for (const name of Object.keys(DEV_DEPENDENCY_ANCHORS)) {
+      const rootRange = rootRangeOf(name);
+      if (rootRange === undefined) continue;
+      for (const [range, plugins] of Object.entries(inRepoPluginRangesOf(name))) {
+        expect(
+          range,
+          `${name} is ${rootRange} at the repo root but ${range} in ${plugins.join(', ')}`
+        ).toBe(rootRange);
+      }
     }
   });
 });
@@ -151,6 +271,19 @@ describe('generated vite.config.ts', () => {
     // RTL only hooks cleanup when `afterEach` exists as a global
     // (`@testing-library/react/dist/index.js`: `if (typeof afterEach === 'function')`).
     expect(viteConfig).toContain('globals: true');
+  });
+
+  it('resolves paths with import.meta.dirname so it survives configLoader native', () => {
+    // vite 8 still defines `__dirname` under its default `bundle` config
+    // loader, but warns on it ("... unsupported by `configLoader: 'native'`,
+    // which is planned to become the default ... Use `import.meta.dirname`
+    // instead") and would fail outright once `native` is the default: that
+    // loader imports the config with Node's own ESM loader, which defines no
+    // `__dirname`. Same conversion `apps/console/vite.config.ts` got in
+    // objectui#3384 (objectui#3742).
+    expect(viteConfig).toContain('path.resolve(import.meta.dirname,');
+    expect(viteConfig).not.toContain('__dirname');
+    expect(viteConfig).not.toContain('__filename');
   });
 
   it('points setupFiles at a file the generator actually writes', () => {

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -45,33 +45,53 @@ export const VITEST_SETUP_FILE = 'vitest.setup.ts';
 /**
  * devDependencies written into the generated plugin.
  *
- * The three testing entries are SOURCED, not invented — each copies this
- * monorepo's own range for the same package verbatim, so the repo has one
- * range per dependency rather than one per file (objectui#3716; these literals
- * sit in `.ts` source, outside the objectui#3711 version-claims gate's scan
- * face, so `templates.test.ts` pins the parity instead):
+ * EVERY entry is SOURCED, not invented — each copies this monorepo's own range
+ * for the same package verbatim, so the repo has one range per dependency
+ * rather than one per file. These literals sit in `.ts` source, outside the
+ * objectui#3711 version-claims gate's scan face, so `templates.test.ts` pins
+ * the parity instead — and it pins the WHOLE map, not a subset, which is what
+ * stops a re-anchored entry from silently rotting again (objectui#3742).
  *
- * - `@testing-library/jest-dom` `^7.0.0`  — repo root package.json (also apps/console)
- * - `@testing-library/react`    `^16.3.2` — repo root package.json (also apps/console)
- * - `jsdom`                     `^30.0.1` — repo root package.json
+ * Two anchors, because not every build dependency exists in the root manifest.
+ * `create-plugin` writes into `<cwd>/packages/plugin-<name>`, so a generated
+ * plugin is a literal sibling of `packages/plugin-*` — those manifests are the
+ * faithful anchor for anything the root does not declare:
+ *
+ * | dependency                  | range     | anchor                                     |
+ * | --------------------------- | --------- | ------------------------------------------ |
+ * | `@testing-library/jest-dom` | `^7.0.0`  | repo root package.json (also apps/console) |
+ * | `@testing-library/react`    | `^16.3.2` | repo root package.json (also apps/console) |
+ * | `@vitejs/plugin-react`      | `^6.0.5`  | every `packages/plugin-*` (not in root)    |
+ * | `jsdom`                     | `^30.0.1` | repo root package.json                     |
+ * | `typescript`                | `^6.0.3`  | repo root package.json                     |
+ * | `vite`                      | `^8.2.0`  | repo root package.json                     |
+ * | `vite-plugin-dts`           | `^5.0.3`  | every `packages/plugin-*` (not in root)    |
+ * | `vitest`                    | `^4.1.10` | repo root package.json                     |
  *
  * `@testing-library/dom` is deliberately absent: it is a peer of
  * `@testing-library/react` 16 and is installed by the workspace's
  * `auto-install-peers=true`, which is also why `apps/console` declares the
  * same three and not four.
  *
- * The five build-side entries below keep the ranges they have shipped with;
- * re-anchoring those is a separate change, not part of this fix.
+ * The build entries carried pre-anchoring ranges until objectui#3742 — the
+ * scaffold handed authors vite 7 / plugin-react 4 / dts 4 / TypeScript 5 while
+ * the repo built and tested every in-tree plugin on vite 8 / plugin-react 6 /
+ * dts 5 / TypeScript 6. objectui#3716's artifact end-to-end run only ever
+ * exercised the in-repo versions, so the declared ranges were never the ones
+ * under test. Not a peer conflict: `^4.2.1` resolved to plugin-react 4.7.0,
+ * whose vite peer had widened to `^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0` and
+ * accepted vite 7 — the cost was a scaffold one to two majors behind its own
+ * monorepo, not a failing install.
  */
 const DEV_DEPENDENCIES: Record<string, string> = {
   '@testing-library/jest-dom': '^7.0.0',
   '@testing-library/react': '^16.3.2',
-  '@vitejs/plugin-react': '^4.2.1',
+  '@vitejs/plugin-react': '^6.0.5',
   jsdom: '^30.0.1',
-  typescript: '^5.9.3',
-  vite: '^7.3.1',
-  'vite-plugin-dts': '^4.5.4',
-  vitest: '^4.0.18'
+  typescript: '^6.0.3',
+  vite: '^8.2.0',
+  'vite-plugin-dts': '^5.0.3',
+  vitest: '^4.1.10'
 };
 
 /** The generated plugin's `package.json`, as an object (not yet serialised). */
@@ -139,6 +159,18 @@ export function buildTsconfig(): Record<string, unknown> {
  *   tests, silently, as soon as the author writes a second one.
  * - `setupFiles` — where the jest-dom matchers get registered; see
  *   {@link buildVitestSetup}.
+ *
+ * The entry path is resolved from `import.meta.dirname`, not `__dirname`. Vite
+ * still defines `__dirname` under its default `configLoader: 'bundle'`, but
+ * vite 8 warns on it ("Your Vite config uses features that are unsupported by
+ * `configLoader: 'native'`, which is planned to become the default in a future
+ * major version of Vite ... Use `import.meta.dirname` instead"), and under
+ * `native` — which imports the config with Node's own ESM loader, where no
+ * `__dirname` exists — it would fail outright. `apps/console/vite.config.ts`
+ * was converted for the same reason (objectui#3384); the generated config now
+ * ships already-correct rather than warning on an author's first `pnpm build`.
+ * Safe unconditionally here: the repo requires Node >= 22 and vite defines
+ * `import.meta.dirname` under the bundle loader too.
  */
 export function buildViteConfig(vars: PluginTemplateVars): string {
   return `import { defineConfig } from 'vite';
@@ -155,7 +187,7 @@ export default defineConfig({
   ],
   build: {
     lib: {
-      entry: path.resolve(__dirname, 'src/index.tsx'),
+      entry: path.resolve(import.meta.dirname, 'src/index.tsx'),
       name: '${vars.pascalName}',
       formats: ['es', 'umd'],
       fileName: (format) => \`index.\${format === 'es' ? 'js' : 'umd.cjs'}\`,


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3742

## 先说结论:issue 标题的那个论断不成立,但卡片要做的事成立

标题说「`@vitejs/plugin-react ^4.2.1` 的 peer 结构性无法被 `vite ^7.3.1` 满足 …… `pnpm install` 必报 peer 冲突」。**这一条经实测不成立**,原因是把「区间」当成了「定版」来量:

- issue 量的是 `npm view @vitejs/plugin-react@4.2.1 peerDependencies` → `{ vite: '^4.2.0 || ^5.0.0' }`,那是**区间下界那一个版本**的 peer。
- 但 `^4.2.1` 实际装的是 4.x 的最高版 **4.7.0**,它的 peer 早已放宽:

```
$ npm view @vitejs/plugin-react@4.7.0 peerDependencies
{ vite: '^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0' }
```

`vite ^7.3.1`(解析到 7.3.6)落在里面。拿改动前的模板清单做一次真实解析,并且把 `strict-peer-dependencies` 开到比本仓更严:

```
$ pnpm install --lockfile-only     # .npmrc: strict-peer-dependencies=true
Done in 5s using pnpm v10.33.0     # 退出码 0,零 peer 警告
# pnpm-lock.yaml:
      '@vitejs/plugin-react':
        specifier: ^4.2.1
        version: 4.7.0(vite@7.3.6)
```

装得干干净净。所以**没有 peer 冲突要修**。

**但漂移是真的**,而且卡片给的修法方向正确、与那个论断无关:五条 build 区间从未被锚定到任何东西,#3716 对生成产物的端到端验证只在仓内实际装的版本下跑过,**声明区间从来不是被测的那一组**。这个 PR 修的是漂移,不是 peer。changeset 和代码注释都按事实写,没有顺着标题写成「修了 peer 冲突」。

## 改了什么

### 1. 五条 build 区间改为从仓内锚点取值

沿用 PR #3733 给三条 test 区间定的做法(锚到仓根清单)。需要**两个**锚点,因为仓根并不声明全部:生成器写入 `packages/plugin-插件名`(相对 cwd),生成的包是 `packages/plugin-*` 的**同级兄弟**,所以仓根不声明的两个 build 工具就锚到这些 plugin 清单上。

| 依赖 | 原 | 现 | 锚点 |
| --- | --- | --- | --- |
| `vite` | `^7.3.1` | `^8.2.0` | 仓根 |
| `typescript` | `^5.9.3` | `^6.0.3` | 仓根 |
| `vitest` | `^4.0.18` | `^4.1.10` | 仓根 |
| `@vitejs/plugin-react` | `^4.2.1` | `^6.0.5` | 19/19 个 `packages/plugin-*`(仓根无) |
| `vite-plugin-dts` | `^4.5.4` | `^5.0.3` | 19/19 个 `packages/plugin-*`(仓根无) |

后两条无需在「选哪个 plugin」上做判断:全部 19 个仓内 plugin 对这两个区间**完全一致**,测试断言的就是这个一致性(不一致就红,并列出分歧的清单),而不是挑一个赢家。

### 2. parity 测试覆盖整张 devDependencies 清单

这是卡片的重点。原测试只钉三条 test 区间,旁边五条 build 区间就是因为**没有任何东西钉它们**才漂了 1–2 个 major。现在:

- **完整性闸门** —— 生成的 devDependencies 的键集合必须与锚点表逐一对应;新增一个依赖却不声明锚点即红。这条是防止「再退回只覆盖子集」的关键。
- **逐条 parity** —— 每条区间必须逐字等于其锚点的区间。
- **双锚一致性** —— 凡是仓根和 plugin 清单都声明的依赖,两处必须已经相同,于是「读哪个锚点」这件事不再承重、不会藏住漂移。

### 3. 生成的 `vite.config.ts`:`__dirname` → `import.meta.dirname`

issue 的附带观察,已核实,而且比「有警告」更严重。用 vite 8.2.0 自己的 `loadConfigFromFile` 把生成产物的两个版本各按两种 loader 加载一遍(预测在前,四条全部命中):

```
########## 旧(__dirname) / bundle
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`,
which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.old.ts:15:27). Use `import.meta.dirname` instead
RESULT: LOAD OK; build.lib.entry = .../src/index.tsx

########## 旧(__dirname) / native
RESULT: LOAD FAILED: __dirname is not defined in ES module scope

########## 新(import.meta.dirname) / bundle
RESULT: LOAD OK; build.lib.entry = .../src/index.tsx      # 无警告

########## 新(import.meta.dirname) / native
RESULT: LOAD OK; build.lib.entry = .../src/index.tsx
```

即在未来默认的 `native` 下旧写法是**直接加载失败**,不只是告警;新写法在两种 loader 下都正常,且解析出同一个 entry。`apps/console/vite.config.ts` 已在 #3384 因同样理由转换过,本仓 `engines.node: ">=22"` 满足 `import.meta.dirname`。

与 #3592(仓内 28 个 config 用 `__dirname`,标 `finding`)不重叠:那张单子的普查是 `git grep -- '*vite.config.ts'`,扫不到本模板 —— 模板是 `.ts` 源码里的字符串字面量。这里修的是**这个模式的产出源头**,#3592 的存量替换不受影响。

## 验证

```
$ pnpm exec vitest run packages/create-plugin/ --maxWorkers=2
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ pnpm --workspace-concurrency=2 --filter @object-ui/create-plugin type-check   # 退出 0
$ pnpm --workspace-concurrency=2 --filter @object-ui/create-plugin lint         # 退出 0
$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3691 tracked text file(s); skipped 85 binary).
$ node scripts/check-changeset-no-major.mjs
✅  No changeset declares a `major` bump.
```

**反向验证(先写预测再跑,四次全部按预测方向红)**:

| 扰动 | 预测 | 实际 |
| --- | --- | --- |
| `vite` 改 `^8.1.0` | parity 红,点名 vite | `AssertionError: vite range must match the repo root: expected '^8.1.0' to be '^8.2.0'` |
| `@vitejs/plugin-react` 改 `^6.0.4` | parity 红,点名该依赖 | `AssertionError: @vitejs/plugin-react range must match packages/plugin-*: expected '^6.0.4' to be '^6.0.5'` |
| 增一条无锚点依赖 | **完整性**测试红 | `AssertionError: expected [ … 8 ] to deeply equal [ … 7 ]` / `+ "unanchored-newcomer"` |
| 还原 `__dirname` | 新增的 config 测试红 | `expected '…' to contain 'path.resolve(import.meta.dirname,'` |

全部扰动已还原,基线 12 passed。

**产物生成 smoke(#3716 的离线做法)**:`pnpm --filter @object-ui/create-plugin build` 后把构建出的生成器跑进临时目录,产出的 `package.json` devDependencies 与 `vite.config.ts` 均为新值(上面第 3 节的 config 加载就是直接拿这份产物跑的)。未做产物的完整 `vite build`。

**改后清单的两两 peer 一致性**(非 optional peer 冲突 0 条):

```
@vitejs/plugin-react@^6.0.5 resolves to 6.0.5
  OK    peer vite@^8.0.0 vs declared ^8.2.0 (resolves 8.2.1)
vite-plugin-dts@^5.0.3 resolves to 5.0.3
  OK    peer vite@>=3 vs declared ^8.2.0 (resolves 8.2.1)
vitest@^4.1.10 resolves to 4.1.10
  OK    peer vite@^6.0.0 || ^7.0.0 || ^8.0.0 vs declared ^8.2.0 (resolves 8.2.1)
  OK    peer jsdom@* vs declared ^30.0.1 (resolves 30.0.1)

non-optional peer conflicts: 0
```

再用真实解析复核(同样开 `strict-peer-dependencies=true`),生成产物的清单装得干净:

```
      vite:            specifier: ^8.2.0   version: 8.2.1
      typescript:      specifier: ^6.0.3   version: 6.0.3
      vite-plugin-dts: specifier: ^5.0.3   version: 5.0.3(rolldown@1.2.3)(typescript@6.0.3)(vite@8.2.1)
      vitest:          specifier: ^4.1.10  version: 4.1.10(jsdom@30.0.1)(vite@8.2.1)
```

另外 `packages/plugin-grid/node_modules` 里实际装着 vite 8.2.0 + @vitejs/plugin-react 6.0.5 + vite-plugin-dts 5.0.3,即这一组本来就在本仓共存。

## 范围

只动 `packages/create-plugin/`(`templates.ts`、`templates.test.ts`)加一个 changeset。未动 `content/docs/utilities/create-plugin.mdx`(属 #3715),未动 `content/docs/releases/`。

越界发现另行记录,未在本 PR 修:生成的 `dependencies` 里 `lucide-react: '^0.563.0'`,而仓内 23 处声明全部是 `^1.28.0`;且没有任何生成的源文件 import 它。0.x 的 caret 不跨 minor 浮动(`^0.563.0` 即 `>=0.563.0 <0.564.0`),所以脚手架是被钉死在 0.563.x 上的。它位于 `dependencies` 而非 `devDependencies`,不在本卡范围内。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_