### PR TITLE
fix(layout): declare the load-time registration in `sideEffects` (#3899)

### DIFF
--- a/.changeset/layout-sideeffects-registration-3899.md
+++ b/.changeset/layout-sideeffects-registration-3899.md
@@ -1,0 +1,65 @@
+---
+"@object-ui/layout": patch
+---
+
+`@object-ui/layout` no longer tells bundlers it has no side effects while registering components at load time (objectui#3899)
+
+The published manifest declared `"sideEffects": false` — a promise that no module
+in the package does anything on evaluation, so any module whose exports go unused
+may be dropped whole. But `src/index.ts` ends with a bare
+`try { registerLayout(); } catch {}`, and that call is the only thing that puts
+`page-header`, `page:card`, `app-shell`, `responsive-grid`,
+`navigation-renderer` and `app-schema-renderer` into the `ComponentRegistry`.
+
+Both statements cannot be true, and a bundler that believes the manifest is
+right to delete the registration. Measured with the repo's own bundler by
+building `import '@object-ui/layout';` — the side-effect-only import, i.e. the
+documented "import it to register" pattern:
+
+- `sideEffects: false` — the bundle is **0 bytes**. Zero registrations, exit
+  code 0, no warning.
+- after this change — the bundle keeps all six `ComponentRegistry.register`
+  calls.
+
+A dropped registration does not fail where it happened. It surfaces later as a
+red `Unknown component type` panel (OBJUI-001) on a fully green build, with
+nothing in the build log to connect the two. Nobody had been bitten yet only
+because every consumer today ALSO imports a named export, which forces the module
+to be evaluated regardless — coincidence, not design. objectui#3787 met the
+hazard and routed around it by calling `registerLayout()` explicitly.
+
+`sideEffects` is now the narrowest honest answer: an array naming the modules
+that actually register, rather than `true`, which would be honest but would hand
+the whole package to every bundler as unshakeable.
+
+```json
+"sideEffects": ["./dist/index.js", "./dist/index.umd.cjs", "./src/index.ts"]
+```
+
+All three are load-bearing, and the set is derived from the manifest rather than
+guessed:
+
+- `./dist/index.js` and `./dist/index.umd.cjs` are every JS file the manifest's
+  own entry fields point at (`module` / `main` / `exports` import+require). The
+  library build inlines everything into those two files, so there is no third
+  chunk to name.
+- `./src/index.ts` is not published (`files` ships `dist` only) but is bundled
+  for real: `apps/console` and `examples/console-starter` both alias the
+  specifier straight at `packages/layout/src`, and a bundler reads this same
+  manifest for those files. With only the published paths declared, the console's
+  alias shape still produced a 0-byte bundle.
+
+What deliberately did NOT change: the load-time `registerLayout()` itself.
+Replacing it with an explicit registration API is the opposite direction — it
+eliminates the side effect instead of declaring it, and it is breaking for any
+consumer relying on automatic registration. objectui#3899 leaves that call to the
+maintainer, and the two steps do not conflict: once the manifest tells the truth,
+the migration to explicit registration can happen whenever it is wanted.
+
+A new pin (`packages/layout/src/__tests__/side-effects-manifest.test.ts`) runs a
+real bundler build per entry form and asserts the registrations survive a
+side-effect-only import, with a `sideEffects: false` control per form asserting
+they are dropped — so the pin cannot pass because the bundler stopped shaking
+anything. The required set is derived from the manifest's own entry fields, so a
+renamed build output or a new `exports` subpath fails as a missing declaration
+instead of drifting silently.

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -21,6 +21,24 @@ pnpm add @object-ui/layout
 - `react-dom` ^18.0.0 || ^19.0.0
 - `react-router-dom` ^6.0.0 || ^7.0.0
 
+## Registration
+
+Importing this package registers its component keys (`page-header`, `page:card`,
+`app-shell`, `responsive-grid`, `navigation-renderer`, `app-schema-renderer`) on
+the `ComponentRegistry` as a module load side effect, so the side-effect-only
+import is enough:
+
+```typescript
+import '@object-ui/layout';
+```
+
+That is a supported entry point, not an accident of the build: `package.json`
+declares the registering modules in `sideEffects`, which is what stops a bundler
+from tree-shaking a side-effect-only import away (objectui#3899 — the manifest
+used to say `"sideEffects": false`, and a bundler honouring it dropped the
+registration silently). `registerLayout()` is also exported for hosts that
+prefer to register explicitly.
+
 ## Components
 
 ### AppShell

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -2,7 +2,11 @@
   "name": "@object-ui/layout",
   "version": "17.3.0",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/index.js",
+    "./dist/index.umd.cjs",
+    "./src/index.ts"
+  ],
   "main": "dist/index.umd.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/layout/src/__tests__/side-effects-manifest.test.ts
+++ b/packages/layout/src/__tests__/side-effects-manifest.test.ts
@@ -1,0 +1,358 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * This package registers its components as a MODULE LOAD SIDE EFFECT, and its
+ * manifest has to say so (objectui#3899).
+ *
+ * `src/index.ts` ends with a bare `try { registerLayout(); } catch {}`, which is
+ * the only thing that puts `page-header`, `app-shell`, `sidebar-nav`,
+ * `page:card`, `responsive-grid` and `app-schema-renderer` into the
+ * `ComponentRegistry`. The manifest used to declare `"sideEffects": false` —
+ * a promise to bundlers that no module here does anything on evaluation, so any
+ * module whose exports go unused may be dropped whole.
+ *
+ * Both statements cannot be true. Measured on main@230ffd875 by bundling
+ * `import '@object-ui/layout';` (the side-effect-only import, i.e. the
+ * documented "import it to register" pattern) with the repo's own bundler:
+ *
+ *   sideEffects: false  ->  bundle is 0 bytes, zero registrations
+ *   this array          ->  bundle keeps all six `ComponentRegistry.register` calls
+ *
+ * Zero bytes, exit code 0, no warning. The failure surfaces far away as a red
+ * `Unknown component type` panel (OBJUI-001) on a green build. Nobody was bitten
+ * only because every consumer today also imports a NAMED export, which forces
+ * evaluation regardless — coincidence, not design. objectui#3787 hit the hazard
+ * and routed around it by calling `registerLayout()` explicitly.
+ *
+ * ## What this file pins, and what it deliberately does not
+ *
+ * It pins the MANIFEST as a bundling contract: the declaration keeps naming
+ * every module form a bundler can resolve this package to, and a real bundler
+ * run confirms each of those forms actually survives a side-effect-only import.
+ *
+ * The spelling is NOT what the probes are sensitive to, which is worth writing
+ * down because it is the natural guess. Measured on vite 8 / rolldown 1.2.1,
+ * `./dist/index.js`, `dist/index.js`, `dist/*.js` and `**\/index.js` all match
+ * the same file. So a red probe means the path is not covered AT ALL, or the
+ * bundler changed how it honours the field — never a leading-`./` nit.
+ *
+ * It does NOT pin the auto-registration itself. Replacing it with an explicit
+ * registration API is a separate, deliberately-not-taken direction (breaking for
+ * any consumer relying on load-time registration) that the issue leaves to the
+ * maintainer. If that lands, `declaresLoadTimeRegistration` below turns red — on
+ * purpose. That test is not defending the side effect, it is defending the
+ * INVARIANT: the manifest and the module body must agree. Remove the side effect
+ * and the honest manifest is `false` again, so both change together or neither
+ * does. A red test here means "update the other half", never "put it back".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { build } from 'vite';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/** `packages/layout` — two levels up from `src/__tests__`. */
+const PKG_DIR = resolve(__dirname, '../..');
+const SRC_DIR = join(PKG_DIR, 'src');
+
+interface Manifest {
+  name: string;
+  main?: string;
+  module?: string;
+  sideEffects?: unknown;
+  exports?: Record<string, Record<string, string> | string>;
+}
+
+const manifest: Manifest = JSON.parse(readFileSync(join(PKG_DIR, 'package.json'), 'utf8'));
+
+/** `"dist/index.js"` and `"./dist/index.js"` name one file; compare on this. */
+const normalize = (p: string): string => (p.startsWith('./') ? p.slice(2) : p);
+
+/**
+ * Every module path a bundler can resolve `@object-ui/layout` to, derived from
+ * the manifest rather than hardcoded — a renamed `fileName` in `vite.config.ts`
+ * or a new `exports` subpath then shows up here as a missing declaration instead
+ * of drifting silently.
+ *
+ * `src/index.ts` is in the list even though `files` does not publish it, because
+ * two in-repo consumers bundle the source tree directly by alias
+ * (`apps/console/vite.config.ts` and `examples/console-starter/vite.config.ts`
+ * both map the specifier at `packages/layout/src`), and the bundler reads THIS
+ * manifest for those files too — measured, not assumed: with the published
+ * paths alone declared, the console's alias shape still produced a 0-byte
+ * bundle. Publishing is not the only consumption surface.
+ */
+function resolvableEntryPaths(): string[] {
+  const found = new Set<string>();
+  for (const field of [manifest.main, manifest.module]) {
+    if (typeof field === 'string') found.add(normalize(field));
+  }
+  for (const target of Object.values(manifest.exports ?? {})) {
+    const conditions = typeof target === 'string' ? { default: target } : target;
+    for (const [condition, file] of Object.entries(conditions)) {
+      // `types` points at a `.d.ts`; type declarations are erased and never
+      // carry a side effect, so they are not a bundling surface.
+      if (condition === 'types' || typeof file !== 'string') continue;
+      found.add(normalize(file));
+    }
+  }
+  found.add('src/index.ts');
+  return [...found].sort();
+}
+
+const declaredSideEffects = (): string[] => {
+  const declared = manifest.sideEffects;
+  expect(
+    Array.isArray(declared),
+    'packages/layout/package.json must declare `sideEffects` as an ARRAY naming the modules that ' +
+      'register components at load time (objectui#3899). `false` is the lie this file exists to catch; ' +
+      '`true` would be honest but hands the whole package to every bundler as unshakeable.',
+  ).toBe(true);
+  return declared as string[];
+};
+
+/** The bare specifier the probes resolve, so each probe picks its own target. */
+const SPECIFIER = '@object-ui/layout';
+
+/** Marker that only survives if the bundler kept the module body. */
+const MARKER = '__objectui_3899_load_time_side_effect__';
+
+/**
+ * Bundle `import '@object-ui/layout';` — nothing else, no named import — with
+ * `target` supplying the module, and return the emitted code.
+ *
+ * Every bare specifier except the package under test is external, so the bundle
+ * holds this package's own graph and nothing more. `write: false` keeps it in
+ * memory; measured at ~250ms cold and ~40ms warm, so this is a real build and
+ * still cheap enough to be an ordinary unit test.
+ */
+async function bundleSideEffectOnlyImport(target: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), 'objectui-3899-entry-'));
+  try {
+    const entry = join(dir, 'entry.mjs');
+    writeFileSync(entry, `import ${JSON.stringify(SPECIFIER)};\n`);
+
+    const result: unknown = await build({
+      configFile: false,
+      logLevel: 'silent',
+      resolve: { alias: { [SPECIFIER]: target } },
+      build: {
+        write: false,
+        minify: false,
+        lib: { entry, formats: ['es'], fileName: 'bundle' },
+        rollupOptions: {
+          external: (id: string) => !/^[./]/.test(id) && !id.startsWith('/') && id !== SPECIFIER,
+        },
+      },
+    });
+
+    const bundles = Array.isArray(result) ? result : [result];
+    const output = (bundles[0] as { output?: Array<{ type: string; code?: string }> } | undefined)?.output;
+    if (!output) {
+      throw new Error(
+        'The probe build returned no output. It must produce an in-memory bundle to inspect — a watcher ' +
+          'or an empty result means this helper needs updating, not that the assertion below passed.',
+      );
+    }
+    return output
+      .filter((chunk) => chunk.type === 'chunk')
+      .map((chunk) => chunk.code ?? '')
+      .join('\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * A copy of this package whose manifest is byte-for-byte the real one except for
+ * `sideEffects`, used to run the same probe under a different declaration.
+ *
+ * Copying rather than mutating the real `package.json`: a test that edits its own
+ * package manifest leaves a dirty tree behind when it fails, and two of these run
+ * in the same worker.
+ *
+ * `entryPaths` get a marker module written at exactly the manifest's own relative
+ * paths, which is what lets the published `dist/*` forms be probed in an unbuilt
+ * worktree. Those probes therefore prove that the DECLARED GLOBS MATCH the
+ * published paths in the bundler's matcher — not that `dist` holds the
+ * registration. The latter is what `declaresLoadTimeRegistration` (the source
+ * side) and the package build (the artifact side) are for.
+ */
+function mirrorPackage(sideEffects: unknown, entryPaths: string[] = []): string {
+  const dir = mkdtempSync(join(tmpdir(), 'objectui-3899-mirror-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ ...manifest, sideEffects }, null, 2));
+
+  for (const rel of entryPaths) {
+    const file = join(dir, normalize(rel));
+    mkdirSync(dirname(file), { recursive: true });
+    // The marker is a global assignment: a side effect no bundler can prove
+    // away, so its absence means the MODULE was dropped, never that the
+    // statement was optimised out.
+    writeFileSync(
+      file,
+      `globalThis[${JSON.stringify(MARKER)}] = ${JSON.stringify(rel)};\n` +
+        (rel.endsWith('.cjs') ? 'module.exports = { unused: 1 };\n' : 'export const unused = 1;\n'),
+    );
+  }
+  return dir;
+}
+
+/** The source tree, copied so the same probe can run under a different manifest. */
+function mirrorSourceTree(sideEffects: unknown): string {
+  const dir = mirrorPackage(sideEffects);
+  cpSync(SRC_DIR, join(dir, 'src'), {
+    recursive: true,
+    filter: (src) => !src.includes('__tests__'),
+  });
+  return join(dir, 'src');
+}
+
+describe('@object-ui/layout declares its load-time registration (objectui#3899)', () => {
+  it('names every module form a bundler can resolve, and nothing that is not one', () => {
+    const declared = declaredSideEffects().map(normalize);
+    const required = resolvableEntryPaths();
+
+    const missing = required.filter((p) => !declared.includes(p));
+    expect(
+      missing,
+      [
+        'A module form of @object-ui/layout is not covered by `sideEffects`, so a bundler resolving the',
+        'package that way may drop the registration entirely — silently, on a green build (objectui#3899).',
+        '',
+        'Add each path below to `sideEffects` in packages/layout/package.json, spelled with a leading',
+        `"./" to match how \`exports\` spells the same paths: ${missing.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+
+    // The other direction. An entry naming nothing real is not harmless: it
+    // reads as "this module has side effects" to the next author and makes the
+    // list look maintained when it is not.
+    const phantom = declared.filter((p) => !required.includes(p));
+    expect(
+      phantom,
+      [
+        '`sideEffects` names a path that is not a module form of this package.',
+        'If a NEW module genuinely has load-time side effects, teach resolvableEntryPaths() where it',
+        'comes from (an `exports` subpath, a build output, a source alias) so the derivation stays the',
+        `authority. Otherwise delete it: ${phantom.join(', ')}`,
+      ].join('\n'),
+    ).toEqual([]);
+
+    // Anti-vacuity: a derivation that silently produced [] would make both
+    // assertions above pass over nothing. These are the three forms measured on
+    // main@230ffd875 — the ESM and UMD published entries plus the source alias.
+    expect(required).toEqual(['dist/index.js', 'dist/index.umd.cjs', 'src/index.ts']);
+  });
+
+  it('declaresLoadTimeRegistration: the barrel still registers on evaluation', () => {
+    const barrel = readFileSync(join(SRC_DIR, 'index.ts'), 'utf8');
+
+    // A bare `registerLayout()` call at column 0 — module body, not inside the
+    // function declaration (whose own body is indented).
+    expect(
+      /^\s{0,2}registerLayout\(\);/m.test(barrel),
+      [
+        'src/index.ts no longer calls `registerLayout()` at load time, so the `sideEffects` array in',
+        'package.json is now claiming a side effect that does not happen.',
+        '',
+        'This test does NOT ask for the call back. It asks the two halves to agree: if the registration',
+        'became an explicit API the consumer calls (the direction objectui#3899 left to the maintainer),',
+        'then the honest manifest is `sideEffects: false` and this file should be deleted with the same',
+        'change. What it forbids is exactly one of the two moving.',
+      ].join('\n'),
+    ).toBe(true);
+  });
+
+  it('keeps a side-effect-only import alive through the workspace source alias', async () => {
+    // The in-place, real-tree probe: the actual src/, read through the actual
+    // manifest, in the shape apps/console and examples/console-starter bundle.
+    const code = await bundleSideEffectOnlyImport(SRC_DIR);
+
+    expect(
+      code,
+      'Bundling `import "@object-ui/layout";` through the workspace src alias dropped the component ' +
+        'registrations. This is objectui#3899 exactly: a bundler took the manifest at its word. Check ' +
+        'that `sideEffects` names "./src/index.ts".',
+    ).toContain('page-header');
+
+    // Every key the barrel registers, so losing all but one cannot pass on the
+    // strength of that one. Read out of the source rather than listed here:
+    // objectui#3899's own prose named a `sidebar-nav` key that this package has
+    // never registered (the SidebarNav component reaches the registry under
+    // `navigation-renderer`), and a hardcoded list is how that kind of mistake
+    // becomes a test asserting a component that does not exist.
+    const registeredKeys = [...readFileSync(join(SRC_DIR, 'index.ts'), 'utf8').matchAll(
+      /ComponentRegistry\.register\(\s*'([^']+)'/g,
+    )].map((match) => match[1]);
+
+    expect(
+      registeredKeys.length,
+      'No `ComponentRegistry.register` call found in src/index.ts — the loop below would assert nothing.',
+    ).toBeGreaterThanOrEqual(6);
+
+    for (const key of registeredKeys) {
+      expect(code, `the \`${key}\` registration must survive a side-effect-only import`).toContain(key);
+    }
+  });
+
+  it.each(['./dist/index.js', './dist/index.umd.cjs'])(
+    'keeps a side-effect-only import alive through the published entry %s',
+    async (entryPath) => {
+      const mirror = mirrorPackage(manifest.sideEffects, [entryPath]);
+      try {
+        const code = await bundleSideEffectOnlyImport(join(mirror, normalize(entryPath)));
+        expect(
+          code,
+          `The declared \`sideEffects\` globs do not cover ${entryPath}, so a consumer resolving the ` +
+            'published package that way loses the registration. Add the path — this is not a spelling ' +
+            'nit: rolldown matches it with or without the leading "./", and through `dist/*.js` too.',
+        ).toContain(MARKER);
+      } finally {
+        rmSync(mirror, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each(['./dist/index.js', './dist/index.umd.cjs'])(
+    'and the declaration is what keeps it: `sideEffects: false` drops %s',
+    async (entryPath) => {
+      // The control. Without it every assertion above could be green because the
+      // bundler never shakes anything here, and the pin would prove nothing —
+      // the exact shape of "green for an empty reason". This is objectui#3899's
+      // reverse verification, run every time rather than once by hand.
+      const mirror = mirrorPackage(false, [entryPath]);
+      try {
+        const code = await bundleSideEffectOnlyImport(join(mirror, normalize(entryPath)));
+        expect(
+          code,
+          `A package declaring \`sideEffects: false\` did NOT lose ${entryPath} on a side-effect-only ` +
+            'import. The bundler no longer honours the flag the way this pin assumes, so the probes above ' +
+            'have stopped measuring anything — fix the probe before trusting them again.',
+        ).not.toContain(MARKER);
+      } finally {
+        rmSync(mirror, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('and the same control holds for the source tree', async () => {
+    const mirrored = mirrorSourceTree(false);
+    try {
+      const code = await bundleSideEffectOnlyImport(mirrored);
+      expect(
+        code,
+        'A copy of this package declaring `sideEffects: false` kept its registrations, so the source-alias ' +
+          'probe above is not measuring the manifest at all.',
+      ).not.toContain('page-header');
+    } finally {
+      rmSync(resolve(mirrored, '..'), { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/layout/src/__tests__/side-effects-manifest.test.ts
+++ b/packages/layout/src/__tests__/side-effects-manifest.test.ts
@@ -11,8 +11,8 @@
  * manifest has to say so (objectui#3899).
  *
  * `src/index.ts` ends with a bare `try { registerLayout(); } catch {}`, which is
- * the only thing that puts `page-header`, `app-shell`, `sidebar-nav`,
- * `page:card`, `responsive-grid` and `app-schema-renderer` into the
+ * the only thing that puts `page-header`, `page:card`, `app-shell`,
+ * `responsive-grid`, `navigation-renderer` and `app-schema-renderer` into the
  * `ComponentRegistry`. The manifest used to declare `"sideEffects": false` —
  * a promise to bundlers that no module here does anything on evaluation, so any
  * module whose exports go unused may be dropped whole.


### PR DESCRIPTION
Fixes #3899

执行 PM 裁决（评论 5229248921）：**只让清单说真话** —— `sideEffects` 从 `false` 收窄为点名含注册副作用的模块。⛔ 本单不动自动注册本身（「删自动注册改显式 API」语义相反、且对所有消费者破坏，留给维护者另立卡）；⛔ 未碰 `apps/site`（#3904 的面）。

## 前提复核（origin/main @ 230ffd875）

两个锚点逐字存在：`packages/layout/package.json:5` 是 `"sideEffects": false`，`packages/layout/src/index.ts` 尾部是裸的 `try { registerLayout(); } catch {}`。**premise 成立。**

一处需要更正的细节：issue 正文说注册的是 `page-header / app-shell / sidebar-nav`，但本包从来没有 `sidebar-nav` 这个 key —— `SidebarNav` 组件是以 `navigation-renderer` 进注册表的。实际六个 key 是 `page-header`、`page:card`、`app-shell`、`responsive-grid`、`navigation-renderer`、`app-schema-renderer`。钉子里的 key 列表因此改成**从 `src/index.ts` 现读**而不是手写，正是为了不把这类笔误写成断言。

## 实测圈定（本单交付要求 1）

先构建再以**发布 tarball 会包含的文件**为准，而不是照 issue 正文的 `dist/index.js` 猜：

`npm pack --dry-run` 的 14 个文件里，JS 只有两个 —— `dist/index.js`（39.5kB）和 `dist/index.umd.cjs`（32.0kB）；其余是 `*.d.ts`（类型声明会被擦除，不构成副作用面）、README / CHANGELOG / LICENSE / package.json。`files` 只发 `dist`，`src` **不在** tarball 里。`vite.config.ts` 的 lib 构建带 `inlineDynamicImports: true`，所以不存在第三个 chunk 要点名。

两个 JS 产物尾部都实测带着注册副作用（`index.js` 是 `try { nt(); } catch {}`，`index.umd.cjs` 是 `try{$()}catch`）。

最终值：

```json
"sideEffects": ["./dist/index.js", "./dist/index.umd.cjs", "./src/index.ts"]
```

三条都是 load-bearing，且集合是**从清单自身推导**的（`main` / `module` / `exports` 的 import+require 指向的全部 JS 文件），不是手列：

- `./dist/index.js`、`./dist/index.umd.cjs` —— 发布产物的全部入口形态。
- `./src/index.ts` —— **不发布，但真的被打包**。`apps/console/vite.config.ts:122` 与 `examples/console-starter/vite.config.ts` 都把 specifier 直接 alias 到 `packages/layout/src`，打包器对这些文件读的是同一份清单。这一条是实测出来的、不是推的：**只声明两个发布路径时，console 的 alias 形态依然产出 0 字节的 bundle**。发布不是唯一的消费面 —— 漏掉它等于 apps/console 原样留着这个 bug。

## 防回归钉：真打包器实测（交付要求 2）

`packages/layout/src/__tests__/side-effects-manifest.test.ts`，用仓内的 vite 8 / rolldown 1.2.1 以编程方式 build 一个只有 `import '@object-ui/layout';`（纯副作用引入）的 entry，逐个入口形态断言注册存活；每个形态配一条 `sideEffects: false` 的**对照**断言注册被摇掉 —— 没有对照，上面全绿也可能只是「打包器根本没在摇」，即「因为什么都没产出所以断言通过」。`write: false` 常驻内存，冷启 ~250ms、热 ~40ms，就是一条普通单测的成本。

修前/修后，对**真实构建产物**、经 bare specifier 走 node 解析（`packages/app-shell/node_modules/@object-ui/layout` → `exports.import` → `dist/index.js`）：

| | bundle | 注册 |
|---|---|---|
| 修前 `sideEffects: false` | **0 字节** | 无 |
| 修后（本 PR） | 35600 字节 | page-header, page:card, app-shell, responsive-grid, navigation-renderer, app-schema-renderer 六个全在 |

反向核验（把清单改回 `false` 跑新钉子）**方向与预期一致：红**。8 条里 4 红 4 绿，红的正好是清单推导 + 三个入口形态的存活探针，报的都是 `expected '' to contain …` —— 空字符串，即 0 字节 bundle 本身：

```
× names every module form a bundler can resolve, and nothing that is not one
× keeps a side-effect-only import alive through the workspace source alias
× keeps a side-effect-only import alive through the published entry ./dist/index.js
× keeps a side-effect-only import alive through the published entry ./dist/index.umd.cjs
Tests  4 failed | 4 passed (8)
```

绿的 4 条正是该绿的：三条 `false` 对照（它们自己就强制 `false`，与清单无关）＋ `declaresLoadTimeRegistration`（源码侧不变量）。

有一处我先写进测试、随后实测**证伪并改掉**的说法：我原本写「探针检查的是拼法」。实测 `./dist/index.js`、`dist/index.js`、`dist/*.js`、双星号 `/index.js` 四种拼法在 rolldown 下**全部命中同一文件**。所以探针对拼法并不敏感，红只意味着「这条路径根本没被覆盖」或「打包器改了对该字段的处理方式」，绝不是少个 `./` 的格式问题 —— 失败信息与文件头注释都按实测改成了这个说法。

## 与另一张卡的关系（钉在测试里）

`declaresLoadTimeRegistration` 断言 `src/index.ts` 仍在加载期调用 `registerLayout()`。它**不是**在保卫这个副作用，而是保卫不变量：**清单与模块体必须同时为真**。若维护者后续采纳「改显式注册 API」，这条会变红 —— 那是故意的，它的意思是「另一半也要改」（那时诚实的清单又是 `false`，本文件应随同一次改动删掉），而不是「把自动注册加回来」。失败信息里写明了这一点。

## 验证

- `pnpm exec vitest run packages/layout/ --maxWorkers=2` → **7 files / 100 tests passed**（新增 8 条）
- `pnpm exec turbo run type-check --concurrency=2` → **78 successful, 78 total**
- `pnpm --filter @object-ui/layout lint` → 0 errors（43 条既有 warning，新文件 0 条）
- `pnpm --filter @object-ui/layout build` → 绿；产物仍为 `dist/index.js` + `dist/index.umd.cjs` 两个 JS
- `node scripts/check-control-bytes.mjs` → OK；改动文件另做了越过该 gate 的自扫（`grep -naP` 覆盖 0x00-0x1f 全段）零命中
- 三个 changeset gate（no-major / fixed / presence）全绿

## changeset

`.changeset/layout-sideeffects-registration-3899.md` —— patch `@object-ui/layout`，正文写明这是**打包契约修正**：清单曾对打包器撒谎，修后 `sideEffects` 是最窄的诚实答案（而不是 `true`，那样虽诚实却把整包交给所有打包器当不可摇）。README 补了一节 Registration，把「`import '@object-ui/layout';` 即注册」写成受支持的入口点并指明是 `sideEffects` 在兜着。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_