### PR TITLE
fix(plugin-detail): record:related_list 的 filter 接通查询,Add 按钮门与 picker 对话框对齐 (objectstack#7118, #3895)

### DIFF
--- a/.changeset/related-list-filter-and-add-gate.md
+++ b/.changeset/related-list-filter-and-add-gate.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`record:related_list` — the declared `filter` reaches the query, and the Add button answers to the same gate as its dialog
+
+- **`filter` is consumed** (objectstack#7118). The spec declares
+  `RecordRelatedListProps.filter` ("additional filter criteria") and this repo
+  published it as a registry input, but nothing read it: `RelatedList` built its
+  query from `{ [relationshipField]: parentId }` alone, so an authored filter was
+  accepted by every gate and silently dropped — the list answered with every child
+  of the parent. It is now AND-combined with the parent condition (never
+  substituted for it, so an additional criterion can only narrow), lowered through
+  the repo's single filter sink so the spec's `[{ field, operator, value }]`
+  vocabulary and a composed `dataSource` binding both work. With nothing authored
+  the query is unchanged. As a consequence a saved view named through
+  `dataSource: { object, view }` no longer contributes its columns/sort/limit while
+  its filter is discarded — the list can no longer be wider than the view it names.
+  On the legacy raw-URL fallback path, which cannot express an operator, a declared
+  filter is refused with a console explanation instead of dropped.
+- **The Add button now requires `dataSource`** (objectui#3895), matching the picker
+  dialog and the add callback. In hosts that supply no `RecordContext` — Studio
+  designer previews, context-free embeds — the button rendered and did nothing at
+  all when clicked; the affordance is now withheld where the capability behind it
+  is absent.

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -247,7 +247,7 @@ ignores would be accepted and dropped, which is the defect this binding removes.
 | `list-view` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `object-grid` | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `element:record_picker` | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `record:related_list` | ✅ | columns / sort / limit | — (see below) | ✅ | ✅ |
+| `record:related_list` | ✅ | columns / filter / sort / limit | ✅ | ✅ | ✅ |
 | `object-calendar` | ✅ | filter / sort | ✅ | ✅ | — no row cap |
 | `object-kanban` | ✅ | filter | ✅ | — no ordering | — fixed window |
 | `object-chart` | ✅ | filter | ✅ | — engine orders | — no page |
@@ -259,12 +259,16 @@ on that block. A view name that does not resolve is reported as a configuration
 error on **every** block in the table, including the ones that take nothing else
 from the view — so a typo never passes silently, whatever the block.
 
-Two current gaps, recorded rather than papered over:
+On `record:related_list` the composed filter is AND-combined with the parent
+relationship condition, never substituted for it: a related list is always scoped
+to the record it appears on, and an *additional* criterion can only narrow that
+set further. (Until objectstack#7118 this block declared `filter` without reading
+it, so a named view contributed its columns / sort / limit while its filter was
+dropped — the list could be wider than the view it named. That gap is closed; the
+`filter` cell above is what closed it.)
 
-- `record:related_list` declares a flat `filter` its renderer does not read (the
-  list scopes itself by the parent relationship alone), so a view named there
-  contributes columns / sort / limit and its filter is dropped — the list can be
-  wider than the view it names.
+One current gap, recorded rather than papered over:
+
 - `object-form` resolves `view` only to report an unresolvable name; a view that
   does resolve contributes nothing, because a list view's columns are not a form
   layout.

--- a/packages/plugin-detail/README.md
+++ b/packages/plugin-detail/README.md
@@ -213,6 +213,26 @@ in the opt-in filter box temporarily falls back to the full-fetch client
 pipeline (the contains-filter sweeps every field, which no generic server
 filter can express).
 
+The node's `filter` (spec `RecordRelatedListProps.filter`, "additional filter
+criteria") narrows the list beyond the parent relationship: it is
+**AND-combined** with `{ [relationshipField]: parentId }`, never substituted for
+it, so a related list stays scoped to the record it appears on and an additional
+criterion can only ever narrow that set. Authors write it in the spec's own
+vocabulary (`[{ field, operator, value }]`); a `dataSource` binding's composed
+filter (component AND saved view AND binding) lands on the same key. Both are
+lowered to ObjectQL through the repo's single filter sink, so no second dialect
+appears. On the legacy raw-URL fallback path (no `dataSource` adapter, where the
+query language is `filter[<field>]=<value>` and cannot carry an operator) a
+declared filter is refused with a console explanation rather than dropped —
+answering with more rows than the metadata asked for is the failure this key's
+wiring exists to remove.
+
+The **Add** affordance renders only where every link in its chain is available:
+a spec-valid `add.picker.object` *and* a `dataSource`. The picker dialog and the
+add callback both required the adapter already, so without it the button used to
+render and do nothing at all when clicked — visible in hosts that supply no
+`RecordContext` (Studio designer previews, context-free embeds).
+
 The `record:related_list` renderer is automatically gated on the current
 user's object-level `read` permission for the child object: when the
 permission system (`@object-ui/permissions`) is loaded and denies read,

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -47,7 +47,10 @@ import {
   getRecordDisplayName,
   getSortValue,
   isExpandableFieldType,
+  mergeFilterNodes,
+  toFilterNode,
   userActionPredicates,
+  type FilterNode,
 } from '@object-ui/core';
 import { useSafeFieldLabel } from '@object-ui/react';
 import { usePermissions } from '@object-ui/permissions';
@@ -136,6 +139,29 @@ export interface RelatedListProps {
    * @default false
    */
   sortable?: boolean;
+  /**
+   * The list's OWN scope filter — spec `RecordRelatedListProps.filter`
+   * ("Additional filter criteria for related records"), which had no read site
+   * on this component at all until objectstack#7118: the query was built from
+   * `{ [referenceField]: parentId }` alone, so an authored `filter` (and the
+   * FILTER half of a `dataSource` binding's saved view) was accepted by every
+   * gate and silently dropped — the list answered wider than the metadata asked.
+   *
+   * ANDed with the parent-relationship condition, never substituted for it:
+   * "additional" means it may only narrow this parent's children. That is also
+   * why it is not routed through `data-table`'s `lookupFilters` — those render
+   * as filter-bar rows the user can edit, which demotes the author's constraint
+   * to a suggestion (#3831 argued this for `add.picker.filter`; it holds harder
+   * for the list's own scope).
+   *
+   * Two shapes arrive, both produced by our own layers: the spec vocabulary
+   * (`ViewFilterRule[]`) as authored, and an ObjectQL AST node as composed by
+   * `ElementDataSourceGate` (which ANDs component/view/binding filters through
+   * `mergeFilterNodes` before this component ever sees them). Both are lowered
+   * here through that same single sink — the repo's one filter→wire exit — so no
+   * second conversion dialect appears.
+   */
+  filter?: ViewFilterRule[] | FilterNode;
   /** Enable text filtering */
   filterable?: boolean;
   /** Whether the card is collapsible */
@@ -290,6 +316,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
   pageSize,
   defaultSort,
   sortable = false,
+  filter,
   filterable = false,
   collapsible = false,
   defaultCollapsed = false,
@@ -359,6 +386,18 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     () => normalizeSortSpec(defaultSort),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [defaultSortKey],
+  );
+  // The list's own scope filter, lowered to an ObjectQL node once. Keyed on
+  // CONTENT for the reason `defaultSortSpec` is: an inline `filter` array on a
+  // schema node is a new identity every render, and this value is a dependency
+  // of the fetch effect — keying on identity would refetch the collection on
+  // every render. `undefined` means "nothing authored", so the query below stays
+  // byte-identical to what it sent before this key had a read site.
+  const filterKey = JSON.stringify(filter ?? null);
+  const listFilterNode = React.useMemo(
+    () => toFilterNode(filter),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filterKey],
   );
 
   // Sync internal state when data prop changes (e.g., parent fetches async data)
@@ -454,9 +493,19 @@ export const RelatedList: React.FC<RelatedListProps> = ({
         return;
       }
       setLoading(true);
-      const filter = { [referenceField!]: parentId } as Record<string, any>;
+      const parentScope = { [referenceField!]: parentId } as Record<string, any>;
+      // Parent relationship AND the list's own scope (objectstack#7118). The
+      // parent condition is never negotiable — an "additional" criterion may only
+      // narrow this parent's children — and with nothing authored the query is
+      // the untouched MongoDB-style object it has always been, rather than a
+      // freshly lowered AST that means the same thing (the difference is
+      // invisible on screen and visible to every caller pinning the wire).
+      const queryFilter =
+        listFilterNode === undefined
+          ? parentScope
+          : mergeFilterNodes(parentScope, listFilterNode);
       if (dataSource && typeof dataSource.find === 'function') {
-        const params: Record<string, any> = { $filter: filter };
+        const params: Record<string, any> = { $filter: queryFilter };
         if (windowed) {
           params.$top = effectivePageSize;
           params.$skip = fetchPage * effectivePageSize;
@@ -497,6 +546,22 @@ export const RelatedList: React.FC<RelatedListProps> = ({
           console.error('Failed to fetch related data:', err);
           if (!cancelled) setLoading(false);
         });
+      } else if (listFilterNode !== undefined) {
+        // No adapter — the legacy raw-URL path, whose query language is
+        // `filter[<field>]=<value>` and cannot carry an operator, let alone a
+        // rule array. Dropping the authored filter here would answer with MORE
+        // rows than the metadata asked for, silently: the exact class this key's
+        // wiring exists to remove (objectstack#7118), so it refuses and says so
+        // instead. Empty-and-loud beats wider-and-quiet; the guard above refuses
+        // an unscoped fetch on the same reasoning.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[RelatedList] "${api}" declares a filter but has no dataSource adapter — the raw-URL fallback cannot express it, so no rows are fetched. Pass a dataSource (RecordContext) to use a filtered related list.`,
+        );
+        setRelatedData([]);
+        setTotal(null);
+        setHasMore(false);
+        setLoading(false);
       } else {
         const qs = new URLSearchParams({
           [`filter[${referenceField}]`]: String(parentId),
@@ -519,7 +584,7 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [api, dataProvided, dataSource, referenceField, parentId, refreshNonce, windowed, effectivePageSize, fetchPage, fetchSortField, fetchSortDirection, defaultSortSpec]);
+  }, [api, dataProvided, dataSource, referenceField, parentId, refreshNonce, windowed, effectivePageSize, fetchPage, fetchSortField, fetchSortDirection, defaultSortSpec, listFilterNode]);
 
   // Windowed mode: a page beyond the (shrunken) collection — e.g. the last
   // row of the last page was just deleted — comes back empty. Step back one
@@ -531,11 +596,14 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     }
   }, [windowed, loading, relatedData, currentPage]);
 
-  // A different parent (or relationship) is a different collection — restart
-  // from the first page.
+  // A different parent (or relationship, or list scope) is a different
+  // collection — restart from the first page. `filterKey` belongs here for the
+  // same reason the other three do: page 3 of the unfiltered children is not
+  // page 3 of the filtered ones.
   React.useEffect(() => {
     setCurrentPage(0);
-  }, [api, referenceField, parentId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, referenceField, parentId, filterKey]);
 
   // Refetch when a mutation elsewhere signals this related object changed —
   // e.g. a child row action executed through the host retargets `api` and
@@ -1154,8 +1222,21 @@ export const RelatedList: React.FC<RelatedListProps> = ({
                 truthy: an `add` without `picker` is metadata the spec rejects,
                 and offering a button that could never open a picker is worse
                 than withholding it (#3838 — the console hint above names the
-                missing key). */}
-            {add && pickerObject && (
+                missing key).
+
+                `dataSource` is part of the SAME gate, because the dialog this
+                button opens (below, `add && pickerObject && dataSource`) and the
+                callback it ends in (`handleAddRecords`: `if (!add ||
+                !dataSource || …) return`) both require it. Without it the button
+                rendered, `setPickerOpen(true)` ran, and no dialog existed to
+                observe the flag: a click with NO visible reaction and no
+                message. Hosts where that is real are the ones passing
+                `dataSource={ctx?.dataSource}` with no `RecordContext` bound —
+                the Studio designer preview and context-free embeds
+                (`renderers/record-related-list.tsx`). Same principle as #3838
+                one condition further: an affordance is offered only where the
+                capability behind it exists (objectui#3895). */}
+            {add && pickerObject && dataSource && (
               <Button
                 variant={isEmpty ? 'ghost' : 'outline'}
                 size="sm"

--- a/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.elementDataSource.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.elementDataSource.test.tsx
@@ -13,20 +13,20 @@
  * requires, so a related list authored with the binding hit the
  * "missing objectName" placeholder instead of listing anything.
  *
- * ## The one key that is NOT mapped, and why it is a finding
+ * ## The key that used to be unmapped, and what closed it
  *
- * `filter` stays unmapped: this renderer DECLARES `filter` in its registry
- * `inputs` ("Additional filter criteria") and never reads it — `RelatedList`
- * builds its query from `{ [referenceField]: parentId }` alone and takes no
- * filter prop for the list's own scope. Mapping the composed filter onto
- * `schema.filter` would hand it to a key nothing consumes, which is the defect
- * objectstack#6953 removes rather than spreads.
+ * `filter` was deliberately left out of the mapping when this suite was written:
+ * the renderer DECLARED `filter` and nothing read it — `RelatedList` built its
+ * query from `{ [referenceField]: parentId }` alone and had no prop for the
+ * list's own scope — so writing the composed filter onto `schema.filter` would
+ * have handed it to a dead key, which is the defect objectstack#6953 removes
+ * rather than spreads. The last test pinned that consequence honestly: a saved
+ * view named here contributed its columns / sort / limit while its FILTER was
+ * dropped, so the list could be wider than the view it names.
  *
- * The consequence is pinned rather than left implicit (last test): while that
- * gap is open, a saved view named here contributes its columns / sort / limit and
- * its FILTER is dropped, so the list can be wider than the view it names. When
- * the flat `filter` gains a read site (objectstack#7118), `filter: true` belongs
- * in the mapping and that test is the one that must change.
+ * objectstack#7118 gave the key a read site, so that test is now the POSITIVE
+ * assertion its own comment predicted: the composed filter reaches `RelatedList`
+ * and the list can no longer be wider than the view it names.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -117,16 +117,45 @@ describe('record:related_list — dataSource: { object, view } (objectstack#6953
     expect(h.captured.pageSize).toBe(7);
   });
 
-  it('does NOT hand a composed filter to a key this block cannot read (open gap)', async () => {
-    // Honest pin on the residual gap, not a claim that filtering works: the
-    // renderer declares `filter` and never reads it, and `RelatedList` has no
-    // prop for the list's own filter. Writing the view's filter onto
-    // `schema.filter` would look like wiring and change nothing, so the mapping
-    // does not — and this asserts that no filter reaches `RelatedList` under any
-    // spelling. Filed as objectstack#7118; when a read site lands, this flips.
+  it('hands the composed view-AND-binding filter to the list (objectstack#7118)', async () => {
+    // The flipped half of this suite. Before objectstack#7118 the assertion here
+    // was `h.captured.filter` is `undefined` — an honest pin on a dead declared
+    // key, with the note that a read site would invert it. It did, so this now
+    // asserts the composition arrives: the view's own filter and the binding's,
+    // ANDed, on the prop `RelatedList` reads for the list's own scope.
     renderRelated({ dataSource: { object: 'contact', view: 'recent', filter: [['x', '=', 1]] } });
     await waitFor(() => expect(h.captured).toBeTruthy());
-    expect(h.captured.filter).toBeUndefined();
+    expect(h.captured.filter).toEqual(['and', [['is_active', '=', true]], [['x', '=', 1]]]);
+    // Still not `baseFilter` — that prop is the ADD PICKER's candidate
+    // restriction (`add.picker.filter`, #3831). Routing the list's scope there
+    // would filter the dialog and leave the list wide.
     expect(h.captured.baseFilter).toBeUndefined();
+  });
+
+  it('narrows, never widens: an authored filter survives alongside the view’s', async () => {
+    // The binding's contract in one case — "additional filter criteria" means
+    // the component's own key and the view's both stay in force. A mapping that
+    // let one replace the other would be able to widen a named view, which is
+    // the failure class the binding exists to remove.
+    renderRelated({
+      filter: [{ field: 'stage', operator: 'equals', value: 'won' }],
+      dataSource: { object: 'contact', view: 'recent' },
+    });
+    await waitFor(() => expect(h.captured).toBeTruthy());
+    expect(h.captured.filter).toEqual([
+      'and',
+      [['stage', 'equals', 'won']],
+      [['is_active', '=', true]],
+    ]);
+  });
+
+  it('leaves an unbound list’s authored filter exactly as authored', async () => {
+    // No binding: the schema key passes through by reference, in the spec's own
+    // vocabulary. `RelatedList` owns the lowering (its own suite pins it), so
+    // nothing converts it twice on the way down.
+    const authored = [{ field: 'stage', operator: 'equals', value: 'won' }];
+    renderRelated({ objectName: 'contact', filter: authored });
+    await waitFor(() => expect(h.captured).toBeTruthy());
+    expect(h.captured.filter).toBe(authored);
   });
 });

--- a/packages/plugin-detail/src/__tests__/RelatedList.addGateDataSource.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.addGateDataSource.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#3895 — the Add button and the picker dialog answer to the SAME gate.
+ *
+ * Three consumers sit on the `add` chain and one of them disagreed with the other
+ * two about `dataSource`: the dialog required it (`add && pickerObject &&
+ * dataSource`) and so did the callback (`handleAddRecords`: `if (!add ||
+ * !dataSource || …) return`), while the BUTTON required only `add &&
+ * pickerObject`. Where no `dataSource` reached the component the button therefore
+ * rendered, its click set `pickerOpen`, and nothing existed to observe the flag —
+ * a visible affordance with no reaction and no message.
+ *
+ * That host is real, not hypothetical: `renderers/record-related-list.tsx` passes
+ * `dataSource={ctx?.dataSource}`, so any mount with no `RecordContext` bound —
+ * the Studio designer preview, a context-free embed (the shape
+ * `apps/console/src/__tests__/public-block-binding-reach.test.tsx` mounts) —
+ * arrives with `undefined`. Which is why the first case below goes through the
+ * RENDERER rather than the component: the gate is only worth pinning at the
+ * mounting shape that produces the missing adapter.
+ *
+ * Direction 1 of the filing (withhold the affordance) over direction 2 (render it
+ * disabled with a reason), settled by the triage seat: the same principle
+ * objectui#3838 applied one condition earlier on this very chain — an affordance
+ * is offered only where the capability behind it exists. Sibling pins for that
+ * condition live in `RelatedList.addPickerGuard.test.tsx`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { RelatedList } from '../RelatedList';
+import { RecordRelatedListRenderer } from '../renderers/record-related-list';
+
+/**
+ * Every mount below with no adapter takes the component's legacy raw-URL branch,
+ * which calls `fetch`. Left real, jsdom dials the origin for a request the
+ * subject of this file does not care about, and the console fills with
+ * `ECONNREFUSED` from a test that passed. Stubbed so the mount is hermetic — the
+ * rows are irrelevant here, the Add gate is not.
+ */
+let originalFetch: typeof globalThis.fetch;
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = vi.fn(async () => ({ json: async () => [] }) as any) as any;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/**
+ * `label` is authored rather than left to default, so the affordance has a name
+ * that does not depend on an i18n provider being mounted: with none, the default
+ * button renders the raw key `detail.add`, and a selector for /^Add$/ would then
+ * find nothing in EITHER direction — the negative pins below would pass because
+ * nothing matched, not because the gate closed.
+ */
+const ADD = {
+  picker: { object: 'sys_permission_set', labelField: 'label' },
+  label: 'Grant permission set',
+};
+
+const makeDS = () => ({
+  find: vi.fn(async () => [{ id: 'ps_1', label: 'Admin' }]),
+  getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+});
+
+/** The Add affordance, by its accessible name. */
+const queryAddButton = () => screen.queryByRole('button', { name: 'Grant permission set' });
+
+describe('record:related_list in a host with no dataSource (objectui#3895)', () => {
+  it('withholds the Add button when no RecordContext supplies an adapter', async () => {
+    // No `RecordContextProvider` — the designer-preview / bare-embed shape, where
+    // `ctx?.dataSource` is `undefined`. Pre-fix the button rendered here and did
+    // nothing at all when clicked.
+    const { container } = render(
+      <RecordRelatedListRenderer
+        schema={{
+          objectName: 'sys_user_permission_set',
+          relationshipField: 'user_id',
+          columns: ['permission_set_id'],
+          add: ADD,
+        } as any}
+      />,
+    );
+
+    // The block itself still renders — only the unbacked affordance is withheld
+    // (the list body is fine; this is not the "cannot render anything" case).
+    await waitFor(() => expect(container.textContent).toContain('Sys User Permission Set'));
+    expect(container.innerHTML).not.toContain('failed to render');
+    expect(queryAddButton()).toBeNull();
+  });
+
+  it('still offers it once a RecordContext brings the adapter', async () => {
+    // Same metadata, the runtime host: the affordance comes back. This is the
+    // half that makes the gate a gate rather than a removal.
+    const ds = makeDS();
+    render(
+      <RecordContextProvider objectName="sys_user" recordId="u_1" dataSource={ds as any}>
+        <RecordRelatedListRenderer
+          schema={{
+            objectName: 'sys_user_permission_set',
+            relationshipField: 'user_id',
+            columns: ['permission_set_id'],
+            add: ADD,
+          } as any}
+        />
+      </RecordContextProvider>,
+    );
+    await waitFor(() => expect(queryAddButton()).not.toBeNull());
+  });
+});
+
+describe('RelatedList — Add button vs picker dialog gate parity (objectui#3895)', () => {
+  const renderList = (dataSource: any) =>
+    render(
+      <RelatedList
+        title="Permission Sets"
+        type="table"
+        api="sys_user_permission_set"
+        objectName="sys_user_permission_set"
+        referenceField="user_id"
+        parentId="u_1"
+        columns={[{ accessorKey: 'permission_set_id', header: 'Permission Set' }]}
+        dataSource={dataSource}
+        add={ADD}
+      />,
+    );
+
+  it('renders neither button nor dialog without a dataSource', async () => {
+    const { container } = renderList(undefined);
+    await waitFor(() => expect(screen.getByText('Permission Sets')).toBeInTheDocument());
+    expect(queryAddButton()).toBeNull();
+    // The dialog was already gated on `dataSource`; asserting it here is what
+    // makes this a PARITY pin — the two must agree, in both directions, or the
+    // click leads nowhere again.
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('renders the button with a dataSource, exactly as before', async () => {
+    const ds = makeDS();
+    renderList(ds as any);
+    await waitFor(() => expect(queryAddButton()).not.toBeNull());
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RelatedList.listFilter.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.listFilter.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectstack#7118 — `record:related_list.filter` reaches the query.
+ *
+ * The spec declares `RecordRelatedListProps.filter` ("Additional filter criteria
+ * for related records") and this repo published it as a registry input; nothing
+ * read it. `RelatedList` built its query from `{ [referenceField]: parentId }`
+ * alone, so an author who wrote `filter` got EVERY child of the parent — no
+ * error, `os validate` green, the SDUI prop walk green (a declared key raises no
+ * `unknown-prop`), and a list wider than the metadata asked for. Same shape as
+ * objectstack#4413: declared, validated, unconsumed.
+ *
+ * Both directions are pinned here, and the second is the one that keeps the fix
+ * honest: with nothing authored the query must stay the object it always was
+ * (`{ account: 'ACC-1' }`), not a freshly lowered AST that happens to mean the
+ * same thing — the difference is invisible on screen and visible to every caller
+ * that pins the wire.
+ *
+ * The composition itself is not re-litigated here (that is #5576's suite): what
+ * this file pins is that the value ARRIVES, that the parent scope survives it,
+ * and that it goes through the repo's single filter sink rather than a private
+ * conversion.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { RelatedList } from '../RelatedList';
+
+const rows = [{ id: 'c1', name: 'Alice' }];
+
+const makeDS = () => ({
+  find: vi.fn(async () => rows),
+  getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+});
+
+/** The parent-scoped list a related list always is; only `filter` varies. */
+const renderList = (ds: any, extra: Record<string, any> = {}) =>
+  render(
+    <RelatedList
+      title="Contacts"
+      type="table"
+      api="contact"
+      objectName="contact"
+      referenceField="account"
+      parentId="ACC-1"
+      dataSource={ds as any}
+      {...extra}
+    />,
+  );
+
+/** The spec's own authoring vocabulary for this key. */
+const WON = [{ field: 'stage', operator: 'equals' as const, value: 'won' }];
+
+describe('RelatedList — the list’s own filter reaches the query (objectstack#7118)', () => {
+  it('ANDs an authored `ViewFilterRule[]` with the parent relationship', async () => {
+    const ds = makeDS();
+    renderList(ds, { filter: WON });
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    // Parent scope FIRST and never negotiable — "additional" criteria may only
+    // narrow this parent's children. The rule array is lowered to ObjectQL nodes
+    // by the shared sink (`toFilterNode`), which is why `equals` survives as
+    // written instead of being re-spelled by a local conversion.
+    expect(ds.find).toHaveBeenCalledWith('contact', {
+      $filter: ['and', ['account', '=', 'ACC-1'], [['stage', 'equals', 'won']]],
+    });
+  });
+
+  it('sends the parent scope UNCHANGED when nothing is authored', async () => {
+    const ds = makeDS();
+    renderList(ds);
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    // Byte-for-byte the pre-#7118 query — a MongoDB-style object, not an AST.
+    expect(ds.find).toHaveBeenCalledWith('contact', { $filter: { account: 'ACC-1' } });
+  });
+
+  it('treats an empty `filter: []` as unauthored, like the designer emits it', async () => {
+    const ds = makeDS();
+    renderList(ds, { filter: [] });
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(ds.find).toHaveBeenCalledWith('contact', { $filter: { account: 'ACC-1' } });
+  });
+
+  it('accepts the AST node `ElementDataSourceGate` composes, without converting it twice', async () => {
+    const ds = makeDS();
+    // What a `dataSource: { object, view, filter }` binding leaves on this key:
+    // the view's filter and the binding's, already ANDed by the shared layer.
+    const composed = ['and', [['is_active', '=', true]], [['x', '=', 1]]];
+    renderList(ds, { filter: composed });
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(ds.find).toHaveBeenCalledWith('contact', {
+      $filter: ['and', ['account', '=', 'ACC-1'], composed],
+    });
+  });
+
+  it('carries the filter on the windowed (server-paged) fetch too', async () => {
+    const ds = makeDS();
+    renderList(ds, { filter: WON, pageSize: 5, defaultSort: '-created' });
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(ds.find).toHaveBeenCalledWith('contact', {
+      $filter: ['and', ['account', '=', 'ACC-1'], [['stage', 'equals', 'won']]],
+      $top: 5,
+      $skip: 0,
+      $orderby: [{ field: 'created', order: 'desc' }],
+    });
+  });
+});
+
+describe('RelatedList — a filter the raw-URL fallback cannot express (objectstack#7118)', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn(async () => ({ json: async () => rows }) as any);
+    globalThis.fetch = fetchMock as any;
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('refuses to fetch rather than answering wider than the metadata asked', async () => {
+    // No adapter, so the legacy `filter[<field>]=<value>` querystring is the only
+    // channel — it cannot carry an operator, let alone a rule array. Dropping the
+    // authored filter here would silently widen the answer, which is the class
+    // this whole card removes; empty-and-loud is the same posture the unscoped
+    // fetch guard already takes.
+    renderList(undefined, { filter: WON });
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).toContain('declares a filter');
+  });
+
+  it('leaves the fallback path itself untouched when no filter is authored', async () => {
+    renderList(undefined);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(String(fetchMock.mock.calls[0][0])).toBe('contact?filter%5Baccount%5D=ACC-1');
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -320,7 +320,15 @@ ComponentRegistry.register('related_list', RecordRelatedListRenderer, {
     { name: 'columns', type: 'array', label: 'Columns', required: true, description: 'Fields to display in the related list' },
     { name: 'sort', type: 'array', label: 'Sort' },
     { name: 'limit', type: 'number', label: 'Limit', defaultValue: 5, description: 'Records to display initially' },
-    { name: 'filter', type: 'array', label: 'Filter', description: 'Additional filter criteria' },
+    // `type: 'array'` matches the spec (`RecordRelatedListProps.filter` is
+    // `z.array(ViewFilterRuleSchema)`), and the description now names the MEMBER
+    // shape for the reason `add`'s does: `ComponentInput` is flat, so an array
+    // input can document its element vocabulary nowhere else — and this key is
+    // one an AI author reaches for often. It also states the combining rule,
+    // which is the part a wrong guess makes dangerous rather than merely broken:
+    // an author who reads "filter" as "the list's whole filter" would expect it
+    // to be able to widen past the parent record, and it cannot (objectstack#7118).
+    { name: 'filter', type: 'array', label: 'Filter', description: 'Additional filter criteria, as spec `ViewFilterRule` entries (`[{ field, operator, value }]`). AND-combined with the parent relationship condition, never a replacement for it: it can only narrow this record\'s children. Also the key a per-element `dataSource` binding\'s composed filter lands on.' },
     { name: 'title', type: 'string', label: 'Title' },
     { name: 'showViewAll', type: 'boolean', label: 'Show "View All"', defaultValue: true },
     { name: 'actions', type: 'array', label: 'Actions', description: 'Action IDs available for related records' },

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -188,6 +188,13 @@ const RecordRelatedListBody: React.FC<RecordRelatedListRendererProps> = ({
             : SPEC_DEFAULT_LIMIT
         }
         defaultSort={schema.sort}
+        // The list's own scope, ANDed with the parent relationship by
+        // `RelatedList` (spec `RecordRelatedListProps.filter`,
+        // objectstack#7118). When a `dataSource` binding is present this key
+        // already carries the composed component-AND-view-AND-binding filter —
+        // `ElementDataSourceGate` wrote it here, which is only legitimate now
+        // that the value is read.
+        filter={schema.filter}
         dataSource={ctx?.dataSource as any}
         add={
           (schema as any).add
@@ -248,22 +255,20 @@ const RecordRelatedListBody: React.FC<RecordRelatedListRendererProps> = ({
 
 /**
  * What this block reads for its own query: `objectName`, `columns` (a FIELD
- * list), `sort` (`defaultSort`) and `limit` (`pageSize`).
+ * list), `filter`, `sort` (`defaultSort`) and `limit` (`pageSize`).
  *
- * `filter` is NOT mapped, and that is a finding rather than a choice: this
- * renderer declares `filter` in its registry `inputs` ("Additional filter
- * criteria") and never reads it — `RelatedList` builds its query from
- * `{ [referenceField]: parentId }` alone and takes no filter prop for the list's
- * own scope. Mapping the composed filter onto `schema.filter` would hand it to a
- * key nothing consumes, which is the defect objectstack#6953 removes rather than
- * spreads. The consequence is recorded honestly: while that gap is open, a saved
- * view named here contributes its columns/sort/limit and its FILTER is dropped,
- * so the list can be wider than the view it names. Filed as objectstack#7118;
- * when the flat `filter` gains a read site, `filter: true` belongs in this
- * mapping and the binding follows it for free.
+ * `filter` was the one key deliberately left unmapped when this wiring landed
+ * (objectstack#6953), because the block DECLARED it and no code read it: writing
+ * the composed filter onto a dead key would have reproduced the very defect that
+ * change removed, one layer deeper. objectstack#7118 gave it a read site —
+ * `RelatedList` now ANDs it with `{ [referenceField]: parentId }` — so the
+ * mapping follows, and with it the consequence recorded here as open: a saved
+ * view named on this block no longer contributes columns/sort/limit while its
+ * FILTER is dropped, i.e. the list can no longer be wider than the view it names.
  */
 const RECORD_RELATED_LIST_DATA_SOURCE: ElementDataSourceMapping = {
   columns: true,
+  filter: true,
   sort: true,
   limit: 'limit',
 };


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7118
Fixes #3895

两单同文件(`packages/plugin-detail/src/RelatedList.tsx`),拆开必然串行,故一 PR 双 Fixes。基 `5bfaabde0`(PR #3969 的 objectstack#6953 落地)。

## 一、objectstack#7118 — `record:related_list.filter` 声明了却无人读

### 前提复核(先验证,再实施)

issue 正文的事实在基 sha 上逐条成立:

- `packages/plugin-detail/src/index.tsx:323` 声明 `{ name: 'filter', type: 'array', label: 'Filter', description: 'Additional filter criteria' }`;
- `RelatedList` 的取数处只有 `const filter = { [referenceField!]: parentId }`,props 里没有任何列表自身作用域的 filter 通道;
- `renderers/record-related-list.tsx` 的 `RECORD_RELATED_LIST_DATA_SOURCE` 故意不含 `filter`,PR #3969 为此钉了一条诚实的反向断言。

作者按已发布的 `inputs` 写 filter,得到该父记录下的**全部**子行 —— 不报错、`os validate` 绿、SDUI prop walk 也绿(已声明键不触发 `unknown-prop`)。objectstack#4413 的形状。

### 方向枚举与选择(AGENTS.md #0.1)

**决定:接通。** 两案在两条轴上的分析:

| | A. 接通(本 PR) | B. 撤声明 |
|---|---|---|
| 长期正确性 | `filter` 是 **spec** 的键 —— `@objectstack/spec` 的 `json-schema/ui/RecordRelatedListProps.json` 明确声明它,item 形状是完整的 `ViewFilterRule`,描述 "Additional filter criteria for related records"。给它一个读点即是让实现追上契约。 | 只删 objectui 的 `inputs` 条目**不能**消除这条声明:spec 仍然声明、渲染器仍然不读,缺陷一字未改,只是变得**更难被发现**(反而制造 spec↔registry 的反向不一致,正是 #3808 为 `add`/`relationshipValueField` 修掉的方向 —— 声明面与运行时互相矛盾且无人报告)。真正的"撤声明"是在 objectstack 仓按 ADR-0049 退休一个 spec 公共属性,超出本 PR 文件面,也是一次公共契约删除。 |
| 让 AI 写的 metadata 难写错 | 声明 = 强制:作者写的约束真的进查询;而且 `dataSource: { object, view }` 里 saved view 的 filter 不再被丢弃 —— 列表不可能再比它引用的 view 更宽(objectstack#5576 立下要禁止的方向)。 | 撤掉后作者失去唯一的合规写法,只能退回 `lookupFilters` 之类把作者约束降级成用户可编辑建议的路子(#3831 已论证过这是错的)。 |

成本上 A 也不贵:合成用仓库既有的**单一 filter 汇聚点** `mergeFilterNodes`,不新增任何转换方言。

### 实现

- `RelatedList` 新增 `filter` prop(spec 的 `ViewFilterRule[]`,或 `ElementDataSourceGate` 合成出的 AST 节点),与 `{ [referenceField]: parentId }` 在 `mergeFilterNodes` 下 **AND 合成**。父关系条件不可协商:"additional" 只能收窄本父记录的子集,永远不能放宽。
- **没写 filter 时查询逐字节不变**(仍是 MongoDB 风格对象,不是等价的新 AST)—— 差别在屏幕上看不见,在每一个钉住 wire 的调用点上看得见。
- `filter: []`(designer 的"未配置")视作未声明。
- `RECORD_RELATED_LIST_DATA_SOURCE` 加 `filter: true`;PR #3969 那条反向断言翻转为它自己注释里预告的正向断言。
- 遗留的 raw-URL 兜底路径(无 adapter,查询语言只有 `filter[字段]=值`,连操作符都表达不了):声明了 filter 就**拒绝取数并说明原因**,而不是静默丢掉 —— 答得比 metadata 要求的更宽,正是本单要消除的那一类。
- issue 第 4 条(核对 `inputs` 的 `type` 与实际形状):`type: 'array'` 与 spec 的 `z.array(ViewFilterRuleSchema)` 一致,无需改;description 补上成员词汇与合成规则(`ComponentInput` 是平的,数组入参的元素形状只能写在自己的 prose 里)。

## 二、objectui#3895 — Add 按钮不判 `dataSource`

方向按分诊席 2026-08-09 的晋级评论既定(方向 1,不重开)。`add` 链上三个消费点原本两判一不判:对话框判 `dataSource`、`handleAddRecords` 判、**按钮不判**。于是无 adapter 的宿主里按钮照常渲染,点击把 `pickerOpen` 置 true 而对话框根本不存在 —— 没有任何可见反应,也没有任何提示。补上同一条件即可,与 #3838 同一原则往前一格:能力不具备就不呈现 affordance。

可达宿主是真实的一类:`renderers/record-related-list.tsx` 传 `dataSource={ctx?.dataSource}`,任何未绑定 `RecordContext` 的挂载(Studio designer 预览、无上下文嵌入)都是 `undefined`。所以第一条钉子走**渲染器**而不是组件 —— 门只在真会产生缺失 adapter 的挂载形态上才值得钉。

## 反向验证(先预判方向,再跑;变异均未提交)

| 变异 | 预判 | 实测 |
|---|---|---|
| 撤掉按钮门的 `dataSource` | 无-dataSource 两钉翻红,两条有-dataSource 正向钉保持绿 | `2 failed / 2 passed` —— 红的正是 `withholds the Add button…` 与 `renders neither button nor dialog…` |
| `queryFilter = parentScope`(断开合成) | listFilter 里三条 AND 钉翻红;"未声明"/"空数组"/兜底两钉保持绿(它们断言的就是裸父作用域) | `3 failed / 12 passed`,红的三条与预判逐条一致 |
| 从 mapping 去掉 `filter: true` | 绑定合成两钉翻红;"无绑定按引用透传"那条保持绿(与 mapping 无关) | `2 failed / 6 passed`,同预判 |

第二个变异**不会**动到 `RecordRelatedListRenderer.elementDataSource.test.tsx`,这是预判的一部分而不是漏洞:该文件钉的是**渲染器那一跳**(什么值到达 `RelatedList` 的 props),组件内部查询合成的变异按定义碰不到它 —— 所以才需要第三个变异专门钉那一跳。

另:两条无-dataSource 钉最初因 i18n 未挂载而**假绿**(默认按钮渲染的是原始 key `detail.add`,选择器 `/^Add$/` 两个方向都匹配不到 —— 绿是因为什么都没匹配上)。已把 `add.label` 显式写进 fixture 并按该名字选择,负向钉不再空转;这一点写在测试文件的注释里。

## 消费半径扫查

`add` prop 在仓内只有 plugin-detail(测试)与本渲染器使用;metadata-admin designer 的 `record:related_list` inspector 不含 `add`,`deriveRelatedLists` 既不产 `add` 也不产 `filter`。故本改动的 fixture 面不外溢 —— 仍按规程连 `apps/console` 的 binding-reach 一起跑了。

## 验证输出

```
# 三个新增/翻转的测试文件
pnpm exec vitest run packages/plugin-detail/src/__tests__/RelatedList.listFilter.test.tsx \
  packages/plugin-detail/src/__tests__/RelatedList.addGateDataSource.test.tsx \
  packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.elementDataSource.test.tsx
  Test Files  3 passed (3)
       Tests  19 passed (19)

# 规程指定的受影响面全量
pnpm exec vitest run packages/plugin-detail apps/console/src/__tests__/public-block-binding-reach.test.tsx --maxWorkers=2
  Test Files  67 passed (67)
       Tests  542 passed (542)

# 仓根类型检查(末次编辑后)
pnpm exec turbo run type-check --concurrency=2
  Tasks:    78 successful, 78 total

node scripts/check-control-bytes.mjs
  OK (scanned 3874 tracked text file(s); skipped 85 binary)

eslint(改动文件):0 errors(仅既有 no-explicit-any warning)
```

## 文档与 changeset

- `content/docs/guide/data-source.md` 的逐 block 覆盖表:`record:related_list` 的 `filter` 由 "— (see below)" 改为 ✅,两处缺口记录减为一处(`object-form`),并写明合成是与父关系 AND 而非替换。
- `packages/plugin-detail/README.md`:补 `filter` 的语义/词汇/兜底路径行为,以及 Add affordance 的门。
- changeset:`@object-ui/plugin-detail` patch。

## 边界

只动 plugin-detail(`RelatedList.tsx`、`renderers/record-related-list.tsx`、`index.tsx` 的一条 input description、测试)+ 两处文档 + changeset。未碰共享层本体(`packages/react` 的 gate、`packages/core` 的 filter sink 一行未改),未碰 objectstack#7121 在飞的 block 外壳,未碰 `releases/`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_