### PR TITLE
docs(links): scan the app READMEs and the rest of the repo root (#4148)

### DIFF
--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -2,7 +2,7 @@
 
 The standard runtime UI for ObjectStack applications. This package provides the **Console** — a full-featured enterprise admin interface that renders from JSON metadata alone, requiring zero custom pages.
 
-> **Version:** see the [npm page](https://www.npmjs.com/package/@object-ui/console) &nbsp;|&nbsp; **Spec:** the `@objectstack/spec` range declared in [`package.json`](./package.json) &nbsp;|&nbsp; [Full Roadmap →](./CONSOLE_ROADMAP.md)
+> **Version:** see the [npm page](https://www.npmjs.com/package/@object-ui/console) &nbsp;|&nbsp; **Spec:** the `@objectstack/spec` range declared in [`package.json`](./package.json) &nbsp;|&nbsp; [Full Roadmap →](../../ROADMAP.md)
 
 ## Features
 
@@ -123,7 +123,7 @@ Console App
 
 | Document | Description |
 |----------|-------------|
-| [Console Roadmap](./CONSOLE_ROADMAP.md) | Full development plan with phases, timeline, and verified status |
+| [Roadmap](../../ROADMAP.md) | Repo-wide development plan — the Console phases and their status live here |
 | [Getting Started Guide](../../content/docs/guide/console.md) | User-facing documentation |
 | [Architecture Guide](../../content/docs/guide/console-architecture.md) | Technical deep-dive |
 | [UI Improvement Proposal](./docs/UI_IMPROVEMENT_PROPOSAL.md) | Modern UI design improvements for metadata inspector |

--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -90,6 +91,16 @@ import {
  * is pinned on DECIDABLE HREFS and not only on file count — and the fixture
  * pair that keeps the row on the `disk` rule, since a package README is read on
  * npm and GitHub and never served by the site.
+ *
+ * objectui#4148 bought the two surfaces the script's header had been DOCUMENTING
+ * as unscanned — the app READMEs and the rest of the root-level markdown — and
+ * the final describe pins them. The live instance was two links in
+ * `apps/console/README.md` that had been dead for six months under a green gate.
+ * One test there is unlike every other in this file: it asserts over the REAL
+ * tree, requiring every tracked root-level markdown file to have a row. That is
+ * deliberate. The root has no glob spelling, so its completeness is a per-file
+ * list, and a list is exactly the thing that goes stale — the assertion is what
+ * makes "all of them" survive the next page someone adds.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -392,6 +403,12 @@ describe('the repo it guards', () => {
       'ROADMAP.md',
       'docs',
       'packages/*/README.md',
+      'apps/*/README.md',
+      'AGENTS.md',
+      'CHANGELOG.md',
+      'CLAUDE.md',
+      'LICENSE-THIRD-PARTY.md',
+      'QUICK_REFERENCE.md',
     ]);
     expect(scanned['README.md']).toBe(1);
     expect(scanned['CONTRIBUTING.md']).toBe(1);
@@ -404,6 +421,13 @@ describe('the repo it guards', () => {
     // expanding before anything is opened — so a floor here is also the floor
     // under `expandWildcard()`.
     expect(scanned['packages/*/README.md']).toBeGreaterThanOrEqual(35);
+    // objectui#4148. Both apps carry one today; the floor is 2 rather than the
+    // exact count because this row exists precisely so the NEXT app is scanned
+    // without anyone editing the table.
+    expect(scanned['apps/*/README.md']).toBeGreaterThanOrEqual(2);
+    for (const rootFile of ['AGENTS.md', 'CHANGELOG.md', 'CLAUDE.md', 'LICENSE-THIRD-PARTY.md', 'QUICK_REFERENCE.md']) {
+      expect(scanned[rootFile], `${rootFile} is a SCAN_ROOTS row that opened no file`).toBe(1);
+    }
   });
 
   it('pairs each scan root with the link semantics that root actually has', () => {
@@ -418,6 +442,13 @@ describe('the repo it guards', () => {
     // objectui#3622 added the package READMEs, `disk` for the same reason and
     // one more: they are read on **npm** as well, where a leading `/` is no
     // more this repo's root than it is on github.com.
+    //
+    // objectui#4148 added the app READMEs and the rest of the root-level
+    // markdown, every one `disk`. `@object-ui/console` is a published package,
+    // so its README is read in exactly the two places a package README is; the
+    // root files are read on GitHub. Nothing here is served by the site, and a
+    // row that quietly took the `docs` rule would re-judge a whole tree — which
+    // is why the table is pinned whole rather than by length.
     expect(SCAN_ROOTS).toEqual([
       { path: 'content/docs', rule: 'docs' },
       { path: 'examples', rule: 'disk' },
@@ -426,6 +457,12 @@ describe('the repo it guards', () => {
       { path: 'ROADMAP.md', rule: 'disk' },
       { path: 'docs', rule: 'disk' },
       { path: 'packages/*/README.md', rule: 'disk' },
+      { path: 'apps/*/README.md', rule: 'disk' },
+      { path: 'AGENTS.md', rule: 'disk' },
+      { path: 'CHANGELOG.md', rule: 'disk' },
+      { path: 'CLAUDE.md', rule: 'disk' },
+      { path: 'LICENSE-THIRD-PARTY.md', rule: 'disk' },
+      { path: 'QUICK_REFERENCE.md', rule: 'disk' },
     ]);
   });
 
@@ -1310,5 +1347,115 @@ describe('packages/*/README.md joined the disk surface — objectui#3622', () =>
 
     expect(decidable.length).toBeGreaterThanOrEqual(150);
     expect(siteAbsolute.length).toBeGreaterThanOrEqual(40);
+  });
+});
+
+describe('objectui#4148 — the app READMEs and the rest of the repo root', () => {
+  /**
+   * The two surfaces this gate's own header had DOCUMENTED as unscanned, bought
+   * together. The live instance was `apps/console/README.md`, which linked twice
+   * to a `./CONSOLE_ROADMAP.md` that left the directory in `c988277ff`: both
+   * links were dead for about six months while `pnpm docs:check-links` reported
+   * green on every push, because `apps/` matched no scan root.
+   *
+   * These tests are fixture-based rather than assertions about the real tree, so
+   * they keep failing for the right reason after the real dead links are gone.
+   * The one exception is the last test, which is deliberately about the real
+   * tree: it is what stops this surface from silently reopening.
+   */
+  it('judges a dead link in an app README, and accepts a live one', () => {
+    // The row's whole purpose, in both directions at once — a green here that
+    // came from the surface not being scanned would have to explain the red.
+    const repo = repoWith({
+      ...SITE_FIXTURE,
+      'ROADMAP.md': '# Roadmap',
+      'apps/console/README.md': '[roadmap](../../ROADMAP.md) and [gone](./CONSOLE_ROADMAP.md)',
+      'apps/site/README.md': '[roadmap](../../ROADMAP.md)',
+    });
+
+    expect(scan(repo).map((item) => [path.relative(repo, item.file), item.href, item.reason])).toEqual([
+      [path.join('apps', 'console', 'README.md'), './CONSOLE_ROADMAP.md', 'example-relative'],
+    ]);
+  });
+
+  it('takes only the READMEs under apps/, not the markdown beside them', () => {
+    // The unbought class is stated as a decision, not left to be discovered:
+    // per-app CHANGELOGs are out with the package-internal markdown. Mirrors the
+    // objectui#3622 test one directory over.
+    expect(
+      rejections({
+        'apps/console/README.md': '[gone](./NOWHERE.md)',
+        'apps/console/CHANGELOG.md': '[also gone](./NOWHERE.md)',
+        'apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md': '[also gone](./NOWHERE.md)',
+      }),
+    ).toEqual([['./NOWHERE.md', 'example-relative']]);
+  });
+
+  it('keeps the docs rules off app READMEs — the contrast pair', () => {
+    // `@object-ui/console` is published, so its README is read on npm and on
+    // GitHub and never served by the site: `disk`, for the same reason as a
+    // package README. The discriminator is the extensionless spelling, which the
+    // docs rule accepts as a route and GitHub 404s.
+    const repo = repoWith({
+      ...SITE_FIXTURE,
+      'content/docs/guide/console.md': '# Console',
+      'apps/console/README.md':
+        '[guide](../../content/docs/guide/console.md) and [bare](../../content/docs/guide/console)',
+    });
+
+    expect(scan(repo).map((item) => [path.relative(repo, item.file), item.href, item.reason])).toEqual([
+      [path.join('apps', 'console', 'README.md'), '../../content/docs/guide/console', 'example-relative'],
+    ]);
+  });
+
+  it('judges a dead link in a root-level file the header used to list as unscanned', () => {
+    // objectui#4149 had resolved QUICK_REFERENCE.md's links inside its own pin
+    // test, explicitly as a stopgap until this row existed. This is the row; that
+    // block was deleted with it, so this is now the only thing making the claim.
+    expect(
+      rejections({
+        'QUICK_REFERENCE.md': '[gone](./NOWHERE.md)',
+        'CLAUDE.md': '[also gone](./NOWHERE.md)',
+        'CHANGELOG.md': '[also gone](./NOWHERE.md)',
+        'AGENTS.md': '[also gone](./NOWHERE.md)',
+        'LICENSE-THIRD-PARTY.md': '[also gone](./NOWHERE.md)',
+      }),
+    ).toEqual([
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+      ['./NOWHERE.md', 'example-relative'],
+    ]);
+  });
+
+  it('scans EVERY tracked root-level markdown file — the invariant that replaces the list', () => {
+    // The reverse direction, and the reason `LICENSE-THIRD-PARTY.md` is a row
+    // even though it carries no links today: the header used to name four
+    // unscanned root files, and a list of names is a thing that goes stale the
+    // next time someone adds a page. "All of them" does not, provided something
+    // holds it — this is that something. A new root-level markdown file with no
+    // SCAN_ROOTS row fails here, which is the only moment anyone is thinking
+    // about the file.
+    //
+    // Tracked files only, via git rather than readdir: an untracked stray at the
+    // root (a scratch note, or a generated `AGENTS.md` of the kind objectui#4149
+    // found `next dev` writing into `apps/site/`) is not this gate's business and
+    // must not redden the suite.
+    const tracked = execFileSync('git', ['ls-files', '--', '*.md'], { cwd: repoRoot, encoding: 'utf8' })
+      .split('\n')
+      .filter((line) => line.trim() !== '' && !line.includes('/'))
+      .sort();
+
+    const rows = new Set((SCAN_ROOTS as { path: string }[]).map((item) => item.path));
+    expect(
+      tracked.filter((file) => !rows.has(file)),
+      'every root-level markdown file needs its own SCAN_ROOTS row — the root has no glob spelling ' +
+        '(`expandWildcard()` expands a whole path segment, never `*.md`), so completeness here is per-file',
+    ).toEqual([]);
+
+    // Floor under the floor: if `git ls-files` ever returned nothing, the
+    // assertion above would pass while proving nothing at all.
+    expect(tracked.length).toBeGreaterThanOrEqual(8);
   });
 });

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -195,7 +195,9 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
 /**
  * The two surfaces objectui#3697 names. Both are read by humans looking for the
  * version they must install, and both are already walked by `check-doc-links.mjs`
- * (scan roots 1 and 7) — this gate adds a second question about the same files.
+ * (its `content/docs` and package-README rows — named rather than numbered, since
+ * that table has grown twice since) — this gate adds a second question about the
+ * same files.
  */
 const SCAN_ROOTS = ['content/docs', 'packages/*/README.md'] as const;
 

--- a/scripts/__tests__/quick-reference-commands-4149.test.ts
+++ b/scripts/__tests__/quick-reference-commands-4149.test.ts
@@ -37,9 +37,15 @@ import { fileURLToPath } from 'node:url';
  *
  * Pinned: everything with a machine anchor — script names (root `package.json`
  * `scripts`), workspace package names and their scripts (the `pnpm-workspace.yaml`
- * globs), filesystem paths, the published-package count, and the internal links (this
- * file sits outside every `SCAN_ROOTS` entry in `scripts/check-doc-links.mjs`, so
- * nothing else resolves them).
+ * globs), filesystem paths, and the published-package count.
+ *
+ * The internal links used to be pinned here too, and are not any more. That block was
+ * written as an explicit stopgap: this page sat outside every `SCAN_ROOTS` entry in
+ * `scripts/check-doc-links.mjs`, so nothing that could fail a build resolved its links.
+ * objectui#4148 added the row, and the stopgap was deleted with it — the real gate
+ * judges this page on every push now, under the same `disk` rule as every other
+ * GitHub-read markdown file, and two implementations of one check is one more than gets
+ * maintained.
  *
  * Not pinned, on purpose: the prose descriptions, the comment text after each command,
  * and the dev-server ports of the examples — a port lives in a `vite.config.ts`
@@ -403,28 +409,6 @@ describe('QUICK_REFERENCE.md — the published-package count is derived', () => 
       misnamed.map((p) => `${p.dir} → ${p.name}`),
       `${docRel}'s \`packages/*\` row calls the published packages \`@object-ui/*\`, but these are not`,
     ).toEqual([]);
-  });
-});
-
-describe('QUICK_REFERENCE.md — internal links resolve', () => {
-  /**
-   * Nothing else checks them. `scripts/check-doc-links.mjs` scans seven roots
-   * (`content/docs`, `examples`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs`,
-   * and each package README) and this page is in none of them — the same hole
-   * objectui#4148 recorded for `apps/**`. Widening `SCAN_ROOTS` is that card's business;
-   * this keeps the page honest in the meantime, at the cost of four lines.
-   */
-  it('points every relative link at something in the tree', () => {
-    const dead: string[] = [];
-    for (const match of doc.matchAll(/\[[^\]]*\]\((\.[^)]+)\)/g)) {
-      const target = match[1].split('#')[0];
-      if (target === '') continue;
-      if (!fs.existsSync(path.join(repoRoot, target))) dead.push(target);
-    }
-
-    expect(dead, `${docRel} links to ${JSON.stringify(dead)}, which ${dead.length === 1 ? 'is' : 'are'} not in the tree`).toEqual(
-      [],
-    );
   });
 });
 

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -228,9 +228,9 @@
  * illustrative route from an executable one, which is a different gate.
  *
  * (A "Still not bought" list closed this section, naming `QUICK_REFERENCE.md`,
- * `AGENTS.md`, `CLAUDE.md` and `CHANGELOG.md`. It has moved to the end of the
- * objectui#3622 section below, which is the current one; those four are still
- * on it.)
+ * `AGENTS.md`, `CLAUDE.md` and `CHANGELOG.md`. It moved to the end of the
+ * objectui#3622 section below, and objectui#4148 bought all four — the current
+ * list of what is still unscanned is at the end of that card's section.)
  *
  * ## Why this file changed again (objectui#3603)
  *
@@ -314,11 +314,86 @@
  *
  * ### Still not bought
  *
- * `QUICK_REFERENCE.md`, `AGENTS.md`, `CLAUDE.md` and `CHANGELOG.md` remain
- * unscanned, along with the non-README markdown inside packages (`CHANGELOG.md`,
- * `TESTING.md`, `MIGRATION.md`, per-package `docs/` trees). Same one-row price,
- * same caveat — measure the surface first, pay its backlog separately, then add
- * the row.
+ * The list that stood here named `QUICK_REFERENCE.md`, `AGENTS.md`, `CLAUDE.md`
+ * and `CHANGELOG.md`, alongside the non-README markdown inside packages. All
+ * four were bought by objectui#4148 — see the next section, which also carries
+ * the current version of this list.
+ *
+ * ## Why this file changed again (objectui#4148): apps and the repo root
+ *
+ * Two rows, landed together because they are one fact: both surfaces were ones
+ * THIS HEADER named as unscanned, and in the months each spent on that list the
+ * only thing that ever noticed a dead link on either was a person reading the
+ * page. A gap a gate documents about itself is still a gap.
+ *
+ * ### 1. The app READMEs
+ *
+ * `apps/console/README.md` linked twice to `./CONSOLE_ROADMAP.md`. That file left
+ * the directory in `c988277ff` (renamed to a root `ROADMAP_CONSOLE.md`) and was
+ * folded into the root `ROADMAP.md` by `3e814e07a` a week later. Both links then
+ * sat dead for about six months while `pnpm docs:check-links` reported green on
+ * every push — `apps/` was in no scan root, so `apps/console/README.md` and
+ * `apps/site/README.md` alike were unlinted. objectui#4148 is that report, filed
+ * out of objectui#4143.
+ *
+ * The row is objectui#3622's purchase one directory over, and takes the `disk`
+ * rule for a stronger version of the same reason: `@object-ui/console` is a
+ * PUBLISHED package (its manifest declares no `private`), so its README is read
+ * on npm and on GitHub exactly like a package README, and is never served by the
+ * site. It is a wildcard row for the same reason as the package one — the surface
+ * is one file per directory rather than a tree — which also means the next app to
+ * land under `apps/` is scanned on arrival, with no row for anyone to remember.
+ *
+ * Only the READMEs: the `CHANGELOG.md` beside each stays out, with the
+ * package-internal markdown below, so there is one unbought class here and not
+ * two.
+ *
+ * Price: **2** dead links, both halves of the `CONSOLE_ROADMAP.md` pair, repointed
+ * at the root `ROADMAP.md` in the same PR. The filing had assumed that content was
+ * deleted and so had no successor; the history above says it was moved, which is
+ * what makes repointing an answer rather than a guess.
+ *
+ * ### 2. The root-level markdown files
+ *
+ * `AGENTS.md`, `CHANGELOG.md`, `CLAUDE.md`, `LICENSE-THIRD-PARTY.md` and
+ * `QUICK_REFERENCE.md` — one row each, joining the root `README.md`,
+ * `CONTRIBUTING.md` and `ROADMAP.md` already in the table. Per-file rows rather
+ * than a glob, because the root is a fixed short list rather than a directory
+ * that grows, and because `expandWildcard()` deliberately expands only a whole
+ * path SEGMENT: `*.md` is not a spelling this table has, and would throw.
+ *
+ * That completes the surface, and completeness is the point — every tracked
+ * markdown file at the top level of this repo is now scanned, which is an
+ * invariant a test can hold rather than a list that goes stale. It does hold one:
+ * a new root-level page with no row turns `check-doc-links.test.ts` red, so this
+ * particular hole cannot silently reopen.
+ *
+ * `LICENSE-THIRD-PARTY.md` was never on the header's list and is bought anyway,
+ * precisely to make that invariant statable. "These four named files" is a claim
+ * that decays; "all of them" is one that a test can keep true.
+ *
+ * Price: **zero** dead links — the objectui#3572 shape, a check arriving with its
+ * backlog already paid. Measured before landing: 11 links across the five files,
+ * 9 of them decidable here. objectui#4149 had already resolved
+ * `QUICK_REFERENCE.md`'s eight inside its own pin test, explicitly as a stopgap
+ * for one file "to be deleted when a SCAN_ROOTS row makes it redundant". This is
+ * that row, and that block goes with it — a second implementation of a check is
+ * worse than no second implementation, because only one of them gets maintained.
+ *
+ * Two of the five carry nothing for this gate to judge today, and are bought
+ * without argument anyway: `AGENTS.md` has no markdown links at all (its paths
+ * are code spans, which `stripCode()` blanks), and both of `CHANGELOG.md`'s are
+ * external. A row over a file with no decidable links is not vacuous — it is the
+ * row that judges the FIRST dead link written into that file, which is the exact
+ * failure this file exists to prevent. Buying a surface while it is empty is the
+ * cheapest this ever gets.
+ *
+ * ### Still not bought
+ *
+ * The non-README markdown inside packages and apps: each `CHANGELOG.md`,
+ * `TESTING.md`, `MIGRATION.md`, and the per-package `docs/` trees. Same one-row
+ * price, same caveat — measure the surface first, pay its backlog separately,
+ * then add the row.
  *
  * ## Code spans are stripped before scanning
  *
@@ -377,13 +452,16 @@ const UNSCANNED_DIRS = new Set(['node_modules', 'dist', 'build', '.next', '.turb
  *
  * The split is the point (objectui#3536). See the header for why applying the
  * docs rules to the second group would reject links that render perfectly well:
- * over today's `disk` surface it would reject 186 links that all render — 111
- * of them before objectui#3622 widened that surface, 75 in the package READMEs
- * it added.
+ * over today's `disk` surface it would reject 198 links that all render — 112 on
+ * the surfaces that predate objectui#3622, 76 in the package READMEs it added,
+ * and 10 in the app READMEs and root-level files objectui#4148 added. (The first
+ * two figures were 111 and 75 when #3622 measured them; the +1 each is ordinary
+ * link churn on those pages since, remeasured here rather than carried forward.)
  *
  * Adding a surface is one row. Adding one that is read on GitHub needs no new
  * rule class at all — which is why objectui#3572 could take the last three for
- * the price of the table entry, and objectui#3622 the package READMEs.
+ * the price of the table entry, objectui#3622 the package READMEs, and
+ * objectui#4148 the app READMEs and the rest of the repo root.
  *
  * A row's `path` is a directory to walk, a single markdown file, or a pattern
  * whose one wildcard SEGMENT stands for every directory at that level — see
@@ -397,6 +475,15 @@ export const SCAN_ROOTS = [
   { path: 'ROADMAP.md', rule: 'disk' },
   { path: 'docs', rule: 'disk' },
   { path: 'packages/*/README.md', rule: 'disk' },
+  { path: 'apps/*/README.md', rule: 'disk' },
+  // The rest of the root-level markdown, completing that surface (objectui#4148).
+  // `README.md`, `CONTRIBUTING.md` and `ROADMAP.md` are already above, in the
+  // positions the rows that bought them left them in.
+  { path: 'AGENTS.md', rule: 'disk' },
+  { path: 'CHANGELOG.md', rule: 'disk' },
+  { path: 'CLAUDE.md', rule: 'disk' },
+  { path: 'LICENSE-THIRD-PARTY.md', rule: 'disk' },
+  { path: 'QUICK_REFERENCE.md', rule: 'disk' },
 ];
 
 const blank = (text) => text.replace(/[^\n]/g, ' ');
@@ -839,8 +926,8 @@ const HINTS = {
     ' `https://github.com/objectstack-ai/objectui/blob/main/...` URL instead' +
     ' (the "Package README" form used throughout content/docs/plugins/).',
   'example-relative':
-    'Outside content/docs (examples/**, README.md, CONTRIBUTING.md, ROADMAP.md,' +
-    ' docs/** and each package README) a relative link is a' +
+    'Outside content/docs (examples/**, docs/**, each package and app README,' +
+    ' and the root-level markdown files) a relative link is a' +
     ' PATH IN THIS REPO, resolved by GitHub against the linking file — so it' +
     ' must name something that exists and lives inside the repository. A' +
     ' directory or a non-markdown file is fine; an extensionless spelling of a' +


### PR DESCRIPTION
Fixes #4148

## Ordering

PR #4159 (which owns `scripts/__tests__/quick-reference-commands-4149.test.ts`, edited here) **merged** as `521a37bd0` before this started, so this branches off `main` rather than stacking on `claude/issue-4149-quick-reference-dead-commands`.

## Premise: valid, with one correction that decides the fix

Both dead links reproduce at the tip, and so does the blind spot:

```
$ node scripts/check-doc-links.mjs        # before the rows
Links are valid across 7 scan roots.
```

The card's second half is the one that changed. It states "the roadmap content is gone, not moved — there is no successor path to repoint at", and that is where its two links-vs-delete options came from. The history says otherwise:

| Commit | Date | What happened |
|---|---|---|
| `c988277ff` | 2026-02-14 | `apps/console/CONSOLE_ROADMAP.md` renamed to a root `ROADMAP_CONSOLE.md` (a pure rename, `git show --stat` reports it as such) |
| `3e814e07a` | 2026-02-21 | "consolidate 4 ROADMAP files into single ROADMAP.md" — `ROADMAP_CONSOLE.md`, `ROADMAP_DESIGNER.md` and `ROADMAP_SPEC.md` folded into `ROADMAP.md` |

Today's `ROADMAP.md` still carries the Console work as its own phases (`P1.2 Console — Forms & Data Collection`, `P1.3 Console — Import/Export Excellence`, `P1.4`, `P1.5`, `P1.6`, `P1.7`, and more). So there IS a successor, both links are repointed at it, and the delete-versus-repoint decision the card deliberately left open does not need a judgement call — it needs the rename history. The links were dead for about six months.

## 1. Two `SCAN_ROOTS` rows

Both `disk`, because both surfaces are read on GitHub and never served by the site.

**One README per directory under `apps/`.** objectui#3622's package-README purchase one directory over, and the rule choice is stronger here than "same shape": `@object-ui/console` declares no `private`, so it is a **published package** and its README is read on npm and on GitHub in exactly the two places a package README is. A wildcard row for the same reason as the package one — the surface is one file per directory rather than a tree — which also means the next app to land is scanned on arrival with no row to remember.

**The rest of the root-level markdown**: `AGENTS.md`, `CHANGELOG.md`, `CLAUDE.md`, `LICENSE-THIRD-PARTY.md`, `QUICK_REFERENCE.md`, joining the `README.md` / `CONTRIBUTING.md` / `ROADMAP.md` already in the table. Per-file rows, not a glob — `expandWildcard()` expands a whole path SEGMENT by design, so `*.md` is not a spelling this table has and would throw.

`LICENSE-THIRD-PARTY.md` was not on the header's list of four and is bought anyway. That is the point: it makes the root **complete**, which converts a list of names (a thing that goes stale the next time someone adds a page) into an invariant a test can hold. See the reverse assertion below.

## 2. What the rows cost — measured before landing

| Row | Files | Links | Decidable here | Dead |
|---|---|---|---|---|
| app READMEs | 2 | 13 | 6 | **2** |
| root-level files | 5 | 11 | 9 | **0** |

The 2 are the `CONSOLE_ROADMAP.md` pair, repaired in this PR, so the rows land green — the objectui#3572 shape (a check arriving with its backlog already paid), not the #3479/#3490 shape.

Two of the five root files carry nothing to judge today: `AGENTS.md` has no markdown links at all (its paths are code spans, which `stripCode()` blanks) and both of `CHANGELOG.md`'s are external. They are bought regardless — a row over a file with no decidable links is the row that judges the FIRST dead link written into it, and buying a surface while it is empty is the cheapest this ever gets.

## 3. The #4159 stopgap, deleted

`scripts/__tests__/quick-reference-commands-4149.test.ts` resolved that one page's links itself, and said so in its own words: a stopgap for one file, "it should be **deleted** when a `SCAN_ROOTS` row makes it redundant, rather than left as a second implementation". The `QUICK_REFERENCE.md` row is that replacement, so the block and its header claim both go. Two implementations of one check is one more than gets maintained.

## 4. Stale counts swept (the #3212 family)

The header did not merely omit these surfaces — it **documented** them as unscanned, so the prose had to move with the rows:

- the `#3622` "Still not bought" list (those four root files) now records that #4148 bought them, and the `#3490` forward-reference to it stops claiming "those four are still on it";
- the residual unbought class is restated as what it now is: the non-README markdown inside packages **and apps**;
- the `example-relative` hint enumerated the disk surfaces and no longer omits the new ones;
- the measured "186 links that all render" claim is remeasured to **198** — and honestly: its 111 + 75 split reads 112 + 76 today, ordinary link churn since #3622, so the +1 each is stated rather than silently folded in;
- `doc-version-claims.test.ts` referred to check-doc-links' "scan roots 1 and 7" positionally. Positions survive an append by luck; the roots are now named.

The success line was already `SCAN_ROOTS.length`, so it needed nothing — it reads `13 scan roots` on its own.

## Reverse verification — predicted first, three directions

**Direction 1 (the point of the card): the widened scan on the pre-fix tree.** Predicted red naming exactly the two roadmap links and nothing else, since the root rows were measured at zero. Measured:

```
$ node scripts/check-doc-links.mjs        # rows added, README not yet fixed
Found 2 broken links (1 distinct target):
- [example-relative] apps/console/README.md:5 -> ./CONSOLE_ROADMAP.md
- [example-relative] apps/console/README.md:126 -> ./CONSOLE_ROADMAP.md
EXIT=1

$ node scripts/check-doc-links.mjs        # after the repair
Links are valid across 13 scan roots.
EXIT=0
```

**Direction 2: delete the apps row from the repaired tree.** Predicted 5 red — the two whole-table pins plus the three app fixtures — and the repo-wide scan staying GREEN, because the README is fixed by then and its links resolve whether or not anything looks at them. That last part is the interesting half: it is precisely why a fixture pair is needed and a repo scan is not sufficient evidence that a row exists. Measured `Tests 5 failed | 82 passed (87)`, exactly those five.

**Direction 3: delete one root-file row.** The self-extending assertion, which no fixture can prove:

```
AssertionError: every root-level markdown file needs its own SCAN_ROOTS row — the root has no glob
spelling (`expandWildcard()` expands a whole path segment, never `*.md`), so completeness here is
per-file: expected [ 'LICENSE-THIRD-PARTY.md' ] to deeply equal []
```

It names the file, and it is derived from `git ls-files` rather than `readdir` on purpose: an untracked stray at the root — a scratch note, or a generated `AGENTS.md` of the kind #4159 caught `next dev` writing into `apps/site/` — is not this gate's business and must not redden the suite.

Both mutations reverted from a patch file. **Never `git stash`** — that stack is shared across worktrees (objectui#3430).

## Gates

```
$ pnpm exec vitest run scripts/                  # whole scripts suite, from repo root
 Test Files  30 passed (30)
      Tests  582 passed (582)

$ node scripts/check-doc-links.mjs               # Links are valid across 13 scan roots.  → exit 0
$ pnpm run type-check:scripts                    # tsc -p tsconfig.scripts.json           → exit 0
$ pnpm run check:control-bytes
✅  check-control-bytes: OK (scanned 3847 tracked text file(s); skipped 85 binary).
$ pnpm exec eslint [the 4 changed script files]  # exit 0
```

Changed files were also swept for control characters beyond the gate's scan surface: clean.

## Changeset

None owed, arbitrated by the script rather than by judgement:

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with 521a37bd0 (merge-base with origin/main): 5 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

No `skip-changeset` label: it is decorative in this repo (objectui#3724 deleted `.github/WORKFLOWS.md` for documenting, among other phantoms, "a changeset gate skippable with a `skip-changeset` label; neither the workflow nor the label was ever real").

## Out-of-scope findings

None new. The one thing worth flagging for whoever reads the card: its "two decisions, deliberately not made here" are both made here, and the first was made by the rename history rather than by a judgement call — the option set in the card ("deleting both links, or repointing them at the root `ROADMAP.md`") had assumed repointing "asserts something about content nobody has checked". Someone has now checked: the content is literally the same document, moved twice.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_