### PR TITLE
fix(cli): make the generated temp app pass its own strict tsconfig, and gate it with real tsc (#3853)

### DIFF
--- a/.changeset/lucky-buttons-shave.md
+++ b/.changeset/lucky-buttons-shave.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/cli': patch
+---
+
+Make the generated temp app pass the strict `tsconfig.json` the generator writes beside it, and gate it with a real `tsc`
+
+Both app generators (`createTempApp`, `createTempAppWithRouting`) emit a `tsconfig.json` carrying `strict`, `noUnusedLocals` and `noUnusedParameters`, but nothing had ever run it — `dev`/`serve`/`build` go through Vite, which transpiles without type-checking — so the generated sources had drifted 17 errors past their own declared config. A user who copies the temp app out as a scaffold, or runs `tsc` in it, met all 17 at once.
+
+Fixed at the templates: dropped five imports that were declared and never used (`Link` in `src/App.tsx`; `cn`, `Button`, `SidebarGroupContent`, `SidebarGroupLabel` in `src/Layout.tsx`), typed `DynamicIcon`'s and `AppLayout`'s props (which also types the `menu`/`children` map callbacks by inference, and makes `className` optional so the two call sites that omit it are legal), and added the `src/vite-env.d.ts` every Vite TS scaffold carries — without it the entry's `import './index.css'` has no declaration behind it, in both generators.
+
+The Lucide lookup no longer needs `@ts-expect-error`: the namespace is narrowed to the component-by-name shape the layout actually uses. No `any` was added.
+
+A real `tsc -p` over a generated app now runs in the package's tests, so the declared strictness is enforced rather than decorative.

--- a/packages/cli/src/__tests__/app-generator.test.ts
+++ b/packages/cli/src/__tests__/app-generator.test.ts
@@ -51,8 +51,18 @@
  *    `create-plugin` where both passed over empty sets. The self-tests are kept
  *    anyway — a non-empty input proves the rule ran, not that it has teeth.
  */
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
-import { isBuiltin } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs';
+import { createRequire, isBuiltin } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -128,6 +138,12 @@ function readManifest(path: string): Manifest {
  * plugins enter, and folds a subpath back onto its package so
  * `react-dom/client` is checked against `react-dom`. Builtins are dropped.
  */
+/** Folds a specifier back onto its package: `react-dom/client` -> `react-dom`. */
+function packageOfSpecifier(specifier: string): string {
+  const segments = specifier.split('/');
+  return specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+}
+
 function importedPackagesOf(source: string): string[] {
   const packages = new Set<string>();
   for (const match of source.matchAll(
@@ -136,8 +152,7 @@ function importedPackagesOf(source: string): string[] {
     const specifier = match[1];
     if (specifier.startsWith('.') || specifier.startsWith('/')) continue;
     if (isBuiltin(specifier)) continue;
-    const segments = specifier.split('/');
-    packages.add(specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0]);
+    packages.add(packageOfSpecifier(specifier));
   }
   return [...packages].sort();
 }
@@ -186,6 +201,23 @@ function unusedVersionedDependencies(
 }
 
 /**
+ * Ambient declaration files, which the module graph is the wrong measure for.
+ *
+ * The single exemption to the rule below. `src/vite-env.d.ts` is pulled into the
+ * program by the generated tsconfig's `include: ['src']` and by nothing else —
+ * being reachable that way rather than by an import is what an ambient
+ * declaration IS — so reachability-from-`main.tsx` would report the one
+ * generated file whose whole job is to be reached differently (objectui#3853).
+ *
+ * The exemption is exactly as wide as the fact that justifies it (`.d.ts`, not
+ * "files the generator says are fine"), and it opens no hole: an ambient file
+ * that stopped carrying its weight would be caught by the `tsc` gate at the
+ * bottom of this file, which goes red the moment `src/index.css` has no
+ * declaration behind it.
+ */
+const isAmbientDeclaration = (path: string) => path.endsWith('.d.ts');
+
+/**
  * Generated `src/**` files not reachable from `src/main.tsx`.
  *
  * objectui#3759's criterion, retargeted: `index.html` loads exactly one module
@@ -224,7 +256,7 @@ function unreachableGeneratedFiles(files: Record<string, string>): string[] {
   }
 
   return Object.keys(files)
-    .filter((path) => path.startsWith('src/') && !reached.has(path))
+    .filter((path) => path.startsWith('src/') && !isAmbientDeclaration(path) && !reached.has(path))
     .sort();
 }
 
@@ -861,6 +893,21 @@ describe('generated app file maps', () => {
     ).toEqual(['src/schemas/page9.json']);
   });
 
+  it('exempts the ambient declaration, and nothing else, from reachability', () => {
+    // The width of the objectui#3853 exemption, pinned in both directions: the
+    // `.d.ts` both generators now write is exempt, and a `.ts` orphan sitting
+    // beside it under the same name still gets reported. An exemption that read
+    // "files matching vite-env*" or "files the generator knows about" would pass
+    // the first assertion and fail to be a rule at all.
+    for (const files of [plainFiles(), routedFiles()]) {
+      expect(files['src/vite-env.d.ts']).toBe(`/// <reference types="vite/client" />\n`);
+      expect(unreachableGeneratedFiles(files)).toEqual([]);
+      expect(unreachableGeneratedFiles({ ...files, 'src/vite-env.ts': '' })).toEqual([
+        'src/vite-env.ts'
+      ]);
+    }
+  });
+
   it('keeps every generated path inside the temp app directory', () => {
     // The generator joins these onto a tmpdir, so a `..` segment would escape.
     for (const files of [plainFiles(), routedFiles()]) {
@@ -1088,5 +1135,244 @@ describe('generation onto disk', () => {
         Object.keys(inRepoRangesOf('lucide-react')).sort()[0]
       );
     });
+  });
+});
+
+/**
+ * A real `tsc -p` over a generated app, using the app's own tsconfig
+ * (objectui#3853).
+ *
+ * Both generators write a `tsconfig.json` carrying `strict`, `noUnusedLocals`
+ * and `noUnusedParameters`, and until this gate landed nothing had ever run it:
+ * `dev`/`serve`/`build` all go through Vite, which transpiles without checking,
+ * and the config itself says `noEmit`. So the strictness was declared and never
+ * enforced — the objectui#3742 shape — and the generated sources had drifted 17
+ * errors past it (the issue's table is 12 of them; measuring turned up two more
+ * `TS7006` callbacks, two `TS2741` call sites where `DynamicIcon` was invoked
+ * without the `className` its inferred type made required, and a `TS2882` for
+ * `import './index.css'` in BOTH generators' entry).
+ *
+ * The gate is the same orientation as the structural ones above — judge the
+ * artifact, not this repo's source text — except that the judge here is the real
+ * compiler rather than a regex.
+ *
+ * WHAT IT DELIBERATELY DOES NOT JUDGE, and why that is not a hole:
+ *
+ * Nothing installs the temp app's dependencies (`generation onto disk` says why:
+ * inside this workspace an install proves nothing about the manifest). So
+ * `@object-ui/*` and `lucide-react` do not resolve here, and tsc says so. Those
+ * diagnostics are exempt — but only when the specifier is BARE, and only after
+ * being checked against the manifest the generator itself writes. A relative
+ * specifier is never exempt, which is what keeps `./index.css`,
+ * `./theme-provider` and `./Layout` under the gate, and an unresolved bare
+ * specifier the manifest does not declare fails here as loudly as anywhere else.
+ * That partition is the issue's own: its error table is the errors "unrelated to
+ * whether `@object-ui/*` is installed".
+ *
+ * The temp app is generated under the repo root rather than `os.tmpdir()`, which
+ * is not an arbitrary choice: it is what `commands/dev.ts` does ("always in cwd
+ * to keep node_modules access"), and it is what makes `react`, `react-dom`,
+ * `react-router-dom`, `@types/react` and `vite/client` resolve from the root
+ * `node_modules` the way they do for the real command. Under `os.tmpdir()`
+ * nothing resolves at all and `React.ReactNode` in `src/theme-provider.tsx`
+ * degrades to `Cannot find namespace 'React'` — a diagnostic about the test's
+ * own setup, wearing the costume of a defect in the generated source.
+ *
+ * Cost: ~1s per invocation, three invocations. Measured, because a gate nobody
+ * can afford to run is not a gate.
+ */
+describe('generated app type-checks under its own tsconfig', () => {
+  /** The workspace's TypeScript, resolved from this package — never a global. */
+  const TSC = createRequire(import.meta.url).resolve('typescript/bin/tsc');
+
+  type Diagnostic = { file: string; code: number; message: string };
+
+  /** `tsc`'s non-pretty output, one diagnostic per line, both of its shapes. */
+  function parseDiagnostics(output: string): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+    for (const line of output.split('\n')) {
+      const located = /^(.+?)\(\d+,\d+\): error TS(\d+): (.*)$/.exec(line);
+      if (located) {
+        diagnostics.push({ file: located[1], code: Number(located[2]), message: located[3] });
+        continue;
+      }
+      // Fileless diagnostics: a broken `include` reports `TS18003: No inputs
+      // were found`, which is exactly how this gate would go vacuous. Parsed so
+      // it lands in the non-exempt bucket and fails.
+      const fileless = /^error TS(\d+): (.*)$/.exec(line);
+      if (fileless) {
+        diagnostics.push({ file: '', code: Number(fileless[1]), message: fileless[2] });
+      }
+    }
+    return diagnostics;
+  }
+
+  /** `Cannot find module`/`type definition file` — the three resolution codes. */
+  const RESOLUTION_CODES = new Set([2307, 2688, 2882]);
+
+  /** The specifier a resolution diagnostic names, or `undefined` if it is not one. */
+  function unresolvedSpecifier(diagnostic: Diagnostic): string | undefined {
+    if (!RESOLUTION_CODES.has(diagnostic.code)) return undefined;
+    return /'([^']+)'/.exec(diagnostic.message)?.[1];
+  }
+
+  const isBareSpecifier = (specifier: string) =>
+    !specifier.startsWith('.') && !specifier.startsWith('/');
+
+  /**
+   * Runs `tsc -p` over a generated app and splits the result.
+   *
+   * `--pretty false` because the ANSI/multi-line form is not parseable, and tsc
+   * chooses it by TTY — which vitest's reporter can change underneath us.
+   */
+  function typeCheck(appDir: string): { beyondResolution: Diagnostic[]; unresolved: string[] } {
+    const result = spawnSync(
+      process.execPath,
+      [TSC, '-p', join(appDir, 'tsconfig.json'), '--pretty', 'false'],
+      { encoding: 'utf-8' }
+    );
+    // Not the same failure as "the code has type errors": tsc exits 1/2 for
+    // those. A signal or a missing binary must not read as a clean run.
+    expect(result.error, `tsc failed to start: ${result.error?.message}`).toBeUndefined();
+    const diagnostics = parseDiagnostics(`${result.stdout}${result.stderr}`);
+    const unresolved = new Set<string>();
+    const beyondResolution: Diagnostic[] = [];
+    for (const diagnostic of diagnostics) {
+      const specifier = unresolvedSpecifier(diagnostic);
+      if (specifier !== undefined && isBareSpecifier(specifier)) unresolved.add(specifier);
+      else beyondResolution.push(diagnostic);
+    }
+    return { beyondResolution, unresolved: [...unresolved].sort() };
+  }
+
+  /**
+   * Generates into `<repo>/.objectui-tmp/…` — the directory `commands/dev.ts`
+   * itself uses, and already `.gitignore`d, so a crashed run cannot leave
+   * anything in `git status`.
+   */
+  function withGeneratedApp(write: (dir: string) => void, run: (dir: string) => void): void {
+    const parent = join(REPO_ROOT, '.objectui-tmp');
+    mkdirSync(parent, { recursive: true });
+    const dir = mkdtempSync(join(parent, 'tsc-gate-3853-'));
+    try {
+      write(dir);
+      run(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  /** Package names the generator's own manifest declares, both maps. */
+  function declaredPackages(manifest: Record<string, unknown>): Set<string> {
+    return new Set(Object.keys(allRangesOf(manifest)));
+  }
+
+  function expectCleanTypeCheck(
+    dir: string,
+    manifest: Record<string, unknown>,
+    shape: string
+  ): void {
+    const { beyondResolution, unresolved } = typeCheck(dir);
+    expect(
+      beyondResolution.map((d) => `${d.file}: TS${d.code}: ${d.message}`),
+      `${shape}: generated sources fail the tsconfig the generator wrote beside them`
+    ).toEqual([]);
+    // The exemption, bounded. Every package tsc could not resolve has to be one
+    // the generated manifest asks for — so the "it just is not installed here"
+    // excuse can never cover a typo or an import nobody declared. Which packages
+    // land here depends on what this workspace happens to hoist, so the SET is
+    // not pinned; its membership rule is.
+    const declared = declaredPackages(manifest);
+    expect(
+      unresolved.filter((specifier) => !declared.has(packageOfSpecifier(specifier))),
+      `${shape}: unresolved import that the generated manifest never declares`
+    ).toEqual([]);
+  }
+
+  it('type-checks the routed app the CLI really writes', () => {
+    withGeneratedApp(
+      (dir) => createTempAppWithRouting(dir, ROUTES, APP_CONFIG),
+      // Judged against the STANDALONE manifest for the reason given at the top
+      // of this file: inside a workspace `createTempApp` writes both maps empty,
+      // so the on-disk manifest would make the membership rule above vacuous.
+      (dir) => expectCleanTypeCheck(dir, buildRoutedAppPackageJson(), 'routed')
+    );
+  });
+
+  it('type-checks the plain app the CLI really writes', () => {
+    withGeneratedApp(
+      (dir) => createTempApp(dir, SCHEMA),
+      (dir) => expectCleanTypeCheck(dir, buildAppPackageJson(STANDALONE), 'plain')
+    );
+  });
+
+  it('goes red on the pre-fix templates, with the defects the issue measured', () => {
+    // Reverse verification, and the answer to "is a green tsc run green because
+    // it checked something?". Each plant restores one of the four defect classes
+    // objectui#3853 reports, spelled as the pre-fix template spelled it. The
+    // direction was predicted before running: unused import -> TS6133; untyped
+    // destructured props -> TS7031, and TS2741 downstream at the two call sites
+    // that omit `className` once it is inferred required; untyped map callbacks
+    // -> TS7006 (five, not the three the issue lists); no ambient declaration ->
+    // TS2882 for `./index.css`. The two type-only declarations the plants strand
+    // were predicted too — the plants are a revert, not a scalpel — but as
+    // TS6133 + TS6196, and measuring said TS6196 twice: `import type { ReactNode }`
+    // binds a TYPE, and an unused type is "declared but never used" (TS6196),
+    // never "its value is never read" (TS6133, which is what an unused VALUE
+    // import like `Link` gets). Pinned as measured rather than as predicted.
+    const plants: Array<[file: string, from: string, to: string]> = [
+      [
+        'src/App.tsx',
+        `import { BrowserRouter, Routes, Route } from 'react-router-dom';`,
+        `import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';`
+      ],
+      [
+        'src/Layout.tsx',
+        `const DynamicIcon = ({ name, className }: { name: string; className?: string }) => {`,
+        `const DynamicIcon = ({ name, className }) => {`
+      ],
+      [
+        'src/Layout.tsx',
+        `const AppLayout = ({ app, children }: { app: AppConfig; children: ReactNode }) => {`,
+        `const AppLayout = ({ app, children }) => {`
+      ]
+    ];
+
+    withGeneratedApp(
+      (dir) => {
+        createTempAppWithRouting(dir, ROUTES, APP_CONFIG);
+        for (const [file, from, to] of plants) {
+          const path = join(dir, file);
+          const before = readFileSync(path, 'utf-8');
+          // A plant that no longer matches would silently check nothing, which
+          // is the failure mode this whole test exists to rule out.
+          expect(before, `${file}: nothing to revert — the template moved`).toContain(from);
+          writeFileSync(path, before.replace(from, to));
+        }
+        rmSync(join(dir, 'src/vite-env.d.ts'));
+      },
+      (dir) => {
+        const { beyondResolution } = typeCheck(dir);
+        const byCode: Record<string, number> = {};
+        for (const diagnostic of beyondResolution) {
+          byCode[`TS${diagnostic.code}`] = (byCode[`TS${diagnostic.code}`] ?? 0) + 1;
+        }
+        expect(byCode).toEqual({
+          TS6133: 1, // 'Link' — an unused VALUE import
+          TS6196: 2, // 'ReactNode' and 'AppConfig' — unused TYPES the plants strand
+          TS7031: 4, // name, className, app, children
+          TS7006: 5, // item, idx, child, child, cIdx
+          TS2741: 2, // <DynamicIcon name={…} /> with no className, twice
+          TS2882: 1 // import './index.css' with no ambient declaration
+        });
+        // The identifiers, not just the counts: a gate that reported the right
+        // number of the wrong errors would pass the assertion above.
+        const named = beyondResolution.map((d) => d.message).join('\n');
+        for (const identifier of ['Link', 'name', 'className', 'app', 'children', 'item', 'idx']) {
+          expect(named, `no diagnostic names ${identifier}`).toContain(`'${identifier}'`);
+        }
+        expect(named).toContain(`'./index.css'`);
+      }
+    );
   });
 });

--- a/packages/cli/src/utils/app-generator.ts
+++ b/packages/cli/src/utils/app-generator.ts
@@ -190,6 +190,25 @@ function buildRoutedAppDependencies(): Record<string, string> {
 }
 
 
+/**
+ * The generated `src/vite-env.d.ts`, identical for both generators.
+ *
+ * Both entries do `import './index.css'`, and TypeScript has no idea what a
+ * `.css` module is: without this the entry file fails its own `tsconfig.json`
+ * with "Cannot find module or type declarations for side-effect import of
+ * './index.css'". `vite/client` is where the `declare module '*.css'` ambient
+ * declarations live, `vite` is already in the generated `devDependencies`, and
+ * this is the file `create-vite`'s own React+TS template writes for the same
+ * reason — so the fix is the ecosystem's spelling of it rather than a local
+ * invention (objectui#3853).
+ *
+ * It is the one generated `src/**` file that is deliberately unreachable from
+ * `src/main.tsx`: an ambient declaration is pulled in by the tsconfig's
+ * `include`, never by the module graph. `app-generator.test.ts`'s reachability
+ * gate exempts `.d.ts` for exactly that reason and pins the exemption's width.
+ */
+const APP_VITE_ENV_D_TS = `/// <reference types="vite/client" />\n`;
+
 /** The generated `tsconfig.json`, identical for both generators. */
 const APP_TSCONFIG = {
   compilerOptions: {
@@ -579,6 +598,7 @@ export default App;`;
     'index.html': html,
     'src/main.tsx': mainTsx,
     'src/App.tsx': appTsx,
+    'src/vite-env.d.ts': APP_VITE_ENV_D_TS,
     'src/index.css': buildAppIndexCss(context),
     'postcss.config.js': APP_POSTCSS_CONFIG,
     'package.json': JSON.stringify(buildAppPackageJson(context), null, 2),
@@ -745,13 +765,12 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       // Since we don't have a Layout component in @object-ui/components yet, we generate a simple one.
 
       const layoutCode = `
+import type { ComponentType, ReactNode } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import * as LucideIcons from 'lucide-react';
 import { Moon, Sun } from "lucide-react"
 import { useTheme } from "./theme-provider"
-import { 
-  cn,
-  Button,
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -763,8 +782,6 @@ import {
   SidebarHeader,
   SidebarRail,
   SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
@@ -777,11 +794,36 @@ import {
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent
-} from '@object-ui/components'; 
+} from '@object-ui/components';
 
-const DynamicIcon = ({ name, className }) => {
-  // @ts-expect-error - Dynamic icon lookup from Lucide icons
-  const Icon = LucideIcons[name];
+/** One entry of \`app.json\`'s \`menu\`, as this layout reads it. */
+type MenuItem = {
+  label?: string;
+  path?: string;
+  icon?: string;
+  children?: MenuItem[];
+};
+
+/** The \`app.json\` fields this layout renders. */
+type AppConfig = {
+  title?: string;
+  logo?: string;
+  menu?: MenuItem[];
+};
+
+// Lucide publishes every icon as a named export, and a menu entry names one as
+// a string — so the lookup is a runtime index into the namespace object, which
+// has no index signature. Narrowing it to the component-by-name shape this file
+// actually uses keeps that honest without an \`any\` or a \`@ts-expect-error\`; the
+// \`undefined\` arm is real, since the namespace also exports helpers that are not
+// components and a schema may name an icon that does not exist.
+const lucideIcons = LucideIcons as unknown as Record<
+  string,
+  ComponentType<{ className?: string }> | undefined
+>;
+
+const DynamicIcon = ({ name, className }: { name: string; className?: string }) => {
+  const Icon = lucideIcons[name];
   if (!Icon) return null;
   return <Icon className={className} />;
 };
@@ -822,7 +864,7 @@ export function ModeToggle() {
   )
 }
 
-const AppLayout = ({ app, children }) => {
+const AppLayout = ({ app, children }: { app: AppConfig; children: ReactNode }) => {
   const location = useLocation();
   const menu = app.menu || [];
   
@@ -932,7 +974,12 @@ export default AppLayout;
   }
 
   // Create App.tsx with routing
-  const appTsx = `import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+  //
+  // `Link` is deliberately absent from this import: the only `<Link>` in the
+  // generated app is in `src/Layout.tsx`, which imports it itself. Naming it
+  // here bought nothing and cost a TS6133 under the `noUnusedLocals` this
+  // generator's own `tsconfig.json` declares (objectui#3853).
+  const appTsx = `import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { SchemaRenderer } from '@object-ui/react';
 import '@object-ui/components';
 import '@object-ui/plugin-charts';
@@ -961,6 +1008,7 @@ export default App;`;
 
   files['src/App.tsx'] = appTsx;
 
+  files['src/vite-env.d.ts'] = APP_VITE_ENV_D_TS;
   files['src/index.css'] = buildAppIndexCss(context);
   files['postcss.config.js'] = APP_POSTCSS_CONFIG;
   files['package.json'] = JSON.stringify(buildRoutedAppPackageJson(), null, 2);


### PR DESCRIPTION
Fixes #3853

Both app generators in `packages/cli/src/utils/app-generator.ts` write a `tsconfig.json` carrying `strict`, `noUnusedLocals` and `noUnusedParameters`, and until this PR nothing had ever run it — `dev`/`serve`/`build` all go through Vite, which transpiles without type-checking, and the config itself says `noEmit`. Declared strictness, never enforced.

## Premise check (current `origin/main` @ `877385a76`)

Reproduced by generating with the real entry points and running the workspace's `tsc -p` with the generated `tsconfig.json`. The issue's table holds verbatim, and measuring found **17** errors rather than 12:

| class | code | count | notes |
|---|---|---|---|
| unused imports | TS6133 | 5 | exactly as reported |
| untyped destructured props | TS7031 | 4 | exactly as reported |
| untyped map callbacks | TS7006 | **5** | issue lists 3; `Layout.tsx(117,50)` `child` and `(117,57)` `cIdx` were not measured |
| required-prop call sites | TS2741 | **2** | `DynamicIcon` invoked without the `className` its inferred type made required |
| missing ambient declaration | TS2882 | **1** | `import './index.css'` in the entry — and this one hits **both** generators, not just the routed one |

`#4099` changed template dep ranges since filing; as expected it moved none of these — measured, not assumed.

### The `theme-provider.tsx` UMD note is 待核 → **not reproducible**, and no fix was made

`React.ReactNode` without a React namespace import produces **no diagnostic**. TypeScript permits a UMD global namespace in a **type** position; `allowUmdGlobalAccess` governs *value* access, which this file never does. Verified that the namespace really resolves rather than silently degrading — a probe referencing a bogus member of the same namespace reports `TS2694: Namespace 'React' has no exported member …`, and assigning a symbol to `React.ReactNode` reports `TS2322`. So the type is being checked, and it is correct. Reported rather than "fixed".

## The fix, at the template source

- dropped the five imports declared and never used: `Link` in `src/App.tsx` (the only link in the app is in `src/Layout.tsx`, which imports it itself), and `cn` / `Button` / `SidebarGroupContent` / `SidebarGroupLabel` in `src/Layout.tsx`;
- typed `DynamicIcon`'s and `AppLayout`'s destructured props. The five TS7006 callbacks then follow **by inference** from the `AppConfig` / `MenuItem` shapes rather than needing annotations of their own, and making `className` optional retires the two TS2741 call sites;
- narrowed the Lucide namespace to the component-by-name shape the layout actually indexes, which retires the `@ts-expect-error` as well. No `any` was added anywhere;
- added `src/vite-env.d.ts` (`/// reference types="vite/client"`) to **both** generators. `vite` is already in the generated `devDependencies`, and this is the file `create-vite`'s own React+TS template writes for exactly this reason.

`AppConfig` is applied to a variable, not to a fresh object literal, so a user `app.json` carrying extra keys is unaffected by excess-property checking.

## The gate

Three real `tsc -p` runs over apps the generators really write, in `packages/cli`'s own suite, spawning the **workspace's** TypeScript (`createRequire(...).resolve('typescript/bin/tsc')`, resolved from this package — never a global).

**Cost, measured**: routed 1012ms + plain 770ms + self-test 981ms = **2.76s**; the whole `app-generator.test.ts` file runs in 3.19s and the `packages/cli` suite in ~22s.

**Module resolution.** The temp app is generated under the repo root inside `.objectui-tmp/` — which is what `commands/dev.ts` itself does ("always in cwd to keep node_modules access"), is already gitignored, and is what makes `react`, `react-dom`, `react-router-dom`, `@types/react` and `vite/client` resolve from the root `node_modules` the way they do for the real command. This is the established mechanism, not a new linker: nothing is installed or symlinked. Under `os.tmpdir()` nothing resolves at all and `React.ReactNode` degrades into `Cannot find namespace 'React'` — a diagnostic about the test's setup wearing the costume of a defect in the generated source.

**What is exempt, and why it is not a hole.** `@object-ui/*` and `lucide-react` genuinely do not resolve here, because nothing installs the temp app's dependencies (the `generation onto disk` block says why an install would prove nothing). Those are exempt — but only when the specifier is **bare**, and only after each one is checked against the manifest the generator itself writes. A relative specifier is **never** exempt, which is what keeps `./index.css`, `./theme-provider` and `./Layout` under the gate. That partition is the issue's own: its table is the errors "unrelated to whether `@object-ui/*` is installed".

**Reverse verification, direction predicted first.** Reverting `app-generator.ts` to `origin/main` and re-running turns both gates red with the full pre-fix inventory — TS6133 ×5, TS7031 ×4, TS7006 ×5, TS2741 ×2, TS2882 ×1 on the routed app, and TS2882 on the plain one. One diagnostic differs by environment and is worth naming: at repo root the pre-fix `@ts-expect-error` reports `TS2578: Unused '@ts-expect-error' directive`, because unresolved `lucide-react` makes the indexed expression `any` and there is nothing left to suppress; with `lucide-react` resolvable (probed by generating under `packages/components/`) the directive is used instead and TS2578 does not appear. The fix removes the directive, so the gate is stable either way.

The in-suite self-test plants the pre-fix templates back and pins the resulting codes. Its predicted set was right in 5 of 6 codes; the miss is recorded in the test rather than papered over: an unused `import type` binding reports **TS6196** ("declared but never used"), not TS6133 ("its value is never read"), because a type-only binding is not a value.

**Reachability gate.** It gains exactly one exemption, `.d.ts`: an ambient declaration is pulled into the program by the tsconfig's `include`, never by the module graph, so reachability-from-`main.tsx` was the wrong measure for it. The exemption's width is pinned in both directions by a new test (`src/vite-env.d.ts` exempt, a `src/vite-env.ts` orphan beside it still reported), and it opens no hole because the tsc gate goes red the moment that file stops carrying its weight.

## Verification

- `vitest run packages/cli/` from the repo root: **101 passed (4 files)**, 22s.
- `tsc --noEmit` in `packages/cli`: exit 0.
- `eslint packages/cli/src`: 0 errors (15 warnings, all pre-existing on untouched lines).
- `node scripts/check-changeset-presence.mjs` and `check-changeset-no-major.mjs`: both green.

Changeset: `patch` on `@object-ui/cli` — template **source** changes ship inside the released package, and the Bump Policy forbids `major` in this fixed group.

## Out of scope

Filed as **#4111**: `commands/init.ts` is a third generator with its own `tsconfig` object, also `strict` + `noUnusedLocals` and also lacking a `vite-env.d.ts`, so its `src/main.tsx` has the same `./index.css` TS2882 (measured, not inferred). It is outside this card's two generators, so it is filed rather than fixed here — but it is **more severe** than the defect this PR fixes: that scaffold's generated `package.json` runs `build: "tsc && vite build"`, so the error is live for any user who runs `objectui init` followed by `npm run build`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_