### PR TITLE
docs(data-objectstack): describe the real dependency contract, not a peer one

### DIFF
--- a/content/docs/utilities/data-objectstack.mdx
+++ b/content/docs/utilities/data-objectstack.mdx
@@ -10,10 +10,10 @@ The `@object-ui/data-objectstack` package provides a data adapter that connects 
 ## Installation
 
 ```bash
-npm install @object-ui/data-objectstack @objectstack/client
+npm install @object-ui/data-objectstack
 ```
 
-**Note:** The `@objectstack/client` package is a peer dependency and must be installed separately.
+**Note:** `@objectstack/client` is a regular dependency of this package — it is installed and resolved along with it, so there is nothing to install separately.
 
 ## Overview
 
@@ -453,9 +453,12 @@ function DataComponent() {
 
 ## Dependencies
 
-- **@objectstack/client** (peer dependency) - ObjectStack API client
+This package declares no peer dependencies. Everything below is a regular dependency that is installed and resolved with the package:
+
+- **@objectstack/client** - ObjectStack API client
+- **@objectstack/spec** - ObjectStack metadata spec and shared contracts
+- **@object-ui/core** - Schema engine and query helpers
 - **@object-ui/types** - TypeScript types
-- **react** (peer dependency) - React library
 
 ## Integration with Plugins
 


### PR DESCRIPTION
Fixes #3781

Docs-only. Aligns `content/docs/utilities/data-objectstack.mdx` with the manifest as it **is** — the manifest is deliberately untouched, per the split ruling on the card.

## Premise re-verified on `origin/main` = `cfeb378b5`

`packages/data-objectstack/package.json`:

- **no `peerDependencies` key at all** — stronger than the card's `"peerDependencies": {}`, same conclusion: the package declares no peers;
- `@objectstack/client` and `@objectstack/spec` are regular `dependencies` (alongside `@object-ui/core` and `@object-ui/types`);
- `react` appears in **no** dependency field — only in `keywords`. `grep -rn react packages/data-objectstack/src/` returns two prose comments naming the separate `@object-ui/react` package and nothing else, so the package imports React nowhere. Its dependency closure is React-free too: `@object-ui/core` and `@object-ui/types` both declare `peerDependencies: {}`.

Premise holds: the docs were wrong, the manifest was not.

## The three sites

| Site | Before | After |
|---|---|---|
| `:13` install | `npm install @object-ui/data-objectstack @objectstack/client` | `npm install @object-ui/data-objectstack` |
| `:16` note | "is a peer dependency and must be installed separately" | "is a regular dependency ... nothing to install separately" |
| `:456` bullets | `client` and `react` both labelled `(peer dependency)` | `react` bullet deleted outright; `client` relabelled |

**One addition beyond the card's three sites**, from its own instruction to cross-check the whole page for dependency-contract prose: the Dependencies section listed only 2 of the package's 4 regular dependencies. Since the `react` bullet was being deleted from that exact list, the two omitted ones (`@objectstack/spec`, `@object-ui/core`) were added, so the section now matches the manifest line for line.

## Page-wide cross-check

`grep -i "peer" / "installed separately"` over the file: the only surviving match is the new truthful sentence. Repo-wide, the only other peer-dependency prose in `content/docs/` is `guide/troubleshooting.md:70` ("ObjectUI packages declare React 18+ as a peer dependency") — **left alone because it is true**: 20+ packages do declare a react peer. `data-objectstack` is the headless adapter that correctly does not, which is exactly how the false bullet got copied onto this page.

## Verification

| Gate | Result |
|---|---|
| `pnpm turbo run build --filter=@object-ui/site` (Build Docs equivalent) | `29 successful, 29 total` in 3m11s |
| `node scripts/check-doc-links.mjs` | `Links are valid across 7 scan roots.` |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 3827 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | `No source of a released package changed in this range, so no changeset is owed.` |

Rendered-output check on the built page (`apps/site/.next/server/app/docs/utilities/data-objectstack.html`): none of the three false claims render any more, and the four corrected bullets do. Changeset: none owed, per the presence script's own arbitration (docs-only, no released package `src/` touched).

## Out-of-scope findings (filed, not fixed here)

- **#4124** — the same page's Quick Start and API Reference document an `ObjectStackProvider` / `useObjectStack` React API the package does not export. It is headless; the real surface is `createObjectStackAdapter` / `ObjectStackAdapter`. Concrete defect, needs its own rewrite.
- **#4125** — `**Version:** 0.3.1` hardcoded on this page and on `vscode-extension.mdx` while both packages are at `17.4.0`. Filed as `finding`.

## Not done, deliberately

The manifest-side half of #3781 — whether `@objectstack/client` *should* become a peer so hosts share one client instance — stays with the maintainer and was declined without measured pain. Today's change makes the docs true under the contract that ships now; if that ruling ever flips, the docs flip back as part of that change.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_