### PR TITLE
fix(charts): ChartContainer 的 min-size 兜底改为显式合并,不再被调用方 style 整体覆盖

### DIFF
--- a/.changeset/chart-container-min-size-style-merge-os7026.md
+++ b/.changeset/chart-container-min-size-style-merge-os7026.md
@@ -1,0 +1,49 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+`ChartContainer`'s min-size fallback survives a consumer-supplied `style` (objectstack#7026)
+
+The container wrote `style={{ minHeight: 280, minWidth: 0, ...props.style }}` and
+then spread `{...props}` on the line BELOW it. `props` is the rest of
+`ComponentProps< "div" >` — only `id`, `className`, `children`, `config` and
+`disableSettleRemount` are destructured out of it — so it still carried the
+consumer's `style`, and a later JSX attribute of the same name replaces an earlier
+one outright. Any caller that passed a `style` therefore replaced the whole object:
+both `minHeight` and `minWidth` vanished, and the `...props.style` merge written
+inside it never executed even once. It was dead code that read, to anyone auditing
+the file, as if the fallback were guaranteed.
+
+That fallback is not decorative. It exists so Recharts' `ResponsiveContainer`
+always has a non-zero box to measure: a dashboard widget that overrides the
+container's `h-[350px]` class and wraps the chart in flex/grid without an explicit
+child height leaves the box at 0, Recharts measures `width/height = -1`, and the
+chart renders invisibly — the exact failure the guard was added for.
+
+`style` is now destructured out of the rest props and merged explicitly, so which
+side wins is stated in code instead of being decided by JSX attribute order, and
+`{...props}` can no longer reach `style` at all.
+
+Precedence: **an author's explicit size wins.** Simply spreading `{...props}`
+first and merging unconditionally would have traded this bug for its mirror image
+— `minHeight: 280` injected next to an authored `height: 100` floors that 100 to
+280, silently overriding the author. So each half of the fallback applies only
+when the consumer style declares neither of its own keys: `height`/`minHeight`
+gate the height half, `width`/`minWidth` gate the width half, and a key present
+but set to `undefined`/`null` counts as not declared. Every other consumer style
+key passes through untouched.
+
+Behaviour change surface, deliberately narrow. A caller that supplies no `style`
+is byte-for-byte unchanged. A caller whose `style` declares a height — which today
+is the only shape in the tree, `AdvancedChartImpl`'s `containerProps` forwarding
+`ChartConfig.height` — keeps exactly the height it authored, also unchanged, and
+additionally regains the `minWidth: 0` half. What changes is the case the issue
+was filed for: a `style` carrying no size key (a margin, a padding, an
+aspect-ratio, any future container-level presentation prop routed through the same
+`containerProps` path) now keeps the min-size fallback instead of silently
+stripping it.
+
+Pinned in both directions, since a one-sided pin would have been satisfied by the
+mirror-image fix: a non-size `style` keeps `min-height: 280` / `min-width: 0`
+(red before this change), and an explicit `height: 100` renders as 100 with no
+`min-height` floor (red under the unconditional-merge alternative).

--- a/packages/plugin-charts/src/ChartContainerImpl.styleMerge.test.tsx
+++ b/packages/plugin-charts/src/ChartContainerImpl.styleMerge.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Regression: `ChartContainer`'s min-size fallback was silently revoked by any
+ * consumer-supplied `style` (objectstack#7026).
+ *
+ * The container used to write `style={{ minHeight: 280, minWidth: 0,
+ * ...props.style }}` and then spread `{...props}` AFTER it. `props` is the rest
+ * of `ComponentProps<"div">` and still carried `style`, so the later spread
+ * replaced the whole style object: `minHeight`/`minWidth` vanished and the
+ * `...props.style` merge inside it never ran once — it was dead code that read
+ * as if the fallback were guaranteed.
+ *
+ * The fallback exists so Recharts' ResponsiveContainer always has a non-zero box
+ * (a dashboard widget that overrides `h-[350px]` via className otherwise makes
+ * Recharts measure width/height = -1 and render invisibly), so these tests pin
+ * both halves of the merge that replaced it:
+ *
+ *  1. a consumer `style` WITHOUT a height key keeps the min-size fallback (this
+ *     is the assertion that was red before the fix), and its own keys pass
+ *     through untouched;
+ *  2. a consumer `style` WITH an explicit height wins outright — no `minHeight:
+ *     280` is injected, so an authored `height: 100` (smaller than the fallback)
+ *     really renders at 100 instead of being floored to 280. This one guards the
+ *     OTHER failure mode: "just spread `{...props}` first and merge
+ *     unconditionally" would make the fallback beat the author's height;
+ *  3. no consumer `style` at all behaves exactly as before.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+// ResponsiveContainer measures 0×0 under happy-dom; a passthrough keeps these
+// tests focused on the container element's own inline style.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => children,
+  };
+});
+
+import { ChartContainer } from './ChartContainerImpl';
+
+afterEach(() => {
+  cleanup();
+});
+
+/** The container div ChartContainer renders (the one carrying the merged style). */
+function renderContainer(props: { style?: React.CSSProperties; className?: string }) {
+  const { container } = render(
+    <ChartContainer config={{}} {...props}>
+      <div data-testid="child" />
+    </ChartContainer>,
+  );
+  const el = container.querySelector<HTMLElement>('[data-slot="chart"]');
+  if (el == null) throw new Error('ChartContainer did not render its chart container');
+  return el;
+}
+
+/** `minWidth: 0` may serialize as "0" or "0px" depending on the DOM impl. */
+function expectZeroLength(value: string) {
+  expect(value).not.toBe('');
+  expect(parseFloat(value)).toBe(0);
+}
+
+describe('ChartContainer — min-size fallback vs. consumer style (objectstack#7026)', () => {
+  it('keeps the min-size fallback when the consumer style declares no size', () => {
+    const el = renderContainer({ style: { margin: 8 } });
+
+    // The fallback the comment promises is actually on the element.
+    expect(el.style.minHeight).toBe('280px');
+    expectZeroLength(el.style.minWidth);
+    // …and the consumer's own keys are passed through, not dropped.
+    expect(el.style.margin).toBe('8px');
+  });
+
+  it('keeps the fallback when the consumer overrides the height CLASS but not the style', () => {
+    // The exact shape the fallback was written for: a dashboard widget drops
+    // `h-[350px]` via className and hands the container a non-size style.
+    const el = renderContainer({ className: 'h-full', style: { padding: 4 } });
+
+    expect(el.className).toContain('h-full');
+    expect(el.style.minHeight).toBe('280px');
+    expectZeroLength(el.style.minWidth);
+  });
+
+  it('lets an explicit consumer height win — no minHeight floor is injected', () => {
+    // AdvancedChartImpl's containerProps do exactly this for `ChartConfig.height`.
+    const el = renderContainer({ style: { height: 100 } });
+
+    expect(el.style.height).toBe('100px');
+    // A `min-height: 280px` here would silently render the author's 100 as 280.
+    expect(el.style.minHeight).toBe('');
+    // Width said nothing, so the width half of the fallback still applies.
+    expectZeroLength(el.style.minWidth);
+  });
+
+  it('lets an explicit consumer minHeight win, even below the fallback', () => {
+    const el = renderContainer({ style: { minHeight: 100 } });
+
+    expect(el.style.minHeight).toBe('100px');
+  });
+
+  it('skips the minWidth fallback when the consumer declares a width', () => {
+    const el = renderContainer({ style: { width: 400 } });
+
+    expect(el.style.width).toBe('400px');
+    expect(el.style.minWidth).toBe('');
+    // Height said nothing, so the height half of the fallback still applies.
+    expect(el.style.minHeight).toBe('280px');
+  });
+
+  it('applies the full fallback when no consumer style is supplied', () => {
+    const el = renderContainer({});
+
+    expect(el.style.minHeight).toBe('280px');
+    expectZeroLength(el.style.minWidth);
+  });
+
+  it('treats an undefined size value as "not declared" and still falls back', () => {
+    // `style: { height: undefined }` reaches the container from spread-built
+    // prop objects; it must not count as an authored height.
+    const el = renderContainer({ style: { height: undefined, margin: 2 } });
+
+    expect(el.style.minHeight).toBe('280px');
+    expect(el.style.margin).toBe('2px');
+  });
+});

--- a/packages/plugin-charts/src/ChartContainerImpl.tsx
+++ b/packages/plugin-charts/src/ChartContainerImpl.tsx
@@ -65,6 +65,7 @@ function ChartContainer({
   children,
   config,
   disableSettleRemount,
+  style,
   ...props
 }: React.ComponentProps<"div"> & {
   config: ChartContainerConfig
@@ -140,6 +141,33 @@ function ChartContainer({
     }
   }, [disableSettleRemount])
 
+  // The min-size fallback exists so Recharts' ResponsiveContainer always has a
+  // non-zero box to measure: a consumer that overrides our `h-[350px]` class
+  // (e.g. a dashboard widget wrapping the chart in flex/grid without an explicit
+  // child height) would otherwise leave the container at 0, Recharts would
+  // measure width/height = -1, and the chart would render invisibly.
+  //
+  // The merge is written out explicitly and `style` is destructured out of the
+  // rest props above, so which side wins is no longer decided by JSX attribute
+  // order. It used to be: `style={{ minHeight: 280, ... }}` was written BEFORE
+  // `{...props}`, and `props` still carried the consumer's `style`, so the later
+  // spread replaced the whole object — both fallbacks silently vanished and the
+  // `...props.style` merge inside it never ran at all (objectstack#7026).
+  //
+  // Precedence: an author's explicit size WINS. Injecting `minHeight: 280`
+  // next to an authored `height: 100` would floor that 100 to 280, so each half
+  // of the fallback applies only when the consumer style declares neither of its
+  // own keys — `height`/`minHeight` for the height half, `width`/`minWidth` for
+  // the width half. A key set to `undefined`/`null` counts as not declared. All
+  // other consumer style keys pass through untouched.
+  const hasDeclaredHeight = style?.height != null || style?.minHeight != null
+  const hasDeclaredWidth = style?.width != null || style?.minWidth != null
+  const containerStyle: React.CSSProperties = {
+    ...(hasDeclaredHeight ? {} : { minHeight: 280 }),
+    ...(hasDeclaredWidth ? {} : { minWidth: 0 }),
+    ...style,
+  }
+
   return (
     <ChartContext.Provider value={{ config }}>
       <div
@@ -155,12 +183,9 @@ function ChartContainer({
           "block w-full h-[350px] text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground",
           className
         )}
-        // Guarantee a non-zero box for Recharts' ResponsiveContainer even when
-        // the consumer-supplied className overrides our h-[350px] (e.g. dashboard
-        // widgets that wrap the chart in flex/grid layouts without an explicit
-        // child height). Without this min-size the chart computes
-        // width/height = -1 and renders invisibly.
-        style={{ minHeight: 280, minWidth: 0, ...props.style }}
+        // Merged above, NOT here: `style` is destructured out of `props`, so the
+        // spread below can no longer replace it (objectstack#7026).
+        style={containerStyle}
         {...props}
       >
         <ChartStyle id={chartId} config={config} />


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7026

## 机理

`ChartContainerImpl.tsx` 把 `style` 写成显式 JSX 属性,而 `{...props}` 展开在它**下面一行**;`props` 是 `ComponentProps< "div" >` 解构后的 rest,只摘掉了 `id`/`className`/`children`/`config`/`disableSettleRemount` —— **`style` 还在里面**。JSX 里后写的同名属性整体覆盖先写的,所以只要调用方传了 `style`,整个 style 对象就被替换:`minHeight: 280` 与 `minWidth: 0` 一起消失,而写在里面的 `...props.style` 那次合并**从未执行过一次**。它是死代码,却让读代码的人以为兜底一直在。

这个兜底不是装饰:它是为了让 Recharts 的 ResponsiveContainer 永远有一个非零盒子可量。dashboard widget 覆盖掉容器的 `h-[350px]` 类、又把 chart 塞进没有显式子高度的 flex/grid 时,盒子停在 0,Recharts 量到 `width/height = -1`,图**渲染不出来** —— 正是当年加这道兜底要防的场景。

## 改法

把 `style` 从 rest props 里显式解构出来、单独合并,于是"谁覆盖谁"写在代码里,而不是靠 JSX 属性顺序这种一眼看不出来的机制;`{...props}` 也再也碰不到 `style`。

**合并语义:作者的显式尺寸赢。** 只是"把 `{...props}` 挪到前面、无条件合并"会把这个 bug 换成它的镜像 —— `minHeight: 280` 与作者写的 `height: 100` 并存时,CSS 里 min-height 赢,作者的 100 被静默压成 280。所以兜底的每一半都只在调用方 style 两个对应键都没声明时才注入:

- 高度那一半:调用方 style 既无 `height` 也无 `minHeight` 时才注入 `minHeight: 280`;
- 宽度那一半:既无 `width` 也无 `minWidth` 时才注入 `minWidth: 0`;
- 键存在但值为 `undefined`/`null` 记作"未声明";
- 调用方其余 style 键原样透传。

注释也改成与实现一致:说清何时兜底、何时让位于作者的显式尺寸,并记下原来的顺序依赖为什么是死代码。

## 行为变化面(刻意收窄)

- 不传 `style` 的调用方:逐字节不变。
- `style` 带高度的调用方 —— 今天树里唯一的形状,即 `AdvancedChartImpl` 的 `containerProps` 转发 `ChartConfig.height` —— 保留它声明的高度,同样不变,额外多拿回 `minWidth: 0` 那一半。
- 真正变的是这单被开出来的那一格:`style` 不含尺寸键时(margin、padding、aspect-ratio,以及以后任何走同一条 `containerProps` 路径的容器级呈现键)现在**保有** min-size 兜底,而不是把它一起静默带走。

## 钉子与反向验证

两方向都钉,因为单方向的钉子会被镜像改法一样满足:

| 钉子 | 修前 | 修后 |
|---|---|---|
| 不含尺寸的 style(`{ margin: 8 }`)仍带 `min-height: 280` / `min-width: 0`,且 margin 透传 | 🔴 红 | 🟢 绿 |
| className 覆盖高度类 + 非尺寸 style 时兜底仍在 | 🔴 红 | 🟢 绿 |
| `style: { height: 100 }` 渲染成 100 且**无** `min-height` | 🔴 红(仅 minWidth 那半条) | 🟢 绿 |
| `style: { minHeight: 100 }` 低于兜底也赢 | 🟢 绿 | 🟢 绿 |
| `style: { width: 400 }` 不注入 minWidth、高度那半仍兜底 | 🔴 红(仅 minHeight 那半条) | 🟢 绿 |
| 无 style 时行为与现状一致 | 🟢 绿 | 🟢 绿 |
| `height: undefined` 记作未声明,仍兜底 | 🔴 红 | 🟢 绿 |

反向验证做了两次,方向都是**先预判后跑**:

1. 新钉子打在**未改动**的源码上 —— 预判 5 红 2 绿,实测逐条命中(红:1、2、3、5、7;绿:4、6)。
2. 另外装了一次"无条件合并"的镜像改法作探针 —— 预判恰好是那两条"作者显式尺寸赢"的钉子转红,实测 `2 failed | 5 passed`,正是第 3、5 条。所以这两条钉子是承重的,不是陪衬。

## 范围

只动 `ChartContainerImpl.tsx` + 新测试 + changeset。⛔ 没动 `AdvancedChartImpl` 的 `containerProps` 生产侧;⛔ 没碰在飞的 chart block 外壳文件;⛔ 没碰 releases/。

`packages/components/src/ui/chart.tsx` 里那份上游 shadcn 的 ChartContainer 副本已核查:它根本没有 min-size style,也没有显式 `style` 属性,不存在同一 bug(且属 No-Touch 区)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_