### PR TITLE
fix(i18n): resolve `_views` translation keys by the bare view name only (#3502)

### DIFF
--- a/.changeset/view-translation-keys-bare-only-3502.md
+++ b/.changeset/view-translation-keys-bare-only-3502.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/i18n": patch
+---
+
+Resolve `_views` translation keys by the bare view name only — the prefixed full name is no longer a second candidate
+
+`useObjectLabel().viewLabel` / `viewDescription` / `viewEmptyState` build their key by stripping the object prefix off the runtime view id (`crm_opportunity.pipeline_kanban` → `objects.crm_opportunity._views.pipeline_kanban.<tail>`). Until now, if that bare key missed, the resolver **also** tried the prefixed full name — `objects.crm_opportunity._views.crm_opportunity.pipeline_kanban.<tail>` — so a bundle authored against the prefixed spelling resolved too.
+
+**Behavior change:** it no longer does. A `_views` entry keyed by the prefixed full name is not read at all; the label falls back to the metadata default, exactly as it would if no translation had been written. Bundles keyed by the bare view name — the only spelling the extractor emits and `os lint` accepts — are unaffected.
+
+This closes an asymmetry, not a feature. The server-side resolver reads the one bare key (objectstack#5165), so a prefixed-key bundle produced a **translated label in the Console and English everywhere else**: the REST boundary, mobile, plain HTTP and SDUI consumers do not run this second resolution pass. The half-success was harder to notice than a clean miss, and it fossilized a second de-facto spelling of a key the platform has now converged on: per the objectstack#5164 ruling (2026-08-06, option A), the canonical `_views` key is the runtime view identity's bare name, with the i18n extractor deriving it from the view composer (objectstack#6124) and `packages/lint` enforcing that single spelling (objectstack#6038). This is the third and last leg of that convergence.
+
+The object-name axis is untouched: a bundle written against the short object name (`objects.opportunity._views.…`) still resolves when the runtime presents the namespaced name (`crm__opportunity`).
+
+**If a label stopped translating after this upgrade,** its `_views` key is written with the object prefix. Drop the prefix — `_views.crm_opportunity.pipeline_kanban.label` becomes `_views.pipeline_kanban.label`. `os lint` names these for you: a prefixed key is reported as `translation-target-unknown`, because no view of the object declares it.

--- a/packages/i18n/src/__tests__/useObjectLabel-view.test.tsx
+++ b/packages/i18n/src/__tests__/useObjectLabel-view.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import React from 'react';
 import { I18nProvider, useObjectTranslation } from '../provider';
@@ -8,6 +8,16 @@ const wrapper = ({ children }: { children: React.ReactNode }) =>
   React.createElement(
     I18nProvider,
     { config: { defaultLanguage: 'en', detectBrowserLanguage: false } },
+    children,
+  );
+
+/** Same provider, with the dev missing-key warner explicitly on. */
+const warningWrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    I18nProvider,
+    {
+      config: { defaultLanguage: 'en', detectBrowserLanguage: false, warnMissingKeys: true },
+    },
     children,
   );
 
@@ -98,5 +108,205 @@ describe('useObjectLabel().viewLabel', () => {
         'Sales Pipeline',
       ),
     ).toBe('Localized pipeline');
+  });
+});
+
+/**
+ * objectstack#5164 ruling A (2026-08-06): the canonical `_views` translation key
+ * is the runtime view identity's BARE name. The extractor now derives it from the
+ * view composer (objectstack#6124) and `packages/lint` enforces that one spelling
+ * (objectstack#6038); this resolver used to additionally accept the prefixed full
+ * name (`_views.<objectName>.<viewName>`) as a second candidate, which made the
+ * Console show a translated label while the server-side resolver — which reads the
+ * one key only (objectstack#5165) — still served English to every consumer that
+ * does not re-resolve (REST, mobile, plain HTTP, SDUI).
+ *
+ * These pin BOTH directions of the narrowing: the bare key resolves, and the
+ * prefixed spelling falls through to the metadata default on every surface that
+ * goes through `viewSuffixes` (label / description / emptyState).
+ */
+describe('useObjectLabel() view keys — bare-key-only resolution (objectui#3502)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not resolve a view translation authored under the prefixed full name', () => {
+    const { result } = renderHook(
+      () => ({ labels: useObjectLabel(), i18n: useObjectTranslation().i18n }),
+      { wrapper },
+    );
+    result.current.i18n.addResourceBundle(
+      'en',
+      'translation',
+      {
+        crm: {
+          objects: {
+            crm_opportunity: {
+              _views: {
+                // The rejected spelling: the view name still carries its object
+                // prefix, so the bundle nests `crm_opportunity` under `_views`.
+                crm_opportunity: {
+                  pipeline_kanban: {
+                    label: 'Prefixed pipeline',
+                    description: 'Prefixed pipeline description',
+                    emptyState: {
+                      title: 'Prefixed empty title',
+                      message: 'Prefixed empty message.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      true,
+      true,
+    );
+
+    expect(
+      result.current.labels.viewLabel(
+        'crm_opportunity',
+        'crm_opportunity.pipeline_kanban',
+        'Sales Pipeline',
+      ),
+    ).toBe('Sales Pipeline');
+    expect(
+      result.current.labels.viewDescription(
+        'crm_opportunity',
+        'crm_opportunity.pipeline_kanban',
+        'Manage opportunities by stage',
+      ),
+    ).toBe('Manage opportunities by stage');
+    expect(
+      result.current.labels.viewEmptyState(
+        'crm_opportunity',
+        'crm_opportunity.pipeline_kanban',
+        { title: 'No opportunities', message: 'Create one to begin.' },
+      ),
+    ).toEqual({
+      title: 'No opportunities',
+      message: 'Create one to begin.',
+    });
+  });
+
+  it('resolves the bare key even when a prefixed sibling exists', () => {
+    const { result } = renderHook(
+      () => ({ labels: useObjectLabel(), i18n: useObjectTranslation().i18n }),
+      { wrapper },
+    );
+    result.current.i18n.addResourceBundle(
+      'en',
+      'translation',
+      {
+        crm: {
+          objects: {
+            crm_opportunity: {
+              _views: {
+                pipeline_kanban: { label: 'Bare pipeline' },
+                crm_opportunity: {
+                  pipeline_kanban: { label: 'Prefixed pipeline' },
+                },
+              },
+            },
+          },
+        },
+      },
+      true,
+      true,
+    );
+
+    expect(
+      result.current.labels.viewLabel(
+        'crm_opportunity',
+        'crm_opportunity.pipeline_kanban',
+        'Sales Pipeline',
+      ),
+    ).toBe('Bare pipeline');
+  });
+
+  it('keeps the object-name axis: a short-object-name bundle still resolves', () => {
+    const { result } = renderHook(
+      () => ({ labels: useObjectLabel(), i18n: useObjectTranslation().i18n }),
+      { wrapper },
+    );
+    // Only the view axis was narrowed. The object axis (namespaced name first,
+    // then the `__`-stripped base name) is a separate fallback and stays.
+    result.current.i18n.addResourceBundle(
+      'en',
+      'translation',
+      {
+        crm: {
+          objects: {
+            opportunity: {
+              _views: {
+                pipeline_kanban: { label: 'Localized pipeline' },
+              },
+            },
+          },
+        },
+      },
+      true,
+      true,
+    );
+
+    expect(
+      result.current.labels.viewLabel(
+        'crm__opportunity',
+        'crm__opportunity.pipeline_kanban',
+        'Sales Pipeline',
+      ),
+    ).toBe('Localized pipeline');
+    // A runtime id qualified with the short object name strips just as well.
+    expect(
+      result.current.labels.viewLabel(
+        'crm__opportunity',
+        'opportunity.pipeline_kanban',
+        'Sales Pipeline',
+      ),
+    ).toBe('Localized pipeline');
+  });
+
+  it('falls back visibly on screen, without adding dev-console noise', () => {
+    // "Loud" here means the on-screen label is the untranslated metadata default
+    // on EVERY consumer, not a Console-only success. The dev missing-key warner
+    // stays out of it by design: convention probes carry `I18N_PROBE_FLAG`
+    // (see `i18n.ts`) because they miss on every app that authored no view
+    // translations at all, so warning here would fire on the healthy path rather
+    // than the broken one. A `_views` key written under the rejected spelling is
+    // reported at authoring time by `os lint` (`translation-target-unknown`,
+    // objectstack#6038) — at the producer, per contract-first.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(
+      () => ({ labels: useObjectLabel(), i18n: useObjectTranslation().i18n }),
+      { wrapper: warningWrapper },
+    );
+    result.current.i18n.addResourceBundle(
+      'en',
+      'translation',
+      {
+        crm: {
+          objects: {
+            crm_opportunity: {
+              _views: {
+                crm_opportunity: { pipeline_kanban: { label: 'Prefixed pipeline' } },
+              },
+            },
+          },
+        },
+      },
+      true,
+      true,
+    );
+    warnSpy.mockClear();
+
+    expect(
+      result.current.labels.viewLabel(
+        'crm_opportunity',
+        'crm_opportunity.pipeline_kanban',
+        'Sales Pipeline',
+      ),
+    ).toBe('Sales Pipeline');
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/i18n/src/useObjectLabel.ts
+++ b/packages/i18n/src/useObjectLabel.ts
@@ -205,19 +205,36 @@ export function useObjectLabel() {
   /**
    * Build suffix candidates for a list-view scoped key.
    *
-   * The runtime uses qualified view ids (`<objectName>.<viewName>`) in URLs
-   * and metadata records, while translation bundles are keyed by the authored
-   * view name under `_views`. Resolve the unqualified name first so every
-   * surface can pass its canonical id without leaking the metadata fallback.
+   * The runtime uses qualified view ids (`<objectName>.<viewName>`) in URLs and
+   * metadata records, while translation bundles are keyed by the **bare** view
+   * name under `_views` — the runtime view identity's own name, stripped of the
+   * object prefix. That single spelling is canonical per the objectstack#5164
+   * ruling A (2026-08-06): the i18n extractor asks the view composer for the key
+   * (objectstack#6124) and `packages/lint` enforces exactly that spelling
+   * (objectstack#6038), so this resolver accepts exactly what those produce.
+   *
+   * Deliberately NOT a second candidate: the prefixed full name
+   * (`_views.<objectName>.<viewName>`). Accepting it made this client more
+   * lenient than the server-side resolver, which only ever reads the one key
+   * (objectstack#5165) — a bundle authored against the prefixed spelling showed
+   * translated labels in the Console while every consumer that does not run a
+   * second resolution pass (REST boundary, mobile, plain HTTP, SDUI) still got
+   * English. A prefixed key now simply misses, and the label falls back to the
+   * metadata default on every surface alike, so the authoring mistake is visible
+   * instead of half-hidden. It is caught at authoring time by `os lint`'s
+   * `translation-target-unknown`, not papered over here.
+   *
+   * The object-name candidates (`objects.<ns__obj>` then `objects.<obj>`) are a
+   * separate axis and stay: they let bundles written against short object names
+   * resolve when the runtime presents fully-qualified ones.
    */
   const viewSuffixes = (objectName: string, viewName: string, tail: string): string[] => {
     const objectNames = [objectName, stripNamespace(objectName)];
     const matchedPrefix = objectNames
       .map((name) => `${name}.`)
       .find((prefix) => viewName.startsWith(prefix));
-    const shortViewName = matchedPrefix ? viewName.slice(matchedPrefix.length) : viewName;
-    const viewNames = shortViewName === viewName ? [viewName] : [shortViewName, viewName];
-    return viewNames.flatMap((name) => objectSuffixes(objectName, `_views.${name}.${tail}`));
+    const bareViewName = matchedPrefix ? viewName.slice(matchedPrefix.length) : viewName;
+    return objectSuffixes(objectName, `_views.${bareViewName}.${tail}`);
   };
 
   return {
@@ -356,7 +373,10 @@ export function useObjectLabel() {
 
     /**
      * Resolve translated list-view label.
-     * Convention (per @objectstack/spec): `{ns}.objects.{objectName}._views.{viewName}.label`.
+     * Convention (per @objectstack/spec): `{ns}.objects.{objectName}._views.{viewName}.label`,
+     * where `{viewName}` is the **bare** view name — pass either the bare name or
+     * the qualified runtime id, the object prefix is stripped either way. A key
+     * that spells the prefix out does not resolve (see `viewSuffixes`).
      */
     viewLabel: (objectName: string, viewName: string, fallback: string) =>
       resolve(viewSuffixes(objectName, viewName, 'label'), fallback),


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3502

objectstack#5164 裁决 A(维护者 2026-08-06 批复)的**第 3 棒 / objectui 段**:`_views` 翻译键 canonical = 运行时视图身份的**裸键**,四面收敛。前两棒已落地 —— 提取器改为向组装器查询运行时身份键(objectstack#6124,`b3c1f3cd5`)、`packages/lint` `collectViewRecord` 收窄到单拼写(objectstack#6038,`7618ee814`)。本 PR 收掉最后一面:客户端二次解析。

## 改了什么

`packages/i18n/src/useObjectLabel.ts` 的 `viewSuffixes` 原本剥掉对象前缀得到裸键后,**若裸键落空还会再试带前缀的全名**作为第二候选:

- 第 1 候选 `objects.crm_opportunity._views.pipeline_kanban.label`(裸键,保留)
- 第 2 候选 `objects.crm_opportunity._views.crm_opportunity.pipeline_kanban.label`(带前缀全名,**已删除**)

删掉第 2 候选后,按带前缀键编写的译文块**完全不再被读取**,标签回落到 metadata 默认文案 —— 与「根本没写译文」表现一致。按裸键编写的(提取器唯一产出、`os lint` 唯一接受的拼写)不受影响。

**对象名那一轴不动**:`objects.{ns__obj}` 落空后仍退到 `objects.{obj}`,所以按短对象名写的译文包在运行时给出带命名空间对象名时照样命中。这是另一条正交的兜底,和视图名无关,已单独钉测试。

## 为什么是删而不是留

服务端解析只认那一个裸键(objectstack#5165,刻意为之)。客户端多接受一个拼写 ⇒ **两端宽容度不对称**:按带前缀键编写的包在 Console 里显示中文,而 REST 边界 / 移动端 / 纯 HTTP / SDUI 这些不做二次解析的消费方拿到的仍是英文。半成功比干净的落空更难被发现,还把一套第二方言事实上固化成了并行契约(违反 AGENTS #0.1 contract-first:宽容读取的正确修法在生产方)。

关于验收词「**响亮回退**」—— 需要如实说明它在本文件里落成什么:

- **响亮的部分**:回退是**全消费面一致可见**的(屏幕上就是未翻译的默认文案),不再是「只有 Console 对」。
- **不新增 warn 通道**:本文件的 convention 探测**刻意**带 `I18N_PROBE_FLAG`,被 `i18n.ts` 的 missing-key warner 跳过(见该文件 36-45 行的设计说明)。那个 hook 是在**键落空**时触发的,而「没写任何视图译文」恰恰是绝大多数 app 的健康状态 —— 让本路径去命中它,会在健康路径上刷警告,而不是在出错路径上。它也无法表达「键写了但拼写已被拒绝」这件事(那需要枚举 bundle)。
- **真正的响亮在生产方**:带前缀键在 `os lint` 里被 `translation-target-unknown` 点名(第 2 棒 objectstack#6038 收窄后,该对象没有任何视图声明这个名字)。这符合裁 A 的「声明即强制」本义 —— 消费端不做第二份弱化副本。

如维护者希望消费端另加一条一次性 dev 警告(仅当带前缀键**确实存在于 bundle** 时才响,零噪音),可以再开一单;本 PR 不擅自新增警告通道。

## 测试

`packages/i18n/src/__tests__/useObjectLabel-view.test.tsx` 新增 4 例(原有 2 例保留、未改):

1. 带前缀键**不解析** —— `label` / `description` / `emptyState` 三个走 `viewSuffixes` 的出口全部回落到默认文案(**反向验证的锚点**)。
2. 裸键与带前缀键**同时存在**时命中裸键(钉候选顺序未被反向改动)。
3. 对象名那一轴仍在:短对象名译文包 + 带命名空间的运行时对象名 → 命中;运行时 id 用短对象名限定也照样剥掉。
4. 回退在 dev 控制台**不产生噪音**(`warnMissingKeys: true` 下 `console.warn` 零调用),把上面那条 probe 约定钉住,防止后人用「取消 probe 标记」来实现响亮。

反向验证(**先声明预期方向再跑**):把删掉的第二候选加回去 → 预期 2 红 4 绿,红的是两条 prefixed-only 钉子(裸键在候选链首位,所以另外 4 例不该动)。实跑一致:

```
× does not resolve a view translation authored under the prefixed full name
    AssertionError: expected 'Prefixed pipeline' to be 'Sales Pipeline'
× falls back visibly on screen, without adding dev-console noise
 Tests  2 failed | 4 passed (6)
```

恢复改动后:

```
pnpm exec vitest run packages/i18n --maxWorkers=2
 Test Files  26 passed (26)      Tests  361 passed (361)      # 改前基线 357
pnpm exec vitest run packages/layout --maxWorkers=2
 Test Files  6 passed (6)        Tests  92 passed (92)        # 消费方 NavigationRenderer
pnpm exec tsc --noEmit -p packages/i18n/tsconfig.json         # exit 0
pnpm --filter @object-ui/i18n lint                            # 0 errors(32 warnings 全部为存量)
node scripts/check-i18n-call-site-keys.mjs                    # 门禁绿,3486 call sites 全解析
node scripts/check-i18n-en-drift.mjs                          # 0 en value changed
node scripts/check-control-bytes.mjs                          # OK(3699 files)
node scripts/check-changeset-fixed.mjs / -no-major.mjs         # 绿
```

`all-locales-key-parity` 在上面 26 个文件内一并跑绿。另外手工扫了改动文件的控制字节(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`,零匹配)。

## 存量键排查(派发说明第 3 条)

全仓 `git grep _views`(排除 CHANGELOG):**没有任何仓内译文包/fixture 使用带前缀拼写** —— `packages/i18n` 两个测试与 `spec-translations` 都是裸键,`app-shell` / `layout` 的命中全是 `list_views` 元数据或注释。第 1 棒已把 showcase / app-todo / app-crm 的存量迁完(在 objectstack 仓),因此本 PR 无 fixture 改名,消费方测试(`viewLabel` 全为 mock)也无一依赖被删的那条候选。

## 影响面

用户可见行为变更,已带 `.changeset`(`@object-ui/i18n` patch,含 FROM→TO 迁移指引:去掉键里的对象前缀)。按仓库约定不标 `major`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_