### PR TITLE
docs(ci): 去掉 check-lint-coverage.mjs 头注里的 object-ui 规则点数,并把守卫扩到该文件 (#3279)

### DIFF
--- a/scripts/__tests__/lint-workflow.test.ts
+++ b/scripts/__tests__/lint-workflow.test.ts
@@ -35,10 +35,35 @@ import { fileURLToPath } from 'node:url';
  * config. Keeping such a list is the thing this issue removed — the generic
  * phrasing ("the rules `eslint.config.js` sets to `error`") is always true, so
  * the only honest list is the config itself.
+ *
+ * ## The scan surface, and why it is a list (objectui#3279)
+ *
+ * That sentence existed a third time, verbatim, in the header docblock of
+ * `scripts/check-lint-coverage.mjs`: same hand-count, same parenthesised source
+ * list, short the same rule. #3261 rewrote only the workflow, so the copy
+ * outlived the fix and was found by someone reading the file for an unrelated
+ * reason (#3274) rather than by a gate. Both files are scanned now — the two
+ * assertions iterate a list of prose surfaces — so a fourth copy fails CI
+ * instead of waiting on the next accidental reading. Any future file arguing
+ * from the same facts belongs in that list, not in a copy of this test.
+ *
+ * The count pattern reads each file's explanatory comment only, never the whole
+ * file, and for the script that scoping is load-bearing rather than tidiness:
+ * its `Known gaps` comment legitimately counts *packages* ("the last two …, 14
+ * errors"), which the pattern would otherwise report as a rule count. The
+ * rule-name pattern does read the whole file — a rule name anywhere in either
+ * file is the same second copy of `eslint.config.js`, wherever it sits.
  */
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const workflowPath = path.join(repoRoot, '.github/workflows/lint.yml');
-const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+const read = (relative: string): string => fs.readFileSync(path.join(repoRoot, relative), 'utf8');
+
+/** Repo-relative, so the same string labels the surface in failure messages. */
+const WORKFLOW = '.github/workflows/lint.yml';
+const COVERAGE_SCRIPT = 'scripts/check-lint-coverage.mjs';
+
+const workflow = read(WORKFLOW);
+const coverageScript = read(COVERAGE_SCRIPT);
 
 type FlatConfigEntry = { rules?: Record<string, unknown>; files?: string[] };
 
@@ -68,31 +93,66 @@ const objectUiErrorRules = eslintConfig
   .map(([name]) => name);
 
 /**
- * The `# …` prose block between `name:` and `on:` — the comment this issue is
- * about. Scoped so the assertions below read the explanation, not the YAML.
+ * The `# …` prose block between `name:` and `on:` — the workflow comment this
+ * issue is about. Scoped so the assertions below read the explanation, not the
+ * YAML.
  */
-function headerComment(): string {
+function workflowHeaderComment(): string {
   const start = workflow.indexOf('\n#');
   const end = workflow.indexOf('\non:');
-  expect(start, 'lint.yml must still carry a header comment above `on:`').toBeGreaterThan(-1);
-  expect(end, 'lint.yml must still have a top-level `on:` block').toBeGreaterThan(start);
+  expect(start, `${WORKFLOW} must still carry a header comment above \`on:\``).toBeGreaterThan(-1);
+  expect(end, `${WORKFLOW} must still have a top-level \`on:\` block`).toBeGreaterThan(start);
   return workflow.slice(start, end);
 }
 
 /**
- * The header comment as one continuous line: `#` markers stripped and wrapping
- * undone. Matching the raw block instead would miss the exact sentence that
- * caused #3261 — "sets three" ended a line and "`object-ui/*` rules" began the
- * next one, so any pattern spanning the two has to survive a `\n# ` in the
- * middle. Comment prose re-wraps whenever a word is edited, so the assertions
- * below must not depend on where the lines happen to break.
+ * The leading docblock of a `.mjs` script — its equivalent of the workflow's
+ * header comment. Scanning from the top of the file is right and not fragile:
+ * the file opens with a shebang and then this block, and a block-comment
+ * terminator cannot hide inside it — a star followed by a slash would have
+ * closed the comment for the JS parser long before this test read it.
  */
-function unwrappedHeaderComment(): string {
-  return headerComment()
-    .replace(/^[ \t]*#[ \t]?/gm, '')
-    .replace(/\s+/g, ' ')
-    .trim();
+function leadingDocblock(source: string, label: string): string {
+  const open = source.indexOf('/**');
+  expect(open, `${label} must still carry a header docblock`).toBeGreaterThan(-1);
+  const close = source.indexOf('*/', open);
+  expect(close, `${label}'s header docblock must still be closed`).toBeGreaterThan(open);
+  return source.slice(open + '/**'.length, close);
 }
+
+/**
+ * Comment prose as one continuous line: line-leading comment markers stripped
+ * and wrapping undone. Matching the raw block instead would miss the exact
+ * sentence that caused #3261 — "sets three" ended a line and "`object-ui/*`
+ * rules" began the next one, so any pattern spanning the two has to survive the
+ * marker and indent in between (`\n# ` in YAML, a newline plus star in a
+ * docblock). Comment prose re-wraps whenever a word is edited, so the
+ * assertions below must not depend on where the lines happen to break.
+ */
+function unwrap(block: string, marker: RegExp): string {
+  return block.replace(marker, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The prose surfaces that argue from the `object-ui/*` error ratchets. Both
+ * explain a gate in terms of those rules, so both are held to the same two
+ * rules: `text` is the whole file, `prose` only the explanatory comment (the
+ * header records why the count pattern may not read the whole file).
+ */
+type ProseSurface = { label: string; text: string; prose: () => string };
+
+const SURFACES: ProseSurface[] = [
+  {
+    label: WORKFLOW,
+    text: workflow,
+    prose: () => unwrap(workflowHeaderComment(), /^[ \t]*#[ \t]?/gm),
+  },
+  {
+    label: COVERAGE_SCRIPT,
+    text: coverageScript,
+    prose: () => unwrap(leadingDocblock(coverageScript, COVERAGE_SCRIPT), /^[ \t]*\*[ \t]?/gm),
+  },
+];
 
 /**
  * The `on:` block, from the top-level `on:` key to the next top-level key.
@@ -106,60 +166,66 @@ function onBlock(): string {
   return next === -1 ? rest : rest.slice(0, next);
 }
 
-describe('lint.yml header comment — objectui#3261', () => {
-  it('never hand-counts the object-ui/* rules again', () => {
-    const comment = unwrappedHeaderComment();
+for (const surface of SURFACES) {
+  describe(`${surface.label} — the object-ui/* ratchet prose (objectui#3261, #3279)`, () => {
+    it('never hand-counts the object-ui/* rules again', () => {
+      const comment = surface.prose();
 
-    // `three \`object-ui/*\` rules`, `all four ratchets`, `4 object-ui rules`…
-    const counted = [
-      ...comment.matchAll(
-        /\b(one|two|three|four|five|six|seven|eight|nine|ten|\d+)\b[^.]{0,20}?(`?object-ui|ratchet)/gi,
-      ),
-    ].map((m) => m[0]);
+      // `three \`object-ui/*\` rules`, `all four ratchets`, `4 object-ui rules`…
+      const counted = [
+        ...comment.matchAll(
+          /\b(one|two|three|four|five|six|seven|eight|nine|ten|\d+)\b[^.]{0,20}?(`?object-ui|ratchet)/gi,
+        ),
+      ].map((m) => m[0]);
 
-    expect(
-      counted,
-      `lint.yml's header comment counts the \`object-ui/*\` error rules again:\n` +
-        counted.map((c) => `  - ${JSON.stringify(c)}`).join('\n') +
-        `\n\nDon't. The count was wrong within weeks last time (objectui#3261: the ` +
-        `comment said three, the config had four) and a stale count still reads as ` +
-        `authoritative to the next person deciding what this gate covers. Say "the ` +
-        `\`object-ui/*\` rules \`eslint.config.js\` sets to \`error\`" instead — always ` +
-        `true, never maintained. content/docs/guide/ci-cd-pipeline.md phrases it that ` +
-        `way for the same reason.`,
-    ).toEqual([]);
+      expect(
+        counted,
+        `${surface.label}'s explanatory comment counts the \`object-ui/*\` error rules again:\n` +
+          counted.map((c) => `  - ${JSON.stringify(c)}`).join('\n') +
+          `\n\nDon't. The count was wrong within weeks last time (objectui#3261: the ` +
+          `comment said three, the config had four) and it was still wrong in a second ` +
+          `copy months later (objectui#3279). A stale count reads exactly as ` +
+          `authoritative as a fresh one to the next person deciding what this gate ` +
+          `covers. Say "the \`object-ui/*\` rules \`eslint.config.js\` sets to \`error\`" ` +
+          `instead — always true, never maintained. ` +
+          `content/docs/guide/ci-cd-pipeline.md phrases it that way for the same reason.`,
+      ).toEqual([]);
+    });
+
+    it('never enumerates them by name either', () => {
+      // Same defect one level down: naming the rules is a list that has to be
+      // maintained in lockstep with the config, and nothing makes anyone do it.
+      const named = objectUiErrorRules.filter((rule) => surface.text.includes(rule));
+
+      expect(
+        named,
+        `${surface.label} names specific \`object-ui/*\` rules:\n` +
+          named.map((r) => `  - ${r}`).join('\n') +
+          `\n\nThat list is a second copy of eslint.config.js and will drift from it ` +
+          `(objectui#3261). This file explains why the gate matters; eslint.config.js ` +
+          `is where the rules are, with each rule's own comment giving its ADR/issue.`,
+      ).toEqual([]);
+    });
   });
+}
 
-  it('never enumerates them by name either', () => {
-    // Same defect one level down: naming the rules is a list that has to be
-    // maintained in lockstep with the config, and nothing makes anyone do it.
-    const named = objectUiErrorRules.filter((rule) => workflow.includes(rule));
-
+describe('the premise both comments rest on', () => {
+  it("eslint.config.js really does set object-ui/* rules to `error`", () => {
+    // Their shared premise. If every ratchet is downgraded or deleted, this
+    // fails — which is the moment both comments have to be rewritten rather
+    // than left describing a gate with nothing behind it.
     expect(
-      named,
-      `lint.yml names specific \`object-ui/*\` rules:\n` +
-        named.map((r) => `  - ${r}`).join('\n') +
-        `\n\nThat list is a second copy of eslint.config.js and will drift from it ` +
-        `(objectui#3261). The workflow explains why the gate exists; eslint.config.js ` +
-        `is where the rules are, with each rule's own comment giving its ADR/issue.`,
-    ).toEqual([]);
+      objectUiErrorRules,
+      `No \`object-ui/*\` rule is set to \`error\` in eslint.config.js, but ${WORKFLOW} ` +
+        `and ${COVERAGE_SCRIPT} both build their explanation entirely on the premise ` +
+        `that some are. Either a severity was downgraded by accident, or the ratchets ` +
+        `are genuinely gone and both comments now need rewriting (objectui#3261, ` +
+        `#3279).`,
+    ).not.toEqual([]);
   });
 });
 
-describe('lint.yml header comment — the claims it still makes', () => {
-  it("eslint.config.js really does set object-ui/* rules to `error`", () => {
-    // The comment's premise. If every ratchet is downgraded or deleted, this
-    // fails — which is the moment the comment has to be rewritten rather than
-    // left describing a gate with nothing behind it.
-    expect(
-      objectUiErrorRules,
-      `No \`object-ui/*\` rule is set to \`error\` in eslint.config.js, but lint.yml's ` +
-        `header comment is built entirely on the premise that some are. Either a ` +
-        `severity was downgraded by accident, or the ratchets are genuinely gone and ` +
-        `that comment now needs rewriting (objectui#3261).`,
-    ).not.toEqual([]);
-  });
-
+describe('lint.yml — the trigger claims its header comment still makes', () => {
   it('still runs on pull requests, so those rules are not inert again (#2923)', () => {
     const on = onBlock();
 

--- a/scripts/check-lint-coverage.mjs
+++ b/scripts/check-lint-coverage.mjs
@@ -8,10 +8,21 @@
  * That is how `apps/console`, the largest surface in the repo, went unlinted
  * while carrying 14 ESLint errors that nobody had ever seen (#2923).
  *
- * The stakes are concrete: `eslint.config.js` sets three `object-ui/*` rules to
- * `error` specifically so a new violation fails CI (ADR-0054 Phase 5, #2879,
- * and the objectql.ts type-discipline ratchet). Those ratchets are worthless in
- * a package that never runs ESLint.
+ * The stakes are concrete: every `object-ui/*` rule that `eslint.config.js`
+ * sets to `error` is a ratchet — added specifically so a new violation fails
+ * CI. Those ratchets are worthless in a package that never runs ESLint.
+ *
+ * That sentence deliberately neither counts those rules nor lists where they
+ * came from. It used to do both, and it was wrong on the day it was written: a
+ * verbatim copy of the enumeration #3261 removed from
+ * `.github/workflows/lint.yml`, short by the same rule, left behind because
+ * that fix only touched the workflow (#3279). A hand-copied enumeration drifts
+ * by construction, and a stale one still reads as authoritative — so the next
+ * person deciding whether their new rule is inside this gate gets a confident,
+ * wrong answer. `eslint.config.js` is the only honest list, each rule carrying
+ * its own ADR/issue in the comment beside it, and
+ * `scripts/__tests__/lint-workflow.test.ts` fails if a count or a rule name
+ * reappears here.
  *
  * Run:  node scripts/check-lint-coverage.mjs
  * Exit: 0 = OK, 1 = coverage regressed or the list is stale


### PR DESCRIPTION
Fixes #3279

## 前提复核(先于实施)

issue 的前提在 `origin/main` 上原样成立,两处读数都显式取自 `origin/main`:

```
$ git show origin/main:scripts/check-lint-coverage.mjs | sed -n '11,14p'
 * The stakes are concrete: `eslint.config.js` sets three `object-ui/*` rules to
 * `error` specifically so a new violation fails CI (ADR-0054 Phase 5, #2879,
 * and the objectql.ts type-discipline ratchet). Those ratchets are worthless in
 * a package that never runs ESLint.

$ git grep -n 'object-ui/' origin/main -- eslint.config.js
origin/main:eslint.config.js:59:    'object-ui/no-synthetic-event-trigger': 'error',
origin/main:eslint.config.js:65:    'object-ui/no-try-catch-around-hook': 'error',
origin/main:eslint.config.js:98:    'object-ui/no-dynamic-import-in-test-hook': 'error',
origin/main:eslint.config.js:111:    'object-ui/no-inline-spec-config': 'error',
```

注释说 three,配置里是四条,漏的正是 `no-dynamic-import-in-test-hook` —— 与 #3261 当初漏掉的是同一条。这不是「将来会错」,是今天就错。

## 改动一:头注去数字化

按 #3261 / PR #3273 在 `lint.yml` 里确立的写法改写:不点数、不在括号里列来源,改成永真表述。这段话本身正确的主张一字未动 —— 没有 `lint` script 的包不是干净而是没被 lint 过,ratchet 在那里一文不值。

并按 `lint.yml` 的同构做法补一段,写下为什么这里刻意不点数也不列举、以及唯一诚实的清单是 `eslint.config.js` 本身(每条规则自己的 ADR/issue 就写在它旁边的注释里)。`lint.yml` 的对应措辞是「`eslint.config.js` is the single list of those rules, and this comment deliberately neither counts them nor names them」,本 PR 的措辞与之同构。

## 改动二:守卫扫描面参数化(issue 正文授权,按判断做了)

`scripts/__tests__/lint-workflow.test.ts`(#3273 新增)的两条断言 —— 不得点数、不得按名列举 —— 此前只扫 `lint.yml`,看不见这第二份副本;所以它是被人顺手读到(#3274)而不是被门禁挡下来的。现在扫描面变成一个 prose surface 列表,`lint.yml` 与 `check-lint-coverage.mjs` 各出一项,**判定逻辑原样复用**(点数正则、规则名比对、求值后 flat config 的读法都没动),只按 surface 取注释:

- 注释块提取按标记参数化:YAML 的 `#` 行首标记与 docblock 的星号行首标记共用一个 `unwrap(block, marker)`,折行还原照旧 —— #3261 那句话正是断在 "sets three" 与 "`object-ui/*` rules" 之间,任何跨行匹配都必须先还原折行。
- **点数正则只读各文件的解释性注释,不读整个文件。** 对这个脚本这条限定是必需的而非洁癖:它的 `Known gaps` 注释合法地在数**包**(「the last two …, 14 errors」),整文件扫描会把它当成规则条数误报出来。这一点写进了测试头注,免得下一个人以为是漏扫。
- 规则名比对仍读整个文件 —— 规则名出现在这两个文件的任何位置,都是 `eslint.config.js` 的第二份拷贝。

原来那条「`eslint.config.js` 确实还有 `object-ui/*` 规则设成 `error`」的前提断言现在被两份注释共用,单独提成一个 describe;`lint.yml` 专属的两条触发器断言(仍跑 `pull_request`、ignore 列表不吞 `.ts`/`.tsx`)留在原处,逻辑未动。

## 验证

**守卫测试**(从仓库根跑,invocation guard 拒绝 package-cwd):

```
$ flock -w 7200 /tmp/os-heavy-verify.lock -c 'NODE_OPTIONS=--max-old-space-size=4096 \
    pnpm vitest run scripts/__tests__/lint-workflow.test.ts --maxWorkers=2'
 RUN  v4.1.10 /home/user/objectui-3279
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

7 条 = 2 条守卫 × 2 个 surface + 1 条共用前提 + 2 条 `lint.yml` 触发器(扩面前为 5 条)。

**变异自证**(方向在跑之前就定了:应当变红,且只有新增的那一条红)。把 `origin/main` 的点数句写回 mjs 头注:

```
 FAIL  scripts/__tests__/lint-workflow.test.ts > scripts/check-lint-coverage.mjs — the
       object-ui/* ratchet prose (objectui#3261, #3279) > never hand-counts the
       object-ui/* rules again
AssertionError: scripts/check-lint-coverage.mjs's explanatory comment counts the
`object-ui/*` error rules again:
  - "three `object-ui"
...
      Tests  1 failed | 6 passed (7)
```

命中项正是 ``"three `object-ui"``;规则名那条仍绿 —— 原句列举的是 ADR/issue 而非规则名,所以只有点数这一条该红,与预期一致。变异已 `git checkout --` 还原,还原后重跑 7 passed,**不入 commit**。

**其余门禁**:

```
$ pnpm type-check:scripts          # tsc -p tsconfig.scripts.json,无输出即通过
$ node scripts/check-lint-coverage.mjs
✅  lint coverage: 45/45 packages linted, 0 with outstanding errors (0 total).
$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3718 tracked text file(s); skipped 85 binary).
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' scripts/check-lint-coverage.mjs \
    scripts/__tests__/lint-workflow.test.ts    # 零命中
```

控制字节除了跑仓库门禁,另对两个改动文件单独自扫了一次(门禁的扫描面之外仍可能藏字节)。

## 不带 changeset 的依据

`scripts/**` 不在 `scripts/check-changeset-presence.mjs` 的守卫面内 —— 那道门禁只看 `.changeset/config.json` 的 `fixed` 组里各包的 `src` 目录。先例也一致:PR #3273(`lint.yml` + 本测试文件)与 PR #3278(`lint.yml` + 本脚本)改的正是同一批文件,均未带 changeset。这次改的是内部脚本的注释与一个仓库根测试,没有发布产物变化。

## 顺带记录(不在本 PR 内)

`content/docs/guide/ci-cd-pipeline.md:201-202` 括号里还有同一事实的第四份手抄清单(而且点了一条规则名)。它今天恰好是完整的,但没有任何门禁钉它,且把它加进本 PR 的 surface 列表会当场变红 —— 需要先做一个文档措辞取舍。已按 Prime Directive #10 单独记为 #3782(`finding` 标签,未指派),不夹带进本 PR。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_