### PR TITLE
docs(skills): console-development.md 顶部注记的搬家归因改成 04-21→04-23 的 commit 链,cccdf84d7 降为其中一步 (#3737)

### DIFF
--- a/skills/objectui/guides/console-development.md
+++ b/skills/objectui/guides/console-development.md
@@ -7,12 +7,37 @@ description: Develop features for the Object UI Console application — the refe
 
 Use this skill when working on the Console application (`apps/console/`), the reference admin interface for Object UI. The Console demonstrates schema-driven patterns at scale and serves as the blueprint for enterprise admin interfaces.
 
-> **`apps/console` is a reference assembly, not the engine.** Commit `cccdf84d7`
-> ("Slim apps/console for third-party customisation") moved the shell, the layouts,
-> the home pages, the navigation and the whole metadata admin into
-> `@object-ui/app-shell`, moved the designer pages into
-> `@object-ui/plugin-designer`, and left `apps/console` as a thin host that mostly
-> declares routes. Two consequences for anyone reading this guide:
+> **`apps/console` is a reference assembly, not the engine.** The shell, the layouts,
+> the home pages, the navigation and the whole metadata admin live in
+> `@object-ui/app-shell`, the designer pages live in `@object-ui/plugin-designer`, and
+> `apps/console` is a thin host that mostly declares routes.
+>
+> **Don't credit that move to one commit.** Earlier revisions of this note attributed
+> all of it to `cccdf84d7` ("Slim apps/console for third-party customisation",
+> 2026-04-22); following that pointer lands you in a diff that never touches the
+> symbols you are looking for. The `app-shell` extraction is a chain of commits
+> spanning 2026-04-21 → 04-23, and `cccdf84d7` is **one step** in it — the step that
+> removed the designer pages and `pages/system/`, not the shell/navigation move:
+>
+> - **Providers** (`AdapterProvider`, `MetadataProvider`, `ExpressionProvider`) —
+>   `app-shell` copies added in `c1e105793` (04-21, "extract core providers and hooks
+>   to @object-ui/app-shell"), `apps/console` copies deleted in `28ffe4033` (04-22,
+>   "Refactor context providers to use @object-ui/app-shell"). Both **before**
+>   `cccdf84d7`.
+> - **Navigation, layout, home pages and the hooks** (`NavigationContext`,
+>   `FavoritesProvider`, `UnifiedSidebar`, `ConsoleLayout`, `console/home/*`,
+>   `useFavorites`, `useMetadataService`, `useNavPins`, `useNavigationSync`,
+>   `useObjectActions`, `useRecentItems`, `useResponsiveSidebar`) — `apps/console`
+>   copies deleted in `b279d80d6` (04-23), which is titled "feat: Add ReportView and
+>   SearchResultsPage components" and names none of it. **After** `cccdf84d7`. (Most
+>   `app-shell` copies land in that same commit; `useObjectActions` and
+>   `useRecentItems` arrived earlier, in `c1e105793`.)
+>
+> Check the symbol you actually care about instead of trusting any single-commit
+> attribution for this refactor:
+> `git log --diff-filter=A --format='%h %ad %s' --date=short -- packages/app-shell/...`
+>
+> Two consequences for anyone reading this guide:
 >
 > - **Look in `packages/app-shell` first.** Most symbols you want to change are
 >   there, not under `apps/console/src/`. Grep before you assume a path.
@@ -79,7 +104,8 @@ apps/console/src/pages/
 └── SharedRecordPage.tsx         # Public share-link landing
 ```
 
-Where the rest went (all of it left `apps/console` in `cccdf84d7`):
+Where the rest went (spread across the 2026-04-21 → 04-23 `app-shell` extraction chain,
+**not** `cccdf84d7` alone — see the commit-attribution note at the top of this guide):
 
 | Looking for | Today's home |
 |---|---|


### PR DESCRIPTION
Fixes #3737

## 问题

`skills/objectui/guides/console-development.md` 顶部引用块(:10 起)把「shell / layouts / home pages / navigation / 整个 metadata admin 迁入 `@object-ui/app-shell`」整包记在 commit `cccdf84d7` 名下,:82 那行又复述一遍「all of it left `apps/console` in `cccdf84d7`」。照这个坐标去 `git show` 会拿到一个**不含目标符号**的 diff,白费一次查证 —— 而这句归因已经被 #3730 / #3713 两张卡的正文继承,是个会被反复引用的错坐标。

## 复核(动笔前跑,基线 `origin/main` @ `c32323e1e4e5d7c72adda03dce0b46ecbe079403`)

卡片的两条时间线**仍然成立**:

```
28ffe4033 EARLIER-THAN cccdf84d7      # git merge-base --is-ancestor
cccdf84d7 EARLIER-THAN b279d80d6
```

逐符号 `--diff-filter=A` / `=D` 实测(13 个符号,无一在 `cccdf84d7`):

| 批次 | app-shell 副本加入 | apps/console 副本删除 | 与 `cccdf84d7`(04-22)次序 |
|---|---|---|---|
| `AdapterProvider` / `MetadataProvider` / `ExpressionProvider` | `c1e105793`(04-21) | `28ffe4033`(04-22) | 都**早于** |
| `NavigationContext` / `FavoritesProvider` / `UnifiedSidebar` / `ConsoleLayout` / `console/home/*` / 七个 hooks | `b279d80d6`(04-23) | `b279d80d6`(04-23) | **晚一天** |

另外量到 `cccdf84d7` 在 `apps/console` 下**到底删了什么** —— 16 个文件:四个 designer 页(`CreateAppPage` `EditAppPage` `DashboardDesignPage` `PageDesignPage`)、五个 `pages/system/` 页、五个测试、两个 view-config 工具。shell / layout / navigation / home / hooks / providers 一个都不在里面,这就是「照注记 `git show` 会空手」的机械原因。

两处与卡片正文的细微出入(结论不变,已按实测写入注记):`useObjectActions` 与 `useRecentItems` 的 app-shell 副本其实早在 `c1e105793`(04-21)就落地,只有 console 副本等到 `b279d80d6` 才删;卡片把七个 hooks 一律归给 `b279d80d6`。

## 改法

只改两处,`cccdf84d7` 这个名字**保留**作纠错锚:

1. **顶部注记(:10)** —— 把「Commit `cccdf84d7` moved …」这半句拆成两段:第一段只陈述**今天**的归属(哪些东西现在住在 `app-shell` / `plugin-designer`),第二段以「**Don't credit that move to one commit.**」开头,明写「早先版本把整包记在 `cccdf84d7` 名下,跟着它走会落进一个不含目标符号的 diff」,再用两条 bullet 给出 04-21 → 04-23 的真实链,并点出 `b279d80d6` 的标题是「feat: Add ReportView and SearchResultsPage components」—— 一个字都没提这批符号,这正是照注记追溯的人**绝不会**往那儿找的原因。末尾给一条自查命令,让读者查具体符号而不是信任任何单 commit 归因。
2. **:82 那行** —— 「all of it left `apps/console` in `cccdf84d7`」改为「spread across the 2026-04-21 → 04-23 `app-shell` extraction chain, **not** `cccdf84d7` alone」,指回顶部注记。

保留锚而不是删名字,是为了让照旧坐标搜索(`grep cccdf84d`)的人**落在订正上**,而不是搜不到、再去别处重建一遍错误。

## 边界(严格按卡片)

- 注记里 **metadata admin 与 designer 两半未逐条复核、不动**:本次只撤掉「单一 commit」这个错坐标,**没有**替它们另指一个 commit,所以注记里不再残留任何未经核实的 commit 归因。
- #3730 / PR #3734 已修的三处表/节未碰;:101-103 三行对 `cccdf84d7` 的引用(`UserManagementPage` 等确实在该 commit 删除)经核实**正确**,原样保留。
- 顺手核实了仓内其余三处 `cccdf84d` 引用 —— `ROADMAP.md:857/871`、`apps/console/src/AppContent.tsx:110` 及其测试注释 —— 都是**正确用法**(说的是 `PermissionManagementPage` / 系统包装页在该 commit 被删),不在改动面内,也与在飞的 #3749 / #3738 零相交。

## 验证

- `node scripts/check-control-bytes.mjs` → `✅ OK (scanned 3762 tracked text file(s); skipped 85 binary)`;改动文件 `grep -naP` 控制字符扫描零命中。
- `node scripts/check-doc-links.mjs` → `Links are valid across 7 scan roots.`
- `pnpm exec turbo run type-check --concurrency=2` → `78 successful, 78 total`。
- `node scripts/check-changeset-presence.mjs` → `No source of a released package changed in this range, so no changeset is owed.`;同文件的前两次 docs(skills) 订正(#3734 / #3729)同样未带 changeset,照仓内先例不加。
- 本 PR 的 16 个 check 全绿(`Test (coverage)` 与 `dependabot` 按设计 skipped)。

> 附带订正一处我自己写错的前提:本 PR 正文起初写「md-only 改动 CI 的 `paths-ignore` 本不会触发」—— 那是照 `AGENTS.md:206` 写的,而 #3523 step 2 已经把 `pull_request` 的 `paths-ignore` 删掉(只留在 `push`),本 PR 起了 16 个 check 就是活体反证。该陈旧断言在 `AGENTS.md:206`、`scripts/check-changeset-presence.mjs:33-40`、`.github/workflows/changeset-guard.yml:3-8` 三处都在,已按纪律另立 #3857(`finding`,未认领),本 PR 不碰。
