### PR TITLE
fix(i18n): delete the dead `t(key) || 'English'` fallback and gate the spelling (#4117)

### DIFF
--- a/.changeset/nervous-pans-repeat.md
+++ b/.changeset/nervous-pans-repeat.md
@@ -1,0 +1,33 @@
+---
+---
+
+Releases nothing on purpose: this deletes 22 dead `t(key) || 'English'` fallbacks in
+`@object-ui/app-shell` and adds the gate that stops them coming back, and not one of
+them can change what a user reads.
+
+The right operand of these was unreachable on **every** path before the deletion, which
+is the whole finding (objectui#4117). With an `I18nProvider` mounted, i18next serves the
+`en` value and the fallback is skipped. Without one, react-i18next's not-ready `t`
+returns the KEY — truthy — so `||` skips the fallback there too and the raw key renders
+either way. Removing an operand that never evaluated leaves both paths byte-identical.
+
+The five rows whose dead string said something *different* from the pack were the ones
+worth checking individually, because a divergent fallback that also carried
+`{{holes}}` could have been hiding an unfilled hole. Each was verified against what the
+call actually passes:
+
+- `marketplace.detail.purgeSuccess` (×2) — `en` `Removed {{count}} sample record(s).`,
+  call passes `{ count: removed }`. Hole filled; renders the same before and after.
+- `marketplace.detail.reseedLocalSuccess` — `en` `Re-seeded sample data: {{inserted}}
+  inserted, {{updated}} updated.`, call passes `{ inserted, updated }`. Both filled.
+- `marketplace.detail.reseedPartialErrors` — `en` `({{count}} record(s) failed to
+  write)`, call passes `{ count: errored }`. Filled.
+- `console.objectView.deleteViewConfirm` — `en` `… delete the view "{{name}}"? …`,
+  call passes `{ name: viewLabel }`. Filled.
+- `marketplace.detail.moreOptions` — `en` `More install options` against a dead
+  `'More options'`. No holes; the `aria-label` already read the pack value.
+
+So no call needed params wired, and the `interpolation-parity` rule from objectui#3845
+independently agrees: it judges all 22 of these sites and reports nothing in either
+direction. The user-visible copy is unchanged, which is why this entry carries no
+version bump.

--- a/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
+++ b/packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx
@@ -393,7 +393,7 @@ export function MarketplacePackagePage() {
         setCloudInstall({ ...cloudInstall, withSampleData: true });
         setSampleDataMsg({
           ok: true,
-          text: t('marketplace.detail.reseedQueued') || 'Sample data will be re-seeded on next environment access.',
+          text: t('marketplace.detail.reseedQueued'),
         });
       } else {
         setSampleDataMsg({ ok: false, text: r.error || 'Re-seed failed' });
@@ -410,10 +410,7 @@ export function MarketplacePackagePage() {
    */
   const doPurgeSampleData = async () => {
     if (!cloudInstall) return;
-    if (!confirm(
-      t('marketplace.detail.purgeConfirm')
-      || 'Delete all sample records seeded by this package? User-added records will NOT be touched.',
-    )) {
+    if (!confirm(t('marketplace.detail.purgeConfirm'))) {
       return;
     }
     setSampleDataBusy('purge');
@@ -426,9 +423,8 @@ export function MarketplacePackagePage() {
         setSampleDataMsg({
           ok: true,
           text: removed > 0
-            ? (t('marketplace.detail.purgeSuccess', { count: removed })
-                || `Removed ${removed} sample record(s).`)
-            : (t('marketplace.detail.purgeNoData') || 'No sample records found to purge.'),
+            ? t('marketplace.detail.purgeSuccess', { count: removed })
+            : t('marketplace.detail.purgeNoData'),
         });
       } else {
         setSampleDataMsg({ ok: false, text: r.error || 'Purge failed' });
@@ -450,13 +446,12 @@ export function MarketplacePackagePage() {
       const inserted = r.inserted ?? 0;
       const updated = r.updated ?? 0;
       const errored = r.errors ?? 0;
-      const base = t('marketplace.detail.reseedLocalSuccess', { inserted, updated })
-        || `Sample data re-seeded (inserted=${inserted}, updated=${updated}).`;
+      const base = t('marketplace.detail.reseedLocalSuccess', { inserted, updated });
       // A reseed can land some rows and fail others (the server only hard-fails
       // when ZERO rows write). Don't hide the partial failures behind a green
       // success toast — flag them so the user knows the data is incomplete.
       setSampleDataMsg(errored > 0
-        ? { ok: false, text: `${base} ${t('marketplace.detail.reseedPartialErrors', { count: errored }) || `(${errored} record(s) failed to write)`}` }
+        ? { ok: false, text: `${base} ${t('marketplace.detail.reseedPartialErrors', { count: errored })}` }
         : { ok: true, text: base });
     } catch (err: any) {
       setSampleDataMsg({ ok: false, text: err?.message || 'Re-seed failed' });
@@ -467,10 +462,7 @@ export function MarketplacePackagePage() {
 
   const doPurgeLocalSampleData = async () => {
     if (!localInstall) return;
-    if (!confirm(
-      t('marketplace.detail.purgeConfirm')
-      || 'Delete all sample records seeded by this package? User-added records will NOT be touched.',
-    )) {
+    if (!confirm(t('marketplace.detail.purgeConfirm'))) {
       return;
     }
     setSampleDataBusy('purge');
@@ -484,9 +476,8 @@ export function MarketplacePackagePage() {
       setSampleDataMsg({
         ok: true,
         text: removed > 0
-          ? (t('marketplace.detail.purgeSuccess', { count: removed })
-              || `Removed ${removed} sample record(s).`)
-          : (t('marketplace.detail.purgeNoData') || 'No sample records found to purge.'),
+          ? t('marketplace.detail.purgeSuccess', { count: removed })
+          : t('marketplace.detail.purgeNoData'),
       });
     } catch (err: any) {
       setSampleDataMsg({ ok: false, text: err?.message || 'Purge failed' });
@@ -649,8 +640,8 @@ export function MarketplacePackagePage() {
                     ? <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                     : <Database className="h-4 w-4 mr-2" aria-hidden="true" />}
                   {localInstall.withSampleData
-                    ? (t('marketplace.detail.reseedAgain') || 'Re-seed sample data')
-                    : (t('marketplace.detail.addSampleData') || 'Add sample data')}
+                    ? t('marketplace.detail.reseedAgain')
+                    : t('marketplace.detail.addSampleData')}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onSelect={doPurgeLocalSampleData}
@@ -660,7 +651,7 @@ export function MarketplacePackagePage() {
                   {sampleDataBusy === 'purge'
                     ? <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                     : <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" />}
-                  {t('marketplace.detail.purgeSampleData') || 'Purge sample data'}
+                  {t('marketplace.detail.purgeSampleData')}
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={doUninstallLocal} disabled={installingLocal} className="text-destructive focus:text-destructive">
                   <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" />
@@ -677,7 +668,7 @@ export function MarketplacePackagePage() {
           {!localInstall && cloudInstall && !getRuntimeConfig().cloudUrl && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" size="lg" className="px-2.5" aria-label={t('marketplace.detail.moreOptions') || 'More options'}>
+                <Button variant="outline" size="lg" className="px-2.5" aria-label={t('marketplace.detail.moreOptions')}>
                   <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </DropdownMenuTrigger>
@@ -687,8 +678,8 @@ export function MarketplacePackagePage() {
                     ? <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                     : <Database className="h-4 w-4 mr-2" aria-hidden="true" />}
                   {cloudInstall.withSampleData
-                    ? (t('marketplace.detail.reseedAgain') || 'Re-seed sample data')
-                    : (t('marketplace.detail.addSampleData') || 'Add sample data')}
+                    ? t('marketplace.detail.reseedAgain')
+                    : t('marketplace.detail.addSampleData')}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onSelect={doPurgeSampleData}
@@ -698,7 +689,7 @@ export function MarketplacePackagePage() {
                   {sampleDataBusy === 'purge'
                     ? <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                     : <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" />}
-                  {t('marketplace.detail.purgeSampleData') || 'Purge sample data'}
+                  {t('marketplace.detail.purgeSampleData')}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/packages/app-shell/src/views/ActionResultDialog.tsx
+++ b/packages/app-shell/src/views/ActionResultDialog.tsx
@@ -236,7 +236,7 @@ function CodeListBlock({ value }: { value: string[] }) {
         </ul>
       </div>
       <div className="flex justify-end">
-        <CopyButton value={joined} label={t('actions.resultDialog.copyAll') || 'Copy all'} />
+        <CopyButton value={joined} label={t('actions.resultDialog.copyAll')} />
       </div>
     </div>
   );

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -936,12 +936,11 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         const targetView = views.find((v: any) => v.id === vid);
         const viewLabel = targetView?.label || vid;
         const confirmed = await confirmHandler(
-            t('console.objectView.deleteViewConfirm', { name: viewLabel }) ||
-                `Are you sure you want to delete the view "${viewLabel}"? This cannot be undone.`,
+            t('console.objectView.deleteViewConfirm', { name: viewLabel }),
             {
-                title: t('console.objectView.deleteViewTitle') || 'Delete view',
-                confirmText: t('console.objectView.delete') || 'Delete',
-                cancelText: t('console.objectView.cancel') || 'Cancel',
+                title: t('console.objectView.deleteViewTitle'),
+                confirmText: t('console.objectView.delete'),
+                cancelText: t('console.objectView.cancel'),
             },
         );
         if (!confirmed) return;
@@ -1941,8 +1940,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                    visibility: saved?.visibility ?? view.visibility,
                    readonly: isSystem,
                    readonlyReason: isSystem
-                     ? (t('console.objectView.systemViewReadonly')
-                       || 'System view defined in code — read-only.')
+                     ? t('console.objectView.systemViewReadonly')
                      : undefined,
                  } as ViewTabItem;
                });

--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -54,6 +54,17 @@ import {
  *      argument is dropped in silence, an unfilled hole renders its own braces
  *      to the user — and a rule that only judged one of them would be green on
  *      half the class it names.
+ *
+ *   5. objectui#4117 added a fifth, and it is the first that reads the call's
+ *      POSITION rather than its arguments: a literal fallback written beside the
+ *      call (`t(key) || 'English'`) is dead once the key exists, and the verdict
+ *      is deletion rather than alignment. Two of its cases carry more weight
+ *      than the reds. The mirror shape `someValue || t(key)` is HEALTHY and
+ *      outnumbers the class 94 to 24 on `main`, so a rule that read "appears in
+ *      a `||`" would condemn four times more than it fixed. And an OPTIONAL call
+ *      `t?.(key) ?? 'English'` really can reach its fallback, which is why the
+ *      two `ContextSelectors.tsx` sites the filing card counted among the 24 are
+ *      pinned here as abstentions instead.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -131,6 +142,9 @@ const EN_FIXTURE = `const en = {
     enlarge: 'Enlarge {{name}}',
     imageAlt: 'Image {{index}}',
   },
+  // The one shape that makes a non-optional \`t()\` falsy, so \`||\` really can
+  // reach its right operand. \`en\` has no such leaf today (objectui#4117).
+  edge: { blank: '' },
   // The real key registered in EXTERNALLY_INTERPOLATED_HOLES, so the registry's
   // effect can be exercised against a synthetic repo rather than only observed
   // on \`main\`. The registry is keyed by NAME, so a fixture is enough.
@@ -788,6 +802,197 @@ export const A = (rest: Record<string, unknown>, key: string, opts: Record<strin
       'utf8',
     );
     expect(marketplace).toContain("t('marketplace.install.updateTo', { defaultValue: 'Update \\u2192 v{{version}}', version: latestVersion })");
+  });
+});
+
+describe('a literal fallback beside the call is dead on every path (objectui#4117)', () => {
+  /** Sibling findings as `key@line: <op> <dead operand>` — position and text both visible. */
+  function siblingsOf(root: string): string[] {
+    return analyze(root)
+      .findings.filter((f: { reason: string }) => f.reason === 'dead-sibling-fallback')
+      .map((f: { detail: string; line: number; operator: string; actual: string }) =>
+        `${f.detail}@${f.line}: ${f.operator} ${f.actual}`,
+      )
+      .sort();
+  }
+
+  /** One synthetic component whose body is `return <expr>;` inside a hook-bound `t`. */
+  function callSite(body: string): Record<string, string> {
+    return {
+      'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+      'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = (name: string, label: string, n: number) => {
+  const { t } = useObjectTranslation();
+  return ${body};
+};
+`,
+    };
+  }
+
+  it('RED even when the dead string says exactly what the pack says', () => {
+    // The load-bearing difference from `default-value-drift`. That rule aligns;
+    // this one deletes, because the ruling on objectui#4117 keeps ONE blessed
+    // fallback spelling rather than two. So byte-equality is not a defence — 21
+    // of the 24 sites on `main` were byte-equal and every one of them went.
+    expect(siblingsOf(repoWith(callSite("t('common.save') || 'Save'")))).toEqual([
+      "common.save@4: || Save",
+    ]);
+  });
+
+  it('RED, and it never reports WHAT the fallback should have said', () => {
+    // A finding carries the dead text only to quote it. There is no "expected"
+    // wording to move toward: the fix is deletion in both cases, and a hint that
+    // said "make it match" would be teaching the spelling this class removes.
+    expect(siblingsOf(repoWith(callSite("t('common.save') || 'Store'")))).toEqual([
+      'common.save@4: || Store',
+    ]);
+  });
+
+  it('RED for `??` as well as `||`, which is the same dead operand', () => {
+    // `t()` returns a string on every path — the pack value, or the key itself
+    // when i18next is not ready — so it is never nullish and `??` is as dead as
+    // `||`. Reading only `||` would have missed both ContextSelectors sites.
+    expect(siblingsOf(repoWith(callSite("t('common.cancel') ?? 'Cancel'")))).toEqual([
+      'common.cancel@4: ?? Cancel',
+    ]);
+  });
+
+  it('RED for a template-literal fallback — the divergent rows are all this shape', () => {
+    // The five rows the card called out (`Removed ${n} sample record(s).` and
+    // friends) are templates, not plain strings. A rule that only read plain
+    // strings would have left exactly the sites whose text differs most.
+    expect(siblingsOf(repoWith(callSite('t(\'interp.counted\', { count: n }) || `Deleted ${n} rows`')))).toEqual([
+      'interp.counted@4: || `Deleted ${n} rows`',
+    ]);
+  });
+
+  it('RED through the parentheses and casts a call site wraps itself in', () => {
+    // `(t(k) || 'x')` inside a ternary arm is how 8 of the 22 were actually
+    // written; walking up from `node.parent` without unwrapping would see a
+    // ParenthesizedExpression and stop.
+    expect(siblingsOf(repoWith(callSite("[(t('common.save')) || 'Save', (t('common.cancel') as string) || 'Cancel']")))).toEqual([
+      'common.cancel@4: || Cancel',
+      'common.save@4: || Save',
+    ]);
+  });
+
+  it('GREEN for the mirror shape — a runtime value falling back to a translation', () => {
+    // The direction that matters most for false positives: `main` carries 94 of
+    // these against the 24 this class is about. Here the translation is the
+    // fallback, which is the healthy arrangement and nothing to report.
+    const root = repoWith(callSite("[label || t('common.save'), name ?? t('common.cancel')]"));
+    expect(siblingsOf(root)).toEqual([]);
+    expect(analyze(root).counters.siblingFallbacks).toBe(0);
+  });
+
+  it('counts rather than judges a non-literal fallback — there is no copy to delete', () => {
+    // `t(k) || label` renders a runtime value, so removing the operator would
+    // change behaviour rather than delete dead code. Same abstention shape as a
+    // computed `defaultValue` in objectui#3810.
+    const root = repoWith(callSite("t('common.save') || label"));
+    expect(siblingsOf(root)).toEqual([]);
+    expect(analyze(root).counters.computedSiblingFallbacks).toBe(1);
+  });
+
+  it('counts rather than judges an OPTIONAL call, where the fallback is live', () => {
+    // Not a parser limitation but a reachable path, and the one case where this
+    // class's premise is simply false: with `t` an optional prop, `t?.(k)` is
+    // `undefined` whenever the prop is absent and the fallback is what renders.
+    // Both sites left on `main` are this shape.
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+      'packages/x/src/B.tsx': `export const B = ({ t, label }: { t?: (key: string, options?: any) => string; label: string }) => {
+  return t?.('common.save') ?? 'Save';
+};
+`,
+    });
+    expect(siblingsOf(root)).toEqual([]);
+    const { counters } = analyze(root);
+    expect(counters.optionalCallFallbacks).toBe(1);
+    // And the file was SCANNED at all: its only spelling is `t?.(`, which the
+    // pre-filter used to drop — silently, out of all five classes at once.
+    expect(counters.packCallSites).toBe(1);
+  });
+
+  it('counts rather than judges an en value that is itself falsy', () => {
+    // The only way a non-optional `t()` can let `||` through. `en` has no empty
+    // leaf today; the abstention is what stops the first one being a wrong red.
+    const root = repoWith(callSite("t('edge.blank') || 'Something'"));
+    expect(siblingsOf(root)).toEqual([]);
+    expect(analyze(root).counters.unjudgedSiblingFallbacks).toBe(1);
+  });
+
+  it('counts rather than judges a plural family and a dynamic key', () => {
+    // Same preconditions as classes 3 and 4: a plural family has no single value
+    // to read, and a dynamic key denotes no one key at all.
+    const root = repoWith(callSite("[t('detail.showEmptyRelated', { count: n }) || 'more', t(`grid.column.${name}`) || 'Label']"));
+    expect(siblingsOf(root)).toEqual([]);
+    const { counters } = analyze(root);
+    expect(counters.siblingFallbacks).toBe(2);
+    expect(counters.unjudgedSiblingFallbacks).toBe(2);
+  });
+
+  it('leaves a key en does not define to the missing-key rule, and reports it ONCE', () => {
+    // A key with no leaf has no value, so "the fallback cannot render" is not a
+    // claim this rule can make about it — and objectui#3546 spent months in
+    // exactly that transition, where the fallback is the only English there is.
+    const root = repoWith(callSite("t('nowhere.key') || 'English'"));
+    expect(analyze(root).findings.map((f: { reason: string }) => f.reason)).toEqual(['missing-key']);
+  });
+
+  it('main carries no literal fallback beside a call, which is why this rule has no baseline', () => {
+    // 24 sites measured on the tip this landed on: 22 judged and deleted in the
+    // same PR, 2 abstained on as optional calls. A finding here is a NEW one.
+    expect(siblingsOf(repoRoot)).toEqual([]);
+  });
+
+  it('the 22 deleted fallbacks are really gone, and the 2 live ones are untouched', () => {
+    // The stock, pinned by name rather than by a count — a rule with no baseline
+    // has nothing else recording what it was worth on the day it landed.
+    const gone: Array<[file: string, absent: string, present: string]> = [
+      [
+        'packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx',
+        "|| 'More options'",
+        "aria-label={t('marketplace.detail.moreOptions')}",
+      ],
+      [
+        'packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx',
+        '|| `Removed ${removed} sample record(s).`',
+        "t('marketplace.detail.purgeSuccess', { count: removed })",
+      ],
+      [
+        'packages/app-shell/src/console/marketplace/MarketplacePackagePage.tsx',
+        '|| `Sample data re-seeded (inserted=${inserted}, updated=${updated}).`',
+        "t('marketplace.detail.reseedLocalSuccess', { inserted, updated })",
+      ],
+      [
+        'packages/app-shell/src/views/ObjectView.tsx',
+        // Tight on purpose: the file still holds a legitimate *computed*
+        // `defaultValue` ending in the same sentence (line ~1657), and a marker
+        // loose enough to catch that one would fail for the wrong reason.
+        'delete the view "${viewLabel}"',
+        "t('console.objectView.deleteViewConfirm', { name: viewLabel })",
+      ],
+      [
+        'packages/app-shell/src/views/ActionResultDialog.tsx',
+        "|| 'Copy all'",
+        "label={t('actions.resultDialog.copyAll')}",
+      ],
+    ];
+    for (const [file, absent, present] of gone) {
+      const src = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+      expect(src, `${file} still carries the dead fallback`).not.toContain(absent);
+      expect(src, `${file} lost the call site itself`).toContain(present);
+    }
+    // The two the rule abstains on are STILL THERE. Deleting them would have
+    // replaced a rendered placeholder with `undefined` on every host that does
+    // not pass the optional `t` — including this file's own persist test.
+    const selectors = fs.readFileSync(
+      path.join(repoRoot, 'packages/app-shell/src/layout/ContextSelectors.tsx'),
+      'utf8',
+    );
+    expect(selectors).toContain("t?.('common.package', { defaultValue: rawLabel }) ?? rawLabel");
+    expect(selectors).toContain('}) ?? `Select ${label}…`');
   });
 });
 

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -4,12 +4,14 @@
  * where the call site also writes an inline `defaultValue`, that dead string
  * must say the same thing the pack does (objectui#3810) — and the interpolation
  * arguments the call site passes must be exactly the holes the `en` value has
- * to receive them (objectui#3845).
+ * to receive them (objectui#3845) — and the OTHER spelling of a fallback,
+ * `t(key) || 'English'`, must not exist at all (objectui#4117).
  *
  * Run:  node scripts/check-i18n-call-site-keys.mjs   (also `pnpm check:i18n-keys`)
  * Exit: 0 = every in-scope call-site key resolves (or is baselined), no inline
- *           default contradicts its `en` value, and no call site's option names
- *           disagree with its `en` value's holes, 1 = otherwise
+ *           default contradicts its `en` value, no call site's option names
+ *           disagree with its `en` value's holes, and no call site carries a
+ *           literal sibling fallback, 1 = otherwise
  *
  * ## The gap this closes (objectui#3530)
  *
@@ -103,7 +105,17 @@
  * every one of them a component that was handed the metadata-admin table's `t`
  * by its parent, and not one of them a real finding.
  *
- * ## Four failure classes
+ * `dead-sibling-fallback` is the sixth, and it was blind to all five — including
+ * the two that read values — for one syntactic reason (objectui#4117): every
+ * rule above reads the call's ARGUMENTS, and this fallback is not an argument.
+ * `t('marketplace.detail.moreOptions') || 'More options'` carries no options
+ * object at all, so class 3 sees no `defaultValue` to compare and class 4 sees
+ * an empty (and correct) argument set. The dead English sits one operator to the
+ * right of everything this file used to look at. `node.parent` is what closes
+ * it, and the rule is the class rather than the instance: the first full run
+ * found 24 such sites in four files, every one of them on a key `en` defines.
+ *
+ * ## Five failure classes
  *
  * 1. `missing-key` — a literal key with no leaf in `en`. i18next plural suffixes
  *    (`_one`, `_other`, …) count as defining the base key, and a key passed with
@@ -189,6 +201,63 @@
  *    product decision about what the string should say — it changes what users
  *    read and obliges the nine other packs through objectui#3650 — so the gate
  *    accepts either resolution and neither is its to make.
+ *
+ * 5. `dead-sibling-fallback` (objectui#4117) — the key EXISTS and the call site
+ *    still writes a literal fallback as the call's SIBLING rather than as an
+ *    argument: `t('detail.moreOptions') || 'More options'`, or the same with
+ *    `??`. Unlike class 3 this rule does not ask what the fallback SAYS. It is
+ *    existence-is-red, and the fix is DELETION, because there is no reading of
+ *    this spelling under which the right operand can render:
+ *
+ *      - With a provider, i18next serves the pack value — the same reason class
+ *        3's `defaultValue` is dead.
+ *      - With NO provider, this spelling is strictly worse than `defaultValue`
+ *        rather than equivalent to it. react-i18next's not-ready `t` returns the
+ *        KEY, and `createSafeTranslation`'s fallback returns `defaults[key] ||
+ *        key` — both truthy — so `||` skips the right operand and the user reads
+ *        a raw `console.objectView.delete`. `defaultValue` at least renders
+ *        English there. Same family as objectui#3865; this is its `||` half.
+ *
+ *    So the two spellings are not two ways to write one thing: one is dead and
+ *    misleading, the other is dead and misleading AND cannot degrade gracefully.
+ *    The ruling on this card keeps ONE blessed fallback spelling — `defaultValue`,
+ *    governed by class 3 — instead of two competing ones, which is also why this
+ *    rule does not simply extend class 3's byte-equality test to the sibling
+ *    position: aligning these strings would bless the spelling.
+ *
+ *    Deliberately NOT judged (counted instead), and each abstention is a
+ *    decision the class above would get wrong:
+ *
+ *      - The same key preconditions as classes 3 and 4 — a dynamic or
+ *        several-literal key, a `returnObjects` subtree, an `en` leaf that is
+ *        not a readable static string (the plural families land here).
+ *      - An `en` value that is the EMPTY STRING. Then `t()` really can return a
+ *        falsy value and `||` really can reach its right operand, so the premise
+ *        of the whole class fails. `en` has no such leaf today; the abstention is
+ *        what stops the first one becoming a wrong red.
+ *      - A NON-LITERAL right operand (`t(key) || label`). What renders is then a
+ *        runtime value, not a second copy of the sentence, and judging it would
+ *        mean claiming something about a variable this parser cannot read —
+ *        exactly how class 3 treats a computed `defaultValue`.
+ *      - An OPTIONAL call, `t?.(key) ?? 'English'`. This one is not a parser
+ *        limitation but a live path: where `t` is an optional prop, the call
+ *        evaluates to `undefined` whenever the prop is absent and the fallback
+ *        is what renders. Both of `packages/app-shell/src/layout/
+ *        ContextSelectors.tsx`'s sites are this shape, and its own
+ *        `ContextSelectors.persist.test.tsx` renders the hook with no `t` — so
+ *        deleting those two would have replaced a rendered placeholder with
+ *        `undefined`. The card that filed this class listed them among the 24;
+ *        measuring the call shape is what took them back out.
+ *
+ *    Only the LEFT operand position is judged. `someLabel || t('common.actions')`
+ *    is the healthy, opposite shape — a runtime value with a translated fallback
+ *    — and `main` has 94 of them against these 24. A rule that read "appears in a
+ *    `||`" rather than "is the left operand of one" would condemn all 94.
+ *
+ *    HARD from day one, like classes 3 and 4: the first full run found 24 sites,
+ *    22 of them judged and deleted in objectui#4117's own PR, so there is no debt
+ *    for a ratchet to hold. And a fallback written on a key `en` does NOT define
+ *    stays legal — that is class 1's business, not this one's.
  *
  * ## Dynamic keys: the explicit policy
  *
@@ -773,6 +842,49 @@ function interpolationOptions(node, source) {
   return { readable: true, names };
 }
 
+/**
+ * The fallback written as this call's SIBLING, i.e. `t(key) || 'English'`
+ * (objectui#4117), or `null` when the call is not in that position at all.
+ *
+ * `node.parent` is the whole mechanism, and the direction matters: only the
+ * LEFT operand of `||`/`??` is this class. The mirror shape,
+ * `someValue || t('key')`, is the healthy one — a runtime value falling back to
+ * a translation — and `main` carries 94 of those.
+ *
+ * `optional` reports `t?.(key)`, where the call itself can evaluate to
+ * `undefined` and the fallback is therefore LIVE. `literal` reports whether the
+ * right operand is a static string or a template literal, which is the only
+ * form this rule judges; `text` is that string, or the right operand's source
+ * for a template, purely so the report can quote it.
+ */
+function siblingFallback(node, source) {
+  let current = node;
+  let parent = node.parent;
+  while (
+    parent &&
+    (ts.isParenthesizedExpression(parent) || ts.isAsExpression(parent) || ts.isNonNullExpression(parent))
+  ) {
+    current = parent;
+    parent = parent.parent;
+  }
+  if (!parent || !ts.isBinaryExpression(parent) || parent.left !== current) return null;
+  const operator = parent.operatorToken.kind;
+  if (operator !== ts.SyntaxKind.BarBarToken && operator !== ts.SyntaxKind.QuestionQuestionToken) return null;
+
+  const right = unwrapExpression(parent.right);
+  const text = staticString(right, source);
+  // A template WITH substitutions is still a literal fallback — the whole point
+  // of the five divergent rows this class was filed over. `staticString` cannot
+  // fold it, so read it as source; the verdict is "delete", never "compare".
+  const isTemplate = !!right && ts.isTemplateExpression(right);
+  return {
+    operator: operator === ts.SyntaxKind.BarBarToken ? '||' : '??',
+    optional: !!node.questionDotToken,
+    literal: text !== null || isTemplate,
+    text: text !== null ? text : right ? right.getText(source).replace(/\s+/g, ' ') : '',
+  };
+}
+
 /** The literal head of a template key, i.e. everything before the first `${`. */
 function staticHead(argument) {
   const inner = unwrapExpression(argument);
@@ -822,6 +934,11 @@ export function analyze(root) {
     judgedInterpolation: 0,
     unjudgedInterpolation: 0,
     opaqueOptions: 0,
+    siblingFallbacks: 0,
+    judgedSiblingFallbacks: 0,
+    computedSiblingFallbacks: 0,
+    optionalCallFallbacks: 0,
+    unjudgedSiblingFallbacks: 0,
   };
 
   for (const file of collectSourceFiles(root)) {
@@ -847,7 +964,11 @@ export function analyze(root) {
       }
     }
 
-    if (!/\bt\s*\(|\btt\s*\(/.test(text)) continue;
+    // `?\.` is not decoration: `packages/app-shell/src/layout/ContextSelectors.tsx`
+    // spells EVERY call `t?.(…)` because its `t` is an optional prop, so it holds
+    // no `t(` at all and this pre-filter used to drop the whole file — silently,
+    // out of all five classes at once (objectui#4117).
+    if (!/\btt?\s*(?:\?\.)?\s*\(/.test(text)) continue;
     const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
     const bindings = collectBindings(root, file, source);
 
@@ -990,6 +1111,38 @@ export function analyze(root) {
             }
           }
 
+          // objectui#4117 — the fallback spelled as a SIBLING of the call
+          // rather than as one of its arguments. Existence is the defect, so
+          // there is nothing to compare; every abstention below is a case where
+          // "the right operand cannot render" stops being true.
+          const sibling = siblingFallback(node, source);
+          if (sibling !== null) {
+            counters.siblingFallbacks += 1;
+            if (sibling.optional) {
+              // `t?.(key)` is `undefined` when the prop is absent, so the
+              // fallback is LIVE. Not a parser limitation — a real path.
+              counters.optionalCallFallbacks += 1;
+            } else if (enValue === undefined || enValue === '') {
+              // No single readable value — or one that is itself falsy, which is
+              // the one way a non-optional `t()` can let `||` through.
+              counters.unjudgedSiblingFallbacks += 1;
+            } else if (!sibling.literal) {
+              // `t(key) || label` renders a runtime value, not a second copy of
+              // the sentence. Same abstention as a computed `defaultValue`.
+              counters.computedSiblingFallbacks += 1;
+            } else {
+              counters.judgedSiblingFallbacks += 1;
+              findings.push({
+                reason: 'dead-sibling-fallback',
+                ...at,
+                detail: key,
+                expected: enValue,
+                actual: sibling.text,
+                operator: sibling.operator,
+              });
+            }
+          }
+
           if (dynamic) {
             counters.dynamicKeySites += 1;
             const head = staticHead(argument);
@@ -1095,6 +1248,18 @@ const HINTS = {
     ' EXTERNALLY_INTERPOLATED_HOLES with the file that does the substitution — and note that' +
     ' those keys must still NOT be passed the argument, or i18next consumes the hole before the' +
     ' consumer gets to see it.',
+  'dead-sibling-fallback':
+    'The key EXISTS in `en`, and this fallback is written as the call\'s SIBLING' +
+    ' (`t(key) || \'English\'`) rather than as an argument — so it is dead on every path, not just' +
+    ' the provider one (objectui#4117). With a provider the pack wins. WITHOUT one, react-i18next\'s' +
+    ' not-ready `t` returns the KEY, which is truthy, so `||` skips this string too and the user' +
+    ' reads a raw `console.objectView.delete` — strictly worse than an inline `defaultValue`, which' +
+    ' at least renders English there. DELETE the operator and the right-hand string; do NOT align it' +
+    ' with the `en` value, because aligning it would bless a second fallback spelling when the point' +
+    ' is that there is one (`defaultValue`, governed by `default-value-drift`). If this call site' +
+    ' genuinely needs English on a provider-less host, that is `t(key, { defaultValue: \'…\' })`.' +
+    ' Note the mirror shape `someValue || t(key)` is HEALTHY and is not reported: only the LEFT' +
+    ' operand of `||`/`??` is this class.',
 };
 
 /** JSON-quoted, with every non-ASCII byte escaped — `...` vs `…` must be visible. */
@@ -1138,6 +1303,12 @@ if (invokedDirectly) {
       `${counters.unjudgedInterpolation} with no single comparable en value, ${counters.opaqueOptions} with an ` +
       `unreadable option set, ${EXTERNALLY_INTERPOLATED_HOLES.length} key(s) whose holes are filled downstream.`,
   );
+  console.log(
+    `Sibling fallbacks: ${counters.siblingFallbacks} call site(s) sit left of a ||/?? — ` +
+      `${counters.judgedSiblingFallbacks} judged, ${counters.computedSiblingFallbacks} with a non-literal ` +
+      `right operand, ${counters.optionalCallFallbacks} an optional call (fallback is live), ` +
+      `${counters.unjudgedSiblingFallbacks} with no single comparable en value.`,
+  );
 
   // Split by class before printing: the two key classes say "en does not define
   // this", the drift class says "en defines it differently", the parity class
@@ -1145,15 +1316,16 @@ if (invokedDirectly) {
   // introduce all three.
   const drift = unexpected.filter((finding) => finding.reason === 'default-value-drift');
   const parity = unexpected.filter((finding) => finding.reason === 'interpolation-parity');
-  const keyFindings = unexpected.filter(
-    (finding) => finding.reason !== 'default-value-drift' && finding.reason !== 'interpolation-parity',
-  );
+  const siblings = unexpected.filter((finding) => finding.reason === 'dead-sibling-fallback');
+  const VALUE_CLASSES = new Set(['default-value-drift', 'interpolation-parity', 'dead-sibling-fallback']);
+  const keyFindings = unexpected.filter((finding) => !VALUE_CLASSES.has(finding.reason));
 
   if (unexpected.length === 0 && stale.length === 0) {
     console.log(
       `Every in-scope call-site key resolves against the en pack (${enKeyCount} keys), every` +
-        ' literal inline defaultValue matches the value the pack serves, and every call site passes' +
-        ' exactly the arguments that value has holes for.',
+        ' literal inline defaultValue matches the value the pack serves, every call site passes' +
+        ' exactly the arguments that value has holes for, and no call site carries a literal' +
+        ' fallback beside itself.',
     );
     process.exit(0);
   }
@@ -1196,6 +1368,21 @@ if (invokedDirectly) {
       console.error(`      en renders: ${quote(finding.expected)}`);
       if (finding.inert.length > 0) console.error(`      inert (passed, no hole):     ${finding.inert.join(', ')}`);
       if (finding.unfilled.length > 0) console.error(`      unfilled (hole, no argument): ${finding.unfilled.join(', ')}`);
+    }
+  }
+
+  if (siblings.length > 0) {
+    const distinct = new Set(siblings.map((finding) => finding.detail));
+    console.error(
+      `\n${siblings.length} call site${siblings.length === 1 ? '' : 's'} carr${siblings.length === 1 ? 'ies' : 'y'} ` +
+        `a literal fallback as the call's SIBLING (${distinct.size} distinct ` +
+        `key${distinct.size === 1 ? '' : 's'}) — the key exists, so nothing can ever reach the right ` +
+        'operand; delete it:',
+    );
+    for (const finding of siblings) {
+      console.error(`  ${finding.file}:${finding.line}:${finding.column}  [${finding.reason}]  ${finding.detail}`);
+      console.error(`      en renders:  ${quote(finding.expected)}`);
+      console.error(`      dead ${finding.operator} operand: ${quote(finding.actual)}`);
     }
   }
 


### PR DESCRIPTION
Fixes #4117

The other spelling of #3810's dead i18n fallback: not an argument of the call but its
**sibling**, one operator to the right of everything `scripts/check-i18n-call-site-keys.mjs`
used to read. `t('marketplace.detail.moreOptions') || 'More options'` carries no options
object at all, so the `default-value-drift` rule sees no `defaultValue` to compare and the
`interpolation-parity` rule sees an empty — and correct — argument set. `node.parent` is
what closes it.

## The ruling this implements

Delegated on the card, veto window open: **existence-is-red demanding deletion**, not
RHS-equality. The reasoning is that this fallback is dead on *every* path, which is one
step stronger than #3810's case:

- With a provider, i18next serves the pack value. Same as `defaultValue`.
- **Without** one, react-i18next's not-ready `t` returns the KEY — truthy — so `||` skips
  the fallback there too and the user reads a raw `console.objectView.delete`. Verified in
  source: `createSafeTranslation`'s provider-less path returns `defaults[key] || key`, also
  always truthy. `defaultValue` at least renders English there.

So the two spellings are not two ways to write one thing. Aligning these strings would have
blessed a second fallback spelling when the point is to keep one (`defaultValue`, governed
by `default-value-drift`).

## What changed

**The gate** — a fifth class, `dead-sibling-fallback`, hard from day one like classes 3 and
4. Also widens the file pre-filter to `t?.(`: `ContextSelectors.tsx` spells every call that
way and holds no `t(` at all, so the whole file used to fall out of **all five classes**
silently — a blind spot inside the thing being extended.

**The stock** — 24 sites measured on this tip (the card's count reproduces exactly), 22
judged and deleted across `MarketplacePackagePage.tsx` (16), `ObjectView.tsx` (5) and
`ActionResultDialog.tsx` (1).

## Where this diverges from the card: `ContextSelectors.tsx`

The card listed its two sites among the 24 and asked for `:409` to be counted-not-judged on
the grounds that its right operand is a variable. Measuring the call **shape** takes both of
them out for a stronger reason: they are **optional calls** on an optional prop
(`t?: (key: string, options?: any) =&gt; string`), so `t?.(key)` evaluates to `undefined`
whenever the prop is absent and the `??` fallback is **live**, not dead. Its own
`ContextSelectors.persist.test.tsx:128` renders the hook with no `t`. Deleting those two —
including `:411`, which the card listed as one of the five divergent rows — would have
replaced a rendered placeholder with `undefined`. They stay, counted as
`optionalCallFallbacks`, and the self-test pins the abstention.

## The five divergent rows: no rendering bug, verified per row

The card flagged these because a divergent fallback that also carried `{{holes}}` could have
been hiding an unfilled hole — a provider-mounted user reading raw `{{count}}`. Each was
checked against what the call actually passes; all were already wired, so **nothing renders
differently** and no params needed adding:

| site | `en` renders | call passes | before → after |
|---|---|---|---|
| `MarketplacePackagePage.tsx:429`/`:487` `purgeSuccess` | `Removed { {count} } sample record(s).` | `{ count: removed }` | `Removed 3 sample record(s).` → same |
| `MarketplacePackagePage.tsx:453` `reseedLocalSuccess` | `Re-seeded sample data: { {inserted} } inserted, { {updated} } updated.` | `{ inserted, updated }` | both filled → same |
| `MarketplacePackagePage.tsx:459` `reseedPartialErrors` (a sixth, not on the card's list) | `({ {count} } record(s) failed to write)` | `{ count: errored }` | filled → same |
| `ObjectView.tsx:939` `deleteViewConfirm` | `… delete the view "{ {name} }"? …` | `{ name: viewLabel }` | filled → same |
| `MarketplacePackagePage.tsx:680` `moreOptions` | `More install options` | — (no holes) | the `aria-label` already read the pack value → same |
| `ContextSelectors.tsx:411` `selectPlaceholder` | `Select { {label} }` | `{ label, defaultValue }` | **not deleted** — optional call |

#4136's `interpolation-parity` class agrees independently: it judges all 22 of these sites
and reports nothing in either direction, which is the mechanical proof that no hole is
unfilled and no argument inert.

*(Placeholder braces are spaced apart in this table only so GitHub's body sanitizer does not
eat them; the source uses the normal doubled form.)*

## The abstentions, each a decision

- **Optional call** — above. Not a parser limitation; a live path.
- **Non-literal right operand** (`t(key) || label`) — renders a runtime value, not a second
  copy of the sentence. Same treatment as a computed `defaultValue` in #3810.
- **Empty `en` value** — the one way a non-optional `t()` is falsy, so the class's premise
  fails. `en` has no such leaf today; the abstention stops the first one being a wrong red.
- **Plural families / dynamic keys / `returnObjects`** — the same key preconditions as
  classes 3 and 4.
- **Right-operand position** — `someValue || t(key)` is the healthy, opposite shape, and
  `main` carries **94** of those against these 24. A rule reading "appears in a `||`" rather
  than "is the left operand of one" would have condemned four times more than it fixed.

## Verification

- **Script self-test**: 64 passed (13 new).
- **Reverse verification, rule removed**: predicted the reds before running — the 5 RED
  cases plus the 5 counter-based abstention cases go red, **10 of 13**, and the 3 that stay
  green do so by construction (a source-level stock pin, the missing-key territory case, and
  the repo-wide "main carries none"). Measured: exactly `10 failed | 54 passed`.
- **Reverse verification, one stock site restored** (`ActionResultDialog.tsx`): the
  repo-wide run names exactly it — `ActionResultDialog.tsx:239:43 [dead-sibling-fallback]
  actions.resultDialog.copyAll`, counters moving `2 → 3` sites and `0 → 1` judged.
- **Repo-wide gate**: green. `Sibling fallbacks: 2 call site(s) sit left of a ||/?? — 0
  judged, 0 with a non-literal right operand, 2 an optional call (fallback is live), 0 with
  no single comparable en value.`
- **app-shell suite** (repo root): 318 files, 2969 passed, 1 skipped.
- **`pnpm type-check:scripts`** and **app-shell `type-check`**: clean.
- **ESLint**: 0 errors; warning counts on the three edited files identical to `origin/main`
  (12 / 144 / 0).

## Changeset

Empty frontmatter — declared as releasing nothing, with the per-row argument above. Removing
an operand that never evaluated leaves both the provider and provider-less paths
byte-identical.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_