### PR TITLE
fix(test): runner 的包级 test 入口指回仓根配置,不再落到 app 的 vite.config (#3746)

### DIFF
--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -19,7 +19,7 @@
     "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run --root ../.. packages/runner/"
   },
   "dependencies": {
     "@object-ui/components": "workspace:*",

--- a/scripts/__tests__/runner-package-test-entry-3746.test.ts
+++ b/scripts/__tests__/runner-package-test-entry-3746.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS CI helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here — adding one
+// would itself be an error (TS2578). See objectui#3494.
+import { evaluateVitestInvocation, parseVitestArgv } from '../vitest-invocation-guard.mjs';
+
+/**
+ * objectui#3746 — `pnpm --filter @object-ui/runner test` was 4 red on a clean
+ * `main` while the very same 13 tests were green from the repo root.
+ *
+ * Mechanism, measured at 6402e253f: `packages/runner` declared
+ * `"test": "vitest run"` and has NO vitest config of its own, so vitest —
+ * launched by pnpm with the package as its cwd, hence as its root — adopted the
+ * `vite.config.ts` sitting in that directory. That file is runner's config as a
+ * Vite APPLICATION: `resolve.alias` plus `build`, with no `test` block, so no DOM
+ * environment and no setup files. The four `App.navigation.test.tsx` cases then
+ * ran in the node environment and died on `ReferenceError: window is not
+ * defined` — the run's own summary said `setup 0ms ... environment 0ms`.
+ *
+ * The fix routes that entry back to the ROOT config rather than giving runner a
+ * local one, and that choice is the part worth pinning:
+ *
+ *  - a package-local vitest config would be an 18th of exactly the kind
+ *    objectui#3240's maintainer ruling (option A, 2026-08-06) is to DELETE, and
+ *    it would resolve `@object-ui/*` through runner's own 15-entry alias table
+ *    (Node resolution, i.e. `dist`, for everything else) while the root config
+ *    maps ~40 of them to `src` — the "one file, two verdicts" divergence #3240
+ *    exists to remove;
+ *  - it would also lift the run out from under
+ *    `scripts/vitest-invocation-guard.mjs`, which is reachable only through the
+ *    root config: the objectui#3288 `--`-forwarding trap would silently stop
+ *    being refused for this package.
+ *
+ * So the script now spells the invocation AGENTS.md (§怎么跑测试) and the guard's
+ * own error message both prescribe for a package directory:
+ * `vitest run --root ../.. packages/runner/`. Both entries are then literally the
+ * same config, and the counts agree (13 tests in 3 files, either way).
+ *
+ * Reverse verification: restore `"test": "vitest run"` and this file goes red
+ * naming runner, while the repo-root entry stays green — the package entry is the
+ * only thing the change moves.
+ *
+ * Scope: this pins RUNNER. Seven sibling packages carry the same hijackable shape
+ * and are deliberately left alone — see BARE_ENTRY_BASELINE.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const RUNNER_DIR = 'packages/runner';
+
+/** Workspace groups from the root `package.json` that can hold a `test` script. */
+const WORKSPACE_GROUPS = ['packages', 'apps', 'examples'];
+
+const VITE_CONFIG = /^vite\.config\.[cm]?[jt]s$/;
+const VITEST_CONFIG = /^vitest\.config\.[cm]?[jt]s$/;
+const TEST_FILE = /\.test\.[cm]?[jt]sx?$/;
+
+/**
+ * Packages whose `test` script still hands vitest a package-level root while the
+ * directory holds a `vite.config.*` and no vitest config, so vitest adopts the
+ * app-facing Vite config. Whether each is actually RED depends on whether its
+ * tests touch the DOM (runner's did) — the shape is what is measured here, which
+ * is all a static check can honestly claim.
+ *
+ * Recorded as a CEILING, not an inventory: the list may shrink and must not grow.
+ * The repo-wide redefinition of the package-level `test` scripts belongs to
+ * objectui#3240 (maintainer ruling A), which is to run as its own batch; this
+ * file must not become a reason to touch these packages out of band.
+ */
+const BARE_ENTRY_BASELINE = [
+  'packages/plugin-ai',
+  'packages/plugin-chatbot',
+  'packages/plugin-designer',
+  'packages/plugin-editor',
+  'packages/plugin-markdown',
+  'packages/plugin-report',
+  'packages/plugin-tree',
+];
+
+type PackageEntry = {
+  /** Repo-relative directory, e.g. `packages/runner`. */
+  dir: string;
+  testScript: string;
+  hasViteConfig: boolean;
+  hasVitestConfig: boolean;
+};
+
+function readEntriesWithTestScript(): PackageEntry[] {
+  const entries: PackageEntry[] = [];
+  for (const group of WORKSPACE_GROUPS) {
+    const groupDir = path.join(repoRoot, group);
+    if (!fs.existsSync(groupDir)) continue;
+    for (const name of fs.readdirSync(groupDir)) {
+      const dir = path.join(groupDir, name);
+      const manifest = path.join(dir, 'package.json');
+      if (!fs.existsSync(manifest)) continue;
+      const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8')) as {
+        scripts?: Record<string, string>;
+      };
+      const testScript = pkg.scripts?.test;
+      if (!testScript) continue;
+      const files = fs.readdirSync(dir);
+      entries.push({
+        dir: `${group}/${name}`,
+        testScript,
+        hasViteConfig: files.some((f) => VITE_CONFIG.test(f)),
+        hasVitestConfig: files.some((f) => VITEST_CONFIG.test(f)),
+      });
+    }
+  }
+  return entries;
+}
+
+/** `process.argv` as pnpm would hand it to a package `test` script. */
+function argvForScript(script: string): string[] {
+  const tokens = script.trim().split(/\s+/);
+  // tokens[0] is the binary (`vitest`); in process.argv that slot is argv[1].
+  return ['/usr/bin/node', '/bin/vitest', ...tokens.slice(1)];
+}
+
+/**
+ * The directory this script makes vitest's ROOT — the cwd it is launched from,
+ * unless it points `--root` somewhere else. That root is what decides which
+ * config file vitest loads and what the projects' `include` globs resolve
+ * against (objectui#3378).
+ */
+function vitestRootOf(entry: PackageEntry): string {
+  const { flags } = parseVitestArgv(argvForScript(entry.testScript));
+  const raw = flags['--root'] ?? flags['-r'];
+  const cwd = path.join(repoRoot, entry.dir);
+  return typeof raw === 'string' ? path.resolve(cwd, raw) : cwd;
+}
+
+function collectTestFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectTestFiles(abs));
+    else if (TEST_FILE.test(entry.name)) out.push(abs);
+  }
+  return out;
+}
+
+const entries = readEntriesWithTestScript();
+
+function requireRunner(): PackageEntry {
+  const found = entries.find((e) => e.dir === RUNNER_DIR);
+  if (!found) {
+    throw new Error(
+      `${RUNNER_DIR} declares no "test" script. objectui#3746 pinned the SHAPE of that ` +
+        'entry; if the entry itself is being removed, retire this pin with it.'
+    );
+  }
+  return found;
+}
+
+const runner = requireRunner();
+
+describe('objectui#3746 — the runner package-level test entry', () => {
+  it('still has the hijackable shape: a vite.config with no `test` block, and no vitest config', () => {
+    // If either of these flips, the assertions below stop protecting what they
+    // were written for and this pin needs re-reading rather than re-spelling.
+    expect(runner.hasViteConfig).toBe(true);
+    expect(runner.hasVitestConfig).toBe(false);
+
+    const viteConfig = fs.readFileSync(path.join(repoRoot, RUNNER_DIR, 'vite.config.ts'), 'utf8');
+    expect(viteConfig).not.toMatch(/^\s*test\s*:/m);
+  });
+
+  it('routes vitest root back to the repo root instead of running under the app vite config', () => {
+    expect(runner.testScript).not.toBe('vitest run');
+    expect(vitestRootOf(runner)).toBe(repoRoot);
+  });
+
+  it('is accepted by the invocation guard that the root config wires up', () => {
+    // Root == repo root, and no `--` forwarding: the two refusals of
+    // objectui#3378 / #3288 both stay live for this entry, and it passes them.
+    const verdict = evaluateVitestInvocation({
+      argv: argvForScript(runner.testScript),
+      cwd: path.join(repoRoot, RUNNER_DIR),
+      repoRoot,
+    });
+
+    expect(verdict).toBeNull();
+  });
+
+  it("filters onto runner's own test files, all of them", () => {
+    const { positionals } = parseVitestArgv(argvForScript(runner.testScript));
+
+    // No filter would mean the package entry runs the WHOLE repo suite; a filter
+    // pointing outside runner would mean it runs somebody else's tests and calls
+    // them green — objectui#3378's original shape.
+    expect(positionals.length).toBeGreaterThan(0);
+    for (const positional of positionals) {
+      const abs = path.resolve(repoRoot, positional);
+      expect(fs.existsSync(abs), `${positional} does not exist relative to the repo root`).toBe(
+        true
+      );
+      expect(abs.startsWith(path.join(repoRoot, RUNNER_DIR))).toBe(true);
+    }
+
+    // Vitest matches a positional as a substring of each test file's path, so
+    // every one of runner's test files has to sit under one of them; otherwise the
+    // package entry would quietly run a subset of the package.
+    const testFiles = collectTestFiles(path.join(repoRoot, RUNNER_DIR));
+    expect(testFiles.length).toBeGreaterThan(0);
+    for (const file of testFiles) {
+      const rel = path.relative(repoRoot, file);
+      expect(
+        positionals.some((positional) => rel.startsWith(positional)),
+        `${rel} is not covered by the test script's filters (${positionals.join(' ')})`
+      ).toBe(true);
+    }
+  });
+
+  it('a bare `vitest run` from the package directory is the invocation this repo refuses', () => {
+    // Note what this does and does not claim. For runner the bare form never
+    // REACHED the guard: with no vitest config, vitest loaded `vite.config.ts` and
+    // the root config — the only place the guard is called from — was never
+    // evaluated, so the run proceeded in the node environment and produced four
+    // `window is not defined` failures instead of a refusal. This is the verdict
+    // the same invocation gets once the root config is in play, i.e. the reason
+    // the fix belongs in the script and not in a new package-local config.
+    const verdict = evaluateVitestInvocation({
+      argv: argvForScript('vitest run'),
+      cwd: path.join(repoRoot, RUNNER_DIR),
+      repoRoot,
+    });
+
+    expect(verdict?.code).toBe('package-cwd');
+  });
+});
+
+describe('objectui#3746 — the hijackable-entry population must not grow', () => {
+  const bareEntries = entries
+    .filter((e) => e.hasViteConfig && !e.hasVitestConfig && vitestRootOf(e) !== repoRoot)
+    .map((e) => e.dir)
+    .sort();
+
+  it('no longer counts runner', () => {
+    expect(bareEntries).not.toContain(RUNNER_DIR);
+  });
+
+  it('admits no package beyond the recorded baseline', () => {
+    // Subset, not equality: objectui#3240 fixing these must keep this green.
+    expect(bareEntries.filter((dir) => !BARE_ENTRY_BASELINE.includes(dir))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #3746

## 现象与机制(在干净 worktree 的 `origin/main` @ `6402e253f` 上原样复现)

```
$ pnpm --workspace-concurrency=2 --filter @object-ui/runner test --maxWorkers=2
 Test Files  1 failed | 2 passed (3)
      Tests  4 failed | 9 passed (13)
ReferenceError: window is not defined
   Duration  11.47s (transform 10.81s, setup 0ms, import 21.88s, tests 27ms, environment 0ms)
```

`packages/runner` 声明了 `"test": "vitest run"` 却没有 vitest 配置。pnpm 把 cwd 定在包目录,
vitest 于是把该目录里那份 **Vite 应用**配置 `vite.config.ts` 当成自己的配置读进来 —— 它只有
`resolve.alias` / `build`,没有 `test` 块,所以没有 DOM 环境也没有 setup(上面那次运行自己的
汇总就写着 `setup 0ms ... environment 0ms`),`App.navigation.test.tsx` 的 4 个用例在 node
环境里撞死在 `window` 上。仓根入口带 projects/happy-dom/setup,所以 CI 一直是绿的。

## 修法:把这个入口指回仓根配置,而不是给 runner 补一份包级配置

派单缺省形状是「给 runner 补 vitest 配置」。落地时发现那条路与仓内两处既有事实冲突,故改成
本 PR 这一行 —— 两点都有 file:line 证据:

1. **#3240 的维护者裁决是 A:全删 17 份包级 vitest 配置、统一走仓根配置**
   (2026-08-06,评论 5200265431),并在同单**重定义包级 `test` 脚本的语义为「对仓根配置传
   路径过滤」**。再新增第 18 份是往一个已有拆除方案的债上加码;而且包级配置解析
   `@object-ui/*` 走 runner 自己那张 15 条的 alias 表(其余落 `dist`),仓根配置则把 ~40 个
   包名指向 `src` —— 正是 #3240 要消灭的「同一文件两套结论」。
2. **包级配置会把这次运行从 `scripts/vitest-invocation-guard.mjs` 底下抬出去。** guard 只在
   `vitest.config.mts` 顶部被调用(`vitest.config.mts:5`、`:23`),包级独立配置根本不加载它,
   于是 #3288 的 `--` 转发陷阱对本包不再被拒绝。仓内已有这种独立配置的包(如
   `packages/plugin-charts/vitest.config.ts`)就处于这个状态。

所以 `packages/runner/package.json` 的脚本改成 AGENTS.md(§怎么跑测试,第 184 行)与 guard
报错正文都明确指定的那条写法:

```diff
-    "test": "vitest run"
+    "test": "vitest run --root ../.. packages/runner/"
```

两个入口从此是**同一份配置**,不存在漂移面;`--root` 指回仓根后 guard 依旧在链路上(root 等于
仓根 → 放行,`--` 转发 → 照样拒绝)。

## 两个入口都绿、用例数一致

```
$ pnpm --workspace-concurrency=2 --filter @object-ui/runner test --maxWorkers=2
> vitest run --root ../.. packages/runner/ --maxWorkers=2
 RUN  v4.1.10 /home/user/objectui-3746
 Test Files  3 passed (3)
      Tests  13 passed (13)
   Duration  13.48s (... setup 453ms ... environment 507ms)     # 环境与 setup 真的生效了

$ pnpm exec vitest run packages/runner/src --maxWorkers=2
 Test Files  3 passed (3)
      Tests  13 passed (13)
```

仓根 projects 机制不受影响 —— 以注册面为证,runner 的 3 个文件各自**只在一个** project 注册,
既不重复也不缺:

```
$ pnpm exec vitest list --filesOnly packages/runner/
[unit] packages/runner/src/plugin-integration.test.ts
[unit] packages/runner/src/__tests__/spec-symbol-batch7.test.ts
[dom] packages/runner/src/App.navigation.test.tsx
```

⛔ 未改动仓根 `vitest.config.mts`(本 PR 只有 2 个文件)。

## 防回归钉子

`scripts/__tests__/runner-package-test-entry-3746.test.ts`(独立文件,与在飞单零共享),
7 条断言分两组:

- **runner 这一条入口**:目录仍是「有 `vite.config.ts` 且其中没有 `test` 块、没有 vitest
  配置」的可劫持形状;脚本把 vitest root 指回仓根;该调用被 guard 判为放行;位置过滤解析得到
  的目录确实在 `packages/runner` 内,且**覆盖 runner 全部测试文件**(防「悄悄只跑一部分」)。
- **全仓棘轮**:按谓词「有 vite.config、无 vitest 配置、脚本没把 root 指回仓根」扫全仓,
  runner 已不在其中;其余命中以**上限**方式记录(见下),断言是**子集**而非相等 —— #3240 把
  它们修好时这条依然绿。

## 顺带测到、⛔ 本 PR 不修的面

issue 正文说 runner 的特殊之处是「只有它目录里有一个 `vite.config.ts` 可被 vitest 误取」。
实测**不止它一个**:同形状(有 `vite.config.ts`、无 vitest 配置、bare `vitest run`)共 8 个包,
除 runner 外还有 `plugin-ai`、`plugin-chatbot`、`plugin-designer`、`plugin-editor`、
`plugin-markdown`、`plugin-report`、`plugin-tree`。是否同红取决于各自的测试是否碰 DOM
(runner 碰了),本 PR 不声称、也不顺手改 —— 它们的整改属于 #3240 的单独批次,已把这份实测清单
评论到 #3240 上,并作为棘轮的 baseline 记在钉子里。

## 反向验证(方向先判后跑,三条全部与预判一致)

把脚本还原成 `"test": "vitest run"`:

| 预判 | 实测 |
|:--|:--|
| 包级入口红,同样 4 个 `window is not defined` | `Tests 4 failed \| 9 passed (13)` + `ReferenceError: window is not defined` ✅ |
| 钉子红 7 条中的 5 条并点名 runner(另 2 条 —— 形状事实与 guard 纯输入对照 —— 必须仍绿) | `Tests 5 failed \| 2 passed (7)`,含 `expected [ 'packages/runner' ] to deeply equal []` ✅ |
| 仓根入口保持绿 | `Test Files 3 passed (3) / Tests 13 passed (13)` ✅ |

## 门禁

- `pnpm exec turbo run type-check --concurrency=2`(CI 同命令):`78 successful, 78 total`。
- `pnpm type-check:scripts`:干净 —— `turbo run type-check` 结构上到不了 `scripts/`,
  新钉子文件由这条覆盖。
- `pnpm exec eslint scripts/__tests__/runner-package-test-entry-3746.test.ts`:exit 0。
- `node scripts/check-control-bytes.mjs`:OK(3762 个文件);改动文件
  `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 零命中。
- changeset:`node scripts/check-changeset-presence.mjs` → 「No source of a released package
  changed in this range, so no changeset is owed.」未动任何发版包的 `src/`;仓内同类先例
  (#3378/#3288 的 guard PR `34a3badc9`,4 个文件全是测试/配置面)也没带 changeset。

## 与在飞单的关系

- #3240(17 包 vitest 配置整改,裁决 A,须单独空批次):**不相交,且同向** —— 本 PR 没有新增
  任何包级 vitest 配置,只把 runner 一条脚本改成 #3240 已裁决的那种语义;#3240 执行时对 runner
  是幂等的。
- #3849 / #3546 切片六 / #3749 / #3735:文件面零相交(#3735 若也落 `scripts/__tests__/`,
  本 PR 用的是带 3746 的独立文件名)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_