### PR TITLE
fix(site): Playground 注册 layout 组件，并删掉两个非依赖的 transpilePackages 死条目

### DIFF
--- a/apps/site/app/playground/page.tsx
+++ b/apps/site/app/playground/page.tsx
@@ -5,6 +5,12 @@ import { SchemaRenderer } from '@object-ui/react';
 import type { SchemaNode } from '@object-ui/core';
 import dynamic from 'next/dynamic';
 import { ObjectUIProvider } from '@/app/components/ObjectUIProvider';
+// Registers `page-header` & friends — see the module header (objectui#3787).
+// The Playground renders hand-typed schemas, so it needs the same registration
+// as the three catalog hosts: without it, typing `page-header` here produced the
+// red OBJUI-001 "Unknown component type" panel for a component the rest of the
+// docs site renders fine (objectui#3904).
+import '@/app/components/registerLayoutBlocks';
 import { ChevronLeft, ChevronRight, Monitor, Smartphone, Tablet } from 'lucide-react';
 
 // Dynamically import Monaco Editor to avoid SSR issues

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -5,15 +5,23 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // Every entry MUST be a declared dependency of this app (pinned by
+  // `scripts/__tests__/site-playground-layout-registration-3904.test.ts`).
+  // Next resolves each name as `<pkg>/package.json` FROM THIS APP'S DIRECTORY to
+  // decide what to bundle instead of externalize; under pnpm's strict linker an
+  // undeclared package is simply unresolvable here, so the entry silently does
+  // nothing. `@object-ui/i18n` and `@object-ui/plugin-aggrid` sat here in exactly
+  // that state (objectui#3904) — and that is how `@object-ui/layout` looked
+  // supported while `page-header` rendered a red OBJUI-001 panel until #3787
+  // added the real dependency. A dead entry here is worse than a missing one: it
+  // reads as "already wired up".
   transpilePackages: [
     '@object-ui/core',
     '@object-ui/components',
     '@object-ui/fields',
-    '@object-ui/i18n',
     '@object-ui/layout',
     '@object-ui/react',
     '@object-ui/types',
-    '@object-ui/plugin-aggrid',
     '@object-ui/plugin-calendar',
     '@object-ui/plugin-charts',
     '@object-ui/plugin-chatbot',

--- a/scripts/__tests__/site-playground-layout-registration-3904.test.ts
+++ b/scripts/__tests__/site-playground-layout-registration-3904.test.ts
@@ -95,7 +95,7 @@ describe('objectui#3904 — every apps/site SchemaRenderer host registers the la
     expect(hosts).toContain('apps/site/app/playground/page.tsx');
   });
 
-  it.each(schemaRendererHosts())('%s imports the layout-block registrar', (host) => {
+  it.each(hosts)('%s imports the layout-block registrar', (host) => {
     const source = fs.readFileSync(path.join(repoRoot, host), 'utf8');
 
     // Any import form is fine — the three catalog hosts use the relative

--- a/scripts/__tests__/site-playground-layout-registration-3904.test.ts
+++ b/scripts/__tests__/site-playground-layout-registration-3904.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#3904 — two faces of the same defect class: a capability the docs site
+ * *declares* but does not actually wire into the graph.
+ *
+ * Face 1 — the fourth `SchemaRenderer` host. `ComponentRegistry` only knows a
+ * type once the package owning it has been loaded, so #3787 added
+ * `apps/site/app/components/registerLayoutBlocks.ts` and imported it for effect
+ * from the three hosts that render CATALOG examples (`InteractiveDemo`,
+ * `SchemaThumbnail`, `LiveSplitDemo`). The Playground renders HAND-TYPED schemas
+ * and was outside that acceptance surface, so it kept resolving `page-header` to
+ * nothing and painting the red OBJUI-001 "Unknown component type" panel — for a
+ * component the rest of the site renders fine. The placeholder net does not catch
+ * it either: `page-header` lives in the opt-in `PROTOCOL_COMPONENTS` of
+ * `packages/components/src/renderers/placeholders.tsx`, not in the eagerly
+ * registered `PALETTE_PLACEHOLDER_BLOCKS`, and `registerPlaceholders()` is only
+ * called by `apps/console`.
+ *
+ * This is pinned by DISCOVERY, not by a hardcoded list of four: the bug was a host
+ * that nobody remembered to add. A fifth host added tomorrow is caught the same
+ * way the Playground should have been.
+ *
+ * Face 2 — `transpilePackages` entries that are not dependencies. Next resolves
+ * each name as `<pkg>/package.json` **from the app directory** to decide what to
+ * bundle rather than externalize (`makeExternalHandler` in
+ * `next/dist/build/handle-externals.js`), and matches resolved module paths
+ * against a `node_modules/(<names>)/` regex (`webpack-config.js`). Under pnpm's
+ * strict linker an UNDECLARED package is unresolvable from `apps/site`, so both
+ * consumers miss it and the entry does exactly nothing. `@object-ui/i18n` and
+ * `@object-ui/plugin-aggrid` sat there in that state (`plugin-aggrid` does not
+ * even exist in the workspace any more).
+ *
+ * Why that is worth a test rather than a one-off deletion: `@object-ui/layout`
+ * had the identical shape before #3787 — listed in `transpilePackages`, neither
+ * declared nor imported — and it read to every reader as "already supported"
+ * while the browser showed a red panel. A dead entry here is worse than a missing
+ * one, and only browser testing found it. This check is the cheap mechanical
+ * version of that browser lap.
+ *
+ * Reverse verification (direction predicted before running, both plain RED):
+ *  - drop the `registerLayoutBlocks` import from `app/playground/page.tsx` and the
+ *    first suite fails naming that file;
+ *  - put `@object-ui/i18n` back into `transpilePackages` and the second suite
+ *    fails naming it as undeclared.
+ *
+ * Deliberately NOT in scope (severable, see the issue): how far the Playground's
+ * component coverage should go at all — it also lacks `plugin-detail`, so every
+ * `record:*` type is still unregistered there. That is a product call about the
+ * Playground's palette, not this registration gap.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SITE_APP_DIR = path.join(repoRoot, 'apps/site/app');
+const SITE_PKG_DIR = path.join(repoRoot, 'apps/site');
+
+/** The module every `SchemaRenderer` host must pull in for its side effect. */
+const REGISTRAR = 'registerLayoutBlocks';
+
+/** JSX usage — a file that actually RENDERS through the renderer. */
+const RENDERS_SCHEMA = /<SchemaRenderer[\s/>]/;
+
+const SOURCE_FILE = /\.tsx?$/;
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.next') continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectSourceFiles(abs));
+    else if (SOURCE_FILE.test(entry.name)) out.push(abs);
+  }
+  return out;
+}
+
+/** Repo-relative paths of the site files that render through `SchemaRenderer`. */
+function schemaRendererHosts(): string[] {
+  return collectSourceFiles(SITE_APP_DIR)
+    .filter((abs) => RENDERS_SCHEMA.test(fs.readFileSync(abs, 'utf8')))
+    .map((abs) => path.relative(repoRoot, abs))
+    .sort();
+}
+
+describe('objectui#3904 — every apps/site SchemaRenderer host registers the layout blocks', () => {
+  const hosts = schemaRendererHosts();
+
+  it('finds the hosts at all (a zero-hit discovery would make the next case vacuously green)', () => {
+    // The failure mode this guards: `SchemaRenderer` gets renamed or the hosts
+    // move out of `app/`, discovery returns [], and the assertion below passes
+    // while checking nothing — the empty-fixture trap.
+    expect(hosts.length).toBeGreaterThanOrEqual(4);
+    expect(hosts).toContain('apps/site/app/playground/page.tsx');
+  });
+
+  it.each(schemaRendererHosts())('%s imports the layout-block registrar', (host) => {
+    const source = fs.readFileSync(path.join(repoRoot, host), 'utf8');
+
+    // Any import form is fine — the three catalog hosts use the relative
+    // `./registerLayoutBlocks`, the Playground the `@/app/components/...` alias it
+    // already uses for its provider. What matters is that the module is in the
+    // host's import graph, at module scope, so registration has happened before
+    // the server render.
+    const imports = new RegExp(`^\\s*import\\s+['"][^'"]*${REGISTRAR}['"];?\\s*$`, 'm');
+
+    expect(
+      imports.test(source),
+      `${host} renders <SchemaRenderer> but never imports ${REGISTRAR}, so types owned by ` +
+        '@object-ui/layout (page-header, app-shell, sidebar-nav) resolve to nothing and render ' +
+        'the red OBJUI-001 panel. Add: import ' +
+        "'@/app/components/registerLayoutBlocks';"
+    ).toBe(true);
+  });
+});
+
+describe('objectui#3904 — the registrar the hosts import actually registers the blocks', () => {
+  /**
+   * The middle link of the chain. Without it the suite above is satisfied by an
+   * import of a module that registers nothing.
+   *
+   * The far end — `registerLayout()` really putting `page-header` into the
+   * `ComponentRegistry` — is already pinned next to the implementation, in
+   * `packages/layout/src/__tests__/page-header-authorable-keys.test.tsx`
+   * ("is registered under the bare key and its namespace"), so it is deliberately
+   * not restated here: that file owns it, and #3899 is working that package.
+   */
+  const registrar = fs.readFileSync(
+    path.join(SITE_APP_DIR, 'components/registerLayoutBlocks.ts'),
+    'utf8'
+  );
+
+  it('imports registerLayout from @object-ui/layout', () => {
+    expect(registrar).toMatch(/import\s*\{[^}]*\bregisterLayout\b[^}]*\}\s*from\s*['"]@object-ui\/layout['"]/);
+  });
+
+  it('CALLS it at module scope rather than relying on the package side effect', () => {
+    // `@object-ui/layout` declares `"sideEffects": false`, which permits a bundler
+    // to drop a module imported only for effect. An invoked named import cannot be
+    // dropped. Module scope (not an effect) also means registration has happened
+    // before the server render.
+    expect(registrar).toMatch(/^registerLayout\(\);?\s*$/m);
+  });
+});
+
+describe('objectui#3904 — every apps/site transpilePackages entry is a real dependency', () => {
+  const nextConfig = fs.readFileSync(path.join(SITE_PKG_DIR, 'next.config.mjs'), 'utf8');
+
+  /**
+   * Parsed out of the source text rather than by importing the config: the module
+   * pulls in `fumadocs-mdx/next`, which is not something a node-env unit test
+   * should have to boot to read a list of strings.
+   */
+  function transpilePackages(): string[] {
+    const block = /transpilePackages:\s*\[([^\]]*)\]/.exec(nextConfig);
+    if (!block) throw new Error('apps/site/next.config.mjs has no transpilePackages array');
+    return [...block[1].matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1]);
+  }
+
+  const declared = (() => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(SITE_PKG_DIR, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    return new Set([...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})]);
+  })();
+
+  const entries = transpilePackages();
+
+  it('reads a non-empty list (the array being non-empty is also what enables external-dir compilation)', () => {
+    // `shouldIncludeExternalDirs = experimental.externalDir || !!transpilePackages`
+    // in Next's webpack config: emptying this array would stop the workspace
+    // `packages/*` sources compiling at all. Removing dead NAMES from a still
+    // non-empty array does not touch that.
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it('lists no package that apps/site does not depend on', () => {
+    const undeclared = entries.filter((name) => !declared.has(name));
+
+    expect(
+      undeclared,
+      'These transpilePackages entries are not dependencies of apps/site, so Next cannot resolve ' +
+        'them from the app directory and the entries do nothing — while reading as if the site ' +
+        'already supported those packages (objectui#3904). Either add the dependency or drop the ' +
+        'entry.'
+    ).toEqual([]);
+  });
+
+  it('no longer lists the two dead entries', () => {
+    // Named explicitly: the generic check above would also go green if someone
+    // "fixed" it by declaring dependencies the site does not use.
+    expect(entries).not.toContain('@object-ui/i18n');
+    expect(entries).not.toContain('@object-ui/plugin-aggrid');
+  });
+
+  it('every entry is actually resolvable from apps/site, which is what Next requires', () => {
+    // The declared-dependency check above is the authoring rule; this is the
+    // measured consequence of it under pnpm's strict linker, and the exact
+    // property the two dead entries failed. Skipped when the app has not been
+    // installed (nothing to measure), never weakened.
+    const linked = path.join(SITE_PKG_DIR, 'node_modules');
+    if (!fs.existsSync(linked)) return;
+
+    const missing = entries.filter((name) => !fs.existsSync(path.join(linked, name)));
+
+    expect(
+      missing,
+      `Not linked into apps/site/node_modules: ${missing.join(', ')}. Next resolves each ` +
+        'transpilePackages name from the app directory, so an unlinked entry is inert.'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #3904

## 背景

文档站有 4 个 SchemaRenderer 宿主。#3787 给渲染 catalog 示例的三个加了 `registerLayoutBlocks`，第四个 —— Playground —— 渲染的是用户手输的 schema，不在那次验收面内，于是今天在 Playground 敲一个 `page-header` 仍然得到红色 OBJUI-001「Unknown component type」面板，而文档站其它地方都能渲染它。占位符也接不住：`page-header` 属于 `placeholders.tsx` 里 opt-in 的 `PROTOCOL_COMPONENTS`，不在 eager 注册的 `PALETTE_PLACEHOLDER_BLOCKS` 里，而 `registerPlaceholders()` 只有 `apps/console` 调。

同时 `apps/site/next.config.mjs` 的 `transpilePackages` 列着两个非依赖包：`@object-ui/i18n` 与 `@object-ui/plugin-aggrid`。

## 改动（三个文件）

1. `apps/site/app/playground/page.tsx`：模块作用域 import `@/app/components/registerLayoutBlocks`，与另三个宿主同款。用 `@/app/...` 别名而非相对路径，是跟随该文件既有的 provider import 写法（相对路径在 `app/playground/` 下拼出来反而不同）。
2. `apps/site/next.config.mjs`：删掉两个死条目，并把「每一项都必须是本 app 已声明的依赖」连同原因写进注释。
3. 新增 `scripts/__tests__/site-playground-layout-registration-3904.test.ts`：把两个面都钉住。

## 两个条目为什么确实是死的（自行核实，不是照抄 issue）

Next 有两处消费 `transpilePackages`：

- `webpack-config.js` 里建的 `node_modules/(名字)/` 路径正则；
- `handle-externals.js` 里按**名字**把每一项解析成 `包名 + /package.json`，**解析起点是 app 目录**；解析成功才记下该包目录，之后按**目录前缀**判定资源要 bundle 而不是 externalize。

pnpm 严格 linker 下这两个包在 `apps/site` 根本解析不到 —— 实测 `MODULE_NOT_FOUND`，而真实依赖给的是 `ERR_PACKAGE_PATH_NOT_EXPORTED`（找到了包，只是 exports 不暴露 package.json），两者可以干净地区分开。解析不到 ⇒ 不记目录 ⇒ 退回 `node_modules/名字/` 子串匹配，而 workspace 包的真实路径是 `packages/xxx/dist/...`（webpack `symlinks: true`），也命不中。两条路径都没有，条目零作用。`packages/plugin-aggrid` 更是整个 workspace 里已经不存在了。

反过来说，**剩下 19 项是有作用的**：它们能解析到，于是走目录前缀匹配，确实阻止了 externalize。所以这不是「整个数组都是装饰」，只有那两项是死的。

## ⚠️ `@object-ui/i18n` 那一项当初是「有意加的」，所以单独交代为什么删它安全

审阅时值得先看这一节。根 `CHANGELOG.md:565` 明确说这一项是为修 SSR 预渲染报错而加：

> **Site SSR build** (`@object-ui/site`): Added `@object-ui/i18n` to `transpilePackages` in `next.config.mjs` to fix "dynamic usage of require is not supported" error when prerendering the tooltip docs page.

所以它不是「一行装饰」，不能凭 issue 的说法一删了之。查证结果：

- 加它的是 `c4489d0fa`（2026-03-31）。那个 commit 对 site **只**改了 `next.config.mjs` 这一行，**没有**同时把 `@object-ui/i18n` 加成 `apps/site` 的依赖 —— 有意思的是同一个 commit 给 console 补的是**真依赖**（`plugin-chatbot`），正好是 site 这半边漏掉的那一步；
- `git log -S '"@object-ui/i18n"' -- apps/site/package.json` **零命中**：它从来没有做过 `apps/site` 的声明依赖；
- 当时数组本来就非空，`shouldIncludeExternalDirs` 早已是开着的，所以这一行唯一可能生效的路径就是「按名字解析」，而那条路径在 pnpm 严格 linker 下解析不到。

**实证**：删掉该项后完整 `next build` 预渲染 **556/556** 页全绿，其中 CHANGELOG 点名的那一页照常产出 —— `.next/server/app/docs/components/overlay/tooltip.html`，133KB 真实内容（`Tooltip` 正文在内），`dynamic usage of require` 零命中。也就是说那个报错并不靠这一项压着。

一处相关细节：`@object-ui/i18n` 其实是 `components`/`react`/`fields` 的**传递**依赖，代码确实进了站点产物 —— 但它一直走的是真实路径 `packages/i18n/dist/*.js`，本来就不靠这个条目；真正让 workspace 外部目录能被编译的是「`transpilePackages` 数组非空」这个布尔，删两个名字后数组仍有 19 项，不受影响。这一点也写进了测试。

## 验收 ②：剩余条目逐一核实

19 项全部是 `apps/site/package.json` 的 `dependencies`，且 `apps/site/node_modules/@object-ui/` 下都有 symlink：`core`、`components`、`fields`、`layout`、`react`、`types`、`plugin-calendar`、`plugin-charts`、`plugin-chatbot`、`plugin-dashboard`、`plugin-editor`、`plugin-form`、`plugin-gantt`、`plugin-grid`、`plugin-kanban`、`plugin-map`、`plugin-markdown`、`plugin-timeline`、`plugin-view`。这条核实已经机械化，不用下次再手数一遍。

## 验收 ①：验证层级（如实报告）

`apps/site` 没有任何测试基建 —— 无 `test` script、无 vitest config，且根 vitest 的 `sharedExclude` 直接排除 `apps/**`。容器里也没有装 Playwright 浏览器（`~/.cache/ms-playwright` 不存在），所以**没有**做真浏览器手敲那一步。按 issue 允许的下限做，并额外补了一层构建实证：

1. **静态断言（新测试，11 个 case 全绿）**：注册链三段接上 —— Playground import 了 registrar；registrar 从 `@object-ui/layout` import 并在模块作用域**调用** `registerLayout()`（该包 `sideEffects: false`，只 import 不调用可能被摇掉）；而 `registerLayout()` 真的注册 `page-header` 这一段，已经由 `packages/layout/src/__tests__/page-header-authorable-keys.test.tsx` 钉在实现旁边，这里不重复（那个文件是它的归属，且 #3899 正在动那个包）。宿主是**发现式**枚举的，不是硬编码四个 —— 这个 bug 本来就是「谁都没想起来加的那个宿主」，第五个宿主会被同样地抓住。
2. **构建差分实证**：`pnpm --filter @object-ui/site build` 两次（有/无本次 import），拿预渲染 `/playground` 页面实际引用的 chunk 去查只属于 `registerLayout` 的标记：

   | 标记 | 无本改动 | 有本改动 |
   |---|---|---|
   | `responsive-grid` | 无 | `105kecdsogrnc.js` |
   | `navigation-renderer` | 无 | `105kecdsogrnc.js` |
   | `app-schema-renderer` | 无 | `105kecdsogrnc.js` |
   | 页面 chunk 数 | 20 | 22 |

   顺带说明一个容易被误读的现象：光查 `page-header` 字符串在两个构建里**都**命中一个 chunk —— 那是 `placeholders.tsx` 里 opt-in 名单的字符串，不是注册。所以差分用的是上面三个只出现在 `registerLayout` 里的标记；构建也证明 `sideEffects: false` 没有把它摇掉。

反向验证（方向先判后跑，两边都是预期的红）：去掉 Playground 那行 import，新测试点名 `apps/site/app/playground/page.tsx` 变红、另三个宿主保持绿；把 `@object-ui/i18n` 放回 `transpilePackages`，另一组点名它变红。

## 一个值得维护者知道的点

`pnpm type-check`（`turbo run type-check`）**覆盖不到本 PR 改的任何文件**：`apps/site` 的脚本叫 `types:check`（不是 `type-check`），`scripts/` 也不是 workspace 包。所以除了全仓 78/78 全绿之外，另外单跑了 `pnpm --filter @object-ui/site types:check` 与 `pnpm type-check:scripts`，都是 0 错。这是既有且登记过的状况（`scripts/check-type-check-coverage.mjs` 绿，把它算作「1 not compiled」），不是本 PR 引入的，所以没有另开 issue。

## 顺手记录的仓外发现

已另开 #3944（`finding` 标签，未认领）：根 `vitest.config.mts` 的 alias 表有 4 个指向不存在目录的死条目（`@object-ui/engine`、`@object-ui/renderer`、`@object-ui/plugin-aggrid`、`@object-ui/ui`），是同一类「配置声明了、依赖图里没有」的漂移。实测这 4 个 specifier 的 import 数都是 0，今天没人碰到，所以按观察类记录、不在本 PR 修（`vitest.config.mts` 是共享热文件）。

## 不在本单内

「Playground 组件覆盖面到哪为止」按分诊定界可分割：它现在也没有 `plugin-detail`，所以 `record:*` 全渲染不出。那是 Playground 调色板的产品决定，不是这次的注册缺口，本 PR 不碰；`packages/layout` 也没碰（#3899 的面）。

## changeset

不需要。`@object-ui/site` 在 `.changeset/config.json` 的 `ignore` 列表里（changesets 从不给它发版），另一个改动是 `scripts/__tests__/`，不属于任何已发布包的 `src/`。`node scripts/check-changeset-presence.mjs` 输出：`No source of a released package changed in this range, so no changeset is owed.`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt
