### PR TITLE
fix(dashboard): resolve a dotted dimension's labels on table and pivot dataset widgets

### DIFF
--- a/.changeset/dotted-dimension-labels-table-pivot-4263.md
+++ b/.changeset/dotted-dimension-labels-table-pivot-4263.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+fix(dashboard): resolve a dotted dimension's labels on table and pivot dataset widgets
+
+A dataset widget's client-side dimension-label safety net returned early for
+`table` / `pivot` / metric widgets, so a DOTTED dimension (`crm_account.industry`)
+rendered the raw stored enum (`education`) there — the same symptom objectui#4053
+fixed for charts, on the widget types its fix did not reach.
+
+The early return stays for LOCAL dimensions, which is what made it correct in the
+first place: on a table the server resolves those labels (ADR-0021), so running
+the client net for them would be a second resolution of an already-resolved
+value. It now opens only for dotted paths — the case the server is silent on too —
+reusing the existing `resolveDimensionFieldOptions` walk unchanged, multi-hop
+paths included. A table with no dotted dimension resolves nothing and issues no
+metadata read at all, so those widgets render byte-identically.
+
+A pivot's marginal totals take the same relabel as its rows, because their bucket
+ids are re-derived from the dimension values that the headers are built from; the
+CSV export follows the table's cells for the same reason. Drill-through still
+filters by the stored value — the relabel preserves row order and count, so the
+raw rows it indexes stay aligned.
+
+Metric widgets are unaffected by design: that branch renders one measure value
+and its header label and puts no dimension value on screen, so it has nothing to
+resolve.

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -597,10 +597,30 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // best-effort shape above the symptom was not an error but semantic option
   // colors and dimension labels silently never applying.
   useEffect(() => {
-    if (isMetric || isTable) { setCategoryColors(null); setDimensionLabels(null); setCategoryOrder(null); return; }
     const object = state.object;
-    if (!object || dimensions.length === 0) { setCategoryColors(null); setDimensionLabels(null); setCategoryOrder(null); return; }
+    // The METRIC branch renders ONE measure value plus that measure's header
+    // label — a dimension's value never reaches its output in any spelling — so
+    // there is nothing on that path to relabel and resolving would be a
+    // metadata read nothing consumes (objectui#4263, pinned).
+    if (isMetric || !object || dimensions.length === 0) { setCategoryColors(null); setDimensionLabels(null); setCategoryOrder(null); return; }
     const fieldOf = (dim: string) => (state.dimensionFields && state.dimensionFields[dim]) || dim;
+    // ── Which dimensions this widget type resolves (objectui#4263) ──────────
+    // On table/pivot the SERVER resolves a dimension's display label
+    // (ADR-0021) — that is exactly why objectui#4053's `table` widget rendered
+    // `Education` while its chart rendered `education`. So this client net
+    // stays OFF for LOCAL dimensions there: running it would be a SECOND
+    // resolution of a value the server already resolved. It opens only for
+    // DOTTED paths, the case the server is silent on too (#4053's premise),
+    // where this is the only resolution available and the table would
+    // otherwise show the raw stored enum.
+    //
+    // Charts keep resolving EVERY dimension: the server's silence for an
+    // AI-built select is the whole reason this net exists there.
+    const dottedOnly = isTable;
+    const resolveDims = dottedOnly ? dimensions.filter((d) => fieldOf(d).includes('.')) : dimensions;
+    // A table with no dotted dimension resolves nothing and — the part that
+    // makes "unchanged" literal — never issues the metadata read at all.
+    if (resolveDims.length === 0) { setCategoryColors(null); setDimensionLabels(null); setCategoryOrder(null); return; }
     let cancelled = false;
     (async () => {
       try {
@@ -620,13 +640,17 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
         // yield no entry, so the raw value survives exactly as before.
         const optionsByPath = await resolveDimensionFieldOptions(
           objSchema,
-          dimensions.map(fieldOf),
+          resolveDims.map(fieldOf),
           loadObjectSchema,
         );
-        const firstDimOptions = optionsByPath[fieldOf(dimensions[0])];
+        // Per-category COLOURS and the declared category ORDER are chart wiring
+        // — they key the palette and the axis sequence, neither of which a
+        // table or pivot renders. They stay null on that path exactly as they
+        // did when it returned early (objectui#4263).
+        const firstDimOptions = dottedOnly ? undefined : optionsByPath[fieldOf(dimensions[0])];
         const colorMap = buildOptionColorMap(firstDimOptions);
         const labels: Record<string, Record<string, string>> = {};
-        for (const dim of dimensions) {
+        for (const dim of resolveDims) {
           const m = buildDimensionLabelMap(optionsByPath[fieldOf(dim)]);
           if (m) labels[dim] = m;
         }
@@ -805,6 +829,21 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   // Table / pivot — a grouped table or, for a pivot with ≥2 dimensions, a true
   // cross-tab.
   if (isTable) {
+    // ── The dotted gap-fill's display rows (objectui#4263) ──────────────────
+    // The table/pivot branch renders `state.rows` as they arrived, which is
+    // correct for a LOCAL dimension (the server resolved its label) and leaves
+    // a DOTTED one showing the raw stored enum, since nothing resolved it.
+    // `dimensionLabels` is populated on this path for DOTTED dimensions ONLY
+    // (see the resolution effect), so for a table whose dimensions are all
+    // local it is null and `relabelDimensions` returns `state.rows` ITSELF —
+    // the same array identity, hence the same rendered bytes as before this
+    // change. It is value-keyed and idempotent besides, so a value the server
+    // already resolved has no entry and passes through untouched.
+    //
+    // Row ORDER and COUNT are preserved, which is what keeps `openDrill(i)`
+    // and `pivot.cellIndex` aligned with the raw `drillRawRows` they index
+    // into — a drill still filters by the stored value, never the label.
+    const displayRows = relabelDimensions(state.rows, dimensionLabels);
     // Drill-through (canDrill / openDrill / drillDrawer) is computed above and
     // shared with the chart path — tables/pivots drill by flat row index.
     // CSV export — display-label headers + the underlying grouped rows (measures
@@ -836,7 +875,10 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     const exportColumns = [...dimensions, ...measureColumns];
     const exportCsv = () => downloadCsv(String(widget?.title ?? datasetName ?? 'export'), [
       exportColumns.map((c) => columnLabel(c)),
-      ...state.rows.map((r) => exportColumns.map((c) => {
+      // The CSV follows the table's own cells (objectui#4263): a dotted
+      // dimension exports the label the table now shows, and a local one is
+      // unchanged for the same reason its cell is.
+      ...displayRows.map((r) => exportColumns.map((c) => {
         const v = r[c];
         return v == null ? '' : (typeof v === 'number' ? v : String(v));
       })),
@@ -861,7 +903,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
     // (an avg/min/max can't be recombined). With <2 dimensions a cross-tab is
     // meaningless, so it degrades to the flat grouped table.
     if (isMatrix) {
-      const pivot = buildPivot(state.rows, rowDims, colDim);
+      const pivot = buildPivot(displayRows, rowDims, colDim);
       // Single measure → one column per across-bucket; multiple → bucket × measure.
       const cellCols = pivot.colHeaders.flatMap((col) =>
         values.map((m) => ({ col, measure: m, header: values.length === 1 ? col.label : `${col.label} · ${headerLabel(m)}` })),
@@ -940,8 +982,17 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       // Server-supplied marginal totals (ADR-0021): match each grouping by its
       // dimension array, then its rows to the pivot headers via the same bucket
       // ids. Absent (older server) → maps stay empty and no totals UI renders.
-      const findTotals = (dims: string[]) =>
-        state.totals?.find((t) => Array.isArray(t.dimensions) && t.dimensions.join(',') === dims.join(','))?.rows;
+      const findTotals = (dims: string[]) => {
+        const totalRows = state.totals?.find((t) => Array.isArray(t.dimensions) && t.dimensions.join(',') === dims.join(','))?.rows;
+        // Marginal totals arrive keyed by the RAW dimension value, and their
+        // bucket ids are re-derived below from those values to meet the
+        // pivot's headers. Both sides must speak the same vocabulary, so the
+        // totals take the SAME relabel the display rows took (objectui#4263) —
+        // otherwise a dotted pivot's headers read `Education` while the
+        // row-total lookup still asked for `education` and every total cell
+        // silently fell back to `—`.
+        return totalRows ? relabelDimensions(totalRows, dimensionLabels) : totalRows;
+      };
       const rowTotalById = new Map<string, Row>();
       for (const r of findTotals(rowDims) ?? []) rowTotalById.set(pivotRowId(rowDims.map((d) => String(r[d] ?? '∅'))), r);
       const colTotalById = new Map<string, Row>();
@@ -1051,7 +1102,7 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
             </tr>
           </thead>
           <tbody>
-            {state.rows.map((row, i) => (
+            {displayRows.map((row, i) => (
               <tr
                 key={i}
                 className={cn('border-t', canDrill && 'cursor-pointer hover:bg-accent/40')}

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimensionTable.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.dottedDimensionTable.test.tsx
@@ -1,0 +1,349 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Regression for objectui#4263 — the half of the dotted-dimension gap that
+ * objectui#4053 (PR #4261) deliberately did not reach.
+ *
+ * #4053 fixed the client-side label safety net so a DOTTED dimension path
+ * (`crm_account.industry`) resolves its select options against the
+ * relationship's target object. That net never runs for table / pivot / metric
+ * widgets: the effect opens with `if (isMetric || isTable) { …; return; }`, and
+ * the relabeling it feeds is applied only on the chart branch. So on a `table`
+ * or `pivot` a dotted dimension still rendered the raw stored enum
+ * (`education`), which is exactly the symptom #4053 reports for charts.
+ *
+ * The ruling on #4263 is a DOTTED-ONLY GAP-FILL, and these pins are shaped to
+ * hold both halves of it apart:
+ *
+ *  - For a LOCAL dimension the server resolves the display label (ADR-0021) —
+ *    that is why #4053's widget B (a `table`) rendered `Education` correctly.
+ *    The client net must stay OFF there, or a table would double-resolve a
+ *    label the server already produced. Pinned by `renders a LOCAL dimension
+ *    exactly as the server sent it` and by the local column of the mixed test.
+ *  - For a DOTTED dimension the server is silent too (that is #4053's premise),
+ *    so the value reaches the table unresolved and the client net is the only
+ *    resolution available. Pinned red-first below.
+ *
+ * The mixed test puts BOTH on ONE table widget for the same reason the #4053
+ * suite does: the two dimensions carry the SAME option set, so any difference
+ * between the two rendered cells is the bug and nothing else — and an
+ * implementation that simply switched the early return off (resolving local
+ * dimensions on tables too) fails it, which a dotted-only fixture could not
+ * detect.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, screen, waitFor, within, fireEvent } from '@testing-library/react';
+import { DatasetWidget } from '../DatasetWidget';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The one option set the dimensions below resolve against. */
+const INDUSTRY_OPTIONS = [
+  { value: 'education', label: 'Education' },
+  { value: 'finance', label: 'Finance' },
+];
+const TYPE_OPTIONS = [
+  { value: 'partner', label: 'Partner' },
+  { value: 'direct', label: 'Direct' },
+];
+
+/** Base object: a local `industry` select + the `crm_account` relationship. */
+const OPPORTUNITY = {
+  name: 'crm_opportunity',
+  fields: {
+    industry: { type: 'select', options: INDUSTRY_OPTIONS },
+    crm_account: { type: 'lookup', reference: 'crm_account' },
+  },
+};
+/** The relationship's TARGET object, where the dotted paths' options live. */
+const ACCOUNT = {
+  name: 'crm_account',
+  fields: {
+    industry: { type: 'select', options: INDUSTRY_OPTIONS },
+    type: { type: 'select', options: TYPE_OPTIONS },
+    owner: { type: 'lookup', reference: 'crm_user' },
+  },
+};
+
+/**
+ * Route `GET /api/v1/meta/object/<name>` to a per-object document, recording
+ * the object names asked for (so "no resolution was attempted at all" is
+ * observable, not just "no relabeling happened"). Mirrors the #4053 suite.
+ */
+function installMetaRouter(docs: Record<string, unknown>) {
+  const requested: string[] = [];
+  const fn = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    const m = /\/api\/v1\/meta\/object\/(.+)$/.exec(url);
+    const name = m ? decodeURIComponent(m[1]) : '';
+    requested.push(name);
+    const doc = docs[name];
+    if (!doc) return { ok: false, json: async () => ({}) };
+    return { ok: true, json: async () => ({ item: doc }) };
+  });
+  global.fetch = fn as any;
+  return { requested };
+}
+
+const sourceOf = (result: unknown) => ({ queryDataset: vi.fn(async () => result) });
+
+/** Cell texts of the flat table's first body row, in column order. */
+const firstRowCells = (): string[] =>
+  Array.from(document.querySelectorAll('tbody tr')[0]?.querySelectorAll('td') ?? []).map(
+    (td) => td.textContent ?? '',
+  );
+
+describe('DatasetWidget dotted-dimension labels on table / pivot (objectui#4263)', () => {
+  it('resolves a DOTTED dimension on a table, and leaves the LOCAL one exactly as it arrived', async () => {
+    // Both dimensions carry the SAME option set. The server sent both
+    // value-keyed — for the local one that is the server's own business
+    // (ADR-0021 resolution is its job and this fixture models a server that
+    // did not do it), for the dotted one it is the #4053 premise.
+    const { requested } = installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'table',
+          dataset: 'd',
+          dimensions: ['industry', 'account_industry'],
+          values: ['total_amount'],
+        }}
+        dataSource={sourceOf({
+          rows: [{ industry: 'education', account_industry: 'education', total_amount: 10 }],
+          fields: [
+            { name: 'industry', type: 'select', label: 'Industry' },
+            { name: 'account_industry', type: 'select', label: 'Account Industry' },
+            { name: 'total_amount', type: 'number', label: 'Total Amount' },
+          ],
+          object: 'crm_opportunity',
+          dimensionFields: { industry: 'industry', account_industry: 'crm_account.industry' },
+        })}
+      />,
+    );
+
+    // THE GAP: the dotted dimension resolves to its option label. Pre-fix this
+    // cell held the raw stored `education`.
+    await waitFor(() => expect(firstRowCells()[1]).toBe('Education'));
+
+    // THE BOUNDARY: the local dimension is untouched in the same render. The
+    // server owns that label on a table; resolving it here would be a second
+    // resolution of the same value.
+    expect(firstRowCells()[0]).toBe('education');
+
+    // It got there through the same `GET /meta/object/:name` channel #4261
+    // already uses, walking to the relationship target.
+    expect(requested).toEqual(['crm_opportunity', 'crm_account']);
+  });
+
+  it('renders a LOCAL-only table exactly as the server sent it, resolving nothing', async () => {
+    // Control for the acceptance boundary: a table whose dimensions are all
+    // local must render byte-identically to today. The server-resolved label
+    // passes through untouched AND no object metadata is fetched at all — the
+    // early return still holds for this widget, so there is no resolution that
+    // could double-apply.
+    const { requested } = installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+    render(
+      <DatasetWidget
+        widget={{ type: 'table', dataset: 'd', dimensions: ['industry'], values: ['total_amount'] }}
+        dataSource={sourceOf({
+          // The server DID resolve it (ADR-0021) — this is #4053's widget B.
+          rows: [{ industry: 'Education', total_amount: 10 }],
+          fields: [
+            { name: 'industry', type: 'select', label: 'Industry' },
+            { name: 'total_amount', type: 'number', label: 'Total Amount' },
+          ],
+          object: 'crm_opportunity',
+          dimensionFields: { industry: 'industry' },
+        })}
+      />,
+    );
+
+    await waitFor(() => expect(firstRowCells()[0]).toBe('Education'));
+    expect(requested).toEqual([]);
+  });
+
+  it('resolves BOTH the row and the column dimension of a dotted pivot, keeping server totals aligned', async () => {
+    // A pivot's row/column bucket IDS are derived from the same values as its
+    // header LABELS, while the server's marginal totals arrive keyed by the raw
+    // values. Relabeling one side only would silently break the total lookup —
+    // the headers would read `Education` while the row-total cell fell back to
+    // `—`. The totals here are what pins that.
+    installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+    render(
+      <DatasetWidget
+        widget={{
+          type: 'pivot',
+          dataset: 'd',
+          dimensions: ['acct_industry', 'acct_type'],
+          values: ['total'],
+        }}
+        dataSource={sourceOf({
+          rows: [
+            { acct_industry: 'education', acct_type: 'partner', total: 5 },
+            { acct_industry: 'finance', acct_type: 'direct', total: 7 },
+          ],
+          fields: [
+            { name: 'acct_industry', type: 'select', label: 'Industry' },
+            { name: 'acct_type', type: 'select', label: 'Type' },
+            { name: 'total', type: 'number', label: 'Total' },
+          ],
+          object: 'crm_opportunity',
+          dimensionFields: {
+            acct_industry: 'crm_account.industry',
+            acct_type: 'crm_account.type',
+          },
+          totals: [
+            {
+              dimensions: ['acct_industry'],
+              rows: [
+                { acct_industry: 'education', total: 5 },
+                { acct_industry: 'finance', total: 7 },
+              ],
+            },
+            {
+              dimensions: ['acct_type'],
+              rows: [
+                { acct_type: 'partner', total: 5 },
+                { acct_type: 'direct', total: 7 },
+              ],
+            },
+            { dimensions: [], rows: [{ total: 12 }] },
+          ],
+        })}
+      />,
+    );
+
+    const matrix = await screen.findByTestId('dataset-matrix');
+    // Row dimension (down the side) resolves.
+    await waitFor(() => {
+      const rowCells = Array.from(matrix.querySelectorAll('tbody tr td')).map((td) => td.textContent);
+      expect(rowCells).toContain('Education');
+      expect(rowCells).toContain('Finance');
+    });
+    // Column dimension (across the top) resolves too.
+    const headers = Array.from(matrix.querySelectorAll('thead th')).map((th) => th.textContent);
+    expect(headers).toContain('Partner');
+    expect(headers).toContain('Direct');
+    expect(headers).not.toContain('partner');
+
+    // …and the server's row totals still find their bucket after the relabel.
+    const rowTotals = within(matrix).getAllByTestId('matrix-row-total').map((td) => td.textContent);
+    expect(rowTotals).toEqual(['5', '7']);
+    expect(within(matrix).getByTestId('matrix-grand-total').textContent).toBe('12');
+  });
+
+  it('walks a MULTI-HOP dotted path on a table (a.b.field)', async () => {
+    // ADR-0071: the dataset designer emits `relationship.relationship.field`,
+    // and #4261's resolver walks per-segment. One pin that the table path gets
+    // the same walk, not a single-hop special case.
+    const { requested } = installMetaRouter({
+      crm_opportunity: OPPORTUNITY,
+      crm_account: ACCOUNT,
+      crm_user: {
+        name: 'crm_user',
+        fields: {
+          department: { type: 'select', options: [{ value: 'rnd', label: 'Research & Development' }] },
+        },
+      },
+    });
+    render(
+      <DatasetWidget
+        widget={{ type: 'table', dataset: 'd', dimensions: ['owner_dept'], values: ['total'] }}
+        dataSource={sourceOf({
+          rows: [{ owner_dept: 'rnd', total: 1 }],
+          fields: [
+            { name: 'owner_dept', type: 'select', label: 'Department' },
+            { name: 'total', type: 'number', label: 'Total' },
+          ],
+          object: 'crm_opportunity',
+          dimensionFields: { owner_dept: 'crm_account.owner.department' },
+        })}
+      />,
+    );
+
+    await waitFor(() => expect(firstRowCells()[0]).toBe('Research & Development'));
+    expect(requested).toEqual(['crm_opportunity', 'crm_account', 'crm_user']);
+  });
+
+  it('exports the resolved label for a dotted column and the untouched value for a local one', async () => {
+    // The CSV is the table's data, so it follows the table's cells: a dotted
+    // dimension exports what the table now shows. For a LOCAL dimension the
+    // export is unchanged for the same reason the cell is.
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    const blobs: any[] = [];
+    (URL as any).createObjectURL = (b: any) => { blobs.push(b); return 'blob:x'; };
+    (URL as any).revokeObjectURL = () => {};
+    try {
+      installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+      render(
+        <DatasetWidget
+          widget={{
+            type: 'table',
+            dataset: 'd',
+            dimensions: ['industry', 'account_industry'],
+            values: ['total_amount'],
+          }}
+          dataSource={sourceOf({
+            rows: [{ industry: 'education', account_industry: 'education', total_amount: 10 }],
+            fields: [
+              { name: 'industry', type: 'select', label: 'Industry' },
+              { name: 'account_industry', type: 'select', label: 'Account Industry' },
+              { name: 'total_amount', type: 'number', label: 'Total Amount' },
+            ],
+            object: 'crm_opportunity',
+            dimensionFields: { industry: 'industry', account_industry: 'crm_account.industry' },
+          })}
+        />,
+      );
+      // Wait for the resolution to land before exporting.
+      await waitFor(() => expect(firstRowCells()[1]).toBe('Education'));
+      fireEvent.click(await screen.findByTestId('dataset-export'));
+      expect(blobs).toHaveLength(1);
+      // downloadCsv prepends a UTF-8 BOM so Excel reads non-ASCII labels.
+      const text: string = (await blobs[0].text()).replace(/^\uFEFF/, '');
+      const [, body] = text.split('\r\n');
+      expect(body).toBe('education,Education,10');
+    } finally {
+      (URL as any).createObjectURL = origCreate;
+      (URL as any).revokeObjectURL = origRevoke;
+    }
+  });
+
+  it('METRIC: the branch renders no dimension value at all, so there is nothing to resolve', async () => {
+    // Measured verdict for the metric third of this card. `METRIC_TYPES`
+    // (metric/kpi/gauge/solid-gauge/bullet) renders ONE measure value plus the
+    // measure's header label — a dimension's value never reaches the DOM, in
+    // any spelling. So a dotted dimension on a metric has no raw value on
+    // screen to resolve: the gap the issue describes for table/pivot is empty
+    // here, and turning the resolution on would be a metadata fetch whose
+    // result nothing reads.
+    const { requested } = installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+    const { container } = render(
+      <DatasetWidget
+        widget={{ type: 'metric', dataset: 'd', dimensions: ['acct_industry'], values: ['total'] }}
+        dataSource={sourceOf({
+          rows: [{ acct_industry: 'education', total: 5 }],
+          fields: [
+            { name: 'acct_industry', type: 'select', label: 'Industry' },
+            { name: 'total', type: 'number', label: 'Total' },
+          ],
+          object: 'crm_opportunity',
+          dimensionFields: { acct_industry: 'crm_account.industry' },
+        })}
+      />,
+    );
+
+    await waitFor(() => expect(container.textContent).toContain('5'));
+    // Neither the raw value nor its label is rendered — the dimension is not
+    // part of this branch's output.
+    expect(container.textContent).not.toContain('education');
+    expect(container.textContent).not.toContain('Education');
+    // And no resolution was attempted for it.
+    expect(requested).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #4263

Implements the **dotted-only gap-fill** ruling on the card. Built on top of #4261, which is on `main`.

## Premise: confirmed, red-first

The pins were written and run BEFORE the source was touched. Four went red on exactly the reported symptom, two were green from the start (the controls):

```
× resolves a DOTTED dimension on a table ...      expected 'education' to be 'Education'
× resolves BOTH row and column dims of a pivot ... expected [ 'education', '5', '—', … ] to include 'Education'
× walks a MULTI-HOP dotted path on a table ...     expected 'rnd' to be 'Research & Development'
× exports the resolved label for a dotted column   expected 'education' to be 'Education'
Tests  4 failed | 2 passed (6)
```

## Where the labels actually enter each render path (measured)

This was the card's open question — the label map does NOT enter the table paths the way it enters the chart path, and one consumer had to follow it or it would have gone quietly wrong.

| path | what it consumes | wiring point |
|---|---|---|
| chart | `relabelDimensions(state.rows, dimensionLabels)` as `chartRows` | already existed (#4261) |
| flat table | `state.rows` rendered verbatim through `formatDimensionValue(row[c])` | now renders `displayRows` |
| pivot / cross-tab | `buildPivot(state.rows, …)`, which derives header labels AND bucket ids from the same row values | now `buildPivot(displayRows, …)` |
| pivot marginal totals | `state.totals` rows, whose bucket ids are RE-DERIVED here to meet the pivot's headers | now take the SAME relabel |
| CSV export | `state.rows` | now `displayRows` |
| metric | one measure value plus its header label — **no dimension value at all** | nothing to wire (see below) |

No new rendering plumbing was needed: every table/pivot consumer reads rows, so feeding it the already-relabeled rows is sufficient. That is why this is not a `needs_decision`.

**The pivot totals were the real trap.** `buildPivot` builds a row's bucket id from `String(row[d])` and its header label from the same value, while the totals lookup re-derives ids from the raw `state.totals` rows. Relabeling the rows alone would have left the headers reading `Education` while the total lookup still asked for `education`, so every total cell would have silently fallen back to `—`. Both sides now speak the same vocabulary. The pivot pin carries server totals specifically to hold this.

## Metric verdict: nothing to resolve, by measurement

The `METRIC_TYPES` branch (`metric`/`kpi`/`gauge`/`solid-gauge`/`bullet`) renders `formatMeasure(value, …)` plus `headerLabel(values[0])`. A dimension's value never reaches its output in any spelling, so a dotted dimension on a metric has no raw value on screen to resolve — the gap the issue describes for table/pivot is empty there, and turning the resolution on would be a metadata read whose result nothing consumes. The effect therefore still returns early for metric, and a pin asserts the branch renders the measure while containing neither `education` nor `Education`.

## The boundary: local dimensions stay the server's job

The early return was not arbitrary. On a table the server resolves a local dimension's label (ADR-0021) — that is exactly why #4053's `table` widget rendered `Education` while its chart rendered `education`. Running the client net for local dimensions there would be a SECOND resolution of an already-resolved value, so it stays off for them and opens only for dotted paths.

Two proofs that local-on-table is byte-identical:

1. **Same widget, side by side.** The main pin puts a local and a dotted dimension carrying the SAME option set on ONE table. The dotted cell resolves to `Education`; the local cell still renders `education` in the same render. Any difference between them is the bug and nothing else — and an implementation that just switched the early return off fails this, which a dotted-only fixture could not detect.
2. **No read is even issued.** A table with no dotted dimension returns before the fetch, so `dimensionLabels` stays null and `relabelDimensions` returns `state.rows` ITSELF (same array identity, not a copy). The control pin asserts the server-provided label passes through untouched AND that the list of requested objects is empty.

Per-category colours and the declared category order stay chart-only — a table renders neither.

Drill-through is untouched: the relabel preserves row order and count, so `openDrill(i)` and `pivot.cellIndex` still index the raw `drillRawRows`, and a drill filters by the stored value rather than the label.

## Reverse verification

Predicted RED on the four new pins with the raw values returning, and both controls staying GREEN. Reverted `DatasetWidget.tsx` alone via `git checkout origin/main -- ...` (no stash), keeping the tests:

```
Tests  4 failed | 2 passed (6)
   expected 'education' to be 'Education'
   expected 'rnd' to be 'Research & Development'
```

Exactly as predicted, then restored to 6 passed.

## Verification

- `vitest run packages/plugin-dashboard/ packages/plugin-charts/ packages/core/src/utils/__tests__/chart-series.test.ts` — **58 files, 491 tests passed**, including #4261's dotted-chart pins (unchanged) and the existing pivot / compareTo / CSV suites.
- `pnpm --filter @object-ui/plugin-dashboard type-check` — clean.
- `pnpm --filter @object-ui/plugin-dashboard lint` — 0 errors (252 pre-existing `any` warnings).
- `pnpm check:control-bytes` — OK, 3987 files; plus a self-scan of both touched files for raw control bytes: clean.
- Build closure built first (`--filter '@object-ui/plugin-dashboard^...' build`).
- **No i18n keys added** — this resolves values against authored field options; no new user-facing strings.
- Changeset: `@object-ui/plugin-dashboard` patch.

## Region note

Stayed out of `buildPivot`'s bucket-id encoding, which #4056 is editing. The only line of `buildPivot`'s call site that changed is the argument passed to it.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_