### PR TITLE
fix(app-shell): metadata-admin 谓词解析不到的路径 fail-open + dev 告警 (objectstack#6936)

### DIFF
--- a/.changeset/metadata-admin-predicate-unresolved-path-fail-open-os6936.md
+++ b/.changeset/metadata-admin-predicate-unresolved-path-fail-open-os6936.md
@@ -1,0 +1,61 @@
+---
+"@object-ui/app-shell": patch
+---
+
+metadata-admin: an unresolvable visibility-predicate path now fails OPEN, loudly (objectstack#6936)
+
+`views/metadata-admin/predicate.ts` promised fail-open in its own header — "on any
+parse error → returns `true`: better to show a field than to silently hide it" —
+and delivered it only for *thrown* errors. A path whose root identifier did not
+exist in the evaluation scope took a quieter route: `resolveValue` returned
+`undefined`, and then every comparison judged it false —
+`['text','number'].includes(undefined)`, `undefined === 'text'` — so a predicate
+referencing a name that is not there **hid** the field. Fail-CLOSED, the opposite
+of the documented promise, with nothing in the console.
+
+The bite case is a version-skew window, measured in objectui#3923: `@objectstack/spec`
+≤ 17.0.0-rc.5 spells the `objectForm` sub-field predicates bare (`type in ['text',…]`,
+16 of them) while this engine evaluates them against a `{ data: draftRow }` scope. A
+console upgraded ahead of its backend resolved `type` to nothing, and all 16
+type-conditional Studio sub-fields — Min / Max / Precision / Scale / Max Length /
+Min Length / reference / deleteBehavior / expression / returnType /
+autonumberFormat / language … — disappeared for every row type at once. The symptom
+users saw was "the config items are gone", indistinguishable from a permission
+problem or an unsupported field type.
+
+Per the maintainer ruling on objectstack#6936 (option C):
+
+- **An unresolvable path evaluates `true`.** The field stays visible instead of
+  vanishing, honouring what the header always claimed.
+- **Dev mode says so**, naming the unresolved path *and* the predicate that
+  carried it, warn-once per (path, predicate) pair — the shape
+  `warnOnUnknownActionKeys` established in `@object-ui/core`. Keying the memo on
+  the path alone would have reported the first of the 16 skewed predicates and
+  stayed silent about the other fifteen.
+
+**The boundary, which is the load-bearing half.** "Unresolvable" means the path's
+ROOT identifier is not a name the scope declares (`type`, `record.status`,
+`page.selectedId` against a scope whose only name is `data`). It does *not* mean
+"the value came out undefined": `data.type == 'text'` on a draft that has no
+`type` yet resolves its root fine, the draft simply carries no value there — that
+comparison is still false and the field stays hidden, silently, exactly as before.
+A draft is allowed to be empty; widening fail-open to any absent value would light
+up every type-conditional sub-field at once on a fresh row. A typo one segment
+deep (`data.tpye`) is indistinguishable from an unfilled draft field *without the
+schema*, which this evaluator does not have — catching that belongs to
+publish-time validation of predicate path references at the producer (filed
+separately), not to a renderer heuristic (Commandment #0.1).
+
+The signal is a thrown internal error, deliberately not a sentinel value: fail-open
+is a property of the whole predicate, not of the sub-expression that failed. A
+sentinel would have to be threaded through `!`, `&&`, `||`, `in` and `==` by hand,
+and the first operator that missed it would invert the verdict — `!unresolvedPath`
+would resolve the inner path to "true-ish" and negate it straight back to false,
+i.e. fail-CLOSED again by another route. Throwing routes every failure to the one
+fail-open gate that already existed; `!unresolvedPath` is pinned true.
+
+Unchanged, and pinned: the pre-existing parse-error fail-open (still silent — the
+path resolved, reading it blew up, a different fact); CEL-order absorption, where
+`false && unresolvable` is false and `true || unresolvable` is true with no
+warning because the unresolvable half was short-circuited away; and CEL-style loose
+nullish equality (`data.type == null` on an empty draft is still true).

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.unresolvedPredicate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.unresolvedPredicate.test.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectstack#6936, end to end at the site the issue measured.
+ *
+ * The probe in objectui PR #3923 read the Studio object field list against two
+ * backends and recorded:
+ *
+ *   B1 objectForm fields (post-#6254 `data.` spelling)
+ *      row currency → Min, Max, Precision, Scale     (correct)
+ *      row text     → Max Length, Min Length         (correct)
+ *   B2 objectForm fields (installed spec 17.0.0-rc.5, bare spelling)
+ *      row currency → not one of the 16 conditional sub-fields renders
+ *      row text     → not one of the 16 conditional sub-fields renders
+ *
+ * B2 is the version-skew window: the predicate says `type in ['text',…]`, this
+ * engine evaluates it against `{ data: draftRow }`, the root `type` resolves to
+ * nothing, `includes(undefined)` is false, and the sub-field disappears with no
+ * diagnostic. This file pins B2's repaired reading (sub-fields render, console
+ * says why) and B1's unchanged one (still row-type-conditional) through the real
+ * `SchemaForm` record-row site, not the evaluator alone.
+ *
+ * The sub-field set here is the simply-typed subset of the 16 — number / text /
+ * select / boolean. The remaining four (`options`, `lookupFilters`,
+ * `summaryOperations`, `expression`) render repeater / JSON / code widgets whose
+ * module graphs are exactly what AGENTS.md §9 warns about pulling into a DOM
+ * test; the full 16-predicate table is pinned at evaluator level in
+ * `predicate.test.ts` instead.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+import { resetPredicateWarnings } from './predicate';
+
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetPredicateWarnings();
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+  cleanup();
+});
+
+/** Mirrors the spec `objectForm`: a name-keyed `fields` record of field defs. */
+const objectishSchema = {
+  type: 'object',
+  properties: {
+    fields: {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', title: 'Name' },
+          type: { type: 'string', title: 'Type' },
+          min: { type: 'number', title: 'Min' },
+          max: { type: 'number', title: 'Max' },
+          precision: { type: 'number', title: 'Precision' },
+          scale: { type: 'number', title: 'Scale' },
+          maxLength: { type: 'number', title: 'Max Length' },
+          minLength: { type: 'number', title: 'Min Length' },
+          reference: { type: 'string', title: 'Reference' },
+          deleteBehavior: { type: 'string', title: 'Delete Behavior' },
+          multiple: { type: 'boolean', title: 'Multiple' },
+          returnType: { type: 'string', title: 'Return Type' },
+          autonumberFormat: { type: 'string', title: 'Autonumber Format' },
+          language: { type: 'string', title: 'Language' },
+        },
+      },
+    },
+  },
+};
+
+const NUMERIC = ['Min', 'Max', 'Precision', 'Scale'];
+const TEXTUAL = ['Max Length', 'Min Length'];
+const LOOKUP = ['Reference', 'Delete Behavior', 'Multiple'];
+const OTHER = ['Return Type', 'Autonumber Format', 'Language'];
+const ALL_CONDITIONAL = [...NUMERIC, ...TEXTUAL, ...LOOKUP, ...OTHER];
+
+/** Sub-field specs gated on the row type, in a given predicate spelling. */
+const rowFields = (spell: (path: string) => string) => [
+  { field: 'type' },
+  { field: 'min', visibleWhen: `${spell('type')} in ['number','currency','percent']` },
+  { field: 'max', visibleWhen: `${spell('type')} in ['number','currency','percent']` },
+  { field: 'precision', visibleWhen: `${spell('type')} in ['number','currency','percent']` },
+  { field: 'scale', visibleWhen: `${spell('type')} in ['number','currency','percent']` },
+  { field: 'maxLength', visibleWhen: `${spell('type')} in ['text','textarea','email']` },
+  { field: 'minLength', visibleWhen: `${spell('type')} in ['text','textarea','email']` },
+  { field: 'reference', visibleWhen: `${spell('type')} in ['lookup','master_detail','tree']` },
+  { field: 'deleteBehavior', visibleWhen: `${spell('type')} in ['lookup','master_detail']` },
+  { field: 'multiple', visibleWhen: `${spell('type')} in ['lookup']` },
+  { field: 'returnType', visibleWhen: `${spell('type')} == 'formula'` },
+  { field: 'autonumberFormat', visibleWhen: `${spell('type')} == 'autonumber'` },
+  { field: 'language', visibleWhen: `${spell('type')} == 'code'` },
+];
+
+const formFor = (spell: (path: string) => string) =>
+  ({
+    type: 'simple' as const,
+    sections: [
+      {
+        label: 'Fields',
+        fields: [
+          {
+            field: 'fields',
+            type: 'record',
+            keyField: { field: 'name', label: 'Name' },
+            fields: rowFields(spell),
+          },
+        ],
+      },
+    ],
+  }) as never;
+
+const bare = (path: string) => path.replace(/^data\./, '');
+const scoped = (path: string) => `data.${path.replace(/^data\./, '')}`;
+
+const renderRow = (spell: (path: string) => string, key: string, row: Record<string, unknown>) => {
+  render(
+    <SchemaForm
+      schema={objectishSchema}
+      form={formFor(spell)}
+      value={{ fields: { [key]: row } }}
+      onChange={() => {}}
+    />,
+  );
+  fireEvent.click(screen.getByText(key));
+};
+
+const warnings = () => warn.mock.calls.map((c) => c.join(' ')).join('\n');
+
+describe('B2 — a backend serving bare predicates no longer empties the row (objectstack#6936)', () => {
+  it('a currency row shows every conditional sub-field instead of none, and says why', () => {
+    renderRow(bare, 'amount', { type: 'currency', precision: 2 });
+    for (const label of ALL_CONDITIONAL) {
+      expect(screen.getByText(label), `${label} must not vanish silently`).toBeInTheDocument();
+    }
+    // Fail-open is the visible half; the console is the audible half.
+    expect(warn).toHaveBeenCalled();
+    expect(warnings()).toContain('`type`');
+    expect(warnings()).toContain("type in ['number','currency','percent']");
+  });
+
+  it('a text row likewise — the sub-fields are shown, not silently dropped', () => {
+    renderRow(bare, 'title', { type: 'text', maxLength: 80 });
+    for (const label of ALL_CONDITIONAL) {
+      expect(screen.getByText(label), `${label} must not vanish silently`).toBeInTheDocument();
+    }
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('B1 — the `data.`-spelled predicates stay row-type-conditional', () => {
+  it('a currency row shows the numeric sub-fields and hides the rest, silently', () => {
+    renderRow(scoped, 'amount', { type: 'currency', precision: 2 });
+    for (const label of NUMERIC) expect(screen.getByText(label)).toBeInTheDocument();
+    for (const label of [...TEXTUAL, ...LOOKUP, ...OTHER]) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a text row shows the length sub-fields and hides the numeric ones', () => {
+    renderRow(scoped, 'title', { type: 'text', maxLength: 80 });
+    for (const label of TEXTUAL) expect(screen.getByText(label)).toBeInTheDocument();
+    for (const label of [...NUMERIC, ...LOOKUP, ...OTHER]) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a row whose type is not set yet keeps its conditional sub-fields hidden', () => {
+    // The boundary, at the render site: an unfilled draft value is NOT an
+    // unresolvable path. If fail-open widened to "any undefined value", a fresh
+    // row would light up with all 13 of these at once.
+    renderRow(scoped, 'untyped', {});
+    for (const label of ALL_CONDITIONAL) expect(screen.queryByText(label)).not.toBeInTheDocument();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/predicate.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/predicate.test.ts
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectstack#6936 — an unresolvable predicate path must fail OPEN, loudly.
+ *
+ * `predicate.ts` promised fail-open in its header and delivered it only for
+ * *thrown* errors. A path whose root identifier did not exist in the scope
+ * resolved to `undefined`, and then `['text'].includes(undefined)` /
+ * `undefined === 'text'` judged the predicate false — the field disappeared with
+ * no diagnostic. Maintainer ruling (option C, 2026-08-09): unresolvable path →
+ * `true`, plus a dev-mode warning naming the path and the predicate.
+ *
+ * The tests below pin the SEMANTIC BOUNDARY as much as the new verdict, because
+ * the boundary is the part that is easy to get wrong in either direction:
+ *
+ *   unresolvable ROOT identifier   → fail-open `true` + one warning
+ *   root resolves, value is absent → ordinary comparison (usually `false`), silent
+ *
+ * Widening the first case to "any undefined value" would show every
+ * type-conditional sub-field at once on a fresh draft; narrowing it away again
+ * restores the silent-hide bug. Both directions are asserted here.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { objectForm } from '@objectstack/spec/data';
+import { evaluatePredicate, resetPredicateWarnings } from './predicate';
+
+/**
+ * The `unit` vitest project runs with `isolate: false`, so this module-global
+ * warn-once memo outlives a single test file. Reset before every test or the
+ * second assertion on a given (path, predicate) pair sees no warning.
+ */
+let warn: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetPredicateWarnings();
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+});
+
+const scope = (data: Record<string, unknown>) => ({ data });
+
+/** All console.warn text emitted so far, joined — order-independent matching. */
+const warnings = () => warn.mock.calls.map((c) => c.join(' ')).join('\n');
+
+/* ── 1. unresolvable root identifier → true, and it says so ──────────────── */
+
+describe('unresolvable path → fail-open true + dev warning (objectstack#6936)', () => {
+  it('a bare `type in [...]` against a `{ data }` scope shows the field instead of hiding it', () => {
+    const row = { type: 'currency' };
+    expect(evaluatePredicate("type in ['number','currency','percent']", scope(row))).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    // The warning has to name BOTH the unresolved path and the predicate that
+    // carried it — a warning that says only "something did not resolve" sends
+    // nobody anywhere.
+    expect(warnings()).toContain('`type`');
+    expect(warnings()).toContain("type in ['number','currency','percent']");
+  });
+
+  it('bare `type == literal` too', () => {
+    expect(evaluatePredicate("type == 'formula'", scope({ type: 'text' }))).toBe(true);
+    expect(warnings()).toContain("type == 'formula'");
+  });
+
+  it('a bare truthy check on an unresolvable name', () => {
+    expect(evaluatePredicate('createOpportunity', scope({ type: 'text' }))).toBe(true);
+    expect(warnings()).toContain('`createOpportunity`');
+  });
+
+  it('NEGATION does not invert the fail-open — `!unresolvable` is still true', () => {
+    // The reason resolution failure is thrown rather than returned as a
+    // sentinel. A sentinel would make the inner path "true-ish" and `!` would
+    // negate it straight back to false — fail-CLOSED, i.e. the bug, reached by
+    // a different route.
+    expect(evaluatePredicate('!type', scope({ type: 'text' }))).toBe(true);
+    expect(warnings()).toContain('`type`');
+  });
+
+  it('a wrong scope root (`record`, `page`) fails open and names the whole path', () => {
+    expect(evaluatePredicate("record.status == 'open'", scope({ status: 'closed' }))).toBe(true);
+    expect(warnings()).toContain('`record.status`');
+    expect(evaluatePredicate("page.selectedId != ''", scope({}))).toBe(true);
+    expect(warnings()).toContain('`page.selectedId`');
+  });
+
+  it('an inherited name is unresolvable, not a resolvable Object member', () => {
+    // `hasOwn`, not `in`: `'constructor' in ctx` is true, and resolving it would
+    // compare a function against a string — false, silently, forever.
+    expect(evaluatePredicate("constructor == 'x'", scope({}))).toBe(true);
+    expect(warnings()).toContain('`constructor`');
+  });
+
+  it('warns ONCE per (path, predicate) pair, not once per evaluation', () => {
+    for (let i = 0; i < 5; i++) evaluatePredicate("type == 'formula'", scope({ type: 'text' }));
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('but a DIFFERENT predicate on the same path gets its own warning', () => {
+    // Keying the memo on the path alone would report the first of the 16 skewed
+    // `objectForm` predicates and stay silent about the other fifteen.
+    evaluatePredicate("type == 'formula'", scope({ type: 'text' }));
+    evaluatePredicate("type == 'code'", scope({ type: 'text' }));
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warnings()).toContain("type == 'formula'");
+    expect(warnings()).toContain("type == 'code'");
+  });
+
+  it('reads the object predicate form as well as the string form', () => {
+    expect(evaluatePredicate({ dialect: 'cel', source: "type == 'formula'" }, scope({}))).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+/* ── 2. resolved and genuinely false → false, silently ───────────────────── */
+
+describe('a resolved path that is genuinely unequal still hides the field', () => {
+  it.each([
+    ["data.type == 'currency'", { type: 'text' }],
+    ["data.type in ['number','currency']", { type: 'text' }],
+    ["data.type != 'text'", { type: 'text' }],
+    ['!data.flag', { flag: true }],
+    ["data.config.kind == 'json'", { config: { kind: 'yaml' } }],
+  ])('%s over %j → false', (expr, row) => {
+    expect(evaluatePredicate(expr, scope(row as Record<string, unknown>))).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a true predicate is still true (and silent)', () => {
+    expect(evaluatePredicate("data.type in ['number','currency']", scope({ type: 'currency' }))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/* ── 3. resolved-to-undefined / null is a VALUE fact, unchanged ──────────── */
+
+describe('an absent draft value is not an unresolvable path (boundary pin)', () => {
+  // Each case: the root `data` resolves, the draft simply carries nothing at
+  // that key. Behaviour must be exactly what it was before objectstack#6936 —
+  // ordinary comparison, no warning. A fresh row must not light up with every
+  // type-conditional sub-field at once.
+  it.each([
+    ["data.type == 'text'", {}, false],
+    ["data.type in ['text','textarea']", {}, false],
+    ['data.type', {}, false],
+    ['data.type', { type: null }, false],
+    ['!data.type', {}, true],
+    ["data.type != 'text'", {}, true],
+    // CEL-style loose nullish equality, live before this change and after it.
+    ['data.type == null', {}, true],
+    ['data.type == null', { type: null }, true],
+    ['data.type != null', {}, false],
+    // Nullish part-way down the path: still a value fact, one level deeper.
+    ["data.config.kind == 'json'", {}, false],
+    ["data.config.kind == 'json'", { config: null }, false],
+    ['data.config.kind == null', {}, true],
+  ])('%s over %j → %s, silently', (expr, row, expected) => {
+    expect(evaluatePredicate(expr as string, scope(row as Record<string, unknown>))).toBe(expected);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('`data` itself resolves — a scope-shaped predicate is not "unresolvable"', () => {
+    expect(evaluatePredicate('data', scope({ type: 'text' }))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/* ── 4. the pre-existing parse-error fail-open, unchanged ────────────────── */
+
+describe('the documented parse-error fail-open is untouched (regression pin)', () => {
+  it('a throwing property access still fails open — and stays silent', () => {
+    // The catch-all branch this file has always had. It must keep failing open,
+    // and it must NOT borrow the unresolved-path warning: the path resolved
+    // fine, reading it blew up, which is a different fact.
+    const row = {};
+    Object.defineProperty(row, 'type', {
+      get() {
+        throw new Error('boom');
+      },
+      enumerable: true,
+    });
+    expect(evaluatePredicate("data.type == 'text'", scope(row))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([null, undefined, ''])('an absent predicate (%j) is "always visible"', (expr) => {
+    expect(evaluatePredicate(expr as never, scope({}))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('an empty object-form source is "always visible"', () => {
+    expect(evaluatePredicate({ dialect: 'cel', source: '' }, scope({}))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('unparseable garbage fails open, and now names what it could not resolve', () => {
+    // Before objectstack#6936 this fell through to a bare truthy check on the
+    // whole string, resolved to `undefined`, and hid the field silently. It is
+    // an unresolvable reference by any reading, so it warns.
+    expect(evaluatePredicate('this is not CEL (((', scope({}))).toBe(true);
+    expect(warnings()).toContain('this is not CEL (((');
+  });
+});
+
+/* ── 5. CEL-style absorption: a short-circuited branch is never reached ──── */
+
+describe('short-circuit absorption (CEL order)', () => {
+  it('`false && unresolvable` is false — the bad half is absorbed, no warning', () => {
+    // Matches CEL, where a false conjunct absorbs an erroring branch. The
+    // verdict is decided by a path that DID resolve, so fail-open never applies
+    // and there is nothing to report.
+    expect(evaluatePredicate("data.type == 'currency' && type == 'formula'", scope({ type: 'text' }))).toBe(
+      false,
+    );
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('`true || unresolvable` is true, also silently', () => {
+    expect(evaluatePredicate("data.type == 'text' || type == 'formula'", scope({ type: 'text' }))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('but a reachable unresolvable half decides the predicate, and warns', () => {
+    expect(evaluatePredicate("data.type == 'text' && type == 'formula'", scope({ type: 'text' }))).toBe(true);
+    expect(warnings()).toContain('`type`');
+  });
+});
+
+/* ── 6. the version-skew specimen, from the bundled spec itself ──────────── */
+
+/**
+ * The reproduction from the issue: `@objectstack/spec` ≤ 17.0.0-rc.5 ships the
+ * `objectForm` sub-field predicates spelled BARE (`type in [...]`), which this
+ * engine evaluates against `{ data: draftRow }`. A frontend carrying the
+ * objectstack#6331 reader fix in front of such a backend resolved `type` to
+ * nothing and hid all 16 type-conditional sub-fields, for every row type.
+ *
+ * Read from the installed spec rather than hand-transcribed — the same choice
+ * `SchemaForm.visibleWhen.test.tsx` made, for the same reason: a hand-written
+ * fixture proves the fixture, not the metadata this engine actually renders.
+ *
+ * When the workspace bumps to a spec with objectstack#6254 landed, the bare
+ * subset legitimately becomes empty. That must not turn this suite into a green
+ * run over nothing (the #5046 trap), so the total-predicate guard below is
+ * asserted unconditionally, and the literal skew table in the next block —
+ * which is version-independent — carries the semantics on its own.
+ */
+describe('bundled spec `objectForm`: bare predicates no longer hide their fields', () => {
+  type Node = Record<string, unknown>;
+  const collect = (node: unknown, out: Array<{ field: string; source: string }>): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const n of node) collect(n, out);
+      return;
+    }
+    const n = node as Node;
+    const pred = n.visibleWhen ?? n.visibleOn;
+    if (pred) {
+      const source = typeof pred === 'string' ? pred : (pred as { source?: string }).source;
+      if (source) out.push({ field: String(n.field ?? '(section)'), source });
+    }
+    for (const v of Object.values(n)) if (v && typeof v === 'object') collect(v, out);
+  };
+
+  const predicates: Array<{ field: string; source: string }> = [];
+  collect(objectForm, predicates);
+  const bare = predicates.filter((p) => !/^\s*data\b/.test(p.source));
+
+  it('the spec ships type-conditional predicates on objectForm at all', () => {
+    // Non-vacuity guard: objectstack#6254 changes the SPELLING of these
+    // predicates, never their presence, so this holds on both sides of the bump.
+    expect(predicates.length).toBeGreaterThan(0);
+  });
+
+  it('every bare-root predicate the installed spec ships evaluates true for any row', () => {
+    for (const { field, source } of bare) {
+      for (const rowType of ['text', 'currency', 'lookup', 'formula', 'code', 'summary', 'autonumber']) {
+        expect(
+          evaluatePredicate(source, scope({ name: 'f', type: rowType })),
+          `${field}: ${source} (row type ${rowType})`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('and every one of them is reported once per predicate', () => {
+    for (const { source } of bare) evaluatePredicate(source, scope({ type: 'text' }));
+    // Distinct predicate sources → distinct warnings; duplicate sources
+    // (maxLength/minLength share one) collapse, which is the intended memo.
+    const distinct = new Set(bare.map((p) => p.source));
+    expect(warn).toHaveBeenCalledTimes(distinct.size);
+  });
+
+  it('`data.`-spelled predicates keep discriminating by row type (post-#6254 shape)', () => {
+    // The other half of the skew window: once the backend is upgraded, the same
+    // sub-fields must go back to being row-type-conditional rather than always
+    // visible. Fail-open applies to unresolvable paths only.
+    const currency = scope({ name: 'amount', type: 'currency' });
+    const text = scope({ name: 'title', type: 'text' });
+    expect(evaluatePredicate("data.type in ['number','currency','percent']", currency)).toBe(true);
+    expect(evaluatePredicate("data.type in ['text','textarea','email']", currency)).toBe(false);
+    expect(evaluatePredicate("data.type in ['text','textarea','email']", text)).toBe(true);
+    expect(evaluatePredicate("data.type in ['number','currency','percent']", text)).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The literal skew table — the 16 `objectForm` sub-field predicates as spec
+ * 17.0.0-rc.5 spells them, with the Studio sub-field each one gates. Kept as a
+ * literal so the specimen survives a spec bump: it is the shape the issue
+ * measured (16 sub-fields, zero shown, zero diagnostics), not whatever the
+ * installed package happens to carry today.
+ */
+const SKEWED_OBJECT_FORM_PREDICATES: Array<[field: string, source: string]> = [
+  ['maxLength', "type in ['text','textarea','email','url','phone','password','markdown','html','richtext']"],
+  ['minLength', "type in ['text','textarea','email','url','phone','password','markdown','html','richtext']"],
+  ['min', "type in ['number','currency','percent','rating','slider','progress']"],
+  ['max', "type in ['number','currency','percent','rating','slider','progress']"],
+  ['precision', "type in ['number','currency','percent']"],
+  ['scale', "type in ['number','currency','percent']"],
+  ['options', "type in ['select','multiselect','radio','checkboxes']"],
+  ['reference', "type in ['lookup','master_detail','tree']"],
+  ['lookupFilters', "type in ['lookup','master_detail']"],
+  ['deleteBehavior', "type in ['lookup','master_detail']"],
+  ['multiple', "type in ['lookup']"],
+  ['expression', "type == 'formula'"],
+  ['returnType', "type == 'formula'"],
+  ['summaryOperations', "type == 'summary'"],
+  ['autonumberFormat', "type == 'autonumber'"],
+  ['language', "type == 'code'"],
+];
+
+describe('the 16 vanished Studio sub-fields (objectstack#6936 reading)', () => {
+  it('is the specimen the issue measured — 16 predicates', () => {
+    expect(SKEWED_OBJECT_FORM_PREDICATES).toHaveLength(16);
+  });
+
+  it.each(SKEWED_OBJECT_FORM_PREDICATES)('%s is shown again, not silently dropped (%s)', (_field, source) => {
+    // Before this change every one of these returned false for every row type:
+    // `['text',…].includes(undefined)` / `undefined === 'formula'`.
+    expect(evaluatePredicate(source, scope({ name: 'amount', type: 'currency' }))).toBe(true);
+    expect(evaluatePredicate(source, scope({ name: 'title', type: 'text' }))).toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/predicate.ts
+++ b/packages/app-shell/src/views/metadata-admin/predicate.ts
@@ -24,6 +24,62 @@
  *
  * On any parse error → returns `true` (fail-open): better to show a
  * field than to silently hide it.
+ *
+ * ## Unresolvable identifiers also fail OPEN (objectstack#6936)
+ *
+ * The fail-open promise above used to cover only *thrown* errors. A path whose
+ * ROOT identifier does not exist in the evaluation scope took a different route:
+ * `resolveValue` returned `undefined`, and then every comparison quietly judged
+ * it false — `['text','number'].includes(undefined)`, `undefined === 'text'` —
+ * so a predicate referencing a name that isn't there HID the field. Fail-CLOSED,
+ * the exact opposite of what this header promised, and undiagnosable: the
+ * symptom is "the config item is gone", with nothing in the console.
+ *
+ * That is not hypothetical. `@objectstack/spec` ≤ 17.0.0-rc.5 spells the
+ * `objectForm` sub-field predicates bare (`type in ['text',…]`) while this
+ * engine evaluates them against a `{ data: draftRow }` scope, so a frontend
+ * upgraded ahead of its backend resolved `type` to nothing and 16 type-
+ * conditional Studio sub-fields (Min / Max / Precision / Scale / Max Length /
+ * Min Length / reference / deleteBehavior / expression / returnType /
+ * autonumberFormat / language …) vanished at once. objectstack#6254 re-spells
+ * them `data.type`; this evaluator must not turn the version-skew window into
+ * silent feature loss.
+ *
+ * Maintainer ruling on objectstack#6936 (option C): an unresolvable path makes
+ * the predicate evaluate `true`, and dev mode says so, naming the path and the
+ * predicate that carried it.
+ *
+ * ### The boundary this draws — read before widening it
+ *
+ * "Unresolvable" means **the path's root identifier is not a name this scope
+ * declares** (`type`, `record.status`, `page.selectedId` against a scope whose
+ * only name is `data`). It does NOT mean "the value came out undefined":
+ *
+ *   - `data.type == 'text'` on a draft that has no `type` yet → the root `data`
+ *     resolves, the draft simply has no value there. That is a legitimate
+ *     `undefined` VALUE, it compares false, and the field stays hidden. A draft
+ *     is allowed to be empty; treating an unfilled field as "unresolvable"
+ *     would show every type-conditional sub-field at once on a fresh row.
+ *   - `data.tpye == 'text'` — a typo one segment deep — is indistinguishable
+ *     from the above WITHOUT the schema, which this evaluator does not have.
+ *     Catching that is the producer's job (publish-time validation of predicate
+ *     path references, filed separately), not something the renderer may guess
+ *     at. Commandment #0.1: one strict contract at the producer beats a
+ *     renderer heuristic.
+ *
+ * The signal is a thrown {@link UnresolvedPathError}, deliberately not a
+ * sentinel value: fail-open is a property of the WHOLE predicate, not of the
+ * sub-expression that failed. A sentinel would have to be threaded through
+ * `!`, `&&`, `||`, `in` and `==` by hand, and the first spot that missed it
+ * would invert the verdict — `!unresolvedPath` would evaluate the inner path to
+ * "true-ish" and then negate it back to false, i.e. fail-CLOSED again, which is
+ * the bug. Throwing routes every failure to the one fail-open gate that already
+ * exists.
+ *
+ * Two consequences of evaluating in CEL order, both pinned in `predicate.test.ts`:
+ * `false && <unresolvable>` is `false` and `true || <unresolvable>` is `true` —
+ * the unresolvable half is short-circuited away, absorbed exactly as CEL absorbs
+ * an erroring branch, and no warning fires because nothing needed it.
  */
 
 export function evaluatePredicate(
@@ -35,9 +91,57 @@ export function evaluatePredicate(
   if (!source) return true;
   try {
     return evalExpr(source.trim(), ctx);
-  } catch {
+  } catch (err) {
+    // Fail-open either way; an unresolvable path additionally gets a name.
+    if (err instanceof UnresolvedPathError) warnUnresolvedPath(err.path, source);
     return true;
   }
+}
+
+/**
+ * Signalled when a path's root identifier is not a name in the evaluation
+ * scope. Carries the path so the top-level handler can name it alongside the
+ * predicate source (which only the top level knows).
+ */
+class UnresolvedPathError extends Error {
+  constructor(readonly path: string) {
+    super(`unresolved predicate path: ${path}`);
+    this.name = 'UnresolvedPathError';
+  }
+}
+
+// Warn once per (path, predicate) pair, not once per evaluation: these
+// predicates run on every keystroke of the form they gate, and a warning that
+// floods the console is a warning that gets muted. Keyed by the predicate
+// source as well as the path, deliberately — keying on the path alone would
+// report the FIRST predicate referencing `type` and stay silent about the other
+// fifteen, sending the author to fix one row of a systemic problem. Mirrors
+// `warnOnUnknownActionKeys` in `@object-ui/core` (`actions/actionKeys.ts`).
+const warnedUnresolvedPaths = new Set<string>();
+
+/** Reset the warn-once memo. Exported for tests. */
+export function resetPredicateWarnings(): void {
+  warnedUnresolvedPaths.clear();
+}
+
+const isDev = (): boolean =>
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.NODE_ENV !==
+  'production';
+
+function warnUnresolvedPath(path: string, source: string): void {
+  if (!isDev()) return;
+  const memo = `${path}::${source}`;
+  if (warnedUnresolvedPaths.has(memo)) return;
+  warnedUnresolvedPaths.add(memo);
+  const root = path.split('.')[0];
+  console.warn(
+    `[metadata-admin] visibility predicate \`${source}\` references \`${path}\`, but \`${root}\` ` +
+      'is not a name in this form\'s evaluation scope — the only name is `data` (the current draft). ' +
+      'The predicate was treated as TRUE (fail-open) so the field stays visible instead of ' +
+      'disappearing without a trace; check the spelling — draft values are addressed as `data.<field>` ' +
+      '(e.g. `data.type in [...]`). A predicate served by an older backend is the usual cause ' +
+      '(objectstack#6254 re-spelled the bare `objectForm` predicates; objectstack#6936).',
+  );
 }
 
 function evalExpr(
@@ -123,8 +227,18 @@ function resolveValue(
     return parseLiteral(path);
   }
   const segs = path.split('.');
+  // The root identifier must be a name the scope actually declares. `hasOwn`,
+  // not `in`: `constructor`/`toString` are inherited, and resolving them to
+  // `Object`'s members would compare a function against a string literal (false,
+  // silently) instead of reporting a path the author cannot have meant.
+  if (!Object.prototype.hasOwnProperty.call(ctx, segs[0])) {
+    throw new UnresolvedPathError(path);
+  }
   let cur: any = ctx;
   for (const seg of segs) {
+    // A nullish value part-way down is a VALUE fact, not a resolution failure:
+    // `data.config.kind` on a draft with no `config` means the draft has no
+    // value there, which compares false. See the header's boundary note.
     if (cur == null) return undefined;
     cur = cur[seg];
   }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6936

执行维护者裁决 **C 案**（objectstack#6936 评论 5230638168）：metadata-admin 谓词求值器对「解析不到的路径」由静默判假改为 **fail-open 判真 + dev 期告警**。

## 问题

`packages/app-shell/src/views/metadata-admin/predicate.ts` 的文件头一直承诺 fail-open（“on any parse error → returns true: better to show a field than to silently hide it”），但只有**抛错**走到那个 catch。标识符解析不到时走的是另一条路：`resolveValue` 逐段下钻取不到就返回 `undefined`，随后所有比较一律判假 —— `['text','number'].includes(undefined)`、`undefined === 'text'` —— 于是引用了不存在名字的谓词把字段**静默隐藏**。实现是 fail-CLOSED，与自述方向相反，且控制台一片安静。

踩法是版本错配窗口（objectui#3923 已浏览器实测）：`@objectstack/spec` 17.0.0-rc.5 及更早把 `objectForm` 的子字段谓词写成裸拼法（`type in ['text',…]`，共 16 条），而本引擎在 `{ data: draftRow }` 作用域下求值。前端带着 objectstack#6331 的读取器修复、后端仍是旧版时，裸 `type` 解析为空，Studio 对象字段列表里 16 个类型相关子字段（Min / Max / Precision / Scale / Max Length / Min Length / reference / deleteBehavior / expression / returnType / autonumberFormat / language …）对所有行类型**同时消失**，用户看到的症状是「配置项没了」，与权限问题、类型不支持无法区分。

## 改动

- **解析不到的路径 → 谓词判真**，字段照常显示，兑现文件头一直写着的承诺。
- **dev 期告警**，同时点名未解析的路径和承载它的谓词原文；按 (path, predicate) 对 warn-once，参照 `@object-ui/core` 的 `warnOnUnknownActionKeys`。memo 只按 path 记的话，只会报出 16 条里的第一条、对其余十五条保持沉默。

## 语义边界（本 PR 的承重部分）

「解析不到」= **路径的根标识符不是本作用域声明的名字**（`type`、`record.status`、`page.selectedId`，而作用域里唯一的名字是 `data`）。它**不**等于「值算出来是 undefined」：

- `data.type == 'text'` 在还没填 `type` 的草稿上 —— 根 `data` 解析成功，草稿只是那个键上没有值。这是**合法的 undefined 值**，照旧判假、字段照旧隐藏、不告警。草稿允许是空的；把 fail-open 扩大到「任何缺失值」会让一行新建字段一次点亮全部类型相关子字段（本 PR 在渲染层钉了这一条）。
- `data.tpye` 这种深一段的拼写错误，**在没有 schema 的情况下**与「草稿没填」不可区分，而本求值器手上没有 schema。抓它属于生产端发布期校验谓词路径引用（伴生卡，已另立），不是渲染器可以猜的事（Commandment #0.1）。

失败信号用**抛出内部错误**而不是 sentinel 值，理由是 fail-open 是**整条谓词**的属性、不是失败那个子表达式的属性。sentinel 需要人工穿过 `!`、`&&`、`||`、`in`、`==` 逐个传递，第一个漏掉的运算符就会把结论反过来 —— `!unresolvedPath` 会把内层解析成「真」再取反回假，即换条路又回到 fail-CLOSED（这一条已单独钉住）。抛出则把所有失败都路由到本来就存在的那一个 fail-open 出口。

不变且已钉：原有 parse-error fail-open（仍静默 —— 路径解析成功、读取时炸了，是另一个事实）；CEL 顺序的短路吸收（`false && 不可解析` 为假、`true || 不可解析` 为真，都不告警，因为那一半根本没被求值）；CEL 风格的宽松 nullish 相等（空草稿上 `data.type == null` 仍为真）。

## 测试

新增 63 个断言，分两个文件：

- `predicate.test.ts`（求值器层）：①解析不到 → 真 + 告警内容含路径与谓词原文（含 `!` 取反、错误作用域根、继承名 `constructor`、warn-once、同路径不同谓词各报一次）；②解析到且真的不等 → 假、静默；③解析到但值为 undefined/null 的合法比较行为逐一钉住（含嵌套 `data.config.kind`、`== null` 宽松相等）；④原 parse-error fail-open 回归钉（getter 抛错 → 真且**不**借用新告警）；⑤短路吸收；⑥直接从安装版 spec 读 `objectForm` 的谓词做版本错配重现（16 条全裸拼法），外加一张字面量表把 16 条固化下来 —— spec 升到含 objectstack#6254 的版本后裸拼子集会合法地变空，所以「谓词总数大于 0」这条守卫无条件断言，避免整块变成对空集合的绿。
- `SchemaForm.unresolvedPredicate.test.tsx`（渲染层，issue 里 B1/B2 两向读数的复现）：B2 裸拼法下子字段重新出现且控制台有话说；B1 `data.` 拼法仍按行类型区分；未填类型的行仍保持子字段隐藏。

命令与结果：

```
pnpm exec vitest run packages/app-shell/src/views/metadata-admin/ --maxWorkers=2
  Test Files  133 passed (133)
        Tests  1335 passed | 1 skipped (1336)

pnpm exec vitest run packages/app-shell --maxWorkers=2
  Test Files  308 passed (308)
        Tests  2835 passed | 1 skipped (2836)

pnpm exec turbo run type-check --concurrency=2
  Tasks:    78 successful, 78 total
```

**反向验证**（方向先判后跑，预判为常规 Red）：把 `resolveValue` 里新增的抛出那一段去掉后，63 条里 **31 条转红**（fail-open 组 9 条、垃圾表达式 1 条、可达的不可解析一半 1 条、bundled-spec 裸谓词 2 条、16 条字面量表、B2 渲染 2 条），典型失败是 `AssertionError: expected false to be true`；其余 **32 条保持绿**，正好是边界组（解析到判假、合法 undefined、parse-error 回归、短路吸收、B1 渲染）—— 这组保持绿正是它们钉的是**改动前就有**的取值语义、而不是新分支的证明。另外 objectstack#6331 留下的既有断言「both keys absent → shown」（`data.type == 'list'` 对 `{}` 判假隐藏）在本改动下保持绿，如果边界放宽到「任何缺失值」它就会红。

changeset：`@object-ui/app-shell` patch。

⛔ 未折叠伴生卡（发布期校验谓词路径引用，producer 侧），⛔ 未碰 objectstack#5149 的运行时求值器文件，⛔ 未改 objectstack#6331 落地的 `readVisibility` 读取面。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_