### PR TITLE
fix(i18n): fail when a call site's arguments are not the holes its en value has, and delete the three that were inert (#3845)

### DIFF
--- a/.changeset/interpolation-parity-gate-3845.md
+++ b/.changeset/interpolation-parity-gate-3845.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Fail when a `t()` call site's arguments are not the holes its `en` value has, and delete the three that were inert
+
+`scripts/check-i18n-call-site-keys.mjs` gains a fourth failure class, `interpolation-parity`: for a call site whose key resolves to a readable `en` leaf, the set of interpolation option names it passes must EQUAL the set of `{{hole}}` names in that value. Both directions fail, because they fail differently — an argument with no hole is dropped by i18next in silence, and a hole with no argument leaves its own braces in what the user reads.
+
+Nothing else could see this. `all-locales-key-parity` does compare placeholder shape, but pack against pack, so ten packs agreeing on `Update` while the call site passes `version` is full parity. `check-i18n-en-drift` fires only when an `en` string changes. And objectui#3810's `default-value-drift` is satisfied the moment the call site's inline default matches the pack — which is exactly how `home.welcome` got here: its value was rewritten from `Welcome to {{product}}` to `Build your business system with AI`, the call site's default was later aligned to the new sentence, and the now-inert `product` argument stayed sitting beside it.
+
+The repo-wide run found **3 inert arguments and 0 unfilled holes**, so the rule lands hard, with no baseline. All three arguments are deleted rather than answered with a new hole in `en.ts`:
+
+- `marketplace.action.updateTo` — `version`, on a primary button reading a bare `Update` while its sister key in the same file renders `Update → v{{version}}`.
+- `home.welcome` — `product`, so no white-label deployment's name has ever reached the console hero.
+- `objectActions.resetPackageSetSuccess` — `label`, copied from the `deleteSuccess` branch next to it, whose sentence does name the record.
+
+**No rendered output moves, on any path.** With a provider mounted, i18next dropped these arguments already. With none, react-i18next's `notReadyT` returns `optsOrDefaultValue.defaultValue` verbatim — there is no interpolation step on that path at all — and all three inline defaults are hole-free too, so the miss path is unaffected as well. Adding the hole instead would have been a copy change: it moves a string users read today and obliges the other nine packs through objectui#3650. The gate accepts either resolution; choosing between them is not its business, and objectui#3546's slice-five assertion — written to force this decision rather than let it be settled silently — now pins the chosen state.
+
+One key is registered as filling its hole downstream: `auth.forgotPassword.successDescription` travels through `t()` with `{{email}}` intact because `ForgotPasswordForm` substitutes the address itself, once the form knows it. That entry silences the unfilled direction only — passing `email` to `t()` there would let i18next consume the hole and make the form append the address a second time, and the gate still reports it.

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -33,7 +33,6 @@ import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText, Hammer, Layou
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
 import { usePublishAllDrafts } from '../../preview/usePublishAllDrafts';
 import { resolveAiApiBase } from '../../hooks/useAiSurface';
-import { getRuntimeConfig } from '../../runtime-config';
 
 /**
  * Which AI home CTAs to surface, driven by the live agent catalog (the single
@@ -327,7 +326,15 @@ export function HomePage() {
         */}
         {isAdmin ? (
           <Empty>
-            <EmptyTitle>{t('home.welcome', { product: getRuntimeConfig().branding.productName, defaultValue: 'Build your business system with AI' })}</EmptyTitle>
+            {/*
+              No `product` argument: `home.welcome` reads `Build your business
+              system with AI` in en, with no `{{product}}` hole, so i18next
+              dropped the branded name in silence (objectui#3845). The argument
+              is a leftover from an earlier `Welcome to {{product}}` value; if
+              white-label deployments should see their own name in the hero, that
+              is a copy change to the ten packs, not an argument at this call site.
+            */}
+            <EmptyTitle>{t('home.welcome', { defaultValue: 'Build your business system with AI' })}</EmptyTitle>
             <EmptyDescription>
               {buildAvailable
                 ? t('home.welcomeAdminDescription', {

--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -552,7 +552,12 @@ export function MarketplacePackagePage() {
         ? t('marketplace.action.installing')
         : cloudInstalledVersion
           ? (cloudUpdateAvailable
-              ? t('marketplace.action.updateTo', { defaultValue: 'Update', version: latestVersion })
+              // No `version` argument: `marketplace.action.updateTo` reads a bare
+              // `Update` in all ten packs, so i18next had nothing to interpolate
+              // and silently dropped it (objectui#3845). Its sister
+              // `marketplace.install.updateTo` below DOES render the version —
+              // whether this button should too is a copy decision, not a fix.
+              ? t('marketplace.action.updateTo', { defaultValue: 'Update' })
               : t('marketplace.action.installed', { defaultValue: 'Installed' }))
           : t('marketplace.action.installToCloud'),
       onClick: openInstall,

--- a/packages/app-shell/src/hooks/useObjectActions.ts
+++ b/packages/app-shell/src/hooks/useObjectActions.ts
@@ -157,8 +157,11 @@ export function useObjectActions({
         onRefresh?.();
         toast.success(
           packagedSetReset
+            // No `label` argument, unlike the `deleteSuccess` branch below: this
+            // sentence names the permission set by kind rather than by label, so
+            // none of the ten packs has a `{{label}}` hole and i18next dropped
+            // the argument in silence (objectui#3845).
             ? t('objectActions.resetPackageSetSuccess', {
-                label: objectLabel || objectName,
                 defaultValue: 'Permission set reset to its shipped baseline',
               })
             : t('objectActions.deleteSuccess', { label: objectLabel || objectName }),

--- a/packages/i18n/src/__tests__/marketplace-preview-namespace-3546.test.tsx
+++ b/packages/i18n/src/__tests__/marketplace-preview-namespace-3546.test.tsx
@@ -387,24 +387,38 @@ describe('objectui#3546 slice five — the marketplace and preview namespaces', 
     expect(at(builtInLocales.en, 'marketplace.org.installed')).toBe('Installed {{name}}');
   });
 
-  it("marketplace.action.updateTo's `version` option is inert, and en does not pretend otherwise", () => {
-    // `MarketplacePackagePage.tsx:555` passes `version` next to a `defaultValue`
-    // that has no hole for it, so nothing has ever been interpolated there and
-    // the primary button reads a bare "Update". Its sibling
-    // `marketplace.install.updateTo` (the environment dropdown, same file) DOES
-    // render the version — the two were plainly meant to match.
+  it("marketplace.action.updateTo takes no `version` option, because no pack has a hole for one", () => {
+    // THE DECISION THIS ASSERTION USED TO FORCE HAS BEEN MADE (objectui#3845).
     //
-    // Deliberately NOT repaired by giving `en` a `{{version}}` hole: that would
-    // change a string the user sees today, on a call site whose intent is
-    // ambiguous, in a slice whose contract is that `en` equals the inline
-    // `defaultValue` byte for byte. Filed as a finding; this assertion is what
-    // makes the next reader see the choice instead of "fixing" it silently.
+    // Slice five landed with `MarketplacePackagePage.tsx` passing `version` next
+    // to a `defaultValue` of `Update`, which has no hole for it: i18next dropped
+    // the argument in silence and the primary button has only ever read a bare
+    // "Update". Its sibling `marketplace.install.updateTo` (the environment
+    // dropdown, same file) DOES render the version, which is what made the
+    // asymmetry legible. The assertion here pinned the inert argument in place
+    // so the next reader would have to decide rather than "fix" it silently.
+    //
+    // The decision was **delete the argument**, not give `en` a `{{version}}`
+    // hole: the second would change a string users see today and oblige nine
+    // more packs through `scripts/check-i18n-en-drift.mjs`, which is a copy
+    // decision about the three-state button (Update / Installed / Installing…)
+    // and its width — not something a dead-argument cleanup gets to smuggle in.
+    // If that copy decision is ever taken, this assertion is the one to revisit,
+    // and `interpolation-parity` in `scripts/check-i18n-call-site-keys.mjs`
+    // accepts either resolution as long as the two ends agree.
+    //
+    // So this now pins the CHOSEN state, both halves of it: the argument is gone
+    // from the call site, and no pack pretends there was ever a hole.
     const src = sourceOf(PACKAGE_PAGE);
-    expect(src).toContain("t('marketplace.action.updateTo', { defaultValue: 'Update', version: latestVersion })");
+    expect(src).toContain("t('marketplace.action.updateTo', { defaultValue: 'Update' })");
+    expect(src).not.toContain("t('marketplace.action.updateTo', { defaultValue: 'Update', version");
     for (const lang of LANGS) {
       expect(at(builtInLocales[lang], 'marketplace.action.updateTo')).not.toContain('{{');
     }
+    // The sister key is untouched, so the asymmetry that made this legible is
+    // still visible to whoever takes the copy decision later.
     expect(at(builtInLocales.en, 'marketplace.install.updateTo')).toContain('{{version}}');
+    expect(src).toContain("t('marketplace.install.updateTo', { defaultValue: 'Update \\u2192 v{{version}}', version: latestVersion })");
   });
 
   it('the two revert labels collapse only in the packs with no letter case', () => {

--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -10,7 +10,10 @@ import {
   collectEnKeys,
   collectSourceFiles,
   EXCLUDED_TRANSLATORS,
+  EXTERNALLY_INTERPOLATED_HOLES,
+  holesOf,
   PACK_HOOK,
+  RESERVED_OPTION_NAMES,
 } from '../check-i18n-call-site-keys.mjs';
 
 /**
@@ -44,6 +47,13 @@ import {
  *      against synthetic repos, including the cases it deliberately declines to
  *      judge. That last group is the one worth reading before widening the rule:
  *      each abstention is a decision, not an oversight.
+ *
+ *   4. objectui#3845 added a fourth: the arguments a call site passes must be
+ *      exactly the `{{holes}}` the `en` value has to receive them. BOTH
+ *      directions are pinned red below, because they fail differently — an inert
+ *      argument is dropped in silence, an unfilled hole renders its own braces
+ *      to the user — and a rule that only judged one of them would be green on
+ *      half the class it names.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -113,6 +123,18 @@ const EN_FIXTURE = `const en = {
   detail: { showEmptyRelated_one: '+ {{count}} empty', showEmptyRelated_other: '+ {{count}} empty' },
   grid: { column: { label: 'Label', width: 'Width' } },
   confirm: { purge: 'Deleting resets it to the shipped baseline. ' + 'Continue?' },
+  interp: {
+    greet: 'Hello {{name}}',
+    both: 'Hello {{name}}, you have {{n}} messages',
+    bare: 'Update',
+    counted: 'Deleted {{count}} rows',
+    enlarge: 'Enlarge {{name}}',
+    imageAlt: 'Image {{index}}',
+  },
+  // The real key registered in EXTERNALLY_INTERPOLATED_HOLES, so the registry's
+  // effect can be exercised against a synthetic repo rather than only observed
+  // on \`main\`. The registry is keyed by NAME, so a fixture is enough.
+  auth: { forgotPassword: { successDescription: 'Sent a reset link to {{email}}.' } },
 } as const;
 export default en;
 `;
@@ -536,6 +558,236 @@ export const A = (flag: boolean) => {
     // pack. If this ever has to be waived, that decision needs a baseline
     // section and an issue — not an edit to `en.ts` to make the red go away.
     expect(driftOf(repoRoot)).toEqual([]);
+  });
+});
+
+describe('what a call site passes must be what the en value has holes for (objectui#3845)', () => {
+  /** Parity findings as `key: inert=[…] unfilled=[…]` — both directions visible. */
+  function parityOf(root: string): string[] {
+    return analyze(root)
+      .findings.filter((f: { reason: string }) => f.reason === 'interpolation-parity')
+      .map(
+        (f: { detail: string; inert: string[]; unfilled: string[] }) =>
+          `${f.detail}: inert=[${f.inert.join(',')}] unfilled=[${f.unfilled.join(',')}]`,
+      )
+      .sort();
+  }
+
+  /** One synthetic component whose body is `return <expr>;` inside a hook-bound `t`. */
+  function callSite(body: string): Record<string, string> {
+    return {
+      'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+      'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = (name: string, n: number, idx: number) => {
+  const { t } = useObjectTranslation();
+  return ${body};
+};
+`,
+    };
+  }
+
+  it('is silent when the argument set is exactly the hole set', () => {
+    const root = repoWith(callSite("[t('interp.greet', { name }), t('interp.both', { name, n }), t('interp.bare')]"));
+    const { findings, counters } = analyze(root);
+    expect(findings).toEqual([]);
+    // Shorthand properties (`{ name }`) are names too — the AST form differs from
+    // `{ name: name }` and reading only one of them would make the rule blind to
+    // whichever spelling the next author picks.
+    expect(counters.judgedInterpolation).toBe(3);
+  });
+
+  it('RED, direction one: an argument with no hole to receive it is inert', () => {
+    // objectui#3845's own instance, in miniature: i18next drops it in silence, so
+    // nothing anywhere else in the stack will ever say a word about it.
+    const root = repoWith(callSite("t('interp.bare', { version: name })"));
+    expect(parityOf(root)).toEqual(['interp.bare: inert=[version] unfilled=[]']);
+  });
+
+  it('RED, direction two: a hole with no argument renders its own braces', () => {
+    // The reverse the card measured at 0 on the day the rule landed. Judged
+    // anyway — "0 by luck" and "0 by guarantee" are different states, and this is
+    // the test that tells them apart.
+    const root = repoWith(callSite("t('interp.greet')"));
+    expect(parityOf(root)).toEqual(['interp.greet: inert=[] unfilled=[name]']);
+  });
+
+  it('reports both directions on one call site, because they are one disagreement', () => {
+    const root = repoWith(callSite("t('interp.both', { name, wrong: n })"));
+    expect(parityOf(root)).toEqual(['interp.both: inert=[wrong] unfilled=[n]']);
+  });
+
+  it('an options object is not needed to be judged — a bare t() can still leave a hole open', () => {
+    const root = repoWith(callSite("[t('interp.greet'), t('interp.bare')]"));
+    // Only the one with a hole is reported; a call with neither holes nor
+    // arguments is the ordinary case and must stay silent.
+    expect(parityOf(root)).toEqual(['interp.greet: inert=[] unfilled=[name]']);
+  });
+
+  it('reads only the outer options object, not a nested t() inside one of its values', () => {
+    // THE documented false positive of this class (objectui#3845): the census
+    // that found it was done with a regex first, and the regex read the inner
+    // call's `index:` as an argument of the outer `fields.image.enlarge`, scoring
+    // 2 hits where there was 1. This is that exact shape, and both calls are
+    // correct — so the whole thing must be silent.
+    const root = repoWith(callSite("t('interp.enlarge', { name: name || t('interp.imageAlt', { index: idx + 1 }) })"));
+    const { findings, counters } = analyze(root);
+    expect(findings).toEqual([]);
+    expect(counters.judgedInterpolation).toBe(2);
+  });
+
+  it('a nested t() that IS wrong is still caught, on its own call site', () => {
+    // The mirror of the test above: excluding the inner call's arguments from the
+    // OUTER name set must not exclude the inner call from being judged at all.
+    const root = repoWith(callSite("t('interp.enlarge', { name: t('interp.imageAlt', { wrong: idx }) })"));
+    expect(parityOf(root)).toEqual(['interp.imageAlt: inert=[wrong] unfilled=[index]']);
+  });
+
+  it('subtracts reserved names from BOTH sides, which is the only way `count` works', () => {
+    // `count` is an i18next control option AND the value of a `{{count}}` hole.
+    // Dropping it from the call site's names only would report every counted
+    // string in the repo as unfilled; dropping it from the holes only would
+    // report every `count` passed to a plural key as inert.
+    const root = repoWith(
+      callSite(
+        "[t('interp.counted', { count: n }), t('interp.counted'), t('interp.bare', { ns: 'x', lng: 'en', defaultValue: 'Update' })]",
+      ),
+    );
+    expect(parityOf(root)).toEqual([]);
+    expect(RESERVED_OPTION_NAMES.has('count')).toBe(true);
+    expect(RESERVED_OPTION_NAMES.has('version')).toBe(false);
+  });
+
+  it('never judges a plural family, where there is no single value to read holes off', () => {
+    const root = repoWith(callSite("t('detail.showEmptyRelated', { count: n, thing: name })"));
+    const { findings, counters } = analyze(root);
+    // `detail.showEmptyRelated` resolves through `_one`/`_other`; picking one
+    // form's holes as the answer would be an invention, so `thing` goes
+    // unreported rather than being called inert on a guess.
+    expect(findings).toEqual([]);
+    expect(counters.unjudgedInterpolation).toBeGreaterThanOrEqual(1);
+  });
+
+  it('abstains, loudly counted, when the option NAME SET cannot be read', () => {
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+      'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = (rest: Record<string, unknown>, key: string, opts: Record<string, unknown>) => {
+  const { t } = useObjectTranslation();
+  return [
+    t('interp.greet', { ...rest }),
+    t('interp.greet', { [key]: 1 }),
+    t('interp.greet', opts),
+    t('interp.greet', { replace: { name: 'x' } }),
+  ];
+};
+`,
+    });
+    const { findings, counters } = analyze(root);
+    // A spread, a computed name and an opaque bag genuinely hide the set. The
+    // fourth is different in kind and the same in verdict: `replace` REDIRECTS
+    // where i18next takes interpolation data from, so the top-level names stop
+    // being the answer to this question at all.
+    expect(findings).toEqual([]);
+    expect(counters.opaqueOptions).toBe(4);
+    expect(counters.judgedInterpolation).toBe(0);
+  });
+
+  it('the two key classes still own their own territory — no double report', () => {
+    // A key `en` does not define has no value, so it has no holes either. Saying
+    // "and its arguments do not match" about it would be noise on top of the one
+    // fact that matters, and false besides.
+    const root = repoWith(callSite("t('nowhere.key', { name })"));
+    expect(analyze(root).findings.map((f: { reason: string }) => f.reason)).toEqual(['missing-key']);
+  });
+
+  it('reads a formatter, an unescape marker and a keypath as the option they name', () => {
+    // None of these three shapes is in `en` today — all 84 distinct holes are
+    // bare names. They cost four lines to read through and would otherwise each
+    // become a phantom hole nobody passes.
+    expect([...holesOf('{{name}}')].sort()).toEqual(['name']);
+    expect([...holesOf('{{n, number}} of {{total, number}}')].sort()).toEqual(['n', 'total']);
+    expect([...holesOf('{{- html}}')].sort()).toEqual(['html']);
+    expect([...holesOf('{{user.name}} <{{user.email}}>')].sort()).toEqual(['user']);
+    expect([...holesOf('no holes at all')].sort()).toEqual([]);
+    // A single brace is not i18next interpolation — `auth.forgotPassword.
+    // resendOtpCountdownText` uses `{seconds}` for exactly that reason.
+    expect([...holesOf('Resend in {seconds}s')].sort()).toEqual([]);
+  });
+
+  describe('holes filled by the CONSUMER of the string, not by i18next', () => {
+    it('does not demand an argument for a registered hole', () => {
+      const root = repoWith(callSite("t('auth.forgotPassword.successDescription')"));
+      expect(parityOf(root)).toEqual([]);
+    });
+
+    it('still reports the argument if someone passes it — that is the real defect here', () => {
+      // Passing it lets i18next consume the hole, `ForgotPasswordForm`'s
+      // `includes('{{email}}')` guard then misses, and its fallback branch appends
+      // the address a SECOND time. So the registry silences one direction only.
+      const root = repoWith(callSite("t('auth.forgotPassword.successDescription', { email: name })"));
+      expect(parityOf(root)).toEqual(['auth.forgotPassword.successDescription: inert=[email] unfilled=[]']);
+    });
+
+    it('every registered entry still describes something real, in en AND in the source', () => {
+      // An exemption that outlives the substitution it describes is an allowlist.
+      // Both halves of each entry's premise are checked against `main`: the pack
+      // really has the hole, and the named file really fills it.
+      const parsed = collectEnKeys(repoRoot);
+      expect(EXTERNALLY_INTERPOLATED_HOLES.length).toBeGreaterThan(0);
+      for (const entry of EXTERNALLY_INTERPOLATED_HOLES) {
+        const value = parsed.values.get(entry.key);
+        expect(value, `en does not define ${entry.key} as a string`).toBeTypeOf('string');
+        for (const hole of entry.holes) {
+          expect([...holesOf(value!)], `en value of ${entry.key} has no {{${hole}}}`).toContain(hole);
+        }
+        const filler = fs.readFileSync(path.join(repoRoot, entry.filledBy), 'utf8');
+        expect(filler, `${entry.filledBy} no longer substitutes ${entry.key}`).toContain(entry.marker);
+        expect(entry.reason.length).toBeGreaterThan(40);
+      }
+    });
+  });
+
+  it('main passes exactly the arguments its en values have holes for', () => {
+    // objectui#3845 measured 3 inert sites and 0 unfilled ones on `main`, and
+    // deleted all three arguments in the same PR — which is why this rule needs
+    // no baseline. A finding here is a NEW disagreement: fix the call site.
+    // Adding or removing a hole in `en.ts` to make it green is a copy change
+    // that obliges nine more packs, and is never the way to silence this.
+    expect(parityOf(repoRoot)).toEqual([]);
+  });
+
+  it('the three arguments this rule deleted are really gone, and their sisters are not', () => {
+    // The stock, pinned by name rather than by a count: a rule with no baseline
+    // has nothing else recording what it was worth on the day it landed.
+    const gone: Array<[file: string, absent: string, present: string]> = [
+      [
+        'packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx',
+        "t('marketplace.action.updateTo', { defaultValue: 'Update', version",
+        "t('marketplace.action.updateTo', { defaultValue: 'Update' })",
+      ],
+      [
+        'packages/app-shell/src/console/home/HomePage.tsx',
+        "t('home.welcome', { product:",
+        "t('home.welcome', { defaultValue: 'Build your business system with AI' })",
+      ],
+      [
+        'packages/app-shell/src/hooks/useObjectActions.ts',
+        "t('objectActions.resetPackageSetSuccess', {\n                label:",
+        "t('objectActions.resetPackageSetSuccess', {",
+      ],
+    ];
+    for (const [file, absent, present] of gone) {
+      const src = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+      expect(src, `${file} still passes the inert argument`).not.toContain(absent);
+      expect(src, `${file} lost the call site itself`).toContain(present);
+    }
+    // The sister call that DOES interpolate is untouched — deleting an argument
+    // because it is inert must not read as "this file does not interpolate".
+    const marketplace = fs.readFileSync(
+      path.join(repoRoot, 'packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx'),
+      'utf8',
+    );
+    expect(marketplace).toContain("t('marketplace.install.updateTo', { defaultValue: 'Update \\u2192 v{{version}}', version: latestVersion })");
   });
 });
 

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -2,11 +2,14 @@
 /**
  * Every key a component asks `t()` for must EXIST in the `en` locale pack — and
  * where the call site also writes an inline `defaultValue`, that dead string
- * must say the same thing the pack does (objectui#3810).
+ * must say the same thing the pack does (objectui#3810) — and the interpolation
+ * arguments the call site passes must be exactly the holes the `en` value has
+ * to receive them (objectui#3845).
  *
  * Run:  node scripts/check-i18n-call-site-keys.mjs   (also `pnpm check:i18n-keys`)
- * Exit: 0 = every in-scope call-site key resolves (or is baselined) and no
- *           inline default contradicts its `en` value, 1 = otherwise
+ * Exit: 0 = every in-scope call-site key resolves (or is baselined), no inline
+ *           default contradicts its `en` value, and no call site's option names
+ *           disagree with its `en` value's holes, 1 = otherwise
  *
  * ## The gap this closes (objectui#3530)
  *
@@ -47,6 +50,17 @@
  * this gate asked only whether the key existed, parity reads no values at all,
  * and en-drift fires on CHANGE — and in every one of the 43 sites the `en` value
  * had not moved for months. The call site was the thing that disagreed.
+ *
+ * `interpolation-parity` is the fifth, and it is blind to all four
+ * (objectui#3845). Parity DOES compare placeholder shape — but pack against
+ * pack: the nine translations must hold the same `{{holes}}` as `en`. Ten packs
+ * agreeing on `Update` while the call site passes `version` is full placeholder
+ * parity, because no pack gate ever reads the argument list. And a `defaultValue`
+ * that agrees byte for byte with `en` says nothing about the arguments either:
+ * `home.welcome` passed `product` to `Welcome to {{product}}`, the `en` value was
+ * later rewritten to `Build your business system with AI`, and #3810's rule is
+ * satisfied the moment the call site copies that new sentence — with the now
+ * inert `product` still sitting beside it.
  *
  * ## What is IN scope, and why the answer is not "every `t(`"
  *
@@ -89,7 +103,7 @@
  * every one of them a component that was handed the metadata-admin table's `t`
  * by its parent, and not one of them a real finding.
  *
- * ## Three failure classes
+ * ## Four failure classes
  *
  * 1. `missing-key` — a literal key with no leaf in `en`. i18next plural suffixes
  *    (`_one`, `_other`, …) count as defining the base key, and a key passed with
@@ -126,6 +140,56 @@
  *    NOT yet in `en` stays legal — that transition period runs for months
  *    (objectui#3546) and is class 1's business, not this one's.
  *
+ * 4. `interpolation-parity` (objectui#3845) — the key EXISTS, and the set of
+ *    interpolation option names the call site passes is not the set of `{{hole}}`
+ *    names the `en` value has. Both directions fail, because the declaration and
+ *    the thing that consumes it are the same statement read from two ends:
+ *
+ *      - **inert** — an argument passed with no hole to receive it. i18next
+ *        drops it silently, so the author's intent evaporates with no runtime
+ *        signal at all: `marketplace.action.updateTo` passed `version` to a value
+ *        reading `Update`, while its sister key three hundred lines down renders
+ *        `Update → v{{version}}` from the same variable. Nothing is broken today,
+ *        which is exactly why nothing ever noticed.
+ *      - **unfilled** — a hole with no argument to fill it. i18next leaves the
+ *        braces in the output, so the user reads a literal `{{name}}`. This
+ *        direction measured 0 on `main` when the rule landed; keeping it judged
+ *        is the difference between "0 by luck" and "0 by guarantee".
+ *
+ *    Deliberately NOT judged (counted instead), and each abstention is a
+ *    decision:
+ *
+ *      - The same key preconditions as class 3 — a dynamic or several-literal
+ *        key, a `returnObjects` subtree, an `en` leaf that is not a readable
+ *        static string. Plural families fall out here too: `t(k, { count })`
+ *        resolves through `_one`/`_other` and there is no single value whose
+ *        holes could be the answer, so the families are never judged.
+ *      - An options object whose NAME SET cannot be read: a spread, a computed
+ *        name, a getter — or a `replace:` redirect, which is where i18next takes
+ *        the interpolation data from when it is present, making the top-level
+ *        names not interpolation at all. Today the repo has none of these; the
+ *        abstention is what stops the first one becoming a false red.
+ *      - RESERVED names are removed from BOTH sides before comparing, not just
+ *        from the call site's. `count` is the reason: it is an i18next control
+ *        option AND the value of a `{{count}}` hole, so subtracting it from one
+ *        side only would report every counted string as unfilled.
+ *
+ *    Nested `t()` inside the options object is not a special case here and must
+ *    not become one: the arguments of an inner call are not properties of the
+ *    outer object literal, so an AST reading the outer literal's own properties
+ *    never sees them. It is called out because the census that found this class
+ *    was done with a regex first, and the regex read the inner `index:` of
+ *    `packages/fields/src/widgets/ImageField.tsx` as an argument of the outer
+ *    `fields.image.enlarge` call — one false positive out of two hits. The
+ *    self-test pins the AST's behaviour on exactly that shape.
+ *
+ *    Also HARD from day one, and for the same reason: the first full run found
+ *    2 inert sites and 0 unfilled ones, both fixed in objectui#3845's PR by
+ *    DELETING the dead argument. Adding the hole to the `en` value instead is a
+ *    product decision about what the string should say — it changes what users
+ *    read and obliges the nine other packs through objectui#3650 — so the gate
+ *    accepts either resolution and neither is its to make.
+ *
  * ## Dynamic keys: the explicit policy
  *
  * A key that is not a string literal cannot be resolved statically. Those call
@@ -150,7 +214,7 @@
  *
  * `scripts/i18n-call-site-key-baseline.json` lists the keys already missing on
  * `main` when this gate landed, each with the issue tracking its fix — classes 1
- * and 2 only; class 3 has no baseline and never needed one. It is a
+ * and 2 only; classes 3 and 4 have no baseline and never needed one. It is a
  * ratchet, not an allowlist: a key that is NOT in it fails, and an entry that no
  * longer fires (key added to `en`, or its last call site deleted) ALSO fails, so
  * the file can only shrink. Fixing the debt means adding the key to
@@ -179,6 +243,114 @@ export const TRANSLATOR_TYPE =
 
 /** The option flag `useObjectLabel` sets on its deliberate convention-key misses. */
 export const PROBE_FLAG_NAMES = /I18N_PROBE_FLAG|__ouiLabelProbe/;
+
+/**
+ * i18next option names that CONTROL the lookup rather than fill a hole
+ * (objectui#3845). Subtracted from both sides of the interpolation comparison —
+ * see the header for why `count` in particular must leave the hole set too.
+ *
+ * `replace` is absent on purpose: it does not merely fail to be interpolation
+ * data, it REDIRECTS where the data comes from, so a call site carrying one is
+ * abstained on rather than having one name dropped.
+ */
+export const RESERVED_OPTION_NAMES = new Set([
+  // plural / context selection — and `count` is also its own `{{count}}` hole
+  'count',
+  'ordinal',
+  'context',
+  // the default a miss falls back to, in all its plural spellings
+  'defaultValue',
+  'defaultValue_zero',
+  'defaultValue_one',
+  'defaultValue_two',
+  'defaultValue_few',
+  'defaultValue_many',
+  'defaultValue_other',
+  // namespace / language selection
+  'ns',
+  'lng',
+  'lngs',
+  'fallbackLng',
+  // return shape and post-processing
+  'returnObjects',
+  'returnDetails',
+  'returnedObjectHandler',
+  'joinArrays',
+  'postProcess',
+  'postProcessorOptions',
+  // interpolation and key parsing control
+  'interpolation',
+  'skipInterpolation',
+  'keySeparator',
+  'nsSeparator',
+  'escapeValue',
+  // missing-key handling
+  'parseMissingKeyHandler',
+  'missingKeyNoValueFallbackToKey',
+  'appendNamespaceToMissingKey',
+]);
+
+/**
+ * Keys whose `{{hole}}` is filled by the CONSUMER of the translated string
+ * rather than by i18next (objectui#3845). Every entry is a decision with a
+ * reason, the way `EXCLUDED_TRANSLATORS` is — and the self-test verifies each
+ * one's premise against both the `en` pack and the named source file, so an
+ * entry cannot outlive the substitution it describes.
+ *
+ * i18next leaves an unmatched `{{name}}` in the output verbatim, which is what
+ * makes a second substitution stage possible at all: the string travels through
+ * `t()` with its hole intact and the component fills it afterwards. That is a
+ * deliberate design here, not an oversight — the sister label three lines away
+ * in `apps/console/src/pages/auth/ForgotPasswordPage.tsx` spells the same
+ * pattern with SINGLE braces (`Resend in {seconds}s`) precisely to stay out of
+ * i18next's way, and the inconsistency between the two spellings is filed as
+ * objectui#4135.
+ *
+ * The listed hole names are removed from the hole set, so the `unfilled`
+ * direction stays silent — and the `inert` direction keeps judging them, which
+ * is the direction that matters here: passing `email` to `t()` would let
+ * i18next consume the hole, `ForgotPasswordForm`'s `includes('{{email}}')`
+ * guard would then miss, and its fallback branch would append the address a
+ * SECOND time. So for these keys the argument must not be passed, and the gate
+ * still says so.
+ */
+export const EXTERNALLY_INTERPOLATED_HOLES = [
+  {
+    key: 'auth.forgotPassword.successDescription',
+    holes: ['email'],
+    filledBy: 'packages/auth/src/ForgotPasswordForm.tsx',
+    marker: "successDescription.replace('{{email}}', email)",
+    reason:
+      'the label is a PROP of `ForgotPasswordForm`, which substitutes the address itself ' +
+      'once the form knows it — the call site cannot, because it renders before the user ' +
+      'has typed anything. All ten packs carry the hole, so this is the shape in every ' +
+      'language, not an en-only quirk.',
+  },
+];
+
+/**
+ * The interpolation names an `en` value has holes for (objectui#3845).
+ *
+ * i18next's default interpolation is `{{name}}`; `{{name, format}}` names a
+ * formatter, `{{- name}}` asks for the unescaped value, and `{{a.b}}` reads a
+ * keypath off the option called `a`. Today's pack uses none of the three — all
+ * 84 distinct holes in `en` are bare names — but reading through them costs four
+ * lines and stops the first one that appears from being read as a different
+ * hole (or, for the keypath, as a missing option nobody passes).
+ */
+export function holesOf(value) {
+  const names = new Set();
+  for (const match of value.matchAll(/\{\{([^{}]+)\}\}/g)) {
+    const name = match[1]
+      .split(',')[0] // `{{n, number}}` — the formatter is not part of the name
+      .trim()
+      .replace(/^-\s*/, '') // `{{- html}}` — the unescape marker is not either
+      .split('.')[0] // `{{user.name}}` is filled by the option called `user`
+      .trim();
+    if (name) names.add(name);
+  }
+  return names;
+}
 
 /**
  * `t` bindings that do NOT resolve against the locale packs. Every entry is a
@@ -541,6 +713,66 @@ function inlineDefaultValue(node, source) {
   return { present: false, text: null };
 }
 
+/**
+ * The interpolation option names a call site passes (objectui#3845).
+ *
+ * `{ readable: true, names }`  — the full name set, reserved names already
+ *                                removed. An empty set is a real answer: it says
+ *                                this call passes nothing to interpolate.
+ * `{ readable: false }`        — the name set is not statically knowable, so the
+ *                                rule abstains rather than guessing at it.
+ *
+ * Only the properties of the options OBJECT LITERAL itself are read. An inner
+ * `t('fields.image.imageAlt', { index })` written as one of those property
+ * VALUES contributes nothing, because its arguments are its own — which is the
+ * whole difference between this and the regex that first measured the class.
+ */
+function interpolationOptions(node, source) {
+  let object = null;
+  for (const argument of node.arguments.slice(1)) {
+    const inner = unwrapExpression(argument);
+    if (!inner) return { readable: false };
+    if (ts.isObjectLiteralExpression(inner)) {
+      // `t(key, 'Default', { name })` is legal i18next; the first object wins,
+      // the way `inlineDefaultValue` reads it.
+      if (object === null) object = inner;
+      continue;
+    }
+    // A positional default (`tt(key, 'Save')`) carries no options.
+    if (ts.isStringLiteral(inner) || ts.isNoSubstitutionTemplateLiteral(inner) || ts.isTemplateExpression(inner)) continue;
+    // `t(key, options)` — an options bag this parser cannot open.
+    return { readable: false };
+  }
+
+  const names = new Set();
+  if (object === null) return { readable: true, names };
+
+  for (const property of object.properties) {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      if (!RESERVED_OPTION_NAMES.has(property.name.text)) names.add(property.name.text);
+      continue;
+    }
+    // A spread, a method, an accessor: the name set is open, so do not judge it.
+    if (!ts.isPropertyAssignment(property)) return { readable: false };
+    if (ts.isComputedPropertyName(property.name)) {
+      // The probe flag is the one computed name with a known meaning, and those
+      // call sites returned before reaching here. Anything else is unreadable.
+      return { readable: false };
+    }
+    const name =
+      ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) || ts.isNumericLiteral(property.name)
+        ? property.name.text
+        : null;
+    if (name === null) return { readable: false };
+    // i18next reads interpolation data OUT of `replace` when it is present, so
+    // the top-level names stop being the answer to this question entirely.
+    if (name === 'replace') return { readable: false };
+    if (RESERVED_OPTION_NAMES.has(name)) continue;
+    names.add(name);
+  }
+  return { readable: true, names };
+}
+
 /** The literal head of a template key, i.e. everything before the first `${`. */
 function staticHead(argument) {
   const inner = unwrapExpression(argument);
@@ -567,6 +799,9 @@ export function analyze(root) {
 
   const registeredModules = new Set(EXCLUDED_TRANSLATORS.map((entry) => entry.module));
   const localScopes = EXCLUDED_TRANSLATORS.flatMap((entry) => entry.forwardedScope ?? []);
+  const externallyFilled = new Map(
+    EXTERNALLY_INTERPOLATED_HOLES.map((entry) => [entry.key, new Set(entry.holes)]),
+  );
 
   const findings = [];
   const counters = {
@@ -584,6 +819,9 @@ export function analyze(root) {
     matchingDefaultValues: 0,
     computedDefaultValues: 0,
     unjudgedDefaultValues: 0,
+    judgedInterpolation: 0,
+    unjudgedInterpolation: 0,
+    opaqueOptions: 0,
   };
 
   for (const file of collectSourceFiles(root)) {
@@ -705,13 +943,18 @@ export function analyze(root) {
           // define is `missing-key`'s territory and is NOT reported here too;
           // keeping the two classifications disjoint is what lets either output
           // be read on its own.
+          // The single `en` value this call site renders, or `undefined` when
+          // there is not exactly one that this parser could read as a string.
+          // Shared by classes 3 and 4: both judge a call site against the
+          // sentence the pack actually serves it, and both decline together.
+          const key = !dynamic && keys.length === 1 ? keys[0] : null;
+          const enValue = key !== null && !returnsObjects ? values.get(key) : undefined;
+
           const inlineDefault = inlineDefaultValue(node, source);
           if (inlineDefault.present && inlineDefault.text === null) {
             counters.computedDefaultValues += 1;
           } else if (inlineDefault.present) {
             counters.literalDefaultValues += 1;
-            const key = !dynamic && keys.length === 1 ? keys[0] : null;
-            const enValue = key !== null && !returnsObjects ? values.get(key) : undefined;
             if (enValue === undefined) {
               // No single static key, or a key whose `en` leaf this parser could
               // not read as a string — including the plural families, where
@@ -721,6 +964,29 @@ export function analyze(root) {
               counters.matchingDefaultValues += 1;
             } else {
               findings.push({ reason: 'default-value-drift', ...at, detail: key, expected: enValue, actual: inlineDefault.text });
+            }
+          }
+
+          // objectui#3845 — what this call site passes must be what the `en`
+          // value has holes for, in both directions. Judged on the same
+          // preconditions as class 3, plus a readable option-name set.
+          if (enValue === undefined) {
+            counters.unjudgedInterpolation += 1;
+          } else {
+            const options = interpolationOptions(node, source);
+            if (!options.readable) {
+              counters.opaqueOptions += 1;
+            } else {
+              const downstream = externallyFilled.get(key) ?? new Set();
+              const holes = new Set(
+                [...holesOf(enValue)].filter((hole) => !RESERVED_OPTION_NAMES.has(hole) && !downstream.has(hole)),
+              );
+              const inert = [...options.names].filter((option) => !holes.has(option)).sort();
+              const unfilled = [...holes].filter((hole) => !options.names.has(hole)).sort();
+              counters.judgedInterpolation += 1;
+              if (inert.length > 0 || unfilled.length > 0) {
+                findings.push({ reason: 'interpolation-parity', ...at, detail: key, expected: enValue, inert, unfilled });
+              }
             }
           }
 
@@ -815,6 +1081,20 @@ const HINTS = {
     ' the same change in the other nine packs. If the pack value is genuinely the wrong' +
     ' copy for this spot, that is a copy change in its own PR, or the call site is asking' +
     ' for the wrong key.',
+  'interpolation-parity':
+    'The arguments this call site passes are not the holes the `en` value has (objectui#3845).' +
+    ' An INERT argument is one i18next drops on the floor — no hole to receive it, no warning,' +
+    ' and the intent behind it disappears. An UNFILLED hole is worse: i18next leaves the braces' +
+    ' in place and the user reads a literal `{{name}}`. Fix it at the CALL SITE by default —' +
+    ' delete the argument nothing consumes, or pass the one the sentence asks for. Editing' +
+    ' `packages/i18n/src/locales/en.ts` to add or drop a hole is a COPY change: it changes what' +
+    ' users read and obliges the other nine packs through `scripts/check-i18n-en-drift.mjs`, so' +
+    ' it needs to be a deliberate decision in its own right rather than a way to silence this.' +
+    ' If the hole is filled by whatever CONSUMES the translated string rather than by i18next' +
+    ' (a label handed to a component that substitutes it later), register the key in' +
+    ' EXTERNALLY_INTERPOLATED_HOLES with the file that does the substitution — and note that' +
+    ' those keys must still NOT be passed the argument, or i18next consumes the hole before the' +
+    ' consumer gets to see it.',
 };
 
 /** JSON-quoted, with every non-ASCII byte escaped — `...` vs `…` must be visible. */
@@ -853,17 +1133,27 @@ if (invokedDirectly) {
       `(${counters.matchingDefaultValues} match their en value, ${counters.unjudgedDefaultValues} not comparable), ` +
       `${counters.computedDefaultValues} computed (report-only).`,
   );
+  console.log(
+    `Interpolation parity: ${counters.judgedInterpolation} call sites compared against their en value's holes, ` +
+      `${counters.unjudgedInterpolation} with no single comparable en value, ${counters.opaqueOptions} with an ` +
+      `unreadable option set, ${EXTERNALLY_INTERPOLATED_HOLES.length} key(s) whose holes are filled downstream.`,
+  );
 
   // Split by class before printing: the two key classes say "en does not define
-  // this", the drift class says "en defines it differently", and one paragraph
-  // cannot honestly introduce both.
+  // this", the drift class says "en defines it differently", the parity class
+  // says "en defines it with different holes", and one paragraph cannot honestly
+  // introduce all three.
   const drift = unexpected.filter((finding) => finding.reason === 'default-value-drift');
-  const keyFindings = unexpected.filter((finding) => finding.reason !== 'default-value-drift');
+  const parity = unexpected.filter((finding) => finding.reason === 'interpolation-parity');
+  const keyFindings = unexpected.filter(
+    (finding) => finding.reason !== 'default-value-drift' && finding.reason !== 'interpolation-parity',
+  );
 
   if (unexpected.length === 0 && stale.length === 0) {
     console.log(
-      `Every in-scope call-site key resolves against the en pack (${enKeyCount} keys), and every` +
-        ' literal inline defaultValue matches the value the pack serves.',
+      `Every in-scope call-site key resolves against the en pack (${enKeyCount} keys), every` +
+        ' literal inline defaultValue matches the value the pack serves, and every call site passes' +
+        ' exactly the arguments that value has holes for.',
     );
     process.exit(0);
   }
@@ -890,6 +1180,22 @@ if (invokedDirectly) {
       console.error(`  ${finding.file}:${finding.line}:${finding.column}  [${finding.reason}]  ${finding.detail}`);
       console.error(`      en renders: ${quote(finding.expected)}`);
       console.error(`      call site:  ${quote(finding.actual)}`);
+    }
+  }
+
+  if (parity.length > 0) {
+    const distinct = new Set(parity.map((finding) => finding.detail));
+    console.error(
+      `\n${parity.length} call site${parity.length === 1 ? '' : 's'} pass${parity.length === 1 ? 'es' : ''} ` +
+        `arguments that do not match the holes in the en value (${distinct.size} distinct ` +
+        `key${distinct.size === 1 ? '' : 's'}) — an inert argument is dropped in silence, an ` +
+        'unfilled hole renders its own braces to the user:',
+    );
+    for (const finding of parity) {
+      console.error(`  ${finding.file}:${finding.line}:${finding.column}  [${finding.reason}]  ${finding.detail}`);
+      console.error(`      en renders: ${quote(finding.expected)}`);
+      if (finding.inert.length > 0) console.error(`      inert (passed, no hole):     ${finding.inert.join(', ')}`);
+      if (finding.unfilled.length > 0) console.error(`      unfilled (hole, no argument): ${finding.unfilled.join(', ')}`);
     }
   }
 


### PR DESCRIPTION
Fixes #3845

Option **C + A** per the delegated ruling on the card. Stacked on #4119 (#3810), which merged as `297534b78` before this started, so this branches off `main` rather than off that branch.

## The rule (C)

`scripts/check-i18n-call-site-keys.mjs` gains a fourth failure class, `interpolation-parity`: for a call site whose key resolves to a readable `en` leaf, the set of interpolation option names it passes must **equal** the set of `{{hole}}` names in that value. Both directions fail, because they fail differently:

- **inert** — an argument with no hole. i18next drops it in silence; there is no runtime signal anywhere.
- **unfilled** — a hole with no argument. i18next leaves the braces in the output and the user reads a literal `{{name}}`.

Nothing else could see either. `all-locales-key-parity` does compare placeholder shape, but pack against pack — ten packs agreeing on `Update` while the call site passes `version` is full parity. `check-i18n-en-drift` fires only on a changed `en` string. And #3810's `default-value-drift` is satisfied the moment the call site's inline default matches the pack, which is exactly the road `home.welcome` travelled: its value was rewritten from `Welcome to {{product}}` to `Build your business system with AI`, #4119 aligned the call site's default to the new sentence, and the now-inert `product` stayed sitting beside it. Byte-alignment and argument-parity are different questions about the same line.

## The measurement, which decided the shape

Run over the whole repo with the rule in and nothing yet fixed:

```
Interpolation parity: 2291 call sites compared against their en value's holes, 72 with no
single comparable en value, 0 with an unreadable option set.

5 call sites pass arguments that do not match the holes in the en value (4 distinct keys)
  apps/console/src/pages/auth/ForgotPasswordPage.tsx:46:31        auth.forgotPassword.successDescription
      unfilled (hole, no argument): email
  packages/app-shell/src/console/auth/ForgotPasswordPage.tsx:30:31 auth.forgotPassword.successDescription
      unfilled (hole, no argument): email
  packages/app-shell/src/console/home/HomePage.tsx:330:26          home.welcome
      inert (passed, no hole): product
  packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx:555:17  marketplace.action.updateTo
      inert (passed, no hole): version
  packages/app-shell/src/hooks/useObjectActions.ts:160:15          objectActions.resetPackageSetSuccess
      inert (passed, no hole): label
```

**Five, where the card predicted two** — and the three extra split cleanly into one more of the card's class and two of something the card did not anticipate.

### One more inert argument the census had not reached

`objectActions.resetPackageSetSuccess` passes `label`, copied from the `deleteSuccess` branch immediately below it, whose sentence *does* name the record. Checked against all ten packs by hand, not inferred from `en`: not one of the ten has a `{{label}}` hole in that string, while all ten have one in `deleteSuccess`. Provably inert, so it takes the same treatment.

### Two that are NOT findings, and the abstention that says so

The two `auth.forgotPassword.successDescription` sites are a **false positive**, and running the two-line fix on them would have been a real bug. `packages/auth/src/ForgotPasswordForm.tsx:286` fills that hole itself:

```js
const successMsg = l.successDescription.includes('{{email}}')
  ? l.successDescription.replace('{{email}}', email)
  : `${l.successDescription} ${email}`;
```

The label is a **prop**; the call site renders before the user has typed an address and cannot interpolate it. The string travels through `t()` with `{{email}}` intact — which works because i18next leaves an unmatched hole verbatim — and the component substitutes afterwards. All ten packs carry the hole, so this is the shape in every language.

So the key is registered in a new `EXTERNALLY_INTERPOLATED_HOLES` list, modelled on the existing `EXCLUDED_TRANSLATORS`: an entry with a reason, not a silent skip. It removes the listed holes from the hole set, which silences the **unfilled** direction **only** — and that asymmetry is the point. Passing `email` at the call site would let i18next consume the hole, `includes('{{email}}')` would then miss, and the fallback branch would append the address a *second* time. That is precisely the "fix" a reader would reach for on seeing a hole with no argument, so the gate keeps reporting it. The self-test re-verifies each entry's premise against both the pack and the named source file, so an entry cannot outlive the substitution it describes.

The spelling collision underneath this — the same "hole i18next must not fill" concept written `{{email}}` here and `{seconds}` three lines away in the same labels object, with only the second one documented — is filed as **#4135** rather than fixed here: it is a ten-pack copy edit or a public-prop change in `@object-ui/auth`, neither of which belongs in a gate PR.

## The stock (A)

All three inert arguments deleted, none of the ten locale packs touched — `check:i18n-drift` reports `0 en value(s) changed`. **A, not B**, per the ruling: adding `{{version}}` to the button is a copy decision about the three-state `Update / Installed / Installing...` label and its width, and a stock cleanup must not smuggle one in. The gate accepts either resolution.

**No rendered output moves, on any path** — verified rather than assumed, since #4119 found a provider-less nuance in the neighbouring class:

- **Provider mounted**: i18next dropped these arguments already. That is the finding.
- **No provider**: react-i18next 17.0.11's `notReadyT` returns `optsOrDefaultValue.defaultValue` **verbatim** — read first-hand in `dist/es/useTranslation.js:5-14`; there is no interpolation step on that path at all, so the argument was unused there too.
- **The miss path**: all three inline defaults (`Update`, `Build your business system with AI`, `Permission set reset to its shipped baseline`) are themselves hole-free, so even a key that vanished would render the same.
- All three sites bind `t` from a bare `useObjectTranslation`, so #3865's third path does not arise.

#3546's slice-five assertion — written explicitly to force this decision rather than let it be settled silently — is **updated to pin the chosen state**, not deleted: the argument is gone from the call site, no pack pretends there was a hole, and the sister `marketplace.install.updateTo` that *does* render the version is asserted untouched, so the asymmetry stays visible to whoever takes the copy decision later.

## The false-positive trap the card documented

The card recorded that its first regex census scored 2 hits where there was 1, because the options object of `t('fields.image.enlarge', { name: ... })` in `packages/fields/src/widgets/ImageField.tsx:105` **nests another `t()` call**, and the regex read the inner `index:` as an outer argument. On an AST this is not a special case and must not become one — the inner call's arguments are its own, not properties of the outer object literal. Pinned both ways in the self-test: the real shape is silent, and an inner call that genuinely disagrees is still reported **on its own call site**.

## Abstentions, each one a decision

- The same key preconditions as #3810's class: a dynamic or several-literal key, a `returnObjects` subtree, an `en` leaf that is not a readable static string. **Plural families fall out here** — `t(k, { count })` resolves through `_one` / `_other` and there is no single value whose holes could be the answer, so they are never judged, consistent with how #4119 handled them.
- Reserved names are subtracted from **both** sides, not just the call site's. `count` is the reason: it is an i18next control option *and* the value of a `{{count}}` hole, so subtracting it from one side only would report every counted string as unfilled.
- An options object whose name set cannot be read — a spread, a computed name, or a `replace:` redirect, which is where i18next takes interpolation data from when present. **0 in the repo today**; the abstention is counted and printed so the first one cannot erode the rule silently.
- `holesOf` reads through a formatter (`{{n, number}}`), an unescape marker (`{{- html}}`) and a keypath (`{{user.name}}` is filled by `user`). None of the three is in `en` today — all 84 distinct holes are bare names — but each would otherwise become a phantom hole nobody passes.

## Verification

- `pnpm exec vitest run scripts/__tests__/check-i18n-call-site-keys.test.ts` — **51 passed** (17 new).
- **Reverse verification**, both halves:
  - *Rule removed* (`git checkout origin/main --` of the script, patch re-applied after — never `git stash`): **13 of the 17 new tests go red**, predicted before running. The 4 that stay green are the ones that should: two over-firing guards (a missing key must report `['missing-key']` only; a registered hole must not be demanded), the `main`-is-clean stock assertion, and the source-text pins on the three deleted arguments — none of which a *removed* rule can falsify.
  - *Stock restored*: the repo-wide run above **is** that state, and it reports exactly the measured sites and no others.
  - Both directions shown discriminating on synthetic repos: a param-with-no-hole case reds, and a **hole-with-no-param** case reds — the direction the card measured at 0 and called "luck, not guarantee".
- `node scripts/check-i18n-call-site-keys.mjs` — exit 0.
- `pnpm exec vitest run packages/app-shell/` — 318 files, **2969 passed**, 1 skipped.
- `pnpm exec vitest run packages/i18n/ scripts/__tests__/check-i18n-call-site-keys.test.ts` — 36 files, **681 passed** (includes the rewritten #3546 slice-five assertion).
- `pnpm type-check:scripts` — exit 0. `turbo run type-check lint --filter=@object-ui/app-shell --filter=@object-ui/i18n` — **32 tasks successful**, 0 lint errors.
- `pnpm check:i18n-drift` — `0 en value(s) changed`. `node scripts/check-control-bytes.mjs` — OK, 3829 files. `check-changeset-presence` / `-fixed` / `-no-major` — all green.

## Out of scope, filed separately

- **#4135** — the two spellings for a hole i18next must not fill (`{{email}}` vs `{seconds}`), which is what made the two `ForgotPasswordForm` sites indistinguishable from real findings. Observation-class: correct in all ten languages today, and the registry plus the retained inert-direction check guard the one way it bites.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_