### PR TITLE
docs(layout): PageHeader 的 Styling/Container 按代码改写,并把它的 live demo 换成真组件 (#3786, #3787)

### DIFF
--- a/apps/site/app/components/InteractiveDemo.tsx
+++ b/apps/site/app/components/InteractiveDemo.tsx
@@ -3,6 +3,8 @@
 import React, { useMemo } from 'react';
 import { SchemaRenderer, SchemaRendererContext } from '@object-ui/react';
 import { SidebarProvider } from '@object-ui/components';
+// Registers `page-header` & friends — see the module header (objectui#3787).
+import './registerLayoutBlocks';
 import type { SchemaNode } from '@object-ui/core';
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
 import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';

--- a/apps/site/app/components/LiveSplitDemo.tsx
+++ b/apps/site/app/components/LiveSplitDemo.tsx
@@ -24,6 +24,8 @@ import {
   getExample,
   type Example,
 } from '@object-ui/example-schema-catalog';
+// Registers `page-header` & friends — see the module header (objectui#3787).
+import './registerLayoutBlocks';
 
 const PRESET_IDS = [
   'auth/login-simple',

--- a/apps/site/app/components/SchemaThumbnail.tsx
+++ b/apps/site/app/components/SchemaThumbnail.tsx
@@ -19,6 +19,8 @@ import React, {
 import { SchemaRenderer, SchemaRendererContext } from '@object-ui/react';
 import { SidebarProvider } from '@object-ui/components';
 import type { SchemaNode } from '@object-ui/core';
+// Registers `page-header` & friends — see the module header (objectui#3787).
+import './registerLayoutBlocks';
 
 const defaultCtx = { dataSource: {} };
 

--- a/apps/site/app/components/registerLayoutBlocks.ts
+++ b/apps/site/app/components/registerLayoutBlocks.ts
@@ -1,0 +1,37 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ */
+
+/**
+ * Registers `@object-ui/layout`'s blocks (`page-header`, `app-shell`,
+ * `sidebar-nav`, …) for the docs site's schema renderers.
+ *
+ * Why this exists (objectui#3787): the site renders catalog examples through
+ * `SchemaRenderer`, and `ComponentRegistry` only knows a type once the package
+ * owning it has been loaded. `@object-ui/components` registers its own blocks
+ * as an import side-effect and every renderer host already imports it, so
+ * `div`/`text`/`button` resolved — but nothing pulled in `@object-ui/layout`,
+ * so `page-header` resolved to nothing and rendered the red
+ * "Unknown component type" panel (OBJUI-001). It was not noticed because no
+ * example used the component: the one demo on the PageHeader docs page
+ * hand-rolled the header out of `div`s instead, which is the defect #3787 is
+ * about.
+ *
+ * Imported for effect by EVERY host that renders a catalog example
+ * (`InteractiveDemo`, `SchemaThumbnail`, `LiveSplitDemo`) rather than wired
+ * into one docs page: `SchemaThumbnail` renders the whole catalog on
+ * `/docs/guide/schema-catalog`, so a page-local loader would fix the component
+ * page and leave that index showing the error panel for the same example.
+ *
+ * `registerLayout()` is called EXPLICITLY even though the package body also
+ * calls it on load: `@object-ui/layout` declares `"sideEffects": false`
+ * (`packages/layout/package.json`), which permits a bundler to drop a module
+ * imported only for its side-effects. A named import that is actually invoked
+ * cannot be dropped. Registration is idempotent, so the double call is safe,
+ * and doing it at module scope (not in an effect) means it has already happened
+ * for the server render — the demos stay in the prerendered HTML.
+ */
+import { registerLayout } from '@object-ui/layout';
+
+registerLayout();

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -17,6 +17,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/example-schema-catalog": "workspace:*",
     "@object-ui/fields": "workspace:*",
+    "@object-ui/layout": "workspace:*",
     "@object-ui/plugin-calendar": "workspace:*",
     "@object-ui/plugin-charts": "workspace:*",
     "@object-ui/plugin-chatbot": "workspace:*",

--- a/content/docs/layout/page-header.mdx
+++ b/content/docs/layout/page-header.mdx
@@ -150,8 +150,9 @@ The PageHeader uses a flex layout:
 
 ### Container
 
-- Padding bottom: `pb-4` on mobile, `pb-8` on desktop
-- Gap: `gap-4` between elements
+- Padding bottom: `pb-4` at every breakpoint — there is no responsive variant
+- Border: `border-b` along the bottom edge
+- Gap: `gap-3` on the outer column; the title row itself uses `gap-x-4 gap-y-2`
 
 ## Usage with Page Component
 

--- a/examples/schema-catalog/package.json
+++ b/examples/schema-catalog/package.json
@@ -29,7 +29,9 @@
     "@object-ui/types": "workspace:*"
   },
   "devDependencies": {
+    "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
+    "@object-ui/layout": "workspace:*",
     "@object-ui/react": "workspace:*",
     "typescript": "^6.0.3"
   }

--- a/examples/schema-catalog/src/schemas/layout-page-header/pageheader-with-actions.json
+++ b/examples/schema-catalog/src/schemas/layout-page-header/pageheader-with-actions.json
@@ -1,49 +1,17 @@
 {
-  "type": "div",
-  "className": "space-y-6",
+  "type": "page-header",
+  "title": "Users",
+  "subtitle": "Manage your team members and permissions",
+  "icon": "users",
   "children": [
     {
-      "type": "div",
-      "className": "flex flex-col gap-4 pb-4",
-      "children": [
-        {
-          "type": "div",
-          "className": "flex items-center justify-between gap-4",
-          "children": [
-            {
-              "type": "div",
-              "className": "flex flex-col gap-1",
-              "children": [
-                {
-                  "type": "text",
-                  "content": "Users",
-                  "className": "text-2xl font-bold tracking-tight"
-                },
-                {
-                  "type": "text",
-                  "content": "Manage your team members and permissions",
-                  "className": "text-sm text-muted-foreground"
-                }
-              ]
-            },
-            {
-              "type": "div",
-              "className": "flex items-center gap-2",
-              "children": [
-                {
-                  "type": "button",
-                  "label": "Export",
-                  "variant": "outline"
-                },
-                {
-                  "type": "button",
-                  "label": "Add User"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      "type": "button",
+      "label": "Export",
+      "variant": "outline"
+    },
+    {
+      "type": "button",
+      "label": "Add User"
     }
   ]
 }

--- a/examples/schema-catalog/test/pageheader-with-actions.test.tsx
+++ b/examples/schema-catalog/test/pageheader-with-actions.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * The PageHeader docs demo renders the COMPONENT, not a hand-rolled header
+ * (objectui#3787).
+ *
+ * `layout-page-header/pageheader-with-actions` is the only runnable example on
+ * `content/docs/layout/page-header.mdx`. It used to be a `div`/`text`/`button`
+ * tree carrying Tailwind classes copied out of `PageHeader.tsx` — so the page
+ * documenting the component shipped a copy-paste reference that told authors
+ * (AI authors included) to bypass it, it exercised none of `page-header`'s
+ * rendering, and it held a third, already-drifted copy of the component's
+ * spacing numbers (objectui#3786 fixed the second copy, in the prose).
+ *
+ * Two things are pinned here, and they are different facts:
+ *
+ *  1. SHAPE — the example's root node is a `page-header`, and it contains none
+ *     of the class strings that only exist inside `PageHeader.tsx`. This is the
+ *     regression that would fire if anyone hand-rolls the header again.
+ *  2. RENDER — driven through the real `SchemaRenderer`, the node produces the
+ *     header: an `<h1>` title, the subtitle, and BOTH schema children in the
+ *     right-hand slot.
+ *
+ * (2) is worth a test rather than an eyeball because the registration for
+ * `page-header` (`packages/layout/src/index.ts`) does NOT declare
+ * `isContainer: true`, which reads like children could not reach the slot.
+ * They do: `isContainer` is registry metadata that the render path never
+ * consults (its consumers are `sdui-parser`'s `not-a-container` diagnostic, the
+ * Studio palette, and the react-page tag map). `SchemaRenderer` strips
+ * `children` from the React props but always passes the whole node as `schema`,
+ * and `PageHeader` re-introduces `schema.children` itself. That is a load-
+ * bearing coincidence of two files, so it gets a pin.
+ *
+ * Module-scope imports, not `beforeAll` (AGENTS.md §测试纪律): the child
+ * `button` node resolves through `@object-ui/components`' registration
+ * side-effects, and paying that cost at import time keeps it out of every
+ * test/hook timeout budget.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@object-ui/components';
+import { SchemaRenderer } from '@object-ui/react';
+import { registerLayout } from '@object-ui/layout';
+import { getExample } from '../src/index.js';
+
+const EXAMPLE_ID = 'layout-page-header/pageheader-with-actions';
+
+/**
+ * Class strings that exist to style the header and live in `PageHeader.tsx`
+ * (`:210`, `:211`, `:231`, `:233`). Their presence in the example JSON is the
+ * signature of a hand-rolled copy — the defect, not a styling choice.
+ */
+const COMPONENT_OWNED_CLASSES = [
+  'text-2xl',
+  'tracking-tight',
+  'text-muted-foreground',
+  'pb-4',
+];
+
+beforeAll(() => {
+  registerLayout();
+});
+
+describe('the page-header docs demo uses the page-header component (#3787)', () => {
+  it('is rooted at a `page-header` node', () => {
+    const schema = getExample(EXAMPLE_ID).schema as { type?: string };
+    expect(schema.type).toBe('page-header');
+  });
+
+  it('declares title/subtitle on the component instead of restating its classes', () => {
+    const schema = getExample(EXAMPLE_ID).schema as Record<string, unknown>;
+    expect(schema.title).toBe('Users');
+    expect(schema.subtitle).toBe('Manage your team members and permissions');
+    // The third copy of the spacing/typography numbers (#3786) is gone, and
+    // stays gone: re-hand-rolling the header re-introduces these strings.
+    const json = JSON.stringify(schema);
+    for (const cls of COMPONENT_OWNED_CLASSES) {
+      expect(json, `example JSON should not restate \`${cls}\``).not.toContain(cls);
+    }
+  });
+
+  it('renders the real header: h1 title, subtitle, and both children in the action slot', () => {
+    const { container } = render(
+      <SchemaRenderer schema={getExample(EXAMPLE_ID).schema as never} />,
+    );
+
+    // The title is the document heading — the page's Accessibility section
+    // claims an `<h1>`, and the hand-rolled demo it replaces emitted a `span`.
+    const h1 = container.querySelector('h1');
+    expect(h1?.textContent).toBe('Users');
+    expect(screen.getByText('Manage your team members and permissions')).toBeTruthy();
+
+    // Both children reach the right-hand slot despite the registration not
+    // declaring `isContainer` — see the module header.
+    expect(screen.getByRole('button', { name: 'Export' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add User' })).toBeTruthy();
+  });
+
+  it('renders the container spacing the docs Styling section states (#3786)', () => {
+    // Pins the CODE side of the three Container bullets in
+    // `content/docs/layout/page-header.mdx`: `pb-4` with no responsive
+    // variant, `gap-3` on the outer column, and a `border-b`. Changing any of
+    // them turns this red, which is the prompt to update that section — the
+    // doc drifted precisely because nothing was watching. (Mechanising the
+    // prose itself is the separate decision #3786 deferred.)
+    const { container } = render(
+      <SchemaRenderer schema={getExample(EXAMPLE_ID).schema as never} />,
+    );
+    const root = container.querySelector('[data-obj-type="page-header"]');
+    const cls = root?.className ?? '';
+
+    expect(cls).toContain('gap-3');
+    expect(cls).toContain('pb-4');
+    expect(cls).toContain('border-b');
+    // No responsive padding variant — the doc used to promise `pb-8` on desktop.
+    expect(cls).not.toMatch(/\b(sm|md|lg|xl):pb-/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       '@object-ui/fields':
         specifier: workspace:*
         version: link:../../packages/fields
+      '@object-ui/layout':
+        specifier: workspace:*
+        version: link:../../packages/layout
       '@object-ui/plugin-calendar':
         specifier: workspace:*
         version: link:../../packages/plugin-calendar
@@ -627,9 +630,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/types
     devDependencies:
+      '@object-ui/components':
+        specifier: workspace:*
+        version: link:../../packages/components
       '@object-ui/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@object-ui/layout':
+        specifier: workspace:*
+        version: link:../../packages/layout
       '@object-ui/react':
         specifier: workspace:*
         version: link:../../packages/react


### PR DESCRIPTION
Fixes #3786
Fixes #3787

两单结对一 PR(PR #3826 先例):它们是**同一组样式数值的两份漂移副本**。demo 手抄的正是 #3786 那三条已漂的数值,分开修会互相踩;demo 换成组件节点后,那组数值的第三份副本自然消灭(下面「第三份副本」一节)。

自 `origin/main` 显式 sha `a0693d531094dc7f23b8ccd992539c796b9af6e7` 切出。

---

## #3786 面 —— Styling → Container 三条

`packages/layout/src/PageHeader.tsx:210` 的根 class 现状(动笔前在 origin/main 复核过,与单里一致):

```
cn('flex flex-col gap-3 pb-4 border-b', className)
```

`content/docs/layout/page-header.mdx` 的 Container 小节按此改写,三条对三条:

| 原文 | 现状 | 改后 |
|---|---|---|
| `pb-4` on mobile, `pb-8` on desktop | `pb-4`,无任何断点变体 | `pb-4` at every breakpoint — there is no responsive variant |
| Gap: `gap-4` between elements | 外层 `gap-3`;标题行 `gap-x-4 gap-y-2`(`:211`) | `gap-3` on the outer column;标题行的 `gap-x-4 gap-y-2` 一并写明 |
| (未提) | 根节点还有 `border-b` | Border: `border-b` along the bottom edge |

内层 `gap-x-4 gap-y-2` 选择**如实展开**而不是略过:这一节的读者是拿公开 `className` 口子做覆盖的作者,只知道外层 `gap-3` 仍会算错标题与右槽之间的横向间距。

同小节的 Title(`:231`)与 Subtitle(`:233`)两块复核后与代码一致,未动。「把样式数值文档改成指向代码」的根治方向按单里的裁定**未搭车**。

## #3787 面 —— 先量再写

单里写明这是要看运行环境的活,所以第一步是两点实测。**两点的结论都和单里的猜测不同**,记在这里:

### 实测 1:`children` 能进右槽,`isContainer` 与渲染无关

单里担心 `page-header` 注册没有 `isContainer: true`(`packages/layout/src/index.ts:50-58`)会让右槽空掉。实测:不会。`isContainer` 在**渲染路径上没有任何消费者** —— 全仓消费者只有 `packages/sdui-parser/src/validate.ts:89` 的 `not-a-container` 诊断、Studio 调色板元数据(`page.tsx:464` / `react-page.tsx:66`)和 codegen 的文档表格。真正的通路是另外两处配合:`SchemaRenderer` 把 `children` 从 React props 里剥掉,但**始终**把整个节点作为 `schema` 传下去(`packages/react/src/SchemaRenderer.tsx:396`、`:456`),`PageHeader` 再自己把 `schema.children` 渲染回右槽(`PageHeader.tsx:182-190`、`:207`)。

浏览器读数(`page-header` 节点 + 两个 button children):

```
objTypes: ["page-header", "button", "button"]
h1: ["Users"]
headerRootClass: "flex flex-col gap-3 pb-4 border-b"
unknownComponent: false   exportBtn: true   addUserBtn: true
```

这条通路横跨两个文件、靠注释维系,所以配了 pin(见下)。

### 实测 2:`actions` 形态在无后端 gallery 渲染不出 —— 但卡点不是 record 上下文

单里推测第一等 `actions` 委派 `record:quick_actions` 需要 record 上下文。实测卡在更前一层:`record:quick_actions` 住在 `@object-ui/plugin-detail`,而文档站**不依赖**它。把 demo 写成 `actions` 形态的实际读数是右槽里套一块红面板:

```
demoText: "... Users / Manage your team members and permissions /
           Unknown component type: record:quick_actions ... (OBJUI-001)"
objTypes: ["page-header"]      exportBtn: false   addUserBtn: false
```

(`record:quick_actions` 本身对内联 ActionDef 数组并不需要 record 上下文 —— `needsLookup` 只在 actions 是字符串 id 时才要 `objectName`。但这里够不到那一步。)

**按单里的规则**(两条都能用才二选一,拿不到就选 children):选 **children 形态**,标题「With Actions」的语义由右槽两个按钮保留。

### 实测 3(单里没要求,但决定了这个 PR 的面):demo 换成组件节点后**根本渲染不出来**

单里提议的那份 JSON 直接落上去,文档页上是一块红面板:

```
demoText: "Unknown component type: page-header ... (OBJUI-001)"
objTypes: []
```

原因:`@object-ui/layout` 既不是 `apps/site` 的依赖,也没有任何代码 import 它(`apps/site/node_modules/@object-ui/` 下没有 symlink;`next.config.mjs` 的 `transpilePackages` 倒是列着它 —— 一条不生效的配置,已另立 #3904)。`page-header` 的占位符也接不住:它在 `placeholders.tsx` 里属于 opt-in 名单,只有 `apps/console` 调 `registerPlaceholders()`。

也就是说 **#3787 无法只靠改一份 JSON 关掉**。本 PR 补上最小的注册面:

- `apps/site/package.json` 加 `@object-ui/layout` 依赖(+ lockfile)
- 新增 `apps/site/app/components/registerLayoutBlocks.ts`,由**三个**渲染 catalog 示例的宿主 import:`InteractiveDemo`、`SchemaThumbnail`、`LiveSplitDemo`

三个而不是一个,是扫过消费半径后的结论:`SchemaThumbnail` 在 `/docs/guide/schema-catalog` 上渲染**整个** catalog,只在组件页包一层 loader 会把索引页留在红面板状态。两个页面都实测过:

| 页面 | pageHeaderCount | headerRootClass | unknownComponent |
|---|---|---|---|
| `/docs/layout/page-header` | 1 | `flex flex-col gap-3 pb-4 border-b` | false |
| `/docs/guide/schema-catalog` | 1 | `flex flex-col gap-3 pb-4 border-b` | false |

registrar 是**显式调用**的,尽管 `@object-ui/layout` 的模块体自己也会调:该包声明了 `sideEffects: false`,纯副作用 import 可以被打包器整体丢掉。这是绕行不是修复,原因写在模块头,并另立了 #3899。模块作用域调用(不是放进 effect)也保证 server render 时注册已完成,demo 留在预渲染 HTML 里。

### 顺带被消灭的:第三份副本 + 两个附带修正

demo 原来手抄了 `text-2xl font-bold tracking-tight` / `text-sm text-muted-foreground` / `gap-4 pb-4` —— 与组件、文档 Styling 小节并列的**第三份**副本,而且已经漂了(抄的正是 #3786 修掉的 `gap-4`)。换成组件节点后这份副本没有了,同一组数值回到一处。另外两条附带:

- 老 demo 每个 `div` 节点都在触发 `The "div" component is deprecated` 弃用警告,现在没有了。
- 老 demo 的标题是 `span`,整个 demo 一个 `h1` 都没有 —— 这一页的 Accessibility 小节却承诺「Semantic HTML (`h1` for title)」。现在真的渲染出 `h1: ["Users"]`。

## 测试

新增 `examples/schema-catalog/test/pageheader-with-actions.test.tsx`(4 条)。分两类事实钉:**形状**(根节点是 `page-header`;JSON 里不再出现只属于 `PageHeader.tsx` 的 class 串 —— 有人再手搓就红)与**渲染**(走真 `SchemaRenderer`,断言 `h1` 标题、副标题、两个 children 都到右槽)。第 4 条钉住 #3786 那三条数值的**代码侧**:`gap-3` / `pb-4` / `border-b` 都在,且不含 `sm|md|lg|xl:pb-` 断点变体 —— class 一改就红,提示回来同步文档。钉代码侧不是单里推迟的那个「文档改成指向代码」的根治方案,只是普通组件 pin。

反向验证(方向**事前**判定为红):把手搓 div 版 JSON 放回去,4 条**全红**,且第 4 条是在**正向断言**上失败而不是空过 —— 这条尤其要看清,因为 `page-header` 根节点不存在时 `className` 取到空串,末尾那句 `not.toMatch` 本身是会空过的:

```
× is rooted at a `page-header` node
× declares title/subtitle on the component instead of restating its classes
× renders the real header: h1 title, subtitle, and both children in the action slot
× renders the container spacing the docs Styling section states (#3786)
AssertionError: expected 'div' to be 'page-header'
AssertionError: expected undefined to be 'Users'
AssertionError: expected '' to contain 'gap-3'
Test Files  1 failed (1)      Tests  4 failed (4)
```

`examples/schema-catalog` 的 tsconfig `exclude` 了 `test/`(既有两个测试同此),所以仓库门禁不做这个文件的类型检查;另跑了一次定向 `tsc --noEmit` 通过。

## 门禁

- `pnpm exec vitest run examples/schema-catalog packages/layout --maxWorkers=2` → **9 files / 944 tests passed**
- `pnpm exec turbo run type-check --concurrency=2` → **78/78 successful**(`apps/site` 没有 `type-check` task,单独跑了 `pnpm --filter @object-ui/site types:check`,通过)
- `pnpm exec eslint`(全部改动文件)→ 0 errors(`LiveSplitDemo` 的 2 条 `set-state-in-effect` warning 在 `:153-156`,既有代码,与本次 import 无关)
- `node scripts/check-doc-links.mjs` → Links are valid across 7 scan roots
- `node scripts/check-control-bytes.mjs` → OK;改动文件另做 `grep -naP` 控制字节自扫,零命中
- `node scripts/check-changeset-presence.mjs` → **No source of a released package changed in this range, so no changeset is owed**(改动全部落在 `content/docs`、`examples/schema-catalog`、`apps/site`,无 released 包的 `src/`)
- 起过的 dev server(:5241)已按记下的 PID 收净,端口已释放;临时 probe 脚本已删

浏览器实证用仓库自带 Playwright + Next dev,截图与读数见上;完整 demo 外观:图标块 + 加粗 `h1` 标题 + 副标题 + 右对齐 Export / Add User + 底部 `border-b`。

## 越界发现(均已另立单,本 PR 不碰)

- #3899 — `packages/layout` 声明 `sideEffects: false` 却把注册放在模块加载副作用里,纯副作用 import 可被 tree-shake 掉(本 PR 显式调 registrar 绕开)
- #3900 — `page-header` 注册缺 `isContainer: true`,而组件与文档都认 `schema.children`,sdui-parser 因此对本 PR 的 demo 写法报 `not-a-container`
- #3902 — 同一文档页 Responsive Behavior 的「Spacing: Adjusts padding for different screen sizes」是 #3786 那个假断言的第四份副本(在 #3786 钉定的面之外)
- #3903 — Schema Catalog 索引页把缩略图包在 `button` 里,85 个含 button 节点的示例都触发嵌套按钮 hydration 报错(**先于本 PR 存在**)
- #3904 — Playground 是第四个渲染宿主、仍未注册 layout;`transpilePackages` 还列着两个非依赖包

## 协调

不碰 `PageHeader.tsx` 本体(两单都是文档/示例面);与在飞 #3852(cli)、#3838(plugin-detail)、#3837(app-shell/ai)零文件相交;#3789(`description` 退役,`pm:blocked`)未碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_