### PR TITLE
fix(components,plugin-detail): 动作 disabled 的「已声明」判定剩余五处改读 hasDeclaredVisibilityGate (#3849)

### DIFF
--- a/.changeset/action-member-declared-disabled-gate-3849.md
+++ b/.changeset/action-member-declared-disabled-gate-3849.md
@@ -1,0 +1,50 @@
+---
+"@object-ui/components": patch
+"@object-ui/plugin-detail": patch
+---
+
+`disabled: ''` no longer greys out the remaining five action surfaces (objectui#3849)
+
+objectui#3842 / PR #3851 fixed the "is a `disabled` gate DECLARED?" test on
+`action:button` and app-shell's `DeclaredActionsBar`. Five same-shaped sites were
+outside that PR's scope and stayed on `!= null`, so within one component the
+`visible` gate asked `hasDeclaredVisibilityGate` while the `disabled` gate on the
+next line asked `!= null` — two spellings of one question:
+
+- `@object-ui/components` — `action:icon`, `action:group`'s inline button
+  (`InlineActionButton`) and dropdown item (`DropdownActionItem`), and
+  `action:menu`'s item (`ActionMenuItem`).
+- `@object-ui/plugin-detail` — `record:quick_actions`' `QuickActionButton`.
+
+Why the missing `!== ''` half is a defect on this key and not on `visible`:
+`toPredicateInput('')` is `undefined` and `evaluateCondition(undefined)` is
+`true`. On `visible` that `true` means SHOW, so an over-broad "declared" test and
+a permissive empty predicate cancel out. On `disabled` it means DISABLE, so they
+compound — `disabled: ''` (an empty predicate: nothing declared) rendered a
+permanently greyed-out control, with nothing the author could write to un-grey
+it. Unlike #3842's approvals inbox, these five are the general action face
+(toolbars, dropdowns, record quick actions), so the reach is wider even though no
+single high-value host owns them.
+
+**Behaviour change surface, deliberately narrow.** Only `disabled: ''` changes —
+from disabled to clickable, which is what "no predicate" asked for. `disabled:
+true` still disables, `disabled: false` and an absent `disabled` still do not, and
+no expression-valued `disabled` changes verdict. On the four sites that also carry
+the legacy non-spec `enabled` fallback, one consequence follows: an empty
+`disabled` now falls THROUGH to that leg instead of short-circuiting on the empty
+predicate, so an action spelling both (`disabled: ''` + `enabled: true`) becomes
+clickable. `record:quick_actions` has no `enabled` leg, so its chain is the single
+gate.
+
+Routing those legacy `enabled` legs through the same definition is
+behaviour-preserving by derivation rather than a fix: the leg is negated
+(`disabled = !isEnabled`), so an empty predicate's `true` already arrived as "not
+disabled" — the verdict "no gate declared" produces. #3842's four-shape derivation
+table is reproduced next to the new pins, together with the statement that no
+`enabled` case can go red by reverting that leg.
+
+`hasDeclaredVisibilityGate` keeps its historic name (the objectui#3842 ruling): the
+predicate is key-neutral, and one implementation behind two names is how a repo
+grows dialects. The three `@object-ui/components` sites import it relatively;
+`record:quick_actions` takes it from the package barrel, the cross-package route
+objectui#3835 opened. Every call site says so in a comment.

--- a/packages/components/src/renderers/action/__tests__/action-member-disabled-declared-gate.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-member-disabled-declared-gate.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3849 — the declared-`disabled` gate on the four remaining action-face
+ * sites. objectui#3842 / PR #3851 fixed `action:button` (and app-shell's
+ * `DeclaredActionsBar`); these four stayed on `!= null`, so the same component
+ * asked "is a gate DECLARED?" one way for `visible` and another for `disabled`.
+ *
+ * The mechanism is #3842's, verbatim: `toPredicateInput('')` is `undefined` and
+ * `evaluateCondition(undefined)` is `true`. On `visible` that `true` means SHOW,
+ * so an over-broad "declared" test and a permissive empty predicate cancel out.
+ * On `disabled` the same `true` means DISABLE, so they compound — `disabled: ''`
+ * (an empty predicate, i.e. nothing declared) became "greyed out forever", with
+ * nothing the author could write to un-grey it. All four now read
+ * `hasDeclaredVisibilityGate` (`!= null && !== ''`), imported rather than
+ * re-spelled; historic name kept per the #3842 ruling.
+ *
+ * ## What each case detects
+ *
+ *   • `disabled: ''` → NOT disabled. THE defect, and a genuine mutation
+ *     detector on this key: restore `!= null` at one site and that site's `''`
+ *     case alone goes red (the reverse-verification this PR ran).
+ *   • `disabled: true` → disabled; `disabled: false` / undeclared → not
+ *     disabled. Anti-mutation guards: "never disable anything" satisfies three
+ *     of the four shapes on its own, and `true` is what refuses it.
+ *   • expression-valued `disabled` → the verdict still decides, both ways. The
+ *     gate narrowed; evaluation did not change.
+ *
+ * ## The legacy `enabled` leg — four cases that are documentation, one that moves
+ *
+ * The leg is NEGATED (`disabled = !isEnabled`), so an empty predicate's `true`
+ * arrives as `!true` = "not disabled", which is exactly what "no gate declared"
+ * produces. Every shape reaches the same verdict under either test, so the
+ * tightening is behaviour-preserving by derivation (#3842's table):
+ *
+ *   | `enabled`   | `!= null` (old)           | `hasDeclaredVisibilityGate` (new) |
+ *   |-------------|---------------------------|-----------------------------------|
+ *   | `''`        | gate → `!true`  = enabled | no gate → `false` = enabled       |
+ *   | `true`      | gate → `!true`  = enabled | gate → `!true`  = enabled         |
+ *   | `false`     | gate → `!false` = DISABLED| gate → `!false` = DISABLED        |
+ *   | undeclared  | no gate → `false`         | no gate → `false`                 |
+ *
+ * Stated plainly rather than dressed up as coverage: no `enabled` case here can
+ * go red by reverting the `enabled` leg. They are kept because they pin the
+ * semantics the derivation asserts (`enabled: false` must still disable), which
+ * a future rewrite of this chain would otherwise break silently. The case that
+ * DOES move is precedence: with `disabled: ''` no longer a gate, the chain falls
+ * through to the legacy leg instead of short-circuiting on an empty predicate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PredicateScopeProvider } from '@object-ui/react';
+// Module-scope side-effect imports so the two hosts are in the registry when
+// `ComponentRegistry.get` runs — the light `dom` project deliberately does not
+// load the `@object-ui/components` graph. Module scope, not a `beforeAll`, per
+// AGENTS.md §测试纪律: the cost lands in the import phase, unbounded by any
+// hook timeout.
+import '../action-icon';
+import { DropdownActionItem } from '../action-group';
+import { ActionMenuItem } from '../action-menu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '../../../ui';
+
+const LABEL = 'Act';
+const ACT = { name: 'act', label: LABEL, type: 'script' };
+
+/** An ungated companion — a passing assertion must not mean "the host vanished". */
+const COMPANION = { name: 'view', label: 'View', type: 'script' };
+
+function getRenderer(type: string) {
+  const R = ComponentRegistry.get(type);
+  if (!R) throw new Error(`${type} is not registered`);
+  return R;
+}
+
+/**
+ * Site 1 — `action:icon`, mounted the way `action:bar` mounts a member: the
+ * whole action spread onto the leaf's own `schema` (`action-bar.tsx` resolves
+ * the renderer from the registry itself, so this gate is the only one on that
+ * path — the reachability #3823 established for the `visible` half of the same
+ * two lines).
+ */
+function mountIcon(action: any, scope: Record<string, any> = {}) {
+  const Renderer = getRenderer('action:icon');
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Renderer schema={{ ...action, type: 'action:icon', actionType: action.type }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+/**
+ * Site 2 — `InlineActionButton`, through the real `action:group` host so the
+ * member gate is observed where it runs (the group `.map()`s its own `actions`;
+ * neither `SchemaRenderer` nor `ActionEngine` is in this path).
+ */
+function mountInlineGroup(action: any, scope: Record<string, any> = {}) {
+  const Group = getRenderer('action:group');
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Group schema={{ type: 'action:group', display: 'inline', actions: [action, COMPANION] }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+/**
+ * Sites 3 and 4 — the two dropdown leaves, each inside a controlled-open menu so
+ * the portal content mounts deterministically (Radix opens on pointerdown, flaky
+ * to synthesize in happy-dom). Same harness as
+ * `action-group-dropdown-visible.test.tsx` and `action-member-visible-gate.test.tsx`.
+ */
+function mountInMenu(node: React.ReactNode, scope: Record<string, any> = {}) {
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <DropdownMenu open modal={false}>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>{node}</DropdownMenuContent>
+      </DropdownMenu>
+    </PredicateScopeProvider>,
+  );
+}
+
+/** A `<button disabled>` leaf: the DOM property is the verdict. */
+const buttonIsDisabled = (label: string) =>
+  (screen.getByRole('button', { name: label }) as HTMLButtonElement).disabled;
+
+/**
+ * A Radix `DropdownMenuItem` leaf: it is a `role="menuitem"` div, so a disabled
+ * item carries `data-disabled` rather than the `disabled` attribute (the probe
+ * `action-group-dropdown-visible.test.tsx` established for #1885).
+ */
+const menuItemIsDisabled = (label: string) => {
+  const item = screen.getByText(label).closest('[role="menuitem"]');
+  if (!item) throw new Error(`no menuitem found for "${label}"`);
+  return item.hasAttribute('data-disabled');
+};
+
+interface Site {
+  /** Site name, as it reads in the test output. */
+  id: string;
+  mount: (action: any, scope?: Record<string, any>) => { unmount: () => void };
+  isDisabled: (label: string) => boolean;
+}
+
+const SITES: Site[] = [
+  { id: 'action:icon', mount: mountIcon, isDisabled: buttonIsDisabled },
+  { id: 'action:group inline member', mount: mountInlineGroup, isDisabled: buttonIsDisabled },
+  {
+    id: 'action:group dropdown member',
+    mount: (action, scope) =>
+      mountInMenu(<DropdownActionItem action={action} index={0} onSelect={() => {}} />, scope),
+    isDisabled: menuItemIsDisabled,
+  },
+  {
+    id: 'action:menu member',
+    mount: (action, scope) =>
+      mountInMenu(<ActionMenuItem action={action} onExecute={async () => {}} />, scope),
+    isDisabled: menuItemIsDisabled,
+  },
+];
+
+describe.each(SITES)('$id — declared `disabled` gate (objectui#3849)', ({ mount, isDisabled }) => {
+  it("an empty-string `disabled` is not a declared gate — the action stays clickable", () => {
+    mount({ ...ACT, disabled: '' });
+    expect(isDisabled(LABEL)).toBe(false);
+  });
+
+  it('disabled:true → the action is disabled', () => {
+    mount({ ...ACT, disabled: true });
+    expect(isDisabled(LABEL)).toBe(true);
+  });
+
+  it('disabled:false → the action is not disabled', () => {
+    mount({ ...ACT, disabled: false });
+    expect(isDisabled(LABEL)).toBe(false);
+  });
+
+  it('no `disabled` at all → the action is not disabled (ungated stays ungated)', () => {
+    mount({ ...ACT });
+    expect(isDisabled(LABEL)).toBe(false);
+  });
+
+  it('an expression-valued `disabled` keeps its verdict — true disables, false does not', () => {
+    const gated = { ...ACT, disabled: 'features.locked == true' };
+    const { unmount } = mount(gated, { features: { locked: true } });
+    expect(isDisabled(LABEL)).toBe(true);
+    unmount();
+    mount(gated, { features: { locked: false } });
+    expect(isDisabled(LABEL)).toBe(false);
+  });
+});
+
+describe.each(SITES)('$id — legacy `enabled` leg (objectui#3849)', ({ mount, isDisabled }) => {
+  it("an empty-string `enabled` is not a declared gate — the action stays clickable", () => {
+    mount({ ...ACT, enabled: '' });
+    expect(isDisabled(LABEL)).toBe(false);
+  });
+
+  it('enabled:false → the action is disabled (the legacy leg still decides)', () => {
+    mount({ ...ACT, enabled: false });
+    expect(isDisabled(LABEL)).toBe(true);
+  });
+
+  it('enabled:true → the action is not disabled', () => {
+    mount({ ...ACT, enabled: true });
+    expect(isDisabled(LABEL)).toBe(false);
+  });
+
+  it('an empty `disabled` falls THROUGH to the legacy `enabled` leg', () => {
+    // The precedence case, and the second one the narrowing moves: `disabled:
+    // ''` used to short-circuit the chain on an empty predicate (→ disabled), so
+    // the author's `enabled: true` was never consulted. With `''` no longer a
+    // gate, the legacy leg decides — "no `disabled` declared" means exactly
+    // that, whatever else the action declares.
+    mount({ ...ACT, disabled: '', enabled: true });
+    expect(isDisabled(LABEL)).toBe(false);
+  });
+
+  it('an empty `disabled` does not mask a legacy `enabled: false`', () => {
+    // Same fall-through, opposite verdict: the legacy leg is reached and says
+    // disabled. Green before and after (the old chain also disabled, for the
+    // wrong reason) — it is here so the fall-through cannot degrade into "read
+    // the `enabled` leg only when it agrees with not-disabled".
+    mount({ ...ACT, disabled: '', enabled: false });
+    expect(isDisabled(LABEL)).toBe(true);
+  });
+});

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -102,10 +102,19 @@ const InlineActionButton: React.FC<{
       variant={btnVariant as any}
       size={btnSize as any}
       className={action.className}
+      // Is a `disabled` / `enabled` gate DECLARED? Same question as the
+      // `visible` gate above, so it reads the same definition (historic name
+      // kept, not aliased — objectui#3842 ruling, applied here by #3849). On
+      // this key `!= null` alone was a live defect: an empty predicate reaches
+      // the evaluation entry as "no condition → true", which means DISABLE
+      // here, so `disabled: ''` greyed the button out forever. The legacy
+      // `enabled` leg is negated and therefore behaviour-preserving under the
+      // same definition — derivation in
+      // `__tests__/action-disabled-declared-gate.test.tsx`.
       disabled={(
-        (action as any).disabled != null
+        hasDeclaredVisibilityGate((action as any).disabled)
           ? isDisabledPred
-          : action.enabled != null
+          : hasDeclaredVisibilityGate(action.enabled)
             ? !isEnabled
             : false
       ) || loading}
@@ -145,9 +154,14 @@ export const DropdownActionItem: React.FC<{
   // hidden in one display mode and shown in the other (objectui#3812).
   if (hasDeclaredVisibilityGate(action.visible) && !isVisible) return null;
   const Icon = resolveIcon(action.icon);
-  const isDisabled = (action as any).disabled != null
+  // Declared-gate test, same definition as `InlineActionButton` above: one
+  // action cannot be greyed out in one display mode and clickable in the other
+  // (objectui#3842 / #3849). `disabled: ''` is not a declared gate — an empty
+  // predicate is nothing to evaluate, and on this key the evaluation entry's
+  // "no condition → true" means DISABLE.
+  const isDisabled = hasDeclaredVisibilityGate((action as any).disabled)
     ? isDisabledPred
-    : action.enabled != null
+    : hasDeclaredVisibilityGate(action.enabled)
       ? !isEnabled
       : false;
   const showSeparator = action.tags?.includes('separator-before') && index > 0;

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -93,10 +93,25 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
         variant={variant as any}
         size={size}
         className={cn('h-8 w-8', schema.className, className)}
+        // Is a `disabled` / `enabled` gate DECLARED? The same question the
+        // `visible` gate above asks, so it reads the same definition — the name
+        // is historic (objectui#3492 arrived through `visible`), the predicate
+        // is key-neutral: "declared" is `!= null && !== ''`. Deliberately NOT
+        // renamed or aliased (objectui#3842 ruling, applied here by #3849).
+        //
+        // `!= null` alone was a live defect on `disabled` in a way it is not on
+        // `visible`: the evaluation entry reads an empty predicate as "no
+        // condition → true", which means SHOW on `visible` (harmless) but
+        // DISABLE here — `disabled: ''` was a permanently greyed-out button.
+        // The legacy `enabled` leg is negated, so its `''` case already landed
+        // on "not disabled"; routing it through the same definition is
+        // behaviour-preserving (derivation table in
+        // `__tests__/action-disabled-declared-gate.test.tsx`) and leaves one
+        // spelling of "declared" on both legs.
         disabled={(
-          (schema as any).disabled != null
+          hasDeclaredVisibilityGate((schema as any).disabled)
             ? isDisabledPred
-            : schema.enabled != null
+            : hasDeclaredVisibilityGate(schema.enabled)
               ? !isEnabled
               : false
         ) || loading}

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -95,9 +95,16 @@ export const ActionMenuItem: React.FC<{
 
   return (
     <DropdownMenuItem
-      disabled={(action as any).disabled != null
+      // Declared-gate test, the same definition the `visible` gate above reads
+      // and the same one `action:group`'s two leaves read (objectui#3842 ruling
+      // applied here by #3849 — historic name kept, no alias). `disabled: ''`
+      // is not a gate: the evaluation entry reads an empty predicate as "no
+      // condition → true", which on this key means DISABLE, so `!= null` alone
+      // greyed the item out forever. The negated legacy `enabled` leg is
+      // behaviour-preserving under the same definition.
+      disabled={hasDeclaredVisibilityGate((action as any).disabled)
         ? isDisabledPred
-        : action.enabled != null
+        : hasDeclaredVisibilityGate(action.enabled)
           ? !isEnabled
           : false}
       onSelect={(e) => {

--- a/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.disabled-declared-gate.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.disabled-declared-gate.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3849 — `record:quick_actions`, the fifth and last site whose
+ * declared-`disabled` test stayed on `!= null` after objectui#3842 / PR #3851.
+ *
+ * `toPredicateInput('')` is `undefined` and `evaluateCondition(undefined)` is
+ * `true`. On `visible` that `true` means SHOW, so an over-broad "is a gate
+ * declared?" test cancels out; on `disabled` it means DISABLE, so the two
+ * compound: `disabled: ''` — an empty predicate, i.e. nothing declared — greyed
+ * the quick action out permanently. The gate now reads
+ * `hasDeclaredVisibilityGate` (`!= null && !== ''`) from the one definition on
+ * the action face, imported through the `@object-ui/components` barrel (the
+ * cross-package route objectui#3835 opened for exactly this).
+ *
+ * This surface has NO legacy `enabled` leg (unlike `action:button` /
+ * `action:icon` / the two `action:group` leaves / `action:menu`), so the chain is
+ * a single gate and the four shapes below are the whole behaviour.
+ *
+ * The host is driven for real — `useActionEngine` filters by `locations`, the
+ * renderer maps the survivors to `QuickActionButton`, and the button's own
+ * `useCondition` / `toPredicateInput` are the genuine ones. Nothing about
+ * evaluation is stubbed, because the empty-predicate chain IS the mechanism
+ * under test.
+ */
+
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordQuickActionsRenderer } from '../record-quick-actions';
+
+const LABEL = 'Act';
+/** `locations` is not defaulted — `getActionsForLocation` requires the match. */
+const ACT = { name: 'act', label: LABEL, type: 'script', locations: ['record_header'] };
+
+function mount(action: any, record: Record<string, unknown> = {}) {
+  return render(
+    <RecordContextProvider
+      objectName="crm_account"
+      recordId="rec-1"
+      data={{ id: 'rec-1', ...record }}
+    >
+      <RecordQuickActionsRenderer schema={{ actions: [action] } as any} />
+    </RecordContextProvider>,
+  );
+}
+
+const isDisabled = () =>
+  (screen.getByRole('button', { name: LABEL }) as HTMLButtonElement).disabled;
+
+describe('record:quick_actions — declared `disabled` gate (objectui#3849)', () => {
+  it("an empty-string `disabled` is not a declared gate — the action stays clickable", () => {
+    mount({ ...ACT, disabled: '' });
+    expect(isDisabled()).toBe(false);
+  });
+
+  it('disabled:true → the action is disabled', () => {
+    mount({ ...ACT, disabled: true });
+    expect(isDisabled()).toBe(true);
+  });
+
+  it('disabled:false → the action is not disabled', () => {
+    mount({ ...ACT, disabled: false });
+    expect(isDisabled()).toBe(false);
+  });
+
+  it('no `disabled` at all → the action is not disabled (ungated stays ungated)', () => {
+    mount({ ...ACT });
+    expect(isDisabled()).toBe(false);
+  });
+
+  it('an expression-valued `disabled` keeps its verdict — true disables, false does not', () => {
+    // The predicate is evaluated against the bound record (the renderer passes
+    // `{ record }` as the local scope), so this also pins that the narrowed gate
+    // did not disturb the record-scoped evaluation path.
+    const gated = { ...ACT, disabled: 'record.status == "closed"' };
+    const { unmount } = mount(gated, { status: 'closed' });
+    expect(isDisabled()).toBe(true);
+    unmount();
+    mount(gated, { status: 'open' });
+    expect(isDisabled()).toBe(false);
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-quick-actions.tsx
+++ b/packages/plugin-detail/src/renderers/record-quick-actions.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { useRecordContext, useActionEngine, useMetadataItem, useCondition, toPredicateInput, useSafeFieldLabel } from '@object-ui/react';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
-import { Button, cn } from '@object-ui/components';
+import { Button, cn, hasDeclaredVisibilityGate } from '@object-ui/components';
 import { Loader2 } from 'lucide-react';
 import type { ActionDef, ActionLocation } from '@object-ui/core';
 
@@ -205,7 +205,17 @@ function QuickActionButton({
   // engine. The previous `typeof === 'string'` split dropped the envelope, so
   // a spec-authored `disabled` never disabled anything on this surface.
   const isDisabledPred = useCondition(toPredicateInput((action as any).disabled), recordCtx);
-  const isDisabled = ((action as any).disabled != null ? isDisabledPred : false) || running;
+  // Is a `disabled` gate DECLARED? Read from the one definition on the action
+  // face rather than re-spelled here (objectui#3842 ruling, applied to this
+  // site by #3849 — the historic `visible`-flavoured name is kept on purpose;
+  // the predicate is key-neutral, "declared" is `!= null && !== ''`).
+  //
+  // `!= null` alone was a live defect on this key: `toPredicateInput('')` is
+  // `undefined` and `evaluateCondition(undefined)` is `true`, which on
+  // `disabled` means DISABLE — so `disabled: ''` (an empty predicate, i.e.
+  // nothing declared) greyed this quick action out permanently, with no way for
+  // the author to un-grey it. There is no legacy `enabled` leg on this surface.
+  const isDisabled = (hasDeclaredVisibilityGate((action as any).disabled) ? isDisabledPred : false) || running;
   return (
     <Button
       variant={variant}


### PR DESCRIPTION
Fixes #3849

基于 `origin/main` @ `993336f7c481e1fd724512363b8b2f15b305da86`（即 #3842 / PR #3851 的合并点）。

## 落点核对（逐处，不整批假设）

开工前在该 sha 上逐处核过现拼法，issue 正文的五处落点表全部成立，五处现拼法一律是 `disabled != null`：

| # | 文件:行(基线 sha) | 组件 | 现拼法 | 有 `enabled` 腿 |
|---|---|---|---|---|
| 1 | `packages/components/src/renderers/action/action-icon.tsx:97` | `action:icon` | `disabled != null` | 有 |
| 2 | `packages/components/src/renderers/action/action-group.tsx:106` | `InlineActionButton` | `disabled != null` | 有 |
| 3 | `packages/components/src/renderers/action/action-group.tsx:148` | `DropdownActionItem` | `disabled != null` | 有 |
| 4 | `packages/components/src/renderers/action/action-menu.tsx:98` | `ActionMenuItem` | `disabled != null` | 有 |
| 5 | `packages/plugin-detail/src/renderers/record-quick-actions.tsx:208` | `QuickActionButton` | `disabled != null` | 无 |

三个 `packages/components` 文件此前**已经**导入了 `hasDeclaredVisibilityGate`（`visible` 门在 #3812 / #3823 就改过），所以是同一文件同一按钮上 `visible` 问「已声明」、隔一行的 `disabled` 问 `!= null` —— 一个问题两种拼法。`record-quick-actions.tsx` 从 `@object-ui/components` barrel 新增导入（#3835 开的跨包路子）。

`SchemaRenderer.tsx:323` 的第三种拼法（`!== undefined`）确认存在但**不在**本单文件面，未动，见下方「越界发现」。

## 机理（与 #3842 逐字相同，方向是关键）

`toPredicateInput('')` 为 `undefined`，`evaluateCondition(undefined)` 为 `true`。

- 在 `visible` 上这个 `true` 意味着「显示」，与过宽的「已声明」判定互相抵消 —— 所以 `visible: ''` 前后都渲染，`''` 在那一侧不是变异探测器。
- 在 `disabled` 上同一个 `true` 意味着「禁用」，两个错误叠加：空谓词从「没有门」变成「永久置灰」，作者写什么都解不开。

五处统一改读 `hasDeclaredVisibilityGate`（`!= null && !== ''`）。按 #3842 裁定：不重命名、不加别名、不上提 core；包内三处从 `./visibility-gate` 相对取；每处落点就地注释说明名称系历史、语义为谓词通用。

## 行为变更面（刻意窄）

只有 `disabled: ''` 从「置灰」变「可点」—— 这正是「没有谓词」本来要求的结果。`disabled: true` 仍置灰，`disabled: false` 与未声明仍不置灰，表达式取值的 verdict 一律不变。

四处带 legacy `enabled` 腿的落点多一条推论：空 `disabled` 现在**落到** `enabled` 腿，而不再在空谓词上短路，所以同时写 `disabled: ''` + `enabled: true` 的动作变为可点。`record:quick_actions` 没有 `enabled` 腿，它的链条就是单个门。

`enabled` 腿本身取反（`disabled = !isEnabled`），空谓词的 `true` 到达时已是 `!true` = 「不置灰」，与「没声明门」同 verdict —— 四形状在新旧判定下完全一致，属**推演等价而非修复**。#3842 的四形状推演表连同「没有任何 `enabled` 用例能因还原该腿而变红」这句话一并抄在钉子旁，如实说明而不包装成覆盖率。

## 测试

新增两个钉子文件，形状抄 PR #3851 的 `action-disabled-declared-gate.test.tsx` 保持家族一致：

- `packages/components/src/renderers/action/__tests__/action-member-disabled-declared-gate.test.tsx` —— 四处落点 × (`''` / `true` / `false` / 未声明 / 表达式双向) + `enabled` 腿五形状，表驱动。宿主按各自真实路径挂载：`action:icon` 按 `action:bar` 的成员方式把整个 action 摊到叶子自己的 `schema` 上；`InlineActionButton` 走真实 `action:group` 宿主；两个下拉叶子放在 controlled-open 菜单里（沿用 `action-member-visible-gate.test.tsx` 的 harness）。
- `packages/plugin-detail/src/renderers/__tests__/record-quick-actions.disabled-declared-gate.test.tsx` —— 真实驱动宿主（`useActionEngine` 按 `locations` 过滤 → 渲染器 map 出 `QuickActionButton`），`useCondition` / `toPredicateInput` 一律用真的，不 stub —— 空谓词链条本身就是被测机理。

判定探针按 DOM 形状区分：原生 button 元素读它的 `disabled` DOM 属性；Radix `DropdownMenuItem` 渲染成 `role="menuitem"` 的 div，禁用时带的是 `data-disabled`（沿用 `action-group-dropdown-visible.test.tsx` 为 #1885 立的探针）。

实跑（仓根、`flock` 串行、`--maxWorkers=2`）：

- 两个新文件：`Test Files 2 passed (2)` / `Tests 45 passed (45)`
- 消费半径扫面（`renderers/action/__tests__` 全量 + `components` 的 action-bar / action-group + `plugin-detail/renderers/__tests__` 全量 + `DeclaredActionsBar` + `actionPredicate.parity` + console 的 `record-block-record-reach`）：`Test Files 17 passed (17)` / `Tests 243 passed (243)`
- 末次编辑后全仓 `turbo run type-check --concurrency=2`：`Tasks: 78 successful, 78 total`

## 反向验证（方向先判后跑）

预判写在跑之前：单还原 `action-icon.tsx` 一处的 `!= null`，该处 `''` 钉子必须红且点名该处；其余四处与 `record:quick_actions` 保持绿。

实跑与预判一致 —— 恰好两条红，都在 `'action:icon'` 名下：

```
FAIL  'action:icon' — declared `disabled` gate (objectui#3849) :
      an empty-string `disabled` is not a declared gate — the action stays clickable
AssertionError: expected true to be false
FAIL  'action:icon' — legacy `enabled` leg (objectui#3849) :
      an empty `disabled` falls THROUGH to the legacy `enabled` leg
AssertionError: expected true to be false
Tests  2 failed | 43 passed (45)
```

第二条红是**预判到的**同一处的另一面：`disabled: ''` 一旦重新算作「已声明」，链条就在空谓词上短路，作者的 `enabled: true` 根本没被读到。还原后已复原为 `hasDeclaredVisibilityGate`。

## 越界发现

`packages/react/src/SchemaRenderer.tsx:322-334` 的 `newSchema.disabled !== undefined`（第三种拼法，范围比 `!= null` 再宽一格 —— `disabled: null` 也会置灰）确认存在于 `origin/main`，不在本单文件面，本 PR 未动。已立单 #3862（未认领，附 file:line 取证：该值经 `SchemaRenderer.tsx:461` 的 `disabled: __disabled || undefined` 转发成组件 prop，不是死标记；修法涉及「共享定义放哪一层」的跨包裁定，建议与 #3850 同批裁），交 PM 分诊。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_