### PR TITLE
fix(fields): 退役 capability-multiselect widget 名 —— 删注册面与最后一个 hint 消费方,组件保留 (#3308)

### DIFF
--- a/.changeset/capability-multiselect-widget-retired-3308.md
+++ b/.changeset/capability-multiselect-widget-retired-3308.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/fields": minor
+"@object-ui/plugin-detail": minor
+"@object-ui/components": minor
+"@object-ui/plugin-form": minor
+---
+
+Retire the `capability-multiselect` field widget name, which existed only on the docs-site registration path and which nothing ever stamped (objectui#3308, ADR-0049 enforce-or-remove)
+
+`field:capability-multiselect` was registered by `registerFields()` and only there. That function's sole caller is the docs site, so the key never existed on the live path (`registerAllFields()`, run at module import, iterates `fieldWidgetMap` — which never listed it). A field authored with `widget: 'capability-multiselect'` therefore resolved to nothing in every real application, while the comment above the registration described it as usable from a record form: a code comment promising a capability that does not exist, which is the worst direction for a metadata renderer AI-authored apps read as authority.
+
+Nothing stamped the hint either. ADR-0056 P1 stamps `permission-facet-link` on all six `sys_permission_set` facets — `system_permissions` included — through the single `ObjectStackAdapter.getObjectSchema` choke point, and P2 put the capability editor in Studio. The widget name was a leftover from an intermediate iteration of that rollout.
+
+Removed, with a tombstone at each site:
+
+- `@object-ui/fields` — the `field:capability-multiselect` registration and the comment that advertised it. **Breaking in name only**: the key was unreachable outside the docs site, so no application could have resolved it. A field still carrying the hint now degrades to its declared `type` renderer, the defined behavior for an unregistered widget.
+- `@object-ui/plugin-detail` — `InlineFieldInput`'s `widget === 'capability-multiselect'` branch, the hint's last honoring surface. Leaving one consumer for a name no producer emits and no form resolves is the same declared-vs-enforced split, inverted. The sibling `permission-facet-link` branch is untouched and pinned.
+- `@object-ui/components` — the dead `capability-multiselect` entry in the form renderer's `DATA_SOURCE_FIELD_TYPES` set, which could never match a resolvable widget.
+- `@object-ui/plugin-form` — a comment naming `capability-multiselect` as the widget stamped onto `sys_permission_set.system_permissions`; it names `permission-facet-link` now, which is what is actually stamped.
+
+`CapabilityMultiSelectField` itself is **unchanged and still exported**: Studio's `PermissionMatrixEditor` imports and renders it directly, which is ADR-0056 P2's design. Only the widget name is retired — the component is not a registry field widget and its doc comment now says so.
+
+`registerFields()` is also **kept**, with its `@deprecated Use registerAllFields() instead` note corrected. The two are not interchangeable: it registers `createFieldRenderer(widget)`, which synthesizes the label, description and the local `value`/`onChange` state that lets a bare field node (`{ type: 'currency', label: 'Amount' }`) render standalone in the docs demos. Retiring it needs a decision about where that demo chrome goes; the note now records that instead of implying a drop-in replacement.

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -231,7 +231,11 @@ const resolveWidgetType = (f: any): string => f?.widget || f?.field?.widget || f
 
 const BUILTIN_FIELD_TYPES = new Set(['input', 'textarea', 'checkbox', 'switch', 'select']);
 const DATA_SOURCE_FIELD_TYPES = new Set([
-  'lookup', 'master_detail', 'tree', 'capability-multiselect',
+  // `capability-multiselect` was listed here until objectui#3308 retired the
+  // widget name (ADR-0049 enforce-or-remove): no producer stamped the hint and
+  // `field:capability-multiselect` was never registered on the live path, so the
+  // entry could never match a resolvable widget.
+  'lookup', 'master_detail', 'tree',
   // Widget-hint pickers that resolve records / object catalogs and read sibling
   // field values — they need both `dataSource` and `dependentValues` threaded.
   'object-ref', 'filter-condition', 'recipient-picker',

--- a/packages/fields/src/__tests__/capability-multiselect-retired.test.ts
+++ b/packages/fields/src/__tests__/capability-multiselect-retired.test.ts
@@ -1,0 +1,91 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — `field:capability-multiselect` (objectui#3308, ADR-0049
+ * enforce-or-remove).
+ *
+ * The key was registered on ONE path only: `registerFields()`, whose sole caller
+ * is the docs site. The live path (`registerAllFields()`, run at module import)
+ * never had it, because `fieldWidgetMap` never listed it — so a field authored
+ * with `widget: 'capability-multiselect'` resolved to nothing in every real app
+ * while a code comment advertised it as usable from a record form. Nothing
+ * stamped the hint either: ADR-0056 P1 stamps `permission-facet-link` on all six
+ * `sys_permission_set` facets (including `system_permissions`), and P2 put the
+ * capability editor in Studio.
+ *
+ * What this pins:
+ *   1. the key is absent after importing the package (the live path), AND
+ *   2. absent after `registerFields()` too — the retirement covers the docs
+ *      path, which is where the key actually used to come from. Asserting only
+ *      (1) would have passed on `origin/main` and pinned nothing.
+ *   3. `registerFields()` still registers every OTHER key it used to — the
+ *      retirement subtracts exactly one name, it does not thin the docs path.
+ *
+ * `CapabilityMultiSelectField` the component is deliberately NOT asserted gone:
+ * Studio's `PermissionMatrixEditor` imports and renders it directly, which is
+ * ADR-0056 P2's design. Only the widget NAME is retired.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+
+// Importing the entry runs `registerAllFields()` at module load — the live path.
+import { registerFields, registerAllFields, FORM_FIELD_TYPES } from '../index';
+
+const RETIRED = 'capability-multiselect';
+
+/**
+ * Every key `registerFields()` registered before the retirement, minus the
+ * retired one. Spelled out rather than derived so a future edit that silently
+ * drops a docs-path registration fails here instead of passing vacuously.
+ */
+const DOCS_PATH_KEYS = [
+  'text', 'textarea', 'number', 'boolean', 'select', 'date', 'datetime', 'time',
+  'email', 'phone', 'url',
+  'currency', 'percent', 'password', 'markdown', 'html', 'lookup', 'master_detail',
+  'file', 'image', 'location',
+  'formula', 'summary', 'auto_number',
+  'user', 'owner',
+  'object', 'vector', 'grid',
+  'color', 'slider', 'rating', 'code', 'avatar', 'address', 'geolocation',
+  'signature', 'qrcode',
+] as const;
+
+describe('capability-multiselect widget retirement (objectui#3308)', () => {
+  it('is absent on the live registerAllFields() path', () => {
+    registerAllFields();
+    expect(ComponentRegistry.get(`field:${RETIRED}`)).toBeUndefined();
+    expect(ComponentRegistry.get(RETIRED)).toBeUndefined();
+  });
+
+  it('is not in fieldWidgetMap, so no bare field type can reach it either', () => {
+    expect(FORM_FIELD_TYPES).not.toContain(RETIRED);
+  });
+
+  describe('after the docs-site registerFields() path runs', () => {
+    beforeAll(() => {
+      registerFields();
+    });
+
+    it('still does not register the retired key', () => {
+      expect(ComponentRegistry.get(`field:${RETIRED}`)).toBeUndefined();
+      expect(ComponentRegistry.get(RETIRED)).toBeUndefined();
+    });
+
+    it('registers every other docs-path key (retirement subtracts exactly one)', () => {
+      for (const key of DOCS_PATH_KEYS) {
+        expect(
+          ComponentRegistry.get(`field:${key}`),
+          `field:${key} must survive the retirement`,
+        ).toBeTruthy();
+      }
+      expect(DOCS_PATH_KEYS).toHaveLength(38);
+    });
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -297,7 +297,6 @@ import { CurrencyField } from './widgets/CurrencyField';
 import { TextAreaField } from './widgets/TextAreaField';
 import { RichTextField } from './widgets/RichTextField';
 import { LookupField } from './widgets/LookupField';
-import { CapabilityMultiSelectField } from './widgets/CapabilityMultiSelectField';
 import { DateTimeField } from './widgets/DateTimeField';
 import { TimeField } from './widgets/TimeField';
 import { PercentField } from './widgets/PercentField';
@@ -2060,7 +2059,11 @@ export function evaluateCondition(condition: any, formData: any): boolean {
   return true;
 }
 
-// Create wrapper renderers for field widgets to work with ComponentDemo
+// Create wrapper renderers for field widgets to work with ComponentDemo.
+// Docs-site only — it synthesizes the label/description chrome AND the local
+// value/onChange state a bare field node has no host for. See the note on
+// `registerFields()` (its only caller) for why the live app path does NOT use
+// this and why the two are not interchangeable.
 function createFieldRenderer(FieldWidget: React.ComponentType<any>) {
   const FieldRenderer: React.FC<any> = ({ schema, className, value: initialValue, ...props }) => {
     const [value, setValue] = React.useState(initialValue ?? schema?.value ?? '');
@@ -2331,8 +2334,34 @@ export function registerAllFields(): void {
 }
 
 /**
- * Legacy function - kept for backward compatibility
- * @deprecated Use registerAllFields() instead
+ * Register every field widget wrapped in the **docs-demo** renderer
+ * ({@link createFieldRenderer}) instead of the plain registration seam.
+ *
+ * ⚠️ This is NOT an interchangeable alias of {@link registerAllFields}, despite
+ * what its former `@deprecated Use registerAllFields() instead` note implied
+ * (objectui#3308 was dispatched on that reading). The two differ in what the
+ * registry entry *is*:
+ *
+ *  - `registerAllFields()` — the live path every app uses. Registers
+ *    `withFieldCarrier(lazy(widget))`: the bare widget, which renders a control
+ *    and nothing else. Label / description / value state belong to the host
+ *    (the form renderer, `FieldEditWidget`, an action dialog).
+ *  - `registerFields()` — registers `createFieldRenderer(widget)`, which ALSO
+ *    synthesizes the `<label>`, the description, and a local `useState` +
+ *    `onChange`. That chrome is what makes a **bare field node** (`{ type:
+ *    'currency', label: 'Amount' }`) renderable standalone by `SchemaRenderer`,
+ *    which is exactly how the docs site demos every `content/docs/fields/*.mdx`
+ *    example — `InteractiveDemo` passes no `value`/`onChange` of its own.
+ *
+ * Hence its only caller, `apps/site` (the docs site), cannot simply switch to
+ * `registerAllFields()`: `FieldWidgetComponentProps.onChange` is REQUIRED and
+ * widgets call it unguarded, so the demo inputs would go inert and throw
+ * `TypeError: onChange is not a function` per keystroke.
+ *
+ * Retiring this second path therefore needs a decision on where the demo chrome
+ * goes (docs-site-owned wrapper vs. form-hosted catalog examples) — tracked on
+ * objectui#3308. Until then: **apps use `registerAllFields()`**; this function
+ * is the docs-demo adapter and nothing else should call it.
  */
 export function registerFields() {
   // Basic fields - wrapped for documentation compatibility
@@ -2377,12 +2406,18 @@ export function registerFields() {
   // display widget remains the default for { type: 'html', content }.
   ComponentRegistry.register('html', createFieldRenderer(RichTextField), { namespace: 'field', skipFallback: true });
   ComponentRegistry.register('lookup', createFieldRenderer(LookupField), { namespace: 'field' });
-  // Capability multi-select (ADR-0056 P2) — reached only via the field
-  // `widget: 'capability-multiselect'` hint (see MetadataProvider), never a bare
-  // field type. Registered WITHOUT createFieldRenderer: it is a fully-controlled
-  // widget (value/onChange from RHF), so the wrapper's extra label + local value
-  // buffer would only duplicate the form's FormLabel and desync the value.
-  ComponentRegistry.register('capability-multiselect', withFieldCarrier(CapabilityMultiSelectField), { namespace: 'field', skipFallback: true });
+  // TOMBSTONE (objectui#3308, ADR-0049 enforce-or-remove) — `capability-multiselect`
+  // was registered here, and ONLY here, as `field:capability-multiselect`. Since
+  // this function is called by the docs site alone, the key never existed on the
+  // live `registerAllFields()` path, so a field authored with
+  // `widget: 'capability-multiselect'` resolved to nothing in every real app
+  // while the comment here advertised it as usable from a record form. Nothing
+  // stamped that hint either: ADR-0056 P1 stamps `permission-facet-link` on all
+  // six `sys_permission_set` facets (`data-objectstack/src/index.ts`
+  // applyFieldWidgetOverrides) and P2 put the capability editor in Studio. The
+  // widget NAME is retired; do not re-add it. `CapabilityMultiSelectField`
+  // itself lives on as a plain component — Studio's `PermissionMatrixEditor`
+  // imports and renders it directly, which is ADR-0056 P2's design.
   // master_detail = child-side FK lookup (single value, typically required). See
   // fieldWidgetMap above for rationale.
   ComponentRegistry.register('master_detail', createFieldRenderer(LookupField), { namespace: 'field' });

--- a/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
+++ b/packages/fields/src/widgets/CapabilityMultiSelectField.tsx
@@ -18,9 +18,18 @@ import { useFieldTranslation } from './useFieldTranslation';
  * labelled, with the capability description on hover — while round-tripping the
  * stored value **byte-for-byte** as a JSON string of names.
  *
- * Reached via the field `widget: 'capability-multiselect'` hint (stamped onto
- * the object metadata in MetadataProvider), registered in the field registry as
- * `field:capability-multiselect`.
+ * ## Not a registry field widget (objectui#3308)
+ *
+ * This is a plain component, imported directly by its host — Studio's
+ * `PermissionMatrixEditor` (`packages/app-shell`), which is where ADR-0056 P2
+ * put the capability editor. It is deliberately NOT reachable through the field
+ * registry, and `widget: 'capability-multiselect'` is a **retired** hint: the
+ * key only ever existed on the docs-site-only `registerFields()` path, nothing
+ * ever stamped the hint (ADR-0056 P1 stamps `permission-facet-link` on all six
+ * `sys_permission_set` facets), and it was removed under ADR-0049
+ * enforce-or-remove. Do not re-register it without re-deciding ADR-0056 P2 —
+ * a field carrying that hint now degrades to its declared `type` renderer,
+ * which is the defined behavior for an unregistered widget.
  */
 
 interface Capability {

--- a/packages/plugin-detail/src/InlineFieldInput.tsx
+++ b/packages/plugin-detail/src/InlineFieldInput.tsx
@@ -15,7 +15,6 @@ import {
   NumberField,
   CurrencyField,
   PercentField,
-  CapabilityMultiSelectField,
   ImageField,
   FileField,
   AvatarField,
@@ -77,11 +76,10 @@ export interface InlineFieldInputProps {
  * `DetailSection` so any record-level surface — the details body AND the
  * highlights strip (objectui#2407) — renders an identical editor. Covers every
  * widget the detail body handles: `SelectField`, `BooleanField`, `LookupField`,
- * `UserField`, `CapabilityMultiSelectField` (#2403), the `permission-facet-link`
- * read-only facet (#2403), the numeric widgets (`NumberField` /
- * `CurrencyField` / `PercentField`, objectui#2572), and the plain date/text
- * input (with ISO date coercion + object-value guarding so an unexpanded
- * reference never leaks "[object Object]").
+ * `UserField`, the `permission-facet-link` read-only facet (#2403), the numeric
+ * widgets (`NumberField` / `CurrencyField` / `PercentField`, objectui#2572), and
+ * the plain date/text input (with ISO date coercion + object-value guarding so
+ * an unexpanded reference never leaks "[object Object]").
  *
  * Editability GATING (computed types, `readonly`, system fields, object
  * lifecycle) stays with the host — this component only renders the editor once
@@ -95,25 +93,24 @@ export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
   autoFocus,
 }) => {
   const editType = field.type;
-  // Per-field widget override (ADR-0056 P2) — honor a `widget` hint before the
-  // type switch so a structured editor (e.g. the capability multi-select on
-  // sys_permission_set.system_permissions) replaces the raw type in inline
-  // edit too, matching the form path.
+  // Per-field widget override (ADR-0056 P1) — honor a `widget` hint before the
+  // type switch so a structured editor replaces the raw type in inline edit too,
+  // matching the form path.
+  //
+  // TOMBSTONE (objectui#3308): a `capability-multiselect` branch used to sit
+  // below, rendering `CapabilityMultiSelectField` for that hint. The hint was
+  // retired under ADR-0049 enforce-or-remove — nothing ever stamped it (P1
+  // stamps `permission-facet-link` on all six `sys_permission_set` facets,
+  // including `system_permissions`) and its registry key only existed on the
+  // docs-site-only `registerFields()` path, so the form path never honored it.
+  // Keeping the branch would have left one surviving special case for a name no
+  // producer emits and no form resolves. The component itself is unaffected —
+  // Studio's `PermissionMatrixEditor` renders it directly (P2).
   const editWidget = (field as any).widget;
   // Permission facets are designed in Studio, never edited in Setup — even in
   // section edit mode they stay a read-only summary + deep-link.
   if (editWidget === 'permission-facet-link') {
     return <PermissionFacetLink value={value} field={field as any} />;
-  }
-  if (editWidget === 'capability-multiselect') {
-    return (
-      <CapabilityMultiSelectField
-        value={value}
-        onChange={(v: any) => onChange(v)}
-        field={field as any}
-        dataSource={dataSource}
-      />
-    );
   }
   // Picklist → real Select widget so users see localized option labels and
   // can't free-type invalid values. A `multiple` picklist (spec canon: `select`

--- a/packages/plugin-detail/src/__tests__/InlineFieldInput.capabilityWidgetRetired.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineFieldInput.capabilityWidgetRetired.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — the `capability-multiselect` widget hint (objectui#3308,
+ * ADR-0049 enforce-or-remove).
+ *
+ * `InlineFieldInput` used to special-case `field.widget ===
+ * 'capability-multiselect'` and render `CapabilityMultiSelectField`. It was the
+ * hint's ONLY surviving consumer: no producer stamps it (ADR-0056 P1 stamps
+ * `permission-facet-link` on all six `sys_permission_set` facets, including
+ * `system_permissions`), and `field:capability-multiselect` was registered only
+ * on the docs-site-only `registerFields()` path, so the form path never resolved
+ * it. Keeping one honoring surface for a name nothing emits and no form resolves
+ * is the declared-vs-enforced split #3308 was filed about, inverted.
+ *
+ * Contract now: an unregistered/retired widget hint degrades to the field's
+ * declared `type` renderer — the same behavior every other unknown hint gets.
+ *
+ * Reverse-verified: restoring the deleted branch turns this file red (the picker
+ * renders its "Loading capabilities…" placeholder and no text input carries the
+ * stored JSON).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { InlineFieldInput } from '../InlineFieldInput';
+
+// The retired hint, exactly as stored metadata could still spell it.
+const RETIRED_HINT_FIELD = {
+  name: 'system_permissions',
+  type: 'textarea',
+  widget: 'capability-multiselect',
+} as any;
+
+const STORED = '["setup.access","studio.access"]';
+
+describe('InlineFieldInput — retired capability-multiselect hint (objectui#3308)', () => {
+  it('degrades to the declared type renderer instead of the capability picker', () => {
+    render(
+      <InlineFieldInput field={RETIRED_HINT_FIELD} value={STORED} onChange={vi.fn()} />,
+    );
+
+    // The picker is gone: its unconditional empty-state placeholder must not
+    // appear, and neither must the toggle chips it renders (role=button).
+    expect(screen.queryByText(/Loading capabilities/i)).toBeNull();
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+
+    // The value round-trips through the plain type renderer instead.
+    expect(screen.getByDisplayValue(STORED)).toBeInTheDocument();
+  });
+
+  it('still honors permission-facet-link, the hint ADR-0056 P1 actually stamps', () => {
+    // Guards the removal from over-reaching: the sibling branch above the
+    // deleted one is the live one and must keep working.
+    render(
+      <InlineFieldInput
+        field={{ name: 'system_permissions', type: 'textarea', widget: 'permission-facet-link' } as any}
+        value={STORED}
+        onChange={vi.fn()}
+      />,
+    );
+    // The facet link is read-only — it must NOT hand back an editable input.
+    expect(screen.queryByDisplayValue(STORED)).toBeNull();
+  });
+});

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -582,9 +582,9 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
           group: field.group,
           // Important: Pass the original field metadata so widgets can access properties like precision, currency, etc.
           field: field,
-          // A per-field widget override (e.g. capability-multiselect stamped onto
-          // sys_permission_set.system_permissions by MetadataProvider, ADR-0056
-          // P2). `form.tsx` resolves `widget || type`, so this makes the
+          // A per-field widget override (e.g. permission-facet-link stamped onto
+          // the six sys_permission_set facets by `ObjectStackAdapter.getObjectSchema`,
+          // ADR-0056 P1). `form.tsx` resolves `widget || type`, so this makes the
           // auto-generated (no-form-view) form honor the override just like the
           // authored-section path already does (sectionFields.ts).
           widget: (field as any).widget,


### PR DESCRIPTION
Fixes #3308

按 2026-08-06 维护者裁决(**该死 —— 删除**,ADR-0049 enforce-or-remove)落地。核验后裁决三条里**第 1、3 条按裁决执行**,**第 2 条的前提被证伪**,原因与证据见下,未强推。

## 裁决逐条落实

### 1. 删 `capability-multiselect` 组件与承诺不存在能力的注释 —— 已删,但删的是 widget 名而非组件文件

前提复核(`origin/main` = `00b9451d8`)确认 issue 的注册表事实成立:`field:capability-multiselect` 只由 `registerFields()` 注册,该函数唯一调用方是文档站,所以键从未存在于活路径(`registerAllFields()`,模块加载即执行,遍历 `fieldWidgetMap` —— 表里没有它)。

但引用面扫描发现 issue 未列的两个**直接 import** 消费方,组件本身并没有死:

- `packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx:72,788` —— Studio 权限矩阵编辑器直接 import 并渲染它(不经注册表),而且在活跃维护中(就地注释引用 objectui#3332 的 chip wall 高度修复)。这正是 **ADR-0056 P2** 的设计:"能力编辑器本身位于 Studio"。
- `packages/plugin-detail/src/InlineFieldInput.tsx:108` —— 也直接 import,在 `widget === 'capability-multiselect'` 分支里渲染。

所以字面执行"删组件"会打掉一个活的 Studio 编辑器。真正死的是 **widget 名**:注册面 + hint 分支。裁决意图(退役这个不可达的 field widget)完整保留,删除面为:

| 位置 | 删了什么 |
|---|---|
| `packages/fields/src/index.tsx` | `field:capability-multiselect` 注册 + 那段承诺注释 + 已无用的静态 import |
| `packages/plugin-detail/src/InlineFieldInput.tsx` | `widget === 'capability-multiselect'` 分支(该 hint 最后一个 honoring surface)+ import |
| `packages/components/src/renderers/form/form.tsx:234` | `DATA_SOURCE_FIELD_TYPES` 里的死条目(永远匹配不到可解析 widget) |
| `packages/plugin-form/src/ObjectForm.tsx:585` | 注释里把它说成 stamp 到 `system_permissions` —— 改为实际 stamp 的 `permission-facet-link` |

`CapabilityMultiSelectField` 组件不动、仍从 `@object-ui/fields` 导出,doc 注释改为如实写明"它不是注册表 field widget"。

**没有任何生产方 stamp 过这个 hint** —— 这条是删 `InlineFieldInput` 分支的依据。`packages/data-objectstack/src/index.ts:2486-2501`(`applyFieldWidgetOverrides`,ADR-0056 P1 的单一 choke point)给 `sys_permission_set` 六个 facet(含 `system_permissions`)stamp 的是 `permission-facet-link`。全仓 + framework 仓零命中 stamp 处。留一个特例给无人 emit、无表单能解析的名字,正是本 issue 要消灭的声明/实际背离,只是方向相反。

### 2. 收敛 `registerFields()` 废弃路径、文档站改走 `registerAllFields()` —— 前提证伪,未执行

裁决(与 issue)把 `registerFields()` 当成"废弃的重复注册路径"。它不是。它是**文档站的 demo host adapter**,以注册表覆写的形式实现:

- `registerAllFields()` 注册 `withFieldCarrier(lazy(widget))` —— 裸 widget,只渲染控件。label / description / value 状态归 host(表单渲染器、`FieldEditWidget`、action dialog)。
- `registerFields()` 注册 `createFieldRenderer(widget)` —— **额外**合成 label、description 和本地 `useState` + `onChange`。

正是这套 chrome 让**裸字段节点**能被 `SchemaRenderer` 独立渲染,而这就是文档站 demo 每一个 `content/docs/fields/*.mdx` 例子的方式:`apps/site/app/components/InteractiveDemo.tsx` 只 `render` 一个 `SchemaRenderer`,自己不传 `value`/`onChange`;`examples/schema-catalog` 里的例子形如 `{ "type": "currency", "name": "amount", "label": "Amount", "placeholder": "$0.00" }`。

实测(一次性 probe,未入 commit):按 demo 路径渲染 `withFieldCarrier(CurrencyField)`,只给 schema 派生的 props 而不给 `value`/`onChange`——

```
PROBE onChange throw = null
stderr: TypeError: onChange is not a function
    at onChange (packages/fields/src/widgets/CurrencyField.tsx:79:11)
```

`FieldWidgetComponentProps.onChange` 是**必填**(`widgets/types.ts:122`)且 widget 无保护地调用它。方向值得如实记录:错误确实抛出,但发生在 React 事件系统内部,`fireEvent` 不会同步 rethrow —— 浏览器里的表现是 **demo 输入框失灵 + 每次击键一条未捕获错误**,而非组件崩溃边界。同时 label chrome 消失(`queryByText('Amount')` 为 null)。受影响面是 `content/docs/fields/` 下 26 个字段文档页里走裸键的约 24 个类别。

所以"文档站改走 `registerAllFields()`"不是一次等价替换,它需要先决定 **demo chrome 归谁**。这一条留给维护者,本 PR 不猜。作为替代,本 PR 把引发误读的那句声明就地改对:`@deprecated Use registerAllFields() instead` 改写为如实说明两者不可互换、为什么文档站不能直接切、以及退役门槛,并注明 apps 一律用 `registerAllFields()`。选项与建议见文末。

裁决里预设的 semver 冲突点因此**没有发生**:`registerFields` 导出保留,没有公开导出被删,`check-changeset-no-major.mjs` 无需对抗。`apps/site` 一行未改(`ObjectUIProvider.tsx` 未动),emitted dts 里 `export declare function registerFields(): void;` 仍在,故文档站编译面无风险。

### 3. 存量引用留 tombstone —— 已留

四处删除点各有一段 tombstone 注释,写明:键曾在哪里、为什么死、谁 stamp 的是什么、组件为何还活着、以及"不要重新加回来"。CHANGELOG 里的历史提及按退役纪律原样保留,未改。

## 引用面扫描

`origin/main` = `00b9451d8`。词界扫描防 `registerAllFields` 子串误命中。

`git grep -n "capability-multiselect" origin/main` —— 11 命中:4 处历史 CHANGELOG(不动)、1 处注册 + 1 处注释(删)、1 处组件 doc 注释(改写)、`plugin-detail` hint 分支(删)、`components` 死条目(删)、`plugin-form` 注释(改)。

`git grep -nw "registerFields" origin/main` —— 3 命中:定义 1 处 + `apps/site/app/components/ObjectUIProvider.tsx:5,13`。issue 所列的消费方完整。

跨仓:`git -C /home/user/objectstack grep -nw "capability-multiselect" origin/main` 唯一命中是 `packages/spec/liveness/field.json:109` 的一条 liveness note,把该 widget 记作 `sys_permission_set` 在用 —— 那条记录已陈旧(实际 stamp 的是 `permission-facet-link`)。属 framework 仓文档面、非本 PR 范围,已作为 observation-class finding 记入报告交 PM。

改后 `git grep --untracked -n "capability-multiselect"` 仅剩 tombstone / pin test / changeset / 历史 CHANGELOG。

## semver 与 changeset 依据

**minor**,四个包(`fields` / `plugin-detail` / `components` / `plugin-form`)。依据 AGENTS.md「版本号策略」:objectui 的 major 跟随 `@objectstack` 节奏,fixed 组(39 包)任一 `major` 都会把全组推上去,**因此自身破坏性变更也标 `minor`,破坏语义写在正文** —— 这是仓内明写的约定,不是偷偷降档。`scripts/check-changeset-no-major.mjs` 已跑,通过。

破坏性实际范围:仅"名字层面"。`field:capability-multiselect` 在文档站以外不可达,没有应用能解析到它;仍带该 hint 的字段现在退化为其声明的 `type` 渲染器,即未注册 widget 的既定行为(framework liveness note 原文:"Degrades to the `type` renderer when the widget is unregistered")。没有公开导出被删。

## 验证证据

引用面扫描见上。测试与门禁:

```
pnpm vitest run packages/fields                       -> 65 files | 978 tests passed
pnpm vitest run packages/plugin-detail packages/plugin-form
                                                      -> 88 files | 785 tests passed
pnpm vitest run packages/components                   -> 95 files | 698 tests passed
pnpm vitest run packages/app-shell/.../PermissionMatrixEditor
                                                      ->  7 files |  25 tests passed
```

`type-check`(`fields` / `plugin-detail` / `plugin-form` / `components`)全 `Done`;`app-shell` `type-check` 全绿(它是组件的直接消费方)。四包 `build` 全 `Done`。四包 `lint` **0 errors**(warnings 是仓库既有基线)。

首轮 `plugin-form` type-check 报 9 条 TS2307 `Cannot find module '@object-ui/fields'` —— 新 worktree 未建依赖产物所致(AGENTS.md §9 陷阱),`pnpm --filter '@object-ui/plugin-form^...' --filter '@object-ui/plugin-detail^...' build` 后全绿,非本改动引起。

注册行为自证(`packages/fields/src/__tests__/capability-multiselect-retired.test.ts`):`import '@object-ui/fields'` 后 `ComponentRegistry.get('field:capability-multiselect')` 与裸键均为 `undefined`;**且** `registerFields()`(文档站路径)跑完后仍为 `undefined`;同时逐条断言该路径其余 **38** 个键全部仍注册 —— 退役恰好减一个名字,没有顺手削薄文档站路径。

**反向自证**:把删掉的两处肢体加回,两个 pin 按预期变红 —— fields pin 第 77 行拿到 `[Function FieldCarrierAdapter]`(期望 `undefined`),`InlineFieldInput` pin 渲染出 2 个 chip button(期望 0)。值得单独记一笔:fields pin 的**第一条**(只看活路径)在肢体加回后**仍然绿** —— 只钉活路径的测试在 `origin/main` 上就会通过、什么也钉不住,所以 pin 显式覆盖了文档站路径。变异未入 commit。

字节纪律:`pnpm check:control-bytes` OK(3718 tracked text files);改动文件另做一次 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零控制字节。

`content/docs/releases/**` 未触。

## 待裁决:`registerFields()` 的最终归属(裁决第 2 条)

三个选项,按「本项目长期健康」与「让 AI 写的元数据难写错」两轴评估:

- **A. demo adapter 下沉到 `apps/site`** —— 从 `@object-ui/fields` 删掉 `registerFields` + `createFieldRenderer`,文档站自己拥有一个 demo 包装器。库侧只剩一条路,文档不坏。代价:第二个包装器仍然存在(只是换了归属),文档 demo 仍渲染出真实应用不会产生的样子,**"文档是错误权威"这个失效类没被消掉** —— 而这恰是本 issue 的病根。
- **B. 把 `fields-*` catalog 例子改成表单托管**(`{ "type": "form", "fields": [...] }`),两个包装器都删掉。文档从此展示真实应用的渲染结果(真表单渲染器拥有 label 与状态)。代价:约 60 个 catalog JSON + 26 个文档页要重验,PR 体量大,且**改变了文档教什么**,应当是维护者决定并单开一单。
- **C. 保留现状,只把声明改对**(本 PR 已做的部分)。最省;但两路并存会继续长出漂移,即 #3308 发现的东西。

**建议 B,单开一单;不建议 A。** 两轴同向:长期健康上,A 是 patch —— 它把"文档 demo 与真实渲染不一致"这个二元契约原样保留下来,只换了持有者;B 消灭它。对"让 AI 写的元数据难写错"这一轴,差别更大:模型读文档看到裸字段节点渲染成带 label 的输入框,就会生成同样的裸节点,而在真实应用里它渲染不出 label、也没有 host 提供 `onChange` —— 文档正在充当一份错误权威,与本 issue 抱怨的注释是同一类缺陷。B 让文档只能展示真实可行的写法。本 PR 已按 C 把误导性声明改对,作为 B 落地前的安全垫。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_