### PR TITLE
fix(plugin-map): type-check its tests (#4040 tranche 1)

### DIFF
--- a/.changeset/type-check-tests-plugin-map-4040.md
+++ b/.changeset/type-check-tests-plugin-map-4040.md
@@ -1,0 +1,16 @@
+---
+---
+
+Releases nothing on purpose: `@object-ui/plugin-map` now type-checks its four test files
+(`tsconfig.test.json` chained from `type-check`), and its `TEST_DEBT` entry is gone. No
+published source changed.
+
+Its one declared code-tier error turned out to be config-tier under a fuller template,
+the same reclassification `sdui-parser`'s 50 `TS2304`s got in objectui#3032. The error was
+`TS2882` on `ObjectMap.tsx`'s side-effect import of `maplibre-gl/dist/maplibre-gl.css` —
+raised not because the source is wrong (the package build compiles it cleanly) but because
+`src/global.d.ts`, which declares `*.css`, was not a program input. An ambient declaration
+file is only an input when a pattern NAMES it; being reachable by import is not enough,
+since nothing imports it. `"src/**/*.d.ts"` in the project's `include` is the fix, and it
+is the general shape for any package whose build gets ambient declarations for free from
+`"include": ["src"]`.

--- a/packages/plugin-map/package.json
+++ b/packages/plugin-map/package.json
@@ -27,7 +27,7 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/plugin-map/tsconfig.test.json
+++ b/packages/plugin-map/tsconfig.test.json
@@ -1,0 +1,30 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` excludes.
+  // See `packages/types/tsconfig.test.json` for why that exclusion was a hole:
+  // the build correctly keeps tests out of `dist`, but nothing else compiled
+  // them, so a test could assert a contract the compiler never checked.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The package build emits `dist`; this project emits nothing, so it must
+    // not inherit `composite` / `declaration` from the build config.
+    "composite": false,
+    // The `toBeInTheDocument` / `toHaveTextContent` matchers these tests use are
+    // a global augmentation, not an import, and `@testing-library/jest-dom` does
+    // not live under `@types/` — so it is never picked up automatically and has
+    // to be named here. Naming `types` at all switches off automatic `@types/*`
+    // inclusion, which is fine: nothing in these tests touches Node globals.
+    "types": ["@testing-library/jest-dom"],
+    // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` and
+    // `@objectstack/spec` resolve through the workspace dependency's built
+    // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
+    "paths": {}
+  },
+  // `src/global.d.ts` is pulled in explicitly. The build program gets it for
+  // free from `"include": ["src"]`, but an ambient declaration file is only a
+  // program input when a pattern names it — being imported is not enough,
+  // because nothing imports it. Without it `ObjectMap.tsx`'s side-effect import
+  // of `maplibre-gl/dist/maplibre-gl.css` is TS2882 here and nowhere else,
+  // which reads as a defect in the source the build compiles cleanly.
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.d.ts"]
+}

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -129,7 +129,6 @@ export const TEST_DEBT = {
   "@object-ui/auth": { errors: 2, issue: 4118 },
   "@object-ui/plugin-chatbot": { errors: 2, issue: 4118 },
   "@object-ui/plugin-grid": { errors: 2, issue: 4118 },
-  "@object-ui/plugin-map": { errors: 1, issue: 4118 },
 };
 
 // ── Collect workspace packages ───────────────────────────────────────────────


### PR DESCRIPTION
Part of #4040 — tranche 1, package 1 of 5. One package per PR, per the 裁决 on objectstack-ai/objectstack#4118 (PM, 2026-08-03):

> 小包先行,`core`(80)/`react`(76)最后;
> 每包独立 PR;守卫类 PR 必须附 pre-fix 代码报红的运行记录(判别力证明,防「绿灯守卫从未真正跑过」——已发现的第三种失败模式:tsconfig.test.json 存在但没人跑);
> TEST_DEBT 条目随包清零,只减不增。

## Measured before / after

| | code-tier errors |
|---|---|
| declared in `TEST_DEBT` | 1 |
| measured on this branch's base (`4cb0562b5`) | 1 |
| after | **0** |

Before, with the objectui#3032 template applied as-is:

```
src/ObjectMap.tsx(31,8): error TS2882: Cannot find module or type declarations for side-effect import of 'maplibre-gl/dist/maplibre-gl.css'.
```

## The one error was config-tier, not code-tier — no source changed

That `TS2882` is not a defect in `ObjectMap.tsx`; the package build compiles that
same file cleanly. It is raised because `src/global.d.ts`, which declares `*.css`,
was not a program input of the new project. An ambient declaration file is a program
input only when a pattern NAMES it — being reachable by import is not enough, because
nothing imports it. The build program gets it for free from `"include": ["src"]`; the
test project's include listed only test globs.

So the fix is `"src/**/*.d.ts"` in `include`, and this package needed **zero** source
or test changes. That is the same reclassification `sdui-parser`'s 50 `TS2304`s got in
objectui#3032 (env globals, config-tier) — worth flagging because the general shape
generalizes: any package whose build inherits ambient declarations from
`"include": ["src"]` will re-raise them here unless the test project names them too.

## Discrimination proof — the new project can fail

A `tsconfig.test.json` that exists but compiles nothing is the objectui#3009 shape and
the third failure mode the 4118 thread names. Since no guard test's assertions changed
here, the thing that needs its discrimination proven is the new project itself: does it
really read these test files? Appending a provably-false line to `src/ObjectMap.test.tsx`
and re-running:

```
$ npx tsc -p tsconfig.test.json
src/ObjectMap.test.tsx(113,7): error TS2322: Type 'string' is not assignable to type 'number'.
EXIT:2
```

Reverted immediately; the probe is not in the diff.

## Verification

```
$ pnpm --filter @object-ui/plugin-map type-check
> tsc --noEmit && tsc -p tsconfig.test.json
EXIT:0

$ pnpm exec vitest run packages/plugin-map --maxWorkers=2      # from the repo root, per objectui#3378
 Test Files  4 passed (4)
      Tests  11 passed (11)

$ node scripts/check-type-check-coverage.mjs
type-check coverage: 43/45 via `type-check`, 1 via their own build, 0 known-broken (0 errors outstanding), 1 not compiled.
test type-check coverage: 26/40 packages compile their tests, 14 declared debt (239 errors outstanding), 10 with a narrow type-assertion project.
```

`TEST_DEBT` shrinks by exactly this package's line (240 to 239 outstanding); no other
entry is touched, so the registry is the only file this tranche's PRs share.

The changeset carries empty frontmatter on purpose: config-only, releases nothing.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_