### PR TITLE
fix(components): 记录页头的动作谓词改走 CEL,与行菜单/批量栏同一入口 (#3521)

### DIFF
--- a/.changeset/header-action-predicates-speak-cel-3521.md
+++ b/.changeset/header-action-predicates-speak-cel-3521.md
@@ -1,0 +1,32 @@
+---
+"@object-ui/components": patch
+---
+
+Record page header action predicates now speak CEL, like every other action surface
+
+`visible` / `hidden` / `disabled` on a `page:header` action were handed to
+ObjectUI's legacy JS evaluator, while the row kebab, the selection bar and
+conditional formatting have evaluated the identical metadata on the canonical
+CEL engine since objectui#1584 / ADR-0058. Every construct that exists only in
+CEL therefore worked in a list row and threw on the record page — where the
+throw fail-closed hid the button, leaving nothing on screen to notice:
+
+- method calls — `record.f_tags.size() > 0`, `record.f_textarea.contains("x")`
+- the `in` operator — `'"red" in record.f_multiselect'` (a parse error)
+- stdlib functions — `record.f_date < today()` (`today is not a function`)
+
+Both header evaluation sites now go through `evalRowPredicate`: the same entry,
+the same bindings (`record.*` + bare field names + `data.*` + the host scope,
+with relations bound as the stored foreign key), and the same fail-closed +
+warn-once semantics as the row surfaces. One predicate on one record now reaches
+the same show/hide verdict in the row menu, the selection bar and the record
+header.
+
+Legacy-dialect strings are unaffected: `${…}`, `===`/`!==`, `?.`, `??` and
+JS-only methods such as `.includes()` still route to the legacy evaluator (with
+its existing one-time deprecation warning), so authored pages keep working. A
+`${…}` template predicate, which the header previously could not evaluate at
+all, now resolves through that fallback instead of hiding the button. A
+predicate that genuinely cannot be evaluated still hides its action, and now
+reports itself once in the same words the other surfaces use, naming the
+surface, the action and the predicate.

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -633,7 +633,7 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
   });
 
   describe('unified diagnostics: no more silent fail-closed hide', () => {
-    it('hides a throwing predicate AND warns once with the action name', () => {
+    it('hides an unevaluatable predicate AND warns once with the action name', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
         const schema = {
@@ -652,7 +652,15 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
         const matching = () =>
           warn.mock.calls.filter(c => String(c[0]).includes('bad_scope_2358'));
         expect(matching()).toHaveLength(1);
-        expect(String(matching()[0][0])).toMatch(/predicate threw/);
+        // Since objectui#3521 the fault report is written by the SAME warn-once
+        // machinery the row kebab and the selection bar use (`evalRowPredicate`
+        // with `warnOnError`), carrying the label this surface passes — so the
+        // wording is "failed to evaluate … treated as its safe default" rather
+        // than the header's former bespoke "predicate threw". What #2358 asked
+        // for is unchanged and still asserted here: the hidden button names
+        // itself, quotes its predicate, and says it once.
+        expect(String(matching()[0][0])).toMatch(/failed to evaluate/);
+        expect(String(matching()[0][0])).toContain('page:header');
         expect(String(matching()[0][0])).toContain('undeclared_var_2358 == 1');
         // Re-render must not spam the warning (deduped per action+predicate).
         unmount();
@@ -686,9 +694,18 @@ describe('PageHeaderRenderer — #2358 action visibility traps', () => {
         const hits = warn.mock.calls.filter(c =>
           String(c[0]).includes('hidden_field_gate_2358'),
         );
-        expect(hits).toHaveLength(1);
-        expect(String(hits[0][0])).toContain('secret_level_2358');
-        expect(String(hits[0][0])).toMatch(/not present in the record payload/);
+        // TWO diagnostics, one per fact, each once (objectui#3521): this local
+        // one names the missing field — a CAUSE only this surface can see, since
+        // the server strips `hidden: true` fields from detail payloads — and the
+        // shared `evalRowPredicate` report states the VERDICT (a CEL fault on an
+        // absent key, resolved to the fail-closed default). Before #3521 the
+        // legacy JS evaluator returned `undefined` for the absent key without
+        // faulting, so only the first line existed.
+        const missingField = hits.filter(c => /not present in the record payload/.test(String(c[0])));
+        const fault = hits.filter(c => /failed to evaluate/.test(String(c[0])));
+        expect(missingField).toHaveLength(1);
+        expect(fault).toHaveLength(1);
+        expect(String(missingField[0][0])).toContain('secret_level_2358');
       } finally {
         warn.mockRestore();
       }

--- a/packages/components/src/__tests__/page-header-predicate-dialect.test.tsx
+++ b/packages/components/src/__tests__/page-header-predicate-dialect.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `page:header` action predicates speak CEL — one dialect, one engine
+ * (objectui#3521).
+ *
+ * The record header was the last action surface still handing EVERY predicate
+ * to the legacy JS evaluator. The row kebab, the selection bar and conditional
+ * formatting have routed through `evalRowPredicate` since objectui#1584 /
+ * ADR-0058, where a bare string is CEL (what `@objectstack/spec` types
+ * `ActionSchema.visible` as, and what the server enforces with). So every
+ * construct that exists ONLY in CEL — a method call, the `in` operator, a
+ * stdlib function — parsed fine in a list row and threw on the detail page,
+ * where the throw fail-closed hid the button with nothing on screen to see:
+ *
+ *   Failed to evaluate expression '"red" in record.f_multiselect':
+ *     Unexpected token "i" at position 6
+ *   Failed to evaluate expression 'record.f_date < today()':
+ *     "today" is not a function
+ *
+ * These tests pin the three families from the issue plus the fallback that
+ * keeps the switch non-breaking: a legacy-dialect string (`${…}`, `===`,
+ * `.includes()`) still routes to the old evaluator with its deprecation
+ * warning, and a predicate that genuinely cannot be evaluated still fails
+ * CLOSED, once, with the action named.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider, RecordContextProvider, PredicateScopeProvider } from '@object-ui/react';
+
+function PageHeader({ schema }: { schema: any }) {
+  const Component = ComponentRegistry.get('page:header');
+  if (!Component) throw new Error('page:header not registered');
+  // eslint-disable-next-line react-hooks/static-components -- registry component is stable
+  return <Component schema={schema} />;
+}
+
+/** The showcase field-zoo shape the issue was measured on. */
+const OBJECT_SCHEMA = {
+  name: 'showcase_field_zoo',
+  label: 'Field Zoo',
+  fields: {
+    f_status: { type: 'select' },
+    f_tags: { type: 'select', multiple: true },
+    f_multiselect: { type: 'select', multiple: true },
+    f_textarea: { type: 'textarea' },
+    f_date: { type: 'date' },
+    owner: { type: 'user' },
+  },
+};
+
+const RECORD = {
+  id: 'r1',
+  f_status: 'open',
+  f_tags: ['alpha', 'beta'],
+  f_multiselect: ['red', 'blue'],
+  f_textarea: 'please handle, urgent',
+  f_date: '2020-01-01',
+  owner: { id: 'U1', name: 'Ada Lovelace' },
+};
+
+const SCOPE = { user: { id: 'U1' }, os: { user: { id: 'U1' } } };
+
+function renderHeader(action: Record<string, unknown>, record: any = RECORD) {
+  return render(
+    <PredicateScopeProvider scope={SCOPE}>
+      <ActionProvider>
+        <RecordContextProvider
+          objectName="showcase_field_zoo"
+          recordId={record?.id ?? null}
+          data={record}
+          objectSchema={OBJECT_SCHEMA}
+        >
+          <PageHeader
+            schema={{
+              type: 'page:header',
+              title: 'Specimen',
+              actions: [{ locations: ['record_header'], label: 'Zoo Action', type: 'api', ...action }],
+            }}
+          />
+        </RecordContextProvider>
+      </ActionProvider>
+    </PredicateScopeProvider>,
+  );
+}
+
+const button = () => screen.queryByRole('button', { name: /Zoo Action/i });
+const shown = () => !!button();
+
+describe('page:header — CEL-only constructs in action predicates (#3521)', () => {
+  describe('method calls', () => {
+    it('evaluates `.size()` instead of throwing on it', () => {
+      renderHeader({ name: 'zoo_size_true', visible: 'record.f_tags.size() > 0' });
+      expect(shown()).toBe(true);
+    });
+
+    it('reaches the NEGATIVE verdict too — not just "no longer hidden"', () => {
+      renderHeader({ name: 'zoo_size_false', visible: 'record.f_tags.size() > 0' }, { ...RECORD, f_tags: [] });
+      expect(shown()).toBe(false);
+    });
+
+    it('evaluates `.contains()`', () => {
+      renderHeader({ name: 'zoo_contains_true', visible: 'record.f_textarea.contains("urgent")' });
+      expect(shown()).toBe(true);
+    });
+
+    it('hides when `.contains()` is false', () => {
+      renderHeader(
+        { name: 'zoo_contains_false', visible: 'record.f_textarea.contains("urgent")' },
+        { ...RECORD, f_textarea: 'nothing to see here' },
+      );
+      expect(shown()).toBe(false);
+    });
+  });
+
+  describe('the `in` operator', () => {
+    it('evaluates membership instead of failing to parse at position 6', () => {
+      renderHeader({ name: 'zoo_in_true', visible: '"red" in record.f_multiselect' });
+      expect(shown()).toBe(true);
+    });
+
+    it('hides when the member is absent', () => {
+      renderHeader({ name: 'zoo_in_false', visible: '"green" in record.f_multiselect' });
+      expect(shown()).toBe(false);
+    });
+  });
+
+  describe('stdlib functions', () => {
+    it('resolves `today()` instead of reporting it is not a function', () => {
+      renderHeader({ name: 'zoo_today_true', visible: 'record.f_date != null && record.f_date < today()' });
+      expect(shown()).toBe(true);
+    });
+
+    it('hides for a future date', () => {
+      renderHeader(
+        { name: 'zoo_today_false', visible: 'record.f_date != null && record.f_date < today()' },
+        { ...RECORD, f_date: '2999-01-01' },
+      );
+      expect(shown()).toBe(false);
+    });
+  });
+
+  it('honours a CEL construct inside the `{ dialect, source }` envelope', () => {
+    renderHeader({
+      name: 'zoo_envelope',
+      visible: { dialect: 'cel', source: 'record.f_tags.size() > 1' },
+    });
+    expect(shown()).toBe(true);
+  });
+
+  it('applies CEL to `hidden`, the mirror predicate', () => {
+    renderHeader({ name: 'zoo_hidden_cel', hidden: '"red" in record.f_multiselect' });
+    expect(shown()).toBe(false);
+  });
+
+  it('keeps `hidden` false-y when the CEL verdict is false', () => {
+    renderHeader({ name: 'zoo_hidden_cel_false', hidden: '"green" in record.f_multiselect' });
+    expect(shown()).toBe(true);
+  });
+
+  it('applies CEL to `disabled` — the second call site of the same evaluator', () => {
+    renderHeader({ name: 'zoo_disabled_cel', disabled: 'record.f_tags.size() > 0' });
+    expect(button()).toBeTruthy();
+    expect(button()).toBeDisabled();
+  });
+
+  it('leaves the button enabled when the `disabled` CEL verdict is false', () => {
+    renderHeader({ name: 'zoo_enabled_cel', disabled: '"green" in record.f_multiselect' });
+    expect(button()).toBeTruthy();
+    expect(button()).not.toBeDisabled();
+  });
+
+  describe('bindings the row surfaces already offered', () => {
+    it('binds bare field names', () => {
+      renderHeader({ name: 'zoo_bare', visible: 'f_status == "open"' });
+      expect(shown()).toBe(true);
+    });
+
+    it('binds `data.*`', () => {
+      renderHeader({ name: 'zoo_data', visible: 'data.f_status == "open"' });
+      expect(shown()).toBe(true);
+    });
+
+    it('binds the host scope (`os.user.*`) alongside the record', () => {
+      renderHeader({ name: 'zoo_scope', visible: 'os.user.id == "U1" && record.f_status == "open"' });
+      expect(shown()).toBe(true);
+    });
+
+    it('keeps #3501 relation binding: an EXPANDED lookup still compares as its id, in the same predicate as a CEL construct', () => {
+      renderHeader({
+        name: 'zoo_relation_and_cel',
+        visible: 'record.owner == os.user.id && record.f_tags.size() > 0',
+      });
+      expect(shown()).toBe(true);
+    });
+
+    it('and reaches the same verdict when the lookup arrived UNexpanded', () => {
+      renderHeader(
+        { name: 'zoo_relation_unexpanded', visible: 'record.owner == os.user.id && record.f_tags.size() > 0' },
+        { ...RECORD, owner: 'U1' },
+      );
+      expect(shown()).toBe(true);
+    });
+  });
+});
+
+describe('page:header — legacy dialect still falls back (#3521)', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    return () => warn.mockRestore();
+  });
+
+  const legacyWarnings = () =>
+    warn.mock.calls.filter(c => String(c[0]).includes('legacy expression dialect'));
+
+  it('evaluates a `${…}` template predicate on the legacy engine', () => {
+    renderHeader({ name: 'zoo_legacy_template', visible: '${record.f_status === "open"}' });
+    expect(shown()).toBe(true);
+    expect(legacyWarnings().length).toBeGreaterThan(0);
+  });
+
+  it('hides when the `${…}` template predicate is false', () => {
+    renderHeader({ name: 'zoo_legacy_template_false', visible: '${record.f_status === "closed"}' });
+    expect(shown()).toBe(false);
+  });
+
+  it('evaluates a bare `===` predicate on the legacy engine', () => {
+    renderHeader({ name: 'zoo_legacy_strict_eq', visible: 'record.f_status === "open"' });
+    expect(shown()).toBe(true);
+    expect(legacyWarnings().length).toBeGreaterThan(0);
+  });
+
+  it('evaluates a JS-only method (`.includes()`) on the legacy engine', () => {
+    renderHeader({ name: 'zoo_legacy_includes', visible: 'record.f_textarea.includes("urgent")' });
+    expect(shown()).toBe(true);
+  });
+
+  it('routes a legacy `disabled` predicate the same way', () => {
+    renderHeader({ name: 'zoo_legacy_disabled', disabled: 'record.f_status === "open"' });
+    expect(button()).toBeDisabled();
+  });
+});
+
+describe('page:header — fail-closed stays fail-closed, and says so once (#3521)', () => {
+  it('hides a predicate that cannot be evaluated and warns exactly once, naming the action', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const action = { name: 'zoo_broken_3521', visible: 'no_such_var_3521 == 1' };
+      const { unmount } = renderHeader(action);
+      expect(shown()).toBe(false);
+
+      // The fault report now comes from `evalRowPredicate`'s warn-once
+      // machinery — the SAME words the row kebab and the selection bar print —
+      // carrying the label this surface passes, so the hidden button still
+      // names itself.
+      const faults = () =>
+        warn.mock.calls.filter(
+          c => String(c[0]).includes('failed to evaluate') && String(c[0]).includes('zoo_broken_3521'),
+        );
+      expect(faults()).toHaveLength(1);
+      expect(String(faults()[0][0])).toContain('page:header');
+      expect(String(faults()[0][0])).toContain('no_such_var_3521 == 1');
+
+      // Re-render must not spam it (deduped per label + predicate).
+      unmount();
+      renderHeader(action);
+      expect(faults()).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('leaves a faulting `disabled` predicate enabled — the historical direction', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      renderHeader({ name: 'zoo_broken_disabled_3521', disabled: 'no_such_var_disabled_3521 == 1' });
+      expect(button()).toBeTruthy();
+      expect(button()).not.toBeDisabled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('leaves a faulting `hidden` predicate rendered — the historical direction', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      renderHeader({ name: 'zoo_broken_hidden_3521', hidden: 'no_such_var_hidden_3521 == 1' });
+      expect(shown()).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/components/src/__tests__/page-header-predicate-dialect.test.tsx
+++ b/packages/components/src/__tests__/page-header-predicate-dialect.test.tsx
@@ -52,6 +52,7 @@ const OBJECT_SCHEMA = {
     f_tags: { type: 'select', multiple: true },
     f_multiselect: { type: 'select', multiple: true },
     f_textarea: { type: 'textarea' },
+    f_email: { type: 'email' },
     f_date: { type: 'date' },
     owner: { type: 'user' },
   },
@@ -63,6 +64,7 @@ const RECORD = {
   f_tags: ['alpha', 'beta'],
   f_multiselect: ['red', 'blue'],
   f_textarea: 'please handle, urgent',
+  f_email: 'ada@example.com',
   f_date: '2020-01-01',
   owner: { id: 'U1', name: 'Ada Lovelace' },
 };
@@ -116,6 +118,29 @@ describe('page:header — CEL-only constructs in action predicates (#3521)', () 
       renderHeader(
         { name: 'zoo_contains_false', visible: 'record.f_textarea.contains("urgent")' },
         { ...RECORD, f_textarea: 'nothing to see here' },
+      );
+      expect(shown()).toBe(false);
+    });
+
+    // `.matches()` is CEL's regex method — the third method call the issue's
+    // table names, and the one closest to a legacy marker: `.match(` IS a
+    // legacy JS marker, `.matches(` deliberately is not (the marker requires
+    // `(` right after `match`), so this must reach the CEL engine.
+    it('evaluates `.matches()` — and is not mistaken for the legacy `.match()`', () => {
+      renderHeader({
+        name: 'zoo_matches_true',
+        visible: 'record.f_email != null && record.f_email.matches(".*@example[.]com")',
+      });
+      expect(shown()).toBe(true);
+    });
+
+    it('hides when `.matches()` is false', () => {
+      renderHeader(
+        {
+          name: 'zoo_matches_false',
+          visible: 'record.f_email != null && record.f_email.matches(".*@example[.]com")',
+        },
+        { ...RECORD, f_email: 'ada@other.org' },
       );
       expect(shown()).toBe(false);
     });

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { ComponentRegistry, ExpressionEvaluator, getRecordDisplayName, toPredicateRecord } from '@object-ui/core';
+import { ComponentRegistry, ExpressionEvaluator, evalRowPredicate, getRecordDisplayName, toPredicateRecord } from '@object-ui/core';
 import { actionRendersAt } from '@object-ui/types';
 import { useRecordContext, useAction, useCapabilityGate, usePredicateScope, usePageVariables, useInlineEdit } from '@object-ui/react';
 import { renderChildren, cn } from '../../lib/utils';
@@ -857,23 +857,18 @@ export function cleanupTitleSeparators(s: string): string {
 
 /**
  * One-time diagnostics for header-action `visible` / `hidden` predicates
- * (#2358). Both warn-once per (action, predicate) pair so re-renders don't
- * spam the console, mirroring ActionEngine's `warnHiddenPredicate` (#2183).
+ * (#2358). Warn-once per (action, predicate) pair so re-renders don't spam the
+ * console, mirroring ActionEngine's `warnHiddenPredicate` (#2183).
+ *
+ * The *fault* half of these diagnostics is no longer written here: since
+ * objectui#3521 the predicates run through `evalRowPredicate`, whose own
+ * warn-once machinery reports a faulting predicate under the label this file
+ * passes (`page:header action "…" visible`) — one report per broken predicate,
+ * identical in wording to the row kebab and the selection bar. What stays local
+ * is the missing-field diagnostic below, which explains a *cause* the engine
+ * cannot see (fields stripped from the payload server-side).
  */
 const _warnedHeaderPredicates = new Set<string>();
-
-/** Warn when a predicate THREW — the action is fail-closed hidden. */
-function warnHeaderActionPredicate(name: unknown, source: string, err: unknown): void {
-  const key = `throw::${String(name)}::${source}`;
-  if (_warnedHeaderPredicates.has(key)) return;
-  _warnedHeaderPredicates.add(key);
-  const msg = err instanceof Error ? err.message : String(err);
-  console.warn(
-    `[page:header] action "${String(name)}" hidden: its predicate threw — ${msg}. ` +
-    `Predicate: ${source}. Header-action predicates evaluate against ` +
-    `{ record, user, os.user, ctx.user, app, features, <record fields> }.`,
-  );
-}
 
 /**
  * Warn when a predicate references `record.<field>` keys that are absent from
@@ -997,37 +992,53 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   // synthesised. Authored pages may opt out by omitting them at the host
   // or by adding a name-clashing action of their own.
   const hostSystemActions = (ctx as any)?.headerSystemActions as any[] | undefined;
-  const headerActions = React.useMemo<any[]>(() => {
-    const recordData: any = ctx?.data;
-    // Spread record fields as top-level bindings so author-friendly CEL like
-    // `status == "active"` or `is_default != true` resolves directly. Without
-    // this, bare identifiers fall through to the JS global scope and silently
-    // resolve to e.g. `window.status` (empty string), causing every action
-    // with a `visible` expression to be filtered out.
-    // Carry the ambient host scope (user / app / features) and expose the
-    // canonical `ctx.*` namespace so `ctx.user.isPlatformAdmin`-style
-    // predicates resolve — alongside the record fields spread for bare
-    // `status`/`is_default` CEL.
+
+  // ── Action predicates: ONE dialect, ONE entry (objectui#3521) ──────────────
+  //
+  // `visible` / `hidden` / `disabled` on a header action are evaluated by
+  // `evalRowPredicate` — the SAME entry the row kebab (`RowActionMenu`), the
+  // selection bar (`partitionBulkRows`) and conditional formatting have used
+  // since objectui#1584 / ADR-0058. A bare string is therefore CEL, which is
+  // what `@objectstack/spec` types `ActionSchema.visible` as and what the
+  // server enforces with, so the CEL-only constructs an author writes once
+  // (`record.tags.size() > 0`, `'"red" in record.f_multiselect'`,
+  // `record.f_date < today()`) now reach a verdict here instead of throwing in
+  // a JS parser and fail-closed hiding the button. Before this, the header was
+  // the last surface still handing EVERY predicate to the legacy JS evaluator,
+  // so one piece of metadata meant two different things depending on whether
+  // the reader was a list row or a record page.
+  //
+  // A legacy-dialect string (`${…}`, `===`/`!==`, `?.`, `??`, JS-only methods
+  // like `.includes()`) still routes to the legacy evaluator inside
+  // `evalRowPredicate` via `isLegacyDialectSource`, with its one-time
+  // deprecation warning — existing authored pages do not regress.
+  //
+  // Fail-closed and warn-once come from that same entry (`fallback: false`,
+  // `warnOnError: true`), so a broken predicate hides its button here exactly
+  // as it does on the other surfaces, and says so once.
+  const headerPredicateFields = headerObjectSchema?.fields;
+  const headerPredicateScope = React.useMemo(() => {
     const scopeUser = (predicateScope as any)?.user;
     // Relation fields bind as the FOREIGN KEY the server stores, not as the
-    // record `$expand` substituted for them: the detail fetch expands every
-    // relation it can, so `record.owner == os.user.id` — the spelling that
-    // works server-side and in a bare list — could only ever be false here,
-    // while `record.owner.id` throws on any record whose lookup is empty. See
-    // `toPredicateRecord`. Display (`interpolate` above) still reads the raw
-    // `ctx.data`, which is what renders the related record's NAME.
-    // `toPredicateRecord` passes a null/undefined record straight through, so
-    // "no record loaded yet" stays distinguishable from "an empty record" —
-    // spreading either into `evalCtx` is a no-op.
-    const predicateRecord = toPredicateRecord(recordData, headerObjectSchema?.fields);
-    const evalCtx = {
-      ...predicateRecord,
-      record: predicateRecord,
-      data: predicateRecord,
+    // record `$expand` substituted for them (objectui#3501): the detail fetch
+    // expands every relation it can, so `record.owner == os.user.id` — the
+    // spelling that works server-side and in a bare list — could only ever be
+    // false here, while `record.owner.id` faults on an empty lookup. The
+    // top-level `record` / bare-field / `data.*` bindings get this same
+    // normalization from `evalRowPredicate`'s `fields` option below; this copy
+    // is for the `ctx.*` namespace, which the engine does not build. Display
+    // (`interpolate` above) still reads the raw `ctx.data`, which is what
+    // renders the related record's NAME.
+    const predicateRecord = toPredicateRecord(ctx?.data, headerPredicateFields);
+    return {
+      // The ambient host scope (`features` / `app` / `current_user` / …) binds
+      // top-level, the way it does for a row predicate — the header used to
+      // expose it only under `ctx.*`.
+      ...(predicateScope && typeof predicateScope === 'object' ? predicateScope : {}),
       user: scopeUser,
       // Server-CEL-parity identity alias (#2358 trap 1): the spec's canonical
       // CEL identity scope is `os.user.*`, so a predicate authored against the
-      // server dialect resolves here too instead of throwing (fail-closed).
+      // server dialect resolves here too instead of faulting (fail-closed).
       os: (predicateScope as any)?.os ?? { user: scopeUser },
       ctx: {
         user: scopeUser,
@@ -1037,20 +1048,38 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
         features: (predicateScope as any)?.features,
       },
     };
-    const evaluator = new ExpressionEvaluator(evalCtx);
-    // Fail-closed BUT diagnosable (#2358): a throwing `visible`/`hidden`
-    // predicate still hides the action, but now warns once (action name +
-    // predicate + reason) instead of silently swallowing the error — a
-    // predicate that throws is almost always an authoring bug (wrong scope
-    // variable, bare field reference), not a real precondition.
-    const evalExpr = (src: string, actionName: unknown): any => {
-      try {
-        return evaluator.evaluateExpression(src);
-      } catch (err) {
-        warnHeaderActionPredicate(actionName, src, err);
-        return undefined;
-      }
-    };
+  }, [predicateScope, ctx?.data, headerPredicateFields]);
+
+  /**
+   * Evaluate one header-action predicate. `label` is the locator carried into
+   * the fault warning, so a hidden button names itself in the console.
+   *
+   * `fallback: false` is what preserves both historical fail directions: a
+   * faulting `visible`/`disabled` hides/enables nothing new (fail-closed), and
+   * a faulting `hidden` leaves the action rendered exactly as the old
+   * `catch → undefined` did.
+   */
+  const evalHeaderPredicate = React.useCallback(
+    (pred: unknown, label: string): boolean =>
+      evalRowPredicate(pred as never, ctx?.data ?? {}, {
+        fallback: false,
+        scope: headerPredicateScope,
+        fields: headerPredicateFields,
+        warnOnError: true,
+        label,
+      }),
+    [ctx?.data, headerPredicateScope, headerPredicateFields],
+  );
+
+  const headerActions = React.useMemo<any[]>(() => {
+    const recordData: any = ctx?.data;
+    // The record binds three ways inside `evalRowPredicate` — `record.status`
+    // (spec/canonical), bare `status` (the row-action shorthand) and
+    // `data.status` (legacy) — so no authoring convention silently falls
+    // through to the JS global scope the way a bare identifier used to
+    // (`window.status`, an empty string, filtering the action out). The host
+    // scope and the `ctx.*` / `os.user` namespaces come from
+    // `headerPredicateScope` above. See `evalHeaderPredicate`.
     const filterAction = (a: any): boolean => {
       // [ADR-0066 D4 / framework#3923] Capability gate — the UI half of the
       // dual-surface `requiredPermissions` contract.
@@ -1084,10 +1113,15 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
                 : null;
           if (src) {
             warnMissingRecordFields(a?.name, src, recordData);
-            const result = evalExpr(src, a?.name);
-            // On evaluation error (undefined), hide the action rather than
-            // risk surfacing a destructive button in the wrong state.
-            if (!result) return false;
+            // The predicate is handed over WHOLE, not as its `source`: a
+            // `{ dialect: 'cel' }` envelope is authoritative CEL and must not
+            // be flattened onto a dialect guess — the same rule the row kebab
+            // applies by passing `def.visible` through untouched.
+            // On a fault (`fallback: false`) the action hides rather than risk
+            // surfacing a destructive button in the wrong state.
+            if (!evalHeaderPredicate(v, `page:header action "${String(a?.name)}" visible`)) {
+              return false;
+            }
           }
         }
       }
@@ -1105,8 +1139,12 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
                 : null;
           if (src) {
             warnMissingRecordFields(a?.name, src, recordData);
-            const result = evalExpr(src, a?.name);
-            if (result) return false;
+            // `fallback: false` keeps `hidden`'s historical fail direction: a
+            // predicate that cannot be evaluated does NOT hide the action (the
+            // old `catch → undefined` read as "not hidden").
+            if (evalHeaderPredicate(h, `page:header action "${String(a?.name)}" hidden`)) {
+              return false;
+            }
           }
         }
       }
@@ -1162,7 +1200,10 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       const bp = b?.variant === 'primary' ? 0 : 1;
       return ap - bp; // equal → stable sort preserves registration order
     });
-  }, [rawHeaderActions, hostSystemActions, ctx?.data, predicateScope]);
+    // `evalHeaderPredicate` closes over `predicateScope` (via
+    // `headerPredicateScope`) and the object's fields, so it replaces the raw
+    // scope in this list rather than adding to it.
+  }, [rawHeaderActions, hostSystemActions, ctx?.data, evalHeaderPredicate]);
 
   // Dispatch shape for record-page header actions (objectui#3391) — the same
   // shape ObjectGrid row actions, RelatedRecordActionsBridge, and
@@ -1245,46 +1286,31 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       ...moreOnlyActions,
     ];
     const useOverflow = overflowActions.length > 0;
-    // Resolve a `disabled` predicate against the record. Mirrors the `visible`
-    // evaluation above — a boolean OR a CEL expression (`'record.status == …'`
-    // or the `{ dialect, source }` envelope). Without this a CEL `disabled`
-    // silently did nothing (only boolean was honoured).
-    // Same relation normalization the `visible` evaluation above applies, so a
-    // `disabled` predicate over a lookup reaches the same verdict (and the same
-    // one the server would) instead of throwing on `record.owner.id`.
-    const dRecord: any = toPredicateRecord(ctx?.data, headerObjectSchema?.fields);
-    const dScopeUser = (predicateScope as any)?.user;
-    const dEvaluator = new ExpressionEvaluator({
-      ...(dRecord && typeof dRecord === 'object' ? dRecord : {}),
-      record: dRecord,
-      data: dRecord,
-      // Same identity scope as the `visible` evaluation above so a
-      // user-gated `disabled` predicate resolves instead of faulting.
-      user: dScopeUser,
-      os: (predicateScope as any)?.os ?? { user: dScopeUser },
-      ctx: {
-        user: dScopeUser,
-        record: dRecord,
-        data: dRecord,
-        app: (predicateScope as any)?.app,
-        features: (predicateScope as any)?.features,
-      },
-    });
-    const resolveDisabled = (d: any): boolean => {
+    // Resolve a `disabled` predicate against the record — a boolean OR an
+    // expression (`'record.status == …'` or the `{ dialect, source }`
+    // envelope). Without this a CEL `disabled` silently did nothing (only
+    // boolean was honoured).
+    //
+    // Same entry, same bindings and same fail direction as `visible` above:
+    // ONE evaluator for this surface, so a `disabled` predicate cannot speak a
+    // different dialect from the `visible` predicate sitting next to it in the
+    // same action (objectui#3521). A faulting predicate still leaves the button
+    // enabled (`fallback: false`), it just says so once now.
+    const resolveDisabled = (d: any, actionName: unknown): boolean => {
       if (d === undefined || d === null) return false;
       if (typeof d === 'boolean') return d;
       const src = typeof d === 'string'
         ? d
         : (d && typeof d === 'object' && typeof (d as any).source === 'string' ? (d as any).source : undefined);
       if (!src) return false;
-      try { return !!dEvaluator.evaluateExpression(src); } catch { return false; }
+      return evalHeaderPredicate(d, `page:header action "${String(actionName)}" disabled`);
     };
     // A live inline-edit session disables actions the host flagged with
     // `disableDuringInlineEdit` (objectui#2572 item 4) — see `inlineEditing`
     // at the top of the renderer.
     const isActionDisabled = (action: any): boolean =>
       (inlineEditing && action?.disableDuringInlineEdit === true) ||
-      resolveDisabled(action?.disabled);
+      resolveDisabled(action?.disabled, action?.name ?? action?.id);
     const renderButton = (action: any, idx: number) => {
       const label = resolveLabel(action, idx);
       // `variant: 'primary'` is valid ActionSchema but not a Shadcn Button

--- a/packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx
+++ b/packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One predicate, one record, THREE surfaces, one verdict (objectui#3521).
+ *
+ * The acceptance criterion of #3521 is not "the header stops throwing on
+ * `.size()`" — it is that the same declaration reaches the same show/hide
+ * conclusion in the row kebab, the selection bar and the record page header.
+ * Teaching the legacy JS evaluator a few missing functions would have satisfied
+ * the symptom list and left two dialects in place; routing all three surfaces
+ * through `evalRowPredicate` is what makes them one.
+ *
+ * This file is the only place that can see all three: `plugin-grid` owns the row
+ * kebab (`isCustomRowActionVisible` — the single definition its items and its
+ * "⋮" guard share) and the selection bar (`partitionBulkRows`), and depends on
+ * `@object-ui/components`, which owns `page:header`.
+ *
+ * Scope of the claim, deliberately: these fixtures are all non-empty predicate
+ * STRINGS / envelopes, i.e. the dialect question. Boolean and empty `visible`
+ * are a separate, still-open divergence — the kebab renders a `visible: false`
+ * def (objectui#3758) while the header hides it — and pinning them here would
+ * read as blessing a difference this issue did not fix.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider, RecordContextProvider, PredicateScopeProvider } from '@object-ui/react';
+// Module-scope import for the registry side effect (AGENTS.md §测试纪律): the
+// `page:header` renderer must be registered before the first render, and a
+// dynamic import inside a hook would race the RTL assertion budget.
+import '@object-ui/components';
+import { isCustomRowActionVisible } from '../components/RowActionMenu';
+import { partitionBulkRows } from '../bulkEligibility';
+
+const OBJECT_FIELDS = {
+  f_status: { type: 'select' },
+  f_tags: { type: 'select', multiple: true },
+  f_multiselect: { type: 'select', multiple: true },
+  f_textarea: { type: 'textarea' },
+  f_date: { type: 'date' },
+  owner: { type: 'user' },
+};
+
+const OBJECT_SCHEMA = { name: 'showcase_field_zoo', label: 'Field Zoo', fields: OBJECT_FIELDS };
+
+/** What the host's `ExpressionProvider` feeds every one of the three surfaces. */
+const SCOPE = { user: { id: 'U1' }, os: { user: { id: 'U1' } } };
+
+const BASE_RECORD = {
+  id: 'r1',
+  f_status: 'open',
+  f_tags: ['alpha', 'beta'],
+  f_multiselect: ['red', 'blue'],
+  f_textarea: 'please handle, urgent',
+  f_date: '2020-01-01',
+  owner: { id: 'U1', name: 'Ada Lovelace' },
+};
+
+function PageHeader({ schema }: { schema: any }) {
+  const Component = ComponentRegistry.get('page:header');
+  if (!Component) throw new Error('page:header not registered');
+  // eslint-disable-next-line react-hooks/static-components -- registry component is stable
+  return <Component schema={schema} />;
+}
+
+/** Surface 3 — the record page header. */
+function headerVerdict(name: string, visible: unknown, record: any): boolean {
+  render(
+    <PredicateScopeProvider scope={SCOPE}>
+      <ActionProvider>
+        <RecordContextProvider
+          objectName="showcase_field_zoo"
+          recordId={record?.id ?? null}
+          data={record}
+          objectSchema={OBJECT_SCHEMA}
+        >
+          <PageHeader
+            schema={{
+              type: 'page:header',
+              title: 'Specimen',
+              actions: [
+                { name, locations: ['record_header'], label: 'Parity Action', type: 'api', visible },
+              ],
+            }}
+          />
+        </RecordContextProvider>
+      </ActionProvider>
+    </PredicateScopeProvider>,
+  );
+  return !!screen.queryByRole('button', { name: /Parity Action/i });
+}
+
+/** Surface 1 — the row kebab / inline row button. */
+function rowVerdict(name: string, visible: unknown, record: any): boolean {
+  return isCustomRowActionVisible({ name, visible } as any, record, SCOPE, OBJECT_FIELDS);
+}
+
+/** Surface 2 — the selection bar's per-record eligibility fold. */
+function bulkVerdict(name: string, visible: unknown, record: any): boolean {
+  const { eligible } = partitionBulkRows({ name, visible } as any, [record], {
+    scope: SCOPE,
+    fields: OBJECT_FIELDS,
+  });
+  return eligible.length === 1;
+}
+
+interface Case {
+  /** What the fixture demonstrates. */
+  what: string;
+  /** Unique action name — the warn-once registries are module-global. */
+  name: string;
+  visible: unknown;
+  record?: Record<string, unknown>;
+  expected: boolean;
+}
+
+const CASES: Case[] = [
+  // The three CEL-only families from the issue. Before #3521 the header threw
+  // on every one of them and fail-closed hid the button, so the header column
+  // read `false` while the other two read the real verdict.
+  { what: 'method call `.size()` — true', name: 'par_size_true', visible: 'record.f_tags.size() > 0', expected: true },
+  {
+    what: 'method call `.size()` — false',
+    name: 'par_size_false',
+    visible: 'record.f_tags.size() > 0',
+    record: { f_tags: [] },
+    expected: false,
+  },
+  {
+    what: 'method call `.contains()` — true',
+    name: 'par_contains_true',
+    visible: 'record.f_textarea.contains("urgent")',
+    expected: true,
+  },
+  { what: '`in` operator — true', name: 'par_in_true', visible: '"red" in record.f_multiselect', expected: true },
+  { what: '`in` operator — false', name: 'par_in_false', visible: '"green" in record.f_multiselect', expected: false },
+  {
+    what: 'stdlib `today()` — true',
+    name: 'par_today_true',
+    visible: 'record.f_date != null && record.f_date < today()',
+    expected: true,
+  },
+  {
+    what: 'stdlib `today()` — false',
+    name: 'par_today_false',
+    visible: 'record.f_date != null && record.f_date < today()',
+    record: { f_date: '2999-01-01' },
+    expected: false,
+  },
+  // A CEL construct inside the `{ dialect, source }` envelope — the shape the
+  // spec bridge produces for every authored predicate.
+  {
+    what: 'CEL envelope',
+    name: 'par_envelope',
+    visible: { dialect: 'cel', source: 'record.f_tags.size() > 1' },
+    expected: true,
+  },
+  // objectui#3501's binding half, now reached through the shared entry on all
+  // three surfaces: an EXPANDED relation compares as the foreign key, and an
+  // unexpanded one reaches the same verdict.
+  {
+    what: 'relation bound as its foreign key (expanded payload)',
+    name: 'par_relation_expanded',
+    visible: 'record.owner == os.user.id && record.f_tags.size() > 0',
+    expected: true,
+  },
+  {
+    what: 'relation bound as its foreign key (unexpanded payload)',
+    name: 'par_relation_unexpanded',
+    visible: 'record.owner == os.user.id && record.f_tags.size() > 0',
+    record: { owner: 'U1' },
+    expected: true,
+  },
+  {
+    what: 'relation on someone else’s record',
+    name: 'par_relation_other',
+    visible: 'record.owner == os.user.id',
+    record: { owner: { id: 'U2', name: 'Grace' } },
+    expected: false,
+  },
+  // Bare-field and `data.*` shorthands.
+  { what: 'bare field shorthand', name: 'par_bare', visible: 'f_status == "open"', expected: true },
+  { what: '`data.*` binding', name: 'par_data', visible: 'data.f_status == "open"', expected: true },
+  // The legacy fallback lives inside the shared entry, so parity covers it too.
+  {
+    what: 'legacy `${…}` template — true',
+    name: 'par_legacy_template',
+    visible: '${record.f_status === "open"}',
+    expected: true,
+  },
+  {
+    what: 'legacy `===` — false',
+    name: 'par_legacy_strict_eq',
+    visible: 'record.f_status === "closed"',
+    expected: false,
+  },
+  // A predicate that cannot be evaluated: fail-CLOSED on all three.
+  { what: 'faulting predicate fails closed', name: 'par_fault', visible: 'no_such_var_par == 1', expected: false },
+];
+
+describe('one predicate, one verdict on all three action surfaces (#3521)', () => {
+  it.each(CASES)('$what', ({ what, name, visible, record, expected }) => {
+    const row = { ...BASE_RECORD, ...(record ?? {}) };
+    const verdicts = {
+      rowKebab: rowVerdict(name, visible, row),
+      selectionBar: bulkVerdict(name, visible, row),
+      recordHeader: headerVerdict(name, visible, row),
+    };
+    expect(verdicts, what).toEqual({
+      rowKebab: expected,
+      selectionBar: expected,
+      recordHeader: expected,
+    });
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -99,11 +99,13 @@ const heavyDomTests = [
   'packages/components/src/__tests__/page-header-actions.test.tsx',
   'packages/components/src/__tests__/page-header-capability-gate.test.tsx',
   'packages/components/src/__tests__/page-header-lookup-predicate.test.tsx',
+  'packages/components/src/__tests__/page-header-predicate-dialect.test.tsx',
   'packages/components/src/__tests__/page-header-title.test.tsx',
   'packages/plugin-calendar/src/registration.test.tsx',
   'packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx',
   'packages/plugin-dashboard/src/__tests__/DashboardRenderer.filters.test.tsx',
   'packages/plugin-dashboard/src/__tests__/DashboardRenderer.legacyRetired.test.tsx',
+  'packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx',
   'packages/plugin-kanban/src/registration.test.tsx',
   'packages/plugin-kanban/src/KanbanRenderer.uncolumned.test.tsx',
 ];


### PR DESCRIPTION
Fixes #3521

## 问题:同一条元数据,两种方言

记录页头(`page:header`)的动作谓词一直交给 objectui 的遗留 JS 求值器 —— `packages/components/src/renderers/layout/containers.tsx` 里 `new ExpressionEvaluator(evalCtx)` + `evaluator.evaluateExpression(src)` 的两处(`visible`/`hidden` 的 `evalExpr`,以及 `disabled` 的 `dEvaluator`)。而行 kebab、批量选择栏、条件格式自 #1584 / ADR-0058 起统一走 `evalRowPredicate`:裸字符串即 CEL —— 这正是 `@objectstack/spec` 给 `ActionSchema.visible` 的类型,也是服务端执行的方言。

于是每一个 **CEL 独有构造**在列表里对、在详情页头抛错,而抛错是 fail-closed:按钮直接消失,页面上没有任何痕迹。

## 前后对照

| 谓词 | 修复前(页头) | 修复后(页头) | 行 kebab / 批量栏(一直如此) |
|---|---|---|---|
| `record.f_tags.size() > 0` | 抛错 → 静默隐藏 | 正常求值 | 正常求值 |
| `record.f_textarea.contains("x")` | 抛错 → 静默隐藏 | 正常求值 | 正常求值 |
| `'"red" in record.f_multiselect'` | 解析失败(position 6)→ 隐藏 | 正常求值 | 正常求值 |
| `record.f_date < today()` | `today is not a function` → 隐藏 | 正常求值 | 正常求值 |
| `{ dialect: 'cel', source: '…' }` 信封 | 拆出 `.source` 后仍按 JS 求值 | 权威 CEL | 权威 CEL |
| `${record.f_status === "open"}` | `evaluateExpression` 求不出模板 → 恒隐藏 | 经遗留引擎正确求值 | 经遗留引擎正确求值 |
| `record.f_status === "open"` | 遗留引擎(结论正确) | 遗留引擎(结论不变)+ deprecation 警告 | 同 |

改动落在同一处的**方言**这一半 —— #3501 刚落的**绑定**那一半(`toPredicateRecord`)完整保留:关系字段仍按服务端存的外键绑定,只是现在由 `evalRowPredicate` 的 `fields` 选项统一完成(`record.*` / 裸字段 / `data.*` 三路绑定都过同一次归一化),页头本地那份只留给引擎不构造的 `ctx.*` 命名空间。展示不受影响(标题仍读原始 `ctx.data`,关系字段照常显示名称)。

谓词现在**整体**传入 `evalRowPredicate`(不再拆出 `.source`),所以 `{ dialect: 'cel' }` 信封不会被拍平成方言猜测 —— 与行 kebab 直接传 `def.visible` 的规则逐字一致。

## 三面 parity 证据

`packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx`(plugin-grid 是唯一能同时看见三面的包:它拥有行 kebab 的 `isCustomRowActionVisible` 与批量栏的 `partitionBulkRows`,并依赖 `@object-ui/components` 拿到 `page:header`)。16 个 case(16 passed),每个 case 断言三面结论**逐字相等**:

```
✓ 'method call `.size()` — true' / '— false'
✓ 'method call `.contains()` — true'
✓ '`in` operator — true' / '— false'
✓ 'stdlib `today()` — true' / '— false'
✓ 'CEL envelope'
✓ 'relation bound as its foreign key (expanded payload)' / '(unexpanded payload)' / 'on someone else's record'
✓ 'bare field shorthand' / '`data.*` binding'
✓ 'legacy `${…}` template — true' / 'legacy `===` — false'
✓ 'faulting predicate fails closed'
```

**反向验证**(方向预先声明为「改动前红」):只回退 `containers.tsx`、保留两个新测试文件后重跑,20 个断言转红,红的正是页头列:

```
× 'method call `.size()` — true'   AssertionError: expected { rowKebab: true, …(2) } to deeply equal { rowKebab: true, …(2) }
× '`in` operator — true'           (同上,recordHeader: false)
× 'stdlib `today()` — true'
× 'CEL envelope'
× 'relation bound as its foreign key (expanded / unexpanded payload)'
× 'legacy `${…}` template — true'
× applies CEL to `hidden`, the mirror predicate      expected true to be false
× applies CEL to `disabled` …                        (按钮未 disabled)
```

两处如实记录,免得后人误读:

1. **CEL-false 的 case 在改动前也是绿的** —— 因为「抛错 → fail-closed 隐藏」和「求值为 false → 隐藏」看起来一样。所以每类构造都钉了**双向**,红的那一半才是证据。
2. **`${…}` 模板在改动前也是红的**:老页头调的是 `evaluateExpression`,它拿不到 `${…}` 模板,按钮恒隐藏。也就是说遗留方言这条路不但没回归,`${…}` 反而从「求不出」变成「经回退正确求值」。

## 遗留方言不回归

`packages/components/src/__tests__/page-header-predicate-dialect.test.tsx` 里单列一组:`${…}` 模板、裸 `===`、JS-only 方法 `.includes()`、遗留 `disabled`,全部仍走遗留引擎并保留既有 deprecation 警告(`isLegacyDialectSource` 兜底,未动 spec)。

fail-closed 与 warn-once 也逐条钉住:故障 `visible` 仍隐藏、故障 `disabled` 仍保持可用、故障 `hidden` 仍渲染(都是历史方向,由 `fallback: false` 保住)。

## 诊断措辞的一处变化(有意)

故障报告改由 `evalRowPredicate` 自己的 warn-once 机制写出,label 带 `page:header action "…" visible`,与行 kebab / 批量栏逐字同一措辞 —— 页头原来那条 `[page:header] … its predicate threw` 的本地实现随之删除。#2358 要的事实一件没少(隐藏的按钮报自己的名字、引用自己的谓词、只报一次),但引擎给的 reason 文本不再回显。页头本地只保留「谓词引用了 payload 里不存在的字段」这一条 —— 那是引擎看不到的**成因**(服务端会把 `hidden: true` 字段从详情 payload 里剥掉)。

因此 `page-header-actions.test.tsx` 里两条断言按新事实更新:措辞从 `predicate threw` 改为 `failed to evaluate`(仍断言含 `page:header`、动作名、谓词原文、去重一次);trap 3 从「一共一条警告」改为「成因一条 + 判决一条,各一次」—— 遗留引擎对缺席键返回 `undefined` 不抛错,所以以前只有第一条,CEL 对缺席键是 fault,判决那条是新增的信号。

## 验证

```
pnpm vitest run packages/components packages/plugin-detail packages/react   → 182 files, 1583 passed
pnpm vitest run packages/plugin-grid packages/core/src/evaluator            →  65 files,  784 passed
pnpm vitest run packages/app-shell/src/views                               → 184 files, 1691 passed, 1 skipped
pnpm --filter @object-ui/components type-check                             → tsc --noEmit + typetests 通过
pnpm --filter @object-ui/plugin-grid type-check                            → 通过
eslint(4 个改动文件)                                                      → 0 errors(仅既有 no-explicit-any warning)
node scripts/check-control-bytes.mjs                                       → OK(3721 tracked files)
新增两个文件单跑                                                            → parity 16 passed / dialect 26 passed
```

消费半径已按调用方清扫:`page:header` 的渲染方(components 自身测试、app-shell 的 `RecordDetailView.*`、plugin-detail 的 header 合成)全跑过;仓内没有别的 `record_header` 动作谓词夹具使用遗留语法(已 grep 确认)。

两个新测试文件按约定登记进 `vitest.config.mts` 的 `heavyDomTests`(都经 ComponentRegistry 渲染)。

⛔ 未扩进 objectstack#5970(spec 侧 `ActionSchema.visible` 统一):`isLegacyDialectSource` 回退在不动 spec 的前提下完整保住了,本单不需要 spec 变更。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_