### PR TITLE
docs(guide): teach the Tailwind 4 CSS-first setup on theming / troubleshooting / quick-start

### DIFF
--- a/content/docs/guide/quick-start.md
+++ b/content/docs/guide/quick-start.md
@@ -56,12 +56,9 @@ Add to your `src/index.css`:
 @import "tailwindcss";
 @import "@object-ui/components/style.css";
 @import "@object-ui/fields/style.css";
-
-@source "../node_modules/@object-ui/components/**/*.{js,ts,tsx}";
-@source "../node_modules/@object-ui/fields/**/*.{js,ts,tsx}";
 ```
 
-The `@source` lines let Tailwind see the utility classes used by ObjectUI packages.
+Each `style.css` is the stylesheet that package compiled from its own sources, and it already carries every utility its components use — the themed ones (`bg-primary`, `border-input`) included. That is the whole styling setup: you do not add `@source` lines for these packages, and pointing Tailwind at them inside `node_modules` only regenerates utilities the import already gave you.
 
 ## Step 4: Render Your First Schema
 

--- a/content/docs/guide/quick-start.md
+++ b/content/docs/guide/quick-start.md
@@ -55,10 +55,9 @@ Add to your `src/index.css`:
 ```css
 @import "tailwindcss";
 @import "@object-ui/components/style.css";
-@import "@object-ui/fields/style.css";
 ```
 
-Each `style.css` is the stylesheet that package compiled from its own sources, and it already carries every utility its components use — the themed ones (`bg-primary`, `border-input`) included. That is the whole styling setup: you do not add `@source` lines for these packages, and pointing Tailwind at them inside `node_modules` only regenerates utilities the import already gave you.
+`style.css` is the stylesheet `@object-ui/components` compiled from its own sources, and it already carries every utility its components use — the themed ones (`bg-primary`, `border-input`) included. That is the whole styling setup: you do not add `@source` lines for the ObjectUI packages, and pointing Tailwind at them inside `node_modules` only regenerates utilities the import already gave you.
 
 ## Step 4: Render Your First Schema
 

--- a/content/docs/guide/theming.md
+++ b/content/docs/guide/theming.md
@@ -60,58 +60,24 @@ Components reference these tokens through Tailwind:
 <button className="bg-primary text-primary-foreground" />
 ```
 
-## Tailwind Configuration
+## Tailwind Setup
 
-Extend your `tailwind.config.js` to map tokens to Tailwind utilities:
+There is no `tailwind.config.js` step. ObjectUI is Tailwind 4, which is configured in CSS: the packages have no such file of their own, and consuming them does not need one on your side either.
 
-```js
-// tailwind.config.js
-export default {
-  darkMode: "class",
-  content: [
-    "./src/**/*.{ts,tsx}",
-    "./node_modules/@object-ui/components/dist/**/*.js",
-  ],
-  theme: {
-    extend: {
-      colors: {
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
-        destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
-        },
-        border: "hsl(var(--border))",
-        ring: "hsl(var(--ring))",
-      },
-      borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
-      },
-      fontFamily: {
-        sans: ["Inter", "ui-sans-serif", "system-ui"],
-      },
-    },
-  },
-};
+Import the published stylesheets after your own Tailwind entry:
+
+```css
+/* src/index.css */
+@import "tailwindcss";
+@import "@object-ui/components/style.css";
+@import "@object-ui/fields/style.css";
 ```
+
+`style.css` is the stylesheet each package compiles at build time from its own sources — the subpath is a real export, mapped to the package's `dist/index.css`. It already carries every utility its components use **and** the `@theme` block those utilities are built on, so the whole Shadcn palette (`bg-background`, `bg-primary`, `border-input`, `ring-ring`) arrives with the import. You do not restate those tokens in a config of your own.
+
+Do **not** point Tailwind at the packages inside `node_modules` — neither with a v4 `@source` line nor a v3 `content` entry. Scanning the published files regenerates the shape-only utilities (`inline-flex`, `rounded-md`, `h-9`) that `style.css` already contains, and it cannot produce the themed ones at all: the `@theme` block they come from lives in the package's own source, which is not published. Your Tailwind entry goes on generating the classes *your* source uses, exactly as before.
+
+To recolour ObjectUI, override the token values rather than the utilities — either the `:root` custom properties shown above, or a `Theme` object handed to `ThemeProvider` (see below). Both re-theme every component without any scanning.
 
 ## Component Variants with `cva`
 
@@ -220,7 +186,7 @@ function ModeToggle() {
 }
 ```
 
-Ensure your Tailwind config uses `darkMode: "class"` so that `.dark` scoped utilities work correctly.
+There is no `darkMode` option to set on your side. ObjectUI declares the class-based dark variant in its own CSS — `@custom-variant dark (&:where(.dark, .dark *))` — so `.dark`-scoped utilities are already compiled into the stylesheet you import. What you do need is for the `dark` class to sit on an ancestor of your components; `ThemeProvider` puts it on `document.documentElement` for you.
 
 ## Custom Component Themes
 

--- a/content/docs/guide/theming.md
+++ b/content/docs/guide/theming.md
@@ -64,16 +64,15 @@ Components reference these tokens through Tailwind:
 
 There is no `tailwind.config.js` step. ObjectUI is Tailwind 4, which is configured in CSS: the packages have no such file of their own, and consuming them does not need one on your side either.
 
-Import the published stylesheets after your own Tailwind entry:
+Import the published stylesheet after your own Tailwind entry:
 
 ```css
 /* src/index.css */
 @import "tailwindcss";
 @import "@object-ui/components/style.css";
-@import "@object-ui/fields/style.css";
 ```
 
-`style.css` is the stylesheet each package compiles at build time from its own sources — the subpath is a real export, mapped to the package's `dist/index.css`. It already carries every utility its components use **and** the `@theme` block those utilities are built on, so the whole Shadcn palette (`bg-background`, `bg-primary`, `border-input`, `ring-ring`) arrives with the import. You do not restate those tokens in a config of your own.
+`style.css` is the stylesheet `@object-ui/components` compiles at build time from its own sources — the subpath is a real export, mapped to that package's `dist/index.css`. It already carries every utility its components use **and** the `@theme` block those utilities are built on, so the whole Shadcn palette (`bg-background`, `bg-primary`, `border-input`, `ring-ring`) arrives with the import. You do not restate those tokens in a config of your own.
 
 Do **not** point Tailwind at the packages inside `node_modules` — neither with a v4 `@source` line nor a v3 `content` entry. Scanning the published files regenerates the shape-only utilities (`inline-flex`, `rounded-md`, `h-9`) that `style.css` already contains, and it cannot produce the themed ones at all: the `@theme` block they come from lives in the package's own source, which is not published. Your Tailwind entry goes on generating the classes *your* source uses, exactly as before.
 

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -44,25 +44,20 @@ npx objectui doctor
 
 **Symptom:** Tailwind utility classes are not applied. Components render without styling.
 
-**Cause:** The `content` paths in your Tailwind config do not include ObjectUI package files.
+**Cause:** You are not importing the stylesheet the ObjectUI packages publish. Their utilities — including every themed one, such as `bg-primary` and `border-input` — are compiled at build time into the package's `style.css`, and nothing in your own build can reproduce the themed ones.
 
-**Fix:** Update your `tailwind.config.ts` (or `postcss.config.mjs`) to scan ObjectUI packages inside `node_modules`:
+**Fix:** Import them in your main CSS file, after your own Tailwind entry:
 
-```typescript
-// tailwind.config.ts
-export default {
-  content: [
-    './src/**/*.{ts,tsx}',
-    './node_modules/@object-ui/components/**/*.{js,ts,tsx}',
-    './node_modules/@object-ui/fields/**/*.{js,ts,tsx}',
-    './node_modules/@object-ui/layout/**/*.{js,ts,tsx}',
-    './node_modules/@object-ui/plugin-*/**/*.{js,ts,tsx}',
-  ],
-  // ...
-};
+```css
+/* src/index.css */
+@import 'tailwindcss';
+@import '@object-ui/components/style.css';
+@import '@object-ui/fields/style.css';
 ```
 
-Also ensure `postcss.config.mjs` is present at the project root (see `postcss.config.mjs` in the monorepo root for reference).
+`@object-ui/components` and `@object-ui/fields` are the packages that publish a `style.css` subpath; the others carry no stylesheet of their own. Then check that the Tailwind 4 build plugin is actually installed and wired up — `@tailwindcss/postcss` in `postcss.config.mjs`, or `@tailwindcss/vite` in `vite.config.ts`. Without it, `@import 'tailwindcss'` is passed through as a plain CSS import and no utilities are generated at all.
+
+> **Do not** try to fix this by adding `node_modules` paths to a `content` array or an `@source` line. ObjectUI is Tailwind 4 and has no `tailwind.config.js`; Tailwind 4 does not load one unless you opt in with `@config`, so on most projects those paths do nothing whatsoever. Even when they are read, scanning the published files only regenerates the shape-only utilities (`inline-flex`, `rounded-md`, `h-9`) that `style.css` already contains — it can never produce the themed ones, because the `@theme` block declaring their tokens lives in the package's unpublished source. Missing theme colours are always the missing `style.css` import, never a missing path.
 
 ## 3. Missing Peer Dependencies
 

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -52,10 +52,9 @@ npx objectui doctor
 /* src/index.css */
 @import 'tailwindcss';
 @import '@object-ui/components/style.css';
-@import '@object-ui/fields/style.css';
 ```
 
-`@object-ui/components` and `@object-ui/fields` are the packages that publish a `style.css` subpath; the others carry no stylesheet of their own. Then check that the Tailwind 4 build plugin is actually installed and wired up — `@tailwindcss/postcss` in `postcss.config.mjs`, or `@tailwindcss/vite` in `vite.config.ts`. Without it, `@import 'tailwindcss'` is passed through as a plain CSS import and no utilities are generated at all.
+`@object-ui/components` is the package that publishes a working `style.css`. (`@object-ui/fields` declares the same subpath, but its published package contains no stylesheet — see [#4059](https://github.com/objectstack-ai/objectui/issues/4059) — so importing it fails to resolve. Do not add it.) Then check that the Tailwind 4 build plugin is actually installed and wired up — `@tailwindcss/postcss` in `postcss.config.mjs`, or `@tailwindcss/vite` in `vite.config.ts`. Without it, `@import 'tailwindcss'` is passed through as a plain CSS import and no utilities are generated at all.
 
 > **Do not** try to fix this by adding `node_modules` paths to a `content` array or an `@source` line. ObjectUI is Tailwind 4 and has no `tailwind.config.js`; Tailwind 4 does not load one unless you opt in with `@config`, so on most projects those paths do nothing whatsoever. Even when they are read, scanning the published files only regenerates the shape-only utilities (`inline-flex`, `rounded-md`, `h-9`) that `style.css` already contains — it can never produce the themed ones, because the `@theme` block declaring their tokens lives in the package's unpublished source. Missing theme colours are always the missing `style.css` import, never a missing path.
 


### PR DESCRIPTION
Fixes #3883
Fixes #3884

Two-card docs sweep, one root cause: three consumer-facing guide pages taught Tailwind 3 configuration for a Tailwind 4 library, and #3780's compile matrix measured that the prescriptions cannot restore the utilities they claim to. The theme-class utilities (`bg-primary`, `bg-background`, `border-input`, `ring-ring`) exist only where the `@theme` block declaring their tokens is compiled — `packages/components/src/index.css`, which `files` does not publish — so scanning the published files, by v4 `@source` or v3 `content`, can only regenerate the shape-only utilities the prebuilt `style.css` already contains.

## Per-item checklist

| 落点 | before | after |
| --- | --- | --- |
| `content/docs/guide/theming.md` §Tailwind Configuration (was 63-114) | "Extend your `tailwind.config.js`…" + a v3 config: `darkMode: "class"`, a `content` array reaching into `node_modules/@object-ui/components/dist`, and 30 lines mapping `--background` / `--primary` / `--border` into `theme.extend.colors` | §Tailwind Setup: no config file step, `@import "@object-ui/components/style.css"` (which carries the `@theme` block), and an explicit "do not point Tailwind at `node_modules`" with the reason. Retheming is pointed at token overrides. |
| `content/docs/guide/theming.md` §Dark Mode (was :223) | "Ensure your Tailwind config uses `darkMode: \"class\"`…" — dangling once the config section is gone | There is no `darkMode` option to set; the class-based dark variant is declared in the package's own CSS as `@custom-variant dark (&:where(.dark, .dark *))`, and what the reader must ensure is that the `dark` class sits on an ancestor. |
| `content/docs/guide/troubleshooting.md` §2 (was 44-66) | Cause: "the `content` paths in your Tailwind config do not include ObjectUI package files"; fix: a `tailwind.config.ts` with four `node_modules` globs | Cause: the published `style.css` is not imported. Fix: import `@object-ui/components/style.css`, then check the Tailwind 4 build plugin is wired up (`@tailwindcss/postcss` or `@tailwindcss/vite`). Names `@object-ui/fields`' subpath as unimportable and points at #4059. Closes with a blockquote naming the old prescription as the wrong direction and why. |
| `content/docs/guide/quick-start.md` Step 3 (was 55-64) | Two `@source "../node_modules/@object-ui/…"` lines plus "The `@source` lines let Tailwind see the utility classes used by ObjectUI packages" — the mechanism stated backwards | Both `@source` lines deleted (measured +100 kB CSS for 14 selectors, none needed); the sentence now says what `style.css` actually carries and why no `@source` is added for these packages. |
| all three pages, second commit | each taught snippet also carried `@import "@object-ui/fields/style.css"` — quick-start had it already, and the two rewritten sections had inherited it | that line removed everywhere, and the surrounding prose narrowed to `@object-ui/components` — the one package measured to publish a working `style.css`. See the tarball reading below. |

`git diff --name-only` against the merge base is exactly the three files in those rows, nothing else:

```
 content/docs/guide/quick-start.md     |  6 +--
 content/docs/guide/theming.md         | 69 +++++++++--------------------------
 content/docs/guide/troubleshooting.md | 24 +++++-------
 3 files changed, 27 insertions(+), 72 deletions(-)
```

## Verification

Measurement basis is #3780's four-cell matrix, quoted in both cards and ruled not re-litigable ([#3884 裁决](https://github.com/objectstack-ai/objectui/issues/3884#issuecomment-5229249267)):

> ⚖️ **PM 裁决(维护者已授权代裁,session `session_01GTRjn8xBqp75dk7kFupVRt`):按实测删 quick-start 的两条 `@source node_modules` 冗余行,并改写那句会把排查推错方向的解释**
>
> 依据:#3780/PR3886 的四组入口探针已证预构建 `style.css` 是 node_modules 扫描所得的**严格超集**(1410 ⊇ 1331,0 缺失),两条 `@source` 只多 +100kB 与 14 条无人使用的选择器;解释句(「让 Tailwind 看见 ObjectUI 的 utility class」)与实测机理相反。纯测量结论,无产品取舍。

Spot-verified on `origin/main` rather than re-run, per that ruling — every claim this PR now makes in prose:

- `packages/components/package.json`: `"./style.css": "./dist/index.css"`, and `files` is `["dist", "README.md", "CHANGELOG.md", "LICENSE"]` — so `src/index.css`, which holds the `@theme` block, is not published.
- `packages/components` has no `tailwind.config.js`; `postcss.config.js` loads `@tailwindcss/postcss`; `src/index.css` opens `@import 'tailwindcss'` and uses `@theme` / `@custom-variant` / `@source`.
- The `@custom-variant dark (&:where(.dark, .dark *))` quoted in the dark-mode paragraph is copied verbatim from `packages/components/src/index.css:11`.
- **Why the fields import left (second commit).** The published-artifact reading recorded on [#4059](https://github.com/objectstack-ai/objectui/issues/4059#issuecomment-5235337719): the `@object-ui/fields@17.3.0` npm tarball contains **zero `.css` files**, so its declared `"./style.css": "./dist/index.css"` export resolves to nothing and `@import '@object-ui/fields/style.css'` fails a consumer's build; the control, `@object-ui/components@17.3.0`, ships `package/dist/index.css` as expected. That falsifies the cards' "both `@import` lines are correct" premise for the fields line specifically, which is why removing it here is required rather than a rider — troubleshooting §2 is the page a reader lands on with a broken build, and its fix must not break it further. Nothing is asserted about how fields' widgets are styled without that import: whether their class shapes are a subset of components' published utilities is the open measurement #4059 names, and it belongs to that card.

Gates, re-run in the worktree after the rework:

```
$ node scripts/check-control-bytes.mjs
✅  check-control-bytes: OK (scanned 3927 tracked text file(s); skipped 85 binary).

$ node scripts/check-doc-links.mjs
Links are valid across 7 scan roots.
```

`scripts/__tests__/doc-version-claims.test.ts` could not be executed (docs-only worktree, no install), so its matcher was replicated over both revisions of the three pages instead. The flagged set is identical before and after — the two inventoried claims, untouched by this diff:

```
content/docs/guide/theming.md:320: "Tailwind CSS v3.3"      (KNOWN_CLAIMS: unanchored)
content/docs/guide/troubleshooting.md:65: "React 18+"       (KNOWN_CLAIMS: unanchored)
```

Neither direction of that ratchet can trip: nothing was added that the matcher reads as a version literal (a bare major such as "Tailwind 4" is documented in the test header as deliberately unmatched), and no inventoried literal was removed.

## Changeset

None owed, and this is the repo's own gate saying so rather than a judgement call:

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with 5419f552a (merge-base with origin/main): 3 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

No `skip-changeset` label was applied, and none should be: that label is not this repo's convention. `.github/workflows/changeset-presence.yml` decides from the diff inside the script and reports green when nothing is owed, and `scripts/__tests__/ci-cd-pipeline-doc.test.ts:184` records that objectui's `skip-changeset` label "was never real" (it was documented only by the `.github/WORKFLOWS.md` inventory deleted in #3724). A label lookup confirms it: `skip-changeset` does not exist in this repository.

## Out of scope, filed not fixed

- #4059 — `@object-ui/fields` declares a `./style.css` export with nothing published behind it. The docs half of that defect dies in this PR (second commit above); the package half stays on #4059 — either build real CSS for fields or retire the phantom export, a disposition that needs the subset measurement recorded there.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
