### PR TITLE
fix(app-shell): ActionParamDialog 的 boolean 分支下发控件 id,可访问名不再是两份 label 的拼接 (#3962)

### DIFF
--- a/.changeset/actionparamdialog-boolean-host-id-3962.md
+++ b/.changeset/actionparamdialog-boolean-host-id-3962.md
@@ -1,0 +1,30 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`ActionParamDialog` boolean params: the dialog now owns the control id, so the checkbox is named once instead of twice
+
+The boolean branch rendered `<Label htmlFor={param.name}>` beside the control but
+passed the widget no `id`, unlike its own generic branch a few dozen lines below,
+which has always passed `id={param.name}`. Measured on a real dialog render, a
+`boolean` param labelled "Confirm This" produced TWO label elements pointing at
+one control — the dialog's visible one and a `sr-only` copy the widget emitted —
+so the checkbox's accessible name was the two concatenated: screen readers
+announced "Confirm This Confirm This".
+
+Two distinct problems, one line apart:
+
+- The association was IMPLICIT. It resolved only because `BooleanField`'s id
+  fallback chain reaches `config.name`, which `paramToField` seeds from
+  `param.name`, so both sides landed on the same string by coincidence of
+  another package's internals. A host that renders `htmlFor` must emit the id it
+  names; that is what the declared `id` key of the widget contract is for.
+- The duplicate `sr-only` label. objectui#3952 / PR #3959 made `BooleanField`
+  suppress its own label whenever a host supplies the id — precisely because a
+  host that supplies an id is a host that renders a label. Receiving no id, this
+  branch never triggered that suppression.
+
+Both `for` targets resolved, so unlike objectui#3341 and objectui#3952 this was
+never a dangling label: clicking the row's text already toggled the control, and
+still does. What changes is the announced name, which is now the single
+"Confirm This" the author declared. The generic branch is untouched.

--- a/packages/app-shell/src/views/ActionParamDialog.ariaRequired.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.ariaRequired.test.tsx
@@ -99,3 +99,76 @@ describe('app-shell ActionParamDialog — `aria-required` reaches the widget con
     expect(input.required).toBe(false);
   });
 });
+
+/**
+ * The HOST owns the control id on the boolean branch too (objectui#3962).
+ *
+ * The boolean branch renders `<Label htmlFor={param.name}>` but used to pass no
+ * `id` to the widget, so the association only held because `BooleanField`'s
+ * fallback chain happened to reach the same string (`config.name`, which
+ * `paramToField` seeds from `param.name`). Two consequences, one of them a real
+ * defect:
+ *
+ * 1. The association was IMPLICIT — it lived in another package's fallback, not
+ *    in this host's own output. The generic branch a few dozen lines below has
+ *    always passed `id={param.name}`; this branch now matches it.
+ * 2. Receiving no host id, the widget could not know the host had already
+ *    rendered a label, so it emitted its own `sr-only` one as well. Two label
+ *    elements pointing at one control CONCATENATE into the accessible name
+ *    (accname §2D), so the control announced "Confirm This Confirm This".
+ *
+ * Both `for` targets resolved, so this was never the dangling-label failure of
+ * #3341/#3952 — it was a duplicated name. The measurable half is therefore the
+ * NAME, not clickability: the pins below assert one label element and an
+ * un-doubled accessible name. `getAllByLabelText` deliberately is NOT the
+ * probe — it de-dupes its matches through a `Set` and splits multi-label names,
+ * so it returns exactly one control in both the broken and the fixed tree.
+ */
+describe('app-shell ActionParamDialog — the boolean branch names its control ONCE (objectui#3962)', () => {
+  const boolParam = def({ name: 'confirmed', label: 'Confirm This', type: 'boolean' });
+
+  it('gives the boolean control the host id and exactly one label element', async () => {
+    openDialog([boolParam]);
+
+    const checkbox = await screen.findByRole('checkbox');
+    // Explicit, not inherited: the id the dialog's own `<Label htmlFor>` names.
+    expect(checkbox).toHaveAttribute('id', 'confirmed');
+
+    const labels = Array.from(document.querySelectorAll('label[for="confirmed"]'));
+    expect(labels).toHaveLength(1);
+    // …and the surviving one is the dialog's VISIBLE label, not the widget's
+    // sr-only copy — a checkbox row whose only name is screen-reader-only
+    // would pass a bare count while showing the user nothing.
+    expect(labels[0].className).not.toContain('sr-only');
+    expect(labels[0]).toHaveTextContent('Confirm This');
+  });
+
+  it('announces the label once, not twice concatenated', async () => {
+    openDialog([boolParam]);
+
+    const checkbox = await screen.findByRole('checkbox');
+    expect(checkbox).toHaveAccessibleName('Confirm This');
+  });
+
+  it('still names a required boolean param without folding in the asterisk', async () => {
+    // The `*` marker lives inside the visible label; suppressing the widget's
+    // duplicate must not drag the visual-only marker into the name (#3299).
+    openDialog([def({ name: 'confirmed', label: 'Confirm This', type: 'boolean', required: true })]);
+
+    const checkbox = await screen.findByRole('checkbox');
+    expect(checkbox).toHaveAccessibleName('Confirm This');
+    expect(checkbox).toHaveAttribute('aria-required', 'true');
+  });
+
+  it('leaves the generic branch exactly as it was — host id, one label, one name', async () => {
+    // The generic branch already passed `id={param.name}`; this is the
+    // unchanged-direction half of the pin, so a future "simplification" that
+    // moves id ownership back into the widgets fails here as well.
+    openDialog([def({ name: 'note', label: 'Note This', type: 'text' })]);
+
+    const input = await screen.findByLabelText('Note This');
+    expect(input).toHaveAttribute('id', 'note');
+    expect(document.querySelectorAll('label[for="note"]')).toHaveLength(1);
+    expect(input).toHaveAccessibleName('Note This');
+  });
+});

--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -129,6 +129,26 @@ describe('ActionParamDialog — shared field-widget rendering (ADR-0059)', () =>
     await waitFor(() => expect(resolve).toHaveBeenCalledWith({ force: true }));
   });
 
+  it('toggles the boolean param by clicking its visible label (objectui#3962)', async () => {
+    // The boolean branch renders `<Label htmlFor={param.name}>` beside the
+    // control and now hands the widget that same id explicitly, so the row's
+    // normal affordance — click the text — has to work off the host's own
+    // output rather than off `BooleanField`'s id fallback chain. Pinned as
+    // BEHAVIOR here; the naming half (one label, un-doubled accessible name)
+    // is pinned in ActionParamDialog.ariaRequired.test.tsx.
+    const resolve = openDialog([def({ name: 'force', label: 'Force It', type: 'boolean' })]);
+    const checkbox = await screen.findByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+    const label = document.querySelector('label[for="force"]') as HTMLLabelElement;
+    expect(label).not.toBeNull();
+    fireEvent.click(label);
+
+    await waitFor(() => expect(checkbox).toHaveAttribute('aria-checked', 'true'));
+    confirm();
+    await waitFor(() => expect(resolve).toHaveBeenCalledWith({ force: true }));
+  });
+
   it('renders a select param through the shared SelectField (combobox trigger)', async () => {
     openDialog([
       def({

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -256,6 +256,21 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
                   <div className="flex items-start gap-2">
                     <Suspense fallback={<div className="size-4 mt-0.5 animate-pulse rounded-sm bg-muted" aria-hidden="true" />}>
                       <Widget
+                        // The HOST owns the control id (objectui#3962), exactly
+                        // as the generic branch below does. Omitting it made
+                        // this branch's `<Label htmlFor>` association IMPLICIT:
+                        // it only resolved because `BooleanField`'s id fallback
+                        // chain reaches `config.name`, which `paramToField`
+                        // seeds from `param.name` — a host living off another
+                        // package's fallback. Worse, a widget that receives no
+                        // host id cannot know the host already rendered a label,
+                        // so it emitted its own `sr-only` copy too, and two
+                        // label elements referencing one control CONCATENATE
+                        // into the accessible name (accname §2D): the checkbox
+                        // announced "Confirm This Confirm This". Passing the id
+                        // makes the association explicit and suppresses the
+                        // duplicate (PR #3959's `emitOwnLabel = !hostId`).
+                        id={param.name}
                         value={values[param.name] === true}
                         onChange={(checked: unknown) => updateValue(param.name, checked === true)}
                         field={field}


### PR DESCRIPTION
Fixes #3962

`ActionParamDialog` 的 boolean 分支渲染 `Label htmlFor={param.name}` 放在控件旁边,却**不**给 widget 传 `id` —— 而同一文件下面几十行的通用分支一直传的是 `id={param.name}`。本 PR 让 boolean 分支与它自己的通用分支对齐,一行。

## 修前实测(真 dialog 渲染,#3952/PR #3959 之后)

一个 `boolean` param(`name: confirmed`,`label: "Confirm This"`)产出**两个** label 元素指向**同一个**控件:

```
controlId=confirmed  role=checkbox
labels=[
  { text: "Confirm This", for: "confirmed", srOnly: true  },   widget 自己发的
  { text: "Confirm This", for: "confirmed", srOnly: false }    dialog 发的可见 label
]
```

两个 `for` 都能解析,所以这**不是** #3341 / #3952 那种悬空 label —— 点击一直是好的。坏的是**名字**:按 accname §2D,引用同一控件的多个 label 会**拼接**成可访问名,屏幕阅读器听到的是 "Confirm This Confirm This"。

## 两个缺陷,相隔一行

1. **关联是隐式的。** 它成立只因为 `BooleanField` 的 id 回退链第二项落在 `config.name`,而 `paramToField` 把它设成了 `param.name` —— 两边靠另一个包的内部实现恰好撞成同一个字符串。一个渲染了 `htmlFor` 的 host 必须自己发出它所指的 id;widget 契约(`FieldWidgetDomProps`)声明 `id` 就是为这个。
2. **重复的 sr-only label。** #3952 / PR #3959 让 `BooleanField` 在 host 下发 id 时不再发自己的 label(`emitOwnLabel = !hostId`),理由正是「会下发 id 的 host 就是会渲染 label 的 host」。这个分支收不到 id,那条抑制从来没被触发。

修后:关联从隐式变显式,widget 的 sr-only 副本被抑制,可访问名回到作者声明的那一份 "Confirm This"。通用分支未动。

## 钉子(两个方向)

`ActionParamDialog.ariaRequired.test.tsx` 新增 4 条(命名一半):

- boolean 控件的 `id` 恰为 `param.name`,且 `label[for]` 恰好 1 个,而且活下来的那个是**可见**的那份(不是 sr-only —— 只数个数会让一个只有屏幕阅读器可见名字的 checkbox 行蒙混过关);
- 可访问名恰为 `Confirm This`,不是它的两倍;
- 必填 boolean 的可访问名仍不含星号(`aria-hidden` 的 `*` 不能被抑制重复的动作带进名字里),且控件带 `aria-required="true"`;
- **不变方向**:通用分支的 host id / 单 label / 单名字照旧 —— 将来若有人把 id 归属搬回 widget,这条也会红。

`ActionParamDialog.test.tsx` 新增 1 条(行为一半):点击可见 label 翻转开关并 round-trip 到 `resolve`。

**刻意没有用 `getAllByLabelText` 做探针**(issue 正文提议过):`@testing-library/dom` 10.4.1 的 `queryAllByLabelText` 最后一步是 `Array.from(new Set(matchingLabelledElements))`,并且对多 label 会把名字拆开分别匹配 —— 修前修后它都只解析出 1 个控件,当探针是空转的。可测量的那一半是**名字**与**label 元素个数**,钉子就钉在这两处。

## 反向验证(先预判,后跑)

预判:删掉 boolean 分支那一行 `id={param.name}`(只删 24 空格缩进那条,通用分支的同名行不动),**恰好** 3 条命名钉翻红(2 个 label / 名字翻倍 / 必填那条也因名字翻倍红),而「通用分支不变」与新增的点击 label 钉**保持绿** —— 因为修前 `for` 目标本来就能解析,这个缺陷是重复而非悬空。

实测与预判逐条一致。带修:`Test Files 2 passed (2)` / `Tests 46 passed (46)`。删掉那一行后(`id={param.name}` 出现次数 2 → 1,通用分支那条完好):

```
× gives the boolean control the host id and exactly one label element
    AssertionError: expected [ label …(2) , …(1) ] to have a length of 1 but got 2
× announces the label once, not twice concatenated
    expect(element).toHaveAccessibleName()
× still names a required boolean param without folding in the asterisk
    expect(element).toHaveAccessibleName()
Test Files  1 failed | 1 passed (2)
Tests  3 failed | 43 passed (46)
```

「通用分支不变」与点击 label 那条在变异树里如预判保持绿。变异随后由 `git checkout --` + 重新 `git apply` 还原(未用 `git stash`,共享栈),未提交。

## 验证

- 仓根 `flock` 串行 + `NODE_OPTIONS=--max-old-space-size=4096`:
  - `pnpm exec vitest run packages/app-shell --maxWorkers=2` → `Test Files 308 passed (308)` / `Tests 2842 passed | 1 skipped (2843)`
  - `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` → 退出 0
  - `pnpm exec turbo run type-check --concurrency=2` → `Tasks: 78 successful, 78 total`,退出 0
- `node scripts/check-control-bytes.mjs` → OK(3856 个跟踪文本文件)。改动的 4 个文件另做了一次越过门禁盲区的自扫:用 `grep -naP` 匹配 C0 控制字符区间(NUL 到退格、垂直制表、换页、以及 SO 到 US),即除制表符/换行/回车之外的全部控制字节,无命中。
- changeset 三道门:presence / no-major / fixed-group 全绿。

## 消费半径

`getLazyFieldWidget` 在仓内只有两个非测试调用点。另一个 host(`plugin-grid` 的 `BulkActionDialog`)`id` 下发是对的,但缺 `aria-hidden` 的星号与 `aria-required`,已另立 #3967,**不在本 PR 范围**。

## 边界

只动 boolean 分支 + 两个既有测试文件 + changeset。未碰 `BooleanField` 本体(#3959 已定型)、未碰 `releases/`、未碰 #3913 在飞的 metadata-admin 面。
