### PR TITLE
fix(fields): percent/progress 单元格让数值优先于装饰条,窄 chip 不再裁掉数值 (objectstack#5066)

### DIFF
--- a/.changeset/percent-cell-value-over-bar-os5066.md
+++ b/.changeset/percent-cell-value-over-bar-os5066.md
@@ -1,0 +1,33 @@
+---
+"@object-ui/fields": patch
+---
+
+`percent` / `progress` cells now give the NUMBER shrink priority over the decorative bar (objectstack#5066)
+
+In a narrow clipping container the percent display renderer sacrificed the wrong
+half of itself. It emitted a `w-16 shrink-0` bar in front of a shrinkable value
+span, so in a `record:highlights` chip — `basis-[9rem]`, shrinking toward
+`min-w-[7rem]` as chips are added, clipping with `truncate` — the 64px bar plus
+the 8px gap consumed the content box and `truncate` removed what was left of the
+value. A stored `33.33` carried `33%` in the DOM and read as `3` on screen
+(measured: 79px clip box, 32px text node, 25px overflow), with no ellipsis and
+nothing in the accessible name to signal the loss: a silently smaller, plausible
+number rather than a cosmetic glitch. Downstream the app had to override the
+highlight's render type to `number` to get its digits back, losing the `%` glyph
+and the bar entirely.
+
+The priority is now inverted, on the principle that the number is the CONTENT and
+the bar is DECORATION: the value span is `shrink-0` and the bar carries
+`min-w-0 shrink`, keeping `w-16` only as its PREFERRED width, so a squeezed
+container eats the bar and the digits survive intact.
+
+The bar is deliberately NOT `flex-1`. `flex-1` would let it GROW as well as
+shrink, stretching the bar across every wide grid cell and changing a surface
+that has no bug; `w-16` stays the upper bound, so wide containers render exactly
+as before and only the shrink direction changed. Below roughly 40px of content
+the bar has collapsed to nothing and the value clips like any other single-line
+cell — same floor as the plain number renderer, which is as far as a
+self-contained renderer fix reaches (the chip's own width is a function of how
+many chips the record has, so the strip's `@container` cannot see it).
+
+The neighbouring `number` renderer is untouched.

--- a/packages/fields/src/__tests__/PercentCellRenderer.test.tsx
+++ b/packages/fields/src/__tests__/PercentCellRenderer.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression for objectstack-ai/objectstack#5066: the percent / progress cell
+ * renderer emitted a FIXED-WIDTH, NON-SHRINKABLE bar (`w-16 shrink-0`) next to a
+ * shrinkable value span. Inside a narrow clipping container — a
+ * `record:highlights` chip is `basis-[9rem]` / `min-w-[7rem]` and clips with
+ * `truncate` — the 64px bar won the space and the VALUE was cut mid-digit: a
+ * stored `33.33` carried `33%` in the DOM but read as `3` on screen (measured:
+ * 79px clipping box, 32px text node, 25px overflow), with no ellipsis and no
+ * signal in the accessible name. A silently wrong number, not a cosmetic glitch.
+ *
+ * Pin: the number is the CONTENT (`shrink-0`, never sacrificed) and the bar is
+ * DECORATION (`w-16` as its preferred width, free to shrink away under
+ * pressure — and never `flex-1`, so a wide grid cell keeps today's 64px bar).
+ *
+ * jsdom has no layout engine, so these are class-semantics assertions (same
+ * approach as `cell-truncation.test.tsx` for objectui#3466) plus DOM-text
+ * assertions — deliberately not brittle pixel measurements.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { PercentCellRenderer } from '../index';
+
+const renderPercent = (value: unknown, field: Record<string, unknown> = {}) =>
+  render(
+    <PercentCellRenderer value={value as any} field={{ type: 'percent', ...field } as any} />,
+  );
+
+/** The decorative bar: `role="progressbar"` wrapper the renderer emits. */
+const bar = () => screen.getByRole('progressbar');
+/** The row that holds bar + value. */
+const row = () => bar().parentElement!;
+
+describe('PercentCellRenderer — value beats the decorative bar (issue #5066)', () => {
+  it('renders BOTH the bar and the value at normal width', () => {
+    renderPercent(33.33);
+
+    expect(bar()).toBeInTheDocument();
+    expect(bar()).toHaveAttribute('aria-valuenow', '33.33');
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    // Bar and value are siblings in one flex row (nothing was dropped).
+    expect(row()).toHaveClass('flex');
+    expect(row()).toContainElement(screen.getByText('33%'));
+  });
+
+  it('gives the value span shrink priority so a narrow chip cannot clip it', () => {
+    renderPercent(33.33);
+
+    const value = screen.getByText('33%');
+    // The number never shrinks — it is the content of the cell.
+    expect(value).toHaveClass('shrink-0');
+    expect(value).toHaveClass('whitespace-nowrap', 'tabular-nums');
+  });
+
+  it('lets the bar shrink away instead of pushing the value out of the clip box', () => {
+    renderPercent(33.33);
+
+    // The bar keeps `w-16` as its PREFERRED width but is shrinkable, and
+    // `min-w-0` stops the automatic minimum size from pinning it at 64px.
+    expect(bar()).toHaveClass('w-16', 'min-w-0', 'shrink');
+    // The pre-fix spelling: a non-shrinkable bar is exactly the bug.
+    expect(bar()).not.toHaveClass('shrink-0');
+    // The row itself must be able to shrink below its content width inside the
+    // chip's flex column, or the deficit never reaches the bar.
+    expect(row()).toHaveClass('min-w-0');
+  });
+
+  it('does not let the bar GROW in a wide cell (no flex-1 / grow)', () => {
+    renderPercent(33.33);
+
+    // `flex-1` would also make the bar stretch to fill every wide grid cell —
+    // `w-16` stays the upper bound, only the shrink direction changed.
+    expect(bar().className).not.toMatch(/(^|\s)(flex-1|grow|basis-)/);
+  });
+
+  it('keeps the full formatted value in the DOM (fraction, whole, precision)', () => {
+    const first = renderPercent(33.33);
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    first.unmount();
+
+    // Declared precision keeps the decimals — the widest text, worst overflow.
+    renderPercent(33.33, { precision: 2 });
+    const wide = screen.getByText('33.33%');
+    expect(wide).toBeInTheDocument();
+    expect(wide).toHaveClass('shrink-0');
+  });
+
+  it('scales a fraction-stored percent and still renders both parts', () => {
+    renderPercent(0.8);
+
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(bar()).toHaveAttribute('aria-valuenow', '80');
+    expect(screen.getByText('80%')).toHaveClass('shrink-0');
+  });
+
+  it('applies the same contract to whole-percent `progress` fields', () => {
+    renderPercent(33.33, { type: 'progress', name: 'progress' });
+
+    // 0-100 storage: no fraction scaling, value rendered as-is.
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.getByText('33%')).toHaveClass('shrink-0');
+    expect(bar()).toHaveClass('min-w-0', 'shrink');
+    expect(bar()).not.toHaveClass('shrink-0');
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -703,10 +703,23 @@ export function PercentCellRenderer({ value, field }: CellRendererProps): React.
   const formatted = isWholePercentField ? `${numValue.toFixed(precision)}%` : formatPercent(numValue, precision);
   const clampedBar = Math.max(0, Math.min(100, barValue));
   
+  // Layout contract (objectstack#5066): THE NUMBER IS THE CONTENT, THE BAR IS
+  // DECORATION. The bar used to be `w-16 shrink-0` while the value span was
+  // shrinkable, so in a narrow clipping container — a `record:highlights` chip
+  // is `basis-[9rem]`/`min-w-[7rem]` and clips with `truncate` — the 64px bar
+  // took the space and the value was silently cut mid-digit: a stored `33.33`
+  // rendered `33%` in the DOM but read as `3` on screen, with no ellipsis and
+  // nothing in the accessible name to signal the loss.
+  //
+  // So the priority is inverted: the value span is `shrink-0` (never sacrificed)
+  // and the bar keeps `w-16` only as its PREFERRED width, free to shrink away
+  // under pressure. It is deliberately NOT `flex-1` — growing is not wanted, or
+  // every wide grid cell would stretch its bar; `w-16` stays the upper bound and
+  // wide containers look exactly as before.
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex min-w-0 items-center gap-2">
       <div
-        className="h-1.5 w-16 rounded-full bg-muted ring-1 ring-inset ring-border/60 overflow-hidden shrink-0"
+        className="h-1.5 w-16 min-w-0 shrink rounded-full bg-muted ring-1 ring-inset ring-border/60 overflow-hidden"
         role="progressbar"
         aria-valuenow={clampedBar}
         aria-valuemin={0}
@@ -717,7 +730,7 @@ export function PercentCellRenderer({ value, field }: CellRendererProps): React.
           style={{ width: `${clampedBar}%` }}
         />
       </div>
-      <span className="tabular-nums whitespace-nowrap">{formatted}</span>
+      <span className="shrink-0 tabular-nums whitespace-nowrap">{formatted}</span>
     </div>
   );
 }

--- a/packages/plugin-detail/src/__tests__/RecordHighlightsRenderer.percentClip.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordHighlightsRenderer.percentClip.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectstack#5066 — a `percent` chip in `record:highlights` showed a smaller,
+ * plausible number. The chip clips with `truncate` (`basis-[9rem]`, shrinking
+ * toward `min-w-[7rem]` as more chips are added, so ~72-104px of content), and
+ * the percent display renderer put a `w-16 shrink-0` bar in front of a
+ * shrinkable value span: bar (64) + gap (8) left the value 0-32px and `truncate`
+ * removed the rest. Downstream a stored `33.33` was read off the screen as `3`
+ * (yinlianghui/hotcrm-heimao#59) and the app had to override the highlight's
+ * render type to `number` to get its digits back.
+ *
+ * These pin the whole authored-metadata → chip → renderer path from the
+ * CONSUMER side (`packages/fields` owns the renderer, but this strip is where
+ * the clipping container lives): the value span keeps shrink priority even at
+ * the chip count that squeezes hardest, and the chip still clips — the fix is a
+ * shrink-priority inversion in the renderer, NOT the removal of the chip's
+ * truncation.
+ *
+ * jsdom has no layout engine, so this is a class-semantics pin, not a pixel
+ * measurement (same approach as `cell-truncation.test.tsx`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordHighlightsRenderer } from '../renderers/record-highlights';
+
+const objectSchema = {
+  fields: {
+    supply_share: { type: 'percent' },
+    progress: { type: 'progress' },
+    owner: { type: 'text' },
+    stage: { type: 'text' },
+    amount: { type: 'number' },
+    city: { type: 'text' },
+    code: { type: 'text' },
+  },
+};
+
+const data = {
+  supply_share: 33.33,
+  progress: 62,
+  owner: 'Alice',
+  stage: 'Won',
+  amount: 1200,
+  city: 'Shanghai',
+  code: 'A-1',
+};
+
+const renderStrip = (fields: unknown[]) =>
+  render(
+    <RecordContextProvider
+      objectName="crm_account"
+      recordId="A1"
+      data={data}
+      objectSchema={objectSchema}
+    >
+      <RecordHighlightsRenderer schema={{ fields } as any} />
+    </RecordContextProvider>,
+  );
+
+describe('record:highlights — a percent chip shows its number, not the bar (#5066)', () => {
+  it('keeps the value shrink-proof and the bar shrinkable inside the chip', () => {
+    renderStrip([{ name: 'supply_share', label: 'Supply Share' }]);
+
+    const value = screen.getByText('33%');
+    expect(value).toHaveClass('shrink-0');
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar).not.toHaveClass('shrink-0');
+    expect(bar).toHaveClass('w-16', 'min-w-0', 'shrink');
+  });
+
+  it('still clips the chip — the renderer, not the chip, gave way', () => {
+    const { container } = renderStrip([{ name: 'supply_share', label: 'Supply Share' }]);
+
+    // The chip's single-line clipping span is unchanged: this fix must not buy
+    // legible percents by letting every other renderer overflow the strip.
+    const clipBox = container.querySelector('span.truncate');
+    expect(clipBox).not.toBeNull();
+    expect(clipBox).toHaveClass('block', 'min-w-0', 'truncate');
+    expect(clipBox).toContainElement(screen.getByRole('progressbar'));
+  });
+
+  it('holds at the chip count that squeezes hardest (7 chips)', () => {
+    renderStrip([
+      { name: 'supply_share', label: 'Supply Share' },
+      'progress',
+      'owner',
+      'stage',
+      'amount',
+      'city',
+      'code',
+    ]);
+
+    // Both bar-carrying chips keep the number as the protected content.
+    expect(screen.getByText('33%')).toHaveClass('shrink-0');
+    expect(screen.getByText('62%')).toHaveClass('shrink-0');
+    for (const bar of screen.getAllByRole('progressbar')) {
+      expect(bar).not.toHaveClass('shrink-0');
+      expect(bar).toHaveClass('min-w-0', 'shrink');
+    }
+  });
+
+  it('renders the full formatted value in the DOM (the loss was purely visual)', () => {
+    renderStrip([{ name: 'supply_share', label: 'Supply Share' }]);
+
+    // The DOM always carried `33%` — that is why a DOM-only probe called this
+    // healthy. Pinned so a future "fix" cannot shorten the text instead.
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.queryByText('3')).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5066

## 现象与机制

percent 显示渲染器把「不可缩的 64px 装饰条」排在「可缩的数值文本」前面,于是在带裁剪的窄容器里牺牲了错的那一半。`record:highlights` 的 chip 是 `basis-[9rem]`、随 chip 数量收缩到 `min-w-[7rem]`、并用 `truncate` 裁剪:条(64px)加 `gap-2`(8px)吃掉内容盒,`truncate` 静默抹掉剩下的数值。

库里存 `33.33`,DOM 里是 `33%`,屏上只剩 `3` —— issue 正文的量测:裁剪盒 79px、文本节点 32px、右溢出 25px,既无省略号,可访问名里也没有任何截断信号。**这是静默错数,不是观感瑕疵**;下游应用被迫把高亮项的渲染类型改写成 `number` 才能拿回数字,代价是丢掉 `%` 与进度条。

## 改法(issue 正文建议一)

按「**数值是内容、条是装饰**」反转收缩优先级,只动 `PercentCellRenderer`:

| 位置 | 修前 | 修后 |
|---|---|---|
| 行容器 | `flex items-center gap-2` | `flex min-w-0 items-center gap-2` |
| 条外层 | `w-16 … shrink-0` | `w-16 min-w-0 shrink …` |
| 数值 span | `tabular-nums whitespace-nowrap` | `shrink-0 tabular-nums whitespace-nowrap` |

`w-16` 从「硬宽度」降级为「首选宽度」,容器一挤先把条挤没、数字完整保留;行容器补 `min-w-0`,否则负空间传不到条上。

**刻意没有用建议里的 `flex-1`。** `flex-1` 会让条同时可以*变宽*,把每个宽表格单元里的条拉长 —— 那是一个本来没有 bug 的面。`w-16` 仍是上界(`flex-grow` 保持 0),宽容器渲染与改动前一致,只有收缩方向变了。

**也没有叠加容器查询降级。** 高亮条的 `@container` 在 section 上,而 chip 的实际宽度是「这条记录有几个高亮项」的函数,section 的宽度查询看不到它 —— 容器查询在这个形态下无法表达真正的判据,加了只是换一种猜。内容宽度低于约 40px 时条已缩为 0、数值和其他单行单元一样开始裁剪,这就是自闭环渲染器修法能到的下界;这条残余与整个 chip 侧的通用机制已单独记为 objectstack-ai/objectstack#6950(observation-class,未入队)。

同文件相邻的 number 渲染器**未动**(objectstack#5067 的面)。

## 测试

jsdom 没有布局引擎,像素测不了也不该造脆弱的像素测试,因此按 **class 语义**钉(与 objectui#3466 的 `cell-truncation.test.tsx` 同一做法),再叠 DOM 文本断言:

- `packages/fields/src/__tests__/PercentCellRenderer.test.tsx`(7 例):正常宽度下条与数值都在;数值 `shrink-0`;条 `w-16 min-w-0 shrink` 且**非** `shrink-0`;条无 `flex-1`/`grow`/`basis-`(不许变宽);DOM 文本仍是完整格式化值(`33%` / `precision: 2` → `33.33%` / 分数存储 `0.8` → `80%` / `progress` 整数百分比)。
- `packages/plugin-detail/src/__tests__/RecordHighlightsRenderer.percentClip.test.tsx`(4 例):从**消费侧**钉 authored metadata → chip → renderer 整条路径,含 7 个 chip 挤压最狠的形态;并钉住 chip 自己仍然 `truncate` —— 让位的是渲染器,不是 chip 的裁剪。

实跑证据:

```
vitest run packages/fields/ packages/plugin-detail/ --maxWorkers=2
 Test Files  129 passed (129)
      Tests  1492 passed (1492)

turbo run type-check --concurrency=2
 Tasks:    78 successful, 78 total
```

**反向验证**(方向事先预判为红):把三处 class 还原成修前拼写后重跑两个新文件 —— `7 failed | 4 passed`,失败点正是 `expect(value).toHaveClass('shrink-0')` 与 `expect(bar()).toHaveClass('w-16', 'min-w-0', 'shrink')`。如实说明它证明了什么:class 名断言在修前拼写下必然红,所以这一跑证的是「测试真的接在被改代码上、查询非空转」,**不是**独立证明了布局后果 —— jsdom 评估不了布局。为把 class 名与真实 CSS 属性对上,另用仓内 Tailwind 4.3.3 编译过这几个 utility:`w-16` → `width: calc(var(--spacing) * 16)`、`min-w-0` → `min-width: 0px`、`shrink` → `flex-shrink: 1`、`shrink-0` → `flex-shrink: 0`。

**没有浏览器实证**:本容器里没有任何 Chromium 二进制(`ms-playwright` 缓存为空、系统无 chromium/chrome),所以 issue 里那 25px 溢出没有在改后重新量过一遍,也没有截图。这一格如实留白,而不是拿别的东西凑。

changeset:`.changeset/percent-cell-value-over-bar-os5066.md`(`@object-ui/fields` patch)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_