### PR TITLE
fix(plugin-detail): 相关列表的 Add 门改问 add.picker.object,漏写 picker 不再把整块换成红卡 (#3838)

### DIFF
--- a/.changeset/related-list-add-picker-guard-3838.md
+++ b/.changeset/related-list-add-picker-guard-3838.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`record:related_list`: an `add` without `add.picker` no longer takes the whole related list down.
+
+The Add-picker gate compared only `add` for truthiness and then read `add.picker.object` bare, so page metadata declaring `add` but omitting the (spec-required) `picker` threw during render and `SchemaRenderer` replaced the entire related list with a "Component failed to render" card whose message never mentioned `picker`. Both the Add button and the picker dialog now gate on the resolved `add.picker.object` — the list body renders as usual, only the unconfigured Add affordance is withheld, and a console hint names the missing key. Off-spec `add` still does nothing, so no lenient second dialect is introduced; producing-side validation of page metadata is tracked separately.

--- a/apps/console/src/__tests__/public-block-binding-reach.test.tsx
+++ b/apps/console/src/__tests__/public-block-binding-reach.test.tsx
@@ -235,8 +235,9 @@ const sampleFor = (input: any): unknown => {
   if (input.name === 'objectName') return PROBE_OBJECT;
   // `record:related_list.add` — the generic `object` sample below is `{}`, and
   // `{}` is not a valid `add`: the spec makes `picker` required. An invalid one
-  // does not merely under-configure this block, it CRASHES it
-  // (`RelatedList.tsx:1299` dereferences `add.picker.object`, objectui#3838) —
+  // did not merely under-configure this block, it CRASHED it
+  // (`RelatedList.tsx:1299` dereferenced `add.picker.object`, objectui#3838,
+  // whose fix now gates the Add affordance on the resolved picker target) —
   // and a crashed block makes no data calls, which is indistinguishable from the
   // "declines to fetch" verdict this block is ledgered for below. That is a green
   // for the wrong reason, so the sample is spec-valid at the source instead.
@@ -381,11 +382,12 @@ describe('public blocks — a declared objectName reaches the data layer (object
         //
         // Added with objectui#3808, and DEFENSIVE rather than load-bearing today:
         // that change made an invalid `add` sample crash `record:related_list`
-        // (objectui#3838), which is what it does in the sibling probe, but not
+        // (objectui#3838), which is what it did in the sibling probe, but not
         // here — `renderers/record-related-list.tsx:185` passes
         // `dataSource={ctx?.dataSource}`, this probe mounts with no RecordContext,
-        // so `RelatedList`'s `add && dataSource` guard short-circuits before the
-        // unguarded read. Checked, not assumed: reverting the sample to `{}` keeps
+        // so `RelatedList`'s picker gate (`add && pickerObject && dataSource`,
+        // truthiness-only on `add` before #3838) short-circuits before the read
+        // either way. Checked, not assumed: reverting the sample to `{}` keeps
         // all 16 green. The predicate itself is known to work — applied to both
         // branches it reports the two crashes in objectui#3840 — so this is a
         // cheap standing guard on the one branch where a crash IS the pass

--- a/apps/console/src/__tests__/record-block-record-reach.test.tsx
+++ b/apps/console/src/__tests__/record-block-record-reach.test.tsx
@@ -205,10 +205,14 @@ const DATA_SOURCE_METHODS = [
  * sample, which would put an unspecified bag on every future `object` input.
  *
  * That `{}` did not merely under-exercise the block, it CRASHED it —
- * `RelatedList.tsx:1299` dereferences `add.picker.object` where `:378` / `:390`
- * optional-chain the same path — and the crash is filed as objectui#3838 rather
+ * `RelatedList.tsx:1299` dereferenced `add.picker.object` where `:378` / `:390`
+ * optional-chain the same path — and the crash was filed as objectui#3838 rather
  * than papered over here: this fixture's job is to be spec-valid, not to steer
- * clear of the renderer's unguarded reads.
+ * clear of the renderer's unguarded reads. #3838 has since tightened that gate
+ * to require the resolved `add.picker.object`, so the same `{}` now withholds
+ * the Add affordance behind a named console hint instead of taking the block
+ * down; the sample below stays spec-valid on its own merit, not as crash
+ * avoidance.
  */
 const SAMPLE_BY_INPUT: Readonly<Record<string, unknown>> = {
   // On `record:*` this names the RELATED object, not the page's object —

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -393,6 +393,27 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     return derived.length > 0 ? derived : undefined;
   }, [pickerSchema, pickerDisplayField]);
 
+  // Developer hint for an `add` that cannot be honoured (#3838). `picker` is
+  // REQUIRED on `add` by the spec (`RecordRelatedListProps.add`), so getting
+  // here means the page metadata is off-spec — but nothing on the render path
+  // parses it (the sdui-parser manifest gate compares top-level key names and
+  // coarse types only), so the renderer is the first place able to say so. It
+  // says WHICH key is missing, because the failure it replaces — a bare
+  // `add.picker.object` read that threw and made SchemaRenderer swap the whole
+  // list for a "failed to render" card — never mentioned `picker` at all.
+  // Console-only, matching the in-file hint for the other partial
+  // misconfiguration (`no referenceField/parentId` below): the block-level
+  // dashed placeholder precedent in `renderers/record-related-list.tsx` is for
+  // blocks that can render NOTHING (missing objectName), whereas here only the
+  // Add affordance is unconfigured and the list body is perfectly fine.
+  React.useEffect(() => {
+    if (!add || pickerObject) return;
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[RelatedList] "${api || objectName || 'related list'}" declares add without add.picker.object — the Add affordance is not rendered. add.picker is required by the spec (RecordRelatedListProps.add): set add.picker.object to the object the picker should list.`,
+    );
+  }, [add, pickerObject, api, objectName]);
+
   React.useEffect(() => {
     // Stale-response guard: page flips re-run this effect while an earlier
     // window may still be in flight — a slow page-2 response must not
@@ -1118,7 +1139,12 @@ export const RelatedList: React.FC<RelatedListProps> = ({
                 onToolbarAction={onToolbarAction}
               />
             ))}
-            {add && (
+            {/* Gated on the RESOLVED picker target, not merely on `add` being
+                truthy: an `add` without `picker` is metadata the spec rejects,
+                and offering a button that could never open a picker is worse
+                than withholding it (#3838 — the console hint above names the
+                missing key). */}
+            {add && pickerObject && (
               <Button
                 variant={isEmpty ? 'ghost' : 'outline'}
                 size="sm"
@@ -1290,13 +1316,19 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           {addError}
         </div>
       )}
-      {add && dataSource && (
+      {/* Same gate as the Add button above — `pickerObject` (i.e.
+          `add?.picker?.object`, computed once near the picker-schema fetch) is
+          what the dialog needs, so requiring it here removes the last
+          render-path bare read of `add.picker` rather than optional-chaining
+          it: off-spec `add` still does nothing at all, so no second dialect
+          appears (AGENTS.md #0.1). #3838. */}
+      {add && pickerObject && dataSource && (
         <RecordPickerDialog
           open={pickerOpen}
           onOpenChange={(o) => setPickerOpen(o)}
           multiple
           dataSource={dataSource as any}
-          objectName={add.picker.object}
+          objectName={pickerObject}
           title={add.label || t('detail.add', { defaultValue: 'Add' })}
           displayField={pickerDisplayField}
           columns={pickerColumns}

--- a/packages/plugin-detail/src/__tests__/RelatedList.addPickerGuard.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.addPickerGuard.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3838 — an `add` without `add.picker` must not take the whole
+ * related list down.
+ *
+ * `add.picker` is REQUIRED by the spec (`RecordRelatedListProps.add`:
+ * `safeParse({ add: { label: 'Add' } })` reports `invalid_type` on
+ * `add.picker`), and `RelatedListProps` types it as required too — which is
+ * exactly why the bare `add.picker.object` read behind a truthiness-only
+ * `{add && dataSource && (` gate type-checked. Nothing on the render path
+ * parses the schema (the sdui-parser manifest gate compares top-level key
+ * names and coarse types only, `validateComponentProps` is advisory, and this
+ * renderer did not check), so off-spec page metadata reached the read and threw
+ * `TypeError: Cannot read properties of undefined (reading 'object')`, which
+ * `SchemaRenderer` turned into a "Component 'record:related_list' failed to
+ * render" card over the ENTIRE list — with no mention of `picker` anywhere in
+ * the message.
+ *
+ * The fix tightens the gates to the resolved picker target (the same
+ * `add?.picker?.object` the file already computes for the picker schema fetch),
+ * so the bare read is gone rather than optional-chained: an `add` missing
+ * `picker` withholds the Add affordance and names the missing key in the
+ * console, while the list body renders as usual. It is not consumer-side
+ * leniency (AGENTS.md #0.1) — off-spec `add` still does nothing, so no second
+ * dialect appears; the producer-side fix is #3838's route (c), out of scope
+ * here.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { RelatedList } from '../RelatedList';
+
+const junctionRows = [
+  { id: 'ups_1', permission_set_id: 'ps_1' },
+  { id: 'ups_2', permission_set_id: 'ps_2' },
+];
+
+const makeDataSource = () => ({
+  getObjectSchema: vi.fn(async () => ({
+    name: 'sys_user_permission_set',
+    fields: { permission_set_id: { type: 'text', label: 'Permission Set' } },
+  })),
+  find: vi.fn(async (api: string) =>
+    api === 'sys_user_permission_set'
+      ? { data: junctionRows, total: junctionRows.length }
+      : { data: [], total: 0 },
+  ),
+});
+
+/**
+ * `add` is the only thing that varies across these cases; everything else is
+ * the configuration a working assignment list uses (referenceField + parentId
+ * present, so the unrelated "refusing to fetch all rows" hint stays silent and
+ * the console spy sees only the diagnostic under test).
+ */
+const renderList = (ds: any, add?: any) =>
+  render(
+    <RelatedList
+      title="Permission Sets"
+      type="table"
+      api="sys_user_permission_set"
+      objectName="sys_user_permission_set"
+      referenceField="user_id"
+      parentId="u_1"
+      columns={[{ accessorKey: 'permission_set_id', header: 'Permission Set' }]}
+      dataSource={ds}
+      add={add}
+    />,
+  );
+
+/** The Add affordance, whatever label the metadata gave it. */
+const queryAddButton = () =>
+  screen.queryByRole('button', { name: /Assign position|Grant permission set|^Add$/ });
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+});
+
+const warnings = () => warn.mock.calls.map((c) => String(c[0])).join('\n');
+
+describe('RelatedList — add without add.picker (#3838)', () => {
+  it('renders the list body, withholds the Add affordance, and names add.picker.object', async () => {
+    const ds = makeDataSource();
+
+    // Pre-fix this render THREW the TypeError above (in the app: the red card
+    // replacing the whole block). Reaching the assertions at all is the
+    // no-crash half of the pin.
+    renderList(ds, { label: 'Assign position' });
+
+    // The list body is untouched: the parent-scoped fetch still runs and its
+    // rows still reach the view (the count badge is fed by the same
+    // `relatedData` the table renders from — the table itself is a `data-table`
+    // delegated to SchemaRenderer/plugin-grid, out of this unit's scope).
+    await waitFor(() =>
+      expect(ds.find).toHaveBeenCalledWith('sys_user_permission_set', expect.objectContaining({
+        $filter: { user_id: 'u_1' },
+      })),
+    );
+    expect(screen.getByText('Permission Sets')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByLabelText(`${junctionRows.length} records`)).toBeInTheDocument(),
+    );
+
+    // The unconfigured Add affordance does not render — clicking a button that
+    // can never open a picker is worse than not offering it.
+    expect(queryAddButton()).toBeNull();
+
+    // …and the author is told WHICH key is missing, which the crash never did.
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(warnings()).toContain('add.picker.object');
+    expect(warnings()).toContain('sys_user_permission_set');
+  });
+
+  it('still renders the Add affordance and opens the picker for a spec-valid add', async () => {
+    const ds = makeDataSource();
+    renderList(ds, {
+      picker: { object: 'sys_permission_set', labelField: 'label' },
+      linkField: 'permission_set_id',
+      label: 'Grant permission set',
+    });
+
+    const button = await waitFor(() => {
+      const b = queryAddButton();
+      expect(b).not.toBeNull();
+      return b!;
+    });
+    fireEvent.click(button);
+
+    // Opening the dialog fetches the picker TARGET's schema — proof the gate
+    // still passes the resolved `add.picker.object` through.
+    await waitFor(() =>
+      expect(ds.getObjectSchema).toHaveBeenCalledWith('sys_permission_set'),
+    );
+    expect(warnings()).not.toContain('add.picker.object');
+  });
+
+  it('leaves a list with no add untouched and silent', async () => {
+    const ds = makeDataSource();
+    renderList(ds, undefined);
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(queryAddButton()).toBeNull();
+    // No `add` is a legitimate configuration, not a misconfiguration.
+    expect(warnings()).not.toContain('add.picker.object');
+  });
+});


### PR DESCRIPTION
Fixes #3838

## 前提复核(先证后改)

- **崩溃点确认在 `:1299`**,按内容锚定复核过:`grep -n "add\.picker" packages/plugin-detail/src/RelatedList.tsx` 只有 `:724` / `:734` / `:1299` 三处裸取,前两处在 `handleAddRecords` 回调内、`:723` 有 `if (!add || !dataSource || …) return` 前置,不在渲染路径 —— **未动**。
- **spec 侧确认 `picker` 必填**:`RecordRelatedListProps.safeParse({ objectName, relationshipField, add: { label: 'Add' } })` 报 `invalid_type` on path `["add","picker"]`。也就是说触发者只能是**不合规元数据**;而渲染路径上没有任何一处解析 schema,所以它一路抵达裸取。
- **`RelatedListProps.add.picker` 在 TS 里被声明为必填**(`RelatedList.tsx:84`)—— 这正是裸取当年能通过 type-check 的原因:类型声明可信,运行时拿到的是未校验 JSON。
- **崩溃在钉子测试里实测复现**(改代码前跑,见下「反向验证」的 before 一栏)。

## 改了什么

方向按分诊缺省 **(a) 收紧门 + (b) 具名诊断**:

1. **Add 按钮(`:1121`)与 picker 对话框(`:1293`)的门统一收紧**为 `add && pickerObject`,`:1299` 改用文件里已有的 `pickerObject`(即 `add?.picker?.object`,原本就为 picker schema 预取而算过一次)。
   - 结果是渲染路径上**最后一处 `add.picker` 裸取消失**,而不是给它加可选链 —— 后者是消费端宽容(AGENTS.md #0.1),会让缺 `picker` 的 `add` 变成一种"能用"的第二方言。现在它**仍旧什么都不做**,只是从「炸整块」变成「Add affordance 不渲染」,与同一路径上 `:378`/`:390` 既有的可选链同向。
   - 两处门一起收是必要的:只收 `:1293` 会留下一个点了没有对话框可开的死按钮。
2. **具名诊断**:缺 `add.picker.object` 时 `console.warn` 点名缺失的键(旧的报错文案里根本没有 `picker` 三个字)。
   - **诊断形态的取舍**:`renderers/record-related-list.tsx` 的整块 dashed placeholder 先例,语义是「这个块什么都渲染不出来」(缺 `objectName` → 没有任何数据可取;同族的 `record:path — no stages`、`record:quick_actions — no actions` 同理)。这里不是那个情形 —— 列表主体、计数、分页、行操作全都正常,**只有 Add 一个 affordance 缺配置**,把一个能用的列表换成一行虚线提示是净损失。
   - 因此照的是**同一文件里针对局部误配的开发者提示先例**(`:405-416`,`no referenceField/parentId — refusing to fetch all rows`):同样是"降级一个行为、点名一个键"的 console.warn,放在 effect 里(每次挂载/配置变化告警一次,不随每次渲染刷屏)。
3. **消费半径注释同步**:`apps/console` 两个 reach 探针里把该崩溃与旧门形状写成现存事实的注释更正为过去时(#3808 留下的历史说明保留)。**只改注释,fixture 样本与断言一行未动** —— `add: { picker: { object } }` 本来就是 spec 合法样本,与本 PR 无关地成立。

## 反向验证(方向先判后跑)

**预判**(写在跑之前):只还原 `:1293` 的旧门与裸取、**保留**新加的 warn effect 与收紧后的按钮门 → 缺 picker 的钉子**红**在同一个 TypeError 上,且**具名诊断依然不出现**(render 先抛,effect 根本轮不到 flush),合法样本两例保持绿。

| | 缺 picker 钉子 | 合法 add | 无 add |
|---|---|---|---|
| **改前(origin/main 原样)** | ❌ `TypeError: Cannot read properties of undefined (reading 'object')` @ `RelatedList.tsx:1299:34` | ✅ | ✅ |
| **改后** | ✅ | ✅ | ✅ |
| **单独还原 `:1293`(保留 warn)** | ❌ 同一个 TypeError @ 还原后的 `:1331:34`,warn 从未触发 | ✅ | ✅ |

预判与实测一致。第三行是这次真正的信息量:**门才是承重的那条腿** —— warn effect 单独存在时是装饰性的,因为抛异常发生在 effect flush 之前;所以 (b) 必须叠在 (a) 上,不能替代它。

## 测试

- `pnpm exec vitest run packages/plugin-detail/src/__tests__/RelatedList.addPickerGuard.test.tsx` → 3 passed(新钉子)
- `pnpm exec vitest run packages/plugin-detail` → **60 files / 493 tests passed**(消费半径:plugin-detail 全量)
- `pnpm exec vitest run apps/console/src/__tests__/record-block-record-reach.test.tsx apps/console/src/__tests__/public-block-binding-reach.test.tsx` → 2 files / 29 passed
- `pnpm exec turbo run type-check --concurrency=2` → **78 successful, 78 total**
- `pnpm run check:control-bytes` → OK(3780 tracked files)
- 全部重活跑在仓根 `flock /tmp/os-heavy-verify.lock` + `NODE_OPTIONS=--max-old-space-size=4096` + `--maxWorkers=2` 下

## 不在本单

- **(c) 产出端校验**:让写页面元数据的路径真的跑一次 spec 解析(save-gate / `os build`)仍是最正的方向 —— 它才能在发布时**拒绝**这种元数据,而本 PR 只改变已在野坏元数据的渲染后果。范围远超本单。
- **#3831**(`add.picker.filter` 未接线)另单,未碰。
- `:724`/`:734` 回调内的裸取:有前置 return 且现在只能由已通过新门的对话框触发,按 issue 结论未动。

基线:`origin/main` @ `47f60785474ca68889a376bd0dff7aedec5d2725`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_