### PR TITLE
docs(data-objectstack): document the real headless surface, not a phantom React API

### DIFF
--- a/content/docs/utilities/data-objectstack.mdx
+++ b/content/docs/utilities/data-objectstack.mdx
@@ -28,7 +28,7 @@ The ObjectStack adapter bridges ObjectUI's schema-driven UI with ObjectStack's d
 ## Features
 
 - **ObjectStack Client Integration** - Uses `@objectstack/client` for API communication
-- **Data Provider** - React context provider for data access
+- **Headless** - No React dependency; the adapter is a plain `DataSource` object you inject at the renderer boundary
 - **Query Support** - Full ObjectQL query support
 - **Automatic Field Mapping** - Maps ObjectStack schemas to UI components
 - **Type Safety** - Full TypeScript support
@@ -36,414 +36,367 @@ The ObjectStack adapter bridges ObjectUI's schema-driven UI with ObjectStack's d
 
 ## Quick Start
 
-### 1. Setup Provider
+### 1. Create the adapter
 
-Wrap your app with the `ObjectStackProvider`:
+This package is **headless** — it exports no React components and no hooks. You
+create a plain adapter object:
 
 ```typescript
-import { ObjectStackProvider } from '@object-ui/data-objectstack'
-import { SchemaRenderer } from '@object-ui/react'
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+
+const dataSource = createObjectStackAdapter({
+  baseUrl: 'https://api.example.com',
+  token: 'your-api-token', // optional if auth is handled elsewhere
+});
+```
+
+`createObjectStackAdapter` returns a `DataSource` — the same universal interface
+every ObjectUI renderer consumes. `new ObjectStackAdapter(config)` is the class
+form of the same thing.
+
+### 2. Inject it at the renderer boundary
+
+React wiring lives in `@object-ui/react`, not here. Wrap your tree in
+`SchemaRendererProvider` and hand it the adapter:
+
+```tsx
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+
+const dataSource = createObjectStackAdapter({
+  baseUrl: 'https://api.example.com',
+});
 
 function App() {
   return (
-    <ObjectStackProvider
-      apiUrl="https://api.example.com"
-      apiKey="your-api-key"
-    >
-      <SchemaRenderer schema={schema} />
-    </ObjectStackProvider>
-  )
+    <SchemaRendererProvider dataSource={dataSource}>
+      <SchemaRenderer schema={mySchema} />
+    </SchemaRendererProvider>
+  );
 }
 ```
 
-### 2. Use in Schemas
+`SchemaRenderer` also accepts an explicit `dataSource` prop
+(`<SchemaRenderer schema={mySchema} dataSource={dataSource} />`) when you would
+rather inject per render than through context.
 
-Reference ObjectStack data sources in your schemas:
+### 3. Bind a block to data
+
+A schema node's `dataSource` key is **metadata, not the adapter** — it is the
+spec's per-element binding describing *what to query*, while the adapter above
+describes *how to reach the backend*:
 
 ```json
 {
-  "type": "data-table",
-  "dataSource": {
-    "type": "objectstack",
-    "object": "users",
-    "query": {
-      "filters": [
-        {
-          "field": "status",
-          "operator": "eq",
-          "value": "active"
-        }
-      ],
-      "sort": [
-        {
-          "field": "createdAt",
-          "direction": "desc"
-        }
-      ],
-      "limit": 50
-    }
-  },
-  "columns": [
-    {
-      "key": "name",
-      "title": "Name"
-    },
-    {
-      "key": "email",
-      "title": "Email"
-    },
-    {
-      "key": "status",
-      "title": "Status"
-    }
-  ]
+  "type": "list-view",
+  "dataSource": { "object": "user", "view": "active", "limit": 50 }
 }
 ```
 
+The binding accepts `object`, `view`, `filter`, `sort` and `limit`. `view` names
+a saved view whose columns, filter, sort and page size are applied to the render;
+`filter` is *additional* criteria that AND-combines with the view's rather than
+replacing it. See [Per-element data binding](/docs/guide/data-source) for the
+full table of which blocks honour which keys.
+
 ## API Reference
 
-### `ObjectStackProvider`
+### `createObjectStackAdapter`
 
-React context provider for ObjectStack integration.
+Factory returning a `DataSource` backed by an ObjectStack backend.
 
-**Props:**
+**Config:**
 
 ```typescript
-interface ObjectStackProviderProps {
-  /** API endpoint URL */
-  apiUrl: string
-  
-  /** API authentication key */
-  apiKey: string
-  
-  /** Optional organization ID */
-  organizationId?: string
-  
-  /** Optional custom configuration */
-  config?: ObjectStackConfig
-  
-  /** Children components */
-  children: React.ReactNode
-}
+function createObjectStackAdapter<T = unknown>(config: {
+  /** ObjectStack server base URL */
+  baseUrl: string;
+
+  /** Optional bearer token */
+  token?: string;
+
+  /** Optional custom fetch (proxies, auth headers, test doubles) */
+  fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+  /** Metadata cache tuning */
+  cache?: {
+    maxSize?: number; // default 100 schemas
+    ttl?: number; // default 5 * 60 * 1000 ms
+  };
+
+  /** Reconnect behaviour */
+  autoReconnect?: boolean; // default true
+  maxReconnectAttempts?: number; // default 3
+  reconnectDelay?: number; // default 1000 ms
+}): DataSource<T>;
 ```
 
 **Example:**
 
 ```typescript
-<ObjectStackProvider
-  apiUrl="https://api.objectstack.dev"
-  apiKey={process.env.REACT_APP_OBJECTSTACK_KEY}
-  organizationId="org_123"
->
-  <App />
-</ObjectStackProvider>
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+
+const dataSource = createObjectStackAdapter({
+  baseUrl: 'https://api.objectstack.dev',
+  token: 'your-api-token',
+  cache: { maxSize: 100, ttl: 5 * 60 * 1000 },
+  autoReconnect: true,
+  maxReconnectAttempts: 5,
+});
 ```
 
-### `useObjectStack`
-
-Hook to access the ObjectStack client:
+Pass a record type to get typed results — the default is `unknown`:
 
 ```typescript
-import { useObjectStack } from '@object-ui/data-objectstack'
+type User = { id: string; name: string; email: string };
 
-function MyComponent() {
-  const client = useObjectStack()
-  
-  const fetchUsers = async () => {
-    const users = await client.query('users', {
-      filters: [{ field: 'status', operator: 'eq', value: 'active' }]
-    })
-    return users
-  }
-  
-  // ...
-}
+const dataSource = createObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
 ```
 
-### Data Source Schema
+### `ObjectStackAdapter`
 
-Configure ObjectStack data sources in your schemas:
+The class behind the factory. `new ObjectStackAdapter(config)` takes the same
+config, but its declared type is the **concrete adapter** rather than the
+`DataSource` interface the factory returns — which matters, because part of the
+adapter's surface is not on that interface:
 
 ```typescript
-interface ObjectStackDataSource {
-  /** Data source type */
-  type: 'objectstack'
-  
-  /** Object/table name */
+import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+const adapter = new ObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
+```
+
+**On the `DataSource` interface** (available from either form):
+
+- `find(resource, params?)` - Query multiple records
+- `findOne(resource, id, params?)` - Get a single record by ID
+- `create(resource, data)` - Create a record
+- `update(resource, id, data, opts?)` - Update a record
+- `delete(resource, id, opts?)` - Delete a record
+- `getObjectSchema(objectName)` - Fetch schema metadata (cached)
+- `bulk?(resource, operation, data)` - Batch create/update/delete on one object
+- `batchTransaction?(operations)` - Cross-object atomic batch (master-detail)
+
+`bulk` and `batchTransaction` are **optional** members of `DataSource`: not every
+adapter implements them, so through a `DataSource`-typed value they must be
+feature-detected (`typeof dataSource.bulk === 'function'`). `ObjectStackAdapter`
+implements both unconditionally, so a value held at the class type calls them
+directly.
+
+**Adapter-only** (hold the class type to reach these):
+
+- `connect()` - Establish the connection (called lazily by every operation)
+- `getCacheStats()` / `invalidateCache(key?)` / `clearCache()` - Cache control
+- `getClient()` - Access the underlying `@objectstack/client` instance
+- `getConnectionState()` / `isConnected()` - Connection introspection
+- `onConnectionStateChange(listener)` - Subscribe to state changes (returns unsubscribe)
+- `onBatchProgress(listener)` - Subscribe to bulk progress (returns unsubscribe)
+- `onMutation(listener)` - Subscribe to create/update/delete events
+
+### Per-element data binding
+
+A schema node's `dataSource` key is the spec's `ElementDataSource` (validated by
+`ElementDataSourceSchema` in `@objectstack/spec`) — plain JSON metadata, **not**
+the adapter object:
+
+```typescript
+interface ElementDataSource {
+  /** Object to query (required) */
   object: string
-  
-  /** Optional query */
-  query?: {
-    /** Filter conditions */
-    filters?: Array<{
-      field: string
-      operator: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'nin' | 'like'
-      value: any
-    }>
-    
-    /** Sort order */
-    sort?: Array<{
-      field: string
-      direction: 'asc' | 'desc'
-    }>
-    
-    /** Pagination */
-    limit?: number
-    offset?: number
-    
-    /** Field selection */
-    select?: string[]
-  }
+
+  /** Saved view name — supplies columns, filter, sort and page size */
+  view?: string
+
+  /** Additional filter criteria; AND-combines with the view's filter */
+  filter?: FilterCondition
+
+  /** Sort order — overrides the view's */
+  sort?: Array<{ field: string; order: 'asc' | 'desc' }>
+
+  /** Row cap — overrides the view's page size */
+  limit?: number
 }
 ```
+
+The spec schema is **strict**: a key outside this list is rejected rather than
+silently ignored. `SchemaRenderer` also strips this key from the props it
+spreads, so the metadata can never shadow the injected adapter. Full per-block
+support table: [Per-element data binding](/docs/guide/data-source).
 
 ## Usage Examples
 
-### Basic Data Table
+Every example below binds a block with the per-element `dataSource` metadata. The
+adapter itself is injected once, at the renderer boundary, as shown in Quick Start.
+
+### Grid over an object
 
 ```json
 {
-  "type": "data-table",
-  "dataSource": {
-    "type": "objectstack",
-    "object": "products",
-    "query": {
-      "limit": 20,
-      "sort": [{ "field": "name", "direction": "asc" }]
-    }
-  },
-  "columns": [
-    { "key": "name", "title": "Product Name" },
-    { "key": "price", "title": "Price" },
-    { "key": "stock", "title": "Stock" }
-  ]
+  "type": "object-grid",
+  "dataSource": { "object": "product", "limit": 20 }
 }
 ```
 
-### Filtered Data
+### Narrowing a saved view
+
+`filter` AND-combines with the view's own filter, so a binding can only narrow
+what the view already restricts:
 
 ```json
 {
-  "type": "grid",
+  "type": "object-grid",
   "dataSource": {
-    "type": "objectstack",
-    "object": "orders",
-    "query": {
-      "filters": [
-        { "field": "status", "operator": "eq", "value": "pending" },
-        { "field": "total", "operator": "gt", "value": 100 }
-      ],
-      "sort": [{ "field": "createdAt", "direction": "desc" }],
-      "limit": 50
-    }
+    "object": "order",
+    "view": "open_orders",
+    "filter": { "total": { "$gt": 100 } },
+    "limit": 50
   }
 }
 ```
 
-### Form with ObjectStack Backend
+### Form on one record
+
+Form blocks honour `object` (a form edits a record, so there is no collection
+query to filter or page):
 
 ```json
 {
-  "type": "form",
-  "dataSource": {
-    "type": "objectstack",
-    "object": "users",
-    "action": "create"
-  },
-  "fields": [
-    {
-      "name": "name",
-      "type": "text",
-      "label": "Full Name",
-      "required": true
-    },
-    {
-      "name": "email",
-      "type": "email",
-      "label": "Email Address",
-      "required": true
-    },
-    {
-      "name": "role",
-      "type": "select",
-      "label": "Role",
-      "options": [
-        { "value": "admin", "label": "Administrator" },
-        { "value": "user", "label": "User" }
-      ]
-    }
-  ],
-  "onSubmit": {
-    "type": "objectstack.create",
-    "object": "users",
-    "redirect": "/users"
-  }
+  "type": "object-form",
+  "dataSource": { "object": "user" }
 }
 ```
 
-### Real-time Updates
+### Kanban
+
+`object-kanban` honours `object` and `filter`; it has no ordering or row cap of
+its own:
 
 ```json
 {
-  "type": "kanban",
-  "dataSource": {
-    "type": "objectstack",
-    "object": "tasks",
-    "realtime": true,
-    "query": {
-      "filters": [
-        { "field": "project", "operator": "eq", "value": "${projectId}" }
-      ]
-    }
-  },
-  "columns": [
-    {
-      "id": "todo",
-      "title": "To Do",
-      "statusField": "status",
-      "statusValue": "todo"
-    },
-    {
-      "id": "in-progress",
-      "title": "In Progress",
-      "statusField": "status",
-      "statusValue": "in-progress"
-    },
-    {
-      "id": "done",
-      "title": "Done",
-      "statusField": "status",
-      "statusValue": "done"
-    }
-  ]
+  "type": "object-kanban",
+  "dataSource": { "object": "task", "filter": { "project": "acme" } }
 }
 ```
 
 ## Configuration
 
-### Environment Variables
-
-```bash
-# .env
-REACT_APP_OBJECTSTACK_API_URL=https://api.objectstack.dev
-REACT_APP_OBJECTSTACK_API_KEY=your_api_key_here
-REACT_APP_OBJECTSTACK_ORG_ID=org_123
-```
-
-### Custom Configuration
+The adapter reads **no environment variables of its own** — configuration is
+passed to `createObjectStackAdapter` in code. Sourcing those values from the
+environment is your bundler's business (`process.env.*` under Node or webpack,
+`import.meta.env.*` under Vite):
 
 ```typescript
-import { ObjectStackProvider } from '@object-ui/data-objectstack'
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
-const config = {
-  timeout: 30000,
-  retries: 3,
-  caching: true,
-  debug: process.env.NODE_ENV === 'development',
-}
+const dataSource = createObjectStackAdapter({
+  baseUrl: process.env.OBJECTSTACK_API_URL!,
+  token: process.env.OBJECTSTACK_API_TOKEN,
+  cache: { maxSize: 200, ttl: 10 * 60 * 1000 },
+  autoReconnect: true,
+  maxReconnectAttempts: 5,
+  reconnectDelay: 2000,
+});
+```
 
-<ObjectStackProvider
-  apiUrl={process.env.REACT_APP_OBJECTSTACK_API_URL}
-  apiKey={process.env.REACT_APP_OBJECTSTACK_API_KEY}
-  config={config}
->
-  <App />
-</ObjectStackProvider>
+### Custom fetch
+
+Pass your own `fetch` to route requests through a proxy or attach extra headers:
+
+```typescript
+const dataSource = createObjectStackAdapter({
+  baseUrl: 'https://api.objectstack.dev',
+  fetch: (input, init) =>
+    fetch(input, { ...init, headers: { ...init?.headers, 'X-Tenant': 'acme' } }),
+});
 ```
 
 ## Advanced Usage
 
 ### Custom Queries
 
-Use the client directly for complex queries:
+Call the adapter directly for queries a block does not cover. Query parameters
+are OData-style (`$filter`, `$orderby`, `$top`, `$skip`, `$select`, `$expand`):
 
 ```typescript
-import { useObjectStack } from '@object-ui/data-objectstack'
+const [users, orders] = await Promise.all([
+  dataSource.find('user', {
+    $filter: { createdAt: { $gte: startDate } },
+    $orderby: 'createdAt desc',
+    $top: 20,
+  }),
+  dataSource.find('order', {
+    $filter: { status: 'completed' },
+    $select: ['id', 'total', 'createdAt'],
+  }),
+]);
 
-function Dashboard() {
-  const client = useObjectStack()
-  
-  const fetchDashboardData = async () => {
-    // Multiple queries in parallel
-    const [users, orders, revenue] = await Promise.all([
-      client.query('users', { 
-        filters: [{ field: 'createdAt', operator: 'gte', value: startDate }]
-      }),
-      client.query('orders', {
-        filters: [{ field: 'status', operator: 'eq', value: 'completed' }]
-      }),
-      client.aggregate('orders', {
-        field: 'total',
-        operation: 'sum',
-        groupBy: 'month'
-      })
-    ])
-    
-    return { users, orders, revenue }
-  }
-  
-  // ...
-}
+// find() resolves to { data, total? }
+console.log(users.data.length, users.total);
 ```
 
 ### Mutations
 
-Create, update, and delete records:
+```typescript
+type User = { id: string; name: string; email: string };
+
+const dataSource = createObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
+
+const user = await dataSource.create('user', { name: 'Ada', email: 'ada@example.com' });
+
+const updated = await dataSource.update('user', user.id, { name: 'Ada Lovelace' });
+
+await dataSource.delete('user', user.id);
+```
+
+Batch writes on one object go through `bulk`, and cross-object writes that must
+commit or roll back together go through `batchTransaction`. Both are optional on
+the `DataSource` interface, so hold the adapter at its class type (or
+feature-detect) before calling them:
 
 ```typescript
-import { useObjectStack } from '@object-ui/data-objectstack'
+import { ObjectStackAdapter } from '@object-ui/data-objectstack';
 
-function UserForm() {
-  const client = useObjectStack()
-  
-  const createUser = async (data) => {
-    const user = await client.create('users', data)
-    return user
-  }
-  
-  const updateUser = async (id, data) => {
-    const user = await client.update('users', id, data)
-    return user
-  }
-  
-  const deleteUser = async (id) => {
-    await client.delete('users', id)
-  }
-  
-  // ...
-}
+const adapter = new ObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
+
+await adapter.bulk('user', 'create', [
+  { name: 'Alice', email: 'alice@example.com' },
+  { name: 'Bob', email: 'bob@example.com' },
+]);
+
+// `{ $ref: 0 }` resolves to the id minted by operation 0
+await adapter.batchTransaction([
+  { object: 'invoice', action: 'create', data: { no: 'INV-1' } },
+  { object: 'invoice_line', action: 'create', data: { invoice: { $ref: 0 }, amount: 10 } },
+]);
 ```
 
 ### Error Handling
 
-```typescript
-import { useObjectStack } from '@object-ui/data-objectstack'
+The adapter throws typed errors with stable codes:
 
-function DataComponent() {
-  const client = useObjectStack()
-  const [error, setError] = useState(null)
-  
-  const fetchData = async () => {
-    try {
-      const data = await client.query('users')
-      return data
-    } catch (err) {
-      if (err.code === 'UNAUTHORIZED') {
-        // Handle auth error
-        setError('Please log in')
-      } else if (err.code === 'NOT_FOUND') {
-        // Handle not found
-        setError('Data not found')
-      } else {
-        // Handle other errors
-        setError('An error occurred')
-      }
-    }
+```typescript
+import {
+  MetadataNotFoundError,
+  AuthenticationError,
+  ConnectionError,
+} from '@object-ui/data-objectstack';
+
+try {
+  const schema = await dataSource.getObjectSchema('user');
+} catch (error) {
+  if (error instanceof MetadataNotFoundError) {
+    // code 'METADATA_NOT_FOUND', statusCode 404
+  } else if (error instanceof AuthenticationError) {
+    // code 'AUTHENTICATION_ERROR', statusCode 401
+  } else if (error instanceof ConnectionError) {
+    // code 'CONNECTION_ERROR', statusCode 503
   }
-  
-  // ...
 }
 ```
+
+Exported error types: `ObjectStackError` (base), `MetadataNotFoundError`,
+`BulkOperationError`, `ConnectionError`, `AuthenticationError`,
+`DataApiValidationError`, plus the `isObjectStackError` / `isErrorType` guards.
 
 ## Package Information
 
@@ -482,11 +435,23 @@ Many plugins support ObjectStack data sources:
 
 ### Authentication Errors
 
-Check your API key and URL:
+An `AuthenticationError` (code `AUTHENTICATION_ERROR`, status 401) means the
+`token` passed to `createObjectStackAdapter` was missing, expired or rejected.
+Check the connection state and the values you passed in:
+
+Connection introspection lives on the adapter class, not on the `DataSource`
+interface, so hold it at the class type:
 
 ```typescript
-console.log('API URL:', process.env.REACT_APP_OBJECTSTACK_API_URL)
-console.log('API Key:', process.env.REACT_APP_OBJECTSTACK_API_KEY?.substring(0, 10) + '...')
+import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+const adapter = new ObjectStackAdapter({ baseUrl: 'https://api.example.com' });
+
+console.log(adapter.getConnectionState()); // 'connected' | 'error' | ...
+
+adapter.onConnectionStateChange((event) => {
+  if (event.error) console.error('Connection error:', event.error);
+});
 ```
 
 ### CORS Issues
@@ -496,10 +461,12 @@ Configure CORS on your ObjectStack backend to allow your domain.
 ### Data Not Loading
 
 Check browser console and network tab for errors. Verify:
-- API endpoint is correct
-- API key is valid
-- Object name exists in your ObjectStack instance
-- Query syntax is correct
+- `baseUrl` points at the right ObjectStack server
+- The token is valid and not expired
+- The object name exists in your ObjectStack instance
+- The block's `dataSource` binding names an object (and a `view`, if used) that resolves
+- An adapter is actually injected — a block with no `SchemaRendererProvider`
+  above it and no `dataSource` prop has nothing to query with
 
 ## Need Help?
 


### PR DESCRIPTION
Fixes #4124

Docs-only. Rewrites `content/docs/utilities/data-objectstack.mdx` around the surface the package actually exports.

## Ordering

PR #4127 (#3781) edits the same page and **has merged** — `1b6188d41`, the tip of `origin/main`. This branches off main; no stacking was needed. Its dependency prose (install note at `:16`, the Dependencies list) is untouched — verified by grepping the diff for those lines: zero hits.

## Premise re-verified on the branch tip

Both symbols are genuinely absent, so the card holds:

- `grep -rn "ObjectStackProvider|useObjectStack" packages/data-objectstack/src/` -> **exit 1, zero matches**.
- The export list in `packages/data-objectstack/src/index.ts` is `ObjectStackAdapter`, `createObjectStackAdapter`, the error classes, `MetadataClient`, `CloudOperations`, `SecurityManager`, `IntegrationManager`, `createObjectStackUserStateAdapter`, the studio/contract helpers and types. No provider, no hook.

Reverse verification — the API the page used to teach, compiled against the built package:

```
error TS2724: '"@object-ui/data-objectstack"' has no exported member named
  'ObjectStackProvider'. Did you mean 'ObjectStackError'?
error TS2305: Module '"@object-ui/data-objectstack"' has no exported member 'useObjectStack'.
```

That is the error a reader following the old Quick Start hit.

## Two fabrication families, not one

**1. The phantom React API** (the card). Removed page-wide, not just at the three cited lines — it reached well beyond them: the Features bullet calling the package a "React context provider", Quick Start, both API Reference entries, the whole Configuration section, all three Advanced Usage examples, and Troubleshooting. Replaced with `createObjectStackAdapter` / `ObjectStackAdapter` injected via `@object-ui/react`'s `SchemaRendererProvider`, which is what the README, `content/docs/guide/data-source.md` and seven plugin READMEs already teach.

The `REACT_APP_OBJECTSTACK_*` environment variables went with it: the package reads **no** environment variable of its own (`grep` for `process.env` in its `src/` finds only a JSDoc example).

**2. The JSON `dataSource` shape** — found by the page-wide sweep the card asked for. Every JSON block used a `type: "objectstack"` discriminator with a `query: { filters, sort, limit }` body. That shape has **zero occurrences repo-wide** (`grep` over all `.ts`/`.tsx`/`.json`). The real per-element binding is the spec's `ElementDataSource`, validated by `ElementDataSourceSchema` in `@objectstack/spec`:

| | documented before | actual |
|---|---|---|
| discriminator | `"type": "objectstack"` | none — the binding has no type tag |
| object | `object` | `object` (**required**) |
| filter | `query.filters: [{field, operator, value}]` | `filter: FilterCondition` (object form, e.g. `{ "total": { "$gt": 100 } }`) |
| sort | `query.sort: [{field, direction}]` | `sort: [{ field, order }]` |
| limit | `query.limit` | `limit` |
| saved view | — | `view` |

The spec schema is `z.strict`, so the old `type` key would have been **rejected**, not ignored. Examples now use the block names from the guide's own support table (`object-grid`, `object-form`, `object-kanban`); `kanban` as written had no registration at all.

## Corrected symbols

| symbol | disposition |
|---|---|
| `ObjectStackProvider` | deleted — not exported |
| `useObjectStack` | deleted — not exported |
| `ObjectStackDataSource` (interface) | replaced by `ElementDataSource` |
| `apiUrl` / `apiKey` / `organizationId` props | replaced by `baseUrl` / `token` |
| `REACT_APP_OBJECTSTACK_*` | deleted — package reads no env vars |
| `client.query` / `client.aggregate` | replaced by `find` / `findOne` / `create` / `update` / `delete` |
| `createObjectStackAdapter` | added, real config incl. `fetch`, `cache`, reconnect options |
| `ObjectStackAdapter` | added, class form |
| `SchemaRendererProvider` | added, the real injection point |

## Three inaccuracies the type-check caught in my own draft

The mechanical check earned its keep — it went red on my first rewrite and each red was a real fact:

1. `create()` returns `unknown` unless the adapter is parameterised, so `user.id` did not compile. The docs now show the generic form.
2. `bulk` and `batchTransaction` are **optional** members of `DataSource` (`bulk?(...)`, `batchTransaction?(...)`), so through a `DataSource`-typed value they need feature-detection. The page now says so and shows the class type for those calls.
3. `getConnectionState` / `onConnectionStateChange` are **not on `DataSource` at all** — they are `ObjectStackAdapter` class members. The method list is now split into "on the `DataSource` interface" and "adapter-only".

Without compiling the snippets all three would have shipped as new, confidently-worded errors.

## Verification

No mdx snippet-check gate exists in this repo (`scripts/extract-mdx-demos.mjs` is an unwired one-off migration tool, not a gate), so per the card I extracted the snippets and ran `tsc` against the built workspace packages.

| gate | result |
|---|---|
| snippet `tsc` (extracted, strict, against built `dist/*.d.ts`) | **exit 0** |
| snippet `tsc` on the OLD phantom imports (reverse) | **exit 2** — TS2724 / TS2305 above |
| `pnpm turbo run build --filter=@object-ui/site --force` | `29 successful, 29 total`, `0 cached`, 2m13s |
| `node scripts/check-doc-links.mjs` | `Links are valid across 7 scan roots.` |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 3829 tracked text file(s))` |
| `node scripts/check-changeset-presence.mjs` | `No source of a released package changed in this range, so no changeset is owed.` |

The build closure was built first (`--filter '...^...'`) so `tsc` read real declarations rather than stale ones.

**A note on the docs build:** an unforced re-run reported `29 cached / FULL TURBO` in 80ms *after* I had edited the mdx — turbo's input hash for `@object-ui/site` does not appear to track `content/docs/**`. The green above is therefore from a `--force` run. Worth knowing for anyone reading a cached Build Docs as validation of a content change.

Rendered-output check on `apps/site/.next/server/app/docs/utilities/data-objectstack.html`: `ObjectStackProvider`, `useObjectStack`, `REACT_APP`, `apiKey`, `organizationId` and `"type": "objectstack"` all render **0** times; `createObjectStackAdapter` 17, `SchemaRendererProvider` 6, `ElementDataSource` 4.

Changeset: none owed, per the presence script's own arbitration (docs-only). Labelled `skip-changeset`.

## Out of scope, deliberately

- `**Version:** 0.3.1` at `:~380` is stale (the package is at `17.4.0`) but is already filed as #4125 — left alone so this PR does not collide with that card.
- `packages/data-objectstack/README.md:16` still says `npm install @object-ui/data-objectstack @objectstack/client`, the same claim #4127 corrected on this docs page. Filed separately rather than fixed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_