### PR TITLE
docs(auth): mark passkeys / magicLink as reserved, not consumed

### DIFF
--- a/.changeset/reserved-auth-feature-flags-2514.md
+++ b/.changeset/reserved-auth-feature-flags-2514.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/auth': patch
+---
+
+`features.passkeys` and `features.magicLink` are documented as reserved, so enabling them no longer implies a login-page entry point that does not exist
+
+`GET /api/v1/auth/config` advertises eight login-surface capability flags. Six of them gate something real — `sso` gates the "Sign in with SSO" button, `phoneNumberOtp` the verification-code mode, `deviceAuthorization` the device-approval page — and each carries a doc comment saying what it gates. Two did not gate anything: `passkeys` and `magicLink` existed only as two undocumented lines in `AuthPublicConfig.features`, consumed by no component, no route and no metadata. A deployer who turned one on got a flag that changed nothing, with nothing anywhere to say so. That is the mirror of the defect the audit was looking for (framework#2874 P2②): not UI advertising a capability the backend lacks, but a backend advertising a capability the UI lacks.
+
+Both flags are now marked reserved at the two places a deployer meets them. The declarations in `packages/auth/src/types.ts` carry doc comments — which ship in the published `.d.ts`, so the warning appears on hover — stating that enabling the flag adds no entry point and naming the follow-up card. `packages/auth/README.md` gains a "Server Feature Flags" section documenting what the `features` map is for and a "Reserved flags" table saying the same thing in prose. Per the maintainer's ruling on objectui#2514, the UI is deliberately not built here; it is filed as objectui#4179 and left unscheduled.
+
+No runtime behaviour changes: nothing read these flags before and nothing reads them now. What changes is that the published types and docs stop being silent about it.
+
+The three artifacts are pinned together by `packages/auth/src/__tests__/reserved-auth-features.test.ts`, which asserts the declarations still exist, that each carries a reserved marking naming the card, that the README section says the same, and — the inverse direction — that no source file under `packages/*/src`, `apps/*/src` or `examples/*/src` references either identifier. The sweep covers `.json` as well as `.ts`/`.tsx` because `AppContent` hands the whole `features` object to `ExpressionProvider`, so authored metadata can reach these flags without any source file naming them. Two calibration cases keep the pin from rotting into a vacuous pass: one asserts the sweep reads a non-trivial number of files, the other that it can still find a flag that *is* consumed. When the UI is eventually built, the pin fails and its docblock spells out the retirement checklist — the doc comments, the README section and the pin itself come out in the same PR.
+
+`features.twoFactor` is untouched and explicitly excluded: two-factor is implemented in this package (`enableTwoFactor` / `verifyTwoFactor`) and its challenge is driven by server-side remediation rather than by the flag, so `LoginForm` not reading it is the design rather than a gap. The README says so, and the pin asserts `twoFactor` never appears in the reserved table.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -137,6 +137,42 @@ const authedFetch = createAuthenticatedFetch();
 const apiProviderFetch = createAuthenticatedFetch({ sameOriginOnly: true });
 ```
 
+## Server Feature Flags (`GET /auth/config`)
+
+`createAuthClient().getConfig()` fetches the server's public auth configuration. The
+`features` map on it tells the login surface which capabilities the deployment actually
+has, so the UI never renders an entry point whose endpoint is not mounted — `features.sso`
+gates the "Sign in with SSO" button, `features.phoneNumberOtp` gates the
+verification-code mode, `features.deviceAuthorization` gates the device-approval page,
+and so on.
+
+### Reserved flags — advertised by the server, consumed by nothing
+
+Two members of that map are **declared but deliberately not consumed** by this package:
+
+| Flag | Status | What enabling it does in the UI today |
+| --- | --- | --- |
+| `features.passkeys` | **Reserved** | Nothing. There is no passkey sign-in or registration UI for it to gate. |
+| `features.magicLink` | **Reserved** | Nothing. There is neither a magic-link request step nor a route that consumes the emailed token. |
+
+They are typed so the `/auth/config` payload round-trips without loss, not because
+anything reads them. **Turning either flag on server-side adds no entry point to the login
+page.** If you are enabling one because you expect a button to appear, it will not — and
+that is the whole reason this section exists.
+
+Building the two flows is tracked as a separate, unscheduled feature card,
+[objectui#4179](https://github.com/objectstack-ai/objectui/issues/4179). Documenting them
+as reserved rather than building them now follows the maintainer's ruling on
+[objectui#2514](https://github.com/objectstack-ai/objectui/issues/2514): mark them
+reserved today, build the UI when the login surface gets roadmap time, at which point it
+renders driven by these same flags. When that lands, this section retires with it.
+
+`features.twoFactor` is **not** in this category, despite also not being read by
+`LoginForm`. Two-factor authentication is implemented here (`enableTwoFactor` /
+`verifyTwoFactor` on the auth client) and its challenge is driven by server-side
+remediation rather than by the flag, so the login form ignoring the flag is the design,
+not a gap.
+
 ## Preview Mode
 
 Preview mode allows visitors (e.g. marketplace customers) to explore the platform without registering or logging in. The `AuthProvider` auto-authenticates with a simulated user identity and bypasses login/registration screens.

--- a/packages/auth/src/__tests__/reserved-auth-features.test.ts
+++ b/packages/auth/src/__tests__/reserved-auth-features.test.ts
@@ -1,0 +1,276 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#2514 — `features.passkeys` and `features.magicLink` are **reserved**:
+ * the server advertises them on `GET /api/v1/auth/config`, this package declares
+ * them so the payload types cleanly, and nothing consumes them. A deployer who
+ * turns one on gets no entry point on the login page, which is exactly the lie
+ * the audit (framework#2874 P2②) found and the maintainer's 2026-08-03 ruling
+ * chose to close by documentation rather than by building the UI.
+ *
+ * ## What this pin is for
+ *
+ * Documentation that a thing does not exist is only true for as long as the thing
+ * does not exist, and nothing else in the repo notices when that changes. The
+ * failure this guards is silent in **both** directions:
+ *
+ * - Someone builds a consumer and leaves the "reserved" wording in place. The docs
+ *   then understate the product — a deployer reads "turning this on adds no entry
+ *   point" about a flag that now adds one, and disables a working feature.
+ * - Someone deletes or dilutes the reserved marking without building anything. The
+ *   flag goes back to being advertised with no warning attached, which is the
+ *   original defect restored.
+ *
+ * So the three artifacts are pinned as one unit: the **declaration**, its
+ * **doc comment**, and the **README section**. Any of them moving alone reds.
+ *
+ * ## ⛔ Retirement checklist — when a consumer lands deliberately (objectui#4179)
+ *
+ * The reserved status is meant to end. When the passkey / magic-link login UI is
+ * built, that PR deletes all of this together — the pin is not an obstacle to
+ * clear, it is the checklist:
+ *
+ * 1. the RESERVED doc comments on `passkeys` / `magicLink` in `../types.ts`;
+ * 2. the "Reserved flags" subsection of `packages/auth/README.md`;
+ * 3. **this file**.
+ *
+ * Deleting only #3 to make the suite green is the one wrong move: it leaves the
+ * docs asserting a falsehood with nothing left to catch it.
+ *
+ * ## Why the consumer sweep is a blunt string match
+ *
+ * It follows the `scripts/__tests__/ci-cd-pipeline-doc.test.ts` pattern (#4170):
+ * read the real files, compare them, pin the inverse direction too. A type-aware
+ * "is this identifier read anywhere" analysis would be more precise and much more
+ * fragile, and it would still miss the reachable path that has no static reference
+ * at all — `AppContent` hands the whole `features` object to `ExpressionProvider`,
+ * so metadata can reach `${features.passkeys}` without any source file naming it.
+ * The sweep therefore covers authored metadata (`.json`) as well as `.ts`/`.tsx`,
+ * and matches the identifiers case-sensitively with word boundaries so that prose
+ * about unrelated server-side "magic link" emails (the identity-import wizard's
+ * hint text) does not count as a consumer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+
+const typesPath = path.join(packageRoot, 'src/types.ts');
+const readmePath = path.join(packageRoot, 'README.md');
+
+const typesSource = readFileSync(typesPath, 'utf8');
+const readme = readFileSync(readmePath, 'utf8');
+
+/** The two flags, and the login-surface entry point each one would gate if built. */
+const RESERVED_FLAGS = ['passkeys', 'magicLink'] as const;
+
+/** The follow-up card that ends the reserved status. Named in all three artifacts. */
+const FEATURE_CARD = '4179';
+
+/**
+ * The declaration line for `flag` plus the block comment immediately above it
+ * (empty string when there is none — only whitespace may separate the two, so a
+ * comment attached to some other member cannot be mistaken for this one).
+ */
+function declarationOf(flag: string): { index: number; doc: string } | null {
+  const match = new RegExp(`^[ \\t]*${flag}\\?: boolean;$`, 'm').exec(typesSource);
+  if (!match) return null;
+
+  const before = typesSource.slice(0, match.index);
+  const close = before.lastIndexOf('*/');
+  const open = before.lastIndexOf('/**');
+  const attached = close !== -1 && open !== -1 && open < close && before.slice(close + 2).trim() === '';
+
+  return { index: match.index, doc: attached ? before.slice(open, close + 2) : '' };
+}
+
+/**
+ * A block comment as prose: leaders stripped and wrapping undone, so an assertion
+ * about a sentence is not defeated by where the sentence happens to wrap.
+ */
+function asProse(doc: string): string {
+  return doc
+    .replace(/^\s*\/\*\*/, '')
+    .replace(/\*\/\s*$/, '')
+    .split('\n')
+    .map((line) => line.replace(/^\s*\* ?/, ''))
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+describe('reserved auth feature flags — declaration', () => {
+  it.each(RESERVED_FLAGS)('`%s` is still declared on AuthPublicConfig.features', (flag) => {
+    const declaration = declarationOf(flag);
+    expect(declaration, `${flag} must still be declared in packages/auth/src/types.ts`).not.toBeNull();
+
+    const interfaceStart = typesSource.indexOf('export interface AuthPublicConfig {');
+    const featuresStart = typesSource.indexOf('features?: {', interfaceStart);
+    expect(interfaceStart, 'AuthPublicConfig must still be declared').toBeGreaterThan(-1);
+    expect(featuresStart, 'AuthPublicConfig.features must still be declared').toBeGreaterThan(-1);
+    expect(
+      declaration!.index,
+      `${flag} must live inside AuthPublicConfig.features, not somewhere else in the file`,
+    ).toBeGreaterThan(featuresStart);
+  });
+
+  it.each(RESERVED_FLAGS)('`%s` carries a doc comment marking it RESERVED', (flag) => {
+    const doc = asProse(declarationOf(flag)!.doc);
+    expect(
+      doc,
+      `${flag} must carry a doc comment immediately above it saying RESERVED — see this file's retirement checklist`,
+    ).toMatch(/RESERVED/);
+  });
+
+  it.each(RESERVED_FLAGS)('the doc comment on `%s` says enabling it adds no UI', (flag) => {
+    const doc = asProse(declarationOf(flag)!.doc);
+    // The operative promise to a deployer: the flag changes nothing they can see.
+    expect(doc, `the doc comment on ${flag} must state that enabling it adds **no** entry point`).toMatch(
+      /adds \*\*no\*\* .*entry point/,
+    );
+  });
+
+  it.each(RESERVED_FLAGS)('the doc comment on `%s` points at the follow-up card', (flag) => {
+    const doc = asProse(declarationOf(flag)!.doc);
+    expect(doc, `the doc comment on ${flag} must reference objectui#${FEATURE_CARD}`).toContain(
+      `objectui#${FEATURE_CARD}`,
+    );
+  });
+});
+
+describe('reserved auth feature flags — README', () => {
+  /**
+   * The reserved subsection only, so a stray match elsewhere on the page cannot
+   * satisfy these assertions.
+   *
+   * Resolved per-test rather than once at collection time on purpose: an
+   * `expect` in a `describe` body aborts the whole FILE, so deleting the section
+   * would have taken the declaration and consumer-sweep suites down with it and
+   * reported "no tests" instead of naming what broke.
+   */
+  function reservedSection(): string {
+    const start = readme.indexOf('### Reserved flags');
+    expect(start, 'packages/auth/README.md must keep a "### Reserved flags" subsection').toBeGreaterThan(-1);
+    const rest = readme.slice(start);
+    const next = rest.indexOf('\n## ');
+    return next === -1 ? rest : rest.slice(0, next);
+  }
+
+  it.each(RESERVED_FLAGS)('documents `features.%s` as Reserved', (flag) => {
+    const row = reservedSection()
+      .split('\n')
+      .find((line) => line.startsWith('|') && line.includes(`features.${flag}`));
+    expect(row, `the README's reserved table must have a row for features.${flag}`).toBeDefined();
+    expect(row, `the features.${flag} row must be marked **Reserved**`).toContain('**Reserved**');
+  });
+
+  it('states plainly that enabling either flag adds no login entry point', () => {
+    expect(reservedSection()).toMatch(/adds no entry point to the login\s+page/);
+  });
+
+  it('links the follow-up card that retires the reserved status', () => {
+    expect(reservedSection()).toContain(`objectstack-ai/objectui/issues/${FEATURE_CARD}`);
+  });
+
+  it('does not claim `twoFactor` is reserved — its non-consumption is by design', () => {
+    // objectui#2514 is explicit that twoFactor is a different case: the capability
+    // IS implemented here, the challenge is server-remediation driven (framework
+    // ADR-0069), so LoginForm not reading the flag is deliberate, not a gap.
+    const row = reservedSection()
+      .split('\n')
+      .find((line) => line.startsWith('|') && line.includes('features.twoFactor'));
+    expect(row, 'twoFactor must not appear in the reserved table').toBeUndefined();
+  });
+});
+
+/**
+ * The inverse pin. Everything above documents an absence; this is what proves the
+ * absence is real, and it is the assertion that fires when someone builds the UI.
+ */
+describe('reserved auth feature flags — nothing consumes them', () => {
+  const SWEEP_ROOTS = ['packages', 'apps', 'examples'];
+  const SWEEP_EXTENSIONS = new Set(['.ts', '.tsx', '.json']);
+  const UNSCANNED = new Set(['node_modules', 'dist', 'build', '.next', '.turbo', 'coverage']);
+
+  /** The declaration site and this pin are the two legitimate mentions. */
+  const ALLOWED = new Set([
+    path.join(packageRoot, 'src/types.ts'),
+    fileURLToPath(import.meta.url),
+  ]);
+
+  function collect(dir: string, out: string[] = []): string[] {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return out;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!UNSCANNED.has(entry.name)) collect(full, out);
+      } else if (SWEEP_EXTENSIONS.has(path.extname(entry.name))) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  // The `src` tree of every workspace under each sweep root — the authored source
+  // of each package, app and example.
+  const sourceFiles = SWEEP_ROOTS.flatMap((root) => {
+    const rootDir = path.join(repoRoot, root);
+    let workspaces;
+    try {
+      workspaces = readdirSync(rootDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+    return workspaces
+      .filter((entry) => entry.isDirectory() && !UNSCANNED.has(entry.name))
+      .flatMap((entry) => collect(path.join(rootDir, entry.name, 'src')));
+  }).filter((file) => !ALLOWED.has(file));
+
+  it('the sweep itself reads a non-trivial number of files', () => {
+    // Without this, a bad path would make every assertion below pass vacuously —
+    // the exact way a "nothing consumes it" pin rots into a permanently green test.
+    expect(sourceFiles.length).toBeGreaterThan(500);
+  });
+
+  it('the sweep can actually see a consumed sibling flag', () => {
+    // Calibration: `features.sso` IS consumed. If the sweep cannot find that, its
+    // silence about passkeys/magicLink means nothing.
+    const ssoConsumers = sourceFiles.filter((file) => /\bsso\b/.test(readFileSync(file, 'utf8')));
+    expect(ssoConsumers.length).toBeGreaterThan(0);
+  });
+
+  it.each(RESERVED_FLAGS)('no source file reads `%s`', (flag) => {
+    const pattern = new RegExp(`\\b${flag}\\b`);
+    const consumers = sourceFiles
+      .filter((file) => pattern.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(repoRoot, file));
+
+    expect(
+      consumers,
+      [
+        `\`${flag}\` is now referenced outside its declaration:`,
+        ...consumers.map((file) => `  - ${file}`),
+        '',
+        'If a consumer landed deliberately (objectui#4179), this pin has done its job —',
+        'retire the whole reserved unit in the SAME PR: the RESERVED doc comments in',
+        'packages/auth/src/types.ts, the "Reserved flags" subsection of',
+        'packages/auth/README.md, and this file. Do not delete this file alone.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -166,7 +166,36 @@ export interface AuthPublicConfig {
   socialProviders?: AuthSocialProvider[];
   features?: {
     twoFactor?: boolean;
+    /**
+     * RESERVED — declared so the `/auth/config` payload types cleanly, and
+     * consumed by nothing in this repository. Enabling it server-side adds
+     * **no** passkey entry point to the login page, because there is no passkey
+     * sign-in or registration UI for it to gate. Contrast `sso`,
+     * `phoneNumberOtp` and `deviceAuthorization` below, which each gate a real
+     * surface.
+     *
+     * Building the flow is objectui#4179, filed unscheduled. This marking
+     * follows the maintainer's 2026-08-03 ruling on objectui#2514: document the
+     * flag as reserved now, build the UI when the login surface gets roadmap
+     * time (at which point it renders driven by this flag).
+     *
+     * Pinned by `__tests__/reserved-auth-features.test.ts`. That pin fails the
+     * moment a consumer appears, because the declaration, this doc comment and
+     * `README.md`'s reserved section have to retire in one PR — see the pin's
+     * docblock for the retirement checklist.
+     */
     passkeys?: boolean;
+    /**
+     * RESERVED — declared so the `/auth/config` payload types cleanly, and
+     * consumed by nothing in this repository. Enabling it server-side adds
+     * **no** "email me a sign-in link" entry point to the login page: there is
+     * neither a magic-link request step nor a route that consumes the emailed
+     * token.
+     *
+     * Same ruling, same follow-up card and same pin as `passkeys` above
+     * (objectui#2514 / objectui#4179 /
+     * `__tests__/reserved-auth-features.test.ts`).
+     */
     magicLink?: boolean;
     organization?: boolean;
     /**


### PR DESCRIPTION
Fixes #2514

## The defect

`GET /api/v1/auth/config` advertises eight login-surface capability flags. Six of them
gate a real surface and each carries a doc comment saying what it gates — `sso` gates the
"Sign in with SSO" button, `phoneNumberOtp` the verification-code mode,
`deviceAuthorization` the device-approval page. Two gated nothing and said nothing:
`passkeys` and `magicLink` existed as two undocumented lines in
`AuthPublicConfig.features`, read by no component, no route and no metadata. A deployer
who turned one on got a flag that changed nothing, with nothing anywhere to say so.

That is the mirror of what the audit was hunting (framework#2874 P2②): not UI advertising
a capability the backend lacks, but a backend advertising a capability the UI lacks.

## Premise check (re-verified on this tip, `fa511094a`)

Still valid. An exhaustive case-insensitive sweep of the worktree — every file, not just
`.ts`/`.tsx` — returns the two declarations and nothing else:

```
packages/auth/src/types.ts:169:    passkeys?: boolean;
packages/auth/src/types.ts:170:    magicLink?: boolean;
```

The only other "magic link" hits are prose in the identity-import wizard's hint text
(`IdentityImportPanels.tsx` and its locale strings), describing how an admin-imported user
first signs in server-side. Not a consumer.

I also checked the dynamic path the card asked about, and it is real but empty:
`AppContent` reads `cfg.features` and hands the **whole object** to `ExpressionProvider`,
so metadata can reach `${features.passkeys}` in a CEL/template predicate without any
source file naming the identifier. No metadata in this repo does. The pin below covers
`.json` for exactly this reason.

`twoFactor`'s note also still holds, and it is a genuinely different case rather than a
third reserved flag: the *flag* is not read by `LoginForm`, but the *capability* is
implemented here (`enableTwoFactor` / `verifyTwoFactor` on the auth client), and the
challenge is driven by server-side remediation (framework ADR-0069). Out of scope per the
card, untouched here, and the pin asserts it never appears in the reserved table.

## What this does

Per the maintainer's ruling of 2026-08-03 on #2514, quoted verbatim:

> 选 **2（摘牌/文档化）**：短期把 `passkeys` / `magicLink` 在文档标注 **reserved**，不建 UI；登录面 UI 进产品路线，有档期再做（届时按 flag 驱动渲染）。

Both flags are marked reserved at **both** places a deployer meets them:

- **`packages/auth/src/types.ts`** — doc comments on the two declarations. These ship in
  the published `.d.ts`, so the warning appears on hover in a consumer's editor.
- **`packages/auth/README.md`** — a new "Server Feature Flags (`GET /auth/config`)"
  section explaining what the `features` map is for, with a "Reserved flags" subsection
  stating plainly that turning either flag on adds no entry point to the login page.

Both point at #4179, the Option-1 feature card (gated passkey login/registration +
magic-link request/consume, scoped per this card's sketch), filed **unassigned and
unqueued** for the maintainer's roadmap call.

No runtime behaviour changes: nothing read these flags before, nothing reads them now.

## The pin

`packages/auth/src/__tests__/reserved-auth-features.test.ts`, following the #4170 checker
pattern (read the real files, compare them, pin the inverse direction too). It asserts:

1. both flags are still declared on `AuthPublicConfig.features`;
2. each carries a doc comment marking it RESERVED, saying enabling it adds no entry point,
   and naming #4179;
3. the README's reserved table says the same and links the card;
4. `twoFactor` does **not** appear in that table;
5. **the inverse** — no file under `packages/*/src`, `apps/*/src` or `examples/*/src`
   references either identifier.

Two calibration cases keep it from rotting into a vacuous pass: one asserts the sweep
reads a non-trivial number of files, the other that it can still find a flag that *is*
consumed. The docblock carries the retirement checklist — when the UI lands, the doc
comments, the README section and the pin come out in the **same** PR, and deleting the pin
alone is called out as the one wrong move.

## Reverse verification

Predicted direction: **red in all three**, since every assertion here documents an absence.
All three confirmed, then restored:

| Removed | Result |
| --- | --- |
| Added a probe consumer reading `features.passkeys` | 1 failed / 16 passed — named the file and printed the retirement checklist |
| The doc comments (`git checkout origin/main -- types.ts`) | 6 failed / 11 passed |
| The README section | 5 failed / 12 passed |

The README case found a real flaw on its first run: the section lookup was an `expect` in
the `describe` body, so its failure aborted collection for the whole file and reported
"no tests" instead of naming what broke — masking the other two suites. Moved into a
per-test helper; the table above is the re-run.

## Gates

```
pnpm exec vitest run packages/auth/     Test Files 11 passed  Tests 142 passed (142)
pnpm --filter '@object-ui/auth' type-check     tsc --noEmit && tsc -p tsconfig.typetests.json — clean
pnpm --filter '@object-ui/auth' lint           52 problems (0 errors, 52 warnings — all pre-existing)
node scripts/check-doc-links.mjs               Links are valid across 13 scan roots.
node scripts/check-control-bytes.mjs           exit 0
node scripts/check-changeset-presence.mjs      exit 0
node scripts/check-changeset-no-major.mjs      exit 0
node scripts/check-spec-symbol-derivation.mjs  exit 0
```

Dependency closure built first (`pnpm --filter '@object-ui/auth^...' build`) so the
type-check read a fresh `.d.ts`.

## Changeset

`patch` on `@object-ui/auth`, not empty frontmatter. `check-changeset-presence.mjs`
arbitrated that one is owed (`packages/auth/src/types.ts` is released source), and the
change is user-visible in the published artifact even though no runtime behaviour moves:
the doc comments ship in the `.d.ts` and the README ships in the tarball, which is the
entire mechanism by which this fix reaches a deployer.

## For the PM — framework lane, not acted on

The framework registry `packages/spec/src/kernel/public-auth-features.ts` carries an
`exempt.reason` on both entries pointing at #2514. This PR does not touch the framework
repo. The open question there — stop advertising the flags, or keep advertising them now
that the reserved status is documented — is theirs to answer.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_