### PR TITLE
fix(scripts): check-i18n-en-drift 的显式 base 提为权威,解析不出即失败 (#3766)

### DIFF
--- a/scripts/__tests__/check-i18n-en-drift.test.ts
+++ b/scripts/__tests__/check-i18n-en-drift.test.ts
@@ -138,8 +138,17 @@ function repoWithCommits(commits: Array<Record<string, string>>): { root: string
   return { root, shas };
 }
 
-/** Runs the real gate as CI runs it. Returns the exit code and the merged output. */
-function runGate(root: string, args: string[]): { code: number; output: string } {
+/**
+ * Runs the real gate as CI runs it. Returns the exit code and the merged output.
+ *
+ * `envOverrides` re-supplies one of the two vars the gate reads, for the tests
+ * that are ABOUT those vars; everything else keeps them cleared.
+ */
+function runGate(
+  root: string,
+  args: string[],
+  envOverrides: Record<string, string> = {},
+): { code: number; output: string } {
   const result = execFileSync(
     process.execPath,
     [gateScript, '--root', root, ...args],
@@ -149,7 +158,7 @@ function runGate(root: string, args: string[]): { code: number; output: string }
       cwd: root,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, OS_I18N_DRIFT_BASE: '', GITHUB_BASE_REF: '' },
+      env: { ...process.env, OS_I18N_DRIFT_BASE: '', GITHUB_BASE_REF: '', ...envOverrides },
     },
     // `execFileSync` throws on a non-zero exit; the status and both streams are
     // on the error, so the two paths are unified here rather than at each site.
@@ -157,9 +166,13 @@ function runGate(root: string, args: string[]): { code: number; output: string }
   return { code: 0, output: result };
 }
 
-function runGateExpectingFailure(root: string, args: string[]): { code: number; output: string } {
+function runGateExpectingFailure(
+  root: string,
+  args: string[],
+  envOverrides: Record<string, string> = {},
+): { code: number; output: string } {
   try {
-    runGate(root, args);
+    runGate(root, args, envOverrides);
   } catch (error) {
     const failure = error as { status: number; stdout: string; stderr: string };
     return { code: failure.status, output: `${failure.stdout}${failure.stderr}` };
@@ -561,6 +574,128 @@ describe('resolving the commit to compare against', () => {
       ok: true,
       ref: shas[0],
       how: 'merge-base with origin/main',
+    });
+  });
+
+  // ── an explicitly named base is authoritative (objectui#3766) ─────────────
+
+  /** Well-formed, forty hex digits, and in no clone anywhere. */
+  const ABSENT_SHA = '0123456789abcdef0123456789abcdef01234567';
+
+  it('FAILS on an explicitly named --base that does not exist — it does NOT fall back', () => {
+    // The defect objectui#3766 filed, in the shape it was measured. `--base` used
+    // to be merely the FIRST link of the candidate chain, so a sha missing from
+    // this clone (a shallow checkout, an unfetched sha, a typo) fell through to
+    // `merge-base with main` — which in this fixture repo resolves to HEAD. The
+    // gate then compared the packs at HEAD against the identical working tree,
+    // found no changed en value, and printed a confident green (measured: exit 0,
+    // with `(--base …)` in the summary line replaced by the candidate it actually
+    // used, so the log gave the reader nothing to notice). Restoring the
+    // fallthrough turns this case green again — exit 0 and the "followed by all
+    // nine" line below — which is the reverse verification for the fix.
+    //
+    // "The base you named is missing" and "you named no base" are different
+    // facts, and only the second may be answered by guessing. Ported verbatim in
+    // spirit from `check-changeset-presence.test.ts`, where the sibling gate's
+    // own tests caught this first (objectui#3762).
+    const { root } = reconstructed3625();
+
+    const { code, output } = runGateExpectingFailure(root, [...FIXTURE_FLOOR, '--base', ABSENT_SHA]);
+    expect(code).toBe(1);
+    expect(output).toContain('Cannot resolve the commit to compare against');
+    expect(output).toContain(`--base ${ABSENT_SHA} (unresolved)`);
+    expect(output).toContain('named EXPLICITLY');
+    expect(output).toContain('a diff gate with no diff would pass while');
+    // And specifically NOT the pass it used to produce by comparing against main.
+    expect(output).not.toContain('Every changed en value was followed');
+  });
+
+  it('FAILS the same way on an OS_I18N_DRIFT_BASE that does not exist', () => {
+    // The env var is the other documented explicit entrypoint — same authority,
+    // same failure, and it is the one CI-adjacent callers reach for. Driven
+    // through the real CLI with the var actually set, because `runGate` clears it
+    // for every other test in this file.
+    const { root } = reconstructed3625();
+
+    const { code, output } = runGateExpectingFailure(root, FIXTURE_FLOOR, {
+      OS_I18N_DRIFT_BASE: ABSENT_SHA,
+    });
+    expect(code).toBe(1);
+    expect(output).toContain(`OS_I18N_DRIFT_BASE=${ABSENT_SHA} (unresolved)`);
+    expect(output).toContain('named EXPLICITLY');
+    expect(output).not.toContain('Every changed en value was followed');
+  });
+
+  it('consults NOTHING but the named base — not even a candidate that would resolve', () => {
+    // The mechanism, asserted directly rather than through an exit code: `tried`
+    // holds exactly one entry. `GITHUB_BASE_REF=main` plus a real `origin/main`
+    // here means the discovery candidate WOULD have produced a base, so a single
+    // `tried` entry is the proof that it was never asked.
+    const { root, shas } = repoWithCommits([
+      packFiles(treesFor((lang) => ({ a: `x-${lang}` }))),
+      packFiles(treesFor((lang) => ({ a: `y-${lang}` }))),
+    ]);
+    execFileSync('git', ['remote', 'add', 'origin', root], { cwd: root });
+    execFileSync('git', ['update-ref', 'refs/remotes/origin/main', shas[0]], { cwd: root });
+
+    const outcome = resolveBaseRef(root, { explicit: ABSENT_SHA, env: { GITHUB_BASE_REF: 'main' } });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.named).toBe(true);
+      expect(outcome.tried).toEqual([`--base ${ABSENT_SHA} (unresolved)`]);
+    }
+    // Sanity: the same repo, same env, WITHOUT a named base still finds one.
+    expect(resolveBaseRef(root, { env: { GITHUB_BASE_REF: 'main' } })).toMatchObject({ ok: true });
+  });
+
+  it('still resolves a named base that DOES exist, and --base outranks the env var', () => {
+    const { root, shas } = repoWithCommits([
+      packFiles(treesFor((lang) => ({ a: `x-${lang}` }))),
+      packFiles(treesFor((lang) => ({ a: `y-${lang}` }))),
+    ]);
+
+    expect(resolveBaseRef(root, { explicit: shas[0], env: {} })).toMatchObject({
+      ok: true,
+      ref: shas[0],
+      how: `--base ${shas[0]}`,
+    });
+    expect(resolveBaseRef(root, { env: { OS_I18N_DRIFT_BASE: shas[0] } })).toMatchObject({
+      ok: true,
+      ref: shas[0],
+      how: `OS_I18N_DRIFT_BASE=${shas[0]}`,
+    });
+    // `--base` outranks the env var: both name a real commit, and the flag's is
+    // the one compared against.
+    const both = resolveBaseRef(root, { explicit: shas[0], env: { OS_I18N_DRIFT_BASE: shas[1] } });
+    expect(both).toMatchObject({ ok: true, ref: shas[0], how: `--base ${shas[0]}` });
+  });
+
+  it('keeps guessing through the whole chain when NO base was named', () => {
+    // The other half of objectui#3766, and the half CI depends on: only "you
+    // named one and it is missing" became a failure. With nothing named, an
+    // unresolvable `GITHUB_BASE_REF` still falls through to `origin/main` exactly
+    // as before — `pnpm check:i18n-drift` passes no `--base`, so this is the path
+    // every real CI run takes.
+    const { root, shas } = repoWithCommits([
+      packFiles(treesFor((lang) => ({ a: `x-${lang}` }))),
+      packFiles(treesFor((lang) => ({ a: `y-${lang}` }))),
+    ]);
+    execFileSync('git', ['remote', 'add', 'origin', root], { cwd: root });
+    execFileSync('git', ['update-ref', 'refs/remotes/origin/main', shas[0]], { cwd: root });
+
+    // `GITHUB_BASE_REF` names a branch this clone does not have; the chain moves
+    // on and `origin/main` answers.
+    expect(resolveBaseRef(root, { env: { GITHUB_BASE_REF: 'no-such-branch' } })).toMatchObject({
+      ok: true,
+      ref: shas[0],
+      how: 'merge-base with origin/main',
+    });
+    // And in a clone with no `origin` at all, the last link — the local `main` —
+    // still answers, so the chain is intact end to end and not just at its head.
+    const solo = repoWithCommits([packFiles(treesFor((lang) => ({ a: `x-${lang}` })))]);
+    expect(resolveBaseRef(solo.root, { env: {} })).toMatchObject({
+      ok: true,
+      how: 'merge-base with main',
     });
   });
 

--- a/scripts/check-changeset-presence.mjs
+++ b/scripts/check-changeset-presence.mjs
@@ -185,8 +185,9 @@ function gitQuiet(root, args) {
  * silently judged the change against `main`'s tip instead and printed a
  * confident green. "The base you named is missing" and "you named no base" are
  * different facts, and only the second one may be answered by guessing. (The
- * sibling gate `check-i18n-en-drift.mjs` still has the fallthrough shape — filed
- * separately, not fixed here.)
+ * sibling gate `check-i18n-en-drift.mjs` inherited the fallthrough shape from
+ * this gate's first draft; it was fixed to match under objectui#3766, so the two
+ * resolvers are the same shape again — keep them that way.)
  *
  * @returns {{ ok: true, ref: string, how: string } | { ok: false, tried: string[], shallow: boolean, named: boolean }}
  */

--- a/scripts/check-i18n-en-drift.mjs
+++ b/scripts/check-i18n-en-drift.mjs
@@ -340,16 +340,52 @@ export function readPacks(root, ref) {
 /**
  * Which commit this branch should be judged against.
  *
- * Order: an explicit `--base`, then `OS_I18N_DRIFT_BASE`, then the merge base
- * with the PR's own base branch (`GITHUB_BASE_REF`), then `origin/main`, then a
- * local `main`. A base that cannot be resolved is a HARD FAILURE, never a skip:
- * a diff gate that quietly finds nothing to diff reports green while checking
- * nothing, which is the failure this whole family of gates exists to stop.
+ * An explicitly NAMED base (`--base`, `OS_I18N_DRIFT_BASE`) is authoritative and
+ * is the only thing consulted when given. Otherwise the base is DISCOVERED: the
+ * merge base with the pull request's own base branch (`GITHUB_BASE_REF`), then
+ * `origin/main`, then a local `main`. The merge base — rather than the target
+ * branch's tip — is what makes a branch answer for the edits IT made and not for
+ * whatever landed on `main` after it forked.
  *
- * @returns {{ ok: true, ref: string, how: string } | { ok: false, tried: string[], shallow: boolean }}
+ * A base that cannot be resolved is a HARD FAILURE, never a skip: a diff gate
+ * that quietly finds nothing to diff reports green while checking nothing, which
+ * is the failure this whole family of gates exists to stop. And an explicit one
+ * that cannot be resolved does NOT fall through to the discovery candidates —
+ * with the fallthrough, a `--base` sha absent from this clone (a shallow clone,
+ * an unfetched sha, a typo) silently judged the packs against whatever the
+ * discovery chain answered next instead (`merge-base with origin/main` on this
+ * repo, as measured) and printed a confident green, with the `(--base …)` in the
+ * summary line replaced by the candidate actually used so the log gave the
+ * reader nothing to notice (objectui#3766, measured: exit 0 → exit 1). "The base
+ * you named is missing" and "you named no base" are different facts, and only
+ * the second one may be answered by guessing. `check-changeset-presence.mjs`
+ * resolves its base from the same sources and had this same defect caught by its
+ * own tests first (objectui#3762) — the two `resolveBaseRef`s are deliberately
+ * the same shape.
+ *
+ * @param {string} root
+ * @param {{ explicit?: string | null, env?: Record<string, string | undefined> }} [options]
+ * @returns {{ ok: true, ref: string, how: string } | { ok: false, tried: string[], shallow: boolean, named: boolean }}
  */
 export function resolveBaseRef(root, { explicit = null, env = process.env } = {}) {
   const tried = [];
+  const verify = (ref) => gitQuiet(root, ['rev-parse', '--verify', `${ref}^{commit}`]);
+  const shallow = () => gitQuiet(root, ['rev-parse', '--is-shallow-repository']) === 'true';
+
+  const named = explicit
+    ? { how: `--base ${explicit}`, ref: explicit }
+    : env.OS_I18N_DRIFT_BASE
+      ? { how: `OS_I18N_DRIFT_BASE=${env.OS_I18N_DRIFT_BASE}`, ref: env.OS_I18N_DRIFT_BASE }
+      : null;
+
+  if (named) {
+    const resolved = verify(named.ref);
+    tried.push(`${named.how}${resolved ? '' : ' (unresolved)'}`);
+    return resolved
+      ? { ok: true, ref: resolved, how: named.how }
+      : { ok: false, tried, shallow: shallow(), named: true };
+  }
+
   const attempt = (how, compute) => {
     const value = compute();
     tried.push(`${how}${value ? '' : ' (unresolved)'}`);
@@ -357,10 +393,6 @@ export function resolveBaseRef(root, { explicit = null, env = process.env } = {}
   };
 
   const candidates = [
-    explicit ? () => attempt(`--base ${explicit}`, () => gitQuiet(root, ['rev-parse', '--verify', `${explicit}^{commit}`])) : null,
-    env.OS_I18N_DRIFT_BASE
-      ? () => attempt(`OS_I18N_DRIFT_BASE=${env.OS_I18N_DRIFT_BASE}`, () => gitQuiet(root, ['rev-parse', '--verify', `${env.OS_I18N_DRIFT_BASE}^{commit}`]))
-      : null,
     env.GITHUB_BASE_REF
       ? () => attempt(`merge-base with origin/${env.GITHUB_BASE_REF}`, () => gitQuiet(root, ['merge-base', 'HEAD', `origin/${env.GITHUB_BASE_REF}`]))
       : null,
@@ -372,7 +404,7 @@ export function resolveBaseRef(root, { explicit = null, env = process.env } = {}
     const hit = candidate();
     if (hit) return hit;
   }
-  return { ok: false, tried, shallow: gitQuiet(root, ['rev-parse', '--is-shallow-repository']) === 'true' };
+  return { ok: false, tried, shallow: shallow(), named: false };
 }
 
 // -- the comparison -----------------------------------------------------------
@@ -536,10 +568,15 @@ if (invokedDirectly) {
     console.error(
       'Cannot resolve the commit to compare against, so there is nothing to diff.\n' +
         `  tried: ${base.tried.join(', ')}\n` +
-        (base.shallow
-          ? '  This clone is SHALLOW. In CI, give the checkout `fetch-depth: 0`; locally,\n' +
-            '  run `git fetch --no-tags origin main` (or `git fetch --unshallow`).\n'
-          : '  Fetch the base branch (`git fetch --no-tags origin main`) and re-run.\n') +
+        (base.named
+          ? '  That base was named EXPLICITLY, so it is not guessed around: comparing the packs\n' +
+            '  against some other commit instead would answer a question nobody asked, and\n' +
+            '  answer it confidently. Name a commit that exists in this clone, or pass none and\n' +
+            '  let the merge base with the target branch be found.\n'
+          : base.shallow
+            ? '  This clone is SHALLOW. In CI, give the checkout `fetch-depth: 0`; locally,\n' +
+              '  run `git fetch --no-tags origin main` (or `git fetch --unshallow`).\n'
+            : '  Fetch the base branch (`git fetch --no-tags origin main`) and re-run.\n') +
         '  This is a failure, not a skip: a diff gate with no diff would pass while\n' +
         '  checking nothing. See the header of scripts/check-i18n-en-drift.mjs.',
     );


### PR DESCRIPTION
Fixes #3766

## 问题

`scripts/check-i18n-en-drift.mjs` 的 `resolveBaseRef` 把**显式指定**的基准(`--base`、`OS_I18N_DRIFT_BASE`)仅当作候选链的第一环。解析不出时它不失败,而是继续往下猜,拿 `merge-base with origin/main` 之类的**另一个**提交当基准把比对做完,并打印一行自信的绿灯 —— 摘要行里的 `(--base …)` 也被换成了实际用的那一环,读日志的人看不出自己指的基准被忽略了。

「你指的 base 在这个 clone 里不存在」和「你没指 base」是两件不同的事,只有后者可以靠猜回答。

## 修法

显式来源提为**权威**:给出即只查它,解析不出直接返回 `{ ok: false, named: true }`,并给一条针对性提示(你指的 base 在这个 clone 里不存在),而不是原来那句会把人带偏的「去 fetch base 分支」。

形状是仓内先例 `scripts/check-changeset-presence.mjs:209` 的直移植 —— 同族缺陷先在那里被它自己的测试抓到(#3762),两个 `resolveBaseRef` 现在又是同一形状。该文件里那句「sibling 仍是跌落形状,另行开单」的注释随之更正。

`resolveBaseRef` 另补了 JSDoc `@param`:没有它,`explicit` 会被 TS 从默认值 `null` 推成 `null | undefined`,任何传显式 base 的测试都过不了 `pnpm type-check:scripts`(先例文件的测试从不传 `explicit`,所以那边没暴露)。这是在**生产者**声明契约,而不是在测试里加 cast。

## 修好前后 exit 对照(本仓真实实测)

缺陷版(= 改动前的形状),显式给一个本 clone 里不存在的 sha:

```
$ node scripts/check-i18n-en-drift.mjs --base 0123456789abcdef0123456789abcdef01234567
Compared the ten locale packs at 5147d9305 (merge-base with origin/main) with the working tree: 0 en value(s) changed ...
No en value changed in this range.
exit=0                     # 请求的 sha 被无声换掉,报绿
```

修好后,同一条命令:

```
$ node scripts/check-i18n-en-drift.mjs --base 0123456789abcdef0123456789abcdef01234567
Cannot resolve the commit to compare against, so there is nothing to diff.
  tried: --base 0123456789abcdef0123456789abcdef01234567 (unresolved)
  That base was named EXPLICITLY, so it is not guessed around: comparing the packs
  against some other commit instead would answer a question nobody asked, and
  answer it confidently. Name a commit that exists in this clone, or pass none and
  let the merge base with the target branch be found.
  This is a failure, not a skip: a diff gate with no diff would pass while
  checking nothing. See the header of scripts/check-i18n-en-drift.mjs.
exit=1
```

另一个显式入口 `OS_I18N_DRIFT_BASE` 同权威、同失败:

```
$ OS_I18N_DRIFT_BASE=0123456789abcdef0123456789abcdef01234567 node scripts/check-i18n-en-drift.mjs
  tried: OS_I18N_DRIFT_BASE=0123456789abcdef0123456789abcdef01234567 (unresolved)
  ... named EXPLICITLY ...
exit=1
```

## 候选链不变的证明

只有「你指了但解析不出」这一情形从猜测变失败;**没指定显式 base 时的发现链完全不变**。CI 的 `pnpm check:i18n-drift` 不传 `--base`,走的正是这条路径。

1. **无参实跑(= CI 走的路径),行为与改动前逐字一致:**

```
$ node scripts/check-i18n-en-drift.mjs
Compared the ten locale packs at 5147d9305 (merge-base with origin/main) with the working tree: 0 en value(s) changed ...
exit=0
```

2. **显式给一个存在的 sha,正常比对**,并且摘要行现在诚实地报 `(--base …)` 而不是替换成别的候选:

```
$ node scripts/check-i18n-en-drift.mjs --base 5147d9305c0275290f215abe35a6bbf4e80bbdc3
Compared the ten locale packs at 5147d9305 (--base 5147d9305c0275290f215abe35a6bbf4e80bbdc3) with the working tree: ...
exit=0
```

3. **新增用例直接钉链路完整**(`keeps guessing through the whole chain when NO base was named`):无显式 base 时,`GITHUB_BASE_REF` 指向本 clone 没有的分支 -> 继续跌落到 `merge-base with origin/main`;在完全没有 `origin` 的 clone 里 -> 跌落到链尾的本地 `main`。链首链尾都测到,不是只测了链首。

4. 原有的 `prefers the merge base with the PR base branch when CI names one` 与 `fails loudly rather than passing when there is no base to diff` 两条**未改动**,仍绿。

5. 两个 workflow 里描述 base 解析的注释(`ci.yml` 的 `fetch-depth: 0`、`changeset-presence.yml` 关于 merge_group 跌落到 `origin/main`)描述的都是**发现链**,未受影响,无需改动 —— 已逐条核对。

## 反向验证(方向先判后跑)

预判:恢复跌落写法后,新用例应当红,且**门禁 exit 0** 并打印那句绿灯 —— 因为 fixture 仓里 `merge-base with main` 解析得到 HEAD,与工作树同内容,0 个 en 变更。跑出来正是如此:

```
❯ scripts/__tests__/check-i18n-en-drift.test.ts (37 tests | 2 failed | 30 skipped)
  × FAILS on an explicitly named --base that does not exist — it does NOT fall back
      Error: the gate exited 0 where a failure was expected
  × consults NOTHING but the named base — not even a candidate that would resolve
      AssertionError: expected true to be false   // outcome.ok
```

修好后同两条绿。这与 `check-changeset-presence.test.ts` 用例注释里记录的方向(exit 0 -> 1)一致。

## 新增用例

落在 `scripts/__tests__/check-i18n-en-drift.test.ts` 既有的 `resolving the commit to compare against` 块里,沿用本文件的形态(throwaway git 仓 + 真跑 CLI 钉 exit code):

- `FAILS on an explicitly named --base that does not exist — it does NOT fall back` —— 真跑 CLI,断言 exit 1、`(unresolved)`、`named EXPLICITLY`,并显式断言**不含**它过去产生的那句绿灯。
- `FAILS the same way on an OS_I18N_DRIFT_BASE that does not exist` —— 另一个显式入口。为此给 `runGate` 加了可选的 `envOverrides`(其余用例仍照旧清空这两个 env var)。
- `consults NOTHING but the named base — not even a candidate that would resolve` —— 直接钉机理:`tried` 只有一条。此仓同时备好了 `GITHUB_BASE_REF=main` 和真实的 `origin/main`,发现候选**本来能**解析出基准,所以单条 `tried` 就是「它根本没被问」的证据。
- `still resolves a named base that DOES exist, and --base outranks the env var` —— 权威不等于总是失败:好 sha 照常解析,`--base` 优先于 env var。
- `keeps guessing through the whole chain when NO base was named` —— 上面「候选链不变」的第 3 条。

## 验证

```
$ pnpm vitest run scripts/__tests__/check-i18n-en-drift.test.ts scripts/__tests__/check-changeset-presence.test.ts --maxWorkers=2
 Test Files  2 passed (2)
      Tests  68 passed (68)

$ pnpm vitest run scripts/__tests__/scripts-type-check.test.ts scripts/__tests__/ci-cd-pipeline-doc.test.ts scripts/__tests__/check-control-bytes.test.ts --maxWorkers=2
 Test Files  3 passed (3)
      Tests  62 passed (62)

$ pnpm type-check:scripts
exit=0

$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3735 tracked text file(s); skipped 85 binary).
```

改动三个文件另跑了一次控制字节自查(`grep -naP` 覆盖闸门不扫的 `0x01`-`0x1f`),零命中。

## Changeset

不带。`node scripts/check-changeset-presence.mjs` 实跑结论:`3 file(s) changed, 0 of them under the src/ of a package the release covers` -> `No source of a released package changed in this range, so no changeset is owed.` —— `scripts/**` 在发版包守卫面外,与 #3273 / #3784 先例一致。门禁本身也不是用户可见的运行时行为。

## 影响面

今天的 CI 路径不受影响(不传 `--base`,走 `GITHUB_BASE_REF` 那一环)。受影响的是该脚本对外声明支持的两个显式入口 —— 复现历史提交、跨 worktree 比对、以及该门禁自身测试所用的入口:它们从「静默拿错基准报绿」变成「明确失败并说清原因」。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_