### PR TITLE
fix(data-table): 行「更多操作」触发器改为数「真正会渲染的项」，空则不渲染

### DIFF
--- a/.changeset/data-table-row-menu-empty-guard.md
+++ b/.changeset/data-table-row-menu-empty-guard.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/components': patch
+---
+
+fix(data-table): don't render a row overflow ("⋮") trigger that opens an empty menu
+
+The row overflow trigger was gated on whether row-action **handlers** were
+supplied (`onRowEdit` / `onRowDelete` / `rowActionDefs`), while the menu's items
+were filtered a second time — per item, per record — against
+`rowEditPredicates` / `rowDeletePredicates` and a custom action's `visible`. On a
+row where every item was predicate-suppressed the trigger still rendered and
+opened an empty box, which reads as a broken page.
+
+The trigger is now decided by the items that will actually render for that row,
+resolved through the same visibility rule the items gate themselves on, so the
+two cannot disagree. The decision is per row: within one table a row that keeps
+an action keeps its trigger while a row with nothing left renders none. The
+actions cell itself is unchanged, so the column stays aligned with its header.

--- a/packages/components/src/renderers/complex/__tests__/data-table-row-menu-empty-guard.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-row-menu-empty-guard.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3562 — the row overflow ("⋮") trigger must be decided by the menu
+ * items that will ACTUALLY render for that row, not by the handlers the schema
+ * supplied.
+ *
+ * Bug shape: the guard asked `!onRowEdit && !onRowDelete && customActions === 0`
+ * (handlers supplied), while the items were filtered a SECOND time, per item and
+ * per record, against `rowEditPredicates` / `rowDeletePredicates` / a custom
+ * def's `visible`. Handlers present + every item suppressed = a trigger that
+ * opens an empty box — measured downstream at 128×10 with zero `[role=menu]`
+ * children, which reads as a broken page.
+ *
+ * Predicates are per-RECORD, so the decision is per row: within one table, one
+ * row can legitimately keep its menu while the next has nothing left. The
+ * actions `<TableCell>` is never dropped, so the column stays aligned with its
+ * header no matter which rows kept a trigger.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { planDataTableRowMenu } from '../data-table';
+
+/** Both rows frozen: an edit/delete gated on "not frozen" survives on neither. */
+const FROZEN_ROWS = [
+  { id: 'r1', name: 'Frozen A', frozen: true },
+  { id: 'r2', name: 'Frozen B', frozen: true },
+];
+/** One frozen, one not — the mixed-column case. */
+const MIXED_ROWS = [
+  { id: 'r1', name: 'Frozen A', frozen: true },
+  { id: 'r2', name: 'Draft B', frozen: false },
+];
+
+/** The real `userActions.edit.visibleWhen` shape (objectui#2614). */
+const NOT_FROZEN = 'record.frozen != true';
+
+const BASE_SCHEMA = {
+  type: 'data-table',
+  pagination: false,
+  searchable: false,
+  // The table-level actions column: header + one cell per row. Independent of
+  // whether any given row ends up with a trigger.
+  rowActions: true,
+  columns: [{ header: 'Name', accessorKey: 'name' }],
+};
+
+function renderTable(schema: Record<string, unknown>) {
+  const DataTable = ComponentRegistry.get('data-table') as any;
+  if (!DataTable) throw new Error('data-table not registered');
+  return render(
+    <PredicateScopeProvider scope={{}}>
+      <DataTable schema={{ ...BASE_SCHEMA, ...schema }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+/** Every row overflow trigger currently in the document. */
+const triggers = () => screen.queryAllByLabelText('Row actions');
+
+/** The actions cell of each body row (always the last one here). */
+function actionCells(container: HTMLElement): HTMLTableCellElement[] {
+  return Array.from(container.querySelectorAll('tbody tr')).map((tr) => {
+    const cells = Array.from(tr.querySelectorAll('td')) as HTMLTableCellElement[];
+    return cells[cells.length - 1];
+  });
+}
+
+describe('data-table row overflow menu — the trigger counts renderable items (#3562)', () => {
+  it('renders NO trigger on a row whose every item is predicate-suppressed', () => {
+    const { container } = renderTable({
+      data: FROZEN_ROWS,
+      onRowEdit: () => {},
+      onRowDelete: () => {},
+      rowEditPredicates: { visibleWhen: NOT_FROZEN },
+      rowDeletePredicates: { visibleWhen: NOT_FROZEN },
+    });
+
+    // Handlers ARE supplied — the old guard rendered a trigger here.
+    expect(triggers()).toHaveLength(0);
+    // Nothing can be opened, so the empty 128×10 box has no way to exist.
+    expect(screen.queryByRole('menu')).toBeNull();
+
+    // The column survives: header plus one (empty) actions cell per row, so
+    // rows stay aligned exactly as in a table with no handlers at all.
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeInTheDocument();
+    const cells = actionCells(container);
+    expect(cells).toHaveLength(FROZEN_ROWS.length);
+    for (const cell of cells) expect(cell.querySelector('button')).toBeNull();
+  });
+
+  it('keeps the trigger when only SOME items are suppressed', () => {
+    renderTable({
+      data: FROZEN_ROWS,
+      onRowEdit: () => {},
+      onRowDelete: () => {},
+      // Edit is gated away on both rows; Delete is ungated and survives.
+      rowEditPredicates: { visibleWhen: NOT_FROZEN },
+    });
+    expect(triggers()).toHaveLength(FROZEN_ROWS.length);
+  });
+
+  it('renders no trigger when no handlers are supplied (unchanged)', () => {
+    renderTable({ data: MIXED_ROWS });
+    expect(triggers()).toHaveLength(0);
+  });
+
+  it('renders one trigger per row for the plain Edit + Delete case (unchanged)', () => {
+    renderTable({ data: MIXED_ROWS, onRowEdit: () => {}, onRowDelete: () => {} });
+    expect(triggers()).toHaveLength(MIXED_ROWS.length);
+  });
+
+  it('mixes rows with and without a trigger while keeping the column aligned', () => {
+    const { container } = renderTable({
+      data: MIXED_ROWS,
+      onRowEdit: () => {},
+      rowEditPredicates: { visibleWhen: NOT_FROZEN },
+    });
+
+    // Only the non-frozen row keeps an item, so only it keeps a trigger.
+    expect(triggers()).toHaveLength(1);
+    const cells = actionCells(container);
+    expect(cells).toHaveLength(MIXED_ROWS.length);
+    // Same cell count on every row — no row is short a `<td>`.
+    const widths = Array.from(container.querySelectorAll('tbody tr')).map(
+      (tr) => tr.querySelectorAll('td').length,
+    );
+    expect(new Set(widths).size).toBe(1);
+    expect(cells[0].querySelector('button')).toBeNull();
+    expect(cells[1].querySelector('button')).not.toBeNull();
+  });
+
+  it('suppresses the trigger when every CUSTOM action is invisible for the row', () => {
+    renderTable({
+      data: FROZEN_ROWS,
+      onRowActionDef: () => {},
+      rowActionDefs: [
+        { name: 'unfreeze', label: 'Unfreeze', visible: NOT_FROZEN },
+        { name: 'publish', label: 'Publish', visible: NOT_FROZEN },
+      ],
+    });
+    expect(triggers()).toHaveLength(0);
+  });
+});
+
+/**
+ * The item-resolution the guard counts with, exercised directly: the DOM tests
+ * above pin whether a trigger exists, these pin WHICH items it would hold. Both
+ * read the same `planDataTableRowMenu`, which is also what the item components
+ * gate themselves on — so the trigger and its contents cannot drift apart.
+ */
+describe('planDataTableRowMenu', () => {
+  const scope = {};
+  const frozen = FROZEN_ROWS[0];
+  const draft = MIXED_ROWS[1];
+  const noop = () => {};
+
+  it('counts nothing when no handlers are supplied', () => {
+    const plan = planDataTableRowMenu({ customActions: [], row: draft, scope });
+    expect(plan).toMatchObject({ edit: false, remove: false, count: 0 });
+  });
+
+  it('counts both built-ins when they are ungated', () => {
+    const plan = planDataTableRowMenu({
+      onRowEdit: noop,
+      onRowDelete: noop,
+      customActions: [],
+      row: frozen,
+      scope,
+    });
+    expect(plan).toMatchObject({ edit: true, remove: true, count: 2 });
+  });
+
+  it('drops only the suppressed built-in', () => {
+    const plan = planDataTableRowMenu({
+      onRowEdit: noop,
+      onRowDelete: noop,
+      editPredicates: { visibleWhen: NOT_FROZEN },
+      customActions: [],
+      row: frozen,
+      scope,
+    });
+    expect(plan).toMatchObject({ edit: false, remove: true, count: 1 });
+  });
+
+  it('reaches zero when every built-in is suppressed for the row', () => {
+    const args = {
+      onRowEdit: noop,
+      onRowDelete: noop,
+      editPredicates: { visibleWhen: NOT_FROZEN },
+      deletePredicates: { visibleWhen: NOT_FROZEN },
+      customActions: [],
+      scope,
+    };
+    expect(planDataTableRowMenu({ ...args, row: frozen }).count).toBe(0);
+    // …and the very same table keeps both items on a row that passes.
+    expect(planDataTableRowMenu({ ...args, row: draft }).count).toBe(2);
+  });
+
+  it('keeps the custom actions whose `visible` passes, in declared order', () => {
+    const plan = planDataTableRowMenu({
+      customActions: [
+        { name: 'unfreeze', visible: 'record.frozen == true' },
+        { name: 'publish', visible: NOT_FROZEN },
+        { name: 'view' },
+      ] as any,
+      row: frozen,
+      scope,
+    });
+    expect(plan.custom.map((a) => a.name)).toEqual(['unfreeze', 'view']);
+    expect(plan.count).toBe(2);
+  });
+
+  it('still counts an item that renders merely DISABLED', () => {
+    const plan = planDataTableRowMenu({
+      onRowEdit: noop,
+      editPredicates: { disabledWhen: 'record.frozen == true' },
+      customActions: [],
+      row: frozen,
+      scope,
+    });
+    expect(plan).toMatchObject({ edit: true, count: 1 });
+  });
+
+  it('fails CLOSED on a faulting predicate (no phantom item, no phantom trigger)', () => {
+    const plan = planDataTableRowMenu({
+      onRowEdit: noop,
+      editPredicates: { visibleWhen: 'record.frozen ==' },
+      customActions: [],
+      row: frozen,
+      scope,
+    });
+    expect(plan).toMatchObject({ edit: false, count: 0 });
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -11,9 +11,9 @@ import React, { useState, useMemo, useRef, useEffect, useLayoutEffect } from 're
 import { cn } from '../../lib/utils';
 import { resolveIcon } from '../action/resolve-icon';
 import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
-import { ComponentRegistry, compareSortValues, getSortValue } from '@object-ui/core';
+import { ComponentRegistry, compareSortValues, evalRowPredicate, getSortValue } from '@object-ui/core';
 import type { DataTableSchema, TableSortItem } from '@object-ui/types';
-import { useRowPredicate } from '@object-ui/react';
+import { useRowPredicate, usePredicateScope } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { 
   Table, 
@@ -189,6 +189,123 @@ function extractSaveErrorMessage(error: unknown): string {
 type RowActionDef = NonNullable<DataTableSchema['rowActionDefs']>[number];
 
 /**
+ * Evaluate a row-action visibility predicate the way the row menu's items do —
+ * on the canonical CEL engine, failing CLOSED with a diagnosable warning — but
+ * WITHOUT a hook.
+ *
+ * Hook-free matters because the row-level guard below asks this question for a
+ * VARIABLE number of custom actions inside a single `useMemo`; one
+ * `useRowPredicate` per action would tie the hook count to
+ * `schema.rowActionDefs.length`. Mirrors
+ * `useRowPredicate(pred, row, { fallback: false, warnOnError: true, label })`,
+ * boolean short-circuit included — a boolean handed to the engine faults
+ * ("AST-only evaluation not yet supported") and fails closed, which is how
+ * `visible: true` once hid a bulk button from everyone (objectui#3492; the same
+ * short-circuit is spelled out in plugin-grid's `bulkEligibility`).
+ */
+function evalRowActionVisibility(
+  pred: unknown,
+  row: any,
+  scope: Record<string, unknown>,
+  label: string,
+): boolean {
+  if (typeof pred === 'boolean') return pred;
+  if (pred == null || pred === '') return false;
+  return evalRowPredicate(pred as never, row ?? {}, {
+    fallback: false,
+    scope,
+    warnOnError: true,
+    label,
+  });
+}
+
+/**
+ * Does the built-in Edit/Delete item render for THIS row? The single
+ * definition, read both by the item itself and by the row-level guard that
+ * decides whether the "⋮" trigger exists at all. The two disagreeing is
+ * objectui#3562: the guard counted handlers, the items were then filtered by
+ * these predicates, and a row with every item suppressed still got a trigger
+ * that opened an empty 128×10 box.
+ *
+ * `visibleWhen` counts as a declared gate by `!= null`, not by truthiness —
+ * `visibleWhen: false` hides the item rather than reading as "ungated".
+ */
+export function isBuiltinRowActionVisible(
+  predicates: { visibleWhen?: unknown } | undefined,
+  name: 'edit' | 'delete',
+  row: any,
+  scope: Record<string, unknown>,
+): boolean {
+  const pred = predicates?.visibleWhen;
+  if (pred == null) return true;
+  return evalRowActionVisibility(pred, row, scope, `builtin:${name}:visibleWhen`);
+}
+
+/**
+ * Does this schema-driven custom row action render for THIS row? Same
+ * single-definition rule as the built-ins above.
+ *
+ * The gate is truthiness, which is what the item has always applied: a
+ * `visible: false` def renders (the objectui#3492 shape). Preserved verbatim —
+ * the contract this function exists for is that the guard and the item agree,
+ * and re-deciding `visible: false` would change WHICH items render, a separate
+ * question tracked on its own issue.
+ */
+export function isCustomRowActionVisible(
+  action: { name?: string; visible?: unknown } | undefined,
+  row: any,
+  scope: Record<string, unknown>,
+): boolean {
+  if (!action?.visible) return true;
+  return evalRowActionVisibility(action.visible, row, scope, action.name ?? 'row-action');
+}
+
+/** What the row overflow menu will actually render for ONE row. */
+export interface DataTableRowMenuPlan {
+  /** The built-in Edit item renders for this row. */
+  edit: boolean;
+  /** The built-in Delete item renders for this row. */
+  remove: boolean;
+  /** Custom actions surviving their own `visible` predicate, in declared order. */
+  custom: RowActionDef[];
+  /** Items that will render. `0` means: render no trigger at all (#3562). */
+  count: number;
+}
+
+/**
+ * Resolve the row overflow menu for ONE row — which items survive their
+ * per-record predicates, and how many that leaves.
+ *
+ * Per ROW, not per table: `visibleWhen` / `visible` are per-record predicates,
+ * so two rows of the same table legitimately differ (one keeps Edit, the next
+ * has nothing left). A table-level guard cannot express that, which is why the
+ * trigger decision lives here and is recomputed for every row.
+ *
+ * Only visibility is decided here — a `disabled` item still renders (greyed
+ * out) and still counts, exactly as before.
+ */
+export function planDataTableRowMenu(input: {
+  onRowEdit?: unknown;
+  onRowDelete?: unknown;
+  editPredicates?: { visibleWhen?: unknown };
+  deletePredicates?: { visibleWhen?: unknown };
+  customActions: readonly RowActionDef[];
+  row: any;
+  scope: Record<string, unknown>;
+}): DataTableRowMenuPlan {
+  const { row, scope } = input;
+  const edit = !!input.onRowEdit && isBuiltinRowActionVisible(input.editPredicates, 'edit', row, scope);
+  const remove = !!input.onRowDelete && isBuiltinRowActionVisible(input.deletePredicates, 'delete', row, scope);
+  const custom = input.customActions.filter((action) => isCustomRowActionVisible(action, row, scope));
+  return {
+    edit,
+    remove,
+    custom,
+    count: (edit ? 1 : 0) + (remove ? 1 : 0) + custom.length,
+  };
+}
+
+/**
  * One schema-driven custom row action in the data-table's inline row overflow
  * menu. Extracted into its own component so the action's `visible` (and
  * `disabled`) CEL predicate can be evaluated with a hook (`useCondition`)
@@ -215,13 +332,18 @@ export const DataTableRowActionItem: React.FC<{
   row: any;
   onActionDef?: (action: RowActionDef, row: any) => void | Promise<void>;
 }> = ({ action, row, onActionDef }) => {
-  const visiblePred = action.visible;
   // Evaluate on the canonical CEL engine (issue #1584): row bound bare + as
   // `record.*`, ambient `features`/`user` scope merged. `visible` fails CLOSED
   // (hidden + warn); `disabled` fails soft (not disabled).
-  const isVisible = useRowPredicate(visiblePred, row, { fallback: false, warnOnError: true, label: action.name });
+  //
+  // `visible` goes through the shared `isCustomRowActionVisible` — the SAME
+  // function the row-level guard uses to decide whether this row gets a "⋮"
+  // trigger at all, so an item can never be suppressed behind a trigger that
+  // survived (objectui#3562).
+  const scope = usePredicateScope();
+  const isVisible = useMemo(() => isCustomRowActionVisible(action, row, scope), [action, row, scope]);
   const isDisabled = useRowPredicate(action.disabled, row, { fallback: false, warnOnError: true, label: `${action.name}:disabled` });
-  if (visiblePred && !isVisible) return null;
+  if (!isVisible) return null;
   const ActionIcon = resolveIcon(action.icon);
   return (
     <DropdownMenuItem
@@ -263,17 +385,19 @@ export const DataTableBuiltinRowActionItem: React.FC<{
   className?: string;
   onSelect: (row: any) => void;
 }> = ({ name, predicates, row, icon, label, className, onSelect }) => {
-  const isVisible = useRowPredicate(predicates?.visibleWhen, row, {
-    fallback: false,
-    warnOnError: true,
-    label: `builtin:${name}:visibleWhen`,
-  });
+  // `visibleWhen` is read through the shared `isBuiltinRowActionVisible`, the
+  // same function the row-level guard counts with — see objectui#3562.
+  const scope = usePredicateScope();
+  const isVisible = useMemo(
+    () => isBuiltinRowActionVisible(predicates, name, row, scope),
+    [predicates, name, row, scope],
+  );
   const isDisabled = useRowPredicate(predicates?.disabledWhen, row, {
     fallback: false,
     warnOnError: true,
     label: `builtin:${name}:disabledWhen`,
   });
-  if (predicates?.visibleWhen != null && !isVisible) return null;
+  if (!isVisible) return null;
   const disabled = predicates?.disabledWhen != null && isDisabled;
   return (
     <DropdownMenuItem
@@ -285,6 +409,115 @@ export const DataTableBuiltinRowActionItem: React.FC<{
       {icon}
       {label}
     </DropdownMenuItem>
+  );
+};
+
+/**
+ * The row overflow ("⋮") menu for ONE row — trigger included, or nothing at all.
+ *
+ * A component per row rather than inline JSX in the row loop, because deciding
+ * whether the trigger exists means evaluating THIS row's predicates, and that
+ * needs a hook scope of its own (the row loop's arity is the page's row count).
+ *
+ * objectui#3562: the old guard asked whether HANDLERS were supplied
+ * (`onRowEdit` / `onRowDelete` / `rowActionDefs`) while the items were filtered
+ * a second time by their per-record predicates. Handlers present + every item
+ * suppressed = a trigger that opens an empty box (measured at 128×10 with zero
+ * `[role=menu]` children). The guard now counts the items that will actually
+ * render, so the two can't disagree.
+ *
+ * The actions `<TableCell>` around this is NOT conditional: a row with no
+ * surviving actions renders an empty cell, keeping every row aligned with the
+ * `Actions` header — the same shape a table with no handlers at all has always
+ * produced.
+ */
+const DataTableRowActionsMenu: React.FC<{
+  schema: DataTableSchema;
+  row: any;
+  t: (key: string) => string;
+}> = ({ schema, row, t }) => {
+  const scope = usePredicateScope();
+  // Custom defs are only dispatchable when there is a handler to dispatch them
+  // to, so an unhandled `rowActionDefs` contributes no items (unchanged).
+  const customActions = useMemo(
+    () => (Array.isArray(schema.rowActionDefs) && schema.onRowActionDef ? schema.rowActionDefs : []),
+    [schema.rowActionDefs, schema.onRowActionDef],
+  );
+  const plan = useMemo(
+    () =>
+      planDataTableRowMenu({
+        onRowEdit: schema.onRowEdit,
+        onRowDelete: schema.onRowDelete,
+        editPredicates: schema.rowEditPredicates,
+        deletePredicates: schema.rowDeletePredicates,
+        customActions,
+        row,
+        scope,
+      }),
+    [
+      schema.onRowEdit,
+      schema.onRowDelete,
+      schema.rowEditPredicates,
+      schema.rowDeletePredicates,
+      customActions,
+      row,
+      scope,
+    ],
+  );
+  // Nothing to show → no trigger. An affordance that opens empty reads as a
+  // broken page, which is the whole of #3562.
+  if (plan.count === 0) return null;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Row actions"
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        {plan.edit && (
+          <DataTableBuiltinRowActionItem
+            name="edit"
+            predicates={schema.rowEditPredicates}
+            row={row}
+            icon={<Edit className="mr-2 h-4 w-4" />}
+            label={t('table.edit')}
+            onSelect={(r) => schema.onRowEdit?.(r)}
+          />
+        )}
+        {/* Child-object custom actions (e.g. a related list surfacing the
+            child's `list_item` actions). Dispatched with the clicked row.
+            Separators are placed off the SURVIVING groups, so a suppressed
+            group can no longer leave a stray rule behind. */}
+        {plan.custom.length > 0 && plan.edit && <DropdownMenuSeparator />}
+        {plan.custom.map((action) => (
+          <DataTableRowActionItem
+            key={action.name}
+            action={action}
+            row={row}
+            onActionDef={schema.onRowActionDef}
+          />
+        ))}
+        {plan.remove && (plan.edit || plan.custom.length > 0) && <DropdownMenuSeparator />}
+        {plan.remove && (
+          <DataTableBuiltinRowActionItem
+            name="delete"
+            predicates={schema.rowDeletePredicates}
+            row={row}
+            icon={<Trash2 className="mr-2 h-4 w-4" />}
+            label={t('table.delete')}
+            className="text-destructive focus:text-destructive"
+            onSelect={(r) => schema.onRowDelete?.(r)}
+          />
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 
@@ -1968,66 +2201,9 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                 </Button>
                               </>
                             ) : (
-                              (() => {
-                                const customActions =
-                                  Array.isArray(schema.rowActionDefs) && schema.onRowActionDef
-                                    ? schema.rowActionDefs
-                                    : [];
-                                if (!schema.onRowEdit && !schema.onRowDelete && customActions.length === 0) {
-                                  return null;
-                                }
-                                return (
-                                <DropdownMenu>
-                                  <DropdownMenuTrigger asChild>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8"
-                                      onClick={(e) => e.stopPropagation()}
-                                      aria-label="Row actions"
-                                    >
-                                      <MoreHorizontal className="h-4 w-4" />
-                                    </Button>
-                                  </DropdownMenuTrigger>
-                                  <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-                                    {schema.onRowEdit && (
-                                      <DataTableBuiltinRowActionItem
-                                        name="edit"
-                                        predicates={schema.rowEditPredicates}
-                                        row={row}
-                                        icon={<Edit className="mr-2 h-4 w-4" />}
-                                        label={t('table.edit')}
-                                        onSelect={(r) => schema.onRowEdit?.(r)}
-                                      />
-                                    )}
-                                    {/* Child-object custom actions (e.g. a related
-                                        list surfacing the child's `list_item`
-                                        actions). Dispatched with the clicked row. */}
-                                    {customActions.length > 0 && schema.onRowEdit && <DropdownMenuSeparator />}
-                                    {customActions.map((action) => (
-                                      <DataTableRowActionItem
-                                        key={action.name}
-                                        action={action}
-                                        row={row}
-                                        onActionDef={schema.onRowActionDef}
-                                      />
-                                    ))}
-                                    {schema.onRowDelete && (schema.onRowEdit || customActions.length > 0) && <DropdownMenuSeparator />}
-                                    {schema.onRowDelete && (
-                                      <DataTableBuiltinRowActionItem
-                                        name="delete"
-                                        predicates={schema.rowDeletePredicates}
-                                        row={row}
-                                        icon={<Trash2 className="mr-2 h-4 w-4" />}
-                                        label={t('table.delete')}
-                                        className="text-destructive focus:text-destructive"
-                                        onSelect={(r) => schema.onRowDelete?.(r)}
-                                      />
-                                    )}
-                                  </DropdownMenuContent>
-                                </DropdownMenu>
-                                );
-                              })()
+                              /* Trigger + menu, or nothing when this row's
+                                 predicates leave no item to show (#3562). */
+                              <DataTableRowActionsMenu schema={schema} row={row} t={t} />
                             )}
                           </div>
                         </TableCell>


### PR DESCRIPTION
Part of objectstack-ai/objectui#3562（data-table 半件——本 PR 不关闭该单；报告人那一屏的 plugin-grid 孪生半件已由 PM 按同一裁定另派，落地后由该 PR 关闭 #3562）

> **PM 裁定(方案 A,2026-08-08)**:本 PR 修掉的是 data-table 行菜单守卫(真实、可达、与本单同一类缺陷,生产者为详情页关联列表);报告人所在的 console 对象列表走 plugin-grid 的 `RowActionMenu`(证据见下「登陆点更正」),孪生修复同裁定另单交付。

## 问题

行「更多操作」触发器的守卫数的是**传入了哪些 handler**,而菜单项随后又被**逐项、逐记录**地按谓词过滤了第二遍:

`packages/components/src/renderers/complex/data-table.tsx`(修改前,`origin/main@b7b05da7f`):

```
const customActions = Array.isArray(schema.rowActionDefs) && schema.onRowActionDef ? schema.rowActionDefs : [];
if (!schema.onRowEdit && !schema.onRowDelete && customActions.length === 0) return null;
```

而项一级的过滤在 `DataTableBuiltinRowActionItem`(`rowEditPredicates` / `rowDeletePredicates` 的 `visibleWhen`)和 `DataTableRowActionItem`(自定义动作的 `visible`)里。于是「handler 都在、但这一行的每一项都被谓词压掉」这个状态是可达的:触发器活过了守卫,菜单里却什么都不渲染 —— 一个点开是空白的按钮。

## 修复(方案 2,对象无关)

守卫改为数**真正会渲染的项**,零则整个触发器不渲染。

- **谓词求值只有一处**:新增 `isBuiltinRowActionVisible` / `isCustomRowActionVisible`,`planDataTableRowMenu` 与两个 item 组件**都**读它们。项与触发器因此在结构上无法再各说各话(不是靠两处写法碰巧一致)。
- **守卫落在行级,不是表级**:`visibleWhen` / `visible` 是**按记录**求值的谓词,同一张表里第一行可能保留 Edit、第二行一项不剩。表级守卫表达不了这件事,所以行菜单被抽成 per-row 组件 `DataTableRowActionsMenu`,每行各自决定。
- **求值不用 hook**:`evalRowActionVisibility` 走 `@object-ui/core` 的 `evalRowPredicate`(`fallback: false` + `warnOnError`,与 `useRowPredicate` 同参),因为自定义动作的条数是变量,一项一个 `useRowPredicate` 会把 hook 数量绑到 `schema.rowActionDefs.length` 上。布尔短路照抄 plugin-grid `bulkEligibility` 里写明的理由(objectui#3492:布尔交给引擎会 fault 并 fail-closed)。
- **分隔线跟着存活的分组走**:以前 `onRowDelete && (onRowEdit || custom > 0)` 会在两项都被压掉时留下一条孤立横线,现在按 plan 里存活的分组放。
- **列对齐不变**:操作列的表头与每行的操作单元格都由表级 `rowActions` 决定,本次只改单元格**内部**的内容 —— 没有动作可显示的行渲染一个空单元格,与「完全没接 handler 的表」历来的形态一致。测试里钉住了混合行(一行有触发器、一行没有)的 `td` 数量一致。

自定义动作的 `visible` 仍按**真值**判断门(`visible: false` 会渲染),与今天的项行为逐字一致 —— 本函数存在的意义是守卫和项一致,重新裁决 `visible: false` 会改变**哪些项渲染**,那是另一个问题(objectui#3492 的形状),已单独记录为 #3758。

## 登陆点更正(issue 只是线索,premise 验证结果)

分诊把落点定在本文件,但**报告人那块空白 ⋮ 不在这条路径上**。按 `origin/main@b7b05da7f` 逐条核:

1. `packages/plugin-grid/src/ObjectGrid.tsx:2194` —— `rowActions: !!(schema.editable && hasActions)`,注释写明「RowActionMenu column (from columnsWithActions) already handles edit/delete … Only enable DataTable's built-in action column for inline-editing save/cancel」。console 的对象列表不 editable 时,data-table 的操作单元格**根本不渲染**。
2. `ObjectGrid.tsx:1624-1660` —— 列表自己注入一列操作列,cell 渲染 `RowActionMenu`(plugin-grid),条件是 `hasActions || hasRowActions`。
3. `grep -c 'onRowEdit\|onRowDelete' packages/plugin-grid/src/ObjectGrid.tsx` = **0** —— ObjectGrid 从不把 `onRowEdit` / `onRowDelete` / `rowEditPredicates` 传给 data-table,所以即便操作单元格渲染了,本文件的下拉分支也拿不出任何项。
4. `ObjectGrid.tsx:1448` 注释:「ObjectGrid is the single convergence point of all three list callers」—— console 的三种列表调用方(含 Setup 的系统对象列表)都汇到 ObjectGrid。
5. 孪生缺陷在 `packages/plugin-grid/src/components/RowActionMenu.tsx:273-278`:`hasMenu = (canEdit && onEdit) || (canDelete && onDelete) || menuDefs.length > 0 || rowActions.length > 0` —— **同样在数 handler / 声明数**;项一级过滤在 `:130`、`:179`、`:219`。sys_approval_request 在 `list_item` 上声明的动作(approve / reject / recall 等)`visible` 是写给审批人的,admin 在「全部」视图里逐行都不满足 → `hasMenu` 为真、0 项,与报告完全吻合。
6. 旁证:报告实测 `[role=menu]` 的 `children.length === 0`。本文件修改前,`onRowEdit` 与 `onRowDelete` 同时在场时会**无条件**渲染一条 `DropdownMenuSeparator`,那种状态下 children 至少是 1;plugin-grid 的 `RowActionMenu` 一条分隔线都没有,全压掉正好是 0。
7. 本文件这条路径的真实生产者是 `packages/plugin-detail/src/RelatedList.tsx:1004-1042`(详情页关联列表把子对象的 `userActions.edit/delete` 谓词与 `list_item` 动作喂进 data-table)—— 缺陷在这里真实可达(子记录被父状态冻结后 Edit/Delete 双双压掉即空菜单),只是不是报告人那一屏。

所以:本单描述的**缺陷类别**成立且已在本文件修掉;本单**报告人的那一屏**要修 plugin-grid 的 `RowActionMenu`,由 PM 按同一裁定另单派发。

## 测试

`packages/components/src/renderers/complex/__tests__/data-table-row-menu-empty-guard.test.tsx`(新增):

- 整行被压掉 → 一个触发器都没有,`[role=menu]` 不存在,同时操作列表头与每行空单元格仍在(本单形状);
- 只压掉一部分 → 触发器保留;
- 完全没接 handler → 无触发器(旧行为不变);
- 常规 Edit + Delete 两项 → 每行一个触发器(报告人的对照组不变);
- 混合行(frozen 行无触发器 / draft 行有)→ 触发器数 1,两行 `td` 数量相同;
- 全部自定义动作被 `visible` 压掉 → 无触发器;
- `planDataTableRowMenu` 纯函数:计数、只掉被压的那一项、存活自定义动作按声明序、`disabledWhen` 的项**仍然算数**、谓词报错 fail-closed(不产生幽灵项/幽灵触发器)。

既有的两套项级测试(`data-table-builtin-row-action-predicates.test.tsx` / `data-table-row-action-visible.test.tsx`)未改动即全绿 —— item 组件改成走共享谓词函数后行为等价。

## 反向验证(先预测后运行)

预测:把守卫换回数 handler 的旧式(`!onRowEdit && !onRowDelete && custom === 0`),则「整行被压掉 → 无触发器」、「混合行触发器数 1」、「自定义动作全被压 → 无触发器」三条**转红**,其余(部分压掉 / 无 handler / 常规两项 / 7 条纯函数用例)**保持绿** —— 它们的触发器存在性在两种守卫下相同,纯函数用例根本不经过守卫。

正向(仓库根,flock 串行,`--maxWorkers=2`):

```
pnpm exec vitest run packages/components/src/renderers/complex/ --maxWorkers=2
 Test Files  7 passed (7)
      Tests  38 passed (38)
```

反向(仅把守卫那一行换回旧式):

```
 × renders NO trigger on a row whose every item is predicate-suppressed
 × mixes rows with and without a trigger while keeping the column aligned
 × suppresses the trigger when every CUSTOM action is invisible for the row
 Test Files  1 failed | 4 passed (5)
      Tests  3 failed | 30 passed (33)
AssertionError: expected [ ... ] to have a length of +0 but got 2
```

三红三十绿,与事先写下的预测逐条一致。

其余门:`pnpm --filter @object-ui/components type-check` → 0;`pnpm --filter @object-ui/components lint` → 0;`node scripts/check-control-bytes.mjs` → OK(另对改动文件手工扫过控制字符类,无命中)。

消费半径清查(不是只扫本包):`data-table` 行菜单的消费者为 `plugin-detail/RelatedList`、`plugin-dashboard`、`plugin-grid`(仅 inline-edit 存/撤路径)与 SDUI 原生 `data-table`;全仓 grep 触发器断言(`Row actions`)与 `rowEditPredicates|rowDeletePredicates|onRowActionDef` 的测试,只有 `plugin-detail/src/__tests__/RelatedList.rowactions.test.tsx` 命中,而它 mock 掉了 data-table、只断言透传的 schema,不经过本次改动。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_