### PR TITLE
fix(plugin-form): seed create forms from the object schema's declared defaults

### DIFF
--- a/.changeset/create-form-seeds-declared-defaults-4047.md
+++ b/.changeset/create-form-seeds-declared-defaults-4047.md
@@ -1,0 +1,45 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+Create forms now open with the object schema's declared `defaultValue`s
+
+A field declared `required: true, defaultValue: 'draft'` opened the console's
+create dialog with an empty select and a required marker: the user had to pick a
+value the system already knew, with every neighbouring option — some with side
+effects — one click away. `defaultValue` + `required` produced the worst create
+experience of any modelling choice, strictly worse than declaring no default.
+
+The server was never the problem. Omitting the field from a create request
+stores the declared default, because `ObjectQL.applyFieldDefaults` resolves it on
+insert. The gap was container-side: `ObjectForm` seeded its opening values from
+the object schema, and the five other object-form containers did not — their
+create branch set the form data to `initialData || initialValues || {}` and never
+looked at the schema. The console's create dialog is the global `<ModalForm>`,
+one of those five. Modal, Drawer, Tabbed, Split and Wizard now seed through one
+shared module (`schemaDefaults`), so a create form opens preselected and
+submittable.
+
+Three boundaries came with it, each pinned in both directions:
+
+- **Create only.** An edit form shows a persisted row as the server holds it.
+  `ObjectForm`'s pass had been running in every mode, so a column the record
+  leaves unset showed the default — arming a silent write of a value the user
+  never chose on the next save of any other field. It is now gated on the same
+  "no persisted record" test the data-fetch effect uses.
+- **Static defaults only.** A `defaultValue` may be an instruction the server
+  resolves per insert — the `NOW()` / `current_user` runtime tokens
+  (`DEFAULT_VALUE_TOKENS`) or a CEL Expression envelope. `ObjectForm` had been
+  seeding those verbatim, which put the literal text `NOW()` into a datetime
+  input and then submitted it as the field's value, suppressing the very
+  resolution the declaration asked for (`applyFieldDefaults` only fills fields
+  that arrive empty). Those are now left empty for the server.
+- **Callers still win.** `initialData` / `initialValues` outrank a schema
+  default — a lookup prefill or a duplicate-record seed is the more specific
+  instruction.
+
+Only the field-level `defaultValue` is honoured, not a select option's
+`default: true`, even though `@objectstack/spec`'s `SelectOptionSchema` declares
+that key: the insert path resolves `defaultValue` and nothing else, so seeding
+from option-level `default` would preselect values the server would never have
+applied — a UI-only second default contract.

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -236,6 +236,15 @@ Add a "New Task" button and handle row clicks to open the edit form:
 
 The form automatically renders the correct field widgets (text inputs, select dropdowns, date pickers) based on your `FieldMetadata` definitions. Validation rules like `required` are enforced out of the box.
 
+In **create** mode the form also opens with the `defaultValue`s your schema
+declares — the `status` and `priority` fields above start on `Todo` and
+`Medium`, already submittable, rather than empty next to a required marker.
+Only static defaults are seeded: a `defaultValue` that is a runtime token
+(`'NOW()'`, `'current_user'`) or a CEL expression is an instruction the server
+resolves at insert time, so the form leaves that field empty and lets it. In
+**edit** mode nothing is seeded — the form shows the record as stored. Values
+you pass as `initialData` / `initialValues` outrank a schema default.
+
 ## Step 7: Add Filters and Search
 
 Leverage the `active` list view you defined in Step 3, or add dynamic search:

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -83,6 +83,38 @@ interface FormField {
 }
 ```
 
+### What a create form opens with
+
+A create form has no persisted record, so its opening values come from the
+object schema's declared field `defaultValue`s. Every object-form container
+(`ObjectForm`, `ModalForm`, `DrawerForm`, `TabbedForm`, `SplitForm`,
+`WizardForm`) resolves them the same way, through `schemaDefaults`:
+
+| Declared | Create form opens with | Why |
+|---|---|---|
+| `defaultValue: 'draft'` (any static literal) | `draft`, preselected and submittable | the value is known; making the user pick it is busywork, and on a status-like field every wrong option is one click away |
+| `defaultValue: 'NOW()'` / `'current_user'` (a runtime token) | empty | the token is an *instruction*, not a value. The server resolves it at insert — but only for fields that arrive empty, so seeding the literal text would suppress it |
+| `defaultValue: cel\`today()\`` (an Expression envelope) | empty | same reason: the server evaluates it per insert |
+| an option's `default: true` | empty | see below |
+| nothing | empty | no default is invented |
+
+`initialData` / `initialValues` passed by the caller always outrank a schema
+default — a lookup prefill or a "duplicate this record" seed is the more
+specific instruction.
+
+Only the **field-level** `defaultValue` is read, never a select option's
+`default: true`, even though `@objectstack/spec`'s `SelectOptionSchema` declares
+that key. The server's insert path resolves `defaultValue` and nothing else, so
+a form that also seeded from option-level `default` would preselect values the
+server would never have applied on its own — a renderer-side second default
+contract (AGENTS.md #0.1). If option-level `default` is meant to mean "the
+initial value", that belongs at the producer.
+
+**Edit forms are never seeded.** An edit form shows the row as the server holds
+it; folding a default in over a column the record leaves unset would arm a
+silent write of a value the user never chose, on the next save of any other
+field.
+
 ### Column width of a sectioned form
 
 A sectioned form renders as ONE grid, and two keys decide its shape:

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -41,6 +41,7 @@ import { mapFieldTypeToFormType, buildValidationRules } from '@object-ui/fields'
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
 import { applyAutoLayout } from './autoLayout';
 import { sanitizeFormData } from './sanitize';
+import { seedCreateValues } from './schemaDefaults';
 import { useOccSave } from './occSave';
 
 /**
@@ -239,7 +240,10 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
     let cancelled = false;
     const fetchData = async () => {
       if (schema.mode === 'create' || !schema.recordId) {
-        setFormData(schema.initialData || schema.initialValues || {});
+        // Declared static defaults are this form's opening values (#4047) —
+        // see `schemaDefaults` for the create-only boundary and for why
+        // runtime defaults are left to the server.
+        setFormData(seedCreateValues(objectSchema, schema.initialData || schema.initialValues));
         setLoading(false);
         return;
       }

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -50,6 +50,7 @@ import {
 } from './autoLayout';
 import { deriveFieldGroupSections } from './fieldGroups';
 import { sanitizeFormData } from './sanitize';
+import { seedCreateValues } from './schemaDefaults';
 import { usePermissions } from '@object-ui/permissions';
 import { useOccSave } from './occSave';
 
@@ -313,7 +314,12 @@ export const ModalForm: React.FC<ModalFormProps> = ({
     let cancelled = false;
     const fetchData = async () => {
       if (schema.mode === 'create' || !schema.recordId) {
-        setFormData(schema.initialData || schema.initialValues || {});
+        // No persisted record to show, so the object's declared static
+        // `defaultValue`s are the form's opening values (#4047) — caller-
+        // supplied initial values still win. See `schemaDefaults` for why
+        // runtime defaults (`NOW()`, `current_user`, CEL envelopes) are left
+        // to the server and why option-level `default` is not read here.
+        setFormData(seedCreateValues(objectSchema, schema.initialData || schema.initialValues));
         setLoading(false);
         return;
       }

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -37,6 +37,7 @@ import {
 } from './autoLayout';
 import { deriveFieldGroupSections } from './fieldGroups';
 import { sanitizeFormData } from './sanitize';
+import { schemaDefaultValues } from './schemaDefaults';
 import { useOccSave } from './occSave';
 
 export interface ObjectFormProps {
@@ -816,21 +817,27 @@ const SimpleObjectForm: React.FC<ObjectFormProps> = ({
     }
   }, [schema]);
 
-  // Calculate default values from schema fields
-  const schemaDefaultValues = React.useMemo(() => {
-    if (!objectSchema?.fields) return {};
-    const defaults: Record<string, any> = {};
-    Object.keys(objectSchema.fields).forEach(key => {
-        const field = objectSchema.fields[key];
-        if (field.defaultValue !== undefined) {
-            defaults[key] = field.defaultValue;
-        }
-    });
-    return defaults;
-  }, [objectSchema]);
+  // The object's declared field defaults, as this form's opening values.
+  //
+  // CREATE ONLY (#4047). This pass used to run in every mode — on an edit form
+  // it folded a default under a persisted row, so a column the record leaves
+  // unset showed the default and the next save wrote a value the user never
+  // chose. `!recordId || mode === 'create'` is the same "no persisted record"
+  // test the data-fetch effect above uses, so the two cannot drift.
+  //
+  // It also used to seed `defaultValue` VERBATIM, including the runtime
+  // instructions the server resolves per insert (`NOW()`, `current_user`, CEL
+  // envelopes) — which put the literal text `NOW()` into a datetime input and
+  // then submitted it, suppressing the resolution the declaration asked for.
+  // `schemaDefaultValues` seeds static literals only; see that module.
+  const isCreateForm = !schema.recordId || schema.mode === 'create';
+  const schemaDefaults = React.useMemo(
+    () => (isCreateForm ? schemaDefaultValues(objectSchema) : {}),
+    [objectSchema, isCreateForm],
+  );
 
   const finalDefaultValues = {
-     ...schemaDefaultValues,
+     ...schemaDefaults,
      ...initialData
   };
 

--- a/packages/plugin-form/src/SplitForm.tsx
+++ b/packages/plugin-form/src/SplitForm.tsx
@@ -28,6 +28,7 @@ import type { FormField, DataSource } from '@object-ui/types';
 import { cn } from '@object-ui/components';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
+import { seedCreateValues } from './schemaDefaults';
 import { applyAutoColSpan, containerGridColsFor } from './autoLayout';
 import { useOccSave } from './occSave';
 
@@ -160,7 +161,10 @@ export const SplitForm: React.FC<SplitFormProps> = ({
     let cancelled = false;
     const fetchData = async () => {
       if (schema.mode === 'create' || !schema.recordId) {
-        setFormData(schema.initialData || schema.initialValues || {});
+        // Declared static defaults are this form's opening values (#4047) —
+        // see `schemaDefaults` for the create-only boundary and for why
+        // runtime defaults are left to the server.
+        setFormData(seedCreateValues(objectSchema, schema.initialData || schema.initialValues));
         setLoading(false);
         return;
       }

--- a/packages/plugin-form/src/TabbedForm.tsx
+++ b/packages/plugin-form/src/TabbedForm.tsx
@@ -18,6 +18,7 @@ import type { FormField, DataSource } from '@object-ui/types';
 import { cn } from '@object-ui/components';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
+import { seedCreateValues } from './schemaDefaults';
 import { applyAutoColSpan, containerGridColsFor } from './autoLayout';
 import { useOccSave } from './occSave';
 
@@ -241,7 +242,10 @@ export const TabbedForm: React.FC<TabbedFormProps> = ({
     let cancelled = false;
     const fetchData = async () => {
       if (schema.mode === 'create' || !schema.recordId || !dataSource) {
-        setFormData(schema.initialData || schema.initialValues || {});
+        // Declared static defaults are this form's opening values (#4047) —
+        // see `schemaDefaults` for the create-only boundary and for why
+        // runtime defaults are left to the server.
+        setFormData(seedCreateValues(objectSchema, schema.initialData || schema.initialValues));
         setLoading(false);
         return;
       }

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -22,6 +22,7 @@ import { createSafeTranslation } from '@object-ui/i18n';
 import { FormSectionContainer } from './FormSection';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
+import { seedCreateValues } from './schemaDefaults';
 import { applyAutoColSpan, containerGridColsFor } from './autoLayout';
 import { resolveSuccessNavigate, isSameOriginUrl, type SubmitBehavior } from './successBehavior';
 import { useOccSave } from './occSave';
@@ -284,7 +285,10 @@ export const WizardForm: React.FC<WizardFormProps> = ({
     const fetchData = async () => {
       if (schema.mode === 'create' || !schema.recordId || !dataSource) {
         if (!seededRef.current) {
-          setFormData(schema.initialData || schema.initialValues || {});
+          // Declared static defaults are this wizard's opening values (#4047)
+          // — see `schemaDefaults` for the create-only boundary and for why
+          // runtime defaults are left to the server.
+          setFormData(seedCreateValues(objectSchema, schema.initialData || schema.initialValues));
           seededRef.current = true;
         }
         setLoading(false);
@@ -461,8 +465,10 @@ export const WizardForm: React.FC<WizardFormProps> = ({
               break;
             }
             case 'continue':
-              // Back to a fresh step 1 for the next entry.
-              setFormData({});
+              // Back to a fresh step 1 for the next entry — "fresh" means the
+              // same opening values the wizard had, defaults included (#4047),
+              // not a blank object the first entry never started from.
+              setFormData(seedCreateValues(objectSchema, schema.initialData || schema.initialValues));
               setCompletedSteps(new Set());
               setCurrentStep(0);
               setResetNonce((n) => n + 1);
@@ -490,8 +496,9 @@ export const WizardForm: React.FC<WizardFormProps> = ({
           }
           toast.success(schema.successMessage || (schema.mode === 'create' ? 'Created' : 'Saved'));
           if (schema.resetOnSuccess && schema.mode === 'create') {
-            // Back to a fresh step 1 for the next entry.
-            setFormData({});
+            // Back to a fresh step 1 for the next entry — same opening values
+            // as the first entry, defaults included (#4047).
+            setFormData(seedCreateValues(objectSchema, schema.initialData || schema.initialValues));
             setCompletedSteps(new Set());
             setCurrentStep(0);
             setResetNonce((n) => n + 1);
@@ -510,7 +517,7 @@ export const WizardForm: React.FC<WizardFormProps> = ({
       // Move to next step
       goToStep(currentStep + 1);
     }
-  }, [formData, currentStep, isLastStep, schema, dataSource, missingRequiredByStep, t, saveWithOcc]);
+  }, [formData, currentStep, isLastStep, schema, objectSchema, dataSource, missingRequiredByStep, t, saveWithOcc]);
 
   // Navigation
   const goToStep = useCallback((step: number) => {

--- a/packages/plugin-form/src/createDefaults.test.tsx
+++ b/packages/plugin-form/src/createDefaults.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A CREATE form seeds the object schema's declared `defaultValue`s (#4047).
+ *
+ * `ObjectForm` has always done this; the four sectioned/overlay containers
+ * (Modal / Drawer / Tabbed / Split) and the wizard did not — their create
+ * branch set the form data to `initialData || initialValues || {}` and never
+ * looked at the object schema. The console's create dialog IS the global
+ * `<ModalForm>`, so a field declared `required: true, defaultValue: 'draft'`
+ * opened with an empty select and a required marker: the user had to pick a
+ * value the system already knew, and every neighbouring option (some with side
+ * effects) was one click away.
+ *
+ * Four directions are pinned here, because "seed the defaults" is wrong in
+ * three of them:
+ *
+ *   1. create + declared default        → preselected AND submittable
+ *   2. create + no default              → still empty (no invention)
+ *   3. edit                             → the STORED record wins; a default is
+ *      never folded in over a persisted row (an edit form must not silently
+ *      rewrite a column the user never touched)
+ *   4. create + a RUNTIME default       → left empty for the server. `NOW()` /
+ *      `current_user` (`DEFAULT_VALUE_TOKENS`) and CEL Expression envelopes are
+ *      instructions, not values: seeding them literally would put the text
+ *      `NOW()` into a datetime input and submit it as the field's value, which
+ *      is strictly worse than today's empty control. The engine resolves them
+ *      at insert time for exactly the omitted-field case.
+ *
+ * Caller-supplied `initialData` / `initialValues` outrank a schema default in
+ * every case — they are the more specific instruction (a lookup prefill, a
+ * "duplicate this record" seed).
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectForm } from './ObjectForm';
+import { ModalForm } from './ModalForm';
+import { DrawerForm } from './DrawerForm';
+import { TabbedForm } from './TabbedForm';
+import { SplitForm } from './SplitForm';
+
+registerAllFields();
+
+const STATUS_OPTIONS = [
+  { label: 'Draft', value: 'draft', default: true },
+  { label: 'Pending Approval', value: 'pending' },
+  { label: 'Approved', value: 'approved' },
+  { label: 'Rejected', value: 'rejected' },
+];
+
+/** The reported object: a required select carrying a field-level default. */
+const OBJECT_SCHEMA = {
+  name: 'rating',
+  fields: {
+    title: { type: 'text', label: 'Title' },
+    // The reported field — both spellings present, as in the issue.
+    status: { type: 'select', label: 'Status', required: true, defaultValue: 'draft', options: STATUS_OPTIONS },
+    // No default at all: must stay untouched.
+    stage: { type: 'select', label: 'Stage', options: [{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }] },
+  },
+};
+
+const makeDS = (objectSchema: any = OBJECT_SCHEMA, record?: any) =>
+  ({
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    create: vi.fn().mockResolvedValue({ id: 'r1' }),
+    update: vi.fn().mockResolvedValue({ id: 'r1' }),
+    findOne: vi.fn().mockResolvedValue(record ?? { id: 'r1' }),
+  }) as any;
+
+const SECTIONS = [{ name: 'basics', label: 'Basics', fields: ['title', 'status', 'stage'] }];
+
+/** The label a select trigger currently displays (placeholder when unset). */
+const triggerText = (field: string) =>
+  document.body.querySelector(`[data-testid="select-trigger-${field}"]`)?.textContent ?? '';
+
+const submit = () => {
+  const form = document.body.querySelector('form') as HTMLFormElement;
+  fireEvent.submit(form);
+};
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => cleanup());
+
+/**
+ * The four sectioned containers share one create branch, so they are pinned as
+ * one table. `ObjectForm` (the flat container) is covered separately below —
+ * it already seeded, and the point there is that it still does.
+ */
+const CONTAINERS: Array<[string, React.ComponentType<any>, string]> = [
+  ['ModalForm', ModalForm as any, 'modal'],
+  ['DrawerForm', DrawerForm as any, 'drawer'],
+  ['TabbedForm', TabbedForm as any, 'tabbed'],
+  ['SplitForm', SplitForm as any, 'split'],
+];
+
+describe.each(CONTAINERS)('%s — create-mode default seeding (#4047)', (_name, Container, formType) => {
+  const renderCreate = (ds: any, extra: Record<string, unknown> = {}) =>
+    render(
+      <Container
+        schema={{
+          type: 'object-form',
+          formType,
+          objectName: 'rating',
+          mode: 'create',
+          open: true,
+          sections: SECTIONS,
+          ...extra,
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+  it('preselects a declared `defaultValue` and submits it without a manual choice', async () => {
+    const ds = makeDS();
+    renderCreate(ds);
+
+    await waitFor(() => expect(triggerText('status')).toContain('Draft'));
+
+    submit();
+    await waitFor(() => expect(ds.create).toHaveBeenCalled());
+    expect(ds.create.mock.calls[0][1]).toMatchObject({ status: 'draft' });
+  });
+
+  it('leaves a field with no declared default empty', async () => {
+    const ds = makeDS();
+    renderCreate(ds);
+
+    await waitFor(() => expect(triggerText('status')).toContain('Draft'));
+    expect(triggerText('stage')).not.toContain('A');
+    expect(triggerText('stage')).not.toContain('B');
+  });
+
+  it('lets caller-supplied initial values outrank the schema default', async () => {
+    const ds = makeDS();
+    renderCreate(ds, { initialData: { status: 'pending' } });
+
+    await waitFor(() => expect(triggerText('status')).toContain('Pending Approval'));
+  });
+
+  it('does not seed a runtime default token — the server resolves it at insert', async () => {
+    const ds = makeDS({
+      name: 'rating',
+      fields: {
+        title: { type: 'text', label: 'Title' },
+        remind_at: { type: 'datetime', label: 'Remind at', defaultValue: 'NOW()' },
+        assignee: { type: 'text', label: 'Assignee', defaultValue: 'current_user' },
+        note: { type: 'text', label: 'Note', defaultValue: { dialect: 'cel', source: 'today()' } },
+      },
+    });
+    render(
+      <Container
+        schema={{
+          type: 'object-form',
+          formType,
+          objectName: 'rating',
+          mode: 'create',
+          open: true,
+          sections: [{ name: 'basics', label: 'Basics', fields: ['title', 'remind_at', 'assignee', 'note'] }],
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const assigneeInput = await waitFor(() => {
+      const el = document.body.querySelector<HTMLInputElement>('[data-field="assignee"] input');
+      if (!el) throw new Error('assignee input not rendered');
+      return el;
+    });
+    expect(assigneeInput.value).toBe('');
+    expect(
+      document.body.querySelector<HTMLInputElement>('[data-field="note"] input')?.value ?? '',
+    ).toBe('');
+    expect(document.body.textContent).not.toContain('NOW()');
+  });
+
+  it('does not fold a schema default into an EDIT form over the stored record', async () => {
+    // The stored row does not carry `status` AT ALL — the sharp case. A row
+    // carrying `status: null` would hide a seeding bug behind the spread (the
+    // explicit null overwrites the default either way), so it proves nothing;
+    // an ABSENT key is what a leaking default actually shows up on. An edit
+    // form must show the row as the server holds it — seeding `draft` here
+    // would arm a silent write of a value the user never chose, the moment
+    // they save some unrelated field.
+    const ds = makeDS(OBJECT_SCHEMA, { id: 'r1', title: 'Acme' });
+    render(
+      <Container
+        schema={{
+          type: 'object-form',
+          formType,
+          objectName: 'rating',
+          mode: 'edit',
+          recordId: 'r1',
+          open: true,
+          sections: SECTIONS,
+        } as any}
+        dataSource={ds}
+      />,
+    );
+
+    await waitFor(() => expect(ds.findOne).toHaveBeenCalled());
+    await waitFor(() => {
+      const el = document.body.querySelector<HTMLInputElement>('[data-field="title"] input');
+      if (el?.value !== 'Acme') throw new Error('record not loaded yet');
+    });
+    expect(triggerText('status')).not.toContain('Draft');
+  });
+});
+
+describe('ObjectForm — create-mode default seeding stays put (#4047)', () => {
+  it('preselects a declared `defaultValue` on create', async () => {
+    const ds = makeDS();
+    render(
+      <ObjectForm
+        schema={{ type: 'object-form', objectName: 'rating', mode: 'create' } as any}
+        dataSource={ds}
+      />,
+    );
+
+    await waitFor(() => expect(triggerText('status')).toContain('Draft'));
+    submit();
+    await waitFor(() => expect(ds.create).toHaveBeenCalled());
+    expect(ds.create.mock.calls[0][1]).toMatchObject({ status: 'draft' });
+  });
+
+  it('does not seed a runtime default token on create', async () => {
+    const ds = makeDS({
+      name: 'rating',
+      fields: {
+        title: { type: 'text', label: 'Title' },
+        assignee: { type: 'text', label: 'Assignee', defaultValue: 'current_user' },
+      },
+    });
+    render(
+      <ObjectForm
+        schema={{ type: 'object-form', objectName: 'rating', mode: 'create' } as any}
+        dataSource={ds}
+      />,
+    );
+
+    const assigneeInput = await waitFor(() => {
+      const el = document.body.querySelector<HTMLInputElement>('[data-field="assignee"] input');
+      if (!el) throw new Error('assignee input not rendered');
+      return el;
+    });
+    expect(assigneeInput.value).toBe('');
+  });
+
+  it('does not fold a schema default into an EDIT form over the stored record', async () => {
+    // Absent key, not `status: null` — see the sectioned suite above for why
+    // the null variant cannot fail. This is the assertion that goes red if the
+    // create-only gate on the seeding pass is removed.
+    const ds = makeDS(OBJECT_SCHEMA, { id: 'r1', title: 'Acme' });
+    render(
+      <ObjectForm
+        schema={{ type: 'object-form', objectName: 'rating', mode: 'edit', recordId: 'r1' } as any}
+        dataSource={ds}
+      />,
+    );
+
+    await waitFor(() => expect(ds.findOne).toHaveBeenCalled());
+    await waitFor(() => {
+      const el = document.body.querySelector<HTMLInputElement>('[data-field="title"] input');
+      if (el?.value !== 'Acme') throw new Error('record not loaded yet');
+    });
+    expect(triggerText('status')).not.toContain('Draft');
+  });
+});

--- a/packages/plugin-form/src/schemaDefaults.ts
+++ b/packages/plugin-form/src/schemaDefaults.ts
@@ -1,0 +1,127 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Create-mode seeding of an object's declared field defaults (#4047).
+ *
+ * ## What this is for
+ *
+ * A CREATE form starts from a blank record, so the values it opens with are
+ * whatever the form puts there. `ObjectForm` derived them from the object
+ * schema's `defaultValue`s; the sectioned/overlay containers (Modal / Drawer /
+ * Tabbed / Split / Wizard) did not, and the console's create dialog is one of
+ * those — a field declared `required: true, defaultValue: 'draft'` opened
+ * empty, with a required marker, forcing the user to pick a value the system
+ * already knew (and putting every neighbouring option one click away).
+ *
+ * ## Which spelling is honoured, and why only that one
+ *
+ * `field.defaultValue` — and deliberately NOT a select option's `default: true`,
+ * even though `@objectstack/spec`'s `SelectOptionSchema` declares that key.
+ * The reason is the producer, not taste: the server's insert path
+ * (`ObjectQL.applyFieldDefaults`) resolves `field.defaultValue` and nothing
+ * else, which is exactly why omitting the field from a create request stores
+ * the declared default (measured on the reporting stack). A console that
+ * additionally seeded from option-level `default` would preselect values the
+ * server would never have applied — a second, UI-only default contract, which
+ * is the renderer-side dialect AGENTS.md #0.1 forbids. If option-level
+ * `default` is to mean "the initial value", that belongs at the producer.
+ *
+ * ## Which defaults are seeded, and why the rest are skipped
+ *
+ * Only STATIC defaults. A `defaultValue` may also be an *instruction* the
+ * server resolves per insert:
+ *
+ *   - a runtime token — `'NOW()'` / `'current_user'`, the whole
+ *     `DEFAULT_VALUE_TOKENS` family from `@objectstack/spec/data`
+ *   - a CEL Expression envelope — `{ dialect: 'cel', source: 'today()' }`
+ *
+ * Seeding those literally is worse than leaving the control empty: the string
+ * `NOW()` lands in a datetime input and is then SUBMITTED as that field's
+ * value, which suppresses the server-side resolution the declaration asked for
+ * (`applyFieldDefaults` only fills fields that arrive empty). Skipping them
+ * leaves the field absent from the create payload, which is precisely the case
+ * the engine resolves. `ObjectForm` had been seeding them verbatim — that is
+ * fixed here along with the missing-seeding half.
+ *
+ * ## Create only
+ *
+ * An EDIT form shows a persisted row and must show it as the server holds it.
+ * Folding a default in over a column the record leaves unset would arm a silent
+ * write of a value the user never chose, on the next save of any other field.
+ * Callers gate on create; this module never sees the mode.
+ */
+
+import { isRuntimeDefaultToken } from '@objectstack/spec/data';
+
+/** An object schema as the data source serves it (`{ fields: { [name]: def } }`). */
+interface ObjectSchemaLike {
+  fields?: Record<string, { defaultValue?: unknown } | undefined>;
+}
+
+/**
+ * Is `v` a CEL/template Expression envelope rather than a literal value?
+ *
+ * Same shape test the engine applies before handing a default to
+ * `ExpressionEngine` (`{ dialect, source }`), kept structural on purpose: the
+ * point is "the server evaluates this", which is true for every dialect.
+ */
+function isExpressionEnvelope(v: unknown): boolean {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as { dialect?: unknown }).dialect === 'string' &&
+    typeof (v as { source?: unknown }).source === 'string'
+  );
+}
+
+/**
+ * Can this declared `defaultValue` be used as a form's initial value as-is?
+ *
+ * True for static literals only — see the module docblock for why runtime
+ * tokens and Expression envelopes are left to the server.
+ */
+export function isSeedableDefault(v: unknown): boolean {
+  if (v === undefined || v === null) return false;
+  if (isRuntimeDefaultToken(v)) return false;
+  if (isExpressionEnvelope(v)) return false;
+  return true;
+}
+
+/**
+ * The static `defaultValue`s an object schema declares, as a form-values patch.
+ *
+ * Returns a fresh object (never shared), and `{}` for a missing/!object schema
+ * so callers can spread it unconditionally.
+ */
+export function schemaDefaultValues(objectSchema: ObjectSchemaLike | null | undefined): Record<string, unknown> {
+  const fields = objectSchema?.fields;
+  if (!fields || typeof fields !== 'object') return {};
+  const defaults: Record<string, unknown> = {};
+  for (const name of Object.keys(fields)) {
+    const dv = fields[name]?.defaultValue;
+    if (isSeedableDefault(dv)) defaults[name] = dv;
+  }
+  return defaults;
+}
+
+/**
+ * The initial values a CREATE form opens with: the schema's static defaults,
+ * overlaid with whatever the caller supplied.
+ *
+ * Caller values win — `initialData` / `initialValues` are the more specific
+ * instruction (a lookup prefill, a "duplicate this record" seed, a wizard
+ * carrying state forward), and an explicit `null` from a caller is a real
+ * "leave this blank", not an absence.
+ */
+export function seedCreateValues(
+  objectSchema: ObjectSchemaLike | null | undefined,
+  initial?: Record<string, unknown> | null,
+): Record<string, unknown> {
+  return { ...schemaDefaultValues(objectSchema), ...(initial ?? {}) };
+}


### PR DESCRIPTION
Fixes #4047

## Premise: confirmed, and the producer is one level up from where the card looked

The card's mechanism hypothesis was that seeding logic exists in `ObjectForm.tsx` and the create dialog "bypasses it — likely a wiring gap". Measured against `origin/main`, that is right about the symptom and wrong about the shape: there is nothing to wire. `ObjectForm` is not on the create dialog's path at all, and `ModalForm` is not a consumer of it — it is a **peer container with its own create branch**, which simply never read the object schema:

```
ModalForm.tsx (create branch, before)
  setFormData(schema.initialData || schema.initialValues || {});
```

The same line, verbatim, in `DrawerForm`, `TabbedForm`, `SplitForm` and `WizardForm`. `ObjectForm` (the flat container) was the only one of the six that seeded. The console's create dialog is the global `&lt;ModalForm&gt;` mounted by `app-shell`'s `AppContent`, so nothing in `app-shell` needed touching — the defect and the fix are both in `packages/plugin-form`.

Reproduced as a failing test before any source change (`createDefaults.test.tsx`, 9 red / 14 green on `origin/main`): the four sectioned containers all showed `expected 'Select an option' to contain 'Draft'`.

The card's server-side ruling held up independently: `ObjectQL.applyFieldDefaults` (`packages/objectql/src/engine.ts`) resolves `defaultValue` on the insert path for any field that arrives absent or null, which is exactly why the issue's `curl` that omits `status` stores `draft`.

## Which spelling is honoured — `defaultValue`, not the option's `default: true`

The card asked for this to be stated rather than invented, so: **field-level `defaultValue` only.**

Both spellings do exist in the spec vocabulary — `SelectOptionSchema` declares `default: z.boolean().optional()`. But the vocabulary is not the contract; the **insert path** is, and it reads `field.defaultValue` and nothing else. The only consumer of option-level `default` found anywhere on the platform is a nullability heuristic in `packages/lint/src/validate-expressions.ts` (`isNullableField`), which is an analysis, not an application.

So a form that also seeded from option-level `default` would preselect a value the server would **not** have applied had the field been omitted — a UI-only default that disagrees with the stored outcome. That is the renderer-side second dialect AGENTS.md #0.1 forbids. No precedence is invented here: one key is honoured because one key is enforced. If option-level `default` is meant to mean "the initial value", that belongs at the producer, not here.

## Three boundaries, each pinned in both directions

**1. Create only.** `ObjectForm`'s pass ran in *every* mode:

```ts
const finalDefaultValues = { ...schemaDefaultValues, ...initialData };   // before
```

`initialData` wins for keys the record **carries**, so a stored `null` was safe — but a key the record omits entirely fell through to the default. An edit form then displayed `Draft` on a column the row has never had set, arming a silent write of a value the user never chose on the next save of any other field. It is now gated on `!schema.recordId || schema.mode === 'create'` — deliberately the same "no persisted record" test the data-fetch effect two hundred lines above already uses, so the two cannot drift apart. The sectioned containers seed inside their existing create branch and never touch the edit path.

The edit-direction test uses a record that **omits** `status` rather than one carrying `status: null`. The null variant passes with or without the gate (the explicit null overwrites the default either way) — it would have been green for an empty reason. Reverse-verified: replacing the gate with `true` turns exactly that assertion red, `expected 'Draft' not to contain 'Draft'`, and nothing else.

**2. Static defaults only — and this half is a fix in its own right.** A `defaultValue` may be an *instruction* the server resolves per insert: the `NOW()` / `current_user` runtime tokens (`DEFAULT_VALUE_TOKENS`) or a CEL Expression envelope `{ dialect, source }`. `ObjectForm` had been seeding those **verbatim**, which the red baseline measured directly:

```
ObjectForm > does not seed a runtime default token on create
  → expected 'current_user' to be ''
```

That puts the literal text `NOW()` into a datetime input and then submits it as the field's value — which suppresses the very resolution the declaration asked for, since `applyFieldDefaults` only fills fields that arrive empty. Roughly a hundred platform objects declare `defaultValue: 'NOW()'`, so propagating the old behaviour into the console's create dialog would have been a regression shipped under a bug fix. `schemaDefaults` seeds literals only, using the spec's own `isRuntimeDefaultToken` predicate rather than a local copy of the token list.

**3. Callers still win.** `initialData` / `initialValues` outrank a schema default — a lookup prefill or a duplicate-record seed is the more specific instruction.

## Scope

One shared module, `packages/plugin-form/src/schemaDefaults.ts`, consumed by all six containers. Fixing only `ModalForm` would have left the identical line in four siblings, so the same card returns the moment an object's form view is authored as a drawer or a wizard; the wizard's "create another" reset is included for the same reason (a second entry must open like the first). No `GridField` / grid-column file is touched, per the declared region exclusion against #3569.

## Verification

- `vitest run packages/plugin-form` — **39 files, 375 tests passed**.
- `vitest run packages/plugin-view packages/plugin-designer packages/app-shell` — **326 files, 3056 passed, 1 skipped** (the consumers of these containers).
- `pnpm --filter @object-ui/plugin-form type-check` — clean (`tsc --noEmit` + type tests), after building the dependency closure `--filter '@object-ui/plugin-form^...'`.
- `pnpm --filter @object-ui/plugin-form lint` — 0 errors.
- `node scripts/check-control-bytes.mjs` — OK.
- Before/after on the new suite: 9 failed / 14 passed → 23 passed.

Changeset: `.changeset/create-form-seeds-declared-defaults-4047.md` (patch, user-visible). Docs updated per AGENTS.md #2 — `packages/plugin-form/README.md` gains a "What a create form opens with" table, and `content/docs/guide/building-crud-app.md` step 6 states the create/edit split.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_