### PR TITLE
feat(plugin-dashboard): dataset-bound metric 卡接上已声明的 colorVariant 强调色 (#3359)

### DIFF
--- a/.changeset/dataset-widget-colorvariant-3359.md
+++ b/.changeset/dataset-widget-colorvariant-3359.md
@@ -1,0 +1,45 @@
+---
+"@object-ui/plugin-dashboard": patch
+---
+
+Dataset-bound metric cards honour their declared `colorVariant` (objectui#3359, objectstack#5010 ruling B)
+
+`DashboardWidgetSchema.widgets[].colorVariant` has been spec-declared, offered by
+every authoring surface (the widget inspector, the dashboard editor, the config
+panel) and authored **16 times** in shipped metadata — `system_overview` ×7 in
+`platform-objects`, app-showcase's `ops-dashboard` / `revenue-pulse` ×9 — with
+every one of those a `type: 'metric'` widget bound to a dataset. None of them
+ever rendered a colour.
+
+The reason is structural rather than a missing branch: `dataset` is **required**
+on `DashboardWidgetSchema`, so every legal widget reaches `DatasetWidget` through
+one of `DashboardRenderer`'s two dispatch sites, and `DatasetWidget` read the key
+nowhere. Only the inline (`object` + `valueField`) path had a colour affordance,
+via the `...options` spread into `MetricWidget` — a path the current schema
+cannot produce. Declared, authored, offered in the designer, and inert: the
+renderer painted all sixteen the same.
+
+The metric card now maps the declaration onto the accent system this package
+already has, instead of a second one:
+
+- the vocabulary is the spec's `WidgetColorVariantSchema` enum, read from the
+  spec **in a test** rather than restated in prose — `default`, `blue`, `teal`,
+  `orange`, `purple`, `success`, `warning`, `danger`;
+- the accent lands on the big number, the way `MetricWidget`'s chrome-less
+  `bare` layout carries it, because a dataset-bound metric renders no icon chip
+  and no card of its own. A dataset-bound KPI and an inline `bare` KPI declaring
+  the same variant now read the same;
+- the two class tables both layouts use moved into one shared module
+  (`colorVariants.ts`) rather than being copied — the designer's swatch picker
+  already calls itself a mirror of "the renderer's colorVariant tokens", and a
+  second copy of a palette is how a declared-but-unenforced key becomes the
+  harder bug: a key declared two disagreeing ways.
+
+Nothing changes for a widget that declares no `colorVariant`: its markup is
+pinned byte-for-byte against the pre-change render, as is the enum's own
+`'default'` (its name for "no accent"). Off-spec tokens — including the swatch
+picker's three display-only aliases `green` / `red` / `amber`, which exist so a
+legacy stored value can still be drawn as a swatch — get no accent and no
+aliasing here: the spec enum rejects them where metadata is authored and
+published, and teaching the renderer a second spelling would hand AI-authored
+metadata a dialect the contract does not have.

--- a/packages/app-shell/src/views/metadata-admin/color-variant-field.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/color-variant-field.test.tsx
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The designer's swatch palette ↔ the spec's `colorVariant` enum (objectui#3359).
+ *
+ * `COLOR_VARIANTS`' header calls itself "Canonical semantic palette (mirrors the
+ * renderer's colorVariant tokens)" — a claim that was, until #3359, unverifiable
+ * on the renderer side: `DatasetWidget` read `colorVariant` nowhere, so the
+ * dataset-bound metric card had no tokens to mirror. Wiring the renderer up
+ * closed that gap and opened a sharper one: three lists now state the same
+ * vocabulary — this picker, the spec enum (`WidgetColorVariantSchema`), and
+ * `plugin-dashboard/src/colorVariants.ts` — and a silent disagreement between
+ * them would trade a declared-but-unenforced key for a declared-two-ways key,
+ * which is harder to find because every surface looks correct on its own.
+ *
+ * So the canonical row is pinned here against the spec itself, in the SAME order
+ * (the picker renders it as a swatch row; the order is what the admin sees).
+ * The renderer's own table is pinned to the same enum in
+ * `plugin-dashboard/src/__tests__/DatasetWidget.colorVariant.test.tsx`; between
+ * the two, all three lists are held to one source.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WidgetColorVariantSchema } from '@objectstack/spec/ui';
+import { COLOR_VARIANTS, colorVariantCss } from './color-variant-field';
+
+const specVariants: string[] = (() => {
+  const raw = (WidgetColorVariantSchema as unknown as { options?: readonly string[] }).options;
+  return Array.isArray(raw) ? [...raw] : [];
+})();
+
+/**
+ * The picker's canonical row — `ColorVariantPicker` renders exactly
+ * `COLOR_VARIANTS.slice(0, 8)`, so this is the slice that has to match the spec.
+ */
+const CANONICAL_COUNT = 8;
+
+describe('color-variant-field ↔ spec colorVariant enum', () => {
+  it('reads a non-empty enum from the spec', () => {
+    // Guards against the parity assertions passing vacuously against [].
+    expect(specVariants, 'could not read WidgetColorVariantSchema.options from the spec').not.toEqual([]);
+  });
+
+  it('offers the spec tokens, in the spec order, as its canonical swatch row', () => {
+    expect(COLOR_VARIANTS.slice(0, CANONICAL_COUNT).map((c) => c.value)).toEqual(specVariants);
+    expect(specVariants).toHaveLength(CANONICAL_COUNT);
+  });
+
+  it('gives every canonical token a distinct, labelled swatch', () => {
+    const canonical = COLOR_VARIANTS.slice(0, CANONICAL_COUNT);
+    for (const variant of canonical) {
+      expect(variant.label, `token ${variant.value} has no label`).toBeTruthy();
+      expect(variant.css, `token ${variant.value} has no css colour`).toMatch(/^#[0-9a-f]{6}$/i);
+    }
+    // `default` is the neutral swatch; the seven accents must be visually
+    // distinguishable from each other in the picker.
+    const accents = canonical.filter((c) => c.value !== 'default').map((c) => c.css);
+    expect(new Set(accents).size).toBe(accents.length);
+  });
+
+  /**
+   * The entries past the canonical 8 are the file's declared display-only
+   * aliases. They exist so a swatch can still be drawn for an OFF-SPEC stored
+   * value; they are deliberately outside the picker's own row and are NOT
+   * renderer vocabulary (`metricAccentTextClass` ignores them). Pinning them as
+   * aliases is what keeps a future edit from quietly promoting one into a ninth
+   * authorable variant the spec never declared.
+   */
+  it('keeps its extra entries as off-spec display aliases, never new tokens', () => {
+    const extras = COLOR_VARIANTS.slice(CANONICAL_COUNT);
+    for (const extra of extras) {
+      expect(specVariants, `${extra.value} is a spec token and must join the canonical row`).not.toContain(extra.value);
+      // An alias only earns its place by re-using a canonical token's colour.
+      const canonicalCss = COLOR_VARIANTS.slice(0, CANONICAL_COUNT).map((c) => c.css);
+      expect(canonicalCss, `alias ${extra.value} paints a colour no canonical token uses`).toContain(extra.css);
+    }
+  });
+
+  it('resolves hex values as-is and unknown tokens to the neutral swatch', () => {
+    expect(colorVariantCss('#1f2937')).toBe('#1f2937');
+    expect(colorVariantCss('chartreuse')).toBe(colorVariantCss('default'));
+    expect(colorVariantCss(undefined)).toBe(colorVariantCss('default'));
+  });
+});

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -267,6 +267,39 @@ Notes:
   warning instead of emitting a query that matches nothing. Explicit
   `filterBindings` strings are always honoured as written.
 
+## Widget accent colour (`colorVariant`)
+
+A KPI widget can declare a semantic accent. The vocabulary is
+`@objectstack/spec`'s `WidgetColorVariantSchema` enum — `default`, `blue`,
+`teal`, `orange`, `purple`, `success`, `warning`, `danger` — the same eight
+tokens the designer's swatch picker offers:
+
+```typescript
+{
+  id: 'kpi_at_risk',
+  type: 'metric',
+  title: 'At-Risk Projects',
+  dataset: 'project_health',
+  values: ['project_count'],
+  filter: { health: 'red' },
+  colorVariant: 'danger',   // tints the value; card chrome stays neutral
+}
+```
+
+Where the accent lands depends on the layout, not on the token:
+
+| Layout | Accent |
+| --- | --- |
+| Card chrome (`MetricWidget`, inline `object-metric`) | the icon chip's background + foreground |
+| Chrome-less (`MetricWidget variant: 'bare'`, and every dataset-bound `metric`) | the big number's text colour |
+
+Both read one shared table (`src/colorVariants.ts`), so the same declaration
+reads the same on either surface. `default` — and omitting the key — means "no
+accent"; the widget renders in the ambient foreground colour. A token outside
+the enum gets no accent and is not aliased to a nearby colour: it is invalid
+metadata, rejected where it is authored and published rather than reinterpreted
+here.
+
 ## TypeScript Support
 
 ```typescript

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -58,6 +58,7 @@ import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
 import { BarChart3, AlertTriangle, Download, ArrowUpIcon, ArrowDownIcon, MinusIcon } from 'lucide-react';
 import { useFilterScope } from '@object-ui/react';
 import { resolveFilterPlaceholders, computeMetricDelta } from './utils';
+import { metricAccentTextClass } from './colorVariants';
 import { DrillDownDrawer } from './DrillDownDrawer';
 
 type Row = Record<string, unknown>;
@@ -620,9 +621,27 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
           typeof previous === 'number' ? previous : null,
         )
       : null;
+    // ── The declared accent (objectui#3359, objectstack#5010 ruling B) ──────
+    // `widget.colorVariant` has been spec-declared and authored for a long time
+    // (16 live authorizations across platform-objects' system_overview and
+    // app-showcase's dashboards, every one of them a dataset-bound `metric`) —
+    // and `dataset` being REQUIRED on DashboardWidgetSchema means every legal
+    // widget lands here, in a component that read the key nowhere. So the
+    // renderer painted all sixteen identically and the key was declared but
+    // never enforced.
+    //
+    // It maps onto the accent system this package already has rather than a new
+    // one: no icon chip and no card chrome is rendered here, exactly like
+    // MetricWidget's `bare` layout, so the accent lands where that layout puts
+    // it — on the big number, via the same shared `VARIANT_TEXT_CLASSES`. A
+    // dataset-bound KPI and an inline `bare` KPI declaring the same variant now
+    // read the same. No declaration (and the enum's own `'default'`) resolves to
+    // `undefined`, which `cn` drops: the markup of every widget that never
+    // declared the key stays byte-identical.
+    const accentClass = metricAccentTextClass(widget?.colorVariant);
     return (
       <div className="flex h-full w-full flex-col items-start justify-center gap-1 p-2">
-        <span className="text-2xl font-semibold tabular-nums">{formatMeasure(value, f?.format, f?.currency, f?.percentScale)}</span>
+        <span className={cn('text-2xl font-semibold tabular-nums', accentClass)}>{formatMeasure(value, f?.format, f?.currency, f?.percentScale)}</span>
         {delta && (
           <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground" data-testid="dataset-compare-trend">
             <span className={cn(

--- a/packages/plugin-dashboard/src/MetricWidget.tsx
+++ b/packages/plugin-dashboard/src/MetricWidget.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle, getLazyIcon } from '@object-u
 import { cn } from '@object-ui/components';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { ArrowDownIcon, ArrowUpIcon, MinusIcon, AlertCircle, Loader2 } from 'lucide-react';
+import { VARIANT_ICON_CLASSES, VARIANT_TEXT_CLASSES, type MetricColorVariant } from './colorVariants';
 
 const TREND_LABEL_DEFAULTS: Record<string, string> = {
   'dashboard.trend.vsLastQuarter': 'vs last quarter',
@@ -121,39 +122,14 @@ function resolveLabel(label: string | { key?: string; defaultValue?: string } | 
   return label.defaultValue || label.key;
 }
 
-export type MetricColorVariant =
-  | 'default' | 'blue' | 'teal' | 'orange' | 'purple'
-  | 'success' | 'warning' | 'danger';
-
 /**
- * Static map of color variants → Tailwind class strings.
- * Defined statically so Tailwind v4's content scanner picks them up.
- * Each variant tints the icon container with a soft background + bold foreground,
- * keeping the rest of the card in the neutral Shadcn palette.
+ * The variant vocabulary and its two class tables now live in
+ * `./colorVariants` — the dataset-bound KPI (`DatasetWidget`, objectui#3359)
+ * paints the SAME accents, and two copies of a palette is how a
+ * declared-but-unenforced key becomes two disagreeing declarations. Re-exported
+ * here because this module was the type's original home.
  */
-const VARIANT_ICON_CLASSES: Record<MetricColorVariant, string> = {
-  default: 'bg-muted text-muted-foreground',
-  blue:    'bg-blue-500/10 text-blue-600 dark:text-blue-400',
-  teal:    'bg-teal-500/10 text-teal-600 dark:text-teal-400',
-  orange:  'bg-orange-500/10 text-orange-600 dark:text-orange-400',
-  purple:  'bg-purple-500/10 text-purple-600 dark:text-purple-400',
-  success: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-  warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
-  danger:  'bg-rose-500/10 text-rose-600 dark:text-rose-400',
-};
-
-/** Text-colour per variant — used by the `bare` layout to tint the big number
- *  (data-screen KPIs) instead of an icon chip. */
-const VARIANT_TEXT_CLASSES: Record<MetricColorVariant, string> = {
-  default: 'text-foreground',
-  blue:    'text-blue-600 dark:text-blue-400',
-  teal:    'text-teal-600 dark:text-teal-400',
-  orange:  'text-orange-600 dark:text-orange-400',
-  purple:  'text-purple-600 dark:text-purple-400',
-  success: 'text-emerald-600 dark:text-emerald-400',
-  warning: 'text-amber-600 dark:text-amber-400',
-  danger:  'text-rose-600 dark:text-rose-400',
-};
+export type { MetricColorVariant };
 
 export interface MetricWidgetProps {
   label: string | { key?: string; defaultValue?: string };

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.colorVariant.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.colorVariant.test.tsx
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#3359 / objectstack#5010 ruling B — a dataset-bound metric card must
+ * honour its declared `DashboardWidgetSchema.widgets[].colorVariant`.
+ *
+ * Why it never did: `dataset` is REQUIRED on the widget schema, so every legal
+ * widget renders through `DatasetWidget` (DashboardRenderer's two dispatch
+ * sites), and `DatasetWidget` read the key nowhere — 16 real authorizations
+ * (platform-objects' `system_overview` ×7, app-showcase's dashboards ×9, every
+ * one a dataset-bound `metric`) all painted the same. Captured on
+ * objectui origin/main@f9d70a72e, `colorVariant: 'success'` and no declaration
+ * at all produced DOM identical character-for-character:
+ *
+ *   PROBE_UNDECLARED and PROBE_SUCCESS both →
+ *   `…<span class="text-2xl font-semibold tabular-nums">510000</span>…`
+ *
+ * The two halves of this file pin OPPOSITE directions on purpose:
+ *
+ *  - the **default** (undeclared) markup is asserted byte-for-byte. It was
+ *    green BEFORE this change and stays green after — a no-regression pin, not
+ *    evidence of the feature. Reverting the change must NOT turn it red;
+ *  - the **per-variant** assertions were RED before (every variant produced the
+ *    default markup) and are green after. Those are the feature's evidence.
+ *
+ * The vocabulary parity block reads the enum out of `@objectstack/spec/ui` at
+ * test time rather than restating it, so a spec token added or retired fails
+ * here instead of silently becoming a variant the renderer ignores.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+// The parity guard reads the spec's own enum — a direct spec import, as in
+// widget-dispatch-spec-parity.test.ts. `@objectstack/spec` is this package's
+// devDependency; the schema is deliberately NOT re-exported by
+// `@object-ui/types` (decision (a) of objectui#2561), so this is the supported
+// way to reach it.
+import { WidgetColorVariantSchema } from '@objectstack/spec/ui';
+import { DatasetWidget } from '../DatasetWidget';
+import { VARIANT_ICON_CLASSES, VARIANT_TEXT_CLASSES, metricAccentTextClass } from '../colorVariants';
+
+afterEach(cleanup);
+
+/** The spec's own token list, read at test time (see the parity block below). */
+const specVariants: string[] = (() => {
+  const raw = (WidgetColorVariantSchema as unknown as { options?: readonly string[] }).options;
+  return Array.isArray(raw) ? [...raw] : [];
+})();
+
+/**
+ * The metric card's markup with NO `colorVariant` declared, exactly as
+ * origin/main@f9d70a72e renders it. Spelled out in full (not a snapshot file)
+ * so a regression shows up as a diff in the test source review, and so nobody
+ * can "fix" it by deleting an obsolete snapshot.
+ */
+const BASELINE_UNDECLARED =
+  '<div class="flex h-full w-full flex-col items-start justify-center gap-1 p-2">'
+  + '<span class="text-2xl font-semibold tabular-nums">510000</span>'
+  + '<span class="text-xs text-muted-foreground">revenue</span>'
+  + '</div>';
+
+const renderMetric = async (widgetExtras: Record<string, unknown> = {}, rows = [{ revenue: 510000 }]) => {
+  const src = { queryDataset: vi.fn(async () => ({ rows })) };
+  const { container } = render(
+    <DatasetWidget
+      widget={{ type: 'metric', dataset: 'sales', values: ['revenue'], ...widgetExtras }}
+      dataSource={src}
+    />,
+  );
+  await screen.findByText('510000');
+  return container;
+};
+
+/** The big number's class attribute — where a chrome-less KPI carries its accent. */
+const valueClass = (container: HTMLElement) =>
+  container.querySelector('span.tabular-nums')?.getAttribute('class') ?? '';
+
+const BASE_VALUE_CLASS = 'text-2xl font-semibold tabular-nums';
+
+/**
+ * The mapping this issue delivers, restated independently of the
+ * implementation: spec token → the accent appended to the value's classes.
+ * `default` is absent deliberately — the enum's own name for "no accent".
+ */
+const EXPECTED_ACCENT: Record<string, string> = {
+  blue: 'text-blue-600 dark:text-blue-400',
+  teal: 'text-teal-600 dark:text-teal-400',
+  orange: 'text-orange-600 dark:text-orange-400',
+  purple: 'text-purple-600 dark:text-purple-400',
+  success: 'text-emerald-600 dark:text-emerald-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  danger: 'text-rose-600 dark:text-rose-400',
+};
+
+describe('DatasetWidget metric card — the declared colorVariant (#3359)', () => {
+  // ── No-regression half: green before AND after this change ───────────────
+  it('renders the pre-change markup byte-for-byte when no colorVariant is declared', async () => {
+    const container = await renderMetric();
+    expect(container.innerHTML).toBe(BASELINE_UNDECLARED);
+  });
+
+  it("treats the enum's own 'default' as no accent — identical bytes to undeclared", async () => {
+    const container = await renderMetric({ colorVariant: 'default' });
+    expect(container.innerHTML).toBe(BASELINE_UNDECLARED);
+  });
+
+  // An off-spec token gets NO accent and NO aliasing. The designer's swatch
+  // picker carries three display-only aliases (`green`/`red`/`amber`) so it can
+  // still paint a swatch for a legacy stored value; honouring them HERE would
+  // give the renderer a vocabulary the spec does not have — a second de-facto
+  // contract for AI-authored metadata to drift into (AGENTS.md #0.1). The spec
+  // enum rejects them where the metadata is authored and published; a cosmetic
+  // key is also the wrong place to fail a whole widget, hence "no accent"
+  // rather than an error.
+  it.each(['chartreuse', 'green', 'red', 'amber', '', '#ff0000'])(
+    'ignores the off-spec token %j — no accent, no alias, baseline bytes',
+    async (token) => {
+      const container = await renderMetric({ colorVariant: token });
+      expect(container.innerHTML).toBe(BASELINE_UNDECLARED);
+    },
+  );
+
+  it('leaves a non-string colorVariant alone instead of throwing', async () => {
+    const container = await renderMetric({ colorVariant: { token: 'blue' } });
+    expect(container.innerHTML).toBe(BASELINE_UNDECLARED);
+  });
+
+  // ── Feature half: RED before this change, green after ────────────────────
+  it.each(Object.entries(EXPECTED_ACCENT))(
+    'tints the value with the %s accent',
+    async (variant, accent) => {
+      const container = await renderMetric({ colorVariant: variant });
+      expect(valueClass(container)).toBe(`${BASE_VALUE_CLASS} ${accent}`);
+      // The declared variant changes ONLY the value's colour — the layout, the
+      // measure label and the value text are untouched.
+      expect(container.innerHTML).toBe(
+        BASELINE_UNDECLARED.replace(BASE_VALUE_CLASS, `${BASE_VALUE_CLASS} ${accent}`),
+      );
+    },
+  );
+
+  it('renders all eight enum values distinguishably (七个强调色 + default)', async () => {
+    const seen: string[] = [];
+    for (const variant of specVariants) {
+      const container = await renderMetric({ colorVariant: variant });
+      seen.push(valueClass(container));
+      cleanup();
+    }
+    // 8 tokens → 8 distinct class strings: `default` keeps the bare base class,
+    // each accent token adds its own. No two variants render alike.
+    expect(new Set(seen).size).toBe(specVariants.length);
+    expect(seen[specVariants.indexOf('default')]).toBe(BASE_VALUE_CLASS);
+  });
+
+  it('keeps the comparison trend row untouched by the accent', async () => {
+    const rows = [{ revenue: 510000, revenue__compare: 400000 }];
+    const plain = await renderMetric({ compareTo: { kind: 'previousPeriod' } }, rows);
+    const plainHtml = plain.innerHTML;
+    cleanup();
+    // The delta row renders (that is what makes this case worth pinning) …
+    expect(plainHtml).toContain('data-testid="dataset-compare-trend"');
+    const tinted = await renderMetric({ compareTo: { kind: 'previousPeriod' }, colorVariant: 'danger' }, rows);
+    // … and the tinted render differs from it in exactly one place: the value's
+    // class attribute. The trend's own up/down colouring is data-driven and must
+    // not inherit the widget's accent.
+    expect(tinted.innerHTML).toBe(
+      plainHtml.replace(BASE_VALUE_CLASS, `${BASE_VALUE_CLASS} ${EXPECTED_ACCENT.danger}`),
+    );
+  });
+});
+
+// ── Vocabulary parity: spec enum ↔ the renderer's tables ───────────────────
+describe('colorVariant vocabulary is the spec enum, not a renderer invention', () => {
+  it('reads a non-empty enum from the spec', () => {
+    // Without this the parity assertions below could pass vacuously against an
+    // empty list — the failure mode that makes a "green" parity test worthless.
+    expect(specVariants, 'could not read WidgetColorVariantSchema.options from the spec').not.toEqual([]);
+  });
+
+  it('the accent tables cover exactly the spec tokens', () => {
+    expect(Object.keys(VARIANT_TEXT_CLASSES).sort()).toEqual([...specVariants].sort());
+    expect(Object.keys(VARIANT_ICON_CLASSES).sort()).toEqual([...specVariants].sort());
+  });
+
+  it('every spec token except `default` resolves to an accent', () => {
+    for (const token of specVariants) {
+      const resolved = metricAccentTextClass(token);
+      if (token === 'default') expect(resolved).toBeUndefined();
+      else expect(resolved, `spec token ${token} has no accent class`).toBeTruthy();
+    }
+  });
+
+  it('the accent classes are pairwise distinct', () => {
+    const accents = specVariants.filter((t) => t !== 'default').map((t) => metricAccentTextClass(t));
+    expect(new Set(accents).size).toBe(accents.length);
+  });
+
+  // The tokens the 16 live authorizations actually use (system_overview +
+  // app-showcase). Every one must resolve, or this issue's own metadata is
+  // still unenforced after the fix.
+  it('resolves every token the shipped dashboards authorize', () => {
+    for (const token of ['blue', 'teal', 'orange', 'purple', 'success', 'warning', 'danger']) {
+      expect(specVariants, `${token} is no longer a spec token`).toContain(token);
+      expect(metricAccentTextClass(token)).toBe(EXPECTED_ACCENT[token]);
+    }
+  });
+});

--- a/packages/plugin-dashboard/src/colorVariants.ts
+++ b/packages/plugin-dashboard/src/colorVariants.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The dashboard renderer's `colorVariant` tokens — ONE table, shared by every
+ * surface that paints a KPI accent.
+ *
+ * The vocabulary is `@objectstack/spec`'s `WidgetColorVariantSchema` enum
+ * (`packages/spec/src/ui/dashboard.zod.ts`), mirrored by the designer's swatch
+ * picker (`app-shell/.../color-variant-field.tsx` — "Canonical semantic
+ * palette"). Those three lists must state the same eight tokens; a renderer
+ * that invented a ninth variant, or dropped one, would turn a
+ * declared-but-unenforced key into the harder bug: two disagreeing
+ * declarations. The picker carries three EXTRA display-only aliases
+ * (`green`/`red`/`amber`) so a swatch can still be drawn for an off-spec
+ * stored value — deliberately NOT honoured here (see `metricAccentTextClass`).
+ *
+ * Class strings stay static literals so Tailwind's content scanner sees them
+ * (`apps/console/src/index.css` sources this package's `src/**`).
+ */
+
+export type MetricColorVariant =
+  | 'default' | 'blue' | 'teal' | 'orange' | 'purple'
+  | 'success' | 'warning' | 'danger';
+
+/**
+ * Icon-chip classes per variant — a soft background + bold foreground that
+ * tints the icon container while the rest of the card stays in the neutral
+ * Shadcn palette. Used by the card-chrome KPI layout (`MetricWidget`).
+ */
+export const VARIANT_ICON_CLASSES: Record<MetricColorVariant, string> = {
+  default: 'bg-muted text-muted-foreground',
+  blue:    'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  teal:    'bg-teal-500/10 text-teal-600 dark:text-teal-400',
+  orange:  'bg-orange-500/10 text-orange-600 dark:text-orange-400',
+  purple:  'bg-purple-500/10 text-purple-600 dark:text-purple-400',
+  success: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  danger:  'bg-rose-500/10 text-rose-600 dark:text-rose-400',
+};
+
+/** Text-colour per variant — tints the big number on the chrome-less
+ *  (`bare` / dataset-bound) KPI layouts, which have no icon chip to carry the
+ *  accent. */
+export const VARIANT_TEXT_CLASSES: Record<MetricColorVariant, string> = {
+  default: 'text-foreground',
+  blue:    'text-blue-600 dark:text-blue-400',
+  teal:    'text-teal-600 dark:text-teal-400',
+  orange:  'text-orange-600 dark:text-orange-400',
+  purple:  'text-purple-600 dark:text-purple-400',
+  success: 'text-emerald-600 dark:text-emerald-400',
+  warning: 'text-amber-600 dark:text-amber-400',
+  danger:  'text-rose-600 dark:text-rose-400',
+};
+
+/**
+ * Resolve a widget's declared `colorVariant` to the accent text class for a
+ * KPI that already renders in the ambient foreground colour, or `undefined`
+ * when there is no accent to add.
+ *
+ * `undefined` is returned for three distinct inputs, and the caller wants the
+ * same thing in all three — emit no extra class at all:
+ *
+ *  - **not declared** — the widget said nothing, so its markup must not change
+ *    (objectui#3359 pins this byte-for-byte);
+ *  - **`'default'`** — the enum's own name for "no accent". Painting the
+ *    explicit `text-foreground` here would be a no-op on a surface that
+ *    already inherits it, and would make `colorVariant: 'default'` differ from
+ *    omitting the key purely in class-attribute bytes;
+ *  - **off-spec token** (`'chartreuse'`, or the picker's display-only
+ *    `'green'`/`'red'`/`'amber'` aliases) — deliberately no accent and no
+ *    aliasing. The spec enum rejects these where the metadata is authored and
+ *    published; teaching the renderer to accept a second spelling would
+ *    fossilize a dialect the contract does not have (AGENTS.md #0.1). A
+ *    cosmetic key is also the wrong place to fail a widget's whole render,
+ *    hence "no accent" rather than an error.
+ *
+ * `MetricWidget`'s own layouts keep indexing `VARIANT_TEXT_CLASSES` /
+ * `VARIANT_ICON_CLASSES` directly — they take a defaulted prop, so `'default'`
+ * genuinely resolves to a class there.
+ */
+export function metricAccentTextClass(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value === 'default') return undefined;
+  return VARIANT_TEXT_CLASSES[value as MetricColorVariant];
+}


### PR DESCRIPTION
Fixes #3359

objectstack#5010 维护者裁决 B 的 objectui 半边实现单,spec 零改动。

## 前提复核(实读 objectui `origin/main@f9d70a72e` / objectstack `origin/main@ea1d9165d`)

前提成立,且比正文描述多一层字节级证据:

1. `dataset` 在 `DashboardWidgetSchema` **必填**(objectstack `packages/spec/src/ui/dashboard.zod.ts`),因此所有合法 widget 经 `DashboardRenderer.tsx` 两处派发口(`isSelfContained` 分支的 dataset-bound 口、Card 分支的 dataset-bound 口)恒走 `DatasetWidget`;`isSelfContained = widget.type === 'metric' && !datasetBound`,dataset-bound metric 落在后者。
2. `grep -c colorVariant packages/plugin-dashboard/src/DatasetWidget.tsx` = **0**;邻近词反查 `categoryColors` = **4**,证伪「扫描器/路径错」。
3. **字节级实证**:改动前在 origin/main 上取证,声明 `colorVariant: 'success'` 与完全不声明,渲染出的 DOM **逐字符相同**:

```
PROBE_UNDECLARED  →  div.class="flex h-full w-full flex-col items-start justify-center gap-1 p-2"
                     span.class="text-2xl font-semibold tabular-nums"        510000
                     span.class="text-xs text-muted-foreground"              revenue
PROBE_SUCCESS     →  (与上完全一致,零差异)
```

(为绕开 GitHub body 的 HTML 清洗,上面用 `标签.class=` 代替尖括号书写;完整字节串以字符串常量 `BASELINE_UNDECLARED` 落在测试文件里。)

4. 授权面复核:16 处真实授权全部是 dataset-bound 的 `type: 'metric'` —— `platform-objects/src/apps/dashboards/system_overview.dashboard.ts` 7 处,`examples/app-showcase` 的 `ops-dashboard` 4 处 + `revenue-pulse` 5 处。用到的 token 恰好是 7 个非 default 强调色的全集。(app-showcase 各 page 里还有若干 `object-metric` 组件块也写 `colorVariant`,那是 `properties` 里传给 `ObjectMetricWidget` 的另一条已生效路径,不在本单计数内。)

## 实现

`DatasetWidget` 的 metric 卡读 `widget.colorVariant`,映射到**本包已有**的强调色体系,不新造一套:

- **落点选择**:dataset-bound metric 既不画 icon chip、也不自带 Card 外框,结构上正是 `MetricWidget` 的 `bare` 布局 —— 所以强调色落在**大数字的文字色**上,复用 `VARIANT_TEXT_CLASSES`。同一个声明在 inline `bare` KPI 与 dataset-bound KPI 上从此读起来一致。
- **一张表,不是两张**:把 `VARIANT_ICON_CLASSES` / `VARIANT_TEXT_CLASSES` 从 `MetricWidget.tsx` 提到新的 `src/colorVariants.ts`,两个布局共用(纯搬移,`MetricWidget` 渲染零变化;`MetricColorVariant` 在原处 re-export 保持源码兼容)。设计器那份色板的注释本来就自称 "mirrors the renderer's colorVariant tokens",复制第二份正是把 declared≠enforced 换成更难查的 declared≠declared。
- **`metricAccentTextClass(value)`** 对三种输入统一返回 `undefined`(即不追加任何 class):未声明、枚举自带的 `'default'`(它就是「无强调色」的名字)、以及任何非 spec token。不做 `??` 兜底、不认别名 —— 非法 token 由 spec 的 Zod 枚举在**授权/发布处**拒绝,消费端再认一种拼法就是给 AI 生成的元数据造第二套事实契约(AGENTS.md #0.1);同时一个纯装饰键也不该让整个 widget 渲染失败,所以是「无强调色」而非报错。

## 词表三方对照(spec ↔ 设计器 ↔ 渲染器)

spec 枚举实读:`objectstack packages/spec/src/ui/dashboard.zod.ts:28` `WidgetColorVariantSchema`。

| spec 枚举(8) | 设计器 `color-variant-field.tsx:19-27`(canonical 8) | 渲染器 `colorVariants.ts` → 大数字文字色 |
| --- | --- | --- |
| `default` | `default` / `#9ca3af` | 不追加 class(与未声明逐字节一致) |
| `blue` | `blue` / `#3b82f6` | `text-blue-600 dark:text-blue-400` |
| `teal` | `teal` / `#14b8a6` | `text-teal-600 dark:text-teal-400` |
| `orange` | `orange` / `#f97316` | `text-orange-600 dark:text-orange-400` |
| `purple` | `purple` / `#a855f7` | `text-purple-600 dark:text-purple-400` |
| `success` | `success` / `#22c55e` | `text-emerald-600 dark:text-emerald-400` |
| `warning` | `warning` / `#f59e0b` | `text-amber-600 dark:text-amber-400` |
| `danger` | `danger` / `#ef4444` | `text-rose-600 dark:text-rose-400` |

三方**完全对齐,零自造变体**。两处机械钉住,不靠这张表的人工核对:

- `DatasetWidget.colorVariant.test.tsx` 从 `@objectstack/spec/ui` 读 `WidgetColorVariantSchema.options`,断言渲染器两张表的 key 集合 === spec 枚举(并先断言枚举非空,避免空列表下的空转绿)。
- 新增 `packages/app-shell/src/views/metadata-admin/color-variant-field.test.tsx`(纯测试,无源码改动)把设计器 canonical 行按 **spec 顺序**钉到同一枚举上。此前这条腿完全没有机械约束。

设计器那份色板在 canonical 8 之后还有 3 条 `green`/`red`/`amber`,文件自己注明是「让非 canonical token 也能显示一个合理色块」的**显示用别名**,且 `ColorVariantPicker` 只渲染 `slice(0, 8)`。它们**不是**渲染器词表:新测试同时钉住「额外条目必须不是 spec token,且必须复用某个 canonical 色值」,防止将来有人把别名悄悄升格成第 9 个可授权变体。

## 缺省不回归证据

改动前先在 `origin/main@f9d70a72e` 上取字节基线(上文 PROBE),再把它写成测试里的字符串常量 `BASELINE_UNDECLARED`(不是 snapshot 文件 —— 回归要在 review diff 里看得见,也不能靠删过期快照「修好」)。断言:

- 未声明 `colorVariant` → `container.innerHTML` **全等**基线;
- `colorVariant: 'default'` → 全等基线;
- 非 spec token(`chartreuse` / `green` / `red` / `amber` / `''` / `#ff0000`)→ 全等基线;
- 非字符串(对象)→ 全等基线,不抛异常;
- 7 个强调色 → `innerHTML` 恰好等于「基线把大数字 class 换成 `基础 class + 该强调色`」,即**只有一处差异**;
- 带 compareTo 的趋势行同理只差那一处 —— 趋势的红绿是数据驱动的,不能被 widget 强调色带跑。

## 反向验证(方向事先声明)

本单**两个方向同时存在**,模板不能一概而论,所以事先写明预测再跑:

- 「缺省不回归」半边:**改动前绿、改动后也绿**。它是防回归钉,不是功能证据;把 accent 读数删掉它必须**仍然绿**。
- 「各枚举值映射」半边:**改动前红、改动后绿**。

实测(把 `const accentClass = metricAccentTextClass(widget?.colorVariant)` 临时改为常量 `undefined` 后重跑同一测试文件):

```
× tints the value with the blue accent
× tints the value with the teal accent
× tints the value with the orange accent
× tints the value with the purple accent
× tints the value with the success accent
× tints the value with the warning accent
× tints the value with the danger accent
× renders all eight enum values distinguishably
× keeps the comparison trend row untouched by the accent
Tests  9 failed | 14 passed (23)
```

9 红全部落在功能半边,14 绿是缺省半边 + 词表 parity —— 与事先声明的方向一致。随后已复原。

## 验证

```
# 依赖先构建,防 TS2307 假红
pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-dashboard^...' build   → 全部 Done

pnpm vitest run packages/plugin-dashboard \
  packages/app-shell/src/views/metadata-admin/color-variant-field.test.tsx --maxWorkers=2
  → Test Files 28 passed (28) / Tests 246 passed (246)
    (其中新增 DatasetWidget.colorVariant.test.tsx 23 项、color-variant-field.test.tsx 5 项)

pnpm --filter @object-ui/plugin-dashboard type-check   → tsc --noEmit 无输出(通过)
pnpm --filter @object-ui/app-shell type-check          → tsc --noEmit && tsc -p tsconfig.typetests.json 无输出(通过)

eslint(4 个改动/新增文件)                              → 0 error
node scripts/check-changeset-no-major.mjs               → No changeset declares a `major` bump
node scripts/check-changeset-fixed.mjs                  → All workspace packages in the fixed group
node scripts/check-changeset-presence.mjs               → 1 changeset declared ✅
grep -naP 控制字节扫描(全部改动文件)                    → 零命中;file(1) 全部 UTF-8 text
```

重型步骤全部在 `flock /tmp/os-heavy-verify.lock` 下串行、`--max-old-space-size=4096`、`--maxWorkers=2`。

## Changeset

`.changeset/dataset-widget-colorvariant-3359.md`,`@object-ui/plugin-dashboard: patch`。档位依据仓内同类先例:同一组件同族的 declared→enforced 改动 `compareto-kind-convergence.md`(范围更大)也是 `patch`;`minor` 在本仓的现存两例都是公共 API 破坏性改名。app-shell 只加了测试、无用户可见变化,故不进 changeset 条目。README 补了 `colorVariant` 一节(AGENTS.md #2)。

## 范围外(未在本 PR 触碰)

- 正文第 3 条 **framework 侧 `liveness/dashboard.json` 该行翻 `live`** + 解除 objectstack PR #5255 钉的「恰好只警告 colorVariant」正向对照 —— 按分诊席点名,由验收本 PR 的执行座位在 objectstack 立单承办(带 `Blocked-by:` 本 PR)。本 PR 不改 objectstack 仓。
- inline 旧路径的 `componentSchema` 色彩逻辑未被搬用(正文第 3 条禁令)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_