### PR TITLE
retire(core): drop the legacy `params.newTab` fallback on url actions (#4097)

### DIFF
--- a/.changeset/retire-url-action-params-newtab-4097.md
+++ b/.changeset/retire-url-action-params-newtab-4097.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/core': patch
+---
+
+Retire `params.newTab` on a url action — `openIn: 'new-tab'` is the sanctioned spelling
+
+`ActionRunner`'s navigator read a legacy `params.newTab` escape hatch below `openIn` and above the external-URL heuristic. That read is removed, executing the objectstack#6828 maintainer ruling of 2026-08-10, whose contract half shipped in objectstack PR #7375: the url-side readings of an object-form `params` are retired, not renamed.
+
+Nothing that ever validated can regress. `params` is declared as `z.array(ActionParamSchema)`, so an object-form `params` has always failed the props parse — the fallback could only fire on a stack the spec refuses. The removal also closes a collision hazard: a params dialog declaring a field named `newTab` had the user's own collected input silently steering navigation.
+
+`openIn: 'self' | 'new-tab'`, the legacy `navigate.newTab` modifier on the `navigation` shape, and the external/relative default are all unchanged.

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -1174,13 +1174,25 @@ export class ActionRunner {
       return { success: true };
     }
     // `openIn` is the first-class, declarative switch (ActionSchema.openIn);
-    // it wins over the legacy `navigate.newTab` / `params.newTab` escape
-    // hatches and the external-URL heuristic.
+    // it wins over the legacy `navigate.newTab` escape hatch and the
+    // external-URL heuristic.
+    //
+    // `params.newTab` used to sit between them and is RETIRED (objectui#4097,
+    // executing the objectstack#6828 maintainer ruling of 2026-08-10). It could
+    // only ever fire on an OBJECT-form `params`, which the spec has always
+    // refused on an action (`params` is `z.array(ActionParamSchema)`), so no
+    // validated stack could reach it; and no internal caller synthesizes a
+    // navigation directive into that bag — the runtime value bags carry
+    // collected dialog values, `_selectedIds` and `_rowRecord`, never `newTab`.
+    // Removing it also closes the collision hazard where a params dialog
+    // declaring a field literally named `newTab` would have had the user's own
+    // input silently steer navigation. The spec's refusal message names the
+    // sanctioned spelling: `openIn: 'new-tab'`.
     const openIn = source.openIn ?? action.openIn;
     const newTab =
       openIn === 'new-tab' ? true
         : openIn === 'self' ? false
-          : (source.newTab ?? action.params?.newTab ?? isExternal);
+          : (source.newTab ?? isExternal);
 
     // History semantics, the one thing the `navigation` shape carries that
     // `ActionSchema` has no field for. Omitted from the handler call when

--- a/packages/core/src/actions/__tests__/ActionRunner.bodyExtra.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.bodyExtra.test.ts
@@ -160,10 +160,15 @@ describe('ActionRunner — object-form params deprecation window (#5777)', () =>
   });
 
   it('stays SILENT for a type:url action — #6828 is a third meaning, not this one', async () => {
-    // `interpolateTarget`'s `${param.X}` scope and `executeUrl`'s `params.newTab`
-    // read object-form params on a url action. `bodyExtra` is not their
-    // replacement, so prescribing it here would be wrong advice. The `api` guard
-    // mirrors the ADR-0087 conversion's own guard.
+    // `interpolateTarget`'s `${param.X}` scope reads object-form params on a url
+    // action. `bodyExtra` is not its replacement, so prescribing it here would be
+    // wrong advice. The `api` guard mirrors the ADR-0087 conversion's own guard.
+    //
+    // The `params.newTab` half of that pair is now RETIRED (objectui#4097,
+    // objectstack#6828 ruling) — `openIn` is the sanctioned spelling and the
+    // fallback is gone. `newTab` stays in this fixture on purpose: it is now an
+    // inert key on the retired shape, and this test's claim is about the
+    // bodyExtra warning's TYPE GUARD, which is unaffected either way.
     const runner = new ActionRunner({});
     await runner.execute({
       type: 'url',

--- a/packages/core/src/actions/__tests__/ActionRunner.urlParamsRetirement.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.urlParamsRetirement.test.ts
@@ -1,0 +1,203 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `params.newTab` is RETIRED on a url action — and the sanctioned spellings it
+ * used to shadow are pinned here so the removal cannot quietly come back.
+ *
+ * The objectstack maintainer ruling of 2026-08-10 (objectstack#6828, comment
+ * 5237221393) retired the url-side readings of an OBJECT-form `params`. The
+ * contract half shipped in objectstack PR #7375; the spec's refusal message now
+ * says so in as many words — measured against the installed
+ * `@objectstack/spec@17.0.0-rc.6`:
+ *
+ *   "The url-side readings of an object `params` — a static `${param.X}` scope,
+ *    and `params.newTab` — are RETIRED, not renamed (#6828)."
+ *
+ * This file removes the `params.newTab` half only. The `${param.X}` scope half
+ * is NOT dead in this repo and is deliberately left standing — four internal
+ * callers synthesize a non-array `params` as the runtime VALUE bag that the
+ * scope reads (ActionRunner's own collected-params merge, plugin-grid's
+ * aggregate `_selectedIds` dispatch, the record-header `_rowRecord` stash, and
+ * the nav-item value bag). Retiring it needs a non-authorable channel for those
+ * values, which is a cross-package contract change — see objectui#4097.
+ *
+ * `params.newTab` has no such caller: every synthesized bag carries collected
+ * dialog values, `_selectedIds` or `_rowRecord`, never a navigation directive.
+ * The only shape that could reach it is an AUTHORED object `params`, which the
+ * spec has always refused at parse time — so the read could only ever fire on a
+ * stack that never validated.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ActionRunner } from '../ActionRunner';
+
+describe('url action: `openIn` is the sanctioned new-tab spelling (objectstack#6828)', () => {
+  let runner: ActionRunner;
+  let navHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    runner = new ActionRunner({});
+    navHandler = vi.fn();
+    runner.setNavigationHandler(navHandler);
+  });
+
+  // ── The sanctioned spelling, positive ──────────────────────────────────────
+  it('`openIn: "new-tab"` opens a new tab', async () => {
+    await runner.execute({ type: 'url', name: 'print', target: '/print/a4', openIn: 'new-tab' });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      '/print/a4',
+      expect.objectContaining({ newTab: true }),
+    );
+  });
+
+  it('`openIn: "self"` keeps an EXTERNAL url in the same tab — it outranks the heuristic', async () => {
+    await runner.execute({ type: 'url', name: 'docs', target: 'https://example.com/docs', openIn: 'self' });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      'https://example.com/docs',
+      expect.objectContaining({ newTab: false }),
+    );
+  });
+
+  // ── The retirement, negative ───────────────────────────────────────────────
+  // Red against the unfixed tree: `params.newTab` used to be read below `openIn`
+  // and above the external/relative default, so it forced a new tab here.
+  it('object-form `params.newTab` no longer opens a new tab — the read is RETIRED', async () => {
+    await runner.execute({
+      type: 'url',
+      name: 'open_report',
+      target: '/reports/r1',
+      // The retired shape. No author can produce it (the spec refuses object
+      // `params`), and no internal caller synthesizes a navigation directive
+      // into the value bag — so nothing legitimate reaches this read.
+      params: { newTab: true } as never,
+    });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      '/reports/r1',
+      // Relative url with no `openIn` ⇒ the surviving default is same-tab.
+      expect.objectContaining({ newTab: false }),
+    );
+  });
+
+  it('`params.newTab` cannot override an explicit `openIn: "self"` either', async () => {
+    await runner.execute({
+      type: 'url',
+      name: 'open_report',
+      target: 'https://example.com/r1',
+      openIn: 'self',
+      params: { newTab: true } as never,
+    });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      'https://example.com/r1',
+      expect.objectContaining({ newTab: false }),
+    );
+  });
+
+  // ── What the retirement must NOT touch ─────────────────────────────────────
+  it('the external-url default still opens a new tab without any `openIn`', async () => {
+    await runner.execute({ type: 'url', name: 'docs', target: 'https://example.com/docs' });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      'https://example.com/docs',
+      expect.objectContaining({ newTab: true }),
+    );
+  });
+
+  it('the legacy `navigate.newTab` escape hatch is a DIFFERENT read and survives', async () => {
+    // `source.newTab` on the nested `navigate` block is the `navigation` shape's
+    // own modifier, not the retired `params` reading. #6828 does not touch it.
+    await runner.execute({ type: 'navigation', name: 'print', navigate: { to: '/print/a3', newTab: true } });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      '/print/a3',
+      expect.objectContaining({ newTab: true }),
+    );
+  });
+});
+
+describe('url action: `${param.X}` still interpolates the COLLECTED dialog values', () => {
+  let runner: ActionRunner;
+  let navHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    runner = new ActionRunner({});
+    navHandler = vi.fn();
+    runner.setNavigationHandler(navHandler);
+  });
+
+  // The live mechanism the ruling explicitly keeps — the spec's own refusal
+  // message names it: "`${param.X}` interpolates a value collected by the
+  // params dialog". Green on BOTH sides of the `params.newTab` removal.
+  it('interpolates a value the params dialog collected, URL-encoded', async () => {
+    runner.setParamCollectionHandler(async () => ({ provider: 'acme corp' }));
+
+    await runner.execute({
+      type: 'url',
+      name: 'sign_in',
+      // Deliberately NOT an `/api/…` path: those short-circuit to a full-page
+      // `window.location.href` navigation before the handler is consulted.
+      target: '/reports/social?provider=${param.provider}',
+      // ARRAY `params` — the surviving meaning of the key: a DEFINITION list the
+      // runner collects through the dialog before executing.
+      params: [{ name: 'provider', label: 'Provider', type: 'text' }] as never,
+    });
+
+    expect(navHandler.mock.calls[0][0]).toBe('/reports/social?provider=acme%20corp');
+  });
+
+  it('degrades a token the dialog did not collect to an empty string', async () => {
+    runner.setParamCollectionHandler(async () => ({ provider: 'acme' }));
+
+    await runner.execute({
+      type: 'url',
+      name: 'sign_in',
+      target: '/go?provider=${param.provider}&team=${param.team}',
+      params: [{ name: 'provider', label: 'Provider', type: 'text' }] as never,
+    });
+
+    expect(navHandler.mock.calls[0][0]).toBe('/go?provider=acme&team=');
+  });
+});
+
+describe('url action: `${ctx.X}` is untouched by the retirement (control)', () => {
+  let runner: ActionRunner;
+  let navHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    navHandler = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('interpolates `${ctx.recordId}` and `${ctx.user.*}` from the action context', async () => {
+    runner = new ActionRunner({ recordId: 'rec 42', user: { id: 'u1' } });
+    runner.setNavigationHandler(navHandler);
+
+    await runner.execute({
+      type: 'url',
+      name: 'audit',
+      target: '/audit?rec=${ctx.recordId}&by=${ctx.user.id}',
+    });
+
+    expect(navHandler.mock.calls[0][0]).toBe('/audit?rec=rec%2042&by=u1');
+  });
+
+  it('interpolates `${ctx.selection.ids}` from the grid selection', async () => {
+    runner = new ActionRunner({ selectedRecords: [{ id: 'd1' }, { id: 'd2' }] });
+    runner.setNavigationHandler(navHandler);
+
+    await runner.execute({ type: 'url', name: 'zip', target: '/qr/zip?ids=${ctx.selection.ids}' });
+
+    expect(navHandler.mock.calls[0][0]).toBe('/qr/zip?ids=d1%2Cd2');
+  });
+});


### PR DESCRIPTION
Part of #4097

Executes the consumer half of the objectstack#6828 maintainer ruling (2026-08-10) — **but only one of the card's two removals.** The card's own binding measurement clause fired: the other half is not dead, and its retirement needs a decision. Details below.

## What this PR removes

`ActionRunner.navigateTo` read a legacy `params.newTab` escape hatch, below `openIn` and above the external-URL heuristic:

```ts
const newTab =
  openIn === 'new-tab' ? true
    : openIn === 'self' ? false
      : (source.newTab ?? action.params?.newTab ?? isExternal);   // ← the retired read
```

That read is gone. `openIn: 'self' | 'new-tab'`, the legacy `navigate.newTab` modifier on the `navigation` shape, and the external/relative default are all unchanged.

**Nothing that ever validated can regress.** `params` is declared `z.array(ActionParamSchema)`, so an object-form `params` has always failed the props parse — the fallback could only fire on a stack the spec refuses. Removing it also closes a collision hazard: a params dialog declaring a field named `newTab` had the user's own collected input silently steering navigation.

## The internal-producer sweep (the card's binding measurement clause)

The card asked whether any objectui-INTERNAL caller synthesizes a non-array `params` — the corpus grep behind the ruling covered *authored* metadata only. **It does. Eight sites, in four packages:**

| # | Site | Shape it synthesizes |
|---|---|---|
| 1 | `packages/core/src/actions/ActionRunner.ts:836` | `action.params = { ...priorParams, ...collected }` — the params dialog's collected values, written back onto the action |
| 2 | `packages/plugin-grid/src/ObjectGrid.tsx:2076` | `params: { ...params, _selectedIds: ids }` — aggregate bulk dispatch |
| 3 | `packages/plugin-grid/src/ObjectGrid.tsx:1721` | `dispatch.params = { _rowRecord: r }` |
| 4 | `packages/components/src/renderers/layout/containers.tsx:1287` / `:1289` | `dispatch.params = { _rowRecord: record }` / `{ ...rawParams, _rowRecord: record }` |
| 5 | `packages/app-shell/src/hooks/useNavActionDispatch.ts:93` | `dispatch.params = { ...actionDef.params }` — nav-item value bag |
| 6 | `packages/components/src/renderers/action/action-button.tsx:94` | `Array.isArray(schema.params) ? { actionParams } : { params }` |
| 7 | `packages/components/src/renderers/action/action-group.tsx:251`, `action-icon.tsx:83`, `action-menu.tsx:233` | forward `action.params` as `Record` |

**Effect on the two halves of the card, which is opposite for each:**

- **`params.newTab` (removed here).** None of these bags ever carries a navigation directive — they carry collected dialog values, `_selectedIds`, `_rowRecord`. Sites 5–7 copy an *authored* object `params` through, and that shape is spec-refused. So `params.newTab` is genuinely unreachable from any legitimate producer. Removal is safe.
- **The `${param.X}` interpolation scope (NOT removed — see below).** Sites 1–4 exist precisely to feed it. It is the live read point for runtime-injected param values.

## Why the interpolation-scope half is not in this PR

`interpolateTarget`'s non-array `params` branch is **live**, not dead vocabulary. Three independent confirmations, all already in the repo or in the shipped contract:

1. **The spec's own refusal message**, shipped by objectstack PR #7375 and measured against the installed `@objectstack/spec@17.0.0-rc.6`, names the mechanism as surviving: "`${param.X}` interpolates a value collected by the params dialog".
2. **Two existing tests pin it on a url/navigation action carrying object-form `params`** — `ActionRunner.resultDialog.test.ts:238` (`${param._selectedIds}` injected by an aggregate bulk dispatch) and `ActionRunner.test.ts:660` (`${param.owner}` on the `navigation` alias). Deleting the branch turns both red.
3. **`ActionRunner.bodyExtra.test.ts:190`** already documents the host-stashed bag as legitimate and explicitly not an authored payload.

The branch cannot distinguish an authored object from a runtime-injected one, because ActionRunner writes the collected values into the *same* `action.params` field the authored shape would occupy. Separating them needs a non-authorable channel for injected param VALUES threaded through all four packages above — and it would also have to move `executeAPI`'s body base (`asRecord(action.params)`), `executeModal`'s `params?.schema`, and `serverActionHandler`. That is a cross-package runtime-contract change, not a retirement, and the ruling supplies no spelling to move to: its sanctioned spellings (`target` interpolation, `openIn`) are *authoring* spellings, while these are internal injection channels that never pass through the spec parse.

Per the card's clause — "any producer found must move to the sanctioned spelling in this change, or if that move is non-trivial, STOP and report" — that half is reported for a ruling rather than guessed at. `Part of #4097`, not `Fixes`, for exactly this reason.

## Pins

New file `packages/core/src/actions/__tests__/ActionRunner.urlParamsRetirement.test.ts`, 10 cases:

- **Sanctioned, positive** — `openIn: 'new-tab'` opens a new tab; `openIn: 'self'` keeps an external url in the same tab.
- **The retirement, negative** — object-form `params: { newTab: true }` gets no new tab; and it cannot override `openIn: 'self'`.
- **Not touched** — the external-url default still opens a new tab; the legacy `navigate.newTab` escape hatch survives.
- **The live mechanism, positive** — `${param.X}` interpolates values the params dialog collected (URL-encoded), and degrades an uncollected token to empty string.
- **Control** — `${ctx.recordId}` / `${ctx.user.id}` / `${ctx.selection.ids}` untouched.

## Verification

- **Reverse verification** (revert `ActionRunner.ts` only, restore after): predicted and measured **1 red / 9 green** — only the negative retirement pin goes red; every positive and control stays green through the revert, which is the proof they pin live mechanisms this change does not alter.
- `vitest packages/core/ packages/components/src/renderers/action/ packages/app-shell/src/hooks/ packages/plugin-grid/src` — **165 files / 2636 tests pass**.
- `pnpm --filter @object-ui/core type-check` — clean (`tsc --noEmit` + typetests).
- `eslint --no-inline-config` on changed files — **0 errors** (25 pre-existing `no-explicit-any` warnings, none in the new file).
- `check:control-bytes` — OK (3977 files); plus a targeted control-byte self-scan of the changed files, clean.
- **`check:action-forward-parity` (#4207) — green, and the delta is ZERO.** Measured on both sides of the revert: identical "41 runtime-read keys from 3 consumers; 19 justified omissions, 7 known gaps" and identical per-surface owes/forwards. Expected: the gate extracts property accesses bound to the ActionDef parameter, so `action.params?.newTab` contributed `params`, and `params` is still read at four other sites.
- No i18n change — the removal touches no user-facing copy (the authoring guidance for this lives in the spec's refusal message, shipped in objectstack PR #7375).

Changeset: `@object-ui/core` patch.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_