### PR TITLE
fix(site): Schema Catalog 卡片外壳去 button 化,示例预览不再嵌套按钮 (#3903)

### DIFF
--- a/apps/site/app/components/SchemaCatalogIndex.tsx
+++ b/apps/site/app/components/SchemaCatalogIndex.tsx
@@ -103,16 +103,26 @@ interface CardProps {
   onOpen: (e: Example) => void;
 }
 
+/**
+ * One gallery card.
+ *
+ * The shell is deliberately NON-interactive and the click target is an overlay
+ * sibling, never an ancestor of the thumbnail (objectui#3903). `SchemaThumbnail`
+ * renders the example itself through a real `SchemaRenderer`, and 85 of the 423
+ * catalog examples contain `"type": "button"` nodes — with a `button` shell those
+ * cards shipped `button` inside `button`, which React classifies as a hydration
+ * error (the HTML parser hoists the inner button out of the outer one, so the
+ * server HTML and the client tree disagree) on top of being an accessibility
+ * defect in its own right. A `div role="button"` shell would keep both problems;
+ * an absolutely positioned overlay removes them without giving up a real,
+ * natively focusable control.
+ */
 const GalleryCard = React.memo(function GalleryCard({
   entry,
   onOpen,
 }: CardProps) {
   return (
-    <button
-      type="button"
-      onClick={() => onOpen(entry)}
-      className="group flex flex-col gap-2 rounded-lg border border-fd-border bg-fd-card p-3 text-left transition hover:border-fd-primary hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
-    >
+    <div className="group relative flex flex-col gap-2 rounded-lg border border-fd-border bg-fd-card p-3 text-left transition hover:border-fd-primary hover:shadow-sm">
       <SchemaThumbnail schema={entry.schema as SchemaNode} />
       <div className="flex flex-col gap-0.5">
         <div className="line-clamp-1 text-sm font-medium text-fd-foreground">
@@ -122,7 +132,20 @@ const GalleryCard = React.memo(function GalleryCard({
           {entry.id}
         </code>
       </div>
-    </button>
+      {/*
+        The card's only focusable node: it covers the whole card (`inset-0`
+        resolves against the shell's padding box), so the focus ring still reads
+        as "the card is focused", and its accessible name carries both labels the
+        card shows — title and id — which keeps WCAG 2.5.3 (label in name)
+        satisfied. The `button` role itself announces what activation does.
+      */}
+      <button
+        type="button"
+        onClick={() => onOpen(entry)}
+        aria-label={`Open ${entry.meta.title} (${entry.id})`}
+        className="absolute inset-0 cursor-pointer rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+      />
+    </div>
   );
 });
 

--- a/apps/site/app/components/SchemaThumbnail.tsx
+++ b/apps/site/app/components/SchemaThumbnail.tsx
@@ -114,6 +114,17 @@ export function SchemaThumbnail({
           }
         >
           <div
+            // `inert`, not just `pointer-events: none`: the preview renders the
+            // example's own controls, and this frame is `aria-hidden`. A
+            // focusable node inside an `aria-hidden` subtree is itself a
+            // violation (axe `aria-hidden-focus`), and because the preview
+            // precedes the card's open button in DOM order, a keyboard user
+            // otherwise tabs through every example's internal buttons before
+            // reaching the card (measured: Tab from card 1 stopped on Submit,
+            // Save Draft, Delete, Cancel — objectui#3903). `inert` removes the
+            // subtree from focus order and hit-testing, which is what makes the
+            // "non-interactive preview" in this component's contract true.
+            inert
             className="pointer-events-none absolute left-0 top-0 origin-top-left select-none"
             style={{
               width: `${viewportWidth}px`,

--- a/scripts/__tests__/site-catalog-card-interactive-nesting-3903.test.ts
+++ b/scripts/__tests__/site-catalog-card-interactive-nesting-3903.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+/**
+ * objectui#3903 — the docs site must never nest a schema preview inside an
+ * interactive control.
+ *
+ * The defect: `SchemaCatalogIndex` rendered every gallery card as a `button`
+ * and embedded `SchemaThumbnail` inside it. `SchemaThumbnail` renders the
+ * example itself through a real `SchemaRenderer`, and 85 of the catalog
+ * examples contain `"type": "button"` nodes — so `/docs/guide/schema-catalog`
+ * shipped `button` inside `button` for a fifth of the gallery. React classifies
+ * that as a hydration error, not a style nit: the HTML parser RESTRUCTURES
+ * nested buttons (the inner one is hoisted out of the outer), so the server
+ * HTML and the client tree disagree. It is also an accessibility defect on its
+ * own — an interactive control inside an interactive control has undefined
+ * keyboard and screen-reader behaviour.
+ *
+ * Why a static check rather than a render test: `apps/site` has no Vitest
+ * project (the root config excludes `apps/**` and only `apps/console` is
+ * registered), and the defect's shape is structural — a preview host sitting in
+ * the subtree of a control. `scripts/__tests__/site-playground-layout-registration-3904.test.ts`
+ * established the same altitude for the same app. The behavioural half (zero
+ * "cannot be a descendant of" console errors on the live page) is browser
+ * evidence on the PR; this file is the cheap mechanical version that runs in CI
+ * on every shard.
+ *
+ * Pinned by DISCOVERY, not by a hardcoded file list: the bug was one card shell
+ * nobody thought about, and a second host added tomorrow is caught the same way.
+ *
+ * Reverse verification (direction predicted before running, plain RED both
+ * ways, and both were measured):
+ *  - restore the `button` card shell in `SchemaCatalogIndex.tsx` and
+ *    `finds no schema preview nested inside an interactive control` fails,
+ *    naming that file and `SchemaThumbnail`;
+ *  - drop `inert` from the scaled preview wrapper in `SchemaThumbnail.tsx` and
+ *    the last suite fails.
+ *
+ * Deliberately NOT in scope: nesting that only exists through a component
+ * boundary (a shell component that renders a `button` internally). This walker
+ * reads one file's JSX tree, which is the shape the defect had and the shape a
+ * regression would have. Whole-graph interactivity analysis is a different,
+ * much more expensive tool.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SITE_APP_DIR = path.join(repoRoot, 'apps/site/app');
+
+/**
+ * Components that render UNKNOWN catalog schema, i.e. whose output may contain
+ * interactive nodes. None of them may appear inside a control.
+ */
+const SCHEMA_PREVIEW_HOSTS = new Set([
+  'SchemaRenderer',
+  'SchemaThumbnail',
+  'InteractiveDemo',
+  'LiveSplitDemo',
+  'SchemaExample',
+]);
+
+/** Intrinsic elements that are interactive controls in their own right. */
+const CONTROL_TAGS = new Set(['button']);
+
+const SOURCE_FILE = /\.tsx$/;
+
+interface Violation {
+  /** Repo-relative file. */
+  file: string;
+  /** 1-based line of the nested element. */
+  line: number;
+  /** Tag name of the nested element. */
+  child: string;
+  /** Tag name of the enclosing control. */
+  control: string;
+  /** 1-based line of the enclosing control. */
+  controlLine: number;
+}
+
+type JsxNode = ts.JsxElement | ts.JsxSelfClosingElement;
+
+function openingElement(node: JsxNode): ts.JsxOpeningElement | ts.JsxSelfClosingElement {
+  return ts.isJsxElement(node) ? node.openingElement : node;
+}
+
+function tagNameOf(node: JsxNode, sf: ts.SourceFile): string {
+  const name = openingElement(node).tagName;
+  return ts.isIdentifier(name) ? name.text : name.getText(sf);
+}
+
+function attributes(node: JsxNode): ts.JsxAttribute[] {
+  return openingElement(node).attributes.properties.filter((p): p is ts.JsxAttribute =>
+    ts.isJsxAttribute(p)
+  );
+}
+
+function attributeName(attr: ts.JsxAttribute): string {
+  return ts.isIdentifier(attr.name) ? attr.name.text : attr.name.getText();
+}
+
+/** Literal text of a string-valued attribute (`x="y"` and `x={'y'}` both). */
+function stringAttr(node: JsxNode, attrName: string): string | undefined {
+  for (const attr of attributes(node)) {
+    if (attributeName(attr) !== attrName) continue;
+    const init = attr.initializer;
+    if (!init) continue;
+    if (ts.isStringLiteral(init)) return init.text;
+    if (ts.isJsxExpression(init) && init.expression && ts.isStringLiteralLike(init.expression)) {
+      return init.expression.text;
+    }
+  }
+  return undefined;
+}
+
+function hasAttr(node: JsxNode, attrName: string): boolean {
+  return attributes(node).some((attr) => attributeName(attr) === attrName);
+}
+
+/**
+ * A control is a `button` element, or anything wearing `role="button"` — the
+ * `div role="button"` rewrite is the OTHER way to keep this bug (the issue says
+ * so explicitly), so the rule has to see it too.
+ */
+function isControl(node: JsxNode, sf: ts.SourceFile): boolean {
+  return CONTROL_TAGS.has(tagNameOf(node, sf)) || stringAttr(node, 'role') === 'button';
+}
+
+function lineOf(node: ts.Node, sf: ts.SourceFile): number {
+  return sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+}
+
+function parse(fileLabel: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(fileLabel, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+}
+
+/**
+ * Walk one file's JSX trees, reporting every schema-preview host and every
+ * nested `button` that has a control among its JSX ancestors.
+ */
+function findViolations(fileLabel: string, source: string): Violation[] {
+  const sf = parse(fileLabel, source);
+  const found: Violation[] = [];
+  /** Enclosing controls, innermost last. */
+  const controls: JsxNode[] = [];
+
+  const visit = (node: ts.Node): void => {
+    const jsx = ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node) ? (node as JsxNode) : null;
+
+    if (jsx) {
+      const tag = tagNameOf(jsx, sf);
+      const enclosing = controls[controls.length - 1];
+      if (enclosing && (SCHEMA_PREVIEW_HOSTS.has(tag) || CONTROL_TAGS.has(tag))) {
+        found.push({
+          file: fileLabel,
+          line: lineOf(jsx, sf),
+          child: tag,
+          control: tagNameOf(enclosing, sf),
+          controlLine: lineOf(enclosing, sf),
+        });
+      }
+      if (isControl(jsx, sf)) controls.push(jsx);
+    }
+
+    ts.forEachChild(node, visit);
+
+    if (jsx && isControl(jsx, sf)) controls.pop();
+  };
+
+  visit(sf);
+  return found;
+}
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.next') continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectSourceFiles(abs));
+    else if (SOURCE_FILE.test(entry.name)) out.push(abs);
+  }
+  return out;
+}
+
+function siteTsxFiles(): string[] {
+  return collectSourceFiles(SITE_APP_DIR)
+    .map((abs) => path.relative(repoRoot, abs))
+    .sort();
+}
+
+const CARD_FILE = 'apps/site/app/components/SchemaCatalogIndex.tsx';
+const THUMBNAIL_FILE = 'apps/site/app/components/SchemaThumbnail.tsx';
+
+describe('objectui#3903 — the walker detects the nesting it is meant to detect', () => {
+  /**
+   * Without this suite the real check below is a rule of unknown power: a
+   * walker that silently reports nothing passes over a healthy tree exactly the
+   * way it passes over a broken one. Sample 1 is the shape `main` shipped.
+   */
+  it('flags the pre-fix card shell (button wrapping the thumbnail)', () => {
+    const violations = findViolations(
+      'sample-prefix.tsx',
+      [
+        'export const Card = () => (',
+        '  <button type="button" onClick={open}>',
+        '    <SchemaThumbnail schema={entry.schema} />',
+        '    <div>{entry.meta.title}</div>',
+        '  </button>',
+        ');',
+      ].join('\n')
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ child: 'SchemaThumbnail', control: 'button', line: 3 });
+  });
+
+  it('flags a literal button inside a button', () => {
+    const violations = findViolations(
+      'sample-nested-button.tsx',
+      ['export const X = () => (', '  <button>', '    <button>inner</button>', '  </button>', ');'].join(
+        '\n'
+      )
+    );
+
+    expect(violations.map((v) => v.child)).toEqual(['button']);
+  });
+
+  it('flags the div role="button" rewrite as well, which the issue warns against', () => {
+    const violations = findViolations(
+      'sample-role-button.tsx',
+      [
+        'export const X = () => (',
+        '  <div role="button" tabIndex={0} onClick={open}>',
+        '    <SchemaThumbnail schema={s} />',
+        '  </div>',
+        ');',
+      ].join('\n')
+    );
+
+    expect(violations.map((v) => v.child)).toEqual(['SchemaThumbnail']);
+  });
+
+  it('accepts the overlay shape: preview and click target as SIBLINGS', () => {
+    const violations = findViolations(
+      'sample-overlay.tsx',
+      [
+        'export const Card = () => (',
+        '  <div className="relative">',
+        '    <SchemaThumbnail schema={entry.schema} />',
+        '    <div>{entry.meta.title}</div>',
+        '    <button type="button" className="absolute inset-0" aria-label={name} onClick={open} />',
+        '  </div>',
+        ');',
+      ].join('\n')
+    );
+
+    expect(violations).toEqual([]);
+  });
+});
+
+describe('objectui#3903 — no apps/site schema preview sits inside an interactive control', () => {
+  const files = siteTsxFiles();
+
+  it('discovers the site tree at all (a zero-hit scan would be vacuously green)', () => {
+    expect(files.length).toBeGreaterThanOrEqual(10);
+    expect(files).toContain(CARD_FILE);
+  });
+
+  it('the catalog index really does render a preview AND a button, so it is in scope', () => {
+    // The other half of the empty-fixture guard: if the card ever stops
+    // embedding a preview host, or stops having a click target, the sweep below
+    // would go green over a file that no longer exercises the rule — and the
+    // page would be broken in a different way.
+    const source = fs.readFileSync(path.join(repoRoot, CARD_FILE), 'utf8');
+    const sf = parse(CARD_FILE, source);
+    const tags: string[] = [];
+    const visit = (node: ts.Node): void => {
+      if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+        tags.push(tagNameOf(node as JsxNode, sf));
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+
+    expect(tags).toContain('SchemaThumbnail');
+    expect(tags).toContain('button');
+  });
+
+  it('finds no schema preview nested inside an interactive control', () => {
+    const violations = files.flatMap((file) =>
+      findViolations(file, fs.readFileSync(path.join(repoRoot, file), 'utf8'))
+    );
+
+    expect(
+      violations.map((v) => `${v.file}:${v.line} ${v.child} inside <${v.control} > at line ${v.controlLine}`),
+      'A schema preview renders whatever the example JSON says, and 85 catalog examples contain ' +
+        'button nodes — inside a control that is a React hydration error plus an accessibility ' +
+        'defect (objectui#3903). Keep the shell non-interactive and make the click target an ' +
+        'absolutely positioned button SIBLING with an aria-label naming the example.'
+    ).toEqual([]);
+  });
+});
+
+describe('objectui#3903 — the thumbnail preview is inert, not merely unclickable', () => {
+  /**
+   * The overlay fix alone leaves the preview's own controls FOCUSABLE, and the
+   * thumbnail frame is `aria-hidden` — a focusable node inside `aria-hidden` is
+   * itself a violation (axe `aria-hidden-focus`), and because the preview
+   * precedes the overlay in DOM order, a keyboard user would tab through every
+   * example's internal buttons before reaching the card's own open button.
+   * `inert` is what makes SchemaThumbnail's documented contract ("scaled,
+   * non-interactive preview") true; `pointer-events: none` only ever covered
+   * the mouse.
+   */
+  const source = fs.readFileSync(path.join(repoRoot, THUMBNAIL_FILE), 'utf8');
+  const sf = parse(THUMBNAIL_FILE, source);
+
+  function ancestorsOfRenderer(): JsxNode[][] {
+    const chains: JsxNode[][] = [];
+    const stack: JsxNode[] = [];
+    const visit = (node: ts.Node): void => {
+      const jsx =
+        ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node) ? (node as JsxNode) : null;
+      if (jsx) {
+        if (tagNameOf(jsx, sf) === 'SchemaRenderer') chains.push([...stack]);
+        stack.push(jsx);
+      }
+      ts.forEachChild(node, visit);
+      if (jsx) stack.pop();
+    };
+    visit(sf);
+    return chains;
+  }
+
+  const chains = ancestorsOfRenderer();
+
+  it('renders a SchemaRenderer at all', () => {
+    expect(chains.length).toBeGreaterThan(0);
+  });
+
+  chains.forEach((chain, i) => {
+    it(`SchemaRenderer #${i} is wrapped in an inert, pointer-events-none subtree`, () => {
+      const inert = chain.filter((n) => hasAttr(n, 'inert'));
+      expect(
+        inert.length,
+        `no ancestor of the SchemaRenderer in ${THUMBNAIL_FILE} carries inert, so the preview's own ` +
+          'controls stay focusable inside an aria-hidden frame and sit ahead of the card button in ' +
+          'tab order (objectui#3903)'
+      ).toBeGreaterThan(0);
+
+      const unclickable = chain.filter((n) =>
+        (stringAttr(n, 'className') ?? '').includes('pointer-events-none')
+      );
+      expect(
+        unclickable.length,
+        `no ancestor of the SchemaRenderer in ${THUMBNAIL_FILE} carries pointer-events-none`
+      ).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3903

## 问题

`SchemaCatalogIndex` 把每张卡片渲染成 `button`(修前 `:111`),而卡片里嵌的 `SchemaThumbnail`(`:116`)用真实 `SchemaRenderer` 渲染示例本身。目录 423 个示例里 **85** 个含 `"type": "button"` 节点,于是这些卡片在 `/docs/guide/schema-catalog` 上落成「按钮套按钮」。

React 把它判为 hydration error 而非样式瑕疵:HTML 解析器会把内层按钮**提出**外层,server HTML 与 client 树因此不一致。它同时本身就是可访问性缺陷 —— 交互控件套交互控件,键盘与读屏行为未定义。

前提已在 `origin/main` @ `69becd2d1` 上复核:AST 扫描 apps/site 全部 17 个 tsx,命中恰好一处 —— `SchemaCatalogIndex.tsx:116 SchemaThumbnail inside button@111`,与 issue 正文与分诊评论完全一致。

## 改法

**1. 卡片外壳去 button 化。** 外壳改为非交互 `div`(加 `relative`,边框 / hover / 间距类不变),点击目标改为绝对定位的覆盖层 `button` 兄弟节点(`absolute inset-0`)。缩略图与文字都不再位于任何交互控件的子树内。正文提到的 `div role="button"` 写法会把 hydration 与 a11y 两个问题都留下,因此没有采用(结构钉也把它一并禁掉)。

**2. `SchemaThumbnail` 的缩放预览层加 `inert`。** 仅有覆盖层不够 —— 见下方焦点顺序实测。

### a11y 论证

- **焦点顺序**:覆盖层 `button` 是卡片内唯一可聚焦节点,焦点顺序 = 卡片视觉顺序,**一卡一停**。修前 DOM 顺序上缩略图在前,从第一张卡 Tab 出去依次落在示例内部的 Submit / Save Draft / Delete / Cancel 才到第二张卡(实测轨迹见下)。`inert` 同时移除聚焦与命中测试,这才让该组件文档里写的「scaled, non-interactive preview」成立;原来的 `pointer-events: none` 只管住了鼠标。另外缩略图框本身带 `aria-hidden`,子树里存在可聚焦节点本身就是 axe `aria-hidden-focus` 违规。
- **焦点环**:`focus-visible:ring-2` 画在覆盖层上,而覆盖层 `inset-0` 解析到外壳的 padding box,因此视觉上仍是「整卡获得焦点」(修后截图里 Simple Login Form 那张卡的环即是)。
- **可访问名**:`aria-label` 为 `Open {title} ({id})`,包含卡片上**可见**的标题与 id,满足 WCAG 2.5.3 label-in-name;role 由 `button` 元素本身提供。
- **鼠标**:hover 仍作用在外壳(hover 沿祖先链传播),边框高亮行为不变;覆盖层带 `cursor-pointer`(Tailwind v4 preflight 不再给 button 设 pointer)。

## 浏览器实证

Chromium(`/opt/pw-browsers/chromium`)+ `next dev`,同一 dev server 上先复现后修复;缩略图是 IntersectionObserver 懒挂载,因此滚动加载后再统计。

| 读数 | 修前 | 修后 |
|---|---|---|
| `document.querySelectorAll('button button').length` | **136** | **0** |
| `cannot be a descendant of` / `cannot contain a nested` 控制台报错 | **2** | **0** |
| 其中 `This will cause a hydration error` | **1** | **0** |
| aria-hidden 预览内可聚焦节点 | **180** | **0** |
| `[inert]` 预览层 | 0 | 115(已挂载的) |
| 卡片外壳是 button | 423 | 0 |
| 覆盖层 button | 0 | 423 |
| Next dev 指示器 Issues 计数 | 12 | 10 |

修前报错样本(祖先栈直接点名 GalleryCard 的外壳 button 套住 ButtonRenderer 的 button):

```
[error] In HTML, %s cannot be a descendant of  %s .
This will cause a hydration error.%s  button   button
  ...
    GalleryCard entry={{id:"action...", ...}}
>     button
>       type="button"
>       onClick={function onClick}
>       className="group flex flex-col gap-2 rounded-lg border border-fd-border bg-fd-card p-3..."
>     
        ...
          SchemaErrorBoundary componentType="button"
            ButtonRenderer schema={{type:"button", ...}} label="Submit"
              Button ref={null} type="button" variant="default"
>               button
>                 className={"inline-flex items-center justify-center gap-2 whitespace-nowrap..."}
```

点击导航实测(抽 3 张卡实点,dialog 的 aria-label 与卡片标题一致,Esc 关闭):

```
Open Action Button Variants (actions/action-button-variants) -> dialog "Action Button Variants"
Open Action Toolbar (actions/action-toolbar)                 -> dialog "Action Toolbar"
Open Confirmation Dialog (actions/confirmation-dialog)       -> dialog "Confirmation Dialog"
```

焦点顺序实测(聚焦第一张卡后连按 Tab):

```
修前: 卡1外壳 -> Submit -> Save Draft -> Delete -> Cancel -> 卡2外壳 -> Reject
修后: 卡1覆盖层 -> 卡2 -> 卡3 -> 卡4 -> 卡5 -> 卡6 -> 卡7
```

截图与完整控制台日志留在 scratchpad(`3903-before.png` / `3903-after.png` / `3903-*-console.log`)。

## 测试

`apps/site` **没有 vitest 面**(根 `vitest.config.mts` 的 `sharedExclude` 含 `apps/**`,`projects` 只额外注册了 `apps/console`),而这个缺陷形态是静态可判的,所以结构钉放在 `scripts/__tests__/` —— 与 `site-playground-layout-registration-3904.test.ts` 同一高度、同一理由,且它在 CI 的根 vitest 分片里真的会跑(不是只能靠一个默认被 skip 的 docs-smoke e2e)。

钉子用 TS AST 遍历 apps/site 全部 tsx:任何 schema 预览宿主(`SchemaRenderer` / `SchemaThumbnail` / `InteractiveDemo` / `LiveSplitDemo` / `SchemaExample`)与任何 `button`,都不得落在 `button` 或 `role="button"` 的子树里 —— **按发现而非硬编码文件清单**,明天新加的第二个宿主会被同样抓到。防空转绿三重:检测器先对四份合成样本自测(修前形状、button 套 button、`div role=button` 改写、覆盖层形状),再断言扫描确实覆盖到 ≥10 个文件且含卡片文件,并断言卡片文件里确实同时存在预览宿主与 button。最后一条 suite 钉 `inert` + `pointer-events-none`。

反向验证(方向在跑之前就已预判,两条都是朴素红):

```
修前(pristine main):  Tests  2 failed | 7 passed (9)
  × finds no schema preview nested inside an interactive control
      + [ "apps/site/app/components/SchemaCatalogIndex.tsx:116 SchemaThumbnail inside  button  at line 111" ]
  × SchemaRenderer #0 is wrapped in an inert, pointer-events-none subtree
      no ancestor ... carries inert: expected 0 to be greater than 0
修后:                 Test Files  1 passed (1) / Tests  9 passed (9)
```

其余门(仓根,全部在共享 verify 锁内串行):

```
pnpm exec vitest run scripts/__tests__/site-catalog-card-interactive-nesting-3903.test.ts --maxWorkers=2   PIN_EXIT=0
pnpm run type-check:scripts                                                                                SCRIPTS_TC_EXIT=0
pnpm --filter @object-ui/site types:check                                                                  SITE_TC_EXIT=0
pnpm exec turbo run type-check --concurrency=2                        Tasks: 78 successful, 78 total       TURBO_TC_EXIT=0
node scripts/check-control-bytes.mjs        OK (3852 tracked text files)
pnpm exec eslint (三个改动文件)              0
```

## changeset

无需 changeset:`.changeset/config.json` 把 `@object-ui/site` 列在 `ignore`,且 `scripts/check-changeset-presence.mjs` 只守 `fixed` 组里每个包自己的 `src` 目录(即 包名 + `/src/**`);本 PR 改的是 `apps/site/app/**` 与 `scripts/__tests__/**`,两者都不在守护面内。

## 范围之外

- `content/**/*.mdx` 里的 `SchemaExample` 用法不在这条 AST 规则的扫描面(只扫 tsx),跨组件边界的交互性分析也不在 —— 缺陷本身与回归都会是同一文件内的 JSX 形状,更大的全图分析是另一件工具。
- 修后 `button [aria-hidden]` 仍有 91 处:那是页面上**其它** button(站点 chrome 与预览内部按钮)里的 aria-hidden 图标节点,与本单无关,非残留。
