### PR TITLE
fix(detail): inline-edit an address as sub-fields, not a text box reading `[Object]`

### DIFF
--- a/.changeset/inline-address-input-4216.md
+++ b/.changeset/inline-address-input-4216.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+Inline-editing an `address` on the record detail page now edits it as real sub-fields, instead of collapsing it to one text box reading `[Object]` and saving a string over the structured value.
+
+`InlineFieldInput`'s type switch routed the scalar and relational families to their dedicated widgets; every structured-object type matched nothing and fell through to the terminal raw text input at the end of the component. That fallback stringifies an object value through `coerceToSafeValue`, whose general-object case extracts `name || label || externalId || id || _id` and otherwise returns the literal `[Object]`. A stored address carries none of those keys, so the edit box read `[Object]`.
+
+The display half was cosmetic; the write half was not. The fallback is a plain input wired to `onChange(v)`, so whatever the user typed was emitted as a **string** that replaced the whole `{ street, city, state, postalCode, country }` object on save — and `[Object]` was what the user saw as the current value they were correcting, which makes typing over it the natural gesture. An ordinary double-click inline edit therefore destroyed the sub-field structure. This is the input path only: objectui#4037 fixed the display registry, and read mode (including the inline-edit read state before editing starts) already rendered a formatted address.
+
+`location` and `geolocation` are fixed with it. Both store objects too (`{ latitude, longitude }`), both reached the same terminal input, and both produced the identical `[Object]`-then-overwrite pair — one defect in three spellings, not three defects.
+
+No new editor was written and no consumer-side tolerance was added. All three route to the widgets the create/edit dialog already uses (`AddressField` / `LocationField` / `GeolocationField`, the form's own structured-value editors), so the two entry points cannot diverge on the value shape they write back, and `coerceToSafeValue` is left untouched — the routing is what stops an address from ever reaching it. `autoFocus` follows the numeric branches' convention and lands on each widget's first sub-input (street / the coordinate box / latitude).
+
+String-valued types are unchanged: `text`, `textarea`, `email`, `phone`, `url`, `color`, `code`, `time`, `qrcode` and the rest keep the terminal text input, where stringification is the identity and nothing is lost.

--- a/packages/plugin-detail/src/InlineFieldInput.tsx
+++ b/packages/plugin-detail/src/InlineFieldInput.tsx
@@ -19,6 +19,9 @@ import {
   FileField,
   AvatarField,
   SignatureField,
+  AddressField,
+  LocationField,
+  GeolocationField,
   coerceToSafeValue,
 } from '@object-ui/fields';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
@@ -77,9 +80,12 @@ export interface InlineFieldInputProps {
  * highlights strip (objectui#2407) — renders an identical editor. Covers every
  * widget the detail body handles: `SelectField`, `BooleanField`, `LookupField`,
  * `UserField`, the `permission-facet-link` read-only facet (#2403), the numeric
- * widgets (`NumberField` / `CurrencyField` / `PercentField`, objectui#2572), and
- * the plain date/text input (with ISO date coercion + object-value guarding so
- * an unexpanded reference never leaks "[object Object]").
+ * widgets (`NumberField` / `CurrencyField` / `PercentField`, objectui#2572), the
+ * structured composites (`AddressField` / `LocationField` / `GeolocationField`,
+ * objectui#4216 — their value is an OBJECT, so the text fallback both displayed
+ * and WROTE it wrong), and the plain date/text input (with ISO date coercion +
+ * object-value guarding so an unexpanded reference never leaks
+ * "[object Object]").
  *
  * Editability GATING (computed types, `readonly`, system fields, object
  * lifecycle) stays with the host — this component only renders the editor once
@@ -204,6 +210,34 @@ export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
   }
   if (editType === 'percent') {
     return <PercentField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
+  }
+  // Structured-value composites → the SAME widgets the create/edit dialog uses
+  // (objectui#4216). Their stored value is an OBJECT, and the terminal text
+  // input below is a value-destroying editor for all three: it renders the
+  // object through `coerceToSafeValue`, whose general-object case extracts
+  // `name || label || externalId || id || _id` — none of which an address or a
+  // coordinate pair has — so the box reads the literal "[Object]", and then
+  // emits whatever is typed over it as a bare STRING that replaces the whole
+  // object on save. Routing them here is what makes the sub-fields the editing
+  // surface and keeps the write an object, so the inline path and the form path
+  // cannot diverge on the value SHAPE they write back.
+  //
+  // The widgets are the form's own (`fieldWidgetMap`, and `FieldEditWidget`'s
+  // "structured-value editors" block) — all three are dependency-light, so a
+  // static import here costs the detail bundle nothing a map/code editor would.
+  //
+  // `autoFocus` follows the numeric branches' convention: each widget forwards
+  // the DOM pass-through set onto its FIRST focusable sub-input (street /
+  // latitude / the coordinate box), so entering inline edit on the field lands
+  // the caret in the same place a single-input type would.
+  if (editType === 'address') {
+    return <AddressField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
+  }
+  if (editType === 'location') {
+    return <LocationField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
+  }
+  if (editType === 'geolocation') {
+    return <GeolocationField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
   }
   const isDate = editType === 'date' || editType === 'datetime';
   const inputType = isDate ? 'date' : 'text';

--- a/packages/plugin-detail/src/__tests__/InlineFieldInput.composite.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineFieldInput.composite.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InlineFieldInput } from '../InlineFieldInput';
+
+/**
+ * Type into whatever the FIRST editable box of the rendered editor happens to
+ * be, and hand back what `onChange` emitted.
+ *
+ * Deliberately query-INDEPENDENT. The obvious way to pin the write half is
+ * `fireEvent.change(screen.getByDisplayValue('San Francisco'), …)`, but that
+ * sub-input does not exist before the fix, so the test fails on "unable to find
+ * an element" — a signature that names the missing SUB-INPUT and says nothing
+ * about the missing structured write. Those are two different defects, and the
+ * data-destroying one is the second.
+ *
+ * Addressing the first `<input>` instead reaches the terminal text box before
+ * the fix and the first sub-field after it, so the assertion that follows is
+ * always about the emitted VALUE SHAPE: before → `'…'` (a string that replaces
+ * the whole object), after → an object. That is the half this issue is about.
+ */
+function typeIntoFirstBox(container: HTMLElement, text: string): void {
+  const input = container.querySelector('input');
+  expect(input).not.toBeNull();
+  fireEvent.change(input as HTMLInputElement, { target: { value: text } });
+}
+
+/**
+ * Structured-composite inline editing (objectui#4216).
+ *
+ * `InlineFieldInput`'s type switch used to route only the scalar and relational
+ * families; every STRUCTURED-object type fell through to the terminal raw text
+ * input at the end of the component. That fallback stringifies an object value
+ * through `coerceToSafeValue`, which has no branch for any of these shapes — an
+ * address / location / geolocation carries none of `name` / `label` /
+ * `externalId` / `id` / `_id`, so its general-object case returns the literal
+ * `[Object]`.
+ *
+ * The defect has TWO halves, and both are pinned for every type below, because
+ * either one alone is a test that cannot see the real damage:
+ *
+ *  1. **Display** — the edit box reads `[Object]`, so `[Object]` is what the
+ *     user sees as "the current value I am correcting".
+ *  2. **Write** — the box is a plain `<input>` wired to `onChange(v)`, so
+ *     whatever is typed is emitted as a STRING that replaces the structured
+ *     object on save. An ordinary inline edit destroys the sub-field structure.
+ *
+ * Half 2 is the data-destroying one and it is invisible to a display-only
+ * assertion, so each type asserts the emitted value is an OBJECT and that
+ * sub-fields the user did not touch survive the round-trip.
+ *
+ * Assertions are provider-free (matching the sibling `InlineFieldInput` suite)
+ * so they hold whether or not i18n / permission providers are mounted.
+ */
+describe('InlineFieldInput — structured composite values (objectui#4216)', () => {
+  describe('address', () => {
+    const ADDRESS = {
+      street: '123 Main St',
+      city: 'San Francisco',
+      state: 'CA',
+      postalCode: '94102',
+      country: 'United States',
+    };
+
+    it('renders the real sub-field editor, never a single box reading "[Object]"', () => {
+      render(
+        <InlineFieldInput
+          field={{ name: 'billing_address', type: 'address' }}
+          value={{ ...ADDRESS }}
+          onChange={vi.fn()}
+        />,
+      );
+      // Half 1: the stringified placeholder must not be the editable value.
+      expect(screen.queryByDisplayValue('[Object]')).toBeNull();
+      expect(screen.queryByText('[Object]')).toBeNull();
+      // Every sub-field is separately editable, the way the form path renders it.
+      expect(screen.getByDisplayValue('123 Main St')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('San Francisco')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('CA')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('94102')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('United States')).toBeInTheDocument();
+    });
+
+    it('emits a STRUCTURED OBJECT on edit, preserving the untouched sub-fields', () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput
+          field={{ name: 'billing_address', type: 'address' }}
+          value={{ ...ADDRESS }}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.change(screen.getByDisplayValue('San Francisco'), {
+        target: { value: 'Oakland' },
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const next = onChange.mock.calls[0][0];
+      // Half 2: an object, NOT a string — this is the data-destroying half.
+      expect(typeof next).toBe('object');
+      expect(next).not.toBeNull();
+      expect(next).toEqual({ ...ADDRESS, city: 'Oakland' });
+    });
+
+    it('never emits a bare STRING that replaces the whole object', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <InlineFieldInput
+          field={{ name: 'billing_address', type: 'address' }}
+          value={{ ...ADDRESS }}
+          onChange={onChange}
+        />,
+      );
+      typeIntoFirstBox(container, 'Oakland');
+      expect(onChange).toHaveBeenCalledTimes(1);
+      // The signature that matters: before the routing fix this is the string
+      // 'Oakland', which overwrites `{ street, city, state, postalCode,
+      // country }` wholesale on save.
+      expect(typeof onChange.mock.calls[0][0]).not.toBe('string');
+      expect(typeof onChange.mock.calls[0][0]).toBe('object');
+    });
+
+    it('auto-focuses the first sub-input when autoFocus is set', () => {
+      render(
+        <InlineFieldInput
+          field={{ name: 'billing_address', type: 'address' }}
+          value={{ ...ADDRESS }}
+          onChange={vi.fn()}
+          autoFocus
+        />,
+      );
+      // Same convention as the other routed widgets: focus lands on the first
+      // focusable control of the editor, here the street line.
+      expect(screen.getByDisplayValue('123 Main St')).toHaveFocus();
+    });
+
+    it('renders empty sub-inputs for a null value instead of a blank text box', () => {
+      render(
+        <InlineFieldInput
+          field={{ name: 'billing_address', type: 'address' }}
+          value={null}
+          onChange={vi.fn()}
+        />,
+      );
+      // The composite is still the editor when there is nothing stored yet —
+      // that is how an address gets authored inline in the first place.
+      expect(screen.getByPlaceholderText('123 Main St')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('San Francisco')).toBeInTheDocument();
+    });
+  });
+
+  describe('location', () => {
+    it('renders the coordinate pair, never "[Object]"', () => {
+      render(
+        <InlineFieldInput
+          field={{ name: 'site', type: 'location' }}
+          value={{ latitude: 37.7749, longitude: -122.4194 }}
+          onChange={vi.fn()}
+        />,
+      );
+      expect(screen.queryByDisplayValue('[Object]')).toBeNull();
+      expect(screen.getByDisplayValue('37.7749, -122.4194')).toBeInTheDocument();
+    });
+
+    it('emits a STRUCTURED OBJECT on edit', () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput
+          field={{ name: 'site', type: 'location' }}
+          value={{ latitude: 37.7749, longitude: -122.4194 }}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.change(screen.getByDisplayValue('37.7749, -122.4194'), {
+        target: { value: '40.7128, -74.006' },
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const next = onChange.mock.calls[0][0];
+      expect(typeof next).toBe('object');
+      expect(next).toEqual({ latitude: 40.7128, longitude: -74.006 });
+    });
+
+    it('never emits a bare STRING that replaces the whole object', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <InlineFieldInput
+          field={{ name: 'site', type: 'location' }}
+          value={{ latitude: 37.7749, longitude: -122.4194 }}
+          onChange={onChange}
+        />,
+      );
+      typeIntoFirstBox(container, '40.7128, -74.006');
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(typeof onChange.mock.calls[0][0]).not.toBe('string');
+      expect(typeof onChange.mock.calls[0][0]).toBe('object');
+    });
+  });
+
+  describe('geolocation', () => {
+    it('renders separate latitude / longitude inputs, never "[Object]"', () => {
+      render(
+        <InlineFieldInput
+          field={{ name: 'checkin', type: 'geolocation' }}
+          value={{ latitude: 37.7749, longitude: -122.4194 }}
+          onChange={vi.fn()}
+        />,
+      );
+      expect(screen.queryByDisplayValue('[Object]')).toBeNull();
+      expect(screen.getByDisplayValue('37.7749')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('-122.4194')).toBeInTheDocument();
+    });
+
+    it('emits a STRUCTURED OBJECT on edit, preserving the untouched coordinate', () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput
+          field={{ name: 'checkin', type: 'geolocation' }}
+          value={{ latitude: 37.7749, longitude: -122.4194 }}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.change(screen.getByDisplayValue('37.7749'), {
+        target: { value: '40.7128' },
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const next = onChange.mock.calls[0][0];
+      expect(typeof next).toBe('object');
+      expect(next).toEqual({ latitude: 40.7128, longitude: -122.4194 });
+    });
+
+    it('never emits a bare STRING that replaces the whole object', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <InlineFieldInput
+          field={{ name: 'checkin', type: 'geolocation' }}
+          value={{ latitude: 37.7749, longitude: -122.4194 }}
+          onChange={onChange}
+        />,
+      );
+      typeIntoFirstBox(container, '40.7128');
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(typeof onChange.mock.calls[0][0]).not.toBe('string');
+      expect(typeof onChange.mock.calls[0][0]).toBe('object');
+    });
+  });
+
+  /**
+   * CONTROLS — the terminal text input is still the right editor for the
+   * already-a-string families, and routing the composites above must not
+   * disturb them. A `text` field whose value is an unexpanded object is the
+   * pre-existing guard (a reference that slipped through type detection) and
+   * deliberately keeps its `coerceToSafeValue` behaviour.
+   */
+  describe('controls — string-valued types keep the terminal text input', () => {
+    it('text still edits as one text box emitting a string', () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput
+          field={{ name: 'title', type: 'text' }}
+          value="Hello"
+          onChange={onChange}
+        />,
+      );
+      const input = screen.getByDisplayValue('Hello');
+      expect(input).toHaveAttribute('type', 'text');
+      fireEvent.change(input, { target: { value: 'Hi there' } });
+      expect(onChange).toHaveBeenCalledWith('Hi there');
+      expect(typeof onChange.mock.calls[0][0]).toBe('string');
+    });
+
+    it('email still edits as one text box emitting a string', () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput
+          field={{ name: 'email', type: 'email' }}
+          value="a@b.com"
+          onChange={onChange}
+        />,
+      );
+      fireEvent.change(screen.getByDisplayValue('a@b.com'), {
+        target: { value: 'c@d.com' },
+      });
+      expect(onChange).toHaveBeenCalledWith('c@d.com');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #4216

Inline-editing an `address` on the record detail page collapsed it to one text box reading `[Object]`, and saving wrote a bare string over the structured value. `location` and `geolocation` are fixed with it — same cause, same two signatures, one defect in three spellings.

## Cause

`InlineFieldInput`'s type switch routes the scalar and relational families to dedicated widgets. Every **structured-object** type matched nothing and fell through to the terminal raw text input at the end of the component, which stringifies through `coerceToSafeValue`. That helper's general-object case extracts `name || label || externalId || id || _id` and otherwise returns the literal `[Object]` — and an address (`{ street, city, state, postalCode, country }`) or a coordinate pair (`{ latitude, longitude }`) carries none of those keys.

The defect has two halves and the second is the damaging one:

1. **Display** — the edit box reads `[Object]`, so `[Object]` is what the user sees as the value they are correcting, which makes typing over it the natural gesture.
2. **Write** — that box is a plain text input wired to `onChange(v)`, so whatever is typed is emitted as a **string** replacing the whole object on save. An ordinary double-click inline edit destroys the sub-field structure.

Input path only. #4037 / PR #4215 fixed the display registry, so read mode — including the inline-edit read state before editing starts — already renders a formatted address; once a field is actively being edited, `DetailSection` renders `InlineFieldInput` instead, which is why that PR does not touch this.

## The fix

Route `address`, `location` and `geolocation` to the widgets the create/edit dialog already uses — `AddressField`, `LocationField`, `GeolocationField`, the form's own structured-value editors (`fieldWidgetMap`, and `FieldEditWidget`'s "structured-value editors" block). No new editor, and no consumer-side tolerance: the two entry points now cannot diverge on the value shape they write back.

`coerceToSafeValue` is **untouched**. Adding an address branch there would only have improved the display half while leaving the write half intact; the routing is what stops these values from reaching it at all, which makes the branch unnecessary rather than merely unwritten.

`autoFocus` follows the numeric branches' convention — each widget forwards the DOM pass-through set onto its first focusable sub-input (street / the coordinate box / latitude), so entering inline edit lands the caret where a single-input type would. Commit/cancel semantics are unchanged: `InlineFieldInput` is a controlled input in every branch, and the hosts commit through `InlineEditSaveBar`, so there is no per-input keyboard contract to mirror. Both hosts (`DetailSection` body and the `HeaderHighlight` strip) share the component and get the fix identically; the highlights strip renders a taller editor for these types, as it already does for the routed `ImageField` / `FileField`.

## Composite fall-through sweep

Every field type reaching the terminal text input before this change, and the verdict for each. Fixed here: the object-valued composites, which are the same-shape routing the card scopes. Everything else is filed.

| Class | Types | Stringification | Disposition |
|---|---|---|---|
| Object-valued composite | `address`, `location`, `geolocation` | **Destructive** — object reads `[Object]`, saves a string | **Fixed here** — routed to the form's widgets |
| Array-valued | `tags`, `checkboxes`, `vector`, options-less `multiselect` | **Destructive** — array joined to a string, saved as one | Filed #4220 |
| Container / embedded | `object`, `composite`, `record`, `grid`, `repeater`, `json` | **Destructive** — reads `[Object]`, saves a string over the embedded structure | Filed #4220 (likely exclusion, not routing) |
| Scalar, wrong editor | `toggle`, `slider`, `progress`, `rating`, `radio` | **Type-lossy** — numbers/booleans emitted as strings; `radio` free-types over its option set | Filed #4220 |
| Credentials | `password`, `secret` | **Destructive + disclosure** — the mask renders as the value and is written back | Filed #4221 |
| Already a string | `text`, `textarea`, `markdown`, `html`, `richtext`, `email`, `phone`, `url`, `time`, `color`, `code`, `qrcode`, options-less `select` | **Benign** — identity | No action; kept on the terminal input, with controls pinning it |
| Computed (gated out) | `formula`, `summary`, `rollup`, `auto_number` | n/a — never enter inline edit | No action, except the `autonumber` spelling filed as #4219 |

The array / container / scalar rows are grouped in #4220 rather than ridden along here because each needs a design call (route vs. exclude; what an options-less `checkboxes` does), not a one-line routing. #4220 also records the root cause behind the whole tail: `@object-ui/fields` already exports `FieldEditWidget` with `INLINE_EXCLUDED_FIELD_TYPES` and a drift-guard test against the form's type list, and `InlineFieldInput` hand-rolls a parallel switch that consults neither.

## Evidence

**Red first.** The pin asserts both halves for all three types and failed on both signatures before the fix — 11 failed, 2 passed, the 2 passes being the string-type controls that legitimately keep the terminal input:

```
× renders the real sub-field editor, never a single box reading "[Object]"
× never emits a bare STRING that replaces the whole object
...
AssertionError: expected [input] to be null
+ Received:
  value="[Object]"

AssertionError: expected 'string' not to be 'string' // Object.is equality
```

The write-half pin is deliberately query-independent (it types into the first box the editor renders, whatever that is). Addressing a named sub-input instead would have failed with "unable to find an element" — a signature naming the missing sub-input, not the missing structured write, which are two different defects.

**After the fix:** `Test Files 1 passed (1) / Tests 13 passed (13)`.

**Affected-package suites** — repo root, path-filtered per AGENTS.md:

```
pnpm exec vitest run packages/plugin-detail/ packages/fields/ --maxWorkers=2
  Test Files  143 passed (143)
       Tests  1738 passed (1738)
```

**Reverse verification.** Predicted RED with **both** signatures returning. Removed only the routing (`git checkout origin/main -- packages/plugin-detail/src/InlineFieldInput.tsx`), keeping the test: 11 failed / 2 passed — the identical split and test set as the pre-fix run, both signatures back. Restored with `git checkout HEAD -- ...`, green again at 13/13.

**Gates:** `type-check` green for `@object-ui/plugin-detail` and `@object-ui/fields` (after building the dependency closure); `eslint` on both changed files 0 errors (32 pre-existing `no-explicit-any` warnings, the same pattern the sibling branches already use); `check-control-bytes` OK across 3917 tracked files; `check-changeset-presence` OK. No copy was touched, so no i18n gate applies — the widgets' sub-labels are the form's existing ones and this change adds no strings.

**Changeset:** `.changeset/inline-address-input-4216.md`, patch on `@object-ui/plugin-detail`. Not a `skip-changeset` candidate — the change is user-visible (objectui#3724).

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_