### PR TITLE
fix(core): stop double-wrapping an already-`${…}` predicate, so action-face visible/disabled finally honour it (#3871)

### DIFF
--- a/.changeset/predicate-input-template-double-wrap-3871.md
+++ b/.changeset/predicate-input-template-double-wrap-3871.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/core': patch
+---
+
+fix(core): stop re-wrapping an already-`${…}` predicate, so action-face `visible` / `disabled` finally honour it (objectui#3871)
+
+`toPredicateInput` — the one normalizer every action surface and the action
+engine share — wrapped **every** string as `${string}`, assuming a bare
+expression. But `${…}` is a spelling this repo documents for a predicate
+(AGENTS.md §4) and one the normalizer's own output type lists as valid, so an
+already-normalized value was wrapped a second time: `'${x}'` became `'${${x}}'`,
+which cannot match the evaluator's single-template fast path and does not parse.
+The author's expression then decided nothing, and which constant came back
+depended on the caller's error policy:
+
+- **fail-soft** legs (every `disabled` / `enabled` leg; `visible` on
+  `action:icon`, `action:group` and the related-list toolbar) got the unparsed
+  string back, so `Boolean(…)` was a constant `true`: `disabled: '${…}'` greyed
+  the action out permanently, `visible: '${…}'` showed one the author had gated
+  away, and `enabled: '${…}'` never disabled anything.
+- **fail-closed** legs (`throwOnError: true` — `visible` on `action:button`,
+  `action:bar`, `action:menu`, `DeclaredActionsBar`, and
+  `ActionEngine.getActionsForLocation`) got a **throw**, which each site turns
+  into "hidden": an action gated with a template predicate was invisible even
+  while its gate held, and the fail-closed warning blamed the author's
+  expression.
+
+A string that already carries `${` is now returned untouched (the same guard
+covers the envelope branch, where an unwrapped `source` reaches the identical
+wrap), which makes the normalizer idempotent. Every affected surface goes from a
+constant verdict to the predicate's real one — converging the action face with
+`SchemaRenderer` and `page:header`, which read the raw value and have always
+been right about this spelling (objectui#3314's shape). Bare expressions and
+`{ dialect: 'cel' }` envelopes are untouched.
+
+`ActionRunner`'s two execution gates already read the raw value and are
+unchanged; the objectui#3871 tripwires they carried have been replaced by pins
+of the now-converged behaviour.
+
+Whether `${…}` should be *authorable* on an action predicate at all is a
+separate, spec-side question (`@objectstack/spec`'s `PredicateInput` models a
+bare string and a dialect envelope): if it is to be rejected, that belongs in
+publish-time validation, not in a consumer that silently invents a verdict.

--- a/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
+++ b/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
@@ -512,6 +512,28 @@ describe('DeclaredActionsBar — declared `visible` on a server-declared action 
     expect(screen.getByTestId('declared-action-approval_approve')).toBeInTheDocument();
   });
 
+  it('a `${…}`-spelled `visible` keeps its verdict — true shows, false hides (objectui#3871)', () => {
+    // This leg opts into `throwOnError`, so the double wrap did not read as
+    // truthy here: `'${${…}}'` THREW inside the evaluator and `useCondition`'s
+    // fail-closed branch turned that into "hidden". Measured before the fix:
+    // Approve was absent in BOTH halves below, i.e. a server-declared approval
+    // action gated with the documented template spelling was invisible to every
+    // approver even while its gate held. That is the direction objectui#3871's
+    // card did not predict (it expected a constant "shown", which is what the
+    // fail-SOFT legs in `packages/components` did).
+    //
+    // Reverse verification: the `pending` half is the detector; the `approved`
+    // half stays green either way (hidden is hidden), and the companion
+    // assertion is what keeps that half from meaning "the bar vanished".
+    const gated = { ...APPROVE, visible: '${status === "pending"}' };
+    const { unmount } = renderWithGate(gated, { ...REQUEST, status: 'approved' });
+    expect(screen.queryByTestId('declared-action-approval_approve')).toBeNull();
+    expect(screen.getByTestId('declared-action-approval_reassign')).toBeInTheDocument();
+    unmount();
+    renderWithGate(gated, { ...REQUEST, status: 'pending' });
+    expect(screen.getByTestId('declared-action-approval_approve')).toBeInTheDocument();
+  });
+
   it('a hidden action leaves NO clickable surface in the toolbar', async () => {
     // Hiding is not cosmetic on this surface: this component's own click handler
     // is what POSTs the approve/reject call, so what matters is that the gated
@@ -594,6 +616,26 @@ describe('DeclaredActionsBar — declared `disabled` on a server-declared action
 
   it('an expression-valued `disabled` keeps its verdict — true disables, false does not', () => {
     const gated = { ...APPROVE, disabled: 'status == "approved"' };
+    const { unmount } = renderWithGate(gated, { ...REQUEST, status: 'approved' });
+    expect(approve()).toBeDisabled();
+    unmount();
+    renderWithGate(gated, { ...REQUEST, status: 'pending' });
+    expect(approve()).not.toBeDisabled();
+  });
+
+  it('a `${…}`-spelled `disabled` keeps its verdict — false leaves Approve clickable (objectui#3871)', () => {
+    // `toPredicateInput` used to wrap EVERY string, so `'${…}'` — a spelling
+    // AGENTS.md §4 documents and this bar's own `visible` sibling accepts —
+    // became `'${${…}}'`, unparseable, returned verbatim, `Boolean(…)` = a
+    // constant `true`. On THIS key that constant means Approve / Reject greyed
+    // out permanently on a server-declared action, with nothing the metadata
+    // author could write to un-grey it.
+    //
+    // Reverse verification: the `pending` half below is the detector (it was
+    // disabled before the fix); the `approved` half was green already, since
+    // "disabled because the predicate holds" and "disabled because it could not
+    // be parsed" look identical from here.
+    const gated = { ...APPROVE, disabled: '${status === "approved"}' };
     const { unmount } = renderWithGate(gated, { ...REQUEST, status: 'approved' });
     expect(approve()).toBeDisabled();
     unmount();

--- a/packages/components/src/renderers/action/__tests__/action-template-predicate-gate.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-template-predicate-gate.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3871 — the `${…}` predicate spelling on the action face. The action
+ * surfaces compose `useCondition(toPredicateInput(x))`, and `toPredicateInput`
+ * used to wrap EVERY string, so a value already spelled `'${…}'` — the spelling
+ * AGENTS.md §4 documents and the one `SchemaRenderer` / `page:header` have
+ * always honored — became `'${${…}}'`, which the evaluator cannot parse. The
+ * author's expression then decided nothing.
+ *
+ * Before this PR, on this package's five call sites (measured, not assumed):
+ *
+ *   | site / key                          | error policy | `${true}` | `${false}` |
+ *   |-------------------------------------|--------------|-----------|------------|
+ *   | action:button `visible`             | fail-CLOSED  | HIDDEN ✗  | hidden     |
+ *   | action:bar / action:menu `visible`  | fail-CLOSED  | HIDDEN ✗  | hidden     |
+ *   | action:icon / :group `visible`      | fail-soft    | shown     | SHOWN ✗    |
+ *   | any leaf `disabled`                 | fail-soft    | disabled  | DISABLED ✗ |
+ *   | any leaf `enabled` (legacy leg)     | fail-soft    | enabled   | ENABLED ✗  |
+ *
+ * The ✗ cells are the ones the author cannot get out of, and note that the two
+ * polarities are on DIFFERENT rows: a fail-closed `visible` hid an action whose
+ * gate HELD (the double wrap threw, and `useCondition`'s `throwOnError` branch
+ * turns a throw into "hidden"), while every fail-soft leg returned the
+ * unparsed string, i.e. a constant `true`. The issue card predicted constant
+ * true everywhere; that holds for the fail-soft legs only.
+ *
+ * ## Reverse verification (direction predicted per case, before running)
+ *
+ * Restore the unconditional wrap in `toPredicateInput` and each site goes red
+ * on exactly ONE of its two cases — the one whose expected verdict differs from
+ * that site's old constant:
+ *
+ *   • fail-CLOSED `visible` → the `${true}` case (expected shown, was hidden);
+ *     its `${false}` sibling stays green for the wrong reason (hidden either
+ *     way), which is why both are here and labelled.
+ *   • fail-soft `visible` → the `${false}` case (expected hidden, was shown).
+ *   • `disabled` → the `${false}` case (expected clickable, was greyed).
+ *   • `enabled` → the `${false}` case (expected greyed, was clickable).
+ *
+ * Every case carries an ungated companion where the host renders a list, so a
+ * passing "not rendered" can never mean "the host itself vanished".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { PredicateScopeProvider } from '@object-ui/react';
+// Module-scope side-effect imports so the renderers are registered before the
+// first render — the light `dom` project deliberately does not load the
+// `@object-ui/components` graph. Module scope, not a `beforeAll`, per AGENTS.md
+// §测试纪律: the cost lands in the import phase, unbounded by any hook timeout.
+import '../action-button';
+import '../action-icon';
+import '../action-bar';
+import { DropdownActionItem } from '../action-group';
+import { ActionMenuItem } from '../action-menu';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '../../../ui';
+
+const LABEL = 'Act';
+const ACT = { name: 'act', label: LABEL, type: 'script' };
+
+/** `features.locked` is the scope both polarities are driven from. */
+const LOCKED = { features: { locked: true } };
+const UNLOCKED = { features: { locked: false } };
+
+/** The template spelling under test — a single `${…}` template, as authored. */
+const TEMPLATE = '${features.locked === true}';
+
+/** An ungated companion — a passing "not rendered" must not mean "host gone". */
+const COMPANION = { name: 'view', label: 'View', type: 'script' };
+
+function getRenderer(type: string) {
+  const R = ComponentRegistry.get(type);
+  if (!R) throw new Error(`${type} is not registered`);
+  return R;
+}
+
+/** A leaf mounted the way `action:bar` mounts a member: action spread onto `schema`. */
+function mountLeaf(type: string, action: any, scope: Record<string, any>) {
+  const Renderer = getRenderer(type);
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Renderer schema={{ ...action, type, actionType: action.type }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+/** The real `action:group` host — it `.map()`s its own `actions`. */
+function mountInlineGroup(action: any, scope: Record<string, any>) {
+  const Group = getRenderer('action:group');
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Group schema={{ type: 'action:group', display: 'inline', actions: [action, COMPANION] }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+/**
+ * The dropdown leaves, each inside a controlled-open menu so the portal content
+ * mounts deterministically (Radix opens on pointerdown, flaky to synthesize in
+ * happy-dom) — same harness as `action-member-disabled-declared-gate.test.tsx`.
+ */
+function mountInMenu(node: React.ReactNode, scope: Record<string, any>) {
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <DropdownMenu open modal={false}>
+        <DropdownMenuTrigger>menu</DropdownMenuTrigger>
+        <DropdownMenuContent>{node}</DropdownMenuContent>
+      </DropdownMenu>
+    </PredicateScopeProvider>,
+  );
+}
+
+const buttonPresent = () => screen.queryByRole('button', { name: LABEL }) !== null;
+const buttonDisabled = () =>
+  (screen.getByRole('button', { name: LABEL }) as HTMLButtonElement).disabled;
+const iconPresent = () => screen.queryByLabelText(LABEL) !== null;
+const iconDisabled = () => (screen.getByLabelText(LABEL) as HTMLButtonElement).disabled;
+const menuItemPresent = () => screen.queryByText(LABEL) !== null;
+const menuItemDisabled = () => {
+  const item = screen.getByText(LABEL).closest('[role="menuitem"]');
+  if (!item) throw new Error(`no menuitem found for "${LABEL}"`);
+  return item.hasAttribute('data-disabled');
+};
+
+interface Site {
+  id: string;
+  /** `true` when this site opts into `throwOnError` on `visible`. */
+  failClosed: boolean;
+  mount: (action: any, scope: Record<string, any>) => { unmount: () => void };
+  present: () => boolean;
+  disabled: () => boolean;
+}
+
+const SITES: Site[] = [
+  {
+    id: 'action:button',
+    failClosed: true,
+    mount: (a, s) => mountLeaf('action:button', a, s),
+    present: buttonPresent,
+    disabled: buttonDisabled,
+  },
+  {
+    id: 'action:icon',
+    failClosed: false,
+    mount: (a, s) => mountLeaf('action:icon', a, s),
+    present: iconPresent,
+    disabled: iconDisabled,
+  },
+  {
+    id: 'action:group inline member',
+    failClosed: false,
+    mount: mountInlineGroup,
+    present: buttonPresent,
+    disabled: buttonDisabled,
+  },
+  {
+    id: 'action:group dropdown member',
+    failClosed: false,
+    mount: (a, s) => mountInMenu(<DropdownActionItem action={a} index={0} onSelect={() => {}} />, s),
+    present: menuItemPresent,
+    disabled: menuItemDisabled,
+  },
+  {
+    id: 'action:menu member',
+    failClosed: true,
+    mount: (a, s) => mountInMenu(<ActionMenuItem action={a} onExecute={async () => {}} />, s),
+    present: menuItemPresent,
+    disabled: menuItemDisabled,
+  },
+];
+
+describe.each(SITES)('$id — `${…}` template `visible` (objectui#3871)', ({ mount, present, failClosed }) => {
+  // Which of the two cases below detects the defect at THIS site is decided by
+  // its error policy, so the label is derived rather than repeated in prose:
+  // the other case was green before the fix as well, for a reason that has
+  // nothing to do with the predicate.
+  const holdsRole = failClosed ? 'DETECTOR here' : 'anti-mutation guard here';
+  const failsRole = failClosed ? 'was green for the wrong reason' : 'DETECTOR here';
+
+  it(`a template \`visible\` that HOLDS shows the action (${holdsRole})`, () => {
+    // On the fail-closed sites the double wrap THREW, and `useCondition` turns a
+    // throw into "hidden", so this action was invisible whatever its author
+    // wrote — the direction the issue card did not predict.
+    mount({ ...ACT, visible: TEMPLATE }, LOCKED);
+    expect(present()).toBe(true);
+  });
+
+  it(`a template \`visible\` that FAILS hides the action (${failsRole})`, () => {
+    // On the fail-soft sites the wrap came back as a non-empty string, i.e. a
+    // constant `true`, so an action the author gated away was always shown.
+    mount({ ...ACT, visible: TEMPLATE }, UNLOCKED);
+    expect(present()).toBe(false);
+  });
+});
+
+describe.each(SITES)('$id — `${…}` template `disabled` / `enabled` (objectui#3871)', ({ mount, disabled }) => {
+  it('a template `disabled` that HOLDS greys the action out', () => {
+    mount({ ...ACT, disabled: TEMPLATE }, LOCKED);
+    expect(disabled()).toBe(true);
+  });
+
+  it('a template `disabled` that FAILS leaves the action clickable', () => {
+    // THE `disabled` detector: a constant `true` greyed this out permanently,
+    // with nothing the author could write to un-grey it.
+    mount({ ...ACT, disabled: TEMPLATE }, UNLOCKED);
+    expect(disabled()).toBe(false);
+  });
+
+  it('a template `enabled` that FAILS greys the action out (legacy leg)', () => {
+    // The negated leg, so the constant pointed the other way: `enabled: '${…}'`
+    // never disabled anything. Deprecated but still shipped, and it is the only
+    // leg where the defect READ as permissive.
+    mount({ ...ACT, enabled: TEMPLATE }, UNLOCKED);
+    expect(disabled()).toBe(true);
+  });
+
+  it('a template `enabled` that HOLDS leaves the action clickable', () => {
+    mount({ ...ACT, enabled: TEMPLATE }, LOCKED);
+    expect(disabled()).toBe(false);
+  });
+});
+
+/**
+ * The two HOSTS whose own `visible` is a separate call site from their members'
+ * (`action-bar.tsx:117` fail-closed, `action-group.tsx:206` fail-soft). A host
+ * gated away takes its whole toolbar with it, so these are pinned on the
+ * container rather than on a leaf.
+ */
+describe('action:bar host `visible` — `${…}` template (objectui#3871, fail-closed)', () => {
+  const barSchema = (visible: unknown) => ({
+    type: 'action:bar',
+    maxVisible: 10,
+    visible,
+    actions: [{ ...COMPANION, component: 'action:button' }],
+  });
+
+  function renderBar(visible: unknown, scope: Record<string, any>) {
+    const Bar = getRenderer('action:bar');
+    return render(
+      <PredicateScopeProvider scope={scope}>
+        <Bar schema={barSchema(visible) as any} />
+      </PredicateScopeProvider>,
+    );
+  }
+
+  it('a template `visible` that HOLDS renders the bar', () => {
+    renderBar(TEMPLATE, LOCKED);
+    expect(screen.getByText('View')).toBeInTheDocument();
+  });
+
+  it('a template `visible` that FAILS renders no bar', () => {
+    renderBar(TEMPLATE, UNLOCKED);
+    expect(screen.queryByText('View')).toBeNull();
+  });
+});
+
+describe('action:group host `visible` — `${…}` template (objectui#3871, fail-soft)', () => {
+  function renderGroup(visible: unknown, scope: Record<string, any>) {
+    const Group = getRenderer('action:group');
+    return render(
+      <PredicateScopeProvider scope={scope}>
+        <Group schema={{ type: 'action:group', display: 'inline', visible, actions: [COMPANION] } as any} />
+      </PredicateScopeProvider>,
+    );
+  }
+
+  it('a template `visible` that HOLDS renders the group', () => {
+    renderGroup(TEMPLATE, LOCKED);
+    expect(screen.getByText('View')).toBeInTheDocument();
+  });
+
+  it('a template `visible` that FAILS renders no group', () => {
+    renderGroup(TEMPLATE, UNLOCKED);
+    expect(screen.queryByText('View')).toBeNull();
+  });
+});

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -592,27 +592,30 @@ function withIdentityAlias(context: ActionContext): ActionContext {
  *
  * ## Why the gate normalizes but the VERDICT still reads the raw value
  *
- * `evaluateCondition(toPredicateInput(raw))` is NOT interchangeable with
- * `evaluateCondition(raw)` for a string that is ALREADY a `${…}` template:
- * `toPredicateInput` assumes a bare expression and wraps unconditionally, so
- * `'${x}'` becomes `'${${x}}'`, which no longer matches the single-template
- * fast path, fails to parse, and comes back as the original NON-EMPTY STRING —
- * `Boolean(…)` = `true`. A `${…}`-spelled `disabled` predicate evaluated that
- * way is therefore ALWAYS "disabled", whatever it says. Measured on this tree:
- * `disabled: '${user.role === "guest"}'` (false, admin context) → blocked.
- * On `condition` the same trap points the other way — a constant `true` would
- * make every template-spelled `condition` always EXECUTE — so that gate also
- * normalizes only to decide declaredness and evaluates the RAW value, keeping
- * the verdict `ActionRunner.test.ts` has pinned for that spelling all along.
+ * Historically the two were NOT interchangeable for a string already spelled as
+ * a `${…}` template: `toPredicateInput` assumed a bare expression and wrapped
+ * unconditionally, so `'${x}'` became `'${${x}}'`, which no longer matched the
+ * single-template fast path and did not parse — leaving a constant verdict whose
+ * direction was set by the caller's error policy (fail-soft got the unparsed
+ * string back, `Boolean(…)` = `true`; fail-closed got a throw). On `disabled`
+ * that meant "always blocked", on `condition` the opposite ("always execute"),
+ * so both gates here normalize only to decide DECLAREDNESS and evaluate the raw
+ * value. That defect was objectui#3871, fixed at the normalizer: an
+ * already-`${…}` string is now returned untouched, the normalizer is idempotent,
+ * and `evaluateCondition(toPredicateInput(raw))` agrees with
+ * `evaluateCondition(raw)` on every shape these gates accept.
+ *
+ * The gates still read the raw value. Nothing forces the change now that the two
+ * agree, and it would be churn on the execution path rather than a fix — but the
+ * reason has shifted from "must" to "no reason to", so the equality is pinned
+ * next to each gate's suite (`ActionRunner.disabledGate.test.ts` /
+ * `ActionRunner.conditionGate.test.ts`, the two cases that replaced the
+ * objectui#3871 tripwires) instead of being assumed.
  *
  * So the value handed to the evaluator is left exactly as it was. Every
  * non-empty shape — boolean, bare CEL, `${…}` template, `{ dialect, source }`
  * envelope — keeps the verdict it reaches today, and this change can only stop
- * blocking things, never start. The double-wrap itself is a defect of
- * `toPredicateInput`, live at the action renderers and `ActionEngine` (which do
- * compose it that way) and filed separately; `SchemaRenderer` and `page:header`
- * both evaluate the raw value and both pin the correct verdict for that
- * spelling, which is the behaviour preserved here.
+ * blocking things, never start.
  *
  * Scope note: `hasDeclaredVisibilityGate`
  * (`components/renderers/action/visibility-gate.ts`, `!= null && !== ''`) is
@@ -783,9 +786,9 @@ export class ActionRunner {
       // short-circuits booleans, so once the gate asks the right question the
       // verdict needs no boolean branch of its own. See `hasDeclaredPredicate`
       // for the shared "declared?" scope (objectui#3850) and for why the verdict
-      // still reads the RAW value (`toPredicateInput` double-wraps an
-      // already-`${…}` string into a constant true — objectui#3871 — which on
-      // THIS key would mean "always execute").
+      // still reads the RAW value (`toPredicateInput` used to double-wrap an
+      // already-`${…}` string into a constant verdict — objectui#3871, fixed at
+      // the normalizer; on THIS key that constant meant "always execute").
       if (hasDeclaredPredicate(action.condition)) {
         const shouldExecute = this.evaluator.evaluateCondition(action.condition);
         if (!shouldExecute) {
@@ -799,8 +802,9 @@ export class ActionRunner {
       // this key means BLOCKED: `disabled: ''` / `'   '` /
       // `{ dialect: 'cel', source: '' }` all returned `Action is disabled` with
       // the handler never invoked. See `hasDeclaredPredicate` above for why the
-      // gate normalizes to decide but the verdict below still reads the RAW
-      // value (`toPredicateInput` double-wraps an already-`${…}` string).
+      // gate normalizes to decide while the verdict below reads the RAW value
+      // (historically load-bearing: `toPredicateInput` double-wrapped an
+      // already-`${…}` string — objectui#3871, now fixed, so the two agree).
       if (hasDeclaredPredicate(action.disabled)) {
         // `disabled` may be a boolean, a CEL string, or the normalized envelope
         // `{ dialect, source }` (what `objectstack build` emits). The previous

--- a/packages/core/src/actions/__tests__/ActionEngine.visibility.test.ts
+++ b/packages/core/src/actions/__tests__/ActionEngine.visibility.test.ts
@@ -310,4 +310,58 @@ describe('ActionEngine.getActionsForLocation — visibility filter', () => {
     });
   });
 
+  /**
+   * objectui#3871 — the legacy `${…}` spelling on the engine's own filter.
+   *
+   * This filter normalizes with `toPredicateInput` and evaluates with
+   * `throwOnError: true`, so the double wrap did NOT read as truthy here: the
+   * unparseable `'${${…}}'` threw, the `catch` below fail-closed HID the action,
+   * and `warnHiddenPredicate` blamed the author's expression. Measured before
+   * the fix on this tree: BOTH actions below were dropped, including the one
+   * whose predicate holds — the direction the issue card mis-predicted (it
+   * expected a constant "visible" here, which is what the fail-SOFT renderer
+   * legs did).
+   *
+   * Reverse verification: restore the unconditional wrap and `tpl_true` goes red
+   * (it was hidden); `tpl_false` stays green, because "hidden because the
+   * predicate is false" and "hidden because the predicate could not be parsed"
+   * are indistinguishable from the outside. Hence both, and hence the warn
+   * assertion — a fail-closed hide is loud, so its ABSENCE is what separates the
+   * two reasons.
+   */
+  describe('the legacy `${…}` template spelling (objectui#3871)', () => {
+    const OPEN = { record: { status: 'open' } };
+
+    it('evaluates a `${…}` predicate to its real verdict on both polarities', () => {
+      const engine = new ActionEngine(OPEN);
+      engine.registerAction(
+        { name: 'tpl_true', type: 'api', visible: '${record.status === "open"}' } as any,
+        { locations: ['record_section'] },
+      );
+      engine.registerAction(
+        { name: 'tpl_false', type: 'api', visible: '${record.status === "closed"}' } as any,
+        { locations: ['record_section'] },
+      );
+      expect(engine.getActionsForLocation('record_section').map(a => a.name)).toEqual(['tpl_true']);
+    });
+
+    it('drops the false one WITHOUT the fail-closed warning (it is a verdict, not a fault)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const engine = new ActionEngine(OPEN);
+        engine.registerAction(
+          { name: 'tpl_quiet', type: 'api', visible: '${record.status === "closed"}' } as any,
+          { locations: ['record_section'] },
+        );
+        expect(engine.getActionsForLocation('record_section')).toHaveLength(0);
+        // Before the fix this same call warned about `tpl_quiet` — the predicate
+        // faulted rather than answering. A genuine `false` is silent, so this is
+        // the assertion that distinguishes the two ways of being hidden.
+        expect(warn.mock.calls.filter(c => String(c[0]).includes('tpl_quiet'))).toHaveLength(0);
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
 });

--- a/packages/core/src/actions/__tests__/ActionRunner.conditionGate.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.conditionGate.test.ts
@@ -71,8 +71,10 @@
  *      does, so the `evaluateCondition` spy is never called with `false`.
  *
  * The two purely tabular tests (the changed-row set, the truthiness-vs-
- * declaredness table) and both tripwires stay GREEN by construction — they
- * assert about `Boolean` / `toPredicateInput` / the engine, not about the gate —
+ * declaredness table) and the normalizer case below stay GREEN by construction —
+ * they assert about `Boolean` / `toPredicateInput` / the engine, not about the
+ * gate (that case was the objectui#3871 tripwire, replaced by its converged
+ * pin when the normalizer was fixed) —
  * and every other execution row stays GREEN too, including `0`, `{}` and all
  * three empty shapes, because the truthy test and the declaredness test agree on
  * every shape except a declared boolean. That is the whole diff, and it is a TIGHTENING:
@@ -262,20 +264,28 @@ describe('why the `condition` gate cannot ask truthiness (objectui#3872)', () =>
     }
   });
 
-  it('TRIPWIRE (objectui#3871): normalizing the VERDICT would make every template-spelled condition always execute', () => {
+  it('normalizing a `${…}` condition now agrees with the raw value (was objectui#3871)', () => {
+    // Replaces the objectui#3871 TRIPWIRE that stood here. It pinned the defect
+    // — `toPredicateInput('${x}')` was `'${${x}}'`, unparseable, returned
+    // verbatim, `Boolean(…)` = a constant `true`, which on THIS key would have
+    // run every template-spelled `condition` regardless of its verdict — and its
+    // note said the day it went red was the day to delete it and (only then) let
+    // the gate evaluate the normalized value.
+    //
+    // It went red as predicted (PR for objectui#3871), and is replaced rather
+    // than deleted for the reasons written out next to its `disabled` twin in
+    // `ActionRunner.disabledGate.test.ts`: the repaired property (the normalizer
+    // is idempotent, so normalized and raw reach one verdict) is what makes
+    // "normalize to decide, evaluate the raw value" safe, and it should be
+    // pinned beside the gate that relies on it. The gate itself is unchanged.
     const ev = new ExpressionEvaluator(CONTEXT);
     const falsePredicate = '${record.status === "inactive"}';
-    // Raw — the correct verdict, and what this gate evaluates.
     expect(ev.evaluateCondition(falsePredicate)).toBe(false);
-    // Normalized — wrapped a second time, unparseable, returned verbatim, truthy.
-    // On `disabled` this constant `true` blocks everything (PR #3873's tripwire);
-    // on `condition` it does the opposite and RUNS everything, so this key must
-    // keep reading the raw value for the same reason.
-    expect(toPredicateInput(falsePredicate)).toBe('${${record.status === "inactive"}}');
-    expect(ev.evaluateCondition(toPredicateInput(falsePredicate) as never)).toBe(true);
-    // When objectui#3871 is fixed this goes RED on the last two expectations —
-    // the signal to delete this tripwire and (only then) let the gate evaluate
-    // the normalized value.
+    expect(toPredicateInput(falsePredicate)).toBe(falsePredicate);
+    expect(ev.evaluateCondition(toPredicateInput(falsePredicate) as never)).toBe(false);
+    const truePredicate = '${record.status === "active"}';
+    expect(ev.evaluateCondition(truePredicate)).toBe(true);
+    expect(ev.evaluateCondition(toPredicateInput(truePredicate) as never)).toBe(true);
   });
 
   it('DOCUMENTED DIVERGENCE: the engine `visible` filter coerces junk, this gate does not', () => {

--- a/packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts
@@ -43,7 +43,7 @@
  *     = false }`): a value that is not a predicate at all must not decide that
  *     an action is disabled.
  *
- * ## The parity claim, and the two rows it deliberately does NOT make
+ * ## The parity claim, and the one row it deliberately does NOT make
  *
  * `rendererDisabled` is transcribed from objectui#3848's divergence table (the
  * action face as it stands after #3842 + #3849), NOT recomputed here:
@@ -52,7 +52,7 @@
  * parity test below therefore asserts that the verdicts THIS suite pins equal
  * the verdicts recorded from the renderers — the #3314 invariant (one predicate
  * value, one answer, whichever entry reads it) — for every row where that claim
- * is honest. Two rows are excluded, each with its owning issue:
+ * is honest. ONE row is excluded, with its owning issue:
  *
  *   • `{ dialect: 'cel', source: '' }` — the renderer still greys this out
  *     (`hasDeclaredVisibilityGate` is `!= null && !== ''`, which an envelope
@@ -60,12 +60,20 @@
  *     "empty predicate" is across the sites; the execution side pins the
  *     normalized semantics (an envelope with no source is nothing to evaluate).
  *     Not fixed here — objectui#3850 owns the renderer half.
- *   • a `${…}`-spelled predicate — the action-face renderers compose
- *     `evaluateCondition(toPredicateInput(x))`, which double-wraps an
- *     already-templated string into `'${${x}}'` and comes back TRUE whatever the
- *     expression says. That is objectui#3871. The execution path keeps reading
- *     the RAW value and therefore keeps the correct verdict — the same verdict
- *     `SchemaRenderer` and `page:header` already pin for that spelling.
+ *
+ * The two `${…}`-spelled rows used to be excluded as well, and no longer are.
+ * The action-face renderers compose `evaluateCondition(toPredicateInput(x))`,
+ * and `toPredicateInput` double-wrapped an already-templated string into
+ * `'${${x}}'`, so the renderer verdict was a CONSTANT unrelated to the
+ * expression — that is objectui#3871, fixed at the normalizer. The renderer face
+ * now reaches the verdicts this suite pins, so both rows claim parity, each
+ * backed by a live renderer-side pin rather than transcription alone:
+ * `packages/components/src/renderers/action/__tests__/action-template-predicate-gate.test.tsx`
+ * (five leaves + two hosts), the `${…}` cases in
+ * `packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx`, and
+ * `packages/plugin-detail/src/renderers/__tests__/record-quick-actions.template-predicate.test.tsx`.
+ * The execution path still reads the RAW value, untouched by that fix — what
+ * changed is that normalizing no longer disagrees with it.
  *
  * ## Reverse verification (direction predicted before running)
  *
@@ -144,23 +152,23 @@ const SHAPES: Shape[] = [
     blocked: false,
     rendererDisabled: false,
   },
+  // Parity claimed since objectui#3871 fixed the normalizer's double wrap; the
+  // renderer face now answers by the expression, as this side always did.
   {
     label: 'disabled: legacy template that is true',
     disabled: '${user.role === "admin"}',
     blocked: true,
-    rendererDisabled: null,
-    divergence: 'objectui#3871 — the renderers double-wrap a template-spelled predicate into a constant true',
+    rendererDisabled: true,
   },
   {
     label: 'disabled: legacy template that is false',
     disabled: '${user.role === "guest"}',
     blocked: false,
-    rendererDisabled: null,
-    divergence: 'objectui#3871 — same double-wrap; here it is the row where the constant true is WRONG',
+    rendererDisabled: false,
   },
   // ── behaviour change: non-predicate junk fails open ─────────────────────
-  { label: 'disabled: 0 (not a predicate)', disabled: 0, blocked: false, rendererDisabled: null, divergence: 'objectui#3871 family — the renderers coerce junk through the same compose' },
-  { label: 'disabled: {} (not a predicate)', disabled: {}, blocked: false, rendererDisabled: null, divergence: 'objectui#3871 family — the renderers coerce junk through the same compose' },
+  { label: 'disabled: 0 (not a predicate)', disabled: 0, blocked: false, rendererDisabled: null, divergence: 'objectui#3850 — the renderers read a non-predicate as a declared gate and coerce it' },
+  { label: 'disabled: {} (not a predicate)', disabled: {}, blocked: false, rendererDisabled: null, divergence: 'objectui#3850 — the renderers read a non-predicate as a declared gate and coerce it' },
 ];
 
 /** Execute one shape and report whether the handler ran. */
@@ -204,8 +212,10 @@ describe('ActionRunner.execute — declared `disabled` gate (objectui#3848)', ()
   it('the execution verdict equals the renderer verdict for every shape where parity is claimed', () => {
     const claimed = SHAPES.filter(s => s.rendererDisabled !== null);
     // Guard the guard: if a future edit nulls out the whole column, this test
-    // would pass by asserting nothing.
-    expect(claimed.length).toBeGreaterThanOrEqual(8);
+    // would pass by asserting nothing. Raised from 8 to 10 when objectui#3871
+    // brought the two `${…}` rows into the claim — a floor that does not move
+    // with the table is a floor that stops guarding it.
+    expect(claimed.length).toBeGreaterThanOrEqual(10);
     for (const shape of claimed) {
       expect(
         shape.blocked,
@@ -219,10 +229,12 @@ describe('ActionRunner.execute — declared `disabled` gate (objectui#3848)', ()
     for (const shape of divergent) {
       expect(shape.divergence, `${shape.label} must name the issue that owns it`).toMatch(/objectui#\d+/);
     }
+    // The two `${…}` rows left this list when objectui#3871 was fixed — the
+    // renderer face stopped answering with a constant, so there is no longer a
+    // difference to own. What remains is one family: the renderer's "is a gate
+    // DECLARED?" scope, which objectui#3850 owns for all three shapes.
     expect(divergent.map(s => s.label)).toEqual([
       "disabled: { dialect: 'cel', source: '' } (empty envelope)",
-      'disabled: legacy template that is true',
-      'disabled: legacy template that is false',
       'disabled: 0 (not a predicate)',
       'disabled: {} (not a predicate)',
     ]);
@@ -250,17 +262,36 @@ describe('why the gate cannot delegate "is there a condition?" to the verdict (o
     expect(toPredicateInput('   ')).toBe('${   }');
   });
 
-  it('TRIPWIRE (objectui#3871): toPredicateInput double-wraps an already-`${…}` string into a constant true', () => {
+  it('normalizing a `${…}` predicate now agrees with the raw value (was objectui#3871)', () => {
+    // This case replaces the objectui#3871 TRIPWIRE that stood here. The
+    // tripwire pinned the defect — `toPredicateInput('${x}')` was `'${${x}}'`,
+    // unparseable, returned verbatim, `Boolean(…)` = a constant `true` — and its
+    // note said the day it went red was the day to delete it and (only then) let
+    // this gate evaluate the normalized value.
+    //
+    // It went red as predicted (PR for objectui#3871). It is REPLACED rather
+    // than deleted, and this gate still reads the raw value, for two reasons:
+    //
+    //   1. deleting it would leave the repaired property — the normalizer is
+    //      idempotent, so normalized and raw reach one verdict — pinned nowhere
+    //      near the gate that depends on it. A regression to the old wrap would
+    //      then be caught only by the producer-side suite, and the reader here
+    //      would have no way to see why "normalize to decide, evaluate the raw
+    //      value" is still safe;
+    //   2. switching the gate to evaluate the normalized value is a change to
+    //      landed objectui#3848 / objectui#3872 semantics with no defect behind
+    //      it: raw and normalized now agree on every shape in the table above,
+    //      so the switch would be pure churn on the execution path. The
+    //      permission its note granted is not an obligation.
     const ev = new ExpressionEvaluator(CONTEXT);
     const falsePredicate = '${user.role === "guest"}';
-    // Raw — the correct verdict, and what this gate evaluates.
     expect(ev.evaluateCondition(falsePredicate)).toBe(false);
-    // Normalized — wrapped a second time, unparseable, returned verbatim, truthy.
-    expect(toPredicateInput(falsePredicate)).toBe('${${user.role === "guest"}}');
-    expect(ev.evaluateCondition(toPredicateInput(falsePredicate) as never)).toBe(true);
-    // When objectui#3871 is fixed this case goes RED on the last two
-    // expectations. That is the signal to delete this tripwire and (only then)
-    // let the gate evaluate the normalized value, which is what objectui#3848's
-    // dispatch originally proposed.
+    expect(toPredicateInput(falsePredicate)).toBe(falsePredicate);
+    expect(ev.evaluateCondition(toPredicateInput(falsePredicate) as never)).toBe(false);
+    // And the other polarity, which is what the double wrap was hiding on the
+    // fail-closed `visible` legs (there it threw rather than reading as true).
+    const truePredicate = '${user.role === "admin"}';
+    expect(ev.evaluateCondition(truePredicate)).toBe(true);
+    expect(ev.evaluateCondition(toPredicateInput(truePredicate) as never)).toBe(true);
   });
 });

--- a/packages/core/src/evaluator/__tests__/predicateInput.test.ts
+++ b/packages/core/src/evaluator/__tests__/predicateInput.test.ts
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3871 — `toPredicateInput` must not re-wrap a string that is ALREADY
+ * a `${…}` template. This is the producer-side pin for the defect; the
+ * consumer-side ones live at the seven action surfaces that compose
+ * `evaluateCondition(toPredicateInput(x))` (see the PR's call-site table).
+ *
+ * ## The defect, measured on `origin/main` @ 230ffd875 before the fix
+ *
+ * `'${x}'` was wrapped into `'${${x}}'`, which cannot match the evaluator's
+ * single-template fast path (`/^\$\{([^}]+)\}$/`, whose `[^}]+` stops at the
+ * inner `}`), so it fell to the global replace, where the inner expression
+ * `'${x'` does not parse. The author's predicate was then never consulted, and
+ * WHICH constant came back depended on the caller's error policy — both
+ * directions measured with one probe, same context, same predicate:
+ *
+ *   template TRUE  | norm="${${user.role === \"admin\"}}" | raw=true  | fail-soft=true | throwOnError=THREW
+ *   template FALSE | norm="${${user.role === \"guest\"}}" | raw=false | fail-soft=true | throwOnError=THREW
+ *   bare FALSE     | norm="${user.role == \"guest\"}"     | raw=false | fail-soft=false| throwOnError=false
+ *
+ * So fail-soft callers (`disabled` / `enabled`, and the `visible` legs that do
+ * not opt into `throwOnError`) got a constant `true`, and fail-CLOSED callers
+ * (`visible` on `action:button` / `action:bar` / `action:menu` /
+ * `DeclaredActionsBar`, plus `ActionEngine.getActionsForLocation`) got a throw
+ * they turn into a constant "hidden". The issue card predicted constant-true
+ * everywhere; the throw direction is the correction this suite pins, because it
+ * is the one that hides an action whose predicate HOLDS.
+ *
+ * ## What each case detects (reverse verification, direction per case)
+ *
+ * Restore the unconditional wrap and:
+ *   • every `toPredicateInput` shape case on a `${…}` input goes RED — they
+ *     assert the normalizer's output directly, so neither error policy can
+ *     mask them;
+ *   • of the verdict cases, the ones whose predicate is TRUE go red under
+ *     `throwOnError` and the ones whose predicate is FALSE go red fail-soft.
+ *     Both polarities are therefore present on purpose: a suite carrying only
+ *     `${false}` cases would have stayed green on the fail-closed sites for the
+ *     wrong reason (hidden is hidden, whatever the reason).
+ * The bare-expression cases stay GREEN in both directions — the wrap they rely
+ * on is untouched, which is the other half of the claim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toPredicateInput } from '../predicateInput';
+import { ExpressionEvaluator } from '../ExpressionEvaluator';
+
+const CONTEXT = { user: { role: 'admin' }, record: { status: 'active' } };
+
+const TEMPLATE_TRUE = '${user.role === "admin"}';
+const TEMPLATE_FALSE = '${user.role === "guest"}';
+
+describe('toPredicateInput — a bare expression is wrapped (unchanged)', () => {
+  it('wraps a bare expression as a `${…}` template', () => {
+    expect(toPredicateInput('data.age >= 18')).toBe('${data.age >= 18}');
+  });
+
+  it('wraps a bare `source` out of a non-cel envelope', () => {
+    expect(toPredicateInput({ dialect: 'template', source: 'data.age >= 18' }))
+      .toBe('${data.age >= 18}');
+  });
+
+  it('passes a cel envelope through intact (#2661 / #3314)', () => {
+    expect(toPredicateInput({ dialect: 'cel', source: 'record.x == 1' }))
+      .toEqual({ dialect: 'cel', source: 'record.x == 1' });
+  });
+
+  it('keeps the empty / boolean shapes exactly as they were', () => {
+    expect(toPredicateInput(true)).toBe(true);
+    expect(toPredicateInput(false)).toBe(false);
+    expect(toPredicateInput('')).toBeUndefined();
+    expect(toPredicateInput(null)).toBeUndefined();
+    expect(toPredicateInput(undefined)).toBeUndefined();
+    expect(toPredicateInput({ dialect: 'cel', source: '' })).toBeUndefined();
+    expect(toPredicateInput('   ')).toBe('${   }');
+    expect(toPredicateInput(0)).toBeUndefined();
+    expect(toPredicateInput({})).toBeUndefined();
+  });
+});
+
+describe('toPredicateInput — an already-`${…}` string is already normalized (objectui#3871)', () => {
+  it('returns a single-template string untouched instead of double-wrapping it', () => {
+    expect(toPredicateInput(TEMPLATE_FALSE)).toBe(TEMPLATE_FALSE);
+    expect(toPredicateInput(TEMPLATE_TRUE)).toBe(TEMPLATE_TRUE);
+  });
+
+  it('is idempotent — normalizing twice is normalizing once', () => {
+    // The property that makes the normalizer safe to compose. Every action
+    // surface calls it on a value it did not produce, and `${…}` is one of the
+    // shapes it produces, so a non-idempotent normalizer corrupts its own
+    // output the moment two call sites are chained.
+    const once = toPredicateInput('data.age >= 18');
+    expect(toPredicateInput(once)).toBe(once);
+    expect(toPredicateInput(toPredicateInput(TEMPLATE_TRUE))).toBe(TEMPLATE_TRUE);
+  });
+
+  it('applies the same rule to a template-dialect envelope whose source is a template', () => {
+    // The sibling spelling, one line away in the same function: the envelope
+    // branch unwraps `source` and reaches the identical wrap.
+    expect(toPredicateInput({ dialect: 'template', source: TEMPLATE_FALSE })).toBe(TEMPLATE_FALSE);
+    expect(toPredicateInput({ source: TEMPLATE_TRUE })).toBe(TEMPLATE_TRUE);
+  });
+
+  it('leaves a multi-part template alone rather than nesting it', () => {
+    // Not a predicate in any spelling (`Boolean('a 1 b')` was true before and is
+    // true now — no verdict claim is made here). What IS pinned is that the
+    // normalizer stops corrupting a string the evaluator can still read, which
+    // is why the guard asks `includes('${')` and not an anchored full match.
+    expect(toPredicateInput('a ${record.status} b')).toBe('a ${record.status} b');
+  });
+});
+
+describe('the normalized verdict now equals the raw verdict (objectui#3871)', () => {
+  const ev = new ExpressionEvaluator(CONTEXT);
+
+  /** The fail-soft policy: every `disabled` / `enabled` leg, and 3 `visible` legs. */
+  const softVerdict = (v: unknown) => ev.evaluateCondition(toPredicateInput(v) as never);
+
+  /**
+   * The fail-closed policy (`throwOnError: true`): `visible` on `action:button`
+   * / `action:bar` / `action:menu` / `DeclaredActionsBar`, and
+   * `ActionEngine.getActionsForLocation`. Their own `catch` turns a throw into
+   * "hidden", so a throw here IS the constant those sites served.
+   */
+  const closedVerdict = (v: unknown) => {
+    try {
+      return ev.evaluateCondition(toPredicateInput(v) as never, { throwOnError: true });
+    } catch {
+      return 'THREW';
+    }
+  };
+
+  const CASES: { what: string; value: unknown; expected: boolean }[] = [
+    { what: 'template that holds', value: TEMPLATE_TRUE, expected: true },
+    { what: 'template that fails', value: TEMPLATE_FALSE, expected: false },
+    { what: 'bare expression that holds', value: 'user.role == "admin"', expected: true },
+    { what: 'bare expression that fails', value: 'user.role == "guest"', expected: false },
+    { what: 'template-dialect envelope over a template that fails', value: { dialect: 'template', source: TEMPLATE_FALSE }, expected: false },
+    { what: 'cel envelope that fails', value: { dialect: 'cel', source: 'record.status == "closed"' }, expected: false },
+    { what: 'cel envelope that holds', value: { dialect: 'cel', source: 'record.status == "active"' }, expected: true },
+  ];
+
+  it.each(CASES)('$what — same verdict raw, fail-soft and fail-closed', ({ value, expected }) => {
+    // The raw value is what `SchemaRenderer`, `page:header` and
+    // `ActionRunner`'s two execution gates evaluate; the normalized value is
+    // what the seven action surfaces evaluate. objectui#3871 is the record of
+    // those two answering differently for one spelling (#3314's shape), so the
+    // pin is that all three columns agree.
+    expect(ev.evaluateCondition(value as never)).toBe(expected);
+    expect(softVerdict(value)).toBe(expected);
+    expect(closedVerdict(value)).toBe(expected);
+  });
+
+  it('a `${…}` predicate no longer throws on the fail-closed path', () => {
+    // Named separately because it is the correction to the issue card's
+    // "always visible" prediction: on the five fail-closed sites the double
+    // wrap did not read as `true`, it THREW, and each of those sites turns a
+    // throw into "hidden" — an action the author gated with a template was
+    // invisible even when the gate held.
+    expect(() => ev.evaluateCondition(toPredicateInput(TEMPLATE_TRUE) as never, { throwOnError: true }))
+      .not.toThrow();
+    expect(closedVerdict(TEMPLATE_TRUE)).toBe(true);
+  });
+});

--- a/packages/core/src/evaluator/predicateInput.ts
+++ b/packages/core/src/evaluator/predicateInput.ts
@@ -41,13 +41,25 @@ export type EvaluatorPredicateInput =
   | undefined;
 
 /**
+ * Wrap a BARE expression as a `${…}` template, and leave a string that already
+ * carries template syntax alone (objectui#3871 — rationale in
+ * {@link toPredicateInput}'s doc below). One rule, so the two string spellings
+ * inside the normalizer cannot drift apart.
+ */
+function wrapIfBare(expression: string): string {
+  return expression.includes('${') ? expression : `\${${expression}}`;
+}
+
+/**
  * Normalize a schema-supplied predicate (`visible` / `enabled` / `disabled` /
  * `hidden`) into the form {@link ExpressionEvaluator.evaluateCondition}
  * expects.
  *
  * Accepts:
  *   - `boolean` → returned as-is (predicate evaluation short-circuits).
- *   - `string`  → wrapped as `${string}` (legacy DX shorthand).
+ *   - `string`  → a BARE expression is wrapped as `${string}` (legacy DX
+ *     shorthand); a string that is already a `${…}` template is ALREADY in the
+ *     normalized shape and is returned untouched (objectui#3871, below).
  *   - `Expression` envelope `{ dialect, source }` (the normalized form
  *     `@objectstack/spec`'s `ExpressionInputSchema` produces for every
  *     authored predicate, including bare strings) → a `cel` dialect keeps
@@ -76,8 +88,54 @@ export type EvaluatorPredicateInput =
  * site. `@object-ui/react`'s `toPredicateInput` is a re-export of this function
  * (since #3367; it used to be an independent twin held in step by a 14-shape
  * normalization parity table, which is exactly the arrangement the paragraph
- * above describes the failure mode of). What pins that now is the identity
- * assertion in
+ * above describes the failure mode of).
+ *
+ * ## Why an already-`${…}` string is NOT wrapped again (objectui#3871)
+ *
+ * `${…}` is one of the spellings this repo documents for a predicate
+ * (AGENTS.md §4: `hidden?: string; // expression: "${data.role != 'admin'}"`)
+ * AND one of the shapes {@link EvaluatorPredicateInput} lists as a normalized
+ * OUTPUT. Wrapping unconditionally therefore corrupted every value that was
+ * already normalized: `'${x}'` became `'${${x}}'`, which no longer matches
+ * `ExpressionEvaluator`'s single-template fast path (`/^\$\{([^}]+)\}$/` —
+ * `[^}]+` cannot cross the inner `}`), so it fell to the global replace, whose
+ * inner expression `'${x'` does not parse. The verdict then stopped depending
+ * on the predicate at all, in a direction set by the CALLER's error policy:
+ *
+ *   - fail-soft callers (every `disabled` / `enabled` leg, and the `visible`
+ *     legs of `action:group` / `action:icon` / `RelatedList`) got the original
+ *     non-empty string back from the evaluator's `catch { return match }`, so
+ *     `Boolean(…)` was a constant `true` — `disabled` greyed out forever,
+ *     `visible` shown forever, `enabled` never disabling.
+ *   - fail-closed callers (`throwOnError: true` — `action:button` / `action:bar`
+ *     / `action:menu` / `DeclaredActionsBar` `visible`, and
+ *     `ActionEngine.getActionsForLocation`) got a THROW, so the constant was
+ *     the other one: the action was hidden forever, including when its
+ *     predicate held.
+ *
+ * Either way the author's expression was never consulted. The guard is
+ * `includes('${')` — "does this string already carry template syntax", the
+ * same question `evaluateCondition` itself asks before choosing the template
+ * path — not an anchored full match: a multi-part string like `'a ${x} b'` is
+ * not a predicate in any spelling, and wrapping it produced the same constant
+ * verdict, so the narrower guard would buy nothing and would still corrupt a
+ * value the evaluator can read.
+ *
+ * The same guard covers the envelope branch below, where the unwrapped
+ * `source` reaches the identical wrap one line later. It is one defect with two
+ * spellings, and `{ dialect: 'template', source: '${x}' }` is the shape a
+ * producer that compiles an authored template emits. A bare `source` (what
+ * `@objectstack/spec`'s `ExpressionInputSchema` produces today, pinned in
+ * `packages/react/src/hooks/__tests__/useExpression.test.ts`) is unaffected.
+ *
+ * What this does NOT do is decide whether `${…}` SHOULD be authorable on an
+ * action predicate: `@objectstack/spec`'s `PredicateInput` models a bare string
+ * and a dialect envelope, not the template spelling. Rejecting it loudly at
+ * publish time is a spec-side ruling (deferred to the objectstack seat by the
+ * objectui#3871 dispatch); until then this normalizer must not silently invent
+ * a verdict for a spelling both the docs and this file's own output type bless.
+ *
+ * What pins the single implementation is the identity assertion in
  * `packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx` — the
  * react export must BE this function object — alongside the engine-path vs
  * renderer-path verdict parity suite in the same file, which is a separate
@@ -87,7 +145,7 @@ export type EvaluatorPredicateInput =
 export function toPredicateInput(value: unknown): EvaluatorPredicateInput {
   if (value === null || value === undefined || value === '') return undefined;
   if (typeof value === 'boolean') return value;
-  if (typeof value === 'string') return `\${${value}}`;
+  if (typeof value === 'string') return wrapIfBare(value);
   if (typeof value === 'object' && typeof (value as { source?: unknown }).source === 'string') {
     const src = (value as { source: string }).source;
     if (!src) return undefined;
@@ -96,7 +154,7 @@ export function toPredicateInput(value: unknown): EvaluatorPredicateInput {
     // server) instead of collapsing it onto the legacy JS path.
     if ((value as { dialect?: unknown }).dialect === 'cel') return { dialect: 'cel', source: src };
     // Every other dialect (template / unset) keeps the legacy `${…}` behavior.
-    return `\${${src}}`;
+    return wrapIfBare(src);
   }
   return undefined;
 }

--- a/packages/plugin-detail/src/__tests__/related-toolbar-visible.test.tsx
+++ b/packages/plugin-detail/src/__tests__/related-toolbar-visible.test.tsx
@@ -54,3 +54,35 @@ describe('RelatedList list_toolbar button — visible CEL', () => {
     expect(screen.getByTestId('related-toolbar-action-export')).toBeInTheDocument();
   });
 });
+
+/**
+ * objectui#3871 — the same gate, with the predicate written in the documented
+ * `${…}` template spelling. This leg does NOT opt into `throwOnError`, so the
+ * double wrap came back from the evaluator as the unparsed string and
+ * `Boolean(…)` read it as a constant `true`: the toolbar action was shown
+ * whatever its predicate said. `invite_user` is the live example in the prose
+ * above — spelled as a template it would have appeared with the org feature off.
+ *
+ * Reverse verification: restore the unconditional wrap and the "false hides"
+ * case goes red; the "true shows" case was green already (shown either way), so
+ * both are here and only one is the detector.
+ */
+describe('RelatedList list_toolbar button — `${…}` template `visible` (objectui#3871)', () => {
+  const TEMPLATE = '${features.organization !== false}';
+
+  it('hides a toolbar action whose template predicate is false (DETECTOR)', () => {
+    renderButton(
+      { name: 'invite_user', label: 'Invite User', visible: TEMPLATE },
+      { features: { organization: false } },
+    );
+    expect(screen.queryByTestId('related-toolbar-action-invite_user')).toBeNull();
+  });
+
+  it('shows a toolbar action whose template predicate is true', () => {
+    renderButton(
+      { name: 'invite_user', label: 'Invite User', visible: TEMPLATE },
+      { features: { organization: true } },
+    );
+    expect(screen.getByTestId('related-toolbar-action-invite_user')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.template-predicate.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.template-predicate.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3871 — the `${…}` predicate spelling on `record:quick_actions`.
+ *
+ * This surface is the one place where BOTH halves of the defect are observable
+ * in one mount: the actions are surfaced through
+ * `ActionEngine.getActionsForLocation` (which normalizes `visible` and
+ * evaluates it fail-CLOSED) and each button's `disabled` is evaluated by the
+ * renderer fail-SOFT. The double wrap therefore produced two opposite constants
+ * on the same component:
+ *
+ *   visible: '${…}'   → the predicate threw → the engine's catch HID the action
+ *                       (even when it held) — measured before the fix: the
+ *                       button was absent for both polarities.
+ *   disabled: '${…}'  → the unparsed string came back → `Boolean` = constant
+ *                       `true` → greyed out forever.
+ *
+ * ## Reverse verification (direction predicted before running)
+ *
+ * Restore the unconditional wrap in `toPredicateInput` and exactly the two
+ * "the predicate should have let it through" cases go red — `visible` that
+ * HOLDS (was hidden) and `disabled` that FAILS (was greyed). Their siblings
+ * stay green: a hidden action and a greyed button look the same whether the
+ * reason is the author's verdict or an unparseable predicate, which is why both
+ * polarities are pinned and labelled rather than just the failing one.
+ *
+ * The `disabled`-gate suite next door (`record-quick-actions.disabled-declared-
+ * gate.test.tsx`, objectui#3849) covers the empty/boolean/bare-expression
+ * shapes on this surface; this file adds only the template spelling.
+ */
+
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordQuickActionsRenderer } from '../record-quick-actions';
+
+const LABEL = 'Act';
+/** `locations` is not defaulted — `getActionsForLocation` requires the match. */
+const ACT = { name: 'act', label: LABEL, type: 'script', locations: ['record_header'] };
+
+function mount(action: any, record: Record<string, unknown> = {}) {
+  return render(
+    <RecordContextProvider
+      objectName="crm_account"
+      recordId="rec-1"
+      data={{ id: 'rec-1', ...record }}
+    >
+      <RecordQuickActionsRenderer schema={{ actions: [action] } as any} />
+    </RecordContextProvider>,
+  );
+}
+
+const present = () => screen.queryByRole('button', { name: LABEL }) !== null;
+const isDisabled = () =>
+  (screen.getByRole('button', { name: LABEL }) as HTMLButtonElement).disabled;
+
+describe('record:quick_actions — `${…}` template `visible` (objectui#3871, fail-closed via the engine)', () => {
+  const gated = { ...ACT, visible: '${record.status === "open"}' };
+
+  it('a template `visible` that HOLDS renders the quick action (DETECTOR)', () => {
+    mount(gated, { status: 'open' });
+    expect(present()).toBe(true);
+  });
+
+  it('a template `visible` that FAILS hides it (green before the fix, for the wrong reason)', () => {
+    mount(gated, { status: 'closed' });
+    expect(present()).toBe(false);
+  });
+});
+
+describe('record:quick_actions — `${…}` template `disabled` (objectui#3871, fail-soft in the renderer)', () => {
+  const gated = { ...ACT, disabled: '${record.status === "closed"}' };
+
+  it('a template `disabled` that FAILS leaves the quick action clickable (DETECTOR)', () => {
+    mount(gated, { status: 'open' });
+    expect(isDisabled()).toBe(false);
+  });
+
+  it('a template `disabled` that HOLDS greys it out (green before the fix, for the wrong reason)', () => {
+    mount(gated, { status: 'closed' });
+    expect(isDisabled()).toBe(true);
+  });
+});

--- a/packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx
+++ b/packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx
@@ -130,6 +130,22 @@ describe('action `visible` — engine path vs renderer path parity (#3314)', () 
       visible: { dialect: 'cel', source: 'record.status == "closed"' },
       expected: false,
     },
+    // objectui#3871 — the legacy `${…}` spelling. Both paths normalize with
+    // `toPredicateInput` and both opt into `throwOnError`, so the double wrap
+    // made them agree on a constant "hidden": this table was GREEN for the
+    // `false` row and could only have caught the defect on the `true` row,
+    // which is why that row is the one added first. Parity was never the
+    // question here — the shared verdict was simply wrong on both paths.
+    {
+      what: 'legacy `${…}` template that holds → shown on both paths',
+      visible: '${record.status === "open"}',
+      expected: true,
+    },
+    {
+      what: 'legacy `${…}` template that fails → hidden on both paths',
+      visible: '${record.status === "closed"}',
+      expected: false,
+    },
     { what: 'literal true', visible: true, expected: true },
     { what: 'literal false', visible: false, expected: false },
     { what: 'absent predicate', visible: undefined, expected: true },

--- a/packages/react/src/hooks/__tests__/useExpression.test.ts
+++ b/packages/react/src/hooks/__tests__/useExpression.test.ts
@@ -197,6 +197,23 @@ describe('toPredicateInput — CEL envelope preservation (#2661)', () => {
     expect(toPredicateInput('')).toBeUndefined();
     expect(toPredicateInput({ dialect: 'cel', source: '' })).toBeUndefined();
   });
+
+  it('does NOT re-wrap a string that is already a `${…}` template (objectui#3871)', () => {
+    // Through the react export, because that is the name every renderer calls.
+    // Wrapping twice produced `'${${…}}'`, which the evaluator cannot parse, so
+    // the action-face verdict stopped depending on the predicate — constant
+    // `true` on the fail-soft legs, a throw (→ constant "hidden") on the
+    // `throwOnError` ones. Full shape + verdict coverage lives next to the
+    // implementation, in `packages/core/src/evaluator/__tests__/predicateInput.test.ts`.
+    expect(toPredicateInput('${data.age >= 18}')).toBe('${data.age >= 18}');
+  });
+
+  it('evaluates a `${…}`-spelled predicate to its real verdict (objectui#3871)', () => {
+    const { result } = renderHook(() =>
+      useCondition(toPredicateInput('${record.status === "closed"}'), { record: { status: 'open' } }),
+    );
+    expect(result.current).toBe(false);
+  });
 });
 
 describe('useCondition — CEL envelope routes to the canonical engine (#2661)', () => {


### PR DESCRIPTION
Fixes #3871

## 机理与修法(A 案,PM 裁决 5229247549)

`packages/core/src/evaluator/predicateInput.ts` 的 `toPredicateInput` 是动作面与
动作引擎共用的**唯一**谓词归一器,它对字符串**无条件**包裹 `${…}`,假定入参是裸表达式。
但 `${…}` 既是本仓文档在册的谓词拼法(AGENTS.md §4),也是该函数自己的输出类型
`EvaluatorPredicateInput` 列为合法的形态之一 —— 于是一个**已经归一好**的值被再包一层:
`'${x}'` 变成 `'${${x}}'`,单模板快路正则 `/^\$\{([^}]+)\}$/` 的 `[^}]+` 跨不过内层
`}`,匹配失败落到全局 replace,内层表达式 `'${x'` 不可解析。作者写的表达式从此完全
不参与判定。

本 PR 执行已裁 A 案:已含 `${` 的字符串视为已归一,原样返回(同一个守卫也覆盖 envelope
分支 —— 那里 unwrap 出来的 `source` 一行之后落到完全相同的包裹,是同一缺陷的第二种拼法;
`{ dialect: 'cel' }` envelope 与裸表达式的行为完全不变)。归一器由此**幂等**。

## ⚠️ 影响面清点:issue 正文的方向判断需要修正一处

issue 说所有落点都是「恒真」。实测(探针,`origin/main` @ `230ffd875`,同一 context
同一谓词)显示**恒定的方向由调用方的错误策略决定**,而非一律恒真:

```
template TRUE  | norm="${${user.role === \"admin\"}}" | raw=true  | fail-soft=true | throwOnError=THREW
template FALSE | norm="${${user.role === \"guest\"}}" | raw=false | fail-soft=true | throwOnError=THREW
bare FALSE     | norm="${user.role == \"guest\"}"     | raw=false | fail-soft=false| throwOnError=false
```

- **fail-soft** 调用点(不传 `throwOnError`)拿回未解析的原字符串,`Boolean(非空串)`=
  **恒 true**,与 issue 一致。
- **fail-closed** 调用点(`throwOnError: true`)拿到的是**抛错**;各站点的 catch 把抛错
  转成「隐藏」,所以是**恒隐藏**,不是恒显示 —— 方向相反,而且更糟:作者用模板拼法
  gate 的动作,即使谓词取真也**永远不出现**,并且 fail-closed 的 warn 还会去指责作者的
  表达式。

两个方向都被本次修复收敛到「按取值判」。

### 七个调用点逐点 verdict 变更

| # | 调用点 | 键 | 错误策略 | 修复前(与取值无关) | 修复后 | 新钉子 |
|---|---|---|---|---|---|---|
| 1 | `components/renderers/action/action-button.tsx:59` | `visible` | fail-closed | 恒隐藏 | 按取值 | `action-template-predicate-gate.test.tsx`(`action:button`) |
| 1 | 同上 `:69` / `:70` | `disabled` / `enabled` | fail-soft | 恒置灰 / 恒可点 | 按取值 | 同上 |
| 2 | `action-icon.tsx:46` | `visible` | fail-soft | 恒显示 | 按取值 | 同上(`action:icon`) |
| 2 | `action-icon.tsx:50` / `:51` | `disabled` / `enabled` | fail-soft | 恒置灰 / 恒可点 | 按取值 | 同上 |
| 3 | `action-group.tsx:73/78/79`(内联成员)、`:148/151/152`(下拉项) | `visible` / `disabled` / `enabled` | fail-soft | 恒显示 / 恒置灰 / 恒可点 | 按取值 | 同上(inline member、dropdown member) |
| 3 | `action-group.tsx:206`(宿主自身) | `visible` | fail-soft | 恒显示 | 按取值 | 同上(`action:group host`) |
| 4 | `action-menu.tsx:74`(成员) | `visible` | fail-closed | 恒隐藏 | 按取值 | 同上(`action:menu member`) |
| 4 | `action-menu.tsx:81` / `:82` | `disabled` / `enabled` | fail-soft | 恒置灰 / 恒可点 | 按取值 | 同上 |
| 4 | `action-menu.tsx:142`(宿主) | `visible` | fail-closed | 恒隐藏 | 按取值 | 由成员/宿主同一 hook 覆盖(见备注) |
| 5 | `action-bar.tsx:117`(宿主) | `visible` | fail-closed | 恒隐藏 | 按取值 | 同上(`action:bar host`) |
| 6 | `app-shell/views/DeclaredActionsBar.tsx:119` | `visible` | fail-closed | 恒隐藏 | 按取值 | `DeclaredActionsBar.test.tsx` 新增两例 |
| 6 | 同上 `:128` | `disabled` | fail-soft | 恒置灰 | 按取值 | 同上 |
| 7a | `plugin-detail/renderers/record-quick-actions.tsx:207` | `disabled` | fail-soft | 恒置灰 | 按取值 | `record-quick-actions.template-predicate.test.tsx` |
| 7b | `plugin-detail/RelatedList.tsx:250` | `visible` | fail-soft | 恒显示 | 按取值 | `related-toolbar-visible.test.tsx` 新增两例 |
| 8 | `core/actions/ActionEngine.ts:237`(`getActionsForLocation` 的 `visible` 过滤) | `visible` | fail-closed | **恒隐藏**(issue 记为恒显示,已修正) | 按取值 | `ActionEngine.visibility.test.ts` 新增 describe |

备注:

- `action-menu.tsx:142` 宿主 gate 与 `:74` 成员 gate 用的是同一个
  `useCondition(toPredicateInput(x), …, { throwOnError: true })` 复合;成员侧已有直接
  钉子,宿主侧的等价形状由 `action:bar host` 的两例覆盖(`action-bar.tsx:117` 与之逐字
  相同),没有为它单独造第三份 Radix 门面。
- `record-quick-actions` 这一面**同时**跑两条路:动作是经
  `ActionEngine.getActionsForLocation`(fail-closed `visible`)浮出来的,`disabled` 又由
  渲染器 fail-soft 判定 —— 所以它是唯一一处能在同一次 mount 里观察到两个相反恒量的站点,
  新钉子把两半都钉了。
- 另有**第 8 个**调用点 `plugin-detail/renderers/record-alert.tsx:140`(`visible`,
  fail-soft,恒显示 → 按取值),issue 未列。它同样被本次生产端修复治好,但它自己的测试
  (`record-alert.test.tsx:36`)把 `toPredicateInput` 与 `useCondition` 一起替成了 stub,
  该面的谓词判定从它的 suite 里根本观察不到,所以本 PR 不在那里加钉子 —— 按 Prime
  Directive #10 另记为 finding(测试替身缺口),不在本 PR 修。

## 收敛方向的证明(既有绿钉保持绿)

同一拼法在这两条路上一直是对的,本次是把动作面收敛到它们:

- `packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx:135`(`disabled: '${…}'`
  取假时不置灰)—— 仍绿。
- `packages/components/src/__tests__/page-header-predicate-dialect.test.tsx:257`
  (`${…}` 取假时隐藏)—— 仍绿。
- 顺带按「规则消费半径」扫到 `packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx`
  (三面 parity,含 `par_legacy_template` 一行)—— 仍绿。

## 反向验证(方向先判后跑,含一处「反向」)

还原无条件包裹后,**每个站点只有两例中的一例转红**,红的那一例由该站点的错误策略决定:

- fail-closed `visible` → 转红的是 `${取真}` 应显示那一例(修复前恒隐藏);它的
  `${取假}` 兄弟例在修复前**就是绿的**(隐藏就是隐藏,理由无从区分)。
- fail-soft `visible` → 转红的是 `${取假}` 应隐藏那一例。
- `disabled` → 转红的是 `${取假}` 应可点那一例。
- `enabled`(取反腿)→ 转红的是 `${取假}` 应置灰那一例。

因此每个站点都成对钉了两个极性,并在测试名/注释里标明哪一例是 detector、哪一例
「修复前也绿,但理由不对」—— 只钉 `${取假}` 的写法会在五个 fail-closed 站点上以空理由
长绿。裸表达式钉子与上面两条既有绿钉在两个方向都保持绿。

**实跑结果(把 `wrapIfBare` 临时改回无条件包裹,37 个测试转红,逐条与预判一致)**:

| 站点 / 用例 | `${取真}` | `${取假}` |
|---|---|---|
| `action:button` visible(fail-closed) | **× 红(detector)** | ✓ 绿(理由不对) |
| `action:menu` member visible(fail-closed) | **× 红(detector)** | ✓ 绿(理由不对) |
| `action:bar` host visible(fail-closed) | **× 红(detector)** | ✓ 绿(理由不对) |
| `action:icon` visible(fail-soft) | ✓ 绿(反变异守卫) | **× 红(detector)** |
| `action:group` inline / dropdown / host visible(fail-soft) | ✓ 绿 | **× 红(detector)** |
| 五个 leaf 的 `disabled`(fail-soft) | ✓ 绿 | **× 红(detector)** |
| 五个 leaf 的 `enabled`(取反腿) | ✓ 绿 | **× 红(detector)** |
| `DeclaredActionsBar` visible / disabled | 2 例转红 | — |
| `record:quick_actions` visible(经引擎)/ disabled | 2 例转红 | — |
| `RelatedList` toolbar visible | — | **× 红(detector)** |
| `ActionEngine` `${…}` describe | 2 例转红(含 warn 断言) | — |
| 两处替换后的 tripwire | 各 1 例转红 | — |
| `predicateInput.test.ts` | 16 例中 8 例转红(全部 `${…}` 形态/verdict) | — |
| `actionPredicate.parity` 新增两行 | `${取真}` 行转红 | `${取假}` 行绿 —— parity 修复前是「两条路同错」而非同对 |
| **既有绿钉**:`SchemaRenderer.expressions`、`page-header-predicate-dialect`、`plugin-grid` 三面 parity | 全绿 | 全绿 |

一处需要点明的**非预期方向**:`disabledGate` 那张跨面 parity 表本身在变异下**仍然绿**
—— 它比较的是 `blocked` 与**转写**进表的 `rendererDisabled` 两列静态数据,不调用渲染器
(该文件自己就写明了这一点:core 不能 import 渲染器包)。所以转写在变异下会变成谎言而
测试看不见;真正抓住它的是本 PR 在 components / app-shell / plugin-detail 新加的**活钉子**。
这正是把两行从 `null` 改成声明 parity 时必须同时补活钉子的原因。

`ActionEngine` 那处另加了一条 warn 断言:fail-closed 隐藏是会 warn 的,所以「谓词取假
而**不** warn」才能把「判定为假」与「解析失败」两种隐藏区分开。

## #3848 / #3872 tripwire 更新

两处 tripwire(`ActionRunner.disabledGate.test.ts:253`、`ActionRunner.conditionGate.test.ts:265`)
按预测转红。它们的注释说「红了就删掉这条 tripwire,并且(只有那时)才可以让门去求值归一后的值」。

本 PR 的处理是**替换而非删除**,且**不动**执行门语义:

1. 删掉会把「归一器幂等 ⇒ 归一值与原始值同判」这条修好的性质丢在依赖它的门旁边无人钉住,
   下次退回旧包裹只有生产端 suite 会红,读者也无从看出「归一只用于判门、verdict 读原始值」
   为什么仍然安全;
2. 把门改成求值归一值,是在没有缺陷驱动的情况下改动已落地的 #3848 / #3872 语义 —— 两者
   现在对表内每一种形态都同判,改了纯属执行路径上的 churn。注释给的是许可,不是义务。

同时更新了 `disabledGate` 的跨面 parity 表:两行 `${…}` 从 `rendererDisabled: null`
(不声明 parity)变成声明 parity(`true` / `false`),divergence 列表相应少两行,parity
下限从 8 抬到 10。两行 `0` / `{}` 的 divergence 归属从「#3871 family」改指 **#3850** ——
它们从不走字符串分支,与二次包裹无关,真正的分歧是渲染端「什么算已声明的 gate」的口径
(`hasDeclaredVisibilityGate(0)` 为真),那正是 #3850 的范围。

## B 案(spec 发布期响亮拒绝)不在本 PR

`${…}` 该不该在动作谓词上**可写**是 `@objectstack/spec` 面的裁决(`PredicateInput` 只
建模裸串与 dialect envelope)。若要拒绝,应当在发布期校验里拒绝,而不是留给消费端静默
发明一个 verdict。PM 已说明 A 落地后由其在 objectstack 立转办单。

## 验证

- `pnpm exec vitest run packages/core/ packages/react/src/hooks/ packages/plugin-detail/ packages/app-shell/src/views/ --maxWorkers=2` → 334 files / 3937 passed, 1 skipped
- `pnpm exec vitest run packages/components/ packages/react/ packages/plugin-grid/src/__tests__/predicate-surface-parity.test.tsx --maxWorkers=2` → 137 files / 1271 passed
- 反向验证与还原后复跑:49 files / 780 passed
- `pnpm exec turbo run type-check --concurrency=2` → 78 tasks successful, 0 error
- `node scripts/check-control-bytes.mjs` → OK(扫 3833 个文本文件,零命中)
