### PR TITLE
fix(metadata-admin): 页面块检查器自身的 chrome 跟随会话语言 (#3963)

### DIFF
--- a/.changeset/page-block-inspector-chrome-i18n.md
+++ b/.changeset/page-block-inspector-chrome-i18n.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': patch
+---
+
+fix(metadata-admin): page block inspector chrome follows the locale
+
+`PageBlockInspector`'s own JSX carried hardcoded English that no translation
+table could reach: the row-adder of every field list (`Add`), the per-row and
+per-item remove `aria-label`s (`Remove` / `Remove item`), and the free-text
+fallback placeholders of the object picker and the field list. All now resolve
+through `engine.inspector.pageBlock.*` keys defined in both en-US and zh-CN.
+The JSON editor's parse error reuses the catalog's existing
+`engine.form.invalidJson` instead of its own literal, and holds the parse
+failure as state so the message follows a later locale switch. English is
+unchanged.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -478,6 +478,17 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.advanced': 'Advanced',
   'engine.inspector.pageBlock.remove': 'Remove block',
   'engine.inspector.pageBlock.outlineLabel': 'Blocks',
+  // Chrome of the panel's own list/JSON editors (#3963) — NOT block-config
+  // data. These live beside the keys above (not under `.field.`, which is
+  // reserved for keys derived from a BLOCK_CONFIG position) because they are
+  // one shared control repeated across every list field, with no per-field
+  // wording. `list.*` mirrors `engine.inspector.flowNode.list.*`, the same
+  // editor shape in a sibling panel.
+  'engine.inspector.pageBlock.list.add': 'Add',
+  'engine.inspector.pageBlock.list.remove': 'Remove',
+  'engine.inspector.pageBlock.list.removeItem': 'Remove item',
+  'engine.inspector.pageBlock.objectPlaceholder': 'snake_case object',
+  'engine.inspector.pageBlock.fieldPlaceholder': 'field name',
   // Page block inspector — curated property labels (#3913).
   // These are the `label` / `addLabel` / option-label values of
   // `previews/block-config.ts`; that file stores the KEY and the inspector
@@ -2197,6 +2208,12 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.advanced': '高级属性',
   'engine.inspector.pageBlock.remove': '删除区块',
   'engine.inspector.pageBlock.outlineLabel': '区块',
+  // 面板自身列表/JSON 编辑器的 chrome(#3963)—— 不是 block-config 表数据。
+  'engine.inspector.pageBlock.list.add': '添加',
+  'engine.inspector.pageBlock.list.remove': '删除',
+  'engine.inspector.pageBlock.list.removeItem': '删除项',
+  'engine.inspector.pageBlock.objectPlaceholder': 'snake_case 对象名',
+  'engine.inspector.pageBlock.fieldPlaceholder': '字段名',
   // 页面区块检查器 —— curated 属性 label(#3913)。
   // 键形状与 en 侧一一对应,由 `previews/__tests__/block-config-i18n.test.ts`
   // 按 BLOCK_CONFIG 的结构重新推导并断言两语齐备。

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
@@ -2,6 +2,7 @@
 
 /**
  * objectui#3913 — the PROPERTIES panel renders in the session's language.
+ * objectui#3963 — and so does the panel's OWN chrome (see the second describe).
  *
  * The sibling `previews/__tests__/block-config-i18n.test.ts` pins the TABLE
  * (every label is a key its position implies, and both locales define it). That
@@ -18,9 +19,13 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { PageSchema } from '@objectstack/spec/ui';
 import { PageBlockInspector } from './PageBlockInspector';
+import { t } from '../i18n';
 
 afterEach(cleanup);
 
@@ -99,28 +104,18 @@ describe('PageBlockInspector PROPERTIES labels follow the locale (#3913)', () =>
   });
 
   /**
-   * NOT asserted anywhere above, deliberately: that this panel contains no
-   * English at all. It still does, and the boundary is worth pinning.
+   * The boundary this describe deliberately did NOT cover used to be pinned
+   * here, as an assertion that the panel's own chrome was still English —
+   * `<Plus /> Add`, the "Remove" / "Remove item" aria-labels, "Invalid JSON",
+   * and two placeholders were literals in `PageBlockInspector.tsx` itself,
+   * never `block-config` labels, so they were outside objectui#3913 and filed
+   * as objectui#3963.
    *
-   * `FieldListField` and the `string-list` branch render their row-adder as a
-   * hardcoded `<Plus /> Add`, and `aria-label`s ("Remove", "Remove item"), the
-   * JSON parse error ("Invalid JSON") and two placeholders ("field name",
-   * "snake_case object") are literals in `PageBlockInspector.tsx` itself. None
-   * of them was ever a `block-config` label — different mechanism, different
-   * surface — so they are outside objectui#3913 and filed as objectui#3963.
-   *
-   * Asserting their PRESENCE (rather than quietly not mentioning them) means the
-   * day objectui#3963 lands, this case fails and has to be tightened, instead of
-   * the two fixes silently overlapping and leaving nobody sure what is covered.
+   * That case did its job: objectui#3963 landing turned it red instead of the
+   * two fixes silently overlapping. It is now the second describe below, which
+   * asserts the same sites resolve THROUGH the catalog in both locales — the
+   * boundary moved rather than disappeared.
    */
-  it('leaves only the known non-block-config chrome in English (objectui#3963)', () => {
-    renderInspector(pageDraft('record:details', { sections: [{ label: 'Contact info' }] }), 'zh-CN');
-
-    // The section's `fields` item editor is a `field-list`; its adder is chrome.
-    const adders = screen.getAllByRole('button').filter((b) => b.textContent?.trim() === 'Add');
-    expect(adders.length).toBeGreaterThan(0);
-    expect(screen.getAllByLabelText('Remove item').length).toBeGreaterThan(0);
-  });
 
   it('translates nested array-item labels, not just the container', () => {
     // Item fields recurse through `renderField` with a different read/write
@@ -168,5 +163,164 @@ describe('PageBlockInspector PROPERTIES labels follow the locale (#3913)', () =>
     expect(screen.getByText('显示面包屑')).toBeTruthy();
     expect(screen.queryByText('Subtitle')).toBeNull();
     expect(screen.queryByText('Show breadcrumb')).toBeNull();
+  });
+});
+
+/**
+ * objectui#3963 — the panel's OWN chrome follows the locale too.
+ *
+ * A different mechanism from the describe above: these strings were never
+ * `block-config` data, they were literals inside `PageBlockInspector.tsx`'s
+ * JSX. The visible symptom was one panel in two languages the other way round
+ * — after #3913 a zh-CN admin read 「分区」/「字段」 with an English `Add`
+ * underneath each list.
+ *
+ * Two of the sites are `aria-label`s and two are placeholders, i.e. invisible
+ * to a text query and to a screenshot; that is why they survived #3913's
+ * review and why the assertions below use `getByLabelText` /
+ * `getByPlaceholderText` rather than reading the rendered text.
+ */
+describe("PageBlockInspector's own chrome follows the locale (#3963)", () => {
+  /** `record:details` with one populated section: array card + field-list rows. */
+  const detailsDraft = () =>
+    pageDraft('record:details', { sections: [{ label: 'Contact info', fields: ['name'] }] });
+
+  it('renders every chrome site in Chinese under zh-CN', () => {
+    renderInspector(detailsDraft(), 'zh-CN');
+
+    // Row adder of the `field-list` editor (was a bare `<Plus /> Add`).
+    const adders = screen.getAllByRole('button').filter((b) => b.textContent?.trim() === '添加');
+    expect(adders.length).toBeGreaterThan(0);
+    // Per-row remove (aria-label only) and the array item card's remove.
+    expect(screen.getAllByLabelText('删除').length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('删除项').length).toBeGreaterThan(0);
+    // The free-text fallback row of a `field-list` — a placeholder, invisible
+    // to `getByText`.
+    expect(screen.getAllByPlaceholderText('字段名').length).toBeGreaterThan(0);
+
+    // The English literals are gone, not merely joined by Chinese ones.
+    expect(screen.queryAllByRole('button').filter((b) => b.textContent?.trim() === 'Add')).toEqual([]);
+    expect(screen.queryByLabelText('Remove')).toBeNull();
+    expect(screen.queryByLabelText('Remove item')).toBeNull();
+    expect(screen.queryByPlaceholderText('field name')).toBeNull();
+    expectNoRawKeys();
+  });
+
+  it('renders the same chrome in English under en-US, unchanged', () => {
+    // en-US is this repo's baseline language: the new keys carry exactly the
+    // literals that used to be hardcoded, so this panel must not have moved.
+    renderInspector(detailsDraft(), 'en-US');
+
+    const adders = screen.getAllByRole('button').filter((b) => b.textContent?.trim() === 'Add');
+    expect(adders.length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('Remove').length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('Remove item').length).toBeGreaterThan(0);
+    expect(screen.getAllByPlaceholderText('field name').length).toBeGreaterThan(0);
+    expectNoRawKeys();
+  });
+
+  it('translates the string-list branch too, not only FieldListField', () => {
+    // Two independent copies of the same adder/remove chrome: `FieldListField`
+    // (a component) and `renderField`'s `string-list` case (inline JSX). A fix
+    // applied to one only would leave the other English, and no fixture in the
+    // describe above renders `string-list` at all.
+    renderInspector(pageDraft('record:quick_actions', { actionNames: ['send_email'] }), 'zh-CN');
+
+    const adders = screen.getAllByRole('button').filter((b) => b.textContent?.trim() === '添加');
+    expect(adders.length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('删除').length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText('Remove')).toBeNull();
+    expectNoRawKeys();
+  });
+
+  it("translates the object picker's free-text placeholder", () => {
+    // `ObjectPickerField` degrades to a free-text input when the object list is
+    // unavailable — which is the state every offline session starts in.
+    renderInspector(pageDraft('object-grid'), 'zh-CN');
+
+    expect(screen.getByPlaceholderText('snake_case 对象名')).toBeTruthy();
+    expect(screen.queryByPlaceholderText('snake_case object')).toBeNull();
+  });
+
+  it('reuses the catalog key for the JSON parse error instead of a literal', () => {
+    // `engine.form.invalidJson` already existed and `translateValidationMessage()`
+    // already mapped `'invalid json'` onto it — this site had bypassed it. Asserting
+    // the RESOLVED value in both locales is what distinguishes "reused the key"
+    // from "hardcoded the same English words".
+    renderInspector(pageDraft('element:button'), 'zh-CN');
+    const zhArea = document.querySelector('textarea');
+    expect(zhArea).toBeTruthy();
+    fireEvent.change(zhArea!, { target: { value: '{ not json' } });
+    fireEvent.blur(zhArea!);
+    expect(screen.getByText(t('engine.form.invalidJson', 'zh-CN'))).toBeTruthy();
+    expect(screen.queryByText('Invalid JSON')).toBeNull();
+
+    cleanup();
+    renderInspector(pageDraft('element:button'), 'en-US');
+    const enArea = document.querySelector('textarea');
+    fireEvent.change(enArea!, { target: { value: '{ not json' } });
+    fireEvent.blur(enArea!);
+    expect(screen.getByText('Invalid JSON')).toBeTruthy();
+  });
+});
+
+/**
+ * Key completeness for the panel's own chrome — the same shape as the
+ * structural pin `previews/__tests__/block-config-i18n.test.ts` uses for the
+ * table, adapted to the one thing that differs: these keys have no position to
+ * be derived from, they are `t('…')` call sites in one file. So the list is
+ * read back OUT of that file instead of hand-copied here, and the day someone
+ * adds a chrome key with only an en translation this is red without anybody
+ * remembering to extend a list.
+ *
+ * Completeness is measured through `t()` — it returns the key unchanged on a
+ * miss, so `t(key, locale) === key` is exactly "this locale has no entry".
+ */
+describe("PageBlockInspector's chrome keys resolve in both locales (#3963)", () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(path.join(here, 'PageBlockInspector.tsx'), 'utf8');
+  /** Literal keys passed to `t()`. Dynamic `t(f.label)` sites are block-config's. */
+  const KEYS = [...new Set([...source.matchAll(/\bt\(\s*'([^']+)'/g)].map((m) => m[1]))];
+
+  /**
+   * Keys whose two locales are deliberately identical, with the reason. A
+   * ledger, not a rule — everything else staying red is the point.
+   */
+  const LOCALE_INVARIANT = new Set<string>([
+    'engine.inspector.pageBlock.id', // 'ID' — an acronym, not translated in zh-CN
+  ]);
+
+  it('finds the call sites at all — the scan is not vacuous', () => {
+    expect(KEYS.length).toBeGreaterThan(12);
+    // The five keys #3963 added, plus the existing one it reuses rather than
+    // duplicating. Named explicitly so a regex that silently stops matching
+    // (e.g. after a reformat) fails here instead of passing over nothing.
+    for (const key of [
+      'engine.inspector.pageBlock.list.add',
+      'engine.inspector.pageBlock.list.remove',
+      'engine.inspector.pageBlock.list.removeItem',
+      'engine.inspector.pageBlock.objectPlaceholder',
+      'engine.inspector.pageBlock.fieldPlaceholder',
+      'engine.form.invalidJson',
+    ]) {
+      expect(KEYS).toContain(key);
+    }
+  });
+
+  it('every key resolves in en-US', () => {
+    expect(KEYS.filter((k) => t(k, 'en-US') === k)).toEqual([]);
+  });
+
+  it('every key resolves in zh-CN', () => {
+    expect(KEYS.filter((k) => t(k, 'zh-CN') === k)).toEqual([]);
+  });
+
+  it('zh-CN is actually translated, not a copy of en-US', () => {
+    const untranslated = KEYS.filter(
+      (k) => !LOCALE_INVARIANT.has(k) && t(k, 'zh-CN') === t(k, 'en-US'),
+    ).map((k) => `${k} = '${t(k, 'en-US')}'`);
+    // If a chrome string really is locale-invariant, add it to
+    // LOCALE_INVARIANT above with its reason — do not weaken this assertion.
+    expect(untranslated).toEqual([]);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
@@ -14,7 +14,7 @@
 import * as React from 'react';
 import type { MetadataInspectorProps } from '../inspector-registry';
 import type { ExpressionInput } from '@objectstack/spec/shared';
-import { t } from '../i18n';
+import { t, type SupportedLocale } from '../i18n';
 import {
   InspectorShell,
   InspectorReorderButtons,
@@ -53,12 +53,13 @@ function useFieldOptions(objectName: string | undefined): Array<{ value: string;
 }
 
 /** Object dropdown; falls back to a free-text input when the list is empty. */
-function ObjectPickerField({ label, value, onCommit, disabled }: {
+function ObjectPickerField({ label, value, onCommit, disabled, locale }: {
   label: string; value: string | undefined; onCommit: (v: string) => void; disabled?: boolean;
+  locale: SupportedLocale;
 }) {
   const { options } = useObjectOptions();
   if (options.length === 0) {
-    return <InspectorTextField label={label} value={value ?? ''} placeholder="snake_case object" onCommit={onCommit} disabled={disabled} mono />;
+    return <InspectorTextField label={label} value={value ?? ''} placeholder={t('engine.inspector.pageBlock.objectPlaceholder', locale)} onCommit={onCommit} disabled={disabled} mono />;
   }
   return <InspectorSelectField label={label} value={value || undefined} options={options} onCommit={onCommit} disabled={disabled} />;
 }
@@ -75,8 +76,9 @@ function FieldPickerField({ label, objectName, value, onCommit, disabled }: {
 }
 
 /** Editable list of field names — each row a field dropdown (or text fallback). */
-function FieldListField({ label, objectName, value, onChange, disabled }: {
+function FieldListField({ label, objectName, value, onChange, disabled, locale }: {
   label: string; objectName: string | undefined; value: unknown; onChange: (v: string[]) => void; disabled?: boolean;
+  locale: SupportedLocale;
 }) {
   const options = useFieldOptions(objectName);
   const arr: string[] = Array.isArray(value) ? (value as string[]) : [];
@@ -95,10 +97,11 @@ function FieldListField({ label, objectName, value, onChange, disabled }: {
               </Select>
             </div>
           ) : (
-            <Input className="h-8 text-sm" value={String(s ?? '')} placeholder="field name" disabled={disabled}
+            <Input className="h-8 text-sm" value={String(s ?? '')} placeholder={t('engine.inspector.pageBlock.fieldPlaceholder', locale)} disabled={disabled}
               onChange={(e) => { const n = [...arr]; n[i] = e.target.value; onChange(n); }} />
           )}
-          <Button type="button" variant="ghost" size="icon" className="h-8 w-8" disabled={disabled} aria-label="Remove"
+          <Button type="button" variant="ghost" size="icon" className="h-8 w-8" disabled={disabled}
+            aria-label={t('engine.inspector.pageBlock.list.remove', locale)}
             onClick={() => onChange(arr.filter((_, j) => j !== i))}>
             <X className="h-4 w-4" />
           </Button>
@@ -106,7 +109,7 @@ function FieldListField({ label, objectName, value, onChange, disabled }: {
       ))}
       {!disabled && (
         <Button type="button" variant="outline" size="sm" onClick={() => onChange([...arr, ''])}>
-          <Plus className="mr-1 h-3.5 w-3.5" /> Add
+          <Plus className="mr-1 h-3.5 w-3.5" /> {t('engine.inspector.pageBlock.list.add', locale)}
         </Button>
       )}
     </div>
@@ -125,26 +128,30 @@ function safeStringify(value: unknown): string {
 
 /** Editable JSON field for object/array properties — commits on blur so a
  *  half-typed value never trips the parser. Empty clears the property. */
-function InspectorJsonField({ label, value, onCommit, disabled, placeholder }: {
+function InspectorJsonField({ label, value, onCommit, disabled, placeholder, locale }: {
   label: string; value: unknown; onCommit: (v: unknown) => void; disabled?: boolean;
   /** Shown while the property is unset — the expected shape, since an empty
    *  JSON textarea tells an author nothing about what to type. */
   placeholder?: string;
+  locale: SupportedLocale;
 }) {
   const initial = React.useMemo(() => safeStringify(value), [value]);
   const [text, setText] = React.useState(initial);
-  const [error, setError] = React.useState<string | null>(null);
-  React.useEffect(() => { setText(initial); setError(null); }, [initial]);
+  // State holds the FACT (the text does not parse), not the wording — so the
+  // message is resolved at render and follows a locale switch instead of
+  // freezing whatever language was active when the parse failed.
+  const [invalid, setInvalid] = React.useState(false);
+  React.useEffect(() => { setText(initial); setInvalid(false); }, [initial]);
   const commit = () => {
     if (disabled) return;
     const trimmed = text.trim();
-    if (trimmed === '') { setError(null); onCommit(undefined); return; }
+    if (trimmed === '') { setInvalid(false); onCommit(undefined); return; }
     try {
       const parsed = JSON.parse(trimmed);
-      setError(null);
+      setInvalid(false);
       onCommit(parsed);
     } catch {
-      setError('Invalid JSON');
+      setInvalid(true);
     }
   };
   return (
@@ -160,7 +167,10 @@ function InspectorJsonField({ label, value, onCommit, disabled, placeholder }: {
         rows={Math.min(12, Math.max(2, text.split('\n').length))}
         className="w-full rounded border border-input bg-background px-2 py-1.5 text-xs font-mono outline-none focus:ring-1 focus:ring-primary resize-y disabled:opacity-60"
       />
-      {error && <div className="text-[11px] text-destructive">{error}</div>}
+      {/* Reuses the catalog's existing `engine.form.invalidJson` — the same key
+          the shared `translateValidationMessage()` already maps `'invalid
+          json'` onto — rather than minting a second wording for one fact. */}
+      {invalid && <div className="text-[11px] text-destructive">{t('engine.form.invalidJson', locale)}</div>}
     </div>
   );
 }
@@ -168,8 +178,9 @@ function InspectorJsonField({ label, value, onCommit, disabled, placeholder }: {
 /** Renders one arbitrary block property by inferring an editor from its
  *  runtime type. Guarantees the inspector can edit anything visible in the
  *  source, even block types with no curated BLOCK_CONFIG entry. */
-function GenericPropField({ name, value, onCommit, disabled }: {
+function GenericPropField({ name, value, onCommit, disabled, locale }: {
   name: string; value: unknown; onCommit: (v: unknown) => void; disabled?: boolean;
+  locale: SupportedLocale;
 }) {
   if (typeof value === 'boolean') {
     return <InspectorCheckboxField label={name} value={value} onCommit={onCommit} disabled={disabled} />;
@@ -180,7 +191,7 @@ function GenericPropField({ name, value, onCommit, disabled }: {
   if (value === null || typeof value === 'string') {
     return <InspectorTextField label={name} value={value == null ? '' : value} onCommit={onCommit} disabled={disabled} mono />;
   }
-  return <InspectorJsonField label={name} value={value} onCommit={onCommit} disabled={disabled} />;
+  return <InspectorJsonField label={name} value={value} onCommit={onCommit} disabled={disabled} locale={locale} />;
 }
 
 /** Block `properties` keys whose values are nested block trees — these are
@@ -434,7 +445,7 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
         // without this a curated JSON prop could be edited and never added.
         return (
           <InspectorJsonField key={k} label={fieldLabel(f.label)} value={read(f.name)}
-            placeholder={f.placeholder}
+            placeholder={f.placeholder} locale={locale}
             onCommit={(v) => write(f.name, v)} disabled={readOnly} />
         );
       case 'string-list': {
@@ -447,14 +458,15 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
                 <Input className="h-8 text-sm" value={String(s ?? '')} placeholder={f.placeholder} disabled={readOnly}
                   onChange={(e) => { const next = [...arr]; next[i] = e.target.value; write(f.name, next); }} />
                 <Button type="button" variant="ghost" size="icon" className="h-8 w-8" disabled={readOnly}
-                  aria-label="Remove" onClick={() => write(f.name, arr.filter((_, j) => j !== i))}>
+                  aria-label={t('engine.inspector.pageBlock.list.remove', locale)}
+                  onClick={() => write(f.name, arr.filter((_, j) => j !== i))}>
                   <X className="h-4 w-4" />
                 </Button>
               </div>
             ))}
             {!readOnly && (
               <Button type="button" variant="outline" size="sm" onClick={() => write(f.name, [...arr, ''])}>
-                <Plus className="mr-1 h-3.5 w-3.5" /> Add
+                <Plus className="mr-1 h-3.5 w-3.5" /> {t('engine.inspector.pageBlock.list.add', locale)}
               </Button>
             )}
           </div>
@@ -472,7 +484,8 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
                   <div className="flex items-center justify-between">
                     <span className="text-xs text-muted-foreground">#{i + 1}</span>
                     <Button type="button" variant="ghost" size="icon" className="h-7 w-7" disabled={readOnly}
-                      aria-label="Remove item" onClick={() => write(f.name, arr.filter((_, j) => j !== i))}>
+                      aria-label={t('engine.inspector.pageBlock.list.removeItem', locale)}
+                      onClick={() => write(f.name, arr.filter((_, j) => j !== i))}>
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>
                   </div>
@@ -497,7 +510,7 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
       }
       case 'object-picker':
         return (
-          <ObjectPickerField key={k} label={fieldLabel(f.label)}
+          <ObjectPickerField key={k} label={fieldLabel(f.label)} locale={locale}
             value={read(f.name) != null ? String(read(f.name)) : undefined}
             onCommit={(v) => write(f.name, v)} disabled={readOnly} />
         );
@@ -509,7 +522,7 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
         );
       case 'field-list':
         return (
-          <FieldListField key={k} label={fieldLabel(f.label)} objectName={resolveObject(f)}
+          <FieldListField key={k} label={fieldLabel(f.label)} objectName={resolveObject(f)} locale={locale}
             value={read(f.name)} onChange={(v) => write(f.name, v)} disabled={readOnly} />
         );
       default:
@@ -617,6 +630,7 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
               value={blockProps[key]}
               onCommit={(v) => patchProp(key, v)}
               disabled={readOnly}
+              locale={locale}
             />
           ))}
         </div>


### PR DESCRIPTION
Fixes #3963

基:`5bfaabde0`(含 #3913 的落地 `62c644168`,已 `git merge-base --is-ancestor` 核验)。

## 症状与机制

#3913(PR #3970)修的是 `previews/block-config.ts` 的 curated 属性 label —— **表数据**。本单是另一条机制:`PageBlockInspector.tsx` **自己 JSX 里**的硬编码英文,从来不是 `block-config` 的 label,任何翻译表都碰不到。#3913 之后症状恰好反了过来:zh-CN 管理员打开 `record:details` 检查器,「分区」「字段」都是中文,每个字段列表下面的添加按钮却是英文 `Add`。

## 字面量清扫(逐处 grep,含处置)

| worktree 行 | 位置 | 原字面量 | 处置 |
|---|---|---|---|
| 62 | `ObjectPickerField` 自由文本兜底 | `placeholder="snake_case object"` | 新键 `…pageBlock.objectPlaceholder` |
| 100 | `FieldListField` 自由文本行 | `placeholder="field name"` | 新键 `…pageBlock.fieldPlaceholder` |
| 104 | `FieldListField` 行删除 | `aria-label="Remove"` | 新键 `…pageBlock.list.remove` |
| 112 | `FieldListField` 行添加 | 裸 `Add` | 新键 `…pageBlock.list.add` |
| 171 | `InspectorJsonField` 解析错误 | `setError('Invalid JSON')` | **复用现成键** `engine.form.invalidJson`(不新增) |
| 466 | `string-list` 分支行删除 | `aria-label="Remove"` | 同 `…pageBlock.list.remove` |
| 473 | `string-list` 分支行添加 | 裸 `Add` | 同 `…pageBlock.list.add` |
| 492 | `array` 分支 item 卡片删除 | `aria-label="Remove item"` | 新键 `…pageBlock.list.removeItem` |

清扫方式:`aria-label=`/`title=`/`alt=`/`placeholder=` 属性全量列举 + 自闭合标签后的裸文本节点扫描。**零残留**,唯一剩下的属性字面量是 `SelectValue placeholder="—"`(全角破折号,无语言内容,不译)。**阳性反查**:对同一文件 grep `Add|Remove|Invalid|field name|snake_case`,命中只剩标识符(`InspectorRemoveButton`、`setInvalid`)与注释,证明模式确实找得到这些词、而不是模式失效。

分诊评论给的 main 锚点(61/101/147/440/465)逐条对上,只有行号随 #3913 漂移。

## 键命名:共享键,且**不放在** `.field.` 下

分诊席把「共享 `addRow` 键 vs 逐点键」留给 PR 决定。**选共享键**:两个添加按钮语义完全相同(给这个标量列表加一行),两处本就没有 per-field 文案。逐点键会造出两个值相同、译者无从区分的键 —— 「一键一义」在反方向失效。

同时对 issue 建议的键名 `engine.inspector.pageBlock.field.addRow` 做了**一处偏离**:不放进 `.field.` 命名空间。`.field.*` / `.add.*` / `.option.*` 三支的契约是「由 label 在 `BLOCK_CONFIG` 里的位置推导」,`previews/__tests__/block-config-i18n.test.ts` 正是照这个形状反推的;chrome 键混进去会长得像一个叫 `addRow` 的块类型,而这恰是那条推导断言在防的复制粘贴失误。所以 chrome 键与 `kind`/`close`/`properties`/`advanced`/`remove` 平级:

```
engine.inspector.pageBlock.list.add          Add        / 添加
engine.inspector.pageBlock.list.remove       Remove     / 删除
engine.inspector.pageBlock.list.removeItem   Remove item/ 删除项
engine.inspector.pageBlock.objectPlaceholder snake_case object / snake_case 对象名
engine.inspector.pageBlock.fieldPlaceholder  field name / 字段名
```

`list.*` 这个子命名空间照抄 `engine.inspector.flowNode.list.*` —— 兄弟面板里同一种列表编辑器的现成惯例;`…Placeholder` 后缀照抄同表已有的 `engine.inspector.widget.datasetPlaceholder`。zh 取值与既有惯例对齐(`删除` 同 `engine.form.remove`,`删除项` 同 `flowNode.list.remove`)。

**没有复用 `engine.form.add`/`engine.form.remove`**(值恰好也是 `Add`/`添加`):那是 SchemaForm 终端用户表单的面,复用会让设计器检查器的措辞随另一个面板改动而变 —— PR #3970 对同一面板已论证过这条 split-brain 取舍。**但 `Invalid JSON` 反过来必须复用**:`engine.form.invalidJson` 已存在,且共享的 `translateValidationMessage()` 已经把 `'invalid json'` 映射到它,这里原本是把现成键绕过去了,新增第二个键就是给同一个事实造第二种措辞。

en 侧五个新键的值**逐字等于**原来的字面量,所以英文面无漂移(下面 en 钉与 `check:i18n-drift` 双向印证)。

## 顺带修正:错误消息不再冻结语言

`InspectorJsonField` 原来把**已翻译的字符串**存进 state。改成存布尔事实、渲染时解析 —— 否则解析失败后切换语言,消息会停在失败当时那门语言。state 存事实、渲染管措辞。

## PR #3970 边界钉的收紧

PR #3970 里那条 `leaves only the known non-block-config chrome in English (objectui#3963)` **断言这些英文仍然存在** —— 设计好的接力信号。它按预期精确翻红,**收紧而非删除**:原位置留下一段注释说明「边界移动了、没有消失」,断言本身变成新的 describe,钉同一批站点现在**经由目录解析**、两语齐备。

## 钉子

1. **`PageBlockInspector's own chrome follows the locale (#3963)`**(5 例)—— zh-CN 下八处站点全中文 + 英文原文逐条 `queryBy…` 为空;en-US 下逐条仍是原英文(基准语言未动);`string-list` 分支单独一例(它与 `FieldListField` 是同一套 chrome 的两份独立拷贝,上面的 describe 没有任何 fixture 渲染到它);object picker 的 placeholder;JSON 解析错误在两语下的解析值。两个 `aria-label` 与两个 placeholder **对文本查询和截图都不可见**,所以断言走 `getByLabelText` / `getByPlaceholderText` —— 这也正是它们能躲过 #3913 那轮 review 的原因。
2. **`chrome keys resolve in both locales (#3963)`**(4 例)—— 形状照 #3913 的结构钉,但适配了唯一的差别:chrome 键没有「位置」可推导,它们是一个文件里的 `t('…')` 调用点。所以键表不是手抄进测试,而是**从组件源码读回来**(`readFileSync` + 正则取字面量键,动态 `t(f.label)` 自然落在 block-config 那条钉里),于是将来谁加一个只有 en 译文的 chrome 键,这里直接翻红,不依赖谁记得来扩列表。完整性照 #3913 的写法用 `t()` 度量(未命中原样返回键,`t(k,l) === k` 恰好就是「这门语言没有条目」)。另有 `LOCALE_INVARIANT` 台账一条:`engine.inspector.pageBlock.id`(`ID` 是缩写,zh 不译)—— 台账而非放宽,其余全部保持红。

## 反向验证(方向先预判、写在 scratchpad 再跑;两个变异均已回退,不提交)

**变异 A —— 还原 `aria-label="Remove item"` 字面量。** 预判:zh 例翻红、键扫描例翻红,而 **en 例保持绿**(还原的字面量**就是** en 值 —— en 钉是漂移守卫,不是回归探测器,这个方向是反的,如实记录)。实测 `Tests 2 failed | 14 passed`,两处预判的翻红点逐条命中(`Unable to find a label with the text of: 删除项`;`expected [ …(16) ] to include 'engine.inspector.pageBlock.list.remov…'`),en 例如预判保持绿。**与预判的偏差**:我原写「预计 3 条红」,把同一个用例里的两句断言数成了两条 —— 首句断言抛出后第二句不再执行,**用例数**是 2。方向全部吻合,计数是我数错了。

**变异 B —— 删掉 zh 侧 `list.add` 一条。** 预判:`every key resolves in zh-CN` 精确指名该键;`zh-CN is actually translated, not a copy of en-US` **保持绿**(`t()` 兜底返回键本身,与 `Add` 不同,那条断言无从触发 —— 与 PR #3970 对自己那个变异测到的方向一致);两条渲染例翻红。实测 `Tests 5 failed | 11 passed`,`AssertionError: … + [ "engine.inspector.pageBlock.list.add" ]` 精确指名,「zh 不等于 en」如预判保持绿。**比预判多两条红**:#3913 原有的两条 zh 渲染例(`renders curated field labels…`、`translates the array add button…`)也翻了 —— 它们的 `expectNoRawKeys()` 扫的是整个面板 body,于是也看见了 chrome 漏键渲染出的裸键串。这是「诊断变多而非变少」的方向,我低估了爆炸半径,如实记录。

## 消费半径清扫

按规则不只扫改动包:全仓 grep 断言这些字面量的测试/fixture/e2e,以及渲染 `PageBlockInspector` 的全部测试文件 —— 命中只在 `packages/app-shell/src/views/metadata-admin` 内(`block-config-i18n`、`page-block-path`、`visibleWhen`、`sectionName`、本文件),已被下面的全量跑覆盖;其它包没有 fixture 喂给这个组件。

## 校验记录(全部实测)

- `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`(持共享锁)—— 通过。
- 仓根 `pnpm exec vitest run packages/app-shell/src/views/metadata-admin --maxWorkers=2`(持共享锁,`NODE_OPTIONS=--max-old-space-size=4096`)—— `Test Files 135 passed (135)` / `Tests 1360 passed | 1 skipped (1361)`,exit=0。
- 仓根 `pnpm exec turbo run type-check --concurrency=2` —— `78 successful, 78 total`,exit=0。
- `pnpm check:i18n-keys` exit=0(`2316/2316 literal keys resolve`;`module-local table` 计数 1076 → **1084**,恰好等于本 PR 新增的 8 个 `t()` 调用点)。`pnpm check:i18n-drift` exit=0(`0 en value(s) changed`)。两张门都不覆盖 `metadata-admin/i18n.ts` 本表(它在 `EXCLUDED_TRANSLATORS` / 门只读 locale pack),所以它们的绿是「未被本改动破坏」,表内完整性由上面第 2 条钉负责。
- `node scripts/check-control-bytes.mjs` OK(3874 文件);另对 3 个改动文件做了 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 自扫(gate 有已知盲区),干净。
- `pnpm exec eslint` 三个改动文件:`0 errors`(33 条既存 `any`/react-refresh warning,与本改动无关)。
- `node scripts/check-changeset-presence.mjs` exit=0;changeset `@object-ui/app-shell` patch。

## 边界

- ⛔ 未动 `previews/block-config.ts`(#3913 已定型)。
- ⛔ 未动 #3912 的 `BlockPropField` 能力位面。
- ⛔ 未动在飞 #3962 的 `ActionParamDialog`(同包不同文件,不相交)。
- 实施中发现 `block-config.ts` 的 **`placeholder` 列**仍是英文显示文本(8 处有语言内容,如 `lucide icon name` ×4、`snake_case, e.g. contact_info`)—— 与 #3913 同一条机制、同一个文件的另一列,**不是**本单的面,已另开 #3979,未夹带。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_