### PR TITLE
fix(analytics): resolve a dotted dimension's select options against the relationship target

### DIFF
--- a/.changeset/dotted-dimension-option-labels-4053.md
+++ b/.changeset/dotted-dimension-option-labels-4053.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/core': patch
+'@object-ui/plugin-dashboard': patch
+'@object-ui/plugin-charts': patch
+---
+
+A dataset dimension on a dotted relationship path now renders its option labels instead of the raw stored enum
+
+A `DatasetDimension` whose `field` is a relationship path (`crm_account.industry`) got no select-option resolution at all: the chart plotted `education`, `finance`, `manufacturing` — the database column, unresolved — while the **same underlying field** reached as a **local** dimension rendered `Education`, `Finance`, `Manufacturing` beside it on the same dashboard. Nothing errored, so the widget just quietly showed database enum values to end users; on a non-English deployment those are words that appear nowhere else in the UI, since every form and list shows the translated label.
+
+The label lookup read options as `baseObject.fields[<path>]`, which only ever matches the local spelling. For a dotted path the options live on the **related** object, so the lookup missed and the renderer fell through to the stored value.
+
+The object-resolution step of that one lookup now walks the path: each segment before the last must be a declared relationship (`lookup` / `master_detail`, target read from `reference` / `reference_to` / `referenceTo` / `reference_to_object`), and the terminal field's options are read off the object that actually owns it. This is the same lookup for both spellings rather than a dotted-path variant beside it — a single-segment path never enters the walk and resolves exactly as before, so the local and joined paths cannot drift apart. Multi-hop paths (`crm_account.owner.department`) resolve too, which is the shape the dataset designer already emits.
+
+Hops ride the caller's existing `GET /meta/object/:name` channel — the same authenticated read that fetched the base object — so no new fetch layer is introduced, and objects are fetched once per resolution even when several dimensions share a prefix. Every failure stays best-effort: a segment that is not a relationship, a target that cannot be loaded, or a terminal field with no options yields no mapping and the raw value survives, exactly as it does today.
+
+Applies to both surfaces that carried this lookup: dashboard dataset widgets (`DatasetWidget`) and the chart view's dataset path (`ObjectChart`).
+
+Scope: this ends at "the label is in hand". Whether that label then passes through the i18n bundle is a separate gap tracked upstream as objectstack#5076.

--- a/packages/core/src/utils/__tests__/chart-series.test.ts
+++ b/packages/core/src/utils/__tests__/chart-series.test.ts
@@ -12,6 +12,8 @@ import {
   buildDimensionLabelMap,
   relabelDimensions,
   buildChartSeries,
+  resolveRelationshipTarget,
+  resolveDimensionFieldOptions,
 } from '../chart-series';
 
 describe('buildOptionColorMap', () => {
@@ -189,5 +191,143 @@ describe('relabelDimensions + buildChartSeries (the value≠label chart bug, clo
       { month: '2025-01', 合作中: 5, 已流失: 1 },
       { month: '2025-02', 合作中: 7 },
     ]);
+  });
+});
+
+describe('resolveRelationshipTarget (objectui#4053)', () => {
+  it('reads the target off every spelling of the reference key', () => {
+    expect(resolveRelationshipTarget({ type: 'lookup', reference: 'crm_account' })).toBe('crm_account');
+    expect(resolveRelationshipTarget({ type: 'lookup', reference_to: 'crm_account' })).toBe('crm_account');
+    expect(resolveRelationshipTarget({ type: 'lookup', referenceTo: 'crm_account' })).toBe('crm_account');
+    expect(resolveRelationshipTarget({ type: 'lookup', reference_to_object: 'crm_account' })).toBe('crm_account');
+    // Array and `{ object }` carriers, both seen on spec-shaped defs.
+    expect(resolveRelationshipTarget({ type: 'lookup', reference: ['crm_account'] })).toBe('crm_account');
+    expect(resolveRelationshipTarget({ type: 'lookup', reference: { object: 'crm_account' } })).toBe('crm_account');
+  });
+
+  it('accepts every master-detail spelling, case-insensitively', () => {
+    for (const type of ['master_detail', 'masterDetail', 'master-detail', 'LOOKUP']) {
+      expect(resolveRelationshipTarget({ type, reference: 'crm_account' })).toBe('crm_account');
+    }
+  });
+
+  it('refuses a NON-relationship field even when it carries a reference-shaped key', () => {
+    // The type gate is what stops a plain field's segment from being turned
+    // into an object name and fetched speculatively.
+    expect(resolveRelationshipTarget({ type: 'select', reference: 'crm_account' })).toBeUndefined();
+    expect(resolveRelationshipTarget({ type: 'lookup' })).toBeUndefined();
+    expect(resolveRelationshipTarget(null)).toBeUndefined();
+    expect(resolveRelationshipTarget('crm_account')).toBeUndefined();
+  });
+});
+
+describe('resolveDimensionFieldOptions (objectui#4053)', () => {
+  const INDUSTRY = [
+    { value: 'education', label: 'Education' },
+    { value: 'finance', label: 'Finance' },
+  ];
+  const OPPORTUNITY = {
+    name: 'crm_opportunity',
+    fields: {
+      stage: { type: 'select', options: [{ value: 'won', label: 'Won' }] },
+      crm_account: { type: 'lookup', reference: 'crm_account' },
+    },
+  };
+  const ACCOUNT = {
+    name: 'crm_account',
+    fields: {
+      industry: { type: 'select', options: INDUSTRY },
+      tier: { type: 'select', options: [{ value: 'a', label: 'A' }] },
+      owner: { type: 'lookup', reference: 'crm_user' },
+      website: { type: 'text' },
+    },
+  };
+  const USER = {
+    name: 'crm_user',
+    fields: { department: { type: 'select', options: [{ value: 'rnd', label: 'R&D' }] } },
+  };
+  const DOCS: Record<string, unknown> = {
+    crm_opportunity: OPPORTUNITY,
+    crm_account: ACCOUNT,
+    crm_user: USER,
+  };
+  /** Records which objects the walk asked for, in order. */
+  const makeLoader = () => {
+    const asked: string[] = [];
+    return {
+      asked,
+      load: async (name: string) => {
+        asked.push(name);
+        return DOCS[name] ?? null;
+      },
+    };
+  };
+
+  it('resolves a LOCAL field straight off the base schema, fetching nothing', async () => {
+    const { asked, load } = makeLoader();
+    const out = await resolveDimensionFieldOptions(OPPORTUNITY, ['stage'], load);
+    expect(out).toEqual({ stage: [{ value: 'won', label: 'Won' }] });
+    expect(asked).toEqual([]);
+  });
+
+  it('resolves a DOTTED path against the relationship target', async () => {
+    const { asked, load } = makeLoader();
+    const out = await resolveDimensionFieldOptions(OPPORTUNITY, ['crm_account.industry'], load);
+    expect(out['crm_account.industry']).toEqual(INDUSTRY);
+    expect(asked).toEqual(['crm_account']);
+  });
+
+  it('walks N hops', async () => {
+    const { asked, load } = makeLoader();
+    const out = await resolveDimensionFieldOptions(OPPORTUNITY, ['crm_account.owner.department'], load);
+    expect(out['crm_account.owner.department']).toEqual([{ value: 'rnd', label: 'R&D' }]);
+    expect(asked).toEqual(['crm_account', 'crm_user']);
+  });
+
+  it('fetches a shared prefix ONCE and never re-fetches the base object', async () => {
+    const { asked, load } = makeLoader();
+    const out = await resolveDimensionFieldOptions(
+      OPPORTUNITY,
+      ['stage', 'crm_account.industry', 'crm_account.tier', 'crm_account.owner.department'],
+      load,
+    );
+    expect(Object.keys(out).sort()).toEqual(
+      ['crm_account.industry', 'crm_account.owner.department', 'crm_account.tier', 'stage'],
+    );
+    // `crm_account` serves three paths on one read; the base is seeded, not read.
+    expect(asked).toEqual(['crm_account', 'crm_user']);
+  });
+
+  it('yields NO entry for a terminal field with no options, a missing field, or a dead hop', async () => {
+    const { asked, load } = makeLoader();
+    const out = await resolveDimensionFieldOptions(
+      OPPORTUNITY,
+      ['crm_account.website', 'crm_account.no_such_field', 'stage.nested', 'crm_account.ghost.name'],
+      load,
+    );
+    expect(out).toEqual({});
+    // `stage` is not a relationship, so it was never fetched; `ghost` is not a
+    // field at all. Only the one reachable object was read.
+    expect(asked).toEqual(['crm_account']);
+  });
+
+  it('survives a loader that throws, costing only that path', async () => {
+    const out = await resolveDimensionFieldOptions(
+      OPPORTUNITY,
+      ['stage', 'crm_account.industry'],
+      async () => { throw new Error('offline'); },
+    );
+    expect(out).toEqual({ stage: [{ value: 'won', label: 'Won' }] });
+  });
+
+  it('is a no-op for an empty / undefined path list and a junk base schema', async () => {
+    const { asked, load } = makeLoader();
+    expect(await resolveDimensionFieldOptions(OPPORTUNITY, [], load)).toEqual({});
+    expect(await resolveDimensionFieldOptions(OPPORTUNITY, [undefined, null, ''], load)).toEqual({});
+    expect(await resolveDimensionFieldOptions(null, ['stage'], load)).toEqual({});
+    // `fields` as an array (not the map shape this lookup reads) resolves to
+    // nothing rather than throwing.
+    expect(await resolveDimensionFieldOptions({ fields: [] }, ['stage'], load)).toEqual({});
+    expect(asked).toEqual([]);
   });
 });

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -286,3 +286,128 @@ export function buildDimensionLabelMap(options: unknown): Record<string, string>
   }
   return Object.keys(map).length > 0 ? map : null;
 }
+
+/**
+ * Field types that JOIN to another object, so they can be a hop in a dotted
+ * dimension path. Mirrors the dataset designer's allowlist
+ * (`useDatasetFields.ts`), matched case-insensitively so `masterDetail` and
+ * `master_detail` both resolve.
+ */
+const RELATIONSHIP_FIELD_TYPES = new Set(['lookup', 'master_detail', 'masterdetail', 'master-detail']);
+
+/** The `fields` map of an object metadata doc, or null when it isn't one. */
+function fieldDefsOf(schema: unknown): Record<string, unknown> | null {
+  const fields = (schema as { fields?: unknown } | null | undefined)?.fields;
+  return fields && typeof fields === 'object' && !Array.isArray(fields)
+    ? (fields as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * The object a relationship field points at, or `undefined` when the field is
+ * not a relationship (or names no target).
+ *
+ * The target lives under `reference` on framework-served field defs; older /
+ * spec shapes spell it `reference_to` / `referenceTo` / `reference_to_object`,
+ * and any of them may carry a bare name, a one-element array, or `{ object }`.
+ * Same canonicalization as the dataset designer's `resolveReferenceTo`.
+ *
+ * The **type gate is deliberate**: only a declared relationship is walked, so a
+ * path segment naming a plain field can never be turned into an object name and
+ * fetched speculatively.
+ */
+export function resolveRelationshipTarget(fieldDef: unknown): string | undefined {
+  if (!fieldDef || typeof fieldDef !== 'object') return undefined;
+  const def = fieldDef as {
+    type?: unknown;
+    reference?: unknown;
+    reference_to?: unknown;
+    referenceTo?: unknown;
+    reference_to_object?: unknown;
+  };
+  const type = typeof def.type === 'string' ? def.type.toLowerCase() : '';
+  if (!RELATIONSHIP_FIELD_TYPES.has(type)) return undefined;
+  const raw = def.reference ?? def.reference_to ?? def.referenceTo ?? def.reference_to_object;
+  if (typeof raw === 'string' && raw) return raw;
+  if (Array.isArray(raw) && typeof raw[0] === 'string' && raw[0]) return raw[0];
+  if (raw && typeof raw === 'object') {
+    const obj = (raw as { object?: unknown }).object;
+    if (typeof obj === 'string' && obj) return obj;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve each dataset dimension's underlying `field` to that field's select
+ * `options`, following DOTTED relationship paths to the object that actually
+ * owns the terminal field (objectui#4053).
+ *
+ * A dimension's `field` is either a local field name (`industry`) or a
+ * relationship path (`crm_account.industry`, and — per ADR-0071, which the
+ * dataset designer emits — `crm_account.owner.department`). Reading the options
+ * as `baseSchema.fields[path]` only ever works for the local spelling: for a
+ * dotted path the options live on the RELATED object, the lookup missed
+ * silently, and the chart fell through to the raw stored enum while the same
+ * field as a local dimension rendered its labels beside it.
+ *
+ * This is the object-resolution step of that ONE lookup, not a dotted-path
+ * variant beside it: a single-segment path never enters the walk and resolves
+ * exactly as before, so the local path cannot drift away from the joined one.
+ *
+ * `loadObjectSchema` supplies each hop's object metadata doc — the caller's
+ * existing channel (the same `GET /meta/object/:name` read that produced
+ * `baseSchema`), so no new fetch layer is introduced. It is memoized per call,
+ * because sibling dimensions routinely share a prefix (`crm_account.industry`
+ * alongside `crm_account.type` fetches `crm_account` once), and seeded with
+ * `baseSchema` under its own `name` so the base is never re-fetched.
+ *
+ * Best-effort by construction: a hop that is not a relationship, a target that
+ * cannot be loaded, or a terminal field that carries no `options` simply yields
+ * no entry, and the caller keeps the raw value. Returns `{ fieldPath → options }`
+ * for the paths that did resolve.
+ */
+export async function resolveDimensionFieldOptions(
+  baseSchema: unknown,
+  fieldPaths: Array<string | undefined | null>,
+  loadObjectSchema: (objectName: string) => Promise<unknown>,
+): Promise<Record<string, unknown>> {
+  const out: Record<string, unknown> = {};
+  const paths = Array.from(new Set((fieldPaths ?? []).filter((p): p is string => !!p)));
+  if (paths.length === 0) return out;
+
+  const cache = new Map<string, Promise<unknown>>();
+  const baseName = (baseSchema as { name?: unknown } | null | undefined)?.name;
+  if (typeof baseName === 'string' && baseName) cache.set(baseName, Promise.resolve(baseSchema));
+  const load = (name: string): Promise<unknown> => {
+    let hit = cache.get(name);
+    if (!hit) {
+      // A rejected hop resolves to null rather than throwing, so one unreachable
+      // relationship costs its own dimension's labels and not the whole chart's.
+      hit = Promise.resolve().then(() => loadObjectSchema(name)).catch(() => null);
+      cache.set(name, hit);
+    }
+    return hit;
+  };
+
+  for (const path of paths) {
+    const segments = path.split('.');
+    let schema: unknown = baseSchema;
+    let walked = true;
+    // Every segment but the last must be a relationship; walk to its target.
+    // Hops are sequential by nature — hop N's object is only known once hop
+    // N-1 has been read.
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const target = resolveRelationshipTarget(fieldDefsOf(schema)?.[segments[i]]);
+      if (!target) { walked = false; break; }
+      // eslint-disable-next-line no-await-in-loop
+      schema = await load(target);
+      if (!schema) { walked = false; break; }
+    }
+    if (!walked) continue;
+    const terminal = fieldDefsOf(schema)?.[segments[segments.length - 1]] as
+      | { options?: unknown }
+      | undefined;
+    if (terminal?.options !== undefined) out[path] = terminal.options;
+  }
+  return out;
+}

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useContext, useCallback, useMemo, useRef } from 'react';
 import { useDataScope, SchemaRendererContext, SchemaRenderer, useDrillNavigation, useFilterScope, ElementDataSourceGate, type ElementDataSourceMapping } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
-import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, buildDimensionLabelMap, relabelDimensions, type CompareToConfig, type DrillEvent, type ChartResultField } from '@object-ui/core';
+import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, buildDimensionLabelMap, relabelDimensions, resolveDimensionFieldOptions, type CompareToConfig, type DrillEvent, type ChartResultField } from '@object-ui/core';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button, ChartSkeleton } from '@object-ui/components';
 import { AlertCircle, ArrowUpRight } from 'lucide-react';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
@@ -364,19 +364,37 @@ export const ObjectChart = (props: any) => {
           fieldName = dim?.field ?? dim0;
         }
         if (!objectName || !fieldName) { if (!cancelled) { setFieldOptionColors(null); setDimensionLabels(null); } return; }
-        const schemaRes = await doFetch(`/api/v1/meta/object/${encodeURIComponent(objectName)}`, reqOpts);
-        const sj = await schemaRes.json().catch(() => null);
-        const objSchema = sj?.item ?? sj?.data ?? sj;
-        const map = buildOptionColorMap(objSchema?.fields?.[fieldName]?.options);
+        const loadObjectSchema = async (name: string) => {
+          const r = await doFetch(`/api/v1/meta/object/${encodeURIComponent(name)}`, reqOpts);
+          const doc = await r.json().catch(() => null);
+          return doc?.item ?? doc?.data ?? doc;
+        };
+        const objSchema = await loadObjectSchema(objectName);
+        // Each dimension's underlying field, which for a dataset dimension may be
+        // a DOTTED relationship path (`crm_account.industry`) — objectui#4053.
+        const fieldByDim: Record<string, string> = {};
+        if (schema.dataset && Array.isArray(schema.dimensions)) {
+          for (const dimName of schema.dimensions) {
+            const dimDef = (datasetDef?.dimensions || []).find((d: any) => d?.name === dimName);
+            fieldByDim[dimName] = dimDef?.field ?? dimName;
+          }
+        }
+        // One resolution for every path: a local field name reads straight off
+        // `objSchema` as before, a dotted one walks to the object that owns the
+        // terminal field. Unresolvable paths yield no entry → raw value survives.
+        const optionsByPath = await resolveDimensionFieldOptions(
+          objSchema,
+          [fieldName, ...Object.values(fieldByDim)],
+          loadObjectSchema,
+        );
+        const map = buildOptionColorMap(optionsByPath[fieldName]);
         // dataset path: build a {value → label} map for EVERY select dimension
         // (the objectName path resolves labels via resolveGroupByLabels instead).
         let labels: Record<string, Record<string, string>> | null = null;
         if (schema.dataset && Array.isArray(schema.dimensions)) {
           const acc: Record<string, Record<string, string>> = {};
           for (const dimName of schema.dimensions) {
-            const dimDef = (datasetDef?.dimensions || []).find((d: any) => d?.name === dimName);
-            const f = dimDef?.field ?? dimName;
-            const m = buildDimensionLabelMap(objSchema?.fields?.[f]?.options);
+            const m = buildDimensionLabelMap(optionsByPath[fieldByDim[dimName]]);
             if (m) acc[dimName] = m;
           }
           if (Object.keys(acc).length > 0) labels = acc;

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -34,6 +34,7 @@ import {
   buildDimensionLabelMap,
   buildCategoryOrder,
   relabelDimensions,
+  resolveDimensionFieldOptions,
   findChartSeriesRow,
   formatMeasure,
   formatDimensionValue,
@@ -604,14 +605,29 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     (async () => {
       try {
         const doFetch = apiFetch ?? fetch;
-        const res = await doFetch(`/api/v1/meta/object/${encodeURIComponent(object)}`, { headers: { accept: 'application/json' }, credentials: 'include' });
-        const j = await res.json().catch(() => null);
-        const objSchema = j?.item ?? j?.data ?? j;
-        const firstDimOptions = objSchema?.fields?.[fieldOf(dimensions[0])]?.options;
+        const loadObjectSchema = async (name: string) => {
+          const r = await doFetch(`/api/v1/meta/object/${encodeURIComponent(name)}`, { headers: { accept: 'application/json' }, credentials: 'include' });
+          const doc = await r.json().catch(() => null);
+          return doc?.item ?? doc?.data ?? doc;
+        };
+        const objSchema = await loadObjectSchema(object);
+        // A dimension's field may be a DOTTED relationship path
+        // (`crm_account.industry`) whose options live on the RELATED object, not
+        // on the dataset's base object — objectui#4053. `resolveDimensionFieldOptions`
+        // is the object-resolution step of this same lookup: a local field name
+        // still resolves straight off `objSchema`, a dotted one walks each hop
+        // through the SAME channel `objSchema` came from. Unresolvable paths
+        // yield no entry, so the raw value survives exactly as before.
+        const optionsByPath = await resolveDimensionFieldOptions(
+          objSchema,
+          dimensions.map(fieldOf),
+          loadObjectSchema,
+        );
+        const firstDimOptions = optionsByPath[fieldOf(dimensions[0])];
         const colorMap = buildOptionColorMap(firstDimOptions);
         const labels: Record<string, Record<string, string>> = {};
         for (const dim of dimensions) {
-          const m = buildDimensionLabelMap(objSchema?.fields?.[fieldOf(dim)]?.options);
+          const m = buildDimensionLabelMap(optionsByPath[fieldOf(dim)]);
           if (m) labels[dim] = m;
         }
         if (!cancelled) {

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimension.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimension.test.tsx
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Regression for objectui#4053 (migrated from objectstack#5144): a dataset
+ * dimension whose `field` is a DOTTED relationship path (`crm_account.industry`)
+ * got no select-option resolution at all, so the chart plotted the raw stored
+ * enum (`education`, `finance`) — while the SAME field reached as a LOCAL
+ * dimension resolved to its option labels (`Education`, `Finance`) beside it on
+ * the same dashboard.
+ *
+ * Mechanism: the widget looks options up as `objSchema.fields[<path>]`, and
+ * `objSchema` is the dataset's BASE object. For a dotted path the options live
+ * on the RELATED object, so the lookup missed silently and the renderer fell
+ * through to the stored value. Nothing errored — end users just read database
+ * enum values.
+ *
+ * The pins below put BOTH dimensions on ONE widget so the split the issue
+ * reports side-by-side is a single assertion pair: `industry` (local) and
+ * `account_industry` (`crm_account.industry`) carry the SAME option set, so any
+ * difference between their rendered categories is the bug and nothing else.
+ *
+ * Scope boundary: this file ends at "the label is in hand". Whether that label
+ * then passes through the i18n bundle is objectstack#5076, deliberately not
+ * fixed or asserted here.
+ *
+ * Like the sibling relabel suite, we register a stub `chart` component to
+ * capture the schema the widget hands the renderer rather than asserting on
+ * Recharts' SVG (which doesn't lay out in jsdom). This exercises the REAL
+ * DatasetWidget + SchemaRenderer.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { DatasetWidget } from '../DatasetWidget';
+
+let capturedChartSchema: any = null;
+beforeAll(() => {
+  ComponentRegistry.register('chart', (props: any) => {
+    capturedChartSchema = props?.schema;
+    return null;
+  });
+});
+afterEach(() => {
+  cleanup();
+  capturedChartSchema = null;
+  vi.restoreAllMocks();
+});
+
+/** The one option set both dimensions below resolve against. */
+const INDUSTRY_OPTIONS = [
+  { value: 'education', label: 'Education' },
+  { value: 'finance', label: 'Finance' },
+];
+
+/**
+ * TWO measures on purpose: `buildChartSeries` pivots the second dimension into
+ * series only for 2+ dimensions with a SINGLE measure. With two measures the
+ * rows pass through in long format, so `schema.data` is exactly the relabeled
+ * rows and each dimension's rendered category can be read directly.
+ */
+const WIDGET = {
+  type: 'bar',
+  dataset: 'opportunity_metrics',
+  dimensions: ['industry', 'account_industry'],
+  values: ['total_amount', 'deal_count'],
+};
+
+/** Rows as the analytics layer returns them: grouped by the STORED value. */
+const valueKeyedSource = () => ({
+  queryDataset: vi.fn(async () => ({
+    rows: [
+      { industry: 'education', account_industry: 'education', total_amount: 10, deal_count: 2 },
+      { industry: 'finance', account_industry: 'finance', total_amount: 20, deal_count: 3 },
+    ],
+    fields: [
+      { name: 'industry', type: 'select', label: 'Industry' },
+      { name: 'account_industry', type: 'select', label: 'Account Industry' },
+      { name: 'total_amount', type: 'number', label: 'Total Amount' },
+      { name: 'deal_count', type: 'number', label: 'Deal Count' },
+    ],
+    object: 'crm_opportunity',
+    // The server's dimension → underlying field map. `account_industry` is the
+    // dotted one; `industry` is local. This is what the widget resolves against.
+    dimensionFields: { industry: 'industry', account_industry: 'crm_account.industry' },
+  })),
+});
+
+/**
+ * Route `GET /api/v1/meta/object/<name>` to a per-object document, recording the
+ * object names asked for. A name with no document 404s the way a real server
+ * would, so "the walk asked for an object that doesn't exist" stays visible
+ * rather than resolving to an empty schema.
+ */
+function installMetaRouter(docs: Record<string, unknown>) {
+  const requested: string[] = [];
+  const fn = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    const m = /\/api\/v1\/meta\/object\/(.+)$/.exec(url);
+    const name = m ? decodeURIComponent(m[1]) : '';
+    requested.push(name);
+    const doc = docs[name];
+    if (!doc) return { ok: false, json: async () => ({}) };
+    return { ok: true, json: async () => ({ item: doc }) };
+  });
+  global.fetch = fn as any;
+  return { requested };
+}
+
+/** Categories the renderer received for one dimension key, in row order. */
+const categoriesOf = (dim: string): unknown[] =>
+  ((capturedChartSchema?.data ?? []) as Array<Record<string, unknown>>).map((r) => r[dim]);
+
+describe('DatasetWidget dotted-path dimension label resolution (objectui#4053)', () => {
+  /** Base object: a local `industry` select + the `crm_account` relationship. */
+  const OPPORTUNITY = {
+    name: 'crm_opportunity',
+    fields: {
+      industry: { type: 'select', options: INDUSTRY_OPTIONS },
+      crm_account: { type: 'lookup', reference: 'crm_account' },
+    },
+  };
+  /** The relationship's TARGET object, where the dotted path's options live. */
+  const ACCOUNT = {
+    name: 'crm_account',
+    fields: { industry: { type: 'select', options: INDUSTRY_OPTIONS } },
+  };
+
+  it('resolves a dotted dimension against the relationship target, matching the local dimension', async () => {
+    const { requested } = installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+
+    render(<DatasetWidget widget={WIDGET} dataSource={valueKeyedSource()} />);
+
+    // The local dimension resolves its option labels — this half already worked
+    // and must keep working (the issue's widget B).
+    await waitFor(() => {
+      expect(capturedChartSchema).toBeTruthy();
+      expect(categoriesOf('industry')).toEqual(['Education', 'Finance']);
+    });
+
+    // The dotted dimension must resolve to the SAME labels (the issue's widget
+    // A). Pre-fix this held the raw stored values.
+    await waitFor(() => expect(categoriesOf('account_industry')).toEqual(['Education', 'Finance']));
+    expect(categoriesOf('account_industry')).not.toContain('education');
+
+    // ...and it got there by reading the TARGET object's metadata, through the
+    // same `GET /meta/object/:name` channel the base read already uses — not a
+    // new fetch layer.
+    expect(requested).toContain('crm_account');
+  });
+
+  it('walks MULTI-HOP paths (a.b.field), the shape the dataset designer emits', async () => {
+    // ADR-0071: the dataset designer offers `relationship.relationship.field`
+    // paths (`useDatasetFields.ts` builds them, capped at 3 hops), so 2-hop
+    // paths genuinely reach this resolver — the walk is per-segment, not
+    // single-hop special-casing.
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [{ owner_dept: 'rnd', total: 1 }],
+        fields: [{ name: 'owner_dept', type: 'select' }, { name: 'total', type: 'number' }],
+        object: 'crm_opportunity',
+        dimensionFields: { owner_dept: 'crm_account.owner.department' },
+      })),
+    };
+    const { requested } = installMetaRouter({
+      crm_opportunity: OPPORTUNITY,
+      crm_account: {
+        name: 'crm_account',
+        fields: { owner: { type: 'lookup', reference: 'crm_user' } },
+      },
+      crm_user: {
+        name: 'crm_user',
+        fields: {
+          department: { type: 'select', options: [{ value: 'rnd', label: 'Research & Development' }] },
+        },
+      },
+    });
+
+    render(
+      <DatasetWidget
+        widget={{ type: 'bar', dataset: 'd', dimensions: ['owner_dept'], values: ['total'] }}
+        dataSource={src}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(categoriesOf('owner_dept')).toEqual(['Research & Development']),
+    );
+    // Every hop along the chain was fetched, in order.
+    expect(requested).toEqual(['crm_opportunity', 'crm_account', 'crm_user']);
+  });
+
+  it('leaves a dotted path to a NON-select target field untouched', async () => {
+    // Control: the target field has no `options`, so there is nothing to
+    // resolve. The raw value must survive rather than be coerced or dropped.
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [{ site: 'acme.example', total: 1 }],
+        fields: [{ name: 'site', type: 'text' }, { name: 'total', type: 'number' }],
+        object: 'crm_opportunity',
+        dimensionFields: { site: 'crm_account.website' },
+      })),
+    };
+    installMetaRouter({
+      crm_opportunity: OPPORTUNITY,
+      crm_account: { name: 'crm_account', fields: { website: { type: 'text' } } },
+    });
+
+    render(
+      <DatasetWidget
+        widget={{ type: 'bar', dataset: 'd', dimensions: ['site'], values: ['total'] }}
+        dataSource={src}
+      />,
+    );
+
+    await waitFor(() => expect(categoriesOf('site')).toEqual(['acme.example']));
+  });
+
+  it('falls through gracefully when the target object lacks the field', async () => {
+    // Control: the relationship resolves but the terminal field is absent —
+    // today's behaviour (raw value, no crash) stays exactly as it is.
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [{ ghost: 'education', total: 1 }],
+        fields: [{ name: 'ghost', type: 'select' }, { name: 'total', type: 'number' }],
+        object: 'crm_opportunity',
+        dimensionFields: { ghost: 'crm_account.no_such_field' },
+      })),
+    };
+    installMetaRouter({
+      crm_opportunity: OPPORTUNITY,
+      crm_account: { name: 'crm_account', fields: {} },
+    });
+
+    render(
+      <DatasetWidget
+        widget={{ type: 'bar', dataset: 'd', dimensions: ['ghost'], values: ['total'] }}
+        dataSource={src}
+      />,
+    );
+
+    await waitFor(() => expect(categoriesOf('ghost')).toEqual(['education']));
+  });
+
+  it('falls through gracefully when the relationship segment is not a relationship', async () => {
+    // Control: `industry` is a plain select on the base object, so
+    // `industry.something` names no relationship at all. No target object can
+    // be reached, and the raw value must survive — the walk must not invent an
+    // object name out of the segment.
+    const src = {
+      queryDataset: vi.fn(async () => ({
+        rows: [{ bogus: 'education', total: 1 }],
+        fields: [{ name: 'bogus', type: 'select' }, { name: 'total', type: 'number' }],
+        object: 'crm_opportunity',
+        dimensionFields: { bogus: 'industry.nested' },
+      })),
+    };
+    const { requested } = installMetaRouter({ crm_opportunity: OPPORTUNITY });
+
+    render(
+      <DatasetWidget
+        widget={{ type: 'bar', dataset: 'd', dimensions: ['bogus'], values: ['total'] }}
+        dataSource={src}
+      />,
+    );
+
+    await waitFor(() => expect(categoriesOf('bogus')).toEqual(['education']));
+    // Only the base object was ever asked for.
+    expect(requested).toEqual(['crm_opportunity']);
+  });
+});


### PR DESCRIPTION
Fixes #4053

A `DatasetDimension` whose `field` is a dotted relationship path (`crm_account.industry`) got no select-option resolution at all, so the chart plotted the raw stored enum (`education`, `finance`) — while the **same underlying field** reached as a **local** dimension rendered `Education`, `Finance` beside it on the same dashboard. Nothing errored; end users just read database enum values.

Source thread objectstack#5144 (required reading per the migration header) was reviewed: its triage ruling is "先按纯前端解析修" — fix as pure frontend resolution, and only split cross-domain if the spec surface must change. It did not: no `DatasetDimension` key was added, so this stays entirely in the renderer.

## Where the resolver lives

Two sites carried the identical lookup, both reading options off the dataset's **base** object:

| site | pre-fix expression |
| --- | --- |
| `packages/plugin-dashboard/src/DatasetWidget.tsx` | `objSchema?.fields?.[fieldOf(dim)]?.options` |
| `packages/plugin-charts/src/ObjectChart.tsx` (dataset path) | `objSchema?.fields?.[f]?.options` |

`objSchema` is the dataset's base object, and `fieldOf(dim)` comes from the server's `dimensionFields` map — for the issue's widget A that is the literal string `crm_account.industry`. Indexing a base-object field map with a dotted path only ever matches the local spelling, so the lookup missed silently and the renderer fell through to the stored value.

## How the target object is reached

`resolveDimensionFieldOptions` (new, in `packages/core/src/utils/chart-series.ts` beside `buildDimensionLabelMap` / `buildOptionColorMap`) is the **object-resolution step of that same lookup**, not a dotted-path variant beside it: a single-segment path never enters the walk and resolves exactly as before, so the local and joined paths cannot drift.

Each segment before the last must be a **declared relationship** — type in `lookup` / `master_detail` / `masterdetail` / `master-detail`, target read from `reference` / `reference_to` / `referenceTo` / `reference_to_object`, accepting a bare name, a one-element array, or `{ object }`. Same canonicalization the dataset designer's `resolveReferenceTo` already uses. The type gate is deliberate: a segment naming a plain field can never be turned into an object name and fetched speculatively.

**No new fetch layer.** The related object's metadata was already reachable at this point — the resolver's own `GET /api/v1/meta/object/:name` read, which rides the host `apiFetch` when a provider supplies one (objectui#4121). Hops go through that same channel via a `loadObjectSchema` callback the call site passes in, so authentication, base-URL rewriting and draft-preview params are inherited rather than re-implemented. The loader is memoized per resolution and seeded with the base schema under its own `name`, so sibling dimensions sharing a prefix (`crm_account.industry` alongside `crm_account.tier`) fetch `crm_account` once and the base is never re-read.

## Multi-hop verdict: handled, and pinned

Multi-hop is **not** hypothetical here — the dataset designer emits it. `useDatasetFields.ts` builds `relationship.relationship.field` paths under ADR-0071 (capped at 3 hops in the picker), so 2-hop paths genuinely reach this resolver. The walk is per-segment rather than single-hop special-casing, so N hops work for free; `crm_account.owner.department` is pinned end-to-end through the widget, asserting both the resolved label and that every hop was fetched in order. No artificial cap is imposed — each hop must be a real declared relationship, so a garbage path stops on its first segment.

## Evidence

Red-first, before any fix, with one fixture carrying **both** dimensions so the issue's side-by-side split is a single assertion pair:

```
× resolves a dotted dimension against the relationship target, matching the local dimension
    expected [ 'education', 'finance' ] to deeply equal [ 'Education', 'Finance' ]
× walks MULTI-HOP paths (a.b.field), the shape the dataset designer emits
    expected [ 'rnd' ] to deeply equal [ 'Research &amp; Development' ]
Tests  2 failed | 3 passed (5)
```

The local dimension in that same fixture rendered `Education` / `Finance` pre-fix — the split reproduced exactly as reported. The 3 passing controls are the fall-through cases, green before and after.

After the fix: `Test Files 132 passed (132)`, `Tests 2108 passed (2108)` across `packages/core/`, `packages/plugin-dashboard/`, `packages/plugin-charts/` — including the existing `DatasetWidget.relabel.test.tsx` suite and the objectui#4121 `apiFetch`-routing pins, so local dimensions and probe routing are unchanged.

**Reverse verification** (walk removed, fix otherwise intact — the direction was predicted before running): both dotted pins went RED with the raw values returning, and the three fall-through controls stayed GREEN. One core unit test I had predicted green also went red — `yields NO entry for a terminal field with no options…` — because besides asserting the empty result it asserts the walk *reached* `crm_account` once; with the walk gone the fetch trace is empty. Its result assertion still held; only the trace moved. Reported rather than smoothed over.

Controls pinned (all green before and after, i.e. today's behavior preserved):

- local dimensions unchanged;
- a dotted path to a **non-select** target field (`crm_account.website`) — raw value survives, nothing coerced;
- a dotted path whose target object **lacks** the field — graceful fall-through, no crash;
- a segment that is **not a relationship** (`industry.nested`) — no target invented, only the base object ever fetched.

## Gates

`pnpm exec vitest run` for the three packages (repo root, per AGENTS.md) · `turbo run type-check lint` for the three packages: 17/17 · `node scripts/check-control-bytes.mjs`: OK · `check-changeset-presence`: OK · `check-changeset-no-major`: OK. Changeset added (patch × 3; never `major`, per the version-alignment rule — and no `skip-changeset`, per objectui#3724). No copy was touched, so the i18n gates do not apply.

The core change is purely **additive** — two new exports, no existing signature narrowed — so no downstream consumer can break on it; the two consumers of the changed lookup are both edited and green here.

## Scope

Ends at "the label is in hand", per the card's own not-a-duplicate reasoning. Whether that label then passes through the i18n bundle is objectstack#5076 and is deliberately neither fixed nor asserted here.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_