### PR TITLE
refactor(app-shell): bind DeclaredActionsBar's row through usePredicateRecordContext (#4080)

### DIFF
--- a/.changeset/declared-actions-bar-predicate-helper-4080.md
+++ b/.changeset/declared-actions-bar-predicate-helper-4080.md
@@ -1,0 +1,11 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`DeclaredActionsBar` binds its row through the shared `usePredicateRecordContext`
+
+The bar held an inline copy of the three-way row binding — `{ ...row, record: row, data: row }`, added by objectui#4077 to fix its root-only predicate scope. objectui#4079 fixed the same fault on the four generic action renderers and gave the rule one name instead of a fifth copy: `usePredicateRecordContext`, exported from `@object-ui/react` beside `useCondition`. The bar now calls it.
+
+No verdict changes on any row: the two copies agreed wherever a row exists, which is every surface that mounts this bar today. They differed in one corner, and the helper's semantics are the ones kept — with **no** row, the bar now binds nothing where it used to bind `{ record: {}, data: {} }`. Since `useCondition` merges this context over the ambient predicate scope, the old shape blanked out a `record` a host had put in the scope itself; "this surface has no row" and "this surface's row is empty" are now distinct here too.
+
+Two implementations of one binding rule is what objectui#3367 / #3842 rule against, and this family already paid for it once at the `toPredicateInput` level (objectui#3314: two normalizations drifted, and the same `visible:` predicate reached different verdicts depending on which path surfaced the action). Nothing had drifted here yet — the next edit to the rule is what this closes off.

--- a/packages/app-shell/src/views/DeclaredActionsBar.tsx
+++ b/packages/app-shell/src/views/DeclaredActionsBar.tsx
@@ -37,6 +37,7 @@ import {
   useAction,
   useCondition,
   toPredicateInput,
+  usePredicateRecordContext,
 } from '@object-ui/react';
 import type { ActionDef } from '@object-ui/core';
 import { useObjectLabel, useObjectTranslation } from '@object-ui/i18n';
@@ -124,32 +125,28 @@ const DeclaredActionButton: React.FC<{
   const recordData = record != null && typeof record === 'object' ? (record as Record<string, any>) : {};
   /**
    * The predicate scope, with the record bound the THREE ways the platform's
-   * row surfaces bind it (objectui#3055).
+   * row surfaces bind it (objectui#3055) — through the ONE named helper that
+   * states the rule, not a local restatement of it (objectui#4080).
    *
-   * The bar used to hand the row in as the bare context bag, so only the
-   * shorthand spelling — `status == "pending"` — resolved. The CANONICAL
-   * spelling is the `record.` root: it is what `ExpressionEvaluator`'s CEL path
-   * binds (`bag.record` as the record namespace), what `evalRowPredicate` binds
-   * on the record header and on list rows, and what the server itself
-   * enforces with. Under a root-only bag `record.viewer.can_act` does not read
-   * as false — it throws `record is not defined`, and `throwOnError` turns that
-   * into "hidden".
+   * The rationale lives with the definition (`usePredicateRecordContext` in
+   * `@object-ui/react`): why the `record.` root is canonical, why `record` /
+   * `data` are written after the spread, and why a surface with no row of its
+   * own binds NOTHING rather than an empty row. The bar carried an inline copy
+   * of that expression from objectui#4077 until the four generic action
+   * renderers gave the rule its name in objectui#4079; two implementations of
+   * one binding rule is the shape objectui#3367 / #3842 rule against, and this
+   * family has already paid for it once at the `toPredicateInput` level
+   * (objectui#3314 — two normalizations drifted and the same `visible:`
+   * predicate reached different verdicts).
    *
-   * Which is not hypothetical: EVERY declared action on `sys_approval_request`
-   * gates on `record.viewer.*` (framework#3310 / #3424), so the whole
+   * What is specific to this bar is the cost of getting it wrong: EVERY
+   * declared action on `sys_approval_request` gates on `record.viewer.*`
+   * (framework#3310 / #3424), so under a root-only bag the whole
    * server-declared decision set was invisible on every surface this bar
-   * renders. The record page's two hand-written buttons were, in practice, the
-   * only decision UI that could still be reached — the fork objectui#3055 is
-   * about, kept alive by the "full" path being unable to evaluate its own gate.
-   *
-   * `record` / `data` are written AFTER the spread, so a row that happens to
-   * carry a field of either name cannot shadow the namespace a predicate means.
+   * renders — `record.viewer.can_act` does not read as false there, it throws
+   * `record is not defined` and `throwOnError` turns that into "hidden".
    */
-  const predicateRecord = useMemo(
-    () => ({ ...recordData, record: recordData, data: recordData }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [record],
-  );
+  const predicateRecord = usePredicateRecordContext(record);
   // `visible` fails CLOSED on a throwing predicate — mirrors action:button and
   // ActionEngine.getActionsForLocation: a guard that can't be evaluated hides
   // the action rather than exposing one whose precondition is broken.

--- a/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
+++ b/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
@@ -91,6 +91,10 @@ vi.mock('@object-ui/components', async () => {
 });
 
 import { DeclaredActionsBar } from '../DeclaredActionsBar';
+// The real provider — the `@object-ui/react` double above spreads `actual`, so
+// the ambient predicate scope the objectui#4080 no-row case needs is the
+// shipped one, not a stand-in for it.
+import { PredicateScopeProvider } from '@object-ui/react';
 
 const REQUEST = { id: 'req_1', status: 'pending', record_id: 'proj_9' };
 
@@ -652,5 +656,84 @@ describe('DeclaredActionsBar — declared `disabled` on a server-declared action
     fireEvent.click(approve());
     await waitFor(() => expect(executeSpy).toHaveBeenCalledTimes(1));
     expect(executeSpy.mock.calls[0][0]).toMatchObject({ name: 'approval_approve' });
+  });
+});
+
+/**
+ * objectui#4080 — the bar binds the row through the SHARED
+ * `usePredicateRecordContext`, not through a local copy of that expression.
+ *
+ * objectui#4077 fixed the root-only binding here with an inline
+ * `{ ...row, record: row, data: row }`; objectui#4079 fixed the same fault on
+ * the four generic action renderers and gave the rule one name instead of a
+ * fifth copy. The two copies agreed on every row the bar has ever been mounted
+ * over — which is why this is a convergence card and not a defect report, and
+ * why the two cases below are deliberately different in kind:
+ *
+ *   • the ROW-PRESENT case is an EQUIVALENCE pin. It was green before the
+ *     migration and is green after it, because the copies agree wherever a row
+ *     exists. It is not a mutation detector for this change and must not be
+ *     read as one; it is here so the reachable path — the only path any host
+ *     drives today — is pinned against a future edit to the helper, which now
+ *     owns the verdict for this bar too.
+ *   • the NO-ROW case is the CONVERGENCE detector, and the one difference the
+ *     two copies ever had. `usePredicateRecordContext` binds NOTHING when there
+ *     is no row; the inline copy bound `{ record: {}, data: {} }`. Since
+ *     `useCondition` merges this context OVER the ambient predicate scope, the
+ *     inline shape blanks out a `record` the HOST put in the scope — a
+ *     legitimate pattern, and how `action-group-dropdown-visible.test.tsx`
+ *     drives the group's dropdown leaves. No host mounts this bar without a
+ *     row today, so this case is unreachable in production; it is exercised
+ *     here precisely because it is where the copies part, and it is what goes
+ *     red if the inline expression comes back.
+ */
+describe('DeclaredActionsBar — the row binds through the shared helper (objectui#4080)', () => {
+  const APPROVE = {
+    name: 'approval_approve',
+    type: 'api',
+    label: 'Approve',
+    target: '/api/v1/approvals/requests/{id}/approve',
+    locations: ['record_section'],
+  };
+
+  it('with a row present, all three spellings reach the same verdict', () => {
+    // Both halves per spelling: "renders" alone is satisfied by a bar that
+    // ignores `visible` entirely, which is the mutation objectui#3835 was.
+    for (const visible of [
+      'record.status == "pending"',
+      'status == "pending"',
+      'data.status == "pending"',
+    ]) {
+      const shown = renderWithGate({ ...APPROVE, visible }, { ...REQUEST, status: 'pending' });
+      expect(screen.getByTestId('declared-action-approval_approve'), visible).toBeInTheDocument();
+      shown.unmount();
+
+      const hidden = renderWithGate({ ...APPROVE, visible }, { ...REQUEST, status: 'approved' });
+      expect(screen.queryByTestId('declared-action-approval_approve'), visible).toBeNull();
+      // The ungated companion proves the bar itself rendered — "not found" here
+      // must mean the gate said no, not that the located set was empty.
+      expect(screen.getByTestId('declared-action-approval_reassign')).toBeInTheDocument();
+      hidden.unmount();
+    }
+  });
+
+  it('with NO row of its own, the bar does not shadow a host-supplied ambient `record`', () => {
+    render(
+      <PredicateScopeProvider scope={{ record: { status: 'pending' } }}>
+        <DeclaredActionsBar
+          objectName="sys_approval_request"
+          record={undefined}
+          location="record_section"
+          actions={[
+            { ...APPROVE, visible: 'record.status == "pending"' },
+            COMPANION,
+          ] as any}
+        />
+      </PredicateScopeProvider>,
+    );
+    // Under the inline copy this was hidden: `record` merged down to `{}`, so
+    // the host's row never reached the predicate and a fail-closed `visible`
+    // turned that into "hidden".
+    expect(screen.getByTestId('declared-action-approval_approve')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/hooks/__tests__/useExpression.test.ts
+++ b/packages/react/src/hooks/__tests__/useExpression.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { createElement } from 'react';
-import { useExpression, useCondition, useRowPredicate, toPredicateInput, PredicateScopeProvider } from '../useExpression';
+import { useExpression, useCondition, useRowPredicate, toPredicateInput, PredicateScopeProvider, usePredicateRecordContext } from '../useExpression';
 
 describe('useExpression', () => {
   it('returns string value directly for non-expression strings', () => {
@@ -175,6 +175,46 @@ describe('useRowPredicate (canonical CEL row predicate — issue #1584)', () => 
     expect(result.current).toBe(false);
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+/**
+ * `usePredicateRecordContext` — the no-row half of the binding rule
+ * (objectui#4075 / #4080).
+ *
+ * The row-PRESENT half (all three spellings resolving) is pinned behaviorally
+ * where the rule is consumed: `action-record-predicate-root.test.tsx` for the
+ * four generic renderers, `DeclaredActionsBar.test.tsx` for the bar. What is
+ * pinned HERE is the return shape itself, one level below any renderer — the
+ * distinction between "this surface has no row" and "this surface's row is
+ * empty", which is the single point on which the helper and the inline copies
+ * it replaced ever differed. Its consumers can only fail it through a rendered
+ * verdict; a caller reading the bag directly (or a future "simplification" of
+ * the helper) would not be caught by them at all.
+ */
+describe('usePredicateRecordContext — no row binds NOTHING (objectui#4075)', () => {
+  it('returns an EMPTY bag for no row — not `{ record: {}, data: {} }`', () => {
+    for (const noRow of [null, undefined, 'a string', 42, [1, 2]]) {
+      const { result } = renderHook(() => usePredicateRecordContext(noRow));
+      expect(result.current, String(noRow)).toEqual({});
+      // Spelled out: the ABSENCE of these two keys is the whole contract, and
+      // `toEqual({})` above would still pass if they were present-and-undefined.
+      expect('record' in result.current, String(noRow)).toBe(false);
+      expect('data' in result.current, String(noRow)).toBe(false);
+    }
+  });
+
+  it('so a host-supplied ambient `record` survives the merge `useCondition` does', () => {
+    // The consequence the shape exists for. `useCondition` evaluates on
+    // `{ ...scope, ...context }`, so an empty-row bag would shadow the scope's
+    // `record` with `{}` and a correctly-authored predicate would read false.
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(PredicateScopeProvider, { scope: { record: { status: 'pending' } } }, children);
+    const { result } = renderHook(
+      () => useCondition('${record.status === "pending"}', usePredicateRecordContext(undefined)),
+      { wrapper },
+    );
+    expect(result.current).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes #4080

`DeclaredActionsBar` held an inline copy of the three-way row binding — `{ ...row, record: row, data: row }` — added by #4077 to fix its root-only predicate scope. #4079 fixed the same fault on the four generic action renderers and, rather than repeating the expression a fifth time, gave the rule one name: `usePredicateRecordContext`, exported from `@object-ui/react` beside `useCondition`. The bar kept its copy.

This is that migration: one import, one substitution, the inline `useMemo` deleted. The long rationale in the bar's comment moves to a pointer at the definition, keeping only what is specific to this bar (every declared action on `sys_approval_request` gates on `record.viewer.*`, so a root-only bag made the whole server-declared decision set invisible here).

## The one semantic subtlety — the helper's semantics are kept

The two copies differ in exactly one place, which is why this is a migration rather than a rename. With **no** row, `usePredicateRecordContext` binds NOTHING; the inline copy bound `{ record: {}, data: {} }`. `useCondition` evaluates on the local context merged OVER the ambient predicate scope, so the inline shape blanks out a `record` a host had put in the scope itself — a legitimate pattern, and how `action-group-dropdown-visible.test.tsx` drives the group's dropdown leaves.

Per the card, the helper's semantics are the ones kept. That corner is unreachable in the bar today (it is always mounted over a record), so no user-visible behaviour changes; the point is that the bar no longer holds a second answer to the question.

## Premise check

Verified on the branch tip before implementing, all three still true:

- inline `useMemo` live at `DeclaredActionsBar.tsx:148`;
- `usePredicateRecordContext` exported at `packages/react/src/hooks/useExpression.ts:142`;
- the bar already imports `useCondition` from `@object-ui/react`, so no new dependency edge.

## Tests

Two pins on the bar, deliberately different in kind, plus one at the helper level.

- **Equivalence (row present)** — all three spellings (`record.status`, bare `status`, `data.status`) reach the same verdict, both halves per spelling with the ungated companion asserting the bar itself rendered. Green **before and after**; it is not a mutation detector for this change and the comment says so.
- **Convergence (no row)** — the bar mounted with no row inside a `PredicateScopeProvider` that supplies `record`: the host's row must still reach the predicate. This is the one place the copies part.
- **Helper level** (`useExpression.test.ts`) — the return shape itself: no row yields an empty bag, and `record` / `data` are absent rather than present-and-undefined, so the ambient `record` survives the merge. Not a duplicate of existing coverage: the no-row semantics is pinned behaviourally through the renderers in `action-record-predicate-root.test.tsx` and incidentally by the dropdown suite, but nothing pinned the contract one level below a rendered verdict, which is what the bar now depends on.

```
npx vitest run packages/app-shell/src/views/ packages/components/src/renderers/action/
  Test Files  217 passed (217)
  Tests  2283 passed | 1 skipped (2284)

pnpm --filter @object-ui/app-shell --filter @object-ui/react type-check   → both Done
npx eslint (the 3 changed files)                                          → 0 errors
node scripts/check-control-bytes.mjs                                      → OK (3982 files)
```

## Reverse verification

Direction predicted before running, and it matched. The fix was taken out with `git checkout origin/main -- DeclaredActionsBar.tsx` (never `git stash` — shared stack), then restored from HEAD.

```
× with NO row of its own, the bar does not shadow a host-supplied ambient `record`
  Test Files  1 failed | 1 passed (2)
  Tests  1 failed | 59 passed (60)
```

The convergence pin went red, alone. The equivalence pin stayed green in both directions — honestly, that is the expected result and not a weak test: the two copies agree on every row that exists, so nothing about a row-present predicate can distinguish them. The helper-level pins stayed green both ways too; they do not touch the bar.

## Changeset

The card said "no changeset". `scripts/check-changeset-presence.mjs` arbitrates and disagrees — `@object-ui/app-shell` is a released package and this is a change under its `src/` — so the gate is followed: `@object-ui/app-shell: patch`. The empty-frontmatter form was considered and rejected; it asserts "no published behaviour changes", and the no-row binding of an exported component did change, even where no host reaches it. `check-changeset-no-major` is green, and no `skip-changeset` label is requested (#3724).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_