### PR TITLE
fix(data-objectstack): queryDataset 透传服务端 drillRanges,恢复日期分桶钻取 (#3813)

### DIFF
--- a/.changeset/dataset-drill-ranges-passthrough-3813.md
+++ b/.changeset/dataset-drill-ranges-passthrough-3813.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+data-objectstack: pass the server's `drillRanges` date-bucket drill scope through `queryDataset` (restores date drill-through)
+
+`queryDataset` rebuilds its result by **hand-picking** keys off the REST payload,
+and `drillRanges` was never in the list — so the analytics service's date-range
+drill sidecar (framework#1752) was dropped by the only real adapter in this repo,
+while five consumer call sites were already reading it (`DatasetWidget.tsx:471`
+and `:593`, `DatasetReportRenderer.tsx:316`, `:431`, `:855`).
+
+The user-visible effect was not a degraded drill but a missing one. A
+`dateGranularity` dimension groups a **span** of records into one bucket, which
+equality filters cannot express, so `service-analytics` deliberately excludes
+date dimensions from `dimensionFields`/`drillRawRows` and sends a parallel
+half-open `[gte, lt)` range per row instead. For a chart or report grouped **only
+by time** that makes `drillRanges` the *only* thing that can make
+`canDrill = !!object && (drillDims.length > 0 || !!drillRanges?.length)` true —
+with the key dropped, the entire drill entry point disappeared. A mixed
+date + non-date grouping kept its drill but built a filter with no time bound, so
+clicking June's bar opened every month (a superset).
+
+Neither side's tests could see it: the dashboard and report tests mock their own
+data source and feed `drillRanges` in directly, and the adapter's own suite never
+asserted the key. The new adapter-level tests therefore mock the **envelope the
+server actually sends** — bare (`res.json(result)`, no `{ success, data }`
+wrapper), carrying `sql`, and for a date-only grouping carrying `object` +
+`drillRanges` and *no* `dimensionFields`/`drillRawRows` — then assert the key
+arrives verbatim and row-aligned, that the consumers' own `canDrill` predicate is
+true, and that `buildDatasetDrillFilter` (the shared builder both surfaces call)
+scopes the drilled list to the clicked bucket.
+
+The declared entry type is `@object-ui/core`'s `DatasetDrillRange` **by
+reference**, per the objectui#3613/#3752 discipline: it is the single in-repo
+declaration of this shape (what the filter builder accepts and what both
+renderers type their state with), and nothing in `@objectstack/spec` owns it yet,
+so restating `{ field, gte, lt }` locally would create a third dialect of it.
+
+`drillRawTotals` (the totals-row companion, framework#3214) is deliberately
+**not** added: it has zero consumers in this repo, so passing it through would
+add a declared-but-unexercised return key with no user-facing effect — it belongs
+in the change that lands a totals-row drill and can test it.

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -33,6 +33,7 @@ import {
   convertFiltersToAST,
   emulateBatchTransaction,
   normalizeSchemaReferenceKeys,
+  type DatasetDrillRange,
 } from '@object-ui/core';
 import { MetadataCache } from './cache/MetadataCache';
 import { MetadataClient } from './metadata-client';
@@ -3285,6 +3286,27 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     dimensionFields?: Record<string, string>;
     /** Raw grouped values per row (aligned to `rows` by index) for drill filters. */
     drillRawRows?: Array<Record<string, unknown>>;
+    /**
+     * Half-open date-range drill scope per row (framework#1752), aligned to
+     * `rows` by index: dimension NAME → the field and `[gte, lt)` bounds of that
+     * row's time bucket. The RANGE companion to `drillRawRows`, which handles
+     * equality dims only — a `dateGranularity` dimension groups a SPAN of
+     * records into one bucket, so the server excludes date dims from
+     * `dimensionFields`/`drillRawRows` and sends this sidecar instead.
+     *
+     * The entry type is `@object-ui/core`'s `DatasetDrillRange` BY REFERENCE,
+     * not a local restatement of it (objectui#3613/#3752 discipline): the same
+     * declaration is what `buildDatasetDrillFilter` — the single consumer that
+     * turns these bounds into an ObjectQL `{ $gte, $lt }` — accepts, and what
+     * `DatasetWidget` / `DatasetReportRenderer` type their state with. Nothing
+     * in `@objectstack/spec` owns this shape yet (the server's own
+     * `AnalyticsResultWithDrill` is local to `service-analytics`), so the shared
+     * in-repo interface is the one contract available; restating it here would
+     * make a third dialect of it. Like `drillRawRows`, only the ARRAY is
+     * validated below — the bounds are unvalidated payload, which is exactly why
+     * `DatasetDrillRange` declares them `unknown`.
+     */
+    drillRanges?: Array<Record<string, DatasetDrillRange>>;
     /** Server-computed marginal aggregates, one entry per requested grouping. */
     totals?: Array<{ dimensions: string[]; rows: Array<Record<string, unknown>> }>;
   }> {
@@ -3351,8 +3373,16 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         ? ((data as any).dimensionFields as Record<string, string>)
         : undefined;
     const drillRawRows = Array.isArray((data as any)?.drillRawRows) ? (data as any).drillRawRows : undefined;
+    // framework#1752 — the date-range sidecar. Dropping it here (objectui#3813)
+    // made date-bucket drill-through impossible through the only real adapter:
+    // a widget grouped ONLY by a date dimension gets no `dimensionFields` (the
+    // server excludes date dims from the equality drill), so `drillRanges` is
+    // the ONLY thing that can make `canDrill` true — with the key hand-picked
+    // away, the whole drill entry point disappeared, and a mixed grouping
+    // drilled to a superset (every bucket, not the clicked one).
+    const drillRanges = Array.isArray((data as any)?.drillRanges) ? (data as any).drillRanges : undefined;
     const totals = Array.isArray((data as any)?.totals) ? (data as any).totals : undefined;
-    return { rows, fields, object, dimensionFields, drillRawRows, totals };
+    return { rows, fields, object, dimensionFields, drillRawRows, drillRanges, totals };
   }
 
   /** Client-side aggregation fallback */

--- a/packages/data-objectstack/src/queryDataset.test.ts
+++ b/packages/data-objectstack/src/queryDataset.test.ts
@@ -14,6 +14,10 @@ import type {
   DatasetSelection as SpecDatasetSelection,
 } from '@objectstack/spec/contracts';
 import type { PercentScale as SpecPercentScale } from '@objectstack/spec/data';
+// The shared drill-filter builder + its range type (objectui#3813): the date
+// sidecar's only consumer, imported rather than reproduced so the assertions
+// below are about the SAME code the dashboard widget and report renderer run.
+import { buildDatasetDrillFilter, type DatasetDrillRange } from '@object-ui/core';
 import {
   ObjectStackAdapter,
   clearSharedDiscoveryCache,
@@ -317,6 +321,7 @@ describe('queryDataset result fields ARE @objectstack/spec AnalyticsResult field
     type _HasDrillObject = Assert<HasKey<DatasetEnvelope, 'object'>>;
     type _HasDimensionFields = Assert<HasKey<DatasetEnvelope, 'dimensionFields'>>;
     type _HasDrillRawRows = Assert<HasKey<DatasetEnvelope, 'drillRawRows'>>;
+    type _HasDrillRanges = Assert<HasKey<DatasetEnvelope, 'drillRanges'>>;
 
     expect(true).toBe(true);
   });
@@ -345,5 +350,194 @@ describe('queryDataset result fields ARE @objectstack/spec AnalyticsResult field
     expect(winRate.percentScale).toBe('fraction');
     const region = result.fields.find((f) => f.name === 'region')!;
     expect(region.percentScale).toBeUndefined();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* objectui#3813 — the date-range drill sidecar reaches the caller.            */
+/*                                                                             */
+/* Third instance of the same family as #3613/#3752, this time on the RUNTIME   */
+/* face: `queryDataset` rebuilds its result by hand-picking keys off the        */
+/* payload, and `drillRanges` was never in the list — so the server's #1752     */
+/* date-bucket drill scope was silently dropped by the only real adapter, and   */
+/* a date-only dashboard/report lost its entire drill entry point (`canDrill`   */
+/* can only be true via these ranges when no equality drill dim exists).        */
+/*                                                                             */
+/* The envelopes below are the SHAPES THE SERVER ACTUALLY SENDS, not idealised  */
+/* ones — that distinction is why the existing consumer tests could not see the */
+/* bug (they mock a data source and feed `drillRanges` in directly):            */
+/*   - `POST /analytics/dataset/query` answers `res.json(result)` — a BARE      */
+/*     result, no `{ success, data }` wrapper (objectstack `rest-server.ts`);    */
+/*   - it carries `sql`, which this adapter deliberately does not return;       */
+/*   - for a DATE-ONLY grouping the server sets `object` + `drillRanges` and    */
+/*     NOTHING else drill-related: `service-analytics` excludes date dims from  */
+/*     `drillDims`, so `dimensionFields` / `drillRawRows` are absent entirely.  */
+/* -------------------------------------------------------------------------- */
+
+/** Sales bucketed by month only — no non-date dimension, so no equality drill. */
+const monthlyDataset = {
+  name: 'sales_by_month', label: 'Sales by month', object: 'opportunity',
+  dimensions: [{ name: 'closed_month', field: 'close_date', type: 'date', dateGranularity: 'month' }],
+  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+};
+const monthlySelection = { dimensions: ['closed_month'], measures: ['revenue'] };
+
+/**
+ * `DatasetWidget`'s drill predicate, reproduced from the widget rather than
+ * restated: `drillDims` is `dimensions.filter((d) => d in dimensionFields)` and
+ * `canDrill = !!drillObject && (drillDims.length > 0 || !!drillRanges?.length)`
+ * (`packages/plugin-dashboard/src/DatasetWidget.tsx:590-593`; the report
+ * renderer's per-row `hasRange` gate at `DatasetReportRenderer.tsx:431` and its
+ * pivot twin at `:855` are the same fact per row). Fed straight from the
+ * adapter's return so the assertion is about what the ADAPTER produced.
+ */
+function consumerDrillView(
+  result: Awaited<ReturnType<ObjectStackAdapter['queryDataset']>>,
+  dimensions: string[],
+) {
+  const drillDims = result.dimensionFields ? dimensions.filter((d) => d in result.dimensionFields!) : [];
+  return {
+    drillDims,
+    canDrill: !!result.object && (drillDims.length > 0 || !!result.drillRanges?.length),
+  };
+}
+
+describe('queryDataset passes the server drillRanges sidecar through (#1752)', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('keeps drillRanges verbatim for a DATE-ONLY grouping, so canDrill is true', async () => {
+    const { fetchImpl } = makeFetch({
+      ok: true,
+      // The real envelope: bare (no success/data wrapper), with `sql`, with
+      // `object` re-set by the range block, and WITHOUT dimensionFields /
+      // drillRawRows — the server emits none of those for a date-only grouping.
+      body: {
+        rows: [
+          { closed_month: '2026-05', revenue: 100 },
+          { closed_month: '2026-06', revenue: 250 },
+        ],
+        fields: [
+          { name: 'closed_month', type: 'date', label: 'Closed month' },
+          { name: 'revenue', type: 'number', label: 'Revenue', format: '$0,0' },
+        ],
+        sql: 'SELECT date_trunc(...) AS closed_month, SUM(amount) AS revenue FROM opportunity GROUP BY 1',
+        object: 'opportunity',
+        drillRanges: [
+          { closed_month: { field: 'close_date', gte: '2026-05-01', lt: '2026-06-01' } },
+          { closed_month: { field: 'close_date', gte: '2026-06-01', lt: '2026-07-01' } },
+        ],
+      },
+    });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+    const result = await adapter.queryDataset(monthlyDataset as any, monthlySelection);
+
+    // (1) The key arrives at the caller, untouched and row-aligned. Read through
+    // the DECLARED type, not `as any` — before the fix this line did not compile.
+    expect(result.drillRanges).toEqual([
+      { closed_month: { field: 'close_date', gte: '2026-05-01', lt: '2026-06-01' } },
+      { closed_month: { field: 'close_date', gte: '2026-06-01', lt: '2026-07-01' } },
+    ]);
+    expect(result.drillRanges).toHaveLength(result.rows.length);
+
+    // (2) The mock really is the server's date-only shape, not a convenient one:
+    // if these ever become defined, the fixture stopped exercising the case
+    // where `drillRanges` is the ONLY thing that can make a widget drillable.
+    expect(result.dimensionFields).toBeUndefined();
+    expect(result.drillRawRows).toBeUndefined();
+
+    // (3) The issue's acceptance anchor, evaluated with the consumers' own
+    // predicate: a date-only chart is drillable again.
+    const { drillDims, canDrill } = consumerDrillView(result, monthlySelection.dimensions);
+    expect(drillDims).toEqual([]);
+    expect(canDrill).toBe(true);
+
+    // (4) …and the drilled filter really scopes to the CLICKED bucket, built by
+    // the shared `buildDatasetDrillFilter` the widget and the report both call.
+    expect(buildDatasetDrillFilter(result.drillRawRows?.[1], drillDims, result.dimensionFields ?? {}, undefined, result.drillRanges?.[1]))
+      .toEqual({ close_date: { $gte: '2026-06-01', $lt: '2026-07-01' } });
+  });
+
+  it('keeps BOTH sidecars for a mixed date + non-date grouping (no superset drill)', async () => {
+    const { fetchImpl } = makeFetch({
+      ok: true,
+      body: {
+        rows: [{ region: 'North America', closed_month: '2026-06', revenue: 250 }],
+        fields: [
+          { name: 'region', type: 'string', label: 'Region' },
+          { name: 'closed_month', type: 'date', label: 'Closed month' },
+          { name: 'revenue', type: 'number', label: 'Revenue' },
+        ],
+        object: 'opportunity',
+        // Equality sidecars cover the non-date dim only (and carry the RAW value
+        // `NA`, not the row's resolved label "North America"); the date dim gets
+        // a range instead.
+        dimensionFields: { region: 'account.region' },
+        drillRawRows: [{ region: 'NA' }],
+        drillRanges: [{ closed_month: { field: 'close_date', gte: '2026-06-01', lt: '2026-07-01' } }],
+      },
+    });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+    const result = await adapter.queryDataset(monthlyDataset as any, { dimensions: ['region', 'closed_month'], measures: ['revenue'] });
+
+    const { drillDims, canDrill } = consumerDrillView(result, ['region', 'closed_month']);
+    expect(canDrill).toBe(true);
+    expect(drillDims).toEqual(['region']);
+
+    // Both halves in one filter. Without the range the drill was a SUPERSET —
+    // clicking June's bar opened every month for that region.
+    expect(buildDatasetDrillFilter(result.drillRawRows?.[0], drillDims, result.dimensionFields ?? {}, { stage: 'won' }, result.drillRanges?.[0]))
+      .toEqual({
+        stage: 'won',
+        'account.region': 'NA',
+        close_date: { $gte: '2026-06-01', $lt: '2026-07-01' },
+      });
+  });
+
+  it('leaves drillRanges undefined when the server sends none (non-date grouping)', async () => {
+    const { fetchImpl } = makeFetch({
+      ok: true,
+      body: {
+        rows: [{ region: 'NA', revenue: 100 }],
+        fields: [{ name: 'revenue', type: 'number' }],
+        object: 'opportunity',
+        dimensionFields: { region: 'account.region' },
+        drillRawRows: [{ region: 'NA' }],
+      },
+    });
+    const adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000', autoReconnect: false, fetch: fetchImpl as any });
+
+    const result = await adapter.queryDataset(inlineDataset as any, selection);
+
+    // Absent stays absent — the passthrough must not invent an empty array,
+    // which would flip `canDrill`'s `!!drillRanges?.length` reasoning nowhere
+    // but would make the two sidecars' index alignment meaningless.
+    expect(result.drillRanges).toBeUndefined();
+    expect(consumerDrillView(result, ['region']).canDrill).toBe(true);
+  });
+
+  it('is pinned at compile time as the SHARED DatasetDrillRange, not a restatement', () => {
+    type DrillRanges = NonNullable<DatasetEnvelope['drillRanges']>;
+    type RangeEntry = DrillRanges[number][string];
+
+    // THE pin. `@object-ui/core`'s `DatasetDrillRange` is the single in-repo
+    // declaration of this shape — it is what `buildDatasetDrillFilter` accepts
+    // and what `DatasetWidget` / `DatasetReportRenderer` type their state with.
+    // Nothing in `@objectstack/spec` owns it yet (the producer's own
+    // `AnalyticsResultWithDrill` is local to `service-analytics`), so identity
+    // with the shared interface is the strongest available contract pin: a local
+    // `{ field: string; gte: string; lt: string }` copy — the shape a reader is
+    // most tempted to write here — fails this line, per #3613's lesson that a
+    // restatement stays assignable while it drifts.
+    type _IsTheSharedType = Assert<Equal<RangeEntry, DatasetDrillRange>>;
+    type _SharedTypeNotAny = Assert<Equal<IsAny<DatasetDrillRange>, false>>;
+
+    // Row-aligned array of dimension NAME → range, mirroring `drillRawRows`.
+    type _IsRowAlignedArray = Assert<Equal<DrillRanges, Array<Record<string, DatasetDrillRange>>>>;
+    // Optional, because the server omits it whenever no date dim was bucketed.
+    type _IsOptional = Assert<Equal<DatasetEnvelope['drillRanges'], DrillRanges | undefined>>;
+
+    expect(true).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #3813

## 问题

`queryDataset` 的返回是**逐项挑键**重建的,`drillRanges` 从来不在那份名单里 —— 于是服务端 framework#1752 的日期区间钻取旁路,被本仓**唯一**的真实 adapter 静默丢掉,而消费端五处已经在读它。

影响不是"钻取变弱",而是"钻取整块消失":`dateGranularity` 维度把一个**时间跨度**归成一个桶,等值过滤表达不了,所以 `service-analytics` 故意把日期维度排除在 `dimensionFields` / `drillRawRows` 之外,改为每行发一条半开区间 `[gte, lt)`。因此对**只按时间分组**的图表/报表,`drillRanges` 是唯一能让

```
canDrill = !!drillObject && (drillDims.length > 0 || !!drillRanges?.length)
```

为真的东西 —— 键被挑掉,整个钻取入口就没了。日期 + 非日期混合分组时钻取还在,但过滤条件缺时间边界,点 6 月的柱子打开的是该地区**全时段**(超集)。

两侧测试都看不见:dashboard/report 的用例 mock 自己的 data source 直接喂 `drillRanges`,adapter 自己的用例从没断言过这个键。

## 跨仓证据链

**objectui**(基线 `origin/main` @ `d83f6b3de`,即 PR #3817 落地后的现状):

- `packages/data-objectstack/src/index.ts:3355`(改前)`return { rows, fields, object, dimensionFields, drillRawRows, totals };` —— 挑键处,无 `drillRanges`。
- `packages/data-objectstack/src/index.ts:3257` 是本仓唯一的 `queryDataset` 实装(`apps/console/src/dataSource.ts:14` 就是原样 re-export,中间没有二次挑键的包装层)。
- 消费端五处:`packages/plugin-dashboard/src/DatasetWidget.tsx:471`(读取)、`:593`(`canDrill`)、`packages/plugin-report/src/DatasetReportRenderer.tsx:316`(读取)、`:431`(行钻 `hasRange`)、`:855`(透视单元格钻 `hasRange`)。
- 共享消费函数:`packages/core/src/utils/dataset-format.ts:165` 的 `DatasetDrillRange` 与 `buildDatasetDrillFilter`(把区间落成 ObjectQL `{ $gte, $lt }`)。

**objectstack**(只读实证,@ `b4872a868`):

- `packages/services/service-analytics/src/analytics-service.ts:741` 起:等值钻取块的 `drillDims` 只收 `!!d.field && d.type !== 'date'` 的维度 —— 日期维度被排除,所以**只按日期分组时 `dimensionFields`/`drillRawRows` 根本不产出**。
- 同文件 `:807` 起:`rangeDims` 非空时 `result.drillRanges = result.rows.map(...)`,并**重新设上 `object`**(注释写明:只按时间分组的报表也需要 base object 才能打开列表)。
- `packages/rest/src/rest-server.ts:6284`:`res.json(result)` —— **裸下发**,不裁剪、也没有 `{ success, data }` 包装。

## 改动

`packages/data-objectstack/src/index.ts`,两处:

1. 运行时:`const drillRanges = Array.isArray((data as any)?.drillRanges) ? (data as any).drillRanges : undefined;`,并加入返回字面量。与 `drillRawRows` 同一档校验强度 —— 只校验数组性,不发明空数组(缺失保持 `undefined`)。
2. 返回类型:新增 `drillRanges?: Array< Record< string, DatasetDrillRange > >`,条目类型是 `@object-ui/core` 的 `DatasetDrillRange`,**引用而非重述**。

**为什么引用而不是在 adapter 里写 `{ field, gte, lt }`**(#3613/#3752 的同一条纪律):`DatasetDrillRange` 是本仓这个形状的**唯一**声明 —— 它既是 `buildDatasetDrillFilter` 接受的类型,也是 DatasetWidget / DatasetReportRenderer 给 state 标的类型;`@objectstack/spec` 目前**不拥有**这个形状(产出侧的 `AnalyticsResultWithDrill` 是 `service-analytics` 的**局部**类型,未导出),所以共享的仓内接口就是当下唯一可用的契约,在 adapter 里重述一遍等于造它的第三种方言。边界值声明为 `unknown` 也是诚实的:这里和 `drillRawRows` 一样只校验了数组性,没校验条目内部。

**没有**改成整体透传信封(spread):#3752 已经把"这个信封不是 `AnalyticsResult`、且刻意不返回 `sql`"钉成了 pin,整体透传会把 `sql` 一起带出并让那条 pin 变红 —— 契约边界是故意的,不是遗漏。

## 测试(`packages/data-objectstack/src/queryDataset.test.ts`,+4)

三条运行时用例都 mock **服务端真实回包形状**,而不是理想形状(这正是两侧测试此前失明的原因):裸信封(无 `success`/`data` 包装)、带 `sql`、且**只按日期分组时只有 `object` + `drillRanges`,没有 `dimensionFields`/`drillRawRows`**。

1. **只按日期维度分组**:`drillRanges` 原样、按行对齐地到达调用方(通过**声明的类型**读,不用 `as any`);顺带断言 `dimensionFields`/`drillRawRows` 确为 `undefined`(fixture 一旦被"补全"成理想形状,这条用例就不再覆盖"`drillRanges` 是唯一钻取依据"的场景了);再用消费端自己的判据算出 `drillDims === []` 且 `canDrill === true`(issue 的验收锚);最后用**共享的** `buildDatasetDrillFilter` 断出 `{ close_date: { $gte: '2026-06-01', $lt: '2026-07-01' } }` —— 落到点中的那个桶。
2. **日期 + 非日期混合分组**:两条旁路都到达,合成的过滤器同时含等值维(用 RAW 值 `NA`,不是行里的显示标签 "North America")与时间边界 —— 这正是"超集"那一半影响的反面。
3. **服务端没发**(纯非日期分组):`drillRanges` 保持 `undefined`,不发明空数组。
4. **编译期 pin**:`Equal` 钉住条目类型与 `DatasetDrillRange` 结构同一(本地 `{ field: string; gte: string; lt: string }` 复制品会让这行红)、钉住"按行对齐的数组"与"可选";并在 #3752 那条"信封不是 AnalyticsResult"的 pin 里补了 `HasKey ... 'drillRanges'`。

命令与输出(仓根 `flock` + `--max-old-space-size=4096` + `--maxWorkers=2`):

```
pnpm exec vitest run --maxWorkers=2 packages/data-objectstack/src/queryDataset.test.ts
  Test Files  1 passed (1)
       Tests  19 passed (19)

pnpm --workspace-concurrency=2 --filter @object-ui/data-objectstack type-check
  > tsc --noEmit        (无输出 = 通过)

pnpm --workspace-concurrency=2 --filter @object-ui/data-objectstack lint
  ✖ 343 problems (0 errors, 343 warnings)      # 全是既有的 no-explicit-any warning

node scripts/check-control-bytes.mjs
  ✅  check-control-bytes: OK (scanned 3740 tracked text file(s); skipped 85 binary).
```

**消费半径定向跑**(规则/数据形状的消费者在别的包里,预期零改动零变化 —— 它们 mock 自己的 data source,本改动只是给 adapter 返回多一个可选键):

```
pnpm exec vitest run --maxWorkers=2 packages/data-objectstack/ \
  packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx \
  packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
  Test Files  26 passed (26)
       Tests  451 passed (451)
```

## 反向验证(方向先判后跑)

**判**:①删掉运行时透传 → 只按日期那条与混合那条**红**,而"服务端没发"那条**保持绿**(它断言的是 `undefined`,是"不许发明空数组"的守卫,**不是**修复检测器 —— 按 fixture 三分法,这条通过是因为"本来就什么都没产出",必须说清而不是记作反向证据);②只删类型声明 → **type-check 红**、vitest 仍绿(vitest 不做类型检查)。

**跑**,① 删 `return {...}` 里的 `drillRanges`:

```
 × keeps drillRanges verbatim for a DATE-ONLY grouping, so canDrill is true
   AssertionError: expected undefined to deeply equal [ { closed_month: { …(3) } }, …(1) ]
 × keeps BOTH sidecars for a mixed date + non-date grouping (no superset drill)
   AssertionError: expected { Object (stage, account.region) } to deeply equal { stage: 'won', …(2) }
   -   "close_date": {
 Test Files  1 failed (1)
      Tests  2 failed | 17 passed (19)
```

"服务端没发"那条如判定所述保持绿。

**跑**,② 只删返回类型里那一段声明(运行时透传留着):

```
src/index.ts(3364,67): error TS2353: Object literal may only specify known properties,
  and 'drillRanges' does not exist in type '{ rows: ... }'
src/queryDataset.test.ts(324,35): error TS2344: Type 'false' does not satisfy the constraint 'true'
  # ↑ 就是 HasKey 那条 pin
src/queryDataset.test.ts(401,68) / (437,19) / (441,19) / (457,121) / (490,128) / (516,19)
  / (521,52) / (539,53): error TS2339: Property 'drillRanges' does not exist on type ...
```

两个方向都与判定一致;两次破坏后均已还原,提交内容只含上述三个文件。

## `drillRawTotals`:按「声明即使用」不补,另立观察项 #3822

服务端同样产出 `drillRawTotals`(`analytics-service.ts:756` 起,framework#3214 小计行钻取),adapter 也同样把它挑掉了。**本 PR 故意不补**:

- 本仓消费者数为 **0**(`grep -rn drillRawTotals packages apps` objectui 侧零命中;`buildDatasetDrillFilter` 只被喂 `drillRawRows`)。
- 所以透传它修复不了任何用户可见行为,只是给返回类型加一个没有任何面在读的键 —— 一个「声明了但没人使用」的面(ADR-0049 enforce-or-remove 要避免的那类债);能为它写的测试也只能自证透传本身。
- 与 `drillRanges` 的**关键不对称**:后者缺失让日期分组图表 `canDrill` 恒为 false(功能整块消失、五处在读、有等价判据可断言);前者缺失时,小计行钻取在本仓根本还没有实现面。
- 正确时机:落小计行钻取消费端时同一改动里透传 + 声明 + 一条"点小计行按该分组维度过滤、点总计行不过滤"的测试。已按观察项(`finding`,不带 `pm:queue`)记在 #3822,不会随本 issue 关闭而丢。

## changeset

`.changeset/dataset-drill-ranges-passthrough-3813.md` —— `@object-ui/data-objectstack: patch`,同 #3817 档位先例(运行时修复且用户可见:恢复日期分桶钻取入口、修掉混合分组的超集过滤)。未标 `major`(AGENTS.md 版本策略)。未触 `content/docs/releases/**`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_