### PR TITLE
docs(console-starter): correct the "Without a backend" root-route paragraph

### DIFF
--- a/examples/console-starter/README.md
+++ b/examples/console-starter/README.md
@@ -102,10 +102,27 @@ Nothing in this repo reads it. There is no mock mode.)
 
 ### Without a backend
 
-Measured with nothing listening on `:3000`: `/login` renders in full but cannot
-sign in, and `/` stops at the branded "Initializing application… / Connecting to
-data source" screen — the adapter never connects, so no route below it mounts.
-The browser console shows `ERR_CONNECTION_REFUSED`.
+Measured with nothing listening on `:3000`, `pnpm dev` on a free port, headless
+Chromium on `/`:
+
+**`/` redirects to `/login`.** The root route is wrapped in `AuthenticatedRoute`
+(objectui#4042), so the guard resolves the session before `RootRedirect` — and the
+`/meta/*` reads behind it — ever mount. The branded "Initializing application... /
+Connecting to data source" screen still appears, but only as a *transient* frame
+while `GET /api/v1/auth/get-session` is in flight; the redirect lands within a few
+hundred milliseconds of that request being refused. `/login` then renders in full
+but cannot sign in. The browser console shows `ERR_CONNECTION_REFUSED` for
+`/api/v1/auth/get-session`, `/api/v1/auth/config` and
+`/api/v1/i18n/translations/en`.
+
+**A stored credential does not change this.** `isAuthenticated` is
+`user !== null && session !== null`, and both come only from the server's
+`get-session` answer — `localStorage` holds a bearer *token*, never a session — so
+seeding `auth-session-token` and reloading `/` still lands on `/login`. With the
+backend down no cold load reaches an authenticated state, so nothing below the
+guard renders. (Not measured: a session signed in against a live backend that is
+then killed under it; until the next reload that one still holds its in-memory
+session.)
 
 ## Which example do I want?
 


### PR DESCRIPTION
Fixes #4102

`examples/console-starter/README.md`'s "Without a backend" section still described the pre-#4042 root route. Re-measured on current `origin/main` and reworded to the measured truth.

## What was measured

Nothing listening on `:3000` (curl → connection refused), `pnpm dev` on a free port with **no prior build** (the run story #4103 established, confirmed again here), headless Chromium via the repo's own Playwright:

| Probe | Final URL | Result |
|---|---|---|
| cold load `/` | `/login` | login screen renders — HTTP 200, `#root` 2506 chars |
| cold load `/login` | `/login` | same, renders in full |
| `auth-session-token` seeded in `localStorage`, then `/` | `/login` | unchanged |

Sampling the first frames of `/` shows the old paragraph was not fiction, just not the resting state:

```
+80ms   url=/        "ObjectOS Initializing application... Connecting to data source ..."
+220ms  url=/login   "ObjectOS ... Sign in to your account ..."
```

Failed requests on every probe: `/api/v1/auth/get-session`, `/api/v1/auth/config`, `/api/v1/i18n/translations/en` — all `net::ERR_CONNECTION_REFUSED`.

## The half the card left unmeasured

The card asked whether an *authenticated* session with a dead backend still sees the "Initializing application…" screen, and asked for it to be measured rather than assumed. Measured answer: **no cold load can reach an authenticated state at all.**

`AuthProvider` computes `isAuthenticated` as `user !== null && session !== null`, and both are populated only from `client.getSession()` — a network read. `localStorage` holds a bearer *token*, never a session, and `getSession()`'s transport-error path returns `null` (its stale-bearer self-heal retry is another network call, so it fails the same way). Probe C seeds the token and still lands on `/login`; that probe is the measurement, not the reasoning.

The new paragraph names the one corner that stays unmeasured rather than guessing it: a session signed in against a *live* backend that is then killed under it keeps its in-memory session until the next reload. Setting that up needs a live backend, so it is flagged as unmeasured.

## `apps/console` docs — checked, drift absent

Nothing to fix there. `apps/console/README.md` and `apps/console/docs/*.md` carry no "Without a backend" section and no claim about the root route's dead-backend behaviour. A repo-wide search for the loading-screen strings matches only `packages/i18n/src/locales/en.ts` (the strings themselves) and this README.

## Gates

- `node scripts/check-control-bytes.mjs` — OK, 3836 tracked text files scanned
- `node scripts/check-doc-links.mjs` — "Links are valid across 7 scan roots"
- `node scripts/check-changeset-presence.mjs` — "No source of a released package changed in this range, so no changeset is owed." README-only, so none is added.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_