### PR TITLE
fix(plugin-list): allowAddTab 的「新增 tab」按钮接上会话级行为(objectstack#5236)

### DIFF
--- a/.changeset/userfilters-allowaddtab-session-tabs-os5236.md
+++ b/.changeset/userfilters-allowaddtab-session-tabs-os5236.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/plugin-list': patch
+---
+
+`userFilters` tabs: the `allowAddTab` button now adds a tab instead of doing nothing (objectstack#5236)
+
+The affordance `allowAddTab` renders had hover styling and `title="Add filter tab"` but no `onClick`, and `TabFilters` took no add-tab callback at all — a control that looked fully clickable and did nothing, which disguises "not implemented" as "a bug where clicking does nothing". That mattered more once objectstack#5073 promoted `allowAddTab` into the spec's `UserFiltersSchema`: the key became discoverable through JSON Schema, the Studio SchemaForm and the reference docs, so an author writing `allowAddTab: true` gets a declaration the runtime did not honour.
+
+Clicking it now opens a small naming popover (the same Popover primitive the filter chips and the "More" overflow already use). Confirming a name adds a tab to the same bar as the presets, carrying a snapshot of the conditions applied at that moment, and selects it. Session tabs also carry a remove affordance; authored presets deliberately do not, since those are metadata. Removing the active session tab re-selects the author's default with the same precedence the initial mount uses, so the bar is never left with no active tab while the removed tab's conditions stay applied.
+
+The new tab is **session-scoped, held in component state** — no `sys_metadata` write, no API call, no web storage, per ADR-0047 ("an end user's filter choices are session-scoped and never become metadata"). `sessionStorage` was available and deliberately not used: `UserFilters` receives no object or view identity, so any storage key it could invent would be shared by every list in the browser tab, surfacing one list's ad-hoc tabs on another's bar. Persistence beyond the mount, if ever wanted, belongs to the host that already owns the session channel for filter selections (`onSelectionsChange` mirrored into `uf_*` URL params) and can key it by view. The synthetic tab id is reported through `onSelectionsChange` like any other tab switch, so a host mirroring it into the URL hands it back on the next mount, where the existing id check finds no such tab and falls back to the author's default.
+
+No public API change: `UserFiltersProps` is untouched, and `allowAddTab: false` / an omitted `allowAddTab` still render no affordance at all.

--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from 'react';
-import { cn, Button, Popover, PopoverContent, PopoverTrigger, LookupValuePicker } from '@object-ui/components';
+import { cn, Button, Input, Popover, PopoverContent, PopoverTrigger, LookupValuePicker } from '@object-ui/components';
 import { ChevronDown, X, Plus } from 'lucide-react';
 import type { ListViewSchema } from '@object-ui/types';
 import { normalizeFilterOperator } from '@objectstack/spec/ui';
@@ -708,6 +708,16 @@ interface TabFiltersProps {
   onSelectionsChange?: (selections: Record<string, Array<string | number | boolean>>) => void;
 }
 
+/**
+ * A tab the END USER added at runtime through `allowAddTab` — never an
+ * authored preset, never metadata. See {@link TabFilters} for the scope rules.
+ */
+interface SessionTab {
+  id: string;
+  label: string;
+  filters: any[];
+}
+
 function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, className, initialTab, onSelectionsChange }: TabFiltersProps) {
   const [activeTab, setActiveTab] = React.useState<string>(() => {
     // URL-restored tab wins over the author's default.
@@ -718,18 +728,49 @@ function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, classNa
     return defaultTab?.id || (showAllRecords ? '__all__' : tabs[0]?.id || '');
   });
 
+  /**
+   * User-added tabs (`allowAddTab`), held in **component state only**.
+   *
+   * ADR-0047 scopes an end user's filter choices to the session and forbids
+   * them ever becoming metadata, so this renderer stays a metadata READER:
+   * adding a tab writes no `sys_metadata`, calls no API, and touches no
+   * storage. Component state (not `sessionStorage`) is the deliberate pick —
+   * `UserFilters` receives no object/view identity, so a shared
+   * `sessionStorage` key would surface one list's ad-hoc tabs on another
+   * list's bar in the same browser tab. Persistence beyond the mount, if it
+   * is ever wanted, belongs to the host that already owns the session channel
+   * for filter selections (`onSelectionsChange` → `uf_*` URL params) and can
+   * key it by view.
+   */
+  const [sessionTabs, setSessionTabs] = React.useState<SessionTab[]>([]);
+  const [addOpen, setAddOpen] = React.useState(false);
+  const [draftLabel, setDraftLabel] = React.useState('');
+
+  /**
+   * Conditions currently applied for `tabId` — the preset's filters, the
+   * session tab's snapshot, or `[]` for the synthetic "All records" tab (and
+   * for an id nothing answers to, which is how a stale restored `_tab`
+   * degrades). In tabs mode this IS the whole filter state of the bar: the
+   * component owns no other filter surface.
+   */
+  const filtersForTab = React.useCallback(
+    (tabId: string): any[] => {
+      if (tabId === '__all__') return [];
+      // `normalizeTabPresets` guarantees `id` on every preset it emits.
+      const preset = tabs.find(t => t.id === tabId);
+      if (preset) return preset.filters || [];
+      return sessionTabs.find(t => t.id === tabId)?.filters || [];
+    },
+    [tabs, sessionTabs],
+  );
+
   const handleTabChange = React.useCallback(
     (tabId: string) => {
       setActiveTab(tabId);
-      if (tabId === '__all__') {
-        onFilterChange([]);
-      } else {
-        const tab = tabs.find(t => t.id === tabId);
-        onFilterChange(tab?.filters || []);
-      }
+      onFilterChange(filtersForTab(tabId));
       onSelectionsChange?.({ _tab: [tabId] });
     },
-    [tabs, onFilterChange, onSelectionsChange],
+    [filtersForTab, onFilterChange, onSelectionsChange],
   );
 
   const allTabs = React.useMemo(() => {
@@ -739,6 +780,60 @@ function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, classNa
     }
     return result;
   }, [tabs, showAllRecords]);
+
+  /**
+   * Confirm the naming input: snapshot the conditions currently applied under
+   * the typed label and select the new tab.
+   *
+   * The snapshot source is the active tab's conditions because that is the
+   * entire filter state tabs mode carries (see {@link filtersForTab}) — the
+   * new tab therefore reproduces exactly the rows the user is looking at when
+   * they press Add. Each condition is copied so a later preset change cannot
+   * alias into the session tab.
+   *
+   * The synthetic id is reported through `onSelectionsChange` like any other
+   * tab switch, so the host's mirror stays truthful. A host that persists it
+   * (`uf__tab` in the URL) hands it back as `initialTab` on the next mount,
+   * where the existing id check finds no such tab and falls back to the
+   * author's default — a session tab cannot outlive the mount by the back door.
+   */
+  const handleAddTab = React.useCallback(() => {
+    const label = draftLabel.trim();
+    if (!label) return;
+    // Synthetic, session-only id. `__…__` mirrors the "__all__" spelling this
+    // component already uses for the tab it invents; the loop keeps it clear
+    // of author-defined preset ids.
+    const taken = new Set<string>([
+      ...tabs.map(t => t.id ?? t.name ?? ''),
+      ...sessionTabs.map(t => t.id),
+    ]);
+    let seq = sessionTabs.length + 1;
+    while (taken.has(`__session_${seq}__`)) seq += 1;
+    const id = `__session_${seq}__`;
+    const snapshot = filtersForTab(activeTab).map(c => (Array.isArray(c) ? [...c] : c));
+    setSessionTabs(prev => [...prev, { id, label, filters: snapshot }]);
+    setActiveTab(id);
+    setDraftLabel('');
+    setAddOpen(false);
+    onFilterChange(snapshot);
+    onSelectionsChange?.({ _tab: [id] });
+  }, [draftLabel, tabs, sessionTabs, filtersForTab, activeTab, onFilterChange, onSelectionsChange]);
+
+  /**
+   * Drop a session tab. Removing the ACTIVE one re-selects the author's
+   * default with the same precedence the initial mount uses, so the bar is
+   * never left with no active tab while the removed tab's conditions stay
+   * applied. Presets have no remove affordance — they are metadata.
+   */
+  const handleRemoveTab = React.useCallback(
+    (tabId: string) => {
+      setSessionTabs(prev => prev.filter(t => t.id !== tabId));
+      if (activeTab !== tabId) return;
+      const defaultTab = tabs.find(t => t.default);
+      handleTabChange(defaultTab?.id || (showAllRecords ? '__all__' : tabs[0]?.id || ''));
+    },
+    [activeTab, tabs, showAllRecords, handleTabChange],
+  );
 
   // Emit the initially-active tab's filters on mount (restored tab or
   // author default — `activeTab` already resolved the precedence).
@@ -772,14 +867,91 @@ function TabFilters({ tabs, showAllRecords, allowAddTab, onFilterChange, classNa
           </button>
         );
       })}
+      {/* User-added tabs, in the same bar as the presets. They carry a remove
+          affordance (presets don't — those are metadata), so the pill is a
+          wrapper around two buttons rather than one button. */}
+      {sessionTabs.map(tab => {
+        const isActive = activeTab === tab.id;
+        return (
+          <span
+            key={tab.id}
+            className={cn(
+              'inline-flex items-center h-7 rounded-md transition-colors shrink-0',
+              isActive ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted',
+            )}
+          >
+            <button
+              type="button"
+              data-testid={`filter-tab-${tab.id}`}
+              onClick={() => handleTabChange(tab.id)}
+              className="inline-flex items-center h-7 pl-3 pr-1 text-xs font-medium rounded-l-md"
+            >
+              {tab.label}
+            </button>
+            <button
+              type="button"
+              data-testid={`filter-tab-remove-${tab.id}`}
+              onClick={() => handleRemoveTab(tab.id)}
+              title="Remove tab"
+              aria-label={`Remove tab ${tab.label}`}
+              className="inline-flex items-center h-7 pl-0.5 pr-2 rounded-r-md opacity-60 hover:opacity-100"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        );
+      })}
       {allowAddTab && (
-        <button
-          className="inline-flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted shrink-0"
-          data-testid="filter-tab-add"
-          title="Add filter tab"
+        <Popover
+          open={addOpen}
+          onOpenChange={open => {
+            setAddOpen(open);
+            if (!open) setDraftLabel('');
+          }}
         >
-          <Plus className="h-3.5 w-3.5" />
-        </button>
+          <PopoverTrigger asChild>
+            <button
+              // Explicit type: a Radix trigger keeps the HTML default of
+              // `submit`, which submits an enclosing form on click (#3344).
+              type="button"
+              className="inline-flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted shrink-0"
+              data-testid="filter-tab-add"
+              title="Add filter tab"
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-64 p-2 space-y-2" data-testid="filter-tab-add-content">
+            <p className="text-xs text-muted-foreground">
+              Name this tab. It keeps the filters applied right now, and lives in this session only.
+            </p>
+            <Input
+              autoFocus
+              value={draftLabel}
+              onChange={e => setDraftLabel(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddTab();
+                }
+              }}
+              placeholder="Tab name"
+              className="h-7 text-xs"
+              data-testid="filter-tab-add-input"
+            />
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                className="h-7 px-2 text-xs"
+                disabled={!draftLabel.trim()}
+                data-testid="filter-tab-add-confirm"
+                onClick={handleAddTab}
+              >
+                Add tab
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
       )}
     </div>
   );

--- a/packages/plugin-list/src/__tests__/UserFilters.addTab.test.tsx
+++ b/packages/plugin-list/src/__tests__/UserFilters.addTab.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectstack#5236 — `allowAddTab` rendered a dead button.
+ *
+ * The affordance had hover styling and `title="Add filter tab"` but no
+ * `onClick`, and the component took no add-tab callback: a control that looked
+ * fully clickable and did nothing, which disguises "not implemented" as "a bug
+ * where clicking does nothing". Maintainer ruling **A1** (2026-08-06) wired it
+ * up instead of removing it: naming input, snapshot of the filters currently
+ * applied, and the new tab is **session-scoped**.
+ *
+ * Session scope here means **component state** — no metadata, no API, no
+ * storage (ADR-0047: an end user's filter choices are session-scoped and never
+ * become metadata). `sessionStorage` was available and deliberately not used:
+ * `UserFilters` receives no object/view identity, so any storage key it could
+ * invent would be shared by every list in the browser tab. These tests pin
+ * that decision from both sides — nothing is written (`Storage.setItem`, the
+ * data source, `fetch` all stay at zero calls) and nothing survives a remount.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { SchemaRendererProvider } from '@object-ui/react';
+import { UserFilters } from '../UserFilters';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+/** Two authored presets, the first one the author's default. */
+const tabsConfig = {
+  element: 'tabs' as const,
+  tabs: [
+    {
+      name: 'open',
+      label: 'Open',
+      isDefault: true,
+      filter: [{ field: 'status', operator: 'equals', value: 'todo' }],
+    },
+    {
+      name: 'urgent',
+      label: 'Urgent',
+      filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }],
+    },
+  ],
+};
+
+const OPEN_CONDITIONS = [['status', 'equals', 'todo']];
+const URGENT_CONDITIONS = [['priority', 'equals', 'urgent']];
+
+/** Open the naming popover, type `label`, confirm. */
+function addTab(label: string) {
+  fireEvent.click(screen.getByTestId('filter-tab-add'));
+  fireEvent.change(screen.getByTestId('filter-tab-add-input'), { target: { value: label } });
+  fireEvent.click(screen.getByTestId('filter-tab-add-confirm'));
+}
+
+/** The pill wrapper carries the active styling for a session tab. */
+function pillClassName(tabId: string): string {
+  return screen.getByTestId(`filter-tab-${tabId}`).parentElement?.className ?? '';
+}
+
+describe('UserFilters tabs — allowAddTab (objectstack#5236, ruling A1)', () => {
+  it('clicking add opens a naming input; confirming snapshots the applied filters into a new, selected tab', () => {
+    const onFilterChange = vi.fn();
+    const onSelectionsChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ ...tabsConfig, allowAddTab: true }}
+        data={[]}
+        onFilterChange={onFilterChange}
+        onSelectionsChange={onSelectionsChange}
+      />,
+    );
+
+    // Move off the default so the snapshot has something distinguishable in it.
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    expect(onFilterChange).toHaveBeenLastCalledWith(URGENT_CONDITIONS);
+
+    // The add affordance now opens a naming input rather than doing nothing.
+    fireEvent.click(screen.getByTestId('filter-tab-add'));
+    expect(screen.getByTestId('filter-tab-add-content')).toBeTruthy();
+    const input = screen.getByTestId('filter-tab-add-input') as HTMLInputElement;
+    // Empty name cannot be confirmed.
+    expect((screen.getByTestId('filter-tab-add-confirm') as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: '  My urgent  ' } });
+    expect((screen.getByTestId('filter-tab-add-confirm') as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId('filter-tab-add-confirm'));
+
+    // The new tab renders in the same bar, label trimmed, and is selected.
+    const added = screen.getByTestId('filter-tab-__session_1__');
+    expect(added.textContent).toBe('My urgent');
+    expect(added.closest('[data-testid="user-filters-tabs"]')).toBeTruthy();
+    expect(pillClassName('__session_1__')).toContain('bg-primary');
+    expect(onSelectionsChange).toHaveBeenLastCalledWith({ _tab: ['__session_1__'] });
+
+    // …carrying the conditions that were applied when it was created.
+    expect(onFilterChange).toHaveBeenLastCalledWith(URGENT_CONDITIONS);
+  });
+
+  it('the snapshot is stored, not recomputed — switching away and back re-emits the captured conditions', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ ...tabsConfig, allowAddTab: true }}
+        data={[]}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    addTab('Snapshot');
+
+    fireEvent.click(screen.getByTestId('filter-tab-open'));
+    expect(onFilterChange).toHaveBeenLastCalledWith(OPEN_CONDITIONS);
+
+    fireEvent.click(screen.getByTestId('filter-tab-__session_1__'));
+    expect(onFilterChange).toHaveBeenLastCalledWith(URGENT_CONDITIONS);
+    expect(pillClassName('__session_1__')).toContain('bg-primary');
+  });
+
+  it('snapshots an empty condition set when "All records" is the active tab', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ ...tabsConfig, allowAddTab: true }}
+        data={[]}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-tab-__all__'));
+    addTab('Everything');
+    expect(onFilterChange).toHaveBeenLastCalledWith([]);
+
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    fireEvent.click(screen.getByTestId('filter-tab-__session_1__'));
+    expect(onFilterChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('confirms on Enter as well as on the button', () => {
+    render(
+      <UserFilters config={{ ...tabsConfig, allowAddTab: true }} data={[]} onFilterChange={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-tab-add'));
+    fireEvent.change(screen.getByTestId('filter-tab-add-input'), { target: { value: 'Typed' } });
+    fireEvent.keyDown(screen.getByTestId('filter-tab-add-input'), { key: 'Enter' });
+
+    expect(screen.getByTestId('filter-tab-__session_1__').textContent).toBe('Typed');
+  });
+
+  it('adds a second tab under its own id', () => {
+    render(
+      <UserFilters config={{ ...tabsConfig, allowAddTab: true }} data={[]} onFilterChange={vi.fn()} />,
+    );
+
+    addTab('First');
+    addTab('Second');
+
+    expect(screen.getByTestId('filter-tab-__session_1__').textContent).toBe('First');
+    expect(screen.getByTestId('filter-tab-__session_2__').textContent).toBe('Second');
+  });
+});
+
+describe('UserFilters tabs — adding a tab writes nothing (ADR-0047)', () => {
+  it('calls no data-source method, no fetch, and no web storage', () => {
+    const dataSource = {
+      find: vi.fn().mockResolvedValue([]),
+      findOne: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    // Storage.prototype covers both sessionStorage and localStorage.
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+
+    render(
+      <SchemaRendererProvider dataSource={dataSource}>
+        <UserFilters
+          config={{ ...tabsConfig, allowAddTab: true }}
+          data={[]}
+          onFilterChange={vi.fn()}
+        />
+      </SchemaRendererProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    addTab('No metadata please');
+    expect(screen.getByTestId('filter-tab-__session_1__')).toBeTruthy();
+
+    // A session tab is not metadata: no write API of any shape was reached.
+    expect(dataSource.create).toHaveBeenCalledTimes(0);
+    expect(dataSource.update).toHaveBeenCalledTimes(0);
+    expect(dataSource.delete).toHaveBeenCalledTimes(0);
+    expect(dataSource.find).toHaveBeenCalledTimes(0);
+    expect(dataSource.findOne).toHaveBeenCalledTimes(0);
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+    expect(setItem).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('UserFilters tabs — session tabs do not survive a remount', () => {
+  it('drops the added tab and falls back to the author default, even when the host mirrored the tab id back', () => {
+    const first = vi.fn();
+    const { unmount } = render(
+      <UserFilters config={{ ...tabsConfig, allowAddTab: true }} data={[]} onFilterChange={first} />,
+    );
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    addTab('Ephemeral');
+    expect(screen.getByTestId('filter-tab-__session_1__')).toBeTruthy();
+
+    unmount();
+
+    // The host persists `_tab` (uf_* URL params), so it hands the synthetic id
+    // straight back. The tab itself is gone and the restored id resolves to
+    // nothing, so the author's default wins — no empty bar, no stale filters.
+    const second = vi.fn();
+    render(
+      <UserFilters
+        config={{ ...tabsConfig, allowAddTab: true }}
+        data={[]}
+        onFilterChange={second}
+        initialSelections={{ _tab: ['__session_1__'] }}
+      />,
+    );
+
+    expect(screen.queryByTestId('filter-tab-__session_1__')).toBeNull();
+    expect(screen.queryByText('Ephemeral')).toBeNull();
+    expect(second).toHaveBeenLastCalledWith(OPEN_CONDITIONS);
+    expect(screen.getByTestId('filter-tab-open').className).toContain('bg-primary');
+  });
+});
+
+describe('UserFilters tabs — session tabs can be removed', () => {
+  it('removing the active session tab re-selects the author default and re-emits its filters', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ ...tabsConfig, allowAddTab: true }}
+        data={[]}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    addTab('Temporary');
+    fireEvent.click(screen.getByTestId('filter-tab-remove-__session_1__'));
+
+    expect(screen.queryByTestId('filter-tab-__session_1__')).toBeNull();
+    expect(onFilterChange).toHaveBeenLastCalledWith(OPEN_CONDITIONS);
+    expect(screen.getByTestId('filter-tab-open').className).toContain('bg-primary');
+  });
+
+  it('removing an inactive session tab leaves the applied filters alone', () => {
+    const onFilterChange = vi.fn();
+    render(
+      <UserFilters
+        config={{ ...tabsConfig, allowAddTab: true }}
+        data={[]}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    addTab('Temporary');
+    fireEvent.click(screen.getByTestId('filter-tab-urgent'));
+    const callsBefore = onFilterChange.mock.calls.length;
+
+    fireEvent.click(screen.getByTestId('filter-tab-remove-__session_1__'));
+
+    expect(screen.queryByTestId('filter-tab-__session_1__')).toBeNull();
+    expect(onFilterChange.mock.calls.length).toBe(callsBefore);
+    expect(screen.getByTestId('filter-tab-urgent').className).toContain('bg-primary');
+  });
+
+  it('offers no remove affordance on authored presets', () => {
+    render(
+      <UserFilters config={{ ...tabsConfig, allowAddTab: true }} data={[]} onFilterChange={vi.fn()} />,
+    );
+
+    expect(screen.queryByTestId('filter-tab-remove-open')).toBeNull();
+    expect(screen.queryByTestId('filter-tab-remove-urgent')).toBeNull();
+    expect(screen.queryByTestId('filter-tab-remove-__all__')).toBeNull();
+  });
+});
+
+describe('UserFilters tabs — allowAddTab off (regression)', () => {
+  it('renders no add affordance when allowAddTab is false', () => {
+    render(
+      <UserFilters config={{ ...tabsConfig, allowAddTab: false }} data={[]} onFilterChange={vi.fn()} />,
+    );
+    expect(screen.getByTestId('user-filters-tabs')).toBeTruthy();
+    expect(screen.queryByTestId('filter-tab-add')).toBeNull();
+  });
+
+  it('renders no add affordance when allowAddTab is omitted', () => {
+    render(<UserFilters config={tabsConfig} data={[]} onFilterChange={vi.fn()} />);
+    expect(screen.getByTestId('user-filters-tabs')).toBeTruthy();
+    expect(screen.queryByTestId('filter-tab-add')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5236

## 背景

`packages/plugin-list/src/UserFilters.tsx` 的 `TabFilters` 里,`allowAddTab` 渲染的「新增 tab」按钮(`data-testid="filter-tab-add"`)带 hover 态与 `title="Add filter tab"`,**却没有 `onClick`**,组件也没有任何 `onAddTab` / `addTab` 回调入参 —— 一个看起来完全可点、点下去什么都不发生的控件。它比「没有这个按钮」更糟:把「未实现」伪装成「点了没反应的 bug」。

objectstack#5073 把该键提升进 spec 的 `UserFiltersSchema` 之后这更要紧:键在 JSON Schema、Studio SchemaForm、参考文档三处可见,AI 作者会照着 schema 写 `allowAddTab: true`,而运行时不兑现 —— declared ≠ enforced 的 UI 变体。

**前提复核(对 `origin/main` 实测,非阅读推断)**:premise 成立,只是行号漂了 —— 按钮现在在 `UserFilters.tsx:778`(issue 正文写的 `:742`)。全仓 `git grep origin/main` 命中:`filter-tab-add` 仅 1 处(那个按钮),`onAddTab` 零命中,`allowAddTab` 4 处(prop 声明、传入、渲染 + `packages/types` 的 zod 镜像与其测试),确认无任何回调入参存在。

## 本 PR 做了什么(维护者裁决 A1,评论 5200253516)

- **命名输入**:点击 add 按钮弹出 Popover(复用该组件筛选 chip 与 More 溢出已在用的 Popover 原语,贴合现有交互习惯),内含名称输入框 + 「Add tab」确认按钮;空白名不可确认,回车等价于点确认。
- **快照当前筛选**:确认后把「此刻已应用的筛选条件」快照进新 tab 并立即选中。tabs 模式下这就是该组件承载的全部筛选状态(组件不拥有第二个筛选面),所以新 tab 复现的正是用户按下 Add 时看到的那批记录。每条 condition 逐条拷贝,预设日后变动不会串到会话级 tab 上。
- **与预设同栏**:新 tab 渲染在同一栏预设之后,可自由选中/切换。
- **删除入口(带上了)**:会话级 tab 带一个 x;预设**不带** —— 那是元数据。删掉当前选中的会话级 tab 时,按初次挂载的同一优先级回落到作者默认 tab 并重新发出其条件,不会留下「无选中 tab、却仍套用着已删 tab 条件」的状态。实现成本确实低(一个 span 包两个 button,预设那条渲染分支一字未动)。

## 会话级语义:选了**组件态**,不是 sessionStorage(理由)

⛔ 不写 `sys_metadata`、不发任何 API、不碰 web storage —— ADR-0047:end-user 的筛选选择 session-scoped、从不落成元数据,渲染器保持元数据**读方**。

`sessionStorage` 是可用的,刻意没用:`UserFilters` 拿不到 object/view 身份,它能自己编出的任何 storage key 都会被同一浏览器 tab 里的**所有列表**共用,把一个列表的临时 tab 显示到另一个列表的栏上 —— 那是个真 bug,换来的只是刷新后还在。要跨挂载存续,该归**已经握着筛选选择会话通道**(`onSelectionsChange` → `uf_*` URL 参数)、且能按视图分键的宿主;那需要给 `UserFiltersProps` 加公共入参,是裁决没做的契约决定,不该顺手塞进本单。

合成 tab id(`__session_1__`,沿用该文件为自己发明的 `__all__` 拼法)与其它 tab 切换一样经 `onSelectionsChange` 上报,宿主镜像的真实性不被撒谎;宿主把它持久到 `uf__tab` 后下次挂载还回来时,**既有的** id 校验找不到该 tab,回落作者默认 —— 会话级 tab 没有走后门跨挂载存活的路径。这条降级被测试钉住了。

## 测试

新增 `packages/plugin-list/src/__tests__/UserFilters.addTab.test.tsx`(12 例):

1. 点 add 出命名输入 → 输入名字 → 确认:新 tab 出现在同栏、label 已 trim、处于选中态、`onSelectionsChange` 报 `{ _tab: ['__session_1__'] }`、`onFilterChange` 最后一次调用等于创建时刻已应用的条件;空白名时确认按钮 disabled。
2. 快照是**存下来的、不是重算的**:切走到别的预设再切回来,重新发出被捕获的那批条件。
3. 以「All records」为当前 tab 时快照出空条件集。
4. 回车确认;连加两个 tab 各得自己的 id。
5. **零元数据写入**:mock dataSource(`create`/`update`/`delete`/`find`/`findOne`)+ `fetch` + `Storage.prototype.setItem` 全部断言 0 次调用。该例**先**断言新 tab 确实出现,再断言这些 0 —— 否则「加不出 tab」也能让 0 断言空转通过(objectstack PR #5046 的空转陷阱)。
6. **会话级存续语义**:unmount 后重新 render(并模拟宿主把 `_tab: ['__session_1__']` 从 URL 还回来)→ 会话级 tab 不在了,活动 tab 回落作者默认,重新发出默认条件。
7. 删除:删当前选中的 → 回落默认并重新发条件;删非选中的 → 已应用条件一动不动(`onFilterChange` 调用次数不变);预设**没有**删除入口。
8. 既有行为回归:`allowAddTab: false` 与**缺省**时都完全不渲染该控件(筛选栏本体照常渲染)。

命令与实测输出:

```
pnpm exec vitest run packages/plugin-list/src/__tests__/UserFilters.addTab.test.tsx --maxWorkers=2
  Test Files  1 passed (1)       Tests  12 passed (12)

pnpm exec vitest run packages/plugin-list/ --maxWorkers=2
  Test Files  24 passed (24)     Tests  376 passed (376)

pnpm exec turbo run type-check --concurrency=2
  Tasks:    78 successful, 78 total
```

### 反向验证(方向是**先**预测的:红)

把 `UserFilters.tsx` 整体还原成 `origin/main` 的死按钮版本再跑新测试:**9 红 / 3 绿**,与预测一致。

```
× clicking add opens a naming input; confirming snapshots the applied filters ...
× the snapshot is stored, not recomputed ...
× calls no data-source method, no fetch, and no web storage
× drops the added tab and falls back to the author default ...
TestingLibraryElementError: Unable to find an element by: [data-testid="filter-tab-add-content"]
 Tests  9 failed | 3 passed (12)
```

三个绿的是两条 `allowAddTab` 关闭回归(本就该两向都绿,它们钉的是既有行为)+「预设没有删除入口」那条(负向断言,两向都绿;它防的是将来给预设误加删除入口,不是钉本次接线)。这里如实记一笔:**零元数据写入那条是红的**,红在它自己的非空转前置断言上 —— 正是它该红的位置。

## 范围之外(未做,已确认)

- spec 侧 `UserFiltersSchema.allowAddTab` 的 `.describe()` 从「仅承诺渲染入口」升回真实语义 —— 裁决已归 spec 车道,渲染器不依赖该文案。本仓 `packages/types` 的 zod 镜像写的是 `'Allow adding new tabs'`,与新行为无冲突,未动。
- 没碰 `app-shell/src/views/metadata-admin/widgets.tsx` 的 Studio 编辑期 addTab(`filter-mode-add-tab`)—— 那是另一族。

## Changeset

`.changeset/userfilters-allowaddtab-session-tabs-os5236.md`,`@object-ui/plugin-list: patch`。定 patch 而非 minor 的理由:公共 API 面零变化(`UserFiltersProps` 一字未动,没有新增入参),用户可见的变化是**一个已发布但失灵的控件开始按其 title 与 spec 声明工作**,属行为补全/修复;且按仓内约定 breaking 也只标 minor、`major` 被 CI 禁掉,patch 与本仓「fix(...) + patch」的既有惯例一致。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_