### PR TITLE
test(e2e): assert a boot state the console actually settles in — `Build & E2E` main red (#4086)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,12 +535,28 @@ jobs:
         if: steps.relevant.outputs.should_run == 'true'
         run: pnpm test:e2e --project=chromium
 
+      # `playwright.config.ts` selects the `github` reporter when CI is set, and
+      # that reporter writes annotations only — it produces NO
+      # `playwright-report/` directory, so this step uploaded nothing and said
+      # so in a warning rather than a failure: `No files were found with the
+      # provided path: playwright-report/` (objectui#4086). Every failure's
+      # actual evidence — screenshot, trace and `error-context.md` — is written
+      # by the `use.screenshot` / `use.trace` settings into `test-results/`
+      # instead, which is why a red E2E job left nothing behind to diagnose and
+      # #4086 had to be reproduced from scratch locally.
+      #
+      # Both paths are listed: `test-results/` is the one that exists today, and
+      # `playwright-report/` keeps working if the HTML reporter is ever enabled
+      # on CI. upload-artifact only warns when NO path matches, so the absent
+      # one costs nothing.
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: ${{ steps.relevant.outputs.should_run == 'true' && !cancelled() && failure() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/
           retention-days: 14
 
   docs:

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -75,16 +75,48 @@ test.describe('Console App – Smoke', () => {
     await expect(page).toHaveTitle(/.+/);
   });
 
-  test('should show the app shell or loading screen', async ({ page }) => {
+  /**
+   * The app must settle into one of its RECOGNISED boot destinations. Which one
+   * it reaches depends on the session, and in this suite — a production bundle
+   * served by `vite preview` with no backend behind it — that is always the
+   * signed-out sign-in screen: `/api/v1/auth/get-session` cannot resolve to a
+   * session, so the shell is never entitled to render a `nav` and the router
+   * lands on `/login`.
+   *
+   * Until objectui#4086 this test listed only the first two destinations, and
+   * the boot splash it named is on screen for roughly 35 ms — measured against
+   * this same production bundle at 30 ms polling granularity: blank until
+   * ~70 ms, the "Initializing application…" splash from ~70 ms, replaced by the
+   * sign-in screen from ~105 ms and never returning. So the assertion could
+   * only ever pass by catching that window. On a runner where Playwright's
+   * first poll landed after it, the expectation was ALREADY unsatisfiable and
+   * burned the full 30 s timeout — identically on all three retries, because
+   * each retry re-runs the same race. That is the whole of the `Build & E2E`
+   * red on `main` at 9154d9e90, which no code change could explain and which
+   * cleared on its own at 8497579db with the suspected commit still in place.
+   *
+   * The set below stays CLOSED on purpose: a blank page, a crashed render or an
+   * error boundary matches none of these three and still fails the test. What
+   * changes is that every state the app is legitimately allowed to be in is now
+   * terminal-stable, so passing no longer depends on winning a race.
+   */
+  test('should settle into a recognised boot state (app shell, loading screen or sign-in)', async ({
+    page,
+  }) => {
     await page.goto(`${CONSOLE_BASE}/`);
 
-    // Either the app shell (nav / sidebar) or the loading screen should appear
-    // within a reasonable time. Both are acceptable initial states.
     const appShell = page.locator('nav').first();
     const loadingScreen = page.getByText(/Initializing|Loading|Connecting/i).first();
+    // The signed-out sign-in screen, matched structurally rather than by its
+    // copy so a locale change cannot silently stop matching it: the auth-config
+    // spinner it opens with, then the identifier field of whichever sign-in
+    // mode the server reports (`LoginForm.tsx`).
+    const signInScreen = page
+      .locator('[data-testid="login-config-loading"], #login-email, #login-phone')
+      .first();
 
     await expect(
-      appShell.or(loadingScreen),
+      appShell.or(loadingScreen).or(signInScreen),
     ).toBeVisible({ timeout: 30_000 });
   });
 });


### PR DESCRIPTION
Fixes #4086

## The premise did not survive verification

Two of the issue's stated facts are disproven, and the third is real:

| Claim | Verdict |
|---|---|
| `Build & E2E` red on `main` at the smoke test | **True** |
| "the console never reaches paint" | **False** — it paints, and settles on the sign-in screen |
| `9154d9e90` (#4081) is the cause | **False** — see below |

**#4081 is exonerated by inclusion.** `main` is green again at `8497579db`
([run 31366842685](https://github.com/objectstack-ai/objectui/actions/runs/31366842685),
`Build & E2E` = success, 07:43Z) with every line of `9154d9e90` still on it —
`toFilterNode` hop, `GRID_QUERY_INPUTS`, pin test. A commit that deterministically
broke the boot cannot be present on a green tip. The suspected import-cycle /
tree-shake mechanism is also ruled out mechanically: the `toFilterNode` import was
added to an import statement that *already* pulled `@object-ui/core`, so the module
graph did not change.

**The console reaches paint.** In the same red run, `should load the page without
JavaScript errors`, `should render React content inside #root`, `should not show a
blank page` and `should have correct page title` all **passed**. Only the shell
assertion failed. An app that never boots cannot pass the first four.

## What actually fails

`e2e/smoke.spec.ts:78` asserted `nav` OR `/Initializing|Loading|Connecting/i`.
Against the harness's own artifact — the CI build command byte for byte
(`VITE_BASE_PATH=/console/ pnpm --filter @object-ui/console exec vite build`) served
by `vite preview`, no backend — the app settles into **neither**. Measured at 30 ms
polling granularity, three consecutive boots agreeing to within 10 ms:

```text
RUN 1
  +   37ms nav=0 loadingText=false url=/console/ |
  +   79ms nav=0 loadingText=true  url=/       | ObjectOS Initializing application... Connecting to data source
  +  112ms nav=0 loadingText=false url=/login  | ObjectOS Sign in to your account ...
  + 5646ms nav=0 loadingText=false url=/login  | ... Email Password Forgot password? Sign In
RUN 2   +71ms splash / +104ms sign-in
RUN 3   +70ms splash / +102ms sign-in
```

The only state the old assertion could match was on screen for **~35 ms**. It
passed by catching that window; it failed for the whole 30 s timeout — identically
on all three retries, because each retry re-runs the same race — whenever
Playwright's first poll landed after it. A coin flip on runner speed, which is
exactly the observed history: identical code red at 06:15Z, green at 07:40Z.

**The app is not at fault.** With `/api/v1/auth/get-session` unable to resolve a
session, the shell is never entitled to render a `nav` and `/login` is the correct
destination. The test simply never listed the state the app is actually in.

## The fix

The assertion now names all three **recognised** boot destinations — app shell,
boot splash, signed-out sign-in screen — each of them terminal-stable, so passing
no longer depends on winning a race. The set stays **closed**: a blank page, a
crashed render or an error boundary matches none of the three and still fails. The
sign-in screen is matched structurally (`[data-testid="login-config-loading"]`,
`#login-email`, `#login-phone`) rather than by copy, so a locale change cannot
silently stop matching it.

Rider from the issue, also fixed: CI selects Playwright's `github` reporter, which
writes annotations and **no** `playwright-report/` directory — hence
`No files were found with the provided path: playwright-report/` and a red job that
discarded its own evidence. Screenshot, trace and `error-context.md` land in
`test-results/`; both paths are uploaded now.

## Verification, both directions

Reverse verification had to be made deterministic, since the bug *is* a race — so
the settle step is forced (`waitForSelector('#login-email')`) and then each
assertion is run against the settled page:

```text
✘  1 OLD assertion (nav | loading text) after settle — EXPECTED RED  (13.3s)
✓  2 NEW assertion (+ sign-in screen) after settle — EXPECTED GREEN  (7.2s)

   Error: expect(locator).toBeVisible() failed
   Locator: locator('nav').first().or(getByText(/Initializing|Loading|Connecting/i).first())
   Expected: visible
   Error: element(s) not found
```

That is the CI failure reproduced verbatim, on demand. Note the honest shape here:
the old test could **not** be shown red by simply running it on this container — it
wins the race locally. What is falsifiable is the mechanism, and it is, in both
directions.

Full suite on this branch, mirroring the CI job (build, then
`playwright test --project=chromium`):

```text
✓  33 e2e/smoke.spec.ts:103 › should settle into a recognised boot state (app shell, loading screen or sign-in) (1.3s)
   23 skipped
   10 passed (19.0s)
```

#4081's pins intact — `pnpm exec vitest run --maxWorkers=2 packages/plugin-grid`:

```text
Test Files  58 passed (58)
     Tests  533 passed (533)
```

Also green: `pnpm exec eslint e2e/smoke.spec.ts` (exit 0),
`node scripts/check-control-bytes.mjs` (3960 files),
`scripts/__tests__/merge-queue-reporting.test.ts` (11 passed, the test that guards
this workflow's gated jobs), and `ci.yml` re-parsed as YAML.

## No changeset

Only `e2e/` and `.github/workflows/` change; no source of a released package does.
`node scripts/check-changeset-presence.mjs` agrees:

```text
Compared the working tree with 8497579db (merge-base with origin/main): 2 file(s)
changed, 0 of them under the src/ of a package the release covers ...
✅  No source of a released package changed in this range, so no changeset is owed.
```

No `skip-changeset` label is needed or possible — objectui#3724 records that neither
that workflow nor that label was ever real in this repo; the presence script is the
gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_