### PR TITLE
fix(app-shell): record:details 段落设计器补上 name 这个 i18n 锚点位 (#3819)

### DIFF
--- a/.changeset/record-details-sections-name-anchor-3819.md
+++ b/.changeset/record-details-sections-name-anchor-3819.md
@@ -1,0 +1,56 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`record:details` section editor now offers the `name` i18n anchor
+
+The page block inspector's `record:details` → Sections editor exposed
+`label` / `columns` / `fields` and silently omitted `name`. That key is not
+decoration: it is the section heading's i18n anchor. `plugin-detail`'s
+`record-details` renderer resolves the heading through
+`objects.<object>._sections.<name>.label` and falls back to the authored string
+whenever `name` is absent —
+
+```
+const translatedTitle = s.name && objectName
+  ? sectionLabel(objectName, s.name, rawTitle ?? s.name)
+  : rawTitle;
+```
+
+— so every section built in Studio was untranslatable by construction: one
+authored string in every locale, plus an upstream
+`translation-section-name-missing` diagnostic the author had no control to
+clear. The key was reachable only by hand-editing source, which is precisely
+what a designer exists to avoid.
+
+The new `Name (i18n key)` text box sits first in each section entry, matching
+`page:tabs` / `page:accordion` where the stable identifier precedes the human
+label. Its placeholder carries the snake_case convention, because
+`BlockPropField` has no description or pattern affordance — the same reason the
+suite already requires every `json` field to carry a shape placeholder.
+
+Two authoring decisions, both deliberate and both pinned:
+
+**The anchor is never derived from `label`.** `InspectorTextField` does expose an
+`onBlur` hook for deriving a dependent field, and the block-config renderer
+deliberately leaves it unwired here. A label may already be localized prose — or
+an inline `{ en, 'zh-CN' }` map, which `record-details` runs through
+`pickLocalized` — and seeding an anchor from it freezes one locale's text into
+the one value that must stay locale-independent. Worse, it would be invisible:
+the renderer falls back to the authored label when a translation misses, so a
+wrongly-derived anchor renders exactly like the bug it was meant to fix, until
+someone adds a second locale.
+
+**Sections authored before this field existed are not backfilled.** They open
+with the anchor box empty and their `label` untouched; nothing is written until
+the author types. This needs no code — the inspector is read-through, writing
+only from a commit handler — and the alternative would mark an untouched page
+dirty merely for being opened.
+
+No validation was added. `BlockPropField` has no pattern/validate capability,
+and inventing one for a single field is out of scope; the placeholder states the
+convention and the upstream lint rule remains the enforcement point.
+
+Coverage for this block's section entry is now derived from the spec's own
+`RecordDetailsProps` shape rather than hand-listed, so the next section key the
+spec grows fails loudly here instead of quietly never reaching the designer.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.sectionName.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.sectionName.test.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#3819 — the `record:details` block inspector must let an author write
+ * a section's `name`, because `name` is the section heading's i18n ANCHOR.
+ *
+ * The renderer resolves the heading through
+ * `objects.<object>._sections.<name>.label` (`plugin-detail`'s
+ * `record-details.tsx`: `s.name && objectName ? sectionLabel(objectName, s.name,
+ * rawTitle ?? s.name) : rawTitle`; key convention in
+ * `i18n/useObjectLabel.ts`). While the inspector offered only
+ * `label`/`columns`/`fields`, every section built in Studio fell into the
+ * `: rawTitle` branch forever — one authored string in every locale — and
+ * carried an upstream `translation-section-name-missing` diagnostic its author
+ * had no control to clear.
+ *
+ * ## Why this is an interaction test and not only a config-face assertion
+ *
+ * `BLOCK_CONFIG` is data; what authors get is whatever `PageBlockInspector`'s
+ * recursive `renderField` does with it. The array branch renders `itemFields`
+ * against a per-item read/write pair, so "the entry exists in the table" and
+ * "the box is on screen and its value lands in `properties.sections[i]`" are
+ * different facts. These drive the real component and read the committed patch.
+ *
+ * ## NOT pinned here, deliberately: schema rejection
+ *
+ * Unlike #3229's `visibleWhen` (where the page schema is `.strict()` and the
+ * old key made drafts unsavable), this surface is PERMISSIVE — verified against
+ * the pinned `@objectstack/spec@17.0.0-rc.5`: `PageSchema.parse` does not
+ * validate `properties` against `RecordDetailsProps` at all, and
+ * `RecordDetailsProps` itself accepts an unknown key inside a `sections[]`
+ * entry. So a nameless section always parsed; it just could never be
+ * translated. Asserting "the committed draft parses" would therefore be a
+ * green light that means nothing — the reachability of the KEY is the fact
+ * under test.
+ *
+ * FIXTURE DISCIPLINE (#3216's method, as in the sibling visibleWhen suite): the
+ * page is authored the way a user does and fed through `PageSchema.parse`, so
+ * the fixture cannot drift from the spec.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { PageSchema } from '@objectstack/spec/ui';
+import { PageBlockInspector } from './PageBlockInspector';
+
+afterEach(cleanup);
+
+/** Selection id for the single block in the fixture page. */
+const BLOCK_PATH = 'regions[0].components[0]';
+
+/** A record page carrying one `record:details` block with the given sections. */
+function pageDraft(sections: Array<Record<string, unknown>>): Record<string, unknown> {
+  return PageSchema.parse({
+    name: 'contact_record',
+    label: 'Contact',
+    type: 'record',
+    object: 'contact',
+    template: 'default',
+    regions: [
+      {
+        name: 'main',
+        components: [{ type: 'record:details', id: 'b1', properties: { sections } }],
+      },
+    ],
+  }) as unknown as Record<string, unknown>;
+}
+
+function renderInspector(draft: Record<string, unknown>, onPatch = vi.fn()) {
+  render(
+    <PageBlockInspector
+      type="page"
+      name="contact_record"
+      draft={draft}
+      selection={{ kind: 'block', id: BLOCK_PATH }}
+      onPatch={onPatch}
+      onClearSelection={() => {}}
+      readOnly={false}
+      locale={'en-US' as never}
+    />,
+  );
+  return onPatch;
+}
+
+/** The sections array as the inspector last committed it. */
+function committedSections(onPatch: ReturnType<typeof vi.fn>): Array<Record<string, unknown>> {
+  const patch = onPatch.mock.calls.at(-1)![0] as any;
+  return patch.regions[0].components[0].properties.sections as Array<Record<string, unknown>>;
+}
+
+/**
+ * The section-name boxes, in section order. Located by the placeholder because
+ * `InspectorTextField` renders its `<Label>` unassociated with the `<input>`
+ * (no `htmlFor`/`id`), so `getByLabelText` cannot reach it — and locating by
+ * placeholder doubles as proof the snake_case hint reaches the DOM, which is
+ * the only convention affordance this field has.
+ */
+const nameBoxes = () => screen.getAllByPlaceholderText(/snake_case/i) as HTMLInputElement[];
+/** The label box of section #1 — "Contact info" in these fixtures. */
+const labelBox = () => screen.getByDisplayValue('Contact info') as HTMLInputElement;
+
+/* ───────────────────────── the box exists and commits ───────────────────── */
+
+describe('PageBlockInspector — record:details sections expose the i18n anchor (#3819)', () => {
+  it('renders one name box per section', () => {
+    renderInspector(
+      pageDraft([
+        { label: 'Contact info', fields: ['first_name'] },
+        { label: 'Address', fields: ['city'] },
+      ]),
+    );
+    expect(nameBoxes()).toHaveLength(2);
+  });
+
+  it('typing a name commits it to `properties.sections[i].name`', () => {
+    const onPatch = renderInspector(pageDraft([{ label: 'Contact info', columns: 2, fields: ['first_name'] }]));
+
+    fireEvent.change(nameBoxes()[0], { target: { value: 'contact_info' } });
+
+    const [section] = committedSections(onPatch);
+    expect(section.name).toBe('contact_info');
+    // The write must be a merge, not a replacement: the array branch commits
+    // `{ ...itemObj, [n]: v }`, and a section that lost its `fields` to gain a
+    // name would render nothing at all.
+    expect(section).toMatchObject({ label: 'Contact info', columns: 2, fields: ['first_name'] });
+  });
+
+  it('names the right section when several exist', () => {
+    const onPatch = renderInspector(
+      pageDraft([
+        { label: 'Contact info', fields: ['first_name'] },
+        { label: 'Address', fields: ['city'] },
+      ]),
+    );
+
+    fireEvent.change(nameBoxes()[1], { target: { value: 'address' } });
+
+    const sections = committedSections(onPatch);
+    expect(sections[1].name).toBe('address');
+    expect(sections[0]).not.toHaveProperty('name');
+  });
+
+  it('the committed name satisfies the renderer guard that reaches the i18n lookup', () => {
+    // `record-details.tsx` gates the translated read on `s.name && objectName`.
+    // Before this field existed the guard could never be satisfied from Studio;
+    // this asserts the authored value is what makes it truthy, and spells out
+    // the key the convention then resolves.
+    const onPatch = renderInspector(pageDraft([{ label: 'Contact info', fields: ['first_name'] }]));
+    fireEvent.change(nameBoxes()[0], { target: { value: 'contact_info' } });
+
+    const [section] = committedSections(onPatch);
+    expect(typeof section.name === 'string' && section.name.length > 0).toBe(true);
+    expect(`objects.contact._sections.${section.name}.label`).toBe(
+      'objects.contact._sections.contact_info.label',
+    );
+  });
+
+  it('a freshly added section offers an empty name box', () => {
+    // Start from a page that already has one section so the new entry is
+    // rendered by the same pass — `onPatch` is a spy, not a state setter, so the
+    // pushed item is not fed back into this render.
+    const onPatch = renderInspector(pageDraft([{ label: 'Contact info', fields: ['first_name'] }]));
+
+    fireEvent.click(screen.getByText('Add section'));
+
+    // The array branch pushes a bare `{}`, so the new entry carries no keys —
+    // in particular no `name` derived from anything.
+    expect(committedSections(onPatch)).toEqual([
+      { label: 'Contact info', fields: ['first_name'] },
+      {},
+    ]);
+    // And the box the author needs is really on screen for the existing entry.
+    // Asserted here too so this case fails — rather than passing vacuously —
+    // if the itemField is ever dropped again.
+    expect(nameBoxes()[0].value).toBe('');
+  });
+});
+
+/* ─────────── sub-question ②: no backfill onto pre-existing sections ─────── */
+
+/**
+ * A section authored before this field existed has a `label` and no `name`.
+ * Opening it must leave the anchor EMPTY rather than seeding it from the label.
+ *
+ * Backfilling would be actively harmful, and silently so: `label` may already
+ * be a localized string (or an inline `{ en, 'zh-CN' }` map — `record-details`
+ * runs it through `pickLocalized`). Deriving an anchor from it freezes one
+ * locale's prose into the key that is supposed to be locale-INDEPENDENT, and
+ * because the renderer falls back to the authored label when a translation
+ * misses, the damage renders identically to the bug — invisible until someone
+ * adds a second locale.
+ */
+describe('PageBlockInspector — an existing label-only section is not backfilled (#3819)', () => {
+  const legacy = () => pageDraft([{ label: 'Contact info', columns: 2, fields: ['first_name'] }]);
+
+  it('opens the name box empty and leaves the label alone', () => {
+    renderInspector(legacy());
+
+    expect(nameBoxes()[0].value).toBe('');
+    expect(labelBox().value).toBe('Contact info');
+  });
+
+  it('rendering the inspector writes nothing by itself', () => {
+    // The inspector is read-through: `renderField` only writes from a commit
+    // handler. A backfill would have to patch during render — which would also
+    // mark an untouched page dirty just for being opened.
+    const onPatch = renderInspector(legacy());
+    expect(onPatch).not.toHaveBeenCalled();
+  });
+
+  it('keeps the section nameless until the author types one', () => {
+    const onPatch = renderInspector(legacy());
+
+    // Touch a neighbouring field: any commit re-writes the whole item object,
+    // which is exactly where an accidental derived `name` would appear.
+    fireEvent.change(labelBox(), { target: { value: 'Contact details' } });
+
+    const [section] = committedSections(onPatch);
+    expect(section.label).toBe('Contact details');
+    expect(section).not.toHaveProperty('name');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PageComponentType } from '@objectstack/spec/ui';
+import { PageComponentType, RecordDetailsProps } from '@objectstack/spec/ui';
 import { BLOCK_CONFIG, blockHasConfig } from '../block-config';
 import { BLOCK_TYPE_META, PALETTE_EXCLUSIONS } from '../block-types';
 
@@ -47,6 +47,86 @@ describe('block-config', () => {
     for (const [type, fields] of Object.entries(BLOCK_CONFIG)) {
       for (const f of fields) check(f, type);
     }
+  });
+});
+
+/**
+ * `record:details.sections` ↔ the spec's own section-entry shape (#3819).
+ *
+ * The designer offered `label` / `columns` / `fields` and silently omitted
+ * `name` — which the spec describes as the section's i18n ANCHOR ("resolves
+ * `objects.<object>._sections.<name>.label`; a nameless section renders its
+ * authored label in every locale") and which the renderer really reads
+ * (`record-details.tsx`: `s.name && objectName ? sectionLabel(objectName,
+ * s.name, …)`). Every section Studio produced was therefore untranslatable by
+ * construction, and carried an upstream `translation-section-name-missing`
+ * diagnostic no designer control could clear.
+ *
+ * The coverage half is DERIVED from `RecordDetailsProps`, not hand-listed, for
+ * the reason the palette suite below states: a hand-written
+ * `expect(name).toBeDefined()` pins today's gap closed but stays green the next
+ * time the spec grows a section key the inspector never learns to author.
+ */
+describe('record:details sections ↔ spec section-entry coverage (#3819)', () => {
+  /** The spec's authorable keys for one `sections[]` entry, read off the Zod shape. */
+  const specSectionKeys: string[] = (() => {
+    const props = RecordDetailsProps as unknown as { shape?: Record<string, unknown> };
+    const sections = props.shape?.sections as { _def?: Record<string, any> } | undefined;
+    // sections: ZodOptional< ZodArray< ZodObject > > — unwrap to the element object.
+    let node: any = sections;
+    for (let i = 0; i < 6 && node; i++) {
+      const def = node._def ?? {};
+      if (def.innerType) { node = def.innerType; continue; }
+      if (def.element) { node = def.element; continue; }
+      break;
+    }
+    const shape = node?.shape;
+    return shape ? Object.keys(shape) : [];
+  })();
+
+  /** The inspector's item editors for one section. */
+  const sectionsField = BLOCK_CONFIG['record:details'].find((f) => f.name === 'sections') as
+    | { kind: 'array'; itemFields: Array<{ name: string; label: string; kind: string; placeholder?: string }> }
+    | undefined;
+
+  it('reads a non-empty section-entry shape from the spec', () => {
+    // Guards the derivation itself: a spec refactor that moves the shape must
+    // fail here loudly rather than turn the coverage assertion into a no-op
+    // that passes over an empty list.
+    expect(specSectionKeys, 'could not read RecordDetailsProps.sections[] shape').not.toEqual([]);
+    expect(specSectionKeys).toContain('name');
+  });
+
+  it('exposes an editor for every key the spec declares on a section', () => {
+    expect(sectionsField?.kind).toBe('array');
+    const authored = (sectionsField?.itemFields ?? []).map((f) => f.name);
+    const missing = specSectionKeys.filter((k) => !authored.includes(k));
+    // If this fails: the spec declares a section key the block designer gives
+    // authors no way to write. Add the itemField — a key that only source-mode
+    // editing can reach is a key Studio-built pages structurally cannot carry.
+    expect(missing, 'section keys with no designer control').toEqual([]);
+  });
+
+  it('the `name` editor is a text box carrying the snake_case convention', () => {
+    const nameField = sectionsField?.itemFields.find((f) => f.name === 'name');
+    expect(nameField, 'record:details sections must expose the i18n anchor `name`').toBeDefined();
+    expect(nameField!.kind).toBe('text');
+    // `BlockPropField` has no description/pattern affordance, so the
+    // placeholder is the only place the snake_case convention can be stated —
+    // the same argument the json-placeholder test below makes.
+    expect(nameField!.placeholder, '`name` needs a placeholder stating snake_case').toMatch(/snake_case/);
+    // The label must say what the box is FOR. A bare "Name" next to "Label"
+    // reads as a second display string, which is how an author ends up typing
+    // a heading into the anchor.
+    expect(nameField!.label).toMatch(/i18n/i);
+  });
+
+  it('lists `name` before `label` — the entry identity comes first', () => {
+    // Matches `page:tabs` (`key`) and `page:accordion` (`value`), where the
+    // stable identifier precedes the human label.
+    const order = (sectionsField?.itemFields ?? []).map((f) => f.name);
+    expect(order.indexOf('name')).toBeGreaterThanOrEqual(0);
+    expect(order.indexOf('name')).toBeLessThan(order.indexOf('label'));
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -309,11 +309,29 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
   ],
   'record:details': [
     {
+      // A section's `name` is its i18n anchor, not decoration: the renderer
+      // resolves the heading through `objects.<object>._sections.<name>.label`
+      // (`record-details.tsx` → `sectionLabel`; key convention in
+      // `i18n/useObjectLabel.ts`), and a nameless section shows its authored
+      // label in every locale. While this field was missing the designer could
+      // only produce structurally untranslatable sections, and every page it
+      // built carried an upstream `translation-section-name-missing`
+      // diagnostic its author had no UI to clear (objectui#3819). It is listed
+      // first because it is the entry's identity — same order as
+      // `page:tabs`/`page:accordion`, where the key precedes the label.
+      //
+      // Deliberately NOT derived from `label`: an author who already localized
+      // the heading would get that translated text frozen into the anchor, and
+      // the anchor is the one value that must stay stable across locales. The
+      // placeholder carries the snake_case convention because `BlockPropField`
+      // has no pattern/validate affordance — see the type above — and adding
+      // one for a single field is outside this fix.
       name: 'sections',
       label: 'Sections',
       kind: 'array',
       addLabel: 'Add section',
       itemFields: [
+        { name: 'name', label: 'Name (i18n key)', kind: 'text', placeholder: 'snake_case, e.g. contact_info' },
         { name: 'label', label: 'Label', kind: 'text' },
         { name: 'columns', label: 'Columns', kind: 'number', placeholder: '2' },
         { name: 'fields', label: 'Fields', kind: 'field-list', objectFrom: 'page' },


### PR DESCRIPTION
Fixes #3819

## 问题

`record:details` 的 sections 编辑器只给了 `label` / `columns` / `fields`,漏掉了 `name`。而 `name` 不是可选的装饰位,它是段落标题的 **i18n 锚点** —— `plugin-detail` 的 `record-details.tsx` 用它去解析 `objects.{object}._sections.{name}.label`,`name` 缺失时直接退回作者当时敲进去的那串字:

```
const translatedTitle = s.name && objectName
  ? sectionLabel(objectName, s.name, rawTitle ?? s.name)
  : rawTitle;
```

于是 Studio 里搭出来的每个 section 在结构上就不可翻译:所有 locale 下同一串英文,并且必然挂着上游 `translation-section-name-missing` 这条作者在设计器里修不掉的诊断。这个键此前只能靠手改 source 才能写上 —— 而"不必手改 source"正是设计器存在的理由。

## 前提复核(origin/main @ `50fa3766ebb2ebf2ec78c5d13b1d627e6a91696f`)

三个锚点都还在,issue 前提成立:

- `previews/block-config.ts` 的 `record:details` sections `itemFields` 确实只有 label/columns/fields;
- `plugin-detail/src/renderers/record-details.tsx:199` 的 `sectionLabel(objectName, s.name, …)` 实读在;
- `packages/i18n/src/useObjectLabel.ts:419` 的键约定(`{ns}.objects.{objectName}._sections.{sectionName}.label`)在。

## 改法

新增 `Name (i18n key)` 文本位,放在每个 section 条目的**第一个** —— 与 `page:tabs`(`key`)、`page:accordion`(`value`)一致:标识符在人类标签之前。snake_case 约定写在 placeholder 里,因为 `BlockPropField` 没有 description/pattern 这类能力位(与本套件已有的"每个 json 位必须带形状 placeholder"同一条理由)。

## 两个实现级子问题的判定

**① 不做自动派生,也不新造校验。** 实测 `BlockPropField` 的 `text` 只支持 `placeholder`,没有 pattern/validate 能力位;按分诊"没有就不为此单独造",不为一个字段单独造校验层,约定交给 placeholder 陈述、强制点仍在上游 lint 规则。派生能力其实**存在**(`InspectorTextField` 有一个注释写明"e.g. to derive a dependent field"的 `onBlur` 钩子),这里刻意不接:`label` 可能已经是译好的文案,甚至是内联 `{ en, 'zh-CN' }` 映射(`record-details` 会走 `pickLocalized`),从它派生等于把某一个 locale 的文案冻进那个本该与 locale 无关的键里。更糟的是这种损坏**看不见** —— 译文缺失时渲染器回退到 authored label,派生错的锚点渲染出来和 bug 本身一模一样,要等有人加第二个 locale 才暴露。

**② 既有仅 label 的 section 不回填。** 打开时锚点位留空、`label` 原样不动,作者不输入就什么都不写。这一条**不需要代码**:inspector 是纯读穿的,`renderField` 只在 commit 回调里写;反过来做回填要在 render 期打补丁,还会让一个只是被点开过的页面变成 dirty。

## 钉子

- **配置面**:`record:details` 的 section 条目覆盖率现在**从 spec 自身的 `RecordDetailsProps` 形状推导**,不再手列 —— 手写一句 `expect(name).toBeDefined()` 只能把今天这个洞钉住,spec 下次长出新的 section 键时它照样绿。另加三条:`name` 是 text 位、placeholder 陈述 snake_case、label 说明是 i18n 键、且排在 `label` 之前。
- **交互面**(`PageBlockInspector.sectionName.test.tsx`,仿同目录 `visibleWhen` 先例):输入位真的渲染出来、输入落进 `properties.sections[i].name` 且合并而非覆盖同条目其它键、多 section 时写对那一个、既有 label-only section 打开留空、仅渲染不产生任何 patch、改邻位 label 不会派生出 `name`。
- **刻意不钉 schema 拒绝**:与 #3229 的 `visibleWhen` 不同,这个面是**宽松**的 —— 实测 pin 版 `@objectstack/spec@17.0.0-rc.5`:`PageSchema.parse` 根本不拿 `RecordDetailsProps` 校验 `properties`,`RecordDetailsProps` 自己对 section 条目里的未知键也放行。所以无名 section 一直都能 parse,只是永远不可翻译。写一条"提交的 draft 能 parse"是绿得没有意义的断言,本单真正要钉的是**这个键可达**。测试文件头把这点写清了,免得下一个读者照抄错的判据。

## 反向验证(方向先判后跑,结果与预判一致)

预判 **Red**:去掉新 itemField → 9 条红(配置面 3:spec 覆盖率 pin 报 `missing: ['name']`、形状 pin、顺序 pin;交互面 6:所有定位锚点输入位的用例),15 条绿。实跑:

```
Tests  9 failed | 15 passed (24)
  × exposes an editor for every key the spec declares on a section
  × the `name` editor is a text box carrying the snake_case convention
  × lists `name` before `label` — the entry identity comes first
  × renders one name box per section
  × typing a name commits it to `properties.sections[i].name`
  × names the right section when several exist
  × the committed name satisfies the renderer guard that reaches the i18n lookup
  × a freshly added section offers an empty name box
  × opens the name box empty and leaves the label alone

AssertionError: section keys with no designer control: expected [ 'name' ] to deeply equal []
```

失败集合与预判逐条对上。**如实说明**:保持绿的 15 条里,子问题 ② 的两条(`rendering the inspector writes nothing by itself`、`keeps the section nameless until the author types one`)在改动前也是绿的 —— 它们钉的是"不回填/不派生"这个**无代码**的决定,走 `labelBox` 而不是锚点位,因此按定义不可能因为删掉字段而变红。这不是缺陷,是那条决定的正确钉法。另有一条 `a freshly added section offers an empty name box` 初版只断言 Add 推入 `{}`,删掉字段后会**空绿**(断言通过是因为什么都没产生);已补上锚点位读数,现在会红。

## 浏览器实证(preview gallery,无后端)

走真实授权路径:palette 加 `record:details` 块 → 画布选中 → Add section → 输入锚点。探针直接读 `DesignerCard` 的 draft state(React fiber 的 `queue.lastRenderedState`,`memoizedState` 会慢一帧):

```
STEP 1  block authored from palette = {"type":"record:details"}
STEP 2  inspector open | "Sections" panel = 1 | name boxes (no sections yet) = 0
STEP 3  after "Add section":
        "Name (i18n key)" label on screen = 1
        anchor boxes = 1 | placeholder = "snake_case, e.g. contact_info"
        value (empty = no backfill) = ""
        draft = {"type":"record:details","properties":{"sections":[{}]}}
STEP 4  label authored, anchor untouched:
        draft = {"type":"record:details","properties":{"sections":[{"label":"Contact info"}]}}
        anchor box value = ""
STEP 5  anchor typed:
        draft = {"type":"record:details","properties":{"sections":[{"label":"Contact info","name":"contact_info"}]}}
        box still shows = "contact_info"
STEP 6  second section — anchor boxes = 2 | values = ["contact_info",""]
        draft = {"type":"record:details","properties":{"sections":[{"label":"Contact info","name":"contact_info"},{}]}}
```

STEP 4 是子问题 ② 在真实 UI 里的读数:写了 label,`name` 仍不存在、输入位仍空 —— 没有派生。STEP 5 是"落进 schema"的读数(输入位是受控的,值留得住就说明真的进了 state)。placeholder 量了一下没有被截断:文本 206px / 输入内宽 243px,完整可读。

## 验证命令

- 依赖构建:`pnpm --filter '@object-ui/app-shell^...' build` → 通过
- 新钉子:`pnpm exec vitest run` 两个测试文件 `--maxWorkers=2` → `Test Files 2 passed | Tests 24 passed`
- 消费半径(12 个文件:previews/inspectors + `plugin-detail` 的 `recordDetailsInputs.spec-parity` / `record-details` / `buildDefaultPageSchema`)→ `Test Files 12 passed | Tests 204 passed`
- 末次编辑后全仓 `pnpm exec turbo run type-check --concurrency=2` → `78 successful, 78 total`
- `node scripts/check-control-bytes.mjs` → OK(3789 文件);改动文件另做 `grep -naP` 控制字节自查,零命中

## 边界

只改 `previews/block-config.ts` 的 `record:details` 一条 + 测试 + changeset。上游 lint 规则本体没动;#3831(plugin-detail/fields)、#3134(表单布局设计面)零相交;`content/docs/releases/**` 未碰。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_