### PR TITLE
fix(actions): forward bodyExtra end-to-end through the action chain

### DIFF
--- a/.changeset/quiet-doors-forward-bodyextra.md
+++ b/.changeset/quiet-doors-forward-bodyextra.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/components': patch
+'@object-ui/core': patch
+'@object-ui/types': patch
+---
+
+fix(actions): forward `bodyExtra` end-to-end through the action chain
+
+An action's static request body (`bodyExtra`) was dropped one hop before the
+`ActionRunner`: every action renderer forwards an explicit whitelist of keys, and
+none of them listed `bodyExtra`. Since `@objectstack/spec` 17 made it the only way
+a `type: 'api'` action can carry a payload (`params` keeps its single meaning as
+the parameter definition array), and the ADR-0087
+`inline-action-api-params-to-body-extra` conversion rewrites older object-form
+`params` pages onto it at load, a previously-working published page validated,
+published and then POSTed an empty body.
+
+`element:button`, `action:button`, `action:group`, `action:icon` and `action:menu`
+now forward the key; `ActionRunner.executeAPI` merges it into the request body
+**last** (so a constant always overrides a same-named user param, matching the
+console `apiHandler`); `ActionSchema` declares it; and a non-array `params` on a
+`type: 'api'` action keeps working for one version window with a dev-mode
+deprecation warning naming `bodyExtra`.

--- a/packages/components/src/__tests__/action-bodyExtra-forward.test.tsx
+++ b/packages/components/src/__tests__/action-bodyExtra-forward.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `bodyExtra` survives the renderer hop (objectstack#6837).
+ *
+ * Every action renderer forwards an EXPLICIT whitelist of keys to the
+ * `ActionRunner` — a deliberate list, not a spread, so that a key no renderer
+ * honours cannot look wired. The cost of that design is that a NEW key is
+ * invisible until it is added to each list, and `bodyExtra` was the live example:
+ * `@objectstack/spec` 17 made it the only way a `type: 'api'` action can carry a
+ * static request payload (#5777 ruling, direction A — `params` keeps its one
+ * meaning as the parameter DEFINITION array), and the ADR-0087 conversion
+ * rewrites old object-form `params` pages onto it at load. The whitelists then
+ * dropped it one hop before the runner, so a previously-working published page
+ * POSTed an empty body.
+ *
+ * These tests assert at the two ends that matter: what the runner RECEIVES
+ * (the forward itself) and what goes on the WIRE (the forward plus the runner's
+ * merge order). A test that only checked the props would have passed while the
+ * payload was still lost downstream.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider } from '@object-ui/react';
+import '../renderers/basic/elements';
+import '../renderers/action/action-button';
+import '../renderers/action/action-menu';
+
+function Registered({ type, schema }: { type: string; schema: any }) {
+  const C = ComponentRegistry.get(type);
+  if (!C) throw new Error(`${type} not registered`);
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
+  return <C schema={schema} />;
+}
+
+describe('bodyExtra survives the renderer forward whitelist', () => {
+  let api: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    api = vi.fn(async () => ({ success: true }));
+  });
+
+  /** The ActionDef the runner was handed for the click. */
+  const dispatched = () => api.mock.calls[0][0];
+
+  it('element:button forwards bodyExtra to the runner', async () => {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <Registered
+          type="element:button"
+          schema={{
+            type: 'element:button',
+            properties: {
+              label: 'Submit inquiry',
+              action: {
+                type: 'api',
+                target: '/api/v1/forms/contact-us/submit',
+                method: 'POST',
+                bodyExtra: { name: '{{page.inquiryName}}', source: 'web' },
+              },
+            },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Submit inquiry/i }));
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(dispatched().bodyExtra).toEqual({ name: '{{page.inquiryName}}', source: 'web' });
+  });
+
+  it('action:button forwards bodyExtra off a declared ActionSchema', async () => {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <Registered
+          type="action:button"
+          schema={{
+            type: 'api',
+            name: 'revoke_key',
+            label: 'Revoke',
+            target: '/api/v1/sys_api_key/k1',
+            method: 'PATCH',
+            bodyExtra: { revoked: true },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Revoke/i }));
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(dispatched().bodyExtra).toEqual({ revoked: true });
+  });
+
+  it('action:menu forwards bodyExtra for an overflow item', async () => {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <Registered
+          type="action:menu"
+          schema={{
+            type: 'action:menu',
+            label: 'More',
+            actions: [
+              {
+                type: 'api',
+                name: 'close_order',
+                label: 'Close order',
+                target: '/api/v1/order/close',
+                bodyExtra: { status: 'closed' },
+              },
+            ],
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    // Radix opens its dropdown on pointerdown, not click — same gesture the
+    // form-widget tests use for a Radix Select trigger.
+    fireEvent.pointerDown(screen.getByRole('button', { name: /More/i }), { button: 0 });
+    const item = await screen.findByText(/Close order/i);
+    fireEvent.click(item);
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(dispatched().bodyExtra).toEqual({ status: 'closed' });
+  });
+});
+
+describe('bodyExtra wins over a deprecated object-form params, end to end', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('renders, clicks, and puts bodyExtra last on the wire', async () => {
+    // No custom `api` handler here on purpose: the click has to travel the whole
+    // chain — renderer whitelist, then the runner's own executeAPI body assembly —
+    // so the merge order is asserted on the actual request body rather than on
+    // props. `status` is declared in BOTH places with different values, which is
+    // what makes a reversed merge red instead of a tie.
+    render(
+      <ActionProvider>
+        <Registered
+          type="element:button"
+          schema={{
+            type: 'element:button',
+            properties: {
+              label: 'Close order',
+              action: {
+                type: 'api',
+                target: '/api/v1/order/close',
+                method: 'PATCH',
+                params: { status: 'draft', note: 'from the user' },
+                bodyExtra: { status: 'closed', closed_at: '2026-08-09' },
+              },
+            },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Close order/i }));
+    await waitFor(() => expect(global.fetch as any).toHaveBeenCalledOnce());
+
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body).toEqual({
+      status: 'closed',       // bodyExtra beat the same-named param
+      note: 'from the user',  // the untouched param still rides along
+      closed_at: '2026-08-09',
+    });
+  });
+});

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -103,6 +103,11 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
           endpoint: schema.endpoint,
           method: schema.method,
           ...paramsPayload,
+          // Static request body of a `type: 'api'` action, merged last by the
+          // runner. Separate key from `params` by the objectstack#5777 ruling —
+          // dropping it here left a declared action whose payload lives only in
+          // `bodyExtra` POSTing nothing (objectstack#6837).
+          bodyExtra: schema.bodyExtra,
           confirmText: schema.confirmText,
           successMessage: schema.successMessage,
           errorMessage: schema.errorMessage,

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -220,6 +220,8 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
           endpoint: action.endpoint,
           method: action.method,
           params: action.params as Record<string, any> | undefined,
+          // See action-button.tsx — the `type: 'api'` payload key (objectstack#6837).
+          bodyExtra: action.bodyExtra,
           confirmText: action.confirmText,
           successMessage: action.successMessage,
           errorMessage: action.errorMessage,

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -66,6 +66,8 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
           endpoint: schema.endpoint,
           method: schema.method,
           params: schema.params as Record<string, any> | undefined,
+          // See action-button.tsx — the `type: 'api'` payload key (objectstack#6837).
+          bodyExtra: schema.bodyExtra,
           confirmText: schema.confirmText,
           successMessage: schema.successMessage,
           errorMessage: schema.errorMessage,

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -165,6 +165,8 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
             endpoint: action.endpoint,
             method: action.method,
             params: action.params as Record<string, any> | undefined,
+            // See action-button.tsx — the `type: 'api'` payload key (objectstack#6837).
+            bodyExtra: action.bodyExtra,
             confirmText: action.confirmText,
             successMessage: action.successMessage,
             errorMessage: action.errorMessage,

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -240,6 +240,14 @@ function ElementButtonRenderer({ schema }: { schema: any }) {
         navigate: action.navigate,
         to: action.to,
         opensInNewTab: action.opensInNewTab,
+        // The static request body of a `type: 'api'` action. `params` is the
+        // parameter DEFINITION array and carries no payload (objectstack#5777
+        // ruling, direction A), so without this forward an inline action's
+        // payload has no way through: it validates, publishes, and is dropped
+        // exactly here, one hop before the runner (objectstack#6837). With it,
+        // this list matches spec's `InlineActionSchema` pick list field for
+        // field — that pick list is the contract this whitelist mirrors.
+        bodyExtra: action.bodyExtra,
         confirmText: action.confirmText,
         successMessage: action.successMessage,
         errorMessage: action.errorMessage,

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -26,7 +26,7 @@ import type { ActionInput as SpecActionInput } from '@objectstack/spec/ui';
 import { ExpressionEvaluator } from '../evaluator/ExpressionEvaluator';
 import { toPredicateInput } from '../evaluator/predicateInput';
 import { globalUndoManager, type UndoableOperation } from './UndoManager';
-import { warnOnUnknownActionKeys } from './actionKeys';
+import { warnOnDeprecatedObjectParams, warnOnUnknownActionKeys } from './actionKeys';
 
 export interface ActionResult {
   success: boolean;
@@ -761,6 +761,14 @@ export class ActionRunner {
       // does nothing" shape. Dev-only, warn-once, changes nothing (#4075 step 1).
       warnOnUnknownActionKeys(action);
 
+      // The compat window for the object-form `params` payload (#5777, maintainer
+      // ruling 2026-08-06 direction A). Checked HERE, before the param-collection
+      // block below rewrites `action.params` into a values map — after that point
+      // an action that authored a legitimate ActionParam[] DEFINITION array also
+      // carries an object under `params`, and the warning could no longer tell the
+      // two apart. Dev-only, warn-once, changes nothing.
+      warnOnDeprecatedObjectParams(action);
+
       // Resolve the action type
       const actionType = action.type || action.actionType || action.name || '';
 
@@ -1359,6 +1367,39 @@ export class ActionRunner {
   }
 
   /**
+   * Assemble the request body for the runner's OWN `executeAPI` — the path taken
+   * when no host registered an `api` handler.
+   *
+   * `bodyExtra` is merged LAST, which is the spec's documented semantics for the
+   * key ("Static request-body fields for a `type:'api'` action, merged last
+   * (overrides user params)") and what the console's `apiHandler` already does on
+   * both of its branches. Before objectstack#6837 this path read `action.params`
+   * alone and never looked at `bodyExtra` at all, so an action whose payload lives
+   * entirely in `bodyExtra` — the shape the ADR-0087 conversion produces from an
+   * old object-form `params` page — POSTed an empty body here.
+   *
+   * `params` contributes only in its DEPRECATED non-array form (the compat window
+   * #5777 opened; see `warnOnDeprecatedObjectParams`). An ARRAY `params` is a
+   * parameter DEFINITION list, not a payload: it reaches this method unconsumed
+   * only when no `paramCollectionHandler` is mounted, and POSTing the definitions
+   * as the request body was never a payload any endpoint wanted. It now falls
+   * through to the context record like an absent `params` does.
+   */
+  private buildApiRequestBody(action: ActionDef): unknown {
+    const asRecord = (value: unknown): Record<string, unknown> | undefined => (
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : undefined
+    );
+    const bodyExtra = asRecord(action.bodyExtra);
+    const base = asRecord(action.params) ?? this.context.data;
+    // Nothing to merge: hand back the historical value as-is, so a host passing a
+    // non-object `context.data` still serializes exactly what it used to.
+    if (!bodyExtra) return base ?? {};
+    return { ...asRecord(base), ...bodyExtra };
+  }
+
+  /**
    * Execute API action — supports both simple string endpoint and complex ApiConfig.
    */
   private async executeAPI(action: ActionDef): Promise<ActionResult> {
@@ -1380,7 +1421,7 @@ export class ActionRunner {
         // Simple string endpoint
         url = this.interpolateTarget(apiConfig, action);
         method = action.method || 'POST';
-        body = JSON.stringify(action.params || this.context.data || {});
+        body = JSON.stringify(this.buildApiRequestBody(action));
       } else {
         // Complex ApiConfig
         const config = apiConfig as ApiConfig;
@@ -1401,7 +1442,7 @@ export class ActionRunner {
             ? config.body
             : JSON.stringify(config.body);
         } else if (method !== 'GET' && method !== 'HEAD') {
-          body = JSON.stringify(action.params || this.context.data || {});
+          body = JSON.stringify(this.buildApiRequestBody(action));
         }
       }
 

--- a/packages/core/src/actions/__tests__/ActionRunner.bodyExtra.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.bodyExtra.test.ts
@@ -1,0 +1,218 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `bodyExtra` on the runner's own API path, and the object-form `params`
+ * deprecation window (objectstack#6837, the objectui half of #5777).
+ *
+ * Two facts under test, and they are different facts:
+ *
+ * 1. **Merge order** — `bodyExtra` is merged LAST, so a constant always beats a
+ *    same-named user param. That is spec's documented semantics for the key
+ *    ("merged last (overrides user params)") and what the console `apiHandler`
+ *    already did on both branches; `ActionRunner.executeAPI` — the path taken
+ *    when no host registered an `api` handler — never read the key at all, so an
+ *    action whose payload lives only in `bodyExtra` POSTed an empty body.
+ * 2. **The compat window is scoped** — the deprecation warning fires for exactly
+ *    the shape `@objectstack/spec`'s `inline-action-api-params-to-body-extra`
+ *    conversion rewrites (non-array `params` on `type: 'api'`), and for nothing
+ *    else. The negative cases carry as much weight as the positive one: a
+ *    warning on a `type: 'url'` action would prescribe `bodyExtra` for
+ *    objectstack#6828's third meaning, and a warning on a host's `_rowRecord`
+ *    stash would fire on nearly every declared-action click.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ActionRunner } from '../ActionRunner';
+import { resetActionKeyWarnings } from '../actionKeys';
+
+/** The body the runner handed to `fetch`, parsed. */
+function sentBody(): any {
+  const init = (global.fetch as any).mock.calls[0][1];
+  return JSON.parse(init.body);
+}
+
+function okFetch() {
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
+}
+
+describe('ActionRunner.executeAPI — bodyExtra', () => {
+  beforeEach(() => {
+    resetActionKeyWarnings();
+    okFetch();
+  });
+
+  it('sends bodyExtra as the payload when the action has no other body source', async () => {
+    // The shape the ADR-0087 conversion produces from an old object-form
+    // `params` page. Before #6837 this POSTed the context record (or `{}`) and
+    // the author's payload never left the browser.
+    const runner = new ActionRunner({});
+    const result = await runner.execute({
+      type: 'api',
+      target: '/api/v1/forms/contact-us/submit',
+      bodyExtra: { name: 'Ada', email: 'ada@example.com' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(sentBody()).toEqual({ name: 'Ada', email: 'ada@example.com' });
+  });
+
+  it('merges bodyExtra LAST — a constant beats a same-named collected param', async () => {
+    // The merge-order fact. `status` is present in BOTH places with different
+    // values, so a reversed merge is a red test rather than a silent tie.
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      target: '/api/v1/sys_api_key/k1',
+      method: 'PATCH',
+      params: { status: 'draft', note: 'from the user' },
+      bodyExtra: { status: 'closed', revoked: true },
+    });
+
+    expect(sentBody()).toEqual({
+      status: 'closed',      // bodyExtra won
+      note: 'from the user', // untouched param survives
+      revoked: true,
+    });
+  });
+
+  it('merges bodyExtra over the context record on the ApiConfig branch too', async () => {
+    // Same assembly, second call site (`api` as an object rather than a string).
+    const runner = new ActionRunner({ data: { id: 7, status: 'draft' } });
+    await runner.execute({
+      type: 'api',
+      api: { url: '/api/v1/order/7', method: 'PATCH' },
+      bodyExtra: { status: 'closed' },
+    });
+
+    expect(sentBody()).toEqual({ id: 7, status: 'closed' });
+  });
+
+  it('leaves the body untouched when no bodyExtra is declared (back-compat)', async () => {
+    const runner = new ActionRunner({ data: { id: 1, name: 'Test' } });
+    await runner.execute({ type: 'api', target: '/api/v1/thing' });
+
+    expect(sentBody()).toEqual({ id: 1, name: 'Test' });
+  });
+
+  it('ignores an ARRAY params — it is a definition list, never a payload', async () => {
+    // Reachable only with no paramCollectionHandler mounted. POSTing the
+    // ActionParam[] definitions as the request body was never a payload any
+    // endpoint wanted; it now falls through to the context record, and
+    // `bodyExtra` still lands.
+    const runner = new ActionRunner({ data: { id: 3 } });
+    await runner.execute({
+      type: 'api',
+      target: '/api/v1/thing',
+      params: [{ name: 'reason', label: 'Reason', type: 'text' }] as any,
+      bodyExtra: { archived: true },
+    });
+
+    expect(sentBody()).toEqual({ id: 3, archived: true });
+  });
+});
+
+describe('ActionRunner — object-form params deprecation window (#5777)', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetActionKeyWarnings();
+    okFetch();
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  /** Every `console.warn` argument list, flattened to one searchable string. */
+  const warnings = () => warn.mock.calls.map((c) => c.join(' ')).join('\n');
+
+  it('warns and names bodyExtra for a non-array params on a type:api action', async () => {
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      name: 'submit_inquiry',
+      target: '/api/v1/forms/contact-us/submit',
+      params: { name: '{{page.inquiryName}}' },
+    });
+
+    expect(warnings()).toMatch(/bodyExtra/);
+    expect(warnings()).toMatch(/submit_inquiry/);
+    // …and it still WORKS. That is what makes it a window rather than a break.
+    expect(sentBody()).toEqual({ name: '{{page.inquiryName}}' });
+  });
+
+  it('warns once per action, not once per click', async () => {
+    const runner = new ActionRunner({});
+    const action = { type: 'api', name: 'a1', target: '/api/v1/x', params: { k: 1 } };
+    await runner.execute({ ...action });
+    await runner.execute({ ...action });
+    await runner.execute({ ...action });
+
+    const hits = warn.mock.calls.filter((c) => c.join(' ').includes('bodyExtra'));
+    expect(hits).toHaveLength(1);
+  });
+
+  it('stays SILENT for a type:url action — #6828 is a third meaning, not this one', async () => {
+    // `interpolateTarget`'s `${param.X}` scope and `executeUrl`'s `params.newTab`
+    // read object-form params on a url action. `bodyExtra` is not their
+    // replacement, so prescribing it here would be wrong advice. The `api` guard
+    // mirrors the ADR-0087 conversion's own guard.
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'url',
+      name: 'open_report',
+      target: '/reports/x?id=${param.reportId}',
+      params: { reportId: 'r1', newTab: true },
+    });
+
+    expect(warnings()).not.toMatch(/bodyExtra/);
+  });
+
+  it('stays SILENT for an ARRAY params — that is the surviving meaning of the key', async () => {
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      name: 'close_order',
+      target: '/api/v1/order/close',
+      params: [{ name: 'reason', label: 'Reason', type: 'text' }] as any,
+    });
+
+    expect(warnings()).not.toMatch(/bodyExtra/);
+  });
+
+  it('stays SILENT for a host-stashed params object (_rowRecord / recordId)', async () => {
+    // DeclaredActionsBar dispatches `params: { _rowRecord: record }` and the api
+    // handler lifts `recordId` out of the field values. Neither is an authored
+    // payload, and warning on them would fire on nearly every declared action.
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      name: 'approve',
+      target: '/api/v1/approvals/approve',
+      params: { _rowRecord: { id: 'rec1' }, _selectedIds: ['rec1'], recordId: 'rec1' },
+    });
+
+    expect(warnings()).not.toMatch(/bodyExtra/);
+  });
+
+  it('still warns when an authored key rides ALONGSIDE the host stash', async () => {
+    // Discrimination proof for the filter above: it must not become a blanket
+    // "params object with any underscore key is fine".
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      name: 'approve_with_payload',
+      target: '/api/v1/approvals/approve',
+      params: { _rowRecord: { id: 'rec1' }, decision: 'approved' },
+    });
+
+    expect(warnings()).toMatch(/bodyExtra/);
+  });
+});

--- a/packages/core/src/actions/actionKeys.ts
+++ b/packages/core/src/actions/actionKeys.ts
@@ -304,3 +304,83 @@ export function warnOnUnknownActionKeys(action: object | null | undefined, where
       'still carries `[key: string]: any`, so the compiler cannot see this (objectstack#4075).',
   );
 }
+
+/**
+ * Keys a HOST stashes into an action's `params` for the runner's own plumbing,
+ * rather than an author writing them there as a request payload.
+ *
+ * {@link warnOnDeprecatedObjectParams} has to tell "the author put the payload in
+ * `params`" (the shape objectstack#5777 retires) apart from "a host stashed row
+ * context there" (a shape the runner itself asks for, and that is not going
+ * away). `DeclaredActionsBar` dispatches `params: { _rowRecord: record }`,
+ * `RelatedRecordActionsBridge` does the same, and `ObjectGrid` adds
+ * `_selectedIds`; the api handler lifts `recordId` out of the field values
+ * before it updates. Warning on those would fire on nearly every declared-action
+ * click and prescribe `bodyExtra`, which is the wrong home for all of them.
+ *
+ * The `_` prefix is the existing convention for the stash — `recordId` is its one
+ * unprefixed member, so it is listed rather than inferred.
+ */
+const HOST_STASHED_PARAM_KEYS: ReadonlySet<string> = new Set(['recordId']);
+
+const isAuthoredParamKey = (key: string): boolean =>
+  !key.startsWith('_') && !HOST_STASHED_PARAM_KEYS.has(key);
+
+/**
+ * Does this action carry the DEPRECATED object-form `params` — a static request
+ * payload written under the key that means "parameter definitions"?
+ *
+ * The discriminator is `Array.isArray` and the type guard is `api`, mirroring
+ * `@objectstack/spec`'s `inline-action-api-params-to-body-extra` conversion
+ * (ADR-0087 D2) key for key. Contract parity with the producer is the point: the
+ * conversion rewrites exactly this shape to `bodyExtra` at load, so the runner
+ * must recognize exactly the same shape as "the thing that got rewritten".
+ *
+ * The `api` guard is also what keeps the deprecation out of objectstack#6828's
+ * territory — object-form `params` on a `type: 'url'` action is a THIRD meaning
+ * (`interpolateTarget`'s `${param.X}` scope, `executeUrl`'s `params.newTab`) and
+ * `bodyExtra` is NOT its replacement. Do not widen this guard without that
+ * ruling.
+ */
+export function hasDeprecatedObjectParams(action: object | null | undefined): boolean {
+  if (!action || typeof action !== 'object') return false;
+  const { type, actionType, params } = action as {
+    type?: unknown; actionType?: unknown; params?: unknown;
+  };
+  if ((type ?? actionType) !== 'api') return false;
+  if (!params || typeof params !== 'object' || Array.isArray(params)) return false;
+  return Object.keys(params).some(isAuthoredParamKey);
+}
+
+/**
+ * Dev-mode only: name the object-form `params` that `@objectstack/spec` 17 already
+ * refuses at the authoring door, and prescribe `bodyExtra`.
+ *
+ * This is the audible half of the compat window the maintainer's 2026-08-06
+ * ruling on objectstack#5777 ordered (direction A — a separate key, no same-name
+ * union): the runner keeps READING a non-array `params` as the static payload for
+ * one version window, says so, and the arm is deleted at 18. The loud half lives
+ * at the producer, where it belongs — spec's `params` field refuses the object
+ * form outright with a message naming `bodyExtra`, and the ADR-0087 conversion
+ * rewrites sources that still carry it. So a warning is the correct severity
+ * HERE: by the time metadata reaches this runner the producer has already had its
+ * say, and what is left to catch is a host composing an ActionDef in code.
+ *
+ * Dev-only and warn-once, matching {@link warnOnUnknownActionKeys} — a warning
+ * that floods a production console is a warning that gets muted.
+ */
+export function warnOnDeprecatedObjectParams(action: object | null | undefined, where = 'ActionRunner'): void {
+  if (!isDev()) return;
+  if (!hasDeprecatedObjectParams(action)) return;
+  const name = (action as { name?: unknown; type?: unknown })?.name ?? '(unnamed)';
+  const memo = `deprecated-object-params:${String(name)}`;
+  if (warned.has(memo)) return;
+  warned.add(memo);
+  console.warn(
+    `[${where}] action "${String(name)}" carries a static request payload in \`params\`. ` +
+      '`params` is the parameter DEFINITION array (fields collected from the user before the ' +
+      'action runs), never a payload map — put the payload in `bodyExtra` instead ' +
+      '(objectstack#5777). Still read as the payload for one version window; the arm is ' +
+      'removed at 18. `bodyExtra` is merged LAST, so it overrides anything left here.',
+  );
+}

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -429,7 +429,27 @@ export interface ActionSchema {
    * checkbox instead of being treated as an instruction.
    */
   params?: ActionParam[];
-  
+
+  /**
+   * Static request-body fields for a `type: 'api'` action, merged into the
+   * outgoing body **last** so constants always win over user-collected params
+   * and over `recordIdParam`.
+   *
+   * This — not {@link params} — is where a payload goes. The two are different
+   * concepts that shared one name until objectstack#5777: `params` describes
+   * fields to COLLECT (an `ActionParam[]` definition array), `bodyExtra` is data
+   * to SEND. The maintainer's 2026-08-06 ruling took direction A (a separate
+   * key, no same-name union), so `@objectstack/spec` 17 refuses an object under
+   * `params` by name and rewrites sources that still carry it via the
+   * `inline-action-api-params-to-body-extra` conversion (ADR-0087 D2).
+   *
+   * Declared here so the action renderers can forward it off a typed
+   * `ActionSchema` rather than through an `as any` cast — the renderers are the
+   * consumers this field exists for (objectstack#6837). Typed off the spec
+   * rather than restated, so the shape cannot drift from the contract.
+   */
+  bodyExtra?: SpecAction['bodyExtra'];
+
   // === Feedback ===
   
   /** Confirmation text to show before execution */


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6837

## 背景

`bodyExtra` 是 `type: 'api'` 动作的静态请求体。spec 半边(objectstack#6819)已合入:`params` 只保留「参数定义数组」一个含义,ADR-0087 的 `inline-action-api-params-to-body-extra` 转换在**加载时**把旧的对象形 `params` 页面改写成 `bodyExtra`。

而 objectui 每个动作渲染器都用一份**显式转发白名单**(刻意如此:没有渲染器读的键不该看起来像接好了),这些名单里都没有 `bodyExtra`。结果:一个已发布页面通过校验、成功发布,然后在到达 runner 前**一跳丢掉 payload**,POST 出去是空体。这是发布完整性件。

## 四个落点的实况

| 落点 | 实况 |
|---|---|
| ① `packages/components/src/renderers/basic/elements.tsx` | **已改**。`element:button` 白名单补 `bodyExtra: action.bodyExtra`。补完后该名单与 spec 的 `InlineActionSchema` pick list **逐字段对齐**(那份 pick list 正是本白名单所镜像的契约)。同文件只有这一处 `execute()` 转发。 |
| ② `packages/core/src/actions/ActionRunner.ts` — 弃用窗 + 合并顺序 | **已改**。派发词说的 `:780/790` 分叉在实际 main 上是 `:840/850`,且那处分叉服务于**参数收集**,与 payload 组装无关 —— runner 里原本**完全没有**读 `bodyExtra` 的地方。所以合并顺序落在 runner 自己组装 body 的位置(`executeAPI`),弃用告警落在「非数组 `params`」的判定上。 |
| ③ `executeAPI` 回退路径 | **已改**,但文件不是派发词写的 `useConsoleActionRuntime.tsx` —— issue 正文点明这一处在 `ActionRunner.executeAPI`(`body = JSON.stringify(action.params \|\| context.data \|\| {})`,两个调用点)。**`useConsoleActionRuntime.tsx` 免改**:`apiHandler` 两条分支都已经把 `bodyExtra` 最后合并(`:308`-309 绝对 HTTP 分支、`:385`-386 dataSource 分支),复核后未动一行。 |
| ④ `packages/types/src/ui-action.ts` | **已改**。`ActionSchema` 补 `bodyExtra`,类型**从 spec 派生**而非手抄,形状不会与契约漂移。 |

## 具体做了什么

**转发白名单(components)。** 除 `element:button` 外,四个**声明式**动作渲染器(`action:button` / `action:group` / `action:icon` / `action:menu`)同样漏掉了 `bodyExtra`,一并补上。这是对派发范围的一次**有意扩大,在此明说请复核**:理由是落点 ④ 只有这些渲染器才是它的消费者 —— `element:button` 走 `readProps` 拿到的是无类型的对象袋,根本用不到 `ActionSchema`,所以若不补这四处,落点 ④ 就是一个「没有任何渲染器读」的死字段,恰好是 spec 注释里警告的那种失败。改动本身是同一个键、同一跳、零契约决策。`action:bar` 免改:它把成员动作整体 spread 到子渲染器上,天然带过去(已核验)。

**合并顺序(core)。** `ActionRunner.executeAPI`(没有 host 注册 `api` handler 时走的路径)现在集中组装 body,`bodyExtra` **最后合并**,与 spec 对该键的描述("merged last (overrides user params)")以及 console `apiHandler` 两条分支一致。顺带:数组形 `params` 不再进 body —— 它是定义列表不是 payload,把 `ActionParam` 定义当请求体 POST 出去从来不是任何端点想要的。

**弃用窗(core)。** 非数组 `params` 在 `type: 'api'` 上继续被当作静态 payload 读一个版本窗口,并在 dev 下 warn-once 地点名 `bodyExtra`。判定条件与 ADR-0087 转换**逐条对齐**(`Array.isArray` 作判别式 + `api` 类型守卫),因此:

- ⛔ **不碰 objectstack#6828**:url 型动作上的对象形 `params` 是**第三义**(`interpolateTarget` 的 `param` 作用域、`executeUrl` 的 `params.newTab`),`bodyExtra` 不是它的替代品,`api` 守卫正是把这条挡在外面的东西。
- 过滤掉 host 塞进 `params` 的内部键(`_rowRecord` / `_selectedIds` / `recordId`),否则几乎每次声明式动作点击都会误报。

告警是 dev-only + warn-once,与既有的 `warnOnUnknownActionKeys` 同一套约定。**响亮的那一半在生产者侧**(contract-first):spec 的 `params` 字段直接拒收对象形并在报错里点名 `bodyExtra`,转换负责改写存量源 —— 到了 runner 这一层生产者已经说过话,剩下要兜的只是 host 在代码里手搓 ActionDef 的情形,所以 warn 是正确的严重级别。

## 测试

新增两个文件,`pnpm exec vitest run` 全绿:

- `packages/core/src/actions/__tests__/ActionRunner.bodyExtra.test.ts`(11 个)—— 合并顺序(`status` 在两边取不同值,反向合并必红)、纯 `bodyExtra` payload、`ApiConfig` 分支、无 `bodyExtra` 时的 back-compat 钉子、数组 `params` 不进 body;弃用窗的正例 + **四个负例**(url 型静默、数组静默、host stash 静默、host stash 旁边带真实作者键时仍告警)。
- `packages/components/src/__tests__/action-bodyExtra-forward.test.tsx`(4 个)—— `element:button` / `action:button` / `action:menu` 三个渲染器转发到 runner;以及一条**端到端**:渲染 → 点击 → 断言真实 fetch 请求体里 `bodyExtra` 压过同名旧 `params` 键(不注册自定义 handler,让点击走完白名单 + runner 合并两跳)。

**反向验证分三次跑,方向事先各自预测,结果全部吻合:**

1. 撤掉 runner 改动 → 11 个里 **7 红**;其中三条 `stays SILENT` 负例**依旧绿** —— 因为功能不在时什么都不 warn,`not.toMatch` 空绿。这一点如实记录,撤销**无法**验证这三条。
2. 于是改为**放宽守卫**(去掉 `api` 判定 + 去掉 host stash 过滤)→ url 负例与 host stash 负例**转红**。
3. 再放宽 `Array.isArray` 那条 → 数组负例也**转红**。三条负例各由其对应的守卫分支单独钉住,非空绿。
4. 剥掉三个渲染器的 `bodyExtra` 转发 → 4 个**全红**,端到端那条的请求体退回 `status: 'draft'`(旧 `params` 未被覆盖),正是预测的样子。

其余验证:

- `pnpm exec vitest run packages/core/ packages/types/` → **99 files / 1909 tests passed**(含 `actionKeys.pin.test.ts`)
- `pnpm exec vitest run packages/components/` → **102 files / 823 tests passed**
- app-shell 相关面 `useConsoleActionRuntime.test.tsx` + `RecordDetailView.headerApiInterpolation.test.tsx` → **47 passed**
- `pnpm exec turbo run type-check --concurrency=2` → **78/78 successful,零错**
- `check-control-bytes.mjs` OK;`check-changeset-no-major.mjs` OK;改动文件控制字节自查零命中
- eslint 改动文件:**0 error**

## changeset

`.changeset/quiet-doors-forward-bodyextra.md`,`patch` 覆盖 `@object-ui/components` / `@object-ui/core` / `@object-ui/types`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_