### PR TITLE
fix(plugin-grid): BulkActionDialog 必填 param 宣告 required 状态而非把星号念进名字 (objectui#3967)

### DIFF
--- a/.changeset/bulkactiondialog-required-aria-3967.md
+++ b/.changeset/bulkactiondialog-required-aria-3967.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/plugin-grid": patch
+---
+
+`BulkActionDialog` required params: the control now announces the required state, and the visual `*` stays out of its accessible name
+
+`ParamField` renders each bulk param's label with a `*` marker when
+`param.required`, inside a `<Label htmlFor>` that points at the control. Two
+conventions the app-shell `ActionParamDialog` has carried since objectui#3299 /
+objectui#3290 were missing at this site:
+
+- The `*` span had no `aria-hidden="true"`. Accname folds a referencing label's
+  text into the control's name, so every required bulk param announced as
+  "Notify owner asterisk" — a decorative glyph read aloud as part of the label.
+- No `aria-required` was passed to the widget. `param.required` is otherwise
+  live — the dialog's own pre-submit gate reads it to keep Next disabled — but
+  nothing carried the state to the control, and no widget derives it from
+  `field.required` (`toDomProps` forwards `aria-*` by prefix; it invents
+  nothing). So the only channel that could announce requiredness was empty
+  while the only thing present was the glyph.
+
+The required state now rides the state channel to the control, deliberately as
+`aria-required` and not the native `required` attribute — per the objectui#3290
+ruling, the native attribute would arm the browser's constraint-validation
+bubble alongside this dialog's own gating, giving one field two validators.
+`|| undefined` keeps an optional param free of the attribute entirely rather
+than carrying `aria-required="false"`, matching `ActionParamDialog`.
+
+The marker remains visible; only its participation in the accessible name
+changes. `id` ownership at this site was already correct and is untouched, as
+is `ActionParamDialog`.

--- a/packages/plugin-grid/src/__tests__/bulkActionDialogParams.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkActionDialogParams.test.tsx
@@ -17,6 +17,9 @@
  * lookup suite pins the #3064 contract itself: no eager candidate prefetch,
  * fetch errors surfaced with a Retry affordance, and no failure caching
  * (reopening the picker refetches).
+ *
+ * objectui#3967 added the a11y suite at the bottom: the required STATE reaches
+ * the control and the visual-only `*` stays out of its accessible name.
  */
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
@@ -201,5 +204,116 @@ describe('BulkActionDialog — lookup param uses the shared record picker (#3064
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
     await screen.findByText('Support queue');
     expect(ds.find).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Required params announce STATE, not the decoration (objectui#3967).
+ *
+ * `ParamField` renders one row per param through a SINGLE code path (unlike
+ * app-shell's `ActionParamDialog`, which forks a boolean branch), so both
+ * defects landed on every param type at once:
+ *
+ * 1. The visible `*` sat inside `<Label htmlFor={id}>` with no `aria-hidden`.
+ *    Accname §2D folds a referencing label's text into the control's name, so
+ *    a required bulk param announced as "Notify owner asterisk" — a decorative
+ *    glyph read aloud as if it were part of the label.
+ * 2. `aria-required` was never passed. `param.required` IS live — the dialog's
+ *    own pre-submit gate reads it to disable Next — but nothing carried the
+ *    state to the control, and no widget derives it from `field.required`
+ *    (`toDomProps` forwards `aria-*` by prefix; it invents nothing). So the
+ *    only channel that could announce "required" was empty while the only
+ *    thing present was the glyph now hidden.
+ *
+ * Both halves have to be pinned together, because either one alone is
+ * satisfiable the wrong way: hiding the `*` without `aria-required` announces
+ * NOTHING about requiredness, and `aria-required` without hiding the `*`
+ * announces it twice, once as noise. The visible-marker assertions exist for
+ * the same reason — deleting the `*` outright would also produce a clean name.
+ */
+describe('BulkActionDialog — required params announce state, not the asterisk (objectui#3967)', () => {
+  function renderParams(params: any[]) {
+    const ds = makeDataSource();
+    const def: any = { name: 'set_it', label: 'Set it', operation: 'update', params };
+    render(
+      <BulkActionDialog
+        def={def}
+        rows={[{ id: 'r1' }]}
+        resource="thing"
+        dataSource={ds}
+        open
+        onClose={() => {}}
+      />,
+    );
+    return ds;
+  }
+
+  /**
+   * Query by the host-owned id rather than by role or label text: the id is
+   * what `<Label htmlFor>` names, it is stable across widget types (switch,
+   * textbox, …), and — unlike `*ByLabelText`, which matches on the label's raw
+   * `textContent` — it does not quietly depend on the very `aria-hidden` these
+   * tests are asserting.
+   */
+  async function control(paramName: string): Promise<HTMLElement> {
+    return await waitFor(() => {
+      const el = document.getElementById(`bulk-param-${paramName}`);
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+  }
+
+  function labelFor(paramName: string): HTMLLabelElement {
+    const el = document.querySelector(`label[for="bulk-param-${paramName}"]`);
+    expect(el).not.toBeNull();
+    return el as HTMLLabelElement;
+  }
+
+  it('gives a required boolean param aria-required and an asterisk-free name', async () => {
+    renderParams([{ name: 'notify', label: 'Notify owner', type: 'boolean', required: true }]);
+
+    const el = await control('notify');
+    // The state channel of #3299/#3290 — deliberately not the native
+    // `required` attribute, which would arm a second validator (#3290).
+    expect(el).toHaveAttribute('aria-required', 'true');
+    expect(el).not.toHaveAttribute('required');
+    // The name is exactly what the author declared: no trailing glyph.
+    expect(el).toHaveAccessibleName('Notify owner');
+
+    // …and the marker is still SHOWN, just excluded from the name.
+    const label = labelFor('notify');
+    expect(label.textContent).toContain('*');
+    expect(label.querySelector('[aria-hidden="true"]')?.textContent).toBe('*');
+  });
+
+  it('leaves an optional boolean param with no aria-required attribute at all', async () => {
+    renderParams([{ name: 'notify', label: 'Notify owner', type: 'boolean' }]);
+
+    const el = await control('notify');
+    // Absent, not `aria-required="false"` — an optional control should not
+    // appear in the a11y tree as one whose requiredness was considered.
+    expect(el).not.toHaveAttribute('aria-required');
+    expect(el).toHaveAccessibleName('Notify owner');
+    expect(labelFor('notify').textContent).not.toContain('*');
+  });
+
+  it('applies the same shape to a non-boolean param — one ParamField path, not a per-type one', async () => {
+    // The unchanged-direction half: `ParamField` has no type branches, so a
+    // text param must come out with the identical treatment. A future refactor
+    // that forks a boolean-only branch (as app-shell's dialog has) and fixes
+    // only that fork fails here.
+    renderParams([
+      { name: 'note', label: 'Note', type: 'text', required: true },
+      { name: 'memo', label: 'Memo', type: 'text' },
+    ]);
+
+    const required = await control('note');
+    expect(required).toHaveAttribute('aria-required', 'true');
+    expect(required).toHaveAccessibleName('Note');
+    expect(labelFor('note').querySelector('[aria-hidden="true"]')?.textContent).toBe('*');
+
+    const optional = await control('memo');
+    expect(optional).not.toHaveAttribute('aria-required');
+    expect(optional).toHaveAccessibleName('Memo');
   });
 });

--- a/packages/plugin-grid/src/components/BulkActionDialog.tsx
+++ b/packages/plugin-grid/src/components/BulkActionDialog.tsx
@@ -586,7 +586,13 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChang
       <div className="flex items-center justify-between">
         <Label htmlFor={id} className="text-xs">
           {param.label ?? param.name}
-          {param.required && <span className="text-destructive ml-0.5">*</span>}
+          {/* Visual-only (objectui#3299, aligned with app-shell's
+              `ActionParamDialog` in objectui#3967): the required STATE is
+              announced through `aria-required` on the control below. This
+              `*` sits inside a `<Label htmlFor>`, so without `aria-hidden`
+              accname folds it into the referenced control's name and every
+              required bulk param announces as "Label asterisk". */}
+          {param.required && <span className="text-destructive ml-0.5" aria-hidden="true">*</span>}
         </Label>
       </div>
       <Suspense fallback={<div className="h-9 w-full animate-pulse rounded-md bg-muted" aria-hidden="true" />}>
@@ -596,6 +602,18 @@ const ParamField: React.FC<ParamFieldProps> = ({ param, multiple, value, onChang
           value={value ?? null}
           onChange={onChange}
           field={field}
+          // Required is a STATE, so it rides the state channel to the control
+          // (objectui#3299) — deliberately NOT the native `required` attribute
+          // (#3290: that arms the browser's constraint bubble alongside this
+          // dialog's own `missing`/Next gating — two validators, one field).
+          // `param.required` is otherwise live only in the dialog's own
+          // pre-submit gate, so before this the control announced no required
+          // state at all. Widgets forward `aria-*` by prefix through their
+          // `toDomProps` whitelist, so it reaches the rendered control; none of
+          // them derives it from `field.required`. `|| undefined` keeps an
+          // optional param free of the attribute entirely (not `"false"`),
+          // matching `ActionParamDialog`.
+          aria-required={param.required || undefined}
           {...dataSourceProps}
         />
       </Suspense>


### PR DESCRIPTION
Fixes #3967

## 前提复核（origin/main @ c4768a760）

正文两条缺陷都成立,并且比正文更具体的一点值得先写清楚:

- `packages/plugin-grid/src/components/BulkActionDialog.tsx` 全文只有一处 `aria-hidden`(Suspense 骨架屏),星号 span 上没有;全文 `aria-required` 出现 **0** 次。
- 「控件自己会从 `field.required` 推出 `aria-required`」这条可能的反驳被证伪:`bulkParamToField` 确实把 `required` 写进 field metadata,但 `packages/fields/src/widgets/BooleanField.tsx` 与 `TextField.tsx` 里 `required` 出现 0 次 —— `toDomProps` 按前缀转发 `aria-*`,它不发明属性。所以 host 不传就是没有,通路空着。
- `param.required` 本身是活的声明:同文件的提交前 gate 读它来禁用 Next。也就是说必填语义在逻辑上生效、在可访问性树里缺席,而唯一在场的是那个装饰字符。

## 改动(仅 2 处,均在 `ParamField`)

1. 星号 span 补 `aria-hidden="true"`。它位于 `Label htmlFor` 内部,accname 会把被引用 label 的文本折进控件名字,所以每个必填 bulk param 都被念成「Notify owner 星号」。
2. `Widget` 补 `aria-required={param.required || undefined}`。

两条都与 app-shell 的 `ActionParamDialog` 对齐(#3299 / #3290 的裁决),不在这里发明第二套写法:

- 刻意不用原生 `required` —— 按 #3290,那会让浏览器的约束校验气泡与本 dialog 自己的 gating 并存,一个字段两个校验器。
- `|| undefined` 使可选 param 完全不带该属性,而不是 `aria-required="false"`。

`id` 下发在本站点原本就正确(`bulk-param-${param.name}`),未动;`ActionParamDialog` 未动(PR #3971 已定型)。星号仍然可见,变的只是它是否参与可访问名。

## 与派单口径的一处偏差(请复核)

派单写的是「boolean 分支」,并要求「generic 分支不变作阳性对照」。实际代码里 **`ParamField` 没有类型分支** —— 它是单一路径,所有类型走同一段 JSX(与 app-shell 的 `ActionParamDialog` 不同,后者确实 fork 了一个 boolean 分支)。因此:

- 两条缺陷本来就同时命中所有类型,不只 boolean;修改点也只有这一处,自然覆盖全部类型。
- 「阳性对照」相应改写成:**非 boolean(text)param 必须呈现完全相同的形态**。这条钉子的作用方向是「保持不变」——将来若有人照 app-shell 的样子 fork 出一个 boolean-only 分支并只修那一支,它会红。

## 钉子(两个方向必须一起钉)

任何一条单独成立都能被错误地满足:只隐藏星号而不给 `aria-required`,则关于必填**什么都不宣告**;只给 `aria-required` 而不隐藏星号,则宣告**两次**、其中一次是噪音。所以三个用例都同时断言两侧,并额外断言星号**仍然可见**(否则「直接删掉星号」也能得到干净的名字)。

- 必填 boolean:控件 `aria-required="true"`、**无** `required` 原生属性、可访问名恰为 `Notify owner`;label 的 textContent 仍含 `*`,且该 `*` 在一个 `aria-hidden="true"` 元素内。
- 可选 boolean:控件**完全不带** `aria-required`,名字仍为 `Notify owner`,label 不含 `*`。
- 非 boolean(必填 text + 可选 text):形态与上面逐条一致。

探针刻意用 host 拥有的 id(`document.getElementById` 上拼 `bulk-param-` 前缀加 param 名)而不是 `*ByLabelText`:后者匹配 label 的原始 `textContent`,会悄悄依赖本 PR 正在断言的那个 `aria-hidden`,自证其成。

## 反向验证(先预判,再跑;变异未提交)

两个变异分别跑,方向都是**预判的红**:

- 变异 A —— 删掉 `aria-required={param.required || undefined}`:预判「两条必填断言红、两条可选(断言属性缺席)保持绿」。实测 `2 failed | 5 passed`,红的正是 `:278`(boolean)与 `:311`(text)两处 `toHaveAttribute("aria-required", "true")`。
- 变异 B —— 删掉星号 span 的 `aria-hidden="true"`:预判「可访问名断言红」。实测 `2 failed | 5 passed`,红在 `:281` 与 `:312` 的 `toHaveAccessibleName` —— 直接证明没有 `aria-hidden` 时星号确实折进了名字。

复原后全绿。

## 验证

- `pnpm exec vitest run packages/plugin-grid --maxWorkers=2` → `Test Files 57 passed (57)` / `Tests 523 passed (523)`
- `pnpm exec turbo run type-check --concurrency=2` → `78 successful, 78 total`
- `node scripts/check-control-bytes.mjs` → OK(3885 个文件);改动文件另做越界自扫,无命中
- 消费半径已清:`BulkActionDialog` 的仓内引用只在 `plugin-grid`(`ObjectGrid.tsx`、demo、3 个测试),`bulk-param` 前缀无其它包的 fixture 依赖,plugin-grid 无快照文件

changeset:`@object-ui/plugin-grid` patch。
