### PR TITLE
docs(components): README §Setup 删掉 Tailwind 3 的 config 步骤,并修正预构建样式表的 specifier (#3780)

### DIFF
--- a/.changeset/components-readme-setup-tailwind-3780.md
+++ b/.changeset/components-readme-setup-tailwind-3780.md
@@ -1,0 +1,54 @@
+---
+---
+
+`packages/components/README.md` §Setup drops the Tailwind 3 configuration step and
+corrects the stylesheet specifier (objectui#3780).
+
+Step 1 told readers to write a `tailwind.config.js` with a `content` array covering
+`./node_modules/@object-ui/components/**`. This package is Tailwind 4: it has no such
+file, `postcss.config.js` loads `@tailwindcss/postcss`, and `src/index.css` opens with
+`@import 'tailwindcss'` plus `@theme` / `@custom-variant` / `@source`. Tailwind 4 does not
+load a config file unless the CSS opts in with `@config`, so a reader who followed step 1
+created a file nothing reads. objectui#3750 had already narrowed the peer line two lines
+above it from `^3.0.0` to `^4.2.1`; the prose underneath did not move with it.
+
+Measured against the built package rather than translated on sight, because the step's
+premise turned out to be unreachable in Tailwind 4 and not merely misspelled. Four
+consumer-shaped CSS entries, one Tailwind 4.3.3 PostCSS run each, against the real
+`@object-ui/components` install:
+
+| consumer entry | consumer's own class | library shape utilities | library theme utilities |
+| --- | --- | --- | --- |
+| step 1 verbatim (config file, no `@config`) | present | absent | absent |
+| `@source` into the installed package | present | present | absent |
+| step 1 plus an explicit `@config` opt-in | present | present | absent |
+| the prebuilt stylesheet | not its job | present | present |
+
+Neither faithful translation of step 1 reaches what step 1 was for. `bg-primary`,
+`bg-background`, `border-input` and `ring-ring` — the whole Shadcn palette — exist only
+where the `@theme` block that declares their tokens is compiled, and that block is in
+`src/index.css`, which `files` does not publish. Scanning the published files therefore
+regenerates the shape-only utilities (`inline-flex`, `rounded-md`, `h-9`) and can never
+recover the themed ones, so a rewritten `@source` step would have been a new wrong
+instruction rather than a fixed one. The step is deleted, and the paragraph that replaces
+it says why the `@source` line a reader might reach for next is not the answer either.
+
+What the prebuilt stylesheet covers was measured the same way instead of assumed: every
+class-shaped token in `dist/index.js` + `dist/index.umd.cjs` — the entire surface a
+`node_modules` glob could ever see — was compiled against this package's own theme, and
+all 1331 rules that produces are already among the 1410 in the shipped `dist/index.css`.
+Zero missing. The prebuilt stylesheet is a strict superset of what scanning could add.
+
+The surviving import step also had the wrong specifier. It read
+`@object-ui/components/dist/style.css`, a subpath the manifest's `exports` map does not
+define — Node resolves it to `ERR_PACKAGE_PATH_NOT_EXPORTED`, and no such file is built
+(`dist/index.css` is). The exported spelling is `@object-ui/components/style.css`, which is
+what the three package demos, `content/docs/guide/quick-start.md` and the comment in
+`src/index.ts` that points readers at this README have all used the whole time. It is now
+what the README says too, shown together with the `@import 'tailwindcss'` line above it so
+the order that makes the theme tokens win is visible.
+
+No package is declared: nothing published changes shape, no version literal moves, and the
+corrected README ships with the group's next release. The peer-line block two lines above
+§Setup is untouched, so `doc-version-claims.test.ts`'s restatement assertion keeps reading
+the same line against the same manifest.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -42,29 +42,32 @@ npm install @object-ui/components @object-ui/react @object-ui/core
 
 ## Setup
 
-### 1. Configure Tailwind
+There is no `tailwind.config.js` step. This package is Tailwind 4, which is
+configured in CSS: it has no such file of its own, and consuming it does not need
+one on your side either.
 
-Add to your `tailwind.config.js`:
+### 1. Import Styles
 
-```js
-module.exports = {
-  content: [
-    './src/**/*.{js,jsx,ts,tsx}',
-    './node_modules/@object-ui/components/**/*.{js,ts,jsx,tsx}'
-  ],
-  // ... your config
-}
-```
-
-### 2. Import Styles
-
-Add to your main CSS file:
+Add to your main CSS file, after your own Tailwind entry:
 
 ```css
-@import '@object-ui/components/dist/style.css';
+@import 'tailwindcss';
+@import '@object-ui/components/style.css';
 ```
 
-### 3. Register Components
+`style.css` is the stylesheet this package compiles at build time from its own
+sources. It already carries every utility its components use **and** the theme
+tokens those utilities are built on — `bg-primary`, `border-input`, `ring-ring`
+and the rest of the Shadcn palette — so importing it is the whole of the styling
+setup.
+
+You do **not** add a `@source` line for `node_modules/@object-ui/components`.
+Pointing Tailwind at the published files generates the shape-only utilities a
+second time and still cannot produce the themed ones, because the `@theme` block
+they come from lives in this package's unpublished source. Your own Tailwind
+entry goes on generating the classes your own source uses, as it always did.
+
+### 2. Register Components
 
 ```tsx
 import { registerDefaultRenderers } from '@object-ui/components'


### PR DESCRIPTION
Fixes #3780

`packages/components/README.md` §Setup 第 1 步教读者写一个带 `content` 数组的 `tailwind.config.js`。该包是 Tailwind 4:它自己没有这个文件,`postcss.config.js` 加载 `@tailwindcss/postcss`,`src/index.css` 首行 `@import 'tailwindcss'` 并使用 `@theme` / `@custom-variant` / `@source`。Tailwind 4 不经 CSS 里的 `@config` opt-in 不会加载 config 文件,所以照第 1 步做的读者写出的是一个没人读的文件。#3750 已把两行之上的 peer 行从 `^3.0.0` 收窄到 `^4.2.1`,底下这段散文没跟上。

分支自 `origin/main` = `56ff0916e09085a5430957d5c62a7e5dc1a80d82` 显式 sha 切出。

## 先量再选:这一步不能翻译,只能删

issue 留了一格未定:第 1 步在 v4 下改写成 `@source`,还是整步删除。按分诊「先量再选」,对着**真实安装**测量而不是照着 v4 语法逐句翻译 —— 结论是这一步的前提在 Tailwind 4 下**不可达**,不只是拼错了。

消费者形状的 fixture(`node_modules` 里装着本包,Tailwind 4.3.3 + `@tailwindcss/postcss`),四组 CSS 入口各跑一次真实编译。方向在跑之前先写进探针脚本头部,以便被证伪:

| 消费者入口 | 消费者自己的 class | 库的形状类 utility | 库的**主题**类 utility |
| --- | --- | --- | --- |
| 第 1 步原样(v3 config,无 `@config`) | 有 | **无** | **无** |
| v4 `@source` 指向已安装包 | 有 | 有 | **无** |
| 第 1 步 + 显式 `@config` opt-in | 有 | 有 | **无** |
| 第 2 步的预构建样式表 | 不归它管 | 有 | 有 |

- **第 1 步原样是完全空转的**:整份产物 74 条选择器,全部来自消费者自己的源码,库的 utility 一条都没有 —— issue 的前提实测坐实。
- **两种「忠实翻译」都到不了第 1 步想去的地方**:`bg-primary` / `bg-background` / `border-input` / `ring-ring`(整套 Shadcn 配色)只在声明其 token 的 `@theme` 块被编译处存在,而该块在 `packages/components/src/index.css` —— `files` 只发布 `dist`,不发布它。扫描已发布文件只能把形状类 utility(`inline-flex` / `rounded-md` / `h-9`)再生成一遍,永远补不回主题类。

所以「改写为 `@source`」会是一条**新的错指令**:读者会得到一堆没有配色的组件,然后去排查一个不存在的路径问题。**该步整步删除**,替换它的段落明写读者接下来最可能伸手去拿的 `@source` 行为什么也不是答案。

### 预构建样式表覆盖多少,也是量出来的

把 `dist/index.js` + `dist/index.umd.cjs` 里所有 class 形状的 token 取出来(18099 个;这就是一个 `node_modules` glob 所能看到的**全部**表面),对着本包自己的主题编译,再与发布的 `dist/index.css` 逐选择器比对:

```
harvested 18099 distinct tokens from dist/index.js + dist/index.umd.cjs
shipped dist/index.css : 161.98 kB, 1410 rules
node_modules-scan probe: 152.78 kB, 1331 rules
rules the probe produces that the shipped CSS does NOT contain: 0
```

零缺失 —— 预构建 CSS 是扫描所能得到之物的**严格超集**。

## 顺带修正:存活下来的 import 步骤 specifier 是错的

测量过程中发现第 2 步自己也不成立。它写 `@object-ui/components/dist/style.css`,而 manifest 的 `exports` 映射里没有这个子路径:

```
OK   @object-ui/components/style.css      -> …/packages/components/dist/index.css
FAIL @object-ui/components/dist/style.css -> ERR_PACKAGE_PATH_NOT_EXPORTED
FAIL @object-ui/components/dist/index.css -> ERR_PACKAGE_PATH_NOT_EXPORTED
```

而且 `dist/style.css` 这个文件根本不存在(构建产物是 `dist/index.css`)。导出的拼法是 `@object-ui/components/style.css` —— 三个包的 demo(`plugin-gantt` / `plugin-grid` 两处)、`content/docs/guide/quick-start.md:57`,以及 `packages/components/src/index.ts:14` 里那句**把读者指向本 README** 的注释,一直用的都是它;只有 README 自己是错的。

这一条**同 PR 修**而不是另立,理由是它与本 issue 的裁决直接耦合:删掉第 1 步之后,第 2 步是 §Setup 里唯一剩下的样式指令,把一条 `ERR_PACKAGE_PATH_NOT_EXPORTED` 的 specifier 留成唯一答案,比原来两步都错更糟。

## 改后的 §Setup 是跑通过的

PR 里写给读者的那两行,按同一套 fixture 实测(180.27 kB,1447 条选择器):形状类、主题类、以及消费者自己源码里的 class **全部**present。作为对照,`content/docs/guide/quick-start.md` 现行教法(同样两行再加一条 `@source node_modules`)是 280.25 kB / 1461 条 —— 多 100 kB,换来 14 条没人用的选择器(已另立 #3884)。

## 反向验证

doc 类改动没有可回装的谓词,可测等价物取三样,方向均在跑之前写定:

1. **把删掉的那一步当作被测对象跑一遍**(而不是回装进代码):v3 config 原样放进真实 Tailwind 4 编译 —— 预测「库 utility 全无」,实测 74 条选择器里库的 utility 零命中。这一步的空转是被**运行**出来的,不是从 v4 文档推出来的。
2. **门禁前后全绿**:`check-doc-links.mjs`、`check-control-bytes.mjs`、`doc-version-claims.test.ts`(14 passed —— peer 行区块未动,restatement 断言仍在读同一行对同一 manifest)、`check-changeset-presence.mjs`、`check-changeset-no-major.mjs`、`check-changeset-fixed.mjs`、全仓 `turbo run type-check`(78/78)。
3. **我教给读者的每条写法自己跑一遍**:见上一节。

`doc-version-claims` 的 inventory 无需联动:本次改动不新增版本字面量(新增散文只写不带点、不带运算符的 `Tailwind 4`,该拼法被 `VERSION` 正则明确排除,test 自己的注释就记着这件事),peer 行区块一个字节没动。

## changeset

`check-changeset-presence.mjs` 判定不欠(它只守每个包的 `src/**`,README 在其守备面之外,header 里明写了这条边界)。仍按 #3749/PR3860 先例补一份**空 frontmatter** 的 changeset:不声明包,因为没有任何已发布产物改变形状、没有版本字面量移动,改好的 README 随该版本组的下一次发版一起出去。

## 越界发现(均已查重后另立,本 PR 不碰)

- **#3883** — `content/docs/guide/theming.md` §Tailwind Configuration 与 `troubleshooting.md` §2 仍在教 v3 `tailwind.config` `content` 数组;后者尤其致命,它正是读者「class 没生效」之后落地的页面,而实测那个处方补不回主题类 utility。
- **#3884** — `quick-start.md` 的两条 `@source node_modules` 行冗余:实测多 100 kB / 14 条无用选择器,且它补不回它看似要补的主题 utility。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_