### PR TITLE
fix(core): ActionRunner.execute 的 disabled 门改问「有没有条件」,空谓词不再拦掉执行 (#3848)

### DIFF
--- a/.changeset/action-runner-declared-disabled-gate-3848.md
+++ b/.changeset/action-runner-declared-disabled-gate-3848.md
@@ -1,0 +1,54 @@
+---
+"@object-ui/core": patch
+---
+
+An empty `disabled` predicate no longer refuses to run the action (objectui#3848)
+
+`ActionRunner.execute` — the engine's public execution entry, shared by every
+action surface — gated on `action.disabled != null && action.disabled !== false`
+and handed the value straight to `evaluateCondition`. That function documents one
+default for "there is no condition here": return `true`, meaning
+*visible/enabled*. On `disabled`, `true` means BLOCKED. So every empty predicate
+was read as "disabled": the handler was never invoked and the caller got
+`{ success: false, error: 'Action is disabled' }` — a state the metadata never
+declared. Measured with a call-counting handler:
+
+- `disabled: ''` — handler ran: false
+- `disabled: '   '` (whitespace only) — handler ran: false
+- `disabled: { dialect: 'cel', source: '' }` (the empty envelope `objectstack build` can emit) — handler ran: false
+
+After objectui#3842 / objectui#3849 fixed the renderer halves, this was live
+user-visible behaviour: the button became clickable and clicking it returned
+`Action is disabled` — the renderer and the execution entry disagreeing about one
+predicate value, the shape objectui#3314 already paid for once.
+
+The gate now asks whether a `disabled` gate is DECLARED — whether there is a
+condition to reach a verdict on — before evaluating. "Nothing to evaluate" is
+read from core's single predicate normalizer (`toPredicateInput`, which maps
+`''`, `null`, an empty-`source` envelope and non-predicate values to
+`undefined`), plus the whitespace-only string, which the normalizer wraps rather
+than collapses and which `evaluateCondition` itself calls "no condition"
+(`evalRowPredicate` applies the same blank-source rule).
+
+**Behaviour change surface, deliberately one-directional.** Only values with
+nothing to evaluate change, and only from blocked to allowed: `''`,
+whitespace-only, an empty-`source` envelope, and non-predicate junk (`0`, `{}`,
+which previously coerced to "disabled"). `disabled: true`, a truthy expression
+and a truthy CEL envelope still block; `disabled: false` and an absent `disabled`
+still run; no expression- or envelope-valued predicate changes verdict. The
+existing `catch { isDisabled = false }` fail-open posture is untouched, and this
+change can only stop blocking things, never start.
+
+The value handed to the evaluator is deliberately left RAW rather than normalized
+first. `evaluateCondition(toPredicateInput(x))` is not interchangeable with
+`evaluateCondition(x)` for a string that is already a `${…}` template:
+`toPredicateInput` assumes a bare expression and wraps unconditionally, so
+`'${x}'` becomes `'${${x}}'`, fails to parse, returns verbatim, and coerces to a
+constant `true` — a template-spelled predicate evaluated that way is ALWAYS
+"disabled", whatever it says. That normalizer defect is filed as objectui#3871
+(it is live at the action renderers and `ActionEngine`, while `SchemaRenderer` and
+`page:header` evaluate the raw value and pin the correct verdict); a tripwire next
+to the new pins goes red the day it is fixed. Two rows therefore still differ
+between the execution and renderer paths, each recorded with its owning issue:
+the empty envelope (objectui#3850 owns the renderer half's scope ruling) and the
+`${…}` spelling (objectui#3871).

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -24,6 +24,7 @@
 import type { RunnableActionType } from '@object-ui/types';
 import type { ActionInput as SpecActionInput } from '@objectstack/spec/ui';
 import { ExpressionEvaluator } from '../evaluator/ExpressionEvaluator';
+import { toPredicateInput } from '../evaluator/predicateInput';
 import { globalUndoManager, type UndoableOperation } from './UndoManager';
 import { warnOnUnknownActionKeys } from './actionKeys';
 
@@ -526,6 +527,67 @@ function withIdentityAlias(context: ActionContext): ActionContext {
   return { ...context, os: { ...(os && typeof os === 'object' ? os : {}), user } };
 }
 
+/**
+ * Did this action declare a `disabled` gate at all — i.e. is there a CONDITION
+ * for the evaluator to reach a verdict on? (objectui#3848)
+ *
+ * `ExpressionEvaluator.evaluateCondition` documents and implements one default
+ * for "there is no condition here": it returns `true`, meaning
+ * *visible/enabled*. That default is correct on `visible` / `enabled`, and
+ * INVERTED on `disabled`, where `true` means "blocked". So the execution gate
+ * must decide "is there a condition?" itself, BEFORE evaluating — asking
+ * `!= null && !== false` (what it used to ask) hands every empty predicate to a
+ * function whose answer for "nothing to evaluate" is the strongest possible
+ * "yes, disabled". Measured consequence: `disabled: ''` returned
+ * `{ success: false, error: 'Action is disabled' }` and the handler never ran.
+ *
+ * The shapes `evaluateCondition` itself calls "no condition" are `null` /
+ * `undefined` / `''` / a whitespace-only string (`if (!trimmed) return true`) /
+ * an envelope whose `source` is blank. This gate excludes exactly those:
+ *
+ *   - `toPredicateInput` is core's single predicate normalizer and already maps
+ *     `''`, `null`, `undefined`, an empty-`source` envelope, and any
+ *     non-predicate junk (`0`, `{}`) to `undefined` = "nothing to evaluate".
+ *   - the whitespace-only string is the one shape it does NOT collapse (it
+ *     wraps it as `'${   }'`), so it is named here. This is the same blank-source
+ *     rule core's other predicate entry already applies —
+ *     `evalRowPredicate` (`evaluator/listConditional.ts`) returns its fallback
+ *     for `!source.trim()`.
+ *
+ * ## Why the gate normalizes but the VERDICT still reads the raw value
+ *
+ * `evaluateCondition(toPredicateInput(raw))` is NOT interchangeable with
+ * `evaluateCondition(raw)` for a string that is ALREADY a `${…}` template:
+ * `toPredicateInput` assumes a bare expression and wraps unconditionally, so
+ * `'${x}'` becomes `'${${x}}'`, which no longer matches the single-template
+ * fast path, fails to parse, and comes back as the original NON-EMPTY STRING —
+ * `Boolean(…)` = `true`. A `${…}`-spelled `disabled` predicate evaluated that
+ * way is therefore ALWAYS "disabled", whatever it says. Measured on this tree:
+ * `disabled: '${user.role === "guest"}'` (false, admin context) → blocked.
+ *
+ * So the value handed to the evaluator is left exactly as it was. Every
+ * non-empty shape — boolean, bare CEL, `${…}` template, `{ dialect, source }`
+ * envelope — keeps the verdict it reaches today, and this change can only stop
+ * blocking things, never start. The double-wrap itself is a defect of
+ * `toPredicateInput`, live at the action renderers and `ActionEngine` (which do
+ * compose it that way) and filed separately; `SchemaRenderer` and `page:header`
+ * both evaluate the raw value and both pin the correct verdict for that
+ * spelling, which is the behaviour preserved here.
+ *
+ * Scope note: `hasDeclaredVisibilityGate`
+ * (`components/renderers/action/visibility-gate.ts`, `!= null && !== ''`) is
+ * the renderer-side spelling of this question. It is deliberately NOT reused or
+ * moved: it lives in a package that depends on this one, it does not cover the
+ * empty-`source` envelope (objectui#3850) or the whitespace string, and
+ * objectui#3850 is the queued ruling on unifying the scope of "empty
+ * predicate" across the sites. Kept module-private until that lands — one gate,
+ * one site, no new exported dialect of the same question.
+ */
+function hasDisabledCondition(value: unknown): boolean {
+  if (typeof value === 'string' && value.trim() === '') return false;
+  return toPredicateInput(value) !== undefined;
+}
+
 export class ActionRunner {
   private handlers = new Map<string, ActionRunnerHandler>();
   private scripts = new Map<string, ActionRunnerHandler>();
@@ -663,7 +725,15 @@ export class ActionRunner {
         }
       }
 
-      if (action.disabled != null && action.disabled !== false) {
+      // Ask "is a `disabled` gate DECLARED?" — not "is the key present and not
+      // `false`?" (objectui#3848). The old test let every EMPTY predicate reach
+      // `evaluateCondition`, whose answer for "no condition" is `true`, which on
+      // this key means BLOCKED: `disabled: ''` / `'   '` /
+      // `{ dialect: 'cel', source: '' }` all returned `Action is disabled` with
+      // the handler never invoked. See `hasDisabledCondition` above for why the
+      // gate normalizes to decide but the verdict below still reads the RAW
+      // value (`toPredicateInput` double-wraps an already-`${…}` string).
+      if (hasDisabledCondition(action.disabled)) {
         // `disabled` may be a boolean, a CEL string, or the normalized envelope
         // `{ dialect, source }` (what `objectstack build` emits). The previous
         // code only evaluated the STRING form and treated any object as truthy,

--- a/packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts
@@ -1,0 +1,266 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3848 — `ActionRunner.execute`'s declared-`disabled` gate. The
+ * EXECUTION half of the objectui#3492 family whose renderer halves are
+ * objectui#3842 (PR #3851) and objectui#3849 (PR #3861).
+ *
+ * The gate asked `action.disabled != null && action.disabled !== false`, so every
+ * EMPTY predicate got past it and was handed to `evaluateCondition` — which
+ * documents exactly one default for "there is no condition here": return `true`,
+ * meaning visible/enabled. On `disabled` that `true` means BLOCKED. Measured on
+ * `origin/main` @ f0a625aa7 before this change, with a `probe` handler that
+ * counts its own calls:
+ *
+ *   disabled ''                        | handler ran: false | {"success":false,"error":"Action is disabled"}
+ *   disabled '   '                     | handler ran: false | {"success":false,"error":"Action is disabled"}
+ *   disabled {dialect:'cel',source:''} | handler ran: false | {"success":false,"error":"Action is disabled"}
+ *   disabled absent                    | handler ran: true  | {"success":true}
+ *   disabled false                     | handler ran: true  | {"success":true}
+ *
+ * So this was not "the click did nothing" — execution was refused and the caller
+ * got an error naming a state the metadata never declared.
+ *
+ * ## What each row detects
+ *
+ *   • the three EMPTY shapes (`''`, whitespace-only, empty-`source` envelope) →
+ *     the handler must run. THE defect; each is an independent mutation
+ *     detector, since the three arrive at "nothing to evaluate" by three
+ *     different routes (string identity, `trim()`, envelope `source`).
+ *   • `true` / a truthy expression / a truthy CEL envelope → still blocked.
+ *     Anti-mutation guards: "never block anything" satisfies most of this table
+ *     on its own, and these are what refuse it.
+ *   • `false` / absent → still runs (ungated stays ungated), and `false` proves
+ *     the gate did not start treating a declared-and-false gate as absent.
+ *   • the non-predicate junk rows (`0`, `{}`) → now run. Behaviour change, and
+ *     the fail-open direction the file already commits to (`catch { isDisabled
+ *     = false }`): a value that is not a predicate at all must not decide that
+ *     an action is disabled.
+ *
+ * ## The parity claim, and the two rows it deliberately does NOT make
+ *
+ * `rendererDisabled` is transcribed from objectui#3848's divergence table (the
+ * action face as it stands after #3842 + #3849), NOT recomputed here:
+ * `@object-ui/core` is the dependency of the renderer packages, so it cannot
+ * import them, and the live renderer-side pins are in those two PRs' tests. The
+ * parity test below therefore asserts that the verdicts THIS suite pins equal
+ * the verdicts recorded from the renderers — the #3314 invariant (one predicate
+ * value, one answer, whichever entry reads it) — for every row where that claim
+ * is honest. Two rows are excluded, each with its owning issue:
+ *
+ *   • `{ dialect: 'cel', source: '' }` — the renderer still greys this out
+ *     (`hasDeclaredVisibilityGate` is `!= null && !== ''`, which an envelope
+ *     passes). That residual is objectui#3850, the queued ruling on how wide
+ *     "empty predicate" is across the sites; the execution side pins the
+ *     normalized semantics (an envelope with no source is nothing to evaluate).
+ *     Not fixed here — objectui#3850 owns the renderer half.
+ *   • a `${…}`-spelled predicate — the action-face renderers compose
+ *     `evaluateCondition(toPredicateInput(x))`, which double-wraps an
+ *     already-templated string into `'${${x}}'` and comes back TRUE whatever the
+ *     expression says. That is objectui#3871. The execution path keeps reading
+ *     the RAW value and therefore keeps the correct verdict — the same verdict
+ *     `SchemaRenderer` and `page:header` already pin for that spelling.
+ *
+ * ## Reverse verification (direction predicted before running)
+ *
+ * Restoring the old gate (`action.disabled != null && action.disabled !== false`)
+ * while leaving evaluation untouched must turn exactly the five
+ * nothing-to-evaluate rows RED — `''`, `'   '`, the empty envelope, `0`, `{}` —
+ * each naming its own shape, and leave `absent` / `false` / `true` / both
+ * expression rows / both non-empty envelope rows GREEN. That is the whole diff:
+ * this change can only stop blocking things, never start.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ActionRunner, type ActionContext, type ActionDef } from '../ActionRunner';
+import { ExpressionEvaluator } from '../../evaluator/ExpressionEvaluator';
+import { toPredicateInput } from '../../evaluator/predicateInput';
+
+const CONTEXT: ActionContext = {
+  data: { id: 1 },
+  record: { id: 1, status: 'active' },
+  user: { id: 'u1', role: 'admin' },
+};
+
+interface Shape {
+  label: string;
+  /** Omit the key entirely (the "undeclared" row). */
+  absent?: boolean;
+  disabled?: unknown;
+  /** Execution-side expectation: does the gate refuse to run the handler? */
+  blocked: boolean;
+  /**
+   * The action-face renderer's verdict for the SAME value, transcribed from
+   * objectui#3848's table. `null` = parity deliberately not claimed for this
+   * row; `divergence` names the issue that owns the difference.
+   */
+  rendererDisabled: boolean | null;
+  divergence?: string;
+}
+
+const SHAPES: Shape[] = [
+  // ── the defect: nothing to evaluate must not block ───────────────────────
+  { label: "disabled: '' (empty predicate)", disabled: '', blocked: false, rendererDisabled: false },
+  { label: "disabled: '   ' (whitespace-only predicate)", disabled: '   ', blocked: false, rendererDisabled: false },
+  {
+    label: "disabled: { dialect: 'cel', source: '' } (empty envelope)",
+    disabled: { dialect: 'cel', source: '' },
+    blocked: false,
+    rendererDisabled: null,
+    divergence: 'objectui#3850 — the renderer still reads an empty-source envelope as a declared gate',
+  },
+  // ── unchanged: ungated stays ungated ────────────────────────────────────
+  { label: 'disabled absent (undeclared)', absent: true, blocked: false, rendererDisabled: false },
+  { label: 'disabled: false (declared, verdict false)', disabled: false, blocked: false, rendererDisabled: false },
+  // ── unchanged: a real gate still blocks ─────────────────────────────────
+  { label: 'disabled: true', disabled: true, blocked: true, rendererDisabled: true },
+  {
+    label: 'disabled: bare CEL that is true',
+    disabled: 'user.role == "admin"',
+    blocked: true,
+    rendererDisabled: true,
+  },
+  {
+    label: 'disabled: bare CEL that is false',
+    disabled: 'user.role == "guest"',
+    blocked: false,
+    rendererDisabled: false,
+  },
+  {
+    label: "disabled: { dialect: 'cel', source: 'true' }",
+    disabled: { dialect: 'cel', source: 'true' },
+    blocked: true,
+    rendererDisabled: true,
+  },
+  {
+    label: "disabled: { dialect: 'cel', source: 'false' }",
+    disabled: { dialect: 'cel', source: 'false' },
+    blocked: false,
+    rendererDisabled: false,
+  },
+  {
+    label: 'disabled: legacy template that is true',
+    disabled: '${user.role === "admin"}',
+    blocked: true,
+    rendererDisabled: null,
+    divergence: 'objectui#3871 — the renderers double-wrap a template-spelled predicate into a constant true',
+  },
+  {
+    label: 'disabled: legacy template that is false',
+    disabled: '${user.role === "guest"}',
+    blocked: false,
+    rendererDisabled: null,
+    divergence: 'objectui#3871 — same double-wrap; here it is the row where the constant true is WRONG',
+  },
+  // ── behaviour change: non-predicate junk fails open ─────────────────────
+  { label: 'disabled: 0 (not a predicate)', disabled: 0, blocked: false, rendererDisabled: null, divergence: 'objectui#3871 family — the renderers coerce junk through the same compose' },
+  { label: 'disabled: {} (not a predicate)', disabled: {}, blocked: false, rendererDisabled: null, divergence: 'objectui#3871 family — the renderers coerce junk through the same compose' },
+];
+
+/** Execute one shape and report whether the handler ran. */
+async function runShape(shape: Shape) {
+  const runner = new ActionRunner(CONTEXT);
+  const onClick = vi.fn();
+  const action: Record<string, unknown> = { onClick };
+  if (!shape.absent) action.disabled = shape.disabled;
+  const result = await runner.execute(action as unknown as ActionDef);
+  return { result, ran: onClick.mock.calls.length > 0 };
+}
+
+describe('ActionRunner.execute — declared `disabled` gate (objectui#3848)', () => {
+  it.each(SHAPES)('$label', async (shape) => {
+    const { result, ran } = await runShape(shape);
+    if (shape.blocked) {
+      expect(ran).toBe(false);
+      expect(result).toEqual({ success: false, error: 'Action is disabled' });
+    } else {
+      // The handler RUNNING is the assertion that matters: objectui#3848 was
+      // measured by the handler never being invoked, not by a missing toast.
+      expect(ran).toBe(true);
+      expect(result.success).toBe(true);
+      expect(result.error).toBeUndefined();
+    }
+  });
+
+  it('an empty predicate does not even reach the evaluator (the gate decides, not the verdict)', async () => {
+    const runner = new ActionRunner(CONTEXT);
+    const spy = vi.spyOn(
+      runner.getEvaluator() as unknown as { evaluateCondition: (c: unknown) => boolean },
+      'evaluateCondition',
+    );
+    const onClick = vi.fn();
+    await runner.execute({ disabled: '', onClick } as unknown as ActionDef);
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('the execution verdict equals the renderer verdict for every shape where parity is claimed', () => {
+    const claimed = SHAPES.filter(s => s.rendererDisabled !== null);
+    // Guard the guard: if a future edit nulls out the whole column, this test
+    // would pass by asserting nothing.
+    expect(claimed.length).toBeGreaterThanOrEqual(8);
+    for (const shape of claimed) {
+      expect(
+        shape.blocked,
+        `${shape.label}: execution and the action-face renderer must agree (objectui#3314)`,
+      ).toBe(shape.rendererDisabled);
+    }
+  });
+
+  it('records which shapes are knowingly still divergent, and who owns each', () => {
+    const divergent = SHAPES.filter(s => s.rendererDisabled === null);
+    for (const shape of divergent) {
+      expect(shape.divergence, `${shape.label} must name the issue that owns it`).toMatch(/objectui#\d+/);
+    }
+    expect(divergent.map(s => s.label)).toEqual([
+      "disabled: { dialect: 'cel', source: '' } (empty envelope)",
+      'disabled: legacy template that is true',
+      'disabled: legacy template that is false',
+      'disabled: 0 (not a predicate)',
+      'disabled: {} (not a predicate)',
+    ]);
+  });
+});
+
+describe('why the gate cannot delegate "is there a condition?" to the verdict (objectui#3848)', () => {
+  it('evaluateCondition answers `true` for "no condition" — which on `disabled` means blocked', () => {
+    const ev = new ExpressionEvaluator(CONTEXT);
+    // The inverted default, in one line. This is the whole mechanism: correct on
+    // `visible`/`enabled`, backwards on `disabled`.
+    expect(ev.evaluateCondition(undefined)).toBe(true);
+    expect(ev.evaluateCondition('')).toBe(true);
+    expect(ev.evaluateCondition('   ')).toBe(true);
+    expect(ev.evaluateCondition({ dialect: 'cel', source: '' })).toBe(true);
+  });
+
+  it('toPredicateInput collapses two of the three empty shapes, and wraps the third', () => {
+    // Why the gate is not simply `toPredicateInput(x) !== undefined`: the
+    // whitespace string survives normalization as an evaluable-looking template,
+    // so the gate names it explicitly (same blank-source rule `evalRowPredicate`
+    // applies in `evaluator/listConditional.ts`).
+    expect(toPredicateInput('')).toBeUndefined();
+    expect(toPredicateInput({ dialect: 'cel', source: '' })).toBeUndefined();
+    expect(toPredicateInput('   ')).toBe('${   }');
+  });
+
+  it('TRIPWIRE (objectui#3871): toPredicateInput double-wraps an already-`${…}` string into a constant true', () => {
+    const ev = new ExpressionEvaluator(CONTEXT);
+    const falsePredicate = '${user.role === "guest"}';
+    // Raw — the correct verdict, and what this gate evaluates.
+    expect(ev.evaluateCondition(falsePredicate)).toBe(false);
+    // Normalized — wrapped a second time, unparseable, returned verbatim, truthy.
+    expect(toPredicateInput(falsePredicate)).toBe('${${user.role === "guest"}}');
+    expect(ev.evaluateCondition(toPredicateInput(falsePredicate) as never)).toBe(true);
+    // When objectui#3871 is fixed this case goes RED on the last two
+    // expectations. That is the signal to delete this tripwire and (only then)
+    // let the gate evaluate the normalized value, which is what objectui#3848's
+    // dispatch originally proposed.
+  });
+});


### PR DESCRIPTION
Fixes #3848

基线 `origin/main` = `f0a625aa7b00c93a48329e1c456b1aeacfceba43`(即 #3849 / PR #3861 落地那一提交)。文件面仅 `packages/core`。

## 机理

`ActionRunner.execute` 的执行门问的是 `action.disabled != null && action.disabled !== false`,然后把**原始值**直接交给 `evaluateCondition` —— 而那个函数对「这里没有条件」只有一个默认答案:返回 `true`,含义是 *visible/enabled*。在 `disabled` 这个键上,`true` 的意思恰好相反,是「已禁用」。于是任何空谓词都被判成禁用:handler 一次不跑,调用方收到一个元数据从未声明过的 `{ success: false, error: 'Action is disabled' }`。

#3842 / #3849 修完渲染器两侧之后,这已经是**活的**用户可见行为:按钮能点了,点下去收到 `Action is disabled`。同一个谓词值,渲染器与执行入口给出相反答案 —— #3314 已经付过一次代价的形状。

## 逐形状新旧对照(计数 handler,同一张探针表跑基线与改后)

「拦」= handler 未被调用且返回 `Action is disabled`;「跑」= handler 被调用、`success: true`。

| `disabled` | 基线(旧门) | 改后 | 动作面渲染器(#3848 正文表) |
|---|---|---|---|
| `''` | **拦** | 跑 | 可点 |
| `'   '`(纯空白) | **拦** | 跑 | 可点 |
| `{ dialect: 'cel', source: '' }` | **拦** | 跑 | 置灰(#3850 归属) |
| 未声明 | 跑 | 跑 | 可点 |
| `false` | 跑 | 跑 | 可点 |
| `true` | 拦 | 拦 | 置灰 |
| 裸 CEL 取真 `user.role == "admin"` | 拦 | 拦 | 置灰 |
| 裸 CEL 取假 `user.role == "guest"` | 跑 | 跑 | 可点 |
| `{ dialect: 'cel', source: 'true' }` | 拦 | 拦 | 置灰 |
| `{ dialect: 'cel', source: 'false' }` | 跑 | 跑 | 可点 |
| `'${user.role === "admin"}'`(模板取真) | 拦 | 拦 | 置灰(#3871) |
| `'${user.role === "guest"}'`(模板取假) | 跑 | 跑 | 置灰(#3871,该行渲染器错) |
| `0`(非谓词) | **拦** | 跑 | 置灰(#3871 同族) |
| `{}`(非谓词) | **拦** | 跑 | 置灰(#3871 同族) |

变化只有加粗那五行,方向一律是「拦 → 放行」。

## 修法

新门先问「有没有条件可判」,再求值。「没有条件」的判定取自 core 唯一的谓词归一器 `toPredicateInput`(把 `''`/`null`/空 `source` envelope/非谓词值映射为 `undefined`),外加纯空白字符串 —— 归一器对它是包裹而非折叠,而 `evaluateCondition` 自己就把空白 `trimmed` 叫做「没有条件」,`evalRowPredicate`(`evaluator/listConditional.ts`)用的也是这条 blank-source 规则。`catch { isDisabled = false }` 失败放行姿态原样保留。

### 为什么求值仍读原始值,而不是归一结果

派发时的优先形状是「先 `toPredicateInput` 归一,再据归一结果求值」。逐形状实测发现这个复合对**已经是 `${…}` 模板**的字符串不成立:`toPredicateInput` 假定入参是裸表达式、无条件包裹,`'${x}'` 变成 `'${${x}}'`,单模板快路 `/^\$\{([^}]+)\}$/` 不再匹配,内层解析失败后 catch 里原样退回,`Boolean(非空串)` 恒为 `true`。也就是说那样求值的模板谓词**永远「已禁用」**,与表达式取值无关。实测:`disabled: '${user.role === "guest"}'`(admin context,取假)基线放行 → 归一求值后被拦。

这是本 PR 唯一偏离派发形状的地方:归一只用于**判门**,verdict 仍读原始值,于是每个非空形状的 verdict 逐一不变,本改动只可能少拦、不可能多拦。归一器的二次包裹缺陷另立 **#3871**(动作面渲染器与 `ActionEngine` 都以该复合书写,因此都中招;而 `SchemaRenderer` 与 `page:header` 读原始值、各自有钉子钉住正确 verdict)。钉子里留了指向 #3871 的 tripwire,该单修好那天它会红,提示可以让本门改读归一结果。

仍然不一致的两行都写明归属,不在本单顺手修:空 `source` envelope 的渲染器半边归 **#3850**(「空谓词」范围裁决,在队),`${…}` 拼法归 **#3871**。⛔ 未碰 `components/visibility-gate.ts`、未搬 helper 进 core、未碰 `packages/react`(#3862)。

## 钉子

`packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts`(表驱动,形状抄 PR #3851 / #3861 的钉子风格):14 形状逐一断言 handler 跑没跑;一条断言空谓词**根本不该到达求值器**(门决定,不是 verdict 决定);一条断言「已声明 parity 的每一行,执行侧 verdict 等于渲染器侧 verdict」(渲染器列是从 #3848 正文表**转录**的证据 —— core 是渲染器包的被依赖方,不能反向 import,活的渲染器钉子在 #3842/#3861 的测试里),并把两行**故意不声明** parity 的形状连同归属单号一起钉住;另有机理钉:`evaluateCondition(undefined) === true` 这条反向默认值,以及 #3871 的 tripwire。

### 反向验证(方向先判后跑,预判写在钉子头注释里)

还原旧门(`!= null && !== false`)、求值不动 → 预判「恰好五行『没有条件』变红并各自点名形状,非空形状全绿」。实跑:

```
 ❯ packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts (20 tests | 6 failed)
     × 'disabled: \'\' (empty predicate)'
     × 'disabled: \'   \' (whitespace-only pr…'
     × 'disabled: { dialect: \'cel\', source:…'
     × 'disabled: 0 (not a predicate)'
     × 'disabled: {} (not a predicate)'
     × an empty predicate does not even reach the evaluator (the gate decides, not the verdict)
      Tests  6 failed | 14 passed (20)
```

与预判一致(第六条红的是那条「不该到达求值器」的钉子,同属这条门)。

## 验证

```
pnpm exec vitest run packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts --maxWorkers=2
  → Test Files 1 passed (1) | Tests 20 passed (20)

pnpm exec vitest run packages/core/src/actions packages/core/src/evaluator --maxWorkers=2   # 消费半径
  → Test Files 25 passed (25) | Tests 596 passed (596)

pnpm exec vitest run packages/core --maxWorkers=2
  → Test Files 68 passed (68) | Tests 1489 passed (1489)

pnpm exec vitest run packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx --maxWorkers=2
  → Test Files 1 passed (1) | Tests 11 passed (11)

pnpm exec turbo run type-check --concurrency=2
  → Tasks: 78 successful, 78 total

node scripts/check-control-bytes.mjs
  → OK (scanned 3768 tracked text file(s))
```

全仓扫过执行门的消费半径:`Action is disabled` 的断言只在 `packages/core`;`components` / `plugin-detail` 里的 `disabled: ''` 用例全是渲染器侧钉子,不经 `ActionRunner.execute`,未受影响。

## 顺手发现(已另立,未在本 PR 修)

- **#3871** —— `toPredicateInput` 对已经是 `${…}` 模板的字符串二次包裹,动作面渲染器与 `ActionEngine` 因此把模板谓词一律判成 true(`visible` 永远显示 / `disabled` 永远置灰),而 `SchemaRenderer` 与 `page:header` 对同一拼法是对的(各有绿钉子)。
- **#3872** —— 就在本门上面一行:`condition` 门用真值判定(`if (action.condition)`),于是 `condition: false`(最明确的「永不执行」)**照样执行**,实测 handler 跑了;而同义的 `{ dialect: 'cel', source: 'false' }` 被拦。#3812 的形状,方向是过度放行。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_