### PR TITLE
docs(core): fieldRules 模块头收窄 readonly fail-open 的「与服务端一致」断言 (#3828)

### DIFF
--- a/.changeset/fieldrules-readonly-failopen-server-parity-3828.md
+++ b/.changeset/fieldrules-readonly-failopen-server-parity-3828.md
@@ -1,0 +1,34 @@
+---
+---
+
+Comment-only change, no behaviour and no authoring-surface change (objectui#3828).
+
+The module head of `packages/core/src/evaluator/fieldRules.ts` described the
+client's readonly fail-open as "matching the server, which logs and allows the
+change through". That was true when it was written and has not been true for one
+whole fault class since objectstack#4889: a `readonlyWhen` predicate that faults
+because it names a scope ROOT the write never bound (`parent.status == 'paid'`
+with no master-detail header in hand) is fail-CLOSED on the server —
+`isReadonlyWhenLocked` warns and returns TRUE (LOCKED), and
+`stripReadonlyWhenFields` / `stripReadonlyWhenFieldsMulti` then delete that key
+from the UPDATE payload. The client, correctly, keeps the same fault fail-OPEN.
+
+So the two ends point in OPPOSITE directions for that class, and the comment
+described them as agreeing — which points a reader the wrong way on the one
+symptom the divergence produces: the form renders the field editable, the save
+reports success, and the value silently never lands. The narrowed text names the
+divergence, cites the framework's ADR-0057 D10 (server enforces, client is
+courtesy) as the reason the client does NOT follow the server here, and tells the
+caller which end to debug (the server's `treating the field as LOCKED` warning
+and the write response's `droppedFields`, not the client predicate).
+
+The `requiredWhen` half stays as it was, re-verified accurate: objectstack#4977
+bound the `parent` scope for those predicates and deliberately kept the fail-open
+semantics, so an unevaluable requirement is skipped on both ends. Field-level
+`visibleWhen` likewise — the server does not evaluate it at all. The "log and
+allow" quote further down the docblock is now marked as the GENERIC-fault
+message, so the narrowing is not undone two paragraphs later.
+
+No package is declared because nothing published changed: the diff is a docblock
+only, every line of code untouched, and `packages/core/src/evaluator`'s tests keep
+their count byte for byte (289 passed before, 289 passed after).

--- a/packages/core/src/evaluator/fieldRules.ts
+++ b/packages/core/src/evaluator/fieldRules.ts
@@ -23,8 +23,33 @@
  * CEL (mirrors the server's `toExpression`). Evaluation is *fail-open* for
  * visibility/required (a broken predicate must not hide a field or wrongly
  * block submit) and *fail-open* for readonly (a broken predicate leaves the
- * field editable) — matching the server, which logs and allows the change
- * through.
+ * field editable).
+ *
+ * Fail-open agrees with the server for MOST faults — but not for all, and the
+ * exception is the half worth knowing. Since objectstack#4889 a `readonlyWhen`
+ * predicate that faults because it names a scope ROOT the write never bound —
+ * `parent.status == 'paid'` with no master-detail header in hand — is
+ * fail-CLOSED on the server: `isReadonlyWhenLocked` warns and then returns
+ * TRUE, i.e. LOCKED (a declared lock is not waived merely because it could not
+ * be evaluated), and `stripReadonlyWhenFields` — plus
+ * `stripReadonlyWhenFieldsMulti` on the bulk path — DELETES that key from the
+ * UPDATE payload. This file keeps the same fault fail-OPEN. For that one class
+ * the two ends therefore point in OPPOSITE directions, deliberately: the
+ * framework's ADR-0057 D10 — server enforces, client is courtesy (framework
+ * numbering; this repo's own ADR-0057 is an unrelated document) — makes the
+ * server the authority, so the courtesy layer does not get to guess "locked"
+ * and grey out a field the server might have accepted.
+ *
+ * The caller-visible consequence, spelled out because the symptom is silent:
+ * the form renders the field EDITABLE, the user edits it, the save reports
+ * SUCCESS, and the new value never lands — the server dropped the key and kept
+ * the persisted one. Debug that toward the SERVER-side lock (its `… treating
+ * the field as LOCKED` warning, and the write response's `droppedFields`), not
+ * toward the client predicate, which did exactly what it was asked to. The
+ * other two halves carry no such carve-out: `requiredWhen` binds the same
+ * `parent` scope but deliberately kept fail-open semantics (objectstack#4977),
+ * so an unevaluable requirement is skipped on BOTH ends, and field-level
+ * `visibleWhen` is not a server concept at all.
  *
  * Fail-open is **loud**, not silent (objectstack#5149): a predicate that
  * cannot be evaluated — parse error, unbound identifier, engine fault — logs
@@ -32,8 +57,10 @@
  * reason, then still returns the caller's fallback. Without the warning a
  * broken predicate is indistinguishable from an absent one, so
  * conditional-visibility bugs survive inspection indefinitely. This is the
- * client half of the server's "log and allow" convention (`readonlyWhen for
- * 'x' failed to evaluate — change allowed through`). The *default* stays
+ * client half of the server's "log and allow" convention for the faults where
+ * the two ends DO agree (`readonlyWhen for 'x' failed to evaluate — change
+ * allowed through` — the GENERIC-fault message; the unbound-root fault above
+ * logs `treating the field as LOCKED` instead). The *default* stays
  * fail-open on purpose — flipping it is a shipped-behavior change tracked
  * separately in objectstack#5149 (appeal 1, undecided).
  */


### PR DESCRIPTION
Fixes #3828

## 改了什么

只有一处:`packages/core/src/evaluator/fieldRules.ts` 的**模块头注释**。零行为改动 —— 代码一行未动,`packages/core/src/evaluator` 的测试前后都是 289 passed / 9 files(用例数逐个一致)。

改前(`fieldRules.ts:23-27` @ `47f607854`):

> Evaluation is *fail-open* for visibility/required (…) and *fail-open* for readonly (a broken predicate leaves the field editable) — **matching the server, which logs and allows the change through**.

按分诊裁定的**方向 1** 收窄:多数 fault 两端一致 fail-open;**未绑定根**那一类服务端自 objectstack#4889 起是 fail-CLOSED,两端方向相反;相反是刻意的,按 ADR-0057 D10 以服务端为准;并写明调用方后果。

## 为什么这句话必须改

客户端这一侧本身没错 —— `resolveFieldRuleState` 给 `readonlyWhen` 传 `fallback: false`(`fieldRules.ts:196`),字段仍可编辑,这是 ADR-0057 D10「server enforces, client is courtesy」下的合理选择。错的只是「一致」这半句。

服务端侧证据(objectstack `origin/main` @ `fec784863`,`packages/objectql/src/validation/rule-validator.ts`):

| 事实 | 位置 |
|---|---|
| `readonlyWhen` 未绑定根 → 记日志 `treating the field as LOCKED` | `:599-603` |
| 同一分支 `return true`(= LOCKED) | `:604` |
| **其他** fault 仍 fail-open:`failed to evaluate — change allowed through` + `return false` | `:606-607` |
| `isReadonlyWhenLocked` 定义 | `:580` |
| `stripReadonlyWhenFields` 定义 / `delete` 掉该 key | `:522` / `:537` |
| 批量路径同源(`stripReadonlyWhenFieldsMulti`) | `:741` / `:772`,说明见 `:723-728` |
| 该 carve-out 的设计说明「the UNBOUND-ROOT case is fail-CLOSED (#4889)」 | `:99-109` |
| ADR-0057 D10 是这个方向的依据(「puts enforcement on the server」) | `:567-569` |
| `requiredWhen` 两端仍都 fail-open(objectstack#4977 只绑 scope、不改语义) | `:117-141`、`:1416-1430` |

于是真实链路和注释描述的正好相反:注释让人建立「客户端可编辑 + 服务端放行 = 值会落库」的模型,而实际是「客户端可编辑 + 服务端锁死丢弃 = 表单能改、保存报成功、值静默不落库」。新正文因此额外写了一段**排障方向**:往服务端锁死那边查(服务端的 `treating the field as LOCKED` 警告,加写响应的 `droppedFields` —— 后者证据 objectstack `packages/client/src/index.ts:335,349`),而不是查客户端谓词。

## 两处需要评审留意的判断

1. **ADR-0057 的编号在两仓撞号。** framework 的 ADR-0057 D10 才是「server enforces, client is courtesy」(`docs/adr/0057-erp-authorization-core-business-units-and-scope-depth.md:422`,PS-2 实现注记 `:516-526` 把 client-side gate 与 server-side teeth 讲得最清楚);而本仓的 `docs/adr/0057-console-ai-chat-one-conversation-docked.md` 是完全无关的文档。本仓读者按裸编号翻会翻到错的那份,所以新注释写成 "the framework's ADR-0057 D10 …(framework numbering; this repo's own ADR-0057 is an unrelated document)"。
2. **下文那句 "log and allow" 加了限定词。** 模块头第三段原本写 "This is the client half of the server's `log and allow` convention",引用的是服务端**通用 fault** 的消息(`rule-validator.ts:606`)—— 这句本身准确,但**不加限定**就会把上一段刚收窄的结论在两段之后抹平,使 docblock 自相矛盾。因此只加了「for the faults where the two ends DO agree」+ 标注它是 GENERIC-fault 消息。仍在 issue 划定的文件面(同一个模块头)内,但确实超出「只改那一句」的字面范围,故在此显式说明。

`requiredWhen` 半句与可见性半句按分诊结论**未动**(前者 objectstack#4977 两端都 fail-open,后者服务端根本不评估字段级 `visibleWhen`)。

## 验证

- 反向验证:注释-only 无谓词可回装,可测等价物 = **前后测试用例数与结果完全一致**(证明零行为改动),而非「回装变红」。改前 `289 passed (9 files)`,改后 `289 passed (9 files)`。新注释里引用的每个符号与单号都给了上表的 file:line。
- `pnpm exec vitest run packages/core/src/evaluator --maxWorkers=2`:前后各一次,均 `Test Files 9 passed (9) / Tests 289 passed (289)`。
- `pnpm exec turbo run type-check --concurrency=2`(全仓):`78 successful, 78 total`。
- `node scripts/check-control-bytes.mjs`:`OK (scanned 3778 tracked text file(s))`;改动两文件 `grep -naP` 控制字节零命中。
- changeset:`packages/core/src/**` 在 `check-changeset-presence.mjs` 的守护面内,注释-only 故按 #3749 / PR #3860 先例走**空 frontmatter 声明不发布**;三个 changeset 门禁(presence / no-major / fixed)均绿。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_