### PR TITLE
fix(app-shell): SchemaForm 读取归一化后的 `visibleWhen`,让 metadata-form 谓词首次真正生效

### DIFF
--- a/.changeset/schemaform-visiblewhen-os6331.md
+++ b/.changeset/schemaform-visiblewhen-os6331.md
@@ -1,0 +1,48 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Make metadata-form visibility predicates work again in the Setup/Studio admin
+engine: `SchemaForm` now reads the canonical `visibleWhen` key, falling back to
+the deprecated `visibleOn` alias (objectstack#6331).
+
+ADR-0089 renamed the FormView predicate `visibleOn` → `visibleWhen`, and the
+spec's normaliser REWRITES the alias rather than keeping both — a parsed
+`FormView` carries `visibleWhen` and no `visibleOn` at all. All five predicate
+read sites in `SchemaForm.tsx` looked at `visibleOn` only, so every spec-served
+predicate read as absent and each guard short-circuited to "visible". Every
+conditional field, section and tab in every metadata form rendered
+unconditionally.
+
+Measured over the bundled `@objectstack/spec@17`: `objectForm` carries 16
+sub-field predicates, `viewForm` 7, `actionForm` 6, `pageForm` 4 — all spelled
+`visibleWhen`, none spelled `visibleOn`. Every one of them was inert.
+
+Fixed sites: the flat per-property path, section-level, section field-level,
+the tabbed path's field probe, and `type: 'record'` row sub-fields. Spelling and
+precedence mirror the runtime record-form adapter (`@object-ui/plugin-form`
+`sectionFields.ts`) and the spec bridge (`@object-ui/react` `form-view.ts`),
+which already read `visibleWhen ?? visibleOn` — one dialect across the repo,
+canonical wins. `FormSectionSpec` / `FormFieldSpec` declare both keys, the alias
+marked `@deprecated`.
+
+**Visible behaviour change** — these predicates have never taken effect in a
+shipped build, so they switch on for the first time here:
+
+- Studio's object field list now shows only the type-relevant row sub-fields: a
+  `currency` field shows Min / Max / Precision / Scale, a `text` field shows Max
+  Length / Min Length, instead of all of them at once.
+- Page authoring hides Data Context / Layout / Template on a `list` page and
+  shows the Interface section, and the mirror for a record page. View, Action and
+  Report authoring forms gain their type-conditional sections and fields.
+
+Predicates authored with the deprecated alias keep working, including this app's
+own create schemas, which set `visibleOn` directly on raw JSONSchema properties
+(`view-create-body.ts`, `anchors.ts`) and never pass through the spec normaliser.
+
+Note for the rollout: the predicates must be `data.`-scoped to evaluate against
+the draft (objectstack#6254 corrected 16 bare spellings in `object.form.ts`). A
+backend still serving the pre-#6254 bare spelling now yields the opposite
+symptom — those sub-fields stay hidden rather than always shown — because the
+admin engine's evaluator resolves an unscoped identifier to `undefined` and the
+predicate goes false.

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.pageVisibility.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.pageVisibility.test.tsx
@@ -17,10 +17,17 @@ afterEach(cleanup);
  *
  * This test pins the renderer side of that contract: given the PR-#1817 form
  * shape and a draft carrying `type: 'list'`, `SectionedSchemaForm` evaluates
- * each `visibleOn` against `value` and renders the right sections. (The bug
+ * each predicate against `value` and renders the right sections. (The bug
  * report's "still shows Data Context + Layout" symptom turned out to be a
- * stale backend serving the pre-#1817 form — see the section labels below for
- * the exact predicates the backend must serve.)
+ * stale backend serving the pre-#1817 form.)
+ *
+ * NOTE (objectstack#6331): the `visibleOn` spelling below is the DEPRECATED
+ * ADR-0089 alias, so this file pins the legacy limb, not the shape a current
+ * backend serves — the spec normaliser rewrites the alias and ships
+ * `visibleWhen`. Because these fixtures spell the alias they stayed green while
+ * the reader was alias-only and every spec-served predicate was dead. The
+ * canonical key (and the bundled `pageForm` itself) is pinned in
+ * `SchemaForm.visibleWhen.test.tsx`.
  */
 
 // Minimal JSONSchema mirroring the page item fields the form references.

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.tsx
@@ -392,13 +392,44 @@ export interface FormViewSpec {
   sections?: FormSectionSpec[];
 }
 
+/** Wire shapes a visibility predicate arrives in: bare CEL, or `{dialect, source}`. */
+export type VisibilityPredicate = string | { dialect?: string; source: string };
+
+/**
+ * Read a visibility predicate off a spec node — **canonical key first**.
+ *
+ * ADR-0089 renamed the FormView predicate `visibleOn` → `visibleWhen`, and the
+ * spec's normaliser REWRITES the alias instead of keeping both: a parsed
+ * `FormView` carries `visibleWhen` and no `visibleOn` at all
+ * (`@objectstack/spec` `shared/visibility.ts`). Reading only `visibleOn` — what
+ * this admin engine did until objectstack#6331 — therefore found `undefined` on
+ * every spec-served form and short-circuited each predicate to "always
+ * visible", so conditional fields/sections rendered unconditionally.
+ *
+ * Spelling and precedence mirror the runtime record-form adapter
+ * (`@object-ui/plugin-form` `sectionFields.ts`: `fd.visibleWhen ?? fd.visibleOn`)
+ * so metadata-admin and the runtime form speak ONE dialect. The deprecated
+ * alias stays honoured because it still has live producers: hand-written
+ * layouts, and this app's own create schemas, which set `visibleOn` directly on
+ * raw JSONSchema properties (`view-create-body.ts`) — those never pass through
+ * the spec normaliser.
+ */
+function readVisibility(
+  node: { visibleWhen?: VisibilityPredicate; visibleOn?: VisibilityPredicate } | undefined | null,
+): VisibilityPredicate | undefined {
+  return node?.visibleWhen ?? node?.visibleOn;
+}
+
 export interface FormSectionSpec {
   label?: string;
   description?: string;
   collapsible?: boolean;
   collapsed?: boolean;
   columns?: 1 | 2 | 3 | 4;
-  visibleOn?: string | { dialect?: string; source: string };
+  /** Canonical section visibility predicate (ADR-0089). */
+  visibleWhen?: VisibilityPredicate;
+  /** @deprecated ADR-0089 alias of `visibleWhen`; still read for legacy layouts. */
+  visibleOn?: VisibilityPredicate;
   fields: Array<string | FormFieldSpec>;
 }
 
@@ -440,7 +471,10 @@ export interface FormFieldSpec {
   disclosure?: 'inline' | 'popover';
   /** For `type: 'code'` — syntax highlighting language (e.g. 'javascript', 'sql', 'json'). */
   language?: string;
-  visibleOn?: string | { dialect?: string; source: string };
+  /** Canonical field visibility predicate (ADR-0089). */
+  visibleWhen?: VisibilityPredicate;
+  /** @deprecated ADR-0089 alias of `visibleWhen`; still read for legacy layouts. */
+  visibleOn?: VisibilityPredicate;
   /** Sub-fields for `composite` (single embedded object) and `repeater`
    * (array of embedded objects) types. Recursive. */
   fields?: Array<string | FormFieldSpec>;
@@ -530,16 +564,16 @@ export function SchemaForm({
   // Resolve top-level object properties.
   const props = (effectiveSchema.properties ?? {}) as Record<string, JsonSchema>;
   const required: string[] = Array.isArray(effectiveSchema.required) ? effectiveSchema.required : [];
-  // Per-property `visibleOn` predicate context — the current draft under
+  // Per-property visibility predicate context — the current draft under
   // `data`, mirroring the sectioned form's field-level filtering. Lets a flat
   // (create) schema gate a field on a sibling value (e.g. show the list layout
-  // picker only when `data.viewKind == 'list'`). No `visibleOn` → always shown.
+  // picker only when `data.viewKind == 'list'`). No predicate → always shown.
   const predicateData = (value ?? {}) as Record<string, unknown>;
   const keys = orderKeys(Object.keys(props), fieldOrder)
     .filter((k) => !hiddenFields.includes(k))
     .filter((k) => {
-      const visibleOn = (props[k] as any)?.visibleOn;
-      return !visibleOn || evaluatePredicate(visibleOn, { data: predicateData });
+      const visibility = readVisibility(props[k] as any);
+      return !visibility || evaluatePredicate(visibility, { data: predicateData });
     });
 
   const v = value ?? {};
@@ -652,9 +686,10 @@ function SectionedSchemaForm({
   onChange: (key: string, val: unknown) => void;
 }) {
   const locale = useMetadataLocale();
-  const sections = (form.sections ?? []).filter(
-    (s) => !s.visibleOn || evaluatePredicate(s.visibleOn, { data: value }),
-  );
+  const sections = (form.sections ?? []).filter((s) => {
+    const visibility = readVisibility(s);
+    return !visibility || evaluatePredicate(visibility, { data: value });
+  });
 
   // Decide whether to render as tabs or stacked sections.
   const isTabbed = form.type === 'tabbed' && sections.length > 1;
@@ -665,7 +700,8 @@ function SectionedSchemaForm({
       .filter((f) => {
         if (f.hidden) return false;
         if (hiddenFields.includes(f.field)) return false;
-        if (f.visibleOn && !evaluatePredicate(f.visibleOn, { data: value })) {
+        const visibility = readVisibility(f);
+        if (visibility && !evaluatePredicate(visibility, { data: value })) {
           return false;
         }
         return true;
@@ -777,13 +813,12 @@ function SectionedSchemaForm({
       (s) =>
         s.fields
           .map(normaliseField)
-          .some(
-            (f) =>
-              !f.hidden &&
-              !hiddenFields.includes(f.field) &&
-              (!f.visibleOn ||
-                evaluatePredicate(f.visibleOn, { data: value })),
-          ),
+          .some((f) => {
+            if (f.hidden) return false;
+            if (hiddenFields.includes(f.field)) return false;
+            const visibility = readVisibility(f);
+            return !visibility || evaluatePredicate(visibility, { data: value });
+          }),
     );
     if (tabSections.length === 0) return null;
     const defaultTab = (tabSections[0].label ?? 'section-0').toLowerCase();
@@ -1890,7 +1925,8 @@ function RecordField({
                   onChange={(v) => renameItem(key, String(v ?? '').trim())}
                 />
                 {specs.map((s) => {
-                  if (s.visibleOn && !evaluatePredicate(s.visibleOn, { data: row })) return null;
+                  const visibility = readVisibility(s);
+                  if (visibility && !evaluatePredicate(visibility, { data: row })) return null;
                   const sub = pickSubSchema(schema, 'record', s.field);
                   return (
                     <FieldRow

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.visibleWhen.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.visibleWhen.test.tsx
@@ -1,0 +1,347 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+import { getPageForm, getPageSchema } from './page-schema';
+
+afterEach(cleanup);
+
+/**
+ * objectstack#6331 — metadata-form visibility predicates arrive as
+ * `visibleWhen`, not `visibleOn`.
+ *
+ * ADR-0089 renamed the FormView predicate and the spec's normaliser REWRITES
+ * the alias rather than keeping both: a parsed `FormView` carries `visibleWhen`
+ * and no `visibleOn` at all. A probe over the bundled `@objectstack/spec@17`
+ * forms this engine actually renders:
+ *
+ *   objectForm  70 sub-fields / 16 predicates / any visibleWhen: true / any visibleOn: false
+ *   pageForm     4 predicate nodes, all `visibleWhen`
+ *   viewForm     7 predicate nodes, all `visibleWhen`
+ *   actionForm   6 predicate nodes, all `visibleWhen`
+ *
+ * Until this fix all five SchemaForm read sites looked at `visibleOn` only, so
+ * every one of those predicates evaluated as absent and the guard short-circuited
+ * to "visible" — conditional fields and sections rendered unconditionally.
+ *
+ * These tests pin each of the five sites on the CANONICAL key, in both
+ * directions (true → shown, false → hidden), plus the deprecated alias (still
+ * honoured for hand-written layouts and this app's own create schemas) and the
+ * no-predicate default. Precedence mirrors `@object-ui/plugin-form`
+ * `sectionFields.ts` (`fd.visibleWhen ?? fd.visibleOn`) — one dialect, canonical
+ * wins.
+ */
+
+const schema = {
+  type: 'object',
+  properties: {
+    type: { type: 'string', title: 'Type' },
+    listOnly: { type: 'string', title: 'List Only' },
+    recordOnly: { type: 'string', title: 'Record Only' },
+  },
+};
+
+/* ── site 1: flat path, per-property predicate ───────────────────────────── */
+
+describe('SchemaForm flat path — per-property visibleWhen (objectstack#6331)', () => {
+  const flatSchema = {
+    type: 'object',
+    properties: {
+      viewKind: { type: 'string', title: 'View family' },
+      kind: { type: 'string', title: 'List layout', visibleWhen: "data.viewKind == 'list'" },
+      formType: { type: 'string', title: 'Form layout', visibleWhen: "data.viewKind == 'form'" },
+    },
+  };
+
+  it('shows the property whose visibleWhen is true and hides the false one', () => {
+    render(<SchemaForm schema={flatSchema} value={{ viewKind: 'list' }} onChange={() => {}} />);
+    expect(screen.getByText('List layout')).toBeInTheDocument();
+    expect(screen.queryByText('Form layout')).not.toBeInTheDocument();
+  });
+
+  it('flips with the draft', () => {
+    render(<SchemaForm schema={flatSchema} value={{ viewKind: 'form' }} onChange={() => {}} />);
+    expect(screen.getByText('Form layout')).toBeInTheDocument();
+    expect(screen.queryByText('List layout')).not.toBeInTheDocument();
+  });
+});
+
+/* ── site 2: sectioned path, section-level predicate ─────────────────────── */
+
+describe('SchemaForm sections — section-level visibleWhen (objectstack#6331)', () => {
+  const form = {
+    type: 'simple' as const,
+    sections: [
+      { label: 'Basics', fields: [{ field: 'type' }] },
+      {
+        label: 'Data Context',
+        visibleWhen: { dialect: 'cel', source: "data.type != 'list'" },
+        fields: [{ field: 'recordOnly' }],
+      },
+      {
+        label: 'Interface',
+        visibleWhen: "data.type == 'list'",
+        fields: [{ field: 'listOnly' }],
+      },
+    ],
+  };
+
+  it('hides the section whose visibleWhen is false and shows the true one', () => {
+    render(<SchemaForm schema={schema} form={form} value={{ type: 'list' }} onChange={() => {}} />);
+    expect(screen.getByText('Basics')).toBeInTheDocument();
+    expect(screen.queryByText('Data Context')).not.toBeInTheDocument();
+    expect(screen.queryByText('Record Only')).not.toBeInTheDocument();
+    expect(screen.getByText('Interface')).toBeInTheDocument();
+    expect(screen.getByText('List Only')).toBeInTheDocument();
+  });
+
+  it('flips for a non-list draft', () => {
+    render(<SchemaForm schema={schema} form={form} value={{ type: 'record' }} onChange={() => {}} />);
+    expect(screen.getByText('Data Context')).toBeInTheDocument();
+    expect(screen.getByText('Record Only')).toBeInTheDocument();
+    expect(screen.queryByText('Interface')).not.toBeInTheDocument();
+    expect(screen.queryByText('List Only')).not.toBeInTheDocument();
+  });
+});
+
+/* ── site 3: sectioned path, field-level predicate ───────────────────────── */
+
+describe('SchemaForm sections — field-level visibleWhen (objectstack#6331)', () => {
+  const form = {
+    type: 'simple' as const,
+    sections: [
+      {
+        label: 'Configuration',
+        fields: [
+          { field: 'type' },
+          { field: 'listOnly', visibleWhen: "data.type == 'list'" },
+          { field: 'recordOnly', visibleWhen: { dialect: 'cel', source: "data.type == 'record'" } },
+        ],
+      },
+    ],
+  };
+
+  it('renders only the fields whose visibleWhen holds', () => {
+    render(<SchemaForm schema={schema} form={form} value={{ type: 'list' }} onChange={() => {}} />);
+    expect(screen.getByText('Type')).toBeInTheDocument();
+    expect(screen.getByText('List Only')).toBeInTheDocument();
+    expect(screen.queryByText('Record Only')).not.toBeInTheDocument();
+  });
+
+  it('flips with the draft', () => {
+    render(<SchemaForm schema={schema} form={form} value={{ type: 'record' }} onChange={() => {}} />);
+    expect(screen.getByText('Record Only')).toBeInTheDocument();
+    expect(screen.queryByText('List Only')).not.toBeInTheDocument();
+  });
+
+  it('a field with no predicate always renders; both keys absent → shown', () => {
+    render(<SchemaForm schema={schema} form={form} value={{}} onChange={() => {}} />);
+    expect(screen.getByText('Type')).toBeInTheDocument();
+    expect(screen.queryByText('List Only')).not.toBeInTheDocument();
+    expect(screen.queryByText('Record Only')).not.toBeInTheDocument();
+  });
+});
+
+/* ── site 4: tabbed path, tab kept only if a field survives the predicate ── */
+
+describe('SchemaForm tabs — field visibleWhen decides whether a tab renders (objectstack#6331)', () => {
+  const tabbedForm = {
+    type: 'tabbed' as const,
+    sections: [
+      { label: 'General', fields: [{ field: 'type' }] },
+      { label: 'ListTab', fields: [{ field: 'listOnly', visibleWhen: "data.type == 'list'" }] },
+      { label: 'RecordTab', fields: [{ field: 'recordOnly', visibleWhen: "data.type == 'record'" }] },
+    ],
+  };
+
+  it('drops the tab whose only field is predicated away', () => {
+    render(<SchemaForm schema={schema} form={tabbedForm} value={{ type: 'list' }} onChange={() => {}} />);
+    expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'ListTab' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'RecordTab' })).not.toBeInTheDocument();
+  });
+
+  it('flips with the draft', () => {
+    render(<SchemaForm schema={schema} form={tabbedForm} value={{ type: 'record' }} onChange={() => {}} />);
+    expect(screen.getByRole('tab', { name: 'RecordTab' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'ListTab' })).not.toBeInTheDocument();
+  });
+});
+
+/* ── site 5: `type: 'record'` row sub-fields (Studio object field list) ───── */
+
+describe('SchemaForm record rows — sub-field visibleWhen (objectstack#6331)', () => {
+  // Mirrors the spec `objectForm`: a name-keyed `fields` record whose row
+  // sub-fields are gated on the row's own `type` (`data.type in [...]`).
+  const objectishSchema = {
+    type: 'object',
+    properties: {
+      fields: {
+        type: 'object',
+        additionalProperties: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', title: 'Name' },
+            type: { type: 'string', title: 'Type' },
+            precision: { type: 'number', title: 'Precision' },
+            maxLength: { type: 'number', title: 'Max Length' },
+          },
+        },
+      },
+    },
+  };
+  const objectishForm = {
+    type: 'simple' as const,
+    sections: [
+      {
+        label: 'Fields',
+        fields: [
+          {
+            field: 'fields',
+            type: 'record',
+            keyField: { field: 'name', label: 'Name' },
+            fields: [
+              { field: 'type' },
+              { field: 'precision', visibleWhen: "data.type in ['number','currency']" },
+              { field: 'maxLength', visibleWhen: "data.type in ['text','textarea']" },
+            ],
+          },
+        ],
+      },
+    ],
+  } as never;
+
+  it('a currency row shows Precision and hides Max Length', () => {
+    render(
+      <SchemaForm
+        schema={objectishSchema}
+        form={objectishForm}
+        value={{ fields: { amount: { type: 'currency', precision: 2 } } }}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('amount'));
+    expect(screen.getByText('Precision')).toBeInTheDocument();
+    expect(screen.queryByText('Max Length')).not.toBeInTheDocument();
+  });
+
+  it('a text row shows Max Length and hides Precision', () => {
+    render(
+      <SchemaForm
+        schema={objectishSchema}
+        form={objectishForm}
+        value={{ fields: { title: { type: 'text', maxLength: 80 } } }}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText('title'));
+    expect(screen.getByText('Max Length')).toBeInTheDocument();
+    expect(screen.queryByText('Precision')).not.toBeInTheDocument();
+  });
+});
+
+/* ── the deprecated alias, and precedence when both are authored ─────────── */
+
+describe('SchemaForm — deprecated `visibleOn` alias (objectstack#6331)', () => {
+  it('a legacy hand-written layout spelling only `visibleOn` still works', () => {
+    const legacyForm = {
+      type: 'simple' as const,
+      sections: [
+        { label: 'Basics', fields: [{ field: 'type' }] },
+        { label: 'Legacy', visibleOn: "data.type == 'list'", fields: [{ field: 'listOnly' }] },
+        {
+          label: 'LegacyField',
+          fields: [{ field: 'recordOnly', visibleOn: "data.type == 'record'" }],
+        },
+      ],
+    };
+    render(<SchemaForm schema={schema} form={legacyForm} value={{ type: 'list' }} onChange={() => {}} />);
+    expect(screen.getByText('Legacy')).toBeInTheDocument();
+    expect(screen.getByText('List Only')).toBeInTheDocument();
+    expect(screen.queryByText('Record Only')).not.toBeInTheDocument();
+  });
+
+  it('a legacy create schema spelling `visibleOn` on a raw JSONSchema property still works', () => {
+    // `view-create-body.ts` / `anchors.ts` author this shape directly; it never
+    // passes through the spec normaliser, so the alias is the live spelling.
+    const createSchema = {
+      type: 'object',
+      properties: {
+        viewKind: { type: 'string', title: 'View family' },
+        kind: { type: 'string', title: 'List layout', visibleOn: "data.viewKind == 'list'" },
+      },
+    };
+    render(<SchemaForm schema={createSchema} value={{ viewKind: 'list' }} onChange={() => {}} />);
+    expect(screen.getByText('List layout')).toBeInTheDocument();
+    cleanup();
+    render(<SchemaForm schema={createSchema} value={{ viewKind: 'form' }} onChange={() => {}} />);
+    expect(screen.queryByText('List layout')).not.toBeInTheDocument();
+  });
+
+});
+
+/* ── precedence: canonical over alias ────────────────────────────────────── */
+
+/**
+ * Deliberately its own block, not part of the alias suite above: reverse
+ * verification showed this test tracks the CANONICAL limb, not the alias one.
+ * Reverting the section read site to `visibleOn`-only turns it red along with
+ * the section tests, because the stale alias then decides the verdict. The
+ * alias tests above, by contrast, stay green under that revert — which is
+ * exactly why alias-spelled fixtures could never have caught this bug.
+ */
+describe('SchemaForm — visibleWhen wins over visibleOn (objectstack#6331)', () => {
+  it('canonical wins when a node carries both keys with conflicting predicates', () => {
+    const bothForm = {
+      type: 'simple' as const,
+      sections: [
+        {
+          label: 'Both',
+          // Canonical says show for a list draft; the stale alias says the
+          // opposite. `visibleWhen ?? visibleOn` must follow the canonical key.
+          visibleWhen: "data.type == 'list'",
+          visibleOn: "data.type == 'record'",
+          fields: [{ field: 'listOnly' }],
+        },
+      ],
+    };
+    render(<SchemaForm schema={schema} form={bothForm} value={{ type: 'list' }} onChange={() => {}} />);
+    expect(screen.getByText('Both')).toBeInTheDocument();
+    expect(screen.getByText('List Only')).toBeInTheDocument();
+  });
+});
+
+/* ── the real bundled spec form, not a hand-written mirror ───────────────── */
+
+describe('SchemaForm — bundled spec `pageForm` predicates are reachable (objectstack#6331)', () => {
+  /**
+   * The strongest pin: the Page inspector feeds `getPageForm()` — the BUNDLED
+   * `@objectstack/spec` FormView, post-ADR-0089 normalisation, i.e. carrying
+   * `visibleWhen` — straight into SchemaForm. If the reader ever regresses to
+   * `visibleOn` only, this goes red without anyone having to hand-transcribe
+   * the spec's predicates into a fixture (which is how #4984's family of dead
+   * rules stayed green).
+   */
+  const form = getPageForm();
+  const pageSchema = getPageSchema();
+
+  it('the spec ships `visibleWhen` (and not the alias) on the sections we assert', () => {
+    const dataContext = form?.sections?.find((s) => s.label === 'Data Context');
+    expect(dataContext).toBeDefined();
+    expect(dataContext?.visibleWhen).toBeDefined();
+    expect(dataContext?.visibleOn).toBeUndefined();
+  });
+
+  it('a `list` page hides the Data Context section; a record page shows it', () => {
+    render(
+      <SchemaForm schema={pageSchema} form={form} value={{ name: 'p', type: 'list' }} onChange={() => {}} />,
+    );
+    expect(screen.queryByText('Data Context')).not.toBeInTheDocument();
+    cleanup();
+    render(
+      <SchemaForm schema={pageSchema} form={form} value={{ name: 'p', type: 'record' }} onChange={() => {}} />,
+    );
+    expect(screen.getByText('Data Context')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6331

## 问题

ADR-0089 把 FormView 的可见性谓词从 `visibleOn` 改名为 `visibleWhen`,spec 的归一化是**改写**而非双写:parse 之后的 FormView 只带 `visibleWhen`,`visibleOn` 完全不存在。而 metadata-admin 的 `SchemaForm.tsx` **五个**谓词读取站点只读 `visibleOn`,于是每一条 spec 下发的谓词都读到 `undefined`,guard 短路成「可见」—— 所有 metadata 表单的条件字段、条件分区、条件页签一律恒显。

一次性探针跑在本仓实际安装的 `@objectstack/spec@17.0.0-rc.5` 上(读数入 issue 报告):

```
objectForm  70 sub-fields / 16 predicates / ANY_visibleWhen true / ANY_visibleOn false
pageForm     4 predicate nodes,全部 visibleWhen
viewForm     7 predicate nodes,全部 visibleWhen
actionForm   6 predicate nodes,全部 visibleWhen
```

33 条谓词,一条都没生效过。

## 修法

五个站点统一走一个 `readVisibility()`(canonical 在前):扁平逐属性、分区级、分区内字段级、tabbed 路径的字段探测、`type: 'record'` 行内子字段。拼法与优先级**镜像仓内既有适配**,不新造方言 —— `@object-ui/plugin-form` 的 `sectionFields.ts` 与 `@object-ui/react` 的 `form-view.ts` 早就是 `visibleWhen ?? visibleOn`。`FormSectionSpec` / `FormFieldSpec` 两处类型同时声明两个键,别名标 `@deprecated`。

别名这条腿保留不是「容错」,而是它**有活的生产者**:本 app 自己的 create schema 直接把 `visibleOn` 写在原始 JSONSchema 属性上(`view-create-body.ts`、`anchors.ts`),这条路径根本不经过 spec 归一化。

## 行为变更面(这些谓词从未在发布版里生效过,本 PR 是第一次打开)

- Studio 对象字段列表按类型显隐行内子字段:`currency` 字段只出 Min / Max / Precision / Scale,`text` 字段只出 Max Length / Min Length,不再一次性全出。
- Page 编辑:`list` 页隐藏 Data Context / Layout / Template 并显示 Interface 分区,record 页反之。View / Action / Report 表单同样拿回各自的类型条件分区与字段。

## 浏览器实证

临时探针页(未提交)把**真实 bundled spec 表单**喂进真实 `SchemaForm`,Playwright 驱动 Chromium 读数:

- `pageForm`,`type: home` → 分区 Basics / Data Context / Advanced,字段含 Template;切到 `type: list` → Data Context 与 Template 消失,`Interface (list pages)` 整棵子树出现。
- `objectForm` 的 `fields` record 节点(#6254 后的 `data.` 拼法),行 `type: currency` → `Min, Max, Precision, Scale`;切到 `text` → `Max Length, Min Length`。两向都对。

## 反向验证(方向先判后跑,逐站点点名)

五个站点各自还原成只读 `visibleOn`,红点与预判完全一致:站点1 → 扁平 2 红;站点2 → 分区 2 红 + bundled pageForm 渲染 1 红;站点3 → 字段级 3 红;站点4 → tabbed 2 红;站点5 → record 行 2 红。

一处预判需要更正:我原本写「别名 describe 在任何还原下都保持绿」,但站点2 还原时**多出第 4 个红点** —— 那条「canonical wins」测试虽然写在别名 describe 里,实际钉的是 canonical 优先级(删掉 canonical 腿后由过期别名定胜负,必然红)。已按它真正守的东西把它移进独立 describe 并注明。别名测试本身在每次还原下确实全绿 —— 这正是这个 bug 能长期潜伏的原因:别名拼法的 fixture 永远看不见它。

## rollout 注意

谓词必须是 `data.` 作用域才能对着草稿求值(objectstack#6254 修正了 `object.form.ts` 里 16 处裸拼法)。仍在下发 #6254 之前裸拼法的后端,配上本 PR 会得到**相反**症状 —— 这些子字段变成恒隐而非恒显,因为本引擎的求值器把未作用域标识符解析成 `undefined`、谓词判假。浏览器探针里两种拼法并排验证过。求值器这个「未解析标识符静默判假、与自身文档承诺的 fail-open 相反」的行为已另立 finding 单,不在本 PR 范围。

## 验证

- `pnpm --filter '@object-ui/app-shell^...' build` ✅
- 新 `SchemaForm.visibleWhen.test.tsx` + 既有三个 SchemaForm 测试文件 + repeaterUnion:`Test Files 5 passed (5) / Tests 26 passed (26)`
- 消费半径全量:`packages/app-shell/src/views/metadata-admin` → `Test Files 131 passed (131) / Tests 1272 passed | 1 skipped`
- `packages/core` 的 column-identity ratchet(按文件计数的闸门,确认新增 `??` 不撞它):7 passed
- 全仓 `pnpm exec turbo run type-check --concurrency=2`:`78 successful, 78 total`
- `node scripts/check-control-bytes.mjs`:OK(3799 tracked text files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_