### PR TITLE
fix(schema-catalog): grid 示例的列数键 cols → columns —— 3/4 列示例不再静默渲染成 2 列 (#4001)

### DIFF
--- a/examples/schema-catalog/src/schemas/auth/signup.json
+++ b/examples/schema-catalog/src/schemas/auth/signup.json
@@ -19,7 +19,7 @@
       "children": [
         {
           "type": "grid",
-          "cols": 2,
+          "columns": 2,
           "gap": 4,
           "children": [
             {

--- a/examples/schema-catalog/src/schemas/components-basic-div/grid-layout.json
+++ b/examples/schema-catalog/src/schemas/components-basic-div/grid-layout.json
@@ -1,6 +1,6 @@
 {
   "type": "grid",
-  "cols": 2,
+  "columns": 2,
   "gap": 4,
   "children": [
     {

--- a/examples/schema-catalog/src/schemas/components-complex-resizable/complex-layout.json
+++ b/examples/schema-catalog/src/schemas/components-complex-resizable/complex-layout.json
@@ -26,7 +26,7 @@
                     },
                     {
                       "type": "grid",
-                      "cols": 2,
+                      "columns": 2,
                       "gap": 4,
                       "children": [
                         {

--- a/examples/schema-catalog/src/schemas/components-data-display-statistic/metrics-grid.json
+++ b/examples/schema-catalog/src/schemas/components-data-display-statistic/metrics-grid.json
@@ -1,6 +1,6 @@
 {
   "type": "grid",
-  "cols": 3,
+  "columns": 3,
   "gap": 4,
   "children": [
     {

--- a/examples/schema-catalog/src/schemas/components-data-display-statistic/sales-dashboard.json
+++ b/examples/schema-catalog/src/schemas/components-data-display-statistic/sales-dashboard.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "grid",
-      "cols": 2,
+      "columns": 2,
       "gap": 4,
       "children": [
         {

--- a/examples/schema-catalog/src/schemas/components-layout-page/full-dashboard.json
+++ b/examples/schema-catalog/src/schemas/components-layout-page/full-dashboard.json
@@ -5,7 +5,7 @@
   "body": [
     {
       "type": "grid",
-      "cols": 4,
+      "columns": 4,
       "gap": 4,
       "className": "mb-6",
       "children": [

--- a/examples/schema-catalog/src/schemas/components-layout-page/page-with-header.json
+++ b/examples/schema-catalog/src/schemas/components-layout-page/page-with-header.json
@@ -5,7 +5,7 @@
   "body": [
     {
       "type": "grid",
-      "cols": 3,
+      "columns": 3,
       "gap": 4,
       "children": [
         {

--- a/examples/schema-catalog/src/schemas/forms/contact-form.json
+++ b/examples/schema-catalog/src/schemas/forms/contact-form.json
@@ -26,7 +26,7 @@
       "children": [
         {
           "type": "grid",
-          "cols": 2,
+          "columns": 2,
           "gap": 4,
           "children": [
             {

--- a/examples/schema-catalog/src/schemas/forms/payment-form.json
+++ b/examples/schema-catalog/src/schemas/forms/payment-form.json
@@ -64,7 +64,7 @@
             },
             {
               "type": "grid",
-              "cols": 3,
+              "columns": 3,
               "gap": 4,
               "children": [
                 {

--- a/examples/schema-catalog/src/schemas/plugin-view/form-view-mode.json
+++ b/examples/schema-catalog/src/schemas/plugin-view/form-view-mode.json
@@ -15,7 +15,7 @@
       "children": [
         {
           "type": "grid",
-          "cols": 2,
+          "columns": 2,
           "gap": 4,
           "children": [
             {

--- a/examples/schema-catalog/src/schemas/report/report-header-with-kpis.json
+++ b/examples/schema-catalog/src/schemas/report/report-header-with-kpis.json
@@ -53,7 +53,7 @@
     },
     {
       "type": "grid",
-      "cols": 4,
+      "columns": 4,
       "gap": 4,
       "children": [
         {

--- a/examples/schema-catalog/src/schemas/theme/semantic-color-palette.json
+++ b/examples/schema-catalog/src/schemas/theme/semantic-color-palette.json
@@ -1,6 +1,6 @@
 {
   "type": "grid",
-  "cols": 4,
+  "columns": 4,
   "gap": 3,
   "className": "p-4",
   "children": [

--- a/examples/schema-catalog/src/schemas/theme/theme-aware-ui-elements.json
+++ b/examples/schema-catalog/src/schemas/theme/theme-aware-ui-elements.json
@@ -61,7 +61,7 @@
     },
     {
       "type": "grid",
-      "cols": 2,
+      "columns": 2,
       "gap": 3,
       "children": [
         {

--- a/examples/schema-catalog/test/grid-columns-key.test.tsx
+++ b/examples/schema-catalog/test/grid-columns-key.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Catalog-wide guardrail: `grid` nodes declare their column count as `columns`,
+ * never `cols` (objectui#4001).
+ *
+ * `GridSchema` declares `columns` (`packages/types/src/layout.ts`), the `grid`
+ * renderer reads only `schema.columns`, and the registered designer `inputs`
+ * expose only `columns` / `smColumns` / `mdColumns` / `lgColumns` / `xlColumns`.
+ * `cols` was never declared by the spec, the types, or the registry — nothing in
+ * `core` / `react` / `types` normalizes it. Thirteen catalog examples spelled it
+ * anyway, so the engine dropped the value on the floor: `baseCols` fell back to
+ * its literal `2` default AND the mobile-first ramp never fired (it is gated on
+ * `typeof schema.columns === 'number'`), producing a flat two columns at EVERY
+ * breakpoint. Examples asking for three or four columns rendered as two on the
+ * docs site, in production builds included.
+ *
+ * The fix is at the producer, not the renderer: no `schema.columns ?? schema.cols`
+ * alias was added, because a lenient consumer fossilizes the wrong spelling into a
+ * second de-facto contract (AGENTS.md #0.1). This file is the ratchet that keeps
+ * the fourteenth `cols` out — every shipped example is copy-paste reference
+ * material and an AI few-shot retrieval source, so a wrong key here teaches the
+ * mistake at scale.
+ *
+ * Two different facts get pinned:
+ *
+ *  1. DATA — no `grid` node anywhere in the catalog carries a `cols` key, and the
+ *     thirteen repaired examples each still declare the column count they were
+ *     written to demonstrate (so the guard cannot pass by the keys having simply
+ *     been deleted).
+ *  2. RENDER — a sample of the repaired examples, driven through the real
+ *     registered `grid` renderer, produces the responsive class ramp. These are
+ *     the NEW correct values: every one of them differs from what `cols` produced
+ *     (`grid grid-cols-2 gap-N`), including the "coincidentally 2" cases, whose
+ *     base breakpoint now collapses to one column as the ramp intends.
+ *
+ * Module-scope import of `@object-ui/components`, not `beforeAll` (AGENTS.md
+ * §测试纪律): registering the renderers is an unbounded module load and must not
+ * be billed to a bounded hook timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@object-ui/components';
+import { SchemaRenderer } from '@object-ui/react';
+import { allExamples } from '../src/index.js';
+
+type Node = Record<string, unknown>;
+
+/** Collect every `type: 'grid'` node anywhere in a schema tree. */
+function collectGridNodes(node: unknown, out: Node[] = []): Node[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collectGridNodes(item, out);
+    return out;
+  }
+  if (node && typeof node === 'object') {
+    const rec = node as Node;
+    if (rec.type === 'grid') out.push(rec);
+    for (const value of Object.values(rec)) collectGridNodes(value, out);
+  }
+  return out;
+}
+
+/**
+ * The thirteen examples repaired by #4001, with the column count each one was
+ * written to demonstrate. Asserting the VALUE (not merely the absence of `cols`)
+ * is what makes the ban above non-vacuous: dropping the key entirely would
+ * silence the ban while re-breaking the example.
+ */
+const REPAIRED: ReadonlyArray<readonly [string, number]> = [
+  ['auth/signup', 2],
+  ['components-basic-div/grid-layout', 2],
+  ['components-complex-resizable/complex-layout', 2],
+  ['components-data-display-statistic/metrics-grid', 3],
+  ['components-data-display-statistic/sales-dashboard', 2],
+  ['components-layout-page/full-dashboard', 4],
+  ['components-layout-page/page-with-header', 3],
+  ['forms/contact-form', 2],
+  ['forms/payment-form', 3],
+  ['plugin-view/form-view-mode', 2],
+  ['report/report-header-with-kpis', 4],
+  ['theme/semantic-color-palette', 4],
+  ['theme/theme-aware-ui-elements', 2],
+];
+
+describe('schema-catalog — grid nodes spell their column count `columns` (#4001)', () => {
+  it('no grid node in the catalog carries an undeclared `cols` key', () => {
+    const offenders = allExamples().flatMap((example) =>
+      collectGridNodes(example.schema)
+        .filter((node) => Object.hasOwn(node, 'cols'))
+        .map((node) => `${example.id} (cols: ${JSON.stringify(node.cols)})`),
+    );
+    expect(
+      offenders,
+      '`cols` is not declared by GridSchema, the grid renderer, or the registry — ' +
+        'the engine drops it silently and the example renders 2 columns at every ' +
+        'breakpoint. Spell it `columns`; do not teach the renderer the alias (#4001).',
+    ).toEqual([]);
+  });
+
+  it('sees enough grid nodes for the ban to mean something (guard is not vacuous)', () => {
+    const gridNodes = allExamples().flatMap((example) => collectGridNodes(example.schema));
+    // 21 at the time of writing; a floor, so adding examples never fails this.
+    expect(gridNodes.length).toBeGreaterThanOrEqual(21);
+  });
+
+  it.each(REPAIRED)('%s declares columns: %i', (id, columns) => {
+    const example = allExamples().find((e) => e.id === id);
+    expect(example, `${id} is missing from the catalog`).toBeTruthy();
+    const declared = collectGridNodes(example!.schema)
+      .map((node) => node.columns)
+      .filter((value) => typeof value === 'number');
+    expect(declared).toContain(columns);
+  });
+});
+
+/**
+ * Render-level pins. The class strings below are the CORRECTED output — under
+ * `cols` every one of these grids rendered the flat `grid grid-cols-2 gap-N`
+ * fallback instead.
+ */
+describe('repaired grid examples render the responsive ramp (#4001)', () => {
+  const pins: ReadonlyArray<readonly [string, string]> = [
+    // columns: 3 — was `grid grid-cols-2 gap-4`
+    [
+      'components-data-display-statistic/metrics-grid',
+      'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4',
+    ],
+    // columns: 4 — was `grid grid-cols-2 gap-4`
+    [
+      'report/report-header-with-kpis',
+      'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4',
+    ],
+    // columns: 4 + className passthrough — was `grid grid-cols-2 gap-4 mb-6`
+    [
+      'components-layout-page/full-dashboard',
+      'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-6',
+    ],
+    // columns: 4 with a non-default gap — was `grid grid-cols-2 gap-3 p-4`
+    [
+      'theme/semantic-color-palette',
+      'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 p-4',
+    ],
+    // columns: 2 — the `div` → `grid` migration exemplar that
+    // `content/docs/components/basic/div.mdx` points authors at. Its column count
+    // matched the old default, so the bug was invisible here; the ramp still
+    // changes the base breakpoint from two columns to one.
+    [
+      'components-basic-div/grid-layout',
+      'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 gap-4',
+    ],
+  ];
+
+  it.each(pins)('%s renders %s', (id, expected) => {
+    const example = allExamples().find((e) => e.id === id);
+    expect(example, `${id} is missing from the catalog`).toBeTruthy();
+    const [gridNode] = collectGridNodes(example!.schema);
+    expect(gridNode, `${id} has no grid node`).toBeTruthy();
+
+    // Through the real `SchemaRenderer`, not `ComponentRegistry.get('grid')`
+    // directly: the grid renderer reads its Tailwind overrides from the
+    // `className` PROP, and it is `SchemaRenderer` that plumbs `schema.className`
+    // into it (`SchemaRenderer.tsx` sets both spellings). Rendering the registry
+    // component by hand silently drops the authored `className` and the pin would
+    // then be blind to it — measured while writing this test.
+    const { container } = render(<SchemaRenderer schema={gridNode as never} />);
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toBe(expected);
+  });
+});


### PR DESCRIPTION
Fixes #4001

## 问题

`GridSchema` 声明的列数键是 `columns`(`packages/types/src/layout.ts`),`grid` 渲染器只读 `schema.columns`(`packages/components/src/renderers/layout/grid.tsx:50-103`),注册的 designer `inputs` 也只有 `columns` / `smColumns` / `mdColumns` / `lgColumns` / `xlColumns` / `gap` / `className`。`cols` 从未被 spec、类型或注册表声明,`core` / `react` / `types` 里也没有任何把它归一到 `columns` 的处理(已 `git grep` 核实:`packages/*/src` 内除 Tailwind 的 `grid-cols-*` 字面量外无一处读 `cols`)。

13 个 catalog 示例把列数写成 `cols`,于是值被整个丢弃:`baseCols` 落到字面默认 `2`,而且 mobile-first 降级的门禁是 `typeof schema.columns === 'number'`,连降级也不触发 —— **在所有断点上都是死板 2 列**,production 构建同样如此。

## 修法(契约优先)

改**生产者**:13 个 JSON 的 `cols` → `columns`。**没有**给渲染器加 `schema.columns ?? schema.cols` 之类的别名兼容 —— 按 AGENTS.md #0.1,宽容的 consumer 会把错拼法固化成第二套事实契约,而 `cols` 从来不是契约的一部分。

## 命中清单(13 个,每个文件一行改动,均在 grid 节点上)

已用脚本逐个核验:每个文件恰好一处 `cols` 键、且落在 `type: "grid"` 节点上、改后仍为数字。

| 文件 | columns |
|---|---|
| `report/report-header-with-kpis.json` | 4 |
| `theme/semantic-color-palette.json` | 4 |
| `components-layout-page/full-dashboard.json` | 4 |
| `components-data-display-statistic/metrics-grid.json` | 3 |
| `components-layout-page/page-with-header.json` | 3 |
| `forms/payment-form.json` | 3 |
| `components-data-display-statistic/sales-dashboard.json` | 2 |
| `auth/signup.json` | 2 |
| `components-complex-resizable/complex-layout.json` | 2 |
| `components-basic-div/grid-layout.json` | 2 |
| `theme/theme-aware-ui-elements.json` | 2 |
| `plugin-view/form-view-mode.json` | 2 |
| `forms/contact-form.json` | 2 |

## 渲染变化(是修好,不是回归)

实测(经真 SchemaRenderer):

- `columns: 4` → `grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4`(原 `grid grid-cols-2 gap-4`)
- `columns: 3` → `grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4`(原 `grid grid-cols-2 gap-4`)
- `columns: 2` → `grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 gap-4`(原 `grid grid-cols-2 gap-4`)

**一处需要向 issue 正文更正**:正文把那 7 个「要 2 列」的示例记为「碰巧和默认值一致、渲染无变化」。实测并非如此 —— `columns: 2` 会触发 mobile-first 降级,base 断点从 2 列变成 1 列(`sm` 起才回到 2 列)。所以 **13 个示例的渲染全部变化**:6 个在 `md` 及以上从 2 列变成正确的 3/4 列,7 个只在 base(手机)断点从 2 列变成 1 列。后者正是渲染器写明的窄屏可读性意图,不是回归。

## 防回潮钉

新增 `examples/schema-catalog/test/grid-columns-key.test.tsx`(数据面 + 渲染面,与 #3972 / #3987 的 manifest 钉同族版位),钉三件事:

1. **数据面禁令** —— catalog 全量 423 个 JSON,任何 `type: "grid"` 节点都不得出现 `cols` 键,失败时报出示例 id 与值。第 14 个 `cols` 进不来。
2. **禁令非空转** —— 13 个示例各自仍声明其应有列数(只删键也能让禁令变绿,所以列数值单独钉);另有一条 grid 节点总数下限(21),保证遍历器确实看到了节点。
3. **渲染面抽样** —— 5 个示例经真 SchemaRenderer 钉住完整 class 串(含 `className` / 非默认 `gap` 透传),值按上表的**新正确值**。抽样含 `components-basic-div/grid-layout` —— `content/docs/components/basic/div.mdx` 让作者照抄的迁移范本。

注意钉的范围刻意只针对 `cols` 这一个键,没有做 grid 节点的键白名单:`type: "grid"` 被两个 tier 共用 —— 布局 grid 的 `columns` 是数字,而 `fields-grid/*` 的字段网格 `columns` 是列定义数组(带 `name` / `label` / `readonly`),白名单会误伤后者。

## 反向验证(方向先书面预判,再跑变异,变异未提交)

**变异 A** —— 把 `metrics-grid.json` 的 `columns` 改回 `cols`。预判:三条翻红(禁令列出 offender、`declares columns: 3` 因 `declared` 变空、渲染钉收到旧的错值)。实跑与预判一致:

```
× no grid node in the catalog carries an undeclared `cols` key
  + "components-data-display-statistic/metrics-grid (cols: 3)"
× components-data-display-statistic/metrics-grid declares columns: 3
  AssertionError: expected [] to include 3
× components-data-display-statistic/metrics-grid renders grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4
  Expected: "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
  Received: "grid grid-cols-2 gap-4"
Tests  3 failed | 17 passed (20)
```

第三条尤其值得记:渲染钉在变异下**复现了 issue 实测的那个缺陷值**,说明它钉的是真渲染而不是恒真式。

**变异 B** —— 把 `report-header-with-kpis` 的期望值改回修复前的 `grid grid-cols-2 gap-4`。预判:该条单独翻红。实跑一致(`Expected: "grid grid-cols-2 gap-4"` / `Received: "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4"`),证明钉里写的是新正确值。

**过程中踩到的一个坑,如实记录**:变异 A 的还原用了 `git checkout --`,而当时改动尚未 commit,于是它把文件还原到了 HEAD(即未修复态),连带污染了变异 B 那一跑的输出(B 的日志里同时出现 metrics-grid 的三条红)。已重新施加修复、复跑全绿后才 commit;后续变异都在 commit 之后做。B 自身的预判判据(那一条 pin 的 Expected/Received)不受影响。

## 写钉时测出的一处渲染器事实

`grid` 渲染器的 Tailwind 覆盖读的是 **`className` prop**,而把 `schema.className` 灌进这个 prop 的是 `SchemaRenderer`(`SchemaRenderer.tsx:479-523` 两种拼法都设)。所以渲染钉走真 SchemaRenderer,而不是 `ComponentRegistry.get('grid')` 直渲 —— 后者会静默丢掉作者写的 `className`,钉就看不见它了。这是先按直渲写、被 `full-dashboard` / `semantic-color-palette` 两条翻红纠正后的结论,注释已写进测试文件。

## 验证

- `pnpm exec vitest run examples/schema-catalog --maxWorkers=2` → 5 files / **1113 passed**(含新钉 20 条)
- `pnpm exec vitest run packages/components --maxWorkers=2` → 109 files / **929 passed**
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **78/78 successful**
- `node scripts/check-control-bytes.mjs` → OK(3911 files);并对改动文件自查了门禁扫不到的控制字节区间,clean
- `pnpm --filter @object-ui/example-schema-catalog lint` → 0 errors(2 条既有 warning 在我未碰的文件里)

**changeset**:无。`node scripts/check-changeset-presence.mjs` 判定 `No source of a released package changed in this range, so no changeset is owed.` —— `@object-ui/example-schema-catalog` 是 `private`、且在 `.changeset/config.json` 的 `ignore` 组里;本 PR 只动 examples 数据与测试,按 AGENTS.md「纯 bug 修复不需要 changeset」处理。

**测试面的一个既有缺口(未动)**:`examples/schema-catalog/tsconfig.json` 的 `exclude` 含 `test`,所以本包的 `type-check` 覆盖不到任何测试文件(含本 PR 新增的)。这正是在飞 #3968 的面,按边界不碰;新文件的类型另行用一次性 `tsc --noEmit --ignoreConfig ...` 单独核过,exit 0。

## 边界

未碰 `grid.tsx`(不加别名)、未碰 `div.tsx` 与 #3965 / #4003 的 div 词表面(`components-basic-div/grid-layout.json` 的根节点本就是 `grid`,只改了键)、未碰 #3968 的 tsconfig 面、未碰 `content/docs/releases/`。

另有两类**超范围发现**(同一缺陷类、不同文件,未在本 PR 修、未立单,已回传 PM 定夺):`skills/objectui/rules/protocol.md` 与 `skills/objectui/guides/mobile.md`、`apps/site/app/components/ReactVsObjectUI.tsx` 仍在教 `cols`,且 AGENTS.md #5 自身的例子也写作 `cols`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_