### PR TITLE
docs: drop the hardcoded package versions from the utilities pages and correct the data-objectstack README install line

### DIFF
--- a/content/docs/utilities/data-objectstack.mdx
+++ b/content/docs/utilities/data-objectstack.mdx
@@ -400,8 +400,8 @@ Exported error types: `ObjectStackError` (base), `MetadataNotFoundError`,
 
 ## Package Information
 
-**Package Name:** `@object-ui/data-objectstack`  
-**Version:** 0.3.1  
+**Package Name:** `@object-ui/data-objectstack` — published on npm, see the
+[npm page](https://www.npmjs.com/package/@object-ui/data-objectstack) for the current version  
 **License:** MIT
 
 ## Dependencies

--- a/content/docs/utilities/vscode-extension.mdx
+++ b/content/docs/utilities/vscode-extension.mdx
@@ -24,10 +24,11 @@ code --install-extension objectui.object-ui
 
 ### Manual Installation
 
-Download the `.vsix` file from the releases page and install:
+Download the `.vsix` file from the releases page and install it. The file name carries
+the package name and the version you downloaded:
 
 ```bash
-code --install-extension objectui-0.3.1.vsix
+code --install-extension object-ui-<version>.vsix
 ```
 
 ## Features
@@ -415,7 +416,6 @@ The preview panel includes:
 ## Package Information
 
 **Extension ID:** `objectui.object-ui`  
-**Version:** 0.3.1  
 **License:** MIT
 
 ## Extension Dependencies

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -11,8 +11,10 @@ This enables strictly typed, metadata-driven UI components to communicate seamle
 ## Installation
 
 ```bash
-npm install @object-ui/data-objectstack @objectstack/client
+npm install @object-ui/data-objectstack
 ```
+
+**Note:** `@objectstack/client` is a regular dependency of this package — it is installed and resolved along with it, so there is nothing to install separately.
 
 ## Usage
 


### PR DESCRIPTION
Fixes #4125
Fixes #4130

Two small docs-truth drifts on adjacent surfaces, one PR, one `Fixes` each. Both premises re-verified on `origin/main` = `148ade326` before implementing; both still held.

## #4125 — hardcoded `**Version:** 0.3.1` in the utilities Package Information blocks

Both lines claimed `0.3.1` while both manifests read `17.4.0`. Taken the **removal** direction, per the card's own first option.

The decisive evidence for removing rather than updating is that this repo already made the call, twice, on the same page family: commit `616353ad1` (#3577) replaced `**Version:** 0.3.1` in `runner.mdx` with a pointer to the npm page, and `b1204af0a` (#3715) did the same for `create-plugin.mdx`. Of the four `## Package Information` blocks under `content/docs/utilities/`, two had already shed the hardcoded version and two had not — so this change finishes a convention rather than inventing one. Verified that nothing renders or reads these lines specially: they are plain bold markdown, and a repo-wide search for code touching a `Version:` line or injecting versions into docs finds nothing.

The two pages are treated slightly differently, deliberately:

- **`data-objectstack.mdx`** follows the `runner.mdx` precedent exactly — the package name line gains "published on npm, see the npm page for the current version". The package is publishable (no `private` flag) and its own README already links that npm page, so the pointer is a claim I can stand behind.
- **`vscode-extension.mdx`** drops the version line with **no** replacement pointer. The parallel move would be "see the Marketplace listing", but `packages/vscode-extension/package.json` carries `"private": true`, so I could not verify a live Marketplace listing — and adding an unverified availability claim is the exact class of defect these cards exist to remove. Bare removal is the edit I can prove correct; whether that page's existing "search the Extensions panel for ObjectUI" instructions are accurate is a separate question this PR does not touch.

**Sweep result — the card's "only two such lines" claim is correct, but a third instance of the same stale value exists in another shape.** A broader hardcoded-version grep over `content/docs/` found `vscode-extension.mdx:30`:

```
code --install-extension objectui-0.3.1.vsix
```

Wrong twice over: `vsce package` names its output `NAME-VERSION.vsix` from the manifest, so with `"name": "object-ui"` at `17.4.0` the real file is `object-ui-17.4.0.vsix` — the doc used the *publisher* segment and the stale version. Replaced with the placeholder form rather than the current number, so it cannot re-drift. (Written in this description with spaces inside the angle brackets — `object-ui-< version >.vsix` — because GitHub's body sanitizer eats a bare angle-bracket-plus-letter; the file itself has no spaces.)

The only other version-shaped hit under `content/docs/` is `guide/plugins.md:374`'s `"version": "1.0.0"` inside an example plugin manifest — a template for the reader's own package, not a claim about ours. Left alone.

## #4130 — README told readers to install `@objectstack/client` separately

`packages/data-objectstack/README.md:16` still carried `npm install @object-ui/data-objectstack @objectstack/client`. Confirmed against the manifest: the package declares **no** `peerDependencies` at all, and `@objectstack/client` sits in `dependencies` at `^17.0.0-rc.5`. The install line and the note now match `content/docs/utilities/data-objectstack.mdx` verbatim, which is where PR #4127 landed the corrected wording.

**Whole-README dependency-contract sweep** (the #3781 discipline), all other candidates checked and found clean:

- No occurrence of "peer" anywhere in the README — no false peer claim to correct.
- The usage example imports `SchemaRenderer` from `@object-ui/react`, which is not a dependency of this package. Left as-is and **not** added to the install line: the corrected docs page states the same relationship in prose ("React wiring lives in `@object-ui/react`, not here"), so the README is consistent with it. Adding the package to the install command would be inventing a contract claim, the opposite of what this card asks for.
- `## Links` targets resolve: `./CHANGELOG.md`, `./LICENSE`, and the relative `content/docs/guide/user-state-persistence.md` all exist.

## Verification

| Gate | Result |
|---|---|
| `node scripts/check-doc-links.mjs` | `Links are valid across 7 scan roots.` |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 3836 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | `No source of a released package changed in this range, so no changeset is owed.` |
| `turbo run build --filter=@object-ui/site --force` | `29 successful, 29 total`; `Generating static pages (556/556)` |

The site build was run with `--force` because turbo does not hash `content/docs` (the #4124 finding), so a cached build would not have exercised these files.

The build was not just a smoke test — the placeholder edit puts angle brackets into an MDX file, so the rendered output was read back to confirm MDX treated it as code text rather than parsing it as a JSX element. Built HTML for `/docs/utilities/vscode-extension` contains the command with the placeholder intact, and its Package Information block now renders `Extension ID: objectui.object-ui` straight into `License: MIT`. Neither built page contains `0.3.1` any more (0 occurrences in each), and no changeset is owed since this is docs and README prose only.

## Out of scope, filed not fixed

- **#4143** — `apps/console/README.md:5` and `QUICK_REFERENCE.md:107-109` hardcode stale versions too (`0.5.1` vs `17.4.0`; spec/client `^4.0.4` vs `^17.0.0-rc.5`). Same drift shape, different site — the same split that made #4130 its own card rather than part of #4125. Filed rather than fixed here because the direction is genuinely not inherited: `QUICK_REFERENCE.md`'s "Current Release" block is a deliberately maintained status section whose Node/pnpm/React entries are still accurate, so "delete the line" is not obviously right for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_