### PR TITLE
fix(core): evalRowPredicate carries the engine fault reason and pins the row as subject (#3792, #3796)

### DIFF
--- a/.changeset/row-predicate-fault-reason-and-record-pin-3792-3796.md
+++ b/.changeset/row-predicate-fault-reason-and-record-pin-3792-3796.md
@@ -1,0 +1,61 @@
+---
+"@object-ui/core": patch
+---
+
+`evalRowPredicate`: the fail-closed report now names the engine's failure reason, and the ROW always wins over host scope (objectui#3792, objectui#3796)
+
+Two defects in one function, `packages/core/src/evaluator/listConditional.ts`,
+shared by every surface that gates on a row predicate: the row kebab, the bulk
+selection bar, kanban conditional formatting, and — since objectui#3521 — the
+record page header.
+
+**The safest path said the least (objectui#3792).** `evalRowPredicate` has two
+diagnostic routes, and their information content was inverted. The single-eval
+fast route lets the canonical helper warn, so it prints the engine's own reason
+(`Reason: [runtime] No such key: owner_id`). The `warnOnError: true` route — the
+fail-CLOSED one, taken by every caller that makes a button disappear — runs
+`evalFieldPredicate` twice with `{ warn: false }` to tell a fault from a genuine
+`false`, and that silence discarded the reason along with the duplicate warning.
+So the more decisively a surface hid a control, the less it said about why: the
+console line named the predicate but not the defect, and `No such key: owner_id`
+or `no such overload: string == null` is usually the whole answer.
+
+`FieldPredicateDiagnostic` gains an optional `onFault(reason)` passback:
+`evalFieldPredicate` hands out the engine's verbatim text (kind tag, message and
+source excerpt — the exact string it prints after `Reason:`) even when its own
+warning is suppressed. It fires per fault, deliberately independent of the
+once-per-predicate warning dedupe, so a caller doing its own warn-once
+bookkeeping keeps control of it; the verdict is unaffected, and callers that pass
+nothing are unchanged. `evalRowPredicate` threads that reason into its labelled
+warning, and the legacy-dialect route does the same with the message its engine
+throws (`Reason: [legacy] …`), so both dialect paths report a fault the same way.
+Warn-once semantics are unchanged — the reason is deliberately not part of the
+dedupe key.
+
+**Wording: not a list function, and not for a long time.** The same message
+called every caller a "**list** conditional predicate". A hidden button on a
+record page header reporting "a list conditional predicate" sends its author to
+the list view to look for a control that was never there. Both messages this
+module emits (evaluation failure and the legacy-dialect deprecation) now read
+"conditional predicate".
+
+**The row is the subject — on both dialect paths (objectui#3796).** The scope
+merge pinned `data` after the host-scope spread but not `record`, leaving
+`record` to each engine's own binding — and the two engines disagreed. The legacy
+evaluator re-pinned `record` to the row (row won); the CEL engine takes its
+`extra` bag over its `record` binding, so a host scope carrying a `record` key
+won there instead. One function, one predicate text, two subjects — selected by
+whether the string happens to contain `===` or `${…}`, the dialect-routing
+markers, which no author picks deliberately. `record` is now pinned after the
+spread exactly as `data` is, which fixes both paths at the merge site rather than
+relying on either engine's precedence.
+
+No host injects a `record` key today — `ExpressionProvider` binds
+`current_user` / `user` / `ctx` / `os` / `app` / `data` / `features` — so nothing
+observable changes for existing apps; this closes the edge before a host adds one
+(`ctx.record` already exists, which is exactly how it would arrive). A row FIELD
+named `record` is likewise no longer able to become the row root; it stays
+addressable as `data.record`.
+
+Shipped as a patch: no new exported symbol, one optional field added to an
+already-exported options interface, and no existing call signature changed.

--- a/packages/core/src/evaluator/__tests__/fieldRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/fieldRules.test.ts
@@ -205,6 +205,56 @@ describe('failure diagnostics — loud fail-open (objectstack#5149, appeal 2)', 
     expect(warn).not.toHaveBeenCalled();
   });
 
+  // objectui#3792 — the passback that makes `warn: false` cost only the
+  // WARNING, not the information. A fault-probing caller silences the built-in
+  // line so it can print one labelled line of its own; before this hook that
+  // also threw away the engine's description of the failure, which is the part
+  // that actually locates the author's typo.
+  it('`onFault` hands the engine reason to a caller that silenced the warning', () => {
+    const pred = "passback_3792 == 'x'";
+    const reasons: string[] = [];
+    expect(
+      evalFieldPredicate(pred, {}, true, undefined, undefined, {
+        warn: false,
+        onFault: (r) => reasons.push(r),
+      }),
+    ).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+    // The engine's text verbatim — kind tag, message, and the source excerpt it
+    // appends — not a rephrasing built by this layer.
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain('[type] Unknown variable: passback_3792');
+  });
+
+  it('`onFault` fires per fault — it is not subject to the once-per-predicate dedupe', () => {
+    // The built-in warning is deduped module-wide so a re-rendering predicate
+    // logs once; the passback must NOT inherit that, or the second caller of a
+    // predicate someone else already broke would silently get nothing back.
+    const pred = "passback_dedupe_3792 == 'x'";
+    const reasons: string[] = [];
+    const onFault = (r: string) => reasons.push(r);
+    evalFieldPredicate(pred, {}, true, undefined, undefined, { warn: false, onFault });
+    evalFieldPredicate(pred, {}, false, undefined, undefined, { warn: false, onFault });
+    evalFieldPredicate(pred, {}, true, undefined, undefined, { onFault });
+    expect(reasons).toHaveLength(3);
+    // …while the warning itself still fires at most once for that text.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain(`Reason: ${reasons[2]}`);
+  });
+
+  it('`onFault` is not called for a healthy or genuinely false predicate', () => {
+    const seen: string[] = [];
+    const onFault = (r: string) => seen.push(r);
+    expect(
+      evalFieldPredicate("record.ok3_3792 == 'y'", { ok3_3792: 'y' }, false, undefined, undefined, { onFault }),
+    ).toBe(true);
+    expect(
+      evalFieldPredicate("record.ok3_3792 == 'y'", { ok3_3792: 'n' }, true, undefined, undefined, { onFault }),
+    ).toBe(false);
+    expect(evalFieldPredicate(undefined, {}, true, undefined, undefined, { onFault })).toBe(true);
+    expect(seen).toEqual([]);
+  });
+
   it('includes the caller-provided context locator', () => {
     const pred = "ctx_unbound_5149 == 'x'";
     evalFieldPredicate(pred, {}, true, undefined, undefined, {

--- a/packages/core/src/evaluator/__tests__/listConditional.test.ts
+++ b/packages/core/src/evaluator/__tests__/listConditional.test.ts
@@ -138,6 +138,69 @@ describe('evalRowPredicate', () => {
       expect(warn).toHaveBeenCalledTimes(1);
     });
 
+    // objectui#3792. The fail-closed route runs the canonical helper twice with
+    // `warn: false` (to tell a fault from a genuine `false`), which used to
+    // discard the engine's own description of the failure — so the surfaces
+    // that hide a button outright were the ones that said least about why.
+    it("carries the ENGINE's failure reason into the fail-closed warning", () => {
+      const r = evalRowPredicate('record.absent.deep == 1', { status: 'x' }, {
+        fallback: false,
+        warnOnError: true,
+        label: 'resume',
+      });
+      expect(r).toBe(false);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = String(warn.mock.calls[0][0]);
+      expect(msg).toContain('(resume)');
+      // The reason is the engine's verbatim text, not a rephrasing of it: kind
+      // tag and message both, exactly as the single-eval fast path prints them.
+      expect(msg).toContain('Reason: [runtime] No such key: absent');
+    });
+
+    it('carries an unbound-root reason too (the typo class this exists for)', () => {
+      evalRowPredicate('nosuchroot.x == 1', { status: 'x' }, {
+        fallback: false,
+        warnOnError: true,
+        label: 'unbound',
+      });
+      expect(String(warn.mock.calls[0][0])).toContain('Reason: [type] Unknown variable: nosuchroot');
+    });
+
+    it('reports the legacy path fault with the legacy engine reason', () => {
+      // `===` routes to the legacy engine, which reports by throwing; the
+      // fail-closed report carries that message for the same reason.
+      evalRowPredicate('record.a === $$$', { a: 1 }, {
+        fallback: false,
+        warnOnError: true,
+        label: 'legacy-fault',
+      });
+      const failure = warn.mock.calls
+        .map((c) => String(c[0]))
+        .find((m) => m.includes('failed to evaluate'));
+      expect(failure).toBeDefined();
+      expect(failure).toContain('(legacy-fault)');
+      expect(failure).toContain('Reason: [legacy]');
+    });
+
+    // The other half of objectui#3792: this function stopped being list-only
+    // long ago — kanban formatting, the bulk selection bar and (since #3521)
+    // `page:header` all report through it. Naming every surface "list" sends a
+    // page-header author to the list view to look for a button that was never
+    // there.
+    it('names the surface neutrally — never "list conditional predicate"', () => {
+      evalRowPredicate('record.absent.wording == 1', { a: 1 }, {
+        warnOnError: true,
+        label: 'page:header/publish',
+      });
+      evalRowPredicate('${data.wording === "x"}', { a: 1 });
+      const messages = warn.mock.calls.map((c) => String(c[0]));
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+      for (const msg of messages) {
+        expect(msg).not.toContain('list conditional predicate');
+        expect(msg).toContain('[object-ui] A conditional predicate');
+      }
+    });
+
     it('keeps the label/source boundary unambiguous', () => {
       // The obvious repair for an "impossible character" separator is to pick a
       // printable one, which merely relocates the collision. These two pairs
@@ -150,6 +213,80 @@ describe('evalRowPredicate', () => {
       expect(String(warn.mock.calls[0][0])).toContain('(alpha)');
       expect(String(warn.mock.calls[1][0])).toContain('(alpha beta)');
     });
+  });
+});
+
+/**
+ * objectui#3796 — the row is this function's SUBJECT, on both dialect paths.
+ *
+ * `data` was already pinned after the host-scope spread; `record` was not, and
+ * leaned on each engine's own binding instead — which disagreed. The legacy
+ * evaluator re-pinned `record` (row won); the CEL engine takes its `extra` bag
+ * over its `record` binding (host scope won). So one predicate text meant two
+ * different things depending on whether it happened to contain `===`/`${…}`,
+ * the marker that routes dialects — something no author selects deliberately.
+ *
+ * No host injects a `record` key today (`ExpressionProvider` binds
+ * `current_user`/`user`/`ctx`/`os`/`app`/`data`/`features`), so this is a pin
+ * against a plausible future addition — `ctx.record` already exists — not a
+ * live bug repro. It is one test on purpose: the two paths' precedence is a
+ * single contract, and pinning them apart is what let them drift.
+ */
+describe('evalRowPredicate — row wins over host scope (both dialect paths)', () => {
+  const ROW = { tag: 'ROW' };
+  // A host scope carrying a decoy `record` (and `data`, already protected).
+  const DECOY = { record: { tag: 'SCOPE' }, data: { tag: 'SCOPE' }, features: { on: true } };
+
+  it('binds `record` to the row on the CEL path AND the legacy path', () => {
+    // CEL (canonical): no legacy marker in the source.
+    expect(evalRowPredicate("record.tag == 'ROW'", ROW, { scope: DECOY })).toBe(true);
+    expect(evalRowPredicate("record.tag == 'SCOPE'", ROW, { scope: DECOY })).toBe(false);
+
+    // Legacy: `===` routes to the other engine — same subject, same verdicts.
+    expect(evalRowPredicate("record.tag === 'ROW'", ROW, { scope: DECOY })).toBe(true);
+    expect(evalRowPredicate("record.tag === 'SCOPE'", ROW, { scope: DECOY })).toBe(false);
+  });
+
+  it('binds `data` and the bare name to the row on both paths too', () => {
+    expect(evalRowPredicate("data.tag == 'ROW'", ROW, { scope: DECOY })).toBe(true);
+    expect(evalRowPredicate("data.tag === 'ROW'", ROW, { scope: DECOY })).toBe(true);
+    expect(evalRowPredicate("tag == 'ROW'", ROW, { scope: DECOY })).toBe(true);
+    expect(evalRowPredicate("tag === 'ROW'", ROW, { scope: DECOY })).toBe(true);
+  });
+
+  it('still resolves host-scope keys the row does not shadow', () => {
+    // The row winning is not the scope being dropped: background stays bound.
+    expect(evalRowPredicate('features.on == true', ROW, { scope: DECOY })).toBe(true);
+    expect(evalRowPredicate('features.on === true', ROW, { scope: DECOY })).toBe(true);
+  });
+
+  it('holds on the fail-closed route as well as the fast route', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(
+        evalRowPredicate("record.tag == 'ROW'", ROW, { scope: DECOY, warnOnError: true, fallback: false }),
+      ).toBe(true);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('a row FIELD named `record` does not become the subject either', () => {
+    // The pin sits after the bare-field spread, so a column literally called
+    // `record` is addressable as `data.record`, never as the row root.
+    const row = { record: { tag: 'FIELD' }, tag: 'ROW' };
+    expect(evalRowPredicate("record.tag == 'ROW'", row, { scope: DECOY })).toBe(true);
+    expect(evalRowPredicate("data.record.tag == 'FIELD'", row, { scope: DECOY })).toBe(true);
+  });
+
+  it('applies through conditional formatting, which shares the entry point', () => {
+    expect(
+      resolveConditionalFormatting(ROW, [{ condition: "record.tag == 'ROW'", backgroundColor: 'row' }], DECOY),
+    ).toEqual({ backgroundColor: 'row' });
+    expect(
+      resolveConditionalFormatting(ROW, [{ condition: "record.tag == 'SCOPE'", backgroundColor: 'scope' }], DECOY),
+    ).toEqual({});
   });
 });
 

--- a/packages/core/src/evaluator/fieldRules.ts
+++ b/packages/core/src/evaluator/fieldRules.ts
@@ -90,6 +90,22 @@ export interface FieldPredicateDiagnostic {
    * warnings for one broken predicate. Defaults to `true`.
    */
   warn?: boolean;
+  /**
+   * Called with the engine's failure reason (`"[kind] message"`, the exact text
+   * the built-in warning prints after `Reason:`) when the predicate cannot be
+   * evaluated. This is the passback for callers that set `warn: false` and
+   * report the fault themselves — without it, silencing the built-in warning
+   * also discards the only description of *why* the predicate failed, which is
+   * how the fail-closed row-predicate path ended up the least debuggable one
+   * (objectui#3792).
+   *
+   * Independent of `warn` and of the one-time-warning dedupe: it fires on every
+   * fault, so a caller doing its own warn-once bookkeeping keeps control of it.
+   * The returned verdict is unaffected. Must not throw — it is invoked outside
+   * the engine guard, so an exception here propagates to the caller rather than
+   * being reported as an engine fault.
+   */
+  onFault?: (reason: string) => void;
 }
 
 const warnedPredicates = new Set<string>();
@@ -149,39 +165,35 @@ export function evalFieldPredicate(
 ): boolean {
   if (pred == null || (typeof pred === 'string' && !pred.trim())) return fallback;
   const expr = toExpression(pred);
+  // The two fault sources — a not-ok verdict and a throw that slipped past the
+  // engine's "never throws" contract — converge on one reason string and one
+  // reporting site below, so the built-in warning and the `onFault` passback
+  // can never describe the failure differently.
+  let reason: string | undefined;
+  let value = fallback;
   try {
     const res = ExpressionEngine.evaluate<boolean>(expr, {
       record,
       previous,
       ...(scope ? { extra: scope } : {}),
     });
-    if (!res.ok) {
-      // Parse error, type error, unbound identifier, engine fault … — every
-      // not-ok verdict resolves to the fallback, but never silently (#5149).
-      if (diagnostic?.warn !== false) {
-        warnPredicateFailure(
-          expr,
-          fallback,
-          `[${res.error.kind}] ${res.error.message}`,
-          diagnostic?.context,
-        );
-      }
-      return fallback;
-    }
-    return res.value === true;
+    // Parse error, type error, unbound identifier, engine fault … — every
+    // not-ok verdict resolves to the fallback, but never silently (#5149).
+    if (!res.ok) reason = `[${res.error.kind}] ${res.error.message}`;
+    else value = res.value === true;
   } catch (err) {
-    // The engine contract is "never throws"; this guard is for anything that
-    // slips past it. Same loud fail-open as the not-ok branch.
+    reason = `[throw] ${err instanceof Error ? err.message : String(err)}`;
+  }
+  if (reason !== undefined) {
     if (diagnostic?.warn !== false) {
-      warnPredicateFailure(
-        expr,
-        fallback,
-        `[throw] ${err instanceof Error ? err.message : String(err)}`,
-        diagnostic?.context,
-      );
+      warnPredicateFailure(expr, fallback, reason, diagnostic?.context);
     }
+    // Outside the try on purpose: a throwing callback is a caller bug and must
+    // surface as one, not be swallowed and re-reported as an engine fault.
+    diagnostic?.onFault?.(reason);
     return fallback;
   }
+  return value;
 }
 
 /**

--- a/packages/core/src/evaluator/listConditional.ts
+++ b/packages/core/src/evaluator/listConditional.ts
@@ -59,7 +59,7 @@ function warnLegacyDialect(source: string): void {
   if (warnedLegacy.has(source)) return;
   warnedLegacy.add(source);
   console.warn(
-    '[object-ui] A list conditional predicate uses the legacy expression dialect ' +
+    '[object-ui] A conditional predicate uses the legacy expression dialect ' +
       'and is not portable to the server CEL engine: ' +
       JSON.stringify(source) +
       '. Rewrite it as CEL (use "==" not "===", "x in [..]" for membership, ' +
@@ -68,20 +68,40 @@ function warnLegacyDialect(source: string): void {
 }
 
 const warnedError = new Set<string>();
-function warnEvalError(source: string, label?: string): void {
+/**
+ * One-time fail-closed report for a predicate that could not be evaluated.
+ *
+ * `reason` is the engine's own description of the failure (`"[runtime] No such
+ * key: owner_id"`) — the single most useful line for the author, and precisely
+ * what this path used to discard: the fault-probing CEL route silences the
+ * canonical helper's warning to avoid double-reporting, so before objectui#3792
+ * the more safety-critical the surface, the LESS it said. It is optional
+ * because a caller may genuinely have no reason to pass (nothing fabricates
+ * one).
+ *
+ * The wording is deliberately surface-neutral: this function is not
+ * list-specific and has not been for a long time — row kebabs, the bulk
+ * selection bar, kanban conditional formatting and (since objectui#3521)
+ * `page:header` all report through it, and telling a page-header author that
+ * "a list conditional predicate" failed sends them to the wrong screen.
+ */
+function warnEvalError(source: string, label?: string, reason?: string): void {
   // One-time-warning identity for the (label, source) pair. JSON-encoded rather
   // than joined on a character the two halves "cannot contain" — that separator
   // was a raw U+0000, which made this whole file binary to grep (objectstack#5450).
   // JSON needs no impossible character, so the boundary is unambiguous for any
   // label and any predicate source, and the literal is plain ASCII.
+  // `reason` is deliberately NOT part of the key: one predicate text has one
+  // reason, so keying on it could only ever weaken the warn-once contract.
   const key = JSON.stringify([label ?? '', source]);
   if (warnedError.has(key)) return;
   warnedError.add(key);
   console.warn(
-    '[object-ui] A list conditional predicate failed to evaluate' +
+    '[object-ui] A conditional predicate failed to evaluate' +
       (label ? ` (${label})` : '') +
       ' and was treated as its safe default: ' +
       JSON.stringify(source) +
+      (reason ? `. Reason: ${reason}` : '') +
       '. Check the field names and CEL syntax.',
   );
 }
@@ -91,6 +111,8 @@ function warnEvalError(source: string, label?: string): void {
 interface CelVerdict {
   ok: boolean;
   value: boolean;
+  /** The engine's failure reason when `ok` is false — see {@link warnEvalError}. */
+  reason?: string;
 }
 
 /**
@@ -111,10 +133,17 @@ function evalCel(
   // verbatim — no second engine — so CEL semantics never drift from B2.
   // `warn: false`: this caller reports the fault itself (the labelled
   // `warnEvalError` in `evalRowPredicate`) — one warning per broken predicate,
-  // not two (#5149).
-  const asTrue = evalFieldPredicate(pred, record, true, undefined, scope, { warn: false });
-  const asFalse = evalFieldPredicate(pred, record, false, undefined, scope, { warn: false });
-  if (asTrue !== asFalse) return { ok: false, value: false };
+  // not two (#5149). `onFault` carries the engine's reason across that silence
+  // so the labelled report can still name it (objectui#3792); both probes fault
+  // identically, so the first reason is the reason.
+  let reason: string | undefined;
+  const onFault = (r: string): void => {
+    reason ??= r;
+  };
+  const diagnostic = { warn: false, onFault };
+  const asTrue = evalFieldPredicate(pred, record, true, undefined, scope, diagnostic);
+  const asFalse = evalFieldPredicate(pred, record, false, undefined, scope, diagnostic);
+  if (asTrue !== asFalse) return { ok: false, value: false, reason };
   return { ok: true, value: asTrue };
 }
 
@@ -125,7 +154,8 @@ export interface RowPredicateOptions {
    * row-action `visible`/`disabled`; `false` (no style) for formatting. */
   fallback?: boolean;
   /** Extra top-level scope merged alongside the row — e.g. the global predicate
-   * scope (`features` / `user` / `app`) a host shell provides. */
+   * scope (`features` / `user` / `app`) a host shell provides. The row wins on
+   * collision: a `record` or `data` key here never shadows the row. */
   scope?: Record<string, unknown>;
   /** When true, log a one-time warning if a *present* predicate faults. */
   warnOnError?: boolean;
@@ -147,7 +177,9 @@ export interface RowPredicateOptions {
  * fields are bound three ways so every authoring convention resolves:
  * `record.status` (spec/canonical), bare `status` (row-action shorthand), and
  * `data.status` (legacy). The optional `scope` (host predicate scope) is bound
- * alongside so `features.*` / `user.*` predicates keep working.
+ * alongside so `features.*` / `user.*` predicates keep working — but the row is
+ * the subject: `record` and `data` always name THIS row, on both dialect paths,
+ * even when the host scope carries keys of those names (objectui#3796).
  */
 export function evalRowPredicate(
   pred: FieldRulePredicate | undefined | null,
@@ -163,19 +195,33 @@ export function evalRowPredicate(
   // means one thing whether or not this surface expanded the column
   // (objectui#3501). Returned by reference when there is nothing to collapse.
   const rowObj = toPredicateRecord(row && typeof row === 'object' ? row : {}, opts.fields);
-  // Bare fields + `data.*` + the host scope, all top-level; `record` is bound
-  // by the engine call itself (evalCel / the legacy evaluator below).
-  const scope = { ...(opts.scope ?? {}), ...rowObj, data: rowObj };
+  // Bare fields + `data.*` + `record.*` + the host scope, all top-level.
+  //
+  // `data` AND `record` are pinned AFTER the spread, so a host scope that
+  // happens to carry either key is background and the ROW stays the subject of
+  // this function — on BOTH dialect paths. `data` always had that protection;
+  // `record` did not, and relied instead on each engine's own binding, which
+  // disagreed: the legacy evaluator re-pinned `record` (row won) while the CEL
+  // engine takes `extra` over its `record` binding (host scope won). Same
+  // function, same predicate text, opposite subjects — decided by whether the
+  // string happens to contain `===`/`${…}`, which no author is choosing
+  // deliberately (objectui#3796). Pinning here fixes both paths at the merge,
+  // independently of either engine's precedence.
+  const scope = { ...(opts.scope ?? {}), ...rowObj, data: rowObj, record: rowObj };
 
   // Legacy-dialect *strings* route to the legacy engine (back-compat). The
   // `{ dialect: 'cel', source }` envelope is never routed here — it is CEL.
   if (source !== undefined && isLegacyDialectSource(source)) {
     warnLegacyDialect(source);
     try {
-      const evaluator = new ExpressionEvaluator({ ...scope, record: rowObj });
+      const evaluator = new ExpressionEvaluator(scope);
       return evaluator.evaluateCondition(source, { throwOnError: true });
-    } catch {
-      if (opts.warnOnError) warnEvalError(source, opts.label);
+    } catch (err) {
+      // The legacy engine reports by throwing, so its message IS the reason —
+      // the fail-closed report carries it for the same reason the CEL path does.
+      if (opts.warnOnError) {
+        warnEvalError(source, opts.label, `[legacy] ${err instanceof Error ? err.message : String(err)}`);
+      }
       return fallback;
     }
   }
@@ -191,7 +237,7 @@ export function evalRowPredicate(
   }
   const verdict = evalCel(pred, rowObj, scope);
   if (!verdict.ok) {
-    warnEvalError(source ?? '(expression)', opts.label);
+    warnEvalError(source ?? '(expression)', opts.label, verdict.reason);
     return fallback;
   }
   return verdict.value;


### PR DESCRIPTION
Fixes #3792
Fixes #3796

Two defects in one function — `packages/core/src/evaluator/listConditional.ts`'s
`evalRowPredicate` — packed into one PR because they share the file and the same
four consumer surfaces: the row kebab, the bulk selection bar, kanban conditional
formatting, and (since #3521) the record page header.

Both cards were filed as observations during #3521 and both premises were
re-verified against current `origin/main` before implementing; both still hold at
the lines the cards name.

## #3792 — the fail-closed report discarded the engine's reason

`evalRowPredicate` has two diagnostic routes whose information content was
inverted:

| route | who warns | reason included |
|---|---|---|
| fast (`warnOnError` unset) | the canonical helper | yes — `Reason: [runtime] No such key: owner_id` |
| fail-closed (`warnOnError: true`) | this module's `warnEvalError` | **no** |

The fail-closed route runs `evalFieldPredicate` twice with `{ warn: false }` to
tell a fault from a genuine `false`. That silence suppressed the duplicate
warning — and discarded the engine's failure reason with it. So the more
decisively a surface hid a control, the less it said about why: the console named
the predicate but not the defect, while `No such key: owner_id` is usually the
whole answer.

**Seam chosen: an optional `onFault(reason)` on the existing
`FieldPredicateDiagnostic` options bag** — the card sketched this or a
rich-result sibling function. `onFault` was preferred because it changes no
existing call signature (`evalFieldPredicate`'s six parameters are untouched, and
`FieldPredicateDiagnostic` was already optional), adds no second exported
function whose fault semantics could drift from the canonical one, and needs no
call-site migration. It hands out the engine's verbatim text — kind tag, message
and source excerpt, exactly the string printed after `Reason:` — and fires **per
fault**, deliberately independent of the once-per-predicate warning dedupe, so a
caller doing its own warn-once bookkeeping keeps control of it. The verdict is
unaffected.

It is invoked outside the engine try/catch on purpose: a throwing callback is a
caller bug and must surface as one, not be swallowed and re-reported as an engine
fault.

The legacy-dialect path had the same hole and is fixed alongside — that engine
reports by throwing, so its message is the reason (`Reason: [legacy] …`). Both
dialect paths now report a fault the same way. Warn-once semantics are unchanged;
the reason is deliberately **not** part of the dedupe key (one predicate text has
one reason, so keying on it could only weaken the contract).

### Wording

The same message called every caller a "list conditional predicate". A hidden
button on a record page header reporting that sends its author to the list view
to look for a control that was never there. Both messages this module emits — the
evaluation failure and the legacy-dialect deprecation, which carried the identical
phrase — now read "conditional predicate".

## #3796 — the row is the subject, on both dialect paths

The scope merge pinned `data` after the host-scope spread but not `record`,
leaving `record` to each engine's own binding — and the two engines disagreed.
Re-measured on this branch against the current `@objectstack/formula`:

```
ExpressionEngine.evaluate({ dialect: 'cel', source: 'record.x' },
  { record: { x: 'ROW' }, extra: { record: { x: 'SCOPE' } } })
// => { ok: true, value: 'SCOPE' }        extra beats the record binding
```

The legacy evaluator re-pinned `record` to the row, so the row won there. One
function, one predicate text, two subjects — selected by whether the string
happens to contain `===` or `${…}`, the dialect-routing markers, which no author
picks deliberately.

`record` is now pinned after the spread exactly as `data` is. That fixes both
paths **at the merge site**, independently of either engine's precedence — the
reason this was chosen over stripping `record` from the host scope: the pin is
one token next to the `data` pin it mirrors, and it cannot be re-broken by a
future change to which binding an engine prefers.

No host injects a `record` key today (`ExpressionProvider` binds `current_user` /
`user` / `ctx` / `os` / `app` / `data` / `features`), so nothing observable
changes for existing apps; this closes the edge before a host adds one —
`ctx.record` already exists, which is exactly how it would arrive. A row FIELD
named `record` can no longer become the row root either; it stays addressable as
`data.record`.

## Tests

New pins, all in `packages/core/src/evaluator/__tests__/`:

- **#3792** — the fail-closed warning carries `Reason: [runtime] No such key:
  absent` and `Reason: [type] Unknown variable: nosuchroot` (the two fault classes
  an author actually hits); the legacy path carries `Reason: [legacy] …`; and a
  wording pin asserting no message contains "list conditional predicate".
- **#3792 seam** — `onFault` in `fieldRules.test.ts`: reason handed back under
  `warn: false`, fires per fault rather than once per predicate (with the warning
  still firing at most once for the same text), and stays silent for healthy and
  genuinely-false predicates.
- **#3796** — the card asked for one test pinning BOTH dialect paths together,
  and that is what the first case is: a host scope carrying a decoy `record`, a
  CEL predicate and a legacy predicate, both required to read the row. Plus the
  `data` / bare-name spellings, the fail-closed route, a row field named
  `record`, host-scope keys the row does not shadow (the row winning is not the
  scope being dropped), and conditional formatting, which shares the entry point.

### Reverse verification (both halves, independently)

**(a) Revert the reason passback** — `git checkout origin/main -- fieldRules.ts`,
leaving everything else in place:

```
× carries the ENGINE's failure reason into the fail-closed warning
    AssertionError: expected '[object-ui] A conditional predicate f…'
      to contain 'Reason: [runtime] No such key: absent'
× carries an unbound-root reason too (the typo class this exists for)
    AssertionError: … to contain 'Reason: [type] Unknown variable: nosuchroot'
```

Reported honestly, since the template presumes a uniform red: the **legacy**
reason test stays GREEN under this revert, and correctly so — that path's reason
comes from the caught exception, not from the passback. Only the CEL half depends
on `onFault`, and only the CEL half goes red.

**(b) Revert the `record` pin** — the measured asymmetry reproduced as the red,
not merely a failure. With the pin reverted, one probe over the identical row and
the identical decoy scope:

```
CEL    record.tag -> SCOPE(decoy)
LEGACY record.tag -> ROW
```

and the suite:

```
× binds `record` to the row on the CEL path AND the legacy path
× holds on the fail-closed route as well as the fast route
× a row FIELD named `record` does not become the subject either
× applies through conditional formatting, which shares the entry point
```

The two cases that stayed green under that revert are the `data` / bare-name and
host-scope-still-resolves ones — which is the card's own finding restated: `data`
already had the protection, `record` did not.

## Verification

Run from the repo root with path filters, per AGENTS.md.

- `pnpm exec vitest run packages/core/` — **75 files, 1628 tests passed**
- `pnpm --filter @object-ui/core type-check` — clean
- Consumer suites (the four named surfaces plus the runtime):
  `pnpm exec vitest run packages/plugin-list/ packages/plugin-grid/
  packages/plugin-kanban/ packages/react/` — **127 files, 1465 tests passed**
- Consumer surface files: `page-header-predicate-dialect`, `page-header-actions`,
  `action-record-predicate-root`, `ConditionalFormattingEditor`,
  `ActionRunner.disabledGate`, `predicate-surface-parity` — **6 files, 194 tests
  passed**
- Downstream closure type-check, **prefix direction**
  (`pnpm --filter '...@object-ui/core' type-check` = the 36 packages that DEPEND
  on core) — 34 with a `type-check` script, all clean. This required a full build
  first: the first attempt failed with `TS6305 … core/dist/index.d.ts has not
  been built from source`, i.e. consumers type-check against `dist/*.d.ts`, so a
  pre-build green would have been read off stale declarations.
- `node scripts/check-changeset-presence.mjs`, `check-changeset-no-major.mjs`,
  `pnpm check:control-bytes`, and `eslint` on the four changed files — all clean.

## Changeset

`@object-ui/core` **patch**. Arguing the level, since the passback does touch an
exported type: no new exported symbol, one optional field added to an
already-exported options interface, no existing call signature changed, and every
existing caller behaves identically. The user-visible surface is diagnostics text
plus a binding-precedence edge no shipped host can currently reach.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_