### PR TITLE
fix(app-shell): context selector 的 auto-select-first 移到 commit 阶段,pick 不再被后发的自动选中覆盖 (objectstack#6979)

### DIFF
--- a/.changeset/context-selector-auto-select-race-os6979.md
+++ b/.changeset/context-selector-auto-select-race-os6979.md
@@ -1,0 +1,35 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Context selectors: picking an option the instant the dropdown fills no longer snaps back to the first one
+
+A context selector is a *mandatory* scope, so `SelectorControl` auto-selects
+`options[0]` as soon as the option list resolves and nothing concrete is
+selected yet. That repair ran in a passive effect — a task AFTER the commit that
+rendered the option rows — which left a gap in which the dropdown was already
+rendered and clickable while no selection had been made. A pick delivered inside
+that gap was applied and then immediately undone: the queued auto-select fired
+second, carrying a closure from before the pick (`hasConcrete` still `false`,
+and the search string it wrote from still the pre-pick one), so the user's
+choice was replaced by the first row — silently, and for a `persist: 'query'`
+selector with a URL rewrite behind it.
+
+The gap is widest exactly where it matters: a slow options endpoint, a loaded
+machine, or a low-end device, i.e. the cases where a user is most likely to be
+already reaching for the option they want. The repair is now a layout effect, so
+it lands in the same synchronous flush as the options it reacts to — no event
+can be delivered in between, and the control is never painted with an empty
+value while options exist.
+
+Nothing else about the behaviour moves: same trigger, same deps, same one write
+per medium. A scope that a later param-less nav link drops is still
+re-established from the first option (the re-selection objectstack#5994 relied
+on when it deleted the storage-to-URL bridge), which is pinned alongside the two
+medium cases in `ContextSelectors.autoSelectRace.test.tsx`.
+
+Found as a CI flake in `ContextSelectors.persist.test.tsx`
+(objectstack#6979): under load the test's own pick lost the same race, twice,
+with `expected 'billing' to be 'crm_core'`. Those cases now settle the
+auto-select before picking, which also pins a fact none of them pinned before —
+a user's pick overrides the auto-selected first option.

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -423,7 +423,21 @@ function SelectorControl({
   // nothing). We never render an "All" row, and auto-select the first option
   // as soon as the list resolves when nothing concrete is selected yet.
   const hasConcrete = !!value && value !== (def.allValue ?? '');
-  React.useEffect(() => {
+  // A LAYOUT effect, deliberately — this one is not interchangeable with
+  // `useEffect` (objectstack#6979). As a passive effect the repair was queued
+  // for a task AFTER the commit that rendered the options, so it carried a
+  // closure captured before that gap: `hasConcrete` still `false`, and (via
+  // `onChange`) a `location.search` that predated anything the gap contained.
+  // A pick made inside the gap — a user clicking an option the instant it
+  // appears, on a loaded machine or a slow device — was therefore navigated
+  // away again by this effect firing second with `options[0]`, silently
+  // replacing the user's choice with the first row. Running in the commit phase
+  // closes the gap at its source: the repair lands in the same synchronous
+  // flush as the options it reacts to, so no event can be delivered in
+  // between, and the control is never painted with an empty value while
+  // options exist. Everything else is unchanged — same trigger, same deps, so
+  // a scope dropped later by a param-less nav link is still re-established.
+  React.useLayoutEffect(() => {
     if (hasConcrete) {
       return;
     }

--- a/packages/app-shell/src/layout/__tests__/ContextSelectors.autoSelectRace.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ContextSelectors.autoSelectRace.test.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * A pick made the instant the options appear is never overwritten by
+ * auto-select-first (objectstack#6979).
+ *
+ * A context selector is a *mandatory* scope, so `SelectorControl` auto-selects
+ * `options[0]` as soon as the option list resolves and nothing concrete is
+ * selected. That repair used to run in a passive effect — i.e. in a task AFTER
+ * the commit that rendered the options — which left a gap with a rendered,
+ * clickable dropdown in it and no selection yet. A pick delivered inside that
+ * gap was applied and then immediately navigated away again, because the
+ * queued auto-select fired second with a closure captured before the pick
+ * (`hasConcrete` still `false`, and the search string it wrote from still the
+ * pre-pick one). The user's choice silently became `options[0]`.
+ *
+ * The gap is not a test artefact: a click on a loaded machine or a slow device
+ * lands in whatever task the event loop gives it, and nothing a test does can
+ * make a real user wait for React's passive effects. What the tests below add is
+ * the ability to *aim* at the gap deterministically, so the regression is pinned
+ * by a red assertion instead of by CI's luck.
+ *
+ * ## Why the raw MutationObserver instead of `waitFor`
+ *
+ * RTL's async wrapper drains a macrotask after the callback first succeeds, so
+ * `await waitFor(optionRowsExist)` usually returns on the far side of the gap —
+ * which is exactly why this bug read as flaky rather than broken, and why the
+ * sibling `ContextSelectors.persist.test.tsx` cases can settle-then-click and be
+ * stable. {@link atOptionsCommit} stops at the commit that adds the option rows,
+ * with the post-commit work still outstanding, so the click below lands inside
+ * the gap on every machine.
+ *
+ * ## Reverse verification (direction predicted before running)
+ *
+ * Turning `SelectorControl`'s auto-select back into `React.useEffect` turns both
+ * medium cases red *immediately* — not by timeout: the clobber happens inside
+ * the click's own `act`, so the control comes back from `fireEvent.click`
+ * already showing `billing`, and the synchronous assertion right after the click
+ * is the one that fires. (Measured: `expected 'billing' to be 'crm_core'`, the
+ * same message as the two CI runs in objectstack#6979.) The third case is the
+ * opposite direction — it stays green across that revert, because it pins the
+ * behaviour the fix must NOT change: it is the guard against "fix the race by
+ * latching auto-select off after the first pick", which would leave the scope
+ * blank the next time a nav link drops the param (objectstack#5994 deleted the
+ * storage → URL bridge on the strength of that re-selection).
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+
+// Radix's Select is not driveable in happy-dom (pointer capture), and the
+// choreography is not what is under test — the ORDER of two writes is. Swap the
+// primitives for a flat list of buttons calling `onValueChange`; the outer
+// `data-current` is the rendered value, which is how the clobber is observed
+// synchronously (no `waitFor` to smear the timing being asserted).
+vi.mock('@object-ui/components', async () => {
+  const R = await import('react');
+  const PickCtx = R.createContext<(value: string) => void>(() => {});
+  return {
+    getLazyIcon: () => () => null,
+    Select: ({ value, onValueChange, children }: any) => (
+      <PickCtx.Provider value={onValueChange}>
+        <div data-current={value ?? ''}>{children}</div>
+      </PickCtx.Provider>
+    ),
+    SelectTrigger: ({ children, 'aria-label': label }: any) => (
+      <div role="combobox" aria-label={label}>{children}</div>
+    ),
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectItem: ({ value, children }: any) => {
+      const pick = R.useContext(PickCtx);
+      return (
+        <button type="button" data-testid={`opt-${value}`} onClick={() => pick(value)}>
+          {children}
+        </button>
+      );
+    },
+    SelectValue: () => null,
+  };
+});
+
+import { useAppContextSelectors, type ContextSelectorDef } from '../ContextSelectors';
+
+const PACKAGES_ENDPOINT = '/api/v1/packages';
+
+/** Labels sort so `options[0]` is `billing` — the value a clobber lands on. */
+const ROWS = [
+  { id: 'billing', name: 'Billing' },
+  { id: 'crm_core', name: 'CRM Core' },
+];
+
+const STORAGE_KEY = 'objectui-ctx-studio-active_package';
+/** Studio's `active_package` is grandfathered onto `?package=` (objectui#3500). */
+const URL_KEY = 'package';
+
+/** Module-level so effects key off a stable ref. */
+const QUERY_SEL: ContextSelectorDef[] = [
+  { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT }, persist: 'query' },
+];
+const SESSION_SEL: ContextSelectorDef[] = [
+  { id: 'active_package', label: 'Package', optionsSource: { endpoint: PACKAGES_ENDPOINT }, persist: 'session' },
+];
+
+let snapshot: { contextValues: Record<string, string>; search: string };
+
+function Probe({ list }: { list: ContextSelectorDef[] }) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { contextValues, element } = useAppContextSelectors('studio', list);
+  // Published from an effect, not during render: the hook re-navigates from its
+  // own effects, so only a committed render is a meaningful sample.
+  React.useEffect(() => {
+    snapshot = { contextValues, search: location.search };
+  });
+  return (
+    <>
+      {element}
+      {/* A param-less nav link, the way Studio's own nav items drop the scope. */}
+      <button type="button" data-testid="drop-scope" onClick={() => navigate('/apps/studio')}>
+        drop
+      </button>
+    </>
+  );
+}
+
+function mount(list: ContextSelectorDef[], url = '/apps/studio') {
+  snapshot = { contextValues: {}, search: '' };
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <Probe list={list} />
+    </MemoryRouter>,
+  );
+}
+
+/** The value the control is currently rendering, read straight off the DOM. */
+function rendered() {
+  return document.querySelector('[data-current]')?.getAttribute('data-current');
+}
+
+function query() {
+  return new URLSearchParams(snapshot.search);
+}
+
+/**
+ * Resolves on the commit that first renders the option rows, with React's
+ * post-commit work still outstanding — the gap a real click can land in.
+ *
+ * A `MutationObserver` and not `waitFor`: the latter's wrapper drains a
+ * macrotask once its callback succeeds, which hands the pending auto-select a
+ * turn and closes the gap before the test can aim at it.
+ */
+function atOptionsCommit() {
+  const seen = () => document.querySelector('[data-testid="opt-crm_core"]');
+  return new Promise<void>((resolve) => {
+    if (seen()) return resolve();
+    const observer = new MutationObserver(() => {
+      if (!seen()) return;
+      observer.disconnect();
+      resolve();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ROWS })));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('auto-select-first never overwrites a pick made in the same flush', () => {
+  it('keeps a `query` pick that lands before the auto-select is done reacting', async () => {
+    mount(QUERY_SEL);
+    await atOptionsCommit();
+
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+
+    // Synchronous, deliberately: the clobber used to happen inside this click's
+    // own `act`, so `billing` was already rendered by the time control returned.
+    expect(rendered()).toBe('crm_core');
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('crm_core'));
+    // And no late navigation follows it.
+    expect(rendered()).toBe('crm_core');
+  });
+
+  it('keeps a `session` pick the same way — the gap is not URL-specific', async () => {
+    // Auto-select goes through the same one-medium `setValue` as a pick, so the
+    // race is the same race in storage. Pinning both media keeps a future fix
+    // from closing it for the URL only.
+    mount(SESSION_SEL);
+    await atOptionsCommit();
+
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+
+    expect(rendered()).toBe('crm_core');
+    await waitFor(() => expect(sessionStorage.getItem(STORAGE_KEY)).toBe('crm_core'));
+    expect(rendered()).toBe('crm_core');
+    // `'session'` stays out of the address bar (objectstack#5994).
+    expect(query().has(URL_KEY)).toBe(false);
+  });
+
+  it('still re-selects a first option when a nav link drops the scope param', async () => {
+    mount(QUERY_SEL);
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('billing'));
+    fireEvent.click(screen.getByTestId('opt-crm_core'));
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('crm_core'));
+
+    fireEvent.click(screen.getByTestId('drop-scope'));
+
+    // A mandatory scope is never left blank: the param-less URL is repaired back
+    // to the first option. This is why the race must NOT be fixed by disabling
+    // auto-select once the user has picked.
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('billing'));
+    expect(snapshot.contextValues.active_package).toBe('billing');
+  });
+});

--- a/packages/app-shell/src/layout/__tests__/ContextSelectors.persist.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ContextSelectors.persist.test.tsx
@@ -26,6 +26,35 @@
  * whole, which is why it asserts the published template var too and not merely
  * two empty stores (an all-empty assertion would pass for a selector that
  * produced nothing at all).
+ *
+ * ## Settle before you click (objectstack#6979)
+ *
+ * Every case that mounts a param-less, storage-less URL gets a value it did not
+ * ask for first: `SelectorControl` auto-selects `options[0]` (`billing`) as soon
+ * as the option list resolves, because a context selector is a *mandatory*
+ * scope. So `mount` → `optionsReady()` → `fireEvent.click(other option)` is two
+ * writes racing, and `optionsReady` is not a barrier for the first of them —
+ * it only waits for the option rows to be in the DOM, which happens one commit
+ * BEFORE the auto-select is done reacting to them. On a loaded CI worker the
+ * pick therefore landed first and the auto-select second, overwriting it
+ * (`expected 'billing' to be 'crm_core'`, twice in CI).
+ *
+ * Hence the shape below: **wait for the auto-select to land in the selector's
+ * own medium, then click.** It costs one `waitFor` and buys two things — the
+ * case stops depending on machine load, and it now pins a fact none of these
+ * cases pinned before: a user's pick OVERRIDES the auto-selected first option
+ * (previously a case could have passed with the pick never applied at all, as
+ * long as the auto-selected value happened to be the expected one).
+ *
+ * Only the param-less mounts need it, and they need it in the medium `persist`
+ * names — the auto-select goes through the same one-medium `setValue` as a
+ * pick, so it is the URL for `'query'`, `sessionStorage` for `'session'`, and
+ * the published value alone for `'none'`. A case that mounts a URL param, or
+ * seeds storage for a `'session'` selector, hands the control a concrete value
+ * on its very first render: auto-select never fires there and there is nothing
+ * to settle. The load-independent counterpart of this race — a pick delivered
+ * inside the gap, which no amount of waiting in a test can prevent for a real
+ * user — is pinned in `ContextSelectors.autoSelectRace.test.tsx`.
  */
 
 import '@testing-library/jest-dom/vitest';
@@ -139,6 +168,9 @@ describe("persist: 'query' — the URL query string, and nothing else", () => {
   it('writes the pick to the URL and leaves sessionStorage untouched', async () => {
     mount(QUERY_SEL);
     await optionsReady();
+    // Settle the auto-selected first option before picking, so this asserts a
+    // pick that overrode `billing` — not a pick racing it (objectstack#6979).
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('billing'));
 
     fireEvent.click(screen.getByTestId('opt-crm_core'));
 
@@ -175,6 +207,9 @@ describe("persist: 'query' — the URL query string, and nothing else", () => {
   it("applies the spec's `'query'` default when `persist` is omitted", async () => {
     mount(DEFAULT_SEL);
     await optionsReady();
+    // Same settle-then-click as the first case: an omitted `persist` resolves to
+    // `'query'`, so the auto-select lands in the URL here too.
+    await waitFor(() => expect(query().get(URL_KEY)).toBe('billing'));
 
     fireEvent.click(screen.getByTestId('opt-crm_core'));
 
@@ -187,6 +222,10 @@ describe("persist: 'session' — sessionStorage, and nothing else", () => {
   it('writes the pick to sessionStorage and never to the URL', async () => {
     mount(SESSION_SEL);
     await optionsReady();
+    // The auto-select races the pick here too — it just races it in storage,
+    // because auto-select and pick share one `setValue` and this selector's
+    // medium is storage (objectstack#6979).
+    await waitFor(() => expect(sessionStorage.getItem(STORAGE_KEY)).toBe('billing'));
 
     fireEvent.click(screen.getByTestId('opt-crm_core'));
 
@@ -227,6 +266,9 @@ describe("persist: 'none' — not persisted at all", () => {
   it('writes neither the URL nor sessionStorage, and still publishes the pick', async () => {
     mount(NONE_SEL);
     await optionsReady();
+    // `'none'` has no store to settle in, so the published value IS the medium
+    // to wait on before picking (objectstack#6979).
+    await waitFor(() => expect(snapshot.contextValues.active_package).toBe('billing'));
 
     fireEvent.click(screen.getByTestId('opt-crm_core'));
 
@@ -254,6 +296,7 @@ describe("persist: 'none' — not persisted at all", () => {
   it('drops the pick when the shell remounts', async () => {
     const first = mount(NONE_SEL);
     await optionsReady();
+    await waitFor(() => expect(snapshot.contextValues.active_package).toBe('billing'));
     fireEvent.click(screen.getByTestId('opt-crm_core'));
     await waitFor(() => expect(snapshot.contextValues.active_package).toBe('crm_core'));
 
@@ -279,6 +322,9 @@ describe('collision warning follows the URL medium', () => {
     ]);
     await optionsReady(2);
 
+    // No settle needed even though both selectors auto-select: the warning is
+    // emitted from the collision effect at mount and keyed off the declared
+    // ids, so no value write — pick or auto-select — can add or remove it.
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('both map to the URL scope key'));
     warn.mockRestore();
   });


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6979

## 结论:issue 的机理判断成立,且不止是测试写法问题

issue 的诊断逐字复核成立:`ContextSelectors.persist.test.tsx` 首用例在 `optionsReady()` 之后立即点击,与 `SelectorControl` 的 auto-select-first 竞速;高负载下 auto-select 后发、带过期闭包(`hasConcrete` 仍为 false、写入用的 search 仍是 pick 之前的),把用户 pick 覆盖回 `options[0]`(`billing`)。

补充一层 issue 没写、但决定了修法的事实:**这个 gap 不是测试环境的产物**。auto-select 原本是 passive effect,排在「渲染出选项行的那次 commit」之后的一个 task 里执行,于是存在一个「下拉已渲染、可点,但尚无选中值」的真实窗口。选项接口慢、机器负载高、低端设备上,用户恰好在这个窗口里点选,pick 会被随后落地的 auto-select 覆盖 —— 对 `persist: 'query'` 的选择器还会连带改写 URL。测试里再怎么等,都替真实用户等不了。所以本 PR 两侧都修。

## 组件侧:把 auto-select-first 移到 commit 阶段

`packages/app-shell/src/layout/ContextSelectors.tsx` 里 auto-select 那条 `React.useEffect` 改为 `React.useLayoutEffect`。它与选项所在的 commit 落在同一个同步 flush 里,期间无法投递任何事件,窗口从源头消失;顺带也不再有「选项已就绪却渲染空值」的一帧。

**触发条件、依赖数组、每种介质一次写入全部不变** —— 后续 nav link 把 scope 参数抹掉时,依旧从首项重新建立(objectstack#5994 删掉 storage 到 URL 的 bridge 时依赖的就是这条),该行为已单独钉住。

评估过、**未采用**的另一种改法:给「用户已 pick」加一个 ref 闩,让后发的 auto-select 看到闩就放弃。它能修同一个竞态,但语义不唯一 —— 闩什么时候清很关键,清晚了(比如永久闩上)就会在 nav link 抹掉参数后把 scope 留空,正是 #5994 判定「不需要 bridge」所依赖的那条行为。相比之下换 effect 相位不引入新状态、不新增分支,风险面小得多。另外确认过「fire 时重读当前 location/params」这条 issue 提到的方向**不足以**修好:覆盖发生时,pick 触发的 re-render 还没 commit(React 在开始下一次渲染前先 flush pending passive effects),所以任何在 render 期更新的 ref 读到的仍是 pick 之前的值 —— 只有相位或闩能解决。

SSR 面已核:依赖 `@object-ui/app-shell` 的只有 console SPA(Vite)与两个 console example,唯一 SSR 的 `@object-ui/site` 不依赖它;仓内 `useLayoutEffect` 已有先例(`RouteFader`、`form.tsx` 的状态修复)。

## 测试侧:逐用例排查,param-less 挂载全部 settle-then-click

`ContextSelectors.persist.test.tsx` 全文件 11 个用例逐条判定过:

| 用例 | 判定 |
|---|---|
| `'query'` 写 URL / 不碰 storage | **改**:点击前先等 `?package=billing` 落定 |
| `'query'` 从 URL 读回 | 免改:挂载即带参数,首帧就有具体值,auto-select 不触发 |
| `'query'` 忽略过期 storage 条目 | 免改:本来就是 settle-then-assert 的正确写法(issue 引用的对照样本) |
| `'query'` 默认值(省略 `persist`) | **改**:同首用例,默认解析为 `'query'`,auto-select 落在 URL |
| `'session'` 写 storage / 不碰 URL | **改**:auto-select 与 pick 共用同一个 `setValue`,这里的竞态发生在 storage 里,等 storage 出现 `billing` 再点 |
| `'session'` 从 storage 恢复 | 免改:storage 已播种,首帧就有具体值 |
| `'session'` 不被同名 query 参数遮蔽 | 免改:同上 |
| `'none'` 两处都不写但仍发布 pick | **改**:`'none'` 没有 store 可等,发布值本身就是要等的介质 |
| `'none'` 不恢复上次会话 / 不读 URL | 免改:本来就在等 `billing`,且没有点击 |
| `'none'` 重新挂载后丢弃 pick | **改**:点击前补等 `billing`(后半段本来就是 settle 形状) |
| 冲突告警跟随 URL 介质 | 免改:告警由挂载时的冲突 effect 按声明的 id 发出,任何值写入都不影响它(已在用例里写明理由) |

即:`session` / `none` 的用例**并非**「不经 auto-select 路径」,而是 auto-select 走同一个 `setValue`、只是落在各自介质里 —— 所以 param-less 挂载的那三条一并治了,免改的四条都是「首帧即有具体值,auto-select 从不触发」。

顺手核过同目录的 `ContextSelectors.scopeKey.test.tsx`:6 个用例全部挂载带参数的 URL 或播种 storage,没有同形用例,不需要改。

## 新增 ContextSelectors.autoSelectRace.test.tsx —— 钉住不依赖负载的那一半

三条用例。前两条把点击**精确瞄进 gap**:用裸 `MutationObserver` 停在「渲染出选项行的那次 commit」,RTL 的 `waitFor` 在回调首次成功后会额外 drain 一个 macrotask、正好把 pending 的 auto-select 放过去(这也正是本 bug 表现为 flaky 而不是稳定红的原因)。URL 介质与 storage 介质各钉一条,防止将来只修一半。

第三条方向相反,是故意的:它钉住「nav link 抹掉参数后仍从首项重选」,把上面那个 ref 闩式改法可能踩坏的行为提前挡住。

## 验证证据

反向验证(**方向先判后跑,判断成立**):把组件改回 `React.useEffect`,新增文件前两条**立刻**变红而不是超时 —— 覆盖发生在点击自己的 `act` 里,所以 `fireEvent.click` 之后那条同步断言先炸,消息与 CI 两跑一字不差:

```
× keeps a `query` pick that lands before the auto-select is done reacting 58ms
× keeps a `session` pick the same way — the gap is not URL-specific 11ms
AssertionError: expected 'billing' to be 'crm_core'
 Test Files  1 failed | 1 passed (2)
      Tests  2 failed | 12 passed (14)
```

同一次反向验证里,**改好写法的 `persist.test.tsx` 12 条全绿**(上面 `1 passed`)—— settle-then-click 不依赖 effect 相位,两侧修法各自独立成立。第三条用例在这次 revert 下保持绿,与预判一致。

稳定性(修后):

- `pnpm exec vitest run packages/app-shell/src/layout/__tests__/ --maxWorkers=2` **连跑 5 次**:`17 passed (17) / 88 passed (88)` × 5
- 同目录 `--maxWorkers=4` 连跑 3 次:同上全绿
- `pnpm exec vitest run packages/app-shell --maxWorkers=2`:`306 passed (306)` / `2772 passed | 1 skipped`
- `pnpm exec turbo run type-check --concurrency=2`:`78 successful, 78 total`
- changeset 三道闸:presence / no-major / fixed 全 0 退出

**没能复现的部分,如实说明**:修前状态在 4 核机器上加 6 个 CPU 占用进程、`--maxWorkers=4` 连跑 6 次,原用例始终是绿的 —— CI 那个 shard 的负载(约 1/4 全量 dom 文件 + 饱和的 Vite transform 管线)本地无法等价复制。红绿的实际开关是 Node 事件循环的相位竞争:React scheduler 用 `setImmediate`(check 阶段)排 passive effect flush,RTL 的 drain 用 `setTimeout(0)`(timers 阶段),两者谁先取决于当前处在循环的哪个阶段、每个阶段在负载下有多长。所以本 PR 用的是**确定性复现**而非概率复现:裸 `MutationObserver` 直接把测试放到「effect 仍 pending」这个 CI 命中的状态上,产出与 CI 完全同签名的失败,再证明修后同条件全绿。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_