### PR TITLE
docs(create-plugin): 按 route B 收缩到不漂移的部分,产物一律指向 buildPluginFiles() (#3715)

### DIFF
--- a/content/docs/utilities/create-plugin.mdx
+++ b/content/docs/utilities/create-plugin.mdx
@@ -69,10 +69,11 @@ Two things are worth knowing before you look:
   config emitting an ES and a UMD bundle into `dist/`. There is no application to serve,
   so there is no dev server to start — see [Development Workflow](#development-workflow).
 - **Its dependency ranges are not listed here on purpose.** They live in that one
-  template literal, and the testing ones are asserted to equal this repository's own
-  ranges by `packages/create-plugin/src/__tests__/templates.test.ts`. Reading the literal
-  is the only way to see what your scaffold will actually contain; a range copied onto
-  this page would be the first thing to go stale.
+  template literal, and `packages/create-plugin/src/__tests__/templates.test.ts` anchors
+  the generated `devDependencies` to this repository's own declarations, so the scaffold
+  cannot drift away from the toolchain it is part of. Reading the literal is the only way
+  to see what your scaffold will actually contain; a range copied onto this page would be
+  the first thing to go stale.
 
 ## Development Workflow
 

--- a/content/docs/utilities/create-plugin.mdx
+++ b/content/docs/utilities/create-plugin.mdx
@@ -5,7 +5,10 @@ description: "Interactive CLI tool for creating ObjectUI plugins"
 
 # Create Plugin
 
-The `@object-ui/create-plugin` package is an interactive CLI tool that scaffolds new ObjectUI plugins with best practices and TypeScript support. It generates a complete plugin structure ready for development.
+The `@object-ui/create-plugin` package is a small interactive CLI that scaffolds a new
+ObjectUI plugin package. It asks a couple of questions, writes a ready-to-build package,
+and prints the commands to run next. Writing those files is the whole of what it does: it
+installs no dependencies and initialises no git repository.
 
 ## Installation
 
@@ -13,301 +16,123 @@ The `@object-ui/create-plugin` package is an interactive CLI tool that scaffolds
 npm install -g @object-ui/create-plugin
 ```
 
-Or use with npx (recommended):
+Or use with npx (recommended — nothing to install, and you always get the published
+version):
 
 ```bash
 npx @object-ui/create-plugin my-plugin
 ```
 
-## Features
-
-- 🎯 **Interactive Prompts** - Step-by-step plugin creation
-- 📦 **Complete Scaffold** - All files needed to start
-- 🔷 **TypeScript First** - Full TypeScript support
-- 🎨 **Best Practices** - Follow ObjectUI conventions
-- 🚀 **Ready to Develop** - Start coding immediately
-- 📝 **Documentation Template** - Includes README and docs
-
 ## Quick Start
 
-### Create a New Plugin
+**Run it from the root of a pnpm workspace.** The new package is written to
+`packages/plugin-<name>` **relative to the current directory**, and what it writes is
+built for a workspace: it depends on the `@object-ui` packages through `workspace:*`
+links, and its `tsconfig.json` extends the one two directories above it. Run the
+generator anywhere else and you get a package whose dependencies and TypeScript config
+resolve to nothing.
 
 ```bash
-npx @object-ui/create-plugin my-awesome-plugin
+cd my-workspace
+npx @object-ui/create-plugin awesome
 ```
 
-This will:
+The CLI validates the name you gave it — lowercase letters, digits and hyphens only, no
+scopes and no path separators — and then cleans it up: a leading `plugin-` is stripped, so
+`awesome` and `plugin-awesome` mean the same thing. From the cleaned name it derives,
+without asking:
 
-1. Ask you a few questions about your plugin
-2. Generate the plugin structure
-3. Install dependencies
-4. Initialize a git repository
+- the directory it writes into, `packages/plugin-<name>`;
+- the package name, `@object-ui/plugin-<name>`;
+- the `type` key the plugin registers itself under in the
+  [Component Registry](/docs/guide/component-registry) — the cleaned name itself, so
+  `awesome` in the example above;
+- the PascalCase component name, and the name of the file implementing it.
 
-### Interactive Prompts
+One name decides all four, so pick it with all four in mind. Everything else — a
+description and an author — is asked interactively with a default filled in. The
+`--description` and `--author` options **pre-fill those prompts rather than skip them**;
+run `npx @object-ui/create-plugin --help` for the options it accepts today.
 
-When you run `create-plugin`, you'll be asked:
+## What It Generates
 
-```
-? Plugin name: my-awesome-plugin
-? Description: An awesome plugin for ObjectUI
-? Author: Your Name
-? Component name: AwesomeComponent
-? Component type: awesome-component
-? License: MIT
-```
+This page deliberately does **not** reproduce the generated tree or the generated files.
+Run the generator and read what it wrote — and when you need the answer without running
+it, read the one function that decides it:
+[`buildPluginFiles()` in `packages/create-plugin/src/templates.ts`](https://github.com/objectstack-ai/objectui/blob/main/packages/create-plugin/src/templates.ts).
+That map of *path to file contents* is the single source of truth for what a scaffolded
+plugin contains; the CLI in `src/index.ts` is the loop that writes it to disk.
 
-## Generated Structure
+Two things are worth knowing before you look:
 
-The tool creates a complete plugin structure:
-
-```
-my-awesome-plugin/
-├── src/
-│   ├── index.tsx              # Main entry point
-│   ├── AwesomeComponent.tsx   # Component implementation
-│   └── types.ts               # TypeScript types
-├── package.json               # Package configuration
-├── tsconfig.json             # TypeScript config
-├── vite.config.ts            # Vite build config
-├── README.md                 # Documentation
-└── .gitignore                # Git ignore rules
-```
-
-## Generated Files
-
-### `src/index.tsx`
-
-The main entry point that registers your component:
-
-```typescript
-import { ComponentRegistry } from '@object-ui/core'
-import { AwesomeComponent } from './AwesomeComponent'
-
-// Auto-register the component
-ComponentRegistry.register('awesome-component', AwesomeComponent)
-
-// Export for direct use
-export { AwesomeComponent }
-export * from './types'
-```
-
-### `src/AwesomeComponent.tsx`
-
-The component implementation with lazy loading:
-
-```typescript
-import React, { Suspense } from 'react'
-import { Skeleton } from '@object-ui/components'
-import type { AwesomeComponentProps } from './types'
-
-// Lazy load heavy implementation
-const AwesomeImpl = React.lazy(() => import('./AwesomeImpl'))
-
-export const AwesomeComponent: React.FC<AwesomeComponentProps> = (props) => {
-  return (
-    <Suspense fallback={<Skeleton className="w-full h-[400px]" />}>
-      <AwesomeImpl {...props} />
-    </Suspense>
-  )
-}
-```
-
-### `src/types.ts`
-
-TypeScript type definitions:
-
-```typescript
-import type { BaseComponentSchema } from '@object-ui/types'
-
-export interface AwesomeComponentSchema extends BaseComponentSchema {
-  type: 'awesome-component'
-  // Your component-specific props
-  message?: string
-  color?: string
-}
-
-export interface AwesomeComponentProps {
-  schema: AwesomeComponentSchema
-}
-```
-
-### `package.json`
-
-Pre-configured with all necessary settings: the package identity (`name`, `version`,
-`type`, `license`, `description`), the build entry points (`main`, `module`, `types` and
-an `exports` map covering both the ES and the UMD bundle), and its `scripts`.
-
-It also writes three dependency groups:
-
-- `dependencies` — four `@object-ui` workspace packages plus an icon library, written as
-  workspace links rather than as published version ranges. Note the field: the generator
-  puts these under **`dependencies`**, not under `peerDependencies`.
-- `peerDependencies` — `react` and `react-dom`, left for the host application to supply.
-- `devDependencies` — what the generated Vite build and its tests need.
-
-Do not transcribe version ranges out of this page into a hand-written manifest. They are
-written by one template — the manifest literal in
-[`packages/create-plugin/src/index.ts`](https://github.com/objectstack-ai/objectui/blob/main/packages/create-plugin/src/index.ts) —
-and reading them there is the only way to see what your scaffold will actually contain.
+- **It scaffolds a library, not an app.** The generated Vite config is a `build.lib`
+  config emitting an ES and a UMD bundle into `dist/`. There is no application to serve,
+  so there is no dev server to start — see [Development Workflow](#development-workflow).
+- **Its dependency ranges are not listed here on purpose.** They live in that one
+  template literal, and the testing ones are asserted to equal this repository's own
+  ranges by `packages/create-plugin/src/__tests__/templates.test.ts`. Reading the literal
+  is the only way to see what your scaffold will actually contain; a range copied onto
+  this page would be the first thing to go stale.
 
 ## Development Workflow
 
-After creating your plugin:
+When the generator finishes it prints the next steps for the package it just wrote —
+follow those. Inside the new package, `pnpm run` lists the scripts it actually has. Two
+notes on what to expect from them:
 
-### 1. Install Dependencies
+- **There is no dev server, and no `dev` script to run one.** A library build has no app
+  to serve. Iterate either by building the plugin and reloading the app that consumes it,
+  or — the way this repository develops its own plugins — by pointing the consuming app's
+  Vite `resolve.alias` at your plugin's `src`, so your sources become part of that app's
+  dev server. The [Runner](/docs/utilities/runner) documents that alias table, including
+  the transitive-closure rule that makes it work.
+- **Tests are green on a fresh scaffold, and are meant to stay that way.** The generator
+  writes an example test together with the Vitest setup file its config points at, and
+  `templates.test.ts` pins those pieces to each other: the test stack is declared, the
+  environment is a DOM, the setup file exists. If the first test run in a freshly
+  scaffolded plugin is red, that is a bug in the generator rather than in your machine —
+  please file it.
 
-```bash
-cd my-awesome-plugin
-npm install
-```
+To use the plugin from an app in the same workspace, add it as a `workspace:*` dependency
+and import the package for its side effect: importing it is what registers the component,
+which is what makes its `type` key usable in a schema. See
+[Plugin Concepts](/docs/guide/plugins).
 
-### 2. Start Development
+To publish it, use `pnpm publish`. pnpm rewrites the `workspace:*` links into real ranges
+as it packs; a plain `npm publish` would ship the literal `workspace:*` and the resulting
+tarball is uninstallable.
 
-```bash
-npm run dev
-```
+## Configuration
 
-This starts Vite in dev mode with HMR.
+There is none beyond the command line. The generator reads no configuration file — there
+is no `.create-plugin.config.js` and no template directory to point it at. Everything it
+can be told, it is told through the plugin-name argument and the options `--help` lists.
 
-### 3. Implement Your Component
+## Plugin Naming Conventions
 
-Edit `src/AwesomeImpl.tsx`:
-
-```typescript
-import React from 'react'
-import type { AwesomeComponentProps } from './types'
-
-const AwesomeImpl: React.FC<AwesomeComponentProps> = ({ schema }) => {
-  const { message = 'Hello!', color = 'blue' } = schema
-
-  return (
-    <div className={`p-4 text-${color}-600`}>
-      <h2 className="text-2xl font-bold">{message}</h2>
-    </div>
-  )
-}
-
-export default AwesomeImpl
-```
-
-### 4. Add Tests
-
-Create `src/AwesomeComponent.test.tsx`:
-
-```typescript
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { AwesomeComponent } from './AwesomeComponent'
-
-describe('AwesomeComponent', () => {
-  it('renders message', () => {
-    const schema = {
-      type: 'awesome-component' as const,
-      message: 'Test message',
-    }
-    
-    render(<AwesomeComponent schema={schema} />)
-    expect(screen.getByText('Test message')).toBeInTheDocument()
-  })
-})
-```
-
-### 5. Build for Production
-
-```bash
-npm run build
-```
-
-This creates optimized bundles in the `dist/` folder.
-
-### 6. Test in Your App
-
-Link your plugin for local testing:
-
-```bash
-# In plugin directory
-npm link
-
-# In your app directory
-npm link @object-ui/plugin-awesome
-```
-
-### 7. Publish to NPM
-
-```bash
-npm publish
-```
-
-## Configuration Options
-
-### Custom Templates
-
-You can customize the scaffolding by creating a `.create-plugin.config.js`:
-
-```javascript
-// .create-plugin.config.js
-module.exports = {
-  template: 'custom',
-  defaults: {
-    author: 'Your Name',
-    license: 'MIT',
-  },
-  prompts: {
-    // Custom prompts
-  },
-}
-```
-
-### Plugin Naming Conventions
-
-Follow these naming conventions:
-
-- **Package name:** `@object-ui/plugin-<name>` or `@yourorg/objectui-plugin-<name>`
-- **Component type:** `kebab-case` (e.g., `awesome-component`)
-- **Component name:** `PascalCase` (e.g., `AwesomeComponent`)
+- **Package name:** `@object-ui/plugin-<name>` — the CLI composes it, you only choose
+  `<name>`.
+- **Schema `type` key:** `kebab-case`, the cleaned plugin name.
+- **Component name:** `PascalCase`, derived from the same name.
 
 ## Best Practices
 
-### 1. Lazy Loading
+Advice for the plugin you are about to write, beyond whatever the scaffold hands you:
 
-Always use lazy loading for heavy dependencies:
+- **Lazy-load heavy dependencies.** `@object-ui/plugin-*` is the layer where heavy
+  third-party libraries are allowed to live, which makes it the layer that most needs a
+  `React.lazy` boundary, so an app that never renders your component never pays for it:
 
-```typescript
-const HeavyImpl = React.lazy(() => import('./HeavyImpl'))
-```
+  ```tsx
+  const HeavyImpl = React.lazy(() => import('./HeavyImpl'));
+  ```
 
-### 2. Type Safety
-
-Export all TypeScript types:
-
-```typescript
-export type { AwesomeComponentSchema, AwesomeComponentProps }
-```
-
-### 3. Loading States
-
-Provide meaningful loading states:
-
-```typescript
-<Suspense fallback={<Skeleton className="w-full h-[200px]" />}>
-  <AwesomeImpl {...props} />
-</Suspense>
-```
-
-### 4. Documentation
-
-Include comprehensive documentation:
-
-- README with usage examples
-- JSDoc comments for all exports
-
-### 5. Testing
-
-Write tests for all functionality:
-
-- Unit tests for components
-- Integration tests for schemas
-- E2E tests for user flows
+- **Give that boundary a real fallback.** A `Skeleton` shaped like the component beats a
+  bare spinner: the layout does not jump when the chunk arrives.
+- **Export your schema types.** The schema interface is the contract between a metadata
+  author and your renderer, so make it importable rather than internal.
+- **Treat the registry key as public.** The `type` you register appears in every schema
+  that uses your plugin, so renaming it is a breaking change for metadata already stored.
 
 ## Example Plugins
 
@@ -319,55 +144,37 @@ See these official plugins for reference:
 
 ## Package Information
 
-**Package Name:** `@object-ui/create-plugin`  
-**Version:** 0.3.1  
+**Package Name:** `@object-ui/create-plugin` — published on npm, see the
+[npm page](https://www.npmjs.com/package/@object-ui/create-plugin) for the current version  
 **Binary:** `create-plugin`  
 **License:** MIT
 
-## Dependencies
+## Troubleshooting
 
-The tool uses:
+**It stopped because the directory already exists.** The generator never writes into an
+existing directory. Pick another name, or remove the old package first.
 
-- **Inquirer** - Interactive prompts
-- **Chalk** - Terminal colors
-- **Ora** - Loading spinners
-- **fs-extra** - File system utilities
+**The name was rejected.** Only lowercase letters, digits and hyphens are accepted; a
+scope, a slash or a `..` is refused. The validation is at the top of
+[`src/index.ts`](https://github.com/objectstack-ai/objectui/blob/main/packages/create-plugin/src/index.ts).
+
+**The new package's imports and `tsconfig.json` resolve to nothing.** The generator was
+almost certainly run outside a workspace root — see [Quick Start](#quick-start). Move the
+package into a real workspace's `packages/` directory, or re-run the generator from
+there.
+
+**Permission denied installing globally.** Use npx instead of `npm install -g`; it needs
+no write access outside the npm cache.
 
 ## Next Steps
 
 - **[Plugin Concepts](/docs/guide/plugins)** - Learn how plugins work
-- **[CLI](/docs/utilities/cli)** - Test your plugin with the CLI
+- **[Plugin Development Guide](/docs/guide/plugin-development)** - The full authoring guide
 - **[Component Registry](/docs/guide/component-registry)** - Register components
-- **[Plugin Development Guide](/docs/guide/plugins)** - Learn plugin best practices
-
-## Troubleshooting
-
-### Permission Denied
-
-```bash
-# On Linux/Mac, use sudo
-sudo npm install -g @object-ui/create-plugin
-```
-
-### Template Not Found
-
-Make sure you have the latest version:
-
-```bash
-npm update -g @object-ui/create-plugin
-```
-
-### Dependencies Not Installing
-
-Try clearing npm cache:
-
-```bash
-npm cache clean --force
-npx @object-ui/create-plugin my-plugin
-```
+- **[CLI](/docs/utilities/cli)** - Test your plugin with the CLI
 
 ## Need Help?
 
 - [GitHub Issues](https://github.com/objectstack-ai/objectui/issues)
-- [Plugin Development Guide](/docs/guide/plugins)
+- [Plugin Development Guide](/docs/guide/plugin-development)
 - [Examples](https://github.com/objectstack-ai/objectui/tree/main/packages)


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3715

按分诊裁决走 **route B(收缩)**,不做 route A 全量重写:本页每一处失真都是「把生成器产物转写成散文」造成的,重写转写等于把同一把枪重新上膛(#3645 家族)。所以「产物长什么样」的整段一律**删除并指路**,只留下不会自己变旧的那部分。

真相锚:`packages/create-plugin/src/templates.ts` 与 `src/index.ts`,对 `origin/main` @ `0c28a0720` 逐条实测(#3733 已落 main,模板已在 `templates.ts`)。全页 374 行 → 181 行(+123 / -315)。

## 删除(照做即坏 / 纯虚构)

| 删掉的内容 | 实测真相 |
|---|---|
| Quick Start「This will: Install dependencies / Initialize a git repository」 | 两件都不做。`index.ts` 全文只有一处 `pnpm install` 字样,是**打印**给用户的 next step(`:132`),没有任何 exec / spawn / git 调用 |
| Interactive Prompts 的 6 问假脚本(含 Component name / Component type / License) | 传了名字时只问 2 个(description / author,`:82-95`);不传名字才多问一个名字 |
| Generated Structure 树(产物在 cwd 的 `my-awesome-plugin/`,列 `.gitignore`,缺示例测试) | 实际写到 `path.join(process.cwd(), 'packages', fullPackageName)`(`:97`);产物 9 个,不含 `.gitignore`,含示例测试与 `vitest.setup.ts` |
| Generated Files 四段代码样例(`src/AwesomeComponent.tsx`、`export * from './types'`、Props/Schema 成对的 `types.ts`) | 形状全不符:入口从 `PascalImpl` 导入并在模块顶层注册,`types.ts` 只有一个 Schema 接口 |
| §2 Start Development 的 `npm run dev` + "starts Vite in dev mode with HMR" | 生成 scripts 只有 build / test / lint;配置是 `build.lib`,**没有 dev server 可启**。照做得到 "Missing script: dev" —— 本单最重的一条 |
| §Configuration Options 整节(`.create-plugin.config.js` 的 template / defaults / prompts) | 生成器不读任何配置文件,整节虚构 |
| **Version:** `0.3.1` | 实际 `17.3.0`;按 #3711 的取向直接删字面量、改指 npm 页 |
| §Dependencies(Inquirer / Ora) | 实为 chalk / commander / fs-extra / prompts;而且 CLI 自身依赖对读者无用,整节删除 |
| Troubleshooting 的 "Template Not Found" / "Dependencies Not Installing" | 生成器没有模板目录概念、也不装依赖,两条都是虚构故障 |
| §Features 的营销条目 | 其中 "Documentation Template - Includes README and docs" 只写 README;整体信息量为零,一并删 |
| `### package.json` 一节(#3726 刚订正过) | 分诊已预告「route B 很可能删掉 #3709/#3726 刚订正的文字,这是预期、不是白干」。其中「不要从文档抄版本号,去读那份字面量」的用意保留,路径按 #3716 席位的追评从 `src/index.ts` 改成 `src/templates.ts` |

## 指路(取代转写)

- **§What It Generates** 明说本页不复制产物树与产物文件,指向 [`buildPluginFiles()` in `src/templates.ts`](https://github.com/objectstack-ai/objectui/blob/main/packages/create-plugin/src/templates.ts) —— 「一个插件包含哪些文件」的唯一真相,`index.ts` 只是写盘循环。**没有任何文件清单被手工维护**(#3716 席位的交接项 1)。
- **依赖区间一个不写**,改为说明它们在那份模板字面量里、并由 `src/__tests__/templates.test.ts` 机械锚定到仓内声明(交接项 3)。
- CLI 选项不逐条转写,改为指 `--help`;脚本清单不转写,改为「新包里跑 `pnpm run` 看它到底有哪些」—— 两句都是自更新的真相。
- next steps 不转写,改为「生成器跑完会自己打印,照它做」。

## 保留 / 新增(都是不会自己变旧的事实)

- Installation、Naming Conventions、Best Practices、Example Plugins、Package Information、Next Steps、Need Help? 的骨架保留。Package Information 仿 `runner.mdx` 的写法(#3616):只留名字 / binary / license,版本改指 npm 页。
- Best Practices 收成 4 条**建议**(lazy 边界、真实 fallback、导出 schema 类型、注册键即公开契约),并明说这是给作者的建议而非脚手架已做之事 —— 旧页把它读成了「产物长这样」。
- 新增三条读者真正会踩、且由结构决定的事实:**必须在 pnpm workspace 根目录运行**(产物写到 cwd 的 `packages/` 下,依赖是 `workspace:*`,tsconfig 往上两级 extends);**一个名字同时决定四样东西**(目录 / 包名 / 注册 `type` 键 / PascalCase 组件名),`plugin-` 前缀会被剥掉;**发布用 `pnpm publish`**(pnpm 打包时会把 `workspace:*` 改写成真实区间,`npm publish` 会把字面量原样发出去)。
- Troubleshooting 换成三条真实故障:目录已存在即中止、名字校验(小写字母 / 数字 / 连字符)、在 workspace 外面跑导致依赖与 tsconfig 解析不到。

## 第二个 commit:被 #3742 追上的那一句

`b8b219bac` 是分支开着的时候 PR #3754(#3742)落 main 触发的:那个 PR 把 `templates.test.ts` 从「三条测试区间取自仓内」升级成「**每一条** devDependency 区间都被锚定,没有未钉的」。本页原写「the testing ones are asserted…」在我的 fetch 点是准确的,合并后就变成了低估 —— 正是本次收缩要消灭的那种漂移,所以改成只说锚定这件事本身,不说子集、不说条数。因为**禁止 force-push**,这一句以追加 commit 落下而非 rebase 重写。

## Ledger(#3711 双向棘轮)

**无需删任何 KNOWN_CLAIMS 行:该 ledger 里本就没有 `create-plugin.mdx` 的登记行**(仅在文件头注释中作为 #3709 的案例被提及,不是条目)。原因是它的匹配需要「包名与版本同行相邻」,而旧页的 `0.3.1` 单独一行,从未被扫成 claim。改动前后各跑一次确认:

```
# 改动前(把页面 checkout 回 main 的版本)
Test Files  1 passed (1)
     Tests  10 passed (10)
```

新写的散文也不含任何版本字面量,所以棘轮上行方向同样不会红。

## 验证

```
$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3692 tracked text file(s); skipped 85 binary).
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' content/docs/utilities/create-plugin.mdx
(clean)
$ node scripts/check-doc-links.mjs
Links are valid across 7 scan roots.
$ flock /tmp/os-heavy-verify.lock -c 'NODE_OPTIONS=--max-old-space-size=4096 pnpm exec vitest run scripts/__tests__ --maxWorkers=2'
Test Files  20 passed (20)
     Tests  369 passed (369)
```

本地另外单独编译过 MDX(用仓内 `@mdx-js/mdx@3.1.1` 直接 `compile()` 本页 → OK,16611 bytes JSX;对照编译未改动的 `runner.mdx` 同样 OK,证明这个检查不是空转)。

**订正一处我先前写错的话**:这段最初写的是「`ci.yml` 的 `paths-ignore` 含 `content/**`,纯 docs PR 不会启动 Build Docs」。**错的**,而且错得正是本单批评的那个模式 —— 我把 Build Docs job 里一段**讲历史**的注释读成了当前事实。实际上 `ci.yml` 的 `pull_request` 触发器自 #3523 起**已经没有 `paths-ignore`**(只有 `push:` 还保留一份),路径判断移进了 job 内部;所以本 PR 确实拉起了 Build Docs,而它的 "Check for docs changes" 步看到 `content/` 有改动 → `should_run=true` → 真的构建站点。本地那次 MDX 编译因此只是提前一步的自检,不是 CI 缺口的补丁。

**Changeset:无。** 纯文档订正,依 AGENTS.md 与同族先例(PR #3698 / #3726 / #3616 都是 docs-only 且无 changeset)。

**未触碰** `packages/create-plugin/**`(#3742 在途,现已落 main)、`scripts/__tests__/doc-version-claims.test.ts`(无行可删)、`content/docs/releases/`。与 `origin/main` @ `e473b6c29` 实测无冲突(`git merge-tree`:0 处冲突标记)。

## 越界发现

已另开 **#3759**(`finding`,未排队、未指派):生成的 `src/types.ts` 是死产物 —— 没有任何生成源文件 import 它,生成的 `exports` map 又只暴露 `.`,那个 Schema 接口在包内无人用、包外不可达。与 #3742 / #3755 同族同文件但范围互不覆盖。有意思的是,本 PR 删掉的那段虚构文档写的 `export * from './types'` 恰好比真实模板更合理。本 PR 未改一行生成器代码。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_
