### PR TITLE
fix(fields): a detail-page `address` reads as a formatted address, not stringified JSON

### DIFF
--- a/.changeset/address-display-formatter-4037.md
+++ b/.changeset/address-display-formatter-4037.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/fields': patch
+---
+
+A `Field.address` value now reads as a formatted postal address on the record detail page, instead of stringified JSON.
+
+The display (read) registry mapped `address` straight to `JsonCellRenderer`, so a populated address rendered as `{"street":"中策路 1 号","city":"杭州",…}` — while a `location` field sitting next to it in the same field group rendered formatted, and the create/edit dialog rendered the very same value as proper Street / City / State / ZIP / Country inputs. The gap was display-side only: the input registry has always carried `address`. Both read surfaces the detail page exposes are affected and both are fixed, because they share one `displayValue` path — read mode, and the inline-edit read state (the row carrying the pencil affordance, before a field is actually being edited).
+
+Layout is not invented for the read side. `AddressField`'s readonly branch already collapsed a stored address to a single line, and that rule — `Street, City, State ZIP, Country`, with `state` and the postal code sharing one comma group — is now the *only* implementation, moved into a pure `address-format` module that both surfaces call. A readonly form and a detail page therefore cannot spell one stored address two ways; a second copy next to the renderer would have been a rule that drifts. The module is deliberately React-free, so the eagerly-loaded barrel can format a cell without pulling `AddressField` and its inputs out of the lazy widget chunk.
+
+Partial values degrade the way the readonly line already did: absent, non-string and whitespace-only parts are dropped rather than spaced over, so a street-only address renders as `中策路 1 号` and never as `, , ,` or as the string `undefined`. Legacy records whose postal code was written under `zipCode` (objectstack#5143) still render it, matching what the input widget reads.
+
+Nothing is silently swallowed by the change: a value the formatter cannot recognize — an object carrying no known part — keeps today's compact-JSON rendering rather than disappearing, and `{}` or a null value shows the usual empty placeholder. A plain string address passes straight through. `location`, `geolocation`, and the genuinely structural `json` / `object` types are untouched.
+
+The address *input* is unchanged on every surface, including the create/edit dialog.

--- a/packages/fields/src/__tests__/AddressCellRenderer.test.tsx
+++ b/packages/fields/src/__tests__/AddressCellRenderer.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4037 (migrated from objectstack#5019): a `Field.address` value read
+ * as stringified JSON on the record detail page — `{"street":"中策路 1 号",…}` —
+ * because the DISPLAY registry mapped `address` to `JsonCellRenderer`, while
+ * `location` next to it in the same field group had a real formatter. The
+ * create/edit dialog rendered the same field correctly, so the gap was
+ * display-side only.
+ *
+ * Every case below resolves its renderer through `getCellRenderer` — the
+ * display resolver the detail page itself calls — rather than importing
+ * `AddressCellRenderer` directly, so these tests fail on the JSON signature if
+ * the registry entry ever regresses, not merely if the formatter changes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { getCellRenderer, resolveCellRendererType } from '../index';
+
+/** Resolve + render exactly the way `DetailSection` builds a read-mode value. */
+function renderThroughDisplayRegistry(type: string, value: unknown) {
+  const Renderer = getCellRenderer(resolveCellRendererType({ type }) || type);
+  return render(<Renderer value={value as any} field={{ type } as any} />);
+}
+
+/** The stringified-object signature this issue is about. */
+function expectNoJsonSignature(text: string | null) {
+  expect(text).not.toMatch(/[{}]/);
+  expect(text).not.toMatch(/"(street|city|state|postalCode|country)"/);
+  expect(text).not.toMatch(/undefined/);
+}
+
+/** The record from the issue's evidence table. */
+const ISSUE_ADDRESS = {
+  street: '中策路 1 号',
+  city: '杭州',
+  state: '浙江',
+  postalCode: '310000',
+  country: '中国',
+};
+
+describe('address display renderer (objectui#4037)', () => {
+  it('renders a populated address as a formatted line, not stringified JSON', () => {
+    const { container } = renderThroughDisplayRegistry('address', ISSUE_ADDRESS);
+    expectNoJsonSignature(container.textContent);
+    expect(
+      screen.getByText('中策路 1 号, 杭州, 浙江 310000, 中国'),
+    ).toBeInTheDocument();
+  });
+
+  it('resolves `address` through the display registry the way it resolves `location`', () => {
+    // The issue's decisive comparison: one address field beside one location
+    // field, same record, same page. Both must be formatted; neither may fall
+    // through to object stringification.
+    const address = renderThroughDisplayRegistry('address', ISSUE_ADDRESS);
+    const location = renderThroughDisplayRegistry('location', { lat: 30.2741, lng: 120.1551 });
+    expectNoJsonSignature(address.container.textContent);
+    expectNoJsonSignature(location.container.textContent);
+    expect(location.container.textContent).toContain('30.2741');
+  });
+
+  it('carries the full value: every authored sub-field appears', () => {
+    const { container } = renderThroughDisplayRegistry('address', ISSUE_ADDRESS);
+    for (const part of Object.values(ISSUE_ADDRESS)) {
+      expect(container.textContent).toContain(part);
+    }
+  });
+});
+
+describe('address display renderer — partial values render gracefully', () => {
+  it('drops missing parts instead of leaving dangling separators', () => {
+    const { container } = renderThroughDisplayRegistry('address', {
+      street: '中策路 1 号',
+      city: '杭州',
+    });
+    expect(screen.getByText('中策路 1 号, 杭州')).toBeInTheDocument();
+    expectNoJsonSignature(container.textContent);
+    expect(container.textContent).not.toMatch(/,\s*$/);
+    expect(container.textContent).not.toMatch(/,\s*,/);
+  });
+
+  it('renders a street-only address as just the street', () => {
+    renderThroughDisplayRegistry('address', { street: '中策路 1 号' });
+    expect(screen.getByText('中策路 1 号')).toBeInTheDocument();
+  });
+
+  it('keeps state and postal code in one group, either alone', () => {
+    const stateOnly = renderThroughDisplayRegistry('address', { city: 'SF', state: 'CA' });
+    expect(stateOnly.container.textContent).toBe('SF, CA');
+    const postalOnly = renderThroughDisplayRegistry('address', { city: 'SF', postalCode: '94102' });
+    expect(postalOnly.container.textContent).toBe('SF, 94102');
+    const both = renderThroughDisplayRegistry('address', {
+      city: 'SF',
+      state: 'CA',
+      postalCode: '94102',
+    });
+    expect(both.container.textContent).toBe('SF, CA 94102');
+  });
+
+  it('ignores whitespace-only parts rather than spacing over them', () => {
+    const { container } = renderThroughDisplayRegistry('address', {
+      street: '  ',
+      city: '杭州',
+      country: '',
+    });
+    expect(container.textContent).toBe('杭州');
+  });
+
+  it('reads a legacy `zipCode` postal code (objectstack#5143 data)', () => {
+    // Records written by builds up to 17.0.0-rc.1 stored the postal code under
+    // `zipCode`. The input widget reads it; the detail page must not drop it.
+    const { container } = renderThroughDisplayRegistry('address', {
+      city: 'San Francisco',
+      state: 'CA',
+      zipCode: '94102',
+    });
+    expect(container.textContent).toBe('San Francisco, CA 94102');
+  });
+});
+
+describe('address display renderer — nothing is silently swallowed', () => {
+  it('shows the empty placeholder for a null value and for `{}`', () => {
+    const nullValue = renderThroughDisplayRegistry('address', null);
+    expect(nullValue.container.querySelector('[data-slot="empty-value"]')).not.toBeNull();
+    const emptyObject = renderThroughDisplayRegistry('address', {});
+    expect(emptyObject.container.querySelector('[data-slot="empty-value"]')).not.toBeNull();
+  });
+
+  it('keeps an unrecognized shape visible as JSON rather than blanking it', () => {
+    // Strictly better than today, never worse: a value the formatter cannot
+    // read retains the current compact-JSON rendering instead of disappearing.
+    const { container } = renderThroughDisplayRegistry('address', { unexpected: 'data' });
+    expect(container.textContent).toContain('unexpected');
+  });
+
+  it('passes a plain string address straight through', () => {
+    renderThroughDisplayRegistry('address', '中策路 1 号, 杭州');
+    expect(screen.getByText('中策路 1 号, 杭州')).toBeInTheDocument();
+  });
+});
+
+describe('address display renderer — controls (unchanged surfaces)', () => {
+  it('leaves `location` and `geolocation` formatting untouched', () => {
+    const location = renderThroughDisplayRegistry('location', { lat: 30.2741, lng: 120.1551 });
+    expect(location.container.textContent).toBe('30.2741, 120.1551');
+    const geo = renderThroughDisplayRegistry('geolocation', { latitude: 30.2741, longitude: 120.1551 });
+    expect(geo.container.textContent).toBe('30.2741, 120.1551');
+  });
+
+  it('leaves genuinely structural types stringifying as JSON', () => {
+    // `address` moved out of the JSON bucket; `json` / `object` stay in it.
+    for (const type of ['json', 'object', 'composite', 'record']) {
+      const { container } = renderThroughDisplayRegistry(type, { a: 1 });
+      expect(container.textContent).toBe('{"a":1}');
+    }
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -15,6 +15,9 @@ import { Check, X, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import { SchemaRendererContext as _SchemaRendererContext } from '@object-ui/react';
 import { withFieldCarrier } from './withFieldCarrier';
+// Pure formatting rule shared with `AddressField`'s readonly branch — no React,
+// so this does not pull the widget out of its lazy chunk (objectui#4037).
+import { formatAddress, type AddressValue } from './widgets/address-format';
 
 // Module-level cache so multiple renderers fetching the same lookup ID
 // only trigger one network call. Keyed by `${objectName}:${id}`.
@@ -1779,6 +1782,39 @@ export function LocationCellRenderer({ value }: CellRendererProps): React.ReactE
 }
 
 /**
+ * Renders an `address` value as a formatted single-line postal address instead
+ * of stringified JSON (objectui#4037).
+ *
+ * The detail page's display registry mapped `address` to {@link JsonCellRenderer},
+ * so a populated address read as `{"street":"中策路 1 号","city":"杭州",…}` on the
+ * detail page and in its inline-edit read state — while the very same value
+ * rendered correctly in the create/edit dialog, whose input registry has always
+ * carried `address`. Read side only: nothing about the input widget changes.
+ *
+ * Layout is not invented here. It is {@link formatAddress} — the rule
+ * `AddressField`'s own readonly branch already applied, over the sub-field set
+ * its inputs expose — so a readonly form and a detail page cannot spell one
+ * stored address two ways.
+ *
+ * Anything `formatAddress` cannot recognize falls back to compact JSON rather
+ * than rendering blank: an unknown shape stays visible (today's behaviour) and
+ * is never silently swallowed by the fix.
+ */
+export function AddressCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  if (value == null || value === '') return <EmptyValue />;
+  // A plain string address (some apps store one) is already display-ready.
+  if (typeof value === 'string') return <TruncatedText text={value} className="text-sm" />;
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const formatted = formatAddress(value as AddressValue);
+    if (formatted) return <TruncatedText text={formatted} className="text-sm" />;
+    // An object carrying no recognized part: `{}` reads as empty, while
+    // `{ foo: 1 }` keeps its JSON so real data is never hidden.
+    if (Object.keys(value as Record<string, unknown>).length === 0) return <EmptyValue />;
+  }
+  return <JsonCellRenderer value={value} field={{} as any} />;
+}
+
+/**
  * Get the appropriate cell renderer for a field type
  */
 export function getCellRenderer(fieldType: string): React.FC<CellRendererProps> {
@@ -1834,7 +1870,7 @@ export function getCellRenderer(fieldType: string): React.FC<CellRendererProps> 
     secret: () => <span>••••••</span>,
     location: LocationCellRenderer,
     geolocation: LocationCellRenderer,
-    address: JsonCellRenderer,
+    address: AddressCellRenderer,
     color: ColorSwatchCellRenderer,
     json: JsonCellRenderer,
     object: JsonCellRenderer,

--- a/packages/fields/src/widgets/AddressField.tsx
+++ b/packages/fields/src/widgets/AddressField.tsx
@@ -3,46 +3,18 @@ import { Input, Label, EmptyValue } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { toHostGroupProps } from './toHostGroupProps';
+// The value shape and the single-line formatting rule now live in a pure module
+// so the display (read) cell renderer formats a stored address exactly the way
+// this widget's readonly branch does — one rule, not two copies that drift
+// (objectui#4037). Behaviour here is unchanged; only the definition moved.
+import {
+  formatAddress,
+  readPostalCode,
+  type AddressValue,
+  type LegacyAddressValue,
+} from './address-format';
 
-/**
- * Address data structure — the part names of `@objectstack/spec`'s
- * `AddressSchema`, which is what the platform stores and what
- * `/api/v1/data/**` serves back.
- *
- * The postal code is spelled `postalCode` (objectstack#5143). This widget used
- * to read and write `zipCode`, a key that appears nowhere in the spec, so the
- * stored postal code never reached the input — and whatever the user then typed
- * into that apparently-empty box was written under a key `AddressValueSchema`
- * strips: lost outright on a new record, and on an existing one silently
- * discarded while the stale stored value survived. (A postal code nobody
- * touched did survive an unrelated edit, because the write spread the whole
- * stored object through; the issue's account of that half is corrected in
- * `AddressField.postalCode.test.tsx`.) One name, on both sides: the contract's.
- */
-export interface AddressValue {
-  street?: string;
-  city?: string;
-  state?: string;
-  postalCode?: string;
-  country?: string;
-}
-
-/**
- * The shape written by builds up to and including 17.0.0-rc.1, whose postal
- * code landed under `zipCode` (objectstack#5143). Read-time compatibility ONLY,
- * and deliberately not part of {@link AddressValue}: authoring code must not be
- * able to spell `zipCode`, and nothing here ever writes it back — the first
- * edit of any part normalizes the record onto `postalCode` (see
- * `handleFieldChange`). This is not a producer alias to be honoured forever;
- * it exists to carry data THIS widget mis-wrote, and can go once no such data
- * remains.
- */
-type LegacyAddressValue = AddressValue & { zipCode?: string };
-
-/** Postal code of a stored address, preferring the canonical key. */
-function readPostalCode(addr: AddressValue): string | undefined {
-  return addr.postalCode ?? (addr as LegacyAddressValue).zipCode;
-}
+export type { AddressValue };
 
 /**
  * Address field widget - provides a structured address input
@@ -105,16 +77,6 @@ export function AddressField({ value, onChange, field, readonly, error, ...props
       ...(postalCode ? { postalCode } : null),
       [fieldName]: fieldValue,
     });
-  };
-
-  const formatAddress = (addr: AddressValue): string => {
-    const parts = [
-      addr.street,
-      addr.city,
-      [addr.state, readPostalCode(addr)].filter(Boolean).join(' '),
-      addr.country,
-    ].filter(Boolean);
-    return parts.join(', ');
   };
 
   if (readonly) {

--- a/packages/fields/src/widgets/address-format.ts
+++ b/packages/fields/src/widgets/address-format.ts
@@ -1,0 +1,104 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The address value shape, and the ONE formatting rule every address surface
+ * renders it with.
+ *
+ * This module exists because the rule had exactly one implementation and only
+ * one consumer could reach it (objectui#4037). `AddressField`'s readonly branch
+ * collapsed a stored address to a formatted line, while the display (read)
+ * registry the detail page uses mapped `address` straight to `JsonCellRenderer`
+ * — so the same stored value rendered as `Street, City, State ZIP, Country` in
+ * a readonly form and as `{"street":"…","city":"…"}` on the detail page.
+ *
+ * The fix keeps ONE definition rather than a second copy next to the renderer:
+ * a duplicated rule is a rule that drifts, and two spellings of the same
+ * address on two surfaces of one app is the very failure the issue reports.
+ *
+ * Deliberately pure — no React, no component imports — so the eager
+ * `@object-ui/fields` barrel can use it for cell rendering without pulling
+ * `AddressField` (and its inputs) out of the lazily-loaded widget chunk.
+ */
+
+/**
+ * Address data structure — the part names of `@objectstack/spec`'s
+ * `AddressSchema`, which is what the platform stores and what
+ * `/api/v1/data/**` serves back.
+ *
+ * The postal code is spelled `postalCode` (objectstack#5143). `AddressField`
+ * used to read and write `zipCode`, a key that appears nowhere in the spec, so
+ * the stored postal code never reached the input — and whatever the user then
+ * typed into that apparently-empty box was written under a key
+ * `AddressValueSchema` strips: lost outright on a new record, and on an
+ * existing one silently discarded while the stale stored value survived. (A
+ * postal code nobody touched did survive an unrelated edit, because the write
+ * spread the whole stored object through; the issue's account of that half is
+ * corrected in `AddressField.postalCode.test.tsx`.) One name, on both sides:
+ * the contract's.
+ */
+export interface AddressValue {
+  street?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+/**
+ * The shape written by builds up to and including 17.0.0-rc.1, whose postal
+ * code landed under `zipCode` (objectstack#5143). Read-time compatibility ONLY,
+ * and deliberately not part of {@link AddressValue}: authoring code must not be
+ * able to spell `zipCode`, and nothing here ever writes it back — the first
+ * edit of any part normalizes the record onto `postalCode` (see
+ * `AddressField`'s `handleFieldChange`). This is not a producer alias to be
+ * honoured forever; it exists to carry data THIS widget mis-wrote, and can go
+ * once no such data remains.
+ */
+export type LegacyAddressValue = AddressValue & { zipCode?: string };
+
+/** Postal code of a stored address, preferring the canonical key. */
+export function readPostalCode(addr: AddressValue): string | undefined {
+  return addr.postalCode ?? (addr as LegacyAddressValue).zipCode;
+}
+
+/**
+ * One address part, normalized for joining: absent, non-string and
+ * whitespace-only parts all collapse to `''` so the caller's `filter(Boolean)`
+ * drops them. This is what keeps a partial address free of dangling separators
+ * and of the string `undefined`.
+ */
+function part(value: unknown): string {
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+/**
+ * Formats a stored address as a single line: `Street, City, State ZIP, Country`.
+ *
+ * Ordering and separators are NOT invented here — they are the rule
+ * `AddressField` already applied in its readonly branch, and the sub-field set
+ * its inputs expose (street / city / state / postalCode / country). Missing
+ * parts are dropped rather than spaced over, so a street-only address is
+ * `"中策路 1 号"` and never `", , ,"`.
+ *
+ * Returns `''` when no part is usable — callers decide what an empty address
+ * looks like (an `EmptyValue` placeholder for the cell renderer), and a value
+ * carrying no recognized part at all is NOT silently blanked: see
+ * `AddressCellRenderer`, which falls back to JSON so unknown data stays visible.
+ */
+export function formatAddress(addr: AddressValue): string {
+  // State and postal code share one comma-delimited group, space-separated
+  // inside it ("CA 94102"); either one alone occupies the group by itself.
+  const stateAndPostal = [part(addr.state), part(readPostalCode(addr))]
+    .filter(Boolean)
+    .join(' ');
+  return [part(addr.street), part(addr.city), stateAndPostal, part(addr.country)]
+    .filter(Boolean)
+    .join(', ');
+}

--- a/packages/plugin-detail/src/__tests__/DetailSection.addressDisplay.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.addressDisplay.test.tsx
@@ -88,11 +88,20 @@ describe('DetailSection — address fields render formatted, not as JSON (object
     expectNoJsonSignature(container.textContent);
   });
 
-  it('leaves the sibling location field formatted (control)', () => {
+  it('leaves the location field formatted (control — unchanged by this fix)', () => {
+    // A real control renders `location` ALONE. Asserting over a container that
+    // also holds the address field would make this case red for the address
+    // regression — it would restate the tests above instead of controlling for
+    // them. Isolated, it is green with the fix and green without it, which is
+    // what "the sibling formatter is untouched" actually claims.
     const { container } = render(
-      <DetailSection section={section} data={data} objectSchema={objectSchema} />,
+      <DetailSection
+        section={{ fields: [{ name: 'office_location', label: '办公地点' }] } as DetailViewSection}
+        data={{ office_location: data.office_location }}
+        objectSchema={objectSchema}
+      />,
     );
-    expect(container.textContent).toContain('30.2741');
+    expect(screen.getByText('30.2741, 120.1551')).toBeInTheDocument();
     expectNoJsonSignature(container.textContent);
   });
 

--- a/packages/plugin-detail/src/__tests__/DetailSection.addressDisplay.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.addressDisplay.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DetailSection } from '../DetailSection';
+import type { DetailViewSection } from '@object-ui/types';
+
+/**
+ * objectui#4037 (migrated from objectstack#5019): on a record detail page a
+ * `Field.address` value rendered as `{"street":"中策路 1 号","city":"杭州",…}`
+ * while a `location` field in the same field group rendered formatted. The card
+ * names TWO read surfaces — detail page read mode and the inline-edit read
+ * state — and both take the same `displayValue` path through the display
+ * registry, so both are pinned here.
+ *
+ * These are end-of-path tests: they drive the real `DetailSection`, not the
+ * renderer, so they stay red if the registry entry regresses even when the
+ * formatter itself is fine.
+ */
+describe('DetailSection — address fields render formatted, not as JSON (objectui#4037)', () => {
+  // The read-mode desktop row (which carries the inline-edit affordance) only
+  // renders above the mobile breakpoint.
+  beforeAll(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+  });
+
+  const objectSchema = {
+    fields: {
+      billing_address: { type: 'address' },
+      office_location: { type: 'location' },
+    },
+  };
+
+  const section: DetailViewSection = {
+    fields: [
+      { name: 'billing_address', label: '账单地址' },
+      { name: 'office_location', label: '办公地点' },
+    ],
+  } as DetailViewSection;
+
+  // The issue's evidence: one address field next to one location field.
+  const data = {
+    billing_address: {
+      street: '中策路 1 号',
+      city: '杭州',
+      state: '浙江',
+      postalCode: '310000',
+      country: '中国',
+    },
+    office_location: { lat: 30.2741, lng: 120.1551 },
+  };
+
+  const FORMATTED = '中策路 1 号, 杭州, 浙江 310000, 中国';
+
+  /** The stringified-object signature the issue reports. */
+  function expectNoJsonSignature(text: string | null) {
+    expect(text).not.toMatch(/"(street|city|state|postalCode|country)"\s*:/);
+    expect(text).not.toContain('[object Object]');
+  }
+
+  it('renders a formatted address in detail page read mode', () => {
+    const { container } = render(
+      <DetailSection section={section} data={data} objectSchema={objectSchema} />,
+    );
+    expect(screen.getByText(FORMATTED)).toBeInTheDocument();
+    expectNoJsonSignature(container.textContent);
+  });
+
+  it('renders a formatted address in the inline-edit read state', () => {
+    // Inline edit available on the record (the parent supplies
+    // `onEnterInlineEdit`), with no field actively being edited — the row the
+    // card calls the inline-edit read state.
+    const { container } = render(
+      <DetailSection
+        section={section}
+        data={data}
+        objectSchema={objectSchema}
+        onEnterInlineEdit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(FORMATTED)).toBeInTheDocument();
+    expectNoJsonSignature(container.textContent);
+  });
+
+  it('leaves the sibling location field formatted (control)', () => {
+    const { container } = render(
+      <DetailSection section={section} data={data} objectSchema={objectSchema} />,
+    );
+    expect(container.textContent).toContain('30.2741');
+    expectNoJsonSignature(container.textContent);
+  });
+
+  it('renders a partial address without dangling separators', () => {
+    const { container } = render(
+      <DetailSection
+        section={{ fields: [{ name: 'billing_address', label: '账单地址' }] } as DetailViewSection}
+        data={{ billing_address: { street: '中策路 1 号', city: '杭州' } }}
+        objectSchema={objectSchema}
+      />,
+    );
+    expect(screen.getByText('中策路 1 号, 杭州')).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/undefined/);
+  });
+});


### PR DESCRIPTION
Fixes #4037

## The gap

The display (read) registry mapped `address` straight to `JsonCellRenderer`, so a populated address rendered as `{"street":"中策路 1 号","city":"杭州",…}` on a record detail page — while a `location` field in the same field group rendered formatted, and the create/edit dialog rendered the same value as proper Street / City / State / ZIP / Country inputs. Display-side only: the input registry has always carried `address`.

Premise verified against `origin/main` before implementing, and it still holds: `packages/fields/src/index.tsx` had `address: JsonCellRenderer` in `getCellRenderer`'s map, exactly as the source thread's triage recorded.

## Both read surfaces, one path

The card names two surfaces — detail read mode and the inline-edit read state. `DetailSection` builds **one** `displayValue` (`packages/plugin-detail/src/DetailSection.tsx:244`) and renders it from both the mobile read row and the desktop row that carries the pencil affordance, so a single registry entry fixes both. Both are pinned by tests driving the real `DetailSection`, not the renderer.

## Layout choice and its source

The layout is **not** invented here. `AddressField`'s readonly branch already collapsed a stored address to one line, and that rule is now the only implementation:

`Street, City, State ZIP, Country` — `state` and the postal code share one comma group, space-separated inside it ("CA 94102"), either one able to occupy the group alone.

It moved into a pure `packages/fields/src/widgets/address-format.ts` that both the widget and the new `AddressCellRenderer` call, so a readonly form and a detail page cannot spell one stored address two ways. A copy next to the renderer would have been a rule that drifts — which is the failure the issue reports, one surface later. The module is deliberately React-free so the eager barrel can format a cell without pulling `AddressField` and its inputs out of the lazy widget chunk.

**On locale-aware ordering:** the report was zh-CN, and Chinese postal convention is largest-to-smallest (country first). I did **not** introduce locale-dependent ordering. Neither the issue nor the source thread objectstack#5019 (read in full, including both triage comments) establishes a format ruling, and the sub-field set is the input widget's own. Reordering by locale would make the read line disagree with the readonly form line and with the input order users type in — a bigger inconsistency than the one being fixed, decided unilaterally. The existing single rule is applied uniformly; if the maintainer wants locale-ordered addresses, that is one deliberate change to `formatAddress` affecting every surface at once, which is exactly the point of it having one home.

## Graceful partials

Absent, non-string and whitespace-only parts collapse and are dropped rather than spaced over: a street-only address is `中策路 1 号`, never `, , ,` and never the string `undefined`. Legacy records whose postal code was written under `zipCode` (objectstack#5143) still render it, matching what the input widget reads.

Nothing is silently swallowed: an object carrying no recognized part keeps today's compact-JSON rendering rather than disappearing, `{}` and null show the usual empty placeholder, and a plain string address passes straight through.

## Reverse verification

Predicted direction first, then measured. Reverting **only** the two fix files to `origin/main` (`git checkout origin/main -- …`, never `git stash`) and re-running:

```
Tests  12 failed | 5 passed (17)
→ expected '{"street":"中策路 1 号","city":"杭州","stat…' not to match /[{}]/
→ expected '{"city":"SF","state":"CA"}' to be 'SF, CA'
→ expected '{"city":"San Francisco","state":"CA",…' to be 'San Francisco, CA 94102'
→ Unable to find an element with the text: 中策路 1 号, 杭州, 浙江 310000, 中国
```

That is the issue's own signature. Two reported deviations from the naive expectation, both honest:

1. **"carries the full value: every authored sub-field appears" stays GREEN when reverted** — stringified JSON also contains every part. It is a completeness assertion, not a defect pin, and is reported as such rather than counted as red-first evidence.
2. **The location control was initially red too**, because it asserted the no-JSON signature over a container that also held the address field — it restated the tests above instead of controlling for them. Fixed in its own commit: the control now renders `location` alone and is **green in both directions**, which is what "the sibling formatter is untouched" actually claims.

Controls: `location` / `geolocation` formatting unchanged, `json` / `object` / `composite` / `record` still stringify, address inputs unchanged on every surface including the dialog.

## Verification

- `npx vitest run packages/fields/ packages/plugin-detail/` — **142 files, 1725 tests passed**
- New: 13 cases in `AddressCellRenderer.test.tsx` (resolved through `getCellRenderer`, so a registry regression is caught, not merely a formatter change) + 4 in `DetailSection.addressDisplay.test.tsx`
- `type-check` both packages: Done. `lint` both packages: **0 errors**
- `check:control-bytes`: OK (3909 files); explicit control-byte self-scan of every touched file: clean
- i18n gates green — "No en value changed in this range". **No i18n discipline needed here**: this is pure value formatting with no labels or copy; the only user-visible strings are the record's own stored data
- Changeset: patch for `@object-ui/fields`. `plugin-detail`'s only change is a test, which releases nothing

## Scope

`index.tsx` diff is strictly the address entries (one import, one renderer, one registry line) — no `ImageField` (#4141), no app-shell/ListView (#4155), no data-objectstack (#4139), no AppHeader (#4197).

Out of scope, filed separately: actively inline-editing an address collapses it into one raw text box reading `[Object]` via `coerceToSafeValue`, and typing writes a string over the structured value. That is the inline-edit **input** path missing the address widget, a different defect from this display-registry gap — not fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_