### PR TITLE
fix(editor,markdown): complete the vite alias tables so the per-package test task resolves

### DIFF
--- a/packages/plugin-editor/vite.config.ts
+++ b/packages/plugin-editor/vite.config.ts
@@ -28,13 +28,29 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      // The table must cover every `@object-ui/*` specifier the aliased-to-source
+      // trees themselves reach, not just this package's own imports: `test.setupFiles`
+      // pulls in the root `vitest.setup.tsx`, which imports the components / fields /
+      // plugin-dashboard / plugin-grid barrels, and those sources import further
+      // workspace packages. An entry missing here falls through to the workspace
+      // package's `exports` (i.e. `dist`), which either fails outright when that
+      // package is not in this one's `^build` closure (`Failed to resolve import
+      // "@object-ui/providers"`, objectui#4194) or silently tests `dist` where the
+      // canonical root Vitest run tests `src`. Ordering mirrors the root
+      // `vitest.config.mts` alias table.
+      '@object-ui/i18n': resolve(__dirname, '../i18n/src'),
       '@object-ui/core': resolve(__dirname, '../core/src'),
+      '@object-ui/sdui-parser': resolve(__dirname, '../sdui-parser/src'),
       '@object-ui/types': resolve(__dirname, '../types/src'),
       '@object-ui/react': resolve(__dirname, '../react/src'),
       '@object-ui/components': resolve(__dirname, '../components/src'),
+      '@object-ui/providers': resolve(__dirname, '../providers/src'),
       '@object-ui/fields': resolve(__dirname, '../fields/src'),
       '@object-ui/plugin-dashboard': resolve(__dirname, '../plugin-dashboard/src'),
       '@object-ui/plugin-grid': resolve(__dirname, '../plugin-grid/src'),
+      '@object-ui/data-objectstack': resolve(__dirname, '../data-objectstack/src'),
+      '@object-ui/mobile': resolve(__dirname, '../mobile/src'),
+      '@object-ui/permissions': resolve(__dirname, '../permissions/src'),
     },
   },
   build: {

--- a/packages/plugin-markdown/vite.config.ts
+++ b/packages/plugin-markdown/vite.config.ts
@@ -28,13 +28,29 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      // The table must cover every `@object-ui/*` specifier the aliased-to-source
+      // trees themselves reach, not just this package's own imports: `test.setupFiles`
+      // pulls in the root `vitest.setup.tsx`, which imports the components / fields /
+      // plugin-dashboard / plugin-grid barrels, and those sources import further
+      // workspace packages. An entry missing here falls through to the workspace
+      // package's `exports` (i.e. `dist`), which either fails outright when that
+      // package is not in this one's `^build` closure (`Failed to resolve import
+      // "@object-ui/providers"`, objectui#4194) or silently tests `dist` where the
+      // canonical root Vitest run tests `src`. Ordering mirrors the root
+      // `vitest.config.mts` alias table.
+      '@object-ui/i18n': resolve(__dirname, '../i18n/src'),
       '@object-ui/core': resolve(__dirname, '../core/src'),
+      '@object-ui/sdui-parser': resolve(__dirname, '../sdui-parser/src'),
       '@object-ui/types': resolve(__dirname, '../types/src'),
       '@object-ui/react': resolve(__dirname, '../react/src'),
       '@object-ui/components': resolve(__dirname, '../components/src'),
+      '@object-ui/providers': resolve(__dirname, '../providers/src'),
       '@object-ui/fields': resolve(__dirname, '../fields/src'),
       '@object-ui/plugin-dashboard': resolve(__dirname, '../plugin-dashboard/src'),
       '@object-ui/plugin-grid': resolve(__dirname, '../plugin-grid/src'),
+      '@object-ui/data-objectstack': resolve(__dirname, '../data-objectstack/src'),
+      '@object-ui/mobile': resolve(__dirname, '../mobile/src'),
+      '@object-ui/permissions': resolve(__dirname, '../permissions/src'),
     },
   },
   build: {


### PR DESCRIPTION
Fixes #4194

## Premise check (first, before any edit)

Reproduced on the branch tip off `origin/main` @ `433ff9fd3` — the premise holds, unchanged after 8+ hours:

```
$ pnpm turbo run test --filter=@object-ui/plugin-editor --force
FAIL src/index.test.ts [ src/index.test.ts ]
Error: Failed to resolve import "@object-ui/providers" from "../fields/src/widgets/FileField.tsx". Does the file exist?
  Plugin: vite:import-analysis
  File: /home/user/objectui-issue-4194/packages/fields/src/widgets/FileField.tsx:3:26
 Test Files  1 failed (1)
      Tests  no tests
```

## Mechanism

Both configs alias `@object-ui/fields` (and friends) to source, but not the workspace packages **those sources in turn import**. `test.setupFiles` pulls in the root `vitest.setup.tsx`, which imports the components / fields / plugin-dashboard / plugin-grid barrels, so the setup graph reaches `@object-ui/providers` from `packages/fields/src/widgets/FileField.tsx`. With no alias entry the specifier falls through to the workspace package's `exports` (i.e. `dist`) — and `providers` is not in either package's `^build` closure, so nothing ever creates that `dist`.

Masked in day-to-day CI because `ci.yml` runs the canonical root Vitest (sharded), not per-package `turbo run test`.

## Fix — the alias table completed, not the reachable graph trimmed

Per #3240's ruled direction applied by analogy. The card asked for **all** gaps, not just `providers`, so the reachable set was measured rather than guessed: every `@object-ui/*` specifier imported by the src trees the aliases already point at.

Six entries added to each config, in the root `vitest.config.mts` ordering:

| Added | Reached from | Was |
|:--|:--|:--|
| `providers` | `fields/src/widgets/FileField.tsx`, `ImageField.tsx` | **hard red** — no `dist` |
| `mobile` | `plugin-grid/src/ObjectGrid.tsx` | latent red — no `dist` |
| `permissions` | `plugin-grid/src/ObjectGrid.tsx` | latent red — no `dist` |
| `i18n` | `components/src/custom/navigation-overlay.tsx` | silent divergence — resolved to `dist` |
| `sdui-parser` | `components/src/renderers/layout/page.tsx` | silent divergence — resolved to `dist` |
| `data-objectstack` | `react/src/context/AppShellContext.tsx` | silent divergence — resolved to `dist` |

The three "silent divergence" rows were green only because those packages happen to sit in the `^build` closure, so the per-package path was testing `dist` where the canonical root run tests `src` — the two-verdicts-for-one-file shape #3240 documents. `@object-ui/types/zod` was deliberately **not** added: the root table needs it ahead of `@object-ui/types` because of Vite's prefix matching, but nothing in the reach set imports it, and the runs are green without it.

## Sweep: plugin-markdown has the same gap

The card asked to check it; it was red too, on the same signature, all 4 files:

```
$ pnpm turbo run test --filter=@object-ui/plugin-markdown --force   # BEFORE, unmodified config
Error: Failed to resolve import "@object-ui/providers" from "../fields/src/widgets/FileField.tsx"
 Test Files  4 failed (4)
      Tests  no tests
```

Same fix applied, in this PR, with its own evidence below.

## Evidence

Red-before / green-after of the same command, per package:

```
$ pnpm turbo run test --filter=@object-ui/plugin-editor --force     # AFTER
 ✓ src/index.test.ts (7 tests) 8ms
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ pnpm turbo run test --filter=@object-ui/plugin-markdown --force   # AFTER
 ✓ src/index.test.ts (5 tests)  ✓ src/metadata-fence.test.ts (6 tests)
 ✓ src/markdown-render.test.tsx (12 tests)  ✓ src/toc.test.ts (6 tests)
 Test Files  4 passed (4)
      Tests  29 passed (29)
```

Note the before/after is not merely red-to-green: it was `0 test` / `no tests` (the suite could not load at all), and it is now 7 and 29 tests actually executing.

Canonical CI path unregressed, and the two paths now agree on the count (7 + 29 = 36):

```
$ pnpm exec vitest run packages/plugin-editor/ packages/plugin-markdown/
 Test Files  5 passed (5)
      Tests  36 passed (36)
```

## Reverse verification

Predicted direction **RED** (the ordinary one — the resolve failure returns), with its precondition recorded first, since a `providers/dist` created by some unrelated build would have made the revert falsely green:

```
providers/dist present: no
$ git checkout origin/main -- packages/plugin-editor/vite.config.ts
$ pnpm turbo run test --filter=@object-ui/plugin-editor --force
Error: Failed to resolve import "@object-ui/providers" from "../fields/src/widgets/FileField.tsx"
 Test Files  1 failed (1)
```

Confirmed, then restored.

## Changeset

Let the gate arbitrate rather than guessing, as the card directed. Verdict — **none owed**, and no `skip-changeset` label (#3724):

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with 433ff9fd3 (merge-base with origin/main): 2 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

Other gates: `node scripts/check-control-bytes.mjs` OK (3920 files); `eslint` on both changed files exits 0.

## Relationship to #3240's own execution

This is the targeted un-redding of two packages, not a move away from #3240's ruling. That ruling (Direction A — delete the 17 per-package vitest configs, root config becomes the single entry) is explicitly **deferred to a dedicated quiet-window batch**, and neither package here is among those 17: both carry a `vite.config.ts` with a `test` block, not a `vitest.config.ts`. When A executes, both of these tables disappear along with the divergence they are patching.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_