### PR TITLE
fix(plugin-detail): record:highlights 的 fields 声明补上 readonly,让 manifest 能被作者读到 (#3407)

### DIFF
--- a/.changeset/highlights-readonly-authoring-surface-3407.md
+++ b/.changeset/highlights-readonly-authoring-surface-3407.md
@@ -1,0 +1,35 @@
+---
+"@object-ui/plugin-detail": patch
+---
+
+`record:highlights` publishes the `readonly` entry key, so an AI author can discover it from the manifest
+
+`readonly` on a `fields[]` entry has been enforced for a while — the renderer copies it
+through normalization and `HeaderHighlight`'s editability gate refuses inline editing on a
+chip carrying it (objectstack#5077) — and `@objectstack/spec` declares it on
+`RecordHighlightsField` (objectstack#5176 / PR #5607). The block's own published authoring
+surface never mentioned it: the `fields` input still spelled the entry shape
+`{name,label?,icon?,type?}`, and since the registry `inputs` are what
+`gen-manifest.ts` serializes into `sdui.manifest.json`, an author reading the manifest was
+told the key did not exist. The `fields` description now states the full entry shape and
+what `readonly` does, which is the discoverability the manifest is for.
+
+`readonly` is documented **inside** the `fields` description rather than declared as an
+input of its own, because that is where the contract puts it. The spec's
+`RecordHighlightsProps` has exactly three top-level keys (`fields`, `layout`, `aria`) and
+carries `readonly` per ENTRY. A top-level `{ name: 'readonly', type: 'boolean' }` input
+would publish a key the platform silently discards: the generated `sdui.manifest.json` and
+`sdui-intrinsics.d.ts` would advertise a `readonly` prop, the manifest gate validates
+top-level props only and would raise no diagnostic, `RecordHighlightsProps` is a plain
+`z.object` so the unknown key is stripped on parse without error, and the renderer — which
+reads `field.readonly` per entry — would never see it. An author who trusted that surface
+would be left with the machine-owned column still hand-editable and no diagnostic anywhere
+explaining why. `ComponentInput` is flat by design, so an array-of-objects input publishes
+its member keys in prose, as `record:path.stages` and `record:alert.action` already do.
+
+A new spec-parity test derives both directions from `@objectstack/spec` at runtime instead
+of restating today's key list: every key of `RecordHighlightsField`'s object arm must be
+named in the `fields` description, and the block must declare no top-level input that
+`RecordHighlightsProps` does not accept. Nothing previously cross-checked the registry
+`inputs` against the spec, so both drift directions were silent. No runtime behaviour
+changes.

--- a/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:highlights` — the published authoring surface stays in parity with
+ * `@objectstack/spec` RecordHighlights* (objectui#3407, objectstack#5176).
+ *
+ * The registry `inputs` ARE the published contract: `gen-manifest.ts`
+ * serializes them into `sdui.manifest.json` (the save-gate + parser whitelist)
+ * and into `sdui-intrinsics.d.ts` (the JSX authoring type surface). Nothing in
+ * the repo cross-checks them against the spec, so both drift directions are
+ * silent and both are harmful:
+ *
+ *   - a spec ENTRY key that no input mentions is a key an AI author cannot
+ *     discover (the complaint that opened #3407: `readonly` was enforced by the
+ *     HeaderHighlight gate and honoured by the renderer, but the `fields`
+ *     description still spelled the entry shape `{name,label?,icon?,type?}`);
+ *   - a top-level input the spec does not declare is worse than undocumented,
+ *     it is actively misleading. `RecordHighlightsProps` is a plain `z.object`,
+ *     so an unknown top-level key is STRIPPED on parse with no error, the
+ *     manifest gate only validates top-level props and raises no diagnostic,
+ *     and the renderer never sees it. The manifest would be telling authors to
+ *     write something the platform throws away.
+ *
+ * Both assertions derive their expectation from the spec at runtime rather than
+ * restating today's key list, so a spec change fails here instead of quietly
+ * widening the gap.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { RecordHighlightsField, RecordHighlightsProps } from '@objectstack/spec/ui';
+import '../index';
+
+/** Keys of the object arm of the spec's `RecordHighlightsField` union. */
+function specEntryKeys(): string[] {
+  const union = RecordHighlightsField as unknown as {
+    def?: { options?: unknown[] };
+    _def?: { options?: unknown[] };
+  };
+  const arms = union.def?.options ?? union._def?.options ?? [];
+  for (const arm of arms) {
+    const shape = (arm as { shape?: unknown; _def?: { shape?: unknown } }).shape
+      ?? (arm as { _def?: { shape?: unknown } })._def?.shape;
+    const resolved = typeof shape === 'function' ? (shape as () => object)() : shape;
+    if (resolved && typeof resolved === 'object') return Object.keys(resolved);
+  }
+  return [];
+}
+
+/** Top-level keys of the spec's `RecordHighlightsProps`. */
+function specTopLevelKeys(): string[] {
+  const obj = RecordHighlightsProps as unknown as {
+    shape?: unknown;
+    _def?: { shape?: unknown };
+  };
+  const shape = obj.shape ?? obj._def?.shape;
+  const resolved = typeof shape === 'function' ? (shape as () => object)() : shape;
+  return resolved && typeof resolved === 'object' ? Object.keys(resolved) : [];
+}
+
+const config = () => ComponentRegistry.getConfig('record:highlights');
+const inputs = () => config()?.inputs ?? [];
+const fieldsInput = () => inputs().find((i) => i.name === 'fields');
+
+describe('record:highlights — registry inputs vs @objectstack/spec', () => {
+  it('is registered with a non-empty `inputs` surface', () => {
+    expect(config()).toBeDefined();
+    expect(inputs().length).toBeGreaterThan(0);
+    expect(inputs().map((i) => i.name)).toContain('fields');
+  });
+
+  it('the spec really carries `readonly` per ENTRY, not top-level', () => {
+    // Guards the premise the rest of the file rests on. If a future spec moves
+    // `readonly` up to the props object, this fails and the `inputs` shape
+    // above should be revisited — a top-level input would then be correct.
+    expect(specEntryKeys()).toContain('readonly');
+    expect(specTopLevelKeys()).not.toContain('readonly');
+  });
+
+  it('a top-level `readonly` is silently stripped by the spec, so it must not be published', () => {
+    // The concrete harm: no throw, no diagnostic, key gone.
+    const parsed = RecordHighlightsProps.parse({ fields: ['amount'], readonly: true });
+    expect(parsed).not.toHaveProperty('readonly');
+    // …while the per-entry spelling survives, which is the one authors need.
+    const perEntry = RecordHighlightsProps.parse({ fields: [{ name: 'amount', readonly: true }] });
+    expect(perEntry.fields[0]).toMatchObject({ name: 'amount', readonly: true });
+  });
+
+  it('every spec entry key is discoverable from the `fields` input description', () => {
+    const description = fieldsInput()?.description ?? '';
+    expect(description).not.toBe('');
+    const undocumented = specEntryKeys().filter((key) => !description.includes(key));
+    expect(undocumented).toEqual([]);
+    // The key this issue was filed for, named explicitly so the regression is
+    // legible if the derived check above is ever loosened.
+    expect(description).toContain('readonly');
+  });
+
+  it('declares no top-level input the spec does not accept', () => {
+    const allowed = new Set(specTopLevelKeys());
+    const offSpec = inputs().map((i) => i.name).filter((name) => !allowed.has(name));
+    expect(offSpec).toEqual([]);
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -278,8 +278,26 @@ ComponentRegistry.register('highlights', RecordHighlightsRenderer, {
   label: 'Highlights Panel',
   icon: 'Star',
   // Mirrors @objectstack/spec RecordHighlightsProps.
+  //
+  // `readonly` is documented INSIDE the `fields` description, not declared as
+  // an input of its own, because that is where the contract puts it: the spec's
+  // `RecordHighlightsField` carries `readonly` on each ENTRY, while
+  // `RecordHighlightsProps` has exactly three top-level keys (fields, layout,
+  // aria). A top-level `{ name: 'readonly', type: 'boolean' }` here would look
+  // like the fix for "the manifest never mentions readonly" and would instead
+  // publish a key the platform silently discards: the generated
+  // `sdui.manifest.json` and `sdui-intrinsics.d.ts` would advertise
+  // `<RecordHighlights readonly>`, the manifest gate validates top-level props
+  // only and would raise no diagnostic, the spec strips the unknown key on
+  // parse without error, and the renderer — which reads `field.readonly` per
+  // entry — would never see it. An author who trusted that surface would be
+  // left with the machine-owned column still hand-editable and nothing
+  // anywhere saying why. `ComponentInput` is flat by design (`name` = "must
+  // match schema property"), so an array-of-objects input publishes its member
+  // keys in prose, the same way `record:path.stages` and `record:alert.action`
+  // do. objectui#3407 / objectstack#5176.
   inputs: [
-    { name: 'fields', type: 'array', label: 'Fields', required: true, description: 'Key fields to highlight (1-7), bare names or {name,label?,icon?,type?}' },
+    { name: 'fields', type: 'array', label: 'Fields', required: true, description: 'Key fields to highlight (1-7), bare names or {name,label?,icon?,type?,readonly?}. Set readonly: true on an entry to render that chip read-only — it suppresses the inline-edit affordance and the HeaderHighlight editability gate enforces it. Use it for hook/automation-maintained columns that must not be hand-edited from the record header; marking the OBJECT field readonly instead would also strip the hook\'s own write-back.' },
     { name: 'layout', type: 'enum', label: 'Layout', enum: ['horizontal', 'vertical'], defaultValue: 'horizontal', description: 'Layout orientation for highlight fields' },
   ],
 });


### PR DESCRIPTION
Fixes #3407
Part of objectstack-ai/objectstack#5176(spec 侧 PR objectstack-ai/objectstack#5607 已 MERGED)

## 摘要

把 `record:highlights` 的**发布面**补齐:`fields` input 的 description 现在写出完整条目形状
`{name,label?,icon?,type?,readonly?}` 并说明 `readonly` 的语义。registry `inputs` 正是
`packages/sdui-parser/scripts/gen-manifest.ts` 序列化进 `sdui.manifest.json` 的东西,所以这
一行就是 AI 作者能否从 manifest 得知该键存在的全部差别。

`readonly` 早已两侧兑现:renderer 归一化逐条拷贝(`renderers/record-highlights.tsx:70`
`readonly: f?.readonly === true`),`HeaderHighlight` 可编辑门据此拒绝内联编辑
(objectstack#5077);spec 已在 `RecordHighlightsField` 上声明(#5607)。缺的只有本仓 description。

## ⚠️ 前提核验:issue 的三条陈述有两条已失效,第三条需要改写落点

按 AGENTS.md「issue 是线索不是规格」,动码前逐条核到 `origin/main`(objectui `00b9451d8`,
objectstack `d42a92fc6`):

| issue 陈述 | 核验结果 |
|---|---|
| 该 block 是 "zero inputs" | ❌ **不成立**。`origin/main` 上 `record:highlights` 已有 2 个 inputs(`fields`、`layout`),自 #2113 / #3027 起就有 |
| 依据是 `docs/audits/2026-06-react-blocks-conformance.md` | ❌ **该文件不存在**。`git log --oneline --all -- 'docs/audits/2026-06-react-blocks-conformance.md'` 零命中,任何分支任何历史都没有过;`docs/audits/` 现存只有 3 个文件,均无此名 |
| 在 `inputs` 中声明 `readonly` 键(boolean) | ⚠️ **落点需改写**:`readonly` 在 spec 里是 `fields[]` 的**逐条**键,不是顶层 prop |

第三条是本 PR 最关键的判断,证据(运行本仓 pin 的 `@objectstack/spec@17.0.0-rc.5`):

```
RecordHighlightsField 对象分支 keys: [ 'name', 'label', 'icon', 'type', 'readonly' ]
RecordHighlightsProps  顶层 keys:   [ 'fields', 'layout', 'aria' ]

RecordHighlightsProps.parse({ fields: ['amount'], readonly: true })
  -> {"fields":["amount"],"layout":"horizontal"}      # readonly 被静默剥掉,不报错
RecordHighlightsProps.parse({ fields: [{ name: 'amount', readonly: true }] })
  -> {"fields":[{"name":"amount","readonly":true}],"layout":"horizontal"}   # 逐条保留
```

**若按 issue 字面加顶层 `{ name: 'readonly', type: 'boolean' }`,后果是发布一个平台默默丢弃的键**:

1. 生成的 `sdui.manifest.json` 与 `sdui-intrinsics.d.ts` 会宣告 RecordHighlights 有 `readonly` prop;
2. `packages/sdui-parser/src/validate.ts` 的 manifest 门**只**遍历节点顶层 prop(`Object.entries(node)`
   对 `comp.inputs`),不下探 `fields[]` 条目,因此顶层 `readonly` 被判为「已知 prop」,零诊断;
3. spec 是普通 `z.object`,parse 时把未知顶层键无声剥掉(上方实测);
4. renderer 读的是逐条 `field.readonly`,永远看不到顶层的那个。

净结果:作者信了平台自己的 manifest,写下的键被丢弃,他想保护的机器维护列**仍然可手改**,
而且任何地方都没有诊断说明原因 —— 这正是 spec 侧注释里声明 `readonly` 的理由所反对的那件事
(「an undeclared key is silently stripped here, which turns a machine-owned column editable
again with no diagnostic anywhere」),只是上移了一层。也正是 issue 自己引的
objectstack#5435「平台权威不得指向自己闸门会拒绝的键」的反向违例。

**因此采用契约忠实的落点**:`readonly` 写在 `fields` 的 description 里。`ComponentInput` 本就
是扁平的(`name` = "must match schema property",无任何嵌套机制),所以数组对象型 input 用散文
发布成员键 —— 这是本仓既有体例,非变通:`record:path.stages` 写
`'Explicit stage definitions [{ value, label }]'`,`record:alert.action` 写
`'{ actionName, label?, variant? }'`,`fields` 自己原本也写 `'bare names or {name,label?,icon?,type?}'`,
只是漏了 `readonly?`。issue 的**目的**(「AI 作者无法从 manifest 得知该键存在」)由此达成,
且不污染契约。

## 验收逐条证据

**① `record:highlights` 的 `inputs` 含 `readonly`(boolean,含语义描述)** — ✅ 达成,落点为
`fields` 的 description(理由见上)。描述措辞抄自 spec 原文
(`RecordHighlightsField.readonly.describe()` 与 `HeaderHighlight` 门实际行为),未自造语义:

> Key fields to highlight (1-7), bare names or {name,label?,icon?,type?,readonly?}. Set
> readonly: true on an entry to render that chip read-only — it suppresses the inline-edit
> affordance and the HeaderHighlight editability gate enforces it. Use it for
> hook/automation-maintained columns that must not be hand-edited from the record header;
> marking the OBJECT field readonly instead would also strip the hook's own write-back.

**② 重新生成的 `sdui.manifest.json` 携带该键** — ✅ 实测。`sdui.manifest.json` **不是**仓内提交
产物(全仓零命中),而是 `gen-manifest.ts` 的构建期产物,由 `manifestFromConfigs` 从 registry
现场序列化(`packages/sdui-parser/src/index.ts:152` `description: i.description` 原样带出)。按
`gen-manifest.ts` 同样的调用形状(`getPublicConfigs()` → `manifestFromConfigs`)实跑,
`record:highlights` 条目:

```json
{
  "type": "record:highlights",
  "namespace": "record",
  "inputs": [
    { "name": "fields", "type": "array", "required": true,
      "description": "Key fields to highlight (1-7), bare names or {name,label?,icon?,type?,readonly?}. Set readonly: true on an entry to render that chip read-only — …" },
    { "name": "layout", "type": "enum", "enum": ["horizontal","vertical"],
      "description": "Layout orientation for highlight fields" }
  ]
}
```

`readonly` 可从 manifest 读到 = `true`;顶层 input 名单仍为 `['fields','layout']`,与 spec 顶层
可接受键一致(`aria` 按本文件既有注释的理由继续不声明)。

**③ conformance 审计中该 block 不再是 "zero inputs"** — ⚠️ **空条**:该审计文件从不存在(证据见
上表),且该 block 在 `origin/main` 上本就不是 zero inputs。故无条目可改,也未新建审计文档
(超出本单范围)。若维护者确实想要这份 react-blocks conformance 审计,建议单开一单。

## 生成物 diff 审查

**无生成物 diff 可审**:`sdui.manifest.json` / `sdui-intrinsics.d.ts` / `sdui-blocks.md` 三者
均不在仓内提交(`git ls-tree -r origin/main | grep -E 'sdui\.manifest|sdui-intrinsics|sdui-blocks'`
零命中),由构建期生成。因此**未手改任何生成物**;上面 ② 的 manifest 是用官方生成路径实跑打印
出来核对的,不落盘、不提交。源码 diff 仅本键增量:`packages/plugin-detail/src/index.tsx`
1 处 description 改写 + 说明注释,无其他移动。

## 反向核验(方向事先预判:两个都应转红,各钉住改动的一半)

| 反向操作 | 预判 | 实测 |
|---|---|---|
| description 退回旧文本 | 「every spec entry key is discoverable」转红 | ✅ 红,`undocumented = ['readonly']` |
| 按 issue 字面加顶层 `readonly` input | 「declares no top-level input the spec does not accept」转红 | ✅ 红,`offSpec = ['readonly']` |

第二条尤其有意义:新增的门恰好拦住 issue 的字面方案。反向核验后已还原,`grep REVERSE-VERIFICATION`
零残留。

## 测试

新增 `packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts` —— 两个
方向都在**运行时从 spec 推导**,不复述今天的键表:`RecordHighlightsField` 对象分支的每个键都必须
出现在 `fields` description 里;本 block 不得声明 `RecordHighlightsProps` 不接受的顶层 input。
此前仓内**没有任何东西**交叉校验 registry `inputs` 与 spec(`getPublicConfigs`/`manifestFromConfigs`
的使用点里没有这类门),两个漂移方向都是静默的。

```
✓ record:highlights — registry inputs vs @objectstack/spec > is registered with a non-empty `inputs` surface
✓ … > the spec really carries `readonly` per ENTRY, not top-level
✓ … > a top-level `readonly` is silently stripped by the spec, so it must not be published
✓ … > every spec entry key is discoverable from the `fields` input description
✓ … > declares no top-level input the spec does not accept
Test Files 1 passed (1) | Tests 5 passed (5)
```

全包:`pnpm --workspace-concurrency=2 --filter @object-ui/plugin-detail test`
→ `Test Files 55 passed (55) / Tests 466 passed (466)`(基线 54/461,+1 文件 +5 测试;
`vitest list` 已确认新文件被默认收集)。
`type-check` → 干净(`tsc --noEmit && tsc -p tsconfig.typetests.json` 零输出)。
`lint` → 0 errors(707 warnings 全为未触及文件的既有基线;单独 lint 本次两文件亦 0 errors,
27 warnings 均为 barrel 文件既有的 `react-refresh/only-export-components`)。
控制字节:`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 三个改动文件零命中。

## Changeset

`.changeset/highlights-readonly-authoring-surface-3407.md`,`@object-ui/plugin-detail: patch`。
依据:改动落在 `packages/plugin-detail/src/` 内(`check-changeset-presence.mjs` 的欠账判据),
且 `sdui.manifest.json` 是发版包的对外发布面 —— 作者可读到的键集合变了,属用户可见;
但无运行时行为变化、纯 additive 文档面,故取 patch(与
`.changeset/bulk-action-param-options-open-3309.md` 这类「类型/声明面放宽、无运行时变化」的
同类先例同档)。

## 未触碰

`content/docs/releases/**` 未动。#3521 在 `packages/components/src/renderers/layout/containers.tsx`,
与本单(`packages/plugin-detail/`)文件面不相交。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_