### PR TITLE
docs(hooks): guard-shared-stash 头注的自测用例数改为 32,并写下计数规则 (#3721)

### DIFF
--- a/.claude/hooks/guard-shared-stash.sh
+++ b/.claude/hooks/guard-shared-stash.sh
@@ -46,7 +46,10 @@
 # for anyone who means it. Widening it to string-match anywhere in the command would block
 # every `grep "git stash"` run against this very file.
 #
-# Self-test (26 cases, no network, no build): .claude/hooks/guard-shared-stash.selftest.sh
+# Self-test (32 cases, no network, no build): .claude/hooks/guard-shared-stash.selftest.sh
+# 32 = 30 `expect ` lines + 2 inline specials (empty-tool_input fail-open, no-jq fallback).
+# Re-derive when the matrix changes: `grep -c '^expect ' <selftest>` + 2, and the run's own
+# tail prints the total ("N passed, N failed") — keep this number equal to it.
 
 set -uo pipefail
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3721

## 问题

`.claude/hooks/guard-shared-stash.sh` 的头注写着「Self-test (26 cases, no network, no build)」,而自测矩阵从 #3430 落地起就一直是 32 条:30 条 `expect ` 用例,加 2 条内联特例(空 tool_input 时 fail-open、PATH 上没有 jq 时的解析回退)。

这一行正是读者在依赖该守卫前会信的覆盖面声明,少报了 6 条——恰好是这个 hook 自己在管的「声明与实际不一致」形状。

## 改动

只改头注:把 26 改成 32,并把计数规则和重新推导的方法写在紧随其后的注释里。这三行注释就是「派生计数」的轻量版——为一个数字造一套派生机制是过度设计,所以不做;数字仍然手写,但下次矩阵变动时有现成的重算配方可读:

- 32 = 30 条 `expect ` 行 + 2 条内联特例;
- 重算方式:对 selftest 文件 `grep -c '^expect '` 再 + 2,并且跑一遍自测,尾部本身会打印总数「N passed, N failed」,保持这个数字与它相等。

`.claude/hooks/guard-shared-stash.selftest.sh` 未改动,守卫逻辑未改动——本 PR 是纯注释。

## 验证

真跑自测(这才是本任务的实质验证),在 `objectui-3721` worktree 内:

```
$ bash .claude/hooks/guard-shared-stash.selftest.sh
...
  ok   allow  (empty tool_input)
== jq-less fallback still parses the command ==
  ok   block  (no jq on PATH)

32 passed, 0 failed
EXIT=0
```

- `grep -c '^expect '` 对 selftest = 30;30 + 2 = 32,与写入的数字、与自测自己打印的总数三者一致。
- `node scripts/check-control-bytes.mjs` → `check-control-bytes: OK (scanned 3699 tracked text file(s); skipped 85 binary)`;另对改动文件做了一次手工扫描 `grep -naP` (0x00-0x08、0x0b、0x0c、0x0e-0x1f),无命中,`file` 仍报 UTF-8 text。
- 未跑 `pnpm install` / 构建 / 单测:改动是一行 shell 注释,不进任何包的编译或测试面,跑它们只会白占共享容器的内存。

## 与 objectstack 镜像的一致性

objectstack 侧的同名副本(见 objectstack-ai/objectstack#6632)头注已经是 32。修正后,本仓这一行与镜像那一行**逐字节相同**(已用 `git show origin/main:...` 比对确认),issue 里说的「两份副本头注最后一处非故意的文字差异」由此消除。

新增的 3 行计数说明是本仓这边的增量,建议后续把同样的说明同步到镜像;那是跨仓改动,不放进本 PR。

## 无 changeset

仓库内部工具链(PreToolUse hook),不属于任何已发布包,对用户不可见。先例:`.claude/hooks/` 下全部 4 个历史提交(6801806、03b0f70、4d617a6、87df0b4)都没有带 `.changeset/` 文件。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_