### PR TITLE
fix(app-shell): wire clientValidation for sharing_rule / translation / connector (#3561)

### DIFF
--- a/.changeset/tidy-cameras-shake.md
+++ b/.changeset/tidy-cameras-shake.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin: wire client-side Zod validation for `sharing_rule`, `translation` and `connector` (objectui#3561)
+
+These three metadata types opted out of live client-side validation on recorded
+reasons that no longer held against the resolved `@objectstack/spec` 17.0.0-rc.5:
+`SharingRuleSchema` was described as having an empty shape (it is a `.strict()`
+object of nine keys), `translation` was judged by `TranslationBundleSchema` (the
+bundle map, not the kind's schema — it rejects a valid translation item), and
+`connector` was blocked on a required `id` field that does not exist in
+`ConnectorSchema`.
+
+Each loader now names the schema the platform actually binds — `SharingRuleSchema`,
+`TranslationItemSchema` and `DeclarativeConnectorEntrySchema`. Behaviour change:
+drafts of these types are now rejected in the editor before save, through the same
+diagnostics banner every other wired type already uses. Most notably a `connector`
+draft that inlines credentials or authors provider-derived `actions` is caught at
+authoring time by the ADR-0097 rules the bare `ConnectorSchema` does not carry.
+
+`sharing_rule` is gated on the **create** door only: its schema is `.strict()` and
+declares none of the ADR-0010 envelope keys that a stored body carries, so judging
+a stored body with it would make the client stricter than the server.
+`hasClientValidator(type, mode)` takes the door as a second argument for that
+reason — without it the editor would have read a type with no gate on the edit
+path as "clean" and suppressed the server's own diagnostics.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -112,7 +112,7 @@ import { getMetadataInspector } from './inspector-registry';
 import { getMetadataDefaultInspector } from './default-inspector-registry';
 import { useMetadataLocale, t, tFormat, translateValidationMessage } from './i18n';
 import { JsonSourceEditor } from './JsonSourceEditor';
-import { validateMetadataDraft, hasClientValidator } from './clientValidation';
+import { validateMetadataDraft, hasClientValidator, type DraftMode } from './clientValidation';
 import { describeIssuePath } from './issuePath';
 import { buildCreateModeBody } from './createBody';
 import { errorCodeIs, errorCodeIsAnyOf } from '@object-ui/types';
@@ -272,6 +272,12 @@ function MetadataResourceEditPageImpl({
       : (entry?.schema as Record<string, unknown> | undefined)) ??
     (config.defaultSchema as Record<string, unknown> | undefined);
   const locale = useMetadataLocale();
+  // Which DOOR this page is (objectstack#5316): a create draft is authored here
+  // and judged by the strict authoring schema; an edit draft is a body that came
+  // back out of storage. Hoisted to one name because it now also decides whether
+  // a client validator exists at all — some schemas are author-shape-only and
+  // gate `create` only (objectui#3561, `AUTHOR_SHAPE_ONLY_TYPES`).
+  const draftMode: DraftMode = createMode ? 'create' : 'edit';
 
   const [layered, setLayered] = React.useState<MetadataLayered<any> | null>(null);
   const identityField = config.identityField ?? 'name';
@@ -414,7 +420,7 @@ function MetadataResourceEditPageImpl({
   // so behavior matches the post-save diagnostics but appears live.
   // Types without a client schema keep the existing server-only flow.
   React.useEffect(() => {
-    if (!hasClientValidator(type)) return;
+    if (!hasClientValidator(type, draftMode)) return;
     let cancelled = false;
     const handle = window.setTimeout(() => {
       // Pass the live server schema so the client never flags fields the
@@ -430,7 +436,7 @@ function MetadataResourceEditPageImpl({
         type,
         draft,
         entry?.schema as { required?: unknown } | undefined,
-        { mode: createMode ? 'create' : 'edit' },
+        { mode: draftMode },
       ).then((res) => {
         if (cancelled) return;
         setIssues(res.issues);
@@ -440,7 +446,7 @@ function MetadataResourceEditPageImpl({
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [type, draft, entry?.schema, createMode]);
+  }, [type, draft, entry?.schema, draftMode]);
   // Issues to DISPLAY (banner + inline). Suppressed on a pristine create form
   // so a blank new item doesn't open covered in required-field errors.
   const displayIssues = React.useMemo(
@@ -458,7 +464,7 @@ function MetadataResourceEditPageImpl({
     const diag = (layered as any)?._diagnostics as
       | { errors?: Array<{ path: string; message: string }>; warnings?: Array<{ path: string; message: string }> }
       | undefined;
-    const errs = hasClientValidator(type)
+    const errs = hasClientValidator(type, draftMode)
       ? displayIssues.map((i) => ({ path: i.path, message: translateValidationMessage(i.message, locale) }))
       : (diag?.errors ?? []).map((i) => ({ path: i.path, message: translateValidationMessage(i.message, locale) }));
     const warns = (diag?.warnings ?? []).map((i) => ({
@@ -469,7 +475,7 @@ function MetadataResourceEditPageImpl({
       ...errs.map((e) => ({ path: e.path || undefined, message: e.message, severity: 'error' as const })),
       ...warns.map((w) => ({ path: w.path || undefined, message: w.message, severity: 'warning' as const })),
     ];
-  }, [layered, displayIssues, type, locale]);
+  }, [layered, displayIssues, type, locale, draftMode]);
   // Per-item draft pending publish (mode=draft saves land here).
   // When non-null, the editor is "viewing the draft" and we surface
   // Publish / Discard-draft actions.
@@ -1977,7 +1983,7 @@ function MetadataResourceEditPageImpl({
               // live `issues` state instead of the stale load-time
               // diagnostics, so it stays in sync with every keystroke.
               // Warnings remain server-sourced (Zod doesn't model them).
-              const liveErrors = hasClientValidator(type)
+              const liveErrors = hasClientValidator(type, draftMode)
                 ? issues.map((i) => ({
                     path: i.path,
                     message: translateValidationMessage(i.message, locale),
@@ -1986,7 +1992,7 @@ function MetadataResourceEditPageImpl({
                     ...i,
                     message: translateValidationMessage(i.message, locale),
                   }));
-              const liveValid = hasClientValidator(type)
+              const liveValid = hasClientValidator(type, draftMode)
                 ? liveErrors.length === 0
                 : diag?.valid !== false;
               // Gate the whole diagnostics block on a successful load with
@@ -2001,7 +2007,7 @@ function MetadataResourceEditPageImpl({
                 !shouldRenderDiagnostics({
                   loadFailed,
                   hasDiag: !!diag,
-                  hasClientValidator: hasClientValidator(type),
+                  hasClientValidator: hasClientValidator(type, draftMode),
                 })
               ) {
                 return null;

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.optOuts.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.optOuts.test.ts
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `sharing_rule` / `translation` / `connector` — the three client-validation
+ * opt-outs objectui#3561 retired, and the pins that keep them retired.
+ *
+ * Each of the three used to sit on `clientValidation.ts`'s "server-only" list
+ * with a stated reason. Re-verified against the RESOLVED `@objectstack/spec`
+ * (`17.0.0-rc.5`, what pnpm installs for the `^17.0.0-rc.5` pin), none of the
+ * three reasons held:
+ *
+ *  - `sharing_rule` — "declared but has empty shape". It is
+ *    `CriteriaSharingRuleSchema`: a `.strict()` object of nine keys.
+ *  - `translation` — judged by `TranslationBundleSchema`, which is not this
+ *    kind's schema. It is also not the "accepts anything" the note claimed:
+ *    it is `z.record(LocaleSchema, TranslationDataSchema)` and it REJECTS a
+ *    valid translation item.
+ *  - `connector` — "requires an `id` field". There is no `id` key in
+ *    `ConnectorSchema` at all; and the authoring shape is
+ *    `DeclarativeConnectorEntrySchema`, which carries the ADR-0097 rules.
+ *
+ * Two kinds of test live here.
+ *
+ * 1. RED/GREEN per type — a draft the newly wired schema provably rejects, and
+ *    a valid draft that passes. The red cases are chosen so that reverting the
+ *    wiring (or naming the schema the stale note named) turns them green-in-
+ *    the-wrong-way: for `connector` every red case is one `ConnectorSchema`
+ *    ACCEPTS, so pointing the loader at the base schema fails these and nothing
+ *    else would have noticed.
+ *
+ * 2. BINDING PARITY — the structural safeguard against the wrong-schema class
+ *    this file has already paid for twice (`email_template`, then these three).
+ *    See the block comment above those tests for why parity is asserted
+ *    structurally rather than by object identity: it is a measured property of
+ *    how the spec package is bundled, not a preference.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateMetadataDraft, hasClientValidator } from './clientValidation';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/** A sharing rule that parses clean on the resolved spec. */
+const SHARING_RULE: Record<string, unknown> = {
+  name: 'west_accounts',
+  label: 'West accounts',
+  object: 'account',
+  active: true,
+  accessLevel: 'read',
+  sharedWith: { type: 'position', value: 'sales_west' },
+  type: 'criteria',
+  condition: 'region == "west"',
+};
+
+/** A translation item that parses clean on the resolved spec. */
+const TRANSLATION: Record<string, unknown> = {
+  name: 'zh_CN',
+  locale: 'zh-CN',
+  label: '简体中文',
+  objects: {},
+};
+
+/** A connector catalog descriptor — no `provider`, so no ADR-0097 rule fires. */
+const CONNECTOR: Record<string, unknown> = {
+  name: 'stripe_api',
+  label: 'Stripe',
+  type: 'saas',
+};
+
+// ── sharing_rule ────────────────────────────────────────────────────────────
+
+describe('validateMetadataDraft("sharing_rule") — objectui#3561', () => {
+  it('accepts a valid rule (the stale note claimed an empty shape)', async () => {
+    const res = await validateMetadataDraft('sharing_rule', SHARING_RULE);
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects an unknown key — the shape is strict, so a typo is caught now', async () => {
+    const res = await validateMetadataDraft('sharing_rule', {
+      ...SHARING_RULE,
+      critera: 'region == "west"',
+    });
+    expect(res.ok).toBe(false);
+    // The spec ships a curated unknown-key message for this shape; assert the
+    // offending key is named rather than pinning the whole sentence.
+    expect(JSON.stringify(res.issues)).toContain('critera');
+  });
+
+  it('rejects an accessLevel outside the declared enum', async () => {
+    const res = await validateMetadataDraft('sharing_rule', {
+      ...SHARING_RULE,
+      accessLevel: 'superuser',
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toContain('accessLevel');
+  });
+
+  /**
+   * The author-shape-only boundary (`AUTHOR_SHAPE_ONLY_TYPES`).
+   *
+   * `SharingRuleSchema` is `.strict()` and declares NONE of the seven ADR-0010
+   * envelope keys, while the metadata read path stamps `_packageId` onto any
+   * body served out of a package-owned overlay row, without looking at the type.
+   * So this shape may judge an AUTHORED draft and must not judge a STORED one —
+   * doing so would make this client stricter than the server (objectstack#5316).
+   *
+   * These two pins are what keep that boundary from being "simplified" away.
+   */
+  it('does not gate the edit door — a stored body may carry `_packageId`', async () => {
+    const stored = { ...SHARING_RULE, _packageId: 'crm_pkg' };
+    // Authoring door: strict, so the stamped key is an unrecognized key.
+    const create = await validateMetadataDraft('sharing_rule', stored, undefined, {
+      mode: 'create',
+    });
+    expect(create.ok).toBe(false);
+    // Edit door: no client gate, so the server stays authoritative and the
+    // client cannot report a stored body as broken.
+    const edit = await validateMetadataDraft('sharing_rule', stored, undefined, { mode: 'edit' });
+    expect(edit.ok).toBe(true);
+    expect(edit.issues).toEqual([]);
+  });
+
+  it('reports the edit door as having NO client validator', () => {
+    // Load-bearing: `ResourceEditPage` reads this to decide whether the banner's
+    // errors come from live client issues or from the server's `_diagnostics`.
+    // If this answered `true` for the edit door, an item whose client gate never
+    // runs would render as clean and the server's errors would be suppressed.
+    expect(hasClientValidator('sharing_rule', 'create')).toBe(true);
+    expect(hasClientValidator('sharing_rule', 'edit')).toBe(false);
+    // Every other wired type gates both doors.
+    expect(hasClientValidator('translation', 'edit')).toBe(true);
+    expect(hasClientValidator('connector', 'edit')).toBe(true);
+    expect(hasClientValidator('webhook', 'edit')).toBe(true);
+  });
+});
+
+// ── translation ─────────────────────────────────────────────────────────────
+
+describe('validateMetadataDraft("translation") — objectui#3561', () => {
+  it('accepts a valid translation item', async () => {
+    const res = await validateMetadataDraft('translation', TRANSLATION);
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects an unknown key with the spec-authored suggestion', async () => {
+    const res = await validateMetadataDraft('translation', { ...TRANSLATION, objectz: {} });
+    expect(res.ok).toBe(false);
+    expect(JSON.stringify(res.issues)).toContain('objectz');
+  });
+
+  it('rejects a mistyped translation-data block', async () => {
+    const res = await validateMetadataDraft('translation', { ...TRANSLATION, objects: 'nope' });
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toContain('objects');
+  });
+
+  it('rejects a nested translation-data block of the wrong type', async () => {
+    const res = await validateMetadataDraft('translation', {
+      ...TRANSLATION,
+      objects: { account: { fields: 'nope' } },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toContain('objects.account.fields');
+  });
+
+  /**
+   * The WRONG-SCHEMA pin. `TranslationBundleSchema` — the schema the retired
+   * note named — is `z.record(LocaleSchema, TranslationDataSchema)`, a map keyed
+   * by locale. It does not merely fail to catch mistakes: it rejects the valid
+   * item above, reporting `expected object, received string` on the item's own
+   * scalar keys. Had the loader been pointed at it on the strength of the stale
+   * note, every valid translation draft would have been flagged.
+   *
+   * This asserts the CURRENT wiring does not behave that way, so swapping the
+   * loader to the bundle schema turns this red.
+   */
+  it('is not judged by the bundle schema — a valid item is not flagged', async () => {
+    const res = await validateMetadataDraft('translation', TRANSLATION);
+    expect(res.issues.map((i) => i.path)).not.toContain('locale');
+    expect(res.issues.map((i) => i.path)).not.toContain('label');
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts a stored body carrying the ADR-0010 envelope on the edit door', async () => {
+    // Unlike `sharing_rule`, this shape declares all seven envelope keys, which
+    // is why it gates both doors.
+    const res = await validateMetadataDraft(
+      'translation',
+      { ...TRANSLATION, _packageId: 'crm_pkg', _lock: 'no-delete' },
+      undefined,
+      { mode: 'edit' },
+    );
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+});
+
+// ── connector ───────────────────────────────────────────────────────────────
+
+describe('validateMetadataDraft("connector") — objectui#3561', () => {
+  it('accepts a catalog descriptor (no `id` is required — the stale blocker)', async () => {
+    const res = await validateMetadataDraft('connector', CONNECTOR);
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts a provider-bound instance that references its credentials', async () => {
+    const res = await validateMetadataDraft('connector', {
+      ...CONNECTOR,
+      provider: 'stripe',
+      auth: { type: 'bearer', credentialRef: 'stripe_token' },
+    });
+    expect(res.issues, JSON.stringify(res.issues)).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  /**
+   * ── The ADR-0097 rules, i.e. why `ConnectorSchema` is the wrong target ──
+   *
+   * Every draft below is ACCEPTED by the bare `ConnectorSchema` and REJECTED by
+   * `DeclarativeConnectorEntrySchema`. That asymmetry is the entire reason the
+   * loader names the entry schema, and these four cases are the only thing that
+   * can detect a swap back to the base: the base's shape check passes them all,
+   * so no other assertion in this repo would go red.
+   *
+   * The inline-credential case is the security-shaped one — ADR-0097 §3 requires
+   * credentials to be REFERENCES on a provider-bound instance, never authored
+   * literals. Before this wiring the author learned that only from a save
+   * round-trip, having already typed the secret into the editor.
+   */
+  it('rejects `providerConfig` without a `provider`', async () => {
+    const res = await validateMetadataDraft('connector', {
+      ...CONNECTOR,
+      providerConfig: { model: 'gpt-4' },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toContain('providerConfig');
+  });
+
+  it('rejects `auth` without a `provider`', async () => {
+    const res = await validateMetadataDraft('connector', {
+      ...CONNECTOR,
+      auth: { type: 'none' },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toContain('auth');
+  });
+
+  it('rejects a provider-bound instance that inlines a secret (ADR-0097 §3)', async () => {
+    const res = await validateMetadataDraft('connector', {
+      ...CONNECTOR,
+      provider: 'stripe',
+      authentication: { type: 'bearer', token: 'sk_live_NOT_A_REFERENCE' },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toContain('authentication');
+    expect(JSON.stringify(res.issues)).toContain('credentialRef');
+  });
+
+  it('rejects a provider-bound instance that authors `actions` (ADR-0097 §5)', async () => {
+    const res = await validateMetadataDraft('connector', {
+      ...CONNECTOR,
+      provider: 'stripe',
+      actions: [{ key: 'charge', label: 'Charge' }],
+    });
+    expect(res.ok).toBe(false);
+    expect(res.issues.map((i) => i.path)).toContain('actions');
+  });
+});
+
+// ── Binding parity ──────────────────────────────────────────────────────────
+
+/**
+ * ── The structural safeguard against the wrong-schema class ──
+ *
+ * `email_template` was checked against a schema the platform does not bind, and
+ * so were all three types above. The kill for that class is to assert, from the
+ * resolved spec itself, that each loader names the schema the platform binds for
+ * that kind — so a spec-side move shows up as a red test rather than as
+ * validation that silently judges the wrong contract.
+ *
+ * WHY STRUCTURAL AND NOT IDENTITY. Object identity is unusable here, and that is
+ * measured rather than assumed: `@objectstack/spec` publishes each subpath as
+ * its own bundle, so a schema reachable from two subpaths is two distinct
+ * instances. `ObjectStackSchema.shape.webhooks`'s element — the already-wired
+ * `webhook` precedent, whose binding nobody disputes — is `!==` the
+ * `WebhookSchema` exported from `@objectstack/spec/automation`. An identity
+ * assertion would therefore fail for every type including the correct ones, which
+ * is why parity is asserted over the shape key set and the strictness flag.
+ *
+ * WHICH AUTHORITY, PER TYPE — the resolved version decides, not framework main:
+ *
+ *  - `translation` is a registered metadata KIND, so the kernel registry answers
+ *    directly: `getMetadataTypeSchema('translation')`.
+ *  - `sharing_rule` and `connector` are NOT kinds on the resolved version —
+ *    `getMetadataTypeSchema` answers `undefined` for both, and the
+ *    `UNREGISTERED_KIND_SCHEMAS` map that binds them on framework `origin/main`
+ *    (#6245) is not in `17.0.0-rc.5`. On the resolved version the authority is
+ *    the stack schema, which is where these two are declared: `sharingRules:
+ *    z.array(SharingRuleSchema)` and `connectors:
+ *    z.array(DeclarativeConnectorEntrySchema)`. When a later spec release brings
+ *    the registry binding, these assertions keep holding — #6245 binds each entry
+ *    to "the SAME schema its stack collection is validated against".
+ */
+describe('binding parity — the wired schema is the one the platform binds', () => {
+  type ZodInternals = {
+    shape?: Record<string, unknown>;
+    _zod?: { def?: { type?: string; catchall?: { _zod?: { def?: { type?: string } } } } };
+  };
+
+  const shapeKeys = (s: unknown): string[] => Object.keys((s as ZodInternals)?.shape ?? {}).sort();
+  const isStrict = (s: unknown): boolean =>
+    (s as ZodInternals)?._zod?.def?.catchall?._zod?.def?.type === 'never';
+
+  /** Unwrap optional/default/lazy wrappers down to the schema that carries a shape. */
+  const unwrap = (s: unknown, depth = 0): unknown => {
+    const def = (s as { _zod?: { def?: Record<string, unknown> } })?._zod?.def;
+    if (!def || depth > 6) return s;
+    const kind = def.type as string | undefined;
+    if (kind && ['optional', 'nullable', 'default', 'readonly', 'lazy'].includes(kind)) {
+      const inner = def.innerType ?? (typeof def.getter === 'function' ? def.getter() : undefined);
+      return unwrap(inner, depth + 1);
+    }
+    return s;
+  };
+
+  /** The element schema of an `z.array(X)` collection on the stack schema. */
+  const arrayElement = (s: unknown): unknown => {
+    const outer = unwrap(s) as { _zod?: { def?: { type?: string; element?: unknown } } };
+    return outer?._zod?.def?.type === 'array' ? unwrap(outer._zod.def.element) : undefined;
+  };
+
+  it('translation → the schema the kernel metadata-type registry binds', async () => {
+    const { getMetadataTypeSchema } = await import('@objectstack/spec/kernel');
+    const { TranslationItemSchema } = await import('@objectstack/spec/system');
+    const bound = getMetadataTypeSchema('translation');
+    expect(bound, 'translation must be a registered metadata kind').toBeDefined();
+    expect(shapeKeys(bound)).toEqual(shapeKeys(TranslationItemSchema));
+    expect(isStrict(bound)).toBe(isStrict(TranslationItemSchema));
+    // And it is emphatically NOT the bundle shape the retired note named.
+    const { TranslationBundleSchema } = await import('@objectstack/spec/system');
+    expect(shapeKeys(bound)).not.toEqual(shapeKeys(TranslationBundleSchema));
+  });
+
+  it('sharing_rule → the schema `ObjectStackSchema.sharingRules` binds', async () => {
+    const { ObjectStackSchema } = await import('@objectstack/spec');
+    const { SharingRuleSchema } = await import('@objectstack/spec/security');
+    const element = arrayElement(ObjectStackSchema.shape.sharingRules);
+    expect(element, 'sharingRules must be an array collection').toBeDefined();
+    expect(shapeKeys(element)).toEqual(shapeKeys(SharingRuleSchema));
+    expect(isStrict(element)).toBe(isStrict(SharingRuleSchema));
+    // The retired note's premise, pinned so it cannot quietly become true again.
+    expect(shapeKeys(SharingRuleSchema).length).toBeGreaterThan(0);
+    expect(isStrict(SharingRuleSchema)).toBe(true);
+  });
+
+  it('connector → the schema `ObjectStackSchema.connectors` binds', async () => {
+    const { ObjectStackSchema } = await import('@objectstack/spec');
+    const { DeclarativeConnectorEntrySchema, ConnectorSchema } = await import(
+      '@objectstack/spec/integration'
+    );
+    const element = arrayElement(ObjectStackSchema.shape.connectors);
+    expect(element, 'connectors must be an array collection').toBeDefined();
+    expect(shapeKeys(element)).toEqual(shapeKeys(DeclarativeConnectorEntrySchema));
+
+    // The two connector schemas share a shape, so shape parity alone cannot tell
+    // them apart — the ADR-0097 rules are CHECKS, not keys. Count them: the stack
+    // element carries the entry schema's refinement, the base carries none. This
+    // is what makes the parity assertion above meaningful rather than vacuous.
+    const checks = (s: unknown): number =>
+      ((s as { _zod?: { def?: { checks?: unknown[] } } })?._zod?.def?.checks ?? []).length;
+    expect(shapeKeys(ConnectorSchema)).toEqual(shapeKeys(DeclarativeConnectorEntrySchema));
+    expect(checks(ConnectorSchema)).toBe(0);
+    expect(checks(DeclarativeConnectorEntrySchema)).toBeGreaterThan(0);
+    expect(checks(element)).toBe(checks(DeclarativeConnectorEntrySchema));
+
+    // And the retired note's premise: there is no required `id` key.
+    expect(shapeKeys(ConnectorSchema)).not.toContain('id');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -479,6 +479,40 @@ function expandViewIssues(
   });
 }
 
+/**
+ * ── Author-shape-only types (objectui#3561) ──
+ *
+ * A spec schema is usable as an EDIT gate only if it declares the ADR-0010
+ * protection envelope — `_lock` / `_lockReason` / `_lockSource` / `_provenance`
+ * / `_packageId` / `_packageVersion` / `_lockDocsUrl`. A stored body carries
+ * those keys: the metadata read path stamps `_packageId` onto any item served
+ * out of a package-owned overlay row, and it does so WITHOUT looking at the
+ * type. Judging such a body with a `.strict()` schema that does not declare the
+ * envelope makes this client stricter than the server — the objectstack#5316
+ * inversion the `view` gates above exist to avoid.
+ *
+ * Measured on the resolved `@objectstack/spec` 17.0.0-rc.5: every type already
+ * wired below declares all 7 envelope keys. `SharingRuleSchema` declares NONE
+ * of them and is `.strict()`, so it is the one shape that must not judge a
+ * stored body — `safeParse({…validRule, _packageId: 'pkg'})` fails with
+ * `unrecognized_keys`. Framework `origin/main` reaches the same conclusion in
+ * its own words at `kernel/metadata-type-schemas.ts`, where the schema is bound
+ * for the write door only: *"This shape is `.strict()` with no stored/stamped
+ * envelope, so it is an AUTHOR-shape check and is applied only where author
+ * shapes are submitted: the write door. It is not a filter on rows already in
+ * `sys_sharing_rule`."*
+ *
+ * So the type is wired on `create` — the AUTHORING door, which is exactly where
+ * a permissive match-all sharing condition gets written — and deliberately not
+ * on `edit`. This is NOT a tolerant fallback: nothing is coerced and no draft is
+ * waved through; one door has a client gate and the other keeps the server's.
+ * The contract-first repair is spec-side (the envelope belongs on
+ * `SharingRuleSchema`, which framework #6931 notes went undeclared because this
+ * shape sits outside the gate that enforces envelope declaration); until that
+ * lands, reconstructing the envelope here would be a second de-facto contract.
+ */
+const AUTHOR_SHAPE_ONLY_TYPES = new Set<string>(['sharing_rule']);
+
 // Map metadata-type name → loader for that type's root Zod schema.
 // Each loader pulls only one spec subpath so we don't drag the whole
 // 2MB schema bundle into the studio bundle.
@@ -494,11 +528,10 @@ function expandViewIssues(
 //     `policy` metadata file, so it must not be substituted.
 //   - `trigger`: no standalone TriggerSchema export at runtime (only
 //     ConnectorTriggerSchema / WebhookEventSchema variants).
-//   - `sharing_rule`: SharingRuleSchema is declared but has empty shape — server-only.
-//   - `translation`: TranslationBundleSchema is z.object({}) — accepts anything; server-only.
-//   - `connector`: ConnectorSchema requires an `id` field that's not in the on-disk
-//     metadata shape — the spec models the runtime connector instance, not the file.
-//     Wiring it would flag every valid connector definition.
+//
+// `sharing_rule` / `translation` / `connector` used to be on that list too. All
+// three reasons were re-verified against the resolved spec and none held —
+// objectui#3561; each is now wired below with the measurement that replaced it.
 const LOADERS: Record<string, SchemaLoader> = {
   // data
   object: async () => (await import('@objectstack/spec/data')).ObjectSchema as unknown as ZodLikeSchema,
@@ -583,6 +616,27 @@ const LOADERS: Record<string, SchemaLoader> = {
   // and `bodyHtml` / `bodyText`, not `id` and `body` + `bodyType`.
   email_template: async () => (await import('@objectstack/spec/system')).EmailTemplateDefinitionSchema as unknown as ZodLikeSchema,
   job: async () => (await import('@objectstack/spec/system')).JobSchema as unknown as ZodLikeSchema,
+  // NOTE: `TranslationItemSchema`, NOT `TranslationBundleSchema` — the same
+  // wrong-schema class this file already paid for once on `email_template`
+  // above (objectui#3561).
+  //
+  // The old note said "TranslationBundleSchema is z.object({}) — accepts
+  // anything". On the resolved spec 17.0.0-rc.5 that schema is
+  // `z.record(LocaleSchema, TranslationDataSchema)` — the BUNDLE shape, a map
+  // keyed by locale — and it is not lenient at all: it REJECTS a valid
+  // translation item, reporting `expected object, received string` on `name`,
+  // `locale` and `label`. So the stale reason was wrong twice over, and had the
+  // schema been wired on that reasoning it would have flagged every valid
+  // draft.
+  //
+  // `translation` is a registered metadata KIND, so the resolved spec can be
+  // asked directly which schema it binds: `getMetadataTypeSchema('translation')`
+  // (`@objectstack/spec/kernel`) answers a strict object whose shape is exactly
+  // `TranslationItemSchema`'s 19 keys — the translation-data shape plus
+  // `locale` / `name` / `label` and all 7 ADR-0010 envelope keys. That parity is
+  // asserted in `clientValidation.optOuts.test.ts` so the binding cannot drift
+  // out from under this line unnoticed.
+  translation: async () => (await import('@objectstack/spec/system')).TranslationItemSchema as unknown as ZodLikeSchema,
 
   // security
   // NOTE: use PermissionSetSchema from /security, NOT PluginPermissionSchema from /kernel —
@@ -590,6 +644,16 @@ const LOADERS: Record<string, SchemaLoader> = {
   // metadata permission set ({name,objects,fields}). See
   // packages/spec/src/kernel/metadata-type-schemas.ts for the canonical mapping.
   permission: async () => (await import('@objectstack/spec/security')).PermissionSetSchema as unknown as ZodLikeSchema,
+  // The old note said `SharingRuleSchema` "is declared but has empty shape".
+  // On the resolved spec 17.0.0-rc.5 it is `CriteriaSharingRuleSchema` — a
+  // `.strict()` object declaring nine keys (`name`, `label`, `description`,
+  // `object`, `active`, `accessLevel`, `sharedWith`, `type`, `condition`) with
+  // a curated unknown-key error map. Not empty, and the same shape
+  // `ObjectStackSchema.sharingRules` binds element-wise.
+  //
+  // CREATE ONLY — see `AUTHOR_SHAPE_ONLY_TYPES` above for why this shape may
+  // not judge a stored body.
+  sharing_rule: async () => (await import('@objectstack/spec/security')).SharingRuleSchema as unknown as ZodLikeSchema,
   // `policy` intentionally omitted — spec 11.2.0 dropped `PolicySchema` and the metadata-type
   // registry has no `policy` schema; drafts fall through to server-side validation (see top).
   // `profile` intentionally omitted — ADR-0090 D2 removed the profile concept (spec 13);
@@ -600,6 +664,39 @@ const LOADERS: Record<string, SchemaLoader> = {
 
   // api
   api: async () => (await import('@objectstack/spec/api')).ApiEndpointSchema as unknown as ZodLikeSchema,
+
+  // integration
+  //
+  // NOTE: `DeclarativeConnectorEntrySchema`, NOT the bare `ConnectorSchema`.
+  //
+  // The old note claimed `ConnectorSchema` "requires an `id` field that's not
+  // in the on-disk metadata shape" and that wiring it "would flag every valid
+  // connector definition". On the resolved spec 17.0.0-rc.5 there is no `id`
+  // key in that schema at all: its required keys are `name`, `label`, `type`,
+  // and a minimal `{ name, label, type: 'saas' }` entry parses clean.
+  //
+  // But `ConnectorSchema` is still the wrong target, for the reason the spec
+  // states itself: the base "stays a plain object so connector subtypes
+  // (github / database / …) can still `.extend()` it", while
+  // `DeclarativeConnectorEntrySchema` is that base plus the ADR-0097 rules that
+  // apply to a connector AUTHORED in a stack — which is what this admin writes.
+  // `ObjectStackSchema.connectors` binds the entry schema element-wise.
+  //
+  // Measured difference on rc.5 — each of these is ACCEPTED by `ConnectorSchema`
+  // and REJECTED by the entry schema, so naming the base would have been a
+  // vacuous pass on exactly the authoring mistakes ADR-0097 exists to catch:
+  //   - `providerConfig` without a `provider` (§meaningless on a descriptor);
+  //   - `auth` without a `provider`;
+  //   - a provider-bound instance inlining credentials via `authentication`
+  //     rather than referencing them (§3);
+  //   - a provider-bound instance authoring `actions` the provider derives (§5).
+  // The rules fire only for provider-bound instances, so a catalog descriptor
+  // is unaffected. Unlike the two above this schema is NOT strict — unknown keys
+  // are stripped, not rejected — so it judges a stored body safely and is wired
+  // on both gates.
+  connector: async () =>
+    (await import('@objectstack/spec/integration'))
+      .DeclarativeConnectorEntrySchema as unknown as ZodLikeSchema,
 };
 
 // Flow node `type` values the running server accepts but the published
@@ -699,7 +796,10 @@ async function getSchemaForType(type: string, mode: DraftMode): Promise<ZodLikeS
   const key = `${mode}:${type}`;
   if (SCHEMA_CACHE.has(key)) return SCHEMA_CACHE.get(key) ?? null;
   const loader = LOADERS[type];
-  if (!loader) {
+  // `AUTHOR_SHAPE_ONLY_TYPES` is consulted HERE rather than inside the loader so
+  // the fact lives in exactly one place: `hasClientValidator` reads the same set
+  // synchronously, and the two can never disagree about which door has a gate.
+  if (!loader || (mode === 'edit' && AUTHOR_SHAPE_ONLY_TYPES.has(type))) {
     SCHEMA_CACHE.set(key, null);
     return null;
   }
@@ -715,11 +815,23 @@ async function getSchemaForType(type: string, mode: DraftMode): Promise<ZodLikeS
 }
 
 /**
- * Returns true if a client-side schema exists for the given metadata
- * type. Useful for deciding whether to skip the debounce in caller.
+ * Returns true if a client-side schema exists for the given metadata type ON
+ * THE GIVEN DOOR. Useful for deciding whether to skip the debounce in caller.
+ *
+ * The `mode` argument is load-bearing, not cosmetic (objectui#3561). Callers do
+ * not merely skip work when this is `false` — `ResourceEditPage` also uses it to
+ * decide WHERE the diagnostics banner reads its errors from: `true` means "the
+ * live client issues are the error source", which suppresses the server's
+ * load-time `_diagnostics`. A type wired on `create` only would therefore have
+ * silently blanked the server's errors on the edit path had this stayed
+ * mode-blind — reporting a stored item as clean because no client gate ran.
+ *
+ * Defaults to `'create'` to match `validateMetadataDraft`, whose default is the
+ * strict authoring door.
  */
-export function hasClientValidator(type: string): boolean {
-  return type in LOADERS;
+export function hasClientValidator(type: string, mode: DraftMode = 'create'): boolean {
+  if (!(type in LOADERS)) return false;
+  return !(mode === 'edit' && AUTHOR_SHAPE_ONLY_TYPES.has(type));
 }
 
 export interface ValidateResult {


### PR DESCRIPTION
Fixes #3561

Three metadata types opted out of live client-side Zod validation in
`packages/app-shell/src/views/metadata-admin/clientValidation.ts` on recorded
reasons. Every claim was re-verified against the **resolved installed**
`@objectstack/spec` — `17.0.0-rc.5`, what pnpm installs for the workspace pin —
rather than framework `origin/main`, per the card's verification boundary. None
of the three reasons held.

## Per-type findings on the resolved spec

| Type | Recorded reason | Measured on `17.0.0-rc.5` |
|---|---|---|
| `sharing_rule` | "`SharingRuleSchema` is declared but has empty shape" | It is `CriteriaSharingRuleSchema` — a `.strict()` object of **nine** keys (`name`, `label`, `description`, `object`, `active`, `accessLevel`, `sharedWith`, `type`, `condition`) with a curated unknown-key error map. |
| `translation` | "`TranslationBundleSchema` is `z.object({})` — accepts anything" | Wrong schema *and* wrong description. The kind resolves `TranslationItemSchema`; the bundle schema is `z.record(LocaleSchema, TranslationDataSchema)` and it **rejects** a valid translation item, reporting `expected object, received string` on `name` / `locale` / `label`. Wiring it on that reasoning would have flagged every valid draft. |
| `connector` | "`ConnectorSchema` requires an `id` field ... would flag every valid connector definition" | There is no `id` key in the schema at all — required keys are `name`, `label`, `type`, and a minimal entry parses clean. The authoring shape is `DeclarativeConnectorEntrySchema`. |

All three premises are false, so `premise_still_valid` holds for the card itself:
the opt-outs were unjustified. Each loader now names the schema the platform
binds — `SharingRuleSchema`, `TranslationItemSchema`,
`DeclarativeConnectorEntrySchema` — matching the worked `webhook` precedent, and
errors surface through the existing diagnostics banner with no new UX.

## Why `ConnectorSchema` is still the wrong target

The spec says it itself: the base "stays a plain object so connector subtypes
can `.extend()` it", while the entry schema adds the ADR-0097 rules for a
connector authored in a stack. Measured — each of these is **accepted** by
`ConnectorSchema` and **rejected** by `DeclarativeConnectorEntrySchema`:

- `providerConfig` without a `provider`
- `auth` without a `provider`
- a provider-bound instance inlining credentials via `authentication` (§3)
- a provider-bound instance authoring `actions` the provider derives (§5)

So naming the base would have been a vacuous pass on exactly the authoring
mistakes ADR-0097 exists to catch — the security half of the card's framing.

## `sharing_rule` is wired on the create door only

A spec schema can judge a **stored** body only if it declares the ADR-0010
protection envelope. All eight already-wired types declare all seven envelope
keys; `SharingRuleSchema` declares **none** and is `.strict()`, so
`safeParse({ ...validRule, _packageId: 'pkg' })` fails with `unrecognized_keys`
— and the metadata read path stamps `_packageId` onto any body served from a
package-owned overlay row, without looking at the type. Judging a stored body
with it would make this client stricter than the server, the objectstack#5316
inversion the `view` gates already exist to avoid.

Framework `origin/main` reaches the same conclusion in its own words, binding the
schema for the write door only:

> This shape is `.strict()` with no stored/stamped envelope, so it is an
> AUTHOR-shape check and is applied only where author shapes are submitted:
> the write door. It is not a filter on rows already in `sys_sharing_rule`.

So the type gates `create` — the authoring door, which is where a permissive
match-all sharing condition gets written — and not `edit`. This is not a tolerant
fallback: nothing is coerced and no draft is waved through. The contract-first
repair is spec-side (the envelope belongs on `SharingRuleSchema`); reconstructing
it client-side would be a second de-facto contract. Filed upstream as
objectstack#7404 (observation-class; this PR does not depend on it).

`hasClientValidator(type, mode)` therefore takes the door as a second argument.
That is load-bearing rather than cosmetic: `ResourceEditPage` also reads it to
choose the diagnostics **source**, so a mode-blind answer would have made a type
with no gate on the edit path render as clean and suppressed the server's own
`_diagnostics`. The parameter defaults to `'create'`, matching
`validateMetadataDraft`.

## Binding parity — killing the wrong-schema class structurally

This file has now paid for the wrong-schema error twice (`email_template`, then
these three), so the new tests assert from the resolved spec that each loader
names the schema the platform binds.

Parity is asserted **structurally, not by identity**, and that is measured rather
than preferred: `@objectstack/spec` publishes each subpath as its own bundle, so a
schema reachable from two subpaths is two instances. `ObjectStackSchema.shape.webhooks`'s
element — the already-wired `webhook` precedent, whose binding nobody disputes —
is not identical to the `WebhookSchema` exported from `@objectstack/spec/automation`.
An identity assertion would fail for every type including the correct ones.

Authority per type, chosen by what the **resolved** version exposes:

- `translation` is a registered kind, so `getMetadataTypeSchema('translation')` answers.
- `sharing_rule` / `connector` are **not** kinds on rc.5 — `getMetadataTypeSchema`
  answers `undefined` for both, and the `UNREGISTERED_KIND_SCHEMAS` map that binds
  them on framework main (objectstack#6245) is not in this release. The resolved-version
  authority is the stack schema: `sharingRules: z.array(SharingRuleSchema)` and
  `connectors: z.array(DeclarativeConnectorEntrySchema)`. Those assertions keep
  holding when the registry binding ships, since #6245 binds each entry to "the
  SAME schema its stack collection is validated against".

For `connector` the two schemas share a shape, so shape parity alone would be
vacuous — the ADR-0097 rules are *checks*, not keys. The test counts them: base 0,
entry greater than 0, stack element equal to the entry's.

## Tests

New `clientValidation.optOuts.test.ts` — 20 cases, red + green per type.

Reverse verification, direction predicted before each run, all three matched:

| Mutation | Predicted | Observed |
|---|---|---|
| `connector` to `ConnectorSchema` | the 4 ADR-0097 rejections go red, nothing else | exactly those 4 failed (16 passed) |
| `translation` to `TranslationBundleSchema` | the green cases go red | 5 failed (15 passed) |
| `sharing_rule` dropped from `AUTHOR_SHAPE_ONLY_TYPES` | the 2 edit-door pins go red | exactly those 2 failed (18 passed) |

One honest nuance: under mutation 2 the `objects: 'nope'` case stayed **green**,
because the bundle schema rejects that draft too — for an unrelated reason. It is
kept as a shape pin, but it is not what discriminates the two schemas; the other
five are.

Local gates, all from the repo root per AGENTS.md §9:

- `pnpm exec vitest run packages/app-shell/` — **318 files, 2964 passed**, 1 skipped
- `pnpm exec vitest run apps/console/` (downstream consumer) — **29 files, 300 passed**
- `pnpm --filter @object-ui/app-shell type-check` — clean (after
  `pnpm --filter '@object-ui/app-shell^...' build`; without the closure it fails
  with spurious `Cannot find module '@object-ui/*'`)
- `pnpm exec eslint` on the three changed files — **0 errors**
- `node scripts/check-control-bytes.mjs` — OK
- `node scripts/check-changeset-presence.mjs` — OK

Consumer sweep used the **prefix** (downstream) filter direction,
`--filter '...@object-ui/app-shell'`: `@object-ui/console` plus two examples.
`hasClientValidator` / `validateMetadataDraft` have no importers outside
`metadata-admin/`, and the added parameter is optional, so the signature change
has no external blast radius.

## Behaviour change

Drafts of these three types are now rejected in the editor **before** save, where
they previously round-tripped to the server. That is the point of the card's
security framing — most notably a `connector` draft that inlines a credential is
now caught at authoring time, rather than after the author has typed the secret
and saved it. Changeset: `@object-ui/app-shell` patch.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_