### PR TITLE
fix(fields): resolve select + multiple to field:multiselect so its host label names the chip group

### DIFF
--- a/.changeset/select-multiple-widget-mapping-3986.md
+++ b/.changeset/select-multiple-widget-mapping-3986.md
@@ -1,0 +1,16 @@
+---
+'@object-ui/fields': patch
+'@object-ui/plugin-form': patch
+---
+
+Resolve a `select` field declared `multiple: true` to the `field:multiselect` widget, so the object form's visible label actually names the chip picker it renders (objectui#3986).
+
+`mapFieldTypeToFormType` keyed the widget id on the field's `type` string alone, so an object-schema `{ type: 'select', multiple: true }` picklist — a spec-legal, entirely ordinary shape — became `field:select`. `SelectField` then delegated to `MultiSelectField` on `config.multiple`, so the component that RENDERED was the chip picker while everything keyed on the widget id still answered for the single-value combobox. Above all the label-association declaration (`ComponentMeta.labelling`, objectui#3961), which the form renderer resolves per widget id: the host emitted `<label for>` at the chip row's wrapper `div`, where a `for` is inert — `HTMLLabelElement.control` returns `null`. Visually the field had a label; in the accessibility tree that label named nothing. Measured on the object-form path, `role=group` + accessible name went from 1 for a `multiselect`-typed field (fixed in objectui#3975) to 0 for this one.
+
+Declaring `select` itself `labelling: 'group'` was not available: a single-value select's trigger is a labelable `button[role=combobox]` whose `for` association works, and a bare `select` is a builtin the renderer resolves without consulting the registry at all. The fix is therefore at the producer — the widget id now carries the arity, so one place decides which widget renders and the declaration can no longer be addressed to a widget that is not rendering.
+
+- `mapFieldTypeToFormType(fieldType, config?)` takes an optional second argument — the rest of the field definition, of which only `multiple` is read. Existing single-argument calls are unchanged, and so is every type outside the new table: `select` is the only one whose `multiple` form is a different WIDGET. The spec's multi-capable set is larger (select / lookup / file / image, with `radio` on the select branch and `user` storing like `lookup`), but `LookupField`, `FileField` and `ImageField` each render both arities themselves, so their id — and their labelling declaration — is already right for either.
+- The four object-form producers pass the pair: `ObjectForm`, `DrawerForm`, `ModalForm`, and `sectionFields` (Tabbed / Wizard / Split / Drawer / Modal). In `sectionFields` the id is now computed once from the EFFECTIVE pair, after view-level overrides have merged, because `multiple` is itself a spec `FormField` key: a view restating only `multiple: true` over a single-value object field moves the widget too, and `multiple: false` moves it back.
+- `SelectField`'s `multiple` delegation is KEPT, not retired. Measured, it stays reachable from three entrances that never consult the alias map: the inline grid editor (`FieldEditWidget` finds `select` in its own table first), `ActionParamDialog` (`resolveFormWidgetType` returns `select` from `fieldWidgetMap` first), and hand-written SDUI addressing `field:select` by name with `multiple` on its metadata.
+
+Read-only rendering of these widgets is untouched (objectui#4005), as is the built-in `Select` branch (objectui#3976).

--- a/packages/fields/src/__tests__/group-labelling-declaration.test.ts
+++ b/packages/fields/src/__tests__/group-labelling-declaration.test.ts
@@ -31,7 +31,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
-import { registerAllFields } from '../index';
+import { registerAllFields, mapFieldTypeToFormType } from '../index';
 
 /**
  * Every field type whose host label must be associated by IDREF. Two shapes, one
@@ -109,5 +109,40 @@ describe('field widgets declare how their label must be associated (objectui#396
       .sort();
 
     expect(declared).toEqual([...GROUP_LABELLED].sort());
+  });
+});
+
+/**
+ * The join between the two halves (objectui#3986). The declaration above is
+ * per-WIDGET; a form asks for a widget by the id its producer emitted. So the
+ * declaration only reaches the right widget if the producer names the widget that
+ * will actually render — and for `select` that depends on `multiple`, not on the
+ * type string alone.
+ *
+ * Asserting the pair here, rather than in either half alone, is what makes the
+ * failure visible: `mapFieldTypeToFormType`'s own test cannot know what
+ * `labelling` the id it returns carries, and the declaration test cannot know
+ * which id a `multiple: true` select resolves to. The gap between those two blind
+ * spots is exactly where this bug lived.
+ */
+describe('the widget id the object form emits carries the right declaration (objectui#3986)', () => {
+  const labellingOf = (formType: string) =>
+    ComponentRegistry.getMeta(formType.replace(/^field:/, ''), 'field')?.labelling;
+
+  it('select + multiple resolves to a widget declared `group`', () => {
+    // Before the producer fix this resolved to `field:select`, whose declaration
+    // is (correctly) absent — so the host kept emitting a `for` at the chip row's
+    // wrapper `div`, and the visible label named nothing.
+    const formType = mapFieldTypeToFormType('select', { multiple: true });
+    expect(formType).toBe('field:multiselect');
+    expect(labellingOf(formType)).toBe('group');
+  });
+
+  it('a single-value select still resolves to an UNDECLARED widget', () => {
+    // The guard direction. `select`'s trigger is a labelable
+    // `button[role=combobox]`; declaring it `group` would strip a working `for`.
+    const formType = mapFieldTypeToFormType('select');
+    expect(formType).toBe('field:select');
+    expect(labellingOf(formType)).toBeUndefined();
   });
 });

--- a/packages/fields/src/field-type-alias.multiple.test.ts
+++ b/packages/fields/src/field-type-alias.multiple.test.ts
@@ -1,0 +1,81 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The widget id is a function of the (type, `multiple`) PAIR, not of the type
+ * string alone (objectui#3986).
+ *
+ * `mapFieldTypeToFormType` mapped `select` to `field:select` unconditionally,
+ * while `SelectField` delegated to `MultiSelectField` whenever the metadata said
+ * `multiple`. Three correct pieces, one gap between them: the component that
+ * RENDERED was `MultiSelectField`, but everything keyed on the widget id — above
+ * all the label-association declaration (`ComponentMeta.labelling`, resolved via
+ * `getMeta('select')`) — was still answering for the single-value combobox. The
+ * host label of a normal `{ type: 'select', multiple: true }` picklist therefore
+ * emitted a `for` at the chip row's wrapper `div`, where a `for` is inert.
+ *
+ * `select` cannot simply be declared `labelling: 'group'` instead: the
+ * single-value trigger IS labelable, and a bare `select` is a builtin the form
+ * renderer resolves without the registry at all (pinned in
+ * `form-group-label-association.test.ts`). The producer has to name the widget
+ * that renders, which is what this file pins.
+ *
+ * Metadata only — nothing renders here, so no widget module is loaded.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mapFieldTypeToFormType } from './field-type-alias';
+
+describe('select carries its arity in the widget id (objectui#3986)', () => {
+  it('maps select + multiple to the multi-value widget', () => {
+    // The one assertion that was `field:select` before this change.
+    expect(mapFieldTypeToFormType('select', { multiple: true })).toBe('field:multiselect');
+  });
+
+  it('keeps the single-value widget without multiple, and for multiple: false', () => {
+    // The guard direction: single-select must not move. Its trigger is a
+    // labelable `button[role=combobox]` and its `for` association works — taking
+    // that away would break a field that is fine to fix one that is not.
+    expect(mapFieldTypeToFormType('select')).toBe('field:select');
+    expect(mapFieldTypeToFormType('select', {})).toBe('field:select');
+    expect(mapFieldTypeToFormType('select', { multiple: false })).toBe('field:select');
+    expect(mapFieldTypeToFormType('select', { multiple: null })).toBe('field:select');
+  });
+
+  it('is idempotent for the type that is already inherently multi', () => {
+    // `multiselect` is a type in its own right; the arity override must not turn
+    // it into something else, whichever way the flag is set.
+    expect(mapFieldTypeToFormType('multiselect')).toBe('field:multiselect');
+    expect(mapFieldTypeToFormType('multiselect', { multiple: true })).toBe('field:multiselect');
+  });
+
+  /**
+   * The spec's multi-capable set is larger than the widget-moving set, and the
+   * difference is the whole reason this override is table-driven rather than a
+   * `config.multiple` branch sprinkled per type:
+   *
+   *   `MULTI_CAPABLE_TYPES` = select / lookup / file / image (+ `radio` on the
+   *   select branch, `user` storing like `lookup`)
+   *
+   * Every member except `select` renders BOTH arities inside one widget —
+   * `LookupField`, `FileField`, `ImageField` each read `multiple` themselves — so
+   * their widget id, and with it their `labelling` declaration, is correct for
+   * either arity. Moving them would point at widgets that do not exist.
+   */
+  const UNMOVED_MULTI_CAPABLE = ['lookup', 'master_detail', 'user', 'owner', 'file', 'image', 'radio'] as const;
+
+  it.each(UNMOVED_MULTI_CAPABLE)('%s resolves identically with and without multiple', (type) => {
+    expect(mapFieldTypeToFormType(type, { multiple: true })).toBe(mapFieldTypeToFormType(type));
+  });
+
+  it('does not invent a widget for an unknown type flagged multiple', () => {
+    // The fallback is unchanged: an unknown type is `field:text` at either arity,
+    // never `field:text-multiple`-anything.
+    expect(mapFieldTypeToFormType('something-unknown', { multiple: true })).toBe('field:text');
+  });
+});

--- a/packages/fields/src/field-type-alias.ts
+++ b/packages/fields/src/field-type-alias.ts
@@ -7,14 +7,62 @@
  */
 
 /**
+ * The slice of a field definition the widget decision reads beyond `type`.
+ *
+ * Structural (not the spec `Field`) for the same reason the spec's own
+ * `ValueShapeFieldDef` is: every caller — object-schema metadata, a spec
+ * `FormFieldSchema` override, an action param def — can pass its own trimmed
+ * shape verbatim. `multiple` is the only key read; nothing else here is
+ * consulted, so a caller that has the whole metadata object may hand it over
+ * as-is.
+ */
+export interface FieldTypeMappingConfig {
+  /** `FieldSchema.multiple` — the field holds zero-or-more values. */
+  multiple?: boolean | null;
+}
+
+/**
+ * Field types whose `multiple: true` form is a DIFFERENT registered widget,
+ * rather than the same widget in another mode (objectui#3986).
+ *
+ * `select` is the only member, and the narrowness is measured, not assumed. The
+ * spec's `MULTI_CAPABLE_TYPES` is larger — select / lookup / file / image, with
+ * `radio` on the select branch and `user` storing like `lookup` — but every
+ * other member renders both arities INSIDE one widget: `LookupField`,
+ * `FileField` and `ImageField` each branch on `multiple` themselves, so their
+ * registry id, and with it their `labelling` declaration, is the same either
+ * way. A `select` declared `multiple: true` renders `MultiSelectField` instead:
+ * a different component, whose labelled surface is a chip row's container that
+ * a `<label for>` cannot address (it must be named by IDREF, which is what
+ * `field:multiselect`'s `labelling: 'group'` declares — objectui#3975/#3961).
+ *
+ * So the widget id has to carry the arity. When it did not, the host label was
+ * associated by the declaration registered under `select` — a single-value
+ * combobox that was NOT rendering — and the visible label of a normal
+ * `{ type: 'select', multiple: true }` picklist named nothing at all. One place
+ * decides which widget renders, so the declaration and the render cannot
+ * disagree again.
+ */
+const MULTI_VALUE_FORM_TYPES: Record<string, string> = {
+  select: 'field:multiselect',
+};
+
+/**
  * Map field type to form component type
- * 
+ *
  * @param fieldType - The ObjectQL field type identifier to convert
  * (for example: `"text"`, `"number"`, `"date"`, `"lookup"`).
+ * @param config - The rest of the field definition, for the types whose widget
+ * identity depends on more than the type string. Only `multiple` is read; see
+ * {@link MULTI_VALUE_FORM_TYPES}. Omitting it maps the single-value form, which
+ * is what every non-multi-capable type resolves to anyway.
  * @returns The normalized form field type string used in the form schema
  * (for example: `"input"`, `"textarea"`, `"date-picker"`, `"select"`).
  */
-export function mapFieldTypeToFormType(fieldType: string): string {
+export function mapFieldTypeToFormType(
+  fieldType: string,
+  config?: FieldTypeMappingConfig,
+): string {
   const typeMap: Record<string, string> = {
     // Text-based fields
     text: 'field:text',
@@ -95,6 +143,14 @@ export function mapFieldTypeToFormType(fieldType: string): string {
     autonumber: 'field:auto_number',
     auto_number: 'field:auto_number',
   };
+
+  // The arity override comes FIRST and is table-driven: only a type listed in
+  // `MULTI_VALUE_FORM_TYPES` has a second widget to move to, so `multiple` on
+  // any other type (a multi `lookup`, a multi `file`) resolves exactly as
+  // before and keeps reaching the widget that handles both arities itself.
+  if (config?.multiple && MULTI_VALUE_FORM_TYPES[fieldType]) {
+    return MULTI_VALUE_FORM_TYPES[fieldType];
+  }
 
   return typeMap[fieldType] || 'field:text';
 }

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -21,11 +21,31 @@ import { useCascadingOptions } from './useCascadingOptions';
  *
  * A field declared `multiple: true` selects zero-or-more values (spec:
  * `multiple` is valid on `select`), so it renders the multi-value chip picker
- * — the same widget the `multiselect` type uses. Delegating here (rather than
- * only at a type-resolution layer) means every surface that renders the
- * `select` widget — the object form, the inline grid editor, and
- * `ActionParamDialog` — inherits multi-select identically, with no drift
- * between them. Single-value selects keep the cascading dropdown below.
+ * — the same widget the `multiselect` type uses. Single-value selects keep the
+ * cascading dropdown below.
+ *
+ * The FORM no longer arrives here with `multiple` (objectui#3986):
+ * `mapFieldTypeToFormType` now resolves a `select` + `multiple: true` field to
+ * `field:multiselect`, so the object-form path renders `MultiSelectField`
+ * directly under its own registry id — which is what carries the
+ * `labelling: 'group'` declaration the host label needs. Deciding the widget at
+ * the type-resolution layer is what keeps the declaration and the render from
+ * disagreeing; a delegation invisible to the resolver could not.
+ *
+ * The branch below stays because it is NOT dead — measured entrances that reach
+ * it with `multiple` set, none of which consult that resolver:
+ *
+ *  - **the inline grid editor** — `FieldEditWidget` looks `select` up in its own
+ *    `EDIT_WIDGETS` table, which SHORT-CIRCUITS before the alias map is
+ *    consulted, and forwards the whole metadata object as `field`;
+ *  - **`ActionParamDialog`** — `paramToField` resolves through
+ *    `resolveFormWidgetType`, which likewise returns `select` from
+ *    `fieldWidgetMap` before reaching the alias map, and carries
+ *    `multiple: param.multiple` on the field it builds;
+ *  - **hand-written SDUI** — a `{ type: 'field:select' }` node whose metadata
+ *    declares `multiple`, which addresses this widget by name.
+ *
+ * All three then inherit multi-select from here identically, with no drift.
  *
  * Both branches resolve per-option `visibleWhen` cascading / role-gating through
  * the shared {@link useCascadingOptions} hook (#2715), so single and multi stay

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -322,7 +322,8 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
       generated.push({
         name,
         label: fieldLabel(schema.objectName, name, field.label || name),
-        type: mapFieldTypeToFormType(field.type),
+        // (type, multiple) decides the widget (objectui#3986) — see `sectionFields`.
+        type: mapFieldTypeToFormType(field.type, { multiple: field.multiple }),
         required: field.required || false,
         disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
         placeholder: field.placeholder,

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -395,7 +395,8 @@ export const ModalForm: React.FC<ModalFormProps> = ({
       generated.push({
         name,
         label: fieldLabel(schema.objectName, name, field.label || name),
-        type: mapFieldTypeToFormType(field.type),
+        // (type, multiple) decides the widget (objectui#3986) — see `sectionFields`.
+        type: mapFieldTypeToFormType(field.type, { multiple: field.multiple }),
         required: field.required || false,
         disabled: schema.readOnly || schema.mode === 'view' || field.readonly,
         placeholder: field.placeholder,

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -564,7 +564,11 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
         const formField: FormField = {
           name: name,
           label: fieldLabel(schema.objectName, name, field.label || fieldName),
-          type: mapFieldTypeToFormType(field.type),
+          // (type, multiple) decides the widget, not the type alone: a `select`
+          // declared `multiple: true` renders the multi-value chip picker, whose
+          // label must be associated by IDREF — a fact declared per WIDGET, so
+          // the widget id has to carry the arity (objectui#3986).
+          type: mapFieldTypeToFormType(field.type, { multiple: field.multiple }),
           required: field.required || false,
           disabled: schema.readOnly || schema.mode === 'view' || field.readonly || managedBlanketLock,
           placeholder: field.placeholder,

--- a/packages/plugin-form/src/__tests__/selectMultipleGroupLabel.test.tsx
+++ b/packages/plugin-form/src/__tests__/selectMultipleGroupLabel.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * End-to-end: a `{ type: 'select', multiple: true }` field in a real object form
+ * is NAMED by its visible label (objectui#3986).
+ *
+ * Everything below is real — the real `ObjectForm` (the producer that emits the
+ * widget id), the real `mapFieldTypeToFormType`, the real form renderer in
+ * `@object-ui/components`, the real registry, and the real widgets from
+ * `@object-ui/fields`. Only the data source is stubbed. That is deliberate: the
+ * bug lived in the SEAM between four independently-correct pieces, so a unit test
+ * on any one of them stays green through it. Measured on the tree that already
+ * had #3975's fix live, one field per row:
+ *
+ * ```
+ * type: 'multiselect'                   → byRoleGroupNamed=1  role=group   ← #3975
+ * type: 'select', multiple: true        → for=…-form-item resolves to div
+ *                                         byRoleGroupNamed=0  byLabelText=0  ← #3986
+ * ```
+ *
+ * The mechanism: the producer keyed the widget id on the type string only, so it
+ * emitted `field:select`; `SelectField` then delegated to `MultiSelectField` on
+ * `config.multiple`. The component that rendered was the chip picker, but the
+ * label-association declaration the renderer consulted was the one registered
+ * under `select` — which must stay undeclared, because a single-value select's
+ * trigger is labelable and stripping its `for` would break a working field
+ * (pinned in `form-group-label-association.test.ts`: "a BUILTIN type ignores a
+ * registry declaration under the same name"). So the host emitted a `for` at the
+ * chip row's wrapper `div`, where `<label for>` is inert —
+ * `HTMLLabelElement.control` is `null`: a visible label, and no accessible name.
+ *
+ * `registerAllFields` registers each widget as a `React.lazy`, so the assertions
+ * sit behind a dynamic-import boundary — warmed at MODULE SCOPE, never in a
+ * `beforeAll` (AGENTS.md 测试纪律, objectui#3010). The `@object-ui/fields` barrel
+ * import below IS the warm-up: it statically re-exports `./widgets/SelectField`
+ * and `./widgets/MultiSelectField`, the very specifiers the lazy loaders use, so
+ * `React.lazy` resolves off the ESM cache instead of racing RTL's 1000ms budget
+ * against a cold Vite transform.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { registerAllFields, mapFieldTypeToFormType } from '@object-ui/fields';
+import type { ObjectFormSchema } from '@object-ui/types';
+import { ObjectForm } from '../ObjectForm';
+import { normalizeSectionField } from '../sectionFields';
+
+registerAllFields();
+
+const OPTIONS = [
+  { label: 'Alpha', value: 'a' },
+  { label: 'Beta', value: 'b' },
+];
+
+/**
+ * One object, three option fields — the subject, the already-fixed sibling, and
+ * the guard direction — so a change that "fixes" the first by breaking the third
+ * cannot pass.
+ */
+const objectSchema = {
+  name: 'crm_account',
+  label: 'Account',
+  fields: {
+    // The subject: spec-legal `multiple` on a `select` (#3986).
+    regions: { type: 'select', multiple: true, label: 'Regions', options: OPTIONS },
+    // The sibling that #3975 already fixed — a positive control for the whole
+    // group-labelling chain, on a DIFFERENT type.
+    tags: { type: 'multiselect', label: 'Tags', options: OPTIONS },
+    // The guard: a single-value select, whose `for`→trigger association works
+    // today and must survive untouched.
+    stage: { type: 'select', label: 'Stage', options: OPTIONS },
+  },
+};
+
+function makeDataSource(schema: object = objectSchema) {
+  return {
+    getObjectSchema: vi.fn().mockResolvedValue(schema),
+    findOne: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    find: vi.fn().mockResolvedValue([]),
+  } as any;
+}
+
+function renderObjectForm(fields?: string[]) {
+  return render(
+    <ObjectForm
+      schema={
+        {
+          type: 'object-form',
+          objectName: objectSchema.name,
+          mode: 'create',
+          ...(fields ? { fields } : {}),
+        } as ObjectFormSchema
+      }
+      dataSource={makeDataSource()}
+    />,
+  );
+}
+
+/** HTML's labelable elements — the only ones a `<label for>` can address. */
+const LABELABLE = new Set(['button', 'input', 'meter', 'output', 'progress', 'select', 'textarea']);
+
+/**
+ * Every `<label for=…>` in the document, with what it resolves to and whether that
+ * target can legally be labelled. This issue's shape is `resolves: true` +
+ * `labelable: false` — the association that looks fine in the markup and names
+ * nothing in the accessibility tree.
+ */
+function labelTargets(): Array<{ text: string; forId: string; resolves: boolean; labelable: boolean }> {
+  return Array.from(document.querySelectorAll('label'))
+    .map((el) => {
+      const forId = el.getAttribute('for') ?? '';
+      const target = forId ? document.getElementById(forId) : null;
+      return {
+        text: (el.textContent ?? '').trim(),
+        forId,
+        resolves: !!target,
+        labelable: !!target && LABELABLE.has(target.tagName.toLowerCase()),
+      };
+    })
+    .filter((l) => l.forId !== '');
+}
+
+/** The host label of `name`'s form item (not a widget's own sub-label). */
+const hostLabelOf = (name: string): HTMLLabelElement => {
+  const el = document.querySelector(`[data-field="${name}"] > label`);
+  if (!el) throw new Error(`no host label rendered for field "${name}"`);
+  return el as HTMLLabelElement;
+};
+
+describe('ObjectForm: select + multiple is labelled as a group (objectui#3986)', () => {
+  it('the visible label is the accessible name of the chip group', async () => {
+    renderObjectForm(['regions']);
+
+    // The assertion that was 0 before this fix and is 1 after — the issue's
+    // `byRoleGroupNamed` column, on the object-form path.
+    await waitFor(() => {
+      expect(screen.getAllByRole('group', { name: 'Regions' })).toHaveLength(1);
+    });
+    // The same association read from the other side. Queried as `getAllBy…`
+    // deliberately: `getAllByLabelText` de-duplicates into a Set, so a length
+    // assertion states "exactly one element is named this", which a `getBy…`
+    // would only state accidentally.
+    expect(screen.getAllByLabelText('Regions')).toEqual(screen.getAllByRole('group', { name: 'Regions' }));
+  });
+
+  it('the host label drops its `for` and publishes an id the widget points back at', async () => {
+    renderObjectForm(['regions']);
+
+    await screen.findByRole('group', { name: 'Regions' });
+
+    const label = hostLabelOf('regions');
+    // A `for` left in place beside the `aria-labelledby` would give one label two
+    // association channels, and the `for` one is the inert half.
+    expect(label).not.toHaveAttribute('for');
+    expect(label.id).not.toBe('');
+    // The IDREF is not dangling — `aria-labelledby` naming a missing id fails
+    // SILENTLY, which is indistinguishable from success in the markup.
+    const group = screen.getByRole('group', { name: 'Regions' });
+    expect(group).toHaveAttribute('aria-labelledby', label.id);
+    expect(document.getElementById(label.id)).toBe(label);
+  });
+
+  it('renders the SAME shape as the `multiselect` type it now shares an id with', async () => {
+    // #3975 fixed `multiselect`; this issue is the residual path to the same
+    // widget. Both must now be indistinguishable from the host's point of view —
+    // that equality is the whole point of deciding the widget at the producer.
+    renderObjectForm(['regions', 'tags']);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('group', { name: 'Regions' })).toHaveLength(1);
+    });
+    expect(screen.getAllByRole('group', { name: 'Tags' })).toHaveLength(1);
+    for (const name of ['regions', 'tags']) {
+      expect(hostLabelOf(name)).not.toHaveAttribute('for');
+      expect(hostLabelOf(name).id).not.toBe('');
+    }
+  });
+
+  it('leaves a single-value select `for`-labelled to its trigger button', async () => {
+    // The guard direction, and the reason `select` could not simply be declared
+    // `labelling: 'group'`: this association ALREADY works, on a labelable
+    // element, and taking it away would trade one broken field for another.
+    renderObjectForm(['stage']);
+
+    const trigger = await waitFor(() => {
+      const el = document.querySelector('[data-field="stage"] [role="combobox"]');
+      if (!el) throw new Error('no select trigger rendered for "stage"');
+      return el;
+    });
+
+    const label = hostLabelOf('stage');
+    expect(label).toHaveAttribute('for', trigger.getAttribute('id'));
+    expect(label.id).toBe('');
+    expect(screen.getAllByLabelText('Stage')).toEqual([trigger]);
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(screen.queryAllByRole('group', { name: 'Stage' })).toHaveLength(0);
+  });
+
+  it('all three in ONE form: no label is left with an inert or dangling `for`', async () => {
+    // The class-wide invariant this issue is an instance of. It can only be
+    // stated once the group labels stop emitting `for` at all: EVERY remaining
+    // `for` (the widgets' own sub-labels) must resolve to a real labelable
+    // control.
+    renderObjectForm();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('group', { name: 'Regions' })).toHaveLength(1);
+    });
+    expect(screen.getAllByRole('group', { name: 'Tags' })).toHaveLength(1);
+
+    const broken = labelTargets().filter((l) => !l.resolves || !l.labelable);
+    expect(broken).toEqual([]);
+  });
+});
+
+/**
+ * The producer decision itself, at the normalizer the sectioned form variants
+ * share (`sectionFields`). Both halves of the (type, `multiple`) pair are
+ * overridable at the VIEW level, and either one alone moves the widget — so the
+ * id is decided once, from the merged pair, not from `fd.type` in isolation.
+ */
+describe('normalizeSectionField decides the widget from the effective pair (objectui#3986)', () => {
+  const ctx = {
+    objectSchema,
+    objectName: objectSchema.name,
+    fieldLabel: (_obj: string, _name: string, fallback: string) => fallback || _name,
+  };
+
+  it('a string shorthand for a multi select resolves to the multi widget', () => {
+    expect(normalizeSectionField('regions', ctx).type).toBe('field:multiselect');
+  });
+
+  it('a spec field def naming a multi select resolves to the multi widget', () => {
+    expect(normalizeSectionField({ field: 'regions' }, ctx).type).toBe('field:multiselect');
+  });
+
+  it('a view that restates only `multiple: true` moves the widget too', () => {
+    // The second door onto the same defect: `multiple` is a spec FormField key,
+    // so a view can turn a single-value object field into a multi one without
+    // restating `type`. Resolving the id from `fd.type` before `multiple` had
+    // been merged would have left this on the single-value widget.
+    expect(normalizeSectionField({ field: 'stage', multiple: true }, ctx).type).toBe('field:multiselect');
+  });
+
+  it('a view that restates only `multiple: false` moves it BACK', () => {
+    // The inverse, which the same single computation buys: an object-level multi
+    // field narrowed by the view must land on the single-value widget, whose
+    // label association is the `for` one.
+    const f = normalizeSectionField({ field: 'regions', multiple: false }, ctx);
+    expect(f.type).toBe('field:select');
+    expect(f.multiple).toBe(false);
+  });
+
+  it('a view restating both keys agrees with the mapper', () => {
+    expect(normalizeSectionField({ field: 'stage', type: 'select', multiple: true }, ctx).type).toBe(
+      mapFieldTypeToFormType('select', { multiple: true }),
+    );
+  });
+
+  it('a single-value select is untouched', () => {
+    expect(normalizeSectionField({ field: 'stage' }, ctx).type).toBe('field:select');
+    expect(normalizeSectionField('stage', ctx).type).toBe('field:select');
+  });
+
+  it('a spec field naming nothing in the object schema keeps its fallback type', () => {
+    // `fromObjectSchema`'s `input` fallback, unchanged: with no type on either
+    // side there is nothing to decide, and `multiple` alone must not conjure a
+    // widget id.
+    const f = normalizeSectionField({ field: 'ghost', multiple: true }, ctx);
+    expect(f.type).toBe('input');
+    expect(f.multiple).toBe(true);
+  });
+});

--- a/packages/plugin-form/src/sectionFields.ts
+++ b/packages/plugin-form/src/sectionFields.ts
@@ -98,7 +98,11 @@ function fromObjectSchema(fieldName: string, ctx: SectionFieldsContext): FormFie
   return {
     name: fieldName,
     label: ctx.fieldLabel(ctx.objectName, fieldName, field.label || fieldName),
-    type: mapFieldTypeToFormType(field.type),
+    // The widget id is a function of the (type, multiple) PAIR, not of the type
+    // alone: a `select` declared `multiple: true` renders the multi-value chip
+    // picker, and the label-association declaration is keyed on the widget that
+    // actually renders (objectui#3986).
+    type: mapFieldTypeToFormType(field.type, { multiple: field.multiple }),
     required: field.required || false,
     disabled: ctx.readOnly || ctx.mode === 'view' || field.readonly,
     placeholder: field.placeholder,
@@ -145,7 +149,6 @@ export function normalizeSectionField(
   const fieldName = fd.field;
   const base = fromObjectSchema(fieldName, ctx) as any;
 
-  if (fd.type != null) base.type = mapFieldTypeToFormType(fd.type);
   if (fd.widget != null) base.widget = fd.widget;
   if (fd.label != null) base.label = fd.label;
   if (fd.placeholder != null) base.placeholder = fd.placeholder;
@@ -158,6 +161,19 @@ export function normalizeSectionField(
   if (fd.span != null) base.span = fd.span;
   if (fd.options != null) base.options = fd.options;
   if (fd.multiple != null) base.multiple = fd.multiple;
+  // The widget id is decided ONCE, here, from the EFFECTIVE (type, multiple)
+  // pair — because both halves are overridable at the view level and either one
+  // alone moves the widget (objectui#3986). A view restating only `multiple:
+  // true` over an object-schema `select` must land on the multi-value picker
+  // just as a view restating `type: 'select'` alongside it does; resolving from
+  // `fd.type` before `multiple` had been merged could see only one half.
+  //
+  // `rawType` is the PRE-alias spelling, kept because `base.type` is already the
+  // mapped id (`field:…`) and re-deciding from it would need an inverse mapping.
+  // Absent on both sides (a spec field naming nothing in the object schema and
+  // declaring no type) it stays untouched — `fromObjectSchema`'s `input`.
+  const rawType = fd.type ?? ctx.objectSchema?.fields?.[fieldName]?.type;
+  if (rawType != null) base.type = mapFieldTypeToFormType(rawType, { multiple: base.multiple });
   // Spec canon for the lookup target is `reference_to` (views.zod.ts); accept
   // both spellings and stamp both keys so dual-key readers see the override.
   const refOverride = fd.reference ?? fd.reference_to;


### PR DESCRIPTION
Fixes #3986

按 PM 已裁的 **A 案**实施:让**生产端**决定渲染哪个 widget —— `mapFieldTypeToFormType` 对 `select` + `multiple: true` 发 `field:multiselect`。一处决定 widget,声明(`ComponentMeta.labelling`)与渲染从此不可能错位。

## 机制回顾(三段各自正确,拼起来漏一格)

1. `mapFieldTypeToFormType` 只按 `type` 字符串映射,`select` 恒为 `field:select`,不看 `multiple`;
2. 对象表单据此发出 `field:select`,并把 `multiple` 随元数据带下去;
3. `SelectField` 见到 `config.multiple` 就委派给 `MultiSelectField`。

于是**渲染的**是 chip 行(`MultiSelectField`),但 label 关联的声明是按 `select` 这个键查的 —— 而 `select` 必须保持未声明(单选 trigger 是 `button[role=combobox]`,可 label;裸 `select` 还是内建分支,压根不查注册表)。host 照旧发 `for` 指向 chip 行的包裹 `div`,`label[for]` 指向不可 label 元素是惰性的(`HTMLLabelElement.control` 返回 `null`):视觉上有标签,可及性树里这个标签什么都没命名。

## 波及面测量表(改之前逐个量,正文点名的三项)

### ① 两个集合的匹配逻辑

| 集合 | 位置 | 比对方式 | `field:select` → `field:multiselect` | 结论 |
|---|---|---|---|---|
| `CASCADE_OPTION_FIELD_TYPES` | `components/renderers/form/form.tsx:250` | 先过 `normalizeFieldType`(剥 `field:` 前缀)再查集合 | 集合 = {`select`, `radio`, `multiselect`, `checkboxes`} —— **两个拼写都是成员** | **语义不变**;`dependentValues` / `emptyHint` 照旧注入 |
| `DATA_SOURCE_FIELD_TYPES` | `form.tsx:233` | 同上,normalize 后查 | 集合 = {`lookup`, `master_detail`, `tree`, `object-ref`, `filter-condition`, `recipient-picker`} —— **两个拼写都不是成员** | **语义不变**;两者都不拿 `dataSource` |

### ② 一切按 `field:select` 字符串判断的调用点(全仓 grep,逐点)

| 判断点 | 位置 | 结论 |
|---|---|---|
| `BUILTIN_FIELD_TYPES` | `form.tsx:232` | 含**裸名** `select`,且刻意按 RAW type 比对;两个带前缀拼写都不命中 → **不变**(裸 `select` 走内建分支的行为零触碰) |
| `resolveFieldLabelling` | `form.tsx:348` | **这就是修复生效处**:`field:multiselect` → normalize → `multiselect` → `labelling: 'group'` → host 改发 IDREF |
| 级联清值 effect | `form.tsx:944` | 比的是 **RAW** type(`f.widget` 或 `f.type`),未 normalize;`field:select` 与 `field:multiselect` **同样**都落不进去 → **不变**(既有缺陷,与本单无关,见文末「超范围发现」) |
| `PROTOCOL_COMPONENTS` | `renderers/placeholders.tsx:64` | `field:select` 与 `field:multiselect` **都已在列** → 不变 |
| `resolveActionParams.ts:37` 等 | app-shell | 全是**注释**里的引用,无逻辑 → 不变 |

消费半径核验:全仓 grep 确认 `mapFieldTypeToFormType` 的**非注释**引用只在 `packages/fields`(自身 2 处)与 `packages/plugin-form`(4 处);components / app-shell 里的命中全是注释。

### ③ 每个调用点是否拿得到 `multiple`

| 调用点 | 拿得到? | 处置 |
|---|---|---|
| `sectionFields.ts:101`(`fromObjectSchema`) | ✅ `field.multiple`(整份对象元数据在作用域内) | 传 pair |
| `sectionFields.ts:148`(spec 覆盖分支) | ✅ `fd.multiple` 与 `base.multiple` 都在 | 合并完覆盖后**一次性**定 id(见下) |
| `ObjectForm.tsx:567` | ✅ `field.multiple` | 传 pair |
| `DrawerForm.tsx:325` | ✅ `field.multiple` | 传 pair |
| `ModalForm.tsx:398` | ✅ `field.multiple` | 传 pair |
| `fields/src/index.tsx:2160`(`resolveFormWidgetType`) | ❌ 只有 type 字符串 —— **但** `fieldWidgetMap['select']` 命中即早退,`select` **永不到达**映射器 | 结构上不受影响,**零改动** |
| `fields/src/FieldEditWidget.tsx:145`(`resolveInlineEditType`) | ❌ 同上 —— `'select' in EDIT_WIDGETS` 早退,`select` 永不到达映射器 | 结构上不受影响,**零改动** |

**没有任何调用点结构上被卡住**(两个只有 type 字符串的调用点都在 `select` 到达映射器之前早退,且它们本就不传第二参数,行为可证不变),因此按 A 案继续,未升级为契约面裁决。

## 实施

- `mapFieldTypeToFormType(fieldType, config?)` 增可选第二参(结构化,只读 `multiple`,仿 spec 自己的 `ValueShapeFieldDef` 写法),**所有既有单参调用保持有效**。
- override 走**表**(`MULTI_VALUE_FORM_TYPES`)而非散落的 `if`,且 `select` 是唯一成员 —— 这一点是量出来的:spec 的 `MULTI_CAPABLE_TYPES` 更大(select / lookup / file / image,`radio` 挂在 select 分支、`user` 与 `lookup` 同存储),但 `LookupField` / `FileField` / `ImageField` 各自**在同一个 widget 内**分支处理 `multiple`,widget id(以及随之的 labelling 声明)对两种 arity 都已正确。只有 `select` 的多值形态是**另一个组件**。
- `sectionFields` 的 spec 覆盖分支:id 改为在所有覆盖合并**之后一次性**从**有效 pair** 算出。因为 `multiple` 本身就是 spec FormField 键 —— 视图只重述 `multiple: true`(不重述 `type`)也必须把 widget 移过去,`multiple: false` 也必须移回来。这是同一缺陷的第二道门。

## 死码处置:`SelectField` 的委派分支 —— **保留**,并注明

量完确认它**不是**死码。三个入口仍会带着 `multiple` 走到它,且都**不经过**类型解析层:

| 入口 | 为什么绕过映射器 |
|---|---|
| 内联表格编辑器 | `FieldEditWidget` 先在自己的 `EDIT_WIDGETS` 表里查到 `select` 就早退,并把整份元数据作为 `field` 转发 |
| `ActionParamDialog` | `paramToField` 经 `resolveFormWidgetType`,同样先从 `fieldWidgetMap` 拿到 `select` 就早退,并带上 `multiple: param.multiple` |
| 手写 SDUI | 直接点名 `{ type: 'field:select' }` 且元数据声明 `multiple` |

所以按仓内语义**保留**,并把 doc comment 里「对象表单也走这里」的**已过期**说法改成上表(原注释声称覆盖 the object form —— 本 PR 之后不再成立,不留给下一个读者踩)。

## 反向验证(先预判,再跑变异,未提交)

变异 = 删掉映射器里的 arity override(调用点照旧传 pair),即精确撤掉构成修复的那一处逻辑。

预判方向 —— 普通 **Red**,不属于「更多诊断」或「倒置」两族:此前这条栈从未产出规范 id,`field:multiselect` 的 group 声明**压根没被查过**,所以修复前是规则**未施加**、修复后才施加。

实测与预判一致:**9 红,方向逐条对上**

- 复现钉(对象表单 `Regions` 的 `byRoleGroupNamed`)红、映射钉红、声明接合钉红、`normalizeSectionField` 的多值三例红;
- 守方向对照**全绿**:单选 `select` 的 `for` → trigger 关联、`multiple: false` 回落单值、`select-label-association-e2e`(两条 select 路径)、`composite-group-label-e2e`(含 #3975 的 `multiselect`)、以及 components 的「a BUILTIN type ignores a registry declaration under the same name」。

映射钉的实际输出:

```
AssertionError: expected 'field:select' to be 'field:multiselect' // Object.is equality
Expected: "field:multiselect"
Received: "field:select"
```

## 测试

- `packages/fields/src/field-type-alias.multiple.test.ts`(新)—— 映射钉:两个方向 + 幂等 + spec 多值可用但**不移动** widget 的 6 个类型 + 未知类型兜底。
- `packages/fields/src/__tests__/group-labelling-declaration.test.ts` —— 加**接合钉**:生产端发出的 id 必须携带正确声明。这条只能放在两者之间 —— 映射器的测试不知道自己返回的 id 带什么 `labelling`,声明测试不知道多值 select 解析到哪个 id,缺陷就活在两个盲区之间。
- `packages/plugin-form/src/__tests__/selectMultipleGroupLabel.test.tsx`(新)—— 真 `ObjectForm` + 真表单渲染器 + 真注册表 + 真 widget 的复现钉,只 stub dataSource;含守方向单选对照与「一张表里三个字段、没有任何 label 留着惰性/悬空 `for`」的类不变式;另含 `normalizeSectionField` 的有效-pair 单元钉。
- 选择器纪律:label 关联用 DOM 查询实际元素并核对 id 引用(`aria-labelledby` 反查回 label 元素、检查 IDREF 不悬空);`getAllByLabelText` 因 Set 去重,断言长度而不用 `getBy` 顺带成立;`labelable` 白名单区分「resolves 但不可 label」这一本单特有形态。

`registerAllFields` 的 `React.lazy` 边界按 AGENTS.md 测试纪律在**模块作用域**预热(barrel 静态 re-export 即 warm-up),不放 `beforeAll`。

## 验证命令与结果

- `pnpm exec vitest run packages/fields packages/plugin-form --maxWorkers=2` → **112 files / 1523 tests passed**
- 外围消费面抽查(components 表单渲染器全目录 + 其余带 select+multiple fixture 的文件)→ **37 files / 270 tests passed**
- 仓根 `pnpm exec turbo run type-check --concurrency=2` → **78/78 successful**
- `node scripts/check-control-bytes.mjs` → OK(3912 文件);另按 `[\x00-\x08\x0b\x0c\x0e-\x1f]` 自扫本 PR 全部改动文件,无命中

## 面切割

- 只读分支(MultiSelectField 及各 widget)属 #4005 —— **本 PR 零触碰**。
- 内建 `Select` 路径(#3976 已修)—— 零触碰,并有对照钉守住。
- `content/docs/releases/**` —— 未触碰;user-visible 变更走 changeset(`@object-ui/fields` + `@object-ui/plugin-form`,patch)。

## 超范围发现(仅报告,未在本 PR 修)

1. **级联清值 effect 对对象表单路径整体落空** —— `form.tsx:944` 的 `resolvedType` 取的是 RAW type(`f.widget` 或 `f.type`),与集合里的**裸名**比对;对象表单发的是带前缀 id,于是任何来自对象 schema 的选项字段都进不了这个 effect,选项集收窄后旧值不会被清掉。与 #3231 同族:同文件 `:1514` 的 `isOptionField` 已经改用 `normalizeFieldType` 修过一次,这一处漏了。本 PR 前后**同样**都落不进去,故语义不变。
2. **`RadioField` 完全不读 `multiple`** —— spec 的 `MULTI_CAPABLE_TYPES` 把 `radio` 挂在 select 分支(即 `multiple` 对 `radio` 合法),但 widget 里没有任何 `multiple` 分支,`{ type: 'radio', multiple: true }` 会静默渲染成单值 radio 组。观察类:`radio` 本身已声明 `labelling: 'group'`,不存在本单这条 a11y 洞。


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTRjn8xBqp75dk7kFupVRt)_