### PR TITLE
docs(layout): page-header 的 Responsive Behavior 按 PageHeader 现状改写 Spacing 一行 (#3902)

### DIFF
--- a/content/docs/layout/page-header.mdx
+++ b/content/docs/layout/page-header.mdx
@@ -226,7 +226,7 @@ The PageHeader includes:
 
 - **Mobile**: Actions stack below title if needed
 - **Desktop**: Actions align to right side
-- **Spacing**: Adjusts padding for different screen sizes
+- **Spacing**: Identical at every breakpoint — there is no responsive padding variant; the only breakpoint-driven change is the title's font size (see Styling → Title)
 
 ## Related
 


### PR DESCRIPTION
Fixes #3902

## 问题

`content/docs/layout/page-header.mdx:229`(Responsive Behavior 小节)写着
「**Spacing**: Adjusts padding for different screen sizes」—— 这是 #3786 修掉的那个假断言
(`pb-4` on mobile / `pb-8` on desktop)的**第四份副本**。PR #3905 把 Styling → Container
收敛成「`pb-4` at every breakpoint — there is no responsive variant」之后,这一页变成
**自相矛盾**:Container 说没有断点变体,四行之后的 Responsive Behavior 说 padding 会随
屏幕尺寸调整。读者信哪一条,取决于他翻到哪一节。

## 事实核对

基线 `origin/main` @ `c2ecbaed9`(已含 PR #3905 的合并点 `50fa3766e`),逐词对照
`packages/layout/src/PageHeader.tsx`:

| 改写后的措辞 | 代码依据 |
| --- | --- |
| Identical at every breakpoint / there is no responsive padding variant | `:210` 根 class `flex flex-col gap-3 pb-4 border-b` —— `pb-4`、`gap-3` 都没有断点前缀;`:211` 的 `gap-x-4 gap-y-2`、`:235` 的 `gap-2` 同样没有 |
| the only breakpoint-driven change is the title's font size | `:231` 的 `md:text-3xl` 是**整个文件里唯一**带断点前缀的类(`grep -cE '\b(sm\|md\|lg\|xl\|2xl):'` = 1) |
| (see Styling → Title) | 该节 `:142` 已写明 `text-2xl` on mobile / `text-3xl` on desktop |

同小节另两行**已核为真,未改动**:Actions 换行由标题行的 `flex flex-wrap`(`:211`)兑现,
右对齐由右槽的 `ml-auto`(`:235`)兑现。

## 改法

只改 `:229` 这一行(1 行增 / 1 行删,单文件):

- 措辞沿用 #3786 在 Container 节定下的句式,保持同页两节口径一致;
- 真正随断点变化的标题字号只做**指向**(Styling → Title 已经有那个数值),不再复制具体
  数值 —— 这个断言已经长到第四份副本,复制数值就是第五份的种子。

同页其余部分(含 #3786 / PR #3905 已收敛的 Styling 三节、以及 #3906 在议的定位问题)一律未碰。

## 验证

- `node scripts/check-doc-links.mjs` → `Links are valid across 7 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 3792 tracked text file(s); skipped 85 binary)`;
  另按字节纪律自查 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 于改动文件零命中。
- `node scripts/check-changeset-presence.mjs` → 「No source of a released package changed in
  this range, so no changeset is owed.」(纯 docs,未动任何发版包的 `src/`),故本 PR 不带 changeset。
- 末次编辑后全仓 `pnpm exec turbo run type-check --concurrency=2` → `Tasks: 78 successful, 78 total`(md-only 保险)。

**反向验证**:本改动是散文断言的改写,不含任何可执行分支,没有「把删掉的肢体装回去看诊断变红」
的可测等价物 —— 按注释-only 惯例豁免,如实记录。替代证据是上面那张**改写句与代码逐词对照表**
(每个短语都能指回一处 file:line)加门禁前后皆绿。

## 越界发现(未在本 PR 修)

- 已立单 #3914:`content/docs/layout/app-shell.mdx:64` / `:71` 的两处数值与 `AppShell.tsx:249`
  / `:257` 不符(「64px / 4rem」实为 `h-14` = 56px;「4 on mobile」实为 `p-3`,且 mobile 的
  `pb-20` 未记)—— 同一类数值漂移,但属另一文件、另一组件,不在本单判定面内。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_