### PR TITLE
fix(app-shell): inbox/activity "see all" links open in an app the user can open (#4074)

### DIFF
--- a/.changeset/inbox-activity-links-host-app-4074.md
+++ b/.changeset/inbox-activity-links-host-app-4074.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The bell popover's and Home's "see all" drills open inside an app the user can actually open, not the setup app
+
+Four navigation producers hardcoded `/apps/setup/...` for pages that are not bound to the setup app at all: Home's notification fallback (`sys_inbox_message?view=mine`, taken whenever a notification carries no `action_url`), Home's "View all activity" (`sys_activity`), and the bell popover's two footer links to the same two pages. `sys_inbox_message` and `sys_activity` are framework-owned objects that resolve at `/apps/{any app}/{object}` — exactly like `system/approvals`, whose sibling entry in the very same popover was already resolving the current app. The in-code comment defending the hardcoded path argued the OBJECT is app-independent, which is true, and which is precisely why rendering it in `setup` does not follow.
+
+Both halves of the cost were measured in a browser before the fix. A business user whose app list does not contain `setup` clicked "View all notifications" and got the target rendered inside their own app's shell with the page showing "You don't have access" — a softer, more confusing failure than a hard app guard. Every other user, admins included, was switched out of the app they were in: the URL, the sidebar and the header app switcher all flipped to Setup, with no announcement and no way back except the app switcher.
+
+All four now resolve the host app through one shared helper (`resolveHostAppSegment` in `utils/appRoute.ts`), which generalizes the resolution objectstack#7231 introduced for the approvals entry and which Home and the popover both call, so the two surfaces cannot drift into different answers: the app the user is in (or last had open) re-checked against the live active-app list, then their first active app, then — only when the list names no app at all, i.e. it has not loaded yet — the caller's own hint, and `setup` last. A user whose current app is `setup` still lands in `setup`; a remembered app that has since been deactivated or hidden is not resurrected as a link.
+
+Two admin-scoped links, `/apps/setup/system/marketplace` and `/apps/setup/system/apps`, are deliberately left alone and pinned as such: those are setup-app surfaces by intent.
+
+Routing was not the only reason a business user saw an empty inbox — objectstack#7344 (no shipped permission set grants `sys_inbox_message`) is a second, independent cause, and the destination can still refuse the data read until that grant question is settled. This fix is necessary rather than sufficient, and the tests assert the resolved target, never the far end's data grant.

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -27,7 +27,7 @@ import { HomeAppsStrip } from './HomeAppsStrip';
 import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail';
 import { useHomeInbox } from '../../hooks/useHomeInbox';
 import { useNavigationContext } from '../../context/NavigationContext';
-import { appRouteSegment, matchAppBySegment } from '../../utils';
+import { appRouteSegment, filterActiveApps, resolveHostAppSegment } from '../../utils';
 import { Empty, EmptyTitle, EmptyDescription, Button } from '@object-ui/components';
 import { Sparkles, ShieldAlert, X, UploadCloud, MessageSquareText, Hammer, LayoutTemplate } from 'lucide-react';
 import { useMetadataClient } from '../../views/metadata-admin/useMetadata';
@@ -264,35 +264,26 @@ export function HomePage() {
   // when AI isn't enabled. Community builds typically land in the ask-only state.
   const { askAvailable, buildAvailable } = useHomeAiAvailability();
 
-  const activeApps = apps.filter((a: any) => a.active !== false && a.hidden !== true);
+  const activeApps = filterActiveApps(apps);
 
   /**
-   * Which app hosts the Approvals Inbox we link to (objectstack#7231).
+   * Which app hosts the app-independent pages this page links into — the
+   * Approvals Inbox (objectstack#7231), the full inbox and the activity list
+   * (objectui#4074). The resolution and the reasoning live in
+   * `utils/appRoute.ts` so Home and the top-bar bell (`InboxPopover`) cannot
+   * drift into two different answers for the same question.
    *
-   * `system/approvals` is mounted in the host's route fragment as BOTH
-   * `extraRoutes` and `extraRoutesNoApp`, so `/apps/{ANY_APP}/system/approvals`
-   * resolves — the page was never bound to `setup`. The hardcoded
-   * `/apps/setup/...` this replaces was therefore not "where the page lives",
-   * it was a dead end for every business user without access to the setup app.
+   * `currentAppName` is the only "which app is the user in" signal available
+   * here — Home renders OUTSIDE the `/apps/:appName/*` router, so there is no
+   * `params.appName` to read, and the remembered name is stale by construction
+   * (undefined on a cold landing at `/home`, and it outlives the app it names).
+   * That is exactly why the resolution re-checks it against the live list.
    *
-   * Resolution order, each step falling through only when the previous one
-   * cannot name an app the user can actually open:
-   *   1. the app they last had open, if it is still one of their active apps
-   *      (`matchAppBySegment` re-checks it against the live list, so an app
-   *      that was deactivated or hidden since is not resurrected as a link);
-   *   2. their first active app — arbitrary but reachable, and on a business
-   *      user's workspace that is a business app rather than `setup`;
-   *   3. `setup`. NOT the zero-app case: `activeApps.length === 0` returns the
-   *      welcome empty state below, which renders no action center, so this
-   *      producer never runs there. What is left for step 3 is the degenerate
-   *      app carrying neither `_packageId` nor `name` — nothing addressable to
-   *      build a URL from, so the historical target is the least-surprising
-   *      last resort rather than a broken link.
+   * The helper's `setup` last resort is NOT the zero-app case here:
+   * `activeApps.length === 0` returns the welcome empty state below, which
+   * renders no action center, so these producers never run there.
    */
-  const approvalsAppSegment =
-    appRouteSegment(matchAppBySegment(activeApps, currentAppName)) ??
-    appRouteSegment(activeApps[0]) ??
-    'setup';
+  const hostAppSegment = resolveHostAppSegment(activeApps, currentAppName);
 
   const recentApps = recentItems
     .filter(item => item.type === 'object' || item.type === 'dashboard' || item.type === 'page' || item.type === 'record')
@@ -458,6 +449,10 @@ export function HomePage() {
             apps={activeApps}
             favorites={favorites}
             onOpen={(app) => navigate(`/apps/${appRouteSegment(app) ?? app.name}`)}
+            /* Deliberately NOT resolved through `hostAppSegment` (objectui#4074
+               scope guard): the marketplace is an admin-only surface that lives
+               in the setup app, so `setup` here is the target, not an oversight
+               — unlike the app-independent `sys_*` pages below. */
             onBrowseMarketplace={() => navigate('/apps/setup/system/marketplace')}
             isAdmin={isAdmin}
           />
@@ -467,8 +462,13 @@ export function HomePage() {
             <HomeActionCenter
               pendingApprovalsCount={pendingApprovalsCount}
               notifications={notifications}
-              onOpenApprovals={() => navigate(`/apps/${approvalsAppSegment}/system/approvals`)}
-              onOpenNotification={(n) => navigate(n.actionUrl || '/apps/setup/sys_inbox_message?view=mine')}
+              onOpenApprovals={() => navigate(`/apps/${hostAppSegment}/system/approvals`)}
+              /* The fallback arm runs whenever a notification carries no
+                 `action_url`; `?view=mine` selects the user-scoped view, so the
+                 full page matches what the card showed (objectui#4074). */
+              onOpenNotification={(n) =>
+                navigate(n.actionUrl || `/apps/${hostAppSegment}/sys_inbox_message?view=mine`)
+              }
               t={t}
             />
           </div>
@@ -476,7 +476,7 @@ export function HomePage() {
           {/* Continue where you left off + ambient activity */}
           <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
             <HomeContinue items={recentApps} onOpen={(href) => navigate(href)} t={t} />
-            <HomeActivity items={activities} onViewAll={() => navigate('/apps/setup/sys_activity')} t={t} />
+            <HomeActivity items={activities} onViewAll={() => navigate(`/apps/${hostAppSegment}/sys_activity`)} t={t} />
           </div>
         </div>
       </div>

--- a/packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Home's inbox / activity drills — which APP hosts them (objectui#4074).
+ *
+ * ## The defect
+ *
+ * objectstack#7231 fixed ONE producer on this page (the pending-approvals card,
+ * pinned next door in `HomePage.approvalsTarget.test.tsx`) and left its two
+ * siblings hardcoding the same dead app:
+ *
+ *   - `onOpenNotification`'s FALLBACK branch → `/apps/setup/sys_inbox_message?view=mine`
+ *   - `HomeActivity onViewAll`               → `/apps/setup/sys_activity`
+ *
+ * `sys_inbox_message` and `sys_activity` are framework-owned objects, reachable
+ * at `/apps/{any app}/{object}` exactly like `system/approvals` — so naming
+ * `setup` in the URL is a claim about the APP, not about the page. Two browser
+ * verifications on the card measured what that claim costs: a business user
+ * whose app list does not contain `setup` lands on "You don't have access", and
+ * EVERY user is switched out of the app they were in (sidebar and app switcher
+ * flip to Setup) with no announcement.
+ *
+ * ## What these cases assert, and what they deliberately do not
+ *
+ * They assert the RESOLVED TARGET — the argument `navigate()` receives. They say
+ * nothing about what renders at the far end: objectstack#7344 (no shipped
+ * permission set grants `sys_inbox_message`) is a second, independent cause, so
+ * the destination may still show the no-access empty state after this fix. The
+ * routing fix is necessary, not sufficient, and pinning the far end here would
+ * pin someone else's defect.
+ *
+ * ## Scope of the stubs
+ *
+ * Same shape as `HomePage.approvalsTarget.test.tsx`: every hook `HomePage` calls
+ * for an unrelated surface is stubbed at its module boundary, while `HomeRail` /
+ * `HomeAppsStrip` — which own the buttons and their testids — stay real, because
+ * "the click reaches the right URL" is not assertable through a stubbed button.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  }),
+}));
+
+let isAdminFixture = false;
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', email: 'ada@example.com' } }),
+  useIsWorkspaceAdmin: () => isAdminFixture,
+}));
+
+vi.mock('@object-ui/plugin-chatbot', () => ({
+  useAgents: () => ({ agents: [] }),
+  isAskAgent: () => false,
+  agentHasCapability: () => false,
+}));
+
+// --- the app list + the remembered app: the two inputs under test -----------
+let appsFixture: any[] = [];
+let currentAppNameFixture: string | undefined;
+
+vi.mock('../../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: appsFixture, loading: false }),
+}));
+
+vi.mock('../../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ currentAppName: currentAppNameFixture }),
+}));
+
+// --- the inbox feed: notifications with and without an `action_url` ---------
+let notificationsFixture: any[] = [];
+let activitiesFixture: any[] = [];
+
+vi.mock('../../../hooks/useRecentItems', () => ({ useRecentItems: () => ({ recentItems: [] }) }));
+vi.mock('../../../hooks/useFavorites', () => ({ useFavorites: () => ({ favorites: [] }) }));
+vi.mock('../../../hooks/useHomeInbox', () => ({
+  useHomeInbox: () => ({
+    pendingApprovalsCount: 0,
+    notifications: notificationsFixture,
+    activities: activitiesFixture,
+  }),
+}));
+vi.mock('../../../hooks/useAiSurface', () => ({ resolveAiApiBase: () => '' }));
+vi.mock('../../../views/metadata-admin/useMetadata', () => ({
+  useMetadataClient: () => ({ listDrafts: async () => [] }),
+}));
+vi.mock('../../../preview/usePublishAllDrafts', () => ({
+  usePublishAllDrafts: () => ({ publishAll: async () => ({ ok: true }), publishing: false }),
+}));
+vi.mock('../../../runtime-config', () => ({
+  getRuntimeConfig: () => ({ branding: { productName: 'ObjectStack' } }),
+}));
+
+import { HomePage } from '../HomePage';
+
+const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
+
+async function clickAndReadTarget(open: (user: ReturnType<typeof userEvent.setup>) => Promise<void>) {
+  const user = userEvent.setup();
+  render(<HomePage />);
+  await open(user);
+  expect(navigateMock).toHaveBeenCalledTimes(1);
+  return navigateMock.mock.calls[0][0] as string;
+}
+
+/** Click the "Needs your attention" row for the single seeded notification. */
+const clickNotification = () =>
+  clickAndReadTarget(async (user) => {
+    await user.click(screen.getByText('Weekly digest'));
+  });
+
+/** Click HomeActivity's "View all activity" footer link. */
+const clickViewAllActivity = () =>
+  clickAndReadTarget(async (user) => {
+    await user.click(screen.getByText('View all activity'));
+  });
+
+describe('Home inbox/activity drills resolve the host app (objectui#4074)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    appsFixture = [app('setup'), app('crm')];
+    currentAppNameFixture = 'crm';
+    isAdminFixture = false;
+    notificationsFixture = [{ id: 'n1', title: 'Weekly digest' }];
+    activitiesFixture = [];
+  });
+
+  describe('the notification fallback branch (no action_url)', () => {
+    it('opens the inbox inside the app the user last had open', async () => {
+      // The branch neither browser verification could exercise — both seeded
+      // notifications carried an `action_url`. This is its pin.
+      expect(await clickNotification()).toBe('/apps/crm/sys_inbox_message?view=mine');
+    });
+
+    it('CONTROL: an explicit action_url is still followed verbatim', async () => {
+      // The fallback must not start rewriting targets the messaging pipeline
+      // already resolved (ADR-0030) — only the `||` arm is in scope here.
+      notificationsFixture = [
+        { id: 'n1', title: 'Weekly digest', actionUrl: '/apps/acme/invoice/42' },
+      ];
+      expect(await clickNotification()).toBe('/apps/acme/invoice/42');
+    });
+
+    it('falls back to the first active app on a cold landing at /home', async () => {
+      appsFixture = [app('crm'), app('hr')];
+      currentAppNameFixture = undefined;
+      const target = await clickNotification();
+      expect(target).toBe('/apps/crm/sys_inbox_message?view=mine');
+      expect(target).not.toContain('/apps/setup/');
+    });
+
+    it('does not resurrect a remembered app that is no longer active', async () => {
+      appsFixture = [app('hr')];
+      currentAppNameFixture = 'crm';
+      expect(await clickNotification()).toBe('/apps/hr/sys_inbox_message?view=mine');
+    });
+
+    it('CONTROL: a user whose last-open app IS setup still lands in setup', async () => {
+      // The tail of the fallback order is not "never setup" — it is "the app
+      // this user can actually open", and for an admin sitting in Setup that
+      // app is setup.
+      appsFixture = [app('setup'), app('crm')];
+      currentAppNameFixture = 'setup';
+      expect(await clickNotification()).toBe('/apps/setup/sys_inbox_message?view=mine');
+    });
+  });
+
+  describe('the activity drill', () => {
+    beforeEach(() => {
+      activitiesFixture = [
+        { id: 'a1', user: 'Ada', description: 'updated an account', objectName: 'account', timestamp: new Date().toISOString() },
+      ];
+    });
+
+    it('opens the activity list inside the app the user last had open', async () => {
+      expect(await clickViewAllActivity()).toBe('/apps/crm/sys_activity');
+    });
+
+    it('falls back to the first active app on a cold landing at /home', async () => {
+      appsFixture = [app('crm'), app('hr')];
+      currentAppNameFixture = undefined;
+      const target = await clickViewAllActivity();
+      expect(target).toBe('/apps/crm/sys_activity');
+      expect(target).not.toContain('/apps/setup/');
+    });
+
+    it('addresses the app by its package segment when it has one', async () => {
+      appsFixture = [app('crm', { _packageId: 'acme-crm' })];
+      currentAppNameFixture = 'acme-crm';
+      expect(await clickViewAllActivity()).toBe('/apps/acme-crm/sys_activity');
+    });
+  });
+
+  it('CONTROL: the admin-scoped marketplace link is NOT swept in and stays on setup', async () => {
+    // objectui#4074 excludes `/apps/setup/system/marketplace` (and the sibling
+    // `/apps/setup/system/apps`) by name: an admin-only surface where `setup` is
+    // the deliberate target, not an oversight. A fix that "helpfully" resolved
+    // it too would be out of scope.
+    isAdminFixture = true;
+    appsFixture = [app('setup'), app('crm')];
+    currentAppNameFixture = 'crm';
+
+    const target = await clickAndReadTarget(async (user) => {
+      await user.click(screen.getByTestId('browse-marketplace-btn'));
+    });
+    expect(target).toBe('/apps/setup/system/marketplace');
+  });
+});

--- a/packages/app-shell/src/layout/InboxPopover.tsx
+++ b/packages/app-shell/src/layout/InboxPopover.tsx
@@ -36,6 +36,8 @@ import { Bell, CheckSquare, Activity as ActivityIcon, ChevronRight } from 'lucid
 import { useObjectTranslation } from '@object-ui/i18n';
 import type { ActivityItem } from './ActivityFeed';
 import { useNavigationContext } from '../context/NavigationContext';
+import { useMetadata } from '../providers/MetadataProvider';
+import { resolveHostAppSegment } from '../utils/appRoute';
 import { timeAgo } from '../utils/relativeTime';
 import { groupNotifications } from './inboxGrouping';
 import type { InboxNotification, NotificationGroup } from './inboxGrouping';
@@ -72,6 +74,7 @@ export function InboxPopover({
   const navigate = useNavigate();
   const params = useParams();
   const { currentAppName } = useNavigationContext();
+  const { apps } = useMetadata();
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<'notifications' | 'approvals' | 'activity'>('notifications');
   // Sub-filter inside Notifications: default to Unread so users see what
@@ -120,13 +123,25 @@ export function InboxPopover({
     navigate(app ? `/apps/${app}/system/approvals` : '/apps/setup/system/approvals');
   };
 
+  /**
+   * Which app hosts the two full-page drills below (objectui#4074).
+   *
+   * `sys_inbox_message` is the canonical full-page inbox (ADR-0030 L5) and
+   * `sys_activity` the full activity stream; both are framework-owned objects,
+   * so they are app-INDEPENDENT — which is precisely why they render under
+   * whatever app the user can open, exactly like `system/approvals` above.
+   * These two used to hardcode `/apps/setup/...`, and being app-independent
+   * argued for neither half of that: it sent every business user without setup
+   * access to a page they cannot read, and switched everyone else out of the
+   * app they were in without saying so.
+   */
+  const hostAppSegment = resolveHostAppSegment(apps, currentAppName ?? params.appName);
+
   const goToAllNotifications = () => {
     setOpen(false);
-    // Route through the setup app's sys_inbox_message list view — the
-    // canonical full-page inbox (ADR-0030 L5), outside per-app sidebars. The
-    // `?view=mine` query selects the user-scoped "Notifications" view, matching
-    // the popover scope.
-    navigate('/apps/setup/sys_inbox_message?view=mine');
+    // `?view=mine` selects the user-scoped "Notifications" view, matching the
+    // popover's own scope.
+    navigate(`/apps/${hostAppSegment}/sys_inbox_message?view=mine`);
   };
 
   const goToAllActivity = () => {
@@ -134,7 +149,7 @@ export function InboxPopover({
     // Mirror of goToAllNotifications: drill from the popover Activity tab
     // (capped at 20 rows) into the full sys_activity list page. Org-wide
     // scope — no `?view=` qualifier — to match what the popover already shows.
-    navigate('/apps/setup/sys_activity');
+    navigate(`/apps/${hostAppSegment}/sys_activity`);
   };
 
   const handleNotificationClick = (n: InboxNotification) => {

--- a/packages/app-shell/src/layout/__tests__/InboxPopover.viewAllTarget.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/InboxPopover.viewAllTarget.test.tsx
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The bell popover's two "see all" drills — which APP hosts them (objectui#4074).
+ *
+ * ## The defect
+ *
+ * `goToAllNotifications` and `goToAllActivity` sat BETWEEN two handlers that
+ * already resolve the current app (`goToApprovals`, `handleNotificationClick`)
+ * and hardcoded `setup` anyway:
+ *
+ *   - `goToAllNotifications` → `/apps/setup/sys_inbox_message?view=mine`
+ *   - `goToAllActivity`      → `/apps/setup/sys_activity`
+ *
+ * The in-code comment argued the OBJECT is app-independent (ADR-0030 L5), which
+ * is true and does not entail rendering it in `setup`: `sys_inbox_message` and
+ * `sys_activity` resolve at `/apps/{any app}/{object}`, exactly like
+ * `system/approvals` — the sibling one line above, whose objectstack#7234 fix
+ * these cases mirror. Browser-measured on the card: a business user without
+ * `setup` gets "You don't have access", and every user is silently switched out
+ * of the app they were in (sidebar + app switcher flip to Setup).
+ *
+ * ## What these cases assert
+ *
+ * The RESOLVED TARGET — the argument `navigate()` receives — and nothing about
+ * the far end. objectstack#7344 (no shipped permission set grants
+ * `sys_inbox_message`) is a second, independent cause: the destination can still
+ * render the no-access empty state after this fix. Asserting the far end here
+ * would pin someone else's defect.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const navigateMock = vi.fn();
+
+// The two "which app am I in" signals the popover reads, in its own order
+// (`currentAppName ?? params.appName`). Both are fixtures here so the
+// resolution can be driven from either side.
+let currentAppNameFixture: string | undefined;
+let routeAppNameFixture: string | undefined;
+let appsFixture: any[] = [];
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ appName: routeAppNameFixture }),
+}));
+
+vi.mock('../../context/NavigationContext', () => ({
+  useNavigationContext: () => ({ currentAppName: currentAppNameFixture }),
+}));
+
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: appsFixture, loading: false }),
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    language: 'en',
+    t: (key: string, options?: Record<string, unknown>) =>
+      String(options?.defaultValue ?? key).replace(/\{\{(\w+)\}\}/g, (_m, name: string) =>
+        String(options?.[name] ?? ''),
+      ),
+  }),
+}));
+
+// Passthrough primitives so the popover body renders without driving Radix
+// open/close in jsdom (the pattern `InboxPopover.badgeBreakdown.test.tsx` uses).
+vi.mock('@object-ui/components', () => ({
+  Button: ({ children, ...p }: any) => <button type="button" {...p}>{children}</button>,
+  Popover: ({ children }: any) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: any) => <div>{children}</div>,
+  PopoverContent: ({ children }: any) => <div>{children}</div>,
+  Tabs: ({ children }: any) => <div>{children}</div>,
+  TabsList: ({ children }: any) => <div>{children}</div>,
+  TabsTrigger: ({ children }: any) => <button type="button">{children}</button>,
+  TabsContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock('lucide-react', () => ({
+  Bell: () => <span />,
+  CheckSquare: () => <span />,
+  Activity: () => <span />,
+  ChevronRight: () => <span />,
+}));
+
+import { InboxPopover, type InboxNotification } from '../InboxPopover';
+
+const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
+
+const notif = (over: Partial<InboxNotification> & { id: string }): InboxNotification => ({
+  type: 'project.digest',
+  title: 'Scheduled project digest',
+  is_read: false,
+  created_at: '2026-08-10T10:00:00Z',
+  ...over,
+});
+
+function renderPopover(props: Partial<React.ComponentProps<typeof InboxPopover>> = {}) {
+  return render(
+    <InboxPopover
+      notifications={props.notifications ?? []}
+      unreadCount={props.unreadCount ?? 0}
+      pendingApprovalsCount={props.pendingApprovalsCount ?? 0}
+      activities={props.activities ?? []}
+      onMarkAllRead={props.onMarkAllRead ?? vi.fn()}
+      onMarkRead={props.onMarkRead ?? vi.fn()}
+    />,
+  );
+}
+
+async function clickLabel(label: string, props: Partial<React.ComponentProps<typeof InboxPopover>> = {}) {
+  const user = userEvent.setup();
+  renderPopover(props);
+  await user.click(screen.getByText(label));
+  expect(navigateMock).toHaveBeenCalledTimes(1);
+  return navigateMock.mock.calls[0][0] as string;
+}
+
+const clickViewAllNotifications = () => clickLabel('View all notifications');
+const clickViewAllActivity = () => clickLabel('View all activity');
+
+describe('InboxPopover "see all" drills resolve the host app (objectui#4074)', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    appsFixture = [app('setup'), app('crm')];
+    currentAppNameFixture = 'crm';
+    routeAppNameFixture = 'crm';
+  });
+
+  describe('View all notifications', () => {
+    it('opens the inbox inside the app the user is in, not setup', async () => {
+      expect(await clickViewAllNotifications()).toBe('/apps/crm/sys_inbox_message?view=mine');
+    });
+
+    it('keeps the ?view=mine qualifier that scopes the list to this user', async () => {
+      // The popover shows the user's own notifications; dropping the qualifier
+      // would drill from a user-scoped list into an org-wide one.
+      expect(await clickViewAllNotifications()).toContain('?view=mine');
+    });
+
+    it('reads the route app segment when the shell has published no current app', async () => {
+      currentAppNameFixture = undefined;
+      routeAppNameFixture = 'crm';
+      expect(await clickViewAllNotifications()).toBe('/apps/crm/sys_inbox_message?view=mine');
+    });
+
+    it('addresses the app by its package segment when it has one', async () => {
+      appsFixture = [app('crm', { _packageId: 'acme-crm' })];
+      currentAppNameFixture = 'acme-crm';
+      routeAppNameFixture = 'acme-crm';
+      expect(await clickViewAllNotifications()).toBe('/apps/acme-crm/sys_inbox_message?view=mine');
+    });
+
+    it('does not resurrect a remembered app that is no longer active', async () => {
+      appsFixture = [app('hr')];
+      currentAppNameFixture = 'crm';
+      routeAppNameFixture = 'crm';
+      expect(await clickViewAllNotifications()).toBe('/apps/hr/sys_inbox_message?view=mine');
+    });
+
+    it('CONTROL: a user whose app IS setup still lands in setup', async () => {
+      appsFixture = [app('setup'), app('crm')];
+      currentAppNameFixture = 'setup';
+      routeAppNameFixture = 'setup';
+      expect(await clickViewAllNotifications()).toBe('/apps/setup/sys_inbox_message?view=mine');
+    });
+
+    it('keeps the user in the app named by the URL when the app list has not loaded', async () => {
+      // `useMetadata()` answers with an empty list both before the catalog
+      // arrives and outside a provider. That is "unknown", not "this user has
+      // no apps" — demoting a user who is demonstrably rendering inside
+      // `/apps/crm/...` to `setup` would reintroduce this very defect in a
+      // loading race.
+      appsFixture = [];
+      currentAppNameFixture = undefined;
+      routeAppNameFixture = 'crm';
+      expect(await clickViewAllNotifications()).toBe('/apps/crm/sys_inbox_message?view=mine');
+    });
+  });
+
+  describe('View all activity', () => {
+    it('opens the activity list inside the app the user is in, not setup', async () => {
+      expect(await clickViewAllActivity()).toBe('/apps/crm/sys_activity');
+    });
+
+    it('stays org-wide — no ?view= qualifier, matching what the tab shows', async () => {
+      expect(await clickViewAllActivity()).not.toContain('?view=');
+    });
+
+    it('falls back to the first active app when nothing names the current one', async () => {
+      appsFixture = [app('crm'), app('hr')];
+      currentAppNameFixture = undefined;
+      routeAppNameFixture = undefined;
+      const target = await clickViewAllActivity();
+      expect(target).toBe('/apps/crm/sys_activity');
+      expect(target).not.toContain('/apps/setup/');
+    });
+  });
+
+  describe('CONTROLS — the handlers on either side stay exactly as they were', () => {
+    it('goToApprovals still resolves the current app', async () => {
+      const target = await clickLabel('Open Approvals Inbox');
+      expect(target).toBe('/apps/crm/system/approvals');
+    });
+
+    it('handleNotificationClick still follows an explicit action_url', async () => {
+      const target = await clickLabel('Scheduled project digest', {
+        notifications: [notif({ id: 'n1', action_url: '/apps/acme/invoice/42' })],
+        unreadCount: 1,
+      });
+      expect(target).toBe('/apps/acme/invoice/42');
+    });
+
+    it('handleNotificationClick still prefixes a relative action_url with the current app', async () => {
+      const target = await clickLabel('Scheduled project digest', {
+        notifications: [notif({ id: 'n1', action_url: '/invoice/42' })],
+        unreadCount: 1,
+      });
+      expect(target).toBe('/apps/crm/invoice/42');
+    });
+  });
+});

--- a/packages/app-shell/src/utils/__tests__/appRoute.test.ts
+++ b/packages/app-shell/src/utils/__tests__/appRoute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath, appStudioObjectPath, appStudioRoutePath } from '../appRoute';
+import { appRouteSegment, matchAppBySegment, filterActiveApps, resolveHostAppSegment, appStudioDesignPath, appStudioSurfacePath, appStudioObjectPath, appStudioRoutePath } from '../appRoute';
 
 /**
  * ADR-0048 (option A) — package-id route segment.
@@ -36,6 +36,83 @@ describe('matchAppBySegment', () => {
   it('returns undefined for missing inputs', () => {
     expect(matchAppBySegment(apps, undefined)).toBeUndefined();
     expect(matchAppBySegment(null, 'com.acme.crm')).toBeUndefined();
+  });
+});
+
+/**
+ * objectstack#7231 / objectui#4074 — which app hosts an app-INDEPENDENT page
+ * (the Approvals Inbox, `sys_inbox_message`, `sys_activity`). The producers that
+ * consume this are pinned end-to-end in `HomePage.inboxLinksTarget.test.tsx` and
+ * `InboxPopover.viewAllTarget.test.tsx`; these cases pin the resolution itself.
+ */
+describe('filterActiveApps', () => {
+  it('keeps apps that declare neither flag (the common case)', () => {
+    expect(filterActiveApps([{ name: 'crm' }])).toEqual([{ name: 'crm' }]);
+  });
+  it('drops deactivated and hidden apps', () => {
+    const apps = [
+      { name: 'crm' },
+      { name: 'old', active: false },
+      { name: 'account', hidden: true },
+    ];
+    expect(filterActiveApps(apps).map((a) => a.name)).toEqual(['crm']);
+  });
+  it('is idempotent, so a caller that already filtered can pass its list through', () => {
+    const apps = [{ name: 'crm' }, { name: 'old', active: false }];
+    expect(filterActiveApps(filterActiveApps(apps))).toEqual(filterActiveApps(apps));
+  });
+  it('returns an empty list for nullish input', () => {
+    expect(filterActiveApps(null)).toEqual([]);
+    expect(filterActiveApps(undefined)).toEqual([]);
+  });
+});
+
+describe('resolveHostAppSegment', () => {
+  const setup = { name: 'setup' };
+  const crm = { name: 'crm', _packageId: 'com.acme.crm' };
+  const hr = { name: 'hr' };
+
+  it('1. prefers the app the user is in / last had open', () => {
+    expect(resolveHostAppSegment([setup, crm], 'com.acme.crm')).toBe('com.acme.crm');
+  });
+
+  it('1. addresses that app by its package segment, whichever spelling was remembered', () => {
+    // `matchAppBySegment` accepts the name as a legacy alias; the segment we
+    // emit is always the canonical one, so the link cannot disagree with the
+    // app tiles about how the same app is spelled.
+    expect(resolveHostAppSegment([crm], 'crm')).toBe('com.acme.crm');
+  });
+
+  it('1. re-checks the preferred name against the LIVE list and does not resurrect a dead app', () => {
+    // `currentAppName` is plain React state — it outlives the app it names.
+    expect(resolveHostAppSegment([hr], 'crm')).toBe('hr');
+    expect(resolveHostAppSegment([hr, { name: 'crm', active: false }], 'crm')).toBe('hr');
+    expect(resolveHostAppSegment([hr, { name: 'crm', hidden: true }], 'crm')).toBe('hr');
+  });
+
+  it('2. falls back to the first ACTIVE app when nothing names the current one', () => {
+    expect(resolveHostAppSegment([{ name: 'old', active: false }, hr], undefined)).toBe('hr');
+  });
+
+  it('3. keeps an unchecked preferred segment when the list names no app at all', () => {
+    // An empty list is "not loaded yet" as often as "no apps" — a caller
+    // rendering inside `/apps/crm/…` must not be demoted to `setup`.
+    expect(resolveHostAppSegment([], 'crm')).toBe('crm');
+    expect(resolveHostAppSegment(undefined, 'crm')).toBe('crm');
+  });
+
+  it('4. falls back to setup only when nothing addressable is left', () => {
+    expect(resolveHostAppSegment([], undefined)).toBe('setup');
+    expect(resolveHostAppSegment(null, null)).toBe('setup');
+    // A degenerate app carrying neither `_packageId` nor `name`: present, so
+    // step 3 does not apply, but nothing to build a URL from either.
+    expect(resolveHostAppSegment([{ label: 'nameless' }], 'crm')).toBe('setup');
+  });
+
+  it('CONTROL: a user whose current app IS setup resolves to setup', () => {
+    // The fallback order's tail is not "never setup" — it is "an app this user
+    // can actually open", and for an admin sitting in Setup that is `setup`.
+    expect(resolveHostAppSegment([setup, crm], 'setup')).toBe('setup');
   });
 });
 

--- a/packages/app-shell/src/utils/appRoute.ts
+++ b/packages/app-shell/src/utils/appRoute.ts
@@ -11,6 +11,8 @@
  *   fallback doubles as a per-tenant friendly alias and keeps legacy
  *   name-based URLs/bookmarks working. Callers keep their own
  *   default/first-app fallback around this match.
+ * - `resolveHostAppSegment(apps, preferred)` — which app should HOST a
+ *   framework-owned, app-independent page for this user (see below).
  */
 
 type AppLike = { name?: unknown; _packageId?: unknown } & Record<string, unknown>;
@@ -27,6 +29,76 @@ export function matchAppBySegment<T extends AppLike>(
 ): T | undefined {
   if (!apps || seg == null) return undefined;
   return apps.find((a) => a?._packageId === seg) ?? apps.find((a) => a?.name === seg);
+}
+
+/**
+ * The console's own administration app. Only ever a LAST RESORT for the
+ * resolution below — historically it was hardcoded as the FIRST choice, which
+ * is the defect objectstack#7231 / objectui#4074 removed.
+ */
+const SETUP_APP_SEGMENT = 'setup';
+
+/**
+ * The apps a user can actually open, in metadata order. `active === false`
+ * deactivates an app; `hidden === true` keeps it out of the launcher (personal
+ * settings and similar chrome). Neither is a place to send someone.
+ *
+ * One definition, because "an app the user can open" has to mean the same thing
+ * to Home's launcher and to every producer that builds a link into an app.
+ */
+export function filterActiveApps<T extends AppLike>(apps: readonly T[] | null | undefined): T[] {
+  if (!apps) return [];
+  return apps.filter((a) => a?.active !== false && a?.hidden !== true);
+}
+
+/**
+ * Which app should host a framework-owned, **app-independent** page for this
+ * user — the Approvals Inbox (objectstack#7231), the full inbox
+ * (`sys_inbox_message`) and the activity list (`sys_activity`) (objectui#4074).
+ *
+ * Those pages are mounted for every app (`system/approvals` sits in the host's
+ * route fragment as BOTH `extraRoutes` and `extraRoutesNoApp`; `sys_*` objects
+ * are framework-owned and resolve at `/apps/{any app}/{object}`), so the app
+ * segment in their URL is a statement about WHERE THE USER IS, never about
+ * where the page lives. Hardcoding `setup` there was a dead end for every
+ * business user without access to the setup app, and an unannounced app switch
+ * for everyone else — both measured in a browser on objectui#4074.
+ *
+ * Resolution order, each step falling through only when the previous one cannot
+ * name an app the user can actually open:
+ *   1. `preferred` — the app they are in, or last had open — RE-CHECKED against
+ *      the live active list, so an app that was deactivated or hidden since is
+ *      not resurrected as a link;
+ *   2. their first active app — arbitrary but reachable, and on a business
+ *      user's workspace that is a business app rather than `setup`;
+ *   3. `preferred` unchecked, but ONLY when the list names no app at all. An
+ *      empty list means "not loaded yet" (the pre-catalog render, or a consumer
+ *      outside `MetadataProvider`) at least as often as it means "this user has
+ *      no apps", and demoting a user who is demonstrably rendering inside
+ *      `/apps/{preferred}/…` to `setup` would reintroduce the very defect this
+ *      resolves. A caller with a genuinely empty workspace has no reachable app
+ *      to offer anyway;
+ *   4. `setup`. What is left is the degenerate app carrying neither
+ *      `_packageId` nor `name` — nothing addressable to build a URL from — so
+ *      the historical target is the least-surprising last resort rather than a
+ *      broken link.
+ *
+ * Note step 1 takes ONE `preferred` hint: callers inside the `/apps/:appName/*`
+ * router pass `currentAppName ?? params.appName` (the shell's published app,
+ * then the URL's own segment); Home renders outside that router and has only
+ * `currentAppName`, which is stale by construction — hence the re-check.
+ */
+export function resolveHostAppSegment(
+  apps: readonly AppLike[] | null | undefined,
+  preferred: string | null | undefined,
+): string {
+  const active = filterActiveApps(apps);
+  const stillActive = appRouteSegment(matchAppBySegment(active, preferred));
+  if (stillActive) return stillActive;
+  const firstActive = appRouteSegment(active[0]);
+  if (firstActive) return firstActive;
+  if (active.length === 0 && preferred) return preferred;
+  return SETUP_APP_SEGMENT;
 }
 
 /**

--- a/packages/app-shell/src/utils/index.ts
+++ b/packages/app-shell/src/utils/index.ts
@@ -32,7 +32,15 @@ export { deriveRelatedLists } from './deriveRelatedLists';
 export type { DerivedRelatedList } from './deriveRelatedLists';
 
 export { preferLocal } from './preferLocal';
-export { appRouteSegment, matchAppBySegment, appStudioDesignPath, appStudioSurfacePath, appStudioRoutePath } from './appRoute';
+export {
+  appRouteSegment,
+  matchAppBySegment,
+  filterActiveApps,
+  resolveHostAppSegment,
+  appStudioDesignPath,
+  appStudioSurfacePath,
+  appStudioRoutePath,
+} from './appRoute';
 
 /**
  * Resolves objectui's KEYED i18n label to a plain string.


### PR DESCRIPTION
Fixes #4074

Four navigation producers hardcoded `/apps/setup/...` for two pages that are not bound to the setup app. `sys_inbox_message` and `sys_activity` are framework-owned objects reachable at `/apps/{any app}/{object}`, exactly like `system/approvals` — whose entry in the *same* popover, one line above, was already resolving the current app (objectstack#7234). The in-code comment defending the hardcoded target argued the OBJECT is app-independent, which is true, and which is precisely why it renders under whatever app the user can open rather than under `setup`.

Both browser verifications on the card measured the cost, and it is two defects, not one:

- a business user whose app list does not contain `setup` gets the target rendered inside their own app's shell with a **"You don't have access"** empty state (softer, and more confusing, than a hard app guard);
- **every** user, admins included, is switched out of the app they were in — URL, sidebar and header app switcher all flip to Setup, with no announcement and no way back except the app switcher.

## The change

One shared helper, `resolveHostAppSegment` in `packages/app-shell/src/utils/appRoute.ts`, generalizing the resolution objectstack#7231 landed inline in `HomePage` for the approvals entry. Home and the bell popover both call it, so the two surfaces cannot drift into different answers to the same question. Resolution order:

1. the app the user is in / last had open, **re-checked against the live active-app list** (a deactivated or hidden app is not resurrected as a link);
2. their first active app;
3. the caller's own hint, unchecked — but only when the list names no app at all, i.e. it has not loaded yet. An empty list is "unknown" at least as often as "this user has no apps", and demoting a user who is demonstrably rendering inside `/apps/crm/...` to `setup` would reintroduce this very defect in a loading race;
4. `setup` last — what is left is a degenerate app carrying neither `_packageId` nor `name`, so the historical target beats a broken link.

The four anchors now resolve through it:

| Producer | Before | After |
|---|---|---|
| `HomePage` `onOpenNotification` fallback (no `action_url`) | `/apps/setup/sys_inbox_message?view=mine` | `/apps/{host}/sys_inbox_message?view=mine` |
| `HomePage` `HomeActivity onViewAll` | `/apps/setup/sys_activity` | `/apps/{host}/sys_activity` |
| `InboxPopover` `goToAllNotifications` | `/apps/setup/sys_inbox_message?view=mine` | `/apps/{host}/sys_inbox_message?view=mine` |
| `InboxPopover` `goToAllActivity` | `/apps/setup/sys_activity` | `/apps/{host}/sys_activity` |

`HomePage`'s inline `activeApps` predicate moved into the same module as `filterActiveApps`, so "an app the user can open" means one thing to Home's launcher and to every producer building a link into an app.

### Deliberately unchanged, and pinned as such

- `/apps/setup/system/marketplace` and `/apps/setup/system/apps` — admin-scoped surfaces where `setup` is the target rather than an oversight (the card's own scope guard). A case asserts the marketplace link still emits `/apps/setup/system/marketplace`.
- `goToApprovals` and `handleNotificationClick` in the popover — untouched; cases assert they still resolve the current app and still follow an explicit `action_url`.
- A user whose current/last-open app IS `setup` still lands in `setup`. The fallback order's tail is not "never setup", it is "an app this user can actually open".

## Verification

Red-first, then reverse-verified. With the four sites reverted on top of the finished branch (helper left in place), **13 of 63** cases went red — every case asserting a resolved target — while all 12 helper unit cases and every CONTROL stayed green, which is the intended split: the helper is right in isolation, the four anchors are the wiring. Restored: 63 passed.

```
# red-first, before the fix
Tests  6 failed | 3 passed (9)     HomePage.inboxLinksTarget.test.tsx
Tests  7 failed | 6 passed (13)    InboxPopover.viewAllTarget.test.tsx
   AssertionError: expected '/apps/setup/sys_activity' to be '/apps/crm/sys_activity'

# after
pnpm exec vitest run packages/app-shell/
   Test Files  337 passed (337)
   Tests  3205 passed | 1 skipped (3206)

pnpm --filter @object-ui/app-shell type-check   -> clean
pnpm --filter @object-ui/app-shell lint         -> 0 errors (2273 pre-existing warnings)
node scripts/check-control-bytes.mjs            -> OK
node scripts/check-changeset-presence.mjs       -> 1 changeset declared
```

No copy changed — the four edits are navigation targets and comments only — so there is no i18n work in this PR. Changeset: `@object-ui/app-shell` patch.

## What this fix does NOT close — do not misread the empty state

objectstack#7344 is a **second, independent** cause: no shipped permission set grants `sys_inbox_message` (`member_default`, the additive `everyone` baseline, does not name it). Re-pointing these four anchors at an app the user *can* open therefore leaves them on the same "You don't have access" state until that grant question is settled — verified on the card against the **Account** app's own Notifications entry, which reaches `sys_inbox_message` with no `setup` involved anywhere and renders the identical empty state.

The routing fix is necessary, not sufficient. Accordingly every case here asserts the **resolved target** — the argument `navigate()` receives — and none asserts what renders at the far end; pinning the far end would pin someone else's defect.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_