### PR TITLE
fix(cli): make the `objectui init` scaffold register components and load their styles (#4061, #4062)

### DIFF
--- a/.changeset/init-scaffold-registry-and-styles.md
+++ b/.changeset/init-scaffold-registry-and-styles.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/cli': patch
+---
+
+Fix `objectui init` scaffolding an app that renders neither components nor styles.
+
+The generated `src/App.tsx` imported only `SchemaRenderer` from `@object-ui/react`, which does not depend on `@object-ui/components` — and registration is a side effect of importing that package. The component registry was therefore empty in every scaffolded project, and each node of all three templates (`simple`, `form`, `dashboard`) rendered "Unknown component type". The manifest already declared `@object-ui/components`; it was declared and never imported. The generated `src/App.tsx` now performs the side-effect import.
+
+The generated `src/index.css` was a bare `@import 'tailwindcss';` and never loaded the library's published stylesheet, so the theme utilities the templates lean on had no tokens behind them. It now also does `@import '@object-ui/components/style.css';`, matching what the quick-start guide teaches hand-rolled consumers.
+
+`objectui init` is unchanged in every other respect: the same eleven files, byte for byte, apart from these two lines.

--- a/packages/cli/src/__tests__/app-generator.test.ts
+++ b/packages/cli/src/__tests__/app-generator.test.ts
@@ -59,7 +59,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { buildInitPackageJson } from '../commands/init.js';
+import { buildInitFiles, buildInitPackageJson } from '../commands/init.js';
 import {
   buildAppFiles,
   buildAppPackageJson,
@@ -371,6 +371,23 @@ const plainFiles = () => buildAppFiles(SCHEMA, STANDALONE);
 const routedFiles = () => buildRoutedAppFiles(ROUTES, APP_CONFIG, STANDALONE);
 const routedFilesNoConfig = () => buildRoutedAppFiles(ROUTES, undefined, STANDALONE);
 
+/**
+ * The `objectui init` scaffold, as a file map (objectui#4061 / objectui#4062).
+ *
+ * The third generator, and the one an external user meets first. Its manifest
+ * joined `DEPENDENCY_ANCHORS` in objectui#3892; its generated SOURCES were still
+ * under no gate at all, which is how both of these shipped at once:
+ * `@object-ui/components` was declared and never imported (so the registry was
+ * empty and every node rendered "Unknown component type"), and `src/index.css`
+ * imported none of the library's published CSS. The first is exactly what the
+ * unused-declaration gate below reports; see `generated init scaffold sources`.
+ *
+ * `'simple'` is the default template. The gates are asserted over all three,
+ * since each writes a different `app.json` — and the same `src/**`.
+ */
+const INIT_TEMPLATES = ['simple', 'form', 'dashboard'] as const;
+const initFiles = (template: string = 'simple') => buildInitFiles('sample-app', template);
+
 describe('generated app manifests', () => {
   it('declares every package the generated sources import', () => {
     // objectui#3827, generalised over both generators and every generated file.
@@ -380,14 +397,19 @@ describe('generated app manifests', () => {
     // first shape and hide the rest. Reverting the fix has to name `lucide-react`
     // — the reported defect, which lives in the routed layout — and not just
     // whichever shape happens to be checked first.
+    //
+    // `init` joined the shapes in objectui#4061: `src/App.tsx` gained the
+    // `@object-ui/components` side-effect import, and a gate that judged only
+    // the two temp-app generators could not have seen it arrive OR leave.
     expect({
       plain: undeclaredImports(buildAppPackageJson(STANDALONE), plainFiles()),
       routed: undeclaredImports(buildRoutedAppPackageJson(), routedFiles()),
       routedWithoutAppConfig: undeclaredImports(
         buildRoutedAppPackageJson(),
         routedFilesNoConfig()
-      )
-    }).toEqual({ plain: [], routed: [], routedWithoutAppConfig: [] });
+      ),
+      init: undeclaredImports(buildInitPackageJson('sample-app'), initFiles())
+    }).toEqual({ plain: [], routed: [], routedWithoutAppConfig: [], init: [] });
   });
 
   it('names every dependency the pre-fix routed manifest was missing', () => {
@@ -443,6 +465,11 @@ describe('generated app manifests', () => {
       .toEqual([]);
     expect(
       unusedVersionedDependencies(dependenciesOf(buildAppPackageJson(STANDALONE)), plainFiles())
+    ).toEqual([]);
+    // The init scaffold's 4 runtime ranges, judged for the first time
+    // (objectui#4061). This is the gate the defect was a live instance of.
+    expect(
+      unusedVersionedDependencies(dependenciesOf(buildInitPackageJson('sample-app')), initFiles())
     ).toEqual([]);
   });
 
@@ -639,6 +666,158 @@ describe('generated app manifests', () => {
     expect(buildAppPackageJson(IN_WORKSPACE).dependencies).toEqual({});
     expect(buildAppPackageJson(IN_WORKSPACE).devDependencies).toEqual({});
     expect(dependenciesOf(buildRoutedAppPackageJson())['@object-ui/react']).toBeTruthy();
+  });
+});
+
+/**
+ * The `objectui init` scaffold's generated sources (objectui#4061, objectui#4062).
+ *
+ * Both defects are the same shape as objectui#3755's, one in each direction, and
+ * both were invisible for the same reason: this generator's SOURCES had never
+ * been judged against its manifest. The gates above now judge them; the cases
+ * here plant each defect back, because a gate that passes over a shape it cannot
+ * fail is not a gate (objectui#3826).
+ */
+describe('generated init scaffold sources', () => {
+  /** The pre-objectui#4061 `src/App.tsx`, verbatim from `origin/main@11c1e71e8`. */
+  const PRE_FIX_APP_TSX = `import { SchemaRenderer } from '@object-ui/react';
+import schema from '../app.json';
+
+export default function App() {
+  return <SchemaRenderer schema={schema} />;
+}
+`;
+
+  /** The pre-objectui#4062 `src/index.css`, verbatim — the whole file. */
+  const PRE_FIX_INDEX_CSS = `@import 'tailwindcss';
+`;
+
+  it('imports the package registration is a side effect of', () => {
+    // objectui#4061's fix, pinned where a reader can see WHY the line is there.
+    // `SchemaRenderer` resolves nodes through `ComponentRegistry.get(type)` and
+    // `@object-ui/react` does not depend on `@object-ui/components`, so this
+    // side-effect import is the only thing that fills the registry.
+    const app = initFiles()['src/App.tsx'];
+    expect(app).toContain(`import '@object-ui/components';`);
+    expect(importedPackagesOf(app)).toEqual(['@object-ui/components', '@object-ui/react']);
+  });
+
+  it('reports @object-ui/components as unused when the registration import is removed', () => {
+    // Reverse verification, direction predicted before running: RED, naming
+    // exactly one package. The declaration was already in the manifest
+    // (objectui#3892 anchored its range), so removing the import turns the
+    // scaffold back into the objectui#4061 shape — declared, never imported —
+    // and the unused-declaration gate is what now catches it.
+    //
+    // This is the defect's real historical text, not an invented one: deleting
+    // the import yields `PRE_FIX_APP_TSX` byte for byte, asserted here so the
+    // fixture cannot drift away from the shape it claims to restore.
+    const preFix = { ...initFiles(), 'src/App.tsx': PRE_FIX_APP_TSX };
+    expect(initFiles()['src/App.tsx'].replace(
+      `// Registers the component renderers SchemaRenderer looks up. Side-effect\n` +
+      `// import — removing it makes every node render "Unknown component type".\n` +
+      `import '@object-ui/components';\n`,
+      ''
+    )).toBe(PRE_FIX_APP_TSX);
+
+    expect(
+      unusedVersionedDependencies(dependenciesOf(buildInitPackageJson('sample-app')), preFix)
+    ).toEqual(['@object-ui/components']);
+  });
+
+  it('needs no @object-ui/plugin-* to render what its own templates contain', () => {
+    // Why the fix imports ONE package where the temp-app generator imports nine.
+    // None of the three templates names a plugin type: the whole distinct set is
+    // the six below, every one registered by `@object-ui/components` itself
+    // (measured against `ComponentRegistry.register` calls in that package).
+    // Adding nine dependencies a minimal scaffold never uses would be
+    // objectui#3755's direction again — and the unused-declaration gate above
+    // would fail on all nine, which is the structural reason this stays honest.
+    const templateTypes = new Set<string>();
+    for (const template of INIT_TEMPLATES) {
+      const collect = (node: unknown): void => {
+        if (Array.isArray(node)) return node.forEach(collect);
+        if (node === null || typeof node !== 'object') return;
+        const record = node as Record<string, unknown>;
+        if (typeof record.type === 'string') templateTypes.add(record.type);
+        Object.values(record).forEach(collect);
+      };
+      collect(JSON.parse(initFiles(template)['app.json']));
+    }
+    expect([...templateTypes].sort()).toEqual([
+      'button',
+      'card',
+      'div',
+      'input',
+      'text',
+      'textarea'
+    ]);
+    expect(importedPackagesOf(initFiles()['src/App.tsx'])).not.toContain(
+      '@object-ui/plugin-grid'
+    );
+  });
+
+  it('imports the published stylesheet of every declared dependency that ships one', () => {
+    // objectui#4062, as a rule rather than a string pin: of the scaffold's
+    // runtime `@object-ui/*` dependencies, exactly those whose package declares
+    // a `./style.css` export must be imported by the generated CSS. Non-vacuous
+    // and discriminating — `@object-ui/components` exports one,
+    // `@object-ui/react` exports none, so the rule has something to say in both
+    // directions rather than blessing whatever is written.
+    const css = initFiles()['src/index.css'];
+    const imported = [...css.matchAll(/@import\s+['"]([^'"]+)['"]/g)].map((m) => m[1]);
+
+    const platformDeps = Object.keys(dependenciesOf(buildInitPackageJson('sample-app'))).filter(
+      (name) => name.startsWith('@object-ui/')
+    );
+    const publishesStyles = platformDeps.filter((name) => {
+      const exports = readManifest(
+        resolve(REPO_ROOT, 'packages', name.replace('@object-ui/', ''), 'package.json')
+      ) as unknown as { exports?: Record<string, unknown> };
+      return exports.exports?.['./style.css'] !== undefined;
+    });
+
+    expect(publishesStyles).toEqual(['@object-ui/components']);
+    expect(imported).toEqual(['tailwindcss', '@object-ui/components/style.css']);
+  });
+
+  it('is missing that stylesheet when the pre-fix CSS is restored', () => {
+    // Reverse verification for objectui#4062, direction predicted before
+    // running: the pre-fix file is a bare `@import 'tailwindcss';`, so the set of
+    // imported stylesheets loses the components entry and the assertion above
+    // goes RED. Stated as the set difference so the failure names the missing
+    // sheet rather than just "strings differ".
+    const imported = [...PRE_FIX_INDEX_CSS.matchAll(/@import\s+['"]([^'"]+)['"]/g)].map(
+      (m) => m[1]
+    );
+    expect(imported).toEqual(['tailwindcss']);
+    expect(imported).not.toContain('@object-ui/components/style.css');
+  });
+
+  it('imports no stylesheet from a package it does not depend on', () => {
+    // The other half of objectui#4062's undecided cell, settled by measurement:
+    // quick-start names `@object-ui/fields/style.css` too, but this scaffold does
+    // not depend on `@object-ui/fields` AND that package ships zero CSS at
+    // 17.3.0 (published-tarball measurement, objectui#4059). Copying the docs
+    // line would declare-vs-import in the wrong direction at an empty file.
+    const css = initFiles()['src/index.css'];
+    expect(css).not.toContain('@object-ui/fields');
+    const declared = new Set(Object.keys(dependenciesOf(buildInitPackageJson('sample-app'))));
+    for (const specifier of [...css.matchAll(/@import\s+['"](@[^'"]+)['"]/g)].map((m) => m[1])) {
+      const pkg = specifier.split('/').slice(0, 2).join('/');
+      expect(declared, `${specifier} is imported but ${pkg} is not a dependency`).toContain(pkg);
+    }
+  });
+
+  it('keeps the Tailwind entry first, so the library sheet cannot precede it', () => {
+    // `@import` order is load-bearing in a Tailwind 4 entrypoint and the CSS spec
+    // requires `@import` rules to precede other rules; the library sheet is
+    // appended after `@import 'tailwindcss'`, matching what quick-start teaches.
+    const css = initFiles()['src/index.css'];
+    expect(css.indexOf(`@import 'tailwindcss';`)).toBe(0);
+    expect(css.indexOf(`@import '@object-ui/components/style.css';`)).toBeGreaterThan(
+      css.indexOf(`@import 'tailwindcss';`)
+    );
   });
 });
 

--- a/packages/cli/src/__tests__/cli-bin.test.ts
+++ b/packages/cli/src/__tests__/cli-bin.test.ts
@@ -10,10 +10,12 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
+
+import { buildInitFiles } from '../commands/init.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI_BIN = resolve(__dirname, '../../dist/cli.js');
@@ -246,6 +248,78 @@ describe('@object-ui/cli bin', () => {
       expect(readFileSync(join(appDir, 'src/index.css'), 'utf-8')).toContain(
         `@import 'tailwindcss';`
       );
+    });
+
+    it('writes a src/App.tsx that fills the component registry', () => {
+      // objectui#4061, asserted where the user meets it. `SchemaRenderer` looks
+      // every node up in `ComponentRegistry` and renders "Unknown component
+      // type" on a miss; registration happens as a side effect of importing
+      // `@object-ui/components`, and `@object-ui/react` does not depend on that
+      // package — so before this the scaffold's whole visible output was error
+      // boxes for all three templates.
+      //
+      // `app-generator.test.ts` judges the file MAP structurally (declared vs
+      // imported, both directions); this asserts `init()` actually writes it,
+      // which is the half a unit test on the builder cannot see.
+      const app = readFileSync(join(appDir, 'src/App.tsx'), 'utf-8');
+      expect(app).toContain(`import '@object-ui/components';`);
+      expect(app).toContain(`import { SchemaRenderer } from '@object-ui/react';`);
+      // The manifest half was already there — the defect was that it was
+      // declared and never imported, so pin both ends together.
+      const manifest = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf-8')) as {
+        dependencies: Record<string, string>;
+      };
+      expect(manifest.dependencies['@object-ui/components']).toBeDefined();
+      // No plugin dependency is imported that the manifest does not declare:
+      // the three templates name only types `@object-ui/components` registers.
+      expect(app).not.toContain('@object-ui/plugin-');
+    });
+
+    it('writes a src/index.css that loads the library stylesheet', () => {
+      // objectui#4062. The theme utilities the templates lean on resolve through
+      // tokens declared in a `@theme` block that `files` does not publish, so an
+      // installed consumer can only get them from the prebuilt
+      // `@object-ui/components/style.css` — a real export
+      // (`"./style.css": "./dist/index.css"`), and per objectui#3884 a strict
+      // superset of anything a `node_modules` scan yields.
+      const css = readFileSync(join(appDir, 'src/index.css'), 'utf-8');
+      expect(css).toContain(`@import '@object-ui/components/style.css';`);
+      // Tailwind entry stays first (the assertion above must not be satisfied by
+      // a file that reordered the entrypoint).
+      expect(css.indexOf(`@import 'tailwindcss';`)).toBe(0);
+      // `@object-ui/fields` ships zero CSS at 17.3.0 and is not a dependency of
+      // this scaffold, so quick-start's second line is deliberately not copied
+      // (objectui#4059).
+      expect(css).not.toContain('@object-ui/fields');
+    });
+
+    it('writes exactly the file map buildInitFiles returns, byte for byte', () => {
+      // The equivalence the two structural gates in `app-generator.test.ts` rest
+      // on: they judge `buildInitFiles`, so a file `init()` wrote some other way
+      // would be judged by nothing. Every generated path and its bytes, both
+      // directions — an extra file on disk fails as loudly as a missing one.
+      //
+      // A failure here can also mean `dist/cli.js` is stale relative to
+      // `src/commands/init.ts` — `beforeAll` only builds when the bundle is
+      // absent. Rebuild the package before reading it as a real defect.
+      const files = buildInitFiles('sample-app', 'simple');
+
+      const walk = (dir: string, prefix = ''): string[] =>
+        readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+          entry.isDirectory()
+            ? walk(join(dir, entry.name), `${prefix}${entry.name}/`)
+            : [`${prefix}${entry.name}`],
+        );
+
+      expect(walk(appDir).sort()).toEqual(Object.keys(files).sort());
+      expect(
+        Object.fromEntries(
+          Object.keys(files).map((relativePath) => [
+            relativePath,
+            readFileSync(join(appDir, relativePath), 'utf-8'),
+          ]),
+        ),
+      ).toEqual(files);
     });
 
     it('versions the scaffold against the CLI that wrote it, not a literal', () => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import chalk from 'chalk';
 
 import {
@@ -399,41 +399,29 @@ export function buildInitPackageJson(name: string): Record<string, unknown> {
   };
 }
 
-export async function init(name: string, options: InitOptions) {
-  const cwd = process.cwd();
-  const projectDir = join(cwd, name);
-
-  // Check if directory already exists
-  if (existsSync(projectDir) && name !== '.') {
-    throw new Error(`Directory "${name}" already exists. Please choose a different name.`);
-  }
-
-  const targetDir = name === '.' ? cwd : projectDir;
-
-  // Create project directory if needed
-  if (name !== '.') {
-    mkdirSync(projectDir, { recursive: true });
-  }
-
-  console.log(chalk.blue('🎨 Creating Object UI application...'));
-  console.log(chalk.dim(`   Template: ${options.template}`));
-  console.log();
-
-  // Get template
-  const template = templates[options.template as keyof typeof templates];
+/**
+ * Every file `objectui init` writes, as `relative path -> contents`.
+ *
+ * Split out of `init()` for the same reason `buildInitPackageJson` was
+ * (objectui#3892): the command writes with `fs` directly, so until the map is a
+ * value there is nothing for a structural gate to judge. `app-generator.ts`
+ * exports `buildAppFiles` / `buildRoutedAppFiles` for exactly this, and the two
+ * gates `app-generator.test.ts` runs over those maps — every import declared,
+ * every versioned declaration imported — are what objectui#4061 and
+ * objectui#4062 were both invisible to. This scaffold is the third generator and
+ * had never been under either.
+ *
+ * `init()` below writes this map and nothing else, and a test pins that
+ * equivalence through the real bin, so the map cannot drift from the artifact.
+ */
+export function buildInitFiles(name: string, templateName: string): Record<string, string> {
+  const template = templates[templateName as keyof typeof templates];
   if (!template) {
     throw new Error(
-      `Unknown template: ${options.template}\nAvailable templates: ${Object.keys(templates).join(', ')}`
+      `Unknown template: ${templateName}\nAvailable templates: ${Object.keys(templates).join(', ')}`
     );
   }
 
-  // Create schema file
-  const schemaPath = join(targetDir, 'app.json');
-  writeFileSync(schemaPath, JSON.stringify(template, null, 2));
-
-  console.log(chalk.green('✓ Created app.json'));
-
-  // Create README
   const readme = `# ${name}
 
 An Object UI application built from JSON schemas.
@@ -477,10 +465,6 @@ Edit \`app.json\` to customize your application. The dev server will automatical
 Built with ❤️ using [Object UI](https://www.objectui.org)
 `;
 
-  writeFileSync(join(targetDir, 'README.md'), readme);
-  console.log(chalk.green('✓ Created README.md'));
-
-  // Create .gitignore
   const gitignore = `.objectui-tmp
 node_modules
 dist
@@ -488,14 +472,6 @@ dist
 *.log
 `;
 
-  writeFileSync(join(targetDir, '.gitignore'), gitignore);
-  console.log(chalk.green('✓ Created .gitignore'));
-
-  // Create package.json
-  writeFileSync(join(targetDir, 'package.json'), JSON.stringify(buildInitPackageJson(name), null, 2));
-  console.log(chalk.green('✓ Created package.json'));
-
-  // Create vite.config.ts
   const viteConfig = `import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -507,9 +483,6 @@ export default defineConfig({
 });
 `;
 
-  writeFileSync(join(targetDir, 'vite.config.ts'), viteConfig);
-  console.log(chalk.green('✓ Created vite.config.ts'));
-
   // No tailwind.config.js is written: this scaffold's CSS pipeline is Tailwind 4
   // (`postcss.config.js` names `@tailwindcss/postcss`, `src/index.css` does
   // `@import 'tailwindcss'`), and v4 reads a JS config only when a stylesheet
@@ -519,7 +492,6 @@ export default defineConfig({
   // `src/**` from the project root. objectui#3852 removed the same dead file
   // from the temp-app generators; objectui#3892 removes it here.
 
-  // Create postcss.config.js
   const postcssConfig = `export default {
   plugins: {
     '@tailwindcss/postcss': {},
@@ -528,10 +500,6 @@ export default defineConfig({
 };
 `;
 
-  writeFileSync(join(targetDir, 'postcss.config.js'), postcssConfig);
-  console.log(chalk.green('✓ Created postcss.config.js'));
-
-  // Create index.html
   const indexHtml = `<!doctype html>
 <html lang="en">
   <head>
@@ -546,21 +514,29 @@ export default defineConfig({
 </html>
 `;
 
-  writeFileSync(join(targetDir, 'index.html'), indexHtml);
-  console.log(chalk.green('✓ Created index.html'));
-
-  // Create src directory and source files
-  const srcDir = join(targetDir, 'src');
-  mkdirSync(srcDir, { recursive: true });
-
-  // Create src/index.css
+  // The component library's PREBUILT stylesheet, not a `@source` scan of it.
+  //
+  // The theme utilities these templates lean on (`text-muted-foreground` and
+  // `bg-muted/10` in `simple`/`dashboard`, `shadow-sm` on every `card`) resolve
+  // through tokens declared in a `@theme` block that lives in
+  // `packages/components/src/index.css` — a file `files` does not publish, so an
+  // installed consumer cannot compile it and cannot obtain those tokens by
+  // scanning `node_modules` either. objectui#3884 measured both halves against a
+  // real install: the full class surface a `node_modules` glob reaches is 1331
+  // rules, all of them already inside the published `dist/index.css`'s 1410 — the
+  // prebuilt sheet is a strict superset, and the `@source` lines are the
+  // redundant ~100 kB. `@object-ui/components` exports it as `./style.css`
+  // (objectui#4062).
+  //
+  // Components only. `@object-ui/fields` publishes a `style.css` too and
+  // quick-start names it, but `@object-ui/fields@17.3.0` ships ZERO css
+  // (measured on the published tarball, objectui#4059) and this scaffold does not
+  // depend on it — importing it would be a declaration in the wrong direction
+  // (objectui#3755) pointing at an empty file.
   const indexCss = `@import 'tailwindcss';
+@import '@object-ui/components/style.css';
 `;
 
-  writeFileSync(join(srcDir, 'index.css'), indexCss);
-  console.log(chalk.green('✓ Created src/index.css'));
-
-  // Create src/main.tsx
   const mainTsx = `import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
@@ -573,11 +549,27 @@ createRoot(document.getElementById('root')!).render(
 );
 `;
 
-  writeFileSync(join(srcDir, 'main.tsx'), mainTsx);
-  console.log(chalk.green('✓ Created src/main.tsx'));
-
-  // Create src/App.tsx
+  // `import '@object-ui/components'` is what fills the component registry, and
+  // nothing else does it.
+  //
+  // `SchemaRenderer` resolves each node through `ComponentRegistry.get(type)`
+  // and renders `Unknown component type: <type>` on a miss; registration happens
+  // as a side effect of importing `@object-ui/components`, which
+  // `@object-ui/react` does not depend on. Without this line every node of all
+  // three templates — `div`, `card`, `text`, `button`, `input`, `textarea` — took
+  // the miss path, so the scaffold's entire visible output was error boxes
+  // (objectui#4061).
+  //
+  // Components alone, no `@object-ui/plugin-*`: all six types above are
+  // registered by this one package (measured), and none of the three templates
+  // names a plugin type. The temp-app generator imports nine packages because it
+  // renders arbitrary user schemas; adding nine dependencies to a minimal
+  // scaffold that uses none of them is the declared-but-unused direction
+  // objectui#3755 removed.
   const appTsx = `import { SchemaRenderer } from '@object-ui/react';
+// Registers the component renderers SchemaRenderer looks up. Side-effect
+// import — removing it makes every node render "Unknown component type".
+import '@object-ui/components';
 import schema from '../app.json';
 
 export default function App() {
@@ -585,10 +577,6 @@ export default function App() {
 }
 `;
 
-  writeFileSync(join(srcDir, 'App.tsx'), appTsx);
-  console.log(chalk.green('✓ Created src/App.tsx'));
-
-  // Create tsconfig.json
   const tsconfig = {
     compilerOptions: {
       target: 'ES2020',
@@ -611,8 +599,52 @@ export default function App() {
     include: ['src'],
   };
 
-  writeFileSync(join(targetDir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
-  console.log(chalk.green('✓ Created tsconfig.json'));
+  // Insertion order is the order `init()` writes and logs them.
+  return {
+    'app.json': JSON.stringify(template, null, 2),
+    'README.md': readme,
+    '.gitignore': gitignore,
+    'package.json': JSON.stringify(buildInitPackageJson(name), null, 2),
+    'vite.config.ts': viteConfig,
+    'postcss.config.js': postcssConfig,
+    'index.html': indexHtml,
+    'src/index.css': indexCss,
+    'src/main.tsx': mainTsx,
+    'src/App.tsx': appTsx,
+    'tsconfig.json': JSON.stringify(tsconfig, null, 2),
+  };
+}
+
+export async function init(name: string, options: InitOptions) {
+  const cwd = process.cwd();
+  const projectDir = join(cwd, name);
+
+  // Check if directory already exists
+  if (existsSync(projectDir) && name !== '.') {
+    throw new Error(`Directory "${name}" already exists. Please choose a different name.`);
+  }
+
+  const targetDir = name === '.' ? cwd : projectDir;
+
+  // Create project directory if needed
+  if (name !== '.') {
+    mkdirSync(projectDir, { recursive: true });
+  }
+
+  console.log(chalk.blue('🎨 Creating Object UI application...'));
+  console.log(chalk.dim(`   Template: ${options.template}`));
+  console.log();
+
+  // Writes the file map and nothing else — see `buildInitFiles`. Unknown
+  // templates still throw here, before the first write.
+  for (const [relativePath, contents] of Object.entries(
+    buildInitFiles(name, options.template)
+  )) {
+    const target = join(targetDir, relativePath);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+    console.log(chalk.green(`✓ Created ${relativePath}`));
+  }
 
   console.log();
   console.log(chalk.green('✨ Application created successfully!'));


### PR DESCRIPTION
Fixes #4061
Fixes #4062

A sweep pair: both cards are one generated file each in `packages/cli/src/commands/init.ts`, and both are the same defect shape in opposite directions — the scaffold declared `@object-ui/components` and never imported it, and never loaded the stylesheet that package publishes. Both premises were re-verified against post-#4063 `origin/main` (`0a09793f2`) before implementing; both still held, at the exact lines the issues cite.

## Per-item checklist

| # | Landing point | Before | After |
|---|---|---|---|
| 1 (#4061) | generated `src/App.tsx` | `import { SchemaRenderer } from '@object-ui/react';` was the only `@object-ui/*` import | plus a side-effect `import '@object-ui/components';` (and a two-line comment saying why it is not removable) |
| 2 (#4062) | generated `src/index.css` | `@import 'tailwindcss';` — the whole file | plus `@import '@object-ui/components/style.css';` on the next line |
| 3 (both) | `init.ts` structure | `init()` wrote 11 files inline with `fs`, so no gate could judge them | exported `buildInitFiles(name, template)` returns the file map; `init()` writes that map and nothing else |
| 4 (both) | `app-generator.test.ts` | its two import/declaration gates ran over the two temp-app generators only | both gates now also judge the init file map, plus a `generated init scaffold sources` block |
| 5 (both) | `cli-bin.test.ts` | init assertions covered the manifest and the absent `tailwind.config.js` | three cases through the real bin: registry import, stylesheet import, and map-equals-disk byte for byte |

`git diff --stat` is 1:1 with that list — 4 files, nothing outside the declared surface. `doctor.ts` (in-flight #3891) is untouched, and so are `app-generator.ts` and `scaffold-dependencies.ts`.

## Why item 3 was necessary

Both cards ask for `app-generator.test.ts`'s two gates to be ported onto the init generator. Those gates take a file map as input; `init()` had no map — it called `writeFileSync` eleven times. `buildInitFiles` is the same split `buildInitPackageJson` already received in #3892, and the same shape `app-generator.ts` has exported as `buildAppFiles` all along. It is additive: nothing outside this file reads it except the tests.

The refactor is behaviour-preserving, and that is measured rather than argued. I scaffolded all three templates with the real bin built from `origin/main`, then again from this branch, and diffed the two trees:

```
diff -ru before/ after/    # 3 templates x 11 files
```

The entire diff is the two lines in the table above, repeated once per template. Every other byte of all 33 generated files — `app.json`, `README.md`, `.gitignore`, `package.json`, `vite.config.ts`, `postcss.config.js`, `index.html`, `src/main.tsx`, `tsconfig.json` — is identical, including the per-file `Created ...` console lines and their order.

## Why components only, and no plugins

#4061 left this cell open. Measured rather than assumed: the distinct node types across all three templates are exactly `button`, `card`, `div`, `input`, `text`, `textarea`, and every one of them is registered by `@object-ui/components` itself (checked against that package's `ComponentRegistry.register` calls — 112 types). No template names a plugin type. The temp-app generator imports nine packages because it renders arbitrary user schemas; adding nine dependencies to a minimal scaffold that uses none of them is the declared-but-unused direction #3755 removed. A test pins the six-type set, so a future template that adds a plugin type fails here instead of silently rendering an error box.

## Why the components stylesheet only, and not fields

#4062 left this cell open too. `@object-ui/components` declares `"./style.css": "./dist/index.css"` with `dist` in `files` — a real published export. `@object-ui/fields` is deliberately **not** imported: it is not a dependency of this scaffold, and per the published-tarball measurement on #4059 `@object-ui/fields@17.3.0` ships zero CSS, so copying quick-start's second line would point an import at an empty file from a package the manifest does not declare.

The gate is written as a rule, not a string pin: of the scaffold's runtime `@object-ui/*` dependencies, exactly those whose `package.json` declares a `./style.css` export must be imported by the generated CSS. That is discriminating in both directions here — `components` exports one, `react` exports none.

Quote style: the scaffold's existing line is single-quoted (`@import 'tailwindcss';`) and an existing test pins that spelling, so the new line is single-quoted to match. CSS treats both identically; the issue title's double quotes carry no semantics.

## Flagged for the maintainer, deliberately unchanged

#4062's second open cell is out of scope here and nothing about it was touched: the scaffold's Tailwind 4 pipeline is `@tailwindcss/postcss` + `autoprefixer` in `postcss.config.js`, while `content/docs/guide/quick-start.md` teaches `@tailwindcss/vite`. Both are valid Tailwind 4 setups and this fix is correct under either, but a new user reads the two pages as one story. Left for a ruling rather than guessed at.

Second observation, same character: the temp-app generator solves the styling problem a different way — it inlines the theme tokens into the CSS it generates (`APP_THEME_TOKENS`) instead of importing the published sheet. That is coherent for a temp app resolved against the workspace, and the import is the right answer for a scaffold that installs published packages, but the two generators now diverge on styling strategy by design rather than by accident. Noted, not changed.

## Verification

Local, from the repo root:

- `pnpm exec vitest run packages/cli/ --maxWorkers=2` — **76 passed (76)**, 3 files. 12 of those cases are new.
- `pnpm --filter @object-ui/cli type-check` — clean.
- `pnpm --filter @object-ui/cli lint` — 0 errors. The 19 warnings are pre-existing and none is in `init.ts`; the two in `cli-bin.test.ts` (`execFileSync`, `rmSync` unused) predate this branch.
- Control-byte self-scan over the three edited files — clean.

**Reverse verification** — direction predicted before running, then run: with both lines deleted from `init.ts` and the bundle rebuilt, **6 tests go red**, and the split is itself informative.

Red, as predicted:

```
AssertionError: expected [ '@object-ui/components' ] to deeply equal []
  packages/cli/src/__tests__/app-generator.test.ts:473
```

- `declares no versioned runtime dependency the generated sources never import` — the ported gate, naming the package
- `imports the package registration is a side effect of`
- `imports the published stylesheet of every declared dependency that ships one`
- `keeps the Tailwind entry first, so the library sheet cannot precede it`
- `writes a src/App.tsx that fills the component registry` (real bin)
- `writes a src/index.css that loads the library stylesheet` (real bin)

Green, also as predicted, and worth stating because it is the asymmetry the two gates have by construction: the **other** gate, `declares every package the generated sources import`, stays green — removing an import cannot create an undeclared one, so only the reverse-direction gate can catch this defect class. That is precisely why #4061 survived #3892, which extended the anchor table but not these gates. The two self-tests (`reports @object-ui/components as unused when the registration import is removed`, `is missing that stylesheet when the pre-fix CSS is restored`) also stay green by design — they plant the pre-fix text back themselves, so they are gates on the rule rather than on the fix.

**What was NOT verified**, stated plainly: no `npm install` of the published packages was run. CI does not install a scaffolded project against the registry, and neither did I. The evidence for #4062 is therefore structural and documentary — the export exists in `packages/components/package.json`, and #3884's matrix measured the prebuilt sheet as a strict superset (1410 rules vs the 1331 a `node_modules` scan reaches) of what a consumer can otherwise obtain. The claim that the missing import costs a specific rule count in a real install remains unmeasured, as #4062 itself notes.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_