### PR TITLE
fix(sdui): object-timeline / record:line_items 的取数补上 filter/sort/limit 读点 (objectstack#7137)

### DIFF
--- a/.changeset/timeline-line-items-filter-sort-limit-7137.md
+++ b/.changeset/timeline-line-items-filter-sort-limit-7137.md
@@ -1,0 +1,57 @@
+---
+"@object-ui/plugin-timeline": patch
+"@object-ui/plugin-form": patch
+"@object-ui/core": patch
+---
+
+`object-timeline` and `record:line_items` now apply the filter / sort / row cap they are given, so a named `dataSource.view` narrows them instead of contributing nothing
+
+These were the two residual gaps in objectstack#7121's per-block coverage table
+(objectstack#7137). Both blocks are object-bound lists, both accepted the spec's
+per-element `dataSource` binding, and neither had a read site for `filter` or
+`sort` anywhere in its fetch:
+
+- `object-timeline`'s entire query was
+  `find(objectName, { options: { $top: 100 } })`.
+- `record:line_items`' was the parent FK plus a fixed `$top: 500`.
+
+So `dataSource: { object, view: 'hot' }` resolved the view — a typo still reported
+a configuration error, it never degraded into an unfiltered query — and then
+dropped everything the view said. The rendered rows could be **wider than the view
+they named**, silently, which is exactly the class of mistake AI-authored metadata
+hides best: the page looks like it works. objectstack#7121 deliberately left the
+keys unmapped and recorded the gap rather than writing composed values onto schema
+keys nobody read; this closes it at the fetch instead.
+
+What each block now reads:
+
+- **`object-timeline`** — `$filter: schema.filter`,
+  `$orderby: convertSortToQueryParams(schema.sort)`, and
+  `$top: schema.limit ?? 100`, matching the form `object-gantt` / `object-map` /
+  `object-calendar` already use. Its registry mapping gains
+  `filter` / `sort` / `limit`; `columns` stays unmapped, because a timeline
+  projects the fields its `timeline` config names.
+- **`record:line_items`** — the composed filter is **AND-combined** with the parent
+  relationship condition through `mergeFilterNodes`, never substituted for it, the
+  same way `record:related_list` composes its own since objectstack#7118: a
+  line-items panel is always scoped to the record it sits on, so an *additional*
+  criterion can only narrow this parent's children and can never surface another
+  parent's rows. `sort` becomes the load order and `limit` the row cap (default
+  500). `columns` stays unmapped — here they are `GridColumn[]` driving an editable
+  grid, not a field-name projection, so a view's column list would be the wrong
+  *shape* rather than merely a wider answer.
+
+**Behaviour change worth knowing about:** the timeline's default window is now a
+real cap. `{ options: { $top: 100 } }` nested the limit under a key that is not a
+`QueryParams` field and that no adapter in this repo reads (`convertQueryParams`
+maps `params.$top`), so the intended window never reached the wire and a timeline
+over a large object fetched whatever the server chose to return. It is now sent as
+`$top`, and authorable via `limit` or a view's `pagination.pageSize`.
+
+`@object-ui/core` gains `convertSortToQueryParams`, the sort→`$orderby` lowering
+the three sibling blocks each inline privately. It is shared rather than copied
+twice more, and is slightly more faithful to the declared contract than those
+copies: a sort entry that omits `order` means ascending instead of being dropped
+(the string spelling `"amount"` already meant ascending in the same copies), and
+nothing orderable yields `undefined` rather than a truthy empty `{}`. Migrating
+the three existing copies onto it is objectstack#7148 and is not done here.

--- a/content/docs/guide/data-source.md
+++ b/content/docs/guide/data-source.md
@@ -255,11 +255,11 @@ ignores would be accepted and dropped, which is the defect this binding removes.
 | `object-gantt` | ✅ | filter / sort | ✅ | ✅ | — no row cap |
 | `object-map` | ✅ | filter / sort | ✅ | ✅ | — no row cap |
 | `object-pivot` | ✅ | filter | ✅ | — grouping orders | — totals need all rows |
-| `object-timeline` | ✅ | error-checked only | — no read site | — no read site | — fixed window |
+| `object-timeline` | ✅ | filter / sort / limit | ✅ | ✅ | ✅ (`limit`) |
 | `object-form` | ✅ | error-checked only | — no collection query | — | — |
 | `embeddable-form` | ✅ | error-checked only | — no collection query | — | — |
 | `object-master-detail-form` | ✅ | error-checked only | — no collection query | — | — |
-| `record:line_items` | ✅ (`childObject`) | error-checked only | — parent-scoped only | — no read site | — fixed window |
+| `record:line_items` | ✅ (`childObject`) | filter / sort / limit | ✅ (AND parent scope) | ✅ | ✅ (`limit`) |
 
 Reading the `view` column: it lists what a named saved view actually contributes
 on that block. A view name that does not resolve is reported as a configuration
@@ -273,25 +273,36 @@ of the binding and stays the author's — it has to name a field on the bound ch
 object, so rebinding `object` without updating it is an authoring error the panel
 cannot paper over.
 
-On `record:related_list` the composed filter is AND-combined with the parent
-relationship condition, never substituted for it: a related list is always scoped
-to the record it appears on, and an *additional* criterion can only narrow that
-set further. (Until objectstack#7118 this block declared `filter` without reading
-it, so a named view contributed its columns / sort / limit while its filter was
-dropped — the list could be wider than the view it named. That gap is closed; the
-`filter` cell above is what closed it.)
+On `record:related_list` and `record:line_items` the composed filter is
+AND-combined with the parent relationship condition, never substituted for it: a
+child panel is always scoped to the record it appears on, and an *additional*
+criterion can only narrow that set further. (Until objectstack#7118
+`record:related_list` declared `filter` without reading it, so a named view
+contributed its columns / sort / limit while its filter was dropped — the list
+could be wider than the view it named. That gap is closed; the `filter` cell above
+is what closed it.)
 
-Current gaps, recorded rather than papered over:
+`object-timeline` and `record:line_items` were the two residual gaps in this table
+until objectstack#7137. Neither had a `filter` / `sort` read site at all — the
+timeline's whole fetch was `find(objectName, { options: { $top: 100 } })` and the
+line-items panel's was the parent FK plus a fixed `$top: 500` — so a `view` named
+on either resolved (a typo reported) and then contributed nothing: the rendered
+rows could be **wider than the view they named**, with no error anywhere. Both now
+read `filter`, `sort` and `limit`, so the cells above are ✅. Two notes on what
+came with that:
 
-- `object-timeline` has no `$filter` / `$orderby` read site at all: its fetch is
-  `find(objectName, { options: { $top: 100 } })`. A view named there is resolved
-  and then contributes nothing, so the rail can be wider than the view it names.
-  The keys stay unmapped rather than being written where nothing reads them.
-- `record:line_items` likewise takes only the object from the binding: its query is
-  the parent FK plus a fixed `$top: 500`, and its `columns` are editable
+- The timeline's default window is `limit ?? 100` and it is now a real `$top`.
+  The old `{ options: { $top: 100 } }` nested the cap under a key that is not a
+  `QueryParams` field and that no adapter in this repo reads, so the intended cap
+  never reached the wire; a timeline over a large object fetched whatever the
+  server chose to return. Authoring `limit` (or a view's `pagination.pageSize`)
+  now sets it.
+- `record:line_items` still does **not** take a view's `columns`: they are editable
   `GridColumn` objects (`{ field, type, … }`) rather than a field-name projection,
   so a view's column list would be the wrong *shape*, not merely a wider answer.
-  Both of these are tracked as objectstack#7137.
+
+Remaining gap, recorded rather than papered over:
+
 - `object-form` / `embeddable-form` / `object-master-detail-form` resolve `view`
   only to report an unresolvable name; a view that does resolve contributes
   nothing, because a list view's columns are not a form layout. On the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export * from './utils/extract-records.js';
 export * from './utils/expand-fields.js';
 export * from './utils/column-identity.js';
 export * from './utils/sort-values.js';
+export * from './utils/sort-query.js';
 export * from './utils/resolve-view-id.js';
 export * from './evaluator/index.js';
 export * from './actions/index.js';

--- a/packages/core/src/utils/__tests__/sort-query.test.ts
+++ b/packages/core/src/utils/__tests__/sort-query.test.ts
@@ -1,0 +1,74 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `convertSortToQueryParams` — the shared sort→`$orderby` sink introduced with
+ * objectstack#7137, when `object-timeline` and `record:line_items` gained sort
+ * read sites and would otherwise have made a fifth and sixth private copy of the
+ * conversion `ObjectGantt` / `ObjectMap` / `ObjectCalendar` each inline.
+ *
+ * The last two cases pin the two places this function is deliberately MORE
+ * faithful to the declared contract than those copies: `SortConfig.order` is
+ * optional (an entry without it means ascending, not "drop this key"), and
+ * nothing usable yields `undefined` rather than a truthy-but-empty `{}`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { convertSortToQueryParams } from '../sort-query';
+
+describe('convertSortToQueryParams', () => {
+  it('lowers the legacy string clause', () => {
+    expect(convertSortToQueryParams('name desc')).toEqual({ name: 'desc' });
+    expect(convertSortToQueryParams('name asc')).toEqual({ name: 'asc' });
+    // A bare field name is ascending — same as an omitted direction.
+    expect(convertSortToQueryParams('name')).toEqual({ name: 'asc' });
+    // Direction casing is not the author's problem.
+    expect(convertSortToQueryParams('name DESC')).toEqual({ name: 'desc' });
+  });
+
+  it('lowers a SortConfig[] preserving key order', () => {
+    expect(
+      convertSortToQueryParams([
+        { field: 'stage', order: 'asc' },
+        { field: 'amount', order: 'desc' },
+      ]),
+    ).toEqual({ stage: 'asc', amount: 'desc' });
+    expect(
+      Object.keys(
+        convertSortToQueryParams([
+          { field: 'stage', order: 'asc' },
+          { field: 'amount', order: 'desc' },
+        ])!,
+      ),
+    ).toEqual(['stage', 'amount']);
+  });
+
+  it('treats an entry with no `order` as ascending instead of dropping it', () => {
+    // `$orderby`'s own declared shape is `Array<{ field: string; order?: … }>`,
+    // so an omitted direction means ascending. The three private copies this
+    // function replaces require both keys and drop such an entry, losing an
+    // authored sort key.
+    expect(convertSortToQueryParams([{ field: 'line_no' }])).toEqual({ line_no: 'asc' });
+    expect(
+      convertSortToQueryParams([{ field: 'line_no' }, { field: 'amount', order: 'desc' }]),
+    ).toEqual({ line_no: 'asc', amount: 'desc' });
+  });
+
+  it('returns undefined — never an empty object — when nothing is orderable', () => {
+    expect(convertSortToQueryParams(undefined)).toBeUndefined();
+    expect(convertSortToQueryParams(null)).toBeUndefined();
+    expect(convertSortToQueryParams('')).toBeUndefined();
+    expect(convertSortToQueryParams('   ')).toBeUndefined();
+    expect(convertSortToQueryParams([])).toBeUndefined();
+    // Entries with no usable field name contribute nothing, and an all-unusable
+    // array must not produce a truthy `{}` that a caller would send as $orderby.
+    expect(convertSortToQueryParams([{ order: 'desc' }])).toBeUndefined();
+    expect(convertSortToQueryParams([{ field: '' }])).toBeUndefined();
+    // Shapes the schema types do not declare are refused, not guessed at.
+    expect(convertSortToQueryParams(42 as any)).toBeUndefined();
+    expect(convertSortToQueryParams({ name: 'desc' } as any)).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/sort-query.ts
+++ b/packages/core/src/utils/sort-query.ts
@@ -1,0 +1,80 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * sort-query — lower a block's authored `sort` to the `$orderby` value a
+ * `DataSource.find` query carries.
+ *
+ * Two authored spellings reach every object-bound block, because both are
+ * declared: the legacy OData-ish string (`ObjectGridSchema.sort: "name desc"`)
+ * and the spec's `SortConfig[]` (`[{ field, order }]`). A read site that hands
+ * either straight to `$orderby` works only because `QueryParams.$orderby`
+ * accepts four shapes; normalizing here means one shape reaches the wire and a
+ * block does not have to know which spelling its author used.
+ *
+ * This is the same conversion three sibling blocks already inline privately
+ * (`ObjectGantt` / `ObjectMap` / `ObjectCalendar`, byte-identical copies). It is
+ * hoisted here because objectstack#7137 added two more read sites
+ * (`object-timeline`, `record:line_items`), and a fifth and sixth private copy is
+ * how the conversions start disagreeing. Collapsing the three existing copies
+ * onto this one is deliberately NOT part of #7137 — it is tracked as
+ * objectstack#7148.
+ *
+ * Two deliberate differences from those private copies, both of which make this
+ * function more faithful to the declared contract rather than adding tolerance:
+ *
+ *  - **`order` is optional in `SortConfig`**, so an entry that omits it means
+ *    ascending (that is what `$orderby`'s own
+ *    `Array<{ field: string; order?: 'asc' | 'desc' }>` shape says). The private
+ *    copies require BOTH keys and silently drop such an entry, which loses an
+ *    authored sort key instead of ordering by it.
+ *  - **Nothing usable yields `undefined`, never `{}`.** An empty object is a
+ *    truthy value that means "no ordering" only by accident of the adapter's
+ *    serializer; `undefined` says it, so the query simply carries no `$orderby`.
+ *
+ * Not a lenient alias: an unusable input (a number, an object, an array of
+ * strings) yields `undefined` rather than a guess. Only the two spellings the
+ * schema types declare are honoured.
+ */
+
+/** A field name paired with a direction — the spec's `SortConfig`. */
+export interface QuerySortEntry {
+  field?: string;
+  order?: 'asc' | 'desc';
+}
+
+/**
+ * Normalize an authored `sort` into the field→direction map used for
+ * `QueryParams.$orderby`.
+ *
+ * @param sort `"name desc"` (legacy string) or `SortConfig[]`.
+ * @returns The ordering map, or `undefined` when nothing orderable was authored.
+ */
+export function convertSortToQueryParams(
+  sort: string | QuerySortEntry[] | undefined | null,
+): Record<string, 'asc' | 'desc'> | undefined {
+  if (!sort) return undefined;
+
+  // Legacy string clause: "name desc" / "name" (a bare field means ascending).
+  if (typeof sort === 'string') {
+    const [field, direction] = sort.trim().split(/\s+/);
+    if (!field) return undefined;
+    return { [field]: direction?.toLowerCase() === 'desc' ? 'desc' : 'asc' };
+  }
+
+  if (Array.isArray(sort)) {
+    const out: Record<string, 'asc' | 'desc'> = {};
+    for (const entry of sort) {
+      if (!entry || typeof entry.field !== 'string' || entry.field === '') continue;
+      out[entry.field] = entry.order === 'desc' ? 'desc' : 'asc';
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  }
+
+  return undefined;
+}

--- a/packages/plugin-form/src/LineItemsPanel.elementDataSource.test.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.elementDataSource.test.tsx
@@ -5,21 +5,24 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * `record:line_items` consumes `PageComponentSchema.dataSource` (objectstack#7121).
+ * `record:line_items` consumes `PageComponentSchema.dataSource` (objectstack#7121),
+ * and since objectstack#7137 it consumes `filter` / `sort` / `limit` too.
  *
- * This is the one block in the batch whose object does NOT live under
+ * This is the one block in the #7121 batch whose object does NOT live under
  * `objectName`: the collection it lists, fetches and writes is
  * `schema.childObject`, so the binding's `object` maps THERE — the same way it
  * maps onto `record:related_list`'s `objectName`, which likewise names the CHILD
  * object the panel is bound to. Authored with the binding and no `childObject`,
  * the panel used to query the object `undefined`.
  *
- * Nothing else is mapped, and the last two cases pin that rather than trusting a
- * comment: `relationshipField` stays the author's (it must name a field on the
- * bound child object), the query is `{ [relationshipField]: parentId }` and a
- * fixed `$top: 500` — so `filter` / `sort` / `limit` have no read site — and
- * `columns` here is `GridColumn[]` driving an EDITABLE grid, not a field-name
- * projection a saved view could fill.
+ * #7137 gave the fetch the three missing read sites. The composed filter is
+ * AND-combined with the parent relationship condition, never substituted for it —
+ * pinned below, because "additional criteria" that REPLACED the parent scope would
+ * show another record's line items, the worst possible reading of the spec.
+ *
+ * `columns` is still NOT mapped, and the last case keeps pinning that: here they
+ * are `GridColumn[]` driving an EDITABLE grid, not a field-name projection a saved
+ * view could fill.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -71,6 +74,11 @@ const renderBlock = (schema: Record<string, unknown>, adapter: ReturnType<typeof
 const headerTexts = (container: HTMLElement) =>
   Array.from(container.querySelectorAll('thead th')).map((th) => th.textContent ?? '');
 
+const firstQuery = async (adapter: ReturnType<typeof makeAdapter>) => {
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  return adapter.find.mock.calls[0] as [string, any];
+};
+
 describe('record:line_items — dataSource: { object } (objectstack#7121)', () => {
   it('lists the CHILD object named by the binding, scoped to the parent record', async () => {
     const adapter = makeAdapter();
@@ -85,12 +93,13 @@ describe('record:line_items — dataSource: { object } (objectstack#7121)', () =
       adapter,
     );
 
-    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
-    const [object, params] = adapter.find.mock.calls[0] as [string, any];
+    const [object, params] = await firstQuery(adapter);
     expect(object).toBe('invoice_line');
     // The parent relationship is still what scopes the list — the binding named
-    // the object, not the scope.
+    // the object, not the scope. With nothing else authored the filter is the
+    // untouched MongoDB-style object it has always been.
     expect(params.$filter).toEqual({ invoice: 'inv-1' });
+    expect(params.$orderby).toBeUndefined();
     expect(params.$top).toBe(500);
   });
 
@@ -113,7 +122,29 @@ describe('record:line_items — dataSource: { object } (objectstack#7121)', () =
     expect(adapter.find).not.toHaveBeenCalled();
   });
 
-  it('a resolvable view contributes nothing: no filter, no ordering, no cap, no columns', async () => {
+  it('leaves a panel with NO dataSource exactly as it was', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      {
+        type: 'record:line_items',
+        childObject: 'invoice_line',
+        relationshipField: 'invoice',
+        parentId: 'inv-1',
+        columns: COLUMNS,
+      },
+      adapter,
+    );
+
+    const [object, params] = await firstQuery(adapter);
+    expect(object).toBe('invoice_line');
+    expect(params.$filter).toEqual({ invoice: 'inv-1' });
+    expect(params.$orderby).toBeUndefined();
+    expect(params.$top).toBe(500);
+  });
+});
+
+describe('record:line_items — parent scope AND the authored criteria (objectstack#7137)', () => {
+  it('applies a named view’s filter, sort and page size WITHOUT dropping the parent scope', async () => {
     const adapter = makeAdapter();
     const { container } = renderBlock(
       {
@@ -131,23 +162,24 @@ describe('record:line_items — dataSource: { object } (objectstack#7121)', () =
       adapter,
     );
 
-    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
-    const [object, params] = adapter.find.mock.calls[0] as [string, any];
+    const [object, params] = await firstQuery(adapter);
     expect(object).toBe('invoice_line');
-    // The query is the FK scope and the fixed window, exactly as before: none of
-    // the view's filter/sort nor the binding's sort/limit has a read site here.
-    expect(params.$filter).toEqual({ invoice: 'inv-1' });
-    expect(params.$top).toBe(500);
-    expect(params.$orderby).toBeUndefined();
+    // BOTH conditions, ANDed: the parent FK first (it is never negotiable), the
+    // view's criteria as their own child. An override here would show another
+    // invoice's lines.
+    expect(params.$filter).toEqual(['and', ['invoice', '=', 'inv-1'], [['billable', '=', true]]]);
+    // Binding `sort` / `limit` override the view's.
+    expect(params.$orderby).toEqual({ price: 'asc' });
+    expect(params.$top).toBe(3);
 
-    // And the editable grid keeps the authored GridColumn list — a view's bare
-    // field names would arrive with no `field`/`type` and render header-less,
-    // type-less cells. Wrong SHAPE, not merely a wider answer.
+    // And the editable grid still keeps the authored GridColumn list — a view's
+    // bare field names would arrive with no `field`/`type` and render
+    // header-less, type-less cells. Wrong SHAPE, not merely a wider answer.
     await waitFor(() => expect(headerTexts(container)).toContain('Qty'));
     expect(headerTexts(container).join('|')).not.toContain('price');
   });
 
-  it('leaves a panel with NO dataSource exactly as it was', async () => {
+  it('honours filter / sort / limit authored directly on the panel', async () => {
     const adapter = makeAdapter();
     renderBlock(
       {
@@ -156,14 +188,43 @@ describe('record:line_items — dataSource: { object } (objectstack#7121)', () =
         relationshipField: 'invoice',
         parentId: 'inv-1',
         columns: COLUMNS,
+        filter: [['billable', '=', true]],
+        sort: 'qty desc',
+        limit: 25,
       },
       adapter,
     );
 
-    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
-    const [object, params] = adapter.find.mock.calls[0] as [string, any];
+    const [object, params] = await firstQuery(adapter);
     expect(object).toBe('invoice_line');
-    expect(params.$filter).toEqual({ invoice: 'inv-1' });
-    expect(params.$top).toBe(500);
+    expect(params.$filter).toEqual(['and', ['invoice', '=', 'inv-1'], [['billable', '=', true]]]);
+    expect(params.$orderby).toEqual({ qty: 'desc' });
+    expect(params.$top).toBe(25);
+  });
+
+  it('AND-combines the panel’s own filter with the view’s and the binding’s — the parent scope survives all three', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      {
+        type: 'record:line_items',
+        relationshipField: 'invoice',
+        parentId: 'inv-1',
+        columns: COLUMNS,
+        filter: [['void', '=', false]],
+        dataSource: { object: 'invoice_line', view: 'hot', filter: [['qty', '>', 0]] },
+      },
+      adapter,
+    );
+
+    const [, params] = await firstQuery(adapter);
+    expect(params.$filter).toEqual([
+      'and',
+      ['invoice', '=', 'inv-1'],
+      ['and', [['void', '=', false]], ['and', [['billable', '=', true]], [['qty', '>', 0]]]],
+    ]);
+    // The view supplied the ordering and the cap; nothing on the binding overrode
+    // them.
+    expect(params.$orderby).toEqual({ qty: 'desc' });
+    expect(params.$top).toBe(7);
   });
 });

--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -29,7 +29,12 @@ import {
 import { LineItemsField, type GridColumn } from '@object-ui/fields';
 import { useSchemaContext, useRecordContext } from '@object-ui/react';
 import { buildMasterDetailEditBatch, sumRows } from './masterDetailTx';
-import { runBatchTransaction } from '@object-ui/core';
+import {
+  runBatchTransaction,
+  mergeFilterNodes,
+  toFilterNode,
+  convertSortToQueryParams,
+} from '@object-ui/core';
 
 export interface LineItemsPanelSchema {
   type?: 'record:line_items';
@@ -45,7 +50,38 @@ export interface LineItemsPanelSchema {
   readonly?: boolean;
   minRows?: number;
   maxRows?: number;
+  /**
+   * *Additional* criteria for the child rows, in any shape `toFilterNode`
+   * accepts (spec `ViewFilterRule[]`, ObjectQL AST nodes, or a MongoDB-style
+   * object).
+   *
+   * AND-combined with the parent relationship condition, never substituted for
+   * it (objectstack#7137, exactly as `record:related_list` does since
+   * objectstack#7118): a line-items panel is always scoped to the record it sits
+   * on, so an additional criterion can only narrow this parent's children — it
+   * can never surface another parent's rows. When a `dataSource` binding is
+   * present, `ElementDataSourceGate` has already AND-combined this key with the
+   * view's filter and the binding's own before the schema arrives here.
+   */
+  filter?: any[] | Record<string, any>;
+  /**
+   * Load order for the child rows — the legacy `"line_no desc"` clause or the
+   * spec's `SortConfig[]`. Without one the rows arrive in storage order.
+   */
+  sort?: string | Array<{ field?: string; order?: 'asc' | 'desc' }>;
+  /**
+   * Row cap for the child fetch; defaults to {@link DEFAULT_LINE_ITEMS_LIMIT}.
+   * A line-items grid has no pagination control — every loaded row is editable
+   * and saved as one batch — so this is the author's window, not a page size.
+   */
+  limit?: number;
 }
+
+/**
+ * Child rows fetched when the author declared no `limit` — the window this panel
+ * has always used, now authorable (objectstack#7137).
+ */
+export const DEFAULT_LINE_ITEMS_LIMIT = 500;
 
 export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ schema }) => {
   const ctx = useSchemaContext() as any;
@@ -82,6 +118,23 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
     return () => { cancelled = true; };
   }, [dataSource, schema.childObject]);
 
+  // Content keys, not identities: an inline `filter` / `sort` on a schema node is
+  // a new object every render and both are inputs to `load` (which an effect
+  // below depends on) — keying on identity would refetch the children on every
+  // render. Same reason `RelatedList` keys its own scope filter on content.
+  const filterKey = JSON.stringify(schema.filter ?? null);
+  const sortKey = JSON.stringify(schema.sort ?? null);
+  const listFilterNode = useMemo(
+    () => toFilterNode(schema.filter),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on CONTENT, see above
+    [filterKey],
+  );
+  const orderBy = useMemo(
+    () => convertSortToQueryParams(schema.sort),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on CONTENT, see above
+    [sortKey],
+  );
+
   const load = useCallback(async () => {
     if (!dataSource || !parentId) {
       setLoading(false);
@@ -89,9 +142,21 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
     }
     setLoading(true);
     try {
+      // Parent relationship AND the panel's own criteria (objectstack#7137).
+      // The parent condition is not negotiable — an "additional" criterion may
+      // only narrow THIS parent's children — and with nothing authored the query
+      // is the untouched MongoDB-style object it has always been rather than a
+      // freshly lowered AST meaning the same thing (invisible on screen, visible
+      // to every caller pinning the wire). Composed through the repo's single
+      // filter sink, the same way `record:related_list` composes its own.
+      const parentScope = { [schema.relationshipField]: parentId } as Record<string, any>;
       const res = await dataSource.find(schema.childObject, {
-        $filter: { [schema.relationshipField]: parentId },
-        $top: 500,
+        $filter:
+          listFilterNode === undefined
+            ? parentScope
+            : mergeFilterNodes(parentScope, listFilterNode),
+        ...(orderBy ? { $orderby: orderBy } : {}),
+        $top: schema.limit ?? DEFAULT_LINE_ITEMS_LIMIT,
       });
       const data = (res?.data ?? []) as Record<string, any>[];
       setRows(data.map((r) => ({ ...r })));
@@ -102,7 +167,15 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
     } finally {
       setLoading(false);
     }
-  }, [dataSource, parentId, schema.childObject, schema.relationshipField]);
+  }, [
+    dataSource,
+    parentId,
+    schema.childObject,
+    schema.relationshipField,
+    schema.limit,
+    listFilterNode,
+    orderBy,
+  ]);
 
   useEffect(() => {
     void load();

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -265,28 +265,33 @@ import { LineItemsPanel } from './LineItemsPanel';
  * `record:related_list`'s `objectName` — in both blocks that key names the CHILD
  * object the panel is bound to, which is what `dataSource.object` means.
  *
- * Nothing else is mapped, and each omission has a read site behind it (or the
- * lack of one):
+ * `filter` / `sort` / `limit` map too, since objectstack#7137 gave the panel's
+ * fetch read sites for all three: the composed filter is AND-combined with the
+ * parent relationship condition (never substituted for it — a line-items panel is
+ * always scoped to the record it sits on, so an *additional* criterion can only
+ * narrow this parent's children), `sort` becomes the load order, and `limit` the
+ * row cap that used to be a fixed `$top: 500`.
+ *
+ * Two things are still NOT mapped, each for a reason rather than an oversight:
  *
  *  - `relationshipField` stays the author's: it is not part of the binding, and it
  *    must name a field ON the bound child object. Rebinding `object` without
  *    updating it is an authoring error the panel cannot paper over.
- *  - `filter` has no read site — the query is `{ [relationshipField]: parentId }`
- *    and nothing else, so the panel is scoped by the parent record alone.
- *  - `sort` and a row cap likewise: rows come back at a fixed `$top: 500` in
- *    storage order.
  *  - `columns` is NOT a field-name projection here. It is `GridColumn[]`
  *    (`{ field, type, options, computed, expr, … }`) driving an EDITABLE grid; a
  *    saved view's column list would arrive as bare names and render a grid of
  *    column definitions with no `field`. Wrong shape, not merely a wider answer.
  *
- * Consequence, stated rather than hidden: a `view` named on this block is
- * resolved (so a typo reports instead of silently widening) and then contributes
- * nothing — its filter/sort/columns are all dropped, because the panel has no
- * read site for any of them.
+ * So a `view` named on this block now contributes its filter, sort and page size
+ * to the child query (and an unresolvable name still reports instead of silently
+ * widening), while its column list stays out — the one thing whose shape does not
+ * fit this grid.
  */
 const RECORD_LINE_ITEMS_DATA_SOURCE: ElementDataSourceMapping = {
   object: 'childObject',
+  filter: true,
+  sort: true,
+  limit: 'limit',
 };
 
 const LineItemsPanelRenderer: React.FC<{ schema: any }> = ({ schema }) => (

--- a/packages/plugin-timeline/src/ObjectTimeline.elementDataSource.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.elementDataSource.test.tsx
@@ -5,19 +5,24 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * `object-timeline` consumes `PageComponentSchema.dataSource` (objectstack#7121).
+ * `object-timeline` consumes `PageComponentSchema.dataSource` (objectstack#7121),
+ * and since objectstack#7137 it consumes ALL of it: `object`, `filter`, `sort`
+ * and `limit`.
  *
- * Every branch of the timeline's fetch effect is gated on `schema.objectName`,
- * and nothing mapped the spec's `dataSource.object` onto it: a timeline authored
- * with the binding the spec documents never fetched and rendered an empty rail
- * with no request and no error.
+ * Two defects met here. objectstack#7121: every branch of the timeline's fetch
+ * effect is gated on `schema.objectName` and nothing mapped the spec's
+ * `dataSource.object` onto it, so a timeline authored the way the spec documents
+ * never fetched — an empty rail, no request, no error. objectstack#7137: the fetch
+ * was `find(objectName, { options: { $top: 100 } })` — no `$filter`, no
+ * `$orderby`, and `options` is not a `QueryParams` key, so even the window was
+ * inert. A named `view` resolved (a typo reported) and then contributed NOTHING,
+ * which is the failure this binding exists to remove: the rail was wider than the
+ * view it named, and looked right.
  *
- * This block maps `object` and NOTHING else, which the last two cases pin
- * deliberately: the fetch is `find(objectName, { options: { $top: 100 } })` — no
- * `$filter`, no `$orderby`, a hard-coded window — so a `filter` / `sort` / `limit`
- * written onto the schema would be accepted and dropped, the very defect this
- * wiring removes. A named view is still resolved (a typo reports) and then
- * contributes nothing.
+ * The two cases that used to pin the gap honestly ("no filter/orderby in the
+ * query", "options is the whole query") were written to turn RED the day the read
+ * sites landed — see the note they carried. They did; they are now the positive
+ * assertions below.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -65,6 +70,11 @@ const renderBlock = (schema: Record<string, unknown>, adapter: ReturnType<typeof
     </SchemaRendererProvider>,
   );
 
+const firstQuery = async (adapter: ReturnType<typeof makeAdapter>) => {
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  return adapter.find.mock.calls[0] as [string, any];
+};
+
 describe('object-timeline — dataSource: { object, view } (objectstack#7121)', () => {
   it('queries the object named by the binding', async () => {
     const adapter = makeAdapter();
@@ -73,8 +83,7 @@ describe('object-timeline — dataSource: { object, view } (objectstack#7121)', 
       adapter,
     );
 
-    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
-    const [object] = adapter.find.mock.calls[0] as [string, any];
+    const [object] = await firstQuery(adapter);
     expect(object).toBe('campaign');
   });
 
@@ -91,7 +100,41 @@ describe('object-timeline — dataSource: { object, view } (objectstack#7121)', 
     expect(adapter.find).not.toHaveBeenCalled();
   });
 
-  it('does NOT pretend to honour filter/sort/limit — there is no read site for them', async () => {
+  it('leaves a timeline with NO dataSource fetching the same rows as before', async () => {
+    const adapter = makeAdapter();
+    renderBlock({ type: 'object-timeline', objectName: 'campaign', timeline: TIMELINE }, adapter);
+
+    const [object, params] = await firstQuery(adapter);
+    expect(object).toBe('campaign');
+    expect(params.$filter).toBeUndefined();
+    expect(params.$orderby).toBeUndefined();
+    // The default window is now a REAL `$top` rather than a `$top` nested under
+    // `options`, which no adapter in this repo reads (`convertQueryParams` in
+    // `@object-ui/data-objectstack` maps `params.$top`). The number is unchanged;
+    // it just reaches the wire now.
+    expect(params.$top).toBe(100);
+    expect(params.options).toBeUndefined();
+  });
+});
+
+describe('object-timeline — the view actually narrows the rail (objectstack#7137)', () => {
+  it('applies a named view’s filter, sort and page size to the query', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      { type: 'object-timeline', timeline: TIMELINE, dataSource: { object: 'campaign', view: 'hot' } },
+      adapter,
+    );
+
+    const [object, params] = await firstQuery(adapter);
+    expect(object).toBe('campaign');
+    // One surviving filter source passes through verbatim — no pointless `and`.
+    expect(params.$filter).toEqual([['stage', '=', 'live']]);
+    expect(params.$orderby).toEqual({ name: 'desc' });
+    // The view's `pagination.pageSize` is its row cap.
+    expect(params.$top).toBe(7);
+  });
+
+  it('AND-combines the binding’s additional filter with the view’s, and lets binding sort/limit win', async () => {
     const adapter = makeAdapter();
     renderBlock(
       {
@@ -108,27 +151,55 @@ describe('object-timeline — dataSource: { object, view } (objectstack#7121)', 
       adapter,
     );
 
-    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
-    const [, params] = adapter.find.mock.calls[0] as [string, any];
-    // The honest assertion: the timeline's query carries none of these, because
-    // it reads none of them. Recorded here (and in the data-source guide) rather
-    // than hidden behind a mapping that writes to keys nobody reads. When the
-    // fetch gains the read sites, this case is what has to be rewritten.
-    expect(params.$filter).toBeUndefined();
-    expect(params.$orderby).toBeUndefined();
-    expect(params.options).toEqual({ $top: 100 });
+    const [, params] = await firstQuery(adapter);
+    // Additional criteria NARROW the view — each source its own child of the
+    // `and`, never a replacement (a binding filter can't widen a saved view).
+    expect(params.$filter).toEqual(['and', [['stage', '=', 'live']], [['owner', '=', 'me']]]);
+    // `sort` / `limit` override the view's rather than combining.
+    expect(params.$orderby).toEqual({ end_date: 'asc' });
+    expect(params.$top).toBe(3);
   });
 
-  it('leaves a timeline with NO dataSource exactly as it was', async () => {
+  it('honours filter / sort / limit authored directly on the block', async () => {
     const adapter = makeAdapter();
     renderBlock(
-      { type: 'object-timeline', objectName: 'campaign', timeline: TIMELINE },
+      {
+        type: 'object-timeline',
+        objectName: 'campaign',
+        timeline: TIMELINE,
+        filter: [['stage', '=', 'live']],
+        sort: 'end_date desc',
+        limit: 12,
+      },
       adapter,
     );
 
-    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
-    const [object, params] = adapter.find.mock.calls[0] as [string, any];
+    const [object, params] = await firstQuery(adapter);
     expect(object).toBe('campaign');
-    expect(params.options).toEqual({ $top: 100 });
+    expect(params.$filter).toEqual([['stage', '=', 'live']]);
+    // The legacy string clause is lowered the same way the sibling object-bound
+    // blocks lower theirs (`convertSortToQueryParams`).
+    expect(params.$orderby).toEqual({ end_date: 'desc' });
+    expect(params.$top).toBe(12);
+  });
+
+  it('AND-combines the block’s own filter with the view’s and the binding’s', async () => {
+    const adapter = makeAdapter();
+    renderBlock(
+      {
+        type: 'object-timeline',
+        timeline: TIMELINE,
+        filter: [['archived', '=', false]],
+        dataSource: { object: 'campaign', view: 'hot', filter: [['owner', '=', 'me']] },
+      },
+      adapter,
+    );
+
+    const [, params] = await firstQuery(adapter);
+    expect(params.$filter).toEqual([
+      'and',
+      [['archived', '=', false]],
+      ['and', [['stage', '=', 'live']], [['owner', '=', 'me']]],
+    ]);
   });
 });

--- a/packages/plugin-timeline/src/ObjectTimeline.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { DataSource, TimelineSchema, ListViewTimelineConfig } from '@object-ui/types';
 import { useDataScope, useNavigationOverlay, useObjectLabel } from '@object-ui/react';
 import { NavigationOverlay } from '@object-ui/components';
-import { extractRecords, buildExpandFields } from '@object-ui/core';
+import { extractRecords, buildExpandFields, convertSortToQueryParams } from '@object-ui/core';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { z } from 'zod';
 import { TimelineRenderer } from './renderer';
@@ -36,6 +36,17 @@ const OBJECT_LABEL_FALLBACK = {
 function useSafeObjectLabel() {
   return useObjectLabel() ?? OBJECT_LABEL_FALLBACK;
 }
+
+/**
+ * Rows fetched when the author declared no `limit`.
+ *
+ * The number is the one this component has always intended: before
+ * objectstack#7137 the fetch passed `{ options: { $top: 100 } }`, and `options`
+ * is not a `QueryParams` key — no adapter in this repo reads it, so the cap never
+ * reached the wire and the timeline fetched whatever the server chose to return.
+ * The window is now real, and authorable.
+ */
+export const DEFAULT_TIMELINE_LIMIT = 100;
 
 const TimelineMappingSchema = z.object({
   title: z.string().optional(),
@@ -67,6 +78,28 @@ export interface ObjectTimelineProps {
      * has always declared on it, and that this renderer now actually reads.
      */
     timeline?: ListViewTimelineConfig;
+    /**
+     * Query filter for the object fetch, in any shape `toFilterNode` accepts
+     * (spec `ViewFilterRule[]`, ObjectQL AST nodes, or a MongoDB-style object).
+     *
+     * Read here, not merged here: when a `dataSource` binding is present,
+     * `ElementDataSourceGate` has already AND-combined this key with the view's
+     * filter and the binding's own before the schema reaches this component
+     * (objectstack#7137) — the same single sink every other object-bound block
+     * composes through.
+     */
+    filter?: any[] | Record<string, any>;
+    /**
+     * Query ordering — the legacy `"name desc"` clause or the spec's
+     * `SortConfig[]`, both lowered through `convertSortToQueryParams`.
+     */
+    sort?: string | Array<{ field?: string; order?: 'asc' | 'desc' }>;
+    /**
+     * Row cap for the fetch. Defaults to {@link DEFAULT_TIMELINE_LIMIT}; a
+     * timeline renders one rail with no pagination control, so this is the
+     * author's window rather than a page size.
+     */
+    limit?: number;
     /** @deprecated Use timeline.titleField instead */
     titleField?: string;
     /** @deprecated Use timeline.startDateField instead */
@@ -145,6 +178,13 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
     return () => { isMounted = false; };
   }, [schema.objectName, dataSource]);
 
+  // Content keys, not identities. `filter` / `sort` are fetch inputs from here on
+  // (objectstack#7137), and an inline array on a schema node is a NEW object every
+  // render — depending on identity would refetch the whole object on every render.
+  // Same reason `RelatedList` keys its own scope filter on content.
+  const filterKey = JSON.stringify(schema.filter ?? null);
+  const sortKey = JSON.stringify(schema.sort ?? null);
+
   useEffect(() => {
     const fetchData = async () => {
         if (!dataSource || typeof dataSource.find !== 'function' || !schema.objectName) {
@@ -156,8 +196,17 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
         try {
             // Auto-inject $expand for lookup/master_detail fields
             const expand = buildExpandFields(objectDef?.fields);
+            // The authored scope reaches the query (objectstack#7137). Before this,
+            // the fetch was `{ options: { $top: 100 } }` — no `$filter`, no
+            // `$orderby`, and `options` is not a `QueryParams` key, so even the cap
+            // was inert. A `dataSource.view` therefore resolved (a typo still
+            // reported) and then contributed nothing: the rail could be wider than
+            // the view it named. `filter` arrives already AND-composed by
+            // `ElementDataSourceGate`, so there is nothing to merge here.
             const results = await dataSource.find(schema.objectName, {
-                options: { $top: 100 },
+                $filter: schema.filter,
+                $orderby: convertSortToQueryParams(schema.sort),
+                $top: schema.limit ?? DEFAULT_TIMELINE_LIMIT,
                 ...(expand.length > 0 ? { $expand: expand } : {}),
             });
             const data = extractRecords(results);
@@ -176,7 +225,8 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
         // Have inline / bound items — won't fetch; clear loading.
         setLoading(false);
     }
-  }, [schema.objectName, dataSource, boundData, schema.items, (props as any).data, refreshKey, objectDef]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `schema.filter`/`schema.sort` are tracked by CONTENT (filterKey/sortKey) on purpose; see above
+  }, [schema.objectName, dataSource, boundData, schema.items, (props as any).data, refreshKey, objectDef, filterKey, sortKey, schema.limit]);
 
   const rawData = (props as any).data || boundData || fetchedData;
   const { t } = useTimelineTranslation();

--- a/packages/plugin-timeline/src/index.tsx
+++ b/packages/plugin-timeline/src/index.tsx
@@ -312,28 +312,26 @@ import {
 } from '@object-ui/react';
 
 /**
- * `object-timeline` maps the binding's `object` and NOTHING ELSE, because
- * `objectName` is the only query key this block has a read site for.
+ * `object-timeline` maps `object` + `filter` + `sort` + `limit` — every key its
+ * fetch now reads (objectstack#7137).
  *
- * `ObjectTimeline.tsx`'s fetch is literally
- * `dataSource.find(schema.objectName, { options: { $top: 100 } })` — no
- * `$filter`, no `$orderby`, and a HARD-CODED window rather than an authored cap.
- * So `filter` / `sort` / `limit` are deliberately left unmapped: writing them
- * onto schema keys the timeline never reads would look like the binding was
- * honoured while changing nothing about the rows fetched, which is exactly the
- * "declared and dropped" defect objectstack#7121 removes. `columns` is unmapped
- * for the same reason a calendar's is — a timeline projects the fields its
- * `timeline` config names (title/start/end/description/color/groupBy).
+ * Until #7137 the fetch was `dataSource.find(schema.objectName, { options: { $top:
+ * 100 } })`: no `$filter`, no `$orderby`, and a cap nested under a key no adapter
+ * reads. objectstack#7121 therefore mapped `object` alone and said so, rather than
+ * writing the composed filter/sort/limit onto keys nobody read — which would have
+ * looked like the binding was honoured while changing nothing about the rows.
+ * #7137 added the read sites (`$filter` / `$orderby` / `$top: schema.limit ?? 100`),
+ * so the flags come with them and a named `view` now actually narrows the rail.
  *
- * Consequence, recorded rather than papered over: a saved `view` named here
- * contributes NOTHING to the query (its filter and sort are dropped), so the
- * timeline can be wider than the view it names. The name is still resolved, so a
- * typo reports instead of silently widening. Tracked as the residual gap in
- * `content/docs/guide/data-source.md`; when the timeline's fetch gains
- * filter/sort read sites, this mapping gains the flags and the binding follows
- * for free.
+ * `columns` stays unmapped for the same reason a calendar's does: a timeline
+ * projects the fields its `timeline` config names (title / start / end /
+ * description / color / groupBy), not a view's column list.
  */
-const OBJECT_TIMELINE_DATA_SOURCE: ElementDataSourceMapping = {};
+const OBJECT_TIMELINE_DATA_SOURCE: ElementDataSourceMapping = {
+  filter: true,
+  sort: true,
+  limit: 'limit',
+};
 
 // Register object-timeline component
 export const ObjectTimelineRenderer: React.FC<any> = ({ schema, ...props }) => {


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7137

基线 `f3b2874e1a1a54a38d73d66684a1c0e35911e9f3`(显式 `origin/main` sha,未用 FETCH_HEAD)。方向按 PM 裁定的**路线 1(补读点)**,不重开豁免路线。

## 问题

这两块是 objectstack#7121 逐 block 覆盖表里剩下的两行 `— no read site`。它们都是 object-bound 的列表形态,都已经接了 spec 的 per-element `dataSource` 绑定,而整条取数里**没有任何地方读 `filter` / `sort`**:

- `object-timeline` —— 整条查询就是 `find(objectName, { options: { $top: 100 } })`
- `record:line_items` —— 只有父 FK 加固定 `$top: 500`

于是在这两块上写 `dataSource: { object, view: 'hot' }`:view 名字**会**被解析(写错报配置错误,不静默回退全量),解析成功后它的 filter / sort 被整份丢掉 —— **渲染出的行可能比作者引用的 view 更宽,而且不报错**。#7121 刻意没有把合成值写到没有读点的 schema 键上(那只是把「声明了却被丢弃」往下挪一层、更难看见),而是把缺口如实写进文档并各钉了一条诚实反向断言。本 PR 从取数这一端补上读点,那两条钉子按其注释的预期翻红,已按指引改写为正向断言。

## 改了什么

**`object-timeline`**(`packages/plugin-timeline/src/ObjectTimeline.tsx`)

```ts
const results = await dataSource.find(schema.objectName, {
    $filter: schema.filter,
    $orderby: convertSortToQueryParams(schema.sort),
    $top: schema.limit ?? DEFAULT_TIMELINE_LIMIT,
    ...(expand.length > 0 ? { $expand: expand } : {}),
});
```

形态逐字对齐同仓 `object-gantt` / `object-map` / `object-calendar`(先读了三处实现再动手,没有发明新形状)。registry 映射相应补 `filter` / `sort` / `limit: 'limit'`;`columns` 仍不映射 —— 时间轴投影的是 `timeline` 配置点名的字段(title / start / end / description / color / groupBy),不是 view 的列清单。

**`record:line_items`**(`packages/plugin-form/src/LineItemsPanel.tsx`)

父关系条件与面板自己的 criteria 经 `mergeFilterNodes` **AND 合成,绝不替换** —— 与 objectstack#7118 之后 `record:related_list` 的做法逐字一致(同一个 sink,没有手拼对象):子面板永远被它所在的那条记录限定,spec 说的「*additional* criteria」只能 further narrow 这个父的子行,不可能翻出别的父的行。什么都没写时查询仍是那个未经改动的 MongoDB 风格对象(而不是一个语义相同、重新下降过的 AST —— 这个差别在屏幕上看不见,对每一个钉住 wire 的调用方却看得见)。`sort` 成为装载顺序(与 `RelatedList` 一样,只在有内容时才落 `$orderby` 键),`limit` 成为行上限(默认 500)。`columns` 仍**不**映射 —— 这里是可编辑网格的 `GridColumn[]`(`{ field, type, options, computed, expr, … }`),不是字段名投影,view 的列清单在这里是**形状不对**而不仅是更宽。

**顺带修掉的一个行为缺陷:timeline 的默认窗口现在是真的。** `{ options: { $top: 100 } }` 把上限放在了一个不属于 `QueryParams` 的键上,仓内没有任何 adapter 读 `params.options`(`@object-ui/data-objectstack` 的 `convertQueryParams` 读的是 `params.$top`),所以作者写下的 100 从未上线 —— 大对象上的时间轴拉回的是服务端愿意给的全部行。现在以顶层 `$top` 发出,并可由 `limit` 或 view 的 `pagination.pageSize` 指定。这条已写进 changeset 的行为变化段。

**`@object-ui/core` 新增 `convertSortToQueryParams`**(`packages/core/src/utils/sort-query.ts`):gantt / map / calendar 各内联了一份逐字副本,本次两个新读点若照抄就是第五、第六份,所以提为共享 sink。它比副本更贴合已声明的契约:缺 `order` 的数组项按升序处理而非丢弃(同一份副本在**字符串**写法上已经把「只有字段名」当升序,所以这是消除两种写法之间的不一致,不是新增容忍),无可排序内容返回 `undefined` 而非 truthy 的 `{}`。两点都有单测钉住。迁移三份既有副本**不在本 PR**,已立单 objectstack#7148。

文档:`content/docs/guide/data-source.md` 覆盖表两行 `— no read site` 改写为已支持,并把原来的「Current gaps」段按事实重写(剩下的只有三个 form 类 block)。

## 测试

`flock /tmp/os-heavy-verify.lock` 串行 + `--max-old-space-size=4096` + `--maxWorkers=2`:

```
pnpm exec vitest run packages/plugin-timeline packages/plugin-form \
  packages/core/src/utils/__tests__/sort-query.test.ts packages/react/src/element-data-source
→ Test Files 43 passed (43) | Tests 387 passed (387)
```

仓根 `pnpm exec turbo run type-check --concurrency=2` → `78 successful, 78 total`。
`node scripts/check-control-bytes.mjs` → OK(3913 个 tracked 文本文件),另按规矩对本次改动文件做了 `grep -naP` 自扫,零命中。
改动文件 eslint → `0 errors`(81 warnings 全为既有类别:`no-explicit-any` / `react-refresh` / `exhaustive-deps`)。

新钉子:两块各钉「view 的 filter/sort/limit 落到 find 参数」「绑定的附加 filter 与 view 的 AND 合成、sort/limit 覆盖 view」「直接写在 block 上的 flat filter/sort/limit 生效」「block 自身 filter 与 view、绑定三方 AND」;line_items 另钉「父 FK 与 authored filter 同时生效」。

## 反向验证(先预判方向,再跑变异;变异不提交)

- **撤掉 timeline 的 `$filter` 接线** —— 预判:4 条 view 贡献钉翻红,3 条 #7121 钉保持绿(其中「无 dataSource 基线」本就断言 `$filter` 为 undefined,所以它**不该**红)。实测 `4 failed | 3 passed`,红的正是那 4 条,报文形如 `expected undefined to deeply equal [ [ 'stage', '=', 'live' ] ]`。
- **把 line_items 的 AND 合成改成覆盖** —— 预判:3 条新钉翻红,3 条 #7121 钉保持绿(未写 filter 时 `listFilterNode` 为 undefined,查询仍是父 FK)。实测 `3 failed | 3 passed`,报文 `expected [ [ 'billable', '=', true ] ] to deeply equal [ 'and', …(2) ]` —— 「父 FK 从查询里消失」这一失败模式被直接观测到,也就是「显示了别的父的行」。

两次变异均已还原(`git diff` 干净,提交里不含变异)。

## 消费半径扫查

按规则的调用方而不是被编辑的包来扫:`object-timeline` / `record:line_items` 的其余消费方 —— `apps/console` 的 `public-block-binding-reach` / `public-contract` / `record-block-record-reach`、`packages/plugin-list` 的 `ListView.timeline-binding`、`packages/plugin-view` 的 ObjectView 路径、`packages/app-shell` 的 page-block-path —— 全部检查过:它们断言的是 objectName 到达数据层 / `$select` / registry inputs,本 PR 未改 registry `inputs`(与 gantt 同样不在 inputs 里声明 filter/sort),这些 fixture 无需改动,实跑亦全绿。

## 范围与边界

spec 仓零改动;未碰 timeline / line_items 以外的 block;未碰 `content/docs/releases/**`。

顺手记录、未在本 PR 修(均已单独立单,unassigned):

- objectstack#7147 —— `object-kanban` 的行上限同样写在 `options: { $top: 100 }` 这个死键里,`$filter` 在顶层生效而 `$top` 不生效,看板对大对象取数**没有任何行上限**;文档表里 `object-kanban` 的「fixed window」一句因此不成立。附带记录 `packages/fields/src/index.tsx:232` 同形但无害(主键等值查询)。
- objectstack#7148(`finding`)—— gantt / map / calendar 三份 `convertSortToQueryParams` 私有副本迁移到本 PR 引入的共享 sink。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_