### PR TITLE
fix(components): 动作面成员动作的 visible 门按「已声明」判定,visible: false 不再渲染 (#3812)

### DIFF
--- a/.changeset/action-member-declared-visible-gate-3812.md
+++ b/.changeset/action-member-declared-visible-gate-3812.md
@@ -1,0 +1,37 @@
+---
+"@object-ui/components": patch
+---
+
+Action-face member actions declaring `visible: false` are now hidden instead of rendered
+
+The three member-action gates on the action face asked truthiness —
+`if (action.visible && !isVisible) return null` — so `visible: false`, the most
+explicit way an author can say "never show this", fell into the "no gate
+declared" branch and the action rendered anyway:
+
+- `action:group` in `display: 'inline'` mode (`InlineActionButton`);
+- `action:group` in `display: 'dropdown'` mode (`DropdownActionItem`);
+- `action:menu`'s items (`ActionMenuItem`).
+
+These leaves `.map()` the component's own `actions` array, so neither
+`SchemaRenderer`'s node-level `visible` handling nor
+`ActionEngine.getActionsForLocation` (whose boolean `visible` was always
+correct) is in the path — the truthy gate was the only gate.
+
+All three now read one named definition, `hasDeclaredVisibilityGate`
+(`!= null && !== ''`), and let the declaration itself decide. This is not a new
+decision: objectui#3492 established the invariant for the selection bar, whose
+`hasVisibilityGate` spells out why truthiness cannot answer the question, and
+objectui#3758 applied it to both row-action surfaces. The evaluation entry is
+untouched and already short-circuits a boolean rather than handing it to the CEL
+engine, which `actionPredicate.parity` pins for both the engine and the renderer
+path.
+
+Behaviour change surface, deliberately narrow: only a member action whose
+`visible` is the literal boolean `false` (or another falsy non-empty value)
+changes — from rendered to hidden, which is what the declaration asked for.
+`visible: true` still renders, `''` and an absent `visible` are still no gate at
+all, and no expression-valued `visible` changes verdict.
+`ActionSchema.visible` is `ExpressionInputSchema` with no boolean member, so
+`objectstack build` cannot emit this shape; hand-written view JSON and
+in-process callers constructing action defs can.

--- a/packages/components/src/renderers/action/__tests__/action-member-visible-gate.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-member-visible-gate.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3812 — a MEMBER action's declared boolean `visible` is a verdict,
+ * not a missing gate.
+ *
+ * The three member-action gates on the action face (`action:group`'s inline
+ * button and dropdown item, `action:menu`'s item) asked truthiness:
+ * `if (action.visible && !isVisible) return null`. So `visible: false` — the
+ * most explicit way an author can say "never show this" — answered "no gate
+ * declared" and the action rendered anyway. Declaration is now detected by
+ * `hasDeclaredVisibilityGate` (`!= null && !== ''`), the invariant
+ * objectui#3492 established for the selection bar (`hasVisibilityGate`) and
+ * objectui#3758 / PR #3816 applied to the row-action surfaces.
+ *
+ * The evaluation entry was never the problem and is not touched:
+ * `useCondition(toPredicateInput(false))` already answers `false`, pinned in
+ * `packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx:134`
+ * ("literal false" → both the engine and the renderer path say hidden). Only
+ * the gate in front of it refused to ask.
+ *
+ * Each site asserts all THREE shapes — declared-false hides, declared-true
+ * renders, undeclared renders — plus `''`. The symmetry is the point: a
+ * "hide the member unconditionally" rewrite satisfies every `visible: false`
+ * assertion on its own and would leave the suite green.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { DropdownActionItem } from '../action-group';
+import { ActionMenuItem } from '../action-menu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '../../../ui';
+
+/** An ungated companion — see `renderInlineGroup`. */
+const COMPANION = { name: 'view', label: 'View', type: 'script' };
+
+/**
+ * Site 1 — `InlineActionButton`, through the real `action:group` host so the
+ * member gate is observed where it actually runs (the group `.map()`s its own
+ * `actions` array; neither `SchemaRenderer` nor `ActionEngine` is in this path).
+ *
+ * `COMPANION` rides along so a passing "not rendered" assertion cannot be
+ * confused with "the whole group disappeared".
+ */
+function renderInlineGroup(actions: any[], scope: Record<string, any> = {}) {
+  const Group = ComponentRegistry.get('action:group');
+  if (!Group) throw new Error('action:group is not registered');
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Group schema={{ type: 'action:group', display: 'inline', actions: [...actions, COMPANION] }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+/**
+ * Sites 2 and 3 — the two dropdown leaves, each rendered inside a
+ * controlled-open menu so the portal content mounts deterministically (Radix
+ * opens on pointerdown, flaky to synthesize in happy-dom). Same harness as
+ * `action-group-dropdown-visible.test.tsx`, which pinned this leaf's predicate
+ * handling for #1885.
+ */
+function renderInMenu(node: React.ReactNode, scope: Record<string, any> = {}) {
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <DropdownMenu open modal={false}>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>{node}</DropdownMenuContent>
+      </DropdownMenu>
+    </PredicateScopeProvider>,
+  );
+}
+
+const renderDropdownItem = (action: any, scope: Record<string, any> = {}) =>
+  renderInMenu(<DropdownActionItem action={action} index={0} onSelect={() => {}} />, scope);
+
+const renderMenuItem = (action: any, scope: Record<string, any> = {}) =>
+  renderInMenu(<ActionMenuItem action={action} onExecute={async () => {}} />, scope);
+
+describe('action:group inline member — declared boolean `visible` (objectui#3812)', () => {
+  it('visible:false → the inline button does not render', () => {
+    renderInlineGroup([{ name: 'ghost', label: 'Ghost', type: 'script', visible: false }]);
+    expect(screen.getByText('View')).toBeInTheDocument();
+    expect(screen.queryByText('Ghost')).not.toBeInTheDocument();
+  });
+
+  it('visible:true → the inline button renders', () => {
+    renderInlineGroup([{ name: 'always', label: 'Always', type: 'script', visible: true }]);
+    expect(screen.getByText('Always')).toBeInTheDocument();
+  });
+
+  it('no `visible` at all → the inline button renders (ungated stays ungated)', () => {
+    renderInlineGroup([{ name: 'plain', label: 'Plain', type: 'script' }]);
+    expect(screen.getByText('Plain')).toBeInTheDocument();
+  });
+
+  it("an empty-string `visible` is not a declared gate — the button still renders", () => {
+    renderInlineGroup([{ name: 'empty', label: 'Empty', type: 'script', visible: '' }]);
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+  });
+
+  it('an expression-valued `visible` keeps its verdict — false hides, true shows', () => {
+    const { unmount } = renderInlineGroup(
+      [{ name: 'expr', label: 'Expr', type: 'script', visible: 'features.canRun == true' }],
+      { features: { canRun: false } },
+    );
+    expect(screen.queryByText('Expr')).not.toBeInTheDocument();
+    unmount();
+    renderInlineGroup(
+      [{ name: 'expr', label: 'Expr', type: 'script', visible: 'features.canRun == true' }],
+      { features: { canRun: true } },
+    );
+    expect(screen.getByText('Expr')).toBeInTheDocument();
+  });
+});
+
+describe('action:group dropdown member — declared boolean `visible` (objectui#3812)', () => {
+  it('visible:false → the dropdown item does not render', () => {
+    renderDropdownItem({ name: 'ghost', label: 'Ghost', visible: false });
+    expect(screen.queryByText('Ghost')).toBeNull();
+  });
+
+  it('visible:true → the dropdown item renders', () => {
+    renderDropdownItem({ name: 'always', label: 'Always', visible: true });
+    expect(screen.getByText('Always')).toBeInTheDocument();
+  });
+
+  it('no `visible` at all → the dropdown item renders (ungated stays ungated)', () => {
+    renderDropdownItem({ name: 'plain', label: 'Plain' });
+    expect(screen.getByText('Plain')).toBeInTheDocument();
+  });
+
+  it("an empty-string `visible` is not a declared gate — the item still renders", () => {
+    renderDropdownItem({ name: 'empty', label: 'Empty', visible: '' });
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+  });
+});
+
+describe('action:menu member — declared boolean `visible` (objectui#3812)', () => {
+  it('visible:false → the menu item does not render', () => {
+    renderMenuItem({ name: 'ghost', label: 'Ghost', visible: false });
+    expect(screen.queryByText('Ghost')).toBeNull();
+  });
+
+  it('visible:true → the menu item renders', () => {
+    renderMenuItem({ name: 'always', label: 'Always', visible: true });
+    expect(screen.getByText('Always')).toBeInTheDocument();
+  });
+
+  it('no `visible` at all → the menu item renders (ungated stays ungated)', () => {
+    renderMenuItem({ name: 'plain', label: 'Plain' });
+    expect(screen.getByText('Plain')).toBeInTheDocument();
+  });
+
+  it("an empty-string `visible` is not a declared gate — the item still renders", () => {
+    renderMenuItem({ name: 'empty', label: 'Empty', visible: '' });
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+  });
+
+  it('an expression-valued `visible` keeps its verdict — false hides, true shows', () => {
+    const { unmount } = renderMenuItem(
+      { name: 'expr', label: 'Expr', visible: 'features.canRun == true' },
+      { features: { canRun: false } },
+    );
+    expect(screen.queryByText('Expr')).toBeNull();
+    unmount();
+    renderMenuItem(
+      { name: 'expr', label: 'Expr', visible: 'features.canRun == true' },
+      { features: { canRun: true } },
+    );
+    expect(screen.getByText('Expr')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -33,6 +33,7 @@ import {
 import { cn } from '../../lib/utils';
 import { Loader2, ChevronDown } from 'lucide-react';
 import { resolveIcon } from './resolve-icon';
+import { hasDeclaredVisibilityGate } from './visibility-gate';
 
 export interface ActionGroupSchema {
   type: 'action:group';
@@ -91,7 +92,9 @@ const InlineActionButton: React.FC<{
     }
   }, [action, onExecute, loading]);
 
-  if (action.visible && !isVisible) return null;
+  // A DECLARED gate decides; truthiness would read `visible: false` as ungated
+  // and render it (objectui#3812) — see `hasDeclaredVisibilityGate`.
+  if (hasDeclaredVisibilityGate(action.visible) && !isVisible) return null;
 
   return (
     <Button
@@ -138,7 +141,9 @@ export const DropdownActionItem: React.FC<{
   // InlineActionButton above — #1885 follow-through).
   const isDisabledPred = useCondition(toPredicateInput((action as any).disabled));
   const isEnabled = useCondition(toPredicateInput(action.enabled));
-  if (action.visible && !isVisible) return null;
+  // Same declared-gate rule as `InlineActionButton` above — one action cannot be
+  // hidden in one display mode and shown in the other (objectui#3812).
+  if (hasDeclaredVisibilityGate(action.visible) && !isVisible) return null;
   const Icon = resolveIcon(action.icon);
   const isDisabled = (action as any).disabled != null
     ? isDisabledPred

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -30,6 +30,7 @@ import {
 import { cn } from '../../lib/utils';
 import { Loader2, MoreHorizontal } from 'lucide-react';
 import { resolveIcon } from './resolve-icon';
+import { hasDeclaredVisibilityGate } from './visibility-gate';
 
 function useMoreActionsLabel(): string {
   // useObjectTranslation is provider-safe (never throws); no try/catch, which
@@ -59,7 +60,12 @@ export interface ActionMenuSchema {
   [key: string]: any;
 }
 
-const ActionMenuItem: React.FC<{
+/**
+ * One action inside an `action:menu`. Exported for its pin tests only (it is
+ * not re-exported from the package index) — mirrors `DropdownActionItem` in
+ * `action-group.tsx`, whose gate is the same one.
+ */
+export const ActionMenuItem: React.FC<{
   action: ActionSchema;
   onExecute: (action: ActionSchema) => Promise<void>;
 }> = ({ action, onExecute }) => {
@@ -81,7 +87,11 @@ const ActionMenuItem: React.FC<{
     return Icon ? <Icon className="mr-2 h-4 w-4" /> : null;
   }, [action.icon]);
 
-  if (action.visible && !isVisible) return null;
+  // A DECLARED gate decides; truthiness would read `visible: false` as ungated
+  // and render it (objectui#3812) — the same gate `action:group`'s two member
+  // leaves read. `false` short-circuits at the evaluation entry, so the
+  // `throwOnError` posture above still only applies to real predicates.
+  if (hasDeclaredVisibilityGate(action.visible) && !isVisible) return null;
 
   return (
     <DropdownMenuItem

--- a/packages/components/src/renderers/action/visibility-gate.ts
+++ b/packages/components/src/renderers/action/visibility-gate.ts
@@ -1,0 +1,45 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Did this action DECLARE a visibility gate at all? The one definition read by
+ * every member-action leaf on the action face — `action:group`'s inline button
+ * and dropdown item, and `action:menu`'s item — so the three cannot drift into
+ * three answers for one key (the shape objectui#3142 already had to unpick for
+ * `locations` in these same files).
+ *
+ * Truthiness cannot answer this question, and asking it is the objectui#3812
+ * defect: `if (action.visible && !isVisible)` classified `visible: false` — the
+ * most explicit way an author can say "never show this" — as *ungated*, so the
+ * gate never consulted the verdict and the action rendered for everyone.
+ *
+ * `!= null && !== ''` is not a new decision. objectui#3492 established it for
+ * the selection bar, where `plugin-grid`'s `hasVisibilityGate` spells out the
+ * same reasoning verbatim ("Truthiness cannot answer this: `visible: false` is
+ * a declared gate that excludes everything"); objectui#3758 / PR #3816 applied
+ * it to both row-action surfaces (`isCustomRowActionVisible` in
+ * `plugin-grid/src/components/RowActionMenu.tsx` and
+ * `renderers/complex/data-table.tsx`).
+ *
+ * This function decides only whether a gate EXISTS. The verdict is the
+ * declaration's own business and is left to the evaluation entry, which already
+ * short-circuits a boolean instead of handing it to the CEL engine:
+ * `useCondition(toPredicateInput(false))` is `false` and
+ * `useCondition(toPredicateInput(true))` is `true`, pinned for both the engine
+ * and the renderer path in
+ * `packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx`. Nothing
+ * about that entry changes here — only the gate in front of it, which refused
+ * to ask.
+ *
+ * `''` is grouped with `null`/`undefined` deliberately: an empty predicate is
+ * nothing to evaluate, so it must not hide the action from everyone either.
+ * `toPredicateInput` maps it to `undefined` (visible) for the same reason.
+ */
+export function hasDeclaredVisibilityGate(visible: unknown): boolean {
+  return visible != null && visible !== '';
+}


### PR DESCRIPTION
Fixes #3812

## 缺陷

动作面成员动作的可见性**门**用真值判断,于是 `visible: false` —— 作者能写出的最明确的
「永不显示」—— 落进「未声明门」分支,动作照样渲染:

```
if (action.visible && !isVisible) return null;   // false && … 为假 → 不 return null → 渲染
```

这三处是**成员动作**门:组件从自持的 `actions` 数组直接 `.map()` 渲染,既不经
`SchemaRenderer`(那是按节点走的),也不经 `ActionEngine.getActionsForLocation`
(`ActionEngine` 的布尔 `visible` 一直是对的,`packages/core/src/actions/__tests__/ActionEngine.visibility.test.ts:60`)。
所以真值门是这条路径上唯一的门。

求值入口从来没坏:`packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx:134`
已钉「literal false → 引擎路径与渲染器路径都判隐藏」。坏的只是门前不肯问。

## 三处门位前后对照(锚 `origin/main@d83f6b3de`)

| 门位(锚) | 修前 | 修后(本 PR 行号) |
| --- | --- | --- |
| `action-group.tsx:94` — `InlineActionButton`(inline 模式成员) | `if (action.visible && !isVisible) return null;` | `if (hasDeclaredVisibilityGate(action.visible) && !isVisible) return null;` (`:97`) |
| `action-group.tsx:141` — `DropdownActionItem`(dropdown 模式成员) | 同形 | 同上(`:146`) |
| `action-menu.tsx:84` — `ActionMenuItem`(`action:menu` 菜单项) | 同形 | 同上(`:94`) |

三处共读**一处**命名定义 `packages/components/src/renderers/action/visibility-gate.ts`
的 `hasDeclaredVisibilityGate`(`!= null && !== ''`):同一个键在两个文件里长出三种答案
正是 #3142 刚在这两个文件里为 `locations` 收过的形状。verdict 仍交回声明本身 ——
布尔在求值入口(`ExpressionEvaluator.evaluateCondition`)短路成自己的 verdict,不交给
CEL 引擎;`''` 与 `toPredicateInput` 的处理一致地不算门。

`action-menu` 的 `ActionMenuItem` 由 `const` 改为 `export const`(仅为钉子可测,未进包
public index),与同族 `action-group.tsx` 的 `DropdownActionItem` 一致。

## 这不是新决定

- objectui#3492 已把这条不变量钉死在批量选择栏:`packages/plugin-grid/src/bulkEligibility.ts`
  的 `hasVisibilityGate` 注释原文 ——
  「Truthiness cannot answer this: `visible: false` is a declared gate that excludes everything」;
- objectui#3758 / PR #3816 把行动作两处(`RowActionMenu` 与 `data-table` 的
  `isCustomRowActionVisible`)收口到同一不变量;
- 内建 `visibleWhen` 的门一直是 `!= null`。

动作面这一族是同一形状里剩下的成员部分,修法已裁。

## 组件级五处 `schema.visible` 复核结论(#3812 正文第 3 条 / 分诊要求)

**未动其中任何一处**,复核结果是两半:

- **三处确认被宿主遮住(休眠防御层)**:`action-group.tsx:230`、`action-menu.tsx:169`、
  `action-bar.tsx:223`。经 `packages/react/src/SchemaRenderer.tsx:287-289` 路由时,
  宿主按 `newSchema.visible !== undefined` 统一求值并隐藏,组件根本不渲染到自己的门
  (已有钉 `packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx:39`)。
  `action:bar` 为溢出菜单合成的 `action:menu` 节点(`action-bar.tsx:234-241`)不带
  `visible`,所以 `action-menu.tsx:169` 也不在绕过路径上。
- **两处实证可达(不是休眠)**:`action-button.tsx:148`、`action-icon.tsx:82`。
  `action:bar` 自己从注册表取子渲染器并直接挂载(`action-bar.tsx:261`),把成员动作对象
  整体展开成子渲染器的 `schema`(`schema={{ ...action, type: componentType, … }}`),
  于是作者写在成员上的 `visible` 落到子渲染器的组件级门上;`action-bar` 上游只过
  `mayInvoke` 与 `actionRendersAt`,不过 `visible`。一次性探针(未提交)实测:

  ```
  PROBE action:button visible:false → RENDERED (reachable bug)
  PROBE action:icon  visible:false → RENDERED (reachable bug)
  ```

  按分诊「要动须先实证可达、不许顺手改五处」,**不在本 PR**,另开 #3823 交 PM 判级。
- 附带记录(未动):`packages/components/src/SchemaRenderer.tsx` 是一个只看 `hidden`、
  完全不看 `visible` 的极简同名副本,既不在包 index 导出也无任何 import —— 目前是休眠
  代码,不构成绕过宿主,已写进 #3823 备查。

## 反向验证(方向先判后跑)

**预判**:新钉子里 `visible: false` 的三条在旧真值门下必**红**;`visible: true`、
未声明、`''`、表达式取值四类在旧门下**已绿且修后仍绿** —— 旧门对这些形状的 verdict
与新门一致,本次只改「是否算声明了门」。

**实跑与预判一致。** 修门之前(仅先落了测试所需的 `ActionMenuItem` 导出)跑同一文件:

```
 FAIL  … > action:group inline member … > visible:false → the inline button does not render
AssertionError: expected … to be null … Received: 一个真的渲染出来的 button 元素(文本 Ghost)
 FAIL  … > action:group dropdown member … > visible:false → the dropdown item does not render
 FAIL  … > action:menu member … > visible:false → the menu item does not render

 Test Files  1 failed (1)
      Tests  3 failed | 11 passed (14)
```

3 红恰好是三处门位各自的 `visible: false` 用例,11 绿是三类对照断言 —— 既证实了 #3812
的前提(三处都真的渲染),也证实了钉子确实钉在门上。修门之后全绿(见下)。

## 行为变化面(刻意窄)

只有 `visible` 为字面布尔 `false`(或其它非空 falsy 值)的**成员**动作变化 —— 从渲染变
隐藏,即声明所要求的。`visible: true` 照旧渲染,`''` 与未声明照旧不算门,表达式取值的
`visible` verdict 一律不变。`ActionSchema.visible` 是 `ExpressionInputSchema`(无 boolean
成员),`objectstack build` 产不出这个形状;手写视图 JSON 与进程内构造 action def 可以
(#3492 正文记录这两条路径确实发生过)。

## 测试

新增 `packages/components/src/renderers/action/__tests__/action-member-visible-gate.test.tsx`
—— 三处门位各按 #3758/#3816 的**三形状对称**钉子:`false` 隐藏 / `true` 渲染 /
未声明渲染,再加 `''` 不算门与表达式取值 verdict 不变,共 14 条。对称是关键:
「恒隐藏」的错误重写能独自满足所有 `visible: false` 断言而让测试全绿。
inline 门经真实 `action:group` 宿主观察(并带一个未声明门的同伴动作,使「未渲染」不会与
「整组消失」混淆);两个 dropdown 叶按同目录既有范式在受控展开的菜单里渲染。

```
pnpm exec vitest run packages/components/ --maxWorkers=2
 Test Files  97 passed (97)
      Tests  746 passed (746)
```

消费半径(动作面渲染器的调用方 + 不变量同族)定向跑,7 文件 83 条全绿:`packages/react` 的
`actionPredicate.parity` / `SchemaRenderer.expressions` / `useActionEngine.capabilityGate`、
`packages/app-shell` 的 `MetadataTypeActions` / `EnvironmentListToolbar`、
`packages/plugin-grid` 的 `predicate-surface-parity`、`packages/types` 的
`spec-derived-unions`。

`pnpm --filter @object-ui/components type-check`(`tsc --noEmit` + typetests)通过。

Changeset:`.changeset/action-member-declared-visible-gate-3812.md`(`@object-ui/components`
patch,与 #3816 同档)。

未触 `content/docs/releases/**`。`node scripts/check-control-bytes.mjs` 通过。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_