### PR TITLE
fix(grid,list,app-shell): gate row Edit/Delete on the caller's permission, not just apiOperations

### DIFF
--- a/.changeset/row-crud-permission-gate-4096.md
+++ b/.changeset/row-crud-permission-gate-4096.md
@@ -1,0 +1,54 @@
+---
+"@object-ui/plugin-grid": patch
+"@object-ui/plugin-list": patch
+"@object-ui/app-shell": patch
+---
+
+List row Edit/Delete, bulk delete and related-list CRUD now run the caller's own permission, not just the object's API exposure (objectui#4096)
+
+The row kebab's built-in Edit/Delete rendered for every account, including ones
+the server answers `403 PERMISSION_DENIED` on. Clicking Edit opened a fully
+prefilled dialog that could only fail on save; Delete — a destructive entry —
+sat one click away from users who could never perform it.
+
+The gate intersected the object's resolved CRUD affordance with the server's
+effective API operation set (`/me/permissions` `apiOperations`, objectui#3720),
+and nothing else. `apiOperations` is the object's **API exposure surface** —
+"which verbs does this object publish" — and the spec's own describe text says
+so. It is principal-independent: the report measured two accounts with opposite
+`allowEdit`, 30 shared objects, and **30/30 identical** `apiOperations`. A gate
+made only of object-scoped layers therefore fails OPEN for every unprivileged
+caller, which is why the same screen carried three different answers to "may
+this user write this object": the toolbar's New was correctly hidden
+(`affordances.create && can(obj, 'create')`), the record header's Edit/Delete
+were correctly hidden (per-record write probe), and the row kebab was not.
+
+Four surfaces now AND the principal's own verdict — `can(obj, 'update' |
+'delete')`, i.e. `/me/permissions` `allowEdit` / `allowDelete`, the toolbar's
+source — on top of the layers they already had:
+
+- the grid row kebab's built-in Edit/Delete (`resolveRowCrudAffordances` gained
+  `permissionUpdate` / `permissionDelete`, filled at the `ObjectGrid` call site);
+- the grid's bulk-delete bar, which rides the same object-level delete verdict,
+  so the row gate and the more destructive bulk entry move together;
+- the non-grid (kanban / calendar / gallery) bulk bar `ListView` renders itself;
+- the related-list Create/Edit/Delete on a child object
+  (`RelatedRecordActionsBridge`), which had the same object-only gate.
+
+**This is a tightening of the intersection, not a swap.** Every existing layer
+stays: the ADR-0103 lifecycle bucket, `userActions.edit` / `delete`, and
+`apiOperations`. A permission grant cannot re-open what any of them closed, and
+none of them survives a permission denial.
+
+Fail-open is preserved where it is the deliberate contract: `usePermissions()`
+with no `PermissionProvider` answers `can: () => true`, so standalone embeds and
+hosts that ship no permission source keep their Edit/Delete exactly as before.
+Under `MePermissionsProvider` the semantics are the toolbar's, unchanged and now
+shared: an authenticated principal whose object is absent from
+`/me/permissions.objects` resolves fail-closed (objectui#2926 ④), an anonymous
+session keeps the permissive default, and children never render while the
+permission set is loading. Per-key absence is still permissive — an object entry
+without `allowEdit` reads as allowed.
+
+Server-side enforcement was already hard (403, DB unchanged), so this closes a
+UI-affordance gap rather than an authorization hole.

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -123,7 +123,7 @@ export function RelatedRecordActionsBridge({
   const navigate = useNavigate();
   const { execute } = useAction();
   const [, setSearchParams] = useSearchParams();
-  const { getObjectApiOperations } = usePermissions();
+  const { getObjectApiOperations, can } = usePermissions();
   const base = appName ? `/apps/${appName}` : '';
 
   // #2604 D3 — open a child create/edit task as the console's global record
@@ -184,7 +184,21 @@ export function RelatedRecordActionsBridge({
         // (`/me/permissions` `apiOperations`), so a related list never offers
         // Create/Edit/Delete on the child the server would 405. `undefined`
         // (unrestricted / old backend) leaves the affordances untouched.
-        const aff = resolveEffectiveCrudAffordances(childDef, getObjectApiOperations(objectName));
+        //
+        // [#4096] …then with the CURRENT PRINCIPAL's permission on the child
+        // (`allowCreate` / `allowEdit` / `allowDelete`). `apiOperations` is the
+        // child object's exposure surface and is identical for every account,
+        // so on its own it fails open: a related list used to offer Edit and
+        // Delete to a principal with no write grant on the child. `can()`
+        // answers `true` with no `PermissionProvider`, which keeps standalone
+        // embeds exactly where they were.
+        const rawAff = resolveEffectiveCrudAffordances(childDef, getObjectApiOperations(objectName));
+        const aff = {
+          ...rawAff,
+          create: rawAff.create && can(objectName, 'create'),
+          edit: rawAff.edit && can(objectName, 'update'),
+          delete: rawAff.delete && can(objectName, 'delete'),
+        };
         const detailUrl = (id: string | number) => {
           const url = `${base}/${objectName}/record/${encodeURIComponent(String(id))}`;
           // Carry the parent record into the child's `?from=` trail so the
@@ -254,7 +268,7 @@ export function RelatedRecordActionsBridge({
         return handlers;
       },
     }),
-    [objects, base, navigate, dataSource, actionLabel, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle, getObjectApiOperations],
+    [objects, base, navigate, dataSource, actionLabel, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle, getObjectApiOperations, can],
   );
 
   return (

--- a/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.effectiveOps.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.effectiveOps.test.tsx
@@ -1,19 +1,26 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * RelatedRecordActionsBridge — effective API operations (#3546).
+ * RelatedRecordActionsBridge — the two gates that narrow a related list's
+ * Create/Edit/Delete: the effective API operations (#3546) and the CURRENT
+ * PRINCIPAL's permission on the child object (#4096).
  *
- * The related-list Create/Edit/Delete affordances for a CHILD object must be
- * intersected with the server-resolved effective operation set for that child
- * (`/me/permissions` `apiOperations`), so the list never offers an operation
- * the server would 405. These pin the button-visibility outcome:
+ * The related-list affordances for a CHILD object must be intersected with the
+ * server-resolved effective operation set for that child (`/me/permissions`
+ * `apiOperations`), so the list never offers an operation the server would 405:
  *   • full CRUD effective set → onCreate/onEdit/onDelete all present;
  *   • read-only effective set → none present;
  *   • update-only effective set → onEdit present, onCreate/onDelete absent;
  *   • undefined (unrestricted / old backend) → bucket affordances win (all present).
+ *
+ * [#4096] …and with the principal's `allowCreate` / `allowEdit` / `allowDelete`.
+ * `apiOperations` describes the child OBJECT's exposure surface and is identical
+ * for every account, so on its own it fails open — the second face of the row
+ * kebab defect the main list carried. Both gates live in this one file so a
+ * future change that drops either one fails here.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
@@ -21,10 +28,14 @@ import { vi } from 'vitest';
 
 // Controllable effective-operations map, keyed by child object name.
 let effectiveOps: Record<string, string[] | undefined> = {};
+// [#4096] Controllable principal verdict, keyed by action. `undefined` action
+// entries default to allowed, matching `can()`'s permissive fallback.
+let principal: Record<string, boolean> = {};
 
 vi.mock('@object-ui/permissions', () => ({
   usePermissions: () => ({
     getObjectApiOperations: (name: string) => effectiveOps[name],
+    can: (_name: string, action: string) => principal[action] ?? true,
   }),
 }));
 
@@ -65,6 +76,11 @@ function resolveHandlers(): Record<string, boolean> {
   return captured;
 }
 
+beforeEach(() => {
+  effectiveOps = {};
+  principal = {};
+});
+
 describe('RelatedRecordActionsBridge — effective API operations (#3546)', () => {
   it('full-CRUD effective set → Create/Edit/Delete all offered', () => {
     effectiveOps = { [CHILD]: ['get', 'list', 'create', 'update', 'delete'] };
@@ -98,5 +114,60 @@ describe('RelatedRecordActionsBridge — effective API operations (#3546)', () =
     expect(h.onCreate).toBe(true);
     expect(h.onEdit).toBe(true);
     expect(h.onDelete).toBe(true);
+  });
+});
+
+describe('RelatedRecordActionsBridge — principal permission gate (#4096)', () => {
+  const FULL = ['get', 'list', 'create', 'update', 'delete'];
+
+  it('a principal WITH the write grants keeps Create/Edit/Delete', () => {
+    effectiveOps = { [CHILD]: FULL };
+    principal = { create: true, update: true, delete: true };
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(true);
+    expect(h.onEdit).toBe(true);
+    expect(h.onDelete).toBe(true);
+  });
+
+  it('a principal WITHOUT them loses all three — on a fully exposed child', () => {
+    // The #4096 shape carried over to the related list: identical full
+    // `apiOperations`, no write permission. Pre-#4096 all three were offered.
+    effectiveOps = { [CHILD]: FULL };
+    principal = { create: false, update: false, delete: false };
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(false);
+    expect(h.onEdit).toBe(false);
+    expect(h.onDelete).toBe(false);
+    // Viewing a child record is not a write — it must survive.
+    expect(h.onView).toBe(true);
+  });
+
+  it('gates create / update / delete independently', () => {
+    effectiveOps = { [CHILD]: FULL };
+    principal = { create: false, update: true, delete: false };
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(false);
+    expect(h.onEdit).toBe(true);
+    expect(h.onDelete).toBe(false);
+  });
+
+  it('with no permission source at all the affordances survive (fail-open preserved)', () => {
+    // `usePermissions()` with no `PermissionProvider` answers `can: () => true`
+    // and `getObjectApiOperations: () => undefined` — the stub's defaults here.
+    effectiveOps = { [CHILD]: undefined };
+    principal = {};
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(true);
+    expect(h.onEdit).toBe(true);
+    expect(h.onDelete).toBe(true);
+  });
+
+  it('keeps apiOperations as a layer — a write grant cannot re-open a closed surface', () => {
+    effectiveOps = { [CHILD]: ['get', 'list'] };
+    principal = { create: true, update: true, delete: true };
+    const h = resolveHandlers();
+    expect(h.onCreate).toBe(false);
+    expect(h.onEdit).toBe(false);
+    expect(h.onDelete).toBe(false);
   });
 });

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -435,6 +435,15 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   const perms = usePermissions();
   const { getObjectApiOperations } = perms;
   const effectiveApiOps = objectName ? getObjectApiOperations(objectName) : undefined;
+  // [#4096] The CURRENT PRINCIPAL's write verdict on this object, the same
+  // source the toolbar's `can(obj, 'create')` reads (`/me/permissions`
+  // `allowEdit` / `allowDelete`). `effectiveApiOps` above cannot stand in for
+  // it: that set is the object's API exposure surface and is identical for
+  // every account, so the row kebab and the bulk bar used to fail open for a
+  // read-only principal. Undefined when no object name is resolved (element
+  // data source), which leaves the affordance verdict untouched.
+  const permissionUpdate = objectName ? perms.can(objectName, 'update') : undefined;
+  const permissionDelete = objectName ? perms.can(objectName, 'delete') : undefined;
   const schemaFields = schema.fields;
   const schemaColumns = schema.columns;
   // The view's declared filter, lowered ONCE through the repo's single filter
@@ -1644,6 +1653,9 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
   // `operations` above only says whether the CONSUMER wired the affordance; it
   // is not a permission grant, which is why the object verdict is ANDed here
   // rather than assumed to have been applied upstream.
+  // [#4096] …and neither is `apiOperations`, which describes the OBJECT, not
+  // the caller — so the principal's own `allowEdit` / `allowDelete` is ANDed on
+  // top, matching the toolbar and the record header on the very same screen.
   const { canEdit, canDelete, objectCanDelete, editPredicates, deletePredicates } = resolveRowCrudAffordances({
     operationsUpdate: operations?.update,
     operationsDelete: operations?.delete,
@@ -1654,6 +1666,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
     managedBy: (objectSchema as any)?.managedBy,
     userActions: (objectSchema as any)?.userActions,
     effectiveApiOperations: effectiveApiOps,
+    permissionUpdate,
+    permissionDelete,
   });
   const hasActions = !!(operations && (operations.update || operations.delete));
   const hasRowActions = customRowActions.length > 0 || resolvedRowActionDefs.length > 0 || wantEditAction || wantDeleteAction;

--- a/packages/plugin-grid/src/__tests__/legacyRowActionDispatch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/legacyRowActionDispatch.test.tsx
@@ -30,7 +30,7 @@ import '@testing-library/jest-dom';
 import React from 'react';
 
 vi.mock('@object-ui/permissions', () => ({
-  usePermissions: () => ({ isLoaded: false, checkField: () => true, getObjectApiOperations: () => undefined }),
+  usePermissions: () => ({ isLoaded: false, checkField: () => true, getObjectApiOperations: () => undefined, can: () => true }),
 }));
 
 import { ObjectGrid } from '../ObjectGrid';

--- a/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
+++ b/packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx
@@ -33,7 +33,7 @@ import '@testing-library/jest-dom';
 import React from 'react';
 
 vi.mock('@object-ui/permissions', () => ({
-  usePermissions: () => ({ isLoaded: false, checkField: () => true, getObjectApiOperations: () => undefined }),
+  usePermissions: () => ({ isLoaded: false, checkField: () => true, getObjectApiOperations: () => undefined, can: () => true }),
 }));
 
 import { ObjectGrid } from '../ObjectGrid';

--- a/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
+++ b/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
@@ -200,6 +200,92 @@ describe('resolveRowCrudAffordances', () => {
       expect(resolveRowCrudAffordances({ ...wired, managedBy: 'append-only' }).objectCanDelete).toBe(false);
       expect(resolveRowCrudAffordances({ ...wired, effectiveApiOperations: ['get', 'list'] }).objectCanDelete).toBe(false);
       expect(resolveRowCrudAffordances({ ...wired, effectiveApiOperations: ['get', 'list', 'delete'] }).objectCanDelete).toBe(true);
+      // [#4096] …including the principal layer, so the bulk bar cannot outlive
+      // the row kebab for a caller with no delete grant.
+      expect(resolveRowCrudAffordances({ ...wired, permissionDelete: false }).objectCanDelete).toBe(false);
+    });
+  });
+
+  // [#4096] The principal layer. `effectiveApiOperations` describes the OBJECT
+  // (which verbs it publishes) and is byte-identical across accounts with
+  // opposite write grants — measured 30/30 in the report — so it can never act
+  // as the user permission gate on its own. `permissionUpdate` /
+  // `permissionDelete` carry `/me/permissions` `allowEdit` / `allowDelete`.
+  describe('#4096 principal-scoped permission gate', () => {
+    const FULL = ['get', 'list', 'create', 'update', 'delete'];
+
+    it('a principal WITH write permission still sees both entries', () => {
+      expect(rowGate({ ...wired, effectiveApiOperations: FULL, permissionUpdate: true, permissionDelete: true }))
+        .toEqual({ canEdit: true, canDelete: true });
+    });
+
+    it('a principal WITHOUT write permission sees neither — even on a fully exposed object', () => {
+      // The exact #4096 shape: account A's `apiOperations` is the full verb set
+      // (identical to the writer's) while `allowEdit` / `allowDelete` are false.
+      // Before this layer the row kebab rendered both entries regardless.
+      expect(rowGate({ ...wired, effectiveApiOperations: FULL, permissionUpdate: false, permissionDelete: false }))
+        .toEqual({ canEdit: false, canDelete: false });
+    });
+
+    it('gates update and delete independently', () => {
+      expect(rowGate({ ...wired, effectiveApiOperations: FULL, permissionUpdate: true, permissionDelete: false }))
+        .toEqual({ canEdit: true, canDelete: false });
+      expect(rowGate({ ...wired, effectiveApiOperations: FULL, permissionUpdate: false, permissionDelete: true }))
+        .toEqual({ canEdit: false, canDelete: true });
+    });
+
+    it('an absent verdict changes nothing (no object name / no provider)', () => {
+      // `usePermissions()` with no `PermissionProvider` answers `can: () => true`,
+      // so a provider-less host arrives here as `true`, not `undefined` — both
+      // shapes must leave the pre-#4096 outcome intact.
+      expect(rowGate({ ...wired, permissionUpdate: undefined, permissionDelete: undefined }))
+        .toEqual({ canEdit: true, canDelete: true });
+      expect(rowGate({ ...wired, permissionUpdate: true, permissionDelete: true }))
+        .toEqual({ canEdit: true, canDelete: true });
+    });
+
+    it('intersects, never unions — a permission grant cannot re-open a bucket lock', () => {
+      expect(rowGate({ ...wired, managedBy: 'append-only', permissionUpdate: true, permissionDelete: true }))
+        .toEqual({ canEdit: false, canDelete: false });
+    });
+
+    it('intersects, never unions — a permission grant cannot re-open a userActions opt-out', () => {
+      expect(rowGate({
+        ...wired,
+        userActions: { edit: false, delete: false },
+        permissionUpdate: true,
+        permissionDelete: true,
+      })).toEqual({ canEdit: false, canDelete: false });
+    });
+
+    it('intersects, never unions — a permission grant cannot re-open a server denial', () => {
+      expect(rowGate({
+        ...wired,
+        effectiveApiOperations: ['get', 'list'],
+        permissionUpdate: true,
+        permissionDelete: true,
+      })).toEqual({ canEdit: false, canDelete: false });
+    });
+
+    it('intersects, never unions — a userActions opt-in cannot survive a permission denial', () => {
+      expect(rowGate({
+        ...wired,
+        managedBy: 'better-auth',
+        userActions: { edit: true, delete: true },
+        permissionUpdate: false,
+        permissionDelete: false,
+      })).toEqual({ canEdit: false, canDelete: false });
+    });
+
+    it('the apiOperations layer is KEPT, not replaced', () => {
+      // A write grant must not resurrect an entry the object's exposure surface
+      // closed: an `apiOperations` set without `delete` still hides Delete.
+      expect(rowGate({
+        ...wired,
+        effectiveApiOperations: ['get', 'list', 'update'],
+        permissionUpdate: true,
+        permissionDelete: true,
+      })).toEqual({ canEdit: true, canDelete: false });
     });
   });
 });

--- a/packages/plugin-grid/src/__tests__/rowCrudEffectiveOps.test.tsx
+++ b/packages/plugin-grid/src/__tests__/rowCrudEffectiveOps.test.tsx
@@ -7,8 +7,14 @@
  */
 
 /**
- * ObjectGrid row-level CRUD + bulk delete vs the server's effective API
- * operation set (#3720 — the fourth face of #3391).
+ * ObjectGrid row-level CRUD + bulk delete vs every gate that narrows them:
+ * the server's effective API operation set (#3720 — the fourth face of #3391)
+ * and the CURRENT PRINCIPAL's permission on the object (#4096).
+ *
+ * One file on purpose. The row kebab and the bulk bar are two faces of the same
+ * verdict, and the two gates are independent layers over it — keeping all four
+ * combinations here is what makes a future divergence fail a test instead of
+ * shipping.
  *
  * The main list's row kebab is a chain of its own: it never went through
  * `resolveEffectiveCrudAffordances`, so the toolbar (objectui#2823), detail/form
@@ -37,7 +43,14 @@ import React from 'react';
 // builds it before the hoisted `vi.mock` factory runs; the accessor reads
 // mutable state so a test can swap the effective set without changing identity.
 const { permsStub, state } = vi.hoisted(() => {
-  const state: { effectiveOps: string[] | undefined } = { effectiveOps: undefined };
+  const state: {
+    effectiveOps: string[] | undefined;
+    /** [#4096] The principal's `allowEdit` / `allowDelete` on this object. */
+    permUpdate: boolean;
+    permDelete: boolean;
+    /** [#4096] Bypass the stub and run the REAL provider-less hook instead. */
+    noProvider: boolean;
+  } = { effectiveOps: undefined, permUpdate: true, permDelete: true, noProvider: false };
   return {
     state,
     // `isLoaded: false` keeps the FIELD-level filter out of the way so the
@@ -46,11 +59,31 @@ const { permsStub, state } = vi.hoisted(() => {
       isLoaded: false,
       checkField: () => true,
       getObjectApiOperations: () => state.effectiveOps,
+      // [#4096] `can(obj, 'update' | 'delete')` — what `MePermissionsProvider`
+      // resolves from `/me/permissions` `allowEdit` / `allowDelete`. It sits on
+      // the SAME stub as `getObjectApiOperations` deliberately: the two layers
+      // are independent gates, and a change that drops either one has to fail a
+      // case in this file rather than in a file nobody thinks to open.
+      can: (_obj: string, action: string) =>
+        action === 'delete' ? state.permDelete : state.permUpdate,
     },
   };
 });
 
-vi.mock('@object-ui/permissions', () => ({ usePermissions: () => permsStub }));
+// The real module stays reachable so the no-`PermissionProvider` case below
+// exercises the ACTUAL fail-open fallback (`can: () => true`) instead of a
+// hand-written imitation of it. The real hook is invoked on every render so
+// hook order is stable whichever branch is returned.
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return {
+    ...actual,
+    usePermissions: () => {
+      const real = actual.usePermissions();
+      return state.noProvider ? real : permsStub;
+    },
+  };
+});
 
 import { ObjectGrid } from '../ObjectGrid';
 import { registerAllFields } from '@object-ui/fields';
@@ -75,10 +108,19 @@ interface Case {
   userActions?: Record<string, unknown>;
   /** Extra view-schema keys (e.g. an author-declared `bulkActions`). */
   schema?: Record<string, unknown>;
+  /** [#4096] `/me/permissions` `allowEdit` for the caller; default `true`. */
+  permUpdate?: boolean;
+  /** [#4096] `/me/permissions` `allowDelete` for the caller; default `true`. */
+  permDelete?: boolean;
+  /** [#4096] Render with NO `PermissionProvider` (standalone embed / old host). */
+  noProvider?: boolean;
 }
 
 function renderGrid(c: Case) {
   state.effectiveOps = c.effectiveOps;
+  state.permUpdate = c.permUpdate ?? true;
+  state.permDelete = c.permDelete ?? true;
+  state.noProvider = c.noProvider ?? false;
   const dataSource: any = {
     getObjectSchema: async (name: string) => ({
       name,
@@ -138,7 +180,12 @@ async function hasSelection(c: Case): Promise<boolean> {
   return screen.queryAllByRole('checkbox').length > 0;
 }
 
-beforeEach(() => { state.effectiveOps = undefined; });
+beforeEach(() => {
+  state.effectiveOps = undefined;
+  state.permUpdate = true;
+  state.permDelete = true;
+  state.noProvider = false;
+});
 afterEach(() => { cleanup(); });
 
 describe('ObjectGrid row CRUD vs the effective API operation set (#3720)', () => {
@@ -243,6 +290,16 @@ describe('ObjectGrid bulk delete vs the object delete verdict (#3720)', () => {
     expect(screen.queryByTestId('bulk-action-delete')).not.toBeInTheDocument();
   });
 
+  it('drops the built-in bulk delete for a principal with no allowDelete', async () => {
+    // [#4096] The row gate and the bulk bar must move together — fixing the
+    // kebab while the (more destructive) bulk button stays open would be the
+    // same bug one control over.
+    renderGrid({ effectiveOps: FULL, permDelete: false, schema: { bulkActions: ['delete'] } });
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Bob')).toBeInTheDocument());
+    expect(screen.queryAllByRole('checkbox').length).toBe(0);
+  });
+
   it('drops a bulkActionDefs entry whose operation is delete', async () => {
     renderGrid({
       effectiveOps: READ_ONLY,
@@ -259,5 +316,63 @@ describe('ObjectGrid bulk delete vs the object delete verdict (#3720)', () => {
     await userEvent.click(boxes[boxes.length - 1]);
     await waitFor(() => expect(screen.getByTestId('bulk-action-reassign')).toBeInTheDocument());
     expect(screen.queryByTestId('bulk-action-purge')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * [#4096] The principal layer, through the real ObjectGrid.
+ *
+ * `apiOperations` answers "which verbs does this OBJECT publish"; it is
+ * principal-independent (the report measured 30/30 shared objects byte-identical
+ * between an account with `allowEdit` and one without), so intersecting only
+ * with it left the row kebab and the bulk bar permanently open for read-only
+ * accounts — while the toolbar's New button and the record header's Edit/Delete
+ * on the very same screen were correctly hidden. The gate now also ANDs
+ * `can(obj, 'update' | 'delete')`, i.e. `/me/permissions` `allowEdit` /
+ * `allowDelete` — the toolbar's own source.
+ *
+ * The three cases the fix must hold simultaneously, in both directions:
+ *   • a principal WITH the write grant still sees Edit/Delete (no over-tightening);
+ *   • a principal WITHOUT it sees neither (the bug);
+ *   • NO `PermissionProvider` at all still sees both (fail-open preserved for
+ *     standalone embeds / older hosts — this one runs the real hook, not a stub).
+ */
+describe('ObjectGrid row CRUD vs the principal permission gate (#4096)', () => {
+  it('a principal WITH allowEdit/allowDelete keeps both entries', async () => {
+    expect(await rowKebab({ effectiveOps: FULL, permUpdate: true, permDelete: true }))
+      .toEqual({ edit: true, delete: true });
+    cleanup();
+    expect(await hasSelection({ effectiveOps: FULL, permUpdate: true, permDelete: true })).toBe(true);
+  });
+
+  it('a principal WITHOUT allowEdit/allowDelete loses both — on a fully exposed object', async () => {
+    // The exact reported shape: identical full `apiOperations`, opposite
+    // `allowEdit`/`allowDelete`. Pre-#4096 this returned `{ edit: true, delete: true }`.
+    expect(await rowKebab({ effectiveOps: FULL, permUpdate: false, permDelete: false }))
+      .toEqual({ edit: false, delete: false });
+    cleanup();
+    expect(await hasSelection({ effectiveOps: FULL, permUpdate: false, permDelete: false })).toBe(false);
+  });
+
+  it('with NO PermissionProvider both entries survive (fail-open preserved)', async () => {
+    // Runs the REAL `usePermissions` with no provider mounted: `can: () => true`
+    // and `getObjectApiOperations: () => undefined`. A standalone embed has no
+    // permission source and must not lose its Edit/Delete to this tightening.
+    expect(await rowKebab({ noProvider: true })).toEqual({ edit: true, delete: true });
+    cleanup();
+    expect(await hasSelection({ noProvider: true })).toBe(true);
+  });
+
+  it('gates update and delete independently', async () => {
+    expect(await rowKebab({ effectiveOps: FULL, permUpdate: true, permDelete: false }))
+      .toEqual({ edit: true, delete: false });
+    cleanup();
+    expect(await rowKebab({ effectiveOps: FULL, permUpdate: false, permDelete: true }))
+      .toEqual({ edit: false, delete: true });
+  });
+
+  it('keeps apiOperations as a layer — a write grant cannot re-open a closed exposure surface', async () => {
+    expect(await rowKebab({ effectiveOps: READ_ONLY, permUpdate: true, permDelete: true }))
+      .toEqual({ edit: false, delete: false });
   });
 });

--- a/packages/plugin-grid/src/rowCrudAffordances.ts
+++ b/packages/plugin-grid/src/rowCrudAffordances.ts
@@ -35,12 +35,36 @@
  *          `update` and `delete` with `delete`, so a row never offers a
  *          mutation the server would reject.
  *
- * Layer (c) is an INTERSECTION, never a union: a server grant cannot re-open
- * what the bucket or `userActions` closed, and a `userActions` opt-in cannot
- * survive a server denial. An absent effective set (unrestricted object / old
- * backend / no `PermissionProvider`) leaves the bucket verdict untouched, and
- * an absent `managedBy` resolves to the `platform` bucket — so every main list
- * on an ordinary object keeps its Edit/Delete kebab out of the box.
+ * and on top of that verdict:
+ *
+ *       d. [#4096] the CURRENT PRINCIPAL's effective permission on the object
+ *          (`/me/permissions` `allowEdit` / `allowDelete`, reached through
+ *          `usePermissions().can(obj, 'update' | 'delete')`) — passed in as
+ *          `permissionUpdate` / `permissionDelete`.
+ *
+ * Layer (c) and layer (d) answer DIFFERENT questions and neither substitutes
+ * for the other. `apiOperations` is the object's API EXPOSURE SURFACE — "which
+ * verbs does this object publish at all" — and is principal-independent: two
+ * accounts with opposite write grants receive a byte-identical set (measured in
+ * #4096: 30/30 shared objects identical between an account with `allowEdit`
+ * and one without). Intersecting only with (c) therefore fails OPEN for every
+ * unprivileged account. Layer (d) is the per-principal verdict the toolbar's
+ * `affordances.create && can(obj, 'create')` and the record header's
+ * `objectAffordances.edit && recordWriteAllowed` already AND in; the row kebab
+ * and the bulk-delete bar now run the same judgement, so one screen no longer
+ * carries three different answers to "may this user write this object".
+ *
+ * Every layer is an INTERSECTION, never a union: a server grant cannot re-open
+ * what the bucket or `userActions` closed, a `userActions` opt-in cannot
+ * survive a server denial, and neither can survive a permission denial. An
+ * absent effective set (unrestricted object / old backend / no
+ * `PermissionProvider`) leaves the bucket verdict untouched, an absent
+ * `permissionUpdate` / `permissionDelete` likewise leaves it untouched — the
+ * no-provider host keeps today's behavior, because `usePermissions()` without a
+ * `PermissionProvider` answers `can: () => true` by design (standalone embeds
+ * have no permission source and must not lose their Edit/Delete) — and an
+ * absent `managedBy` resolves to the `platform` bucket, so every main list on
+ * an ordinary object keeps its Edit/Delete kebab out of the box.
  *
  * Since objectui#2614, `userActions.edit` / `delete` also accept an object
  * form `{ enabled?, visibleWhen?, disabledWhen? }`: `enabled` carries the
@@ -78,6 +102,24 @@ export function resolveRowCrudAffordances(opts: {
    * untouched; an empty array means "expose nothing" → both entries hidden.
    */
   effectiveApiOperations?: readonly string[] | null;
+  /**
+   * [#4096] The current principal's effective `update` permission on this
+   * object — `usePermissions().can(objectName, 'update')`, which
+   * `MePermissionsProvider` maps to `/me/permissions` `allowEdit`.
+   *
+   * `undefined` (no object name resolved, caller that has not wired the check)
+   * leaves the verdict untouched, exactly like `effectiveApiOperations`. Note
+   * that "no `PermissionProvider`" does NOT arrive here as `undefined`: the
+   * hook's provider-less fallback answers `true`, which is the same
+   * no-narrowing outcome.
+   */
+  permissionUpdate?: boolean;
+  /**
+   * [#4096] The current principal's effective `delete` permission on this
+   * object — `usePermissions().can(objectName, 'delete')` → `allowDelete`.
+   * Same `undefined` semantics as `permissionUpdate`.
+   */
+  permissionDelete?: boolean;
 }): {
   canEdit: boolean;
   canDelete: boolean;
@@ -99,14 +141,19 @@ export function resolveRowCrudAffordances(opts: {
     { managedBy: opts.managedBy, userActions: opts.userActions },
     opts.effectiveApiOperations,
   );
+  // [#4096] …then the principal's own verdict. `apiOperations` above is the
+  // object's exposure surface and says nothing about WHO is asking, so without
+  // this the row kebab fails open for every account with no write grant.
+  const objectCanEdit = aff.edit && opts.permissionUpdate !== false;
+  const objectCanDelete = aff.delete && opts.permissionDelete !== false;
   const canEdit =
-    !!((opts.operationsUpdate || opts.wantEditAction) && opts.hasOnEdit) && aff.edit;
+    !!((opts.operationsUpdate || opts.wantEditAction) && opts.hasOnEdit) && objectCanEdit;
   const canDelete =
-    !!((opts.operationsDelete || opts.wantDeleteAction) && opts.hasOnDelete) && aff.delete;
+    !!((opts.operationsDelete || opts.wantDeleteAction) && opts.hasOnDelete) && objectCanDelete;
   return {
     canEdit,
     canDelete,
-    objectCanDelete: aff.delete,
+    objectCanDelete,
     editPredicates: canEdit ? aff.editPredicates : undefined,
     deletePredicates: canDelete ? aff.deletePredicates : undefined,
   };

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -866,7 +866,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // Missing effective set (unrestricted object / old backend / no provider)
   // keeps the current behavior. The frontend consumes the effective set the
   // server resolved; it never reads the raw `apiMethods`.
-  const { getObjectApiOperations } = usePermissions();
+  const { getObjectApiOperations, can: canDo } = usePermissions();
   const effectiveApiOps = schema.objectName ? getObjectApiOperations(schema.objectName) : undefined;
   const exportPermitted =
     schema.allowExport !== false &&
@@ -881,12 +881,19 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // it: the ADR-0103 bucket lock ∧ `userActions.delete` ∧ the server's
   // effective API operation set (#3391). Custom action ids pass through
   // untouched — they route through the action runner with their own gates.
+  // [#4096] ∧ the CURRENT PRINCIPAL's `allowDelete` — the three layers above
+  // all describe the OBJECT, so without this the most destructive entry on a
+  // kanban/gallery board stayed visible for an account with no delete grant.
+  // `can()` answers `true` with no `PermissionProvider` (standalone embeds).
   const permittedBulkActions = React.useMemo(() => {
     const declared = schema.bulkActions;
     if (!declared || declared.length === 0) return declared;
-    if (resolveEffectiveCrudAffordances(objectDef as any, effectiveApiOps).delete) return declared;
+    const objectDeleteAllowed =
+      resolveEffectiveCrudAffordances(objectDef as any, effectiveApiOps).delete &&
+      (schema.objectName ? canDo(schema.objectName, 'delete') : true);
+    if (objectDeleteAllowed) return declared;
     return declared.filter((a: unknown) => String(a).toLowerCase() !== 'delete');
-  }, [schema.bulkActions, objectDef, effectiveApiOps]);
+  }, [schema.bulkActions, schema.objectName, objectDef, effectiveApiOps, canDo]);
 
   // Normalize exportOptions: support both ObjectUI object format and spec string[] format
   const resolvedExportOptions = React.useMemo(() => {

--- a/packages/plugin-list/src/__tests__/ListView.permissions.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.permissions.test.tsx
@@ -6,8 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, screen, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
 import { ListView } from '../ListView';
 import { SchemaRendererProvider } from '@object-ui/react';
 import { PermissionProvider } from '@object-ui/permissions';
@@ -121,5 +123,113 @@ describe('ListView – field-level permission gating (negative)', () => {
     const select = lastSelect();
     expect(select).toBeDefined();
     expect(select).toContain('annual_revenue');
+  });
+});
+
+/**
+ * [#4096] The NON-grid bulk bar (kanban / calendar / gallery / …), which
+ * ListView renders itself — the grid path delegates to ObjectGrid, which gates
+ * its own.
+ *
+ * The built-in `delete` entry used to be gated on the object's resolved delete
+ * affordance alone: the ADR-0103 bucket ∧ `userActions.delete` ∧ the server's
+ * `apiOperations`. All three describe the OBJECT. `apiOperations` in particular
+ * is byte-identical across accounts with opposite write grants, so the most
+ * destructive control on a board stayed visible for a principal with no
+ * `allowDelete` — the same defect the main list's row kebab carried. It now
+ * also ANDs `can(obj, 'delete')`.
+ *
+ * Both directions plus the no-provider fail-open are pinned here.
+ */
+function makeObjectPermissions(allowDelete: boolean): ObjectPermissionConfig {
+  return {
+    object: 'account',
+    roles: {
+      restricted: {
+        roleName: 'restricted',
+        // `evaluatePermission` reads the role's `actions` list, so the grant
+        // has to live there — `objectPermissions` drives the field-level gate.
+        actions: allowDelete ? ['read', 'delete'] : ['read'],
+        objectPermissions: { read: true, create: false, update: false, delete: allowDelete },
+      },
+    },
+  };
+}
+
+const galleryBulkSchema: ListViewSchema = {
+  type: 'list-view',
+  objectName: 'account',
+  viewType: 'gallery',
+  fields: ['name', 'industry'],
+  bulkActions: ['delete', 'archive'] as any,
+};
+
+/**
+ * Stand in for the gallery renderer and select a row as soon as it mounts —
+ * the bulk bar only renders with a non-empty selection, and driving the real
+ * gallery's selection UI would couple this permission assertion to that
+ * component's markup.
+ */
+function registerSelectingGallery() {
+  ComponentRegistry.register('object-gallery', (props: any) => {
+    const onRowSelect = props.onRowSelect;
+    React.useEffect(() => {
+      onRowSelect?.([{ id: 'A1', name: 'Acme Co' }]);
+    }, [onRowSelect]);
+    return <div data-testid="gallery-stub" />;
+  });
+}
+
+/** `permissions: null` renders with NO PermissionProvider at all. */
+function renderGalleryBulk(permissions: ObjectPermissionConfig | null) {
+  const view = <ListView schema={galleryBulkSchema} dataSource={mockDataSource as any} />;
+  return render(
+    <SchemaRendererProvider dataSource={mockDataSource as any}>
+      {permissions
+        ? (
+          <PermissionProvider roles={roles} permissions={[permissions]} userRoles={['restricted']}>
+            {view}
+          </PermissionProvider>
+        )
+        : view}
+    </SchemaRendererProvider>,
+  );
+}
+
+describe('ListView – non-grid bulk delete vs the principal permission gate (#4096)', () => {
+  let prevGallery: ReturnType<typeof ComponentRegistry.get>;
+
+  beforeEach(() => {
+    mockDataSource.find.mockClear();
+    prevGallery = ComponentRegistry.get('object-gallery');
+    registerSelectingGallery();
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (prevGallery) ComponentRegistry.register('object-gallery', prevGallery);
+    else ComponentRegistry.unregister('object-gallery');
+  });
+
+  it('a principal WITH allowDelete keeps the bulk delete button', async () => {
+    renderGalleryBulk(makeObjectPermissions(true));
+    await waitFor(() => expect(screen.getByTestId('bulk-actions-bar')).toBeInTheDocument());
+    expect(screen.queryByTestId('bulk-action-delete')).not.toBeNull();
+  });
+
+  it('a principal WITHOUT allowDelete loses it, and keeps the non-delete actions', async () => {
+    renderGalleryBulk(makeObjectPermissions(false));
+    await waitFor(() => expect(screen.getByTestId('bulk-actions-bar')).toBeInTheDocument());
+    expect(screen.queryByTestId('bulk-action-delete')).toBeNull();
+    // Control group: proves the bar rendered and the probe can observe a
+    // surviving entry, so the absence above is not a false positive. Custom
+    // ids route through the action runner with their own gates.
+    expect(screen.queryByTestId('bulk-action-archive')).not.toBeNull();
+  });
+
+  it('with NO PermissionProvider the bulk delete survives (fail-open preserved)', async () => {
+    renderGalleryBulk(null);
+    await waitFor(() => expect(screen.getByTestId('bulk-actions-bar')).toBeInTheDocument());
+    expect(screen.queryByTestId('bulk-action-delete')).not.toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #4096

## What was wrong

The list row kebab's built-in **Edit** / **Delete** intersected only *object-scoped* layers — the ADR-0103 lifecycle bucket, `userActions.edit`/`delete`, and the server's effective API operation set (`/me/permissions` `apiOperations`, #3720). `apiOperations` is the object's **API exposure surface** ("which verbs does this object publish"), and the report measured it byte-identical across two accounts with opposite `allowEdit` — 30 shared objects, **30/30 identical**. A gate built only from object-scoped layers therefore fails **open** for every unprivileged caller.

Result: one screen, three different answers to "may this user write this object". The toolbar's New (`affordances.create && can(obj, 'create')`) and the record header's Edit/Delete (per-record write probe) were correct; the row kebab was not.

## The fix — an intersection tightening, not a swap

`apiOperations` stays as the exposure layer. A **principal-scoped** verdict is ANDed on top: `can(obj, 'update' | 'delete')`, which `MePermissionsProvider` maps to `/me/permissions` `allowEdit` / `allowDelete` — the toolbar's own source. No layer can re-open what another closed; a permission grant cannot resurrect an entry the bucket, `userActions` or `apiOperations` closed, and none of them survives a permission denial.

`resolveRowCrudAffordances()` gained two optional inputs, `permissionUpdate?` / `permissionDelete?`, with the same `undefined ⇒ no narrowing` semantics as the existing `effectiveApiOperations` (backward compatible). `ObjectGrid` fills them from the `usePermissions()` it already holds — no new data channel.

## Per-face verdicts

| # | Face | Verdict | Evidence |
|---|---|---|---|
| 1 | `packages/plugin-grid/src/ObjectGrid.tsx` row kebab built-in Edit/Delete | **已改 / changed** | `permissionUpdate` / `permissionDelete` ANDed in `resolveRowCrudAffordances`; filled at the call site (`ObjectGrid.tsx`). |
| 2 | `packages/app-shell/src/views/RelatedRecordActionsBridge.tsx` related-list rows | **已改 / changed** — same defect, second face | It resolved `resolveEffectiveCrudAffordances(childDef, getObjectApiOperations(objectName))` and nothing else, so `onCreate` / `onEdit` / `onDelete` were all offered to a principal with no write grant on the **child**. Now ANDs `can(child, 'create'\|'update'\|'delete')`. `onView` deliberately untouched — viewing is not a write. |
| 3 | `packages/plugin-list/src/ListView.tsx` non-grid bulk `delete` | **已改 / changed** — same disease | `permittedBulkActions` gated the built-in `delete` on `resolveEffectiveCrudAffordances(objectDef, effectiveApiOps).delete` alone. All three layers describe the OBJECT, so a kanban/gallery board's most destructive control stayed visible for an account with no `allowDelete`. Now ANDs `can(obj, 'delete')`. Custom action ids still pass through untouched (own gates via the action runner). |
| 4 | Bulk delete entry (`objectCanDelete` / `onBulkDelete`) | **已改 / changed — falls out of face 1, verified not left open** | The grid's bulk bar (`explicitBulkActions`, `bulkActionDefs` filter, implicit `['delete']`) all ride `objectCanDelete`, which is returned by the *same* resolver, so the principal layer reaches it by construction. Pinned explicitly rather than assumed. On #3492: its `requiredPermissions` work is a **different, orthogonal** gate — the ADR-0066 D4 capability gate for *declared* actions (`mayInvoke`/`useCapabilityGate`), which never covered the built-in `delete`. That is why this one was still open. |

⛔ Untouched, as declared out of scope: `packages/core/src/evaluator/**` and `packages/plugin-grid/src/components/RowActionMenu.tsx` (another seat's in-flight `evalRowPredicate` surface, #3796 / #3792). The fix did not need them — the verdict arrives at `RowActionMenu` through the existing `canEdit` / `canDelete` props.

## fail-open / fail-closed — the named regression risk

All three cases are pinned, in the shared consistency files (no new test file):

| Case | Expected | Pinned in |
|---|---|---|
| Account **with** the write grant | **still sees** Edit/Delete | `rowCrudEffectiveOps.test.tsx`, `rowCrudAffordances.test.ts`, `RelatedRecordActionsBridge.effectiveOps.test.tsx`, `ListView.permissions.test.tsx` |
| Account **without** it | **does not see** them (the bug) | same four |
| **No `PermissionProvider`** | **still sees** them (fail-open preserved) | same four |

The no-provider case in `rowCrudEffectiveOps.test.tsx` runs the **real** `usePermissions` (the mock keeps the actual module reachable via `importOriginal` and returns it for that branch), so it exercises the genuine `can: () => true` fallback rather than an imitation of it. `ListView.permissions.test.tsx` renders with no provider mounted at all.

**`MePermissionsProvider` fail-closed semantics** (`objPerm ? objPerm[k] !== false : data.authenticated !== true`, #2926 ④) are inherited deliberately — "consistent with the toolbar" is the standard this card was given, and the toolbar's `can(obj, 'create')` has run under exactly these semantics on the same screen all along. Checked for the console's own grids specifically:

- **metadata-admin is not affected.** `packages/app-shell/src/views/metadata-admin/ResourceListPage.tsx` renders its own "ObjectGrid-like table" — it does not go through `ObjectGrid`, so this change cannot touch it. (`grep -rln 'ObjectGrid' packages/app-shell/src/views/metadata-admin/` returns only preview/config/i18n files.)
- **`sys_*` object lists reached through `ObjectView` → `ObjectGrid`** are the only console surface in range, and they already run `affordances.create && can(objectDef.name, 'create')` for the New button. If `/me/permissions.objects` omitted `sys_*` for a console admin, New would already be missing today — so the map does carry them (or a `'*'` entry, which `check` honors). Per-key absence is permissive anyway (`allowEdit !== false`).
- **No loading flicker**: `MePermissionsProvider` renders `loadingFallback` and does not mount children until the set resolves (`MePermissionsProvider.tsx:303`), so the `permissions-loading` → `allowed: false` window is never observed by a rendered grid.

⚠️ **Not browser-verified.** The card asked for a real-browser look "if it runs"; this session has no backend to serve `/me/permissions`, so the evidence above is code + test level. Flagging rather than implying otherwise.

## PM mechanism assumptions — verified against `origin/main` @ `c29ceff`

All three **confirmed**, none falsified:

1. ✅ `ObjectGrid.tsx:1647` passed `effectiveApiOperations: effectiveApiOps` and ANDed no principal-scoped verdict; `rowCrudAffordances.ts`'s docblock folded exactly three layers (bucket / `userActions` / `apiOperations`).
2. ✅ Toolbar `ObjectView.tsx:1798/1809/1863` → `affordances.create && can(objectDef.name, 'create')`; detail header `RecordDetailView.tsx:1899-1902` → `objectAffordances.edit && recordWriteAllowed` / `.delete && recordDeleteAllowed`.
3. ✅ `MePermissionsProvider.check` maps `update → allowEdit`, `delete → allowDelete` (`MePermissionsProvider.tsx:230-236`), and `ObjectGrid.tsx:435` already held `usePermissions()` — no new data channel was needed.

The suggested route (explicit params on the pure function + call-site fill) was taken. `useRecordEditable` was **not** used on list rows — it is a per-record HTTP probe, N rows ⇒ 2N requests; the object-level verdict is what the toolbar uses and what the issue asked for. Sinking the layer into `@object-ui/core`'s `resolveEffectiveCrudAffordances` was **not** done: minimum-change was the default instruction, and the four existing call sites there already AND `can()` themselves, so sinking would be idempotent but far broader. Noted as an open question.

## Verification

Run in a dedicated worktree off `origin/main` @ `c29ceff`. Dependency closure built first (`pnpm --filter '@object-ui/plugin-grid...' --filter '@object-ui/plugin-list...' --filter '@object-ui/app-shell...' build`) so the cross-package type surface is not read from stale `dist/*.d.ts`.

```
$ pnpm exec vitest run packages/plugin-grid/ packages/plugin-list/ packages/app-shell/
 Test Files  400 passed (400)
      Tests  3900 passed | 1 skipped (3901)

$ pnpm exec vitest run apps/console/
 Test Files  29 passed (29)
      Tests  300 passed (300)

$ pnpm type-check
 Tasks:    78 successful, 78 total
```

(Package-level `pnpm --filter <pkg> test` is fine for `plugin-grid`/`plugin-list` but the repo's vitest guard refuses it for `app-shell` — everything above was re-run from the repo root, which is what CI does.)

**Negative check — the new cases are not vacuous.** Each face's gate was temporarily reverted and the suite re-run:

```
# rowCrudAffordances.ts principal layer removed:
 Tests  5 failed | 9 passed | 42 skipped (56)     ← the "WITHOUT permission" + "independent" cases
# ListView.tsx `can(obj,'delete')` removed:
 × a principal WITHOUT allowDelete loses it, and keeps the non-delete actions
# RelatedRecordActionsBridge.tsx `can(...)` removed:
 × a principal WITHOUT them loses all three — on a fully exposed child
 × gates create / update / delete independently
```

The "WITH permission" and "no provider" cases stayed green throughout — they assert *unchanged* behavior, which is the point.

**Cross-package sweep direction**: dependents (downstream consumers), `pnpm --filter '...@object-ui/plugin-grid'` — the **prefix** form. It resolves to 9 packages: `app-shell`, `console`, `example-byo-backend-console`, `example-console-starter`, `plugin-designer`, `plugin-grid`, `plugin-report`, `plugin-view`, `site`. `resolveRowCrudAffordances` has no consumer outside `plugin-grid` itself (grep over `packages`/`apps`/`examples`), and the signature change is additive-optional, so nothing downstream needed adapting; `pnpm type-check` covers all 9 and is green.

No new `t()` keys ⇒ `check:i18n-keys` not applicable. Changeset: `.changeset/row-crud-permission-gate-4096.md` (patch × 3).

## Out of scope, per the issue author's own closing line

> 若认为 `os.user` 该带上权限/角色信息(那样下游至少有自救通道),可另开一条;本条只针对「内建行动作没接权限门」。

Extending the CEL predicate scope so `os.user` carries permission/role information is **not** in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQbuY8A4jabkVwkP3GU9oe)_