### PR TITLE
fix(templates): move generator dependency ranges with the dependabot wave (#4098)

### DIFF
--- a/.changeset/template-dep-ranges-follow-dependabot.md
+++ b/.changeset/template-dep-ranges-follow-dependabot.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/create-plugin': patch
+'@object-ui/cli': patch
+---
+
+Move the generator templates' dependency ranges onto the repo's current ones
+
+The dependabot wave of 2026-08-10 bumped `lucide-react` to `1.29.0` and `vite`
+to `8.2.1` in this repo's own manifests, but the ranges hard-coded in the
+scaffold generators do not move with it — dependabot does not know the
+templates exist. A project scaffolded by `objectui init` / `objectui dev` or by
+`create-plugin` therefore declared a range the repo itself had already moved
+past.
+
+Three ranges are re-anchored: `lucide-react` `^1.28.0` → `^1.29.0` in the routed
+app generator, and `vite` `^8.2.0` → `^8.2.1` in both the shared CLI scaffold
+devDependencies and the create-plugin template.

--- a/packages/cli/src/__tests__/app-generator.test.ts
+++ b/packages/cli/src/__tests__/app-generator.test.ts
@@ -1079,7 +1079,14 @@ describe('generation onto disk', () => {
         if (!name.startsWith('@object-ui/')) continue;
         expect(range, `${name} in the written manifest`).toBe(`^${cliVersion}`);
       }
-      expect(manifest.dependencies?.['lucide-react']).toBe('^1.28.0');
+      // Anchored, not a literal. This line held `'^1.28.0'` hard-coded and so
+      // was a second, weaker copy of the anchor rule above pointing the other
+      // way: it went red the moment the template was moved onto the repo's real
+      // range, making a correct fix look like a regression (objectui#4098).
+      // A literal here is the very fossil generator this file exists to stop.
+      expect(manifest.dependencies?.['lucide-react']).toBe(
+        Object.keys(inRepoRangesOf('lucide-react')).sort()[0]
+      );
     });
   });
 });

--- a/packages/cli/src/utils/app-generator.ts
+++ b/packages/cli/src/utils/app-generator.ts
@@ -184,7 +184,7 @@ function buildRoutedAppDependencies(): Record<string, string> {
     react: REACT_RANGE,
     'react-dom': REACT_RANGE,
     'react-router-dom': '^7.18.2',
-    'lucide-react': '^1.28.0',
+    'lucide-react': '^1.29.0',
     ...Object.fromEntries(PLATFORM_RUNTIME_PACKAGES.map((name) => [name, range]))
   };
 }

--- a/packages/cli/src/utils/scaffold-dependencies.ts
+++ b/packages/cli/src/utils/scaffold-dependencies.ts
@@ -143,5 +143,5 @@ export const SCAFFOLD_DEV_DEPENDENCIES: Record<string, string> = {
   postcss: '^8.5.26',
   tailwindcss: '^4.3.3',
   typescript: '^6.0.3',
-  vite: '^8.2.0'
+  vite: '^8.2.1'
 };

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -64,7 +64,7 @@ export const VITEST_SETUP_FILE = 'vitest.setup.ts';
  * | `@vitejs/plugin-react`      | `^6.0.5`  | every `packages/plugin-*` (not in root)    |
  * | `jsdom`                     | `^30.0.1` | repo root package.json                     |
  * | `typescript`                | `^6.0.3`  | repo root package.json                     |
- * | `vite`                      | `^8.2.0`  | repo root package.json                     |
+ * | `vite`                      | `^8.2.1`  | repo root package.json                     |
  * | `vite-plugin-dts`           | `^5.0.3`  | every `packages/plugin-*` (not in root)    |
  * | `vitest`                    | `^4.1.10` | repo root package.json                     |
  *
@@ -89,7 +89,7 @@ const DEV_DEPENDENCIES: Record<string, string> = {
   '@vitejs/plugin-react': '^6.0.5',
   jsdom: '^30.0.1',
   typescript: '^6.0.3',
-  vite: '^8.2.0',
+  vite: '^8.2.1',
   'vite-plugin-dts': '^5.0.3',
   vitest: '^4.1.10'
 };


### PR DESCRIPTION
Fixes #4098

This morning's dependabot wave (07:45–08:03Z) moved this repo's own manifests but not the ranges hard-coded in the scaffold generators — dependabot does not know the templates exist. Two anchor ratchets went red on every PR branched off current `main`.

## Premise re-verified

Both reported failures reproduce on unmodified `origin/main` (`361dfdc01`):

```text
FAIL |unit| packages/cli/src/__tests__/app-generator.test.ts
  AssertionError: routed manifest's lucide-react must match its in-repo range:
    expected '^1.28.0' to be '^1.29.0'

FAIL |unit| packages/create-plugin/src/__tests__/templates.test.ts
  AssertionError: vite range must match the repo root:
    expected '^8.2.0' to be '^8.2.1'
```

Direction confirmed from the ratchets' own documentation rather than assumed — `templates.test.ts` states it outright: *"Bumping an in-repo manifest and leaving the template behind is the drift this test exists to catch — update `src/templates.ts` in the same PR."* Templates follow the repo, not the reverse.

## The sweep found a third drift

Each ratchet aborts at its **first** failing assertion, so each file reports one drift however many it has. Rather than fix-and-re-run, I replicated both anchor rules in a throwaway script and judged all 21 anchored ranges across all four generator maps at once:

| range | declared | anchor says | where | reported? |
|---|---|---|---|---|
| `lucide-react` | `^1.28.0` | `^1.29.0` | `app-generator.ts` routed deps (in-repo) | yes |
| `vite` | `^8.2.0` | `^8.2.1` | `create-plugin/templates.ts` (root) | yes |
| `vite` | `^8.2.0` | `^8.2.1` | `cli/utils/scaffold-dependencies.ts` (root) | **no** |

The third was invisible because `lucide-react` sorts before `vite` in `DEPENDENCY_ANCHORS`, so the CLI test never reached it. Fixing only the two named ranges would have turned shard 1 red again on the very next lap. The other 18 anchored ranges are already correct, and the wave's other bumps (shiki, maplibre-gl, react-hook-form, next) are not declared by any generator, so no ratchet points at them.

`lucide-react` `^1.29.0` is unanimous across all 23 in-repo manifests that declare it; root `vite` is `^8.2.1`.

## Reverse verification

Predicted before running, and the direction is plain red — this rule compares a generated string against a repo fact, so there is no schema underneath to re-judge the same input differently (the file says as much). Restoring only the third, previously-invisible drift:

```text
AssertionError: routed manifest's vite must match the repo root:
  expected '^8.2.0' to be '^8.2.1'
  at packages/cli/src/__tests__/app-generator.test.ts:531:66
Tests  1 failed | 32 passed (33)
```

That is the second red lap this PR avoids, made visible.

## One test line changed, and why

`app-generator.test.ts:1082` asserted `expect(manifest.dependencies?.['lucide-react']).toBe('^1.28.0')` — a hard-coded second copy of the anchor rule pointing the *other* way, which went red the moment the template was moved onto the repo's real range, i.e. it scored a correct fix as a regression. It now reads the same `inRepoRangesOf` anchor the rest of the file uses, so it cannot fossilise again. No assertion strength is lost: it still judges the manifest actually written to disk.

## Verification

- `pnpm test --shard=1/4` → `Test Files 289 passed (289)`, `Tests 3599 passed | 1 skipped`
- `pnpm test --shard=2/4` → `Test Files 289 passed (289)`, `Tests 3569 passed`

Both were `1 failed | 288 passed (289)` on `main`, so each shard is green exactly where the issue reported it red.

- `pnpm exec vitest run packages/cli/ packages/create-plugin/` → `5 passed (5)`, `116 passed`
- `type-check` (both packages) → clean
- `lint` (both packages) → 0 errors (15 pre-existing warnings in untouched files)
- `node scripts/check-control-bytes.mjs` → OK

Changeset: `patch` for `@object-ui/cli` and `@object-ui/create-plugin`. Both are published and in the `fixed` release group, and the change is user-visible — it alters the `package.json` a scaffolded project receives.

## Out of scope

The issue's durable question — whether a dependabot bump touching a mirrored range could update the template in the same PR or fail its own CI — is a workflow change beyond this card and is left for triage. Filed nothing new: the sweep turned up no defect outside the three ranges above.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_