### PR TITLE
fix(react-runtime): 给 react peer 范围补上上界 ^18.0.0 || ^19.0.0 (#3741)

### DIFF
--- a/.changeset/react-runtime-peer-upper-bound-3741.md
+++ b/.changeset/react-runtime-peer-upper-bound-3741.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/react-runtime': patch
+---
+
+Give `@object-ui/react-runtime`'s React peer range an upper bound: `peerDependencies.react` narrows from `>=18` to `^18.0.0 || ^19.0.0`, the spelling the other 30 react peers in the fixed version group already declare (objectui#3741).
+
+An unbounded range is a promise that grows on its own. `>=18` satisfies React 20 the day React 20 is published — a major this package has never been built against, let alone tested — and it makes that claim from an already-published manifest, with no commit and no review to point at. This package is the least appropriate place in the workspace for such a promise: it vendors react-runner and evaluates author-supplied JSX against the *host's* React, so a host on an untested major does not fail at this package's boundary, it fails somewhere inside the page it rendered.
+
+Nothing in the package wanted the wider range. Its entire React surface is `Component`, `createElement`, `isValidElement`, `ReactElement` and `ReactNode`, all unchanged in React 19 and none of them touching anything React 19 removed. The range was never a stated constraint either: `>=18` was written when the package was created on 2026-06-30 (`d23d6ebfa`, PR #2105) and no commit since revisited the line. The workspace pins React to `19.2.8` through the root `pnpm.overrides`, so 19 is the only major this package's tests have ever exercised — the unbounded upper end was untested by construction.
+
+The README sentence restating the range moves with it, and the doc gate that compares the two (`doc-version-claims.test.ts`, objectui#3717) keeps them in step from here.
+
+A new pin, `scripts/__tests__/react-peer-range-norm-3741.test.ts`, now asserts the norm across every workspace manifest, because this was the third package born off-norm and the first two were each corrected in isolation: `plugin-dashboard` was born narrow and fixed on 2026-05-08 (`d2b6ecec6`), `plugin-report` was born narrow and fixed in objectui#3690 (PR #3727) after a React 19 consumer hit `ERESOLVE` on install, and this one was born unbounded. The existing doc gate could not have caught any of them — it checks a README against its own manifest, and react-runtime's two sides agreed with each other while both said `>=18`.

--- a/packages/react-runtime/README.md
+++ b/packages/react-runtime/README.md
@@ -24,7 +24,7 @@ lazy-load it behind a capability flag.
 npm install @object-ui/react-runtime
 ```
 
-`react >= 18` is a peer dependency.
+`react ^18.0.0 || ^19.0.0` is a peer dependency.
 
 ## Usage
 

--- a/packages/react-runtime/package.json
+++ b/packages/react-runtime/package.json
@@ -28,7 +28,7 @@
     "sucrase": "^3.35.0"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {}
 }

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -56,9 +56,14 @@ import { fileURLToPath } from 'node:url';
  * untouched, and both directions of the ratchet report green over a README that now
  * misstates the range. objectui#3690 was exactly that shape, found by a human census
  * (there the README was right and the MANIFEST lagged it — the assertion is symmetric, it
- * names the disagreement, not the guilty side). objectui#3741, still open, proposes
- * narrowing react-runtime's manifest range; the day someone does, this test goes red until
- * that README follows.
+ * names the disagreement, not the guilty side). objectui#3741 was the prediction this
+ * paragraph used to carry as future tense: it narrowed react-runtime's manifest from the
+ * unbounded `>=18` to the group's `^18.0.0 || ^19.0.0`, and this test did exactly what was
+ * written here — it went red until that README followed, in the same change. Worth keeping
+ * as the worked example, because it is also the case that shows what this assertion does
+ * NOT do: both sides said `>=18` and AGREED, so nothing here objected for the five weeks
+ * the unbounded range sat in a published manifest. Agreement is not correctness. The norm
+ * itself is asserted separately, in `react-peer-range-norm-3741.test.ts`.
  *
  * Two boundaries, both deliberate, both pinned below:
  *
@@ -554,9 +559,9 @@ const KNOWN_CLAIMS: KnownClaim[] = [
   { file: 'packages/react/README.md', claim: PEER_18_19, kind: 'restatement', why: PEER_RESTATEMENT_OK },
   {
     file: 'packages/react-runtime/README.md',
-    claim: 'react >= 18',
+    claim: 'react ^18.0.0',
     kind: 'restatement',
-    why: 'Restates this package peerDependencies.react, which is literally ">=18" — the one README whose looser spelling is the manifest spelling.',
+    why: 'Restates this package peerDependencies.react verbatim, in the prose spelling rather than a peer block. Until objectui#3741 both sides read ">=18": the manifest was the last react peer in the workspace with no upper bound, so the README faithfully restated a range that would have claimed React 20 the day it shipped. Narrowing the manifest to the group norm brought this line with it — the restatement was never the defect, the range it restated was.',
   },
   {
     file: 'packages/plugin-chatbot/README.md',
@@ -594,7 +599,7 @@ const RANGE_OPENS = /^[\^~><=\d]/;
  *   - a bullet in a peer-dependency list — 11 of the 12 entries, one spelling between them:
  *       - `react` ^18.0.0 || ^19.0.0
  *   - one code span read as prose, `packages/react-runtime/README.md` alone:
- *       `react >= 18` is a peer dependency.
+ *       `react ^18.0.0 || ^19.0.0` is a peer dependency.
  *
  * Note what the range is here and is not in the inventory key: the key stops at the first
  * version token (`^18.0.0`), this reads the range to end of line (`^18.0.0 || ^19.0.0`).
@@ -689,19 +694,28 @@ function peerBlockBullets(rel: string): PeerBullet[] | null {
 /**
  * Range equality: VERBATIM, up to whitespace INSIDE the range.
  *
- * That one-space normalisation is not a softening, and it exists for a measured reason.
- * `packages/react-runtime/README.md` writes `react >= 18` while its manifest writes
- * `>=18`. Nothing is drifted there — the two spell the same single comparator and npm
- * parses them identically — so byte-strict equality would paint that entry red on a tree
- * where nothing is wrong. The only two answers to such a red are to rewrite one side for
- * the gate's benefit, or to declare the entry uncovered: a cosmetic edit, or lost
- * coverage, in exchange for nothing.
+ * HISTORY — why the normalisation was written. `packages/react-runtime/README.md` wrote
+ * `react >= 18` while its manifest wrote `>=18`. Nothing was drifted there — the two
+ * spell the same single comparator and npm parses them identically — so byte-strict
+ * equality would have painted that entry red on a tree where nothing was wrong. The only
+ * two answers to such a red are to rewrite one side for the gate's benefit, or to declare
+ * the entry uncovered: a cosmetic edit, or lost coverage, in exchange for nothing.
  *
- * Everything this assertion exists to catch survives, because whitespace is the only
- * thing dropped: a bumped major, a `||` arm added or removed, `^` turning into `~`, a
- * vanished upper bound all still compare unequal. Pinned by its own test below — a
- * normaliser that quietly grew to strip operators would make the whole assertion vacuous
- * while every other test in this file stayed green.
+ * CURRENT STATE — that specimen is gone. objectui#3741 narrowed react-runtime's manifest
+ * to the `^18.0.0 || ^19.0.0` group norm (it was the last react peer in the workspace with
+ * no upper bound) and brought the README sentence with it, so both sides now spell the
+ * range identically. Measured on the tree at that change: 21 peer statements resolve to a
+ * manifest counterpart and ZERO of them differ by whitespace alone. The normaliser is
+ * therefore exercised only by its own unit test below, not by the corpus.
+ *
+ * It stays anyway, and deliberately: the two spellings it equates are equally correct npm
+ * ranges, so the day a README writes `>= 19` beside a `>=19` manifest the gate should stay
+ * green rather than demand a cosmetic edit. Tightening it to bytes would buy no new defect
+ * class — everything this assertion exists to catch survives the normalisation, because
+ * whitespace is the only thing dropped: a bumped major, a `||` arm added or removed, `^`
+ * turning into `~`, a vanished upper bound all still compare unequal. Pinned by its own
+ * test below — a normaliser that quietly grew to strip operators would make the whole
+ * assertion vacuous while every other test in this file stayed green.
  */
 const sameRange = (a: string, b: string): boolean =>
   a.replace(/\s+/g, '') === b.replace(/\s+/g, '');
@@ -1152,6 +1166,15 @@ describe('doc version claims - the peer-line assertion', () => {
       dep: 'react-router-dom',
       range: '^6.0.0 || ^7.0.0',
     });
+    // react-runtime's prose sentence, in the spelling it carries since objectui#3741.
+    expect(parsePeerStatement(ticked('react ^18.0.0 || ^19.0.0') + ' is a peer dependency.')).toEqual({
+      dep: 'react',
+      range: '^18.0.0 || ^19.0.0',
+    });
+    // The same shape carrying a single comparator. No longer in the corpus — it WAS
+    // react-runtime's spelling until objectui#3741 narrowed it — but kept because
+    // RANGE_OPENS admits `>` and a prose line is the shape most likely to be written
+    // that way again.
     expect(parsePeerStatement(ticked('react >= 18') + ' is a peer dependency.')).toEqual({
       dep: 'react',
       range: '>= 18',
@@ -1175,8 +1198,10 @@ describe('doc version claims - the peer-line assertion', () => {
   });
 
   it('treats whitespace inside a range as insignificant, and nothing else', () => {
-    // The one pair the normalisation exists for, and the only place in the corpus where
-    // README and manifest differ by anything at all.
+    // The pair the normalisation was written for. It is no longer a corpus pair — since
+    // objectui#3741 every one of the 21 resolved statements matches its manifest byte for
+    // byte — so these two cases are now the ONLY thing keeping the normalisation honest.
+    // See `sameRange` for why it is kept rather than tightened to bytes.
     expect(sameRange('>= 18', '>=18')).toBe(true);
     expect(sameRange('^18.0.0 || ^19.0.0', '^18.0.0||^19.0.0')).toBe(true);
 

--- a/scripts/__tests__/react-peer-range-norm-3741.test.ts
+++ b/scripts/__tests__/react-peer-range-norm-3741.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3741: `packages/react-runtime/package.json` declared
+ * `peerDependencies.react` as `>=18` — no upper bound — while every other react peer
+ * in the workspace declared `^18.0.0 || ^19.0.0`. An unbounded range does not merely
+ * look untidy: the day React 20 ships, that manifest starts claiming compatibility with
+ * a major nobody here has built against, let alone tested, and it makes the claim
+ * silently, in a published package, with no commit and no review to point at.
+ *
+ * Why this is a gate and not just the one-line fix it accompanies: react-runtime is the
+ * THIRD package born off-norm, and the first two were each corrected in isolation with
+ * nothing left behind to stop a fourth.
+ *
+ *   - `plugin-dashboard` was born narrow (`^18.0.0` alone) and corrected on 2026-05-08
+ *     (`d2b6ecec6`) inside an unrelated build fix.
+ *   - `plugin-report` was born narrow on 2026-02-06 (`1e557cbda`) and corrected in
+ *     objectui#3690 / PR #3727 — by then a React 19 consumer installing the published
+ *     package hit an `ERESOLVE` while every sibling installed clean.
+ *   - `react-runtime` was born unbounded on 2026-06-30 (`d23d6ebfa`, PR #2105) and is
+ *     corrected here.
+ *
+ * Three hand-authored manifests, three different wrong spellings, one norm they were all
+ * supposed to copy. That is an authoring mistake with a pattern, which is the case for
+ * enforcing the norm mechanically rather than trusting the next author to look.
+ *
+ * ## Why the existing peer gate could not catch it
+ *
+ * `doc-version-claims.test.ts` already pins peer ranges (objectui#3717, widened in
+ * #3750) — but it compares a README's peer line to ITS OWN manifest. That check is blind
+ * to this defect in two independent ways, and react-runtime tripped both:
+ *
+ *   1. It judges the two sides against EACH OTHER, not against the norm. react-runtime's
+ *      README said `react >= 18` and its manifest said `>=18`; they agreed, so the gate
+ *      was green for the five weeks the unbounded range sat there. A wrong range spelled
+ *      consistently on both sides is invisible to it by construction.
+ *   2. It can only see a manifest that has a README peer line beside it. 11 of 39
+ *      packages carry a peer block; the other 28 declare peers no doc restates, so their
+ *      ranges are judged by nothing at all.
+ *
+ * So the two gates ask genuinely different questions. That one asks "does the doc tell
+ * the truth about the manifest"; this one asks "does the manifest state the range the
+ * fixed version group agreed on". Neither subsumes the other.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * The one spelling. Not derivable from anything in the tree — it is a convention about
+ * which React majors this repo builds and tests against — so it is written here as the
+ * single place that states it, and this test is what makes "declared" mean "enforced".
+ *
+ * Both halves of the range are load-bearing and for different reasons. The `^18.0.0` arm
+ * is the floor the packages actually support. The `^19.0.0` arm is the CEILING: it is
+ * what stops a published manifest from promising a major that does not exist yet. The
+ * workspace resolves React through a root `pnpm.overrides` pin (`19.2.8` at the time of
+ * writing), so 19 is also the only major any of these packages has ever been exercised
+ * against — an upper bound above it would be a claim with no test behind it.
+ *
+ * Moving the norm (adding a `^20.0.0` arm when React 20 is genuinely supported) is
+ * deliberately a repo-wide act: every declaration moves together or this test goes red.
+ * That is the intent. A fixed version group that ships 39 packages from one release
+ * cannot have per-package React support windows without the difference being a lie
+ * somewhere.
+ */
+const REACT_PEER_NORM = '^18.0.0 || ^19.0.0';
+
+/** The React packages the norm governs. Both were widened together in objectui#3690. */
+const GOVERNED = ['react', 'react-dom'] as const;
+
+interface WorkspacePackage {
+  name: string;
+  dir: string;
+  peerDependencies: Record<string, string>;
+}
+
+/**
+ * The `packages:` globs from `pnpm-workspace.yaml`, read rather than hardcoded so a new
+ * workspace root is covered the day it is added — and throwing rather than skipping on a
+ * shape it does not understand, because a guard that quietly stops looking at part of the
+ * workspace keeps reporting success over a shrinking surface. Same reasoning, and the
+ * same two supported shapes (`dir/*` and a bare `dir`), as
+ * `workspace-peer-dependency-edges.test.ts`.
+ */
+function workspaceGlobs(): string[] {
+  const yaml = fs.readFileSync(path.join(repoRoot, 'pnpm-workspace.yaml'), 'utf8');
+  const lines = yaml.split('\n');
+  const start = lines.findIndex((l) => /^packages:\s*$/.test(l));
+  expect(start, '`pnpm-workspace.yaml` must still declare a top-level `packages:` key').toBeGreaterThan(-1);
+
+  const globs: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    // A non-indented line ends the `packages:` block.
+    if (!/^\s/.test(line)) break;
+    const match = line.match(/^\s*-\s*['"]?([^'"#\s]+)['"]?\s*(#.*)?$/);
+    if (!match) {
+      throw new Error(
+        `Unparsed entry in pnpm-workspace.yaml \`packages:\`: ${JSON.stringify(line)} — teach this guard the new syntax.`,
+      );
+    }
+    globs.push(match[1]);
+  }
+  return globs;
+}
+
+function readWorkspacePackages(): WorkspacePackage[] {
+  const found: WorkspacePackage[] = [];
+  for (const glob of workspaceGlobs()) {
+    let dirs: string[];
+    if (glob.endsWith('/*')) {
+      const parent = path.join(repoRoot, glob.slice(0, -2));
+      dirs = fs.existsSync(parent)
+        ? fs
+            .readdirSync(parent)
+            .map((d) => path.join(parent, d))
+            .filter((d) => fs.statSync(d).isDirectory())
+        : [];
+    } else if (!glob.includes('*')) {
+      dirs = [path.join(repoRoot, glob)];
+    } else {
+      throw new Error(`Unsupported workspace glob ${JSON.stringify(glob)} — teach this guard how to expand it.`);
+    }
+
+    for (const dir of dirs) {
+      const pkgPath = path.join(dir, 'package.json');
+      if (!fs.existsSync(pkgPath)) continue;
+      const json = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      if (!json.name) continue;
+      found.push({
+        name: json.name,
+        dir: path.relative(repoRoot, dir),
+        peerDependencies: json.peerDependencies ?? {},
+      });
+    }
+  }
+  return found;
+}
+
+const packages = readWorkspacePackages();
+
+interface Declaration {
+  pkg: WorkspacePackage;
+  dep: string;
+  range: string;
+}
+
+const declarations: Declaration[] = packages.flatMap((pkg) =>
+  GOVERNED.filter((dep) => pkg.peerDependencies[dep] !== undefined).map((dep) => ({
+    pkg,
+    dep,
+    range: pkg.peerDependencies[dep],
+  })),
+);
+
+describe('React peer ranges state the fixed version group norm', () => {
+  it('discovers the workspace and its React peers (guard cannot pass by finding nothing)', () => {
+    // Without these floors a broken glob parser or a moved directory would turn the
+    // assertions below into a vacuous pass over an empty list — the failure mode that
+    // makes a green gate worthless.
+    expect(packages.length, 'the workspace globs resolved to implausibly few packages').toBeGreaterThan(30);
+
+    // Measured on the objectui#3741 branch: 31 `react` + 25 `react-dom` = 56. A floor
+    // rather than a pin, because this legitimately shrinks when a package stops needing
+    // the host to supply React.
+    expect(
+      declarations.length,
+      'implausibly few React peer declarations were found - the manifest read collapsed and ' +
+        'this gate is now green over nothing',
+    ).toBeGreaterThanOrEqual(50);
+  });
+
+  it('declares every React peer as the norm, with no exemptions', () => {
+    const violations = declarations
+      .filter((d) => d.range !== REACT_PEER_NORM)
+      .map((d) => `${d.pkg.name} (${d.pkg.dir}/package.json) declares "${d.dep}": ${JSON.stringify(d.range)}`);
+
+    expect(
+      violations,
+      [
+        `Every React peer range in this workspace must read exactly ${JSON.stringify(REACT_PEER_NORM)}:`,
+        '',
+        ...violations,
+        '',
+        'There is deliberately NO exemption list here, and there should not become one: at the',
+        'time of writing all 56 declarations satisfy this, so an exemption would be',
+        'indistinguishable from the bug it was added to hide (the same reasoning as',
+        'workspace-peer-dependency-edges.test.ts).',
+        '',
+        'An unbounded range (`>=18`) is the specific defect objectui#3741 fixed - it claims a',
+        'major that does not exist yet. A narrow one (`^18.0.0` alone) is objectui#3690 - it',
+        'makes a React 19 consumer hit ERESOLVE on install. Both spellings have shipped from',
+        'this repo before; neither is a matter of taste.',
+        '',
+        'If React 20 support is real, widen the norm above and every declaration in the same',
+        'change, and say so in a changeset - the version group releases as one.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('pins the package fixed in objectui#3741', () => {
+    // The general assertion above catches a regression here too, but naming it means a
+    // revert points straight at the issue that explains why the bound exists, rather than
+    // at a rule someone has to go and read.
+    const pkg = packages.find((p) => p.name === '@object-ui/react-runtime');
+    expect(pkg, '@object-ui/react-runtime must exist in the workspace').toBeDefined();
+    expect(
+      pkg!.peerDependencies.react,
+      'react-runtime declared an unbounded `>=18` from its creation (PR #2105) until ' +
+        'objectui#3741. It vendors react-runner and evaluates JSX against the host React, ' +
+        'so it is exactly the package with no business promising a major it has never seen.',
+    ).toBe(REACT_PEER_NORM);
+  });
+});


### PR DESCRIPTION
Fixes #3741

## 前提复核(先证实,再动手)

基线 `origin/main` @ `7fbef94a99ad7c0c2a8d4e737065c8b443619079`。

- `git show origin/main:packages/react-runtime/package.json` 确认 `"react": ">=18"` 仍在。**前提成立。**
- 实测全仓拼法分布(遍历所有 package.json 的 `peerDependencies`):**声明 `react` peer 的 31 个包中 30 个是 `^18.0.0 || ^19.0.0`**,唯一例外就是 react-runtime 的 `>=18`;另有 **25 个 `react-dom` peer,全部 25 个都是 `^18.0.0 || ^19.0.0`**。合计 56 条声明,55 条合规,越界的恰好一条。issue 正文给的数字准确,`^18.0.0 || ^19.0.0` 确是固定组规范。
- 有没有「更宽」的正当理由?查了三处,**均无支持**:
  - `>=18` 是建包那天(`d23d6ebfa`,PR #2105,2026-06-30)写下的,此后该行从未被任何 commit 重新审视过;
  - 该包全部 React 面只有 `Component` / `createElement` / `isValidElement` / `ReactElement` / `ReactNode`,React 19 一个都没改,也没碰任何 React 19 移除的 API;
  - 仓根 `pnpm.overrides` 把 react 钉在 `19.2.8`,**19 是这个包的测试唯一跑过的 major** —— 无上界的那一端从构造上就没有测试覆盖。

因此按缺省方向直接对齐,不留「故意更宽」的注记。

## 改动

1. `packages/react-runtime/package.json`:`peerDependencies.react` 由 `>=18` 收窄为 `^18.0.0 || ^19.0.0`。同文件**没有**其它 peer(该包只声明 `react` 一条,无 `react-dom`),全仓也再无第二条无上界 peer。
2. `packages/react-runtime/README.md`:restate 该范围的那句散文随之改写。
3. `scripts/__tests__/doc-version-claims.test.ts`:ledger 条目与三处叙述更新(见下)。
4. 新增 `scripts/__tests__/react-peer-range-norm-3741.test.ts` 防回归钉子。
5. changeset:`patch`,照 #3727(同族先例,peer 范围变更)的级别。

## 为什么 README 与 ledger 必须同 PR 改

不是顺手扩面,是**被现存门禁强制**的联动。`doc-version-claims.test.ts` 的 peer-line 断言(#3717,#3750 扩面)逐字比对「README 的 peer 行」与「它自己的清单」。react-runtime 的 README 写着 `react >= 18`,只改清单会立刻让该门禁变红。

值得一提的是:**这份门禁的文件头早就把这次改动写成了预言** —— 原文「objectui#3741, still open, proposes narrowing react-runtime's manifest range; the day someone does, this test goes red until that README follows」。反向验证里它精确地按这句话红了(见下)。该段现已改写为「历史 + 现状」两段(#3749/#3860 的写法)。

同样按「历史 + 现状」改写的还有两处**原本会退化成失效断言**的叙述:

- `sameRange` 的空白归一化,其**实测依据**正是 react-runtime 的 `>= 18` vs 清单 `>=18` 这一对。本次改完,实测 **21 条 peer 语句全部与清单逐字节相等,0 条依赖空白归一化** —— 该归一化如今只由自己的单元测试覆盖,不再由语料覆盖。这一点在注释里如实写明(并说清为何仍然保留而不收紧到逐字节:它等同的两种写法都是合法 npm range,收紧买不到任何新的缺陷类)。
- 对应的单元测试注释原写「the only place in the corpus where README and manifest differ by anything at all」,已随之修正;`parsePeerStatement` 的散文用例改为现行拼法,同时**保留** `>= 18` 那条(RANGE_OPENS 仍接受 `>`,散文行最可能再被那样写)。

README 沿用散文拼法而非改成 `**Peer Dependencies:**` 列表块:它是语料里**唯一**触发 parser 散文分支的样本,改成列表块会白掉一条真实分支覆盖,且属于无谓改动。

## 防回归钉子:现有门禁看不到这一类

先查:仓内既有 peer 相关门禁两处 —— `workspace-peer-dependency-edges.test.ts`(peer 是否能被 turbo `^build` 走到)与上述 peer-line 断言。**两者都覆盖不到本 issue 这一类**,而且 react-runtime 同时踩中两个盲点:

1. peer-line 断言比的是「两侧互相是否一致」,**不是「是否符合规范」**。react-runtime 的 README 与清单当时都写 `>=18`,**两边一致**,于是这条无上界范围在已发布清单里躺了五周而门禁全绿。一致 ≠ 正确。
2. 它只能看到「旁边有 README peer 行」的清单。39 个包里 11 个写了 peer 块,余下 28 个声明的 peer 无任何文档 restate,其范围**不被任何东西判定**。

所以新增钉子问的是另一个问题:**清单是否声明了固定组约定的那个范围**。形状照抄近邻 `workspace-peer-dependency-edges.test.ts`(同目录、同主题、同「不设豁免名单」理由):读 `pnpm-workspace.yaml` 的 globs(遇到不认识的语法直接 throw 而非跳过)、遍历工作区清单、断言每条 `react` / `react-dom` peer 逐字等于规范值、带空转下限(包数 > 30、声明数 >= 50,实测 56),并按名钉住 #3741 修的这个包。

立钉子的理由是「三次同型」而非一次:react-runtime 是**第三个**出生即不合规的包,前两个都是各自单独修掉、没留下任何东西阻止第四个 —— `plugin-dashboard` 生来过窄、2026-05-08 在一个无关构建修复里(`d2b6ecec6`)顺手改掉;`plugin-report` 生来过窄,直到 #3690 / PR #3727,期间 React 19 用户装它会撞 `ERESOLVE`。

规范值写成常量并附理由:下界 `^18.0.0` 是真实支持底线,上界 `^19.0.0` 是**关键的那一半**(阻止清单承诺尚不存在的 major)。将来真支持 React 20,须**全仓 56 条一起动**否则钉子变红 —— 这正是意图:一个 39 包同发的固定组不该有 per-package 的 React 支持窗口。

## 反向验证(方向先判、后跑)

**预判**:仅把清单改回 `>=18`(README 与 ledger 保持已修正状态),应当是常规的「红」向 —— 新钉子红 2 条(通用规范断言 + 按名钉住的 #3741 条),空转下限那条应保持绿;peer-line 断言红 1 条(两侧不再一致)。

**实跑与预判一致**,共 3 红 / 14 绿:

```
× declares every React peer as the norm, with no exemptions
× pins the package fixed in objectui#3741
× pins every peer statement to the range its own manifest declares
  - packages/react-runtime/README.md:27  react: README says "^18.0.0 || ^19.0.0", manifest says ">=18"
  - @object-ui/react-runtime (packages/react-runtime/package.json) declares "react": ">=18"
  - expected '>=18' to be '^18.0.0 || ^19.0.0'
 Test Files  2 failed (2)
      Tests  3 failed | 14 passed (17)
```

空转下限 `discovers the workspace and its React peers` 如期保持绿 —— 证明红是来自被判定的值,不是来自扫描塌缩。随后恢复,复跑全绿。

## 验证

全部在仓根、`flock /tmp/os-heavy-verify.lock` 下、`NODE_OPTIONS=--max-old-space-size=4096`、`--maxWorkers=2`,未用 `--` 转发形式。

- `pnpm --workspace-concurrency=2 --filter '@object-ui/react-runtime^...' build` → `No projects matched the filters`(该包无工作区依赖,唯一 dep 是外部 `sucrase`,如实记录)。
- `pnpm exec vitest run packages/react-runtime/ scripts/__tests__/doc-version-claims.test.ts scripts/__tests__/react-peer-range-norm-3741.test.ts scripts/__tests__/workspace-peer-dependency-edges.test.ts` → `Test Files 4 passed (4) / Tests 39 passed (39)`。
- 全仓 `pnpm exec turbo run type-check --concurrency=2`(CI 同命令)→ `Tasks: 78 successful, 78 total`。
- **补跑 `pnpm type-check:scripts`** → exit 0。`turbo run type-check` 走 package.json 的 scripts,**结构上到不了没有 package.json 的 `scripts/`**(#3494 的原委),新钉子若只靠 turbo 会是编译器从未读过的钉子;另经 `tsc --listFiles` 确认该文件确实在被编译,并跑 `scripts-type-check.test.ts` → 8 passed。
- `pnpm exec eslint` 两个 scripts 文件 → exit 0。
- 三个 changeset 门禁 → 全 exit 0(`no-major` / `fixed` / `presence`)。
- `node scripts/check-control-bytes.mjs` → OK(3763 文件);改动文件 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 零命中。
- **lockfile:`pnpm install` 后 `git status --porcelain` 无 `pnpm-lock.yaml`** —— peer 范围收窄未触发 lockfile 变化(root overrides 已把 react 钉在 19.2.8,解析结果不变)。

## 协调

文件面与在飞 #3849 / #3546 切片六 / #3735 / #3746 零相交。#3735 同在 `scripts/`,但本 PR 只新增一个独立文件(名带 3741)并改 `doc-version-claims.test.ts`,与其面不重叠。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_