### PR TITLE
fix(plugin-dashboard): route DatasetWidget's option-color probe through the host apiFetch

### DIFF
--- a/.changeset/datasetwidget-option-color-probe-apifetch-4121.md
+++ b/.changeset/datasetwidget-option-color-probe-apifetch-4121.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/plugin-dashboard": patch
+---
+
+`DatasetWidget`'s option-color / dimension-label probe now rides the host's
+authenticated fetch (`SchemaRendererContext.apiFetch`) instead of the bare global
+`fetch`.
+
+The one metadata read the effect makes — `GET /api/v1/meta/object/{object}` — went
+out on the global `fetch`, so in a hosted console it skipped whatever the host
+supplies on that channel (Authorization / tenant headers, base-URL rewrite,
+draft-preview params). A bearer-token session carries its credential in a header
+rather than a cookie, so `credentials: 'include'` alone left this read
+unauthenticated. The effect is best-effort and swallows every failure, which made
+the symptom silent: a dataset chart's semantic per-category colors and its
+dimensions' value → label maps simply never applied, and the widget fell back to
+the positional theme palette and the raw stored values on the axis.
+
+Standalone embeds are unaffected — with no provider (or a provider that supplies no
+`apiFetch`) the probe still uses the global `fetch`, the same documented fallback
+`useRecordEditable` and `provider: 'api'` view sources use.
+
+This is the `plugin-dashboard` twin of the same fix made to `plugin-charts`'
+`ObjectChart`.

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -26,8 +26,8 @@
  * objectui bumps its `@objectstack/spec` dependency (cross-repo spec skew).
  */
 
-import { useEffect, useMemo, useState } from 'react';
-import { SchemaRenderer } from '@object-ui/react';
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { SchemaRenderer, SchemaRendererContext } from '@object-ui/react';
 import {
   buildChartSeries,
   buildOptionColorMap,
@@ -494,6 +494,15 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // a user-scoped widget sent `{current_user_id}` to SQL as a literal, matched
   // no row, and rendered 0 with no error anywhere (framework #3574).
   const filterScope = useFilterScope();
+  // Host-authenticated fetch for the object-schema probe further down
+  // (objectui#4121). This widget takes its `dataSource` as a PROP and reads no
+  // other context, so the channel has to be read here — the same context the
+  // rest of the family reads (`ObjectChart`, `ObjectGantt`, `useViewData`,
+  // `useRecordEditable`), consulted DIRECTLY rather than via
+  // `useSchemaContext()`, which throws when no provider is mounted: a widget
+  // rendered outside a host (every existing suite in this package) must keep
+  // degrading to the global fetch instead of crashing the render.
+  const apiFetch = useContext(SchemaRendererContext)?.apiFetch;
   const rawFilter = widget?.filter;
   const runtimeFilter = useMemo(
     () => (rawFilter && typeof rawFilter === 'object' && Object.keys(rawFilter).length > 0
@@ -578,6 +587,14 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // dimension's per-category colors, and a {value → label} map per dimension so
   // the axis/series display labels even when the server returned raw values.
   // Best-effort: any failure leaves both null (positional palette + raw values).
+  //
+  // The read rides the host's AUTHENTICATED fetch (objectui#4121) — the same
+  // channel `provider: 'api'` view sources use — falling back to the global one
+  // only when no host supplies it. A bearer-token session carries its credential
+  // in the `Authorization` header, not a cookie, so `credentials: 'include'`
+  // alone left this read unauthenticated in a hosted console; combined with the
+  // best-effort shape above the symptom was not an error but semantic option
+  // colors and dimension labels silently never applying.
   useEffect(() => {
     if (isMetric || isTable) { setCategoryColors(null); setDimensionLabels(null); setCategoryOrder(null); return; }
     const object = state.object;
@@ -586,7 +603,8 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`/api/v1/meta/object/${encodeURIComponent(object)}`, { headers: { accept: 'application/json' }, credentials: 'include' });
+        const doFetch = apiFetch ?? fetch;
+        const res = await doFetch(`/api/v1/meta/object/${encodeURIComponent(object)}`, { headers: { accept: 'application/json' }, credentials: 'include' });
         const j = await res.json().catch(() => null);
         const objSchema = j?.item ?? j?.data ?? j;
         const firstDimOptions = objSchema?.fields?.[fieldOf(dimensions[0])]?.options;
@@ -604,7 +622,15 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       } catch { if (!cancelled) { setCategoryColors(null); setDimensionLabels(null); setCategoryOrder(null); } }
     })();
     return () => { cancelled = true; };
-  }, [state.object, state.dimensionFields, dimensions, isMetric, isTable]);
+    // `apiFetch` joins the deps (objectui#4121) exactly as it does in
+    // `useRecordEditable`'s. It does not re-open this file's documented refetch
+    // concern — that one is on the query effect above and is about a
+    // render-time `now` inside the RESOLVED filter, i.e. a value this component
+    // recomputes every render. `apiFetch` is not: it comes from the provider's
+    // memoized context value, and this widget's own `setState` cannot re-render
+    // the provider, so the identity is stable across the effect's own updates.
+    // The in-repo host holds it at module scope (`ConsoleShell.tsx:187` → `:245`).
+  }, [state.object, state.dimensionFields, dimensions, isMetric, isTable, apiFetch]);
 
   if (values.length === 0) {
     return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground">{tt('dashboard.pickMeasures', 'Pick measures (values) for this dataset widget.')}</div>;

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.relabel.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.relabel.test.tsx
@@ -13,9 +13,10 @@
  * in jsdom). This exercises the REAL DatasetWidget + SchemaRenderer.
  */
 
-import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
 import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRendererProvider, type ApiFetch } from '@object-ui/react';
 import { DatasetWidget } from '../DatasetWidget';
 
 let capturedChartSchema: any = null;
@@ -113,5 +114,132 @@ describe('DatasetWidget select-dimension relabeling (cloud#667)', () => {
       expect(capturedChartSchema).toBeTruthy();
       expect(capturedChartSchema.data?.[0]).toMatchObject({ status: 'active', count: 6 });
     });
+  });
+});
+
+/**
+ * objectui#4121 — WHICH channel the probe above rides.
+ *
+ * The same `GET /api/v1/meta/object/{object}` read the relabeling tests already
+ * double went out on the bare global `fetch`, so a hosted console's
+ * authenticated channel (Authorization / tenant headers, base-URL rewrite,
+ * draft-preview params — `ConsoleShell.tsx:245` supplies it) was bypassed. The
+ * effect swallows every failure, so the symptom was silent: the semantic option
+ * colors AND the value→label maps the tests above pin simply never applied, and
+ * the chart fell back to the positional theme palette and raw stored values.
+ * The plugin-dashboard twin of objectui#4114 / PR #4122.
+ *
+ * Read off TWO recorders — the global `fetch` stub this file already installs,
+ * plus a standalone recorder handed in as the provider's `apiFetch`. Both answer
+ * the SAME document, so the data path stays green either way and the only thing
+ * these pins can go red on is the routing itself: the host recorder holding
+ * nothing, or the global recorder holding something.
+ */
+describe('DatasetWidget option-color / dimension-label probe routing (objectui#4121)', () => {
+  const CUSTOMER_DOC = {
+    item: {
+      name: 'tk5f_customer',
+      fields: {
+        status: {
+          type: 'select',
+          options: [
+            { value: 'active', label: '合作中', color: '#16a34a' },
+            { value: 'lost', label: '已流失' },
+            { value: 'potential', label: '潜在' },
+          ],
+        },
+      },
+    },
+  };
+
+  /**
+   * The same recorder shape as the global stub at the top of this file, but as
+   * a standalone function so the host channel and the global one can be
+   * recorded SEPARATELY and the probe's routing read off which one moved.
+   */
+  function makeMetaFetchRecorder() {
+    const calls: string[] = [];
+    const inits: (RequestInit | undefined)[] = [];
+    const fn = vi.fn(async (input: unknown, init?: RequestInit) => {
+      calls.push(String(input));
+      inits.push(init);
+      return { ok: true, json: async () => CUSTOMER_DOC };
+    });
+    // The double answers the two fields the probe reads (`ok` / `json()`), not
+    // a whole Response — cast once here so the call sites stay `any`-free.
+    return { fn: fn as unknown as ApiFetch, calls, inits };
+  }
+
+  const WIDGET = { type: 'bar', dataset: 'tk5f_customer_ds', dimensions: ['status'], values: ['count'] };
+
+  /** The captured schema is `any`; narrow ONCE here so the pins stay `any`-free. */
+  const chartRows = (): Array<Record<string, unknown>> =>
+    (capturedChartSchema?.data ?? []) as Array<Record<string, unknown>>;
+
+  let originalFetch: typeof globalThis.fetch;
+  let globalRecorder: ReturnType<typeof makeMetaFetchRecorder>;
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    globalRecorder = makeMetaFetchRecorder();
+    global.fetch = globalRecorder.fn as unknown as typeof globalThis.fetch;
+  });
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('rides the host apiFetch when a provider supplies one, and never the global fetch', async () => {
+    const host = makeMetaFetchRecorder();
+
+    render(
+      <SchemaRendererProvider dataSource={valueKeyedSource()} apiFetch={host.fn}>
+        <DatasetWidget widget={WIDGET} dataSource={valueKeyedSource()} />
+      </SchemaRendererProvider>,
+    );
+
+    // The object probe went through the host channel...
+    await waitFor(() => expect(host.calls).toEqual(['/api/v1/meta/object/tk5f_customer']));
+    // ...and nothing escaped to the global one. This is the assertion the bug
+    // failed: pre-fix the two recorders held exactly the opposite contents.
+    expect(globalRecorder.calls).toEqual([]);
+    // The request options survive the routing — a host that needs the accept
+    // header still gets it, it is not dropped on the way to `apiFetch`.
+    expect(host.inits[0]).toMatchObject({ headers: { accept: 'application/json' } });
+    // And the routed answer is CONSUMED, not merely requested: both products of
+    // this one document reach the renderer over the host channel — the value→
+    // label relabeling and the first dimension's semantic category color.
+    await waitFor(() => {
+      const byCategory = Object.fromEntries(chartRows().map((r) => [r.status, r.count]));
+      expect(byCategory).toEqual({ 合作中: 6, 已流失: 2, 潜在: 4 });
+    });
+    expect(capturedChartSchema?.categoryColors).toMatchObject({ 合作中: '#16a34a' });
+  });
+
+  it('keeps using the global fetch for a standalone widget with no provider', async () => {
+    // The documented boundary of the convention (`useRecordEditable.ts:32`): no
+    // host, no `apiFetch` — the probe must still work off the global fetch
+    // rather than crash or go quiet. This is the shape every other suite in
+    // this package mounts, including the two relabeling tests above.
+    render(<DatasetWidget widget={WIDGET} dataSource={valueKeyedSource()} />);
+
+    await waitFor(() => expect(globalRecorder.calls).toEqual(['/api/v1/meta/object/tk5f_customer']));
+    await waitFor(() =>
+      expect(chartRows().map((r) => r.status)).toContain('合作中'),
+    );
+  });
+
+  it('keeps using the global fetch when a provider supplies no apiFetch', async () => {
+    // A host CAN be mounted without an authenticated channel. Presence of a
+    // provider is not presence of a channel, so this must stay on the fallback
+    // rather than resolve to `undefined` and skip the read.
+    render(
+      <SchemaRendererProvider dataSource={valueKeyedSource()}>
+        <DatasetWidget widget={WIDGET} dataSource={valueKeyedSource()} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(globalRecorder.calls).toEqual(['/api/v1/meta/object/tk5f_customer']));
+    await waitFor(() =>
+      expect(chartRows().map((r) => r.status)).toContain('合作中'),
+    );
   });
 });


### PR DESCRIPTION
Fixes #4121

Branched off `origin/main` @ `bcd3e0219` — that tip **is** PR #4122's merge commit, so the ObjectChart sibling is already on main and this is not stacked. Different package, no shared code; the two fixes only share a pattern.

## Premise: verified, still valid

The bare read is exactly where the issue said, at the unchanged line number on `bcd3e0219`:

```
589:  const res = await fetch(`/api/v1/meta/object/${encodeURIComponent(object)}`, { headers: { accept: 'application/json' }, credentials: 'include' });
```

Both halves of the claim hold:

- **Silent-failure shape** — the effect's body is wrapped in `try { … } catch { … setCategoryColors(null); setDimensionLabels(null); setCategoryOrder(null); }`. Every failure, including a 401, is swallowed into "no colors, no labels", never an error state. Note it also nulls `categoryOrder`, so a third product of this one document (the declared category order, framework#3588) was silently lost too.
- **One bare fetch, not more** — grepping `fetch` across the whole file, and then across all of `packages/plugin-dashboard/src` (non-test), returns exactly this one call site. The card said to measure rather than trust the cited line; measured, one is the true count.

## The card's one real decision: where the channel comes from

The filing dev flagged that unlike `ObjectChart`, `DatasetWidget` consults **no** context today — it takes `dataSource` as a **prop** (`DatasetWidget({ widget, dataSource })`, and `DashboardRenderer` passes it down). So there was nothing to hang `apiFetch` off.

The component's structure does not prevent the family convention — the fetch happens inside a normal `useEffect` in a normal function component — so the default applies and no second channel was invented:

```ts
const apiFetch = useContext(SchemaRendererContext)?.apiFetch;
…
const doFetch = apiFetch ?? fetch;
```

Two details taken from the references rather than invented:

- **The context is read directly, not via `useSchemaContext()`** — that hook throws with no provider mounted. This matters more here than it did for ObjectChart: **every existing suite in this package** mounts the widget bare, so the throwing hook would have turned a routing fix into a package-wide red.
- **`apiFetch` joins the effect's dependency array**, as it does in `useRecordEditable`'s.

## The effect-deps question, checked against THIS file

This file does carry a documented refetch concern, but it is on the **other** effect and it does not transfer. The query effect is keyed on a hand-built `signature` string precisely because the **resolved** filter carries a render-time `now`; that is a value the component recomputes every render, which is what would loop.

`apiFetch` is not that kind of value: it arrives from `SchemaRendererProvider`'s `useMemo`'d context value (`SchemaRendererContext.tsx:42-43`), and this widget's own `setState` cannot re-render the provider — so the identity is stable across the effect's own updates. The sole in-repo host settles it outright by holding the function at **module scope**: `ConsoleShell.tsx:187` → `:245`. No restructuring was needed.

## Behavior boundary — the fallback half is pinned, not assumed

Standalone embeds keep working on the global `fetch`, and there are two distinct no-channel shapes, both pinned:

1. no provider at all — the shape every existing test in this package uses;
2. a provider that supplies `dataSource` but no `apiFetch`. Presence of a host is not presence of a channel.

## Tests

Three pins added to `DatasetWidget.relabel.test.tsx` — the file the card named, which already answers this exact endpoint from a double — in a new `objectui#4121` block. **Extended, not duplicated**: no new test file, and the existing double is untouched. Routing is read off **two separate recorders**, the global stub plus a standalone recorder handed in as the provider's `apiFetch`:

- host-mounted → the probe is in the host recorder, the global recorder is **empty**, the request init survives the hop (`accept: application/json`), and the routed answer is consumed — both products of the document reach the renderer (the value→label relabeling *and* the first dimension's semantic `categoryColors`);
- no provider → global recorder holds the probe;
- provider without `apiFetch` → global recorder holds the probe.

Both recorders answer the **same** document, so the data path stays green either way and the only thing these pins can go red on is the routing itself.

**No existing test changed in meaning.** The two cloud#667 relabeling tests are untouched — which follows from the behavior boundary above: they mount no provider, so the routing change genuinely moves nothing for them.

## Verification

Repo root, both packages, per AGENTS.md:

```
pnpm exec vitest run packages/plugin-dashboard/ packages/plugin-charts/ --maxWorkers=2

Test Files  54 passed (54)
     Tests  449 passed (449)        # 446 on main + 3 new
$ wc -c stderr                 =>  0
$ grep -c ECONNREFUSED stderr  =>  0
```

stderr stays entirely empty — the #4115/#4106 no-live-request guarantee survives the routing change.

**Reverse verification**, direction predicted before running: revert *only* the product routing (`git checkout origin/main -- DatasetWidget.tsx`, new tests held) and exactly **one** pin goes red — the host-mounted one — while the two fallback pins and both cloud#667 tests stay green, because with no channel supplied pre-fix and post-fix code do the identical thing.

```
× rides the host apiFetch when a provider supplies one, and never the global fetch
AssertionError: expected [] to deeply equal [ '/api/v1/meta/object/tk5f_customer' ]
Tests  1 failed | 4 passed (5)
```

Exactly as predicted, 1 red / 4 green, and the failure names the **host recorder holding nothing** — the escape landing in the global recorder instead. Restored afterwards; `git diff` matches the pre-revert diffstat.

Gates: `pnpm --filter @object-ui/plugin-dashboard type-check` green (after `pnpm --filter '@object-ui/plugin-dashboard^...' build`, the fresh-worktree dependency closure). `eslint` on both changed files **0 errors**; warning counts measured against `origin/main` file-by-file — `DatasetWidget.tsx` is 11 before and 11 after, the test file 6 before and 6 after, so the new pins add **zero**. `check:control-bytes` green, plus a control-byte self-scan over the three changed files.

## Changeset

`@object-ui/plugin-dashboard` **patch** — a real behavior fix on a released package.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_