### PR TITLE
retire(metadata-admin): remove the standalone `validation` resource, move its preview to the embedded path

### DIFF
--- a/.changeset/retire-standalone-validation-resource-4132.md
+++ b/.changeset/retire-standalone-validation-resource-4132.md
@@ -1,0 +1,60 @@
+---
+'@object-ui/app-shell': patch
+---
+
+metadata-admin: retire the standalone `validation` resource, and move
+`ValidationPreview` onto the embedded path the framework actually evaluates
+(objectui#4132)
+
+`anchors.ts` registered a standalone `validation` resource anchored by
+`anchorByField('object')`, complete with `createFields` / `createSchema` /
+`createDefaults`. That gave every object's Related tab a "Validations" group
+whose `+` routed to `validation/_new`, and the file justified it in a comment:
+"usually embedded in the object, but standalone variants do exist."
+
+They do not. ADR-0088 / objectstack#4509 retired `validation` as a metadata
+kind, and the framework ledger (`packages/spec/liveness/validation.json`)
+records that the door never led anywhere in the first place:
+
+> a STANDALONE `validation` item (file `*.validation.ts` or Studio) never
+> reached any object's write path, because the schema has no object-binding key
+> and — every variant being `.strict()` — an author could not add one; no merge
+> code existed […] A state machine authored through that door saved cleanly and
+> gated nothing.
+
+Re-measured against the installed `@objectstack/spec` 17.0.0-rc.6 by parsing the
+shipped registries rather than grepping source: `validation` is in neither
+`DEFAULT_METADATA_TYPE_REGISTRY` (27 kinds) nor
+`listUnregisteredKindSchemaTypes()` (`connector`, `sharing_rule`, `webhook`). So
+the console was offering an authoring affordance for a kind the framework does
+not have — the "shipped false signpost" shape, where the most confident surface
+in the product is the one for the thing that does not work.
+
+**What is gone**: the standalone registration, its create affordance, and the
+stale comment. **What stays**: the embedded anchor `__object_validation`
+(`editAs: 'validation'`, `embeddedPath: 'validations'`) — rules live inside their
+object, and that is the path the framework evaluates.
+
+**The renderer moved rather than retiring with the door.** `ValidationPreview`
+renders a rule's label, description, severity/message callout, per-variant body
+and tags, and until now the only route that mounted it was `ResourceEditPage`'s
+Preview tab on the retired standalone resource; the governed route (Related tab
+→ `MetadataDetailDrawer` → `EmbeddedItemEditor`) drew a bare `SchemaForm`.
+`EmbeddedItemEditor` now looks a preview up by the anchor's `editAs` and mounts
+it above the form on the live draft. The lookup is generic, so this is not a
+`validation` special case: an embedded sub-type with no registered preview
+(`index`) is unchanged and grows no empty preview chrome. This also re-opens
+objectstack#7427's `validation.label` / `.description` / `.tags` ledger rows,
+which were graded `dead` precisely because the render was unreachable on the
+evaluated path.
+
+**One read went with the door.** `ValidationPreview` painted an
+`object: <name>` pill, exempted from the objectui#3275 cleanup on the stated
+ground that "anchors.ts registers a standalone `validation` resource … so a
+standalone rule really does carry it". With that registration gone the read has
+no producer, and it never had one on the governed path either — measured,
+`ValidationRuleSchema.safeParse({ type: 'script', …, object: 'account' })`
+returns `unrecognized_keys: ['object']`. The pill could only ever confirm a key
+that makes the rule unsaveable. Its test case is replaced rather than re-spelled:
+the schema's verdict is now the instrument, and the preview is asserted not to
+paint the key.

--- a/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.preview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.preview.test.tsx
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The embedded editor mounts the registered preview (objectui#4132).
+ *
+ * `ValidationPreview` is a complete renderer — rule label, description, the
+ * severity/message callout, per-variant bodies, tags — and until #4132 the only
+ * route that mounted it was `ResourceEditPage`'s Preview tab on the STANDALONE
+ * `validation` resource, i.e. the door ADR-0088 / objectstack#4509 retired. The
+ * governed path (`object.validations`, which is what the framework actually
+ * evaluates) goes Related tab → `MetadataDetailDrawer` → `EmbeddedItemEditor`,
+ * and that rendered a bare `SchemaForm`. Retiring the door without moving the
+ * renderer would have deleted a working surface from the product; moving it is
+ * the point of the change (#4132's shape B).
+ *
+ * SCOPE OF THIS FILE: `EmbeddedItemEditor` is the entirety of the drawer's
+ * embedded branch — `MetadataDetailDrawer` renders `<EmbeddedItemEditor …/>`
+ * and nothing else for `kind: 'embedded'`. It is mounted directly here rather
+ * than through the drawer because the drawer wraps it in a Radix `Sheet`, which
+ * does not settle under this project's light DOM setup (measured: the same
+ * assertions through `<MetadataDetailDrawer>` never completed, while the editor
+ * alone renders in ~6s). The drawer's half — that it forwards `editAs` to this
+ * component — is pinned off source text in `anchors.validation-retired.test.ts`,
+ * so both halves of the path are asserted, neither by a hanging render.
+ *
+ * The wiring is deliberately GENERIC — `getMetadataPreview(editAs)` — not a
+ * `validation` special case. Today only `validation` has both an `editAs` anchor
+ * and a registered preview, so today it is the only sub-type affected; the
+ * control below pins that a sub-type WITHOUT a registered preview (`index`)
+ * still renders its editor and grows no empty preview chrome.
+ *
+ * Read points asserted here are exactly the ones objectstack#7427's liveness
+ * sweep graded `dead` for being unreachable — `label`, `description`, `tags` —
+ * so this file is the evidence those rows can be re-graded.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+/**
+ * Deliberately WITHOUT a `condition` property. `SchemaForm` routes that name
+ * (`CONDITION_FIELD_NAMES`) to the CEL `ConditionWidget`, whose formula loader
+ * is a dynamic import — an unbounded module load inside a bounded test window,
+ * the trap AGENTS.md §测试纪律 describes (measured here: the file never
+ * settles). The rule's `condition` is still asserted below, where it belongs:
+ * on the PREVIEW, which reads it straight off the draft.
+ */
+const VALIDATION_SCHEMA = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', title: 'Name' },
+    label: { type: 'string', title: 'Label' },
+    message: { type: 'string', title: 'Error message' },
+  },
+} satisfies Record<string, unknown>;
+
+vi.mock('./useMetadata', () => ({
+  useMetadataClient: () => ({
+    layered: async () => ({ effective: {}, code: null, overlay: null, overlayScope: null }),
+    save: async (_t: string, _n: string, payload: Record<string, unknown>) => payload,
+  }),
+  useMetadataTypes: () => ({
+    loading: false,
+    error: null,
+    entries: [
+      {
+        type: 'validation',
+        label: 'Validation Rule',
+        allowOrgOverride: true,
+        schema: VALIDATION_SCHEMA,
+      },
+    ],
+  }),
+}));
+
+import { EmbeddedItemEditor } from './EmbeddedItemEditor';
+import { getMetadataPreview, registerMetadataPreview } from './preview-registry';
+import { ValidationPreview } from './previews/ValidationPreview';
+
+// Registered directly rather than via `registerBuiltinPreviews()`: the barrel
+// pulls every preview module (flow canvas, dashboard, report…) into this file's
+// graph, which is minutes of transform for one form. That the BARREL still
+// carries the `validation` line is pinned off its source text in
+// `anchors.validation-retired.test.ts`.
+registerMetadataPreview('validation', ValidationPreview);
+
+afterEach(cleanup);
+
+/** A spec-shaped script rule as it lives inside `object.validations`. */
+const RULE: Record<string, unknown> = {
+  name: 'amount_positive',
+  label: 'Amount Must Be Positive',
+  description: 'Blocks orders whose amount is zero or negative.',
+  type: 'script',
+  condition: 'record.amount <= 0',
+  message: 'Order amount must be greater than zero.',
+  severity: 'error',
+  active: true,
+  events: ['insert', 'update'],
+  priority: 10,
+  tags: ['finance', 'guardrail'],
+};
+
+function openValidation() {
+  return render(
+    <EmbeddedItemEditor
+      parentType="object"
+      parentName="sales_order"
+      embeddedPath="validations"
+      itemName="amount_positive"
+      editAs="validation"
+      initialRaw={RULE}
+    />,
+  );
+}
+
+describe('a preview is registered for the embedded sub-type', () => {
+  it('`validation` still has a registered preview after the standalone retirement', () => {
+    // Shape B: the door goes, the renderer moves. If this were ever
+    // unregistered, the assertions below would go green for the wrong reason
+    // (nothing to mount), so it is asserted before them, not inferred from them.
+    expect(getMetadataPreview('validation')).toBeTruthy();
+  });
+
+  it('control: a sub-type with no preview is genuinely unregistered', () => {
+    expect(getMetadataPreview('index')).toBeUndefined();
+  });
+});
+
+describe('the embedded editor renders the preview alongside the form', () => {
+  it('renders the rule label — objectstack#7427 `validation.label`', () => {
+    openValidation();
+    expect(screen.getByText('Amount Must Be Positive')).toBeInTheDocument();
+  });
+
+  it('renders the rule description — `validation.description`', () => {
+    openValidation();
+    expect(screen.getByText('Blocks orders whose amount is zero or negative.')).toBeInTheDocument();
+  });
+
+  it('renders the rule tags — `validation.tags`', () => {
+    openValidation();
+    expect(screen.getByText('finance')).toBeInTheDocument();
+    expect(screen.getByText('guardrail')).toBeInTheDocument();
+  });
+
+  it('renders the type-specific body, not just the envelope', () => {
+    openValidation();
+    // `script` → the CEL condition block. This is the half that proves the
+    // whole preview mounted, rather than a stray label somewhere in the form.
+    expect(screen.getByText('Condition')).toBeInTheDocument();
+    expect(screen.getByText('record.amount <= 0')).toBeInTheDocument();
+    // The severity callout carries the message as TEXT (the form carries it as
+    // an input VALUE, which `getByText` does not see).
+    expect(screen.getByText('Order amount must be greater than zero.')).toBeInTheDocument();
+  });
+
+  it('ALONGSIDE, not instead of: the SchemaForm is still mounted and editable', () => {
+    const { container } = openValidation();
+    // The form's own labels…
+    expect(screen.getByText('Error message')).toBeInTheDocument();
+    // …bound to the draft, and the save affordance below it.
+    expect(screen.getByDisplayValue('Order amount must be greater than zero.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save into object/i })).toBeInTheDocument();
+    // Not the raw-JSON fallback branch (which renders a textarea instead).
+    expect(container.querySelector('textarea')).toBeNull();
+  });
+});
+
+describe('sub-types without a registered preview are unchanged (control)', () => {
+  it('renders the editor with no preview chrome', () => {
+    render(
+      <EmbeddedItemEditor
+        parentType="object"
+        parentName="sales_order"
+        embeddedPath="indexes"
+        itemName="idx_email"
+        editAs="index"
+        initialRaw={{ name: 'idx_email', fields: ['email'], unique: true }}
+      />,
+    );
+    // `index` falls back to EmbeddedItemEditor's inline FALLBACK_SCHEMAS entry,
+    // so the form is there…
+    expect(screen.getByText('Fields')).toBeInTheDocument();
+    // …and nothing preview-shaped is drawn for a type that has no preview.
+    expect(screen.queryByText('Amount Must Be Positive')).toBeNull();
+    expect(screen.queryByText(/no preview available/i)).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/EmbeddedItemEditor.tsx
@@ -14,12 +14,22 @@
  *
  * If the sub-type isn't registered (e.g. `index` has no `editAs`), we
  * fall back to a raw-JSON editor so users can still hand-edit and save.
+ *
+ * When the sub-type has a registered Preview renderer, it is mounted above the
+ * form on the live draft (objectui#4132). Previews used to be reachable only
+ * from `ResourceEditPage`'s Preview tab, i.e. only for STANDALONE metadata —
+ * which meant `ValidationPreview` rendered only on the standalone `validation`
+ * door ADR-0088 retired, and never on `object.validations`, the path the
+ * framework actually evaluates. The lookup is generic (`getMetadataPreview`),
+ * so any embedded sub-type that has a preview gets it; one that has none is
+ * unchanged, with no empty preview chrome.
  */
 
 import * as React from 'react';
 import { Loader2, Save, AlertTriangle } from 'lucide-react';
 import { Button } from '@object-ui/components';
 import { SchemaForm, type SchemaFormIssue } from './SchemaForm';
+import { getMetadataPreview } from './preview-registry';
 import { useMetadataClient, useMetadataTypes } from './useMetadata';
 import { useMetadataLocale, t, tFormat, translateValidationMessage } from './i18n';
 import { errorCodeIsAnyOf } from '@object-ui/types';
@@ -60,6 +70,10 @@ export function EmbeddedItemEditor({
   const fallback = !subEntry?.schema && editAs ? FALLBACK_SCHEMAS[editAs] : undefined;
   const schema = (subEntry?.schema as Record<string, unknown> | undefined) ?? fallback?.schema;
   const form = (subEntry?.form as any) ?? fallback?.form;
+  // Opt-in per sub-type, exactly like the Preview tab on the full page: a type
+  // with no registered renderer gets no surface at all (never a "preview not
+  // available" placeholder).
+  const Preview = editAs ? getMetadataPreview(editAs) : undefined;
 
   const [draft, setDraft] = React.useState<Record<string, unknown>>(initialRaw);
   const [saving, setSaving] = React.useState(false);
@@ -188,6 +202,20 @@ export function EmbeddedItemEditor({
         <div className="text-xs text-amber-800 border border-amber-300 bg-amber-50 rounded p-2">
           {t('engine.embedded.readOnlyParent', locale)}
         </div>
+      )}
+
+      {Preview && (
+        // Read-only: the drawer edits through the form below, so no `onPatch`
+        // is handed over and `editing` stays false. `draft` is the live value,
+        // so the preview follows keystrokes the way the full-page tab does.
+        /* eslint-disable-next-line react-hooks/static-components -- getMetadataPreview returns a registered component (stable), not one created during render */
+        <Preview
+          type={editAs as string}
+          name={itemName}
+          draft={draft}
+          locale={locale}
+          editing={false}
+        />
       )}
 
       <SchemaForm

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -342,47 +342,18 @@ export function registerBuiltinAnchors(): void {
   // a `hook` (lifecycle events); async automation is a `record_change` flow.
   // Neither anchors here, so there is no standalone "Triggers" group.
 
-  // validation: usually embedded in the object, but standalone variants
-  // do exist. Match anything whose `object` points back at us.
-  registerMetadataResource({
-    type: 'validation',
-    anchors: [{
-      anchorType: 'object',
-      match: anchorByField('object'),
-      groupLabel: 'Validations',
-      order: 25,
-    }],
-    createFields: ['label', 'name', 'message'],
-    createDerive: [
-      { from: 'label', to: 'name', transform: 'slugify', untilUserEdits: true },
-    ],
-    createSchema: {
-      type: 'object',
-      required: ['label', 'name', 'message'],
-      properties: {
-        label: { type: 'string', title: 'Label', description: 'Human-readable rule name.' },
-        name: {
-          type: 'string',
-          title: 'Name',
-          description: 'Machine name (snake_case). Used in URLs.',
-          pattern: '^[a-z_][a-z0-9_]*$',
-        },
-        message: {
-          type: 'string',
-          title: 'Error message',
-          description: 'Shown to the user when the rule blocks save.',
-        },
-      },
-    },
-    createDefaults: {
-      type: 'script',
-      active: true,
-      events: ['insert', 'update'],
-      priority: 10,
-      severity: 'error',
-      condition: 'false',
-    },
-  });
+  // ADR-0088 / objectstack#4509: `validation` retired as a metadata type. A
+  // validation rule is embedded in its object (`object.validations`) and only
+  // there — that anchor is `__object_validation` at the top of this file, and it
+  // stays. There is no standalone "Validations" group and no create affordance,
+  // because a standalone rule was never evaluated: the schema has no
+  // object-binding key, every variant is `.strict()` so an author could not add
+  // one, and no merge code ever read such an item. It saved cleanly and gated
+  // nothing (framework ledger, `packages/spec/liveness/validation.json`).
+  // Re-measured at `@objectstack/spec` 17.0.0-rc.6: `validation` is in neither
+  // the registered-kind registry nor the unregistered-kind schema list.
+  // Console history: this file registered that door (with `createFields` /
+  // `createSchema`) until objectui#4132 removed it.
 
   // permission has a sparse object-keyed map under `objects`. Match by
   // membership of the parent name in that map.

--- a/packages/app-shell/src/views/metadata-admin/anchors.validation-retired.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.validation-retired.test.ts
@@ -137,14 +137,26 @@ describe('anchors.ts source: the retirement is written down, not just absent', (
   });
 
   it('does not carry the stale "standalone variants do exist" justification', () => {
-    expect(ANCHORS_SOURCE).not.toMatch(/standalone variants do exist/i);
+    // The phrase WRAPS in the source it is guarding against —
+    //   `// validation: usually embedded in the object, but standalone variants`
+    //   `// do exist. Match anything whose `object` points back at us.`
+    // — so a flat `/standalone variants do exist/` matches nothing and passes
+    // for free. Measured on #4132's reverse verification: with the original
+    // file restored, the flat spelling stayed GREEN. Anything between the two
+    // halves is newline + comment prefix, hence the bounded gap.
+    expect(ANCHORS_SOURCE).not.toMatch(/standalone variants[\s\S]{0,24}do exist/i);
   });
 
   it('records the retirement where the registration used to be', () => {
     // Same shape as the `workflow` (ADR-0020) and `trigger` (ADR-0088)
     // retirement notes already in this file: the next reader learns why there
-    // is no group rather than re-adding one.
-    expect(ANCHORS_SOURCE).toMatch(/ADR-0088[\s\S]{0,400}validation/);
+    // is no group rather than re-adding one. Asserted on wording unique to
+    // THIS note — a bare `/ADR-0088/` is already satisfied by the neighbouring
+    // `trigger` note, so it would pass on a file that still registers the door
+    // (measured on #4132's reverse verification).
+    expect(ANCHORS_SOURCE).toMatch(/`validation` retired as a metadata type/);
+    expect(ANCHORS_SOURCE).toContain('ADR-0088 / objectstack#4509');
+    expect(ANCHORS_SOURCE).toContain('objectui#4132');
   });
 
   it('non-vacuity: this really is anchors.ts and the embedded entry is in it', () => {

--- a/packages/app-shell/src/views/metadata-admin/anchors.validation-retired.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.validation-retired.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The standalone `validation` resource stays retired (objectui#4132).
+ *
+ * ADR-0088 / objectstack#4509 retired `validation` as a metadata KIND. The
+ * framework ledger (`packages/spec/liveness/validation.json`) records why, and
+ * it is not a deprecation notice — it is a statement that the door never led
+ * anywhere:
+ *
+ *   > a STANDALONE `validation` item (file `*.validation.ts` or Studio) never
+ *   > reached any object's write path, because the schema has no object-binding
+ *   > key and — every variant being `.strict()` — an author could not add one;
+ *   > no merge code existed […] A state machine authored through that door saved
+ *   > cleanly and gated nothing.
+ *
+ * Re-measured here against the INSTALLED `@objectstack/spec` (17.0.0-rc.6):
+ * `DEFAULT_METADATA_TYPE_REGISTRY` lists 27 kinds and `validation` is not one of
+ * them, and `listUnregisteredKindSchemaTypes()` returns `connector`,
+ * `sharing_rule`, `webhook` — also not `validation`. The console nevertheless
+ * kept registering a standalone `validation` resource anchored by
+ * `anchorByField('object')`, WITH `createFields` / `createSchema`, so the
+ * object's Related tab grew a "Validations" group whose `+` navigated to
+ * `validation/_new` — an author could author, and save, a rule that nothing
+ * evaluates. That is the outcome ADR-0088 retired the kind to prevent.
+ *
+ * What this pin asserts, and why in two instruments:
+ *
+ *  • RUNTIME (primary) — the resource registry after `registerBuiltinAnchors()`.
+ *    This is the surface `RelatedPanel` and `ResourceListPage` actually read, so
+ *    it is the one that decides whether a user can reach the door.
+ *  • SOURCE TEXT (secondary) — `anchors.ts`'s own bytes. The registry is a
+ *    `Map` merged by `registerMetadataResource`, so a re-added registration is
+ *    visible at runtime; the source half additionally pins that the stale
+ *    justification comment ("standalone variants do exist") does not come back
+ *    with it, and a comment is invisible to every runtime read.
+ *
+ * The EMBEDDED anchor is the control and must stay: `__object_validation`
+ * (`editAs: 'validation'`, `embeddedPath: 'validations'`) is the path the
+ * framework does evaluate — rules live in `object.validations`. Retiring it
+ * would be the opposite mistake.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { registerBuiltinAnchors } from './anchors';
+import { getMetadataResource, listAnchorsFor, listMetadataResources } from './registry';
+
+registerBuiltinAnchors();
+
+const ANCHORS_SOURCE = readFileSync(
+  fileURLToPath(new URL('./anchors.ts', import.meta.url)),
+  'utf8',
+);
+
+const PREVIEW_BARREL_SOURCE = readFileSync(
+  fileURLToPath(new URL('./previews/index.ts', import.meta.url)),
+  'utf8',
+);
+
+const DRAWER_SOURCE = readFileSync(
+  fileURLToPath(new URL('./MetadataDetailDrawer.tsx', import.meta.url)),
+  'utf8',
+);
+
+describe('the standalone `validation` resource is not registered', () => {
+  it('has no entry in the resource registry', () => {
+    expect(getMetadataResource('validation')).toBeUndefined();
+  });
+
+  it('non-vacuity: the registry IS populated and other standalone kinds are in it', () => {
+    // Without this, an empty registry (a broken import, a renamed export)
+    // would satisfy every assertion in this file forever.
+    const types = listMetadataResources().map((c) => c.type);
+    expect(types.length).toBeGreaterThan(5);
+    expect(types).toContain('hook');
+    expect(types).toContain('permission');
+  });
+
+  it('offers no create affordance — `createFields` / `createSchema` are gone with it', () => {
+    // `ResourceListPage` gates its New button on `config.createFields`, and
+    // `ResourceEditPage` drives the create form off `config.createSchema`.
+    // Both read the registry entry, so an absent entry is the retirement.
+    const entry = listMetadataResources().find((c) => c.type === 'validation');
+    expect(entry).toBeUndefined();
+    // Control: the affordance is a real thing that other kinds still have.
+    expect(getMetadataResource('hook')?.createFields ?? []).not.toHaveLength(0);
+  });
+
+  it('the object Related tab has no standalone "Validations" group', () => {
+    const groups = listAnchorsFor('object');
+    const standalone = groups.filter(
+      (g) => g.type === 'validation' || g.anchor.groupLabel === 'Validations',
+    );
+    expect(
+      standalone.map((g) => `${g.type} (${g.anchor.groupLabel ?? '-'})`),
+      'A non-embedded validation group re-opens the create door RelatedPanel ' +
+        'renders a `+` for — see ADR-0088 / objectstack#4509.',
+    ).toEqual([]);
+  });
+
+  it('no anchored group anywhere routes standalone validation authoring', () => {
+    // Anchors are declared per parent type; sweep them all rather than just
+    // `object`, so re-anchoring the same door under another parent is caught.
+    const parents = ['object', 'app', 'flow', 'page', 'view', 'datasource', 'package'];
+    for (const parent of parents) {
+      const offenders = listAnchorsFor(parent)
+        .filter((g) => g.type === 'validation')
+        .map((g) => `${parent} → ${g.type}`);
+      expect(offenders).toEqual([]);
+    }
+  });
+});
+
+describe('the EMBEDDED validation anchor stays (control)', () => {
+  it('`__object_validation` is still anchored at object', () => {
+    const embedded = listAnchorsFor('object').find((g) => g.type === '__object_validation');
+    expect(embedded, 'the embedded anchor is the path the framework evaluates').toBeTruthy();
+    expect(embedded?.anchor.source).toBe('embedded');
+    expect(embedded?.anchor.editAs).toBe('validation');
+    expect(embedded?.anchor.embeddedPath).toBe('validations');
+  });
+
+  it('its group is reachable from the object Related tab', () => {
+    const labels = listAnchorsFor('object').map((g) => g.anchor.groupLabel);
+    expect(labels).toContain('Embedded Validations');
+  });
+});
+
+describe('anchors.ts source: the retirement is written down, not just absent', () => {
+  it('declares no standalone validation resource registration', () => {
+    // `type: '__object_validation' as any` is the embedded entry and does not
+    // match this pattern — only the standalone spelling does.
+    expect(/type:\s*'validation'/.test(ANCHORS_SOURCE)).toBe(false);
+  });
+
+  it('does not carry the stale "standalone variants do exist" justification', () => {
+    expect(ANCHORS_SOURCE).not.toMatch(/standalone variants do exist/i);
+  });
+
+  it('records the retirement where the registration used to be', () => {
+    // Same shape as the `workflow` (ADR-0020) and `trigger` (ADR-0088)
+    // retirement notes already in this file: the next reader learns why there
+    // is no group rather than re-adding one.
+    expect(ANCHORS_SOURCE).toMatch(/ADR-0088[\s\S]{0,400}validation/);
+  });
+
+  it('non-vacuity: this really is anchors.ts and the embedded entry is in it', () => {
+    expect(ANCHORS_SOURCE).toContain("'__object_validation'");
+    expect(ANCHORS_SOURCE).toContain("embeddedPath: 'validations'");
+  });
+});
+
+describe('the retirement does NOT take the preview registration with it (shape B)', () => {
+  it('the drawer still hands the embedded editor its `editAs`', () => {
+    // `EmbeddedItemEditor.preview.test.tsx` pins that the editor mounts the
+    // preview registered for `editAs`; this pins the other half of the path —
+    // that the drawer's embedded branch passes `editAs` down at all. Asserted
+    // off source text because the drawer wraps the editor in a Radix `Sheet`,
+    // which does not settle under the light DOM setup (measured on #4132).
+    expect(DRAWER_SOURCE).toMatch(/<EmbeddedItemEditor[\s\S]{0,400}editAs=\{target\.editAs\}/);
+  });
+
+  it('previews/index.ts still registers ValidationPreview', () => {
+    // The renderer moved to the embedded path (`EmbeddedItemEditor` looks it up
+    // by `editAs`), so unregistering it here would delete a working surface
+    // from the product rather than close a retired door. Asserted off source
+    // text because importing the preview barrel drags every preview module
+    // (flow canvas, dashboard, report…) into the test's graph.
+    expect(PREVIEW_BARREL_SOURCE).toMatch(
+      /registerMetadataPreview\('validation',\s*ValidationPreview\)/,
+    );
+    expect(PREVIEW_BARREL_SOURCE).toContain('import { ValidationPreview }');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.test.tsx
@@ -24,13 +24,18 @@
  *    VALID conditional rule displayed "No expression set".
  *  • `json_schema` had no branch, so a VALID rule displayed "Unknown rule type".
  *
- * `object` is deliberately still read: `anchors.ts` registers a standalone
- * `validation` resource matched by `anchorByField('object')`, so a standalone
- * rule genuinely carries it. Not every key the union omits is residue.
+ * `object` USED to be exempt from that list, on one stated ground: `anchors.ts`
+ * registered a standalone `validation` resource matched by
+ * `anchorByField('object')`, so a standalone rule was taken to carry the key.
+ * ADR-0088 / objectstack#4509 retired the kind, objectui#4132 removed that
+ * registration, and the exemption goes with it — the last case in this file is
+ * now the negative, with the schema's own verdict as its instrument rather than
+ * a claim about a registration.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
+import { ValidationRuleSchema } from '@objectstack/spec/data';
 import { ValidationPreview } from './ValidationPreview';
 
 afterEach(cleanup);
@@ -171,13 +176,48 @@ describe('ValidationPreview renders the branches it previously got wrong', () =>
 });
 
 describe('ValidationPreview still renders the shared envelope', () => {
-  it('keeps label, name, severity, message and the object pill', () => {
-    // `object` is NOT residue — standalone validations are anchored by it.
-    renderPreview({ ...BASE, type: 'script', object: 'sales_order', condition: 'record.amount <= 0' });
+  it('keeps label, name, severity and message', () => {
+    renderPreview({ ...BASE, type: 'script', condition: 'record.amount <= 0' });
     expect(screen.getByText('Amount Must Be Positive')).toBeTruthy();
     expect(screen.getByText('amount_positive')).toBeTruthy();
     expect(screen.getByText('Order amount must be greater than zero.')).toBeTruthy();
-    expect(screen.getByText('object: sales_order')).toBeTruthy();
     expect(screen.getByText('error')).toBeTruthy();
+  });
+});
+
+describe('`object` is residue after ADR-0088 (objectui#4132)', () => {
+  /**
+   * The old case here asserted the `object: …` pill and justified it with the
+   * standalone resource registration. Re-spelling that case would have kept a
+   * passing test for a key nothing can produce, so it is replaced outright: the
+   * schema is asked directly, and the preview is asserted NOT to paint the key.
+   */
+  const rejectedKeysIn = (draft: Record<string, unknown>): string[] => {
+    const parsed = ValidationRuleSchema.safeParse(draft);
+    if (parsed.success) return [];
+    return parsed.error.issues.flatMap((issue) =>
+      issue.code === 'unrecognized_keys' ? ((issue as { keys: string[] }).keys ?? []) : [],
+    );
+  };
+
+  it('the schema rejects `object` by name — this is why the read is gone', () => {
+    expect(
+      rejectedKeysIn({ ...BASE, type: 'script', condition: 'record.amount <= 0', object: 'sales_order' }),
+    ).toContain('object');
+  });
+
+  it('non-vacuity: the same draft WITHOUT `object` is not rejected for its keys', () => {
+    // Guards the probe above against a schema that rejects everything (or a
+    // renamed export), which would make the assertion meaningless.
+    expect(rejectedKeysIn({ ...BASE, type: 'script', condition: 'record.amount <= 0' })).toEqual([]);
+  });
+
+  it('the preview paints no object pill even when a draft carries the key', () => {
+    renderPreview({ ...BASE, type: 'script', object: 'sales_order', condition: 'record.amount <= 0' });
+    expect(screen.queryByText('object: sales_order')).toBeNull();
+    expect(screen.queryByText(/sales_order/)).toBeNull();
+    // The rest of the envelope is untouched — this deleted one pill, not a tab.
+    expect(screen.getByText('Amount Must Be Positive')).toBeTruthy();
+    expect(screen.getByText('record.amount <= 0')).toBeTruthy();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ValidationPreview.tsx
@@ -40,9 +40,21 @@
  * mistake, while a publish strips the key and the rule silently does
  * nothing. That is the second de-facto contract AGENTS.md #0.1 forbids.
  *
- * `object` is NOT residue and stays: `anchors.ts` registers a standalone
- * `validation` resource matched by `anchorByField('object')`, so a
- * standalone rule really does carry it.
+ * `object` WAS read here, on the strength of one fact that has since gone:
+ * `anchors.ts` registered a standalone `validation` resource matched by
+ * `anchorByField('object')`, so a standalone rule was assumed to carry the
+ * key. ADR-0088 / objectstack#4509 retired the kind and objectui#4132 removed
+ * that registration, which leaves the read with no producer — and it never had
+ * one on the governed path either: `ValidationRuleSchema` rejects `object` BY
+ * NAME. Measured against the installed `@objectstack/spec` 17.0.0-rc.6:
+ *
+ *   ValidationRuleSchema.safeParse({ type: 'script', …, object: 'account' })
+ *   → unrecognized_keys: ['object']
+ *
+ * So the pill could only ever paint a key that makes the rule unsaveable — the
+ * AGENTS.md #0.1 shape this file already deleted `expression` and `pattern`
+ * for. Where the object name comes from now: the parent. A rule is edited
+ * inside its object (`object.validations`), and the drawer header names it.
  */
 
 import * as React from 'react';
@@ -101,7 +113,6 @@ export function ValidationPreview({ name, draft }: MetadataPreviewProps) {
   const label = String(d.label ?? ruleName);
   const description = (d.description as string | undefined) ?? '';
   const type = (d.type as string | undefined) ?? 'script';
-  const object = d.object as string | undefined;
   const message = (d.message as string | undefined) ?? '';
   const severity: Severity = ((d.severity as Severity | undefined) ?? 'error');
   const active = d.active !== false;
@@ -137,7 +148,6 @@ export function ValidationPreview({ name, draft }: MetadataPreviewProps) {
                 )}
                 <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
                   <Pill icon={Power} label={active ? 'Active' : 'Disabled'} tone={active ? 'green' : 'gray'} />
-                  {object && <Pill label={`object: ${object}`} mono />}
                   {priority != null && <Pill label={`priority ${priority}`} />}
                   {events.length > 0 && (
                     <Pill label={`on ${events.join(', ')}`} />

--- a/packages/app-shell/src/views/metadata-admin/previews/index.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/index.ts
@@ -42,6 +42,11 @@ export function registerBuiltinPreviews(): void {
   // Data
   registerMetadataPreview('object', ObjectPreview);
   registerMetadataPreview('datasource', DatasourcePreview);
+  // ADR-0088 retired STANDALONE `validation` items, and objectui#4132 removed
+  // the console door that authored them. This registration is not residue: a
+  // rule lives embedded in `object.validations`, and `EmbeddedItemEditor` looks
+  // the renderer up by the anchor's `editAs` — so the preview now runs on the
+  // path the framework evaluates instead of the one it retired.
   registerMetadataPreview('validation', ValidationPreview);
   // Analytics (ADR-0021): live cross-object dataset preview.
   registerMetadataPreview('dataset', DatasetPreview);


### PR DESCRIPTION
Fixes #4132

## Verdict: shape B landed — the drawer hosts the preview with no structural surgery

The PM ruling was **shape B with A as the measured fallback**: retire the standalone door (non-negotiable), and wire `ValidationPreview` into the embedded path if the drawer can host it; fall back to A (retire the preview with the door) only if hosting it is measurably structural surgery.

**Measurement of the drawer's structure, taken before writing any wiring:**

- `MetadataDetailDrawer.tsx:122-132` renders exactly one thing for `kind: 'embedded'` — `EmbeddedItemEditor`, inside a plain `flex-1 min-h-0 overflow-auto` column. No tab strip to extend, no layout to redesign.
- `EmbeddedItemEditor` already owns the live `draft` state (`:64`) and already resolves the sub-type by `editAs` (`:54`). `MetadataPreviewProps` needs `{ type, name, draft }` — all three were in hand.
- So hosting the preview is **6 lines**: one `getMetadataPreview(editAs)` lookup and one conditional mount above the `SchemaForm`. Diff for the wiring: `EmbeddedItemEditor.tsx`, +28 lines including the header paragraph explaining why.

Not structural surgery, so the fallback was not taken and no follow-up card is needed for the wiring.

## What was retired

`anchors.ts` registered a standalone `validation` resource anchored by `anchorByField('object')`, with `createFields` / `createSchema` / `createDefaults`. That gave every object's Related tab a "Validations" group whose `+` navigated to `validation/_new` (`RelatedPanel.tsx:257` → the generic `metadata/:type/new` route at `AppContent.tsx:642`). Gone, together with the comment that justified it — "usually embedded in the object, but standalone variants do exist" — which the framework contradicts.

**Kept**: the embedded anchor `__object_validation` (`editAs: 'validation'`, `embeddedPath: 'validations'`). That is the path the framework evaluates, and it is the control in the new pin.

## Premise check (requirement 1) — all three items hold

| item | result |
|:--|:--|
| the registrations still exist on my tip | yes — `anchors.ts:347` standalone resource + `previews/index.ts:45` preview registration, both present at `2776b110b` |
| the installed rc.6 spec has no `validation` kind | confirmed **by parsing the shipped dist**, not grep |
| `metadata/validation/new` reachable today | confirmed — the red-first run measured `listAnchorsFor('object')` returning `object → validation`, a non-embedded group, which is what `RelatedPanel` renders the `+` for |

The spec probe imported `@objectstack/spec/dist/kernel/index.mjs` directly. Note the shipped rc.6 names differ from the issue body's: the registry is `DEFAULT_METADATA_TYPE_REGISTRY` (an array of 27 entries), not `METADATA_TYPE_SCHEMAS`, and the unregistered-kind list is behind `listUnregisteredKindSchemaTypes()`.

```
DEFAULT_METADATA_TYPE_REGISTRY (27 kinds) includes 'validation' => false
action, agent, api, app, book, capability, dashboard, dataset, datasource, doc,
email_template, external_catalog, field, flow, hook, job, mapping, object, page,
permission, position, report, seed, skill, tool, translation, view

listUnregisteredKindSchemaTypes() -> 3; includes 'validation' => false
connector, sharing_rule, webhook
```

## What the embedded path renders now

`EmbeddedItemEditor` looks up `getMetadataPreview(editAs)` and mounts it on the live draft above the `SchemaForm`, read-only (no `onPatch`, `editing={false}`). The lookup is **generic, not a `validation` special case** — today `validation` is the only embedded sub-type with both an `editAs` anchor and a registered preview, and the control in the pin asserts a sub-type without one (`index`) is unchanged and grows no empty preview chrome.

This makes objectstack#7427's `validation.label` / `.description` / `.tags` read points reachable on the evaluated path; those rows were graded `dead` precisely because the render only existed behind the retired door.

## One read retired with the door

`ValidationPreview` painted an `object: < name >` pill, explicitly exempted from the #3275 cleanup because "`anchors.ts` registers a standalone `validation` resource … so a standalone rule really does carry it". With that registration gone the read has no producer — and it never had one on the governed path either. Measured against the installed spec:

```
ValidationRuleSchema.safeParse({ ...rule, object: 'sales_order' })
  -> unrecognized_keys: ['object']
ValidationRuleSchema.safeParse({ ...rule })            # same draft, no `object`
  -> success
```

So the pill could only ever confirm a key that makes the rule unsaveable — the AGENTS.md #0.1 shape this file already deleted `expression` and `pattern` for. Its test case was **replaced, not re-spelled** (re-spelling would have kept a green test for a key nothing can produce): the schema's own verdict is the instrument, plus a negative render assertion.

## Pins, and their reverse verification

Three files reverted one at a time against `HEAD`, direction predicted first:

**1. `anchors.ts` reverted → `anchors.validation-retired.test.ts`: 7 red, controls green** (predicted red)

```
x has no entry in the resource registry
x offers no create affordance - createFields / createSchema are gone with it
x the object Related tab has no standalone "Validations" group
x no anchored group anywhere routes standalone validation authoring
x declares no standalone validation resource registration
x does not carry the stale "standalone variants do exist" justification
x records the retirement where the registration used to be
/ non-vacuity: the registry IS populated and other standalone kinds are in it
/ `__object_validation` is still anchored at object
/ its group is reachable from the object Related tab
/ the drawer still hands the embedded editor its `editAs`
/ previews/index.ts still registers ValidationPreview
```

⚠️ **The first pass of this reverse verification was 5 red, not 7 — and the two that stayed green were my own vacuous assertions**, fixed in the second commit:

- `not.toMatch(/standalone variants do exist/)` never matched, because the comment it guards **wraps across two lines** in the source.
- `toMatch(/ADR-0088/)` was already satisfied by the neighbouring `trigger` retirement note, so it passed on a file that still registered the door.

Both now assert wording unique to this retirement. This is the whole reason the fix is taken out and the pins re-run rather than reasoned about.

**2. `EmbeddedItemEditor.tsx` reverted → `EmbeddedItemEditor.preview.test.tsx`: 4 red, 4 controls green** (predicted red)

```
x renders the rule label - objectstack#7427 `validation.label`
x renders the rule description - `validation.description`
x renders the rule tags - `validation.tags`
x renders the type-specific body, not just the envelope
/ `validation` still has a registered preview after the standalone retirement
/ control: a sub-type with no preview is genuinely unregistered
/ ALONGSIDE, not instead of: the SchemaForm is still mounted and editable
/ renders the editor with no preview chrome   (the `index` control)
```

**3. `ValidationPreview.tsx` reverted → `ValidationPreview.test.tsx`: 1 red, 2 partners green — a deliberately partial direction**

Only the render assertion flips. The two schema-probe assertions stay green on the reverted file **by design**: they measure `ValidationRuleSchema`, not this repo's file, so restoring the pill cannot move them. Reporting them as "should have gone red" would misdescribe what they pin.

```
x the preview paints no object pill even when a draft carries the key
/ the schema rejects `object` by name - this is why the read is gone
/ non-vacuity: the same draft WITHOUT `object` is not rejected for its keys
```

## Two test-harness notes worth the next reader's time

Both cost a lap here and neither is a product defect:

- **The pin cannot go through `MetadataDetailDrawer`.** The drawer wraps the editor in a Radix `Sheet`, which never settles under the light DOM setup — the identical assertions through `< MetadataDetailDrawer >` ran past 540s with no output, while `EmbeddedItemEditor` alone renders in ~6s. `EmbeddedItemEditor` *is* the entirety of the drawer's embedded branch, so the pin mounts it directly and the drawer's half (that it forwards `editAs`) is asserted off source text in the sibling pin. Both halves of the path are covered, neither by a hanging render.
- **The pin's form schema must not declare a `condition` property.** `SchemaForm`'s `CONDITION_FIELD_NAMES` routes that name to the CEL `ConditionWidget`, whose formula loader is a dynamic import — the unbounded-module-load trap AGENTS.md §测试纪律 describes. Bisected: schemas with `name` / `label` render in ~44ms, the same schema plus `condition` never settles. The rule's `condition` is asserted on the preview instead, where it is read straight off the draft.

## Gates

- `pnpm exec vitest run packages/app-shell/` — **337 files / 3195 passed, 1 skipped**
- `pnpm --filter @object-ui/app-shell type-check` — clean (`tsc --noEmit` + typetests)
- `pnpm --filter @object-ui/app-shell lint` — **0 errors** (2262 pre-existing warnings repo-wide; none on the changed lines)
- `node scripts/check-control-bytes.mjs` — OK, 3948 files
- `node scripts/check-changeset-no-major.mjs` — OK
- Changeset: `.changeset/retire-standalone-validation-resource-4132.md`, `@object-ui/app-shell: patch`, matching #4131's precedent for a preview-surface removal. **Not** `skip-changeset` (#3724).

## Orphaned artifacts — swept, nothing stranded

- `ValidationPreview.tsx` / `.test.tsx`: **not** orphaned under shape B — the renderer moved to the embedded path, so both stay (with the `object` case replaced).
- i18n: no key was used only by the standalone route, so none went dead. `TYPE_LABELS_EN/ZH.validation` ('Validation Rule' / 校验规则) stays live — the kind still exists as an embedded sub-type via `editAs: 'validation'`. No i18n change, so no i18n gate applies.
- Docs: swept `content/docs/**` for the standalone validation resource (`metadata/validation`, `Validations`, `registerMetadataResource`). No page documents it; the hits for "validation" are all form-field validation. Nothing to correct, and `content/docs/releases/` untouched.
- No other in-repo consumer references the retired registration (`createConformance.test.ts` reads the registry live, so it simply stops seeing the type).

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
