### PR TITLE
docs(layout): page-header 两处文档按组件实读收敛到 subtitle,删掉不存在的 breadcrumbs

### DIFF
--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -243,12 +243,14 @@ renders nothing here.
 
 > **Write `subtitle`, not `description`.** `@objectstack/spec/ui`'s `PageHeaderProps` —
 > the contract for the canonical `page:header` node — declares
-> `title / subtitle / icon / breadcrumb / actions / aria` and has **no** `description`.
-> The renderer still reads `description` as a legacy alias (`subtitle` wins when both are
-> set) for pages authored before `subtitle` existed, but `page-header`'s registration
-> declares only `title` and `subtitle` as authorable inputs. Metadata written with
-> `description` renders a subtitle under the legacy `page-header` alias and **nothing at
-> all** under the canonical `page:header`.
+> `title / subtitle / icon / breadcrumb / actions / aria` and has **no** `description`,
+> and `page-header`'s registration declares only `title` and `subtitle` as authorable
+> inputs. `description` is still accepted in two places: protocol 17's ADR-0087 D2
+> conversion `page-header-subtitle-alias` rewrites it to `subtitle` on header nodes as the
+> stack loads, and this renderer reads it directly as a legacy alias (`subtitle` wins when
+> both are set) for nodes that reach it without passing through that loader. `subtitle` is
+> the only spelling that renders on **every** path, and the alias is on its way out
+> (objectui#3789) — see the [PageHeader reference](/docs/layout/page-header).
 
 > **There is no `breadcrumbs` array.** The component reads no breadcrumb property of any
 > kind, in either spelling. The spec's `breadcrumb` is singular and a **boolean** — a

--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -194,7 +194,8 @@ Available values:
 
 ## PageHeader Component
 
-The `PageHeader` provides consistent page headers with title, breadcrumbs, and actions.
+The `PageHeader` provides consistent page headers with a title, an optional subtitle,
+an icon chip, and an action row.
 
 ### Usage
 
@@ -202,50 +203,57 @@ The `PageHeader` provides consistent page headers with title, breadcrumbs, and a
 {
   "type": "page-header",
   "title": "Customer Details",
-  "description": "View and edit customer information",
-  "breadcrumbs": [
-    { "label": "Home", "href": "/" },
-    { "label": "Customers", "href": "/customers" },
-    { "label": "John Doe" }
-  ],
-  "actions": [
-    {
-      "type": "button",
-      "text": "Edit",
-      "variant": "default",
-      "icon": "pencil"
-    },
-    {
-      "type": "button",
-      "text": "Delete",
-      "variant": "destructive",
-      "icon": "trash"
-    }
-  ]
+  "subtitle": "View and edit customer information",
+  "icon": "users",
+  "actions": ["edit", "delete"]
 }
 ```
+
+`title` and `subtitle` both interpolate `{field.path}` tokens against the surrounding
+record context, so `"title": "{first_name} {last_name}"` resolves on a record page.
+Unresolvable tokens collapse to an empty string rather than leaking the raw template.
 
 ### Schema API
 
 ```typescript
 {
   type: 'page-header',
-  
-  title: string,
-  description?: string,
-  icon?: string,
-  
-  breadcrumbs?: Array<{
-    label: string,
-    href?: string,
-    icon?: string
-  }>,
-  
-  actions?: ComponentSchema[],
-  
-  className?: string
+
+  title: string,                     // required; {field.path} tokens interpolated
+  subtitle?: string,                 // secondary line; {field.path} tokens interpolated
+  icon?: string,                     // Lucide icon name, rendered in a chip left of the title
+  actions?: Array<string | ActionDef>, // action ids, or inline ActionDef objects
+  showBack?: boolean,                // back arrow; inferred from record context when omitted
+  children?: ComponentSchema[],      // rendered into the right-aligned slot; `actions` takes precedence
+  className?: string,
+
+  description?: string               // legacy alias of `subtitle` — do not author, see below
 }
 ```
+
+`showBack` defaults to `true` when a record context carrying a `recordId` is in scope and
+the header is not rendered inside embedded chrome (drawer / modal, which already provide
+their own Close control), and `false` otherwise. Pass it explicitly to override.
+
+`actions` is handed to the `record:quick_actions` widget with
+`location: 'record_header'`. Its entries are **action ids** — resolved from the object's
+own `actions` metadata, which keeps the definitions in one place — or inline `ActionDef`
+objects. They are **not** `ComponentSchema` nodes: a `{ "type": "button", … }` entry
+renders nothing here.
+
+> **Write `subtitle`, not `description`.** `@objectstack/spec/ui`'s `PageHeaderProps` —
+> the contract for the canonical `page:header` node — declares
+> `title / subtitle / icon / breadcrumb / actions / aria` and has **no** `description`.
+> The renderer still reads `description` as a legacy alias (`subtitle` wins when both are
+> set) for pages authored before `subtitle` existed, but `page-header`'s registration
+> declares only `title` and `subtitle` as authorable inputs. Metadata written with
+> `description` renders a subtitle under the legacy `page-header` alias and **nothing at
+> all** under the canonical `page:header`.
+
+> **There is no `breadcrumbs` array.** The component reads no breadcrumb property of any
+> kind, in either spelling. The spec's `breadcrumb` is singular and a **boolean** — a
+> display toggle on the canonical `page:header` node (see
+> [Slotted pages](/docs/guide/slotted-pages)), not a list of links.
 
 ## SidebarNav Component
 

--- a/content/docs/layout/page-header.mdx
+++ b/content/docs/layout/page-header.mdx
@@ -1,11 +1,11 @@
 ---
 title: "PageHeader"
-description: "Page header component with title, description, and actions"
+description: "Page header component with title, subtitle, and actions"
 ---
 
 import { ComponentDemo, DemoGrid } from '@/app/components/ComponentDemo';
 
-The PageHeader component provides a consistent header for pages with title, description, and action buttons.
+The PageHeader component provides a consistent header for pages with title, subtitle, and action buttons.
 
 ## Basic Usage
 
@@ -14,7 +14,7 @@ import { PageHeader } from '@object-ui/layout';
 
 <PageHeader
   title="Dashboard"
-  description="Welcome to your dashboard"
+  subtitle="Welcome to your dashboard"
 />
 ```
 
@@ -25,14 +25,42 @@ import { PageHeader } from '@object-ui/layout';
 ## Component Props
 
 ```plaintext
-interface PageHeaderComponentProps {
-  title: string;                 // Page title (required)
-  description?: string;          // Page description
-  action?: React.ReactNode;      // Action buttons or elements
-  children?: React.ReactNode;    // Additional content (actions)
-  className?: string;            // Additional CSS classes
+interface PageHeaderComponentProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;                      // Page title (required); {field.path} tokens interpolated
+  subtitle?: string;                  // Secondary line under the title — the canonical key
+  icon?: React.ReactNode | string;    // Lucide icon name, or a pre-rendered node
+  action?: React.ReactNode;           // Action buttons or elements (right-aligned slot)
+  actions?: unknown[];                // ActionDef list (or action ids) → record:quick_actions
+  showBack?: boolean;                 // Back arrow; inferred from record context when omitted
+  schema?: { children?: unknown[]; actions?: unknown[]; properties?: { actions?: unknown[] } };
+  children?: React.ReactNode;         // Additional content (right-aligned slot)
+  className?: string;                 // Additional CSS classes
+
+  // DEPRECATED: legacy alias of `subtitle`. Still read, but do not author it.
+  description?: string;
 }
 ```
+
+`subtitle` is the canonical key: `@objectstack/spec/ui`'s `PageHeaderProps` — the contract
+for the authored `page:header` node — declares `title / subtitle / icon / breadcrumb /
+actions / aria` and has no `description`. Both `title` and `subtitle` interpolate
+`{field.path}` tokens against the surrounding record context.
+
+`description` is a **legacy alias** of `subtitle`, kept only for pages authored before
+`subtitle` existed; `subtitle` wins when both are set. It is scheduled for removal
+together with the ADR-0087 D2 conversion entry `page-header-subtitle-alias` (in the
+framework repo), which rewrites `description` → `subtitle` at load time. Until that
+conversion ships, dropping the read here would silently delete the second line on
+out-of-repo pages — so the prop stays, and new pages write `subtitle`.
+
+`actions` is delegated to the `record:quick_actions` widget with
+`location: 'record_header'`, so authors get the standard toolbar (icons, overflow menu,
+permission filtering, confirm dialogs) without declaring a sibling node. Precedence for
+the right-aligned slot is `action` → React `children` → `actions` → schema children.
+
+`showBack` renders a back arrow that navigates one level up the URL. When omitted it
+defaults to `true` on record pages (a `recordId` in scope) that are not embedded in a
+drawer or modal, and `false` otherwise.
 
 ## Examples
 
@@ -42,12 +70,12 @@ interface PageHeaderComponentProps {
 <PageHeader title="Settings" />
 ```
 
-### With Description
+### With Subtitle
 
 ```plaintext
 <PageHeader
   title="Analytics"
-  description="Track your key metrics and performance indicators"
+  subtitle="Track your key metrics and performance indicators"
 />
 ```
 
@@ -56,7 +84,7 @@ interface PageHeaderComponentProps {
 ```plaintext
 <PageHeader
   title="Projects"
-  description="Manage your projects and tasks"
+  subtitle="Manage your projects and tasks"
   action={
     <div className="flex gap-2">
       <Button variant="outline">
@@ -77,7 +105,7 @@ interface PageHeaderComponentProps {
 ```plaintext
 <PageHeader
   title="Team"
-  description="Manage your team members"
+  subtitle="Manage your team members"
 >
   <Button>Invite Member</Button>
   <Button variant="outline">Settings</Button>
@@ -91,11 +119,11 @@ The PageHeader uses a flex layout:
 ```
 ┌─────────────────────────────────────┐
 │ Title                     [Actions] │
-│ Description                         │
+│ Subtitle                            │
 └─────────────────────────────────────┘
 ```
 
-- **Left Side**: Title and description stacked vertically
+- **Left Side**: Title and subtitle stacked vertically
 - **Right Side**: Action buttons or custom content
 - **Responsive**: Actions move below title on mobile (if needed)
 
@@ -107,7 +135,7 @@ The PageHeader uses a flex layout:
 - Font weight: `font-bold`
 - Tracking: `tracking-tight`
 
-### Description
+### Subtitle
 
 - Font size: `text-sm`
 - Color: `text-muted-foreground` (gray)
@@ -132,6 +160,11 @@ The Page component includes built-in PageHeader support:
 />
 ```
 
+Note that `description` here is **the Page component's own prop**, not the header's — it
+renders the page's prose under the page title and is a declared input of the `page`
+renderer. It is unrelated to the legacy `description` alias above; do not rename it to
+`subtitle`.
+
 ## Complete Example
 
 ```plaintext
@@ -144,7 +177,7 @@ function UsersPage() {
     <div>
       <PageHeader
         title="Team Members"
-        description="Manage your team members and their roles"
+        subtitle="Manage your team members and their roles"
         action={
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm">

--- a/content/docs/layout/page-header.mdx
+++ b/content/docs/layout/page-header.mdx
@@ -47,11 +47,19 @@ actions / aria` and has no `description`. Both `title` and `subtitle` interpolat
 `{field.path}` tokens against the surrounding record context.
 
 `description` is a **legacy alias** of `subtitle`, kept only for pages authored before
-`subtitle` existed; `subtitle` wins when both are set. It is scheduled for removal
-together with the ADR-0087 D2 conversion entry `page-header-subtitle-alias` (in the
-framework repo), which rewrites `description` → `subtitle` at load time. Until that
-conversion ships, dropping the read here would silently delete the second line on
-out-of-repo pages — so the prop stays, and new pages write `subtitle`.
+`subtitle` existed; `subtitle` wins when both are set.
+
+Upstream has already closed its half of this. The ADR-0087 D2 conversion entry
+`page-header-subtitle-alias` is **live** in protocol 17: the loader rewrites a header
+node's `properties.description` to `properties.subtitle` as the stack is loaded. An
+already-canonical `subtitle` still wins, and a `description` it shadows is left exactly
+as authored rather than the loader choosing between two different second lines.
+
+Retiring the prop on this side is tracked separately, in objectui#3789. The gate there is
+a measurement rather than a date: every path by which a `page-header` node reaches this
+renderer has to be shown to go through a loader that actually performs that rewrite. Until
+objectui#3789 lands, the prop stays and this renderer keeps reading it — and new pages
+write `subtitle`.
 
 `actions` is delegated to the `record:quick_actions` widget with
 `location: 'record_header'`, so authors get the standard toolbar (icons, overflow menu,


### PR DESCRIPTION
Fixes #3267

## 背景

#3226 / PR #3265 只收窄了**机器读的**声明面(`packages/layout/src/index.ts` 里 `page-header` registration 的 `inputs`)。**人和 AI 作者读的**声明面 —— 文档 —— 还在教同一个非 spec 的 `description`,而且教得比 `inputs` 直接得多:一份是复制粘贴即用的 authored JSON 示例。本 PR 让文档面跟上,纯文档单,不触 `packages/**`,不触 `content/docs/releases/**`。

**文档的每一句都从 `origin/main` 的代码读出,不从 issue 正文抄** —— 下面是逐条对照表。

## 改动

### 1. `content/docs/guide/layout.md`(「PageHeader Component」小节)

- authored JSON 示例:`description` 改 `subtitle`;删掉 6 行 `breadcrumbs` 数组(组件一处都不读);`actions` 从 ComponentSchema 节点列表(`type: "button"`)改成 spec 形状的 action id 列表 `["edit", "delete"]`。
- 「Schema API」块:改 `subtitle`,删 `breadcrumbs`,`actions` 类型改为 action id 或 ActionDef 列表,补 `showBack` / `children`,`description` 降级为标注「legacy alias,不要 author」的一行。
- 新增两段 blockquote:「写 `subtitle` 不写 `description`」与「没有 `breadcrumbs` 数组」(spec 的 `breadcrumb` 是**单数 boolean**,canonical `page:header` 的显示开关,不是链接列表)。
- 补 `{field.path}` 插值与「未解析折叠为空串」的行为说明。

### 2. `content/docs/layout/page-header.mdx`(「Component Props」块)

- Component Props 块补齐组件**真实**的 prop 全集:`subtitle`(标为规范键)、`icon`、`actions`、`showBack`、`schema`,并补上 `extends React.HTMLAttributes< HTMLDivElement >`。
- `description` **保留不删**(见下「退役状态」),但标为 legacy alias、指向 `subtitle`。
- 块后新增说明:`subtitle` 的 spec 依据、`description` 的退役状态与门控、`actions` 的委派与右侧槽优先级、`showBack` 的默认值推断。

**同文件里 5 处 PageHeader 示例的 prop 拼写一并改成 `subtitle`**(含 Layout ASCII 图与 Styling 小节的 "Description" 标题)。这一步超出 issue 字面列的 L25-34,但不做会让新加的「`description` 是 legacy,写 `subtitle`」注解被紧随其后的 5 个 `description=` 示例当场推翻 —— 半个修法比不修更误导。(PM 复核已采纳。)

**唯一不动的 `description`**:`Usage with Page Component` 里 Page 组件的 `description=` 示例。那是 `page` renderer **自己的真 prop**(页面自身的正文,不是 header 的副标题),已就地加注说明,防止后来者顺手「修」错。

## `description` 的退役状态(第二个 commit 修正了这一段)

初版把退役写成「等上游 conversion 落地」。**PM 复核代查后指出该前提已过期**,独立复核确认(objectstack `origin/main` = `d42a92fc6`):

| 事实 | 依据 |
|---|---|
| conversion `page-header-subtitle-alias` 已 **live** | `docs/protocol-upgrade-guide.md:273` —— "live — protocol 17 loader accepts the old shape" |
| 语义:加载期把 header 节点 `properties.description` 改写为 `properties.subtitle` | `packages/spec/src/conversions/registry.ts:4616-4633`(`toMajor: 17`,`renameKey` + `emit` ConversionNotice) |
| canonical 优先:`subtitle` 在场则不改写,被遮蔽的 `description` 原样留下 | `registry.ts:4607-4612` |
| 只动 header 节点(`element:text_input` 的 `description` 是它自己的活属性) | `registry.ts:4610-4612`,fixture `:4652` |
| 加载期 = `defineStack` / `validate` / `lint` + `applyConversionsToStoredItem` 的 `sys_metadata` 存量行 | `packages/spec/CHANGELOG.md:3499`(089767f) |
| lint 侧已按该改写实现 | `packages/lint/src/authoring-rules.ts:550` |

因此文档改为如实三段式:(a) 上游 conversion 已 live 且具体做什么;(b) **本仓 `description` prop 的退役由 objectui#3789 门控**,门槛是核实每条 `page-header` 作者路径都经过执行改写的 loader;(c) #3789 落地前 prop 保留、新页面写 `subtitle`。不预告时间,不替 #3789 下结论。

**同时修掉 `layout.md` 的一处同类失真**(PM 点 2 的一致性自查抓到):原 blockquote 断言「写 `description` 的 metadata 在 canonical `page:header` 下**什么都不出**」。conversion 落地后这个结论变成**路径相关** —— 经 loader 的元数据会被改写成 `subtitle` 并正常渲染(registry fixture `:4645-4647` 明确把 `type: 'page:header'` 也一并转换),只有绕过 loader 的裸 JSON 才仍然不出。已改写为「两处仍接受 `description`(加载期改写 + 本渲染器直读),但 `subtitle` 是唯一在**每条**路径上都渲染的拼写」,并指向 #3789。

## 文档声明 ↔ 代码行号对照表

| 文档声明 | 代码依据(objectui `origin/main` = `00b9451d8`) |
|---|---|
| `title: string` 必填 | `packages/layout/src/PageHeader.tsx:29` |
| `subtitle?: string` 是规范键 | `PageHeader.tsx:35`;`packages/layout/src/index.ts:56`(收窄后的 `inputs`) |
| spec `PageHeaderProps` = title/subtitle/icon/breadcrumb/actions/aria,无 `description` | objectstack `packages/spec/src/ui/component.zod.ts:224-232` |
| `description?` 是 legacy alias,`subtitle` 优先 | `PageHeader.tsx:36` + `:143`(`const secondaryRaw = subtitle ?? description;`) |
| `icon?` 接 Lucide 名或 React node,渲染在标题左侧 chip | `PageHeader.tsx:42`、`:224-228` |
| `action?: React.ReactNode` 落右侧槽 | `PageHeader.tsx:43`、`:207` |
| `actions?` 交给 `record:quick_actions`,`location: 'record_header'` | `PageHeader.tsx:58`、`:192-206` |
| `actions` 条目是 action id 或 ActionDef,**不是** ComponentSchema | `packages/plugin-detail/src/renderers/record-quick-actions.tsx:60-93`(全字符串走对象 metadata 查名,否则当 ActionDef) |
| `showBack?` 省略时按 record 上下文推断(有 `recordId` 且非 embedded 才为 true) | `PageHeader.tsx:50`、`:159-161` |
| `schema?` 的形状 | `PageHeader.tsx:65` |
| `children` 落右侧槽,`actions` 优先 | `PageHeader.tsx:182-190`、`:207`(`action` → `children` → `actionsSlot` → `schemaChildren`) |
| `className` 透传 | `PageHeader.tsx:210` |
| `{field.path}` 插值;未解析折叠为空串而非漏出原模板 | `PageHeader.tsx:89-110`、`:136-140`、`:147-151` |
| **组件不读任何 breadcrumb 属性**(单复数均无) | `PageHeader.tsx` 全文 `breadcrumb` 仅出现在 L16 的 doc 注释里,零处读取 |
| spec 的 `breadcrumb` 是单数 boolean,canonical 节点的显示开关 | objectstack `component.zod.ts:228`;渲染器 `packages/components/src/renderers/layout/containers.tsx:979`(`!== false`)、`:1495-1498`、`:1530-1531`、`:1560` |
| canonical `page:header` 渲染器**只**读 `subtitle` | `containers.tsx:962`(`schema?.subtitle ?? schema?.properties?.subtitle`);该文件 `description` 读取数 = **0**(`grep -c` 实测) |
| `page-header` 的 `inputs` 只声明 title/subtitle | `packages/layout/src/index.ts:50-58` |
| Page 的 `description` 是 `page` renderer 自己的真 prop | `packages/components/src/renderers/layout/page.tsx:605`、`:635`、`:672`;注释 `:603-604` 明说「the page's own prose, not a duplicate of the header's subtitle」 |

## 验证(返工后复跑)

```
$ node scripts/check-doc-links.mjs
Links are valid across 7 scan roots.

$ node scripts/check-control-bytes.mjs
check-control-bytes: OK (scanned 3718 tracked text file(s); skipped 85 binary).

$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' content/docs/guide/layout.md content/docs/layout/page-header.mdx
(无输出,exit 1 —— 零控制字节)

$ pnpm vitest run --maxWorkers=2 scripts/__tests__/doc-version-claims.test.ts \
    scripts/__tests__/check-doc-links.test.ts scripts/__tests__/check-changeset-presence.test.ts
Test Files  3 passed (3)
     Tests  127 passed (127)

$ npx fumadocs-mdx        # apps/site,确认 MDX 仍可解析
[MDX] generated files in 27.6ms
```

## Changeset

**不需要。** 依据是仓里的判定脚本本身,而非推断:

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with 00b9451d8 (merge-base with origin/main): 2 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
No source of a released package changed in this range, so no changeset is owed.
```

与先例一致:近 15 个 docs 提交(含多个改 `content/docs/**` 的)全部零 changeset。

## 顺手发现(未在本 PR 修,另开 issue)

- #3786 —— 同文件 Styling/Container 两条数值失实(`pb-8 on desktop` / `gap-4`,代码是无条件 `pb-4` 与 `gap-3`,且有未写进文档的 `border-b`)。
- #3787 —— PageHeader 文档页唯一 live demo 手搓 div,全文不含 `page-header`。
- #3788 —— 约 40 个 mdx 仍 import 已不用的 `{ ComponentDemo, DemoGrid }`(根因在 `scripts/extract-mdx-demos.mjs` 的 import 替换正则),observation-class。

均属另一类断言,**故意不搭车**。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt