### PR TITLE
fix(i18n): 回填棘轮最后 17 个缺失语言 key 与两个模板 key 家族,调用点欠账清零(#3546 切片七)

### DIFF
--- a/.changeset/residue-locale-keys-3546-slice7.md
+++ b/.changeset/residue-locale-keys-3546-slice7.md
@@ -1,0 +1,63 @@
+---
+"@object-ui/i18n": patch
+---
+
+Backfill the last 17 missing locale keys and both remaining template-key families, emptying the call-site key ratchet (objectui#3546, slice seven — final)
+
+`scripts/check-i18n-call-site-keys.mjs` (objectui#3530) opened this backlog with
+**258 keys and 4 template-key families** that a `t()` call site asks for and that
+**no locale pack defined**. Seven slices later the last of it is paid: this change
+takes the ratchet from 17 keys to **zero** and from 2 prefix families to **zero**,
+and the gate now reports every one of the **2320** literal call-site keys
+resolving against `en`.
+
+The residue was the long tail — nine namespaces across `app-shell`,
+`plugin-detail`, `plugin-dashboard`, `plugin-kanban` and `plugin-gantt`, none of
+them big enough to have been its own slice. 17 distinct keys at **23** call sites
+(five keys are used at more than one site) plus **3** call sites behind the two
+families.
+
+What that meant on the page for a `zh` (or `ja`, `de`, `ar`, …) user: the "App not
+available" empty state a user lands on when an app is still publishing, including
+its whole explanation and its Retry button; the interface page's "source is not
+available" message; the system navigation's **Administration** group header,
+**Datasources** and **Documentation** entries; the "creating new organizations is
+disabled on this instance" guard in the workspace dialog; the invitation list's
+five status labels (All / Pending / Accepted / Rejected / Canceled) on both the
+filter tabs and every invitation badge; the Gantt dependency-drag hint that names
+which endpoint the drop will link (`start` / `end`); the record detail's Add,
+"Record deleted", "No history yet" and the concurrent-update dialog's "this
+record"; the kanban empty board's column count; the dashboard widget's screen
+reader "Loading…"; and the page editor's "Edit in studio" tooltip and accessible
+name. All of it rendered English, in every one of the ten languages.
+
+Nothing here rendered a raw key — slice one (PR #3583) held those sites, and the
+three keys the issue body named as unprotected (`detail.viewSource`,
+`wizard.missingRequired`, `gantt.toolbar.refresh`) have resolved in `en` since.
+
+Both families are repaired as **enumerations, not wildcards**, and the assertion
+that used to live in the ratchet's `missingPrefixes` moves into a test that fails
+if either union grows a member without a key:
+
+- `gantt.linkEnd.` — the closed union `'start' | 'end'`, declared by GanttView's
+  own `linkDrag` state.
+- `organization.invitations.status.` — `StatusFilter`
+  (`all | pending | accepted | rejected | canceled`), declared by InvitationsPage.
+
+Every `en` value is byte-identical to the English the call site rendered before,
+so no string a user sees today changes: 16 keys match an inline
+`t(key, { defaultValue: … })`; `dashboard.loading` matches `useSafeTranslate`'s
+positional fallback `tt(key, 'Loading…')`; `gantt.linkEnd.*` match
+`useGanttTranslation`'s per-key fallback map; and the five status labels match the
+CSS-capitalised wire value each badge and tab showed. The nine translations follow
+each pack's own neighbourhood and reuse an existing neighbour's row wherever the
+`en` string already existed verbatim **and** that row is grammatical here — the
+four invitation adjectives are deliberately not reused from the approvals family,
+because those agree with each pack's word for "request" (`ru` masculine `Отклонён`)
+while an invitation needs its own agreement (`ru` neuter `Отклонено`).
+
+`scripts/i18n-call-site-key-baseline.json` is kept rather than deleted: empty is
+its terminal, load-bearing state — against an empty baseline any NEW unresolved
+call-site key is unexpected and fails the build.
+
+No component changed.

--- a/packages/i18n/src/__tests__/auth-namespace-3546.test.tsx
+++ b/packages/i18n/src/__tests__/auth-namespace-3546.test.tsx
@@ -256,20 +256,16 @@ describe('objectui#3546 slice three — the auth / oauth / acceptInvitation name
     );
     expect(stillBaselined).toEqual([]);
     // 163 before this slice, 54 removed — then slice four (console, 41 keys) took
-    // it to 68, slice five (marketplace + preview, 37 keys) to 31 and slice six
-    // (perm + home, 14 keys) to 17. The other namespaces' debt is not this
-    // slice's to spend, and this number is what catches a slice that overreaches;
-    // it moves once per slice, and only downwards.
-    expect(Object.keys(baseline.missingKeys).length).toBe(17);
+    // it to 68, slice five (marketplace + preview, 37 keys) to 31, slice six
+    // (perm + home, 14 keys) to 17 and slice seven (the 17-key residue) to ZERO.
+    // The counter moved once per slice and only downwards; at zero it stops being
+    // "how much is left" and becomes "nothing may be added back".
+    expect(Object.keys(baseline.missingKeys).length).toBe(0);
     // None of the template-key FAMILIES belonged to the auth family, so this slice
     // left all four. Slice four then took `console.ai.group.` (it is a `console`
-    // key) and slice five `marketplace.disclosure.runtime.`, leaving two. This
-    // assertion is what stops a later slice from thinking one of the remaining
-    // two was already handled.
-    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([
-      'gantt.linkEnd.',
-      'organization.invitations.status.',
-    ]);
+    // key), slice five `marketplace.disclosure.runtime.`, and slice seven the last
+    // two (`gantt.linkEnd.`, `organization.invitations.status.`).
+    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([]);
   });
 
   describe('through the real binding — bare useObjectTranslation, provider mounted', () => {

--- a/packages/i18n/src/__tests__/console-namespace-3546.test.tsx
+++ b/packages/i18n/src/__tests__/console-namespace-3546.test.tsx
@@ -322,18 +322,19 @@ describe('objectui#3546 slice four — the console namespace', () => {
     };
     expect(Object.keys(baseline.missingKeys).filter((k) => k.startsWith('console.'))).toEqual([]);
     // 109 before this slice, 41 removed — then slice five (marketplace + preview,
-    // 37 keys) took it to 31 and slice six (perm + home, 14 keys) to 17. The other
-    // namespaces' debt is not this slice's to spend; this number moves once per
-    // slice, and only downwards.
-    expect(Object.keys(baseline.missingKeys).length).toBe(17);
-    // The prefix family this slice handled is GONE from the ratchet, and the ones
-    // that remain are untouched — none of them belongs to `console`. Slice five
-    // then took `marketplace.disclosure.runtime.`, leaving two.
-    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([
-      'gantt.linkEnd.',
-      'organization.invitations.status.',
-    ]);
-    expect(Object.keys(baseline.missingPrefixes)).not.toContain('console.ai.group.');
+    // 37 keys) took it to 31, slice six (perm + home, 14 keys) to 17 and slice
+    // seven (the 17-key residue) to ZERO. The counter moved once per slice and
+    // only downwards; at zero it stops being "how much is left" and becomes
+    // "nothing may be added back".
+    expect(Object.keys(baseline.missingKeys).length).toBe(0);
+    // The prefix family this slice handled is GONE from the ratchet. Slice five
+    // then took `marketplace.disclosure.runtime.` and slice seven the last two
+    // (`gantt.linkEnd.`, `organization.invitations.status.`), so the list is empty.
+    // The `not.toContain('console.ai.group.')` that used to sit here was dropped
+    // rather than kept: against an empty list it passes because nothing is
+    // produced, not because the logic holds. The set equality above is the
+    // stronger statement and it is not vacuous.
+    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([]);
   });
 
   describe('through the real binding — bare useObjectTranslation, provider mounted', () => {

--- a/packages/i18n/src/__tests__/marketplace-preview-namespace-3546.test.tsx
+++ b/packages/i18n/src/__tests__/marketplace-preview-namespace-3546.test.tsx
@@ -576,16 +576,17 @@ describe('objectui#3546 slice five — the marketplace and preview namespaces', 
       ),
     ).toEqual([]);
     // 68 before this slice, 37 removed — then slice six (perm + home, 14 keys)
-    // took it to 17. The other namespaces' debt is not this slice's to spend;
-    // this number moves once per slice, and only downwards.
-    expect(Object.keys(baseline.missingKeys).length).toBe(17);
-    // The prefix family this slice handled is GONE from the ratchet, and the two
-    // that remain are untouched — neither belongs to these namespaces.
-    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([
-      'gantt.linkEnd.',
-      'organization.invitations.status.',
-    ]);
-    expect(Object.keys(baseline.missingPrefixes)).not.toContain('marketplace.disclosure.runtime.');
+    // took it to 17 and slice seven (the 17-key residue) to ZERO. The counter
+    // moved once per slice and only downwards; at zero it stops being "how much
+    // is left" and becomes "nothing may be added back".
+    expect(Object.keys(baseline.missingKeys).length).toBe(0);
+    // The prefix family this slice handled is GONE from the ratchet, and slice
+    // seven took the last two (`gantt.linkEnd.`,
+    // `organization.invitations.status.`). The `not.toContain(…)` that used to sit
+    // below this line was dropped rather than kept: against an empty list it
+    // passes because nothing is produced, not because the logic holds. The set
+    // equality is the stronger statement and it is not vacuous.
+    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([]);
   });
 
   describe('through the real binding — bare useObjectTranslation, provider mounted', () => {

--- a/packages/i18n/src/__tests__/organization-namespace-3546.test.tsx
+++ b/packages/i18n/src/__tests__/organization-namespace-3546.test.tsx
@@ -257,17 +257,21 @@ describe('objectui#3546 slice two — the organization namespace', () => {
       missingPrefixes: Record<string, unknown>;
     };
     expect(Object.keys(baseline.missingKeys).filter((k) => k.startsWith('organization.'))).toEqual([]);
-    // Untouched on purpose: `organization.invitations.status.*` is a template
-    // key FAMILY, a different repair (enumerate the status values) than the 90
-    // literal keys, and it is still missing. Deliberately left for the
-    // prefix-family slice — this assertion is what stops it being forgotten.
-    expect(Object.keys(baseline.missingPrefixes)).toContain('organization.invitations.status.');
+    // `organization.invitations.status.*` was left untouched by THIS slice — a
+    // template key FAMILY needs a different repair (enumerate the status values)
+    // than the 90 literal keys — and the assertion here used to be
+    // `toContain(…)`, whose whole job was to stop the family being forgotten.
+    // Slice seven enumerated it (`StatusFilter` = all/pending/accepted/rejected/
+    // canceled) and emptied `missingPrefixes`, so the assertion inverts: it now
+    // states the family is gone, which is the fact a reverting change breaks.
+    expect(Object.keys(baseline.missingPrefixes)).not.toContain('organization.invitations.status.');
+    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([]);
     // The other namespaces' debt is not this slice's to spend. Slice three
     // (auth/oauth/acceptInvitation, 54 keys) took it from 163 to 109, slice four
-    // (console, 41 keys) to 68, slice five (marketplace + preview, 37 keys) to 31
-    // and slice six (perm + home, 14 keys) to 17; this number moves once per
-    // slice, and only downwards.
-    expect(Object.keys(baseline.missingKeys).length).toBe(17);
+    // (console, 41 keys) to 68, slice five (marketplace + preview, 37 keys) to 31,
+    // slice six (perm + home, 14 keys) to 17 and slice seven (the 17-key residue)
+    // to ZERO; this number moved once per slice, and only downwards.
+    expect(Object.keys(baseline.missingKeys).length).toBe(0);
   });
 
   describe('through the real binding — bare useObjectTranslation, provider mounted', () => {

--- a/packages/i18n/src/__tests__/perm-home-namespace-3546.test.tsx
+++ b/packages/i18n/src/__tests__/perm-home-namespace-3546.test.tsx
@@ -556,15 +556,14 @@ describe('objectui#3546 slice six — the perm and home namespaces', () => {
     expect(
       Object.keys(baseline.missingKeys).filter((k) => k.startsWith('perm.') || k.startsWith('home.')),
     ).toEqual([]);
-    // 31 before this slice, 14 removed. The other namespaces' debt is not this
-    // slice's to spend; this number moves once per slice, and only downwards.
-    expect(Object.keys(baseline.missingKeys).length).toBe(17);
-    // This slice owns NO prefix family — the two left belong to later slices, and
-    // neither is touched.
-    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([
-      'gantt.linkEnd.',
-      'organization.invitations.status.',
-    ]);
+    // 31 before this slice, 14 removed, leaving 17 — which slice seven (the
+    // residue: 17 keys plus both remaining prefix families) took to ZERO. The
+    // counter moved once per slice and only downwards; at zero it stops being
+    // "how much is left" and becomes "nothing may be added back".
+    expect(Object.keys(baseline.missingKeys).length).toBe(0);
+    // This slice owned NO prefix family — the two left belonged to slice seven,
+    // which enumerated both, so the list is now empty.
+    expect(Object.keys(baseline.missingPrefixes).sort()).toEqual([]);
   });
 
   describe('through the real binding — provider mounted', () => {

--- a/packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx
+++ b/packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx
@@ -1,0 +1,870 @@
+/**
+ * The last of objectui#3546 — slice seven, the **residue**: every entry that was
+ * still in `scripts/i18n-call-site-key-baseline.json`. After this slice both of
+ * the ratchet's lists are empty and `check-i18n-call-site-keys.mjs` reports
+ * **2320/2320** literal call-site keys resolving against `en`.
+ *
+ * ## What was left, precisely (measured, never hand-counted)
+ *
+ * `analyze()` from #3530's gate, run on the branch point:
+ *
+ *   - **17 distinct keys at 23 call sites** — the first slice in this series
+ *     where the two numbers differ by more than a rounding error. Five keys are
+ *     shared: `common.retry` (3 sites), `common.record`, `common.editInStudio`,
+ *     `detail.add` and `layout.systemNav.datasources` (2 each). Slice two
+ *     predicted 90 and the truth was 93; the lesson is applied here by taking
+ *     the call-site list from the script, not from the ratchet's line count.
+ *   - **both remaining `missing-prefix` families**, 3 call sites:
+ *     `gantt.linkEnd.` (1) and `organization.invitations.status.` (2).
+ *
+ * Nine namespaces, ten owning surfaces, spread across `app-shell`,
+ * `plugin-detail`, `plugin-dashboard`, `plugin-kanban` and `plugin-gantt` — the
+ * long tail that was never big enough to be its own slice.
+ *
+ * ## Severity: all English-visible, zero raw keys — and three different ways
+ *
+ * The 8 raw-key sites the issue's body named were slice one's (PR #3583), and
+ * `detail.viewSource` / `wizard.missingRequired` / `gantt.toolbar.refresh` have
+ * resolved in `en` ever since. Everything in THIS slice is the milder
+ * objectui#3517 class, but the inline English default takes three shapes, which
+ * is why the byte-equality test below is split three ways:
+ *
+ *   1. **22 sites / 16 keys** pass `t(key, { defaultValue: 'English' })`.
+ *   2. **1 site** (`dashboard.loading`) uses `useSafeTranslate`'s positional
+ *      form, `tt(key, 'Loading…')` — a fallback, not a `defaultValue` property.
+ *      A test that greps only for `defaultValue:` would call this site
+ *      unprotected and be wrong about it.
+ *   3. **the two families' defaults are not literals at all**:
+ *      `organization.invitations.status.` passes `{ defaultValue: tab }` — the
+ *      enum member itself, CSS-capitalised by the element — and
+ *      `gantt.linkEnd.` passes no default, relying on
+ *      `useGanttTranslation`'s PER-KEY fallback map, which does contain both
+ *      members. So a byte compare is structurally impossible for all seven, and
+ *      what is pinned instead is the equivalence each one actually needs.
+ *
+ * Consequence for test design, as in slices two through six: **`en` output was
+ * already correct before the change**, so an `en` assertion cannot discriminate
+ * before from after. Every assertion that pins the fix is a non-`en` one; the
+ * `en` ones prove reachability and prove the wording did not move.
+ *
+ * ## The provider-less path is a different, filed defect
+ *
+ * Four of the owning files bind `createSafeTranslation` hooks
+ * (`useDetailTranslation`, `useKanbanT`) whose defaults maps do NOT list these
+ * keys, and `useSafeTranslate`/`useGanttTranslation` are per-call/per-key. With
+ * a provider mounted — the console — i18next answers, which is the path these
+ * assertions describe. Without one, `createSafeTranslation`'s `fallbackT` reads
+ * `defaults[key] || key` and never looks at the call site's inline
+ * `defaultValue`, so it renders the raw key: that is objectui#3865, filed by
+ * slice six, and it is not what this slice repairs.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import React from 'react';
+import { I18nProvider, useObjectTranslation } from '../provider';
+import { builtInLocales } from '../locales/index';
+
+/** The 17 keys the guard measured as missing, in the ratchet's own order. */
+const MEASURED_KEYS = [
+  'common.done',
+  'common.editInStudio',
+  'common.record',
+  'common.retry',
+  'dashboard.loading',
+  'detail.add',
+  'detail.concurrentUpdateRecordLabel',
+  'detail.deleted',
+  'detail.historyEmpty',
+  'empty.appNotAvailable',
+  'empty.appNotAvailableDescription',
+  'empty.interfacePageSourceMissing',
+  'kanban.columns',
+  'layout.systemNav.administration',
+  'layout.systemNav.datasources',
+  'layout.systemNav.documentation',
+  'workspace.multiOrgDisabled',
+] as const;
+
+/**
+ * `gantt.linkEnd.` — the value domain is the closed union `'start' | 'end'`,
+ * declared in GanttView itself (the `linkDrag` state type and the `endLabel`
+ * parameter). Same situation as slice four's `console.ai.group.`
+ * (`ConversationGroupKey` in the same file), and unlike slice five's
+ * `marketplace.disclosure.runtime.`, whose authority lives in the sibling repo's
+ * `packages/spec`.
+ */
+const LINK_END_MEMBERS = ['start', 'end'] as const;
+
+/**
+ * `organization.invitations.status.` — the value domain is `StatusFilter`,
+ * declared at the top of InvitationsPage. `all` is the filter tab's extra
+ * member; the other four are also `AuthInvitation.status` values.
+ */
+const STATUS_MEMBERS = ['all', 'pending', 'accepted', 'rejected', 'canceled'] as const;
+
+/** Every path this slice adds: 17 leaves + 2 + 5 family members = 24. */
+const KEYS = [
+  ...MEASURED_KEYS,
+  ...LINK_END_MEMBERS.map((m) => `gantt.linkEnd.${m}`),
+  ...STATUS_MEMBERS.map((m) => `organization.invitations.status.${m}`),
+];
+
+const LANGS = Object.keys(builtInLocales);
+
+// ── the owning surfaces ──────────────────────────────────────────────────────
+const INVITE_DIALOG = 'packages/app-shell/src/console/organizations/manage/InviteMemberDialog.tsx';
+const PAGE_VIEW = 'packages/app-shell/src/views/PageView.tsx';
+const APP_CONTENT = 'packages/app-shell/src/console/AppContent.tsx';
+const INVITATIONS = 'packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx';
+const MEMBERS = 'packages/app-shell/src/console/organizations/manage/MembersPage.tsx';
+const DATASET_WIDGET = 'packages/plugin-dashboard/src/DatasetWidget.tsx';
+const RELATED_LIST = 'packages/plugin-detail/src/RelatedList.tsx';
+const SAVE_BAR = 'packages/plugin-detail/src/InlineEditSaveBar.tsx';
+const RECORD_DETAIL = 'packages/app-shell/src/views/RecordDetailView.tsx';
+const DETAIL_VIEW = 'packages/plugin-detail/src/DetailView.tsx';
+const INTERFACE_LIST = 'packages/app-shell/src/views/InterfaceListPage.tsx';
+const KANBAN = 'packages/plugin-kanban/src/KanbanImpl.tsx';
+const UNIFIED_SIDEBAR = 'packages/app-shell/src/layout/UnifiedSidebar.tsx';
+const APP_SIDEBAR = 'packages/app-shell/src/layout/AppSidebar.tsx';
+const CREATE_WORKSPACE = 'packages/app-shell/src/console/organizations/CreateWorkspaceDialog.tsx';
+const GANTT_VIEW = 'packages/plugin-gantt/src/GanttView.tsx';
+const GANTT_HOOK = 'packages/plugin-gantt/src/useGanttTranslation.ts';
+const OCC_DIALOG = 'packages/plugin-detail/src/ConcurrentUpdateDialog.tsx';
+
+const at = (pack: unknown, path: string): unknown =>
+  path.split('.').reduce<unknown>((n, k) => (n as Record<string, unknown> | undefined)?.[k], pack);
+
+const wrapperFor = (lang: string) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <I18nProvider config={{ defaultLanguage: lang, detectBrowserLanguage: false }}>
+        {children}
+      </I18nProvider>
+    );
+  };
+
+/**
+ * Read a component's source. `import.meta.url` is not a file: URL in the dom
+ * project, so resolve from the vitest root (which the invocation guard pins to
+ * the repo root) — and prove the read landed, or every assertion on it is
+ * vacuous.
+ */
+function sourceOf(rel: string): string {
+  const path = join(process.cwd(), rel);
+  expect(existsSync(path), `source not found at ${path}`).toBe(true);
+  return readFileSync(path, 'utf8');
+}
+
+/** What CSS `text-transform: capitalize` does to a single lowercase word. */
+const cssCapitalize = (word: string) => word.charAt(0).toUpperCase() + word.slice(1);
+
+beforeEach(() => {
+  // The provider persists the last language (objectstack#5406); without this a
+  // stale locale leaks into the `en` cases.
+  window.localStorage.clear();
+});
+
+describe('objectui#3546 slice seven — the ratchet residue', () => {
+  it('covers all ten packs and all twenty-four paths (guards the loops from emptying)', () => {
+    expect(LANGS).toHaveLength(10);
+    expect(MEASURED_KEYS).toHaveLength(17);
+    expect(LINK_END_MEMBERS).toHaveLength(2);
+    expect(STATUS_MEMBERS).toHaveLength(5);
+    expect(KEYS).toHaveLength(24);
+    expect(new Set(KEYS).size).toBe(24);
+    // 17 measured leaves + 7 family members. Keeping the two counts apart here
+    // is what stops a later reader reading "24" off the ratchet, which held 17
+    // key lines and 2 prefix lines.
+    const perNamespace = MEASURED_KEYS.reduce<Record<string, number>>((acc, k) => {
+      const ns = k.split('.')[0];
+      acc[ns] = (acc[ns] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(perNamespace).toEqual({
+      common: 4,
+      dashboard: 1,
+      detail: 4,
+      empty: 3,
+      kanban: 1,
+      layout: 3,
+      workspace: 1,
+    });
+  });
+
+  it.each(LANGS)('%s defines every path in this slice as a non-empty string', (lang) => {
+    for (const key of KEYS) {
+      const value = at(builtInLocales[lang], key);
+      expect(typeof value, `${lang}.${key}`).toBe('string');
+      expect((value as string).trim().length, `${lang}.${key} is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('the nine non-en packs carry real translations, not the English strings', () => {
+    // The failure this catches is a backfill that copy-pastes `en` into the other
+    // nine packs: full key parity, ten packs green, nine languages still reading
+    // English. `all-locales-key-parity.test.ts` cannot see it — it compares key
+    // sets and placeholder shape, never what a value SAYS.
+    //
+    // Exact set, not "few enough": 2 of 216 pairs. Both are `fr`, both are words
+    // French and English genuinely spell the same, and both sit in the system
+    // navigation next to `layout.systemNav.configuration`, which `fr` has spelled
+    // "Configuration" since before this slice. A third entry fails here and must
+    // be justified on this list the way slices two (12), three (18) and four (1)
+    // justified theirs.
+    const identical: string[] = [];
+    for (const lang of LANGS.filter((l) => l !== 'en')) {
+      for (const key of KEYS) {
+        if (at(builtInLocales[lang], key) === at(builtInLocales.en, key)) identical.push(`${lang} :: ${key}`);
+      }
+    }
+    expect(identical.sort()).toEqual([
+      'fr :: layout.systemNav.administration',
+      'fr :: layout.systemNav.documentation',
+    ]);
+    // …and the neighbour that makes them ordinary rather than a slip.
+    expect(at(builtInLocales.fr, 'layout.systemNav.configuration')).toBe('Configuration');
+    expect(at(builtInLocales.en, 'layout.systemNav.configuration')).toBe('Configuration');
+  });
+
+  it('the two-entry cognate set is not vacuous — other packs did translate those two', () => {
+    // A set-equality assertion is also green when the packs are EMPTY (slice
+    // two's B1 lesson). The presence assertion above covers emptiness; this one
+    // covers the other way the set could be right for the wrong reason: if the
+    // two `fr` rows were a copy-paste of `en`, the same copy-paste would show up
+    // in the packs that CAN translate them, and it does not.
+    expect(at(builtInLocales.de, 'layout.systemNav.administration')).toBe('Verwaltung');
+    expect(at(builtInLocales.ru, 'layout.systemNav.administration')).toBe('Администрирование');
+    expect(at(builtInLocales.de, 'layout.systemNav.documentation')).toBe('Dokumentation');
+    expect(at(builtInLocales.ar, 'layout.systemNav.documentation')).toBe('الوثائق');
+    // Loanwords that are carried through and still differ from `en`, so "no more
+    // cognates" is a real zero rather than a pack dodging every English-looking
+    // token: `Studio` and `Datenquellen`/`データソース` all survive.
+    expect(at(builtInLocales.ja, 'common.editInStudio')).toBe('Studio で編集');
+    expect(at(builtInLocales.ko, 'common.editInStudio')).toBe('Studio에서 편집');
+    expect(at(builtInLocales.de, 'layout.systemNav.datasources')).toBe('Datenquellen');
+    for (const [lang, key] of [
+      ['ja', 'common.editInStudio'],
+      ['ko', 'common.editInStudio'],
+      ['de', 'layout.systemNav.datasources'],
+    ] as const) {
+      expect(at(builtInLocales[lang], key)).not.toBe(at(builtInLocales.en, key));
+    }
+  });
+
+  it('exactly one path interpolates, and every pack carries the same hole', () => {
+    // A translator who drops `{{name}}` renders a sentence with the source name
+    // missing; one who invents a second hole renders braces verbatim.
+    // `all-locales-key-parity` compares placeholder shape too — this states the
+    // intended shape BY NAME so a wrong one is legible here.
+    // Deliberately two regexes: a `/g` one is stateful, and reusing it for
+    // `.test()` inside a `filter` silently skips every other match through
+    // `lastIndex` (slice five's own bug).
+    const HOLES = /\{\{\w+\}\}/g;
+    const HAS_HOLE = /\{\{\w+\}\}/;
+    const INTERPOLATED = ['empty.interfacePageSourceMissing'];
+    expect(KEYS.filter((k) => HAS_HOLE.test(at(builtInLocales.en, k) as string)).sort()).toEqual(INTERPOLATED);
+    for (const lang of LANGS) {
+      for (const key of KEYS) {
+        const holes = ((at(builtInLocales[lang], key) as string).match(HOLES) ?? []).join(',');
+        expect(holes, `${lang}.${key}`).toBe(INTERPOLATED.includes(key) ? '{{name}}' : '');
+      }
+    }
+  });
+
+  it('the sixteen literal en values are byte-identical to their inline defaultValue', () => {
+    // Two paths must not diverge: with the pack present i18next answers, and
+    // before this slice the inline default did — a user must not be able to tell
+    // which ran. 16 keys here; `dashboard.loading` and the two families are the
+    // three shapes a byte compare cannot reach, each pinned in its own case.
+    const EXPECTED: Array<[key: string, source: string, value: string]> = [
+      ['common.done', INVITE_DIALOG, 'Done'],
+      ['common.editInStudio', PAGE_VIEW, 'Edit in studio'],
+      ['common.record', APP_CONTENT, 'Record'],
+      ['common.retry', APP_CONTENT, 'Retry'],
+      ['detail.add', RELATED_LIST, 'Add'],
+      ['detail.concurrentUpdateRecordLabel', SAVE_BAR, 'this record'],
+      ['detail.deleted', RECORD_DETAIL, 'Record deleted'],
+      ['detail.historyEmpty', DETAIL_VIEW, 'No history yet'],
+      ['empty.appNotAvailable', APP_CONTENT, 'App not available'],
+      [
+        'empty.appNotAvailableDescription',
+        APP_CONTENT,
+        'This app is not available yet — it may still be publishing. Try again in a moment.',
+      ],
+      [
+        'empty.interfacePageSourceMissing',
+        INTERFACE_LIST,
+        'This interface page references "{{name}}", which is not available.',
+      ],
+      ['kanban.columns', KANBAN, 'columns'],
+      ['layout.systemNav.administration', UNIFIED_SIDEBAR, 'Administration'],
+      ['layout.systemNav.datasources', APP_SIDEBAR, 'Datasources'],
+      ['layout.systemNav.documentation', UNIFIED_SIDEBAR, 'Documentation'],
+      ['workspace.multiOrgDisabled', CREATE_WORKSPACE, 'Creating new organizations is disabled on this instance.'],
+    ];
+    expect(EXPECTED).toHaveLength(16);
+    const cache = new Map<string, string>();
+    for (const [key, rel, value] of EXPECTED) {
+      if (!cache.has(rel)) cache.set(rel, sourceOf(rel));
+      expect(at(builtInLocales.en, key), `en ${key}`).toBe(value);
+      // the premise: the call site still passes exactly this defaultValue
+      expect(cache.get(rel), `${key}'s defaultValue moved`).toContain(`defaultValue: '${value}'`);
+    }
+  });
+
+  it('the five multi-site keys really are one string at every one of their sites', () => {
+    // 17 keys, 23 call sites. A key used twice with two different inline defaults
+    // would make the byte-equality above true at one site and false at the other,
+    // and no single-site check could see it. Both spellings are asserted at both
+    // files, so a divergence introduced later fails here.
+    const MULTI: Array<[key: string, value: string, files: string[]]> = [
+      ['common.editInStudio', 'Edit in studio', [PAGE_VIEW]],
+      ['common.record', 'Record', [APP_CONTENT]],
+      ['common.retry', 'Retry', [APP_CONTENT, INVITATIONS, MEMBERS]],
+      ['detail.add', 'Add', [RELATED_LIST]],
+      ['layout.systemNav.datasources', 'Datasources', [APP_SIDEBAR, UNIFIED_SIDEBAR]],
+    ];
+    for (const [key, value, files] of MULTI) {
+      for (const rel of files) {
+        const src = sourceOf(rel);
+        const occurrences = src.split(`t('${key}', { defaultValue: '${value}' })`).length - 1;
+        expect(occurrences, `${key} in ${rel}`).toBeGreaterThan(0);
+      }
+    }
+    // PageView uses it twice on the same button (title + aria-label) and
+    // RelatedList twice in two different affordances — the counts are pinned so a
+    // silent drop of one of them is visible.
+    expect(sourceOf(PAGE_VIEW).split("t('common.editInStudio', { defaultValue: 'Edit in studio' })").length - 1).toBe(2);
+    expect(sourceOf(RELATED_LIST).split("t('detail.add', { defaultValue: 'Add' })").length - 1).toBe(2);
+    expect(sourceOf(APP_CONTENT).split("t('common.record', { defaultValue: 'Record' })").length - 1).toBe(2);
+  });
+
+  it('dashboard.loading matches useSafeTranslate positional fallback, not a defaultValue', () => {
+    // Shape two. `useSafeTranslate()` returns `t(keyOrKeys, fallback)` — the
+    // English default is the SECOND POSITIONAL ARGUMENT, so a sweep that greps
+    // for `defaultValue:` would report this site as having no fallback and be
+    // wrong. The equivalence is the same one: pack value === the fallback the
+    // call site would otherwise have rendered.
+    const src = sourceOf(DATASET_WIDGET);
+    expect(src, 'the sr-only loading announcement moved').toContain("tt('dashboard.loading', 'Loading…')");
+    expect(src).toContain('const tt = useSafeTranslate();');
+    expect(at(builtInLocales.en, 'dashboard.loading')).toBe('Loading…');
+    // …and the hook really does return the fallback per key, not per provider.
+    const hook = sourceOf('packages/i18n/src/useSafeTranslation.ts');
+    expect(hook).toContain('export function useSafeTranslate()');
+    expect(hook).toContain('if (v && v !== key) return v;');
+    // U+2026, not three ASCII dots. `common.loading` is the older `'Loading...'`
+    // spelling and is a DIFFERENT string, so it is deliberately not reused here.
+    expect(at(builtInLocales.en, 'dashboard.loading')).not.toBe(at(builtInLocales.en, 'common.loading'));
+    expect(at(builtInLocales.en, 'common.loading')).toBe('Loading...');
+  });
+
+  describe('gantt.linkEnd. — the first prefix family', () => {
+    it('the key surface is exactly the closed union declared in GanttView', () => {
+      // Key reachability, asserted on the KEY set — not on a value verdict. A
+      // fourth endpoint kind added to `linkDrag` fails here, which is exactly the
+      // job the ratchet's prefix entry used to do, moved into a test.
+      const family = at(builtInLocales.en, 'gantt.linkEnd') as Record<string, string>;
+      expect(Object.keys(family).sort()).toEqual([...LINK_END_MEMBERS].sort());
+      const src = sourceOf(GANTT_VIEW);
+      // the premise: both the state type and the label helper still say start|end
+      expect(src, 'the linkDrag endpoint union moved').toContain("sourceEnd: 'start' | 'end';");
+      expect(src).toContain("targetEnd: 'start' | 'end' | null;");
+      expect(src, 'the template call moved').toContain(
+        "const endLabel = (e: 'start' | 'end') => t(`gantt.linkEnd.${e}`);",
+      );
+      // `targetEnd` is nullable and the call site collapses null to 'start', so
+      // the union really is two members at the call site too.
+      expect(src).toContain("endLabel(linkDrag.targetEnd ?? 'start')");
+      for (const lang of LANGS) {
+        expect(Object.keys(at(builtInLocales[lang], 'gantt.linkEnd') as object).sort(), `${lang}`).toEqual([
+          ...LINK_END_MEMBERS,
+        ].sort());
+      }
+    });
+
+    it('the en values are byte-identical to the hook per-key fallback map', () => {
+      // Value verdict, asserted separately from the key surface (PR #3546 slice
+      // five wrote this distinction down). This call site passes NO
+      // `defaultValue`: `useGanttTranslation` asks the host first and falls back
+      // to its own map PER KEY, so the map is what rendered before this slice and
+      // i18next is what renders now. If the two disagreed, the drag hint would
+      // change wording for English users, which this slice must not do.
+      const hook = sourceOf(GANTT_HOOK);
+      expect(hook).toContain("'gantt.linkEnd.start': 'start',");
+      expect(hook).toContain("'gantt.linkEnd.end': 'end',");
+      expect(at(builtInLocales.en, 'gantt.linkEnd.start')).toBe('start');
+      expect(at(builtInLocales.en, 'gantt.linkEnd.end')).toBe('end');
+      // the premise for "the map is what rendered": per-key, host-first.
+      expect(hook).toContain('const hostValue = result.t(key, options as never) as unknown;');
+      expect(hook).toContain("if (typeof hostValue === 'string' && hostValue !== key) return hostValue;");
+    });
+
+    it('the nine packs take their endpoint words from gantt own link vocabulary', () => {
+      // Concept adjacency: `gantt.linkType.*` names the same two endpoints
+      // ("Finish → Start"), and `de` deliberately says Anfang there rather than
+      // the `gantt.column.start` label "Start" — so the link family, not the
+      // column family, is the neighbour. `en` is lowercase because the words land
+      // inside parentheses mid-hint; German capitalises nouns regardless, which
+      // is correct German and not a copy of `en`.
+      expect(at(builtInLocales.de, 'gantt.linkType.fs')).toBe('Ende → Anfang');
+      expect(at(builtInLocales.de, 'gantt.linkEnd.start')).toBe('Anfang');
+      expect(at(builtInLocales.de, 'gantt.linkEnd.end')).toBe('Ende');
+      expect(at(builtInLocales.zh, 'gantt.linkType.fs')).toBe('完成 → 开始');
+      expect(at(builtInLocales.zh, 'gantt.linkEnd.start')).toBe('开始');
+      expect(at(builtInLocales.ar, 'gantt.linkType.fs')).toBe('نهاية → بداية');
+      expect(at(builtInLocales.ar, 'gantt.linkEnd.start')).toBe('بداية');
+      expect(at(builtInLocales.ar, 'gantt.linkEnd.end')).toBe('نهاية');
+    });
+  });
+
+  describe('organization.invitations.status. — the second prefix family', () => {
+    it('the key surface is exactly StatusFilter', () => {
+      const family = at(builtInLocales.en, 'organization.invitations.status') as Record<string, string>;
+      expect(Object.keys(family).sort()).toEqual([...STATUS_MEMBERS].sort());
+      const src = sourceOf(INVITATIONS);
+      // the premise: the union and the tab list still spell these five
+      expect(src, 'StatusFilter moved').toContain(
+        "type StatusFilter = 'all' | 'pending' | 'accepted' | 'rejected' | 'canceled';",
+      );
+      expect(src).toContain(
+        "const tabs: StatusFilter[] = ['all', 'pending', 'accepted', 'rejected', 'canceled'];",
+      );
+      expect(src, 'the tab template call moved').toContain(
+        "t(`organization.invitations.status.${tab}`, { defaultValue: tab })",
+      );
+      expect(src, 'the badge template call moved').toContain(
+        "t(`organization.invitations.status.${inv.status}`, { defaultValue: inv.status })",
+      );
+      for (const lang of LANGS) {
+        expect(
+          Object.keys(at(builtInLocales[lang], 'organization.invitations.status') as object).sort(),
+          `${lang}`,
+        ).toEqual([...STATUS_MEMBERS].sort());
+      }
+    });
+
+    it('en renders exactly what the CSS-capitalised wire value rendered', () => {
+      // The equivalence that replaces a byte compare for shape three. The
+      // `defaultValue` here is the enum member itself, and BOTH call sites put
+      // `capitalize` on the element, so what a user saw was `Pending`, not
+      // `pending`. `en` therefore has to be the capitalised member, exactly — one
+      // letter of drift and this slice would have changed the English.
+      for (const member of STATUS_MEMBERS) {
+        expect(
+          at(builtInLocales.en, `organization.invitations.status.${member}`),
+          `en status.${member}`,
+        ).toBe(cssCapitalize(member));
+      }
+      // the premise: both elements still carry `capitalize`
+      const src = sourceOf(INVITATIONS);
+      expect(src, 'the filter tab lost its capitalize class').toContain('transition-colors capitalize');
+      expect(src, 'the status badge lost its capitalize class').toContain('className="shrink-0 capitalize"');
+      // Single words, so `text-transform: capitalize` is exactly "upcase the
+      // first letter" — pinned, because the CSS rule capitalises EVERY word and a
+      // future two-word status would not round-trip through this model.
+      for (const member of STATUS_MEMBERS) expect(member).not.toContain(' ');
+    });
+
+    it('the four invitation adjectives agree with each pack own word for "invitation"', () => {
+      // Deliberately NOT reused from the `approvals*` family even though `en` has
+      // byte-identical rows there, and the reason is grammatical rather than
+      // stylistic: those rows agree with each pack's word for "request", and this
+      // family describes an INVITATION. `ru` is the clearest case —
+      // `approvalsInbox.statusRejected` is the masculine `Отклонён` (запрос),
+      // while приглашение is neuter and needs `Отклонено`. Reusing would have
+      // shipped a grammar error that key parity and the cognate set both pass.
+      expect(at(builtInLocales.en, 'approvalsInbox.statusRejected')).toBe('Rejected');
+      expect(at(builtInLocales.ru, 'approvalsInbox.statusRejected')).toBe('Отклонён');
+      expect(at(builtInLocales.ru, 'organization.invitations.status.rejected')).toBe('Отклонено');
+      expect(at(builtInLocales.ru, 'organization.accept.declined')).toBe('Приглашение отклонено');
+      // fr/es inflect feminine (invitation / invitación), pt masculine (convite) —
+      // taken from the same-namespace toasts, which is where each pack already
+      // committed to a gender.
+      expect(at(builtInLocales.fr, 'organization.accept.accepted')).toBe('Invitation acceptée');
+      expect(at(builtInLocales.fr, 'organization.invitations.status.accepted')).toBe('Acceptée');
+      expect(at(builtInLocales.es, 'organization.accept.accepted')).toBe('Invitación aceptada');
+      expect(at(builtInLocales.es, 'organization.invitations.status.accepted')).toBe('Aceptada');
+      expect(at(builtInLocales.pt, 'organization.accept.accepted')).toBe('Convite aceito');
+      expect(at(builtInLocales.pt, 'organization.invitations.status.accepted')).toBe('Aceito');
+      // …and `all`, the filter tab's own member, follows the same gender: the
+      // noun it quantifies is "invitations".
+      expect(at(builtInLocales.fr, 'organization.invitations.status.all')).toBe('Toutes');
+      expect(at(builtInLocales.es, 'organization.invitations.status.all')).toBe('Todas');
+      expect(at(builtInLocales.pt, 'organization.invitations.status.all')).toBe('Todos');
+      // `canceled` is the ORG withdrawing the invitation, not the invitee
+      // declining it, so de takes `zurückgezogen` from its own cancel toast
+      // rather than the generic `Abgebrochen`.
+      expect(at(builtInLocales.de, 'organization.invitations.canceled')).toBe('Einladung zurückgezogen');
+      expect(at(builtInLocales.de, 'organization.invitations.status.canceled')).toBe('Zurückgezogen');
+    });
+  });
+
+  it('reused strings are the neighbours own translations, not second renderings', () => {
+    // Where this slice's `en` string already existed verbatim elsewhere AND the
+    // neighbour's translation is grammatically usable here, the existing row is
+    // reused rather than re-translated, so one English string never renders as
+    // two different sentences in the same language. A drift on either side fails
+    // here.
+    const REUSED: Array<[newKey: string, neighbour: string]> = [
+      ['common.done', 'view.done'],
+      ['common.record', 'home.recentApps.itemType.record'],
+      ['common.retry', 'lookup.retry'],
+      ['dashboard.loading', 'lookup.loading'],
+      ['detail.add', 'report.editor.fieldPickerAdd'],
+      // The one family member that IS reused: `Pending` is rendered by a verb or
+      // an invariant adjective in every pack (`ru` "Ожидает"), so unlike the
+      // other four it carries no gender to disagree with.
+      ['organization.invitations.status.pending', 'grid.import.jobStatus.pending'],
+    ];
+    for (const [newKey, neighbour] of REUSED) {
+      // the premise: the two really are the same English string
+      expect(at(builtInLocales.en, newKey), `en ${newKey} vs ${neighbour}`).toBe(
+        at(builtInLocales.en, neighbour),
+      );
+      for (const lang of LANGS) {
+        expect(at(builtInLocales[lang], newKey), `${lang} ${newKey} diverged from ${neighbour}`).toBe(
+          at(builtInLocales[lang], neighbour),
+        );
+      }
+    }
+    // Recorded because it looks like an omission and is not: two other rows also
+    // say `Done`/`Pending` in `en` and already disagree with the chosen neighbour
+    // in one pack each — `grid.bulk.done` is es "Hecho" against "Listo", and
+    // `approvalsInbox.statusPending` is zh 待审批 ("awaiting approval"), which is
+    // wrong for an invitation. So the repo ALREADY renders these English strings
+    // more than one way, on purpose, and picking a neighbour is a choice that has
+    // to be made rather than derived.
+    expect(at(builtInLocales.en, 'grid.bulk.done')).toBe('Done');
+    expect(at(builtInLocales.es, 'grid.bulk.done')).toBe('Hecho');
+    expect(at(builtInLocales.es, 'view.done')).toBe('Listo');
+    expect(at(builtInLocales.zh, 'approvalsInbox.statusPending')).toBe('待审批');
+    expect(at(builtInLocales.zh, 'organization.invitations.status.pending')).toBe('等待中');
+  });
+
+  it('the concept neighbours are the ones this slice claims, and they still say so', () => {
+    // "Find the neighbour by CONCEPT, not by bytes" (slice five's blind spot,
+    // slice six's rule). Each premise is asserted next to the value it justified,
+    // so a neighbour that moves takes this with it.
+
+    // `Administration` — the strongest neighbour in the whole slice: a sibling
+    // key NAMES this very menu, per pack, in a sentence.
+    expect(at(builtInLocales.en, 'home.welcomeAdminDescriptionNoAi')).toBe(
+      'Set up your first application from the Administration menu on the left.',
+    );
+    expect(at(builtInLocales.zh, 'home.welcomeAdminDescriptionNoAi')).toContain('「管理」菜单');
+    expect(at(builtInLocales.zh, 'layout.systemNav.administration')).toBe('管理');
+    expect(at(builtInLocales.de, 'home.welcomeAdminDescriptionNoAi')).toContain('Verwaltungsmenü');
+    expect(at(builtInLocales.de, 'layout.systemNav.administration')).toBe('Verwaltung');
+    expect(at(builtInLocales.ru, 'home.welcomeAdminDescriptionNoAi')).toContain('«Администрирование»');
+    expect(at(builtInLocales.ru, 'layout.systemNav.administration')).toBe('Администрирование');
+
+    // `Datasources` — the plural nav label; the singular concept is already
+    // translated as a field label, and the sibling nav entries are plural.
+    expect(at(builtInLocales.en, 'report.editor.objectName')).toBe('Data source');
+    expect(at(builtInLocales.ru, 'report.editor.objectName')).toBe('Источник данных');
+    expect(at(builtInLocales.ru, 'layout.systemNav.datasources')).toBe('Источники данных');
+    expect(at(builtInLocales.ru, 'layout.systemNav.organizations')).toBe('Организации');
+
+    // `Documentation` — the help menu already has it, twice.
+    expect(at(builtInLocales.en, 'help.onlineDocs')).toBe('Online documentation');
+    expect(at(builtInLocales.ja, 'help.onlineDocs')).toBe('オンラインドキュメント');
+    expect(at(builtInLocales.ja, 'layout.systemNav.documentation')).toBe('ドキュメント');
+
+    // `Record deleted` — structural twin: "<Noun> deleted" as a success toast.
+    expect(at(builtInLocales.en, 'organization.settings.deleted')).toBe('Organization deleted');
+    expect(at(builtInLocales.ja, 'organization.settings.deleted')).toBe('組織を削除しました');
+    expect(at(builtInLocales.ja, 'detail.deleted')).toBe('レコードを削除しました');
+    expect(at(builtInLocales.ru, 'organization.settings.deleted')).toBe('Организация удалена');
+    expect(at(builtInLocales.ru, 'detail.deleted')).toBe('Запись удалена');
+
+    // `No history yet` — the "No X yet" empty-state family, plus each pack's own
+    // word for History (ko says 기록, not 히스토리).
+    expect(at(builtInLocales.en, 'detail.noCommentsYet')).toBe('No comments yet');
+    expect(at(builtInLocales.ko, 'detail.noCommentsYet')).toBe('아직 댓글이 없습니다');
+    expect(at(builtInLocales.ko, 'detail.history')).toBe('기록');
+    expect(at(builtInLocales.ko, 'detail.historyEmpty')).toBe('아직 기록이 없습니다');
+
+    // `Edit in studio` — "<verb> in Studio", with each pack's own Edit verb. The
+    // product name stays Latin in all ten, which is why `Studio` shows up in the
+    // loanword check above.
+    expect(at(builtInLocales.en, 'topbar.designInStudio')).toBe('Design in Studio');
+    expect(at(builtInLocales.zh, 'topbar.designInStudio')).toBe('在 Studio 中设计');
+    expect(at(builtInLocales.zh, 'common.edit')).toBe('编辑');
+    expect(at(builtInLocales.zh, 'common.editInStudio')).toBe('在 Studio 中编辑');
+
+    // `on this instance` — ru and ar both render instance/deployment with their
+    // own environment word, and have done so consistently.
+    expect(at(builtInLocales.en, 'auth.login.devAdminHint.title')).toBe('Development instance');
+    expect(at(builtInLocales.ru, 'approvalsInbox.recallUnavailable')).toBe('Отзыв недоступен в этой среде.');
+    expect(at(builtInLocales.ru, 'workspace.multiOrgDisabled')).toContain('в этой среде');
+    expect(at(builtInLocales.ar, 'connectAgent.disabled.title')).toBe('MCP معطّل في هذا النشر');
+    expect(at(builtInLocales.ar, 'workspace.multiOrgDisabled')).toContain('في هذا النشر');
+    // …and the "X ist disabled" sentence shape comes from the pack's own
+    // `gantt.readOnlyHint`, not from a fresh construction.
+    expect(at(builtInLocales.de, 'gantt.readOnlyHint')).toBe('Die Bearbeitung ist in dieser Ansicht deaktiviert.');
+    expect(at(builtInLocales.de, 'workspace.multiOrgDisabled')).toContain('ist auf dieser Instanz deaktiviert');
+  });
+
+  it('kanban.columns is a bare unit word and follows the repo one precedent for that', () => {
+    // The call site concatenates: `` `${boardColumns.length} ${t('kanban.columns')}` ``, so
+    // the pack supplies a UNIT, not a sentence — the same structure as
+    // `preview.history.items` (slice five, which had to be corrected once for
+    // exactly this reason). `en` is plural-only and that is safe here: the empty
+    // state only renders when `boardColumns.length > 1`, so the count is never 1
+    // and no plural family is needed.
+    const src = sourceOf(KANBAN);
+    expect(src, 'the columns count label moved').toContain(
+      "description={`${boardColumns.length} ${t('kanban.columns', { defaultValue: 'columns' })}`}",
+    );
+    expect(src, 'the >1 guard moved — a plural family would now be required').toContain(
+      'const isBoardEmpty = totalCardCount === 0 && boardColumns.length > 1;',
+    );
+    // The precedent's shape, per pack: unit word only, no counter particle, since
+    // the call site already inserts the space and the number.
+    expect(at(builtInLocales.en, 'preview.history.items')).toBe('item(s)');
+    expect(at(builtInLocales.ko, 'preview.history.items')).toBe('항목');
+    expect(at(builtInLocales.ru, 'preview.history.items')).toBe('элементов');
+    // …and the WORD comes from kanban's own column vocabulary, which is not the
+    // table's: ja says カラム here and 列 in `table.columns`, ru колонка against
+    // столбец.
+    expect(at(builtInLocales.ja, 'kanban.addColumn')).toBe('カラムを追加');
+    expect(at(builtInLocales.ja, 'table.columns')).toBe('列');
+    expect(at(builtInLocales.ja, 'kanban.columns')).toBe('カラム');
+    expect(at(builtInLocales.ru, 'kanban.addColumn')).toBe('Добавить колонку');
+    expect(at(builtInLocales.ru, 'kanban.columns')).toBe('колонок');
+    expect(at(builtInLocales.ko, 'kanban.columns')).toBe('열');
+  });
+
+  it('detail.concurrentUpdateRecordLabel is grammatical in the sentence that embeds it', () => {
+    // This value is not a label on its own: `ConcurrentUpdateDialog` splits
+    // `detail.concurrentUpdateDescription` on `{{field}}` and renders it bolded in
+    // the gap, so the pack value has to fit whatever case/preposition precedes
+    // the hole. `de` needs the DATIVE (…Version **von** {{field}}) where its
+    // sibling `detail.deleteConfirmation` uses the accusative, and `ru` needs the
+    // GENITIVE (…версию {{field}}). This is why the value is not simply the
+    // pack's word for "record".
+    const dialog = sourceOf(OCC_DIALOG);
+    expect(dialog).toContain("const descriptionTemplate = t('detail.concurrentUpdateDescription', { field: '{{field}}' });");
+    expect(dialog).toContain("const [beforeField, afterField] = descriptionTemplate.split('{{field}}');");
+    expect(dialog).toContain("const fieldLabel = conflict?.label || conflict?.field || '';");
+    expect(sourceOf(SAVE_BAR)).toContain("label: t('detail.concurrentUpdateRecordLabel', { defaultValue: 'this record' }),");
+
+    const composed = (lang: string) =>
+      (at(builtInLocales[lang], 'detail.concurrentUpdateDescription') as string).replace(
+        '{{field}}',
+        at(builtInLocales[lang], 'detail.concurrentUpdateRecordLabel') as string,
+      );
+    expect(composed('de')).toContain('eine neuere Version von diesem Datensatz gespeichert');
+    expect(at(builtInLocales.de, 'detail.deleteConfirmation')).toContain('diesen Datensatz');
+    expect(composed('ru')).toContain('более новую версию этой записи');
+    expect(composed('fr')).toContain("une version plus récente de cet enregistrement");
+    // `pt` is the one pack where the embedded phrase is NOT idiomatic and cannot
+    // be fixed from this leaf: Portuguese contracts de + este into "deste", but
+    // the "de " lives in the surrounding sentence, which is an EXISTING pack value
+    // this slice does not touch. Pinned as the current truth rather than left for
+    // the next reader to mistake for an oversight; filed separately, and the fix
+    // is to rephrase pt's `concurrentUpdateDescription` so the hole is not
+    // preceded by a bare preposition.
+    expect(composed('pt')).toContain('mais recente de este registro');
+    expect(at(builtInLocales.pt, 'detail.concurrentUpdateDescription')).toContain('mais recente de {{field}}');
+  });
+
+  it('each pack keeps its own typography in the one long sentence of this slice', () => {
+    // The habits a copy-paste from `en` or a machine translation breaks first,
+    // checked on the only multi-clause value here plus across all 24 paths where
+    // the rule is pack-wide.
+    const KEY = 'empty.appNotAvailableDescription';
+    // en's em dash is U+2014; zh writes the doubled `——` its own pack prefers
+    // (45 values against 25 single), everyone else mirrors en.
+    for (const lang of LANGS) {
+      const value = at(builtInLocales[lang], KEY) as string;
+      expect(value.includes(lang === 'zh' ? '——' : '—'), `${lang} ${KEY} dash`).toBe(true);
+    }
+    // fr writes the straight apostrophe U+0027 (502 values against 21 curly) —
+    // across every path, not just this one.
+    for (const key of KEYS) {
+      expect((at(builtInLocales.fr, key) as string).includes('’'), `fr ${key} used a curly apostrophe`).toBe(false);
+    }
+    expect(at(builtInLocales.fr, KEY)).toContain("n'est pas encore disponible");
+    // ru writes ё (163 values in the pack).
+    expect(at(builtInLocales.ru, KEY)).toContain('ещё');
+    // The quote style around `{{name}}` follows the sibling empty-state value in
+    // the SAME pack: zh curly, ja corner brackets, the rest ASCII.
+    expect(at(builtInLocales.zh, 'empty.objectNotFoundDescription')).toContain('“{{name}}”');
+    expect(at(builtInLocales.zh, 'empty.interfacePageSourceMissing')).toContain('“{{name}}”');
+    expect(at(builtInLocales.ja, 'empty.objectNotFoundDescription')).toContain('「{{name}}」');
+    expect(at(builtInLocales.ja, 'empty.interfacePageSourceMissing')).toContain('「{{name}}」');
+    for (const lang of ['ko', 'fr', 'es', 'pt', 'ru', 'ar'] as const) {
+      expect(at(builtInLocales[lang], 'empty.interfacePageSourceMissing'), `${lang} quotes`).toContain('"{{name}}"');
+    }
+    // de is the deliberate divergence: its sibling values pair the German opening
+    // low quote with an ASCII straight quote (20 values do this, measured), which
+    // is a typo rather than a convention, so this slice writes the correctly
+    // paired „…“ and the mismatch is filed instead of copied.
+    expect(at(builtInLocales.de, 'empty.objectNotFoundDescription')).toContain('„{{name}}"');
+    expect(at(builtInLocales.de, 'empty.interfacePageSourceMissing')).toContain('„{{name}}“');
+  });
+
+  it('the ratchet is empty — this is the terminal state, not a partial one', () => {
+    // `scripts/i18n-call-site-key-baseline.json` fails the build both ways: an
+    // unfixed key missing from it, AND a fixed key still listed. With both lists
+    // empty, any NEW unresolved call-site key is `unexpected` and fails — which
+    // is what makes the empty file load-bearing rather than dead weight.
+    const baselinePath = join(process.cwd(), 'scripts/i18n-call-site-key-baseline.json');
+    expect(existsSync(baselinePath), `baseline not found at ${baselinePath}`).toBe(true);
+    const raw = readFileSync(baselinePath, 'utf8');
+    const baseline = JSON.parse(raw) as {
+      note: string[];
+      missingKeys: Record<string, unknown>;
+      missingPrefixes: Record<string, unknown>;
+    };
+    // 258 keys and 4 prefix families at the start (main@a2c8f2a29), across seven
+    // slices: 253 → 163 → 109 → 68 → 31 → 17 → 0, and 4 → 4 → 3 → 2 → 2 → 0.
+    expect(Object.keys(baseline.missingKeys)).toEqual([]);
+    expect(Object.keys(baseline.missingPrefixes)).toEqual([]);
+    // Not deleted, and the file says why — a reader who finds two empty objects
+    // must not conclude the ratchet is obsolete.
+    expect(baseline.note.join(' ')).toContain('BOTH LISTS ARE NOW EMPTY');
+    expect(baseline.note.join(' ')).toContain('fails the build');
+    // Every key this slice removed now resolves, which is the other half of the
+    // same statement: the entries went because the defect went.
+    for (const key of KEYS) expect(typeof at(builtInLocales.en, key), `en ${key}`).toBe('string');
+  });
+
+  describe('through the real binding — provider mounted', () => {
+    /** One key per owning surface. */
+    const SAMPLE: Array<[key: string, owner: string]> = [
+      ['common.done', 'InviteMemberDialog (invitation created footer)'],
+      ['common.editInStudio', 'PageView (edit affordance title/aria-label)'],
+      ['empty.appNotAvailable', 'AppContent (requested app missing)'],
+      ['detail.historyEmpty', 'DetailView (history tab)'],
+      ['kanban.columns', 'KanbanImpl (empty board)'],
+      ['layout.systemNav.administration', 'UnifiedSidebar (admin cluster)'],
+      ['workspace.multiOrgDisabled', 'CreateWorkspaceDialog (submit guard)'],
+      ['gantt.linkEnd.start', 'GanttView (link drag hint)'],
+      ['organization.invitations.status.pending', 'InvitationsPage (filter tab + badge)'],
+    ];
+
+    it('every owning file still binds t the way this suite assumes', () => {
+      // The premise of mounting a provider, per family of binding — asserted, not
+      // assumed. Nine files take i18next directly; four go through a
+      // `createSafeTranslation` hook that hands i18next's `t` over once its probe
+      // key resolves (which it does, since the probe keys are in the packs); one
+      // uses the per-call `useSafeTranslate`; one uses gantt's per-key wrapper.
+      for (const rel of [
+        INVITE_DIALOG,
+        PAGE_VIEW,
+        APP_CONTENT,
+        INVITATIONS,
+        MEMBERS,
+        INTERFACE_LIST,
+        UNIFIED_SIDEBAR,
+        APP_SIDEBAR,
+        CREATE_WORKSPACE,
+      ]) {
+        expect(sourceOf(rel), `${rel} no longer binds the pack hook`).toContain('useObjectTranslation');
+        expect(sourceOf(rel), `${rel} stopped destructuring t`).toContain('const { t } = useObjectTranslation();');
+      }
+      // RecordDetailView takes it from @object-ui/react's re-export, with language.
+      expect(sourceOf(RECORD_DETAIL)).toContain('const { t, language } = useObjectTranslation();');
+      // plugin-detail's three go through useDetailTranslation…
+      for (const rel of [RELATED_LIST, SAVE_BAR, DETAIL_VIEW]) {
+        expect(sourceOf(rel), `${rel}`).toContain("import { useDetailTranslation } from './useDetailTranslation'");
+        expect(sourceOf(rel), `${rel}`).toContain('const { t } = useDetailTranslation();');
+      }
+      // …and kanban through its own createSafeTranslation, whose probe key IS in
+      // the packs, so the provider path wins. Its defaults map does not list
+      // `kanban.columns`, which is the provider-LESS defect objectui#3865 owns.
+      const kanban = sourceOf(KANBAN);
+      expect(kanban).toContain('const useKanbanT = createSafeTranslation(');
+      expect(kanban).toContain("'kanban.noCards',");
+      expect(kanban).not.toContain("'kanban.columns':");
+      expect(typeof at(builtInLocales.en, 'kanban.noCards')).toBe('string');
+      // gantt's wrapper is per-key rather than probe-based (see its own header).
+      expect(sourceOf(GANTT_VIEW)).toContain('const { t, language } = useGanttTranslation();');
+    });
+
+    it.each(['en', 'zh'])('%s resolves every sampled key from the pack', (lang) => {
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor(lang) });
+      for (const [key, owner] of SAMPLE) {
+        const value = result.current.t(key);
+        expect(value, `${lang} ${owner} rendered the raw key for ${key}`).not.toBe(key);
+        expect(value, `${lang}.${key}`).toBe(at(builtInLocales[lang], key));
+      }
+    });
+
+    it('zh is Chinese — the half that was red before the backfill', () => {
+      // Pre-fix each of these returned the inline English default in a zh session.
+      // That is the whole defect, and only a non-en assertion sees it.
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor('zh') });
+      const { t } = result.current;
+      expect(t('common.editInStudio')).toBe('在 Studio 中编辑');
+      expect(t('empty.appNotAvailable')).toBe('应用不可用');
+      expect(t('empty.appNotAvailableDescription')).toBe('此应用尚不可用 —— 可能仍在发布中。请稍后重试。');
+      expect(t('empty.interfacePageSourceMissing', { name: 'crm_lead' })).toBe(
+        '此界面页引用了 “crm_lead”，但该来源不可用。',
+      );
+      expect(t('layout.systemNav.administration')).toBe('管理');
+      expect(t('workspace.multiOrgDisabled')).toBe('此实例已禁用创建新组织。');
+      expect(t('kanban.columns')).toBe('列');
+      expect(t('detail.deleted')).toBe('记录已删除');
+    });
+
+    it('both template families render every member, in en and in zh', () => {
+      // Exercised the way the call sites build the key, so a family that resolves
+      // in the abstract but not through the template would still fail.
+      for (const lang of ['en', 'zh'] as const) {
+        window.localStorage.clear();
+        const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor(lang) });
+        for (const member of LINK_END_MEMBERS) {
+          const key = `gantt.linkEnd.${member}`;
+          expect(result.current.t(key), `${lang} ${key}`).toBe(at(builtInLocales[lang], key));
+          expect(result.current.t(key)).not.toBe(key);
+        }
+        for (const member of STATUS_MEMBERS) {
+          const key = `organization.invitations.status.${member}`;
+          expect(result.current.t(key), `${lang} ${key}`).toBe(at(builtInLocales[lang], key));
+          expect(result.current.t(key)).not.toBe(key);
+        }
+      }
+      // The gantt drag hint, composed the way GanttView composes it.
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor('zh') });
+      const endLabel = (e: 'start' | 'end') => result.current.t(`gantt.linkEnd.${e}`);
+      expect(`设计评审 (${endLabel('end')}) → 上线 (${endLabel('start')})`).toBe('设计评审 (结束) → 上线 (开始)');
+    });
+
+    it.each([
+      ['de', 'workspace.multiOrgDisabled', 'Das Erstellen neuer Organisationen ist auf dieser Instanz deaktiviert.'],
+      ['fr', 'detail.historyEmpty', 'Aucun historique pour le moment'],
+      ['es', 'organization.invitations.status.canceled', 'Cancelada'],
+      ['pt', 'empty.appNotAvailable', 'Aplicativo indisponível'],
+      ['ru', 'layout.systemNav.datasources', 'Источники данных'],
+      ['ja', 'detail.deleted', 'レコードを削除しました'],
+      ['ko', 'common.editInStudio', 'Studio에서 편집'],
+      ['ar', 'layout.systemNav.documentation', 'الوثائق'],
+    ])('%s renders a user-visible string from the pack', (lang, key, expected) => {
+      // One pinned surface per remaining pack, across four writing systems, so a
+      // pack that silently reverts to English is caught by name and not only by
+      // the aggregate above.
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor(lang) });
+      expect(result.current.t(key)).toBe(expected);
+    });
+
+    it('the ar pack does not open an RTL string with a Latin token', () => {
+      // Same rule slices three through six applied. `MCP`/`Studio`-style Latin
+      // runs are allowed inside a string, never at its head, and the one
+      // interpolated path is checked after substitution too — a hole at position
+      // zero would put the caller's Latin value first.
+      const { result } = renderHook(() => useObjectTranslation(), { wrapper: wrapperFor('ar') });
+      for (const key of KEYS) {
+        const value = result.current.t(key, { name: 'crm_lead' });
+        expect(/^[A-Za-z]/.test(value), `${key} starts with a Latin token: ${value}`).toBe(false);
+      }
+      expect(result.current.t('common.editInStudio')).toBe('التعديل في Studio');
+      expect(result.current.t('empty.interfacePageSourceMissing', { name: 'crm_lead' })).toContain('"crm_lead"');
+    });
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -109,6 +109,10 @@ const ar = {
     itemCountOne: "{{count}} عنصر",
     toggleSidebar: "تبديل الشريط الجانبي",
     package: "الحزمة",
+    done: "تم",
+    editInStudio: "التعديل في Studio",
+    record: "سجل",
+    retry: "إعادة المحاولة",
   },
   actions: {
     decisionOutput: {
@@ -602,6 +606,7 @@ const ar = {
   },
   kanban: {
     uncategorized: "غير مصنّف",
+    columns: "أعمدة",
     addCard: "إضافة بطاقة",
     addColumn: "إضافة عمود",
     moveCard: "نقل بطاقة",
@@ -666,6 +671,10 @@ const ar = {
       ss: "بداية → بداية",
       ff: "نهاية → نهاية",
       sf: "بداية → نهاية",
+    },
+    linkEnd: {
+      start: "بداية",
+      end: "نهاية",
     },
     conflict: {
       title: "تعارض في الجدولة",
@@ -804,9 +813,11 @@ const ar = {
     copyToClipboard: "نسخ إلى الحافظة",
     copied: "تم النسخ!",
     deleteConfirmation: "هل أنت متأكد أنك تريد حذف هذا السجل؟",
+    deleted: "تم حذف السجل",
     editRecord: "تحرير السجل",
     viewAll: "عرض الكل",
     new: "جديد",
+    add: "إضافة",
     emptyValue: "—",
     comments: "التعليقات",
     searchComments: "البحث في التعليقات…",
@@ -913,9 +924,11 @@ const ar = {
     concurrentUpdateReload: "تحميل النسخة الحالية",
     concurrentUpdateOverwrite: "الكتابة فوقه على أي حال",
     concurrentUpdateCancel: "إلغاء",
+    concurrentUpdateRecordLabel: "هذا السجل",
     openInNewTab: "فتح في علامة تبويب جديدة",
     activity: "النشاط",
     history: "السجل",
+    historyEmpty: "لا يوجد سجل بعد",
     editRow: "تعديل",
     deleteRow: "حذف",
     deleteRowConfirmation: "حذف هذا السجل؟",
@@ -1011,6 +1024,7 @@ const ar = {
   },
   dashboard: {
     noRows: "لا توجد صفوف",
+    loading: "جارٍ التحميل…",
     pickMeasures: "اختر المقاييس (القيم) لأداة مجموعة البيانات هذه.",
     datasetUnsupported: "مصدر البيانات هذا لا يدعم استعلامات مجموعات البيانات.",
     details: "التفاصيل",
@@ -2155,6 +2169,7 @@ const ar = {
     invite: "دعوة عضو",
     members: "الأعضاء",
     settings: "إعدادات مساحة العمل",
+    multiOrgDisabled: "إنشاء مؤسسات جديدة معطّل في هذا النشر.",
   },
   help: {
     onThisPage: "في هذه الصفحة",
@@ -2311,6 +2326,9 @@ const ar = {
       roles: "الأدوار",
       configuration: "التهيئة",
       createApp: "إنشاء تطبيق",
+      administration: "الإدارة",
+      datasources: "مصادر البيانات",
+      documentation: "الوثائق",
     },
     appSwitcher: {
       switchApplication: "تبديل التطبيق",
@@ -2369,6 +2387,7 @@ const ar = {
   empty: {
     objectNotFound: "الكائن غير موجود",
     objectNotFoundDescription: "تعريف الكائن \"{{name}}\" مفقود. تحقق من الإعداد أو ارجع للخلف.",
+    interfacePageSourceMissing: "تشير صفحة الواجهة هذه إلى \"{{name}}\"، وهو غير متاح.",
     pageNotFound: "الصفحة غير موجودة",
     pageNotFoundDescription: "الصفحة \"{{name}}\" غير موجودة. ربما تم إزالتها أو إعادة تسميتها.",
     dashboardNotFound: "لوحة التحكم غير موجودة",
@@ -2377,6 +2396,8 @@ const ar = {
     reportNotFoundDescription: "التقرير \"{{name}}\" غير موجود. ربما تم إزالته أو إعادة تسميته.",
     noAppsConfigured: "لا تطبيقات مُهيأة",
     noAppsConfiguredDescription: "لا تطبيقات مسجلة. أنشئ تطبيقك الأول أو زر إعدادات النظام.",
+    appNotAvailable: "التطبيق غير متاح",
+    appNotAvailableDescription: "هذا التطبيق غير متاح بعد — قد يكون النشر ما زال جارياً. أعد المحاولة بعد لحظات.",
     createFirstApp: "إنشاء أول تطبيق",
     systemSettings: "إعدادات النظام",
     back: "رجوع",
@@ -2659,6 +2680,13 @@ const ar = {
       sentDescription: "شارك الرابط أدناه مع المدعوّ. سيحتاج إلى تسجيل الدخول للقبول.",
       linkLabel: "رابط القبول",
       invitedAs: "تمت دعوة {{email}} بصفة {{role}}",
+      status: {
+        all: "الكل",
+        pending: "قيد الانتظار",
+        accepted: "مقبولة",
+        rejected: "مرفوضة",
+        canceled: "ملغاة",
+      },
     },
     settings: {
       generalTitle: "عام",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -105,6 +105,10 @@ const de = {
     itemCountOne: "{{count}} Element",
     toggleSidebar: "Seitenleiste umschalten",
     package: "Paket",
+    done: "Fertig",
+    editInStudio: "Im Studio bearbeiten",
+    record: "Datensatz",
+    retry: "Erneut versuchen",
   },
   actions: {
     decisionOutput: {
@@ -598,6 +602,7 @@ const de = {
   },
   kanban: {
     uncategorized: "Nicht kategorisiert",
+    columns: "Spalten",
     addCard: "Karte hinzufügen",
     addColumn: "Spalte hinzufügen",
     moveCard: "Karte verschieben",
@@ -662,6 +667,10 @@ const de = {
       ss: "Anfang → Anfang",
       ff: "Ende → Ende",
       sf: "Anfang → Ende",
+    },
+    linkEnd: {
+      start: "Anfang",
+      end: "Ende",
     },
     conflict: {
       title: "Terminkonflikt",
@@ -798,9 +807,11 @@ const de = {
     copyToClipboard: "In Zwischenablage kopieren",
     copied: "Kopiert!",
     deleteConfirmation: "Sind Sie sicher, dass Sie diesen Datensatz löschen möchten?",
+    deleted: "Datensatz gelöscht",
     editRecord: "Datensatz bearbeiten",
     viewAll: "Alle anzeigen",
     new: "Neu",
+    add: "Hinzufügen",
     emptyValue: "—",
     comments: "Kommentare",
     searchComments: "Kommentare suchen…",
@@ -907,9 +918,11 @@ const de = {
     concurrentUpdateReload: "Aktuelle Version laden",
     concurrentUpdateOverwrite: "Trotzdem überschreiben",
     concurrentUpdateCancel: "Abbrechen",
+    concurrentUpdateRecordLabel: "diesem Datensatz",
     openInNewTab: "In neuem Tab öffnen",
     activity: "Aktivität",
     history: "Verlauf",
+    historyEmpty: "Noch kein Verlauf",
     editRow: "Bearbeiten",
     deleteRow: "Löschen",
     deleteRowConfirmation: "Möchten Sie diesen Datensatz wirklich löschen?",
@@ -1007,6 +1020,7 @@ const de = {
   },
   dashboard: {
     noRows: "Keine Zeilen",
+    loading: "Wird geladen…",
     pickMeasures: "Wählen Sie Kennzahlen (Werte) für dieses Dataset-Widget.",
     datasetUnsupported: "Diese Datenquelle unterstützt keine Dataset-Abfragen.",
     details: "Details",
@@ -2151,6 +2165,7 @@ const de = {
     invite: "Mitglied einladen",
     members: "Mitglieder",
     settings: "Arbeitsbereichseinstellungen",
+    multiOrgDisabled: "Das Erstellen neuer Organisationen ist auf dieser Instanz deaktiviert.",
   },
   help: {
     onThisPage: "Auf dieser Seite",
@@ -2307,6 +2322,9 @@ const de = {
       roles: "Rollen",
       configuration: "Konfiguration",
       createApp: "App erstellen",
+      administration: "Verwaltung",
+      datasources: "Datenquellen",
+      documentation: "Dokumentation",
     },
     appSwitcher: {
       switchApplication: "Anwendung wechseln",
@@ -2365,6 +2383,7 @@ const de = {
   empty: {
     objectNotFound: "Objekt nicht gefunden",
     objectNotFoundDescription: "Definition des Objekts „{{name}}\" fehlt. Überprüfen Sie Ihre Konfiguration oder navigieren Sie zurück.",
+    interfacePageSourceMissing: "Diese Interface-Seite verweist auf „{{name}}“, das nicht verfügbar ist.",
     pageNotFound: "Seite nicht gefunden",
     pageNotFoundDescription: "Die Seite „{{name}}\" wurde nicht gefunden. Sie wurde möglicherweise entfernt oder umbenannt.",
     dashboardNotFound: "Dashboard nicht gefunden",
@@ -2373,6 +2392,8 @@ const de = {
     reportNotFoundDescription: "Der Bericht „{{name}}\" wurde nicht gefunden. Er wurde möglicherweise entfernt oder umbenannt.",
     noAppsConfigured: "Keine Apps konfiguriert",
     noAppsConfiguredDescription: "Es sind keine Anwendungen registriert. Erstellen Sie Ihre erste App oder besuchen Sie die Systemeinstellungen.",
+    appNotAvailable: "App nicht verfügbar",
+    appNotAvailableDescription: "Diese App ist noch nicht verfügbar — sie wird möglicherweise noch veröffentlicht. Versuchen Sie es in einem Moment erneut.",
     createFirstApp: "Erste App erstellen",
     systemSettings: "Systemeinstellungen",
     back: "Zurück",
@@ -2655,6 +2676,13 @@ const de = {
       sentDescription: "Teilen Sie den folgenden Link mit der eingeladenen Person. Sie muss sich anmelden, um anzunehmen.",
       linkLabel: "Annahme-Link",
       invitedAs: "{{email}} als {{role}} eingeladen",
+      status: {
+        all: "Alle",
+        pending: "Ausstehend",
+        accepted: "Angenommen",
+        rejected: "Abgelehnt",
+        canceled: "Zurückgezogen",
+      },
     },
     settings: {
       generalTitle: "Allgemein",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -121,6 +121,10 @@ const en = {
     itemCountOne: '{{count}} item',
     toggleSidebar: 'Toggle sidebar',
     package: 'Package',
+    done: 'Done',
+    editInStudio: 'Edit in studio',
+    record: 'Record',
+    retry: 'Retry',
   },
   actions: {
     decisionOutput: {
@@ -654,6 +658,7 @@ const en = {
     noCards: 'No cards',
     cardTitlePlaceholder: 'Enter card title...',
     uncategorized: 'Uncategorized',
+    columns: 'columns',
   },
   timeline: {
     bucket: {
@@ -739,6 +744,10 @@ const en = {
       ss: 'Start → Start',
       ff: 'Finish → Finish',
       sf: 'Start → Finish',
+    },
+    linkEnd: {
+      start: 'start',
+      end: 'end',
     },
     conflict: {
       title: 'Schedule conflict',
@@ -845,6 +854,7 @@ const en = {
     concurrentUpdateReload: 'Reload latest',
     concurrentUpdateOverwrite: 'Overwrite anyway',
     concurrentUpdateCancel: 'Cancel',
+    concurrentUpdateRecordLabel: 'this record',
     openInNewTab: 'Open in new tab',
     share: 'Share',
     duplicate: 'Duplicate',
@@ -891,12 +901,15 @@ const en = {
     copyToClipboard: 'Copy to clipboard',
     copied: 'Copied!',
     deleteConfirmation: 'Are you sure you want to delete this record?',
+    deleted: 'Record deleted',
     editRecord: 'Edit record',
     viewAll: 'View All',
     new: 'New',
+    add: 'Add',
     emptyValue: '—',
     activity: 'Activity',
     history: 'History',
+    historyEmpty: 'No history yet',
     editRow: 'Edit',
     deleteRow: 'Delete',
     deleteRowConfirmation: 'Are you sure you want to delete this record?',
@@ -1225,6 +1238,7 @@ const en = {
     noDataAvailable: 'No data available',
     noDataSourceFor: 'No data source available for',
     noRows: 'No rows',
+    loading: 'Loading…',
     pickMeasures: 'Pick measures (values) for this dataset widget.',
     datasetUnsupported: 'This data source does not support dataset queries.',
     details: 'Details',
@@ -2410,6 +2424,7 @@ const en = {
     invite: 'Invite member',
     members: 'Members',
     settings: 'Workspace settings',
+    multiOrgDisabled: 'Creating new organizations is disabled on this instance.',
   },
   help: {
     onThisPage: 'On this page',
@@ -2580,6 +2595,9 @@ const en = {
       roles: 'Roles',
       configuration: 'Configuration',
       createApp: 'Create App',
+      administration: 'Administration',
+      datasources: 'Datasources',
+      documentation: 'Documentation',
     },
     activityFeed: {
       title: 'Recent Activity',
@@ -2627,6 +2645,7 @@ const en = {
   empty: {
     objectNotFound: 'Object Not Found',
     objectNotFoundDescription: 'Object "{{name}}" definition missing. Check your configuration or navigate back to select a valid object.',
+    interfacePageSourceMissing: 'This interface page references "{{name}}", which is not available.',
     recordNotFound: 'Record not found',
     recordNotFoundDescription: 'The record you are looking for does not exist or may have been deleted.',
     pageNotFound: 'Page Not Found',
@@ -2637,6 +2656,8 @@ const en = {
     reportNotFoundDescription: 'The report "{{name}}" could not be found. It may have been removed or renamed.',
     noAppsConfigured: 'No Apps Configured',
     noAppsConfiguredDescription: 'No applications have been registered. Create your first app or visit System Settings to configure your environment.',
+    appNotAvailable: 'App not available',
+    appNotAvailableDescription: 'This app is not available yet — it may still be publishing. Try again in a moment.',
     createFirstApp: 'Create Your First App',
     systemSettings: 'System Settings',
     back: 'Back',
@@ -2862,6 +2883,13 @@ const en = {
       sentDescription: 'Share the link below with the invitee. They will need to sign in to accept.',
       linkLabel: 'Accept link',
       invitedAs: '{{email}} invited as {{role}}',
+      status: {
+        all: 'All',
+        pending: 'Pending',
+        accepted: 'Accepted',
+        rejected: 'Rejected',
+        canceled: 'Canceled',
+      },
     },
     settings: {
       generalTitle: 'General',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -104,6 +104,10 @@ const es = {
     itemCountOne: "{{count}} elemento",
     toggleSidebar: "Alternar barra lateral",
     package: "Paquete",
+    done: "Listo",
+    editInStudio: "Editar en Studio",
+    record: "Registro",
+    retry: "Reintentar",
   },
   actions: {
     decisionOutput: {
@@ -602,6 +606,7 @@ const es = {
   },
   kanban: {
     uncategorized: "Sin categoría",
+    columns: "columnas",
     addCard: "Añadir tarjeta",
     addColumn: "Añadir columna",
     moveCard: "Mover tarjeta",
@@ -666,6 +671,10 @@ const es = {
       ss: "Inicio → Inicio",
       ff: "Fin → Fin",
       sf: "Inicio → Fin",
+    },
+    linkEnd: {
+      start: "Inicio",
+      end: "Fin",
     },
     conflict: {
       title: "Conflicto de programación",
@@ -802,9 +811,11 @@ const es = {
     copyToClipboard: "Copiar al portapapeles",
     copied: "¡Copiado!",
     deleteConfirmation: "¿Está seguro de que desea eliminar este registro?",
+    deleted: "Registro eliminado",
     editRecord: "Editar registro",
     viewAll: "Ver todo",
     new: "Nuevo",
+    add: "Agregar",
     emptyValue: "—",
     comments: "Comentarios",
     searchComments: "Buscar comentarios…",
@@ -911,9 +922,11 @@ const es = {
     concurrentUpdateReload: "Cargar versión actual",
     concurrentUpdateOverwrite: "Sobrescribir de todos modos",
     concurrentUpdateCancel: "Cancelar",
+    concurrentUpdateRecordLabel: "este registro",
     openInNewTab: "Abrir en nueva pestaña",
     activity: "Actividad",
     history: "Historial",
+    historyEmpty: "Aún no hay historial",
     editRow: "Editar",
     deleteRow: "Eliminar",
     deleteRowConfirmation: "¿Eliminar este registro?",
@@ -1011,6 +1024,7 @@ const es = {
   },
   dashboard: {
     noRows: "Sin filas",
+    loading: "Cargando…",
     pickMeasures: "Elija medidas (valores) para este widget de dataset.",
     datasetUnsupported: "Esta fuente de datos no admite consultas de dataset.",
     details: "Detalles",
@@ -2155,6 +2169,7 @@ const es = {
     invite: "Invitar miembro",
     members: "Miembros",
     settings: "Configuración del espacio de trabajo",
+    multiOrgDisabled: "La creación de nuevas organizaciones está deshabilitada en esta instancia.",
   },
   help: {
     onThisPage: "En esta página",
@@ -2311,6 +2326,9 @@ const es = {
       roles: "Roles",
       configuration: "Configuración",
       createApp: "Crear aplicación",
+      administration: "Administración",
+      datasources: "Fuentes de datos",
+      documentation: "Documentación",
     },
     appSwitcher: {
       switchApplication: "Cambiar de aplicación",
@@ -2369,6 +2387,7 @@ const es = {
   empty: {
     objectNotFound: "Objeto no encontrado",
     objectNotFoundDescription: "Falta la definición del objeto \"{{name}}\". Verifique su configuración o navegue hacia atrás.",
+    interfacePageSourceMissing: "Esta página de interfaz hace referencia a \"{{name}}\", que no está disponible.",
     pageNotFound: "Página no encontrada",
     pageNotFoundDescription: "La página \"{{name}}\" no fue encontrada. Puede haber sido eliminada o renombrada.",
     dashboardNotFound: "Panel no encontrado",
@@ -2377,6 +2396,8 @@ const es = {
     reportNotFoundDescription: "El informe \"{{name}}\" no fue encontrado. Puede haber sido eliminado o renombrado.",
     noAppsConfigured: "Sin aplicaciones configuradas",
     noAppsConfiguredDescription: "No hay aplicaciones registradas. Cree su primera aplicación o visite la configuración del sistema.",
+    appNotAvailable: "Aplicación no disponible",
+    appNotAvailableDescription: "Esta aplicación aún no está disponible — puede que todavía se esté publicando. Vuelva a intentarlo en un momento.",
     createFirstApp: "Crear primera aplicación",
     systemSettings: "Configuración del sistema",
     back: "Atrás",
@@ -2659,6 +2680,13 @@ const es = {
       sentDescription: "Comparte el enlace de abajo con la persona invitada. Tendrá que iniciar sesión para aceptarla.",
       linkLabel: "Enlace de aceptación",
       invitedAs: "{{email}} invitado como {{role}}",
+      status: {
+        all: "Todas",
+        pending: "Pendiente",
+        accepted: "Aceptada",
+        rejected: "Rechazada",
+        canceled: "Cancelada",
+      },
     },
     settings: {
       generalTitle: "General",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -105,6 +105,10 @@ const fr = {
     itemCountOne: "{{count}} élément",
     toggleSidebar: "Basculer la barre latérale",
     package: "Package",
+    done: "Terminé",
+    editInStudio: "Modifier dans Studio",
+    record: "Enregistrement",
+    retry: "Réessayer",
   },
   actions: {
     decisionOutput: {
@@ -598,6 +602,7 @@ const fr = {
   },
   kanban: {
     uncategorized: "Non catégorisé",
+    columns: "colonnes",
     addCard: "Ajouter une carte",
     addColumn: "Ajouter une colonne",
     moveCard: "Déplacer la carte",
@@ -662,6 +667,10 @@ const fr = {
       ss: "Début → Début",
       ff: "Fin → Fin",
       sf: "Début → Fin",
+    },
+    linkEnd: {
+      start: "Début",
+      end: "Fin",
     },
     conflict: {
       title: "Conflit de planning",
@@ -800,9 +809,11 @@ const fr = {
     copyToClipboard: "Copier dans le presse-papiers",
     copied: "Copié !",
     deleteConfirmation: "Êtes-vous sûr de vouloir supprimer cet enregistrement ?",
+    deleted: "Enregistrement supprimé",
     editRecord: "Modifier l'enregistrement",
     viewAll: "Tout afficher",
     new: "Nouveau",
+    add: "Ajouter",
     emptyValue: "—",
     comments: "Commentaires",
     searchComments: "Rechercher des commentaires…",
@@ -909,9 +920,11 @@ const fr = {
     concurrentUpdateReload: "Charger la version actuelle",
     concurrentUpdateOverwrite: "Écraser quand même",
     concurrentUpdateCancel: "Annuler",
+    concurrentUpdateRecordLabel: "cet enregistrement",
     openInNewTab: "Ouvrir dans un nouvel onglet",
     activity: "Activité",
     history: "Historique",
+    historyEmpty: "Aucun historique pour le moment",
     editRow: "Modifier",
     deleteRow: "Supprimer",
     deleteRowConfirmation: "Supprimer cet enregistrement ?",
@@ -1007,6 +1020,7 @@ const fr = {
   },
   dashboard: {
     noRows: "Aucune ligne",
+    loading: "Chargement…",
     pickMeasures: "Choisissez des mesures (valeurs) pour ce widget de dataset.",
     datasetUnsupported: "Cette source de données ne prend pas en charge les requêtes de dataset.",
     details: "Détails",
@@ -2151,6 +2165,7 @@ const fr = {
     invite: "Inviter un membre",
     members: "Membres",
     settings: "Paramètres de l'espace de travail",
+    multiOrgDisabled: "La création de nouvelles organisations est désactivée sur cette instance.",
   },
   help: {
     onThisPage: "Sur cette page",
@@ -2307,6 +2322,9 @@ const fr = {
       roles: "Rôles",
       configuration: "Configuration",
       createApp: "Créer une application",
+      administration: "Administration",
+      datasources: "Sources de données",
+      documentation: "Documentation",
     },
     appSwitcher: {
       switchApplication: "Changer d'application",
@@ -2365,6 +2383,7 @@ const fr = {
   empty: {
     objectNotFound: "Objet introuvable",
     objectNotFoundDescription: "La définition de l'objet \"{{name}}\" est manquante. Vérifiez votre configuration ou revenez en arrière.",
+    interfacePageSourceMissing: "Cette page d'interface référence \"{{name}}\", qui n'est pas disponible.",
     pageNotFound: "Page introuvable",
     pageNotFoundDescription: "La page \"{{name}}\" est introuvable. Elle a peut-être été supprimée ou renommée.",
     dashboardNotFound: "Tableau de bord introuvable",
@@ -2373,6 +2392,8 @@ const fr = {
     reportNotFoundDescription: "Le rapport \"{{name}}\" est introuvable. Il a peut-être été supprimé ou renommé.",
     noAppsConfigured: "Aucune application configurée",
     noAppsConfiguredDescription: "Aucune application n'est enregistrée. Créez votre première application ou visitez les paramètres système.",
+    appNotAvailable: "Application non disponible",
+    appNotAvailableDescription: "Cette application n'est pas encore disponible — sa publication est peut-être en cours. Réessayez dans un instant.",
     createFirstApp: "Créer la première application",
     systemSettings: "Paramètres système",
     back: "Retour",
@@ -2655,6 +2676,13 @@ const fr = {
       sentDescription: "Partagez le lien ci-dessous avec la personne invitée. Elle devra se connecter pour accepter.",
       linkLabel: "Lien d'acceptation",
       invitedAs: "{{email}} invité en tant que {{role}}",
+      status: {
+        all: "Toutes",
+        pending: "En attente",
+        accepted: "Acceptée",
+        rejected: "Refusée",
+        canceled: "Annulée",
+      },
     },
     settings: {
       generalTitle: "Général",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -105,6 +105,10 @@ const ja = {
     itemCountOne: "{{count}} 件",
     toggleSidebar: "サイドバーを切り替え",
     package: "パッケージ",
+    done: "完了",
+    editInStudio: "Studio で編集",
+    record: "レコード",
+    retry: "再試行",
   },
   actions: {
     decisionOutput: {
@@ -598,6 +602,7 @@ const ja = {
   },
   kanban: {
     uncategorized: "未分類",
+    columns: "カラム",
     addCard: "カードを追加",
     addColumn: "カラムを追加",
     moveCard: "カードを移動",
@@ -662,6 +667,10 @@ const ja = {
       ss: "開始 → 開始",
       ff: "終了 → 終了",
       sf: "開始 → 終了",
+    },
+    linkEnd: {
+      start: "開始",
+      end: "終了",
     },
     conflict: {
       title: "スケジュールの競合",
@@ -798,9 +807,11 @@ const ja = {
     copyToClipboard: "クリップボードにコピー",
     copied: "コピーしました！",
     deleteConfirmation: "このレコードを削除してもよろしいですか？",
+    deleted: "レコードを削除しました",
     editRecord: "レコードを編集",
     viewAll: "すべて表示",
     new: "新規",
+    add: "追加",
     emptyValue: "—",
     activity: "アクティビティ",
     editRow: "編集",
@@ -918,8 +929,10 @@ const ja = {
     concurrentUpdateReload: "最新を読み込む",
     concurrentUpdateOverwrite: "上書きする",
     concurrentUpdateCancel: "キャンセル",
+    concurrentUpdateRecordLabel: "このレコード",
     openInNewTab: "新しいタブで開く",
     history: "履歴",
+    historyEmpty: "履歴はまだありません",
     deleteRowTitle: "レコードを削除",
     createdBy: "作成者",
     updatedBy: "更新者",
@@ -1007,6 +1020,7 @@ const ja = {
   },
   dashboard: {
     noRows: "行がありません",
+    loading: "読み込み中…",
     pickMeasures: "このデータセットウィジェットの指標（値）を選択してください。",
     datasetUnsupported: "このデータソースはデータセットクエリに対応していません。",
     details: "詳細",
@@ -2151,6 +2165,7 @@ const ja = {
     invite: "メンバーを招待",
     members: "メンバー",
     settings: "ワークスペース設定",
+    multiOrgDisabled: "このインスタンスでは新しい組織の作成が無効です。",
   },
   help: {
     onThisPage: "このページの内容",
@@ -2307,6 +2322,9 @@ const ja = {
       roles: "ロール",
       configuration: "構成",
       createApp: "アプリを作成",
+      administration: "管理",
+      datasources: "データソース",
+      documentation: "ドキュメント",
     },
     appSwitcher: {
       switchApplication: "アプリケーションを切り替え",
@@ -2365,6 +2383,7 @@ const ja = {
   empty: {
     objectNotFound: "オブジェクトが見つかりません",
     objectNotFoundDescription: "オブジェクト「{{name}}」の定義が見つかりません。設定を確認するか、有効なオブジェクトを選択してください。",
+    interfacePageSourceMissing: "このインターフェースページは「{{name}}」を参照していますが、利用できません。",
     pageNotFound: "ページが見つかりません",
     pageNotFoundDescription: "ページ「{{name}}」が見つかりません。削除または名前変更された可能性があります。",
     dashboardNotFound: "ダッシュボードが見つかりません",
@@ -2373,6 +2392,8 @@ const ja = {
     reportNotFoundDescription: "レポート「{{name}}」が見つかりません。削除または名前変更された可能性があります。",
     noAppsConfigured: "アプリが設定されていません",
     noAppsConfiguredDescription: "登録されているアプリケーションがありません。最初のアプリを作成するか、システム設定を参照してください。",
+    appNotAvailable: "アプリを利用できません",
+    appNotAvailableDescription: "このアプリはまだ利用できません — まだ公開処理中の可能性があります。しばらくしてからもう一度お試しください。",
     createFirstApp: "最初のアプリを作成",
     systemSettings: "システム設定",
     back: "戻る",
@@ -2655,6 +2676,13 @@ const ja = {
       sentDescription: "以下のリンクを招待相手に共有してください。承諾にはサインインが必要です。",
       linkLabel: "承諾リンク",
       invitedAs: "{{email}} を {{role}} として招待しました",
+      status: {
+        all: "すべて",
+        pending: "待機中",
+        accepted: "承諾済み",
+        rejected: "辞退済み",
+        canceled: "取消済み",
+      },
     },
     settings: {
       generalTitle: "一般",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -105,6 +105,10 @@ const ko = {
     itemCountOne: "{{count}}개 항목",
     toggleSidebar: "사이드바 전환",
     package: "패키지",
+    done: "완료",
+    editInStudio: "Studio에서 편집",
+    record: "레코드",
+    retry: "다시 시도",
   },
   actions: {
     decisionOutput: {
@@ -598,6 +602,7 @@ const ko = {
   },
   kanban: {
     uncategorized: "미분류",
+    columns: "열",
     addCard: "카드 추가",
     addColumn: "열 추가",
     moveCard: "카드 이동",
@@ -662,6 +667,10 @@ const ko = {
       ss: "시작 → 시작",
       ff: "종료 → 종료",
       sf: "시작 → 종료",
+    },
+    linkEnd: {
+      start: "시작",
+      end: "종료",
     },
     conflict: {
       title: "일정 충돌",
@@ -798,9 +807,11 @@ const ko = {
     copyToClipboard: "클립보드에 복사",
     copied: "복사됨!",
     deleteConfirmation: "이 레코드를 삭제하시겠습니까?",
+    deleted: "레코드가 삭제됨",
     editRecord: "레코드 편집",
     viewAll: "모두 보기",
     new: "새로 만들기",
+    add: "추가",
     emptyValue: "—",
     comments: "댓글",
     searchComments: "댓글 검색…",
@@ -907,9 +918,11 @@ const ko = {
     concurrentUpdateReload: "현재 버전 로드",
     concurrentUpdateOverwrite: "그래도 덮어쓰기",
     concurrentUpdateCancel: "취소",
+    concurrentUpdateRecordLabel: "이 레코드",
     openInNewTab: "새 탭에서 열기",
     activity: "활동",
     history: "기록",
+    historyEmpty: "아직 기록이 없습니다",
     editRow: "편집",
     deleteRow: "삭제",
     deleteRowConfirmation: "이 레코드를 삭제하시겠습니까?",
@@ -1007,6 +1020,7 @@ const ko = {
   },
   dashboard: {
     noRows: "행 없음",
+    loading: "로딩 중…",
     pickMeasures: "이 데이터셋 위젯의 측정값(값)을 선택하세요.",
     datasetUnsupported: "이 데이터 소스는 데이터셋 쿼리를 지원하지 않습니다.",
     details: "세부 정보",
@@ -2151,6 +2165,7 @@ const ko = {
     invite: "구성원 초대",
     members: "구성원",
     settings: "워크스페이스 설정",
+    multiOrgDisabled: "이 인스턴스에서는 새 조직을 만들 수 없습니다.",
   },
   help: {
     onThisPage: "이 페이지에서",
@@ -2306,6 +2321,9 @@ const ko = {
       roles: "역할",
       configuration: "구성",
       createApp: "앱 만들기",
+      administration: "관리",
+      datasources: "데이터 소스",
+      documentation: "문서",
     },
     appSwitcher: {
       switchApplication: "애플리케이션 전환",
@@ -2364,6 +2382,7 @@ const ko = {
   empty: {
     objectNotFound: "오브젝트를 찾을 수 없습니다",
     objectNotFoundDescription: "\"{{name}}\" 오브젝트 정의가 없습니다. 구성을 확인하거나 뒤로 이동하세요.",
+    interfacePageSourceMissing: "이 인터페이스 페이지는 \"{{name}}\"을(를) 참조하지만 사용할 수 없습니다.",
     pageNotFound: "페이지를 찾을 수 없습니다",
     pageNotFoundDescription: "\"{{name}}\" 페이지를 찾을 수 없습니다. 삭제되거나 이름이 변경되었을 수 있습니다.",
     dashboardNotFound: "대시보드를 찾을 수 없습니다",
@@ -2372,6 +2391,8 @@ const ko = {
     reportNotFoundDescription: "\"{{name}}\" 보고서를 찾을 수 없습니다. 삭제되거나 이름이 변경되었을 수 있습니다.",
     noAppsConfigured: "구성된 앱 없음",
     noAppsConfiguredDescription: "등록된 앱이 없습니다. 첫 번째 앱을 만들거나 시스템 설정을 방문하세요.",
+    appNotAvailable: "앱을 사용할 수 없습니다",
+    appNotAvailableDescription: "이 앱을 아직 사용할 수 없습니다 — 아직 게시 중일 수 있습니다. 잠시 후 다시 시도하세요.",
     createFirstApp: "첫 번째 앱 만들기",
     systemSettings: "시스템 설정",
     back: "뒤로",
@@ -2654,6 +2675,13 @@ const ko = {
       sentDescription: "아래 링크를 초대 대상자와 공유하세요. 수락하려면 로그인해야 합니다.",
       linkLabel: "수락 링크",
       invitedAs: "{{email}}을(를) {{role}}(으)로 초대함",
+      status: {
+        all: "전체",
+        pending: "대기 중",
+        accepted: "수락됨",
+        rejected: "거절됨",
+        canceled: "취소됨",
+      },
     },
     settings: {
       generalTitle: "일반",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -104,6 +104,10 @@ const pt = {
     itemCountOne: "{{count}} item",
     toggleSidebar: "Alternar barra lateral",
     package: "Pacote",
+    done: "Concluído",
+    editInStudio: "Editar no Studio",
+    record: "Registro",
+    retry: "Tentar novamente",
   },
   actions: {
     decisionOutput: {
@@ -597,6 +601,7 @@ const pt = {
   },
   kanban: {
     uncategorized: "Sem categoria",
+    columns: "colunas",
     addCard: "Adicionar cartão",
     addColumn: "Adicionar coluna",
     moveCard: "Mover cartão",
@@ -661,6 +666,10 @@ const pt = {
       ss: "Início → Início",
       ff: "Término → Término",
       sf: "Início → Término",
+    },
+    linkEnd: {
+      start: "Início",
+      end: "Fim",
     },
     conflict: {
       title: "Conflito de agendamento",
@@ -799,9 +808,11 @@ const pt = {
     copyToClipboard: "Copiar para área de transferência",
     copied: "Copiado!",
     deleteConfirmation: "Tem certeza de que deseja excluir este registro?",
+    deleted: "Registro excluído",
     editRecord: "Editar registro",
     viewAll: "Ver tudo",
     new: "Novo",
+    add: "Adicionar",
     emptyValue: "—",
     comments: "Comentários",
     searchComments: "Pesquisar comentários…",
@@ -908,9 +919,11 @@ const pt = {
     concurrentUpdateReload: "Carregar versão atual",
     concurrentUpdateOverwrite: "Sobrescrever mesmo assim",
     concurrentUpdateCancel: "Cancelar",
+    concurrentUpdateRecordLabel: "este registro",
     openInNewTab: "Abrir em nova aba",
     activity: "Atividade",
     history: "Histórico",
+    historyEmpty: "Nenhum histórico ainda",
     editRow: "Editar",
     deleteRow: "Excluir",
     deleteRowConfirmation: "Excluir este registro?",
@@ -1006,6 +1019,7 @@ const pt = {
   },
   dashboard: {
     noRows: "Sem linhas",
+    loading: "Carregando…",
     pickMeasures: "Escolha medidas (valores) para este widget de dataset.",
     datasetUnsupported: "Esta fonte de dados não oferece suporte a consultas de dataset.",
     details: "Detalhes",
@@ -2150,6 +2164,7 @@ const pt = {
     invite: "Convidar membro",
     members: "Membros",
     settings: "Configurações do espaço de trabalho",
+    multiOrgDisabled: "A criação de novas organizações está desativada nesta instância.",
   },
   help: {
     onThisPage: "Nesta página",
@@ -2306,6 +2321,9 @@ const pt = {
       roles: "Perfis",
       configuration: "Configuração",
       createApp: "Criar aplicativo",
+      administration: "Administração",
+      datasources: "Fontes de dados",
+      documentation: "Documentação",
     },
     appSwitcher: {
       switchApplication: "Trocar de aplicativo",
@@ -2364,6 +2382,7 @@ const pt = {
   empty: {
     objectNotFound: "Objeto não encontrado",
     objectNotFoundDescription: "A definição do objeto \"{{name}}\" está ausente. Verifique sua configuração ou navegue de volta.",
+    interfacePageSourceMissing: "Esta página de interface faz referência a \"{{name}}\", que não está disponível.",
     pageNotFound: "Página não encontrada",
     pageNotFoundDescription: "A página \"{{name}}\" não foi encontrada. Ela pode ter sido removida ou renomeada.",
     dashboardNotFound: "Painel não encontrado",
@@ -2372,6 +2391,8 @@ const pt = {
     reportNotFoundDescription: "O relatório \"{{name}}\" não foi encontrado. Ele pode ter sido removido ou renomeado.",
     noAppsConfigured: "Nenhum aplicativo configurado",
     noAppsConfiguredDescription: "Nenhum aplicativo está registrado. Crie seu primeiro aplicativo ou visite as configurações do sistema.",
+    appNotAvailable: "Aplicativo indisponível",
+    appNotAvailableDescription: "Este aplicativo ainda não está disponível — a publicação pode estar em andamento. Tente novamente em instantes.",
     createFirstApp: "Criar primeiro aplicativo",
     systemSettings: "Configurações do sistema",
     back: "Voltar",
@@ -2654,6 +2675,13 @@ const pt = {
       sentDescription: "Compartilhe o link abaixo com a pessoa convidada. Ela precisará entrar para aceitar.",
       linkLabel: "Link de aceitação",
       invitedAs: "{{email}} convidado como {{role}}",
+      status: {
+        all: "Todos",
+        pending: "Pendente",
+        accepted: "Aceito",
+        rejected: "Recusado",
+        canceled: "Cancelado",
+      },
     },
     settings: {
       generalTitle: "Geral",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -111,6 +111,10 @@ const ru = {
     itemCountOne: "{{count}} элемент",
     toggleSidebar: "Переключить боковую панель",
     package: "Пакет",
+    done: "Готово",
+    editInStudio: "Редактировать в Studio",
+    record: "Запись",
+    retry: "Повторить",
   },
   actions: {
     decisionOutput: {
@@ -604,6 +608,7 @@ const ru = {
   },
   kanban: {
     uncategorized: "Без категории",
+    columns: "колонок",
     addCard: "Добавить карточку",
     addColumn: "Добавить колонку",
     moveCard: "Переместить карточку",
@@ -668,6 +673,10 @@ const ru = {
       ss: "Начало → Начало",
       ff: "Окончание → Окончание",
       sf: "Начало → Окончание",
+    },
+    linkEnd: {
+      start: "Начало",
+      end: "Конец",
     },
     conflict: {
       title: "Конфликт расписания",
@@ -806,9 +815,11 @@ const ru = {
     copyToClipboard: "Копировать в буфер обмена",
     copied: "Скопировано!",
     deleteConfirmation: "Вы уверены, что хотите удалить эту запись?",
+    deleted: "Запись удалена",
     editRecord: "Редактировать запись",
     viewAll: "Показать все",
     new: "Создать",
+    add: "Добавить",
     emptyValue: "—",
     activity: "Активность",
     editRow: "Редактировать",
@@ -926,8 +937,10 @@ const ru = {
     concurrentUpdateReload: "Загрузить текущую версию",
     concurrentUpdateOverwrite: "Всё равно перезаписать",
     concurrentUpdateCancel: "Отмена",
+    concurrentUpdateRecordLabel: "этой записи",
     openInNewTab: "Открыть в новой вкладке",
     history: "История",
+    historyEmpty: "Истории пока нет",
     deleteRowTitle: "Удалить запись",
     createdBy: "Создано",
     updatedBy: "Обновлено",
@@ -1013,6 +1026,7 @@ const ru = {
   },
   dashboard: {
     noRows: "Нет строк",
+    loading: "Загрузка…",
     pickMeasures: "Выберите меры (значения) для этого виджета набора данных.",
     datasetUnsupported: "Этот источник данных не поддерживает запросы к наборам данных.",
     details: "Подробности",
@@ -2157,6 +2171,7 @@ const ru = {
     invite: "Пригласить участника",
     members: "Участники",
     settings: "Настройки рабочего пространства",
+    multiOrgDisabled: "Создание новых организаций отключено в этой среде.",
   },
   help: {
     onThisPage: "На этой странице",
@@ -2314,6 +2329,9 @@ const ru = {
       roles: "Роли",
       configuration: "Конфигурация",
       createApp: "Создать приложение",
+      administration: "Администрирование",
+      datasources: "Источники данных",
+      documentation: "Документация",
     },
     appSwitcher: {
       switchApplication: "Сменить приложение",
@@ -2372,6 +2390,7 @@ const ru = {
   empty: {
     objectNotFound: "Объект не найден",
     objectNotFoundDescription: "Определение объекта \"{{name}}\" отсутствует. Проверьте конфигурацию или вернитесь назад.",
+    interfacePageSourceMissing: "Эта интерфейсная страница ссылается на \"{{name}}\", который недоступен.",
     pageNotFound: "Страница не найдена",
     pageNotFoundDescription: "Страница \"{{name}}\" не найдена. Возможно, она была удалена или переименована.",
     dashboardNotFound: "Панель не найдена",
@@ -2380,6 +2399,8 @@ const ru = {
     reportNotFoundDescription: "Отчёт \"{{name}}\" не найден. Возможно, он был удалён или переименован.",
     noAppsConfigured: "Нет приложений",
     noAppsConfiguredDescription: "Нет зарегистрированных приложений. Создайте первое приложение или посетите системные настройки.",
+    appNotAvailable: "Приложение недоступно",
+    appNotAvailableDescription: "Это приложение пока недоступно — возможно, публикация ещё идёт. Повторите попытку через мгновение.",
     createFirstApp: "Создать приложение",
     systemSettings: "Системные настройки",
     back: "Назад",
@@ -2662,6 +2683,13 @@ const ru = {
       sentDescription: "Отправьте ссылку ниже приглашённому. Чтобы принять приглашение, ему нужно войти в систему.",
       linkLabel: "Ссылка для принятия",
       invitedAs: "{{email}} приглашён как {{role}}",
+      status: {
+        all: "Все",
+        pending: "Ожидает",
+        accepted: "Принято",
+        rejected: "Отклонено",
+        canceled: "Отменено",
+      },
     },
     settings: {
       generalTitle: "Общие",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -112,6 +112,10 @@ const zh = {
     itemCountOne: '{{count}} 项',
     toggleSidebar: '切换侧边栏',
     package: '软件包',
+    done: '完成',
+    editInStudio: '在 Studio 中编辑',
+    record: '记录',
+    retry: '重试',
   },
   actions: {
     decisionOutput: {
@@ -626,6 +630,7 @@ const zh = {
     noCards: '暂无卡片',
     cardTitlePlaceholder: '输入卡片标题...',
     uncategorized: '未分类',
+    columns: '列',
   },
   timeline: {
     bucket: {
@@ -711,6 +716,10 @@ const zh = {
       ss: '开始 → 开始',
       ff: '完成 → 完成',
       sf: '开始 → 完成',
+    },
+    linkEnd: {
+      start: '开始',
+      end: '结束',
     },
     conflict: {
       title: '排程冲突',
@@ -818,6 +827,7 @@ const zh = {
     concurrentUpdateReload: '加载最新',
     concurrentUpdateOverwrite: '仍然覆盖',
     concurrentUpdateCancel: '取消',
+    concurrentUpdateRecordLabel: '此记录',
     openInNewTab: '在新标签页打开',
     share: '分享',
     duplicate: '复制',
@@ -851,12 +861,15 @@ const zh = {
     copyToClipboard: '复制到剪贴板',
     copied: '已复制！',
     deleteConfirmation: '确定要删除此记录吗？',
+    deleted: '记录已删除',
     editRecord: '编辑记录',
     viewAll: '查看全部',
     new: '新建',
+    add: '添加',
     emptyValue: '—',
     activity: '活动',
     history: '历史',
+    historyEmpty: '暂无历史记录',
     editRow: '编辑',
     deleteRow: '删除',
     deleteRowConfirmation: '确定要删除此记录吗？',
@@ -1181,6 +1194,7 @@ const zh = {
     noDataAvailable: '暂无数据',
     noDataSourceFor: '没有可用的数据源：',
     noRows: '暂无数据行',
+    loading: '加载中…',
     pickMeasures: '请为该数据集组件选择度量（值）。',
     datasetUnsupported: '当前数据源不支持数据集查询。',
     details: '明细',
@@ -2329,6 +2343,7 @@ const zh = {
     invite: '邀请成员',
     members: '成员',
     settings: '工作区设置',
+    multiOrgDisabled: '此实例已禁用创建新组织。',
   },
   help: {
     keyboardShortcuts: '键盘快捷键',
@@ -2496,6 +2511,9 @@ const zh = {
       roles: '角色',
       configuration: '配置',
       createApp: '创建应用',
+      administration: '管理',
+      datasources: '数据源',
+      documentation: '文档',
     },
     activityFeed: {
       title: '最近动态',
@@ -2543,6 +2561,7 @@ const zh = {
   empty: {
     objectNotFound: '未找到对象',
     objectNotFoundDescription: '对象 “{{name}}” 的定义不存在。请检查配置或返回选择有效的对象。',
+    interfacePageSourceMissing: '此界面页引用了 “{{name}}”，但该来源不可用。',
     recordNotFound: '未找到记录',
     recordNotFoundDescription: '您查找的记录不存在或已被删除。',
     pageNotFound: '未找到页面',
@@ -2553,6 +2572,8 @@ const zh = {
     reportNotFoundDescription: '未找到报表 “{{name}}”，可能已被删除或重命名。',
     noAppsConfigured: '尚未配置应用',
     noAppsConfiguredDescription: '当前没有任何已注册的应用。请创建您的第一个应用，或前往系统设置进行配置。',
+    appNotAvailable: '应用不可用',
+    appNotAvailableDescription: '此应用尚不可用 —— 可能仍在发布中。请稍后重试。',
     createFirstApp: '创建您的第一个应用',
     systemSettings: '系统设置',
     back: '返回',
@@ -2768,6 +2789,13 @@ const zh = {
       sentDescription: '请将下方链接发送给受邀人。对方需要登录后才能接受。',
       linkLabel: '接受链接',
       invitedAs: '{{email}} 已以 {{role}} 身份受邀',
+      status: {
+        all: '全部',
+        pending: '等待中',
+        accepted: '已接受',
+        rejected: '已拒绝',
+        canceled: '已取消',
+      },
     },
     settings: {
       generalTitle: '常规',

--- a/scripts/i18n-call-site-key-baseline.json
+++ b/scripts/i18n-call-site-key-baseline.json
@@ -6,32 +6,15 @@
     "Fix one by adding the key to packages/i18n/src/locales/en.ts and deleting its line",
     "here; all-locales-key-parity.test.ts then demands the same key in the other nine",
     "packs. Adding an inline defaultValue is NOT a fix -- that is the mechanism that hid",
-    "these for months (objectui#3517)."
+    "these for months (objectui#3517).",
+    "BOTH LISTS ARE NOW EMPTY -- the 258-key stock objectui#3546 opened with was paid off",
+    "across seven slices, the last of them the two template families below. Keep the file:",
+    "empty is its terminal, load-bearing state. Any NEW unresolved call-site key is",
+    "`unexpected` against an empty baseline and fails the build, which is the point."
   ],
 
-  "missingKeys": {
-    "common.done": { "issue": "objectui#3546" },
-    "common.editInStudio": { "issue": "objectui#3546" },
-    "common.record": { "issue": "objectui#3546" },
-    "common.retry": { "issue": "objectui#3546" },
-    "dashboard.loading": { "issue": "objectui#3546" },
-    "detail.add": { "issue": "objectui#3546" },
-    "detail.concurrentUpdateRecordLabel": { "issue": "objectui#3546" },
-    "detail.deleted": { "issue": "objectui#3546" },
-    "detail.historyEmpty": { "issue": "objectui#3546" },
-    "empty.appNotAvailable": { "issue": "objectui#3546" },
-    "empty.appNotAvailableDescription": { "issue": "objectui#3546" },
-    "empty.interfacePageSourceMissing": { "issue": "objectui#3546" },
-    "kanban.columns": { "issue": "objectui#3546" },
-    "layout.systemNav.administration": { "issue": "objectui#3546" },
-    "layout.systemNav.datasources": { "issue": "objectui#3546" },
-    "layout.systemNav.documentation": { "issue": "objectui#3546" },
-    "workspace.multiOrgDisabled": { "issue": "objectui#3546" }
-  },
+  "missingKeys": {},
 
   "//": "Template keys whose static head matches no en key at all, so every expansion misses.",
-  "missingPrefixes": {
-    "gantt.linkEnd.": { "issue": "objectui#3546" },
-    "organization.invitations.status.": { "issue": "objectui#3546" }
-  }
+  "missingPrefixes": {}
 }


### PR DESCRIPTION
`Fixes-part-of: #3546` — 切片七,终章。**本单不写 `Fixes`**:棘轮虽已清零,关单由 PM 核验后执行。

分支自 `origin/main@39136cccb69cd33482fe6886e7142def87e4493c` 显式 sha 切出(先 `git fetch origin main`,不用 `FETCH_HEAD`)。该 sha 含切片六合并点 `e64a52ec3`,已用 `git merge-base --is-ancestor` 实测确认。

## 分母:脚本实测,不手数

`node scripts/check-i18n-call-site-keys.mjs`(#3530 的守卫)的 `analyze()` 实测:

| 项 | 实测 |
|---|---|
| 不重复缺失 key | **17** |
| 对应调用点 | **23** —— 本系列第一次两数明显不等 |
| 多站点 key | **5**:`common.retry` 3 处;`common.record` / `common.editInStudio` / `detail.add` / `layout.systemNav.datasources` 各 2 处 |
| 属本切片的 `missing-prefix` | **2 个家族 / 3 个调用点**(`gantt.linkEnd.` 1、`organization.invitations.status.` 2) |
| 棘轮内条目 | **19**(17 key + 2 prefix),与实测清单双向精确相等,无差集 |
| en 新增 key 路径 | **24**(17 叶子 + 2 + 5 家族成员) |

```
--- multi-site keys ---
common.record                    AppContent.tsx:417:71, AppContent.tsx:446:73
common.retry                     AppContent.tsx:573:16, InvitationsPage.tsx:135:12, MembersPage.tsx:119:12
common.editInStudio              PageView.tsx:108:22, PageView.tsx:109:27
detail.add                       RelatedList.tsx:1130:31, RelatedList.tsx:1300:31
layout.systemNav.datasources     AppSidebar.tsx:354:39, UnifiedSidebar.tsx:352:41
--- ratchet vs measured ---
ratchet keys: 17   measured: 17
in ratchet not measured: []
measured not in ratchet: []
ratchet prefixes: ["gantt.linkEnd.","organization.invitations.status."]
measured prefixes: ["gantt.linkEnd.","organization.invitations.status."]
prefix sets equal: true
```

切片二"预测 90 实为 93"的教训在这里派上了用场:如果按棘轮的 17 行去数调用点,会漏掉 6 处。

守卫读数,前后对照(同一命令):

```
前: 2372 pack-backed (2297/2320 literal keys resolve) … en pack (2894 keys)
后: 2372 pack-backed (2320/2320 literal keys resolve) … en pack (2918 keys)
Every in-scope call-site key resolves against the en pack (2918 keys).   GUARD EXIT=0
```

**2320/2320** —— 整个调用点面第一次全解析。解析数 +23(= 23 个调用点)、en key 数 +24,与清单精确相等。棘轮 ASSERT:

```
before: 17 after: 0 removed: 17
ASSERT removed===17 -> true
ASSERT missingKeys empty -> true {}
ASSERT missingPrefixes 2->0 -> true ["gantt.linkEnd.","organization.invitations.status."] => []
ASSERT file still valid JSON -> true (parsed)
remaining by namespace: {}
```

棘轮按**行删除**而非重序列化(切片四量过:重序列化会把 diff 变成全文件重排)。最终 diff `7 insertions(+), 24 deletions(-)`:删掉 19 个条目行,两个空对象各收成一行,并在 `note` 里加四行说明 —— **文件保留而不删除,空是它的终态且承重**:对空基线来说任何新增未解析 key 都算 `unexpected` 并使构建失败。

## 严重度:全部"英文可见、十语不可译",且英文兜底有三种形态

正文点名的 8 处裸 key 站点是切片一(PR #3583)的;`detail.viewSource`(en.ts:994)、`wizard.missingRequired`、`gantt.toolbar.refresh` 三个 key 从那时起就已在 en 解析 —— **本切片派发说明里"高严重度残余"那一段的前提已过期**,实测本切片零裸 key 站点。

但英文兜底不是一种形态,而是三种,所以逐字节比对拆成三块:

1. **22 站点 / 16 key** 写 `t(key, { defaultValue: 'English' })`。
2. **1 站点** `dashboard.loading` 用 `useSafeTranslate` 的**位置参数**形式 `tt(key, 'Loading…')` —— 只 grep `defaultValue:` 的普查会把这处判成"没有兜底"并且判错。
3. **两个家族的默认值根本不是字面量**:`organization.invitations.status.` 传 `{ defaultValue: tab }`(枚举成员本身,由元素的 CSS `capitalize` 首字母大写);`gantt.linkEnd.` **不传默认值**,靠 `useGanttTranslation` 的**逐 key** 兜底表(表里两个成员都有)。

`zh` 会话下用户实际看到的英文:app 还在发布时落地的 **App not available** 空态(整句说明 + Retry 按钮)、界面页"来源不可用"、系统导航的 **Administration** 分组头与 **Datasources** / **Documentation** 两项、工作区对话框"本实例已禁用创建新组织"、邀请列表五个状态标签(筛选页签 + 每行徽章)、甘特依赖拖拽提示里指出落点端的 `start` / `end`、记录详情的 Add / Record deleted / No history yet 与并发更新对话框的 "this record"、看板空板的列计数、仪表板部件的读屏 Loading…、页面编辑器 "Edit in studio" 的 title 与 aria-label。

## en ↔ 内联英文默认值:16 逐字节 + 1 位置参数 + 7 等价关系

```
slice call sites: 23  (literal defaultValue: 22, positional fallback: 1, none: 0)
en value === inline defaultValue: 16/16   (per key; 5 keys have 2-3 sites, all spelling the same default)
```

多站点 key 的**每一处**拼写都断言了(`PageView` 同一个按钮的 title + aria-label 两处、`RelatedList` 两个入口、`AppContent` 两处 —— 计数各钉 2),否则一个 key 两种默认值会让"逐字节相同"在一处成立、在另一处不成立而无人察觉。

第 2 形态(`dashboard.loading`)取的等价关系相同 —— 包值 === 该站点原本会渲染的 fallback —— 并额外断言 `useSafeTranslate` 确实是 `t(keyOrKeys, fallback)` 且逐 key 判定。顺带说明:`common.loading` 是更老的 `'Loading...'`(三个 ASCII 句点)拼写,是**不同的字符串**,所以刻意不复用(字形分歧另立 #3878)。

第 3 形态的两组等价关系见下。

## 两个前缀家族:封闭枚举,不通配

### `gantt.linkEnd.` —— 取值域是同文件的封闭联合

```
packages/plugin-gantt/src/GanttView.tsx:1369/1373   sourceEnd: 'start' | 'end';  targetEnd: 'start' | 'end' | null;
packages/plugin-gantt/src/GanttView.tsx:4577        const endLabel = (e: 'start' | 'end') => t(`gantt.linkEnd.${e}`);
```

与切片四的 `console.ai.group.` 同类(权威在同一文件),不同于切片五的 `marketplace.disclosure.runtime.`(权威在姐妹仓 `packages/spec`)。`targetEnd` 可为 null,调用点用 `?? 'start'` 收敛,所以调用点上的取值域也确实是两个。

**"key 可达性 vs 值判定"分开断言**(切片五写下的判据):

- **key 面**:`en` 的 `gantt.linkEnd` 子对象键集合 === `['start','end']`,十包同集合。第三种端点一旦加入,这条红 —— 正是棘轮里那条 prefix 条目原本的职责,从棘轮搬进测试。
- **值面**:两个 `en` 值与 `useGanttTranslation` 的兜底表**逐字节相同**(`'gantt.linkEnd.start': 'start'`),并断言该 hook 仍是 host-first / 逐 key 的形态。这两条一起才说明"包在时 i18next 答、包不在时兜底表答,用户不能分辨跑的是哪条"。

### `organization.invitations.status.` —— 取值域是同文件的 `StatusFilter`

```
packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx:30
  type StatusFilter = 'all' | 'pending' | 'accepted' | 'rejected' | 'canceled';
:161  t(`organization.invitations.status.${tab}`, { defaultValue: tab })          ← 筛选页签
:206  t(`organization.invitations.status.${inv.status}`, { defaultValue: inv.status })  ← 每行徽章
```

`all` 只出现在页签,其余四个也是 `AuthInvitation.status` 的取值。逐字节比对结构上不可能(默认值是变量),取的等价关系是:**两个元素都带 CSS `capitalize`,所以用户看到的是 `Pending` 而不是 `pending`,于是 `en` 值必须恰好等于首字母大写后的枚举成员**。差一个字母,本切片就改动了用户今天看到的英文。`capitalize` 类名与五成员联合都作为前提断言了;并且断言五个成员都是单词(CSS `capitalize` 会把**每个**词首字母大写,将来出现两词状态时这个模型不再成立,那条断言就是必须回头看的地方)。

⚠️ 该家族的宽松处**没有**在本 PR 修,已立 **#3879**:`packages/auth/src/types.ts:404` 把 `status` 声明成开放 `string`,枚举只写在文档注释里,由此长出 `statusBadgeVariant` 的 `default:` 兜底与 `defaultValue: inv.status`(未知状态把 wire 原值当界面文案渲染进徽章)。与 #3846 同类。

## 九包实译:逐包邻键取证

| 包 | 邻键证据(实测,非印象) | 本切片落值举例 |
|---|---|---|
| zh | `home.welcomeAdminDescriptionNoAi` 逐包点名这个菜单(zh 写「管理」菜单);`empty.objectNotFoundDescription` 用全角引号 `“{{name}}”`;本包 `——` 45 处对单 `—` 25 处;`detail.deleteConfirmation` 用「此记录」 | `管理`、`此界面页引用了 “{{name}}”，但该来源不可用。`、`此应用尚不可用 —— 可能仍在发布中。请稍后重试。`、`此记录` |
| ja | `help.onlineDocs` = `オンラインドキュメント`;`empty.objectNotFoundDescription` 用 `「{{name}}」`;`organization.settings.deleted` = `組織を削除しました`;`kanban.addColumn` = `カラムを追加`(**不是** `table.columns` 的 `列`) | `ドキュメント`、`「{{name}}」を参照していますが`、`レコードを削除しました`、`カラム` |
| ko | `detail.history` = `기록`(不是 히스토리)、`detail.noCommentsYet` = `아직 댓글이 없습니다`;全包 0 处全角冒号;`preview.history.items` 舍量词只留单位词 | `아직 기록이 없습니다`、`열`、`Studio에서 편집` |
| de | `home.welcomeAdminDescriptionNoAi` 说 `Verwaltungsmenü`;`gantt.readOnlyHint` = `Die Bearbeitung ist in dieser Ansicht deaktiviert.`;`gantt.linkType.fs` 用 `Anfang`(而 `gantt.column.start` 是 `Start`);`concurrentUpdateDescription` 的洞在 `von` 之后 → 第三格 | `Verwaltung`、`… ist auf dieser Instanz deaktiviert.`、`Anfang` / `Ende`、`diesem Datensatz` |
| fr | 直角撇号 U+0027(420 : 18);`Invitation acceptée` 阴性 | `n'est pas encore disponible`、`Acceptée` / `Refusée` / `Annulée` / `Toutes` |
| es | 全包 usted 占优,`empty.*` 邻域一致 usted(`Verifique su configuración`);`Invitación aceptada` 阴性 | `Vuelva a intentarlo en un momento.`、`Aceptada` / `Todas` |
| pt | `Convite aceito` **阳性**(与 es/fr 相反) | `Aceito` / `Recusado` / `Cancelado` / `Todos` |
| ru | ё 163 处;`approvalsInbox.recallUnavailable` 把 instance/deployment 译作 `среда`;`версию` 支配第二格;`preview.history.items` = `элементов`(第二格复数) | `публикация ещё идёт`、`в этой среде`、`этой записи`、`колонок` |
| ar | 导航类复数标签带定冠词(`التطبيقات` / `المستخدمون`);`connectAgent.disabled.title` = `MCP معطّل في هذا النشر`;`gantt.linkType.fs` 用无冠词 `نهاية → بداية` | `الوثائق` / `الإدارة` / `مصادر البيانات`、`في هذا النشر`、`بداية` / `نهاية` |

**en 同串且邻键译文在此语法可用时复用既有行**,6 处,双向钉住(先验证两边 en 真的同字符串,再验证十包同值):`common.done` ← `view.done`;`common.record` ← `home.recentApps.itemType.record`;`common.retry` ← `lookup.retry`;`dashboard.loading` ← `lookup.loading`;`detail.add` ← `report.editor.fieldPickerAdd`;`organization.invitations.status.pending` ← `grid.import.jobStatus.pending`。

**四个邀请状态形容词刻意不复用**,理由是语法而非口味:`approvals*` 家族那几行与各包的「请求」一词性数一致,而这里描述的是**邀请**。最清楚的一条是 ru —— `approvalsInbox.statusRejected` 是阳性 `Отклонён`(запрос),而 приглашение 是中性要 `Отклонено`。照搬会落一个"键名 parity 全绿、反抄袭集合也全绿"的语法错误。fr/es 取阴性(invitation / invitación)、pt 取阳性(convite),都从同命名空间的 toast 里取 —— 那是各包已经对性别做过承诺的地方。`all` 也随同一性别(它量化的名词就是"邀请"):fr `Toutes`、es `Todas`、pt `Todos`。`canceled` 是**组织撤回**而非受邀人拒绝,所以 de 取本包 cancel toast 的 `zurückgezogen` 而不是泛用的 `Abgebrochen`。

**按概念找邻键**(切片五的盲区 / 切片六的新规)本切片有六处,每处的前提都与落值并排断言:

- **`Administration`** —— 全切片最强的一条:兄弟键 `home.welcomeAdminDescriptionNoAi` 在一整句里**逐包点名了这个菜单**(zh「管理」菜单 / de Verwaltungsmenü / ru «Администрирование» 菜单)。
- **`Datasources`** —— 单数概念早已译好(`report.editor.objectName`),而兄弟导航项都是复数,故取复数。
- **`Documentation`** —— `help.allDocs` / `help.onlineDocs` 已有。
- **`Record deleted`** —— 结构孪生 `organization.settings.deleted`(「名词 + deleted」成功 toast)。
- **`No history yet`** —— `detail.noCommentsYet` 的"No X yet"家族,加各包自己的 History 词。
- **`kanban.columns`** —— 裸单位词,取 `preview.history.items` 的形状(组件拼数字与空格,包只供单位词),词取 kanban 自己的列词。en 只有复数形也是安全的:空态只在 `boardColumns.length > 1` 时渲染,计数永不为 1,所以**不需要复数族**(这一条前提也断言了,守卫那个 `> 1` 一旦改动,断言先红)。

`detail.concurrentUpdateRecordLabel` 不是独立标签:`ConcurrentUpdateDialog` 把 `detail.concurrentUpdateDescription` 按 `{{field}}` 切开,粗体渲染在缺口里,所以包值要迁就洞前的格位 —— de 第三格(`von` 之后,与兄弟键 `detail.deleteConfirmation` 的第四格不同)、ru 第二格(`версию` 之后)。合成后的整句逐包断言。

⚠️ **pt 是唯一一个合成后不地道且叶子值无法救的包**:葡语 `de + este` 必须缩合成 `deste`,而 `de ` 在外层既有句子里(本切片不改既有值)。已立 **#3877**,并在测试里把当前渲染(`mais recente de este registro`)钉成"当前真相"而不是留给下一个读者当疏漏,那条断言就是该单落地时必须一起改的地方。

## 反抄袭断言:精确集合恰 2 元,三条防空转

实测"与 en 逐字节相同"的 `lang :: key` 对:**2 / 216**。

```
fr :: layout.systemNav.administration     ("Administration")
fr :: layout.systemNav.documentation      ("Documentation")
```

两处都是法语与英语确实同拼的词,且都紧邻 `layout.systemNav.configuration` —— 该键 fr 在本切片之前就是 `Configuration`。第三个同形一旦出现,这条集合相等会红,必须像切片二(12)、三(18)、四(1)那样在同一行上给理由。

集合相等最容易空转(切片二 B1 的教训:包为空时同样绿),所以配三条:

1. **presence**:十包 × 24 路径 = **240** 个值全部是非空字符串(独立一条 `it.each`);
2. **反面对照**:空/小集合也可能因为"译者绕开了所有像英文的词"而成立。这几条证明那两处不是复制粘贴 —— **能译的包都译了**(de `Verwaltung` / ru `Администрирование` / de `Dokumentation` / ar `الوثائق`),且外来词确实在(ja `Studio で編集`、ko `Studio에서 편집`、de `Datenquellen`)并仍不与 en 逐字节相同;
3. **每包一条用户可见面**的具名钉子(见下 provider 抽样)。

另加本切片特有的形状断言:插值**恰 1 个路径**带洞(`empty.interfacePageSourceMissing` 的 `{{name}}`,其余 23 个十包一律不许有洞 —— 与切片六的 11 个正相反);em dash 十包为 `—`、zh 为该包自己的 `——`;引号风格随**同族**的 `empty.objectNotFoundDescription`(zh 全角、ja 角括号、其余 ASCII);fr 直角撇号**全量 24 路径**;ru ё;ar 的"RTL 句首不落拉丁 token"**全量 24 路径**且插值后仍成立。

**de 的引号是一处刻意分歧**:同族既有值把德语开引号 `„` 与 ASCII 直引号 `"` 配成一对(全包实测 **20** 处这样、21 处正确配对),那是笔误而不是约定,所以本切片写正确配对的 `„{{name}}“`,并把错配单独立单 **#3876** 而不是照抄。测试里两条断言并排,一条钉邻键的错配现状、一条钉本切片的正确配对。

## provider-mounted 抽样钉扎(discrimination check)

十六个组件文件的 `t` 绑定**逐个断言**(不是假设):九个是裸 `useObjectTranslation()`;`RecordDetailView` 从 `@object-ui/react` 取(带 `language`);plugin-detail 三个走 `useDetailTranslation`;kanban 走自己的 `createSafeTranslation`(探针键 `kanban.noCards` 在包里,所以挂 provider 时 i18next 胜出,且其 defaults 表**没有** `kanban.columns` —— 那是无 provider 方向的 #3865);dashboard 走 `useSafeTranslate`;gantt 走逐 key 的 `useGanttTranslation`。

- `en` / `zh` 各解析 **9** 个代表 key(每个 owner 一个),断言 `not.toBe(key)` 且等于包内值;
- zh 具名八条(含插值:`此界面页引用了 “crm_lead”，但该来源不可用。`);
- **两个家族按真实模板调用形态**在 en/zh 两路把全部 7 个成员各渲染一遍,并按 GanttView 的拼法合成拖拽提示(`设计评审 (结束) → 上线 (开始)`);
- 另八包各钉一条**用户可见**面,横跨四种书写系统;
- ar 的"RTL 句首不落拉丁 token"全量 24 路径(且插值后仍不以拉丁开头);fr 直角撇号全量 24 路径。

## 反向验证:六处方向**跑前先判**,六处全中(第 6 处是一次误操作变成的额外方向,如实记下)

方向在跑之前就定了。本切片是"包里没有 → 补上",没有被删的死枝、没有计数类下游门禁、没有 canonical-first 的 `??` 链,所以不存在先例里的"诊断变多"或"反转";第 3、4、5、6 条的预判是**守卫绿而别的东西红**,那是 #3530 记录的门禁分工,不是漏检。

1. **只把棘轮 19 行放回**(包保留)→ 守卫报 **19 条 stale**,`GUARD EXIT=1`;六个 3546 家族测试的总数钉全红,含 `organization-` 那条刚反转的 `not.toContain`。
   ```
   19 baseline entries are stale — the defect is gone, so the entry must go too (this file is a ratchet; it only shrinks):
     missingKeys: common.done …(17 条)
     missingPrefixes: gantt.linkEnd.
     missingPrefixes: organization.invitations.status.
   GUARD EXIT=1

   AssertionError: expected 17 to be +0        ×4(auth / console / marketplace-preview / perm-home)
   AssertionError: expected [ 'gantt.linkEnd.', …(1) ] to not include 'organization.invitations.status.'
     ← organization 那条 not.toContain 排在 toBe(0) 之前,所以它先红
   AssertionError: expected [ 'common.done', …(16) ] to deeply equal []
   Test Files  6 failed (6) | Tests  6 failed | 219 passed (225)
   ```
2. **只回退 `en.ts`**(棘轮保持已删)→ 守卫报 **26 条 unexpected / 19 distinct**,`GUARD EXIT=1`,解析数回落 **2320 → 2297**,en key 数 2918 → 2894;parity 报九包各有 24 个 en 没有的 key。26 = 23 个 missing-key 站点 + 3 个 missing-prefix 站点;19 distinct 正是棘轮那 19 行。
   ```
   2372 pack-backed (2297/2320 literal keys resolve)
   26 call sites reference a key the en pack does not define (19 distinct):
     …InvitationsPage.tsx:161:14  [missing-prefix]  organization.invitations.status.
     …GanttView.tsx:4577:60  [missing-prefix]  gantt.linkEnd.
     …KanbanImpl.tsx:673:52  [missing-key]  kanban.columns
   GUARD EXIT=1

   AssertionError: zh has 24 key(s) absent from en …(九包各一条)
   Test Files  2 failed (2)
   ```
3. **只回退 `zh.ts`**(en 保留)→ 守卫**仍然绿**(它只看 en),parity 与本切片测试红,失败文本就是把**藏了这些 key 数月的机制**摆出来 —— zh 缺 key 时 `t()` 返回的是 **en 的值**,不是 key、不报错:
   ```
   守卫: Every in-scope call-site key resolves against the en pack (2918 keys).  GUARD EXIT=0
   AssertionError: zh is missing 24 key(s)
   AssertionError: expected 'Edit in studio' to be '在 Studio 中编辑'        ← 这就是那个机制
   AssertionError: zh gantt.linkEnd.start: expected 'start' to be undefined
   AssertionError: zh common.done diverged from view.done: expected undefined to be '完成'
   Test Files  2 failed (2) | Tests  12 failed | 51 passed (63)
   ```
4. **给 `StatusFilter` 加第六个成员(`'expired'`),不加 key** —— 本切片特有的一条,预判为"**守卫绿**,只有本测试红"。命中,而且这一条是本 PR 最值得记的反向验证:守卫**看不见**它 —— 模板静态头此刻已能匹配(en 里有这个家族),而动态 key 分支是 report-only,所以一个未枚举的成员**一条 finding 也不产生**。棘轮里那条 prefix 条目从来也做不到这件事;只有测试里钉住的联合原文能做到。
   ```
   守卫: Every in-scope call-site key resolves against the en pack (2918 keys).  GUARD EXIT=0
   × the key surface is exactly StatusFilter
   AssertionError: StatusFilter moved: expected '/**\n * InvitationsPage …' to contain "type StatusFilter = 'all' | 'pendi…"
   Test Files  1 failed (1) | Tests  1 failed | 42 passed (43)
   ```
5. **只把邻键 `grid.import.jobStatus.pending` 的 en 值改成小写** —— 这条**是误操作变成的方向**,如实记下:第一次脚本用 `count=1` 替换 `pending: 'Pending',`,而该邻键在 en.ts 里同缩进且行号更小,于是改到了它。结果恰好验证了复用断言是**双向**钉住的 —— 邻键动了,新键没动,一样红:
   ```
   守卫 GUARD EXIT=0    drift RED(en 值变了九包没跟)
   AssertionError: en organization.invitations.status.pending vs grid.import.jobStatus.pending:
                   expected 'Pending' to be 'pending'
   Test Files  1 failed (1) | Tests  1 failed | 42 passed (43)
   ```
6. **把本家族自己的 `en` 值 `Pending` 改成小写 `pending`**(第 5 条原本要做的事,定位到 `status: {` 之后再替换)→ 预判"守卫绿(key 在)、drift 红(en 值变了九包没跟)、本测试的 `capitalize` 等价关系红"。三道门禁三种判决,全中:
   ```
   守卫 GUARD EXIT=0
   drift: en now: "pending"   unchanged in: zh, ja, ko, de, fr, es, pt, ru, ar   DRIFT EXIT=1
   × en renders exactly what the CSS-capitalised wire value rendered
   AssertionError: en status.pending: expected 'pending' to be 'Pending'
   Test Files  1 failed (1) | Tests  2 failed | 41 passed (43)
   ```

六个方向跑完后工作树恢复干净,六个 3546 家族测试重跑 **225 passed (225)**。

## 顺手量出、未在本 PR 修的事

1. **#3876(新立,concrete)** —— de 包 **20** 个值把 `„` 与 ASCII `"` 配成一对(正确配对的 21 个),德语用户看到的收尾引号是错的;`search.resultsCount` 结尾是连着两个直引号。三道 i18n 门禁按设计都看不见(不读引号 / 只判 key 在不在 / 只在 en 值**变化**时触发,而这些值从落地起就错)。
2. **#3877(新立,concrete)** —— pt 的 `detail.concurrentUpdateDescription` 洞前留了裸 `de`,插入名词短语时渲染 `de este registro`(葡语必须缩合成 `deste`);修法在外层句子或调用点,给了两个选项与各自代价。
3. **#3878(新立,`finding`)** —— en 包 **32** 个值以 ASCII `...` 结尾、**113** 个以 `…` 结尾,九包逐值跟随;统一到 `…` 会触发 drift 门禁的 32 × 10 = 320 处机械改动,需独立 PR + 一条门禁。
4. **#3879(新立,`finding`)** —— `AuthInvitation.status` 声明成开放 `string` 而文档注释只枚举四个成员;与 #3846 同类的 contract-first 反面。
5. **#3880(新立,`finding`)** —— "同一 en 字符串必须同一译文"这条落值纪律**不能做成门禁**:281 组共享 en 值里 **164** 组至少有一个包刻意分开译(`Design in Studio` / `Clear` / `Save` / `Delete` / `{{count}} records` 都是正当分歧),硬门禁会产生 164 个假红。顺带点出其中两组像是笔误(es `Done` 的 `Hecho`/`Listo`、de `Loading...` 的 `Laden...`/`Wird geladen...`),两者都属改既有值,与在飞 #3844 / #3875 有相交风险故未动。

## 验证

```
node scripts/check-i18n-call-site-keys.mjs
  → 2372 pack-backed (2320/2320 literal keys resolve)
    Every in-scope call-site key resolves against the en pack (2918 keys).      EXIT=0
node scripts/check-i18n-en-drift.mjs
  → 0 en value(s) changed (24 key(s) added, 0 removed) — No en value changed in this range.   EXIT=0
node scripts/check-control-bytes.mjs
  → OK (scanned 3777 tracked text file(s); skipped 85 binary)                   EXIT=0
node scripts/check-changeset-presence.mjs
  → 15 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)   EXIT=0
grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]' 全部 18 个改动/新增文件                 → 零命中(gate 之外的自扫)
git log --format=%B origin/main..HEAD | grep -ci fable                          → 0
  (另查 co-authored-by / claude-session / opus / sonnet / haiku                  → 0)

flock -w 7200 /tmp/os-heavy-verify.lock -c 'NODE_OPTIONS=--max-old-space-size=4096 \
  pnpm exec vitest run packages/i18n \
  scripts/__tests__/check-i18n-call-site-keys.test.ts \
  scripts/__tests__/check-i18n-en-drift.test.ts --maxWorkers=2'
  → Test Files 33 passed (33) | Tests 628 passed (628)      (585 → 628,新增 43 条)

# 消费半径扫尾:本切片零组件改动,但这些包是语言包的消费方(按规则的消费半径扫,
# 不按被编辑的包扫 —— 本切片跨 app-shell / plugin-detail / plugin-dashboard /
# plugin-kanban / plugin-gantt 五个包的调用点)
flock … 'pnpm exec vitest run packages/plugin-kanban packages/plugin-dashboard \
  packages/plugin-gantt packages/app-shell/src/layout \
  packages/app-shell/src/console/organizations packages/app-shell/src/preview --maxWorkers=2'
  → Test Files 100 passed (100) | Tests 763 passed (763)

pnpm --workspace-concurrency=2 --filter @object-ui/i18n type-check   → tsc --noEmit 通过
pnpm exec turbo run type-check --concurrency=2                       → 78 successful, 78 total
                                                                       (CI 同命令,末次编辑后全仓)
npx eslint 本 PR 改动的 16 个 i18n 文件                              → 0 problems
```

`all-locales-key-parity.test.ts` 含在上面 33 个文件内,已绿(它是补完 en 后立刻要求九包补齐的那道门禁)。`scripts/__tests__/check-i18n-call-site-keys.test.ts` 的 `applyBaseline` 断言对**空**基线同样成立(`unexpected` 与 `stale` 都是空数组),不需要改。`@object-ui/i18n` 无工作区内依赖,自身不需要先建依赖;`@object-ui/react` 的 `TranslationKeys = typeof en` 只是转出口,加 key 不窄化任何消费方 —— 全仓 turbo type-check 已实跑覆盖。

测试命令按 AGENTS.md §9 的唯一正确写法(仓根 `pnpm exec vitest run` 加相对仓根的路径),不用 `pnpm --filter 包名 test`;`--workspace-concurrency` 一律在 `--filter` 之前。

## 围栏

18 文件:`packages/i18n/src/locales/*.ts`(十包,仅新增本切片 24 个路径)、`scripts/i18n-call-site-key-baseline.json`(删 19 条 + 两个空对象收行 + note 加四行)、`packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx`(新增,43 条)、`auth-` + `console-` + `marketplace-preview-` + `organization-` + `perm-home-namespace-3546.test.tsx`(**仅**棘轮总数 17 → 0 与 `missingPrefixes` 2 → 0 —— 那个计数器每切片动一次且只降;`organization-` 那条 `toContain` 反转成 `not.toContain`,`console-` 与 `marketplace-` 两条对空集恒真的 `not.toContain` 删掉并写明理由)、changeset(`@object-ui/i18n` patch)。**零组件改动**。

与在飞 #3844 / #3875(es 既有值敬称)零相交:本切片只**新增** key,不改任何既有语言包值,es 新增行也不在 `preview.draftBar` 邻近。与 #3848(packages/core)、#3837(AiChatPage 与 `console-namespace-3546.test.tsx` 里的 convZh 字节钉 —— 实测本 PR 该文件 diff 里 `convZh` 命中 0)零相交。未动 `content/docs/releases/**`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_