### PR TITLE
fix(list): the filter panel no longer persists a view overlay over the source-defined filter

### DIFF
--- a/.changeset/filter-panel-no-view-overlay-4155.md
+++ b/.changeset/filter-panel-no-view-overlay-4155.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Using a list's filter panel no longer overwrites the view's source-declared `filter` for everyone
+
+Opening a Console list view's filter panel and clicking **Add filter** wrote a view-customization overlay into `sys_metadata`. The row that button inserts is incomplete by construction — `{ field: <first column>, operator: 'equals', value: '' }` — and a view override is merged over the source-declared view key-wise (`{ ...source, ...override }`), so that one stray condition became the view's *entire* `filter`. The list then came back `total: 0` on every subsequent visit, for every user of the view, and the panel's own **Clear all** could not undo it: clearing wrote `filter: []`, which is still an override that deletes the source declaration. Recovery required deleting the `sys_metadata` row and restarting the service.
+
+Two independent changes, because the defect had a write half and a read half.
+
+**The write is gone.** `persistViewFilter` and both `onFilterChange` persist bindings are removed: a filter-panel interaction is transient state belonging to the session and to `writeListFilterState`'s per-browser restore, never to the view's stored body. The threshold for writing a view overlay is now an explicit save — `handleViewConfigSave`, and `ObjectDataPage`'s "Save as view". `ObjectDataPage` had already made exactly this call for the sibling surface ("Deliberately NO onSortChange/onFilterChange persistence hooks", #2251); this surface was the outlier. The surviving handler still writes localStorage, so the panel is not amnesiac — it just no longer speaks for every other user of the view. `foldFilterGroupToSpecRules` (objectstack#5159) survives untouched and is still the one dialect for the explicit paths; what was removed is the automatic write, not the fold.
+
+**Already-poisoned installs self-heal on read.** `sanitizeViewOverride` runs on both branches of `loadViewOverrides` and strips conditions an overlay must never impose — an empty value against an operator that wants one, in both the spec `ViewFilterRule` shape and the legacy runtime triple — then drops the `filter` **key** entirely when nothing effective survives. Dropping the key rather than writing `[]` is the whole point, and the merge semantics are measured in the tests rather than assumed: `filter: []` wins the spread and blanks the declaration, whereas no `filter` key falls through to it. So a stored `field equals ""` and a stored `filter: []` both stop overriding, and the source filter wins again on the next load — no `sys_metadata` surgery, no restart.
+
+One consequence is deliberate and worth naming: an overlay can no longer express "this view has NO filter" over a source view that declares one. That is the strictly safer side of the trade, because the shape that expressed it is the same shape that silently erased source declarations; an author who genuinely wants no filter edits the view, which writes the view body rather than an overlay.
+
+The existing objectstack#5159 ratchet is retargeted rather than deleted — it now asserts that *no* filter reaches the view-config persist path, that the `persistViewFilter` seam does not exist to be called, and that no `onFilterChange` handler reaches any persist call, with the explicit-save path pinned alongside as a control.

--- a/.changeset/list-filtered-empty-copy-4155.md
+++ b/.changeset/list-filtered-empty-copy-4155.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/plugin-list': patch
+---
+
+A list emptied by the view's own filter says "no records match", instead of inviting you to create your first record
+
+`ListView`'s empty state distinguishes "filtered to empty" from "truly empty (first run)", but the view's own declared `filter` did not count toward that decision — only the search term, the user-filter conditions and the toolbar's live filter group did. A view that returns nothing *because it is filtered* therefore rendered the first-run copy over an object full of records.
+
+That is a small string, and it cost real triage time. In objectui#4155 a stored overlay filter had emptied a list, and the screen said "no data yet / create your first record" — so the report read as data loss or a permission problem, and the investigation went to the data and permission layers rather than to the view layer where the defect was. The same misread is available without any bug at all: a perfectly healthy view declaring `status not_in [archived, deleted]` over an object whose rows are all archived told the user the object was empty.
+
+The base `filter` now counts as an active query, in both at-rest shapes (an array of conditions, and the Mongo-style object form). No new copy — this only routes to the `list.noMatches` / `list.noMatchesMessage` strings that already exist in all ten locales, so there are no new keys to translate. An author-supplied `emptyState.title` / `emptyState.message` still wins over both branches, unchanged.

--- a/packages/app-shell/src/views/ObjectView.overlayFilterRecovery.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.overlayFilterRecovery.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4155, the RECOVERY half — a poisoned view overlay must stop
+ * overriding the source-declared filter, on READ, without a `sys_metadata`
+ * delete and a service restart.
+ *
+ * Two overlay bodies were destructive, both written by the filter panel:
+ *
+ *   `filter: [{ field: 'x', operator: 'equals', value: '' }]` — the row
+ *      `Add filter` inserts. The live grid never applied it, but merged over
+ *      the source view (`{ ...source, ...override }`) it BECAME the view's
+ *      whole filter, so the list came back `total: 0` for every user.
+ *   `filter: []` — what "Clear all" wrote. Not poisoned, but it still deletes
+ *      the source declaration (`status not_in [archived, deleted]`) silently.
+ *
+ * The merge semantics are MEASURED here, not assumed, because the fix rests on
+ * them: `{ ...source, ...override }` is key-wise, so an override carrying
+ * `filter: []` is NOT the same as an override carrying no `filter` — the first
+ * replaces the declaration with "no filter", the second falls through to it.
+ * That is why the sanitizer deletes the key rather than writing an empty array.
+ *
+ * SUITE DIRECTION — predicted, then MEASURED, and the two did not agree; the
+ * measured result is the one recorded here.
+ *
+ * Predicted: the first two blocks RED against `origin/main` (which returns the
+ * override untouched), while the `what must NOT change` block stayed green in
+ * both worlds as a control.
+ *
+ * Measured (revert the three source files, keep these tests): **every** case in
+ * this file goes red — 24 red / 13 green across the #4155 suites. The control
+ * block goes red too, and NOT for a behavioural reason: `sanitizeViewOverride`
+ * does not exist on `origin/main`, so the import on the next line fails and the
+ * whole module dies before a single assertion runs.
+ *
+ * Worth stating plainly, because it bounds what this file can prove: against
+ * `origin/main` the control cases are NOT discriminating — a missing export
+ * cannot tell "kept the real conditions" apart from "module did not load". They
+ * are controls in the FORWARD direction only, pinning what must not change as
+ * the sanitizer is edited from here on. The cases that genuinely discriminate
+ * old behaviour from new are the ones whose failure message quotes a VALUE
+ * (`expected [ { field: 'status', … } ] to deeply equal []`), not an import.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { loadViewOverrides, sanitizeViewOverride } from './ObjectView';
+
+/** The source-declared view body — what the overlay must not be able to erase. */
+const SOURCE_VIEW = {
+    label: 'All work orders',
+    columns: ['name', 'status'],
+    filter: [{ field: 'status', operator: 'not_in', value: ['archived', 'deleted'] }],
+};
+
+/** The overlay row the filter panel wrote on `Add filter`. */
+const POISONED_OVERLAY = {
+    name: 'wo.all',
+    object: 'work_order',
+    filter: [{ field: 'name', operator: 'equals', value: '' }],
+};
+
+describe('sanitizeViewOverride — the stray empty-value condition (#4155)', () => {
+    it('drops the `field equals ""` condition the panel wrote', () => {
+        expect(sanitizeViewOverride(POISONED_OVERLAY)).toEqual({
+            name: 'wo.all',
+            object: 'work_order',
+        });
+    });
+
+    it('drops the `filter` KEY, not just its contents — that is what restores the source filter', () => {
+        const sanitized = sanitizeViewOverride(POISONED_OVERLAY);
+        // `filter: []` would still win the spread and blank the declaration.
+        expect('filter' in sanitized).toBe(false);
+    });
+
+    it('MEASURED merge semantics: the source-declared filter wins again', () => {
+        // Exactly the merge `ObjectView`'s `views` memo performs.
+        const merged = { ...SOURCE_VIEW, ...sanitizeViewOverride(POISONED_OVERLAY) };
+        expect(merged.filter).toEqual(SOURCE_VIEW.filter);
+    });
+
+    it('…and the UNSANITIZED overlay is what destroyed it — the control', () => {
+        const merged = { ...SOURCE_VIEW, ...POISONED_OVERLAY };
+        expect(merged.filter).toEqual([{ field: 'name', operator: 'equals', value: '' }]);
+        expect(merged.filter).not.toEqual(SOURCE_VIEW.filter);
+    });
+
+    it('keeps the overlay’s OTHER personalization — only the filter opinion is dropped', () => {
+        const sanitized = sanitizeViewOverride({
+            ...POISONED_OVERLAY,
+            rowHeight: 'short',
+            columnState: { order: ['status', 'name'] },
+        });
+        expect(sanitized.rowHeight).toBe('short');
+        expect(sanitized.columnState).toEqual({ order: ['status', 'name'] });
+        expect('filter' in sanitized).toBe(false);
+    });
+});
+
+describe('sanitizeViewOverride — "Clear all" left an empty filter (#4155)', () => {
+    it('an overlay with `filter: []` no longer blanks the source declaration', () => {
+        const cleared = { name: 'wo.all', object: 'work_order', filter: [] };
+        const merged = { ...SOURCE_VIEW, ...sanitizeViewOverride(cleared) };
+        expect(merged.filter).toEqual(SOURCE_VIEW.filter);
+    });
+
+    it('the empty array is dropped even though nothing was FILTERED OUT of it', () => {
+        // Regression guard for the ordering bug this fix nearly shipped: an
+        // "unchanged → return as-is" shortcut ahead of the empty check hands
+        // `filter: []` straight back.
+        expect('filter' in sanitizeViewOverride({ name: 'v', filter: [] })).toBe(false);
+    });
+});
+
+describe('sanitizeViewOverride — what must NOT change', () => {
+    it('keeps an overlay filter that carries real conditions (an explicit save)', () => {
+        const saved = {
+            name: 'wo.mine',
+            filter: [{ field: 'owner', operator: 'equals', value: 'u1' }],
+        };
+        expect(sanitizeViewOverride(saved)).toEqual(saved);
+        expect({ ...SOURCE_VIEW, ...sanitizeViewOverride(saved) }.filter).toEqual(saved.filter);
+    });
+
+    it('keeps a value-less operator — `is_empty` needs no value to be complete', () => {
+        const saved = { name: 'v', filter: [{ field: 'closed_at', operator: 'is_empty' }] };
+        expect(sanitizeViewOverride(saved)).toEqual(saved);
+    });
+
+    it('keeps the real conditions and drops only the stray one', () => {
+        const mixed = {
+            name: 'v',
+            filter: [
+                { field: 'owner', operator: 'equals', value: 'u1' },
+                { field: 'name', operator: 'equals', value: '' },
+            ],
+        };
+        expect(sanitizeViewOverride(mixed).filter).toEqual([
+            { field: 'owner', operator: 'equals', value: 'u1' },
+        ]);
+    });
+
+    it('handles the legacy runtime TRIPLE shape a source view may declare', () => {
+        // `persistViewPatch` copies the whole view body into the overlay, so an
+        // overlay's `filter` can be triples rather than spec rule objects.
+        expect(sanitizeViewOverride({ name: 'v', filter: [['status', '=', '']] }))
+            .toEqual({ name: 'v' });
+        const real = { name: 'v', filter: [['status', 'not_in', ['archived']]] };
+        expect(sanitizeViewOverride(real)).toEqual(real);
+    });
+
+    it('leaves a non-array (Mongo-style object) filter alone', () => {
+        const objFilter = { name: 'v', filter: { status: { $ne: 'archived' } } };
+        expect(sanitizeViewOverride(objFilter)).toEqual(objFilter);
+    });
+
+    it('passes through overrides with no filter at all, and non-objects', () => {
+        expect(sanitizeViewOverride({ name: 'v', rowHeight: 'tall' })).toEqual({ name: 'v', rowHeight: 'tall' });
+        expect(sanitizeViewOverride(null)).toBe(null);
+        expect(sanitizeViewOverride(undefined)).toBe(undefined);
+    });
+});
+
+describe('loadViewOverrides applies the sanitizer on BOTH read branches (#4155)', () => {
+    const IDS = ['wo.all'];
+
+    it('the batch branch', async () => {
+        const dataSource = {
+            listViewOverrides: vi.fn(async () => ({ 'wo.all': POISONED_OVERLAY })),
+            getView: vi.fn(),
+        };
+        const map = await loadViewOverrides(dataSource, 'work_order', IDS);
+        expect('filter' in map['wo.all']).toBe(false);
+    });
+
+    it('the per-view fallback branch', async () => {
+        // Only `getView` — the branch a minimal adapter takes. A poisoned row
+        // read here reached the merge untouched before this fix.
+        const dataSource = { getView: vi.fn(async () => POISONED_OVERLAY) };
+        const map = await loadViewOverrides(dataSource, 'work_order', IDS);
+        expect('filter' in map['wo.all']).toBe(false);
+    });
+
+    it('#3774 stays intact: a rejecting batch still falls through to per-view', async () => {
+        const dataSource = {
+            listViewOverrides: vi.fn(async () => { throw new Error('503'); }),
+            getView: vi.fn(async () => ({ name: 'wo.all', rowHeight: 'short' })),
+        };
+        const map = await loadViewOverrides(dataSource, 'work_order', IDS);
+        expect(map).toEqual({ 'wo.all': { name: 'wo.all', rowHeight: 'short' } });
+        expect(dataSource.getView).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -14,7 +14,7 @@ import { useParams, useSearchParams, useNavigate, useLocation } from 'react-rout
 import { resolveFilterPlaceholders, DENSITY_MODE_TO_ROW_HEIGHT, normalizeListViewSchema, type FilterTokenScope } from '@object-ui/core';
 import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState';
 import { buildListFilterKey, readListFilterState, writeListFilterState } from './listFilterStorage';
-import { foldFilterGroupToSpecRules, FILTER_FOLD_REFUSAL_KEYS } from './viewFilterFold';
+import { VALUELESS_FILTER_OPERATORS } from './viewFilterFold';
 const ObjectChart = lazy(() =>
   import('@object-ui/plugin-charts').then((m) => ({ default: m.ObjectChart })),
 );
@@ -210,6 +210,76 @@ export function defaultListColumnsFromObject(
  * the authoritative branch and makes the fallback below unreachable code —
  * that was objectui#3774's second half, fixed in `@object-ui/data-objectstack`.
  */
+/**
+ * Strip conditions an overlay must never impose, and drop the `filter` key
+ * entirely when nothing effective is left (objectui#4155).
+ *
+ * A view override is merged over the source-declared view as `{ ...source,
+ * ...override }`, so its `filter` key REPLACES the view's declared filter
+ * wholesale. That made two overlay bodies destructive:
+ *
+ *   `filter: [{ field: 'x', operator: 'equals', value: '' }]`
+ *        — an incomplete filter-panel row. The live query never applied it
+ *          (`convertFilterGroupToAST` skips empty values), but as a stored
+ *          overlay it became the view's ENTIRE filter and returned `total: 0`:
+ *          the "empty list that used to have rows" this issue reports.
+ *   `filter: []`
+ *        — what "Clear all" wrote. Not a poisoned filter, but still an override
+ *          that silently deletes the source declaration (an archived-records
+ *          exclusion, say) for everyone.
+ *
+ * Both are neutralized HERE, on the read path, so an install already carrying a
+ * poisoned row self-heals on the next load rather than needing a `sys_metadata`
+ * delete plus a service restart. The write that created them is gone too (the
+ * filter panel no longer persists anything) — this is the recovery half.
+ *
+ * Consequence, deliberate and worth naming: an overlay can no longer express
+ * "this view has NO filter" over a source view that declares one. That is the
+ * strictly safer side of the trade — the shape that expressed it is the same
+ * shape that silently erased source declarations, and an author who genuinely
+ * wants no filter edits the view (an explicit save), which writes the view body
+ * rather than an overlay.
+ *
+ * Filter entries are matched in both at-rest shapes: spec `ViewFilterRule`
+ * objects (`{ field, operator, value }`, what the fold writes) and the legacy
+ * runtime triple `[field, operator, value]` a source view may declare and which
+ * `persistViewPatch` copies into the overlay along with the rest of the view.
+ */
+export function sanitizeViewOverride(override: any): any {
+    if (!override || typeof override !== 'object') return override;
+    if (!Array.isArray(override.filter)) return override;
+
+    const kept = override.filter.filter((entry: any) => {
+        if (Array.isArray(entry)) {
+            // Legacy runtime triple: [field, operator, value]
+            if (entry.length < 2) return false;
+            const [, operator, value] = entry;
+            if (VALUELESS_FILTER_OPERATORS.has(String(operator))) return true;
+            return !(value == null || value === '' || (Array.isArray(value) && value.length === 0));
+        }
+        if (!entry || typeof entry !== 'object') return false;
+        if (typeof entry.field !== 'string' || entry.field === '') return false;
+        if (VALUELESS_FILTER_OPERATORS.has(String(entry.operator))) return true;
+        const value = entry.value;
+        return !(value == null || value === '' || (Array.isArray(value) && value.length === 0));
+    });
+
+    // The empty-array case is checked FIRST: `filter: []` (Clear all's write)
+    // leaves `kept.length === override.filter.length`, so an "unchanged"
+    // shortcut ahead of this would hand the destructive empty override straight
+    // back.
+    if (kept.length === 0) {
+        // Nothing effective survives → the overlay carries no opinion about the
+        // filter, so the SOURCE-declared filter must win again. Dropping the key
+        // (rather than writing `[]`) is what makes the `{ ...source, ...override }`
+        // merge fall through to it.
+        const { filter: _dropped, ...rest } = override;
+        return rest;
+    }
+    if (kept.length === override.filter.length) return override;
+    return { ...override, filter: kept };
+}
+
 export async function loadViewOverrides(
     dataSource: any,
     objectName: string,
@@ -221,7 +291,7 @@ export async function loadViewOverrides(
             if (all && typeof all === 'object') {
                 const map: Record<string, any> = {};
                 for (const id of ids) {
-                    if (all[id]) map[id] = all[id];
+                    if (all[id]) map[id] = sanitizeViewOverride(all[id]);
                 }
                 return map;
             }
@@ -242,7 +312,7 @@ export async function loadViewOverrides(
     );
     const map: Record<string, any> = {};
     for (const [id, v] of entries) {
-        if (v && typeof v === 'object') map[id] = v;
+        if (v && typeof v === 'object') map[id] = sanitizeViewOverride(v);
     }
     return map;
 }
@@ -358,33 +428,29 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         [dataSource, objectName]
     );
 
-    /**
-     * Persist a toolbar filter change (objectstack#5159).
+    /*
+     * There is deliberately NO `persistViewFilter` here (objectui#4155).
      *
-     * The list toolbar's FilterBuilder emits its own grouped dialect
-     * (`{ id, logic, conditions }`); `ListViewSchema.filter` declares
-     * `ViewFilterRule[]`. Handing the group straight to `persistViewPatch` is
-     * what made every `Filter → Add filter` PUT come back 422 `invalid_union`.
-     * Fold at the producer (AGENTS.md #0.1) — the spec is not widened.
+     * The list toolbar's filter panel is TRANSIENT state — it belongs to the
+     * session (and to `writeListFilterState`'s per-browser restore), not to the
+     * view's stored body. It used to persist: every `onFilterChange` the panel
+     * emitted was folded and written to the view overlay, so merely opening the
+     * panel and clicking `Add filter` wrote an incomplete `field equals ''`
+     * condition into `sys_metadata` — which then REPLACED the source-declared
+     * `filter` for every user of that view and emptied the list, unrecoverably
+     * from the panel itself.
      *
-     * A group that cannot fold LOSSLESSLY (`logic: 'or'` across several
-     * conditions, or a nested group) is refused out loud and NOT saved, rather
-     * than quietly written as AND: an AND rewrite would return a different
-     * record set than the one the user is looking at. The filter still applies
-     * to the live grid — `convertFilterGroupToAST` honours `logic` in-session —
-     * it just does not become part of the stored view.
+     * The threshold for writing a view overlay is an EXPLICIT save:
+     * `handleViewConfigSave` (the view config panel) and `handleSaveAsView`
+     * (`ObjectDataPage`). `ObjectDataPage` already made this choice for the
+     * sibling surface — "Deliberately NO onSortChange/onFilterChange
+     * persistence hooks: this surface never writes back to any saved view"
+     * (#2251) — and this surface was the outlier.
+     *
+     * `foldFilterGroupToSpecRules` (objectstack#5159) is still the one dialect
+     * for those explicit paths — the Studio inspector's `FilterBuilderField`
+     * folds through it. What is gone is the automatic write, not the fold.
      */
-    const persistViewFilter = useCallback(
-        (viewIdLocal: string, baseViewDef: Record<string, any>, group: unknown) => {
-            const folded = foldFilterGroupToSpecRules(group);
-            if (!folded.ok) {
-                toast.error(t(FILTER_FOLD_REFUSAL_KEYS[folded.reason]));
-                return;
-            }
-            persistViewPatch(viewIdLocal, baseViewDef, { filter: folded.rules });
-        },
-        [persistViewPatch, t]
-    );
 
     const handleViewConfigSave = useCallback((draft: Record<string, any>) => {
         setViewDraft(draft);
@@ -1417,9 +1483,9 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
             onSortChange: (sort: any) => {
                 persistViewPatch(viewDef.id, viewDef, { sort });
             },
-            onFilterChange: (filter: any) => {
-                persistViewFilter(viewDef.id, viewDef, filter);
-            },
+            // NO `onFilterChange` (objectui#4155): the filter panel is session
+            // state. ListView keeps it in `currentFilters` and applies it to the
+            // live query; nothing about it reaches the stored view.
             onHiddenFieldsChange: (hidden: string[]) => {
                 persistViewPatch(viewDef.id, viewDef, { hiddenFields: hidden });
             },
@@ -1666,11 +1732,13 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                     persistViewPatch(viewDef.id, viewDef, { sort });
                 }}
                 onFilterChange={(filter: any) => {
-                    persistViewFilter(viewDef.id, viewDef, filter);
-                    // localStorage keeps the BUILDER's group verbatim — it is
-                    // read back into `initialFilters`, which needs `conditions`
-                    // (and the row ids) to rehydrate the toolbar. Only the
-                    // spec-governed view body is folded.
+                    // SESSION state only (objectui#4155) — localStorage keeps
+                    // the BUILDER's group verbatim, read back into
+                    // `initialFilters`, which needs `conditions` (and the row
+                    // ids) to rehydrate the toolbar. This restore is per
+                    // browser and the panel's own "Clear all" clears it: it
+                    // writes an empty group through this same handler. Nothing
+                    // here touches the view's stored body.
                     writeListFilterState(listFilterKey, { filters: filter });
                 }}
                 onSearchChange={(search: string) => {
@@ -1692,7 +1760,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 dataSource={ds}
             />
         );
-    }, [activeView, objectDef, objectName, refreshKey, navOverlay, actions, persistViewPatch, persistViewFilter, urlFilters, initialUfSelections, handleUserFilterSelectionsChange, user?.id]);
+    }, [activeView, objectDef, objectName, refreshKey, navOverlay, actions, persistViewPatch, urlFilters, initialUfSelections, handleUserFilterSelectionsChange, user?.id]);
 
     // Memoize the merged views array so PluginObjectView doesn't get a new
     // reference on every render (which would trigger unnecessary data refetches).

--- a/packages/app-shell/src/views/view-filter-fold.ratchet.test.ts
+++ b/packages/app-shell/src/views/view-filter-fold.ratchet.test.ts
@@ -2,27 +2,35 @@
  * ObjectUI
  * Copyright (c) 2024-present ObjectStack Inc.
  *
- * objectstack#5159 ratchet — the FilterBuilder's `FilterGroup` must never
- * reach a persisted view `filter` again.
+ * Two ratchets on one call site, in order of strength.
  *
- * The bug: the runtime list toolbar handed `onFilterChange`'s payload straight
- * to `persistViewPatch({ filter })`. That payload is the builder's grouped
- * dialect (`{ id, logic, conditions }`); `ListViewSchema.filter` declares
- * `z.array(ViewFilterRuleSchema)`. Every `Filter → Add filter → save` came back
- * 422 `invalid_union` — and because objectstack#5014 flattens union errors to a
- * bare "Invalid input" that never names `filter`, it lived on `main` unnoticed.
+ * **objectui#4155 (the current contract): the list toolbar's filter panel must
+ * not persist ANYTHING.** Filter-panel state is transient — it belongs to the
+ * session and to `writeListFilterState`'s per-browser restore, not to the
+ * view's stored body. It used to write a view-customization overlay on every
+ * `onFilterChange`, so opening the panel and clicking `Add filter` put an
+ * incomplete `field equals ''` condition into `sys_metadata`, where it REPLACED
+ * the source-declared `filter` for every user of that view and emptied the
+ * list. Overlay writes belong to an EXPLICIT save (`handleViewConfigSave`, and
+ * `ObjectDataPage`'s "Save as view").
  *
- * `viewFilterFold.test.ts` pins what the fold PRODUCES. This pins that the
- * persist path still GOES THROUGH it: a shape assertion on the transform is
- * worth nothing if a future edit routes a raw group around it. The two together
- * close the issue's replay matrix at the persist-call boundary — variant ① (the
- * captured `FilterGroup`) is unreachable, variant ③ (declared keys only) is
- * what the PUT carries.
+ * **objectstack#5159 (subsumed, still pinned): the FilterBuilder's
+ * `FilterGroup` must never reach a persisted view `filter`.** Its bug was that
+ * the toolbar handed `onFilterChange`'s payload straight to
+ * `persistViewPatch({ filter })` — the builder's grouped dialect against
+ * `ListViewSchema.filter`'s `z.array(ViewFilterRuleSchema)`, so every
+ * `Filter → Add filter → save` came back 422 `invalid_union`. #4155 removes the
+ * write entirely, which is strictly stronger for THIS call site; the fold
+ * survives because the explicit save paths still need it, and this file keeps
+ * guarding them.
  *
- * If this fails: do not re-add `persistViewPatch(…, { filter })`. Route the
- * group through `persistViewFilter` (ObjectView) / `foldFilterGroupToSpecRules`
- * (`./viewFilterFold`), which folds to `ViewFilterRule[]` and refuses — out
- * loud — the shapes that cannot fold losslessly.
+ * If the #4155 assertions fail: do not re-add a filter persist to any toolbar
+ * handler. A user's panel interaction is not a save.
+ *
+ * If the #5159 assertions fail: route the group through
+ * `foldFilterGroupToSpecRules` (`./viewFilterFold`), which folds to
+ * `ViewFilterRule[]` and refuses — out loud — the shapes that cannot fold
+ * losslessly.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -39,35 +47,39 @@ const widgetsSrc = readFileSync(widgetsPath, 'utf8');
 
 /**
  * Every `persistViewPatch(…, { filter … })` in the file — the call that shipped
- * the group. Exactly ONE is legitimate: the one inside `persistViewFilter`,
- * whose value is the fold's output. Any other is the bug returning.
+ * the group, and (via the fold) the call that shipped the overlay. Since #4155
+ * there must be NONE: the toolbar persists sort / hiddenFields / columnState /
+ * rowHeight, never the filter.
  */
 const FILTER_PERSIST_CALLS = /persistViewPatch\s*\([^;]*?\{\s*filter\s*(?::\s*([A-Za-z0-9_.]+))?/gs;
 
-describe('objectstack#5159 ratchet — no raw FilterGroup on the view persist path', () => {
+describe('objectui#4155 ratchet — the filter panel persists nothing', () => {
     it('the ratchet is reading real source, not an empty string', () => {
         expect(objectViewSrc.length).toBeGreaterThan(10_000);
         expect(widgetsSrc.length).toBeGreaterThan(10_000);
-        // Sanity: the guarded symbol still exists under these names.
+        // Sanity: the sibling persist helper this file reasons about still
+        // exists under this name (the toolbar DOES persist other keys).
         expect(objectViewSrc).toContain('persistViewPatch');
     });
 
-    it('the only `filter` patch ObjectView persists is the FOLD’s output', () => {
-        // `m[1]` is undefined for the shorthand `{ filter }` — the exact form
-        // the bug shipped — so it can never satisfy the expectation below.
+    it('no `filter` is written through the view-config persist path at all', () => {
         const values = [...objectViewSrc.matchAll(FILTER_PERSIST_CALLS)].map((m) => m[1] ?? '{ filter } shorthand');
-        // Exactly one such call, and it writes the folded rules — never the raw
-        // `filter` argument the toolbar handed in.
-        expect(values, 'a `persistViewPatch(…, { filter })` call appeared that does not write the fold’s output')
-            .toEqual(['folded.rules']);
+        expect(values, 'a filter persist reappeared on the toolbar path — see #4155').toEqual([]);
     });
 
-    it('every toolbar filter change routes through the fold', () => {
-        // Look at the code immediately following each `onFilterChange` binding:
-        // it must reach `persistViewFilter`, not `persistViewPatch`.
+    it('the `persistViewFilter` helper is gone — there is no filter-persist seam to call', () => {
+        // Matched on a CALL/DECLARATION form so the comment that explains the
+        // removal (which names the symbol) does not satisfy the ratchet.
+        expect(objectViewSrc).not.toMatch(/const\s+persistViewFilter\b/);
+        expect(objectViewSrc).not.toMatch(/persistViewFilter\s*\(/);
+    });
+
+    it('no toolbar filter handler reaches ANY persist call', () => {
         const sites = [...objectViewSrc.matchAll(/onFilterChange[=:]/g)];
-        expect(sites.length, 'expected the list-toolbar onFilterChange handlers to be found')
-            .toBeGreaterThanOrEqual(2);
+        // The surviving handler is session state (localStorage) only. If every
+        // handler is gone the loop is vacuous, so pin that at least one exists —
+        // the session restore is a feature, not an accident.
+        expect(sites.length, 'expected at least one onFilterChange handler').toBeGreaterThanOrEqual(1);
         for (const site of sites) {
             // Window = this handler only. It ends where the NEXT `onXxx`
             // binding starts, so the sibling handlers (which legitimately call
@@ -76,16 +88,27 @@ describe('objectstack#5159 ratchet — no raw FilterGroup on the view persist pa
             const rest = objectViewSrc.slice(site.index! + 1, site.index! + 401);
             const next = rest.search(/\bon[A-Z]\w*\s*[=:]/);
             const body = next === -1 ? rest : rest.slice(0, next);
-            expect(body, `this onFilterChange bypasses the fold:\n${body}`).toContain('persistViewFilter');
-            expect(body, `this onFilterChange persists a raw group:\n${body}`).not.toContain('persistViewPatch');
+            expect(body, `this onFilterChange persists a view overlay:\n${body}`).not.toContain('persistViewPatch');
+            expect(body, `this onFilterChange persists a view overlay:\n${body}`).not.toContain('persistViewFilter');
+            expect(body, `this onFilterChange writes view metadata:\n${body}`).not.toContain('updateViewConfig');
+            expect(body, `this onFilterChange writes view metadata:\n${body}`).not.toContain('persistRuntimeMetadata');
         }
     });
 
-    it('ObjectView imports the shared fold rather than re-deriving one', () => {
-        expect(objectViewSrc).toMatch(/import\s*\{[^}]*foldFilterGroupToSpecRules[^}]*\}\s*from\s*'\.\/viewFilterFold'/);
+    it('the surviving handler still keeps SESSION state — the panel is not amnesiac', () => {
+        expect(objectViewSrc).toMatch(/onFilterChange=\{[^}]*writeListFilterState/s);
     });
 
-    it('the Studio inspector folds through the SAME module — one dialect, not two', () => {
+    it('the EXPLICIT save path is untouched — this is the control', () => {
+        // "Save view" through the view config panel still writes the whole view
+        // body through the metadata seam. #4155 removed the automatic write,
+        // not the deliberate one.
+        expect(objectViewSrc).toMatch(/handleViewConfigSave[\s\S]{0,600}persistRuntimeMetadata\('view'/);
+    });
+});
+
+describe('objectstack#5159 ratchet — no raw FilterGroup on any persist path', () => {
+    it('the Studio inspector still folds through the shared module — one dialect, not two', () => {
         expect(widgetsSrc).toMatch(/import\s*\{[^}]*foldFilterGroupToSpecRules[^}]*\}\s*from\s*'\.\.\/viewFilterFold'/);
         // The local operator table it used to carry is gone: a second table is
         // how the runtime toolbar ended up with no fold at all. (Matched on the
@@ -93,12 +116,16 @@ describe('objectstack#5159 ratchet — no raw FilterGroup on the view persist pa
         expect(widgetsSrc).not.toMatch(/const\s+FB_TO_SPEC\b/);
     });
 
-    it('the refusal reaches the user — both fold call sites surface it, none swallow it', () => {
-        for (const [name, src] of [['ObjectView.tsx', objectViewSrc], ['widgets.tsx', widgetsSrc]] as const) {
-            expect(src, `${name} calls the fold`).toContain('foldFilterGroupToSpecRules');
-            expect(src, `${name} surfaces the refusal as a toast`).toMatch(
-                /toast\.error\(\s*tr?\(\s*FILTER_FOLD_REFUSAL_KEYS/,
-            );
-        }
+    it('the refusal still reaches the user where the fold is still called', () => {
+        expect(widgetsSrc).toContain('foldFilterGroupToSpecRules');
+        expect(widgetsSrc, 'widgets.tsx surfaces the refusal as a toast').toMatch(
+            /toast\.error\(\s*tr?\(\s*FILTER_FOLD_REFUSAL_KEYS/,
+        );
+    });
+
+    it('the fold module itself is still exported and used — #4155 removed a caller, not the fold', () => {
+        const foldSrc = readFileSync(path.join(here, 'viewFilterFold.ts'), 'utf8');
+        expect(foldSrc).toMatch(/export function foldFilterGroupToSpecRules/);
+        expect(foldSrc).toMatch(/export const FILTER_FOLD_REFUSAL_KEYS/);
     });
 });

--- a/packages/app-shell/src/views/viewFilterFold.emptyValue.test.ts
+++ b/packages/app-shell/src/views/viewFilterFold.emptyValue.test.ts
@@ -1,0 +1,151 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4155 — an INCOMPLETE filter row must never be persisted.
+ *
+ * The defect this pins is a divergence between two halves of one interaction:
+ *
+ *   `ListView.convertFilterGroupToAST` (what the screen QUERIES) skips a
+ *   condition whose value is `null` / `''` / `[]`, because `[field, '=', '']`
+ *   is a silently-wrong filter (matches only the empty string), not "no
+ *   filter".
+ *
+ *   `foldFilterGroupToSpecRules` (what gets PERSISTED) carried that same row
+ *   through verbatim — deliberately, per its own doc comment.
+ *
+ * So the one condition the live grid ignored was the one condition that reached
+ * storage. `Filter → Add filter` inserts `{ field: <first column>, operator:
+ * 'equals', value: '' }` — a real field, no value yet — and the write path
+ * turned it into the view's stored `filter`, replacing the source-declared one
+ * (`status not_in [archived, deleted]`) for every user of that view. Result:
+ * `total: 0` on the next read, and nothing in the panel to explain it.
+ *
+ * SUITE DIRECTION, predicted before running: every case below is RED against
+ * `origin/main`'s fold — which returns the `value: ''` rule — and green after,
+ * EXCEPT `keeps a row whose value is a real falsy value`, `keeps a value-less
+ * operator` and the builder-parity case, which are green in both worlds by
+ * construction (they pin what must NOT change).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { foldFilterGroupToSpecRules, VALUELESS_FILTER_OPERATORS } from './viewFilterFold';
+
+const group = (conditions: unknown[], logic = 'and') => ({ id: 'root', logic, conditions });
+const rules = (result: ReturnType<typeof foldFilterGroupToSpecRules>) =>
+    result.ok ? result.rules : null;
+
+describe('foldFilterGroupToSpecRules — incomplete rows are not persisted (#4155)', () => {
+    it('drops the `Add filter` row: a real field, `equals`, no value yet', () => {
+        // The exact body the panel emits on one click of `Add filter`, with the
+        // field defaulted to the first column (`fields[0]?.value`).
+        const result = foldFilterGroupToSpecRules(
+            group([{ id: 'a', field: 'status', operator: 'equals', value: '' }]),
+        );
+        expect(result.ok).toBe(true);
+        expect(rules(result)).toEqual([]);
+    });
+
+    it('drops it whatever the operator, as long as the operator wants a value', () => {
+        for (const operator of ['equals', 'notEquals', 'contains', 'startsWith', 'greaterThan', 'in']) {
+            const result = foldFilterGroupToSpecRules(
+                group([{ id: 'a', field: 'status', operator, value: '' }]),
+            );
+            expect(rules(result), `operator ${operator} persisted an empty value`).toEqual([]);
+        }
+    });
+
+    it('treats `null`, `undefined` and `[]` as "no value" — same predicate the live query uses', () => {
+        for (const value of [null, undefined, []]) {
+            const result = foldFilterGroupToSpecRules(
+                group([{ id: 'a', field: 'status', operator: 'equals', value }]),
+            );
+            expect(rules(result), `value ${JSON.stringify(value)} was persisted`).toEqual([]);
+        }
+    });
+
+    it('keeps the complete rows and drops only the incomplete one', () => {
+        const result = foldFilterGroupToSpecRules(
+            group([
+                { id: 'a', field: 'status', operator: 'equals', value: 'open' },
+                { id: 'b', field: 'owner', operator: 'equals', value: '' },
+                { id: 'c', field: 'amount', operator: 'greaterThan', value: 100 },
+            ]),
+        );
+        expect(rules(result)).toEqual([
+            { field: 'status', operator: 'equals', value: 'open' },
+            { field: 'amount', operator: 'greater_than', value: 100 },
+        ]);
+    });
+
+    it('keeps a value-less OPERATOR — no value is that row’s finished state', () => {
+        // `isEmpty` renders no value input at all; dropping it would delete a
+        // legitimate saved condition rather than an unfinished one.
+        const result = foldFilterGroupToSpecRules(
+            group([
+                { id: 'a', field: 'archived_at', operator: 'isEmpty' },
+                { id: 'b', field: 'closed_at', operator: 'isNull', value: '' },
+            ]),
+        );
+        expect(rules(result)).toEqual([
+            { field: 'archived_at', operator: 'is_empty' },
+            { field: 'closed_at', operator: 'is_null', value: '' },
+        ]);
+    });
+
+    it('keeps a row whose value is a real falsy value — `0` and `false` are answers', () => {
+        const result = foldFilterGroupToSpecRules(
+            group([
+                { id: 'a', field: 'amount', operator: 'equals', value: 0 },
+                { id: 'b', field: 'is_active', operator: 'equals', value: false },
+            ]),
+        );
+        expect(rules(result)).toEqual([
+            { field: 'amount', operator: 'equals', value: 0 },
+            { field: 'is_active', operator: 'equals', value: false },
+        ]);
+    });
+
+    it('a group of nothing BUT incomplete rows folds to `[]`, not to a refusal', () => {
+        const result = foldFilterGroupToSpecRules(
+            group([
+                { id: 'a', field: 'status', operator: 'equals', value: '' },
+                { id: 'b', field: 'owner', operator: 'equals', value: '' },
+            ], 'or'),
+        );
+        // Both rows drop, so nothing is left to downgrade: `logic: 'or'` over
+        // fewer than two EFFECTIVE rules folds rather than refusing.
+        expect(result).toEqual({ ok: true, rules: [] });
+    });
+});
+
+describe('VALUELESS_FILTER_OPERATORS — parity with the builder’s own list', () => {
+    it('covers every operator for which the FilterBuilder renders no value input', () => {
+        const builderSrc = readFileSync(
+            path.join(
+                path.dirname(fileURLToPath(import.meta.url)),
+                '../../../components/src/custom/filter-builder.tsx',
+            ),
+            'utf8',
+        );
+        // `const needsValueInput = (operator: string) => { return ![...].includes(operator) }`
+        const match = builderSrc.match(/needsValueInput\s*=\s*\(operator: string\)\s*=>\s*\{\s*return\s*!\[([^\]]*)\]/);
+        expect(match, 'the builder’s needsValueInput list moved — re-point this parity check').not.toBeNull();
+        const builderValueless = [...match![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+        expect(builderValueless.length).toBeGreaterThan(0);
+        for (const operator of builderValueless) {
+            expect(
+                VALUELESS_FILTER_OPERATORS.has(operator),
+                `the builder renders no value input for "${operator}", so the fold must not drop it as incomplete`,
+            ).toBe(true);
+        }
+    });
+});

--- a/packages/app-shell/src/views/viewFilterFold.test.ts
+++ b/packages/app-shell/src/views/viewFilterFold.test.ts
@@ -23,6 +23,13 @@ import { foldFilterGroupToSpecRules, FILTER_FOLD_REFUSAL_KEYS } from './viewFilt
  * The body objectstack#5159 captured off the wire, verbatim: one click of
  * `Filter → Add filter` on `/_console/apps/showcase_app/showcase_task`.
  * Replay variant ① — the shape that must never be emitted again.
+ *
+ * objectui#4155 amended what this folds TO. The captured row is incomplete — a
+ * column with no value yet — and the fold now drops it, because the live query
+ * never applied it and persisting it replaced the source-declared view filter.
+ * The variant-③ shape assertions below therefore run on a COMPLETE row; the
+ * captured body's own verdict (an empty rule list) is pinned in
+ * `viewFilterFold.emptyValue.test.ts`.
  */
 const CAPTURED_TOOLBAR_GROUP = {
     id: 'root',
@@ -32,17 +39,30 @@ const CAPTURED_TOOLBAR_GROUP = {
     ],
 };
 
+/** The same body once the user has actually typed a value into that row. */
+const COMPLETED_TOOLBAR_GROUP = {
+    id: 'root',
+    logic: 'and',
+    conditions: [
+        { id: '712135fb-58c5-4be4-a611-1925181509b0', field: 'title', operator: 'equals', value: 'draft' },
+    ],
+};
+
 describe('foldFilterGroupToSpecRules — flat AND group → ViewFilterRule[]', () => {
     it('#5159: folds the captured toolbar body to replay variant ③ (declared keys only)', () => {
-        const result = foldFilterGroupToSpecRules(CAPTURED_TOOLBAR_GROUP);
+        const result = foldFilterGroupToSpecRules(COMPLETED_TOOLBAR_GROUP);
         expect(result.ok).toBe(true);
         expect(result.ok && result.rules).toEqual([
-            { field: 'title', operator: 'equals', value: '' },
+            { field: 'title', operator: 'equals', value: 'draft' },
         ]);
     });
 
+    it('#4155: the captured body itself — an unfinished row — persists nothing', () => {
+        expect(foldFilterGroupToSpecRules(CAPTURED_TOOLBAR_GROUP)).toEqual({ ok: true, rules: [] });
+    });
+
     it('#5159: what is emitted is an ARRAY — never the FilterGroup object (variant ①)', () => {
-        const result = foldFilterGroupToSpecRules(CAPTURED_TOOLBAR_GROUP);
+        const result = foldFilterGroupToSpecRules(COMPLETED_TOOLBAR_GROUP);
         expect(result.ok).toBe(true);
         const rules = result.ok ? result.rules : null;
         expect(Array.isArray(rules)).toBe(true);
@@ -53,7 +73,7 @@ describe('foldFilterGroupToSpecRules — flat AND group → ViewFilterRule[]', (
     });
 
     it('#5114/#5159: strips the builder-minted row `id` — the read path regenerates it', () => {
-        const result = foldFilterGroupToSpecRules(CAPTURED_TOOLBAR_GROUP);
+        const result = foldFilterGroupToSpecRules(COMPLETED_TOOLBAR_GROUP);
         expect(result.ok && result.rules[0]).not.toHaveProperty('id');
         // Declared vocabulary only.
         expect(result.ok && Object.keys(result.rules[0])).toEqual(['field', 'operator', 'value']);
@@ -265,14 +285,16 @@ describe('the folded body is what the spec actually accepts (replay-matrix closu
 
     // …and the fold is what keeps us out of variant ②.
     it('the fold strips the `id` that variant ② proves the spec rejects', () => {
-        const folded = foldFilterGroupToSpecRules(CAPTURED_TOOLBAR_GROUP);
+        const folded = foldFilterGroupToSpecRules(COMPLETED_TOOLBAR_GROUP);
         expect(folded.ok).toBe(true);
+        // Non-vacuous: there IS a rule, and it carries no `id`.
+        expect(folded.ok && folded.rules.length).toBe(1);
         expect(folded.ok && folded.rules.every((r) => !('id' in r))).toBe(true);
     });
 
     // Replay variant ③ — what the fold now emits.
     it('#5159 variant ③: the folded rule array is ACCEPTED by ListViewSchema', () => {
-        const folded = foldFilterGroupToSpecRules(CAPTURED_TOOLBAR_GROUP);
+        const folded = foldFilterGroupToSpecRules(COMPLETED_TOOLBAR_GROUP);
         expect(folded.ok).toBe(true);
         const parsed = ListViewSchema.safeParse(viewBody(folded.ok ? folded.rules : undefined));
         expect(parsed.success, JSON.stringify((parsed as any).error?.issues)).toBe(true);

--- a/packages/app-shell/src/views/viewFilterFold.ts
+++ b/packages/app-shell/src/views/viewFilterFold.ts
@@ -50,6 +50,33 @@ interface FilterGroupLike {
     conditions?: unknown[];
 }
 
+/**
+ * Operators that are COMPLETE without a value — in both the FilterBuilder's
+ * dialect and the canonical spelling `normalizeFilterOperator` maps it to.
+ *
+ * The builder renders no value input for these (`needsValueInput` in
+ * `@object-ui/components`'s `filter-builder.tsx`), so "no value" is the row's
+ * finished state, not an unfinished one. `exists` / `notExists` have no
+ * canonical spec spelling and pass through verbatim for the server's enum to
+ * reject loudly (see the operator note above) — they are listed so that
+ * rejection stays the reason they fail, rather than being silently dropped here
+ * as incomplete.
+ *
+ * `viewFilterFold.emptyValue.test.ts` pins this set against the builder's own
+ * list so the two cannot drift apart unnoticed.
+ */
+export const VALUELESS_FILTER_OPERATORS: ReadonlySet<string> = new Set([
+    // FilterBuilder vocabulary
+    'isEmpty', 'isNotEmpty', 'isNull', 'isNotNull', 'exists', 'notExists',
+    // …and their canonical spec spellings
+    'is_empty', 'is_not_empty', 'is_null', 'is_not_null',
+]);
+
+/** A value the user has not supplied yet — the same predicate the live query uses. */
+function isMissingValue(value: unknown): boolean {
+    return value == null || value === '' || (Array.isArray(value) && value.length === 0);
+}
+
 function isGroupLike(value: unknown): value is FilterGroupLike {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
     const v = value as Record<string, unknown>;
@@ -89,9 +116,20 @@ function isGroupLike(value: unknown): value is FilterGroupLike {
  *      and `parseSingleOrNested` / `toFilterGroup` fall back to one — so the
  *      builder round-trip is lossless without it.
  *   `viewFilterFold.test.ts` pins both.
- * - **`value` is carried verbatim**, including `''` (the row the toolbar emits
- *   the moment a field is picked). `ViewFilterRuleSchema.value` accepts it and
- *   rewriting it here would silently change what the user saved.
+ * - **An INCOMPLETE row is dropped, exactly as the live query drops it**
+ *   (objectui#4155). `Add filter` inserts `{ field: <first column>, operator:
+ *   'equals', value: '' }` — a row with a real field but no value yet. The live
+ *   grid never applies it: `ListView.convertFilterGroupToAST` skips conditions
+ *   whose value is `null` / `''` / `[]`, because `[field, '=', '']` is a
+ *   silently-wrong filter (matches only the empty string) rather than "no
+ *   filter". This fold used to carry that same row through VERBATIM, so the one
+ *   condition the screen ignores was the one condition that got written to
+ *   storage — and on the next read it became the view's whole filter, replacing
+ *   the source-declared one and emptying the list for every user of that view.
+ *   The two sides now agree: what is not applied is not persisted. A value-less
+ *   OPERATOR ({@link VALUELESS_FILTER_OPERATORS} — `isEmpty` / `isNull` and
+ *   friends) is complete without a value and is kept; only a row that WANTS a
+ *   value and has none is dropped.
  *
  * Refusals (objectstack#5159, maintainer adjudication A1): a shape that cannot
  * fold LOSSLESSLY is refused, never downgraded. `logic: 'or'` has no at-rest
@@ -117,9 +155,17 @@ export function foldFilterGroupToSpecRules(group: unknown): FilterFoldResult {
         const c = condition as Record<string, unknown>;
         // Blank row the builder inserts before a column is chosen.
         if (typeof c.field !== 'string' || c.field === '') continue;
+        const operator = normalizeFilterOperator(c.operator) as ViewFilterRule['operator'];
+        // Row with a column but no value yet (objectui#4155). The live query
+        // skips it; persisting it would store a filter the screen never
+        // applied — and it would then REPLACE the source-declared filter on
+        // the next read.
+        const takesValue = !VALUELESS_FILTER_OPERATORS.has(String(c.operator))
+            && !VALUELESS_FILTER_OPERATORS.has(String(operator));
+        if (takesValue && isMissingValue(c.value)) continue;
         const rule: ViewFilterRule = {
             field: c.field,
-            operator: normalizeFilterOperator(c.operator) as ViewFilterRule['operator'],
+            operator,
         };
         if (c.value !== undefined) rule.value = c.value as ViewFilterRule['value'];
         rules.push(rule);

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2797,8 +2797,24 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
             // Distinguish "filtered/searched to empty" from "truly empty
             // (first run)". A new user with no filters shouldn't be told to
             // "adjust your filters" — they should be invited to create.
+            //
+            // The VIEW's own `filter` counts as an active query too
+            // (objectui#4155). It used to be excluded, so a view that returns
+            // nothing *because it is filtered* — the declared `status not_in
+            // [archived]`, or a stale stored condition — rendered the first-run
+            // copy ("no data yet / create your first record") over an object
+            // full of records. That reads as data loss or a permission problem
+            // and sends triage away from the view layer, which is exactly what
+            // this issue reported.
+            const hasBaseFilter =
+              Array.isArray(schema.filter)
+                ? schema.filter.length > 0
+                : !!schema.filter && typeof schema.filter === 'object'
+                  ? Object.keys(schema.filter).length > 0
+                  : false;
             const hasActiveQuery =
               !!(searchTerm && searchTerm.trim()) ||
+              hasBaseFilter ||
               (Array.isArray(userFilterConditions) && userFilterConditions.length > 0) ||
               (Array.isArray(currentFilters?.conditions) && currentFilters.conditions.length > 0);
             const title = (typeof schema.emptyState?.title === 'string' ? schema.emptyState.title : undefined)

--- a/packages/plugin-list/src/__tests__/ListView.emptyStateFilteredCopy.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.emptyStateFilteredCopy.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4155 — a list emptied BY ITS OWN FILTER must not render the
+ * first-run copy.
+ *
+ * The empty state already distinguished "filtered to empty" from "truly
+ * empty", but it only counted SESSION filters: the search box, the user-filter
+ * chips, and the filter panel's own conditions. The view's declared `filter`
+ * was not counted, so a view returning nothing precisely because it is
+ * filtered — `status not_in [archived, deleted]`, or a stale stored condition
+ * — told the user "Nothing here yet / Create your first record" over an object
+ * full of records.
+ *
+ * That is the misleading half of this issue: it reads as data loss or a
+ * permission problem and sends triage away from the view layer. The copy is
+ * the diagnosis the user gets, so the two cases must not share one string.
+ *
+ * SUITE DIRECTION, predicted before running: `a view filtered to empty says so`
+ * is RED against `origin/main` (which renders the first-run copy) and green
+ * after; the other two are green in both worlds — they pin that the fix does
+ * not swallow the genuine first-run case or the author's own override.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ListView } from '../ListView';
+import { SchemaRendererProvider } from '@object-ui/react';
+import type { ListViewSchema } from '@object-ui/types';
+
+/** A data source that answers every query with zero rows. */
+function emptyDataSource() {
+  return {
+    find: vi.fn().mockResolvedValue([]),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+async function emptyState(schema: ListViewSchema): Promise<HTMLElement> {
+  const ds = emptyDataSource();
+  const { container } = render(
+    <SchemaRendererProvider dataSource={ds as any}>
+      <ListView schema={schema} dataSource={ds as any} />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => {
+    expect(container.querySelector('[data-testid="empty-state"]')).not.toBeNull();
+  });
+  return container.querySelector('[data-testid="empty-state"]') as HTMLElement;
+}
+
+const BASE: ListViewSchema = {
+  type: 'list-view',
+  objectName: 'work_order',
+  fields: ['name'],
+};
+
+describe('ListView empty state — a filtered view says it is filtered (#4155)', () => {
+  it('a view filtered to empty says "no matching records", not "nothing here yet"', async () => {
+    const panel = await emptyState({
+      ...BASE,
+      // The source-declared filter from the issue's repro.
+      filter: [['status', 'not_in', ['archived', 'deleted']]],
+    } as ListViewSchema);
+
+    expect(panel.textContent).toMatch(/No matching records/i);
+    expect(panel.textContent).not.toMatch(/Nothing here yet/i);
+    expect(panel.textContent).not.toMatch(/Create your first record/i);
+  });
+
+  it('a genuinely unfiltered empty list still invites the user to create', async () => {
+    const panel = await emptyState(BASE);
+
+    expect(panel.textContent).toMatch(/Nothing here yet/i);
+    expect(panel.textContent).not.toMatch(/No matching records/i);
+  });
+
+  it('an empty filter array is not "filtered" — it imposes nothing', async () => {
+    const panel = await emptyState({ ...BASE, filter: [] } as ListViewSchema);
+
+    expect(panel.textContent).toMatch(/Nothing here yet/i);
+  });
+
+  it("the author's own emptyState copy still wins over both", async () => {
+    const panel = await emptyState({
+      ...BASE,
+      filter: [['status', 'not_in', ['archived']]],
+      emptyState: { title: 'No open work orders', message: 'Dispatch one to get started.' },
+    } as ListViewSchema);
+
+    expect(panel.textContent).toMatch(/No open work orders/);
+    expect(panel.textContent).not.toMatch(/No matching records/i);
+  });
+});


### PR DESCRIPTION
Fixes #4155

## Diagnosis

The reported symptom — a list permanently empty, the filter panel showing no conditions, recovery only via a `sys_metadata` delete plus a service restart — comes from **one automatic write** meeting **one merge rule**.

**The write.** `ObjectView`'s list toolbar bound `onFilterChange` to `persistViewFilter`, which folded the panel's group and handed it to `persistViewPatch`. So every emission of the filter panel wrote a view-customization overlay. `Add filter` inserts a row that is incomplete by construction — a real field, `operator: 'equals'`, and `value: ''` — and it emits immediately, before the user types a value. Merely opening the panel and clicking the button was therefore enough to write.

**The merge rule.** A view override is applied over the source-declared view **key-wise** (`{ ...source, ...override }`). An override carrying a `filter` key does not add to the declared filter — it *replaces* it wholesale. So the one stray condition became the view's entire filter.

**Why the live screen never warned anyone.** `ListView.convertFilterGroupToAST` skips conditions whose value is `null` / `''` / `[]`, because `[field, '=', '']` is a silently-wrong filter (it matches only the empty string) rather than "no filter". The grid therefore ignored the very row that was being persisted. The one condition the screen refused to apply was the one condition that reached storage — which is why nothing looked wrong until the next load, when it came back as the whole filter and returned `total: 0`.

**Why Clear all could not undo it.** Clearing emitted an empty group, which folded to `[]` and persisted `filter: []`. That is not a poisoned filter, but it is still an override with an opinion about `filter`, so it kept winning the spread and kept the declaration deleted. The panel showed no conditions while the request still carried the stale filter — exactly as reported.

**Why the empty state pointed triage away from the view layer.** `ListView` distinguishes "filtered to empty" from "truly empty (first run)", but the view's own declared `filter` did not count toward that decision. A list emptied by its filter rendered the first-run copy, so the report read as data loss or a permission problem.

## What changed, per ruling

**Ruling 1 — an end-user filter-panel interaction must not persist an overlay.** `persistViewFilter` is deleted, along with both `onFilterChange` persist bindings. Filter-panel state is transient: it belongs to the session and to `writeListFilterState`'s per-browser restore. Overlay writes now require an explicit save — `handleViewConfigSave`, and `ObjectDataPage`'s "Save as view". `ObjectDataPage` had already made this exact call for the sibling surface ("Deliberately NO onSortChange/onFilterChange persistence hooks", #2251); this surface was the outlier. `foldFilterGroupToSpecRules` (objectstack#5159) is untouched and still the one dialect for the explicit paths, including the Studio inspector — a caller was removed, not the fold.

**Ruling 2 — empty-value conditions are never persisted nor applied, and dropping them lets the source filter win again.** Two layers. In `foldFilterGroupToSpecRules`, a row that wants a value and has none is now dropped, matching the predicate the live query already used — what is not applied is not persisted. On the read path, `sanitizeViewOverride` runs on **both** branches of `loadViewOverrides` and strips the same conditions from a stored overlay, in both at-rest shapes (spec `ViewFilterRule` objects and the legacy runtime triple). When nothing effective survives it drops the `filter` **key** rather than writing `[]`, which is what lets the merge fall through to the source declaration. Poisoned installs self-heal on the next read — no `sys_metadata` surgery, no restart.

A value-less **operator** (`isEmpty` / `isNull` and friends) is complete without a value and is kept. The set is pinned against the FilterBuilder's own `needsValueInput` list so the two cannot drift apart unnoticed.

**Ruling 3 — Clear all clears any panel-written overlay.** Reached from both ends. Going forward the panel writes no overlay at all, so there is nothing for Clear all to leave behind; its clear is session state, which it still writes. For installs already carrying one, the `filter: []` that Clear all previously wrote is now dropped on read by the same sanitizer, so the source filter returns without the user having to do anything.

**Ruling 4 — filtered-empty copy.** The view's own `filter` now counts as an active query, in both the array and Mongo-style object shapes, so a filtered-to-empty list says "no records match" instead of inviting the user to create a first record. No new strings: this routes to `list.noMatches` / `list.noMatchesMessage`, which already exist in all ten locales. An author-supplied `emptyState.title` / `emptyState.message` still wins over both branches.

### A deliberate consequence

An overlay can no longer express "this view has NO filter" over a source view that declares one. That is the strictly safer side of the trade: the shape that expressed it is the same shape that silently erased source declarations. An author who genuinely wants no filter edits the view, which writes the view body rather than an overlay.

## Verification

**Reverse verification (red-first).** With the three source files reverted to `origin/main` and the tests kept: **24 failed, 13 passed**. Restored: **63 passed**. Representative signatures, each naming a value rather than a crash:

```
AssertionError: a filter persist reappeared on the toolbar path — see #4155:
  expected [ 'folded.rules' ] to deeply equal []
AssertionError: expected [ { field: 'status', …(2) } ] to deeply equal []
AssertionError: operator equals persisted an empty value: expected [ { field: 'status', …(2) } ] to deeply equal []
```

**One prediction was wrong, and the correction is committed.** The suite header predicted that the `what must NOT change` control block would stay green in both worlds. It does not: reverting removes the `sanitizeViewOverride` export, so the module fails at import and every case in that file goes red, controls included. That bounds what the file can prove against `origin/main` — a missing export cannot tell "kept the real conditions" apart from "module did not load" — so those cases are controls in the forward direction only. The header now records the measured result instead of the prediction, and names the value-quoting failures as the genuinely discriminating ones.

**Gates** (repo root, scoped):

| Gate | Result |
| --- | --- |
| `vitest run packages/app-shell/ packages/plugin-list/` | 357 files, **3517 passed**, 1 skipped |
| `type-check` (both packages) | Done, no errors |
| `lint` (both packages) | **0 errors** (warnings are the repo baseline) |
| `check-control-bytes` | OK, 3909 files scanned |

Build closure (`'@object-ui/app-shell^...'`, `'@object-ui/plugin-list^...'`) built first, so the type-check read fresh `.d.ts` rather than stale artifacts.

Changesets: patch for `@object-ui/app-shell` and `@object-ui/plugin-list`.

## Not fixed here — the cross-user half is platform-side

The card's cross-user angle is real and is **not** closed by this PR. `updateViewConfig` writes `meta.saveItem('view', viewId, merged)` — a single org-wide metadata item keyed by view id, with no per-user scoping. Every key the toolbar still persists by design (`sort`, `hiddenFields`, `columnState`, `rowHeight`) is therefore written org-wide and applies to every user of the view, even though `ObjectView` describes them as "Airtable-style per-view personal config". Removing the filter write takes the destructive key out of that path, but the scoping gap remains for the others, and the client has nowhere to put a per-user overlay. Handed to the seat as evidence per the dispatch lane split; this lane lands no platform code.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_