### PR TITLE
fix(plugin-dashboard): 交叉表(pivot ≥2 维)单元格内叠加 compareTo 对比值 (#3614)

### DIFF
--- a/.changeset/pivot-compare-stacking-3614.md
+++ b/.changeset/pivot-compare-stacking-3614.md
@@ -1,0 +1,16 @@
+---
+"@object-ui/plugin-dashboard": patch
+---
+
+Show the `compareTo` comparison in a dataset pivot cross-tab instead of dropping it
+
+A dataset widget with `type: 'pivot'` and two or more `dimensions` renders a true cross-tab, and that branch was the one render path the `compareTo` work left out (objectui#3614, following objectui#3337 / PR #3612). It laid out its columns as `bucket × measure` and never admitted the `<measure>__compare` columns the executor returns — so a pivot with a bounded date window and a `compareTo` ran a correct comparison query, received correct comparison data, and displayed none of it: headers, cells and all three subtotals were silent.
+
+The comparison is now **stacked inside the cell** — current value on top, comparison value and its delta percentage beneath in smaller type:
+
+- The pivot's column structure is unchanged. Giving the comparison a column of its own would turn `bucket × measure` into `bucket × measure × window`, doubling the width and adding a third header level on the widget family whose width is already the scarce resource.
+- **Row, column and grand subtotals stack it the same way.** A Total that alone showed no comparison would read as "this row has none", which is a different and false statement.
+- One caption names the comparison window ("vs last year") for the whole table, from the same `dashboard.trend.*` vocabulary the KPI and flat-table paths use, and the delta comes from the same helper — so a KPI and a cross-tab cell comparing the same two windows agree on sign and rounding.
+- **CSV export stays data-shaped.** The cross-tab now exports a flat `<measure>__compare` column per compared measure, with bare numbers in the cells: a spreadsheet can compute on the export, and no stacked display string ("$120 $100 20%") ever reaches it.
+
+Presence is detected from the returned data, as on every other path, so there is no new option to set — and a pivot the executor sent no comparison for renders exactly as it did before.

--- a/packages/plugin-dashboard/SKILL.md
+++ b/packages/plugin-dashboard/SKILL.md
@@ -14,7 +14,7 @@ table, pivot, etc.) with drag/resize, drill-down, and async data binding.
 
 ## Period-over-period comparison (`compareTo`)
 
-Any dataset-bound widget (metric / gauge / chart / table) can opt into a
+Any dataset-bound widget (metric / gauge / chart / table / pivot) can opt into a
 period-over-period comparison by adding a `compareTo` field. The dataset
 executor re-runs the same selection over the shifted window and attaches a
 `<measure>__compare` column to each row, which the widget shows as:
@@ -25,6 +25,21 @@ executor re-runs the same selection over the shifted window and attaches a
   a muted second series (dashed line, lower fill opacity). Pie, donut, and
   funnel charts ignore `compareTo`.
 - For **table** widgets, a comparison column beside each compared measure.
+- For a **pivot** cross-tab (`type: 'pivot'` with ≥2 dimensions), the comparison
+  is stacked **inside** the cell — current value on top, comparison value and
+  delta beneath in smaller type — because those columns are already
+  `bucket × measure` and a comparison column would double the width. Row,
+  column and grand subtotals stack it the same way, and one caption names the
+  window for the whole table (objectui#3614).
+
+Nothing is opted into per render path: every path detects the comparison from
+the `<measure>__compare` column in the returned data, so a selection the
+executor sent no comparison for renders exactly as it does without `compareTo`.
+
+**CSV export is data, not a picture of the table.** The export always emits a
+flat `<measure>__compare` column per compared measure — including the cross-tab,
+whose display stacks them — so exported cells stay bare numbers a spreadsheet
+can compute on.
 
 ### Accepted value
 

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -669,9 +669,13 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     const measureColumns = values.flatMap((m) =>
       comparedValues.includes(m) ? [m, compareColumn(m)] : [m],
     );
-    // The cross-tab does not spread comparison columns (that would key every
-    // cell by bucket × measure × window); its export stays the plain grid.
-    const exportColumns = [...dimensions, ...(isMatrix ? values : measureColumns)];
+    // The cross-tab exports its comparison columns too (objectui#3614), even
+    // though its DISPLAY stacks them inside the cell: a CSV is data, not a
+    // picture of the table. So each compared measure keeps its own flat
+    // `<measure>__compare` column here and every exported cell stays the bare
+    // number a spreadsheet can compute on — serializing the stacked cell would
+    // emit strings like "$120 $100 20%", which is a screenshot in CSV clothing.
+    const exportColumns = [...dimensions, ...measureColumns];
     const exportCsv = () => downloadCsv(String(widget?.title ?? datasetName ?? 'export'), [
       exportColumns.map((c) => columnLabel(c)),
       ...state.rows.map((r) => exportColumns.map((c) => {
@@ -705,6 +709,76 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
         values.map((m) => ({ col, measure: m, header: values.length === 1 ? col.label : `${col.label} · ${headerLabel(m)}` })),
       );
       const fmtMeasure = (v: unknown, m: string) => formatMeasure(v, measureField(m)?.format, measureField(m)?.currency, measureField(m)?.percentScale);
+      // ── The comparison, stacked inside the cell (objectui#3614) ───────────
+      // A cross-tab's columns are already `bucket × measure`; giving the
+      // comparison a column of its own would make them `bucket × measure ×
+      // window` — twice the width and a third header level — on the one widget
+      // family whose width is already the scarce resource. So the comparison
+      // stacks INSIDE the cell instead: the current value on top, the
+      // comparison value and its delta beneath in smaller type. Column
+      // structure, header depth and the row/column subtotal correspondence all
+      // stay exactly as they were.
+      //
+      // Presence is read from the DATA — the `<measure>__compare` column the
+      // executor attaches — via the same `comparedValues` the KPI, flat-table
+      // and chart paths read, so there is no widget flag to set and a pivot the
+      // executor sent no comparison for renders exactly as it did before.
+      //
+      // Subtotals get the same treatment as data cells, deliberately: a Total
+      // column that alone showed no comparison reads as "this row has none",
+      // which is a different — and false — statement.
+      const compareStack = (row: Row | undefined, measure: string) => {
+        if (!comparedValues.includes(measure)) return null;
+        const previous = row?.[compareColumn(measure)];
+        if (previous == null) return null;
+        const current = row?.[measure];
+        // The SAME delta helper the KPI path uses, so a dataset KPI and a
+        // cross-tab cell over the same two windows agree on sign and rounding
+        // instead of each rolling their own percentage.
+        const delta = computeMetricDelta(
+          typeof current === 'number' ? current : null,
+          typeof previous === 'number' ? previous : null,
+        );
+        return (
+          <div
+            className="flex items-center justify-end gap-1 text-[10px] font-normal leading-tight text-muted-foreground"
+            data-testid="matrix-cell-compare"
+            data-direction={delta?.direction}
+            title={compareLabel}
+          >
+            {/* A comparison is the same measure over an earlier window, so it
+                carries that measure's own format — never a bare number. */}
+            <span className="tabular-nums">{fmtMeasure(previous, measure)}</span>
+            {delta && (
+              <span
+                className={cn(
+                  'flex shrink-0 items-center tabular-nums font-medium',
+                  delta.direction === 'up' && 'text-emerald-600 dark:text-emerald-400',
+                  delta.direction === 'down' && 'text-rose-600 dark:text-rose-400',
+                )}
+              >
+                {delta.direction === 'up' && <ArrowUpIcon className="h-2.5 w-2.5" />}
+                {delta.direction === 'down' && <ArrowDownIcon className="h-2.5 w-2.5" />}
+                {delta.direction === 'neutral' && <MinusIcon className="h-2.5 w-2.5" />}
+                {delta.value}%
+              </span>
+            )}
+          </div>
+        );
+      };
+      // One caption names the comparison window for the whole table. The
+      // stacked numbers are otherwise unlabeled, and repeating "vs last year"
+      // in every cell would drown the grid it annotates. The flat table
+      // qualifies its comparison COLUMN header instead; a cross-tab has no
+      // per-window header to qualify, which is exactly what stacking traded.
+      const compareCaption = comparedValues.length > 0 ? (
+        <caption
+          className="px-2 pb-1 text-left text-[10px] font-normal text-muted-foreground"
+          data-testid="matrix-compare-caption"
+        >
+          {compareLabel}
+        </caption>
+      ) : null;
       // Server-supplied marginal totals (ADR-0021): match each grouping by its
       // dimension array, then its rows to the pivot headers via the same bucket
       // ids. Absent (older server) → maps stay empty and no totals UI renders.
@@ -721,6 +795,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       return (
         <div className="relative h-full w-full overflow-auto p-1" data-testid="dataset-matrix">{exportBtn}
           <table className="w-full text-xs">
+            {compareCaption}
             <thead className="bg-muted/40">
               <tr>
                 {rowDims.map((d) => (
@@ -755,14 +830,19 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
                         onClick={clickable ? () => openDrill(index as number, title) : undefined}
                       >
                         {fr ? fmtMeasure(fr[cc.measure], cc.measure) : '—'}
+                        {compareStack(fr, cc.measure)}
                       </td>
                     );
                   })}
-                  {showTotalCol && values.map((m) => (
-                    <td key={`total-${m}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap font-medium" data-testid="matrix-row-total">
-                      {fmtMeasure(rowTotalById.get(rh.id)?.[m], m)}
-                    </td>
-                  ))}
+                  {showTotalCol && values.map((m) => {
+                    const rowTotal = rowTotalById.get(rh.id);
+                    return (
+                      <td key={`total-${m}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap font-medium" data-testid="matrix-row-total">
+                        {fmtMeasure(rowTotal?.[m], m)}
+                        {compareStack(rowTotal, m)}
+                      </td>
+                    );
+                  })}
                 </tr>
               ))}
               {showTotalRow && (
@@ -770,14 +850,19 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
                   {rowDims.length > 0 && (
                     <td colSpan={rowDims.length} className="px-2 py-1 whitespace-nowrap">{totalLabel}</td>
                   )}
-                  {cellCols.map((cc) => (
-                    <td key={`${cc.col.id}-${cc.measure}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap">
-                      {fmtMeasure(colTotalById.get(cc.col.id)?.[cc.measure], cc.measure)}
-                    </td>
-                  ))}
+                  {cellCols.map((cc) => {
+                    const colTotal = colTotalById.get(cc.col.id);
+                    return (
+                      <td key={`${cc.col.id}-${cc.measure}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap">
+                        {fmtMeasure(colTotal?.[cc.measure], cc.measure)}
+                        {compareStack(colTotal, cc.measure)}
+                      </td>
+                    );
+                  })}
                   {showTotalCol && values.map((m) => (
                     <td key={`grand-${m}`} className="px-2 py-1 text-right tabular-nums whitespace-nowrap" data-testid="matrix-grand-total">
                       {fmtMeasure(grandTotal?.[m], m)}
+                      {compareStack(grandTotal, m)}
                     </td>
                   ))}
                 </tr>

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.compareTo.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.compareTo.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, cleanup, waitFor, within, fireEvent } from '@testing-library/react';
 
 let lastChartSchema: any = null;
 
@@ -321,5 +321,206 @@ describe('DatasetWidget — showing the comparison the executor returned', () =>
     await waitFor(() => expect(lastChartSchema).not.toBeNull());
     expect(lastChartSchema.series).toHaveLength(1);
     expect(lastChartSchema.series[0].variant).toBeUndefined();
+  });
+});
+
+/**
+ * objectui#3614 — the cross-tab was the one render path PR #3612 left out, so a
+ * `type: 'pivot'` widget with ≥2 dimensions ran a correct comparison query,
+ * received the `<measure>__compare` columns, and showed none of them.
+ *
+ * Maintainer ruling 2026-08-07 chose **form 2, in-cell stacking**: the columns
+ * stay `bucket × measure` (a comparison column would make them
+ * `bucket × measure × window`), the comparison rides underneath the value in
+ * smaller type, all three subtotals get the same treatment, and the CSV export
+ * stays DATA-shaped — flat `<measure>__compare` columns, never a stacked
+ * string. These tests pin all four.
+ */
+const PIVOT_FIELDS = [
+  { name: 'status', type: 'string', label: 'Status' },
+  { name: 'priority', type: 'string', label: 'Priority' },
+  { name: 'amount', type: 'number', label: 'Amount', format: '$0,0' },
+  { name: 'amount__compare', type: 'number' },
+];
+
+/**
+ * Open/High rises (120 vs 100), Open/Low falls (30 vs 60), Done/High is flat
+ * (200 vs 200) and Done/Low has no row at all — one fixture covering every
+ * direction `computeMetricDelta` can return plus the empty cell. Subtotals are
+ * the SERVER's aggregates (ADR-0021), comparison included, and deliberately not
+ * re-derivable from the cells: 150/160, 200/200, 320/300, 30/60, 350/360.
+ */
+const comparedPivotResult = {
+  rows: [
+    { status: 'Open', priority: 'High', amount: 120, amount__compare: 100 },
+    { status: 'Open', priority: 'Low', amount: 30, amount__compare: 60 },
+    { status: 'Done', priority: 'High', amount: 200, amount__compare: 200 },
+  ],
+  fields: PIVOT_FIELDS,
+  totals: [
+    { dimensions: ['status'], rows: [
+      { status: 'Open', amount: 150, amount__compare: 160 },
+      { status: 'Done', amount: 200, amount__compare: 200 },
+    ] },
+    { dimensions: ['priority'], rows: [
+      { priority: 'High', amount: 320, amount__compare: 300 },
+      { priority: 'Low', amount: 30, amount__compare: 60 },
+    ] },
+    { dimensions: [], rows: [{ amount: 350, amount__compare: 360 }] },
+  ],
+};
+
+const pivotWidget = (extra: Record<string, unknown> = {}) => ({
+  type: 'pivot', dataset: 'deals', dimensions: ['status', 'priority'], values: ['amount'],
+  filter: { ...Q2 }, title: 'Deals',
+  ...extra,
+});
+
+/** The row whose first cell reads `label`, as a live element. */
+const rowOf = (matrix: HTMLElement, label: string) =>
+  within(matrix).getByText(label).closest('tr') as HTMLElement;
+const cellsOf = (row: HTMLElement) => [...row.querySelectorAll('td')] as HTMLElement[];
+
+describe('DatasetWidget — the cross-tab’s in-cell comparison (#3614)', () => {
+  it('stacks the comparison value + delta under each cross-tab cell', async () => {
+    const src = makeSource(async () => comparedPivotResult);
+    render(<DatasetWidget widget={pivotWidget({ compareTo: { kind: 'previousYear' } })} dataSource={src} />);
+    const m = await screen.findByTestId('dataset-matrix');
+
+    // Columns are still bucket × measure — the ruling's whole point. Two
+    // buckets (High, Low) + one Total column, no third header level.
+    expect(within(m).getAllByRole('columnheader').map((h) => h.textContent))
+      .toEqual(['Status', 'High', 'Low', 'Total']);
+
+    const cells = cellsOf(rowOf(m, 'Open'));
+    const rising = within(cells[1]).getByTestId('matrix-cell-compare');
+    // The current value stays the cell's own top line; the comparison is a
+    // separate node under it, NOT concatenated into the value.
+    expect(cells[1].textContent?.replace(rising.textContent ?? '', '')).toBe('$120');
+    // The comparison carries the base measure's format ($0,0) — it is the same
+    // measure over an earlier window, so "$100", never a bare 100.
+    expect(rising).toHaveTextContent('$100');
+    expect(rising).toHaveTextContent('20%');
+    expect(rising).toHaveAttribute('data-direction', 'up');
+    // The window is named once per table (caption), and on the stack itself for
+    // hover — the cross-tab has no per-window column header to qualify.
+    expect(rising.getAttribute('title')).toMatch(/vs last year/i);
+    expect(within(m).getByTestId('matrix-compare-caption').textContent).toMatch(/vs last year/i);
+
+    // A fall and a flat cell — same delta helper as the KPI path, so the sign
+    // and rounding come from one place.
+    const falling = within(cells[2]).getByTestId('matrix-cell-compare');
+    expect(falling).toHaveTextContent('$60');
+    expect(falling).toHaveTextContent('50%');
+    expect(falling).toHaveAttribute('data-direction', 'down');
+
+    const doneCells = cellsOf(rowOf(m, 'Done'));
+    expect(within(doneCells[1]).getByTestId('matrix-cell-compare')).toHaveAttribute('data-direction', 'neutral');
+    // Done/Low has no row: an empty cell gains no comparison out of nowhere.
+    expect(doneCells[2].textContent).toBe('—');
+    expect(within(doneCells[2]).queryByTestId('matrix-cell-compare')).not.toBeInTheDocument();
+  });
+
+  it('stacks the comparison in the row, column and grand subtotals too', async () => {
+    const src = makeSource(async () => comparedPivotResult);
+    render(<DatasetWidget widget={pivotWidget({ compareTo: { kind: 'previousYear' } })} dataSource={src} />);
+    const m = await screen.findByTestId('dataset-matrix');
+
+    // Row subtotals (Open 150 vs 160 → down 6%, Done 200 vs 200 → flat).
+    const rowTotals = within(m).getAllByTestId('matrix-row-total');
+    expect(rowTotals.map((t) => within(t).getByTestId('matrix-cell-compare').textContent))
+      .toEqual(['$1606%', '$2000%']);
+    expect(within(rowTotals[0]).getByTestId('matrix-cell-compare')).toHaveAttribute('data-direction', 'down');
+
+    // Column subtotals live in the Total row, before the grand total.
+    const totalRow = within(m).getByTestId('matrix-total-row');
+    const colTotals = cellsOf(totalRow).slice(1, 3);
+    expect(colTotals.map((t) => within(t).getByTestId('matrix-cell-compare').textContent))
+      .toEqual(['$3007%', '$6050%']);
+
+    // Grand total (350 vs 360 → down 3%).
+    const grand = within(m).getByTestId('matrix-grand-total');
+    expect(grand.textContent).toContain('$350');
+    const grandCompare = within(grand).getByTestId('matrix-cell-compare');
+    expect(grandCompare).toHaveTextContent('$360');
+    expect(grandCompare).toHaveTextContent('3%');
+    expect(grandCompare).toHaveAttribute('data-direction', 'down');
+  });
+
+  it('exports FLAT metric__compare columns — the CSV is data, not the stacked cell', async () => {
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    const blobs: any[] = [];
+    (URL as any).createObjectURL = (b: any) => { blobs.push(b); return 'blob:x'; };
+    (URL as any).revokeObjectURL = () => {};
+    try {
+      const src = makeSource(async () => comparedPivotResult);
+      render(<DatasetWidget widget={pivotWidget({ compareTo: { kind: 'previousYear' } })} dataSource={src} />);
+      fireEvent.click(await screen.findByTestId('dataset-export'));
+      expect(blobs).toHaveLength(1);
+      const text: string = await blobs[0].text();
+
+      // One flat column per compared measure, labelled like the flat table's
+      // comparison column header.
+      // downloadCsv prepends a UTF-8 BOM (U+FEFF) so Excel reads non-ASCII
+      // labels; strip it before comparing the header line.
+      const [header, ...body] = text.replace(/^\uFEFF/, '').split('\r\n');
+      expect(header).toBe('Status,Priority,Amount,Amount · vs last year');
+      expect(body).toEqual(['Open,High,120,100', 'Open,Low,30,60', 'Done,High,200,200']);
+      // Not a stacked string anywhere: no display formatting survives into the
+      // data ("$120", "20%"), so a spreadsheet can still compute on it.
+      expect(text).not.toContain('$');
+      expect(text).not.toContain('%');
+    } finally {
+      (URL as any).createObjectURL = origCreate;
+      (URL as any).revokeObjectURL = origRevoke;
+    }
+  });
+
+  // ── Regression pins: nothing appears where no comparison exists ───────────
+  it('renders a pivot WITHOUT compareTo exactly as before', async () => {
+    const src = makeSource(async () => ({
+      rows: [
+        { status: 'Open', priority: 'High', amount: 120 },
+        { status: 'Done', priority: 'High', amount: 200 },
+      ],
+      fields: PIVOT_FIELDS.filter((f) => f.name !== 'amount__compare'),
+      totals: [
+        { dimensions: ['status'], rows: [{ status: 'Open', amount: 120 }, { status: 'Done', amount: 200 }] },
+        { dimensions: ['priority'], rows: [{ priority: 'High', amount: 320 }] },
+        { dimensions: [], rows: [{ amount: 320 }] },
+      ],
+    }));
+    render(<DatasetWidget widget={pivotWidget()} dataSource={src} />);
+    const m = await screen.findByTestId('dataset-matrix');
+    expect(cellsOf(rowOf(m, 'Open')).map((c) => c.textContent)).toEqual(['Open', '$120', '$120']);
+    expect(cellsOf(within(m).getByTestId('matrix-total-row')).map((c) => c.textContent))
+      .toEqual(['Total', '$320', '$320']);
+    expect(within(m).queryAllByTestId('matrix-cell-compare')).toHaveLength(0);
+    expect(within(m).queryByTestId('matrix-compare-caption')).not.toBeInTheDocument();
+  });
+
+  it('stacks nothing when compareTo is set but the executor attached no comparison', async () => {
+    const src = makeSource(async () => ({
+      rows: [{ status: 'Open', priority: 'High', amount: 120 }],
+      fields: PIVOT_FIELDS.filter((f) => f.name !== 'amount__compare'),
+    }));
+    render(<DatasetWidget widget={pivotWidget({ compareTo: { kind: 'previousYear' } })} dataSource={src} />);
+    const m = await screen.findByTestId('dataset-matrix');
+    expect(within(m).getByText('$120')).toBeInTheDocument();
+    expect(within(m).queryAllByTestId('matrix-cell-compare')).toHaveLength(0);
+    expect(within(m).queryByTestId('matrix-compare-caption')).not.toBeInTheDocument();
+  });
+
+  it('stacks nothing for __compare columns the widget never asked to compare', async () => {
+    // Detection is data-driven but still gated on `compareTo` (the same gate the
+    // KPI / flat-table / chart paths use): a stray `<measure>__compare` column
+    // in the result is not a comparison this widget asked for, and rendering it
+    // would put an unexplained second number in every cell.
+    const src = makeSource(async () => comparedPivotResult);
+    render(<DatasetWidget widget={pivotWidget()} dataSource={src} />);
+    const m = await screen.findByTestId('dataset-matrix');
+    expect(within(m).queryAllByTestId('matrix-cell-compare')).toHaveLength(0);
+    expect(within(m).queryByTestId('matrix-compare-caption')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3614

## 问题

`DatasetWidget` 的 matrix 分支(`type: 'pivot'` 且 `dimensions.length >= 2`)是 PR #3612 唯一留白的渲染路径。它按 `桶 × 度量` 铺 `cellCols`,执行器返回的对比列(度量名加 `__compare` 后缀,如 `amount__compare`)既不进表头、也不进单元格,行/列/总计三处小计同样丢弃 —— 于是一个配了有界日期窗口 + `compareTo` 的 pivot:查询正确、对比数据真的返回了、界面一个字看不到。这正是 #3337 要终结的「静默无对比」,只是换了 widget 家族。

## 实现(按 2026-08-07 维护者裁决:形态 2 单元格内叠加)

- **单元格内叠加**:主值在上,对比值与 delta 百分比在下(小字号)。列结构保持 `桶 × 度量` 不变 —— 给对比单独开列会变成 `桶 × 度量 × 窗口`,列数翻倍、表头三层,而交叉表的宽度本来就是最紧张的资源。
- **三处小计同样叠加**:`rowTotalById` / `colTotalById` / `grandTotal` 与数据单元格同一套处理。只有 Total 列不显示对比,读起来是「这一行没有对比」—— 那是另一个、且错误的陈述。
- **CSV 导出保持数据形**:`exportColumns` 去掉 `isMatrix` 例外,交叉表也为每个参与对比的度量导出一列扁平的 `度量名__compare`,单元格仍是裸数字,表格软件可以继续计算。显示叠加,导出是数据,绝不导出 `"$120 $100 20%"` 这种「CSV 外衣的截图」。
- **窗口标签**:整表一条 caption 说明对比窗口(如 "vs last year"),取自 KPI / 扁平表格同一套 `dashboard.trend.*` 词汇;delta 复用同一个 `computeMetricDelta`,所以同样两个窗口下的 KPI 与交叉表单元格在符号和取整上一致,不各算一套百分比。交叉表没有「按窗口的列表头」可以限定 —— 那恰好是叠加换掉的东西,所以标签落在 caption 与单元格 `title` 上。

对比是否存在**从数据判定**(沿用既有的 `comparedValues`),没有新增配置开关:执行器没送对比的 pivot,渲染结果与改动前完全一致。

## 测试

扩写本包既有的 `DatasetWidget.compareTo.test.tsx`:

- 叠加单元格:升(120/100 → up 20%)、降(30/60 → down 50%)、平(200/200 → neutral 0%)、无行的空格子不凭空长出对比;并断言主值与叠加块是两个节点,而非拼接成一个字符串。
- 三处小计:行小计 150/160、列小计 320/300 与 30/60、总计 350/360 都带对比。
- 导出:表头 `Status,Priority,Amount,Amount · vs last year`,数据行 `Open,High,120,100`,并断言整份 CSV 里没有 `$` 也没有 `%`(任何显示格式都没漏进数据)。
- 三条回归钉:无 `compareTo`(逐格断言 td 文本与改前一致);配了 `compareTo` 但执行器没返回对比列;结果里带 `__compare` 而 widget 没要求对比。

**逆向验证(先预测后跑,两个方向都对上)**:只回退渲染改动 → 两条叠加测试红在缺失的 `matrix-cell-compare`,导出测试与三条回归钉全绿;只回退导出改动 → 只有导出测试红(得到 `Status,Priority,Amount`,缺对比列)。

```
pnpm exec vitest run --maxWorkers=2 packages/plugin-dashboard/
 Test Files  26 passed (26)
      Tests  218 passed (218)

pnpm --filter @object-ui/plugin-dashboard type-check   # tsc --noEmit,无输出
pnpm --filter @object-ui/plugin-dashboard lint         # 0 errors(221 个既有 any warning)
node scripts/check-control-bytes.mjs                   # OK(3690 个文本文件)
```

Changeset:`.changeset/pivot-compare-stacking-3614.md`(patch,user-visible)。文档:`packages/plugin-dashboard/SKILL.md` 的 `compareTo` 章节补上 pivot 一条与导出形状说明。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_