### PR TITLE
test(console): registry inputs 与 spec ComponentPropsMap 的 parity 门推到全仓,4 个 OFF-SPEC block 逐块判定 (#3797)

### DIFF
--- a/.changeset/registry-inputs-spec-parity-gate-3797.md
+++ b/.changeset/registry-inputs-spec-parity-gate-3797.md
@@ -1,0 +1,25 @@
+---
+---
+
+Internal test-only gate, no behaviour or authoring-surface change (objectui#3797).
+
+Generalizes PR #3795's single-block `record:highlights` parity check to every
+`@objectstack/spec` `ComponentPropsMap` entry this repo registers with a
+non-empty `inputs`: a block may not DECLARE a top-level input the spec's props
+schema does not accept, with the expectation derived from the spec's own shape at
+runtime and every current divergence registered in an explicit exemption list
+that carries a reason and a tracking issue per entry.
+
+No package is declared because no published behaviour changed: the four blocks
+objectui#3797 flagged (`page:header`, `page:tabs`, `page:accordion`,
+`element:record_picker`) keep their `inputs` byte for byte. Per-block verdicts
+came out on the spec side, not this one — the keys are read by the renderers and
+reachable by authors, so the fix is upstream declaration (objectstack#6776) or,
+for `element:record_picker`, already landed upstream in objectstack#5775 and
+merely awaiting a `@objectstack/spec` pin bump here. Narrowing them locally would
+have deleted live configuration; widening the spec is not this repo's to do
+(AGENTS.md #0 / #0.1).
+
+The exemptions expire by themselves: the gate fails on any entry whose key the
+spec has since declared, so the pin bump and the upstream landing each force
+their own cleanup instead of leaving a permanent allowlist.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -1,0 +1,339 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Registry `inputs` <-> `@objectstack/spec` `ComponentPropsMap` parity, for
+ * EVERY block that has both (objectui#3797).
+ *
+ * PR #3795 landed this check on one block (`record:highlights`, see
+ * `packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts`).
+ * This file is the repo-wide half: it asserts the same direction — a block may
+ * not DECLARE a top-level input its spec props schema does not accept — for
+ * every entry of `ComponentPropsMap` this repo registers with a non-empty
+ * `inputs`.
+ *
+ * WHY THE DIRECTION MATTERS. `inputs` is not documentation, it is the published
+ * authoring surface, and four layers are silent about a key that only exists
+ * there:
+ *
+ *   1. `packages/sdui-parser/scripts/gen-manifest.ts` serializes `inputs` into
+ *      `sdui.manifest.json` (the save-gate + parser whitelist) and into
+ *      `sdui-intrinsics.d.ts` (the JSX authoring type surface), so both declare
+ *      the key legal;
+ *   2. `packages/sdui-parser/src/validate.ts` walks a node's top-level props
+ *      against `comp.inputs`, finds the key there, and raises nothing;
+ *   3. the spec's props schemas are plain (strip-mode) `z.object`s, so
+ *      `parse()` drops an undeclared top-level key with no error;
+ *   4. the renderer never sees it.
+ *
+ * Net: the platform's own manifest tells an author — very often an AI author —
+ * to write a key the platform throws away, and nothing anywhere reports it.
+ * That is objectstack#5435 ("platform authority must not point at keys its own
+ * gate rejects") in reverse, and the second dialect AGENTS.md #0.1 exists to
+ * prevent.
+ *
+ * It is not hypothetical on the objectstack side either. Since objectstack#5068,
+ * `packages/lint/src/validate-component-props.ts` dispatches on the component
+ * `type` and reports undeclared `properties.*` keys on `os validate` /
+ * `os build` / `os lint`. So for the exempted keys below, the two platform
+ * authorities disagree out loud about the same key today: objectui's manifest
+ * offers it, the upstream linter warns on it, and the renderer honours it. Three
+ * answers, and they cannot all be right — which is why an exemption here is
+ * always paired with an issue that resolves the disagreement, never left as a
+ * standing licence.
+ *
+ * WHY IT LIVES HERE. The check needs the FULL registration graph — the same one
+ * that produces the published artifacts. `dev/manifest-dump.tsx` builds them
+ * from `src/register-plugins.ts` plus `@object-ui/components`, so this file
+ * imports exactly that pair (as `public-contract.test.ts` next door already
+ * does) rather than a hand-assembled list that could agree with itself and
+ * prove nothing. Coverage is deliberately NOT limited to the public tier:
+ * `packages/components/src/renderers/layout/page.tsx:462` builds the runtime
+ * JSX-page validation manifest from `getKnownTypes()`, so a non-public block's
+ * `inputs` are a live prop whitelist too — that is how `element:record_picker`,
+ * absent from `PUBLIC_BLOCKS`, still publishes an authoring surface.
+ *
+ * EXPECTATIONS ARE DERIVED, NOT RESTATED. The accepted key set comes from
+ * `ComponentPropsMap[type]`'s own shape at runtime. A spec release that adds or
+ * removes a key therefore moves this gate with it instead of quietly widening
+ * the gap — which is also how the stale-pin exemptions below are meant to
+ * resolve themselves.
+ *
+ * EXEMPTIONS ARE EXPLICIT, EACH CARRIES A REASON, AND A STALE ONE FAILS. A new
+ * divergence has to be registered in a diff someone reviews; it can never
+ * arrive silently. And once the spec declares an exempted key, the entry must be
+ * DELETED rather than kept — the last test in this file turns a no-longer-needed
+ * exemption red, so the list cannot rot into a permanent allowlist.
+ *
+ * LIMIT — worth knowing before trusting a pass. This gate can only see TOP-LEVEL
+ * keys. An `inputs` entry of type `array`/`object` declares no member shape
+ * (`ComponentInput` has no slot for one), so a drifted key INSIDE an array
+ * element is invisible here; making that machine-readable is its own change
+ * across types/core/sdui-parser and is tracked separately (PR #3795's open
+ * question). A pass means the top-level surface is in parity, nothing more.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { ComponentPropsMap } from '@objectstack/spec/ui';
+
+// The two graphs whose registrations this file reads, at module scope rather
+// than in a hook: their cold transform is billed to the import phase, which has
+// no test/hook timeout (AGENTS.md §测试纪律, objectui#3010).
+import '@object-ui/components';
+import '../register-plugins';
+
+/**
+ * Top-level keys `ComponentPropsMap[type]` accepts.
+ *
+ * Reads `.shape` through the same two spellings PR #3795's single-block version
+ * uses, so a `lazySchema()`-wrapped entry (every `element:*`) and a plain
+ * `z.object` both resolve. Zod-internals access is confined to this function.
+ */
+function specTopLevelKeys(type: string): string[] {
+  const schema = (ComponentPropsMap as Record<string, unknown>)[type] as
+    | { shape?: unknown; _def?: { shape?: unknown } }
+    | undefined;
+  const shape = schema?.shape ?? schema?._def?.shape;
+  const resolved = typeof shape === 'function' ? (shape as () => object)() : shape;
+  return resolved && typeof resolved === 'object' ? Object.keys(resolved) : [];
+}
+
+/** Declared input names for a registered block, or `null` when not registered. */
+function declaredInputs(type: string): string[] | null {
+  const config = ComponentRegistry.getConfig(type);
+  if (!config) return null;
+  return (config.inputs ?? []).map((input) => input.name);
+}
+
+/** Top-level inputs this block declares that its spec props schema rejects. */
+function offSpecInputs(type: string): string[] {
+  const allowed = new Set(specTopLevelKeys(type));
+  return (declaredInputs(type) ?? []).filter((name) => !allowed.has(name));
+}
+
+/**
+ * The blocks this gate judges: an entry of `ComponentPropsMap` that this repo
+ * registers with at least one `inputs` entry. A block with no `inputs` — or one
+ * present only as a `registerLazy` stub, which has none yet — has no declaration
+ * to be wrong.
+ */
+const covered = Object.keys(ComponentPropsMap)
+  .filter((type) => (declaredInputs(type) ?? []).length > 0)
+  .sort();
+
+/**
+ * Registered `ComponentPropsMap` blocks whose `inputs` is empty.
+ *
+ * Pinned below so "the declaration surface disappeared" is as visible as "it
+ * grew a dialect": inputs emptied by accident would otherwise just shrink
+ * `covered`, and every per-block assertion would keep passing on less.
+ */
+const registeredWithoutInputs = Object.keys(ComponentPropsMap)
+  .filter((type) => declaredInputs(type)?.length === 0)
+  .sort();
+
+/**
+ * Every block with a spec entry AND a declared authoring surface, in sorted
+ * order. Exact rather than `toContain` for the reason `public-contract.test.ts`
+ * gives: the dangerous direction is a SHRINKING contract, which a containment
+ * assertion sails straight past.
+ */
+const EXPECTED_COVERED = [
+  'element:button',
+  'element:number',
+  'element:record_picker',
+  'element:text',
+  'element:text_input',
+  'page:accordion',
+  'page:card',
+  'page:header',
+  'page:tabs',
+  'record:activity',
+  'record:chatter',
+  'record:details',
+  'record:highlights',
+  'record:path',
+  'record:related_list',
+];
+
+/**
+ * Registered, spec-carried, and deliberately propless. `EmptyProps` blocks
+ * (`page:footer`, `page:section`, `page:sidebar`, `nav:*`, `global:search`)
+ * genuinely take no props; `element:image` / `element:metadata_viewer` /
+ * `element:divider` / `ai:suggestion` are registered without an `inputs` list.
+ * Either way there is no declaration for this gate to judge — but a block moving
+ * OUT of `EXPECTED_COVERED` into here is an authoring surface that vanished, so
+ * the list is pinned rather than derived-and-ignored.
+ */
+const EXPECTED_WITHOUT_INPUTS = [
+  'ai:suggestion',
+  'element:divider',
+  'element:image',
+  'element:metadata_viewer',
+  'global:search',
+  'nav:breadcrumb',
+  'nav:menu',
+  'page:footer',
+  'page:section',
+  'page:sidebar',
+];
+
+/**
+ * Off-spec top-level inputs ACCEPTED for now, each with the reason.
+ * Key format: `BLOCK.INPUT`.
+ *
+ * The bar for an entry is NOT "the renderer reads it". A key the renderer reads
+ * is a key worth declaring SOMEWHERE — it is not a key worth declaring in a
+ * place the contract rejects. The bar is that the divergence is already owned by
+ * a named, open piece of upstream work, because `@objectstack/spec` is not
+ * edited from this repo (AGENTS.md #0 / #0.1): "the spec should declare this"
+ * is an upstream issue plus an entry here, never a local widening. Every reason
+ * therefore has to cite an issue, which `references a tracking issue` asserts.
+ *
+ * All eight entries below were verified against renderer read sites, not
+ * assumed — see objectui#3797 and objectstack#6776 for the per-key evidence.
+ */
+const OFF_SPEC_EXEMPTIONS: Record<string, string> = {
+  // ── page:header — three author-facing booleans the spec never declared ────
+  // Read at `containers.tsx:979/980/981` and consumed at `:1453` (which of the
+  // two header layouts renders) and `:1531/:1532` (the RecordTitleChip star and
+  // copy-id affordances). Author-reachable, NOT host-injected: this block's
+  // host injections come through RecordContext (`headerSystemActions`,
+  // `isFavorite`, `onToggleFavorite`) and are deliberately undeclared.
+  // `recordChrome` already has in-repo authors — `preview-samples.ts:68` writes
+  // it under `properties`, the exact shape the upstream linter warns on, and
+  // `plugin-detail/src/synth/buildDefaultPageSchema.ts:413` emits it on every
+  // synthesized record page. Direction is therefore "the spec should declare
+  // it", filed as objectstack#6776; withdrawing them here would delete live,
+  // author-reachable configuration.
+  //
+  // (objectui#3797 suggested these might be renderer-only props deliberately
+  // kept by objectui#3226 / PR #3265. Checked: #3265 (`d2363e710`) narrowed the
+  // LEGACY `page-header` alias in `packages/layout`, not this canonical block —
+  // there is no such deliberate-retention record.)
+  'page:header.recordChrome':
+    'Renderer reads it (containers.tsx:979) to pick the bare-h1 layout; authored in-repo by preview-samples.ts:68 and emitted by buildDefaultPageSchema.ts:413. Awaiting the spec declaration in objectstack#6776.',
+  'page:header.showStar':
+    'Renderer reads it (containers.tsx:980) and passes it to RecordTitleChip (:1531) to hide the follow star. Awaiting the spec declaration in objectstack#6776.',
+  'page:header.showCopyId':
+    'Renderer reads it (containers.tsx:981) and passes it to RecordTitleChip (:1532) to hide the copy-id button. Awaiting the spec declaration in objectstack#6776.',
+
+  // ── page:accordion.variant ───────────────────────────────────────────────
+  // Read at `containers.tsx:734` and consumed at `:735` to pick each panel's
+  // border class, so `variant: 'card'` renders visibly differently. The spec
+  // declares no equivalent at all.
+  'page:accordion.variant':
+    "Renderer reads it (containers.tsx:734) and it changes per-panel borders (:735); the renderer's own comment documents `variant: 'card'` as an author opt-in. Awaiting the spec declaration in objectstack#6776.",
+
+  // ── page:tabs.tabStyle — a carrier collision, not ordinary drift ──────────
+  // The spec DOES declare this concept, spelled `type` (`PageTabsProps.type`),
+  // and `containers.tsx:381` reads both (`properties.type || tabStyle`). Two
+  // spellings for one semantic is exactly what #0.1 forbids, so the local
+  // instinct is to withdraw `tabStyle` — but both local moves are wrong:
+  //   - withdrawing it deletes the only spelling the FLAT carrier can express.
+  //     `SchemaRenderer.tsx:251-270` deliberately refuses to hoist
+  //     `properties.type` onto the node (it would shadow the dispatch key, and
+  //     its comment names this very case), and a flat node is
+  //     `{ type: 'page:tabs', tabStyle: 'card' }` where `type` is the tag;
+  //   - publishing `type` instead declares a key this repo's own parser cannot
+  //     validate: `sdui-parser/src/validate.ts:20-30` lists `'type'` in
+  //     `BASE_PROPS`, so it is skipped as a base prop on every node.
+  // The only remaining lever is upstream, where the shape (rename `type` to
+  // `tabStyle` per objectstack#5775's precedent, vs declare an alias) is a spec
+  // contract decision this repo must not guess. Both options and their costs are
+  // written out in objectstack#6776.
+  'page:tabs.tabStyle':
+    "Renderer reads it (containers.tsx:381) and it is the only spelling the flat SDUI carrier can express — the spec's `type` is unhoistable (SchemaRenderer.tsx:251-270) and unvalidatable as an input (validate.ts BASE_PROPS). Convergence is an upstream contract decision: objectstack#6776.",
+
+  // ── element:record_picker — ALREADY settled upstream, stale pin only ──────
+  // objectstack#5775 (ADR-0087 D2) declared `labelField` / `valueField` /
+  // `label` (plus `sort` / `limit` / `emptyText`) and turned `displayField` /
+  // `searchFields` / `multiple` into `retiredKey()` tombstones — converging on
+  // the `labelField` this renderer actually reads
+  // (`renderers/basic/record-picker.tsx:80-81`), which is the direction
+  // objectui#3797 guessed at. Verified on objectstack `origin/main`
+  // (`packages/spec/src/ui/component.zod.ts:715-786`). It is not in a published
+  // release yet: the newest `@objectstack/spec` on npm is `17.0.0-rc.5`, which
+  // predates #5775 and is what this repo pins. So these three flags are a
+  // stale-pin artifact with NOTHING to do in either repo — and the
+  // `no stale exemption` test below deletes them for us, loudly, the moment the
+  // pin moves.
+  'element:record_picker.labelField':
+    'Already declared upstream by objectstack#5775 (converging on the spelling this renderer reads); flagged only because the pinned @objectstack/spec@17.0.0-rc.5 predates it. Delete this entry when the pin moves.',
+  'element:record_picker.valueField':
+    'Already declared upstream by objectstack#5775; flagged only because the pinned @objectstack/spec@17.0.0-rc.5 predates it. Delete this entry when the pin moves.',
+  'element:record_picker.label':
+    'Already declared upstream by objectstack#5775; flagged only because the pinned @objectstack/spec@17.0.0-rc.5 predates it. Delete this entry when the pin moves.',
+};
+
+const exemptedFor = (type: string): string[] =>
+  Object.keys(OFF_SPEC_EXEMPTIONS)
+    .filter((key) => key.startsWith(`${type}.`))
+    .map((key) => key.slice(type.length + 1));
+
+describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)', () => {
+  it('judges every spec-carried block that declares an authoring surface', () => {
+    // Non-vacuity guard. Every per-block assertion below is generated from
+    // `covered`; if the registration graph stopped loading, `covered` would be
+    // empty and the whole suite would pass on nothing.
+    expect(covered).toEqual(EXPECTED_COVERED);
+  });
+
+  it('pins the spec-carried blocks that are registered with no inputs', () => {
+    expect(registeredWithoutInputs).toEqual(EXPECTED_WITHOUT_INPUTS);
+  });
+
+  it('resolves a non-empty accepted key set for each covered block', () => {
+    // Guards the derivation itself: if `specTopLevelKeys` ever stopped
+    // resolving `.shape` (a Zod internals change, a `lazySchema` rework), it
+    // would return `[]`, every input would read as off-spec, and the failure
+    // would look like a repo-wide regression instead of a broken probe. An
+    // empty result here means "fix the reader", not "fix the inputs".
+    for (const type of covered) {
+      expect(specTopLevelKeys(type).length, `${type} spec shape did not resolve`).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(covered)('%s declares no top-level input the spec does not accept', (type) => {
+    const exempt = new Set(exemptedFor(type));
+    const unregistered = offSpecInputs(type).filter((name) => !exempt.has(name));
+    expect(unregistered).toEqual([]);
+  });
+
+  it('every exemption names a real declared input on a covered block', () => {
+    // A typo'd exemption key is worse than no exemption: it silently licenses
+    // nothing while reading as deliberate cover for a real divergence.
+    const dangling = Object.keys(OFF_SPEC_EXEMPTIONS).filter((key) => {
+      const dot = key.indexOf('.');
+      const type = key.slice(0, dot);
+      const input = key.slice(dot + 1);
+      return !covered.includes(type) || !(declaredInputs(type) ?? []).includes(input);
+    });
+    expect(dangling).toEqual([]);
+  });
+
+  it('every exemption states a reason and references a tracking issue', () => {
+    const unjustified = Object.entries(OFF_SPEC_EXEMPTIONS)
+      .filter(([, reason]) => !/#\d+/.test(reason))
+      .map(([key]) => key);
+    expect(unjustified).toEqual([]);
+  });
+
+  it('carries no stale exemption — a declared key must lose its entry', () => {
+    // The half that keeps this list from becoming a permanent allowlist. Once
+    // the spec declares an exempted key (upstream landing, or just a pin bump
+    // for the `element:record_picker` trio), the entry stops describing
+    // anything and has to be deleted in the same change that moves the pin.
+    const stale = Object.keys(OFF_SPEC_EXEMPTIONS).filter((key) => {
+      const dot = key.indexOf('.');
+      const type = key.slice(0, dot);
+      const input = key.slice(dot + 1);
+      return !offSpecInputs(type).includes(input);
+    });
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #3797

两半件:**门无条件成立并已落地**;**4 个 OFF-SPEC block 逐块以 `origin/main` 代码两向判定,结论全部落在 spec 一侧**,因此本仓四个 block 的 `inputs` 一个字节都没动,转 objectstack 立单 + 挂显式豁免等上游。

核验基线:objectui `origin/main` @ `c4c0ac8972c2efe69b11997dade1cc7655c15666`(pin `@objectstack/spec@^17.0.0-rc.5`,也是 npm 上最新的已发布版本);objectstack `origin/main` @ `ea1d9165d8d4b5c5d806e095f9604cb3731d4e62`(只读)。

---

## A. 全仓 parity 门

新增 `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`。把 PR #3795 在 `record:highlights` 上落的单块检查(「declares no top-level input the spec does not accept」方向)推广到所有「`ComponentPropsMap` 有条目且本仓注册了非空 `inputs`」的 block。

**期望值运行时从 spec 自身 shape 推导**(`specTopLevelKeys()` 读 `ComponentPropsMap[type]` 的 `.shape`,兼容 `lazySchema()` 代理),不复述键表 —— spec 增删键时门跟着动,而不是静默放宽。

**放置位置及理由**(也写进了测试头注):门需要的是**产出发布物那一份完整注册图**。`dev/manifest-dump.tsx` 用 `src/register-plugins.ts` + `@object-ui/components` 搭 manifest,本文件就导入这一对(与隔壁 `public-contract.test.ts` 同法),不自己攒一份会自说自话的清单。覆盖面**不限于 public tier**:`packages/components/src/renderers/layout/page.tsx:462` 用 `getKnownTypes()` 在运行时现搭 JSX 页面校验 manifest,所以非 public 的 block(`element:record_picker` 不在 `PUBLIC_BLOCKS` 里)的 `inputs` 同样是活的 prop 白名单。

判定的 15 个 block(`EXPECTED_COVERED`,精确列表而非 `toContain` —— 危险方向是**收缩**):`element:button` / `element:number` / `element:record_picker` / `element:text` / `element:text_input` / `page:accordion` / `page:card` / `page:header` / `page:tabs` / `record:activity` / `record:chatter` / `record:details` / `record:highlights` / `record:path` / `record:related_list`。另有 10 个「有 spec 条目、已注册、`inputs` 为空」的 block 单独钉住(`EXPECTED_WITHOUT_INPUTS`),这样「声明面凭空消失」和「声明面长出方言」一样可见。

门共 6 类断言 / 21 个 test:

| 断言 | 作用 |
|---|---|
| `judges every spec-carried block…` | 非空性守卫:注册图掉了就红,不会在空集上全绿 |
| `pins the spec-carried blocks that are registered with no inputs` | 声明面消失可见 |
| `resolves a non-empty accepted key set for each covered block` | 守 derivation 本身:Zod 内部变了导致 `.shape` 读不到时,失败读起来是「修读取器」而不是「全仓回归」 |
| `BLOCK declares no top-level input the spec does not accept`(`it.each`,15 条) | 主断言 |
| `every exemption names a real declared input on a covered block` | 拼错的豁免键不能冒充「有意豁免」 |
| `every exemption states a reason and references a tracking issue` | 每条豁免必须带单号 |
| `carries no stale exemption` | **豁免会过期**:spec 一旦声明该键,条目必须删,名单不会烂成永久 allowlist |

### 显式豁免名单(8 条,全部带理由 + 单号)

| 豁免键 | 理由摘要 |
|---|---|
| `page:header.recordChrome` | 渲染器实读 `containers.tsx:979`,`:1453` 据此选裸 h1 布局;`preview-samples.ts:68` / `buildDefaultPageSchema.ts:413` 今天就在写 → 等 objectstack#6776 补声明 |
| `page:header.showStar` | 实读 `containers.tsx:980`,`:1531` 传给 RecordTitleChip 关掉关注星 → objectstack#6776 |
| `page:header.showCopyId` | 实读 `containers.tsx:981`,`:1532` 传给 RecordTitleChip 关掉复制 ID → objectstack#6776 |
| `page:accordion.variant` | 实读 `containers.tsx:734`,`:735` 据此改每个面板边框类;渲染器注释原文即写 `variant: 'card'` 是作者 opt-in → objectstack#6776 |
| `page:tabs.tabStyle` | 实读 `containers.tsx:381`,且是扁平 SDUI 载体**唯一能表达**的拼法(详见下表)→ objectstack#6776 |
| `element:record_picker.labelField` | 上游 objectstack#5775 已声明,仅因 pin 落后而被 flag;pin 升上来后必须删本条 |
| `element:record_picker.valueField` | 同上 |
| `element:record_picker.label` | 同上 |

豁免的门槛写在代码注释里,不是「渲染器读它」——**读它只说明这个键值得被声明在某处,不说明它值得被声明在契约拒绝它的地方**。门槛是「该偏离已由一张具名的在办上游单持有」,因为 `@objectstack/spec` 不从本仓改(AGENTS.md #0 / #0.1)。

---

## B. 4 个 OFF-SPEC block 逐块判定

三选一的输出:(1) renderer 真实读且用户可达 → 「spec 补声明」,本仓不动 spec,转 objectstack 立单 + 豁免;(2) renderer-only / 不读 → 撤下或留下并在 description 写明;(3) 两向拿不准 → needs_decision。

四块全部落 **(1)**。渲染器读点全在 `packages/components/src/renderers/layout/containers.tsx`,读的都是 `schema.*` / `schema.properties.*`(作者写的页面元数据);该 block 真正由宿主注入的东西走 RecordContext(`headerSystemActions` / `isFavorite` / `onToggleFavorite`)且**故意没有**出现在 `inputs` 里 —— 所以这几条不是 renderer-only 内部 prop,是作者配置项。

| block | input | 判定 | 证据(file:line) | 本仓动作 | 上游单 |
|---|---|---|---|---|---|
| `page:header` | `recordChrome` | (1) spec 补声明 | 读 `containers.tsx:979`;消费 `:1453`(注释原文 `Author hasn't opted out via recordChrome: false`)决定「记录 chip 版页头」还是「裸 h1 版页头」。仓内已有作者:`apps/console/src/preview-samples.ts:68` 写 `properties: { title, recordChrome: false }`;`packages/plugin-detail/src/synth/buildDefaultPageSchema.ts:413-414` 在每个合成记录页页头产出它 | 不动声明面,进豁免 | objectstack#6776 |
| `page:header` | `showStar` | (1) | 读 `containers.tsx:980`;消费 `:1531` → `RecordTitleChip showStar`(`custom/RecordTitleChip.tsx`) | 同上 | objectstack#6776 |
| `page:header` | `showCopyId` | (1) | 读 `containers.tsx:981`;消费 `:1532` → `RecordTitleChip showCopyId`(`RecordTitleChip.tsx:47/64/114`) | 同上 | objectstack#6776 |
| `page:tabs` | `tabStyle` | (1),但上游是**改名**不是新增 | 读 `containers.tsx:381` `schema?.properties?.type \|\| schema?.tabStyle \|\| 'line'` | 同上 | objectstack#6776(含两方案与代价) |
| `page:accordion` | `variant` | (1) | 读 `containers.tsx:734` `schema?.variant ?? schema?.properties?.variant ?? 'flush'`;消费 `:735-736` 决定每个面板 `itemClass`(`flush` = `border-b last:border-b-0`,`card` = 交给内部内容自己给边框),渲染结果肉眼可辨;渲染器注释原文:`Authors opt in by setting variant: 'card' … on the schema` | 同上 | objectstack#6776 |
| `element:record_picker` | `labelField` / `valueField` / `label` | (1),**上游已解决** | 见下 | 同上(等 pin) | objectstack#5775(已完成) |

### `page:tabs.tabStyle` 为什么不是「撤下」也不是 needs_decision

spec **已经声明了这个概念**,拼法是 `type`(`PageTabsProps.type`,enum line/card/pill,default line),所以这不是漏声明,是「一义两拼」,而且两种拼法渲染器都读、spec 那种优先。看起来该按 #0.1 直接撤 `tabStyle`,但**两条本地动作都被证否**:

- **撤掉 `tabStyle`** 会删掉扁平 SDUI 载体**唯一能表达**的拼法。`packages/react/src/SchemaRenderer.tsx:251-270` 故意不把 `properties.type` / `properties.id` 上提到节点上(会遮蔽组件分发键,注释点名说的就是页签视觉风格这个 case);扁平节点长成 `{ type: 'page:tabs', items: [...], tabStyle: 'card' }`,那里 `type` 是标签名。
- **改成发布 `type`** 会声明一个自家 parser 结构上**无法校验**的键:`packages/sdui-parser/src/validate.ts:20-30` 的 `BASE_PROPS` 含 `'type'`,任何节点上都被当基础 prop 跳过。

所以剩下的杠杆只在 spec 侧,而「改名 `type` → `tabStyle`(照 objectstack#5775 处理 `displayField` → `labelField` 的同形做法,往渲染器实读的拼法收敛)」还是「spec 同时声明别名」是**本仓不该猜的契约决定** —— 两方案连代价一起写进 objectstack#6776 交上游拍,本仓侧不因此停摆(门无条件成立,该 input 挂豁免)。

### `element:record_picker`:issue 的猜测对了一半,而且上游早修完了

issue 猜 `labelField` 是 spec `displayField` 的别名漂移。查 objectstack 侧 alias/conversion 登记(`git -C /home/user/objectstack grep`,`origin/main`)结论:

- `packages/spec/src/ui/component.zod.ts:715-786` 现在把 `labelField` / `valueField` / `label`(以及 `sort` / `limit` / `emptyText`)**全部声明好**;
- `displayField` / `searchFields` / `multiple` 转成了 `retiredKey()` 墓碑,由 objectstack#5775 / ADR-0087 D2 完成;
- 收敛方向正是本仓渲染器实读的 `labelField`(`renderers/basic/record-picker.tsx:80-81` `props.labelField ?? 'name'`),`packages/spec/src/conversions/registry.ts:4710-4740` 有 `displayField` → `labelField` 的 conversion 条目。

所以本仓这三条 flag **纯粹是 pin 落后**造成的:npm 上 `@objectstack/spec` 最新已发布版本是 `17.0.0-rc.5`,早于 #5775。**两仓都没有活要干**,只等 pin 升上来;`carries no stale exemption` 会在那一刻把这三条豁免顶红,强制删掉。

### 顺带修正 issue 正文一处误归因

issue 提示「`page:header` 的 inputs 在 #3226 / PR #3265 刚被收窄过,所以那三个可能是**有意保留**的 renderer-only prop」。核验为**否**:PR #3265(`d2363e710`)动的是 `packages/layout` 里的**遗留 kebab 别名 `page-header`**(`registerLayout()` 的 `description` input,对应 objectstack#4827),`packages/components` 里 canonical 的 `page:header` 那次**完全没被碰过**。没有任何「有意保留」的记录,这三条就是普通的未声明作者配置项 —— 也因此不适用 `record:activity.showSubscriptionToggle` 那条先例(那条是**反方向**:spec 声明了、渲染器不读,所以为保持双向 parity 留下并在 description 写明 KNOWN GAP)。

**一处主动没做的事,写出来供 review 推翻**:没有在 `showStar` / `showCopyId` / `tabStyle` / `variant` 的 `description` 里加「本键当前未被 spec 声明」之类的话。理由:那等于把一条上游缺陷的临时说明发布进 `sdui.manifest.json`(AI 作者读的东西),objectstack#6776 一落地它就过期,而且没有任何门会强制删它。豁免名单里的理由才是有过期机制的那份记录。

---

## 验证

### 门的反向验证(方向先判后跑,四条)

| 探针 | 事先预判 | 实际 |
|---|---|---|
| RV1:给 `page:card`(当前零 off-spec、零豁免)塞一个假 input `bogusOffSpecProbe` | 只有 `page:card` 那条主断言红,点名该键 | ✅ 一致 |
| RV2:把 `page:tabs.tabStyle` 的豁免理由换成不含单号的一句话 | 主断言**保持绿**(证明豁免是真放行),`every exemption states a reason…` 红并点名该条 | ✅ 一致(见下方「一次探针自身的失误」) |
| RV3:给 `page:card.title`(spec **确实**接受的键)加一条豁免,模拟「上游已声明」 | `carries no stale exemption` 红并点名,`page:card` 主断言保持绿 | ✅ 一致 |
| RV4:删掉 `import '../register-plugins'`,模拟注册图丢失 | 非空性守卫红,点名掉出去的 6 个 `record:*`;test 总数从 21 掉到 15 | ✅ 一致 |

RV1 输出:

```
FAIL … > page:card declares no top-level input the spec does not accept
AssertionError: expected [ 'bogusOffSpecProbe' ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed | 20 passed (21)
```

RV2 输出(注意 20 passed —— `page:tabs` 主断言仍绿):

```
FAIL … > every exemption states a reason and references a tracking issue
AssertionError: expected [ 'page:tabs.tabStyle' ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed | 20 passed (21)
```

RV3 输出:

```
FAIL … > carries no stale exemption — a declared key must lose its entry
AssertionError: expected [ 'page:card.title' ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed | 20 passed (21)
```

RV4 输出:

```
FAIL … > judges every spec-carried block that declares an authoring surface
AssertionError: expected [ 'element:button', …(8) ] to deeply equal [ 'element:button', …(14) ]
-   "record:activity",
-   "record:chatter",
-   "record:details",
-   "record:highlights",
-   "record:path",
-   "record:related_list",
 Test Files  1 failed (1)
      Tests  1 failed | 14 passed (15)
```

**一次探针自身的失误,如实记下**:RV2 第一次跑成了绿。原因不是断言弱,是探针建错了 —— 我只替换了理由字符串的**前半句**,尾巴上的 `objectstack#6776` 还在,`/#\d+/` 照样命中。把整条理由换成不含任何单号的一句后才拿到预期的红。留在这里是因为「探针没造对」和「断言不管用」在输出上长得一模一样,而结论完全相反。

### 行为不回归

**这一条在本 PR 里是空的,如实说明而不是编证据**:四个 block 的 `inputs` 一个字节都没动,`containers.tsx` / `record-picker.tsx` 的渲染逻辑零改动(diff 只有一个新测试文件 + 一个 changeset),所以没有「撤下 input 后行为是否回归」可验。反向验证阶段临时塞进 `containers.tsx` 的探针已按原文件字节还原(`git status` 干净,只余新增文件)。与 PR #3791 新落的页头 CEL 代码零冲突 —— 本 PR 不碰 `containers.tsx`。

为兜底仍跑了四个 block 的行为面 + PR #3795 的单块门 + PR #3265 的 layout 别名门,全绿:

```
pnpm exec vitest run packages/components/src/__tests__/page-header-actions.test.tsx \
  page-header-title / page-header-predicate-dialect / page-tabs-visibility \
  page-tabs-count-badge-i18n / page-card-i18n-title / page-variables \
  packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts \
  packages/layout/src/__tests__/page-header-authorable-keys.test.tsx
 Test Files  9 passed (9)
      Tests  107 passed (107)
```

### 受影响包 + 新门(仓库根,flock + 4096MB + maxWorkers=2)

先 `pnpm --workspace-concurrency=2 --filter '@object-ui/console^...' build` 建依赖过滤集,防 TS2307 假红。

```
pnpm exec vitest run --project "@object-ui/console" --maxWorkers=2
 Test Files  28 passed (28)
      Tests  268 passed (268)
```

新门单跑:`Test Files 1 passed (1) / Tests 21 passed (21)`。

### type-check / lint / 仓库门

```
apps/console  tsc --noEmit                 -> exit 0
apps/console  eslint (新文件)              -> exit 0
node scripts/check-control-bytes.mjs       -> OK (scanned 3732 tracked text files)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' (改动文件) -> 零命中
node scripts/check-changeset-presence.mjs  -> OK(1 released-package src file, 1 changeset)
node scripts/check-changeset-fixed.mjs     -> OK
node scripts/check-changeset-no-major.mjs  -> OK
```

### Changeset

`.changeset/registry-inputs-spec-parity-gate-3797.md`,**空 frontmatter**。依据:`scripts/check-changeset-presence.mjs` 的守卫面是「`fixed` 组里每个包的 `src/**`」,`@object-ui/console` 在 `fixed` 里且住在 `apps/console`,该脚本头注明确写了「**No carve-out for test files under `src/`** —— 限于 `src/__tests__/**` 的改动由空 frontmatter 豁免一行答完」。它要的是一句**声明**而不是一次发版:本 PR 没有任何发布行为或授权面变化(四个 block 的 `inputs` 未动),所以不声明任何包。已跑该脚本确认按空 frontmatter 通过。

---

## 关联

- 上游新立:objectstack#6776(`pm:queue` / `domain:spec` / `repo:objectui`,带 `Part of objectstack-ai/objectui#3797`;立前已按关键词 + 文件路径查重,零命中)。该单同时纠正了 objectstack `packages/lint/src/authoring-rules.ts:564-566` 那句「the rest of the keys the renderers honour are declared」—— 这 5 个键渲染器 honour、spec 未声明,正卡在 `validateComponentProps` 升 error 的「warning-period inventory is empty」前置上。
- 上游已完成:objectstack#5775(record picker `displayField` → `labelField`,ADR-0087 D2)。
- 同族:#3407 / PR #3795(单块版门)、#3226 / objectstack#4827(`page-header` 别名收窄)、objectstack#5068 / #5435。
- 存档不做(来自 PR #3795 open question,判级评论已定不进本单):门只能拦顶层;数组/对象型 input 的成员键要机器可读需扩展 `ComponentInput` 的成员形状声明位(跨 types/core/sdui-parser),独立一单。测试头注的 LIMIT 段已把这条边界写明,避免「绿了就以为成员键也在管」。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_