### PR TITLE
fix(scripts): test type-check 覆盖率改由解析后的 tsconfig 程序判定,schema-catalog 的测试接上编译

### DIFF
--- a/examples/schema-catalog/package.json
+++ b/examples/schema-catalog/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf dist",
     "regenerate": "python3 ../../scripts/regenerate-catalog-index.py",
     "test": "vitest run",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint ."
   },
   "dependencies": {
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
+    "@object-ui/fields": "workspace:*",
     "@object-ui/layout": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/sdui-parser": "workspace:*",

--- a/examples/schema-catalog/tsconfig.test.json
+++ b/examples/schema-catalog/tsconfig.test.json
@@ -1,0 +1,43 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` does not read.
+  // See `packages/types/tsconfig.test.json` for why that is a hole: the build
+  // config correctly keeps tests out of `dist`, but nothing else compiled them,
+  // so a test could assert a contract the compiler never checked.
+  //
+  // This package is the one that made `scripts/check-type-check-coverage.mjs`
+  // blind (objectui#3968): its tests live in `test/` rather than `src/`, and
+  // `tsconfig.json` keeps them out by naming the DIRECTORY in `exclude` instead
+  // of a `*.test.` glob. Both of those were invisible to the gate, so the four
+  // files here were read by no `tsc` invocation while the gate reported green.
+  //
+  // Not folded into `tsconfig.json`: that file is the package BUILD (`tsc` ->
+  // `dist`, `rootDir: ./src`, `declaration`), so a test compiled by it would
+  // emit into the published output and `test/` would break `rootDir`.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The package build emits `dist` from `src`; this project emits nothing, so
+    // it must not inherit the emit options — and `rootDir` has to widen to the
+    // package root because the tests sit beside `src`, not inside it.
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "composite": false,
+    // The tests are `.tsx` (they render catalog examples through the real
+    // `SchemaRenderer`); the build config has no `jsx` because `src/` is JSON
+    // plus plain `.ts`.
+    "jsx": "react-jsx"
+  },
+  // `test/`, not `src/`: that is where this package keeps its tests, and it is
+  // the layout the gate could not see.
+  "include": ["test/**/*.test.ts", "test/**/*.test.tsx"],
+  // Load-bearing, and the first draft of this file got it wrong: `exclude` is
+  // INHERITED from `tsconfig.json`, which excludes the whole `test` DIRECTORY.
+  // Leaving it inherited made this project compile zero files — `tsc` said
+  // TS18003 ("No inputs were found"), which is loud, but a project that covered
+  // only SOME of the tests would have been silent. That is why section 5b of
+  // `scripts/check-type-check-coverage.mjs` now checks that this project really
+  // reads every test file the build config misses, rather than only that a
+  // `*.test.` glob appears somewhere in it.
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,9 @@ importers:
       '@object-ui/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@object-ui/fields':
+        specifier: workspace:*
+        version: link:../../packages/fields
       '@object-ui/layout':
         specifier: workspace:*
         version: link:../../packages/layout

--- a/scripts/__tests__/check-type-check-coverage.test.ts
+++ b/scripts/__tests__/check-type-check-coverage.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS CI helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
+// re-adding one is now itself an error (TS2578). See objectui#3494.
+import {
+  auditPackages,
+  collect,
+  listTestFiles,
+  programPatterns,
+  programReads,
+  testsCovered,
+  tsPatternToRegExp,
+} from '../check-type-check-coverage.mjs';
+
+/**
+ * objectui#3968 — the test for `scripts/check-type-check-coverage.mjs`.
+ *
+ * The gate reported green while four test files in `examples/schema-catalog` were
+ * read by no `tsc` invocation at all, and it did so for TWO independent reasons
+ * that happened to overlap on that one package:
+ *
+ *  1. it counted test files by recursing `src/` only, and those tests live in
+ *     `test/` — so the count was 0 and the whole "tests are code too" section
+ *     `continue`d past the package;
+ *  2. it decided "the build already compiles them" by probing the tsconfig TEXT
+ *     for a `*.test.` glob, and that package keeps its tests out of the build by
+ *     naming the DIRECTORY (`"exclude": ["test"]`) — so the probe found nothing
+ *     and the package read as covered.
+ *
+ * The fix replaced both text heuristics with one question asked of the resolved
+ * program: walk the whole package for test files, then resolve each tsconfig's
+ * `files`/`include`/`exclude` (through `extends`) and ask whether it really reads
+ * them. This suite is the reverse pin on that. Every fixture is a throwaway
+ * package tree, never this repository's own packages — a committed fixture would
+ * have to contain a deliberately unchecked test file, and this very gate would
+ * eventually find it.
+ *
+ * The one exception is the last block, which asserts against the REAL repository
+ * that `examples/schema-catalog` is now wired up. That is deliberate: the whole
+ * point of #3968 was that nothing noticed when it was not.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** All tables empty, so a fixture tree is judged on its own merits. */
+const NO_TABLES = { debt: {}, notCompiled: [], checkedByOwnBuild: {}, testDebt: {} };
+
+/** Builds a throwaway workspace and runs the REAL collector + audit over it. */
+function withWorkspace(
+  build: (write: (rel: string, contents: string) => void) => void,
+  run: (verdict: { dir: string; errors: string[]; packages: ReturnType<typeof collect> }) => void,
+): void {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-type-check-coverage-'));
+  const write = (rel: string, contents: string) => {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+  };
+  try {
+    build(write);
+    const packages = collect(dir);
+    run({ dir, errors: auditPackages(packages, { ...NO_TABLES, root: dir }), packages });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const manifest = (name: string, typeCheck: string) =>
+  JSON.stringify({ name, version: '0.0.0', private: true, scripts: { 'type-check': typeCheck } }, null, 2);
+
+const A_TEST = ['import { it, expect } from "vitest";', 'it("works", () => expect(1).toBe(1));', ''].join('\n');
+
+/**
+ * The two predicates the gate USED to use, reproduced verbatim so the blind spots
+ * are executable statements rather than a story in a comment. Each fixture below
+ * that must be red is also asserted to have been INVISIBLE to these — that is
+ * what stops a future simplification from quietly restoring one.
+ */
+const legacyTestFileCount = (packageDir: string): number => listTestFiles(path.join(packageDir, 'src')).length;
+const legacyBuildExcludesTests = (tsconfigText: string): boolean => /\*\.test\./.test(tsconfigText);
+
+describe('listTestFiles — what counts as a test file, and where it may live', () => {
+  it('walks the whole package, not just src/ (blind spot 1)', () => {
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit'));
+        write('packages/demo/tsconfig.json', JSON.stringify({ include: ['src/**/*'] }));
+        write('packages/demo/src/a.test.ts', A_TEST);
+        write('packages/demo/test/b.test.tsx', A_TEST);
+        write('packages/demo/test/nested/c.test.ts', A_TEST);
+      },
+      ({ packages }) => {
+        const pkg = packages.find((p) => p.name === '@fixture/demo');
+        expect(pkg?.testFilePaths.sort()).toEqual(['src/a.test.ts', 'test/b.test.tsx', 'test/nested/c.test.ts']);
+      },
+    );
+  });
+
+  it('skips build output and tool state, so a copy in dist is not a test file', () => {
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit'));
+        write('packages/demo/tsconfig.json', JSON.stringify({ include: ['src/**/*'] }));
+        write('packages/demo/test/real.test.ts', A_TEST);
+        write('packages/demo/dist/real.test.ts', A_TEST);
+        write('packages/demo/node_modules/dep/x.test.ts', A_TEST);
+        write('packages/demo/coverage/x.test.ts', A_TEST);
+        write('packages/demo/.turbo/x.test.ts', A_TEST);
+      },
+      ({ packages }) => {
+        expect(packages.find((p) => p.name === '@fixture/demo')?.testFilePaths).toEqual(['test/real.test.ts']);
+      },
+    );
+  });
+});
+
+describe('include/exclude semantics — a directory is a directory (blind spot 2)', () => {
+  it('treats an extension-less, wildcard-less pattern as a recursive directory', () => {
+    expect(tsPatternToRegExp('/repo/pkg/test').test('/repo/pkg/test/a.test.ts')).toBe(true);
+    expect(tsPatternToRegExp('/repo/pkg/test').test('/repo/pkg/test/deep/a.test.ts')).toBe(true);
+    expect(tsPatternToRegExp('/repo/pkg/test').test('/repo/pkg/testing/a.test.ts')).toBe(false);
+  });
+
+  it('matches ** across any number of directories, including none', () => {
+    const pattern = tsPatternToRegExp('/repo/pkg/src/**/*.test.ts');
+    expect(pattern.test('/repo/pkg/src/a.test.ts')).toBe(true);
+    expect(pattern.test('/repo/pkg/src/deep/deeper/a.test.ts')).toBe(true);
+    expect(pattern.test('/repo/pkg/src/a.test.tsx')).toBe(false);
+  });
+
+  it('reads a tsconfig whose comments contain globs (a naive strip eats them)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-type-check-coverage-jsonc-'));
+    try {
+      const file = path.join(dir, 'tsconfig.json');
+      fs.writeFileSync(
+        file,
+        ['{', '  /* block comment mentioning src/*.test.ts */', '  "include": ["src/**/*"],', '  "exclude": ["test"],', '}', ''].join(
+          '\n',
+        ),
+      );
+      const patterns = programPatterns(file);
+      expect(patterns.include?.patterns).toEqual(['src/**/*']);
+      expect(patterns.exclude?.patterns).toEqual(['test']);
+      expect(programReads(patterns, path.join(dir, 'src', 'a.ts'))).toBe(true);
+      expect(programReads(patterns, path.join(dir, 'test', 'a.test.ts'))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('inherits files/include/exclude through extends, relative to the config that declared them', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-type-check-coverage-extends-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'base.json'), JSON.stringify({ include: ['src/**/*'], exclude: ['test'] }));
+      fs.writeFileSync(path.join(dir, 'tsconfig.json'), JSON.stringify({ extends: './base.json' }));
+      const patterns = programPatterns(path.join(dir, 'tsconfig.json'));
+      expect(programReads(patterns, path.join(dir, 'src', 'a.ts'))).toBe(true);
+      // The inherited directory exclude still applies — this is the trap that made
+      // the first draft of examples/schema-catalog/tsconfig.test.json compile zero
+      // files (TS18003).
+      expect(programReads(patterns, path.join(dir, 'test', 'a.test.ts'))).toBe(false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('section 5c — a test file no program reads fails the gate', () => {
+  it('the exact objectui#3968 shape: tests in test/, kept out by a directory exclude', () => {
+    const tsconfig = JSON.stringify({ include: ['src/**/*'], exclude: ['node_modules', 'dist', 'test'] }, null, 2);
+    withWorkspace(
+      (write) => {
+        write('examples/catalog/package.json', manifest('@fixture/catalog', 'tsc --noEmit'));
+        write('examples/catalog/tsconfig.json', tsconfig);
+        write('examples/catalog/src/index.ts', 'export const catalog = 1;\n');
+        write('examples/catalog/test/smoke.test.tsx', A_TEST);
+      },
+      ({ dir, errors, packages }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('@fixture/catalog (examples/catalog) has 1 test file that no `tsc`');
+        expect(errors[0]).toContain('test/smoke.test.tsx');
+        expect(testsCovered(packages[0])).toBe(false);
+
+        // And this is what the two old predicates said about the same tree:
+        // nothing at all, each for its own reason. Both blind spots, executable.
+        expect(legacyTestFileCount(path.join(dir, 'examples/catalog'))).toBe(0);
+        expect(legacyBuildExcludesTests(tsconfig)).toBe(false);
+      },
+    );
+  });
+
+  it('the shape one step over: no exclude at all, an include that never reaches test/', () => {
+    // A fix that only taught the gate to recognise directory-form excludes would
+    // still pass this tree — the tests are missed by the INCLUDE, and there is no
+    // exclude to recognise.
+    const tsconfig = JSON.stringify({ include: ['src/**/*'] }, null, 2);
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit'));
+        write('packages/demo/tsconfig.json', tsconfig);
+        write('packages/demo/src/index.ts', 'export const demo = 1;\n');
+        write('packages/demo/test/a.test.ts', A_TEST);
+        write('packages/demo/test/b.test.ts', A_TEST);
+      },
+      ({ dir, errors }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('has 2 test files that no `tsc`');
+        expect(legacyTestFileCount(path.join(dir, 'packages/demo'))).toBe(0);
+        expect(legacyBuildExcludesTests(tsconfig)).toBe(false);
+      },
+    );
+  });
+
+  it('still fails the classic shape it always caught: glob exclude, tests in src', () => {
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit'));
+        write(
+          'packages/demo/tsconfig.json',
+          JSON.stringify({ include: ['src'], exclude: ['node_modules', 'dist', '**/*.test.ts'] }, null, 2),
+        );
+        write('packages/demo/src/index.ts', 'export const demo = 1;\n');
+        write('packages/demo/src/a.test.ts', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('has 1 test file that no `tsc`');
+      },
+    );
+  });
+
+  it('says nothing when the build program really does compile the tests', () => {
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit'));
+        write('packages/demo/tsconfig.json', JSON.stringify({ include: ['src'] }, null, 2));
+        write('packages/demo/src/index.ts', 'export const demo = 1;\n');
+        write('packages/demo/src/a.test.ts', A_TEST);
+      },
+      ({ errors, packages }) => {
+        expect(errors).toEqual([]);
+        expect(packages[0].buildSkipsTests).toBe(false);
+      },
+    );
+  });
+
+  it('says nothing about a package that has no test files at all', () => {
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit'));
+        write('packages/demo/tsconfig.json', JSON.stringify({ include: ['src'], exclude: ['test'] }, null, 2));
+        write('packages/demo/src/index.ts', 'export const demo = 1;\n');
+      },
+      ({ errors }) => expect(errors).toEqual([]),
+    );
+  });
+});
+
+describe('section 5b — a chained test project that does not read the tests', () => {
+  const wiredManifest = manifest('@fixture/catalog', 'tsc --noEmit && tsc -p tsconfig.test.json');
+  const buildConfig = JSON.stringify({ include: ['src/**/*'], exclude: ['node_modules', 'dist', 'test'] }, null, 2);
+
+  it('accepts a project that reads every test file the build skips', () => {
+    withWorkspace(
+      (write) => {
+        write('examples/catalog/package.json', wiredManifest);
+        write('examples/catalog/tsconfig.json', buildConfig);
+        write(
+          'examples/catalog/tsconfig.test.json',
+          JSON.stringify(
+            {
+              extends: './tsconfig.json',
+              compilerOptions: { noEmit: true },
+              include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+              exclude: ['node_modules', 'dist'],
+            },
+            null,
+            2,
+          ),
+        );
+        write('examples/catalog/src/index.ts', 'export const catalog = 1;\n');
+        write('examples/catalog/test/smoke.test.tsx', A_TEST);
+      },
+      ({ errors, packages }) => {
+        expect(errors).toEqual([]);
+        expect(testsCovered(packages[0])).toBe(true);
+      },
+    );
+  });
+
+  it("rejects a project that inherits the build config's directory exclude and so compiles nothing", () => {
+    // The mistake this file's author actually made. `tsc` happens to shout
+    // TS18003 when the count reaches zero, but a project covering only SOME of
+    // the tests is silent — which is why the gate checks the files, not the text.
+    withWorkspace(
+      (write) => {
+        write('examples/catalog/package.json', wiredManifest);
+        write('examples/catalog/tsconfig.json', buildConfig);
+        write(
+          'examples/catalog/tsconfig.test.json',
+          JSON.stringify(
+            {
+              extends: './tsconfig.json',
+              compilerOptions: { noEmit: true },
+              include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+            },
+            null,
+            2,
+          ),
+        );
+        write('examples/catalog/src/index.ts', 'export const catalog = 1;\n');
+        write('examples/catalog/test/smoke.test.tsx', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('tsconfig.test.json does not read 1 of the');
+        expect(errors[0]).toContain('test/smoke.test.tsx');
+      },
+    );
+  });
+
+  it('rejects a project whose include points at the wrong directory', () => {
+    withWorkspace(
+      (write) => {
+        write('examples/catalog/package.json', wiredManifest);
+        write('examples/catalog/tsconfig.json', buildConfig);
+        write(
+          'examples/catalog/tsconfig.test.json',
+          JSON.stringify(
+            {
+              compilerOptions: { noEmit: true },
+              // Mentions a `*.test.` glob — enough for the old text probe — while
+              // reading nothing: the tests are in `test/`.
+              include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+            },
+            null,
+            2,
+          ),
+        );
+        write('examples/catalog/src/index.ts', 'export const catalog = 1;\n');
+        write('examples/catalog/test/smoke.test.tsx', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('does not read 1 of the');
+      },
+    );
+  });
+
+  it('still requires the chained project to be emit-free', () => {
+    withWorkspace(
+      (write) => {
+        write('examples/catalog/package.json', wiredManifest);
+        write('examples/catalog/tsconfig.json', buildConfig);
+        write(
+          'examples/catalog/tsconfig.test.json',
+          JSON.stringify({ include: ['test/**/*.test.tsx'], exclude: ['node_modules', 'dist'] }, null, 2),
+        );
+        write('examples/catalog/test/smoke.test.tsx', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('must set "noEmit": true');
+      },
+    );
+  });
+
+  it('still reports a test project that "type-check" never runs (objectui#3009)', () => {
+    withWorkspace(
+      (write) => {
+        write('examples/catalog/package.json', manifest('@fixture/catalog', 'tsc --noEmit'));
+        write('examples/catalog/tsconfig.json', buildConfig);
+        write(
+          'examples/catalog/tsconfig.test.json',
+          JSON.stringify({ compilerOptions: { noEmit: true }, include: ['test/**/*.test.tsx'], exclude: [] }, null, 2),
+        );
+        write('examples/catalog/test/smoke.test.tsx', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('never runs');
+      },
+    );
+  });
+
+  it('refuses to guess when a tsconfig cannot be parsed', () => {
+    withWorkspace(
+      (write) => {
+        write('examples/catalog/package.json', manifest('@fixture/catalog', 'tsc --noEmit'));
+        write('examples/catalog/tsconfig.json', '{ "include": ["src/**/*"], oops }\n');
+        write('examples/catalog/test/smoke.test.tsx', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('cannot parse tsconfig.json');
+      },
+    );
+  });
+});
+
+describe('examples/schema-catalog is wired up, in this repository', () => {
+  const packages = collect(repoRoot);
+  const pkg = packages.find((p) => p.name === '@object-ui/example-schema-catalog');
+
+  it('is a package this gate can see at all', () => {
+    expect(pkg).toBeDefined();
+  });
+
+  it('keeps its tests outside src/, where the src-only walk could not find them', () => {
+    // Deliberately not a count: files come and go. What matters is that tests
+    // exist, that they live outside `src/`, and that the walk finds them anyway.
+    expect(pkg!.testFiles).toBeGreaterThan(0);
+    expect(pkg!.testFilePaths.every((rel: string) => !rel.startsWith('src/'))).toBe(true);
+  });
+
+  it('does not compile them in its build program — and does compile them elsewhere', () => {
+    // Both halves matter. The first is why a test project is needed at all (the
+    // build emits `dist` from `src`); the second is the fix. Revert either the
+    // `tsconfig.test.json` or the `type-check` chaining and this goes red.
+    expect(pkg!.buildSkips.length).toBe(pkg!.testFiles);
+    expect(pkg!.hasTestConfig).toBe(true);
+    expect(pkg!.chainsTestConfig).toBe(true);
+    expect(pkg!.testConfigSkips).toEqual([]);
+    expect(testsCovered(pkg)).toBe(true);
+  });
+
+  it('is the only package in the repository whose tests live outside src/', () => {
+    // The premise the fix was scoped on (#3968). If a second package adopts this
+    // layout, that is fine — but it must arrive wired up, and this list is where
+    // the next reader finds out.
+    const outsideSrc = packages
+      .filter((p) => p.testFilePaths.some((rel: string) => !rel.startsWith('src/')))
+      .map((p) => p.name);
+    expect(outsideSrc).toEqual(['@object-ui/example-schema-catalog']);
+  });
+});

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -23,6 +23,28 @@
  * errors. So the second half of this guard: a package with test files either
  * type-checks them or carries a TEST_DEBT entry with a measured error count.
  *
+ * How that second half asks the question matters, and objectui#3968 is why it is
+ * asked the way it is now. It used to be asked with two text heuristics — count
+ * the test files under `src/`, then look for a `*.test.` glob anywhere in the
+ * tsconfig — and BOTH were blind to the same package. `examples/schema-catalog`
+ * keeps its tests in `test/` (so the count was 0 and the whole check was skipped)
+ * and keeps them out of the build by naming the DIRECTORY in `exclude` (so the
+ * glob probe found nothing and reported "already covered"). Four test files were
+ * read by no `tsc` invocation while this gate printed green, and the gate's own
+ * stated risk — an unchecked test asserting a contract the compiler never
+ * checked — was live in the one package laid out that way.
+ *
+ * So neither question is asked about TEXT any more. Test files are enumerated
+ * from the PACKAGE ROOT, and coverage is decided by resolving each tsconfig's
+ * `files`/`include`/`exclude` (through `extends`) and asking whether the program
+ * really reads each test file. Directory-form excludes then fall out of correct
+ * semantics rather than needing a second special case, and so does the shape one
+ * step over that no glob probe could ever have caught: an `include` of
+ * `["src/**\/*"]` with no `exclude` at all, which reads nothing in `test/`
+ * either. `scripts/__tests__/check-type-check-coverage.test.ts` pins all of it
+ * against throwaway package trees, including the exact #3968 shape, so the
+ * blind spots cannot be reintroduced by a simplification.
+ *
  * Run:  node scripts/check-type-check-coverage.mjs
  * Exit: 0 = OK, 1 = coverage regressed or the lists are stale
  */
@@ -41,13 +63,13 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 // peers already carry, so the TS6059 rootDir noise is excluded).
 // Empty, and worth keeping that way: every workspace package now either carries
 // a `type-check` script or is declared in one of the exemption lists below.
-const DEBT = {};
+export const DEBT = {};
 
 // Packages that are not compiled at all: documentation snippets with no build
 // script and no tsconfig, whose sources are read rather than run. Re-validated
 // on every run — the moment one gains a build script or a tsconfig it is a real
 // package, the exemption dies, and the guard fails.
-const NOT_COMPILED = ["@object-ui/example-hello-world"];
+export const NOT_COMPILED = ["@object-ui/example-hello-world"];
 
 // Packages whose own `build` type-checks them, so a separate `type-check` script
 // would only run the compiler twice. Unlike the `vite build` packages — which
@@ -56,7 +78,7 @@ const NOT_COMPILED = ["@object-ui/example-hello-world"];
 //
 // That escape hatch is exactly how this exemption could rot, so it is verified
 // on every run rather than trusted: setting `ignoreBuildErrors` fails the guard.
-const CHECKED_BY_OWN_BUILD = {
+export const CHECKED_BY_OWN_BUILD = {
   "@object-ui/site": {
     build: "next build",
     // Caveat worth knowing: the `docs` CI job runs this build only when
@@ -87,7 +109,7 @@ const CHECKED_BY_OWN_BUILD = {
 //     type, the dialect problem. Declare the dialect next to the vocabulary it
 //     extends (see scripts/check-spec-symbol-derivation.mjs), don't widen the
 //     type to silence it.
-const TEST_DEBT = {
+export const TEST_DEBT = {
   "@object-ui/core": { errors: 72, issue: 4118, note: "TS2741x32, TS2322x17 — mostly the input-vs-output fixture confusion" },
   // Partially covered already: `tsconfig.typetests.json` compiles the test files
   // whose whole value is compile-time type assertions (objectui#3181). The entry
@@ -110,39 +132,216 @@ const TEST_DEBT = {
 };
 
 // ── Collect workspace packages ───────────────────────────────────────────────
-const GROUPS = ["packages", "apps", "examples"];
+export const GROUPS = ["packages", "apps", "examples"];
 
-function countTestFiles(dir) {
-  let n = 0;
+// Directories that hold no authored test source. `dist` and `node_modules` were
+// already skipped when this walk started at `src/`; recursing from the package
+// root (objectui#3968) means it now also meets build caches and coverage output,
+// and a copy of a test file in `dist` is not a test file anyone maintains.
+export const SKIP_DIRS = new Set(["node_modules", "dist", "coverage"]);
+
+/**
+ * Every `*.test.ts(x)` file in a package, as paths relative to the package root.
+ *
+ * Recursing from the PACKAGE ROOT rather than `src/` is half of objectui#3968:
+ * `examples/schema-catalog` keeps its tests in `test/`, so a `src/`-only walk
+ * counted zero and section 5 skipped the package entirely — the check with the
+ * most to say about it never ran.
+ */
+export function listTestFiles(dir, prefix = "", found = []) {
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch {
-    return 0;
+    return found;
   }
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      if (entry.name === "node_modules" || entry.name === "dist") continue;
-      n += countTestFiles(join(dir, entry.name));
+      // Dot-directories are tool state (`.turbo`, `.vite`, `.next`), never
+      // authored sources.
+      if (SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue;
+      listTestFiles(join(dir, entry.name), prefix ? `${prefix}/${entry.name}` : entry.name, found);
     } else if (/\.test\.tsx?$/.test(entry.name)) {
-      n++;
+      found.push(prefix ? `${prefix}/${entry.name}` : entry.name);
     }
   }
-  return n;
+  return found;
 }
 
-function collect() {
+/**
+ * A tsconfig's comments removed, string-aware.
+ *
+ * String-aware is the whole point: every include/exclude pattern in this repo
+ * contains `/*`, so a naive comment strip eats the globs it was meant to
+ * preserve and the config parses to something that never matches anything.
+ */
+export function stripJsonComments(source) {
+  let out = "";
+  let inString = false;
+  let inLine = false;
+  let inBlock = false;
+  let escaped = false;
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i];
+    const next = source[i + 1];
+    if (inLine) {
+      if (char === "\n") {
+        inLine = false;
+        out += char;
+      }
+      continue;
+    }
+    if (inBlock) {
+      if (char === "*" && next === "/") {
+        inBlock = false;
+        i++;
+      }
+      continue;
+    }
+    if (inString) {
+      out += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      out += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      inLine = true;
+      i++;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      inBlock = true;
+      i++;
+      continue;
+    }
+    out += char;
+  }
+  return out;
+}
+
+/** Parses a tsconfig from disk. `null` when absent; `json: null` when unparseable. */
+export function readTsconfig(file) {
+  let source;
+  try {
+    source = readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    return { file, source, json: JSON.parse(stripJsonComments(source).replace(/,(\s*[}\]])/g, "$1")) };
+  } catch (error) {
+    return { file, source, json: null, parseError: String(error) };
+  }
+}
+
+/**
+ * A tsconfig's `files` / `include` / `exclude`, resolved through `extends`.
+ *
+ * Each list is tagged with the directory of the config that DECLARED it, because
+ * that is what its patterns are relative to — an inherited `include` in a base
+ * config one directory up means something different from the same string written
+ * here. A child that declares a key overrides the inherited one wholesale (TS
+ * does not merge these three).
+ */
+export function programPatterns(file, seen = new Set()) {
+  const dir = dirname(file);
+  const config = readTsconfig(file);
+  if (config === null) return { dir, missing: true, files: null, include: null, exclude: null };
+  if (config.json === null) return { dir, parseError: config.parseError, files: null, include: null, exclude: null };
+  const list = (key) => (Array.isArray(config.json[key]) ? { dir, patterns: config.json[key] } : null);
+  const own = { dir, files: list("files"), include: list("include"), exclude: list("exclude") };
+  const base = config.json.extends;
+  // Only relative `extends` is followed: a package-specifier base lives in
+  // `node_modules` and no config in this repo inherits program patterns that way.
+  if (typeof base !== "string" || !base.startsWith(".") || seen.has(file)) return own;
+  seen.add(file);
+  let baseFile = resolve(dir, base);
+  if (!/\.json$/.test(baseFile)) baseFile += ".json";
+  const inherited = programPatterns(baseFile, seen);
+  return {
+    dir,
+    files: own.files ?? inherited.files,
+    include: own.include ?? inherited.include,
+    exclude: own.exclude ?? inherited.exclude,
+    parseError: own.parseError ?? inherited.parseError,
+  };
+}
+
+// A pattern segment naming no extension and no wildcard is a DIRECTORY, and
+// matches everything under it — which is what makes `"exclude": ["test"]` keep a
+// whole test directory out of a program without ever spelling `*.test.`. That
+// reading was the second half of objectui#3968's blindness; here it is just the
+// documented behaviour of `include`/`exclude`.
+const EXTENSION = /\.(?:[cm]?[jt]sx?|json)$/;
+
+/** A TypeScript `include`/`exclude` pattern as an anchored regexp. */
+export function tsPatternToRegExp(pattern) {
+  let normalized = pattern.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (!/[*?]/.test(normalized) && !EXTENSION.test(normalized)) normalized = `${normalized}/**/*`;
+  let source = "";
+  for (let i = 0; i < normalized.length; i++) {
+    const char = normalized[i];
+    if (char === "*") {
+      if (normalized[i + 1] === "*" && normalized[i + 2] === "/") {
+        // `**/` spans any number of directories, including none.
+        source += "(?:[^/]*/)*";
+        i += 2;
+      } else if (normalized[i + 1] === "*") {
+        source += ".*";
+        i += 1;
+      } else {
+        source += "[^/]*";
+      }
+    } else if (char === "?") {
+      source += "[^/]";
+    } else {
+      source += char.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${source}$`);
+}
+
+const DEFAULT_INCLUDE = ["**/*"];
+const DEFAULT_EXCLUDE = ["node_modules", "bower_components", "jspm_packages"];
+
+/** Whether the program described by `patterns` reads `absFile`. */
+export function programReads(patterns, absFile) {
+  const matches = (list) =>
+    Boolean(list) && list.patterns.some((pattern) => tsPatternToRegExp(resolve(list.dir, pattern)).test(absFile));
+  if (matches(patterns.files)) return true;
+  // `files` without `include` means the program is exactly that list.
+  if (!patterns.include && patterns.files) return false;
+  const include = patterns.include ?? { dir: patterns.dir, patterns: DEFAULT_INCLUDE };
+  if (!matches(include)) return false;
+  return !matches(patterns.exclude ?? { dir: patterns.dir, patterns: DEFAULT_EXCLUDE });
+}
+
+/** The subset of `relPaths` that the tsconfig at `file` does NOT read. */
+export function unreadBy(file, packageDir, relPaths) {
+  const patterns = programPatterns(file);
+  if (patterns.missing || patterns.parseError) return { unread: relPaths, patterns };
+  return { unread: relPaths.filter((rel) => !programReads(patterns, join(packageDir, rel))), patterns };
+}
+
+export function collect(repoRoot = root) {
   const out = [];
   for (const group of GROUPS) {
     let entries;
     try {
-      entries = readdirSync(resolve(root, group));
+      entries = readdirSync(resolve(repoRoot, group));
     } catch {
       continue;
     }
     for (const entry of entries) {
       const dir = join(group, entry);
-      const manifest = resolve(root, dir, "package.json");
+      const packageDir = resolve(repoRoot, dir);
+      const manifest = resolve(packageDir, "package.json");
       try {
         statSync(manifest);
       } catch {
@@ -152,23 +351,38 @@ function collect() {
       if (!pkg.name) continue;
       let tsconfig = null;
       try {
-        tsconfig = readFileSync(resolve(root, dir, "tsconfig.json"), "utf8");
+        tsconfig = readFileSync(resolve(packageDir, "tsconfig.json"), "utf8");
       } catch {
         /* no tsconfig */
       }
       let testConfig = null;
       try {
-        testConfig = readFileSync(resolve(root, dir, "tsconfig.test.json"), "utf8");
+        testConfig = readFileSync(resolve(packageDir, "tsconfig.test.json"), "utf8");
       } catch {
         /* no test config */
       }
       let typeTestsConfig = null;
       try {
-        typeTestsConfig = readFileSync(resolve(root, dir, "tsconfig.typetests.json"), "utf8");
+        typeTestsConfig = readFileSync(resolve(packageDir, "tsconfig.typetests.json"), "utf8");
       } catch {
         /* no type-tests config */
       }
       const typeCheck = pkg.scripts?.["type-check"] ?? "";
+      const testFilePaths = listTestFiles(packageDir);
+
+      // Which test files does the BUILD program read? A package whose build
+      // compiles its tests needs nothing else; one whose build skips even a
+      // single test file needs a project that picks that file up.
+      const build =
+        tsconfig === null
+          ? { unread: testFilePaths, patterns: { missing: true } }
+          : unreadBy(resolve(packageDir, "tsconfig.json"), packageDir, testFilePaths);
+      // And of those, which does the chained test project read?
+      const test =
+        testConfig === null
+          ? { unread: build.unread, patterns: { missing: true } }
+          : unreadBy(resolve(packageDir, "tsconfig.test.json"), packageDir, build.unread);
+
       out.push({
         name: pkg.name,
         dir,
@@ -177,12 +391,22 @@ function collect() {
         build: pkg.scripts?.build,
         hasBuild: Boolean(pkg.scripts?.build),
         hasTsconfig: tsconfig !== null,
-        testFiles: countTestFiles(resolve(root, dir, "src")),
-        // A package tsconfig that never excludes a test glob compiles its tests
-        // as part of the build program, so they are already covered.
-        buildExcludesTests: tsconfig !== null && /\*\.test\./.test(tsconfig),
+        testFiles: testFilePaths.length,
+        testFilePaths,
+        // The test files the package's own build program does not read. Named
+        // for the mechanism it replaced (`buildExcludesTests`, a probe for the
+        // string `*.test.` anywhere in the config) but no longer text-based:
+        // this is the resolved `files`/`include`/`exclude` verdict, so a
+        // directory-form exclude and an `include` that simply never reaches
+        // `test/` both land here (objectui#3968).
+        buildSkips: build.unread,
+        buildSkipsTests: build.unread.length > 0,
         hasTestConfig: testConfig !== null,
         testConfig,
+        // Of the files the build skips, the ones the test project does not read
+        // either. A `tsconfig.test.json` that compiles none of them passes the
+        // old "does it mention a test glob" probe while checking nothing.
+        testConfigSkips: test.unread,
         // The config existing is not the same as anything running it — that gap
         // IS objectui#3009. `type-check` has to chain it.
         chainsTestConfig: /-p\s+tsconfig\.test\.json/.test(typeCheck),
@@ -192,259 +416,311 @@ function collect() {
         // (objectui#3181): `type-check` is what CI runs, so `type-check` — not
         // some sibling script CI never invokes — has to be the thing that runs it.
         chainsTypeTestsConfig: /-p\s+tsconfig\.typetests\.json/.test(typeCheck),
+        // A config this gate could not parse decides nothing: say so loudly
+        // rather than reporting a coverage verdict computed from a guess.
+        configParseErrors: [
+          build.patterns?.parseError && `tsconfig.json (${build.patterns.parseError})`,
+          test.patterns?.parseError && `tsconfig.test.json (${test.patterns.parseError})`,
+        ].filter(Boolean),
       });
     }
   }
   return out;
 }
 
-const packages = collect();
-const byName = new Map(packages.map((p) => [p.name, p]));
-
-const errors = [];
-
-// 1. Undeclared gap — a package born without a type-check script.
-for (const pkg of packages) {
-  if (pkg.hasScript) continue;
-  if (DEBT[pkg.name] || NOT_COMPILED.includes(pkg.name) || CHECKED_BY_OWN_BUILD[pkg.name]) continue;
-  errors.push(
-    `${pkg.name} (${pkg.dir}) has no "type-check" script, so \`pnpm type-check\` skips it entirely.\n` +
-      `      Add  "type-check": "tsc --noEmit"  to its package.json. If its types do not compile\n` +
-      `      yet, add it to DEBT in scripts/check-type-check-coverage.mjs with an error count.`
-  );
-}
-
-// 2. Ratchet — a declared gap that has been closed must leave the list.
-for (const name of Object.keys(DEBT)) {
-  const pkg = byName.get(name);
-  if (!pkg) {
-    errors.push(`${name} is listed in DEBT but is not a workspace package any more — delete the entry.`);
-  } else if (pkg.hasScript) {
-    errors.push(
-      `${name} now has a "type-check" script — delete its DEBT entry so the gap cannot reopen` +
-        `${DEBT[name].issue ? ` (and close #${DEBT[name].issue} if it is done)` : ""}.`
-    );
-  }
-}
-
-// 3. Ratchet — an exemption only holds while the package really is not compiled.
-for (const name of NOT_COMPILED) {
-  const pkg = byName.get(name);
-  if (!pkg) {
-    errors.push(`${name} is listed in NOT_COMPILED but is not a workspace package any more — delete the entry.`);
-    continue;
-  }
-  if (pkg.hasScript) {
-    errors.push(`${name} now has a "type-check" script — delete its NOT_COMPILED entry.`);
-    continue;
-  }
-  const acquired = [pkg.hasBuild && "a build script", pkg.hasTsconfig && "a tsconfig.json"].filter(Boolean);
-  if (acquired.length > 0) {
-    errors.push(
-      `${name} is listed in NOT_COMPILED but has gained ${acquired.join(" and ")} — it is a real package now.\n` +
-        `      Add  "type-check": "tsc --noEmit"  and remove the exemption.`
-    );
-  }
-}
-
-// 4. Ratchet — "its own build checks it" only holds while that stays true.
-for (const [name, spec] of Object.entries(CHECKED_BY_OWN_BUILD)) {
-  const pkg = byName.get(name);
-  if (!pkg) {
-    errors.push(`${name} is listed in CHECKED_BY_OWN_BUILD but is not a workspace package any more — delete the entry.`);
-    continue;
-  }
-  if (pkg.hasScript) {
-    errors.push(`${name} now has a "type-check" script — delete its CHECKED_BY_OWN_BUILD entry.`);
-    continue;
-  }
-  if (pkg.build !== spec.build) {
-    errors.push(
-      `${name} is exempt because its build is \`${spec.build}\`, which type-checks — but the build\n` +
-        `      script is now \`${pkg.build}\`. Re-confirm it still type-checks, then update or drop the entry.`
-    );
-    continue;
-  }
-  // `next build` type-checks by default; `ignoreBuildErrors` silently disables
-  // it, which would turn this exemption into exactly the hole #2911 was about.
-  if (spec.verifyNoIgnoreBuildErrors) {
-    const configPath = resolve(root, spec.verifyNoIgnoreBuildErrors);
-    let config;
-    try {
-      config = readFileSync(configPath, "utf8");
-    } catch {
-      errors.push(
-        `${name}: cannot read ${spec.verifyNoIgnoreBuildErrors}, so the exemption cannot be verified.\n` +
-          `      Point verifyNoIgnoreBuildErrors at the real config, or drop the exemption.`
-      );
-      continue;
-    }
-    if (/ignoreBuildErrors\s*:\s*true/.test(config)) {
-      errors.push(
-        `${name} sets \`ignoreBuildErrors: true\` in ${spec.verifyNoIgnoreBuildErrors}, so \`${spec.build}\`\n` +
-          `      no longer type-checks it and nothing else does either. Remove that flag, or add a\n` +
-          `      "type-check" script and delete this exemption.`
-      );
-    }
-  }
-}
-
 // ── 5. Tests are code too (objectstack#4118) ─────────────────────────────────
 // Only asked of packages that are type-checked at all: one whose whole package
 // is unchecked is already covered by DEBT above, and stacking a second entry on
 // it would just make the same gap look like two.
-const testsCovered = (pkg) => !pkg.buildExcludesTests || (pkg.hasTestConfig && pkg.chainsTestConfig);
+export const testsCovered = (pkg) =>
+  !pkg.buildSkipsTests || (pkg.hasTestConfig && pkg.chainsTestConfig && pkg.testConfigSkips.length === 0);
 
-for (const pkg of packages) {
-  if (!pkg.hasScript || pkg.testFiles === 0) continue;
+/** Up to `limit` of `paths`, rendered for an error message. */
+const listSome = (paths, limit = 3) =>
+  paths.slice(0, limit).join(", ") + (paths.length > limit ? `, +${paths.length - limit} more` : "");
 
-  // 5a. A `tsconfig.test.json` nothing runs is the objectui#3009 shape exactly:
-  //     a file that looks like enforcement while no `tsc` invocation reads it.
-  if (pkg.hasTestConfig && !pkg.chainsTestConfig) {
+export function auditPackages(packages, tables = {}) {
+  const debt = tables.debt ?? DEBT;
+  const notCompiled = tables.notCompiled ?? NOT_COMPILED;
+  const checkedByOwnBuild = tables.checkedByOwnBuild ?? CHECKED_BY_OWN_BUILD;
+  const testDebt = tables.testDebt ?? TEST_DEBT;
+  const repoRoot = tables.root ?? root;
+
+  const byName = new Map(packages.map((p) => [p.name, p]));
+  const errors = [];
+
+  // 1. Undeclared gap — a package born without a type-check script.
+  for (const pkg of packages) {
+    if (pkg.hasScript) continue;
+    if (debt[pkg.name] || notCompiled.includes(pkg.name) || checkedByOwnBuild[pkg.name]) continue;
     errors.push(
-      `${pkg.name} (${pkg.dir}) has a tsconfig.test.json that its "type-check" script never runs,\n` +
-        `      so the file looks like enforcement while nothing compiles it — the exact shape of\n` +
-        `      objectui#3009. Chain it:  "type-check": "tsc --noEmit && tsc -p tsconfig.test.json"`
+      `${pkg.name} (${pkg.dir}) has no "type-check" script, so \`pnpm type-check\` skips it entirely.\n` +
+        `      Add  "type-check": "tsc --noEmit"  to its package.json. If its types do not compile\n` +
+        `      yet, add it to DEBT in scripts/check-type-check-coverage.mjs with an error count.`
     );
-    continue;
   }
 
-  // 5b. A config that emits, or that does not actually include the tests, would
-  //     pass 5a while checking nothing.
-  if (pkg.hasTestConfig && pkg.chainsTestConfig) {
-    if (!/"noEmit"\s*:\s*true/.test(pkg.testConfig)) {
+  // 2. Ratchet — a declared gap that has been closed must leave the list.
+  for (const name of Object.keys(debt)) {
+    const pkg = byName.get(name);
+    if (!pkg) {
+      errors.push(`${name} is listed in DEBT but is not a workspace package any more — delete the entry.`);
+    } else if (pkg.hasScript) {
       errors.push(
-        `${pkg.name} (${pkg.dir}): tsconfig.test.json must set "noEmit": true — it is a checking\n` +
+        `${name} now has a "type-check" script — delete its DEBT entry so the gap cannot reopen` +
+          `${debt[name].issue ? ` (and close #${debt[name].issue} if it is done)` : ""}.`
+      );
+    }
+  }
+
+  // 3. Ratchet — an exemption only holds while the package really is not compiled.
+  for (const name of notCompiled) {
+    const pkg = byName.get(name);
+    if (!pkg) {
+      errors.push(`${name} is listed in NOT_COMPILED but is not a workspace package any more — delete the entry.`);
+      continue;
+    }
+    if (pkg.hasScript) {
+      errors.push(`${name} now has a "type-check" script — delete its NOT_COMPILED entry.`);
+      continue;
+    }
+    const acquired = [pkg.hasBuild && "a build script", pkg.hasTsconfig && "a tsconfig.json"].filter(Boolean);
+    if (acquired.length > 0) {
+      errors.push(
+        `${name} is listed in NOT_COMPILED but has gained ${acquired.join(" and ")} — it is a real package now.\n` +
+          `      Add  "type-check": "tsc --noEmit"  and remove the exemption.`
+      );
+    }
+  }
+
+  // 4. Ratchet — "its own build checks it" only holds while that stays true.
+  for (const [name, spec] of Object.entries(checkedByOwnBuild)) {
+    const pkg = byName.get(name);
+    if (!pkg) {
+      errors.push(`${name} is listed in CHECKED_BY_OWN_BUILD but is not a workspace package any more — delete the entry.`);
+      continue;
+    }
+    if (pkg.hasScript) {
+      errors.push(`${name} now has a "type-check" script — delete its CHECKED_BY_OWN_BUILD entry.`);
+      continue;
+    }
+    if (pkg.build !== spec.build) {
+      errors.push(
+        `${name} is exempt because its build is \`${spec.build}\`, which type-checks — but the build\n` +
+          `      script is now \`${pkg.build}\`. Re-confirm it still type-checks, then update or drop the entry.`
+      );
+      continue;
+    }
+    // `next build` type-checks by default; `ignoreBuildErrors` silently disables
+    // it, which would turn this exemption into exactly the hole #2911 was about.
+    if (spec.verifyNoIgnoreBuildErrors) {
+      const configPath = resolve(repoRoot, spec.verifyNoIgnoreBuildErrors);
+      let config;
+      try {
+        config = readFileSync(configPath, "utf8");
+      } catch {
+        errors.push(
+          `${name}: cannot read ${spec.verifyNoIgnoreBuildErrors}, so the exemption cannot be verified.\n` +
+            `      Point verifyNoIgnoreBuildErrors at the real config, or drop the exemption.`
+        );
+        continue;
+      }
+      if (/ignoreBuildErrors\s*:\s*true/.test(config)) {
+        errors.push(
+          `${name} sets \`ignoreBuildErrors: true\` in ${spec.verifyNoIgnoreBuildErrors}, so \`${spec.build}\`\n` +
+            `      no longer type-checks it and nothing else does either. Remove that flag, or add a\n` +
+            `      "type-check" script and delete this exemption.`
+        );
+      }
+    }
+  }
+
+  // ── 5. Tests are code too ──────────────────────────────────────────────────
+  for (const pkg of packages) {
+    if (!pkg.hasScript || pkg.testFiles === 0) continue;
+
+    // 5·0. A config this gate cannot parse: every verdict below would be a guess,
+    //      and a tsconfig that fails to parse falls back to including the whole
+    //      repository, so it is a real defect either way (see the header of
+    //      tsconfig.scripts.json — a `**/` inside a block comment did this once).
+    if (pkg.configParseErrors.length > 0) {
+      errors.push(
+        `${pkg.name} (${pkg.dir}): cannot parse ${pkg.configParseErrors.join(" and ")}, so whether any\n` +
+          `      \`tsc\` invocation reads its ${pkg.testFiles} test file(s) cannot be decided. Fix the config —\n` +
+          `      a tsconfig that fails to parse silently includes the entire repository.`
+      );
+      continue;
+    }
+
+    // 5a. A `tsconfig.test.json` nothing runs is the objectui#3009 shape exactly:
+    //     a file that looks like enforcement while no `tsc` invocation reads it.
+    if (pkg.hasTestConfig && !pkg.chainsTestConfig) {
+      errors.push(
+        `${pkg.name} (${pkg.dir}) has a tsconfig.test.json that its "type-check" script never runs,\n` +
+          `      so the file looks like enforcement while nothing compiles it — the exact shape of\n` +
+          `      objectui#3009. Chain it:  "type-check": "tsc --noEmit && tsc -p tsconfig.test.json"`
+      );
+      continue;
+    }
+
+    // 5b. A config that emits, or that does not actually read the tests its
+    //     package's build skips, would pass 5a while checking nothing.
+    if (pkg.hasTestConfig && pkg.chainsTestConfig) {
+      if (!/"noEmit"\s*:\s*true/.test(pkg.testConfig)) {
+        errors.push(
+          `${pkg.name} (${pkg.dir}): tsconfig.test.json must set "noEmit": true — it is a checking\n` +
+            `      project, and emitting would put test output in the published dist.`
+        );
+      }
+      if (pkg.testConfigSkips.length > 0) {
+        errors.push(
+          `${pkg.name} (${pkg.dir}): tsconfig.test.json does not read ${pkg.testConfigSkips.length} of the\n` +
+            `      ${pkg.buildSkips.length} test file(s) its build program skips, so those are compiled by nothing:\n` +
+            `      ${listSome(pkg.testConfigSkips)}\n` +
+            `      Its resolved "files"/"include"/"exclude" have to reach them. Note "exclude" is INHERITED\n` +
+            `      through "extends": a build config that excludes the whole \`test\` directory keeps this\n` +
+            `      project empty too unless it overrides that (objectui#3968).`
+        );
+      }
+      continue;
+    }
+
+    // 5c. Undeclared gap — tests exist and nothing reads them.
+    if (!testsCovered(pkg) && !testDebt[pkg.name]) {
+      errors.push(
+        `${pkg.name} (${pkg.dir}) has ${pkg.buildSkips.length} test file${pkg.buildSkips.length === 1 ? "" : "s"} that no \`tsc\`\n` +
+          `      invocation reads: its tsconfig.json program does not include them (correctly — it is the\n` +
+          `      build config) and no tsconfig.test.json chains off "type-check". An unchecked test can\n` +
+          `      assert a contract the compiler never checked, and then read as evidence that the contract\n` +
+          `      holds. Unread: ${listSome(pkg.buildSkips)}\n` +
+          `      Add a tsconfig.test.json (see packages/types/tsconfig.test.json, or\n` +
+          `      examples/schema-catalog/tsconfig.test.json for tests that live outside \`src/\`) and chain\n` +
+          `      it, or add a TEST_DEBT entry with the measured error count.`
+      );
+    }
+  }
+
+  // ── 5½. The narrow type-assertion project, if a package has one ────────────
+  // Some test files exist ONLY for their COMPILE-TIME assertions (`Assert<Equal<A,
+  // B>>`). Types are erased at runtime, so vitest proves nothing about those; only
+  // `tsc` does. That is objectui#3181: app-shell's `spec-symbol-parity.test.ts`
+  // carried a header calling its assertions a tripwire, while a provably-false
+  // `Assert<Equal<1, 2>>` appended to it passed `pnpm type-check` at exit 0.
+  //
+  // A package whose test tree is still in TEST_DEBT can rescue those specific
+  // files with a `tsconfig.typetests.json` that lists them explicitly, instead of
+  // waiting for the whole backlog. This section keeps that project honest — it is
+  // worth exactly as much as the gate that runs it, and nothing at all otherwise.
+  for (const pkg of packages) {
+    if (!pkg.hasTypeTestsConfig) continue;
+
+    if (!pkg.chainsTypeTestsConfig) {
+      errors.push(
+        `${pkg.name} (${pkg.dir}) has a tsconfig.typetests.json that its "type-check" script never\n` +
+          `      runs, so its compile-time assertions are erased at runtime and compiled by nothing —\n` +
+          `      the exact state objectui#3181 fixed. CI runs \`pnpm type-check\` (turbo -> the package's\n` +
+          `      own "type-check"), so that is the script that has to chain it:\n` +
+          `      "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json"`
+      );
+      continue;
+    }
+
+    if (!/"noEmit"\s*:\s*true/.test(pkg.typeTestsConfig)) {
+      errors.push(
+        `${pkg.name} (${pkg.dir}): tsconfig.typetests.json must set "noEmit": true — it is a checking\n` +
           `      project, and emitting would put test output in the published dist.`
       );
     }
-    if (!/\*\.test\./.test(pkg.testConfig)) {
+
+    if (!/\.test\.tsx?"/.test(pkg.typeTestsConfig)) {
       errors.push(
-        `${pkg.name} (${pkg.dir}): tsconfig.test.json does not "include" any test glob, so it\n` +
-          `      compiles nothing. Add  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]`
+        `${pkg.name} (${pkg.dir}): tsconfig.typetests.json does not "include" any test file, so it\n` +
+          `      compiles nothing and passes vacuously. List the files whose type assertions it exists\n` +
+          `      to check, e.g. "include": ["src/__tests__/spec-symbol-parity.test.ts"]`
       );
     }
-    continue;
   }
 
-  // 5c. Undeclared gap — tests exist and nothing reads them.
-  if (!testsCovered(pkg) && !TEST_DEBT[pkg.name]) {
-    errors.push(
-      `${pkg.name} (${pkg.dir}) has ${pkg.testFiles} test file${pkg.testFiles === 1 ? "" : "s"} that no \`tsc\`\n` +
-        `      invocation reads: its tsconfig.json excludes them (correctly — it is the build config)\n` +
-        `      and no tsconfig.test.json chains off "type-check". An unchecked test can assert a\n` +
-        `      contract the compiler never checked, and then read as evidence that the contract holds.\n` +
-        `      Add a tsconfig.test.json (see packages/types/tsconfig.test.json) and chain it, or add a\n` +
-        `      TEST_DEBT entry with the measured error count.`
-    );
-  }
-}
-
-// ── 5½. The narrow type-assertion project, if a package has one ──────────────
-// Some test files exist ONLY for their COMPILE-TIME assertions (`Assert<Equal<A,
-// B>>`). Types are erased at runtime, so vitest proves nothing about those; only
-// `tsc` does. That is objectui#3181: app-shell's `spec-symbol-parity.test.ts`
-// carried a header calling its assertions a tripwire, while a provably-false
-// `Assert<Equal<1, 2>>` appended to it passed `pnpm type-check` at exit 0.
-//
-// A package whose test tree is still in TEST_DEBT can rescue those specific
-// files with a `tsconfig.typetests.json` that lists them explicitly, instead of
-// waiting for the whole backlog. This section keeps that project honest — it is
-// worth exactly as much as the gate that runs it, and nothing at all otherwise.
-for (const pkg of packages) {
-  if (!pkg.hasTypeTestsConfig) continue;
-
-  if (!pkg.chainsTypeTestsConfig) {
-    errors.push(
-      `${pkg.name} (${pkg.dir}) has a tsconfig.typetests.json that its "type-check" script never\n` +
-        `      runs, so its compile-time assertions are erased at runtime and compiled by nothing —\n` +
-        `      the exact state objectui#3181 fixed. CI runs \`pnpm type-check\` (turbo -> the package's\n` +
-        `      own "type-check"), so that is the script that has to chain it:\n` +
-        `      "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json"`
-    );
-    continue;
+  // 6. Ratchet — a declared test gap that has been closed must leave the list.
+  for (const [name, spec] of Object.entries(testDebt)) {
+    const pkg = byName.get(name);
+    if (!pkg) {
+      errors.push(`${name} is listed in TEST_DEBT but is not a workspace package any more — delete the entry.`);
+      continue;
+    }
+    if (pkg.testFiles === 0) {
+      errors.push(`${name} is listed in TEST_DEBT but has no test files any more — delete the entry.`);
+      continue;
+    }
+    // A package that is not type-checked AT ALL is already declared in DEBT. A
+    // second entry here would make one gap read as two, and would survive the day
+    // DEBT is paid off, so the test gap has to be re-measured then anyway.
+    if (!pkg.hasScript) {
+      errors.push(
+        `${name} is listed in TEST_DEBT but has no "type-check" script, so its whole package is\n` +
+          `      unchecked and DEBT already declares that. Delete the TEST_DEBT entry; add it back with\n` +
+          `      a fresh measurement once the package type-checks at all.`
+      );
+      continue;
+    }
+    if (testsCovered(pkg)) {
+      errors.push(
+        `${name} type-checks its tests now — delete its TEST_DEBT entry so the gap cannot reopen` +
+          `${spec.issue ? ` (and close #${spec.issue} if the list is empty)` : ""}.`
+      );
+    }
   }
 
-  if (!/"noEmit"\s*:\s*true/.test(pkg.typeTestsConfig)) {
-    errors.push(
-      `${pkg.name} (${pkg.dir}): tsconfig.typetests.json must set "noEmit": true — it is a checking\n` +
-        `      project, and emitting would put test output in the published dist.`
-    );
-  }
-
-  if (!/\.test\.tsx?"/.test(pkg.typeTestsConfig)) {
-    errors.push(
-      `${pkg.name} (${pkg.dir}): tsconfig.typetests.json does not "include" any test file, so it\n` +
-        `      compiles nothing and passes vacuously. List the files whose type assertions it exists\n` +
-        `      to check, e.g. "include": ["src/__tests__/spec-symbol-parity.test.ts"]`
-    );
-  }
-}
-
-// 6. Ratchet — a declared test gap that has been closed must leave the list.
-for (const [name, spec] of Object.entries(TEST_DEBT)) {
-  const pkg = byName.get(name);
-  if (!pkg) {
-    errors.push(`${name} is listed in TEST_DEBT but is not a workspace package any more — delete the entry.`);
-    continue;
-  }
-  if (pkg.testFiles === 0) {
-    errors.push(`${name} is listed in TEST_DEBT but has no test files any more — delete the entry.`);
-    continue;
-  }
-  // A package that is not type-checked AT ALL is already declared in DEBT. A
-  // second entry here would make one gap read as two, and would survive the day
-  // DEBT is paid off, so the test gap has to be re-measured then anyway.
-  if (!pkg.hasScript) {
-    errors.push(
-      `${name} is listed in TEST_DEBT but has no "type-check" script, so its whole package is\n` +
-        `      unchecked and DEBT already declares that. Delete the TEST_DEBT entry; add it back with\n` +
-        `      a fresh measurement once the package type-checks at all.`
-    );
-    continue;
-  }
-  if (testsCovered(pkg)) {
-    errors.push(
-      `${name} type-checks its tests now — delete its TEST_DEBT entry so the gap cannot reopen` +
-        `${spec.issue ? ` (and close #${spec.issue} if the list is empty)` : ""}.`
-    );
-  }
+  return errors;
 }
 
 // ── Report ───────────────────────────────────────────────────────────────────
-const checked = packages.filter((p) => p.hasScript).length;
-const debtCount = Object.keys(DEBT).length;
-const debtErrors = Object.values(DEBT).reduce((sum, d) => sum + d.errors, 0);
-const byBuild = Object.keys(CHECKED_BY_OWN_BUILD).length;
+export function main() {
+  const packages = collect();
+  const errors = auditPackages(packages);
 
-const withTests = packages.filter((p) => p.hasScript && p.testFiles > 0);
-const testsChecked = withTests.filter(testsCovered).length;
-const testDebtErrors = Object.values(TEST_DEBT).reduce((sum, d) => sum + d.errors, 0);
-const typeTestProjects = packages.filter((p) => p.hasTypeTestsConfig && p.chainsTypeTestsConfig).length;
+  const checked = packages.filter((p) => p.hasScript).length;
+  const debtCount = Object.keys(DEBT).length;
+  const debtErrors = Object.values(DEBT).reduce((sum, d) => sum + d.errors, 0);
+  const byBuild = Object.keys(CHECKED_BY_OWN_BUILD).length;
 
-if (errors.length === 0) {
-  console.log(
-    `✅  type-check coverage: ${checked}/${packages.length} via \`type-check\`, ` +
-      `${byBuild} via their own build, ` +
-      `${debtCount} known-broken (${debtErrors} errors outstanding), ` +
-      `${NOT_COMPILED.length} not compiled.`
+  const withTests = packages.filter((p) => p.hasScript && p.testFiles > 0);
+  const testsChecked = withTests.filter(testsCovered).length;
+  const testDebtErrors = Object.values(TEST_DEBT).reduce((sum, d) => sum + d.errors, 0);
+  const typeTestProjects = packages.filter((p) => p.hasTypeTestsConfig && p.chainsTypeTestsConfig).length;
+
+  if (errors.length === 0) {
+    console.log(
+      `✅  type-check coverage: ${checked}/${packages.length} via \`type-check\`, ` +
+        `${byBuild} via their own build, ` +
+        `${debtCount} known-broken (${debtErrors} errors outstanding), ` +
+        `${NOT_COMPILED.length} not compiled.`
+    );
+    console.log(
+      `✅  test type-check coverage: ${testsChecked}/${withTests.length} packages compile their tests, ` +
+        `${Object.keys(TEST_DEBT).length} declared debt (${testDebtErrors} errors outstanding), ` +
+        `${typeTestProjects} with a narrow type-assertion project.`
+    );
+    process.exit(0);
+  }
+
+  console.error("❌  type-check coverage regressed:\n");
+  for (const message of errors) {
+    console.error(`    • ${message}`);
+  }
+  console.error(
+    "\nA package with no `type-check` script is not passing — turbo skips it and CI sees nothing.\n" +
+      "A TEST file no program reads is not passing either — nothing compiles it, so what it asserts\n" +
+      "about a contract was never checked (objectstack#4118, objectui#3968).\n" +
+      "See https://github.com/objectstack-ai/objectui/issues/2911 for why this guard exists."
   );
-  console.log(
-    `✅  test type-check coverage: ${testsChecked}/${withTests.length} packages compile their tests, ` +
-      `${Object.keys(TEST_DEBT).length} declared debt (${testDebtErrors} errors outstanding), ` +
-      `${typeTestProjects} with a narrow type-assertion project.`
-  );
-  process.exit(0);
+  process.exit(1);
 }
 
-console.error("❌  type-check coverage regressed:\n");
-for (const message of errors) {
-  console.error(`    • ${message}`);
-}
-console.error(
-  "\nA package with no `type-check` script is not passing — turbo skips it and CI sees nothing.\n" +
-    "An excluded TEST file is not passing either — nothing compiles it, so what it asserts about\n" +
-    "a contract was never checked (objectstack#4118).\n" +
-    "See https://github.com/objectstack-ai/objectui/issues/2911 for why this guard exists."
-);
-process.exit(1);
+// Run only when invoked directly — `scripts/__tests__/check-type-check-coverage.test.ts`
+// imports `collect()` / `auditPackages()` from here and must not trigger a repo
+// scan (or a `process.exit`) on import. Same guard shape as
+// `scripts/check-skills-paths.mjs` and `scripts/check-control-bytes.mjs`.
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) main();


### PR DESCRIPTION
Fixes #3968

## 结论先说

门的两个盲区都不是"少认一种写法",而是**用文本猜程序内容**。这个 PR 把判据换成"解析后的 tsconfig 程序到底读了哪些文件",两个盲区就一起消失了;`examples/schema-catalog` 的 4 个测试文件同时接上 tsc 编译。

基 sha `0cbdca888`。修前门是绿的(`23/38 packages compile their tests`,本包不在分母里);修后是 `24/39`。

## 一、门修(`scripts/check-type-check-coverage.mjs`)

**盲区 1 —— 只递归 `src/`(原 `:180`)**:`countTestFiles(resolve(root, dir, "src"))` 改为从**包根**枚举(`listTestFiles`,跳过 `node_modules` / `dist` / `coverage` / 点目录)。本包测试住在 `test/`,原先数到 0,于是 `:299` 的 `if (!pkg.hasScript || pkg.testFiles === 0) continue;` 把整个 5c 跳过了 —— 最该说话的检查根本没跑。

**盲区 2 —— 只认 glob 形式的排除(原 `:182`)**:`buildExcludesTests = /\*\.test\./.test(tsconfig)` 改为解析每个 tsconfig 的 `files` / `include` / `exclude`(并沿 `extends` 继承,按声明它的那个 config 的目录解析),逐个测试文件问"这个程序读不读它"。

第二处特意**不是**"再加一条识别目录形式排除的规则"。因为按目录排除只是这一族里的一种写法,还有一种任何 glob 探测都抓不到的:`include: ["src/**/*"]` 且**根本没有 exclude**,测试在 `test/` —— 程序同样一个字节都没读。改成按解析后的程序判定,目录形式排除是 TS 文档语义的自然结果(无扩展名、无通配符的 pattern 就是目录,递归匹配),上面那种也一并抓到。pin 测试里两种形态各有一条。

**顺带收紧 5b(如实披露,这是第三处改动)**:原判据是"testConfig 里出现过 `*.test.` 这样的 glob",现在要求这个 project **真的读到 build 程序漏掉的那些文件**。这不是顺手加严 —— 我自己写本包的 `tsconfig.test.json` 时第一版就踩了:`exclude` 是**沿 extends 继承**的,父配置排除了整个 `test` 目录,于是这个 project 编译了 0 个文件。`tsc` 恰好会喊 TS18003("No inputs were found"),但只覆盖**一部分**测试的 project 是静默的 —— 那正是原判据放过去的形状。

**另加一条 5·0**:tsconfig 解析不了时不再猜覆盖率,而是单独报错(一个解析失败的 tsconfig 会退化成包含整个仓库,本身就是缺陷;`tsconfig.scripts.json` 的头注释记过一次块注释里的 `**/` 把配置弄坏的事故)。注释剥离是**字符串感知**的:本仓每个 include/exclude pattern 里都有 `/*`,粗暴剥离会把它要保护的 glob 吃掉。

脚本结构按仓内既有门的形态改(`check-skills-paths.mjs` / `check-changeset-presence.mjs`):纯函数 `export`,`main()` 收尾,`invokedDirectly` 守卫 —— 否则 pin 测试一 import 就会扫全仓并 `process.exit`。DEBT / NOT_COMPILED / CHECKED_BY_OWN_BUILD / TEST_DEBT 四张表和其余各节的判据、文案一字未动,`auditPackages(packages, tables)` 允许 fixture 传空表。

## 二、补覆盖(`examples/schema-catalog`)

形态取仓内既有形态(先读了 `packages/types`、`packages/sdui-parser`、`packages/layout`、`packages/plugin-report` 四个包):新增 `tsconfig.test.json` + `type-check` 串起来。

与既有 23 个包的差异只在必要处,每处都写了原因:`include` 指向 `test/` 而不是 `src/`;`exclude` 必须**显式重写**(见上);`rootDir` 放宽到包根(测试在 `src` 旁边而不是里面);补 `jsx: react-jsx`(测试是 `.tsx`,build 配置没有 jsx 因为 `src/` 只有 JSON 和 `.ts`);`noEmit` / `declaration` / `composite` 归零。没有折进 `tsconfig.json` —— 那是 build 配置(`tsc` 到 `dist`、`rootDir: ./src`),测试会被 emit 进发布产物。

**首次编译暴露的问题(1 条,如实披露)**:`fields-form-hosted.test.tsx` 里 `import '@object-ui/fields'`,而 `package.json` 从未声明它 —— 幻影依赖,只靠 vitest 的 alias 解析(`packages/sdui-parser/tsconfig.test.json` 的注释记着同一类发现)。已补为 devDependency,pnpm-lock 相应更新。补上之后 4 个文件**零错误**,所以不需要 TEST_DEBT 条目。

⛔ 未动这 4 个测试文件的任何内容,也未动 `src/schemas/**` 与 `div.tsx`(#3965 的面)。

## 三、反向钉

`scripts/__tests__/check-type-check-coverage.test.ts`(21 条,全部对着 tmpdir 里的一次性包树,仓内不留刻意失效的 fixture)。除了正常判据,两条被替换掉的旧谓词**按原样重现在测试里**当断言用:本 bug 的原形态既被断言"新门必须报 1 条 5c",也被断言"旧的 src-only 计数 = 0、旧的 glob 探测 = false" —— 两个盲区变成可执行语句。

实际反向验证(先定方向后跑,都是"红"方向):

- 把 `listTestFiles(packageDir)` 改回 `listTestFiles(resolve(packageDir, "src"))` → **21 条里 12 条红**(含"全仓只有本包测试在 src 外"那条)。
- 删掉目录形式 pattern 的展开一行 → **3 条红**,并且门对真仓库产生 4 条误报(`fields` / `plugin-charts` / `plugin-editor` / `console` 的 `include: ["src"]` 不再展开)—— 两个方向都证明这行是承重的。
- 把本包的 `tsconfig.test.json` 与 `type-check` 串接临时撤掉 → 门 exit 1,正是 5c 那条,点名 4 个文件(这就是"修后对现状必须红"的证据)。
- 往 `test/smoke.test.tsx` 临时塞一个类型错误 → `turbo run type-check` 红(`error TS2322`),已还原、工作树干净。顺手核了 turbo 的 `type-check` 任务 inputs 是 `$TURBO_DEFAULT$`,所以 `test/**` 在缓存键里,改测试文件不会命中旧缓存。

最后一组断言是对**真仓库**的(不是 fixture):本包测试存在、全在 `src/` 外、build 程序不读它们、test project 读全了。撤销任一半都会红。

## 四、孤例复核

重验了一遍(`git ls-files` 独立于门自己的 walker):`*.test.ts(x)` 共 1129 个 —— packages 1070、apps 28、scripts 27(我这条之后 28)、examples 4;按包切分,测试在 `src/` 外的**只有** `examples/schema-catalog`(outside_src=4 / in_src=0)。`scripts/` 那 27 个由 `tsconfig.scripts.json` 覆盖(`pnpm type-check:scripts` 已跑绿)。dev 报告的结论成立,只是文件数是 4 而不是 5(分诊评论已记录这个漂移)。

## 验证

- `pnpm exec vitest run examples/schema-catalog --maxWorkers=2` → `Test Files 4 passed (4) / Tests 1090 passed`
- `pnpm exec vitest run scripts/__tests__/check-type-check-coverage.test.ts` → `21 passed`
- `pnpm exec turbo run type-check --concurrency=2` → `78 successful, 78 total`(本包实跑 `tsc --noEmit && tsc -p tsconfig.test.json`)
- `pnpm type-check:scripts` → exit 0
- `node scripts/check-type-check-coverage.mjs` → 绿,`24/39`
- `node scripts/check-control-bytes.mjs` → OK(另按 `grep -naP` 自查过改动文件,无匹配)
- eslint 改动文件 → 0 problems

## changeset

不需要 —— 以 presence 门的实测判定为据:`node scripts/check-changeset-presence.mjs` 输出 `5 file(s) changed, 0 of them under the src/ of a package the release covers` → `No source of a released package changed in this range, so no changeset is owed.`(改动面是 CI 脚本 + 一个 private example 包的清单/配置。)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_