### PR TITLE
fix(plugin-grid): 行「更多操作」触发器改为数「真正会渲染的项」，空则不渲染

### DIFF
--- a/.changeset/rowactionmenu-empty-guard.md
+++ b/.changeset/rowactionmenu-empty-guard.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+fix(plugin-grid): don't render a row "⋮" trigger that opens an empty menu
+
+The object list's row overflow trigger was gated on whether row-action
+**handlers** were wired and how many actions were **declared**
+(`(canEdit && onEdit) || (canDelete && onDelete) || menuDefs.length > 0 || rowActions.length > 0`),
+while the menu's items were filtered a second time — per item, per record —
+against `visibleWhen` / `visible`. On a row where every item was
+predicate-suppressed the trigger still rendered and opened an empty box, which
+reads as a broken page: a platform object whose row actions are gated for one
+role showed a "⋮" on every row for everyone else, with nothing inside it.
+
+The trigger is now decided by the items that will actually render for that row,
+resolved through the same visibility functions the items gate themselves on, so
+the two cannot disagree. The decision is per row: within one grid a row that
+keeps an action keeps its trigger while a row with nothing left renders none. The
+inline `variant: 'primary'` button reads that same shared rule. The actions
+column is table-level and unchanged, so a row with nothing to offer renders an
+empty cell and every row keeps the same cell count.
+
+Which items render is untouched — only whether the trigger renders when none of
+them survive.

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -15,7 +15,8 @@ import {
   DropdownMenuTrigger,
 } from '@object-ui/components';
 import { Edit, Trash2, MoreVertical } from 'lucide-react';
-import { useObjectTranslation, useRowPredicate, useCapabilityGate } from '@object-ui/react';
+import { evalRowPredicate } from '@object-ui/core';
+import { useObjectTranslation, useRowPredicate, useCapabilityGate, usePredicateScope } from '@object-ui/react';
 
 const ROW_ACTION_FALLBACKS: Record<string, string> = {
   'grid.openMenu': 'Open menu',
@@ -104,6 +105,170 @@ export interface RowActionMenuProps {
   objectFields?: unknown;
 }
 
+// ---------------------------------------------------------------------------
+// Visibility — ONE definition, read by the items AND by the "⋮" guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a row-action visibility predicate the way this file's items do — on
+ * the canonical CEL engine, failing CLOSED with a diagnosable warning — but
+ * WITHOUT a hook.
+ *
+ * Hook-free matters because the guard below asks this question for a VARIABLE
+ * number of declared actions inside one `useMemo`; a `useRowPredicate` per
+ * action would tie the hook count to `rowActionDefs.length`. Mirrors
+ * `useRowPredicate(pred, row, { fallback: false, warnOnError: true, label, fields })`
+ * exactly, boolean short-circuit included — a boolean handed to the engine
+ * faults ("AST-only evaluation not yet supported") and fails closed, which is
+ * how `visible: true` once hid a bulk button from everyone (objectui#3492; the
+ * same short-circuit is spelled out at length in this package's
+ * `bulkEligibility`).
+ */
+function evalRowActionVisibility(
+  pred: unknown,
+  row: any,
+  scope: Record<string, unknown>,
+  label: string,
+  fields: unknown,
+): boolean {
+  if (typeof pred === 'boolean') return pred;
+  if (pred == null || pred === '') return false;
+  return evalRowPredicate(pred as never, row ?? {}, {
+    fallback: false,
+    scope,
+    warnOnError: true,
+    label,
+    fields: fields as never,
+  });
+}
+
+/**
+ * Does the built-in Edit/Delete item render for THIS row? The single
+ * definition, read both by {@link BuiltinRowActionItem} itself and by the guard
+ * that decides whether this row gets a "⋮" trigger at all.
+ *
+ * The two disagreeing is objectui#3562: the guard counted whether HANDLERS were
+ * supplied, the items were then filtered a second time by these per-record
+ * predicates, and a row with every item suppressed still grew a trigger that
+ * opened an empty 128×10 box with zero `[role=menu]` children.
+ *
+ * `visibleWhen` counts as a declared gate by `!= null`, not by truthiness —
+ * `visibleWhen: false` hides the item rather than reading as "ungated". This is
+ * the item's historical rule, extracted verbatim.
+ */
+export function isBuiltinRowActionVisible(
+  predicates: BuiltinRowActionPredicates | undefined,
+  name: 'edit' | 'delete',
+  row: any,
+  scope: Record<string, unknown>,
+  fields?: unknown,
+): boolean {
+  const pred = predicates?.visibleWhen;
+  if (pred == null) return true;
+  return evalRowActionVisibility(pred, row, scope, `builtin:${name}:visibleWhen`, fields);
+}
+
+/**
+ * Does this schema-driven action render for THIS row? Same single-definition
+ * rule as the built-ins above, and it governs BOTH surfaces a def can land on:
+ * the "⋮" menu item ({@link RowActionMenuItem}) and the inline primary button
+ * ({@link RowActionInlineButton}). One function, so a def cannot be visible on
+ * one surface and hidden on the other.
+ *
+ * The gate is truthiness, which is what both items have always applied: a
+ * `visible: false` def RENDERS (the objectui#3492 shape). Preserved verbatim —
+ * the contract this function exists for is that the guard and the items agree,
+ * and re-deciding `visible: false` would change WHICH items render, a separate
+ * question tracked as objectui#3758.
+ */
+export function isCustomRowActionVisible(
+  def: RowActionDef | undefined,
+  row: any,
+  scope: Record<string, unknown>,
+  fields?: unknown,
+): boolean {
+  if (!def?.visible) return true;
+  return evalRowActionVisibility(def.visible, row, scope, def.name ?? 'row-action', fields);
+}
+
+/** What this row's action cell will actually render. */
+export interface RowActionMenuPlan {
+  /** Inline `variant:'primary'` buttons surviving their own `visible`. */
+  inline: RowActionDef[];
+  /** The built-in Edit item renders in the menu for this row. */
+  edit: boolean;
+  /** The built-in Delete item renders in the menu for this row. */
+  remove: boolean;
+  /** Menu-bound defs surviving their own `visible`, in declared order. */
+  custom: RowActionDef[];
+  /** Legacy string row actions. Predicate-free, so all of them render. */
+  legacy: string[];
+  /**
+   * Items that will render INSIDE the "⋮" menu. `0` means: render no trigger at
+   * all (#3562).
+   *
+   * Named `menuCount` rather than the data-table plan's `count` because this
+   * surface also has an inline button path, and inline buttons are NOT part of
+   * the trigger's decision — a row may legitimately show an inline CTA and no
+   * "⋮" (that is today's behavior for a single primary action).
+   */
+  menuCount: number;
+}
+
+/**
+ * Resolve ONE row's action cell — which items survive their per-record
+ * predicates, and how many that leaves inside the "⋮" menu.
+ *
+ * Per ROW, not per grid: `visibleWhen` / `visible` are per-record predicates,
+ * so two rows of the same grid legitimately differ (one keeps Edit, the next
+ * has nothing left). `RowActionMenu` is already instantiated per row by the
+ * `_actions` column's `cell`, so the decision lives here.
+ *
+ * Only visibility is decided here — a `disabled` item still renders (greyed
+ * out) and still COUNTS, exactly as before. Capability filtering
+ * (ADR-0066 D4 / framework#3923) happens upstream of this call, on the declared
+ * set, so its verdict reaches the guard the same way.
+ *
+ * Inline slot allocation is deliberately NOT re-derived from visibility: the
+ * `maxInlineActions` slice runs on the declared primaries, exactly as before,
+ * so a suppressed primary does not promote the next one into its slot. Which
+ * items render, and where, is unchanged — only whether the trigger renders.
+ */
+export function planRowActionMenu(input: {
+  row: any;
+  scope: Record<string, unknown>;
+  /** Primaries occupying the inline slots, already sliced by `maxInlineActions`. */
+  inlineDefs: readonly RowActionDef[];
+  /** Defs bound for the "⋮" menu (folded primaries + non-primaries). */
+  menuDefs: readonly RowActionDef[];
+  /** Legacy string row actions (no predicates). */
+  rowActions?: readonly string[];
+  canEdit?: boolean;
+  canDelete?: boolean;
+  onEdit?: unknown;
+  onDelete?: unknown;
+  editPredicates?: BuiltinRowActionPredicates;
+  deletePredicates?: BuiltinRowActionPredicates;
+  objectFields?: unknown;
+}): RowActionMenuPlan {
+  const { row, scope, objectFields } = input;
+  const inline = input.inlineDefs.filter((def) => isCustomRowActionVisible(def, row, scope, objectFields));
+  const edit = Boolean(input.canEdit && input.onEdit)
+    && isBuiltinRowActionVisible(input.editPredicates, 'edit', row, scope, objectFields);
+  const remove = Boolean(input.canDelete && input.onDelete)
+    && isBuiltinRowActionVisible(input.deletePredicates, 'delete', row, scope, objectFields);
+  const custom = input.menuDefs.filter((def) => isCustomRowActionVisible(def, row, scope, objectFields));
+  const legacy = [...(input.rowActions ?? [])];
+  return {
+    inline,
+    edit,
+    remove,
+    custom,
+    legacy,
+    menuCount: (edit ? 1 : 0) + (remove ? 1 : 0) + custom.length + legacy.length,
+  };
+}
+
 /**
  * One schema-driven row-action menu item. Extracted into its own component
  * so the `visible` CEL predicate can be evaluated with a hook
@@ -125,9 +290,17 @@ const RowActionMenuItem: React.FC<{
   // the ambient `features`/`user` scope is merged. `visible` fails CLOSED
   // (hidden + warn) so a broken predicate can't silently expose an action —
   // matching ActionEngine's posture; `disabled` fails soft (not disabled).
-  const isVisible = useRowPredicate(def.visible, row, { fallback: false, warnOnError: true, label: def.name, fields: objectFields });
+  //
+  // `visible` goes through the shared `isCustomRowActionVisible` — the SAME
+  // function the guard in `RowActionMenu` counts with, so an item can never be
+  // suppressed behind a "⋮" trigger that survived (objectui#3562).
+  const scope = usePredicateScope();
+  const isVisible = React.useMemo(
+    () => isCustomRowActionVisible(def, row, scope, objectFields),
+    [def, row, scope, objectFields],
+  );
   const isDisabled = useRowPredicate((def as any).disabled, row, { fallback: false, warnOnError: true, label: `${def.name}:disabled`, fields: objectFields });
-  if (def.visible && !isVisible) return null;
+  if (!isVisible) return null;
   return (
     <DropdownMenuItem
       disabled={isDisabled}
@@ -164,19 +337,20 @@ export const BuiltinRowActionItem: React.FC<{
   objectFields?: unknown;
   onSelect: (row: any) => void;
 }> = ({ name, predicates, row, icon, label, className, objectFields, onSelect }) => {
-  const isVisible = useRowPredicate(predicates?.visibleWhen, row, {
-    fallback: false,
-    warnOnError: true,
-    label: `builtin:${name}:visibleWhen`,
-    fields: objectFields,
-  });
+  // `visibleWhen` is read through the shared `isBuiltinRowActionVisible`, the
+  // same function the "⋮" guard counts with — see objectui#3562.
+  const scope = usePredicateScope();
+  const isVisible = React.useMemo(
+    () => isBuiltinRowActionVisible(predicates, name, row, scope, objectFields),
+    [predicates, name, row, scope, objectFields],
+  );
   const isDisabled = useRowPredicate(predicates?.disabledWhen, row, {
     fallback: false,
     warnOnError: true,
     label: `builtin:${name}:disabledWhen`,
     fields: objectFields,
   });
-  if (predicates?.visibleWhen != null && !isVisible) return null;
+  if (!isVisible) return null;
   const disabled = predicates?.disabledWhen != null && isDisabled;
   return (
     <DropdownMenuItem
@@ -208,6 +382,12 @@ function toButtonVariant(v: RowActionDef['variant']): 'default' | 'secondary' | 
  * into the "⋮" overflow), so the row's main CTA — e.g. "Open" on an
  * environment — is immediately visible and clickable. Hook-safe per item so
  * the `visible` CEL predicate is honored just like the menu path.
+ *
+ * "Just like the menu path" is now literal rather than parallel prose: the
+ * predicate is read through the shared `isCustomRowActionVisible`, so a primary
+ * action whose `visible` fails for this row cannot render inline while the same
+ * def would be hidden in the menu (objectui#3562, the inline half of the same
+ * single-source rule).
  */
 const RowActionInlineButton: React.FC<{
   def: RowActionDef;
@@ -215,8 +395,12 @@ const RowActionInlineButton: React.FC<{
   objectFields?: unknown;
   onActionDef?: (def: RowActionDef, row: any) => void;
 }> = ({ def, row, objectFields, onActionDef }) => {
-  const isVisible = useRowPredicate(def.visible, row, { fallback: false, warnOnError: true, label: def.name, fields: objectFields });
-  if (def.visible && !isVisible) return null;
+  const scope = usePredicateScope();
+  const isVisible = React.useMemo(
+    () => isCustomRowActionVisible(def, row, scope, objectFields),
+    [def, row, scope, objectFields],
+  );
+  if (!isVisible) return null;
   return (
     <Button
       variant={toButtonVariant(def.variant)}
@@ -264,21 +448,75 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
   // the menu (kept above secondary actions) so a row never renders more inline
   // buttons than the actions column can show, which previously clipped the
   // leftmost button (e.g. "Open" hidden behind "Upgrade Plan").
-  const primaryDefs = gatedActionDefs.filter(d => d.variant === 'primary');
-  const inlineDefs = primaryDefs.slice(0, Math.max(0, maxInlineActions));
-  const menuDefs = [
-    ...primaryDefs.slice(Math.max(0, maxInlineActions)),
-    ...gatedActionDefs.filter(d => d.variant !== 'primary'),
-  ];
-  const hasMenu = Boolean(
-    (canEdit && onEdit) ||
-    (canDelete && onDelete) ||
-    menuDefs.length > 0 ||
-    (rowActions?.length ?? 0) > 0,
+  //
+  // The slice runs on the DECLARED primaries, before any `visible` predicate is
+  // evaluated — unchanged on purpose. Re-deriving the slots from the surviving
+  // primaries would promote the next primary into a suppressed one's slot, i.e.
+  // change WHERE an item renders; #3562 is only about whether the "⋮" renders.
+  const { inlineDefs, menuDefs } = React.useMemo(() => {
+    const primaryDefs = gatedActionDefs.filter(d => d.variant === 'primary');
+    const max = Math.max(0, maxInlineActions);
+    return {
+      inlineDefs: primaryDefs.slice(0, max),
+      menuDefs: [
+        ...primaryDefs.slice(max),
+        ...gatedActionDefs.filter(d => d.variant !== 'primary'),
+      ],
+    };
+  }, [gatedActionDefs, maxInlineActions]);
+  // What this row will ACTUALLY render, per-record predicates applied — the
+  // guard and the items read one visibility source, so they cannot disagree.
+  //
+  // objectui#3562: the old guard asked whether handlers were supplied and how
+  // many actions were DECLARED (`(canEdit && onEdit) || … || menuDefs.length > 0`),
+  // while the items were filtered a second time, per row, by `visibleWhen` /
+  // `visible`. Handlers present + every item suppressed for this record = a "⋮"
+  // that opens an empty box — measured at 128×10 with zero `[role=menu]`
+  // children on `sys_approval_request`, whose `list_item` actions (approve /
+  // reject / recall) are gated for approvers and fail for an admin browsing the
+  // "全部" view. The capability gate above was already folded in for exactly
+  // this reason (#3923); the per-record predicates were not.
+  const scope = usePredicateScope();
+  const plan = React.useMemo(
+    () =>
+      planRowActionMenu({
+        row,
+        scope,
+        inlineDefs,
+        menuDefs,
+        rowActions,
+        canEdit,
+        canDelete,
+        onEdit,
+        onDelete,
+        editPredicates,
+        deletePredicates,
+        objectFields,
+      }),
+    [
+      row,
+      scope,
+      inlineDefs,
+      menuDefs,
+      rowActions,
+      canEdit,
+      canDelete,
+      onEdit,
+      onDelete,
+      editPredicates,
+      deletePredicates,
+      objectFields,
+    ],
   );
+  // Nothing left to show → no trigger. An affordance that opens empty reads as
+  // a broken page, which is the whole of #3562. The wrapper `<div>` is still
+  // returned, so the `_actions` cell stays present and every row keeps the same
+  // `<td>` count — a row with nothing to offer renders an empty cell, the shape
+  // a grid with no actions at all has always produced.
+  const hasMenu = plan.menuCount > 0;
   return (
     <div className="flex items-center justify-end gap-1 whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
-      {inlineDefs.map(def => (
+      {plan.inline.map(def => (
         <RowActionInlineButton
           key={def.name}
           def={def}
@@ -301,7 +539,11 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-            {canEdit && onEdit && (
+            {/* Rendered off the PLAN, the same object the trigger's existence
+                was decided from — the items and the "⋮" cannot drift apart
+                (#3562). Each item component re-reads the shared visibility
+                function too, so it stays correct when used standalone. */}
+            {plan.edit && (
               <BuiltinRowActionItem
                 name="edit"
                 predicates={editPredicates}
@@ -309,10 +551,10 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
                 icon={<Edit className="mr-2 h-4 w-4" />}
                 label={t('grid.edit')}
                 objectFields={objectFields}
-                onSelect={onEdit}
+                onSelect={(r) => onEdit?.(r)}
               />
             )}
-            {canDelete && onDelete && (
+            {plan.remove && (
               <BuiltinRowActionItem
                 name="delete"
                 predicates={deletePredicates}
@@ -320,10 +562,10 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
                 icon={<Trash2 className="mr-2 h-4 w-4" />}
                 label={t('grid.delete')}
                 objectFields={objectFields}
-                onSelect={onDelete}
+                onSelect={(r) => onDelete?.(r)}
               />
             )}
-            {menuDefs.map(def => (
+            {plan.custom.map(def => (
               <RowActionMenuItem
                 key={def.name}
                 def={def}
@@ -332,7 +574,7 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
                 onActionDef={onActionDef}
               />
             ))}
-            {rowActions?.map(action => (
+            {plan.legacy.map(action => (
               <DropdownMenuItem
                 key={action}
                 onClick={() => onAction?.(action, row)}

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
@@ -1,0 +1,426 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3562 — the row "⋮" trigger must be decided by the items that will
+ * ACTUALLY render for that row, not by the handlers wired or the actions
+ * declared.
+ *
+ * This is the reporter's own screen. The console object list (all three list
+ * callers converge on `ObjectGrid`, which injects its own `_actions` column and
+ * renders THIS component in the cell — it never passes `onRowEdit`/`onRowDelete`
+ * to data-table) showed a "⋮" on every `sys_approval_request` row that opened a
+ * 128×10 box with zero `[role=menu]` children. The guard read
+ * `(canEdit && onEdit) || (canDelete && onDelete) || menuDefs.length > 0 || rowActions.length > 0`
+ * — handlers and DECLARATIONS — while the items were filtered a second time, per
+ * item and per record, by `visibleWhen` / `visible`. The object's `list_item`
+ * actions (approve / reject / recall) are gated for approvers, so an admin in the
+ * "全部" view failed every one of them row by row: guard true, zero items.
+ *
+ * That this component renders no separators at all is why the reporter measured
+ * exactly 0 children rather than a stray rule — see PR #3756's「登陆点更正」.
+ *
+ * The data-table half of the same defect is PR #3756; this suite mirrors it
+ * (same dispositions, same pure-function cases) with the two additions this
+ * surface needs: the inline PRIMARY button path, and the legacy string
+ * `rowActions` that carry no predicate.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { PredicateScopeProvider, ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+import { registerAllFields } from '@object-ui/fields';
+import { RowActionMenu, planRowActionMenu } from '../RowActionMenu';
+import { ObjectGrid } from '../../ObjectGrid';
+
+registerAllFields();
+
+/** The real `userActions.edit.visibleWhen` shape (objectui#2614). */
+const NOT_FROZEN = 'record.frozen != true';
+/** The reporter's shape: an action gated for a role the viewer is not in. */
+const IS_APPROVER = 'record.approver == "u-me"';
+
+const FROZEN = { id: 'r1', name: 'Frozen A', frozen: true, approver: 'someone-else' };
+const DRAFT = { id: 'r2', name: 'Draft B', frozen: false, approver: 'someone-else' };
+
+const trigger = () => screen.queryByTestId('row-action-trigger');
+
+function renderMenu(props: Record<string, unknown>) {
+  return render(
+    <PredicateScopeProvider scope={{}}>
+      <RowActionMenu row={FROZEN} onActionDef={() => {}} {...props} />
+    </PredicateScopeProvider>,
+  );
+}
+
+afterEach(() => { cleanup(); });
+
+describe('RowActionMenu — the "⋮" counts renderable items, not handlers (#3562)', () => {
+  it('renders NO trigger when every built-in item is predicate-suppressed', () => {
+    const { container } = renderMenu({
+      canEdit: true,
+      canDelete: true,
+      onEdit: () => {},
+      onDelete: () => {},
+      editPredicates: { visibleWhen: NOT_FROZEN },
+      deletePredicates: { visibleWhen: NOT_FROZEN },
+    });
+
+    // Handlers ARE wired and `canEdit`/`canDelete` ARE true — the old guard
+    // rendered a trigger here, which is the reported empty box.
+    expect(trigger()).not.toBeInTheDocument();
+    // With no trigger there is nothing to open, so the empty menu cannot exist.
+    expect(screen.queryByRole('menu')).toBeNull();
+    // The cell wrapper survives (see the ObjectGrid alignment test below), but
+    // it holds nothing.
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('keeps the trigger when only SOME items are suppressed', () => {
+    renderMenu({
+      canEdit: true,
+      canDelete: true,
+      onEdit: () => {},
+      onDelete: () => {},
+      // Edit is gated away on a frozen row; Delete is ungated and survives.
+      editPredicates: { visibleWhen: NOT_FROZEN },
+    });
+    expect(trigger()).toBeInTheDocument();
+  });
+
+  it('renders one trigger for the plain Edit + Delete case (the reporter’s control group)', () => {
+    // Their own business object: no predicates, two items, menu works. This is
+    // the case that must not move.
+    renderMenu({ canEdit: true, canDelete: true, onEdit: () => {}, onDelete: () => {} });
+    expect(trigger()).toBeInTheDocument();
+  });
+
+  it('renders no trigger when nothing is wired at all (unchanged)', () => {
+    renderMenu({});
+    expect(trigger()).not.toBeInTheDocument();
+  });
+
+  it('suppresses the trigger when every CUSTOM action is invisible for the row', () => {
+    // sys_approval_request as the reporter sees it: the declared list_item
+    // actions all gate on being the approver, and this admin is not.
+    renderMenu({
+      rowActionDefs: [
+        { name: 'approve', label: 'Approve', variant: 'secondary', visible: IS_APPROVER },
+        { name: 'reject', label: 'Reject', variant: 'secondary', visible: IS_APPROVER },
+        { name: 'recall', label: 'Recall', variant: 'secondary', visible: IS_APPROVER },
+      ],
+    });
+    expect(trigger()).not.toBeInTheDocument();
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('keeps the trigger for the custom action that DOES survive', () => {
+    renderMenu({
+      rowActionDefs: [
+        { name: 'approve', label: 'Approve', variant: 'secondary', visible: IS_APPROVER },
+        { name: 'view', label: 'View', variant: 'secondary' },
+      ],
+    });
+    expect(trigger()).toBeInTheDocument();
+  });
+
+  it('legacy string rowActions carry no predicate, so they always keep the trigger', () => {
+    // Preserved deliberately: a bare identifier has nothing to evaluate, so it
+    // cannot be suppressed and the menu is never empty.
+    renderMenu({ rowActions: ['send_email'], onAction: () => {} });
+    expect(trigger()).toBeInTheDocument();
+  });
+});
+
+/**
+ * The inline PRIMARY button path. It already returned `null` on a failing
+ * predicate; what changes is that it reads the SAME visibility function as the
+ * menu items and the guard, so the three cannot drift. These pin the outcome the
+ * ruling names: a primary whose predicate fails for the row renders nothing —
+ * and does not conjure a "⋮" either.
+ */
+describe('RowActionMenu — the inline primary button shares one visibility source (#3562)', () => {
+  const OPEN_IF_APPROVER = {
+    name: 'approve',
+    label: 'Approve',
+    variant: 'primary' as const,
+    visible: IS_APPROVER,
+  };
+
+  it('a primary whose predicate fails renders neither a button nor a trigger', () => {
+    renderMenu({ rowActionDefs: [OPEN_IF_APPROVER] });
+    expect(screen.queryByTestId('row-action-inline-approve')).not.toBeInTheDocument();
+    // …and nothing folded into a menu behind it.
+    expect(trigger()).not.toBeInTheDocument();
+  });
+
+  it('the same def renders inline on a row whose predicate passes', () => {
+    render(
+      <PredicateScopeProvider scope={{}}>
+        <RowActionMenu
+          row={{ ...DRAFT, approver: 'u-me' }}
+          rowActionDefs={[OPEN_IF_APPROVER]}
+          onActionDef={() => {}}
+        />
+      </PredicateScopeProvider>,
+    );
+    expect(screen.getByTestId('row-action-inline-approve')).toBeInTheDocument();
+    // A single surviving primary needs no overflow — unchanged behavior.
+    expect(trigger()).not.toBeInTheDocument();
+  });
+
+  it('a suppressed primary does NOT promote the next primary into its inline slot', () => {
+    // Slot allocation still runs on the DECLARED primaries: #3562 is about
+    // whether the trigger renders, not about relocating items. `upgrade` stays
+    // folded into the menu (and so the menu, holding one item, keeps its "⋮").
+    renderMenu({
+      rowActionDefs: [
+        OPEN_IF_APPROVER,
+        { name: 'upgrade', label: 'Upgrade', variant: 'primary' },
+      ],
+    });
+    expect(screen.queryByTestId('row-action-inline-approve')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('row-action-inline-upgrade')).not.toBeInTheDocument();
+    expect(trigger()).toBeInTheDocument();
+  });
+});
+
+/**
+ * Column alignment through the REAL grid — the surface the reporter looked at.
+ * `ObjectGrid` injects the `_actions` column (header + one cell per row) at
+ * table level; this change only decides what goes INSIDE the cell, so a row with
+ * nothing to offer renders an empty cell and every row keeps the same `<td>`
+ * count. Same convention as PR #3756's data-table half.
+ */
+describe('ObjectGrid actions column stays aligned when a row loses its menu (#3562)', () => {
+  function renderGrid(rows: Record<string, unknown>[], userActions: Record<string, unknown>) {
+    const dataSource: any = {
+      getObjectSchema: async (name: string) => ({
+        name,
+        userActions,
+        fields: {
+          id: { type: 'text' },
+          name: { type: 'text', label: 'Name' },
+          frozen: { type: 'boolean', label: 'Frozen' },
+        },
+      }),
+    };
+    return render(
+      <ActionProvider>
+        <SchemaRendererProvider dataSource={dataSource}>
+          <ObjectGrid
+            schema={{
+              type: 'object-grid',
+              objectName: 'test_object',
+              columns: [{ field: 'name', label: 'Name' }],
+              data: { provider: 'value', items: rows },
+            } as any}
+            dataSource={dataSource}
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+          />
+        </SchemaRendererProvider>
+      </ActionProvider>,
+    );
+  }
+
+  /** The last `<td>` of every body row — the `_actions` cell. */
+  function actionCells(container: HTMLElement): HTMLTableCellElement[] {
+    return Array.from(container.querySelectorAll('tbody tr')).map((tr) => {
+      const cells = Array.from(tr.querySelectorAll('td')) as HTMLTableCellElement[];
+      return cells[cells.length - 1];
+    });
+  }
+
+  it('every row suppressed → no triggers, header intact, empty cells (the reported shape)', async () => {
+    const { container } = renderGrid([FROZEN, { ...DRAFT, frozen: true }], {
+      edit: { enabled: true, visibleWhen: NOT_FROZEN },
+      delete: { enabled: true, visibleWhen: NOT_FROZEN },
+    });
+    await waitFor(() => expect(screen.getByText('Frozen A')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Draft B')).toBeInTheDocument());
+
+    // `waitFor`, not a bare assertion: `userActions` arrives from the async
+    // `getObjectSchema`, so the settled verdict is the one to read — before the
+    // fetch lands the grid has no predicates and BOTH rows carry a trigger.
+    // Verified: asserted synchronously, this reads 2 triggers on the fixed
+    // build. So the transition 2 → 0 is real, not an assertion that passes
+    // because nothing ever rendered.
+    await waitFor(() => expect(screen.queryAllByTestId('row-action-trigger')).toHaveLength(0));
+    expect(screen.queryByRole('menu')).toBeNull();
+    // The column itself is table-level and unaffected: header plus one empty
+    // cell per row, exactly as on a grid that wires no row handlers at all.
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    const cells = actionCells(container);
+    expect(cells).toHaveLength(2);
+    for (const cell of cells) expect(cell.querySelector('button')).toBeNull();
+  });
+
+  it('mixed rows keep identical td counts (one row with a trigger, one without)', async () => {
+    const { container } = renderGrid([FROZEN, DRAFT], {
+      edit: { enabled: true, visibleWhen: NOT_FROZEN },
+      delete: false,
+    });
+    await waitFor(() => expect(screen.getByText('Frozen A')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Draft B')).toBeInTheDocument());
+
+    // Only the non-frozen row keeps an item, so only it keeps a trigger.
+    await waitFor(() => expect(screen.queryAllByTestId('row-action-trigger')).toHaveLength(1));
+    const widths = Array.from(container.querySelectorAll('tbody tr')).map(
+      (tr) => tr.querySelectorAll('td').length,
+    );
+    // No row is short a cell — the trigger's absence never collapses the column.
+    expect(new Set(widths).size).toBe(1);
+    const cells = actionCells(container);
+    expect(cells[0].querySelector('button')).toBeNull();
+    expect(cells[1].querySelector('button')).not.toBeNull();
+  });
+});
+
+/**
+ * The resolution the guard counts with, exercised directly: the DOM tests above
+ * pin whether a trigger exists, these pin WHICH items it would hold. Both read
+ * the same `planRowActionMenu`, and the item components re-read the same
+ * visibility functions — so the trigger and its contents cannot drift apart.
+ */
+describe('planRowActionMenu', () => {
+  const scope = {};
+  const noop = () => {};
+  const base = { scope, inlineDefs: [], menuDefs: [] } as const;
+
+  it('counts nothing when nothing is wired', () => {
+    expect(planRowActionMenu({ ...base, row: DRAFT })).toMatchObject({
+      edit: false,
+      remove: false,
+      menuCount: 0,
+    });
+  });
+
+  it('counts both built-ins when they are ungated', () => {
+    expect(planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      canEdit: true,
+      canDelete: true,
+      onEdit: noop,
+      onDelete: noop,
+    })).toMatchObject({ edit: true, remove: true, menuCount: 2 });
+  });
+
+  it('drops only the suppressed built-in', () => {
+    expect(planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      canEdit: true,
+      canDelete: true,
+      onEdit: noop,
+      onDelete: noop,
+      editPredicates: { visibleWhen: NOT_FROZEN },
+    })).toMatchObject({ edit: false, remove: true, menuCount: 1 });
+  });
+
+  it('reaches zero on a suppressed row while the SAME grid keeps both on a row that passes', () => {
+    const args = {
+      ...base,
+      canEdit: true,
+      canDelete: true,
+      onEdit: noop,
+      onDelete: noop,
+      editPredicates: { visibleWhen: NOT_FROZEN },
+      deletePredicates: { visibleWhen: NOT_FROZEN },
+    };
+    expect(planRowActionMenu({ ...args, row: FROZEN }).menuCount).toBe(0);
+    expect(planRowActionMenu({ ...args, row: DRAFT }).menuCount).toBe(2);
+  });
+
+  it('a wired handler without the object verdict counts for nothing', () => {
+    // `canEdit` folds the ADR-0103 bucket, `userActions` and the server's
+    // effective operation set; a handler alone was never enough.
+    expect(planRowActionMenu({ ...base, row: DRAFT, onEdit: noop, onDelete: noop }))
+      .toMatchObject({ edit: false, remove: false, menuCount: 0 });
+  });
+
+  it('keeps the menu defs whose `visible` passes, in declared order', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      menuDefs: [
+        { name: 'unfreeze', visible: 'record.frozen == true' },
+        { name: 'publish', visible: NOT_FROZEN },
+        { name: 'view' },
+      ],
+      row: FROZEN,
+    });
+    expect(plan.custom.map((a) => a.name)).toEqual(['unfreeze', 'view']);
+    expect(plan.menuCount).toBe(2);
+  });
+
+  it('filters the inline primaries too, without counting them toward the trigger', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      inlineDefs: [{ name: 'approve', variant: 'primary', visible: IS_APPROVER }],
+      row: FROZEN,
+    });
+    expect(plan.inline).toEqual([]);
+    // An inline button is not a menu item: it never keeps the "⋮" alive, and a
+    // surviving one does not either.
+    expect(plan.menuCount).toBe(0);
+    const passing = planRowActionMenu({
+      ...base,
+      inlineDefs: [{ name: 'approve', variant: 'primary', visible: IS_APPROVER }],
+      row: { ...DRAFT, approver: 'u-me' },
+    });
+    expect(passing.inline.map((a) => a.name)).toEqual(['approve']);
+    expect(passing.menuCount).toBe(0);
+  });
+
+  it('legacy string actions count — they have no predicate to fail', () => {
+    expect(planRowActionMenu({ ...base, row: FROZEN, rowActions: ['send_email'] }))
+      .toMatchObject({ legacy: ['send_email'], menuCount: 1 });
+  });
+
+  it('still counts an item that renders merely DISABLED', () => {
+    expect(planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      canEdit: true,
+      onEdit: noop,
+      editPredicates: { disabledWhen: 'record.frozen == true' },
+    })).toMatchObject({ edit: true, menuCount: 1 });
+  });
+
+  it('fails CLOSED on a faulting predicate (no phantom item, no phantom trigger)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(planRowActionMenu({
+        ...base,
+        row: FROZEN,
+        canEdit: true,
+        onEdit: noop,
+        editPredicates: { visibleWhen: 'record.frozen ==' },
+        menuDefs: [{ name: 'broken', visible: 'record.frozen ==' }],
+      })).toMatchObject({ edit: false, custom: [], menuCount: 0 });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('preserves the `visible: false` truthy gate verbatim (objectui#3758, not this issue)', () => {
+    // `!def.visible` reads `false` as "ungated", so the def renders and counts —
+    // exactly what the item components have always done. Re-deciding this would
+    // change WHICH items render, which is out of #3562's scope; the point of the
+    // shared function is only that the guard and the items agree.
+    const plan = planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      menuDefs: [{ name: 'ghost', visible: false }],
+    });
+    expect(plan.custom.map((a) => a.name)).toEqual(['ghost']);
+    expect(plan.menuCount).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3562

孪生半件（plugin-grid），关闭本单。data-table 半件是已合并的 PR #3756（`Part of`，不关单）——两者是**同一裁定、同一形状**在两个渲染路径上的落地。本 PR 修的是**报告人那一屏**：console 对象列表的行菜单。

> **PM 裁定（方案 A，2026-08-08）**：守卫改为数谓词过滤后真正渲染的项，零则不渲染触发器，含 `:219` 的 inline primary 按钮路径；`visible: false` 真值门逐字保留（那是 #3758）。

## 落点（已按 `origin/main@e473b6c29` 复核，行号以内容为锚）

`packages/plugin-grid/src/components/RowActionMenu.tsx` 修改前的守卫：

```
const hasMenu = Boolean(
  (canEdit && onEdit) ||
  (canDelete && onDelete) ||
  menuDefs.length > 0 ||
  (rowActions?.length ?? 0) > 0,
);
```

数的是**「handler 是否接了」+「声明了几条」**；而项一级的过滤在后面各自跑第二遍——`RowActionMenuItem`（自定义动作的 `visible`）、`BuiltinRowActionItem`（`visibleWhen`）、`RowActionInlineButton`（inline primary 的 `visible`）。于是「handler 都在、声明都在，但这一行的每一项都被谓词压掉」这个状态可达：触发器活过守卫，菜单里什么都不渲染。

`sys_approval_request` 在 `list_item` 声明的 approve / reject / recall 等动作，`visible` 是写给审批人的；admin 在「全部」视图里逐行都不满足 → `hasMenu` 为真、0 项 —— 正是报告实测的 `data-state=open` / `z-index: 50` / 128×10 / `[role=menu]` children `=== 0`。本组件**一条分隔线都没有**，全压掉恰好是 0，与报告逐字吻合（data-table 那条路径在两个 handler 同时在场时会无条件渲染一条分隔线，children 至少为 1 —— 这也是 PR #3756 判定落点不在 data-table 的旁证之一）。

**一处早已存在的同类先例**：ADR-0066 D4 的能力门（framework#3923）当初就是因为同样的理由被折进 `hasMenu` 的（注释原文：*applied ONCE to the whole declared set so the inline CTA, the overflow menu and `hasMenu` all agree*）。按记录求值的谓词没有被一并折进去，本 PR 补上这一半。`packages/plugin-grid/src/__tests__/rowCrudEffectiveOps.test.tsx` 的辅助函数甚至已经把**期望行为**写在注释里了（*RowActionMenu renders the "⋮" only when at least one entry survives its gates*）——在此之前那句话只对能力门成立。

## 修复

守卫改为数**真正会渲染的菜单项**，零则整个触发器不渲染。

- **单一可见性源**：新增 `isBuiltinRowActionVisible` / `isCustomRowActionVisible`，`planRowActionMenu` 与**三个**item 渲染器都读它们。项与触发器因此在结构上无法各说各话（不是靠两处写法碰巧一致）。与 PR #3756 的 data-table 实现保持结构平行（同样的函数名、同样的 plan 形状），不跨包 import。
- **`:219` 的 inline primary 路径**：它本来就在谓词失败时 `return null`，所以**行为不变**；变的是它现在读的是同一个共享函数，而不是自己那份 `useRowPredicate` + 真值判断。裁定点名要覆盖这条路径，覆盖方式是**接入单一来源**而不是新增拦截。
- **求值不用 hook**：`evalRowActionVisibility` 走 `@object-ui/core` 的 `evalRowPredicate`（`fallback: false` + `warnOnError` + `fields`，与 `useRowPredicate` 同参），因为动作条数是变量，一项一个 `useRowPredicate` 会把 hook 数量绑到 `rowActionDefs.length` 上。布尔短路照抄本包 `bulkEligibility` 里写明的理由（objectui#3492：布尔交给引擎会 fault 并 fail-closed，`visible: true` 曾因此把按钮对所有人藏起来）。
- **守卫落在行级**：`visibleWhen` / `visible` 是**按记录**求值的，同一张表第一行可能保留 Edit、第二行一项不剩。`RowActionMenu` 本来就由 `_actions` 列的 `cell` 逐行实例化，所以决策天然落在这里，无需像 data-table 那样新抽 per-row 组件。
- **`plan.menuCount` 而不是 `plan.count`**：本表面还有 inline 按钮路径，而 inline 按钮**不参与**触发器的决策（一行只有一个存活 primary 时，历来就是「有 inline、无 ⋮」）。命名上把这件事写死，避免下一个读者误加。

### 刻意**不**改的两处（都在裁定第 4 条内）

1. **`visible: false` 真值门逐字保留**：`!def.visible` 把 `false` 读成「未设门」，于是该项渲染并计数——正是两个 item 组件历来的行为。重新裁决它会改变**哪些项渲染**，越出本单，已由 #3758 单独记录。测试里正向钉住了这一条。
2. **`maxInlineActions` 的 slice 仍跑在「声明的 primaries」上**：不按存活重算。重算会把下一个 primary 提进被压掉那个的槽位，即改变**某一项渲染在哪里**；本单只管**触发器是否渲染**。测试里也钉住了。（顺带发现的槽位浪费问题已单独立单，见下。）

### 列对齐

操作列（`_actions`）是 `ObjectGrid` 在**表级**注入的（`hasActions || hasRowActions`），表头与每行的单元格都不由本次改动决定；本 PR 只改单元格**内部**的内容。没有动作可显示的行渲染一个空单元格，与「完全没接 handler 的表」历来的形态一致（与 PR #3756 同一约定）。测试里用**真实 ObjectGrid** 钉住了混合行（一行有触发器、一行没有）的 `td` 数量一致。

## 测试

`packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx`（新增，23 例）：

- **报告人的形状**：整行被压掉 → 无触发器、`[role=menu]` 不存在、单元格内无按钮；
- 只压掉一部分 → 触发器保留；常规 Edit + Delete → 触发器在（报告人的**对照组**不变）；什么都没接 → 无触发器（旧行为不变）；
- 全部自定义动作被 `visible` 压掉（approve / reject / recall 三条，即 `sys_approval_request` 的形状）→ 无触发器；其中一条存活 → 触发器保留；
- legacy 字符串 `rowActions` 没有谓词可失败，因此永远保住触发器（刻意保留）；
- **`:219` inline primary**：谓词失败 → 既无 inline 按钮也无触发器；同一 def 在通过的行上照常 inline；被压掉的 primary **不**把下一个 primary 提进槽位；
- **真实 ObjectGrid 列对齐**：全行被压 → 0 触发器 + 表头在 + 每行空单元格；混合行 → 1 个触发器且两行 `td` 数量相同；
- `planRowActionMenu` 纯函数 11 例：计数、只掉被压的那一项、同一表格两行不同结论、只有 handler 没有对象裁定不计数、存活动作按声明序、inline 被过滤但不计入 `menuCount`、legacy 计数、`disabledWhen` 的项**仍然算数**、谓词报错 fail-closed（不产生幽灵项/幽灵触发器）、`visible: false` 真值门正向钉住。

既有的行菜单测试（`RowActionMenu.test.tsx` / `RowActionMenu.capabilityGate.test.tsx` / `rowCrudEffectiveOps` / `column-features` / `legacyRowActionDispatch`）未改动即全绿。

正向（仓库根，flock 串行，`--maxWorkers=2`，`NODE_OPTIONS=--max-old-space-size=4096`）：

```
pnpm exec vitest run packages/plugin-grid/ --maxWorkers=2
 Test Files  55 passed (55)
      Tests  479 passed (479)
```

### 反向验证（先写下预测，后运行）

预测（原文存档于运行前）：**只**把守卫那一行换回旧式声明计数（共享可见性函数、plan、item 渲染全部保留），则 **4 红 19 绿**——

1. `renders NO trigger when every built-in item is predicate-suppressed`（`canEdit && onEdit` 为真，旧守卫复活空触发器）
2. `suppresses the trigger when every CUSTOM action is invisible for the row`（`menuDefs.length === 3 > 0`）
3. ObjectGrid `every row suppressed → no triggers…`（0 → 2）
4. ObjectGrid `mixed rows keep identical td counts`（`canEdit` 是表级的，旧守卫给**两行**都发触发器：1 → 2）

并明确预测**不会**红的两条：inline 套件里那两条（单个 primary 占掉 inline 槽 → `menuDefs` 为空且无 handler → **旧守卫同样为 false**）。它们钉的是 `:219` 这条路径，**结构上无法**察觉守卫被换回去——照模板想当然写成「全红」是不对的。11 条纯函数用例不经过守卫，同样保持绿。

实测：

```
 × renders NO trigger when every built-in item is predicate-suppressed
 × suppresses the trigger when every CUSTOM action is invisible for the row
 × every row suppressed → no triggers, header intact, empty cells (the reported shape)
 × mixed rows keep identical td counts (one row with a trigger, one without)
 Test Files  1 failed (1)
      Tests  4 failed | 19 passed (23)
AssertionError: expected 1 to be 2  // mixed-rows：两行都长出了触发器
```

**4 红 19 绿，与事先写下的预测逐条一致（含"哪两条不会红"的预测）。**

### 其余门

- `pnpm --filter @object-ui/plugin-grid type-check` → 0（`tsc --noEmit` + typetests 均通过）
- `pnpm --filter @object-ui/plugin-grid lint` → **0 error**（563 warning 为全包既有基线）
- `node scripts/check-control-bytes.mjs` → OK；另对改动文件手工扫过控制字符类（`grep -naP` 的 `\x00-\x08\x0b\x0c\x0e-\x1f`），无命中
- `node scripts/check-changeset-no-major.mjs` → OK（changeset 为 `patch`）

### 消费半径清查（不是只扫本包）

全仓 grep `RowActionMenu` 与 `row-action-trigger`：源码消费者只有 `plugin-grid/src/ObjectGrid.tsx`（`_actions` 列的 cell）与包 barrel `index.tsx` 的再导出；`app-shell/src/views/ObjectView.tsx` 只在注释里提到它，无 import。跨包无任何 import。e2e live 三个 spec（`action-modal` / `list-row-action-cel` / `screen-flow`）都以「先等到触发器、点开、断言存在的项」为形态——`list-row-action-cel` 显式依赖 *"Edit" is always present*，即 `menuCount >= 1`，不受影响。

## 备注（评审可留意）

三个新的 `export function` 与 PR #3756 一样与组件同文件（保持结构平行、且「守卫和项读同一个函数」这件事对下一个读者是自证的），代价是 `react-refresh/only-export-components` 由 1 条变 4 条 warning。该文件因既有的 `formatActionLabel` 导出**本来就已经**放弃了 fast refresh，故无新增能力损失；若评审倾向拆出独立模块（本包已有 `bulkEligibility.ts` 这样的纯逻辑模块先例），我照改。

---

顺带发现、**未在本 PR 修**、已单独立单：`maxInlineActions` 的槽位分配跑在声明序上，因此被 `visible` 压掉的 primary 会**白占一个 inline 槽**，把本该 inline 的下一个 primary 挤进溢出菜单（详见 issue 正文）。改它属于「某一项渲染在哪里」，越出本单裁定第 4 条。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_