### PR TITLE
fix(app-shell): keep a field's own option keys when an action param inherits them (#3559)

### DIFF
--- a/.changeset/quiet-moons-inherit.md
+++ b/.changeset/quiet-moons-inherit.md
@@ -1,0 +1,26 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/core": patch
+---
+
+Action params that inherit a field's options now keep the keys that field declared
+
+A field-backed action param (`{ field: 'tier' }`) had its inherited option list
+rebuilt entry by entry as `{ label, value }`, which silently dropped every other
+key the field's options declared — most consequentially the per-option
+`visibleWhen` predicate (ADR-0058). A select field whose options narrow by
+predicate in an object form therefore offered the FULL list in an action dialog,
+including the entries the predicate exists to hide, with no diagnostic on either
+side; `color` / `icon` / `disabled` were lost the same way. Options authored
+inline on the param were never affected — they always passed through verbatim,
+which is the asymmetry this restores.
+
+The resolver now preserves each inherited entry and only does its two real jobs:
+expanding bare strings into label/value pairs and translating the label through
+`fieldOptionLabel`. The option widgets already filter on `visibleWhen`, so a
+role-gated option (`'admin' in current_user.positions`) inherited by a dialog
+param now narrows the offered set and clears a seeded value the predicate hides.
+
+`ActionParamDef.options` (`@object-ui/core`) and the resolver's `RawActionParam`
+are widened to match: `ActionParamOption` names the two keys the param layer
+reads and carries the rest of a field's option vocabulary through.

--- a/packages/app-shell/src/utils/resolveActionParams.optionVisibleWhen.test.tsx
+++ b/packages/app-shell/src/utils/resolveActionParams.optionVisibleWhen.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3559, end to end: a field's per-option `visibleWhen` narrows the
+ * option list a dialog param actually renders.
+ *
+ * The unit half lives in `resolveActionParams.test.ts` (the resolved param keeps
+ * the keys, and `resolveVisibleOptions()` filters on them). What that cannot show
+ * is the CONSUMER half — whether the control the dialog builds evaluates the
+ * predicate at all, or merely receives it. So this file drives the real widget
+ * with the real field object, wired the way `ActionParamDialog` wires it:
+ *
+ *   field metadata → `resolveActionParams()` → `paramToField()` → `<SelectField>`
+ *
+ * `ActionParamDialog` renders `field={paramToField(param)}` and `id={param.name}`
+ * through `getLazyFieldWidget(field.type)`; `SelectField` is what that resolves
+ * to for a `select` param. It is imported here at MODULE scope rather than through
+ * the lazy registry on purpose (AGENTS.md §测试纪律): a first dynamic `import()`
+ * under a saturated transform pipeline can eat most of RTL's 1s budget, and the
+ * assertions below are synchronous effects.
+ *
+ * Deliberately NOT passed: `dependentValues`. The dialog does not pass it either —
+ * it keeps the in-progress param values in local state — so the predicate `record`
+ * a dialog option sees is whatever `SchemaRendererContext` supplies (the page's
+ * `formValues` / `data`), never the dialog's own values. The predicates exercised
+ * here are therefore the ones that work in a dialog today: scope-relative
+ * (`current_user`), the role-gating case ADR-0058 opens. RECORD-relative
+ * predicates in a dialog are measured, not asserted, in the last test — see the
+ * note there.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { SelectField } from '@object-ui/fields';
+import { resolveActionParams, type ResolveActionParamsContext } from './resolveActionParams';
+import { paramToField } from './paramToField';
+
+/** An object whose `tier` field gates one option on the viewer's positions. */
+const accountCtx = (
+  options: Array<Record<string, unknown> | string>,
+): ResolveActionParamsContext => ({
+  objectName: 'account',
+  objects: [{ name: 'account', fields: { tier: { type: 'select', label: 'Tier', options } } }],
+  fieldLabel: (_o, _f, fallback) => fallback,
+});
+
+const ROLE_GATED = [
+  { label: 'Standard', value: 'standard' },
+  { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" },
+];
+
+/**
+ * Render the `tier` param exactly as `ActionParamDialog` renders a select param:
+ * resolve it from the field, adapt it with `paramToField()`, hand the result to
+ * the widget as `field` with `id={param.name}`.
+ */
+function renderInheritedSelect(
+  options: Array<Record<string, unknown> | string>,
+  positions: string[],
+  value?: string,
+) {
+  const onChange = vi.fn();
+  const param = resolveActionParams([{ field: 'tier' }], accountCtx(options))[0];
+  const field = paramToField(param);
+  // Same props the dialog passes a non-boolean param's widget. The cast is the
+  // dialog's own seam: `paramToField()` returns `Record< string, unknown >`-shaped
+  // field metadata and the widget is reached through a lazy `any` component there.
+  const props = { id: param.name, value: value ?? null, onChange, field } as unknown as
+    React.ComponentProps<typeof SelectField>;
+  render(
+    <PredicateScopeProvider scope={{ current_user: { positions } }}>
+      <SelectField {...props} />
+    </PredicateScopeProvider>,
+  );
+  return { onChange, field };
+}
+
+describe('field-inherited option predicates reach the dialog control (objectui#3559)', () => {
+  it('drops a role-gated option for a viewer who fails the predicate', () => {
+    // Every option gated → the offered set is empty, and the widget says so
+    // instead of rendering a dropdown of options the predicate excluded.
+    renderInheritedSelect(
+      [{ label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" }],
+      ['sales'],
+    );
+    expect(screen.getByTestId('select-empty-tier')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('offers the same list to a viewer who satisfies it', () => {
+    renderInheritedSelect(
+      [{ label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" }],
+      ['admin'],
+    );
+    expect(screen.queryByTestId('select-empty-tier')).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('clears a pre-filled value the predicate hides (per-option, not whole-list)', () => {
+    // The per-option proof: `standard` survives (so the list is not gated as a
+    // whole — a combobox is still offered) while `admin_only` is not offered, so
+    // the widget's cascade-clear drops the seeded value.
+    const { onChange } = renderInheritedSelect(ROLE_GATED, ['sales'], 'admin_only');
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('keeps that value for a viewer the predicate admits', () => {
+    const { onChange } = renderInheritedSelect(ROLE_GATED, ['admin'], 'admin_only');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unpredicated inherited list fully offered', () => {
+    const { onChange, field } = renderInheritedSelect(
+      [{ label: 'Standard', value: 'standard' }, 'won'],
+      [],
+      'standard',
+    );
+    expect(field.options).toEqual([
+      { label: 'Standard', value: 'standard' },
+      { label: 'won', value: 'won' },
+    ]);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('MEASURES a record-relative predicate with no record in context: fails OPEN', () => {
+    // Not a claim about correct behaviour — a recorded measurement, because the
+    // fix delivers the keys and the widget honours them, but WHICH record a
+    // dialog evaluates them against is a separate question this PR does not
+    // settle.
+    //
+    // Measured, not assumed (the prediction going in was the opposite): with no
+    // `dependentValues` — the dialog passes none, it keeps param values in local
+    // state — and no `SchemaRendererContext` above, `record` is `{}`, and
+    // `record.country == 'cn'` is UNRESOLVABLE rather than false. Per
+    // `resolveVisibleOptions()`'s documented fail-open default the option is
+    // therefore KEPT, not hidden. Same list against a populated record filters
+    // as expected (`{ country: 'us' }` → `[]`), which is what the object form
+    // gets and what a dialog mounted under a page picks up from that page's
+    // `formValues`/`data`.
+    //
+    // So the residual gap is narrow and safe-by-default: a dialog cannot narrow
+    // an inherited list against its OWN in-progress params, and unresolvable
+    // predicates offer everything rather than hiding everything. Reported
+    // separately; nothing here should be read as endorsing it.
+    renderInheritedSelect(
+      [{ label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" }],
+      ['admin'],
+    );
+    expect(screen.queryByTestId('select-empty-tier')).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/utils/resolveActionParams.test.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.test.ts
@@ -17,6 +17,7 @@
  * forms, and across inline / field-backed / missing-field branches.
  */
 import { describe, it, expect, vi } from 'vitest';
+import { resolveVisibleOptions, type ActionParamOption } from '@object-ui/core';
 import type { ActionParam } from '@object-ui/types';
 import {
   RESOLVED_ONLY_PARAM_KEYS,
@@ -356,5 +357,158 @@ describe('resolveActionParams — authored through the public ActionParam type (
     const authored: ActionParam = { name: 'account_id', type: 'lookup', reference: 'account' };
     const raw: RawActionParam = authored;
     expect(raw.reference).toBe('account');
+  });
+});
+
+/**
+ * objectui#3559 — a field-inherited option list keeps the keys the FIELD declared.
+ *
+ * `normaliseOptions()` rebuilt every inherited entry as a fresh `{ label, value }`,
+ * so a select field's per-option `visibleWhen` (ADR-0058 / #2284, declared by
+ * `@objectstack/spec`'s `SelectOptionSchema` and filtered by
+ * `resolveVisibleOptions()` in `@object-ui/core`) survived in the object form and
+ * vanished the moment an action param inherited the field via `{ field: '…' }`.
+ * The dialog then offered the whole list — predicate-hidden entries included —
+ * with no diagnostic on either side. `color` / `icon` / `disabled` went the same
+ * way.
+ *
+ * The asymmetry is the tell: options authored INLINE on the param never came
+ * through `normaliseOptions()` at all (`param.options ?? normaliseOptions(…)`),
+ * so they always sank verbatim. One branch of one `??` behaved one way and the
+ * other the other, for the same authored key.
+ *
+ * These tests follow the resolver's two jobs (expand bare strings, translate the
+ * label) and pin that it does no third one, then carry one inherited list all the
+ * way to `resolveVisibleOptions()` — the reader the option widgets wrap — so the
+ * claim under test is the observable one: the predicate narrows the dialog's list.
+ */
+describe('resolveActionParams — field-inherited option keys (objectui#3559)', () => {
+  /**
+   * A `select` field whose options carry the full declared vocabulary. Authoring
+   * this literal is itself the type-level half of the fix: this file is compiled
+   * by `tsconfig.typetests.json`, so a `RuntimeField.options` re-narrowed to
+   * `{ label, value }` fails excess-property checking right here rather than
+   * silently reverting the behaviour below.
+   */
+  const optionCtx = () =>
+    ctx({
+      objectName: 'account',
+      objects: [
+        {
+          name: 'account',
+          fields: {
+            tier: {
+              type: 'select',
+              label: 'Tier',
+              options: [
+                { label: 'Standard', value: 'standard', color: 'gray' },
+                {
+                  label: 'Admin only',
+                  value: 'admin_only',
+                  visibleWhen: "'admin' in current_user.positions",
+                  color: 'red',
+                  icon: 'shield',
+                  disabled: false,
+                },
+              ],
+            },
+            stage: { type: 'select', label: 'Stage', options: ['open', 'won'] },
+          },
+        },
+      ],
+    });
+
+  it('keeps a per-option visibleWhen the field declared', () => {
+    const resolved = resolveActionParams([{ field: 'tier' }], optionCtx())[0];
+    expect(resolved.options).toEqual([
+      { label: 'Standard', value: 'standard', color: 'gray' },
+      {
+        label: 'Admin only',
+        value: 'admin_only',
+        visibleWhen: "'admin' in current_user.positions",
+        color: 'red',
+        icon: 'shield',
+        disabled: false,
+      },
+    ]);
+  });
+
+  it('still translates the label through fieldOptionLabel, keeping the other keys', () => {
+    const resolved = resolveActionParams(
+      [{ field: 'tier' }],
+      ctx({
+        ...optionCtx(),
+        fieldOptionLabel: (objectName, fieldName, value, fallback) =>
+          `${objectName}.${fieldName}.${value}:${fallback}`,
+      }),
+    )[0];
+    expect(resolved.options?.[1]).toEqual({
+      label: 'account.tier.admin_only:Admin only',
+      value: 'admin_only',
+      visibleWhen: "'admin' in current_user.positions",
+      color: 'red',
+      icon: 'shield',
+      disabled: false,
+    });
+  });
+
+  it('still expands bare strings into label/value pairs', () => {
+    expect(resolveActionParams([{ field: 'stage' }], optionCtx())[0].options).toEqual([
+      { label: 'open', value: 'open' },
+      { label: 'won', value: 'won' },
+    ]);
+  });
+
+  it('leaves options undefined when the field declares none', () => {
+    const resolved = resolveActionParams(
+      [{ field: 'tier' }],
+      ctx({ objectName: 'account', objects: [{ name: 'account', fields: { tier: { type: 'text' } } }] }),
+    )[0];
+    expect(resolved.options).toBeUndefined();
+  });
+
+  it('passes an option list authored INLINE on the param through verbatim', () => {
+    // The branch that was never broken — pinned so the fix is read as making the
+    // two branches agree, not as touching this one. Stays green either way.
+    const inline = [
+      { label: 'Yes', value: 'yes' },
+      { label: 'Admin only', value: 'admin_only', visibleWhen: "'admin' in current_user.positions" },
+    ];
+    const resolved = resolveActionParams(
+      [{ field: 'tier', options: inline }, { name: 'confirm', type: 'select', options: inline }],
+      optionCtx(),
+    );
+    // Field-backed with inline options: the inline list wins and the field's is
+    // not consulted (same object identity — nothing rebuilt it).
+    expect(resolved[0].options).toBe(inline);
+    expect(resolved[1].options).toBe(inline);
+  });
+
+  it('reaches resolveVisibleOptions through paramToField and narrows the offered set', () => {
+    // End to end over the real chain the dialog uses: field metadata →
+    // resolveActionParams → paramToField → the `field.options` a widget reads →
+    // `resolveVisibleOptions`, which is what `useCascadingOptions` wraps.
+    const field = paramToField(resolveActionParams([{ field: 'tier' }], optionCtx())[0]);
+
+    const forSales = resolveVisibleOptions(field.options, {}, { current_user: { positions: ['sales'] } });
+    expect(forSales.map((o) => o.value)).toEqual(['standard']);
+
+    const forAdmin = resolveVisibleOptions(field.options, {}, { current_user: { positions: ['admin'] } });
+    expect(forAdmin.map((o) => o.value)).toEqual(['standard', 'admin_only']);
+  });
+
+  it('keeps `label` and `value` required on a param option (type-level)', () => {
+    // The catch-all widens the vocabulary; it must not dissolve the two keys
+    // this layer itself reads. Compiled by `tsconfig.typetests.json`, so these
+    // assertions are checked — a re-widening to `Record< string, unknown >`
+    // turns the unused suppressions into errors.
+    const complete: ActionParamOption = { label: 'Standard', value: 'standard', color: 'gray' };
+    expect(complete.value).toBe('standard');
+
+    // @ts-expect-error `value` is not optional
+    const noValue: ActionParamOption = { label: 'Standard' };
+    // @ts-expect-error `label` is not optional
+    const noLabel: ActionParamOption = { value: 'standard' };
+    expect([noValue, noLabel]).toHaveLength(2);
   });
 });

--- a/packages/app-shell/src/utils/resolveActionParams.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.ts
@@ -29,7 +29,7 @@
  * rejects it, the server's `.strict()` parse rejects it, and this resolver
  * names it via {@link RESOLVED_ONLY_PARAM_KEYS} rather than reading it.
  */
-import type { ActionParamDef } from '@object-ui/core';
+import type { ActionParamDef, ActionParamOption } from '@object-ui/core';
 
 /**
  * Resolved params keep raw `FieldType` values (`text` / `email` / `select` /
@@ -47,7 +47,13 @@ export interface RawActionParam {
   label?: string;
   type?: string;
   required?: boolean;
-  options?: Array<{ label: string; value: string }>;
+  /**
+   * Option list authored inline on the param. Speaks the same vocabulary as the
+   * resolved side ({@link ActionParamOption}): the two keys this resolver reads
+   * plus a catch-all for whatever else an option declares (`visibleWhen`,
+   * `color`, `icon`, `disabled`) — objectui#3559.
+   */
+  options?: ActionParamOption[];
   placeholder?: string;
   helpText?: string;
   defaultValue?: unknown;
@@ -177,7 +183,13 @@ interface RuntimeField {
   placeholder?: string;
   help?: string;
   description?: string;
-  options?: Array<{ label: string; value: string } | string>;
+  /**
+   * The field's own option list — `select` / `radio` / `checkboxes` metadata as
+   * `@objectstack/spec`'s `SelectOptionSchema` declares it, so entries may carry
+   * `visibleWhen` / `color` / `icon` / `disabled` alongside label and value. A
+   * bare string is shorthand for `{ label: s, value: s }`.
+   */
+  options?: Array<ActionParamOption | string>;
   multiple?: boolean;
   defaultValue?: unknown;
   // ── Upload widget config (file/image fields) ──
@@ -224,20 +236,37 @@ export interface ResolveActionParamsContext {
   row?: Record<string, unknown>;
 }
 
-/** Normalise an options entry (allowing bare strings) into label/value pairs. */
+/**
+ * Normalise a field's option list for a param: expand bare strings into
+ * `{ label, value }` and translate each label through `fieldOptionLabel`.
+ *
+ * Those are the only two jobs. Everything else the option declares is
+ * PRESERVED, not rebuilt (objectui#3559): this used to return a fresh
+ * `{ label, value }` per entry, which silently dropped a field's per-option
+ * `visibleWhen` — so a select field whose options narrow by predicate in the
+ * object form (`resolveVisibleOptions()` in `@object-ui/core`, ADR-0058 /
+ * #2284) offered the FULL list, predicate-hidden entries included, the moment
+ * an action param inherited that field via `{ field: '<name>' }`. Same field
+ * metadata, two surfaces, two behaviours, no diagnostic anywhere. `color` /
+ * `icon` / `disabled` were lost the same way.
+ *
+ * Only the field-inherited branch ever came through here; options authored
+ * inline on the param always passed through verbatim (see `resolvedOptions`
+ * below), which is precisely the asymmetry this restores.
+ */
 function normaliseOptions(
-  options: Array<{ label: string; value: string } | string> | undefined,
+  options: Array<ActionParamOption | string> | undefined,
   objectName: string,
   fieldName: string,
   optionLabel?: ResolveActionParamsContext['fieldOptionLabel'],
-): Array<{ label: string; value: string }> | undefined {
+): ActionParamOption[] | undefined {
   if (!Array.isArray(options) || options.length === 0) return undefined;
   return options.map((o) => {
-    const raw = typeof o === 'string' ? { label: o, value: o } : o;
+    const raw: ActionParamOption = typeof o === 'string' ? { label: o, value: o } : o;
     const label = optionLabel
       ? optionLabel(objectName, fieldName, raw.value, raw.label)
       : raw.label;
-    return { label, value: raw.value };
+    return { ...raw, label, value: raw.value };
   });
 }
 

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -412,23 +412,6 @@ export type ResultDialogHandler = (
 ) => Promise<void>;
 
 /**
- * ActionParam definition accepted by the runner.
- * Compatible with @objectstack/spec ActionParam.
- *
- * The RESOLVED shape — what `resolveActionParams()` emits and `ActionParamDialog`
- * reads, after a field-backed param's `{ field }` reference has been inlined.
- * The AUTHORING counterpart is `@object-ui/types`' `ActionParam` (objectui#3174).
- *
- * `validation?: string` used to sit here too, and was removed by objectui#3201:
- * no producer ever wrote it (it was never a key of `resolveActionParams()`'s
- * `RawActionParam`, and the runtime field metadata a field-backed param inherits
- * from carries no `validation` either) and no consumer ever read it —
- * `paramToField()` did not map it, so it never reached the field widgets, whose
- * rules `buildValidationRules()` builds from `required` / `minLength` /
- * `maxLength` / `pattern`. Declaring it on the resolved side only invited the
- * authoring side to declare it back.
- */
-/**
  * One entry of a param's option list, as the RESOLVED param carries it.
  *
  * `label` / `value` are the two keys this layer itself reads and rewrites (i18n
@@ -454,6 +437,23 @@ export type ActionParamOption = {
   [key: string]: unknown;
 };
 
+/**
+ * ActionParam definition accepted by the runner.
+ * Compatible with @objectstack/spec ActionParam.
+ *
+ * The RESOLVED shape — what `resolveActionParams()` emits and `ActionParamDialog`
+ * reads, after a field-backed param's `{ field }` reference has been inlined.
+ * The AUTHORING counterpart is `@object-ui/types`' `ActionParam` (objectui#3174).
+ *
+ * `validation?: string` used to sit here too, and was removed by objectui#3201:
+ * no producer ever wrote it (it was never a key of `resolveActionParams()`'s
+ * `RawActionParam`, and the runtime field metadata a field-backed param inherits
+ * from carries no `validation` either) and no consumer ever read it —
+ * `paramToField()` did not map it, so it never reached the field widgets, whose
+ * rules `buildValidationRules()` builds from `required` / `minLength` /
+ * `maxLength` / `pattern`. Declaring it on the resolved side only invited the
+ * authoring side to declare it back.
+ */
 export interface ActionParamDef {
   name: string;
   label: string;

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -428,12 +428,38 @@ export type ResultDialogHandler = (
  * `maxLength` / `pattern`. Declaring it on the resolved side only invited the
  * authoring side to declare it back.
  */
+/**
+ * One entry of a param's option list, as the RESOLVED param carries it.
+ *
+ * `label` / `value` are the two keys this layer itself reads and rewrites (i18n
+ * translation of the label, value matching). Everything else an option declares
+ * rides along in the catch-all and reaches the widgets untouched: per-option
+ * `visibleWhen` (the CEL predicate `resolveVisibleOptions()` filters on —
+ * ADR-0058 / #2284), `color`, `icon`, `disabled`.
+ *
+ * The catch-all is deliberate rather than a closed key list (objectui#3559).
+ * A field's option vocabulary is owned by the field metadata (`@objectstack/spec`'s
+ * `SelectOptionSchema`) and read by the option widgets; a param's option list is
+ * only a CONDUIT between the two. When this type restated that vocabulary as
+ * `{ label, value }`, the resolver dutifully rebuilt every inherited option to
+ * match and a field's `visibleWhen` stopped narrowing the dialog's list — the
+ * same field metadata behaving two ways on two surfaces. Naming the two keys
+ * this layer uses and passing the rest through is what keeps that from
+ * recurring; it is NOT an invitation to author new resolved-only option keys
+ * (the spec's schema is the authoring gate, and it is `.strict()`).
+ */
+export type ActionParamOption = {
+  label: string;
+  value: string;
+  [key: string]: unknown;
+};
+
 export interface ActionParamDef {
   name: string;
   label: string;
   type: string;
   required?: boolean;
-  options?: Array<{ label: string; value: string }>;
+  options?: ActionParamOption[];
   defaultValue?: unknown;
   helpText?: string;
   placeholder?: string;

--- a/packages/core/src/actions/__tests__/ActionParamDef.options.test.ts
+++ b/packages/core/src/actions/__tests__/ActionParamDef.options.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3559 — the resolved param's option vocabulary and the reader that
+ * consumes it are the same package's two halves, so pin that they agree.
+ *
+ * `ActionParamDef.options` used to be `Array<{ label, value }>`: a closed
+ * restatement of a field's option shape, one interface away from
+ * `resolveVisibleOptions()` in this very package, which reads a key that
+ * restatement did not list (`visibleWhen`, ADR-0058 / #2284). The resolver in
+ * `@object-ui/app-shell` rebuilt every field-inherited option to match the narrow
+ * type and the predicate stopped narrowing action dialogs. `ActionParamOption`
+ * now names the two keys the param layer itself uses and passes the rest through.
+ *
+ * Scope of this file, stated honestly: vitest does not typecheck, and this package
+ * excludes its own test files from `tsc` (TEST_DEBT in
+ * `scripts/check-type-check-coverage.mjs`), so nothing here can fail because a
+ * TYPE re-narrowed. The type half is pinned where it is actually compiled — in
+ * `@object-ui/app-shell`'s `utils/resolveActionParams.test.ts`, which
+ * `tsconfig.typetests.json` lists. What these cases hold is the behavioural
+ * agreement: an option list of the shape a resolved param carries is filtered by
+ * this package's own predicate reader, per option, on the keys it declares.
+ *
+ * The `as OptionLike[]` below is written out rather than left implicit, because it
+ * is the one visible cost of the catch-all route this widening took: extras are
+ * typed `unknown`, so `ActionParamOption` is not STATICALLY an `OptionLike` (whose
+ * `visibleWhen` is a `FieldRulePredicate`) even though every value it carries is.
+ * No runtime path pays it — the option widgets receive their metadata from
+ * `paramToField()` as `Record< string, any >` — and the alternative (enumerating
+ * `visibleWhen` here) would re-open the vocabulary question objectui#3559 settled
+ * once for both this type and objectui#3309. Recorded so the next reader sees a
+ * deliberate seam, not an oversight.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveVisibleOptions, resolveCascadingOptions, type OptionLike } from '../../evaluator/optionRules';
+import type { ActionParamDef } from '../ActionRunner';
+
+/** The param's options as core's typed option reader accepts them (see header). */
+const asOptions = (param: ActionParamDef): OptionLike[] => param.options as OptionLike[];
+
+/** A resolved `select` param as `resolveActionParams()` now emits it. */
+const tierParam: ActionParamDef = {
+  name: 'tier',
+  label: 'Tier',
+  type: 'select',
+  options: [
+    { label: 'Standard', value: 'standard', color: 'gray' },
+    {
+      label: 'Admin only',
+      value: 'admin_only',
+      visibleWhen: "'admin' in current_user.positions",
+      color: 'red',
+    },
+  ],
+};
+
+describe('ActionParamDef options — read by resolveVisibleOptions (objectui#3559)', () => {
+  it('filters a resolved param option by its visibleWhen', () => {
+    const offered = resolveVisibleOptions(asOptions(tierParam), {}, {
+      current_user: { positions: ['sales'] },
+    });
+    expect(offered.map((o) => o.value)).toEqual(['standard']);
+  });
+
+  it('offers it to a viewer the predicate admits', () => {
+    const offered = resolveVisibleOptions(asOptions(tierParam), {}, {
+      current_user: { positions: ['admin'] },
+    });
+    expect(offered.map((o) => o.value)).toEqual(['standard', 'admin_only']);
+  });
+
+  it('carries the non-predicate keys through the filter untouched', () => {
+    const offered = resolveVisibleOptions(asOptions(tierParam), {}, {
+      current_user: { positions: ['admin'] },
+    });
+    // Filtering selects entries, it never rebuilds them — the option a widget
+    // renders is the one the field declared, `color` and all.
+    expect(offered[1]).toEqual({
+      label: 'Admin only',
+      value: 'admin_only',
+      visibleWhen: "'admin' in current_user.positions",
+      color: 'red',
+    });
+  });
+
+  it('resolves the same list through the widgets\' entry point (dependsOn gating)', () => {
+    // `resolveCascadingOptions` is what `useCascadingOptions` wraps; a param
+    // option list flows through it unchanged when no `dependsOn` is declared.
+    const { options, gated, dependsOnFields } = resolveCascadingOptions(
+      asOptions(tierParam),
+      {},
+      undefined,
+      { current_user: { positions: ['sales'] } },
+    );
+    expect(gated).toBe(false);
+    expect(dependsOnFields).toEqual([]);
+    expect(options.map((o) => o.value)).toEqual(['standard']);
+  });
+
+  it('leaves an unpredicated param option list whole', () => {
+    const param: ActionParamDef = {
+      name: 'stage',
+      label: 'Stage',
+      type: 'select',
+      options: [
+        { label: 'Open', value: 'open' },
+        { label: 'Won', value: 'won' },
+      ],
+    };
+    expect(resolveVisibleOptions(asOptions(param), {}).map((o) => o.value)).toEqual(['open', 'won']);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3559

## 事实核对(前提复核于 `origin/main` @ `b1204af0a`)

正文的三处定位全部成立,仅行号有漂移,按内容锚定:

- `packages/app-shell/src/utils/resolveActionParams.ts` — `normaliseOptions` 在 `:228`,调用点在 `:330-331`(`param.options ?? normaliseOptions(field.options, …)`);
- `RawActionParam.options` 在同文件 `:50`(正文写 `:52`);
- `ActionParamDef.options` 在 `packages/core/src/actions/ActionRunner.ts:436`(与正文一致)。

另外一条正文没提、但修法必须一并动的:同文件 `RuntimeField.options`(`:180`)是**继承来源**的类型,同样写死成 `{ label, value } | string`。不放宽它,连"字段声明了 `visibleWhen`"这件事都在 TS 里写不出来(测试 fixture 会被 excess-property check 打回),运行时展开也在类型层丢光。

消费链逐段核实过,**只有 `normaliseOptions` 一处在剥键**:

| 环节 | 对 options 做什么 |
|---|---|
| `useConsoleActionRuntime.tsx:198` | `p.options.map((o) => ({ ...o, label: … }))` — 展开保留 |
| `ActionParamDialog.tsx:224` | `rawParam.options?.map((o) => ({ ...o, label: … }))` — 展开保留 |
| `paramToField.ts` | `options: param.options` — 直接透传 |
| `SelectField` → `useCascadingOptions` → `resolveCascadingOptions` → `resolveVisibleOptions` | **读 `visibleWhen` 并逐项过滤** |

## 改动

**运行时(一行)**:`normaliseOptions` 保留原条目,只做它真正的两件事 —— 裸字符串展开成 `{ label, value }`、经 `fieldOptionLabel` 翻译 label:

```
- return { label, value: raw.value };
+ return { ...raw, label, value: raw.value };
```

**类型(按分诊预裁的小路线)**:`@object-ui/core` 新增 `ActionParamOption` = `{ label: string; value: string; [key: string]: unknown }`,循 `BulkActionParam` 已有的 catch-all 惯用形;⛔ 未绑定、未改动 `SelectOptionMetadata`(`packages/types` 一字未动,#3309 照同一答案自行跟进)。`ActionParamDef.options`、`RawActionParam.options`、`RuntimeField.options`、`normaliseOptions` 的入参/返回一律说这门词汇,两个站点因此是**同一个**类型而不是两处一致的复述。

## 端到端验证(裁决 3:不止验 map)

`ActionParamDialog` 渲染 select param 的路径是 `field={paramToField(param)}` + `getLazyFieldWidget('select')` → `SelectField`。新增 `resolveActionParams.optionVisibleWhen.test.tsx` 就按这套线接:**字段元数据 → `resolveActionParams()` → `paramToField()` → 真的 `SelectField` 组件**,断言谓词收窄确实发生:

- 全部选项被角色谓词挡掉 → 控件给 `select-empty-tier` 空状态,**不再**渲染一个装着被挡选项的下拉;
- 逐项(不是整表)收窄:`standard` 留下(仍有 combobox),`admin_only` 不在可选集里,widget 的 cascade-clear 把预填值清掉;
- 谓词放行的观察者 → 值保留、列表照旧。

消费方**已经**会算 `visibleWhen`,所以这个修法是完整的一半加另一半:键送到 + 消费方读它。没有过度声称的部分。

### 一处如实测量(不是主张,预测被推翻后按实测记录)

对话框**不**传 `dependentValues`(param 值在它自己的 local state 里),所以 record 相关谓词看到的是 `SchemaRendererContext` 的 `formValues`/`data`,不是对话框自己在填的值。进去前的预测是"`record` 为 `{}` → `record.country == 'cn'` 为假 → 选项被藏";**实测相反**:`{}` 下该谓词**不可解**,按 `resolveVisibleOptions()` 既有的 fail-open 默认**保留**该选项(同一列表在 `{ country: 'us' }` 下照常过滤成 `[]`)。即残留缺口窄且默认安全 —— 对话框无法拿自己在途的 param 收窄继承来的列表,而不可解谓词是全给不是全藏。测量写进测试注释,另行报告,本 PR 不擅自设计它的语义。

## 反向验证(先定方向,再跑)

预测:去掉展开 → 新钉子里 **5 条**转红(unit 3 条 + widget 2 条),而"作者内联 options 逐字下沉"这条回归钉、裸字符串钉、fail-open 测量条**保持绿**。实跑完全一致:

```
× keeps a per-option visibleWhen the field declared
× still translates the label through fieldOptionLabel, keeping the other keys
× reaches resolveVisibleOptions through paramToField and narrows the offered set
× drops a role-gated option for a viewer who fails the predicate
× clears a pre-filled value the predicate hides (per-option, not whole-list)
 Tests  5 failed | 36 passed (41)
```

恢复后 41/41 绿。

## 测试与门禁

- `pnpm exec vitest run packages/core packages/app-shell --maxWorkers=2` → **363 文件 / 4122 通过,0 失败**;
- 消费面抽跑(components 的 action-param-dialog 两支、fields 的 `SelectField.cascade`、core 的 `optionRules`)→ 34/34 绿;
- `type-check`(core / app-shell / components,含 app-shell 的 `tsconfig.typetests.json`)→ 全过。类型钉子放在**真的会被编译**的那个文件里:`resolveActionParams.test.ts` 已在 typetests 名单内,两条 `@ts-expect-error` 钉住 `label`/`value` 仍是必填(未用的 suppression 会 TS2578 报错,所以这钉子是活的)。core 自己的测试被它的 `tsc` 排除(TEST_DEBT),所以 core 那支测试只声称行为一致,类型半件明写在文件头说明放在何处;
- `eslint` 触及文件 → 0 error;`check-control-bytes` → OK(3700 tracked);`check-changeset-no-major` → OK;
- changeset:`@object-ui/app-shell` / `@object-ui/core` 各 patch。

## 未越界

只动 issue 指定的两个文件面 + 两包测试 + 一个 changeset。`packages/types/`、`content/docs/releases/` 一字未动;`SelectOptionMetadata` 未碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_