### PR TITLE
test(plugin-charts): serve ObjectChart's option-color probe from a double, not the network

### DIFF
--- a/.changeset/olive-eels-shave.md
+++ b/.changeset/olive-eels-shave.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only change to `@object-ui/plugin-charts`: `ObjectChart`'s category option-color
+probe (`/api/v1/meta/dataset/*` and `/api/v1/meta/object/*`) is now answered by a
+recording test double in the four suites that were escaping to the real network, and
+its request shape and success path get their first coverage. No published behaviour
+changes.

--- a/packages/plugin-charts/src/ObjectChart.datasetMeasureLabel.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.datasetMeasureLabel.test.tsx
@@ -11,7 +11,7 @@
  * `buildChartSeries()`, so the lookup always fell back to the raw name.
  */
 import React from 'react';
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
 
 vi.mock('recharts', async () => {
@@ -25,7 +25,50 @@ vi.mock('recharts', async () => {
 
 import { ObjectChart } from './ObjectChart';
 
-afterEach(cleanup);
+/**
+ * objectui#4106 — answer ObjectChart's dataset-definition probe from a double.
+ *
+ * A `dataset`-bound chart resolves its category dimension's option colors by
+ * first reading `GET /api/v1/meta/dataset/<dataset>` off the GLOBAL `fetch`
+ * (ObjectChart.tsx:344) to learn the underlying object. Under happy-dom that
+ * was a REAL request — 1 live escape per run from this file, failing
+ * fire-and-forget into `connect ECONNREFUSED 127.0.0.1:3000` while the test
+ * stayed green because the effect is best-effort by design.
+ *
+ * `{}` reproduces the failure's observable outcome exactly: with no `object`
+ * on the definition the effect returns early having set no colors and no
+ * dimension labels — the same state the swallowed rejection produced, and the
+ * same single request. The measure-label assertion below reads `queryDataset`'s
+ * `fields`, which this never touches. The two-hop path that a REAL definition
+ * unlocks is covered in `ObjectChart.optionColors.test.tsx`.
+ */
+function installMetaFetchDouble(routes: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      calls.push(url);
+      return { ok: true, json: async () => routes[url] ?? {} };
+    }),
+  );
+  return calls;
+}
+
+let metaCalls: string[] = [];
+
+beforeEach(() => {
+  metaCalls = installMetaFetchDouble();
+});
+
+afterEach(() => {
+  // Anything other than the dataset-definition probe is a NEW escape.
+  expect(metaCalls.filter((u) => u !== '/api/v1/meta/dataset/showcase_task_metrics')).toEqual([]);
+  vi.unstubAllGlobals();
+  cleanup();
+});
 
 const makeDS = () => ({
   queryDataset: vi.fn().mockResolvedValue({

--- a/packages/plugin-charts/src/ObjectChart.drillNavigate.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.drillNavigate.test.tsx
@@ -20,7 +20,7 @@
  * segment click in jsdom would test the SVG geometry instead of the branch.
  */
 import React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
 import { DrillNavigationProvider } from '@object-ui/react';
 
@@ -38,7 +38,56 @@ vi.mock('./ChartRenderer', () => ({
 
 import { ObjectChart } from './ObjectChart';
 
-afterEach(cleanup);
+/**
+ * objectui#4106 — answer ObjectChart's option-color probe from a double.
+ *
+ * Any schema carrying `objectName` makes ObjectChart resolve the category
+ * dimension's option colors, which reads `GET /api/v1/meta/object/<objectName>`
+ * off the GLOBAL `fetch` (ObjectChart.tsx:352). Under happy-dom that is a REAL
+ * request to the default origin, so this file fired 4 live requests per run —
+ * one per test. The effect swallows the rejection by design (best-effort: a
+ * failure just leaves the theme palette in place), which is why the suite
+ * stayed green while stderr filled with `connect ECONNREFUSED 127.0.0.1:3000`.
+ *
+ * The `{}` answer reproduces the failed request's observable outcome EXACTLY:
+ * `buildOptionColorMap(undefined)` returns null for a schema with no options,
+ * which is the same state the rejection's catch branch set. No assertion below
+ * changes meaning.
+ *
+ * Deliberately NOT a global error sink: it records every URL it is handed, so
+ * an escape to some OTHER endpoint fails the `afterEach` guard instead of
+ * vanishing into a swallowed rejection. The probe's own shape is asserted in
+ * `ObjectChart.optionColors.test.tsx`.
+ */
+function installMetaFetchDouble(routes: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      calls.push(url);
+      return { ok: true, json: async () => routes[url] ?? {} };
+    }),
+  );
+  return calls;
+}
+
+let metaCalls: string[] = [];
+
+beforeEach(() => {
+  metaCalls = installMetaFetchDouble();
+});
+
+afterEach(() => {
+  // Every request this file makes must be the option-color probe. Anything
+  // else is a NEW escape to the real network — fail here rather than let it
+  // fail open into stderr noise again.
+  expect(metaCalls.filter((u) => u !== '/api/v1/meta/object/opportunity')).toEqual([]);
+  vi.unstubAllGlobals();
+  cleanup();
+});
 
 const schema = (drillDown: Record<string, unknown>) => ({
   type: 'object-chart',

--- a/packages/plugin-charts/src/ObjectChart.elementDataSource.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.elementDataSource.test.tsx
@@ -24,12 +24,57 @@
  * reads them.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
 import React from 'react';
 import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 // Registers `object-chart` via `ObjectChartBlock` (the wiring under test).
 import './index';
+
+/**
+ * objectui#4106 — answer ObjectChart's option-color probe from a double.
+ *
+ * Once `dataSource.object` maps onto `objectName`, ObjectChart resolves the
+ * category dimension's option colors via `GET /api/v1/meta/object/account` on
+ * the GLOBAL `fetch` (ObjectChart.tsx:352) — 3 live requests per run here (the
+ * unresolvable-`view` test never resolves an objectName, so it makes none).
+ *
+ * Note this file mounts a real `SchemaRendererProvider`: the host IS present
+ * and still does not intercept the probe, because ObjectChart reads the global
+ * `fetch` rather than the context's `apiFetch`. That gap is a product concern
+ * filed separately — this file only stops the escape.
+ *
+ * `{}` reproduces the failed request's observable outcome exactly (no options
+ * → `buildOptionColorMap` returns null, the same state the swallowed rejection
+ * produced), so no assertion below changes meaning.
+ */
+function installMetaFetchDouble(routes: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      calls.push(url);
+      return { ok: true, json: async () => routes[url] ?? {} };
+    }),
+  );
+  return calls;
+}
+
+let metaCalls: string[] = [];
+
+beforeEach(() => {
+  metaCalls = installMetaFetchDouble();
+});
+
+afterEach(() => {
+  // Anything other than the option-color probe is a NEW escape — fail here.
+  expect(metaCalls.filter((u) => u !== '/api/v1/meta/object/account')).toEqual([]);
+  vi.unstubAllGlobals();
+  cleanup();
+});
 
 const HOT_VIEW = {
   name: 'hot',

--- a/packages/plugin-charts/src/ObjectChart.optionColors.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.optionColors.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#4106 — coverage for ObjectChart's category option-color / dimension
+ * label resolution (the "P3" effect at ObjectChart.tsx:328).
+ *
+ * This effect is where every real-network escape in `plugin-charts` came from:
+ * it reads `/api/v1/meta/dataset/<dataset>` and `/api/v1/meta/object/<object>`
+ * off the global `fetch`, and it is best-effort — any failure is swallowed and
+ * leaves the theme palette in place. Under happy-dom those were REAL requests
+ * that always failed, so the effect's SUCCESS path had never once executed in
+ * this package's suite and nothing asserted the requests at all.
+ *
+ * These pins give that path its first coverage, from the component's own
+ * wiring rather than the helpers' (`buildOptionColorMap` /
+ * `buildDimensionLabelMap` / `relabelDimensions` are unit-tested one level
+ * down in `@object-ui/core`; what is new here is that ObjectChart asks for the
+ * right documents, in the right order, and feeds the results to the renderer).
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+
+let lastSchema: any = null;
+
+vi.mock('./ChartRenderer', () => ({
+  ChartRenderer: (props: any) => {
+    lastSchema = props.schema;
+    return null;
+  },
+}));
+
+import { ObjectChart } from './ObjectChart';
+
+/**
+ * Records every URL and answers only the documents it is given, so an escape
+ * to any other endpoint shows up as a recorded call the assertions reject —
+ * never as a swallowed rejection on the real network.
+ */
+function installMetaFetchDouble(routes: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      calls.push(url);
+      return { ok: true, json: async () => routes[url] ?? {} };
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+  lastSchema = null;
+});
+
+beforeEach(() => {
+  lastSchema = null;
+});
+
+describe('ObjectChart — category option colors (objectui#4106)', () => {
+  it('probes the bound object once and paints categories from its field options', async () => {
+    const metaCalls = installMetaFetchDouble({
+      '/api/v1/meta/object/opportunity': {
+        item: {
+          name: 'opportunity',
+          fields: {
+            stage: {
+              type: 'select',
+              options: [
+                { value: 'won', label: 'Won', color: '#16a34a' },
+                { value: 'lost', label: 'Lost', color: '#dc2626' },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    render(
+      <ObjectChart
+        schema={{
+          type: 'object-chart',
+          chartType: 'bar',
+          objectName: 'opportunity',
+          xAxisKey: 'stage',
+          data: [
+            { stage: 'won', amount: 42 },
+            { stage: 'lost', amount: 7 },
+          ],
+        }}
+        dataSource={{ find: async () => ({ data: [] }) }}
+      />,
+    );
+
+    // The option colors reach the renderer as `categoryColors`, keyed by BOTH
+    // the stored value and the display label (either can key a category).
+    await waitFor(() => expect(lastSchema?.categoryColors).toBeTruthy());
+    expect(lastSchema.categoryColors).toMatchObject({
+      won: '#16a34a',
+      Won: '#16a34a',
+      lost: '#dc2626',
+      Lost: '#dc2626',
+    });
+
+    // Exactly one document, and no second/dataset hop for an object-bound chart.
+    expect(metaCalls).toEqual(['/api/v1/meta/object/opportunity']);
+  });
+
+  it('resolves a dataset chart through its definition to the underlying object', async () => {
+    const metaCalls = installMetaFetchDouble({
+      '/api/v1/meta/dataset/showcase_task_metrics': {
+        item: {
+          name: 'showcase_task_metrics',
+          object: 'task',
+          dimensions: [{ name: 'status', field: 'status' }],
+        },
+      },
+      '/api/v1/meta/object/task': {
+        item: {
+          name: 'task',
+          fields: {
+            status: {
+              type: 'select',
+              options: [
+                { value: 'todo', label: 'To do' },
+                { value: 'done', label: 'Done' },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    render(
+      <ObjectChart
+        schema={{
+          type: 'object-chart',
+          chartType: 'bar',
+          dataset: 'showcase_task_metrics',
+          dimensions: ['status'],
+          values: ['task_count'],
+        }}
+        dataSource={{
+          queryDataset: vi.fn().mockResolvedValue({
+            rows: [{ status: 'todo', task_count: 3 }],
+            fields: [
+              { name: 'status', label: 'Status' },
+              { name: 'task_count', label: 'Tasks' },
+            ],
+          }),
+        }}
+      />,
+    );
+
+    // Two hops, IN ORDER: the dataset definition names the object, and only
+    // then can the object's field options be read. The order is the wiring —
+    // reversing it would mean fetching an object nothing has named yet.
+    await waitFor(() => expect(metaCalls).toHaveLength(2));
+    expect(metaCalls).toEqual([
+      '/api/v1/meta/dataset/showcase_task_metrics',
+      '/api/v1/meta/object/task',
+    ]);
+
+    // The value→label map built from the object's options is applied to the
+    // dataset rows, so the axis shows "To do" rather than the stored `todo`.
+    await waitFor(() => expect(lastSchema?.data?.[0]?.status).toBe('To do'));
+  });
+
+  it('keeps the theme palette when the object document carries no options', async () => {
+    // The pre-fix observable state: the probe fails (or answers nothing
+    // useful), the effect swallows it, and no categoryColors are handed down.
+    // Pinned so the "best-effort" contract cannot regress into a hard failure.
+    const metaCalls = installMetaFetchDouble({
+      '/api/v1/meta/object/opportunity': { item: { name: 'opportunity', fields: {} } },
+    });
+
+    render(
+      <ObjectChart
+        schema={{
+          type: 'object-chart',
+          chartType: 'bar',
+          objectName: 'opportunity',
+          xAxisKey: 'stage',
+          data: [{ stage: 'won', amount: 42 }],
+        }}
+        dataSource={{ find: async () => ({ data: [] }) }}
+      />,
+    );
+
+    await waitFor(() => expect(lastSchema).not.toBeNull());
+    expect(lastSchema.categoryColors).toBeUndefined();
+    expect(metaCalls).toEqual(['/api/v1/meta/object/opportunity']);
+  });
+});

--- a/packages/plugin-charts/src/__tests__/ObjectChart.compareTo.test.tsx
+++ b/packages/plugin-charts/src/__tests__/ObjectChart.compareTo.test.tsx
@@ -19,7 +19,7 @@
  * nothing at jsdom's zero-size container.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
 
 let lastSchema: any = null;
@@ -33,7 +33,44 @@ vi.mock('../ChartRenderer', () => ({
 
 import { ObjectChart } from '../ObjectChart';
 
+/**
+ * objectui#4106 — answer ObjectChart's option-color probe from a double.
+ *
+ * `objectName: 'deal'` makes ObjectChart resolve the category dimension's
+ * option colors via `GET /api/v1/meta/object/deal` on the GLOBAL `fetch`
+ * (ObjectChart.tsx:352) — under happy-dom a REAL request, 4 per run here (one
+ * per test). The effect swallows the rejection by design, so the suite stayed
+ * green while stderr filled with `connect ECONNREFUSED 127.0.0.1:3000`.
+ *
+ * `{}` reproduces that failure's observable outcome exactly: no options →
+ * `buildOptionColorMap` returns null, the state the catch branch already set.
+ * The compareTo assertions below are untouched by it.
+ */
+function installMetaFetchDouble(routes: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      calls.push(url);
+      return { ok: true, json: async () => routes[url] ?? {} };
+    }),
+  );
+  return calls;
+}
+
+let metaCalls: string[] = [];
+
+beforeEach(() => {
+  metaCalls = installMetaFetchDouble();
+});
+
 afterEach(() => {
+  // Anything other than the option-color probe is a NEW escape — fail here.
+  expect(metaCalls.filter((u) => u !== '/api/v1/meta/object/deal')).toEqual([]);
+  vi.unstubAllGlobals();
   cleanup();
   lastSchema = null;
 });


### PR DESCRIPTION
Fixes #4106

Test-only. Product code is untouched.

## Premise: reproduced, still valid

On `origin/main` @ `877385a76`, both packages' suites from the repo root:

```
pnpm exec vitest run packages/plugin-charts/ packages/plugin-dashboard/ --maxWorkers=2

Test Files  53 passed (53)
     Tests  439 passed (439)
$ grep -c ECONNREFUSED stderr  =>  24
$ wc -l stderr                 =>  96
```

Green suite, polluted stderr — the fail-open shape the card described. 96 stderr lines / 8 per error block = **12 escaped requests**, 2 `ECONNREFUSED` lines each = 24. The arithmetic closes before any bisecting starts.

## The bisect: one effect, two call sites, 100% of the noise

Per the card's inherited method (and PR #4105's worked example), I instrumented `fetch` / `XMLHttpRequest` / `EventSource` / `WebSocket` in the root setup file and attributed every escape to its test file rather than bisecting file by file.

| escaping file | live requests | endpoint |
|:--|--:|:--|
| `plugin-charts/src/ObjectChart.drillNavigate.test.tsx` | 4 | `/api/v1/meta/object/opportunity` |
| `plugin-charts/src/__tests__/ObjectChart.compareTo.test.tsx` | 4 | `/api/v1/meta/object/deal` |
| `plugin-charts/src/ObjectChart.elementDataSource.test.tsx` | 3 | `/api/v1/meta/object/account` |
| `plugin-charts/src/ObjectChart.datasetMeasureLabel.test.tsx` | 1 | `/api/v1/meta/dataset/showcase_task_metrics` |
| **total** | **12** | |

12 requests x 2 lines = the 24 `ECONNREFUSED` lines exactly. **All attributed, 0 unexplained.**

Two findings worth stating plainly, because both differ from what the card assumed:

1. **The root cause is confirmed different from #3339.** Nothing here touches `useRecordEditable` or `/api/v1/security/explain`. Every escape is `ObjectChart`'s category option-color effect (`ObjectChart.tsx:328`), which reads the **global** `fetch` at two call sites: line 344 (`/api/v1/meta/dataset/...`, to learn a dataset's underlying object) and line 352 (`/api/v1/meta/object/...`, for the field options). The effect is best-effort and swallows every rejection — which is exactly why the suites stayed green while stderr filled up.

2. **`plugin-dashboard` emits zero live requests.** The card named both packages, but attribution puts all 12 in `plugin-charts`. `plugin-dashboard` resolves the same `/api/v1/meta/object/...` document in `DatasetWidget`, and its suite already answers it from a double (`DatasetWidget.relabel.test.tsx:70`) — which is why it is silent. Nothing to fix there; it is the precedent this PR follows.

Per-file counts are explained too, not just the total: `elementDataSource` renders 4 tests but its unresolvable-`view` case never resolves an `objectName`, so it makes 3 probes; `datasetMeasureLabel`'s single dataset probe fails, so the second (object) hop never runs.

## The fix

A recording test double scoped to the four escaping files, following the sibling package's existing pattern and #4105's.

`{}` as the default answer reproduces the failed request's observable outcome **exactly**: `buildOptionColorMap(undefined)` and `buildDimensionLabelMap(undefined)` both return `null` (`packages/core/src/utils/chart-series.ts:198,275`), which is the same state the swallowed rejection's catch branch already set. No existing assertion changes meaning.

**No global error swallowing.** The double records every URL it is handed, and each file's `afterEach` fails on anything outside its one expected endpoint — so a NEW escape becomes a failing assertion instead of fresh stderr noise. That guard covers every test in those files, not just the ones that probe today.

**Product fallbacks untouched** — but the global-`fetch` read is a genuine product bug, so per the card it is reported rather than silently fixed here: filed as #4114 (`ObjectChart` never consults `SchemaRendererContext.apiFetch`, though it already reads that context at line 253, so a hosted console's auth/base-URL channel is bypassed for these two metadata reads). `ObjectChart.elementDataSource.test.tsx` is the demonstration case — it mounts a real `SchemaRendererProvider` and the probe still escapes.

No MSW harness stood up, per the card.

## Keeping the assertions meaningful

The escaped request was asserted by nobody, and because it always **failed**, the effect's success path had never once executed in this package's suite. New file `ObjectChart.optionColors.test.tsx` gives it real coverage from the component's own wiring (the map builders are unit-tested one level down in `@object-ui/core`; what is new is that ObjectChart asks for the right documents, in the right order, and feeds the results to the renderer):

- an object-bound chart probes its object once and the option colors reach the renderer as `categoryColors`, keyed by both stored value and display label;
- a dataset-bound chart makes **two hops in order** — the definition names the object, only then can that object's options be read — and the resulting value/label map is applied to the rows;
- the best-effort contract itself: no options means no `categoryColors` and no failure.

## Verification

Acceptance bar, the card's own command:

```
Test Files  54 passed (54)          # 53 + the new file
     Tests  442 passed (442)        # 439 + 3 new
$ grep -c ECONNREFUSED stderr  =>  0
$ wc -l stderr                 =>  0     # stderr entirely empty
```

**Reverse verification**, both directions predicted before running:

1. *Fix removed* (`git checkout origin/main --` on the four files, new file held aside) — noise returns at **exactly 24** `ECONNREFUSED`, and the suite is still green at 439 tests. Confirms the doubles are what stop it, and that the escape never had a test watching it.
2. *New assertion is load-bearing* — breaking the product (`buildOptionColorMap(undefined)` at line 355, so field options are never read) turns it **red**: `AssertionError: expected undefined to be truthy`, 1 failed | 2 passed. The other two stay green as predicted, since dimension labels come from a different builder and the no-options case expects `undefined` either way. Restored afterwards; `git diff HEAD -- packages/plugin-charts/src/ObjectChart.tsx` is empty.

Gates: `pnpm --filter @object-ui/plugin-charts type-check` green (after `pnpm --filter '@object-ui/plugin-charts^...' build` — the fresh-worktree dependency closure), `eslint` on all five files **0 errors** (15 pre-existing `no-explicit-any` warnings, same style as the surrounding mocks), control-byte self-scan clean. `scripts/check-changeset-presence.mjs` arbitrated and required the **empty-frontmatter** changeset for a test-only change — its sanctioned pass, not a workaround; `check-changeset-no-major.mjs` green. (`skip-changeset` is not a real label in this repo, per objectui#3724.)

## Deliberately not in this PR

- **The `apiFetch` bypass** (#4114) — a product contract change, out of scope for a hygiene card.
- **`plugin-dashboard`** — verified clean by attribution rather than assumed; adding doubles there would be theatre.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_