### PR TITLE
fix(plugin-detail): 相关列表 Add 选择器兑现 add.picker.filter,作者限定的候选范围真的生效 (#3831)

### DIFF
--- a/.changeset/related-list-add-picker-filter-3831.md
+++ b/.changeset/related-list-add-picker-filter-3831.md
@@ -1,0 +1,17 @@
+---
+"@object-ui/fields": patch
+"@object-ui/plugin-detail": patch
+---
+
+相关列表 Add 选择器兑现 `add.picker.filter`:作者限定的候选范围现在真的生效
+
+`record:related_list.add.picker.filter` 被 spec 声明为「Restrict which records the picker offers」,但渲染器从未读过它 —— 挂 `RecordPickerDialog` 时不传任何 filter,对话框照样提供 `picker.object` 的全部记录,选中即建链接行或改父,`os validate` / `os build` 全绿、运行时零诊断。作者写下「只允许指派 active 的岗位」「只允许挂未过期的许可」,得到的是完整候选列表。
+
+现在它按原样传给 `RecordPickerDialog` 的 `baseFilter` —— 不是 `lookupFilters`,后者会把条件渲染成用户可编辑的筛选栏行,等于把作者的硬性限制降级成建议。
+
+`baseFilter` 因此接受两种形状,按结构判别(`Array.isArray`):
+
+- **`QueryParams.$filter` 记录形式**(依赖型 lookup 链)保持原有的键覆盖语义逐字节不变 —— 级联父值必须**替换**同字段上过期的 `lookupFilters` 条目,而不是与之求交。
+- **spec 的 `ViewFilterRule[]`** 经 `mergeFilterNodes`(仓内唯一的 filter 下沉口)下沉,19 个 operator 全部无损到达服务端,包括记录形式没有 `$op` 可用的 `before` / `after` / `is_empty` / `is_not_empty`。此处**不新增**第二份 operator 词汇表。
+
+槽位类型同时从 `Record<string, any>` 收紧为 `unknown`:前者会接受规则数组(数组满足 `any` 的字符串索引),旧的对象展开再把它压成 `{"0": {...}}`,于是查询去过滤名为 `0` 的列 —— 类型全绿、查询错误、无任何诊断。

--- a/packages/fields/src/widgets/RecordPickerDialog.baseFilterShapes.test.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.baseFilterShapes.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RecordPickerDialog.baseFilter` accepts TWO shapes — objectui#3831.
+ *
+ * The slot was declared `Record< string, any >` and merged by object spread,
+ * which serves the dependent-lookup chain (#2215) exactly right and cannot
+ * carry a spec `ViewFilterRule[]` at all: TypeScript accepts an array there
+ * (an array satisfies a string index of `any`), the spread flattens it to
+ * `{"0": rule, "1": rule}`, and the query then filters on columns literally
+ * named `0`/`1` — green types, wrong query, no diagnostic. That is the slot
+ * `record:related_list.add.picker.filter` has to reach.
+ *
+ * So the merge now discriminates on shape, and both directions are pinned here:
+ *
+ *  - **record form** keeps KEY-OVERWRITE precedence, byte for byte. A cascaded
+ *    parent value must REPLACE a stale same-field `lookupFilters` entry, not
+ *    intersect with it — `account = 'stale' AND account = 'a1'` returns nothing.
+ *    (`LookupField.dependsOn.test.tsx` owns the #2215 behaviour end-to-end and
+ *    is deliberately left untouched; this file pins the same precedence at the
+ *    dialog's own boundary, so a future merge change cannot pass by only
+ *    satisfying the array path.)
+ *  - **rule array** lowers through `mergeFilterNodes`, the repo's single filter
+ *    sink, so all 19 `VIEW_FILTER_OPERATORS` survive — including the four
+ *    (`before`, `after`, `is_empty`, `is_not_empty`) the MongoDB-style record
+ *    form has no `$op` for and which a hand-rolled second lowering would have
+ *    had to drop or throw on.
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { RecordPickerDialog } from './RecordPickerDialog';
+
+const records = [{ id: 'r1', name: 'One' }];
+
+function makeDataSource() {
+  const find = vi.fn(async () => ({ data: records, total: records.length }));
+  return { find } as any;
+}
+
+/** The `$filter` of the most recent query. */
+function lastFilter(ds: any) {
+  const calls = ds.find.mock.calls;
+  return calls[calls.length - 1][1]?.$filter;
+}
+
+describe('RecordPickerDialog baseFilter — record form (#2215 precedence)', () => {
+  it('spreads a record baseFilter last, overwriting lookupFilters on the same field', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="contacts"
+        onSelect={vi.fn()}
+        lookupFilters={[{ field: 'account', operator: 'eq', value: 'stale' }]}
+        baseFilter={{ account: 'a1' }}
+      />,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    // Still the plain record form — NOT lowered to an AST, and emphatically not
+    // an `and` of the stale value with the cascaded one.
+    expect(lastFilter(ds)).toEqual({ account: 'a1' });
+    expect(Array.isArray(lastFilter(ds))).toBe(false);
+  });
+
+  it('sends no $filter at all when nothing is constrained', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="contacts"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(lastFilter(ds)).toBeUndefined();
+  });
+});
+
+describe('RecordPickerDialog baseFilter — spec ViewFilterRule[] (#3831)', () => {
+  it('lowers a rule array to AST nodes instead of spreading it into index keys', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="sys_position"
+        onSelect={vi.fn()}
+        baseFilter={[{ field: 'is_active', operator: 'equals', value: true }]}
+      />,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(lastFilter(ds)).toEqual([['is_active', 'equals', true]]);
+    // The old object-spread failure mode, pinned by structure rather than by
+    // key: the spread produced a PLAIN OBJECT whose values were still rule
+    // objects (`{"0": {field, operator, value}}`), so the query asked for a
+    // column named `0`. Asserting on `Object.keys` cannot tell the two apart —
+    // an array's keys are its indices too — so what is pinned is that each
+    // element is an AST TRIPLE and no longer carries a `field` member.
+    const filter = lastFilter(ds) as unknown[];
+    expect(Array.isArray(filter)).toBe(true);
+    expect(Array.isArray(filter[0])).toBe(true);
+    expect(filter[0]).not.toHaveProperty('field');
+  });
+
+  it('preserves the four operators the record form cannot spell', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="sys_license"
+        onSelect={vi.fn()}
+        baseFilter={[
+          { field: 'starts_at', operator: 'before', value: '2026-01-01' },
+          { field: 'expires_at', operator: 'after', value: '2026-01-01' },
+          { field: 'revoked_at', operator: 'is_empty' },
+          { field: 'assigned_to', operator: 'is_not_empty' },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(lastFilter(ds)).toEqual([
+      ['starts_at', 'before', '2026-01-01'],
+      ['expires_at', 'after', '2026-01-01'],
+      // A rule with no `value` stays two-element: inventing `null` here would be
+      // a real `{revoked_at: null}` predicate, i.e. a different question.
+      ['revoked_at', 'is_empty'],
+      ['assigned_to', 'is_not_empty'],
+    ]);
+  });
+
+  it('keeps a record baseFilter and a rule array as separate `and` children', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="sys_position"
+        onSelect={vi.fn()}
+        // A rule array is the author's restriction; the record-form base still
+        // arrives via `lookupFilters` here, and the two must BOTH apply.
+        lookupFilters={[{ field: 'company', operator: 'eq', value: 'c1' }]}
+        baseFilter={[{ field: 'is_active', operator: 'equals', value: true }]}
+      />,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(lastFilter(ds)).toEqual([
+      'and',
+      ['company', '=', 'c1'],
+      [['is_active', 'equals', true]],
+    ]);
+  });
+
+  it('sends no $filter for an empty rule array', async () => {
+    const ds = makeDataSource();
+    render(
+      <RecordPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        dataSource={ds}
+        objectName="sys_position"
+        onSelect={vi.fn()}
+        baseFilter={[]}
+      />,
+    );
+
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    // An empty restriction is no restriction — not an empty `$filter` the wire
+    // has to interpret.
+    expect(lastFilter(ds)).toBeUndefined();
+  });
+});

--- a/packages/fields/src/widgets/RecordPickerDialog.tsx
+++ b/packages/fields/src/widgets/RecordPickerDialog.tsx
@@ -38,6 +38,10 @@ import {
   X,
 } from 'lucide-react';
 import type { DataSource, LookupColumnDef, LookupFilterDef } from '@object-ui/types';
+// The repo's single filter sink (`packages/core/src/utils/filter-converter.ts`)
+// — shared with plugin-list's `buildEffectiveFilter` and plugin-view's
+// ObjectView, so a spec `ViewFilterRule[]` lowers in exactly one place.
+import { mergeFilterNodes } from '@object-ui/core';
 import { useSafeFieldLabel } from '@object-ui/i18n';
 import { useFieldTranslation } from './useFieldTranslation';
 import { useRecordQuery } from './useRecordQuery';
@@ -360,13 +364,39 @@ export interface RecordPickerDialogProps {
   lookupFilters?: LookupFilterDef[];
 
   /**
-   * Hard filter constraints applied to every query, in QueryParams.$filter
-   * record form. Unlike `lookupFilters`, entries here never surface in the
-   * filter bar and cannot be overridden by user filter input — used for the
-   * dependent (cascading) lookup chain, where the parent field's value MUST
-   * scope the candidate set (#2215).
+   * Hard filter constraint applied to every query. Unlike `lookupFilters`,
+   * entries here never surface in the filter bar and cannot be overridden by
+   * user filter input.
+   *
+   * Two shapes, discriminated STRUCTURALLY (`Array.isArray`), because the two
+   * callers speak two legitimate vocabularies and neither should be bent into
+   * the other:
+   *
+   * - **`QueryParams.$filter` record form** (`{ account: 'a1' }`) — the
+   *   dependent (cascading) lookup chain, where the parent field's value MUST
+   *   scope the candidate set (#2215). Merged by KEY OVERWRITE, so a cascaded
+   *   value REPLACES a stale `lookupFilters` entry on the same field instead of
+   *   intersecting with it. That precedence is load-bearing: an `and` of both
+   *   would ask for `account = 'stale' AND account = 'a1'` and return nothing.
+   * - **A spec `ViewFilterRule[]`** (`[{ field, operator, value? }]`) — an
+   *   author's `record:related_list.add.picker.filter`, handed over VERBATIM
+   *   (#3831). Lowered by `mergeFilterNodes`, the repo's single filter sink, so
+   *   all 19 `VIEW_FILTER_OPERATORS` reach the wire — including the four
+   *   (`before`, `after`, `is_empty`, `is_not_empty`) the record form has no
+   *   `$op` for. No second operator vocabulary is introduced here: two already
+   *   exist (the spec's `AST_OPERATOR_MAP`, data-objectstack's
+   *   `FILTER_OPERATOR_ALIASES`) and #3948 is what a third costs.
+   *
+   * The discriminator is exact rather than heuristic — every AST node is an
+   * ARRAY and a rule is a plain OBJECT, the same predicate `toFilterNode` uses.
+   *
+   * Typed `unknown` rather than `Record< string, any >` on purpose: that type
+   * ACCEPTED a rule array (TypeScript lets an array satisfy a string index of
+   * `any`), the old object-spread merge then flattened it to
+   * `{"0": {...}, "1": {...}}`, and the query filtered on columns literally
+   * named `0`/`1` — type-check green, wrong query, no diagnostic anywhere.
    */
-  baseFilter?: Record<string, any>;
+  baseFilter?: unknown;
 
   /**
    * Cell renderer resolver function.
@@ -586,18 +616,34 @@ export function RecordPickerDialog({
     });
   }, [baseFilterColumns, fieldsMeta, objectName, translateOptions]);
 
-  // Merge base lookup_filters with user filter bar values. The hard
-  // `baseFilter` constraint (dependent-lookup chain, #2215) is spread LAST so
-  // user filter-bar input can never widen it back out.
-  const mergedFilter = useMemo<Record<string, any> | undefined>(() => {
+  // Merge base lookup_filters with user filter bar values, then apply the hard
+  // `baseFilter` constraint BY SHAPE (see the prop's own doc for why the two
+  // shapes exist):
+  //
+  //   record form → spread LAST, exactly as this merge has always done, so
+  //                 user filter-bar input can never widen it back out and a
+  //                 cascaded parent value replaces a stale same-field
+  //                 `lookupFilters` entry (#2215).
+  //   rule array  → its OWN `and` child via `mergeFilterNodes`, the shared
+  //                 sink, so a spec `ViewFilterRule[]` lowers losslessly
+  //                 (#3831) instead of being spread into `{0: rule}`.
+  //
+  // When BOTH are in play the record side is still built first and lowered as
+  // one node, so its key-overwrite precedence survives the conjunction.
+  const mergedFilter = useMemo<unknown>(() => {
     const lookupBase = lookupFilters?.length
       ? lookupFiltersToRecord(lookupFilters)
       : {};
     const userFilter = effectiveFilterColumns?.length
       ? filterValuesToRecord(filterValues, effectiveFilterColumns)
       : {};
-    const combined = { ...lookupBase, ...userFilter, ...(baseFilter ?? {}) };
-    return Object.keys(combined).length > 0 ? combined : undefined;
+    const rules = Array.isArray(baseFilter) ? baseFilter : undefined;
+    const recordBase = rules
+      ? undefined
+      : (baseFilter as Record<string, any> | undefined);
+    const combined = { ...lookupBase, ...userFilter, ...(recordBase ?? {}) };
+    const record = Object.keys(combined).length > 0 ? combined : undefined;
+    return rules ? mergeFilterNodes(record, rules) : record;
   }, [lookupFilters, effectiveFilterColumns, filterValues, baseFilter]);
 
   // Shared query kernel: builds params, fetches, and owns records/loading/error/

--- a/packages/fields/src/widgets/useRecordQuery.ts
+++ b/packages/fields/src/widgets/useRecordQuery.ts
@@ -56,8 +56,14 @@ export interface UseRecordQueryOptions {
    * `$filter` — already merged by the caller (base `lookup_filters`, dependent
    * lookup chain, candidate hygiene like `banned != true`, …). Compared by
    * value, so a referentially-new-but-equal object each render will not loop.
+   *
+   * Either the `QueryParams.$filter` record form or a lowered ObjectQL AST node
+   * (an array), since the picker's merge now produces both (#3831). Typed
+   * `unknown` rather than `Record< string, any >` so an array cannot slip
+   * through a type that silently accepts it; emptiness is decided by
+   * {@link hasFilter}, not by `Object.keys`.
    */
-  filter?: Record<string, any>;
+  filter?: unknown;
   /** `$expand` — related entities to include (e.g. `['primary_business_unit_id']`). */
   expand?: string[];
   /** `$searchFields` — narrow the server searchable set (ADR-0061). */
@@ -97,6 +103,22 @@ export interface UseRecordQueryResult {
   refetch: () => void;
 }
 
+/**
+ * Is this filter source worth sending as `$filter` at all?
+ *
+ * Array-aware on purpose. The picker's merge yields either the
+ * `QueryParams.$filter` record form or a lowered ObjectQL AST node (#3831), and
+ * `Object.keys` on an array returns its INDICES — so the record-only test read
+ * `['0','1','2']` for an AST node and was right only by accident. An empty array
+ * is "no filter" for the same reason an empty object is.
+ */
+function hasFilter(filter: unknown): boolean {
+  if (filter === null || filter === undefined) return false;
+  if (Array.isArray(filter)) return filter.length > 0;
+  if (typeof filter !== 'object') return false;
+  return Object.keys(filter as object).length > 0;
+}
+
 export function useRecordQuery(options: UseRecordQueryOptions): UseRecordQueryResult {
   const {
     dataSource,
@@ -123,7 +145,7 @@ export function useRecordQuery(options: UseRecordQueryOptions): UseRecordQueryRe
   // Stable signatures for object/array inputs so the fetch effect keys on their
   // *value*, not a fresh reference every render.
   const filterSignature = useMemo(
-    () => (filter && Object.keys(filter).length ? JSON.stringify(filter) : ''),
+    () => (hasFilter(filter) ? JSON.stringify(filter) : ''),
     [filter],
   );
   const expandSignature = useMemo(() => (expand?.length ? expand.join(',') : ''), [expand]);
@@ -150,7 +172,12 @@ export function useRecordQuery(options: UseRecordQueryOptions): UseRecordQueryRe
         if (searchTerm && searchTerm.trim()) params.$search = searchTerm.trim();
         if (searchFields && searchFields.length > 0) params.$searchFields = searchFields;
         if (sortArg) params.$orderby = { [sortArg.field]: sortArg.direction };
-        if (filter && Object.keys(filter).length > 0) params.$filter = filter;
+        // `QueryParams.$filter` is declared `Record< string, any >`, which the
+        // AST-array form does not describe — the cast is at this ONE assignment
+        // rather than widening a shared type that several other producers
+        // (plugin-list's `buildEffectiveFilter`, plugin-view's ObjectView)
+        // already feed arrays through.
+        if (hasFilter(filter)) params.$filter = filter as Record<string, any>;
         if (expand && expand.length > 0) params.$expand = expand;
 
         const result = await dataSource.find(objectName, params);

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -39,6 +39,7 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import type { DataSource, FieldMetadata } from '@object-ui/types';
+import type { ViewFilterRule } from '@objectstack/spec/ui';
 import { getCellRenderer, resolveCellRendererType, RecordPickerDialog, deriveLookupColumns } from '@object-ui/fields';
 import {
   columnIdentity,
@@ -79,9 +80,19 @@ export interface RelatedListProps {
    * case), or — when `linkField` is omitted — re-parents the picked child by
    * setting its `referenceField` to `parentId` (1:m case). Server-side rules on
    * insert (e.g. the AI-seat cap) surface as an inline error.
+   *
+   * `picker.filter` restricts which records the dialog offers, and is typed as
+   * the spec's own `ViewFilterRule[]` rather than `any` (#3831): it goes to
+   * `RecordPickerDialog`'s `baseFilter` VERBATIM, so the authored vocabulary is
+   * the one enforced — a looser type here is where a wrong shape would hide.
    */
   add?: {
-    picker: { object: string; valueField?: string; labelField?: string; filter?: any };
+    picker: {
+      object: string;
+      valueField?: string;
+      labelField?: string;
+      filter?: ViewFilterRule[];
+    };
     linkField?: string;
     label?: string;
   };
@@ -1334,6 +1345,12 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           columns={pickerColumns}
           cellRenderer={getCellRenderer}
           fieldsMeta={pickerSchema?.fields}
+          // The author's candidate restriction, handed over VERBATIM (#3831).
+          // `baseFilter` — never `lookupFilters`, which renders its entries as
+          // filter-bar rows the user can edit, i.e. demotes the restriction to a
+          // suggestion. The picker lowers the rule array through the repo's
+          // single filter sink, so no conversion belongs on this side.
+          baseFilter={add.picker.filter}
           onSelect={() => {}}
           onSelectRecords={(records: any[]) => { void handleAddRecords(records); }}
         />

--- a/packages/plugin-detail/src/__tests__/RelatedList.addPickerFilter.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.addPickerFilter.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3831 — the related-list Add picker must honour
+ * `add.picker.filter`.
+ *
+ * The spec declares it ("Restrict which records the picker offers") and, until
+ * this fix, nothing in the repo read it: the dialog mount passed `objectName` /
+ * `title` / `displayField` / `columns` / `cellRenderer` / `fieldsMeta` /
+ * `multiple` / `onSelect` / `onSelectRecords` and no filter at all. An author
+ * who scoped the candidate set — only ACTIVE positions may be assigned, only
+ * unexpired licences may be attached — got every record of `picker.object`,
+ * with `os validate` / `os build` silently green and no runtime diagnostic. The
+ * pick then created the link row or re-parented outright.
+ *
+ * It is wired to `baseFilter`, not `lookupFilters`: `lookupFilters` renders its
+ * entries as filter-bar rows the user can edit, which would turn the author's
+ * restriction into a suggestion. `baseFilter` never surfaces in the UI and
+ * cannot be widened back out.
+ *
+ * These assertions read the `$filter` the picker's own query carries, i.e. the
+ * question actually asked of the data source — not merely that a prop was
+ * threaded somewhere.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { RelatedList } from '../RelatedList';
+
+// The list body itself is irrelevant here — only the Add dialog matters.
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, SchemaRenderer: () => null };
+});
+
+const junctionSchema = {
+  name: 'sys_user_position',
+  fields: {
+    position: { type: 'lookup', label: 'Position', reference_to: 'sys_position' },
+  },
+};
+
+const positionSchema = {
+  name: 'sys_position',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    is_active: { type: 'boolean', label: 'Active' },
+  },
+};
+
+const makeDataSource = () => ({
+  getObjectSchema: vi.fn(async (api: string) =>
+    api === 'sys_position' ? positionSchema : junctionSchema,
+  ),
+  find: vi.fn(async (api: string) =>
+    api === 'sys_position'
+      ? { data: [{ id: 'p1', name: 'Nurse', is_active: true }], total: 1 }
+      : { data: [], total: 0 },
+  ),
+});
+
+/** `$filter` of the most recent query against the PICKER's object. */
+function lastPickerFilter(ds: any) {
+  const calls = ds.find.mock.calls.filter((c: any[]) => c[0] === 'sys_position');
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1][1]?.$filter;
+}
+
+const renderList = (ds: any, filter?: any) =>
+  render(
+    <RelatedList
+      title="Holders"
+      type="table"
+      api="sys_user_position"
+      objectName="sys_user_position"
+      referenceField="user_id"
+      parentId="u_1"
+      columns={[{ accessorKey: 'position', header: 'Position' }]}
+      dataSource={ds}
+      add={{
+        picker: { object: 'sys_position', ...(filter ? { filter } : {}) },
+        linkField: 'position',
+        label: 'Assign position',
+      }}
+    />,
+  );
+
+const openPicker = () =>
+  fireEvent.click(screen.getByRole('button', { name: /Assign position/ }));
+
+describe('RelatedList Add picker — add.picker.filter (#3831)', () => {
+  it('scopes the picker query with the authored restriction', async () => {
+    const ds = makeDataSource();
+    renderList(ds, [{ field: 'is_active', operator: 'equals', value: true }]);
+    openPicker();
+
+    await waitFor(() => expect(lastPickerFilter(ds)).toBeDefined());
+    // Lowered by the shared filter sink, so the rule reaches the wire as an AST
+    // node rather than as a bare rule object the server refuses.
+    expect(lastPickerFilter(ds)).toEqual([['is_active', 'equals', true]]);
+  });
+
+  it('carries every rule of a multi-rule restriction, operators intact', async () => {
+    const ds = makeDataSource();
+    renderList(ds, [
+      { field: 'is_active', operator: 'equals', value: true },
+      // Two rules on ONE field — a range the field-keyed record form could not
+      // have expressed without merging them by hand.
+      { field: 'headcount', operator: 'greater_than', value: 0 },
+      { field: 'headcount', operator: 'less_than', value: 100 },
+      // The operators with no MongoDB-style `$op`, hence no lossless record
+      // representation: `before`/`after` and the emptiness pair.
+      { field: 'starts_at', operator: 'before', value: '2026-06-01' },
+      { field: 'ends_at', operator: 'after', value: '2026-01-01' },
+      { field: 'retired_at', operator: 'is_empty' },
+    ]);
+    openPicker();
+
+    await waitFor(() => expect(lastPickerFilter(ds)).toBeDefined());
+    expect(lastPickerFilter(ds)).toEqual([
+      ['is_active', 'equals', true],
+      ['headcount', 'greater_than', 0],
+      ['headcount', 'less_than', 100],
+      ['starts_at', 'before', '2026-06-01'],
+      ['ends_at', 'after', '2026-01-01'],
+      ['retired_at', 'is_empty'],
+    ]);
+  });
+
+  it('leaves the picker unfiltered when the author declared no restriction', async () => {
+    const ds = makeDataSource();
+    renderList(ds);
+    openPicker();
+
+    await waitFor(() => expect(ds.getObjectSchema).toHaveBeenCalledWith('sys_position'));
+    await waitFor(() =>
+      expect(ds.find.mock.calls.some((c: any[]) => c[0] === 'sys_position')).toBe(true),
+    );
+    // No `add.picker.filter` → no `$filter`. The status quo for every existing
+    // related list stays exactly as it was.
+    expect(lastPickerFilter(ds)).toBeUndefined();
+  });
+
+  it('does not demote the restriction into an editable filter-bar row', async () => {
+    const ds = makeDataSource();
+    renderList(ds, [{ field: 'is_active', operator: 'equals', value: true }]);
+    openPicker();
+
+    await waitFor(() => expect(lastPickerFilter(ds)).toBeDefined());
+    // `lookupFilters` is what derives the picker's filter bar; routing the
+    // author's restriction there would have published it as a user-editable
+    // suggestion. Its absence is the observable difference.
+    expect(screen.queryByTestId('record-picker-filter-panel')).toBeNull();
+    expect(screen.queryByRole('button', { name: /filters/i })).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts
@@ -160,17 +160,21 @@ describe('record:related_list — registry inputs vs @objectstack/spec', () => {
     expect(description).not.toMatch(/labelField[^.]*title field/);
   });
 
-  it('names `picker.filter` as a gap instead of documenting it as a restriction', () => {
-    // The `record:activity.showSubscriptionToggle` precedent applied at member
-    // level. The spec declares `add.picker.filter` ("Restrict which records the
-    // picker offers") and nothing in this repo reads it — `RelatedList` fills
-    // `RecordPickerDialog`'s `objectName` / `displayField` / `columns` and never
-    // its `baseFilter` slot. A description that merely listed `filter` among the
-    // members would tell an author their picker is scoped when it offers every
-    // record; objectui#3831 owns the wiring, and this assertion fails the moment
-    // someone deletes the warning without doing it.
+  it('documents `picker.filter` as a real restriction, with no gap warning left over', () => {
+    // The INVERSE of the assertion this used to carry. Until #3831 the spec
+    // declared `add.picker.filter` ("Restrict which records the picker offers")
+    // and nothing in this repo read it, so the description named it as a KNOWN
+    // GAP on the `record:activity.showSubscriptionToggle` precedent. The wiring
+    // landed (`RelatedList` hands it to `RecordPickerDialog`'s `baseFilter`
+    // verbatim), so the warning had to go — and this direction now fails if
+    // anyone puts a gap warning back, or reverts the wiring and leaves the
+    // description claiming a restriction the dialog does not apply.
     expect(specPickerKeys()).toContain('filter');
-    expect(addDescription()).toMatch(/KNOWN GAP/);
-    expect(addDescription()).toMatch(/filter[\s\S]*not applied/);
+    expect(addDescription()).not.toMatch(/KNOWN GAP/);
+    expect(addDescription()).not.toMatch(/not applied/);
+    expect(addDescription()).toMatch(/`picker\.filter` restricts which records/);
+    // The restriction must be published as un-widenable, not as a suggestion:
+    // `lookupFilters` would have rendered it as an editable filter-bar row.
+    expect(addDescription()).toMatch(/hard constraint the user cannot widen/);
   });
 });

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -339,14 +339,14 @@ ComponentRegistry.register('related_list', RecordRelatedListRenderer, {
     // says. Publishing the spec's wording there would have been a description
     // the platform does not honour.
     //
-    // `picker.filter` is deliberately NOT documented as working: the spec
-    // declares it, and nothing in this repo reads it — `RelatedList` passes
-    // `picker.object` / `labelField` to `RecordPickerDialog` and never fills its
-    // `baseFilter` slot. Naming it here as a gap follows the
-    // `record:activity.showSubscriptionToggle` precedent above; silently
-    // documenting it as a restriction would tell an author their picker is
-    // scoped when it offers every record.
-    { name: 'add', type: 'object', label: 'Add Existing', description: 'Adds an "Add" button that assigns EXISTING records instead of creating one — the m2m/junction case. Shape: `{ picker: { object, valueField?, labelField?, filter? }, linkField?, label? }`. `picker.object` (required) is the object whose records the dialog offers. `picker.valueField` is the field of the picked record used as the link value (default "id"); `picker.labelField` is the column shown in the picker rows (default "name", and the other columns are derived from that object\'s schema). With `linkField` set, selecting records CREATES rows in this list\'s own object as `{ [relationshipField]: parentValue, [linkField]: pickedId }` — the junction case; omit `linkField` and the picked child is RE-PARENTED instead, by setting its own `relationshipField` to this parent. `label` is the button text (default "Add", localizable inline). Setting `add` also enables generic link removal on rows when no host delete handler is wired. KNOWN GAP: `picker.filter` is accepted by the spec but not applied — the dialog offers every record of `picker.object` whatever you put there.' },
+    // `picker.filter` IS documented as working since #3831 wired it: it reaches
+    // `RecordPickerDialog`'s `baseFilter` verbatim (`RelatedList.tsx`, at the
+    // dialog mount), which is the un-editable slot — not `lookupFilters`, whose
+    // entries become filter-bar rows the user can widen back out. It carried a
+    // KNOWN GAP sentence here until then, on the
+    // `record:activity.showSubscriptionToggle` precedent; the sentence went away
+    // with the gap, not before it.
+    { name: 'add', type: 'object', label: 'Add Existing', description: 'Adds an "Add" button that assigns EXISTING records instead of creating one — the m2m/junction case. Shape: `{ picker: { object, valueField?, labelField?, filter? }, linkField?, label? }`. `picker.object` (required) is the object whose records the dialog offers. `picker.valueField` is the field of the picked record used as the link value (default "id"); `picker.labelField` is the column shown in the picker rows (default "name", and the other columns are derived from that object\'s schema). With `linkField` set, selecting records CREATES rows in this list\'s own object as `{ [relationshipField]: parentValue, [linkField]: pickedId }` — the junction case; omit `linkField` and the picked child is RE-PARENTED instead, by setting its own `relationshipField` to this parent. `label` is the button text (default "Add", localizable inline). Setting `add` also enables generic link removal on rows when no host delete handler is wired. `picker.filter` restricts which records the dialog offers — a list of `{ field, operator, value }` rules in the same vocabulary as this list\'s own `filter`, applied as a hard constraint the user cannot widen (it never appears as an editable filter row).' },
   ],
 });
 


### PR DESCRIPTION
Fixes #3831

`record:related_list.add.picker.filter` 被 spec 声明为「Restrict which records the picker offers」,渲染器从未读过它。`RelatedList` 挂 `RecordPickerDialog` 时传 `objectName` / `title` / `displayField` / `columns` / `cellRenderer` / `fieldsMeta` / `multiple` / `onSelect` / `onSelectRecords`,没有任何 filter。作者写下「只允许指派 active 的岗位」「只允许挂未过期的许可」,拿到的是 `picker.object` 的**全部**记录;选中后 `handleAddRecords` 直接建链接行或改父,`os validate` / `os build` 全绿,运行时零诊断 —— 作者只能靠肉眼发现对话框里多出了不该出现的记录。

现在它按原样传给 `baseFilter`,**不是** `lookupFilters`:后者会把条件渲染成用户可编辑的筛选栏行,等于把作者的硬性限制降级成建议。

## 更正 issue 正文的一处误述

正文写「`picker.filter` 在 pin 版是宽类型」。实读 `@objectstack/spec@17.0.0-rc.5`(`src/ui/component.zod.ts:308`):

```
filter: z.array(ViewFilterRuleSchema).optional().describe('Restrict which records the picker offers.'),
```

是**严格的 `ViewFilterRule[]`** —— `{field, operator, value?}`,operator 为 19 个 canonical 值的 enum,与 list 级 `filter`、`ListViewSchema.filter`、`ViewTab.filter` 同族。spec 侧无需任何收敛,但形状差距因此比正文预期的大,见下。

## 为什么改动落到了 packages/fields

派发时的围栏是「只在 RelatedList 侧接线」。复核后发现在该围栏内**无法无损接线**,已带证据上报并由维护者裁决放宽(#3831 评论)。原因:

`baseFilter` 声明为 `Record< string, any >`、以对象展开合并。这个形状服务依赖型 lookup 链(#2215)恰好正确,却装不下 spec 的规则数组 —— TS **接受**数组塞进该槽位(数组满足 `any` 的字符串索引,`tsc --strict` 实测 exit 0),展开再把它压成 `{"0": rule, "1": rule}`,查询于是去过滤名为 `0` / `1` 的列:类型全绿、查询错误、无任何诊断。

绕开它只剩一条路:在 objectui 里再写一份 spec-operator 词汇表。而这份词汇表已存在**两份**(spec 的 `AST_OPERATOR_MAP`、data-objectstack 的 `FILTER_OPERATOR_ALIASES`),`filter-converter.ts` 的文档块以「One lowering, one place」明确反对第三份,并引 #3948 说明两份的代价。实测记录方言确实装不下全部 operator:

```
{ amount: { $gt: 10, $lte: 100 } }        => ["and",["amount",">",10],["amount","<=",100]]   OK
{ expires_at: { $after: '2026-01-01' } }  => THROWS FilterOperatorError: Unknown filter operator '$after'
{ deleted_at: { $isEmpty: true } }        => THROWS FilterOperatorError: Unknown filter operator '$isEmpty'
```

## 落地形状

`baseFilter` 按结构判别(`Array.isArray`)接受两种形状。判别子是**精确**而非启发式的 —— AST 节点必是数组、规则必是普通对象,与 `toFilterNode` 同一谓词:

- **记录形式**(依赖型 lookup 链)保持键覆盖语义**逐字节不变**:级联父值必须**替换**同字段上过期的 `lookupFilters` 条目,而不是与之求交。这一点承重 —— 朴素改成合取会问 `account = 'stale' AND account = 'a1'`,返回零行。`LookupField.dependsOn.test.tsx` 一行未动且保持绿。
- **规则数组**经 `mergeFilterNodes`(仓内唯一 filter 下沉口,与 plugin-list 的 `buildEffectiveFilter`、plugin-view 的 ObjectView 共用)下沉,19 个 operator 全部无损,包括记录形式没有 `$op` 可用的 `before` / `after` / `is_empty` / `is_not_empty`。两者同时在场时,记录侧仍先合成再作为一个节点下沉,键覆盖优先级在合取中存活。

槽位类型同时从 `Record< string, any >` 收紧为 `unknown`;`useRecordQuery` 的 filter 类型与空判随之数组感知(`Object.keys` 对数组返回下标,旧的记录专用判断对 AST 节点只是**碰巧**成立)。`RelatedListProps.add.picker.filter` 从 `any` 收紧为 spec 的 `ViewFilterRule[]` —— 宽类型正是错误形状的藏身处。

## KNOWN GAP 句与它的钉子

`record:related_list.add` 的 input description 删掉 #3808 按 #3165 先例写入的 KNOWN GAP 句 —— **在** gap 兑现之后,不是之前。`recordRelatedListInputs.spec-parity.test.ts` 原本钉着那句话(「fails the moment someone deletes the warning without doing it」),现已翻转方向:现在它在「gap 警告被放回」或「接线被回滚却仍宣称限制生效」时报红。

## 反向验证(方向先判后跑)

两向都跑了,预判先写:

**摘掉 RelatedList 的直传** —— 预判数组路钉红、无 filter 用例绿、fields 侧钉全绿。实测吻合,3 枚红全部点名 `expected undefined to be defined`。一处**预判偏保守需如实说明**:我原判「不降级成筛选栏行」那枚会以「什么都没产出」的空原因保持绿(#5046 式假绿),实测它**也红了** —— 它的首行 `waitFor` 是对接线的真实前置条件,筛选栏断言只在限制真的生效后才执行。比预判更严,不是更松。

**把合并回退成旧的对象展开**(保留直传)—— 预判两个文件的数组路钉红,且报**损坏**而非缺失;记录路钉与 #2215 全绿。实测吻合,5 枚红全部报:

```
AssertionError: expected { '0': { field: 'is_active', …(2) } } to deeply equal [ [ 'is_active', 'equals', true ] ]
```

`LookupField.dependsOn.test.tsx` 六枚钉全绿 —— 这是判别式设计的承重预判。另有一枚「空规则数组不发 `$filter`」在回退下**仍绿**(展开 `[]` 得 `{}`,空判成立),即旧代码下它是**因错误的原因而绿**;如实记录,不当作覆盖。

## 验证

- `pnpm exec vitest run packages/plugin-detail/ packages/fields/` → **127 files / 1481 tests passed**(含新增 10 枚钉;#2215、#3894 的 addPickerGuard、addPickerLabelField 均绿)
- 跨包消费半径:`AssignedUsersSection` / `AccessExplainPanel`(app-shell 用 `RecordPickerDialog`)+ `apps/console` registry-inputs-spec-parity → **51 passed**
- 末次编辑后全仓 `pnpm exec turbo run type-check --concurrency=2` → **78 successful, 78 total**
- `pnpm check:control-bytes` → OK(3785 tracked text files)

## 未做

`QueryParams.$filter` 仍声明为 `Record< string, any >`,而 plugin-list / plugin-view 的下沉口早已往里送 AST 数组 —— 类型漂移先于本单存在,收敛它会波及 `packages/types` 的公共面,故在此仅于单个赋值点就地转换并注明,另立观察单。#3898(`baseFilterColumns` 命名)按分诊未顺手改。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_