### PR TITLE
fix(app-shell): 环境列表创建按钮在 entitlements 解析前渲染 skeleton,消除文案跳变

### DIFF
--- a/.changeset/environment-create-cta-loading-skeleton-3482.md
+++ b/.changeset/environment-create-cta-loading-skeleton-3482.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/app-shell": patch
+---
+
+console: hold the environment list's create CTA with a skeleton until entitlements
+resolve, instead of showing a label that is about to be overwritten (objectui#3482,
+part of cloud#1049).
+
+`EnvironmentListToolbar` presents a state-aware create affordance — "Set up your
+production environment" / "Add development environment" / an upgrade prompt — decided
+from `GET /cloud/environment-entitlements`. While that request was in flight the
+toolbar rendered the action's metadata label, so the button visibly changed its
+wording the moment the response landed. The two texts are owned by different
+packages (the cloud translation bundle vs this repo's locale packs), which made the
+swap read as an inconsistency rather than a load.
+
+The in-flight state now renders a `Skeleton` sized like the button it stands in for,
+matching the adjacent `cloud:onboarding-next` welcome CTA. Only the create action is
+withheld — other toolbar actions never re-label, so they keep rendering — and a
+toolbar without a create action gets no skeleton at all. The skeleton is never
+terminal: when both entitlement signals fail, the resolution settles as
+`{ ready: false, source: 'unknown' }` and the neutral metadata label is shown, which
+remains the honest text for a state where "which create is this?" is genuinely
+unknown.

--- a/packages/app-shell/src/environment/EnvironmentListToolbar.tsx
+++ b/packages/app-shell/src/environment/EnvironmentListToolbar.tsx
@@ -14,16 +14,53 @@
  *                                  makes a dev env).
  *   • has prod + dev NOT allowed → "Add environment" that opens an UPGRADE prompt
  *                                  instead of POST-ing into a 403.
- *   • still resolving / unknown  → the action's default label (neutral), with the
+ *   • still resolving            → a SKELETON where the create button will land —
+ *                                  no label at all (see below).
+ *   • settled with no signal     → the action's metadata label (neutral), with the
  *                                  apiHandler entitlement dialog as the safety net.
  *
  * Create flows reuse the standard `action:bar` runner (name modal → apiHandler),
  * so only the label/variant changes — no duplicate POST logic here.
+ *
+ * ## Why a skeleton while resolving (cloud#1049 → objectui#3482)
+ *
+ * Rendering the metadata label while entitlements were in flight made the button
+ * visibly change its wording mid-load: the cloud action metadata's "create
+ * environment" label, replaced by `environment.setUpProduction` the moment
+ * `/cloud/environment-entitlements` answered. Locale-independent by mechanism,
+ * though it was reported against the Chinese console, where the two texts are
+ * owned by different packages and the swap read as an inconsistency rather than
+ * a load. The maintainer's ruling on cloud#1049 was option A — present nothing
+ * rather than a label we are about to overwrite. Same shape as the adjacent
+ * `cloud:onboarding-next` welcome CTA (`console/home/CloudOnboardingNext.tsx`):
+ * loading → neutral skeleton sized like the button, unknown/error → degrade to a
+ * working button. Option B (a neutral label for every state) was rejected: it is
+ * semantically wrong for an org that already owns its production environment.
+ *
+ * ## Who owns this button's text (the "two sources" question)
+ *
+ * There is no longer one string with two owners — there are two DIFFERENT strings
+ * for two different states, and each has exactly one owner:
+ *
+ *   • Every RESOLVED state → THIS package. `environment.setUpProduction` /
+ *     `environment.addDevelopment` / `environment.addEnvironment` in
+ *     `packages/i18n/src/locales/*.ts` are the sole source of truth. The cloud
+ *     action metadata's `_actions.create_environment.label` translation CANNOT
+ *     reach the button here — `decideEnvironmentCta()` is total over `ready`
+ *     state, so a resolved state always overrides the label.
+ *   • Still resolving → nothing (skeleton).
+ *   • Settled with NO usable signal (`ready: false`, `source: 'unknown'` — the
+ *     summary endpoint was unusable AND the row-derivation threw) → the metadata
+ *     label, deliberately. It is the one state where "which create is this?" is
+ *     genuinely unknown, so the producer's neutral wording is the only honest
+ *     text. This is the metadata label's ONLY surviving path on this button; the
+ *     cloud-side bundle entry therefore still has a job and must not be deleted
+ *     (reported back on cloud#1049 for the cloud seat).
  */
 
 import { useEffect, useRef, useState } from 'react';
 import { SchemaRenderer } from '@object-ui/react';
-import { Button } from '@object-ui/components';
+import { Button, Skeleton } from '@object-ui/components';
 import { Plus } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import {
@@ -73,10 +110,30 @@ function useAutoRunCreate(ctaKind: string | null): boolean {
   return shouldRun;
 }
 
+/** Non-create toolbar actions, rendered through the normal bar in every state. */
+function otherActions(toolbarActions: any[]): any[] {
+  return toolbarActions.filter((a: any) => a?.name !== CREATE_ACTION);
+}
+
+function OtherActionsBar({ actions }: { actions: any[] }) {
+  if (actions.length === 0) return null;
+  return (
+    <SchemaRenderer
+      schema={{ type: 'action:bar', location: 'list_toolbar', actions, size: 'sm', variant: 'outline' }}
+    />
+  );
+}
+
 interface Props {
   /** Toolbar actions already localized by the caller (ObjectView). */
   actions: any[];
-  /** Resolved entitlement state, or null while still loading. */
+  /**
+   * Resolved entitlement state, or `null` while the resolution is still in
+   * flight. The distinction matters: `useEnvironmentEntitlements` holds `null`
+   * only until its async resolution settles, and reports a settled-but-useless
+   * result as `{ ready: false, source: 'unknown' }` — so `null` here means
+   * "wait" (skeleton) and never "we gave up" (which must keep a usable button).
+   */
   entitlements: EnvironmentEntitlementsState | null;
   /** Open the shared entitlement dialog (proactive upgrade prompt). */
   onUpgrade: (spec: EntitlementDialogSpec) => void;
@@ -100,18 +157,35 @@ export function EnvironmentListToolbar({ actions, entitlements, onUpgrade }: Pro
 
   if (toolbarActions.length === 0) return null;
 
+  // Still resolving: hold the create button's slot with a skeleton instead of a
+  // label we are about to overwrite (objectui#3482). Only the create action is
+  // withheld — the other toolbar actions are pure metadata and never re-label,
+  // so blanking them would be a gratuitous loading flash. When the toolbar has
+  // no create action at all, nothing can jump and no skeleton is rendered.
+  if (entitlements === null) {
+    const others = otherActions(toolbarActions);
+    const hasCreate = others.length !== toolbarActions.length;
+    return (
+      <>
+        <OtherActionsBar actions={others} />
+        {hasCreate && (
+          // Sized like the `size="sm"` bar button it stands in for (h-9,
+          // rounded-md), mirroring CloudOnboardingNext's loading placeholder.
+          // The width is an approximation of the resolved labels — the point is
+          // that the header keeps its shape, not a pixel-exact match.
+          <Skeleton className="h-9 w-44 rounded-md" data-testid="environment-create-cta-loading" />
+        )}
+      </>
+    );
+  }
+
   // Upgrade state: a free-plan org clicking "create" must NOT POST-then-403.
   // Render a primary button that opens the upgrade prompt, plus any other
   // (non-create) toolbar actions through the normal bar.
   if (ctaKind === 'upgrade_for_development') {
-    const others = toolbarActions.filter((a: any) => a?.name !== CREATE_ACTION);
     return (
       <>
-        {others.length > 0 && (
-          <SchemaRenderer
-            schema={{ type: 'action:bar', location: 'list_toolbar', actions: others, size: 'sm', variant: 'outline' }}
-          />
-        )}
+        <OtherActionsBar actions={otherActions(toolbarActions)} />
         <Button
           size="sm"
           onClick={() => onUpgrade(upgradeDialogSpec(entitlements!, t))}
@@ -125,13 +199,17 @@ export function EnvironmentListToolbar({ actions, entitlements, onUpgrade }: Pro
     );
   }
 
-  // setup_production / add_development / loading: render the bar, overriding only
-  // the create action's label (and promoting production setup to a primary CTA).
+  // setup_production / add_development: render the bar, overriding only the
+  // create action's label (and promoting production setup to a primary CTA).
   // Labels are locale-aware — the metadata label is already localized by the
   // caller, but these state-aware overrides used to be hard-coded English,
   // which flashed an English button in a zh console (#844). They now resolve
   // from the locale packs, so all ten languages work rather than just zh
   // (objectui#2871).
+  //
+  // `ctaKind == null` can only be the settled-with-no-signal state here (the
+  // in-flight one returned above), so the metadata label passes through — see
+  // the "who owns this button's text" note at the top of the file.
   const renderedActions = toolbarActions.map((a: any) => {
     if (a?.name !== CREATE_ACTION || ctaKind == null) return a;
     if (ctaKind === 'setup_production') {

--- a/packages/app-shell/src/environment/__tests__/EnvironmentListToolbar.test.tsx
+++ b/packages/app-shell/src/environment/__tests__/EnvironmentListToolbar.test.tsx
@@ -32,9 +32,9 @@ import type { EnvironmentEntitlementsState } from '../entitlements';
  * without one would only be asserting the raw key. Pinned to `en` and
  * `detectBrowserLanguage: false` so the expectations stay deterministic.
  */
-const renderToolbar = (ui: React.ReactElement, language = 'en') =>
+const renderToolbar = (ui: React.ReactElement) =>
   render(
-    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
       {ui}
     </I18nProvider>,
   );
@@ -80,7 +80,6 @@ describe('EnvironmentListToolbar', () => {
     expect(onUpgrade).toHaveBeenCalledTimes(1);
     expect(onUpgrade.mock.calls[0][0]).toMatchObject({ code: 'DEV_ENV_PLAN_LOCKED', cta: { url: '/settings/billing' } });
   });
-
 });
 
 /**

--- a/packages/app-shell/src/environment/__tests__/EnvironmentListToolbar.test.tsx
+++ b/packages/app-shell/src/environment/__tests__/EnvironmentListToolbar.test.tsx
@@ -9,6 +9,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
+const CREATE_LOADING = 'environment-create-cta-loading';
+
 vi.mock('@object-ui/react', async (importActual) => ({
   ...(await importActual<any>()),
   SchemaRenderer: ({ schema }: any) => (
@@ -30,9 +32,9 @@ import type { EnvironmentEntitlementsState } from '../entitlements';
  * without one would only be asserting the raw key. Pinned to `en` and
  * `detectBrowserLanguage: false` so the expectations stay deterministic.
  */
-const renderToolbar = (ui: React.ReactElement) =>
+const renderToolbar = (ui: React.ReactElement, language = 'en') =>
   render(
-    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
       {ui}
     </I18nProvider>,
   );
@@ -43,6 +45,15 @@ const CREATE = {
 };
 const st = (o: Partial<EnvironmentEntitlementsState>): EnvironmentEntitlementsState =>
   ({ ready: true, hasProductionEnv: true, upgradeUrl: '/settings/billing', source: 'summary', ...o });
+
+/**
+ * The settled-but-no-signal state: the entitlements endpoint was unusable AND
+ * the row derivation threw, so `useEnvironmentEntitlements` reports a resolved
+ * object that carries nothing. Distinct from `null` (still in flight).
+ */
+const UNRESOLVED: EnvironmentEntitlementsState = {
+  ready: false, hasProductionEnv: false, upgradeUrl: '/settings/billing', source: 'unknown',
+};
 
 describe('EnvironmentListToolbar', () => {
   it('no production env → "Set up your production environment" (primary)', () => {
@@ -70,10 +81,73 @@ describe('EnvironmentListToolbar', () => {
     expect(onUpgrade.mock.calls[0][0]).toMatchObject({ code: 'DEV_ENV_PLAN_LOCKED', cta: { url: '/settings/billing' } });
   });
 
-  it('still resolving (null) → neutral default label, no upgrade button', () => {
+});
+
+/**
+ * cloud#1049 ruling A (objectui#3482): while entitlements are in flight the
+ * create button must render NO text — the metadata label used to show and then
+ * get overwritten by the state-aware one, which the user saw as the button
+ * changing its wording mid-load.
+ */
+describe('EnvironmentListToolbar — loading state (objectui#3482)', () => {
+  it('still resolving (null) → skeleton, no label of any kind, no upgrade button', () => {
     renderToolbar(<EnvironmentListToolbar actions={[CREATE]} entitlements={null} onUpgrade={vi.fn()} />);
-    expect(screen.getByText('Create Environment')).toBeTruthy();
+    expect(screen.getByTestId(CREATE_LOADING)).toBeTruthy();
+    // The metadata label is the one that used to flash here.
+    expect(screen.queryByText('Create Environment')).toBeNull();
+    // …and no state-aware label is guessed at either — the bar isn't rendered.
+    expect(screen.queryByTestId('action-bar')).toBeNull();
     expect(screen.queryByTestId('environment-add-upgrade')).toBeNull();
+  });
+
+  it('non-create toolbar actions still render while resolving (they never re-label)', () => {
+    const REFRESH = { name: 'refresh_all', label: 'Refresh', type: 'api', locations: ['list_toolbar'] };
+    renderToolbar(
+      <EnvironmentListToolbar actions={[CREATE, REFRESH]} entitlements={null} onUpgrade={vi.fn()} />,
+    );
+    expect(screen.getByText('Refresh')).toBeTruthy();
+    expect(screen.getByTestId(CREATE_LOADING)).toBeTruthy();
+    expect(screen.queryByText('Create Environment')).toBeNull();
+  });
+
+  it('no create action in the toolbar → nothing can jump, so no skeleton', () => {
+    const REFRESH = { name: 'refresh_all', label: 'Refresh', type: 'api', locations: ['list_toolbar'] };
+    renderToolbar(<EnvironmentListToolbar actions={[REFRESH]} entitlements={null} onUpgrade={vi.fn()} />);
+    expect(screen.getByText('Refresh')).toBeTruthy();
+    expect(screen.queryByTestId(CREATE_LOADING)).toBeNull();
+  });
+
+  it('settled with NO usable signal (ready:false) → metadata label, skeleton gone', () => {
+    // The skeleton must never be terminal: when both entitlement signals fail
+    // the user still needs a working create button, and the producer's neutral
+    // wording is the only honest text for an unknown state.
+    renderToolbar(<EnvironmentListToolbar actions={[CREATE]} entitlements={UNRESOLVED} onUpgrade={vi.fn()} />);
+    expect(screen.getByText('Create Environment')).toBeTruthy();
+    expect(screen.queryByTestId(CREATE_LOADING)).toBeNull();
+    expect(screen.queryByTestId('environment-add-upgrade')).toBeNull();
+  });
+
+  it('resolving → resolved: the metadata label never appears in any render output', () => {
+    // The reported flash, as a transition on one mounted tree. Asserted in `en`
+    // because the mechanism is locale-independent (metadata label overwritten by
+    // `environment.setUpProduction`); it was reported against the zh console,
+    // whose key is covered by the all-locales key-parity test.
+    const tree = (entitlements: EnvironmentEntitlementsState | null) => (
+      <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+        <EnvironmentListToolbar actions={[CREATE]} entitlements={entitlements} onUpgrade={vi.fn()} />
+      </I18nProvider>
+    );
+
+    const { rerender, container } = render(tree(null));
+    // Intermediate render output carries no button text at all.
+    expect(container.textContent).toBe('');
+    expect(screen.getByTestId(CREATE_LOADING)).toBeTruthy();
+
+    rerender(tree(st({ hasProductionEnv: false })));
+    expect(screen.getByText('Set up your production environment')).toBeTruthy();
+    expect(screen.queryByTestId(CREATE_LOADING)).toBeNull();
+    // The metadata label never appeared — not before, not after.
+    expect(container.textContent).not.toContain(CREATE.label);
   });
 });
 


### PR DESCRIPTION
Fixes #3482
Part of objectstack-ai/cloud#1049(维护者裁决 A 的执行件;方案 B 已否决,C 不作为)

## 问题

`sys_environment` 列表右上角的创建按钮,文案在加载过程中换一次:entitlements 未解析完时用 cloud 侧动作元数据的 label(中文「创建环境」),`/cloud/environment-entitlements` 返回后被 `environment.setUpProduction`(中文「创建你的生产环境」)覆盖。两份文案由不同包维护、指同一个按钮,用户看到的是一次可见跳变。

## 改动

落点:`packages/app-shell/src/environment/EnvironmentListToolbar.tsx`。

`entitlements === null`(解析在途)时不再渲染任何文案,改为在创建按钮的位置渲染一块 `Skeleton`,尺寸对齐它顶替的那颗 `size="sm"` 条形按钮(`h-9 w-44 rounded-md`)。形态照抄同仓邻接先例 `console/home/CloudOnboardingNext.tsx` 的 welcome CTA:loading 给中性 skeleton、unknown/error 降级到可用按钮 —— 没有自造样式,`Skeleton` 就是本仓 147 处 loading 态在用的那个(`ShimmerSkeleton` 全仓无使用者,未采用)。

两处刻意的边界:

- **只藏创建动作。** 工具栏里其它动作纯由元数据驱动、不会改写文案,一起变灰只是白白多一次 loading 闪;它们照常经 `action:bar` 渲染(抽出 `OtherActionsBar`,与既有 upgrade 分支复用同一形状)。
- **工具栏里没有创建动作时不渲染 skeleton** —— 没有会跳的东西,就没有要占的位。

## 加载态前后对照

| 状态 | 改前 | 改后 |
| --- | --- | --- |
| 解析在途(`entitlements === null`) | 元数据 label(「创建环境」) | **skeleton,零文案** |
| 已解析 · 无生产环境 | `environment.setUpProduction` | 不变 |
| 已解析 · 有生产环境 + 允许开发环境 | `environment.addDevelopment` | 不变 |
| 已解析 · 有生产环境 + 计划不含开发环境 | upgrade 按钮 | 不变 |
| 已落定但无可用信号(`ready: false`) | 元数据 label | 不变(见下) |

**skeleton 不是终态。** `null` 只表示解析未落定;两路信号都失败时 `useEnvironmentEntitlements` 落定为 `{ ready: false, source: 'unknown' }`,这一支仍渲染元数据 label —— 否则 skeleton 会永久挂在那里、用户拿不到可用的创建按钮。判据用 `entitlements === null` 而不是 `!entitlements?.ready`,差别就在这里(反向验证第 3 项钉住了它)。

## 文案真源标注(裁决的顺手项)

裁决原文的条件是「**若**元数据 label 那份中文在此按钮已无到达路径」。核验结论:**仍有一条,且只有一条**。已在 `EnvironmentListToolbar.tsx` 顶部注释写明每个状态的唯一归属:

- 所有**已解析**状态 → 真源是本仓 locale packs(`environment.setUpProduction` / `addDevelopment` / `addEnvironment`)。`decideEnvironmentCta()` 对 `ready` 状态是全覆盖的,所以已解析必定覆盖 label,cloud 侧 `_actions.create_environment.label` 到不了这里;
- 解析在途 → 无文案;
- 已落定但无可用信号 → 元数据 label,**故意的**。这是唯一「这次创建到底是哪种」真的未知的状态,producer 的中性措辞是唯一诚实的文案。

因此这不是「一句话两个真源」,而是「两个状态各有一句话、各有一个真源」。

**回报 cloud#1049**:`_actions.create_environment.label` 的 cloud 侧 bundle 条目**仍有职责,不要删** —— 它是降级路径的文案。本 PR 不改 cloud 仓;cloud 侧若需同步(例如把该 label 的措辞校准成明确中性的「创建环境」而非任何暗示环境类型的说法),由 cloud 座位跟进。

## 验证

- `pnpm exec vitest run packages/app-shell/ --maxWorkers=2` → 299 files / 2681 passed, 1 skipped, 0 failed;
- `pnpm --filter @object-ui/app-shell type-check` → 干净通过;
- `node scripts/check-control-bytes.mjs` → OK(3723 个文件);`node scripts/check-changeset-no-major.mjs` → OK;
- eslint 改动文件 → 0 error(21 warning 全是既有的 `no-explicit-any`,以及 `useAutoRunCreate` 上 origin/main 就在的 `react-hooks/refs`);
- 新增 5 个测试(在途 → 无文案 + skeleton;非创建动作照常渲染;无创建动作则无 skeleton;`ready:false` → 元数据 label 且 skeleton 消失;在途→落定的整树 rerender 断言元数据 label 从头到尾没出现过)。

**反向验证**(三个方向,均为事前预判后执行):

1. 删掉在途 skeleton 分支(还原改前行为)→ 3 个新测试转红,其中转场那条报 `expected 'Create Environment' to be ''` —— 正是 issue 描述的那次闪现被复现成诊断;另 2 个新测试按设计保持绿(它们钉的是改动**边界**,不是改动本身,这里如实记下)。
2. 只去掉 `hasCreate` 守卫(无条件渲染 skeleton)→「无创建动作则无 skeleton」那条转红,证明它不是空绿。
3. 把判据写成更可能写错的 `!entitlements?.ready` → `ready:false` 那条转红(`Unable to find an element with the text: Create Environment`),证明它挡住了「skeleton 变永久」这个真实失败模式。

## Changeset

`.changeset/environment-create-cta-loading-skeleton-3482.md`,`@object-ui/app-shell: patch` —— 用户可见的 UI 行为修复,档位随本仓行为修复先例(如 `sour-clouds-yawn.md`);按版本号策略不声明 `major`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_