### PR TITLE
fix(plugin-dashboard): stop authoring the retired widget-level actionUrl key (objectstack#7129)

### DIFF
--- a/.changeset/widget-config-panel-retired-action-keys-os7129.md
+++ b/.changeset/widget-config-panel-retired-action-keys-os7129.md
@@ -1,0 +1,40 @@
+---
+"@object-ui/plugin-dashboard": patch
+"@object-ui/types": patch
+---
+
+Studio's widget config panel no longer authors the retired `actionUrl` widget key
+
+`actionUrl` / `actionType` / `actionIcon` were retired at the WIDGET level in
+`@objectstack/spec` 17.0.0-rc.3 (objectstack#5010, ADR-0049 D2). They are
+`retiredKey` tombstones: `DashboardWidgetSchema` types them `never` and refuses
+any value, so authoring one is a tsc error and a parse error. Two producers in
+`plugin-dashboard` were still emitting the widget-level key anyway
+(objectstack#7129):
+
+- `WidgetConfigPanel` offered a Behavior-group field labelled "Click-through
+  URL", bound to `actionUrl`. That control was inert twice over: no dashboard
+  widget renderer has ever read `widget.actionUrl`, so a URL typed there never
+  navigated anywhere, and the value it wrote was refused by the spec.
+- `DashboardWithConfig` seeded `actionUrl: widget.actionUrl ?? ''` into every
+  widget config handed to the panel. Because the ADR-0021 save scrub only knew
+  the dataset-shape keys, that seed rode through to `onWidgetSave` on EVERY
+  save — so a Studio author who merely renamed a widget still persisted
+  `actionUrl: ''` into stored metadata, a key the spec then refuses. This is
+  the wider half of the defect: it did not require anyone to use the field.
+
+The Behavior group and the seed are both gone, and `sanitizeDraftForType` now
+scrubs all three keys as a second line of defence, for stored widgets that
+already carry them and for hosts that drive `WidgetConfigPanel` directly.
+
+Behaviour change surface: the widget config panel loses its Behavior section
+(that section contained only this one field). Nothing that rendered before stops
+rendering — the field had no consumer. `header.actions[]` keeps its own,
+unrelated and still-live `actionUrl`; only the widget-level key is a tombstone.
+
+Also corrects the `DashboardWidgetSchema` docblock in `@object-ui/types`, which
+listed the three retired keys among those that "flow in from the spec" next to
+live keys like `colorVariant`. They do flow in — as `?: never`. The docblock now
+says so, and notes that while authoring one is a tsc error, *reading* one still
+type-checks (`never | undefined`), which is exactly how these producers survived
+the 2026-08-04 sweep that removed the renderer-side reads.

--- a/packages/plugin-dashboard/src/DashboardWithConfig.tsx
+++ b/packages/plugin-dashboard/src/DashboardWithConfig.tsx
@@ -111,7 +111,12 @@ export function DashboardWithConfig({
       dimensions: Array.isArray(w.dimensions) ? w.dimensions : [],
       values: Array.isArray(w.values) ? w.values : [],
       colorVariant: widget.colorVariant ?? 'default',
-      actionUrl: widget.actionUrl ?? '',
+      // No `actionUrl` / `actionType` / `actionIcon`: retired at the widget
+      // level in @objectstack/spec 17.0.0-rc.3 (objectstack#5010, ADR-0049 D2)
+      // and now `retiredKey` tombstones the spec refuses. Seeding
+      // `actionUrl: widget.actionUrl ?? ''` here meant EVERY save from the
+      // widget panel emitted `actionUrl: ''` — a parse error — even when the
+      // author never opened the Behavior group (objectstack#7129).
       layoutW: widget.layout?.w ?? 1,
       layoutH: widget.layout?.h ?? 1,
     };

--- a/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
+++ b/packages/plugin-dashboard/src/WidgetConfigPanel.tsx
@@ -380,21 +380,18 @@ function buildWidgetSchema(
         ],
       },
 
-      // ----- Behavior (always visible, collapsed by default) -------------
-      {
-        key: 'behavior',
-        title: 'Behavior',
-        collapsible: true,
-        defaultCollapsed: true,
-        fields: [
-          {
-            key: 'actionUrl',
-            label: 'Click-through URL',
-            type: 'input',
-            placeholder: 'https://...',
-          },
-        ],
-      },
+      // ----- Behavior --------------------------------------------------
+      // Deliberately absent. The group held exactly one field, a
+      // "Click-through URL" bound to `actionUrl` — a widget-level key the spec
+      // RETIRED in @objectstack/spec 17.0.0-rc.3 (objectstack#5010, ADR-0049
+      // D2) alongside `actionType` / `actionIcon`. All three are `retiredKey`
+      // tombstones: `DashboardWidgetSchema` types them `never` and refuses any
+      // value, so the field was authoring a parse error into stored metadata
+      // (objectstack#7129). It was also inert on the render side — no dashboard
+      // widget renderer ever read `widget.actionUrl`; every action the
+      // dashboard dispatches comes from `header.actions[]`, which keeps its own
+      // (live, string-typed) `actionUrl`. Do not reintroduce it here: pinned by
+      // `__tests__/WidgetConfigPanel.retiredActionKeys.test.tsx`.
 
       // ----- Appearance (always visible, collapsed by default) ------------
       {
@@ -464,7 +461,18 @@ function resolveLabel(v: unknown): string {
  * removed pre-ADR-0021 inline analytics keys so switching type (or saving a
  * legacy widget) never re-emits the dead shape. Metric-like widgets show a
  * single value, so their `dimensions` are dropped.
+ *
+ * Also scrubs the three widget-level action keys retired in
+ * @objectstack/spec 17.0.0-rc.3 (objectstack#5010, ADR-0049 D2). They are
+ * `retiredKey` tombstones — `DashboardWidgetSchema` types them `never` and
+ * refuses any value — so re-emitting one turns a stored dashboard into a parse
+ * error. The authoring field that produced `actionUrl` is gone (see the
+ * Behavior note in `buildWidgetSchema`); this is the second line of defence,
+ * for a stored widget that already carries the keys or a host that hands the
+ * panel a config containing them (objectstack#7129).
  */
+const RETIRED_ACTION_KEYS = ['actionUrl', 'actionType', 'actionIcon'];
+
 const LEGACY_ANALYTICS_KEYS = [
   'object', 'categoryField', 'categoryGranularity', 'valueField', 'aggregate',
   'aggregation', 'rowField', 'columnField', 'xAxisField', 'yAxisFields',
@@ -478,6 +486,7 @@ export function sanitizeDraftForType(draft: Record<string, any>): Record<string,
   const t = draft.type as string | undefined;
   const out = { ...draft };
   for (const key of LEGACY_ANALYTICS_KEYS) delete out[key];
+  for (const key of RETIRED_ACTION_KEYS) delete out[key];
   if (!usesDimensions(t)) delete out.dimensions;
   return out;
 }

--- a/packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.retiredActionKeys.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/WidgetConfigPanel.retiredActionKeys.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The Studio widget config panel must never author a retired widget-level
+ * action key (objectstack#7129).
+ *
+ * `actionUrl` / `actionType` / `actionIcon` were retired at the widget level in
+ * @objectstack/spec 17.0.0-rc.3 (objectstack#5010, ADR-0049 D2). They are
+ * `retiredKey` tombstones: `DashboardWidgetSchema` types them `never` and
+ * REFUSES any value — including `''`. Until this pin, `WidgetConfigPanel`
+ * offered a Behavior-group "Click-through URL" field bound to `actionUrl`, and
+ * `DashboardWithConfig` seeded `actionUrl: widget.actionUrl ?? ''` into every
+ * widget config it handed the panel — so every save from Studio persisted a
+ * parse-error key, even when the author never opened the Behavior group. The
+ * ADR-0021 save scrub did not drop it (it only knows the dataset-shape keys).
+ *
+ * Note the two different `actionUrl`s: `header.actions[]` keeps its own,
+ * string-typed and live (see `DashboardRenderer.headerActions.test.tsx`). Only
+ * the WIDGET-level key is a tombstone. Each case here therefore carries a
+ * live-neighbour falsifier (`colorVariant`, the sibling that flows through the
+ * exact same seed → field → draft → scrub path), so a green result cannot come
+ * from the assertion simply never reaching anything.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { DashboardWidgetSchema } from '@objectstack/spec/ui';
+import type { DashboardComponentSchema } from '@object-ui/types';
+import { WidgetConfigPanel, sanitizeDraftForType } from '../WidgetConfigPanel';
+import { DashboardWithConfig } from '../DashboardWithConfig';
+
+afterEach(cleanup);
+
+const RETIRED_ACTION_KEYS = ['actionUrl', 'actionType', 'actionIcon'] as const;
+
+// A widget the spec accepts, used as the base for every round-trip assertion.
+const SPEC_VALID_WIDGET = {
+  id: 'w1',
+  type: 'bar',
+  dataset: 'sales_pipeline',
+  dimensions: ['stage'],
+  values: ['revenue'],
+} as const;
+
+describe('the spec really does refuse these keys (premise check)', () => {
+  it('accepts the base widget but refuses each retired action key by name', () => {
+    expect(DashboardWidgetSchema.safeParse({ ...SPEC_VALID_WIDGET }).success).toBe(true);
+    // Falsifier: a live sibling key on the same shape still parses, so the
+    // refusals below are the tombstones firing, not a schema that rejects
+    // everything.
+    expect(
+      DashboardWidgetSchema.safeParse({ ...SPEC_VALID_WIDGET, colorVariant: 'blue' }).success,
+    ).toBe(true);
+
+    for (const key of RETIRED_ACTION_KEYS) {
+      // `''` — not just a real URL — is what an untouched panel save emitted.
+      for (const value of ['', 'https://example.com/deals']) {
+        const result = DashboardWidgetSchema.safeParse({ ...SPEC_VALID_WIDGET, [key]: value });
+        expect(result.success, `'${key}': ${JSON.stringify(value)} must be refused`).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues.some((i) => i.path[0] === key)).toBe(true);
+        }
+      }
+    }
+  });
+});
+
+describe('sanitizeDraftForType — scrubs the retired widget action keys', () => {
+  it('drops all three, keeping the live sibling', () => {
+    const out = sanitizeDraftForType({
+      ...SPEC_VALID_WIDGET,
+      colorVariant: 'blue',
+      actionUrl: 'https://example.com/deals',
+      actionType: 'url',
+      actionIcon: 'Link',
+    });
+    for (const key of RETIRED_ACTION_KEYS) expect(out).not.toHaveProperty(key);
+    // Falsifier: the scrub is selective, not a wholesale strip.
+    expect(out.colorVariant).toBe('blue');
+    expect(out.dataset).toBe('sales_pipeline');
+    expect(DashboardWidgetSchema.safeParse(out).success).toBe(true);
+  });
+
+  it('drops the empty-string spelling too', () => {
+    const out = sanitizeDraftForType({ ...SPEC_VALID_WIDGET, actionUrl: '' });
+    expect(out).not.toHaveProperty('actionUrl');
+  });
+});
+
+describe('WidgetConfigPanel — offers no retired action key as an authoring field', () => {
+  const config = { ...SPEC_VALID_WIDGET, title: 'Revenue', colorVariant: 'blue' };
+
+  it('renders no Behavior section and no field bound to a retired key', () => {
+    render(<WidgetConfigPanel open onClose={vi.fn()} config={config} onSave={vi.fn()} />);
+
+    expect(screen.queryByTestId('config-section-behavior')).not.toBeInTheDocument();
+    expect(screen.queryByText('Click-through URL')).not.toBeInTheDocument();
+    for (const key of RETIRED_ACTION_KEYS) {
+      expect(screen.queryByTestId(`config-field-${key}`)).not.toBeInTheDocument();
+    }
+
+    // Falsifier: the sibling group that was NOT removed still renders, so the
+    // absences above are not "the panel failed to render at all". `appearance`
+    // is `defaultCollapsed` exactly like `behavior` was, so this also proves
+    // the section-level assertion is not blind to collapsed sections.
+    expect(screen.getByTestId('config-section-appearance')).toBeInTheDocument();
+    expect(screen.getByTestId('config-section-general')).toBeInTheDocument();
+  });
+
+  it('emits none of the retired keys on save, even when handed a config carrying them', () => {
+    const onSave = vi.fn();
+    render(
+      <WidgetConfigPanel
+        open
+        onClose={vi.fn()}
+        config={{ ...config, actionUrl: 'https://example.com/deals', actionType: 'url', actionIcon: 'Link' }}
+        onSave={onSave}
+      />,
+    );
+
+    // The footer only appears once the draft is dirty — mirror a real edit.
+    fireEvent.change(screen.getByTestId('config-field-title'), { target: { value: 'Revenue v2' } });
+    fireEvent.click(screen.getByTestId('config-panel-save'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0] as Record<string, unknown>;
+    for (const key of RETIRED_ACTION_KEYS) expect(saved).not.toHaveProperty(key);
+    // Falsifier: the edit and the live sibling did survive the same path.
+    expect(saved.title).toBe('Revenue v2');
+    expect(saved.colorVariant).toBe('blue');
+    expect(DashboardWidgetSchema.safeParse(saved).success).toBe(true);
+  });
+});
+
+describe('DashboardWithConfig — a Studio save round-trip persists no retired key', () => {
+  const schema: DashboardComponentSchema = {
+    type: 'dashboard',
+    title: 'Sales',
+    widgets: [{ id: 'w1', title: 'Revenue', type: 'bar', colorVariant: 'blue' } as never],
+  };
+
+  it('hands the host a config the spec accepts, with the retired keys absent', () => {
+    const onWidgetSave = vi.fn();
+    render(
+      <DashboardWithConfig
+        schema={schema}
+        config={{}}
+        onConfigSave={vi.fn()}
+        onWidgetSave={onWidgetSave}
+        defaultConfigOpen
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('dashboard-preview-widget-w1'));
+    fireEvent.change(screen.getByTestId('config-field-title'), { target: { value: 'Revenue v2' } });
+    fireEvent.click(screen.getByTestId('config-panel-save'));
+
+    expect(onWidgetSave).toHaveBeenCalledTimes(1);
+    const [widgetId, saved] = onWidgetSave.mock.calls[0] as [string, Record<string, unknown>];
+    expect(widgetId).toBe('w1');
+
+    // The regression this pins: the author never touched any action field, and
+    // the seeded `actionUrl: ''` used to ride along into stored metadata.
+    for (const key of RETIRED_ACTION_KEYS) expect(saved).not.toHaveProperty(key);
+
+    // Falsifier: the same seed → panel → scrub path DOES carry the live sibling
+    // and the author's edit, so the absence above is a scrub, not an empty
+    // payload.
+    expect(saved.title).toBe('Revenue v2');
+    expect(saved.colorVariant).toBe('blue');
+
+    // The panel's payload is the documented FLATTENED shape (`layout.w` →
+    // `layoutW`, see `WidgetConfigPanelProps.config`), which the host
+    // un-flattens before persisting; un-flatten it here so the parse measures
+    // the retired action keys and not that intermediate shape.
+    const { layoutW, layoutH, ...rest } = saved as Record<string, never>;
+    const parsed = DashboardWidgetSchema.safeParse({
+      ...rest,
+      layout: { x: 0, y: 0, w: layoutW ?? 1, h: layoutH ?? 1 },
+      dataset: 'sales_pipeline',
+      values: ['revenue'],
+    });
+    expect(
+      parsed.success,
+      parsed.success ? '' : JSON.stringify(parsed.error.issues),
+    ).toBe(true);
+  });
+});

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -672,10 +672,21 @@ export interface DashboardWidgetLayout {
  */
 export interface DashboardWidgetSchema
   extends Omit<Partial<SpecDashboardWidget>, 'type' | 'options' | 'chartConfig' | 'filter' | 'responsive'> {
-  // `id`, `title`, `description`, `colorVariant`, `actionUrl`, `actionType`,
-  // `actionIcon`, `dataset`, `dimensions`, `values`, `filterBindings`,
-  // `requiresObject`, `requiresService`, `compareTo`, `aria`, … all flow in from
-  // the spec through the `extends` above — do not restate them here.
+  // `id`, `title`, `description`, `colorVariant`, `dataset`, `dimensions`,
+  // `values`, `filterBindings`, `requiresObject`, `requiresService`,
+  // `compareTo`, … all flow in from the spec through the `extends` above — do
+  // not restate them here.
+  //
+  // `actionUrl`, `actionType`, `actionIcon` and `aria` flow in too, but as
+  // RETIRED keys: @objectstack/spec 17.0.0-rc.3 (objectstack#5010, ADR-0049 D2)
+  // turned them into `retiredKey` tombstones, so the spec types them `never`
+  // and the Zod twin refuses any value. They inherit as `?: never` — authoring
+  // one is a tsc error here and a parse error at validation. Reading one still
+  // type-checks (`never | undefined`), which is how objectui's widget config
+  // panel kept producing `actionUrl` until objectstack#7129. A dashboard
+  // widget's click-through affordance lives in `header.actions[]`, whose own
+  // `actionUrl` is unrelated and still live.
+  // Pinned by `__tests__/report-chart-query-spec-parity.test.ts`.
   /** Component schema (legacy format) — objectui-only, no spec counterpart. */
   component?: SchemaNode;
   layout?: DashboardWidgetLayout;


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7129

## What was wrong

`actionUrl` / `actionType` / `actionIcon` were retired at the **widget** level in `@objectstack/spec` 17.0.0-rc.3 (objectstack#5010, ADR-0049 D2). They are `retiredKey` tombstones: `DashboardWidgetSchema` types them `never` and refuses any value, so authoring one is a tsc error and a parse error.

`plugin-dashboard` was still producing the widget-level key. All verified on objectui `origin/main` @ `11c1e71e`, not a working tree:

1. **`WidgetConfigPanel.tsx:391`** — a Behavior-group authoring field labelled "Click-through URL", bound to `actionUrl`.
2. **`DashboardWithConfig.tsx:114`** — `actionUrl: widget.actionUrl ?? ''` seeded into every widget config handed to the panel.
3. **`WidgetConfigPanel.tsx` `sanitizeDraftForType`** — the only scrub between panel draft and persistence, and it deletes `LEGACY_ANALYTICS_KEYS` (dataset-shape keys) only.

### The defect is wider than the issue body measured

The issue and its triage thread frame this as "the panel offers a field that authors a tombstoned key". Measured here, the seed at site 2 makes it unconditional: because `selectedWidgetConfig` always sets `actionUrl` (to `''` when absent), `useConfigDraft` starts from it and the scrub does not remove it, so **every save from the widget panel emitted `actionUrl: ''`** — including a save where the author merely renamed a widget and never opened the Behavior group. The reverse-verification run below shows exactly that: `actionUrl` in the persisted payload of a test that touches only the title field.

### The field was inert in the other direction too

Zero-hit result, falsified as the card requires: no dashboard widget renderer reads `widget.actionUrl` anywhere in objectui. Falsifier — `colorVariant`, the sibling key that travels the identical seed to panel-field to draft to scrub path — resolves to a real consumer chain (`DashboardWithConfig.tsx:113`, `WidgetConfigPanel.tsx:407`, `colorVariants.ts`, `DatasetWidget.tsx:722`), so the sweep does find consumers when they exist. Also checked for the blind spots named on the card: no bracket or dynamic access anywhere in `packages`/`apps`/`examples`/`e2e`, and no cross-line concatenation candidates. `DashboardRenderer`'s 14 `actionUrl` occurrences remain `header.actions[]`-scoped, so the ledger's claim about the renderer half still holds.

So the control was a lying control twice over: the URL an author typed was never navigated to, and the value was refused by the spec on the way in.

## What changed

- **`WidgetConfigPanel.tsx`** — the Behavior section is removed (it held exactly this one field), replaced by a comment recording why it must not come back. `sanitizeDraftForType` now also scrubs all three retired keys, as defence in depth for stored widgets that already carry them and for hosts driving `WidgetConfigPanel` directly.
- **`DashboardWithConfig.tsx`** — the `actionUrl` seed is removed.
- **`packages/types/src/complex.ts`** — the `DashboardWidgetSchema` docblock listed the three keys among those that "flow in from the spec" alongside live keys like `colorVariant`. They do flow in, as `?: never`. The prose now says so, and records the asymmetry that let these producers survive the 2026-08-04 renderer-side sweep: authoring one is a tsc error, but *reading* one still type-checks as `never | undefined`.

I took the removal route rather than only widening the scrub, per the dispatch's preference: a UI field whose value is silently scrubbed on save is exactly the lenient-consumer shape this campaign removes. I found no live non-tombstoned consumer that would argue for keeping the field.

`actionType` / `actionIcon` were checked separately, as the card asked: neither is authored by the panel nor read by `DashboardWithConfig`, so no field removal was invented for them. They are covered by the scrub and by the new pin only.

## Verification

All commands run from the repo root (the repo's vitest guard rejects the per-package form).

**Executed the spec parse rather than reading it** — `DashboardWidgetSchema.safeParse` against the real `@objectstack/spec` 17.0.0-rc.5:

```
PASS  baseline (no action keys)
FAIL  actionUrl: '' (what an untouched panel save emits) :: actionUrl=invalid_type
FAIL  actionUrl: 'https://x' :: actionUrl=invalid_type
FAIL  actionType: 'url' :: actionType=invalid_type
FAIL  actionIcon: 'Link' :: actionIcon=invalid_type
PASS  falsifier: known-present neighbour colorVariant: 'blue'
FAIL  falsifier: bogus key nonsenseKey: 1 :: =unrecognized_keys
```

The two falsifiers matter: `colorVariant` passing shows the schema is not rejecting everything, and the bogus key failing with a *different* code (`unrecognized_keys`, not `invalid_type`) shows the `actionUrl` failures are the tombstone firing rather than generic strictness.

**Reverse verification.** Predicted direction: plain red — the new pins assert the absence of a producer this PR removes, so restoring it must break them. Taking the fix out with `git checkout origin/main` on the two source files (never `git stash`):

```
 x drops all three, keeping the live sibling
 x drops the empty-string spelling too
 x renders no Behavior section and no field bound to a retired key
 x emits none of the retired keys on save, even when handed a config carrying them
 x hands the host a config the spec accepts, with the retired keys absent
 Tests  5 failed | 1 passed (6)
```

5 of 6 red as predicted. The single case that stayed green is the intended control — the "spec really does refuse these keys" premise block, which does not depend on this change. The `DashboardWithConfig` failure is the direct evidence for the unconditional-seed claim above: `expected { id: 'w1', title: 'Revenue v2', ... } to not have property "actionUrl"`, in a test that only edits the title.

**One honest correction to my own first draft:** the round-trip assertion initially failed because the panel emits the documented *flattened* shape (`layout.w` becomes `layoutW`), which the spec refuses as `unrecognized_keys`. That is the panel's documented host-facing intermediate shape, not a defect this PR introduces; the test now un-flattens before parsing. It did surface a separate question about that contract, filed rather than fixed here (see below).

Targeted suites, all green:

```
pnpm exec vitest run packages/plugin-dashboard/   ->  Test Files  32 passed (32)   Tests  276 passed (276)
pnpm exec vitest run packages/types/              ->  Test Files  29 passed (29)   Tests  388 passed (388)
pnpm --filter @object-ui/plugin-dashboard --filter @object-ui/types type-check
      packages/types type-check: Done
      packages/plugin-dashboard type-check: Done
pnpm --filter @object-ui/plugin-dashboard --filter @object-ui/types lint
      241 problems (0 errors, 241 warnings)   -- all pre-existing no-explicit-any
eslint (the 4 changed files)
      35 problems (0 errors, 35 warnings)     -- all pre-existing; the new test file emits none
control-character self-scan over the 5 changed files -> clean
```

Dependency closure built first (`pnpm --filter '@object-ui/plugin-dashboard^...' build`) so tsc read rebuilt `.d.ts` rather than stale artefacts.

## Out of scope, filed separately

**objectstack#7193** — `DashboardWithConfig` forwards the panel's flattened `layoutW`/`layoutH` verbatim to `onWidgetSave`, and the spec refuses both as `unrecognized_keys`. Surfaced by the test correction described above. Whether it bites depends on the out-of-repo Studio host (objectui has no in-repo consumer of `DashboardWithConfig`), so it is filed observation-class rather than fixed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_