### PR TITLE
fix(console): the first-run setup exits land inside the console mount

### DIFF
--- a/.changeset/setup-exit-console-basename-4181.md
+++ b/.changeset/setup-exit-console-basename-4181.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/console': patch
+---
+
+The first-run setup wizard no longer drops a brand-new owner outside the console
+
+On a console served under a mount — `/_console/`, which the framework CLI configures for every embedded deployment by injecting a `<base href>` — finishing the first-run owner bootstrap landed the new owner on the ORIGIN root instead of the console. Both of `SetupPage`'s exits navigated to a bare `/`: the success path after the account is created and the bootstrap organization renamed, and the bounce that sends an already-signed-in visitor away. `window.location.assign` does not go through React Router, so its `basename` never applied and a root-relative `/` left the SPA. It is the worst possible moment for a dead end — the first screen after creating the account, on a deployment that by definition has no other account to recover with.
+
+Under the default `/` mount the prefixed and unprefixed spellings are identical, which is why no standalone `os dev` run ever surfaced this.
+
+Both exits now go through the console-mount helper `LoginPage` already used for exactly this, so they land inside the SPA under every mount. They stay full-page navigations deliberately: the console shell mounts its metadata tree as soon as auth *resolves* rather than when it authenticates, and re-keys it only on language, so the app list read while nobody was signed in would survive a router navigation and leave the new owner in an appless console. Tearing the document down is what guarantees the console rebuilds with the session.
+
+The helper itself was module-private to `LoginPage` and had already been copied verbatim into `RegisterPage`. It now lives in one place with all three auth surfaces importing it, so the next mount fix lands once rather than three times. `LoginPage` and `RegisterPage` behaviour is unchanged, and pinned as unchanged across all three mount configurations.

--- a/apps/console/src/pages/auth/LoginPage.tsx
+++ b/apps/console/src/pages/auth/LoginPage.tsx
@@ -23,25 +23,14 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { Card } from '@object-ui/components';
 import { AuthLayout } from './AuthLayout';
 import { followOauthAuthorize } from './followAuthorize';
+// Was module-private here; lifted to a shared module so `SetupPage` (whose
+// first-run exits went without it) and `RegisterPage` (which had copied it)
+// share ONE implementation — objectui#4181. Behaviour here is unchanged.
+import { withConsoleBase } from '../../utils/consoleBase';
 
 /** Restrict the post-login redirect to same-origin paths. */
 function isSafeRedirect(target: string | null): target is string {
   return !!target && target.startsWith('/') && !target.startsWith('//');
-}
-
-/**
- * Prefix a router-relative path with the Console basename for full-page
- * navigations. `window.location.assign` bypasses React Router's `basename`,
- * so a path produced by the router (e.g. `?redirect=/settings` — already
- * basename-stripped) or a literal like `/organizations` would resolve to
- * `http://host/settings`, missing the `/_console` mount and 404-ing.
- * Paths already targeting another absolute SPA mount (`/_studio`,
- * `/_account`, …) pass through untouched.
- */
-function withConsoleBase(path: string): string {
-  if (path.startsWith('/_')) return path;
-  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-  return base + (path.startsWith('/') ? path : `/${path}`);
 }
 
 const DEV_HINT_DISMISSED_KEY = 'os.console.devAdminHintDismissed';

--- a/apps/console/src/pages/auth/RegisterPage.tsx
+++ b/apps/console/src/pages/auth/RegisterPage.tsx
@@ -20,17 +20,12 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { Card } from '@object-ui/components';
 import { AuthLayout } from './AuthLayout';
 import { followOauthAuthorize } from './followAuthorize';
+// Was a second module-private copy of LoginPage's helper; both now share one
+// implementation — objectui#4181. Behaviour here is unchanged.
+import { withConsoleBase } from '../../utils/consoleBase';
 
 function isSafeRedirect(target: string | null): target is string {
   return !!target && target.startsWith('/') && !target.startsWith('//');
-}
-
-/** Prefix a router-relative path with the Console basename for full-page
- * navigations (see LoginPage for the detailed rationale). */
-function withConsoleBase(path: string): string {
-  if (path.startsWith('/_')) return path;
-  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-  return base + (path.startsWith('/') ? path : `/${path}`);
 }
 
 function RouterLink(props: { href: string; className?: string; children: React.ReactNode }) {

--- a/apps/console/src/pages/auth/SetupPage.tsx
+++ b/apps/console/src/pages/auth/SetupPage.tsx
@@ -24,8 +24,36 @@ import {
   Input,
   Label,
 } from '@object-ui/components';
+import { withConsoleBase } from '../../utils/consoleBase';
 
 const AUTH_BASE = `${import.meta.env.VITE_SERVER_URL || ''}/api/v1/auth`;
+
+/**
+ * Both exits below are FULL-PAGE navigations, and they have to stay that way —
+ * `withConsoleBase` fixes where they land, not what kind of navigation they are
+ * (objectui#4181).
+ *
+ * A router `navigate('/')` would keep the SPA alive, and the console's shell is
+ * not built to survive an anonymous → owner transition in place:
+ * `ConsoleShell.ConnectedShellInner` mounts `MetadataProvider` once auth merely
+ * RESOLVES (it deliberately does not gate on `isAuthenticated`, objectui#4042)
+ * and keys it on `language` alone. So on a first-run deployment the metadata
+ * tree is already mounted, populated by reads that ran with no session, and
+ * nothing in its effect deps changes when `signUp()` creates one. The landing
+ * resolution the exit hands off to (`RootLandingRedirect.resolveLandingPath`)
+ * reads that app list — which would still be the empty anonymous-era one, so a
+ * router navigation drops the new owner into an appless console.
+ *
+ * The permission grant makes it worse: the bootstrap runs off a permission-grant
+ * middleware that "may land moments after signUp() resolves" (see handleSubmit),
+ * so even a re-fetch raced at exit time is not reliably the owner's world.
+ *
+ * Tearing the document down is what guarantees the console rebuilds with the
+ * session cookie present. It is also what the two sibling auth surfaces already
+ * do for the same reason — `LoginPage` and `RegisterPage` both exit through
+ * `window.location.assign(withConsoleBase(…))`.
+ */
+const POST_BOOTSTRAP_EXIT = '/';
 
 function slugify(input: string): string {
   return input
@@ -87,7 +115,7 @@ export function SetupPage() {
     // navigating here killed that in-flight rename (the org silently kept the
     // "Default Organization" name). handleSubmit owns the redirect on success.
     if (user && !submitting) {
-      window.location.assign('/');
+      window.location.assign(withConsoleBase(POST_BOOTSTRAP_EXIT));
     }
   }, [user, submitting]);
 
@@ -146,7 +174,7 @@ export function SetupPage() {
         }
       }
 
-      window.location.assign('/');
+      window.location.assign(withConsoleBase(POST_BOOTSTRAP_EXIT));
     } catch (err) {
       toast.error(
         t('auth.setup.failed', { defaultValue: 'Setup failed' }),

--- a/apps/console/src/pages/auth/__tests__/authExitBasename.test.tsx
+++ b/apps/console/src/pages/auth/__tests__/authExitBasename.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * The console's full-page auth exits land INSIDE the SPA mount (objectui#4181).
+ *
+ * ## What was broken
+ *
+ * `SetupPage` finishes the first-run owner bootstrap with a full-page
+ * navigation, twice — the already-signed-in bounce and the success path after
+ * `signUp()` + the bootstrap-org rename. Both went to a bare `'/'`.
+ * `window.location.assign` bypasses React Router's `basename`, so on a console
+ * served under an injected `<base href="/_console/">` (the framework CLI injects
+ * one for every embedded deployment) a root-relative `'/'` resolves to the
+ * ORIGIN root and drops the brand-new owner outside the SPA — on the first
+ * screen after creating their account.
+ *
+ * `LoginPage` already carried the named fix as a module-private helper. This
+ * change lifts it to `utils/consoleBase` and points all three auth surfaces at
+ * it, so the pins below come in two flavours:
+ *
+ *   - **SetupPage** — the fix. Red on the pre-fix source.
+ *   - **LoginPage / RegisterPage** — the LIFT is behaviour-neutral. These pin
+ *     the existing redirects across the same mounts so "pure lift" is a measured
+ *     claim rather than an assertion. (`RegisterPage` had its own byte-identical
+ *     copy of the helper, so the lift covered three call sites, not the two the
+ *     card assumed.)
+ *
+ * ## How landing is asserted
+ *
+ * Not by string equality against the assign argument — that would only restate
+ * the implementation, and it cannot express the shipped embeddable build, where
+ * the correct target is the RELATIVE `'./'` (see `utils/consoleBase.test.ts`).
+ * Each assertion resolves the assign target against the document's base URL,
+ * which is the resolution `location.assign` itself performs, and asks whether
+ * the result is inside the mount.
+ *
+ * The mount is configured the way a real deployment configures it: an injected
+ * `<base href>` plus the `BASE_URL` Vite baked into that build.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter } from 'react-router-dom';
+import { I18nProvider } from '@object-ui/i18n';
+
+/** Only `useAuth` is replaced — `LoginForm`/`RegisterForm` stay real. */
+let authState: Record<string, unknown>;
+vi.mock('@object-ui/auth', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAuth: () => authState,
+}));
+
+vi.mock('sonner', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, toast: { success: vi.fn(), error: vi.fn() } };
+});
+
+const { SetupPage } = await import('../SetupPage');
+const { LoginPage } = await import('../LoginPage');
+const { RegisterPage } = await import('../RegisterPage');
+
+// ---------------------------------------------------------------------------
+// Mount harness
+// ---------------------------------------------------------------------------
+
+/**
+ * The three configurations the console ships in. `baseUrl` is what Vite bakes
+ * into `import.meta.env.BASE_URL`; `href` is what the framework CLI injects.
+ */
+const MOUNTS = {
+  /** `os dev` / a bare standalone deployment. The bug is invisible here. */
+  standalone: { href: null, baseUrl: '/', basename: '/', prefix: '' },
+  /** The shipped embeddable build (`vite.config.ts` `base: './'`). */
+  embedded: { href: '/_console/', baseUrl: './', basename: '/_console', prefix: '/_console' },
+  /** A demo build pinned with `VITE_BASE_PATH=/_console/`. */
+  pinned: { href: '/_console/', baseUrl: '/_console/', basename: '/_console', prefix: '/_console' },
+} as const;
+
+type MountName = keyof typeof MOUNTS;
+
+let baseEl: HTMLBaseElement | null = null;
+let assign: ReturnType<typeof vi.fn>;
+
+function mountConsole(name: MountName, at = '/'): (typeof MOUNTS)[MountName] {
+  const mount = MOUNTS[name];
+  baseEl?.remove();
+  baseEl = null;
+  if (mount.href) {
+    baseEl = document.createElement('base');
+    baseEl.setAttribute('href', mount.href);
+    document.head.appendChild(baseEl);
+  }
+  vi.stubEnv('BASE_URL', mount.baseUrl);
+  window.history.replaceState({}, '', `${mount.prefix}${at}`);
+  return mount;
+}
+
+/** The single full-page navigation this render performed. */
+async function exitTarget(): Promise<string> {
+  await waitFor(() => expect(assign).toHaveBeenCalled());
+  return assign.mock.calls[0][0] as string;
+}
+
+/** Where that navigation actually lands, per the browser's own resolution. */
+function lands(target: string): string {
+  return new URL(target, document.baseURI).pathname;
+}
+
+beforeEach(() => {
+  assign = vi.fn();
+  vi.spyOn(window.location, 'assign').mockImplementation(assign as never);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  baseEl?.remove();
+  baseEl = null;
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+function renderAt(basename: string, ui: React.ReactElement) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <BrowserRouter basename={basename}>{ui}</BrowserRouter>
+    </I18nProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SetupPage — THE FIX
+// ---------------------------------------------------------------------------
+
+/** `hasOwner` decides whether the wizard renders or bounces. */
+function stubBootstrapStatus(hasOwner: boolean) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ hasOwner }) })),
+  );
+}
+
+function setupAuth(overrides: Record<string, unknown> = {}) {
+  authState = {
+    user: null,
+    signUp: vi.fn(async () => undefined),
+    refreshOrganizations: vi.fn(async () => [{ id: 'org_1' }]),
+    updateOrganization: vi.fn(async () => undefined),
+    createOrganization: vi.fn(async () => ({ id: 'org_1' })),
+    switchOrganization: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe('SetupPage — the first-run owner bootstrap exits into the SPA', () => {
+  describe('the success path (after signUp + the bootstrap-org rename)', () => {
+    async function completeTheWizard(name: MountName) {
+      const mount = mountConsole(name, '/setup');
+      stubBootstrapStatus(false);
+      setupAuth();
+      renderAt(mount.basename, <SetupPage />);
+
+      // The wizard only renders once the bootstrap probe answers.
+      const nameField = await screen.findByLabelText('Your name');
+      await userEvent.type(nameField, 'Ada');
+      await userEvent.type(screen.getByLabelText('Organization name'), 'Acme Inc.');
+      await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'hunter2hunter2');
+      await userEvent.click(screen.getByRole('button', { name: 'Create owner account' }));
+      return mount;
+    }
+
+    it('THE FIX: lands inside the mount on an embedded console', async () => {
+      const mount = await completeTheWizard('embedded');
+      const target = await exitTarget();
+
+      expect(lands(target)).toBe('/_console/');
+      // The pre-fix spelling — a root-relative '/' — could not satisfy this.
+      expect(lands(target).startsWith(mount.prefix)).toBe(true);
+    });
+
+    it('THE FIX: lands inside the mount on a pinned-base console', async () => {
+      await completeTheWizard('pinned');
+      expect(lands(await exitTarget())).toBe('/_console/');
+    });
+
+    it('is unchanged on the default `/` mount', async () => {
+      await completeTheWizard('standalone');
+      const target = await exitTarget();
+      expect(target).toBe('/');
+      expect(lands(target)).toBe('/');
+    });
+
+    it('still renames the bootstrap organization before exiting', async () => {
+      await completeTheWizard('embedded');
+      await exitTarget();
+      // The exit is the LAST step — the rename this page exists to perform
+      // must not have been skipped by the redirect change.
+      expect(authState.updateOrganization).toHaveBeenCalledWith('org_1', {
+        name: 'Acme Inc.',
+        slug: 'acme-inc',
+      });
+      expect(authState.switchOrganization).toHaveBeenCalledWith('org_1');
+    });
+  });
+
+  describe('the already-signed-in bounce', () => {
+    async function bounce(name: MountName) {
+      const mount = mountConsole(name, '/setup');
+      stubBootstrapStatus(true);
+      setupAuth({ user: { id: 'u1' } });
+      renderAt(mount.basename, <SetupPage />);
+      return mount;
+    }
+
+    it('THE FIX: lands inside the mount on an embedded console', async () => {
+      await bounce('embedded');
+      expect(lands(await exitTarget())).toBe('/_console/');
+    });
+
+    it('THE FIX: lands inside the mount on a pinned-base console', async () => {
+      await bounce('pinned');
+      expect(lands(await exitTarget())).toBe('/_console/');
+    });
+
+    it('is unchanged on the default `/` mount', async () => {
+      await bounce('standalone');
+      expect(await exitTarget()).toBe('/');
+    });
+  });
+
+  it('stays a FULL-PAGE navigation, not a router navigation', async () => {
+    // Load-bearing: ConsoleShell mounts MetadataProvider once auth RESOLVES
+    // (not once it authenticates) and re-keys it on `language` alone, so the
+    // app list read while nobody was signed in would survive a router
+    // navigation and land the new owner in an appless console. See the comment
+    // on POST_BOOTSTRAP_EXIT in SetupPage.
+    const mount = mountConsole('embedded', '/setup');
+    stubBootstrapStatus(true);
+    setupAuth({ user: { id: 'u1' } });
+    renderAt(mount.basename, <SetupPage />);
+
+    await exitTarget();
+    expect(assign).toHaveBeenCalledTimes(1);
+    // A router navigation would have changed the SPA's location instead.
+    expect(window.location.pathname).toBe('/_console/setup');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LoginPage / RegisterPage — the LIFT is behaviour-neutral
+// ---------------------------------------------------------------------------
+
+function postLoginAuth(overrides: Record<string, unknown> = {}) {
+  authState = {
+    user: { id: 'u1' },
+    isLoading: false,
+    organizations: [{ id: 'org_1' }],
+    isOrganizationsLoading: false,
+    activeOrganization: { id: 'org_1' },
+    switchOrganization: vi.fn(async () => undefined),
+    getAuthConfig: vi.fn(async () => ({})),
+    ...overrides,
+  };
+}
+
+describe('LoginPage — redirect behaviour is unchanged by the lift', () => {
+  it('sends a settled session to the console root, inside the mount', async () => {
+    const mount = mountConsole('embedded', '/login');
+    postLoginAuth();
+    renderAt(mount.basename, <LoginPage />);
+    expect(lands(await exitTarget())).toBe('/_console/');
+  });
+
+  it('honours a safe ?redirect= target, inside the mount', async () => {
+    const mount = mountConsole('embedded', '/login?redirect=%2Fsettings');
+    postLoginAuth();
+    renderAt(mount.basename, <LoginPage />);
+    expect(lands(await exitTarget())).toBe('/_console/settings');
+  });
+
+  it('surfaces the org picker when several orgs and no active one', async () => {
+    const mount = mountConsole('embedded', '/login');
+    postLoginAuth({
+      activeOrganization: null,
+      organizations: [{ id: 'org_1' }, { id: 'org_2' }],
+    });
+    renderAt(mount.basename, <LoginPage />);
+    expect(lands(await exitTarget())).toBe('/_console/organizations');
+  });
+
+  it('leaves a target that names its OWN absolute SPA mount untouched', async () => {
+    // The `/_` passthrough branch — re-prefixing would produce
+    // `/_console/_studio/apps` and 404.
+    const mount = mountConsole('embedded', '/login?redirect=%2F_studio%2Fapps');
+    postLoginAuth();
+    renderAt(mount.basename, <LoginPage />);
+    const target = await exitTarget();
+    expect(target).toBe('/_studio/apps');
+    expect(lands(target)).toBe('/_studio/apps');
+  });
+
+  it('is unchanged on the default `/` mount', async () => {
+    const mount = mountConsole('standalone', '/login');
+    postLoginAuth();
+    renderAt(mount.basename, <LoginPage />);
+    expect(await exitTarget()).toBe('/');
+  });
+});
+
+describe('RegisterPage — redirect behaviour is unchanged by the lift', () => {
+  it('sends a settled session to the console root, inside the mount', async () => {
+    const mount = mountConsole('embedded', '/register');
+    postLoginAuth();
+    renderAt(mount.basename, <RegisterPage />);
+    expect(lands(await exitTarget())).toBe('/_console/');
+  });
+
+  it('is unchanged on the default `/` mount', async () => {
+    const mount = mountConsole('standalone', '/register');
+    postLoginAuth();
+    renderAt(mount.basename, <RegisterPage />);
+    expect(await exitTarget()).toBe('/');
+  });
+});

--- a/apps/console/src/utils/consoleBase.test.ts
+++ b/apps/console/src/utils/consoleBase.test.ts
@@ -1,0 +1,110 @@
+/**
+ * `withConsoleBase` — the console mount prefix for full-page navigations
+ * (objectui#4181).
+ *
+ * This file measures the helper against the THREE mount configurations the
+ * console actually ships in, because the bug it exists to prevent is invisible
+ * in one of them. Under the default `/` mount the prefixed and unprefixed
+ * spellings coincide, which is exactly why `SetupPage` could go without the
+ * helper for as long as it did and no `os dev` run ever noticed.
+ *
+ * The assertion is deliberately not "the helper returns string X". It is where
+ * the returned string LANDS once the browser resolves it against the document's
+ * base URL — the same resolution `window.location.assign` performs. That is the
+ * only form in which the embedded case can be stated honestly: there the helper
+ * returns a RELATIVE url (`'./'`), which is correct precisely because the
+ * framework CLI injects the `<base href>` it resolves against. A string-equality
+ * test would have to assert `'./'` and would tell the reader nothing about
+ * whether that lands inside the SPA or outside it.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { withConsoleBase } from './consoleBase';
+
+let baseEl: HTMLBaseElement | null = null;
+
+/**
+ * Configure a console mount.
+ *
+ * @param href    the `<base href>` the framework CLI injects, or null for a
+ *                bare standalone deployment.
+ * @param baseUrl what Vite bakes into `import.meta.env.BASE_URL` for that build
+ *                (`'/'` in dev, `'./'` for the shipped embeddable build,
+ *                `'/_console/'` when pinned via `VITE_BASE_PATH`).
+ */
+function mountConsole(href: string | null, baseUrl: string): void {
+  baseEl?.remove();
+  baseEl = null;
+  if (href) {
+    baseEl = document.createElement('base');
+    baseEl.setAttribute('href', href);
+    document.head.appendChild(baseEl);
+  }
+  vi.stubEnv('BASE_URL', baseUrl);
+}
+
+/** Where a full-page navigation to `target` actually ends up. */
+function lands(target: string): string {
+  return new URL(target, document.baseURI).pathname;
+}
+
+afterEach(() => {
+  baseEl?.remove();
+  baseEl = null;
+  vi.unstubAllEnvs();
+});
+
+describe('withConsoleBase', () => {
+  describe('the shipped embeddable build — relative base + injected <base href>', () => {
+    // `vite.config.ts` defaults to `base: './'` so one dist/ works under any
+    // mount point; Vite 8 resolves that to a literal './' for BASE_URL at build
+    // time. The mount is then communicated at RUNTIME by the injected base href.
+    it('lands inside the SPA mount', () => {
+      mountConsole('/_console/', './');
+      expect(lands(withConsoleBase('/'))).toBe('/_console/');
+      expect(lands(withConsoleBase('/organizations'))).toBe('/_console/organizations');
+    });
+
+    it('THE BUG: an unprefixed path escapes the mount entirely', () => {
+      mountConsole('/_console/', './');
+      // This is the spelling SetupPage carried at both of its exits. It is a
+      // ROOT-relative url, so the base href cannot reel it back in.
+      expect(lands('/')).toBe('/');
+      expect(lands('/')).not.toBe('/_console/');
+    });
+  });
+
+  describe('pinned absolute base (VITE_BASE_PATH)', () => {
+    it('lands inside the SPA mount', () => {
+      mountConsole('/_console/', '/_console/');
+      expect(withConsoleBase('/')).toBe('/_console/');
+      expect(lands(withConsoleBase('/'))).toBe('/_console/');
+      expect(lands(withConsoleBase('/organizations'))).toBe('/_console/organizations');
+    });
+  });
+
+  describe('the default `/` mount', () => {
+    it('is a no-op — which is why the bug is invisible on a standalone run', () => {
+      mountConsole(null, '/');
+      expect(withConsoleBase('/')).toBe('/');
+      expect(withConsoleBase('/organizations')).toBe('/organizations');
+      // The prefixed and unprefixed spellings are indistinguishable here.
+      expect(lands(withConsoleBase('/'))).toBe(lands('/'));
+    });
+  });
+
+  describe('paths that already name their own absolute SPA mount', () => {
+    it('passes `/_`-prefixed targets through untouched', () => {
+      mountConsole('/_console/', '/_console/');
+      expect(withConsoleBase('/_studio/apps')).toBe('/_studio/apps');
+      expect(withConsoleBase('/_account')).toBe('/_account');
+      // Not re-prefixed into `/_console/_studio/apps`.
+      expect(lands(withConsoleBase('/_studio/apps'))).toBe('/_studio/apps');
+    });
+  });
+
+  it('tolerates a relative path by making it absolute against the mount', () => {
+    mountConsole('/_console/', '/_console/');
+    expect(withConsoleBase('organizations')).toBe('/_console/organizations');
+  });
+});

--- a/apps/console/src/utils/consoleBase.ts
+++ b/apps/console/src/utils/consoleBase.ts
@@ -1,0 +1,44 @@
+/**
+ * Console mount base — the prefix a FULL-PAGE navigation needs.
+ *
+ * Lifted out of `pages/auth/LoginPage` (objectui#4181), where it was
+ * module-private. It had already been copied once into `RegisterPage`, and
+ * `SetupPage` — which needed it just as much — silently went without: its two
+ * first-run exits navigated to a bare `'/'` and dropped a brand-new owner
+ * outside the SPA on the first screen after creating their account. One
+ * implementation, three callers, so the next basename fix lands in one place.
+ *
+ * ## The rule
+ *
+ * `window.location.assign` bypasses React Router's `basename`, so a path
+ * produced by the router (e.g. `?redirect=/settings` — already
+ * basename-stripped) or a literal like `/organizations` would resolve to
+ * `http://host/settings`, missing the `/_console` mount and 404-ing.
+ *
+ * ## Why reading `BASE_URL` is the correct source, in all three mounts
+ *
+ * The router takes its basename from the injected `<base href>`
+ * (`App.tsx:resolveBasename`) while this helper reads `import.meta.env.BASE_URL`
+ * — two different sources, which is worth spelling out because they agree only
+ * for a reason, not by construction:
+ *
+ *  - **dev / default `/` mount** — Vite resolves a relative `base` to `'/'` in
+ *    serve mode, so this is a no-op prefix and both spellings coincide. This is
+ *    why a standalone `os dev` run can never reveal the bug.
+ *  - **embedded, the shipped default** (`vite.config.ts` `base: './'`, no
+ *    `VITE_BASE_PATH`) — `BASE_URL` is the literal `'./'`, so this returns a
+ *    RELATIVE url (`'./'`, `'./organizations'`). `location.assign` resolves it
+ *    against the document base URL, which is exactly the `<base href="/_console/">`
+ *    the framework CLI injects — the same element the router reads. So the two
+ *    sources land on one answer via the browser, not via a shared constant.
+ *  - **pinned absolute base** (`VITE_BASE_PATH=/_console/`) — `BASE_URL` is
+ *    `'/_console/'` and this returns an absolute `/_console/…`.
+ *
+ * Paths already targeting another absolute SPA mount (`/_studio`, `/_account`,
+ * …) pass through untouched.
+ */
+export function withConsoleBase(path: string): string {
+  if (path.startsWith('/_')) return path;
+  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+  return base + (path.startsWith('/') ? path : `/${path}`);
+}


### PR DESCRIPTION
Fixes #4181

## Premise, re-measured at this tip

Holds, both sites, unchanged in substance since filing (they sit at `:90` and `:149` now rather than `:88`/`:148`):

- `SetupPage.tsx:90` — the already-signed-in bounce: `window.location.assign('/')`
- `SetupPage.tsx:149` — the success path, after `signUp()` and the bootstrap-org rename: `window.location.assign('/')`

`location.assign` does not go through React Router, so its `basename` never applies and a root-relative `/` leaves the SPA. PR #4180 had already landed on main and deliberately did not touch `SetupPage`, so this branched off a tip that includes it; nothing needed rebasing.

One correction to the filing, and it changes the shape of the fix: the helper was **not** only module-private to `LoginPage`. `RegisterPage.tsx:30` already carried a byte-identical copy. The drift the card predicted as "next" had already happened, so the lift covers **three** call sites, not two.

## Why the exits stay full-page navigations

The card asked this first, so it was answered before anything was written — and the answer is that the reload is load-bearing. `withConsoleBase()` fixes *where* the exits land, not *what kind* of navigation they are.

`ConsoleShell.ConnectedShellInner` mounts `MetadataProvider` as soon as auth **resolves** — it deliberately does not gate on `isAuthenticated` (objectui#4042) — and keys it on `language` alone. On a first-run deployment that means the metadata tree is already mounted and populated by reads that ran with no session, and **nothing in its effect deps changes when `signUp()` creates one**. The landing resolution the exit hands off to (`RootLandingRedirect.resolveLandingPath`) reads that app list, so a router `navigate('/')` would drop the brand-new owner into an appless console — a second dead end in place of the first.

The permission grant compounds it: the bootstrap runs off a permission-grant middleware that "may land moments after `signUp()` resolves" (`SetupPage.handleSubmit`'s own comment), so even a re-fetch raced at exit time is not reliably the owner's world. Tearing the document down is what guarantees the console rebuilds with the session cookie present.

It is also what the two sibling auth surfaces already do for the same reason — `LoginPage` and `RegisterPage` both exit through `window.location.assign(withConsoleBase(...))`. So this keeps one idiom across all three, rather than inventing a fourth behaviour for the least-exercised page.

The rationale is recorded on `POST_BOOTSTRAP_EXIT` in the source and pinned by a test, so the next reader does not have to re-derive it.

## The lift

`withConsoleBase()` moves to `apps/console/src/utils/consoleBase.ts`, byte-identical in body. `LoginPage`, `RegisterPage` and `SetupPage` all import it.

While documenting it I checked something the card did not ask about but which decides whether this fix works at all: the helper reads `import.meta.env.BASE_URL`, while the router reads the injected `base href` (`App.tsx:resolveBasename`). Two different sources — they agree for a reason rather than by construction, and that reason is now written down:

- **dev / default `/` mount** — Vite resolves a relative `base` to `/` in serve mode, so the prefix is a no-op and both spellings coincide. This is exactly why a standalone `os dev` run can never reveal the bug.
- **the shipped embeddable build** (`vite.config.ts` `base: './'`, no `VITE_BASE_PATH`) — Vite 8 bakes `BASE_URL` as the literal `./`, so the helper returns a **relative** url. `location.assign` resolves that against the document base URL, which is precisely the `base href` the framework CLI injects — the same element the router reads. The two sources meet in the browser.
- **pinned absolute base** (`VITE_BASE_PATH=/_console/`) — `BASE_URL` is `/_console/` and the helper returns an absolute path.

All three are now covered by tests, so the embedded case is asserted rather than assumed.

## Tests

New: `apps/console/src/utils/consoleBase.test.ts` (8) and `apps/console/src/pages/auth/__tests__/authExitBasename.test.tsx` (13).

Landing is **not** asserted by string equality against the `assign` argument — that would only restate the implementation, and it cannot express the embedded build at all, where the correct target is the relative `./`. Each assertion resolves the target against the document's base URL (the same resolution `location.assign` performs) and asks whether the result is inside the mount. The mount is configured the way a real deployment configures it: an injected `base href` plus the `BASE_URL` Vite baked into that build.

Beyond the two exits, the file pins that the success path still performs the org rename before exiting (the redirect change must not skip the work the page exists for), and that the exit remains a full-page navigation rather than a router one.

### Reverse verification — direction predicted before running, then observed

Predicted: reverting **only** `SetupPage.tsx` to `origin/main` turns the four basename pins red, leaves the default-mount pins green, and leaves every `LoginPage`/`RegisterPage` pin green — the last being what shows the lift is behaviour-neutral rather than merely untested.

Observed, exactly that — **4 failed | 17 passed (21)**:

```
× SetupPage > the success path > THE FIX: lands inside the mount on an embedded console
× SetupPage > the success path > THE FIX: lands inside the mount on a pinned-base console
× SetupPage > the already-signed-in bounce > THE FIX: lands inside the mount on an embedded console
× SetupPage > the already-signed-in bounce > THE FIX: lands inside the mount on a pinned-base console
```

The four reds reproduce the filing's escape (`/` instead of `/_console/`). `consoleBase.test.ts` stayed fully green — the helper was untouched by that revert — as did all seven `LoginPage`/`RegisterPage` pins and both default-`/`-mount pins. Restored, re-run: 21/21 green.

## Local gates

```
pnpm exec vitest run --maxWorkers=2 apps/console/
  Test Files  33 passed (33)      Tests  343 passed (343)

pnpm --filter @object-ui/console type-check   → clean (tsc --noEmit && tsc -b)
pnpm --filter @object-ui/console lint         → 0 errors (193 pre-existing warnings)
eslint (the 6 touched files)                  → 0 errors, 4 warnings, all pre-existing
                                                 react-hooks warnings in effects not touched here
node scripts/check-control-bytes.mjs          → OK (3862 tracked text files)
```

Build closure (`--filter '@object-ui/console^...' build`) was run first, before type-check.

Changeset: `@object-ui/console` patch — user-visible on deployed consoles.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_