### PR TITLE
fix(data-objectstack): read view overrides from the type='view' namespace they are written to (#3774)

### DIFF
--- a/.changeset/view-overrides-readback.md
+++ b/.changeset/view-overrides-readback.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/data-objectstack": patch
+"@object-ui/app-shell": patch
+"@object-ui/types": patch
+---
+
+Fix saved list-view preferences never reading back (density, column widths, sort, hidden columns, inline edit)
+
+`listViewOverrides` in the ObjectStack adapter enumerated `GET /api/v1/meta/{objectName}` — putting the object name in the metadata **type** slot — while `updateViewConfig` persists under `type='view'`. The two key spaces are disjoint, so the batch map came back empty for every object and every personalization a user saved on a list view was written to the server but never read back, showing up as "the setting didn't save".
+
+The read now enumerates `type='view'` once and narrows to the object client-side, through the same accessor `listViews()` uses over the same rows — the metadata index is name-only, so there is no server-side `?object=` filter to push it into.
+
+Second half: the batch read no longer swallows its own failures into an empty map. An empty map is an authoritative "this object has no overrides" and callers may still trust it and skip the per-view reads (the batch optimization is intact), but a transport failure now rejects, so the per-view `getView` fallback it was silently disabling becomes reachable again. `DataSource.listViewOverrides` documents both terms so other adapters implement the same contract.

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -293,8 +293,16 @@ export function InterfaceListPage({ page, className, onConfigChange, reserveEdit
         const ds: any = dataSource;
         let full: any = null;
         if (typeof ds?.listViewOverrides === 'function') {
-          const all = await ds.listViewOverrides(cfg.source);
-          full = all?.[resolvedViewKey] ?? null;
+          // Scoped catch: the batch enumeration REJECTS on a transport failure
+          // rather than answering an authoritative-looking `{}` (objectui#3774
+          // / the `DataSource.listViewOverrides` contract). That failure must
+          // not skip the per-view `getView` below — it is precisely the case
+          // the fallback exists for. Without this the outer catch would abort
+          // the whole hydration and the view would stay hollow.
+          try {
+            const all = await ds.listViewOverrides(cfg.source);
+            full = all?.[resolvedViewKey] ?? null;
+          } catch { /* fall through to the per-view read */ }
         }
         if (!hasColumns(full) && typeof ds?.getView === 'function') {
           full = await ds.getView(cfg.source, resolvedViewKey);

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -156,6 +156,67 @@ export function defaultListColumnsFromObject(
     return [];
 }
 
+/**
+ * Read the persisted per-view overrides (density, column widths, sort, hidden
+ * columns, inlineEdit …) for `ids`, preferring the adapter's one-request batch
+ * enumeration and falling back to a per-view `getView`.
+ *
+ * Extracted from the effect below so the three-way branch is pinnable on its
+ * own (objectui#3774) — the file's existing precedent for this is
+ * {@link defaultListColumnsFromObject}.
+ *
+ * The batch/fallback choice hangs entirely on how `listViewOverrides` ANSWERS,
+ * so the two are spelled out:
+ *
+ * - RESOLVES (including to an empty map) → authoritative. The adapter looked
+ *   and reports what exists; an object whose views were never customized
+ *   legitimately has no overrides, and we take that answer and skip N GETs.
+ *   That is the whole point of the batch call — do not "helpfully" re-probe
+ *   per view on an empty map, that reinstates the 404 flurry it removes.
+ * - REJECTS → the adapter could not tell, which is NOT the same fact as
+ *   "nothing is there". Fall through to the per-view reads.
+ *
+ * An adapter that swallows its own failures into `{}` collapses those two into
+ * the authoritative branch and makes the fallback below unreachable code —
+ * that was objectui#3774's second half, fixed in `@object-ui/data-objectstack`.
+ */
+export async function loadViewOverrides(
+    dataSource: any,
+    objectName: string,
+    ids: string[],
+): Promise<Record<string, any>> {
+    if (typeof dataSource?.listViewOverrides === 'function') {
+        try {
+            const all = await dataSource.listViewOverrides(objectName);
+            if (all && typeof all === 'object') {
+                const map: Record<string, any> = {};
+                for (const id of ids) {
+                    if (all[id]) map[id] = all[id];
+                }
+                return map;
+            }
+        } catch {
+            // fall through to per-view fetch
+        }
+    }
+    if (typeof dataSource?.getView !== 'function') return {};
+    const entries = await Promise.all(
+        ids.map(async (id) => {
+            try {
+                const v = await dataSource.getView(objectName, id);
+                return [id, v] as const;
+            } catch {
+                return [id, null] as const;
+            }
+        })
+    );
+    const map: Record<string, any> = {};
+    for (const [id, v] of entries) {
+        if (v && typeof v === 'object') map[id] = v;
+    }
+    return map;
+}
+
 export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: any) {
     const { objectName } = useParams();
     const { t } = useObjectTranslation();
@@ -543,11 +604,9 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     // `dataSource.updateViewConfig` and read back here so toggle preferences
     // survive a hard reload. Keyed by viewId → partial view config to merge.
     //
-    // Use the batch listViewOverrides() when available — fires one HTTP
-    // GET per object instead of N (one per defined view), avoiding a flurry
-    // of 404s for objects whose views have never been customized. Falls
-    // back to per-view getView() for adapters that don't support the batch
-    // method.
+    // Reading strategy (batch first, per-view fallback) lives in the exported
+    // `loadViewOverrides` above so it can be pinned directly — see its doc for
+    // why an empty batch result is authoritative but a rejected one is not.
     const [viewOverrides, setViewOverrides] = useState<Record<string, any>>({});
     useEffect(() => {
         let cancelled = false;
@@ -567,40 +626,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
             return;
         }
 
-        const loadBatch = async (): Promise<Record<string, any>> => {
-            if (typeof (dataSource as any).listViewOverrides === 'function') {
-                try {
-                    const all = await (dataSource as any).listViewOverrides(objectName);
-                    if (all && typeof all === 'object') {
-                        const map: Record<string, any> = {};
-                        for (const id of ids) {
-                            if (all[id]) map[id] = all[id];
-                        }
-                        return map;
-                    }
-                } catch {
-                    // fall through to per-view fetch
-                }
-            }
-            if (typeof dataSource.getView !== 'function') return {};
-            const entries = await Promise.all(
-                ids.map(async (id) => {
-                    try {
-                        const v = await dataSource.getView!(objectName, id);
-                        return [id, v] as const;
-                    } catch {
-                        return [id, null] as const;
-                    }
-                })
-            );
-            const map: Record<string, any> = {};
-            for (const [id, v] of entries) {
-                if (v && typeof v === 'object') map[id] = v;
-            }
-            return map;
-        };
-
-        loadBatch().then((map) => {
+        loadViewOverrides(dataSource, objectName, ids).then((map) => {
             if (!cancelled) setViewOverrides(map);
         });
         return () => { cancelled = true; };

--- a/packages/app-shell/src/views/ObjectView.viewOverrides.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.viewOverrides.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3774, second half — the batch read must not answer "I don't know"
+ * with a value that looks authoritative.
+ *
+ * `loadViewOverrides` prefers the adapter's one-request `listViewOverrides`
+ * and falls back to a per-view `getView`. Which branch runs depends entirely
+ * on how the batch call ANSWERS, and the two answers below are different facts:
+ *
+ *   resolves (even to `{}`)  → authoritative "this is what exists" → take it,
+ *                              skip N GETs. That IS the batch optimization.
+ *   rejects                  → "could not tell" → fall through to per-view.
+ *
+ * `@object-ui/data-objectstack` used to `catch {}` its own failures into `{}`,
+ * collapsing the second case into the first. The fallback below was therefore
+ * unreachable code on that adapter — which is why the wrong-namespace read
+ * (fixed in the same PR) surfaced as a silent "settings didn't save" instead of
+ * an error the fallback could recover from.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, both observed:
+ *   • restore the adapter's swallow (`catch { return {} }` in
+ *     `listViewOverrides`) → the adapter suite's "a FAILING enumeration
+ *     rejects" pin goes RED, and the fall-through case here stays green while
+ *     being unreachable in production — which is exactly why the adapter-side
+ *     pin has to exist and this file alone is not enough.
+ *   • re-inline an unconditional `return map` (dropping the `catch`) here →
+ *     'falls through to per-view getView when the batch read REJECTS' goes RED.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { loadViewOverrides } from './ObjectView';
+
+const IDS = ['crm_lead.all', 'crm_lead.pipeline'];
+
+const OVERRIDE = { name: 'crm_lead.all', object: 'crm_lead', density: 'compact' };
+
+describe('loadViewOverrides — batch first (#3774)', () => {
+  it('uses the batch result and skips the per-view reads entirely', async () => {
+    const getView = vi.fn(async () => ({ never: true }));
+    const dataSource = {
+      listViewOverrides: vi.fn(async () => ({ 'crm_lead.all': OVERRIDE })),
+      getView,
+    };
+
+    const map = await loadViewOverrides(dataSource, 'crm_lead', IDS);
+
+    expect(map).toEqual({ 'crm_lead.all': OVERRIDE });
+    expect(dataSource.listViewOverrides).toHaveBeenCalledWith('crm_lead');
+    expect(getView).not.toHaveBeenCalled();
+  });
+
+  it('an EMPTY successful batch is authoritative — it still returns early', async () => {
+    const getView = vi.fn(async () => ({ density: 'comfortable' }));
+    const dataSource = { listViewOverrides: vi.fn(async () => ({})), getView };
+
+    const map = await loadViewOverrides(dataSource, 'crm_lead', IDS);
+
+    // "No overrides exist" is a real answer. Re-probing per view here would
+    // reinstate the 404 flurry the batch call exists to remove.
+    expect(map).toEqual({});
+    expect(getView).not.toHaveBeenCalled();
+  });
+
+  it('keeps only the ids the caller asked about', async () => {
+    const dataSource = {
+      listViewOverrides: vi.fn(async () => ({
+        'crm_lead.all': OVERRIDE,
+        'crm_lead.retired': { name: 'crm_lead.retired' },
+      })),
+      getView: vi.fn(),
+    };
+
+    expect(Object.keys(await loadViewOverrides(dataSource, 'crm_lead', IDS))).toEqual(['crm_lead.all']);
+  });
+});
+
+describe('loadViewOverrides — the fallback must stay reachable (#3774)', () => {
+  it('falls through to per-view getView when the batch read REJECTS', async () => {
+    const dataSource = {
+      listViewOverrides: vi.fn(async () => { throw new Error('503 metadata store unavailable'); }),
+      getView: vi.fn(async (_o: string, id: string) =>
+        id === 'crm_lead.all' ? OVERRIDE : null),
+    };
+
+    const map = await loadViewOverrides(dataSource, 'crm_lead', IDS);
+
+    // The point of the whole issue: a failed batch read recovers, it does not
+    // silently render as "the user never customized anything".
+    expect(map).toEqual({ 'crm_lead.all': OVERRIDE });
+    expect(dataSource.getView).toHaveBeenCalledTimes(IDS.length);
+  });
+
+  it('falls through when the batch read resolves to a non-object', async () => {
+    const dataSource = {
+      listViewOverrides: vi.fn(async () => null),
+      getView: vi.fn(async () => OVERRIDE),
+    };
+
+    expect(await loadViewOverrides(dataSource, 'crm_lead', IDS)).toEqual({
+      'crm_lead.all': OVERRIDE,
+      'crm_lead.pipeline': OVERRIDE,
+    });
+  });
+
+  it('survives a per-view read failing on its own', async () => {
+    const dataSource = {
+      getView: vi.fn(async (_o: string, id: string) => {
+        if (id === 'crm_lead.pipeline') throw new Error('404');
+        return OVERRIDE;
+      }),
+    };
+
+    expect(await loadViewOverrides(dataSource, 'crm_lead', IDS)).toEqual({ 'crm_lead.all': OVERRIDE });
+  });
+});
+
+describe('loadViewOverrides — adapters without the batch method (#3774)', () => {
+  it('an adapter exposing only getView is unaffected', async () => {
+    const dataSource = { getView: vi.fn(async () => OVERRIDE) };
+
+    expect(await loadViewOverrides(dataSource, 'crm_lead', IDS)).toEqual({
+      'crm_lead.all': OVERRIDE,
+      'crm_lead.pipeline': OVERRIDE,
+    });
+    expect(dataSource.getView).toHaveBeenCalledTimes(IDS.length);
+  });
+
+  it('an adapter with neither method yields an empty map instead of throwing', async () => {
+    expect(await loadViewOverrides({}, 'crm_lead', IDS)).toEqual({});
+    expect(await loadViewOverrides(undefined, 'crm_lead', IDS)).toEqual({});
+  });
+});

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -832,6 +832,33 @@ function withoutNoOpDrops(
 }
 
 /**
+ * Resolve which object a `type='view'` metadata item belongs to.
+ *
+ * The metadata index is name-only, not field-typed: `GET /api/v1/meta/view`
+ * accepts `?package=` and `?preview=draft` and nothing else (measured on
+ * framework `packages/rest/src/rest-server.ts` — the `GET /meta/:type`
+ * handler — and on `client.meta.getItems(type, { packageId })`). So every
+ * reader of the view namespace enumerates `type='view'` once and narrows to
+ * one object HERE, client-side.
+ *
+ * ONE spelling, one place, deliberately: {@link ObjectStackAdapter.listViews}
+ * and {@link ObjectStackAdapter.listViewOverrides} read the same rows out of
+ * the same namespace, and two private copies of "which object is this?" is a
+ * drift waiting to happen — the switcher showing a view whose override the
+ * grid cannot find, or the reverse.
+ *
+ * `object` is the identity field the write path stamps (and that the
+ * framework's overlay heals onto identity-less personalization rows —
+ * objectstack#2555); `data.object` is the config's data-provider target and
+ * `objectName` the legacy artifact spelling.
+ */
+function viewItemObjectName(item: any): string | undefined {
+  // Handle both bare view spec and `{list: {...}}` artifact wrapper
+  const spec = item?.list ?? item;
+  return spec?.data?.object ?? spec?.object ?? spec?.objectName;
+}
+
+/**
  * ObjectStack Data Source Adapter
  *
  * Bridges the ObjectStack Client SDK with the ObjectUI DataSource interface.
@@ -2618,40 +2645,63 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   /**
    * Batch-fetch all persisted view overrides for an object.
    *
-   * Per-view runtime overrides (density, column widths, sort, …) are
-   * stored in the metadata registry under key `<objectName>/<viewName>`.
-   * Loading them per-view fires N HTTP GETs that return 404 for views
-   * the user has never customized — generates console noise on every
-   * page load. This batch method performs a single
-   * `GET /api/v1/meta/<objectName>` (returns `{type, items}`) and
-   * returns a `{viewName: override}` map. Returns an empty map if the
-   * server doesn't expose the listing or returns no items.
+   * Per-view runtime overrides (density, column widths, sort, hidden
+   * columns, inlineEdit …) live in the SAME metadata namespace the
+   * write path uses: `type='view'`, `name=<viewId>` (see
+   * {@link updateViewConfig}). Loading them per-view fires N HTTP GETs
+   * that 404 for every view the user never customized — console noise on
+   * every page load. This batch method performs a single
+   * `GET /api/v1/meta/view` (returns `{type, items}`) and narrows the
+   * result to `objectName` client-side, exactly as {@link listViews}
+   * does over the same rows (shared accessor: {@link viewItemObjectName}).
+   *
+   * objectui#3774 — this used to enumerate `GET /api/v1/meta/<objectName>`,
+   * putting the OBJECT name in the metadata TYPE slot. That key space is
+   * disjoint from the one the write path lands in, so the batch map came
+   * back empty for every object, forever, and every saved personalization
+   * read back as "setting didn't save".
+   *
+   * FAILURES REJECT — they are not answered as `{}`. An empty map is an
+   * authoritative "this object has no overrides" (callers may trust it and
+   * skip the per-view reads); a transport/permission failure is "I could
+   * not tell", and reporting the two as the same value is what made
+   * ObjectView's per-view {@link getView} fallback unreachable code. When
+   * we cannot tell, we do not pretend we can. Rejections are not cached
+   * (the cache stores on success only), so a transient failure does not
+   * pin an empty answer for the TTL.
    *
    * Result is cached identically to {@link getView}; saving a view via
    * {@link updateViewConfig} invalidates the cache.
    *
    * @param objectName - Object name (e.g. 'lead')
    * @returns Map keyed by view name with the persisted override config
+   * @throws whatever the metadata transport throws — callers that have a
+   *   per-view fallback should catch and use it.
    */
   async listViewOverrides(objectName: string): Promise<Record<string, any>> {
     await this.connect();
 
-    try {
-      const cacheKey = `view-overrides:${objectName}`;
-      return await this.metadataCache.get(cacheKey, async () => {
-        const result: any = await this.client.meta.getItems(objectName);
-        const items: any[] = Array.isArray(result?.items) ? result.items : [];
-        const out: Record<string, any> = {};
-        for (const it of items) {
-          if (!it || typeof it !== 'object') continue;
-          const key = it.name ?? it.id ?? it._name;
-          if (typeof key === 'string' && key) out[key] = it;
-        }
-        return out;
-      });
-    } catch {
-      return {};
-    }
+    const cacheKey = `view-overrides:${objectName}`;
+    return await this.metadataCache.get(cacheKey, async () => {
+      const result: any = await this.client.meta.getItems('view');
+      const items: any[] = Array.isArray(result?.items)
+        ? result.items
+        : Array.isArray(result) ? result : [];
+      const out: Record<string, any> = {};
+      for (const it of items) {
+        if (!it || typeof it !== 'object') continue;
+        if (viewItemObjectName(it) !== objectName) continue;
+        // Keyed by the item's canonical `name` — the SAME identity
+        // `updateViewConfig` writes under and `getView` reads back by, which
+        // is what makes this a drop-in substitute for the per-view fetch.
+        // No `?? id ?? _name` alias chain: those are not view identities on
+        // any route (`/meta/view/:name` is name-addressed), and a batch map
+        // keyed by something no caller can ask for is dead weight.
+        const key = it.name;
+        if (typeof key === 'string' && key) out[key] = it;
+      }
+      return out;
+    });
   }
 
   /**
@@ -2734,8 +2784,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * match the view spec shape.
    *
    * Returns view spec objects with their canonical `name` as identifier.
-   * Filters by `data.object === objectName` (or top-level `object`)
-   * client-side because the metadata index is name-only, not field-typed.
+   * Narrows to one object client-side via {@link viewItemObjectName} —
+   * the metadata index is name-only, not field-typed, so the route has no
+   * `?object=` to push the filter down into. {@link listViewOverrides}
+   * reads the same rows through the same accessor.
    */
   async listViews(
     objectName: string,
@@ -2774,8 +2826,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         if (!v) return false;
         // Handle both bare view spec and `{list: {...}}` artifact wrapper
         const spec = v.list ?? v;
-        const obj = spec?.data?.object ?? spec?.object ?? spec?.objectName;
-        if (obj !== objectName) return false;
+        if (viewItemObjectName(v) !== objectName) return false;
         const viewKind = v.viewKind ?? spec?.viewKind;
         return !(viewKind && FORM_FAMILY.has(viewKind));
       }).map((v: any) => {

--- a/packages/data-objectstack/src/listViewOverrides.test.ts
+++ b/packages/data-objectstack/src/listViewOverrides.test.ts
@@ -1,0 +1,241 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3774 — the view-override read and write must share one key space.
+ *
+ * `updateViewConfig` persists a personalization (density, column widths, sort,
+ * hidden columns, inlineEdit …) as `PUT /api/v1/meta/view/{viewId}`, i.e. a
+ * `sys_metadata` row with `type='view'`. `listViewOverrides` used to enumerate
+ * `GET /api/v1/meta/{objectName}` — the OBJECT name in the metadata TYPE slot.
+ * The two key spaces are disjoint, so the batch map came back empty for every
+ * object forever and every saved preference read back as "setting didn't save".
+ *
+ * The measurement that picked the fix: `GET /meta/:type` accepts `?package=`
+ * and `?preview=draft` and NOTHING else (framework
+ * `packages/rest/src/rest-server.ts`, and `client.meta.getItems(type, {
+ * packageId })`). There is no `?object=` to push the filter into, so the
+ * correct route is the one `listViews()` already uses over the same rows:
+ * enumerate `type='view'` once, narrow to the object client-side.
+ *
+ * The suite is written round-trip on purpose — a stub `sys_metadata` that the
+ * adapter's own write path fills and its own read path drains. Asserting the
+ * read against a hand-written fixture would have stayed green through the
+ * entire bug, because the fixture is where the namespace mistake lived.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackAdapter } from './index';
+
+/** A stub metadata store keyed the way `sys_metadata` is: `type` + `name`. */
+function makeMetaStore() {
+  const rows = new Map<string, any>();
+  const getItemsTypes: string[] = [];
+
+  const meta = {
+    getItems: vi.fn(async (type: string) => {
+      getItemsTypes.push(type);
+      const items = [...rows.entries()]
+        .filter(([k]) => k.startsWith(`${type}::`))
+        .map(([, v]) => v);
+      return { type, items };
+    }),
+    getItem: vi.fn(async (type: string, name: string) => {
+      const item = rows.get(`${type}::${name}`);
+      if (!item) {
+        const err: any = new Error(`Not found: ${type}/${name}`);
+        err.status = 404;
+        throw err;
+      }
+      return { type, name, item };
+    }),
+    saveItem: vi.fn(async (type: string, name: string, item: any) => {
+      rows.set(`${type}::${name}`, { ...item });
+      return { success: true, item: rows.get(`${type}::${name}`) };
+    }),
+  };
+
+  return { meta, rows, getItemsTypes };
+}
+
+function makeDS(meta: any) {
+  const ds: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })),
+  });
+  ds.connected = true;
+  ds.connectionState = 'connected';
+  ds.client = { meta };
+  return ds;
+}
+
+/**
+ * What ObjectView's `persistViewPatch` actually sends on a density toggle +
+ * column sort: the view's raw config plus the personalization state. The
+ * adapter stamps `object` / `name` on top (and the framework's overlay heals
+ * the same identity fields onto rows that lack them — objectstack#2555).
+ */
+const PERSONALIZATION = {
+  type: 'grid',
+  data: { provider: 'object', object: 'crm_lead' },
+  columns: ['name', 'status'],
+  density: 'compact',
+  sort: [{ field: 'created_at', order: 'desc' }],
+};
+
+describe('ObjectStackAdapter.listViewOverrides — read/write key space (#3774)', () => {
+  it('round-trips: a config saved through updateViewConfig comes back from listViewOverrides', async () => {
+    const { meta, getItemsTypes } = makeMetaStore();
+    const ds = makeDS(meta);
+
+    await ds.updateViewConfig('crm_lead', 'crm_lead.all', { ...PERSONALIZATION });
+    const map = await ds.listViewOverrides('crm_lead');
+
+    // The bug in one assertion: pre-fix this was `{}`.
+    expect(Object.keys(map)).toEqual(['crm_lead.all']);
+    expect(map['crm_lead.all']).toMatchObject({
+      name: 'crm_lead.all',
+      object: 'crm_lead',
+      density: 'compact',
+      sort: [{ field: 'created_at', order: 'desc' }],
+    });
+
+    // …and the type slot itself, which is the actual defect. The write went to
+    // `saveItem('view', …)`; the read must enumerate the SAME type.
+    expect(meta.saveItem).toHaveBeenCalledWith('view', 'crm_lead.all', expect.any(Object));
+    expect(getItemsTypes).toEqual(['view']);
+    expect(getItemsTypes).not.toContain('crm_lead');
+  });
+
+  it('keys the map by the identity getView reads back by (drop-in for the per-view fetch)', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeDS(meta);
+
+    await ds.updateViewConfig('crm_lead', 'crm_lead.all', { ...PERSONALIZATION });
+
+    const batched = (await ds.listViewOverrides('crm_lead'))['crm_lead.all'];
+    const perView = await ds.getView('crm_lead', 'crm_lead.all');
+
+    // Same key space, same document — that equality is what lets a caller
+    // substitute one call for N without changing what it renders.
+    expect(batched).toEqual(perView);
+  });
+
+  it('finds an override whose only object association is the top-level `object` stamp', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeDS(meta);
+
+    // A saved view with no `data.object` (e.g. a kanban personalization whose
+    // provider block was never sent) — `updateViewConfig`'s stamp is the only
+    // association, and it must be enough.
+    await ds.updateViewConfig('crm_lead', 'crm_lead.pipeline', { type: 'kanban', density: 'comfortable' });
+    const map = await ds.listViewOverrides('crm_lead');
+
+    expect(map['crm_lead.pipeline']).toMatchObject({ object: 'crm_lead', density: 'comfortable' });
+  });
+
+  it('narrows the shared `type=view` enumeration to the requested object', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeDS(meta);
+
+    await ds.updateViewConfig('crm_lead', 'crm_lead.all', { ...PERSONALIZATION });
+    await ds.updateViewConfig('crm_account', 'crm_account.all', {
+      type: 'grid', data: { provider: 'object', object: 'crm_account' }, density: 'compact',
+    });
+
+    expect(Object.keys(await ds.listViewOverrides('crm_lead'))).toEqual(['crm_lead.all']);
+    expect(Object.keys(await ds.listViewOverrides('crm_account'))).toEqual(['crm_account.all']);
+  });
+
+  it('skips rows the enumeration returns without a name (nothing can address them)', async () => {
+    const { meta, rows } = makeMetaStore();
+    const ds = makeDS(meta);
+    rows.set('view::anon', { object: 'crm_lead', density: 'compact' });
+
+    expect(await ds.listViewOverrides('crm_lead')).toEqual({});
+  });
+});
+
+describe('ObjectStackAdapter.listViewOverrides — empty vs unknown (#3774)', () => {
+  it('an EMPTY successful enumeration resolves to {} — that answer is authoritative', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeDS(meta);
+
+    // No overrides exist for this object. The caller may trust this and skip
+    // the per-view reads; the batch optimization depends on it not throwing.
+    await expect(ds.listViewOverrides('crm_lead')).resolves.toEqual({});
+  });
+
+  it('a FAILING enumeration rejects — it must not masquerade as an empty map', async () => {
+    const { meta } = makeMetaStore();
+    meta.getItems.mockRejectedValueOnce(new Error('503 metadata store unavailable'));
+    const ds = makeDS(meta);
+
+    // Pre-fix this resolved to `{}`, which is indistinguishable from the
+    // authoritative "no overrides" above — that is what made ObjectView's
+    // per-view getView fallback unreachable code.
+    await expect(ds.listViewOverrides('crm_lead')).rejects.toThrow('503 metadata store unavailable');
+  });
+
+  it('a rejection is not cached — the next call re-reads instead of pinning the failure', async () => {
+    const { meta } = makeMetaStore();
+    const ds = makeDS(meta);
+    await ds.updateViewConfig('crm_lead', 'crm_lead.all', { ...PERSONALIZATION });
+    meta.getItems.mockRejectedValueOnce(new Error('transient'));
+
+    await expect(ds.listViewOverrides('crm_lead')).rejects.toThrow('transient');
+    // The store recovered; a cached failure would have starved the view of its
+    // overrides for the whole TTL.
+    expect(Object.keys(await ds.listViewOverrides('crm_lead'))).toEqual(['crm_lead.all']);
+  });
+});
+
+describe('ObjectStackAdapter.listViewOverrides — wire route (#3774)', () => {
+  /** Let the REAL `client.meta` run so the request URL is observed, not assumed. */
+  function makeHttpDS(items: any[]) {
+    const urls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.includes('/meta/')) {
+        return new Response(JSON.stringify({ type: 'view', items }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const ds: any = new ObjectStackAdapter({ baseUrl: 'http://test.local', fetch: fetchImpl });
+    ds.connected = true;
+    ds.connectionState = 'connected';
+    return { ds, urls };
+  }
+
+  it('GETs the view TYPE, never a route built from the object name', async () => {
+    const { ds, urls } = makeHttpDS([
+      { name: 'crm_lead.all', object: 'crm_lead', ...PERSONALIZATION },
+    ]);
+
+    const map = await ds.listViewOverrides('crm_lead');
+    expect(map['crm_lead.all']).toMatchObject({ density: 'compact' });
+
+    const metaUrls = urls.filter((u) => u.includes('/meta/'));
+    expect(metaUrls.length).toBeGreaterThan(0);
+    for (const u of metaUrls) {
+      expect(u).toMatch(/\/meta\/view(\?|$)/);
+      // The pre-fix route. Pinned by shape so it cannot come back as
+      // `/meta/crm_lead` under a different spelling of the same mistake.
+      expect(u).not.toContain('/meta/crm_lead');
+    }
+  });
+});

--- a/packages/types/src/data.ts
+++ b/packages/types/src/data.ts
@@ -467,14 +467,26 @@ export interface DataSource<T = any> {
    * Batch-fetch all persisted view overrides for an object in one call.
    *
    * Optional companion to {@link getView} that returns a `{viewName: override}`
-   * map instead of fetching each view individually. Adapters should
-   * implement this when the underlying transport supports a list-by-type
-   * query (e.g. `GET /api/v1/meta/<object>` returning all `<object>/<view>`
-   * items). When not implemented, callers should fall back to per-view
+   * map instead of fetching each view individually. Adapters should implement
+   * this when the underlying transport can enumerate the view namespace in one
+   * request. When not implemented, callers fall back to per-view
    * {@link getView}.
+   *
+   * TWO CONTRACT TERMS, and they are not the same value (objectui#3774):
+   *
+   * - The map MUST be keyed by the SAME view identity {@link updateViewConfig}
+   *   persists under and {@link getView} reads back by. An implementation that
+   *   enumerates a different key space than the one it writes to answers `{}`
+   *   forever, and every saved preference reads back as "didn't save".
+   * - An empty map means "no overrides exist" and is AUTHORITATIVE — callers
+   *   may trust it and skip the per-view reads. A failure MUST therefore
+   *   REJECT, never resolve to `{}`: swallowing it into an empty map is
+   *   indistinguishable from the authoritative answer, which silently disables
+   *   the caller's per-view fallback instead of triggering it.
    *
    * @param objectName - Object name (e.g. 'lead')
    * @returns Promise resolving to a map of view name → override config
+   * @throws on transport/permission failure — do NOT resolve `{}` instead
    */
   listViewOverrides?(objectName: string): Promise<Record<string, any>>;
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#3774

## 结论:前提成立,两半件都在本 PR

写落在 `type='view'`,读却把**对象名塞进了 metadata TYPE 槽**,两边键空间不相交;而读方法自吞异常返回 `{}`,又让本来正确的逐视图回落变成不可达代码。用户调的密度/列宽/排序/隐藏列/inlineEdit 确实写进了 `sys_metadata`,但永远读不回来。

## 先测量,再定方向(不臆造服务端参数)

单里建议的 `/meta/view?object=` **服务端并不存在**。实测两处:

- `packages/client/src/index.ts` — `meta.getItems(type, options?: { packageId })`,URL 只拼 `?package=`。
- `packages/rest/src/rest-server.ts` 的 `GET /meta/:type` handler — 只读 `req.query.package` 与 `req.query.preview`,再无其它过滤位。

所以**没有**可下推的对象过滤。正确路线就是同文件 `listViews()` 已经在走的那条:枚举一次 `type='view'`,在客户端收窄到本对象(它的注释也早写明「metadata index is name-only, not field-typed」)。这不是「拿全量假装过滤」——它就是本仓既有且唯一可行的拼法。

顺带把「这行 view 属于哪个对象」抽成 **一个** 共享 accessor `viewItemObjectName()`,`listViews` 与 `listViewOverrides` 同源。同一命名空间两个读者各留一份私有判断,迟早漂移成「切换器列得出的视图,表格找不到它的 override」。

override 文档的形状按 framework `protocol-view-identity-overlay.test.ts`(objectstack#2555)钉的事实取:个性化行的 `object` / `name` 由 overlay 补齐并保留在顶层,与 `getView` 读回的是同一份文档——测试里直接断言 `batched` 与 `perView` 相等,这个相等性才是「一次调用替代 N 次」的前提。

## 第二半件:吞错不再冒充权威

`listViewOverrides` 去掉外层 `catch { return {} }`。两个答案是两件事,不能折叠成同一个值:

- **成功返回空 map** = 权威的「本对象没有 override」→ 调用方可信任并跳过逐视图读取,**批量优化原样保留**(已钉)。
- **失败** = 「我说不准」→ 抛出,让调用方的逐视图回落真正跑起来。

拒绝不会进缓存(`MetadataCache` 只在成功时 `set`),所以一次抖动不会把空答案钉住整个 TTL——这条也单独钉了。

`DataSource.listViewOverrides` 的接口文档同步写死这两条契约(原文档正是把错误命名空间当成范例写的),让后来的适配器不会再把失败实现成 `{}`。

## 消费半径:两个调用点,不只编辑的那个包

规则改在 data-objectstack,消费者在 app-shell,**有两个**:

- `ObjectView.loadBatch` —— 它的 `catch` 本来就是对的,适配器停止吞错后自然可达,**逻辑一字未改**;只把三分支读取提取成导出的 `loadViewOverrides()` 以便直接钉(沿用本文件 `defaultListColumnsFromObject` 的既有先例)。
- `InterfaceListPage` —— 这个必须改:它把批量调用放在**外层** try 里,适配器改为抛出后,一次失败会连它自己的逐视图 `getView` 回落一起跳过。给批量调用加了独立 catch,失败落到逐视图读取。

## 反向验证(先预判方向,再跑)

**回退 type 槽修复** → 预判适配器 round-trip 与 wire-route 转红。实测 6 红,报错直接指认旧路由:

```
AssertionError: expected [] to deeply equal [ 'crm_lead.all' ]
AssertionError: expected 'http://test.local/api/v1/meta/crm_lead' to match /\/meta\/view(\?|$)/
```

注意「空成功返回 `{}`」那条在此回退下**依然绿** —— 错命名空间的枚举同样合法地返回空。这正是空成功测试单独抓不到本 bug、必须写 round-trip 的原因。

**回退吞错修复** → 这里要如实报告:分诊卡预判的是「(c) 转红」,**实测不成立,也不可能成立**。(c) 在 app-shell,直接 stub 一个会抛的 dataSource,根本不经过适配器,回退适配器的 catch 动不了它。真正转红的是**适配器侧**那两条钉:

```
× a FAILING enumeration rejects — it must not masquerade as an empty map
× a rejection is not cached — the next call re-reads instead of pinning the failure
AssertionError: promise resolved "{}" instead of rejecting
```

而 app-shell 8 条全绿。这恰恰说明为什么两半件必须**各自带钉**:app-shell 那条钉的是「回落分支写对了」,只有适配器那条钉能保证这个分支在真实适配器上**够得着**。

## 测试

- `packages/data-objectstack/src/listViewOverrides.test.ts`(9 条,新增)—— round-trip(用适配器自己的写路径灌一个 stub `sys_metadata`,再用它自己的读路径取;拿手写 fixture 断言会在整个 bug 期间保持绿,因为命名空间错误就住在 fixture 里)、type 槽 + 真实 HTTP 路由双重断言、对象收窄、空成功 vs 失败、拒绝不入缓存。
- `packages/app-shell/src/views/ObjectView.viewOverrides.test.tsx`(8 条,新增)—— 批量优先且不再逐视图读、空成功提前返回、失败落到 `getView`、非对象结果落回、无 `listViewOverrides` 的适配器不受影响。

全量:`data-objectstack + types` 744 passed / 53 files;`app-shell` 2677 passed(1 skipped)/ 299 files;三包 `type-check` 与 `lint` 均 0 error。`check-control-bytes` 通过,并对改动文件做了越过该门的手工扫描。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_