### PR TITLE
fix(console): nest internal `/forms/:name` in the console shell; internal submit lands on the created record (#4109)

### DIFF
--- a/.changeset/internal-form-in-shell-4109.md
+++ b/.changeset/internal-form-in-shell-4109.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/console': minor
+---
+
+Internal `/forms/:name` renders inside the console shell, and an internal submit lands on the record it just created
+
+A `type: 'form'` action navigates to `/forms/:name` (`ActionRunner.executeForm`). That route was declared at the TOP level of the console route tree, a sibling of the app-shell routes, so clicking a button inside an app dropped the user onto a bare form — no header, no navigation, no way back — while the URL still said they were in the console. It now renders inside the console's layout for app-independent authed pages, the same chrome `/home` and `/organizations` use. The route itself is unchanged: deep links to it keep working, because the missing chrome was the defect, not the navigation.
+
+The second half is what happens after Submit. The post-submit default was `{ kind: 'thank-you' }` for both form modes, so a signed-in operator who had just created a record was shown the ANONYMOUS confirmation — "Your submission has been received" — with no link to the thing they had created. The default is now mode-aware: an internal submit navigates to the created record's page, while the public `/f/:slug` path keeps `thank-you`, which is the right answer for a visitor who has no console to be sent into. A form view that declares its own `submitBehavior` still wins in both modes, unchanged and untouched — the point of a default is that the corpus never has to opt out of a wrong one.
+
+Landing on the record needs the created record's id, and that comes from the spec-declared `CreateDataResponse = { object, id, record }` returned by `POST /api/v1/data/:object`. Only that one declared key is read: `record.id` carries the same value, but reading both would be a second de-facto contract for one fact. A response that names no id — or a workspace where no app can host the record's page — falls back to confirming the submit rather than navigating somewhere broken, since the record really was created and silence would be the worse answer.
+
+No authorable surface changed. The "land on the created record" behaviour is deliberately NOT a new `submitBehavior.kind`: the spec's union (`thank-you | redirect | continue | next-record`) is strict and stays exactly as it is, and nothing parses the new internal default out of metadata — it is only what the renderer does when an author declared nothing.

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -46,6 +46,7 @@ import { RootLandingRedirect } from './components/RootLandingRedirect';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { SetupRoute } from './components/SetupRoute';
 import { FormPage } from './components/FormPage';
+import { InternalFormRoute } from './components/InternalFormRoute';
 import { MetadataHmrReloader } from './components/MetadataHmrReloader';
 import SharedRecordPage from './pages/SharedRecordPage';
 import DocPage from './pages/DocPage';
@@ -213,10 +214,17 @@ export function App() {
                 <StudioDesignSurface />
               </ProtectedRoute>
             } />
-            {/* Internal authed form — same renderer, different submit path. */}
+            {/* Internal authed form — same renderer as `/f/:slug`, different
+              * submit path, and (objectui#4109) rendered INSIDE the console
+              * shell instead of as a bare page. The route stays exactly where
+              * it is: per the 2026-08-10 ruling on objectstack#7245 the missing
+              * chrome was the defect, not the navigation, so deep links keep
+              * working. `InternalFormRoute` owns the chrome + the "land on the
+              * created record" target; the public path above stays chrome-less
+              * on purpose (an anonymous visitor has no console to be in). */}
             <Route path="/forms/:name" element={
               <ProtectedRoute>
-                <FormPage mode="internal" />
+                <InternalFormRoute />
               </ProtectedRoute>
             } />
             {/* Package documentation (ADR-0046): a platform-level portal

--- a/apps/console/src/__tests__/internalFormShell.test.tsx
+++ b/apps/console/src/__tests__/internalFormShell.test.tsx
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4109 — `/forms/:name` (mode=internal) renders INSIDE the console
+ * shell; `/f/:slug` (mode=public) stays chrome-less.
+ *
+ * Maintainer ruling, 2026-08-10, quoted verbatim from objectstack#7245:
+ *
+ * > 1. `/forms/:name` in `mode="internal"` nests inside the console shell (keep
+ * >    the route — deep-linking survives; the missing chrome is the defect, not
+ * >    the navigation).
+ *
+ * ## What this measures, and why it renders the REAL App
+ *
+ * The deliverable is a property of `App.tsx`'s route table — which element each
+ * of the two form routes mounts — so this file renders that table rather than a
+ * transcription of it. A hand-copied route list would be free to agree with
+ * whatever the source does, which is the trap
+ * `AppContent.systemHubRoutes.test.tsx` documents at length for the same
+ * reason. Everything App.tsx imports but this card does not touch is stubbed
+ * (auth surfaces, docs, dev harnesses, the per-app SPA) so the table itself is
+ * the only thing under test.
+ *
+ * The console chrome is stubbed to a MARKER, following the same precedent
+ * (`AppContent.systemHubRoutes.test.tsx` stubs `ConsoleLayout` to a
+ * `data-testid` div): what is being pinned here is that the internal form is
+ * nested inside the shell layout at all, not how `HomeLayout` paints — that
+ * belongs to `@object-ui/app-shell`'s own tests.
+ *
+ * ## Reverse verification
+ *
+ * Both tests are change-detectors, in opposite directions. Restoring the
+ * pre-fix element (`<FormPage mode="internal" />` bare, a sibling of the
+ * app-shell routes) turns the first test red — the marker never renders — and
+ * leaves the second green. Wrapping the PUBLIC route in the same chrome turns
+ * the second red and leaves the first green. So neither can pass by accident
+ * for the other one's reason.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// `vi.hoisted`, not plain consts: every `vi.mock` factory below is hoisted to
+// the top of the file, so a factory closing over an ordinary `const` reads it
+// before initialization.
+const { passthrough, stub } = vi.hoisted(() => ({
+  passthrough: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  stub: (testid: string) => () => <div data-testid={testid} />,
+}));
+
+// ── The console chrome, stubbed to a marker ──────────────────────────────
+// `DefaultHomeLayout` is the console's layout for app-INDEPENDENT authed pages
+// (`/home`, `/organizations` — and now the internal form). Its presence IS the
+// "nested inside the console shell" assertion.
+vi.mock('@object-ui/app-shell', () => ({
+  ConsoleShell: passthrough,
+  ConsoleToaster: () => null,
+  RequireAiSurface: passthrough,
+  SystemRedirect: () => null,
+  DefaultHomeLayout: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="console-shell-layout">{children}</div>
+  ),
+  DefaultHomePage: stub('home-page'),
+  DefaultOrganizationsLayout: passthrough,
+  DefaultOrganizationsPage: stub('organizations-page'),
+  DefaultOrganizationLayout: stub('organization-layout'),
+  DefaultMembersPage: stub('members-page'),
+  DefaultInvitationsPage: stub('invitations-page'),
+  DefaultSettingsPage: stub('settings-page'),
+  DefaultAcceptInvitationPage: stub('accept-invitation-page'),
+  DefaultAiChatPage: stub('ai-chat-page'),
+  StudioDesignSurface: stub('studio-design-surface'),
+  BuilderLanding: stub('builder-landing'),
+  getProductName: () => 'ObjectOS',
+  getFaviconUrl: () => '',
+  // Consumed by InternalFormRoute to resolve the created-record target.
+  useMetadata: () => ({ apps: [{ name: 'showcase_app', _packageId: 'ai.objectstack.showcase' }] }),
+  useNavigationContext: () => ({ currentAppName: 'showcase_app' }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  AuthProvider: passthrough,
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+// ── Everything else App.tsx imports but this card does not touch ─────────
+vi.mock('../components/ProtectedRoute', () => ({ ProtectedRoute: passthrough }));
+vi.mock('../components/RootLandingRedirect', () => ({ RootLandingRedirect: stub('root-landing') }));
+vi.mock('../components/SetupRoute', () => ({ SetupRoute: stub('setup-route') }));
+vi.mock('../components/MetadataHmrReloader', () => ({ MetadataHmrReloader: () => null }));
+vi.mock('../AppContent', () => ({ AppContent: stub('app-content') }));
+vi.mock('../pages/SharedRecordPage', () => ({ default: stub('shared-record-page') }));
+vi.mock('../pages/DocPage', () => ({ default: stub('doc-page') }));
+vi.mock('../pages/DocsIndex', () => ({ default: stub('docs-index') }));
+vi.mock('../pages/DocsSlug', () => ({ default: stub('docs-slug') }));
+vi.mock('../pages/DocsLayout', () => ({ default: stub('docs-layout') }));
+vi.mock('../pages/auth/LoginPage', () => ({ LoginPage: stub('login-page') }));
+vi.mock('../pages/auth/RegisterPage', () => ({ RegisterPage: stub('register-page') }));
+vi.mock('../pages/auth/ForgotPasswordPage', () => ({ ForgotPasswordPage: stub('forgot-page') }));
+vi.mock('../pages/auth/ResetPasswordPage', () => ({ ResetPasswordPage: stub('reset-page') }));
+vi.mock('../pages/auth/SetPasswordPage', () => ({ SetPasswordPage: stub('set-password-page') }));
+vi.mock('../pages/auth/VerifyEmailPage', () => ({ VerifyEmailPage: stub('verify-email-page') }));
+vi.mock('../pages/auth/VerifyEmailPromptPage', () => ({ VerifyEmailPromptPage: stub('verify-prompt-page') }));
+vi.mock('../pages/auth/OAuthConsentPage', () => ({ OAuthConsentPage: stub('oauth-consent-page') }));
+vi.mock('../pages/auth/DeviceAuthPage', () => ({ DeviceAuthPage: stub('device-auth-page') }));
+vi.mock('../dev/DevMasterDetail', () => ({ DevMasterDetail: stub('dev-master-detail') }));
+vi.mock('../dev/DevLists', () => ({ DevLists: stub('dev-lists') }));
+vi.mock('../dev/DevModal', () => ({ DevModal: stub('dev-modal') }));
+vi.mock('../dev/DevLookup', () => ({ DevLookup: stub('dev-lookup') }));
+vi.mock('../dev/DevRowActions', () => ({ DevRowActions: stub('dev-row-actions') }));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { App } from '../App';
+
+/** The FormView + object metadata both form modes resolve their spec from. */
+const INTERNAL_VIEW = {
+  name: 'showcase_task.edit',
+  object: 'showcase_task',
+  viewKind: 'form',
+  label: 'Log Time',
+  config: { type: 'simple', sections: [{ fields: ['title'] }] },
+};
+const OBJECT_SCHEMA = { name: 'showcase_task', fields: { title: { type: 'text', label: 'Title' } } };
+const PUBLIC_FORM = {
+  slug: 'contact-us',
+  object: 'showcase_inquiry',
+  label: 'Contact us',
+  form: { type: 'simple', sections: [{ fields: ['title'] }] },
+  objectSchema: { name: 'showcase_inquiry', fields: { title: { type: 'text', label: 'Title' } } },
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      const body = String(url).includes('/meta/view/')
+        ? INTERNAL_VIEW
+        : String(url).includes('/meta/object/')
+          ? OBJECT_SCHEMA
+          : PUBLIC_FORM;
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+      } as unknown as Response;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.history.pushState({}, '', '/');
+});
+
+describe('form routes and the console shell (objectui#4109)', () => {
+  it('nests the internal /forms/:name inside the console shell layout', async () => {
+    window.history.pushState({}, '', '/forms/showcase_task.edit');
+    render(<App />);
+
+    // The form itself resolved and rendered…
+    expect(await screen.findByLabelText(/Title/)).toBeInTheDocument();
+    // …inside the shell chrome, which is the whole point of the ruling.
+    const shell = screen.getByTestId('console-shell-layout');
+    expect(shell).toBeInTheDocument();
+    expect(shell).toContainElement(screen.getByLabelText(/Title/));
+  });
+
+  it('keeps the public /f/:slug chrome-less', async () => {
+    window.history.pushState({}, '', '/f/contact-us');
+    render(<App />);
+
+    // Same renderer, same form…
+    expect(await screen.findByLabelText(/Title/)).toBeInTheDocument();
+    // …but an anonymous visitor has no console to be inside.
+    expect(screen.queryByTestId('console-shell-layout')).not.toBeInTheDocument();
+  });
+});

--- a/apps/console/src/components/FormPage.submit.test.tsx
+++ b/apps/console/src/components/FormPage.submit.test.tsx
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4109 — what happens after a successful submit, rendered.
+ *
+ * Maintainer ruling (2026-08-10, objectstack#7245, quoted verbatim on the
+ * card): "**the `type: 'form'` contract means in-shell, and an internal submit
+ * lands on the record.** … Internal-mode submit defaults to
+ * redirect-to-created-record; `thank-you` stays the default for the public
+ * `/f/:slug` path only." Point 3 adds that a form MAY declare its own
+ * behaviour — so the corpus never has to opt out of a wrong default, and an
+ * explicit declaration must keep winning in both modes.
+ *
+ * ## Reverse verification — which of these go red without the fix
+ *
+ * Restoring the old line (`loaded?.form?.submitBehavior ?? { kind: 'thank-you' }`
+ * for both modes) turns the FIRST test red and only that one: the internal
+ * submit stops navigating and renders the anonymous confirmation instead.
+ * That is the whole behavioural change, so one change-detector is the honest
+ * count.
+ *
+ * The other four are GUARDS, green before and after by design, and they are
+ * here on purpose: the precedence tests are what stop a future "make the
+ * default smarter" edit from swallowing a declared behaviour, and the public
+ * test is what stops the new internal default from leaking onto the anonymous
+ * path. A pin that only ever goes red with its own change would not cover
+ * either risk.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { FormPage } from './FormPage';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+/** The FormView metadata `/meta/view/:name` serves for the internal path. */
+function viewEnvelope(submitBehavior?: unknown) {
+  return {
+    name: 'showcase_task.edit',
+    object: 'showcase_task',
+    viewKind: 'form',
+    label: 'Log Time',
+    config: {
+      type: 'simple',
+      sections: [{ label: 'Task', fields: ['title'] }],
+      ...(submitBehavior ? { submitBehavior } : {}),
+    },
+  };
+}
+
+const OBJECT_SCHEMA = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: { title: { type: 'text', label: 'Title' } },
+};
+
+/** The public `/forms/:slug` resolver payload. */
+function publicPayload(submitBehavior?: unknown) {
+  return {
+    slug: 'contact-us',
+    object: 'showcase_inquiry',
+    label: 'Contact us',
+    form: {
+      type: 'simple',
+      sections: [{ fields: ['title'] }],
+      ...(submitBehavior ? { submitBehavior } : {}),
+    },
+    objectSchema: { name: 'showcase_inquiry', fields: { title: { type: 'text', label: 'Title' } } },
+  };
+}
+
+/**
+ * The create response, in the shape the spec declares and `packages/rest`
+ * actually serves: `CreateDataResponse = { object, id, record }`, bare.
+ */
+const CREATE_RESPONSE = {
+  object: 'showcase_task',
+  id: 'task-42',
+  record: { id: 'task-42', title: 'Write the report' },
+};
+
+let submits: Array<{ url: string; body: unknown }> = [];
+
+function stubFetch(routes: Record<string, unknown>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    if (init?.method === 'POST') {
+      submits.push({ url, body: init.body ? JSON.parse(String(init.body)) : undefined });
+    }
+    const key = Object.keys(routes).find((k) => String(url).includes(k));
+    if (!key) throw new Error(`unstubbed fetch: ${url}`);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => routes[key],
+      text: async () => JSON.stringify(routes[key]),
+    } as unknown as Response;
+  });
+}
+
+/** Records where the router settles, so "navigated" is an assertion. */
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+const recordPath = (objectName: string, recordId: string) =>
+  `/apps/ai.objectstack.showcase/${objectName}/record/${recordId}`;
+
+function renderInternal() {
+  return render(
+    <MemoryRouter initialEntries={['/forms/showcase_task.edit']}>
+      <LocationProbe />
+      <Routes>
+        <Route
+          path="/forms/:name"
+          element={<FormPage mode="internal" recordPath={recordPath} />}
+        />
+        <Route
+          path="/apps/:appName/:objectName/record/:recordId"
+          element={<div data-testid="record-page">record page</div>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderPublic() {
+  return render(
+    <MemoryRouter initialEntries={['/f/contact-us']}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/f/:slug" element={<FormPage mode="public" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  submits = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('internal submit — default behaviour (ruling point 2)', () => {
+  it('lands on the record it just created when the form declares nothing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/meta/view/': viewEnvelope(),
+        '/meta/object/': OBJECT_SCHEMA,
+        '/data/showcase_task': CREATE_RESPONSE,
+      }),
+    );
+    renderInternal();
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.type(screen.getByLabelText(/Title/), 'Write the report');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    // The create really was posted, and the id came off the response.
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/apps/ai.objectstack.showcase/showcase_task/record/task-42',
+      ),
+    );
+    expect(await screen.findByTestId('record-page')).toBeInTheDocument();
+    expect(submits).toHaveLength(1);
+    expect(submits[0].url).toContain('/data/showcase_task');
+
+    // And emphatically NOT the anonymous confirmation.
+    expect(screen.queryByText('Your submission has been received.')).not.toBeInTheDocument();
+  });
+
+  /**
+   * A create that succeeds but answers without the spec-declared `id` leaves
+   * nothing to navigate to. Confirming beats navigating to `record/undefined`
+   * — the record WAS created, so silence would be the worse answer.
+   */
+  it('confirms instead of navigating when the response names no id', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/meta/view/': viewEnvelope(),
+        '/meta/object/': OBJECT_SCHEMA,
+        '/data/showcase_task': { object: 'showcase_task', record: { title: 'x' } },
+      }),
+    );
+    renderInternal();
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    expect(await screen.findByText('Your submission has been received.')).toBeInTheDocument();
+    expect(screen.getByTestId('location').textContent).toBe('/forms/showcase_task.edit');
+  });
+});
+
+describe('an explicitly declared submitBehavior still wins (ruling point 3)', () => {
+  it('internal: a declared thank-you is shown instead of the record redirect', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/meta/view/': viewEnvelope({ kind: 'thank-you', title: 'Logged', message: 'Time saved.' }),
+        '/meta/object/': OBJECT_SCHEMA,
+        '/data/showcase_task': CREATE_RESPONSE,
+      }),
+    );
+    renderInternal();
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    expect(await screen.findByText('Logged')).toBeInTheDocument();
+    expect(screen.getByText('Time saved.')).toBeInTheDocument();
+    // Still on the form route — the declared behaviour suppressed the redirect.
+    expect(screen.getByTestId('location').textContent).toBe('/forms/showcase_task.edit');
+  });
+
+  it('public: a declared `continue` resets the form instead of confirming', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/forms/contact-us/submit': { ok: true },
+        '/forms/contact-us': publicPayload({ kind: 'continue' }),
+      }),
+    );
+    renderPublic();
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.type(screen.getByLabelText(/Title/), 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() => expect(submits).toHaveLength(1));
+    // `continue` keeps the form up with cleared values; no confirmation panel.
+    expect(screen.queryByText('Your submission has been received.')).not.toBeInTheDocument();
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('');
+  });
+});
+
+describe('public submit — default behaviour is unchanged', () => {
+  it('still shows the anonymous thank-you confirmation', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/forms/contact-us/submit': { ok: true },
+        '/forms/contact-us': publicPayload(),
+      }),
+    );
+    renderPublic();
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    expect(await screen.findByText('Thanks!')).toBeInTheDocument();
+    expect(screen.getByText('Your submission has been received.')).toBeInTheDocument();
+    expect(screen.getByTestId('location').textContent).toBe('/f/contact-us');
+  });
+});

--- a/apps/console/src/components/FormPage.test.ts
+++ b/apps/console/src/components/FormPage.test.ts
@@ -11,8 +11,10 @@ import {
   buildSections,
   normalizeColumns,
   normalizeOptions,
+  readCreatedRecordId,
   readPrefill,
   resolveInternalForm,
+  resolveSubmitBehavior,
 } from './FormPage';
 
 describe('normalizeColumns', () => {
@@ -285,5 +287,100 @@ describe('resolveInternalForm', () => {
     });
     expect(out.object).toBe('task');
     expect(out.form.type).toBe('simple');
+  });
+});
+
+/**
+ * objectui#4109 — the mode-aware post-submit default, from the maintainer
+ * ruling of 2026-08-10 (objectstack#7245): an internal submit lands on the
+ * record; `thank-you` stays the default for the public `/f/:slug` path only;
+ * an explicitly declared behaviour still wins in BOTH modes.
+ */
+describe('resolveSubmitBehavior', () => {
+  it('defaults an INTERNAL form to landing on the created record', () => {
+    expect(resolveSubmitBehavior('internal', undefined)).toEqual({ kind: 'created-record' });
+  });
+
+  it('keeps thank-you as the PUBLIC default', () => {
+    expect(resolveSubmitBehavior('public', undefined)).toEqual({ kind: 'thank-you' });
+  });
+
+  it('lets an explicit behaviour win in internal mode', () => {
+    const declared = { kind: 'thank-you', title: 'All set' } as const;
+    expect(resolveSubmitBehavior('internal', declared)).toBe(declared);
+  });
+
+  it('lets an explicit behaviour win in public mode', () => {
+    const declared = { kind: 'continue' } as const;
+    expect(resolveSubmitBehavior('public', declared)).toBe(declared);
+  });
+
+  /**
+   * Ruling point 3 — "the corpus must not have to opt out of a wrong default".
+   * Every authorable kind reaches the renderer unchanged in both modes, so a
+   * form that DOES declare one is never second-guessed.
+   */
+  it('passes every authorable kind through untouched, in both modes', () => {
+    const kinds = [
+      { kind: 'thank-you' },
+      { kind: 'redirect', url: 'https://example.test/done' },
+      { kind: 'continue' },
+      { kind: 'next-record' },
+    ] as const;
+    for (const declared of kinds) {
+      expect(resolveSubmitBehavior('internal', declared)).toBe(declared);
+      expect(resolveSubmitBehavior('public', declared)).toBe(declared);
+    }
+  });
+});
+
+/**
+ * The seam the redirect depends on: what `POST /api/v1/data/:object` returns.
+ * Spec-declared as `CreateDataResponse = { object, id, record }`, served bare
+ * by `packages/rest` and `{ success, data, meta }`-wrapped by the runtime's
+ * http-dispatcher — the one envelope rule `@objectstack/client.unwrapResponse`
+ * already owns, mirrored here because FormPage hand-rolls `fetch`.
+ */
+describe('readCreatedRecordId', () => {
+  it('reads the spec-declared top-level id from a bare CreateDataResponse', () => {
+    expect(
+      readCreatedRecordId({
+        object: 'showcase_task',
+        id: 'task-1',
+        record: { id: 'task-1', title: 'Write the report' },
+      }),
+    ).toBe('task-1');
+  });
+
+  it('reads it through the { success, data } transport envelope too', () => {
+    expect(
+      readCreatedRecordId({
+        success: true,
+        data: { object: 'showcase_task', id: 'task-2', record: { id: 'task-2' } },
+        meta: undefined,
+      }),
+    ).toBe('task-2');
+  });
+
+  it('coerces a numeric primary key to its string form', () => {
+    expect(readCreatedRecordId({ object: 'o', id: 42, record: { id: 42 } })).toBe('42');
+  });
+
+  it('returns null when the payload names no id, so the caller can confirm instead', () => {
+    expect(readCreatedRecordId(null)).toBeNull();
+    expect(readCreatedRecordId('nope')).toBeNull();
+    expect(readCreatedRecordId({})).toBeNull();
+    expect(readCreatedRecordId({ object: 'o', id: '' })).toBeNull();
+    expect(readCreatedRecordId({ success: true, data: null })).toBeNull();
+  });
+
+  /**
+   * `record.id` carries the same value, and reading it as an alias would be the
+   * second de-facto contract AGENTS.md #0.1 forbids: one declared key, one
+   * reader. A response missing the declared `id` is a producer bug and must
+   * surface as "no redirect", not be papered over here.
+   */
+  it('does not fall back to record.id when the declared id is absent', () => {
+    expect(readCreatedRecordId({ object: 'o', record: { id: 'task-3' } })).toBeNull();
   });
 });

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -7,13 +7,17 @@
  * + `POST /api/v1/data/:object`).
  *
  * Both modes share the same renderer; the difference is only in how the
- * spec is loaded and where submissions go. This is the same shape as
- * Airtable Forms — the form view metadata is identical whether it is
- * embedded publicly or used by logged-in operators.
+ * spec is loaded, where submissions go, and — since objectui#4109 — what
+ * happens after a successful submit when the form view declares nothing:
+ * an internal submit lands on the record it just created, while the public
+ * path keeps the anonymous `thank-you` confirmation. See
+ * {@link resolveSubmitBehavior}. This is the same shape as Airtable Forms —
+ * the form view metadata is identical whether it is embedded publicly or
+ * used by logged-in operators.
  */
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
 const API_BASE = (import.meta.env.VITE_SERVER_URL || '') + '/api/v1';
@@ -63,6 +67,25 @@ type SubmitBehavior =
   | { kind: 'redirect'; url: string; delayMs?: number }
   | { kind: 'continue' }
   | { kind: 'next-record' };
+
+/** Which surface is rendering the form — see {@link FormPageProps.mode}. */
+export type FormPageMode = 'public' | 'internal';
+
+/**
+ * What the renderer actually does after a successful submit: every authorable
+ * {@link SubmitBehavior}, plus the one behaviour the PLATFORM supplies rather
+ * than the author.
+ *
+ * `created-record` is deliberately NOT a member of the spec's authorable union
+ * (`thank-you | redirect | continue | next-record` — a STRICT discriminated
+ * union in `@objectstack/spec`, so authoring `kind: 'created-record'` is
+ * rejected at publish time and always will be). Nothing ever parses it out of
+ * metadata: it exists only as the value {@link resolveSubmitBehavior} returns
+ * when an internal form declares nothing. That is what lets the platform
+ * default differ from every authorable kind WITHOUT widening the contract or
+ * teaching authors a second dialect for something they never write.
+ */
+type EffectiveSubmitBehavior = SubmitBehavior | { kind: 'created-record' };
 
 interface FormSectionSpec {
   label?: string;
@@ -173,6 +196,84 @@ export function buildSections(
       fields,
     };
   });
+}
+
+/**
+ * The post-submit behaviour actually applied, given what the form view
+ * declared and which surface is rendering it.
+ *
+ * Maintainer ruling, 2026-08-10 (objectstack#7245, quoted verbatim on
+ * objectui#4109):
+ *
+ * > **the `type: 'form'` contract means in-shell, and an internal submit lands
+ * > on the record.**
+ * >
+ * > 2. Internal-mode submit defaults to redirect-to-created-record;
+ * >    `thank-you` stays the default for the public `/f/:slug` path only.
+ *
+ * Before this, the default was `{ kind: 'thank-you' }` for BOTH modes, so a
+ * signed-in operator who had just created a record was told "Your submission
+ * has been received" with no link to it — the anonymous-form confirmation,
+ * shown to someone who is not anonymous and is not done.
+ *
+ * The DECLARED behaviour still wins in both modes, and that precedence is the
+ * point: per ruling point 3 the corpus must never have to opt out of a wrong
+ * default, so this only ever fills the gap an author left empty.
+ */
+export function resolveSubmitBehavior(
+  mode: FormPageMode,
+  declared: SubmitBehavior | undefined,
+): EffectiveSubmitBehavior {
+  if (declared) return declared;
+  return mode === 'internal' ? { kind: 'created-record' } : { kind: 'thank-you' };
+}
+
+/**
+ * The id of the record an internal submit just created, read off the
+ * `POST /api/v1/data/:object` response.
+ *
+ * The response contract is spec-declared — `CreateDataResponse = { object, id,
+ * record, droppedFields? }` (`@objectstack/spec`, `api/protocol.zod.ts`) — and
+ * the top-level `id` IS the created record's id. We read that one declared key
+ * and no alias: `record.id` carries the same value, but reading both would be
+ * exactly the second de-facto contract AGENTS.md #0.1 forbids.
+ *
+ * What this DOES have to absorb is the transport envelope, which is not a
+ * metadata dialect but a platform fact: two transports serve this route and
+ * only one wraps the body. `packages/rest`'s server answers the bare object
+ * (`res.status(201).json(result)`), while the runtime's http-dispatcher wraps
+ * every success as `{ success, data, meta }`. The platform already resolves
+ * this in exactly ONE rule, in `@objectstack/client`:
+ *
+ *     async unwrapResponse(res) {
+ *       const body = await res.json();
+ *       if (body && typeof body.success === 'boolean' && 'data' in body) return body.data;
+ *       return body;
+ *     }
+ *
+ * `FormPage` hand-rolls `fetch` instead of going through that client (it
+ * predates having one here), so the same rule has to be applied at this call
+ * site. Mirroring it is not inventing a dialect — spelling a DIFFERENT rule
+ * would be.
+ *
+ * Returns null when the payload names no id, so the caller can confirm the
+ * submit instead of navigating to `…/record/undefined`.
+ */
+export function readCreatedRecordId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const body = payload as Record<string, unknown>;
+  const unwrapped =
+    typeof body.success === 'boolean' && 'data' in body
+      ? (body.data as Record<string, unknown> | null | undefined)
+      : body;
+  if (!unwrapped || typeof unwrapped !== 'object') return null;
+  const id = (unwrapped as Record<string, unknown>).id;
+  // The spec declares `id: z.string()`. The numeric branch is a coercion of
+  // that SAME key for drivers whose primary key surfaces as an integer — one
+  // key, one meaning, so it cannot mask a producer emitting the wrong shape.
+  if (typeof id === 'string') return id === '' ? null : id;
+  if (typeof id === 'number' && Number.isFinite(id)) return String(id);
+  return null;
 }
 
 /** Apply `?prefill_<field>=<value>` query params to the initial form state. */
@@ -501,7 +602,23 @@ function FieldInput({ field, value, onChange }: FieldInputProps) {
 
 export interface FormPageProps {
   /** `'public'` for /f/:slug (anonymous), `'internal'` for /forms/:name (authed). */
-  mode: 'public' | 'internal';
+  mode: FormPageMode;
+  /**
+   * Builds the console path of a record an INTERNAL submit just created, so
+   * the default `created-record` behaviour has somewhere to land.
+   *
+   * Injected rather than computed here because the answer is not a property of
+   * the form: a record page is app-scoped (`/apps/<segment>/<object>/record/
+   * <id>` — ADR-0048), and WHICH app should host an app-independent page for
+   * this user is a policy with a home of its own. `InternalFormRoute` owns it;
+   * `FormPage` stays a renderer and keeps working outside a metadata catalog
+   * (which is what the public `/f/:slug` mount is — no catalog, no app, and no
+   * business having either).
+   *
+   * Returning `null` — or omitting the prop, as the public mount does — means
+   * "no record page to land on", and the submit falls back to confirming.
+   */
+  recordPath?: (objectName: string, recordId: string) => string | null;
 }
 
 /**
@@ -512,9 +629,10 @@ export interface FormPageProps {
  * *submit target* differ. Forking the component would duplicate the
  * field-rendering branch which is the bulk of the code.
  */
-export function FormPage({ mode }: FormPageProps) {
+export function FormPage({ mode, recordPath }: FormPageProps) {
   const params = useParams();
   const [search] = useSearchParams();
+  const navigate = useNavigate();
   const identifier = (mode === 'public' ? params.slug : params.name) ?? '';
 
   const [loading, setLoading] = useState(true);
@@ -552,8 +670,10 @@ export function FormPage({ mode }: FormPageProps) {
     [loaded],
   );
 
-  const behavior: SubmitBehavior =
-    loaded?.form?.submitBehavior ?? { kind: 'thank-you' };
+  const behavior: EffectiveSubmitBehavior = resolveSubmitBehavior(
+    mode,
+    loaded?.form?.submitBehavior,
+  );
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -561,14 +681,30 @@ export function FormPage({ mode }: FormPageProps) {
     setSubmitting(true);
     setError(null);
     try {
-      if (mode === 'public') {
-        await submitPublic(identifier, values);
-      } else {
-        await submitInternal(loaded.object, values);
-      }
+      const result =
+        mode === 'public'
+          ? await submitPublic(identifier, values)
+          : await submitInternal(loaded.object, values);
       toast.success('Submitted');
       // Behaviour after submit
       switch (behavior.kind) {
+        case 'created-record': {
+          // The internal default (ruling point 2): land on what was just
+          // created. Client-side `navigate` — NOT `window.location.assign` —
+          // because the record page lives in the same SPA and a full reload
+          // would throw away the shell this route now renders inside.
+          const id = readCreatedRecordId(result);
+          const to = id ? recordPath?.(loaded.object, id) : null;
+          if (to) {
+            navigate(to);
+            break;
+          }
+          // No id in the response, or no record page to land on. Confirm the
+          // submit rather than navigate somewhere broken — the create itself
+          // succeeded, so silence would be the worse answer.
+          setSubmitted(true);
+          break;
+        }
         case 'redirect': {
           const delay = behavior.delayMs ?? 0;
           setTimeout(() => window.location.assign(behavior.url), delay);
@@ -614,15 +750,21 @@ export function FormPage({ mode }: FormPageProps) {
   }
   if (!loaded) return null;
 
-  if (submitted && behavior.kind === 'thank-you') {
+  // `created-record` reaches this branch only on the fallback path above (no
+  // id in the response, or nowhere to land) — a successful redirect navigates
+  // away instead. It carries no author-supplied title/message, so it renders
+  // the generic confirmation.
+  if (submitted && (behavior.kind === 'thank-you' || behavior.kind === 'created-record')) {
+    const title = behavior.kind === 'thank-you' ? behavior.title : undefined;
+    const message = behavior.kind === 'thank-you' ? behavior.message : undefined;
     return (
       <div className="mx-auto max-w-2xl p-6">
         <div className="rounded-md border bg-card p-6 text-center">
           <h2 className="mb-2 text-lg font-semibold">
-            {behavior.title ?? 'Thanks!'}
+            {title ?? 'Thanks!'}
           </h2>
           <p className="text-sm text-muted-foreground">
-            {behavior.message ?? 'Your submission has been received.'}
+            {message ?? 'Your submission has been received.'}
           </p>
         </div>
       </div>

--- a/apps/console/src/components/InternalFormRoute.tsx
+++ b/apps/console/src/components/InternalFormRoute.tsx
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * InternalFormRoute — the element for `/forms/:name`, the AUTHED form surface
+ * a `type: 'form'` action navigates to (`ActionRunner.executeForm`).
+ *
+ * ## Why this wrapper exists (objectui#4109)
+ *
+ * Maintainer ruling, 2026-08-10, quoted verbatim from objectstack#7245:
+ *
+ * > **the `type: 'form'` contract means in-shell, and an internal submit lands
+ * > on the record.**
+ * >
+ * > 1. `/forms/:name` in `mode="internal"` nests inside the console shell (keep
+ * >    the route — deep-linking survives; the missing chrome is the defect, not
+ * >    the navigation).
+ *
+ * `/forms/:name` was a TOP-LEVEL route, a sibling of the app-shell routes, so
+ * clicking an in-app button dropped the user onto a bare form with no header,
+ * no navigation and no way back — while the URL still said they were in the
+ * console. The route itself was never the problem (deep links to it are
+ * legitimate and still work), so it stays exactly where it was; only the chrome
+ * around it changes.
+ *
+ * ## Why `HomeLayout` and not `ConsoleLayout`
+ *
+ * `/forms/:name` names no app, and this is the console's established chrome for
+ * app-INDEPENDENT authed pages: `/home` and `/organizations` both render this
+ * same `AppHeader`-over-`main` layout (in `home` and `orgs` variants). It gives
+ * the page the product header — brand, workspace switcher, search, inbox,
+ * assistant, user menu — i.e. the "navigation" half of the measured defect.
+ *
+ * `ConsoleLayout` (the one with `UnifiedSidebar` and the breadcrumb) is NOT
+ * used here, and the reason is not squeamishness about the extra chrome: it is
+ * app-SCOPED by construction. It takes an `activeAppName`/`activeApp` and
+ * publishes them as the shell's current app, so mounting it here would have to
+ * invent an app for a page that belongs to none — and on a cold deep-link,
+ * where nothing has published a current app yet, that invention resolves to
+ * whichever app happens to be first. Announcing an arbitrary app's sidebar and
+ * breadcrumb around someone's form is a worse answer than no sidebar, and it
+ * writes that guess into shared navigation state on the way past. The sidebar
+ * half of the defect is therefore left open on #4109 rather than faked; see
+ * that card's report for the follow-up.
+ */
+
+import { useMemo } from 'react';
+import { DefaultHomeLayout, useMetadata, useNavigationContext } from '@object-ui/app-shell';
+import { useAuth } from '@object-ui/auth';
+import { FormPage } from './FormPage';
+import { buildCreatedRecordPath, type HostAppLike } from './createdRecordPath';
+
+export function InternalFormRoute() {
+  const { apps } = useMetadata();
+  // The app the user is in, or last had open — published by `ConsoleLayout`
+  // and kept in `NavigationProvider`, which sits ABOVE the route tree in
+  // `ConsoleShell`. So a `type: 'form'` action fired from inside an app still
+  // knows which app that was after the client-side hop to this route; a cold
+  // deep-link legitimately has nothing here, and the resolver falls through.
+  const { currentAppName } = useNavigationContext();
+  const { user } = useAuth();
+
+  const recordPath = useMemo(
+    () => (objectName: string, recordId: string) =>
+      buildCreatedRecordPath(apps as HostAppLike[] | undefined, currentAppName, objectName, recordId),
+    [apps, currentAppName],
+  );
+
+  return (
+    <DefaultHomeLayout userId={user?.id}>
+      <FormPage mode="internal" recordPath={recordPath} />
+    </DefaultHomeLayout>
+  );
+}
+
+export default InternalFormRoute;

--- a/apps/console/src/components/createdRecordPath.test.ts
+++ b/apps/console/src/components/createdRecordPath.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Where an internal form submit lands (objectui#4109) — the host-app policy,
+ * unit-tested without a router or a metadata catalog.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildCreatedRecordPath,
+  resolveRecordHostAppSegment,
+  type HostAppLike,
+} from './createdRecordPath';
+
+const SHOWCASE: HostAppLike = { name: 'showcase_app', _packageId: 'ai.objectstack.showcase' };
+const CRM: HostAppLike = { name: 'crm_app', _packageId: 'ai.objectstack.crm' };
+
+describe('resolveRecordHostAppSegment', () => {
+  it('prefers the app the user is in, matched by package id', () => {
+    expect(resolveRecordHostAppSegment([CRM, SHOWCASE], 'ai.objectstack.showcase')).toBe(
+      'ai.objectstack.showcase',
+    );
+  });
+
+  it('matches the preferred app by name too (runtime/DB apps, legacy URLs)', () => {
+    expect(resolveRecordHostAppSegment([CRM, SHOWCASE], 'showcase_app')).toBe(
+      'ai.objectstack.showcase',
+    );
+  });
+
+  it('returns the package id as the segment, never the name, when both exist (ADR-0048)', () => {
+    expect(resolveRecordHostAppSegment([SHOWCASE], 'showcase_app')).toBe('ai.objectstack.showcase');
+  });
+
+  it('falls back to the name for a runtime app carrying no package id', () => {
+    expect(resolveRecordHostAppSegment([{ name: 'db_app' }], 'db_app')).toBe('db_app');
+  });
+
+  it('falls back to the first openable app when nothing is preferred', () => {
+    expect(resolveRecordHostAppSegment([CRM, SHOWCASE], undefined)).toBe('ai.objectstack.crm');
+  });
+
+  /**
+   * The re-check that keeps a deactivated/hidden app from being resurrected as
+   * a link just because the shell still remembers the user was in it.
+   */
+  it('does not honour a preferred app that is no longer openable', () => {
+    const apps = [{ ...SHOWCASE, active: false }, CRM];
+    expect(resolveRecordHostAppSegment(apps, 'ai.objectstack.showcase')).toBe('ai.objectstack.crm');
+  });
+
+  it('skips hidden apps when falling back', () => {
+    const apps = [{ ...SHOWCASE, hidden: true }, CRM];
+    expect(resolveRecordHostAppSegment(apps, undefined)).toBe('ai.objectstack.crm');
+  });
+
+  /**
+   * The deliberate divergence from app-shell's `resolveHostAppSegment`, which
+   * ends at `setup`. Here an unresolvable app means we cannot NAME the record's
+   * page, and the caller must confirm the submit instead of sending the user to
+   * a URL that resolves to nothing. See the module docblock.
+   */
+  it('returns null when no app can be named, rather than guessing `setup`', () => {
+    expect(resolveRecordHostAppSegment([], 'showcase_app')).toBeNull();
+    expect(resolveRecordHostAppSegment(undefined, undefined)).toBeNull();
+    expect(resolveRecordHostAppSegment([{ name: 'x', active: false }], undefined)).toBeNull();
+    // An app with no addressable identity at all is not a segment either.
+    expect(resolveRecordHostAppSegment([{}], undefined)).toBeNull();
+  });
+});
+
+describe('buildCreatedRecordPath', () => {
+  it('builds the app-scoped record path (ADR-0048 segment + object + id)', () => {
+    expect(
+      buildCreatedRecordPath([SHOWCASE], 'showcase_app', 'showcase_task', 'task-1'),
+    ).toBe('/apps/ai.objectstack.showcase/showcase_task/record/task-1');
+  });
+
+  it('percent-encodes an id that carries URL-significant characters', () => {
+    expect(buildCreatedRecordPath([{ name: 'a' }], 'a', 'obj', 'a/b#c')).toBe(
+      '/apps/a/obj/record/a%2Fb%23c',
+    );
+  });
+
+  it('returns null when there is no object or no id to land on', () => {
+    expect(buildCreatedRecordPath([SHOWCASE], 'showcase_app', 'showcase_task', null)).toBeNull();
+    expect(buildCreatedRecordPath([SHOWCASE], 'showcase_app', '', 'task-1')).toBeNull();
+  });
+
+  it('returns null when no app can host the record page', () => {
+    expect(buildCreatedRecordPath([], 'showcase_app', 'showcase_task', 'task-1')).toBeNull();
+  });
+});

--- a/apps/console/src/components/createdRecordPath.ts
+++ b/apps/console/src/components/createdRecordPath.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Where an internal `/forms/:name` submit lands — the console path of the
+ * record it just created (objectui#4109, maintainer ruling 2026-08-10 on
+ * objectstack#7245: "an internal submit lands on the record").
+ *
+ * Pure, router-free and metadata-free so the policy is unit-testable without
+ * rendering the shell; `InternalFormRoute` feeds it the live app catalog.
+ *
+ * ## Why this needs an app at all
+ *
+ * A record page is app-scoped: `/apps/<segment>/<object>/record/<id>`, with the
+ * segment being the owning package id and the app name as the runtime/DB
+ * fallback (ADR-0048). There is no app-independent record route anywhere in the
+ * console — every producer of a record link in `@object-ui/app-shell`
+ * (`RecordDetailView`, `SearchResultsPage`, `useObjectActions`,
+ * `InterfaceListPage`, …) builds this same shape. But `/forms/:name` names no
+ * app, so one has to be chosen.
+ *
+ * ## Which app, and the honest limit of this copy
+ *
+ * app-shell answers exactly this question for framework-owned, app-independent
+ * pages in `resolveHostAppSegment` (`utils/appRoute.ts`): prefer the app the
+ * user is in or last had open, RE-CHECKED against the live active list; else
+ * their first active app; else fall back further. Its docblock is emphatic that
+ * the order is one hard-won definition, and duplicating it would be the "two
+ * readers of one prose contract" mistake this repo keeps paying for.
+ *
+ * We would import it — but `@object-ui/app-shell` exports only its package
+ * root, and that root re-exports `./utils` nowhere, so the helper is not
+ * reachable from `apps/console` without widening app-shell's public surface.
+ * That edit was out of scope for #4109 (a parallel agent holds app-shell), so
+ * this implements the FIRST TWO steps only and then STOPS:
+ *
+ *   1. `preferred` — the app the user is in / last had open — re-checked
+ *      against the live list, so an app deactivated or hidden since is not
+ *      resurrected as a link;
+ *   2. else their first openable app — arbitrary but reachable, and on a
+ *      business user's workspace that is a business app;
+ *   3. else `null` — NOT `setup`. That is the deliberate divergence: the
+ *      upstream helper's last resorts exist so a framework page always renders
+ *      SOMEWHERE, whereas an unresolvable app here means we cannot name the
+ *      record's page at all, and the caller must confirm the submit instead of
+ *      sending the user to a URL that resolves to nothing.
+ *
+ * Replacing all of this with the upstream helper is a pure deletion once it is
+ * exported; the divergence at step 3 is the only judgement to re-make.
+ */
+
+/** The fields this resolver reads off an App metadata record. */
+export interface HostAppLike {
+  name?: unknown;
+  /** ADR-0048 owning package — the canonical identity of a shipped app. */
+  _packageId?: unknown;
+  active?: unknown;
+  hidden?: unknown;
+}
+
+/**
+ * The `/apps/<segment>` route segment for an app: its package id, falling back
+ * to its name for runtime/DB apps that have none. Mirrors app-shell's
+ * `appRouteSegment` — same reason, same unavailability.
+ */
+function routeSegment(app: HostAppLike | undefined): string | null {
+  if (!app) return null;
+  const seg = (typeof app._packageId === 'string' && app._packageId) || null;
+  if (seg) return seg;
+  return typeof app.name === 'string' && app.name ? app.name : null;
+}
+
+/**
+ * The apps a user can actually open. `active === false` deactivates an app;
+ * `hidden === true` keeps it out of the launcher. Neither is a place to send
+ * someone. (Deliberately NOT filtering `_unpublished`: it is the ADR-0045
+ * publish gate and is enforced server-side — see app-shell's `filterActiveApps`
+ * docblock — so filtering it here would hide a builder's own app from the
+ * builder and buy nothing.)
+ */
+function openableApps(apps: readonly HostAppLike[] | null | undefined): HostAppLike[] {
+  if (!apps) return [];
+  return apps.filter((a) => a?.active !== false && a?.hidden !== true);
+}
+
+/**
+ * Which app should host the created record's page, as a route segment, or
+ * `null` when none can be named. See the module docblock for the order.
+ */
+export function resolveRecordHostAppSegment(
+  apps: readonly HostAppLike[] | null | undefined,
+  preferred: string | null | undefined,
+): string | null {
+  const openable = openableApps(apps);
+  if (preferred) {
+    const stillOpenable =
+      openable.find((a) => a._packageId === preferred) ??
+      openable.find((a) => a.name === preferred);
+    const seg = routeSegment(stillOpenable);
+    if (seg) return seg;
+  }
+  return routeSegment(openable[0]);
+}
+
+/**
+ * The console path of a freshly created record, or `null` when it cannot be
+ * built — no openable app to host it, or a caller with no object/id. A null
+ * return is a supported answer, not a failure: `FormPage` confirms the submit
+ * instead of navigating to a path that resolves to nothing.
+ *
+ * `recordId` is percent-encoded (ids are opaque and may carry `/` or `#`);
+ * `objectName` and the app segment are metadata identifiers, encoded for the
+ * same reason every other producer of this shape does.
+ */
+export function buildCreatedRecordPath(
+  apps: readonly HostAppLike[] | null | undefined,
+  preferredAppName: string | null | undefined,
+  objectName: string | null | undefined,
+  recordId: string | null | undefined,
+): string | null {
+  if (!objectName || !recordId) return null;
+  const appSegment = resolveRecordHostAppSegment(apps, preferredAppName);
+  if (!appSegment) return null;
+  return `/apps/${encodeURIComponent(appSegment)}/${encodeURIComponent(objectName)}/record/${encodeURIComponent(recordId)}`;
+}


### PR DESCRIPTION
Part of #4109 — both deliverables of the ruling are implemented, but one half of deliverable 1 (the **sidebar**) is deliberately left open rather than faked; see "What is NOT in this PR". The card should stay open for that call.

## The ruling this implements

Maintainer ruling of 2026-08-10, quoted verbatim on #4109 (from objectstack#7245) — reproduced untranslated because it is the spec:

> **the `type: 'form'` contract means in-shell, and an internal submit lands on the record.**
>
> 1. `/forms/:name` in `mode="internal"` nests inside the console shell (keep the route — deep-linking survives; the missing chrome is the defect, not the navigation).
> 2. Internal-mode submit defaults to redirect-to-created-record; `thank-you` stays the default for the public `/f/:slug` path only.
> 3. `showcase_task.edit` may declare a `submitBehavior` as an interim corpus fix, but the platform default is the ruling above — the corpus must not have to opt out of a wrong default.

## Premise re-verified against `origin/main`

Both measured starting points on the card are still true at `4cb0562b5` (the card cited a `~line 233` that has since drifted to 217):

- `apps/console/src/App.tsx:217` — `/forms/:name` was a top-level route, a sibling of the app-shell routes.
- `apps/console/src/components/FormPage.tsx:555` — `const behavior: SubmitBehavior = loaded?.form?.submitBehavior ?? { kind: 'thank-you' }`, unconditional across both modes.

## 1. In-shell (ruling point 1)

The route stays exactly where it is; only its element changes, to a new `InternalFormRoute` that wraps `FormPage` in the console's layout for app-independent authed pages — the same chrome `/home` and `/organizations` already use. The public `/f/:slug` path is untouched and stays chrome-less.

## 2. Mode-aware submit default (ruling points 2 and 3)

`resolveSubmitBehavior(mode, declared)` is a pure exported function: a declared `submitBehavior` is returned as-is in **both** modes, and only the empty case differs — internal gets "land on the created record", public keeps `thank-you`.

**No authorable surface changed.** The "land on the created record" behaviour is deliberately not a new `submitBehavior.kind`: the spec's union (`thank-you` / `redirect` / `continue` / `next-record`) is a strict discriminated union and stays exactly as it is. Nothing parses the new internal default out of metadata — it is only what the renderer does when an author declared nothing, which is what lets the platform default differ from every authorable kind without widening the contract.

### The seam: what the submit call actually returns

The redirect needs the created record's id, so I verified the response contract rather than assuming it. `POST /api/v1/data/:object` answers the spec-declared `CreateDataResponse = { object, id, record, droppedFields? }` (`@objectstack/spec`, `api/protocol.zod.ts`), and `packages/rest`'s server returns it bare (`res.status(201).json(result)`).

`readCreatedRecordId` reads that **one declared key**. `record.id` carries the same value and is deliberately NOT read as an alias — that would be the second de-facto contract AGENTS.md #0.1 forbids, and it is pinned by a negative test.

What it does absorb is the transport envelope, which is not a metadata dialect but a platform fact: the runtime's http-dispatcher wraps every success as `{ success, data, meta }` while the REST server does not. The platform already resolves this in exactly ONE rule, in `@objectstack/client.unwrapResponse`; `FormPage` hand-rolls `fetch` instead of going through that client, so the same rule is applied at this call site. Mirroring it is not inventing a dialect — spelling a different one would be. Both shapes are pinned.

A response naming no id, or a workspace where no app can host the record page, falls back to the confirmation panel rather than navigating to `record/undefined` — the record really was created, so silence would be the worse answer.

## What is NOT in this PR, and why

**The sidebar.** The source card measured "no sidebar, navigation, or breadcrumb". This PR delivers the header/navigation; it does not mount `UnifiedSidebar`, and that is a judgement I did not want to make silently:

`ConsoleLayout` (the layout that owns the sidebar and breadcrumb) is app-SCOPED by construction — it takes an `activeAppName`/`activeApp` and publishes them as the shell's current app. `/forms/:name` names no app, so mounting it here means inventing one, and on a cold deep-link that invention resolves to whichever app happens to be first. Wrapping someone's form in an arbitrary app's sidebar and breadcrumb — and writing that guess into shared navigation state on the way past — is worse than no sidebar.

Doing it properly needs app-shell's own `resolveHostAppSegment` (`utils/appRoute.ts`), which is written for exactly this case ("a framework-owned, app-independent page") but is not reachable: `@object-ui/app-shell` exports only its package root, and that root re-exports `./utils` nowhere. Exporting it was out of scope here (a parallel agent holds that package). The same unavailability is why `createdRecordPath.ts` implements only the first two steps of that resolver, documented as a subset with the divergence spelled out.

**`?recordId=` is still ignored** by this route — filed as #4278, not fixed here.

## Tests

New: `createdRecordPath.test.ts` (host-app policy), `FormPage.submit.test.tsx` (rendered submit behaviour), `internalFormShell.test.tsx` (the route table). Extended: `FormPage.test.ts` with `resolveSubmitBehavior` + `readCreatedRecordId`.

`internalFormShell.test.tsx` renders the **real** `App.tsx` route table rather than a transcription, for the reason `AppContent.systemHubRoutes.test.tsx` documents at length: a hand-copied route list is free to agree with whatever the source does.

### Reverse verification (predicted, then measured)

| Change removed | Predicted | Measured |
|---|---|---|
| `resolveSubmitBehavior` back to `thank-you` for both modes | the two internal-default pins go red, everything else green | exactly 2 red / 51 green — `expected { kind: 'thank-you' } to deeply equal { kind: 'created-record' }` and `expected '/forms/showcase_task.edit' to be '/apps/…/record/task-42'` |
| route element back to bare `FormPage mode="internal"` | the shell pin goes red, the chrome-less pin stays green | 1 red / 1 green — `Unable to find an element by: [data-testid="console-shell-layout"]` |

Honest note on the other pins: the two precedence tests and the public-default test are **guards**, green before and after by design. They are here to stop a future "smarter default" from swallowing a declared behaviour, and to stop the new internal default leaking onto the anonymous path — a pin that only goes red with its own change would cover neither risk.

### Commands

```
pnpm exec vitest run apps/console/            → 37 files, 391 tests passed
cd apps/console && pnpm exec tsc --noEmit     → exit 0
cd apps/console && pnpm exec tsc -b tsconfig.node.json --force → exit 0
pnpm exec eslint (new files)                  → 0 problems
node scripts/check-changeset-presence.mjs     → pass (changeset added, minor)
node scripts/check-changeset-no-major.mjs     → pass
```

Lint delta on `FormPage.tsx` is +2 `react-refresh/only-export-components` warnings, one per new exported pure function — the same pattern the file already had 5 of. Warnings, not errors.

## Not browser-verified

Deliverable 3 (the showcase journey end-to-end in a browser) was **not** performed — no dev stack was booted in this environment. It is compensated with the route-level and component-level tests above, not claimed. Worth a browser pass on acceptance, particularly the cold-deep-link case where no app has been published to navigation context yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_