### PR TITLE
fix(detail): inline edit no longer destroys array values or flattens types on the record page

### DIFF
--- a/.changeset/inline-edit-delegate-4220.md
+++ b/.changeset/inline-edit-delegate-4220.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/plugin-detail': patch
+'@object-ui/fields': patch
+---
+
+fix(detail): inline edit no longer destroys array values or flattens types on the record page
+
+`InlineFieldInput`'s type switch ended in a raw text input, and every type it had
+no branch for landed there: the value was displayed through `coerceToSafeValue`
+and written back as whatever the user typed — a bare string.
+
+Two damage classes survived the earlier passes. Array-valued fields (`tags`,
+`checkboxes`, an options-less multi picklist) were offered for editing as
+`"a, b"` — `coerceToSafeValue` joins arrays — and saved back as that string, so
+the array was gone. Type-lossy scalars (`toggle`, `slider`, `progress`,
+`rating`, `radio`) round-tripped through `String()`, so a boolean column
+received `"true"`, a numeric one `"42"`, and `radio` accepted any free-typed
+value its option list never offered.
+
+Types the switch already routes keep their editors. Everything else that the
+fields package can edit inline now falls back to `FieldEditWidget` — the same
+control the form renders, `json` → the code editor included — and only genuinely
+string-valued types (`text`, `textarea`, `email`, `phone`, `url`) keep the plain
+input. A drift guard asserts every field type is exactly one of routed /
+excluded / delegated / benign, so a new type can no longer inherit the
+value-destroying default in silence.
+
+`@object-ui/fields`: the four fixed-option widgets no longer clear the stored
+value when the field declares no `options` at all. An empty offered set had two
+opposite causes — a list that cascaded to zero (clear) and a list that was never
+authored (nothing to decide) — and the second deleted the value on mount, which
+the grid's inline cell editor has always been able to trigger. `FieldEditWidget`
+also forwards `autoFocus` to the widget it renders.

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -174,12 +174,19 @@ const COMPACT_EDIT_TYPES = new Set<string>(['lookup', 'master_detail', 'user', '
  * form uses — as a controlled `{ value, onChange, field }` input. Returns
  * `null` for types without a registered widget so the caller can fall back to
  * a plain editor.
+ *
+ * `autoFocus` is forwarded because an inline-edit host enters edit mode ON a
+ * field and expects the caret to land there (objectui#4220 — the detail page's
+ * delegation): each widget's own `toDomProps` whitelist already carries it onto
+ * the real focusable control, so nothing here needs to know which element that
+ * is. A host that passes nothing is unaffected.
  */
 export function FieldEditWidget({
   field,
   value,
   onChange,
   readonly,
+  autoFocus,
 }: FieldWidgetComponentProps<any>): React.ReactElement | null {
   const resolved = field?.type ? resolveInlineEditType(field.type) : undefined;
   const Widget = resolved ? EDIT_WIDGETS[resolved] : undefined;
@@ -187,5 +194,14 @@ export function FieldEditWidget({
   // `compact` is a declared widget prop (objectui#3221 closed this type), so
   // the spread no longer needs an `any` escape hatch to get past it.
   const compactProps = resolved && COMPACT_EDIT_TYPES.has(resolved) ? { compact: true } : {};
-  return <Widget field={field} value={value} onChange={onChange} readonly={readonly} {...compactProps} />;
+  return (
+    <Widget
+      field={field}
+      value={value}
+      onChange={onChange}
+      readonly={readonly}
+      autoFocus={autoFocus}
+      {...compactProps}
+    />
+  );
 }

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -52,6 +52,9 @@ export function CheckboxesField({
   // per-element clear the multi-value case needs (cf. the scalar select/radio).
   useEffect(() => {
     if (readonly) return;
+    // Never configured → nothing to prune against; see `MultiSelectField`'s
+    // copy of this guard for the measured failure (objectui#4220).
+    if (rawOptions.length === 0) return;
     if (selected.length === 0) return;
     const stillOffered = selected.filter((v) => options.some((o) => o.value === v));
     if (stillOffered.length !== selected.length) onChange(stillOffered);

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -53,6 +53,16 @@ export function MultiSelectField({
   // the scalar case we prune per-element rather than clearing the whole field.
   useEffect(() => {
     if (readonly) return;
+    // Nothing was ever CONFIGURED to prune against (objectui#4220). An empty
+    // offered set has two very different causes: a list that cascaded down to
+    // zero (a real decision — clear), and a field authored with no `options` at
+    // all (no decision — the widget renders its "unfillable" state below). In
+    // the second case pruning is not a cascade, it is deleting the stored value
+    // of a field the user was only ever shown a hint for — measured on the
+    // detail page's inline editor, which stages that empty array into the
+    // record draft the moment the row enters edit mode, and on the grid's
+    // inline cell editor, which has always taken this path.
+    if (rawOptions.length === 0) return;
     if (selected.length === 0) return;
     const stillOffered = selected.filter((v) => options.some((o) => o.value === v));
     if (stillOffered.length !== selected.length) onChange(stillOffered);

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -50,6 +50,9 @@ export function RadioField({
   // (parent changed / predicate flipped), drop it so no stale pair persists.
   useEffect(() => {
     if (readonly) return;
+    // Never configured → nothing to prune against; see `MultiSelectField`'s
+    // copy of this guard for the measured failure (objectui#4220).
+    if (rawOptions.length === 0) return;
     if (value === undefined || value === null || (value as unknown) === '') return;
     if (!isValueStillOffered(value, options)) onChange?.(undefined as unknown as string);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -106,6 +106,12 @@ function SingleSelectField({
   // (parent changed / predicate flipped), drop it so no stale pair persists.
   useEffect(() => {
     if (readonly) return;
+    // Never configured → nothing to prune against; see `MultiSelectField`'s
+    // copy of this guard for the measured failure (objectui#4220). Kept
+    // identical across the four option widgets: an authored list is what the
+    // cascade prunes, and all four render the same `OptionsEmptyState` when
+    // there is none.
+    if (rawOptions.length === 0) return;
     if (value === undefined || value === null || (value as unknown) === '') return;
     if (!isValueStillOffered(value, options)) onChange?.(undefined as unknown as string);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/fields/src/widgets/optionWidgets.unconfiguredOptions.test.tsx
+++ b/packages/fields/src/widgets/optionWidgets.unconfiguredOptions.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * An option widget with NO authored `options` keeps the value it was given
+ * (objectui#4220).
+ *
+ * The four fixed-option widgets each end their cascade resolution with a
+ * "clear what is no longer offered" effect (ADR-0058 / #2715). It ran against
+ * the RESOLVED set without asking why that set was empty, and the two causes
+ * are opposites:
+ *
+ *  - the list cascaded down to zero — a real decision, and clearing is the
+ *    documented behaviour;
+ *  - the field declares no `options` at all — no decision was made anywhere,
+ *    and the widget's own next branch renders `OptionsEmptyState`, i.e. it
+ *    tells the user there is nothing to pick. Clearing here deletes the stored
+ *    value of a field the user was shown nothing but a hint for, on MOUNT,
+ *    without a single interaction.
+ *
+ * Measured on two live hosts, both of which mount these widgets outside a form:
+ * the grid's inline cell editor (`FieldEditWidget`, since #2942) and — since
+ * #4220 — the detail page's inline editor, which stages every `onChange` into
+ * the record draft the moment a section enters edit mode. An options-less
+ * `checkboxes` there wiped its array as soon as the user started editing any
+ * OTHER field in the same section, and the save bar wrote the empty array back.
+ *
+ * The prune now requires an authored list to prune against. The cascade itself
+ * is untouched — the controls below still clear a value the configured list no
+ * longer offers.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SelectField } from './SelectField';
+import { MultiSelectField } from './MultiSelectField';
+import { CheckboxesField } from './CheckboxesField';
+import { RadioField } from './RadioField';
+
+const OPTIONS = [{ label: 'Alpha', value: 'alpha' }];
+
+describe('option widgets — an unconfigured list never deletes the stored value (#4220)', () => {
+  it('MultiSelectField keeps its array and shows the unfillable state', () => {
+    const onChange = vi.fn();
+    render(
+      <MultiSelectField
+        value={['alpha', 'beta']}
+        onChange={onChange}
+        field={{ name: 'topics', type: 'multiselect' } as any}
+      />,
+    );
+    expect(screen.getByTestId('multiselect-empty-topics')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('CheckboxesField keeps its array and shows the unfillable state', () => {
+    const onChange = vi.fn();
+    render(
+      <CheckboxesField
+        value={['alpha', 'beta']}
+        onChange={onChange}
+        field={{ name: 'perks', type: 'checkboxes' } as any}
+      />,
+    );
+    expect(screen.getByTestId('checkboxes-empty-perks')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('RadioField keeps its value and shows the unfillable state', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioField
+        value="alpha"
+        onChange={onChange}
+        field={{ name: 'tier', type: 'radio' } as any}
+      />,
+    );
+    expect(screen.getByTestId('radio-empty-tier')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('SelectField keeps its value and shows the unfillable state', () => {
+    const onChange = vi.fn();
+    render(
+      <SelectField
+        value="alpha"
+        onChange={onChange}
+        field={{ name: 'stage', type: 'select' } as any}
+      />,
+    );
+    expect(screen.getByTestId('select-empty-stage')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('controls — a CONFIGURED list still cascade-clears what it no longer offers', () => {
+  it('MultiSelectField drops the unoffered element, keeps the offered one', () => {
+    const onChange = vi.fn();
+    render(
+      <MultiSelectField
+        value={['alpha', 'zeta']}
+        onChange={onChange}
+        field={{ name: 'topics', type: 'multiselect', options: OPTIONS } as any}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith(['alpha']);
+  });
+
+  it('CheckboxesField drops the unoffered element, keeps the offered one', () => {
+    const onChange = vi.fn();
+    render(
+      <CheckboxesField
+        value={['alpha', 'zeta']}
+        onChange={onChange}
+        field={{ name: 'perks', type: 'checkboxes', options: OPTIONS } as any}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith(['alpha']);
+  });
+
+  it('RadioField clears a value the configured list does not offer', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioField
+        value="zeta"
+        onChange={onChange}
+        field={{ name: 'tier', type: 'radio', options: OPTIONS } as any}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('SelectField clears a value the configured list does not offer', () => {
+    const onChange = vi.fn();
+    render(
+      <SelectField
+        value="zeta"
+        onChange={onChange}
+        field={{ name: 'stage', type: 'select', options: OPTIONS } as any}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/plugin-detail/src/InlineFieldInput.tsx
+++ b/packages/plugin-detail/src/InlineFieldInput.tsx
@@ -22,6 +22,10 @@ import {
   AddressField,
   LocationField,
   GeolocationField,
+  FieldEditWidget,
+  hasFieldEditWidget,
+  mapFieldTypeToFormType,
+  FORM_FIELD_TYPES,
   coerceToSafeValue,
 } from '@object-ui/fields';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
@@ -38,6 +42,110 @@ import { TEXTUAL_REF_FALLBACK_TYPES } from './fieldEnrichment';
  * the package's public name unchanged.
  */
 export { TEXTUAL_REF_FALLBACK_TYPES };
+
+/**
+ * Test id on the terminal raw text input at the end of this component.
+ *
+ * The one editor in here that is lossy by construction — it displays through
+ * `coerceToSafeValue` and emits a STRING — so "did this type reach the terminal
+ * input?" is the question the drift guard has to answer EXACTLY, in both
+ * directions. Sniffing `input[type="text"]` cannot: `TextField`, `ColorField`
+ * and `QRCodeField` render one too, so the heuristic reads a benign type's
+ * correct fallback and a delegated type's correct widget as the same thing.
+ */
+export const INLINE_PLAIN_TEXT_INPUT_TESTID = 'inline-plain-text-input';
+
+/**
+ * **Class D** — field types whose stored value is ALREADY a string, so the
+ * terminal input's stringification is the identity and nothing is lost
+ * (objectui#4220). These, and only these, keep that input.
+ *
+ * Enumerated rather than expressed as "everything the switch didn't match":
+ * an open tail is what let `tags`, `checkboxes`, `toggle`, `slider`, `radio`
+ * and friends land on a value-destroying editor in silence for six cards
+ * running. A new field type is now a RED drift guard until someone decides
+ * which of the four buckets it belongs in — see
+ * `__tests__/inlineEditTypeCoverage.test.tsx`.
+ *
+ * `select` is deliberately absent: it has a routed branch (the picklist), and
+ * only its degenerate options-less SINGLE-value form reaches the terminal
+ * input — see {@link usesInlinePlainTextInput}. `markdown` / `html` /
+ * `richtext` are absent because the hosts never open an editor for them at all
+ * (they are in the fields package's shared exclusion, consulted since #4228).
+ */
+export const INLINE_PLAIN_TEXT_FIELD_TYPES = new Set<string>([
+  'text',
+  'textarea',
+  'email',
+  'phone',
+  'url',
+]);
+
+/**
+ * The type switch's own manifest: every type this component routes to a
+ * dedicated editor before the delegation below is reached.
+ *
+ * Declared next to the switch so the four-way classification is readable in
+ * ONE place, and pinned by rendering — the drift guard asserts each member
+ * really produces something other than the terminal input, so an entry that
+ * outlives its branch fails rather than quietly re-opening the plain-text path
+ * (the discipline #4228 established for `DETAIL_ROUTED_INLINE_TYPES`).
+ *
+ * `select` / `multiselect` are routed only WITH options; the options-less
+ * spellings are covered by {@link usesInlinePlainTextInput} (single, a bare
+ * string) and by the delegation (multi-value, an array). Both are pinned by
+ * name in the guard.
+ */
+export const INLINE_ROUTED_FIELD_TYPES = new Set<string>([
+  // Picklists (with options), booleans, numerics
+  'select', 'multiselect', 'boolean', 'number', 'currency', 'percent',
+  // Native date input
+  'date', 'datetime',
+  // Structured composites (#4216 / #4222)
+  'address', 'location', 'geolocation',
+  // Relational pickers
+  'lookup', 'master_detail', 'tree', 'user', 'owner',
+  // Binary / attachment — the detail page's exemption from the shared
+  // exclusion (#4228): a row can host an upload widget, a grid cell cannot.
+  'image', 'avatar', 'signature', 'file', 'video', 'audio',
+]);
+
+/**
+ * Is this a field type the form actually knows, rather than an unrecognized
+ * string?
+ *
+ * `mapFieldTypeToFormType` FALLS BACK to `field:text` for anything it has no
+ * entry for, which makes `hasFieldEditWidget()` answer `true` for every string
+ * on earth. Delegating on that answer alone would quietly hand a typo'd or
+ * private type (`decimal`, `integer` — deliberately not aliased, see the
+ * numeric branch) to `TextField` instead of leaving it on the documented
+ * fallback, and would let the drift guard's "delegated" bucket swallow a NEW
+ * spec type that nobody has decided about. Both are the recurrence this card
+ * exists to stop, so the alias fallback is not treated as a decision.
+ */
+export function isKnownFieldType(type: string | undefined): boolean {
+  if (!type) return false;
+  // `text` is the fallback's own target, and also a direct widget key — so the
+  // first clause already covers it and no real type is missed here.
+  return FORM_FIELD_TYPES.includes(type) || mapFieldTypeToFormType(type) !== 'field:text';
+}
+
+/**
+ * Does this field edit in the terminal raw text input (class D)?
+ *
+ * The options-less SINGLE `select` is the one conditional member. Its stored
+ * value is a bare string, so the text input is lossless — while the fields
+ * package's own widget would render its "no options to offer" state, leaving
+ * the user unable to enter anything at all. The `multiple` spelling of the same
+ * degenerate field is NOT benign: its value is an array, so it delegates and
+ * keeps that array (class A).
+ */
+export function usesInlinePlainTextInput(field: Record<string, any>): boolean {
+  const type = field?.type as string | undefined;
+  if (!type) return true;
+  if (INLINE_PLAIN_TEXT_FIELD_TYPES.has(type)) return true;
+  return type === 'select' && !field.multiple;
+}
 
 /**
  * Extract the id a reference widget expects from a value that may already be
@@ -240,6 +348,44 @@ export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
     return <GeolocationField field={field as any} value={value} onChange={(v: any) => onChange(v)} autoFocus={autoFocus} />;
   }
   const isDate = editType === 'date' || editType === 'datetime';
+  // Everything the switch did not route, and that is not class D, edits with
+  // the SAME widget the form uses (objectui#4220). One fallback branch, not a
+  // per-type copy of the routing above: the tail this closes is the part of the
+  // #4216 sweep where the terminal input is not merely the wrong control but a
+  // value-destroying one —
+  //
+  //   class A (`tags`, `checkboxes`, an options-less multi picklist) stores a
+  //   `string[]`, and `coerceToSafeValue`'s array case is `.join(', ')`, so the
+  //   box offered `"a, b"` for editing and saved that string over the array;
+  //   class C (`toggle`, `slider`, `progress`, `rating`, `radio`) stores a
+  //   boolean / number / one-of-`options`, all of which came back as strings.
+  //
+  // Plus every type the fields package edits inline that this switch simply had
+  // no branch for (`json` → the code editor, `color`, `qrcode`, `time`, `code`).
+  //
+  // The design calls INSIDE class A — what an options-less `checkboxes` offers,
+  // how a chip row renders — are `FieldEditWidget`'s to make, and it already
+  // makes them for the grid's inline cell editor; asking it here is the point of
+  // delegating rather than routing type by type. `date`/`datetime` are excluded
+  // because they ARE routed (the native date input below) and a working path
+  // does not get churned. Types the hosts gate out entirely (containers,
+  // credentials, computed — #4228 / #3355) never arrive here at all, and none of
+  // them has a widget anyway, so this branch cannot re-open those.
+  //
+  // `autoFocus` follows the numeric/composite branches' convention: it is
+  // forwarded, and `FieldEditWidget` hands it to the widget, whose own
+  // `toDomProps` whitelist lands it on the real focusable control. No
+  // `dataSource` is needed — every record-querying type is routed above.
+  if (!isDate && !usesInlinePlainTextInput(field) && isKnownFieldType(editType) && hasFieldEditWidget(editType)) {
+    return (
+      <FieldEditWidget
+        field={field as any}
+        value={value}
+        onChange={(v: any) => onChange(v)}
+        autoFocus={autoFocus}
+      />
+    );
+  }
   const inputType = isDate ? 'date' : 'text';
   // <input type="date"> needs a YYYY-MM-DD string; raw ISO timestamps
   // ("2026-02-14T14:46:20.862Z") leave the picker blank. Slice down to the date
@@ -261,6 +407,10 @@ export const InlineFieldInput: React.FC<InlineFieldInputProps> = ({
   return (
     <input
       type={inputType}
+      // Marks the RAW TEXT fallback only. The `date`/`datetime` branch shares
+      // this element but is a routed editor (a native date picker with ISO
+      // coercion on both sides), not the lossy fallback the guard hunts for.
+      data-testid={isDate ? undefined : INLINE_PLAIN_TEXT_INPUT_TESTID}
       autoFocus={autoFocus}
       className="w-full px-2 py-1.5 text-sm border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
       value={inputValue}

--- a/packages/plugin-detail/src/__tests__/InlineFieldInput.delegation.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineFieldInput.delegation.test.tsx
@@ -1,0 +1,497 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Inline edit delegates the destructive/type-lossy tail to `FieldEditWidget`
+ * (objectui#4220 — the remainder of the #4216 fall-through sweep).
+ *
+ * `InlineFieldInput` ends in a raw text input. Anything its type switch does
+ * not match landed there, was DISPLAYED through `coerceToSafeValue` and was
+ * WRITTEN back as whatever the user typed — a bare string. Two damage classes
+ * survived #4216 (structured objects) and #4228 (containers + credentials,
+ * closed at the host gate):
+ *
+ *  - **class A, array-valued** — `tags` / `checkboxes` / an options-less multi
+ *    picklist store a `string[]`. `coerceToSafeValue`'s array case is
+ *    `.join(', ')`, so `['alpha','beta']` was offered for editing as the single
+ *    string `"alpha, beta"` and saved back as that string: the array is gone,
+ *    and with it every consumer that indexes it.
+ *  - **class C, type-lossy scalars** — `toggle` (boolean), `slider` /
+ *    `progress` / `rating` (number), `radio` (one of `options`). The value
+ *    round-trips through `String()` and comes back a string, so a boolean
+ *    column receives `"true"`, a numeric one `"42"`, and `radio` accepts any
+ *    free-typed value its option list does not offer.
+ *
+ * Both halves are asserted for every type, because either alone is a test that
+ * cannot see the real damage: the DISPLAY half misses the write, and a write
+ * assertion that only checks "something was emitted" misses the type.
+ *
+ * The fix is one fallback branch, not per-type routing: a type the switch has
+ * no branch for and that is not explicitly benign renders the SAME widget the
+ * form uses, via `FieldEditWidget`. The design calls inside class A (what an
+ * options-less `checkboxes` shows) resolve inside that delegation — the fields
+ * package already owns them.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InlineFieldInput, INLINE_PLAIN_TEXT_INPUT_TESTID } from '../InlineFieldInput';
+import { isInlineExcludedDetailFieldType } from '../fieldEnrichment';
+
+/** The terminal raw text input at the end of `InlineFieldInput`. */
+const plainInput = (): HTMLElement | null =>
+  screen.queryByTestId(INLINE_PLAIN_TEXT_INPUT_TESTID);
+
+/**
+ * Type into whatever the FIRST editable box of the rendered editor happens to
+ * be, and hand back what `onChange` emitted — the query-independent probe the
+ * #4216 suite introduced. Addressing a sub-control by name would fail on
+ * "unable to find an element" BEFORE the fix, which names the missing control
+ * rather than the destroyed value; addressing the first box reaches the
+ * terminal input before and the widget's own input after, so the assertion is
+ * always about the emitted value SHAPE.
+ */
+function typeIntoFirstBox(container: HTMLElement, text: string): unknown[] {
+  const onChangeCalls: unknown[] = [];
+  const input = container.querySelector('input, textarea');
+  if (input) {
+    fireEvent.change(input as HTMLInputElement, { target: { value: text } });
+  }
+  return onChangeCalls;
+}
+
+const OPTIONS = [
+  { label: 'Alpha', value: 'alpha' },
+  { label: 'Beta', value: 'beta' },
+  { label: 'Gamma', value: 'gamma' },
+];
+
+// ---------------------------------------------------------------------------
+// Class A — array-valued types
+// ---------------------------------------------------------------------------
+
+describe('class A — an array-valued field never edits as a joined string (#4220)', () => {
+  describe('tags', () => {
+    const field = { name: 'labels', type: 'tags' };
+    const value = ['alpha', 'beta'];
+
+    it('offers the chip editor, never a box holding the joined "alpha, beta"', () => {
+      render(<InlineFieldInput field={field} value={[...value]} onChange={vi.fn()} />);
+      // Display half: the join is what the terminal input showed as "the
+      // current value I am correcting".
+      expect(screen.queryByDisplayValue('alpha, beta')).toBeNull();
+      expect(plainInput()).toBeNull();
+      // Each element is its own removable chip, as on the form.
+      expect(screen.getByLabelText('Remove alpha')).toBeInTheDocument();
+      expect(screen.getByLabelText('Remove beta')).toBeInTheDocument();
+    });
+
+    it('emits an ARRAY when a tag is added', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <InlineFieldInput field={field} value={[...value]} onChange={onChange} />,
+      );
+      const input = container.querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'gamma' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const next = onChange.mock.calls[0][0];
+      // Write half — the data-destroying one.
+      expect(Array.isArray(next)).toBe(true);
+      expect(next).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('emits an ARRAY when a tag is removed', () => {
+      const onChange = vi.fn();
+      render(<InlineFieldInput field={field} value={[...value]} onChange={onChange} />);
+      fireEvent.click(screen.getByLabelText('Remove alpha'));
+      expect(Array.isArray(onChange.mock.calls[0][0])).toBe(true);
+      expect(onChange.mock.calls[0][0]).toEqual(['beta']);
+    });
+
+    it('never emits a bare STRING over the array', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <InlineFieldInput field={field} value={[...value]} onChange={onChange} />,
+      );
+      typeIntoFirstBox(container, 'alpha, beta, gamma');
+      for (const call of onChange.mock.calls) {
+        expect(typeof call[0]).not.toBe('string');
+      }
+    });
+  });
+
+  describe('checkboxes', () => {
+    const field = { name: 'perks', type: 'checkboxes', options: OPTIONS };
+    const value = ['alpha', 'beta'];
+
+    it('offers the checkbox group, never the joined string', () => {
+      render(<InlineFieldInput field={field} value={[...value]} onChange={vi.fn()} />);
+      expect(screen.queryByDisplayValue('alpha, beta')).toBeNull();
+      expect(plainInput()).toBeNull();
+      expect(screen.getByTestId('checkboxes-option-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('checkboxes-option-gamma')).toBeInTheDocument();
+    });
+
+    it('emits an ARRAY when an option is toggled', () => {
+      const onChange = vi.fn();
+      render(<InlineFieldInput field={field} value={[...value]} onChange={onChange} />);
+      fireEvent.click(screen.getByTestId('checkboxes-option-gamma'));
+      const next = onChange.mock.calls[0][0];
+      expect(Array.isArray(next)).toBe(true);
+      expect([...(next as string[])].sort()).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('an options-less `checkboxes` shows the fields package’s unfillable state, not a text box', () => {
+      // The design call the card flagged (`CheckboxesField` needs options)
+      // resolves INSIDE the delegation: the widget renders its own legible
+      // "no options" state, and the array is left untouched — where the
+      // terminal input offered "alpha, beta" for overwriting.
+      const onChange = vi.fn();
+      const { container } = render(
+        <InlineFieldInput
+          field={{ name: 'perks', type: 'checkboxes' }}
+          value={[...value]}
+          onChange={onChange}
+        />,
+      );
+      expect(plainInput()).toBeNull();
+      expect(screen.queryByDisplayValue('alpha, beta')).toBeNull();
+      expect(screen.getByTestId('checkboxes-empty-perks')).toBeInTheDocument();
+      typeIntoFirstBox(container, 'wiped');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('multiselect / select+multiple with no options (the select branch’s guard)', () => {
+    // The routed select branch requires `Array.isArray(field.options) &&
+    // field.options.length > 0`, so an options-less multi picklist fell
+    // straight through to the terminal input with its array joined.
+    for (const field of [
+      { name: 'topics', type: 'multiselect' },
+      { name: 'topics', type: 'select', multiple: true },
+    ]) {
+      it(`\`${field.type}${field.multiple ? ' + multiple' : ''}\` keeps the array`, () => {
+        const onChange = vi.fn();
+        const { container } = render(
+          <InlineFieldInput field={field} value={['alpha', 'beta']} onChange={onChange} />,
+        );
+        expect(plainInput()).toBeNull();
+        expect(screen.queryByDisplayValue('alpha, beta')).toBeNull();
+        expect(screen.getByTestId('multiselect-empty-topics')).toBeInTheDocument();
+        typeIntoFirstBox(container, 'wiped');
+        expect(onChange).not.toHaveBeenCalled();
+      });
+    }
+
+    it('a multiselect WITH options still routes to the existing chip picker (control)', () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput
+          field={{ name: 'topics', type: 'multiselect', options: OPTIONS }}
+          value={['alpha']}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.click(screen.getByTestId('multiselect-option-beta'));
+      expect(onChange.mock.calls[0][0]).toEqual(['alpha', 'beta']);
+    });
+  });
+
+  it('`vector` needs no editor here — #4228 closed it at the host gate', () => {
+    // Verification, not a re-fix: the shared exclusion set already stops the
+    // hosts from entering inline edit on an embedding vector at all.
+    expect(isInlineExcludedDetailFieldType(undefined, 'vector')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Class C — type-lossy scalars
+// ---------------------------------------------------------------------------
+
+describe('class C — a scalar field keeps its TYPE through inline edit (#4220)', () => {
+  it('`toggle` edits as a switch and emits a BOOLEAN (not "true")', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput field={{ name: 'active', type: 'toggle' }} value={true} onChange={onChange} />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(screen.queryByDisplayValue('true')).toBeNull();
+    const control = screen.getByRole('switch');
+    fireEvent.click(control);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(typeof onChange.mock.calls[0][0]).toBe('boolean');
+    expect(onChange.mock.calls[0][0]).toBe(false);
+  });
+
+  for (const type of ['slider', 'progress']) {
+    it(`\`${type}\` edits as a slider and emits a NUMBER`, () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput
+          field={{ name: 'completion', type, min: 0, max: 100, step: 10 }}
+          value={40}
+          onChange={onChange}
+        />,
+      );
+      expect(plainInput()).toBeNull();
+      expect(screen.queryByDisplayValue('40')).toBeNull();
+      const slider = screen.getByRole('slider');
+      fireEvent.keyDown(slider, { key: 'ArrowRight' });
+      expect(onChange).toHaveBeenCalled();
+      expect(typeof onChange.mock.calls[0][0]).toBe('number');
+    });
+  }
+
+  it('`rating` edits as stars and emits a NUMBER', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput field={{ name: 'score', type: 'rating' }} value={3} onChange={onChange} />,
+    );
+    expect(plainInput()).toBeNull();
+    const stars = screen.getAllByRole('button');
+    fireEvent.click(stars[4]);
+    expect(typeof onChange.mock.calls[0][0]).toBe('number');
+    expect(onChange.mock.calls[0][0]).toBe(5);
+  });
+
+  it('`radio` is CONSTRAINED to its options — no free-typed value can be saved', () => {
+    // The same argument the routed select branch already makes in its own
+    // comment ("users ... can't free-type invalid values"), applied to the
+    // widget that was missed.
+    const onChange = vi.fn();
+    const { container } = render(
+      <InlineFieldInput
+        field={{ name: 'tier', type: 'radio', options: OPTIONS }}
+        value="alpha"
+        onChange={onChange}
+      />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(container.querySelector('input[type="text"]')).toBeNull();
+    expect(screen.getByTestId('radio-option-beta')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('radio-option-beta'));
+    expect(onChange).toHaveBeenCalledWith('beta');
+    // Nothing in the rendered editor accepts an off-list value.
+    typeIntoFirstBox(container, 'not-an-option');
+    for (const call of onChange.mock.calls) {
+      expect(OPTIONS.map((o) => o.value)).toContain(call[0]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The types the switch never had a branch for (#4228's report)
+// ---------------------------------------------------------------------------
+
+describe('types the fields package edits inline but the switch had no branch for', () => {
+  it('`json` delegates to the code editor (alias `json` → `field:code`)', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <InlineFieldInput
+        field={{ name: 'payload', type: 'json' }}
+        value={'{"a":1}'}
+        onChange={onChange}
+      />,
+    );
+    expect(plainInput()).toBeNull();
+    const textarea = container.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: '{"a":2}' } });
+    expect(onChange).toHaveBeenCalledWith('{"a":2}');
+  });
+
+  it('`code` delegates to the code editor', () => {
+    const { container } = render(
+      <InlineFieldInput field={{ name: 'src', type: 'code' }} value="x = 1" onChange={vi.fn()} />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(container.querySelector('textarea')).not.toBeNull();
+  });
+
+  it('`color` delegates to the colour picker', () => {
+    const { container } = render(
+      <InlineFieldInput field={{ name: 'brand', type: 'color' }} value="#ff0000" onChange={vi.fn()} />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(container.querySelector('input[type="color"]')).not.toBeNull();
+  });
+
+  it('`time` delegates to the native time picker', () => {
+    const { container } = render(
+      <InlineFieldInput field={{ name: 'starts', type: 'time' }} value="09:30" onChange={vi.fn()} />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(container.querySelector('input[type="time"]')).not.toBeNull();
+  });
+
+  it('`qrcode` delegates to its form widget', () => {
+    render(
+      <InlineFieldInput field={{ name: 'ticket', type: 'qrcode' }} value="OS-1" onChange={vi.fn()} />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(screen.getByDisplayValue('OS-1')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Class D — benign already-string types keep the terminal input
+// ---------------------------------------------------------------------------
+
+describe('class D — benign string types keep the terminal text input (#4220)', () => {
+  for (const type of ['text', 'textarea', 'email', 'url', 'phone']) {
+    it(`\`${type}\` still edits in the plain input, and emits the typed string`, () => {
+      const onChange = vi.fn();
+      render(
+        <InlineFieldInput field={{ name: 'f', type }} value="before" onChange={onChange} />,
+      );
+      const input = plainInput();
+      expect(input).not.toBeNull();
+      expect((input as HTMLInputElement).value).toBe('before');
+      fireEvent.change(input as HTMLInputElement, { target: { value: 'after' } });
+      expect(onChange).toHaveBeenCalledWith('after');
+    });
+  }
+
+  it('an options-less single `select` keeps the plain input (no picklist to render)', () => {
+    // Stringification is the identity for a bare string value, and the
+    // fields package's own empty state would leave the user unable to enter
+    // anything at all. The array-valued spelling is class A above.
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput field={{ name: 'stage', type: 'select' }} value="alpha" onChange={onChange} />,
+    );
+    expect(plainInput()).not.toBeNull();
+    fireEvent.change(plainInput() as HTMLInputElement, { target: { value: 'beta' } });
+    expect(onChange).toHaveBeenCalledWith('beta');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controls — every currently-routed family keeps its editor
+// ---------------------------------------------------------------------------
+
+describe('controls — the routed families are untouched by the delegation', () => {
+  it('`select` with options keeps the routed dropdown', () => {
+    render(
+      <InlineFieldInput
+        field={{ name: 'stage', type: 'select', options: OPTIONS }}
+        value="alpha"
+        onChange={vi.fn()}
+      />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('`boolean` keeps the routed switch', () => {
+    const onChange = vi.fn();
+    render(
+      <InlineFieldInput field={{ name: 'active', type: 'boolean' }} value={false} onChange={onChange} />,
+    );
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('`number` keeps the routed numeric input', () => {
+    const { container } = render(
+      <InlineFieldInput field={{ name: 'qty', type: 'number' }} value={7} onChange={vi.fn()} />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(container.querySelector('input[type="number"]')).not.toBeNull();
+  });
+
+  for (const type of ['date', 'datetime']) {
+    it(`\`${type}\` keeps the routed native date input`, () => {
+      const { container } = render(
+        <InlineFieldInput
+          field={{ name: 'due', type }}
+          value="2026-08-11T00:00:00.000Z"
+          onChange={vi.fn()}
+        />,
+      );
+      const input = container.querySelector('input[type="date"]') as HTMLInputElement;
+      expect(input).not.toBeNull();
+      expect(input.value).toBe('2026-08-11');
+    });
+  }
+
+  it('`address` keeps the routed sub-field editor (#4222)', () => {
+    render(
+      <InlineFieldInput
+        field={{ name: 'billing', type: 'address' }}
+        value={{ street: '123 Main St', city: 'San Francisco' }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(screen.getByDisplayValue('123 Main St')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('San Francisco')).toBeInTheDocument();
+  });
+
+  it('`lookup` keeps the routed record picker', () => {
+    const { container } = render(
+      <InlineFieldInput
+        field={{ name: 'account', type: 'lookup', reference_to: 'crm_account' }}
+        value={{ id: 'a1', name: 'Northwind' }}
+        onChange={vi.fn()}
+        dataSource={{ find: vi.fn(async () => ({ data: [], total: 0 })) }}
+      />,
+    );
+    expect(plainInput()).toBeNull();
+    expect(container.querySelector('input[type="text"]')).toBeNull();
+  });
+
+  it('`image` keeps the routed upload widget (the #4228 exemption)', () => {
+    render(
+      <InlineFieldInput field={{ name: 'logo', type: 'image' }} value={null} onChange={vi.fn()} />,
+    );
+    expect(plainInput()).toBeNull();
+  });
+
+  it('a `permission-facet-link` widget hint still short-circuits to the read-only facet', () => {
+    render(
+      <InlineFieldInput
+        field={{ name: 'facet', type: 'object', widget: 'permission-facet-link' }}
+        value={{ a: 1 }}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(plainInput()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoFocus — the delegation follows the routed branches' convention
+// ---------------------------------------------------------------------------
+
+describe('autoFocus reaches the delegated widget’s own control', () => {
+  it('`tags` focuses the chip input when the host enters edit on that field', () => {
+    const { container } = render(
+      <InlineFieldInput
+        field={{ name: 'labels', type: 'tags' }}
+        value={['alpha']}
+        onChange={vi.fn()}
+        autoFocus
+      />,
+    );
+    expect(container.querySelector('input')).toBe(document.activeElement);
+  });
+
+  it('`code` focuses the editor', () => {
+    const { container } = render(
+      <InlineFieldInput
+        field={{ name: 'src', type: 'code' }}
+        value="x = 1"
+        onChange={vi.fn()}
+        autoFocus
+      />,
+    );
+    expect(container.querySelector('textarea')).toBe(document.activeElement);
+  });
+});

--- a/packages/plugin-detail/src/__tests__/inlineEditTypeCoverage.test.tsx
+++ b/packages/plugin-detail/src/__tests__/inlineEditTypeCoverage.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Drift guard — every field type has an explicit inline-edit decision on the
+ * DETAIL page (objectui#4220).
+ *
+ * ## Why this file exists
+ *
+ * `InlineFieldInput` hand-rolls a type switch that ends in a raw text input,
+ * and `@object-ui/fields` maintains the form's widget map. The two lists drifted
+ * apart repeatedly, and every time they did, the gap was silent AND lossy: a
+ * type nobody had thought about fell to the terminal input, was displayed
+ * through `coerceToSafeValue` and written back as a bare string. That produced
+ * six cards from ONE cause — #2942 (the grid's copy), #3355, #4216, #4219,
+ * #4221/#4228 and this one — so the deliverable that outlives the fix is not
+ * another routing line, it is this assertion.
+ *
+ * The fields package already guards ITS half (`FieldEditWidget.test.ts`: every
+ * form type is a widget or a documented exclusion). This is the detail page's
+ * matching pair, over the SAME universe of types plus the spec's own enum.
+ *
+ * ## The contract
+ *
+ * Every field type must fall into EXACTLY ONE of four buckets:
+ *
+ * | bucket | who decides | what the user gets |
+ * |---|---|---|
+ * | **excluded** | the hosts' gates (`isInlineExcludedDetailFieldType` / `isComputedFieldType`) | no inline editor at all — containers, credentials, computed |
+ * | **routed** | `InlineFieldInput`'s own switch (`INLINE_ROUTED_FIELD_TYPES`) | the dedicated editor that type already had |
+ * | **delegated** | `FieldEditWidget` | the SAME widget the form uses |
+ * | **benign** | `INLINE_PLAIN_TEXT_FIELD_TYPES` | the terminal text input, losslessly (the value is already a string) |
+ *
+ * A type in NONE of the four is red — that is a new type nobody decided about,
+ * and the default it would otherwise inherit is the value-destroying one. A
+ * type in TWO is red as well: overlapping claims are how a decision gets made
+ * twice and disagrees with itself.
+ *
+ * The two behavioural halves below are what stop this from being a tautology
+ * over four hand-written sets: the declared bucket is checked against what
+ * `InlineFieldInput` actually RENDERS for that type.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FieldType } from '@objectstack/spec/data';
+import { InlineEditProvider, useInlineEdit } from '@object-ui/react';
+import type { DetailViewSection } from '@object-ui/types';
+import { DetailSection } from '../DetailSection';
+import { HeaderHighlight } from '../HeaderHighlight';
+import {
+  FORM_FIELD_TYPES,
+  hasFieldEditWidget,
+  isInlineExcludedFieldType,
+} from '@object-ui/fields';
+import {
+  InlineFieldInput,
+  INLINE_PLAIN_TEXT_FIELD_TYPES,
+  INLINE_PLAIN_TEXT_INPUT_TESTID,
+  INLINE_ROUTED_FIELD_TYPES,
+  isKnownFieldType,
+} from '../InlineFieldInput';
+import { isComputedFieldType, isInlineExcludedDetailFieldType } from '../fieldEnrichment';
+
+/**
+ * The universe: the form's widget-map keys UNION the spec's `FieldType` enum.
+ *
+ * Neither alone is enough. `FORM_FIELD_TYPES` misses every spec spelling that
+ * reaches a widget through the alias table — `toggle`, `progress`, `json`,
+ * `composite`, `autonumber`, `secret`, `video` — which is precisely the set
+ * that fell through the switch in #2942 and again here. The spec enum misses
+ * the form-only keys (`owner`, `object`, `grid`, `geolocation`, the
+ * widget-hint pickers).
+ */
+const specTypes: string[] = Array.isArray((FieldType as { options?: readonly string[] }).options)
+  ? [...(FieldType as { options: readonly string[] }).options]
+  : [];
+const ALL_TYPES = [...new Set([...FORM_FIELD_TYPES, ...specTypes])].sort();
+
+/** The hosts never even render an editor for these (the gates, not this switch). */
+const isGatedByHost = (type: string): boolean =>
+  isInlineExcludedDetailFieldType(undefined, type) || isComputedFieldType(undefined, type);
+
+function bucketsOf(type: string): string[] {
+  const buckets: string[] = [];
+  if (isGatedByHost(type)) buckets.push('excluded');
+  if (INLINE_ROUTED_FIELD_TYPES.has(type)) buckets.push('routed');
+  if (INLINE_PLAIN_TEXT_FIELD_TYPES.has(type)) buckets.push('benign');
+  // Delegation is what the runtime does with everything left over — the same
+  // two conditions `InlineFieldInput` applies, read from the same exports.
+  if (
+    buckets.length === 0 &&
+    isKnownFieldType(type) &&
+    hasFieldEditWidget(type)
+  ) {
+    buckets.push('delegated');
+  }
+  return buckets;
+}
+
+/**
+ * Metadata that makes each type's editor renderable in its CANONICAL shape.
+ * A picklist without options and a lookup without a `reference_to` are
+ * degenerate configurations, not the type's normal form; both degenerate
+ * picklist spellings are pinned by name in the sibling delegation suite.
+ */
+const FIELD_FIXTURE: Record<string, Record<string, unknown>> = {
+  select: { options: [{ label: 'A', value: 'a' }] },
+  multiselect: { options: [{ label: 'A', value: 'a' }] },
+  radio: { options: [{ label: 'A', value: 'a' }] },
+  checkboxes: { options: [{ label: 'A', value: 'a' }] },
+  lookup: { reference_to: 'crm_account' },
+  master_detail: { reference_to: 'crm_account' },
+  tree: { reference_to: 'crm_account' },
+};
+
+/** A value of the type's real SHAPE — the point is what the editor does with it. */
+const VALUE_FIXTURE: Record<string, unknown> = {
+  tags: ['a', 'b'],
+  checkboxes: ['a'],
+  multiselect: ['a'],
+  vector: [1, 2, 3],
+  boolean: true,
+  toggle: true,
+  number: 1,
+  currency: 1,
+  percent: 1,
+  slider: 40,
+  progress: 40,
+  rating: 3,
+  date: '2026-08-11',
+  datetime: '2026-08-11T00:00:00.000Z',
+  time: '09:30',
+  color: '#ff0000',
+  address: { street: '1 Main St' },
+  location: { latitude: 1, longitude: 2 },
+  geolocation: { latitude: 1, longitude: 2 },
+  object: { a: 1 },
+  composite: { a: 1 },
+  record: { a: 1 },
+  grid: [{ a: 1 }],
+  repeater: [{ a: 1 }],
+  json: '{"a":1}',
+  image: null,
+  avatar: null,
+  file: null,
+  video: null,
+  audio: null,
+  signature: '',
+  'filter-condition': [],
+};
+const valueFor = (type: string) => (type in VALUE_FIXTURE ? VALUE_FIXTURE[type] : 'v-1');
+
+const renderInline = (type: string) =>
+  render(
+    <InlineFieldInput
+      field={{ name: 'f', type, ...(FIELD_FIXTURE[type] ?? {}) }}
+      value={valueFor(type)}
+      onChange={vi.fn()}
+      dataSource={{ find: vi.fn(async () => ({ data: [], total: 0 })) }}
+    />,
+  );
+
+/** Did this type land on the terminal raw text input? */
+const reachedPlainInput = () =>
+  screen.queryAllByTestId(INLINE_PLAIN_TEXT_INPUT_TESTID).length > 0;
+
+// ---------------------------------------------------------------------------
+// The partition
+// ---------------------------------------------------------------------------
+
+describe('inline-edit type coverage — every type has exactly one decision (#4220)', () => {
+  it('reads a non-empty enum from the spec', () => {
+    expect(specTypes, 'could not read FieldType.options from the spec').not.toEqual([]);
+  });
+
+  it('the universe is the union of the form widget map and the spec enum', () => {
+    // Sanity on the guard itself: if either source stopped contributing, the
+    // partition below would still pass while covering half the types.
+    expect(ALL_TYPES.length).toBeGreaterThan(FORM_FIELD_TYPES.length);
+    expect(ALL_TYPES.length).toBeGreaterThan(specTypes.length);
+  });
+
+  it('no type is left undecided', () => {
+    const undecided = ALL_TYPES.filter((t) => bucketsOf(t).length === 0);
+    // If this fails: a field type would fall to the terminal raw text input by
+    // ACCIDENT — displayed through `coerceToSafeValue` and saved as a string.
+    // Decide it: give it a branch (INLINE_ROUTED_FIELD_TYPES), let it delegate
+    // (a widget in the fields package's EDIT_WIDGETS), gate it out (the shared
+    // INLINE_EXCLUDED_FIELD_TYPES), or declare it benign
+    // (INLINE_PLAIN_TEXT_FIELD_TYPES — only if its stored value is a string).
+    expect(undecided).toEqual([]);
+  });
+
+  it('no type is claimed twice', () => {
+    const overlapping = ALL_TYPES.map((t) => [t, bucketsOf(t)] as const).filter(
+      ([, b]) => b.length > 1,
+    );
+    expect(overlapping).toEqual([]);
+  });
+
+  it('the benign list is explicit, and every member really is string-valued', () => {
+    // Enumerated, never "everything else" — an open tail is the drift itself.
+    expect([...INLINE_PLAIN_TEXT_FIELD_TYPES].sort()).toEqual([
+      'email',
+      'phone',
+      'text',
+      'textarea',
+      'url',
+    ]);
+  });
+
+  it('the four buckets, as landed (documentation the next reader can diff)', () => {
+    const byBucket: Record<string, string[]> = {};
+    for (const t of ALL_TYPES) {
+      const [bucket] = bucketsOf(t);
+      (byBucket[bucket] ||= []).push(t);
+    }
+    expect(byBucket).toEqual({
+      excluded: [
+        'auto_number', 'autonumber', 'composite', 'filter-condition', 'formula',
+        'grid', 'html', 'markdown', 'object', 'object-ref', 'password',
+        'recipient-picker', 'record', 'repeater', 'richtext', 'secret',
+        'summary', 'vector',
+      ],
+      routed: [
+        'address', 'audio', 'avatar', 'boolean', 'currency', 'date', 'datetime',
+        'file', 'geolocation', 'image', 'location', 'lookup', 'master_detail',
+        'multiselect', 'number', 'owner', 'percent', 'select', 'signature',
+        'tree', 'user', 'video',
+      ],
+      delegated: ['checkboxes', 'code', 'color', 'json', 'progress', 'qrcode', 'radio', 'rating', 'slider', 'tags', 'time', 'toggle'],
+      benign: ['email', 'phone', 'text', 'textarea', 'url'],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The declared buckets, checked against what actually renders
+// ---------------------------------------------------------------------------
+
+describe('the declared bucket matches what InlineFieldInput renders', () => {
+  for (const type of ALL_TYPES) {
+    const [bucket] = bucketsOf(type);
+
+    if (bucket === 'excluded') {
+      it(`\`${type}\` (excluded) is gated before an editor is ever rendered`, () => {
+        // The hosts own this one; nothing is asserted about the switch, which
+        // is never reached. Both gates are alias-aware and narrow-only.
+        expect(isGatedByHost(type)).toBe(true);
+      });
+      continue;
+    }
+
+    if (bucket === 'benign') {
+      it(`\`${type}\` (benign) really does render the terminal text input`, () => {
+        renderInline(type);
+        expect(reachedPlainInput()).toBe(true);
+      });
+      continue;
+    }
+
+    it(`\`${type}\` (${bucket}) renders a real editor, never the terminal text input`, () => {
+      renderInline(type);
+      // This is what makes `INLINE_ROUTED_FIELD_TYPES` honest: a member whose
+      // branch was deleted stops rendering its own editor, and a delegated type
+      // whose widget disappeared falls back here — both surface as a plain
+      // input where the table promised an editor.
+      expect(reachedPlainInput()).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The exclusion half stays anchored to the SHARED set (no second list)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// #4219 ride-along — the spec `autonumber` spelling, re-measured after #4228
+// ---------------------------------------------------------------------------
+
+/**
+ * #4219 reported that `TEXTUAL_REF_FALLBACK_TYPES` — the COMPUTED gate — spells
+ * the type `auto_number` only, while `@objectstack/spec` (and the designer, and
+ * the importer) spell it `autonumber`, so a machine-generated identity was
+ * hand-editable on the detail page.
+ *
+ * #4228 changed the reachability underneath that report: both hosts now also
+ * consult the fields package's shared exclusion, which is alias-aware —
+ * `autonumber` resolves through `mapFieldTypeToFormType` onto the excluded
+ * `auto_number`. The affordance is therefore already gone, by a different gate
+ * than the one #4219 names. These pin that, so the card can be closed on
+ * measurement rather than on reasoning.
+ *
+ * The computed gate's own spelling gap is NOT pinned here in either direction:
+ * it is #4219's to decide, and a pin asserting today's asymmetry would go red
+ * on the very fix that card proposes.
+ */
+describe('#4219 — an `autonumber` field offers no inline editor after #4228', () => {
+  beforeAll(() => {
+    // Desktop layout — the mobile branch renders its own read-only row shape.
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+  });
+
+  const hasPencil = () => screen.queryAllByLabelText('Double-click to edit').length > 0;
+  const schema = { fields: { invoice_no: { type: 'autonumber' } } };
+  const data = { invoice_no: 'INV-000317' };
+
+  function EnterEdit({ name }: { name: string }) {
+    const inline = useInlineEdit();
+    return <button type="button" onClick={() => inline!.enter(name)}>enter-edit</button>;
+  }
+
+  it('the details body renders no affordance, and no editor even in edit mode', () => {
+    const { container } = render(
+      <DetailSection
+        section={{ fields: [{ name: 'invoice_no', label: 'Invoice #' }] } as unknown as DetailViewSection}
+        data={data}
+        objectSchema={schema}
+        isEditing
+        onEnterInlineEdit={vi.fn()}
+      />,
+    );
+    expect(hasPencil()).toBe(false);
+    expect(container.querySelector('input')).toBeNull();
+    expect(screen.queryByDisplayValue('INV-000317')).toBeNull();
+  });
+
+  it('the highlights strip renders no affordance, and no editor inside the session', () => {
+    const { container } = render(
+      <InlineEditProvider canEdit>
+        <HeaderHighlight
+          fields={[{ name: 'invoice_no', label: 'Invoice #' }] as any}
+          data={data}
+          objectSchema={schema}
+        />
+        <EnterEdit name="invoice_no" />
+      </InlineEditProvider>,
+    );
+    expect(hasPencil()).toBe(false);
+    fireEvent.click(screen.getByText('enter-edit'));
+    expect(container.querySelector('input')).toBeNull();
+    expect(screen.queryByDisplayValue('INV-000317')).toBeNull();
+  });
+
+  it('the gate that catches it is the shared exclusion (alias-resolved)', () => {
+    expect(isInlineExcludedDetailFieldType(undefined, 'autonumber')).toBe(true);
+    expect(isInlineExcludedDetailFieldType('autonumber', undefined)).toBe(true);
+  });
+});
+
+describe('the excluded bucket is the fields package’s set, not a local copy', () => {
+  it('every excluded type is either in the shared set or machine-computed', () => {
+    const excluded = ALL_TYPES.filter((t) => bucketsOf(t)[0] === 'excluded');
+    const strays = excluded.filter(
+      (t) => !isInlineExcludedFieldType(t) && !isComputedFieldType(undefined, t),
+    );
+    // A local exclusion with no upstream reason is exactly the second
+    // hand-maintained list this whole family of bugs came from.
+    expect(strays).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #4220

`InlineFieldInput`'s type switch ends in a raw text input, and every type it has no branch for landed there: displayed through `coerceToSafeValue` and written back as whatever the user typed — a bare string. #4216/#4222 closed the structured composites, #4228 closed the containers and credentials at the host gate. This is the rest of the sweep.

## Premise, re-measured on this tip (all confirmed)

A throwaway probe asserted the CURRENT behaviour before a line was changed; every assertion passed on `origin/main` (17/17):

| class | stored | edit box showed | emitted on save |
|---|---|---|---|
| A `tags` / `checkboxes` / `multiselect` / `select`+`multiple`, no options | `['alpha','beta']` | `"alpha, beta"` (`coerceToSafeValue` joins arrays) | `"alpha, beta, gamma"` — a **string** over the array |
| C `toggle` | `true` | `"true"` | `"whatever-i-type"` — a **string** over the boolean |
| C `slider` / `progress` / `rating` | `40` / `3` | `"40"` / `"3"` | a **string** over the number |
| C `radio` | `'alpha'` | `"alpha"` | any free-typed value the option list never offered |
| no branch at all | — | `json`, `code`, `color`, `time`, `qrcode` each reached `input[type=text]` | — |

Class B is already closed and was verified, not redone: `object` / `composite` / `record` / `grid` / `repeater` / `vector` are all gated by #4228's shared-exclusion consultation.

## The four-way classification, as landed

One fallback branch, not per-type routing. Every field type in `FORM_FIELD_TYPES` UNION the spec `FieldType` enum (57 types) now sits in exactly one bucket:

| bucket | decided by | types |
|---|---|---|
| **excluded** (18) | the hosts' gates — the fields package's shared set + the computed set | `auto_number`, `autonumber`, `composite`, `filter-condition`, `formula`, `grid`, `html`, `markdown`, `object`, `object-ref`, `password`, `recipient-picker`, `record`, `repeater`, `richtext`, `secret`, `summary`, `vector` |
| **routed** (22) | `InlineFieldInput`'s own switch — unchanged, no UX churn | `address`, `audio`, `avatar`, `boolean`, `currency`, `date`, `datetime`, `file`, `geolocation`, `image`, `location`, `lookup`, `master_detail`, `multiselect`, `number`, `owner`, `percent`, `select`, `signature`, `tree`, `user`, `video` |
| **delegated** (12) | `FieldEditWidget` — the same control the form renders | `checkboxes`, `code`, `color`, `json`, `progress`, `qrcode`, `radio`, `rating`, `slider`, `tags`, `time`, `toggle` |
| **benign** (5) | the terminal text input, losslessly | `text`, `textarea`, `email`, `phone`, `url` |

Two conditional members are pinned by name rather than by type: an options-less **single** `select` stays on the plain input (its value is a bare string, and the widget's own empty state would leave the user unable to enter anything), while the `multiple` spelling of that same degenerate field delegates and keeps its array.

`select` is deliberately absent from the benign set; `markdown` / `html` / `richtext` are excluded rather than benign because the hosts stopped opening an editor for them in #4228.

## The drift guard is the deliverable that outlives the fix

`packages/plugin-detail/src/__tests__/inlineEditTypeCoverage.test.tsx` — 67 assertions. Every type must be in exactly one bucket: **none** is red (a new type would otherwise inherit the value-destroying default), **two** is red (overlapping claims). The benign list is enumerated explicitly, never "everything else" — the open tail is the drift itself. This family has produced six cards from one cause (#2942, #3355, #4216, #4219, #4221/#4228, #4220).

The declarative half alone would be a tautology over four hand-written sets, so each declared bucket is also checked against what the component really RENDERS, via a `data-testid` on the terminal input. Sniffing `input[type=text]` cannot do this: `TextField`, `ColorField` and `QRCodeField` render one too, so the heuristic reads a benign type's correct fallback and a delegated type's correct widget as the same thing.

## FieldEditWidget under the inline hosts — measured

- **value/onChange contract**: identical to the routed widgets' — `{ field, value, onChange }`. The hosts' draft (`{ ...data, ...editedValues }` → one atomic `dataSource.update`) is value-shape agnostic, so an array / boolean / number reaches the write unchanged. Pinned per class.
- **`autoFocus`**: `FieldEditWidget` now forwards it, and each widget's own `toDomProps` whitelist lands it on the real focusable control (pinned on `tags`' chip input and `code`'s editor). No `dataSource` is needed — every record-querying type is routed above.
- **sizing**: no delegated type needs `compact` (that is set only for the relational pickers, all routed). The tallest surfaces are `checkboxes` / `radio` option lists, which grow the row the same way the routed multi-select chip row already does.
- **One measured hazard, fixed at the producer instead of worked around.** All four fixed-option widgets end their cascade resolution with a "drop what is no longer offered" effect. It ran against the RESOLVED set without asking why that set was empty, and the two causes are opposites: a list that cascaded to zero (a real decision — clear, ADR-0058), and a field that declares no `options` at all (no decision — the widget renders its "nothing to pick" state). In the second case it deleted the stored value **on mount**, and the detail hosts render every editable field in a section at once, so an options-less `checkboxes` would have staged an empty array into the record draft the moment the user started editing any *other* field in that section, and the save bar would have written it back. The prune now requires an authored list to prune against; the cascade itself is untouched, and four controls pin that a configured list still clears what it no longer offers. This also closes the same path in the grid's inline cell editor, which has always delegated here.

No type turned out to be genuinely unusable inline, so no new host-gate exclusion was needed.

## Reverse verification

Predicted before running, both times, and taken out with `git checkout` (never `git stash` — shared stack):

1. **Delegation branch deleted** → 32 red, exactly the predicted set: every class A pin (joined-string display, string write), every class C pin (`getByRole('switch')` / `('slider')` unable to find, stars absent, `radio` back on a text box), the five never-branched types, and the 12 delegated entries of the coverage guard. Every class D pin, every routed control (`select`+options, `boolean`, `number`, `date`, `address`, `lookup`, `image`, the `permission-facet-link` hint) and the whole partition half stayed green — 81 passed.
   One honest deviation from the naive prediction: `tags`' `autoFocus` pin stays GREEN without the fix, because the terminal input honours `autoFocus` too. That assertion only discriminates for a widget whose control is not a bare `input` (`code`'s textarea), which is where it went red.
2. **Cascade guards reverted** → exactly 7 red: one per widget in the new fields pin (`onChange` called once, with `[]` / `undefined`) plus the three detail-page pins for the options-less picklists. All four cascade **controls** stayed green, which is the assertion that the ADR-0058 behaviour was not weakened.
3. **Type level** — pasting a key the rebuilt `.d.ts` rejects (`autoFocusTypo`) at the delegation call site fails with `TS2322 … Did you mean 'autoFocus'?`, so the typecheck read the freshly built declarations rather than a cached copy.

## #4219 ride-along verdict — still worth landing

Measured (and now pinned): a field typed `autonumber` renders **no** inline affordance and no editor on either host, in the details body and inside an active session on the highlights strip. #4228 changed the reachability underneath that report — `autonumber` resolves through the alias table onto the excluded `auto_number`, so the shared exclusion catches it, not the computed set the card names.

**The spelling fix is still worth landing, and not only as defence in depth**, on two measured paths:

1. `TEXTUAL_REF_FALLBACK_TYPES` is read directly by `InlineFieldInput`'s reference fallback — `!!field.reference_to && !TEXTUAL_REF_FALLBACK_TYPES.has(type)` — with **no host gate in front of it**. `InlineFieldInput` is exported public API, so an `autonumber` carrying a `reference_to` still resolves into the record picker there today. That is the input-side half of #4219's own report, and no exclusion-set consultation touches it.
2. The exclusion set is documented as movable ("To add a type to inline editing, move it from here into `EDIT_WIDGETS`"). The two gates are a union precisely so that one of them going away is survivable; today `auto_number` would still be caught by the computed gate and `autonumber` would not, so the protection of a machine-generated identity depends on which spelling the metadata happens to use.

Nothing about #4219 is changed here — it is a separate card, and this PR deliberately does not pin today's asymmetry in either direction, since a pin asserting it would go red on the very fix that card proposes.

## Verification

- `pnpm exec vitest run packages/plugin-detail/ packages/fields/` → **148 files, 1929 tests, all passed** (repo-root cwd, path-filtered per AGENTS.md §测试纪律).
- New: 35 delegation pins, 67 coverage-guard assertions, 8 option-widget pins.
- `pnpm --filter '@object-ui/plugin-detail^...' --filter '@object-ui/plugin-grid^...' build` → Done; `type-check` on `plugin-detail` / `fields` / `plugin-grid` (the other `FieldEditWidget` consumer) → Done.
- `pnpm exec eslint` on all nine changed files → 0 errors (66 pre-existing `no-explicit-any` warnings; `--max-warnings` is deliberately unset in this repo).
- `pnpm run check:control-bytes` → OK, 3946 files. `node scripts/check-changeset-presence.mjs` → OK, 1 changeset for 2 released packages.
- No i18n change: no user-visible copy is authored here. The delegated widgets' strings are the fields package's existing translated keys (`fields.options.empty`, `fields.tags.placeholder`, …).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_