### PR TITLE
fix(plugin-grid): inline 行动作槽位分配给存活的 primaries (#3762)

### DIFF
--- a/.changeset/row-action-inline-slot-survivors-3762.md
+++ b/.changeset/row-action-inline-slot-survivors-3762.md
@@ -1,0 +1,39 @@
+---
+"@object-ui/plugin-grid": patch
+---
+
+Grid row actions: the inline button budget is now spent on the primaries that actually render
+
+`RowActionMenu` allocated its inline slots on the **declared** row actions, before
+any `visible` predicate ran:
+
+```ts
+const primaryDefs = gatedActionDefs.filter(d => d.variant === 'primary');
+const inlineDefs = primaryDefs.slice(0, Math.max(0, maxInlineActions));
+```
+
+So on a row where the *leading* `variant: 'primary'` action was suppressed by its
+own `visible`, that action still held the slot — `RowActionInlineButton` returned
+`null` into it — while the next primary, the one that *did* survive the row's
+predicates, had already been sliced into the overflow list. The row then rendered
+**no inline button and a "⋮" hiding its main CTA**, even though exactly one primary
+was visible and `maxInlineActions` (default 1) allowed exactly one inline button.
+
+Slot allocation now happens inside `planRowActionMenu`, after visibility, so the
+budget is only ever spent on a primary that renders. `maxInlineActions` is
+unchanged in meaning and default — it is a width budget for real buttons, and
+counting an invisible action against it protected no layout.
+
+Behaviour change surface, deliberately narrow:
+
+- a row with 2 or more primaries where a *leading* one is suppressed for that row —
+  the surviving primary moves from the "⋮" menu to an inline button, and the "⋮"
+  disappears if nothing else is left to fold;
+- unchanged: how many primaries may go inline, the menu order (folded primaries
+  above secondaries), which items render at all, the ADR-0066 D4 capability gate
+  (still applied once to the declared set, upstream of this decision), and the
+  #3562 empty-menu guard — a row with nothing renderable still grows no trigger.
+
+Rows whose primaries are all ungated (the `sys_environment` Open + Upgrade Plan
+shape that motivated `maxInlineActions`) are bit-for-bit unaffected: declared order
+and surviving order coincide.

--- a/packages/plugin-grid/src/components/RowActionMenu.tsx
+++ b/packages/plugin-grid/src/components/RowActionMenu.tsx
@@ -93,6 +93,12 @@ export interface RowActionMenuProps {
    * before the rest fold into the "⋮" overflow menu. Bounds the row's inline
    * width so multiple primary actions (e.g. Open + Upgrade Plan) can't crowd
    * and clip each other in the narrow actions column. Defaults to 1.
+   *
+   * Counts the primaries that actually RENDER for this row, not the ones
+   * declared: a primary suppressed by its own `visible` occupies no slot
+   * (objectui#3762). The bound is a width budget for real buttons, so spending
+   * it on an action that renders nothing helps no layout and hides the row's CTA
+   * behind the "⋮".
    */
   maxInlineActions?: number;
   /**
@@ -207,13 +213,21 @@ export function isCustomRowActionVisible(
 
 /** What this row's action cell will actually render. */
 export interface RowActionMenuPlan {
-  /** Inline `variant:'primary'` buttons surviving their own `visible`. */
+  /**
+   * The `variant:'primary'` actions rendering as inline buttons: the first
+   * `maxInlineActions` primaries that SURVIVE their own `visible` for this row,
+   * in declared order (objectui#3762).
+   */
   inline: RowActionDef[];
   /** The built-in Edit item renders in the menu for this row. */
   edit: boolean;
   /** The built-in Delete item renders in the menu for this row. */
   remove: boolean;
-  /** Menu-bound defs surviving their own `visible`, in declared order. */
+  /**
+   * Menu-bound defs surviving their own `visible`: the surviving primaries that
+   * did not fit an inline slot, then the surviving non-primaries — each group in
+   * declared order, primaries above secondaries as before.
+   */
   custom: RowActionDef[];
   /** Legacy string row actions. Predicate-free, so all of them render. */
   legacy: string[];
@@ -243,18 +257,33 @@ export interface RowActionMenuPlan {
  * (ADR-0066 D4 / framework#3923) happens upstream of this call, on the declared
  * set, so its verdict reaches the guard the same way.
  *
- * Inline slot allocation is deliberately NOT re-derived from visibility: the
- * `maxInlineActions` slice runs on the declared primaries, exactly as before,
- * so a suppressed primary does not promote the next one into its slot. Which
- * items render, and where, is unchanged — only whether the trigger renders.
+ * Inline slot allocation happens HERE, after visibility, and that ordering is
+ * the whole of objectui#3762: an inline slot is spent only on a primary that
+ * actually renders for this row. It used to be sliced off the DECLARED primaries
+ * before any predicate ran, so a suppressed leading primary held a slot that
+ * rendered nothing (`RowActionInlineButton` returned `null` into it) while the
+ * next primary — the one that DID survive — had already been folded into the "⋮".
+ * A row with exactly one visible primary and a budget of one inline button
+ * showed no button and a "⋮" hiding its main CTA. Deciding survival and
+ * placement in one function is also why they cannot drift: there is no second
+ * place that partitions the defs.
  */
 export function planRowActionMenu(input: {
   row: any;
   scope: Record<string, unknown>;
-  /** Primaries occupying the inline slots, already sliced by `maxInlineActions`. */
-  inlineDefs: readonly RowActionDef[];
-  /** Defs bound for the "⋮" menu (folded primaries + non-primaries). */
-  menuDefs: readonly RowActionDef[];
+  /**
+   * The row's action defs in DECLARED order, already capability-gated
+   * (ADR-0066 D4) but NOT partitioned — this function splits primary from
+   * non-primary and allocates the inline slots, because both decisions depend on
+   * which defs survive `visible` (objectui#3762).
+   */
+  actionDefs?: readonly RowActionDef[];
+  /**
+   * Inline-button budget, i.e. how many SURVIVING primaries render inline before
+   * the rest fold into the menu. Defaults to 1, matching
+   * {@link RowActionMenuProps.maxInlineActions}; negative values are clamped to 0.
+   */
+  maxInlineActions?: number;
   /** Legacy string row actions (no predicates). */
   rowActions?: readonly string[];
   canEdit?: boolean;
@@ -266,12 +295,24 @@ export function planRowActionMenu(input: {
   objectFields?: unknown;
 }): RowActionMenuPlan {
   const { row, scope, objectFields } = input;
-  const inline = input.inlineDefs.filter((def) => isCustomRowActionVisible(def, row, scope, objectFields));
   const edit = Boolean(input.canEdit && input.onEdit)
     && isBuiltinRowActionVisible(input.editPredicates, 'edit', row, scope, objectFields);
   const remove = Boolean(input.canDelete && input.onDelete)
     && isBuiltinRowActionVisible(input.deletePredicates, 'delete', row, scope, objectFields);
-  const custom = input.menuDefs.filter((def) => isCustomRowActionVisible(def, row, scope, objectFields));
+  // One `visible` evaluation per def, as before — the partition below is pure
+  // array work on the survivors, so honoring the fix costs nothing extra.
+  const surviving = (input.actionDefs ?? []).filter(
+    (def) => isCustomRowActionVisible(def, row, scope, objectFields),
+  );
+  const survivingPrimaries = surviving.filter((def) => def.variant === 'primary');
+  const inlineBudget = Math.max(0, input.maxInlineActions ?? 1);
+  const inline = survivingPrimaries.slice(0, inlineBudget);
+  const custom = [
+    // Primaries that outran the inline budget stay above the secondaries, the
+    // menu order this surface has always had.
+    ...survivingPrimaries.slice(inlineBudget),
+    ...surviving.filter((def) => def.variant !== 'primary'),
+  ];
   const legacy = [...(input.rowActions ?? [])];
   return {
     inline,
@@ -456,33 +497,22 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
     () => (rowActionDefs ?? []).filter(d => mayInvoke((d as any)?.requiredPermissions)),
     [rowActionDefs, mayInvoke],
   );
-  // Surface `variant: 'primary'` row actions inline (as the row's main CTA);
-  // everything else stays in the "⋮" overflow menu. Only the first
-  // `maxInlineActions` primaries render inline — any extra primaries fold into
-  // the menu (kept above secondary actions) so a row never renders more inline
-  // buttons than the actions column can show, which previously clipped the
-  // leftmost button (e.g. "Open" hidden behind "Upgrade Plan").
-  //
-  // The slice runs on the DECLARED primaries, before any `visible` predicate is
-  // evaluated — unchanged on purpose. Re-deriving the slots from the surviving
-  // primaries would promote the next primary into a suppressed one's slot, i.e.
-  // change WHERE an item renders; #3562 is only about whether the "⋮" renders.
-  const { inlineDefs, menuDefs } = React.useMemo(() => {
-    const primaryDefs = gatedActionDefs.filter(d => d.variant === 'primary');
-    const max = Math.max(0, maxInlineActions);
-    return {
-      inlineDefs: primaryDefs.slice(0, max),
-      menuDefs: [
-        ...primaryDefs.slice(max),
-        ...gatedActionDefs.filter(d => d.variant !== 'primary'),
-      ],
-    };
-  }, [gatedActionDefs, maxInlineActions]);
   // What this row will ACTUALLY render, per-record predicates applied — the
   // guard and the items read one visibility source, so they cannot disagree.
   //
+  // `variant: 'primary'` actions surface inline (as the row's main CTA) and
+  // everything else stays in the "⋮" overflow menu; only `maxInlineActions` of
+  // them render inline, so a row never shows more inline buttons than the actions
+  // column can fit — which previously clipped the leftmost button ("Open" hidden
+  // behind "Upgrade Plan"). That partition lives inside `planRowActionMenu`
+  // rather than here (objectui#3762) precisely because the budget must be spent
+  // on the primaries that SURVIVE this row's predicates: slicing the declared
+  // primaries first left a suppressed one holding an empty slot while the
+  // surviving next primary was already folded behind the "⋮".
+  //
   // objectui#3562: the old guard asked whether handlers were supplied and how
-  // many actions were DECLARED (`(canEdit && onEdit) || … || menuDefs.length > 0`),
+  // many actions were DECLARED (`(canEdit && onEdit) || … || menuDefs.length > 0`
+  // — `menuDefs` being the pre-partitioned slice that #3762 moved into the plan),
   // while the items were filtered a second time, per row, by `visibleWhen` /
   // `visible`. Handlers present + every item suppressed for this record = a "⋮"
   // that opens an empty box — measured at 128×10 with zero `[role=menu]`
@@ -496,8 +526,8 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
       planRowActionMenu({
         row,
         scope,
-        inlineDefs,
-        menuDefs,
+        actionDefs: gatedActionDefs,
+        maxInlineActions,
         rowActions,
         canEdit,
         canDelete,
@@ -510,8 +540,8 @@ export const RowActionMenu: React.FC<RowActionMenuProps> = ({
     [
       row,
       scope,
-      inlineDefs,
-      menuDefs,
+      gatedActionDefs,
+      maxInlineActions,
       rowActions,
       canEdit,
       canDelete,

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
@@ -175,19 +175,74 @@ describe('RowActionMenu — the inline primary button shares one visibility sour
     expect(trigger()).not.toBeInTheDocument();
   });
 
-  it('a suppressed primary does NOT promote the next primary into its inline slot', () => {
-    // Slot allocation still runs on the DECLARED primaries: #3562 is about
-    // whether the trigger renders, not about relocating items. `upgrade` stays
-    // folded into the menu (and so the menu, holding one item, keeps its "⋮").
+  // objectui#3762 replaced the fixture that used to live here. It pinned the
+  // status quo — `a suppressed primary does NOT promote the next primary into its
+  // inline slot` — because slot allocation ran on the DECLARED primaries and
+  // #3562's ruling covered only whether the trigger renders, not where an item
+  // lands. #3762 then decided the placement question, the other way: a slot is a
+  // width budget for a button that renders, so a suppressed primary holds none.
+  // The old expectations (`upgrade` not inline, a "⋮" present) are now the wrong
+  // verdicts, so the case is replaced rather than re-spelled — see the describe
+  // below, which asserts the opposite direction on the same fixture.
+});
+
+/**
+ * objectui#3762 — the inline budget belongs to the primaries that RENDER.
+ *
+ * Same shape as the cloud `sys_environment` list that motivated
+ * `maxInlineActions` in the first place (two `variant:'primary'` actions, Open +
+ * Upgrade Plan), with the leading one gated for this row. Slicing the declared
+ * primaries left that suppressed action holding the single inline slot —
+ * `RowActionInlineButton` returned `null` into it — while the surviving primary
+ * had already been folded into the "⋮". The row then showed no inline button at
+ * all and hid its main CTA one click deep, even though exactly one primary was
+ * visible and the budget was exactly one.
+ */
+describe('RowActionMenu — inline slots go to SURVIVING primaries (objectui#3762)', () => {
+  const APPROVE_IF_APPROVER = {
+    name: 'approve',
+    label: 'Approve',
+    variant: 'primary' as const,
+    visible: IS_APPROVER,
+  };
+  const UPGRADE = { name: 'upgrade', label: 'Upgrade', variant: 'primary' as const };
+
+  it('a suppressed leading primary yields its inline slot to the surviving one', () => {
+    renderMenu({ rowActionDefs: [APPROVE_IF_APPROVER, UPGRADE] });
+    // The gated primary renders nowhere, as before.
+    expect(screen.queryByTestId('row-action-inline-approve')).not.toBeInTheDocument();
+    // …and the primary that DOES survive now takes the slot instead of folding.
+    expect(screen.getByTestId('row-action-inline-upgrade')).toBeInTheDocument();
+    // With the budget spent on a real button there is nothing left to fold, so
+    // this row has no "⋮" at all. Before #3762 this row rendered ONLY a "⋮".
+    expect(trigger()).not.toBeInTheDocument();
+  });
+
+  it('both primaries surviving → the second still folds into the menu (budget unchanged)', () => {
+    // The guard against over-correcting: #3762 changes WHICH primaries compete
+    // for the slots, never how many there are. `maxInlineActions` still defaults
+    // to 1, so the clipped-column regression the budget exists for stays fixed.
     renderMenu({
-      rowActionDefs: [
-        OPEN_IF_APPROVER,
-        { name: 'upgrade', label: 'Upgrade', variant: 'primary' },
-      ],
+      row: { ...DRAFT, approver: 'u-me' },
+      rowActionDefs: [APPROVE_IF_APPROVER, UPGRADE],
+    });
+    expect(screen.getByTestId('row-action-inline-approve')).toBeInTheDocument();
+    expect(screen.queryByTestId('row-action-inline-upgrade')).not.toBeInTheDocument();
+    // `upgrade` is folded, so the trigger is back — and holds it.
+    expect(trigger()).toBeInTheDocument();
+  });
+
+  it('every primary suppressed → no inline button and no "⋮" (guard cross-check)', () => {
+    // The empty-guard invariant (#3562) still holds under survivor-based slots:
+    // reallocating slots must not conjure a trigger for a row with nothing to
+    // show. Both primaries gate on being the approver, and FROZEN is not.
+    renderMenu({
+      rowActionDefs: [APPROVE_IF_APPROVER, { ...UPGRADE, visible: IS_APPROVER }],
     });
     expect(screen.queryByTestId('row-action-inline-approve')).not.toBeInTheDocument();
     expect(screen.queryByTestId('row-action-inline-upgrade')).not.toBeInTheDocument();
-    expect(trigger()).toBeInTheDocument();
+    expect(trigger()).not.toBeInTheDocument();
+    expect(screen.queryByRole('menu')).toBeNull();
   });
 });
 
@@ -285,14 +340,21 @@ describe('ObjectGrid actions column stays aligned when a row loses its menu (#35
 
 /**
  * The resolution the guard counts with, exercised directly: the DOM tests above
- * pin whether a trigger exists, these pin WHICH items it would hold. Both read
- * the same `planRowActionMenu`, and the item components re-read the same
- * visibility functions — so the trigger and its contents cannot drift apart.
+ * pin whether a trigger exists, these pin WHICH items it would hold — and, since
+ * objectui#3762, WHERE each one lands. Both read the same `planRowActionMenu`,
+ * and the item components re-read the same visibility functions — so the trigger
+ * and its contents cannot drift apart.
+ *
+ * `actionDefs` is the whole declared (capability-gated) set in declared order;
+ * the function partitions primary from non-primary itself, because the inline
+ * budget may only be spent on defs that survive `visible` (#3762). Defs without
+ * a `variant` are non-primary, so the menu-side cases below read the same as when
+ * this suite handed the split in pre-sliced.
  */
 describe('planRowActionMenu', () => {
   const scope = {};
   const noop = () => {};
-  const base = { scope, inlineDefs: [], menuDefs: [] } as const;
+  const base = { scope, actionDefs: [] } as const;
 
   it('counts nothing when nothing is wired', () => {
     expect(planRowActionMenu({ ...base, row: DRAFT })).toMatchObject({
@@ -349,7 +411,7 @@ describe('planRowActionMenu', () => {
   it('keeps the menu defs whose `visible` passes, in declared order', () => {
     const plan = planRowActionMenu({
       ...base,
-      menuDefs: [
+      actionDefs: [
         { name: 'unfreeze', visible: 'record.frozen == true' },
         { name: 'publish', visible: NOT_FROZEN },
         { name: 'view' },
@@ -363,7 +425,7 @@ describe('planRowActionMenu', () => {
   it('filters the inline primaries too, without counting them toward the trigger', () => {
     const plan = planRowActionMenu({
       ...base,
-      inlineDefs: [{ name: 'approve', variant: 'primary', visible: IS_APPROVER }],
+      actionDefs: [{ name: 'approve', variant: 'primary', visible: IS_APPROVER }],
       row: FROZEN,
     });
     expect(plan.inline).toEqual([]);
@@ -372,7 +434,7 @@ describe('planRowActionMenu', () => {
     expect(plan.menuCount).toBe(0);
     const passing = planRowActionMenu({
       ...base,
-      inlineDefs: [{ name: 'approve', variant: 'primary', visible: IS_APPROVER }],
+      actionDefs: [{ name: 'approve', variant: 'primary', visible: IS_APPROVER }],
       row: { ...DRAFT, approver: 'u-me' },
     });
     expect(passing.inline.map((a) => a.name)).toEqual(['approve']);
@@ -403,7 +465,7 @@ describe('planRowActionMenu', () => {
         canEdit: true,
         onEdit: noop,
         editPredicates: { visibleWhen: 'record.frozen ==' },
-        menuDefs: [{ name: 'broken', visible: 'record.frozen ==' }],
+        actionDefs: [{ name: 'broken', visible: 'record.frozen ==' }],
       })).toMatchObject({ edit: false, custom: [], menuCount: 0 });
     } finally {
       warn.mockRestore();
@@ -421,7 +483,7 @@ describe('planRowActionMenu', () => {
     const plan = planRowActionMenu({
       ...base,
       row: FROZEN,
-      menuDefs: [{ name: 'ghost', visible: false }],
+      actionDefs: [{ name: 'ghost', visible: false }],
     });
     expect(plan.custom).toEqual([]);
     expect(plan.menuCount).toBe(0);
@@ -433,7 +495,7 @@ describe('planRowActionMenu', () => {
     const plan = planRowActionMenu({
       ...base,
       row: FROZEN,
-      menuDefs: [{ name: 'always', visible: true }],
+      actionDefs: [{ name: 'always', visible: true }],
     });
     expect(plan.custom.map((a) => a.name)).toEqual(['always']);
     expect(plan.menuCount).toBe(1);
@@ -443,10 +505,76 @@ describe('planRowActionMenu', () => {
     const plan = planRowActionMenu({
       ...base,
       row: FROZEN,
-      menuDefs: [{ name: 'compiled_away', visible: '' }],
+      actionDefs: [{ name: 'compiled_away', visible: '' }],
     });
     expect(plan.custom.map((a) => a.name)).toEqual(['compiled_away']);
     expect(plan.menuCount).toBe(1);
+  });
+
+  // --- inline slot allocation (objectui#3762) --------------------------------
+  // `base` declares no `maxInlineActions`, so these read the default budget of
+  // 1 — the same default `RowActionMenuProps` documents.
+
+  it('spends the inline slot on the surviving primary, not the declared first', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      actionDefs: [
+        { name: 'approve', variant: 'primary', visible: IS_APPROVER },
+        { name: 'upgrade', variant: 'primary' },
+      ],
+    });
+    expect(plan.inline.map((a) => a.name)).toEqual(['upgrade']);
+    // Nothing folded, so nothing is left for the "⋮" to hold.
+    expect(plan.custom).toEqual([]);
+    expect(plan.menuCount).toBe(0);
+  });
+
+  it('two surviving primaries still put the second in the menu', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      row: { ...DRAFT, approver: 'u-me' },
+      actionDefs: [
+        { name: 'approve', variant: 'primary', visible: IS_APPROVER },
+        { name: 'upgrade', variant: 'primary' },
+      ],
+    });
+    expect(plan.inline.map((a) => a.name)).toEqual(['approve']);
+    expect(plan.custom.map((a) => a.name)).toEqual(['upgrade']);
+    expect(plan.menuCount).toBe(1);
+  });
+
+  it('fills EVERY slot from the survivors, and keeps folded primaries above secondaries', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      maxInlineActions: 2,
+      actionDefs: [
+        { name: 'approve', variant: 'primary', visible: IS_APPROVER },
+        { name: 'open', variant: 'primary' },
+        { name: 'upgrade', variant: 'primary' },
+        { name: 'archive', variant: 'secondary' },
+      ],
+    });
+    // Both slots go to survivors — the suppressed leading primary consumes none.
+    expect(plan.inline.map((a) => a.name)).toEqual(['open', 'upgrade']);
+    expect(plan.custom.map((a) => a.name)).toEqual(['archive']);
+    expect(plan.menuCount).toBe(1);
+  });
+
+  it('maxInlineActions: 0 keeps every surviving primary in the menu, above the secondaries', () => {
+    const plan = planRowActionMenu({
+      ...base,
+      row: FROZEN,
+      maxInlineActions: 0,
+      actionDefs: [
+        { name: 'archive', variant: 'secondary' },
+        { name: 'upgrade', variant: 'primary' },
+      ],
+    });
+    expect(plan.inline).toEqual([]);
+    expect(plan.custom.map((a) => a.name)).toEqual(['upgrade', 'archive']);
+    expect(plan.menuCount).toBe(2);
   });
 });
 

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.test.tsx
@@ -14,6 +14,13 @@
  * the leftmost ("Open") overflowed the fixed-width cell and was clipped to a
  * sliver. Only the first `maxInlineActions` primaries now stay inline; the rest
  * fold into the "⋮" overflow menu.
+ *
+ * The budget counts the primaries that SURVIVE their own `visible` for the row
+ * (objectui#3762). Every fixture in this file is ungated, so declared order and
+ * surviving order coincide and these cases pin the same behavior as before —
+ * which is the point of leaving them untouched: the fix must not move the
+ * clipping regression this suite exists for. The gated cases live in
+ * `RowActionMenu.emptyGuard.test.tsx`.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';


### PR DESCRIPTION
Fixes #3762

## 问题

`RowActionMenu` 的 inline 槽位分配跑在**声明序**上，且**先于**任何 `visible` 求值：

```ts
// 修改前（组件内的 useMemo）
const primaryDefs = gatedActionDefs.filter(d => d.variant === 'primary');
const max = Math.max(0, maxInlineActions);
inlineDefs: primaryDefs.slice(0, max)
menuDefs:   [...primaryDefs.slice(max), ...gatedActionDefs.filter(d => d.variant !== 'primary')]
```

于是当一行有 2 个以上 `variant: 'primary'`、且**靠前**那个的 `visible` 对这一行不成立时：

- 被压掉的 primary 仍占住那个 inline 槽（`RowActionInlineButton` 对它 `return null`，槽位空转）；
- 后面那个**通过了**谓词的 primary 早已被 slice 进 `menuDefs`，只能渲染进「⋮」。

结果：这一行明明只有一个可见 primary、`maxInlineActions`（默认 1）也允许 1 个 inline，用户看到的却是「没有 inline 按钮 + 一个要点开才看得到主操作的 ⋮」——行的主 CTA 被藏进溢出菜单。

## 修法

槽位分配移进 `planRowActionMenu`，**排在可见性之后**。该函数不再接收预先切好的 `inlineDefs` / `menuDefs`，改为接收未分区的 `actionDefs`（已过 ADR-0066 D4 能力门）加 `maxInlineActions`，自己过滤一遍再分区：

```ts
const surviving = (input.actionDefs ?? []).filter(
  (def) => isCustomRowActionVisible(def, row, scope, objectFields),
);
const survivingPrimaries = surviving.filter((def) => def.variant === 'primary');
const inlineBudget = Math.max(0, input.maxInlineActions ?? 1);
const inline = survivingPrimaries.slice(0, inlineBudget);
const custom = [
  ...survivingPrimaries.slice(inlineBudget),
  ...surviving.filter((def) => def.variant !== 'primary'),
];
```

**存活判定沿用 PR #3816（#3758）的入口**：`isCustomRowActionVisible`，声明检测按 `!= null && !== ''`，所以 `visible: false` 同样算「被压掉」、同样不占槽。这次没有新增第二处判定，判定与摆放收在同一个函数里 —— 全仓再没有第二处对 defs 分区，两者结构上无法漂移。

求值成本不变：仍是每个 def 一次 `visible`（改前 `inlineDefs`/`menuDefs` 两次 filter 作用在互斥集合上，总数相同），分区是纯数组操作。

### 前后对照（`maxInlineActions: 1`，两个 primary，靠前那个被 `visible` 压掉）

| | inline 按钮 | 「⋮」 | 菜单内容 |
|---|---|---|---|
| 修改前 | 无（槽位被压掉的 primary 空占） | 有 | 存活的 primary |
| 修改后 | 存活的 primary | 无（没有可折叠项了） | 空 |

**语义边界（都未变）**：能进 inline 的**数量**（默认仍是 1）、菜单内排序（折叠的 primary 仍在 secondary 之上）、哪些项渲染、能力门（仍对声明集只施加一次、在本决定的上游）、#3562 的空菜单守卫（无可渲染项的行仍然不长「⋮」）。全部 primary 都未被门住的行（激发 `maxInlineActions` 的 `sys_environment` Open + Upgrade Plan 那个形态）逐位不受影响 —— 声明序与存活序重合。

## 替换的断言（不是并存矛盾断言）

PR #3761 曾把当时的现状正向钉住：

- `a suppressed primary does NOT promote the next primary into its inline slot`（`RowActionMenu.emptyGuard.test.tsx`）

那条钉子断言的正是本单要反转的行为，它的期望（`upgrade` 不在 inline、存在一个「⋮」）现在是**错的裁定**，因此按 fixture 三分类里的「整条替换」处理：删除该 case，在原地留下一段注释交代它为何被替换（沿用同文件里 #3758 替换 #3562 fixture 时的写法），新不变量写进新 describe。PR #3761 写在代码里的两处「slice 保持原状的理由」注释（`planRowActionMenu` 的 doc 段 + 组件内 useMemo 上方那段）也一并改写为新不变量；组件内引用旧标识符 `menuDefs` 的那句历史引文加了括注，避免留下悬空标识符。

新钉子（`RowActionMenu.emptyGuard.test.tsx`）：

- DOM：靠前 primary 被压 → 存活者拿到 inline 槽，且**该行没有「⋮」**（这条是正向断言，不会因为「什么都没产生」而空绿）；
- DOM：两者都存活 → 第二个仍进菜单、「⋮」回来（钉住 `maxInlineActions` 语义与默认值 1 未被顺手改宽）；
- DOM：全部 primary 被压 → 既无 inline 也无「⋮」（与 #3562 守卫交叉核对，重排槽位不得凭空造出触发器）；
- 纯函数：槽位给存活者而非声明首个；两个存活者第二个进菜单；`maxInlineActions: 2` 时**每个**槽都从存活集填（折叠的 primary 仍在 secondary 之上）；`maxInlineActions: 0` 时不发生任何槽位分配。

`planRowActionMenu` 整个 describe 的入参从 `inlineDefs`/`menuDefs` 迁到 `actionDefs`（无 `variant` 即非 primary，菜单侧各 case 读法不变）。`planRowActionMenu` 不在包 barrel 里（barrel 只导出 `RowActionMenu` / `formatActionLabel` / `RowActionMenuProps`），入参换形不外溢；对外类型面零变化，所以下游包无需重编。

`RowActionMenu.test.tsx` 的 case **故意一条没动** —— 那里的 fixture 全部未加门，声明序与存活序重合，它们守的是当初 `maxInlineActions` 要修的「窄列裁切」回归；只在文件头 doc 补一句说明预算现在按存活集计。

## 消费半径清点

规则的调用方逐一 grep 过：`planRowActionMenu` 只被本组件与 `RowActionMenu.emptyGuard.test.tsx` 引用；`RowActionMenu` 只被同包 `ObjectGrid`（`maxInlineActions={schema.maxInlineRowActions ?? 1}`）消费，`app-shell/src/views/ObjectView.tsx` 里只是一句注释；`packages/components` 的 data-table 半边（PR #3756）没有 inline primary 这条路径，不共享代码。e2e 里只用到 `row-action-trigger`（未门住的 fixture）。全仓无残留的 `inlineDefs`/`menuDefs` 入参写法，仅剩两处明确标注为旧守卫引文的注释。

## 验证

仓根 flock 串行 + `NODE_OPTIONS=--max-old-space-size=4096` + `--maxWorkers=2`（新 worktree 里先 `pnpm --filter '@object-ui/plugin-grid^...' build`）。

```
pnpm --workspace-concurrency=2 --filter @object-ui/plugin-grid test -- --maxWorkers=2
 Test Files  56 passed (56)
      Tests  516 passed (516)

pnpm --workspace-concurrency=2 --filter @object-ui/plugin-grid type-check
 tsc --noEmit && tsc -p tsconfig.typetests.json     （无输出，通过）

pnpm --filter @object-ui/plugin-grid lint
 ✖ 569 problems (0 errors, 569 warnings)            （全部为既有 warning，本文件新增 0）

node scripts/check-control-bytes.mjs
 ✅ OK (scanned 3747 tracked text file(s); skipped 85 binary)
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' 本次改动四个文件 → 零命中
```

### 反向验证（方向先判后跑）

**跑之前**先写下预判：只把 `planRowActionMenu` 内部的分配顺序退回 #3762 前（先按声明序 slice，再 filter 可见性），**保留新签名**，这样测试仍能编译、信号纯粹是语义层面的。预判 **恰好 3 条红**，全在 `emptyGuard` 文件：晋升那条 DOM 钉 + 两条槽位分配的纯函数钉；另外「两者都存活」「全部被压」「`maxInlineActions: 0`」以及整个 `RowActionMenu.test.tsx` 应当**保持绿**——它们是不回归钉，不是本次修复的证据（尤其「全部被压」那条两种语义下都绿，其中一半是「什么都没产生」的空绿，这正是晋升钉写成正向断言的原因）。

实测与预判逐条一致：

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  RowActionMenu.emptyGuard.test.tsx > inline slots go to SURVIVING primaries (objectui#3762)
       > a suppressed leading primary yields its inline slot to the surviving one
TestingLibraryElementError: Unable to find an element by: [data-testid="row-action-inline-upgrade"]
 FAIL  ... > planRowActionMenu > spends the inline slot on the surviving primary, not the declared first
AssertionError: expected [] to deeply equal [ 'upgrade' ]
 FAIL  ... > planRowActionMenu > fills EVERY slot from the survivors, and keeps folded primaries above secondaries
AssertionError: expected [ 'open' ] to deeply equal [ 'open', 'upgrade' ]
 Test Files  1 failed | 55 passed (56)
      Tests  3 failed | 513 passed (516)
```

事后已用 patch 逐字节还原（`diff` 比对确认与反向验证前的改动完全相同），并在推送前重跑一遍全量 + type-check 全绿。

## Changeset

`.changeset/row-action-inline-slot-survivors-3762.md`，`@object-ui/plugin-grid: patch` —— 用户可见的行为变化（某一项从菜单里移到 inline），正文写明变化面与不变面。

## 可达性说明（承接 issue 的诚实标注）

issue 正文明确「未在真实元数据上复现」：形态（同一 `list_item` 上 2 个以上 primary）确实存在且是既有测试的原始动因（cloud `sys_environment` 的 Open + Upgrade Plan），但靠前那个是否带 `visible` 未经核实。本 PR 不改变这一点 —— 代码层面的不对称是确定的且已修，可达性仍按分诊裁定（`pm:queue`，最坏是 CTA 摆错位置，非数据问题）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_