### PR TITLE
fix(plugin-charts): route ObjectChart's option-color probe through the host apiFetch

### DIFF
--- a/.changeset/objectchart-option-color-probe-apifetch-4114.md
+++ b/.changeset/objectchart-option-color-probe-apifetch-4114.md
@@ -1,0 +1,21 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+`ObjectChart`'s category option-color / dimension-label probe now rides the host's
+authenticated fetch (`SchemaRendererContext.apiFetch`) instead of the bare global
+`fetch`.
+
+Both metadata reads the effect makes — `GET /api/v1/meta/dataset/{dataset}` and
+`GET /api/v1/meta/object/{object}` — went out on the global `fetch`, so in a hosted
+console they skipped whatever the host supplies on that channel (Authorization /
+tenant headers, base-URL rewrite, draft-preview params). A bearer-token session
+carries its credential in a header rather than a cookie, so `credentials: 'include'`
+alone left these two reads unauthenticated. The effect is best-effort and swallows
+every failure, which made the symptom silent: semantic option colors and dataset
+dimension labels simply never applied, and the chart fell back to the positional
+theme palette and raw stored values.
+
+Standalone embeds are unaffected — with no provider (or a provider that supplies no
+`apiFetch`) the probe still uses the global `fetch`, the same documented fallback
+`useRecordEditable` and `provider: 'api'` view sources use.

--- a/packages/plugin-charts/src/ObjectChart.optionColors.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.optionColors.test.tsx
@@ -25,6 +25,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
+import { SchemaRendererProvider } from '@object-ui/react';
 
 let lastSchema: any = null;
 
@@ -55,6 +56,25 @@ function installMetaFetchDouble(routes: Record<string, unknown> = {}) {
     }),
   );
   return calls;
+}
+
+/**
+ * objectui#4114 — the same recorder, but as a standalone function rather than
+ * a global stub, so a host's `apiFetch` channel and the global `fetch` can be
+ * recorded SEPARATELY and the probe's routing read off which one moved.
+ */
+function makeMetaFetchRecorder(routes: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  const inits: (RequestInit | undefined)[] = [];
+  const fn = vi.fn(async (input: unknown, init?: RequestInit) => {
+    const url = String(
+      input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+    );
+    calls.push(url);
+    inits.push(init);
+    return { ok: true, json: async () => routes[url] ?? {} };
+  });
+  return { fn, calls, inits };
 }
 
 afterEach(() => {
@@ -200,5 +220,158 @@ describe('ObjectChart — category option colors (objectui#4106)', () => {
     await waitFor(() => expect(lastSchema).not.toBeNull());
     expect(lastSchema.categoryColors).toBeUndefined();
     expect(metaCalls).toEqual(['/api/v1/meta/object/opportunity']);
+  });
+});
+
+/**
+ * objectui#4114 — WHICH channel the two probes above ride.
+ *
+ * `ObjectChart` already reads `SchemaRendererContext`, but the effect used to
+ * call the bare global `fetch` at both call sites, so a hosted console's
+ * authenticated channel (Authorization / tenant headers, base-URL rewrite,
+ * draft-preview params — `ConsoleShell.tsx:245` supplies it) was bypassed. The
+ * effect swallows every failure, so the symptom was silent: option colors and
+ * dataset dimension labels simply never applied.
+ *
+ * Both recorders answer the SAME documents here, so the data path stays green
+ * either way and the only thing these pins can go red on is the routing — the
+ * host recorder holding nothing, or the global recorder holding something.
+ */
+describe('ObjectChart — option-color probe routing (objectui#4114)', () => {
+  const OPPORTUNITY_DOC = {
+    '/api/v1/meta/object/opportunity': {
+      item: {
+        name: 'opportunity',
+        fields: {
+          stage: {
+            type: 'select',
+            options: [{ value: 'won', label: 'Won', color: '#16a34a' }],
+          },
+        },
+      },
+    },
+  };
+
+  const OBJECT_CHART_SCHEMA = {
+    type: 'object-chart',
+    chartType: 'bar',
+    objectName: 'opportunity',
+    xAxisKey: 'stage',
+    data: [{ stage: 'won', amount: 42 }],
+  };
+
+  it('rides the host apiFetch when a provider supplies one, and never the global fetch', async () => {
+    const globalCalls = installMetaFetchDouble(OPPORTUNITY_DOC);
+    const host = makeMetaFetchRecorder(OPPORTUNITY_DOC);
+
+    render(
+      <SchemaRendererProvider
+        dataSource={{ find: async () => ({ data: [] }) } as any}
+        apiFetch={host.fn as any}
+      >
+        <ObjectChart schema={OBJECT_CHART_SCHEMA} />
+      </SchemaRendererProvider>,
+    );
+
+    // The object probe went through the host channel...
+    await waitFor(() => expect(host.calls).toEqual(['/api/v1/meta/object/opportunity']));
+    // ...and nothing escaped to the global one. This is the assertion the bug
+    // failed: pre-fix the two recorders held exactly the opposite contents.
+    expect(globalCalls).toEqual([]);
+    // The request options survive the routing — a host that needs the accept
+    // header still gets it, it is not dropped on the way to `apiFetch`.
+    expect(host.inits[0]).toMatchObject({ headers: { accept: 'application/json' } });
+    // And the routed answer is consumed, not merely requested.
+    await waitFor(() => expect(lastSchema?.categoryColors).toMatchObject({ won: '#16a34a' }));
+  });
+
+  it('routes BOTH dataset hops through the host apiFetch', async () => {
+    const routes = {
+      '/api/v1/meta/dataset/showcase_task_metrics': {
+        item: {
+          name: 'showcase_task_metrics',
+          object: 'task',
+          dimensions: [{ name: 'status', field: 'status' }],
+        },
+      },
+      '/api/v1/meta/object/task': {
+        item: {
+          name: 'task',
+          fields: {
+            status: {
+              type: 'select',
+              options: [
+                { value: 'todo', label: 'To do' },
+                { value: 'done', label: 'Done' },
+              ],
+            },
+          },
+        },
+      },
+    };
+    const globalCalls = installMetaFetchDouble(routes);
+    const host = makeMetaFetchRecorder(routes);
+
+    render(
+      <SchemaRendererProvider
+        dataSource={{
+          queryDataset: vi.fn().mockResolvedValue({
+            rows: [{ status: 'todo', task_count: 3 }],
+            fields: [{ name: 'status', label: 'Status' }, { name: 'task_count', label: 'Tasks' }],
+          }),
+        } as any}
+        apiFetch={host.fn as any}
+      >
+        <ObjectChart
+          schema={{
+            type: 'object-chart',
+            chartType: 'bar',
+            dataset: 'showcase_task_metrics',
+            dimensions: ['status'],
+            values: ['task_count'],
+          }}
+        />
+      </SchemaRendererProvider>,
+    );
+
+    // Both call sites — the dataset definition read AND the object read it
+    // names — are on the host channel, in order.
+    await waitFor(() => expect(host.calls).toHaveLength(2));
+    expect(host.calls).toEqual([
+      '/api/v1/meta/dataset/showcase_task_metrics',
+      '/api/v1/meta/object/task',
+    ]);
+    expect(globalCalls).toEqual([]);
+    // The dimension labels resolved over the host channel reach the rows.
+    await waitFor(() => expect(lastSchema?.data?.[0]?.status).toBe('To do'));
+  });
+
+  it('keeps using the global fetch for a standalone embed with no provider', async () => {
+    // The documented boundary of the convention (`useRecordEditable.ts:32`):
+    // no host, no `apiFetch` — the probe must still work off the global fetch
+    // rather than crash or go quiet.
+    const globalCalls = installMetaFetchDouble(OPPORTUNITY_DOC);
+
+    render(<ObjectChart schema={OBJECT_CHART_SCHEMA} dataSource={{ find: async () => ({ data: [] }) }} />);
+
+    await waitFor(() => expect(lastSchema?.categoryColors).toMatchObject({ won: '#16a34a' }));
+    expect(globalCalls).toEqual(['/api/v1/meta/object/opportunity']);
+  });
+
+  it('keeps using the global fetch when a provider supplies no apiFetch', async () => {
+    // A host CAN be mounted without an authenticated channel (every
+    // `SchemaRendererProvider dataSource={…}` in the suites, e.g.
+    // `ObjectChart.elementDataSource.test.tsx`). Presence of a provider is not
+    // presence of a channel, so this must stay on the fallback.
+    const globalCalls = installMetaFetchDouble(OPPORTUNITY_DOC);
+
+    render(
+      <SchemaRendererProvider dataSource={{ find: async () => ({ data: [] }) } as any}>
+        <ObjectChart schema={OBJECT_CHART_SCHEMA} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(lastSchema?.categoryColors).toMatchObject({ won: '#16a34a' }));
+    expect(globalCalls).toEqual(['/api/v1/meta/object/opportunity']);
   });
 });

--- a/packages/plugin-charts/src/ObjectChart.optionColors.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.optionColors.test.tsx
@@ -25,7 +25,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
-import { SchemaRendererProvider } from '@object-ui/react';
+import { SchemaRendererProvider, type ApiFetch } from '@object-ui/react';
 
 let lastSchema: any = null;
 
@@ -74,7 +74,9 @@ function makeMetaFetchRecorder(routes: Record<string, unknown> = {}) {
     inits.push(init);
     return { ok: true, json: async () => routes[url] ?? {} };
   });
-  return { fn, calls, inits };
+  // The double answers the two fields the probe reads (`ok` / `json()`), not a
+  // whole Response — cast once here so the call sites stay `any`-free.
+  return { fn: fn as unknown as ApiFetch, calls, inits };
 }
 
 afterEach(() => {
@@ -266,8 +268,8 @@ describe('ObjectChart — option-color probe routing (objectui#4114)', () => {
 
     render(
       <SchemaRendererProvider
-        dataSource={{ find: async () => ({ data: [] }) } as any}
-        apiFetch={host.fn as any}
+        dataSource={{ find: async () => ({ data: [] }) }}
+        apiFetch={host.fn}
       >
         <ObjectChart schema={OBJECT_CHART_SCHEMA} />
       </SchemaRendererProvider>,
@@ -319,8 +321,8 @@ describe('ObjectChart — option-color probe routing (objectui#4114)', () => {
             rows: [{ status: 'todo', task_count: 3 }],
             fields: [{ name: 'status', label: 'Status' }, { name: 'task_count', label: 'Tasks' }],
           }),
-        } as any}
-        apiFetch={host.fn as any}
+        }}
+        apiFetch={host.fn}
       >
         <ObjectChart
           schema={{
@@ -366,7 +368,7 @@ describe('ObjectChart — option-color probe routing (objectui#4114)', () => {
     const globalCalls = installMetaFetchDouble(OPPORTUNITY_DOC);
 
     render(
-      <SchemaRendererProvider dataSource={{ find: async () => ({ data: [] }) } as any}>
+      <SchemaRendererProvider dataSource={{ find: async () => ({ data: [] }) }}>
         <ObjectChart schema={OBJECT_CHART_SCHEMA} />
       </SchemaRendererProvider>,
     );

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -252,6 +252,11 @@ export const ObjectChart = (props: any) => {
   const onSegmentClick: ((ev: { category?: string; series?: string; value?: number }) => void) | undefined = props.onSegmentClick;
   const context = useContext(SchemaRendererContext);
   const dataSource = props.dataSource || context?.dataSource;
+  // Host-authenticated fetch for the metadata probes below (#4114). Read from
+  // the context directly rather than `useSchemaContext()`, which throws with no
+  // provider mounted: a standalone chart embed has no host fetch and must keep
+  // degrading to the global one instead of crashing the render.
+  const apiFetch = context?.apiFetch;
   const boundData = useDataScope(schema.bind);
   const { fieldOptionLabel } = useSafeFieldLabel();
   // Keep a stable ref to fieldOptionLabel — the i18n hook returns a fresh
@@ -326,10 +331,20 @@ export const ObjectChart = (props: any) => {
 
   // Resolve the category dimension's option colors (P3). Best-effort: any
   // failure leaves categoryColors null and the chart keeps the theme palette.
+  //
+  // Both metadata reads ride the host's AUTHENTICATED fetch (#4114) — the same
+  // channel `provider: 'api'` view sources use — falling back to the global one
+  // only when no host supplies it. A bearer-token session carries its
+  // credential in the `Authorization` header, not a cookie, so
+  // `credentials: 'include'` alone left these two reads unauthenticated in a
+  // hosted console; the effect swallows every failure, so the symptom was not
+  // an error but semantic option colors and dataset dimension labels silently
+  // never applying.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
+        const doFetch = apiFetch ?? fetch;
         const reqOpts = { headers: { accept: 'application/json' }, credentials: 'include' as const };
         let objectName: string | undefined = schema.objectName;
         let fieldName: string | undefined;
@@ -341,7 +356,7 @@ export const ObjectChart = (props: any) => {
         } else if (schema.dataset) {
           // dataset path: dataset.object + first dimension's underlying field
           const dim0 = Array.isArray(schema.dimensions) && schema.dimensions.length ? schema.dimensions[0] : undefined;
-          const defRes = await fetch(`/api/v1/meta/dataset/${encodeURIComponent(schema.dataset)}`, reqOpts);
+          const defRes = await doFetch(`/api/v1/meta/dataset/${encodeURIComponent(schema.dataset)}`, reqOpts);
           const defJson = await defRes.json().catch(() => null);
           datasetDef = defJson?.item ?? defJson?.data ?? defJson;
           objectName = datasetDef?.object;
@@ -349,7 +364,7 @@ export const ObjectChart = (props: any) => {
           fieldName = dim?.field ?? dim0;
         }
         if (!objectName || !fieldName) { if (!cancelled) { setFieldOptionColors(null); setDimensionLabels(null); } return; }
-        const schemaRes = await fetch(`/api/v1/meta/object/${encodeURIComponent(objectName)}`, reqOpts);
+        const schemaRes = await doFetch(`/api/v1/meta/object/${encodeURIComponent(objectName)}`, reqOpts);
         const sj = await schemaRes.json().catch(() => null);
         const objSchema = sj?.item ?? sj?.data ?? sj;
         const map = buildOptionColorMap(objSchema?.fields?.[fieldName]?.options);
@@ -371,7 +386,7 @@ export const ObjectChart = (props: any) => {
     })();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [schema.objectName, schema.dataset, datasetKey, aggregateKey, schema.xAxisKey]);
+  }, [schema.objectName, schema.dataset, datasetKey, aggregateKey, schema.xAxisKey, apiFetch]);
 
   // Run a single aggregate query (used for both the current and comparison
   // windows). Extracted so the two queries share identical logic.


### PR DESCRIPTION
Fixes #4114

Branched off `origin/main` @ `ce4b9e8af` — PR #4115 (issue #4106) had already merged when this started, so this is **not** stacked; its four test files and their recording doubles are on main.

## Premise: verified, still valid

Both bare reads are exactly where the issue said, at the unchanged line numbers on `ce4b9e8af`:

```
344:  const defRes = await fetch(`/api/v1/meta/dataset/${encodeURIComponent(schema.dataset)}`, reqOpts);
352:  const schemaRes = await fetch(`/api/v1/meta/object/${encodeURIComponent(objectName)}`, reqOpts);
```

and the injection point is genuinely in scope — `const context = useContext(SchemaRendererContext);` at line 253, already used one line later for `dataSource`. Nothing had drifted.

## The fix

`const doFetch = apiFetch ?? fetch;` at the top of the effect, both call sites through it — the idiom `useRecordEditable.ts:74` implements and `useRecordEditable.ts:32` documents ("the same channel `provider: 'api'` view sources use, not the bare global one"), matching `ObjectGantt.tsx:461-468` and `useViewData.ts:100-107`.

Two details taken from the references rather than invented:

- **The context is read directly, not via `useSchemaContext()`** — that hook throws with no provider mounted, and a standalone chart embed has to keep rendering. Same reason `useRecordEditable` gives at its own context read.
- **`apiFetch` joins the effect's dependency array**, as it does in `useRecordEditable`'s. This does not re-open the refetch-loop hazard the surrounding code guards against: `ObjectChart`'s own `setState` cannot re-render the *provider*, so the context value — and with it the `apiFetch` identity — is stable across the effect's own updates.

The sole in-repo host holds it at module scope (`ConsoleShell.tsx:187` → `:245`), so the identity is stable there too.

## Behavior boundary — the fallback half is pinned, not assumed

Standalone embeds keep working on the global `fetch`, and there are **two** distinct no-channel shapes, both now pinned:

1. no provider at all;
2. a provider that supplies `dataSource` but no `apiFetch` — the shape every existing suite mounts, e.g. `ObjectChart.elementDataSource.test.tsx`. Presence of a host is not presence of a channel.

## Tests

Four pins added to `ObjectChart.optionColors.test.tsx` (the file #4115 created for this effect), in a new `objectui#4114` block. The routing is read off **two separate recorders** — the global-`fetch` stub #4115 already had, plus a standalone recorder handed in as the provider's `apiFetch`:

- object-bound chart under a host → the probe is in the host recorder, the global recorder is **empty**, the request init survives the hop (`accept: application/json`), and the routed answer reaches the renderer as `categoryColors`;
- dataset-bound chart under a host → **both** hops (`:344` then `:352`, in order) are in the host recorder, global empty, and the dimension labels resolved over the host channel reach the rows;
- no provider → global recorder holds the probe;
- provider without `apiFetch` → global recorder holds the probe.

Both recorders answer the **same** documents, so the data path stays green either way and the only thing these pins can go red on is the routing itself.

**No existing test was changed in meaning.** The `plugin-charts` diff is additive apart from one import line; the four #4115 files are untouched. That follows from the behavior boundary above — every existing mount is a no-`apiFetch` shape, so the routing change genuinely moves nothing for them. (The second commit only deletes three `as any` casts from the new pins: `SchemaRendererProvider.dataSource` is already typed `any`, and the recorder's fake Response is cast once inside its helper.)

## Verification

Repo root, both packages, per AGENTS.md:

```
pnpm exec vitest run packages/plugin-charts/ packages/plugin-dashboard/ --maxWorkers=2

Test Files  54 passed (54)
     Tests  446 passed (446)        # 442 on main + 4 new
$ wc -l stderr                 =>  0
$ grep -c ECONNREFUSED stderr  =>  0
```

stderr stays entirely empty — #4115's no-escape guarantee survives the routing change.

**Reverse verification**, direction predicted before running: revert *only* the product routing (`git checkout origin/main -- ObjectChart.tsx`, new tests held), and the two host-mounted pins go red while the two fallback pins and all three #4106 pins stay green — because with no channel supplied, pre-fix and post-fix code do the identical thing.

```
× rides the host apiFetch when a provider supplies one, and never the global fetch
× routes BOTH dataset hops through the host apiFetch
AssertionError: expected [] to deeply equal [ '/api/v1/meta/object/opportunity' ]
AssertionError: expected [] to have a length of 2 but got +0
Tests  2 failed | 5 passed (7)
```

Exactly as predicted, 2 red / 5 green, and both failures name the host recorder holding nothing — the escape landing in the global recorder instead. Restored afterwards; `git diff` clean.

Gates: `pnpm --filter @object-ui/plugin-charts type-check` green (after `pnpm --filter '@object-ui/plugin-charts^...' build`, the fresh-worktree dependency closure). `eslint` on both changed files **0 errors**; the test file is at 2 warnings, both pre-existing #4115 lines — the new tests add **zero**. `check-changeset-presence` / `check-changeset-no-major` / `check-control-bytes` green, plus a control-byte self-scan over the three changed files.

## Changeset

`@object-ui/plugin-charts` **patch** — a real behavior fix on a released package, not internal-only, so an empty-frontmatter declaration would be wrong here.

## Out of scope, filed

**#4121** — `plugin-dashboard`'s `DatasetWidget.tsx:589` reads the same `/api/v1/meta/object/…` document off the global `fetch`, for the same colors and labels, with the same silent symptom. #4114's body anticipated this twin. Not folded in: different package, different component, and it needs its own decision about where the context read goes (`DatasetWidget` does not consult `SchemaRendererContext` at all today).

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_