### PR TITLE
fix(fields): group-labelled widget 的只读/零选项分支也消费 host label 的 IDREF (#3990)

### DIFF
--- a/.changeset/fields-readonly-group-label-idref-3990.md
+++ b/.changeset/fields-readonly-group-label-idref-3990.md
@@ -1,0 +1,57 @@
+---
+"@object-ui/fields": patch
+---
+
+Group-labelled field widgets now consume the host label's IDREF in their readonly and zero-option states, so the visible label names something there too
+
+A field declared `labelling: 'group'` (objectui#3961) is named by IDREF: the form
+renderer publishes its `<FormLabel>`'s own `id`, drops the inert `for`, and hands
+the widget `aria-labelledby` plus the host control `id`. All seven such widgets
+consumed that pair on their editable surface only. A field-level
+`readonly: true`, and an option list that resolved to zero offered options, take
+early returns that render before the container doing the consuming — so the label
+published an id that no element in the document referenced.
+
+Measured on the previous `main`, one field per row in a real form, counting the
+elements that reference the host label's published id:
+
+```
+                             consumers  byLabelText  named group
+multiselect  readonly+value      0           0           0
+multiselect  readonly+empty      0           0           0
+multiselect  zeroOptions         0           0           0
+multiselect  editable            1           1           1
+```
+
+All seven measured identically in every readonly state; each is 1 now. The
+user-visible effect is the one objectui#3961 fixed for editable fields: the
+visible label was the accessible name of NOTHING, so a readonly "Tags" or
+"Shipping Address" was announced as loose text next to unattributed values. It is
+not a regression of #3961 or objectui#3975 — before them these same states
+emitted a `for` pointing at an id no element carried, which named nothing either.
+The shape changed from a dangling `for` to an unconsumed IDREF; the defect did
+not.
+
+Each readonly surface now carries exactly two keys — the host `id` and
+`aria-labelledby` — plus the `role="group"` that makes them meaningful, in one
+shared spelling (`toHostGroupProps`). The narrow pair is deliberate: a readonly
+display has no focusable control, so `aria-describedby` / `aria-required` /
+`disabled` / the focus handlers have nothing to announce on, and `name` on a
+`div` is exactly the DOM leak objectui#3291 sweeps for.
+
+Two widgets answer with a different role than they do while editable, because
+they render a different surface: `radio` (editable `radiogroup`) shows the chosen
+option's label as text with no radios in it, and `file` (editable `button`, the
+dropzone) shows file names with no dropzone. `role="group"` is also what the
+shared "no options available" box now answers with for `checkboxes` / `radio` /
+`multiselect`; the single `select` is not group-labelled, keeps its working
+`for`, and that box emits nothing new for it.
+
+Standalone rendering is untouched. The grid's inline cell editor and bare SDUI
+nodes hand down neither key, so nothing is emitted and the markup stays
+byte-identical — including the `EmptyValue` placeholder, which keeps its own
+`aria-label` and gains no role. Hosted-and-empty, that placeholder is the whole
+readonly surface, so it carries the group props: its `aria-label` ("No value") is
+then outranked by `aria-labelledby` per accname, which is the intended outcome —
+on the `generic` role that span carries, an author name is prohibited and was
+never exposed, so the choice was between the field's name and no name.

--- a/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
+++ b/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
@@ -1,0 +1,403 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * End-to-end: a group-labelled field's visible label names the widget's surface
+ * in EVERY state it renders — not only the editable one (objectui#3990).
+ *
+ * The residual of objectui#3961 / #3975. Those two moved the association from an
+ * inert `<label for>` to the WAI-ARIA group pattern (the label publishes its own
+ * `id`, the widget answers with `aria-labelledby` + a role that can carry a
+ * name), and pinned it in `composite-group-label-e2e.test.tsx` — entirely on
+ * EDITABLE samples. Every one of these widgets also returns EARLY, before the
+ * container that consumes that IDREF, for a field-level `readonly: true` and for
+ * an option list that resolved to zero offered options. Measured on
+ * `origin/main` with a real form + the same bare registration this file uses,
+ * counting the elements that reference the host label's published id:
+ *
+ * ```
+ *                              consumers  byLabelText  namedByRole
+ * multiselect  readonly+value      0           0          []
+ * multiselect  readonly+empty      0           0          []
+ * multiselect  zeroOptions         0           0          []
+ * multiselect  editable            1           1          [group:1]     ← #3975
+ * ```
+ *
+ * All seven types measured identically, in every readonly state. Both `for`-less
+ * halves of the association were dropped by those returns, so the visible label
+ * was the accessible name of NOTHING — the same user-visible outcome #3961
+ * fixed, in the states its probe never sampled. It is not a regression of either
+ * PR: before #3961 the same states rendered a `for` pointing at an id no element
+ * carried, which named nothing either. The shape changed; the defect did not.
+ *
+ * ## Why the role is `group` here even where the editable branch says otherwise
+ *
+ * `aria-labelledby` on a role-less `div` / `span` names nothing (`generic`
+ * prohibits an author name), so the readonly surface needs a role that supports
+ * naming, and `group` is the only one that does not lie about interactivity:
+ *
+ *  - `radio` answers `radiogroup` while editable, but its readonly branch renders
+ *    the CHOSEN option's label as text — there is not one radio left in it;
+ *  - `file` answers `button` while editable (the dropzone is its single control),
+ *    but readonly there is no dropzone, only the file names.
+ *
+ * So the roles this file expects deliberately differ from `HOSTED` in the
+ * editable e2e for exactly those two, and the last describe block pins that the
+ * editable answers are untouched.
+ *
+ * The widgets are registered raw rather than through `registerAllFields()`, whose
+ * `React.lazy` loaders put an unbounded module load inside a bounded `findBy`
+ * window — this repo's known flake generator (AGENTS.md 测试纪律, objectui#3010).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { AddressField } from '../widgets/AddressField';
+import { GeolocationField } from '../widgets/GeolocationField';
+import { CheckboxesField } from '../widgets/CheckboxesField';
+import { RadioField } from '../widgets/RadioField';
+import { RatingField } from '../widgets/RatingField';
+import { FileField } from '../widgets/FileField';
+import { MultiSelectField } from '../widgets/MultiSelectField';
+import { SelectField } from '../widgets/SelectField';
+
+const WIDGETS: Record<string, any> = {
+  address: AddressField,
+  geolocation: GeolocationField,
+  checkboxes: CheckboxesField,
+  radio: RadioField,
+  rating: RatingField,
+  file: FileField,
+  multiselect: MultiSelectField,
+};
+
+/** The option widgets — the only ones with a zero-option state to measure. */
+const OPTION_TYPES = ['checkboxes', 'radio', 'multiselect'] as const;
+
+/**
+ * Where the placeholder sits when a readonly field has no value. Three real
+ * shapes, so the assertion is per-widget rather than one presumed form:
+ *
+ *  - `'is-placeholder'`: the whole surface IS `EmptyValue`, which therefore
+ *    carries the group props itself;
+ *  - `'contains-placeholder'`: `geolocation` keeps its icon row and renders the
+ *    placeholder inside it, so the row is the named group;
+ *  - `'no-placeholder'`: `rating` has no empty state at all — an unset rating
+ *    renders the same "0 / max" star row.
+ */
+const EMPTY_SHAPE: Record<string, 'is-placeholder' | 'contains-placeholder' | 'no-placeholder'> = {
+  address: 'is-placeholder',
+  checkboxes: 'is-placeholder',
+  radio: 'is-placeholder',
+  file: 'is-placeholder',
+  multiselect: 'is-placeholder',
+  geolocation: 'contains-placeholder',
+  rating: 'no-placeholder',
+};
+
+const OPTIONS = [
+  { label: 'Alpha', value: 'a' },
+  { label: 'Beta', value: 'b' },
+];
+
+/** A stored value per type, so the readonly branch renders its filled shape. */
+const VALUES: Record<string, unknown> = {
+  address: { street: '1 Main St', city: 'Springfield' },
+  geolocation: { latitude: 1.5, longitude: 2.5 },
+  checkboxes: ['a'],
+  radio: 'a',
+  rating: 3,
+  file: { id: 'f1', name: 'report.pdf' },
+  multiselect: ['a'],
+};
+
+/** The role the EDITABLE branch answers with — unchanged by this issue. */
+const EDITABLE_ROLE: Record<string, string> = {
+  address: 'group',
+  geolocation: 'group',
+  checkboxes: 'group',
+  radio: 'radiogroup',
+  rating: 'group',
+  file: 'button',
+  multiselect: 'group',
+};
+
+const TYPES = Object.keys(WIDGETS);
+
+beforeAll(() => {
+  for (const [type, Component] of Object.entries(WIDGETS)) {
+    ComponentRegistry.register(type, Component as any, {
+      namespace: 'field',
+      skipFallback: true,
+      // The declaration under test, mirroring `FIELD_TYPES_GROUP_LABELLED`.
+      labelling: 'group',
+    });
+  }
+}, 30000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** HTML's labelable elements — the only ones a `<label for>` can address. */
+const LABELABLE = new Set(['button', 'input', 'meter', 'output', 'progress', 'select', 'textarea']);
+
+function labelTargets(): Array<{ forId: string; resolves: boolean; labelable: boolean }> {
+  return Array.from(document.querySelectorAll('label'))
+    .map((el) => {
+      const forId = el.getAttribute('for') ?? '';
+      const target = forId ? document.getElementById(forId) : null;
+      return {
+        forId,
+        resolves: !!target,
+        labelable: !!target && LABELABLE.has(target.tagName.toLowerCase()),
+      };
+    })
+    .filter((l) => l.forId !== '');
+}
+
+function fieldConfig(
+  type: string,
+  opts: { readonly?: boolean; zeroOptions?: boolean } = {},
+): Record<string, unknown> {
+  const config: any = { name: `f_${type}`, label: `Group Label ${type}`, type };
+  if ((OPTION_TYPES as readonly string[]).includes(type)) {
+    config.options = opts.zeroOptions ? [] : OPTIONS;
+  }
+  // Field-level readonly — the state this issue is about. NOT the form-level
+  // `mode: 'view'`, which renders a different (detail) path and was already
+  // naming its group correctly.
+  if (opts.readonly) config.readonly = true;
+  return config;
+}
+
+/** The real form renderer hosting one field — the #3990 reproduction. */
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        defaultValues,
+        fields,
+      }}
+    />,
+  );
+}
+
+const hostLabelOf = (name: string): HTMLLabelElement => {
+  const el = document.querySelector(`[data-field="${name}"] > label`);
+  if (!el) throw new Error(`no host label rendered for field "${name}"`);
+  return el as HTMLLabelElement;
+};
+
+describe('a READONLY group-labelled field is named by its host label (objectui#3990)', () => {
+  it.each(TYPES)('%s: the host label names the readonly surface', (type) => {
+    renderForm([fieldConfig(type, { readonly: true })], { [`f_${type}`]: VALUES[type] });
+
+    // 0 before this fix, 1 after — for all seven, whatever their readonly shape.
+    const named = screen.getAllByRole('group', { name: `Group Label ${type}` });
+    expect(named).toHaveLength(1);
+    // The same association read from the other side.
+    expect(screen.getAllByLabelText(`Group Label ${type}`)).toEqual(named);
+  });
+
+  it.each(TYPES)('%s: the readonly surface is the element the host handed its id to', (type) => {
+    // The name and the host id must land on the SAME element, as in the editable
+    // path: the readonly branches dropped BOTH, so the `…-form-item` id existed
+    // on no element in the document.
+    renderForm([fieldConfig(type, { readonly: true })], { [`f_${type}`]: VALUES[type] });
+
+    const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    expect(named.getAttribute('id')).toMatch(/-form-item$/);
+  });
+
+  it.each(TYPES)('%s: readonly with NO value names the placeholder surface', (type) => {
+    renderForm([fieldConfig(type, { readonly: true })]);
+
+    const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    const shape = EMPTY_SHAPE[type];
+    if (shape === 'is-placeholder') {
+      // `EmptyValue` itself is the field's whole surface here. Its own
+      // `aria-label` ("No value") stays in the markup and is outranked by
+      // `aria-labelledby` per accname — on the `generic` role it carried before
+      // this change, that author name was not exposed at all.
+      expect(named).toHaveAttribute('data-slot', 'empty-value');
+      expect(named).toHaveAccessibleName(`Group Label ${type}`);
+    } else if (shape === 'contains-placeholder') {
+      expect(named.querySelector('[data-slot="empty-value"]')).not.toBeNull();
+    } else {
+      // `rating` has no empty state: an unset rating is the same star row.
+      expect(named.querySelector('[data-slot="empty-value"]')).toBeNull();
+      expect(named.textContent).toContain('0 / 5');
+    }
+  });
+
+  it.each(TYPES)('%s: the host label still emits an id and no `for` when readonly', (type) => {
+    renderForm([fieldConfig(type, { readonly: true })], { [`f_${type}`]: VALUES[type] });
+
+    const label = hostLabelOf(`f_${type}`);
+    expect(label).not.toHaveAttribute('for');
+    expect(label.id).not.toBe('');
+    // A dangling IDREF fails silently, which reads exactly like success.
+    expect(document.getElementById(label.id)).toBe(label);
+    // And no OTHER label in the field is left with an inert/dangling `for`.
+    expect(labelTargets().filter((l) => !l.resolves || !l.labelable)).toEqual([]);
+  });
+
+  it.each(TYPES)('%s: the readonly surface takes the two whole-field keys ONLY', (type) => {
+    // The narrow pair is deliberate (`toHostGroupProps`): a readonly display has
+    // no focusable control, so control-only plumbing must not ride along. `name`
+    // is the one that would be a DOM leak of the objectui#3291 class — it is
+    // legal on form controls only, and these surfaces are `div` / `span`.
+    renderForm([{ ...fieldConfig(type, { readonly: true }), description: 'Some help' }], {
+      [`f_${type}`]: VALUES[type],
+    });
+
+    const named = screen.getByRole('group', { name: `Group Label ${type}` });
+    expect(named).not.toHaveAttribute('name');
+    expect(named).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('all seven readonly in ONE form: each is named exactly once', () => {
+    const fields = TYPES.map((type) => fieldConfig(type, { readonly: true }));
+    const values = Object.fromEntries(TYPES.map((type) => [`f_${type}`, VALUES[type]]));
+    renderForm(fields, values);
+
+    for (const type of TYPES) {
+      expect(screen.getAllByRole('group', { name: `Group Label ${type}` })).toHaveLength(1);
+    }
+    expect(labelTargets().filter((l) => !l.resolves || !l.labelable)).toEqual([]);
+  });
+});
+
+describe('a ZERO-OPTION group-labelled field is named by its host label (objectui#3990)', () => {
+  it.each(OPTION_TYPES)('%s: the unfillable-options box is the named group', (type) => {
+    renderForm([fieldConfig(type, { zeroOptions: true })]);
+
+    const named = screen.getAllByRole('group', { name: `Group Label ${type}` });
+    expect(named).toHaveLength(1);
+    // The named element is the shared `OptionsEmptyState` box, not some ancestor:
+    // in this state it is the only thing the widget renders.
+    expect(named[0]).toBe(screen.getByTestId(`${type}-empty-f_${type}`));
+    expect(named[0].getAttribute('id')).toMatch(/-form-item$/);
+    expect(screen.getAllByLabelText(`Group Label ${type}`)).toEqual(named);
+  });
+
+  it.each(OPTION_TYPES)('%s: readonly wins over zero options, and is still named', (type) => {
+    // Both early returns at once. The readonly branch comes first, so the
+    // measured surface is the readonly one — and it must still be named.
+    renderForm([fieldConfig(type, { readonly: true, zeroOptions: true })], {
+      [`f_${type}`]: VALUES[type],
+    });
+
+    expect(screen.getAllByRole('group', { name: `Group Label ${type}` })).toHaveLength(1);
+    expect(screen.queryByTestId(`${type}-empty-f_${type}`)).toBeNull();
+  });
+});
+
+describe('the editable answers are untouched (objectui#3961 / #3975 regression)', () => {
+  it.each(TYPES)('%s: editable keeps its own role, readonly answers `group`', (type) => {
+    // The drift pin: one widget, two surfaces, both named. `radio` and `file`
+    // deliberately answer with DIFFERENT roles in the two states, so a future
+    // "unify the roles" edit has to come here and say which it broke.
+    renderForm([fieldConfig(type)], { [`f_${type}`]: VALUES[type] });
+    expect(
+      screen.getAllByRole(EDITABLE_ROLE[type], { name: `Group Label ${type}` }),
+    ).toHaveLength(1);
+    cleanup();
+
+    renderForm([fieldConfig(type, { readonly: true })], { [`f_${type}`]: VALUES[type] });
+    expect(screen.getAllByRole('group', { name: `Group Label ${type}` })).toHaveLength(1);
+  });
+});
+
+describe('STANDALONE readonly widgets are unchanged (objectui#3990)', () => {
+  // `FieldEditWidget` (the grid's inline cell editor) and bare SDUI nodes hand
+  // down no id and no host label, so there is nothing to associate and nothing
+  // may be emitted: an unnamed `role="group"` announces a container with no name
+  // to give, and an id nobody asked for can collide with the page's own.
+
+  it.each(TYPES)('%s: no role, no IDREF, no id', (type) => {
+    const Widget = WIDGETS[type];
+    render(
+      <Widget
+        value={VALUES[type]}
+        onChange={() => {}}
+        readonly
+        field={{
+          name: type,
+          label: `Group Label ${type}`,
+          type,
+          ...((OPTION_TYPES as readonly string[]).includes(type) ? { options: OPTIONS } : null),
+        }}
+      />,
+    );
+
+    expect(screen.queryAllByRole('group')).toHaveLength(0);
+    expect(document.querySelector('[aria-labelledby]')).toBeNull();
+    expect(document.querySelector('[id]')).toBeNull();
+  });
+
+  it.each(TYPES)('%s: no value, still nothing emitted', (type) => {
+    const Widget = WIDGETS[type];
+    render(
+      <Widget
+        value={undefined}
+        onChange={() => {}}
+        readonly
+        field={{
+          name: type,
+          label: `Group Label ${type}`,
+          type,
+          ...((OPTION_TYPES as readonly string[]).includes(type) ? { options: OPTIONS } : null),
+        }}
+      />,
+    );
+
+    expect(screen.queryAllByRole('group')).toHaveLength(0);
+    expect(document.querySelector('[aria-labelledby]')).toBeNull();
+    // The placeholder keeps its own name and gains no role it was not given.
+    const placeholder = document.querySelector('[data-slot="empty-value"]');
+    if (placeholder) expect(placeholder).not.toHaveAttribute('role');
+  });
+
+  it('the shared options-empty box emits nothing for a widget that is not group-labelled', () => {
+    // The positive control for `OptionsEmptyState`'s new prop. The single
+    // `SelectField` is NOT in `FIELD_TYPES_GROUP_LABELLED` — its label keeps a
+    // plain, working `for` — so the shared box must stay attribute-for-attribute
+    // what it was: no `role`, no IDREF, no host id.
+    render(
+      <SelectField
+        value={undefined}
+        onChange={() => {}}
+        field={{ name: 'stage', label: 'Stage', type: 'select', options: [] } as any}
+      />,
+    );
+
+    const box = screen.getByTestId('select-empty-stage');
+    expect(box).not.toHaveAttribute('role');
+    expect(box).not.toHaveAttribute('aria-labelledby');
+    expect(box).not.toHaveAttribute('id');
+  });
+});

--- a/packages/fields/src/widgets/AddressField.tsx
+++ b/packages/fields/src/widgets/AddressField.tsx
@@ -2,6 +2,7 @@ import React, { useId } from 'react';
 import { Input, Label, EmptyValue } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 
 /**
  * Address data structure — the part names of `@objectstack/spec`'s
@@ -72,10 +73,15 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
   // stays on the first sub-input: a description or error must be announced when
   // focus lands on something focusable, and a container is not.
   const {
-    id: hostId,
-    'aria-labelledby': hostLabelledBy,
+    id: _hostId,
+    'aria-labelledby': _hostLabelledBy,
     ...domProps
   } = toDomProps(props);
+  // The pair held back above, in the one spelling every group-labelled widget
+  // uses for it — and computed HERE, before the readonly early return below,
+  // because that return used to drop both keys on the floor: a published label
+  // id with no consumer in the document (objectui#3990). See `toHostGroupProps`.
+  const hostGroupProps = toHostGroupProps(props);
   // Sub-input ids (objectui#3343): `useId()` prefix + sub-field name — the
   // `groupId` paradigm of RadioField / CheckboxesField. Hardcoded literals
   // ("street", "city", …) collide as soon as a form renders two address
@@ -112,21 +118,28 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
   };
 
   if (readonly) {
+    // Readonly the composite collapses to ONE formatted line — no sub-inputs and
+    // no sub-labels — so that line is the surface the host label names, and
+    // `EmptyValue` is the same surface with nothing in it (objectui#3990). The
+    // placeholder's own `aria-label` ("No value") is outranked by
+    // `aria-labelledby` per accname, and on its `generic` role an author name was
+    // never exposed anyway.
     const formatted = formatAddress(address);
-    return formatted ? <span className="text-sm">{formatted}</span> : <EmptyValue />;
+    return formatted ? (
+      <span {...hostGroupProps} className="text-sm">{formatted}</span>
+    ) : (
+      <EmptyValue {...hostGroupProps} />
+    );
   }
 
   return (
     // `role="group"` only when a host actually named this container
     // (objectui#3961): an unnamed group adds nothing for assistive tech, and
     // standalone rendering — the inline grid editor, a bare SDUI node — must stay
-    // byte-identical to what it was before.
-    <div
-      className="space-y-3"
-      id={hostId}
-      role={hostLabelledBy ? 'group' : undefined}
-      aria-labelledby={hostLabelledBy}
-    >
+    // byte-identical to what it was before. That condition now lives in
+    // `toHostGroupProps` so this container and the readonly line above cannot
+    // answer differently (objectui#3990).
+    <div className="space-y-3" {...hostGroupProps}>
       <div>
         <Label htmlFor={subId('street')} className="text-xs">Street Address</Label>
         <Input

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -3,6 +3,7 @@ import { Checkbox, Label, EmptyValue, Badge } from '@object-ui/components';
 import type { OptionLike } from '@object-ui/core';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 import { OptionsEmptyState } from './OptionsEmptyState';
 import { useCascadingOptions } from './useCascadingOptions';
 
@@ -57,10 +58,22 @@ export function CheckboxesField({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, gated]);
 
+  // The host's group label has to be consumed on EVERY surface this widget can
+  // render, not only the editable one (objectui#3990): both branches below
+  // return before the editable container's `groupDomProps` spread, which is how
+  // a field-level `readonly: true` and a zero-option list ended up with a
+  // published label id and no consumer at all. See `toHostGroupProps`.
+  const hostGroupProps = toHostGroupProps(props);
+
   if (readonly) {
-    if (selected.length === 0) return <EmptyValue />;
+    // The readonly display of a checkbox set is the set of CHECKED labels — a
+    // set of values, so the same `group` answer as the editable list.
+    // `EmptyValue` is that surface with nothing in it; its own `aria-label`
+    // ("No value") is outranked by `aria-labelledby` per accname, and on the
+    // `generic` role that span carries it was never exposed anyway.
+    if (selected.length === 0) return <EmptyValue {...hostGroupProps} />;
     return (
-      <div className="flex flex-wrap gap-1">
+      <div {...hostGroupProps} className="flex flex-wrap gap-1">
         {selected.map((v) => {
           // Label from the raw set so a stored value hidden by `visibleWhen`
           // still renders its label rather than a bare id.
@@ -83,6 +96,9 @@ export function CheckboxesField({
         dependsOnFields={dependsOnFields}
         testId={fieldName ? `checkboxes-empty-${fieldName}` : undefined}
         className="min-h-9"
+        // This box IS the field in this state, so it is what the host label
+        // names (objectui#3990).
+        hostGroupProps={hostGroupProps}
       />
     );
   }

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -5,6 +5,7 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { Upload, X, File as FileIcon, ImageIcon, Camera, Loader2 } from 'lucide-react';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 import { useUploadingSignal } from './useUploadingSignal';
 import {
   fileValueForSubmit,
@@ -184,10 +185,18 @@ export function FileField({ value, onChange, field, readonly, onUploadingChange,
   }, [accept, processFiles]);
 
   if (readonly) {
-    if (!value) return <EmptyValue />;
+    // Readonly there is no dropzone: the field's whole rendered surface is the
+    // list of file names, so THAT is what the host's group label names
+    // (objectui#3990). The role is therefore `group` here and `button` (the
+    // dropzone) while editable — the same widget, two different surfaces. See
+    // `toHostGroupProps`; `EmptyValue`'s own `aria-label` ("No value") is
+    // outranked by `aria-labelledby` per accname, and on the `generic` role that
+    // placeholder span carries it was never exposed as a name anyway.
+    const hostGroupProps = toHostGroupProps(props);
+    if (!value) return <EmptyValue {...hostGroupProps} />;
 
     return (
-      <div className="flex flex-wrap gap-2">
+      <div {...hostGroupProps} className="flex flex-wrap gap-2">
         {views.map((file, idx) => (
           <span key={idx} className="text-sm truncate max-w-xs">
             {file.name}

--- a/packages/fields/src/widgets/GeolocationField.tsx
+++ b/packages/fields/src/widgets/GeolocationField.tsx
@@ -3,6 +3,7 @@ import { Input, Button, Label, EmptyValue } from '@object-ui/components';
 import { MapPin, Crosshair } from 'lucide-react';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 
 /**
  * Geolocation data structure
@@ -32,10 +33,15 @@ export function GeolocationField({ value, onChange, field, readonly, error, ...p
   // OVERRIDE its own "Latitude" label with the field name. `aria-describedby` and
   // the rest stay on the first sub-input, where focus can reach them.
   const {
-    id: hostId,
-    'aria-labelledby': hostLabelledBy,
+    id: _hostId,
+    'aria-labelledby': _hostLabelledBy,
     ...domProps
   } = toDomProps(props);
+  // The pair held back above, in the one spelling every group-labelled widget
+  // uses for it — and computed HERE, before the readonly early return below,
+  // because that return used to drop both keys on the floor: a published label
+  // id with no consumer in the document (objectui#3990). See `toHostGroupProps`.
+  const hostGroupProps = toHostGroupProps(props);
   // Sub-input ids (objectui#3343): `useId()` prefix + sub-field name — the
   // `groupId` paradigm of RadioField / CheckboxesField. Hardcoded literals
   // ("latitude" / "longitude") collide as soon as a form renders two
@@ -91,9 +97,13 @@ export function GeolocationField({ value, onChange, field, readonly, error, ...p
   };
 
   if (readonly) {
+    // Readonly the composite collapses to the formatted coordinates (plus the
+    // "View on map" link), so THAT row is the surface the host label names
+    // (objectui#3990). The `EmptyValue` placeholder sits inside it, so it needs
+    // nothing of its own.
     const formatted = formatLocation(location);
     return (
-      <div className="flex items-center gap-2">
+      <div {...hostGroupProps} className="flex items-center gap-2">
         <MapPin className="w-4 h-4 text-muted-foreground" />
         {formatted ? <span className="text-sm">{formatted}</span> : <EmptyValue />}
         {location.latitude && location.longitude && (
@@ -113,13 +123,10 @@ export function GeolocationField({ value, onChange, field, readonly, error, ...p
 
   return (
     // `role="group"` only when a host actually named this container
-    // (objectui#3961); standalone rendering stays exactly as it was.
-    <div
-      className="space-y-3"
-      id={hostId}
-      role={hostLabelledBy ? 'group' : undefined}
-      aria-labelledby={hostLabelledBy}
-    >
+    // (objectui#3961); standalone rendering stays exactly as it was. That
+    // condition now lives in `toHostGroupProps` so this container and the
+    // readonly row above cannot answer differently (objectui#3990).
+    <div className="space-y-3" {...hostGroupProps}>
       <div className="flex items-center gap-2">
         <Button
           type="button"

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -3,6 +3,7 @@ import { Badge, EmptyValue, cn } from '@object-ui/components';
 import type { OptionLike } from '@object-ui/core';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 import { OptionsEmptyState } from './OptionsEmptyState';
 import { useCascadingOptions } from './useCascadingOptions';
 
@@ -58,10 +59,23 @@ export function MultiSelectField({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, gated]);
 
+  // The host's group label has to be consumed on EVERY surface this widget can
+  // render, not only the editable one (objectui#3990): both branches below
+  // return before the editable container's `groupDomProps` spread, which is how
+  // a field-level `readonly: true` and a zero-option list ended up with a
+  // published label id and no consumer at all. See `toHostGroupProps`.
+  const hostGroupProps = toHostGroupProps(props);
+
   if (readonly) {
-    if (selected.length === 0) return <EmptyValue />;
+    // A readonly set of values is still a set, so it takes the same `group`
+    // answer the editable chip row gives. `EmptyValue` is that surface with
+    // nothing in it: it publishes an `aria-label` ("No value") of its own, and
+    // `aria-labelledby` outranks that per accname — correctly, because on the
+    // `generic` role that placeholder span carries, an author name is prohibited
+    // and never exposed, so the real choice is the field's name or no name.
+    if (selected.length === 0) return <EmptyValue {...hostGroupProps} />;
     return (
-      <div className="flex flex-wrap gap-1">
+      <div {...hostGroupProps} className="flex flex-wrap gap-1">
         {selected.map((v) => {
           // Label from the raw set so a stored value hidden by `visibleWhen`
           // still renders its label rather than a bare id.
@@ -84,6 +98,9 @@ export function MultiSelectField({
         dependsOnFields={dependsOnFields}
         testId={fieldName ? `multiselect-empty-${fieldName}` : undefined}
         className="min-h-9"
+        // This box IS the field in this state, so it is what the host label
+        // names (objectui#3990).
+        hostGroupProps={hostGroupProps}
       />
     );
   }

--- a/packages/fields/src/widgets/OptionsEmptyState.tsx
+++ b/packages/fields/src/widgets/OptionsEmptyState.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { cn } from '@object-ui/components';
 import { useFieldTranslation } from './useFieldTranslation';
+import type { HostGroupProps } from './toHostGroupProps';
 
 /**
  * The "this option list cannot be filled" state shared by every fixed-option
@@ -52,6 +53,19 @@ export interface OptionsEmptyStateProps {
   testId?: string;
   /** Widget-specific sizing (the dropdown is a fixed `h-9`, lists grow). */
   className?: string;
+  /**
+   * The host label's IDREF plumbing, when this box is the whole rendered surface
+   * of a group-labelled field (objectui#3990) — a `checkboxes` / `radio` /
+   * `multiselect` whose option list came back empty renders NOTHING but this
+   * box, so the visible label named zero elements until it landed here.
+   *
+   * A closed three-key type rather than an open props tail: only `id`,
+   * `aria-labelledby` and the `role` that makes them meaningful may reach this
+   * element, and reopening a spread is what objectui#3291 exists to prevent.
+   * Absent for the single `SelectField` — it is not group-labelled, its label
+   * still uses a plain `for`, and it must keep emitting no such attributes.
+   */
+  hostGroupProps?: HostGroupProps;
 }
 
 export function OptionsEmptyState({
@@ -60,6 +74,7 @@ export function OptionsEmptyState({
   dependsOnFields,
   testId,
   className,
+  hostGroupProps,
 }: OptionsEmptyStateProps) {
   const { t } = useFieldTranslation();
   // The host's hint when it computed one; otherwise this widget's own copy,
@@ -71,6 +86,7 @@ export function OptionsEmptyState({
       : t('fields.options.empty'));
   return (
     <div
+      {...hostGroupProps}
       data-testid={testId}
       className={cn(
         'flex w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground',

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -3,6 +3,7 @@ import { RadioGroup, RadioGroupItem, Label, EmptyValue } from '@object-ui/compon
 import { isValueStillOffered, type OptionLike } from '@object-ui/core';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 import { OptionsEmptyState } from './OptionsEmptyState';
 import { useCascadingOptions } from './useCascadingOptions';
 
@@ -54,12 +55,24 @@ export function RadioField({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, gated]);
 
+  // The host's group label has to be consumed on EVERY surface this widget can
+  // render, not only the `RadioGroup` (objectui#3990): both branches below return
+  // before that spread, which is how a field-level `readonly: true` and a
+  // zero-option list ended up with a published label id and no consumer at all.
+  // See `toHostGroupProps` — note the role it emits is `group`, not the
+  // `radiogroup` the editable branch keeps: there is not one radio left in
+  // either of these surfaces.
+  const hostGroupProps = toHostGroupProps(props);
+
   if (readonly) {
-    if (value == null || value === '') return <EmptyValue />;
+    // `EmptyValue`'s own `aria-label` ("No value") is outranked by
+    // `aria-labelledby` per accname, and on the `generic` role that placeholder
+    // span carries it was never exposed as a name anyway.
+    if (value == null || value === '') return <EmptyValue {...hostGroupProps} />;
     // Label from the raw set so a stored value hidden by `visibleWhen` still
     // renders its label rather than a bare id.
     const opt = rawOptions.find((o) => o.value === value);
-    return <span className="text-sm">{opt?.label || String(value)}</span>;
+    return <span {...hostGroupProps} className="text-sm">{opt?.label || String(value)}</span>;
   }
 
   // No offered options is unfillable — surface a legible state instead of an
@@ -74,6 +87,9 @@ export function RadioField({
         dependsOnFields={dependsOnFields}
         testId={fieldName ? `radio-empty-${fieldName}` : undefined}
         className="min-h-9"
+        // This box IS the field in this state, so it is what the host label
+        // names (objectui#3990).
+        hostGroupProps={hostGroupProps}
       />
     );
   }

--- a/packages/fields/src/widgets/RatingField.tsx
+++ b/packages/fields/src/widgets/RatingField.tsx
@@ -3,6 +3,7 @@ import { Star } from 'lucide-react';
 import { cn } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
+import { toHostGroupProps } from './toHostGroupProps';
 
 /**
  * Rating field widget - provides a star rating input
@@ -19,8 +20,11 @@ export function RatingField({ value, onChange, field, readonly, className, error
   const displayValue = hoverValue !== null ? hoverValue : currentValue;
 
   if (readonly) {
+    // The readonly star row is the field's whole rendered surface, so it — not
+    // only the editable row below — consumes the host's group label
+    // (objectui#3990). See `toHostGroupProps`.
     return (
-      <div className={cn("flex items-center gap-1", className)}>
+      <div {...toHostGroupProps(props)} className={cn("flex items-center gap-1", className)}>
         {Array.from({ length: max }, (_, i) => (
           <Star
             key={i}

--- a/packages/fields/src/widgets/toHostGroupProps.ts
+++ b/packages/fields/src/widgets/toHostGroupProps.ts
@@ -1,0 +1,102 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { toDomProps } from './toDomProps';
+
+/**
+ * The props that make a group-labelled widget's rendered surface the thing its
+ * host label actually NAMES, on the surfaces that are not controls
+ * (objectui#3990).
+ *
+ * ## What it is for
+ *
+ * A widget declared `labelling: 'group'` (objectui#3961) is told by the form
+ * renderer: your label publishes an `id` and drops its `for`, so name yourself
+ * by IDREF. The renderer hands down exactly two facts that address the field as
+ * a WHOLE:
+ *
+ *  - `id` — the host's control id (`…-form-item`), the id the label's `for`
+ *    used to point at;
+ *  - `aria-labelledby` — the IDREF of that visible label.
+ *
+ * Every editable branch already consumes them inside its wider `toDomProps`
+ * spread. The branches that returned EARLY did not — a field-level
+ * `readonly: true`, or an option list with zero offered options — so the label
+ * published an id that no element in the document referenced. Measured on
+ * `origin/main`, one field per row, reading the host label against the DOM:
+ *
+ * ```
+ * multiselect  readonly+value   consumers=0  byLabelText=0  namedByRole=[]
+ * multiselect  readonly+empty   consumers=0  byLabelText=0  namedByRole=[]
+ * multiselect  zeroOptions      consumers=0  byLabelText=0  namedByRole=[]
+ * multiselect  editable         consumers=1  byLabelText=1  namedByRole=[group:1]
+ * ```
+ *
+ * All seven group-labelled types measured the same, in every readonly state.
+ * This is quieter than the dangling `for` #3961 replaced: a `for` that resolves
+ * to nothing can at least be swept for, while "a label published an id and
+ * nobody consumed it" looks like healthy markup.
+ *
+ * ## Why this narrow pair, and not the whole `toDomProps` result
+ *
+ * Everything else in the DOM pass-through addresses a CONTROL, and a readonly
+ * display has none: `aria-describedby` / `aria-required` are announced when
+ * focus lands on something focusable, `disabled` / `tabIndex` / the focus
+ * handlers only mean something on an interactive element, and `name` is
+ * DOM-legal on form controls only — on a `div` it is exactly the leak
+ * objectui#3291 sweeps for. Spreading the full result would also put the host's
+ * `className` on top of the widget's own, because the widgets whose readonly
+ * surface is a placeholder or a plain container (`EmptyValue`, `FileField`,
+ * `AddressField`) keep `className` inside `props`.
+ *
+ * ## Why `role` travels with the two keys
+ *
+ * `aria-labelledby` on a role-less `div` / `span` names NOTHING — `generic`
+ * prohibits an author name — so the pair is inert without a role that supports
+ * naming. `group` is the one that fits a readonly surface: it names a set of
+ * values (chips, checked labels, stars, file names, a formatted address)
+ * without promising the interactivity `textbox` or `radiogroup` would. It is
+ * deliberately NOT the role the same widget answers with while editable:
+ * `RadioField`'s readonly branch renders the chosen label as text with no radios
+ * left in it, and `FileField`'s renders file names with no dropzone button.
+ *
+ * The role is emitted ONLY when a host actually named the field, mirroring
+ * every editable branch's `isLabelledGroup` test: standalone rendering (the
+ * grid's inline cell editor, a bare SDUI node) hands down neither key, so every
+ * value here is `undefined`, React emits no attribute, and that markup stays
+ * byte-identical to what it was.
+ */
+export interface HostGroupProps {
+  /** The host's control id — the id its label would have pointed `for` at. */
+  id?: string;
+  /** IDREF of the host's visible label. */
+  'aria-labelledby'?: string;
+  /** `'group'` when — and only when — a host named this surface. */
+  role?: 'group';
+}
+
+/**
+ * Read the two whole-field keys out of a widget's leftover props, plus the role
+ * that makes them mean something. See {@link HostGroupProps}.
+ *
+ * Routed through {@link toDomProps} rather than reading `props` directly so the
+ * pair keeps ONE gate: those keys reach an element only if the DOM pass-through
+ * whitelist still forwards them, and its two compile-time assertions bind that
+ * whitelist to the props contract in both directions.
+ */
+export function toHostGroupProps(props: {
+  id?: string;
+  'aria-labelledby'?: string;
+}): HostGroupProps {
+  const { id, 'aria-labelledby': labelledBy } = toDomProps(props);
+  return {
+    id,
+    'aria-labelledby': labelledBy,
+    ...(labelledBy != null ? { role: 'group' as const } : null),
+  };
+}


### PR DESCRIPTION
Fixes #3990

## 结论

七个 `labelling: 'group'` widget 只在**可编辑分支**消费 host 递下来的
`aria-labelledby` + host `id`。字段级 `readonly: true` 与零可选项两种状态走的是
**提前 return**,渲染在那个容器之前 —— 于是 form renderer 让 label 发布了自己的
`id`、撤掉了 `for`,而文档里没有任何元素引用这个 id。可见标签是 0 个元素的可访问名。

不是 #3961 / #3975 的回归:改那两单之前,同样这些状态发的是指向「无人携带该 id」的
`for`,一样什么都不命名。形状从悬空 `for` 变成无人消费的 IDREF,严重程度未变 ——
是那次修法没有覆盖到的状态(#3961 的钉子全部在可编辑态取样)。

## 逐 widget 实测(正文警告「写法各异不可推断」,所以七类逐个量)

一次性 probe(未提交,已删),真 form renderer + 裸注册 `labelling: 'group'`,
逐字段数「引用 host label 已发布 id 的元素个数 / byLabelText / 被命名的 role」:

| widget | 只读+有值 | 只读+空值 | 零选项 | 可编辑(对照) | mode:'view'(对照) |
| --- | --- | --- | --- | --- | --- |
| multiselect | 0 → 1 | 0 → 1 | 0 → 1 | 1 → 1 group | 1 → 1 group |
| checkboxes | 0 → 1 | 0 → 1 | 0 → 1 | 1 → 1 group | 1 → 1 group |
| radio | 0 → 1 | 0 → 1 | 0 → 1 | 1 → 1 radiogroup | 1 → 1 radiogroup |
| rating | 0 → 1 | 0 → 1 | 不适用(无选项) | 1 → 1 group | 1 → 1 group |
| file | 0 → 1 | 0 → 1 | 不适用 | 1 → 1 button | 1 → 1 button |
| address | 0 → 1 | 0 → 1 | 不适用 | 1 → 1 group | 1 → 1 group |
| geolocation | 0 → 1 | 0 → 1 | 不适用 | 1 → 1 group | 1 → 1 group |

即:**七类在每个只读态上读数完全一致(全 0)**,并非只有正文实测过的
multiselect / checkboxes;可编辑态与整表单 `mode: 'view'` 两列改前改后都是 1(view
不走 widget 的 readonly 分支,与正文一致)。

## 处置(沿既定 group 机制)

新增 `packages/fields/src/widgets/toHostGroupProps.ts`:只读面统一只带**两个「整字段」
键** —— host `id` 与 `aria-labelledby` —— 外加让它们生效的 `role="group"`,一处拼写。

窄化是刻意的,不是偷懒:只读面**没有可聚焦控件**,`aria-describedby` /
`aria-required` / `disabled` / 焦点回调在那里无人宣读;而 `name` 落到 div 上正是
#3291 在扫的泄漏;把整份 `toDomProps` 铺下去还会用 host 的 `className` 盖掉 widget
自己的(`EmptyValue` / FileField / AddressField 的 `className` 都留在 `props` 里)。
`role` 必须随行:role-less 的 div / span 上 `aria-labelledby` 命名的是 nothing
(`generic` 禁止 author name),这正是本单量到的形状。

逐 widget 落点:

| widget | 只读+有值落点 | 只读+空值落点 | 零选项落点 |
| --- | --- | --- | --- |
| multiselect | chip 行容器 | `EmptyValue` 本身 | `OptionsEmptyState` 框 |
| checkboxes | 已选 Badge 行容器 | `EmptyValue` 本身 | 同上 |
| radio | 选中项文本 span | `EmptyValue` 本身 | 同上 |
| rating | 星星行容器 | 同左(无空态) | 不适用 |
| file | 文件名行容器 | `EmptyValue` 本身 | 不适用 |
| address | 格式化单行 span | `EmptyValue` 本身 | 不适用 |
| geolocation | 图标+坐标行容器 | 同左(占位符在容器内) | 不适用 |

两处 role 与可编辑态**故意不同**,因为渲染的根本不是同一个面:`radio` 可编辑答
`radiogroup`,只读面里一个 radio 都不剩;`file` 可编辑答 `button`(dropzone),
只读面里没有 dropzone,只有文件名。共享的「无可选项」框对 checkboxes / radio /
multiselect 答 `group`;单选 `select` 不属于 group-labelled(label 仍是可用的 `for`),
该框对它一个属性都不多发 —— 这条有阳性对照钉。

顺带把 AddressField / GeolocationField 的可编辑容器也换成同一个 `toHostGroupProps`
(它们此前手写 `id` + 条件 role + `aria-labelledby`,语义与输出完全等价),这样
同一文件里只读面与可编辑面不可能对同一个问题给出两种答案。

## 无缺口/豁免

没有豁免项:七类的每个只读渲染路径都找到了现成的承载元素,**没有新增任何 DOM 节点**。
一处如实记录的取舍:hosted 且空值时 `EmptyValue` 就是整块只读面,于是它自己带上这三个
属性,它原有的 `aria-label`(“No value”)按 accname 被 `aria-labelledby` 压过 ——
这是想要的结果:在它此前的 `generic` role 上 author name 本就被禁止、从未暴露,所以
真实选择是「字段名」还是「没有名字」。standalone 时该占位符不带 role,行为不变。

## 钉子(64 个,新文件 `composite-group-label-readonly-e2e.test.tsx`)

- 逐 widget 只读+有值:`getAllByRole('group', { name })` 前 0 / 后 1,且 `byLabelText` 同元素;
- 逐 widget 只读+空值:同上,并按三种真实形态分别断言(占位符即本体 / 占位符在容器内 /
  rating 无空态);
- 逐 widget 只读态:host id 与 name 落在**同一元素**(`id` 以 `-form-item` 结尾)、label 无
  `for`、字段内无悬空或 inert 的 `for`、只读面不带 `name` / `aria-invalid`;
- 三个选项 widget 零选项态:命名元素就是 `OptionsEmptyState` 框本身(testId 断言);
  以及 readonly 与零选项同时成立时 readonly 分支胜出且仍被命名;
- 可编辑态回归钉:逐 widget 同时断言可编辑角色(radio=radiogroup / file=button / 其余
  group)与只读角色 group,任何「统一角色」的后续改动都必须来这里说明它改了什么;
- standalone 回归钉:逐 widget 只读渲染无 role、无 IDREF、无 id;`SelectField` 零选项框
  无 role / 无 IDREF / 无 id(共享组件新增 prop 的阳性对照)。

## 反向验证(先预判再跑,变异未提交)

- 变异 A:撤掉 MultiSelectField 只读 chip 行的展开。**预判**红在 multiselect 的 4 条
  只读钉 + 「七类同表」+ 漂移钉 = 6 条,不动 EmptyValue / 零选项 / standalone。
  **实测**:`Tests 6 failed | 58 passed`,失败项与预判逐条一致。
- 变异 B:撤掉 CheckboxesField 传给 `OptionsEmptyState` 的 `hostGroupProps`。**预判**只红
  「checkboxes: the unfillable-options box is the named group」1 条。
  **实测**:`Tests 1 failed | 63 passed`。

两次都是经典方向(撤掉即翻红),没有出现计数型或反转型的情况 —— 因为这些钉断言的是
「被命名的元素个数从 0 到 1」这个谓词,而不是某个下游计数。

## 验证

- `pnpm --workspace-concurrency=2 --filter '@object-ui/fields^...' build` → 通过(先行,
  新 worktree 的依赖产物)。
- 仓根 `pnpm exec vitest run packages/fields --maxWorkers=2` → `Test Files 73 passed (73)`,
  `Tests 1160 passed (1160)`。
- 消费半径:仓根 `pnpm exec vitest run packages/components/src/renderers/form --maxWorkers=2`
  → `Test Files 33 passed (33)`,`Tests 182 passed (182)`(group-labelling 是 form renderer
  与 widget 的联合机制,声明位那侧一并跑过)。
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → `Tasks: 78 successful, 78 total`。
- `node scripts/check-control-bytes.mjs` → OK(3902 个跟踪文本文件);另对本 PR 触碰的
  文件做了越界自扫(`grep -naP` 控制字符类)→ 无命中。
- eslint 触碰文件:0 error(仅既有风格 warning,`_` 前缀丢弃变量与 `any`)。

changeset:`@object-ui/fields` patch。

边界:只动 `packages/fields/src/widgets/**` + 测试 + changeset;未碰 form.tsx / index.tsx
的声明集合(机制已定型),未碰 `content/docs/releases/`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_