### PR TITLE
fix(auth): type-check its tests (#4040 tranche 1)

### DIFF
--- a/.changeset/type-check-tests-auth-4040.md
+++ b/.changeset/type-check-tests-auth-4040.md
@@ -1,0 +1,16 @@
+---
+---
+
+Releases nothing on purpose: `@object-ui/auth` now type-checks its eleven test files
+(`tsconfig.test.json` chained from `type-check`), and its `TEST_DEBT` entry is gone. Only
+test sources changed; no published behaviour, and no public type, moved.
+
+Both declared code-tier errors were real:
+
+- `AuthProvider.test.tsx`'s `createMockClient` claimed to return an `AuthClient` while
+  implementing 8 of its ~38 methods. The double is the right call — the provider only
+  reaches those 8 on the paths under test — but the claim was not, and it is the exact
+  thing an unchecked test hides. Asserted at the one seam with `as unknown as AuthClient`,
+  which is what this package's three other mock-client factories already do.
+- `createAuthClient.test.ts` had an unread `input` parameter on a `fetch` double
+  (`TS6133`, from the repo's `noUnusedParameters`), renamed `_input`.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -30,7 +30,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
-    "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json && tsc -p tsconfig.test.json",
     "lint": "eslint ."
   },
   "peerDependencies": {

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -27,7 +27,13 @@ function createMockClient(overrides: Partial<AuthClient> = {}): AuthClient {
     resetPassword: vi.fn().mockResolvedValue(undefined),
     updateUser: vi.fn().mockResolvedValue({ id: '1', name: 'Updated', email: 'test@test.com' }),
     ...overrides,
-  };
+    // `AuthClient` declares ~38 methods; this double implements the eight the
+    // provider reaches on the paths under test, which is the same shape (and
+    // the same assertion) as `LoginForm.test.tsx`, `identifier-trim.test.tsx`
+    // and `SocialSignInButtons.test.tsx` in this package. Asserting at the one
+    // seam keeps the lie in a single named place instead of stubbing thirty
+    // methods no test calls.
+  } as unknown as AuthClient;
 }
 
 function TestConsumer() {

--- a/packages/auth/src/__tests__/createAuthClient.test.ts
+++ b/packages/auth/src/__tests__/createAuthClient.test.ts
@@ -151,7 +151,7 @@ describe('createAuthClient', () => {
     const user = { id: '1', name: 'Jack', email: 'jack@test.com' };
     // Bearer-carrying call sees no session (stale token); the cookie-only
     // retry (no Authorization header) sees the live SSO session.
-    const mockFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const mockFn = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
       const headers = new Headers(init?.headers);
       const hasBearer = Boolean(headers.get('Authorization'));
       const body = hasBearer ? null : { user, session };

--- a/packages/auth/tsconfig.test.json
+++ b/packages/auth/tsconfig.test.json
@@ -1,0 +1,35 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` excludes.
+  // See `packages/types/tsconfig.test.json` for why that exclusion was a hole:
+  // the build correctly keeps tests out of `dist`, but nothing else compiled
+  // them, so a test could assert a contract the compiler never checked.
+  //
+  // `tsconfig.typetests.json` next door is the narrow rescue this supersedes for
+  // this package: it compiles `auth-spec-parity.test.ts` alone, because that one
+  // file's whole value is compile-time assertions and it could not wait for the
+  // rest of the tree to compile (objectui#3181). It stays chained — the file is
+  // now read by both projects, which costs one extra compile and keeps the
+  // narrow project's reasoning where it was written.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The package build emits `dist`; this project emits nothing, so it must
+    // not inherit `composite` / `declaration` from the build config.
+    "composite": false,
+    // Two global augmentations, neither of them an import:
+    //   - `node` for `auth-spec-parity.test.ts` and `reserved-auth-features.test.ts`,
+    //     which resolve `@objectstack/spec`'s own `.d.ts` off disk (createRequire /
+    //     readFileSync / node:path) to read the spec's export names.
+    //   - `@testing-library/jest-dom` for the `toBeInTheDocument` / `toBeDisabled`
+    //     matchers in `LoginForm.test.tsx` and `SocialSignInButtons.test.tsx`;
+    //     it does not live under `@types/`, so it is never picked up automatically.
+    // Naming `types` at all switches off automatic `@types/*` inclusion, so both
+    // have to be listed here.
+    "types": ["node", "@testing-library/jest-dom"],
+    // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` and
+    // `@objectstack/spec` resolve through the workspace dependency's built
+    // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
+    "paths": {}
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.d.ts"]
+}

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -126,7 +126,6 @@ export const TEST_DEBT = {
   "@object-ui/permissions": { errors: 5, issue: 4118, note: "TS2741x5" },
   "@object-ui/plugin-detail": { errors: 5, issue: 4118, note: "TS2353x3 — dialect keys" },
   "@object-ui/plugin-gantt": { errors: 3, issue: 4118 },
-  "@object-ui/auth": { errors: 2, issue: 4118 },
   "@object-ui/plugin-chatbot": { errors: 2, issue: 4118 },
   "@object-ui/plugin-grid": { errors: 2, issue: 4118 },
   "@object-ui/plugin-map": { errors: 1, issue: 4118 },


### PR DESCRIPTION
Part of #4040 — tranche 1, package 2 of 5. One package per PR, per the 裁决 on objectstack-ai/objectstack#4118 (PM, 2026-08-03):

> 小包先行,`core`(80)/`react`(76)最后;
> 每包独立 PR;守卫类 PR 必须附 pre-fix 代码报红的运行记录(判别力证明,防「绿灯守卫从未真正跑过」——已发现的第三种失败模式:tsconfig.test.json 存在但没人跑);
> TEST_DEBT 条目随包清零,只减不增。

## Measured before / after

| | code-tier errors |
|---|---|
| declared in `TEST_DEBT` | 2 |
| measured on this branch's base (`4cb0562b5`) | 2 |
| after | **0** |

Before:

```
src/__tests__/AuthProvider.test.tsx(15,3): error TS2322: Type '{ signIn: ((credentials: SignInCredentials) => Promise< { user: AuthUser; session: AuthClientSession; } >) | Mock< ... >; ... 37 more ...; listUserInvitations?: (() => Promise< AuthInvitation[] >) | undefined; }' is not assignable to type 'AuthClient'.
  Types of property 'sendVerificationEmail' are incompatible.
    Type '((email: string, callbackURL?: string | undefined) => Promise< void >) | undefined' is not assignable to type '(email: string, callbackURL?: string | undefined) => Promise< void >'.
      Type 'undefined' is not assignable to type '(email: string, callbackURL?: string | undefined) => Promise< void >'.
src/__tests__/createAuthClient.test.ts(154,33): error TS6133: 'input' is declared but its value is never read.
```

Both were real code-tier defects — nothing reclassified as config here.

### 1. A mock that claimed to be an `AuthClient` and was not

`createMockClient` is annotated `: AuthClient` and implements 8 of that interface's ~38
methods. The double itself is the right call — `AuthProvider` reaches only those 8 on the
paths under test, and stubbing thirty unreached methods would be noise. The *claim* was
not: an unchecked test asserting a type it does not satisfy is precisely the "reads as
evidence" failure #4040 is about.

Resolved the way this package's three other mock-client factories already do it —
`LoginForm.test.tsx:36`, `identifier-trim.test.tsx:29`, `SocialSignInButtons.test.tsx:29`
all end `} as unknown as AuthClient;`. `AuthProvider.test.tsx` was the one that predated
the convention. No public type changed, and no method was stubbed to make an assertion
pass.

### 2. `TS6133` on an unread fetch-double parameter

`noUnusedParameters` is on repo-wide; `_input` is the sanctioned spelling.

## Discrimination proof — the new project can fail

A `tsconfig.test.json` that exists but compiles nothing is the objectui#3009 shape and the
third failure mode the 4118 thread names, so the new project itself is what needs its
discrimination shown. Appending a provably-false line to `src/__tests__/AuthProvider.test.tsx`
and re-running:

```
$ npx tsc -p tsconfig.test.json
src/__tests__/AuthProvider.test.tsx(331,7): error TS2322: Type 'string' is not assignable to type 'number'.
EXIT:2
```

Reverted immediately; the probe is not in the diff.

## Note on the existing narrow project

`tsconfig.typetests.json` (objectui#3181) compiles `auth-spec-parity.test.ts` alone — the
rescue for a package whose whole test tree was in debt. It stays chained and now overlaps
the full project, at the cost of one extra compile of one file. Retiring the narrow
projects once their package leaves `TEST_DEBT` is a real cleanup but it is not this
tranche's scope, and it is reported to the PM as a finding rather than smuggled in here.

## Verification

```
$ pnpm --filter @object-ui/auth type-check
> tsc --noEmit && tsc -p tsconfig.typetests.json && tsc -p tsconfig.test.json
EXIT:0

$ pnpm exec vitest run packages/auth --maxWorkers=2      # from the repo root, per objectui#3378
 Test Files  11 passed (11)
      Tests  142 passed (142)

$ node scripts/check-type-check-coverage.mjs
type-check coverage: 43/45 via `type-check`, 1 via their own build, 0 known-broken (0 errors outstanding), 1 not compiled.
test type-check coverage: 26/40 packages compile their tests, 14 declared debt (238 errors outstanding), 10 with a narrow type-assertion project.

$ node scripts/check-changeset-presence.mjs
2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) ... EMPTY frontmatter — declared as releasing nothing.
```

`TEST_DEBT` shrinks by exactly this package's line; no other entry is touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_