### PR TITLE
fix(components): action:bar 成员动作声明 visible: false 时隐藏而非渲染 (#3823)

### DIFF
--- a/.changeset/action-bar-member-declared-visible-gate-3823.md
+++ b/.changeset/action-bar-member-declared-visible-gate-3823.md
@@ -1,0 +1,47 @@
+---
+"@object-ui/components": patch
+---
+
+`action:bar` member actions declaring `visible: false` are now hidden instead of rendered
+
+`action:button` and `action:icon` carried the same truthiness gate objectui#3812
+removed from the member-action leaves — `if (schema.visible && !isVisible)
+return null` — so `visible: false`, the most explicit way an author can say
+"never show this", fell into the "no gate declared" branch and the action
+rendered anyway.
+
+objectui#3812's triage judged the five component-level `schema.visible` gates a
+dormant defensive layer, because `packages/react`'s `SchemaRenderer` evaluates
+`newSchema.visible !== undefined` and hides the node before the component ever
+mounts. Two of the five are not dormant, and this is the difference:
+
+`action:bar` does not route through `SchemaRenderer`. It resolves each member's
+renderer from the `ComponentRegistry` itself and spreads the whole member action
+onto that renderer's schema, so an author's `visible` on a member arrives as the
+child's own `schema.visible` and lands on the child's gate. `action:bar` is also
+the only gate on that path by design — its `filteredActions` deliberately
+filters on `requiredPermissions` and `actionRendersAt` only, leaving `visible` to
+the member renderer. The path is reachable end-to-end and is now pinned that way
+(registry-mounted `action:bar`, member declaring `visible: false`), so the
+reachability does not have to be argued again.
+
+Both gates now read the same named definition as the rest of the family,
+`hasDeclaredVisibilityGate` (`!= null && !== ''`) — the invariant objectui#3492
+established for the selection bar and objectui#3758 applied to the row-action
+surfaces. The evaluation entry is untouched and already short-circuits a boolean
+rather than handing it to the CEL engine, which `actionPredicate.parity` pins for
+both the engine and the renderer path.
+
+Behaviour change surface, deliberately narrow: only an `action:button` /
+`action:icon` whose `visible` is the literal boolean `false` (or another falsy
+non-empty value) changes — from rendered to hidden, which is what the
+declaration asked for. `visible: true` still renders, `''` and an absent
+`visible` are still no gate at all, and no expression-valued `visible` changes
+verdict. `ActionSchema.visible` is `ExpressionInputSchema` with no boolean
+member, so `objectstack build` cannot emit this shape; hand-written view JSON and
+in-process callers constructing action defs can.
+
+The remaining three component-level gates (`action:group`, `action:menu`,
+`action:bar`'s own) stay as they are — they only ever mount through
+`SchemaRenderer`, which resolves `visible` first, and the overflow `action:menu`
+that `action:bar` synthesizes carries no `visible` at all.

--- a/packages/components/src/renderers/action/__tests__/action-bar-member-visible-gate.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-bar-member-visible-gate.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3823 — the `action:bar` member path reaches the COMPONENT-level
+ * truthiness gate, so `action:button` / `action:icon` declaring
+ * `visible: false` rendered anyway.
+ *
+ * objectui#3812 fixed the three member-action leaves that `action:group` /
+ * `action:menu` map themselves, and its triage judged the five component-level
+ * `schema.visible` gates a dormant defensive layer — `packages/react`'s
+ * `SchemaRenderer` evaluates `newSchema.visible !== undefined` and hides the
+ * node before the component ever mounts (pinned in
+ * `packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx`). Two of
+ * those five are NOT dormant, which is this issue:
+ *
+ *   `action:bar` does not route through `SchemaRenderer`. It pulls the member's
+ *   renderer out of the registry itself and spreads the whole member action
+ *   into that renderer's schema (`action-bar.tsx`: `schema={{ ...action, type:
+ *   componentType, actionType: action.type, … }}`). So an author's `visible`
+ *   on a member arrives as the child's OWN `schema.visible`, and the child's
+ *   `if (schema.visible && !isVisible) return null` asks truthiness: `false &&
+ *   …` is falsy, the gate is skipped, and the most explicit "never show this"
+ *   an author can write renders for everyone.
+ *
+ * `action:bar` is also the only gate on that path by design — its
+ * `filteredActions` deliberately filters only on `requiredPermissions` and
+ * `actionRendersAt`, leaving `visible` to the member renderer.
+ *
+ * Both gates now ask `hasDeclaredVisibilityGate` (`!= null && !== ''`), the one
+ * definition objectui#3492 established for the selection bar and #3758 / PR
+ * #3816 applied to the row-action surfaces. The verdict stays with the
+ * evaluation entry, which short-circuits a boolean instead of calling the CEL
+ * engine (`packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx`
+ * pins `literal false` → hidden on both the engine and the renderer path).
+ * Nothing about evaluation changes here — only the gate that refused to ask.
+ *
+ * Each gate asserts all THREE shapes (declared-false hides / declared-true
+ * renders / undeclared renders) plus `''`. The symmetry is the point: a "hide
+ * the member unconditionally" rewrite satisfies every `visible: false`
+ * assertion on its own and would leave the suite green. The last block drives
+ * the real `action:bar` host end-to-end, so the reachability this issue had to
+ * prove with a throwaway probe does not have to be argued again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PredicateScopeProvider } from '@object-ui/react';
+// Module-scope side-effect imports so the three renderers are in the registry
+// when `ComponentRegistry.get` runs — the light `dom` project deliberately does
+// not load `@object-ui/components`, and `action:bar` resolves its members
+// through the registry at render time. Module scope (not a `beforeAll`) per
+// AGENTS.md §测试纪律: the cost lands in the import phase, unbounded by any
+// hook timeout.
+import '../action-button';
+import '../action-icon';
+import '../action-bar';
+
+function getRenderer(type: string) {
+  const R = ComponentRegistry.get(type);
+  if (!R) throw new Error(`${type} is not registered`);
+  return R;
+}
+
+/** Mount a leaf renderer the way `action:bar` mounts it: whole action spread onto `schema`. */
+function renderLeaf(type: string, action: any, scope: Record<string, any> = {}) {
+  const Renderer = getRenderer(type);
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Renderer schema={{ ...action, type, actionType: action.type }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+/** An ungated companion — a passing "not rendered" must not mean "the bar vanished". */
+const COMPANION = { name: 'view', label: 'View', type: 'script', component: 'action:button' };
+
+/**
+ * The real `action:bar` host. `maxVisible` is pinned high so no member is
+ * pushed into the overflow `action:menu` — the assertion is about the inline
+ * member gate, and the inline/overflow split otherwise depends on
+ * `useIsMobile()` (whose `mobileMaxVisible` default is 1).
+ */
+function renderBar(actions: any[], scope: Record<string, any> = {}) {
+  const Bar = getRenderer('action:bar');
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Bar schema={{ type: 'action:bar', maxVisible: 10, actions: [...actions, COMPANION] }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+describe('action:button — declared boolean `visible` (objectui#3823)', () => {
+  it('visible:false → the button does not render', () => {
+    renderLeaf('action:button', { name: 'ghost', label: 'Ghost', type: 'script', visible: false });
+    expect(screen.queryByText('Ghost')).toBeNull();
+  });
+
+  it('visible:true → the button renders', () => {
+    renderLeaf('action:button', { name: 'always', label: 'Always', type: 'script', visible: true });
+    expect(screen.getByText('Always')).toBeInTheDocument();
+  });
+
+  it('no `visible` at all → the button renders (ungated stays ungated)', () => {
+    renderLeaf('action:button', { name: 'plain', label: 'Plain', type: 'script' });
+    expect(screen.getByText('Plain')).toBeInTheDocument();
+  });
+
+  it('an empty-string `visible` is not a declared gate — the button still renders', () => {
+    renderLeaf('action:button', { name: 'empty', label: 'Empty', type: 'script', visible: '' });
+    expect(screen.getByText('Empty')).toBeInTheDocument();
+  });
+
+  it('an expression-valued `visible` keeps its verdict — false hides, true shows', () => {
+    const { unmount } = renderLeaf(
+      'action:button',
+      { name: 'expr', label: 'Expr', type: 'script', visible: 'features.canRun == true' },
+      { features: { canRun: false } },
+    );
+    expect(screen.queryByText('Expr')).toBeNull();
+    unmount();
+    renderLeaf(
+      'action:button',
+      { name: 'expr', label: 'Expr', type: 'script', visible: 'features.canRun == true' },
+      { features: { canRun: true } },
+    );
+    expect(screen.getByText('Expr')).toBeInTheDocument();
+  });
+});
+
+// `action:icon` is icon-only: its accessible name is the `aria-label` the
+// renderer builds from `label ?? name`, not text content.
+describe('action:icon — declared boolean `visible` (objectui#3823)', () => {
+  it('visible:false → the icon button does not render', () => {
+    renderLeaf('action:icon', { name: 'ghost', label: 'Ghost', type: 'script', visible: false });
+    expect(screen.queryByLabelText('Ghost')).toBeNull();
+  });
+
+  it('visible:true → the icon button renders', () => {
+    renderLeaf('action:icon', { name: 'always', label: 'Always', type: 'script', visible: true });
+    expect(screen.getByLabelText('Always')).toBeInTheDocument();
+  });
+
+  it('no `visible` at all → the icon button renders (ungated stays ungated)', () => {
+    renderLeaf('action:icon', { name: 'plain', label: 'Plain', type: 'script' });
+    expect(screen.getByLabelText('Plain')).toBeInTheDocument();
+  });
+
+  it('an empty-string `visible` is not a declared gate — the icon button still renders', () => {
+    renderLeaf('action:icon', { name: 'empty', label: 'Empty', type: 'script', visible: '' });
+    expect(screen.getByLabelText('Empty')).toBeInTheDocument();
+  });
+
+  it('an expression-valued `visible` keeps its verdict — false hides, true shows', () => {
+    const { unmount } = renderLeaf(
+      'action:icon',
+      { name: 'expr', label: 'Expr', type: 'script', visible: 'features.canRun == true' },
+      { features: { canRun: false } },
+    );
+    expect(screen.queryByLabelText('Expr')).toBeNull();
+    unmount();
+    renderLeaf(
+      'action:icon',
+      { name: 'expr', label: 'Expr', type: 'script', visible: 'features.canRun == true' },
+      { features: { canRun: true } },
+    );
+    expect(screen.getByLabelText('Expr')).toBeInTheDocument();
+  });
+});
+
+/**
+ * The reachability pin. This is the path objectui#3823 had to demonstrate with
+ * a throwaway probe: the registry-mounted `action:bar` spreads the member onto
+ * the child's schema, so the component-level gate is the only one that runs.
+ */
+describe('action:bar member end-to-end — declared boolean `visible` (objectui#3823)', () => {
+  it('an action:button member declaring visible:false is not rendered by the bar', () => {
+    renderBar([
+      { name: 'ghost', label: 'Ghost', type: 'script', component: 'action:button', visible: false },
+    ]);
+    expect(screen.getByText('View')).toBeInTheDocument(); // the bar itself rendered
+    expect(screen.queryByText('Ghost')).toBeNull();
+  });
+
+  it('an action:icon member declaring visible:false is not rendered by the bar', () => {
+    renderBar([
+      { name: 'ghost', label: 'Ghost', type: 'script', component: 'action:icon', visible: false },
+    ]);
+    expect(screen.getByText('View')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Ghost')).toBeNull();
+  });
+
+  it('members declaring visible:true still render (the bar did not start hiding everything)', () => {
+    renderBar([
+      { name: 'btn', label: 'Btn', type: 'script', component: 'action:button', visible: true },
+      { name: 'ico', label: 'Ico', type: 'script', component: 'action:icon', visible: true },
+    ]);
+    expect(screen.getByText('Btn')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ico')).toBeInTheDocument();
+  });
+
+  it('members with no `visible` at all still render', () => {
+    renderBar([
+      { name: 'btn', label: 'Btn', type: 'script', component: 'action:button' },
+      { name: 'ico', label: 'Ico', type: 'script', component: 'action:icon' },
+    ]);
+    expect(screen.getByText('Btn')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ico')).toBeInTheDocument();
+  });
+
+  it('an expression-valued member `visible` keeps its verdict through the bar', () => {
+    const member = {
+      name: 'expr',
+      label: 'Expr',
+      type: 'script',
+      component: 'action:button',
+      visible: 'features.canRun == true',
+    };
+    const { unmount } = renderBar([member], { features: { canRun: false } });
+    expect(screen.queryByText('Expr')).toBeNull();
+    unmount();
+    renderBar([member], { features: { canRun: true } });
+    expect(screen.getByText('Expr')).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -26,6 +26,7 @@ import { Button } from '../../ui';
 import { cn } from '../../lib/utils';
 import { Loader2 } from 'lucide-react';
 import { resolveIcon } from './resolve-icon';
+import { hasDeclaredVisibilityGate } from './visibility-gate';
 
 export interface ActionButtonProps {
   schema: ActionSchema & { type: string; className?: string; actionType?: string };
@@ -145,7 +146,12 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
       // this once-only regardless, so it's safe to depend on it.
     }, [autoTrigger, handleClick]);
 
-    if (schema.visible && !isVisible) return null;
+    // A declared boolean `visible: false` is a verdict, not a missing gate —
+    // truthiness classified it as "ungated" and rendered the action for
+    // everyone (objectui#3823). Reachable because `action:bar` bypasses
+    // `SchemaRenderer` and spreads the whole member action onto this schema, so
+    // this gate is the only one on that path. See `hasDeclaredVisibilityGate`.
+    if (hasDeclaredVisibilityGate(schema.visible) && !isVisible) return null;
 
     return (
       <Button

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -22,6 +22,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../
 import { cn } from '../../lib/utils';
 import { Loader2 } from 'lucide-react';
 import { resolveIcon } from './resolve-icon';
+import { hasDeclaredVisibilityGate } from './visibility-gate';
 
 export interface ActionIconProps {
   schema: ActionSchema & { type: string; className?: string };
@@ -79,7 +80,11 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
       }
     }, [schema, execute, loading, localContext]);
 
-    if (schema.visible && !isVisible) return null;
+    // Same gate, same reachability as action-button.tsx (objectui#3823): an
+    // `action:icon` member of an `action:bar` gets the author's `visible`
+    // spread onto its own schema, and truthiness read a declared `false` as
+    // "no gate". See `hasDeclaredVisibilityGate`.
+    if (hasDeclaredVisibilityGate(schema.visible) && !isVisible) return null;
 
     const button = (
       <Button


### PR DESCRIPTION
Fixes #3823

## 机理

`action:button` / `action:icon` 的组件级门沿用真值判读,于是 `false && …` 为假 → 不 `return null` → 渲染。作者写 `visible: false`(最明确的「永不显示」)被判读成「没声明门」。

#3812 的分诊把这五处组件级 `schema.visible` 门判为**休眠**防御层 —— 经 `packages/react` 的 `SchemaRenderer` 路由时,宿主按 `newSchema.visible !== undefined` 统一求值并隐藏,组件根本不会挂载到自己的门。**五处里有两处不休眠**,差别就是本单:

`action:bar` 不走 `SchemaRenderer`。它自己从 `ComponentRegistry` 取成员渲染器,并把**成员动作对象整体展开**成子渲染器的 schema(`action-bar.tsx`:`schema={{ ...action, type: componentType, actionType: action.type, … }}`),于是作者写在成员上的 `visible` 成为子渲染器**自己的** `schema.visible`,落到它自己的门上。`action:bar` 上游也**有意**不按 `visible` 过滤成员(`filteredActions` 只过 `requiredPermissions` 与 `actionRendersAt`),所以这条路径上真值门是**唯一的门**。

## 两门位前后对照

| 位置 | 前 | 后 |
| --- | --- | --- |
| `renderers/action/action-button.tsx:148` | `if (schema.visible && !isVisible) return null;` | `if (hasDeclaredVisibilityGate(schema.visible) && !isVisible) return null;` |
| `renderers/action/action-icon.tsx:82` | 同形 | 同形收敛 |

统一到同族那一处命名定义 `renderers/action/visibility-gate.ts` 的 `hasDeclaredVisibilityGate`(`!= null && !== ''`,PR #3825 落 main @ `b5980f471`)。**verdict 不动**,仍交给求值入口 —— 布尔在 `evaluateCondition` 短路,`packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx:134` 已钉「literal false → 引擎与渲染器两条路径都判隐藏」。改的只是**那个拒绝提问的门**。

⛔ 按 issue 正文,另三处被遮住的门(`action-group.tsx:235` / `action-menu.tsx:179` / `action-bar.tsx:223`)与 `packages/components/src/SchemaRenderer.tsx` 那份只看 `hidden` 的休眠同名副本**均未触碰**。

## 端到端钉子(可达性不必下次重新论证)

新增 `renderers/action/__tests__/action-bar-member-visible-gate.test.tsx`,15 条:

- **两门位各三形状对称** —— `false` 隐藏 / `true` 渲染 / 未声明渲染,外加 `''` 不是声明的门、表达式取值仍按 verdict(`false` 隐藏、`true` 显示)。对称性是要点:「无条件隐藏成员」的错误改法能独自满足所有 `visible: false` 断言,把套件留在绿色。
- **经真实 `action:bar` 宿主的端到端钉子** 5 条 —— 从注册表取 `action:bar` 挂载(与真实宿主同一条路径),成员声明 `visible: false` → 不渲染,`action:button` 与 `action:icon` 各一条;并带一个未声明的伴随动作,使「没渲染」的断言不会与「整条 bar 消失了」混淆。`maxVisible` 钉高,免得成员被推进溢出 `action:menu`(`useIsMobile()` 的 `mobileMaxVisible` 默认是 1)。
- `action:icon` 是纯图标,可及名来自渲染器用 `label ?? name` 构造的 `aria-label`,故按 `getByLabelText` 断言而非文本。

## 反向验证(方向先判后跑)

**预判**:改动只影响「已声明且 falsy」的取值(实际就是字面 `false`),故未改代码上应是**四条 `visible: false` 钉子红、其余全绿**;`true` / 未声明 / `''` 前后同绿(它们在两种写法下走同一分支)。

**实跑**(`origin/main@c8526825618f86bff6d270f70893a35992243dea`,先落钉子、后改门):

```
Failed Tests 4
 FAIL  action:button — declared boolean `visible` > visible:false → the button does not render
 FAIL  action:icon — declared boolean `visible` > visible:false → the icon button does not render
 FAIL  action:bar member end-to-end > an action:button member declaring visible:false is not rendered by the bar
 FAIL  action:bar member end-to-end > an action:icon member declaring visible:false is not rendered by the bar
AssertionError: expected  button …(2)  /button  to be null
      Tests  4 failed | 11 passed (15)
```

端到端那两条独立复现了 issue 探针的结论 —— 经 `action:bar` spread 路径,`visible: false` 的成员实测渲染出了 `Ghost` 按钮(`action:icon` 那条连 `aria-label="Ghost"` 一起)。改门后:

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

方向与预判一致(标准 Red 方向,无反转)。

## 验证

仓根规范调用 + `flock` 串行 + `NODE_OPTIONS=--max-old-space-size=4096` + `--maxWorkers=2`:

```
pnpm exec vitest run packages/components
  Test Files  98 passed (98)
      Tests  761 passed (761)

# 消费半径:action:button / action:icon 的宿主与求值入口(跨 4 包 + console)
pnpm exec vitest run packages/react/.../actionPredicate.parity.test.tsx \
  packages/react/.../SchemaRenderer.expressions.test.tsx \
  packages/app-shell/.../PageView.test.tsx packages/app-shell/.../useConsoleActionRuntime.test.tsx \
  packages/app-shell/.../DeclaredActionsBar.test.tsx \
  packages/core/.../actionKeys.types.test.ts packages/types/.../spec-derived-unions.test.ts \
  apps/console/src/__tests__/public-contract.test.ts
  Test Files  8 passed (8)
      Tests  140 passed (140)

pnpm --filter @object-ui/components type-check   → exit 0
pnpm exec eslint <三个改动文件>                   → 0 errors(仅存量 any/react-refresh warning)
pnpm run check:control-bytes                     → OK(3748 tracked;改动文件另做 [\x00-\x08\x0b\x0c\x0e-\x1f] 自扫,零命中)
```

**fixture 清扫**:按规则的消费半径(而非改动包)枚举了全仓 `visible: false` 与 `action:button` / `action:icon` 的引用面 —— 没有任何 fixture 钉住被删掉的真值分支(其余命中分属 page-nav / 行动作面 / 权限 explain 的 `record.visible` / 求值入口 parity,语义无关),故无需重拼或替换。

## Changeset

`.changeset/action-bar-member-declared-visible-gate-3823.md`,`@object-ui/components` **patch**(与 #3825 同档)。已写明行为变化面:**只有** `visible` 为字面布尔 `false`(或其他非空 falsy)的 `action:button` / `action:icon` 从渲染变隐藏;`visible: true` 照旧渲染,`''` 与缺省照旧不算门,表达式取值 verdict 不变。`ActionSchema.visible` 是 `ExpressionInputSchema`(无 boolean 成员),`objectstack build` 产不出这个形状;手写视图 JSON 与进程内构造 action def 可以。

## 顺带发现(未在本 PR 修)

清扫消费半径时在**另一个包**撞到同族第五处同形门,已按 Prime Directive #10 独立立单、**未认领**:**#3835** —— `packages/app-shell/src/views/DeclaredActionsBar.tsx:190` 同一个 `(action as any).visible && !isVisible`,该文件注释自称 "Mirrors `action:button`"。可达性是**构造性**的(普通 React 组件,由 `apps/console/.../ApprovalsInboxPage.tsx:2014`/`:2055` 直接以 JSX 挂载,路径上没有 `SchemaRenderer` 遮挡),已用一次性探针实证(未提交)。授权面比本族更热:那里渲染的是**服务端声明的** action def(审批 Approve/Reject),布尔形状自然可写。单里另记了一处:该文件现有套件把 `useCondition` 整个打桩成常真,所以这个门从未被行使过。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_