### PR TITLE
docs(data-objectstack): declare CloudDeploymentConfig.environment a deliberate deploy-target vocabulary

### DIFF
--- a/.changeset/cloud-deploy-environment-vocabulary-3720.md
+++ b/.changeset/cloud-deploy-environment-vocabulary-3720.md
@@ -1,0 +1,12 @@
+---
+---
+
+`CloudDeploymentConfig.environment` is now declared a deliberate deploy-target vocabulary, with a pin test — no exported type changed, so nothing to release.
+
+objectui#3720 recorded that `packages/data-objectstack/src/cloud.ts` hand-writes a third environment spelling (`'development' | 'staging' | 'production'`) beside the two enums `@objectstack/spec` declares, and left the disposition open: converge onto a spec enum, or write the divergence down as deliberate.
+
+The measurement picked the second. There is no producer-side deploy-target type to converge onto — as of `@objectstack/client@17.0.0-rc.5` the client exports no `cloud` namespace at all, so `CloudOperations.deploy` optional-chains into `undefined` and no wire surface has ever accepted or rejected one of these values. Deriving from `EnvironmentType` instead would assert a subset relationship no producer confirms, and an `Extract` of three members degrades silently: the day spec drops one, the union loses it with no error anywhere. That is the drift the card was filed about, re-introduced in the shape of a fix.
+
+So the union is unchanged and the reasoning is now in the file: a doc comment naming both spec enums with their real member lists, why neither is imported, and the `staging` trap — `staging` is not a `DiscoveryEnvironment` member, and spec's own `NODE_ENV_TO_DISCOVERY_ENVIRONMENT` folds it onto `sandbox`, so a deploy target must never be copied onto a discovery response. `cloud-environment-vocabulary.pin.test.ts` makes each of those claims executable rather than decorative: the union members are pinned at compile time AND in source text (so a member added without touching the note goes red on the pair), the comment is pinned on the tokens that carry the reasoning, and the spec-side facts are pinned against the installed spec so a bump that moves either enum lands on the breakpoint the card named instead of drifting past it.
+
+No frontmatter: the exported `CloudDeploymentConfig` type is byte-identical, the change is a comment plus a test, and there is nothing for a consumer to react to.

--- a/packages/data-objectstack/src/cloud-environment-vocabulary.pin.test.ts
+++ b/packages/data-objectstack/src/cloud-environment-vocabulary.pin.test.ts
@@ -1,0 +1,204 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `CloudDeploymentConfig.environment` — deploy-target vocabulary pin
+ * (objectui#3720).
+ *
+ * The card recorded a third hand-written environment spelling sitting beside
+ * the two enums `@objectstack/spec` declares, and left the disposition open:
+ * converge onto a spec enum, or declare the divergence deliberate. The
+ * measurement decided it — there is no producer-side deploy-target type to
+ * converge ONTO. As of `@objectstack/client@17.0.0-rc.5` the client exports no
+ * `cloud` namespace at all, so `CloudOperations.deploy` optional-chains into
+ * `undefined`; nothing on the wire has ever accepted or rejected one of these
+ * values. Importing `EnvironmentType` instead would assert a subset
+ * relationship no producer confirms.
+ *
+ * So the list stays local and the deliberateness is written down — and this
+ * file is what stops "written down" from decaying into "stale". It pins the
+ * three facts a reader of that comment is entitled to trust:
+ *
+ *   1. the union really is those three members (compile time AND source text),
+ *   2. the comment really does still name both spec enums and the trap,
+ *   3. the spec-side facts the comment asserts are still true of the INSTALLED
+ *      spec — the member lists, and `staging` being outside the discovery
+ *      vocabulary.
+ *
+ * ## Why (1) is pinned twice
+ *
+ * The compile-time `Equal` pin catches a changed union; it cannot catch a
+ * changed union whose comment was left behind, because a comment is invisible
+ * to the checker. The source-text pin reads both out of the same file, so
+ * adding a member without touching the note goes red on the pair. Neither pin
+ * alone closes it — that is the "anchor on both" the card's dispatch asked for.
+ *
+ * ## Why the source is read through `ts.sys` rather than `node:fs`
+ *
+ * Same reason `spec-symbol-batch6.test.ts` gives: this package's `tsconfig.json`
+ * compiles its whole test tree, so keeping `@types/node` out of a browser-side
+ * adapter's type environment is deliberate. TypeScript's own system host is
+ * typed by the `typescript` devDependency this file already needs.
+ *
+ * ## When (3) goes red
+ *
+ * A spec bump moved an environment enum. That is not a reason to edit the
+ * expected list until the comment above `environment` has been re-read: this is
+ * exactly the drift breakpoint objectui#3720 asked to be alarmed on. If
+ * `staging` ever becomes a `DiscoveryEnvironment` member, the trap the comment
+ * warns about has been resolved upstream and the note must be rewritten, not
+ * the assertion relaxed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+
+import { DiscoveryEnvironmentSchema } from '@objectstack/spec/api';
+import { EnvironmentTypeSchema } from '@objectstack/spec/cloud';
+
+import type { CloudDeploymentConfig } from './cloud';
+
+/** The deploy targets this package declares, in declaration order. */
+const DEPLOY_TARGETS = ['development', 'staging', 'production'] as const;
+
+/** This file, as an absolute path — `cloud.ts` is its sibling. */
+const HERE = new URL(import.meta.url).pathname;
+const CLOUD_TS = HERE.replace(/[^/]+$/, 'cloud.ts');
+
+function cloudSource(): string {
+  const raw = ts.sys.readFile(CLOUD_TS);
+  if (!raw) throw new Error(`cannot read ${CLOUD_TS}`);
+  return raw;
+}
+
+const CLOUD_SOURCE = cloudSource();
+
+/** The `environment: …;` member declaration, matched off the interface body. */
+const DECLARATION_MATCH = /\n[ \t]*environment:[ \t]*([^;\n]+);/.exec(CLOUD_SOURCE);
+
+/**
+ * The doc block attached to that declaration — i.e. the last one closing before
+ * it. Deleting the note does not make this return nothing; it makes it return
+ * whatever block is now nearest, which will not carry the tokens below. Either
+ * way the comment assertions go red, which is the point.
+ */
+function environmentDocBlock(): string {
+  if (!DECLARATION_MATCH) return '';
+  const before = CLOUD_SOURCE.slice(0, DECLARATION_MATCH.index);
+  const open = before.lastIndexOf('/**');
+  const close = before.lastIndexOf('*/');
+  if (open < 0 || close < open) return '';
+  return before.slice(open, close + 2);
+}
+
+describe('the source probe itself works', () => {
+  it('found the `environment` member declaration in cloud.ts', () => {
+    expect(
+      DECLARATION_MATCH,
+      `cannot find an \`environment:\` member in ${CLOUD_TS}. If the field was ` +
+        `renamed or moved, every pin in this file is now vacuous — re-point it ` +
+        `rather than deleting it.`,
+    ).not.toBeNull();
+  });
+
+  it('found a doc block attached to it', () => {
+    expect(environmentDocBlock().length).toBeGreaterThan(200);
+  });
+});
+
+describe('the deploy-target union stays exactly three members', () => {
+  it('is what the source text declares', () => {
+    const spelled = (DECLARATION_MATCH?.[1] ?? '')
+      .split('|')
+      .map((part) => part.trim().replace(/^'|'$/g, ''));
+
+    expect(
+      spelled,
+      `\`CloudDeploymentConfig.environment\` changed members. This union is a ` +
+        `DELIBERATE third vocabulary (objectui#3720) and its doc comment states ` +
+        `exactly which members it has — change one and the other is now a lie. ` +
+        `Update the comment above the field and this list together, or converge ` +
+        `onto a real producer type if one has finally landed.`,
+    ).toEqual([...DEPLOY_TARGETS]);
+  });
+
+  it('is what the type declares', () => {
+    // Compile-time half of the same pin: `Equal` rather than `extends`, so a
+    // widening to `string` fails too.
+    type Assert<T extends true> = T;
+    type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+      ? true
+      : false;
+
+    type _ExactlyTheThreeTargets = Assert<
+      Equal<CloudDeploymentConfig['environment'], (typeof DEPLOY_TARGETS)[number]>
+    >;
+    type _NotWidenedToString = Assert<Equal<Equal<CloudDeploymentConfig['environment'], string>, false>>;
+
+    expect(true).toBe(true);
+  });
+});
+
+describe('the note that makes the divergence deliberate is still there', () => {
+  const REQUIRED_TOKENS: Array<[token: string, why: string]> = [
+    ['objectui#3720', 'the card that ruled this list a deliberate island'],
+    ['EnvironmentType', "spec's 7-member environment-registry taxonomy"],
+    ['DiscoveryEnvironment', "spec's 3-member discovery-posture enum"],
+    ['sandbox', 'the discovery member `staging` is NOT, and folds onto'],
+    ['@objectstack/client', 'the producer that would own a deploy-target type, and does not exist yet'],
+  ];
+
+  it.each(REQUIRED_TOKENS)('names `%s` (%s)', (token) => {
+    expect(
+      environmentDocBlock().includes(token),
+      `the doc comment on \`CloudDeploymentConfig.environment\` no longer mentions ` +
+        `\`${token}\`. That comment is the entire deliverable of objectui#3720: ` +
+        `without it this union is indistinguishable from the accidental third ` +
+        `spelling the card filed. Restore the reasoning, do not delete the pin.`,
+    ).toBe(true);
+  });
+});
+
+describe("the spec-side facts the comment asserts are still true of the installed spec", () => {
+  it('DiscoveryEnvironment is still the three coarse postures', () => {
+    expect(
+      [...DiscoveryEnvironmentSchema.options],
+      `@objectstack/spec's \`DiscoveryEnvironmentSchema\` moved. Re-read the ` +
+        `comment on \`CloudDeploymentConfig.environment\` before touching this ` +
+        `expectation — objectui#3720 named this the drift breakpoint.`,
+    ).toEqual(['production', 'sandbox', 'development']);
+  });
+
+  it('EnvironmentType is still the seven-member registry taxonomy', () => {
+    expect(
+      [...EnvironmentTypeSchema.options],
+      `@objectstack/spec's \`EnvironmentTypeSchema\` moved. The comment on ` +
+        `\`CloudDeploymentConfig.environment\` quotes this member list verbatim; ` +
+        `update both together.`,
+    ).toEqual(['production', 'sandbox', 'development', 'test', 'staging', 'preview', 'trial']);
+  });
+
+  it('`staging` is rejected by the discovery vocabulary — the trap the comment warns about', () => {
+    expect(
+      DiscoveryEnvironmentSchema.safeParse('staging').success,
+      `\`staging\` is now accepted by \`DiscoveryEnvironmentSchema\`. The trap the ` +
+        `comment warns about (a deploy target must not be copied onto a discovery ` +
+        `response) has changed shape — rewrite the note rather than relaxing this.`,
+    ).toBe(false);
+  });
+
+  it('every deploy target is nonetheless a valid EnvironmentType member', () => {
+    // Not a derivation and not a mapping — a recorded fact. The day it stops
+    // being true, the comment's table is wrong.
+    for (const target of DEPLOY_TARGETS) {
+      expect(EnvironmentTypeSchema.safeParse(target).success, `EnvironmentType lost \`${target}\``).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/packages/data-objectstack/src/cloud.ts
+++ b/packages/data-objectstack/src/cloud.ts
@@ -12,7 +12,52 @@
  */
 
 export interface CloudDeploymentConfig {
-  /** Target environment */
+  /**
+   * Deploy target requested by {@link CloudOperations.deploy}.
+   *
+   * **A deliberate third vocabulary — not drift** (objectui#3720). It is
+   * neither of the two environment enums `@objectstack/spec` declares, and the
+   * pin test next door (`cloud-environment-vocabulary.pin.test.ts`) keeps every
+   * claim below executable rather than merely written down:
+   *
+   * | vocabulary | members | models |
+   * |:--|:--|:--|
+   * | `EnvironmentType` (`@objectstack/spec/cloud`) | `production` `sandbox` `development` `test` `staging` `preview` `trial` | the categorical tag of a provisioned `sys_environment` row |
+   * | `DiscoveryEnvironment` (`@objectstack/spec/api`) | `production` `sandbox` `development` | the coarse posture a `/discovery` response advertises — "am I talking to production?" |
+   * | this list | `development` `staging` `production` | the target a deploy REQUEST asks for |
+   *
+   * ## Why nothing is imported from either
+   *
+   * Neither models a deploy target. The producer that would own that vocabulary
+   * is the cloud deploy API itself — and as of `@objectstack/client@17.0.0-rc.5`
+   * that API does not exist: the client exports no `cloud` namespace at all, so
+   * `deploy()` below optional-chains into `undefined` and returns its synthetic
+   * pending result. There is no producer-side type to derive from, and no
+   * accepted vocabulary to measure this list against.
+   *
+   * Restating it as a subset of `EnvironmentType` (an `Extract` of those three
+   * members) was considered and rejected twice over. It would assert a subset
+   * relationship no producer confirms; and `Extract` degrades SILENTLY — the day
+   * spec drops or renames a member, this union quietly loses it with no error
+   * anywhere, which is the drift this note exists to prevent.
+   *
+   * ## The `staging` trap
+   *
+   * `staging` is NOT a `DiscoveryEnvironment` member. Spec's own
+   * `NODE_ENV_TO_DISCOVERY_ENVIRONMENT` (`src/api/discovery.zod.ts`) folds a raw
+   * `staging` onto `sandbox`, because `sandbox` is that enum's pre-production
+   * member. So a value of this field must never be copied onto a discovery
+   * response — and no mapping between the two is invented here, because they
+   * answer different questions.
+   *
+   * ## When to revisit
+   *
+   * When a real deploy API lands — a `cloud` surface on `@objectstack/client`,
+   * or a deploy-target enum in spec — converge onto ITS type and delete this
+   * note. That is also the moment objectui#3720 named as the breakpoint: if
+   * deploy targets and discovery postures ever have to interconvert, the
+   * conversion belongs at the producer, not in a consumer-side guess.
+   */
   environment: 'development' | 'staging' | 'production';
   /** Cloud region */
   region?: string;


### PR DESCRIPTION
Fixes #3720

The card recorded a third hand-written environment spelling in `packages/data-objectstack/src/cloud.ts` beside the two enums `@objectstack/spec` declares, and deliberately left the disposition open: converge onto a spec enum, or write the divergence down as deliberate. This PR takes the second option, because the measurement ruled out the first.

## Premise: still valid, with two details of the body now stale

`cloud.ts:16` still hand-writes `'development' | 'staging' | 'production'`, and it is still a third vocabulary matching neither spec enum. Two parentheticals in the issue body have drifted against the installed `@objectstack/spec@17.0.0-rc.5`, and neither changes the verdict:

- The body describes `DiscoveryEnvironment` as `development`/`test`/`sandbox`/`production`. The installed enum has **three** members — `production`, `sandbox`, `development`. There is no `test` member; a raw `NODE_ENV=test` folds onto `development`.
- The body cites the warning as living in spec's `api/environment.zod.ts`. It is in `api/discovery.zod.ts`, in the `NODE_ENV_TO_DISCOVERY_ENVIRONMENT` table.

Also checked and **not** found: objectstack#6610's `preview`/`trial` fold onto `sandbox` is not present anywhere in the installed rc.5 spec. The only fold shipped is the raw-`NODE_ENV` table above, which is keyed on operator-supplied strings rather than on `EnvironmentType` members. No `EnvironmentType` to `DiscoveryEnvironment` conversion exists in spec at all.

The core claim — a third spelling, and `staging` not being usable as a discovery value — holds in full.

## What the measurement found

The deciding question was what the deploy API's accepted vocabulary actually is. It has none, because the API does not exist:

- The installed `@objectstack/client@17.0.0-rc.5` exports **no `cloud` namespace whatsoever**. Its export list is `ObjectStackClient`, `ScopedProjectClient`, `RealtimeAPI`, `QueryBuilder`, `FilterBuilder` and their types; there is no `deploy`, no deployment-config type, no marketplace surface.
- `CloudOperations.deploy` therefore optional-chains through `client.cloud?.deploy?.(…)` against an `any`, always resolves `undefined`, and returns its synthetic `{ deploymentId, status: 'pending' }` fallback. Nothing on any wire has ever accepted or rejected one of these three values.

The two spec enums, read off the resolved install:

| vocabulary | members | models |
|:--|:--|:--|
| `EnvironmentType` (`@objectstack/spec/cloud`) | `production` `sandbox` `development` `test` `staging` `preview` `trial` | the categorical tag of a provisioned `sys_environment` row |
| `DiscoveryEnvironment` (`@objectstack/spec/api`) | `production` `sandbox` `development` | the coarse posture a `/discovery` response advertises |
| this list | `development` `staging` `production` | the target a deploy request asks for |

So the dispatch's branch condition resolved to "no producer-side type exists" and this is direction 2.

## Why not converge anyway

The local union happens to be an exact subset of `EnvironmentType`, so `Extract< EnvironmentType, 'development' | 'staging' | 'production' >` was the tempting move. Rejected twice over:

1. It asserts a subset relationship **no producer confirms**. `EnvironmentType` is documented as the categorical tag of an environment registry row — a different concept from a deploy target, as the card itself insists.
2. `Extract` degrades **silently**. The day spec drops or renames a member, that member vanishes from this union with no type error anywhere — the exact drift the card was filed about, re-introduced in the shape of a fix.

No mapping onto the discovery vocabulary is invented, per the card.

## What landed

- The doc comment on `CloudDeploymentConfig.environment` now states the deliberateness: both spec enums with their real member lists, why neither is imported, the `staging` trap (`staging` is not a `DiscoveryEnvironment` member — spec folds it onto `sandbox`, so this value must never be copied onto a discovery response), and the revisit condition. It ships in the emitted `.d.ts`, so consumers see the reasoning in tooltips.
- `packages/data-objectstack/src/cloud-environment-vocabulary.pin.test.ts` — 13 assertions keeping every claim executable. The union is pinned **twice**, at compile time and in source text, because a checker cannot see a comment: adding a member without touching the note goes red on the pair. The comment is pinned on its load-bearing tokens, and the spec-side facts are pinned against the installed spec so a bump that moves either enum lands on the breakpoint the card named.
- The exported type is **byte-identical** — the only removed line is the old `/** Target environment */`. Changeset is the empty-frontmatter form; `check-changeset-presence.mjs` reports that as "the explicit exemption and a complete answer to this gate".

## Reverse verification

Both directions were predicted before running, and both landed as predicted.

- **Silently add a member** (`| 'preview'`, comment untouched): source-text pin red — `expected [ 'development', 'staging', …(2) ] to deeply equal [ 'development', 'staging', …(1) ]` — and `tsc` red at the compile-time half, `error TS2344: Type 'false' does not satisfy the constraint 'true'`. The five comment-token assertions stayed green, which is correct: the comment was not touched, and the **pair** is what catches this.
- **Restore the original one-line comment** (union untouched): 6 red — all five comment tokens plus the doc-block probe. This is the strongest form available here: the pre-change state of the file fails the new test.

Restored, then re-verified green.

## Verification

- `pnpm --filter '@object-ui/data-objectstack^...' build` (upstream closure, suffix filter, run first per the stale-artefact trap) — `packages/types`, `packages/core` Done.
- `pnpm --filter '@object-ui/data-objectstack' type-check` — clean (`tsc --noEmit`; this package compiles its whole test tree, so the compile-time pins are load-bearing without a separate `tsconfig.typetests.json`).
- `pnpm vitest run packages/data-objectstack` — **26 files, 385 tests passed**; the new file contributes 13.
- `pnpm --filter '@object-ui/data-objectstack' lint` — **0 errors** (346 pre-existing `any` warnings package-wide). The two `no-unused-vars` warnings on the compile-time type aliases are the identical pattern the sibling `spec-symbol-batch6.test.ts` already produces.
- Consumer sweep, **downstream direction** (prefix filter `...@object-ui/data-objectstack`, 20+ packages): the type is byte-identical and the only references to `CloudDeploymentConfig` in the whole repo are its own declaration and the `index.ts` re-export, so there is nothing for a consumer to react to. `@object-ui/app-shell` and `@object-ui/react` type-check green as a spot check — after building their closure, since the first attempt hit the stale-artefact trap on an unbuilt `@object-ui/i18n`.
- `node scripts/check-control-bytes.mjs` — OK (3836 files). `check-changeset-presence` / `-no-major` / `-fixed` — all green.
- Package `build` green; the test file does not leak into `dist`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_