### PR TITLE
fix(types): open the BulkActionParam.options entry the renderer already forwards (#3309)

### DIFF
--- a/.changeset/bulk-action-param-options-open-3309.md
+++ b/.changeset/bulk-action-param-options-open-3309.md
@@ -1,0 +1,25 @@
+---
+"@object-ui/types": patch
+---
+
+`BulkActionParam.options` entries now accept the widget config the renderer already forwards
+
+The entry type was a closed `{ label, value }`, and it was the only layer in the
+path that said so. `bulkParamToField` spreads each entry into the metadata it
+hands the field widget (`{ ...o, value: String(o.value) }`), so extra keys
+survive; the destination shape `SelectOptionMetadata` declares `color` / `icon` /
+`disabled` / `visibleWhen` and `@object-ui/fields` genuinely reads them; and
+`@objectstack/spec`'s `BulkActionParamSchema` makes the same entry
+`.passthrough()`, so the server accepts them. Writing
+`options: [{ label: 'Purple', value: 'purple', color: '#8B5CF6' }]` therefore
+produced a TypeScript excess-property error on a configuration the renderer
+honours — the type rejected working metadata, which is the most expensive
+direction for an author (an AI author especially) that trusts it absolutely.
+
+The entry now carries a `[key: string]: unknown` catch-all, matching the one its
+parent `BulkActionParam` has had all along and the idiom `ActionParamOption`
+settled one interface over. `label` and `value` stay required and keep their
+exact types: open is not optional, and the catch-all is not an invitation to
+author new option keys — the authoring gate remains the spec's strict
+`SelectOptionSchema`. No runtime behaviour changes; the widening is
+backward-compatible for consumers.

--- a/packages/types/src/__tests__/bulk-action-param-options.test.ts
+++ b/packages/types/src/__tests__/bulk-action-param-options.test.ts
@@ -1,0 +1,154 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3309 — `BulkActionParam.options`' ENTRY is open, and the three layers
+ * that touch it agree.
+ *
+ * The entry used to be a closed `{ label, value }`. Nothing else in the path
+ * agreed with it:
+ *
+ *  - the runtime spreads every entry into the metadata it hands the widget
+ *    (`bulkParamToField`: `{ ...o, value: String(o.value) }`), so extra keys
+ *    survive;
+ *  - the destination shape, {@link SelectOptionMetadata}, declares
+ *    `color` / `icon` / `disabled` / `visibleWhen`, and `@object-ui/fields`
+ *    genuinely reads them (`option?.color`);
+ *  - `@objectstack/spec`'s `BulkActionParamSchema` makes the same entry
+ *    `.passthrough()` (objectstack#4001), so the server accepts them;
+ *  - the parent interface `BulkActionParam` had a `[key: string]: unknown`
+ *    catch-all one level up all along.
+ *
+ * So the type was the only layer rejecting `options: [{ label, value, color }]`
+ * — a configuration the renderer honours. Not a runtime bug; a machine-readable
+ * surface that lied, which is the worst kind for an AI author that trusts it.
+ * The fix follows the idiom objectui#3559 settled one interface over (core's
+ * `ActionParamOption`): name the two keys this layer reads, pass the rest through.
+ *
+ * These pins really do run: `packages/types/tsconfig.test.json` compiles every
+ * test file in this package (#3009), so the `@ts-expect-error` and `Assert<…>`
+ * lines below are `tsc` errors when violated — unlike the same pins in
+ * `@object-ui/core`, whose tests are excluded from its `tsc`.
+ *
+ * Reverse verification (predicted, then run — see the PR): reverting the index
+ * signature turns the two compile-time pins below red — the authored entry with
+ * `color`/`visibleWhen` becomes an excess-property error, and
+ * `BulkParamOption['color']` stops resolving — while the `@ts-expect-error`
+ * required-key pins are unaffected in either direction (they are about the
+ * DECLARED pair, which this change does not touch).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BulkActionParamSchema as SpecBulkActionParamSchema } from '@objectstack/spec/ui';
+import type { BulkActionParam } from '../objectql';
+import type { SelectOptionMetadata } from '../field-types';
+
+/** One entry of the option list, exactly as the type declares it. */
+type BulkParamOption = NonNullable<BulkActionParam['options']>[number];
+
+/**
+ * The working configuration the closed type used to reject: the two declared
+ * keys plus the widget config the option renderers read.
+ */
+const authoredOption: BulkParamOption = {
+  label: 'Purple',
+  value: 'purple',
+  color: '#8B5CF6',
+  visibleWhen: "'admin' in current_user.positions",
+};
+
+/** …and the same thing at the surface an author actually writes. */
+const authoredParam: BulkActionParam = {
+  name: 'tier',
+  type: 'select',
+  options: [
+    { label: 'Standard', value: 'standard' },
+    { label: 'Admin only', value: 'admin_only', color: 'red', disabled: false, icon: 'shield' },
+  ],
+};
+
+/**
+ * What `bulkParamToField` (plugin-grid) builds from an entry: the spread, plus
+ * the `String(value)` the Radix selects need. Restated here rather than imported
+ * — this package takes no workspace dependency, and plugin-grid depends on it.
+ */
+const toFieldOption = (o: BulkParamOption) => ({ ...o, value: String(o.value) });
+
+describe('BulkActionParam.options entry is open (objectui#3309)', () => {
+  it('accepts the widget-config keys the option renderers read', () => {
+    // Compile-time: the assignments above are the pin. Runtime: the keys are
+    // present, not swallowed by the type-level widening.
+    expect(authoredOption.color).toBe('#8B5CF6');
+    expect(authoredOption.visibleWhen).toBe("'admin' in current_user.positions");
+    expect(authoredParam.options?.[1]).toEqual({
+      label: 'Admin only',
+      value: 'admin_only',
+      color: 'red',
+      disabled: false,
+      icon: 'shield',
+    });
+  });
+
+  it('keeps `label` and `value` REQUIRED — open is not optional', () => {
+    // @ts-expect-error `label` is not optional; the catch-all widens the entry,
+    // it does not soften the two keys this layer itself reads.
+    const noLabel: BulkParamOption = { value: 'purple', color: '#8B5CF6' };
+    // @ts-expect-error `value` is not optional, same reason.
+    const noValue: BulkParamOption = { label: 'Purple', color: '#8B5CF6' };
+    expect([noLabel, noValue]).toHaveLength(2);
+  });
+
+  it('pins the catch-all itself, and the declared pair it must not have loosened', () => {
+    // An undeclared key resolves through the index signature as `unknown`.
+    // Without the index signature this is a `tsc` error, not a `false` — which
+    // is exactly the reverse-verification signal.
+    type _CatchAll = Assert<Equal<BulkParamOption['color'], unknown>>;
+    // The two declared keys keep their exact types and their required-ness.
+    type _DeclaredPair = Assert<
+      Equal<Pick<BulkParamOption, 'label' | 'value'>, { label: string; value: string | number | boolean }>
+    >;
+    expect(true).toBe(true);
+  });
+
+  it('stays structurally compatible with what a SelectOptionMetadata consumer accepts', () => {
+    // The renderer's own projection of the entry lands in the destination shape
+    // without a cast — the three layers now describe one thing. (`value` is
+    // where they differ by design: this entry admits number/boolean for form
+    // binding, and the projection is what closes that gap.)
+    const consumed: SelectOptionMetadata = toFieldOption(authoredOption);
+    expect(consumed.label).toBe('Purple');
+    expect(consumed.value).toBe('purple');
+    // The key `@object-ui/fields` reads survives the whole trip.
+    expect(consumed.color).toBe('#8B5CF6');
+
+    // A number-valued entry is what the projection stringifies (#2204 forms
+    // bind numbers; the widgets compare option values as strings).
+    const numeric: BulkParamOption = { label: 'Ten', value: 10, color: 'gray' };
+    const projected: SelectOptionMetadata = toFieldOption(numeric);
+    expect(projected.value).toBe('10');
+  });
+
+  it('agrees with the spec schema that made the same entry passthrough (objectstack#4001)', () => {
+    // The precondition for this widening, asserted rather than assumed: if the
+    // spec ever re-closes the entry, this fails and names the layer to revisit.
+    const res = SpecBulkActionParamSchema.safeParse(authoredParam);
+    expect(res.success).toBe(true);
+    const parsed = res.success ? (res.data.options as SelectOptionMetadata[]) : [];
+    expect(parsed[1]?.color).toBe('red');
+    expect(parsed[1]?.icon).toBe('shield');
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pin helpers. A violation is a `tsc` error, not a test failure. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -284,8 +284,34 @@ export interface BulkActionParam {
   required?: boolean;
   /** Default value applied when the dialog opens. */
   default?: unknown;
-  /** Static options for select-style fields. */
-  options?: Array<{ label: string; value: string | number | boolean }>;
+  /**
+   * Static options for select-style fields.
+   *
+   * The ENTRY is open for the same reason this interface is (see the catch-all
+   * at the bottom): `bulkParamToField` spreads each entry into the field
+   * metadata it hands the widget (`{ ...o, value: String(o.value) }`), so every
+   * extra key survives, and the option widgets read `color` / `icon` /
+   * `disabled` / `visibleWhen` beyond the declared pair (`SelectOptionMetadata`
+   * in `./field-types` declares them; `@object-ui/fields` reads them). While
+   * this entry was closed, the type was the ONLY layer rejecting a configuration
+   * the renderer honours — `@objectstack/spec`'s `BulkActionParamSchema` makes
+   * the same entry `.passthrough()` (objectstack#4001) — and an author (an AI
+   * author especially) trusts the type absolutely (objectui#3309).
+   *
+   * Structurally identical to `@object-ui/core`'s `ActionParamOption`
+   * (objectui#3559), deliberately restated inline rather than imported: this
+   * package is the protocol layer and takes no workspace dependency.
+   *
+   * Naming the two keys this layer itself uses and passing the rest through is
+   * NOT an invitation to author new option keys — the authoring gate is the
+   * spec's `SelectOptionSchema`, and it is strict.
+   */
+  options?: Array<{
+    label: string;
+    value: string | number | boolean;
+    /** Extra option config forwarded to the field widget as-is (see above). */
+    [key: string]: unknown;
+  }>;
   /** For lookup widgets — the related object name (e.g. 'user'). */
   object?: string;
   /**


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3309

## 问题

`BulkActionParam.options` 的 **entry** 是封闭的 `{ label, value }`,而这条路径上其余每一层都不同意它:

| 层 | 位置 | 现状 |
|---|---|---|
| 类型(本 PR 修改) | `packages/types/src/objectql.ts` | entry 封闭,无索引签名 |
| 运行期 | `packages/plugin-grid/src/components/bulkParamToField.ts` | `options?.map(o => ({ ...o, value: String(o.value) }))` —— 整体 spread,额外键全部存活 |
| 目的地 | `packages/types/src/field-types.ts` `SelectOptionMetadata` | 声明 `color` / `icon` / `disabled` / `visibleWhen` |
| 消费 | `packages/fields/src/index.tsx` | `option?.color` 两处命中,这些键真被读 |
| 规格 | `@objectstack/spec` `BulkActionParamSchema` | 同一个 entry 已是 `.passthrough()`(objectstack#4001,裁决 A) |
| 父级 | 同文件 `BulkActionParam` 本身 | 一直有 `[key: string]: unknown` 兜底(带 catch-all 注释) |

于是作者写 `options: [{ label, value, color: '#8B5CF6' }]` 会拿到一个 excess-property 编译错误,**而渲染器其实会 honour 它**。今天不是运行期 bug —— 但类型是唯一在拒绝一份能正常工作的配置的那一层,这正是 machine-readable surface 说谎的形状,对绝对信任类型的(AI)元数据作者杀伤最大。

## 改动

给 entry 补 `[key: string]: unknown`,注释沿用父级 catch-all 的写法。惯用形不是本 PR 发明的:#3559(PR #3764,已合 main)在一个接口之外走的正是同一条 catch-all 路线(core 导出 `ActionParamOption`),本单照同答案执行。

- ⛔ **没有**动 `SelectOptionMetadata`,**没有**把 `objectql.ts` 绑到 `field-types.ts`。
- ⛔ **没有**改成引用 core 的 `ActionParamOption`,尽管两者结构完全一致。`@object-ui/types` 是协议层,按 AGENTS.md §3 拓扑「Zero deps」,不能吃 `@object-ui/core` 的依赖(方向也反了 —— core 依赖 types)。因此是**结构等价的 inline entry + 一条交叉引用注释**,注释里点名 `ActionParamOption` 与 objectui#3559,让下一个读者看到的是刻意的并置而不是重复。
- `label` / `value` 保持**必填**且类型不变:open 不等于 optional。注释里也写清了兜底不是新增选项键的邀请函 —— authoring gate 仍是 spec 严格的 `SelectOptionSchema`。

用户可见(对 TS 作者而言),已带 `@object-ui/types` 的 patch changeset。

## 前置事实(分诊要求核验,已实读)

objectstack#4001 的 `.passthrough()` **确在 objectstack `origin/main`**,不是只在 PR 里:`packages/spec/src/ui/bulk-action.zod.ts` 的 `options` 为 `z.array(z.object({ label, value }).passthrough())`,describe 文案明写「the renderer forwards unknown option keys to the field widget, which reads `color` / `icon` / `disabled` / `visibleWhen` beyond the declared pair」。本仓 `node_modules` 里已安装的 `@objectstack/spec@17.0.0-rc.5` 运行期实测也放行并保留了 `color` / `visibleWhen`(不是 stale install)。

## 钉子(`packages/types/src/__tests__/bulk-action-param-options.test.ts`)

这些钉子**真的会跑**:`packages/types/tsconfig.test.json` 编译本包每一个测试文件(#3009),所以 `@ts-expect-error` 与 `Assert< … >` 违反时是 `tsc` 错误 —— 与 `@object-ui/core` 把自己测试排除在 `tsc` 之外的情况不同(PR #3764 的同类钉子在头注释里如实记录了那一点)。

1. 带 `color` / `visibleWhen` / `icon` / `disabled` 的 entry 通过编译(能工作的配置现在写得出来);
2. `label` / `value` 仍必填 —— 两条必须命中的 `@ts-expect-error`(与 #3764 同款);
3. 索引签名本身:`BulkParamOption['color']` 解析为 `unknown`;声明对 `Pick< …, 'label' | 'value' >` 未被放松;
4. **结构兼容**:把 entry 经渲染器自己的投影(`{ ...o, value: String(o.value) }`)后赋给 `SelectOptionMetadata`,**无需 cast** 即通过 —— `objectql.ts` 自身不 import `field-types.ts`,只有测试文件同时 import 两者;
5. spec 侧 `.passthrough()` 这个前置事实被**断言**而非假定:spec 若哪天回封,这条会失败并指名要复查的层。

## 反向验证(先写预测,再跑)

预测:撤掉索引签名 → 第 1 条与第 3 条转红(excess-property / 属性不存在),第 2 条的两条 `@ts-expect-error` **不受影响**(它们钉的是本次不动的声明对)。

实测 `npx tsc -p packages/types/tsconfig.test.json`(已撤销索引签名):

```
bulk-action-param-options.test.ts(61,3):  error TS2353: Object literal may only specify known properties, and 'color' does not exist in type '{ label: string; value: string | number | boolean; }'.
bulk-action-param-options.test.ts(71,49): error TS2353: ... 'color' does not exist ...
bulk-action-param-options.test.ts(86,27): error TS2339: Property 'color' does not exist on type '{ label: string; value: string | number | boolean; }'.
bulk-action-param-options.test.ts(87,27): error TS2339: Property 'visibleWhen' does not exist ...
bulk-action-param-options.test.ts(110,51): error TS2339: Property 'color' does not exist ...
bulk-action-param-options.test.ts(131,65): error TS2353: ... 'color' does not exist ...
```

方向与预测一致。两处补充说明,如实记录:

- 86 / 87 行是运行期断言读 `authoredOption.color` / `.visibleWhen`,同因转红 —— 预测里没单列,但同向,不构成意外。
- **两条 `@ts-expect-error` 在两个方向都没报错**:恢复索引签名后 `tsc` 全绿,这本身就证明它们**命中**了(未命中的 `@ts-expect-error` 会以 TS2578 报错);撤销后也未出现在错误清单里。它们对本次改动确实免疫,与预测一致。

## 验证

- `pnpm --filter @object-ui/types type-check`(含 `tsconfig.test.json`)—— 绿。
- `turbo run type-check --filter @object-ui/plugin-grid --filter @object-ui/fields --filter @object-ui/app-shell --concurrency=2` —— 31 tasks successful(含整条 build 闭包)。加宽是向后兼容的,亦无 `exactOptionalPropertyTypes` 之类意外(仓库根 tsconfig 未开)。
- `vitest run --maxWorkers=2 packages/types/src/__tests__ packages/plugin-grid/…` —— 34 files / 451 tests passed。
- 消费半径清扫:全仓无任何 fixture 钉着**封闭**的 bulk options 形状(app-shell `resolveActionParams.test.ts:508/510` 是 #3764 的 `ActionParamOption` 必填钉,同族、不受影响,且在上面的 app-shell type-check 里一并绿)。
- 门禁:`check-control-bytes`(OK)+ 手工 `grep -naP` 扫本次三个文件(clean);`check-changeset-presence` / `check-changeset-no-major` / `check-changeset-fixed` 全绿;`eslint` 改动文件 0 errors(两条 `_CatchAll` / `_DeclaredPair` unused 警告与 `packages/auth/src/__tests__/auth-spec-parity.test.ts` 的既有惯用形一致,该文件同类警告 23 条)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_