### PR TITLE
fix(plugin-map): 删掉模块作用域遗留的 console.log('Registering object-map...') (objectstack#7139)

### DIFF
--- a/.changeset/plugin-map-drop-module-scope-console-log-7139.md
+++ b/.changeset/plugin-map-drop-module-scope-console-log-7139.md
@@ -1,0 +1,27 @@
+---
+"@object-ui/plugin-map": patch
+---
+
+`plugin-map` 加载时不再向控制台打印 `Registering object-map...`
+
+`packages/plugin-map/src/index.tsx` 的注册调用之前留着一句调试输出
+`console.log('Registering object-map...')`。它位于**模块作用域**,所以不是「渲染地图时打一行」,
+而是**只要这个 plugin 被 import 就打一行**:console 应用的 `register-plugins` 一加载即触发,
+单元测试里跟着刷,生产 bundle 同样保留 —— 使用者控制台里凭空多出一行来源不明的噪音。
+
+同仓其余 18 个 plugin 的 `src/index.tsx` 注册处都没有这类输出,这一句是孤例
+(`plugin-editor` 里唯一的 `console.log` 命中是 `defaultProps.value` 示例代码字符串,
+不是会执行的语句)。纯噪音,不涉及任何行为:注册本身、`ObjectMap` 的渲染与取数都不读它。
+
+顺带记一条搜索时确认的背景:仓库的 eslint 配置没有开 `no-console` 规则,所以这类遗留
+调试输出没有任何自动化拦网 —— 这次是靠人工发现的。是否全仓开 `no-console`(以及
+`ObjectMap.tsx` 里三处**有意**保留的 `console.warn`/`console.error` 诊断如何豁免)是一个
+影响多个包的策略决定,已另行开单,不混进本 PR。
+
+回潮钉在 `src/index.registration.test.tsx`:spy 掉 `console.log`/`info`/`debug` 后
+`vi.resetModules()` 再 `import('./index')`,断言零输出。钉子刻意只覆盖这三个「噪音通道」,
+不含 `warn`/`error` —— `ComponentRegistry.register()` 在缺 namespace、以及裸名 fallback
+覆盖冲突时**按设计**会 `console.warn`(`packages/core/src/registry/Registry.ts`),
+一刀切断言「零 console 输出」等于把 Registry 的诊断契约钉在这里,将来会因与「遗留调试输出」
+无关的原因变红。钉子里还有一条非空断言:import 后校验 `object-map`/`map` 两个注册确实进了
+registry,免得模块缓存导致 import 未真正执行、于是「没有输出」是因为**什么都没发生**而假绿。

--- a/packages/plugin-map/src/index.registration.test.tsx
+++ b/packages/plugin-map/src/index.registration.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// `src/index.tsx` pulls in `ObjectMap.tsx`, which imports the real map bindings.
+// Stub them so a plain module import needs no WebGL canvas (`maplibre-gl` itself
+// is already stubbed in `vitest.setup.ts`).
+vi.mock('react-map-gl/maplibre', () => ({
+  default: () => null,
+  Map: () => null,
+  NavigationControl: () => null,
+  Marker: () => null,
+  Popup: () => null,
+}));
+
+/**
+ * Regression pin for objectstack#7139: a leftover
+ * `console.log('Registering object-map...')` sat at this module's top level, so
+ * *merely loading* the plugin printed to the console — in the console app (where
+ * `register-plugins` imports it eagerly), in tests, and in the production bundle.
+ *
+ * Scope note — this asserts the debug-noise channels (`log`/`info`/`debug`) only,
+ * deliberately not `warn`/`error`. `ComponentRegistry.register()` warns by design
+ * on namespace-less registration and on bare-name fallback collisions
+ * (`packages/core/src/registry/Registry.ts`), so a blanket "zero console output"
+ * assertion here would be pinning *Registry's* diagnostics contract rather than
+ * this module's, and would go red for reasons unrelated to a leftover debug print.
+ * The defect class being pinned is the leftover debug print itself.
+ */
+const NOISE_CHANNELS = ['log', 'info', 'debug'] as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('plugin-map module load', () => {
+  it('registers its components without printing to the console', async () => {
+    const spies = new Map(
+      NOISE_CHANNELS.map((channel) => [
+        channel,
+        vi.spyOn(console, channel).mockImplementation(() => {}),
+      ])
+    );
+
+    // Re-evaluate the module even if another test file already imported it, so
+    // the top-level side effects actually run under the spies rather than being
+    // served from the module cache (which would make this assertion vacuous).
+    vi.resetModules();
+    await import('./index');
+
+    // Non-vacuity guard: prove the module body really executed. Without this a
+    // silently skipped import would satisfy the console assertion for the wrong
+    // reason — green because nothing happened, not because nothing printed.
+    const { ComponentRegistry } = await import('@object-ui/core');
+    expect(ComponentRegistry.has('object-map', 'plugin-map')).toBe(true);
+    expect(ComponentRegistry.has('map', 'view')).toBe(true);
+
+    const printed = NOISE_CHANNELS.flatMap((channel) =>
+      spies.get(channel)!.mock.calls.map((args) => `console.${channel}(${JSON.stringify(args)})`)
+    );
+    expect(printed).toEqual([]);
+  });
+});

--- a/packages/plugin-map/src/index.tsx
+++ b/packages/plugin-map/src/index.tsx
@@ -61,7 +61,6 @@ export const ObjectMapRenderer: React.FC<any> = ({ schema, ...props }) => {
   );
 };
 
-console.log('Registering object-map...');
 ComponentRegistry.register('object-map', ObjectMapRenderer, {
   namespace: 'plugin-map',
   label: 'Object Map',


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7139

## 问题

`packages/plugin-map/src/index.tsx` 在两处 `ComponentRegistry.register` 调用之前留着一句调试输出:

```ts
console.log('Registering object-map...');
```

它位于**模块作用域**,所以不是「渲染地图时打一行」,而是**只要这个 plugin 被 import 就打一行**:console 应用的 `register-plugins` 一加载即触发,单元测试里跟着刷,生产 bundle 同样保留 —— 使用者控制台里凭空多出一行来源不明的噪音。纯噪音,不涉及任何行为:注册本身、`ObjectMap` 的渲染与取数都不读它。

**孤例已核实**:遍历同仓 19 个 `packages/plugin-*/src/index.tsx`,只有 plugin-map 有这句。`plugin-editor` 里唯一的 `console.log` 命中是 `defaultProps.value` 里的示例代码字符串,不是会执行的语句。

## 前提复核(issue 正文是线索,不是规格)

issue 说的是第 24 行,实际在 `origin/main` 上已经是**第 64 行** —— objectstack#7121 的 dataSource 绑定(commit 022002aba)在它上方插入了注释与代码。行号漂移,但结论成立:这句 `console.log` 确实还在模块作用域。基线 sha 见下。

## 改动

1. 删掉那一行。同文件 objectstack#7121 刚落的 `dataSource` 绑定**零触碰**。
2. 防回潮钉 `packages/plugin-map/src/index.registration.test.tsx`。

## 关于钉子的两个刻意取舍

**只覆盖 log / info / debug 三个「噪音通道」,不含 warn / error。** `ComponentRegistry.register()` 在缺 namespace、以及裸名 fallback 覆盖冲突时**按设计**会 `console.warn`(见 `packages/core/src/registry/Registry.ts`)。一刀切断言「零 console 输出」等于把 Registry 的诊断契约钉在 plugin-map 这里,将来会因与「遗留调试输出」完全无关的原因变红。要钉的缺陷类就是**遗留调试输出**本身。另外 `ObjectMap.tsx` 里三处 `console.warn` / `console.error` 是有意保留的运行时诊断,同理不该被这条钉子牵连。

**含一条非空断言。** import 之后校验 `object-map`(namespace `plugin-map`)与 `map`(namespace `view`)两个注册确实进了 registry。没有这条,一旦模块缓存导致 `import` 未真正执行,「没有输出」就会是因为**什么都没发生**而假绿 —— 断言通过的原因是错的。配套用 `vi.resetModules()` 保证模块体在 spy 之下重新求值,解决 import 不可重放的问题。

## 反向验证(方向先判后跑)

预判方向:**保留 console.log 时钉子必须红**,因为断言直接指向被删语句的唯一效果,不存在反转可能。实跑一致 —— 先在**未修改**的 `index.tsx` 上跑钉子:

```
AssertionError: expected [ Array(1) ] to deeply equal []
- []
+ [ "console.log([\"Registering object-map...\"])" ]
```

红,且原样抓到被删语句的 payload;两条 registry 非空断言在它之前先通过,证明模块体确实执行了(不是空跑假红)。删掉该行后转绿。

## 验证

- `pnpm exec vitest run packages/plugin-map --maxWorkers=2` → **4 files / 11 tests 全绿**
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **78 successful, 78 total**
- `pnpm --filter @object-ui/plugin-map lint` → **0 errors**(58 条既有 warning,新增测试文件零命中)
- `node scripts/check-control-bytes.mjs` → OK(3910 tracked text files)

changeset:`.changeset/plugin-map-drop-module-scope-console-log-7139.md`(patch)。

## 超范围发现(未在本 PR 修)

仓库 eslint 配置**没有开 `no-console` 规则**,所以这类遗留调试输出没有任何自动化拦网,这次靠人工发现。是否全仓开启(以及 `ObjectMap.tsx` 那三处有意保留的诊断如何豁免)是影响多个包的策略决定,不该混进这个 XS 单 —— 另行开单交 PM 分诊。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_