### PR TITLE
fix(app-shell): datetime action 参数提交带显式时区的 ISO instant

### DIFF
--- a/.changeset/action-param-datetime-zoned-instant-os5061.md
+++ b/.changeset/action-param-datetime-zoned-instant-os5061.md
@@ -1,0 +1,55 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`datetime` action params are usable in the Console for the first time — the dialog now POSTs the zoned ISO instant the platform requires instead of a shape the validator rejects
+
+An action declaring a `type: 'datetime'` param was unusable from the UI: **no
+value a user could pick could pass validation**. The dialog rendered the param
+as `datetime-local` (which is zone-less by nature) and then serialized on
+submit back to that control's own naive wall clock, e.g. `2026-08-10T15:00`.
+Since 17.0 the dispatcher validates a params bag against the action's
+declaration before the handler runs (ADR-0104 D2, `validateActionParams` →
+`InstantValueSchema`), and that contract is an ISO-8601 instant with an
+explicit zone. Every submission earned:
+
+```
+HTTP 400 VALIDATION_ERROR
+Action param "start" (datetime): expected an ISO-8601 instant with explicit
+zone (e.g. 2026-03-15T14:30:00.000Z)
+```
+
+The renderer and the validator wanted disjoint shapes, and an app author had no
+seam between them — declaring a `datetime` param doomed the action in the UI,
+whatever the app. Found in a hotcrm dogfood run (objectstack#5061), reproduced
+from two separate entry points (list-view row menu and record header).
+
+The fix is a removal, not a conversion. `DateTimeField` has been ISO-canonical
+on both sides since objectui#3127/#3565 — it takes the record's ISO instant in
+and hands an ISO instant back out, seconds, milliseconds and zone included — so
+the widget's own value already satisfies the contract. #3565 added the
+back-conversion to keep the wire shape byte-identical while it fixed a display
+bug, and named the follow-up in its own commit message: moving action params
+onto ISO is a contract change of its own. This is that change.
+`serializeParamValues` now passes `datetime` values through untouched, which
+makes it idempotent for a value that already carries a zone (a `+08:00` offset
+survives byte-for-byte rather than being re-derived and re-cut to the minute)
+and leaves an empty or unfilled param alone.
+
+Deliberately still rejected: an authored `defaultValue` written as a zone-less
+wall clock. That value is ambiguous metadata — whose zone? — and coercing it in
+the renderer would make it "work" in the UI while the identical literal kept
+400ing from REST and MCP, which is the worst split to debug. It stays loud
+until the spec validates a param default against the param's own value
+contract, filed as objectstack#6970 (the same hole lets a `number` param
+default to `'abc'`, so it is not datetime-specific).
+
+The render proof that pinned the old shape was replaced rather than re-spelled:
+it asserted `2026-07-20T14:30` and was green while the feature was 100% broken,
+because the shape it pinned is the one shape nothing accepts. It now drives the
+real widget and asks the real `validateActionParams` — the exact function that
+produced the 400 — whether the resolved bag is acceptable. The datetime
+assertions are written to hold in every timezone (verified under
+`Asia/Shanghai`, `UTC` and `America/Los_Angeles`), since a zone-shaped test that
+only holds in UTC goes green on CI while the defect is live for every user east
+or west of it.

--- a/docs/adr/0059-action-params-shared-field-widgets.md
+++ b/docs/adr/0059-action-params-shared-field-widgets.md
@@ -103,7 +103,7 @@ Follow-ups and objectui#2698 / #2710):
 | Param `type` (spelling → widget) | Emitted (POST) shape | Notes |
 |---|---|---|
 | `text` `textarea` `email` `phone` `url` `password`/`secret` `markdown` `html` `richtext` `code`/`json` `color` `avatar` `signature` `qrcode` | `string` | Free/encoded text, hex, or data-URL string. |
-| `date` `datetime` `time` | `string` | ISO-ish: `YYYY-MM-DD`, `…THH:mm`, `HH:mm`. |
+| `date` `datetime` `time` | `string` | `date` → `YYYY-MM-DD` (calendar day). `datetime` → an **ISO-8601 instant with an explicit zone** (`2026-08-10T07:00:00.000Z`), never the `datetime-local` control's zone-less wall clock — that shape is rejected by the dispatcher's param validation (`validateActionParams`, ADR-0104 D2) and 400'd every UI submission until objectstack#5061. `DateTimeField` converts on both sides (objectui#3127), so the dialog POSTs its value unchanged. `time` → `HH:mm`. |
 | `number` `currency` `percent` `slider` `rating` | `number` | A real number, **not** a string; `null` when cleared. |
 | `boolean`/`checkbox`/`toggle` | `boolean` | Rendered as the dialog's inline checkbox row. |
 | `select` | `string`, or **`string[]` when `multiple`** | `multiple` delegates to the chip picker (objectui#2709). |

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -156,6 +156,14 @@ guarded by `paramValueShape.test.ts` (#2714): `number`→number, `boolean`→boo
 `date`/`datetime`/`time`→string, `select`→string (`string[]` when `multiple`),
 `lookup`/`user`→id string(s), `file`/`image`→fileId string(s) (via
 `serializeParamValues`, #2698/#2710), `object`/`address`→object, `grid`→object[].
+
+For `datetime` the string is an **ISO-8601 instant with an explicit zone**
+(`2026-08-10T07:00:00.000Z`) — not the `datetime-local` control's zone-less wall
+clock. That is the platform's own `datetime` value contract, enforced by the
+dispatcher before the handler runs (`validateActionParams`, ADR-0104 D2), so the
+naive shape earned a 400 on every submission until objectstack#5061.
+`DateTimeField` already converts on both sides (objectui#3127), so the dialog
+POSTs its value unchanged — no zone handling lives at the dialog boundary.
 See the full table in [ADR-0059](../../docs/adr/0059-action-params-shared-field-widgets.md#value-shapes-the-emitted-shape-contract).
 
 ## Metadata designers

--- a/packages/app-shell/src/utils/paramValueShape.test.ts
+++ b/packages/app-shell/src/utils/paramValueShape.test.ts
@@ -196,7 +196,12 @@ describe('contract ↔ realistic value agreement', () => {
     [{ type: 'number' }, 42],
     [{ type: 'boolean' }, true],
     [{ type: 'date' }, '2026-07-20'],
-    [{ type: 'datetime' }, '2026-07-20T14:30'],
+    // A zoned ISO instant — the real emitted form since objectstack#5061. Note
+    // this row DOCUMENTS the sample; it cannot guard the change, because the
+    // zone-less string it replaced classifies to the same `'string'` tag. The
+    // guard lives in `ActionParamDialog.test.tsx`, which runs the sample past
+    // the platform's own `validateActionParams`.
+    [{ type: 'datetime' }, '2026-07-20T06:30:00.000Z'],
     [{ type: 'select' }, 'prod'],
     [{ type: 'select', multiple: true }, ['prod', 'stage']],
     [{ type: 'multiselect' }, ['a', 'b']],

--- a/packages/app-shell/src/utils/paramValueShape.ts
+++ b/packages/app-shell/src/utils/paramValueShape.ts
@@ -124,7 +124,7 @@ export const PARAM_VALUE_SHAPES: Readonly<Record<string, ParamValueShapeSpec>> =
 
   // Date/time → ISO-ish string
   date: { base: 'string', cardinality: 'scalar', note: 'ISO date string (YYYY-MM-DD).' },
-  datetime: { base: 'string', cardinality: 'scalar', note: 'datetime-local string (YYYY-MM-DDTHH:mm).' },
+  datetime: { base: 'string', cardinality: 'scalar', note: 'ISO-8601 instant with an explicit zone (2026-08-10T07:00:00.000Z) — what the platform `datetime` value contract requires. The control is zone-less; DateTimeField converts (objectstack#5061).' },
   time: { base: 'string', cardinality: 'scalar', note: 'Time string (HH:mm).' },
 
   // Numeric → number

--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -22,6 +22,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { ActionParamDef } from '@object-ui/core';
+import { validateActionParams } from '@objectstack/spec/ui';
 import { ActionParamDialog, filterVisibleParams, serializeParamValues } from './ActionParamDialog';
 import { expectedParamShape, classifyValueShape } from '../utils/paramValueShape';
 
@@ -235,7 +236,16 @@ describe('emitted value-shape parity (contract-tied render proofs, #2714)', () =
     expect(classifyValueShape(emitted)).toBe(expectedParamShape(param)); // 'number'
   });
 
-  it('datetime param emits an ISO-ish string matching its declared contract', async () => {
+  // objectstack#5061: this proof used to assert the emitted value was the
+  // control's own `2026-07-20T14:30` — the one shape `validateActionParams`
+  // rejects, so it was pinning a value that earned a 400 on every submission.
+  // It now drives the same real widget and asks the REAL platform validator
+  // whether the bag would be accepted, which is the fact the user cares about.
+  // Written to hold in EVERY timezone (the repo's rule for zone-shaped tests,
+  // see nativeDateValue.test.ts): never hardcode the expected instant — assert
+  // the shape the contract demands, and that it denotes the same instant as the
+  // local wall clock the user typed into the control.
+  it('datetime param emits a zoned ISO instant the platform validator accepts', async () => {
     const param = def({ name: 'when', type: 'datetime' });
     const resolve = openDialog([param]);
     const input = await screen.findByLabelText('Param One');
@@ -244,8 +254,17 @@ describe('emitted value-shape parity (contract-tied render proofs, #2714)', () =
     confirm();
     await waitFor(() => expect(resolve).toHaveBeenCalled());
     const emitted = resolve.mock.calls[0][0].when;
-    expect(emitted).toBe('2026-07-20T14:30');
+
+    // 1. The declared table shape is still `string` — the contract change is in
+    //    the string's FORM, which the shape tag can't see (so this line alone
+    //    would have stayed green through the bug; it is not the guard).
     expect(classifyValueShape(emitted)).toBe(expectedParamShape(param)); // 'string'
+    // 2. The guard: the exact validator that produced the 400 in the issue now
+    //    reports no issues for the bag the dialog resolved.
+    expect(validateActionParams([{ name: 'when', type: 'datetime' }], { when: emitted })).toEqual([]);
+    // 3. …and it is still the minute the user picked, read on the local basis
+    //    the control writes on.
+    expect(new Date(emitted as string).getTime()).toBe(new Date('2026-07-20T14:30').getTime());
   });
 
   it('time param emits a string matching its declared contract', async () => {
@@ -344,45 +363,82 @@ describe('serializeParamValues', () => {
     expect(out).toEqual({ attachments: 'f_1', comment: 'keep me' });
   });
 
-  // `DateTimeField` became ISO-canonical on both sides in objectui#3127 (a
-  // record's stored value arrives as an ISO instant, which the native control
-  // silently rejects, so read and write must share one basis). Action params
-  // have no stored value, so the endpoint contract stays the control's own
-  // zone-less local wall clock — converted back HERE rather than by weakening
-  // the widget, which would put the record form back on two bases.
-  describe('datetime params (objectui#3127 / contract pinned by #2714)', () => {
+  /**
+   * objectstack#5061 — the whole point of this block INVERTED.
+   *
+   * The previous version pinned the opposite behavior: it asserted the widget's
+   * ISO instant was converted BACK to `2026-07-20T14:30` on the way out. That
+   * assertion was green and the feature was still 100% broken, because the shape
+   * it pinned is the one shape the platform's `datetime` value contract rejects
+   * — so those cases were replaced rather than re-spelled. The oracle here is
+   * `validateActionParams` from `@objectstack/spec/ui`, i.e. the exact function
+   * the dispatcher runs before the handler (ADR-0104 D2) and the source of the
+   * 400 quoted in the issue. Pinning against the real validator instead of a
+   * re-spelled literal is what keeps this from re-pinning a shape nobody accepts.
+   *
+   * Zone-agnostic by construction: no expected instant is hardcoded (see
+   * `nativeDateValue.test.ts`'s note — a zone-shaped test that only holds in UTC
+   * goes green on CI while the defect is live for every user east or west of it).
+   */
+  describe('datetime params (objectstack#5061)', () => {
     const dtParam = (name: string): ActionParamDef =>
       ({ name, label: name, type: 'datetime' } as ActionParamDef);
+    /** The resolved declaration the dispatcher validates the bag against. */
+    const dtDecl = (name: string) => [{ name, type: 'datetime' }];
 
-    it('converts the widget ISO instant back to the local wall clock it POSTs', () => {
+    it('passes the widget ISO instant straight through, so the platform accepts it', () => {
+      // What DateTimeField hands the dialog: `fromDateTimeInputValue` → an ISO
+      // instant with an explicit zone, seconds and milliseconds included.
       const iso = new Date(2026, 6, 20, 14, 30).toISOString();
-      expect(serializeParamValues([dtParam('when')], { when: iso })).toEqual({
-        when: '2026-07-20T14:30',
-      });
+      const out = serializeParamValues([dtParam('when')], { when: iso });
+      expect(out).toEqual({ when: iso });
+      expect(validateActionParams(dtDecl('when'), out)).toEqual([]);
     });
 
-    it('leaves an already zone-less value untouched', () => {
-      expect(serializeParamValues([dtParam('when')], { when: '2026-07-20T14:30' })).toEqual({
-        when: '2026-07-20T14:30',
-      });
+    it('is idempotent for a value that already carries a zone — no second conversion', () => {
+      // A `+HH:MM` offset is as valid an instant as `Z` for the contract, and
+      // must survive byte-for-byte: re-deriving it would re-cut the seconds.
+      const offset = '2026-07-20T14:30:45.123+08:00';
+      expect(serializeParamValues([dtParam('when')], { when: offset })).toEqual({ when: offset });
+      expect(validateActionParams(dtDecl('when'), { when: offset })).toEqual([]);
+      // Applying the boundary twice changes nothing (the property, not a sample).
+      const once = serializeParamValues([dtParam('when')], { when: offset });
+      expect(serializeParamValues([dtParam('when')], once)).toEqual(once);
     });
 
-    it('leaves an empty / absent datetime alone', () => {
+    it('leaves an empty / unfilled datetime alone — no Invalid Date, no required error', () => {
       expect(serializeParamValues([dtParam('when')], { when: '' })).toEqual({ when: '' });
+      expect(serializeParamValues([dtParam('when')], { when: null })).toEqual({ when: null });
       expect(serializeParamValues([dtParam('when')], { other: 1 })).toEqual({ other: 1 });
+      // An optional param left blank is ABSENT to the validator, not invalid.
+      expect(validateActionParams(dtDecl('when'), { when: '' })).toEqual([]);
     });
 
-    it('keeps an unparseable value rather than blanking it', () => {
-      expect(serializeParamValues([dtParam('when')], { when: 'not-a-date' })).toEqual({
-        when: 'not-a-date',
-      });
-    });
-
-    it('does not touch a plain date param', () => {
+    it('does not touch a plain date param (its contract is the calendar day)', () => {
       const dateParam = { name: 'day', label: 'day', type: 'date' } as ActionParamDef;
-      expect(serializeParamValues([dateParam], { day: '2026-07-20' })).toEqual({
-        day: '2026-07-20',
-      });
+      const out = serializeParamValues([dateParam], { day: '2026-07-20' });
+      expect(out).toEqual({ day: '2026-07-20' });
+      // A `date` param must NOT become an instant — the calendar day is the
+      // value, and zoning it would move the day west of Greenwich.
+      expect(validateActionParams([{ name: 'day', type: 'date' }], out)).toEqual([]);
+    });
+
+    it('documents the shape that is still rejected: a zone-less authored default', () => {
+      // Deliberately NOT laundered here (see serializeParamValues' note): an
+      // authored `defaultValue: '2026-07-20T14:30'` is ambiguous metadata, and
+      // coercing it would make it pass in the UI while the same literal keeps
+      // 400ing from REST/MCP. This pins that the renderer does not hide it.
+      // The authoring-time rejection that SHOULD catch it is objectstack#6970.
+      const naive = '2026-07-20T14:30';
+      expect(serializeParamValues([dtParam('when')], { when: naive })).toEqual({ when: naive });
+      expect(validateActionParams(dtDecl('when'), { when: naive })).toEqual([
+        {
+          param: 'when',
+          code: 'invalid_shape',
+          message:
+            'Action param "when" (datetime): expected an ISO-8601 instant with explicit zone (e.g. 2026-03-15T14:30:00.000Z)',
+        },
+      ]);
     });
   });
 });

--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -431,14 +431,14 @@ describe('serializeParamValues', () => {
       // The authoring-time rejection that SHOULD catch it is objectstack#6970.
       const naive = '2026-07-20T14:30';
       expect(serializeParamValues([dtParam('when')], { when: naive })).toEqual({ when: naive });
-      expect(validateActionParams(dtDecl('when'), { when: naive })).toEqual([
-        {
-          param: 'when',
-          code: 'invalid_shape',
-          message:
-            'Action param "when" (datetime): expected an ISO-8601 instant with explicit zone (e.g. 2026-03-15T14:30:00.000Z)',
-        },
-      ]);
+      // Asserted structurally, plus the one phrase that identifies the rule.
+      // Pinning the validator's full sentence would couple this suite to a
+      // message owned by `@objectstack/spec`, so a reword there would red this
+      // repo's CI for a reason that has nothing to do with the renderer.
+      const issues = validateActionParams(dtDecl('when'), { when: naive });
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toMatchObject({ param: 'when', code: 'invalid_shape' });
+      expect(issues[0].message).toMatch(/explicit zone/);
     });
   });
 });

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -32,7 +32,7 @@ import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionParamDef } from '@object-ui/core';
 import { ExpressionEvaluator } from '@object-ui/core';
 import { usePredicateScope } from '@object-ui/react';
-import { getLazyFieldWidget, fileIdOf, toDateTimeInputValue } from '@object-ui/fields';
+import { getLazyFieldWidget, fileIdOf } from '@object-ui/fields';
 import { paramToField } from '../utils/paramToField';
 
 export interface ParamDialogState {
@@ -85,43 +85,49 @@ export function filterVisibleParams(
  * returned as-is. Pure + exported so the mapping is unit-testable without the
  * dialog render tree.
  *
- * `datetime` params are converted back to the control's zone-less local wall
- * clock (`YYYY-MM-DDTHH:mm`) — the shape this endpoint contract pins (#2714).
- * `DateTimeField` is ISO-canonical on both sides since objectui#3127: it has to
- * be, because a record's stored value arrives as an ISO instant and the control
- * silently rejects that shape, so read and write must share one basis or a
- * UTC+8 user picking 08:33 would store `08:33Z`. Action params have no stored
- * value to read, so that widget-level basis is invisible here — but its ISO
- * output would still reach endpoints that were built against the naive string.
- * Converting at this boundary keeps the widget coherent AND the wire shape
- * byte-identical; moving action params onto ISO is a contract change of its own
- * and belongs in its own ticket, not in a display-bug fix.
+ * `datetime` params pass through here untouched, and that is the fix for
+ * objectstack#5061 — the previous version of this function converted them back
+ * to the control's zone-less local wall clock (`YYYY-MM-DDTHH:mm`), which is
+ * the one shape the platform's `datetime` value contract REJECTS. Since 17.0
+ * the dispatcher validates a params bag against the action's declaration before
+ * the handler runs (ADR-0104 D2, `validateActionParams` →
+ * `InstantValueSchema`), and that contract is an ISO-8601 instant with an
+ * explicit zone. A zone-less wall clock earned a 400 on every UI submission, so
+ * no value a user could pick could pass: the renderer and the validator wanted
+ * disjoint shapes.
+ *
+ * No conversion is needed at this boundary, because `DateTimeField` is already
+ * ISO-canonical on both sides (objectui#3127/#3565): it takes the record's ISO
+ * instant in, and hands an ISO instant back out — seconds and milliseconds
+ * included, zone explicit. #3565 added the back-conversion to keep the wire
+ * shape byte-identical while it fixed a display bug, and said so: moving action
+ * params onto ISO is a contract change of its own. objectstack#5061 is that
+ * change, and it only removes the conversion — every param value the dialog can
+ * hold is already zoned (widget output, or a `defaultFromRow` seed read from a
+ * stored instant). Deliberately NOT normalized here: an authored
+ * `defaultValue` written as a zone-less wall clock. That value is ambiguous
+ * metadata (whose zone?), the spec types it `unknown` so nothing rejects it at
+ * authoring time yet, and coercing it in the renderer would make it "work" in
+ * the UI while the identical literal still 400s from REST/MCP — the worst split
+ * to debug. It stays loud until the spec validates a param default against the
+ * param's own value contract (objectstack#6970).
  */
 export function serializeParamValues(
   params: ActionParamDef[],
   values: Record<string, any>,
 ): Record<string, any> {
   const uploadNames = new Set<string>();
-  const datetimeNames = new Set<string>();
   for (const p of params) {
     const t = paramToField(p).type;
     if (t === 'file' || t === 'image') uploadNames.add(p.name);
-    else if (t === 'datetime') datetimeNames.add(p.name);
   }
-  if (uploadNames.size === 0 && datetimeNames.size === 0) return values;
+  if (uploadNames.size === 0) return values;
   const toId = (item: any) => fileIdOf(item) ?? item;
   const out: Record<string, any> = { ...values };
   for (const name of uploadNames) {
     const v = out[name];
     if (v == null) continue;
     out[name] = Array.isArray(v) ? v.map(toId) : toId(v);
-  }
-  for (const name of datetimeNames) {
-    const v = out[name];
-    if (v == null || v === '') continue;
-    // An unconvertible value is left intact rather than blanked — the same
-    // failure-visible rule the upload branch above follows.
-    out[name] = toDateTimeInputValue(v) || v;
   }
   return out;
 }

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -2536,11 +2536,14 @@ export type { DomProps } from './widgets/toDomProps';
 
 // The native date/time control value adapters (objectui#3127). `DateTimeField`
 // is ISO-canonical on BOTH sides — it takes the record's ISO instant and hands
-// an ISO instant back — so a caller whose own endpoint contract is the control's
-// zone-less local wall clock (`ActionParamDialog`'s `datetime` param, pinned by
-// #2714) needs `toDateTimeInputValue` to convert at its serialization boundary.
-// Exported rather than duplicated so the two surfaces cannot drift on what the
-// local wall clock of an instant is.
+// an ISO instant back, which is also the wire form the platform's `datetime`
+// value contract requires (`InstantValueSchema`: an ISO-8601 instant with an
+// explicit zone), so no consumer has to convert at its own serialization
+// boundary. `ActionParamDialog` used to (objectstack#5061 removed it — the
+// zone-less wall clock it produced was the one shape the validator rejects).
+// Exported for the same reason as `toDomProps` above: a widget authored outside
+// this repo needs the same pair, and a second copy of "what the local wall clock
+// of an instant is" would drift from this one.
 export {
   toDateInputValue,
   toDateTimeInputValue,

--- a/packages/fields/src/widgets/nativeDateValue.test.ts
+++ b/packages/fields/src/widgets/nativeDateValue.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { InstantValueSchema } from '@objectstack/spec/data';
 import {
   toDateInputValue,
   toDateTimeInputValue,
@@ -92,5 +93,23 @@ describe('fromDateTimeInputValue', () => {
   it('returns an unparseable value untouched rather than blanking it', () => {
     expect(fromDateTimeInputValue('garbage')).toBe('garbage');
     expect(fromDateTimeInputValue('')).toBe('');
+  });
+
+  /**
+   * The producer side of objectstack#5061. This function's output is not just
+   * "an ISO string" by convention — it IS the platform's `datetime` value
+   * contract, and `ActionParamDialog` now relies on that: it POSTs the widget's
+   * value with no conversion of its own, so a change here that dropped the zone
+   * (or emitted the control's naive wall clock) would make every datetime action
+   * param 400 again. Pinned against the real schema rather than a regex so the
+   * two cannot drift.
+   */
+  it('emits a value the platform datetime contract accepts (InstantValueSchema)', () => {
+    expect(InstantValueSchema.safeParse(fromDateTimeInputValue('2026-06-17T14:30')).success).toBe(true);
+    // The control may include seconds; those must survive into the instant.
+    expect(InstantValueSchema.safeParse(fromDateTimeInputValue('2026-06-17T14:30:45')).success).toBe(true);
+    // The shape the contract rejects — what the control itself hands us, and so
+    // exactly what must NOT come back out of this function.
+    expect(InstantValueSchema.safeParse('2026-06-17T14:30').success).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#5061

## 问题

声明 `type: 'datetime'` 参数的 action 在 Console 上**完全不可用** —— 没有任何用户能输入的值可以通过校验。

对话框把参数渲染成 `datetime-local`(天然无时区),`serializeParamValues` 在提交前又把值**转回**该控件自己的无时区墙上时钟(如 `2026-08-10T15:00`)—— 而这恰好是平台 `datetime` 值契约唯一拒绝的形状。自 17.0 起 dispatcher 会在 handler 之前按 action 声明校验 params bag(ADR-0104 D2,`validateActionParams` 走 `InstantValueSchema`),于是每一次 UI 提交都拿到:

```
HTTP 400 VALIDATION_ERROR
Action param "start" (datetime): expected an ISO-8601 instant with explicit zone (e.g. 2026-03-15T14:30:00.000Z)
```

渲染器与校验器要的形状不相交,app 作者在两者之间没有任何可作用的缝隙。

## 修法:是删除,不是新增转换

`DateTimeField` 自 objectui#3127 / objectui#3565 起就是**两向 ISO 规范**的 —— 读入记录的 ISO instant,交回 ISO instant(秒、毫秒、时区都在)。也就是说 widget 交给对话框的值**本来就满足契约**,提交边界不需要任何转换。

objectui#3565 当时为了在修显示 bug 时保持线上形状逐字节不变而加了这段回转,并在自己的 commit message 里点名了后续:「moving action params onto ISO is a contract change of its own」。本 PR 就是那个 contract change,它只是把回转删掉。

顺带得到的性质:

- **幂等** —— 已带时区的值原样通过,`+08:00` 偏移逐字节存活,不会被重新推导后再截到分钟;
- **空值安全** —— 空串/未填原样通过,不会产生 Invalid Date(校验器把空串视为「缺失」而非「非法」);
- **秒与毫秒** —— 由 `toISOString()` 天然补全;
- **`date` 参数不受影响** —— 它的契约是日历日,加时区反而会让格林尼治以西整体错一天。

## 刻意**不**兜的一种形状

作者手写成无时区墙上时钟的 `defaultValue`。这是歧义元数据(按谁的时区?),在渲染器里归一化会让同一份元数据对不同用户产生不同 instant;更糟的是造成分裂 —— UI 里「能用了」,而 REST / MCP 提交同一个字面量依旧 400,这是最难排查的一种不一致。按 contract-first(AGENTS.md #0.1)正确的位置是生产端在授权期被拒绝,已另开 objectstack-ai/objectstack#6970(该洞不限于 datetime:同样允许 `number` 参数默认值写成 `'abc'`)。本 PR 用一条测试把「渲染器不掩盖它」钉住。

## 测试

原来那条 render proof 是**整条替换**而不是改写字面量的:它断言产出等于 `2026-07-20T14:30`,一直是绿的,而功能 100% 坏着 —— 因为它钉的形状正是无人接受的那一个。现在它驱动真实 widget,然后把对话框 resolve 出来的 bag 交给**真的** `validateActionParams`(即产生 issue 里那条 400 的同一个函数)判定。同时在 `packages/fields` 补了生产端的钉子:`fromDateTimeInputValue` 的产出必须被 `InstantValueSchema` 接受。

`paramValueShape.test.ts` 的样例值改了,但注释里说明它是**文档而非守卫** —— 新旧字符串都归类成同一个 `'string'` tag,那一行本来就抓不到这个缺陷。

**反向验证(方向为事先预测的「红」)**:把删掉的回转分支放回去,三条新断言转红,报错文案与 issue 里的 400 逐字一致:

```
× datetime param emits a zoned ISO instant the platform validator accepts
× passes the widget ISO instant straight through, so the platform accepts it
× is idempotent for a value that already carries a zone — no second conversion
AssertionError: expected [ { param: 'when', …(2) } ] to deeply equal []
+ "message": "Action param \"when\" (datetime): expected an ISO-8601 instant with explicit zone (e.g. 2026-03-15T14:30:00.000Z)"
 Tests  3 failed | 33 passed (36)
```

时区形状的断言**全部写成任意时区成立**(仓库既有约定,见 `nativeDateValue.test.ts` 的说明:只在 UTC 下成立的测试会在 CI 绿着,而缺陷对每一个东西向用户都活着)。三个时区各跑一遍:

| 命令 | 结果 |
|---|---|
| `TZ=Asia/Shanghai vitest run …/ActionParamDialog.test.tsx …/nativeDateValue.test.ts` | 46 passed |
| `TZ=UTC` 同上 | 46 passed |
| `TZ=America/Los_Angeles` 同上 | 46 passed |
| `TZ=Asia/Shanghai vitest run packages/app-shell/src/utils/` | 19 files / 311 passed |
| `TZ=UTC vitest run packages/app-shell/src/utils/ packages/fields/src/widgets/` | 63 files / 739 passed |
| 参数提交路径(ActionParamDialog + uploading + useConsoleActionRuntime + datetime-widgets + plugin-grid bulk param) | 6 files / 109 passed |
| `turbo run type-check --concurrency=2` | 78 successful, 78 total |
| `pnpm run check:control-bytes` | OK(3808 文件) |
| `pnpm run changeset:check` | OK(fixed 组齐全,无 major) |
| `eslint`(改动文件) | 0 errors(仅既有 react-refresh warning) |

## ADR-0059 两向约定核对

按任务要求核对了 objectui#3127 的反方向(其修复已随 objectui#3565 落地),**未**把它折叠进本单:

- 记录表单:读 ISO -> 控件显示本地 -> 写回 ISO,单一基准;
- action 参数:无「读」,写 = widget 的 ISO。

本 PR 之前,action 参数是**唯一**跑在另一个基准上的表面;之后两向都以 ISO instant 为规范形式,本地墙上时钟只存在于控件内部。这是让 ADR-0059 更一致,而不是引入新分歧。

## 变更文件

- `packages/app-shell/src/views/ActionParamDialog.tsx` —— 删掉 datetime 回转分支与 `toDateTimeInputValue` 导入,注释改写为记录真实契约与「为什么不兜 defaultValue」
- `packages/app-shell/src/utils/paramValueShape.ts` —— `datetime` 的契约说明改为带显式时区的 ISO instant
- `packages/fields/src/index.tsx` —— 导出注释里已过时的理由(原文写着「app-shell 的契约是无时区墙上时钟」)
- `packages/app-shell/README.md`、`docs/adr/0059-action-params-shared-field-widgets.md` —— 契约表
- 测试:`ActionParamDialog.test.tsx`(替换 + 新增)、`paramValueShape.test.ts`(样例)、`packages/fields/src/widgets/nativeDateValue.test.ts`(生产端钉子)
- `.changeset/action-param-datetime-zoned-instant-os5061.md` —— patch `@object-ui/app-shell`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_