### PR TITLE
fix(console): a Setup-only environment lands on /home, not the all-zero System Overview

### DIFF
--- a/.changeset/sso-landing-setup-only-home-4048.md
+++ b/.changeset/sso-landing-setup-only-home-4048.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/console': patch
+---
+
+fix(console): a Setup-only environment lands on `/home`, not Setup's all-zero System Overview
+
+A new builder arriving on a just-created environment (platform SSO, no explicit
+target) landed on Setup's **System Overview** — a platform-health/audit
+dashboard reading all zeros, because a fresh environment has no audit history
+yet. The intended first screen is the environment's own home: build with AI,
+start from a template, Your apps.
+
+The path was `resolveLandingPath`'s rule 2. Measured end to end:
+
+    /  →  RootLandingRedirect  →  resolveLandingPath([setup])
+       →  rule 2 "single visible app"  →  /apps/setup
+       →  AppContent.resolveLandingRoute() → the app's first nav item
+       →  dashboard/system_overview
+
+Rule 2 itself is right — a one-app PRODUCT deployment should not have to click
+through a one-tile launcher. Setup is not that app: it is the platform
+administration console that `@objectstack/platform-objects` ships into every
+deployment, so "the only app this viewer can see is Setup" means *this
+environment has no product apps yet*, not *Setup is the product*. Under ADR-0075
+the environment layer's home is the environment's own responsibility, so that
+case now resolves `/home`.
+
+Deliberately narrow — everything else is byte-identical:
+
+- a declared landing still wins (rule 1, `isDefault`, untouched): an admin
+  console that genuinely wants Setup first says so, and gets it;
+- a one-app product deployment still lands in its app;
+- `[product, setup]` still resolves `/home` exactly as before — Setup is
+  excluded from the single-app *outcome*, never from the visible *count*;
+- the `/setup` deep link is unchanged: `/` is "an arrival with no target",
+  `/setup` is an explicit one, and it still resolves into Setup.

--- a/apps/console/src/components/RootLandingRedirect.test.ts
+++ b/apps/console/src/components/RootLandingRedirect.test.ts
@@ -53,6 +53,80 @@ describe('resolveLandingPath', () => {
     expect(resolveLandingPath([{ name: 'a' }, { name: 'b' }])).toBe('/home');
   });
 
+  // ── objectui#4048 — Setup is not a "one-app deployment" ──────────────
+  //
+  // A new builder arriving on a just-created environment (platform SSO, no
+  // explicit target) landed on Setup's System Overview — an audit/health
+  // dashboard reading all zeros, because a fresh environment HAS no audit
+  // history. The chain, measured end to end:
+  //
+  //   `/` → RootLandingRedirect → resolveLandingPath([setup])
+  //       → rule 2 "single visible app" → `/apps/setup`
+  //       → AppContent.resolveLandingRoute() → first nav item
+  //       → `dashboard/system_overview`
+  //
+  // Rule 2 is right — a one-app PRODUCT deployment shouldn't have to click
+  // through a one-tile launcher (#2027). Setup is not that app: it is the
+  // platform administration console shipped by @objectstack/platform-objects
+  // into every deployment, so "the only app I can see is Setup" means "this
+  // environment has no product apps yet", not "Setup is the product". Under
+  // ADR-0075 the environment layer's home is the environment's own
+  // responsibility, and `/home` — build-with-AI, start-from-a-template, Your
+  // apps — is that home.
+  describe('objectui#4048 — a Setup-only deployment lands on the env home', () => {
+    const SETUP = { name: 'setup', _packageId: 'com.objectstack.setup' };
+
+    it('THE FIX: Setup as the only visible app resolves /home, not the audit dashboard', () => {
+      expect(resolveLandingPath([SETUP])).toBe('/home');
+    });
+
+    it('matches Setup by package id even when it carries a different name', () => {
+      // ADR-0048 keys the app on its package id; the name is a per-tenant alias.
+      expect(resolveLandingPath([{ name: 'platform_admin', _packageId: 'com.objectstack.setup' }])).toBe(
+        '/home',
+      );
+    });
+
+    it('matches a package-less Setup by name — runtime/DB apps carry no _packageId', () => {
+      // Same fallback order `resolveSetupAppPath` uses, so the two resolvers
+      // cannot disagree about which app is Setup.
+      expect(resolveLandingPath([{ name: 'setup' }])).toBe('/home');
+    });
+
+    it('still lands in Setup when the deployment DECLARES it (ADR-0075 wins over the default)', () => {
+      // The declared landing is the escape hatch: an admin-console deployment
+      // that genuinely wants Setup as its first screen says so with
+      // `isDefault`, and rule 1 is deliberately untouched by this fix.
+      expect(resolveLandingPath([{ ...SETUP, isDefault: true }])).toBe('/apps/setup');
+    });
+
+    it('CONTROL: a one-app PRODUCT deployment still lands in its app (#2027 rule 2 intact)', () => {
+      expect(resolveLandingPath([{ name: 'crm' }])).toBe('/apps/crm');
+    });
+
+    it('CONTROL: Setup alongside a product app is unchanged — this fix only reads the SINGLE-app case', () => {
+      // Every real deployment ships Setup. Excluding it from the *count* would
+      // silently re-route `[crm, setup]` from /home into /apps/crm — a far
+      // bigger behavior change than this card asks for, and not this fix.
+      expect(resolveLandingPath([{ name: 'crm' }, SETUP])).toBe('/home');
+      expect(resolveLandingPath([{ name: 'crm' }, SETUP, { name: 'showcase' }])).toBe('/home');
+    });
+
+    it('CONTROL: a product app stays the landing when Setup is hidden/inactive beside it', () => {
+      expect(resolveLandingPath([{ name: 'crm' }, { ...SETUP, hidden: true }])).toBe('/apps/crm');
+    });
+
+    it('Studio alone is deliberately NOT redirected — the workbench IS a builder surface', () => {
+      // Scoped to Setup on purpose. Landing a builder in Studio is defensible
+      // (it is where you build); landing them on an all-zero audit dashboard is
+      // not. Widening this to every platform app is a separate judgment call
+      // that this card does not authorize.
+      expect(resolveLandingPath([{ name: 'studio', _packageId: 'com.objectstack.studio' }])).toBe(
+        '/apps/studio',
+      );
+    });
+  });
+
   it('falls back to /home when there are no apps', () => {
     expect(resolveLandingPath([])).toBe('/home');
     expect(resolveLandingPath(null)).toBe('/home');

--- a/apps/console/src/components/RootLandingRedirect.tsx
+++ b/apps/console/src/components/RootLandingRedirect.tsx
@@ -17,7 +17,9 @@
  *      be selectable with `homePageId`, retired in spec 17.0.0
  *      (objectstack#4667 / #4709);
  *   2. else the single visible App (`active !== false && hidden !== true`)
- *      → `/apps/<it>` (a one-app deployment shouldn't show a one-tile launcher);
+ *      → `/apps/<it>` (a one-app deployment shouldn't show a one-tile launcher)
+ *      — UNLESS that one App is the platform's built-in Setup console, which
+ *      means the environment has no product apps yet (objectui#4048, below);
  *   3. else `/home` — the multi-app workspace launcher (the legacy default).
  *
  * NOTE: this gives `isDefault` ROUTING semantics; it was previously a
@@ -28,7 +30,12 @@
  */
 
 import { Navigate } from 'react-router-dom';
-import { useMetadata, LoadingFallback } from '@object-ui/app-shell';
+import {
+  useMetadata,
+  LoadingFallback,
+  SETUP_APP_PACKAGE_ID,
+  SETUP_APP_NAME,
+} from '@object-ui/app-shell';
 
 /** Minimal shape this resolver needs off each App metadata record. */
 interface LandingApp {
@@ -36,6 +43,20 @@ interface LandingApp {
   isDefault?: boolean;
   active?: boolean;
   hidden?: boolean;
+  /** ADR-0048 owning package — the canonical identity of a shipped app. */
+  _packageId?: string;
+}
+
+/**
+ * Is this the platform's built-in Setup console (objectui#4048)?
+ *
+ * Package id first, app name as the fallback — the SAME order
+ * `resolveSetupAppPath` resolves Setup in, so the `/` landing policy and the
+ * `/setup` deep link cannot disagree about which app Setup is. A runtime/DB
+ * app carries no `_packageId`, which is why the name alias is kept.
+ */
+function isPlatformSetupApp(app: LandingApp): boolean {
+  return app._packageId === SETUP_APP_PACKAGE_ID || app.name === SETUP_APP_NAME;
 }
 
 /**
@@ -49,9 +70,32 @@ export function resolveLandingPath(apps: readonly LandingApp[] | null | undefine
   const defaultApp = list.find((a) => a.isDefault === true);
   if (defaultApp) return `/apps/${defaultApp.name}`;
 
-  // 2. A single-app deployment lands straight in that App (no one-tile launcher).
+  // 2. A single-app deployment lands straight in that App (no one-tile
+  //    launcher) — but Setup alone is NOT a one-app deployment.
+  //
+  //    objectui#4048: a new builder arriving on a just-created environment
+  //    landed on Setup's System Overview, an audit/health dashboard reading all
+  //    zeros because a fresh environment has no audit history yet. The path was
+  //    this rule: the only app such a viewer can see is the platform
+  //    administration console that @objectstack/platform-objects ships into
+  //    EVERY deployment, so `visible.length === 1` was true and the resolver
+  //    read it as "this deployment's product is Setup". `/apps/setup` then
+  //    resolves to the app's first navigation item (`AppContent
+  //    .resolveLandingRoute`), which for Setup is `dashboard/system_overview`.
+  //
+  //    "The only app I can see is Setup" means the environment has no product
+  //    apps yet — and under ADR-0075 the environment layer's home is the
+  //    environment's own responsibility, which is `/home` (build with AI, start
+  //    from a template, Your apps). Rule 1 is deliberately left alone: a
+  //    deployment that genuinely wants Setup as its first screen DECLARES it
+  //    with `isDefault`, and a declared landing still wins.
+  //
+  //    Scoped to the SINGLE-app case on purpose. Dropping Setup from the
+  //    `visible` count instead would re-route every ordinary `[product, setup]`
+  //    deployment from `/home` into the product app — a far larger change than
+  //    this card asks for, and one nobody measured.
   const visible = list.filter((a) => a.active !== false && a.hidden !== true);
-  if (visible.length === 1) return `/apps/${visible[0].name}`;
+  if (visible.length === 1 && !isPlatformSetupApp(visible[0])) return `/apps/${visible[0].name}`;
 
   // 3. Multi-app default: the workspace launcher.
   return '/home';

--- a/apps/console/src/components/SetupRoute.test.tsx
+++ b/apps/console/src/components/SetupRoute.test.tsx
@@ -249,6 +249,24 @@ describe('/setup deep link — the routed chain', () => {
     expect(pathname()).toBe('/setup');
   });
 
+  it('CONTROL (objectui#4048): the deep link still wins on a Setup-ONLY deployment', async () => {
+    // #4048 changed `resolveLandingPath([setup])` from `/apps/setup` to
+    // `/home`, so this is the one app list where the two policies could be
+    // confused for each other. They are different questions and must stay
+    // that way: `/` is "where does an arrival with NO target belong" (the env
+    // home), `/setup` is an EXPLICIT target and still resolves into Setup.
+    // Asserted on the same list the fix redirects, because a control drawn
+    // from a multi-app list could not have caught a regression here.
+    auth = { isAuthenticated: true, isLoading: false, user: { id: 'u1' } };
+    apps = [SETUP_APP];
+    expect(resolveLandingPath([SETUP_APP])).toBe('/home');
+
+    renderSetupDeepLink();
+    expect(await screen.findByTestId('app-subtree')).toBeInTheDocument();
+    expect(pathname()).toBe('/apps/com.objectstack.setup');
+    expect(screen.queryByTestId('home-launcher')).not.toBeInTheDocument();
+  });
+
   it('a viewer whose metadata has no Setup app gets "app not available", not home', async () => {
     // `SETUP_APP.requiredPermissions = ['setup.access']`, so this is a normal
     // permission outcome. The target is the canonical package-id URL, which


### PR DESCRIPTION
Fixes #4048

The card is 25 days old and carries a standing injunction from its source thread
(objectstack-ai/objectstack#3083): a 2026-07-17 local prod-like rig failed to reproduce the
landing symptom for either a fresh user or a platform admin, and every triage round since
repeated ⛔ 不要盲改 `RootRedirect` / `sso-exchange`. So both halves were premise-checked
before any edit, and they resolved differently: **half 1 reproduces and is fixed here;
half 2's stated cause is disproven and its real cause already shipped.**

## Half 1 — the measured resolution chain

There is no `callbackURL` or SSO surface in this repo at all (grep over
`apps/console/src` + `packages/app-shell/src` finds only a verify-email usage), so the
console-side question is purely the default-route resolution. For an authenticated
arrival with no explicit target:

```
/                                   apps/console/src/App.tsx:349
  → RootLandingRedirect             apps/console/src/components/RootLandingRedirect.tsx
  → resolveLandingPath([setup])
      rule 1 isDefault              — no match: platform-objects ships setup/studio/account
                                      all with `isDefault: false`
      rule 2 single visible app     — MATCHES → `/apps/setup`
  → AppContent.resolveLandingRoute()   packages/app-shell/src/console/AppContent.tsx:944
  → the app's first navigation item
  → dashboard/system_overview       platform-objects setup-nav.contributions.ts:38
                                      (`group_overview` → `nav_system_overview`)
```

That last address is the one the card reported, and it is independently recorded in
`setupRedirectTarget.test.tsx:17` as where objectui#2794 landed. The symptom is reachable
on this tip whenever the viewer's visible app set is exactly Setup — `account` is
`hidden: true`, and `studio` is withheld from anyone without `studio.access`, so a viewer
holding `setup.access` alone sees exactly one app. That also explains the 07-17
non-reproduction without contradicting it: the rig's users saw Setup **and** Studio, i.e.
two visible apps, which rule 3 already sends to `/home`.

### The fix, and why it is this narrow

Rule 2 is right — a one-app **product** deployment should not have to click through a
one-tile launcher (#2027). Setup is not that app: it is the platform administration
console that `@objectstack/platform-objects` ships into every deployment, so "the only app
this viewer can see is Setup" means *this environment has no product apps yet*, not *Setup
is the product*. Under ADR-0075 the environment layer's home is the environment's own
responsibility, and `/home` — build with AI, start from a template, Your apps — is that
home. Setup is excluded from the single-app **outcome**, never from the visible **count**:

| visible apps | before | after |
|---|---|---|
| `[setup]` | `/apps/setup` → System Overview | **`/home`** |
| `[setup]` with `isDefault: true` | `/apps/setup` | `/apps/setup` (unchanged — a declared landing wins) |
| `[crm]` | `/apps/crm` | `/apps/crm` (unchanged — rule 2 intact) |
| `[crm, setup]` | `/home` | `/home` (unchanged) |
| `[studio]` | `/apps/studio` | `/apps/studio` (unchanged — deliberate, see below) |
| `[]` | `/home` | `/home` (unchanged) |

Dropping Setup from the *count* instead would re-route every ordinary `[product, setup]`
deployment out of `/home` and into the product app — a far larger change than this card
asks for, and one nobody measured. Studio alone is deliberately left landing in Studio:
the workbench IS a builder surface, so that is defensible where an all-zero audit
dashboard is not, and widening this to every platform app is a judgment call this card
does not authorize.

`isPlatformSetupApp` resolves Setup by package id first and app name second — the same
order `resolveSetupAppPath` uses — so the `/` landing policy and the `/setup` deep link
cannot disagree about which app Setup is.

### #4180 / #4186 interaction

- **#4180's `/setup` deep link is untouched and pinned as a control** on the very app list
  this fix redirects: `/` is "an arrival with no target" (the env home), `/setup` is an
  explicit target and still resolves to `/apps/com.objectstack.setup`.
- **#4186's first-run wizard exit** hands off to this same resolver
  (`SetupPage.tsx:43`, `POST_BOOTSTRAP_EXIT = '/'`), so a freshly bootstrapped owner also
  stops landing on the all-zero dashboard. Same direction, no conflict.

## Half 2 — premise disproven, real cause already shipped

The card asks for Total Users to become "a real `sys_user` count, 统计口径基于审计事件?".
It already is one, and always was. The widget is authored in the **framework**, not here —
`packages/platform-objects/src/apps/dashboards/system_overview.dashboard.ts:31-39`:

```ts
id: 'widget_total_users',
dataset: 'sys_user_metrics', values: ['user_count'],
```

`sys_user_metrics`, not `sys_audit_log_metrics` — the audit-derived widgets are the other
ones (Login Events, Permission Changes, Config Changes, the pies and the table). So the
count was never audit-derived and there is nothing to re-point.

The reason it *read* 0 is a different defect, and it is **already fixed in this repo**: the
dashboard declares `globalFilters: [{ field: 'created_at', type: 'date', defaultValue:
'last_7_days' }]`, and that bare preset name was passed through raw instead of being lifted
to a range, so `buildFilterCondition` fell into its "a bare string date means equality on
that day" branch and the backend compiled

```
SELECT COUNT(*) AS "user_count" FROM "sys_user" WHERE created_at = $1
```

verified against a live server, with an actual `sys_user` count of 4 — 200 OK, zero rows,
no error anywhere, which is also why *every* KPI tile read 0 and the period selector said
"All time". `normalizeDateDefault` in `packages/core/src/utils/dashboard-filters.ts` now
applies the same lift the sibling `dateRange` declaration always received (commit b414983,
objectstack#4475), pinned by `dashboard-filters.test.ts` "[#4475] lifts a date filter's
preset-name default to { preset }" and `DashboardFilterBar.dateDefault.test.tsx` "shows the
declared preset, not All time".

Both of the card's symptoms — the all-zeros dashboard *and* Total Users reading 0 — are that
one bug. No change is made for half 2 because none is needed, in either repo.

## Tests

Red-first, then reverse-verified by reverting only the source and keeping the tests:
**4 red exactly** (the 3 fix pins plus the new deep-link control), **27 green** — every
control held, which is what proves they are not passing because of the fix.

- `pnpm --filter '@object-ui/console^...' build` — build closure green before judging anything
- `vitest run apps/console packages/app-shell` — **374 files, 3596 passed, 1 skipped, 0 failed**
- `pnpm --filter @object-ui/console --filter @object-ui/app-shell type-check` — Done, both
- `eslint` on the three changed files — 0 errors (1 pre-existing `react-refresh` warning:
  the file already exported both the resolver and the component on `main`)
- `pnpm check:control-bytes` — OK, 3965 files; plus a direct escape-range self-scan of the
  four touched files, clean

No copy changed, so the i18n gates have no new surface. Changeset: patch for
`@object-ui/console`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_