### PR TITLE
refactor(plugin-chatbot): ApproveOutcome/RejectOutcome 改为从 spec 派生,id 归位到 reject 一侧 (#3783)

### DIFF
--- a/.changeset/hitl-decision-outcomes-spec-derived-3783.md
+++ b/.changeset/hitl-decision-outcomes-spec-derived-3783.md
@@ -1,0 +1,43 @@
+---
+"@object-ui/plugin-chatbot": minor
+---
+
+`ApproveOutcome` / `RejectOutcome` are now derived from `@objectstack/spec`
+instead of hand-transcribed (objectui#3783). Same failure class #3220 cleared
+from the same file for `PendingActionRow` / `PendingActionStatus` — but this pair
+wore local names rather than spec names, so `check-spec-symbol-derivation.mjs`,
+which fires on a spec export name being occupied, had no handle on it. A renamed
+hand copy is invisible to a name-based guard by construction.
+
+Both types now re-export the spec's decision responses
+(`ApproveAiPendingActionResponse` / `RejectAiPendingActionResponse` from
+`@objectstack/spec/api` — the same schemas `@objectstack/client`'s
+`ai.pendingActions.approve()` / `.reject()` type their returns with). The public
+export names do not change. The shapes do, in three ways:
+
+- **`ApproveOutcome` no longer declares `id`.** The approve response has never
+  carried one — `id` is on the *reject* response. This was the one drift that
+  was not dormant: `useHitlInChat`'s public `onDecided` callback promised
+  consumers `id: string` and handed them `undefined` at runtime, with nothing
+  in the compiler to say so. **If you read `outcome.id` after an approve, that
+  read was already `undefined` and now fails to compile** — take the id from
+  `ContinueContext.pendingActionId` or from the row you decided on.
+- **`status` is closed.** `'executed' | 'failed' | string` and
+  `'rejected' | string` were both just `string`: a union with `string` absorbs
+  the literals, so neither annotation carried any information. They are now
+  `'executed' | 'failed'` and `'rejected'`.
+- **The `[k: string]: unknown` index signature on `ApproveOutcome` is gone.** The
+  objectstack#4075 mechanism: with it, any structural comparison against the
+  spec answers "identical" however far the copy has drifted, so a parity test
+  bolted onto the old type would have been green from its first day.
+
+**Breaking at the type level for importers of `@object-ui/plugin-chatbot`** —
+narrowing a published type is a break even when the old type was lying, which is
+why it is spelled out here. Shipped as `minor` per AGENTS.md §版本号策略: the
+family's `major` tracks `@objectstack`'s, and objectui's own breaking changes go
+out as `minor` with the break named in the changeset.
+
+Runtime behaviour is unchanged — including the hook's decision handling for a
+status outside the spec vocabulary, and the locally synthesized failure envelope
+on a non-2xx, both now pinned by tests. The consumer-side tolerances that remain
+in `useHitlInChat` are recorded in objectui#3790 for a maintainer decision.

--- a/packages/plugin-chatbot/src/__tests__/spec-symbol-batch6.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/spec-symbol-batch6.test.ts
@@ -33,6 +33,16 @@
  *    A path skip is broader than an ALLOW entry, and the hole it opens is an
  *    objectui-AUTHORED file dropped into that directory and silently unscanned.
  *    `the vendored directory stays vendored` below is what closes it.
+ *
+ * objectui#3783 added a fifth and sixth pin here for the guard's OTHER hole —
+ * the one no allowlist and no path skip is responsible for. `ApproveOutcome` /
+ * `RejectOutcome` in the same `usePendingActions.ts` were hand copies of the
+ * spec's approve/reject wire responses under DIFFERENT local names, so the
+ * name-collision guard was never going to see them: it fires on a spec name
+ * being occupied, and these occupied none. A renamed hand copy is invisible to
+ * a name-based check by construction, which makes a compile-time parity pin the
+ * only thing that can hold them — see
+ * `the decision outcomes ARE the spec wire responses` at the bottom.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -42,11 +52,20 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { PendingActionRow, PendingActionStatus } from '../usePendingActions';
+import type {
+  ApproveOutcome,
+  PendingActionRow,
+  PendingActionStatus,
+  RejectOutcome,
+} from '../usePendingActions';
 import type {
   PendingActionRow as SpecPendingActionRow,
   PendingActionStatus as SpecPendingActionStatus,
 } from '@objectstack/spec/contracts';
+import type {
+  ApproveAiPendingActionResponse,
+  RejectAiPendingActionResponse,
+} from '@objectstack/spec/api';
 
 /** Every name `@objectstack/spec` exports from any subpath — types AND values. */
 function specExportNames(): Set<string> {
@@ -239,5 +258,75 @@ describe('the pending-action row and status ARE the spec contract', () => {
     // status, this fails here rather than as an unstyled badge in the queue.
     const all: PendingActionStatus[] = ['pending', 'approved', 'executed', 'failed', 'rejected'];
     expect(new Set(all).size).toBe(5);
+  });
+});
+
+describe('the decision outcomes ARE the spec wire responses', () => {
+  it('is pinned at compile time', () => {
+    type _ApproveNotAny = Assert<Equal<IsAny<ApproveAiPendingActionResponse>, false>>;
+    type _ApproveNotUnknown = Assert<Equal<IsUnknown<ApproveAiPendingActionResponse>, false>>;
+    type _RejectNotAny = Assert<Equal<IsAny<RejectAiPendingActionResponse>, false>>;
+
+    type _ApproveIsSpec = Assert<Equal<ApproveOutcome, ApproveAiPendingActionResponse>>;
+    type _RejectIsSpec = Assert<Equal<RejectOutcome, RejectAiPendingActionResponse>>;
+
+    // Drift 1 — the copy declared `id: string`, REQUIRED, on the APPROVE side.
+    // The approve response has no `id` at all; `id` is the REJECT response's.
+    // This is the one drift that was not dormant: `useHitlInChat`'s public
+    // `onDecided` callback handed consumers this type over a payload that has
+    // never carried the field, so `outcome.id` type-checked and evaluated to
+    // `undefined`. The pin is `keyof`-shaped rather than an `Equal` on the
+    // property type because the failure to catch is the key EXISTING.
+    type _ApproveHasNoId = Assert<Equal<'id' extends keyof ApproveOutcome ? true : false, false>>;
+    type _RejectHasId = Assert<Equal<RejectOutcome['id'], string>>;
+
+    // Drift 2 — `'executed' | 'failed' | string` and `'rejected' | string`. A
+    // union with `string` ABSORBS the literals, so both annotations conveyed
+    // nothing; `AiPendingActionsInbox`'s `out.status === 'executed'` could have
+    // been compared against any spelling at all.
+    type _ApproveStatusNotString = Assert<
+      Equal<string extends ApproveOutcome['status'] ? true : false, false>
+    >;
+    type _RejectStatusNotString = Assert<
+      Equal<string extends RejectOutcome['status'] ? true : false, false>
+    >;
+    type _ApproveVocabulary = Assert<Equal<ApproveOutcome['status'], 'executed' | 'failed'>>;
+    type _RejectVocabulary = Assert<Equal<RejectOutcome['status'], 'rejected'>>;
+
+    // Drift 3 — `[k: string]: unknown` on the approve copy. objectstack#4075:
+    // with it, this whole describe block would have been green on the copies.
+    type _ApproveNoIndexSignature = Assert<Equal<HasIndexSignature<ApproveOutcome>, false>>;
+    type _RejectNoIndexSignature = Assert<Equal<HasIndexSignature<RejectOutcome>, false>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('the spec still exports the names these are derived from', () => {
+    // The reverse pin. `check-spec-symbol-derivation.mjs` cannot cover this
+    // pair — the local names are `ApproveOutcome` / `RejectOutcome`, which
+    // collide with nothing, and that is exactly how a renamed hand copy hides
+    // from a name-based guard. So the only thing standing between these types
+    // and a fresh hand copy is the `Assert<Equal<…>>` block above plus this:
+    // if the spec renames or retires either response type, the import breaks
+    // loudly at compile time instead of the derivation quietly rotting.
+    for (const owned of ['ApproveAiPendingActionResponse', 'RejectAiPendingActionResponse']) {
+      expect(
+        SPEC_NAMES.has(owned),
+        `@objectstack/spec no longer exports \`${owned}\`, which ` +
+          `packages/plugin-chatbot/src/usePendingActions.ts derives its public ` +
+          `\`${owned.startsWith('Approve') ? 'ApproveOutcome' : 'RejectOutcome'}\` from. ` +
+          `Re-derive from the replacement — do NOT re-transcribe the shape locally ` +
+          `(objectui#3783).`,
+      ).toBe(true);
+    }
+  });
+
+  it('neither local name collides with a spec export', () => {
+    // Pins the PREMISE of the two pins above: were either name to become a spec
+    // export, `check-spec-symbol-derivation.mjs` would start covering this file
+    // for it and this note would be stale.
+    for (const local of ['ApproveOutcome', 'RejectOutcome']) {
+      expect(SPEC_NAMES.has(local)).toBe(false);
+    }
   });
 });

--- a/packages/plugin-chatbot/src/__tests__/useHitlInChat.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/useHitlInChat.test.tsx
@@ -31,8 +31,12 @@ describe('useHitlInChat', () => {
   it('fires continueConversation with an executed-outcome prompt on approve', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
+      // The approve wire response, exactly: `{ status, result?, error? }` and no
+      // `id` (spec `ApproveAiPendingActionResponseSchema`; objectui#3783). The
+      // `pa_42` the prompt below carries comes from the message index, not from
+      // this payload — which is why the old `id: string` promise on
+      // `ApproveOutcome` was never load-bearing here and stayed invisible.
       text: async () => JSON.stringify({
-        id: 'pa_42',
         status: 'executed',
         result: { deleted: 1, taskId: 't1' },
       }),
@@ -93,7 +97,7 @@ describe('useHitlInChat', () => {
   it('does NOT continue when execution failed', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      text: async () => JSON.stringify({ id: 'pa_42', status: 'failed', error: 'boom' }),
+      text: async () => JSON.stringify({ status: 'failed', error: 'boom' }),
     } as Response);
 
     const continueConversation = vi.fn();
@@ -113,10 +117,121 @@ describe('useHitlInChat', () => {
     expect(result.current.decisions['tc-1']?.message).toContain('boom');
   });
 
+  /* ------------------------------------------------------------------ */
+  /* objectui#3783 — what `onDecided` actually receives.                 */
+  /* ------------------------------------------------------------------ */
+
+  it('hands onDecided the approve payload verbatim — which carries no id', async () => {
+    // The drift `ApproveOutcome.id: string` promised: it was REQUIRED on the
+    // type and absent from the wire, so a consumer reading `outcome.id` here
+    // got `undefined` with no compiler complaint. The type no longer declares
+    // it; this pins that the runtime object never had it either.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ status: 'executed', result: { deleted: 1 } }),
+    } as Response);
+
+    const onDecided = vi.fn();
+    const { result } = renderHook(() =>
+      useHitlInChat({ messages: [baseMessage('pa_42')], onDecided }),
+    );
+
+    await act(async () => {
+      await result.current.decide('tc-1', true);
+    });
+
+    expect(onDecided).toHaveBeenCalledTimes(1);
+    const [toolCallId, outcome] = onDecided.mock.calls[0];
+    expect(toolCallId).toBe('tc-1');
+    expect(outcome).toEqual({ status: 'executed', result: { deleted: 1 } });
+    expect('id' in (outcome as object)).toBe(false);
+  });
+
+  it('hands onDecided the reject payload verbatim — where id IS the wire', async () => {
+    // Mirror image: the spec puts `id` on the reject response, so it is present
+    // here and `RejectOutcome` declares it.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ status: 'rejected', id: 'pa_42' }),
+    } as Response);
+
+    const onDecided = vi.fn();
+    const { result } = renderHook(() =>
+      useHitlInChat({ messages: [baseMessage('pa_42')], onDecided }),
+    );
+
+    await act(async () => {
+      await result.current.decide('tc-1', false, 'too risky');
+    });
+
+    expect(onDecided).toHaveBeenCalledWith('tc-1', { status: 'rejected', id: 'pa_42' });
+  });
+
+  it('still synthesizes the locally-built failure envelope, id included, on a non-2xx', async () => {
+    // Behaviour pin for the type-only narrowing (objectui#3783): on a non-2xx
+    // there is no decision response at all, so the hook fabricates one. That
+    // object has carried `id` since the callback shipped and still does —
+    // `ApproveOutcome` simply stopped DECLARING a field the wire never sent.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      text: async () => JSON.stringify({ error: 'ai:approve required' }),
+    } as Response);
+
+    const onDecided = vi.fn();
+    const continueConversation = vi.fn();
+    const { result } = renderHook(() =>
+      useHitlInChat({ messages: [baseMessage('pa_42')], onDecided, continueConversation }),
+    );
+
+    await act(async () => {
+      await result.current.decide('tc-1', true);
+    });
+
+    expect(onDecided).toHaveBeenCalledWith('tc-1', {
+      id: 'pa_42',
+      status: 'failed',
+      error: 'ai:approve required',
+    });
+    expect(result.current.decisions['tc-1']?.state).toBe('error');
+    expect(continueConversation).not.toHaveBeenCalled();
+  });
+
+  it('keeps treating an unrecognised status as a success chip, without continuing', async () => {
+    // The `else` fallback in `decide()`. objectui#3783 narrowed the TYPES only,
+    // and deliberately left this branch alone: `status` is read off an unparsed
+    // `Record<string, unknown>`, so the closed enum exerts no exhaustiveness
+    // pressure on it and the branch stays reachable for a server that answers
+    // outside the spec vocabulary. Pinned as-is so a later behaviour verdict
+    // is a visible diff rather than a silent one — including the part the
+    // filing report got wrong: `succeeded` goes true, but the continuation
+    // prompt builder returns `undefined` for an unknown status, so the
+    // conversation is NOT continued.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ status: 'quarantined' }),
+    } as Response);
+
+    const continueConversation = vi.fn();
+    const { result } = renderHook(() =>
+      useHitlInChat({ messages: [baseMessage('pa_42')], continueConversation }),
+    );
+
+    await act(async () => {
+      await result.current.decide('tc-1', true);
+    });
+
+    expect(result.current.decisions['tc-1']).toEqual({
+      state: 'success',
+      message: 'Status: quarantined',
+    });
+    expect(continueConversation).not.toHaveBeenCalled();
+  });
+
   it('does NOT continue when option is omitted', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
-      text: async () => JSON.stringify({ id: 'pa_42', status: 'executed', result: 'ok' }),
+      text: async () => JSON.stringify({ status: 'executed', result: 'ok' }),
     } as Response);
 
     const { result } = renderHook(() =>

--- a/packages/plugin-chatbot/src/useHitlInChat.ts
+++ b/packages/plugin-chatbot/src/useHitlInChat.ts
@@ -59,6 +59,19 @@ export interface UseHitlInChatOptions {
    * Optional callback fired after a decision completes (regardless of
    * success/failure). Useful for refreshing the inbox view if it is also
    * mounted on the same page.
+   *
+   * `outcome` is the spec decision response as the endpoint returned it, so
+   * read it by side: `result` / `error` on approve, `id` on reject
+   * (objectui#3783 — the previous local types promised `id` on BOTH, and the
+   * approve response has never carried one). `pendingActionId` is available
+   * from `ContinueContext` and from the row you decided on; do not fish it out
+   * of an approve outcome.
+   *
+   * One honest caveat: on a transport error or non-2xx there IS no decision
+   * response, and this callback is still invoked — with an envelope the hook
+   * synthesizes locally (`{ status: 'failed', error }`). That case is not
+   * modelled by this parameter's type; narrowing it is a public-contract
+   * decision tracked in objectui#3790.
    */
   onDecided?: (toolCallId: string, outcome: ApproveOutcome | RejectOutcome) => void;
   /**
@@ -80,7 +93,12 @@ export interface ContinueContext {
   toolCallId: string;
   pendingActionId: string;
   decision: 'approved' | 'rejected';
-  /** Raw REST payload — `{ status, result?, error?, … }`. */
+  /**
+   * Raw REST payload — the spec decision response: `{ status: 'executed' |
+   * 'failed', result?, error? }` on approve, `{ status: 'rejected', id }` on
+   * reject (objectui#3783). Note `id` is on the REJECT side only; use
+   * `pendingActionId` above, which is populated for both decisions.
+   */
   outcome: ApproveOutcome | RejectOutcome;
   /** Tool name as it appeared in the message part (e.g. `action_delete_task`). */
   toolName?: string;
@@ -206,6 +224,14 @@ export function useHitlInChat(options: UseHitlInChatOptions): UseHitlInChatRetur
               ? payload.error
               : `Approval failed: HTTP ${response.status}`;
           setDecision(toolCallId, { state: 'error', message });
+          // Not a wire response: on a non-2xx there IS no decision response, so
+          // this envelope is synthesized locally to notify `onDecided`. The
+          // `id` stays on it deliberately — it has been part of what consumers
+          // receive on this path since the callback shipped, and objectui#3783
+          // is a type-only correction (`ApproveOutcome` no longer DECLARES
+          // `id`, because the approve wire never carried one). What the
+          // callback SHOULD be handed on transport/HTTP failure is a public
+          // contract question, filed as objectui#3790, not settled here.
           onDecided?.(toolCallId, {
             id,
             status: 'failed',

--- a/packages/plugin-chatbot/src/usePendingActions.ts
+++ b/packages/plugin-chatbot/src/usePendingActions.ts
@@ -25,6 +25,10 @@
 import * as React from 'react';
 
 import type {
+  ApproveAiPendingActionResponse,
+  RejectAiPendingActionResponse,
+} from '@objectstack/spec/api';
+import type {
   PendingActionRow,
   PendingActionStatus,
 } from '@objectstack/spec/contracts';
@@ -58,26 +62,46 @@ import type {
 export type { PendingActionRow, PendingActionStatus };
 
 /**
- * Successful approval outcome returned by
- * `POST /api/v1/ai/pending-actions/:id/approve`.
+ * The two decision responses —
+ * `POST /api/v1/ai/pending-actions/:id/approve` and `…/reject` — THE spec
+ * types, re-exported under this package's published names (objectui#3783).
  *
- * The HTTP status is 200 when `status === 'executed'` and 500 when the
- * downstream dispatcher failed (`status === 'failed'`). The hook surfaces
- * both as a normal resolved value so the UI can show the error inline
- * without throwing.
+ * `@objectstack/spec/api` declares both (`ApproveAiPendingActionResponseSchema`
+ * / `RejectAiPendingActionResponseSchema` in `api/protocol.zod.ts`), and those
+ * are the same schemas `@objectstack/client`'s `ai.pendingActions.approve()` /
+ * `.reject()` type their return values with — so what is re-exported here IS
+ * the wire, not a second reading of it. The local names stay `ApproveOutcome` /
+ * `RejectOutcome` because they are this package's public API surface
+ * (`src/index.tsx`); only the shapes change.
+ *
+ * `status: 'failed'` is an HTTP **200** carrying a reason, not a 5xx: the
+ * approval succeeded, the execution did not (see the doc comment on
+ * `ApproveAiPendingActionResponseSchema`). The comment that used to sit here
+ * claimed 500, which contradicted both the spec and this hook's own design —
+ * `call()` throws on `!res.ok`, so a 500 could never reach the resolved-value
+ * path `AiPendingActionsInbox` reads `out.error` from.
+ *
+ * The copies this replaces were hand transcriptions and had drifted three ways.
+ * Because the local names are NOT the spec's names,
+ * `scripts/check-spec-symbol-derivation.mjs` — which fires when a local
+ * declaration OCCUPIES a spec export name — had no handle on them at all;
+ * renaming a hand copy is invisible to a name-based guard:
+ *
+ *  - `ApproveOutcome.id: string`, REQUIRED here and absent from the approve
+ *    response — `id` is on the REJECT side. This drift was not dormant: the
+ *    public `onDecided` callback (`useHitlInChat`) promised consumers a
+ *    `string` and handed them `undefined` at runtime, with no compiler
+ *    complaint anywhere;
+ *  - `status: 'executed' | 'failed' | string` — a union with `string` ABSORBS
+ *    the literals, so the annotation carried no information at all. The same
+ *    drift #3220 removed from the row above;
+ *  - `[k: string]: unknown` — the objectstack#4075 mechanism: an index
+ *    signature makes any structural comparison against the spec answer
+ *    "identical" however far the copy has drifted, so a parity test bolted onto
+ *    the copy would have been green from its first day.
  */
-export interface ApproveOutcome {
-  id: string;
-  status: 'executed' | 'failed' | string;
-  result?: unknown;
-  error?: string;
-  [k: string]: unknown;
-}
-
-export interface RejectOutcome {
-  id: string;
-  status: 'rejected' | string;
-}
+export type ApproveOutcome = ApproveAiPendingActionResponse;
+export type RejectOutcome = RejectAiPendingActionResponse;
 
 export interface UsePendingActionsOptions {
   /**


### PR DESCRIPTION
Fixes #3783

`packages/plugin-chatbot/src/usePendingActions.ts` 里手写的 `ApproveOutcome` / `RejectOutcome` 改为从 `@objectstack/spec` 派生。与 #3220 从**同一文件**清掉 `PendingActionRow` / `PendingActionStatus` 是同一失败类;不同之处在于这两个穿的是**本地名字**,所以 `scripts/check-spec-symbol-derivation.mjs`(按"spec 导出名被本地声明占用"触发)对它们天生没有抓手 —— **换个名字手抄,对名字型守卫是隐形的**。

## 派生形态(#3220 范式,零新依赖)

`@objectstack/spec` 已是本包运行时依赖(`package.json`,#3220 引入),且本次只用 `import type`,**编译期即擦除,不进 bundle**:

```ts
import type {
  ApproveAiPendingActionResponse,
  RejectAiPendingActionResponse,
} from '@objectstack/spec/api';

export type ApproveOutcome = ApproveAiPendingActionResponse;
export type RejectOutcome = RejectAiPendingActionResponse;
```

派生源实读(不凭 issue 转述),objectstack `origin/main` `d42a92fc6`:

- `packages/spec/src/api/protocol.zod.ts:1453-1462` —— `ApproveAiPendingActionResponseSchema` 只有 `status: z.enum(['executed','failed'])` / `result?` / `error?`;`RejectAiPendingActionResponseSchema` 是 `status: z.literal('rejected')` + `id: z.string()`。
- `:1680-1681` 导出这两个类型名;`packages/spec/src/api/index.ts:44` `export * from './protocol.zod'`,故 `@objectstack/spec/api` 子路径可达(装在本 worktree 的 `17.0.0-rc.5` dist 里两个名字都实测在导出清单内)。
- 第二个独立信源:`packages/spec/src/contracts/ai-service.ts:298-301` 的 `IAIService.approvePendingAction` 返回 `Promise< { status: 'executed' | 'failed'; result?: unknown; error?: string } >` —— 同样没有 `id`。
- 第三个:`packages/client/src/index.ts:4109-4127`,`ai.pendingActions.approve()` / `.reject()` 正是用这两个 spec 类型标注返回值。也就是说本 PR 之后,objectui 与 objectstack client 对同一条 wire 的读法收敛到同一个声明。

公开导出名保持 `ApproveOutcome` / `RejectOutcome` 不变(`src/index.tsx` 的已发布 API 面),只改形状。

## 三处漂移的逐条处置

| 漂移 | 处置 | 证据 |
|:--|:--|:--|
| `ApproveOutcome.id: string` **必填**,而 approve 响应根本不带 `id` | 删除;`id` 按 spec 归位到 `RejectOutcome`(reject 响应确实带) | 下游探针:改前 `outcome.id` 编译通过(运行期 `undefined`),改后 TS2339 |
| `status: 'executed' \| 'failed' \| string` / `'rejected' \| string` | 收敛为 `'executed' \| 'failed'` 与 `'rejected'` | 下游探针:改前 `outcome.status === 'quarantined'` 编译通过,改后 TS2367 |
| `[k: string]: unknown` 索引签名 | 删除(objectstack#4075:有它在,任何结构比较恒答"一致",给旧类型补 parity 测试也会从第一天就是绿的) | sabotage:`HasIndexSignature` 钉子在恢复手写形态后变红 |

第 1 条是**当下在跑**的那条:公开回调 `onDecided` 编译期承诺 `id: string`,运行期给 `undefined`,编译器全程沉默。

### 顺手改正的第四处漂移(prose,不是类型)

被替换掉的注释写着 approve 失败是 **HTTP 500**。这与 spec 的注释(`status: 'failed'` 是**带原因的 200** —— 审批成功、执行失败)相反,也与本文件自身设计自相矛盾:`call()` 在 `!res.ok` 时抛错,若真是 500,`AiPendingActionsInbox.tsx:204-206` 读 `out.error` 的那条 resolved-value 路径就永远不可达。新注释按 spec 写。这类"声称 canonical 的错注释"正是本守卫家族要消灭的东西(它会成为下一个 agent 的既定前提),所以在替换该声明时一并订正,而非留给下一张单。

## 行为零变更论证(PM 判级边界指定的一节)

**默认仅类型收紧。** 逐处交代:

### 1. `useHitlInChat.ts` 的 `else` 兜底(未知 status)—— 保留

```ts
} else {
  setDecision(toolCallId, { state: 'success', message: `Status: ${status}` });
  succeeded = true;
}
```

- **类型层压力:零。** `status` 来自 `const status = (payload.status as string) ?? …`,而 `payload` 是 `parseJson()` 返回的 `Record< string, unknown >` —— **未经任何解析**。它是 `string`,不是闭合枚举,所以 `ApproveOutcome['status']` 收紧到两个字面量对这条分支施加不了穷尽性检查,`tsc` 也不会把它判死。也就是说:**不改行为完全能过 type-check**(实测绿),不存在"exhaustiveness 逼死 else"的情形,无需停手。
- **运行期可达性:** 仅当服务端返回 spec 词表之外的 status 时可达 —— 即不合规服务端或未来新增 status。对今天合规的服务端不可达。
- **核实后修正 issue 正文一处描述:** 该分支**不会**"继续对话"。`succeeded` 确实置 true,但 `buildContinuationPrompt` 对 `executed`/`rejected`/`failed` 之外的 status 返回 `undefined`,`if (prompt)` 不成立,`continueConversation` 不被调用。所以后果只是一个乐观的 UI chip,不是"把假成功喂给模型"。已用测试钉住(`keeps treating an unrecognised status as a success chip, without continuing`)。
- **保留理由:** 关掉它需要先回答"未知 status 该显示成错误、还是抛错、还是静默忽略",那是行为裁决而非实现细节;而且真要闭合,正确做法是在此处用 spec schema `safeParse`(producer 说话),那会把 zod 拖进这个以 tiny bundle 为卖点的包 —— 属政策问题。已连同下面两条一起记入 #3790。

### 2. 非 2xx 时本地虚构的失败信封 —— 保留,`id` 也保留

```ts
onDecided?.(toolCallId, { id, status: 'failed', error: message } as ApproveOutcome);
```

这条路径上**没有**决策响应(服务端返回的是错误体),所以这个信封是本地造的通知。它自带 `id` 是既有行为,外部消费者在这条路径上今天**确实能读到**,删掉即运行期回归 —— 所以留着。类型层面 `ApproveOutcome` 不再声明 `id`(approve wire 从来没有),断言允许多余属性,故不需要改代码形状。已用测试钉住(`still synthesizes the locally-built failure envelope, id included, on a non-2xx`)。

### 3. `useHitlInChat.ts:237` 的断言 —— 核对通过,无需改写

`payload as ApproveOutcome | RejectOutcome`:`payload` 是 `Record< string, unknown >`,而收紧后的两个类型都是匿名对象类型(`z.infer` 别名),带隐式索引签名,可比较关系成立,断言合法。实测 `tsc` 绿,未退化成 `as unknown as`。

## sabotage 自证(方向:红。改动即钉子,所以是常规方向)

把派生临时改回手写漂移形态(`id: string` + `| string` + 索引签名),只跑 typetests 工程:

```
$ pnpm --filter @object-ui/plugin-chatbot exec tsc -p tsconfig.typetests.json
src/__tests__/spec-symbol-batch6.test.ts(270,34): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/__tests__/spec-symbol-batch6.test.ts(271,33): error TS2344: ...
src/__tests__/spec-symbol-batch6.test.ts(280,35): error TS2344: ...
src/__tests__/spec-symbol-batch6.test.ts(288,7):  error TS2344: ...
src/__tests__/spec-symbol-batch6.test.ts(291,7):  error TS2344: ...
src/__tests__/spec-symbol-batch6.test.ts(293,38): error TS2344: ...
src/__tests__/spec-symbol-batch6.test.ts(294,37): error TS2344: ...
src/__tests__/spec-symbol-batch6.test.ts(298,44): error TS2344: ...
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command failed with exit code 2
```

八条红对应:`_ApproveIsSpec`(270)、`_RejectIsSpec`(271)、`_ApproveHasNoId`(280,即那条在跑的缺陷)、`_ApproveStatusNotString`(288)、`_RejectStatusNotString`(291)、`_ApproveVocabulary`(293)、`_RejectVocabulary`(294)、`_ApproveNoIndexSignature`(298)。

诚实标注:`_RejectNoIndexSignature`(299)在 sabotage 下**仍是绿的** —— 因为 reject 那份手抄本来就没有索引签名。这条钉子钉的是"以后别加",不是"当时有"。

还原后 `pnpm --filter @object-ui/plugin-chatbot type-check` 全绿(sabotage 未入 commit)。

## 下游消费者探针(证明收紧穿透到已发布的 .d.ts,且没有擦成 any)

`vite build` 后拿 `dist/index.d.ts` 当真实下游编译(探针文件已删除,未入 commit)。`dist/usePendingActions.d.ts` 首行保留了 `import { ApproveAiPendingActionResponse, RejectAiPendingActionResponse } from '@objectstack/spec/api';`,类型未擦除(objectstack#4171 是"spec 类型在 dist 里擦成 any"的先例,这里实测没有发生)。

改后(期望:两条错,其余静默):

```
probe-3783.ts(28,18): error TS2339: Property 'id' does not exist on type
  '{ status: "failed" | "executed"; result?: unknown; error?: string | undefined; }'.
probe-3783.ts(33,10): error TS2367: This comparison appears to be unintentional
  because the types '"failed" | "executed"' and '"quarantined"' have no overlap.
```

改前(把 origin/main `4028adfc3` 的手写形态原文抄进探针,同样两处读法):`exit 0`,**零错**。这就是本单要消灭的东西:一个 wire 从未兑现的承诺,和一个任何拼写都能通过的 status 比较。`IsAny` / `IsUnknown` 探针、以及 `outcome.status === 'executed'`、`RejectOutcome.id` 这些**合法**读法在改后依然无错。

## 消费半径清单(逐个确认)

全仓 grep `ApproveOutcome|RejectOutcome|onDecided`(排除 node_modules)命中三个文件,全在本包内:

| 消费方 | 读什么 | 结论 |
|:--|:--|:--|
| `packages/plugin-chatbot/src/usePendingActions.ts` | `approve()`/`reject()` 的返回标注 | 定义方,已改 |
| `packages/plugin-chatbot/src/useHitlInChat.ts` | 两处 `as` 断言 + `onDecided`/`ContinueContext` 类型面 | 已核对,注释补齐,无代码形状变更 |
| `packages/plugin-chatbot/src/index.tsx` | 只 re-export 两个名字 | 名字不变,无改动 |
| `packages/plugin-chatbot/src/AiPendingActionsInbox.tsx` | `out.status === 'executed'`、`out.error` | 两处在收紧后仍合法(词表内的字面量 + 可选 `error`);type-check 绿 |
| `packages/app-shell/src/console/ai/AiChatPage.tsx:1637` | `useHitlInChat({ messages, apiBase, continueConversation })` | **不**使用 `onDecided`、不读 outcome;options 接口未变。已单独跑 `pnpm --filter @object-ui/app-shell type-check`(先 build 其全部依赖,避免 TS2307 假红)→ 绿 |
| `apps/console/src/pages/system/AiPendingActionsPage.tsx` | 只渲染 `AiPendingActionsInbox` | `AiPendingActionsInboxProps` 不含任何 outcome 类型,零影响 |

**本仓没有读 `outcome.id` 的外部消费者**。仓外消费者若读了,那读的就是 `undefined`,现在会在编译期显形 —— changeset 正文写了替代取值处(`ContinueContext.pendingActionId`)。

## 守卫配套

`src/__tests__/spec-symbol-batch6.test.ts` 的既有范式(`Assert< Equal< … > >`,由本包 `tsconfig.typetests.json` 编译,已在 `type-check` 执行面内)扩了一个 describe:`the decision outcomes ARE the spec wire responses`,含

- 派生同一性(`_ApproveIsSpec` / `_RejectIsSpec`)与 `IsAny`/`IsUnknown` 探针;
- 三条漂移各自的钉子(`id` 键不存在 / status 不被 `string` 吸收 + 词表精确 / 无索引签名);
- 两条**反向钉**:spec 仍导出被派生的两个名字(retire 即在编译期炸,而非派生悄悄腐烂);两个本地名字**仍不与 spec 撞名** —— 这正是名字型守卫看不见它们的前提,前提变了这段注释就该重读。

`node scripts/check-spec-symbol-derivation.mjs` 通过(1210 文件 / 4862 个 spec 名,13 declared dialects,3 untriaged collisions in 1 package —— 与 main 同数,本 PR 未新增也未消除该计数:两个本地名字不撞名,守卫按设计不计)。

## 验证

```
$ pnpm vitest run packages/plugin-chatbot --maxWorkers=2
 Test Files  17 passed (17)
      Tests  258 passed (258)

$ pnpm --filter @object-ui/plugin-chatbot type-check      # tsc --noEmit && tsc -p tsconfig.typetests.json
 (无输出,exit 0)

$ pnpm --filter @object-ui/app-shell type-check
 (无输出,exit 0)

$ pnpm --filter @object-ui/plugin-chatbot lint
 ✖ 106 problems (0 errors, 106 warnings)     # 全部为既有 warning,0 error

$ node scripts/check-spec-symbol-derivation.mjs
 ✅ spec symbol derivation: 1210 files scanned against 4862 spec export names; ...

$ node scripts/check-changeset-no-major.mjs
 ✅ No changeset declares a `major` bump.

$ node scripts/check-control-bytes.mjs
 ✅ check-control-bytes: OK (scanned 3718 tracked text file(s); skipped 85 binary).

$ pnpm vitest run scripts/__tests__/check-changeset-no-major.test.ts scripts/__tests__/check-changeset-presence.test.ts
 Test Files  2 passed (2)   Tests  38 passed (38)
```

新增测试(`useHitlInChat.test.tsx`,4 条)与 fixture 处置:

- 三个 approve mock **重新拼写**为真正的 approve wire(去掉 `id`)—— 顺带证明 `[HITL pa_42]` 提示语里的 id 来自 message 索引而非 payload,这也解释了那条假承诺为何能长期无人察觉;reject mock 保留 `id`(按 spec 它就在那儿)。
- `hands onDecided the approve payload verbatim — which carries no id`:钉住 approve 侧运行期确实没有 `id`。
- `hands onDecided the reject payload verbatim — where id IS the wire`:镜像。
- `still synthesizes the locally-built failure envelope, id included, on a non-2xx`:钉住行为零变更。
- `keeps treating an unrecognised status as a success chip, without continuing`:钉住刻意保留的 `else` 行为(含"不继续对话"这一被更正的事实)。

## changeset 档位

`minor`(`@object-ui/plugin-chatbot`)。依据 AGENTS.md §版本号策略:固定版本组的 major 跟随 `@objectstack`,**objectui 自身的破坏性变更一律标 `minor`,在正文里写清 breaking 语义**;`scripts/check-changeset-no-major.mjs` 机械强制。#3220 当时标了 `major`,但那正是该守卫因之诞生的四张单之一(17.x 期间会把 39 个包发成 18.0.0),所以此处不沿用它的档位,沿用的是它的**处置范式**。changeset 正文点名了收紧本身、以及 `outcome.id` 读法的替代取值处。

## 关联

- #3790(本单实施中发现,`finding`,不带 `pm:queue`):`useHitlInChat` 剩下的三处消费侧容忍 —— 失败信封不是 wire 响应、status 兜底默认、未知 status 当成功;含 A/B/C 三个选项与长期取舍分析,交 maintainer 裁决。
- #3220(同文件同失败类的处置范式)、#3293(本单发现来源)、#3720(同类)、objectstack#4075(索引签名机制)、objectstack#4115(ledger)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_