### PR TITLE
fix(permissions): type-check its tests (#4040 tranche 1)

### DIFF
--- a/.changeset/type-check-tests-permissions-4040.md
+++ b/.changeset/type-check-tests-permissions-4040.md
@@ -1,0 +1,15 @@
+---
+---
+
+Releases nothing on purpose: `@object-ui/permissions` now type-checks its four test files
+(`tsconfig.test.json` chained from `type-check`), and its `TEST_DEBT` entry is gone. Only
+test sources changed; no published behaviour, and no public type, moved.
+
+All five declared code-tier errors were the same `TS2741`: fixtures typed `RoleDefinition`
+while omitting its required `permissions`. The empty array they gained is the accurate
+value rather than padding — those roles grant nothing directly, and every grant the cases
+exercise arrives through the `ObjectPermissionConfig[]` beside them, keyed by object.
+
+A further 21 errors appeared first and were config-tier, not code: `TS2304` on the Node
+`global` the two `MePermissionsProvider` suites stub `fetch` through, resolved by naming
+`types: ["node"]` in the test project.

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -30,7 +30,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint ."
   },
   "peerDependencies": {

--- a/packages/permissions/src/__tests__/evaluator.test.ts
+++ b/packages/permissions/src/__tests__/evaluator.test.ts
@@ -13,9 +13,14 @@ import type {
   ObjectPermissionConfig,
 } from '@object-ui/types';
 
-const adminRole: RoleDefinition = { name: 'admin', label: 'Admin' };
-const editorRole: RoleDefinition = { name: 'editor', label: 'Editor', inherits: ['viewer'] };
-const viewerRole: RoleDefinition = { name: 'viewer', label: 'Viewer' };
+// `RoleDefinition.permissions` is required and carries a role's DIRECT object
+// grants. These three roles grant nothing directly — every grant these cases
+// exercise arrives through the `ObjectPermissionConfig[]` below, keyed by object
+// — so the empty array is the accurate value, not padding. What the fixtures pin
+// here is identity and inheritance, which is all `resolveRoles` reads.
+const adminRole: RoleDefinition = { name: 'admin', label: 'Admin', permissions: [] };
+const editorRole: RoleDefinition = { name: 'editor', label: 'Editor', inherits: ['viewer'], permissions: [] };
+const viewerRole: RoleDefinition = { name: 'viewer', label: 'Viewer', permissions: [] };
 
 const roles: RoleDefinition[] = [adminRole, editorRole, viewerRole];
 

--- a/packages/permissions/src/__tests__/store.test.ts
+++ b/packages/permissions/src/__tests__/store.test.ts
@@ -10,9 +10,12 @@ import { describe, it, expect } from 'vitest';
 import { createPermissionStore } from '../store';
 import type { RoleDefinition, ObjectPermissionConfig } from '@object-ui/types';
 
+// Empty `permissions` is the accurate value, not padding: a role's DIRECT object
+// grants live there, and every grant these cases exercise arrives through the
+// `ObjectPermissionConfig[]` below instead.
 const roles: RoleDefinition[] = [
-  { name: 'admin', label: 'Admin' },
-  { name: 'viewer', label: 'Viewer' },
+  { name: 'admin', label: 'Admin', permissions: [] },
+  { name: 'viewer', label: 'Viewer', permissions: [] },
 ];
 
 const permissions: ObjectPermissionConfig[] = [

--- a/packages/permissions/tsconfig.test.json
+++ b/packages/permissions/tsconfig.test.json
@@ -1,0 +1,25 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` excludes.
+  // See `packages/types/tsconfig.test.json` for why that exclusion was a hole:
+  // the build correctly keeps tests out of `dist`, but nothing else compiled
+  // them, so a test could assert a contract the compiler never checked.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The package build emits `dist`; this project emits nothing, so it must
+    // not inherit `composite` / `declaration` from the build config.
+    "composite": false,
+    // The two `MePermissionsProvider` suites stub the fetch seam through Node's
+    // `global` object (`global.fetch = vi.fn()`), which is an ambient declaration
+    // rather than an import — 21 of this package's 26 initial errors were TS2304
+    // on that one name. Naming `types` at all switches off automatic `@types/*`
+    // inclusion, so `node` has to be listed explicitly; nothing here needs the
+    // jest-dom matchers, which these suites do not use.
+    "types": ["node"],
+    // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` and
+    // `@objectstack/spec` resolve through the workspace dependency's built
+    // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
+    "paths": {}
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -123,7 +123,6 @@ export const TEST_DEBT = {
   "@object-ui/plugin-form": { errors: 12, issue: 4118, note: "TS2322x10" },
   "@object-ui/plugin-dashboard": { errors: 6, issue: 4118 },
   "@object-ui/plugin-list": { errors: 6, issue: 4118, note: "TS2353x3 — dialect keys" },
-  "@object-ui/permissions": { errors: 5, issue: 4118, note: "TS2741x5" },
   "@object-ui/plugin-detail": { errors: 5, issue: 4118, note: "TS2353x3 — dialect keys" },
   "@object-ui/plugin-gantt": { errors: 3, issue: 4118 },
   "@object-ui/auth": { errors: 2, issue: 4118 },


### PR DESCRIPTION
Part of #4040 — tranche 1, package 5 of 5. Substituted for `plugin-grid`, which stopped on a public-type question and is filed as #4277. One package per PR, per the 裁决 on objectstack-ai/objectstack#4118 (PM, 2026-08-03):

> 小包先行,`core`(80)/`react`(76)最后;
> 每包独立 PR;守卫类 PR 必须附 pre-fix 代码报红的运行记录(判别力证明,防「绿灯守卫从未真正跑过」——已发现的第三种失败模式:tsconfig.test.json 存在但没人跑);
> TEST_DEBT 条目随包清零,只减不增。

## Measured before / after

| | errors |
|---|---|
| declared in `TEST_DEBT` | 5 (code-tier) |
| measured on this branch's base (`90e792e11`), template as-is | 26 — 21 config-tier + **5 code-tier** |
| after | **0** |

The 21 are `TS2304: Cannot find name 'global'` across the two `MePermissionsProvider`
suites, which stub the fetch seam as `global.fetch = vi.fn()`. `global` is an ambient
declaration, so `types: ["node"]` in the test project resolves all 21 — config-tier, exactly
the class the card's template section is about, and it leaves the declared **5** intact:

```
src/__tests__/evaluator.test.ts(16,7): error TS2741: Property 'permissions' is missing in type '{ name: string; label: string; }' but required in type 'RoleDefinition'.
src/__tests__/evaluator.test.ts(17,7): error TS2741: ... '{ name: string; label: string; inherits: string[]; }' ...
src/__tests__/evaluator.test.ts(18,7): error TS2741: ...
src/__tests__/store.test.ts(14,3): error TS2741: ...
src/__tests__/store.test.ts(15,3): error TS2741: ...
```

## The five code-tier errors: incomplete fixtures, not a wrong type

`RoleDefinition.permissions` (`packages/types/src/permissions.ts:50`) is a required
`ObjectLevelPermission[]` carrying a role's **direct** object grants. Five fixtures declared
`RoleDefinition` without it.

The type is not the problem, so it was not touched: every grant these cases exercise arrives
through the `ObjectPermissionConfig[]` beside the roles, keyed by object, and what the role
fixtures pin is identity and inheritance — which is all `resolveRoles`
(`src/evaluator.ts:92`) reads. `permissions: []` is therefore the accurate value for these
roles rather than padding added to satisfy a compiler, and the cases assert exactly what
they did before.

## Discrimination proof — the new project can fail

No guard test's assertions changed here, so the thing that needs its discrimination shown is
the new project itself. Appending a provably-false line to `src/__tests__/store.test.ts`:

```
$ npx tsc -p tsconfig.test.json
src/__tests__/store.test.ts(101,7): error TS2322: Type 'string' is not assignable to type 'number'.
EXIT:2
```

Reverted immediately; the probe is not in the diff.

## Filed, not fixed

`RoleDefinition.permissions` is required and **read by nothing in this repository** — the
evaluator, store and provider all take `RoleDefinition[]` and use only `name`/`inherits`.
That is an observation about a dormant declared surface, not a defect a user meets, so it is
filed separately rather than resolved here; changing it either way is a public-type call.

## Verification

```
$ pnpm --filter @object-ui/permissions type-check
> tsc --noEmit && tsc -p tsconfig.test.json
EXIT:0

$ pnpm exec vitest run packages/permissions --maxWorkers=2      # from the repo root, per objectui#3378
 Test Files  4 passed (4)
      Tests  52 passed (52)

$ node scripts/check-type-check-coverage.mjs
type-check coverage: 43/45 via `type-check`, 1 via their own build, 0 known-broken (0 errors outstanding), 1 not compiled.
test type-check coverage: 26/40 packages compile their tests, 14 declared debt (235 errors outstanding), 10 with a narrow type-assertion project.
```

`TEST_DEBT` shrinks by exactly this package's line; no other entry is touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_