### PR TITLE
fix(actions): forward `bodyShape` so a declared body wrap is honoured (objectstack#6938)

### DIFF
--- a/.changeset/forward-bodyshape-os6938.md
+++ b/.changeset/forward-bodyshape-os6938.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/components': patch
+'@object-ui/core': patch
+'@object-ui/types': patch
+---
+
+fix(actions): forward `bodyShape` end-to-end so a declared body wrap is honoured
+
+Sibling of the `bodyExtra` fix, same failure shape one key over. `bodyShape` is
+the spec's body-WRAPPING declaration for a `type: 'api'` action — `'flat'` (the
+default) or `{ wrap: key }` to nest the collected params under `key`, the shape
+better-auth's `organization/update` needs. The console `apiHandler` read it
+unconditionally while **no** action renderer forwarded it, so an author who
+declared `bodyShape: { wrap: 'data' }` on an `action:button` / `:group` / `:icon`
+/ `:menu` action got a FLAT body on the wire: the endpoint received the params at
+the top level, and the declaration read as honoured because it parsed and
+published.
+
+The four declared-action renderers now forward the key, and `ActionSchema`
+declares it (typed by derivation from the spec, so the union cannot drift).
+`ActionRunner.executeAPI` — the fallback path taken when no host registered an
+`api` handler — now reads it too, closing a second asymmetry in which the same
+action changed body shape depending on which host executed it. The wrap covers
+the collected params only; `bodyExtra` and other top-level keys stay flat, which
+is the spec's own wording for the key and what both console read-sites already
+did.
+
+`element:button` deliberately does **not** forward it: its whitelist mirrors
+spec's `InlineActionSchema` pick list field for field, and that pick list does
+not include `bodyShape` — it is not inline vocabulary.

--- a/packages/components/src/__tests__/action-bodyShape-forward.test.tsx
+++ b/packages/components/src/__tests__/action-bodyShape-forward.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `bodyShape` survives the renderer hop (objectstack#6938).
+ *
+ * Sibling of `action-bodyExtra-forward.test.tsx` (#6837) and the same failure
+ * shape: every action renderer forwards an EXPLICIT whitelist of keys to the
+ * `ActionRunner` — deliberate, so a key no renderer honours cannot look wired —
+ * and a NEW spec key stays invisible until each list is edited, with nothing
+ * failing while they are not. `bodyShape` is the spec's body-WRAPPING
+ * declaration for a `type: 'api'` action (`'flat'`, or `{ wrap: key }` to nest
+ * the collected params). The console `apiHandler` read it unconditionally while
+ * zero renderers forwarded it, so an action declaring `{ wrap: 'data' }` POSTed
+ * a FLAT body and the declaration read as honoured because it parsed and
+ * published.
+ *
+ * Deliberately NOT covered here: `element:button`. Its forward list mirrors
+ * spec's `InlineActionSchema` pick list field for field (its own comment says
+ * so), and that pick list does not include `bodyShape` — verified against
+ * `packages/spec/src/ui/action.zod.ts` on objectstack `origin/main`, where the
+ * picks are `type name label target openIn method params bodyExtra confirmText
+ * successMessage errorMessage refreshAfter opensInNewTab`. `bodyShape` is not
+ * inline vocabulary, and the spec's rule for that boundary is explicit:
+ * "Widen this when a renderer widens, not before" — with the window always
+ * opening spec-first, never renderer-first. Forwarding it from `element:button`
+ * would be the forbidden direction.
+ *
+ * Asserted at the two ends that matter, as #6837 established: what the runner
+ * RECEIVES (the forward itself) and what lands on the WIRE (the forward plus the
+ * runner's body assembly). Props-only assertions would have stayed green while
+ * the wrap was still dropped downstream.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider } from '@object-ui/react';
+import '../renderers/action/action-button';
+import '../renderers/action/action-group';
+import '../renderers/action/action-icon';
+import '../renderers/action/action-menu';
+
+function Registered({ type, schema }: { type: string; schema: any }) {
+  const C = ComponentRegistry.get(type);
+  if (!C) throw new Error(`${type} not registered`);
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
+  return <C schema={schema} />;
+}
+
+describe('bodyShape survives the declared-action renderer whitelists', () => {
+  let api: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    api = vi.fn(async () => ({ success: true }));
+  });
+
+  /** The ActionDef the runner was handed for the click. */
+  const dispatched = () => api.mock.calls[0][0];
+
+  it('action:button forwards bodyShape off a declared ActionSchema', async () => {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <Registered
+          type="action:button"
+          schema={{
+            type: 'api',
+            name: 'update_organization',
+            label: 'Save organization',
+            target: '/api/v1/auth/organization/update',
+            method: 'POST',
+            bodyShape: { wrap: 'data' },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Save organization/i }));
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(dispatched().bodyShape).toEqual({ wrap: 'data' });
+  });
+
+  it('action:icon forwards bodyShape', async () => {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <Registered
+          type="action:icon"
+          schema={{
+            type: 'api',
+            name: 'update_organization',
+            label: 'Save',
+            icon: 'save',
+            target: '/api/v1/auth/organization/update',
+            bodyShape: { wrap: 'data' },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(dispatched().bodyShape).toEqual({ wrap: 'data' });
+  });
+
+  it('action:group forwards bodyShape for an inline member', async () => {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <Registered
+          type="action:group"
+          schema={{
+            type: 'action:group',
+            actions: [
+              {
+                type: 'api',
+                name: 'update_organization',
+                label: 'Save organization',
+                target: '/api/v1/auth/organization/update',
+                bodyShape: { wrap: 'data' },
+              },
+            ],
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Save organization/i }));
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(dispatched().bodyShape).toEqual({ wrap: 'data' });
+  });
+
+  it('action:menu forwards bodyShape for an overflow item', async () => {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <Registered
+          type="action:menu"
+          schema={{
+            type: 'action:menu',
+            label: 'More',
+            actions: [
+              {
+                type: 'api',
+                name: 'update_organization',
+                label: 'Save organization',
+                target: '/api/v1/auth/organization/update',
+                bodyShape: { wrap: 'data' },
+              },
+            ],
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    // Radix opens its dropdown on pointerdown, not click — same gesture the
+    // bodyExtra sibling test uses.
+    fireEvent.pointerDown(screen.getByRole('button', { name: /More/i }), { button: 0 });
+    const item = await screen.findByText(/Save organization/i);
+    fireEvent.click(item);
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(dispatched().bodyShape).toEqual({ wrap: 'data' });
+  });
+});
+
+describe('bodyShape reaches the wire, end to end', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  const sentBody = () => JSON.parse((global.fetch as any).mock.calls[0][1].body);
+
+  it('wraps the payload under the declared key', async () => {
+    // No custom `api` handler on purpose: the click travels the whole chain —
+    // renderer whitelist, then the runner's own executeAPI body assembly — so the
+    // wrap is asserted on the actual request body rather than on props.
+    render(
+      <ActionProvider>
+        <Registered
+          type="action:button"
+          schema={{
+            type: 'api',
+            name: 'update_organization',
+            label: 'Save organization',
+            target: '/api/v1/auth/organization/update',
+            method: 'POST',
+            params: { name: 'Acme Inc', slug: 'acme' },
+            bodyShape: { wrap: 'data' },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Save organization/i }));
+    await waitFor(() => expect(global.fetch as any).toHaveBeenCalledOnce());
+
+    expect(sentBody()).toEqual({ data: { name: 'Acme Inc', slug: 'acme' } });
+  });
+
+  it('keeps bodyExtra flat BESIDE the wrap, per the spec wording', async () => {
+    // "…nests the user-collected params under that key, while `recordIdParam` and
+    // other top-level keys stay flat." Both console read-sites do exactly this;
+    // this pins the runner to the same reading, so the body shape does not depend
+    // on which host executed the action.
+    render(
+      <ActionProvider>
+        <Registered
+          type="action:button"
+          schema={{
+            type: 'api',
+            name: 'update_organization',
+            label: 'Save organization',
+            target: '/api/v1/auth/organization/update',
+            method: 'POST',
+            params: { name: 'Acme Inc' },
+            bodyExtra: { organizationId: 'org_1' },
+            bodyShape: { wrap: 'data' },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Save organization/i }));
+    await waitFor(() => expect(global.fetch as any).toHaveBeenCalledOnce());
+
+    expect(sentBody()).toEqual({
+      data: { name: 'Acme Inc' },   // collected params nest
+      organizationId: 'org_1',      // bodyExtra stays top-level
+    });
+  });
+
+  it('sends a FLAT body when no bodyShape is declared (regression pin)', async () => {
+    // The default path, unchanged by this fix. Without this the wrap branch could
+    // start applying to every action and nothing here would notice.
+    render(
+      <ActionProvider>
+        <Registered
+          type="action:button"
+          schema={{
+            type: 'api',
+            name: 'close_order',
+            label: 'Close order',
+            target: '/api/v1/order/close',
+            method: 'PATCH',
+            params: { note: 'from the user' },
+            bodyExtra: { status: 'closed' },
+          }}
+        />
+      </ActionProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Close order/i }));
+    await waitFor(() => expect(global.fetch as any).toHaveBeenCalledOnce());
+
+    expect(sentBody()).toEqual({ note: 'from the user', status: 'closed' });
+  });
+});

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -108,6 +108,13 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
           // dropping it here left a declared action whose payload lives only in
           // `bodyExtra` POSTing nothing (objectstack#6837).
           bodyExtra: schema.bodyExtra,
+          // How that body is SHAPED — `'flat'` or `{ wrap: key }`. Read
+          // unconditionally by the console apiHandler and by the runner's own
+          // executeAPI, so dropping it here did not fail: the action POSTed a
+          // flat body while its declaration said `{ wrap: 'data' }`
+          // (objectstack#6938). Sibling of `bodyExtra` above, same whitelist,
+          // same failure mode.
+          bodyShape: schema.bodyShape,
           confirmText: schema.confirmText,
           successMessage: schema.successMessage,
           errorMessage: schema.errorMessage,

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -222,6 +222,8 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
           params: action.params as Record<string, any> | undefined,
           // See action-button.tsx — the `type: 'api'` payload key (objectstack#6837).
           bodyExtra: action.bodyExtra,
+          // See action-button.tsx — the body-WRAPPING key (objectstack#6938).
+          bodyShape: action.bodyShape,
           confirmText: action.confirmText,
           successMessage: action.successMessage,
           errorMessage: action.errorMessage,

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -68,6 +68,8 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
           params: schema.params as Record<string, any> | undefined,
           // See action-button.tsx — the `type: 'api'` payload key (objectstack#6837).
           bodyExtra: schema.bodyExtra,
+          // See action-button.tsx — the body-WRAPPING key (objectstack#6938).
+          bodyShape: schema.bodyShape,
           confirmText: schema.confirmText,
           successMessage: schema.successMessage,
           errorMessage: schema.errorMessage,

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -167,6 +167,8 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
             params: action.params as Record<string, any> | undefined,
             // See action-button.tsx — the `type: 'api'` payload key (objectstack#6837).
             bodyExtra: action.bodyExtra,
+            // See action-button.tsx — the body-WRAPPING key (objectstack#6938).
+            bodyShape: action.bodyShape,
             confirmText: action.confirmText,
             successMessage: action.successMessage,
             errorMessage: action.errorMessage,

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -1384,6 +1384,15 @@ export class ActionRunner {
    * only when no `paramCollectionHandler` is mounted, and POSTing the definitions
    * as the request body was never a payload any endpoint wanted. It now falls
    * through to the context record like an absent `params` does.
+   *
+   * `bodyShape` then decides how that payload is WRAPPED, and the wrap covers the
+   * collected payload ONLY — `bodyExtra` stays at the top level. That is the
+   * spec's own wording for the key ("`{ wrap: 'data' }` nests the user-collected
+   * params under that key, while `recordIdParam` and other top-level keys stay
+   * flat") and what both console read-sites already do, so the key means one
+   * thing on every path that honours it. Until objectstack#6938 this path did not
+   * read it at all: the console `apiHandler` wrapped and the runner's own fallback
+   * did not, so the same action changed body shape with the host it ran under.
    */
   private buildApiRequestBody(action: ActionDef): unknown {
     const asRecord = (value: unknown): Record<string, unknown> | undefined => (
@@ -1393,6 +1402,20 @@ export class ActionRunner {
     );
     const bodyExtra = asRecord(action.bodyExtra);
     const base = asRecord(action.params) ?? this.context.data;
+    // `'flat'` (and an absent//malformed value) means no wrapping — the same
+    // predicate the console read-sites use, so an off-spec `bodyShape` degrades
+    // to the documented default here too instead of producing a `{ undefined: … }`
+    // key on the wire.
+    const shape = action.bodyShape;
+    const wrap = shape && typeof shape === 'object' && typeof shape.wrap === 'string' && shape.wrap
+      ? shape.wrap
+      : undefined;
+    if (wrap) {
+      // The payload nests; `bodyExtra` rides flat beside it. No key collision to
+      // resolve in this branch — that is the point of the wrap — so "merged last"
+      // is preserved by construction.
+      return { [wrap]: base ?? {}, ...bodyExtra };
+    }
     // Nothing to merge: hand back the historical value as-is, so a host passing a
     // non-object `context.data` still serializes exactly what it used to.
     if (!bodyExtra) return base ?? {};

--- a/packages/core/src/actions/__tests__/ActionRunner.bodyShape.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.bodyShape.test.ts
@@ -1,0 +1,147 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `bodyShape` on the runner's OWN api path (objectstack#6938).
+ *
+ * The card's face is the four declared-action renderer whitelists, which dropped
+ * the key before it reached any runner. Fixing only those would have left a
+ * second, narrower version of the same defect in place: the console `apiHandler`
+ * (`useConsoleActionRuntime`) and `RecordDetailView.apiHandler` both wrapped, and
+ * the runner's fallback `executeAPI` — the path taken when no host registered an
+ * `api` handler — did not read `bodyShape` at all. The same action would then
+ * change body shape depending on which host executed it, which is the "declared ≠
+ * enforced" trap one hop further down.
+ *
+ * The semantics are the spec's, not invented here. `packages/spec/src/ui/action.zod.ts`
+ * documents the key as: "`'flat'` (default) sends collected params at the top
+ * level. `{ wrap: 'data' }` nests the user-collected params under that key (used
+ * by better-auth `organization/update`), while `recordIdParam` and other
+ * top-level keys stay flat." Both console read-sites implement exactly that
+ * ordering, so there was one reading to mirror rather than a choice to make.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ActionRunner } from '../ActionRunner';
+import { resetActionKeyWarnings } from '../actionKeys';
+
+/** The body the runner handed to `fetch`, parsed. */
+function sentBody(): any {
+  const init = (global.fetch as any).mock.calls[0][1];
+  return JSON.parse(init.body);
+}
+
+function okFetch() {
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
+}
+
+describe('ActionRunner.executeAPI — bodyShape', () => {
+  beforeEach(() => {
+    resetActionKeyWarnings();
+    okFetch();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('nests the collected params under the declared wrap key', async () => {
+    const runner = new ActionRunner({});
+    const result = await runner.execute({
+      type: 'api',
+      target: '/api/v1/auth/organization/update',
+      method: 'POST',
+      params: { name: 'Acme Inc', slug: 'acme' },
+      bodyShape: { wrap: 'data' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(sentBody()).toEqual({ data: { name: 'Acme Inc', slug: 'acme' } });
+  });
+
+  it('wraps the context record when the action carries no params', async () => {
+    // `context.data` is the runner's documented fallback payload source; the wrap
+    // covers whatever the flat path would have sent, not `params` specifically.
+    const runner = new ActionRunner({ data: { id: 7, status: 'draft' } });
+    await runner.execute({
+      type: 'api',
+      target: '/api/v1/order/7',
+      method: 'PATCH',
+      bodyShape: { wrap: 'data' },
+    });
+
+    expect(sentBody()).toEqual({ data: { id: 7, status: 'draft' } });
+  });
+
+  it('keeps bodyExtra FLAT beside the wrap', async () => {
+    // The spec's "other top-level keys stay flat" clause, and what both console
+    // read-sites do (`Object.assign(body, action.bodyExtra)` AFTER the wrap is
+    // built). A `bodyExtra` swallowed into the wrapped object would be red here.
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      target: '/api/v1/auth/organization/update',
+      params: { name: 'Acme Inc' },
+      bodyExtra: { organizationId: 'org_1' },
+      bodyShape: { wrap: 'data' },
+    });
+
+    expect(sentBody()).toEqual({
+      data: { name: 'Acme Inc' },
+      organizationId: 'org_1',
+    });
+  });
+
+  it('wraps on the ApiConfig branch too', async () => {
+    // Second call site of the same assembly (`api` as an object, not a string).
+    const runner = new ActionRunner({ data: { id: 7 } });
+    await runner.execute({
+      type: 'api',
+      api: { url: '/api/v1/order/7', method: 'PATCH' },
+      bodyShape: { wrap: 'data' },
+    });
+
+    expect(sentBody()).toEqual({ data: { id: 7 } });
+  });
+
+  it('sends a flat body for bodyShape: "flat"', async () => {
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      target: '/api/v1/order/close',
+      params: { note: 'from the user' },
+      bodyShape: 'flat',
+    });
+
+    expect(sentBody()).toEqual({ note: 'from the user' });
+  });
+
+  it('sends a flat body when no bodyShape is declared (regression pin)', async () => {
+    // The unchanged default. Pinned so the wrap branch cannot start applying to
+    // every action unnoticed.
+    const runner = new ActionRunner({ data: { id: 1, name: 'Test' } });
+    await runner.execute({ type: 'api', target: '/api/v1/thing' });
+
+    expect(sentBody()).toEqual({ id: 1, name: 'Test' });
+  });
+
+  it('degrades to flat for an off-spec bodyShape instead of inventing a key', async () => {
+    // `{ wrap: 42 }` and `{}` are parse REJECTIONS at the producer (the spec's
+    // `bodyShape` is `'flat' | { wrap: string }` under a strictObject), so this is
+    // not a tolerated dialect — it is the shape an unvalidated host could hand the
+    // runner directly. The read-site predicate is the console's, so such a value
+    // produces the documented default rather than a literal `{"undefined": …}` key
+    // on the wire. Fixing bad metadata stays the producer's job.
+    const runner = new ActionRunner({});
+    await runner.execute({
+      type: 'api',
+      target: '/api/v1/order/close',
+      params: { note: 'n' },
+      bodyShape: { wrap: 42 } as any,
+    });
+
+    expect(sentBody()).toEqual({ note: 'n' });
+  });
+});

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -450,6 +450,26 @@ export interface ActionSchema {
    */
   bodyExtra?: SpecAction['bodyExtra'];
 
+  /**
+   * Request-body WRAPPING for a `type: 'api'` action: `'flat'` (the default —
+   * collected params ride at the top level) or `{ wrap: key }` to nest the
+   * collected params under `key` (better-auth `organization/update` is the
+   * shape it exists for).
+   *
+   * Per the spec's own wording the wrap covers the **collected params only** —
+   * `recordIdParam` and every other top-level key stay flat, {@link bodyExtra}
+   * among them. Both console read-sites (`useConsoleActionRuntime.apiHandler`,
+   * `RecordDetailView.apiHandler`) and the runner's own `executeAPI` implement
+   * exactly that, so the key has one meaning everywhere it is honoured.
+   *
+   * Declared here for the same reason as {@link bodyExtra}: the action
+   * renderers forward it off a typed `ActionSchema` instead of an `as any`
+   * cast, and dropping it from those whitelists is what made a declared wrap
+   * degrade silently to a flat body (objectstack#6938). Typed by derivation
+   * from the spec so the union cannot drift from the contract.
+   */
+  bodyShape?: SpecAction['bodyShape'];
+
   // === Feedback ===
   
   /** Confirmation text to show before execution */


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6938

`bodyExtra`(objectstack#6837 / #3924)的姊妹单,同一个转发白名单形状,换一个键。

## 缺陷

`bodyShape` 是 spec 给 `type: 'api'` 动作的 **body 包裹声明** —— `'flat'`(默认)或 `{ wrap: key }` 把采集到的参数嵌到该键下(better-auth `organization/update` 就是它存在的理由)。console `apiHandler` 无条件读它,而**五个动作渲染器一个都不转发**。于是声明了 `bodyShape: { wrap: 'data' }` 的 action:button 类动作实际发出**扁平** body:端点在顶层收到参数,而声明看起来是"已兑现"的 —— 因为它能解析、能发布。

## 改动

1. **四个 declared-action 渲染器**(`action-{button,group,icon,menu}.tsx`)白名单补 `bodyShape` 转发,就在 #6837 刚补的 `bodyExtra` 旁边。
2. **`ActionSchema`**(`packages/types/src/ui-action.ts`)声明该键,按 #3924 的先例从 `SpecAction['bodyShape']` **派生**,联合类型无法与契约漂移。
3. **`ActionRunner.executeAPI`**(无宿主注册 `api` handler 时走的回退路径)也开始读它。这一条超出 issue 正文点名的四个文件,理由写在下面。

## 为什么连 ActionRunner 一起补

只修渲染器会留下同一缺陷的窄版:console `apiHandler` 与 `RecordDetailView.apiHandler` 都兑现 wrap,而 runner 回退不兑现 —— **同一个动作会因为承载它的宿主不同而改变 body 形状**,这正是"声明 ≠ 兑现"再往下一跳。

关键是这里**没有需要猜的语义**。spec 自己的措辞是:`{ wrap: 'data' }` "nests the user-collected params under that key … while `recordIdParam` and other top-level keys stay flat"。两个 console 读点(`useConsoleActionRuntime.tsx:277`、`RecordDetailView.tsx:670`)实现的**正是**这个次序 —— 先构造 wrap,再把 `recordIdParam` / `organizationId` / `bodyExtra` 平铺到顶层。所以只有一个读法要镜像,不是一个要做的选择。runner 现在与之逐字一致:包裹只覆盖采集到的 payload,`bodyExtra` 平铺在旁。

## `element:button` 故意不补

它的转发列表逐字段镜像 spec 的 `InlineActionSchema` pick list(该文件自己的注释就这么写),而那份 pick list 不含 `bodyShape` —— 已用 `git show origin/main:packages/spec/src/ui/action.zod.ts` 亲验,13 个 pick 为 `type name label target openIn method params bodyExtra confirmText successMessage errorMessage refreshAfter opensInNewTab`。`bodyShape` 不是 inline 词汇,而 spec 对这个边界的规矩是明写的:"Widen this when a renderer widens, not before",且窗口**只能 spec 先行,不能渲染器先行**。从 `element:button` 转发它就是被禁的那个方向。

spread 型宿主(`DeclaredActionsBar` / `RelatedRecordActionsBridge` / `ObjectGrid`)转发整个 def(`{ params: rawParams, ...rest }`),天然携带该键,免改 —— 已抽查 `DeclaredActionsBar.tsx:135`,其注释本就点名 `bodyShape`。

## 测试

新增两个文件,在两端断言:runner **收到**什么(转发本身),以及**线上**是什么形状(转发加 body 组装)。只查 props 的测试会在 payload 依然丢失时保持绿色。

- `packages/components/src/__tests__/action-bodyShape-forward.test.tsx` —— 四个渲染器各一条转发;端到端两条(真实 `fetch`,断言 `{ data: {...} }`,以及 `bodyExtra` 平铺在 wrap 旁);无 `bodyShape` 时扁平 body 的回归钉。
- `packages/core/src/actions/__tests__/ActionRunner.bodyShape.test.ts` —— runner 自身 7 条:wrap 生效、无 params 时包裹 context record、`bodyExtra` 保持平铺、`ApiConfig` 分支同样生效、`'flat'` 与缺省两条扁平钉,以及一条 off-spec 值退化为文档默认值(而不是在线上造出一个字面量 undefined 键)。

**反向验证**(方向先判后跑,两次都是标准 red):

- 只回退四处渲染器转发 → 4 条转发断言 + 2 条端到端 wrap 断言变红(`expected undefined to deeply equal { wrap: 'data' }`),扁平钉保持绿。
- 只回退 runner 的 wrap 分支 → 4 条 runner wrap 断言 + 2 条端到端变红(`expected { name: 'Acme Inc', slug: 'acme' } to deeply equal { data: { … } }`),4 条渲染器转发断言与两处扁平钉保持绿。

如实记一处:那条 off-spec 退化用例在 runner 改动前后都是绿的(改动前 runner 根本不读该键,行为也是扁平),所以它对本次改动**不具判别力** —— 它是往后防止 wrap 分支在坏值上造键的钉子,不是本次修复的证据。

## 验证

- `pnpm exec vitest run packages/components/ packages/core/ --maxWorkers=2` → **174 files / 2358 tests passed**
- 消费半径复查(渲染器的宿主):`pnpm exec vitest run packages/app-shell/ packages/plugin-grid/` → **361 files / 3285 passed, 1 skipped**
- `pnpm exec turbo run type-check --concurrency=2` → **78 successful, 78 total**
- `pnpm check:control-bytes` → OK(3808 个文本文件);`pnpm changeset:check` → OK
- changeset:`patch`,覆盖 `@object-ui/components` / `@object-ui/core` / `@object-ui/types`

Base:`5e524950d`(含 #3924 的 `7e5bb5d4e`)。

正文点名的通用 pin test(渲染器转发键集 vs runtime 实读键集 diff)未在本 PR 落地,理由与后续单见评论。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_