### PR TITLE
fix(app-shell): InspectorComboField 的 label 关联 trigger,无名 combo 不再可编译 (#3997)

### DIFF
--- a/.changeset/inspector-combo-field-label-3997.md
+++ b/.changeset/inspector-combo-field-label-3997.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Name the `InspectorComboField` trigger: the visible label now owns it, and an anonymous combo no longer compiles (objectui#3997).
+
+This is the fourth inspector field atom with the shape PR #3996 fixed for the three in `_shared.tsx` — a `Label` rendered as a plain sibling of the control, with no `htmlFor`, no `id` and no `aria-label`. It lives in its own module, so it stayed broken after the other three were closed. The label and the `button[role=combobox]` were adjacent only visually: assistive tech announced an anonymous combobox with the field name floating above it as unowned text, `getByLabelText` could not reach it, and clicking the visible label did nothing. It renders at eighteen call sites across the object-field, dataset, dashboard-widget, app-nav and view-variant inspectors (lookup display/description fields, `lookupFilters` rows, summary aggregates, dataset dimensions and measures, nav targets), so it is on screen the moment any of those panels opens.
+
+The labelled branch closes the pair the same way the other atoms do: `React.useId()` mints the id inside the atom, `Label` gets the `htmlFor`, and the id lands on the trigger `Button` that `PopoverTrigger asChild` renders. Never on `Popover` — Radix's `Popover.Root` is a context provider that renders no DOM element, so an id handed to it is dropped silently and the `for` dangles, which is the objectui#3976 / #3994 mistake this repo has now paid for twice.
+
+`label` was optional, and the un-labelled branch was the same defect one notch worse: a combobox with no name at all. Five of the eighteen call sites had authored exactly that. Rather than adding a lenient fallback (synthesising a name from the placeholder would have produced "Select…" as the announced name), naming became a type-level requirement of exactly one of three channels:
+
+- `label` — the atom renders the visible label and owns the association. Unchanged for the thirteen call sites that already passed one.
+- `ariaLabel` — for repeated rows where no visible label exists and one would break the grid: an app-nav URL filter's `field = value` pair, a dataset's list of joined relationships, the dependent-lookup "add a field" picker.
+- `id` — for when an external `Label htmlFor` already owns the naming. `DashboardWidgetInspector` wraps its controls in a `Field` that renders `Label htmlFor={id}` and hands the same id to the control; every other field honoured it (`Input id`, `SelectTrigger id`) but the dataset combo could not, because the atom accepted no id. That `for` pointed at an id nothing carried — a dangling IDREF, worse than an unnamed control, because tooling reports an association that resolves to nothing.
+
+Zero channels and two channels are now both unauthorable: zero is anonymous, and two is the double-announcement failure objectui#3961/#3978 exists to avoid. Neither has a runtime symptom the component could detect and report — an unnamed combobox renders, lays out and commits values perfectly, and is wrong only for the users who cannot see it — so the check is compile-time or nothing. It is pinned in `InspectorComboField.naming.types.test.tsx`, listed in `tsconfig.typetests.json` so a compiler actually reads it.
+
+One new pair of strings (`engine.inspector.widget.filterBindingField`, en-US + zh-CN) names the per-filter binding combo in the dashboard widget inspector, which sits under a heading that captions its whole row rather than the combo alone.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -328,6 +328,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
     'Map each dashboard-level filter to one of this widget’s own fields, or untick Apply to opt the widget out. Empty = the filter’s own field.',
   'engine.inspector.widget.filterBindingApply': 'Apply',
   'engine.inspector.widget.filterBindingDefault': 'Default ({field})',
+  'engine.inspector.widget.filterBindingField': 'Bound field for {filter}',
   'engine.inspector.widget.filterBindingReset': 'Reset',
   // Flow node inspector
   'engine.inspector.flowNode.kind': 'Node',
@@ -2074,6 +2075,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
     '把每个仪表盘级过滤器映射到本组件自己的字段；取消勾选「应用」可让本组件不受该过滤器影响。留空表示使用过滤器自身的字段。',
   'engine.inspector.widget.filterBindingApply': '应用',
   'engine.inspector.widget.filterBindingDefault': '默认（{field}）',
+  'engine.inspector.widget.filterBindingField': '{filter} 绑定的字段',
   'engine.inspector.widget.filterBindingReset': '恢复默认',
   // Flow node inspector
   'engine.inspector.flowNode.kind': '节点',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/AppNavInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/AppNavInspector.tsx
@@ -235,6 +235,10 @@ function FiltersEditor({
         <div key={`${field}-${i}`} className="flex items-center gap-1">
           <div className="min-w-0 flex-1">
             <InspectorComboField
+              // No visible per-row label — the `field = value` shape is read
+              // from the row itself — so the trigger carries its own name
+              // instead of being an anonymous combobox (objectui#3997).
+              ariaLabel={t('engine.inspector.appNav.filtersField', locale)}
               value={field}
               onCommit={(v) => update(i, v, value)}
               options={fieldOptions}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.test.tsx
@@ -95,6 +95,34 @@ describe('DashboardWidgetInspector — dataset binding', () => {
     expect(screen.getByText('维度')).toBeInTheDocument();
   });
 
+  it('the Dataset label resolves to the combo trigger, not to nothing (#3997)', () => {
+    // This panel labels its controls through a `Field` wrapper that renders
+    // `<Label htmlFor={id}>` and expects the wrapped control to carry the same
+    // id. Every other field honoured it (`Input id`, `SelectTrigger id`); the
+    // dataset combo could not, because `InspectorComboField` took no id — so
+    // `htmlFor="widget-dataset"` pointed at an id nothing carried and the
+    // picker was an anonymous combobox. This is the call-site half of the fix:
+    // the atom's own pins live in `_shared.labels.test.tsx`.
+    renderWidget({ dataset: 'sales_pipeline' });
+
+    const label = screen.getByText('Dataset');
+    const forId = label.getAttribute('for');
+    expect(forId).toBeTruthy();
+
+    const trigger = screen.getByLabelText('Dataset');
+    expect(trigger).toBe(document.getElementById(forId!));
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('role', 'combobox');
+    expect(trigger).toHaveAccessibleName('Dataset');
+    // Exactly one element answers that id — the trigger, not a wrapper.
+    expect(document.querySelectorAll(`[id="${forId}"]`)).toHaveLength(1);
+
+    // Scoped to this `Field` deliberately: a panel-wide "no dangling for" sweep
+    // would also catch `widget-color`, whose `ColorVariantPicker` accepts no id
+    // either. That is a different component and out of this issue's scope — it
+    // is filed separately rather than fixed here or asserted broken here.
+  });
+
   it('disables every picker when readOnly', () => {
     renderWidget({ dataset: 'sales_pipeline', object: 'crm_opportunity' }, { readOnly: true });
     const combos = screen.getAllByRole('combobox');

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DashboardWidgetInspector.tsx
@@ -259,6 +259,12 @@ export function DashboardWidgetInspector({
         </div>
         <Field id="widget-dataset" label={t('engine.inspector.widget.dataset', locale)}>
           <InspectorComboField
+            // `Field` above renders `<Label htmlFor="widget-dataset">`; the id
+            // has to reach the trigger or that `for` dangles (objectui#3997).
+            // Every other `Field` in this file already hands its id to the
+            // control it wraps (`Input id`, `SelectTrigger id`) — this one could
+            // not, because the combo took no id at all.
+            id="widget-dataset"
             value={datasetName}
             onCommit={(v) => patchWidget({ dataset: v || undefined } as Partial<DashboardWidgetSchema>)}
             options={datasetComboOptions}
@@ -346,6 +352,15 @@ export function DashboardWidgetInspector({
                   <div className="flex items-center gap-1">
                     <div className="min-w-0 flex-1">
                       <InspectorComboField
+                        // The filter's name above is a heading for the whole row
+                        // (it also captions the Apply checkbox) and disappears
+                        // from the association when the row is opted out, so the
+                        // trigger carries its own name rather than borrowing it
+                        // (objectui#3997). Includes the filter name because a
+                        // dashboard has several of these rows.
+                        ariaLabel={tFormat('engine.inspector.widget.filterBindingField', locale, {
+                          filter: def.label || def.name,
+                        })}
                         value={override}
                         onCommit={(v) => setBinding(v ? v : undefined)}
                         options={fieldComboOptions}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/DatasetDefaultInspector.tsx
@@ -412,6 +412,10 @@ export function DatasetDefaultInspector({ draft, onPatch, readOnly, name }: Meta
           include.map((rel, i) => (
             <div key={i} className="flex items-center gap-1.5">
               <InspectorComboField
+                // One row per join under the "Included relationships" heading;
+                // no per-row visible label, so the trigger is named directly
+                // rather than left anonymous (objectui#3997).
+                ariaLabel="Included relationship"
                 value={rel}
                 onCommit={(v) => onPatch({ include: include.map((r, idx) => (idx === i ? v : r)) })}
                 options={relationshipComboOptions}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/InspectorComboField.naming.types.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/InspectorComboField.naming.types.test.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `InspectorComboField`'s naming contract is enforced by the TYPE, so it is
+ * pinned at compile time (objectui#3997).
+ *
+ * The atom accepts exactly one of `label` / `ariaLabel` / `id` — never zero,
+ * never two. Zero is an anonymous `button[role=combobox]`: assistive tech reads
+ * "combobox" with no idea which field it edits. Two is the double-announcement
+ * failure objectui#3961/#3978 exists to avoid. Both were authorable before this
+ * change, and five of the eleven live call sites had in fact authored zero.
+ *
+ * The reason this is a TYPE and not a runtime guard is that neither mistake has
+ * a runtime symptom the component could detect and report: an unnamed combobox
+ * renders, lays out and commits values perfectly. It is only wrong for the users
+ * who cannot see it. So the check has to happen at authoring time or not at all.
+ *
+ * ## Why this file exists separately, and why it is listed
+ *
+ * The assertions below are its entire point, so it is listed in
+ * `packages/app-shell/tsconfig.typetests.json`. That listing is the difference
+ * between a pin and a decoration: the package's build tsconfig excludes
+ * `**\/*.test.tsx`, and vitest erases types before running, so a
+ * `@ts-expect-error` written in an ordinary `*.test.tsx` file in this directory
+ * is read by NO compiler — it neither fails when the error disappears nor when
+ * the error was never there. This was drafted that way first, and the mutation
+ * run said so: making naming optional again produced a completely green
+ * `tsc --noEmit`. That is objectui#3009's failure verbatim (assertions that
+ * never ran, under a header calling them the real enforcement), and
+ * `tsconfig.typetests.json`'s own header warns about it — so the type-level
+ * cases moved here, out of `_shared.labels.test.tsx`, where they are compiled.
+ *
+ * The runtime `expect` at the bottom is deliberately thin: the DOM consequences
+ * (which element carries the id, what the accessible name resolves to, that the
+ * id never lands on the Radix `Popover` root) are pinned in
+ * `_shared.labels.test.tsx`, which renders. This file only has to be a file
+ * vitest can run without complaining that it holds no tests.
+ */
+
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { InspectorComboField, type InspectorComboFieldProps } from './InspectorComboField';
+
+type Assert<T extends true> = T;
+type Extends<A, B> = [A] extends [B] ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+const OPTIONS = [{ value: 'profile', label: 'Profile' }];
+const noop = (_v: string) => {};
+
+/** Everything the combo needs EXCEPT a name. */
+type Base = {
+  value: string;
+  onCommit: (v: string) => void;
+  options: Array<{ value: string; label: string }>;
+};
+
+describe('InspectorComboField — naming is required, and singular (#3997)', () => {
+  it('is pinned at compile time', () => {
+    // Guard against the probe lying: were the props `any`, every assignability
+    // assertion below would pass while proving nothing.
+    type _PropsNotAny = Assert<Equal<IsAny<InspectorComboFieldProps>, false>>;
+
+    // ── the three legal spellings ────────────────────────────────────────────
+    // The atom renders the visible label and owns the `htmlFor` ⇄ `id` pair.
+    type _LabelIsANaming = Assert<Extends<Base & { label: string }, InspectorComboFieldProps>>;
+    // No visible label exists (repeated rows); the trigger names itself.
+    type _AriaLabelIsANaming = Assert<Extends<Base & { ariaLabel: string }, InspectorComboFieldProps>>;
+    // An external `<Label htmlFor={id}>` owns the naming; the id must reach the
+    // trigger or that `for` dangles.
+    type _IdIsANaming = Assert<Extends<Base & { id: string }, InspectorComboFieldProps>>;
+
+    // ── zero naming channels is not authorable ───────────────────────────────
+    // The regression this file exists for. Five call sites shipped this shape.
+    type _AnonymousRejected = Assert<Equal<Extends<Base, InspectorComboFieldProps>, false>>;
+
+    // ── two naming channels is not authorable either ─────────────────────────
+    type _LabelPlusAriaRejected = Assert<
+      Equal<Extends<Base & { label: string; ariaLabel: string }, InspectorComboFieldProps>, false>
+    >;
+    type _LabelPlusIdRejected = Assert<
+      Equal<Extends<Base & { label: string; id: string }, InspectorComboFieldProps>, false>
+    >;
+    type _AriaPlusIdRejected = Assert<
+      Equal<Extends<Base & { ariaLabel: string; id: string }, InspectorComboFieldProps>, false>
+    >;
+
+    // ── the same two rejections as a caller actually writes them ─────────────
+    // Assignability above is the contract; JSX is the authoring surface, and
+    // excess-property checking makes them differ often enough to pin both.
+    const anonymous = (
+      // @ts-expect-error objectui#3997 — a combo with no name must not compile.
+      <InspectorComboField value="" options={OPTIONS} onCommit={noop} />
+    );
+    const doublyNamed = (
+      // @ts-expect-error objectui#3997 — `label` and `ariaLabel` are exclusive.
+      <InspectorComboField label="Group" ariaLabel="Group" value="" options={OPTIONS} onCommit={noop} />
+    );
+
+    expect([anonymous, doublyNamed].every(React.isValidElement)).toBe(true);
+  });
+
+  it('accepts each legal spelling as a real element', () => {
+    // Keeps the three positive cases honest: an over-tight union that rejected a
+    // shape a call site needs would fail here rather than only in CI's build.
+    const labelled = <InspectorComboField label="Group" value="" options={OPTIONS} onCommit={noop} />;
+    const ariaLabelled = <InspectorComboField ariaLabel="Group" value="" options={OPTIONS} onCommit={noop} />;
+    const externallyLabelled = (
+      <InspectorComboField id="widget-dataset" value="" options={OPTIONS} onCommit={noop} />
+    );
+
+    expect([labelled, ariaLabelled, externallyLabelled].every(React.isValidElement)).toBe(true);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/InspectorComboField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/InspectorComboField.tsx
@@ -12,6 +12,23 @@
  * catalog, a computed path, or a server-only field is never a dead end).
  *
  * Self-filters (`shouldFilter={false}`) for predictable label+value matching.
+ *
+ * ## Naming (objectui#3997)
+ *
+ * The trigger is a `button[role=combobox]` rendered by `PopoverTrigger asChild`,
+ * so it is a labelable element — but visual adjacency to a `<Label>` is NOT an
+ * association. Before this fix the labelled branch rendered the `<Label>` as a
+ * bare sibling (no `htmlFor`, no id, no `aria-label`), so assistive tech read an
+ * anonymous "combobox" with the field name floating above it as unowned text,
+ * `getByLabelText` could not reach it, and clicking the visible label did
+ * nothing — the same defect PR #3996 closed for the three `_shared.tsx` atoms.
+ * The un-labelled branch was one notch worse: the combobox was wholly anonymous.
+ *
+ * Naming is therefore a TYPE-LEVEL requirement (see {@link InspectorComboFieldNaming}):
+ * exactly one of `label` / `ariaLabel` / `id` must be given, so an anonymous
+ * combo cannot be authored — it fails `tsc`, not a review. One channel only,
+ * never two: a control carrying both an associated `<Label>` and an `aria-label`
+ * is the double-announcement failure objectui#3961/#3978 exists to avoid.
  */
 
 import * as React from 'react';
@@ -40,8 +57,40 @@ export interface InspectorComboOption {
   group?: string;
 }
 
-export interface InspectorComboFieldProps {
-  label?: string;
+/**
+ * Where this combo's accessible name comes from — exactly one of three, never
+ * zero and never two. Pick the variant that matches where the name already lives:
+ *
+ * • `label`     — this atom renders the visible `<Label>` and owns the pair
+ *                 (`htmlFor` ⇄ a `React.useId()`-minted trigger id). The default
+ *                 choice, and the only one that needs no caller bookkeeping.
+ * • `ariaLabel` — there is no visible label to associate: repeated rows whose
+ *                 column is obvious from context (an object filter's `field =
+ *                 value` pair, a dataset's list of joined relationships) and
+ *                 "add another" pickers sitting under a group heading. The
+ *                 trigger carries the name itself.
+ * • `id`        — an EXTERNAL `<Label htmlFor={…}>` already owns the naming (the
+ *                 `Field` wrapper in `DashboardWidgetInspector` is the live
+ *                 case). The caller's id lands on the trigger so that `for`
+ *                 RESOLVES; without this prop the caller's `for` pointed at an
+ *                 id nothing carried, which is a dangling IDREF — strictly worse
+ *                 than no label, because the tooling reports an association that
+ *                 does not exist.
+ *
+ * `label` mints its id internally rather than accepting one because these combos
+ * render in loops over array items (`lookupFilters[i]`, `dimensions[i]`), where a
+ * caller-supplied id is exactly what collides: two rows sharing a label would
+ * share an id and both labels would silently resolve to the FIRST trigger.
+ * `useId()` cannot be authored into a collision. The `id` variant re-opens that
+ * door by necessity — the caller must already own the id to have written the
+ * `for` — so reach for it only when an external label is genuinely in charge.
+ */
+export type InspectorComboFieldNaming =
+  | { label: string; ariaLabel?: never; id?: never }
+  | { label?: never; ariaLabel: string; id?: never }
+  | { label?: never; ariaLabel?: never; id: string };
+
+export type InspectorComboFieldProps = InspectorComboFieldNaming & {
   value: string;
   onCommit: (v: string) => void;
   options: InspectorComboOption[];
@@ -56,7 +105,7 @@ export interface InspectorComboFieldProps {
   mono?: boolean;
   /** Override the trigger label for the currently-selected custom value. */
   className?: string;
-}
+};
 
 function matches(option: InspectorComboOption, q: string): boolean {
   if (!q) return true;
@@ -70,6 +119,8 @@ function matches(option: InspectorComboOption, q: string): boolean {
 
 export function InspectorComboField({
   label,
+  ariaLabel,
+  id,
   value,
   onCommit,
   options,
@@ -84,6 +135,20 @@ export function InspectorComboField({
 }: InspectorComboFieldProps) {
   const [open, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
+
+  // The id goes on the trigger `Button`, never on `Popover`: Radix's
+  // `Popover.Root` is a context provider that renders no DOM element of its own,
+  // so an id (or any aria-*) handed to it is silently DROPPED and the label's
+  // `for` resolves to nothing — the failure objectui#3976 (PR #3992) and #3994
+  // (PR #3996) each paid for once. `PopoverTrigger asChild` merges its props
+  // onto the `Button` below, which renders the real `button[role=combobox]`.
+  //
+  // It is minted only when something points AT it: the `<Label>` this atom
+  // renders (`autoId`), or the caller's external label (`id`). In the
+  // `ariaLabel` variant nothing references an id, so none is emitted — an
+  // unreferenced id would be noise, and the naming channel stays exactly one.
+  const autoId = React.useId();
+  const triggerId = label ? autoId : id;
 
   const selected = options.find((o) => o.value === value);
   const triggerText = selected ? selected.label : value || (loading ? 'Loading…' : placeholder);
@@ -126,6 +191,8 @@ export function InspectorComboField({
           type="button"
           variant="outline"
           role="combobox"
+          id={triggerId}
+          aria-label={ariaLabel}
           aria-expanded={open}
           disabled={disabled}
           className={cn('h-8 w-full justify-between px-2 text-sm font-normal', className)}
@@ -173,10 +240,12 @@ export function InspectorComboField({
     </Popover>
   );
 
+  // No visible label to render: the name is already on the trigger (`ariaLabel`)
+  // or owned by an external `<Label htmlFor={id}>` that now resolves to it.
   if (!label) return field;
   return (
     <div className="space-y-1">
-      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <Label htmlFor={autoId} className="text-xs text-muted-foreground">{label}</Label>
       {field}
     </div>
   );

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -1147,6 +1147,10 @@ function LookupConfigFields({
         )}
         {!readOnly && hostOptions.length > 0 && (
           <InspectorComboField
+            // The `Depends on` label above heads the whole group (chips + this
+            // "add another" picker), so the picker names itself rather than
+            // hijacking the group heading (objectui#3997).
+            ariaLabel={tr('designer.field.lookup.addDependsOn')}
             value=""
             onCommit={(v) => addDependsOn(v)}
             options={hostOptions.filter((o) => !dependsOn.includes(o.value))}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/_shared.labels.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/_shared.labels.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * objectui#3994 — the three shared inspector atoms that render a `<Label>` as a
+ * objectui#3994 / #3997 — the inspector field atoms that render a `<Label>` as a
  * SIBLING of their control must close the association (`htmlFor` ⇄ `id`).
  *
  * Before this fix `InspectorTextField` / `InspectorNumberField` /
@@ -20,6 +20,24 @@
  * workaround — `PageBlockInspector.sectionName.test.tsx` located its boxes by
  * placeholder *because* `getByLabelText` could not reach them; that locator is
  * tightened in the same change.
+ *
+ * ## The fourth atom (objectui#3997)
+ *
+ * `InspectorComboField` lives in its own module but is the same shape — a
+ * `<Label>` sibling over a `button[role=combobox]` — and PR #3996 did not touch
+ * it, so it kept the defect after the three `_shared.tsx` atoms were fixed. It
+ * joins the component-agnostic `describe.each` below unchanged, which is the
+ * point of having written those rows against a roster rather than per component.
+ *
+ * Its `label` is optional, and the un-labelled branch was the defect one notch
+ * worse: a wholly ANONYMOUS combobox (no `for`, no `aria-label`). That is now
+ * unauthorable rather than merely fixed at the five call sites — naming is a
+ * type-level requirement of exactly one of `label` / `ariaLabel` / `id`, pinned
+ * by the `@ts-expect-error` case at the bottom of this file. The `id` variant
+ * exists because one real call site (`DashboardWidgetInspector`'s `Field`
+ * wrapper) already rendered `<Label htmlFor="widget-dataset">` over a combo that
+ * accepted no id — a dangling IDREF, which is worse than an unnamed control
+ * because tooling reports an association that resolves to nothing.
  *
  * ## Why the id is minted inside the atom
  *
@@ -41,6 +59,10 @@
  *     select rows go red while text/number stay green, because Radix's
  *     `Select.Root` renders no DOM element and silently DROPS the id (the
  *     objectui#3976 / PR #3992 mechanism, one directory over).
+ *  3. (#3997) Move the combo's `id` off the trigger `Button` and onto `Popover`
+ *     → the combo rows go red for the same reason as (2): `Popover.Root` is a
+ *     context provider that renders no DOM element, so the id is dropped and the
+ *     `for` dangles. The other three atoms stay green.
  *
  * Measured outcomes are in the PR body.
  */
@@ -48,12 +70,14 @@
 import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { Label } from '@object-ui/components';
 import {
   InspectorTextField,
   InspectorNumberField,
   InspectorSelectField,
   InspectorCheckboxField,
 } from './_shared';
+import { InspectorComboField } from './InspectorComboField';
 
 afterEach(cleanup);
 
@@ -116,6 +140,22 @@ const ATOMS: AtomCase[] = [
       <InspectorSelectField
         label={label}
         value={undefined}
+        options={OPTIONS}
+        onCommit={onCommit as (v: string) => void}
+      />
+    ),
+  },
+  {
+    // objectui#3997 — the fourth atom, from its own module. Same shape, so the
+    // rows below apply verbatim; the trigger is the `Button` that
+    // `PopoverTrigger asChild` renders as `button[role=combobox]`.
+    atom: 'InspectorComboField',
+    role: 'combobox',
+    tag: 'BUTTON',
+    render: (label, onCommit) => (
+      <InspectorComboField
+        label={label}
+        value=""
         options={OPTIONS}
         onCommit={onCommit as (v: string) => void}
       />
@@ -262,6 +302,43 @@ describe('the labelled element is the live control, not a decoy (#3994)', () => 
     expect(trigger.textContent).toContain('Profile');
   });
 
+  it('InspectorComboField — the id lands on the trigger, not on the Radix Popover root', () => {
+    // Same mechanism as the select one line up: `Popover.Root` is a context
+    // provider with no DOM element of its own (objectui#3997). The trigger is
+    // the real control — it is the element that displays the selected option's
+    // label, takes focus, and toggles the list.
+    render(
+      <InspectorComboField label="Group" value="profile" options={OPTIONS} onCommit={vi.fn()} />,
+    );
+
+    const trigger = screen.getByLabelText('Group');
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('role', 'combobox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger.textContent).toContain('Profile');
+    // Nothing else in the tree carries the id — in particular no wrapper div
+    // stood in for the dropped Root.
+    expect(idOwners(trigger.getAttribute('id')!)).toBe(1);
+  });
+
+  it('InspectorComboField — a custom value keeps the trigger named', () => {
+    // The escape hatch (`allowCustom`) renders the raw value as the trigger
+    // text; naming must not depend on the value matching a catalog option.
+    render(
+      <InspectorComboField
+        label="Group"
+        value="account.owner.name"
+        options={OPTIONS}
+        onCommit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Group' }).textContent).toContain(
+      'account.owner.name',
+    );
+    expect(labelTargets().filter((l) => !l.resolves)).toEqual([]);
+  });
+
   it('InspectorSelectField — a disabled field is still named', () => {
     // `disabled` stays on the Root (single authority over trigger + items +
     // the hidden native mirror); naming must not travel with it.
@@ -278,6 +355,83 @@ describe('the labelled element is the live control, not a decoy (#3994)', () => 
     expect(screen.getByRole('combobox', { name: 'Group' })).toBeDisabled();
     expect(labelTargets().filter((l) => !l.resolves)).toEqual([]);
   });
+});
+
+/* ────────── the un-labelled combo branch still names its trigger ─────────── */
+
+describe('InspectorComboField — a combo without a visible label is still named (#3997)', () => {
+  it('names the trigger from `ariaLabel` when no label is rendered', () => {
+    // The repeated-row shape: an object filter's `field = value` pair, a
+    // dataset's list of joins, an "add another" picker under a group heading.
+    // Pre-fix these rendered a wholly anonymous combobox.
+    render(
+      <InspectorComboField
+        ariaLabel="Included relationship"
+        value="account_id"
+        options={OPTIONS}
+        onCommit={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox', { name: 'Included relationship' });
+    expect(trigger).toHaveAccessibleName('Included relationship');
+    expect(trigger.tagName).toBe('BUTTON');
+    // No visible label was rendered, so there is nothing to associate — and in
+    // particular no `for` pointing at nothing.
+    expect(document.querySelectorAll('label')).toHaveLength(0);
+    expect(labelTargets()).toEqual([]);
+    // `aria-label` is then the ONLY channel: no second `aria-labelledby`.
+    expect(trigger).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('resolves an EXTERNAL label to the trigger when the caller owns the id', () => {
+    // `DashboardWidgetInspector`'s `Field` wrapper verbatim: the caller renders
+    // `<Label htmlFor={id}>` and hands the same id to the control it wraps.
+    // Pre-fix the combo accepted no id, so that `for` dangled.
+    render(
+      <div className="space-y-1.5">
+        <Label htmlFor="widget-dataset">Dataset</Label>
+        <InspectorComboField
+          id="widget-dataset"
+          value="sales_pipeline"
+          options={OPTIONS}
+          onCommit={vi.fn()}
+        />
+      </div>,
+    );
+
+    const trigger = screen.getByLabelText('Dataset');
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('role', 'combobox');
+    expect(trigger).toHaveAccessibleName('Dataset');
+    // The caller's `for` now RESOLVES, and to exactly one element.
+    expect(labelTargets()).toEqual([{ text: 'Dataset', forId: 'widget-dataset', resolves: true }]);
+    expect(idOwners('widget-dataset')).toBe(1);
+    // The external label is the only channel — the atom did not also stamp an
+    // `aria-label` "just in case", which would double-announce.
+    expect(trigger).not.toHaveAttribute('aria-label');
+  });
+
+  it('does not render a visible label for either un-labelled variant', () => {
+    // Guards against "fixing" the anonymous branch by inventing a visible label
+    // out of the aria name or the placeholder: these call sites are laid out in
+    // rows where a rendered label would break the grid.
+    const { container } = render(
+      <InspectorComboField ariaLabel="Field" value="" options={OPTIONS} onCommit={vi.fn()} />,
+    );
+
+    expect(container.querySelector('label')).toBeNull();
+    expect(screen.queryByText('Field')).not.toBeInTheDocument();
+  });
+
+  // The type-level half of this contract — that a combo with NO name, or with
+  // two names, does not compile — is pinned in
+  // `InspectorComboField.naming.types.test.tsx`, not here. A `@ts-expect-error`
+  // in this file would be read by no compiler: the package's build tsconfig
+  // excludes `**/*.test.tsx` and vitest erases types, so it would neither fail
+  // when the error disappeared nor when it was never there (objectui#3009). That
+  // sibling file is listed in `tsconfig.typetests.json`, which is what makes its
+  // directives load-bearing.
 });
 
 /* ───────────────────────── the counter-example holds ─────────────────────── */

--- a/packages/app-shell/tsconfig.typetests.json
+++ b/packages/app-shell/tsconfig.typetests.json
@@ -68,9 +68,20 @@
   // in which the hand-written shape was too NARROW — excess-property checking
   // rejected the canonical `{ dialect, source }` literal outright. No test that
   // vitest runs can observe that, so unlisted it would be commentary.
+  // `views/metadata-admin/inspectors/InspectorComboField.naming.types.test.tsx`
+  // earns its place through objectui#3997: the combo's naming contract (exactly
+  // one of `label` / `ariaLabel` / `id`) is enforced only by its props union, and
+  // neither violation has a runtime symptom the component could report — an
+  // unnamed combobox renders and commits perfectly, it is just anonymous to
+  // assistive tech. So the whole check is compile-time, and unlisted it would be
+  // decoration: the first draft put the `@ts-expect-error` cases in
+  // `_shared.labels.test.tsx`, and making naming optional again type-checked
+  // completely green. It is also the first `.tsx` entry here — JSX compiles
+  // because the root tsconfig sets `"jsx": "react-jsx"`.
   "include": [
     "src/__tests__/spec-symbol-parity.test.ts",
     "src/utils/resolveActionParams.test.ts",
+    "src/views/metadata-admin/inspectors/InspectorComboField.naming.types.test.tsx",
     "src/views/metadata-admin/previews/flow-designer-edge.types.test.ts",
     "src/views/metadata-admin/previews/simulator/__tests__/flow-sim-edge.types.test.ts"
   ]


### PR DESCRIPTION
Fixes #3997

第四个字段原子,与 PR #3996 修掉的 `_shared.tsx` 三个原子形状完全相同:`Label` 是控件的兄弟节点,没有 `htmlFor`;trigger 没有 `id`,也没有 `aria-label` 兜底。它住在自己的模块里,所以那三个修好之后它仍旧带着缺陷。标签与 `button[role=combobox]` 之间只有视觉邻接:焦点落上去读到的是匿名 combobox,可见标签是一段无归属文本,`getByLabelText` 到不了它,点标签什么都不会发生。

非测试调用点 **18 处**(对象字段 / 数据集 / 仪表盘部件 / 应用导航 / 视图变体检查器 —— lookup 显示与描述字段、`lookupFilters` 行、汇总聚合、数据集维度与度量、导航目标),打开任一面板即渲染,不是 dormant。

## 带 label 分支

照 #3994 的定型机制闭合:`React.useId()` 在原子内部生成 id,`Label` 补 `htmlFor`,id 落到 `PopoverTrigger asChild` 渲染出的那个 `Button`。

⛔ **不落 `Popover`** —— Radix `Popover.Root` 是纯 context provider,不渲染任何 DOM 元素,给它的 `id` 会被静默丢弃、`for` 随之悬空。这是 #3976(PR #3992)与 #3994(PR #3996)已经付过两次学费的同一机制,所以这次把「落点在 DOM 真实元素上」单独钉成一条断言,而不是靠注释约束。

## 无 label 分支:命名改成类型级要求,而不是消费端兜底

`label` 原本可选,无 label 分支是同缺陷更重一档 —— combobox 完全无名(既没有 `for` 也没有 `aria-label`),而 18 处调用点里有 **5 处**正是这么写的。

没有采用宽松兜底:用 `placeholder` 合成名字会把「Select…」念成字段名,而「消费端容忍」正是 AI 写出的元数据错误藏身与繁殖的地方。改为「三条通道恰选其一」,零条与两条都不可编译:

| 通道 | 何时用 | 本 PR 里的站点 |
| --- | --- | --- |
| `label` | 原子渲染可见标签并自持关联 | 已传 label 的 13 处,不变 |
| `ariaLabel` | 重复行里本就没有可见标签,加一个会破坏栅格 | 应用导航 URL 过滤条件的 `field = value` 行、数据集 join 列表、依赖查找的「添加字段」选择器、仪表盘部件的按过滤器绑定行 |
| `id` | 外部 `Label htmlFor` 已经持有命名 | `DashboardWidgetInspector` 的 `widget-dataset` |

`id` 这一条是被真实站点逼出来的:`DashboardWidgetInspector` 用一个 `Field` 包装器渲染 `Label htmlFor={id}` 并把同一个 id 交给被包控件,其余字段都履行了这个约定(`Input id`、`SelectTrigger id`),只有 dataset combo 落不下去,因为原子根本不收 id。那个 `for` 指向一个没有任何元素持有的 id —— **悬空 IDREF,比无标签更糟**,因为工具会报告一个解析不到的关联。

两条通道同时给出是 #3961/#3978 要避免的重复播报,故一并禁掉。

之所以把它做成**类型**而不是运行期守卫:两种错误都没有组件能自行发现并报告的运行期症状 —— 无名 combobox 渲染、布局、提交值全都正常,只对看不见它的用户是错的。所以检查只能发生在编写期,否则就不存在。

## 反向验证(先预判方向,再跑变异;变异均未提交)

三个方向都实测了,其中第三个的预判**是错的**,写在这里而不是抹平:

1. **撤 `htmlFor`** → 预判 combo 各行翻红。实测 8 行红,其余三原子与 `InspectorCheckboxField` 保持绿。预判里特意点出「`mints exactly one owner for the id` 应当保持绿」(id 还在 Button 上,只是没人指向它)—— 实测确认,该行是这一变异唯一测不到的行。
2. **id 改落 `Popover` Root** → 预判 combo 各行红,且外部 `id` 分支一并红。实测 11 行红:上面 8 行 + `mints exactly one owner`(id 被整个丢弃,owner 计数 1 到 0)+ 外部 `id` 分支 + `DashboardWidgetInspector` 真实调用点的钉子。Radix 不报任何警告,静默丢弃如注释所述。
3. **命名改回可选** → 预判 typecheck 因两条 unused `@ts-expect-error` 翻红。**实测完全绿 —— 假绿。** 第一稿把 `@ts-expect-error` 写在 `_shared.labels.test.tsx` 里,而包的构建 tsconfig 排除 `**/*.test.tsx`、vitest 又擦除类型,没有任何编译器读它:那两条指令既不会在错误消失时失败,也不会在错误从来不存在时失败。这正是 #3009 的失效模式(断言从未运行,而文件头声称它们是「真正的强制」),`tsconfig.typetests.json` 自己的头注释也在警告同一件事。于是类型级断言移入独立文件 `InspectorComboField.naming.types.test.tsx` 并列入 `tsconfig.typetests.json`;同一变异现在报 **6 条**错(4 条 assignability 断言 + 2 条 unused `@ts-expect-error`)。

## 钉子

- `_shared.labels.test.tsx` —— 第四原子直接加入既有的 `describe.each`(它已把「for 有宿主 / 命中可聚焦控件 / 可访问名 / 单一命名通道 / 多实例不撞车」写成与组件无关的形状,这正是按名册而非按组件写的回报),另加四组:trigger 落点(含 owner 计数)、自定义值仍有名、`ariaLabel` 分支、外部 `id` 分支。
- `DashboardWidgetInspector.test.tsx` —— 真实调用点上钉 Dataset 标签解析到 combo trigger。**刻意只锁这一对**,没有做整面板「无悬空 for」扫描:`widget-color` 的 `ColorVariantPicker` 同样不收 id,那个 `for` 也悬空、且它的 radiogroup 完全无可访问名 —— 另一个组件、本单范围外,已单独立单 **#4010**(未认领,交 triage)。整面板扫描会把它锁成红,或更糟,锁成一条将来被「修绿」的假断言。
- `InspectorComboField.naming.types.test.tsx`(新增)—— 类型级断言,来历见上。

## 范围

主体是 `InspectorComboField` 这一个已核实站点 + 其无 label 分支的命名兜底。issue 正文附的 18 处宽面清单**不在本 PR**(逐处「Label 下面到底是不是控件、还是纯分组小标题」未核)。实施中顺手核实到的两处判断已回传给 PM,代码未动。

新增一对 i18n 字符串(`engine.inspector.widget.filterBindingField`,en-US + zh-CN),给仪表盘部件里按过滤器的绑定 combo 命名 —— 它上方那个标题同时统辖一个 checkbox 和这个 combo,是行级标题而非控件标签,故不去改动它的归属(那正属于宽面 sweep 要裁定的事)。

## 验证

- `pnpm exec vitest run packages/app-shell --maxWorkers=2` —— 312 文件 / 2921 通过 / 1 跳过。
- 仓根 `pnpm exec turbo run type-check --concurrency=2` —— 78/78 成功。
- `node scripts/check-control-bytes.mjs`、`check-type-check-coverage.mjs`、`check-i18n-call-site-keys.mjs`、`check-i18n-en-drift.mjs` 全绿;`@object-ui/app-shell` lint 0 error。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_