### PR TITLE
fix(metadata-admin): block-config 的 placeholder 提示随语言切换(#3979)

### DIFF
--- a/.changeset/block-config-placeholder-i18n-3979.md
+++ b/.changeset/block-config-placeholder-i18n-3979.md
@@ -1,0 +1,46 @@
+---
+"@object-ui/app-shell": patch
+---
+
+Page block inspector: the input hints inside the properties panel follow the session's language
+
+objectui#3913 turned `block-config.ts`'s `label` / `addLabel` / option labels into
+translation keys and stopped at the column next to them. The 8 `placeholder`
+values that are prose stayed display text, so a zh-CN admin opening `page:header`
+read 「图标」 over a box hinting `lucide icon name`, and `record:details`'
+「名称（i18n 键）」 over `snake_case, e.g. contact_info` — in the panel #3913 and
+objectui#3963 had just finished translating. Those 8 are now keys under
+`engine.inspector.pageBlock.placeholder.<blockType>.<field path>`, resolved by
+`PageBlockInspector` at render, with en-US and zh-CN both defined. The en-US text
+is byte-identical to the literals it replaces, ellipsis included, so an English
+admin sees no change.
+
+The column could not simply follow `label`, and that is the design half of this
+change: it is a MIXED surface. Of the 18 placeholders, 10 are example VALUES — a
+row count `20`, `https://…`, the inline-action sample
+`{ "type": "url", "target": "/environments" }` — and translating those would be a
+defect, not a courtesy. A localized JSON sample is metadata `InlineActionSchema`
+rejects, and a "translated" default row count means nothing at all.
+
+So which kind a placeholder is, is declared in the type rather than left to a
+convention plus a list of exceptions:
+
+    placeholder?: { key: string } | { literal: string }
+
+A bare `placeholder: 'lucide icon name'` — the shape this file used until now,
+and the first thing anything generating a new field reaches for — no longer
+compiles. That matters more than the eight strings: `type-check` runs in every
+lane and in the editor, so the mistake is caught where it is made instead of
+becoming an English box in a Chinese panel that waits for a reviewer to notice.
+`addLabel` was made required for the same reason in #3913; `placeholder` stays
+optional, because a field with no hint is legitimate.
+
+The keyed half joins the derivation pin
+(`previews/__tests__/block-config-i18n.test.ts`) as a fifth key family, so a new
+prose placeholder without a translation is red rather than shipping. The literal
+half is pinned as an inventory with a reason per entry, because "finish
+translating the other ten" is the plausible next edit and it needs to argue with
+a test first. `block-config.test.ts`'s snake_case assertion moved from the raw
+placeholder to the RESOLVED hint in both locales, which is now the stronger
+statement: the `snake_case` token has to survive translation, not merely exist in
+English.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -489,12 +489,19 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.list.removeItem': 'Remove item',
   'engine.inspector.pageBlock.objectPlaceholder': 'snake_case object',
   'engine.inspector.pageBlock.fieldPlaceholder': 'field name',
-  // Page block inspector — curated property labels (#3913).
+  // Page block inspector — curated property labels (#3913) and the prose
+  // placeholders (#3979).
   // These are the `label` / `addLabel` / option-label values of
   // `previews/block-config.ts`; that file stores the KEY and the inspector
   // resolves it through `t()` at render. Key shape is derived from the label's
   // position in BLOCK_CONFIG and pinned by
   // `previews/__tests__/block-config-i18n.test.ts` — see that file's header.
+  //
+  // `placeholder.*` is the same derivation for a field's input hint, and it is
+  // deliberately only PART of that column: a placeholder holding an example
+  // VALUE (`20`, `https://…`, a JSON sample) stays a literal in block-config and
+  // has no key here, because translating it would corrupt what the author is
+  // being told to type. `block-config.ts` declares which kind each one is.
   'engine.inspector.pageBlock.field.object-grid.objectName': 'Object',
   'engine.inspector.pageBlock.field.object-grid.columns': 'Columns',
   'engine.inspector.pageBlock.field.object-grid.pageSize': 'Page size',
@@ -525,6 +532,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.object-metric.label': 'Label',
   'engine.inspector.pageBlock.field.object-metric.description': 'Description',
   'engine.inspector.pageBlock.field.object-metric.icon': 'Icon',
+  'engine.inspector.pageBlock.placeholder.object-metric.icon': 'lucide icon name',
   'engine.inspector.pageBlock.field.object-metric.colorVariant': 'Color',
   'engine.inspector.pageBlock.option.colorVariant.default': 'Default',
   'engine.inspector.pageBlock.option.colorVariant.blue': 'Blue',
@@ -547,6 +555,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.grid.columns': 'Columns',
   'engine.inspector.pageBlock.field.grid.gap': 'Gap',
   'engine.inspector.pageBlock.field.element:text.content': 'Content',
+  'engine.inspector.pageBlock.placeholder.element:text.content': 'Text…',
   'engine.inspector.pageBlock.field.element:text.variant': 'Variant',
   'engine.inspector.pageBlock.option.variant.heading': 'Heading',
   'engine.inspector.pageBlock.option.variant.subheading': 'Subheading',
@@ -597,10 +606,12 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.option.size.medium': 'Medium',
   'engine.inspector.pageBlock.option.size.large': 'Large',
   'engine.inspector.pageBlock.field.element:button.icon': 'Icon',
+  'engine.inspector.pageBlock.placeholder.element:button.icon': 'lucide icon name',
   'engine.inspector.pageBlock.field.element:button.action': 'Action',
   'engine.inspector.pageBlock.field.page:header.title': 'Title',
   'engine.inspector.pageBlock.field.page:header.subtitle': 'Subtitle',
   'engine.inspector.pageBlock.field.page:header.icon': 'Icon',
+  'engine.inspector.pageBlock.placeholder.page:header.icon': 'lucide icon name',
   'engine.inspector.pageBlock.field.page:header.breadcrumb': 'Show breadcrumb',
   'engine.inspector.pageBlock.field.page:card.title': 'Title',
   'engine.inspector.pageBlock.field.page:card.bordered': 'Bordered',
@@ -621,6 +632,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.record:details.sections': 'Sections',
   'engine.inspector.pageBlock.add.record:details.sections': 'Add section',
   'engine.inspector.pageBlock.field.record:details.sections.name': 'Name (i18n key)',
+  'engine.inspector.pageBlock.placeholder.record:details.sections.name': 'snake_case, e.g. contact_info',
   'engine.inspector.pageBlock.field.record:details.sections.label': 'Label',
   'engine.inspector.pageBlock.field.record:details.sections.columns': 'Columns',
   'engine.inspector.pageBlock.field.record:details.sections.fields': 'Fields',
@@ -632,6 +644,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.record:alert.title': 'Title',
   'engine.inspector.pageBlock.field.record:alert.body': 'Body',
   'engine.inspector.pageBlock.field.record:alert.icon': 'Icon',
+  'engine.inspector.pageBlock.placeholder.record:alert.icon': 'lucide icon name',
   'engine.inspector.pageBlock.field.record:alert.dismissible': 'Dismissible',
   'engine.inspector.pageBlock.field.record:path.statusField': 'Status field',
   'engine.inspector.pageBlock.field.record:path.stages': 'Stages',
@@ -639,6 +652,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.record:path.stages.value': 'Value',
   'engine.inspector.pageBlock.field.record:path.stages.label': 'Label',
   'engine.inspector.pageBlock.field.record:quick_actions.actionNames': 'Action names',
+  'engine.inspector.pageBlock.placeholder.record:quick_actions.actionNames': 'action name',
   'engine.inspector.pageBlock.field.record:quick_actions.location': 'Location',
   'engine.inspector.pageBlock.option.location.record_header': 'Record header',
   'engine.inspector.pageBlock.option.location.record_more': 'Record more menu',
@@ -648,6 +662,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.option.location.list_item': 'List item',
   'engine.inspector.pageBlock.option.location.global_nav': 'Global nav',
   'engine.inspector.pageBlock.field.ai:input.agentName': 'Agent',
+  'engine.inspector.pageBlock.placeholder.ai:input.agentName': 'agent name',
   'engine.inspector.pageBlock.field.ai:input.placeholder': 'Input placeholder',
   // Report default ("home") inspector
   'engine.inspector.report.kind': 'Report',
@@ -2247,6 +2262,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.object-metric.label': '标签',
   'engine.inspector.pageBlock.field.object-metric.description': '描述',
   'engine.inspector.pageBlock.field.object-metric.icon': '图标',
+  'engine.inspector.pageBlock.placeholder.object-metric.icon': 'lucide 图标名',
   'engine.inspector.pageBlock.field.object-metric.colorVariant': '颜色',
   'engine.inspector.pageBlock.option.colorVariant.default': '默认',
   'engine.inspector.pageBlock.option.colorVariant.blue': '蓝色',
@@ -2269,6 +2285,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.grid.columns': '列数',
   'engine.inspector.pageBlock.field.grid.gap': '间距',
   'engine.inspector.pageBlock.field.element:text.content': '内容',
+  'engine.inspector.pageBlock.placeholder.element:text.content': '文本…',
   'engine.inspector.pageBlock.field.element:text.variant': '样式',
   'engine.inspector.pageBlock.option.variant.heading': '标题',
   'engine.inspector.pageBlock.option.variant.subheading': '副标题',
@@ -2319,10 +2336,12 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.option.size.medium': '中',
   'engine.inspector.pageBlock.option.size.large': '大',
   'engine.inspector.pageBlock.field.element:button.icon': '图标',
+  'engine.inspector.pageBlock.placeholder.element:button.icon': 'lucide 图标名',
   'engine.inspector.pageBlock.field.element:button.action': '动作',
   'engine.inspector.pageBlock.field.page:header.title': '标题',
   'engine.inspector.pageBlock.field.page:header.subtitle': '副标题',
   'engine.inspector.pageBlock.field.page:header.icon': '图标',
+  'engine.inspector.pageBlock.placeholder.page:header.icon': 'lucide 图标名',
   'engine.inspector.pageBlock.field.page:header.breadcrumb': '显示面包屑',
   'engine.inspector.pageBlock.field.page:card.title': '标题',
   'engine.inspector.pageBlock.field.page:card.bordered': '显示边框',
@@ -2343,6 +2362,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.record:details.sections': '分区',
   'engine.inspector.pageBlock.add.record:details.sections': '添加分区',
   'engine.inspector.pageBlock.field.record:details.sections.name': '名称（i18n 键）',
+  'engine.inspector.pageBlock.placeholder.record:details.sections.name': 'snake_case，例如：contact_info',
   'engine.inspector.pageBlock.field.record:details.sections.label': '标签',
   'engine.inspector.pageBlock.field.record:details.sections.columns': '列数',
   'engine.inspector.pageBlock.field.record:details.sections.fields': '字段',
@@ -2354,6 +2374,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.record:alert.title': '标题',
   'engine.inspector.pageBlock.field.record:alert.body': '正文',
   'engine.inspector.pageBlock.field.record:alert.icon': '图标',
+  'engine.inspector.pageBlock.placeholder.record:alert.icon': 'lucide 图标名',
   'engine.inspector.pageBlock.field.record:alert.dismissible': '可关闭',
   'engine.inspector.pageBlock.field.record:path.statusField': '状态字段',
   'engine.inspector.pageBlock.field.record:path.stages': '阶段',
@@ -2361,6 +2382,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.record:path.stages.value': '值',
   'engine.inspector.pageBlock.field.record:path.stages.label': '标签',
   'engine.inspector.pageBlock.field.record:quick_actions.actionNames': '动作名称',
+  'engine.inspector.pageBlock.placeholder.record:quick_actions.actionNames': '动作名称',
   'engine.inspector.pageBlock.field.record:quick_actions.location': '位置',
   'engine.inspector.pageBlock.option.location.record_header': '记录头部',
   'engine.inspector.pageBlock.option.location.record_more': '记录更多菜单',
@@ -2370,6 +2392,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.option.location.list_item': '列表行',
   'engine.inspector.pageBlock.option.location.global_nav': '全局导航',
   'engine.inspector.pageBlock.field.ai:input.agentName': '智能体',
+  'engine.inspector.pageBlock.placeholder.ai:input.agentName': '智能体名称',
   'engine.inspector.pageBlock.field.ai:input.placeholder': '输入框占位提示',
   // Report default ("home") inspector
   'engine.inspector.report.kind': '报表',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.i18n.test.tsx
@@ -3,6 +3,7 @@
 /**
  * objectui#3913 — the PROPERTIES panel renders in the session's language.
  * objectui#3963 — and so does the panel's OWN chrome (see the second describe).
+ * objectui#3979 — and so do the input HINTS inside it, the prose ones (third).
  *
  * The sibling `previews/__tests__/block-config-i18n.test.ts` pins the TABLE
  * (every label is a key its position implies, and both locales define it). That
@@ -61,6 +62,19 @@ function renderInspector(draft: Record<string, unknown>, locale: 'en-US' | 'zh-C
 /** No raw translation key may reach the DOM in any locale. */
 function expectNoRawKeys() {
   expect(document.body.textContent ?? '').not.toContain('engine.inspector.pageBlock.');
+}
+
+/**
+ * The same guard for `placeholder` attributes (#3979) — and it has to be its own
+ * function, because `textContent` cannot see an attribute. A key forwarded raw
+ * into a placeholder is invisible to `expectNoRawKeys` above, which is the exact
+ * blind spot that let #3963's two placeholder literals through #3913's review.
+ */
+function expectNoRawKeyPlaceholders() {
+  const raw = [...document.querySelectorAll('[placeholder]')]
+    .map((el) => el.getAttribute('placeholder') ?? '')
+    .filter((v) => v.startsWith('engine.inspector.pageBlock.'));
+  expect(raw).toEqual([]);
 }
 
 describe('PageBlockInspector PROPERTIES labels follow the locale (#3913)', () => {
@@ -261,6 +275,105 @@ describe("PageBlockInspector's own chrome follows the locale (#3963)", () => {
     fireEvent.change(enArea!, { target: { value: '{ not json' } });
     fireEvent.blur(enArea!);
     expect(screen.getByText('Invalid JSON')).toBeTruthy();
+  });
+});
+
+/**
+ * objectui#3979 — the block-config PLACEHOLDER column, on screen.
+ *
+ * Third mechanism in this file, and the third time the same defect shape came
+ * back one column over: #3913 keyed the labels, #3963 keyed the panel's own
+ * chrome, and the hints inside block-config's own boxes stayed English until
+ * here. `renderField` reaches `f.placeholder` from four branches — number, json,
+ * string-list and the default text field — and each was handing the table's value
+ * straight to the input.
+ *
+ * What makes this column different from the two before it is that translating
+ * ALL of it would be wrong. Ten of the eighteen placeholders are example VALUES,
+ * and the assertions come in matching pairs: the prose ones must change with the
+ * locale, the value ones must NOT. Both halves are pinned here because both are
+ * regressions a reader could introduce while believing they were finishing the
+ * job — and neither is visible to `expectNoRawKeys`, since a placeholder is an
+ * attribute.
+ */
+describe('PageBlockInspector placeholders follow the locale — but only the prose ones (#3979)', () => {
+  it('translates the text-field hint under an already-Chinese label', () => {
+    // The issue's headline symptom: 「图标」 over a box hinting `lucide icon name`.
+    renderInspector(pageDraft('page:header'), 'zh-CN');
+
+    expect(screen.getByText('图标')).toBeTruthy(); // #3913's half, still working
+    expect(screen.getByPlaceholderText('lucide 图标名')).toBeTruthy();
+    expect(screen.queryByPlaceholderText('lucide icon name')).toBeNull();
+    expectNoRawKeyPlaceholders();
+    expectNoRawKeys();
+  });
+
+  it('renders the same panel in English under en-US, unchanged', () => {
+    // en-US is the baseline: the new keys carry the exact literals the table
+    // used to hold, so nothing an English admin sees may have moved.
+    renderInspector(pageDraft('page:header'), 'en-US');
+
+    expect(screen.getByPlaceholderText('lucide icon name')).toBeTruthy();
+    expectNoRawKeyPlaceholders();
+  });
+
+  it('translates the nested array-item hint, and leaves the count beside it alone', () => {
+    // One fixture, both halves: `sections.name` is prose (a key) while
+    // `sections.columns` is a column count (a literal). Nested items recurse
+    // through `renderField` with a different read/write pair, so a fix applied
+    // only at the top level would leave these English.
+    renderInspector(pageDraft('record:details', { sections: [{ label: 'Contact info' }] }), 'zh-CN');
+
+    expect(screen.getByPlaceholderText('snake_case，例如：contact_info')).toBeTruthy();
+    expect(screen.queryByPlaceholderText('snake_case, e.g. contact_info')).toBeNull();
+    // The `2` box is untouched — a "translated" default count is meaningless.
+    expect(screen.getByPlaceholderText('2')).toBeTruthy();
+    expectNoRawKeyPlaceholders();
+  });
+
+  it('translates the string-list branch too — its own copy of the placeholder site', () => {
+    // `string-list` builds its rows inline in `renderField` rather than through a
+    // field component, so it is a separate forwarding of `f.placeholder` and no
+    // other fixture in this file renders one with a hint.
+    renderInspector(pageDraft('record:quick_actions', { actionNames: ['send_email'] }), 'zh-CN');
+
+    expect(screen.getAllByPlaceholderText('动作名称').length).toBeGreaterThan(0);
+    expect(screen.queryByPlaceholderText('action name')).toBeNull();
+    expectNoRawKeyPlaceholders();
+  });
+
+  it('translates element:text and ai:input, the remaining prose sites', () => {
+    renderInspector(pageDraft('element:text'), 'zh-CN');
+    expect(screen.getByPlaceholderText('文本…')).toBeTruthy();
+    expect(screen.queryByPlaceholderText('Text…')).toBeNull();
+
+    cleanup();
+    renderInspector(pageDraft('ai:input'), 'zh-CN');
+    expect(screen.getByPlaceholderText('智能体名称')).toBeTruthy();
+    expect(screen.queryByPlaceholderText('agent name')).toBeNull();
+    expectNoRawKeyPlaceholders();
+  });
+
+  it('passes example VALUES through untranslated in zh-CN', () => {
+    // The half that must NOT move. A number, a URL scheme and a JSON sample:
+    // these are the characters the author is being shown to type, and the JSON
+    // one would fail `InlineActionSchema` if its keys were localized.
+    renderInspector(pageDraft('object-grid'), 'zh-CN');
+    expect(screen.getByPlaceholderText('20')).toBeTruthy();
+
+    cleanup();
+    renderInspector(pageDraft('element:image'), 'zh-CN');
+    expect(screen.getByPlaceholderText('https://…')).toBeTruthy();
+
+    cleanup();
+    renderInspector(pageDraft('element:button'), 'zh-CN');
+    const sample = '{ "type": "url", "target": "/environments" }';
+    expect(screen.getByPlaceholderText(sample)).toBeTruthy();
+
+    // …and identical in en-US: a locale-invariant placeholder is invariant.
+    cleanup();
+    renderInspector(pageDraft('element:button'), 'en-US');
+    expect(screen.getByPlaceholderText(sample)).toBeTruthy();
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
@@ -26,7 +26,7 @@ import {
   InspectorEmptyState,
   moveArray,
 } from './_shared';
-import { BLOCK_CONFIG, blockHasConfig, type BlockPropField } from '../previews/block-config';
+import { BLOCK_CONFIG, blockHasConfig, type BlockPropField, type PlaceholderSpec } from '../previews/block-config';
 import { ColorVariantPicker } from '../color-variant-field';
 import { ConditionBuilder } from './ConditionBuilder';
 import { expressionSource, writeExpressionSource } from './expression-envelope';
@@ -398,6 +398,16 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
   /** Option labels are keys too — translate before handing them to a picker. */
   const optionLabels = <T extends { value: string; label: string }>(options: T[]) =>
     options.map((o) => ({ ...o, label: t(o.label, locale) }));
+  /**
+   * Placeholders are a MIXED column (#3979) and the table says which kind each
+   * one is: `{ key }` is prose about the value and goes through `t()`, `{ literal }`
+   * is the value itself (a number, `https://…`, a JSON sample) and must reach the
+   * DOM untouched. Resolving in one place is what keeps the four `placeholder=`
+   * sites below from drifting apart — the panel's contents were English in a
+   * zh-CN panel precisely because one column skipped the accessor.
+   */
+  const placeholderText = (p: PlaceholderSpec | undefined): string | undefined =>
+    p === undefined ? undefined : p.key !== undefined ? t(p.key, locale) : p.literal;
 
   // Generic, recursive field renderer. `read`/`write` abstract the value source
   // (the block's `properties` at the top level, or an item object inside an
@@ -414,7 +424,7 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
         return (
           <InspectorNumberField key={k} label={fieldLabel(f.label)}
             value={typeof read(f.name) === 'number' ? (read(f.name) as number) : undefined}
-            placeholder={f.placeholder} onCommit={(v) => write(f.name, v)} disabled={readOnly} />
+            placeholder={placeholderText(f.placeholder)} onCommit={(v) => write(f.name, v)} disabled={readOnly} />
         );
       case 'boolean':
         return (
@@ -445,7 +455,7 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
         // without this a curated JSON prop could be edited and never added.
         return (
           <InspectorJsonField key={k} label={fieldLabel(f.label)} value={read(f.name)}
-            placeholder={f.placeholder} locale={locale}
+            placeholder={placeholderText(f.placeholder)} locale={locale}
             onCommit={(v) => write(f.name, v)} disabled={readOnly} />
         );
       case 'string-list': {
@@ -455,7 +465,7 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
             <Label className="text-xs text-muted-foreground">{fieldLabel(f.label)}</Label>
             {arr.map((s, i) => (
               <div key={i} className="flex items-center gap-1.5">
-                <Input className="h-8 text-sm" value={String(s ?? '')} placeholder={f.placeholder} disabled={readOnly}
+                <Input className="h-8 text-sm" value={String(s ?? '')} placeholder={placeholderText(f.placeholder)} disabled={readOnly}
                   onChange={(e) => { const next = [...arr]; next[i] = e.target.value; write(f.name, next); }} />
                 <Button type="button" variant="ghost" size="icon" className="h-8 w-8" disabled={readOnly}
                   aria-label={t('engine.inspector.pageBlock.list.remove', locale)}
@@ -529,7 +539,8 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
         return (
           <InspectorTextField key={k} label={fieldLabel(f.label)}
             value={read(f.name) != null ? String(read(f.name)) : ''}
-            placeholder={(f as any).placeholder} onCommit={(v) => write(f.name, v)} disabled={readOnly} />
+            placeholder={placeholderText((f as { placeholder?: PlaceholderSpec }).placeholder)}
+            onCommit={(v) => write(f.name, v)} disabled={readOnly} />
         );
     }
   };

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
@@ -33,6 +33,7 @@
  *   nested item label    engine.inspector.pageBlock.field.<blockType>.<array>.<name>
  *   array add button     engine.inspector.pageBlock.add.<blockType>.<name>
  *   select/color option  engine.inspector.pageBlock.option.<fieldName>.<value>
+ *   placeholder prose    engine.inspector.pageBlock.placeholder.<blockType>.<name>
  *
  * Option keys omit the block type on purpose (so `format`'s number/currency/
  * percent are translated once and shared by `object-metric` and
@@ -44,18 +45,34 @@
  * `t()` returns the key unchanged on a miss, so `t(key, locale) === key` is
  * exactly "this locale has no translation" — measured through the same accessor
  * the component uses, not a private table this test would have to be given.
+ *
+ * ## objectui#3979 — the `placeholder` column, and why it is only PARTLY keyed
+ *
+ * #3913 stopped at labels, so the hints under them stayed English: 「图标」 over
+ * a box reading `lucide icon name`. The column joins the walk above as a fifth
+ * family, with the SAME positional derivation — but only for the 8 placeholders
+ * that are prose. The other 10 are example VALUES (`20`, `https://…`, a JSON
+ * sample) and are `{ literal: … }` in `block-config.ts`, never keys: translating
+ * them would corrupt the thing the author is being told to type.
+ *
+ * Which kind a placeholder is, is declared in the TYPE (`PlaceholderSpec`), not
+ * inferred here — a bare `placeholder: 'lucide icon name'` no longer compiles.
+ * What this file adds on top is the part a type cannot state: that the key side
+ * is complete in both locales (with the rest of the walk), and that the literal
+ * side is an inventory somebody has to argue with before "helpfully" translating
+ * a JSON sample. The last describe holds that inventory.
  */
 
 import { describe, it, expect } from 'vitest';
-import { BLOCK_CONFIG, type BlockPropField } from '../block-config';
+import { BLOCK_CONFIG, type BlockPropField, type PlaceholderSpec } from '../block-config';
 import { t } from '../../i18n';
 
 const PREFIX = 'engine.inspector.pageBlock';
 
 /** One translatable label site: where it lives, what key that implies, what is stored. */
 interface LabelSite {
-  /** `field` | `add` | `option` — which key family. */
-  family: 'field' | 'add' | 'option';
+  /** `field` | `add` | `option` | `placeholder` — which key family. */
+  family: 'field' | 'add' | 'option' | 'placeholder';
   /** The key the site's position implies. */
   derived: string;
   /** The key `block-config.ts` actually stores there. */
@@ -64,9 +81,21 @@ interface LabelSite {
   where: string;
 }
 
-/** Walk BLOCK_CONFIG and derive a key for every label / addLabel / option label. */
-function labelSites(): LabelSite[] {
+/** Every placeholder in the table, with its position — both kinds (#3979). */
+interface PlaceholderSite {
+  /** Human-readable position: `<blockType>.<dotted field path>`. */
+  where: string;
+  /** The key a keyed placeholder's position implies. */
+  derived: string;
+  /** What `block-config.ts` declares there. */
+  spec: PlaceholderSpec;
+}
+
+/** Walk BLOCK_CONFIG and derive a key for every label / addLabel / option label
+ *  / prose placeholder, and collect every placeholder spec of either kind. */
+function labelSites(): { sites: LabelSite[]; placeholders: PlaceholderSite[] } {
   const sites: LabelSite[] = [];
+  const placeholders: PlaceholderSite[] = [];
 
   const walk = (f: BlockPropField, blockType: string, path: string[]) => {
     const dotted = [...path, f.name].join('.');
@@ -76,6 +105,23 @@ function labelSites(): LabelSite[] {
       stored: f.label,
       where: `${blockType}.${dotted} (label)`,
     });
+
+    // A placeholder is either prose (a key — same positional derivation as the
+    // label it sits under) or a locale-invariant value literal. Only the first
+    // kind is a translation site; the second is inventoried further down.
+    const ph = (f as { placeholder?: PlaceholderSpec }).placeholder;
+    if (ph !== undefined) {
+      const derived = `${PREFIX}.placeholder.${blockType}.${dotted}`;
+      placeholders.push({ where: `${blockType}.${dotted}`, derived, spec: ph });
+      if (ph.key !== undefined) {
+        sites.push({
+          family: 'placeholder',
+          derived,
+          stored: ph.key,
+          where: `${blockType}.${dotted} (placeholder)`,
+        });
+      }
+    }
 
     if (f.kind === 'array') {
       sites.push({
@@ -104,10 +150,10 @@ function labelSites(): LabelSite[] {
   for (const [blockType, fields] of Object.entries(BLOCK_CONFIG)) {
     for (const f of fields) walk(f, blockType, []);
   }
-  return sites;
+  return { sites, placeholders };
 }
 
-const SITES = labelSites();
+const { sites: SITES, placeholders: PLACEHOLDERS } = labelSites();
 
 /**
  * Keys whose two locales are deliberately identical (an acronym, a symbol —
@@ -132,6 +178,12 @@ describe('block-config labels are translation keys (#3913)', () => {
     expect(families.field).toBeGreaterThan(80);
     expect(families.add).toBe(5);
     expect(families.option).toBeGreaterThan(50);
+    // Exact, like `add`: the keyed half of the placeholder column is 8 of 18
+    // (#3979). A 9th prose placeholder should fail here and be translated; a
+    // 9th VALUE placeholder does not reach this family at all and is caught by
+    // the literal inventory instead. Either way the new one gets classified
+    // rather than defaulting to English-on-screen.
+    expect(families.placeholder).toBe(8);
   });
 
   it('stores exactly the key its position implies', () => {
@@ -188,8 +240,11 @@ describe('block-config labels are translation keys (#3913)', () => {
       .map(([key, families]) => `${key}: ${[...families].join('+')}`);
     expect(crossFamily).toEqual([]);
 
-    // A `field`/`add` key is positional and must therefore be unique outright;
-    // only `option` keys may legitimately repeat.
+    // A `field`/`add`/`placeholder` key is positional and must therefore be
+    // unique outright; only `option` keys may legitimately repeat. Note the four
+    // `lucide icon name` placeholders are four DISTINCT keys with equal English
+    // text — same reason field keys carry the block type: the blocks may want
+    // different wording later, and one key cannot say two things.
     const positional = SITES.filter((s) => s.family !== 'option').map((s) => s.derived);
     expect(positional.length).toBe(new Set(positional).size);
   });
@@ -237,6 +292,21 @@ describe('en-US labels are unchanged by the key migration (#3913)', () => {
     'engine.inspector.pageBlock.option.align.center': 'Center',
     'engine.inspector.pageBlock.option.location.record_more': 'Record more menu',
     'engine.inspector.pageBlock.option.severity.warning': 'Warning',
+    // ── the placeholder family (#3979) ───────────────────────────────────────
+    // ALL EIGHT, not a sample: this column was migrated by hand rather than
+    // mechanically, and the en side is the only thing standing between "the key
+    // resolves" and "the key resolves to what the box used to say". Each value
+    // below is byte-identical to the literal `block-config.ts` held at
+    // `origin/main` 6bd6a4d76 — including the U+2026 ellipsis in `Text…`, which
+    // a re-typed `...` would silently replace.
+    'engine.inspector.pageBlock.placeholder.object-metric.icon': 'lucide icon name',
+    'engine.inspector.pageBlock.placeholder.element:text.content': 'Text…',
+    'engine.inspector.pageBlock.placeholder.element:button.icon': 'lucide icon name',
+    'engine.inspector.pageBlock.placeholder.page:header.icon': 'lucide icon name',
+    'engine.inspector.pageBlock.placeholder.record:details.sections.name': 'snake_case, e.g. contact_info',
+    'engine.inspector.pageBlock.placeholder.record:alert.icon': 'lucide icon name',
+    'engine.inspector.pageBlock.placeholder.record:quick_actions.actionNames': 'action name',
+    'engine.inspector.pageBlock.placeholder.ai:input.agentName': 'agent name',
   };
 
   it('renders the pre-change English text for every sampled key', () => {
@@ -251,5 +321,102 @@ describe('en-US labels are unchanged by the key migration (#3913)', () => {
     const derived = new Set(SITES.map((s) => s.derived));
     const orphans = Object.keys(EXPECTED).filter((k) => !derived.has(k));
     expect(orphans).toEqual([]);
+  });
+});
+
+/**
+ * The OTHER half of the placeholder column: the ones that must stay literal
+ * (#3979).
+ *
+ * Everything above pins the keys. This describe pins the decision NOT to key the
+ * rest, because that is the half a future reader is most likely to "finish": the
+ * column is half translated, ten English-looking strings remain, and translating
+ * `{ "type": "url", … }` or `https://…` looks like completing somebody's
+ * unfinished work. It is not — those characters are the value the author is being
+ * shown, and a localized JSON sample produces metadata the spec rejects.
+ *
+ * So the literal side is an inventory with a stated reason per entry, and adding
+ * to it is a deliberate act. The prose tripwire below is the cheaper half of the
+ * same guard: it can catch `{ literal: 'lucide icon name' }` (two adjacent words)
+ * but not a single-word hint, which is exactly why the inventory is exhaustive
+ * rather than a heuristic.
+ */
+describe('placeholders that must NOT be translated (#3979)', () => {
+  /** Position → the literal it declares, and why that is not a translation gap. */
+  const INVARIANT: Record<string, { literal: string; because: string }> = {
+    'object-grid.pageSize': { literal: '20', because: 'a default row count' },
+    'object-form.columns': { literal: '2', because: 'a grid column count' },
+    'grid.columns': { literal: '3', because: 'a grid column count' },
+    'grid.gap': { literal: '4', because: 'a spacing step' },
+    'element:image.src': { literal: 'https://…', because: 'a URL scheme — the value starts this way in every locale' },
+    'element:definition-list.columns': { literal: '1', because: 'a column count' },
+    'element:repeater.limit': { literal: '10', because: 'a row limit' },
+    'element:button.action': {
+      literal: '{ "type": "url", "target": "/environments" }',
+      because: 'a JSON sample the author copies — translated keys would fail InlineActionSchema',
+    },
+    'record:related_list.limit': { literal: '10', because: 'a row limit' },
+    'record:details.sections.columns': { literal: '2', because: 'a column count' },
+  };
+
+  it('collects all 18 placeholders — 8 keyed, 10 literal', () => {
+    // Guards the walk: if placeholder collection silently found nothing, every
+    // assertion here would pass over an empty list.
+    expect(PLACEHOLDERS.length).toBe(18);
+    expect(PLACEHOLDERS.filter((p) => p.spec.key !== undefined).length).toBe(8);
+    expect(PLACEHOLDERS.filter((p) => p.spec.literal !== undefined).length).toBe(10);
+  });
+
+  it('every placeholder declares exactly one of key / literal', () => {
+    // `PlaceholderSpec`'s mutual `never`s make this a type error already. Pinned
+    // at runtime too, because the table is also reached from JS-shaped places
+    // (JSON fixtures, tests) where the type is not consulted.
+    const bad = PLACEHOLDERS.filter(
+      (p) => (p.spec.key === undefined) === (p.spec.literal === undefined),
+    ).map((p) => `${p.where}: ${JSON.stringify(p.spec)}`);
+    expect(bad).toEqual([]);
+  });
+
+  it('the literal inventory is exactly the declared one', () => {
+    const actual = Object.fromEntries(
+      PLACEHOLDERS.filter((p) => p.spec.literal !== undefined).map((p) => [p.where, p.spec.literal]),
+    );
+    const expected = Object.fromEntries(
+      Object.entries(INVARIANT).map(([where, v]) => [where, v.literal]),
+    );
+    // If this fails, one of three things happened, and they need different fixes:
+    //   - a new placeholder was added as a literal → is it a VALUE? add it here
+    //     with its reason. Is it prose? make it a `{ key }` instead.
+    //   - a literal changed → the en baseline moved; say so in a changeset.
+    //   - a literal became a key → drop it here and add the key to the
+    //     `en-US labels are unchanged` sample above.
+    expect(actual).toEqual(expected);
+  });
+
+  it('no invariant literal is prose — that would be a missed translation', () => {
+    // Two adjacent alphabetic words is the signature of a sentence, and every
+    // value in the inventory is a number, a URL scheme or JSON — none of which
+    // can match. `lucide icon name` parked here as a literal would.
+    const prose = Object.entries(INVARIANT)
+      .filter(([, v]) => /[A-Za-z]{2,}\s+[A-Za-z]{2,}/.test(v.literal))
+      .map(([where, v]) => `${where}: '${v.literal}'`);
+    expect(prose).toEqual([]);
+  });
+
+  it('every inventory entry carries a reason', () => {
+    // The ledger is only worth anything if each line says why. A bare list
+    // becomes a place to append to without thinking.
+    for (const [where, v] of Object.entries(INVARIANT)) {
+      expect(v.because.length, `${where} needs a reason`).toBeGreaterThan(10);
+    }
+  });
+
+  it('no literal placeholder accidentally holds a translation key', () => {
+    // The mirror of "no label is left as display text": a key parked on the
+    // literal side renders `engine.inspector.pageBlock.…` into the box.
+    const keys = PLACEHOLDERS.filter((p) => p.spec.literal?.startsWith(`${PREFIX}.`)).map(
+      (p) => `${p.where}: '${p.spec.literal}'`,
+    );
+    expect(keys).toEqual([]);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { PageComponentType, RecordDetailsProps } from '@objectstack/spec/ui';
-import { BLOCK_CONFIG, blockHasConfig } from '../block-config';
+import { BLOCK_CONFIG, blockHasConfig, type PlaceholderSpec } from '../block-config';
 import { BLOCK_TYPE_META, PALETTE_EXCLUSIONS } from '../block-types';
 import { t } from '../../i18n';
 
@@ -87,7 +87,10 @@ describe('record:details sections ↔ spec section-entry coverage (#3819)', () =
 
   /** The inspector's item editors for one section. */
   const sectionsField = BLOCK_CONFIG['record:details'].find((f) => f.name === 'sections') as
-    | { kind: 'array'; itemFields: Array<{ name: string; label: string; kind: string; placeholder?: string }> }
+    | {
+        kind: 'array';
+        itemFields: Array<{ name: string; label: string; kind: string; placeholder?: PlaceholderSpec }>;
+      }
     | undefined;
 
   it('reads a non-empty section-entry shape from the spec', () => {
@@ -115,7 +118,17 @@ describe('record:details sections ↔ spec section-entry coverage (#3819)', () =
     // `BlockPropField` has no description/pattern affordance, so the
     // placeholder is the only place the snake_case convention can be stated —
     // the same argument the json-placeholder test below makes.
-    expect(nameField!.placeholder, '`name` needs a placeholder stating snake_case').toMatch(/snake_case/);
+    //
+    // Asserted on the RESOLVED hint in both locales, for the same reason the
+    // label assertion below is: since #3979 the placeholder holds a translation
+    // key, and matching /snake_case/ against the KEY would pass on the key's
+    // spelling while a zh-CN author read whatever the table happens to say. The
+    // convention has to survive translation — `snake_case` is a literal token
+    // both locales must keep verbatim, not a word to render as 「蛇形命名」.
+    const namePlaceholder = nameField!.placeholder;
+    expect(namePlaceholder?.key, '`name`s placeholder must be a translation key (#3979)').toBeTruthy();
+    expect(t(namePlaceholder!.key!, 'en-US'), 'en hint must state snake_case').toMatch(/snake_case/);
+    expect(t(namePlaceholder!.key!, 'zh-CN'), 'zh hint must state snake_case').toMatch(/snake_case/);
     // The label must say what the box is FOR. A bare "Name" next to "Label"
     // reads as a second display string, which is how an author ends up typing
     // a heading into the anchor.
@@ -207,12 +220,18 @@ describe('page palette ↔ spec PageComponentType coverage', () => {
     // An empty JSON textarea tells an author nothing. The placeholder is the
     // only affordance a raw-JSON editor has, so a json field without one is a
     // blank box.
-    const missing = Object.entries(BLOCK_CONFIG).flatMap(([type, fields]) =>
+    const jsonFields = Object.entries(BLOCK_CONFIG).flatMap(([type, fields]) =>
       fields
-        .filter((f) => f.kind === 'json' && !(f as { placeholder?: string }).placeholder)
-        .map((f) => `${type}.${f.name}`),
+        .filter((f) => f.kind === 'json')
+        .map((f) => ({ where: `${type}.${f.name}`, spec: (f as { placeholder?: PlaceholderSpec }).placeholder })),
     );
-    expect(missing).toEqual([]);
+    expect(jsonFields.length, 'no json field found — the filter is vacuous').toBeGreaterThan(0);
+    expect(jsonFields.filter((f) => !f.spec).map((f) => f.where)).toEqual([]);
+    // …and it stays a LITERAL (#3979). A JSON sample is the text the author
+    // copies: a "translated" `"type"` / `"target"` yields metadata
+    // `InlineActionSchema` rejects, so this is the one placeholder kind where
+    // going through `t()` would be the bug rather than the fix.
+    expect(jsonFields.filter((f) => f.spec?.key !== undefined).map((f) => f.where)).toEqual([]);
   });
 
   it('a block with a config panel is a block the palette offers', () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -36,12 +36,33 @@
  *   nested item label    engine.inspector.pageBlock.field.<blockType>.<array>.<name>
  *   array add button     engine.inspector.pageBlock.add.<blockType>.<name>
  *   select/color option  engine.inspector.pageBlock.option.<fieldName>.<value>
+ *   placeholder prose    engine.inspector.pageBlock.placeholder.<blockType>.<name>
  *
- * `previews/__tests__/block-config-i18n.test.ts` re-derives all four shapes from
+ * `previews/__tests__/block-config-i18n.test.ts` re-derives all five shapes from
  * the table's own structure and asserts (a) the stored key equals the derived
  * one and (b) both locales define it. So a field added here without a
  * translation is red, and so is a key copy-pasted from a neighbouring block —
  * the second is the failure a bare "does the key exist?" check cannot see.
+ *
+ * ## `placeholder` is a KEY *or* a LITERAL, declared per field (#3979)
+ *
+ * #3913 moved `label`/`addLabel`/option labels and stopped there, so the
+ * placeholder column stayed display text: a zh-CN admin opening `page:header`
+ * read 「图标」 over a box hinting `lucide icon name`, in the panel #3913 had
+ * just finished translating.
+ *
+ * The column could not simply follow `label`, because it is a MIXED surface —
+ * of the 18 placeholders, 8 are prose telling the author what to type and 10 are
+ * example VALUES (`20`, `https://…`, a JSON sample). Translating the second kind
+ * is a defect, not a courtesy: those characters are what the author is meant to
+ * enter, and a "translated" JSON sample yields metadata the schema rejects. So
+ * the two meanings are separated in the TYPE (`PlaceholderSpec` below) rather
+ * than by a convention plus a list of exceptions — the author of a new field
+ * states which kind it is and cannot leave it implicit.
+ *
+ * The literal side is inventoried in the same test, so a later "helpful"
+ * translation of `lucide icon name`'s neighbours has to argue with a pin instead
+ * of quietly landing.
  *
  * Option keys deliberately omit the block type, so `format`'s number/currency/
  * percent are translated once for `object-metric` and `element:number`. Field
@@ -58,27 +79,50 @@
 export type ObjectSource = { objectFrom: 'page' } | { objectFrom: 'self'; objectProp: string };
 
 /**
- * One curated property editor. Every `label` is a translation key — see the
- * file header for the four key shapes and the test that enforces them.
+ * A field's input hint — EXACTLY ONE of two shapes, chosen where the field is
+ * written (#3979):
+ *
+ *   { key: '…' }      prose telling the author what to type ("lucide icon
+ *                     name"). A translation key into `../i18n.ts`, resolved by
+ *                     `PageBlockInspector` through `t()` at render, exactly like
+ *                     `label`.
+ *   { literal: '…' }  a locale-invariant example VALUE — a number, a URL scheme,
+ *                     a JSON sample. Passed through untranslated, because those
+ *                     characters are what the author is meant to type.
+ *
+ * A bare string is deliberately NOT assignable. `placeholder: 'lucide icon
+ * name'` — this file's own shape until #3979, and the first thing anything
+ * generating a new field will reach for — is a TYPE error now, caught by
+ * `type-check` in every lane and in the editor, instead of an English string
+ * that renders into a Chinese panel and waits for a test somebody remembers to
+ * run. The mutual `never`s reject "both at once" too, so the renderer never has
+ * to pick a winner between them.
+ */
+export type PlaceholderSpec = { key: string; literal?: never } | { literal: string; key?: never };
+
+/**
+ * One curated property editor. Every `label` is a translation key, and every
+ * `placeholder` declares whether it is one — see the file header for the five
+ * key shapes and the tests that enforce them.
  */
 export type BlockPropField =
-  | { name: string; label: string; kind: 'text'; placeholder?: string }
-  | { name: string; label: string; kind: 'number'; placeholder?: string }
+  | { name: string; label: string; kind: 'text'; placeholder?: PlaceholderSpec }
+  | { name: string; label: string; kind: 'number'; placeholder?: PlaceholderSpec }
   | { name: string; label: string; kind: 'boolean' }
   | { name: string; label: string; kind: 'select'; options: Array<{ value: string; label: string }> }
-  | { name: string; label: string; kind: 'string-list'; placeholder?: string }
+  | { name: string; label: string; kind: 'string-list'; placeholder?: PlaceholderSpec }
   // `addLabel` is REQUIRED (#3913). It was optional, and the inspector rendered
   // a bare English `'Add'` when it was absent — an untranslatable literal that
   // no locale table could reach. Making the contract require it is the fix that
   // deletes the fallback instead of translating it: a new array field cannot
   // compile without naming its add-button key.
   | { name: string; label: string; kind: 'array'; itemFields: BlockPropField[]; addLabel: string }
-  | { name: string; label: string; kind: 'json'; placeholder?: string }
+  | { name: string; label: string; kind: 'json'; placeholder?: PlaceholderSpec }
   | { name: string; label: string; kind: 'color'; options?: Array<{ value: string; label: string }> }
   // Schema-driven pickers — dropdowns populated from the live metadata.
-  | { name: string; label: string; kind: 'object-picker'; placeholder?: string }
-  | ({ name: string; label: string; kind: 'field-picker'; placeholder?: string } & ObjectSource)
-  | ({ name: string; label: string; kind: 'field-list'; placeholder?: string } & ObjectSource);
+  | { name: string; label: string; kind: 'object-picker'; placeholder?: PlaceholderSpec }
+  | ({ name: string; label: string; kind: 'field-picker'; placeholder?: PlaceholderSpec } & ObjectSource)
+  | ({ name: string; label: string; kind: 'field-list'; placeholder?: PlaceholderSpec } & ObjectSource);
 
 /** Shared alignment options. The keys name the field (`align`), so reusing this
  *  const on a field called anything else turns the key-derivation pin red. */
@@ -98,7 +142,8 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
   'object-grid': [
     { name: 'objectName', label: 'engine.inspector.pageBlock.field.object-grid.objectName', kind: 'object-picker' },
     { name: 'columns', label: 'engine.inspector.pageBlock.field.object-grid.columns', kind: 'field-list', objectFrom: 'self', objectProp: 'objectName' },
-    { name: 'pageSize', label: 'engine.inspector.pageBlock.field.object-grid.pageSize', kind: 'number', placeholder: '20' },
+    // `{ literal: … }` — an example VALUE, not prose: see `PlaceholderSpec`.
+    { name: 'pageSize', label: 'engine.inspector.pageBlock.field.object-grid.pageSize', kind: 'number', placeholder: { literal: '20' } },
     { name: 'striped', label: 'engine.inspector.pageBlock.field.object-grid.striped', kind: 'boolean' },
     { name: 'bordered', label: 'engine.inspector.pageBlock.field.object-grid.bordered', kind: 'boolean' },
   ],
@@ -132,7 +177,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
         { value: 'grid', label: 'engine.inspector.pageBlock.option.layout.grid' },
       ],
     },
-    { name: 'columns', label: 'engine.inspector.pageBlock.field.object-form.columns', kind: 'number', placeholder: '2' },
+    { name: 'columns', label: 'engine.inspector.pageBlock.field.object-form.columns', kind: 'number', placeholder: { literal: '2' } },
     { name: 'fields', label: 'engine.inspector.pageBlock.field.object-form.fields', kind: 'field-list', objectFrom: 'self', objectProp: 'objectName' },
     { name: 'title', label: 'engine.inspector.pageBlock.field.object-form.title', kind: 'text' },
     { name: 'description', label: 'engine.inspector.pageBlock.field.object-form.description', kind: 'text' },
@@ -141,7 +186,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
     { name: 'objectName', label: 'engine.inspector.pageBlock.field.object-metric.objectName', kind: 'object-picker' },
     { name: 'label', label: 'engine.inspector.pageBlock.field.object-metric.label', kind: 'text' },
     { name: 'description', label: 'engine.inspector.pageBlock.field.object-metric.description', kind: 'text' },
-    { name: 'icon', label: 'engine.inspector.pageBlock.field.object-metric.icon', kind: 'text', placeholder: 'lucide icon name' },
+    { name: 'icon', label: 'engine.inspector.pageBlock.field.object-metric.icon', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.object-metric.icon' } },
     {
       name: 'colorVariant', label: 'engine.inspector.pageBlock.field.object-metric.colorVariant', kind: 'color',
       options: [
@@ -177,13 +222,13 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
 
   // ── Layout grid ───────────────────────────────────────────────────────────
   grid: [
-    { name: 'columns', label: 'engine.inspector.pageBlock.field.grid.columns', kind: 'number', placeholder: '3' },
-    { name: 'gap', label: 'engine.inspector.pageBlock.field.grid.gap', kind: 'number', placeholder: '4' },
+    { name: 'columns', label: 'engine.inspector.pageBlock.field.grid.columns', kind: 'number', placeholder: { literal: '3' } },
+    { name: 'gap', label: 'engine.inspector.pageBlock.field.grid.gap', kind: 'number', placeholder: { literal: '4' } },
   ],
 
   // ── Content elements ──────────────────────────────────────────────────────
   'element:text': [
-    { name: 'content', label: 'engine.inspector.pageBlock.field.element:text.content', kind: 'text', placeholder: 'Text…' },
+    { name: 'content', label: 'engine.inspector.pageBlock.field.element:text.content', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.element:text.content' } },
     {
       name: 'variant',
       label: 'engine.inspector.pageBlock.field.element:text.variant',
@@ -198,7 +243,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
     { name: 'align', label: 'engine.inspector.pageBlock.field.element:text.align', kind: 'select', options: ALIGN_OPTS },
   ],
   'element:image': [
-    { name: 'src', label: 'engine.inspector.pageBlock.field.element:image.src', kind: 'text', placeholder: 'https://…' },
+    { name: 'src', label: 'engine.inspector.pageBlock.field.element:image.src', kind: 'text', placeholder: { literal: 'https://…' } },
     { name: 'alt', label: 'engine.inspector.pageBlock.field.element:image.alt', kind: 'text' },
     {
       name: 'fit',
@@ -224,14 +269,14 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
         { name: 'value', label: 'engine.inspector.pageBlock.field.element:definition-list.items.value', kind: 'text' },
       ],
     },
-    { name: 'columns', label: 'engine.inspector.pageBlock.field.element:definition-list.columns', kind: 'number', placeholder: '1' },
+    { name: 'columns', label: 'engine.inspector.pageBlock.field.element:definition-list.columns', kind: 'number', placeholder: { literal: '1' } },
     { name: 'inline', label: 'engine.inspector.pageBlock.field.element:definition-list.inline', kind: 'boolean' },
   ],
   'element:repeater': [
     { name: 'object', label: 'engine.inspector.pageBlock.field.element:repeater.object', kind: 'object-picker' },
     { name: 'titleField', label: 'engine.inspector.pageBlock.field.element:repeater.titleField', kind: 'field-picker', objectFrom: 'self', objectProp: 'object' },
     { name: 'fields', label: 'engine.inspector.pageBlock.field.element:repeater.fields', kind: 'field-list', objectFrom: 'self', objectProp: 'object' },
-    { name: 'limit', label: 'engine.inspector.pageBlock.field.element:repeater.limit', kind: 'number', placeholder: '10' },
+    { name: 'limit', label: 'engine.inspector.pageBlock.field.element:repeater.limit', kind: 'number', placeholder: { literal: '10' } },
     { name: 'emptyText', label: 'engine.inspector.pageBlock.field.element:repeater.emptyText', kind: 'text' },
     { name: 'divided', label: 'engine.inspector.pageBlock.field.element:repeater.divided', kind: 'boolean' },
   ],
@@ -287,7 +332,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
         { value: 'large', label: 'engine.inspector.pageBlock.option.size.large' },
       ],
     },
-    { name: 'icon', label: 'engine.inspector.pageBlock.field.element:button.icon', kind: 'text', placeholder: 'lucide icon name' },
+    { name: 'icon', label: 'engine.inspector.pageBlock.field.element:button.icon', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.element:button.icon' } },
     // Without `action` a button renders inert, and the generic "Advanced"
     // section can only edit properties the block ALREADY has — so a button
     // created in Studio had no way to become interactive at all. The spec
@@ -297,7 +342,10 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
       name: 'action',
       label: 'engine.inspector.pageBlock.field.element:button.action',
       kind: 'json',
-      placeholder: '{ "type": "url", "target": "/environments" }',
+      // A literal on purpose: this is the JSON an author copies, and a
+      // "translated" `"type"`/`"target"` would produce metadata the spec
+      // rejects. Pinned as locale-invariant in `block-config.test.ts`.
+      placeholder: { literal: '{ "type": "url", "target": "/environments" }' },
     },
   ],
 
@@ -305,7 +353,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
   'page:header': [
     { name: 'title', label: 'engine.inspector.pageBlock.field.page:header.title', kind: 'text' },
     { name: 'subtitle', label: 'engine.inspector.pageBlock.field.page:header.subtitle', kind: 'text' },
-    { name: 'icon', label: 'engine.inspector.pageBlock.field.page:header.icon', kind: 'text', placeholder: 'lucide icon name' },
+    { name: 'icon', label: 'engine.inspector.pageBlock.field.page:header.icon', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.page:header.icon' } },
     { name: 'breadcrumb', label: 'engine.inspector.pageBlock.field.page:header.breadcrumb', kind: 'boolean' },
   ],
   'page:card': [
@@ -343,7 +391,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
     { name: 'objectName', label: 'engine.inspector.pageBlock.field.record:related_list.objectName', kind: 'object-picker' },
     { name: 'relationshipField', label: 'engine.inspector.pageBlock.field.record:related_list.relationshipField', kind: 'field-picker', objectFrom: 'self', objectProp: 'objectName' },
     { name: 'title', label: 'engine.inspector.pageBlock.field.record:related_list.title', kind: 'text' },
-    { name: 'limit', label: 'engine.inspector.pageBlock.field.record:related_list.limit', kind: 'number', placeholder: '10' },
+    { name: 'limit', label: 'engine.inspector.pageBlock.field.record:related_list.limit', kind: 'number', placeholder: { literal: '10' } },
   ],
   'record:highlights': [
     { name: 'fields', label: 'engine.inspector.pageBlock.field.record:highlights.fields', kind: 'field-list', objectFrom: 'page' },
@@ -366,15 +414,17 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
       // the anchor is the one value that must stay stable across locales. The
       // placeholder carries the snake_case convention because `BlockPropField`
       // has no pattern/validate affordance — see the type above — and adding
-      // one for a single field is outside this fix.
+      // one for a single field is outside this fix. That convention is prose
+      // ABOUT the value, so the placeholder is a key (#3979) and both locales
+      // must keep the `snake_case` token verbatim inside it.
       name: 'sections',
       label: 'engine.inspector.pageBlock.field.record:details.sections',
       kind: 'array',
       addLabel: 'engine.inspector.pageBlock.add.record:details.sections',
       itemFields: [
-        { name: 'name', label: 'engine.inspector.pageBlock.field.record:details.sections.name', kind: 'text', placeholder: 'snake_case, e.g. contact_info' },
+        { name: 'name', label: 'engine.inspector.pageBlock.field.record:details.sections.name', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.record:details.sections.name' } },
         { name: 'label', label: 'engine.inspector.pageBlock.field.record:details.sections.label', kind: 'text' },
-        { name: 'columns', label: 'engine.inspector.pageBlock.field.record:details.sections.columns', kind: 'number', placeholder: '2' },
+        { name: 'columns', label: 'engine.inspector.pageBlock.field.record:details.sections.columns', kind: 'number', placeholder: { literal: '2' } },
         { name: 'fields', label: 'engine.inspector.pageBlock.field.record:details.sections.fields', kind: 'field-list', objectFrom: 'page' },
       ],
     },
@@ -393,7 +443,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
     },
     { name: 'title', label: 'engine.inspector.pageBlock.field.record:alert.title', kind: 'text' },
     { name: 'body', label: 'engine.inspector.pageBlock.field.record:alert.body', kind: 'text' },
-    { name: 'icon', label: 'engine.inspector.pageBlock.field.record:alert.icon', kind: 'text', placeholder: 'lucide icon name' },
+    { name: 'icon', label: 'engine.inspector.pageBlock.field.record:alert.icon', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.record:alert.icon' } },
     { name: 'dismissible', label: 'engine.inspector.pageBlock.field.record:alert.dismissible', kind: 'boolean' },
   ],
   'record:path': [
@@ -410,7 +460,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
     },
   ],
   'record:quick_actions': [
-    { name: 'actionNames', label: 'engine.inspector.pageBlock.field.record:quick_actions.actionNames', kind: 'string-list', placeholder: 'action name' },
+    { name: 'actionNames', label: 'engine.inspector.pageBlock.field.record:quick_actions.actionNames', kind: 'string-list', placeholder: { key: 'engine.inspector.pageBlock.placeholder.record:quick_actions.actionNames' } },
     {
       name: 'location',
       label: 'engine.inspector.pageBlock.field.record:quick_actions.location',
@@ -432,7 +482,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
   // renderer — see block-types.ts PALETTE_EXCLUSIONS, #2943). A config panel
   // for an unauthorable block is how the contradiction stayed invisible.
   'ai:input': [
-    { name: 'agentName', label: 'engine.inspector.pageBlock.field.ai:input.agentName', kind: 'text', placeholder: 'agent name' },
+    { name: 'agentName', label: 'engine.inspector.pageBlock.field.ai:input.agentName', kind: 'text', placeholder: { key: 'engine.inspector.pageBlock.placeholder.ai:input.agentName' } },
     { name: 'placeholder', label: 'engine.inspector.pageBlock.field.ai:input.placeholder', kind: 'text' },
   ],
 };


### PR DESCRIPTION
Fixes #3979

#3913(PR #3970)把 `block-config.ts` 的 `label` / `addLabel` / option label 搬成翻译键,停在了相邻的一列。18 个 `placeholder` 里有 8 个是语言内容,至今仍是显示文本:zh-CN 管理员打开 `page:header`,「图标」下面的输入框提示还是 `lucide icon name`;`record:details` 的「名称(i18n 键)」下面是 `snake_case, e.g. contact_info` —— 正好在 #3913 / #3963 刚修好的那个面板里。

本 PR 把这 8 个改为 `engine.inspector.pageBlock.placeholder.` 后接 blockType 与字段路径的键,渲染处过 `t()`,en-US / zh-CN 双语补齐。**en 值与被替换的字面量逐字节相等**(含 `Text…` 的 U+2026 省略号,已用脚本按 hex 比对),所以英文面板没有任何变化。

## 逐条判定表(18 条,判定理由在最后一列)

| # | 位置 | 值 | 判定 | 理由 |
|---|---|---|---|---|
| 1 | `object-grid.pageSize` | `20` | 字面 | 默认行数,是要输入的**值** |
| 2 | `object-form.columns` | `2` | 字面 | 网格列数 |
| 3 | `object-metric.icon` | `lucide icon name` | **键** | 描述"该输入什么"的散文,不是值本身;`lucide` 作为库名在 zh 里保留 |
| 4 | `grid.columns` | `3` | 字面 | 网格列数 |
| 5 | `grid.gap` | `4` | 字面 | 间距档位 |
| 6 | `element:text.content` | `Text…` | **键** | 名词性提示文案;zh 为「文本…」 |
| 7 | `element:image.src` | `https://…` | 字面 | URL scheme,任何语言下值都这样开头;翻译它会误导 |
| 8 | `element:definition-list.columns` | `1` | 字面 | 列数 |
| 9 | `element:repeater.limit` | `10` | 字面 | 条数上限 |
| 10 | `element:button.icon` | `lucide icon name` | **键** | 同 #3 |
| 11 | `element:button.action` | `{ "type": "url", "target": "/environments" }` | 字面 | 作者要照抄的 JSON 样例;键被"翻译"后是 `InlineActionSchema` 会拒的元数据 |
| 12 | `page:header.icon` | `lucide icon name` | **键** | 同 #3(issue 标题点名的那一处) |
| 13 | `record:related_list.limit` | `10` | 字面 | 条数上限 |
| 14 | `record:details.sections.name` | `snake_case, e.g. contact_info` | **键**(边缘条目) | 「格式说明 + 示例」混合面:主体是散文,`snake_case` 与 `contact_info` 两个 token 在 zh 值里**原样保留**(`snake_case,例如:contact_info`)。仓内已有同形先例:`engine.inspector.view.objectPlaceholder` = `e.g. crm_lead` → 「例如:crm_lead」,`engine.inspector.report.namePlaceholder` = `e.g. pipeline_by_stage` → 「例如:pipeline_by_stage」 |
| 15 | `record:details.sections.columns` | `2` | 字面 | 列数 |
| 16 | `record:alert.icon` | `lucide icon name` | **键** | 同 #3 |
| 17 | `record:quick_actions.actionNames` | `action name` | **键** | 散文提示;zh 「动作名称」 |
| 18 | `ai:input.agentName` | `agent name` | **键** | 散文提示;zh 「智能体名称」 |

合计 8 键 / 10 字面,与 issue 正文的 8/10 拆分一致。

### ⚠️ 与派发单括注的一处分歧(4 个 lucide 图标名)

派发提示写的是「lucide 图标名 ×4 ... 保持字面」,但 issue **正文的命中表把这 4 条列在「8 个有语言内容」之内**,而且 issue 标题与「影响」段正是拿它举证(「打开 `page:header`,字段名「图标」是中文,它下面输入框的提示是 `lucide icon name`」)。逐条判定的结论站正文一边,理由是:

- `lucide icon name` **不是**要输入的值 —— 值是 `users` / `bar-chart` 这类图标名。它是描述"该输入什么"的英文名词短语,与 `20` / `https://…` / JSON 样例不同类。
- 同一个面板里的邻居 `engine.inspector.pageBlock.objectPlaceholder`(`snake_case object` → 「snake_case 对象名」)与 `fieldPlaceholder`(`field name` → 「字段名」)在 #3963 里**已经是翻译键**。让 `lucide icon name` 保持字面,会让同一面板的同类提示一半中文一半英文。
- zh 值为「lucide 图标名」:库名 `lucide` 保留,只翻译其余散文 —— 与 `snake_case 对象名` 完全同形。

若维护者仍要求 4 条保持字面,回退面很小:4 行 `{ key: … }` 改回 `{ literal: … }`、删 8 行译文、把 `families.placeholder` 由 8 改 4、并把这 4 条加进字面台账。

## 机制:混合面写进类型,而不是"约定 + 豁免清单"

issue 正文把这条列为留给实施者论证的契约面小决定(两个选项:显式豁免台账,或在 `BlockPropField` 上拆成两个字段)。本 PR 取第三种、也是两者的严格上界 —— 一个可辨识联合:

```ts
export type PlaceholderSpec = { key: string; literal?: never } | { literal: string; key?: never };
```

- ⛔ **没有**照抄 label 那条改必填:`placeholder` 保持可选(无提示的字段是合法的);只有 `addLabel` 在 #3913 里改了必填。
- 裸字符串不再可赋值:`placeholder: 'lucide icon name'`(本文件在此前的写法,也是任何生成新字段的东西最先伸手去写的写法)现在是**类型错误**。这比那 8 个字符串本身更要紧 —— `type-check` 在每条流水线和编辑器里都跑,错误在写下的地方就被拦住,而不是变成中文面板里的一个英文框、等某个评审者注意到。
- 互斥的 `never` 让"两个都填"也编译不过,渲染处不需要在两者之间挑赢家。
- 渲染处四个 `placeholder=` 站点(number / json / string-list / 默认 text)收敛到一个 `placeholderText()` 解析器 —— 面板内容当初之所以在中文面板里是英文,就是因为有一列绕过了访问器。

键形沿 #3913 的位置推导惯例(`engine.inspector.pageBlock.placeholder.` + blockType + 字段路径),因此**并入**了那条结构钉的推导断言,成为第五个键族;推导测试不需要新族的例外分支,只多了一次 `walk` 里的采集。4 个 lucide 提示是 4 个**不同的键**、英文文本相同 —— 与 field 键携带 blockType 同理:一个键不能说两件事,将来某个块想换措辞不必先拆键。

## 钉子

1. **走键的一半**并入 `block-config-i18n.test.ts`:`families.placeholder` 精确等于 8(像 `add` 那样精确,新增的散文 placeholder 缺翻译即红);en 侧 8 个键**全部**进 `en-US labels are unchanged` 样本(不是抽样 —— 这一列是手工迁移的,en 是"键能解析"与"键解析出原来那句话"之间唯一的东西);zh≠en、两语齐备、位置推导相等由既有的 5 条断言自动覆盖。
2. **保持字面的一半**钉成逐条带理由的台账(10 条,`because` 必须 > 10 字符)+ 一条"字面不得是散文"的正则哨兵(相邻两个字母词 = 句子的签名;`{ literal: 'lucide icon name' }` 会被它抓住,单词提示不会 —— 所以台账是穷举而非启发式)。理由:"顺手把另外十个也翻掉"是最可能的下一次编辑。
3. **渲染面**在 `PageBlockInspector.i18n.test.tsx` 加了成对断言:散文随语言变、值不变(同一个 `record:details` fixture 里 `sections.name` 变、旁边的 `sections.columns` = `2` 不变)。另补 `expectNoRawKeyPlaceholders()` —— placeholder 是**属性**,`textContent` 看不见它,既有的 `expectNoRawKeys()` 结构上抓不到裸键进 placeholder,这正是 #3963 那两个 placeholder 躲过 #3913 评审的缝。
4. **fixture 三态处置**:`block-config.test.ts` 的 `expect(nameField.placeholder).toMatch(/snake_case/)` 属"钉住了被改掉的形态"——改判为断言**解析后**的提示且两语都断言(与同一测试里 #3913 已经这么做的 label 断言同形)。这是更强的说法:`snake_case` 这个 token 必须**活过翻译**,而不只是在英文里存在。json placeholder 那条从"存在"加强到"必须是 literal"。`PageBlockInspector.sectionName.test.tsx` 的 `getAllByPlaceholderText(/snake_case/i)` 无需改动 —— 它跑 en-US,而 en 值逐字节不变(反向验证里它是最响的一处红)。

## 反向验证(先预判方向,再跑;变异**未**提交)

**M1 —— 渲染处不再调 `t()`**(`placeholderText` 直接返回 `p.key`):

- 预判:数据面两个测试文件**保持绿**(它们钉的是表,结构上看不见"渲染处漏了访问器"),渲染面 #3979 的散文用例红,其中 `passes example VALUES through untranslated` 应**保持绿**(字面值有没有 `t()` 都一样),另外 `PageBlockInspector.sectionName.test.tsx`(#3819)应红 —— 它按 `/snake_case/i` 定位输入框,裸键里没有这个 token。
- 实测:`Tests 11 failed | 50 passed` —— #3979 的 6 条里 5 条红(第 6 条 `passes example VALUES…` 如预判保持绿)、`sectionName`(#3819)6 条红、`block-config-i18n.test.ts`(15)与 `block-config.test.ts`(16)**全绿**。**方向与预判一致**,包含那条"表钉看不见渲染"的分工:这正是这两个文件各自存在的理由,#3913 的文件头也这么写着。

**M2 —— 把一个字面值改成键**(`element:button.action` 的 JSON 样例改 `{ key: … }`,不加译文):

- 预判:`block-config.test.ts` 的 json-must-be-literal 红;`block-config-i18n.test.ts` 的 `families.placeholder`(8→9)、字面台账等值、en/zh 解析三条红;渲染面 `passes example VALUES through untranslated` 红。
- 实测:`Tests 8 failed | 45 passed`,红的正是上述 8 条(3 个文件都红)。**方向与预判一致**。

两次变异后 `git checkout --` 复原,`git status` 干净,树等于提交 `622ff385`。

## 验证

- 基 sha:`6bd6a4d76`;`git merge-base --is-ancestor 708aaf8e4 HEAD` 通过(#3963 的 PR #3980 在基内)。
- `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` —— 先行,通过。
- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin --maxWorkers=2` —— `Test Files 135 passed (135)`,`Tests 1372 passed | 1 skipped (1373)`。
- `pnpm exec turbo run type-check --concurrency=2` —— `78 successful, 78 total`。
- `check:i18n-keys` —— `Every in-scope call-site key resolves against the en pack (2918 keys)`;`check:i18n-drift` —— `0 en value(s) changed`(本 PR 只**新增**键,不改既有 en 值;metadata-admin 的 `i18n.ts` 是模块内表、按设计不在 call-site 门的扫描面内)。
- `node scripts/check-control-bytes.mjs` —— OK(3889 个文件);另按控制字节纪律自查 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f]'` 全部改动文件,无命中。
- changeset:`.changeset/block-config-placeholder-i18n-3979.md`,`@object-ui/app-shell` patch;`check-changeset-fixed` / `check-changeset-no-major` 通过。

## 边界

- ⛔ 未动 #3912 的 capability 面(`BlockPropField` 仍**没有** pattern/validate 能力位;`sections.name` 依旧只能靠 placeholder 陈述 snake_case 约定 —— 本 PR 只保证这句约定会翻译,不去加能力位)。
- ⛔ 未碰在飞 #3976 / #3967 的文件;未碰 `content/docs/releases/`。
- 改动面 6 个文件:`previews/block-config.ts`、`metadata-admin/i18n.ts`、`inspectors/PageBlockInspector.tsx`、`inspectors/PageBlockInspector.i18n.test.tsx`、`previews/__tests__/block-config-i18n.test.ts`、`previews/__tests__/block-config.test.ts`。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_