### PR TITLE
feat(app-shell): build the language menu from the app's locale list

### DIFF
--- a/.changeset/locale-menu-from-app-4039.md
+++ b/.changeset/locale-menu-from-app-4039.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/i18n': minor
+'@object-ui/app-shell': patch
+'@object-ui/console': patch
+---
+
+The console's language menu now asks the app which locales it actually ships, instead of always offering the same ten.
+
+`LocaleSwitcher` built its items from a module-level `LANGUAGES` constant — exactly the ten codes `@object-ui/i18n` ships packs for — and never consulted the app, even though `GET /api/v1/i18n/locales` has been serving that list all along. It failed in both directions at once. An app shipping a locale outside those ten (`th`, a regional `pt-BR`) had no way to be selected from the console: the bundle could be complete and lint clean, and the menu simply had no entry for it. An app shipping only `en` and `zh` still listed all ten, so picking 日本語 handed the user the console's own chrome in Japanese with everything app-authored in the fallback language — a half-translated UI its author never opted into.
+
+The menu is now the **intersection**: the app's own locale list ∩ what the renderer can actually resolve (built-in packs, `config.resources`, and — for an app that wires a dynamic `loadLanguage` loader, which is how the console gets its packs — the locales that loader can fetch). Both failure directions close in the same change: an app-shipped locale becomes offerable, and locales the app does not ship disappear. The endpoint is reached through a new `loadLocales` prop on `I18nProvider`, wired exactly like the existing `loadLanguage`: the app owns the transport, the provider owns what is done with the answer. An app that does not wire it keeps today's menu unchanged.
+
+**The restore validation widened in lockstep, because otherwise this fix would have minted the next bug.** A restored language was validated against "the locales this provider can produce" — built-in packs plus `config.resources` — a bound that was correct only for as long as the menu offered exactly the built-in ten. The moment the menu grows to the app's real list, a locale the user can now pick is a locale that bound rejects, so a user-picked app locale would have been purged on the next page load. It now also accepts a locale a wired dynamic loader may be able to fetch, and the bound stays honest rather than absent: only well-formed BCP-47 tags qualify (`constructor`, `__proto__`, `en_US` are still rejected, as is any stored locale in an app with no loader), and the app's own locale list adjudicates the choice for real once it arrives — a locale the app has since dropped is reverted and purged rather than left locking the UI to a language with no translations.
+
+Labels come from the built-in native names where they exist (`中文`, `日本語`, … are unchanged) and from `Intl.DisplayNames` for everything else, so an app locale is named in its own language rather than by its code. The endpoint's own `label` is deliberately not used for display: the server sets it to the code echoed back, which would have put `th` in the menu where `ไทย` belongs.
+
+While the app's list is in flight the switcher renders nothing, following the sibling menus in the same folder — the ten never flash past on an app that only ships two. When there is no backend, the endpoint fails, or the app answers with nothing this renderer can produce, the built-in ten remain as the offline fallback, so the menu is never empty and never unusable.

--- a/apps/console/src/loadLocales.test.ts
+++ b/apps/console/src/loadLocales.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `loadLocales` — reading the app's locale list off `GET /api/v1/i18n/locales`
+ * (objectui#4039).
+ *
+ * The endpoint answers with locale *descriptors*, not bare codes, and the
+ * descriptor's `label` is the code echoed back (`toLocaleDescriptors` in
+ * @objectstack/spec sets `label: code`). Both facts are pinned here: the parse
+ * reads `code`, and nothing downstream is tempted to treat `label` as a display
+ * name.
+ *
+ * Every failure path returns `[]` — the provider reads that as "I don't know"
+ * and falls back to the built-in packs, so a language menu can never take the
+ * console down.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loadLocales } from './loadLocales';
+
+function respond(json: unknown, ok = true, status = 200) {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok, status, json: async () => json })));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('loadLocales', () => {
+  it('reads codes out of the spec REST envelope', async () => {
+    respond({
+      data: {
+        locales: [
+          { code: 'en', label: 'en', isDefault: true },
+          { code: 'zh', label: 'zh', isDefault: false },
+          { code: 'th', label: 'th', isDefault: false },
+        ],
+      },
+    });
+
+    await expect(loadLocales()).resolves.toEqual(['en', 'zh', 'th']);
+  });
+
+  it('accepts the un-enveloped body a mock server may return', async () => {
+    respond({ locales: [{ code: 'en' }, { code: 'pt-BR' }] });
+
+    await expect(loadLocales()).resolves.toEqual(['en', 'pt-BR']);
+  });
+
+  it('tolerates a bare string array from an older mock', async () => {
+    respond(['en', 'ja']);
+
+    await expect(loadLocales()).resolves.toEqual(['en', 'ja']);
+  });
+
+  it('drops entries with no usable code, and de-duplicates', async () => {
+    respond({ data: { locales: [{ code: 'en' }, { label: 'no code' }, { code: '' }, { code: 'en' }] } });
+
+    await expect(loadLocales()).resolves.toEqual(['en']);
+  });
+
+  it('returns [] on a non-OK response', async () => {
+    respond({}, false, 503);
+
+    await expect(loadLocales()).resolves.toEqual([]);
+  });
+
+  it('returns [] when there is no backend at all', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+
+    await expect(loadLocales()).resolves.toEqual([]);
+  });
+
+  it('returns [] on a payload that is not a list', async () => {
+    respond({ data: { locales: 'en,zh' } });
+
+    await expect(loadLocales()).resolves.toEqual([]);
+  });
+});

--- a/apps/console/src/loadLocales.ts
+++ b/apps/console/src/loadLocales.ts
@@ -1,0 +1,49 @@
+/**
+ * Load the list of locales this app actually ships (objectui#4039).
+ *
+ * The @objectstack/spec REST API (`GET /api/v1/i18n/locales`) answers with the
+ * standard envelope wrapping locale *descriptors*, not bare codes:
+ * `{ data: { locales: [{ code, label, isDefault }] } }` — the shape
+ * `GetLocalesResponseSchema` declares and both serving surfaces (the runtime
+ * dispatcher's `/i18n` domain and `service-i18n`'s own route) emit through the
+ * shared `toLocaleDescriptors`. Only `code` is read here: that helper sets
+ * `label` to the code itself, so the descriptor's label is not a display name
+ * and the switcher names locales for itself.
+ *
+ * Sibling of {@link ./loadLanguage.ts} and deliberately the same shape — same
+ * `VITE_SERVER_URL` base, same envelope-first / flat-fallback parse for mock
+ * and local-dev servers, same degrade-quietly contract. A language menu is
+ * never worth taking the console down for: every failure returns `[]`, which
+ * the provider reads as "I don't know" and answers with the built-in packs.
+ */
+
+export async function loadLocales(): Promise<string[]> {
+  try {
+    const serverUrl = import.meta.env.VITE_SERVER_URL || '';
+    const res = await fetch(`${serverUrl}/api/v1/i18n/locales`);
+    if (!res.ok) {
+      console.warn(`[i18n] Failed to load the app locale list: HTTP ${res.status}`);
+      return [];
+    }
+    const json = await res.json();
+    // Unwrap the spec REST API envelope when present; mock / local-dev servers
+    // may answer with the bare `{ locales: [...] }` body or a plain array.
+    const raw = json?.data?.locales ?? json?.locales ?? json;
+    if (!Array.isArray(raw)) {
+      console.warn('[i18n] Unexpected /i18n/locales payload; ignoring.');
+      return [];
+    }
+    const codes: string[] = [];
+    for (const entry of raw) {
+      // Descriptors are the contract; a bare string is tolerated only because
+      // `getLocales()` hands back `string[]` and older mocks pass it straight
+      // through — the very drift the shared descriptor mapping exists to stop.
+      const code = typeof entry === 'string' ? entry : entry?.code;
+      if (typeof code === 'string' && code.length > 0 && !codes.includes(code)) codes.push(code);
+    }
+    return codes;
+  } catch (err) {
+    console.warn('[i18n] Failed to load the app locale list:', err);
+    return [];
+  }
+}

--- a/apps/console/src/main.tsx
+++ b/apps/console/src/main.tsx
@@ -13,6 +13,7 @@ import { MobileProvider, generatePWAManifest } from '@object-ui/mobile';
 import { registerPlaceholders } from '@object-ui/components';
 import { initSentry, initRuntimeConfig, getProductName, getProductShortName, getFaviconUrl, getPwaDescription, getPwaThemeColor } from '@object-ui/app-shell';
 import { loadLanguage } from './loadLanguage';
+import { loadLocales } from './loadLocales';
 import { preflightAuth } from './lib/auth-preflight';
 
 const AUTH_URL = `${import.meta.env.VITE_SERVER_URL || ''}/api/v1/auth`;
@@ -111,7 +112,7 @@ Promise.all([
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <MobileProvider pwa={{ enabled: true, name: getProductName(), shortName: getProductShortName() }}>
-        <I18nProvider loadLanguage={loadLanguage}>
+        <I18nProvider loadLanguage={loadLanguage} loadLocales={loadLocales}>
           <App />
         </I18nProvider>
       </MobileProvider>

--- a/packages/app-shell/src/layout/LocaleSwitcher.tsx
+++ b/packages/app-shell/src/layout/LocaleSwitcher.tsx
@@ -3,6 +3,14 @@
  *
  * Dropdown menu for switching the application language.
  * Uses the i18n context to change language at runtime.
+ *
+ * The menu is not a list of its own (objectui#4039): it renders whatever the
+ * i18n provider says is offerable — the app's own locale list ∩ what the
+ * renderer can resolve. This file owns only the *labels*, because the native
+ * names of the built-in packs are the one piece of that no API supplies:
+ * `GET /api/v1/i18n/locales` returns descriptors whose `label` is the code
+ * echoed back (`toLocaleDescriptors` in @objectstack/spec), so a server label
+ * would put `th` in the menu where `ไทย` belongs.
  */
 
 import { Globe } from 'lucide-react';
@@ -15,22 +23,64 @@ import {
 } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/i18n';
 
-/** Supported language metadata */
-const LANGUAGES = [
-  { code: 'en', label: 'English' },
-  { code: 'zh', label: '中文' },
-  { code: 'ja', label: '日本語' },
-  { code: 'ko', label: '한국어' },
-  { code: 'de', label: 'Deutsch' },
-  { code: 'fr', label: 'Français' },
-  { code: 'es', label: 'Español' },
-  { code: 'pt', label: 'Português' },
-  { code: 'ru', label: 'Русский' },
-  { code: 'ar', label: 'العربية' },
-] as const;
+/**
+ * Native display names for the built-in language packs.
+ *
+ * Kept by hand rather than derived from `Intl.DisplayNames`: these are the
+ * names the console has always shown, they are stable across ICU versions and
+ * runtimes, and several read better than the CLDR rendering. Any code *not*
+ * in here — an app-shipped locale like `th` or `pt-BR` — is named by
+ * `Intl.DisplayNames` instead. A `Map` rather than an object literal so a code
+ * like `constructor` cannot pick a label off `Object.prototype`.
+ */
+const BUILT_IN_LABELS = new Map<string, string>([
+  ['en', 'English'],
+  ['zh', '中文'],
+  ['ja', '日本語'],
+  ['ko', '한국어'],
+  ['de', 'Deutsch'],
+  ['fr', 'Français'],
+  ['es', 'Español'],
+  ['pt', 'Português'],
+  ['ru', 'Русский'],
+  ['ar', 'العربية'],
+]);
+
+/**
+ * Name a locale in its own language.
+ *
+ * Built-in names win where they exist; everything else goes through
+ * `Intl.DisplayNames` in the locale itself, so a menu of app locales reads the
+ * way the built-in ten always have (native, not translated into the current
+ * UI language). Every failure degrades to the bare code, which is still a
+ * selectable, honest entry: `Intl.DisplayNames` is absent on old runtimes,
+ * throws `RangeError` on a malformed tag, and returns the input unchanged for
+ * a tag it has no name for.
+ */
+export function localeLabel(code: string): string {
+  const builtIn = BUILT_IN_LABELS.get(code);
+  if (builtIn) return builtIn;
+  try {
+    const name = new Intl.DisplayNames([code], { type: 'language' }).of(code);
+    if (!name || name === code) return code;
+    // CLDR names many languages lowercase (`português (Brasil)`); the built-in
+    // labels are capitalized, and a menu mixing both reads as a bug. A no-op
+    // for caseless scripts (ไทย, العربية).
+    return name.charAt(0).toLocaleUpperCase(code) + name.slice(1);
+  } catch {
+    return code;
+  }
+}
 
 export function LocaleSwitcher() {
-  const { t, language, changeLanguage } = useObjectTranslation();
+  const { t, language, changeLanguage, offerableLanguages } = useObjectTranslation();
+
+  // Still asking the app which locales it ships. Render nothing rather than a
+  // fallback list that would be replaced a tick later — the same idiom the
+  // sibling menus in this folder use for data they do not have yet
+  // (`AppSwitcher`, `WorkspaceSwitcher`), and it keeps the ten from flashing
+  // past on an app that only ships two.
+  if (offerableLanguages === null) return null;
 
   return (
     <DropdownMenu>
@@ -41,14 +91,14 @@ export function LocaleSwitcher() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
-        {LANGUAGES.map((lang) => (
+        {offerableLanguages.map((code) => (
           <DropdownMenuItem
-            key={lang.code}
-            onClick={() => changeLanguage(lang.code)}
+            key={code}
+            onClick={() => changeLanguage(code)}
             className="gap-2"
           >
-            {lang.label}
-            {language === lang.code && <span className="ml-auto text-xs">✓</span>}
+            {localeLabel(code)}
+            {language === code && <span className="ml-auto text-xs">✓</span>}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/packages/app-shell/src/layout/__tests__/LocaleSwitcher.appLocales.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/LocaleSwitcher.appLocales.test.tsx
@@ -1,0 +1,164 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * LocaleSwitcher — the menu is the app's locale list, not a constant
+ * (objectui#4039, migrated from objectstack#5418).
+ *
+ * The switcher used to build its items from a module-level `LANGUAGES` array:
+ * exactly the ten codes `@object-ui/i18n` ships packs for, never asking the app
+ * which locales it actually has. That failed in both directions at once —
+ * an app shipping `th` could not offer it from the console at all, and an app
+ * shipping only `en`+`zh` still listed all ten, so picking 日本語 handed the
+ * user a half-translated UI its author never opted into.
+ *
+ * The ruling on the card is INTERSECTION: (the app's `/api/v1/i18n/locales`
+ * response) ∩ (what this renderer can resolve — built-in packs,
+ * `config.resources`, and anything the dynamic loader can fetch). The hardcoded
+ * ten survive only as the offline/no-backend fallback.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+
+// Passthrough dropdown primitives — the open/close choreography is Radix's
+// business; what matters here is which items the menu is built from.
+vi.mock('@object-ui/components', () => ({
+  Button: (p: any) => <button {...p} />,
+  DropdownMenu: (p: any) => <div>{p.children}</div>,
+  DropdownMenuTrigger: (p: any) => <div>{p.children}</div>,
+  DropdownMenuContent: (p: any) => <div>{p.children}</div>,
+  DropdownMenuItem: ({ onClick, children }: any) => <div onClick={onClick}>{children}</div>,
+}));
+vi.mock('lucide-react', () => ({ Globe: () => <span /> }));
+
+import { LocaleSwitcher } from '../LocaleSwitcher';
+
+/** The eight built-in native names an app shipping only `en`+`zh` must NOT show. */
+const PHANTOM_LABELS = ['日本語', '한국어', 'Deutsch', 'Français', 'Español', 'Português', 'Русский', 'العربية'];
+
+/** The console's real wiring: app packs arrive through the dynamic loader. */
+function mountConsole(opts: {
+  locales?: () => Promise<string[]>;
+  resources?: Record<string, Record<string, unknown>>;
+  loader?: boolean;
+}) {
+  return render(
+    <I18nProvider
+      config={{ defaultLanguage: 'en', detectBrowserLanguage: false, resources: opts.resources }}
+      loadLocales={opts.locales}
+      loadLanguage={opts.loader === false ? undefined : async () => ({})}
+    >
+      <LocaleSwitcher />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('LocaleSwitcher — menu composed from the app locale list', () => {
+  it('offers an app-shipped locale outside the built-in ten, named by Intl.DisplayNames', async () => {
+    mountConsole({ locales: async () => ['en', 'zh', 'th'] });
+
+    // `th` has no built-in pack and no hand-written label; CLDR names it.
+    await waitFor(() => expect(screen.getByText('ไทย')).toBeInTheDocument());
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.getByText('中文')).toBeInTheDocument();
+  });
+
+  it('offers an app-shipped locale supplied through config.resources', async () => {
+    mountConsole({
+      locales: async () => ['en', 'th'],
+      resources: { th: { common: { save: 'บันทึก' } } },
+      loader: false,
+    });
+
+    await waitFor(() => expect(screen.getByText('ไทย')).toBeInTheDocument());
+    expect(screen.getByText('English')).toBeInTheDocument();
+  });
+
+  it('names a regional app locale, capitalized like the built-in labels', async () => {
+    mountConsole({ locales: async () => ['en', 'pt-BR'] });
+
+    // The exact CLDR string moves with ICU versions; what this pins is that a
+    // regional tag gets a real display name (not the bare code) and that it
+    // does not arrive lowercase next to `English`.
+    await waitFor(() => expect(screen.queryByText('English')).toBeInTheDocument());
+    const item = screen.getByText((text) => text.startsWith('Portugu'));
+    expect(item.textContent).not.toBe('pt-BR');
+  });
+
+  it('shows ONLY what the app ships — the phantom eight are gone', async () => {
+    mountConsole({ locales: async () => ['en', 'zh'] });
+
+    await waitFor(() => expect(screen.getByText('English')).toBeInTheDocument());
+    expect(screen.getByText('中文')).toBeInTheDocument();
+    for (const phantom of PHANTOM_LABELS) {
+      expect(screen.queryByText(phantom)).not.toBeInTheDocument();
+    }
+  });
+
+  it('falls back to the built-in ten when the endpoint fails', async () => {
+    mountConsole({ locales: async () => { throw new Error('ECONNREFUSED'); } });
+
+    // No backend is not "this app ships nothing" — the switcher must stay
+    // usable, offering everything this renderer can produce on its own.
+    await waitFor(() => expect(screen.getByText('English')).toBeInTheDocument());
+    for (const label of PHANTOM_LABELS) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(screen.getByText('中文')).toBeInTheDocument();
+  });
+
+  it('falls back to the built-in ten when the app answers with nothing usable', async () => {
+    mountConsole({ locales: async () => [] });
+
+    await waitFor(() => expect(screen.getByText('English')).toBeInTheDocument());
+    expect(screen.getByText('日本語')).toBeInTheDocument();
+  });
+
+  it('keeps the built-in native names rather than re-deriving them', async () => {
+    mountConsole({ locales: async () => ['ja', 'ar', 'ru'] });
+
+    // Control: the labels the console has always shown are unchanged, and are
+    // NOT whatever CLDR would produce for these codes.
+    await waitFor(() => expect(screen.getByText('日本語')).toBeInTheDocument());
+    expect(screen.getByText('العربية')).toBeInTheDocument();
+    expect(screen.getByText('Русский')).toBeInTheDocument();
+  });
+
+  it('renders nothing until the app has answered — no flash of the fallback ten', async () => {
+    let answer: (codes: string[]) => void = () => {};
+    const pending = new Promise<string[]>((resolve) => { answer = resolve; });
+    const { container } = mountConsole({ locales: () => pending });
+
+    // In flight: not the ten, not two, nothing at all. The sibling menus in
+    // this folder (AppSwitcher, WorkspaceSwitcher) do the same with data they
+    // do not have yet.
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText('English')).not.toBeInTheDocument();
+
+    answer(['en', 'zh']);
+
+    await waitFor(() => expect(screen.getByText('English')).toBeInTheDocument());
+    expect(screen.queryByText('日本語')).not.toBeInTheDocument();
+  });
+
+  it('offers the built-in ten when no locale endpoint is wired at all', async () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+        <LocaleSwitcher />
+      </I18nProvider>,
+    );
+
+    // An app that never wires `loadLocales` keeps exactly today's menu, with
+    // no blank frame in front of it.
+    expect(screen.getByText('English')).toBeInTheDocument();
+    for (const label of PHANTOM_LABELS) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});

--- a/packages/i18n/src/__tests__/provider-app-locale-restore.test.tsx
+++ b/packages/i18n/src/__tests__/provider-app-locale-restore.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * I18nProvider — a user-picked APP locale survives a reload (objectui#4039).
+ *
+ * The lockstep half of the switcher change, and the card's own warning:
+ * PR objectui#3376 validated a restored language against "the locales this
+ * provider can produce" — built-in packs plus `config.resources`. That bound
+ * was correct precisely *because* the menu offered exactly the built-in ten.
+ * The moment the menu grows to the app's real locale list, a locale the user
+ * can now pick is a locale that bound rejects, and the preference is purged on
+ * the next page load — the next thing that does not survive a reload.
+ *
+ * The console is the case that matters: it wires `loadLanguage` and NO
+ * `config.resources`, so an app pack for `th` lives behind
+ * `GET /api/v1/i18n/translations/th` and is invisible to any synchronous check.
+ *
+ * A "reload" here is an unmount + a fresh `I18nProvider` mount — a new i18next
+ * instance, so anything it knows had to come out of storage.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider, useObjectTranslation, LOCALE_STORAGE_KEY } from '../provider';
+
+/** The console's wiring: app packs fetched on demand, nothing in `resources`. */
+function mountConsole(
+  props: Partial<React.ComponentProps<typeof I18nProvider>> = {},
+  appLocales: string[] | null = ['en', 'zh', 'th'],
+) {
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(I18nProvider, {
+      config: { defaultLanguage: 'en', detectBrowserLanguage: false },
+      loadLanguage: async (lang: string) => (lang === 'th' ? { common: { save: 'บันทึก' } } : {}),
+      ...(appLocales ? { loadLocales: async () => appLocales } : {}),
+      ...props,
+      children,
+    });
+  return renderHook(() => useObjectTranslation(), { wrapper });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('app-locale restore (lockstep with the switcher)', () => {
+  it('restores an app-shipped locale that has no built-in pack', async () => {
+    const first = mountConsole();
+    await act(async () => {
+      await first.result.current.changeLanguage('th');
+    });
+    await waitFor(() => expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('th'));
+    first.unmount();
+
+    // Reload. Before the widening this asserted `en`: `th` is not a built-in
+    // pack and not in `config.resources`, so the restore validation dropped
+    // AND purged it — the user's pick lost on the first F5.
+    const second = mountConsole();
+    expect(second.result.current.language).toBe('th');
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('th');
+  });
+
+  it('restores it in the BOOTSTRAP language, not as a late correction', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'th');
+
+    const { result } = mountConsole();
+
+    // Asserted without waitFor on purpose, same reason as the #5406 suite:
+    // `<html lang>` seeds Accept-Language on every API call (#1319), so a late
+    // switch would fetch the first wave of server-resolved labels in the wrong
+    // locale and then have to remount to fix it.
+    expect(result.current.language).toBe('th');
+  });
+
+  it('keeps rejecting junk that is not a language tag at all', () => {
+    // The widening is "a well-formed tag the loader may be able to fetch", not
+    // "anything in storage". `constructor` is the prototype-pollution probe the
+    // original guard was written for; `en_US` is a malformed tag.
+    for (const junk of ['constructor', '__proto__', 'en_US']) {
+      window.localStorage.setItem(LOCALE_STORAGE_KEY, junk);
+      const { result, unmount } = mountConsole();
+      expect(result.current.language).toBe('en');
+      expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBeNull();
+      unmount();
+    }
+  });
+
+  it('treats an empty stored value as nothing stored', () => {
+    // Not folded into the junk loop above: `''` never reaches the tag check —
+    // `readStoredLanguage` returning `''` is falsy, so the bootstrap reads it
+    // as "no preference" and leaves the (empty, harmless) entry where it is.
+    // Pinned so the distinction is a decision rather than a surprise.
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, '');
+
+    const { result } = mountConsole();
+
+    expect(result.current.language).toBe('en');
+  });
+
+  it('still drops a stale app locale when the app no longer ships it', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'th');
+
+    // The app dropped `th` today. Nothing synchronous can know that, so the
+    // bootstrap accepts it on the loader's credit — and the app's own answer
+    // then adjudicates it. One stale entry must never lock the UI to a locale
+    // with no translations (the invariant the #3376 guard was written for).
+    const { result } = mountConsole({}, ['en', 'zh']);
+
+    await waitFor(() => expect(result.current.language).toBe('en'));
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('does not yank a language the user picked while the list was in flight', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'th');
+
+    const { result } = mountConsole({}, ['en', 'zh']);
+    await act(async () => {
+      await result.current.changeLanguage('ja');
+    });
+
+    // The self-heal undoes exactly our own bootstrap optimism — never a
+    // deliberate in-session choice that has since replaced it.
+    await waitFor(() => expect(result.current.language).toBe('ja'));
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('ja');
+  });
+
+  it('leaves the stored locale alone when the app answers with nothing', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'th');
+
+    // An empty/failed answer is "I don't know", not "I ship no locales" —
+    // a backend outage must not wipe the user's preference.
+    const { result } = mountConsole({}, []);
+
+    await waitFor(() => expect(result.current.language).toBe('th'));
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe('th');
+  });
+
+  it('an app with NO dynamic loader keeps the narrow bound', () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'th');
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(I18nProvider, {
+        config: { defaultLanguage: 'en', detectBrowserLanguage: false },
+        children,
+      });
+    const { result } = renderHook(() => useObjectTranslation(), { wrapper });
+
+    // Nothing can fetch `th` here, so accepting it would be the very "locked to
+    // a locale with no translations" state the guard exists to prevent. The
+    // widening is scoped to apps that wired a loader; every other app keeps
+    // exactly the #3376 behaviour.
+    expect(result.current.language).toBe('en');
+    expect(window.localStorage.getItem(LOCALE_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('offerableLanguages — the intersection the switcher renders', () => {
+  it('is the app list ∩ what this renderer can resolve', async () => {
+    const { result } = mountConsole({}, ['en', 'zh', 'th']);
+
+    await waitFor(() => expect(result.current.offerableLanguages).toEqual(['en', 'zh', 'th']));
+  });
+
+  it('drops an app locale this renderer cannot produce', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(I18nProvider, {
+        config: { defaultLanguage: 'en', detectBrowserLanguage: false },
+        loadLocales: async () => ['en', 'zh', 'th'],
+        children,
+      });
+    const { result } = renderHook(() => useObjectTranslation(), { wrapper });
+
+    // No loader and no `config.resources`: `th` is in the app's list but this
+    // renderer has no way to produce a single string of it.
+    await waitFor(() => expect(result.current.offerableLanguages).toEqual(['en', 'zh']));
+  });
+
+  it('is null while the app list is in flight', () => {
+    const { result } = mountConsole({ loadLocales: () => new Promise<string[]>(() => {}) });
+
+    expect(result.current.offerableLanguages).toBeNull();
+  });
+
+  it('asks the app exactly once, under StrictMode and re-renders alike', async () => {
+    // `main.tsx` mounts the console inside `<React.StrictMode>`, which
+    // double-invokes effects — and an inline `loadLocales` prop changes
+    // identity on every render. Both must still produce ONE request, and the
+    // answer must still land: a guard that skips the re-run while the first
+    // run's request was cancelled would leave the switcher blank forever.
+    const calls = { n: 0 };
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        React.StrictMode,
+        null,
+        React.createElement(I18nProvider, {
+          config: { defaultLanguage: 'en', detectBrowserLanguage: false },
+          loadLocales: async () => {
+            calls.n += 1;
+            return ['en', 'zh'];
+          },
+          children,
+        }),
+      );
+    const { result, rerender } = renderHook(() => useObjectTranslation(), { wrapper });
+
+    await waitFor(() => expect(result.current.offerableLanguages).toEqual(['en', 'zh']));
+    rerender();
+    rerender();
+    expect(calls.n).toBe(1);
+  });
+});

--- a/packages/i18n/src/provider.tsx
+++ b/packages/i18n/src/provider.tsx
@@ -59,15 +59,75 @@ function clearStoredLanguage(): void {
 }
 
 /**
- * Languages `createI18n(config)` will know about: the built-in packs plus any
- * extra `config.resources`.
+ * Languages `createI18n(config)` will know about *synchronously*: the built-in
+ * packs plus any extra `config.resources`.
  *
  * `hasOwnProperty` rather than `in`: a junk stored value like `constructor`
  * would pass an `in` check against the locale map's prototype.
  */
-function isKnownLanguage(lang: string, config?: I18nConfig): boolean {
+function isStaticallyKnownLanguage(lang: string, config?: I18nConfig): boolean {
   const own = Object.prototype.hasOwnProperty;
   return own.call(builtInLocales, lang) || Boolean(config?.resources && own.call(config.resources, lang));
+}
+
+/** The built-in packs' codes, as a stable identity for consumers' dep arrays. */
+const BUILT_IN_LANGUAGE_CODES: readonly string[] = Object.freeze(Object.keys(builtInLocales));
+
+/**
+ * Every language this renderer can produce *without asking the app*: the
+ * built-in packs plus `config.resources`.
+ *
+ * This is the offline/no-backend answer — the set the switcher offers when
+ * there is no `loadLocales` wiring, or when the app's locale endpoint cannot
+ * be reached (objectui#4039).
+ */
+function resolvableLanguages(config?: I18nConfig): string[] {
+  const extra = Object.keys(config?.resources ?? {}).filter(
+    (code) => !BUILT_IN_LANGUAGE_CODES.includes(code),
+  );
+  return [...BUILT_IN_LANGUAGE_CODES, ...extra];
+}
+
+/**
+ * Whether `tag` is a well-formed BCP-47 language tag.
+ *
+ * `Intl.getCanonicalLocales` is the standard's own parser, so this rejects
+ * exactly what a locale code cannot be — `constructor`, `__proto__`, `en_US`,
+ * `''` all throw `RangeError` — while accepting codes no pack exists for yet
+ * (`th`, `pt-BR`). Guarded for runtimes that ship no `Intl`: a language
+ * preference is never worth taking the app down for.
+ */
+function isWellFormedLanguageTag(tag: string): boolean {
+  if (typeof Intl === 'undefined' || typeof Intl.getCanonicalLocales !== 'function') {
+    return /^[A-Za-z]{2,8}(-[A-Za-z0-9]{1,8})*$/.test(tag);
+  }
+  try {
+    return Intl.getCanonicalLocales(tag).length === 1;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether this provider can end up rendering `lang` at all.
+ *
+ * Wider than {@link isStaticallyKnownLanguage} by exactly one case: when a
+ * dynamic {@link I18nProviderProps.loadLanguage} loader is wired, that loader
+ * *is* the mechanism that produces app-shipped locales, and nothing can
+ * enumerate what it will answer for synchronously — the app's pack for `th`
+ * lives behind `GET /api/v1/i18n/translations/th`, not in `config.resources`.
+ *
+ * This is the lockstep half of objectui#4039. The switcher now offers the
+ * app's own locales, so the restore validation had to grow with it or a
+ * user-picked app locale would be purged on the next reload — the exact bug
+ * objectstack#5418 predicted this fix would otherwise mint. The bound stays
+ * honest rather than absent: only well-formed tags qualify, and the app's own
+ * locale list adjudicates the choice for real once it lands (see the
+ * `provisional` self-heal in {@link I18nProvider}).
+ */
+function canResolveLanguage(lang: string, config?: I18nConfig, hasLoader = false): boolean {
+  if (isStaticallyKnownLanguage(lang, config)) return true;
+  return hasLoader && isWellFormedLanguageTag(lang);
 }
 
 /**
@@ -89,18 +149,35 @@ function isKnownLanguage(lang: string, config?: I18nConfig): boolean {
  * A stored value the app no longer offers is dropped *and purged*, so one stale
  * entry can never lock the UI to a locale that has no translations.
  */
+interface BootstrapResolution {
+  /** The config to build the i18next instance from. */
+  config: I18nConfig | undefined;
+  /**
+   * The stored language accepted on the dynamic loader's credit alone — not a
+   * built-in pack, not in `config.resources`. Nothing synchronous can confirm
+   * the app still ships it, so the app's own locale list adjudicates it once
+   * it lands. `null` when the bootstrap language needed no such credit, which
+   * is every case that existed before objectui#4039.
+   */
+  provisional: string | null;
+}
+
 function resolveBootstrapConfig(
   config: I18nConfig | undefined,
   persist: boolean,
-): I18nConfig | undefined {
-  if (!persist) return config;
+  hasLoader: boolean,
+): BootstrapResolution {
+  if (!persist) return { config, provisional: null };
   const stored = readStoredLanguage();
-  if (!stored) return config;
-  if (!isKnownLanguage(stored, config)) {
+  if (!stored) return { config, provisional: null };
+  if (!canResolveLanguage(stored, config, hasLoader)) {
     clearStoredLanguage();
-    return config;
+    return { config, provisional: null };
   }
-  return { ...config, defaultLanguage: stored, detectBrowserLanguage: false };
+  return {
+    config: { ...config, defaultLanguage: stored, detectBrowserLanguage: false },
+    provisional: isStaticallyKnownLanguage(stored, config) ? null : stored,
+  };
 }
 
 interface I18nContextValue {
@@ -112,6 +189,19 @@ interface I18nContextValue {
   direction: 'ltr' | 'rtl';
   /** The underlying i18next instance */
   i18n: I18nInstance;
+  /**
+   * The languages a switcher may offer (objectui#4039): the app's own locale
+   * list ∩ what this renderer can resolve. Computed here because only the
+   * provider knows both sides — the built-in packs, `config.resources` and
+   * whether a dynamic loader is wired.
+   *
+   * `null` means "still asking the app". Consumers render nothing (or a
+   * skeleton) rather than a list they will have to retract a tick later.
+   * Without {@link I18nProviderProps.loadLocales} wiring, or when the app's
+   * endpoint cannot be reached, this is the offline fallback: the built-in
+   * packs plus `config.resources`.
+   */
+  offerableLanguages: readonly string[] | null;
 }
 
 const ObjectI18nContext = createContext<I18nContextValue | null>(null);
@@ -139,6 +229,24 @@ export interface I18nProviderProps {
    * ```
    */
   loadLanguage?: (lang: string) => Promise<Record<string, unknown>>;
+  /**
+   * The app's own locale list — the codes it actually ships translations for
+   * (objectui#4039). Wired the same way as {@link I18nProviderProps.loadLanguage}:
+   * the app owns the transport, the provider owns what is done with the answer.
+   *
+   * The console reads `GET /api/v1/i18n/locales`; see
+   * `apps/console/src/loadLocales.ts`. Without this prop the switcher keeps
+   * offering the built-in packs (plus `config.resources`) exactly as before, so
+   * an app that never wires it is unaffected.
+   *
+   * @example
+   * ```tsx
+   * <I18nProvider loadLanguage={loadLanguage} loadLocales={loadLocales}>
+   *   <App />
+   * </I18nProvider>
+   * ```
+   */
+  loadLocales?: () => Promise<string[]>;
   /**
    * Remember the active language in `localStorage` ({@link LOCALE_STORAGE_KEY})
    * and restore it on the next mount. Default: `true`.
@@ -177,13 +285,21 @@ export function I18nProvider({
   config,
   instance: externalInstance,
   loadLanguage,
+  loadLocales,
   persistLanguage = true,
   children,
 }: I18nProviderProps) {
-  const i18nInstance = useMemo(
-    () => externalInstance || createI18n(resolveBootstrapConfig(config, persistLanguage)),
-    [externalInstance, config, persistLanguage],
-  );
+  // A boolean, not `loadLanguage` itself: an inline arrow would change identity
+  // every render and rebuild the i18next instance (and with it the language)
+  // on each one. What the bootstrap needs to know is only whether a loader
+  // exists at all.
+  const hasLoader = Boolean(loadLanguage);
+  const bootstrap = useMemo(() => {
+    if (externalInstance) return { instance: externalInstance, provisional: null as string | null };
+    const resolved = resolveBootstrapConfig(config, persistLanguage, hasLoader);
+    return { instance: createI18n(resolved.config), provisional: resolved.provisional };
+  }, [externalInstance, config, persistLanguage, hasLoader]);
+  const i18nInstance = bootstrap.instance;
 
   const [language, setLanguage] = useState(i18nInstance.language || 'en');
   const direction = getDirection(language);
@@ -247,6 +363,77 @@ export function I18nProvider({
     });
   }, [i18nInstance, loadLanguage]);
 
+  // The app's own locale list (objectui#4039). `null` = not answered yet; `[]`
+  // = asked and got nothing usable, which is "I don't know", not "I ship no
+  // locales" — both degrade to the offline fallback below.
+  const [appLocales, setAppLocales] = useState<string[] | null>(null);
+
+  // Asked exactly once per provider, guarded by a ref — the same shape as the
+  // `loadedAppLangs` guard on `loadLanguage` above, and for two reasons at
+  // once. An inline `loadLocales={() => …}` changes identity every render, so
+  // without the guard the answer would set state, the re-render would mint a
+  // new arrow, and the new arrow would re-run the effect: a fetch loop. And
+  // StrictMode's double-invoked effect must not fire a second request.
+  //
+  // Deliberately no `cancelled` flag: under StrictMode the cleanup would
+  // cancel the only in-flight request while the re-run declines to start
+  // another, leaving the list permanently unanswered and the switcher
+  // permanently blank. Settling state after unmount is a no-op in React 18 —
+  // which is exactly why the `loadLanguage` effect above does the same.
+  const hasLocaleLoader = Boolean(loadLocales);
+  const askedForLocales = useRef(false);
+
+  useEffect(() => {
+    if (!loadLocales || askedForLocales.current) return;
+    askedForLocales.current = true;
+    loadLocales()
+      .then((codes) => setAppLocales(Array.isArray(codes) ? codes : []))
+      .catch((err) => {
+        // A language menu is not worth an unhandled rejection: fall back to the
+        // locales this renderer can produce on its own.
+        setAppLocales([]);
+        console.warn('[i18n] Failed to load the app locale list:', err);
+      });
+  }, [loadLocales]);
+
+  const offerableLanguages = useMemo<readonly string[] | null>(() => {
+    const fallback = resolvableLanguages(config);
+    // No wiring at all: the built-in packs are the whole truth, as before.
+    if (!hasLocaleLoader) return fallback;
+    if (appLocales === null) return null;
+    const offerable = appLocales.filter((code) => canResolveLanguage(code, config, hasLoader));
+    // An app that answers with nothing this renderer can produce leaves the
+    // user with no way to switch at all — strictly worse than the offline
+    // fallback, so the fallback wins.
+    return offerable.length > 0 ? offerable : fallback;
+  }, [config, hasLocaleLoader, appLocales, hasLoader]);
+
+  // Self-heal: a stored language accepted on the loader's credit alone is
+  // adjudicated by the app's real list once it lands. Without this, widening
+  // the restore validation would reintroduce exactly what it was written to
+  // stop — one stale entry locking the UI to a locale with no translations.
+  // Scoped to our own optimism: only the bootstrap language, only while the
+  // user has not moved on, and never on an empty/failed answer.
+  useEffect(() => {
+    const provisional = bootstrap.provisional;
+    if (!provisional || !appLocales || appLocales.length === 0) return;
+    if (appLocales.includes(provisional)) return;
+    if ((i18nInstance.language || '') !== provisional) return;
+    const revertTo = config?.defaultLanguage || config?.fallbackLanguage || 'en';
+    void (async () => {
+      await i18nInstance.changeLanguage(revertTo);
+      // Purge AFTER the switch, not before: every language change persists
+      // itself (that is the point of the single choke point in the
+      // `languageChanged` handler), so clearing first would just be overwritten
+      // with `revertTo` — recording a preference the user never expressed and
+      // suppressing browser detection from then on. Ending with nothing stored
+      // is what the bootstrap purge has always left behind.
+      // Guarded: if the user picked something in the meantime, that choice is
+      // theirs to keep.
+      if ((i18nInstance.language || '') === revertTo) clearStoredLanguage();
+    })();
+  }, [bootstrap, appLocales, i18nInstance, config]);
+
   const contextValue = useMemo<I18nContextValue>(
     () => ({
       language,
@@ -266,8 +453,9 @@ export function I18nProvider({
       },
       direction,
       i18n: i18nInstance,
+      offerableLanguages,
     }),
-    [language, direction, i18nInstance, loadLanguage],
+    [language, direction, i18nInstance, loadLanguage, offerableLanguages],
   );
 
   return React.createElement(
@@ -303,6 +491,13 @@ export function useObjectTranslation(ns?: string) {
     direction: context?.direction || 'ltr',
     /** The underlying i18next instance */
     i18n,
+    /**
+     * Languages a switcher may offer (objectui#4039). `null` while the app's
+     * locale list is in flight. Outside a provider there is nobody to ask, so
+     * the built-in packs are the answer — not `null`, which would leave a
+     * standalone switcher permanently blank.
+     */
+    offerableLanguages: context ? context.offerableLanguages : BUILT_IN_LANGUAGE_CODES,
   };
 }
 


### PR DESCRIPTION
Fixes #4039

Implements the binding **INTERSECTION** ruling on the card: the switcher offers (the app's `GET /api/v1/i18n/locales` response) ∩ (what the renderer can resolve). The hardcoded ten survive only as the offline/no-backend fallback, and PR #3376's restore validation widens **in this same PR**, as the card's own warning required.

## Premise check (verified on tip, before implementing)

All three parts of the premise held:

- `LocaleSwitcher.tsx` did build its menu from a module-level `LANGUAGES` constant — the ten built-in codes, never consulting the app.
- The restore validation's bound was what #3376 landed: `isKnownLanguage` = built-in packs ∪ `config.resources`.
- **No client accessor existed** for `/api/v1/i18n/locales` (only `/i18n/translations/:locale`, via `apps/console/src/loadLanguage.ts`), so adding a minimal one was in scope per the dispatch. It mirrors that sibling exactly.

## The two sides of the intersection, as implemented

**App side** — a new `loadLocales` prop on `I18nProvider`, wired the same way as the existing `loadLanguage`: the app owns the transport, the provider owns what is done with the answer. `apps/console/src/loadLocales.ts` reads the real producer contract — `GetLocalesResponseSchema` declares `{ data: { locales: [{ code, label, isDefault }] } }`, emitted through the shared `toLocaleDescriptors` by both serving surfaces.

**Renderer side** — built-in packs, `config.resources`, **and** the locales a wired dynamic loader can fetch. That last clause is load-bearing rather than generous: the console wires `loadLanguage` and **no `config.resources`** at all, so its app packs live behind `GET /api/v1/i18n/translations/:locale`. Without it the intersection in the real product would collapse to `appLocales ∩ the built-in ten`, and the card's first failure direction (an app shipping `th`) could never close.

**One predicate serves both sides.** `canResolveLanguage` is simultaneously the menu's right-hand side and the restore bound, so the two cannot drift apart — the lockstep is structural, not a convention someone has to remember. Reverse verification 2 below demonstrates this by construction.

## Lockstep: the restore validation

A locale the user can now pick was a locale the old bound rejected, so the preference would have been purged on the next reload — the exact next bug objectstack#5418 predicted this fix would mint. The bound is widened, not removed:

- only well-formed BCP-47 tags qualify (`Intl.getCanonicalLocales` rejects `constructor`, `__proto__`, `en_US`) — the prototype-pollution guard #3376 wrote still holds;
- only for apps that wired a loader — an app without one keeps #3376's behaviour exactly;
- the app's own list **adjudicates** the choice once it arrives: a locale the app has since dropped is reverted and purged, so the "one stale entry can never lock the UI to a locale with no translations" invariant survives the widening. The purge happens *after* the revert, because every language change persists itself — clearing first would just be overwritten, recording an `en` preference the user never expressed and suppressing browser detection from then on.

## Labels, loading, fallback

Built-in native names are kept where they exist (`中文`, `日本語`, … unchanged); everything else is named by `Intl.DisplayNames` in its own locale. **The endpoint's own `label` is deliberately not used for display** — `toLocaleDescriptors` sets `label: code`, so a server label would put `th` in the menu where `ไทย` belongs. No new i18n keys are added: `check:i18n-drift` reports 0 en values changed, 0 keys added.

While the list is in flight the switcher renders nothing, following the closest existing idiom in the same folder (`AppSwitcher`, `WorkspaceSwitcher` both `return null` for data they do not have yet) — so the ten never flash past on an app that ships two. No backend, a failed endpoint, or an answer with nothing this renderer can produce all fall back to the built-in ten: the menu is never empty.

## Reverse verification

**1 — revert the switcher alone** (`git checkout origin/main -- LocaleSwitcher.tsx`): predicted RED on the intersection and loading pins. Confirmed, 4 failed / 5 passed:

```
× offers an app-shipped locale outside the built-in ten, named by Intl.DisplayNames
× offers an app-shipped locale supplied through config.resources
× shows ONLY what the app ships — the phantom eight are gone
× renders nothing until the app has answered — no flash of the fallback ten
```

The 5 that stayed green are **expected to stay green and were predicted to**: the two fallback pins and the built-in-native-name control cannot go red by reverting the switcher, because the offline fallback *is* the old behaviour. Reported rather than manufactured into a red.

**2 — revert the validation widening alone** (`canResolveLanguage`'s loader clause only, switcher intact): predicted RED on the restore pins. Confirmed, 4 failed / 8 passed:

```
× restores an app-shipped locale that has no built-in pack
× restores it in the BOOTSTRAP language, not as a late correction
× leaves the stored locale alone when the app answers with nothing
× is the app list ∩ what this renderer can resolve
```

I predicted three; the fourth is the informative one. `offerableLanguages` went red too because the same predicate feeds the menu — which is the lockstep proven by construction: you cannot revert the restore half without also shrinking the menu half.

One honest non-red: `still drops a stale app locale when the app no longer ships it` stays green under the narrow bound, because it reaches the same end state through the bootstrap purge instead of the self-heal.

## Tests

New: `LocaleSwitcher.appLocales.test.tsx` (9), `provider-app-locale-restore.test.tsx` (12, incl. a StrictMode single-request pin — `main.tsx` mounts under `React.StrictMode` and an inline prop identity changes every render), `loadLocales.test.ts` (7).

```
packages/i18n/        Test Files 38 passed   Tests 661 passed
packages/app-shell/   Test Files 342 passed  Tests 3250 passed | 1 skipped
type-check (i18n + app-shell + console, turbo)   37 successful, 37 total
lint (same three)                                3 successful, 0 errors
check:control-bytes  OK (3965 tracked text files)   + control-byte self-scan on every touched file: clean
check:i18n-keys      OK      check:i18n-drift  0 en values changed, 0 keys added
changeset:check      OK
```

Changeset: `.changeset/locale-menu-from-app-4039.md` (`@object-ui/i18n` minor, `@object-ui/app-shell` + `@object-ui/console` patch). No `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_