### PR TITLE
fix(create-plugin): 清掉脚手架的未用 lucide 声明,并让生成的 schema 接口真的可达 (#3755, #3759)

### DIFF
--- a/.changeset/create-plugin-scaffold-dead-artifacts-3755-3759.md
+++ b/.changeset/create-plugin-scaffold-dead-artifacts-3755-3759.md
@@ -1,0 +1,46 @@
+---
+"@object-ui/create-plugin": patch
+---
+
+Remove the scaffold's unused pinned icon dependency, and make its generated schema interface reachable
+
+Two declared-but-unreachable artifacts in the generated plugin, both on the blind side of
+the import gate objectui#3733 added — that gate rejects an import nothing declares, and
+never looked for a declaration nothing imports.
+
+**The generated `dependencies` no longer pin `lucide-react`** (objectui#3755). It was
+declared at `^0.563.0` and imported by no generated source file, so every freshly
+scaffolded plugin really installed lucide 0.563.x for code that never referenced it — two
+majors behind the 23 in-repo declarations, all `^1.28.0`. Worse than ordinary caret drift:
+a `0.x` caret does not cross minors, so `^0.563.0` is `>=0.563.0 <0.564.0` and could not
+float even within `0.x`. It is removed rather than re-anchored because this repo declares
+an icon library where it imports one — of the 24 manifests mentioning `lucide-react`, 23
+import it, and none pre-declares it for code not yet written. An author who wants icons
+runs `pnpm add lucide-react` and lands the current version by construction, with no anchor
+table to maintain for an unused entry. The generated `dependencies` is now exactly the four
+`workspace:*` platform packages, which cannot drift at all.
+
+**The generated `src/index.tsx` now re-exports the schema interface** from `src/types.ts`
+(objectui#3759). The generated `exports` map exposes exactly one key — `.` — so the entry
+is a consumer's only door, and nothing walked through it to `src/types.ts`: no generated
+source imported it, and the deep paths that would have reached it (`<pkg>/types`,
+`<pkg>/dist/types`) are closed by that same map. The interface in it is the plugin's schema
+contract, and it shipped dead — while the generator's own documentation page told authors to
+"export your schema types … make it importable rather than internal". A named type-only
+re-export, matching the four in-repo plugins that ship a `src/types.ts` and the worked
+example in the plugin-development guide.
+
+**That interface now extends `BaseSchema` from `@object-ui/types`** instead of re-declaring
+a subset of the base node. Unreachable, a hand-rolled `{ type; id?; className? }` was only
+dead weight; published, it would be a second dialect of a node the protocol already defines,
+silently missing everything else `BaseSchema` carries (`name`, `label`, `visible`, …). Only
+the `type` literal is narrowed locally, the same shape every in-repo plugin uses. This also
+makes the generated `@object-ui/types` dependency a used declaration.
+
+Both halves are pinned structurally rather than by string match, so the next dead artifact
+fails a test instead of shipping: no versioned runtime dependency may be declared that no
+generated source imports (`workspace:*` exempt — it cannot drift), and no generated `src/**`
+module may be unreachable from the single entry the `exports` map exposes. Each of those
+gates passes over an empty result on today's templates, so each is paired with a self-test
+that plants the removed defect back and asserts the rule names it — a gate that is green
+because it produces nothing is not a gate.

--- a/packages/create-plugin/src/__tests__/templates.test.ts
+++ b/packages/create-plugin/src/__tests__/templates.test.ts
@@ -16,6 +16,19 @@
  *   dependency of the generated package (the exact defect, generalised);
  * - the `setupFiles` path in the generated Vitest config must name a file the
  *   generator actually writes.
+ *
+ * Two more structural gates close the blind spot on the OTHER side of that
+ * import check, which only ever caught undeclared imports and never declared
+ * things nothing used (objectui#3755, objectui#3759):
+ *
+ * - no versioned runtime dependency may be declared that no generated source
+ *   imports (`workspace:*` exempt — it cannot drift);
+ * - no generated `src/**` module may be unreachable from `src/index.tsx`, the
+ *   single entry the generated `exports` map exposes.
+ *
+ * Both would pass over an empty result on today's templates, so each is paired
+ * with a self-test that plants the removed defect back and asserts the rule
+ * names it. A gate that is green because it produces nothing is not a gate.
  */
 import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
@@ -25,6 +38,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   VITEST_SETUP_FILE,
+  buildIndexFile,
   buildPackageJson,
   buildPluginFiles,
   buildTestFile,
@@ -155,6 +169,101 @@ function generatedDevDependencies(vars: PluginTemplateVars): Record<string, stri
   return (buildPackageJson(vars) as { devDependencies: Record<string, string> }).devDependencies;
 }
 
+function generatedDependencies(vars: PluginTemplateVars): Record<string, string> {
+  return (buildPackageJson(vars) as { dependencies: Record<string, string> }).dependencies;
+}
+
+/**
+ * Runtime dependencies pinned to a VERSION that no generated source imports.
+ *
+ * The reverse of the `import nothing the manifest does not declare` gate below.
+ * That one is one-way — objectui#3733 added it against undeclared imports, so
+ * `'lucide-react': '^0.563.0'` sat in the generated `dependencies` for as long
+ * as it did precisely because nothing looked in this direction (objectui#3755).
+ *
+ * `workspace:*` entries are exempt by design, not by oversight: they resolve to
+ * whatever this workspace currently builds, so an unused one costs nothing and
+ * cannot drift. A versioned range is the opposite — it is installed as written,
+ * and `^0.563.0` could not even float within `0.x` (a `0.x` caret is
+ * `>=0.563.0 <0.564.0`), so it stayed two majors behind the repo's own
+ * `^1.28.0` indefinitely.
+ *
+ * Returned rather than asserted so the rule can be exercised against a manifest
+ * that DOES violate it — see the self-test beside its use. Without that, the
+ * gate would pass by producing nothing (there are no versioned runtime ranges
+ * left) and would keep passing if it were broken.
+ */
+function unusedVersionedDependencies(
+  dependencies: Record<string, string>,
+  files: Record<string, string>
+): string[] {
+  const imported = new Set<string>();
+  for (const [relativePath, contents] of Object.entries(files)) {
+    if (!/\.tsx?$/.test(relativePath)) continue;
+    for (const pkg of importedPackagesOf(contents)) imported.add(pkg);
+  }
+  return Object.entries(dependencies)
+    .filter(([name, range]) => !range.startsWith('workspace:') && !imported.has(name))
+    .map(([name]) => name)
+    .sort();
+}
+
+/**
+ * Generated `src/**` modules NOT reachable from the entry the `exports` map names.
+ *
+ * objectui#3759's criterion, structurally. The generated manifest exposes one
+ * `exports` key (`.` → `dist/*`), so `src/index.tsx` is a consumer's only door;
+ * a module the entry does not pull in transitively is unreachable no matter what
+ * it contains. `src/types.ts` was written to disk in exactly that state — the
+ * deep paths that would have reached it (`<pkg>/types`, `<pkg>/dist/types`) are
+ * closed by the same `exports` map, so the plugin's schema contract shipped
+ * dead. The pre-existing file-map test asserted only that the path EXISTS,
+ * which is what let it stay dead.
+ *
+ * Test files are excluded from the roots on purpose: Vitest loads them
+ * directly, so entry-reachability is not required of them — and if they counted
+ * as roots, a module reachable only from a test would read as live while still
+ * being unreachable for every consumer.
+ */
+function unreachableGeneratedSources(files: Record<string, string>): string[] {
+  const isSource = (path: string) => /^src\/.*\.tsx?$/.test(path) && !/\.test\.tsx?$/.test(path);
+
+  const resolveRelative = (fromPath: string, specifier: string): string | undefined => {
+    const fromDir = fromPath.slice(0, fromPath.lastIndexOf('/'));
+    const segments = `${fromDir}/${specifier}`.split('/');
+    const stack: string[] = [];
+    for (const segment of segments) {
+      if (segment === '.' || segment === '') continue;
+      if (segment === '..') stack.pop();
+      else stack.push(segment);
+    }
+    const base = stack.join('/');
+    return [base, `${base}.tsx`, `${base}.ts`, `${base}/index.tsx`, `${base}/index.ts`].find(
+      (candidate) => files[candidate] !== undefined
+    );
+  };
+
+  const reached = new Set<string>();
+  const queue = ['src/index.tsx'];
+  while (queue.length > 0) {
+    const current = queue.pop() as string;
+    if (reached.has(current) || files[current] === undefined) continue;
+    reached.add(current);
+    // Covers `import … from './x'`, `import './x'` and `export … from './x'`,
+    // including the `export type { … } from './types'` form the entry uses.
+    for (const match of files[current].matchAll(
+      /(?:^|\n)\s*(?:import|export)\s+(?:type\s+)?(?:[^;'"]*?from\s+)?'(\.[^']*)'/g
+    )) {
+      const target = resolveRelative(current, match[1]);
+      if (target !== undefined) queue.push(target);
+    }
+  }
+
+  return Object.keys(files)
+    .filter((path) => isSource(path) && !reached.has(path))
+    .sort();
+}
+
 function declaredDependencies(vars: PluginTemplateVars): Record<string, string> {
   const pkg = buildPackageJson(vars) as {
     dependencies: Record<string, string>;
@@ -178,6 +287,49 @@ describe('generated package.json', () => {
     expect(Object.keys(pkg.devDependencies)).toEqual(
       expect.arrayContaining(['@testing-library/react', '@testing-library/jest-dom', 'jsdom'])
     );
+  });
+
+  it('declares exactly the four workspace platform packages as runtime dependencies', () => {
+    // objectui#3755. The whole map, not `arrayContaining`: a versioned runtime
+    // range added here has to fail this test and be argued for, which is what
+    // `'lucide-react': '^0.563.0'` never was. `workspace:*` throughout is the
+    // property that makes the generated manifest undriftable by construction —
+    // no anchor table needed, unlike the devDependencies above.
+    expect(generatedDependencies(VARS)).toEqual({
+      '@object-ui/components': 'workspace:*',
+      '@object-ui/core': 'workspace:*',
+      '@object-ui/react': 'workspace:*',
+      '@object-ui/types': 'workspace:*'
+    });
+  });
+
+  it('declares no versioned runtime dependency that the generated sources never import', () => {
+    // The other half of objectui#3733's one-way import gate. That gate rejects
+    // an import nothing declares; this one rejects a versioned declaration
+    // nothing imports — the direction that let lucide-react be installed by
+    // every scaffolded plugin for code that never referenced it (objectui#3755).
+    expect(unusedVersionedDependencies(generatedDependencies(VARS), buildPluginFiles(VARS))).toEqual(
+      []
+    );
+  });
+
+  it('catches an unused versioned runtime dependency when one is present', () => {
+    // Self-test, because the assertion above currently passes over an EMPTY
+    // set — there are no versioned runtime ranges left to judge. Without this,
+    // that gate would go green on a broken rule just as readily as on a clean
+    // manifest. Plants back the exact declaration objectui#3755 removed.
+    const files = buildPluginFiles(VARS);
+    const withLucide = { ...generatedDependencies(VARS), 'lucide-react': '^0.563.0' };
+    expect(unusedVersionedDependencies(withLucide, files)).toEqual(['lucide-react']);
+
+    // And does not fire on a versioned range the sources really do import, so
+    // the rule rejects unused declarations rather than versioned ones.
+    const withImported = { ...generatedDependencies(VARS), 'lucide-react': '^1.28.0' };
+    const importingFiles = {
+      ...files,
+      'src/Icon.tsx': `import { Flame } from 'lucide-react';\nexport const Icon = Flame;\n`
+    };
+    expect(unusedVersionedDependencies(withImported, importingFiles)).toEqual([]);
   });
 
   it('anchors every devDependency range, leaving none unpinned', () => {
@@ -251,6 +403,23 @@ describe('generated sources', () => {
     }
   });
 
+  it('derives the published schema interface from the protocols BaseSchema', () => {
+    // objectui#3759's second half. Reachable-from-the-entry made this interface
+    // the plugin's published contract; a hand-rolled `{ type; id?; className? }`
+    // in that position is a second dialect of a base node `@object-ui/types`
+    // already defines (AGENTS.md #0.1). It also silently omits everything else
+    // `BaseSchema` carries (`name`, `label`, `visible`, …). Every in-repo plugin
+    // that ships a `src/types.ts` extends it; `packages/plugin-markdown` is the
+    // closest model. Narrowing `type` to the registry key is the only local part.
+    const typesFile = buildPluginFiles(VARS)['src/types.ts'];
+    expect(typesFile).toContain(`import type { BaseSchema } from '@object-ui/types';`);
+    expect(typesFile).toContain('export interface HeatmapSchema extends BaseSchema {');
+    expect(typesFile).toContain(`type: 'heatmap';`);
+    // The copied subset is gone rather than kept alongside `extends`.
+    expect(typesFile).not.toContain('id?: string;');
+    expect(typesFile).not.toContain('className?: string;');
+  });
+
   it('has its jest-dom matchers registered by the setup file', () => {
     expect(buildTestFile(VARS)).toContain('toBeInTheDocument');
     expect(buildVitestSetup()).toContain('@testing-library/jest-dom');
@@ -313,6 +482,45 @@ describe('generated file map', () => {
       'vitest.setup.ts'
     ]);
     expect(files[VITEST_SETUP_FILE]).toContain(`import '@testing-library/jest-dom/vitest';`);
+  });
+
+  it('writes no source file that is unreachable from the packages only entry point', () => {
+    // objectui#3759. `src/types.ts` used to be written and then reachable from
+    // nowhere: no generated source imported it, and the `exports` map exposes
+    // only `.`, so `<pkg>/types` and `<pkg>/dist/types` were closed too. The
+    // interface in it is the plugin's schema contract — the one thing a
+    // metadata author needs from the package — and it shipped dead.
+    //
+    // Structural rather than a grep for the re-export line: any future template
+    // file added to the map has to be wired up to the entry (or be a test),
+    // instead of quietly becoming the next dead artifact.
+    expect(unreachableGeneratedSources(buildPluginFiles(VARS))).toEqual([]);
+  });
+
+  it('pins that entry-reachability is what makes a type consumable, via the exports map', () => {
+    // The premise the test above rests on. If a `./types` subpath were ever
+    // added to `exports`, entry-reachability would stop being the criterion —
+    // so the premise is asserted rather than assumed.
+    const pkg = buildPackageJson(VARS) as { exports: Record<string, unknown> };
+    expect(Object.keys(pkg.exports)).toEqual(['.']);
+    expect(buildIndexFile(VARS)).toContain(`export type { HeatmapSchema } from './types';`);
+  });
+
+  it('reports the schema module as unreachable when the entry stops re-exporting it', () => {
+    // Self-test for the gate above, which passes over an empty result: with the
+    // re-export line stripped, `src/types.ts` must be NAMED. This is the
+    // reverse verification of objectui#3759 encoded in the suite — restore the
+    // pre-fix entry and the gate goes red, rather than silently green because
+    // it stopped looking.
+    const files = buildPluginFiles(VARS);
+    const preFixEntry = files['src/index.tsx'].replace(
+      `export type { HeatmapSchema } from './types';\n`,
+      ''
+    );
+    expect(preFixEntry).not.toContain(`from './types'`);
+    expect(unreachableGeneratedSources({ ...files, 'src/index.tsx': preFixEntry })).toEqual([
+      'src/types.ts'
+    ]);
   });
 
   it('keeps every path inside the generated plugin directory', () => {

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -94,6 +94,39 @@ const DEV_DEPENDENCIES: Record<string, string> = {
   vitest: '^4.1.10'
 };
 
+/**
+ * Runtime `dependencies` written into the generated plugin.
+ *
+ * EVERY entry is a `workspace:*` platform package — the four `@object-ui/*` the
+ * scaffold's own sources build against. That is not an accident of the list, it
+ * is the rule: a generated plugin is written into `<cwd>/packages/plugin-<name>`
+ * and shares this workspace, so `workspace:*` always resolves to the version the
+ * repo currently builds and tests with, and can never drift.
+ *
+ * A VERSIONED runtime range here can drift, and one did. Until objectui#3755 the
+ * map also carried `'lucide-react': '^0.563.0'` — a declaration no generated
+ * source file imported, nailed two majors behind the 23 in-repo declarations
+ * (all `^1.28.0`) and unable to float off it, because a `0.x` caret does not
+ * cross minors: `^0.563.0` is `>=0.563.0 <0.564.0`. Every scaffolded plugin
+ * really installed lucide 0.563.x for code that never referenced it.
+ *
+ * It is gone rather than re-anchored because this repo declares an icon library
+ * where it imports one: of the 24 manifests that mention `lucide-react`, 23
+ * import it, and no package pre-declares it for code not yet written. An author
+ * who wants icons runs `pnpm add lucide-react` and lands the current version by
+ * construction — no anchor table has to be maintained to keep an unused
+ * declaration honest. `templates.test.ts` pins both halves: this map is exactly
+ * the four `workspace:*` entries, and no versioned runtime range may be
+ * declared without a generated source importing it (the reverse of the one-way
+ * import gate objectui#3733 added, which only ever caught the other direction).
+ */
+const DEPENDENCIES: Record<string, string> = {
+  '@object-ui/components': 'workspace:*',
+  '@object-ui/core': 'workspace:*',
+  '@object-ui/react': 'workspace:*',
+  '@object-ui/types': 'workspace:*'
+};
+
 /** The generated plugin's `package.json`, as an object (not yet serialised). */
 export function buildPackageJson(vars: PluginTemplateVars): Record<string, unknown> {
   return {
@@ -117,13 +150,7 @@ export function buildPackageJson(vars: PluginTemplateVars): Record<string, unkno
       test: 'vitest run',
       lint: 'eslint .'
     },
-    dependencies: {
-      '@object-ui/components': 'workspace:*',
-      '@object-ui/core': 'workspace:*',
-      '@object-ui/react': 'workspace:*',
-      '@object-ui/types': 'workspace:*',
-      'lucide-react': '^0.563.0'
-    },
+    dependencies: { ...DEPENDENCIES },
     peerDependencies: {
       react: '^18.0.0 || ^19.0.0',
       'react-dom': '^18.0.0 || ^19.0.0'
@@ -265,7 +292,26 @@ MIT © ${vars.author}
 `;
 }
 
-/** The generated plugin's `src/index.tsx` (entry point + registry registration). */
+/**
+ * The generated plugin's `src/index.tsx` (entry point + registry registration).
+ *
+ * The `./types` re-export is load-bearing, not tidiness (objectui#3759). The
+ * generated `package.json` exposes exactly one `exports` key — `.` → `dist/*` —
+ * so the entry is the ONLY door a consumer has. Until this line existed,
+ * `buildTypesFile`'s schema interface was written to disk and reachable from
+ * nowhere: no generated source imported it, and the deep paths that would have
+ * reached it (`<pkg>/types`, `<pkg>/dist/types`) are closed by that same
+ * `exports` map. The author's schema contract — the one thing a metadata
+ * producer needs from a renderer package — was a dead file.
+ *
+ * Named type-only re-export rather than `export * from './types'`, matching all
+ * four in-repo plugins that ship a `src/types.ts` (`plugin-charts`,
+ * `plugin-editor`, `plugin-kanban`, `plugin-markdown` — each
+ * `export type { XSchema } from './types';` behind the same `.`-only exports
+ * map) and the worked example in `content/docs/guide/plugin-development.md`.
+ * A star export would make every future local type public by accident; the
+ * named form keeps the published surface a deliberate act.
+ */
 export function buildIndexFile(vars: PluginTemplateVars): string {
   return `/**
  * ObjectUI
@@ -281,6 +327,7 @@ import { ${vars.pascalName} } from './${vars.pascalName}Impl';
 
 export { ${vars.pascalName} };
 export type { ${vars.pascalName}Props } from './${vars.pascalName}Impl';
+export type { ${vars.pascalName}Schema } from './types';
 
 // Register component with ComponentRegistry
 const ${vars.pascalName}Renderer: React.FC<{ schema: any }> = ({ schema }) => {
@@ -331,7 +378,25 @@ export const ${vars.pascalName}: React.FC<${vars.pascalName}Props> = ({ classNam
 `;
 }
 
-/** The generated plugin's `src/types.ts`. */
+/**
+ * The generated plugin's `src/types.ts`.
+ *
+ * Extends `BaseSchema` from `@object-ui/types` instead of re-declaring the base
+ * node's fields. This became mandatory the moment objectui#3759 made the file
+ * reachable from the entry: an unreachable interface is only dead weight, but a
+ * PUBLISHED one is the plugin's schema contract, and shipping a hand-rolled
+ * `{ type; id?; className? }` as that contract would hand every scaffolded
+ * plugin a second dialect of a base node the protocol already defines —
+ * precisely the "one strict contract beats N dialects" failure in AGENTS.md
+ * commandment #0.1. `BaseSchema` already carries `id?` and `className?` (plus
+ * `name`, `label`, `visible`, … which a copied subset silently omits), so only
+ * the `type` literal is narrowed here. Same shape as every in-repo plugin that
+ * ships one — `packages/plugin-markdown/src/types.ts` is the closest model —
+ * and as the anatomy table in `content/docs/guide/plugin-development.md`.
+ *
+ * This is also what makes the generated `@object-ui/types` dependency a used
+ * declaration rather than a third unused one beside objectui#3755's.
+ */
 export function buildTypesFile(vars: PluginTemplateVars): string {
   return `/**
  * ObjectUI
@@ -341,13 +406,16 @@ export function buildTypesFile(vars: PluginTemplateVars): string {
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { BaseSchema } from '@object-ui/types';
+
 /**
- * Schema definition for ${vars.pascalName}
+ * Schema definition for ${vars.pascalName}.
+ *
+ * This is the contract between a metadata author and the renderer: it is
+ * re-exported from \`src/index.tsx\`, which is the package's only entry point.
  */
-export interface ${vars.pascalName}Schema {
+export interface ${vars.pascalName}Schema extends BaseSchema {
   type: '${vars.pluginName}';
-  id?: string;
-  className?: string;
   // Add schema properties here
 }
 `;


### PR DESCRIPTION
Fixes #3755
Fixes #3759

两条都是 create-plugin 生成产物里「声明了但不可达」的死产物,且都落在 PR #3733 那道 import 闸门的**盲侧** —— 它只拒绝「未声明的 import」,从不反过来查「没人 import 的声明」。#3742 / PR #3754 已落 main,本 PR 在其现状上动,未回退其锚点表(那张表管 devDependencies,与本 PR 的两处面不相交)。

核验基线:`origin/main` @ `5147d9305`(worktree `/home/user/objectui-3755`,`git worktree add ... origin/main`,未依赖 FETCH_HEAD)。两单前提**实测均仍成立**:`templates.ts:125` 仍是 `'lucide-react': '^0.563.0'`;仓内 23 处声明全为 `^1.28.0`;`grep "from './types"` 空;`exports` 仅 `.` 一个键。

---

## 取舍与否决窗

分诊席与 PM 的干净缺省是**两单都走方向 2(删除)**。实读之后我对两单给出**不同**结论,依据如下 —— 这正是 dispatch note 授权的分叉("若 dev 实读后判方向 1 更当,须给证据")。

### #3755 → 方向 2(删除),与缺省一致

`lucide-react` 从生成的 `dependencies` 移除,该 map 现在恰为四条 `workspace:*`。

证据:

1. **零个生成源文件 import 它**(`buildIndexFile` / `buildImplFile` / `buildTypesFile` / `buildTestFile` 全部不碰)。
2. **它被钉死,不是「落后但会追上」**:`0.x` 的 caret 不跨 minor,`^0.563.0` 等价于 `>=0.563.0` 且小于 `0.564.0`,连 `0.x` 内的后续版本都拿不到。
3. **仓内约定就是「import 才声明」**:24 个提到 `lucide-react` 的 manifest 里 23 个真的 import 它(两种引号都数过 —— 只用单引号 grep 会漏掉 calendar/gantt/kanban 的双引号写法,初查时我漏过一次),**没有任何包为「还没写的代码」预声明图标库**。所以脚手架这条未用声明在仓内是孤例。
4. **方向 1 要为一条死声明持续付维护费**:把它锚到 `^1.28.0` 就必须同步把 PR #3754 的锚点表从 devDependencies 扩到 `dependencies`,即为一条**永远没人 import** 的声明维护一行锚点。删掉之后作者要图标就 `pnpm add lucide-react`,在本 workspace 里装到的自然是当前版本,与 23 个兄弟包一致 —— 不需要任何表。

补充说明(如实):`@object-ui/components` 并**不**再导出 lucide 图标,所以不存在「改用 components 取图标」这条替代路径;删除后的效果就是作者自己按需装。

### #3759 → 方向 1(补 entry 导出),**与缺省相反**

生成的 `src/index.tsx` 增加一行 `export type { PascalSchema } from './types';`,`src/types.ts` 产物**保留**。

之所以推翻「删除」,是因为这条产品判断在仓内**已经做过并且写进了文档**,不需要维护者重新拍:

1. **create-plugin 自己的文档页把它写成 Best Practice** —— `content/docs/utilities/create-plugin.mdx`:

   > **Export your schema types.** The schema interface is the contract between a metadata author and your renderer, so make it importable rather than internal.

   也就是说脚手架违反的是**它自己那页文档给作者的建议**。删掉产物等于把这条建议也一并作废。

2. **`content/docs/guide/plugin-development.md` 把 `types.ts` 写进 plugin anatomy**(文件表一行:"`types.ts` | Schema interfaces extending `BaseSchema` from `@object-ui/types`."),其 worked example 的 entry 末尾就是 `export type { BoardSchema, BoardProps, BoardColumn, BoardItem } from './types';`。
3. **仓内 4 个带 `src/types.ts` 的插件(charts / editor / kanban / markdown)全部从 entry 导出它**,且 4 个的 `exports` map 都只有 `.` —— 说明 entry re-export 正是本仓让 schema 类型可达的既有手法,#3759 正文里的方向 3(给 `exports` 加 `./types` 子路径)确实是多余的。
4. **「写了但 entry 不导出」这个形态在仓内是 0 例**,脚手架产出的是一个仓内任何地方都不存在的形状。
5. #3759 正文自己也记了这一点:被 #3715 删掉的旧文档虚构的 `export * from './types'`「恰好比真实模板更合理」。

用**具名 type-only** 导出而非 `export *`:4 个在仓插件用的都是具名形式(kanban 显式列了 6 个名字),且 `export *` 会让作者以后往 `types.ts` 里加的每个类型都自动变成公共面。代价是作者新增类型要同时在 entry 补名字 —— 这是有意的,公共面应当是一次自觉动作。

### #3759 的连带项:`types.ts` 改为 `extends BaseSchema`(这一条最需要否决窗)

这不是顺手扩范围,而是方向 1 的**前置条件**。原本那个手写的 `{ type; id?; className? }` 在不可达状态下只是死重量;一旦 entry 导出它,它就成了每个脚手架插件**已发布的 schema 契约面** —— 那时候发布一份 `@object-ui/types` 已经定义过的 base node 的**手抄子集**,就是 AGENTS.md 戒律 #0.1 说的「一份严格契约胜过 N 种方言」,而且这份子集静默丢掉了 `BaseSchema` 其余全部字段(`name`、`label`、`visible` …)。所以:

- `import type { BaseSchema } from '@object-ui/types';` + `extends BaseSchema`,只把 `type` 窄化成注册键(`packages/plugin-markdown/src/types.ts` 是最近的模型);
- 手抄的 `id?` / `className?` 删掉(BaseSchema 已有),不与 `extends` 并存;
- 顺带把生成的 `@object-ui/types` 依赖变成**被使用**的声明。

**否决窗**:如果维护者认为脚手架不该预置 schema 类型面,那么正确的动作是把 #3759 退回方向 2(删 `buildTypesFile` 与 `src/types.ts`),此时 `extends BaseSchema` 这一条自动随之消失,并且需要同步改 `create-plugin/README.md:28` 与 `plugin-development.md` 的 anatomy 表。若只想否决 `extends BaseSchema` 而保留 entry 导出,我不建议:那会把一份 base-node 方言发布给每个脚手架插件。

---

## 新增的钉子:两道都做了「非空」自检

两条规则都是**结构性**的,不是字符串 grep:

- **没有任何 versioned 运行时依赖可以在无人 import 的情况下被声明**(`workspace:*` 豁免 —— 它按定义解析到本 workspace 当前版本,不会漂);
- **没有任何生成的 `src/**` 模块可以从 entry 不可达**(entry 是 `exports` map 暴露的唯一入口)。

关键点:这两条在**修好之后的模板上都是对空集断言**(已经没有 versioned 运行时依赖了;已经没有不可达模块了)。按 PR #5046 那个教训,「因为什么都没产出所以绿」不是闸门。所以每条各配一个**自检**:把删掉的缺陷原样种回去,断言规则点得出它的名字。

- `catches an unused versioned runtime dependency when one is present` —— 种回 `'lucide-react': '^0.563.0'`,断言返回 `['lucide-react']`;并反向确认规则**不**误伤真的被 import 的 versioned 依赖(否则它就变成「禁止 versioned」而非「禁止未使用」)。
- `reports the schema module as unreachable when the entry stops re-exporting it` —— 把 entry 的 re-export 行剥掉,断言 `src/types.ts` 被**点名**。

另外 `derives the published schema interface from the protocols BaseSchema` 钉住上面那条连带项,否则它无人看守、会被静默改回去。

### fixture 三分类的实际落点(与派单预设不同,如实报告)

派单要求把「`src/types.ts` 存在」那条断言**整条替换**。这条要求预设了 #3759 走方向 2。实际走方向 1 之后,`src/types.ts` **仍然被写出**,那条 exact-key-list 断言依旧成立且依旧正确,因此它属于三分类里的「不动」而非「换掉」—— 真正变的不是它的 verdict,而是它**从来没有断言过可达性**(这正是 #3759 点出的弱闸门)。所以做法是给它**补**一个可达性兄弟,而不是替换它。若当初照字面替换,就会在方向 1 下删掉一条仍然有效的覆盖。

---

## 反向验证(方向先判后跑,三例全部与预判一致)

预判写在跑之前:两个 manifest/产物级闸门各应变红,而与之配对的**规则自检应当保持绿**(它们判的是规则本身,不是当前 manifest)。

**A. 把 `'lucide-react': '^0.563.0'` 加回 `DEPENDENCIES`** —— 预判 2 红:

```
× declares exactly the four workspace platform packages as runtime dependencies
× declares no versioned runtime dependency that the generated sources never import
AssertionError: expected { …(5) } to deeply equal { …(4) }
AssertionError: expected [ 'lucide-react' ] to deeply equal []
 Tests  2 failed | 17 passed (19)
```

**B. 剥掉 entry 的 `export type { ... } from './types';`** —— 预判 2 红:

```
× writes no source file that is unreachable from the packages only entry point
× pins that entry-reachability is what makes a type consumable, via the exports map
AssertionError: expected [ 'src/types.ts' ] to deeply equal []
 Tests  2 failed | 17 passed (19)
```

**C. 把 `types.ts` 退回手写接口(去掉 `extends BaseSchema`)** —— 预判 1 红:

```
× derives the published schema interface from the protocols BaseSchema
AssertionError: expected '/**\n * ObjectUI\n * Copyright (c) 20…' to contain 'import type { BaseSchema } from \'@ob…'
 Tests  1 failed | 18 passed (19)
```

三例中配对的自检都如预判保持绿:A 里 `catches an unused versioned …` 因为种植 spread 成了 no-op 而仍返回 `['lucide-react']`;B 里 `reports the schema module as unreachable …` 因为 `.replace()` 成了 no-op 而仍返回 `['src/types.ts']`。这是设计使然,不是漏检。

---

## 验证

**单测**(仓库根,路径过滤,不加 `--`):

```
$ flock /tmp/os-heavy-verify.lock -c 'NODE_OPTIONS=--max-old-space-size=4096 pnpm vitest run packages/create-plugin --maxWorkers=2'
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

改前基线 12 passed,新增 7 条(4 条闸门 + 2 条自检 + 1 条 BaseSchema 钉子)。

`pnpm --filter '@object-ui/create-plugin^...' build` 报 `No projects matched the filters` —— 如实记录原因:该包只依赖 chalk / commander / fs-extra / prompts,没有 workspace 依赖,测试也只 import node builtins 与 `../templates`,所以这一步没有可建的上游,不存在 TS2307 假红的风险面。

**type-check + build**:

```
$ pnpm --filter @object-ui/create-plugin type-check   # 无输出,通过
$ pnpm --filter @object-ui/create-plugin build
DTS ⚡️ Build success in 1525ms
```

**生成产物冒烟(用真 CLI 走一遍,不是只断言数据)**:仓内既有测试**不编译**生成产物(全是纯数据断言),所以这一步实跑了一次而非复用。用构建出的 CLI 在 worktree 内 scaffold 出 `packages/plugin-heatsmoke`,`pnpm install` 后:

```
$ pnpm exec vite build
dist/index.js  5.19 kB │ gzip: 1.89 kB
dist/index.umd.cjs  4.60 kB │ gzip: 1.82 kB
✓ built in 6.79s

$ pnpm exec vitest run --root .
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

关键一步 —— #3759 的修复在**产物层**成立,不只是源码层。生成的 `dist/index.d.ts`:

```
import { Heatsmoke } from './HeatsmokeImpl';
export { Heatsmoke };
export type { HeatsmokeProps } from './HeatsmokeImpl';
export type { HeatsmokeSchema } from './types';
```

`dist/types.d.ts` 一并 emit,内容为 `export interface HeatsmokeSchema extends BaseSchema`。即消费者 `import type { HeatsmokeSchema } from '@object-ui/plugin-heatsmoke'` 现在真的解析得到 —— 改前这个 import 无路可走。生成的 `dependencies` 实测为四条 `workspace:*`,`exports` 键实测为 `['.']`。

冒烟产物与被它改动的 `pnpm-lock.yaml` 已清除并还原,`git status` 只剩本 PR 的三个文件。

**消费半径扫描**(按规则被消费的地方扫,不是按被改的包):`0.563` 在仓内(除 lockfile 与无关的向量 fixture)已只出现在本 PR 自己的注释/自检里;`content/**` 无任何脚手架依赖区间声明(`create-plugin.mdx` 明确写了「Its dependency ranges are not listed here on purpose」),故 #3711 版本声明闸门与 `doc-version-claims` 均无需同步改动;`create-plugin/README.md:28` 的 `types.ts # Schema definitions` 在方向 1 下**依旧准确**,无需改。

**门禁自查**:

```
$ node scripts/check-changeset-presence.mjs
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
$ node scripts/check-changeset-no-major.mjs
✅  No changeset declares a `major` bump.
$ pnpm exec eslint packages/create-plugin --max-warnings=0    # 静默通过
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' templates.ts templates.test.ts changeset.md   # 零命中
```

changeset 档位 `patch`,与同族先例 PR #3754(#3742)和 #3716 一致 —— 生成产物变化对用户可见,但不改 create-plugin 自身 API。本仓 `major` 由 objectstack 对齐节奏决定,不在此声明。

---

## 越界发现(未在本 PR 修)

`packages/cli/src/utils/app-generator.ts` 的 `createTempAppWithRouting()` 生成的 layout `import`(`:591-592`)了 `lucide-react`,而它写出的 `package.json`(`:963` 起)显式声明了 `react-router-dom` 却**没有** `lucide-react` —— 与 #3716 完全同类的缺陷(生成源 import 未声明的依赖),只是位于 `packages/cli` 而非 `create-plugin`,PR #3733 的闸门伸不到那里;同时它的工具链区间落后本仓一到三个 major(`vite ^5.0.0` vs 仓根 `^8.2.0`、`typescript ~5.7.3` vs `^6.0.3`、`@vitejs/plugin-react ^4.2.1` vs `^6.0.5`、`@object-ui/react|components ^0.1.0` 而本仓已在 major 17),与 #3742 同类。已按 Prime Directive #10 单独建 issue(见 report),未在本 PR 处理。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_