### PR TITLE
refactor(core): derive DatasetResultField from spec AnalyticsResult.fields[]

### DIFF
--- a/.changeset/dataset-result-field-derive-3815.md
+++ b/.changeset/dataset-result-field-derive-3815.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/core': minor
+---
+
+`DatasetResultField` is now `@objectstack/spec`'s `AnalyticsResult.fields[]` element itself, not a hand-written restatement of it
+
+`packages/core/src/utils/dataset-format.ts` declared its own six-key interface for the analytics result column, under a doc comment describing the server's contract. The key set happened to match the spec today, so nothing was broken — but it was the last surviving member of the derive-don't-restate family (#3613 / #3753 on the parameter side, #3752 on the adapter return side), and it was the member with no compile-time tripwire: three surfaces (`plugin-dashboard`'s `DatasetWidget`, `plugin-report`'s `DatasetReportRenderer`, app-shell's `DatasetPreview`) consume this name AS the real column type, so the next spec column key would simply never appear here and no build would complain. It is now `AnalyticsResult['fields'][number]`, so it cannot lag the contract again.
+
+**Consumer-visible type tightening (the reason this is a minor, not a patch).** The restatement had relaxed `type` to optional; the contract requires it. Anything that assigned a column literal without `type` — or a bare `{ name, label?, format? }` — to `DatasetResultField` will now fail to compile, and the fix is to supply the `type` the server always sends. Nothing in this repo needed changing: every value of this type originates in `ObjectStackAdapter.queryDataset`, which already declares the spec element, and no consumer reads `.type` at all, so the widening had bought no caller anything while advertising a `string | undefined` the wire never produces. Marked `minor` per the repo's bump policy, which reserves `major` for following `@objectstack/spec` across a major.
+
+The exported name is unchanged and the `PercentScale` re-export from this module is untouched, so existing import paths keep working. `packages/core/tsconfig.typetests.json` (chained off the package's `type-check`) compiles the new parity test, so the pins are checked by CI rather than merely written down — including a negative pin that goes red if the hand-written interface is ever restored, and the `ChartResultField` superset relationship the module's comment claims.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/core/src/utils/__tests__/dataset-result-field-spec-parity.test.ts
+++ b/packages/core/src/utils/__tests__/dataset-result-field-spec-parity.test.ts
@@ -1,0 +1,147 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `DatasetResultField` IS `@objectstack/spec`'s `AnalyticsResult.fields[]`
+ * element — pinned at COMPILE TIME (objectui#3815).
+ *
+ * Why a whole file for one alias: the alias is the fix, and an alias cannot
+ * drift while it exists — but nothing stops the next session from "restoring"
+ * a readable local interface, which is exactly how the restatement this
+ * replaced was born. So the sabotage direction is recorded here as a negative
+ * pin rather than in a commit message: re-hand-writing the six keys turns
+ * `_NotTheHandWrittenCopy` red.
+ *
+ * The assertions below are TYPES. `Assert< Equal< Local, Spec > >` is a compile
+ * error or it is nothing — and this package's own `tsconfig.json` is the BUILD
+ * config, which excludes every `.test.ts` file under `src` (correctly: a test
+ * must not emit into `dist`), while `@object-ui/core` is still in
+ * `scripts/check-type-check-coverage.mjs`'s TEST_DEBT, so no other `tsc`
+ * invocation reads this tree either. `packages/core/tsconfig.typetests.json`
+ * lists this file explicitly and is chained off the package's `type-check`
+ * script; without that project these pins would be the "declared != enforced"
+ * landmine objectstack#4115 exists to remove, sitting inside a guard for it
+ * (objectui#3009 found precisely that: reverting a derived alias produced zero
+ * errors under a header calling the assertions "the real enforcement").
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { AnalyticsResult as SpecAnalyticsResult } from '@objectstack/spec/contracts';
+import type { PercentScale as SpecPercentScale } from '@objectstack/spec/data';
+import { buildDatasetFieldHelpers, type DatasetResultField } from '../dataset-format.js';
+import type { ChartResultField } from '../chart-series.js';
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+type Extends<A, B> = A extends B ? true : false;
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
+
+/** The spec element this name is supposed to BE. */
+type SpecResultField = SpecAnalyticsResult['fields'][number];
+
+describe('DatasetResultField IS @objectstack/spec AnalyticsResult.fields[]', () => {
+  it('is pinned at compile time', () => {
+    // The spec side has to have resolved to a real type: every assertion below
+    // is vacuously true against `any`, so this is what keeps a broken import
+    // from reading as a green pin.
+    type _SpecNotAny = Assert<Equal<IsAny<SpecAnalyticsResult>, false>>;
+
+    // THE pin. `Equal` rather than a two-way `extends` on purpose (the #3613
+    // reason): a restatement that merely *overlaps* the contract stays mutually
+    // assignable in the drifted direction too — a required `type` is still
+    // assignable to an optional one, which is exactly how this declaration sat
+    // "not drifted" while being one relaxation away from lying. Structural
+    // identity is the only assertion a hand copy cannot pass while drifting.
+    type _IsTheSpecField = Assert<Equal<DatasetResultField, SpecResultField>>;
+
+    // The single difference the restatement had accumulated, named so a reader
+    // learns WHICH relaxation cost something rather than merely that one
+    // existed: `type` is REQUIRED on the wire, and was optional here.
+    type _TypeIsRequired = Assert<Equal<DatasetResultField['type'], string>>;
+    type _TypeIsNotOptional = Assert<
+      Equal<Equal<DatasetResultField['type'], string | undefined>, false>
+    >;
+
+    // `percentScale` (#3136) is the spec's union, not a widened `string` — a
+    // renderer branches on `fraction` vs `whole` instead of guessing from the
+    // value's magnitude, so the union IS the capability.
+    type _HasPercentScale = Assert<HasKey<DatasetResultField, 'percentScale'>>;
+    type _PercentScaleIsTheSpecUnion = Assert<
+      Equal<DatasetResultField['percentScale'], SpecPercentScale | undefined>
+    >;
+    type _PercentScaleIsNotString = Assert<
+      Equal<Equal<DatasetResultField['percentScale'], string | undefined>, false>
+    >;
+
+    // The exact interface this replaced, kept as a NEGATIVE pin: hand-writing
+    // the six keys back — with the `type?` relaxation that made it a superset
+    // of the contract rather than the contract — turns this red.
+    type _NotTheHandWrittenCopy = Assert<
+      Equal<
+        Equal<
+          DatasetResultField,
+          {
+            name: string;
+            type?: string;
+            label?: string;
+            format?: string;
+            currency?: string;
+            percentScale?: SpecPercentScale;
+          }
+        >,
+        false
+      >
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  // The file-header claim on `DatasetResultField`, stated as a type instead of
+  // as prose. `ChartResultField` is `@object-ui/core`'s own renderer-internal
+  // shape (nothing in the spec owns it), and `DatasetWidget` hands its
+  // `DatasetResultField[]` state straight to `buildChartSeries`, which accepts
+  // `ChartResultField[]` — so the superset direction is load-bearing, not
+  // documentation.
+  it('is still a superset of ChartResultField', () => {
+    type _DatasetFieldIsAChartField = Assert<Extends<DatasetResultField, ChartResultField>>;
+    type _ChartKeysAreDatasetKeys = Assert<Extends<keyof ChartResultField, keyof DatasetResultField>>;
+
+    // …and NOT the other way round, which is new: with `type` required, a bare
+    // `{ name, label?, format? }` no longer satisfies `DatasetResultField`. No
+    // caller flows in that direction (`buildChartSeries` and
+    // `buildDatasetFieldHelpers` both take the wider value), but the asymmetry
+    // is the whole content of the word "superset" and is recorded rather than
+    // assumed.
+    type _ChartFieldIsNotADatasetField = Assert<
+      Equal<Extends<ChartResultField, DatasetResultField>, false>
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  // The runtime half: a spec-shaped column — every key the contract carries,
+  // including the required `type` — flows through the shared helper the three
+  // dataset surfaces build their headers with.
+  it('a spec-shaped column feeds buildDatasetFieldHelpers', () => {
+    const fields: DatasetResultField[] = [
+      { name: 'win_rate', type: 'number', label: 'Win rate', format: '0.0%', percentScale: 'fraction' },
+      { name: 'revenue', type: 'number', label: 'Revenue', format: '0,0', currency: 'USD' },
+    ];
+    const { measureField, headerLabel } = buildDatasetFieldHelpers(fields, 'opportunity');
+
+    expect(headerLabel('win_rate')).toBe('Win rate');
+    expect(measureField('win_rate')?.percentScale).toBe('fraction');
+    expect(measureField('revenue')?.currency).toBe('USD');
+    // Every column the wire produces declares its `type`; the helper passes it
+    // through untouched.
+    expect(measureField('revenue')?.type).toBe('number');
+  });
+});

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -17,22 +17,35 @@
  * by both `@object-ui/plugin-dashboard` and `@object-ui/plugin-report`.
  */
 
+import type { AnalyticsResult } from '@objectstack/spec/contracts';
 import type { PercentScale } from '@objectstack/spec/data';
 
 /**
- * Column metadata the analytics server returns alongside the rows: a display
- * `label` for both dimensions and measures, plus a measure's numeral `format`
- * and declared `currency`. A superset of {@link ChartResultField} (which only
- * needs name/label/format).
+ * Column metadata the analytics server returns alongside the rows — the spec's
+ * `AnalyticsResult.fields[]` element BY REFERENCE, never a local restatement of
+ * it (objectui#3815). Read `@objectstack/spec` for what a column carries; this
+ * comment deliberately does not re-list the keys, because the enumeration it
+ * replaced was the latent bug: a hand-written interface stops at the contract
+ * of the day it was written and cannot grow with the spec, and here it would
+ * not even fail to compile — three surfaces (`plugin-dashboard`'s
+ * `DatasetWidget`, `plugin-report`'s `DatasetReportRenderer`, app-shell's
+ * `DatasetPreview`) consume this name AS the real thing, so a spec column key
+ * they never learn about is one they can never render. The same derive-don't-
+ * restate fix as the parameter side (#3613/#3753) and the adapter return side
+ * (#3752); this was the last surviving restatement of the family.
+ *
+ * `type` is REQUIRED, as the contract has it. The restatement had relaxed it to
+ * optional, which was a promise the server never asked for: nothing in this repo
+ * constructs a result column (every value originates in
+ * `ObjectStackAdapter.queryDataset`, which already declares the spec element),
+ * and nothing reads `.type` — so the widening bought no caller anything and only
+ * offered future readers a `string | undefined` the wire never produces.
+ *
+ * Still a superset of {@link ChartResultField} (which needs only
+ * name/label/format) — pinned, not merely asserted, in
+ * `__tests__/dataset-result-field-spec-parity.test.ts`.
  */
-export interface DatasetResultField {
-  name: string;
-  type?: string;
-  label?: string;
-  format?: string;
-  currency?: string;
-  percentScale?: PercentScale;
-}
+export type DatasetResultField = AnalyticsResult['fields'][number];
 
 /**
  * How a percentage column's stored number relates to its displayed percentage —

--- a/packages/core/tsconfig.typetests.json
+++ b/packages/core/tsconfig.typetests.json
@@ -1,0 +1,31 @@
+{
+  // Compiles the test file whose ENTIRE value is compile-time type assertions,
+  // so those assertions are actually checked by CI (objectui#3181).
+  //
+  // `src/utils/__tests__/dataset-result-field-spec-parity.test.ts` states its
+  // claims as TYPES — `Assert< Equal< Local, Spec > >` is a compile error or it
+  // is nothing. This package's own `tsconfig.json` is the BUILD config and
+  // excludes its test files (correctly — a test file must not emit into dist),
+  // and CI's only type gate drives that config, so without this project the
+  // pins would be the "declared != enforced" landmine objectstack#4115 exists
+  // to remove, sitting inside the guard for it.
+  //
+  // Chained from this package's `type-check` script, which is what the CI
+  // `Type Check` job runs; scripts/check-type-check-coverage.mjs enforces the
+  // chaining. Explicit include list, not a glob: this package is still in that
+  // script's TEST_DEBT, so a glob would drag in the rest of the test tree.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // A checking project, never an emitting one.
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "lib": ["ES2020", "DOM"],
+    "types": ["node"],
+    // Drop the root tsconfig's source-tree `paths` so `@objectstack/spec` and
+    // the `@object-ui/*` workspace deps resolve through the real dependency
+    // graph rather than through sibling `src/`.
+    "paths": {}
+  },
+  "include": ["src/utils/__tests__/dataset-result-field-spec-parity.test.ts"]
+}

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -110,11 +110,12 @@ export const CHECKED_BY_OWN_BUILD = {
 //     extends (see scripts/check-spec-symbol-derivation.mjs), don't widen the
 //     type to silence it.
 export const TEST_DEBT = {
+  // `@object-ui/core` and `@object-ui/app-shell` are partially covered already:
+  // a `tsconfig.typetests.json` compiles the test files whose whole value is
+  // compile-time type assertions (objectui#3181), listed one by one so the rest
+  // of the debt tree stays out. Both entries stay because that REST is still
+  // unchecked — each number below is that remainder, not the whole package.
   "@object-ui/core": { errors: 72, issue: 4118, note: "TS2741x32, TS2322x17 — mostly the input-vs-output fixture confusion" },
-  // Partially covered already: `tsconfig.typetests.json` compiles the test files
-  // whose whole value is compile-time type assertions (objectui#3181). The entry
-  // stays because the REST of the test tree is still unchecked — the number below
-  // is that remainder, not the whole package.
   "@object-ui/app-shell": { errors: 53, issue: 4118, note: "TS2339x24 — implementation wider than the type" },
   "@object-ui/components": { errors: 31, issue: 4118, note: "TS7006x12, TS7031x12 — untyped test callback params" },
   "@object-ui/react": { errors: 27, issue: 4118, note: "TS2769x9 — overload mismatch on render helpers" },


### PR DESCRIPTION
Fixes #3815

## Premise check (first, per the card)

Both halves re-verified before implementing, on current `origin/main` (`cfeb378b5`) and the **resolved installed** `@objectstack/spec@17.0.0-rc.5` (read out of `node_modules/.pnpm`, not framework main):

- `packages/core/src/utils/dataset-format.ts` has not moved since `2a54e860c`; the hand-written `DatasetResultField` interface is at line 28 with `type?: string`.
- `AnalyticsResult` in `dist/contracts/index.d.ts` declares `fields` as an inline array element with the same six keys and `type: string` **required**. There is no named exported element type for it, so `AnalyticsResult['fields'][number]` is the only derivation available.

Premise holds: same key set, one relaxation (`type`), and no drift today.

## Phase 1 — what the construction-site read found

The card left two pre-decisions open. Both resolved by reading, and both resolved the same way:

**1. `type` can be required.** Nothing in this repo constructs a result column. Every value of this type originates in `ObjectStackAdapter.queryDataset` (`packages/data-objectstack/src/index.ts:3322`), whose `fields` was **already** declared as `Array< AnalyticsResult['fields'][number] >` by #3752 — so the producer has been handing out required-`type` columns all along, and the consumer type was the looser of the pair. The three named consumers only ever receive: `DatasetWidget` (`fields?: DatasetResultField[]` state), `DatasetReportRenderer` (same), `DatasetPreview` (same). No adapter or mapper constructs one either — `queryDataset` has no other implementation in `packages/`, `apps/` or `examples/`. The only fixture typed as `DatasetResultField[]` (`dataset-format.test.ts:86`) already supplies `type` on both entries.

**2. Nothing reads `.type`.** A sweep of the dataset surfaces for a read off a result column found zero. Every `.type` hit in those files belongs to a different shape (`widget.type`, `chart.type`, `report.type`, dashboard filter defs, `ReportViewer`'s spec-report columns). So the relaxation had bought no caller anything, while advertising a `string | undefined` the wire never produces.

That is the PREFERRED path in the dispatch, so no fallback tripwire was needed: full derivation.

## What changed

```ts
export type DatasetResultField = AnalyticsResult['fields'][number];
```

Public name preserved; the `PercentScale` re-export at line 51 is untouched, so existing `@object-ui/core` import paths keep working. The doc comment no longer re-lists the keys — re-listing them is the failure mode #3752 named.

**`ChartResultField` claim: verified, and it survives the tightening.** `ChartResultField` (`chart-series.ts`, renderer-internal, nothing in the spec owns it) needs only `name`/`label?`/`format?`. Every `DatasetResultField` is still one, which is load-bearing: `DatasetWidget:1050` hands its `DatasetResultField[]` state straight to `buildChartSeries`. The claim is now pinned rather than asserted in prose. One genuinely new fact, also pinned: the reverse direction **stops** holding — with `type` required, a bare `{ name, label?, format? }` no longer satisfies `DatasetResultField`. No caller flows that way, but that asymmetry is the entire content of the word "superset", so it is recorded instead of assumed.

## Where the pin lives, and why it needed a tsconfig

`@object-ui/core` is in `scripts/check-type-check-coverage.mjs`'s `TEST_DEBT` (72 errors, #4118) and its build tsconfig excludes test files — so **no `tsc` invocation reads core's test tree**. A compile-time `Assert< Equal< Local, Spec > >` dropped in there would have been exactly the "declared != enforced" landmine objectui#3009 found (assertions under a header calling them "the real enforcement", with reverting the derived alias producing zero errors).

So this PR follows the repo's sanctioned narrow-rescue pattern (objectui#3181, as used by `auth` / `components` / `plugin-detail`): a `packages/core/tsconfig.typetests.json` with an **explicit** include list (not a glob — the rest of the debt tree must stay out), chained from the package's `type-check` script, which is what CI's Type Check job runs. `check-type-check-coverage.mjs` enforces that chaining and is green; its TEST_DEBT comment is updated so the "partially covered already" note names core as well as app-shell.

## Reverse verification (predicted direction: RED)

Took the fix out with `git checkout -- packages/core/src/utils/dataset-format.ts` (restoring the exact pre-fix interface — no `git stash`), re-ran the typetests project, restored with a saved patch. Five assertions went red, at the predicted lines:

```
src/utils/__tests__/dataset-result-field-spec-parity.test.ts(63,35): error TS2344: Type 'false' does not satisfy the constraint 'true'.   # THE pin
src/utils/__tests__/dataset-result-field-spec-parity.test.ts(68,35): error TS2344: ...   # type is required
src/utils/__tests__/dataset-result-field-spec-parity.test.ts(70,7):  error TS2344: ...   # type is not optional
src/utils/__tests__/dataset-result-field-spec-parity.test.ts(88,7):  error TS2344: ...   # negative pin vs the hand-written shape
src/utils/__tests__/dataset-result-field-spec-parity.test.ts(124,7): error TS2344: ...   # ChartResultField asymmetry
```

Restored, both projects green again.

**One honest deviation from the dispatch template.** It asked to "demonstrate a consumer reading `field.type` no longer needs undefined-handling (and clean up now-dead undefined guards)". There are none to clean up — no consumer reads `.type` at all, which is *why* the requiredness restoration is free rather than a coincidence. Reporting that instead of manufacturing a guard to delete.

## Verification

- `pnpm --filter '@object-ui/core^...' build` then `pnpm --filter '@object-ui/core' type-check` (`tsc --noEmit && tsc -p tsconfig.typetests.json`) — green.
- Downstream **consumer** sweep, prefix direction (`--filter '...@object-ui/core'` = the packages that depend on core, not its dependencies): `turbo run build` 42/42 tasks, `turbo run type-check` **68/68 tasks green**. No construction site anywhere needed to change — which is the measurement behind decision 1 above.
- `vitest run packages/core/ packages/plugin-dashboard/ packages/plugin-report/ packages/data-objectstack/` — 139 files, 2357 tests passed.
- `vitest run packages/app-shell/src/views/metadata-admin/previews/ packages/plugin-charts/` — 55 files, 570 tests passed.
- Gates: `check-changeset-presence` OK, `check-changeset-fixed` + `check-changeset-no-major` OK, `check-type-check-coverage` OK (now "10 with a narrow type-assertion project"), `check-control-bytes` OK, `check-spec-symbol-derivation` OK, `eslint` on core 0 errors.

## Changeset

`@object-ui/core: minor`. Patch was arguable — no runtime change, no in-repo caller affected — but the released `.d.ts` **narrows**: a downstream consumer assigning a column literal without `type` now fails to compile, and that is what consumer-visible means. AGENTS.md's bump policy reserves `major` for following `@objectstack/spec` across a major and directs objectui's own breaking changes to `minor` with the breaking semantics spelled out in the body, which the changeset does.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_