### PR TITLE
fix(plugin-detail,components): 补齐渲染器已兑现的四个 spec 键的 inputs 声明,并把 parity 门的反方向推到全仓 (#3808)

### DIFF
--- a/.changeset/inputs-reverse-parity-3808.md
+++ b/.changeset/inputs-reverse-parity-3808.md
@@ -1,0 +1,53 @@
+---
+"@object-ui/plugin-detail": patch
+"@object-ui/components": patch
+---
+
+Four spec keys the renderers already honoured are now discoverable from the published `inputs`
+
+`record:details.hideFields`, `record:related_list.relationshipValueField`,
+`record:related_list.add` and `element:text_input.defaultValue` were declared by
+`@objectstack/spec` and read by their renderers, while the registry `inputs` —
+the surface `gen-manifest.ts` serializes into `sdui.manifest.json` and
+`sdui-intrinsics.d.ts` — never mentioned them. Nothing anywhere reported the
+mismatch, and every layer that reads a manifest said the opposite of the
+runtime: the keys were in no designer panel and no generated `.d.ts`,
+`sdui-parser`'s prop walk returned `unknown-prop` for an author who wrote one,
+and the renderer honoured it regardless. That is objectui#3407's original
+complaint (`readonly` was enforced and honoured, the description just never said
+so) on four more keys.
+
+Each description is derived from what the renderer actually does, not from
+restating the spec's one-liner, because the two can differ and the published
+text is what an AI author reads:
+
+- `hideFields` documents bare field names only — the renderer tolerates
+  `{name}` / `{field}` entries but the spec is `z.array(z.string())` and rejects
+  them, so teaching that spelling would publish a dialect the contract refuses;
+- `relationshipValueField` publishes the renderer's `'id'` default and says that
+  the resolved value drives the list filter, the Add-picker link value and the
+  pre-filled create form together;
+- `add` publishes its member shape in prose (`ComponentInput` is flat and has no
+  member-shape slot) with each default taken from the renderer — including
+  `picker.labelField`, where the renderer defaults to `name` while the spec's
+  own wording says "the object title field". It also names `picker.filter` as a
+  KNOWN GAP rather than documenting it as a restriction: the spec declares it
+  and nothing reads it, so an author would otherwise believe their picker is
+  scoped when it offers every record (objectui#3831);
+- `defaultValue` distinguishes the two behaviours an author can get — seeding a
+  bound page variable once while it is still empty, versus the native
+  uncontrolled initial value with no variable bound.
+
+`element:text_input` is not in the public tier, so its gap was not in
+`sdui.manifest.json` at all — it was in the JSX-page compiler's prop whitelist,
+which `renderers/layout/page.tsx` builds from `getKnownTypes()` plus these same
+`inputs`, making the undeclared `defaultValue` a live `unknown-prop` warning.
+
+The repo-wide parity gate now runs in both directions over one covered set and
+one exemption discipline, so neither direction can be forgotten again the way
+the reverse half was after PR #3806. Nine spec keys stay deliberately
+unpublished, each with a written reason and a tracking issue: two the renderers
+do not read at all (objectui#3829), three retired upstream by ADR-0087
+tombstones, `page:tabs.type` (a carrier collision, objectstack#6776), two
+`targetVariable` declarative hints (objectui#3834), and
+`element:record_picker.filter` (objectui#3830).

--- a/apps/console/src/__tests__/public-block-binding-reach.test.tsx
+++ b/apps/console/src/__tests__/public-block-binding-reach.test.tsx
@@ -233,6 +233,15 @@ const SUPERSEDES_BINDING = new Set(['data']);
  */
 const sampleFor = (input: any): unknown => {
   if (input.name === 'objectName') return PROBE_OBJECT;
+  // `record:related_list.add` — the generic `object` sample below is `{}`, and
+  // `{}` is not a valid `add`: the spec makes `picker` required. An invalid one
+  // does not merely under-configure this block, it CRASHES it
+  // (`RelatedList.tsx:1299` dereferences `add.picker.object`, objectui#3838) —
+  // and a crashed block makes no data calls, which is indistinguishable from the
+  // "declines to fetch" verdict this block is ledgered for below. That is a green
+  // for the wrong reason, so the sample is spec-valid at the source instead.
+  // Arrived with objectui#3808, which is when `add` became a declared input.
+  if (input.name === 'add') return { picker: { object: PROBE_OBJECT } };
   if (input.defaultValue !== undefined) return input.defaultValue;
   switch (input.type) {
     case 'number':
@@ -309,12 +318,21 @@ async function dataCallsFor(cfg: any): Promise<string[]> {
   // its object. Every call it made is already recorded above, so swallow the
   // unmount and let the assertion speak to the data reach. Deliberately scoped
   // to unmount: an error thrown during RENDER still propagates and fails.
+  // Read the DOM before unmounting: `SchemaRenderer` CATCHES a renderer's throw
+  // and paints an error card, so a crash never propagates here — it just makes
+  // the block produce nothing, including no data calls. For a ledgered block
+  // ("declines to fetch") that is a green earned by crashing, which is why this
+  // is captured and asserted rather than left to the calls alone. Same guard the
+  // sibling probe carries as `assertRendered`
+  // (`record-block-record-reach.test.tsx`), added here after objectui#3808 made
+  // an invalid `add` sample able to trigger exactly that.
+  const html = view.container.innerHTML;
   try {
     view.unmount();
   } catch {
     /* see above */
   }
-  return calls;
+  return { calls, html };
 }
 
 const candidates = ComponentRegistry.getPublicConfigs().filter(declaresObjectName);
@@ -335,9 +353,40 @@ describe('public blocks — a declared objectName reaches the data layer (object
   for (const cfg of candidates) {
     const ledgered = cfg.type in NO_DATA_REACH;
     it(`${cfg.type} ${ledgered ? 'does not reach the data layer (ledgered)' : 'asks the data layer for its objectName'}`, async () => {
-      const calls = await dataCallsFor(cfg);
+      const { calls, html } = await dataCallsFor(cfg);
       const reached = calls.filter((c) => c.includes(PROBE_OBJECT));
       if (ledgered) {
+        // A crash is not a binding answer, and on THIS branch it is
+        // indistinguishable from one: "made no data call" is the pass condition,
+        // and a block that threw during render made none either. `SchemaRenderer`
+        // catches the throw and paints an error card, so nothing propagates —
+        // without this the ledger entry would be confirmed by the block being
+        // broken.
+        //
+        // Added with objectui#3808, and DEFENSIVE rather than load-bearing today:
+        // that change made an invalid `add` sample crash `record:related_list`
+        // (objectui#3838), which is what it does in the sibling probe, but not
+        // here — `renderers/record-related-list.tsx:185` passes
+        // `dataSource={ctx?.dataSource}`, this probe mounts with no RecordContext,
+        // so `RelatedList`'s `add && dataSource` guard short-circuits before the
+        // unguarded read. Checked, not assumed: reverting the sample to `{}` keeps
+        // all 16 green. The predicate itself is known to work — applied to both
+        // branches it reports the two crashes in objectui#3840 — so this is a
+        // cheap standing guard on the one branch where a crash IS the pass
+        // condition, not a claim that it fires today.
+        //
+        // Deliberately NOT applied to the other branch: `object-form` and
+        // `object-master-detail-form` do paint an error card under this fixture
+        // ("Cannot read properties of undefined (reading 'map')") while still
+        // making their data calls, so their verdicts are earned rather than
+        // vacuous. Whether that card is a product bug or this fixture handing
+        // them an implausible configuration — the lesson the header records four
+        // instances of — is objectui#3840, not something to decide by widening a
+        // guard here.
+        expect(
+          html.includes('failed to render'),
+          `<${cfg.type}> threw during render, so "made no data call" proves nothing:\n${html.slice(0, 600)}`,
+        ).toBe(false);
         // Asserted, not skipped: the day this block starts binding, this fails
         // and the ledger entry has to go — a ledger nobody is forced to update
         // decays into the accepted-baseline problem this whole test exists for.

--- a/apps/console/src/__tests__/public-block-binding-reach.test.tsx
+++ b/apps/console/src/__tests__/public-block-binding-reach.test.tsx
@@ -262,13 +262,29 @@ const sampleFor = (input: any): unknown => {
 };
 
 /**
- * Mount one block bare and report every data-layer call it made.
+ * What one probe mount observed: every data-layer call the block made, and the
+ * DOM it produced.
+ *
+ * The html half is here because a crash is invisible in `calls` alone —
+ * `SchemaRenderer` catches a renderer's throw and paints an error card, so a
+ * crashed block simply makes no calls, which is the pass condition on the
+ * ledgered branch below. Deliberately the same shape and field names as the
+ * sibling probe's `Mount` (`record-block-record-reach.test.tsx:310-313`), which
+ * has captured both halves from the start for the same reason.
+ */
+interface Mount {
+  calls: string[];
+  html: string;
+}
+
+/**
+ * Mount one block bare and report every data-layer call it made, plus the DOM.
  *
  * The data source is a Proxy so ANY method a block reaches for is recorded
  * rather than crashing it — a block that calls `dataSource.aggregate` must not
  * fail the probe merely because a hand-written stub didn't anticipate it.
  */
-async function dataCallsFor(cfg: any): Promise<string[]> {
+async function dataCallsFor(cfg: any): Promise<Mount> {
   const calls: string[] = [];
   const record = (key: string) =>
     (...args: unknown[]) => {

--- a/apps/console/src/__tests__/record-block-record-reach.test.tsx
+++ b/apps/console/src/__tests__/record-block-record-reach.test.tsx
@@ -196,6 +196,19 @@ const DATA_SOURCE_METHODS = [
  * CONFIGURATION. It is also why {@link assertRendered} exists — a crash must
  * fail loudly rather than land in the "no difference" bucket and read as a
  * finding about the block.
+ *
+ * `add` is the FIFTH instance, and arrived the moment `record:related_list`
+ * started publishing it (objectui#3808). The generic `object` sample is `{}`,
+ * and `{}` is not a valid `add`: the spec makes `picker` required, so the sample
+ * has to carry `picker.object` or the fixture is exercising metadata no author
+ * could publish. Filled here rather than by loosening the generic `object`
+ * sample, which would put an unspecified bag on every future `object` input.
+ *
+ * That `{}` did not merely under-exercise the block, it CRASHED it —
+ * `RelatedList.tsx:1299` dereferences `add.picker.object` where `:378` / `:390`
+ * optional-chain the same path — and the crash is filed as objectui#3838 rather
+ * than papered over here: this fixture's job is to be spec-valid, not to steer
+ * clear of the renderer's unguarded reads.
  */
 const SAMPLE_BY_INPUT: Readonly<Record<string, unknown>> = {
   // On `record:*` this names the RELATED object, not the page's object —
@@ -223,6 +236,11 @@ const SAMPLE_BY_INPUT: Readonly<Record<string, unknown>> = {
   visible: "record.stage === 'qualified'",
   title: 'Probe Alert',
   body: 'Probe alert body',
+  // `record:related_list.add` — spec-valid minimum, i.e. `picker.object` present.
+  // Points at the same child object the rest of this fixture uses, so the Add
+  // affordance is configured against something that exists rather than at a
+  // dangling name.
+  add: { picker: { object: PROBE_CHILD_OBJECT } },
 };
 
 /** Fill one declared input. */

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -6,18 +6,27 @@
  * LICENSE file in the root directory of this source tree.
  *
  * Registry `inputs` <-> `@objectstack/spec` `ComponentPropsMap` parity, for
- * EVERY block that has both (objectui#3797).
+ * EVERY block that has both, in BOTH directions (objectui#3797, objectui#3808).
  *
- * PR #3795 landed this check on one block (`record:highlights`, see
+ * PR #3795 landed both directions on one block (`record:highlights`, see
  * `packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts`).
- * This file is the repo-wide half: it asserts the same direction — a block may
- * not DECLARE a top-level input its spec props schema does not accept — for
- * every entry of `ComponentPropsMap` this repo registers with a non-empty
- * `inputs`.
+ * This file is the repo-wide half, and it carries the same two:
  *
- * WHY THE DIRECTION MATTERS. `inputs` is not documentation, it is the published
- * authoring surface, and four layers are silent about a key that only exists
- * there:
+ *   FORWARD (objectui#3797, PR #3806) — a block may not DECLARE a top-level
+ *   input its spec props schema does not accept.
+ *
+ *   REVERSE (objectui#3808) — a top-level key the spec DOES declare must be
+ *   discoverable from that block's `inputs`.
+ *
+ * Both live in one file on purpose. #3808 exists because PR #3806 shipped only
+ * the forward half repo-wide and the reverse half stayed on the single block
+ * PR #3795 had covered; keeping them side by side, over one `covered` set and
+ * one exemption discipline, is what stops a direction from being forgotten
+ * again.
+ *
+ * WHY THE FORWARD DIRECTION MATTERS. `inputs` is not documentation, it is the
+ * published authoring surface, and four layers are silent about a key that only
+ * exists there:
  *
  *   1. `packages/sdui-parser/scripts/gen-manifest.ts` serializes `inputs` into
  *      `sdui.manifest.json` (the save-gate + parser whitelist) and into
@@ -45,6 +54,26 @@
  * always paired with an issue that resolves the disagreement, never left as a
  * standing licence.
  *
+ * WHY THE REVERSE DIRECTION MATTERS JUST AS MUCH. A key the spec declares, the
+ * renderer honours, and `inputs` omits does not exist as far as an author can
+ * tell — and the same four layers are just as quiet, only inverted:
+ * `gen-manifest.ts` leaves it out of `sdui.manifest.json` and
+ * `sdui-intrinsics.d.ts`, so it is in no designer panel and no `.d.ts`;
+ * `validate.ts:74` does not find it in `comp.inputs` and reports `unknown-prop`
+ * on it; and the renderer honours it anyway. An author who writes it is warned
+ * off a key that works, and an author who doesn't never learns it is there.
+ * That is objectui#3407's original complaint verbatim (`readonly` was enforced
+ * by the HeaderHighlight gate and honoured by the renderer — the description
+ * just never mentioned it), and objectui#3808 found it on three more keys plus
+ * one this gate now covers as an exemption.
+ *
+ * The reverse direction bites non-public blocks too, which is the other reason
+ * coverage is not limited to `PUBLIC_BLOCKS`: `element:text_input` never reaches
+ * `sdui.manifest.json`, but `page.tsx:462` builds the JSX-page compiler's prop
+ * whitelist from `getKnownTypes()` + these same `inputs`, so its undeclared
+ * `defaultValue` was a live `unknown-prop` warning on a key the renderer seeded
+ * page variables from.
+ *
  * WHY IT LIVES HERE. The check needs the FULL registration graph — the same one
  * that produces the published artifacts. `dev/manifest-dump.tsx` builds them
  * from `src/register-plugins.ts` plus `@object-ui/components`, so this file
@@ -68,12 +97,29 @@
  * DELETED rather than kept — the last test in this file turns a no-longer-needed
  * exemption red, so the list cannot rot into a permanent allowlist.
  *
- * LIMIT — worth knowing before trusting a pass. This gate can only see TOP-LEVEL
- * keys. An `inputs` entry of type `array`/`object` declares no member shape
- * (`ComponentInput` has no slot for one), so a drifted key INSIDE an array
- * element is invisible here; making that machine-readable is its own change
- * across types/core/sdui-parser and is tracked separately (PR #3795's open
- * question). A pass means the top-level surface is in parity, nothing more.
+ * LIMIT — worth knowing before trusting a pass. This gate compares TOP-LEVEL
+ * KEY NAMES and nothing else. Three things it therefore cannot see, all of them
+ * real and all filed:
+ *
+ *   - member shapes. An `inputs` entry of type `array`/`object` declares no
+ *     member shape (`ComponentInput` has no slot for one), so a drifted key
+ *     INSIDE an array element or nested object is invisible here — which is why
+ *     `record:details.sections`, `record:highlights.fields` and
+ *     `record:related_list.add` publish their members in prose and are pinned by
+ *     per-block tests next to their renderers. PR #3795's open question;
+ *   - types. `ComponentInput.type` is one coarse control kind and cannot spell a
+ *     spec union, so a key can be in perfect NAME parity while publishing a
+ *     narrower type than the contract accepts (objectui#3832);
+ *   - `retiredKey()` tombstones. `Object.keys(shape)` still contains a key the
+ *     spec rejects BY NAME, and the two directions then fail opposite ways —
+ *     forward reads the tombstone as "accepted" and goes falsely GREEN, reverse
+ *     reads it as "declared" and would demand the block publish it, going
+ *     falsely RED. Dormant today (zero tombstones in the pinned rc.5) and fixed
+ *     in one place — narrowing `specTopLevelKeys` — for both directions at once:
+ *     objectui#3809. Until then the reverse direction's exemptions for the
+ *     `element:record_picker` trio are what absorb the red, and they say so.
+ *
+ * A pass means the top-level key names are in parity, nothing more.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -113,6 +159,35 @@ function declaredInputs(type: string): string[] | null {
 function offSpecInputs(type: string): string[] {
   const allowed = new Set(specTopLevelKeys(type));
   return (declaredInputs(type) ?? []).filter((name) => !allowed.has(name));
+}
+
+/**
+ * Spec keys that no block is expected to publish, with the reason — applied to
+ * every block rather than repeated as one exemption entry per block.
+ *
+ * Only `aria` qualifies, and only because the reason is genuinely uniform: it is
+ * an accessibility escape hatch, not a layout choice, and the blocks that omit
+ * it say so in the same words at their registration sites
+ * (`plugin-detail/src/index.tsx:335-337`, verbatim: "`aria` is omitted for the
+ * same reason it is omitted on `record:details` above"). Publishing it would put
+ * an `aria` object in every designer panel and every generated `.d.ts` as though
+ * hand-writing ARIA were the normal way to configure a block, when the renderers
+ * derive their accessible names from labels and object metadata. A key whose
+ * reason is per-block belongs in `UNPUBLISHED_EXEMPTIONS` below, not here.
+ */
+const GLOBALLY_UNPUBLISHED_SPEC_KEYS: Record<string, string> = {
+  aria: 'Accessibility escape hatch, not a layout choice — renderers derive accessible names from labels and object metadata, and every block omits it for this one reason (plugin-detail/src/index.tsx:335-337). objectui#3808.',
+};
+
+/**
+ * Top-level keys this block's spec props schema declares that its `inputs` do
+ * not publish — the reverse direction (objectui#3808).
+ */
+function undiscoverableSpecKeys(type: string): string[] {
+  const declared = new Set(declaredInputs(type) ?? []);
+  return specTopLevelKeys(type).filter(
+    (key) => !declared.has(key) && !(key in GLOBALLY_UNPUBLISHED_SPEC_KEYS),
+  );
 }
 
 /**
@@ -270,8 +345,121 @@ const OFF_SPEC_EXEMPTIONS: Record<string, string> = {
     'Already declared upstream by objectstack#5775; flagged only because the pinned @objectstack/spec@17.0.0-rc.5 predates it. Delete this entry when the pin moves.',
 };
 
+/**
+ * Spec-declared top-level keys deliberately NOT published, each with the reason.
+ * Key format: `BLOCK.KEY`. The reverse direction's half of the same discipline
+ * as `OFF_SPEC_EXEMPTIONS` above: explicit, reasoned, issue-backed, and deleted
+ * by a failing test once it stops describing anything.
+ *
+ * The bar for an entry is NOT "we haven't got round to it". A spec key the
+ * renderer HONOURS and `inputs` omits is a plain defect and gets declared —
+ * that is what objectui#3808 did to `record:details.hideFields`,
+ * `record:related_list.relationshipValueField`, `record:related_list.add` and
+ * `element:text_input.defaultValue`. The bar is that publishing the key would
+ * itself be wrong or premature, and WHICH of those it is has to be named:
+ *
+ *   - the renderer does not read it, so publishing it would advertise
+ *     configuration the platform silently drops (the objectui#3797 direction, in
+ *     reverse) — the choice between wiring it and declaring it with a KNOWN GAP
+ *     is a contract decision, not an implementation detail;
+ *   - the spec rejects it by name upstream already and only a stale pin still
+ *     lists it;
+ *   - the key is out of the dispatched scope of the change that added this gate,
+ *     and its own issue owns it.
+ *
+ * Every reason cites an issue, which `references a tracking issue` asserts.
+ * Verified against renderer read sites at objectui `origin/main` @ `c85268256`
+ * with `@objectstack/spec@17.0.0-rc.5` — not assumed from the spec's wording.
+ */
+const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
+  // ── B class — spec declares it, NO renderer read point at all (2 keys) ─────
+  // The instinct here is to add an input, and it is wrong: that publishes a key
+  // the platform drops on the floor, which is exactly the defect objectui#3797
+  // spent a repo-wide gate closing. The other instinct — wire it — is a visual
+  // decision (where an icon sits next to RecordTitleChip; whether a card grows
+  // an actions area, which reaches into `renderers/action/**`). The third option
+  // is the `record:activity.showSubscriptionToggle` precedent: declare it and
+  // say NOT IMPLEMENTED in the description, so both directions are in parity and
+  // the author is told. Three viable shapes, one public contract — filed as
+  // objectui#3829 rather than guessed at here.
+  'page:header.icon':
+    'Spec declares it; PageHeaderRenderer has NO read point — `icon` in containers.tsx:822-1570 is only ever per-action (`action.icon`, :1321/:1365) or a nav item (:604). Wire it, or declare it with a KNOWN GAP per the showSubscriptionToggle precedent: objectui#3829.',
+  'page:card.actions':
+    'Spec declares it; PageCardRenderer (containers.tsx:666-695) renders title/body/footer only and never reads `actions`. Wire it, or declare it with a KNOWN GAP per the showSubscriptionToggle precedent: objectui#3829.',
+
+  // ── page:tabs.type — the carrier collision, from the other side ────────────
+  // The mirror image of the `page:tabs.tabStyle` exemption in
+  // `OFF_SPEC_EXEMPTIONS` above, and the same single fact seen twice: the spec
+  // spells this concept `type`, the flat SDUI carrier cannot express it (a flat
+  // node is `{ type: 'page:tabs', … }` where `type` is the dispatch tag, and
+  // `SchemaRenderer.tsx:251-270` deliberately refuses to hoist
+  // `properties.type`), and `validate.ts` lists `'type'` in `BASE_PROPS` so it
+  // is skipped as a base prop and could not be validated as an input even if
+  // declared. Publishing it would advertise a key this repo's own parser cannot
+  // check, on a spelling the carrier cannot carry. Convergence is upstream.
+  'page:tabs.type':
+    "Spec's spelling of the tabStyle concept; unpublishable in the flat carrier (`type` is the dispatch key, SchemaRenderer.tsx:251-270) and unvalidatable as an input (validate.ts BASE_PROPS). The renderer does read it when it survives as `properties.type` (containers.tsx:381). Upstream contract decision: objectstack#6776.",
+
+  // ── element:record_picker — retired upstream, stale pin only (3 keys) ──────
+  // objectstack#5775 (ADR-0087 D2) turned these three into `retiredKey()`
+  // tombstones, converging on the `labelField` / `valueField` this renderer
+  // actually reads (`renderers/basic/record-picker.tsx:80-81`). Declaring a key
+  // the spec has retired is the objectui#3797 direction again.
+  //
+  // TWO THINGS THE PIN BUMP WILL DO HERE, and objectui#3808 got the first of
+  // them wrong, so it is written out:
+  //   1. these three do NOT vanish from `Object.keys(shape)`. ADR-0087 D2
+  //      retirement REPLACES the entry with `z.never().optional()`, it does not
+  //      delete it — so they stay "declared" to this gate and these exemptions
+  //      stay live rather than going stale. They resolve when objectui#3809's
+  //      tombstone recognition narrows `specTopLevelKeys`, not when the pin
+  //      moves;
+  //   2. `sort` / `limit` / `emptyText` — which #5775 ADDS and this renderer
+  //      already reads (`record-picker.tsx:79/80` and `:170`) — become brand-new
+  //      A-class gaps, and this gate will go RED demanding them. That red is
+  //      correct and wanted: it is the pin bump's own reminder to declare them,
+  //      the way `record:details.hideFields` was declared here.
+  'element:record_picker.displayField':
+    'Retired upstream by objectstack#5775 (ADR-0087 D2 tombstone, converging on the `labelField` this renderer reads); declaring it would publish a key the spec rejects by name. Listed here only because the pinned @objectstack/spec@17.0.0-rc.5 predates the retirement. Resolves via objectui#3809, not via the pin bump.',
+  'element:record_picker.searchFields':
+    'Retired upstream by objectstack#5775 (ADR-0087 D2 tombstone); declaring it would publish a key the spec rejects by name. Listed here only because the pinned @objectstack/spec@17.0.0-rc.5 predates the retirement. Resolves via objectui#3809, not via the pin bump.',
+  'element:record_picker.multiple':
+    'Retired upstream by objectstack#5775 (ADR-0087 D2 tombstone); declaring it would publish a key the spec rejects by name. Listed here only because the pinned @objectstack/spec@17.0.0-rc.5 predates the retirement. Resolves via objectui#3809, not via the pin bump.',
+
+  // ── element:record_picker.filter — a real A-class gap, out of scope here ───
+  // The renderer DOES read it (`record-picker.tsx:78`, `ds.filter ?? props.filter`,
+  // into `query.$filter` at :103) and the spec DOES declare it, so by the bar
+  // above this key should be declared, not exempted. It is exempted because
+  // objectui#3808's own three-class triage never sorted it into A, B or C — it
+  // appears in that issue's raw key dump and then in none of the three lists —
+  // so it fell outside the dispatched scope of the change that added this gate.
+  // Filed as objectui#3830 with the same evidence, rather than widened into a
+  // PR nobody reviewed for it.
+  'element:record_picker.filter':
+    'A genuine A-class gap (renderer reads it at record-picker.tsx:78 → query.$filter at :103), not a deliberate omission — it fell out of objectui#3808\'s three-class triage and so out of that PR\'s scope. Owned by objectui#3830; delete this entry when it declares the input.',
+
+  // ── targetVariable — the spec's own "declarative hint" (2 keys) ────────────
+  // Zero read points repo-wide (`grep -rn targetVariable packages/ apps/` is
+  // empty), and that is by design, not drift: the spec's describe says the live
+  // binding resolves via the variable whose `source` equals the component id,
+  // which is exactly what `usePageVariableBinding(schema?.id)` does
+  // (`text-input.tsx:60`). So publishing it is neither a fix nor a defect — it
+  // is a judgement about whether to publish an intent-only key, with a concrete
+  // risk on the publish side (an author who writes only `targetVariable` and no
+  // variable `source` gets an input that writes nowhere, silently).
+  'element:text_input.targetVariable':
+    "Spec's own declarative hint with zero read points repo-wide; the live binding is the reverse lookup in usePageVariableBinding(schema.id) (text-input.tsx:60). Whether to publish an intent-only key is an open judgement: objectui#3834.",
+  'element:record_picker.targetVariable':
+    "Spec's own declarative hint with zero read points repo-wide; the live binding is the reverse lookup by component id, as on element:text_input. Whether to publish an intent-only key is an open judgement: objectui#3834.",
+};
+
 const exemptedFor = (type: string): string[] =>
   Object.keys(OFF_SPEC_EXEMPTIONS)
+    .filter((key) => key.startsWith(`${type}.`))
+    .map((key) => key.slice(type.length + 1));
+
+const unpublishedExemptedFor = (type: string): string[] =>
+  Object.keys(UNPUBLISHED_EXEMPTIONS)
     .filter((key) => key.startsWith(`${type}.`))
     .map((key) => key.slice(type.length + 1));
 
@@ -335,5 +523,97 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
       return !offSpecInputs(type).includes(input);
     });
     expect(stale).toEqual([]);
+  });
+
+  // ── the REVERSE direction (objectui#3808) ──────────────────────────────────
+  //
+  // Same `covered` set, same derived-not-restated expectations, same exemption
+  // discipline — only the subtraction is turned round: spec keys minus declared
+  // inputs, instead of declared inputs minus spec keys.
+
+  it('every globally unpublished key is a real spec key on a covered block', () => {
+    // Non-vacuity for the blanket exclusion. `aria` is subtracted from EVERY
+    // block's expected surface, so a typo there (or the spec renaming the key)
+    // would quietly stop excluding anything while still reading as a documented
+    // decision — and, worse, would make the per-block assertion below start
+    // demanding an `aria` input on fifteen blocks for a reason nobody wrote down.
+    //
+    // Non-empty FIRST: a `for` over an emptied map — and the reason check below —
+    // both pass on nothing, so the map's own existence is the first assertion.
+    expect(Object.keys(GLOBALLY_UNPUBLISHED_SPEC_KEYS).length).toBeGreaterThan(0);
+    for (const key of Object.keys(GLOBALLY_UNPUBLISHED_SPEC_KEYS)) {
+      const carriers = covered.filter((type) => specTopLevelKeys(type).includes(key));
+      expect(carriers.length, `no covered block's spec declares "${key}"`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every globally unpublished key states a reason and references a tracking issue', () => {
+    const unjustified = Object.entries(GLOBALLY_UNPUBLISHED_SPEC_KEYS)
+      .filter(([, reason]) => !/#\d+/.test(reason))
+      .map(([key]) => key);
+    expect(unjustified).toEqual([]);
+  });
+
+  it.each(covered)('%s publishes every top-level key its spec props schema declares', (type) => {
+    const exempt = new Set(unpublishedExemptedFor(type));
+    const undiscoverable = undiscoverableSpecKeys(type).filter((key) => !exempt.has(key));
+    expect(undiscoverable).toEqual([]);
+  });
+
+  it('every unpublished-key exemption names a key the spec really declares', () => {
+    // The dangling check, in the reverse direction. Two ways to be wrong here,
+    // and both read as deliberate cover while licensing nothing: a typo'd key,
+    // and an entry for a block this gate does not judge.
+    const dangling = Object.keys(UNPUBLISHED_EXEMPTIONS).filter((key) => {
+      const dot = key.indexOf('.');
+      const type = key.slice(0, dot);
+      const specKey = key.slice(dot + 1);
+      return !covered.includes(type) || !specTopLevelKeys(type).includes(specKey);
+    });
+    expect(dangling).toEqual([]);
+  });
+
+  it('every unpublished-key exemption states a reason and references a tracking issue', () => {
+    // The discipline that separates "deliberately not published, and here is who
+    // owns the decision" from "we forgot". Four of the nine entries below exist
+    // only because objectui#3829 / #3830 / #3834 were opened to own them.
+    const unjustified = Object.entries(UNPUBLISHED_EXEMPTIONS)
+      .filter(([, reason]) => !/#\d+/.test(reason))
+      .map(([key]) => key);
+    expect(unjustified).toEqual([]);
+  });
+
+  it('carries no stale unpublished-key exemption — a published key must lose its entry', () => {
+    // Keeps the reverse list from rotting the same way. An entry goes stale when
+    // the block declares the input (objectui#3829/#3830/#3834 landing) or when
+    // the spec genuinely deletes the key — note that ADR-0087 D2 retirement is
+    // NOT a deletion, so the `element:record_picker` trio does not go stale on
+    // the pin bump; objectui#3809 is what resolves those.
+    const stale = Object.keys(UNPUBLISHED_EXEMPTIONS).filter((key) => {
+      const dot = key.indexOf('.');
+      const type = key.slice(0, dot);
+      const specKey = key.slice(dot + 1);
+      return !undiscoverableSpecKeys(type).includes(specKey);
+    });
+    expect(stale).toEqual([]);
+  });
+
+  it('the four keys objectui#3808 declared are discoverable, block by block', () => {
+    // Named, not just covered by the derived loop above. The derived assertion
+    // would also pass if these four were added to `UNPUBLISHED_EXEMPTIONS`
+    // instead of declared — which is precisely the move #3808 exists to rule
+    // out — so the keys it fixed are pinned by name, and pinned as DECLARED
+    // rather than merely "not failing".
+    const fixed: Array<[string, string]> = [
+      ['record:details', 'hideFields'],
+      ['record:related_list', 'relationshipValueField'],
+      ['record:related_list', 'add'],
+      ['element:text_input', 'defaultValue'],
+    ];
+    for (const [type, key] of fixed) {
+      expect(specTopLevelKeys(type), `${type} spec no longer declares ${key}`).toContain(key);
+      expect(declaredInputs(type) ?? [], `${type} does not publish ${key}`).toContain(key);
+      expect(Object.keys(UNPUBLISHED_EXEMPTIONS)).not.toContain(`${type}.${key}`);
+    }
   });
 });

--- a/packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts
+++ b/packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts
@@ -1,0 +1,131 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `element:text_input` — the published authoring surface stays in parity with
+ * `@objectstack/spec` `ElementTextInputProps` (objectui#3808).
+ *
+ * `text-input.test.tsx` next door already proves the RENDERER seeds a bound page
+ * variable from `defaultValue`. This file proves the complementary and, until
+ * #3808, false half: that an author can find out the key exists.
+ *
+ * WHY THIS BLOCK NEEDED IT MOST. `element:text_input` is deliberately NOT in
+ * `PUBLIC_BLOCKS` ("bare inputs belong to a form, not a page block",
+ * `packages/core/src/registry/public-blocks.ts:80`), so it never reaches
+ * `sdui.manifest.json` and the usual argument — "the manifest advertises it" —
+ * does not apply. Its `inputs` are a live contract anyway:
+ * `renderers/layout/page.tsx:462` builds the JSX-page compiler's prop whitelist
+ * from `getKnownTypes()` plus these same `inputs`, so while `defaultValue` was
+ * undeclared, `sdui-parser/src/validate.ts:74` reported `unknown-prop` for it on
+ * every JSX page — a warning against a key the renderer then went on to honour,
+ * with no way for the author to discover which of the two was right.
+ *
+ * Expectations are derived from the spec at runtime, not restated.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { ElementTextInputPropsSchema } from '@objectstack/spec/ui';
+// Module scope, not a hook: the cold transform is billed to the import phase,
+// which has no test/hook timeout (AGENTS.md §测试纪律, objectui#3010).
+import '../renderers';
+
+type ShapeCarrier = { shape?: unknown; _def?: { shape?: unknown } };
+
+/** Resolve the props object's `.shape` through both spellings, lazy or plain. */
+function specTopLevelKeys(): string[] {
+  const carrier = ElementTextInputPropsSchema as unknown as ShapeCarrier;
+  const shape = carrier.shape ?? carrier._def?.shape;
+  const resolved = typeof shape === 'function' ? (shape as () => object)() : shape;
+  return resolved && typeof resolved === 'object' ? Object.keys(resolved) : [];
+}
+
+const config = () => ComponentRegistry.getConfig('element:text_input');
+const inputs = () => config()?.inputs ?? [];
+const inputNames = () => inputs().map((i) => i.name);
+const input = (name: string) => inputs().find((i) => i.name === name);
+const defaultValueDescription = () => input('defaultValue')?.description ?? '';
+
+describe('element:text_input — registry inputs vs @objectstack/spec', () => {
+  it('is registered with a non-empty `inputs` surface', () => {
+    expect(config()).toBeDefined();
+    expect(inputNames().length).toBeGreaterThan(0);
+  });
+
+  it('resolves a non-empty spec key set', () => {
+    // Guards the probe, not the subject: a Zod internals change would return `[]`
+    // here and make every assertion below vacuously agreeable.
+    expect(specTopLevelKeys().length).toBeGreaterThan(0);
+  });
+
+  it('declares no top-level input the spec does not accept', () => {
+    const allowed = new Set(specTopLevelKeys());
+    expect(inputNames().filter((name) => !allowed.has(name))).toEqual([]);
+  });
+
+  it('publishes `defaultValue`, which the renderer has read all along', () => {
+    // A KEY-reachability claim, so the criterion is that the key SURVIVES the
+    // parse — not that the parse succeeds. This props schema is a strip-mode
+    // `z.object`, so an UNDECLARED key parses green too and is simply absent from
+    // `data` afterwards; asserting `success` alone would prove nothing at all.
+    expect(specTopLevelKeys()).toContain('defaultValue');
+    const parsed = ElementTextInputPropsSchema.safeParse({ defaultValue: 'acme' });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.defaultValue).toBe('acme');
+
+    // The contrast that makes the criterion meaningful: same green parse, key
+    // gone, no diagnostic. That is what `defaultValue` looked like to every
+    // manifest consumer before it was declared here.
+    const undeclared = ElementTextInputPropsSchema.safeParse({ notASpecKey: 1 } as never);
+    expect(undeclared.success).toBe(true);
+    expect(Object.keys(undeclared.data ?? {})).not.toContain('notASpecKey');
+
+    expect(inputNames()).toContain('defaultValue');
+    expect(defaultValueDescription()).not.toBe('');
+  });
+
+  it('names the number arm the coarse `type` cannot express', () => {
+    // The spec's type is the union `string | number`; `ComponentInput.type` is one
+    // coarse control kind, so `'string'` is a real narrowing —
+    // `sdui-parser`'s `checkType` warns `type-mismatch` on `defaultValue={42}`,
+    // which the spec accepts. The narrowing is not the thing being asserted (it
+    // is a `ComponentInput` limit, tracked as objectui#3832); what is asserted is
+    // that the description does not hide it, so an author reaching for a numeric
+    // default knows the key takes one and knows why the warning appears.
+    expect(ElementTextInputPropsSchema.safeParse({ defaultValue: 42 }).success).toBe(true);
+    expect(ElementTextInputPropsSchema.safeParse({ defaultValue: true } as never).success).toBe(false);
+
+    expect(input('defaultValue')?.type).toBe('string');
+    expect(defaultValueDescription()).toMatch(/number/);
+  });
+
+  it('the `defaultValue` description says which of the two behaviours an author gets', () => {
+    // The seeding path and the uncontrolled-input path do different things, and
+    // which one applies depends on something the block does not own: whether a
+    // page variable's `source` points at this component's id. A description
+    // saying only "initial value" would be true and useless — the author of a
+    // form that submits `page.<var>` needs to know the seed happens once, only
+    // while the variable is empty, and that the variable's own default wins.
+    const description = defaultValueDescription();
+    expect(description).toMatch(/source/);
+    expect(description).toMatch(/once/i);
+    expect(description).toMatch(/empty/i);
+  });
+
+  it('carries no `defaultValue` OF ITS OWN on the defaultValue entry', () => {
+    // A `ComponentInput.defaultValue` on this input would publish a default for
+    // the default — the designer would pre-fill a seed value the renderer has no
+    // opinion about, and every text input in the gallery would come up carrying
+    // it. The spec declares no default here either.
+    //
+    // Existence asserted first: `input('defaultValue')?.defaultValue` is also
+    // `undefined` when the input is GONE, so without this line the check would
+    // pass most loudly in the one case it is supposed to notice.
+    expect(input('defaultValue')).toBeDefined();
+    expect(input('defaultValue')?.defaultValue).toBeUndefined();
+    expect(ElementTextInputPropsSchema.safeParse({}).data).not.toHaveProperty('defaultValue');
+  });
+});

--- a/packages/components/src/renderers/basic/text-input.tsx
+++ b/packages/components/src/renderers/basic/text-input.tsx
@@ -131,6 +131,17 @@ ComponentRegistry.register('text_input', ElementTextInputRenderer, {
   skipFallback: true,
   label: 'Text Input',
   category: 'input',
+  // `defaultValue` is DECLARED, not merely honoured (objectui#3808). The
+  // renderer has read it since the seeding effect landed, and the spec declares
+  // it (`ElementTextInputProps.defaultValue`, `string | number`) — but while it
+  // was missing from this list an author could not discover it, and every layer
+  // that reads a manifest said the opposite: `page.tsx`'s JSX-page compiler
+  // builds its prop whitelist from `getKnownTypes()` + these `inputs`, so
+  // `<element-text-input defaultValue="acme">` came back as an `unknown-prop`
+  // warning on a key the renderer then went on to honour. That is objectui#3407
+  // in the same shape as `readonly` — enforced, undiscoverable — and the
+  // reverse half of the parity gate in
+  // `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`.
   inputs: [
     { name: 'label', type: 'string', label: 'Label' },
     { name: 'placeholder', type: 'string', label: 'Placeholder' },
@@ -140,6 +151,30 @@ ComponentRegistry.register('text_input', ElementTextInputRenderer, {
       label: 'Type',
       enum: ['text', 'email', 'number', 'tel', 'url', 'password'],
       defaultValue: 'text',
+    },
+    {
+      name: 'defaultValue',
+      // The spec's type is the union `string | number`, which `ComponentInput`
+      // has no way to spell — its `type` is one coarse control kind. `'string'`
+      // is the arm chosen here (a text input's ordinary case, and the DOM value
+      // is `String(...)`-coerced anyway) and the number arm is named in the
+      // description, following the same call made for the inline-translation
+      // shapes on `page:header.title` / `record:alert.title`. It is a real
+      // narrowing, not a free choice: `sdui-parser`'s `checkType` warns
+      // `type-mismatch` on `defaultValue={42}`, a value the spec accepts. The
+      // limit is `ComponentInput`'s, tracked separately — it is the union twin
+      // of the member-shape limit PR #3795 left open.
+      type: 'string',
+      label: 'Default Value',
+      // Description taken from what the renderer DOES with the key (the seeding
+      // effect above, and the native `defaultValue` pass-through at the
+      // `<Input>`), not from restating the spec's one-liner — the two
+      // behaviours differ depending on whether a page variable targets this
+      // input, and an author who only knew "initial value" would not know which
+      // one they get. No `defaultValue` on this entry: the value IS the default,
+      // so a default-for-the-default would be meaningless.
+      description:
+        'Initial value (string or number). With a page variable bound to this input — a variable whose `source` is this component id — it is pushed into that variable ONCE on mount, and only while the variable is still empty, so `page.<var>` and the submit body carry it before the user types; a variable that declares its own defaultValue wins. With no bound variable it becomes the native input\'s uncontrolled initial value and nothing else reads it.',
     },
     { name: 'required', type: 'boolean', label: 'Required' },
     { name: 'disabled', type: 'boolean', label: 'Disabled' },

--- a/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
@@ -180,6 +180,57 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     expect(offSpec).toEqual([]);
   });
 
+  it('publishes `hideFields`, which the renderer has read all along', () => {
+    // The reverse direction on this block (objectui#3808). `hideFields` was
+    // declared by the spec (objectstack#5611) and read by
+    // `renderers/record-details.tsx:147` while `inputs` omitted it, so the
+    // manifest, the generated `.d.ts` and the designer panel all said the key
+    // did not exist and `sdui-parser` reported `unknown-prop` on an author who
+    // wrote it anyway — while the renderer honoured it. Same shape as `readonly`
+    // in objectui#3407.
+    //
+    // A KEY-reachability claim, so the criterion is that the key SURVIVES the
+    // parse. These props schemas are strip-mode `z.object`s: an undeclared key
+    // is dropped from `data` with no error at all, which is exactly why the gap
+    // was silent — so "it is still there afterwards" is the proof, not
+    // `success === true` (which an undeclared key also gets).
+    expect(specTopLevelKeys()).toContain('hideFields');
+    const parsed = RecordDetailsProps.safeParse({ hideFields: ['phone'] });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.hideFields).toEqual(['phone']);
+
+    expect(inputs().map((i) => i.name)).toContain('hideFields');
+    expect(input('hideFields')?.description ?? '').not.toBe('');
+  });
+
+  it('`hideFields` documents bare names only, because the spec rejects entry objects', () => {
+    // The same fence `fields` is held to below, on the sibling key — and here it
+    // is a VALUE verdict, so the criterion is a full parse either way: the object
+    // spelling has to be rejected on its value, not merely stripped.
+    //
+    // The renderer is more tolerant than the contract at this read site
+    // (`typeof n === 'string' ? n : fieldName(n)`), which is not a second
+    // contract to advertise. Every in-repo producer passes strings
+    // (`synth/buildDefaultPageSchema.ts:557-562` types it `string[]`), so the
+    // tolerant arm is unexercised drift rather than a live dialect.
+    const element = arrayElement(shapeMember(RecordDetailsProps, 'hideFields'));
+    expect(shapeKeys(element)).toEqual([]);
+    expect(RecordDetailsProps.safeParse({ hideFields: ['phone'] }).success).toBe(true);
+
+    const objectForm = RecordDetailsProps.safeParse({ hideFields: [{ name: 'phone' }] });
+    expect(objectForm.success).toBe(false);
+    expect(objectForm.error?.issues.map((i) => i.code)).toContain('invalid_type');
+
+    // Non-empty FIRST. A `not.toContain('{')` on a description that does not
+    // exist passes for the wrong reason — the reverse-verification run for
+    // objectui#3808 deleted the `hideFields` declaration and watched this
+    // assertion stay green on `''` while the three assertions that matter went
+    // red. An empty description is a failure here, not a vacuous pass.
+    const description = input('hideFields')?.description ?? '';
+    expect(description).not.toBe('');
+    expect(description).not.toContain('{');
+  });
+
   it('`fields` documents no entry shape, because the spec accepts bare names only', () => {
     // objectui#3807's fence check on the sibling input at the same call site.
     // Top-level `fields` is `z.array(z.string())`: there is no member shape to

--- a/packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts
@@ -1,0 +1,176 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:related_list` — the published authoring surface stays in parity with
+ * `@objectstack/spec` `RecordRelatedListProps` (objectui#3808).
+ *
+ * Third sibling of `recordHighlightsInputs.spec-parity.test.ts` (objectui#3407 /
+ * PR #3795) and `recordDetailsInputs.spec-parity.test.ts` (objectui#3807), added
+ * for the direction those two carry and the repo-wide gate had not: a top-level
+ * key the SPEC declares must be discoverable from `inputs`.
+ *
+ * This block had the worst instance of it. `relationshipValueField` and `add`
+ * were both spec keys the renderer had honoured all along —
+ * `renderers/record-related-list.tsx:95` and `:186` — while `inputs` published
+ * neither, and nothing anywhere reported the mismatch:
+ * `gen-manifest.ts` left them out of `sdui.manifest.json` and
+ * `sdui-intrinsics.d.ts`, `sdui-parser/src/validate.ts:74` returned
+ * `unknown-prop` for an author who wrote one, and the renderer went on honouring
+ * it. `add` in particular is the ONLY way to build a junction-assignment list,
+ * so the single published route to that feature was an undiscoverable key.
+ *
+ * WHY A DESCRIPTION IS WORTH A TEST, and why `add`'s is checked member by
+ * member: `ComponentInput` is flat by design, so an `object` input can document
+ * its member shape nowhere but its own prose. The assertions below derive the
+ * member list from the spec at runtime, so a spec change fails here rather than
+ * leaving the description quietly incomplete — the failure mode objectui#3807
+ * was filed for.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { RecordRelatedListProps } from '@objectstack/spec/ui';
+import '../index';
+
+type ShapeCarrier = { shape?: unknown; _def?: { shape?: unknown } };
+
+/** Resolve a Zod object's `.shape` through both spellings, lazy or plain. */
+function shapeKeys(schema: unknown): string[] {
+  const carrier = schema as ShapeCarrier | undefined;
+  const shape = carrier?.shape ?? carrier?._def?.shape;
+  const resolved = typeof shape === 'function' ? (shape as () => object)() : shape;
+  return resolved && typeof resolved === 'object' ? Object.keys(resolved) : [];
+}
+
+/**
+ * One entry of `.shape`, unwrapped past the optional/default wrappers until an
+ * object shape is reachable. `add` is `.optional()` and `add.picker` carries
+ * defaults on its own members, so a single `.unwrap()` is not enough.
+ */
+function innerObject(schema: unknown, key: string): unknown {
+  const carrier = schema as ShapeCarrier | undefined;
+  const shape = carrier?.shape ?? carrier?._def?.shape;
+  const resolved = (typeof shape === 'function' ? (shape as () => object)() : shape) as
+    | Record<string, unknown>
+    | undefined;
+  let member = resolved?.[key] as
+    | { shape?: unknown; _def?: { shape?: unknown; innerType?: unknown; type?: unknown } }
+    | undefined;
+  for (let hop = 0; hop < 8; hop += 1) {
+    if (member?.shape ?? member?._def?.shape) return member;
+    const next = member?._def?.innerType ?? member?._def?.type;
+    if (!next || typeof next !== 'object') return member;
+    member = next as typeof member;
+  }
+  return member;
+}
+
+const specTopLevelKeys = (): string[] => shapeKeys(RecordRelatedListProps);
+const specAddKeys = (): string[] => shapeKeys(innerObject(RecordRelatedListProps, 'add'));
+const specPickerKeys = (): string[] =>
+  shapeKeys(innerObject(innerObject(RecordRelatedListProps, 'add'), 'picker'));
+
+const config = () => ComponentRegistry.getConfig('record:related_list');
+const inputs = () => config()?.inputs ?? [];
+const inputNames = () => inputs().map((i) => i.name);
+const input = (name: string) => inputs().find((i) => i.name === name);
+const addDescription = () => input('add')?.description ?? '';
+
+/** A spec-valid related list, so a fixture only ever carries the key under test. */
+const baseline = { objectName: 'task', relationshipField: 'account', columns: ['name'] };
+
+describe('record:related_list — registry inputs vs @objectstack/spec', () => {
+  it('is registered with a non-empty `inputs` surface', () => {
+    expect(config()).toBeDefined();
+    expect(inputNames().length).toBeGreaterThan(0);
+  });
+
+  it('declares no top-level input the spec does not accept', () => {
+    const allowed = new Set(specTopLevelKeys());
+    expect(inputNames().filter((name) => !allowed.has(name))).toEqual([]);
+  });
+
+  it('publishes `relationshipValueField`, which the renderer has read all along', () => {
+    // A KEY-reachability claim, so the criterion is that the key SURVIVES the
+    // parse rather than merely that the parse succeeds. `RecordRelatedListProps`
+    // is a strip-mode `z.object`: an UNDECLARED key also parses green, it is just
+    // silently gone from `data` afterwards — which is exactly how this gap stayed
+    // invisible for as long as it did.
+    expect(specTopLevelKeys()).toContain('relationshipValueField');
+    const parsed = RecordRelatedListProps.safeParse({ ...baseline, relationshipValueField: 'name' });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.relationshipValueField).toBe('name');
+
+    expect(inputNames()).toContain('relationshipValueField');
+  });
+
+  it("`relationshipValueField` publishes the renderer's default, and it matches the read site", () => {
+    // `record-related-list.tsx:95` is `schema.relationshipValueField || 'id'`, and
+    // the input carries `defaultValue: 'id'` to match. Pinned because a default
+    // published on the authoring surface that disagrees with the renderer is
+    // worse than no default: the designer would pre-fill one value and the page
+    // would behave as another, with nothing comparing them.
+    expect(input('relationshipValueField')?.defaultValue).toBe('id');
+
+    // And the spec agrees, so all three say `id`.
+    expect(RecordRelatedListProps.safeParse(baseline).data?.relationshipValueField ?? 'id').toBe('id');
+  });
+
+  it('publishes `add`, the only route to a junction-assignment list', () => {
+    expect(specTopLevelKeys()).toContain('add');
+    const parsed = RecordRelatedListProps.safeParse({
+      ...baseline,
+      add: { picker: { object: 'sys_position' }, linkField: 'position', label: 'Assign' },
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.add?.picker?.object).toBe('sys_position');
+
+    expect(inputNames()).toContain('add');
+    expect(input('add')?.type).toBe('object');
+    expect(addDescription()).not.toBe('');
+  });
+
+  it('every spec member key of `add` is discoverable from its description', () => {
+    // `ComponentInput` has no member-shape slot (the LIMIT the repo-wide gate in
+    // `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` documents),
+    // so this prose is the only published description of the shape. Derived from
+    // the spec at runtime: a member key added upstream fails here instead of
+    // going unmentioned.
+    expect(specAddKeys().length).toBeGreaterThan(0);
+    expect(specPickerKeys().length).toBeGreaterThan(0);
+
+    const description = addDescription();
+    expect(specAddKeys().filter((key) => !description.includes(key))).toEqual([]);
+    expect(specPickerKeys().filter((key) => !description.includes(key))).toEqual([]);
+  });
+
+  it("`add`'s published defaults are the RENDERER's, not the spec's prose", () => {
+    // The one place the two disagree. `RelatedList.tsx:724` defaults
+    // `picker.valueField` to `id` — same as the spec — but `:390` defaults
+    // `picker.labelField` to `name`, where the spec's `.describe()` says it
+    // "defaults to the object title field". The description publishes what the
+    // platform does; publishing the spec's wording would document a behaviour no
+    // code implements.
+    const description = addDescription();
+    expect(description).toMatch(/labelField[^.]*default "name"/);
+    expect(description).not.toMatch(/labelField[^.]*title field/);
+  });
+
+  it('names `picker.filter` as a gap instead of documenting it as a restriction', () => {
+    // The `record:activity.showSubscriptionToggle` precedent applied at member
+    // level. The spec declares `add.picker.filter` ("Restrict which records the
+    // picker offers") and nothing in this repo reads it — `RelatedList` fills
+    // `RecordPickerDialog`'s `objectName` / `displayField` / `columns` and never
+    // its `baseFilter` slot. A description that merely listed `filter` among the
+    // members would tell an author their picker is scoped when it offers every
+    // record; objectui#3831 owns the wiring, and this assertion fails the moment
+    // someone deletes the warning without doing it.
+    expect(specPickerKeys()).toContain('filter');
+    expect(addDescription()).toMatch(/KNOWN GAP/);
+    expect(addDescription()).toMatch(/filter[\s\S]*not applied/);
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -274,6 +274,25 @@ ComponentRegistry.register('details', RecordDetailsRenderer, {
     { name: 'layout', type: 'enum', label: 'Layout', enum: ['auto', 'custom'], defaultValue: 'auto', description: 'auto uses the object highlightFields; custom uses explicit sections' },
     { name: 'sections', type: 'array', label: 'Sections', description: 'Field groups rendered as the detail body, in order. Every entry is an OBJECT — `{ name?, label?, columns?, fields }` — a bare section-id string is NOT accepted (the spec retired that spelling in objectstack#5611, and the renderer reads name/label/fields off each entry, so a string entry renders no fields at all). `fields` (required) are the field names shown in this section, in order. `label` is the section heading; omit it for an untitled, borderless section. `name` is a stable snake_case identifier and the i18n anchor — the heading resolves through objects.<object>._sections.<name>.label, so a section without a name shows its authored label in every locale. `columns` (1-4) is THIS section\'s field-grid width; omit it and the renderer derives the width. Required when layout is "custom", where sections are the only source of the detail body.' },
     { name: 'fields', type: 'array', label: 'Fields', description: 'Explicit field list (overrides highlightFields)' },
+    // `hideFields` is DECLARED, not merely honoured (objectui#3808). The spec
+    // declares it (objectstack#5611) and `RecordDetailsRenderer` has read it
+    // since the highlight-dedup phase (`renderers/record-details.tsx:147`), but
+    // it was missing here — so an author reading the manifest could not
+    // discover it, and every layer that reads the manifest said the opposite:
+    // `sdui.manifest.json` / `sdui-intrinsics.d.ts` omitted it and
+    // `sdui-parser`'s prop walk reported `unknown-prop` on a key the renderer
+    // then honoured. Same failure as `readonly` in objectui#3407.
+    //
+    // Bare field NAMES only. The renderer also tolerates `{name}` / `{field}`
+    // entries (`typeof n === 'string' ? n : fieldName(n)` at the read site), but
+    // `hideFields` is `z.array(z.string())` in the spec and rejects those values
+    // on parse — teaching them here would publish a second dialect the contract
+    // refuses, the same fence `fields` above is held to.
+    //
+    // The "hiding every field drops the section" sentence is read off
+    // `DetailSection.tsx:439` (`visibleFields.length === 0 &&
+    // emptyCount === section.fields.length` returns null), not assumed.
+    { name: 'hideFields', type: 'array', label: 'Hide Fields', description: 'Field names to omit from the body — applied to the top-level `fields` list AND to every section\'s `fields`. Bare field names only. Authors rarely need it: the synth pipeline fills it with the fields already shown in `record:highlights`, and hand-authored pages get the same dedup live from HighlightFieldsContext, so its purpose is suppressing a field you do not want repeated (the page H1 title field is dropped for you too). Hiding every field of a section leaves that section out entirely.' },
   ],
 });
 
@@ -284,9 +303,20 @@ ComponentRegistry.register('related_list', RecordRelatedListRenderer, {
   label: 'Related List',
   icon: 'List',
   // Mirrors @objectstack/spec RecordRelatedListProps.
+  //
+  // `relationshipValueField` and `add` are DECLARED, not merely honoured
+  // (objectui#3808). Both are spec keys this renderer has read all along —
+  // `renderers/record-related-list.tsx:95` and `:186` — while `inputs` omitted
+  // them, so the published surface and the runtime disagreed in the direction
+  // nothing reports: `sdui.manifest.json` / `sdui-intrinsics.d.ts` never
+  // mentioned them, `sdui-parser`'s prop walk raised `unknown-prop` on an
+  // author who wrote one anyway, and the renderer honoured it regardless. `add`
+  // in particular is not cosmetic — without it declared, the ONLY published way
+  // to build a junction-assignment list was to write an undiscoverable key.
   inputs: [
     { name: 'objectName', type: 'string', label: 'Related Object', required: true, description: 'Related object name (e.g. "task")' },
     { name: 'relationshipField', type: 'string', label: 'Relationship Field', required: true, description: 'Field on the related object pointing back to this record' },
+    { name: 'relationshipValueField', type: 'string', label: 'Relationship Value Field', defaultValue: 'id', description: 'Which field OF THIS PARENT record `relationshipField` stores. Defaults to "id"; set it to the field a name-keyed junction points at (e.g. "name" when sys_user_position.position holds sys_position.name). The resolved value drives three things at once — the list filter, the Add-picker link value, and the pre-filled create form — so they cannot drift apart. While the parent record is still loading, a non-"id" field resolves to null and the list holds its fetch rather than querying on an empty value.' },
     { name: 'columns', type: 'array', label: 'Columns', required: true, description: 'Fields to display in the related list' },
     { name: 'sort', type: 'array', label: 'Sort' },
     { name: 'limit', type: 'number', label: 'Limit', defaultValue: 5, description: 'Records to display initially' },
@@ -294,6 +324,29 @@ ComponentRegistry.register('related_list', RecordRelatedListRenderer, {
     { name: 'title', type: 'string', label: 'Title' },
     { name: 'showViewAll', type: 'boolean', label: 'Show "View All"', defaultValue: true },
     { name: 'actions', type: 'array', label: 'Actions', description: 'Action IDs available for related records' },
+    // `add` publishes its MEMBER shape in prose for the reason the sibling
+    // array-of-objects inputs do (`record:details.sections`,
+    // `record:highlights.fields`, `record:path.stages`): `ComponentInput` is flat
+    // by design and has no slot for a member shape, so an `object` input can
+    // only document its members here.
+    //
+    // Documented members are exactly the spec's — `picker.object`,
+    // `picker.valueField`, `picker.labelField`, `linkField`, `label` — with each
+    // default taken from the RENDERER, which is where an author's expectation
+    // gets settled: `RelatedList.tsx:724` defaults `picker.valueField` to `id`
+    // (matching the spec's own default) but `:390` defaults `picker.labelField`
+    // to `name`, NOT to the object's title field as the spec's `.describe()`
+    // says. Publishing the spec's wording there would have been a description
+    // the platform does not honour.
+    //
+    // `picker.filter` is deliberately NOT documented as working: the spec
+    // declares it, and nothing in this repo reads it — `RelatedList` passes
+    // `picker.object` / `labelField` to `RecordPickerDialog` and never fills its
+    // `baseFilter` slot. Naming it here as a gap follows the
+    // `record:activity.showSubscriptionToggle` precedent above; silently
+    // documenting it as a restriction would tell an author their picker is
+    // scoped when it offers every record.
+    { name: 'add', type: 'object', label: 'Add Existing', description: 'Adds an "Add" button that assigns EXISTING records instead of creating one — the m2m/junction case. Shape: `{ picker: { object, valueField?, labelField?, filter? }, linkField?, label? }`. `picker.object` (required) is the object whose records the dialog offers. `picker.valueField` is the field of the picked record used as the link value (default "id"); `picker.labelField` is the column shown in the picker rows (default "name", and the other columns are derived from that object\'s schema). With `linkField` set, selecting records CREATES rows in this list\'s own object as `{ [relationshipField]: parentValue, [linkField]: pickedId }` — the junction case; omit `linkField` and the picked child is RE-PARENTED instead, by setting its own `relationshipField` to this parent. `label` is the button text (default "Add", localizable inline). Setting `add` also enables generic link removal on rows when no host delete handler is wired. KNOWN GAP: `picker.filter` is accepted by the spec but not applied — the dialog offers every record of `picker.object` whatever you put there.' },
   ],
 });
 


### PR DESCRIPTION
Fixes #3808

PR #3806 把全仓 parity 门只推了**一个方向**(「registry 不得声明 spec 不接受的顶层 input」);PR #3795 的单块版有**两个**,另一个「spec 声明的键必须能从 `inputs` 被发现」没跟出来。本 PR 把反方向补上(同一个 `covered` 集合、同一套豁免纪律、同一个文件),并修掉它找出来的 A 类缺口。

## A 类逐键对照(渲染器读点实读,非按 spec 措辞推断)

pin 版 `@objectstack/spec@17.0.0-rc.5`,基线 `origin/main` @ `c85268256`。

| 键 | spec 声明 | 渲染器读点 | 原 `inputs` | 本 PR |
|---|---|---|---|---|
| `record:details.hideFields` | ✅ `z.array(z.string())`(objectstack#5611) | `renderers/record-details.tsx:147` | ❌ | ✅ 声明 |
| `record:related_list.relationshipValueField` | ✅ 默认 `'id'` | `renderers/record-related-list.tsx:95` | ❌ | ✅ 声明,`defaultValue: 'id'` |
| `record:related_list.add` | ✅ `picker` 必填 | `renderers/record-related-list.tsx:186` / `:231` | ❌ | ✅ 声明 + 成员形状写进 description |
| `element:text_input.defaultValue` | ✅ `string \| number` | `renderers/basic/text-input.tsx:73/76/119` | ❌ | ✅ 声明 |

四条都是 #3407 的同一失效:manifest 与生成的 `.d.ts` 不提这个键 → 设计器面板里不存在;`sdui-parser/src/validate.ts:74` 在 `comp.inputs` 里找不到它 → 对照写了这个键的作者报 `unknown-prop`;渲染器照样兑现。三个答案。

`element:text_input` 不在 `PUBLIC_BLOCKS`(`public-blocks.ts:80` 有成文理由),所以它的缺口**不在** `sdui.manifest.json`,而在 JSX 页面编译器的白名单 —— `renderers/layout/page.tsx:462` 用 `getKnownTypes()` + 同一份 `inputs` 现搭那份 manifest。manifest 链实跑(不落盘)确认:

```
published blocks: 57
PUBLISHED record:details.hideFields:                    block=yes input=yes type=array  desc=492 chars
PUBLISHED record:related_list.relationshipValueField:   block=yes input=yes type=string desc=501 chars
PUBLISHED record:related_list.add:                      block=yes input=yes type=object desc=1075 chars
PUBLISHED element:text_input.defaultValue:              block=NO (non-public tier) input=no
runtime blocks: 505
RUNTIME  record:details.hideFields:                    block=yes input=yes type=array
RUNTIME  record:related_list.relationshipValueField:   block=yes input=yes type=string
RUNTIME  record:related_list.add:                      block=yes input=yes type=object
RUNTIME  element:text_input.defaultValue:              block=yes input=yes type=string
RUNTIME  element:record_picker.filter:                 block=yes input=no      ← 见豁免 #3830
```

## `record:related_list.add` 的核对结论:A 类,同修

#3808 正文写「也可能属于这一类,没细查」。细查结论是**属于**,而且是四条里最要紧的一条:`add` 是构建 junction 指派列表的**唯一**途径,不声明就等于那个功能只能靠写一个不可发现的键来用。三个成员键渲染器全兑现(`RelatedList.tsx:378` / `:390` / `:724`),第四个不兑现。

description 从渲染器取材而非照抄 spec,三处刻意的差异:

1. **`picker.labelField` 的默认值**写 `name`(`RelatedList.tsx:390`),**不写** spec `.describe()` 说的「the object title field」—— 后者没有任何代码实现;
2. **`picker.filter` 写成 KNOWN GAP**:spec 声明「Restrict which records the picker offers」,全仓零读点(`RelatedList` 把 `picker.object` / `labelField` 传给 record picker 对话框,从不填它的 `baseFilter`)。按 `record:activity.showSubscriptionToggle` 先例把 gap 说出口 —— 静默把它列进成员清单,等于告诉作者候选被限定了,而实际上对话框提供全部记录。接线另开 #3831;
3. **`hideFields` 只教裸字段名**:渲染器容忍 `{name}` / `{field}` 条目,spec 是 `z.array(z.string())` 按值拒绝,教那种拼法就是发布一种契约拒收的方言(与同文件 `fields` 同一道围栏)。

## 反方向门:豁免名单全文(9 条,逐条理由 + tracking issue)

`aria` 走**全局**排除(理由统一:无障碍逃生口,不是布局选项,15 个 block 同一个理由,`plugin-detail/src/index.tsx:335-337` 已成文),并有非空 + 「确实是某个 covered block 的 spec 键」双重非空洞断言。其余逐条:

**B 类 —— spec 声明、渲染器零读点(2 条,⛔ 不许无脑补 input)→ #3829**

| 键 | 证据 |
|---|---|
| `page:header.icon` | `containers.tsx:822-1570` 里 `icon` 只出现在**每个 action 自己的** `action.icon`(`:1321`/`:1365`)与导航项 `item.icon`(`:604`);block 自己的 `icon` 零读点 |
| `page:card.actions` | `PageCardRenderer`(`containers.tsx:666-695`)只渲染 title / body(或 children)/ footer |

补 input 会发布一个平台默默丢掉的键 —— 正是 #3797 修的方向;接线是视觉决定(且 `page:card.actions` 会伸进 `renderers/action/**`,PR #3825 刚动过);第三条路是 `showSubscriptionToggle` 先例(声明 + KNOWN GAP)。三种形状、一个公开契约,另立 #3829。

**载体冲突(1 条)→ objectstack#6776**

| 键 | 理由 |
|---|---|
| `page:tabs.type` | 与同文件正方向的 `page:tabs.tabStyle` 豁免是同一事实的两面:扁平载体里 `type` 是分发键(`SchemaRenderer.tsx:251-270` 明确拒绝 hoist),且 `validate.ts` 的 `BASE_PROPS` 含 `'type'`,声明了也校验不到 |

**ADR-0087 墓碑(3 条)→ objectstack#5775 + #3809**

`element:record_picker` 的 `displayField` / `searchFields` / `multiple`。**顺带纠正 #3808 正文的一处错误**:它写这三个键「pin 升上来后会从 spec 的接受集消失」。按 #3809 的机制这是错的 —— ADR-0087 D2 的退役是**替换成 `z.never().optional()`,不是删条目**,`Object.keys(shape)` 照样包含它们。所以这三条豁免**不会**随 pin 升级自动过期,只会随 #3809 的墓碑识别落地而过期,豁免理由里逐条写明了。

同一个盲区在两个方向的症状相反(正方向假绿、反方向**假红**:门会要求本仓去声明一个按名被拒的键,照做则正方向立刻红),已写进门的 LIMIT 段落并在 #3809 补了评论。

**declarative hint(2 条)→ #3834**

`element:record_picker.targetVariable` / `element:text_input.targetVariable`。`grep -rn targetVariable packages/ apps/` **零命中** —— 不是「读了没用上」,是这个标识符全仓没出现过;真正的绑定是 `usePageVariableBinding(schema?.id)` 按组件 id 反查 `PageVariableSchema.source`,与 spec 自己的 describe 一致。发布与否是判断题(发布的风险很具体:只写 `targetVariable` 不写变量 `source` 的作者会得到一个什么都不写入的输入)。

**新发现的第 4 个 A 类,超出本单派发范围(1 条)→ #3830**

`element:record_picker.filter`。渲染器实读(`record-picker.tsx:78` 的 `ds.filter ?? props.filter` → `:103` 的 `query.$filter`)、spec 已声明、`inputs` 不提 —— 与本 PR 修的四条完全同形。它在 #3808 的原始 key dump 里出现过,却**没有被归入 A / B / C 任何一类**(正文自称 15 条、逐行相加实为 13 条,C 类小计写 5 条实为 6 条,掉的就是它),因此落在派发范围之外。按 Prime Directive #10 另开 #3830 + 带理由豁免,而不是在没人为它做过 review 的 PR 里扩面。

**`emptyText` / `sort` / `limit`**(本仓实读、pin 版 spec 未声明、objectstack#5775 已声明)在墓碑那段的注释里记档:pin 一升它们变成**新的 A 类**,门会**报红要它们** —— 这个红是对的、是想要的,就是 pin 升级自带的提醒。

## 反向验证(方向先判后跑,四次)

**1. 去掉任一新声明 → 门红(预判:红。命中)**

删 `record:details.hideFields` 的声明:

```
× publishes `hideFields`, which the renderer has read all along
× record:details publishes every top-level key its spec props schema declares
× the four keys objectui#3808 declared are discoverable, block by block
AssertionError: expected [ 'hideFields' ] to deeply equal []
AssertionError: record:details does not publish hideFields
 Tests  3 failed | 48 passed (51)
```

三处一起红:派生的全仓门、按名钉住的那条、块级 parity。**这一跑还抓出一个空绿**:同文件的「`hideFields` 只教裸名」断言在声明被删后**仍然绿**,因为 `not.toContain('{')` 对 `''` 恒真。已加 `expect(description).not.toBe('')` 前置,并在注释里写明是这次反向验证发现的。

**2. 豁免塞无理由条目 → 豁免纪律断言红(预判:恰好一条红。命中)**

把 `page:tabs.type` 的理由改成不含 issue 号:

```
× every unpublished-key exemption states a reason and references a tracking issue
AssertionError: expected [ 'page:tabs.type' ] to deeply equal []
 Tests  1 failed | 41 passed (42)
```

**3. 给已声明的键塞豁免 → 陈旧豁免 + 按名钉住 两条红(预判:2 条。命中)**

```
× carries no stale unpublished-key exemption — a published key must lose its entry
× the four keys objectui#3808 declared are discoverable, block by block
AssertionError: expected [ 'record:details.hideFields' ] to not include 'record:details.hideFields'
 Tests  2 failed | 40 passed (42)
```

第二条是刻意的:它把「用豁免代替声明」这条退路堵死 —— 派生断言本身对「补进豁免名单」也会绿,而那正是本单要排除的动作。

**4. `public-block-binding-reach` 的崩溃守卫 —— 预判红,实测绿,按实情记账**

把那里的 `add` 样本退回 `{}`,预判它会触发新加的崩溃守卫。**实测 16 个全绿**。原因查清了:`renderers/record-related-list.tsx:185` 传的是 `dataSource={ctx?.dataSource}`,这个探针不带 RecordContext,于是 `RelatedList` 收到 `dataSource: undefined`,`:1293` 的 `add && dataSource` 短路,裸取根本到不了。所以那条守卫今天是**防御性的、不是承重的**,已在注释里如实写明(而不是留一句「它会红」)。守卫的判据本身可用 —— 把它同时加到两个分支上时,它报出了 #3840 里那两个崩溃。

崩溃本身是真的,在**兄弟探针**里实测到(那个探针带 RecordContext + dataSource):

```
Component "record:related_list" failed to render
Cannot read properties of undefined (reading 'object')
```

## 两个 console 探针的 fixture 处置

两者都按声明**自动生成** fixture,`type: 'object'` 的通用样本是 `{}`。`add` 一旦成为声明的 `object` 输入,它们就拿到了 `{}` —— 而 `{}` 不是合法的 `add`(spec 里 `picker` 必填)。按 fixture 三分法这属于「补声明」:重新拼写暴露出 fixture 本来就不 spec 合法,补上缺失的必填键。

- `record-block-record-reach.test.tsx`:样本补成 `{ picker: { object: PROBE_CHILD_OBJECT } }`。头注释里这是该文件记录的**第五次**「a plausible value for EVERY input is not a plausible CONFIGURATION」;
- `public-block-binding-reach.test.tsx`:同样补成 spec 合法值,**并给 ledgered 分支加崩溃守卫** —— 那一支的通过条件是「**没有**数据调用」,而崩掉的块恰好满足它,所以本 PR 若只补样本会留下一类空绿。守卫**刻意只加在 ledgered 分支**:`object-form` / `object-master-detail-form` 在这个 fixture 下确实会渲染成错误卡(`reading 'map'`),但它们**发出了**真实数据调用、断言是挣来的,那是既有状态,记入 #3840,不靠加宽守卫顺手裹进本 PR。

渲染器那处裸取(`RelatedList.tsx:1299` 取 `add.picker.object`,而同文件 `:378`/`:390` 是可选链)按 AGENTS.md #0.1 **没有**在本 PR 加宽容 —— 修法有三条(一致化守卫 / 显式诊断 / 产出端校验),定的是诊断契约与校验时机,另立 #3838。

## `element:text_input.defaultValue` 的一处刻意收窄

spec 是联合 `string | number`,`ComponentInput.type` 是单一粗类型、表达不了。选了 `'string'`(文本输入的常态,且 DOM 值本来就 `String(...)` 强转),number arm 写进 description 并有断言钉住。这是**真收窄**:`sdui-parser` 的 `checkType` 会对 `defaultValue={42}` 报 `type-mismatch` warning,而 spec 接受这个值。同族标本(`page:header.title` / `record:alert.title` 的内联翻译映射,今天就会被误报)与四条可能方向记入 #3832;本 PR 不在 `checkType` 侧加任何宽容。

## 验证

```
pnpm exec vitest run apps/console/ packages/plugin-detail/ --maxWorkers=2
  Test Files  86 passed (86)
       Tests  774 passed (774)

pnpm exec vitest run packages/components/ --maxWorkers=2
  Test Files  98 passed (98)
       Tests  753 passed (753)

pnpm --filter @object-ui/components --filter @object-ui/plugin-detail --filter @object-ui/console run type-check
  packages/components type-check: Done
  packages/plugin-detail type-check: Done
  apps/console type-check: Done

node scripts/check-control-bytes.mjs
  ✅ OK (scanned 3746 tracked text file(s); skipped 85 binary)
node scripts/check-changeset-fixed.mjs && node scripts/check-changeset-no-major.mjs
  ✅ All workspace packages are in the changeset fixed group.
  ✅ No changeset declares a `major` bump.

eslint(8 个改动文件):0 errors, 45 warnings —— 全部是 plugin-detail/src/index.tsx
第 61-124 行 export 语句上既有的 react-refresh/only-export-components,与本改动无关。
```

反方向门跑下来 42 条断言全绿(原 12 条 + 新 6 类)。

## 围栏

- ⛔ 未触 `content/docs/releases/**`;⛔ 未触 `components/renderers/action/**`(PR #3825 在闸);未改 `containers.tsx`(B 类只进豁免)。
- 未改 `packages/types` 的 mirror(`RecordDetailsComponentProps` 缺 `hideFields` 那半落在 #2890 / #3818 的完成范围里,渲染器走 `(schema as any)` 读,本 PR 无需类型面改动)。
- changeset:`@object-ui/plugin-detail` + `@object-ui/components` patch(未声明 `major`)。

## 本 PR 过程中另立的 issue(均未认领,交 PM triage)

| # | 类型 | 一句话 |
|---|---|---|
| #3829 | 待决策 | `page:header.icon` / `page:card.actions`:spec 声明、渲染器零读点,接线 / 声明+KNOWN GAP / 上游退役 三择一 |
| #3830 | 缺陷 | `element:record_picker.filter` 是第 4 个 A 类缺口,#3808 的三类清单把它漏出了分类 |
| #3831 | 缺陷 | `add.picker.filter` 全仓零读点,作者限定了候选范围而对话框提供全部记录(`baseFilter` 是现成槽位) |
| #3832 | 缺陷 | `ComponentInput.type` 表达不了 spec 联合类型,`page:header.title` 的内联翻译映射今天就被 manifest 门误报 |
| #3834 | `finding` | `targetVariable` 全仓零读点,发布与否是未定判断题 |
| #3838 | 缺陷 | 写了 `add` 漏了 `add.picker` → 整段相关列表变错误卡(`RelatedList.tsx:1299` 裸取) |
| #3840 | `finding` | `object-form` / `object-master-detail-form` 在 binding-reach 探针 fixture 下渲染成错误卡,两分支崩溃守卫因此没法一起开 |

另在 #3809 补了评论:同一个墓碑盲区在反方向的症状是**假红**,且 `page:card.body` 那个标本在 pin 升级时会同时是一个假绿(`body`)和一个真红(`children`),一次处置解决两个。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_