### PR TITLE
fix(plugin-detail): synthesize page components in the spec `properties` carrier so Studio page-create persists (#4232)

### DIFF
--- a/.changeset/synth-page-canonical-properties-4232.md
+++ b/.changeset/synth-page-canonical-properties-4232.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+fix(plugin-detail): synthesize page components in the spec's `properties` carrier so Studio page-create can persist
+
+Creating a page in Studio never completed. The create path seeds a record
+page's `regions` from `buildDefaultPageSchema(objectDef)` and PUTs the result,
+and every node that synthesizer emitted carried its widget props at the TOP
+level of the component — `{ type: 'page:header', recordChrome: true }`,
+`{ type: 'page:tabs', items: [...] }`, and the same for `record:highlights`,
+`record:path`, `record:details`, `record:related_list`, `record:history` and
+`record:reference_rail`. ADR-0089 D3a closed `PageComponentSchema` with
+`.strict()`, so those keys are not stripped, they are a parse error
+(`Unrecognized key(s) on this view/page schema: 'recordChrome', 'actions'`).
+The server refused the body and no page row was ever stored.
+
+The props now go where the spec declares them — the node's `properties` bag,
+which is where `ComponentPropsMap` defines `page:header.recordChrome` and
+`page:tabs.items` in the first place. Nothing is dropped and nothing changes on
+screen: a header still defaults to record chrome ON, an author's
+`recordChrome: false` is still carried (and now actually persists), the tabs
+keep their items, and `SchemaRenderer` hoists `properties` back onto the node
+before dispatch, so every renderer receives exactly the props it did before.
+
+One code path does the wrapping for every node the synthesizer builds, so there
+is a single answer to "what may go in a page write". Slot overrides are
+untouched — a node handed in by a caller is still placed verbatim.

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.strictPayload.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.strictPayload.test.ts
@@ -1,0 +1,259 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#4232 — the synthesized page must SURVIVE THE SERVER'S WRITE.
+ *
+ * Studio's page-create seeds a record page's `regions` from
+ * `buildDefaultPageSchema(objectDef)` (app-shell
+ * `views/metadata-admin/anchors.ts` → `createSeed`) and PUTs the result. The
+ * server parses that body with `@objectstack/spec`'s `PageSchema`, whose page
+ * component shape was closed with `.strict()` by **ADR-0089 D3a**, so a widget
+ * prop written at the top level of a component node is a parse error rather
+ * than a silent strip:
+ *
+ *     Unrecognized key(s) on this view/page schema: `recordChrome`, `actions`.
+ *     Before ADR-0089 D3a these were dropped silently, shipping inert
+ *     metadata; a mis-layered or stale key is now a loud parse error.
+ *
+ * That is why page-create never completed: the body was refused and no page row
+ * was stored.
+ *
+ * These pins are measured against the REAL schema the server enforces — the
+ * vendored `@objectstack/spec` — not a hand-mirrored key list, so they follow
+ * the contract when it moves. Delete `componentNode`'s `properties` wrapping
+ * and every assertion here goes red with the server's own message.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PageSchema,
+  PageComponentSchema,
+  PageTabsProps,
+} from '@objectstack/spec/ui';
+import {
+  buildDefaultPageSchema,
+  buildDefaultHeader,
+  buildDefaultActions,
+  buildDefaultHighlights,
+  buildDefaultDetails,
+  buildDefaultTabs,
+  buildDefaultDiscussion,
+  buildDefaultAttachments,
+  type ObjectDefLike,
+} from '../buildDefaultPageSchema';
+
+const leadDef: ObjectDefLike = {
+  name: 'lead',
+  label: 'Lead',
+  fields: {
+    first_name: { name: 'first_name', label: 'First Name', type: 'text' },
+    email: { name: 'email', label: 'Email', type: 'email' },
+    phone: { name: 'phone', label: 'Phone', type: 'phone' },
+    status: {
+      name: 'status',
+      label: 'Status',
+      type: 'picklist',
+      options: [
+        { value: 'new', label: 'New' },
+        { value: 'qualified', label: 'Qualified' },
+      ],
+    },
+  },
+};
+
+/**
+ * The parse issues, flattened to one readable line each.
+ *
+ * Asserted as `toEqual([])` rather than `success === true` on purpose: when a
+ * node regresses, the failure output IS the server's rejection message
+ * (offending key included), which is the whole diagnostic a fixer needs.
+ */
+function issuesOf(result: { success: boolean; error?: { issues: any[] } }): string[] {
+  if (result.success) return [];
+  return (result.error?.issues ?? []).map(
+    (i: any) => `${i.code} @ ${i.path.join('.') || '<root>'}: ${String(i.message).split('\n')[0]}`,
+  );
+}
+
+/**
+ * The body Studio PUTs on create, assembled the way the console does:
+ * identity + type + object come from the create form, `regions` and `template`
+ * from the synthesizer (`createSeed` contributes ONLY those two).
+ */
+function createBody(def: ObjectDefLike, options?: Parameters<typeof buildDefaultPageSchema>[1]) {
+  const synth = buildDefaultPageSchema(def, options);
+  return {
+    name: 'lead_record',
+    label: 'Lead Record',
+    type: 'record',
+    object: def.name,
+    ...(synth.template ? { template: synth.template } : {}),
+    ...(Array.isArray(synth.regions) && synth.regions.length ? { regions: synth.regions } : {}),
+  };
+}
+
+describe('ADR-0089 D3a — the Studio create payload parses server-side (objectui#4232)', () => {
+  it('the default record page seed is accepted by PageSchema', () => {
+    expect(issuesOf(PageSchema.safeParse(createBody(leadDef)))).toEqual([]);
+  });
+
+  it('is accepted with every optional surface the synthesizer can emit', () => {
+    const body = createBody({ ...leadDef, enable: { files: true } }, {
+      headerActions: [{ name: 'convert', label: 'Convert', locations: ['record_header'] }],
+      related: [
+        { objectName: 'task', relationshipField: 'lead_id', title: 'Tasks', limit: 10, icon: 'check' },
+        { objectName: 'note', relationshipField: 'parent_id', isPrimary: true },
+      ],
+      showActivity: true,
+      history: { entries: [{ id: 'h1' }], loading: false },
+      approvals: { count: 2, node: { currentUserId: 'u_1' } },
+    });
+    expect(issuesOf(PageSchema.safeParse(body))).toEqual([]);
+  });
+
+  it('is accepted for an object with no derivable highlights or status field', () => {
+    expect(issuesOf(PageSchema.safeParse(createBody({ name: 'note', fields: {} })))).toEqual([]);
+  });
+
+  it('is accepted when the caller suppresses every optional slot', () => {
+    const body = createBody(leadDef, {
+      hideDiscussion: true,
+      hideHighlights: true,
+      hidePath: true,
+    });
+    expect(issuesOf(PageSchema.safeParse(body))).toEqual([]);
+  });
+
+  /**
+   * The regression guard with the smallest blast radius: EVERY node the
+   * synthesizer puts in a region is a `PageComponentSchema`, so a future prop
+   * added at the top level of any one of them is caught here by name.
+   */
+  it('every synthesized component node parses as a PageComponentSchema', () => {
+    const common = {
+      headerActions: [{ name: 'convert', label: 'Convert', locations: ['record_header'] }],
+      related: [
+        { objectName: 'task', relationshipField: 'lead_id', title: 'Tasks' },
+        { objectName: 'note', relationshipField: 'parent_id' },
+      ],
+      showActivity: true,
+      history: { entries: [], loading: false },
+      approvals: { node: { currentUserId: 'u_1' } },
+    };
+    const filesDef = { ...leadDef, enable: { files: true } };
+    // Two pages, because the two branches are mutually exclusive by design:
+    // turning the Reference Rail on suppresses the Related tab, so
+    // `record:related_list` and `record:reference_rail` never co-occur.
+    const pages = [
+      buildDefaultPageSchema(filesDef, common),
+      buildDefaultPageSchema(filesDef, { ...common, showReferenceRail: true }),
+    ];
+    const nodes: any[] = [];
+    const walk = (n: any): void => {
+      if (Array.isArray(n)) return n.forEach(walk);
+      if (!n || typeof n !== 'object') return;
+      if (typeof n.type === 'string') nodes.push(n);
+      walk(n.properties?.items?.flatMap((i: any) => i.children ?? []));
+    };
+    for (const page of pages) for (const region of page.regions) walk(region.components);
+    // The coverage claim, asserted rather than assumed: every component type
+    // this synthesizer can emit is in the set being parsed below.
+    expect([...new Set(nodes.map((n) => n.type))].sort()).toEqual([
+      'page:header',
+      'page:tabs',
+      'record:activity',
+      'record:approvals',
+      'record:attachments',
+      'record:details',
+      'record:discussion',
+      'record:highlights',
+      'record:history',
+      'record:path',
+      'record:reference_rail',
+      'record:related_list',
+    ]);
+    for (const node of nodes) {
+      expect([node.type, issuesOf(PageComponentSchema.safeParse(node))]).toEqual([node.type, []]);
+    }
+  });
+
+  it('the sub-builders emit accepted nodes on their own (slot authors compose these)', () => {
+    const nodes = [
+      buildDefaultHeader(leadDef),
+      buildDefaultHeader(leadDef, { recordChrome: false }),
+      buildDefaultActions(leadDef, [{ name: 'edit', label: 'Edit' }]),
+      ...buildDefaultHighlights(leadDef),
+      buildDefaultDetails(leadDef),
+      buildDefaultTabs(leadDef),
+      buildDefaultDiscussion(),
+      buildDefaultAttachments(),
+    ];
+    for (const node of nodes) {
+      expect([node.type, issuesOf(PageComponentSchema.safeParse(node))]).toEqual([node.type, []]);
+    }
+  });
+});
+
+describe('the accepted shape still carries the semantics (objectui#4232)', () => {
+  /**
+   * Chrome ON is the default, and it survives the server's parse — it is not
+   * "accepted because it was dropped". `PageComponentSchema` keeps `properties`
+   * as an opaque record, so what comes back out is what would be stored.
+   */
+  it('record chrome defaults ON and survives the parse', () => {
+    const node = buildDefaultHeader(leadDef);
+    expect(node).toEqual({ type: 'page:header', properties: { recordChrome: true } });
+    const parsed = PageComponentSchema.parse(node) as any;
+    expect(parsed.properties.recordChrome).toBe(true);
+  });
+
+  /**
+   * The half that must never be lost to "just strip the key": an author who
+   * turned the record chrome OFF (a dashboard / landing page) gets that choice
+   * PERSISTED, because `recordChrome` is a declared `page:header` prop
+   * (`ComponentPropsMap['page:header'].recordChrome`, #6776) and the bag it
+   * lives in is the spec's own carrier.
+   */
+  it('record chrome turned OFF survives the parse rather than silently reverting', () => {
+    const node = buildDefaultHeader(leadDef, { recordChrome: false });
+    expect(node).toEqual({ type: 'page:header', properties: { recordChrome: false } });
+    const parsed = PageComponentSchema.parse(node) as any;
+    expect(parsed.properties.recordChrome).toBe(false);
+    // …and it reaches the page body the console PUTs.
+    const body = createBody(leadDef, { recordChrome: false });
+    const page = PageSchema.parse(body) as any;
+    expect(page.regions[0].components[0].properties.recordChrome).toBe(false);
+  });
+
+  /**
+   * The tabs' item structure is the other named semantic. `PageTabsProps` is
+   * the spec's own declaration of that bag, so parsing the emitted
+   * `properties` against it proves the items are the DECLARED surface —
+   * not merely tolerated as unknown values inside an opaque record.
+   */
+  it('the tab items are the spec-declared `page:tabs` props, labels/values/children intact', () => {
+    const tabs = buildDefaultTabs(leadDef, {
+      related: [{ objectName: 'task', relationshipField: 'lead_id', title: 'Tasks' }],
+      showActivity: true,
+    });
+    const parsed = PageTabsProps.parse(tabs.properties) as any;
+    expect(parsed.items.map((i: any) => i.label)).toEqual(['Details', 'Related', 'Activity']);
+    expect(parsed.items.map((i: any) => i.value)).toEqual(['details', 'related', 'activity']);
+    expect(parsed.items[0].children[0].type).toBe('record:details');
+    expect(parsed.items[1].children[0].properties.objectName).toBe('task');
+  });
+
+  it('the tab items survive the whole-page parse the server runs', () => {
+    const body = createBody(leadDef, {
+      related: [{ objectName: 'task', relationshipField: 'lead_id', title: 'Tasks' }],
+    });
+    const page = PageSchema.parse(body) as any;
+    const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
+    expect(tabs.properties.items.map((i: any) => i.value)).toEqual(['details', 'related']);
+    expect(tabs.properties.items[1].children[0].properties.relationshipField).toBe('lead_id');
+  });
+});

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -23,6 +23,23 @@ import {
   type ObjectDefLike,
 } from '../buildDefaultPageSchema';
 
+/**
+ * A page component's props live in the node's `properties` bag — the spec's
+ * canonical carrier, and since **ADR-0089 D3a** closed `PageComponentSchema`
+ * with `.strict()`, the only spelling the server accepts on a page write
+ * (objectui#4232: the flat spelling made Studio's page-create PUT fail, so no
+ * page row was ever stored).
+ *
+ * Deliberately NOT tolerant — no `?? node` fallback to a top-level read. A
+ * regression to the flat spelling turns every assertion reached through these
+ * two helpers red, instead of quietly passing on the shape the server refuses.
+ * The payload is pinned against the real spec schema in
+ * `buildDefaultPageSchema.strictPayload.test.ts`.
+ */
+const props = (node: any): Record<string, any> => node?.properties ?? {};
+/** A `page:tabs` node's tab items, out of that same bag. */
+const tabItems = (node: any): any[] => props(node).items ?? [];
+
 const leadDef: ObjectDefLike = {
   name: 'lead',
   label: 'Lead',
@@ -232,25 +249,25 @@ describe('buildDefaultPageSchema', () => {
     });
     const hl = page.regions[0].components.find((c: any) => c.type === 'record:highlights');
     const path = page.regions[0].components.find((c: any) => c.type === 'record:path');
-    expect(hl.fields).toEqual(['email']);
-    expect(path.statusField).toBe('rating');
-    expect(path.stages).toEqual([{ value: 'hot', label: 'Hot' }]);
+    expect(props(hl).fields).toEqual(['email']);
+    expect(props(path).statusField).toBe('rating');
+    expect(props(path).stages).toEqual([{ value: 'hot', label: 'Hot' }]);
   });
 
   it('page:header.recordChrome defaults to true and can be turned off', () => {
     const on = buildDefaultPageSchema(leadDef).regions[0].components[0];
     const off = buildDefaultPageSchema(leadDef, { recordChrome: false }).regions[0].components[0];
-    expect(on.recordChrome).toBe(true);
-    expect(off.recordChrome).toBe(false);
+    expect(props(on).recordChrome).toBe(true);
+    expect(props(off).recordChrome).toBe(false);
   });
 
   it('page:tabs always carries a details tab containing record:details', () => {
     const tabs = buildDefaultPageSchema(leadDef).regions[0].components.find(
       (c: any) => c.type === 'page:tabs',
     );
-    expect(tabs.items).toHaveLength(1);
-    expect(tabs.items[0].label).toBe('Details');
-    expect(tabs.items[0].children[0].type).toBe('record:details');
+    expect(tabItems(tabs)).toHaveLength(1);
+    expect(tabItems(tabs)[0].label).toBe('Details');
+    expect(tabItems(tabs)[0].children[0].type).toBe('record:details');
   });
 
   it('handles undefined def gracefully', () => {
@@ -275,9 +292,9 @@ describe('buildDefaultPageSchema', () => {
       // No separate record:quick_actions sibling — actions live on the header.
       expect(types).not.toContain('record:quick_actions');
       const header = page.regions[0].components[0];
-      expect(Array.isArray(header.actions)).toBe(true);
-      expect(header.actions).toHaveLength(1);
-      expect(header.actions[0].name).toBe('edit');
+      expect(Array.isArray(props(header).actions)).toBe(true);
+      expect(props(header).actions).toHaveLength(1);
+      expect(props(header).actions[0].name).toBe('edit');
     });
 
     it('omits header.actions when headerActions empty or absent', () => {
@@ -285,8 +302,8 @@ describe('buildDefaultPageSchema', () => {
       const emptyOpt = buildDefaultPageSchema(leadDef, { headerActions: [] });
       const header1 = noOpt.regions[0].components[0];
       const header2 = emptyOpt.regions[0].components[0];
-      expect(header1.actions).toBeUndefined();
-      expect(header2.actions).toBeUndefined();
+      expect(props(header1).actions).toBeUndefined();
+      expect(props(header2).actions).toBeUndefined();
     });
 
     it('emits Related tab with one record:related_list per entry', () => {
@@ -308,13 +325,13 @@ describe('buildDefaultPageSchema', () => {
         ],
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      expect(tabs.items).toHaveLength(2);
-      expect(tabs.items[1].label).toBe('Related');
-      expect(tabs.items[1].children).toHaveLength(2);
-      expect(tabs.items[1].children[0].type).toBe('record:related_list');
-      expect(tabs.items[1].children[0].objectName).toBe('task');
-      expect(tabs.items[1].children[0].relationshipField).toBe('lead_id');
-      expect(tabs.items[1].children[0].limit).toBe(10);
+      expect(tabItems(tabs)).toHaveLength(2);
+      expect(tabItems(tabs)[1].label).toBe('Related');
+      expect(tabItems(tabs)[1].children).toHaveLength(2);
+      expect(tabItems(tabs)[1].children[0].type).toBe('record:related_list');
+      expect(props(tabItems(tabs)[1].children[0]).objectName).toBe('task');
+      expect(props(tabItems(tabs)[1].children[0]).relationshipField).toBe('lead_id');
+      expect(props(tabItems(tabs)[1].children[0]).limit).toBe(10);
     });
 
     it('promotes an isPrimary related list to its OWN tab (rule Z default)', () => {
@@ -323,7 +340,7 @@ describe('buildDefaultPageSchema', () => {
           { objectName: 'opportunity', relationshipField: 'lead_id', title: 'Opportunities', isPrimary: true },
         ],
       });
-      const labels = tabs.items.map((t: any) => t.label);
+      const labels = tabItems(tabs).map((t: any) => t.label);
       expect(labels).toEqual(['Details', 'Opportunities']);
       expect(labels).not.toContain('Related');
     });
@@ -336,11 +353,11 @@ describe('buildDefaultPageSchema', () => {
           { objectName: 'note', relationshipField: 'parent_id', title: 'Notes' },
         ],
       });
-      const labels = tabs.items.map((t: any) => t.label);
+      const labels = tabItems(tabs).map((t: any) => t.label);
       expect(labels).toEqual(['Details', 'Opportunities', 'Related']);
-      const related = tabs.items.find((t: any) => t.label === 'Related');
+      const related = tabItems(tabs).find((t: any) => t.label === 'Related');
       expect(related.children).toHaveLength(2);
-      expect(related.children.map((c: any) => c.objectName)).toEqual(['task', 'note']);
+      expect(related.children.map((c: any) => props(c).objectName)).toEqual(['task', 'note']);
     });
 
     it("relatedLayout:'tabs' gives every related list its own tab, ignoring isPrimary", () => {
@@ -351,7 +368,7 @@ describe('buildDefaultPageSchema', () => {
           { objectName: 'note', relationshipField: 'parent_id', title: 'Notes' },
         ],
       });
-      const labels = tabs.items.map((t: any) => t.label);
+      const labels = tabItems(tabs).map((t: any) => t.label);
       expect(labels).toEqual(['Details', 'Tasks', 'Notes']);
       expect(labels).not.toContain('Related');
     });
@@ -364,9 +381,9 @@ describe('buildDefaultPageSchema', () => {
           { objectName: 'task', relationshipField: 'lead_id', title: 'Tasks' },
         ],
       });
-      const labels = tabs.items.map((t: any) => t.label);
+      const labels = tabItems(tabs).map((t: any) => t.label);
       expect(labels).toEqual(['Details', 'Related']);
-      const related = tabs.items.find((t: any) => t.label === 'Related');
+      const related = tabItems(tabs).find((t: any) => t.label === 'Related');
       expect(related.children).toHaveLength(2);
     });
 
@@ -381,7 +398,7 @@ describe('buildDefaultPageSchema', () => {
       expect(page.regions.find((r: any) => r.name === 'aside')).toBeUndefined();
       // Related tab survives (Details + Related).
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      const labels = tabs.items.map((t: any) => t.label);
+      const labels = tabItems(tabs).map((t: any) => t.label);
       expect(labels).toContain('Related');
     });
 
@@ -395,14 +412,14 @@ describe('buildDefaultPageSchema', () => {
       });
       // Related tab is suppressed (Details only)
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      expect(tabs.items).toHaveLength(1);
-      expect(tabs.items[0].label).toBe('Details');
+      expect(tabItems(tabs)).toHaveLength(1);
+      expect(tabItems(tabs)[0].label).toBe('Details');
       // Aside region emitted with the rail
       const aside = page.regions.find((r: any) => r.name === 'aside');
       expect(aside).toBeDefined();
       expect(aside.components[0].type).toBe('record:reference_rail');
-      expect(aside.components[0].entries).toHaveLength(2);
-      expect(aside.components[0].entries[0].objectName).toBe('task');
+      expect(props(aside.components[0]).entries).toHaveLength(2);
+      expect(props(aside.components[0]).entries[0].objectName).toBe('task');
     });
 
     it('emits aside region from slots.rightRail even without any related lists', () => {
@@ -442,9 +459,9 @@ describe('buildDefaultPageSchema', () => {
     it('emits Activity tab when showActivity is true', () => {
       const page = buildDefaultPageSchema(leadDef, { showActivity: true });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      const labels = tabs.items.map((t: any) => t.label);
+      const labels = tabItems(tabs).map((t: any) => t.label);
       expect(labels).toContain('Activity');
-      const act = tabs.items.find((t: any) => t.label === 'Activity');
+      const act = tabItems(tabs).find((t: any) => t.label === 'Activity');
       expect(act.children[0].type).toBe('record:activity');
     });
 
@@ -456,11 +473,11 @@ describe('buildDefaultPageSchema', () => {
         history: { entries, loading: false },
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      const hist = tabs.items.find((t: any) => t.label === 'History');
+      const hist = tabItems(tabs).find((t: any) => t.label === 'History');
       expect(hist).toBeDefined();
       expect(hist.children[0].type).toBe('record:history');
-      expect(hist.children[0].entries).toEqual(entries);
-      expect(hist.children[0].loading).toBe(false);
+      expect(props(hist.children[0]).entries).toEqual(entries);
+      expect(props(hist.children[0]).loading).toBe(false);
     });
 
     it('Details / Related / Activity / History tab order is stable', () => {
@@ -470,7 +487,7 @@ describe('buildDefaultPageSchema', () => {
         history: { entries: [], loading: false },
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      expect(tabs.items.map((t: any) => t.label)).toEqual([
+      expect(tabItems(tabs).map((t: any) => t.label)).toEqual([
         'Details',
         'Related',
         'Activity',
@@ -502,20 +519,20 @@ describe('buildDefaultPageSchema', () => {
           (c: any) => c.type === 'page:tabs',
         );
         // Details + one tab per related child (no shared 'Related' tab).
-        expect(tabs.items.map((t: any) => t.label)).toEqual([
+        expect(tabItems(tabs).map((t: any) => t.label)).toEqual([
           'Details',
           'Tasks',
           'note',
         ]);
-        const tasksTab = tabs.items[1];
+        const tasksTab = tabItems(tabs)[1];
         expect(tasksTab.icon).toBe('check');
         expect(tasksTab.children).toHaveLength(1);
         expect(tasksTab.children[0].type).toBe('record:related_list');
-        expect(tasksTab.children[0].objectName).toBe('task');
-        expect(tasksTab.children[0].relationshipField).toBe('lead_id');
-        expect(tasksTab.children[0].limit).toBe(10);
+        expect(props(tasksTab.children[0]).objectName).toBe('task');
+        expect(props(tasksTab.children[0]).relationshipField).toBe('lead_id');
+        expect(props(tasksTab.children[0]).limit).toBe(10);
         // The second related child (no title) falls back to its objectName.
-        expect(tabs.items[2].children[0].objectName).toBe('note');
+        expect(props(tabItems(tabs)[2].children[0]).objectName).toBe('note');
       });
 
       it("defaults to the stacked 'Related' tab when relatedLayout is omitted", () => {
@@ -523,11 +540,11 @@ describe('buildDefaultPageSchema', () => {
         const tabs = page.regions[0].components.find(
           (c: any) => c.type === 'page:tabs',
         );
-        expect(tabs.items.map((t: any) => t.label)).toEqual([
+        expect(tabItems(tabs).map((t: any) => t.label)).toEqual([
           'Details',
           'Related',
         ]);
-        expect(tabs.items[1].children).toHaveLength(2);
+        expect(tabItems(tabs)[1].children).toHaveLength(2);
       });
 
       it("still honours hideRelatedTab (no related tabs emitted)", () => {
@@ -539,7 +556,7 @@ describe('buildDefaultPageSchema', () => {
         const tabs = page.regions[0].components.find(
           (c: any) => c.type === 'page:tabs',
         );
-        expect(tabs.items.map((t: any) => t.label)).toEqual(['Details']);
+        expect(tabItems(tabs).map((t: any) => t.label)).toEqual(['Details']);
       });
 
       it("keeps Activity / History after the per-table tabs", () => {
@@ -552,7 +569,7 @@ describe('buildDefaultPageSchema', () => {
         const tabs = page.regions[0].components.find(
           (c: any) => c.type === 'page:tabs',
         );
-        expect(tabs.items.map((t: any) => t.label)).toEqual([
+        expect(tabItems(tabs).map((t: any) => t.label)).toEqual([
           'Details',
           'Tasks',
           'note',
@@ -621,25 +638,31 @@ describe('buildDefaultPageSchema', () => {
         slots: { details: { type: 'div', id: 'custom-details' } },
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      expect(tabs.items.map((t: any) => t.label)).toEqual([
+      expect(tabItems(tabs).map((t: any) => t.label)).toEqual([
         'Details',
         'Related',
         'History',
       ]);
-      expect(tabs.items[0].children).toEqual([{ type: 'div', id: 'custom-details' }]);
+      expect(tabItems(tabs)[0].children).toEqual([{ type: 'div', id: 'custom-details' }]);
       // record:details default body must be gone
-      const firstBodyType = tabs.items[0].children[0].type;
+      const firstBodyType = tabItems(tabs)[0].children[0].type;
       expect(firstBodyType).toBe('div');
     });
 
     it('tabs slot wins over details slot when both provided', () => {
+      // Authored verbatim, in the caller's own spelling: a slot node is the
+      // author's, and the synthesizer places it UNTOUCHED — it does not
+      // re-shape someone else's tree (objectui#4232 canonicalizes the nodes
+      // this file BUILDS, not the ones it is handed).
+      const slotNode = { type: 'page:tabs', items: [{ label: 'Only', children: [] }] };
       const page = buildDefaultPageSchema(leadDef, {
         slots: {
-          tabs: { type: 'page:tabs', items: [{ label: 'Only', children: [] }] },
+          tabs: slotNode,
           details: { type: 'div', id: 'unused' },
         },
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
+      expect(tabs).toEqual(slotNode);
       expect(tabs.items).toHaveLength(1);
       expect(tabs.items[0].label).toBe('Only');
       // details slot was not applied
@@ -674,7 +697,7 @@ describe('buildDefaultPageSchema', () => {
   describe('slice I — sub-builders', () => {
     it('buildDefaultHeader returns a page:header node with recordChrome default true', () => {
       const node = buildDefaultHeader(leadDef);
-      expect(node).toEqual({ type: 'page:header', recordChrome: true });
+      expect(node).toEqual({ type: 'page:header', properties: { recordChrome: true } });
     });
 
     it('buildDefaultActions returns null for empty actions list', () => {
@@ -685,8 +708,8 @@ describe('buildDefaultPageSchema', () => {
     it('buildDefaultActions returns a quick_actions node when actions are provided', () => {
       const node = buildDefaultActions(leadDef, [{ id: 'edit', label: 'Edit' }]);
       expect(node?.type).toBe('record:quick_actions');
-      expect(node?.location).toBe('record_header');
-      expect(node?.actions).toHaveLength(1);
+      expect(props(node).location).toBe('record_header');
+      expect(props(node).actions).toHaveLength(1);
     });
 
     it('buildDefaultHighlights returns [chips, path] when status field is present', () => {
@@ -711,7 +734,7 @@ describe('buildDefaultPageSchema', () => {
         history: { entries: [], loading: false },
       });
       expect(tabs.type).toBe('page:tabs');
-      expect(tabs.items.map((t: any) => t.label)).toEqual([
+      expect(tabItems(tabs).map((t: any) => t.label)).toEqual([
         'Details',
         'Related',
         'Activity',
@@ -742,7 +765,7 @@ describe('buildDefaultPageSchema', () => {
     it('enable.files → tabs carry an Attachments tab wrapping record:attachments', () => {
       const page = buildDefaultPageSchema(filesDef);
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      const tab = tabs.items.find((t: any) => t.value === 'attachments');
+      const tab = tabItems(tabs).find((t: any) => t.value === 'attachments');
       expect(tab).toBeDefined();
       expect(tab.label).toBe('Attachments');
       expect(tab.children).toEqual([{ type: 'record:attachments' }]);
@@ -758,7 +781,7 @@ describe('buildDefaultPageSchema', () => {
         showActivity: true,
         history: { entries: [], loading: false },
       });
-      expect(tabs.items.map((t: any) => t.value)).toEqual([
+      expect(tabItems(tabs).map((t: any) => t.value)).toEqual([
         'details',
         'related',
         'attachments',
@@ -777,8 +800,8 @@ describe('buildDefaultPageSchema', () => {
         slots: { details: { type: 'div', id: 'custom-details' } },
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      expect(tabs.items.some((t: any) => t.value === 'attachments')).toBe(true);
-      expect(tabs.items[0].children[0].id).toBe('custom-details');
+      expect(tabItems(tabs).some((t: any) => t.value === 'attachments')).toBe(true);
+      expect(tabItems(tabs)[0].children[0].id).toBe('custom-details');
     });
   });
 
@@ -802,11 +825,11 @@ describe('buildDefaultPageSchema', () => {
         approvals: { count: 2, node: nodePayload },
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      const tab = tabs.items.find((t: any) => t.value === 'approvals');
+      const tab = tabItems(tabs).find((t: any) => t.value === 'approvals');
       expect(tab).toBeDefined();
       expect(tab.label).toBe('Approvals');
       expect(tab.count).toBe(2);
-      expect(tab.children).toEqual([{ type: 'record:approvals', ...nodePayload }]);
+      expect(tab.children).toEqual([{ type: 'record:approvals', properties: { ...nodePayload } }]);
     });
 
     it('the Approvals tab sits after Related and before Attachments/Activity/History', () => {
@@ -816,7 +839,7 @@ describe('buildDefaultPageSchema', () => {
         history: { entries: [], loading: false },
         approvals: { node: nodePayload },
       });
-      expect(tabs.items.map((t: any) => t.value)).toEqual([
+      expect(tabItems(tabs).map((t: any) => t.value)).toEqual([
         'details',
         'related',
         'approvals',
@@ -832,8 +855,8 @@ describe('buildDefaultPageSchema', () => {
         slots: { details: { type: 'div', id: 'custom-details' } },
       });
       const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-      expect(tabs.items.some((t: any) => t.value === 'approvals')).toBe(true);
-      expect(tabs.items[0].children[0].id).toBe('custom-details');
+      expect(tabItems(tabs).some((t: any) => t.value === 'approvals')).toBe(true);
+      expect(tabItems(tabs)[0].children[0].id).toBe('custom-details');
     });
   });
 });
@@ -1079,9 +1102,9 @@ describe('buildDefaultPageSchema integration (#2148)', () => {
     };
     const page = buildDefaultPageSchema(def);
     const tabs = page.regions[0].components.find((c: any) => c.type === 'page:tabs');
-    const details = tabs.items[0].children[0];
+    const details = tabItems(tabs)[0].children[0];
     expect(details.type).toBe('record:details');
-    expect(details.sections[0]).toMatchObject({ name: 'basic', title: 'Basic' });
+    expect(props(details).sections[0]).toMatchObject({ name: 'basic', title: 'Basic' });
   });
 
   it('stageField: false drops record:path', () => {
@@ -1104,16 +1127,16 @@ describe('buildDefaultTabs — stable tab values (objectui#2257)', () => {
       showActivity: true,
       history: { entries: [], loading: false },
     });
-    expect(tabs.items.map((i: any) => i.value)).toEqual([
+    expect(tabItems(tabs).map((i: any) => i.value)).toEqual([
       'details', 'related:invoice', 'related', 'activity', 'history',
     ]);
   });
 
   it('relatedLayout tabs → every child gets related:<child>; stack → one related', () => {
     const asTabs = buildDefaultTabs(undefined, { related: [relA, relB], relatedLayout: 'tabs' });
-    expect(asTabs.items.map((i: any) => i.value)).toEqual(['details', 'related:invoice', 'related:note']);
+    expect(tabItems(asTabs).map((i: any) => i.value)).toEqual(['details', 'related:invoice', 'related:note']);
     const stacked = buildDefaultTabs(undefined, { related: [relA, relB], relatedLayout: 'stack' });
-    expect(stacked.items.map((i: any) => i.value)).toEqual(['details', 'related']);
+    expect(tabItems(stacked).map((i: any) => i.value)).toEqual(['details', 'related']);
   });
 
   it('values stay stable when the related list shrinks (URL tokens must not shift)', () => {
@@ -1121,7 +1144,7 @@ describe('buildDefaultTabs — stable tab values (objectui#2257)', () => {
     const onlyB = buildDefaultTabs(undefined, { related: [relB] });
     // 'related' names the same (stacked) tab in both trees — an index value
     // would have pointed at 'related:invoice' before and 'related' after.
-    expect(both.items.some((i: any) => i.value === 'related')).toBe(true);
-    expect(onlyB.items.some((i: any) => i.value === 'related')).toBe(true);
+    expect(tabItems(both).some((i: any) => i.value === 'related')).toBe(true);
+    expect(tabItems(onlyB).some((i: any) => i.value === 'related')).toBe(true);
   });
 });

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -260,6 +260,51 @@ function toNodeArray(slot: any | any[] | undefined): any[] {
 }
 
 /**
+ * Build ONE page component node — the single place this synthesizer decides
+ * where a component's props live (objectui#4232).
+ *
+ * A page component's own shape is CLOSED. `PageComponentSchema` declares
+ * `type` / `id` / `label` / `properties` / `events` / `style` / `className` /
+ * `responsiveStyles` / `visibleWhen` / `visibility` / `dataSource` /
+ * `responsive` / `aria` and nothing else, and ADR-0089 D3a flipped it to
+ * `.strict()` — so a widget prop written at the TOP level of the node is not
+ * dropped, it is a parse error:
+ *
+ * ```
+ * unrecognized_keys | regions.0.components.0 |
+ *   Unrecognized key(s) on this view/page schema: `recordChrome`, `actions`.
+ *   Before ADR-0089 D3a these were dropped silently, shipping inert metadata;
+ *   a mis-layered or stale key is now a loud parse error.
+ * ```
+ *
+ * That error is what made Studio's page-create never complete: the create path
+ * seeds `regions` from `buildDefaultPageSchema(objectDef)`
+ * (`app-shell/views/metadata-admin/anchors.ts` → `createSeed`), the console
+ * PUT carried the flat props, the server refused the body, and no page row was
+ * ever stored.
+ *
+ * The canonical carrier is the node's `properties` bag — which is exactly
+ * where the spec declares these props (`ComponentPropsMap`:
+ * `PageHeaderProps.recordChrome`, `PageTabsProps.items`, …), and what
+ * `SchemaRenderer` hoists back onto the node before dispatching to a renderer
+ * (`packages/react/src/SchemaRenderer.tsx`, "COMPAT: Hoist 'properties' up to
+ * schema level"). So the semantics are unchanged in both directions: the same
+ * props reach the same renderers, and the body now parses.
+ *
+ * `undefined` values are dropped rather than written as present-but-undefined
+ * keys, and a component with no props at all emits no `properties` key —
+ * `PageComponentSchema.properties` is `.optional().default({})`, so `{ type }`
+ * is complete.
+ */
+function componentNode(type: string, props: Record<string, unknown> = {}): any {
+  const properties: Record<string, unknown> = {};
+  for (const key of Object.keys(props)) {
+    if (props[key] !== undefined) properties[key] = props[key];
+  }
+  return Object.keys(properties).length > 0 ? { type, properties } : { type };
+}
+
+/**
  * Detect the canonical "status" / "stage" field on an object definition.
  *
  * The implementation moved to `@object-ui/types` (`detectStatusField`) so
@@ -409,13 +454,12 @@ export function buildDefaultHeader(
   _def: ObjectDefLike | undefined,
   options: Pick<BuildPageOptions, 'recordChrome'> & { actions?: any[] } = {},
 ): any {
-  return {
-    type: 'page:header',
+  return componentNode('page:header', {
     recordChrome: options.recordChrome !== false,
     ...(Array.isArray(options.actions) && options.actions.length > 0
       ? { actions: options.actions }
       : {}),
-  };
+  });
 }
 
 /**
@@ -429,11 +473,10 @@ export function buildDefaultActions(
   headerActions: any[] | undefined,
 ): any | null {
   if (!Array.isArray(headerActions) || headerActions.length === 0) return null;
-  return {
-    type: 'record:quick_actions',
+  return componentNode('record:quick_actions', {
     actions: headerActions,
     location: 'record_header',
-  };
+  });
 }
 
 /**
@@ -455,10 +498,10 @@ export function buildDefaultHighlights(
     options.highlightFields ?? deriveHighlightFields(def, statusField);
   const out: any[] = [];
   if (!options.hideHighlights && highlightFields.length > 0) {
-    out.push({ type: 'record:highlights', fields: highlightFields });
+    out.push(componentNode('record:highlights', { fields: highlightFields }));
   }
   if (!options.hidePath && statusField && stages && stages.length > 0) {
-    out.push({ type: 'record:path', statusField, stages });
+    out.push(componentNode('record:path', { statusField, stages }));
   }
   return out;
 }
@@ -556,11 +599,10 @@ export function buildDefaultDetails(
   sections?: BuildPageOptions['sections'],
   hideFields?: string[],
 ): any {
-  return {
-    type: 'record:details',
+  return componentNode('record:details', {
     sections: resolveDetailSections(def, sections),
     ...(hideFields && hideFields.length > 0 ? { hideFields } : {}),
-  };
+  });
 }
 
 /**
@@ -592,15 +634,15 @@ export function buildDefaultTabs(
     Array.isArray(options.related) &&
     options.related.length > 0
   ) {
-    const relatedNode = (rel: NonNullable<BuildPageOptions['related']>[number]) => ({
-      type: 'record:related_list',
-      title: rel.title,
-      objectName: rel.objectName,
-      relationshipField: rel.relationshipField,
-      ...(rel.columns ? { columns: rel.columns } : {}),
-      ...(rel.limit ? { limit: rel.limit } : {}),
-      ...(rel.icon ? { icon: rel.icon } : {}),
-    });
+    const relatedNode = (rel: NonNullable<BuildPageOptions['related']>[number]) =>
+      componentNode('record:related_list', {
+        title: rel.title,
+        objectName: rel.objectName,
+        relationshipField: rel.relationshipField,
+        ...(rel.columns ? { columns: rel.columns } : {}),
+        ...(rel.limit ? { limit: rel.limit } : {}),
+        ...(rel.icon ? { icon: rel.icon } : {}),
+      });
     const asOwnTab = (rel: NonNullable<BuildPageOptions['related']>[number]) => ({
       label: rel.title || rel.objectName,
       value: `related:${rel.objectName}`,
@@ -638,7 +680,7 @@ export function buildDefaultTabs(
       label: 'Approvals',
       value: 'approvals',
       ...(options.approvals.count != null ? { count: options.approvals.count } : {}),
-      children: [{ type: 'record:approvals', ...(options.approvals.node || {}) }],
+      children: [componentNode('record:approvals', { ...(options.approvals.node || {}) })],
     });
   }
   // Attachments tab (objectstack#4358) — emitted for `enable.files: true`
@@ -651,31 +693,30 @@ export function buildDefaultTabs(
     items.push({ label: 'Attachments', value: 'attachments', children: [buildDefaultAttachments()] });
   }
   if (options.showActivity) {
-    items.push({ label: 'Activity', value: 'activity', children: [{ type: 'record:activity' }] });
+    items.push({ label: 'Activity', value: 'activity', children: [componentNode('record:activity')] });
   }
   if (options.history) {
     items.push({
       label: 'History',
       value: 'history',
       children: [
-        {
-          type: 'record:history',
+        componentNode('record:history', {
           entries: options.history.entries,
           loading: options.history.loading,
           emptyText: options.history.emptyText,
           unknownUserText: options.history.unknownUserText,
-        },
+        }),
       ],
     });
   }
-  return { type: 'page:tabs', items };
+  return componentNode('page:tabs', { items });
 }
 
 /**
  * Sub-builder: the inline `record:discussion` footer slot.
  */
 export function buildDefaultDiscussion(): any {
-  return { type: 'record:discussion' };
+  return componentNode('record:discussion');
 }
 
 /**
@@ -684,7 +725,7 @@ export function buildDefaultDiscussion(): any {
  * on `sys_attachment` rows (403 FILES_DISABLED otherwise).
  */
 export function buildDefaultAttachments(): any {
-  return { type: 'record:attachments' };
+  return componentNode('record:attachments');
 }
 
 /**
@@ -794,9 +835,12 @@ export function buildDefaultPageSchema(
       relatedLayout: options.relatedLayout,
       hideAttachments: options.hideAttachments,
     });
-    // Replace the first tab's children (Details) with the override.
-    if (Array.isArray(tabsNode.items) && tabsNode.items.length > 0) {
-      tabsNode.items[0] = { ...tabsNode.items[0], children: detailsBody };
+    // Replace the first tab's children (Details) with the override. The items
+    // live in the node's `properties` bag — the canonical carrier per
+    // ADR-0089 D3a (see `componentNode`).
+    const tabItems = tabsNode.properties?.items;
+    if (Array.isArray(tabItems) && tabItems.length > 0) {
+      tabItems[0] = { ...tabItems[0], children: detailsBody };
     }
     components.push(tabsNode);
   } else {
@@ -842,8 +886,7 @@ export function buildDefaultPageSchema(
   if (willEmitAside) {
     const asideComponents: any[] = [];
     if (willEmitRail) {
-      asideComponents.push({
-        type: 'record:reference_rail',
+      asideComponents.push(componentNode('record:reference_rail', {
         entries: (options.related as any[]).map((rel) => ({
           objectName: rel.objectName,
           relationshipField: rel.relationshipField,
@@ -852,7 +895,7 @@ export function buildDefaultPageSchema(
           displayField: rel.displayField,
           limit: 3,
         })),
-      });
+      }));
     }
     // Author-contributed right-rail nodes follow the reference rail so the
     // canonical "related" summary stays anchored at the top.


### PR DESCRIPTION
Fixes #4232

Creating a page in Studio never completed. The create path seeds a record page's
`regions` from `buildDefaultPageSchema(objectDef)` (app-shell
`views/metadata-admin/anchors.ts` → `createSeed`) and PUTs the result; the server
refused the body and no page row was ever stored.

## What the server actually rejects — measured, not assumed

I parsed the synthesizer's output with the schema the server enforces (the
vendored `@objectstack/spec` 17.0.0-rc.6, `PageSchema` from
`packages/spec/src/ui/page.zod.ts`). On `origin/main` the seed payload fails on
**four** component nodes, not the two the report named:

```
unrecognized_keys | regions.0.components.0 | Unrecognized key(s) on this view/page schema: `recordChrome`, `actions`.
unrecognized_keys | regions.0.components.1 | Unrecognized key(s) on this view/page schema: `fields`.
unrecognized_keys | regions.0.components.2 | Unrecognized key(s) on this view/page schema: `statusField`, `stages`.
unrecognized_keys | regions.0.components.3 | Unrecognized key(s) on this view/page schema: `items`.
```

The full message names the cause:

> Before ADR-0089 D3a these were dropped silently, shipping inert metadata; a
> mis-layered or stale key is now a loud parse error.

## What ADR-0089 D3a sanctions

**ADR-0089** (`docs/adr/0089-unify-visibility-predicate-naming.md`, Accepted
2026-07-14) records D3a as shipped:

> **D3a (`.strict()` flip) implemented (#2902)** — the monorepo + examples sweep
> found a single offender (a test fixture), and the strict flip ships as a major
> (`@objectstack/spec` 15.0.0).

and states the decision it belongs to:

> **Decision:** make **`visibleWhen`** the single canonical name across all three
> layers; keep `visibleOn` and `visibility` as `@deprecated` aliases normalized
> to `visibleWhen` at parse time; add `.strict()` + a lint rule so a mis-layered
> or mis-rooted key becomes a **loud** error instead of a silent no-op.

So D3a is not about `recordChrome` or `items` specifically: it closes the
view/page shapes, and a page component's shape is small and explicit —
`PageComponentSchema` declares `type`, `id`, `label`, `properties`, `events`,
`style`, `className`, `responsiveStyles`, `visibleWhen`, `visibility`,
`dataSource`, `responsive`, `aria`, and nothing else.

**Both semantics have a spec-shaped carrier, so nothing had to be dropped.** The
carrier is the node's own `properties` bag, declared in the same file:

```ts
properties: z.record(z.string(), z.unknown()).optional().default({})
  .describe('Component props passed to the widget. See component.zod.ts for schemas.'),
```

whose comment already names this synthesizer as the reason it is optional:

> the platform's own default-page synthesizer (buildDefaultPageSchema) emits
> nodes with props at the top level rather than under `properties`. Requiring
> `properties` forced `properties: {}` boilerplate and — worse — made every
> Studio attempt to seed a record page from its object's synthesized default
> layout fail validation ("regions.N.components.M.properties: expected record"),
> which was the real reason record/home/app pages couldn't be created in Studio.

And both keys are **declared props** on that bag in
`packages/spec/src/ui/component.zod.ts` (`ComponentPropsMap`), added by
objectstack#6776:

- `PageHeaderProps.recordChrome: z.boolean().default(true)` — "Render the record
  chrome … Set false on a non-record page (dashboard, landing) to fall back to
  the bare heading layout."
- `PageTabsProps.items` — the tab array (`label`, `icon`, `visibleWhen`, `value`,
  `count`, `children`).

`docs/protocol-upgrade-guide.md` records the same, including the read points in
this repo:

> Four are plain additions with no behaviour change (`page:header`
> `recordChrome`/`showStar`/`showCopyId`, which select between the record-chip
> header and the bare heading a dashboard wants …)

So the fix shape is **emit-canonical**: put the props where the spec declares
them. No lenient consumer, no lift window, no lost semantics.

## The fix

One helper, `componentNode(type, props)`, is now the single place this file
decides where a component's props live — every node it builds goes through it,
rather than each call site spelling a page-write payload its own way:

```ts
function componentNode(type: string, props: Record< string, unknown > = {}): any {
  const properties: Record< string, unknown > = {};
  for (const key of Object.keys(props)) {
    if (props[key] !== undefined) properties[key] = props[key];
  }
  return Object.keys(properties).length > 0 ? { type, properties } : { type };
}
```

Thirteen node kinds move onto it: `page:header`, `page:tabs`, `record:highlights`,
`record:path`, `record:details`, `record:related_list`, `record:quick_actions`,
`record:history`, `record:activity`, `record:attachments`, `record:approvals`,
`record:discussion`, `record:reference_rail`.

**Slot overrides stay verbatim.** A node handed in through `options.slots` is the
caller's, and is placed untouched — this canonicalizes the nodes the file
*builds*, not the ones it is *given*. That is pinned.

## Nothing on screen changes

`SchemaRenderer` hoists `properties` back onto the node before dispatch
(`packages/react/src/SchemaRenderer.tsx`, "COMPAT: Hoist 'properties' up to
schema level"), and that is the renderer every path uses: page regions render
through it (`components/renderers/layout/page.tsx` → `RegionContent`), and tab
panels reach it through `renderChildren`. So each renderer receives exactly the
props it received before.

**The registry declaration is untouched, per the card.**
`packages/components/src/renderers/layout/containers.tsx:1036` already reads

```ts
schema?.recordChrome === false || schema?.properties?.recordChrome === false
```

so the renderer keeps working for schemas carrying either spelling, the
`recordChrome` input declaration (`:1644`) stays, and
`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` is untouched.
This is a payload-shape change, not a renderer-property removal. (The console's
own preview sample already authors the canonical spelling:
`{ type: 'page:header', properties: { title: 'Welcome to the CRM', recordChrome: false } }`.)

`app-shell`'s introspection already reads both carriers —
`pageSchemaIntrospect.ts` walks `properties.items` / `properties.children`
alongside the flat keys — so the discussion / attachments / approvals
auto-append decisions are unaffected. No app-shell file is touched.

## Semantics preserved — pinned three ways

New file `packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.strictPayload.test.ts`
parses the emission with the REAL spec schemas rather than restating a key list,
so it follows the contract when the contract moves:

- **chrome ON (default)** — `{ type: 'page:header', properties: { recordChrome: true } }`,
  and `PageComponentSchema.parse(...)` returns it unchanged.
- **chrome explicitly OFF** — survives both the component parse and the whole
  page parse: `page.regions[0].components[0].properties.recordChrome === false`.
  This is the half that "just strip the key" would have silently destroyed.
- **tabs items intact** — `PageTabsProps.parse(node.properties)` accepts the bag
  and returns the same labels/values/children, i.e. the items are the *declared*
  props surface, not merely tolerated as unknown values inside an opaque record.

Plus a coverage pin that walks both synthesis branches, asserts the set of
emitted component types, and parses each node as a `PageComponentSchema` — so a
prop added at the top level of any future node is caught by name.

## Reverse verification

Direction predicted before running: the new payload pins should be **red on
`origin/main`'s emitter and green with it** — a plain before-red/after-green,
because the pins assert an accept where the old shape produced `unrecognized_keys`.

Ran it that way — `git checkout origin/main -- packages/plugin-detail/src/synth/buildDefaultPageSchema.ts`,
re-run the new pins, restore. **10 of 10 red**, and the failure output is the
server's own message rather than a synthetic one:

```
 Test Files  1 failed (1)
      Tests  10 failed (10)

AssertionError: expected [ …(4) ] to deeply equal []
+   "unrecognized_keys @ regions.0.components.0: Unrecognized key(s) on this view/page schema: `recordChrome`, `actions`. …"
+   "unrecognized_keys @ regions.0.components.1: Unrecognized key(s) on this view/page schema: `fields`. …"
+   "unrecognized_keys @ regions.0.components.2: Unrecognized key(s) on this view/page schema: `statusField`, `stages`. …"
+   "unrecognized_keys @ regions.0.components.3: Unrecognized key(s) on this view/page schema: `items`. …"
```

The existing pin file goes red in the same direction, because its accessors read
`node.properties` with no fallback to the flat spelling — that is deliberate, so a
regression cannot pass by reading the shape the server refuses.

## Tests

All from the repo root (objectui#3378), serialized under the shared verify lock,
`NODE_OPTIONS=--max-old-space-size=4096 --maxWorkers=2`:

| command | result |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/` | `Test Files 76 passed (76)` / `Tests 756 passed (756)` |
| `pnpm exec vitest run packages/components/src/__tests__/page-header-title.test.tsx packages/components/src/__tests__/page-single-h1.test.tsx packages/app-shell/src/utils/ packages/app-shell/src/views/metadata-admin/ apps/console/src/__tests__/record-block-record-reach.test.tsx` | `Test Files 166 passed (166)` / `Tests 1871 passed \| 1 skipped (1872)` |
| `pnpm exec vitest run packages/app-shell/src/views/` | `Test Files 207 passed (207)` / `Tests 2063 passed \| 1 skipped (2064)` |
| `pnpm --workspace-concurrency=2 --filter @object-ui/plugin-detail type-check` (both tsc projects) | exit 0 (`tsc --noEmit && tsc -p tsconfig.typetests.json`, after `pnpm --filter '@object-ui/plugin-detail^...' build`) |
| `npx eslint` on the three changed files | `160 problems (0 errors, 160 warnings)` — every warning is the file's pre-existing `no-explicit-any` style |
| `node scripts/check-changeset-presence.mjs` | declares `.changeset/synth-page-canonical-properties-4232.md` |
| `node scripts/check-control-bytes.mjs` | OK (3994 files scanned) |

The second and third rows are the **consumer** direction: every package that
renders or introspects this synthesizer's output (`components`, `app-shell`
views + utils + metadata-admin, `apps/console`), run as their own suites rather
than through a `--filter` prefix.

## Measured but deliberately out of this card's path

Two keys the same probe reports, both outside the create PUT and neither part of
this fix:

- **`pageType`** on the page object — an objectui local fork, already declared as
  such in `packages/types/src/zod/layout.zod.ts` and pinned as `local` by
  `packages/types/src/__tests__/page-app-dashboard-spec-parity.test.ts`. It never
  reaches the PUT: `createSeed` contributes only `regions` and `template`.
- **`className` on the `aside` region** — `PageRegionSchema` declares `name` /
  `width` / `components` only, so the rail region's `hidden xl:flex flex-col gap-4`
  has no spec carrier at region level, and moving it onto the child components
  would leave an empty column below `xl` instead of hiding it. That region is
  never emitted by the create path (the seed calls the synthesizer with no
  options), so it is not part of this user-blocking bug. Filed separately as
  #4286.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_