### PR TITLE
fix(fields): enforce an image field's declared maxSize before the upload starts

### DIFF
--- a/.changeset/image-field-maxsize-guard-4141.md
+++ b/.changeset/image-field-maxsize-guard-4141.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/fields': patch
+---
+
+An image field's declared `maxSize` is enforced before the upload starts, not after it finishes
+
+`ImageField` received a `maxSize` and ignored it. `paramToField` copies `maxSize` onto the field config for every action param regardless of type, so an image param declared with a 5 MB limit handed the widget its constraint and the widget uploaded anyway: a 6.3 MB PNG fired the full `presigned → PUT → complete` chain and rendered a thumbnail, with no rejection anywhere. The sibling file param, declared the same way, refused the identical pick without a single request. Reported from a QA run driving the two side by side (objectui#4141).
+
+Both of the widget's upload doors now check the limit first. The native picker rejects oversize picks before any request, keeping FileField's partial-acceptance rule — the in-limit members of a multi-select still upload, and only the oversize ones are reported. The crop dialog is the second door and needed the check in its own right: the cropper re-encodes to PNG, so cropping an in-limit JPEG can produce a blob *over* the limit, and it is the crop's size that is uploaded. A rejected pick or crop now surfaces the same message the file widget has always shown, in a new error row — this widget had no surface for rejections before, because it never rejected anything.
+
+The guard itself moved into one shared `maxSizeError` helper that both widgets call, rather than a second copy living in the image widget. The check is the only thing between a declared limit and a real upload, and a per-widget copy is what let these two drift apart unnoticed in the first place. Both widgets also share the existing `fields.file.exceedsMaxSize` message: it names a file and a limit, says nothing file-specific, and is already translated in all built-in locales, so no new key was added and no translation is pending. FileField's own behavior is unchanged — same threshold, same message, same partial acceptance.
+
+An undeclared `maxSize` still means unrestricted; the falsy check is preserved deliberately, so a missing limit can never be read as a zero-byte one.

--- a/packages/fields/src/widgets/FileField.tsx
+++ b/packages/fields/src/widgets/FileField.tsx
@@ -7,6 +7,7 @@ import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { toHostGroupProps } from './toHostGroupProps';
 import { useUploadingSignal } from './useUploadingSignal';
+import { maxSizeError, type TranslateFn } from './file-size-guard';
 import {
   fileValueForSubmit,
   readFileValues,
@@ -48,13 +49,11 @@ function useFileUploads(opts: {
     if (selectedFiles.length === 0) return;
     const newErrors: string[] = [];
 
+    // Shared with ImageField — see `file-size-guard`.
     const validFiles = selectedFiles.filter(file => {
-      if (maxSize && file.size > maxSize) {
-        const maxMB = (maxSize / (1024 * 1024)).toFixed(1);
-        newErrors.push(t('fields.file.exceedsMaxSize', {
-          defaultValue: `"${file.name}" exceeds max size (${maxMB} MB)`,
-          name: file.name, max: maxMB,
-        }));
+      const rejection = maxSizeError(t as TranslateFn, file, maxSize);
+      if (rejection) {
+        newErrors.push(rejection);
         return false;
       }
       return true;

--- a/packages/fields/src/widgets/ImageField.maxSize.test.tsx
+++ b/packages/fields/src/widgets/ImageField.maxSize.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * ImageField — a declared `maxSize` is enforced BEFORE any upload starts
+ * (objectui#4141).
+ *
+ * The defect this pins: `paramToField` copies `maxSize` onto the field config
+ * for every param type, so the image widget RECEIVES the constraint — it just
+ * never read it. An oversized pick therefore fired the whole
+ * `presigned → PUT → complete` chain and rendered a preview, while the sibling
+ * file param rejected the same pick with zero uploads.
+ *
+ * So the assertion that matters is **zero upload attempts**, not "no preview":
+ * a widget that uploads the bytes and then hides the thumbnail has still
+ * stored an over-limit file. The spy sits on the `UploadProvider` adapter —
+ * the layer that performs the presigned request — so a call there IS the
+ * network attempt.
+ *
+ * Two upload entry points exist on this widget and both are covered here:
+ *   1. the native picker (`handleFileChange`, single and `multiple`);
+ *   2. the crop dialog's confirm (`handleCropConfirm`), which uploads a
+ *      freshly re-encoded PNG blob — canvas re-encoding can push a crop of an
+ *      in-limit JPEG *over* the limit, so it is a real second door.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { UploadProvider, type UploadAdapter } from '@object-ui/providers';
+import { ImageField } from './ImageField';
+// Imported at module scope (not awaited in a hook) so the widget's
+// `React.lazy(() => import('./ImageCropperDialog'))` resolves from the ESM
+// cache instead of racing RTL's 1000ms `findBy` budget — AGENTS.md §测试纪律.
+import './ImageCropperDialog';
+
+const MB = 1024 * 1024;
+
+/** A File whose reported `size` is the declared one (constructor bytes are not). */
+function imageOfSize(name: string, bytes: number): File {
+  const file = new File(['x'], name, { type: 'image/png' });
+  Object.defineProperty(file, 'size', { value: bytes });
+  return file;
+}
+
+function blobOfSize(bytes: number): Blob {
+  const blob = new Blob(['x'], { type: 'image/png' });
+  Object.defineProperty(blob, 'size', { value: bytes });
+  return blob;
+}
+
+function renderField(field: Record<string, unknown>, value: unknown = undefined) {
+  const upload = vi.fn(async (f: File | Blob) => ({
+    url: 'https://cdn.example/uploaded.png',
+    name: (f as File).name ?? 'cropped.png',
+    size: f.size,
+    mimeType: f.type || 'image/png',
+  }));
+  const adapter: UploadAdapter = { name: 'spy', upload };
+  const onChange = vi.fn();
+  render(
+    <UploadProvider adapter={adapter}>
+      <ImageField field={field as any} value={value} onChange={onChange} />
+    </UploadProvider>,
+  );
+  return { upload, onChange, input: document.querySelector('input[type="file"]') as HTMLInputElement };
+}
+
+describe('ImageField — client-side maxSize guard (#4141)', () => {
+  it('never reaches the upload layer for a pick over the declared maxSize', async () => {
+    const { upload, onChange, input } = renderField({ name: 'p_cover', maxSize: 5 * MB });
+
+    fireEvent.change(input, { target: { files: [imageOfSize('huge.png', 6.3 * MB)] } });
+
+    // The message is the proof the guard ran; the spy is the proof nothing was sent.
+    await screen.findByText(/"huge\.png" exceeds max size \(5\.0 MB\)/);
+    expect(upload).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still uploads a pick inside the declared maxSize', async () => {
+    const { upload, onChange, input } = renderField({ name: 'p_cover', maxSize: 5 * MB });
+
+    fireEvent.change(input, { target: { files: [imageOfSize('ok.png', 1 * MB)] } });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/exceeds max size/)).toBeNull();
+  });
+
+  it('uploads unrestricted when the param declares no maxSize', async () => {
+    const { upload, onChange, input } = renderField({ name: 'p_cover' });
+
+    fireEvent.change(input, { target: { files: [imageOfSize('enormous.png', 500 * MB)] } });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/exceeds max size/)).toBeNull();
+  });
+
+  it('rejects only the oversized picks of a multi-select and uploads the rest', async () => {
+    const { upload, onChange, input } = renderField({ name: 'p_gallery', multiple: true, maxSize: 5 * MB });
+
+    fireEvent.change(input, {
+      target: { files: [imageOfSize('small.png', 1 * MB), imageOfSize('huge.png', 6.3 * MB)] },
+    });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect((upload.mock.calls[0][0] as File).name).toBe('small.png');
+    expect(screen.getByText(/"huge\.png" exceeds max size \(5\.0 MB\)/)).toBeTruthy();
+  });
+
+  it('guards the crop dialog too — an oversized re-encode is never uploaded', async () => {
+    const existing = { name: 'cover.png', url: 'https://cdn.example/cover.png', mime_type: 'image/png' };
+    const { upload, onChange } = renderField({ name: 'p_cover', maxSize: 5 * MB, crop: true }, existing);
+
+    fireEvent.click(screen.getByTestId('image-field-crop-0'));
+    const confirm = await screen.findByTestId('fake-crop-confirm');
+    fireEvent.click(confirm);
+
+    await screen.findByText(/exceeds max size \(5\.0 MB\)/);
+    expect(upload).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still uploads a crop that fits inside the declared maxSize', async () => {
+    const existing = { name: 'cover.png', url: 'https://cdn.example/cover.png', mime_type: 'image/png' };
+    const { upload, onChange } = renderField({ name: 'p_cover', maxSize: 5 * MB, crop: true }, existing);
+
+    fireEvent.click(screen.getByTestId('image-field-crop-0'));
+    fireEvent.click(await screen.findByTestId('fake-crop-confirm-small'));
+
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(upload).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The real cropper is a canvas + `toBlob` pipeline that happy-dom cannot run;
+ * this stand-in drives the ONE contract ImageField has with it — `onConfirm`
+ * hands back a blob and a name — with a blob size on either side of the limit.
+ */
+vi.mock('./ImageCropperDialog', () => ({
+  ImageCropperDialog: ({ onConfirm }: { onConfirm: (blob: Blob, name: string) => void }) => (
+    <div>
+      <button type="button" data-testid="fake-crop-confirm" onClick={() => onConfirm(blobOfSize(6.3 * MB), 'cover.png')}>
+        confirm big
+      </button>
+      <button
+        type="button"
+        data-testid="fake-crop-confirm-small"
+        onClick={() => onConfirm(blobOfSize(0.5 * MB), 'cover.png')}
+      >
+        confirm small
+      </button>
+    </div>
+  ),
+}));

--- a/packages/fields/src/widgets/ImageField.tsx
+++ b/packages/fields/src/widgets/ImageField.tsx
@@ -7,6 +7,7 @@ import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { ImageLightbox } from './ImageLightbox';
 import { useUploadingSignal } from './useUploadingSignal';
+import { maxSizeError, type TranslateFn } from './file-size-guard';
 import {
   fileValueForSubmit,
   readFileValues,
@@ -31,6 +32,12 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
   const multiple = imageField?.multiple || false;
   const accept = imageField?.accept ? imageField.accept.join(',') : 'image/*';
   /**
+   * Max upload size in bytes. Delivered by `paramToField` for an action param
+   * and by the field config for a record field; enforced before any upload
+   * starts, exactly as FileField does (objectui#4141).
+   */
+  const maxSize = imageField?.maxSize as number | undefined;
+  /**
    * Set `field.crop = false` to opt out of inline cropping. Defaults to enabled.
    */
   const cropEnabled = imageField?.crop !== false;
@@ -39,6 +46,8 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
   const { upload } = useUpload();
   const { t } = useObjectTranslation();
   const [uploading, setUploading] = useState(false);
+  /** Client-side rejections (oversize picks), cleared on the next attempt. */
+  const [errors, setErrors] = useState<string[]>([]);
   // Display details of just-uploaded images, keyed by their new `sys_file` id.
   // Submitting the reference form means the field value no longer carries the
   // URL a thumbnail needs; these keep the preview visible until the next read
@@ -59,6 +68,18 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
   const handleCropConfirm = useCallback(
     async (blob: Blob, name: string) => {
       if (!cropTarget) return;
+      // The size that matters here is the CROP's, not the source image's: the
+      // cropper re-encodes to PNG, so cropping an in-limit JPEG can produce a
+      // blob over the limit. Checked before `setUploading` so a rejected crop
+      // never flashes the spinner, and the dialog closes so the message lands
+      // in the field's error row rather than behind the open dialog.
+      const rejection = maxSizeError(t as TranslateFn, { name, size: blob.size }, maxSize);
+      if (rejection) {
+        setErrors([rejection]);
+        setCropTarget(null);
+        return;
+      }
+      setErrors([]);
       setUploading(true);
       try {
         const result = await upload(blob);
@@ -76,7 +97,7 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
         setCropTarget(null);
       }
     },
-    [cropTarget, images, multiple, onChange, upload, remember],
+    [cropTarget, images, multiple, onChange, upload, remember, maxSize, t],
   );
 
   const openCropper = useCallback(
@@ -128,12 +149,32 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = Array.from(e.target.files || []);
+    // Reset the input up front rather than in `finally`: a pick rejected below
+    // returns before the upload runs, and leaving the old value in place would
+    // stop the user re-picking the same name after shrinking the image.
+    // `selectedFiles` already holds the File objects, so clearing is safe.
+    if (inputRef.current) inputRef.current.value = '';
     if (selectedFiles.length === 0) return;
+
+    // Enforce the declared limit before anything touches the network. Partial
+    // acceptance matches FileField: the in-limit picks of a multi-select still
+    // upload, and only the oversize ones are reported.
+    const rejections: string[] = [];
+    const validFiles = selectedFiles.filter((file) => {
+      const rejection = maxSizeError(t as TranslateFn, file, maxSize);
+      if (rejection) {
+        rejections.push(rejection);
+        return false;
+      }
+      return true;
+    });
+    setErrors(rejections);
+    if (validFiles.length === 0) return;
 
     setUploading(true);
     try {
       const imageObjects = await Promise.all(
-        selectedFiles.map(async (file) => {
+        validFiles.map(async (file) => {
           const result = await upload(file);
           remember(result, file.name);
           return fileValueForSubmit(result, file.name);
@@ -147,8 +188,6 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
       }
     } finally {
       setUploading(false);
-      // Reset input so picking the same file again still triggers change.
-      if (inputRef.current) inputRef.current.value = '';
     }
   };
 
@@ -237,6 +276,17 @@ export function ImageField({ value, onChange, field, readonly, onUploadingChange
               ? t('fields.image.addMore')
               : t('fields.image.upload')}
         </Button>
+
+        {/* Client-side rejections (oversize picks). Same presentation as
+            FileField's error row — this widget previously had no surface for
+            them at all, because it never rejected anything (objectui#4141). */}
+        {errors.length > 0 && (
+          <div className="space-y-0.5">
+            {errors.map((err, i) => (
+              <p key={i} className="text-xs text-destructive">{err}</p>
+            ))}
+          </div>
+        )}
       </div>
 
       {cropEnabled && cropTarget && (

--- a/packages/fields/src/widgets/file-size-guard.ts
+++ b/packages/fields/src/widgets/file-size-guard.ts
@@ -1,0 +1,55 @@
+/**
+ * The client-side `maxSize` guard shared by the file and image widgets
+ * (objectui#4141).
+ *
+ * Why this is shared rather than mirrored per widget: the guard is the only
+ * thing standing between a declared `maxSize` and a real `presigned → PUT →
+ * complete` round trip, and `paramToField` copies `maxSize` onto the field
+ * config for **every** param type regardless of which widget ends up rendering
+ * it. So a widget that re-derives the check drifts silently — the image param
+ * shipped receiving the constraint and never reading it, while the file param
+ * rejected the identical pick, and nothing failed until QA drove the two side by
+ * side. One exported function makes the difference visible: a widget either
+ * calls it or conspicuously does not.
+ *
+ * Both widgets deliberately share the `fields.file.exceedsMaxSize` key too. The
+ * sentence names a file and a limit and says nothing file-widget-specific, it is
+ * already translated in all 11 built-in locales, and a parallel `fields.image.*`
+ * twin would be the same sentence maintained twice — drifting the moment one
+ * translator rewords one of them.
+ */
+
+/**
+ * Minimal shape of the i18next `t` this module needs, matching the established
+ * `TranslateFn` pattern in `app-shell/src/providers/writeWarningToast`.
+ */
+export type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
+
+/** Divisor for rendering a byte limit as MB, matching the widgets' size display. */
+const BYTES_PER_MB = 1024 * 1024;
+
+/**
+ * The rejection message for a pick that exceeds `maxSize`, or `null` when the
+ * pick is within the limit — so a caller reads it as `if (err) reject`.
+ *
+ * A falsy `maxSize` (undeclared, or an explicit `0`) means **unrestricted**,
+ * preserving the `if (maxSize && …)` semantics the file widget has always
+ * applied: an undeclared limit must never turn into a 0-byte one.
+ *
+ * Takes `name` and `size` separately instead of a `File` because the image
+ * widget's crop path validates a re-encoded `Blob`, which carries no name of its
+ * own — that name comes from the cropper's output.
+ */
+export function maxSizeError(
+  t: TranslateFn,
+  pick: { name: string; size: number },
+  maxSize: number | undefined,
+): string | null {
+  if (!maxSize || pick.size <= maxSize) return null;
+  const maxMB = (maxSize / BYTES_PER_MB).toFixed(1);
+  return t('fields.file.exceedsMaxSize', {
+    defaultValue: `"${pick.name}" exceeds max size (${maxMB} MB)`,
+    name: pick.name,
+    max: maxMB,
+  });
+}


### PR DESCRIPTION
Fixes #4141

`ImageField` received a declared `maxSize` and ignored it. `paramToField` copies `maxSize` onto the field config for every action param regardless of type, so an image param declared with a 5 MB limit handed the widget its constraint and the widget uploaded anyway: a 6.3 MB PNG fired the full `presigned → PUT → complete` chain and rendered a thumbnail, with no rejection. The sibling file param, declared the same way, refused the identical pick with zero requests.

## What changed

Both of the widget's upload entry points now enforce the limit before anything touches the network. **These are the only two** — measured, not assumed: the widget has no drag-and-drop zone, no paste handler and no camera input (grepping the file for `onDrop` / `onDragOver` / `dataTransfer` / `paste` returns nothing; the dropzone belongs to `FileField`).

1. **Native picker** (`handleFileChange`, single and `multiple`) — keeps FileField's partial-acceptance rule: the in-limit members of a multi-select still upload, and only the oversize ones are reported.
2. **Crop dialog confirm** (`handleCropConfirm`) — a real second door, not a formality. The cropper re-encodes to PNG, so cropping an in-limit JPEG can produce a blob *over* the limit, and it is the crop's bytes that get uploaded. The check therefore reads the blob's size, and runs before `setUploading` so a rejected crop never flashes the spinner.

Rejections render in a new error row. This widget had no surface for them before, because it never rejected anything.

## Shared, not mirrored

The guard is extracted into one `maxSizeError` helper (`packages/fields/src/widgets/file-size-guard.ts`) that both widgets call, rather than a second copy living in the image widget. The check is the only thing standing between a declared limit and a real upload, and a per-widget copy is exactly what let these two drift apart unnoticed. FileField now calls the helper too — same threshold, same message, same partial acceptance, no behavior change.

Both widgets also share the existing `fields.file.exceedsMaxSize` message. It names a file and a limit and says nothing file-widget-specific, and it is already translated in all 11 built-in locales — so **no new i18n key** was added and nothing is pending translation. An undeclared `maxSize` still means unrestricted: the falsy check is preserved deliberately, so a missing limit can never be read as a zero-byte one.

## Verification

Red-first pin `ImageField.maxSize.test.tsx` (6 cases). The core assertion is **zero upload attempts**, not "no preview" — a widget that uploads the bytes and then hides the thumbnail has still stored an over-limit file. The spy sits on the `UploadProvider` adapter, the layer that performs the presigned request, so a call there is the network attempt.

Before the fix: `3 failed | 3 passed`. The three failures are the guard cases; the three passes are the controls (in-limit upload, no-`maxSize` unrestricted, in-limit crop), which pass pre-fix precisely because the unfixed widget uploads everything.

After the fix: `Tests 6 passed (6)`.

Reverse verification — reverted **only** `ImageField.tsx` to `origin/main`, keeping the helper and the pin. Predicted RED with the full-upload signature; confirmed:

```
× never reaches the upload layer for a pick over the declared maxSize
× rejects only the oversized picks of a multi-select and uploads the rest
× guards the crop dialog too — an oversized re-encode is never uploaded
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
Tests  3 failed | 3 passed (6)
```

That assertion is the point: the unfixed widget uploads **both** members of the multi-select where the fix uploads only the in-limit one. Restored afterwards, green again.

Gates, all green:

- `packages/fields` full suite — `Test Files 75 passed`, `Tests 1187 passed` (FileField untouched and green)
- Consumers plus i18n — `ActionParamDialog`, `ActionParamDialog.uploading`, `RelatedList.filecolumns`, `packages/i18n` — `40 passed / 690 passed`
- `pnpm --filter @object-ui/fields type-check`, after building the dependency closure — clean
- `pnpm --filter @object-ui/fields lint` — 0 errors
- `check:control-bytes` — OK, plus a targeted control-byte self-scan of the touched files
- `check:i18n-keys` and `check:i18n-drift` — `0 en value(s) changed`, every call-site key resolves against the en pack

Changeset: `.changeset/image-field-maxsize-guard-4141.md` (`@object-ui/fields` patch).

Scope note: `packages/fields/src/index.tsx` is deliberately untouched, so nothing here collides with #4037 running in the same package.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_