### PR TITLE
fix(plugin-list): 消费 PageComponentSchema.dataSource —— saved view 按名引用首次可用,写了 dataSource 不再把组件弄坏 (objectstack#5576)

### DIFF
--- a/.changeset/element-datasource-view-os5576.md
+++ b/.changeset/element-datasource-view-os5576.md
@@ -1,0 +1,49 @@
+---
+"@object-ui/core": patch
+"@object-ui/react": patch
+"@object-ui/plugin-list": patch
+"@object-ui/app-shell": patch
+---
+
+`PageComponentSchema.dataSource` is now consumed instead of discarded — a
+`list-view` page component can reference a **saved view by name** for the first
+time, and writing the binding no longer breaks the component
+(objectstack#5576).
+
+The spec declares a per-element data binding on every page component —
+`dataSource: { object, view?, filter?, sort?, limit? }` — and objectui read none
+of it. `ViewDataProvider.resolveElementDataSource` forwarded
+`filter`/`sort`/`limit` and dropped `view` entirely, and had no caller outside its
+own test; nothing mapped `object` onto the `objectName` a list actually reads. So
+"reference a saved view by name" was published, validated and inert, and every
+page that wanted a saved view's columns/filter/sort had to inline a second copy of
+them — the drift the binding exists to remove.
+
+Writing the binding also **broke** the block, for a reason unrelated to `view`:
+`SchemaRenderer` spread the schema's `dataSource` metadata onto the component as a
+React prop, and that is the prop name the host uses to inject the data-source
+ADAPTER. The plain `{ object, view }` object shadowed the adapter, so the first
+`dataSource.find(…)` threw `dataSource.find is not a function` and `list-view`
+rendered "Couldn't load records" — a spec-compliant component failing next to
+identical ones that omitted the binding.
+
+- `@object-ui/react` — `SchemaRenderer` no longer spreads `schema.dataSource` as a
+  prop (it is metadata, like `visibleWhen`); renderers read it off `schema`. An
+  explicit React `dataSource` prop is unaffected. New
+  `useElementDataSource(schema, dataSource?)` hook resolves a binding, fetching
+  the named saved view from the object definition's `listViews` and the metadata
+  overlay's `listViews()`.
+- `@object-ui/core` — new `isElementDataSourceConfig` / `collectSavedViews` /
+  `resolveSavedView` / `composeElementDataSource`, and `resolveElementDataSource`
+  now honours `view` through an optional `DataFetcher.fetchViews`, reporting an
+  unresolvable view as an error instead of silently returning every record.
+  `resolveViewId` moved here from `@object-ui/app-shell` (re-exported there) so
+  one matcher serves both the object page and a page component.
+- `@object-ui/plugin-list` — `list-view` maps the binding onto the props
+  `ListView` reads. `dataSource.*` keys are authoritative, view-supplied values
+  are a baseline the component's own keys override, and `filter` AND-combines at
+  every level (the spec calls the binding's filter "additional criteria"), so a
+  binding can narrow a saved view but never widen it. A `view` name that does not
+  resolve renders a configuration error naming the object's actual views and
+  issues no query — it never falls back to the object's default view, because that
+  turns a typo into a silently wider answer.

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -201,3 +201,35 @@ against backends that advertise the capability; older ones still save, but
 best-effort. See the
 [adapter README](https://github.com/objectstack-ai/objectui/blob/main/packages/data-objectstack/README.md#cross-object-atomic-batch-batchtransaction)
 for the full capability table and minimum-backend note.
+
+## Per-element data binding on a page (`dataSource`)
+
+A metadata page component carries its own data binding —
+`PageComponentSchema.dataSource`, the spec's `ElementDataSourceSchema` — so one
+page can show several objects without a page-level object context:
+
+```json
+{
+  "type": "list-view",
+  "dataSource": { "object": "account", "view": "hot", "limit": 10 }
+}
+```
+
+This is metadata, **not** the data-source adapter. The two share a name and are
+different things: the adapter is injected by the host (`SchemaRendererProvider`),
+while `dataSource` on a schema node is JSON describing *what to query*. A
+renderer therefore reads the binding off `schema.dataSource` and gets its adapter
+from context — never from a prop the schema could occupy. `SchemaRenderer` strips
+the binding from the props it spreads for exactly this reason.
+
+`view` names a **saved view** of that object; its columns, filter, sort and page
+size are applied to the render, so a page never has to keep a second copy of a
+view's configuration. `filter` is *additional* criteria — it AND-combines with the
+view's filter rather than replacing it — while `sort` and `limit` override the
+view's. A `view` name that does not resolve is reported as a configuration error;
+it never degrades into an unfiltered query for the object.
+
+`@object-ui/react` exposes `useElementDataSource(schema, dataSource?)` for
+renderers that need the same resolution, and `@object-ui/core` exposes the pure
+parts (`isElementDataSourceConfig`, `resolveSavedView`,
+`composeElementDataSource`).

--- a/packages/app-shell/src/utils/resolveViewId.ts
+++ b/packages/app-shell/src/utils/resolveViewId.ts
@@ -7,34 +7,11 @@
  */
 
 /**
- * Resolve a URL-requested view name against the object's actual view ids.
- *
- * Canonical view ids are fully qualified (`<object>.<viewKind>`, see
- * MetadataProvider), but nav items emit their `viewName` verbatim — usually
- * the short form — and legacy embedded listViews carry bare keys (including
- * the `'all'` fallback view). Accept both directions (#2217):
- *
- * 1. exact id match;
- * 2. short name (no `.`) → retry as `<objectName>.<name>`;
- * 3. qualified name → retry with the `<objectName>.` prefix stripped.
- *
- * Returns the matching view id, or `undefined` when nothing matches — the
- * caller decides how to fall back (and should warn rather than swallow it).
+ * Re-export only. The matcher moved to `@object-ui/core`
+ * (`utils/resolve-view-id.ts`) when a second layer needed it: a page
+ * component's `dataSource.view` names a saved view exactly the way a nav item
+ * names one, and `@object-ui/plugin-list` cannot import from app-shell
+ * (objectstack#5576). Kept as a re-export so this module path — and its
+ * dedicated test — stay valid.
  */
-export function resolveViewId(
-    requested: string | undefined | null,
-    viewIds: readonly string[],
-    objectName: string,
-): string | undefined {
-    if (!requested) return undefined;
-    const has = (id: string) => viewIds.includes(id);
-    if (has(requested)) return requested;
-    const prefix = `${objectName}.`;
-    if (!requested.includes('.') && has(prefix + requested)) {
-        return prefix + requested;
-    }
-    if (requested.startsWith(prefix) && has(requested.slice(prefix.length))) {
-        return requested.slice(prefix.length);
-    }
-    return undefined;
-}
+export { resolveViewId } from '@object-ui/core';

--- a/packages/core/src/data-scope/ViewDataProvider.ts
+++ b/packages/core/src/data-scope/ViewDataProvider.ts
@@ -20,6 +20,15 @@
  * @packageDocumentation
  */
 
+import {
+  collectSavedViews,
+  composeElementDataSource,
+  elementDataSourceViewNotFoundMessage,
+  resolveSavedView,
+  type ElementDataSourceConfig,
+  type ElementSavedView,
+} from './element-data-source.js';
+
 /** ViewData union — matches @objectstack/spec ViewDataSchema */
 export type ViewDataConfig =
   | { provider: 'object'; object: string }
@@ -30,14 +39,12 @@ export type ViewDataConfig =
     }
   | { provider: 'value'; items: any[] };
 
-/** Element-level data source — matches @objectstack/spec ElementDataSourceSchema */
-export interface ElementDataSourceConfig {
-  object: string;
-  view?: string;
-  filter?: Record<string, any>;
-  sort?: Array<{ field: string; order: 'asc' | 'desc' }>;
-  limit?: number;
-}
+/**
+ * Re-exported from `./element-data-source.js`, where the binding's type now
+ * lives alongside the logic that consumes it. Kept on this module path because
+ * that is where it was declared before objectstack#5576.
+ */
+export type { ElementDataSourceConfig };
 
 /** Fetcher interface — consumers provide the actual fetch implementation */
 export interface DataFetcher {
@@ -74,6 +81,22 @@ export interface DataFetcher {
       body?: any;
     },
   ): Promise<any>;
+
+  /**
+   * Fetch the object's saved views, so an `ElementDataSource.view` name can be
+   * resolved to real columns / filter / sort (objectstack#5576).
+   *
+   * Optional because most fetchers only read records. A fetcher WITHOUT it
+   * cannot honour a named view, and {@link ViewDataProvider.resolveElementDataSource}
+   * says so in `error` rather than dropping the key — the whole point of #5576
+   * is that a `view` the runtime cannot apply must never look applied.
+   *
+   * Either shape stored views come in is accepted: a map keyed by view id, or
+   * the array of overlay rows an adapter's `listViews()` returns.
+   */
+  fetchViews?(
+    object: string,
+  ): Promise<Record<string, ElementSavedView> | ElementSavedView[]>;
 }
 
 /** Resolved data result */
@@ -265,16 +288,87 @@ export class ViewDataProvider {
     }
   }
 
-  /** Resolve element-level data source */
+  /**
+   * Resolve an element-level data source (`PageComponentSchema.dataSource`).
+   *
+   * `view` is HONOURED here, not dropped. Until objectstack#5576 this method
+   * forwarded `filter`/`sort`/`limit` and silently discarded `view`, so a page
+   * component that named a saved view got every record the object had — the
+   * declared binding was inert while looking applied.
+   *
+   * Three outcomes, all explicit:
+   *  - no `view` → unchanged behaviour, the binding's own keys are forwarded;
+   *  - `view` resolved → its columns become the `fields` projection and its
+   *    filter/sort/limit the baseline the binding's keys compose with (see
+   *    {@link composeElementDataSource} for the per-key rule);
+   *  - `view` unresolvable, or the fetcher cannot list views at all → an
+   *    `error` naming the view and what the object does have. NOT an empty
+   *    result, and NOT a silent fall back to the unfiltered object.
+   */
   async resolveElementDataSource(
     config: ElementDataSourceConfig,
   ): Promise<ResolvedData> {
+    let view: ElementSavedView | undefined;
+
+    if (config.view) {
+      if (!this.fetcher?.fetchViews) {
+        return {
+          records: [],
+          total: 0,
+          provider: 'object',
+          loading: false,
+          error:
+            `dataSource.view "${config.view}" cannot be resolved: this data ` +
+            `fetcher does not implement fetchViews().`,
+        };
+      }
+      let views: Record<string, ElementSavedView>;
+      try {
+        views = collectSavedViews(await this.fetcher.fetchViews(config.object));
+      } catch (error) {
+        return {
+          records: [],
+          total: 0,
+          provider: 'object',
+          loading: false,
+          error: (error as Error).message,
+        };
+      }
+      view = resolveSavedView(views, config.view, config.object);
+      if (!view) {
+        return {
+          records: [],
+          total: 0,
+          provider: 'object',
+          loading: false,
+          error: elementDataSourceViewNotFoundMessage(
+            config.object,
+            config.view,
+            Object.keys(views),
+          ),
+        };
+      }
+    }
+
+    const composed = composeElementDataSource(config, view);
+    const fields = Array.isArray(composed.columns)
+      ? composed.columns.filter((c): c is string => typeof c === 'string' && !!c)
+      : undefined;
+
     return this.resolve(
-      { provider: 'object', object: config.object },
+      { provider: 'object', object: composed.object },
       {
-        filter: config.filter,
-        sort: config.sort,
-        limit: config.limit,
+        // `DataFetcher.fetchRecords`'s `filter` is declared
+        // `Record<string, any>`, which predates the three filter shapes that
+        // legitimately circulate here: a MongoDB-style condition object, an
+        // ObjectQL AST node array, and a spec `ViewFilterRule[]`. The last two
+        // are arrays, so a saved view's filter does not fit the declared option
+        // — the cast is that gap, not a coercion. Widening the declared option
+        // is a separate change with its own consumers.
+        filter: composed.filter as Record<string, any> | undefined,
+        sort: composed.sort as Array<{ field: string; order: 'asc' | 'desc' }> | undefined,
+        limit: composed.limit,
+        ...(fields && fields.length > 0 ? { fields } : {}),
       },
     );
   }

--- a/packages/core/src/data-scope/__tests__/ViewDataProvider.test.ts
+++ b/packages/core/src/data-scope/__tests__/ViewDataProvider.test.ts
@@ -256,6 +256,113 @@ describe('ViewDataProvider', () => {
         limit: 5,
       });
     });
+
+    // ===== `view` — objectstack#5576 =====
+    //
+    // This method used to forward `filter`/`sort`/`limit` and DROP `view`, and it
+    // had no caller outside this file. "Reference a saved view by name" was a
+    // published binding with no implementation: a page that used it got every
+    // record the object had, with no error, and the author had no way to tell.
+    describe('view (objectstack#5576)', () => {
+      const savedViews = {
+        'Contact.hot': {
+          type: 'grid',
+          columns: ['name', 'email'],
+          filter: [['rating', '=', 'hot']],
+          sort: [{ field: 'name', order: 'asc' }],
+          pagination: { pageSize: 20 },
+        },
+      };
+
+      const fetcherWithViews = (): DataFetcher => ({
+        fetchRecords: vi.fn().mockResolvedValue({ records: [{ id: '1' }], total: 1 }),
+        fetchViews: vi.fn().mockResolvedValue(savedViews),
+      });
+
+      it('applies the named view’s columns, filter, sort and page size', async () => {
+        const fetcher = fetcherWithViews();
+        provider.setFetcher(fetcher);
+
+        const result = await provider.resolveElementDataSource({
+          object: 'Contact',
+          view: 'hot',
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(fetcher.fetchViews).toHaveBeenCalledWith('Contact');
+        expect(fetcher.fetchRecords).toHaveBeenCalledWith('Contact', {
+          filter: [['rating', '=', 'hot']],
+          sort: [{ field: 'name', order: 'asc' }],
+          limit: 20,
+          fields: ['name', 'email'],
+        });
+      });
+
+      it('AND-combines the binding filter onto the view’s ("additional criteria")', async () => {
+        const fetcher = fetcherWithViews();
+        provider.setFetcher(fetcher);
+
+        await provider.resolveElementDataSource({
+          object: 'Contact',
+          view: 'hot',
+          filter: { owner: 'me' },
+        });
+
+        expect((fetcher.fetchRecords as any).mock.calls[0][1].filter).toEqual([
+          'and',
+          [['rating', '=', 'hot']],
+          ['owner', '=', 'me'],
+        ]);
+      });
+
+      it('reports an unresolvable view instead of returning every record', async () => {
+        const fetcher = fetcherWithViews();
+        provider.setFetcher(fetcher);
+
+        const result = await provider.resolveElementDataSource({
+          object: 'Contact',
+          view: 'nope',
+        });
+
+        expect(result.records).toEqual([]);
+        expect(result.error).toContain('"nope"');
+        expect(result.error).toContain('Contact.hot');
+        // The load that must NOT have happened: a named view the runtime cannot
+        // apply may never degrade into an unfiltered query.
+        expect(fetcher.fetchRecords).not.toHaveBeenCalled();
+      });
+
+      it('reports a fetcher that cannot list views at all', async () => {
+        const fetcher: DataFetcher = {
+          fetchRecords: vi.fn().mockResolvedValue({ records: [], total: 0 }),
+        };
+        provider.setFetcher(fetcher);
+
+        const result = await provider.resolveElementDataSource({
+          object: 'Contact',
+          view: 'hot',
+        });
+
+        expect(result.error).toContain('fetchViews');
+        expect(fetcher.fetchRecords).not.toHaveBeenCalled();
+      });
+
+      it('surfaces a failed view lookup as an error, not as an empty view', async () => {
+        const fetcher: DataFetcher = {
+          fetchRecords: vi.fn().mockResolvedValue({ records: [], total: 0 }),
+          fetchViews: vi.fn().mockRejectedValue(new Error('meta unavailable')),
+        };
+        provider.setFetcher(fetcher);
+
+        const result = await provider.resolveElementDataSource({
+          object: 'Contact',
+          view: 'hot',
+        });
+
+        expect(result.error).toBe('meta unavailable');
+        expect(fetcher.fetchRecords).not.toHaveBeenCalled();
+      });
+    });
   });
 
   // ===== Unknown Provider =====

--- a/packages/core/src/data-scope/__tests__/element-data-source.test.ts
+++ b/packages/core/src/data-scope/__tests__/element-data-source.test.ts
@@ -1,0 +1,183 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `ElementDataSource` resolution — the pure half of objectstack#5576.
+ *
+ * The spec declares `PageComponentSchema.dataSource` as
+ * `{ object, view?, filter?, sort?, limit? }`. Until #5576 the renderer dropped
+ * `view` entirely, so "reference a saved view by name" was published and inert.
+ * These tests pin the two decisions that make it real: telling the BINDING apart
+ * from a runtime data-source ADAPTER (they collide by name, and the collision
+ * broke the component outright), and the per-key composition rule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  collectSavedViews,
+  composeElementDataSource,
+  elementDataSourceViewNotFoundMessage,
+  isElementDataSourceConfig,
+  resolveSavedView,
+} from '../element-data-source';
+
+describe('isElementDataSourceConfig', () => {
+  it('accepts the spec binding', () => {
+    expect(isElementDataSourceConfig({ object: 'account' })).toBe(true);
+    expect(isElementDataSourceConfig({ object: 'account', view: 'hot' })).toBe(true);
+  });
+
+  it('rejects a runtime data-source adapter', () => {
+    // The collision this guard exists for: `ListView`'s `dataSource` prop is the
+    // injected adapter, and a page component's `dataSource` is metadata. An
+    // adapter reaching the metadata read path (or vice versa) is the #5576 bug.
+    const adapter = {
+      find: () => Promise.resolve({ data: [] }),
+      getObjectSchema: () => Promise.resolve({}),
+    };
+    expect(isElementDataSourceConfig(adapter)).toBe(false);
+    // Even one carrying an `object` field, which a wrapper adapter might.
+    expect(isElementDataSourceConfig({ ...adapter, object: 'account' })).toBe(false);
+  });
+
+  it('rejects everything that is not a binding', () => {
+    for (const v of [null, undefined, 'account', 42, [], {}, { object: '' }, { object: 1 }]) {
+      expect(isElementDataSourceConfig(v)).toBe(false);
+    }
+  });
+});
+
+describe('collectSavedViews', () => {
+  it('flattens an embedded map and an overlay array, overlay last wins', () => {
+    const embedded = { hot: { label: 'Metadata hot' }, cold: { label: 'Cold' } };
+    const overlay = [{ name: 'hot', label: 'Saved hot' }, { id: 'mine', label: 'Mine' }];
+    expect(collectSavedViews(embedded, overlay)).toEqual({
+      hot: { name: 'hot', label: 'Saved hot' },
+      cold: { label: 'Cold' },
+      mine: { id: 'mine', label: 'Mine' },
+    });
+  });
+
+  it('skips entries with no usable identity and non-object sources', () => {
+    expect(collectSavedViews(undefined, null, 'nope', [{ label: 'anonymous' }, 7])).toEqual({});
+  });
+});
+
+describe('resolveSavedView', () => {
+  const views = {
+    'account.tabular': { columns: ['name'] },
+    all: { columns: ['id'] },
+  };
+
+  it('matches short and qualified spellings in both directions (#2217 parity)', () => {
+    expect(resolveSavedView(views, 'tabular', 'account')).toBe(views['account.tabular']);
+    expect(resolveSavedView(views, 'account.tabular', 'account')).toBe(views['account.tabular']);
+    expect(resolveSavedView(views, 'all', 'account')).toBe(views.all);
+    expect(resolveSavedView(views, 'account.all', 'account')).toBe(views.all);
+  });
+
+  it('returns undefined for a name the object does not have', () => {
+    expect(resolveSavedView(views, 'hot', 'account')).toBeUndefined();
+    expect(resolveSavedView(views, undefined, 'account')).toBeUndefined();
+    expect(resolveSavedView({}, 'hot', 'account')).toBeUndefined();
+  });
+});
+
+describe('composeElementDataSource', () => {
+  const view = {
+    type: 'kanban',
+    columns: ['name', 'stage'],
+    filter: [['stage', '=', 'won']],
+    sort: [{ field: 'name', order: 'asc' }],
+    pagination: { pageSize: 25 },
+  };
+
+  it('forwards the binding unchanged when no view is named', () => {
+    expect(
+      composeElementDataSource({
+        object: 'account',
+        filter: { rating: 'hot' },
+        sort: [{ field: 'name', order: 'desc' }],
+        limit: 10,
+      }),
+    ).toEqual({
+      object: 'account',
+      // A LONE filter passes through in the shape it was authored in — lowering
+      // a stored filter to an ObjectQL AST belongs at the last hop before the
+      // wire, not here.
+      filter: { rating: 'hot' },
+      sort: [{ field: 'name', order: 'desc' }],
+      limit: 10,
+    });
+  });
+
+  it('takes the view whole when the binding declares only `object` + `view`', () => {
+    expect(composeElementDataSource({ object: 'account', view: 'won' }, view)).toEqual({
+      object: 'account',
+      columns: ['name', 'stage'],
+      filter: [['stage', '=', 'won']],
+      sort: [{ field: 'name', order: 'asc' }],
+      limit: 25,
+      viewType: 'kanban',
+    });
+  });
+
+  it('AND-combines the two filters — the binding narrows, never widens', () => {
+    // The spec describes `dataSource.filter` as "Additional filter criteria",
+    // which is the whole reason this is a merge and not an override. A binding
+    // filter that REPLACED the view's would silently expose the rows the saved
+    // view excludes.
+    const composed = composeElementDataSource(
+      { object: 'account', view: 'won', filter: { owner: 'me' } },
+      view,
+    );
+    expect(composed.filter).toEqual([
+      'and',
+      [['stage', '=', 'won']],
+      ['owner', '=', 'me'],
+    ]);
+  });
+
+  it('lets an explicit sort / limit override the view', () => {
+    const composed = composeElementDataSource(
+      { object: 'account', view: 'won', sort: [{ field: 'amount', order: 'desc' }], limit: 5 },
+      view,
+    );
+    expect(composed.sort).toEqual([{ field: 'amount', order: 'desc' }]);
+    expect(composed.limit).toBe(5);
+  });
+
+  it('reads the legacy view spellings (`fields`, `viewType`, flat `limit`)', () => {
+    expect(
+      composeElementDataSource({ object: 'account', view: 'legacy' }, {
+        viewType: 'gallery',
+        fields: ['name'],
+        limit: 7,
+      }),
+    ).toEqual({ object: 'account', columns: ['name'], limit: 7, viewType: 'gallery' });
+  });
+
+  it('emits no key at all for what neither side supplies', () => {
+    expect(composeElementDataSource({ object: 'account', view: 'bare' }, {})).toEqual({
+      object: 'account',
+    });
+  });
+});
+
+describe('elementDataSourceViewNotFoundMessage', () => {
+  it('names the view, the object and what the object does have', () => {
+    const msg = elementDataSourceViewNotFoundMessage('account', 'hot', ['all', 'account.tabular']);
+    expect(msg).toContain('"hot"');
+    expect(msg).toContain('"account"');
+    // Sorted, so the list reads the same however the sources were enumerated.
+    expect(msg).toContain('account.tabular, all');
+  });
+
+  it('says so plainly when the object has no saved views', () => {
+    expect(elementDataSourceViewNotFoundMessage('account', 'hot', []))
+      .toContain('no saved views');
+  });
+});

--- a/packages/core/src/data-scope/element-data-source.ts
+++ b/packages/core/src/data-scope/element-data-source.ts
@@ -1,0 +1,280 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/core` — ElementDataSource resolution (objectstack#5576).
+ *
+ * `PageComponentSchema.dataSource` (the spec's `ElementDataSourceSchema`) is the
+ * per-element data binding a page component uses to query a different object
+ * than the page's own context:
+ *
+ * ```json
+ * { "object": "account", "view": "hot", "filter": { … }, "sort": [ … ], "limit": 20 }
+ * ```
+ *
+ * This module owns the two pure halves of consuming it — telling the METADATA
+ * apart from a runtime data-source adapter, and composing a named saved view
+ * with the binding's own keys. Both are needed in two places (the render path in
+ * `@object-ui/plugin-list`, and `ViewDataProvider.resolveElementDataSource`), so
+ * they live here rather than being written twice.
+ *
+ * ## Composition semantics
+ *
+ * The spec's own `describe()` text settles the one case that could go either
+ * way. `filter` is documented as "**Additional** filter criteria" — additional
+ * to what the named view already restricts — so a view filter and a binding
+ * filter COMBINE under `and`; the binding can only narrow the view, never widen
+ * it. That is also the safe direction for AI-authored metadata: a typo in a
+ * per-element filter cannot silently expose rows the saved view excluded.
+ *
+ * Nothing else in the binding is described as additional, and the remaining keys
+ * are single-valued (one ordering, one cap), so for those the rule is **the view
+ * provides the baseline and an explicit key overrides it**:
+ *
+ * | key        | source                                  | rule                        |
+ * |------------|-----------------------------------------|-----------------------------|
+ * | `object`   | binding (required)                      | binding wins                |
+ * | `columns`  | view only — the binding has no such key | view                        |
+ * | `filter`   | view + binding                          | AND-combined ("additional") |
+ * | `sort`     | view or binding                         | binding overrides view      |
+ * | `limit`    | view (`pagination.pageSize`) or binding | binding overrides view      |
+ * | `viewType` | view only                               | view                        |
+ *
+ * A lone `filter` — only the view has one, or only the binding does — is passed
+ * through in the shape it was stored in; only the two-source case is lowered to
+ * an ObjectQL AST, because that is what combining requires.
+ *
+ * `viewType` rides along because `list-view` IS the multi-kind view container
+ * (its registry `inputs` enumerate grid/kanban/gallery/…): naming a saved kanban
+ * view and rendering a grid would be a silently wrong answer.
+ */
+
+import { mergeFilterNodes } from '../utils/filter-converter.js';
+import { resolveViewId } from '../utils/resolve-view-id.js';
+
+/** Sort entry, as both the spec's `SortItem` and objectui's view configs spell it. */
+export interface ElementDataSourceSort {
+  field: string;
+  order: 'asc' | 'desc';
+}
+
+/**
+ * Element-level data source — matches `@objectstack/spec` `ElementDataSourceSchema`.
+ *
+ * `filter` is typed `unknown` rather than the spec's `FilterCondition` because
+ * three shapes legitimately reach a renderer here (a MongoDB-style condition
+ * object, an ObjectQL AST node array, a spec `ViewFilterRule[]`) and
+ * {@link mergeFilterNodes} is the single sink that lowers all three. Narrowing
+ * the type here would only move the cast, not remove it.
+ */
+export interface ElementDataSourceConfig {
+  object: string;
+  view?: string;
+  filter?: unknown;
+  sort?: ElementDataSourceSort[];
+  limit?: number;
+}
+
+/**
+ * The subset of a saved view's config that an `ElementDataSource` `view` name
+ * contributes. Deliberately loose: stored view metadata is user data and carries
+ * both the spec vocabulary and the legacy objectui spellings that
+ * `normalizeListViewSchema` folds at the component boundary.
+ */
+export type ElementSavedView = Record<string, unknown>;
+
+/** What {@link composeElementDataSource} produces for a renderer to consume. */
+export interface ComposedElementDataSource {
+  /** Object to query. */
+  object: string;
+  /** Columns the named view shows; absent when no view was named. */
+  columns?: unknown;
+  /** View filter AND binding filter, combined; `undefined` when neither. */
+  filter?: unknown;
+  /** Binding sort if given, else the view's. */
+  sort?: unknown;
+  /** Binding limit if given, else the view's page size. */
+  limit?: number;
+  /** The view's render kind (grid / kanban / …), when the view declares one. */
+  viewType?: string;
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === 'object' && !Array.isArray(v);
+
+/**
+ * Is this value the spec's `dataSource` METADATA, rather than a runtime
+ * data-source adapter?
+ *
+ * This guard exists because the two collide by name and the collision was live:
+ * `SchemaRenderer` spreads every non-metadata schema key onto the component as a
+ * React prop, so a spec-compliant `dataSource: { object, view }` on a page
+ * component landed on `ListView`'s `dataSource` PROP — which is the injected
+ * adapter — and shadowed it. The first `dataSource.find(…)` then threw
+ * `dataSource.find is not a function`, which the list reported as
+ * "Couldn't load records": writing the binding the spec documents BROKE the
+ * component (objectstack#5576).
+ *
+ * The test is positive on the metadata rather than negative on the adapter: a
+ * binding is a plain object with a non-empty string `object` and no `find`
+ * method. An adapter never has a string `object`; metadata never has `find`.
+ */
+export function isElementDataSourceConfig(
+  value: unknown,
+): value is ElementDataSourceConfig {
+  if (!isPlainObject(value)) return false;
+  if (typeof (value as { find?: unknown }).find === 'function') return false;
+  const object = (value as { object?: unknown }).object;
+  return typeof object === 'string' && object.length > 0;
+}
+
+/**
+ * Flatten every place saved views for one object can live into `id → config`.
+ *
+ * Two sources are real and both are read, in the order app-shell's `ObjectView`
+ * reads them: the object definition's embedded `listViews` / `list_views` map
+ * (metadata-defined) and the metadata overlay rows an adapter returns from
+ * `listViews()` (user-defined). Later sources win, so a saved view shadows a
+ * metadata view of the same id — the same precedence `ObjectView` applies when
+ * it dedups its tab list.
+ *
+ * Accepts a record keyed by view id or an array of view configs (overlay rows
+ * are an array and carry their identity in `name`, falling back to `id`).
+ */
+export function collectSavedViews(
+  ...sources: unknown[]
+): Record<string, ElementSavedView> {
+  const out: Record<string, ElementSavedView> = {};
+  for (const source of sources) {
+    if (Array.isArray(source)) {
+      for (const entry of source) {
+        if (!isPlainObject(entry)) continue;
+        const id = entry.name ?? entry.id;
+        if (typeof id === 'string' && id) out[id] = entry;
+      }
+    } else if (isPlainObject(source)) {
+      for (const [id, entry] of Object.entries(source)) {
+        if (isPlainObject(entry)) out[id] = entry;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Find the saved view a `dataSource.view` name refers to.
+ *
+ * Name matching is {@link resolveViewId}'s — the same short/qualified tolerance
+ * the object page applies to a URL-requested view — so a name that works in one
+ * surface works in the other. Returns `undefined` when nothing matches; the
+ * caller must REPORT that rather than fall back to the object's default view.
+ * Silently widening a named view to "all records" is the failure mode this whole
+ * binding exists to remove.
+ */
+export function resolveSavedView(
+  views: Record<string, ElementSavedView>,
+  requested: string | undefined | null,
+  object: string,
+): ElementSavedView | undefined {
+  const id = resolveViewId(requested, Object.keys(views), object);
+  return id === undefined ? undefined : views[id];
+}
+
+/** Read a saved view's row cap — `pagination.pageSize`, or a flat `limit`. */
+function savedViewLimit(view: ElementSavedView | null | undefined): number | undefined {
+  if (!view) return undefined;
+  const pagination = view.pagination;
+  if (isPlainObject(pagination) && typeof pagination.pageSize === 'number') {
+    return pagination.pageSize;
+  }
+  return typeof view.limit === 'number' ? view.limit : undefined;
+}
+
+/**
+ * Read a saved view's render kind. `type` is the spec's key (and what
+ * `ObjectView` reads); `viewType` is objectui's legacy spelling, folded by
+ * `normalizeListViewSchema` downstream but accepted here so a view stored either
+ * way resolves to the same kind.
+ */
+function savedViewType(view: ElementSavedView | null | undefined): string | undefined {
+  if (!view) return undefined;
+  const kind = view.type ?? view.viewType;
+  return typeof kind === 'string' && kind ? kind : undefined;
+}
+
+/** Read a saved view's column list — canonical `columns`, legacy `fields`. */
+function savedViewColumns(view: ElementSavedView | null | undefined): unknown {
+  if (!view) return undefined;
+  if (Array.isArray(view.columns)) return view.columns;
+  if (Array.isArray(view.fields)) return view.fields;
+  return undefined;
+}
+
+/**
+ * Compose an `ElementDataSource` binding with the saved view it names.
+ *
+ * Pure — the caller resolves the view (see {@link resolveSavedView}) and owns
+ * the "named a view that does not exist" decision. Passing `undefined` /`null`
+ * for `view` composes a binding with no view, which is exactly the pre-#5576
+ * behaviour for the other four keys.
+ *
+ * See the module doc for the per-key rule table; `filter` is the only key that
+ * combines rather than overrides, because the spec describes the binding's
+ * filter as *additional*.
+ */
+export function composeElementDataSource(
+  config: ElementDataSourceConfig,
+  view?: ElementSavedView | null,
+): ComposedElementDataSource {
+  const composed: ComposedElementDataSource = { object: config.object };
+
+  const columns = savedViewColumns(view);
+  if (columns !== undefined) composed.columns = columns;
+
+  // "Additional filter criteria" (spec) — the view restricts, the binding
+  // restricts further, so two filters COMBINE under `and` via the repo's single
+  // combiner. A lone source passes through VERBATIM: lowering a stored filter to
+  // an ObjectQL AST belongs at the last hop before the wire and nowhere earlier
+  // (see `toFilterNode`'s doc on why), and every consumer of this result hands
+  // the value to that hop anyway. Combining is the one case that cannot preserve
+  // the input shape — putting two sources under one `and` requires AST — and
+  // `mergeFilterNodes` is the sanctioned place for it.
+  const viewFilter = view?.filter;
+  const filter = viewFilter !== undefined && config.filter !== undefined
+    ? mergeFilterNodes(viewFilter, config.filter)
+    : (config.filter ?? viewFilter);
+  if (filter !== undefined) composed.filter = filter;
+
+  const sort = config.sort ?? view?.sort;
+  if (sort !== undefined) composed.sort = sort;
+
+  const limit = config.limit ?? savedViewLimit(view);
+  if (limit !== undefined) composed.limit = limit;
+
+  const viewType = savedViewType(view);
+  if (viewType !== undefined) composed.viewType = viewType;
+
+  return composed;
+}
+
+/**
+ * The message shown when `dataSource.view` names a view the object does not
+ * have. Built here so the render path and `ViewDataProvider` report the same
+ * defect the same way, and so the known-view list (the thing that actually gets
+ * an author unstuck) is never omitted by one caller.
+ */
+export function elementDataSourceViewNotFoundMessage(
+  object: string,
+  view: string,
+  knownViews: readonly string[],
+): string {
+  const known = knownViews.length
+    ? `Known views: ${[...knownViews].sort().join(', ')}.`
+    : 'This object has no saved views.';
+  return `dataSource.view "${view}" was not found on object "${object}". ${known}`;
+}

--- a/packages/core/src/data-scope/index.ts
+++ b/packages/core/src/data-scope/index.ts
@@ -18,7 +18,18 @@ export {
 export {
   ViewDataProvider,
   type ViewDataConfig,
-  type ElementDataSourceConfig,
   type DataFetcher,
   type ResolvedData,
 } from './ViewDataProvider.js';
+
+export {
+  collectSavedViews,
+  composeElementDataSource,
+  elementDataSourceViewNotFoundMessage,
+  isElementDataSourceConfig,
+  resolveSavedView,
+  type ComposedElementDataSource,
+  type ElementDataSourceConfig,
+  type ElementDataSourceSort,
+  type ElementSavedView,
+} from './element-data-source.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from './utils/extract-records.js';
 export * from './utils/expand-fields.js';
 export * from './utils/column-identity.js';
 export * from './utils/sort-values.js';
+export * from './utils/resolve-view-id.js';
 export * from './evaluator/index.js';
 export * from './actions/index.js';
 export * from './query/index.js';

--- a/packages/core/src/utils/resolve-view-id.ts
+++ b/packages/core/src/utils/resolve-view-id.ts
@@ -1,0 +1,48 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Resolve a REQUESTED view name against an object's actual view ids.
+ *
+ * Canonical view ids are fully qualified (`<object>.<viewKind>`, see app-shell's
+ * MetadataProvider), but the surfaces that NAME a view emit the short form —
+ * nav items write their `viewName` verbatim, `ElementDataSource.view` on a page
+ * component is authored by hand, and legacy embedded `listViews` carry bare keys
+ * (including the `'all'` fallback view). Accept both directions (#2217):
+ *
+ * 1. exact id match;
+ * 2. short name (no `.`) → retry as `<objectName>.<name>`;
+ * 3. qualified name → retry with the `<objectName>.` prefix stripped.
+ *
+ * Returns the matching view id, or `undefined` when nothing matches — the
+ * caller decides how to fall back (and should report it rather than swallow it).
+ *
+ * Lives in `@object-ui/core` because it has two consumers in different layers:
+ * app-shell's `ObjectView` (URL-requested view) and the page-component data
+ * binding that resolves `dataSource.view` (objectstack#5576). A second copy at
+ * the second call site is the drift AGENTS.md #0.1 forbids — one matcher, one
+ * place, so a view name that resolves in the object page resolves identically
+ * when a page component names it.
+ */
+export function resolveViewId(
+  requested: string | undefined | null,
+  viewIds: readonly string[],
+  objectName: string,
+): string | undefined {
+  if (!requested) return undefined;
+  const has = (id: string) => viewIds.includes(id);
+  if (has(requested)) return requested;
+  const prefix = `${objectName}.`;
+  if (!requested.includes('.') && has(prefix + requested)) {
+    return prefix + requested;
+  }
+  if (requested.startsWith(prefix) && has(requested.slice(prefix.length))) {
+    return requested.slice(prefix.length);
+  }
+  return undefined;
+}

--- a/packages/plugin-list/README.md
+++ b/packages/plugin-list/README.md
@@ -180,6 +180,42 @@ interface ListViewSchema {
 }
 ```
 
+## Page binding — `dataSource` (referencing a saved view by name)
+
+On a metadata page, a `list-view` component can bind its data through the spec's
+per-element data source (`PageComponentSchema.dataSource`,
+`ElementDataSourceSchema`) instead of spelling `objectName` and inlining the
+view's configuration:
+
+```json
+{
+  "type": "list-view",
+  "dataSource": { "object": "account", "view": "hot", "limit": 10 }
+}
+```
+
+`view` names a **saved view** of that object — either one embedded in the object
+definition (`listViews`) or one created in the UI (the metadata overlay an
+adapter serves from `listViews()`). Its `columns`, `filter`, `sort`, page size
+and view kind are applied to the render, so a page no longer has to keep a second
+copy of a view's configuration in sync with the view itself. Both the short key
+(`hot`) and the qualified id (`account.hot`) resolve.
+
+**Precedence.** `dataSource.*` keys are authoritative — the author wrote them on
+this placement, and they beat the component's own same-named key. Values that
+come from the named view are a *baseline*: a key written on the component itself
+is more specific than the view it points at, so the component's key wins
+(an empty `columns: []` counts as "not authored"). `filter` is the exception —
+the spec calls `dataSource.filter` "additional filter criteria", so the
+component's filter, the view's filter and the binding's filter all AND together.
+A binding can narrow what the view selects, never widen it.
+
+**An unresolvable `view` is an error, not an empty table.** If the named view
+does not exist, the block renders a configuration error listing the object's
+actual views, and issues no query. It deliberately does not fall back to the
+object's default view: that would turn a typo into a silently *wider* answer on a
+page that still looks like it works.
+
 ## Sorting (and why relational columns are not offered)
 
 The toolbar sort becomes a server `$orderby` on the **flat field name**, so the

--- a/packages/plugin-list/src/ListViewBlock.tsx
+++ b/packages/plugin-list/src/ListViewBlock.tsx
@@ -1,0 +1,177 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useContext, useMemo } from 'react';
+import { isElementDataSourceConfig, mergeFilterNodes } from '@object-ui/core';
+import { SchemaRendererContext, useElementDataSource } from '@object-ui/react';
+import { ListView, type ListViewHandle, type ListViewProps } from './ListView';
+
+/**
+ * Registry entry point for `<ListView>` — two bridges in one component.
+ *
+ * ## 1. The data-source ADAPTER (#3144)
+ *
+ * `ListView` reads `props.dataSource` (the injected adapter), and
+ * `SchemaRenderer` never passes it — it only puts the data source on
+ * `SchemaRendererContext`. Registering the component bare meant that on the
+ * registry/SDUI path (a metadata page, a `kind:'react'` page, the designer
+ * preview) it received no data source at all: its `getObjectSchema` effect
+ * returned immediately, nothing was ever fetched, and it rendered the "Nothing
+ * here" empty state — while its registry `inputs` declared `objectName`
+ * **required**. The app never showed this because the console reaches ListView
+ * through `ObjectView`'s `renderListView` render-prop, which passes a data
+ * source itself. That is the objectstack#4413 shape (a declared binding nothing
+ * can consume), caught by
+ * `apps/console/src/__tests__/public-block-binding-reach.test.tsx` rather than by
+ * hand. `object-form`, `object-kanban` and `object-calendar` carry the same
+ * one-line bridge.
+ *
+ * An explicit `dataSource` prop still wins — hosts that pass their own (as
+ * `ObjectView` does) are unaffected. `useContext` rather than
+ * `useSchemaContext()` because the latter throws outside a provider, and a bare
+ * `<ListView>` with a host-supplied data source must keep working.
+ *
+ * ## 2. The spec's per-element data BINDING (objectstack#5576)
+ *
+ * `PageComponentSchema.dataSource` — `{ object, view?, filter?, sort?, limit? }` —
+ * is how a page component declares what to query. It was published and unread:
+ * `resolveElementDataSource` dropped `view`, had no caller outside its own test,
+ * and nothing mapped `object` onto `objectName`. Worse, the binding and the
+ * adapter above collide by NAME, so a page that wrote the binding the spec
+ * documents got the plain `{ object, view }` object where the adapter belongs:
+ * the first `dataSource.find(…)` threw `dataSource.find is not a function` and
+ * the list rendered **"Couldn't load records"**. Three `list-view` components on
+ * one home page, the two without `dataSource` fine and the spec-compliant one
+ * broken, is the single-variable reproduction in the issue.
+ *
+ * `SchemaRenderer` no longer spreads the schema's `dataSource` as a prop, which
+ * removes the collision at its source. This component completes the other half:
+ * it maps the binding onto the props `ListView` actually reads, resolving a named
+ * saved view through {@link useElementDataSource}.
+ *
+ * ### Precedence
+ *
+ * Two kinds of value arrive, and they do not have the same standing:
+ *
+ *  - **`dataSource.*` keys are authoritative.** The author wrote them on THIS
+ *    placement, and the spec says the binding "overrides page-level object
+ *    context". They beat the component's own same-named key.
+ *  - **View-sourced values are a baseline.** A `view` is a *reference*; a key
+ *    written on the component itself is more specific than the view it points at,
+ *    so the component's key wins. ("view provides the baseline, explicit keys
+ *    override".)
+ *  - **`filter` never overrides — it combines.** The spec describes the
+ *    binding's filter as "*Additional* filter criteria", so component filter,
+ *    view filter and binding filter all AND together through
+ *    `mergeFilterNodes`. A binding can only narrow what the view already
+ *    restricts, never widen it: a mistyped per-element filter cannot expose rows
+ *    the saved view excluded. (`ListView` then ANDs the user's own toolbar
+ *    filters onto this, unchanged.)
+ *
+ * An authored-but-EMPTY `columns` counts as "not authored": `[]` is what the
+ * designer emits for an unconfigured column list, and supplying the columns is
+ * exactly why a view was named. Any non-empty `columns` on the component wins.
+ *
+ * ### An unresolvable `view` fails loudly
+ *
+ * When the named view does not exist we render a configuration error instead of
+ * falling back to the object's default view. Silently widening a named view to
+ * "all records" is the failure class the binding exists to remove, and it is the
+ * one an AI-authored page hides best: the page looks like it works. Same posture
+ * (and same shape of panel) as `SchemaRenderer`'s "Unknown component type" —
+ * authored metadata pointing at something that is not there.
+ */
+const ListViewBlock = React.forwardRef<ListViewHandle, ListViewProps>((props, ref) => {
+  const context = useContext(SchemaRendererContext as React.Context<any>);
+
+  // Defence in depth for the collision above: even though SchemaRenderer no
+  // longer spreads it, a host (or an older cached bundle) handing us the spec
+  // BINDING under this prop name must never be mistaken for an adapter.
+  const explicitAdapter = isElementDataSourceConfig(props.dataSource)
+    ? undefined
+    : props.dataSource;
+  const adapter = explicitAdapter ?? context?.dataSource;
+
+  const binding = useElementDataSource(props.schema, adapter);
+
+  const schema = useMemo(() => {
+    const composed = binding.composed;
+    if (!composed) return props.schema;
+
+    const base = props.schema as Record<string, any>;
+    const next: Record<string, any> = { ...base };
+
+    next.objectName = composed.object;
+
+    const authoredColumns = Array.isArray(base.columns) && base.columns.length > 0
+      ? base.columns
+      : undefined;
+    if (authoredColumns === undefined && composed.columns !== undefined) {
+      next.columns = composed.columns;
+    }
+
+    // Component filter AND (view filter AND binding filter). `composed.filter`
+    // already carries the latter pair; a single surviving source comes back
+    // unwrapped, so the common "only the view filters" case stays flat.
+    const filter = mergeFilterNodes(base.filter, composed.filter);
+    if (filter !== undefined) next.filter = filter;
+    else delete next.filter;
+
+    // `composed.sort` is the binding's sort when it declared one, else the
+    // view's — so the component's own `sort` may only win over the latter.
+    if (composed.sort !== undefined) {
+      const viewSuppliedSort = binding.config?.sort === undefined;
+      if (!viewSuppliedSort || base.sort === undefined) next.sort = composed.sort;
+    }
+
+    if (composed.limit !== undefined) {
+      const viewSuppliedLimit = binding.config?.limit === undefined;
+      const authoredPageSize = base.pagination?.pageSize;
+      if (!viewSuppliedLimit || authoredPageSize === undefined) {
+        next.pagination = { ...(base.pagination ?? {}), pageSize: composed.limit };
+      }
+    }
+
+    if (composed.viewType !== undefined && base.viewType === undefined) {
+      next.viewType = composed.viewType;
+    }
+
+    return next as ListViewProps['schema'];
+  }, [props.schema, binding.composed, binding.config]);
+
+  if (binding.status === 'missing') {
+    return (
+      <div
+        className="p-4 border border-red-500 rounded text-red-500 bg-red-50 my-2"
+        role="alert"
+        data-testid="list-view-datasource-error"
+      >
+        <p className="font-medium">This list view&rsquo;s data source could not be resolved</p>
+        <p className="text-sm mt-1">{binding.error}</p>
+      </div>
+    );
+  }
+
+  if (binding.status === 'loading') {
+    return (
+      <div
+        className="p-2 text-sm text-muted-foreground animate-pulse"
+        role="status"
+        aria-live="polite"
+        data-testid="list-view-resolving-view"
+      >
+        Loading view&hellip;
+      </div>
+    );
+  }
+
+  return <ListView ref={ref} {...props} schema={schema} dataSource={adapter} />;
+});
+ListViewBlock.displayName = 'ListViewBlock';
+
+export { ListViewBlock };

--- a/packages/plugin-list/src/__tests__/ListView.elementDataSource.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.elementDataSource.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `list-view` consumes `PageComponentSchema.dataSource` (objectstack#5576).
+ *
+ * ## What was wrong, in two halves
+ *
+ * The spec declares a per-element data binding on every page component —
+ * `dataSource: { object, view?, filter?, sort?, limit? }` — and objectui read
+ * none of it on this block. `resolveElementDataSource` dropped `view` and had no
+ * caller outside its own test, and nothing mapped `object` onto the `objectName`
+ * that `ListView` actually reads. So "reference a saved view by name" was
+ * published and inert (the objectstack#4413 shape).
+ *
+ * Worse, writing the binding BROKE the block. `ListView`'s `dataSource` prop is
+ * the injected data-source ADAPTER, `SchemaRenderer` spread the schema's
+ * `dataSource` METADATA onto it, and the plain `{ object, view }` object won —
+ * `dataSource.find is not a function`, surfaced as "Couldn't load records".
+ * Three `list-view` components on one home page, the two without `dataSource`
+ * rendering real data and the spec-compliant one failing, is the reproduction in
+ * the issue; the tests below are that reproduction in both directions.
+ *
+ * ## Why the not-found case is an error and not an empty table
+ *
+ * A `view` name that does not resolve renders a configuration error. It must not
+ * fall back to the object's default view: that turns a typo into a silently
+ * WIDER answer — every record instead of the ones the saved view selects — on a
+ * page that still looks like it works. It is the exact failure that hides best in
+ * AI-authored metadata, so it fails loudly at the only place that can see it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `list-view` (and the ListViewBlock bridge under test).
+import '../index';
+
+const HOT_VIEW = {
+  name: 'hot',
+  label: 'Hot accounts',
+  type: 'grid',
+  columns: ['name', 'rating'],
+  filter: [['rating', '=', 'hot']],
+  sort: [{ field: 'name', order: 'desc' }],
+};
+
+/** A data source shaped like the console's adapter, with saved views embedded. */
+function makeAdapter(listViews: Record<string, unknown> = { hot: HOT_VIEW }) {
+  return {
+    find: vi.fn().mockResolvedValue({ data: [{ id: '1', name: 'Acme', rating: 'hot' }], total: 1 }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'account',
+      fields: [
+        { name: 'name', type: 'text' },
+        { name: 'rating', type: 'text' },
+        { name: 'owner', type: 'text' },
+      ],
+      listViews,
+    }),
+  };
+}
+
+function renderPageComponent(schema: Record<string, unknown>, adapter: ReturnType<typeof makeAdapter>) {
+  return render(
+    <SchemaRendererProvider dataSource={adapter as any}>
+      <SchemaRenderer schema={schema as any} />
+    </SchemaRendererProvider>,
+  );
+}
+
+const firstQuery = (adapter: ReturnType<typeof makeAdapter>) => adapter.find.mock.calls[0][1] as any;
+
+describe('list-view — dataSource: { object, view } (objectstack#5576)', () => {
+  it('renders the saved view’s columns, filter and sort', async () => {
+    const adapter = makeAdapter();
+    const { container } = renderPageComponent(
+      { type: 'list-view', dataSource: { object: 'account', view: 'hot' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+
+    const query = firstQuery(adapter);
+    // `object` reached the data layer as the queried object — the binding half
+    // that nothing used to map.
+    expect(adapter.find.mock.calls[0][0]).toBe('account');
+    // The view's filter and sort are applied…
+    expect(query.$filter).toEqual([['rating', '=', 'hot']]);
+    expect(query.$orderby).toEqual([{ field: 'name', order: 'desc' }]);
+    // …and its columns drive the projection (`id` is always requested).
+    expect(query.$select).toEqual(['id', 'name', 'rating']);
+    // The regression face: writing the binding must not break the block.
+    expect(container.querySelector('[data-testid="list-error-state"]')).toBeNull();
+  });
+
+  it('does NOT report "Couldn’t load records" for a spec-compliant binding', async () => {
+    // The literal symptom from the issue. Before the fix the schema's
+    // `dataSource` shadowed the adapter and `dataSource.find` was not a
+    // function, so this panel was the whole rendered output.
+    const adapter = makeAdapter();
+    const { container } = renderPageComponent(
+      { type: 'list-view', objectName: 'account', dataSource: { object: 'account', view: 'hot' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    const panel = container.querySelector('[data-testid="list-error-state"]');
+    expect(panel).toBeNull();
+  });
+
+  it('leaves a component with NO dataSource exactly as it was', async () => {
+    // The other direction of the single-variable reproduction: the two
+    // components on that page that worked must keep working, unchanged.
+    const adapter = makeAdapter();
+    const { container } = renderPageComponent(
+      { type: 'list-view', objectName: 'account', columns: ['name'] },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(adapter.find.mock.calls[0][0]).toBe('account');
+    const query = firstQuery(adapter);
+    expect(query.$select).toEqual(['id', 'name']);
+    expect(query.$filter).toBeUndefined();
+    expect(container.querySelector('[data-testid="list-error-state"]')).toBeNull();
+    expect(container.querySelector('[data-testid="list-view-datasource-error"]')).toBeNull();
+  });
+
+  it('binds `object` with no `view` — no saved view needed', async () => {
+    const adapter = makeAdapter();
+    renderPageComponent(
+      { type: 'list-view', columns: ['name'], dataSource: { object: 'account', limit: 7 } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(adapter.find.mock.calls[0][0]).toBe('account');
+    expect(firstQuery(adapter).$top).toBe(7);
+  });
+
+  it('AND-combines the binding filter with the view’s, never replacing it', async () => {
+    const adapter = makeAdapter();
+    renderPageComponent(
+      {
+        type: 'list-view',
+        dataSource: { object: 'account', view: 'hot', filter: { owner: 'me' } },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    // The view's own restriction survives — a binding filter narrows, it cannot
+    // widen the view back to rows the view excludes.
+    expect(firstQuery(adapter).$filter).toEqual([
+      'and',
+      [['rating', '=', 'hot']],
+      ['owner', '=', 'me'],
+    ]);
+  });
+
+  it('lets the binding’s own sort and limit override the view’s', async () => {
+    const adapter = makeAdapter();
+    renderPageComponent(
+      {
+        type: 'list-view',
+        dataSource: {
+          object: 'account',
+          view: 'hot',
+          sort: [{ field: 'rating', order: 'asc' }],
+          limit: 3,
+        },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    const query = firstQuery(adapter);
+    expect(query.$orderby).toEqual([{ field: 'rating', order: 'asc' }]);
+    expect(query.$top).toBe(3);
+  });
+
+  it('lets columns authored on the component win over the view’s', async () => {
+    const adapter = makeAdapter();
+    renderPageComponent(
+      {
+        type: 'list-view',
+        columns: ['name'],
+        dataSource: { object: 'account', view: 'hot' },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(firstQuery(adapter).$select).toEqual(['id', 'name']);
+    // The view is still applied for everything the component did not author.
+    expect(firstQuery(adapter).$filter).toEqual([['rating', '=', 'hot']]);
+  });
+
+  it('reads a view from the metadata overlay (`dataSource.listViews`) too', async () => {
+    // Saved views created in the UI live in the overlay, not in the object
+    // definition — app-shell's ObjectView reads both, and so must this.
+    const adapter = Object.assign(makeAdapter({}), {
+      listViews: vi.fn().mockResolvedValue([{ ...HOT_VIEW }]),
+    });
+    renderPageComponent(
+      { type: 'list-view', dataSource: { object: 'account', view: 'hot' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(adapter.listViews).toHaveBeenCalledWith('account');
+    expect(firstQuery(adapter).$filter).toEqual([['rating', '=', 'hot']]);
+  });
+
+  it('accepts the qualified spelling of a bare view key', async () => {
+    const adapter = makeAdapter();
+    renderPageComponent(
+      { type: 'list-view', dataSource: { object: 'account', view: 'account.hot' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(firstQuery(adapter).$filter).toEqual([['rating', '=', 'hot']]);
+  });
+});
+
+describe('list-view — an unresolvable dataSource.view fails loudly', () => {
+  it('renders a configuration error naming the view, object and known views', async () => {
+    const adapter = makeAdapter();
+    const { container } = renderPageComponent(
+      { type: 'list-view', dataSource: { object: 'account', view: 'lukewarm' } },
+      adapter,
+    );
+
+    const panel = await waitFor(() => {
+      const el = container.querySelector('[data-testid="list-view-datasource-error"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    expect(panel.getAttribute('role')).toBe('alert');
+    expect(panel.textContent).toContain('lukewarm');
+    expect(panel.textContent).toContain('account');
+    // What the object DOES have — the part that gets an author unstuck.
+    expect(panel.textContent).toContain('hot');
+  });
+
+  it('never falls back to an unfiltered query for the object', async () => {
+    const adapter = makeAdapter();
+    const { container } = renderPageComponent(
+      { type: 'list-view', dataSource: { object: 'account', view: 'lukewarm' } },
+      adapter,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="list-view-datasource-error"]')).not.toBeNull();
+    });
+    // The silent-widening this whole binding exists to remove: a mistyped view
+    // name must not become "every record in the object".
+    expect(adapter.find).not.toHaveBeenCalled();
+  });
+
+  it('reports it on an object with no saved views at all', async () => {
+    const adapter = makeAdapter({});
+    const { container } = renderPageComponent(
+      { type: 'list-view', dataSource: { object: 'account', view: 'hot' } },
+      adapter,
+    );
+
+    const panel = await waitFor(() => {
+      const el = container.querySelector('[data-testid="list-view-datasource-error"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    expect(panel.textContent).toContain('no saved views');
+    expect(adapter.find).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes "cannot answer" from "the view does not exist"', async () => {
+    // A data source that can read records but cannot list views at all. Saying
+    // "this object has no view called hot" would be a claim we cannot make;
+    // the two facts get two messages.
+    const adapter = { find: vi.fn().mockResolvedValue({ data: [], total: 0 }) } as any;
+    const { container } = renderPageComponent(
+      { type: 'list-view', dataSource: { object: 'account', view: 'hot' } },
+      adapter,
+    );
+
+    const panel = await waitFor(() => {
+      const el = container.querySelector('[data-testid="list-view-datasource-error"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    expect(panel.textContent).toContain('cannot list the saved views');
+    expect(adapter.find).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-list/src/index.tsx
+++ b/packages/plugin-list/src/index.tsx
@@ -6,14 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useContext } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
-import { SchemaRendererContext } from '@object-ui/react';
-import { ListView, type ListViewHandle, type ListViewProps } from './ListView';
+import { ListView } from './ListView';
+import { ListViewBlock } from './ListViewBlock';
 import { ViewSwitcher } from './ViewSwitcher';
 import { ObjectGallery } from './ObjectGallery';
 
-export { ListView, ViewSwitcher, ObjectGallery };
+export { ListView, ListViewBlock, ViewSwitcher, ObjectGallery };
 export { ViewSwitcherDropdown } from './ViewSwitcher';
 export { TabBar, TabBarSelect } from './components/TabBar';
 export type { TabBarProps, ViewTab } from './components/TabBar';
@@ -25,34 +24,12 @@ export type { ObjectGalleryProps } from './ObjectGallery';
 export type { ViewSwitcherProps, ViewType } from './ViewSwitcher';
 
 /**
- * Registry entry point for `<ListView>` — bridges the schema-renderer context
- * onto the component's `dataSource` PROP (#3144).
- *
- * `ListView` reads `props.dataSource`, and `SchemaRenderer` never injects it —
- * it only puts the data source on `SchemaRendererContext`. So registering the
- * component bare meant that on the registry/SDUI path (a metadata page, a
- * `kind:'react'` page, the designer preview) it received no data source at all:
- * its `getObjectSchema` effect returned immediately, nothing was ever fetched,
- * and it rendered the "Nothing here" empty state — while its registry `inputs`
- * declared `objectName` **required**. The app never showed this because the
- * console reaches ListView through `ObjectView`'s `renderListView` render-prop,
- * which passes a data source itself.
- *
- * That is the objectstack#4413 shape (a declared binding nothing can consume),
- * caught this time by `apps/console/src/__tests__/public-block-binding-reach.test.tsx`
- * rather than by hand. `object-form`, `object-kanban` and `object-calendar` have
- * carried this same one-line bridge all along.
- *
- * An explicit `dataSource` prop still wins — hosts that pass their own (as
- * `ObjectView` does) are unaffected. `useContext` rather than
- * `useSchemaContext()` because the latter throws outside a provider, and a bare
- * `<ListView>` with a host-supplied data source must keep working.
+ * Registry entry point for `<ListView>`. Both bridges it carries — the
+ * schema-renderer context onto the `dataSource` PROP (#3144), and the spec's
+ * `PageComponentSchema.dataSource` BINDING onto the props `ListView` reads
+ * (objectstack#5576) — are documented on {@link ListViewBlock}.
  */
-const ListViewRenderer = React.forwardRef<ListViewHandle, ListViewProps>((props, ref) => {
-  const context = useContext(SchemaRendererContext as React.Context<any>);
-  return <ListView ref={ref} {...props} dataSource={props.dataSource ?? context?.dataSource} />;
-});
-ListViewRenderer.displayName = 'ListViewRenderer';
+const ListViewRenderer = ListViewBlock;
 
 // Register ListView component
 ComponentRegistry.register('list-view', ListViewRenderer, {

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -407,6 +407,18 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
     hiddenOn: _hiddenOn,
     disabled: _disabled,
     disabledOn: _disabledOn,
+    // stripped: `PageComponentSchema.dataSource` is the spec's per-element data
+    // BINDING (`{ object, view, filter, sort, limit }`) — schema metadata, like
+    // `visibleWhen` above, not a visual prop. Renderers that consume it read
+    // `schema.dataSource` (element:record_picker, list-view); it must not be
+    // spread as a React prop, because several data-bound blocks take the
+    // injected data-source ADAPTER under that very name. Spreading it shadowed
+    // the adapter with a plain `{ object, view }` object, so the first
+    // `dataSource.find(…)` threw `dataSource.find is not a function` and the
+    // block reported "Couldn't load records" — writing the binding the spec
+    // documents BROKE the component (objectstack#5576). An explicit React
+    // `dataSource` prop is unaffected: it arrives via `...props`, spread last.
+    dataSource: _dataSource,
     _hidden: __hidden,    // stripped: internal visibility flag
     _disabled: __disabled, // stripped: internal disabled flag
     responsiveStyles: _responsiveStyles, // stripped: compiled to scoped CSS, not a DOM prop

--- a/packages/react/src/__tests__/SchemaRenderer.dataSourceBinding.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.dataSourceBinding.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `PageComponentSchema.dataSource` is schema METADATA, not a React prop
+ * (objectstack#5576).
+ *
+ * SchemaRenderer spreads every non-metadata schema key onto the resolved
+ * component. `dataSource` was not on the strip list, so the spec's per-element
+ * data BINDING (`{ object, view, filter, sort, limit }` — plain JSON) landed on
+ * the `dataSource` PROP of every data-bound block, which is where the host
+ * injects the runtime data-source ADAPTER. The plain object shadowed the
+ * adapter, and the block's first `dataSource.find(…)` threw
+ * `dataSource.find is not a function`: `list-view` reported that as
+ * **"Couldn't load records"**, so a page component that wrote the binding the
+ * spec documents was BROKEN by writing it, while the same component without it
+ * worked. That is the single-variable reproduction in the issue.
+ *
+ * These tests pin the three facts that make the collision impossible to
+ * reintroduce: the binding does not arrive as a prop, it is still readable off
+ * `schema` (which is how a consumer is supposed to read it), and an explicit
+ * React `dataSource` prop — how `ObjectView` and every test harness pass a real
+ * adapter — still reaches the component untouched.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+
+/**
+ * Props the probe was rendered with. An ARRAY that is pushed to, rather than a
+ * variable reassigned from inside the component — `react-hooks/globals` (error
+ * in this repo) forbids the latter.
+ */
+const renders: Array<Record<string, any>> = [];
+const seen = () => renders[renders.length - 1];
+
+const ProbeWidget: React.FC<any> = (props) => {
+  renders.push(props);
+  return <div data-testid="probe" />;
+};
+
+const BINDING = { object: 'account', view: 'hot' } as const;
+
+describe('SchemaRenderer — schema.dataSource is metadata, not a prop', () => {
+  beforeEach(() => {
+    renders.length = 0;
+    ComponentRegistry.register('probe-widget', ProbeWidget);
+  });
+
+  afterEach(() => {
+    ComponentRegistry.unregister?.('probe-widget');
+  });
+
+  it('does not spread the schema binding onto the component as `dataSource`', () => {
+    render(<SchemaRenderer schema={{ type: 'probe-widget', dataSource: { ...BINDING } } as any} />);
+    // No provider is mounted, so there is no adapter either — the point is that
+    // the METADATA is not standing in for one.
+    expect(seen()?.dataSource).toBeUndefined();
+  });
+
+  it('keeps the binding readable on `schema` — the supported read path', () => {
+    render(<SchemaRenderer schema={{ type: 'probe-widget', dataSource: { ...BINDING } } as any} />);
+    expect(seen()?.schema?.dataSource).toEqual(BINDING);
+  });
+
+  it('still delivers an explicit React `dataSource` prop (a real adapter)', () => {
+    const adapter = { find: async () => ({ data: [] }) };
+    render(
+      <SchemaRenderer
+        schema={{ type: 'probe-widget', dataSource: { ...BINDING } } as any}
+        dataSource={adapter}
+      />,
+    );
+    expect(seen()?.dataSource).toBe(adapter);
+    // …and the binding is still on the schema, so a block can consume both.
+    expect(seen()?.schema?.dataSource).toEqual(BINDING);
+  });
+
+  it('leaves a `props.dataSource` written under the schema’s `props` bag alone', () => {
+    // `schema.props` is the explicit visual-prop channel, spread after the
+    // metadata strip. Nothing about #5576 changes it.
+    const adapter = { find: async () => ({ data: [] }) };
+    render(
+      <SchemaRenderer
+        schema={{ type: 'probe-widget', props: { dataSource: adapter } } as any}
+      />,
+    );
+    expect(seen()?.dataSource).toBe(adapter);
+  });
+});

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -14,6 +14,8 @@ export * from './useNavigationOverlay';
 export * from './usePageVariables';
 export * from './usePageVariableActionBridge';
 export * from './useViewData';
+// PageComponentSchema.dataSource — the spec's per-element data binding.
+export * from './useElementDataSource';
 export * from './useDynamicApp';
 export * from './useDiscovery';
 export * from './useFocusTrap';

--- a/packages/react/src/hooks/useElementDataSource.ts
+++ b/packages/react/src/hooks/useElementDataSource.ts
@@ -1,0 +1,212 @@
+/**
+ * ObjectUI — useElementDataSource
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Runtime half of consuming `PageComponentSchema.dataSource` — the spec's
+ * `ElementDataSourceSchema` per-element data binding (objectstack#5576).
+ *
+ * `@object-ui/core` owns the pure half (telling the binding apart from a runtime
+ * adapter, matching a view name, composing the view with the binding's own keys).
+ * This hook owns the part that needs React and a data source: FETCHING the
+ * object's saved views so `view` can be resolved to real columns/filter/sort.
+ *
+ * It lives in `@object-ui/react` rather than in the one plugin that consumes it
+ * today because the binding is declared on EVERY page component: `list-view`
+ * reads it here, `element:record_picker` already reads `schema.dataSource` (and
+ * still ignores `view`), and the remaining object-bound blocks will need the same
+ * resolution. One resolver in the runtime layer, not one per plugin.
+ */
+
+import { useContext, useEffect, useMemo, useState, type Context } from 'react';
+import {
+  collectSavedViews,
+  composeElementDataSource,
+  elementDataSourceViewNotFoundMessage,
+  isElementDataSourceConfig,
+  resolveSavedView,
+  type ComposedElementDataSource,
+  type ElementDataSourceConfig,
+  type ElementSavedView,
+} from '@object-ui/core';
+import { SchemaRendererContext } from '../context/SchemaRendererContext';
+
+/**
+ * Where a resolution attempt stands. Distinguishing `loading` from `missing`
+ * matters: a component that treated "not resolved yet" as "does not exist" would
+ * flash the configuration error on every mount.
+ */
+export type ElementDataSourceStatus =
+  /** The node carries no `dataSource` binding — nothing to resolve. */
+  | 'absent'
+  /** Binding present, no `view` named — composition is already final. */
+  | 'ready'
+  /** A `view` was named and the saved views are still being fetched. */
+  | 'loading'
+  /** The named `view` was found and composed in. */
+  | 'resolved'
+  /** The named `view` does not exist on the object (or could not be read). */
+  | 'missing';
+
+export interface UseElementDataSourceResult {
+  status: ElementDataSourceStatus;
+  /** The binding as authored, or `undefined` when the node carries none. */
+  config?: ElementDataSourceConfig;
+  /**
+   * Binding composed with the resolved view. Present for `ready` and
+   * `resolved`; withheld for `loading` and `missing` so a caller cannot render a
+   * half-resolved query by accident.
+   */
+  composed?: ComposedElementDataSource;
+  /** The saved view that was applied, when one was. */
+  view?: ElementSavedView;
+  /** Author-facing explanation, set only for `missing`. */
+  error?: string;
+}
+
+/** A data source able to answer "what saved views does this object have?". */
+interface ViewCapableDataSource {
+  listViews?: (object: string) => Promise<unknown>;
+  getObjectSchema?: (object: string) => Promise<unknown>;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === 'object';
+
+/**
+ * Read every saved view for `object` from the two places they live, in the same
+ * precedence app-shell's `ObjectView` uses: the object definition's embedded
+ * `listViews` / `list_views` map first, then the metadata-overlay rows
+ * `listViews()` returns — so a user-saved view shadows a metadata one of the
+ * same id.
+ *
+ * `capable` is false when there is no data source, or it exposes neither read —
+ * "this object has no view called X" and "nobody here can answer that question"
+ * are different facts and must not be reported as the same one. Both are still
+ * reported; only the message differs.
+ *
+ * A REJECTION from either source is swallowed to an empty contribution rather
+ * than propagated: one unavailable source must not make an existing view in the
+ * OTHER source read as missing.
+ */
+async function fetchSavedViews(
+  dataSource: ViewCapableDataSource | null | undefined,
+  object: string,
+): Promise<{ capable: boolean; views: Record<string, ElementSavedView> }> {
+  const canReadObjectDef = typeof dataSource?.getObjectSchema === 'function';
+  const canReadOverlay = typeof dataSource?.listViews === 'function';
+  if (!canReadObjectDef && !canReadOverlay) return { capable: false, views: {} };
+
+  const embedded = canReadObjectDef
+    ? dataSource!.getObjectSchema!(object).then(
+        (def) => (isRecord(def) ? (def.listViews ?? def.list_views) : undefined),
+        () => undefined,
+      )
+    : Promise.resolve(undefined);
+
+  const overlay = canReadOverlay
+    ? dataSource!.listViews!(object).then((rows) => rows, () => undefined)
+    : Promise.resolve(undefined);
+
+  const [embeddedViews, overlayViews] = await Promise.all([embedded, overlay]);
+  return { capable: true, views: collectSavedViews(embeddedViews, overlayViews) };
+}
+
+/**
+ * Resolve a schema node's `dataSource` binding, fetching the named saved view.
+ *
+ * @param schema      The component's schema node (its `dataSource` is read).
+ * @param dataSource  Explicit adapter; falls back to `SchemaRendererContext`.
+ *
+ * @example
+ * ```tsx
+ * const binding = useElementDataSource(schema, adapter);
+ * if (binding.status === 'missing') return <ConfigError message={binding.error} />;
+ * if (binding.status === 'loading') return <Skeleton />;
+ * const objectName = binding.composed?.object ?? schema.objectName;
+ * ```
+ */
+export function useElementDataSource(
+  schema: unknown,
+  dataSource?: unknown,
+): UseElementDataSourceResult {
+  const context = useContext(SchemaRendererContext as Context<any>);
+  const adapter = (dataSource ?? context?.dataSource ?? null) as ViewCapableDataSource | null;
+
+  const config = useMemo(() => {
+    const raw = isRecord(schema) ? (schema as Record<string, unknown>).dataSource : undefined;
+    return isElementDataSourceConfig(raw) ? raw : undefined;
+  }, [schema]);
+
+  const object = config?.object;
+  const viewName = config?.view;
+
+  /**
+   * Which (object, view) pair a stored resolution belongs to.
+   *
+   * The state carries its own key instead of being CLEARED when the binding
+   * changes, so the effect never calls `setState` synchronously in its body
+   * (`react-hooks/set-state-in-effect`, an error in this repo — and the cascading
+   * render it names is real: every mount would render twice). A resolution whose
+   * key no longer matches simply does not count, which reads as `loading` below
+   * — the same answer clearing would have produced, without the extra render.
+   */
+  const requestKey = object && viewName ? JSON.stringify([object, viewName]) : '';
+
+  // `view: null` = resolved to nothing (missing). `null` state = never resolved.
+  const [resolved, setResolved] = useState<
+    { key: string; view: ElementSavedView | null; error?: string } | null
+  >(null);
+
+  useEffect(() => {
+    if (!object || !viewName) return;
+    let cancelled = false;
+    fetchSavedViews(adapter, object).then(({ capable, views }) => {
+      if (cancelled) return;
+      if (!capable) {
+        setResolved({
+          key: requestKey,
+          view: null,
+          error:
+            `dataSource.view "${viewName}" cannot be resolved: this data source ` +
+            `cannot list the saved views of object "${object}".`,
+        });
+        return;
+      }
+      const view = resolveSavedView(views, viewName, object);
+      setResolved(
+        view
+          ? { key: requestKey, view }
+          : {
+              key: requestKey,
+              view: null,
+              error: elementDataSourceViewNotFoundMessage(
+                object,
+                viewName,
+                Object.keys(views),
+              ),
+            },
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [adapter, object, viewName, requestKey]);
+
+  return useMemo<UseElementDataSourceResult>(() => {
+    if (!config) return { status: 'absent' };
+    if (!config.view) {
+      return { status: 'ready', config, composed: composeElementDataSource(config) };
+    }
+    if (resolved?.key !== requestKey) return { status: 'loading', config };
+    if (resolved.view === null) return { status: 'missing', config, error: resolved.error };
+    return {
+      status: 'resolved',
+      config,
+      view: resolved.view,
+      composed: composeElementDataSource(config, resolved.view),
+    };
+  }, [config, resolved, requestKey]);
+}


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5576

## 结论先说:「Couldn't load records」的真实机理不是 view 键被丢弃

issue 正文把两件事归到了一起。实测(单变量对照,见下)后它们是**两个独立缺陷**,必须分别修:

1. **声明但丢弃(declared, not delivered)** —— `resolveElementDataSource` 透传 `filter`/`sort`/`limit`、把 `view` 整个丢掉,且除测试外零调用方;渲染路径上也没有任何地方把 `dataSource.object` 映射到 list-view 真正读的 `objectName`。所以「按名字引用 saved view」这条能力在运行时**不存在**。
2. **写了 `dataSource` 反而坏掉** —— 与 `view` 无关,是**同名撞车**:`SchemaRenderer` 会把 schema 上所有非元数据键 spread 成 React props,而 `dataSource` 恰好正是宿主注入**数据源适配器**用的那个 prop 名。于是 spec 合法的 `dataSource: { object, view }` 这个纯 JSON 对象把适配器**遮蔽**掉,第一次 `dataSource.find(…)` 抛 `dataSource.find is not a function`,list-view 把它渲染成 **"Couldn't load records"**。

实测原始读数(改前,`packages/plugin-list` 一次性探针,已删):

```
WITH-DS  → error: "Couldn’t load records…", errorKind: "network",
           find calls: [], getObjectSchema calls: []
           stderr: TypeError: dataSource.find is not a function
                   at fetchData (packages/plugin-list/src/ListView.tsx:1257)
NO-DS    → find calls: [["account", {"$select":["id","name"],"$top":100}]], error: null
WITH-DS 且不写 objectName → find calls: [], error: null(静默空表 —— 这才是 view 被丢弃那一半的症状)
```

也就是说:分诊预判的「view 键丢弃导致查询坏」不成立;`view` 被丢弃的表现是**静默空表/全量**,而 "Couldn't load records" 来自 prop 撞车。两条都在本 PR 修掉。

## 合成语义论证(spec 自己定了关键的一条)

`ElementDataSourceSchema` 的 describe 文本把唯一有歧义的键定死了 —— `filter` 是 "**Additional** filter criteria"。「additional」只能读成:view 已经限定的基础上**再**限定,所以 view filter 与 binding filter 必须 `and` 合成,binding 只能收窄、不能放宽。这也是 AI 产出的元数据里最安全的方向:一个写错的 per-element filter 不可能把 saved view 排除掉的行重新暴露出来。

其余键 spec 没有 additional 之说,且都是单值(一个排序、一个上限),按分诊定的「view 提供基线、显式键覆盖」:

| 键 | 来源 | 规则 |
|---|---|---|
| `object` | binding(必填) | binding 胜(spec: "Overrides page-level object context") |
| `columns` | 只来自 view(binding 无此键) | view |
| `filter` | view + binding + 组件自身 | 三者 `and` 合成("additional") |
| `sort` | view 或 binding | binding 覆盖 view |
| `limit` | view 的 `pagination.pageSize` 或 binding | binding 覆盖 view |
| `viewType` | 只来自 view | view |

组件自身写的键与 view 的关系单独说一句:`view` 是**引用**,组件上直接写的键比它指向的东西更具体,所以组件自身的键盖过 view(空的 `columns: []` 视为「没写」—— 那是设计器对「未配置」的产物,而指定 view 的用意正是由 view 提供列)。`dataSource.*` 是作者在**这一处**写的,标准更高:它同时盖过 view 和组件自身的同名键。

## view 名解析不到:报错,不是静默空表(语义已定并钉住)

解析不到时渲染一个配置错误面板(`role="alert"`,列出该对象**实际有哪些 view**),并且**不发任何查询**。刻意不回退到对象默认 view:那会把一个拼写错误变成**更宽**的答案(整个对象 vs saved view 选出的行),而页面看上去还是好的 —— 这正是 AI 生成的元数据最容易藏住的一类错。姿态与 `SchemaRenderer` 既有的 "Unknown component type" 红框一致(同一类:作者写的元数据指向了不存在的东西),因此沿用英文文案而未新造 10 个 locale 的 i18n 键。

另有一条相邻但不同的事实要分开报:「该对象没有这个 view」与「这个数据源压根答不了 view 有哪些」是两件事,给两条不同的错误文案,不合并。

## 改了什么

- **`@object-ui/react`** —— `SchemaRenderer` 把 `dataSource` 加入「schema 元数据、不作为 prop spread」名单(与 `visibleWhen` 同列)。消除撞车的根,对所有 data-bound block 一次生效;显式 React `dataSource` prop 不受影响(它走 `...props`,最后 spread)。新增 `useElementDataSource(schema, dataSource?)`,从对象定义的 `listViews` 与元数据 overlay 的 `listViews()` 两处取 saved view(与 app-shell `ObjectView` 同一优先级:overlay 覆盖 metadata)。
- **`@object-ui/core`** —— 新增 `element-data-source.ts`:`isElementDataSourceConfig`(binding 与适配器的判别式)、`collectSavedViews`、`resolveSavedView`、`composeElementDataSource`、`elementDataSourceViewNotFoundMessage`。`resolveElementDataSource` 不再丢弃 `view`:经可选的 `DataFetcher.fetchViews` 解析,解析不到就返回 `error`(而不是回退成全量)。`resolveViewId` 从 app-shell 移到 core(app-shell 原路径改为 re-export),使对象页与页面组件用**同一个**名字匹配器,而不是两份会漂移的实现。
- **`@object-ui/plugin-list`** —— 新 `ListViewBlock` 取代原来的一行 `ListViewRenderer`,把 binding 映射到 `ListView` 真正读的 props;并保留一层判别式兜底(即使有宿主把 binding 塞进 `dataSource` prop,也不会被当成适配器)。

## 验证(两方向对照 + 反向验证)

`packages/plugin-list/src/__tests__/ListView.elementDataSource.test.tsx` 就是正文那份单变量复现:
- 带 `dataSource: { object, view }` → `find('account', …)`,`$filter` = view 的 filter、`$orderby` = view 的 sort、`$select` = view 的 columns,且 `list-error-state` 面板为 null;
- 不带 `dataSource` → 行为逐字不变;
- view 名解析不到 → 配置错误面板,`find` 零调用。

命令与读数:

```
pnpm exec vitest run packages/core/src/data-scope/ packages/react/ packages/plugin-list/ \
  packages/components/src/__tests__/page-variables.test.tsx packages/app-shell/src/utils/ \
  apps/console/src/__tests__/public-block-binding-reach.test.tsx --maxWorkers=2
→ Test Files  80 passed (80)     Tests  1152 passed (1152)

pnpm exec turbo run type-check --concurrency=2
→ Tasks:  78 successful, 78 total     (0 error TS)
```

### 反向验证:两处各自独立,方向**不同**,先预判后跑

两个缺陷是分开修的,所以反向验证也必须分开做,否则一处的红会掩盖另一处压根没被钉住。

**RV-B —— 把 `plugin-list/src/index.tsx` 换回 origin/main(binding 消费撤掉,`SchemaRenderer` 的剥离保留)。**
预判:view 系测试全红(`objectName` 未设 → 压根不发查询),但「不报 Couldn't load records」与「不带 dataSource 行为不变」两条**仍绿** —— 前者靠的是剥离,不是 binding 消费。实测:

```
Test Files  1 failed | 1 passed (2)
     Tests  11 failed | 6 passed (17)
× renders the saved view's columns, filter and sort
× binds `object` with no `view` — no saved view needed
× AND-combines the binding filter with the view's, never replacing it
× lets the binding's own sort and limit override the view's
× lets columns authored on the component win over the view's
× reads a view from the metadata overlay (`dataSource.listViews`) too
× accepts the qualified spelling of a bare view key
× renders a configuration error naming the view, object and known views
× never falls back to an unfiltered query for the object
× reports it on an object with no saved views at all
× distinguishes "cannot answer" from "the view does not exist"
```

6 条通过的正是预判的那 6 条(2 条 plugin-list + 4 条 `SchemaRenderer.dataSourceBinding`)。

**RV-A —— 把 `packages/react/src/SchemaRenderer.tsx` 换回 origin/main(撞车恢复,`ListViewBlock` 保留)。**
预判(与「改回去就红」的直觉相反,故先写下来):plugin-list 的 13 条**仍然全绿**,因为 `ListViewBlock` 自己那层 `isElementDataSourceConfig` 兜底会拦住被塞进 prop 的 binding;转红的只有 `SchemaRenderer.dataSourceBinding` 里那条「不把 binding spread 成 prop」。实测读数与预判一致:

```
Test Files  1 failed | 1 passed (2)
     Tests  1 failed | 16 passed (17)
× does not spread the schema binding onto the component as `dataSource`
```

`ListView.elementDataSource.test.tsx` 的 13 条**一条没红**。这条反向读数本身就是一个结论:**两层各自有独立的钉子**,剥离(根)与判别式(兜底)不是同一件事的两种写法。

### 未做浏览器实证,如实说明

任务建议用 `verify` skill 做浏览器读数。没做,理由写清而不是补一个看起来像验证的东西:`verify` skill 的作用域是 metadata-admin designer 的 preview gallery(**无后端**),而本改动的关键路径恰恰是「从适配器取 saved view 并解析」—— 无后端时它必然走到「无法列出该对象的 saved view」那条分支,得到的读数不能支撑正向结论。真正的端到端实证需要一张 `type: 'home'` 页面上带 `dataSource: { object, view }` 的 list-view,而那份元数据在 objectstack 仓的 example app 里,超出本 PR 范围。替代证据是上面的**真实单变量复现**(含 `TypeError` 现场与 `ListView.tsx:1257` 行号)与两个方向的反向验证。

### 顺手记录的越界发现(未在本 PR 修)

- objectstack-ai/objectstack#6953 —— 同一条绑定在 `list-view` 之外仍无人消费:`element:record_picker` 读了 `object`/`filter`/`sort`/`limit` 但丢 `view`;`object-grid`/`object-form`/`object-kanban`/`object-calendar` 等整条绑定都不读(按 spec 写 `dataSource` 渲染出空)。本 PR 已把崩溃面(prop 撞车)一次性消除,剩下的接线用本 PR 落地的公共 helper 逐 block 做,单独立单以便每个 block 有自己的钉子。

---
_Generated by [Claude Code](https://claude.ai/code) — session `session_01GTRjn8xBqp75dk7kFupVRt`_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_