### PR TITLE
fix(app-shell): honour all three persist values in ContextSelectors

### DIFF
--- a/.changeset/os5994-context-selector-persist-enforce.md
+++ b/.changeset/os5994-context-selector-persist-enforce.md
@@ -1,0 +1,5 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Honour all three `AppContextSelectorSchema.persist` values in app context selectors: `'query'` (the default) writes and reads the URL query parameter only, `'session'` writes and reads `sessionStorage` only, and `'none'` writes neither — the pick stays in memory for that mount. Previously every selector was mirrored into both stores and read back as `URL ?? storage`, so `'session'` and `'query'` were indistinguishable and `'none'` persisted anyway. Selectors on the `'query'` default (including Studio's package scope) no longer write `objectui-ctx-*` storage, and a scope dropped by a param-less nav link is re-established by auto-select-first instead of from a store the author never declared.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -197,9 +197,14 @@ Studio as browse-only.
 ### Studio package scope
 
 Studio treats the selected package as the authoring scope. The package selector
-is mandatory, and Studio repairs missing `?package=` query parameters from the
-last selected package or the first project package so scoped pages do not drift
-out of sync with the sidebar. The Studio home overview, quick-create links,
+is mandatory, and Studio repairs a missing `?package=` query parameter from the
+first project package so scoped pages do not drift out of sync with the sidebar.
+It is *not* repaired from the last selected package any more: Studio declares
+`persist: 'query'`, and each `persist` value now names exactly one medium — the
+URL for `'query'`, `sessionStorage` for `'session'`, neither for `'none'`
+(objectstack#5994). An app that wants its scope remembered beyond the URL
+declares `persist: 'session'`, which keeps it out of the address bar in
+exchange. The Studio home overview, quick-create links,
 metadata counts, and diagnostics all follow that active package. The dedicated
 package-management page remains the global place to create, import, publish,
 enable, or disable packages; direct `/metadata/package` links redirect there.

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -12,9 +12,25 @@
  * Selecting an option therefore transparently scopes every child nav
  * item — no per-item wiring required.
  *
- * The active value also lives in the URL query string, under a key derived
- * per selector by {@link contextSelectorQueryKey} — see that helper for the
- * one grandfathered key (`active_package` → `?package=`) and its sunset.
+ * Where the active value LIVES is the author's choice, declared per selector by
+ * `persist` (`AppContextSelectorSchema`, default `'query'`) and honoured here
+ * as exactly ONE medium per value — the spec's own words are "Persist
+ * selection via URL query, sessionStorage, or not at all":
+ *
+ *   - `'query'`   → the URL query string only, under a key derived per selector
+ *                   by {@link contextSelectorQueryKey} (see that helper for the
+ *                   one grandfathered key, `active_package` → `?package=`, and
+ *                   its sunset);
+ *   - `'session'` → `sessionStorage` only, never the URL;
+ *   - `'none'`    → neither; the pick lives in memory for this mount only.
+ *
+ * The media are exclusive on BOTH sides: a `'session'` selector is never read
+ * back off the query string, and a `'query'` selector is never read back out of
+ * storage. Mirroring every pick into both stores is exactly what made
+ * `'session'` and `'query'` indistinguishable and let `'none'` persist anyway
+ * (objectstack#5994). A selector that wants URL reflection *and* a remembered
+ * fallback is asking for a new `persist` value in the spec — not for this
+ * renderer to write a second store the author never declared.
  *
  * @module
  */
@@ -99,6 +115,48 @@ const LEGACY_SCOPE_QUERY_KEYS: ReadonlyMap<string, string> = new Map([
  */
 export function contextSelectorQueryKey(selectorId: string): string {
   return LEGACY_SCOPE_QUERY_KEYS.get(selectorId) ?? selectorId;
+}
+
+/** The persistence media `AppContextSelectorSchema.persist` can name. */
+type PersistMode = NonNullable<ContextSelectorDef['persist']>;
+
+/**
+ * The selector's declared persistence medium.
+ *
+ * `persist` carries `.default('query')` in the spec, so an omitted key IS a
+ * declaration of `'query'` — resolving it here honours the spec's default, it
+ * does not tolerate under-specified metadata.
+ */
+function persistMode(sel: ContextSelectorDef): PersistMode {
+  return sel.persist ?? 'query';
+}
+
+/** sessionStorage key holding a `persist: 'session'` selector's active value. */
+function sessionScopeKey(appName: string, selectorId: string): string {
+  return `objectui-ctx-${appName}-${selectorId}`;
+}
+
+/**
+ * Active values of the `persist: 'session'` selectors, read back from storage.
+ *
+ * Only `'session'` selectors are read. `'query'` lives in the URL and `'none'`
+ * must not survive at all, so an `objectui-ctx-*` entry left behind by an older
+ * build — which mirrored EVERY selector into storage — is ignored rather than
+ * resurrected under a value that no longer names storage as its medium.
+ */
+function readSessionScopes(
+  appName: string,
+  list: ContextSelectorDef[],
+): Record<string, string> {
+  const seed: Record<string, string> = {};
+  for (const sel of list) {
+    if (persistMode(sel) !== 'session') continue;
+    try {
+      const saved = sessionStorage.getItem(sessionScopeKey(appName, sel.id));
+      if (saved) seed[sel.id] = saved;
+    } catch { /* storage disabled */ }
+  }
+  return seed;
 }
 
 /** Read a (possibly dotted) property path off a row, e.g. `manifest.id`. */
@@ -201,39 +259,70 @@ export function useAppContextSelectors(
   const navigate = useNavigate();
   const location = useLocation();
 
-  // The URL query string is the single source of truth for the active
-  // scope. Deriving the selected value from it (rather than a parallel
-  // useState) keeps the sidebar control in lock-step with the page — no
-  // more "sidebar says A while the list shows B" drift.
+  // For a `persist: 'query'` selector the query string IS the value. Deriving
+  // it from `location` (rather than a parallel useState) keeps the sidebar
+  // control in lock-step with the page — no "sidebar says A while the list
+  // shows B" drift.
   const params = new URLSearchParams(location.search);
 
-  // Re-apply a remembered scope whenever navigation drops the query param.
-  // The selector is mandatory for Studio: package-scoped pages should never
-  // sit at a blank package value just because a nav link omitted `?package=`.
+  // …and the non-URL media need a render source of their own. A bare
+  // `sessionStorage` read during render would never re-render on write — only
+  // the URL medium gets that for free, from `navigate` — so a `'session'` pick
+  // would sit invisible until something unrelated re-rendered the sidebar.
+  // State is that source: `'session'` seeds it from storage and mirrors writes
+  // back, `'none'` keeps it in memory and lets it die with the mount.
+  const [storedValues, setStoredValues] = React.useState<Record<string, string>>(
+    () => readSessionScopes(appName, list),
+  );
+
+  // Selectors can arrive after mount (app metadata loads async), so seed again
+  // when the list changes — only for ids not yet resolved, so a pick made in
+  // this mount is never overwritten by the storage read trailing behind it.
   React.useEffect(() => {
-    const p = new URLSearchParams(location.search);
-    let changed = false;
-    for (const sel of list) {
-      if (sel.persist === 'none') continue;
-      const key = contextSelectorQueryKey(sel.id);
-      if (p.get(key)) continue;
-      try {
-        const saved = sessionStorage.getItem(`objectui-ctx-${appName}-${sel.id}`);
-        if (saved) { p.set(key, saved); changed = true; }
-      } catch { /* storage disabled */ }
-    }
-    if (changed) {
-      navigate({ pathname: location.pathname, search: p.toString() }, { replace: true });
-    }
-  }, [appName, list, location.pathname, location.search, navigate]);
+    const seed = readSessionScopes(appName, list);
+    if (Object.keys(seed).length === 0) return;
+    setStoredValues((prev) => {
+      let next: Record<string, string> | undefined;
+      for (const [id, value] of Object.entries(seed)) {
+        if (prev[id] !== undefined) continue;
+        next ??= { ...prev };
+        next[id] = value;
+      }
+      return next ?? prev;
+    });
+  }, [appName, list]);
+
+  // NOTE — there is deliberately NO "repair the missing query param from
+  // storage" effect any more. It bridged storage → URL for every selector,
+  // which is precisely how `'query'` and `'session'` became indistinguishable:
+  // a `'query'` selector was silently backed by a second store its author never
+  // declared, and `'none'` only opted out of the re-apply while still writing
+  // both. With one medium per value there is nothing left to bridge — a
+  // `'query'` scope dropped by a param-less nav link is re-established by
+  // `SelectorControl`'s auto-select-first (so the surface is never left blank,
+  // which was the bridge's stated reason to exist), and an author who wants the
+  // pick remembered beyond the URL declares `persist: 'session'`.
 
   const setValue = React.useCallback((sel: ContextSelectorDef, raw: string) => {
     const value = raw === ALL_SENTINEL ? (sel.allValue ?? '') : raw;
-    try {
-      const key = `objectui-ctx-${appName}-${sel.id}`;
-      if (value) sessionStorage.setItem(key, value);
-      else sessionStorage.removeItem(key);
-    } catch { /* storage disabled */ }
+    const mode = persistMode(sel);
+
+    if (mode !== 'query') {
+      // `'session'` and `'none'` both render out of state and never touch the
+      // URL; they differ only in whether the write is ALSO mirrored to the
+      // durable store.
+      setStoredValues((prev) => (
+        prev[sel.id] === value ? prev : { ...prev, [sel.id]: value }
+      ));
+      if (mode === 'session') {
+        try {
+          const key = sessionScopeKey(appName, sel.id);
+          if (value) sessionStorage.setItem(key, value);
+          else sessionStorage.removeItem(key);
+        } catch { /* storage disabled */ }
+      }
+      return;
+    }
 
     // Reflect the scope onto the current page immediately, under THIS
     // selector's own query key — writing a shared key made a second selector
@@ -254,6 +343,11 @@ export function useAppContextSelectors(
     if (process.env.NODE_ENV === 'production') return;
     const owners = new Map<string, string>();
     for (const sel of list) {
+      // Only `'query'` selectors read and write the query string, so only they
+      // can mirror each other through it. A `'session'`/`'none'` selector whose
+      // id happens to derive the same key never touches it — warning about that
+      // pair would be a false positive.
+      if (persistMode(sel) !== 'query') continue;
       const key = contextSelectorQueryKey(sel.id);
       const owner = owners.get(key);
       if (owner) {
@@ -268,13 +362,16 @@ export function useAppContextSelectors(
     }
   }, [list]);
 
+  // Read side, same exclusivity as the write side: each selector resolves out
+  // of its declared medium and no other. Reading "URL ?? storage" for every
+  // selector is what let a `'session'` pick be shadowed by a shared link's
+  // query string and a `'query'` pick be answered by a store nobody declared.
   const contextValues: Record<string, string> = {};
   for (const sel of list) {
-    let saved = '';
-    try {
-      saved = sessionStorage.getItem(`objectui-ctx-${appName}-${sel.id}`) ?? '';
-    } catch { /* storage disabled */ }
-    contextValues[sel.id] = (params.get(contextSelectorQueryKey(sel.id)) ?? saved) || (sel.allValue ?? '');
+    const active = persistMode(sel) === 'query'
+      ? (params.get(contextSelectorQueryKey(sel.id)) ?? '')
+      : (storedValues[sel.id] ?? '');
+    contextValues[sel.id] = active || (sel.allValue ?? '');
   }
 
   const element = list.length === 0 ? null : (

--- a/packages/app-shell/src/layout/__tests__/ContextSelectors.persist.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ContextSelectors.persist.test.tsx
@@ -1,0 +1,285 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `AppContextSelectorSchema.persist` gets all three of its values honoured
+ * (objectstack#5994).
+ *
+ * The spec declares `persist: 'query' | 'session' | 'none'` (default `'query'`)
+ * as "Persist selection via URL query, sessionStorage, or not at all" — one
+ * medium per value. The shell used to write BOTH stores for every selector and
+ * read them back as `URL ?? storage`, so:
+ *
+ *   - `'none'` persisted anyway (it only skipped the storage → URL re-apply);
+ *   - `'session'` and `'query'` were behaviourally identical.
+ *
+ * Every case below therefore asserts BOTH stores, not just the one the value
+ * names — "writes the URL" is only half the claim, "and leaves storage alone"
+ * is the half that was broken. The read side is pinned the same way: a value's
+ * medium is the ONLY place its pick is read back from.
+ *
+ * Reverse verification (direction predicted before running): restoring either
+ * deleted limb — the unconditional `sessionStorage.setItem` in `setValue`, or
+ * the `URL ?? storage` read — turns the `'query'` storage assertions and the
+ * `'session'` URL assertions red. It does NOT turn the `'none'` case red on its
+ * own, because `'none'`'s in-memory value is produced by new state rather than
+ * by a surviving store; that case is red only against the pre-change file as a
+ * whole, which is why it asserts the published template var too and not merely
+ * two empty stores (an all-empty assertion would pass for a selector that
+ * produced nothing at all).
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+
+// Radix's Select is not driveable in happy-dom (pointer capture), and the
+// choreography is not what is under test — which store the pick lands in is.
+// Swap the primitives for a flat list of buttons calling `onValueChange`.
+vi.mock('@object-ui/components', async () => {
+  const R = await import('react');
+  const PickCtx = R.createContext<(value: string) => void>(() => {});
+  return {
+    getLazyIcon: () => () => null,
+    Select: ({ value, onValueChange, children }: any) => (
+      <PickCtx.Provider value={onValueChange}>
+        <div data-current={value ?? ''}>{children}</div>
+      </PickCtx.Provider>
+    ),
+    SelectTrigger: ({ children, 'aria-label': label }: any) => (
+      <div role="combobox" aria-label={label}>{children}</div>
+    ),
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectItem: ({ value, children }: any) => {
+      const pick = R.useContext(PickCtx);
+      return (
+        <button type="button" data-testid={`opt-${value}`} onClick={() => pick(value)}>
+          {children}
+        </button>
+      );
+    },
+    SelectValue: () => null,
+  };
+});
+
+import { useAppContextSelectors, type ContextSelectorDef } from '../ContextSelectors';
+
+const PACKAGES_ENDPOINT = '/api/v1/packages';
+
+// Labels sort so `options[0]` is `billing` — deliberately DIFFERENT from the
+// `crm_core` seeded into the stores below. A stored value that happened to equal
+// the auto-selected first option would make "restored from storage" and "never
+// read storage, auto-selected instead" indistinguishable.
+const ROWS = [
+  { id: 'billing', name: 'Billing' },
+  { id: 'crm_core', name: 'CRM Core' },
+];
+
+const STORAGE_KEY = 'objectui-ctx-studio-active_package';
+/** Studio's `active_package` is grandfathered onto `?package=` (objectui#3500). */
+const URL_KEY = 'package';
+
+/** One selector per `persist` value; module-level so effects key off a stable ref. */
+function selectors(persist: ContextSelectorDef['persist']): ContextSelectorDef[] {
+  return [{ id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT }, persist }];
+}
+const QUERY_SEL = selectors('query');
+const SESSION_SEL = selectors('session');
+const NONE_SEL = selectors('none');
+/** `persist` omitted — the spec's `.default('query')` must apply. */
+const DEFAULT_SEL: ContextSelectorDef[] = [
+  { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT } },
+];
+
+let snapshot: { contextValues: Record<string, string>; search: string };
+
+function Probe({ list }: { list: ContextSelectorDef[] }) {
+  const location = useLocation();
+  const { contextValues, element } = useAppContextSelectors('studio', list);
+  // Published from an effect, not during render: the hook re-navigates from its
+  // own effects, so only a committed render is a meaningful sample.
+  React.useEffect(() => {
+    snapshot = { contextValues, search: location.search };
+  });
+  return <>{element}</>;
+}
+
+function mount(list: ContextSelectorDef[], url = '/apps/studio') {
+  snapshot = { contextValues: {}, search: '' };
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Probe list={list} />
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * The option rows have resolved and rendered, once per declared selector — the
+ * fixtures share one endpoint, so N selectors render N copies of each option.
+ */
+async function optionsReady(selectorCount = 1) {
+  await waitFor(() => expect(screen.getAllByTestId('opt-crm_core')).toHaveLength(selectorCount));
+}
+
+function query() {
+  return new URLSearchParams(snapshot.search);
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ROWS })));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("persist: 'query' — the URL query string, and nothing else", () => {
+  it('writes the pick to the URL and leaves sessionStorage untouched', async () => {
+    mount(QUERY_SEL);
+    await optionsReady();
+
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('crm_core'));
+    // The half that was broken: storage was written for EVERY selector, which
+    // is what made `'query'` and `'session'` the same behaviour.
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(snapshot.contextValues.active_package).toBe('crm_core');
+  });
+
+  it('reads the pick back out of the URL', async () => {
+    mount(QUERY_SEL, `/apps/studio?${URL_KEY}=crm_core`);
+    await optionsReady();
+
+    expect(snapshot.contextValues.active_package).toBe('crm_core');
+  });
+
+  it('ignores a stale storage entry instead of restoring it to the URL', async () => {
+    // Left behind by a build that mirrored every selector into storage. The
+    // deleted storage → URL bridge would have re-applied it as `?package=`;
+    // under one-medium-per-value the URL is empty, so the selector
+    // auto-selects the first option (`billing`, not the stored `crm_core`).
+    sessionStorage.setItem(STORAGE_KEY, 'crm_core');
+
+    mount(QUERY_SEL);
+    await optionsReady();
+
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('billing'));
+    expect(snapshot.contextValues.active_package).toBe('billing');
+    // Not read AND not written: the stale entry is left exactly as it was.
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('crm_core');
+  });
+
+  it("applies the spec's `'query'` default when `persist` is omitted", async () => {
+    mount(DEFAULT_SEL);
+    await optionsReady();
+
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('crm_core'));
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("persist: 'session' — sessionStorage, and nothing else", () => {
+  it('writes the pick to sessionStorage and never to the URL', async () => {
+    mount(SESSION_SEL);
+    await optionsReady();
+
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+
+    await waitFor(() => expect(sessionStorage.getItem(STORAGE_KEY)).toBe('crm_core'));
+    // The point of `'session'`: the scope stays out of the address bar, so the
+    // link is not a scoped link.
+    expect(query().has(URL_KEY)).toBe(false);
+    // …and it is still published as the nav template var.
+    expect(snapshot.contextValues.active_package).toBe('crm_core');
+  });
+
+  it('restores the remembered pick from storage on mount', async () => {
+    sessionStorage.setItem(STORAGE_KEY, 'crm_core');
+
+    mount(SESSION_SEL);
+    await optionsReady();
+
+    expect(snapshot.contextValues.active_package).toBe('crm_core');
+    // Restored into the value, NOT into the query string.
+    expect(query().has(URL_KEY)).toBe(false);
+  });
+
+  it('is not shadowed by a query parameter of the same key', async () => {
+    sessionStorage.setItem(STORAGE_KEY, 'crm_core');
+
+    // A shared link carrying `?package=billing` must not override a selector
+    // whose declared medium is storage — that read (`URL ?? storage`) is what
+    // made the two values indistinguishable.
+    mount(SESSION_SEL, `/apps/studio?${URL_KEY}=billing`);
+    await optionsReady();
+
+    expect(snapshot.contextValues.active_package).toBe('crm_core');
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('crm_core');
+  });
+});
+
+describe("persist: 'none' — not persisted at all", () => {
+  it('writes neither the URL nor sessionStorage, and still publishes the pick', async () => {
+    mount(NONE_SEL);
+    await optionsReady();
+
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+
+    // The pick is live for this mount — asserting only the two empty stores
+    // would also pass for a selector that produced nothing at all.
+    await waitFor(() => expect(snapshot.contextValues.active_package).toBe('crm_core'));
+    expect(query().has(URL_KEY)).toBe(false);
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not restore a previous session, and does not read the URL', async () => {
+    sessionStorage.setItem(STORAGE_KEY, 'crm_core');
+
+    mount(NONE_SEL, `/apps/studio?${URL_KEY}=crm_core`);
+    await optionsReady();
+
+    // Neither store answers the read, so the selector starts from nothing and
+    // auto-selects the first option.
+    await waitFor(() => expect(snapshot.contextValues.active_package).toBe('billing'));
+    // Both stores are left exactly as they were — `'none'` writes nowhere.
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('crm_core');
+    expect(query().get(URL_KEY)).toBe('crm_core');
+  });
+
+  it('drops the pick when the shell remounts', async () => {
+    const first = mount(NONE_SEL);
+    await optionsReady();
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+    await waitFor(() => expect(snapshot.contextValues.active_package).toBe('crm_core'));
+
+    first.unmount();
+    mount(NONE_SEL);
+    await optionsReady();
+
+    // In-memory only: a new mount has no medium to recover `crm_core` from.
+    await waitFor(() => expect(snapshot.contextValues.active_package).toBe('billing'));
+  });
+});
+
+describe('collision warning follows the URL medium', () => {
+  it('does not warn when the id collision is on a non-`query` selector', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // `active_package` is grandfathered onto `?package=`, so a selector literally
+    // named `package` derives the same key — the one collision the legacy table
+    // can still produce. With the second selector on storage, nothing mirrors
+    // through the query string, so warning would be a false positive.
+    mount([
+      { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT }, persist: 'query' },
+      { id: 'package', label: 'Package (again)', optionsSource: { endpoint: PACKAGES_ENDPOINT }, persist: 'session' },
+    ]);
+    await optionsReady(2);
+
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('both map to the URL scope key'));
+    warn.mockRestore();
+  });
+});

--- a/packages/app-shell/src/layout/__tests__/ContextSelectors.scopeKey.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ContextSelectors.scopeKey.test.tsx
@@ -93,6 +93,14 @@ const TWO_SELECTORS: ContextSelectorDef[] = [
   { id: 'active_env', label: 'Environment', optionsSource: { endpoint: ENVS_ENDPOINT } },
 ];
 
+// Same pair on the storage medium — the per-selector scope key has a
+// sessionStorage half too, and `persist: 'session'` is what selects it now
+// (objectstack#5994). Values are read back per `objectui-ctx-<app>-<id>`.
+const TWO_SESSION_SELECTORS: ContextSelectorDef[] = [
+  { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT }, persist: 'session' },
+  { id: 'active_env', label: 'Environment', optionsSource: { endpoint: ENVS_ENDPOINT }, persist: 'session' },
+];
+
 /** Latest render's hook output plus the router's query string. */
 let snapshot: { contextValues: Record<string, string>; search: string };
 
@@ -179,26 +187,40 @@ describe('useAppContextSelectors — one URL scope key per selector', () => {
     expect(snapshot.contextValues.active_package).toBe('crm_core');
     expect(query().get('package')).toBe('crm_core');
     expect(query().get('active_env')).toBe('staging');
-    // The per-selector sessionStorage half was already correct; keep it pinned
-    // so the URL/session halves cannot drift apart again.
-    expect(sessionStorage.getItem('objectui-ctx-studio-active_env')).toBe('staging');
+    // Neither selector declares `persist`, so both are on the spec's `'query'`
+    // default and sessionStorage is not their medium (objectstack#5994). This
+    // assertion used to read `…-active_env` back as `'staging'`, from the
+    // unconditional storage mirror that made `'query'` and `'session'`
+    // indistinguishable; the mirror is gone, so both keys stay empty. The
+    // three-value matrix lives in `ContextSelectors.persist.test.tsx`.
+    expect(sessionStorage.getItem('objectui-ctx-studio-active_env')).toBeNull();
     expect(sessionStorage.getItem('objectui-ctx-studio-active_package')).toBeNull();
   });
 
-  it('re-applies each remembered scope under its own key', async () => {
+  it('restores each `session`-persisted scope from its own storage key', async () => {
+    // Replaces a case that pinned the deleted storage → URL bridge: it seeded
+    // both storage keys, mounted a param-less URL and expected the query string
+    // to gain both params (objectstack#5994 removed that bridge — storage is
+    // only `persist: 'session'`'s medium now, and it never writes the URL).
+    // The old case could not have reported that honestly either: `active_env`'s
+    // stored `'prod'` is ALSO its auto-selected first option, so that half would
+    // have stayed green while nothing was restored at all. Both values below are
+    // deliberately not the first option (`billing` / `prod`), and the surviving
+    // per-selector fact — two selectors, two independent scopes — is asserted on
+    // the storage keys instead.
     sessionStorage.setItem('objectui-ctx-studio-active_package', 'crm_core');
-    sessionStorage.setItem('objectui-ctx-studio-active_env', 'prod');
+    sessionStorage.setItem('objectui-ctx-studio-active_env', 'staging');
 
-    mount(TWO_SELECTORS, '/apps/studio');
+    mount(TWO_SESSION_SELECTORS, '/apps/studio');
+    await optionsReady('opt-crm_core', 'opt-staging');
 
-    await waitFor(() => {
-      expect(query().get('package')).toBe('crm_core');
-      expect(query().get('active_env')).toBe('prod');
-    });
     expect(snapshot.contextValues).toEqual({
       active_package: 'crm_core',
-      active_env: 'prod',
+      active_env: 'staging',
     });
+    // Restored into the values, never into the address bar.
+    expect(query().has('package')).toBe(false);
+    expect(query().has('active_env')).toBe(false);
   });
 
   it('publishes distinct nav template vars per selector id', async () => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5994

按维护者裁定(**enforce,不退役**;spec 不改)兑现 `AppContextSelectorSchema.persist` 的三个取值。spec 对该键的原话是 “Persist selection via URL query, sessionStorage, or not at all” —— **一值一介质**。而 `packages/app-shell/src/layout/ContextSelectors.tsx` 此前把每个选择器同时写进 sessionStorage 和 URL,读取侧再按 `URL ?? storage` 兜一次:于是 `'session'` 与 `'query'` 完全无差别,`'none'` 也只是跳过「从 storage 回灌 URL」那一个 effect,照样两处都写。

## 行为矩阵(三值 × 写入/恢复)

| persist | 写 URL query | 写 sessionStorage | 恢复来源 | 备注 |
|---|---|---|---|---|
| `'query'`(默认) | ✅ 只写自己派生的 query 键 | ❌ | 仅 URL | 旧版遗留的 `objectui-ctx-*` 条目既不读也不删,直接忽略 |
| `'session'` | ❌ 从不进地址栏 | ✅ `objectui-ctx-{app}-{id}` | 仅 sessionStorage | 同名 query 参数不再遮蔽它 |
| `'none'` | ❌ | ❌ | 无 —— 组件 state,随 mount 消亡 | 仍照常发布为导航模板变量 |

**读取侧与写入侧同等排他**:`'session'` 选择器不再从 query string 读回,`'query'` 选择器也不再从 storage 读回 —— 那个 `??` 正是两值同化的根因。想同时要「URL 反映」和「记忆兜底」,应当去 spec 加一个新取值,而不是让渲染器背着作者写第二处存储。

## 一并删掉的 storage → URL 回灌 effect

它是「两处都写」的配套设施:URL 缺参时用 storage 补回。一值一介质之后已无可桥接之物 —— `'query'` 作用域被无参导航丢掉时,由 `SelectorControl` 的 auto-select-first 重新确立(「不能停在空值上」本来就是该 effect 自述的存在理由);想要超出 URL 的记忆,作者显式声明 `'session'`,代价是不进地址栏。

dev 环境下「两个选择器撞同一个 scope 键」的告警随之只看 `'query'` 选择器:其余取值根本不碰 URL,再告警就是误报。

## 与裁定注记不符的一处实况(请复核)

裁定写道「默认仍是 `'query'`,只有显式声明 `'session'`/`'none'` 的作者会看到变化」。实测并非如此:Studio 在 framework 仓 `packages/platform-objects/src/apps/studio.app.ts` **显式声明了 `persist: 'query'`**,且它是全仓唯一声明 `contextSelectors` 的应用(objectui 里没有任何元数据声明过 `persist`)。所以本 PR 唯一影响到的就是它,而变化恰好是「只有你声明的那一处才生效」:

- `?package=` 的读写一切照旧 —— 六个 Studio 读取面、以及约 15 条导航元数据里的 `params: { package: '{active_package}' }`,全不受影响;
- 不再写 `objectui-ctx-studio-active_package`;
- 无参导航落到「首个 project 包」而不是「上次选中的包」(此前靠 storage 回灌)。

第三条是本 PR 唯一的用户可见退化,它是「兑现声明」的直接后果而非附带损伤:作者声明的介质是 URL,URL 里没有,就没有。`packages/app-shell/README.md` 的 Studio package scope 段落原写着 “repairs missing `?package=` … from the last selected package”,已按此改正。

## 测试

- 新增 `ContextSelectors.persist.test.tsx`:三值 × (写 URL / 写 storage / 恢复来源) 全矩阵,外加「`persist` 省略时套用 spec 的 `'query'` 默认」「`'none'` 在 remount 后丢弃」「非 `'query'` 选择器不再触发撞键告警」。每个用例都断言**两个**存储而非仅该取值命名的那一个 —— 「写了 URL」只是半句话,「且没碰 storage」才是坏掉的那半句。
- **反向验证(方向先判后跑)**:把实现整体退回 `origin/main`,19 个用例 **12 转红、7 保持绿**;保持绿的那 7 个断言的事实本来就成立(「从 URL 读回」、scope 键派生、legacy `?package=` 兼容钉、两个 `'query'` 选择器撞键告警、模板变量发布)。三个 `'none'` 用例也在转红之列 —— 测试文件里记了原因:`'none'` 的内存值来自新增 state,单独恢复被删的那两条写入并不会让它红,只有整体退回才会。
- 既有 `ContextSelectors.scopeKey.test.tsx` **逐条重判**(不是批量重写):一条断言翻转(默认取值下 storage 必须为空);一条**整体替换** —— 原 “re-applies each remembered scope under its own key” 钉的正是被删的回灌桥,而且它本就无法诚实报告:`active_env` 存的 `'prod'` 恰好也是它 auto-select 的首个选项,那一半即使什么都没恢复也会绿。替换后的用例改在 `persist: 'session'` 上钉「两个选择器、两把 storage 键、互不干扰、且都不进 URL」,两个取值都刻意避开首选项。

```
pnpm exec vitest run packages/app-shell/src/layout/__tests__/ContextSelectors.persist.test.tsx \
  packages/app-shell/src/layout/__tests__/ContextSelectors.scopeKey.test.tsx --maxWorkers=2
  → Test Files 2 passed (2) / Tests 19 passed (19)   连跑 5 次稳定

pnpm exec vitest run packages/app-shell/src/layout/__tests__/ --maxWorkers=2
  → Test Files 16 passed (16) / Tests 85 passed (85)  (整目录连跑 3 次绿;见下)

pnpm exec turbo run type-check --concurrency=2
  → Tasks: 78 successful, 78 total

pnpm exec eslint 「本 PR 三个改动文件」  → 0 errors
```

整目录**首跑**曾有 1 个 `waitFor` 超时的偶发红(随后连跑 3 次全绿,且本 PR 两个文件单跑 5/5 绿),报告为偶发而非隐瞒:失败栈是 `@testing-library` 的 real-timer 超时,即 AGENTS.md 记的「满并行下有界窗口被无界模块加载吃掉」那一类。本 PR 的 fixture 未声明 `icon`,`getIcon(undefined)` 返回静态导入的兜底图标,断言路径上没有 lazy 边界。

## 影响面核对

`useAppContextSelectors` 的消费者只有 `AppSidebar` / `UnifiedSidebar`,两者仅取 `contextValues` 与 `element`;全仓 `objectui-ctx` 的引用除本文件外只在上述两个测试文件里。其余 layout 测试的 fixture 均未声明 `contextSelectors`,已逐个 grep 确认。

> 注:objectui#3500 的前半段(per-selector scope 键派生 + Studio `?package=` grandfather)**已在 `origin/main` 落地**,本 PR 基于其形态,不存在串行冲突。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_