### PR TITLE
fix(predicate): 「空谓词」不再算已声明门 —— 唯一定义下沉 core,渲染面 / SchemaRenderer / 执行门同读 (#3850, #3862)

### DIFF
--- a/.changeset/empty-predicate-declared-gate-3850-3862.md
+++ b/.changeset/empty-predicate-declared-gate-3850-3862.md
@@ -1,0 +1,74 @@
+---
+"@object-ui/core": patch
+"@object-ui/components": patch
+"@object-ui/react": patch
+---
+
+An empty predicate is no longer a declared gate anywhere (objectui#3850, objectui#3862)
+
+"Is a gate DECLARED on this key — is there a condition to reach a verdict on?" was
+answered three times in this repo, with three different scopes, and the widest
+answers sat on `disabled`, where the mistake is not benign:
+
+- `hasDeclaredVisibilityGate` (the action face) asked `!= null && !== ''`, so every
+  OBJECT counted — including `{ dialect: 'cel', source: '' }`. That envelope is not
+  a hand-written curiosity: `@objectstack/spec`'s `ExpressionInputSchema` normalizes
+  every authored predicate into one, so "the author left the predicate empty"
+  compiles to exactly it. The verdict path normalized the same value back to
+  `undefined`, and `evaluateCondition(undefined)` answers `true` — "no condition, so
+  visible/enabled". On `visible` that `true` means SHOW, so the two mistakes
+  cancelled; on `disabled` it means GREY, so they compounded: a button disabled
+  forever that no author asked to disable (objectui#3850, the residue objectui#3842
+  left behind).
+- `SchemaRenderer` asked `disabled !== undefined` inline, one notch wider again, so
+  `disabled: null` greyed out too — on the GENERIC rendering path, since that block
+  runs for every node type, and not as an internal flag either: `_disabled` is
+  forwarded to the component as a real `disabled` prop (objectui#3862).
+- `ActionRunner`'s execution gates asked "does this normalize to something
+  evaluable?" — the scope that turned out to be right (objectui#3848 / objectui#3872).
+
+There is now ONE definition, `hasDeclaredPredicate`, exported from
+`@object-ui/core` (`evaluator/declaredPredicate.ts`, beside the `toPredicateInput`
+normalizer it is derived from): a gate is declared when normalization still leaves a
+condition to evaluate. `''`, a whitespace-only string, an empty-`source` envelope
+and any non-predicate value (`0`, `{}`) are NOT declared; `false` IS (a verdict is
+not a missing gate — objectui#3812). `hasDeclaredVisibilityGate` keeps its name as a
+re-export of it, so the five member-action renderer call sites, `DeclaredActionsBar`
+and `record-quick-actions` are unchanged and inherit the scope;
+`SchemaRenderer`'s `disabled` / `disabledOn` chain and `ActionRunner`'s two gates
+read the same function. No consumer got a local "and also check for empty" test —
+that fourth dialect is what objectui#3842 / objectui#3849 spent two PRs merging away.
+
+Measured behaviour change, `action:button` and the generic path, before → after:
+
+| value | `visible` | `disabled` | `enabled` | `SchemaRenderer` `disabled` prop |
+|---|---|---|---|---|
+| `''` | shown → shown | on → on | on → on | forwarded → absent |
+| `null` | shown → shown | on → on | on → on | forwarded → absent |
+| `{ dialect: 'cel', source: '' }` | shown → shown | GREY → on | on → on | forwarded → absent |
+| `{ source: '' }` | shown → shown | GREY → on | on → on | forwarded → absent |
+| `'   '` (whitespace) | HIDDEN → shown | on → on | GREY → on | forwarded → absent |
+| `0` / `{}` (not predicates) | shown → shown | GREY → on | on → on | forwarded → absent |
+| `true` / `false` / bare CEL / `${…}` / non-empty envelope | unchanged | unchanged | unchanged | unchanged |
+
+Every row moves toward "there is no gate here", never away from it, and no value
+that HAS a verdict changes it — the verdict is still read from the raw value, only
+the gate in front of it narrowed. Two rows are behaviour changes rather than the
+equivalence the ruling expected, and are pinned as such: the whitespace string moves
+on `visible` / `enabled` (it used to normalize to `'${   }'`, which evaluates falsy,
+so a predicate that says nothing HID the action from everyone), and non-predicate
+junk stops greying controls out (fail-open, the posture `ActionRunner` already
+committed to).
+
+One blank spelling is knowingly still outside the scope: an envelope whose `source`
+is blank but not EMPTY (`{ dialect: 'cel', source: '   ' }`) — the normalizer folds a
+`source` of `''` and does not trim, so the string spelling of a blank predicate is
+trimmed and the envelope spelling is not, and `disabled` still greys out for that one
+value. The ruling enumerated three empty spellings; this is a fourth, measured and
+filed as objectui#3960 rather than widened in here.
+
+One chain is deliberately untouched: `SchemaRenderer`'s `visible` / `visibleWhen` /
+`visibleOn` / `visibility` / `hidden` / `hiddenOn` legs keep `!== undefined`, because
+narrowing them would change ALIAS PRECEDENCE, not just emptiness. The `hidden` legs
+are not negated and therefore carry this same defect with the polarity that makes the
+node vanish — measured, out of this ruling's scope, filed as objectui#3955.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -42,9 +42,12 @@ export { cva } from 'class-variance-authority';
 export { getLazyIcon, isLucideIconName, LazyIcon, toKebabIconName } from './lib/lazy-icon';
 
 // The member-action visibility gate — "did this action DECLARE a `visible` gate
-// at all?" (`!= null && !== ''`), the single definition objectui#3492
-// established and PR #3816 / #3825 / #3836 applied to every member-action gate
-// in this package and in `plugin-grid`.
+// at all?", the single definition objectui#3492 established and PR #3816 /
+// #3825 / #3836 applied to every member-action gate in this package and in
+// `plugin-grid`. Since objectui#3850 the answer is "normalization still leaves a
+// condition to evaluate" (so an empty-`source` envelope is NOT a gate, where the
+// older `!= null && !== ''` counted every object), and this name is a re-export
+// of core's one definition, `hasDeclaredPredicate`.
 //
 // Exported because the family has a member OUTSIDE these packages: app-shell's
 // `DeclaredActionsBar` mounts an object's server-declared actions as plain JSX

--- a/packages/components/src/renderers/action/__tests__/action-empty-predicate-scope.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-empty-predicate-scope.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3850 — how wide "empty predicate" is on the action face, now that
+ * `hasDeclaredVisibilityGate` is a re-export of core's one definition
+ * (`hasDeclaredPredicate`, `evaluator/declaredPredicate.ts`) instead of a
+ * second, narrower answer to the same question.
+ *
+ * The residue objectui#3842 left behind: `hasDeclaredVisibilityGate` asked
+ * `!= null && !== ''`, so every OBJECT counted as a declared gate — including
+ * `{ dialect: 'cel', source: '' }`, the shape `@objectstack/spec`'s
+ * `ExpressionInputSchema` produces when an author leaves a predicate empty, and
+ * therefore the empty shape most likely to reach a renderer from real metadata.
+ * The verdict path normalized the same value to `undefined`, and
+ * `evaluateCondition(undefined)` answers `true` = "no condition → visible /
+ * enabled". On `visible` that `true` means SHOW, so the two mistakes cancelled;
+ * on `disabled` it means GREY, so they compounded — a button disabled forever
+ * that no author asked to disable.
+ *
+ * ## What each case detects
+ *
+ *   • the `disabled` leg's two envelope cases (`{ dialect, source: '' }` and
+ *     `{ source: '' }`) → clickable. THE defect, one case per row of the #3850
+ *     table's "残留" lines. Restore `!= null && !== ''` in the definition and
+ *     exactly these go red.
+ *   • the `disabled` leg's junk cases (`0`, `{}`) → clickable. Behaviour change
+ *     in the same fail-open direction: a value the evaluator cannot read must not
+ *     be the reason a control is dead. (`ActionRunner` already committed this
+ *     module family to `catch { isDisabled = false }`.)
+ *   • `disabled: true` / a truthy expression / a truthy CEL envelope → still
+ *     greyed. Anti-mutation guards: "never disable anything" satisfies most of
+ *     this file on its own, and these refuse it.
+ *   • `disabled: false` and no `disabled` at all → still clickable, so widening
+ *     "empty" did not swallow a declared-and-false verdict (objectui#3812).
+ *   • the `visible` leg's empty cases → still rendered, which is the EQUIVALENCE
+ *     the objectui#3850 ruling asked for on that family. Two of the three rows
+ *     are equivalence in the strict sense (`''` and the envelope reached "shown"
+ *     before this change too, by cancellation); the whitespace row is NOT — see
+ *     the next block, which pins the change rather than hiding it.
+ *
+ * ## The whitespace row moves, and this suite says so out loud
+ *
+ * Measured on this tree, `action:button` before → after:
+ *
+ *   | value                          | `visible`      | `disabled`  | `enabled`  |
+ *   |--------------------------------|----------------|-------------|------------|
+ *   | `''`                           | shown → shown  | on → on     | on → on    |
+ *   | `{ dialect:'cel', source:'' }` | shown → shown  | GREY → on   | on → on    |
+ *   | `{ source: '' }`               | shown → shown  | GREY → on   | on → on    |
+ *   | `'   '` (whitespace only)      | HIDDEN → shown | on → on     | GREY → on  |
+ *   | `0` / `{}`                     | shown → shown  | GREY → on   | on → on    |
+ *
+ * `'   '` used to be a declared gate whose verdict came from `'${   }'` (the
+ * normalizer wraps a whitespace string rather than folding it), which evaluates
+ * falsy — so a predicate that says nothing HID the action from everyone, and
+ * greyed it out through the negated `enabled` leg. Moving it to "no gate" is the
+ * direction this gate's own doc has always claimed ("an empty predicate must not
+ * hide the action from everyone either"); it is a behaviour CHANGE on `visible`
+ * and `enabled` all the same, so it is pinned as one.
+ *
+ * ## Why one leaf plus an identity assertion covers five call sites
+ *
+ * `action:button`, `action:icon`, `action:group`'s inline button and dropdown
+ * item, and `action:menu`'s item all import the same symbol from
+ * `../visibility-gate` — unchanged by this move, which is the point of keeping
+ * the name. The identity case below asserts that symbol IS core's
+ * `hasDeclaredPredicate`, so the scope pinned here is the scope all five read; a
+ * leaf that re-spelled the question locally would break that claim, not hide
+ * behind it. The `''` rows for the member leaves stay where objectui#3842 /
+ * objectui#3849 put them (`action-member-disabled-declared-gate.test.tsx`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry, hasDeclaredPredicate } from '@object-ui/core';
+import { PredicateScopeProvider } from '@object-ui/react';
+// Module-scope side-effect import so the renderer is in the registry when
+// `ComponentRegistry.get` runs (the light `dom` project does not load the
+// `@object-ui/components` graph), per AGENTS.md §测试纪律.
+import '../action-button';
+import { hasDeclaredVisibilityGate } from '../visibility-gate';
+
+/** Mount the leaf the way `action:bar` mounts it: whole action spread onto `schema`. */
+function renderLeaf(action: Record<string, unknown>, scope: Record<string, unknown> = {}) {
+  const Renderer = ComponentRegistry.get('action:button');
+  if (!Renderer) throw new Error('action:button is not registered');
+  return render(
+    <PredicateScopeProvider scope={scope}>
+      <Renderer schema={{ ...action, type: 'action:button', actionType: 'script' }} />
+    </PredicateScopeProvider>,
+  );
+}
+
+const ACT = { name: 'act', label: 'Act', type: 'script' };
+const act = () => screen.getByRole('button', { name: 'Act' });
+
+/** The shapes with nothing to evaluate, by the spelling that produces them. */
+const EMPTY_SHAPES: Array<{ label: string; value: unknown }> = [
+  { label: "'' (empty string)", value: '' },
+  { label: "'   ' (whitespace only)", value: '   ' },
+  { label: "{ dialect: 'cel', source: '' } (what `objectstack build` emits)", value: { dialect: 'cel', source: '' } },
+  { label: "{ source: '' } (envelope without a dialect)", value: { source: '' } },
+  { label: 'null', value: null },
+];
+
+/** Values the evaluator cannot read at all. */
+const JUNK_SHAPES: Array<{ label: string; value: unknown }> = [
+  { label: '0', value: 0 },
+  { label: '{} (an object with no source)', value: {} },
+];
+
+describe('the one definition — `hasDeclaredVisibilityGate` is core\'s `hasDeclaredPredicate` (objectui#3850)', () => {
+  it('is the same function object, not a same-shaped copy', () => {
+    // A re-spelled twin here is how this question grew three scopes in the first
+    // place (objectui#3142 is what copies of one answer cost). Identity, so the
+    // five member-action call sites and this suite cannot drift apart.
+    expect(hasDeclaredVisibilityGate).toBe(hasDeclaredPredicate);
+  });
+
+  it('answers the empty spellings and the junk with "no gate", and a declared boolean with "gate"', () => {
+    for (const { label, value } of [...EMPTY_SHAPES, ...JUNK_SHAPES]) {
+      expect(hasDeclaredVisibilityGate(value), `${label} must not count as a declared gate`).toBe(false);
+    }
+    expect(hasDeclaredVisibilityGate(false)).toBe(true);
+    expect(hasDeclaredVisibilityGate(true)).toBe(true);
+  });
+});
+
+describe('action:button `disabled` — an empty predicate is not a gate (objectui#3850)', () => {
+  it.each(EMPTY_SHAPES)('disabled: $label → the button stays clickable', ({ value }) => {
+    renderLeaf({ ...ACT, disabled: value });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it.each(JUNK_SHAPES)('disabled: $label (not a predicate) → the button stays clickable', ({ value }) => {
+    renderLeaf({ ...ACT, disabled: value });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('disabled: true → still greyed out', () => {
+    renderLeaf({ ...ACT, disabled: true });
+    expect(act()).toBeDisabled();
+  });
+
+  it('disabled: false → still clickable (a verdict, not a missing gate)', () => {
+    renderLeaf({ ...ACT, disabled: false });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('no `disabled` at all → still clickable', () => {
+    renderLeaf({ ...ACT });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it("disabled: { dialect: 'cel', source: 'true' } → still greyed out (a NON-empty envelope is a gate)", () => {
+    renderLeaf({ ...ACT, disabled: { dialect: 'cel', source: 'true' } });
+    expect(act()).toBeDisabled();
+  });
+
+  it('an expression-valued `disabled` keeps its verdict, both ways', () => {
+    const gated = { ...ACT, disabled: 'features.locked == true' };
+    const { unmount } = renderLeaf(gated, { features: { locked: true } });
+    expect(act()).toBeDisabled();
+    unmount();
+    renderLeaf(gated, { features: { locked: false } });
+    expect(act()).not.toBeDisabled();
+  });
+});
+
+describe('action:button `visible` — the equivalence the ruling asked for, and the one row that moves', () => {
+  it.each(EMPTY_SHAPES)('visible: $label → the action is still rendered', ({ value }) => {
+    renderLeaf({ ...ACT, visible: value });
+    expect(act()).toBeInTheDocument();
+  });
+
+  it.each(JUNK_SHAPES)('visible: $label (not a predicate) → still rendered', ({ value }) => {
+    renderLeaf({ ...ACT, visible: value });
+    expect(act()).toBeInTheDocument();
+  });
+
+  it('visible: false → still hidden, and visible: true / a true predicate still shown', () => {
+    const { container, unmount } = renderLeaf({ ...ACT, visible: false });
+    expect(container.querySelector('button')).toBeNull();
+    unmount();
+    renderLeaf({ ...ACT, visible: true });
+    expect(act()).toBeInTheDocument();
+  });
+
+  it('a false expression still hides it (the gate narrowed; evaluation did not change)', () => {
+    const { container } = renderLeaf({ ...ACT, visible: 'features.beta == true' }, { features: { beta: false } });
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it("CHANGED: visible: '   ' was HIDDEN before this ruling and is now shown", () => {
+    // Not equivalence — the honest row. `'   '` normalized to `'${   }'`, which
+    // evaluates falsy, so a predicate that says nothing hid the action from
+    // everyone. See this file's header table.
+    renderLeaf({ ...ACT, visible: '   ' });
+    expect(act()).toBeInTheDocument();
+  });
+});
+
+describe('action:button legacy `enabled` leg — same definition, same scope', () => {
+  it.each(EMPTY_SHAPES)('enabled: $label → not greyed out', ({ value }) => {
+    renderLeaf({ ...ACT, enabled: value });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('CHANGED: enabled: \'   \' greyed the button out before this ruling', () => {
+    // The negated leg (`disabled = !isEnabled`) turned the whitespace string's
+    // falsy verdict into "disabled". Covered by the row above; stated separately
+    // because it is a behaviour change, not a preserved one.
+    renderLeaf({ ...ACT, enabled: '   ' });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('enabled: false → still greyed out (unchanged)', () => {
+    renderLeaf({ ...ACT, enabled: false });
+    expect(act()).toBeDisabled();
+  });
+
+  it('enabled: true → not greyed out (unchanged)', () => {
+    renderLeaf({ ...ACT, enabled: true });
+    expect(act()).not.toBeDisabled();
+  });
+
+  it('`disabled` still wins over `enabled` when it is declared', () => {
+    renderLeaf({ ...ACT, disabled: true, enabled: true });
+    expect(act()).toBeDisabled();
+  });
+
+  it("an EMPTY `disabled` no longer short-circuits the chain — `enabled: false` is reached", () => {
+    // The precedence case: with `disabled: ''` no longer a gate, the chain falls
+    // through to the legacy leg instead of stopping at an empty predicate.
+    renderLeaf({ ...ACT, disabled: '', enabled: false });
+    expect(act()).toBeDisabled();
+  });
+
+  it('an empty ENVELOPE `disabled` falls through the same way (objectui#3850 row)', () => {
+    const { unmount } = renderLeaf({ ...ACT, disabled: { dialect: 'cel', source: '' }, enabled: false });
+    expect(act()).toBeDisabled();
+    unmount();
+    // The other direction is the mutation detector of the pair: under the old
+    // scope the envelope was a declared gate whose verdict was `true`, so the
+    // button was greyed out no matter what `enabled` said.
+    renderLeaf({ ...ACT, disabled: { dialect: 'cel', source: '' }, enabled: true });
+    expect(act()).not.toBeDisabled();
+  });
+});

--- a/packages/components/src/renderers/action/visibility-gate.ts
+++ b/packages/components/src/renderers/action/visibility-gate.ts
@@ -7,39 +7,76 @@
  */
 
 /**
- * Did this action DECLARE a visibility gate at all? The one definition read by
- * every member-action leaf on the action face — `action:group`'s inline button
- * and dropdown item, and `action:menu`'s item — so the three cannot drift into
- * three answers for one key (the shape objectui#3142 already had to unpick for
- * `locations` in these same files).
+ * Did this action DECLARE a visibility gate at all? The renderer-side name for
+ * the repo's one definition of that question, which now lives one layer down in
+ * `@object-ui/core` as `hasDeclaredPredicate`
+ * (`packages/core/src/evaluator/declaredPredicate.ts`) — read the reasoning
+ * there; only what is specific to this file is repeated below.
  *
- * Truthiness cannot answer this question, and asking it is the objectui#3812
- * defect: `if (action.visible && !isVisible)` classified `visible: false` — the
- * most explicit way an author can say "never show this" — as *ungated*, so the
- * gate never consulted the verdict and the action rendered for everyone.
+ * ## Why this module is now a re-export (objectui#3850 / objectui#3862)
  *
- * `!= null && !== ''` is not a new decision. objectui#3492 established it for
- * the selection bar, where `plugin-grid`'s `hasVisibilityGate` spells out the
- * same reasoning verbatim ("Truthiness cannot answer this: `visible: false` is
- * a declared gate that excludes everything"); objectui#3758 / PR #3816 applied
- * it to both row-action surfaces (`isCustomRowActionVisible` in
- * `plugin-grid/src/components/RowActionMenu.tsx` and
- * `renderers/complex/data-table.tsx`).
+ * The question was answered three times with three different scopes, and the
+ * widest-scoped answer was on the key where the mistake is not benign:
  *
- * This function decides only whether a gate EXISTS. The verdict is the
- * declaration's own business and is left to the evaluation entry, which already
- * short-circuits a boolean instead of handing it to the CEL engine:
- * `useCondition(toPredicateInput(false))` is `false` and
- * `useCondition(toPredicateInput(true))` is `true`, pinned for both the engine
- * and the renderer path in
- * `packages/react/src/hooks/__tests__/actionPredicate.parity.test.tsx`. Nothing
- * about that entry changes here — only the gate in front of it, which refused
- * to ask.
+ *   - HERE, `!= null && !== ''` — so every OBJECT counted as a declared gate,
+ *     including `{ dialect: 'cel', source: '' }`. That envelope is not an exotic
+ *     spelling: `@objectstack/spec`'s `ExpressionInputSchema` normalizes every
+ *     authored predicate into one, so "the author left the predicate empty"
+ *     compiles to exactly it. The verdict path then normalized the same value to
+ *     `undefined` and `evaluateCondition(undefined)` answered `true` = "no
+ *     condition, so visible/enabled" — which on `disabled` means GREYED OUT.
+ *     A button disabled forever, indistinguishable from the metadata's intent
+ *     (objectui#3850).
+ *   - `SchemaRenderer`'s inline `!== undefined`, one notch wider again, so
+ *     `disabled: null` greyed out any node on the generic rendering path
+ *     (objectui#3862).
+ *   - `ActionRunner`'s module-private helper, which asked "does this normalize
+ *     to something evaluable?" — the scope objectui#3850 then ruled to be THE
+ *     scope (objectui#3848).
  *
- * `''` is grouped with `null`/`undefined` deliberately: an empty predicate is
- * nothing to evaluate, so it must not hide the action from everyone either.
- * `toPredicateInput` maps it to `undefined` (visible) for the same reason.
+ * The ruling: a gate is declared when normalization still leaves a condition to
+ * evaluate. `''`, a whitespace-only string, an empty-`source` envelope and any
+ * non-predicate value are therefore NOT declared, and one definition in core
+ * says so for the renderers, `SchemaRenderer` and the execution entry alike.
+ *
+ * The NAME is kept (`hasDeclaredVisibilityGate`) and this module keeps
+ * re-exporting it: the five member-action call sites — `action:button`,
+ * `action:icon`, `action:group`'s inline button and dropdown item, and
+ * `action:menu`'s item, plus `DeclaredActionsBar` and `record-quick-actions`
+ * through the `@object-ui/components` barrel — are unchanged by this move. The
+ * name is historic (objectui#3492 arrived through `visible`) and the predicate is
+ * key-neutral, which the call-site comments already say.
+ *
+ * ## What did NOT change: truthiness still cannot answer this
+ *
+ * `if (action.visible && !isVisible)` was the objectui#3812 defect: it
+ * classified `visible: false` — the most explicit way an author can say "never
+ * show this" — as *ungated*, so the gate never consulted the verdict and the
+ * action rendered for everyone. A declared boolean is still a declared gate
+ * here; only the empty and non-predicate shapes moved.
+ *
+ * ## The scope change is not verdict-neutral on every key — measured
+ *
+ * On `visible` the empty shapes were mostly benign already, because the two
+ * mistakes cancelled: over-broad "declared" plus `evaluateCondition` answering
+ * `true` for an empty predicate = SHOWN, the same result as "no gate". Measured
+ * on this tree (`action:button`, before → after):
+ *
+ *   | value                        | `visible`         | `disabled`        | `enabled`         |
+ *   |------------------------------|-------------------|-------------------|-------------------|
+ *   | `''`                         | shown → shown     | on → on           | on → on           |
+ *   | `{ dialect:'cel', source:'' }`| shown → shown    | GREY → on         | on → on           |
+ *   | `{ source: '' }`             | shown → shown     | GREY → on         | on → on           |
+ *   | `'   '` (whitespace)         | HIDDEN → shown    | on → on           | GREY → on         |
+ *   | `0` / `{}` (not a predicate) | shown → shown     | GREY → on         | on → on           |
+ *   | `true` / `false` / CEL / `${…}`| unchanged        | unchanged         | unchanged         |
+ *
+ * The whitespace row is the one that moves on `visible`, and it moves toward the
+ * invariant rather than away from it: `'   '` used to be normalized to `'${   }'`
+ * (the normalizer wraps it rather than folding it), which evaluates falsy, so a
+ * predicate that says nothing HID the action from everyone. "An empty predicate
+ * must not hide the action from everyone" is what this gate has always claimed —
+ * the whitespace spelling simply never obeyed it. Same story on the negated
+ * `enabled` leg, where it greyed the control out instead.
  */
-export function hasDeclaredVisibilityGate(visible: unknown): boolean {
-  return visible != null && visible !== '';
-}
+export { hasDeclaredPredicate as hasDeclaredVisibilityGate } from '@object-ui/core';

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -24,7 +24,7 @@
 import type { RunnableActionType } from '@object-ui/types';
 import type { ActionInput as SpecActionInput } from '@objectstack/spec/ui';
 import { ExpressionEvaluator } from '../evaluator/ExpressionEvaluator';
-import { toPredicateInput } from '../evaluator/predicateInput';
+import { hasDeclaredPredicate } from '../evaluator/declaredPredicate';
 import { globalUndoManager, type UndoableOperation } from './UndoManager';
 import { warnOnDeprecatedObjectParams, warnOnUnknownActionKeys } from './actionKeys';
 
@@ -536,19 +536,19 @@ function withIdentityAlias(context: ActionContext): ActionContext {
   return { ...context, os: { ...(os && typeof os === 'object' ? os : {}), user } };
 }
 
-/**
- * Did this action declare a gate at all — i.e. is there a CONDITION for the
- * evaluator to reach a verdict on? (objectui#3848 for `disabled`, objectui#3872
- * for `condition`)
+/*
+ * ## The two predicate gates in `execute`, and the one question they ask first
  *
- * ## One definition, two gates — why this is not two helpers
- *
- * `execute` has two predicate gates, and both need this ONE question answered
- * before evaluating. They need it for OPPOSITE reasons, which is exactly why the
- * question has to be asked separately from the verdict:
+ * `execute` gates on `condition` and on `disabled`, and both need ONE question
+ * answered before evaluating — "is a gate DECLARED here, i.e. is there a
+ * condition to reach a verdict on?" — for OPPOSITE reasons, which is exactly why
+ * the question has to be asked separately from the verdict:
  *
  *   - `disabled` (objectui#3848): an EMPTY predicate must not be handed to
  *     `evaluateCondition`, whose answer for "no condition" is `true` = BLOCKED.
+ *     Measured consequence of asking `!= null && !== false` instead:
+ *     `disabled: ''` returned `{ success: false, error: 'Action is disabled' }`
+ *     and the handler never ran.
  *   - `condition` (objectui#3872): a DECLARED-FALSE predicate must not be
  *     skipped by a truthiness test. `if (action.condition)` never asked whether
  *     a gate was declared, so `condition: false` — the most explicit "never
@@ -560,49 +560,28 @@ function withIdentityAlias(context: ActionContext): ActionContext {
  *     short-circuits booleans (`if (typeof condition === 'boolean') return
  *     condition`) and blocks.
  *
- * The scope of "empty predicate" below is objectui#3850's ruling (`''` /
- * whitespace-only / empty-`source` envelope are NOT declared), so both gates
- * read the same one. A second module-private twin of the same question in this
- * one file is the drift the closing scope note refuses; the name is therefore
- * key-neutral, and the `disabled` gate's semantics and message are unchanged by
- * objectui#3872.
+ * Both read {@link hasDeclaredPredicate} — the repo's one definition of that
+ * question, in `evaluator/declaredPredicate.ts` beside the normalizer it is
+ * derived from, with the scope objectui#3850 ruled on (`''` / whitespace-only /
+ * empty-`source` envelope / non-predicate junk are NOT declared; a declared
+ * `false` IS). This gate arrived here first as a module-private helper with a
+ * scope note saying it stayed private until that ruling landed; it has, so the
+ * definition moved down a layer and the renderer side reads the same one
+ * (`components/renderers/action/visibility-gate.ts` re-exports it as
+ * `hasDeclaredVisibilityGate`, `SchemaRenderer`'s `disabled` chain calls it).
  *
- * `ExpressionEvaluator.evaluateCondition` documents and implements one default
- * for "there is no condition here": it returns `true`, meaning
- * *visible/enabled*. That default is correct on `visible` / `enabled`, and
- * INVERTED on `disabled`, where `true` means "blocked". So the execution gate
- * must decide "is there a condition?" itself, BEFORE evaluating — asking
- * `!= null && !== false` (what it used to ask) hands every empty predicate to a
- * function whose answer for "nothing to evaluate" is the strongest possible
- * "yes, disabled". Measured consequence: `disabled: ''` returned
- * `{ success: false, error: 'Action is disabled' }` and the handler never ran.
+ * ## Why the gates normalize to DECIDE but evaluate the RAW value
  *
- * The shapes `evaluateCondition` itself calls "no condition" are `null` /
- * `undefined` / `''` / a whitespace-only string (`if (!trimmed) return true`) /
- * an envelope whose `source` is blank. This gate excludes exactly those:
- *
- *   - `toPredicateInput` is core's single predicate normalizer and already maps
- *     `''`, `null`, `undefined`, an empty-`source` envelope, and any
- *     non-predicate junk (`0`, `{}`) to `undefined` = "nothing to evaluate".
- *   - the whitespace-only string is the one shape it does NOT collapse (it
- *     wraps it as `'${   }'`), so it is named here. This is the same blank-source
- *     rule core's other predicate entry already applies —
- *     `evalRowPredicate` (`evaluator/listConditional.ts`) returns its fallback
- *     for `!source.trim()`.
- *
- * ## Why the gate normalizes but the VERDICT still reads the raw value
- *
- * Historically the two were NOT interchangeable for a string already spelled as
+ * Historically the two were not interchangeable for a string already spelled as
  * a `${…}` template: `toPredicateInput` assumed a bare expression and wrapped
  * unconditionally, so `'${x}'` became `'${${x}}'`, which no longer matched the
  * single-template fast path and did not parse — leaving a constant verdict whose
  * direction was set by the caller's error policy (fail-soft got the unparsed
  * string back, `Boolean(…)` = `true`; fail-closed got a throw). On `disabled`
- * that meant "always blocked", on `condition` the opposite ("always execute"),
- * so both gates here normalize only to decide DECLAREDNESS and evaluate the raw
- * value. That defect was objectui#3871, fixed at the normalizer: an
- * already-`${…}` string is now returned untouched, the normalizer is idempotent,
- * and `evaluateCondition(toPredicateInput(raw))` agrees with
+ * that meant "always blocked", on `condition` the opposite ("always execute").
+ * That defect was objectui#3871, fixed at the normalizer: an already-`${…}`
+ * string is returned untouched, the normalizer is idempotent, and
+ * `evaluateCondition(toPredicateInput(raw))` agrees with
  * `evaluateCondition(raw)` on every shape these gates accept.
  *
  * The gates still read the raw value. Nothing forces the change now that the two
@@ -610,33 +589,18 @@ function withIdentityAlias(context: ActionContext): ActionContext {
  * reason has shifted from "must" to "no reason to", so the equality is pinned
  * next to each gate's suite (`ActionRunner.disabledGate.test.ts` /
  * `ActionRunner.conditionGate.test.ts`, the two cases that replaced the
- * objectui#3871 tripwires) instead of being assumed.
- *
- * So the value handed to the evaluator is left exactly as it was. Every
- * non-empty shape — boolean, bare CEL, `${…}` template, `{ dialect, source }`
- * envelope — keeps the verdict it reaches today, and this change can only stop
- * blocking things, never start.
- *
- * Scope note: `hasDeclaredVisibilityGate`
- * (`components/renderers/action/visibility-gate.ts`, `!= null && !== ''`) is
- * the renderer-side spelling of this question. It is deliberately NOT reused or
- * moved: it lives in a package that depends on this one, it does not cover the
- * empty-`source` envelope (objectui#3850) or the whitespace string, and
- * objectui#3850 is the queued ruling on unifying the scope of "empty
- * predicate" across the sites. Kept module-private until that lands — one
- * definition, one module, no new exported dialect of the same question.
+ * objectui#3871 tripwires) instead of being assumed. Every non-empty shape —
+ * boolean, bare CEL, `${…}` template, `{ dialect, source }` envelope — keeps the
+ * verdict it reaches today.
  *
  * Nor is the `visible`-filter template in `ActionEngine.getActionsForLocation`
- * copied wholesale: its non-predicate branch keeps a historical
- * `Boolean(raw)` coercion, so `0` there means "hidden" — fail-CLOSED on junk,
- * the opposite of what this module already committed to for `disabled`
+ * copied wholesale: its non-predicate branch keeps a historical `Boolean(raw)`
+ * coercion, so `0` there means "hidden" — fail-CLOSED on junk, the opposite of
+ * what this module already committed to for `disabled`
  * (`catch { isDisabled = false }`). A value that is not a predicate at all must
- * not decide an action's fate, on either key, so `0` / `{}` are "no gate" here.
+ * not decide an action's fate, on either key, so `0` / `{}` are "no gate" here
+ * and in the shared definition.
  */
-function hasDeclaredPredicate(value: unknown): boolean {
-  if (typeof value === 'string' && value.trim() === '') return false;
-  return toPredicateInput(value) !== undefined;
-}
 
 export class ActionRunner {
   private handlers = new Map<string, ActionRunnerHandler>();

--- a/packages/core/src/actions/__tests__/ActionRunner.conditionGate.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.conditionGate.test.ts
@@ -295,7 +295,13 @@ describe('why the `condition` gate cannot ask truthiness (objectui#3872)', () =>
     // does not copy that: `catch { isDisabled = false }` already committed this
     // module to fail-OPEN on junk, and a value that is not a predicate must not
     // decide an action's fate. Pinned so the next reader sees the difference is
-    // chosen, not overlooked — objectui#3850's follow-up owns unifying it.
+    // chosen, not overlooked.
+    //
+    // Ownership, corrected: objectui#3850 landed WITHOUT unifying this — its
+    // ruling covered the "declared?" definition and its placement (core, with
+    // the renderer face and `SchemaRenderer` reading it), not the engine filter's
+    // own scope. `ActionEngine` is now the last consumer answering this question
+    // with its own range, measured on both faces and filed as objectui#3957.
     const engine = new ActionEngine(CONTEXT);
     engine.registerAction(
       { name: 'junk_visible', type: 'script', target: '"ran"', visible: 0 } as unknown as ActionDef,

--- a/packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts
@@ -43,23 +43,30 @@
  *     = false }`): a value that is not a predicate at all must not decide that
  *     an action is disabled.
  *
- * ## The parity claim, and the one row it deliberately does NOT make
+ * ## The parity claim, now made for EVERY row (objectui#3850 closed the last three)
  *
  * `rendererDisabled` is transcribed from objectui#3848's divergence table (the
  * action face as it stands after #3842 + #3849), NOT recomputed here:
  * `@object-ui/core` is the dependency of the renderer packages, so it cannot
- * import them, and the live renderer-side pins are in those two PRs' tests. The
+ * import them, and the live renderer-side pins are in those PRs' tests. The
  * parity test below therefore asserts that the verdicts THIS suite pins equal
  * the verdicts recorded from the renderers — the #3314 invariant (one predicate
- * value, one answer, whichever entry reads it) — for every row where that claim
- * is honest. ONE row is excluded, with its owning issue:
+ * value, one answer, whichever entry reads it).
  *
- *   • `{ dialect: 'cel', source: '' }` — the renderer still greys this out
- *     (`hasDeclaredVisibilityGate` is `!= null && !== ''`, which an envelope
- *     passes). That residual is objectui#3850, the queued ruling on how wide
- *     "empty predicate" is across the sites; the execution side pins the
- *     normalized semantics (an envelope with no source is nothing to evaluate).
- *     Not fixed here — objectui#3850 owns the renderer half.
+ * Three rows used to be excluded, all of them the renderer's "is a gate
+ * DECLARED?" scope: `{ dialect: 'cel', source: '' }` (an envelope passes
+ * `!= null && !== ''`, so the renderer greyed the button out while this side read
+ * the same value as nothing to evaluate) and the two junk rows `0` / `{}` (same
+ * mechanism, coerced instead of folded). objectui#3850 ruled that scope — a gate
+ * is declared when normalization still leaves a condition — and the definition
+ * this file's gate asked privately moved into
+ * `evaluator/declaredPredicate.ts` as `hasDeclaredPredicate`, which the renderer
+ * side now re-exports as `hasDeclaredVisibilityGate`. So the three rows claim
+ * parity, backed by live renderer-side pins rather than transcription alone:
+ * `packages/components/src/renderers/action/__tests__/action-empty-predicate-scope.test.tsx`
+ * (the action leaf, all five empty spellings plus the junk rows) and
+ * `packages/react/src/__tests__/SchemaRenderer.disabledDeclaredGate.test.tsx`
+ * (the generic path, objectui#3862).
  *
  * The two `${…}`-spelled rows used to be excluded as well, and no longer are.
  * The action-face renderers compose `evaluateCondition(toPredicateInput(x))`,
@@ -117,11 +124,13 @@ const SHAPES: Shape[] = [
   { label: "disabled: '' (empty predicate)", disabled: '', blocked: false, rendererDisabled: false },
   { label: "disabled: '   ' (whitespace-only predicate)", disabled: '   ', blocked: false, rendererDisabled: false },
   {
+    // Parity claimed since objectui#3850 moved the "declared?" definition into
+    // core and the renderer side started reading it: an envelope with no source
+    // is nothing to evaluate on both faces.
     label: "disabled: { dialect: 'cel', source: '' } (empty envelope)",
     disabled: { dialect: 'cel', source: '' },
     blocked: false,
-    rendererDisabled: null,
-    divergence: 'objectui#3850 — the renderer still reads an empty-source envelope as a declared gate',
+    rendererDisabled: false,
   },
   // ── unchanged: ungated stays ungated ────────────────────────────────────
   { label: 'disabled absent (undeclared)', absent: true, blocked: false, rendererDisabled: false },
@@ -167,8 +176,10 @@ const SHAPES: Shape[] = [
     rendererDisabled: false,
   },
   // ── behaviour change: non-predicate junk fails open ─────────────────────
-  { label: 'disabled: 0 (not a predicate)', disabled: 0, blocked: false, rendererDisabled: null, divergence: 'objectui#3850 — the renderers read a non-predicate as a declared gate and coerce it' },
-  { label: 'disabled: {} (not a predicate)', disabled: {}, blocked: false, rendererDisabled: null, divergence: 'objectui#3850 — the renderers read a non-predicate as a declared gate and coerce it' },
+  // Parity claimed since objectui#3850: the renderers stopped reading a
+  // non-predicate as a declared gate, so junk fails open on both faces.
+  { label: 'disabled: 0 (not a predicate)', disabled: 0, blocked: false, rendererDisabled: false },
+  { label: 'disabled: {} (not a predicate)', disabled: {}, blocked: false, rendererDisabled: false },
 ];
 
 /** Execute one shape and report whether the handler ran. */
@@ -211,11 +222,12 @@ describe('ActionRunner.execute — declared `disabled` gate (objectui#3848)', ()
 
   it('the execution verdict equals the renderer verdict for every shape where parity is claimed', () => {
     const claimed = SHAPES.filter(s => s.rendererDisabled !== null);
-    // Guard the guard: if a future edit nulls out the whole column, this test
-    // would pass by asserting nothing. Raised from 8 to 10 when objectui#3871
-    // brought the two `${…}` rows into the claim — a floor that does not move
-    // with the table is a floor that stops guarding it.
-    expect(claimed.length).toBeGreaterThanOrEqual(10);
+    // Guard the guard: if a future edit nulls out the column, this test would
+    // pass by asserting nothing. 8 → 10 when objectui#3871 brought the two `${…}`
+    // rows into the claim, 10 → the whole table when objectui#3850 brought the
+    // envelope and junk rows in. A floor that does not move with the table is a
+    // floor that stops guarding it.
+    expect(claimed.length).toBe(SHAPES.length);
     for (const shape of claimed) {
       expect(
         shape.blocked,
@@ -224,20 +236,22 @@ describe('ActionRunner.execute — declared `disabled` gate (objectui#3848)', ()
     }
   });
 
-  it('records which shapes are knowingly still divergent, and who owns each', () => {
+  it('no shape is exempt from the parity claim any more, and a future exemption must name its issue', () => {
+    // This replaces the "which rows are knowingly divergent" case, which after
+    // objectui#3850 would have asserted an EMPTY list — green because nothing is
+    // produced, not because the invariant holds. The claim now is the stronger
+    // one: every shape in the table is compared, and the `divergence` escape
+    // hatch stays exercised — re-introducing one without an owning issue fails
+    // here rather than quietly shrinking the comparison.
     const divergent = SHAPES.filter(s => s.rendererDisabled === null);
-    for (const shape of divergent) {
-      expect(shape.divergence, `${shape.label} must name the issue that owns it`).toMatch(/objectui#\d+/);
+    expect(divergent.map(s => s.label)).toEqual([]);
+    for (const shape of SHAPES) {
+      if (shape.rendererDisabled === null) {
+        expect(shape.divergence, `${shape.label} must name the issue that owns it`).toMatch(/objectui#\d+/);
+      } else {
+        expect(shape.divergence, `${shape.label} claims parity, so it must not also claim a divergence`).toBeUndefined();
+      }
     }
-    // The two `${…}` rows left this list when objectui#3871 was fixed — the
-    // renderer face stopped answering with a constant, so there is no longer a
-    // difference to own. What remains is one family: the renderer's "is a gate
-    // DECLARED?" scope, which objectui#3850 owns for all three shapes.
-    expect(divergent.map(s => s.label)).toEqual([
-      "disabled: { dialect: 'cel', source: '' } (empty envelope)",
-      'disabled: 0 (not a predicate)',
-      'disabled: {} (not a predicate)',
-    ]);
   });
 });
 

--- a/packages/core/src/evaluator/__tests__/declaredPredicate.test.ts
+++ b/packages/core/src/evaluator/__tests__/declaredPredicate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3850 — the ONE definition of "is a predicate gate declared here?",
+ * now that it lives in core beside the normalizer it is derived from. The
+ * consumer-side pins are
+ * `packages/components/src/renderers/action/__tests__/action-empty-predicate-scope.test.tsx`
+ * (the action face, through the `hasDeclaredVisibilityGate` re-export),
+ * `packages/react/src/__tests__/SchemaRenderer.disabledDeclaredGate.test.tsx`
+ * (objectui#3862, the generic rendering path) and
+ * `packages/core/src/actions/__tests__/ActionRunner.disabledGate.test.ts` /
+ * `.conditionGate.test.ts` (the execution entry, which asked this scope first).
+ *
+ * ## What this suite pins that the consumers cannot
+ *
+ * The consumers can only observe the ANSWER through a rendered control. This one
+ * pins the scope itself, one shape per case, plus the two structural claims that
+ * keep the scope from drifting again:
+ *
+ *   • DERIVATION: for every shape except the whitespace string,
+ *     `hasDeclaredPredicate(x)` is exactly `toPredicateInput(x) !== undefined`.
+ *     That equality is the reason this definition is trustworthy — "declared"
+ *     means "normalization still leaves something to evaluate", not a hand-rolled
+ *     list of empty spellings. A re-spelled predicate that happens to agree on
+ *     today's shapes would pass the row cases and fail this one.
+ *   • the whitespace string is the single deliberate DIFFERENCE from the
+ *     normalizer (which wraps `'   '` into `'${   }'` rather than folding it),
+ *     asserted as such so the next reader sees it is chosen, not overlooked.
+ *   • the one shape this scope does NOT cover — an envelope whose `source` is
+ *     blank but not empty (`{ dialect: 'cel', source: '   ' }`) — is pinned as a
+ *     documented residue with the issue that owns it (objectui#3960). It was
+ *     found by this suite: the first draft assumed the normalizer folds it, and
+ *     that assertion went red. `disabled` still greys out for that spelling, so
+ *     it is recorded rather than left for the next reader to rediscover.
+ *
+ * ## Reverse verification (direction predicted before running)
+ *
+ * Narrowing the definition back to the renderer's historic scope
+ * (`value != null && value !== ''`) must turn RED exactly: the empty-envelope
+ * rows (both spellings), the whitespace row, the junk rows, and the derivation
+ * case. `''` / `null` / `undefined` / `true` / `false` / every non-empty
+ * expression row stays GREEN — they agreed under both scopes, which is why the
+ * envelope residue survived objectui#3842 in the first place.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hasDeclaredPredicate } from '../declaredPredicate';
+import { toPredicateInput } from '../predicateInput';
+import { ExpressionEvaluator } from '../ExpressionEvaluator';
+
+/** Every shape the #3850 table measured, plus the boolean verdicts. */
+const SHAPES: Array<{ label: string; value: unknown; declared: boolean }> = [
+  // ── nothing to evaluate ────────────────────────────────────────────────
+  { label: 'undefined (no key)', value: undefined, declared: false },
+  { label: 'null', value: null, declared: false },
+  { label: "'' (empty predicate)", value: '', declared: false },
+  { label: "'   ' (whitespace only)", value: '   ', declared: false },
+  { label: "'\\t\\n' (other blanks)", value: '\t\n', declared: false },
+  { label: "{ dialect: 'cel', source: '' } (the envelope `objectstack build` emits)", value: { dialect: 'cel', source: '' }, declared: false },
+  { label: "{ source: '' } (envelope, no dialect)", value: { source: '' }, declared: false },
+  // NOT here: `{ dialect: 'cel', source: '   ' }`. Measured as still DECLARED —
+  // objectui#3850's ruling enumerated three empty spellings and the blank-source
+  // envelope is a fourth. Pinned as a documented residue below (objectui#3960)
+  // rather than silently folded into this table.
+  // ── not a predicate at all → fail open, never a reason to disable ──────
+  { label: '0', value: 0, declared: false },
+  { label: '{} (no source)', value: {}, declared: false },
+  { label: '[] (array)', value: [], declared: false },
+  { label: '{ dialect: "cel" } (envelope with no source key)', value: { dialect: 'cel' }, declared: false },
+  // ── a declared verdict, including the explicit `false` ─────────────────
+  { label: 'true', value: true, declared: true },
+  { label: 'false (a verdict, not a missing gate — objectui#3812)', value: false, declared: true },
+  { label: 'bare CEL expression', value: 'user.role == "admin"', declared: true },
+  { label: '`${…}` template', value: '${user.role === "admin"}', declared: true },
+  { label: "{ dialect: 'cel', source: 'true' }", value: { dialect: 'cel', source: 'true' }, declared: true },
+  { label: "{ dialect: 'template', source: '${x}' }", value: { dialect: 'template', source: '${x}' }, declared: true },
+];
+
+describe('hasDeclaredPredicate — the scope objectui#3850 ruled on', () => {
+  it.each(SHAPES)('$label → declared=$declared', ({ value, declared }) => {
+    expect(hasDeclaredPredicate(value)).toBe(declared);
+  });
+
+  it('the three empty spellings the ruling names are one answer, not three', () => {
+    // `''` was objectui#3842's half, the envelope objectui#3850's, the
+    // whitespace string objectui#3848's. One definition, so they cannot diverge
+    // again.
+    expect([
+      hasDeclaredPredicate(''),
+      hasDeclaredPredicate('   '),
+      hasDeclaredPredicate({ dialect: 'cel', source: '' }),
+    ]).toEqual([false, false, false]);
+  });
+});
+
+describe('hasDeclaredPredicate is DERIVED from the normalizer, not re-spelled', () => {
+  it('agrees with `toPredicateInput(x) !== undefined` on every shape but the whitespace string', () => {
+    const disagreements = SHAPES.filter(
+      s => hasDeclaredPredicate(s.value) !== (toPredicateInput(s.value) !== undefined),
+    ).map(s => s.label);
+    expect(disagreements).toEqual([
+      "'   ' (whitespace only)",
+      "'\\t\\n' (other blanks)",
+    ]);
+  });
+
+  it('the whitespace string is the one shape the normalizer wraps instead of folding', () => {
+    // Which is why the definition names it explicitly. Same blank-source rule
+    // `evaluateCondition` (`if (!trimmed) return true`) and `evalRowPredicate`
+    // (`listConditional.ts`, `if (!source.trim())`) already apply.
+    expect(toPredicateInput('   ')).toBe('${   }');
+    expect(toPredicateInput('')).toBeUndefined();
+    expect(toPredicateInput({ dialect: 'cel', source: '' })).toBeUndefined();
+  });
+
+  it('DOCUMENTED RESIDUE (objectui#3960): a BLANK envelope `source` is still declared', () => {
+    // The asymmetry, stated rather than hidden: this definition trims the STRING
+    // spelling and does not trim an envelope's `source`, because
+    // `toPredicateInput` only folds a source that is `''`:
+    expect(toPredicateInput({ dialect: 'cel', source: '   ' })).toEqual({ dialect: 'cel', source: '   ' });
+    expect(hasDeclaredPredicate({ dialect: 'cel', source: '   ' })).toBe(true);
+    // …while core's own CEL entry calls exactly that value "no predicate":
+    const ev = new ExpressionEvaluator({ record: { id: 1 } });
+    expect(ev.evaluateCondition({ dialect: 'cel', source: '   ' })).toBe(true);
+    // Declared gate + "no condition → true" is the objectui#3850 mechanism with
+    // the blank moved inside the envelope, so `disabled` still greys out for this
+    // one spelling. objectui#3850's ruling enumerated three empty spellings and
+    // this is a fourth, so it is filed (objectui#3960) instead of being widened
+    // into the ruled scope here. These expectations are what go RED when it is
+    // fixed — the signal to move the shape into the table above.
+  });
+});
+
+describe('why the question cannot be delegated to the verdict', () => {
+  it('evaluateCondition answers `true` for "nothing to evaluate" — which on `disabled` means GREY', () => {
+    const ev = new ExpressionEvaluator({ record: { id: 1 } });
+    // The inverted default, in four lines. Correct on `visible`/`enabled`,
+    // backwards on `disabled` — so every consumer has to ask "declared?" first.
+    expect(ev.evaluateCondition(undefined)).toBe(true);
+    expect(ev.evaluateCondition('')).toBe(true);
+    expect(ev.evaluateCondition('   ')).toBe(true);
+    expect(ev.evaluateCondition({ dialect: 'cel', source: '' })).toBe(true);
+  });
+
+  it('and truthiness cannot answer it either — `false` is a verdict (objectui#3812)', () => {
+    expect(hasDeclaredPredicate(false)).toBe(true);
+    const ev = new ExpressionEvaluator({});
+    expect(ev.evaluateCondition(false)).toBe(false);
+  });
+});

--- a/packages/core/src/evaluator/declaredPredicate.ts
+++ b/packages/core/src/evaluator/declaredPredicate.ts
@@ -1,0 +1,98 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { toPredicateInput } from './predicateInput';
+
+/**
+ * Is a predicate gate DECLARED on this value — i.e. after normalization, is
+ * there still a CONDITION for {@link ExpressionEvaluator.evaluateCondition} to
+ * reach a verdict on? (objectui#3850's ruling, key-neutral: `visible` /
+ * `hidden` / `enabled` / `disabled` / `condition` all ask it.)
+ *
+ * This is the ONE definition of that question in the repo, and it lives here —
+ * one layer under every consumer, beside {@link toPredicateInput}, whose answer
+ * it is derived from. It has to be asked separately from the verdict because
+ * `evaluateCondition` documents and implements exactly one default for "there
+ * is nothing here to evaluate": it returns `true`, meaning *visible/enabled*.
+ * That default is right on `visible` / `enabled` and INVERTED on `disabled`,
+ * where `true` means "greyed out" — so a gate that hands an empty predicate to
+ * the evaluator gets the strongest possible "yes, disable it" for a value the
+ * metadata never used to say anything. Truthiness cannot answer it either, and
+ * asking it that way was objectui#3812: `if (action.visible && !isVisible)`
+ * read `visible: false` — the most explicit "never show this" an author can
+ * write — as *ungated*, and rendered the action for everyone.
+ *
+ * ## What counts as "nothing to evaluate"
+ *
+ * Exactly the shapes {@link toPredicateInput} folds to `undefined`, plus the one
+ * it wraps instead of folding:
+ *
+ *   - `null` / `undefined` — no key at all.
+ *   - `''` — an empty predicate (objectui#3492 / objectui#3842).
+ *   - a whitespace-only string — the shape the normalizer does NOT collapse
+ *     (`'   '` becomes `'${   }'`), named here so it cannot slip through. Core's
+ *     other predicate entries already treat it as blank: `evaluateCondition`
+ *     (`if (!trimmed) return true`) and `evalRowPredicate`
+ *     (`evaluator/listConditional.ts`, `if (!source.trim())`).
+ *   - `{ dialect, source: '' }` — the empty ENVELOPE. This is not an exotic
+ *     spelling: `@objectstack/spec`'s `ExpressionInputSchema` normalizes every
+ *     authored predicate into an envelope, so "author left the predicate empty"
+ *     compiles to exactly this, which makes it the likeliest empty shape in real
+ *     metadata (objectui#3850).
+ *   - anything that is not a predicate at all (`0`, `{}`, an array): a value the
+ *     evaluator cannot read must not be the reason a control is disabled or an
+ *     action refuses to run. Fail-open on junk, which is the posture
+ *     `ActionRunner` already committed to (`catch { isDisabled = false }`).
+ *
+ * A declared-and-`false` gate is DECLARED (`toPredicateInput` returns the
+ * boolean unchanged): `disabled: false` / `visible: false` are verdicts, and
+ * routing them to the evaluator — which short-circuits booleans — is the point
+ * of asking "declared?" rather than "truthy?".
+ *
+ * ## The one blank shape this scope does NOT cover (objectui#3960)
+ *
+ * An envelope whose `source` is blank but not EMPTY —
+ * `{ dialect: 'cel', source: '   ' }` — is still "declared" here, because
+ * `toPredicateInput` folds a `source` of `''` and does not trim. So the string
+ * spelling of a blank predicate is trimmed and the envelope spelling is not,
+ * which means `disabled` still greys out for that one value while core's own CEL
+ * entry calls it "no predicate" (`evaluateCelCondition`: `if (!source.trim())
+ * return true`). objectui#3850's ruling enumerated three empty spellings and this
+ * is a fourth, so it is filed rather than widened in here — the asymmetry is
+ * pinned in `__tests__/declaredPredicate.test.ts` so it cannot be mistaken for
+ * a covered case.
+ *
+ * ## Why the callers still evaluate the RAW value
+ *
+ * Every consumer normalizes to decide DECLAREDNESS and then evaluates whatever
+ * it was given, `evaluateCondition(raw)` or `evaluateCondition(toPredicateInput(
+ * raw))` as it did before. Both agree since objectui#3871 made the normalizer
+ * idempotent for an already-`${…}` string; before that they did not, and a
+ * template-spelled predicate normalized twice came back as a constant. Nothing
+ * here changes a verdict for a value that HAS one — this gate only decides
+ * whether there is one to reach.
+ *
+ * ## Scope history (objectui#3850)
+ *
+ * The question used to be answered three times with three different scopes: the
+ * renderer-side `hasDeclaredVisibilityGate` (`!= null && !== ''`, so every
+ * object counted — including the empty envelope), `SchemaRenderer`'s inline
+ * `!== undefined` (wider still: `disabled: null` greyed the control out,
+ * objectui#3862), and `ActionRunner`'s module-private helper (this scope, which
+ * arrived first with objectui#3848 and is what the ruling adopted). One
+ * definition with one scope replaces all three:
+ * `components/renderers/action/visibility-gate.ts` re-exports this function
+ * under its historic name `hasDeclaredVisibilityGate` (the five member-action
+ * renderer call sites are unchanged), `SchemaRenderer`'s `disabled` /
+ * `disabledOn` chain reads it, and `ActionRunner`'s two gates read it instead of
+ * a private twin.
+ */
+export function hasDeclaredPredicate(value: unknown): boolean {
+  if (typeof value === 'string' && value.trim() === '') return false;
+  return toPredicateInput(value) !== undefined;
+}

--- a/packages/core/src/evaluator/index.ts
+++ b/packages/core/src/evaluator/index.ts
@@ -9,6 +9,7 @@
 export * from './ExpressionContext.js';
 export * from './ExpressionEvaluator.js';
 export * from './predicateInput.js';
+export * from './declaredPredicate.js';
 export * from './fieldRules.js';
 export * from './listConditional.js';
 export * from './optionRules.js';

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -19,6 +19,7 @@ import {
   debugTimeEnd,
   DebugCollector,
   validateSchema,
+  hasDeclaredPredicate,
   hasResponsiveStyles,
   scopeClassFor,
   compileScopedStyles,
@@ -319,11 +320,41 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
     }
 
     // Evaluate disabled: disabled / disabledOn
+    //
+    // Ask "is a `disabled` gate DECLARED?" — not "is the key present?"
+    // (objectui#3862). `!== undefined` was the widest of the three spellings this
+    // question used to have, and this is the key where breadth is not free: the
+    // evaluation entry answers an empty predicate with `true`, meaning "no
+    // condition → visible/enabled", and on `disabled` that `true` means GREYED
+    // OUT. So `disabled: ''`, `disabled: null` (`null !== undefined`), a
+    // whitespace-only string and the `{ dialect, source: '' }` envelope
+    // `objectstack build` emits for an empty predicate each disabled the node —
+    // on the GENERIC path, since this block runs for every schema type, and not
+    // as an internal flag either: `_disabled` is forwarded below as a real
+    // `disabled` prop.
+    //
+    // The `visible` / `visibleWhen` / `visibleOn` / `visibility` legs above keep
+    // `!== undefined` deliberately: their `true` is NEGATED, so an empty predicate
+    // already lands on "shown", which is what "no gate" means anyway, and
+    // narrowing them would change ALIAS PRECEDENCE rather than fix anything. The
+    // `hidden` / `hiddenOn` legs are the exception — not negated, so they carry
+    // this same defect with the polarity that makes the node VANISH; measured and
+    // filed as objectui#3955, out of objectui#3850's ruling.
+    //
+    // `hasDeclaredPredicate` is the one definition of "declared" (core's
+    // `evaluator/declaredPredicate.ts`, objectui#3850's ruling — read there for
+    // the scope), shared with the action renderers' `hasDeclaredVisibilityGate`
+    // and `ActionRunner`'s execution gates. A local `&& !== ''` here would have
+    // been a fourth dialect of one question, which is what objectui#3842 /
+    // objectui#3849 spent two PRs merging away. The verdict still reads the RAW
+    // value, exactly as before — only the gate in front of it narrowed. An
+    // undeclared `disabled` now falls through to `disabledOn` instead of
+    // short-circuiting on an empty predicate.
     const isDisabled = (() => {
-      if (newSchema.disabled !== undefined) {
+      if (hasDeclaredPredicate(newSchema.disabled)) {
         return evaluator.evaluateCondition(newSchema.disabled);
       }
-      if (newSchema.disabledOn !== undefined) {
+      if (hasDeclaredPredicate(newSchema.disabledOn)) {
         return evaluator.evaluateCondition(newSchema.disabledOn);
       }
       return false;

--- a/packages/react/src/__tests__/SchemaRenderer.disabledDeclaredGate.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.disabledDeclaredGate.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#3862 — `SchemaRenderer`'s inline `disabled` gate asked
+ * `newSchema.disabled !== undefined`, the WIDEST of the three spellings this
+ * repo had for "is a gate declared?", on the one key where width is not free.
+ *
+ * `evaluateCondition` answers an empty predicate with `true` — "no condition, so
+ * visible/enabled". On `visible` that `true` is negated and means SHOW, which is
+ * what "no gate" means anyway, so the `visible` chain above is benign. On
+ * `disabled` it means GREY. So `disabled: ''` set `_disabled = true`, and one
+ * notch wider than the `!= null` family, so did `disabled: null`.
+ *
+ * Two things make this the generic-path defect rather than one renderer's:
+ *
+ *   • the block runs in the `evaluatedSchema` useMemo with no type branch, so it
+ *     covers EVERY node that renders through `SchemaRenderer`.
+ *   • `_disabled` is not an internal marker. It is stripped from
+ *     `componentProps` and re-injected as `disabled: __disabled || undefined`,
+ *     so any component taking a `disabled` prop — inputs, buttons, form fields —
+ *     is really disabled. That forwarding is pinned below, because "the flag is
+ *     not set" and "the prop does not arrive" are different claims and only the
+ *     second is what a user sees.
+ *
+ * The fix reads core's one definition (`hasDeclaredPredicate`, objectui#3850's
+ * ruling) instead of adding a fourth local spelling — the `&& !== ''` this card
+ * explicitly ruled out.
+ *
+ * ## What each case detects
+ *
+ *   • `disabled: ''` / `null` / `'   '` / `{ dialect, source: '' }` /
+ *     `{ source: '' }` → NOT disabled, and no `disabled` prop forwarded. THE
+ *     defect. `''` and `null` are the two rows the card measured; the envelope is
+ *     objectui#3850's shape reaching this path too.
+ *   • `disabled: true` / a truthy expression / a truthy CEL envelope → still
+ *     disabled. Anti-mutation guards: "never disable" satisfies most of this file
+ *     alone, and these refuse it.
+ *   • `disabled: false` → still not disabled, and `disabled: 0` → not disabled
+ *     (junk fails open, as it now does at every other gate).
+ *   • `disabledOn` in each of those directions → the alias reads the same
+ *     definition, not a copy of it.
+ *   • precedence: an EMPTY `disabled` no longer short-circuits the chain, so a
+ *     declared `disabledOn` is finally consulted. This case is the one that would
+ *     stay green if someone "fixed" the defect by deleting the `disabled` leg.
+ *   • the `visible` chain, unchanged: it keeps `!== undefined` (its alias
+ *     precedence is load-bearing and its `true` is benign), so `visible: ''`
+ *     still renders and `visible: false` still hides.
+ *   • the `hidden` / `hiddenOn` legs of that same chain, which are NOT negated
+ *     and therefore have this defect with the polarity that makes the node
+ *     VANISH. Measured while writing the equivalence cases, out of this ruling's
+ *     scope, filed as objectui#3955 and pinned here as a documented divergence
+ *     rather than left for the next reader to rediscover.
+ *
+ * ## Reverse verification (direction predicted before running)
+ *
+ * Restoring `newSchema.disabled !== undefined` / `disabledOn !== undefined` must
+ * turn RED exactly the five empty-shape cases on each key (`disabled`,
+ * `disabledOn`), their forwarding cases, the `0` junk case and the precedence
+ * case — and leave every `true` / `false` / expression / `visible` case GREEN.
+ * Nothing here can go red in the other direction: the change only ever removes a
+ * `disabled` prop, never adds one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+import { SchemaRendererContext } from '../context/SchemaRendererContext';
+
+/**
+ * Records the `disabled` prop EXACTLY as it arrives — `absent` when the renderer
+ * forwarded nothing, so the pin can tell "no prop" from "disabled={false}".
+ */
+const Probe = (props: { disabled?: unknown }) => (
+  <div
+    data-testid="probe"
+    data-disabled-prop={props.disabled === undefined ? 'absent' : String(props.disabled)}
+  />
+);
+
+const DATA = { status: 'locked', readOnly: true, unlocked: false };
+
+function renderNode(schema: Record<string, unknown>) {
+  return render(
+    <SchemaRendererContext.Provider value={{ dataSource: DATA }}>
+      <SchemaRenderer schema={{ type: 'probe-3862', ...schema } as never} />
+    </SchemaRendererContext.Provider>,
+  );
+}
+
+/** The forwarded prop, or `null` when the node did not render at all. */
+function disabledProp(): string | null {
+  const el = screen.queryByTestId('probe');
+  return el ? el.getAttribute('data-disabled-prop') : null;
+}
+
+const EMPTY_SHAPES: Array<{ label: string; value: unknown }> = [
+  { label: "'' (empty string)", value: '' },
+  { label: 'null', value: null },
+  { label: "'   ' (whitespace only)", value: '   ' },
+  { label: "{ dialect: 'cel', source: '' } (what `objectstack build` emits)", value: { dialect: 'cel', source: '' } },
+  { label: "{ source: '' } (envelope without a dialect)", value: { source: '' } },
+];
+
+describe('SchemaRenderer `disabled` — an empty predicate is not a declared gate (objectui#3862)', () => {
+  beforeEach(() => {
+    ComponentRegistry.register('probe-3862', Probe as never);
+  });
+  afterEach(() => {
+    ComponentRegistry.unregister?.('probe-3862');
+  });
+
+  it.each(EMPTY_SHAPES)('disabled: $label → not disabled, and no `disabled` prop forwarded', ({ value }) => {
+    renderNode({ disabled: value });
+    // Both halves of the claim: the node renders, and the prop channel
+    // (`disabled: __disabled || undefined`) carries nothing.
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it.each(EMPTY_SHAPES)('disabledOn: $label → not disabled either (the alias reads the same definition)', ({ value }) => {
+    renderNode({ disabledOn: value });
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it('disabled: 0 (not a predicate) → not disabled — junk fails open here too', () => {
+    renderNode({ disabled: 0 });
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it('disabled: true → still disabled, and the prop is forwarded', () => {
+    renderNode({ disabled: true });
+    expect(disabledProp()).toBe('true');
+  });
+
+  it('disabled: false → still not disabled', () => {
+    renderNode({ disabled: false });
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it('no `disabled` at all → not disabled', () => {
+    renderNode({});
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it('an expression-valued `disabled` keeps its verdict, both ways', () => {
+    const { unmount } = renderNode({ disabled: '${data.status === "locked"}' });
+    expect(disabledProp()).toBe('true');
+    unmount();
+    renderNode({ disabled: '${data.unlocked}' });
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it("a non-empty CEL envelope keeps its verdict, both ways", () => {
+    const { unmount } = renderNode({ disabled: { dialect: 'cel', source: 'true' } });
+    expect(disabledProp()).toBe('true');
+    unmount();
+    renderNode({ disabled: { dialect: 'cel', source: 'false' } });
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it('an expression-valued `disabledOn` keeps its verdict', () => {
+    renderNode({ disabledOn: '${data.readOnly}' });
+    expect(disabledProp()).toBe('true');
+  });
+});
+
+describe('SchemaRenderer `disabled` chain precedence (objectui#3862)', () => {
+  beforeEach(() => {
+    ComponentRegistry.register('probe-3862', Probe as never);
+  });
+  afterEach(() => {
+    ComponentRegistry.unregister?.('probe-3862');
+  });
+
+  it('an EMPTY `disabled` no longer short-circuits — a declared `disabledOn` is consulted', () => {
+    // Before: `'' !== undefined` won the chain, `evaluateCondition('')` was
+    // `true`, and the node was disabled for a reason no key stated. Now the
+    // empty leg is not a gate, so the declared alias decides.
+    renderNode({ disabled: '', disabledOn: '${data.readOnly}' });
+    expect(disabledProp()).toBe('true');
+  });
+
+  it('… and the alias verdict is honoured in the other direction too', () => {
+    renderNode({ disabled: { dialect: 'cel', source: '' }, disabledOn: '${data.unlocked}' });
+    expect(disabledProp()).toBe('absent');
+  });
+
+  it('a DECLARED `disabled` still wins over `disabledOn`', () => {
+    renderNode({ disabled: false, disabledOn: true });
+    expect(disabledProp()).toBe('absent');
+  });
+});
+
+describe('SchemaRenderer `visible` chain is untouched by this change (objectui#3862)', () => {
+  beforeEach(() => {
+    ComponentRegistry.register('probe-3862', Probe as never);
+  });
+  afterEach(() => {
+    ComponentRegistry.unregister?.('probe-3862');
+  });
+
+  it.each(EMPTY_SHAPES)('visible: $label → still rendered', ({ value }) => {
+    renderNode({ visible: value });
+    expect(screen.getByTestId('probe')).toBeInTheDocument();
+  });
+
+  it('visible: false → still hidden; visible: true → still rendered', () => {
+    const { unmount } = renderNode({ visible: false });
+    expect(disabledProp()).toBeNull();
+    unmount();
+    renderNode({ visible: true });
+    expect(screen.getByTestId('probe')).toBeInTheDocument();
+  });
+
+  it('DOCUMENTED DIVERGENCE (objectui#3955): the `hidden` leg is NOT negated, so an empty predicate still hides', () => {
+    // The other polarity exit of the same asymmetry, in the same `useMemo`:
+    // `hidden` / `hiddenOn` return `evaluateCondition(...)` UN-negated, so
+    // "nothing to evaluate → true" means HIDE — the node vanishes for
+    // `hidden: ''` / `null` / `'   '` / `{ dialect, source: '' }`. Measured, and
+    // deliberately out of this PR's ruling (objectui#3850's placement clause
+    // names the `disabled` / `disabledOn` legs; the `visible` family keeps
+    // `!== undefined` and its alias precedence). Pinned as the current state so
+    // the next reader sees it is known, with the issue that owns it — this
+    // expectation is what goes RED when objectui#3955 is fixed, which is the
+    // signal to move these rows into the fixed column.
+    renderNode({ hidden: '' });
+    expect(screen.queryByTestId('probe')).toBeNull();
+    const { unmount } = renderNode({ hidden: { dialect: 'cel', source: '' } });
+    expect(screen.queryByTestId('probe')).toBeNull();
+    unmount();
+    // The `visible` legs of the same chain ARE negated, which is why the same
+    // empty value is benign there — the cases above this one.
+    renderNode({ visible: '' });
+    expect(screen.getByTestId('probe')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #3850
Fixes #3862

按 2026-08-09 01:50 的 PM 裁决(#3850 评论 5229248164)三条实施,#3850 与 #3862 一 PR 结对。

## 1. 语义:「已声明门」= 归一后仍有可求值条件

`evaluateCondition` 对「没有条件」的唯一默认是 `return true`(意为 *visible/enabled*)。这个默认在 `visible` / `enabled` 上正确,在 `disabled` 上**反向** —— 同一个 `true` 意味着置灰。所以每一处门都必须在求值**之前**自己回答「有没有条件」,而这个问题此前在仓里被回答了三次、三种范围,且最宽的两种恰好落在 `disabled` 这个不能宽的键上:

- 动作面的 `hasDeclaredVisibilityGate` 问 `!= null && !== ''`,于是**任何对象**都算已声明 —— 包括 `{ dialect: 'cel', source: '' }`。这不是手写才有的拼法:`@objectstack/spec` 的 `ExpressionInputSchema` 把**任何**已授权谓词归一成信封,所以「作者把谓词留空」编译出来正好是它。求值侧把同一个值归一回 `undefined`,`evaluateCondition(undefined)` 答 `true` → 置灰,永久,界面上与元数据本意无法区分(#3850,#3842 修完后的残留)。
- `SchemaRenderer` 内联问 `disabled !== undefined`,再宽一格,于是 `disabled: null` 也置灰 —— 而且是**通用路径**(该块在 `evaluatedSchema` 的 `useMemo` 里不带 type 判定,覆盖全部节点),且 `_disabled` 不是内部标记:它被 `disabled: __disabled || undefined` 交给组件,真的置灰(#3862)。
- `ActionRunner` 的 module-private helper 问「归一后还有东西可求值吗」—— 事后证明这就是对的那一档(#3848 / #3872)。

裁决采纳第三档:`''`、纯空白串、`{ dialect, source: '' }` 空信封、以及压根不是谓词的值(`0`、`{}`)一律**不算已声明**;声明为 `false` 的门**算**已声明(verdict 不是缺门,#3812)。

## 2. 放置:唯一定义下沉 packages/core,三处改读

- **新增** `packages/core/src/evaluator/declaredPredicate.ts` 的 `hasDeclaredPredicate(value)` —— 与 `toPredicateInput` 同层(它的答案就是从归一器推出来的),经 `evaluator/index.ts` 从 `@object-ui/core` 导出。依赖方向成立:core 是 react / components 的共同下游。
- `packages/components/src/renderers/action/visibility-gate.ts` **保名 re-export**:`export { hasDeclaredPredicate as hasDeclaredVisibilityGate } from '@object-ui/core'`。五处 member-action 落点(`action:button` / `action:icon` / `action:group` 的内联按钮与下拉项 / `action:menu` 的项)以及经 `@object-ui/components` barrel 读它的 `DeclaredActionsBar`、`record-quick-actions` **零改动**,自动继承新范围;barrel 导出面不变。
- `packages/react/src/SchemaRenderer.tsx` 的 `disabled` / `disabledOn` 两条腿改读它(#3862 的第三拼法)。
- `packages/core/src/actions/ActionRunner.ts` 删掉 module-private 的 `hasDeclaredPredicate`,改 import 下沉后的同名函数(PR #3873 注释里预告的收敛);两处门(`condition` / `disabled`)的调用点与语义不变。

⛔ 没有任何调用点新增「顺便判一下空」的本地判定 —— 那第 N 种拼法正是 #3842 / #3849 两个 PR 合掉的东西。verdict 仍读**原始值**,只有它前面的门收窄了。

## 3. 钉子(实测,非推演)

`action:button` 与通用路径,改动前 → 改动后:

| value | `visible` | `disabled` | `enabled` | SchemaRenderer 的 `disabled` prop |
|---|---|---|---|---|
| `''` | 显示 → 显示 | 可点 → 可点 | 可点 → 可点 | 注入 → 不注入 |
| `null` | 显示 → 显示 | 可点 → 可点 | 可点 → 可点 | 注入 → 不注入 |
| `{ dialect: 'cel', source: '' }` | 显示 → 显示 | **置灰 → 可点** | 可点 → 可点 | **注入 → 不注入** |
| `{ source: '' }`(无 dialect) | 显示 → 显示 | **置灰 → 可点** | 可点 → 可点 | **注入 → 不注入** |
| `'   '`(纯空白) | **隐藏 → 显示** | 可点 → 可点 | **置灰 → 可点** | **注入 → 不注入** |
| `0` / `{}`(非谓词) | 显示 → 显示 | **置灰 → 可点** | 可点 → 可点 | **注入 → 不注入** |
| `true` / `false` / 裸 CEL / `${…}` / 非空信封 | 不变 | 不变 | 不变 | 不变 |

#3850 表格里那两行「残留」(两种空信封)转绿;#3862 的 `disabled: ''` / `disabled: null` 转绿,且 `_disabled` 转发链在空拼法上不再注入 `disabled` prop(钉子直接读组件收到的 prop,区分「没收到」与 `disabled={false}`)。

**两处不是等价而是行为变更,如实钉住而不是包装成等价**:

- **纯空白串**在 `visible` / `enabled` 上会动(裁决第 3 条的钉子①原文说三种空拼法在 `visible` 侧「行为不变」,这一行不成立)。机理:`'   '` 被归一器包成 `'${   }'`(它是归一器唯一不折叠的空形状),求值出 falsy,于是**一个什么都没说的谓词把动作从所有人面前藏起来**、并通过取反的 `enabled` 腿把按钮置灰。改后落在「没有门」= 显示 / 可点,方向与 `visibility-gate` 自己文档一直声称的不变量一致(「空谓词不该把动作藏起来」),但它确实是行为变更。
- **非谓词值**(`0` / `{}`)不再置灰(fail-open),与 `ActionRunner` 早已承诺的 `catch { isDisabled = false }` 同向。

`SchemaRenderer` 的 `visible` / `visibleWhen` / `visibleOn` / `visibility` 四条腿**故意不动**:它们的 `true` 被取反,空谓词本来就落在「显示」,收窄只会改**别名优先级**而不修任何东西。

## 反向验证(先预判方向,再跑)

把下沉定义临时改回历史窄范围(`value != null && value !== ''`,不提交),预判:只有本 PR 新增 / 更新的四个 suite 翻红,既有 suite 全绿(它们只拼 `''` 与布尔,对信封不敏感 —— 这正是残留能活过 #3842 的原因)。实测 32 个用例红,分布与预判逐条相符:

```
❯ packages/components/.../action-empty-predicate-scope.test.tsx   (35 tests | 10 failed)
❯ packages/react/.../SchemaRenderer.disabledDeclaredGate.test.tsx (27 tests |  8 failed)
❯ packages/core/.../declaredPredicate.test.ts                     (23 tests | 10 failed)
❯ packages/core/.../ActionRunner.disabledGate.test.ts             (20 tests |  4 failed)
```

其余 209 个 test file 全绿,`ActionRunner.conditionGate.test.ts` 亦全绿(它的空拼法行在两种范围下都落在「执行」,方向上不构成检测器 —— 这一点也如实记录)。

## fixture 逐条重判(不是批量改拼法)

`ActionRunner.disabledGate.test.ts` 的 parity 表里有三行原本标着「与渲染面已知分叉,owner = #3850」(空信封、`0`、`{}`)。本 PR 让渲染面读同一个定义,这三行**变成可主张 parity**,所以逐行改判为 `rendererDisabled: false` 并删掉 divergence 说明。原先那条「记录哪些行仍分叉」的用例在改判后会断言一个**空数组** —— 绿是因为什么都没产生,不是因为逻辑对 —— 所以整条替换成更强的主张:表里每一行都参与 parity 比较(`claimed.length === SHAPES.length`),且 divergence 逃生口仍被检查(将来重新引入分叉但不写 owner 的行会在这里红)。

## 范围外发现(只立卡,不在本 PR 修)

量这条链时顺手量到三处同族缺陷,全部**未认领**、按「附着而非散落」立成独立卡:

- **#3955** —— 同一个 `useMemo` 里 `hidden` / `hiddenOn` 两条腿**不取反**,所以同一个「空谓词 → `true`」在那里意味着 HIDE:`hidden: ''` / `null` / `'   '` / 空信封让节点在通用路径上**整个消失**。#3862 的反极性孪生,后果比置灰更难诊断。本 PR 把它作为 documented divergence 钉在 SchemaRenderer 的 suite 里(修好时那条用例会红,即为搬行信号)。
- **#3960** —— 「空」的**第四种拼法**:`{ dialect: 'cel', source: '   ' }`(source 只有空白)。归一器对信封只判 `if (!src)` 而**不 trim**,所以它仍算已声明 → `disabled` 侧仍永久置灰、执行入口仍拒执行,而 core 自己的 `evaluateCelCondition` 第一行 `if (!source.trim()) return true` 已经把它叫作「没有谓词」。裁决显式枚举了三种拼法,把第四种并进来会同时改到 #3848 已合入并钉住的执行门行为 —— 那是 PM 该裁的一步,故立卡不顺手改;共享定义的这处不对称(trim 字符串、不 trim 信封 source)在单元 suite 里钉成 documented residue。
- **#3957**(`finding`)—— 收敛之后 `ActionEngine.getActionsForLocation` 的 `visible` 过滤是**最后一处**自带范围的消费者:非对象非谓词值保留 `Boolean(raw)` 强转、纯空白串走求值,于是 `visible: 0` / `NaN` / `'   '` 在引擎面隐藏、在渲染面显示。其中 `'   '` 一行是**本 PR 造成的新分叉**(改前两面都隐藏),已在卡里如实写明。

## 验证

- 构建:`pnpm --workspace-concurrency=2 --filter '@object-ui/components...' build`(含 core / react 依赖闭包)—— 通过。
- 测试(仓根,不用 `--filter`):`pnpm exec vitest run packages/core packages/components packages/react --maxWorkers=2` → **213 files / 2921 tests 全绿**。
- 消费半径另跑(它们经 barrel 读 `hasDeclaredVisibilityGate`):`pnpm exec vitest run packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx packages/plugin-detail/src/renderers/__tests__ --maxWorkers=2` → **9 files / 106 tests 全绿**。这一步是必要的:`DeclaredActionsBar.test.tsx` 用 `vi.mock` 深导入 `visibility-gate` 模块以避开 components barrel,而该模块现在改成从 `@object-ui/core` re-export,解析面变了。两处 fixture 只拼 `''`(在新旧范围下都不算门),无需重判。
- `pnpm exec turbo run type-check --concurrency=2` → **78 / 78 successful**。
- `node scripts/check-control-bytes.mjs`,以及对本 PR 全部文件的越界自查 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'`(gate 不扫的那几个字节)。

## changeset

`.changeset/empty-predicate-declared-gate-3850-3862.md`,`@object-ui/core` / `@object-ui/components` / `@object-ui/react` 三个包 **patch**。依据:①按 AGENTS.md 版本号策略,fixed 组内不声明 `major`;②本 PR 的头条是缺陷修复(#3850 / #3862 都是 bug),不是新能力;③core 新增一个公开导出属**增量** API,同族先例 `.changeset/components-export-declared-visibility-gate-3835.md`(「Export `hasDeclaredVisibilityGate` from the package barrel」)同样按 `patch` 发。行为变更的两行(纯空白、非谓词值)在 changeset 正文里逐行写明。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_