### PR TITLE
fix(data-objectstack): queryDataset 返回的 fields 元素改用 spec 的 AnalyticsResult.fields[] 类型 (#3752)

### DIFF
--- a/.changeset/dataset-result-fields-spec-type-3752.md
+++ b/.changeset/dataset-result-fields-spec-type-3752.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+data-objectstack: type `queryDataset`'s result `fields[]` as the spec's `AnalyticsResult.fields[]` element instead of a hand-written copy
+
+The return-value half of the drift objectui#3613 fixed on the parameter side. The
+adapter hand-listed five keys for a result column
+(`name`/`type`/`label`/`format`/`currency`) and, like every restatement, stopped
+at the contract of the day it was written: it never grew **`percentScale`**,
+which `@objectstack/spec@17.0.0-rc.5` carries on
+`AnalyticsResult.fields[]` and documents as mandatory reading for renderers —
+"renderers that receive it must scale by it instead of guessing from the value"
+(objectui#3136).
+
+That omission was not cosmetic. `percentScale` is the server's answer to a
+question a `%` format string cannot express (is the stored number a 0–1 fraction,
+or already percentage points?), and objectui#3136 exists because guessing from
+the value's magnitude printed a ratio of exactly `1` as "1.0%". Three in-repo
+consumers read the field through their own local types
+(`DatasetResultField` in `@object-ui/core`), so nothing was red here — but any
+author reading columns through the adapter's **declared** return type got
+`Property 'percentScale' does not exist`, i.e. the declaration actively steered
+them back to the guess the spec bans.
+
+`fields` is now the spec type by reference, so there is nothing left to re-sync;
+the change is additive for existing consumers (one more optional key).
+`queryDataset.test.ts` pins structural identity with the spec element, pins
+`percentScale` as the `'fraction' | 'whole'` union rather than a widened
+`string`, keeps a negative pin against the five-key shape, and adds a runtime
+test that reads `percentScale` off a result column **through the declared type**.
+
+The rest of the envelope stays locally declared, deliberately. It is the REST
+envelope, not an `AnalyticsResult`: the route adds ADR-0021 D2 drill metadata
+(`object` / `dimensionFields` / `drillRawRows`) on top of the spec result, and
+this method rebuilds its own object from the payload without copying `sql` — so
+declaring the envelope as `AnalyticsResult & { … }` would advertise a key the
+adapter structurally cannot return. A pin records that too.

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -8,7 +8,7 @@
 
 import { ObjectStackClient, type QueryOptions as ObjectStackQueryOptions } from '@objectstack/client';
 import type { DroppedFieldsEvent } from '@objectstack/spec/data';
-import type { DatasetSelection } from '@objectstack/spec/contracts';
+import type { AnalyticsResult, DatasetSelection } from '@objectstack/spec/contracts';
 import type {
   DataSource,
   BatchTransactionOperation,
@@ -3259,9 +3259,26 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     selection: DatasetSelection,
   ): Promise<{
     rows: Array<Record<string, unknown>>;
-    /** Column metadata: a display `label` (dimensions and measures), and a
-     *  measure's numeral `format` + declared `currency` for value formatting. */
-    fields: Array<{ name: string; type: string; label?: string; format?: string; currency?: string }>;
+    /**
+     * Column metadata — the spec's `AnalyticsResult.fields[]` element BY
+     * REFERENCE, never a local restatement of it (objectui#3752). Read
+     * `@objectstack/spec` for what a column carries; this comment deliberately
+     * does not re-list the keys, because the enumeration it replaced was the
+     * bug: it named five (`name`/`type`/`label`/`format`/`currency`) and stopped
+     * at the contract of the day it was written, so it never grew
+     * `percentScale` — the server's answer to whether a percentage column is a
+     * 0–1 fraction or already percentage points. The spec says a renderer that
+     * receives it "must scale by it instead of guessing from the value"
+     * (objectui#3136), so a declaration that hides the key steers a typed
+     * consumer into exactly the guess-by-magnitude the issue banned. Pinned in
+     * `queryDataset.test.ts`.
+     *
+     * Only this element is spec-owned: the envelope around it (`object` /
+     * `dimensionFields` / `drillRawRows`) is ADR-0021 D2 drill metadata the REST
+     * route adds on top of `AnalyticsResult`, and this method never returns the
+     * result's `sql`, so the whole envelope is NOT an `AnalyticsResult`.
+     */
+    fields: Array<AnalyticsResult['fields'][number]>;
     /** ADR-0021 D2 drill-through: the dataset's base object (records to drill into). */
     object?: string;
     /** Drillable dimension NAME → underlying object FIELD name. */

--- a/packages/data-objectstack/src/queryDataset.test.ts
+++ b/packages/data-objectstack/src/queryDataset.test.ts
@@ -9,9 +9,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type {
   AnalyticsQuery as SpecAnalyticsQuery,
+  AnalyticsResult as SpecAnalyticsResult,
   DatasetCompareTo as SpecDatasetCompareTo,
   DatasetSelection as SpecDatasetSelection,
 } from '@objectstack/spec/contracts';
+import type { PercentScale as SpecPercentScale } from '@objectstack/spec/data';
 import {
   ObjectStackAdapter,
   clearSharedDiscoveryCache,
@@ -252,5 +254,96 @@ describe('queryDataset(selection) is @objectstack/spec DatasetSelection itself',
     const sent = JSON.parse(post.init.body);
     expect(sent.selection.compareTo).toEqual({ kind: 'previousPeriod' });
     expect(sent.selection.compareTo).not.toHaveProperty('dimension');
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* objectui#3752 — the RESULT's `fields` element is the spec type, not a copy.  */
+/*                                                                             */
+/* Same drift family as #3613 above, on the other side of the call: the return  */
+/* type hand-listed five keys and had already stopped at the contract of the    */
+/* day it was written — no `percentScale`. Compile-time pins, checked by        */
+/* `pnpm --filter @object-ui/data-objectstack type-check` for the reason that   */
+/* section documents (this package's tsconfig.json compiles its own tests).     */
+/* -------------------------------------------------------------------------- */
+
+/** What `queryDataset` RESOLVES to, read off the method. */
+type DatasetEnvelope = Awaited<ReturnType<ObjectStackAdapter['queryDataset']>>;
+/** …and the declared shape of one result column. */
+type ResultField = DatasetEnvelope['fields'][number];
+
+describe('queryDataset result fields ARE @objectstack/spec AnalyticsResult fields', () => {
+  it('is pinned at compile time', () => {
+    type _SpecNotAny = Assert<Equal<IsAny<SpecAnalyticsResult>, false>>;
+
+    // THE pin: structural identity with the spec's element, so the declaration
+    // cannot lag the contract again. `Equal` rather than `extends` for the
+    // #3613 reason — a narrower copy stays assignable while drifting.
+    type _IsTheSpecField = Assert<Equal<ResultField, SpecAnalyticsResult['fields'][number]>>;
+
+    // The single key the deleted copy was missing, named so a reader learns
+    // WHICH omission cost something rather than merely that one existed.
+    type _HasPercentScale = Assert<HasKey<ResultField, 'percentScale'>>;
+    type _PercentScaleIsTheSpecUnion = Assert<
+      Equal<ResultField['percentScale'], SpecPercentScale | undefined>
+    >;
+    // …and not a widened `string`: 'fraction' | 'whole' is the whole point —
+    // a renderer branches on it instead of guessing from the value (#3136).
+    type _PercentScaleIsNotString = Assert<
+      Equal<Equal<ResultField['percentScale'], string | undefined>, false>
+    >;
+
+    // The exact shape this replaced, kept as a NEGATIVE pin: restoring the
+    // hand-written five keys turns this red, so the sabotage direction is
+    // recorded in the test rather than in a commit message.
+    type _NotTheFiveKeyCopy = Assert<
+      Equal<
+        Equal<ResultField, { name: string; type: string; label?: string; format?: string; currency?: string }>,
+        false
+      >
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  // Why only `fields` is spec-owned and the envelope is not (objectui#3752
+  // direction B). The REST route answers `AnalyticsResult` PLUS ADR-0021 D2
+  // drill sidecars, but this method rebuilds its own object from the payload
+  // and never copies `sql` — so declaring the envelope as `AnalyticsResult &
+  // {…}` would advertise a key the adapter structurally cannot return.
+  it('pins the envelope as NOT an AnalyticsResult (no `sql`)', () => {
+    type _NoSql = Assert<Equal<HasKey<DatasetEnvelope, 'sql'>, false>>;
+    // The drill sidecars the spec type does not carry stay locally declared.
+    type _HasDrillObject = Assert<HasKey<DatasetEnvelope, 'object'>>;
+    type _HasDimensionFields = Assert<HasKey<DatasetEnvelope, 'dimensionFields'>>;
+    type _HasDrillRawRows = Assert<HasKey<DatasetEnvelope, 'drillRawRows'>>;
+
+    expect(true).toBe(true);
+  });
+
+  // The runtime half: a column's `percentScale` must reach the caller verbatim.
+  // The adapter passes `fields` through untouched, so this guards against a
+  // future "normalisation" quietly dropping the key the declaration now shows.
+  it('returns a percentage column with its percentScale untouched', async () => {
+    const { fetchImpl } = makeFetch({
+      ok: true,
+      body: {
+        rows: [{ region: 'NA', winRate: 1 }],
+        fields: [
+          { name: 'region', type: 'string', label: 'Region' },
+          { name: 'winRate', type: 'number', label: 'Win rate', format: '0.0%', percentScale: 'fraction' },
+        ],
+      },
+    });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+    const result = await adapter.queryDataset(inlineDataset as any, selection);
+
+    // Read through the DECLARED type, not `as any`: this line is the reason the
+    // issue was filed — before the fix it did not compile.
+    const winRate = result.fields.find((f) => f.name === 'winRate')!;
+    expect(winRate.percentScale).toBe('fraction');
+    const region = result.fields.find((f) => f.name === 'region')!;
+    expect(region.percentScale).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes #3752

## 做了什么

`ObjectStackAdapter.queryDataset` 返回类型里 `fields` 的元素形状,由手写的五键改成 spec 拥有的那一个类型:

```ts
// before —— packages/data-objectstack/src/index.ts
fields: Array< { name: string; type: string; label?: string; format?: string; currency?: string } >;

// after
import type { AnalyticsResult, DatasetSelection } from '@objectstack/spec/contracts';
fields: Array< AnalyticsResult['fields'][number] >;
```

JSDoc 一并改写:原来那段逐项列举("a display `label`…, and a measure's numeral `format` + declared `currency`")本身就是第二方言的载体 —— 它和被删的类型犯的是同一个错,停在了写它那天的 spec 上。新注释指向 spec、不再复述键名,只留下"为什么只有这一项派生"的理由。

## 为什么漏项不是纸面问题

实装 `@objectstack/spec@17.0.0-rc.5` 的 `AnalyticsResult.fields[]` 除那五项外还有 `percentScale?: PercentScale`,spec 注释写明「renderers that receive it must scale by it instead of guessing from the value (objectui#3136)」。仓内三个消费端(`plugin-dashboard` / `plugin-report` / `DatasetPreview`)靠 `@object-ui/core` 的本地 `DatasetResultField` 读到它,所以今天不红;而按 adapter **声明的返回类型**取值的外部作者会拿到 `Property 'percentScale' does not exist` —— 声明在把作者推回 #3136 明令禁止的"按数值大小猜刻度"。

## 取向:守 B,不升 A(实读 framework 路由后的结论)

派单允许在"实证服务端回全 `AnalyticsResult`"时升级为 A(整体交叉类型)。实读后**结论相反,且证据在本仓自己这边**:

- framework(`objectstack` @ `ea1d9165d`)`packages/rest/src/rest-server.ts` 的 `POST /analytics/dataset/query` 是 `res.json(result)`,原样下发 `svc.queryDataset(...)` 的结果;`packages/services/service-analytics/src/analytics-service.ts:614` 声明返回 `Promise< AnalyticsResult >`,并在 `:745` 起把 ADR-0021 D2 的钻取旁路(`object` / `dimensionFields` / `drillRawRows` / `drillRawTotals` / `drillRanges`)通过 `AnalyticsResultWithDrill` **加在** `AnalyticsResult` 之上。也就是说线上信封确实是「`AnalyticsResult` + 增量」。
- **但 adapter 并不返回它收到的东西**:`packages/data-objectstack/src/index.ts:3355` 是 `return { rows, fields, object, dimensionFields, drillRawRows, totals };` —— 逐项挑键,**从不拷贝 `sql`**。所以哪怕路由回全,声明成 `AnalyticsResult & { … }` 也会向调用方广告一个本方法结构上永远不会给出的键(`sql?: string` 虽是可选,但"可能有"本身就是假声明)。

因此 A 的前提在**本仓一侧**就不成立,和路由回不回 `sql` 无关。信封其余字段保持本地声明,并把这个事实钉成测试(`_NoSql`),下一个读者不必再重查一遍。

## 类型钉子与 sabotage 自证

`packages/data-objectstack/src/queryDataset.test.ts` 追加一段(沿用本包 #3613 那节的 `Assert` / `Equal` 范式;本包 tsconfig 编译自己的测试树,所以这些钉子由 `tsc --noEmit` 承载):

- `_IsTheSpecField` —— 与 spec 元素**结构相等**(用 `Equal` 而非 `extends`:窄化的手抄件在漂移方向上仍然可赋值)。
- `_HasPercentScale` / `_PercentScaleIsTheSpecUnion` / `_PercentScaleIsNotString` —— 点名那一个漏键,并钉住它是 `'fraction' | 'whole'` 而不是被放宽的 `string`。
- `_NotTheFiveKeyCopy` —— **负向钉子**:把手写五键放回去就红,sabotage 方向写进测试而不是只写进 commit message。
- `_NoSql` / `_HasDrillObject` / `_HasDimensionFields` / `_HasDrillRawRows` —— 钉住"信封不是 `AnalyticsResult`"这个取向。
- 一个运行时测试:服务端回包里带 `percentScale: 'fraction'` 的列,**经声明类型**读出来仍是 `'fraction'`(修前这一行根本不编译)。

**sabotage(临时把五键手写形状放回 `index.ts`,未入 commit)**。预判方向:vitest 只做类型擦除、不会变红,红信号必须来自 `tsc --noEmit` —— 实测如此:

```
src/queryDataset.test.ts(282,35): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/queryDataset.test.ts(286,36): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/queryDataset.test.ts(288,25): error TS2339: Property 'percentScale' does not exist on type '{ name: string; type: string; label?: string | undefined; format?: string | undefined; currency?: string | undefined; }'.
src/queryDataset.test.ts(293,7): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/queryDataset.test.ts(293,31): error TS2339: Property 'percentScale' does not exist on type '{ … }'.
src/queryDataset.test.ts(300,7): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/queryDataset.test.ts(345,20): error TS2339: Property 'percentScale' does not exist on type '{ … }'.
src/queryDataset.test.ts(347,19): error TS2339: Property 'percentScale' does not exist on type '{ … }'.
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @object-ui/data-objectstack@17.3.0 type-check: `tsc --noEmit` Exit status 2
```

`:345` 那两条正是 issue 描述的外部作者现场:**读一列的 `percentScale` 编译不过**。还原后 `tsc --noEmit` 无输出(绿)。

## 验证

- `pnpm vitest run packages/data-objectstack --maxWorkers=2` —— **24 files / 359 tests passed**(含新增的 3 个断言块)。
- `pnpm --filter @object-ui/data-objectstack type-check` —— 绿(钉子在这里生效)。
- `pnpm --filter @object-ui/data-objectstack lint` —— 0 errors(330 个既有 `no-explicit-any` warning,与本改动无关)。
- **消费半径**:`plugin-dashboard` / `plugin-report` / `app-shell` 三个读 `percentScale` 的包 `type-check` 全绿、零改动 —— 与预期一致,它们走 `@object-ui/core` 的本地类型,而本改动对它们是**加性**的(多一个可选键)。
- `node scripts/check-control-bytes.mjs` —— OK(3733 个文件);改动文件另做 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫,零命中。

## Changeset

`.changeset/dataset-result-fields-spec-type-3752.md`,`@object-ui/data-objectstack: patch` —— 类型面修正、对既有消费者加性,与同族的 #3753(`dataset-selection-spec-type-3613.md`)同档。

## 顺手核对与越界发现(均已单开,本 PR 不修)

- **#3815**(`finding`,只核对不实施):`packages/core/src/utils/dataset-format.ts:29` 的 `DatasetResultField` 仍是同一契约的手写重述。今天**没有**漂移(六键齐,`PercentScale` 还是从 `@objectstack/spec/data` import 的真身),唯一形状差异是 `type` 被放宽成可选而 spec 必填。属休眠漂移面,且改它要先决 `type` 可选性是否有意、以及公开名字的兼容路线,跨 `packages/core` 面 —— 超出本单文件面,故只记录。
- **#3813**(运行时缺陷,concrete):`index.ts:3355` 的挑键式返回**丢掉了服务端的 `drillRanges`**,而 `DatasetWidget.tsx:471/593` 与 `DatasetReportRenderer.tsx:316/431/855` 都在读它 —— 只按日期维度分组的图表因此 `canDrill === false`,#1752 的日期分桶钻取经真实 adapter 永不可用。现有测试看不见,因为两边的测试都用自己 mock 的 data source 直接喂这个键。与本 PR 同一处代码但是**运行时行为**改动,按 PD #10 不并入纯类型面的这个 PR。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_