### PR TITLE
fix(i18n): es 的 preview.draftBar 统一 usted,横幅不再在发布后换人称 (#3844)

### DIFF
--- a/.changeset/draftbar-es-register-3844.md
+++ b/.changeset/draftbar-es-register-3844.md
@@ -1,0 +1,59 @@
+---
+'@object-ui/i18n': patch
+---
+
+`preview.draftBar` speaks one second person in `es` — the draft-preview banner no
+longer switches from tú to usted when a Spanish user publishes (#3844)
+
+`DraftPreviewBar` renders two mutually exclusive sentences in the same strip of
+the same banner: `message` while there are unpublished changes, `messageClean`
+once there are none. In `es` the two disagreed on register — `message` was tú
+(`estás viendo`, `publiques`) while `messageClean` (`ve`) and `sampleDataBody`
+(`Está`, `su`, `Publíquela`) were usted. So a Spanish user who pressed Publish
+watched the banner change person: same component, same position, same session.
+
+This is a third defect class in the value-domain blind spot behind #3582 and
+#3625, and no gate in the repo can see it. Both `es` values are correct
+translations of their `en` sentences — nothing is missing, nothing is stale, and
+nothing holds English. The inconsistency is *internal to one pack, on one UI
+surface*: `scripts/check-i18n-call-site-keys.mjs` only asks whether a key exists
+in `en`, `all-locales-key-parity` compares key sets and placeholder shapes and
+never reads values, and `scripts/check-i18n-en-drift.mjs` only fires when an `en`
+value moves — these two `en` values never moved.
+
+`message` is the value that changes, because usted is what the pack already says
+everywhere around it: the `es` pack censuses 102 usted markers to 30 tú (tú being
+the marked exception, concentrated in the auth, report-editor and organizations
+neighbourhoods that #3546 slice two deliberately ruled informal); the other three
+strings of this same object were already usted; and #3546 slice five gave the 19
+new `preview.unpublishedBar.*` / `preview.history.*` keys usted on the strength
+of `home.pendingDrafts.published` ("¡Publicado! Sus cambios están activos."). Two
+smaller divergences inside the same sentence are closed with it, so the banner's
+two halves stop disagreeing about wording as well as person:
+
+- **`—` instead of `:`** in `messageClean`, matching `en`, where both sentences
+  open `Draft preview — `. That is the whole of `messageClean`'s diff.
+- **`activo` instead of `en producción`** for "live". The pack spells this concept
+  `activo` in four neighbouring places including `publishCta` in this very object
+  ("Publicar para verlo activo"), and it reserves *producción* for the actual
+  production environment (`environment.entitlement.planLockedBody`), so the
+  outlier was ambiguous as well as inconsistent.
+- **`Vista previa del borrador`** as the shared opening, `del` being the form
+  `messageClean` already used.
+
+No `en` value changes (the en-drift gate reports 0), no key is added or removed
+(so `all-locales-key-parity` is untouched by construction), and the nine other
+packs are not touched. The diff is two values in one file.
+
+Re-voicing the whole `preview` namespace to tú was considered and rejected — a
+much larger change that would collide with the adjacent `marketplace.*` (9:0
+usted) and `console.ai.*`. `preview.empty.notReadyDescription` therefore stays
+tú on purpose: it is a different surface, nothing switches under the user
+mid-session, and #3844's body records it. A gate that checks "one register per
+namespace" is deliberately **not** here: recognising usted vs tú needs real
+morphology (the ad-hoc regex used to take the census above already miscounted the
+imperative `Revisa` as a tú marker), and the neighbourhood boundary such a gate
+would police is human judgement — #3546 slice two's "same rule, different
+answer". A new `draftBar-es-register-3844.test.ts` pins the four `es` values byte
+for byte instead, plus the `en` literals, so a future reword of either `en`
+sentence fails in the same PR that reworded it.

--- a/.changeset/draftbar-es-register-3844.md
+++ b/.changeset/draftbar-es-register-3844.md
@@ -47,13 +47,19 @@ packs are not touched. The diff is two values in one file.
 
 Re-voicing the whole `preview` namespace to tú was considered and rejected — a
 much larger change that would collide with the adjacent `marketplace.*` (9:0
-usted) and `console.ai.*`. `preview.empty.notReadyDescription` therefore stays
-tú on purpose: it is a different surface, nothing switches under the user
-mid-session, and #3844's body records it. A gate that checks "one register per
-namespace" is deliberately **not** here: recognising usted vs tú needs real
-morphology (the ad-hoc regex used to take the census above already miscounted the
-imperative `Revisa` as a tú marker), and the neighbourhood boundary such a gate
-would police is human judgement — #3546 slice two's "same rule, different
-answer". A new `draftBar-es-register-3844.test.ts` pins the four `es` values byte
-for byte instead, plus the `en` literals, so a future reword of either `en`
-sentence fails in the same PR that reworded it.
+usted) and `console.ai.*`. `preview.empty.notReadyDescription` therefore stays tú
+here, since #3844's ruling is this banner only; it is filed as #3875 rather than
+waved through, because `PreviewDraftEmptyState` renders *underneath*
+`DraftPreviewBar` and so those two show usted and tú on screen at the same time.
+After this change the `preview` namespace is 23 usted to that 1 tú.
+
+A gate that checks "one register per namespace" is deliberately **not** here:
+recognising usted vs tú needs real morphology, and token matching demonstrably
+cannot — in this pack the token `revisa` is usted in `console.ai.empty.build`
+(es.ts:1365, "…y usted revisa y publica.") and tú in
+`auth.forgotPassword.successTitle` (es.ts:1918, "Revisa tu correo electrónico"),
+the same eight letters in opposite registers. The neighbourhood boundary such a
+gate would police is human judgement anyway — #3546 slice two's "same rule,
+different answer". A new `draftBar-es-register-3844.test.ts` pins the four `es`
+values byte for byte instead, plus the `en` literals, so a future reword of
+either `en` sentence fails in the same PR that reworded it.

--- a/packages/i18n/src/__tests__/draftBar-es-register-3844.test.ts
+++ b/packages/i18n/src/__tests__/draftBar-es-register-3844.test.ts
@@ -1,0 +1,192 @@
+/**
+ * `preview.draftBar` speaks ONE second person in `es` — usted (objectui#3844).
+ *
+ * ## The defect this pins
+ *
+ * `DraftPreviewBar` renders two mutually exclusive sentences in the same strip
+ * of the same banner: `message` when there are unpublished changes,
+ * `messageClean` when there are none. In `es` the two disagreed on register —
+ * `message` was tú (`estás viendo`, `publiques`) while `messageClean` (`ve`)
+ * and `sampleDataBody` (`Está`, `su`, `Publíquela`) were usted. A Spanish user
+ * who pressed Publish watched the banner switch from tú to usted: same
+ * component, same position, same session.
+ *
+ * ## Why usted is the answer here (the ruling, not a preference)
+ *
+ * Three independent readings, all measured rather than guessed:
+ *
+ *   1. **Pack default.** The `es` pack censuses 102 usted markers against 30
+ *      tú. tú is the marked exception, concentrated in auth sign-in/sign-up,
+ *      the report editor and organizations — neighbourhoods objectui#3546
+ *      slice two deliberately ruled informal. `preview` is not one of them.
+ *   2. **Same banner, same voice.** The other two strings of this very object
+ *      (`messageClean`, `sampleDataBody`) were already usted, and so is
+ *      `publishCta`. Aligning the one outlier is a strictly smaller change
+ *      than re-voicing the namespace, and it is the change that removes the
+ *      user-visible switch.
+ *   3. **The sister banner.** objectui#3546 slice five gave the 19 new
+ *      `preview.unpublishedBar.*` / `preview.history.*` keys usted, on the
+ *      strength of `home.pendingDrafts.published` ("¡Publicado! Sus cambios
+ *      están activos."), the structural twin of
+ *      `preview.unpublishedBar.published`. Leaving `draftBar.message` tú would
+ *      have made the older banner disagree with its freshly-translated sister.
+ *
+ * Direction B (re-voicing all of `preview` to tú) was rejected: it is a much
+ * larger change and would collide with the adjacent `marketplace.*` (9:0
+ * usted) and `console.ai.*`.
+ *
+ * ## What this file deliberately does NOT do
+ *
+ * **No morphological register detection.** objectui#3844 evaluated a gate that
+ * checks "one register per namespace" and argued it down: recognising usted vs
+ * tú needs real morphology, and the ad-hoc regex used to take the census above
+ * already miscounted the imperative `Revisa` as a tú marker. Worse, the
+ * boundary such a gate would police — which neighbourhood is informal — is
+ * human judgement (slice two's "same rule, different answer" precedent), so a
+ * gate could only ever check consistency *within* a boundary it cannot draw.
+ * This file therefore pins **these four literal values, byte for byte**, and
+ * generalises to nothing. The retired-spelling checks below are exact
+ * substrings lifted from the pre-fix value of this one key — the same
+ * technique as `viewReadonlyTooltip-semantics-3625.test.ts` — not a register
+ * rule in disguise.
+ *
+ * Scope note: `preview.empty.notReadyDescription` is still tú and is left
+ * that way on purpose. It is a different surface (an empty state, not this
+ * banner), nothing switches under the user mid-session, and re-voicing the
+ * whole namespace is exactly the rejected direction B. objectui#3844's body
+ * records it.
+ *
+ * Related: objectui#3546 (slice five measured this while ruling es register),
+ * objectui#3810 / objectui#3582 / objectui#3625 (the other value-domain blind
+ * spots), objectui#3530 (call-site gate), objectui#3650 (en-drift gate). None
+ * of the three i18n gates can see this defect: the call-site gate only asks
+ * whether a key exists in `en`, `all-locales-key-parity` compares key names
+ * and placeholder shapes and never reads values, and the en-drift gate only
+ * fires when an `en` value moves — these two `en` values never moved.
+ */
+import { describe, it, expect } from 'vitest';
+import { builtInLocales } from '../locales';
+
+type Bag = Record<string, any>;
+const draftBar = (lang: string) => (builtInLocales[lang] as Bag)?.preview?.draftBar as Bag;
+const at = (lang: string, key: string) => draftBar(lang)?.[key] as string;
+
+/** The four `es` values this file owns, at their post-objectui#3844 final bytes. */
+const ES_FINAL = {
+  message:
+    'Vista previa del borrador — está viendo cambios sin publicar. Nada de lo que ve aquí está activo hasta que publique.',
+  messageClean:
+    'Vista previa del borrador — no hay cambios sin publicar; todo lo que ve aquí ya está activo.',
+  sampleDataBody:
+    'Está viendo la estructura de su aplicación. Publíquela para cargar registros de ejemplo y activarla.',
+  publishCta: 'Publicar para verlo activo',
+} as const;
+
+/** `en`'s current wording. If either moves, the `es` pins above must be revisited. */
+const EN_CURRENT = {
+  message: 'Draft preview — you are seeing unpublished changes. Nothing here is live until you publish.',
+  messageClean: 'Draft preview — no unpublished changes; everything here is already live.',
+} as const;
+
+/**
+ * Exact substrings the pre-fix `es` value held, scoped to this key. Each names
+ * one sub-change of the fix, so a red points at which one came back:
+ *   - the tú morphology (`estás viendo`, `publiques`);
+ *   - `en producción` for "live", which the pack spells `activo` (see
+ *     `publishCta` in this same object, `home.pendingDrafts.published`) and
+ *     which additionally collides with the pack's *production environment*
+ *     sense in `environment.entitlement.planLockedBody`;
+ *   - `Vista previa de borrador`, the prefix that differed from
+ *     `messageClean`'s `Vista previa del borrador` so the banner's two halves
+ *     opened with different words where `en`'s both open "Draft preview — ".
+ */
+const RETIRED_SPELLINGS = [
+  'estás viendo',
+  'publiques',
+  'en producción',
+  'Vista previa de borrador',
+] as const;
+
+const EM_DASH = '—';
+const BANNER_PREFIX = `Vista previa del borrador ${EM_DASH} `;
+
+describe('preview.draftBar es register (objectui#3844)', () => {
+  it('the keys this file pins are present and non-empty', () => {
+    // Anti-empty-green: every assertion below reads one of these four values,
+    // and a renamed or dropped key would otherwise let the negative checks
+    // pass on `undefined`.
+    for (const key of Object.keys(ES_FINAL)) {
+      const value = at('es', key);
+      expect(typeof value, `es preview.draftBar.${key}`).toBe('string');
+      expect(value.trim().length, `es preview.draftBar.${key} is empty`).toBeGreaterThan(0);
+    }
+    for (const key of Object.keys(EN_CURRENT)) {
+      expect(typeof at('en', key), `en preview.draftBar.${key}`).toBe('string');
+    }
+  });
+
+  it.each(Object.entries(ES_FINAL))('es preview.draftBar.%s is exactly the ruled value', (key, expected) => {
+    // THE assertion. Byte-exact on purpose: register lives in individual
+    // morphemes (está vs estás, publique vs publiques), so a substring or
+    // regex check would let a partial re-edit through.
+    expect(at('es', key)).toBe(expected);
+  });
+
+  it('no retired spelling of the tú/en-producción wording is back', () => {
+    // Red before the fix on `message` for three of these four literals; kept
+    // as the named tripwire so a future re-edit that reintroduces one fails
+    // with the offending literal in the message rather than as an opaque
+    // byte diff.
+    for (const key of Object.keys(ES_FINAL)) {
+      const value = at('es', key);
+      for (const retired of RETIRED_SPELLINGS) {
+        expect(value.includes(retired), `es preview.draftBar.${key} reintroduced "${retired}"`).toBe(
+          false,
+        );
+      }
+    }
+  });
+
+  it('both halves of the banner open with the same words and the same em-dash', () => {
+    // The structural half of the fix, stated as its own claim: `en` opens both
+    // sentences "Draft preview — ", so `es` must open both identically too.
+    // `messageClean` used to separate with a colon, which made the banner
+    // change punctuation as well as person when the user published.
+    expect(at('es', 'message').startsWith(BANNER_PREFIX)).toBe(true);
+    expect(at('es', 'messageClean').startsWith(BANNER_PREFIX)).toBe(true);
+    expect(at('es', 'messageClean')).not.toContain('borrador:');
+    for (const key of ['message', 'messageClean']) {
+      expect(at('en', key).startsWith(`Draft preview ${EM_DASH} `), `en ${key} prefix`).toBe(true);
+    }
+  });
+
+  it('all four values spell "live" with the pack\'s own word', () => {
+    // "Same concept, same word" — the stem covers `activo` (message,
+    // messageClean, publishCta) and `activarla` (sampleDataBody). Paired with
+    // the `en producción` literal above: this side proves the replacement is
+    // present, that side proves the outlier is gone.
+    for (const key of Object.keys(ES_FINAL)) {
+      expect(at('es', key), `es preview.draftBar.${key} lost the pack's word for "live"`).toContain(
+        'activ',
+      );
+    }
+  });
+
+  it('en still says what the es values were translated against', () => {
+    // objectui#3650's gate only fires when an `en` value changes, and it asks
+    // the nine packs to follow — it cannot know this `es` ruling. This line
+    // goes red in the same PR that rewords either `en` sentence, which is what
+    // forces the usted rewrite above to be re-read then.
+    expect(at('en', 'message')).toBe(EN_CURRENT.message);
+    expect(at('en', 'messageClean')).toBe(EN_CURRENT.messageClean);
+  });
+
+  it('es serves neither en sentence verbatim', () => {
+    // The objectui#3582 failure mode (English pasted into a translation pack)
+    // applied to these keys. Green before this fix too — recorded as a guard
+    // against a future paste, not as evidence for objectui#3844.
+    const english = Object.values(EN_CURRENT) as string[];
+    expect(english).not.toContain(at('es', 'message'));
+    expect(english).not.toContain(at('es', 'messageClean'));
+  });
+});

--- a/packages/i18n/src/__tests__/draftBar-es-register-3844.test.ts
+++ b/packages/i18n/src/__tests__/draftBar-es-register-3844.test.ts
@@ -38,23 +38,40 @@
  * ## What this file deliberately does NOT do
  *
  * **No morphological register detection.** objectui#3844 evaluated a gate that
- * checks "one register per namespace" and argued it down: recognising usted vs
- * tú needs real morphology, and the ad-hoc regex used to take the census above
- * already miscounted the imperative `Revisa` as a tú marker. Worse, the
- * boundary such a gate would police — which neighbourhood is informal — is
- * human judgement (slice two's "same rule, different answer" precedent), so a
- * gate could only ever check consistency *within* a boundary it cannot draw.
+ * checks "one register per namespace" and argued it down. Recognising usted vs
+ * tú needs real morphology, and token matching demonstrably cannot: in this
+ * very pack the token `revisa` is **usted** in `console.ai.empty.build`
+ * (es.ts:1365, "…y usted revisa y publica.", present indicative with an
+ * explicit `usted`) and **tú** in `auth.forgotPassword.successTitle`
+ * (es.ts:1918, "Revisa tu correo electrónico", imperative). Same eight
+ * letters, opposite registers, and no regex over the string can tell them
+ * apart. The reverse error is just as easy: third-person and impersonal forms
+ * read as usted markers — a crude `puede|su|…` scan over `approvalsInbox`
+ * returns five "usted" hits that are all about *el solicitante* or are
+ * impersonal ("No se puede determinar la identidad"), in a namespace whose
+ * second-person address is in fact uniformly tú (nine strings). objectui#3844
+ * recorded this hazard as "the census regex miscounted `Revisa`"; the
+ * measurement above is the precise version — the miscount is the usted
+ * indicative at :1365, not an imperative. Worse, the boundary such a gate
+ * would police — which neighbourhood is informal — is human judgement (slice
+ * two's "same rule, different answer" precedent), so a gate could only ever
+ * check consistency *within* a boundary it cannot draw.
  * This file therefore pins **these four literal values, byte for byte**, and
  * generalises to nothing. The retired-spelling checks below are exact
  * substrings lifted from the pre-fix value of this one key — the same
  * technique as `viewReadonlyTooltip-semantics-3625.test.ts` — not a register
  * rule in disguise.
  *
- * Scope note: `preview.empty.notReadyDescription` is still tú and is left
- * that way on purpose. It is a different surface (an empty state, not this
- * banner), nothing switches under the user mid-session, and re-voicing the
- * whole namespace is exactly the rejected direction B. objectui#3844's body
- * records it.
+ * Scope note: `preview.empty.notReadyDescription` (es.ts:3286, `Revisa`) is
+ * still tú and is left that way here, because re-voicing the namespace is the
+ * rejected direction B and objectui#3844's ruling is this banner only. It is
+ * **not** harmless, and this file does not pin it: `PreviewDraftEmptyState`
+ * (`AppContent.tsx`, returned while `previewDrafts` and the app is not yet
+ * staged) renders in the content area *underneath* `DraftPreviewBar`
+ * (`ConsoleLayout.tsx`), so those two are on screen at the SAME time — usted in
+ * the bar, tú in the pane below it. That is sharper than objectui#3844's own
+ * sequential switch and is filed separately as objectui#3875. After this change
+ * the `preview` namespace is 23 usted to that 1 tú.
  *
  * Related: objectui#3546 (slice five measured this while ruling es register),
  * objectui#3810 / objectui#3582 / objectui#3625 (the other value-domain blind

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -3288,11 +3288,11 @@ const es = {
       retry: 'Reintentar',
     },
     draftBar: {
-      messageClean: "Vista previa del borrador: no hay cambios sin publicar; todo lo que ve aquí ya está activo.",
+      messageClean: "Vista previa del borrador — no hay cambios sin publicar; todo lo que ve aquí ya está activo.",
       sampleDataTitle: "Los datos de ejemplo aparecen tras publicar",
       sampleDataBody: "Está viendo la estructura de su aplicación. Publíquela para cargar registros de ejemplo y activarla.",
       publishCta: "Publicar para verlo activo",
-      message: 'Vista previa de borrador — estás viendo cambios sin publicar. Nada está en producción hasta que publiques.',
+      message: 'Vista previa del borrador — está viendo cambios sin publicar. Nada de lo que ve aquí está activo hasta que publique.',
       publish: 'Publicar',
       publishing: 'Publicando…',
       exit: 'Salir de la vista previa',


### PR DESCRIPTION
Fixes #3844

## 现象

`DraftPreviewBar` 在**同一条横幅的同一行**渲染两句互斥文案:有待发布变更时是 `message`,没有时是 `messageClean`(`packages/app-shell/src/preview/DraftPreviewBar.tsx:104-111`)。es 包里这两句的第二人称不一致:

| key | 修前 es 值 | 人称 |
|---|---|---|
| `preview.draftBar.message` | `Vista previa de borrador — estás viendo cambios sin publicar. Nada está en producción hasta que publiques.` | **tú**(`estás`、`publiques`) |
| `preview.draftBar.messageClean` | `Vista previa del borrador: no hay cambios sin publicar; todo lo que ve aquí ya está activo.` | **usted**(`ve`) |
| `preview.draftBar.sampleDataBody` | `Está viendo la estructura de su aplicación. Publíquela para cargar registros de ejemplo y activarla.` | **usted** |

后果:西语用户按下「发布」之后,横幅当场从 tú 切到 usted —— 同一个组件、同一个位置、同一次会话。

**前提已在本单基线复核**(base `39136cccb69cd33482fe6886e7142def87e4493c`):三个值逐字节如上,分隔符分歧也在(`message` 用 `—`、`messageClean` 用 `:`,而 en 两条都是 `—`)。

## 为什么三道 i18n 门禁都看不见

这是 #3582 / #3625 之后值域盲区的**第三类**:两条 es 译文都正确表达了各自 en 原意,不缺 key、不陈旧、也没有存英文;不一致是**同一语言包内部、同一 UI 表面上的语域分裂**。

- `scripts/check-i18n-call-site-keys.mjs`(#3530):只问 key 在 en 存不存在。
- `all-locales-key-parity.test.ts`:只比键名集合与占位符形状,从不读值。
- `scripts/check-i18n-en-drift.mjs`(#3650):只在 **en 值变化**时要求九包跟改;这两条 en 值静止不动。

## 方向 A:改 `message`,依据是包里它周围本来就说 usted

三条独立读数,都是量出来的:

1. **包默认语域** —— es 全包普查 usted 102 : tú 30。tú 是有标记的例外,集中在 #3546 切片二明确裁定为非正式的 auth 登录/注册、report editor、organizations 几个邻域;`preview` 不在其中。
2. **同一条横幅一个声音** —— 同一个对象里另外三条(`messageClean`、`sampleDataBody`、`publishCta`)本来就是 usted。对齐这一处离群值,比给整个命名空间重新配音小得多,而且它正是消除「用户眼前切换」的那一处改动。
3. **姐妹横幅** —— #3546 切片五给新增的 19 个 `preview.unpublishedBar.*` / `preview.history.*` 定 usted,最强依据是结构孪生 `home.pendingDrafts.published`(`¡Publicado! Sus cambios están activos.`)。留着 `draftBar.message` 是 tú,会让旧横幅和刚翻好的姐妹横幅互相矛盾。

## 改了什么(两个值,一个文件)

`packages/i18n/src/locales/es.ts`:

```
message:      Vista previa del borrador — está viendo cambios sin publicar. Nada de lo que ve aquí está activo hasta que publique.
messageClean: Vista previa del borrador — no hay cambios sin publicar; todo lo que ve aquí ya está activo.
```

`messageClean` 的全部 diff 就是分隔符 `:` 还原为 `—`(与 en 对齐,en 两句都以 `Draft preview — ` 起头)。`message` 除敬称形态(`estás viendo` → `está viendo`、`publiques` → `publique`)外,一并收口同一句内另外两处措辞分歧,使横幅两半不再连用词也互相矛盾:

- **「live」用 `activo` 而不是 `en producción`** —— 这个概念在包里四处邻近位置都写 `activo`,含同一对象内的 `publishCta`(`Publicar para verlo activo`)、`home.pendingDrafts.published`、`sampleDataBody` 的 `activarla`;而 producción 在包里留给**真正的生产环境**(`environment.entitlement.planLockedBody`:`un entorno de producción`),所以原值不只是不一致,还有歧义。
- **共同开头统一为 `Vista previa del borrador`** —— `del` 是 `messageClean` 本来就在用的形式(两种形式在包里各只出现在这两个 key 上,是这条横幅自己跟自己不一致);因为 `messageClean` 只许动分隔符,统一只能落在 `message` 一侧。

em dash 已核为与 en 同一码位 U+2014(四条值全部 `—=U+2014`)。调用点只传 `defaultValue`、无插值参数,占位符形状不受影响。

## 钉子

新增 `packages/i18n/src/__tests__/draftBar-es-register-3844.test.ts`(独立文件,名带 3844),10 个用例:四个 es 值按修后终值**逐字节精确断言**,加 en 两条原文的 tripwire(将来任何一次 en 改写会在改写它的那个 PR 里当场红),外加 presence 防空转、退役拼写字面量、横幅两半同开头/同 em dash、`activ` 词干在位。注释写明语域裁定依据(102:30 普查、同横幅一致性、切片五的 19 个 key、#3844)。

**不做敬称形态学检测**:识别 usted / tú 需要真正的形态学,而 token 级正则**实测**做不到 —— 同一个 token `revisa` 在 `console.ai.empty.build`(es.ts:1365,`…y usted revisa y publica.`,带显式主语 `usted` 的陈述式)是 **usted**,在 `auth.forgotPassword.successTitle`(es.ts:1918,`Revisa tu correo electrónico`,命令式)是 **tú** —— 同样八个字母、敬称相反,任何字符串正则都分不开。反向误判同样容易:粗正则扫 `approvalsInbox` 得到的 5 个「usted」全是假阳性(`puede` 说的是第三人称的申请人 / 被指派人,`No se puede determinar` 是无人称),而该命名空间的第二人称称呼实为**一致 tú**(9 条)—— 属于切片二「按邻域裁定」的正当情形,已在注释里写明以免下一个人误伤。而这种门禁要 police 的邻域边界本身得人来划(#3546 切片二「同一规则、不同答案」的先例)。

退役拼写检查是从这一个 key 的修前值里摘出的**精确子串**(与 `viewReadonlyTooltip-semantics-3625.test.ts` 同一手法),不推广到任何别处。

> 自查更正:第一版注释照抄了 #3844 正文那句未复核的「普查正则把命令式 `Revisa` 误算成 tú 标记」。实测机制不是这样(:1918 的 `Revisa` 是真 tú 命令式,真正的假阳性是 :1365 的 usted 陈述式),已在第二个提交里改正 —— 不把没验证过的断言固化进永久注释。

## 反向验证(方向先判后跑,两次都与预判一致)

**预判**:钉子是对修后终值的正向逐字节断言,加 presence 防空转,所以两次都只能是**朴素的红**(不存在反转,也不存在「诊断变多」的方向)。

- **还原 `message` 为 tú 旧值** → 预判 4 红且逐条点名 `message`。实跑正是 4 红:byte pin `expected 'Vista previa de borrador — estás vien…' to be 'Vista previa del borrador — está vien…'`;退役拼写 `es preview.draftBar.message reintroduced "estás viendo"`;横幅同开头检查红;`es preview.draftBar.message lost the pack's word for "live"`。`Tests 4 failed | 6 passed (10)`
- **还原 `messageClean` 分隔符为 `:`** → 预判 2 红。实跑 2 红:byte pin `expected 'Vista previa del borrador: no hay cam…' to be 'Vista previa del borrador — no hay ca…'`,以及横幅同开头/同 em dash(内含 `not.toContain('borrador:')`)。`Tests 2 failed | 8 passed (10)`

两次实验后均已还原,最终 diff 只有两个值行。

## 验证

- `node scripts/check-i18n-en-drift.mjs` → `0 en value(s) changed (0 key(s) added, 0 removed)`,`No en value changed in this range.`(本单不碰 en)
- 仓根 vitest:`packages/i18n` 全包 + `packages/app-shell/src/preview`(横幅自己的消费者测试)→ **35 文件 / 554 用例全绿**(更正提交后复跑同样 35/554 绿);新钉子单跑 10/10 绿;`all-locales-key-parity`、`marketplace-preview-namespace-3546`、`objectView-value-language-3582`、`viewReadonlyTooltip-semantics-3625` 一并绿(只改值不改键,parity 按构造不受影响)。
- 全仓 `turbo run type-check --concurrency=2` → **78/78 successful**(两次编辑后各跑一次)。
- 改动文件控制字节 grep 零命中(CI 的 Control Byte Scan 亦绿)。

## 刻意不做

- **方向 B(把整个 `preview` 改成 tú)**:改动面大得多,且会与紧邻的 `marketplace.*`(9:0 usted)与 `console.ai.*` 冲突。
- **`preview.empty.notReadyDescription`(es.ts:3286,`Revisa`)保持 tú,但已单独立单 #3875** —— #3844 的裁定只覆盖这条横幅,所以本单不动它;但它**不是无害的**:`PreviewDraftEmptyState`(`AppContent.tsx`,`previewDrafts` 且应用未就绪时返回)渲染在 `DraftPreviewBar`(`ConsoleLayout.tsx`)**下方的内容区**,两者会**同屏** —— 横幅 usted、下面的空态 tú,比 #3844 本身的先后切换更尖。本单落地后 `preview` 命名空间为 23 usted : 1 tú。(第一版正文曾写「不存在会话中途切换」,过弱且不准,已更正。)
- **方向 C(敬称门禁)**:见上「钉子」一节的实测。
- **不碰 en、不碰棘轮、不碰其余九个语言包。**

## 协调

- **#3546 切片七零相交**:切片七只新增 key、不动既有值;本单的两个既有值在 `origin/main` 上仍是修前值(推送前复核)。
- **未动 `*-namespace-3546.test.tsx` 家族** —— `marketplace-preview-namespace-3546.test.tsx` 只在**注释**里提到这两个 key(第 434-436 行「genuinely split **before this slice** — filed as a finding」,作为历史陈述在本单落地后依然成立),其断言只覆盖 `unpublishedBar.*` / `marketplace.*` / `home.pendingDrafts.published` / zh 的 `draftBar.sampleDataBody`,与本单零相交,实跑亦绿。
- **与已合并的 #3848 / #3873(`packages/core`)零相交** —— 推送后 main 前进了这一个提交,`git diff --name-only` 与本单三个文件无交集。
