### PR TITLE
ci(turbo): derive the `test` inputs guard from each package's Vitest config program (#4178)

### DIFF
--- a/scripts/__tests__/helpers/turbo-inputs.ts
+++ b/scripts/__tests__/helpers/turbo-inputs.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared plumbing for the `turbo.json` `inputs` guards.
+ *
+ * There are two of them now, and they guard the same structural defect on two
+ * different tasks:
+ *
+ *  - `turbo-type-check-inputs.test.ts` (objectui#3514) derives each package's
+ *    **tsc program** and asserts `type-check`'s inputs cover it.
+ *  - `turbo-test-inputs.test.ts` (objectui#4178) derives each package's
+ *    **Vitest configuration program** and asserts `test`'s inputs cover it.
+ *
+ * The derivations are different in kind and deliberately live apart. What is
+ * NOT different is everything around them: which directories are workspace
+ * packages, how a `$TURBO_ROOT$` entry is read out of `turbo.json`, and how a
+ * turbo input glob is matched against a path. Those three are subtle enough
+ * that a second hand-written copy would drift from the first — and a guard that
+ * drifts toward *matching more* silently waves through the very files it exists
+ * to require. One implementation, used by both.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Repo root: this file sits at `scripts/__tests__/helpers/`. */
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const turboConfigPath = path.join(repoRoot, 'turbo.json');
+const workspaceConfigPath = path.join(repoRoot, 'pnpm-workspace.yaml');
+
+/** POSIX-separated, repo-relative. The one path spelling these guards compare in. */
+export function rel(absolute: string): string {
+  return path.relative(repoRoot, absolute).split(path.sep).join('/');
+}
+
+/**
+ * Package directories, derived from `pnpm-workspace.yaml` rather than a
+ * hardcoded group list.
+ *
+ * Only the two entry shapes the file actually uses are understood (`dir/*` and
+ * a bare `dir`); anything else throws. A workspace layout a guard silently
+ * failed to walk would quietly shrink its own coverage back to nothing, which
+ * is the failure mode both guards exist to prevent.
+ */
+export function workspacePackageDirs(): string[] {
+  const yaml = fs.readFileSync(workspaceConfigPath, 'utf8');
+  const patterns: string[] = [];
+  let inPackages = false;
+  for (const line of yaml.split('\n')) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages) {
+      const item = line.match(/^\s+-\s*['"]?([^'"#]+?)['"]?\s*$/);
+      if (item) {
+        patterns.push(item[1]);
+        continue;
+      }
+      if (line.trim() !== '') break;
+    }
+  }
+  if (patterns.length === 0) {
+    throw new Error('pnpm-workspace.yaml must declare at least one package pattern');
+  }
+
+  const dirs: string[] = [];
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/*')) {
+      const group = path.join(repoRoot, pattern.slice(0, -2));
+      if (!fs.existsSync(group)) continue;
+      for (const entry of fs.readdirSync(group, { withFileTypes: true })) {
+        const dir = path.join(group, entry.name);
+        if (entry.isDirectory() && fs.existsSync(path.join(dir, 'package.json'))) dirs.push(dir);
+      }
+      continue;
+    }
+    if (!pattern.includes('*')) {
+      const dir = path.join(repoRoot, pattern);
+      if (fs.existsSync(path.join(dir, 'package.json'))) dirs.push(dir);
+      continue;
+    }
+    throw new Error(
+      `pnpm-workspace.yaml pattern ${JSON.stringify(pattern)} is a glob shape this guard does ` +
+        `not understand. Teach workspacePackageDirs() about it — do not let the sweep skip it.`,
+    );
+  }
+  return dirs.sort();
+}
+
+/** A workspace package that declares the named script, i.e. one turbo's task runs for. */
+export interface WorkspacePackage {
+  readonly name: string;
+  readonly dir: string;
+  readonly script: string;
+}
+
+/** Every workspace package whose `package.json` declares the given script. */
+export function packagesWithScript(script: string): WorkspacePackage[] {
+  const out: WorkspacePackage[] = [];
+  for (const dir of workspacePackageDirs()) {
+    const manifest = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')) as {
+      name?: string;
+      scripts?: Record<string, string>;
+    };
+    const declared = manifest.scripts?.[script];
+    if (declared) out.push({ name: manifest.name ?? rel(dir), dir, script: declared });
+  }
+  return out;
+}
+
+/**
+ * The `$TURBO_ROOT$`-anchored `inputs` of a task, as repo-relative globs.
+ *
+ * Everything else in the list is package-relative and therefore cannot reach
+ * outside the package directory — turbo has no `..` escape, which is why
+ * `$TURBO_ROOT$` exists at all.
+ */
+export function rootAnchoredInputs(task: string): string[] {
+  const turbo = JSON.parse(fs.readFileSync(turboConfigPath, 'utf8')) as {
+    tasks?: Record<string, { inputs?: string[] }>;
+  };
+  const definition = turbo.tasks?.[task];
+  if (!definition) throw new Error(`turbo.json must define a \`${task}\` task`);
+  const inputs = definition.inputs ?? [];
+  if (inputs.length === 0) throw new Error(`turbo.json \`${task}\` must declare \`inputs\``);
+
+  return inputs
+    .filter((entry) => entry.startsWith('$TURBO_ROOT$/'))
+    .map((entry) => entry.slice('$TURBO_ROOT$/'.length));
+}
+
+/**
+ * A turbo input glob as a regular expression.
+ *
+ * Deliberately narrow — `**`, `*` and `?` only. Any richer syntax (brace
+ * alternation, character classes, `!` negation) throws instead of being
+ * approximated, because an approximated match that comes out TRUE is a file
+ * the guards would wave through while turbo does not hash it. Wrong-and-red is
+ * recoverable; wrong-and-green is the bug.
+ */
+export function globToRegExp(glob: string): RegExp {
+  if (/[!{}[\]()+@]/.test(glob)) {
+    throw new Error(
+      `turbo input ${JSON.stringify(glob)} uses glob syntax this guard does not implement. ` +
+        `Teach globToRegExp() about it rather than letting it guess.`,
+    );
+  }
+  let pattern = '';
+  for (let i = 0; i < glob.length; i += 1) {
+    const char = glob[i];
+    if (char === '*') {
+      if (glob[i + 1] === '*') {
+        // `**/` spans zero or more directories; a trailing `**` spans the rest.
+        if (glob[i + 2] === '/') {
+          pattern += '(?:[^/]+/)*';
+          i += 2;
+        } else {
+          pattern += '.*';
+          i += 1;
+        }
+      } else {
+        pattern += '[^/]*';
+      }
+      continue;
+    }
+    if (char === '?') {
+      pattern += '[^/]';
+      continue;
+    }
+    pattern += char.replace(/[.^$|\\]/g, '\\$&');
+  }
+  return new RegExp(`^${pattern}$`);
+}
+
+/**
+ * Every tracked-ish file in the repo, repo-relative — dotted directories and
+ * `node_modules` skipped. Used by the phantom-input assertion both guards
+ * carry: a `$TURBO_ROOT$` entry matching nothing on disk reads as coverage
+ * while hashing nothing.
+ */
+export function repoFilesOnDisk(): Set<string> {
+  const files = new Set<string>();
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(abs);
+      else files.add(rel(abs));
+    }
+  };
+  walk(repoRoot);
+  return files;
+}

--- a/scripts/__tests__/helpers/vitest-config-program.ts
+++ b/scripts/__tests__/helpers/vitest-config-program.ts
@@ -1,0 +1,298 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { rel, repoRoot, type WorkspacePackage } from './turbo-inputs';
+
+/**
+ * Derives a workspace package's **Vitest configuration program** — the set of
+ * files Vitest reads in order to know how that package's tests run.
+ *
+ * Extracted as its own module rather than folded into the guard that consumes
+ * it (`../turbo-test-inputs.test.ts`, objectui#4178) for two reasons. It is a
+ * mechanism, not a policy: the guard decides what must be true of the result,
+ * this file decides only what the result IS. And a derivation that can only be
+ * exercised through the assertions it feeds is a derivation nobody can probe —
+ * which is how a sweep quietly degrades to returning nothing while every
+ * assertion over it stays green.
+ *
+ * ## The program
+ *
+ *  1. The config file Vitest resolves for the package's `test` script,
+ *     following the script's own `--root` / `--config` flags and then Vitest's
+ *     upward search.
+ *  2. Every file that program statically imports by RELATIVE specifier,
+ *     transitively.
+ *  3. Every file it DESIGNATES through a file-valued Vitest option
+ *     (`setupFiles`, `globalSetup`, `projects`, `workspace`) — themselves
+ *     walked as program files, which is how `vitest.setup.tsx` pulls in the
+ *     `vitest.setup.dom.tsx` it imports, and how the root config's `projects`
+ *     entry pulls in `apps/console/vitest.config.ts` and the two
+ *     `scripts/vite-*.ts` plugins that one imports.
+ *
+ * ## Narrowings, stated so they are visible rather than assumed
+ *
+ *  - THE CONFIGURATION PROGRAM, not the module closure of the tests. Vitest
+ *    resolves `@object-ui/*` through the root config's alias table straight to
+ *    other packages' `src/`, so the true read set of any package's test run is
+ *    most of the repository. Requiring that is not a stricter version of this
+ *    derivation, it is a different (and wrong) one — turbo's
+ *    `dependsOn: ["^build"]` and per-package `$TURBO_DEFAULT$` already answer
+ *    source. The failure being guarded is "change the SHARED TEST HARNESS, get
+ *    a stale verdict", and the harness is exactly this program.
+ *  - DESIGNATION IS KEY-DIRECTED, not every string in the file. A literal
+ *    counts as a designated path only inside one of the file-valued options
+ *    above. The root config also holds ~45 concrete test-file paths in
+ *    `domTsTests` / `heavyDomTests`; those are `include` / `exclude` inputs to
+ *    project definitions, covered by their own packages' inputs — not files
+ *    this program reads. A literal under a designating key that LOOKS like a
+ *    concrete source path and does not resolve throws rather than being
+ *    skipped, so a renamed setup file cannot quietly leave the program.
+ *  - BARE SPECIFIERS ARE NOT FOLLOWED. `vitest.setup.dom.tsx` imports
+ *    `@object-ui/components` for its registration side effects; that is the
+ *    alias closure of the first point, not a config file.
+ *
+ * Every narrowing errs the same way: toward requiring MORE files, and toward
+ * throwing on a shape not understood. An approximation that comes out
+ * "covered" is a file waved through while turbo does not hash it —
+ * wrong-and-red is recoverable, wrong-and-green is the bug.
+ */
+
+// ── Which config file Vitest actually loads ─────────────────────────────────
+
+/**
+ * Vitest's config candidates, in its own precedence order.
+ *
+ * Mirrors `CONFIG_NAMES` x `CONFIG_EXTENSIONS` from `vitest/dist/chunks/
+ * constants.*.js`. The order is load-bearing: `packages/components` has BOTH a
+ * `vitest.config.ts` and a `vite.config.ts`, and only the first is the config
+ * Vitest reads (the second arrives as one of its imports, which is a different
+ * fact).
+ */
+export const CONFIG_NAMES = ['vitest.config', 'vite.config'];
+export const CONFIG_EXTENSIONS = ['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs'];
+export const CONFIG_FILES = CONFIG_NAMES.flatMap((name) =>
+  CONFIG_EXTENSIONS.map((extension) => name + extension),
+);
+
+/** Extensions tried, in order, when a relative specifier carries none. */
+export const RESOLVE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
+
+/** Vitest options whose value names FILES rather than globs or data. */
+export const FILE_VALUED_OPTIONS = new Set(['setupFiles', 'globalSetup', 'projects', 'workspace']);
+
+export interface VitestInvocation {
+  /** The directory Vitest treats as its root (`--root`, else the package dir). */
+  readonly root: string;
+  /** An explicit `--config`, already resolved; `null` means "search". */
+  readonly config: string | null;
+}
+
+/**
+ * The Vitest invocation a package's `test` script performs.
+ *
+ * Every shape in the repo today is a single `vitest run [flags] [filters]`.
+ * A script that runs a test command this parser cannot read throws rather than
+ * being skipped: an unparsed script is an unswept program, and this guard's
+ * whole value is that it cannot quietly sweep nothing.
+ */
+export function invocationFor(pkgDir: string, script: string): VitestInvocation {
+  const commands = script
+    .split('&&')
+    .map((segment) => segment.trim())
+    .filter((command) => /(?:^|\s)vitest(?:\s|$)/.test(command));
+
+  if (commands.length !== 1) {
+    throw new Error(
+      `${rel(pkgDir)}: \`${script}\` does not run exactly one \`vitest\` command ` +
+        `(found ${commands.length}). Teach invocationFor() how to read it — do not let the ` +
+        `sweep skip this package.`,
+    );
+  }
+
+  const tokens = commands[0].split(/\s+/);
+  let root: string | null = null;
+  let config: string | null = null;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    const [flag, inlineValue] = token.includes('=')
+      ? [token.slice(0, token.indexOf('=')), token.slice(token.indexOf('=') + 1)]
+      : [token, null];
+    if (flag === '--root' || flag === '-r') root = inlineValue ?? tokens[++i];
+    else if (flag === '--config' || flag === '-c') config = inlineValue ?? tokens[++i];
+  }
+
+  const resolvedRoot = path.resolve(pkgDir, root ?? '.');
+  return { root: resolvedRoot, config: config === null ? null : path.resolve(resolvedRoot, config) };
+}
+
+/**
+ * The config file Vitest loads for an invocation.
+ *
+ * Reproduces `any(configFiles, { cwd: root })` — Vitest walks UP from its root,
+ * and in each directory takes the first name in `CONFIG_FILES` order that
+ * exists. This is why `packages/app-shell`, which has no config of its own,
+ * still runs under the repo-root `vitest.config.mts`; verified against the real
+ * binary, which refuses that invocation with the root config's own guard
+ * message rather than running configless.
+ *
+ * The walk stops at the repo root: a config above it is not this repo's.
+ */
+export function resolveConfigFile(invocation: VitestInvocation): string | null {
+  if (invocation.config !== null) {
+    if (!fs.existsSync(invocation.config)) {
+      throw new Error(`--config names ${rel(invocation.config)}, which does not exist.`);
+    }
+    return invocation.config;
+  }
+  let dir = invocation.root;
+  for (;;) {
+    for (const name of CONFIG_FILES) {
+      const candidate = path.join(dir, name);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    if (dir === repoRoot) return null;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// ── Walking the configuration program ───────────────────────────────────────
+
+/** Resolve a relative specifier to a file on disk, trying Vitest's extensions. */
+function resolveRelative(fromFile: string, specifier: string): string | null {
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  const candidates = [
+    base,
+    ...RESOLVE_EXTENSIONS.map((extension) => base + extension),
+    ...RESOLVE_EXTENSIONS.map((extension) => path.join(base, `index${extension}`)),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+/** Does this literal look like a concrete source path rather than a glob or a name? */
+function looksLikeSourcePath(literal: string): boolean {
+  if (/[*?{}[\]]/.test(literal)) return false;
+  return RESOLVE_EXTENSIONS.some((extension) => literal.endsWith(extension));
+}
+
+/**
+ * Every relative module specifier a source file imports, and every path it
+ * designates through a file-valued Vitest option.
+ *
+ * Parsed with TypeScript's own parser rather than regexes — `.mts`, `.tsx` and
+ * plain `.mjs` all land here, and a specifier inside a comment or a string must
+ * not count.
+ */
+export function programEdges(file: string): { imports: string[]; designated: string[] } {
+  const source = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    file.endsWith('x') ? ts.ScriptKind.TSX : undefined,
+  );
+
+  const imports: string[] = [];
+  const designated: string[] = [];
+
+  const literalValue = (node: ts.Node): string | null =>
+    ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node) ? node.text : null;
+
+  /** Collect every literal under a file-valued option's value. */
+  const collectDesignated = (node: ts.Node): void => {
+    const value = literalValue(node);
+    if (value !== null) {
+      designated.push(value);
+      return;
+    }
+    node.forEachChild(collectDesignated);
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined
+    ) {
+      const value = literalValue(node.moduleSpecifier);
+      if (value !== null) imports.push(value);
+    } else if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require')) &&
+      node.arguments.length > 0
+    ) {
+      const value = literalValue(node.arguments[0]);
+      if (value !== null) imports.push(value);
+    } else if (
+      ts.isPropertyAssignment(node) &&
+      (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) &&
+      FILE_VALUED_OPTIONS.has(node.name.text)
+    ) {
+      collectDesignated(node.initializer);
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+
+  return { imports, designated };
+}
+
+/**
+ * Every file a package's Vitest configuration program reads from outside the
+ * package directory, repo-relative and sorted.
+ */
+export function outOfPackageFiles(pkg: WorkspacePackage): string[] {
+  const entry = resolveConfigFile(invocationFor(pkg.dir, pkg.script));
+  if (entry === null) return [];
+
+  const found = new Set<string>();
+  const seen = new Set<string>();
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    if (path.relative(pkg.dir, file).startsWith('..')) found.add(rel(file));
+
+    const { imports, designated } = programEdges(file);
+
+    for (const specifier of imports) {
+      // Bare specifiers are node_modules or workspace packages — the alias
+      // closure this guard deliberately does not follow (see the docblock).
+      if (!specifier.startsWith('.')) continue;
+      const resolved = resolveRelative(file, specifier);
+      if (resolved === null) {
+        throw new Error(
+          `${rel(file)} imports ${JSON.stringify(specifier)}, which resolves to no file on disk. ` +
+            `Teach resolveRelative() about it rather than letting the program shrink silently.`,
+        );
+      }
+      queue.push(resolved);
+    }
+
+    for (const literal of designated) {
+      // A designated path is spelled either relative to the designating file
+      // (`'../../vitest.setup.tsx'`) or as `path.resolve(<this file's dir>, …)`
+      // — `__dirname` / `import.meta.dirname`, which IS that directory. Both
+      // resolve the same way, so the base is the file, not the cwd.
+      const resolved = resolveRelative(file, literal);
+      if (resolved !== null) {
+        queue.push(resolved);
+        continue;
+      }
+      if (looksLikeSourcePath(literal)) {
+        throw new Error(
+          `${rel(file)} designates ${JSON.stringify(literal)} through a file-valued Vitest ` +
+            `option, and it resolves to no file on disk. A renamed setup file must go red here, ` +
+            `not drop out of the program.`,
+        );
+      }
+    }
+  }
+  return [...found].sort();
+}

--- a/scripts/__tests__/turbo-test-inputs.test.ts
+++ b/scripts/__tests__/turbo-test-inputs.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  globToRegExp,
+  packagesWithScript,
+  rel,
+  repoFilesOnDisk,
+  rootAnchoredInputs,
+} from './helpers/turbo-inputs';
+import {
+  CONFIG_FILES,
+  invocationFor,
+  outOfPackageFiles,
+  resolveConfigFile,
+} from './helpers/vitest-config-program';
+
+/**
+ * objectui#4178 — turbo's `test` task has the same out-of-package `inputs` hole
+ * that objectui#3514 closed for `type-check`, and it has it worse.
+ *
+ * Turbo hashes a task from its `inputs`. `$TURBO_DEFAULT$` covers only files
+ * inside the package directory, and `globalDependencies` is unset — so any file
+ * the task reads from elsewhere in the repo is invisible to the cache key. When
+ * such a file changes, turbo does not re-run the task; it REPLAYS the previous
+ * verdict. Before this guard, EVERY entry in the `test` task's list was
+ * package-relative:
+ *
+ *     "inputs": ["src/**", "test/**", "tests/**", "vitest.config.*",
+ *                "vitest.setup.*", "tsconfig*.json", "package.json",
+ *                "$TURBO_DEFAULT$", and two negated markdown globs]
+ *
+ * (The two negations are spelled out in `turbo.json`, not here: a `!` glob of
+ * that shape carries the character pair that ENDS a block comment, and a
+ * docblock that terminates early takes the rest of itself down with it —
+ * `tsconfig.scripts.json` carries the same warning for the same reason.)
+ *
+ * `vitest.config.*` and `vitest.setup.*` read as if they covered the Vitest
+ * configuration. They do not: they resolve inside the package, while the files
+ * that actually decide how a package's tests run live at the repo root. Every
+ * package reaches them — `packages/core/vitest.config.ts` is two lines that
+ * re-export `../../vitest.config.mts`, and a package with no config of its own
+ * (`packages/app-shell`) resolves upward to that same root file, because Vitest
+ * looks for `vitest.config.*` / `vite.config.*` in each directory from its root
+ * upward and takes the first hit.
+ *
+ * Measured on `main` at eb5f8cea0, `@object-ui/core#test`:
+ *
+ *     baseline                                  2e2087e2c30ef125
+ *     after touching vitest.config.mts          2e2087e2c30ef125   <- frozen
+ *     after touching vitest.setup.base.ts       2e2087e2c30ef125   <- frozen
+ *     after touching vitest.setup.dom.tsx       2e2087e2c30ef125   <- frozen
+ *     after touching scripts/vitest-invocation-guard.mjs
+ *                                               2e2087e2c30ef125   <- frozen
+ *     after touching packages/core/src/index.ts 55923ba1954a7352   (control)
+ *
+ * Worse than the `type-check` instance in two ways. A package's `type-check`
+ * reaches out only where a tsconfig says so, whereas every package's test run
+ * goes through the shared Vitest configuration by construction. And the root
+ * config is not passive data: it calls `assertCanonicalVitestInvocation` from
+ * `scripts/vitest-invocation-guard.mjs`, which decides whether a run is
+ * REFUSED at all (objectui#3378 / objectui#3288). A stale replay of a `test`
+ * task is a replay of that judgement too.
+ *
+ * So this defect DERIVES its requirement rather than restating it, the way the
+ * `type-check` sibling does — but from a different program, and by a different
+ * mechanism. The derivation lives in `./helpers/vitest-config-program.ts`,
+ * which assembles each package's Vitest configuration program: the config file
+ * Vitest resolves for its `test` script, that program's transitive relative
+ * imports, and the files it designates through file-valued Vitest options.
+ * That module's docblock carries the mechanism and its stated narrowings; this
+ * file carries only the policy over the result.
+ *
+ * The policy: every file in that program that lands outside the package
+ * directory must be matched by a `$TURBO_ROOT$` input, or this test reds naming
+ * the package, the file, and the entry to add. Two assertions police the
+ * reverse direction (an entry matching nothing on disk, an entry no program
+ * requires any more), one pins the derivation's own liveness, and two pin the
+ * config-resolution premise the whole sweep rests on.
+ *
+ * The turbo-side plumbing is shared with the sibling guard via
+ * `./helpers/turbo-inputs.ts`; only the derivation differs, and it differs in
+ * kind.
+ */
+
+/** The turbo task this guard is about. */
+const TASK = 'test';
+
+/**
+ * `$TURBO_ROOT$` inputs for `test` that are deliberately NOT derivable from any
+ * package's Vitest configuration program, each with the reason it cannot be.
+ *
+ * Empty, and worth keeping that way: an entry nothing derives is an entry
+ * nobody can verify, and a glob that matches nothing at all reads as coverage
+ * while providing none.
+ */
+const INPUTS_NOT_DERIVABLE: ReadonlyMap<string, string> = new Map();
+
+// ── The derivation, computed once ───────────────────────────────────────────
+
+const PACKAGES = packagesWithScript(TASK);
+const DERIVED = PACKAGES.map((pkg) => ({ ...pkg, outside: outOfPackageFiles(pkg) }));
+const ROOT_INPUTS = rootAnchoredInputs(TASK);
+const MATCHERS = ROOT_INPUTS.map((glob) => ({ glob, re: globToRegExp(glob) }));
+
+describe('turbo `test` inputs cover every out-of-package file (objectui#4178)', () => {
+  /**
+   * The guard's own liveness. Every assertion below is vacuously true if the
+   * sweep found no packages or no out-of-package files — and a sweep that
+   * silently degrades to nothing is precisely the failure this file exists to
+   * make impossible.
+   */
+  it('sweeps the whole workspace and finds a non-empty out-of-package set', () => {
+    expect(PACKAGES.length).toBeGreaterThan(20);
+    const reaching = DERIVED.filter((pkg) => pkg.outside.length > 0);
+    expect(
+      reaching.map((pkg) => pkg.name),
+      'no package configuration program reaches outside its directory — the derivation has ' +
+        'stopped working, because at minimum packages/core/vitest.config.ts is a one-line ' +
+        're-export of ../../vitest.config.mts',
+    ).not.toHaveLength(0);
+  });
+
+  it.each(DERIVED.filter((pkg) => pkg.outside.length > 0).map((pkg) => [pkg.name, pkg] as const))(
+    '%s',
+    (_name, pkg) => {
+      const uncovered = pkg.outside.filter((file) => !MATCHERS.some(({ re }) => re.test(file)));
+      expect(
+        uncovered,
+        `${pkg.name}'s Vitest configuration program reads ${uncovered.join(', ')} from outside ` +
+          `${rel(pkg.dir)}, and turbo hashes ${TASK} from ${JSON.stringify(ROOT_INPUTS)} plus the ` +
+          `package directory. Turbo will replay a stale verdict when ${uncovered.length === 1 ? 'that file changes' : 'those files change'}. ` +
+          `Add ${uncovered.map((file) => `"$TURBO_ROOT$/${file}"`).join(', ')} to turbo.json's ` +
+          `\`${TASK}\` inputs.`,
+      ).toEqual([]);
+    },
+  );
+
+  /**
+   * The other direction. A `$TURBO_ROOT$` entry matching nothing is not
+   * harmless: it reads as coverage, survives review, and quietly stops covering
+   * the file it was written for the moment that file is renamed.
+   */
+  it('every $TURBO_ROOT$ input matches at least one file on disk', () => {
+    const onDisk = repoFilesOnDisk();
+    for (const { glob, re } of MATCHERS) {
+      expect(
+        [...onDisk].some((file) => re.test(file)),
+        `turbo.json \`${TASK}\` input "$TURBO_ROOT$/${glob}" matches no file in the repo. It is ` +
+          `hashing nothing while reading as coverage — fix the glob or delete the entry.`,
+      ).toBe(true);
+    }
+  });
+
+  /**
+   * And the entry is not merely non-empty but actually earned: some package's
+   * program reads a file it matches. This is what keeps the list SHRINKING —
+   * when a program stops reaching out, its input entry has to go with it.
+   */
+  it('every $TURBO_ROOT$ input is required by some package program', () => {
+    const derivedFiles = [...new Set(DERIVED.flatMap((pkg) => pkg.outside))];
+    for (const { glob, re } of MATCHERS) {
+      if (INPUTS_NOT_DERIVABLE.has(glob)) continue;
+      expect(
+        derivedFiles.filter((file) => re.test(file)),
+        `turbo.json \`${TASK}\` input "$TURBO_ROOT$/${glob}" is not required by any package's ` +
+          `Vitest configuration program any more. Delete it, or record why it cannot be derived ` +
+          `in INPUTS_NOT_DERIVABLE.`,
+      ).not.toHaveLength(0);
+    }
+  });
+
+  /**
+   * The derivation's own premise, pinned against the real Vitest.
+   *
+   * Everything above rests on "a package with no config of its own resolves
+   * upward to the repo-root one". That is not documented API — it is
+   * `any(configFiles, { cwd: root })` in Vitest's `createVitest`. If a future
+   * Vitest stops walking up, every configless package's derived set silently
+   * becomes empty and this guard goes quiet without a single red test. Pin the
+   * two halves that would break: the candidate ORDER (a package holding both
+   * `vitest.config.ts` and `vite.config.ts` must derive from the former) and
+   * the upward walk itself.
+   */
+  it('resolves a configless package upward to the repo-root config', () => {
+    const configless = PACKAGES.find(
+      (pkg) => !CONFIG_FILES.some((name) => fs.existsSync(path.join(pkg.dir, name))),
+    );
+    expect(configless, 'no configless package left to pin the upward walk with').toBeTruthy();
+    expect(rel(resolveConfigFile(invocationFor(configless!.dir, configless!.script))!)).toBe(
+      'vitest.config.mts',
+    );
+  });
+
+  it('prefers vitest.config.* over vite.config.* in the same directory', () => {
+    const both = PACKAGES.find(
+      (pkg) =>
+        fs.existsSync(path.join(pkg.dir, 'vitest.config.ts')) &&
+        fs.existsSync(path.join(pkg.dir, 'vite.config.ts')),
+    );
+    expect(both, 'no package holds both config spellings any more').toBeTruthy();
+    expect(rel(resolveConfigFile(invocationFor(both!.dir, both!.script))!)).toBe(
+      `${rel(both!.dir)}/vitest.config.ts`,
+    );
+  });
+});

--- a/scripts/__tests__/turbo-type-check-inputs.test.ts
+++ b/scripts/__tests__/turbo-type-check-inputs.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
+import {
+  globToRegExp,
+  packagesWithScript,
+  rel,
+  repoFilesOnDisk,
+  rootAnchoredInputs,
+} from './helpers/turbo-inputs';
 
 /**
  * objectui#3514 — turbo's `type-check` `inputs` list is hand-maintained, and it
@@ -60,10 +66,16 @@ import ts from 'typescript';
  *    out-of-package file rather than waved through on the assumption that
  *    turbo's `dependsOn: ["^build"]` covers it — `^build` covers declared
  *    DEPENDENCIES, and a tsconfig reference is not required to be one.
+ *
+ * The turbo-side plumbing this file used to carry inline — workspace discovery,
+ * reading `$TURBO_ROOT$` entries out of `turbo.json`, and matching an input
+ * glob — now lives in `./helpers/turbo-inputs.ts`, shared with the sibling
+ * guard `turbo-test-inputs.test.ts` (objectui#4178, the same defect on the
+ * `test` task). Only the DERIVATION differs between the two, and it differs in
+ * kind: tsc programs here, Vitest configuration programs there. Two copies of a
+ * glob matcher whose whole doctrine is "never approximate toward a match" is
+ * exactly the drift neither guard would survive.
  */
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-const turboConfigPath = path.join(repoRoot, 'turbo.json');
-const workspaceConfigPath = path.join(repoRoot, 'pnpm-workspace.yaml');
 
 /** The turbo task this guard is about. */
 const TASK = 'type-check';
@@ -78,67 +90,6 @@ const TASK = 'type-check';
  * include objectui#3476 found in `apps/console/tsconfig.node.json`.
  */
 const INPUTS_NOT_DERIVABLE: ReadonlyMap<string, string> = new Map();
-
-/** POSIX-separated, repo-relative. The one path spelling this file compares in. */
-function rel(absolute: string): string {
-  return path.relative(repoRoot, absolute).split(path.sep).join('/');
-}
-
-// ── Workspace discovery ──────────────────────────────────────────────────────
-
-/**
- * Package directories, derived from `pnpm-workspace.yaml` rather than a
- * hardcoded group list.
- *
- * Only the two entry shapes the file actually uses are understood (`dir/*` and
- * a bare `dir`); anything else throws. A workspace layout this guard silently
- * failed to walk would quietly shrink its own coverage back to nothing, which
- * is the failure mode it exists to prevent.
- */
-function workspacePackageDirs(): string[] {
-  const yaml = fs.readFileSync(workspaceConfigPath, 'utf8');
-  const patterns: string[] = [];
-  let inPackages = false;
-  for (const line of yaml.split('\n')) {
-    if (/^packages:\s*$/.test(line)) {
-      inPackages = true;
-      continue;
-    }
-    if (inPackages) {
-      const item = line.match(/^\s+-\s*['"]?([^'"#]+?)['"]?\s*$/);
-      if (item) {
-        patterns.push(item[1]);
-        continue;
-      }
-      if (line.trim() !== '') break;
-    }
-  }
-  expect(patterns.length, 'pnpm-workspace.yaml must declare at least one package pattern').
-    toBeGreaterThan(0);
-
-  const dirs: string[] = [];
-  for (const pattern of patterns) {
-    if (pattern.endsWith('/*')) {
-      const group = path.join(repoRoot, pattern.slice(0, -2));
-      if (!fs.existsSync(group)) continue;
-      for (const entry of fs.readdirSync(group, { withFileTypes: true })) {
-        const dir = path.join(group, entry.name);
-        if (entry.isDirectory() && fs.existsSync(path.join(dir, 'package.json'))) dirs.push(dir);
-      }
-      continue;
-    }
-    if (!pattern.includes('*')) {
-      const dir = path.join(repoRoot, pattern);
-      if (fs.existsSync(path.join(dir, 'package.json'))) dirs.push(dir);
-      continue;
-    }
-    throw new Error(
-      `pnpm-workspace.yaml pattern ${JSON.stringify(pattern)} is a glob shape this guard does ` +
-        `not understand. Teach workspacePackageDirs() about it — do not let the sweep skip it.`,
-    );
-  }
-  return dirs.sort();
-}
 
 // ── The type-check program, as the scripts actually drive it ─────────────────
 
@@ -242,91 +193,13 @@ function outOfPackageFiles(pkgDir: string, script: string): string[] {
   return [...found].sort();
 }
 
-/** Every workspace package that turbo's `type-check` task actually runs for. */
-function packagesWithTypeCheck(): { name: string; dir: string; script: string }[] {
-  const out: { name: string; dir: string; script: string }[] = [];
-  for (const dir of workspacePackageDirs()) {
-    const manifest = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')) as {
-      name?: string;
-      scripts?: Record<string, string>;
-    };
-    const script = manifest.scripts?.[TASK];
-    if (script) out.push({ name: manifest.name ?? rel(dir), dir, script });
-  }
-  return out;
-}
-
 // ── turbo.json inputs ────────────────────────────────────────────────────────
-
-/**
- * The `$TURBO_ROOT$`-anchored `inputs` of the task, as repo-relative globs.
- *
- * Everything else in the list is package-relative and therefore cannot reach
- * outside the package directory — turbo has no `..` escape, which is why
- * `$TURBO_ROOT$` exists at all.
- */
-function rootAnchoredInputs(): string[] {
-  const turbo = JSON.parse(fs.readFileSync(turboConfigPath, 'utf8')) as {
-    tasks?: Record<string, { inputs?: string[] }>;
-  };
-  const task = turbo.tasks?.[TASK];
-  expect(task, `turbo.json must define a \`${TASK}\` task`).toBeTruthy();
-  const inputs = task?.inputs ?? [];
-  expect(inputs, `turbo.json \`${TASK}\` must declare \`inputs\``).not.toHaveLength(0);
-
-  return inputs
-    .filter((entry) => entry.startsWith('$TURBO_ROOT$/'))
-    .map((entry) => entry.slice('$TURBO_ROOT$/'.length));
-}
-
-/**
- * A turbo input glob as a regular expression.
- *
- * Deliberately narrow — `**`, `*` and `?` only. Any richer syntax (brace
- * alternation, character classes, `!` negation) throws instead of being
- * approximated, because an approximated match that comes out TRUE is a file
- * this guard would wave through while turbo does not hash it. Wrong-and-red is
- * recoverable; wrong-and-green is the bug.
- */
-function globToRegExp(glob: string): RegExp {
-  if (/[!{}[\]()+@]/.test(glob)) {
-    throw new Error(
-      `turbo input ${JSON.stringify(glob)} uses glob syntax this guard does not implement. ` +
-        `Teach globToRegExp() about it rather than letting it guess.`,
-    );
-  }
-  let pattern = '';
-  for (let i = 0; i < glob.length; i += 1) {
-    const char = glob[i];
-    if (char === '*') {
-      if (glob[i + 1] === '*') {
-        // `**/` spans zero or more directories; a trailing `**` spans the rest.
-        if (glob[i + 2] === '/') {
-          pattern += '(?:[^/]+/)*';
-          i += 2;
-        } else {
-          pattern += '.*';
-          i += 1;
-        }
-      } else {
-        pattern += '[^/]*';
-      }
-      continue;
-    }
-    if (char === '?') {
-      pattern += '[^/]';
-      continue;
-    }
-    pattern += char.replace(/[.^$|\\]/g, '\\$&');
-  }
-  return new RegExp(`^${pattern}$`);
-}
 
 // ── The derivation, computed once ────────────────────────────────────────────
 
-const PACKAGES = packagesWithTypeCheck();
+const PACKAGES = packagesWithScript(TASK);
 const DERIVED = PACKAGES.map((pkg) => ({ ...pkg, outside: outOfPackageFiles(pkg.dir, pkg.script) }));
-const ROOT_INPUTS = rootAnchoredInputs();
+const ROOT_INPUTS = rootAnchoredInputs(TASK);
 const MATCHERS = ROOT_INPUTS.map((glob) => ({ glob, re: globToRegExp(glob) }));
 
 describe('turbo `type-check` inputs cover every out-of-package file (objectui#3514)', () => {
@@ -367,16 +240,7 @@ describe('turbo `type-check` inputs cover every out-of-package file (objectui#35
    * the file it was written for the moment that file is renamed.
    */
   it('every $TURBO_ROOT$ input matches at least one file on disk', () => {
-    const onDisk = new Set<string>();
-    const walk = (dir: string): void => {
-      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
-        const abs = path.join(dir, entry.name);
-        if (entry.isDirectory()) walk(abs);
-        else onDisk.add(rel(abs));
-      }
-    };
-    walk(repoRoot);
+    const onDisk = repoFilesOnDisk();
 
     for (const { glob, re } of MATCHERS) {
       expect(

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,12 @@
         "tsconfig*.json",
         "package.json",
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/vitest.config.mts",
+        "$TURBO_ROOT$/vitest.setup.*",
+        "$TURBO_ROOT$/scripts/vitest-invocation-guard.mjs",
+        "$TURBO_ROOT$/scripts/vite-*.ts",
+        "$TURBO_ROOT$/apps/console/vitest.config.ts",
+        "$TURBO_ROOT$/apps/console/vite.config.ts",
         "!**/*.md",
         "!**/CHANGELOG.md"
       ]


### PR DESCRIPTION
Fixes #4178

PR #4176 (the #3514 sibling) merged as `eb5f8cea0` before this started, so this branches off `main` rather than stacking.

## Premise check first

The card's premise holds and its headline number reproduces exactly. On `main` at `eb5f8cea0`, `@object-ui/core#test`:

```
baseline                                    2e2087e2c30ef125
after touching root vitest.config.mts       2e2087e2c30ef125     <- frozen
after touching root vitest.setup.base.ts    2e2087e2c30ef125     <- frozen
after touching root vitest.setup.dom.tsx    2e2087e2c30ef125     <- frozen
after touching scripts/vitest-invocation-guard.mjs
                                            2e2087e2c30ef125     <- frozen
after touching packages/core/src/index.ts   55923ba1954a7352     (control: moves)
```

Two things the card got wrong, both found by measuring instead of trusting the filing — which is why this ships a derivation and not the filing's list.

**The set is 10 files, not 5.** Beyond the root config and the four `vitest.setup.*`, the program also reaches `scripts/vitest-invocation-guard.mjs` (the root config calls `assertCanonicalVitestInvocation` at load — the thing that decides whether a run is *refused at all*), `apps/console/vitest.config.ts` (named in the root config's `projects`), `apps/console/vite.config.ts`, and the two `scripts/vite-*.ts` plugins that one imports.

**"Every per-package `vitest.config.ts` literally re-exports the root" is false.** 16 of 39 packages derive **zero** out-of-package files — `packages/plugin-grid/vitest.config.ts` and friends are self-contained. Had the entries been pinned from the filing's prose, the guard would have asserted a shape the repo does not have.

## What ships

**1. `scripts/__tests__/helpers/vitest-config-program.ts`** — the derivation, as its own module. A mechanism, not a policy, and a derivation only exercisable through the assertions it feeds is one nobody can probe. It assembles each package's Vitest **configuration program**:

- the config file Vitest resolves for that package's `test` script, following the script's own `--root` / `--config` and then Vitest's upward search. That search is mirrored from `vitest/dist/chunks/constants.*.js` (`CONFIG_NAMES` x `CONFIG_EXTENSIONS`) and the `any()` helper in `createVitest` — walk up from the root, first name in list order that exists wins. Verified against the real binary: `packages/app-shell` has no config of its own and `npx vitest list` there is refused by the *root* config's guard, so the upward walk is real, not assumed;
- every file that program imports by relative specifier, transitively;
- every file it **designates** through a file-valued option (`setupFiles`, `globalSetup`, `projects`, `workspace`), themselves walked.

That third step is load-bearing rather than decorative: `@object-ui/plugin-editor` and `@object-ui/plugin-markdown` reach outside their directories *only* through `setupFiles: ['../../vitest.setup.tsx']`. A pure import-chain walk — which is what the card proposed — would have missed both.

Narrowings are stated in the module's docblock rather than left implicit: the configuration program, not the alias closure of the tests (that closure is most of the repo, and is what `dependsOn: ["^build"]` plus `$TURBO_DEFAULT$` already answer); designation is key-directed, so the ~45 concrete test paths in `domTsTests` / `heavyDomTests` are `include` globs and not program files. Both narrowings err toward requiring more and toward throwing on a shape not understood.

**2. `scripts/__tests__/turbo-test-inputs.test.ts`** — the policy over that result, mirroring #4176's assertion set: every out-of-package file must be matched by a `$TURBO_ROOT$` input; two assertions police the reverse direction; one pins the sweep's liveness. Two more pin the config-resolution premise the whole sweep rests on (the upward walk, and `vitest.config.*` winning over `vite.config.*` in the same directory) — without those, a future Vitest that stopped walking up would empty every configless package's derived set and this guard would go quiet with no red test.

**3. `scripts/__tests__/helpers/turbo-inputs.ts`** — the turbo-side plumbing (workspace discovery, `$TURBO_ROOT$` extraction, glob matching) lifted out of #4176's guard, now shared. Only the derivations differ between the two guards, and they differ in kind. A second hand-written copy of a glob matcher whose entire doctrine is "never approximate toward a match" is exactly the drift neither guard would survive. #4176's own test count is unchanged at 43, which is the evidence the extraction was behaviour-preserving.

**4. `turbo.json`** — the six entries the guard's first run named:

```
+        "$TURBO_ROOT$/vitest.config.mts",
+        "$TURBO_ROOT$/vitest.setup.*",
+        "$TURBO_ROOT$/scripts/vitest-invocation-guard.mjs",
+        "$TURBO_ROOT$/scripts/vite-*.ts",
+        "$TURBO_ROOT$/apps/console/vitest.config.ts",
+        "$TURBO_ROOT$/apps/console/vite.config.ts",
```

## Measured end to end

Subject: `@object-ui/runner`, the one package whose `test` task both succeeds under turbo and runs through the root config (its script is `vitest run --root ../.. packages/runner/`, so the invocation guard passes). Defect planted: an unconditional `throw` appended to the root `vitest.setup.base.ts`.

```
=== [1] PRE-FIX, clean tree: warm the cache ===
 Tasks:    15 successful, 15 total
Cached:    10 cached, 15 total
@object-ui/runner:test:  Test Files  3 passed (3)

=== [3] PRE-FIX, defect present: re-run  <-- RED BASELINE ===
 Tasks:    15 successful, 15 total
Cached:    15 cached, 15 total
  Time:    61ms >>> FULL TURBO
exit=0
```

Not merely a stale exit code — turbo replayed the previous run's captured output verbatim, `Start at 17:58:30` and all, over a setup file that now throws on import.

```
=== [4] control: same tree, cache bypassed (--force) ===
@object-ui/runner:test: Error: objectui-4178: root vitest setup was mutated
@object-ui/runner:test:  Test Files  3 failed (3)
 Tasks:    14 successful, 15 total
Cached:    0 cached, 15 total
Failed:    @object-ui/runner#test
```

The verdict depended on cache state, not on the code. With the fix, same tree, same defect:

```
=== [5] apply the fix (turbo.json), defect still present ===
@object-ui/runner:test: Error: objectui-4178: root vitest setup was mutated
@object-ui/runner:test:  Test Files  3 failed (3)
Cached:    14 cached, 15 total          <- the test task is the one MISS
Failed:    @object-ui/runner#test

=== [6] restore vitest.setup.base.ts, keep the fix: back to green ===
@object-ui/runner:test:  Test Files  3 passed (3)
 Tasks:    15 successful, 15 total
```

And each of the nine files behind the six entries now moves the hash independently (`@object-ui/core#test`, baseline `47146abf3e1fbf25`): `vitest.config.mts` to `5c8802c4cf88c84f`, `vitest.setup.base.ts` to `070d14e80dc8a673`, `vitest.setup.dom.tsx` to `92265af76c689c45`, `vitest.setup.tsx` to `d809128224b22750`, `vitest.setup.dom-light.tsx` to `2edc9e09c9a8cdac`, `vitest-invocation-guard.mjs` to `083f717d6a07d292`, `vite-crypto-stub.ts` to `7a1265fb5e8730b5`, `apps/console/vitest.config.ts` to `d3b74eda29c8b7e4`, `apps/console/vite.config.ts` to `b751da4988a97a08`.

## Reverse verification

Each new entry removed in turn, a phantom entry added, and — the one that matters most — a new root file introduced into a chain that previously had none:

```
[1] drop $TURBO_ROOT$/vitest.config.mts       -> Tests  21 failed | 7 passed (28)
    "reads vitest.config.mts from outside apps/console"
[2] drop $TURBO_ROOT$/vitest.setup.*          -> Tests  23 failed | 5 passed (28)
    "reads vitest.setup.base.ts, vitest.setup.dom-light.tsx,
     vitest.setup.dom.tsx, vitest.setup.tsx from outside apps/console"
[3] drop $TURBO_ROOT$/scripts/vitest-invocation-guard.mjs
                                              -> Tests  21 failed | 7 passed (28)
[4] drop $TURBO_ROOT$/scripts/vite-*.ts       -> Tests  21 failed | 7 passed (28)
    "reads scripts/vite-crypto-stub.ts, scripts/vite-maplibre-worker.ts ..."
[5] drop $TURBO_ROOT$/apps/console/vitest.config.ts -> Tests  20 failed | 8 passed (28)
[6] drop $TURBO_ROOT$/apps/console/vite.config.ts   -> Tests  20 failed | 8 passed (28)

[7] add $TURBO_ROOT$/no-such-file-4178.ts     -> Tests  2 failed | 26 passed (28)
    "matches no file in the repo. It is hashing nothing while reading as coverage"
    "is not required by any package's Vitest configuration program any more"

[8] new root file enters a chain: add '../../vitest.probe-4178.ts' to
    packages/plugin-view's setupFiles (a package deriving ZERO before)
                                              -> Tests  1 failed | 28 passed (29)
    "@object-ui/plugin-view's Vitest configuration program reads
     vitest.probe-4178.ts from outside packages/plugin-view"
```

[8] is the one that separates a derivation from a restatement: the case count goes 28 to 29 because `it.each` enumerates only packages with a non-empty set, so a package that reached nowhere before now has a case at all — and it names a file no entry, comment or fixture in this PR mentions.

## Sweep — the other cached tasks, measured

The card asked for a hash-freeze probe per task rather than a guess. `build` and `lint` are the two remaining cached tasks, and both declare **no `inputs` at all**. Both are frozen:

```
$ npx turbo run lint --filter @object-ui/core --dry=json
  baseline                             79872f192ee4828c
  after touching eslint.config.js      79872f192ee4828c     <- frozen

$ npx turbo run build --filter @object-ui/core --dry=json
  baseline                             3f85d1417964dce6
  after touching tsconfig.json         3f85d1417964dce6     <- frozen
  after touching tsconfig.base.json    3f85d1417964dce6     <- frozen

$ npx turbo run build --filter @object-ui/console --dry=json
  baseline                             e6c5943a3e062002
  after touching scripts/vite-crypto-stub.ts
                                       e6c5943a3e062002     <- frozen
```

Filed, not fixed here — this PR is scoped to `test`: #4184 (`lint`, the root flat config that *is* the lint program) and #4185 (`build`, root tsconfigs plus the Vite plugins, and the highest-stakes of the three since `dist/` is what every other task consumes).

## Gates

```
pnpm exec vitest run scripts/__tests__/turbo-test-inputs.test.ts
   Tests  28 passed (28)

pnpm exec vitest run scripts/__tests__          (whole scripts suite)
   Test Files  34 passed (34)    Tests  707 passed (707)

pnpm type-check:scripts                          exit=0
node scripts/check-control-bytes.mjs             OK (3854 tracked text files)
npx eslint (the two guards + the two helpers)    exit=0

turbo run test --filter @object-ui/runner        cold-run green post-change
   Tasks: 15 successful, 15 total
```

**Changeset:** none owed — `check-changeset-presence.mjs` arbitrates: *"No source of a released package changed in this range, so no changeset is owed."* No `skip-changeset` label per #3724.

One thing worth flagging for triage, since it narrows this card's blast radius without touching its premise: `ci.yml` deliberately does **not** run `turbo run test` (it runs the canonical root Vitest once, sharded, with a comment explaining why). So the stale-replay this closes bites local `turbo run test` and any future CI use of it, rather than today's CI test job — unlike #4184 and #4185, where `lint.yml` and `ci.yml` do run the cached turbo task with `.turbo/cache` persisted.

## Out of scope, noticed while measuring

`@object-ui/plugin-editor`'s `test` task is already red on `main`, independently of this change: its `vite.config.ts` aliases `@object-ui/fields` to source but not `@object-ui/providers`, so the heavy setup graph fails to resolve (`Failed to resolve import "@object-ui/providers" from "../fields/src/widgets/FileField.tsx"`). Not filed as part of this card's sweep since it is a different mechanism; flagging it here for the PM to decide whether it wants its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
