### PR TITLE
fix(components): div 废弃提示每次模块加载只报一次;catalog 换类型那一半升级待定夺 (#3965)

### DIFF
--- a/.changeset/div-deprecation-warn-once.md
+++ b/.changeset/div-deprecation-warn-once.md
@@ -1,0 +1,18 @@
+---
+"@object-ui/components": patch
+---
+
+The `div` deprecation notice is now reported once per module load, not once per render (objectui#3965)
+
+`DivRenderer` called `console.warn` on every render. That is invisible on a page
+with one `div` and destructive on a page with many: the docs schema-catalog index
+renders 400+ example thumbnails and emitted ~190 byte-identical notices, burying
+the page's real console errors underneath — the two nested-button errors fixed in
+objectui#3903 / PR #3964 had to be fished out of that flood, and it cost a
+browser-verification run its signal twice.
+
+The deprecation itself is unchanged: dev builds still report it, the message and
+its migration guidance are byte-identical, and production builds are still
+silent. Only the repetition is gone. The guard is a module-level `Set` keyed by
+type, and the production early-return happens *before* the set is marked, so a
+production render cannot suppress a later dev-build notice.

--- a/packages/components/src/__tests__/div-deprecation-warn-once.test.tsx
+++ b/packages/components/src/__tests__/div-deprecation-warn-once.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pins the once-semantics of the `div` deprecation notice (objectui#3965).
+ *
+ * `DivRenderer` used to `console.warn` on EVERY render. That is harmless on a
+ * page with one `div`, and destructive on a page with many: the docs
+ * schema-catalog index renders 400+ example thumbnails and emitted ~190
+ * identical notices, which buried the page's real console errors underneath —
+ * it twice cost a browser-verification run the signal it was looking for
+ * (#3903 / PR #3964 had to fish two nested-button errors out of the flood).
+ *
+ * What is pinned here is the DEDUPLICATION, not the removal of the warning:
+ * the deprecation still fires in dev builds, exactly once per module load.
+ *
+ * NOTE ON ORDER — the guard is a module-level Set, so it latches for the
+ * lifetime of this module instance. The production-silence case must therefore
+ * run BEFORE the dev case, and it doubles as a pin on the guard's ordering:
+ * the production early-return happens before the Set is marked, so a
+ * production render must not swallow a later dev notice.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+const DEPRECATION_RE = /The "div" component is deprecated/;
+
+function renderDiv(schema: Record<string, unknown>) {
+  const Component = ComponentRegistry.get('div');
+  if (!Component) throw new Error('Component "div" is not registered');
+  return render(<Component schema={schema} />);
+}
+
+function deprecationCalls(spy: ReturnType<typeof vi.spyOn>): unknown[][] {
+  return spy.mock.calls.filter((args) => DEPRECATION_RE.test(String(args[0])));
+}
+
+describe('div deprecation notice — once per module load (#3965)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  // MUST run first: see the note above. A production render may not mark the
+  // warn-once Set, otherwise it would suppress the dev notice that follows.
+  it('stays silent in production builds', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubEnv('NODE_ENV', 'production');
+
+    renderDiv({ type: 'div', className: 'p-4', children: [{ type: 'text', content: 'a' }] });
+
+    expect(deprecationCalls(warn)).toHaveLength(0);
+  });
+
+  it('warns exactly once however many div nodes render', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Three separate renders, and one of them nests three more `div` nodes:
+    // seven DivRenderer invocations in total, one notice expected.
+    renderDiv({ type: 'div', className: 'a' });
+    renderDiv({ type: 'div', className: 'b' });
+    renderDiv({
+      type: 'div',
+      className: 'outer',
+      children: [
+        {
+          type: 'div',
+          className: 'middle',
+          children: [
+            { type: 'div', className: 'inner-1' },
+            { type: 'div', className: 'inner-2' },
+          ],
+        },
+      ],
+    });
+
+    const calls = deprecationCalls(warn);
+    expect(calls).toHaveLength(1);
+    // The notice itself is unchanged — the deprecation is still being reported,
+    // with its migration guidance intact.
+    expect(String(calls[0][0])).toContain('"card", "flex", or semantic layout components');
+    expect(String(calls[0][0])).toContain('"container", "stack", or "grid"');
+  });
+
+  it('does not warn again on a later render', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderDiv({ type: 'div', className: 'later' });
+
+    expect(deprecationCalls(warn)).toHaveLength(0);
+  });
+});

--- a/packages/components/src/renderers/basic/div.tsx
+++ b/packages/components/src/renderers/basic/div.tsx
@@ -11,18 +11,44 @@ import type { DivSchema } from '@object-ui/types';
 import { renderChildren } from '../../lib/utils';
 import { forwardRef } from 'react';
 
+/**
+ * Deprecated types already reported in this module instance — the notice is a
+ * property of the TYPE, not of the node, so one report per page load is the
+ * whole signal. Mirrors the warn-once machinery in `layout/containers.tsx`.
+ */
+const _warnedDeprecations = new Set<string>();
+
+/**
+ * Report the deprecation ONCE per type per module load.
+ *
+ * The renderer used to warn on every single render, which turns any page with
+ * many `div` nodes into a console flood: the docs schema-catalog index renders
+ * 400+ example thumbnails and produced ~190 identical notices, burying the
+ * real errors underneath (it twice cost a browser-verification run the signal
+ * it was looking for — objectui#3965, discovered during #3903 / PR #3964).
+ *
+ * The deprecation itself is unchanged and still fires in dev builds; only the
+ * repetition is dropped. Order matters: the production check returns BEFORE the
+ * seen-set is marked, so a production render never suppresses the dev notice.
+ */
+function warnDeprecatedOnce(type: string, message: string): void {
+  if (process.env.NODE_ENV === 'production') return;
+  if (_warnedDeprecations.has(type)) return;
+  _warnedDeprecations.add(type);
+  console.warn(message);
+}
+
 const DivRenderer = forwardRef<HTMLDivElement, { schema: DivSchema; className?: string; [key: string]: any }>(
   ({ schema, className, ...props }, ref) => {
-    // Deprecation warning
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        '[ObjectUI] The "div" component is deprecated. Please use Shadcn components instead:\n' +
-        '  - For containers: use "card", "flex", or semantic layout components\n' +
-        '  - For simple wrappers: use layout components like "container", "stack", or "grid"\n' +
-        'See documentation at https://www.objectui.org/docs/components for alternatives.'
-      );
-    }
-    
+    // Deprecation warning (once per module load — see warnDeprecatedOnce)
+    warnDeprecatedOnce(
+      'div',
+      '[ObjectUI] The "div" component is deprecated. Please use Shadcn components instead:\n' +
+      '  - For containers: use "card", "flex", or semantic layout components\n' +
+      '  - For simple wrappers: use layout components like "container", "stack", or "grid"\n' +
+      'See documentation at https://www.objectui.org/docs/components for alternatives.'
+    );
+
     // Extract designer-related props
     const { 
         'data-obj-id': dataObjId, 


### PR DESCRIPTION
Fixes #3965

> ⚠️ **合并前请把上面的 `Fixes` 改成 `Refs`。** 本 PR 只落地 #3965 的**第二半**(`div.tsx` 的 warn 去重)。**第一半**(catalog 示例换掉废弃的 `div`)在现有组件词表下无法完整完成 —— 已带 file:line 证据升级给维护者定夺,见下面「第一半为什么没做」。按 `Fixes` 合并会把还有一半未做的 issue 自动关掉。

基 sha `0cbdca888`。

---

## 落地的:`div` 废弃提示改为每次模块加载只报一次

`packages/components/src/renderers/basic/div.tsx`

`DivRenderer` 原先在**每一次渲染**里 `console.warn`。单个 `div` 的页面看不出问题,`div` 多的页面就被刷成噪声墙:docs 的 schema-catalog 索引页渲染 400+ 个示例缩略图,catalog 里共 **189 个 `div` 节点**,于是刷出百来条完全相同的提示,把页面真正的报错埋在下面 —— #3903 / PR #3964 的两条嵌套按钮报错就是从这堆噪声里捞出来的,浏览器实证因此两次丢掉信号。

**废弃本身一字未动**:dev 构建照旧提示,文案与迁移建议逐字节不变,production 构建照旧静默;去掉的只是重复。守卫是模块级 `Set`(按 type 记,`span.tsx` 将来照抄同一形状即可),**production 的提前返回发生在标记之前** —— 所以一次 production 渲染不会吞掉后续 dev 构建的提示。这一条顺序是被测试钉住的,不是注释里的口头承诺。

### 钉子

`packages/components/src/__tests__/div-deprecation-warn-once.test.tsx`,3 条:

1. `stays silent in production builds` —— production 构建零提示,**且必须跑在最前**(守卫是模块级的,会 latch)。它同时钉住上面那条顺序:production 渲染不得标记 Set。
2. `warns exactly once however many div nodes render` —— 3 次 render、其中一次嵌 3 层共 6 个 `div` 节点,只允许 1 条提示;并断言文案里的两条迁移建议原样保留(证明钉的是「去重」而不是「删警告」)。
3. `does not warn again on a later render` —— 同一模块实例里后续渲染不再报。

### 反向验证(先预判,后执行)

预判:把无守卫的旧写法改回去,用例 1 应当**保持绿**(旧写法同样按 `NODE_ENV` 门控,production 本来就静默),用例 2、3 应当**翻红**。

实测与预判一致:

```
❯ |dom| packages/components/src/__tests__/div-deprecation-warn-once.test.tsx (3 tests | 2 failed)
     × warns exactly once however many div nodes render 19ms
     × does not warn again on a later render 3ms
AssertionError: expected [ …(9) ] to have a length of 1 but got 9
AssertionError: expected [ Array(1) ] to have a length of +0 but got 1
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

旧写法下实测 9 条(不是节点数 6 —— 提示条数取决于 React 的渲染次数,不是 schema 里的节点数)。这正是钉子在修好一侧断言「恰好 1 条」而不是断言某个具体刷屏条数的原因。变异未提交。

---

## 第一半为什么没做:现有词表里有一半 `div` 没有非废弃对等物

在基 sha 上重新量过(与分诊评论的 47 一致,issue 卡片的 48 是过时计数):**47 个文件、189 个 `div` 节点**。节点上出现过的键只有 `type` / `className` / `children` / `body` —— 没有 `id`、没有 `events`,它们全是纯样式包装。

按 className 里**是否真的写着布局意图**分类:

| 分类 | 节点数 | 有对等物? |
|---|---|---|
| className 含 `flex`(不含 `flex-col`) | 84 | 是 → `flex` |
| className 含 `space-y-*` | 9 | 是 → `stack` |
| className 含 `max-w-*` | 8 | 是 → `container` |
| className 含 `grid` / `grid-cols-*` | 5 | 是 → `grid` |
| **纯装饰盒子**(`p-4 h-full bg-slate-50`、`w-full h-12 rounded-md bg-primary mb-2`、`p-12 border rounded bg-gradient-to-r …`) | **61** | **否** |
| **完全没有 className 的分组包装** | **22** | **否** |

可换的 106 个,换不掉的 **83 个、散在 26 个文件里** —— 也就是说即使把能换的全换掉,**47 个文件里仍有 26 个含 `div`**。那不是「豁免清单」,那是这一半做不成。

### 为什么废弃提示自己给的建议都不是对等物

提示推荐 `card` / `flex` / `container` / `stack` / `grid`。逐个读渲染器:每一个都往 className 前面**注入类**,`div` 是唯一的透传:

- `layout/container.tsx:21-53` —— 注入 `w-full max-w-xl mx-auto p-2 sm:p-3 md:p-4`
- `layout/flex.tsx:22-55` —— 注入 `flex flex-row justify-start items-start gap-1.5 sm:gap-2`
- `layout/stack.tsx:25-58` —— 注入 `flex flex-col justify-start items-stretch gap-*`
- `layout/grid.tsx:91-103` —— 注入 `grid grid-cols-* gap-*`
- `layout/card.tsx:36-56` —— `Card` 自带 border / shadow / rounded,children 还被塞进 `CardContent`(自带 padding)

对 8 个空的颜色色板(`theme/semantic-color-palette.json` 里 `w-full h-12 rounded-md bg-primary mb-2` 这种、无 children)来说,以上每一个都会**改变渲染**:凭空多出边框、flex 上下文或 max-width。

唯一逐字节等价的是 `layout/semantic.tsx:13-47` —— `article` / `aside` / `main` / `nav` / `section` / `header` / `footer` 就是 `className` + `children || body` 的裸透传(bare `section`/`header`/`footer` 由它拿走:`containers.tsx` 那三个注册的是 `page:*` 且 `skipFallback: true`,不冲突)。但它们是 **sectioning / landmark 元素**:`main` 标签在一个文档里必须唯一,而 docs 页面是把示例嵌进去渲染的;把 22 个「没有 className 的分组包装」和 8 个空色板写成 `section`,等于把「用 sectioning 元素当通用盒子」这条**写进 45 个文档范本**。issue 的立论正是「范本的示范价值」—— 用一个错范本换掉另一个错范本,不解决问题。

### 而且 `div` 结构上退不掉

`kind: 'html'` 那一层作者面(ADR-0080)会**把标签名原样变成 type**:

- `sdui-parser/src/parse.ts:85` —— `const node: SchemaElement = { type: tag, ...props }`
- `sdui-parser/src/index.ts:33` —— `allowedTags = new Set(Object.keys(manifest.components))`
- `components/src/renderers/layout/page.tsx:438-470` —— 白名单由 `ComponentRegistry.getKnownTypes()` 生成,裸 `div` 在内
- `basic/html-elements.tsx:15,36` —— 自己的 TAGS 列表**故意排除** div,注释写明「div 已在别处注册」

所以一个 `kind: 'html'` 页面里写一个 div 标签,编译出的就是 `{ "type": "div" }`,照样打到废弃渲染器上。**`div` 是 html tier 词表的必需成员,不可退休** —— 于是「零 `div`」在本仓永远不可能是一条全仓不变量,而这条废弃提示会永久地对引擎自己解析器的输出开火。

另外查了 `@objectstack/spec`:`element:*` 词表里既没有 `div` 也没有 `box`,`div` 是 objectui 本地词表(`ui` 命名空间)的东西 —— 所以这不是 spec 层的取舍,是本仓自己的公共契约取舍。

### 请维护者定夺的三个选项

**A. 补一个中性容器类型(如 `box`)。** 注册表 + `@object-ui/types` schema + docs + parser 白名单一并落。之后 189 个节点 `div` → `box` 是一次**零渲染差异、机械可验**的替换,catalog 才可能真的零 `div`。
- *长期健康度*:高。废弃一个类型却没给替代品,本来就是这条废弃没做完 —— 补上替代品是把契约补完整,不是绕过它。
- *让 AI 写的 metadata 不容易写错*:高。作者面得到一个**名字就说明「我只是个盒子」**的类型,不必在 `container`(悄悄加 max-width)和 `section`(悄悄加 landmark 语义)之间猜。
- *代价*:新增公共类型;`div` 的废弃需要重新指向 `box`。

**B. 收窄这条废弃,承认残余 `div` 合法。** JSON 作者面继续劝退;html tier 的解析产物不再报废弃;catalog 里 106 个**明确写着**布局意图的节点转成 `flex`/`stack`/`grid`/`container`(那 106 个是纯赚:JSON 手写 Tailwind 复刻一等公民组件的 props,本来就该用 props);余下 83 个保留 `div`。
- *长期健康度*:中。诚实地承认 `div` 退不掉,但留下「一个废弃类型永久合法」这一含糊状态。
- *让 AI 写的 metadata 不容易写错*:中。提示不再对 html tier 误伤是净收益,但作者仍要自己判断「这个 `div` 属于劝退的那批还是合法的那批」。
- *代价*:最小改动,不动公共词表。

**C. 强推 semantic 标签。** 83 个残余全换 `section` / `article`。
- *长期健康度*:低。词表不用动,但把「sectioning 元素 = 通用盒子」写进 45 个文档范本,a11y 与文档大纲语义都变差,而且 `div` 在 html tier 依然会被解析出来 —— 提示照旧刷。
- *让 AI 写的 metadata 不容易写错*:**负**。这是最典型的「照着范本抄」放大错误的路径:AI 会学到用 landmark 元素包一切。
- *代价*:表面上最省,实际把成本转移给未来的每一个作者。

**推荐:短期 B,长期 A。** 两轴一致指向「先把误伤 html tier 的部分收窄 + 把 106 个明确布局意图转成 props(这批与词表决定无关,任何选项下都成立),同时把 `box` 作为把这条废弃真正做完的方向」。**明确不推荐 C** —— 它在第二轴上是负的,而第二轴正是这个 issue 的立论。

选定之后我可以把对应的 sweep 单独接着做;现在不猜,因为三个选项指向的 diff 形状完全不同(A 是 189 个节点一行改一个字;B 是 106 个节点重写成 props;C 是 83 个节点换 sectioning 标签),猜错要全部推倒。

---

## 验证

- `pnpm --workspace-concurrency=2 --filter "@object-ui/components^..." build` —— 绿(新 worktree 先建依赖)。
- `pnpm exec vitest run packages/components/src/__tests__/div-deprecation-warn-once.test.tsx packages/components/src/__tests__/basic-renderers.test.tsx examples/schema-catalog --maxWorkers=2` —— `Test Files 6 passed (6) / Tests 1115 passed (1115)`。
- `pnpm exec turbo run type-check --filter=@object-ui/components --concurrency=2` —— `Tasks: 8 successful, 8 total`。
- `node scripts/check-control-bytes.mjs` —— `OK (scanned 3902 tracked text file(s))`;改动文件另做了越过门禁盲区的自查,零命中。
- `node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs` —— 均绿。

## 边界

只动了 `packages/components/src/renderers/basic/div.tsx` + 一个新测试 + 一个 changeset。**没有**碰 `examples/schema-catalog/**`(含同批 #3968 的 test/tsconfig/scripts 面)、**没有**碰 26 个 MDX 文档页、**没有**碰 `content/docs/releases/`。`basic/span.tsx` 带同族的逐次渲染警告(catalog 里 `span` 命中 0),按派发边界未动 —— 它该照抄本 PR 的守卫形状,留作后续。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_