### PR TITLE
docs: repair QUICK_REFERENCE's dead commands and layout claims, and pin them (#4149)

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -9,7 +9,7 @@ A one-page cheat-sheet for working in the `objectui` monorepo.
 ```bash
 pnpm install              # Install all workspace dependencies
 pnpm build                # Build every package (turbo, parallel & cached)
-pnpm typecheck            # Run tsc --noEmit across the workspace
+pnpm type-check           # Run tsc --noEmit across the workspace (turbo)
 pnpm lint                 # Run eslint across the workspace
 ```
 
@@ -29,7 +29,7 @@ pnpm test                                              # Run every vitest projec
 pnpm exec vitest run packages/core/                    # Run a single package's tests
 pnpm exec vitest run packages/core/src/<file>.test.ts  # Run a single test file
 pnpm exec vitest run apps/console/                     # Run just the console tests
-pnpm playwright test                                   # End-to-end tests
+pnpm test:e2e                                          # End-to-end tests (playwright)
 ```
 
 Not `pnpm --filter <pkg> test`, not `turbo run test`, not `cd packages/x && pnpm exec
@@ -53,10 +53,14 @@ Details in [AGENTS.md](./AGENTS.md) (“怎么跑测试”) and `scripts/vitest-
 ### Run Examples
 
 ```bash
-pnpm --filter @object-ui/example-crm dev          # CRM demo
-pnpm --filter @object-ui/example-todo dev         # Todo demo
-pnpm --filter @object-ui/example-kitchen-sink dev # Kitchen-sink showcase
+pnpm --filter @object-ui/example-console-starter dev     # Fork-ready ObjectStack console
+pnpm --filter @object-ui/example-byo-backend-console dev # ObjectUI on your own backend
 ```
+
+Those are the only two dev servers under `examples/`: `hello-world` is a snippet to paste
+into your own app and `schema-catalog` is a data package, so neither declares a `dev`
+script. [`examples/README.md`](./examples/README.md) is the index — which one to pick,
+what to build first, and the port each one serves on.
 
 ### Release (via changesets)
 
@@ -70,11 +74,10 @@ pnpm changeset publish         # Publish to npm (CI only)
 
 | Path | Purpose |
 | --- | --- |
-| `packages/*` | 39 published packages (`@object-ui/*`) |
+| `packages/*` | 38 published packages (`@object-ui/*`), plus the private `vscode-extension` |
 | `apps/console` | Full ObjectUI console app (Vite + React) |
 | `apps/site` | Public docs site at <https://www.objectui.org> (fumadocs) |
-| `apps/server` | Vercel backend for `demo.objectstack.ai` |
-| `examples/*` | Runnable integration examples (CRM, todo, byo-backend-console, console-starter, …) |
+| `examples/*` | Runnable examples and the schema catalog — see [`examples/README.md`](./examples/README.md) |
 | `content/docs/` | MDX source for the docs site |
 | `e2e/` | Playwright end-to-end tests |
 | `.changeset/` | Pending release notes |
@@ -91,7 +94,7 @@ pnpm changeset publish         # Publish to npm (CI only)
 | Plugins | `packages/plugin-*` | Heavy view widgets (grid, kanban, charts, …) |
 | Runtime | `packages/react`, `packages/runner` | React bindings & bootstrap |
 | Adapters | `packages/data-objectstack`, `packages/providers` | Data source integration |
-| Platform | `packages/auth`, `packages/permissions`, `packages/tenant`, `packages/i18n`, `packages/mobile`, `packages/collaboration` | Cross-cutting concerns |
+| Platform | `packages/auth`, `packages/permissions`, `packages/i18n`, `packages/mobile`, `packages/collaboration` | Cross-cutting concerns |
 | Tooling | `packages/cli`, `packages/create-plugin`, `packages/vscode-extension` | Developer experience |
 
 ## Key Documents

--- a/scripts/__tests__/quick-reference-commands-4149.test.ts
+++ b/scripts/__tests__/quick-reference-commands-4149.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#4149: `QUICK_REFERENCE.md`'s command and layout sections were dead.
+ *
+ * objectui#4143 repaired and pinned the file's "Current Release" block, and argued the
+ * rest of the page was observation-class because "no copy-pasteable instruction is
+ * wrong". On the tree that landed it, four of them were — and this is the worse class,
+ * because a stale version number misleads while a dead command simply fails:
+ *
+ *   - `pnpm typecheck` → `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "typecheck" not
+ *     found. Did you mean "pnpm type-check"?` There has never been a `typecheck` script.
+ *   - all three documented `example-*` dev commands named packages that do not exist
+ *     (`example-crm`, `example-todo`, `example-kitchen-sink`), while the two examples
+ *     that DO run dev servers went unmentioned. Worse than an error: pnpm prints
+ *     `No projects matched the filters` and exits **0**, so a script following this
+ *     page succeeds while doing nothing.
+ *   - `apps/server` was listed in the Repository Layout table; `apps/` holds `console`
+ *     and `site`.
+ *   - `packages/tenant` was listed in the Package Tiers table; that package was deleted
+ *     by objectui#2564 (commit d5b1bc0b4).
+ *
+ * ## Why this is a sibling file and not more `it`s in the #4143 pin
+ *
+ * `quick-reference-current-release-4143.test.ts` is scoped, in its own words, to the
+ * `## Current Release` section — deliberately, because "`## Repository Layout` above it
+ * also carries numbers, and asserting over the whole file would conflate a status claim
+ * with a package count". That scoping is load-bearing for its reverse direction (no
+ * un-derived version literal), which would go red on this page's ports and counts if it
+ * were widened. So the two files split by section, and this one never reads
+ * `## Current Release`.
+ *
+ * ## What is pinned here, and what is deliberately not
+ *
+ * Pinned: everything with a machine anchor — script names (root `package.json`
+ * `scripts`), workspace package names and their scripts (the `pnpm-workspace.yaml`
+ * globs), filesystem paths, the published-package count, and the internal links (this
+ * file sits outside every `SCAN_ROOTS` entry in `scripts/check-doc-links.mjs`, so
+ * nothing else resolves them).
+ *
+ * Not pinned, on purpose: the prose descriptions, the comment text after each command,
+ * and the dev-server ports of the examples — a port lives in a `vite.config.ts`
+ * `server.port` that not every example sets, so the page points at
+ * `examples/README.md` instead of quoting numbers it cannot derive. The rule this file
+ * follows is the one #4143 established: derive the expectation from the anchor, never
+ * write the value a second time.
+ *
+ * There is also no reverse "every root script must be documented" direction. The root
+ * manifest declares ~50 scripts and this is a one-page cheat-sheet; requiring it to
+ * enumerate them would turn a curated page into a generated one, and the failure this
+ * card is about is a documented command that does not exist, not an existing command
+ * that is undocumented.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const docRel = 'QUICK_REFERENCE.md';
+const doc = fs.readFileSync(path.join(repoRoot, docRel), 'utf8');
+
+interface Manifest {
+  name?: string;
+  private?: boolean;
+  scripts?: Record<string, string>;
+}
+
+function manifest(rel: string): Manifest {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, rel), 'utf8')) as Manifest;
+}
+
+const rootScripts = new Set(Object.keys(manifest('package.json').scripts ?? {}));
+
+/**
+ * The `packages:` globs from `pnpm-workspace.yaml`, read rather than hardcoded, in the
+ * shape `package-files-exist.test.ts` and `react-peer-range-norm-3741.test.ts` already
+ * use here: understand the two syntaxes the file actually uses and throw on anything
+ * else, because a guard that silently stops looking at part of the workspace goes on
+ * reporting success over a shrinking surface.
+ */
+function workspaceGlobs(): string[] {
+  const yaml = fs.readFileSync(path.join(repoRoot, 'pnpm-workspace.yaml'), 'utf8');
+  const lines = yaml.split('\n');
+  const start = lines.findIndex((l) => /^packages:\s*$/.test(l));
+  expect(start, '`pnpm-workspace.yaml` must still declare a top-level `packages:` key').toBeGreaterThan(-1);
+
+  const globs: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    if (!/^\s/.test(line)) break; // a non-indented line ends the block
+    const match = line.match(/^\s*-\s*['"]?([^'"#\s]+)['"]?\s*(#.*)?$/);
+    if (!match) {
+      throw new Error(
+        `Unparsed entry in pnpm-workspace.yaml \`packages:\`: ${JSON.stringify(line)} — teach this guard the new syntax.`,
+      );
+    }
+    globs.push(match[1]);
+  }
+  return globs;
+}
+
+interface WorkspacePackage {
+  /** Repo-relative directory, e.g. `examples/console-starter`. */
+  dir: string;
+  name: string;
+  private: boolean;
+  scripts: Set<string>;
+}
+
+function readWorkspacePackages(): WorkspacePackage[] {
+  const found: WorkspacePackage[] = [];
+
+  for (const glob of workspaceGlobs()) {
+    let dirs: string[];
+    if (glob.endsWith('/*')) {
+      const parent = path.join(repoRoot, glob.slice(0, -2));
+      dirs = fs.existsSync(parent)
+        ? fs
+            .readdirSync(parent)
+            .map((d) => path.join(parent, d))
+            .filter((d) => fs.statSync(d).isDirectory())
+        : [];
+    } else if (!glob.includes('*')) {
+      dirs = [path.join(repoRoot, glob)];
+    } else {
+      throw new Error(`Unsupported workspace glob ${JSON.stringify(glob)} — teach this guard how to expand it.`);
+    }
+
+    for (const dir of dirs) {
+      const pkgPath = path.join(dir, 'package.json');
+      if (!fs.existsSync(pkgPath)) continue;
+      const json = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Manifest;
+      if (!json.name) continue;
+      found.push({
+        dir: path.relative(repoRoot, dir).split(path.sep).join('/'),
+        name: json.name,
+        private: json.private === true,
+        scripts: new Set(Object.keys(json.scripts ?? {})),
+      });
+    }
+  }
+
+  return found;
+}
+
+const workspacePackages = readWorkspacePackages();
+const byName = new Map(workspacePackages.map((p) => [p.name, p]));
+
+/**
+ * A section of the page, from its heading to the next heading of the same or higher
+ * level. Used to scope the two reverse directions to the block that owns the claim.
+ */
+function section(heading: string): string {
+  const lines = doc.split('\n');
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start === -1) throw new Error(`${docRel} must still have a "${heading}" heading`);
+
+  const level = (heading.match(/^#+/) as RegExpMatchArray)[0].length;
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => /^#{1,6} /.test(line) && (line.match(/^#+/) as RegExpMatchArray)[0].length <= level);
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/**
+ * Commands this page tells a reader to run: the ` ```bash ` fences only.
+ *
+ * The page also quotes one plain ``` fence — the vitest guard's rejection message,
+ * which is program output rather than an instruction authored here. It is pinned
+ * against its own source below instead, so that quoting it verbatim stays honest
+ * without this parser having to tell the two kinds of block apart by their content.
+ */
+function documentedCommands(): string[] {
+  const out: string[] = [];
+  for (const block of doc.matchAll(/```bash\n([\s\S]*?)```/g)) {
+    for (const raw of block[1].split('\n')) {
+      const command = raw.replace(/\s+#.*$/, '').trim();
+      if (command.startsWith('pnpm ') || command === 'pnpm') out.push(command);
+    }
+  }
+  return out;
+}
+
+const commands = documentedCommands();
+
+/** pnpm's own subcommands, which are not root scripts and are not ours to check. */
+const PNPM_BUILTINS = new Set(['install', 'exec', 'dlx', 'add', 'remove', 'run', 'why', 'ls', 'store']);
+
+describe('QUICK_REFERENCE.md — every documented `pnpm` command exists', () => {
+  it('finds commands to check at all', () => {
+    // Guards the parser, not the doc: a fence-syntax change that made
+    // `documentedCommands()` return nothing would turn every assertion below into a
+    // vacuous pass, which is the failure mode a doc gate can least afford.
+    expect(commands.length, `${docRel} must still document \`pnpm\` commands in \`\`\`bash fences`).toBeGreaterThan(5);
+  });
+
+  it('names only scripts the root `package.json` declares', () => {
+    const dead: string[] = [];
+
+    for (const command of commands) {
+      const tokens = command.split(/\s+/).slice(1);
+      if (tokens.length === 0) continue;
+      if (tokens[0] === '--filter' || tokens[0].startsWith('-')) continue; // covered by the filter test
+      const [first] = tokens;
+      if (PNPM_BUILTINS.has(first)) continue;
+      if (!rootScripts.has(first)) dead.push(`${command}   (no root script "${first}")`);
+    }
+
+    expect(
+      dead,
+      `${docRel} documents ${JSON.stringify(dead)}. Each is a copy-pasteable line that fails: ` +
+        'the root `package.json` `scripts` block is the anchor, and `pnpm typecheck` (objectui#4149) ' +
+        `is what happens when nothing checks it. Declared scripts: ${JSON.stringify([...rootScripts].sort())}.`,
+    ).toEqual([]);
+  });
+
+  it('filters on workspace packages that exist and declare the script it runs', () => {
+    const broken: string[] = [];
+
+    for (const command of commands) {
+      const tokens = command.split(/\s+/);
+      const at = tokens.indexOf('--filter');
+      if (at === -1) continue;
+
+      const selector = tokens[at + 1];
+      const script = tokens.slice(at + 2).find((t) => !t.startsWith('-'));
+      const pkg = byName.get(selector);
+
+      if (!pkg) {
+        broken.push(`${command}   (no workspace package named "${selector}")`);
+        continue;
+      }
+      if (script && !pkg.scripts.has(script)) {
+        broken.push(`${command}   ("${selector}" declares no "${script}" script)`);
+      }
+    }
+
+    expect(
+      broken,
+      `${docRel} documents ${JSON.stringify(broken)}. A filter that matches nothing is the ` +
+        'objectui#4149 defect in its worst form: pnpm prints "No projects matched the filters" and ' +
+        `exits 0, so a reader's script "succeeds". Workspace packages: ${JSON.stringify([...byName.keys()].sort())}.`,
+    ).toEqual([]);
+  });
+});
+
+describe('QUICK_REFERENCE.md — the "Run Examples" section covers the examples that run', () => {
+  /**
+   * The reverse direction, and the one that would have caught this card before it was
+   * filed. The forward test above only says the documented examples exist; it stays
+   * green on a page that documents nothing. What was actually wrong is that the two
+   * runnable examples were BOTH missing while three phantoms were listed.
+   *
+   * "Runnable" is derived, not judged: an `examples/*` package is a dev server exactly
+   * when its manifest declares a `dev` script. `hello-world` (a snippet) and
+   * `schema-catalog` (a data package) declare none, so they are correctly absent from
+   * the command block — and the day either grows one, this goes red.
+   */
+  it('documents a dev command for every `examples/*` package that declares one', () => {
+    const runnable = workspacePackages.filter((p) => p.dir.startsWith('examples/') && p.scripts.has('dev'));
+    expect(
+      runnable.length,
+      'no `examples/*` package declares a `dev` script any more — the "Run Examples" section ' +
+        'is now describing something that does not exist and needs rewriting, not re-pinning',
+    ).toBeGreaterThan(0);
+
+    const block = section('### Run Examples');
+    const missing = runnable.filter((p) => !block.includes(`--filter ${p.name} dev`));
+
+    expect(
+      missing.map((p) => p.name),
+      `${docRel}'s "Run Examples" section documents no \`pnpm --filter <name> dev\` line for ` +
+        `${JSON.stringify(missing.map((p) => p.dir))}. Before objectui#4149 this section listed three ` +
+        'packages that did not exist and neither of the two that did, so a newcomer following it got ' +
+        'nothing runnable at all.',
+    ).toEqual([]);
+  });
+});
+
+describe('QUICK_REFERENCE.md — every path it names is in the tree', () => {
+  /**
+   * A path claim, in the spellings this page uses: an inline-code span with no
+   * whitespace and at least one `/`. Placeholders (`packages/<pkg>/`) and package names
+   * (`@object-ui/site`, `@objectstack/spec`) are excluded by construction rather than by
+   * an allowlist — the first carry angle brackets, the second start with `@`.
+   */
+  const PATH_LIKE = /`([^`\s]+)`/g;
+
+  function pathClaims(): string[] {
+    const out = new Set<string>();
+    for (const match of doc.matchAll(PATH_LIKE)) {
+      const token = match[1];
+      if (token.includes('<') || token.includes('>')) continue;
+      if (token.startsWith('@') || token.includes('://')) continue;
+      if (token.includes('/')) out.add(token);
+      else if (/^[\w.-]+\.(md|mjs|mts|ts|json|yaml)$/.test(token)) out.add(token);
+    }
+    return [...out];
+  }
+
+  it('resolves every path in a code span, and every glob to at least one directory', () => {
+    const claims = pathClaims();
+    expect(claims.length, `${docRel} must still name paths in code spans`).toBeGreaterThan(5);
+
+    const dead: string[] = [];
+    for (const claim of claims) {
+      const cleaned = claim.replace(/\/$/, '');
+      if (cleaned.includes('*')) {
+        const dir = path.dirname(cleaned);
+        const pattern = new RegExp(`^${path.basename(cleaned).replace(/\*/g, '.*')}$`);
+        const parent = path.join(repoRoot, dir);
+        const matches = fs.existsSync(parent) ? fs.readdirSync(parent).filter((e) => pattern.test(e)) : [];
+        if (matches.length === 0) dead.push(`${claim}   (matches nothing)`);
+        continue;
+      }
+      if (!fs.existsSync(path.join(repoRoot, cleaned))) dead.push(`${claim}   (not in the tree)`);
+    }
+
+    expect(
+      dead,
+      `${docRel} names ${JSON.stringify(dead)}. objectui#4149 found two of these: \`apps/server\`, ` +
+        'gone with the Vercel backend, and `packages/tenant`, deleted by objectui#2564 — both still ' +
+        'sitting in tables that a reader uses to navigate the repo.',
+    ).toEqual([]);
+  });
+
+  /**
+   * The reverse direction for `apps/`, which the layout table enumerates one row per
+   * app (unlike `packages/*`, which it summarises). Forward catches a row whose app was
+   * deleted; this catches an app that was added and never listed — the same rot, one
+   * direction over.
+   */
+  it('gives every directory under `apps/` a row in the Repository Layout table', () => {
+    const layout = section('## Repository Layout');
+    const apps = fs
+      .readdirSync(path.join(repoRoot, 'apps'), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => `apps/${e.name}`);
+
+    const unlisted = apps.filter((app) => !layout.includes(`\`${app}\``));
+    expect(
+      unlisted,
+      `${docRel}'s Repository Layout table has no row for ${JSON.stringify(unlisted)}. The table ` +
+        'lists apps individually, so a new one is invisible to a reader until someone adds it.',
+    ).toEqual([]);
+  });
+});
+
+describe('QUICK_REFERENCE.md — the published-package count is derived', () => {
+  /**
+   * The count kept a number rather than becoming a pointer, because unlike a churning
+   * enumeration it has an exact anchor (`private` in each manifest) and it tells the
+   * reader something a pointer cannot: the scale of the repo. What it may not do is be
+   * written by hand — "39 published packages" counted directories, and
+   * `packages/vscode-extension` (published to the VS Code marketplace, not to npm) is
+   * `private: true`. Off by one, in the direction that overstates.
+   */
+  const packagesRow = (): string => {
+    const layout = section('## Repository Layout');
+    const row = layout.split('\n').find((line) => line.startsWith('| `packages/*` |'));
+    expect(row, `${docRel}'s Repository Layout table must still have a \`packages/*\` row`).toBeDefined();
+    return row as string;
+  };
+
+  const inPackages = workspacePackages.filter((p) => p.dir.startsWith('packages/'));
+  const published = inPackages.filter((p) => !p.private);
+  const privateOnes = inPackages.filter((p) => p.private);
+
+  it('states the number of packages that are actually published', () => {
+    expect(
+      packagesRow(),
+      `${docRel} must state "${published.length} published packages" — that is how many manifests ` +
+        `under \`packages/\` are not \`private: true\` (${inPackages.length} directories, ` +
+        `${privateOnes.length} of them private: ${JSON.stringify(privateOnes.map((p) => p.dir))})`,
+    ).toContain(`${published.length} published`);
+  });
+
+  it('accounts for the private packages instead of quietly dropping them', () => {
+    if (privateOnes.length === 0) {
+      // Nothing to reconcile: the count and the directory listing agree, so the row
+      // saying only "N published packages" is complete. This branch exists so the
+      // requirement below retires itself the day the last private package leaves.
+      return;
+    }
+
+    const row = packagesRow();
+    expect(
+      row,
+      `${docRel}'s \`packages/*\` row states a published count that is smaller than the ` +
+        `${inPackages.length} directories a reader sees there. It must say why — name the private ` +
+        `package(s) ${JSON.stringify(privateOnes.map((p) => p.name))} — or the next reader "corrects" ` +
+        'the number back to the directory count, which is exactly how objectui#4149 happened.',
+    ).toMatch(/private/i);
+
+    for (const pkg of privateOnes) {
+      expect(row, `${docRel}'s \`packages/*\` row must name the private package "${pkg.dir}"`).toContain(
+        path.basename(pkg.dir),
+      );
+    }
+  });
+
+  it('keeps the `@object-ui/*` parenthetical true', () => {
+    const misnamed = published.filter((p) => !p.name.startsWith('@object-ui/'));
+    expect(
+      misnamed.map((p) => `${p.dir} → ${p.name}`),
+      `${docRel}'s \`packages/*\` row calls the published packages \`@object-ui/*\`, but these are not`,
+    ).toEqual([]);
+  });
+});
+
+describe('QUICK_REFERENCE.md — internal links resolve', () => {
+  /**
+   * Nothing else checks them. `scripts/check-doc-links.mjs` scans seven roots
+   * (`content/docs`, `examples`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs`,
+   * and each package README) and this page is in none of them — the same hole
+   * objectui#4148 recorded for `apps/**`. Widening `SCAN_ROOTS` is that card's business;
+   * this keeps the page honest in the meantime, at the cost of four lines.
+   */
+  it('points every relative link at something in the tree', () => {
+    const dead: string[] = [];
+    for (const match of doc.matchAll(/\[[^\]]*\]\((\.[^)]+)\)/g)) {
+      const target = match[1].split('#')[0];
+      if (target === '') continue;
+      if (!fs.existsSync(path.join(repoRoot, target))) dead.push(target);
+    }
+
+    expect(dead, `${docRel} links to ${JSON.stringify(dead)}, which ${dead.length === 1 ? 'is' : 'are'} not in the tree`).toEqual(
+      [],
+    );
+  });
+});
+
+describe('QUICK_REFERENCE.md — the quoted vitest-guard message is still what the guard prints', () => {
+  /**
+   * The page quotes the guard's rejection box so a reader recognises it. Two of the five
+   * quoted lines are built by interpolation in `canonicalLines()`
+   * (`  pnpm exec vitest run ${file}   # 只跑一个文件`), so they are not literals in the
+   * source and are not asserted here — that is the "brittle prose stays unpinned rather
+   * than force-parsed" half of objectui#4149. The three that ARE literals are asserted,
+   * which is enough to catch the guard being reworded out from under the quote.
+   */
+  it('quotes lines that appear verbatim in `scripts/vitest-invocation-guard.mjs`', () => {
+    const guardRel = 'scripts/vitest-invocation-guard.mjs';
+    const guard = fs.readFileSync(path.join(repoRoot, guardRel), 'utf8');
+
+    const quoted = ['vitest 调用被拒绝:从包目录跑 vitest 会静默跑错测试集 (objectui#3378)', 'pnpm test   # 全量'];
+
+    for (const line of quoted) {
+      expect(doc, `${docRel} must still quote the guard line ${JSON.stringify(line)}`).toContain(line);
+      expect(
+        guard,
+        `${docRel} quotes ${JSON.stringify(line)} as the guard's output, but ${guardRel} no longer ` +
+          'contains that text — the quote has drifted from the program it claims to reproduce',
+      ).toContain(line);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #4149

## Ordering

PR #4150 (same file, armed for auto-merge) **merged** as `43b2e4565` before this started, so this branches off `main` rather than stacking on `claude/issue-4143-console-version-drift`. The `## Current Release` block that PR repaired and pinned is untouched here, and its test stays green.

## Premise: valid, and it under-reported

All four claims on the card reproduce on `43b2e4565`. Sweeping the rest of the page — the card says its list is the floor — found **two more**, one of them the same class as `apps/server`:

- `packages/tenant` sits in the Package Tiers table. That package was deleted by objectui#2564 (commit `d5b1bc0b4`, "drop zero-consumer @object-ui/tenant package").
- `QUICK_REFERENCE.md` is outside every `SCAN_ROOTS` entry in `scripts/check-doc-links.mjs`, so **none** of its internal links has ever been resolved by anything that can fail a build — the same hole objectui#4148 recorded for `apps/**`.

## 1. Commands — run-it-or-derive-it, one row each

| Documented | What running it did | Now | Anchor |
|---|---|---|---|
| `pnpm install` | `Done in 6.2s using pnpm v10.31.0` | unchanged | pnpm builtin |
| `pnpm build` | `--dry=json` → turbo resolved **44** build tasks | unchanged | root script |
| **`pnpm typecheck`** | `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "typecheck" not found` / `Did you mean "pnpm type-check"?` (exit **254**) | **`pnpm type-check`** — `--dry=json` → **80** tasks | root script |
| `pnpm lint` | `--dry=json` → **45** lint tasks | unchanged | root script |
| `pnpm --filter @object-ui/site dev` | `Next.js 16.3.0` … `Local: http://localhost:3000` | unchanged — **the documented port is correct** | workspace pkg + script |
| `pnpm test` | CI runs `pnpm test --shard=…` (`ci.yml:379`) | unchanged — the "(CI runs this)" note is accurate | root script |
| `pnpm exec vitest run …` | exercised by this PR's own runs | unchanged | binary |
| **`pnpm playwright test`** | **works** — `pnpm playwright --version` → `Version 1.62.1` | **`pnpm test:e2e`** — `--list` → `Total: 165 tests in 6 files`, exit 0 | root script |
| **3 × `example-*` dev** | `No projects matched the filters` — **and exit 0** | the two real ones (below) | workspace globs |
| `pnpm changeset` / ` version` / ` publish` | not executed — see the split below | unchanged | root script |

Two rows need their reasoning stated rather than assumed.

**`pnpm playwright test` was replaced even though it works.** That is the one command on the page I changed without it being broken. It resolves because pnpm falls back to the local binary, but it is not a script, so it has no manifest anchor and the pin below would have needed a permanent carve-out for it. `pnpm test:e2e` is the repo's own declared spelling and the one CI runs (`ci.yml:536`, `pnpm test:e2e --project=chromium`). The pin found this by itself: on the pre-fix file it reports `pnpm playwright test (no root script "playwright")` beside `pnpm typecheck`.

**The changesets block was verified, not executed** — `version` rewrites every manifest and `publish` pushes to npm. What I checked instead is the only thing that was in doubt, read-only: that `pnpm changeset SUBCOMMAND` forwards its argument, since the repo also declares `changeset:version` and `changeset:publish`. `pnpm changeset status` prints `> changeset status` and exits 0, so `pnpm changeset version` runs `changeset version` exactly as `changeset:version` does. All three lines stand.

### Run Examples

`examples/` holds `byo-backend-console`, `console-starter`, `hello-world` and `schema-catalog` — none of the three the section named. The card flagged this as needing a judgement call about which examples a newcomer should run. It does not need one: **`examples/README.md` already owns that decision** and is maintained. It documents `hello-world` as a snippet and `schema-catalog` as "Not a runnable app — a data package", and their manifests agree: only the other two declare a `dev` script. So the block documents those two, and the prose points at that README rather than restating it.

Both were started and stopped for this PR:

```
> @object-ui/example-console-starter@0.1.0 dev
  VITE v8.2.1  ready in 425 ms
  ➜  Local:   http://localhost:5173/

> @object-ui/example-byo-backend-console@0.1.0 dev
  VITE v8.2.1  ready in 387 ms
  ➜  Local:   http://localhost:5174/
```

No ports in the page: one of the two pins `server.port` in its `vite.config.ts` and the other takes Vite's default, so the numbers are not uniformly derivable and `examples/README.md` already says "each exposes its own dev server port (see its README)". Pointer, not enumeration.

## 2. Paths

`apps/server` and `packages/tenant` are removed. The `examples/*` row enumerated four examples, two of which no longer exist; it becomes a pointer to `examples/README.md`, which is the file that stays current by being the examples index. Every other path in the file was checked against the tree and is present.

## 3. The count: a derived number, not a pointer

The card allowed either. This one keeps a number, because it has an exact anchor (`private` in each manifest) and because a count carries information a pointer cannot — the scale of the repo. What it may not be is hand-written: "39" counted **directories**, and `packages/vscode-extension` (package name `object-ui`, shipped to the VS Code marketplace) is `private: true`.

The row now reads `38 published packages (@object-ui/*), plus the private vscode-extension`. Naming the private one is load-bearing, not decoration: without it a reader who counts 39 directories and reads 38 "corrects" the number back, which is how the original defect is most likely to return. The test requires that reconciliation **only while a private package exists** — see below.

Contrast the `examples/*` row and the `.changeset/` note (the latter already pointer-ised by #4150): those enumerate a set that churns and have no stable form, so they get pointers. The rule I applied is per-claim, as the card asked: anchor exists and is exact → derive a number; set churns → point at the file that owns it.

## 4. The pin — `scripts/__tests__/quick-reference-commands-4149.test.ts`

A **sibling** of #4143's test, not an extension of it. That file is scoped to `## Current Release` in its own words, deliberately, because "asserting over the whole file would conflate a status claim with a package count" — and its reverse direction (no un-derived version literal) would go red on this page's ports and counts if widened. So the two split by section and this one never reads `## Current Release`.

Eleven assertions, every expectation computed from an anchor, no value written twice:

- every `pnpm` command in the page's bash fences names a **root script** (or a pnpm builtin)
- every `--filter` target is a **real workspace package** that declares the script it is asked to run
- **reverse:** every `examples/*` package declaring a `dev` script has a documented command. Forward alone stays green on a page that documents nothing — what was actually wrong is that both runnable examples were missing while three phantoms were listed
- every path in a code span exists; globs must match at least one directory
- **reverse:** every directory under `apps/` has a layout row (the table lists apps individually, so a new one is invisible until someone adds it)
- the published count is derived from the manifests' `private` flags, the `@object-ui/*` parenthetical is checked against the published names, and the private packages must be accounted for — that last assertion **retires itself** when the last private package leaves, so the exemption cannot outlive its justification
- every relative link resolves (nothing else does this, per the `SCAN_ROOTS` gap above)
- the quoted vitest-guard message still appears in `scripts/vitest-invocation-guard.mjs`

**What is deliberately left unpinned, per the card's "report the split":** the prose, the trailing comment on each command, the example ports, and two of the five quoted guard lines — those two are built by string interpolation in the guard's `canonicalLines()` and are not literals in the source, so asserting them would mean re-implementing the guard's formatting. The three that are literals are asserted, which is enough to catch a rewording. There is also **no** "every root script must be documented" direction: the root manifest declares ~50 scripts, this is a one-page cheat-sheet, and the defect is a documented command that does not exist — not an existing command that is undocumented.

## Reverse verification — both directions, predicted first

Fix taken out with `git checkout origin/main -- QUICK_REFERENCE.md` plus a patch file. **Never `git stash`** — that stack is shared across worktrees (objectui#3430).

**Doc side.** Predicted 6 red / 5 green before running: dead script, dead filter, missing-examples reverse, dead paths, wrong count, unexplained private gap red; link check, `apps/` reverse, guard quote, parser guard and the `@object-ui/*` naming check green. Measured: `Tests 6 failed | 5 passed (11)`.

```
QUICK_REFERENCE.md documents ["pnpm typecheck   (no root script \"typecheck\")",
  "pnpm playwright test   (no root script \"playwright\")"]
QUICK_REFERENCE.md documents ["pnpm --filter @object-ui/example-crm dev   (no workspace package named …)", …]
QUICK_REFERENCE.md's "Run Examples" section documents no `pnpm --filter … dev` line for
  ["examples/byo-backend-console","examples/console-starter"]
QUICK_REFERENCE.md names ["apps/server   (not in the tree)","packages/tenant   (not in the tree)"]
QUICK_REFERENCE.md must state "38 published packages" … (39 directories, 1 of them private: ["packages/vscode-extension"])
QUICK_REFERENCE.md's `packages/*` row states a published count that is smaller than the 39 directories a reader sees
```

The five that stayed green are the claims that had **not** drifted — the same asymmetry #4150 relied on as evidence the gate measures the doc rather than the edit.

**Anchor side** — two mutations against the **repaired** page, the direction that proves the expectations are computed rather than hardcoded a second time:

1. rename root `type-check` → `type-check-renamed`: `documents ["pnpm type-check   (no root script \"type-check\")"]`
2. delete `private` from `packages/vscode-extension/package.json`: `must state "39 published packages" … (39 directories, 0 of them private: [])`

Mutation 2 produced a **third**, unpredicted red that is the guard working correctly: `keeps the @object-ui/* parenthetical true` fired, because an un-privated `vscode-extension` publishes under the name `object-ui`, which is not `@object-ui/*`. And the self-retiring clause behaved: with zero private packages, "accounts for the private packages" went **green** on its own. Both mutations reverted; `git status` clean apart from this change.

## Gates

```
$ pnpm exec vitest run scripts/            # whole pin-test suite, incl. #4143's
 Test Files  30 passed (30)
      Tests  576 passed (576)

$ pnpm run type-check:scripts              # tsc -p tsconfig.scripts.json   → exit 0
$ pnpm run check:control-bytes
✅  check-control-bytes: OK (scanned 3844 tracked text file(s); skipped 85 binary).
$ pnpm run docs:check-links
Links are valid across 7 scan roots.
$ pnpm exec eslint scripts/__tests__/quick-reference-commands-4149.test.ts   # exit 0
```

ESLint earned its keep here: it caught a **zero-width space** (U+200B) I had used inside a block comment to keep a glob from closing the comment — `no-irregular-whitespace`, an invisible byte that the control-byte scan does not cover. Rewritten in words; both files then re-swept for invisible and control characters, clean.

## Changeset

None owed — arbitrated by the script, not by judgement:

```
$ node scripts/check-changeset-presence.mjs
✅  No source of a released package changed in this range, so no changeset is owed.
```

On the `skip-changeset` label: it exists as a label object in this repo, but nothing reads it — `changeset-presence.yml` decides from the diff and matches no label, and `scripts/__tests__/ci-cd-pipeline-doc.test.ts:184` records that objectui#3724 deleted `.github/WORKFLOWS.md` for documenting, among other phantoms, "a changeset gate skippable with a `skip-changeset` label; neither the workflow nor the label was ever real". It is applied here for consistency with the dispatch convention, with no mechanical effect either way.

## Out-of-scope findings — reported, not fixed

- **`check-doc-links` cannot see this file.** Its seven scan roots do not include the repo root, so `QUICK_REFERENCE.md`, `AGENTS.md`, `CLAUDE.md` and `CHANGELOG.md` have never had a link resolved by a blocking gate. objectui#4148 already covers widening `SCAN_ROOTS` (it was filed for `apps/**`); this is the same gap, one directory over, and belongs there rather than in a second card. The new test resolves this page's own links in the meantime.
- **`next dev` writes two untracked files that nothing ignores.** Running `pnpm --filter @object-ui/site dev` (for the port check above) made Next.js 16 generate `apps/site/AGENTS.md` and `apps/site/CLAUDE.md` via `node_modules/next/dist/server/lib/generate-agent-files.js`. They are neither committed nor in `.gitignore`, and the generated text tells the reader to commit them. In a repo where parallel agents run `git add -A`, that is a live trap for sweeping generated files into an unrelated PR. Deleted from this worktree, not fixed here; filed separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_