### PR TITLE
fix(plugin-grid,components): 行动作的 visible 门按「已声明」判定,visible: false 不再渲染 (#3758)

### DIFF
--- a/.changeset/row-action-declared-visible-gate-3758.md
+++ b/.changeset/row-action-declared-visible-gate-3758.md
@@ -1,0 +1,33 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/components": patch
+---
+
+Row actions declaring `visible: false` are now hidden instead of rendered
+
+A custom row action's visibility **gate** was detected by truthiness, so
+`visible: false` — the most explicit way an author can say "never show this" —
+fell into the "no gate declared" branch and the action rendered for every row.
+Both surfaces of the ObjectGrid row cell (the "⋮" overflow item and the inline
+`variant:'primary'` button) and the data-table's row overflow menu read the same
+gate, so all three rendered it; the `#3562` emptiness guard counts with that same
+gate, so a row whose only action was `visible: false` also grew a "⋮" it could
+not fill.
+
+The gate now detects a **declared** gate by `!= null && !== ''` and lets the
+declaration itself decide — a boolean short-circuits to its own verdict rather
+than being handed to the CEL engine. This is the invariant objectui#3492 already
+established for the selection bar, whose `hasVisibilityGate` spells out why
+truthiness cannot answer the question, and the same `!= null` posture the
+built-in `visibleWhen` gate has always had. `visible: true` still renders,
+`''` and an absent `visible` are still no gate at all, and no expression-valued
+`visible` changes verdict.
+
+Behaviour change surface, deliberately narrow: only an action whose `visible` is
+the literal boolean `false` (or another falsy non-empty value) changes — it goes
+from rendered to hidden, which is what the declaration asked for.
+`ActionSchema.visible` is `ExpressionInputSchema` with no boolean member, so
+`objectstack build` cannot emit this shape; hand-written view JSON and
+in-process callers constructing defs can, and did. The three row surfaces now
+reach the same verdict as the selection bar and the record page header for every
+non-expression shape, which `predicate-surface-parity` pins.

--- a/packages/components/src/renderers/complex/__tests__/data-table-row-action-visible.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-row-action-visible.test.tsx
@@ -114,3 +114,36 @@ describe('data-table row action — visible / disabled CEL evaluation', () => {
     expect(screen.getByTestId('row-action-locked_action')).toHaveAttribute('data-disabled');
   });
 });
+
+/**
+ * objectui#3758 — a DECLARED boolean `visible` is a verdict, not a missing gate.
+ *
+ * `isCustomRowActionVisible` used to ask truthiness (`if (!action?.visible)
+ * return true`), so `visible: false` — the most explicit way to say "never show
+ * this" — answered "no gate declared" and the item rendered for every row.
+ * Declaration is now detected by `!= null && !== ''`, the invariant
+ * objectui#3492 established for the selection bar (`hasVisibilityGate`) and the
+ * one the built-in `visibleWhen` gate has always used, so a declared boolean
+ * reaches the evaluator and decides.
+ *
+ * The `visible: true` and empty-string cases are asserted alongside on purpose:
+ * they are what separates "detect the declaration" from "hide unconditionally".
+ */
+describe('data-table row action — declared boolean `visible` (objectui#3758)', () => {
+  it('hides an action declaring `visible: false`', () => {
+    renderRowActionItem({ name: 'ghost', label: 'Ghost', visible: false }, { id: '2', role: 'member' });
+    expect(screen.queryByTestId('row-action-ghost')).toBeNull();
+    expect(screen.queryByText('Ghost')).toBeNull();
+  });
+
+  it('renders an action declaring `visible: true`', () => {
+    renderRowActionItem({ name: 'always', label: 'Always', visible: true }, { id: '2', role: 'member' });
+    expect(screen.getByTestId('row-action-always')).toBeInTheDocument();
+    expect(screen.getByText('Always')).toBeInTheDocument();
+  });
+
+  it('treats an empty-string `visible` as no gate at all, matching `hasVisibilityGate`', () => {
+    renderRowActionItem({ name: 'compiled_away', label: 'Compiled Away', visible: '' }, { id: '2', role: 'member' });
+    expect(screen.getByTestId('row-action-compiled_away')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/complex/__tests__/data-table-row-menu-empty-guard.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-row-menu-empty-guard.test.tsx
@@ -243,3 +243,46 @@ describe('planDataTableRowMenu', () => {
     expect(plan).toMatchObject({ edit: false, count: 0 });
   });
 });
+
+/**
+ * objectui#3758 reaching the guard: `planDataTableRowMenu` counts with the same
+ * `isCustomRowActionVisible` the item gates itself on, so correcting the gate
+ * propagates to whether the row gets a "⋮" at all — no separate change, and no
+ * way for the trigger and its contents to disagree about a boolean `visible`.
+ */
+describe('planDataTableRowMenu — declared boolean `visible` (objectui#3758)', () => {
+  const scope = {};
+  const row = MIXED_ROWS[1];
+
+  it('drops a custom action declaring `visible: false`, reaching zero items', () => {
+    const plan = planDataTableRowMenu({
+      customActions: [{ name: 'ghost', visible: false }] as any,
+      row,
+      scope,
+    });
+    expect(plan.custom).toEqual([]);
+    expect(plan.count).toBe(0);
+  });
+
+  // Keeps the assertion above from passing for the empty reason: a gate
+  // rewritten to "always hide" would also reach `count: 0`.
+  it('keeps a custom action declaring `visible: true` — declaration detection, not "always hide"', () => {
+    const plan = planDataTableRowMenu({
+      customActions: [{ name: 'always', visible: true }] as any,
+      row,
+      scope,
+    });
+    expect(plan.custom.map((a) => a.name)).toEqual(['always']);
+    expect(plan.count).toBe(1);
+  });
+
+  it('treats an empty-string `visible` as no gate at all, matching `hasVisibilityGate`', () => {
+    const plan = planDataTableRowMenu({
+      customActions: [{ name: 'compiled_away', visible: '' }] as any,
+      row,
+      scope,
+    });
+    expect(plan.custom.map((a) => a.name)).toEqual(['compiled_away']);
+    expect(plan.count).toBe(1);
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -210,6 +210,11 @@ function evalRowActionVisibility(
   label: string,
 ): boolean {
   if (typeof pred === 'boolean') return pred;
+  // Not dead, and not the place that decides "was a gate declared?" — the two
+  // callers below answer that first, each by its own rule. `''` still arrives
+  // here from `isBuiltinRowActionVisible`, whose gate is `!= null` alone; a
+  // nothing-to-evaluate predicate that reached an evaluator fails CLOSED like
+  // any other unevaluable one.
   if (pred == null || pred === '') return false;
   return evalRowPredicate(pred as never, row ?? {}, {
     fallback: false,
@@ -245,19 +250,28 @@ export function isBuiltinRowActionVisible(
  * Does this schema-driven custom row action render for THIS row? Same
  * single-definition rule as the built-ins above.
  *
- * The gate is truthiness, which is what the item has always applied: a
- * `visible: false` def renders (the objectui#3492 shape). Preserved verbatim —
- * the contract this function exists for is that the guard and the item agree,
- * and re-deciding `visible: false` would change WHICH items render, a separate
- * question tracked on its own issue.
+ * A gate counts as DECLARED by `!= null && !== ''`, never by truthiness
+ * (objectui#3758). Truthiness cannot answer the question: `visible: false` is a
+ * declared gate that excludes every row, and testing `!action.visible`
+ * classified it as *ungated* — so the most explicit way to say "never show this"
+ * rendered the item for everyone, and counted toward the "⋮" guard. This is the
+ * invariant objectui#3492 established for the selection bar (plugin-grid's
+ * `hasVisibilityGate`), and the same `!= null` posture the built-in `visibleWhen`
+ * gate above has always had. The boolean then decides in
+ * {@link evalRowActionVisibility}, which short-circuits it instead of handing it
+ * to the engine.
+ *
+ * `''` is grouped with `null` deliberately: an empty predicate is nothing to
+ * evaluate, so it must not hide the item from everyone either.
  */
 export function isCustomRowActionVisible(
   action: { name?: string; visible?: unknown } | undefined,
   row: any,
   scope: Record<string, unknown>,
 ): boolean {
-  if (!action?.visible) return true;
-  return evalRowActionVisibility(action.visible, row, scope, action.name ?? 'row-action');
+  const pred = action?.visible;
+  if (pred == null || pred === '') return true;
+  return evalRowActionVisibility(pred, row, scope, action?.name ?? 'row-action');
 }
 
 /** What the row overflow menu will actually render for ONE row. */

--- a/packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx
+++ b/packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx
@@ -21,11 +21,14 @@
  * "⋮" guard share) and the selection bar (`partitionBulkRows`), and depends on
  * `@object-ui/components`, which owns `page:header`.
  *
- * Scope of the claim, deliberately: these fixtures are all non-empty predicate
- * STRINGS / envelopes, i.e. the dialect question. Boolean and empty `visible`
- * are a separate, still-open divergence — the kebab renders a `visible: false`
- * def (objectui#3758) while the header hides it — and pinning them here would
- * read as blessing a difference this issue did not fix.
+ * Scope of the claim: most fixtures are non-empty predicate STRINGS / envelopes,
+ * i.e. the dialect question #3521 asked. The boolean and empty-string shapes were
+ * excluded while they still diverged — the kebab rendered a `visible: false` def
+ * while the bar and the header hid it — and pinning them then would have read as
+ * blessing a difference #3521 did not fix. objectui#3758 closed that divergence
+ * by making the kebab's gate detect a DECLARED gate (`!= null && !== ''`) instead
+ * of a truthy one, so they belong in the table now: the shapes an author can
+ * write with no expression at all reach one verdict on all three surfaces too.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -203,6 +206,13 @@ const CASES: Case[] = [
   },
   // A predicate that cannot be evaluated: fail-CLOSED on all three.
   { what: 'faulting predicate fails closed', name: 'par_fault', visible: 'no_such_var_par == 1', expected: false },
+  // The non-expression shapes, parity-checked since objectui#3758. A declared
+  // BOOLEAN is a verdict every surface short-circuits rather than evaluating;
+  // `''` and an absent `visible` are no gate at all on every surface.
+  { what: 'declared boolean false excludes every row', name: 'par_bool_false', visible: false, expected: false },
+  { what: 'declared boolean true offers every row', name: 'par_bool_true', visible: true, expected: true },
+  { what: 'empty-string `visible` is no gate', name: 'par_empty_string', visible: '', expected: true },
+  { what: 'absent `visible` is no gate', name: 'par_absent', visible: undefined, expected: true },
 ];
 
 describe('one predicate, one verdict on all three action surfaces (#3521)', () => {

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -132,6 +132,11 @@ function evalRowActionVisibility(
   fields: unknown,
 ): boolean {
   if (typeof pred === 'boolean') return pred;
+  // Not dead, and not the place that decides "was a gate declared?" — the two
+  // callers below answer that first, each by its own rule. `''` still arrives
+  // here from `isBuiltinRowActionVisible`, whose gate is `!= null` alone; a
+  // nothing-to-evaluate predicate that reached an evaluator fails CLOSED like
+  // any other unevaluable one.
   if (pred == null || pred === '') return false;
   return evalRowPredicate(pred as never, row ?? {}, {
     fallback: false,
@@ -175,11 +180,19 @@ export function isBuiltinRowActionVisible(
  * ({@link RowActionInlineButton}). One function, so a def cannot be visible on
  * one surface and hidden on the other.
  *
- * The gate is truthiness, which is what both items have always applied: a
- * `visible: false` def RENDERS (the objectui#3492 shape). Preserved verbatim —
- * the contract this function exists for is that the guard and the items agree,
- * and re-deciding `visible: false` would change WHICH items render, a separate
- * question tracked as objectui#3758.
+ * A gate counts as DECLARED by `!= null && !== ''`, never by truthiness
+ * (objectui#3758). Truthiness cannot answer the question: `visible: false` is a
+ * declared gate that excludes every row, and testing `!def.visible` classified
+ * it as *ungated* — so the most explicit way to say "never show this" rendered
+ * the action for everyone, on both surfaces and in the "⋮" guard's count. This
+ * is `bulkEligibility`'s `hasVisibilityGate` verbatim, the invariant
+ * objectui#3492 established for the selection bar, and the same `!= null`
+ * posture the built-in `visibleWhen` gate above has always had. The boolean then
+ * decides in {@link evalRowActionVisibility}, which short-circuits it instead of
+ * handing it to the engine.
+ *
+ * `''` is grouped with `null` deliberately: an empty predicate is nothing to
+ * evaluate, so it must not hide the action from everyone either.
  */
 export function isCustomRowActionVisible(
   def: RowActionDef | undefined,
@@ -187,8 +200,9 @@ export function isCustomRowActionVisible(
   scope: Record<string, unknown>,
   fields?: unknown,
 ): boolean {
-  if (!def?.visible) return true;
-  return evalRowActionVisibility(def.visible, row, scope, def.name ?? 'row-action', fields);
+  const pred = def?.visible;
+  if (pred == null || pred === '') return true;
+  return evalRowActionVisibility(pred, row, scope, def?.name ?? 'row-action', fields);
 }
 
 /** What this row's action cell will actually render. */

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
@@ -410,17 +410,60 @@ describe('planRowActionMenu', () => {
     }
   });
 
-  it('preserves the `visible: false` truthy gate verbatim (objectui#3758, not this issue)', () => {
-    // `!def.visible` reads `false` as "ungated", so the def renders and counts —
-    // exactly what the item components have always done. Re-deciding this would
-    // change WHICH items render, which is out of #3562's scope; the point of the
-    // shared function is only that the guard and the items agree.
+  // objectui#3758 replaced the fixture that used to live here. It pinned the
+  // truthiness gate verbatim — `!def.visible` read `false` as "ungated", so the
+  // def rendered and counted — because re-deciding `visible: false` changes
+  // WHICH items render and was out of #3562's scope. #3758 then decided it, the
+  // other way: a declared boolean is a verdict (the #3492 invariant), so the
+  // fixture's expectations (`['ghost']` / `1`) are now the wrong verdicts and
+  // are replaced rather than re-spelled.
+  it('a declared `visible: false` excludes the def and leaves no trigger (objectui#3758)', () => {
     const plan = planRowActionMenu({
       ...base,
       row: FROZEN,
       menuDefs: [{ name: 'ghost', visible: false }],
     });
-    expect(plan.custom.map((a) => a.name)).toEqual(['ghost']);
+    expect(plan.custom).toEqual([]);
+    expect(plan.menuCount).toBe(0);
+  });
+
+  // The counterpart that keeps the assertion above from passing for the empty
+  // reason: a gate rewritten to "always hide" would also reach `menuCount: 0`.
+  it('a declared `visible: true` still counts — declaration detection, not "always hide"', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      menuDefs: [{ name: 'always', visible: true }],
+    });
+    expect(plan.custom.map((a) => a.name)).toEqual(['always']);
     expect(plan.menuCount).toBe(1);
+  });
+
+  it('an empty-string `visible` is no gate at all, matching `hasVisibilityGate`', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      menuDefs: [{ name: 'compiled_away', visible: '' }],
+    });
+    expect(plan.custom.map((a) => a.name)).toEqual(['compiled_away']);
+    expect(plan.menuCount).toBe(1);
+  });
+});
+
+/**
+ * The DOM half of objectui#3758 on this surface: a row whose only custom action
+ * declares `visible: false` renders no "⋮" at all. This is the #3562 guard and
+ * the #3758 gate meeting — the guard counts what the items will render, so
+ * correcting the gate propagates to the trigger with no separate change.
+ */
+describe('declared `visible: false` reaches the "⋮" guard (objectui#3758)', () => {
+  it('renders no trigger when the row\'s only custom action declares `visible: false`', () => {
+    renderMenu({ rowActionDefs: [{ name: 'ghost', label: 'Ghost', variant: 'secondary', visible: false }] });
+    expect(trigger()).not.toBeInTheDocument();
+  });
+
+  it('keeps the trigger when that same action declares `visible: true`', () => {
+    renderMenu({ rowActionDefs: [{ name: 'ghost', label: 'Ghost', variant: 'secondary', visible: true }] });
+    expect(trigger()).toBeInTheDocument();
   });
 });

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
@@ -17,6 +17,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { PredicateScopeProvider } from '@object-ui/react';
@@ -194,5 +195,77 @@ describe('BuiltinRowActionItem per-record CEL predicates (#2614)', () => {
     } finally {
       warn2.mockRestore();
     }
+  });
+});
+
+/**
+ * objectui#3758 — a DECLARED boolean `visible` is a verdict, not a missing gate.
+ *
+ * Both of this component's custom-action surfaces read one gate
+ * (`isCustomRowActionVisible`), and that gate used to ask truthiness: `visible:
+ * false` — the most explicit way to say "never show this" — answered "no gate
+ * declared" and the action rendered for everyone. Declaration is detected by
+ * `!= null && !== ''`, the invariant objectui#3492 already established for the
+ * selection bar (`hasVisibilityGate`) and the one the built-in `visibleWhen`
+ * gate has always used, so a boolean reaches the evaluator and decides.
+ *
+ * The `visible: true` and undeclared cases are asserted alongside on purpose:
+ * they are what separates "detect the declaration" from "hide unconditionally",
+ * a rewrite that would satisfy every `visible: false` assertion on its own.
+ */
+describe('declared boolean `visible` on a custom row action (objectui#3758)', () => {
+  const UNGATED = { name: 'archive', label: 'Archive', variant: 'secondary' as const };
+  const GHOST = { name: 'ghost', label: 'Ghost', variant: 'secondary' as const, visible: false };
+
+  // --- surface 1: the "⋮" overflow menu item -------------------------------
+  // A second, UNGATED action rides along so the "⋮" trigger survives its own
+  // #3562 emptiness guard — otherwise a passing assertion could not tell "the
+  // item was suppressed" from "the whole menu disappeared".
+
+  it('visible:false → the overflow menu item does not render', async () => {
+    renderMenu({ rowActionDefs: [GHOST, UNGATED] });
+    await userEvent.click(screen.getByTestId('row-action-trigger'));
+    expect(screen.getByTestId('row-action-archive')).toBeInTheDocument();
+    expect(screen.queryByTestId('row-action-ghost')).not.toBeInTheDocument();
+  });
+
+  it('visible:true → the overflow menu item renders', async () => {
+    renderMenu({ rowActionDefs: [{ ...GHOST, name: 'always', label: 'Always', visible: true }, UNGATED] });
+    await userEvent.click(screen.getByTestId('row-action-trigger'));
+    expect(screen.getByTestId('row-action-always')).toBeInTheDocument();
+  });
+
+  it('no `visible` at all → the overflow menu item renders (ungated stays ungated)', async () => {
+    renderMenu({ rowActionDefs: [UNGATED] });
+    await userEvent.click(screen.getByTestId('row-action-trigger'));
+    expect(screen.getByTestId('row-action-archive')).toBeInTheDocument();
+  });
+
+  // --- surface 2: the inline `variant:'primary'` button --------------------
+  // Always mounted, so it needs no menu interaction to observe.
+
+  it('visible:false → the inline primary button does not render', () => {
+    renderMenu({ rowActionDefs: [{ ...OPEN, visible: false }] });
+    expect(screen.queryByTestId('row-action-inline-open')).not.toBeInTheDocument();
+  });
+
+  it('visible:true → the inline primary button renders', () => {
+    renderMenu({ rowActionDefs: [{ ...OPEN, visible: true }] });
+    expect(screen.getByTestId('row-action-inline-open')).toBeInTheDocument();
+  });
+
+  it('no `visible` at all → the inline primary button renders (ungated stays ungated)', () => {
+    renderMenu({ rowActionDefs: [OPEN] });
+    expect(screen.getByTestId('row-action-inline-open')).toBeInTheDocument();
+  });
+
+  // --- the other half of "declared": empty string is NOT a gate ------------
+  // `hasVisibilityGate` excludes `''` for the selection bar; the row surfaces
+  // match it, so an action whose predicate compiled away to an empty string is
+  // not silently hidden from everyone.
+
+  it('an empty-string `visible` is not a declared gate — the action still renders', () => {
+    renderMenu({ rowActionDefs: [{ ...OPEN, visible: '' }] });
+    expect(screen.getByTestId('row-action-inline-open')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #3758

## 修了什么

自定义行动作的可见性**门**用真值判断,于是 `visible: false` —— 作者能写出的最明确的「永不显示」—— 落进「未声明门」分支,动作对所有行渲染。门判定改为按「**是否声明了门**」检测(`!= null && !== ''`),声明本身随后决定 verdict:布尔在求值入口短路成自己的 verdict,不交给 CEL 引擎。

## 门位:三个变两个(核验读数与派发单不一致,已核实)

派发单与 #3758 正文/分诊(锚 `b1204af`)列了**三**个门位。按 rule 6 在 `origin/main@d9ce38529` 上核验时发现:PR #3761(`1a33b1aba`,「gate the row '...' trigger on renderable items」)此后已把 plugin-grid 的 `RowActionMenu.tsx:130`(overflow 项)与 `:219`(inline 按钮)**收敛成一处共享函数** `isCustomRowActionVisible` —— 与 #3756 对 data-table 做的相同。

**缺陷与修法不变,门位数由 3 变 2**;`:130`/`:219` 两个渲染面现在读同一处门,所以改一处即同时覆盖两个面,并且天然不可能只修一半。

| 门位 | 改前 | 改后 | 覆盖的渲染面 |
|---|---|---|---|
| `packages/plugin-grid/src/components/RowActionMenu.tsx` `isCustomRowActionVisible` | `if (!def?.visible) return true;` | `const pred = def?.visible;` 然后 `if (pred == null \|\| pred === '') return true;` | overflow 菜单项 + inline primary 按钮 + `planRowActionMenu` 的计数(即「⋮」触发器是否渲染,#3562 的守卫) |
| `packages/components/src/renderers/complex/data-table.tsx` `isCustomRowActionVisible` | `if (!action?.visible) return true;` | `const pred = action?.visible;` 然后 `if (pred == null \|\| pred === '') return true;` | data-table 行菜单项 + `planDataTableRowMenu` 的计数 |

`evalRowActionVisibility` 未改(布尔短路早已在里面)。其中 `pred === ''` 一支改后仍**不是死代码**:`isBuiltinRowActionVisible` 的门只有 `!= null`,`''` 仍从那条路到达 —— 已加注释写明,免得后来的读者当死支删掉。

## 不变量依据(#3492,已裁不重开)

`packages/plugin-grid/src/bulkEligibility.ts` 的 `hasVisibilityGate` 注释原文,objectui#3492 落地时写的:

> Truthiness cannot answer this: `visible: false` is a declared gate that excludes everything, and testing `def.visible &&` classified it as *ungated* — which rendered the button `false` was written to remove (objectui#3492).

行动作这两处是同一形状里没有一起收口的部分;内建 `visibleWhen` 的门一直是 `!= null`。本 PR 只是把行动作收口到同一处不变量,**不是新决定**。

## 行为变化面(刻意窄)

只有 `visible` 为字面布尔 `false`(或其它非空 falsy 值)的行动作变化 —— **从渲染变隐藏**,即声明所要求的。`visible: true` 照旧渲染,`''` 与未声明照旧不算门,表达式取值的 `visible` verdict 一律不变。

`ActionSchema.visible` 是 `ExpressionInputSchema`(无 boolean 成员),`objectstack build` 产不出这个形状;手写视图 JSON 与进程内构造 def 可以 —— #3492 正文记录这两条路径确实发生过。故可达性低。

## 反向验证(方向先判后跑)

**预判**:6 条 `visible: false` 断言在未改的门上必须**红**;所有 `visible: true` / `''` / 未声明的对称断言必须**绿**(它们不是方向钉,而是防止把「声明检测」写成「恒隐藏」的护栏 —— 那样重写能让每一条 `visible: false` 断言独自通过)。

先在 `origin/main` 的门上跑新钉子(即「还原门」),实测与预判逐条一致:

```
❯ RowActionMenu.test.tsx (20 tests | 2 failed)
    × visible:false → the overflow menu item does not render
    × visible:false → the inline primary button does not render
❯ RowActionMenu.emptyGuard.test.tsx (27 tests | 2 failed)
    × a declared `visible: false` excludes the def and leaves no trigger (objectui#3758)
    × renders no trigger when the row's only custom action declares `visible: false`
❯ data-table-row-menu-empty-guard.test.tsx (16 tests | 1 failed)
    × drops a custom action declaring `visible: false`, reaching zero items
❯ data-table-row-action-visible.test.tsx (10 tests | 1 failed)
    × hides an action declaring `visible: false`
 Tests  6 failed | 67 passed (73)

AssertionError: expected [ { name: 'ghost', visible: false } ] to deeply equal []
AssertionError: expected [div role="menuitem" …(5)] to be null
```

改后同一批:`Test Files 10 passed (10) / Tests 125 passed (125)`。

另有一条**测得的**前置读数(临时探针,已删):`visible: false` 在改前三面分别是 行菜单 `true`(渲染,缺陷)、选择栏 `false`、记录页头 `false` —— 即行菜单是唯一读错的那一面,改后三面一致。

## 测试

- 三个观测面各一条 `visible: false` 钉子:plugin-grid overflow 项、inline primary 按钮、data-table 菜单项;
- 守卫/plan 层三条(`planRowActionMenu` / `planDataTableRowMenu` 计数归零)+「⋮」DOM 两条;
- 每条都配 `visible: true`(声明门、恒真)与 `''` / 未声明(不算门)的对照断言;
- `predicate-surface-parity.test.tsx`:新增四条非表达式形状的三面一致用例。该文件头注释此前把这条差异记为「still-open divergence —— the kebab renders a `visible: false` def」,现已成立并改写。

**Fixture 处置**:`RowActionMenu.emptyGuard.test.tsx` 里钉住旧真值行为的那条 fixture(`preserves the visible: false truthy gate verbatim`)**整条替换**,不是重拼 —— 它的期望值(`['ghost']` / `1`)现在是错的 verdict。原注释说明当时为何刻意保留,替换处留注写明 #3758 把它另裁了。

## 命令与输出

```
pnpm vitest run packages/plugin-grid packages/components --maxWorkers=2
  → Test Files 152 passed (152) / Tests 1242 passed (1242)

pnpm --filter @object-ui/plugin-grid --filter @object-ui/components type-check
  → packages/components type-check: Done
  → packages/plugin-grid type-check: Done

pnpm vitest run packages/plugin-detail packages/plugin-view --maxWorkers=2   # 消费半径
  → Test Files 66 passed (66) / Tests 575 passed (575)

pnpm exec eslint (7 个改动文件)  → 0 errors(仅既有 warning)
node scripts/check-control-bytes.mjs → OK (3731 tracked text files)
node scripts/check-changeset-no-major.mjs → No changeset declares a major bump
```

消费半径按规则的调用方枚举,不按被改包:两处门的调用方(两处 plan 函数、四个 item/按钮组件、`predicate-surface-parity`)全部定向跑过;`plugin-detail` 的 `RelatedList` 把子对象 `list_item` 动作喂给 data-table,故一并跑。全仓扫过 row-action 的布尔 `visible` fixture,除已处置的两处外无他。

## Changeset

`.changeset/row-action-declared-visible-gate-3758.md` —— `@object-ui/plugin-grid` + `@object-ui/components` 均 `patch`(行为修复;按仓规不声明 `major`)。

## 范围外发现(未在本 PR 改动)

- **#3812** —— `packages/components/src/renderers/action/**` 有 8 处同形真值门。其中 `action:group` 的 inline/dropdown 成员动作与 `action:menu` 的项**确实可达**(直接从组件自己的 `actions` 数组 `.map()` 渲染,既不经 `SchemaRenderer` 也不经 `ActionEngine`);另五处组件级 `schema.visible` 大概率被 `SchemaRenderer.tsx:288` 的统一处理遮住。已带锚点与可达性分析单独立单交分诊定级。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_