### PR TITLE
fix(plugin-chatbot): parseAiQuotaError 先学会嵌套声明信封(三方言全部可读)(#3491)

### DIFF
--- a/.changeset/quota-error-envelope-3491.md
+++ b/.changeset/quota-error-envelope-3491.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/plugin-chatbot': patch
+---
+
+`parseAiQuotaError` now reads the AI quota refusal code from all three shapes the
+cloud 429 producers use, instead of only the flat `error`-holds-the-code dialect.
+
+The two live producers fill the same `error` key in opposite ways — the token
+guardrail puts the **code** there, `service-ai` puts the **message** there and the
+code in a `code` sibling — while ADR-0112 declares a third shape both are
+converging on: `{ success: false, error: { code, message } }`. The consumer had to
+learn the declared shape **first**, or the producers' convergence would silently
+turn every quota refusal back into a generic "Response failed" banner (the same
+consumer-first sequencing as objectui#2992).
+
+- Code lookup order is a total order — declared envelope, then the flat guardrail
+  code, then the `code` sibling — so a transitional producer that double-emits the
+  new envelope alongside the legacy top-level keys has one defined outcome.
+- Only the code's **location** widens. The recognized code set is unchanged, and
+  any unrecognized shape still degrades to today's behavior (`null`), so no
+  non-quota error is newly captured by the quota CTA.
+- Companion fields (`upgrade`, `topUp`, `messageEn`) keep their established
+  top-level read; their position inside the declared envelope is deliberately not
+  presumed, and is aligned once the producer PR fixes the real shape.

--- a/packages/plugin-chatbot/src/tool-display.test.ts
+++ b/packages/plugin-chatbot/src/tool-display.test.ts
@@ -81,4 +81,171 @@ describe('parseAiQuotaError', () => {
     expect(parseAiQuotaError(undefined)).toBeNull();
     expect(parseAiQuotaError('')).toBeNull();
   });
+
+  // The three-dialect matrix (objectui#3491 / cloud#944). The two live producers
+  // fill `error` in opposite ways and ADR-0112 declares a third shape they are
+  // converging on (cloud#1168); every one of them must be readable HERE before
+  // any producer moves, and every one must miss on a non-quota code.
+  describe('dialect matrix', () => {
+    const err = (payload: unknown) => new Error(JSON.stringify(payload));
+    const CODES = [
+      'ai_design_quota_exhausted',
+      'ai_data_chat_trial_exhausted',
+      'ai_allowance_exhausted',
+    ] as const;
+
+    describe('flat guardrail dialect — `error` holds the code', () => {
+      it.each(CODES)('hits on %s', (code) => {
+        expect(parseAiQuotaError(err({ error: code, message: 'zh', upgrade: true }))).toMatchObject({
+          code,
+          message: 'zh',
+          upgrade: true,
+        });
+      });
+
+      it('misses on a code outside the recognized set', () => {
+        expect(parseAiQuotaError(err({ error: 'ai_quota_exhausted', message: 'zh' }))).toBeNull();
+      });
+    });
+
+    describe('service-ai dialect — code in the `code` sibling key', () => {
+      it.each(CODES)('hits on %s', (code) => {
+        expect(
+          parseAiQuotaError(err({ error: '', code, resetAt: '2026-08-09T00:00:00Z' })),
+        ).toMatchObject({ code, message: '' });
+      });
+
+      it('reads the prose this dialect puts in `error` as the message', () => {
+        // `error` carries the message here, so it must surface as the message —
+        // and, in the flat dialect above, must NOT (it is the code there).
+        const prose = 'AI allowance exhausted, retry after the reset.';
+        expect(
+          parseAiQuotaError(err({ error: prose, code: 'ai_allowance_exhausted' })),
+        ).toMatchObject({ code: 'ai_allowance_exhausted', message: prose });
+      });
+
+      it('misses on the code service-ai emits today, which is not in the set', () => {
+        // Documents a real remaining gap rather than asserting it away: the
+        // shape is now readable, the vocabulary is cloud#1168's to align.
+        expect(
+          parseAiQuotaError(err({ error: '', code: 'ai_quota_exhausted', resetAt: 'x' })),
+        ).toBeNull();
+      });
+    });
+
+    describe('declared envelope (ADR-0112) — code nested under `error`', () => {
+      it.each(CODES)('hits on %s', (code) => {
+        expect(
+          parseAiQuotaError(err({ success: false, error: { code, message: 'zh' } })),
+        ).toMatchObject({ code, message: 'zh' });
+      });
+
+      it('misses on a declared non-quota code', () => {
+        expect(
+          parseAiQuotaError(
+            err({ success: false, error: { code: 'QUOTA_EXCEEDED', message: 'zh' } }),
+          ),
+        ).toBeNull();
+      });
+
+      it('misses when the nested error carries no code at all', () => {
+        expect(parseAiQuotaError(err({ success: false, error: { message: 'zh' } }))).toBeNull();
+      });
+    });
+
+    it('degrades to today’s behavior (null) for unknown shapes', () => {
+      expect(parseAiQuotaError(err({ success: false, error: null }))).toBeNull();
+      expect(parseAiQuotaError(err({ success: false, error: [] }))).toBeNull();
+      expect(parseAiQuotaError(err({ error: { code: 42 } }))).toBeNull();
+      expect(parseAiQuotaError(err({ code: 42 }))).toBeNull();
+      expect(parseAiQuotaError(new Error('{ not json }'))).toBeNull();
+    });
+
+    it('still locates a quota body embedded in surrounding text', () => {
+      // Unchanged pre-existing behavior, pinned because the dialect widening
+      // reads more keys off whatever this substring extraction returns: the body
+      // is sliced from the first `{` to the last `}`, so a wrapper (prose, or a
+      // JSON array of one error) does not hide it.
+      expect(
+        parseAiQuotaError(new Error('POST /api/chat 429: {"error":"ai_allowance_exhausted"}')),
+      ).toMatchObject({ code: 'ai_allowance_exhausted' });
+      expect(
+        parseAiQuotaError(err([{ success: false, error: { code: 'ai_allowance_exhausted' } }])),
+      ).toMatchObject({ code: 'ai_allowance_exhausted' });
+    });
+
+    describe('companion fields stay backward compatible', () => {
+      it('reads top-level upgrade / topUp / messageEn alongside a nested code', () => {
+        // The realistic transitional producer: declared envelope emitted next to
+        // the legacy top-level keys old clients still read.
+        expect(
+          parseAiQuotaError(
+            err({
+              success: false,
+              error: { code: 'ai_allowance_exhausted', message: 'zh' },
+              messageEn: 'Allowance used up',
+              upgrade: false,
+              topUp: true,
+            }),
+          ),
+        ).toMatchObject({
+          code: 'ai_allowance_exhausted',
+          message: 'zh',
+          messageEn: 'Allowance used up',
+          upgrade: false,
+          topUp: true,
+        });
+      });
+
+      it('defaults the CTA flags to false when a payload carries none', () => {
+        // A nested-only payload gets no CTA flags: their position in the declared
+        // envelope is deliberately not presumed (cloud#1168 aligns it).
+        expect(
+          parseAiQuotaError(err({ success: false, error: { code: 'ai_allowance_exhausted' } })),
+        ).toEqual({
+          code: 'ai_allowance_exhausted',
+          message: '',
+          messageEn: undefined,
+          upgrade: false,
+          topUp: false,
+        });
+      });
+    });
+
+    describe('parse priority is a total order', () => {
+      it('prefers the declared envelope over the legacy limbs', () => {
+        expect(
+          parseAiQuotaError(
+            err({
+              success: false,
+              error: { code: 'ai_design_quota_exhausted', message: 'nested' },
+              code: 'ai_allowance_exhausted',
+              message: 'flat',
+            }),
+          ),
+        ).toMatchObject({ code: 'ai_design_quota_exhausted', message: 'nested' });
+      });
+
+      it('prefers the flat code over the sibling code key', () => {
+        expect(
+          parseAiQuotaError(
+            err({ error: 'ai_design_quota_exhausted', code: 'ai_allowance_exhausted' }),
+          ),
+        ).toMatchObject({ code: 'ai_design_quota_exhausted' });
+      });
+
+      it('falls through to a legacy limb when the nested code is unrecognized', () => {
+        expect(
+          parseAiQuotaError(
+            err({
+              success: false,
+              error: { code: 'QUOTA_EXCEEDED', message: 'nested' },
+              code: 'ai_allowance_exhausted',
+              message: 'flat',
+            }),
+          ),
+        ).toMatchObject({ code: 'ai_allowance_exhausted', message: 'nested' });
+      });
+    });
+  });
 });

--- a/packages/plugin-chatbot/src/tool-display.ts
+++ b/packages/plugin-chatbot/src/tool-display.ts
@@ -169,6 +169,22 @@ const AI_QUOTA_CODES = new Set<string>([
   'ai_allowance_exhausted',
 ]);
 
+/** The value as a recognized quota code, or undefined for anything else. */
+function asAiQuotaCode(value: unknown): AiQuotaCode | undefined {
+  return typeof value === 'string' && AI_QUOTA_CODES.has(value)
+    ? (value as AiQuotaCode)
+    : undefined;
+}
+
+/**
+ * The value as non-empty text, or undefined — so an empty string falls through
+ * to the next candidate source instead of winning as the message (the
+ * `{ error: '', code: … }` dialect emits exactly that).
+ */
+function asText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
 /**
  * Recognize the cloud AI token guardrail's 429 quota refusals so the chat UI can
  * show a friendly upgrade / top-up CTA instead of a generic "response failed".
@@ -176,7 +192,36 @@ const AI_QUOTA_CODES = new Set<string>([
  * The ai-sdk chat transport throws a plain Error whose `message` is the response
  * body text (no HTTP status is preserved), so the only signal is the JSON body:
  * strip the same retry/format prefixes summarizeChatError handles, locate the
- * JSON object, and match its `error` code. Returns null for anything else.
+ * JSON object, and find the code in it. Returns null for anything else.
+ *
+ * ## Three dialects, one code set
+ *
+ * The two cloud 429 producers fill the same `error` key in OPPOSITE ways, and
+ * ADR-0112 declares a third shape they are converging on (objectui#3491,
+ * cloud#944). All three are read here so the consumer is ready BEFORE the
+ * producers move (cloud#1168) — the alternative is a silent misfit at the
+ * moment they converge:
+ *
+ * | dialect                      | shape                                          |
+ * |------------------------------|------------------------------------------------|
+ * | declared envelope (ADR-0112) | `{ success: false, error: { code, message } }`  |
+ * | flat guardrail               | `{ error: CODE, message, upgrade, topUp }`     |
+ * | service-ai sibling key       | `{ error: PROSE, code: CODE }`                 |
+ *
+ * Only the code's LOCATION widens; the recognized code set is unchanged, so an
+ * unknown shape still degrades to today's behavior (null). Note that a
+ * spec-conformant `error.code` must be an `ErrorCode` ledger member
+ * (SCREAMING_SNAKE) and none of these three codes is registered today, so the
+ * nested branch matches the legacy vocabulary only — aligning the vocabulary is
+ * cloud#1168's call and needs a follow-up here, not a guess now.
+ *
+ * ## Parse priority (a total order, deliberately)
+ *
+ * `declared envelope > flat guardrail > sibling code key`. A payload that
+ * satisfies two dialects at once — a transitional producer double-emitting the
+ * new envelope alongside the legacy top-level keys is the realistic case — must
+ * have ONE defined outcome, so the most-declared position wins, and the legacy
+ * limbs remain reachable when the nested code is absent or unrecognized.
  */
 export function parseAiQuotaError(err: unknown): AiQuotaError | null {
   const raw = err instanceof Error ? err.message : String(err ?? '');
@@ -194,13 +239,33 @@ export function parseAiQuotaError(err: unknown): AiQuotaError | null {
   } catch {
     return null;
   }
-  if (!body || typeof body.error !== 'string' || !AI_QUOTA_CODES.has(body.error)) {
-    return null;
-  }
+  if (!body || typeof body !== 'object') return null;
+
+  // The declared envelope's nested error object, when `error` carries one.
+  const nested =
+    body.error && typeof body.error === 'object'
+      ? (body.error as Record<string, unknown>)
+      : undefined;
+
+  const flatCode = asAiQuotaCode(body.error);
+  const code = asAiQuotaCode(nested?.code) ?? flatCode ?? asAiQuotaCode(body.code);
+  if (!code) return null;
+
   return {
-    code: body.error as AiQuotaCode,
-    message: typeof body.message === 'string' ? body.message : '',
-    messageEn: typeof body.messageEn === 'string' ? body.messageEn : undefined,
+    code,
+    message:
+      asText(nested?.message) ??
+      asText(body.message) ??
+      // The service-ai dialect puts prose in `error`. Read it as text only when
+      // `error` is not itself the code slot, or the flat dialect would surface
+      // its own code ('ai_allowance_exhausted') to the user as the message.
+      (flatCode ? undefined : asText(body.error)) ??
+      '',
+    // Companion fields keep their established top-level read. Their position in
+    // the declared envelope is NOT presumed here (`error.details.upgrade`? a
+    // sibling of `error.code`?) — cloud#1168 decides the real shape, and
+    // inventing a nested key now would fossilize a contract nobody agreed to.
+    messageEn: asText(body.messageEn),
     upgrade: body.upgrade === true,
     topUp: body.topUp === true,
   };


### PR DESCRIPTION
Fixes #3491
Part of objectstack-ai/cloud#944 —— 消费端先行;本单落地后 cloud#1168(生产者按 ADR-0112 收敛)才可动。⛔ 本 PR 不改任何生产者、不动 cloud 仓。

## 为什么消费端必须先行

两个 AI 配额 429 生产者用**相反**的方式填同一个 `error` 键(guardrail 塞 **code**,service-ai 塞 **message**、code 放在 `code` 兄弟键),而 ADR-0112 声明的是第三种:`{ success:false, error:{ code, message } }`。`parseAiQuotaError` 今天只认「平铺 `error` 就是 code」这一种,生产者一旦按声明收敛,配额拒绝会**静默失配**、退回通用的「Response failed」红条 —— 与 objectui#2992(useAgents 先学信封、服务端再转)同一套路。

## 改动(`packages/plugin-chatbot/src/tool-display.ts`)

- `parseAiQuotaError` 现在在三个位置找 code:嵌套声明形 `error.code`、平铺 `error`、兄弟键 `code`。
- **只拓宽 code 的位置,不拓宽 code 的值域** —— 固定集合(`ai_design_quota_exhausted` / `ai_data_chat_trial_exhausted` / `ai_allowance_exhausted`)一字未动,任何未知形状仍降级为现状行为(`null`),因此不会有非配额错误被新捕进配额 CTA。
- message 主干:嵌套 `error.message` → 平铺 `message` → (仅当 `error` 不是 code 槽时)`error` 里的散文。service-ai 方言的 message 就在 `error` 里,而平铺方言的 `error` 是 code —— 后者绝不能当 message 显示给用户,这个 gate 由测试钉住。
- 伴随字段(`upgrade` / `topUp` / `messageEn`)**保持既有的顶层读取**,嵌套位置**不预设**(是 `error.details.upgrade`?还是 `error.code` 的兄弟?)—— 那是 cloud#1168 决定的形状,现在编一个嵌套键出来等于把没人同意过的契约固化下来(AGENTS.md #0.1)。
- 新增两个小 helper:`asAiQuotaCode`(值域判定)、`asText`(空串**不**算 message,因为 `{ error:'', code:… }` 方言正好发空串)。

## 三方言 × 命中/不命中矩阵(实跑)

`pnpm vitest run packages/plugin-chatbot/src/tool-display.test.ts` → **Test Files 1 passed / Tests 30 passed**;整包 `pnpm vitest run packages/plugin-chatbot` → **17 files / 272 tests passed**;`pnpm --filter @object-ui/plugin-chatbot type-check` 干净通过。

| 方言 | 命中 | 不命中 |
|---|---|---|
| 平铺 guardrail(`error` 是 code) | 三个 code 各一例 | `error:'ai_quota_exhausted'` → null |
| service-ai(`code` 兄弟键) | 三个 code 各一例 + `error` 散文当 message | `code:'ai_quota_exhausted'` → null |
| 嵌套声明形(ADR-0112) | 三个 code 各一例 | `code:'QUOTA_EXCEEDED'` → null;`error` 无 code → null |

另有:未知形状降级(`error:null` / `error:[]` / `code:42` / 非 JSON)、伴随字段向后兼容(嵌套 code + 顶层 upgrade/topUp/messageEn 双发)、嵌套-only 时 CTA flag 落 false、以及嵌套在外层文本/数组里的 body 仍能被定位(既有 substring 抽取行为,顺手钉住)。

## 解析优先级依据

`嵌套声明形 > 平铺 code > 兄弟 code`,是一条**全序**,不是「先试哪个都行」:过渡期生产者**新信封与旧顶层键双发**是很现实的一步,同时命中两形态时必须只有一个确定结果,所以最「声明」的位置优先;而嵌套 code 缺失或不在值域时,旧 limb 仍然可达(测试里 `QUOTA_EXCEEDED` 嵌套 + 顶层旧 code 就落到旧 limb)。

## 反向验证(方向先判后跑,两次都对上)

- 砍掉嵌套 limb → 预判 7 红:嵌套三 code 命中、嵌套优先级、两条伴随字段、嵌套 body 定位;实跑 **7 failed | 23 passed**,逐条对上。三条嵌套「不命中」用例**照旧绿** —— 它们钉的是 miss 侧,本来区分不了,如实记下而不是假装它们证明了什么。
- 砍掉兄弟键 limb → 预判 5 红:service-ai 三 code 命中、散文当 message、旧 limb 兜底;实跑 **5 failed | 25 passed**。「平铺优先于兄弟键」那条**两种情况下都绿** —— 它是**优先级钉子**,不是可达性钉子;兄弟键的可达性由上面 4 条钉住。

## 一个必须记下的剩余缺口(本单不动手,交 PM/维护者定)

ADR-0112 的 `error.code` 值域是**封闭** `z.enum`(`ErrorCode` = `StandardErrorCode` ∪ `ERROR_CODE_LEDGER`,SCREAMING_SNAKE,由 `error-code-ledger.test.ts` 机械强制),而这三个配额 code 在 ledger 里**零登记**(`git grep` over `origin/main` `packages/spec/src` 零命中)。也就是说:一个**真正合规**的嵌套信封今天**装不下** `ai_allowance_exhausted` —— `ApiErrorSchema.parse` 会拒。所以本 PR 的嵌套分支只对「嵌套形 + 旧小写词汇」的生产者生效;cloud#1168 若把词汇一并收敛(登记 `AI_*`,或按 ledger 自己的建议直接用标准的 `QUOTA_EXCEEDED` 把三态与 CTA flag 挪进 `details`),objectui 这边还需要一次**词汇对齐**的后续小 PR。那是契约决策,不该由我猜 —— 已写进 JSDoc 与 dev 报告的 open_questions。

顺带更正 issue 描述里的一处:`parseAiQuotaError` 并非「今天无仓内生产调用方」—— `ChatbotEnhanced.tsx` 有两处活调用(`:2781` 的红条抑制、`:3790` 的配额 CTA)。核心前提(只认平铺 `error`-as-code)经 `origin/main` 实读成立,`tool-display.ts:197` 一带确如描述。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_