### PR TITLE
fix(app-shell,components): 动作 disabled 的「已声明」判定补上 !== '' 半边,disabled: '' 不再永久置灰 (#3842)

### DIFF
--- a/.changeset/action-declared-disabled-gate-3842.md
+++ b/.changeset/action-declared-disabled-gate-3842.md
@@ -1,0 +1,52 @@
+---
+"@object-ui/app-shell": patch
+"@object-ui/components": patch
+---
+
+An action declaring `disabled: ''` is no longer greyed out forever (objectui#3842)
+
+The "is a `disabled` gate declared?" test stopped at `!= null`, missing the
+`!== ''` half of the invariant the `visible` family converged on
+(`hasDeclaredVisibilityGate`, objectui#3492 / #3758 / #3812 / #3823 / #3835). So
+`disabled: ''` counted as a declared gate, and the verdict went to the evaluation
+entry — which reads an empty predicate as "no condition → `true`"
+(`toPredicateInput('')` is `undefined`, `evaluateCondition(undefined)` is `true`).
+
+The direction is why this half is a defect and the `visible` half was not. On
+`visible`, that `true` means SHOW, so an over-broad "declared" test and a
+permissive empty predicate cancel out and `visible: ''` renders either way. On
+`disabled`, the same `true` means DISABLE — the two mistakes compound, and an
+empty predicate stopped meaning "no gate" and started meaning "permanently
+greyed out". One empty predicate, opposite treatment under two keys.
+
+Two gates now ask the shared definition instead:
+
+- `@object-ui/app-shell`'s `DeclaredActionsBar` — the hot one. Its actions are
+  SERVER-declared (`objectDef.actions[]`) and its hosts are the approvals inbox's
+  record sections, so a `disabled: ''` arriving from metadata (an authoring form
+  left empty, a template that rendered to an empty string) produced an Approve /
+  Reject button nobody could click, indistinguishable from deliberate metadata.
+  objectui#3835 was this same surface failing the other way.
+- `@object-ui/components`' `action:button` — verified to be the same shape before
+  it was changed (the issue inferred it from the identical spelling but did not
+  probe it): with `disabled: ''` the rendered button carried `disabled=""`.
+
+**Behaviour change surface, deliberately narrow.** Only `disabled: ''` changes —
+from disabled to clickable, which is what "no predicate" asked for. `disabled:
+true` still disables, `disabled: false` and an absent `disabled` still do not, and
+no expression-valued `disabled` changes verdict. One consequence worth naming: on
+`action:button`, an empty `disabled` now falls THROUGH to the legacy non-spec
+`enabled` fallback instead of short-circuiting on the empty predicate, so an
+action spelling both (`disabled: ''` + `enabled: true`) becomes clickable.
+
+The legacy `enabled` leg of `action:button` was routed through the same
+definition for consistency, and that part is behaviour-preserving by derivation
+rather than a fix: the leg is negated (`disabled = !isEnabled`), so an empty
+predicate's `true` already arrived as "not disabled" — the same verdict "no gate"
+produces. All four shapes are identical under either test; the derivation table
+and the reason no test can distinguish them are written down next to the pins.
+
+`hasDeclaredVisibilityGate` keeps its historic name at both call sites (the
+objectui#3842 dispatch ruling): the predicate is key-neutral, and one
+implementation behind two names is how a repo grows dialects. Each call site says
+so in a comment.

--- a/packages/app-shell/src/views/DeclaredActionsBar.tsx
+++ b/packages/app-shell/src/views/DeclaredActionsBar.tsx
@@ -227,7 +227,23 @@ const DeclaredActionButton: React.FC<{
       type="button"
       size="sm"
       variant={variant as any}
-      disabled={((action as any).disabled != null ? isDisabledPred : false) || loading}
+      // Is a `disabled` gate DECLARED? The same question the `visible` gate
+      // above asks, so it reads the same definition rather than re-spelling it.
+      // The name is historic — objectui#3492 arrived through `visible` — and the
+      // predicate is key-neutral: "declared" is `!= null && !== ''`, because an
+      // empty predicate is nothing to evaluate. Kept under that name
+      // deliberately (objectui#3842 ruling): one implementation behind two names
+      // is a dialect, not a clarification.
+      //
+      // `!= null` alone was a real defect here, and NOT for the reason it was on
+      // `visible`: the evaluation entry reads an empty predicate as "no
+      // condition → true", which on `visible` means SHOW (so an over-broad
+      // "declared" test cancels out and `''` renders either way), but here means
+      // DISABLE. A `disabled: ''` on a server-declared approval action rendered
+      // a permanently greyed-out Approve / Reject — the mirror image of
+      // objectui#3835 on the same surface, and equally impossible to tell from
+      // deliberate metadata by looking at it.
+      disabled={(hasDeclaredVisibilityGate((action as any).disabled) ? isDisabledPred : false) || loading}
       onClick={handleClick}
       data-testid={`declared-action-${action.name}`}
     >

--- a/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
+++ b/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
@@ -529,3 +529,86 @@ describe('DeclaredActionsBar — declared `visible` on a server-declared action 
     expect(executeSpy.mock.calls[0][0]).toMatchObject({ name: 'approval_reassign' });
   });
 });
+
+/**
+ * objectui#3842 — the declared `disabled` gate on the same surface, and the
+ * half of the objectui#3492 family where the `''` reasoning INVERTS.
+ *
+ * The gate asked `(action as any).disabled != null`, so `disabled: ''` counted
+ * as "a gate is declared" and the verdict went to the evaluation entry — which
+ * reads an empty predicate as "no condition → true"
+ * (`toPredicateInput('')` → `undefined` → `evaluateCondition(undefined)` →
+ * `true`). Direction is everything: on `visible` that `true` means SHOW, so the
+ * over-broad "declared" test and the permissive empty predicate cancel out
+ * (which is why the `visible: ''` case above is documentation, not a detector,
+ * and says so). On `disabled` the same `true` means DISABLE, so the two
+ * compound: an empty predicate stopped meaning "no gate" and started meaning
+ * "greyed out forever".
+ *
+ * What that costs on THIS surface: the actions are server-declared
+ * (`objectDef.actions[]`) and the bar's own hosts are the approvals inbox's
+ * record sections, so a `disabled: ''` — an authoring form left empty, a
+ * template that rendered to an empty string — greys out Approve / Reject with
+ * no way for the approver to tell metadata intent from a bug. objectui#3835 was
+ * the same surface failing the other way (hidden action still clickable).
+ *
+ * `''` IS a mutation detector here, unlike on `visible`: restore `!= null` and
+ * this block's first case goes red on its own. All four shapes are asserted
+ * because "never disable anything" satisfies three of them, and `disabled: true`
+ * is what refuses that rewrite.
+ *
+ * No legacy `enabled` leg on this surface by design (see the component: server-
+ * declared actions are spec-shaped and never carried the non-spec key) — that
+ * leg's four shapes are pinned in `packages/components`, next to the renderer
+ * that has it.
+ */
+describe('DeclaredActionsBar — declared `disabled` on a server-declared action (objectui#3842)', () => {
+  const APPROVE = {
+    name: 'approval_approve',
+    type: 'api',
+    label: 'Approve',
+    target: '/api/v1/approvals/requests/{id}/approve',
+    locations: ['record_section'],
+  };
+  const approve = () => screen.getByTestId('declared-action-approval_approve');
+
+  it("an empty-string `disabled` is not a declared gate — Approve stays clickable", () => {
+    renderWithGate({ ...APPROVE, disabled: '' });
+    expect(approve()).not.toBeDisabled();
+  });
+
+  it('disabled:true → Approve is disabled', () => {
+    renderWithGate({ ...APPROVE, disabled: true });
+    expect(approve()).toBeDisabled();
+  });
+
+  it('disabled:false → Approve is not disabled', () => {
+    renderWithGate({ ...APPROVE, disabled: false });
+    expect(approve()).not.toBeDisabled();
+  });
+
+  it('no `disabled` at all → Approve is not disabled (ungated stays ungated)', () => {
+    renderWithGate({ ...APPROVE });
+    expect(approve()).not.toBeDisabled();
+  });
+
+  it('an expression-valued `disabled` keeps its verdict — true disables, false does not', () => {
+    const gated = { ...APPROVE, disabled: 'status == "approved"' };
+    const { unmount } = renderWithGate(gated, { ...REQUEST, status: 'approved' });
+    expect(approve()).toBeDisabled();
+    unmount();
+    renderWithGate(gated, { ...REQUEST, status: 'pending' });
+    expect(approve()).not.toBeDisabled();
+  });
+
+  it('an empty-string `disabled` leaves an Approve that actually DISPATCHES', async () => {
+    // Not-disabled is only the visible half of the claim. The `disabled`
+    // attribute is what this component hands its own click handler — the one
+    // that POSTs the approve call — so the case worth pinning is that the
+    // button reaches `execute`, not merely that an attribute is absent.
+    renderWithGate({ ...APPROVE, disabled: '' });
+    fireEvent.click(approve());
+    await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1));
+    expect(executeSpy.mock.calls[0][0]).toMatchObject({ name: 'approval_approve' });
+  });
+});

--- a/packages/components/src/renderers/action/__tests__/action-disabled-declared-gate.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-disabled-declared-gate.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3842 — the declared-`disabled` gate. The `disabled` half of the
+ * objectui#3492 family, and the half where the family's usual "`''` is
+ * harmless" reasoning INVERTS.
+ *
+ * The gate asked `(schema as any).disabled != null`, so `disabled: ''` counted
+ * as "a gate is declared" and the verdict was handed to the evaluation entry —
+ * which reads an empty predicate as "nothing to evaluate → true"
+ * (`toPredicateInput('')` is `undefined`, `evaluateCondition(undefined)` is
+ * `true`). On `visible` that `true` means SHOW, so an over-broad "declared"
+ * test and a permissive empty predicate cancel out and `visible: ''` renders
+ * either way (which is why PR #3843 could only document `''` on that side, not
+ * detect a mutation with it). On `disabled` the same `true` means DISABLE, so
+ * the two mistakes compound instead of cancelling: an empty predicate stopped
+ * meaning "no gate" and started meaning "greyed out forever".
+ *
+ * Both legs now ask `hasDeclaredVisibilityGate` (`!= null && !== ''`) — the one
+ * definition, imported rather than re-spelled, historic name kept per the
+ * objectui#3842 dispatch ruling (see the comment at the gate).
+ *
+ * ## What each case detects
+ *
+ *   • `disabled: ''` → NOT disabled. THE defect, and on this side a genuine
+ *     mutation detector: restore `!= null` and this case alone goes red.
+ *   • `disabled: true` → disabled, and `disabled: false` / undeclared → not
+ *     disabled. Anti-mutation guards: "never disable anything" satisfies three
+ *     of the four shapes on its own, and `true` is what refuses it.
+ *   • expression-valued `disabled` → the verdict still decides, both ways. The
+ *     gate narrowed; evaluation did not change.
+ *
+ * ## The legacy `enabled` leg, and why its four cases are documentation
+ *
+ * The leg is NEGATED (`disabled = !isEnabled`), so the empty predicate's `true`
+ * arrives as `!true` = "not disabled" — which is exactly what "no gate
+ * declared" produces. Every shape therefore reaches the same verdict under
+ * either test, and the tightening is behaviour-preserving by derivation:
+ *
+ *   | `enabled`   | `!= null` (old)          | `hasDeclaredVisibilityGate` (new) |
+ *   |-------------|--------------------------|-----------------------------------|
+ *   | `''`        | gate → `!true`  = enabled | no gate → `false` = enabled       |
+ *   | `true`      | gate → `!true`  = enabled | gate → `!true`  = enabled         |
+ *   | `false`     | gate → `!false` = DISABLED| gate → `!false` = DISABLED        |
+ *   | undeclared  | no gate → `false`         | no gate → `false`                 |
+ *
+ * So no `enabled` case here can go red by reverting the `enabled` leg — stated
+ * plainly rather than dressed up as coverage. They are kept because they pin
+ * the semantics the derivation asserts (`enabled: false` must still disable),
+ * which is what a future rewrite of this chain would break silently. The one
+ * case that DOES move is the precedence case below: with `disabled: ''` no
+ * longer a gate, the chain falls through to the legacy leg instead of
+ * short-circuiting on an empty predicate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PredicateScopeProvider } from '@object-ui/react';
+// Module-scope side-effect import so the renderer is in the registry when
+// `ComponentRegistry.get` runs (the light `dom` project does not load the
+// `@object-ui/components` graph), per AGENTS.md §测试纪律 — the cost lands in
+// the import phase, not under a hook timeout.
+import '../action-button';
+
+/** Mount the leaf the way `action:bar` mounts it: whole action spread onto `schema`. */
+function renderLeaf(action: any, scope: Record<string, any> = {}) {
+  const Renderer = ComponentRegistry.get('action:button');
+  if (!Renderer) throw new Error('action:button is not registered');
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Renderer schema={{ ...action, type: 'action:button', actionType: action.type }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+const ACT = { name: 'act', label: 'Act', type: 'script' };
+const act = () => screen.getByRole('button', { name: 'Act' });
+
+describe('action:button — declared `disabled` gate (objectui#3842)', () => {
+  it("an empty-string `disabled` is not a declared gate — the button stays clickable", () => {
+    renderLeaf({ ...ACT, disabled: '' });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('disabled:true → the button is disabled', () => {
+    renderLeaf({ ...ACT, disabled: true });
+    expect(act()).toBeDisabled();
+  });
+
+  it('disabled:false → the button is not disabled', () => {
+    renderLeaf({ ...ACT, disabled: false });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('no `disabled` at all → the button is not disabled (ungated stays ungated)', () => {
+    renderLeaf({ ...ACT });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('an expression-valued `disabled` keeps its verdict — true disables, false does not', () => {
+    const gated = { ...ACT, disabled: 'features.locked == true' };
+    const { unmount } = renderLeaf(gated, { features: { locked: true } });
+    expect(act()).toBeDisabled();
+    unmount();
+    renderLeaf(gated, { features: { locked: false } });
+    expect(act()).not.toBeDisabled();
+  });
+});
+
+describe('action:button — legacy `enabled` leg (objectui#3842)', () => {
+  it("an empty-string `enabled` is not a declared gate — the button stays clickable", () => {
+    renderLeaf({ ...ACT, enabled: '' });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('enabled:false → the button is disabled (the legacy leg still decides)', () => {
+    renderLeaf({ ...ACT, enabled: false });
+    expect(act()).toBeDisabled();
+  });
+
+  it('enabled:true → the button is not disabled', () => {
+    renderLeaf({ ...ACT, enabled: true });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('no `enabled` at all → the button is not disabled', () => {
+    renderLeaf({ ...ACT });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('an empty `disabled` falls THROUGH to the legacy `enabled` leg', () => {
+    // The precedence case, and the second one the narrowing moves: `disabled:
+    // ''` used to short-circuit the chain on an empty predicate (→ disabled),
+    // so the author's `enabled: true` was never consulted. With `''` no longer
+    // a gate, the legacy leg decides — "no `disabled` declared" means exactly
+    // that, whatever else the action declares.
+    renderLeaf({ ...ACT, disabled: '', enabled: true });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('an empty `disabled` does not mask a legacy `enabled: false`', () => {
+    // Same fall-through, opposite verdict: the legacy leg is reached and says
+    // disabled. Green before and after (the old chain also disabled, for the
+    // wrong reason) — it is here so the fall-through cannot be "read the
+    // `enabled` leg only when it agrees with not-disabled".
+    renderLeaf({ ...ACT, disabled: '', enabled: false });
+    expect(act()).toBeDisabled();
+  });
+});

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -160,10 +160,30 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
         variant={variant as any}
         size={size as any}
         className={cn(schema.className, className)}
+        // Is a `disabled` / `enabled` gate DECLARED? Same question as the
+        // `visible` gate above, so it reads the same definition — the name is
+        // historic (objectui#3492 arrived through `visible`); the predicate is
+        // key-neutral: "declared" means `!= null && !== ''`, an empty predicate
+        // is nothing to evaluate and therefore no gate. Deliberately NOT
+        // renamed or aliased for this call site (objectui#3842 ruling): one
+        // implementation under two names is how a repo grows dialects.
+        //
+        // `!= null` alone was a live defect here in a way it is not on
+        // `visible` (objectui#3842). The evaluation entry reads an empty
+        // predicate as "no condition → true"; on `visible` that `true` means
+        // SHOW, so an over-broad "declared" test cancels out, while here it
+        // means DISABLE — `disabled: ''` was a permanently greyed-out button.
+        //
+        // The legacy `enabled` leg is negated (`!isEnabled`), so its `''` case
+        // already landed on "not disabled" by double negation; routing it
+        // through the same definition is behaviour-preserving for all four
+        // shapes (derivation table in
+        // `__tests__/action-disabled-declared-gate.test.tsx`) and keeps one
+        // spelling of "declared" on both legs.
         disabled={(
-          (schema as any).disabled != null
+          hasDeclaredVisibilityGate((schema as any).disabled)
             ? isDisabled
-            : schema.enabled != null
+            : hasDeclaredVisibilityGate(schema.enabled)
               ? !isEnabled
               : false
         ) || loading}


### PR DESCRIPTION
Fixes #3842

`disabled` 的「是否声明了门」判定停在 `!= null`,少了 `visible` 一族已收敛的 `hasDeclaredVisibilityGate`(`!= null && !== ''`)的另一半。两处落点改读同一处定义。

## 机理:为什么这半边是缺陷,而 `visible` 那半边不是

`disabled: ''` 被判成「声明了门」,verdict 交给求值入口 —— 求值入口把空谓词读成「没有条件 → `true`」(`toPredicateInput('')` → `undefined` → `evaluateCondition(undefined)` → `true`)。

**方向是全部**:在 `visible` 上这个 `true` 意味着「显示」,于是过宽的「已声明」判定与宽松的空谓词**互相抵消**,`visible: ''` 两种写法都渲染(这就是 PR #3843 只能把 `''` 当文档、当不了变异探测器的原因,那边注释里写明了)。在 `disabled` 上同一个 `true` 意味着「禁用」,两个错误**叠加**:空谓词从「没有门」变成「永久置灰」。同一个空谓词,两个 key 得到相反待遇。

## 两处落点前后对照

**`packages/app-shell/src/views/DeclaredActionsBar.tsx:212` 一带**(最烫的一处:动作是服务端声明的 `objectDef.actions[]`,宿主是审批收件箱记录区):

```
- disabled={((action as any).disabled != null ? isDisabledPred : false) || loading}
+ disabled={(hasDeclaredVisibilityGate((action as any).disabled) ? isDisabledPred : false) || loading}
```

**`packages/components/src/renderers/action/action-button.tsx:164`**(两条腿):

```
- (schema as any).disabled != null
-   ? isDisabled
-   : schema.enabled != null
+ hasDeclaredVisibilityGate((schema as any).disabled)
+   ? isDisabled
+   : hasDeclaredVisibilityGate(schema.enabled)
      ? !isEnabled
      : false
```

命名按 #3842 的派发裁定沿用历史名(谓词与 key 无关,同一实现两个名字即轻度方言),两处各就地注释说明。

## `action:button` 同形实证(改前先探针,不按拼法推断)

issue 明示 `action-button.tsx:164` 未单独实证。先写 pin 测试、在**未改动的源码**上跑,得到的红正是同形证据:

```
× an empty-string `disabled` is not a declared gate — the button stays clickable
  Error: expect(element).not.toBeDisabled()
  Received element is disabled:  (button ... disabled="" type="button")
× an empty `disabled` falls THROUGH to the legacy `enabled` leg
Tests  2 failed | 9 passed (11)
```

同一次运行里,`disabled: true` / `false` / 未声明、以及 `enabled` 四形状全绿 —— 坏的只是「已声明」的判定,不是求值。

## `enabled` legacy 腿:按推演行为等价,不是修复

该腿**取反**(`disabled = !isEnabled`),所以空谓词的 `true` 落成「不置灰」,与「没有门」同一结果。四形状在两种判定下逐一相同:

| `enabled` | `!= null`(旧) | `hasDeclaredVisibilityGate`(新) |
|---|---|---|
| `''` | 有门 → `!true` = 不置灰 | 没门 → `false` = 不置灰 |
| `true` | 有门 → `!true` = 不置灰 | 有门 → `!true` = 不置灰 |
| `false` | 有门 → `!false` = **置灰** | 有门 → `!false` = **置灰** |
| 未声明 | 没门 → `false` | 没门 → `false` |

所以**没有任何测试能靠还原这条腿变红** —— 这一点直说,不包装成覆盖率。改它只为「已声明」在两条腿上只有一种拼法。四个 `enabled` 钉子留着,钉的是推演所断言的语义(`enabled: false` 必须仍然置灰),那才是将来重写这段链条会静默弄坏的东西。

真正被这次收紧**移动**的是穿透一例:`disabled: ''` 不再是门之后,链条落到 legacy 腿而不是在空谓词上短路,所以 `disabled: '' + enabled: true` 从置灰变可点(改前红、改后绿,见上)。

## 反向验证(方向先判后跑)

**方向 A —— 两处落点还原 `disabled` 腿的 `!= null`。预判:红,共 4 例**(每包 2 例)。`''` 在本侧**是**真的变异探测器,与 `visible` 侧相反(#3843 的 M2 记账说明了为什么)。实跑:

```
× DeclaredActionsBar ... an empty-string `disabled` is not a declared gate — Approve stays clickable
× DeclaredActionsBar ... an empty-string `disabled` leaves an Approve that actually DISPATCHES
× action:button ... an empty-string `disabled` is not a declared gate — the button stays clickable
× action:button ... an empty `disabled` falls THROUGH to the legacy `enabled` leg
Tests  4 failed | 33 passed (37)
```

预判命中:正好这 4 例,无第五例。

**方向 B —— 只还原 `enabled` 腿的 `!= null`。预判:零红**(上表的推演结论)。实跑 `Tests 11 passed (11)`。推演由实测确认,而不是只被断言。

## 行为变化面(刻意窄)+ 一处诚实披露

只有 `disabled: ''` 改变:从置灰变可点,即「没有谓词」本来的含义。`disabled: true` 仍置灰,`disabled: false` 与未声明仍不置灰,任何表达式取值的 `disabled` 判定不变。

**披露**:实测 `ActionRunner.execute` 的执行门(`ActionRunner.ts:666`,`disabled != null && disabled !== false`)对空谓词同样判「已禁用」,handler 一次不跑、回 `{"success":false,"error":"Action is disabled"}`。所以本 PR 之后,`disabled: ''` 的动作**按钮能点了,点下去收到 `Action is disabled` 报错**。比原来「永久置灰、无任何解释」是改善,但那半边不在 #3842 的范围内(PM 已裁范围为两处渲染落点),已另立 #3848,不在此扩范围。

## 顺手发现(均已独立成单、未认领,不在本 PR)

- **#3848** —— `ActionRunner.execute` 的同族半边(上面那条披露);另有渲染器/执行器对纯空白串判定相反的分歧(可点 vs 拦),#3314 同类。
- **#3849** —— 同一 `!= null` 拼法还剩五处渲染落点:`action-icon.tsx:97`、`action-group.tsx:106` 与 `:148`、`action-menu.tsx:98`、`plugin-detail/record-quick-actions.tsx:208`。同一按钮上 `visible` 问「已声明」而 `disabled` 问 `!= null`。
- **#3850** —— 修完 `''` 后的残留:`disabled: { dialect: 'cel', source: '' }` 仍被判成已声明的门 → 置灰(实测)。修法要动 `visible` 一族共用的那处定义,是契约范围变更,附两轴分析,请先裁。(同一批探针还证伪了一个我原本的怀疑:纯空白串在渲染侧**良性**,机制是走字符串腿包成模板求出 falsy,不是被哪处判为空。)

## 验证

固件扫面:全仓 `grep` 无任何既有 fixture 拼 `disabled: ''` / `enabled: ''`,所以没有 fixture 被这次收紧重新判决(无需重拼 / 补声明 / 整例替换)。

```
# 涉及面(components 动作面 + app-shell views + 谓词归一 parity)
npx vitest run --maxWorkers=2 packages/components/src/renderers/action/ \
  packages/components/src/__tests__/action-bar.test.tsx \
  packages/components/src/__tests__/action-group.test.tsx \
  packages/components/src/__tests__/page-header-actions.test.tsx \
  packages/app-shell/src/views/__tests__/ \
  packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx
→ Test Files 18 passed (18) | Tests 195 passed (195)

# 末次编辑后按 CI 同命令全仓复跑(PR #3841 教训:vitest 的 esbuild 掩盖类型红)
npx turbo run type-check --concurrency=2
→ Tasks: 78 successful, 78 total

npx eslint (四个改动文件) → 0 errors(仅既有 no-explicit-any warning)
pnpm run check:control-bytes → OK(scanned 3758 tracked text files);另做 grep -naP 控制字节自扫,零命中
```

新增 11 例(`packages/components/.../__tests__/action-disabled-declared-gate.test.tsx`)+ 6 例(`DeclaredActionsBar.test.tsx`,沿用 PR #3843 收紧后的 `importOriginal` 偏 mock 桩形态:求值入口是真的,`hasDeclaredVisibilityGate` 从真源模块取)。`DeclaredActionsBar` 侧多钉一例「空谓词的按钮真的能 DISPATCH」—— 「没有 disabled 属性」只是这个论断的一半,而这个组件的点击处理器就是发出 approve 调用的那个。

Changeset:`.changeset/action-declared-disabled-gate-3842.md`(`@object-ui/app-shell` + `@object-ui/components` patch,写明 `disabled: ''` 从永久置灰变可点、以及穿透到 legacy `enabled` 腿这一连带后果)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_