### PR TITLE
fix(app-shell): stop authoring the retired `rowLevelSecurity[].priority` key in the Studio RLS editor (objectstack#7130)

### DIFF
--- a/.changeset/permission-facets-rls-priority-retired-7130.md
+++ b/.changeset/permission-facets-rls-priority-retired-7130.md
@@ -1,0 +1,39 @@
+---
+"@object-ui/app-shell": patch
+---
+
+The Studio RLS editor no longer authors the retired `rowLevelSecurity[].priority` key (objectstack#7130)
+
+`rowLevelSecurity[].priority` was removed in `@objectstack/spec` 17.0.0
+(objectstack#3896) and left as a `retiredKey` tombstone in
+`packages/spec/src/security/rls.zod.ts` — an authored value is REJECTED at parse
+time with the upgrade prescription, not ignored. It promised "conflict
+resolution" that cannot exist: applicable policies OR-combine (most permissive
+wins), so there is no conflict to order.
+
+`PermissionAdvancedFacets` — the structured RLS editor on the Studio permission
+matrix — was still typing the key and seeding `priority: 0` on every policy its
+"Add policy" button created. Its docblock described the shapes as mirroring the
+framework spec, but that mirror was sampled before the removal. Nothing on the
+save path removed the key: `doSave` sends the draft verbatim, and at package
+scope `mergePermissionSlice` copies `rowLevelSecurity` from the freshly-read
+base while taking only `objects`/`fields` from the edit — so at environment
+scope (the only scope where these facets are persisted) the seeded key went
+straight into the saved permission set. A user who added an RLS policy through
+the editor therefore wrote a permission set the parser refuses.
+
+Three changes, all editor-side:
+
+- the local `RlsPolicy` shape drops `priority`;
+- the Add-policy seed drops `priority: 0` — it now authors exactly
+  `{name,object,operation,using,enabled}`;
+- policies are stripped of the retired key as they are read out of the draft, so
+  a permission set already carrying `priority` (written by this editor before
+  this fix) comes out clean the moment any RLS edit re-emits the list. This is
+  editor hygiene, not a data migration: a set nobody opens is untouched, and the
+  strip is keyed to the named tombstone rather than being a blanket unknown-key
+  purge, so every live key the editor does not itself render survives a
+  round-trip.
+
+The docblock stops claiming the shapes are "sampled from live data" — that
+sampling is exactly how a removed key stayed in the editor for ten days.

--- a/packages/app-shell/src/views/metadata-admin/PermissionAdvancedFacets.retiredKeys.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionAdvancedFacets.retiredKeys.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Pins that the RLS facet never authors `rowLevelSecurity[].priority`
+ * (objectstack#7130).
+ *
+ * The key is a `retiredKey` tombstone in `@objectstack/spec` 17.0.0
+ * (`packages/spec/src/security/rls.zod.ts` — removed by objectstack#3896):
+ * an authored value is REJECTED at parse time with the upgrade prescription,
+ * not ignored. This editor used to seed `priority: 0` on every policy its Add
+ * button created, so every permission set saved after touching the structured
+ * RLS editor carried a parse-rejected key.
+ *
+ * Two directions are pinned, because the seed is only half of it:
+ *  - the Add-policy seed's key set, so the key cannot quietly return;
+ *  - an edit-and-save round-trip of an ALREADY-poisoned stored policy, which
+ *    every write path spreads (`{ ...pol, name }`) and would otherwise carry
+ *    the key back out verbatim.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PermissionAdvancedFacets } from './PermissionAdvancedFacets';
+
+afterEach(cleanup);
+
+const t = (k: string) => k;
+
+type Draft = Record<string, unknown>;
+
+/**
+ * Render the facets with a `setDraft` spy, and expose the drafts the component
+ * asked for — the updater is applied to the draft it was rendered with, which
+ * is what the host's whole-record Save would then persist.
+ */
+function renderFacets(draft: Draft) {
+  const drafts: Draft[] = [];
+  const setDraft = vi.fn((updater: (prev: Draft) => Draft) => {
+    drafts.push(updater(draft));
+  });
+  const props = {
+    draft,
+    setDraft,
+    writable: true,
+    allSetNames: [] as string[],
+    t,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render(<PermissionAdvancedFacets {...(props as any)} />);
+  const policiesAfter = () => {
+    const last = drafts[drafts.length - 1];
+    return (last?.rowLevelSecurity ?? []) as Array<Record<string, unknown>>;
+  };
+  return { drafts, policiesAfter };
+}
+
+/** The RLS facet is collapsed by default — expand it to mount the editors. */
+async function openRls(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText('perm.rls.title'));
+}
+
+describe('PermissionAdvancedFacets · RLS retired-key hygiene (objectstack#7130)', () => {
+  it('the Add-policy seed authors exactly the live spec keys — no `priority`', async () => {
+    const user = userEvent.setup();
+    const { policiesAfter } = renderFacets({ rowLevelSecurity: [] });
+    await openRls(user);
+    await user.click(screen.getByRole('button', { name: /perm\.rls\.add/ }));
+
+    const policies = policiesAfter();
+    expect(policies).toHaveLength(1);
+    // Key SET, not just the absence of `priority`: a pin on the whole seed is
+    // what stops a retired key drifting back in beside a live one.
+    expect(Object.keys(policies[0]).sort()).toEqual(
+      ['enabled', 'name', 'object', 'operation', 'using'].sort(),
+    );
+    expect('priority' in policies[0]).toBe(false);
+  });
+
+  it('an edit-and-save round-trip of a stored policy carrying `priority` comes out clean', async () => {
+    const user = userEvent.setup();
+    const { policiesAfter } = renderFacets({
+      // What this editor itself wrote before objectstack#7130.
+      rowLevelSecurity: [
+        {
+          name: 'p1',
+          object: 'account',
+          operation: 'all',
+          using: 'owner_id == current_user.id',
+          check: 'owner_id == current_user.id',
+          enabled: true,
+          priority: 0,
+        },
+      ],
+    });
+    await openRls(user);
+    // Any edit re-emits the whole policy list; the name field is the cheapest.
+    await user.type(screen.getByPlaceholderText('perm.rls.name'), 'x');
+
+    const policies = policiesAfter();
+    expect(policies).toHaveLength(1);
+    expect('priority' in policies[0]).toBe(false);
+    // Falsification: the strip is keyed to the tombstone, not a blanket
+    // unknown-key purge — every live key the editor does not render survives.
+    expect(policies[0].check).toBe('owner_id == current_user.id');
+    expect(policies[0].using).toBe('owner_id == current_user.id');
+    expect(policies[0].enabled).toBe(true);
+    expect(policies[0].name).toBe('p1x');
+  });
+
+  it('a policy the editor never touches is still emitted without `priority` once any policy is edited', async () => {
+    const user = userEvent.setup();
+    const { policiesAfter } = renderFacets({
+      rowLevelSecurity: [
+        { name: 'p1', object: 'account', operation: 'all', using: 'true', enabled: true, priority: 0 },
+        { name: 'p2', object: 'contact', operation: 'select', using: 'true', enabled: true, priority: 5 },
+      ],
+    });
+    await openRls(user);
+    // Adding a policy re-emits the existing ones alongside the new seed.
+    await user.click(screen.getByRole('button', { name: /perm\.rls\.add/ }));
+
+    const policies = policiesAfter();
+    expect(policies).toHaveLength(3);
+    expect(policies.some((p) => 'priority' in p)).toBe(false);
+    expect(policies.map((p) => p.name)).toEqual(['p1', 'p2', '']);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/PermissionAdvancedFacets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionAdvancedFacets.tsx
@@ -33,10 +33,12 @@ import type { CelLintIssue } from './celAuthoring';
  * in Setup (PermissionFacetLink, P1). Each editor reads/writes the draft's
  * parsed camelCase field (`rowLevelSecurity` / `tabPermissions` / `adminScope`)
  * — tolerating a JSON string on load so legacy rows survive — and is persisted
- * by the editor's existing whole-record Save. Shapes mirror the framework spec
- * (sampled from live data): RLS policies `{name,object,operation,using,check,
- * enabled,priority}`; admin scope `{businessUnit,includeSubtree,manage*,
- * authorEnvironmentSets,assignablePermissionSets[]}`.
+ * by the editor's existing whole-record Save. The shapes below are the subset
+ * of the framework spec this editor authors, checked against the spec schemas
+ * rather than sampled from live data (objectstack#7130): RLS policies
+ * `{name,object,operation,using,check,enabled}`; admin scope
+ * `{businessUnit,includeSubtree,manage*,authorEnvironmentSets,
+ * assignablePermissionSets[]}`.
  */
 
 interface RlsPolicy {
@@ -46,7 +48,35 @@ interface RlsPolicy {
   using?: string;
   check?: string;
   enabled?: boolean;
-  priority?: number;
+}
+
+/**
+ * Keys this editor must never author onto an RLS policy, because the framework
+ * spec REJECTS them at parse time.
+ *
+ * `rowLevelSecurity[].priority` was removed in `@objectstack/spec` 17.0.0
+ * (objectstack#3896) and left as a `retiredKey` tombstone
+ * (`packages/spec/src/security/rls.zod.ts`): an authored value is refused with
+ * the upgrade prescription rather than ignored. Applicable policies OR-combine
+ * (most permissive wins), so the "conflict resolution" it promised cannot
+ * exist and there is nothing to preserve.
+ *
+ * Until objectstack#7130 this editor seeded `priority: 0` on every policy its
+ * Add button created, so drafts it wrote can still carry the key. `policies`
+ * below is the single value every write path spreads from, so stripping on
+ * load — not a data migration — is what makes an edit-and-save round-trip of
+ * such a policy come out parseable.
+ */
+const RETIRED_RLS_KEYS = ['priority'] as const;
+
+/** Drop {@link RETIRED_RLS_KEYS} from a policy read out of the draft. */
+function stripRetiredRlsKeys(policy: RlsPolicy): RlsPolicy {
+  if (!policy || typeof policy !== 'object') return policy;
+  const present = RETIRED_RLS_KEYS.filter((k) => k in policy);
+  if (present.length === 0) return policy;
+  const next: Record<string, unknown> = { ...policy };
+  for (const k of present) delete next[k];
+  return next as RlsPolicy;
 }
 
 interface AdminScope {
@@ -158,7 +188,10 @@ export function PermissionAdvancedFacets({
   onCelErrorsChange,
   t,
 }: PermissionAdvancedFacetsProps) {
-  const policies = React.useMemo<RlsPolicy[]>(() => asArray(draft.rowLevelSecurity), [draft.rowLevelSecurity]);
+  const policies = React.useMemo<RlsPolicy[]>(
+    () => asArray<RlsPolicy>(draft.rowLevelSecurity).map(stripRetiredRlsKeys),
+    [draft.rowLevelSecurity],
+  );
   const scope = React.useMemo<AdminScope>(() => asObject(draft.adminScope), [draft.adminScope]);
   const tabs = React.useMemo<TabPerms>(() => asObject(draft.tabPermissions), [draft.tabPermissions]);
 
@@ -365,7 +398,7 @@ export function PermissionAdvancedFacets({
               onClick={() =>
                 setPolicies([
                   ...policies,
-                  { name: '', object: '*', operation: 'all', using: '', enabled: true, priority: 0 },
+                  { name: '', object: '*', operation: 'all', using: '', enabled: true },
                 ])
               }
             >


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7130

`rowLevelSecurity[].priority` was removed in `@objectstack/spec` 17.0.0 (objectstack#3896) and left as a `retiredKey` tombstone, so an authored value is **rejected at parse time** with the upgrade prescription rather than ignored. The Studio structured RLS editor was still authoring it: `PermissionAdvancedFacets` typed the key and seeded `priority: 0` on every policy its "Add policy" button created. Per the objectstack#7130 ruling, only the objectui producer changes here — the spec/ledger side is already executed and correct, and no objectstack file is touched.

## Premise re-verified at objectui `origin/main` @ `11c1e71e8`

The card's three sites are all present, unchanged (the file's last touch is #3779, long merged):

- `:38` docblock — "Shapes mirror the framework spec (sampled from live data): RLS policies `{name,object,operation,using,check,enabled,priority}`"
- `:49` — `priority?: number;` on the local `RlsPolicy` interface
- `:368` — `{ name: '', object: '*', operation: 'all', using: '', enabled: true, priority: 0 }`

Zero-hit census re-run and falsified in both directions: `grep -n priority` on the file yields exactly those three lines; the known-present neighbour `enabled` yields 6 hits on the same file, and `grep -n prior` adds nothing (no cross-line concatenation hiding a fourth site). Repo-wide, every other `priority` in objectui belongs to a **live** key on a different surface (validation rules, hooks, kanban) — no other file types or produces an RLS policy shape.

Spec side re-read at objectstack `origin/main`: `packages/spec/src/security/rls.zod.ts:432` is the `retiredKey(...)` call, and `:219` records the deliberate exclusion of `priority` from the alias suggestion pool.

## The unmeasured half the filer flagged: there is NO save-path scrub

Measured end to end; the answer is that nothing strips the key.

- `PermissionAdvancedFacets.tsx:161` loads policies with `asArray(draft.rowLevelSecurity)` — verbatim, no normalization.
- Every field edit spreads the loaded policy (`next[i] = { ...pol, name: e.target.value }`), so a stored `priority` is **carried back out verbatim** on any edit.
- `PermissionMatrixEditor.tsx:546` `doSave` sends `payload` (the draft) straight to `client.save`; the only transform is package scope's `mergePermissionSlice`.
- `permission-slice.ts:94` `mergePermissionSlice` returns `{ ...base, name, label, isDefault, objects, fields }` — it takes only `objects`/`fields` from the edit and copies `rowLevelSecurity` from the freshly-read base.

So at **environment scope** — the only scope where these facets are persisted (the docblock and `PermissionMatrixEditor.tsx:754` both say "persisted by the whole-record Save at env scope") — the seeded `priority: 0` goes into the saved permission set unmodified. The severity in the card stands as filed: this is a live producer of a parse-rejected key, not a seeded-then-scrubbed field.

Round-trip behaviour of an **already-poisoned** stored policy, before this PR: loaded verbatim, spread verbatim on every edit, re-persisted verbatim — the poison stays alive indefinitely.

## The fix (editor-side only, no data migration)

1. `priority` dropped from the local `RlsPolicy` interface.
2. `priority: 0` dropped from the Add-policy seed — it now authors exactly `{name,object,operation,using,enabled}`.
3. Retired keys are stripped as policies are read out of the draft (`RETIRED_RLS_KEYS` + `stripRetiredRlsKeys`). `policies` is the single value every write path spreads from, so an edit-and-save round-trip of a policy already carrying the key now comes out clean — which is what the dispatch ruling asked for. This is deliberately **not** a migration: a set nobody opens is untouched, nothing rewrites the draft on mount (that would fake an unsaved-changes state on open), and the strip is keyed to the named tombstone rather than being a blanket unknown-key purge, so live keys the editor does not itself render (e.g. `positions`, `tags`) survive a round-trip.
4. The docblock stops claiming the shapes are "sampled from live data" — that sampling is precisely how a removed key stayed in the editor.

## Verification

Build closure first (fresh worktree), then the targeted gates:

```
pnpm --filter '@object-ui/app-shell^...' build              # green
pnpm --filter '@object-ui/app-shell' type-check             # tsc --noEmit + typetests, green
pnpm --filter '@object-ui/app-shell' lint                   # 0 errors
node scripts/check-control-bytes.mjs                        # OK (3923 files)
pnpm exec vitest run packages/app-shell/src/views/metadata-admin/PermissionAdvancedFacets.retiredKeys.test.tsx \
                     packages/app-shell/src/views/metadata-admin/PermissionAdvancedFacets.cel.test.tsx
  -> Test Files  2 passed (2) / Tests  5 passed (5)
```

`eslint` on the two touched files reports 0 errors and 3 warnings, all on pre-existing lines (`:164` props `any`, `:233` set-state-in-effect).

### Reverse verification — direction predicted, then measured

Prediction: restoring the pre-fix component should turn **all three** new pins red — the seed pin because the key set gains a member, the two round-trip pins because the strip is gone. Took the fix out with `git checkout origin/main -- PermissionAdvancedFacets.tsx` (never `git stash`), re-ran the new file, then reapplied from a patch:

```
 × the Add-policy seed authors exactly the live spec keys — no `priority`
 × an edit-and-save round-trip of a stored policy carrying `priority` comes out clean
 × a policy the editor never touches is still emitted without `priority` once any policy is edited
AssertionError: expected [ 'enabled', 'name', 'object', ...(3) ] to deeply equal [ 'enabled', 'name', 'object', ...(2) ]
AssertionError: expected true to be false
Test Files  1 failed (1) / Tests  3 failed (3)
```

Red in the predicted direction, on all three. The third pin also carries a falsification assertion in the positive direction (`check` / `using` / `enabled` survive the strip), so the pins cannot pass by emitting nothing.

## Scope

No objectstack edits. No data migration. Disjoint from objectstack#7129 (`packages/plugin-dashboard`); at PR time the only other open objectui PR is the release PR #3598, and nothing in flight touches this file.


---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_