### PR TITLE
fix(console): /forms/:name honours ?recordId= — load the record, prefill it, PATCH it (#4278)

### DIFF
--- a/.changeset/form-route-edit-recordid-4278.md
+++ b/.changeset/form-route-edit-recordid-4278.md
@@ -1,0 +1,16 @@
+---
+'@object-ui/console': patch
+'@object-ui/app-shell': patch
+---
+
+A `type: 'form'` action fired from a record now EDITS that record instead of creating a duplicate
+
+`ActionRunner.executeForm` forwards the record an action was fired from as `/forms/:name?recordId=<id>`, but the console's internal form route never read that param. The only query params it consumed were the `prefill_` ones, so the route rendered EMPTY inputs, and its submit was an unconditional `POST /api/v1/data/:object` — an insert. An "edit this record" action therefore opened a blank form and, on Submit, created a second record while leaving the original untouched. In the showcase app: open any Task, click **Log Time**, fill it in, Submit — a NEW Task appeared. Until objectui#4109 the damage was hidden behind the anonymous "Your submission has been received" panel; once an internal submit started landing on the record it wrote, the duplicate became visible immediately.
+
+`?recordId=` now selects the whole read/write pair. The route loads the record with `GET /api/v1/data/:object/:id`, prefills the inputs with its stored values, and saves with `PATCH /api/v1/data/:object/:id` — the verb the data plugin declares (`plugin-rest-api.zod.ts`), the one `packages/rest` registers, and the one every other update client in this workspace already spells. After a successful save the user lands back on the record they edited.
+
+A `recordId` the route cannot honour now fails closed. A record that 404s or 403s, a payload whose object contradicts the form's target, and a present-but-blank `?recordId=` each render the form's error state; none of them falls back to create mode, because a blank form whose submit inserts a duplicate is this bug's exact harm and silently degrading into it would just re-arm it. A `recordId` naming a record of a different object is not found under the form's own object, so it takes the same refusal path.
+
+When a URL carries both a `recordId` and `prefill_` params, the explicit params win for the fields they name and the record's stored values fill the rest — a producer that forwards both is expressing intent, and the per-field instruction is the more specific one. Stored nulls and empty strings count as real values and beat a field's create-time `defaultValue`, so opening an edit form never silently proposes a change the user did not make.
+
+Two surfaces are deliberately untouched. Create mode — no `recordId` — behaves exactly as before, and the public `/f/:slug` path ignores `recordId` entirely: an anonymous visitor controls the URL, so honouring it there would turn a public form into an arbitrary-record reader and writer. In `@object-ui/app-shell` only the URL-param registry's documentation changed, recording that `recordId` now has a second reader on a route that can never match the same URL as the record drawer's.

--- a/apps/console/src/components/FormPage.recordId.test.tsx
+++ b/apps/console/src/components/FormPage.recordId.test.tsx
@@ -1,0 +1,463 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4278 — `/forms/:name?recordId=` is an EDIT, rendered.
+ *
+ * `ActionRunner.executeForm` forwards the record an action was fired from
+ * (`packages/core/src/actions/ActionRunner.ts`: `recordId != null ?
+ * `${base}?recordId=${encodeURIComponent(String(recordId))}` : base`). Before
+ * this card the route consumed only `prefill_` params, so an "edit this
+ * record" action rendered EMPTY inputs and its submit was an unconditional
+ * `POST /api/v1/data/:object` — an insert. Clicking **Log Time** on a showcase
+ * Task created a second Task and left the first untouched.
+ *
+ * PM rulings pinned here (issue #4278, quoted on the claim comment):
+ *   1. this route implements the read side — load, prefill, `PATCH`;
+ *   2. fail closed on a bad `recordId` — 403/404 or an object mismatch renders
+ *      the error state, NEVER a silent degrade to create mode;
+ *   3. `prefill_` params override the loaded record per field.
+ *
+ * ## Reverse verification — predicted directions, with the fix reverted
+ *
+ * Reverting `FormPage.tsx` to its post-#4279 state (the param unread, submit
+ * an unconditional POST) turns these RED, and each fails in a distinct way
+ * that names the defect:
+ *
+ *   - "renders the record's stored values"        → inputs are empty
+ *   - "PATCHes the record instead of inserting"   → one POST to `/data/:object`
+ *   - "lands back on the record it updated"       → id read off the response
+ *   - "a 404 … renders the error state"           → renders an empty CREATE form
+ *   - "a 403 … renders the error state"           → same
+ *   - "an object mismatch … refuses"              → prefills from the wrong object
+ *   - "a blank ?recordId= refuses"                → silently creates
+ *   - "prefill_ overrides the record per field"   → no record values at all
+ *
+ * GREEN BOTH SIDES, on purpose — these are controls, not change-detectors:
+ *
+ *   - "no recordId ⇒ the create path is unchanged" (the whole point of a
+ *     control: this card must not move create mode a byte);
+ *   - "the PUBLIC path ignores ?recordId= entirely", both its read and its
+ *     write. `/f/:slug` is anonymous and visitor-controlled; if #4278 ever
+ *     leaks onto it, that is a data-exposure bug, not a cosmetic one — so it
+ *     is pinned here even though nothing in this change can turn it red today.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { FormPage } from './FormPage';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+/** The FormView metadata `/meta/view/:name` serves — `showcase_task.edit`. */
+const VIEW_ENVELOPE = {
+  name: 'showcase_task.edit',
+  object: 'showcase_task',
+  viewKind: 'form',
+  label: 'Log Time',
+  config: {
+    type: 'simple',
+    sections: [{ label: 'Task', fields: ['title', 'hours'] }],
+  },
+};
+
+const OBJECT_SCHEMA = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: {
+    title: { type: 'text', label: 'Title' },
+    hours: { type: 'text', label: 'Hours', defaultValue: '0' },
+  },
+};
+
+/** `GetDataResponse = { object, id, record }` — the spec-declared read shape. */
+const GET_RESPONSE = {
+  object: 'showcase_task',
+  id: 'task-42',
+  record: { id: 'task-42', title: 'Write the report', hours: '3' },
+};
+
+/** `UpdateDataResponse` — measured to carry the same `{object,id,record}`. */
+const PATCH_RESPONSE = {
+  object: 'showcase_task',
+  id: 'task-42',
+  record: { id: 'task-42', title: 'Write the report v2', hours: '5' },
+};
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+let calls: Call[] = [];
+
+/**
+ * A fetch stub that answers per (method, url-substring) so a GET and a PATCH
+ * on the SAME path can be told apart — which is the whole point here.
+ * `status`-bearing entries answer not-ok, for the fail-closed cases.
+ */
+function stubFetch(routes: Array<{
+  method?: string;
+  match: string;
+  body?: unknown;
+  status?: number;
+  statusText?: string;
+}>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    calls.push({
+      url: String(url),
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    const route = routes.find(
+      (r) => (r.method ?? 'GET').toUpperCase() === method && String(url).includes(r.match),
+    );
+    if (!route) throw new Error(`unstubbed fetch: ${method} ${url}`);
+    const status = route.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: route.statusText ?? 'OK',
+      json: async () => route.body,
+      text: async () => (route.body === undefined ? '' : JSON.stringify(route.body)),
+    } as unknown as Response;
+  });
+}
+
+/** Records where the router settles, so "navigated" is an assertion. */
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+const recordPath = (objectName: string, recordId: string) =>
+  `/apps/ai.objectstack.showcase/${objectName}/record/${recordId}`;
+
+function renderInternal(query = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/forms/showcase_task.edit${query}`]}>
+      <LocationProbe />
+      <Routes>
+        <Route
+          path="/forms/:name"
+          element={<FormPage mode="internal" recordPath={recordPath} />}
+        />
+        <Route
+          path="/apps/:appName/:objectName/record/:recordId"
+          element={<div data-testid="record-page">record page</div>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** The happy-path route table: metadata + object schema + the record read. */
+function editRoutes(extra: Parameters<typeof stubFetch>[0] = []) {
+  return stubFetch([
+    { match: '/meta/view/', body: VIEW_ENVELOPE },
+    { match: '/meta/object/', body: OBJECT_SCHEMA },
+    { match: '/data/showcase_task/task-42', body: GET_RESPONSE },
+    { method: 'PATCH', match: '/data/showcase_task/task-42', body: PATCH_RESPONSE },
+    ...extra,
+  ]);
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('?recordId= makes the internal form an EDIT (ruling point 1)', () => {
+  it("renders the record's stored values instead of empty inputs", async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=task-42');
+
+    // RED before the fix: both inputs render empty.
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('Write the report');
+    expect(screen.getByLabelText(/Hours/)).toHaveValue('3');
+
+    // And the record really was read from the declared endpoint.
+    const read = calls.find((c) => c.method === 'GET' && c.url.includes('/data/showcase_task/'));
+    expect(read?.url).toContain('/data/showcase_task/task-42');
+  });
+
+  it('PATCHes the record instead of inserting a duplicate', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=task-42');
+
+    const title = await screen.findByLabelText(/Title/);
+    await userEvent.clear(title);
+    await userEvent.type(title, 'Write the report v2');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() => expect(calls.some((c) => c.method === 'PATCH')).toBe(true));
+    const write = calls.find((c) => c.method === 'PATCH')!;
+    // The measured convention: PATCH /api/v1/data/:object/:id, bare field body.
+    expect(write.url).toContain('/data/showcase_task/task-42');
+    expect(write.body).toMatchObject({ title: 'Write the report v2' });
+
+    // RED before the fix, and this is the defect itself: a POST to the
+    // collection endpoint is an INSERT — the duplicate record #4278 is about.
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+  });
+
+  it('lands back on the record it updated', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=task-42');
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/apps/ai.objectstack.showcase/showcase_task/record/task-42',
+      ),
+    );
+    expect(await screen.findByTestId('record-page')).toBeInTheDocument();
+  });
+
+  /**
+   * The destination is the id from the URL — the row we PATCHed — not one read
+   * back out of the response. Pinned with a response that names a DIFFERENT
+   * id: a server answering that way is a bug, and following it would send the
+   * user to a record they did not edit.
+   */
+  it('uses the URL id as the destination, not the update response body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/meta/view/', body: VIEW_ENVELOPE },
+        { match: '/meta/object/', body: OBJECT_SCHEMA },
+        { match: '/data/showcase_task/task-42', body: GET_RESPONSE },
+        {
+          method: 'PATCH',
+          match: '/data/showcase_task/task-42',
+          body: { object: 'showcase_task', id: 'task-999', record: {} },
+        },
+      ]),
+    );
+    renderInternal('?recordId=task-42');
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/apps/ai.objectstack.showcase/showcase_task/record/task-42',
+      ),
+    );
+  });
+});
+
+describe('a recordId this route cannot honour FAILS CLOSED (ruling point 2)', () => {
+  /**
+   * Every case in here asserts the same two things, and the second is the one
+   * that matters: an error panel IS shown, and no editable form is left behind
+   * it. A create form here would be #4278's harm re-armed — the user fills it
+   * in and inserts a duplicate.
+   */
+  async function expectRefusal(pattern: RegExp) {
+    const panel = await screen.findByText(pattern);
+    expect(panel).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Submit/ })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Title/)).not.toBeInTheDocument();
+  }
+
+  it('404 (no such record) ⇒ error state, not an empty create form', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/meta/view/', body: VIEW_ENVELOPE },
+        { match: '/meta/object/', body: OBJECT_SCHEMA },
+        { match: '/data/showcase_task/', status: 404, statusText: 'Not Found' },
+      ]),
+    );
+    renderInternal('?recordId=task-404');
+    await expectRefusal(/Could not open record "task-404".*404/s);
+  });
+
+  /**
+   * This is also the LIVE shape of "the record belongs to another object": the
+   * read is issued under the FORM's object, so an id from a different object
+   * is simply not found there. (`packages/metadata-protocol`'s `getData`
+   * throws `recordNotFoundError`, which REST maps to 404.)
+   */
+  it('403 (no permission) ⇒ error state, not an empty create form', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/meta/view/', body: VIEW_ENVELOPE },
+        { match: '/meta/object/', body: OBJECT_SCHEMA },
+        { match: '/data/showcase_task/', status: 403, statusText: 'Forbidden' },
+      ]),
+    );
+    renderInternal('?recordId=task-42');
+    await expectRefusal(/Could not open record "task-42".*403/s);
+  });
+
+  it("an object mismatch in the payload ⇒ refuses to open the form", async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/meta/view/', body: VIEW_ENVELOPE },
+        { match: '/meta/object/', body: OBJECT_SCHEMA },
+        {
+          match: '/data/showcase_task/',
+          body: { object: 'showcase_account', id: 'task-42', record: { title: 'Acme' } },
+        },
+      ]),
+    );
+    renderInternal('?recordId=task-42');
+    await expectRefusal(/belongs to showcase_account/);
+  });
+
+  it('a present-but-blank ?recordId= refuses instead of creating', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=');
+    await expectRefusal(/no record id was supplied/);
+    // Nothing was even asked for — a refusal short-circuits the loaders.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('never issues a write after refusing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/meta/view/', body: VIEW_ENVELOPE },
+        { match: '/meta/object/', body: OBJECT_SCHEMA },
+        { match: '/data/showcase_task/', status: 404, statusText: 'Not Found' },
+      ]),
+    );
+    renderInternal('?recordId=task-404');
+    await screen.findByText(/Could not open record/);
+    expect(calls.filter((c) => c.method === 'POST' || c.method === 'PATCH')).toHaveLength(0);
+  });
+});
+
+describe('prefill_ params override the loaded record, per field (ruling point 3)', () => {
+  it('takes the param for the field it names and the record for the rest', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=task-42&prefill_hours=8');
+
+    // The param wins for `hours` — a producer forwarding both is expressing
+    // intent: edit THIS record, with THIS field pre-changed.
+    expect(await screen.findByLabelText(/Hours/)).toHaveValue('8');
+    // …and every field it does not name keeps the stored value.
+    expect(screen.getByLabelText(/Title/)).toHaveValue('Write the report');
+  });
+
+  it('sends the merged values on the PATCH', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=task-42&prefill_hours=8');
+
+    await screen.findByLabelText(/Hours/);
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() => expect(calls.some((c) => c.method === 'PATCH')).toBe(true));
+    expect(calls.find((c) => c.method === 'PATCH')!.body).toMatchObject({
+      title: 'Write the report',
+      hours: '8',
+    });
+  });
+});
+
+/**
+ * CONTROLS — green before and after this change, and that is the point.
+ * #4278 must move the create path by nothing at all.
+ */
+describe('control: no recordId ⇒ the create path is unchanged', () => {
+  it('renders empty inputs (bar schema defaults) and POSTs to the collection', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/meta/view/', body: VIEW_ENVELOPE },
+        { match: '/meta/object/', body: OBJECT_SCHEMA },
+        {
+          method: 'POST',
+          match: '/data/showcase_task',
+          body: { object: 'showcase_task', id: 'task-new', record: {} },
+        },
+      ]),
+    );
+    renderInternal();
+
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('');
+    // The schema default still applies in create mode.
+    expect(screen.getByLabelText(/Hours/)).toHaveValue('0');
+    // No record read was issued at all.
+    expect(calls.filter((c) => c.url.includes('/data/'))).toHaveLength(0);
+
+    await userEvent.type(screen.getByLabelText(/Title/), 'A new task');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() => expect(calls.some((c) => c.method === 'POST')).toBe(true));
+    const write = calls.find((c) => c.method === 'POST')!;
+    expect(write.url).toMatch(/\/data\/showcase_task$/);
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0);
+    // #4109's default still lands on the CREATED record, read off the response.
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe(
+        '/apps/ai.objectstack.showcase/showcase_task/record/task-new',
+      ),
+    );
+  });
+});
+
+describe('control: the PUBLIC /f/:slug path is untouched by #4278', () => {
+  const PUBLIC_PAYLOAD = {
+    slug: 'contact-us',
+    object: 'showcase_inquiry',
+    label: 'Contact us',
+    form: { type: 'simple', sections: [{ fields: ['title'] }] },
+    objectSchema: {
+      name: 'showcase_inquiry',
+      fields: { title: { type: 'text', label: 'Title' } },
+    },
+  };
+
+  function renderPublic(query = '') {
+    return render(
+      <MemoryRouter initialEntries={[`/f/contact-us${query}`]}>
+        <LocationProbe />
+        <Routes>
+          <Route path="/f/:slug" element={<FormPage mode="public" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  /**
+   * An anonymous visitor controls the URL. If `?recordId=` were honoured here
+   * it would turn a public form into an arbitrary-record READER (prefilled
+   * with someone else's data) and WRITER (a PATCH). Neither may ever happen.
+   */
+  it('reads no record and still POSTs to the public submit endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/forms/contact-us', body: PUBLIC_PAYLOAD },
+        { method: 'POST', match: '/forms/contact-us/submit', body: { ok: true } },
+      ]),
+    );
+    renderPublic('?recordId=task-42');
+
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('');
+    // No data-API read whatsoever — the anonymous surface never touches /data.
+    expect(calls.filter((c) => c.url.includes('/data/'))).toHaveLength(0);
+
+    await userEvent.type(screen.getByLabelText(/Title/), 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() => expect(calls.some((c) => c.method === 'POST')).toBe(true));
+    expect(calls.find((c) => c.method === 'POST')!.url).toContain('/forms/contact-us/submit');
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(0);
+    // The anonymous confirmation, unchanged.
+    expect(await screen.findByText('Your submission has been received.')).toBeInTheDocument();
+  });
+});

--- a/apps/console/src/components/FormPage.test.ts
+++ b/apps/console/src/components/FormPage.test.ts
@@ -9,9 +9,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildSections,
+  FORM_RECORD_ID_PARAM,
   normalizeColumns,
   normalizeOptions,
   readCreatedRecordId,
+  readFormRecordTarget,
+  readLoadedRecord,
   readPrefill,
   resolveInternalForm,
   resolveSubmitBehavior,
@@ -181,6 +184,172 @@ describe('readPrefill', () => {
   it('treats empty-string values as a real prefill', () => {
     const out = readPrefill(fields, new URLSearchParams('prefill_company='));
     expect(out.company).toBe('');
+  });
+
+  /**
+   * objectui#4278 — the three-source precedence, pinned one rung at a time:
+   * `defaultValue` < stored record < explicit `prefill_` param.
+   */
+  describe('with a stored record (edit mode)', () => {
+    it('fills every field the record names', () => {
+      const out = readPrefill(fields, new URLSearchParams(), {
+        first_name: 'Grace',
+        company: 'Initech',
+        phone: '555-0100',
+      });
+      expect(out).toEqual({ first_name: 'Grace', company: 'Initech', phone: '555-0100' });
+    });
+
+    it("beats the field's create-time defaultValue", () => {
+      const out = readPrefill(fields, new URLSearchParams(), { company: 'Initech' });
+      // NOT 'Acme' — on an edit form the stored value is the truth.
+      expect(out.company).toBe('Initech');
+    });
+
+    /**
+     * The precedence that actually protects data: a stored null/empty must
+     * not be repainted by a default, or the next save silently writes a
+     * change the user never made.
+     */
+    it('lets a stored null or empty string beat the default', () => {
+      expect(readPrefill(fields, new URLSearchParams(), { company: null }).company).toBeNull();
+      expect(readPrefill(fields, new URLSearchParams(), { company: '' }).company).toBe('');
+    });
+
+    it('is overridden per FIELD by an explicit prefill_ param (the ruling)', () => {
+      const out = readPrefill(
+        fields,
+        new URLSearchParams('prefill_company=Umbrella'),
+        { first_name: 'Grace', company: 'Initech', phone: '555-0100' },
+      );
+      // The named field takes the param; the rest keep the record's values.
+      expect(out).toEqual({ first_name: 'Grace', company: 'Umbrella', phone: '555-0100' });
+    });
+
+    it('ignores record keys that are not fields on this form', () => {
+      const out = readPrefill(fields, new URLSearchParams(), {
+        company: 'Initech',
+        secret_internal_column: 'nope',
+      });
+      expect(out).not.toHaveProperty('secret_internal_column');
+    });
+
+    /** Control: the create path is byte-identical when no record is passed. */
+    it('is unchanged when the record is null/undefined (create mode)', () => {
+      const search = new URLSearchParams('prefill_first_name=Ada');
+      expect(readPrefill(fields, search, null)).toEqual(readPrefill(fields, search));
+      expect(readPrefill(fields, search, undefined)).toEqual(readPrefill(fields, search));
+    });
+  });
+});
+
+/**
+ * objectui#4278 — what the URL says an internal form is FOR.
+ *
+ * Reverse verification: with the fix reverted the param is not read at all,
+ * so every `edit` expectation below collapses to `create` — which is the
+ * defect verbatim (an edit intent silently becoming an insert).
+ */
+describe('readFormRecordTarget', () => {
+  it('spells the param exactly as app-shell reserves it', () => {
+    // `RECORD_DRAWER_PARAM` in packages/app-shell/src/urlParams.ts. Pinned as
+    // a literal because app-shell exports only its package root, which does
+    // not re-export ./urlParams — so the two spellings cannot drift silently.
+    expect(FORM_RECORD_ID_PARAM).toBe('recordId');
+  });
+
+  it('is create mode when the param is absent', () => {
+    expect(readFormRecordTarget('internal', new URLSearchParams())).toEqual({ kind: 'create' });
+    expect(readFormRecordTarget('internal', new URLSearchParams('prefill_title=x')))
+      .toEqual({ kind: 'create' });
+  });
+
+  it('is edit mode when the param names a record', () => {
+    expect(readFormRecordTarget('internal', new URLSearchParams('recordId=task-42')))
+      .toEqual({ kind: 'edit', recordId: 'task-42' });
+  });
+
+  it('decodes a percent-encoded id (ActionRunner encodes it)', () => {
+    // `ActionRunner.executeForm` builds the URL with encodeURIComponent, and
+    // URLSearchParams decodes on read — so an id carrying `/` or `#` survives.
+    const search = new URLSearchParams(`recordId=${encodeURIComponent('a/b#c')}`);
+    expect(readFormRecordTarget('internal', search)).toEqual({ kind: 'edit', recordId: 'a/b#c' });
+  });
+
+  /**
+   * Fail closed (ruling point 2). `ActionRunner` appends the param for any
+   * `recordId != null`, and an empty-string id passes that test — so this is
+   * reachable, and the safe answer is to refuse rather than quietly insert.
+   */
+  it('REFUSES a present-but-blank param instead of degrading to create', () => {
+    for (const raw of ['recordId=', 'recordId=%20%20']) {
+      const target = readFormRecordTarget('internal', new URLSearchParams(raw));
+      expect(target.kind).toBe('refuse');
+      expect(target.kind === 'refuse' && target.reason).toMatch(/no record id/i);
+    }
+  });
+
+  /**
+   * Control pin — the public `/f/:slug` surface is untouched by all of #4278.
+   * An anonymous visitor controls the URL, so honouring `?recordId=` there
+   * would turn a public form into an arbitrary-record reader AND writer.
+   */
+  it('never reads the param in PUBLIC mode, whatever the URL says', () => {
+    expect(readFormRecordTarget('public', new URLSearchParams('recordId=task-42')))
+      .toEqual({ kind: 'create' });
+    expect(readFormRecordTarget('public', new URLSearchParams('recordId=')))
+      .toEqual({ kind: 'create' });
+  });
+});
+
+/**
+ * objectui#4278 — reading `GET /api/v1/data/:object/:id`, which the spec
+ * declares as `GetDataResponse = { object, id, record }`.
+ */
+describe('readLoadedRecord', () => {
+  const RESPONSE = {
+    object: 'showcase_task',
+    id: 'task-42',
+    record: { id: 'task-42', title: 'Write the report', hours: 3 },
+  };
+
+  it('reads the record off a bare GetDataResponse', () => {
+    expect(readLoadedRecord(RESPONSE, 'showcase_task', 'task-42')).toEqual(RESPONSE.record);
+  });
+
+  it('reads it through the { success, data } transport envelope too', () => {
+    // Same one rule `@objectstack/client.unwrapResponse` applies — the
+    // http-dispatcher wraps, packages/rest does not.
+    const wrapped = { success: true, data: RESPONSE, meta: { ts: 1 } };
+    expect(readLoadedRecord(wrapped, 'showcase_task', 'task-42')).toEqual(RESPONSE.record);
+  });
+
+  it('accepts a response that omits the echoed object key', () => {
+    expect(readLoadedRecord({ id: 'task-42', record: { title: 'x' } }, 'showcase_task', 'task-42'))
+      .toEqual({ title: 'x' });
+  });
+
+  /**
+   * Object mismatch ⇒ refuse (ruling point 2). Honest reachability: the
+   * deployed server ECHOES the path object, and we build that path from the
+   * view's target, so `packages/rest` cannot produce this payload — it is a
+   * contract assertion at the consumer, pinned with a hand-built body.
+   */
+  it('throws when the served object contradicts the form target', () => {
+    expect(() =>
+      readLoadedRecord({ ...RESPONSE, object: 'showcase_account' }, 'showcase_task', 'task-42'),
+    ).toThrow(/belongs to showcase_account.*edits showcase_task/s);
+  });
+
+  it('throws — never returns empty — when the payload carries no record', () => {
+    // An empty object would land in the same state as create mode, which is
+    // the harm; so each of these must be an error rather than `{}`.
+    expect(() => readLoadedRecord(null, 'showcase_task', 'task-42')).toThrow(/no record payload/);
+    expect(() => readLoadedRecord('not json', 'showcase_task', 'task-42')).toThrow(/no record payload/);
+    expect(() => readLoadedRecord({ object: 'showcase_task', id: 'task-42' }, 'showcase_task', 'task-42'))
+      .toThrow(/no "record"/);
+    expect(() => readLoadedRecord({ record: [] }, 'showcase_task', 'task-42')).toThrow(/no "record"/);
+    expect(() => readLoadedRecord({ record: null }, 'showcase_task', 'task-42')).toThrow(/no "record"/);
   });
 });
 

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -9,11 +9,24 @@
  * Both modes share the same renderer; the difference is only in how the
  * spec is loaded, where submissions go, and — since objectui#4109 — what
  * happens after a successful submit when the form view declares nothing:
- * an internal submit lands on the record it just created, while the public
+ * an internal submit lands on the record it just wrote, while the public
  * path keeps the anonymous `thank-you` confirmation. See
  * {@link resolveSubmitBehavior}. This is the same shape as Airtable Forms —
  * the form view metadata is identical whether it is embedded publicly or
  * used by logged-in operators.
+ *
+ * ## Create vs edit (objectui#4278)
+ *
+ * The internal route also serves EDIT, and which one it is comes from the URL:
+ * `ActionRunner.executeForm` forwards the record an action was fired from as
+ * `/forms/:name?recordId=<id>`. Until #4278 this route ignored that param
+ * entirely — it rendered empty inputs and its submit was an unconditional
+ * `POST` — so an "edit this record" action produced a blank form and then a
+ * DUPLICATE record. `?recordId=` now selects the whole read/write pair:
+ * `GET /data/:object/:id` to prefill, `PATCH /data/:object/:id` to save. See
+ * {@link readFormRecordTarget} for the create/edit/refuse decision and
+ * {@link readPrefill} for what wins when a `prefill_` param and a stored value
+ * name the same field.
  */
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
@@ -72,6 +85,84 @@ type SubmitBehavior =
 export type FormPageMode = 'public' | 'internal';
 
 /**
+ * The query param naming the record an internal form edits — the one
+ * `ActionRunner.executeForm` forwards (`/forms/:name?recordId=<id>`).
+ *
+ * ## Why the same spelling as the drawer's reserved param, deliberately
+ *
+ * `recordId` is ALREADY reserved in `@object-ui/app-shell`'s registry
+ * (`src/urlParams.ts` → `RECORD_DRAWER_PARAM`), where it opens a record-detail
+ * drawer over a list. That is not a collision to route around, and #4278 ruling
+ * point 3 asked for the relationship to be measured rather than assumed:
+ *
+ *  - the two readers can never see one URL. React Router renders exactly one
+ *    leaf per location, `/forms/:name` is a TOP-LEVEL route in `App.tsx`
+ *    (sibling of `/apps/*`, where `ObjectView` — the drawer's only reader,
+ *    `views/ObjectView.tsx`, the single `RECORD_DRAWER_PARAM` call site
+ *    outside the registry itself — is mounted), and `InternalFormRoute` renders
+ *    `DefaultHomeLayout` + this component and no list. Disjoint subtrees, so
+ *    the same URL cannot carry both meanings at once;
+ *  - and the MEANING is the same one either way — "the record this surface is
+ *    about". A second spelling (`formRecordId`, …) for that fact would be the
+ *    de-facto second contract AGENTS.md #0.1 forbids, and would make the
+ *    already-reserved name look free to repurpose.
+ *
+ * So this is the registry's name, used as the registry defines it. It is a
+ * literal here rather than an import only because `@object-ui/app-shell`
+ * exports its package root alone and that root does not re-export
+ * `./urlParams` — the same unreachability `createdRecordPath.ts` documents for
+ * `resolveHostAppSegment`. `FormPage.test.ts` pins the two spellings equal so
+ * they cannot drift apart in silence.
+ */
+export const FORM_RECORD_ID_PARAM = 'recordId';
+
+/**
+ * What the URL says this internal form is FOR: creating a record, editing a
+ * named one, or nothing coherent.
+ *
+ * The third case is the point. #4278 ruling point 2 is fail-closed: an edit
+ * intent this route cannot honour must reach the error state, because silently
+ * falling back to create mode is the EXACT harm the card was filed about (an
+ * empty form whose submit inserts a duplicate). A present-but-blank
+ * `?recordId=` — which `ActionRunner` really can emit, since it appends the
+ * param for any `recordId != null` and an empty-string id passes that test —
+ * declares edit intent and names no record, so it refuses rather than degrades.
+ */
+export type FormRecordTarget =
+  | { kind: 'create' }
+  | { kind: 'edit'; recordId: string }
+  | { kind: 'refuse'; reason: string };
+
+/**
+ * Decide {@link FormRecordTarget} from the surface and the query string.
+ *
+ * PUBLIC mode never reads the param, and that is a contract, not an
+ * optimisation: `/f/:slug` is the anonymous surface, where the visitor
+ * controls the URL and the backend resolver deliberately exposes one
+ * submit-only endpoint. Honouring `?recordId=` there would turn a public form
+ * into an arbitrary-record reader and writer. The public path is unchanged by
+ * every part of #4278, and this line is where that holds.
+ */
+export function readFormRecordTarget(
+  mode: FormPageMode,
+  search: URLSearchParams,
+): FormRecordTarget {
+  if (mode !== 'internal') return { kind: 'create' };
+  const raw = search.get(FORM_RECORD_ID_PARAM);
+  if (raw === null) return { kind: 'create' };
+  const recordId = raw.trim();
+  if (!recordId) {
+    return {
+      kind: 'refuse',
+      reason:
+        `This form was opened to edit a record (?${FORM_RECORD_ID_PARAM}=), but no record id was supplied. ` +
+        'Re-open it from the record, or drop the parameter to create a new one.',
+    };
+  }
+  return { kind: 'edit', recordId };
+}
+
+/**
  * What the renderer actually does after a successful submit: every authorable
  * {@link SubmitBehavior}, plus the one behaviour the PLATFORM supplies rather
  * than the author.
@@ -84,6 +175,14 @@ export type FormPageMode = 'public' | 'internal';
  * when an internal form declares nothing. That is what lets the platform
  * default differ from every authorable kind WITHOUT widening the contract or
  * teaching authors a second dialect for something they never write.
+ *
+ * Since objectui#4278 the internal route also EDITS, and this one value covers
+ * both writes: "land on the record this submit wrote" — the created one, or
+ * the one `?recordId=` named. It is one behaviour, so it keeps one name; a
+ * second `updated-record` kind would be two spellings of a single rule, and
+ * the name is #4109's rather than churned here because renaming it would
+ * restate a just-landed contract for cosmetics. The create/edit split lives
+ * where it belongs — in the id the handler navigates with, not in the union.
  */
 type EffectiveSubmitBehavior = SubmitBehavior | { kind: 'created-record' };
 
@@ -229,6 +328,41 @@ export function resolveSubmitBehavior(
 }
 
 /**
+ * Strip the transport envelope off a data-API body, if there is one.
+ *
+ * Not a metadata dialect but a platform fact: two transports serve these
+ * routes and only one wraps the body. `packages/rest`'s server answers the
+ * bare protocol payload (`res.json(result)`), while the runtime's
+ * http-dispatcher wraps every success as `{ success, data, meta }`. The
+ * platform already resolves this in exactly ONE rule, in
+ * `@objectstack/client`:
+ *
+ *     async unwrapResponse(res) {
+ *       const body = await res.json();
+ *       if (body && typeof body.success === 'boolean' && 'data' in body) return body.data;
+ *       return body;
+ *     }
+ *
+ * `FormPage` hand-rolls `fetch` instead of going through that client (it
+ * predates having one here), so the same rule has to be applied at these call
+ * sites. Mirroring it is not inventing a dialect — spelling a DIFFERENT rule
+ * would be, which is why this is ONE function read by every data-API response
+ * this file consumes (create, and since #4278 the record read) rather than the
+ * same three lines written out twice.
+ *
+ * Returns null for anything that is not an object, so callers get one shape to
+ * check instead of two.
+ */
+function unwrapTransportEnvelope(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const body = payload as Record<string, unknown>;
+  const unwrapped =
+    typeof body.success === 'boolean' && 'data' in body ? body.data : body;
+  if (!unwrapped || typeof unwrapped !== 'object') return null;
+  return unwrapped as Record<string, unknown>;
+}
+
+/**
  * The id of the record an internal submit just created, read off the
  * `POST /api/v1/data/:object` response.
  *
@@ -238,36 +372,28 @@ export function resolveSubmitBehavior(
  * and no alias: `record.id` carries the same value, but reading both would be
  * exactly the second de-facto contract AGENTS.md #0.1 forbids.
  *
- * What this DOES have to absorb is the transport envelope, which is not a
- * metadata dialect but a platform fact: two transports serve this route and
- * only one wraps the body. `packages/rest`'s server answers the bare object
- * (`res.status(201).json(result)`), while the runtime's http-dispatcher wraps
- * every success as `{ success, data, meta }`. The platform already resolves
- * this in exactly ONE rule, in `@objectstack/client`:
+ * The transport envelope is absorbed by {@link unwrapTransportEnvelope} —
+ * see there for why that is a platform fact rather than a dialect.
  *
- *     async unwrapResponse(res) {
- *       const body = await res.json();
- *       if (body && typeof body.success === 'boolean' && 'data' in body) return body.data;
- *       return body;
- *     }
+ * ## Why the EDIT path does not use this (objectui#4278)
  *
- * `FormPage` hand-rolls `fetch` instead of going through that client (it
- * predates having one here), so the same rule has to be applied at this call
- * site. Mirroring it is not inventing a dialect — spelling a DIFFERENT rule
- * would be.
+ * `UpdateDataResponse` was measured and declares the identical triple
+ * (`{ object, id, record, droppedFields? }`, `api/protocol.zod.ts`), so this
+ * function would fit an update response byte for byte. It is deliberately not
+ * pointed at one: on the edit path the id is already known — it came from the
+ * URL and is the id we just `PATCH`ed — so reading it back would create a
+ * SECOND source for one fact, and the two could only ever disagree by way of a
+ * server bug this renderer would then silently follow. The create path has no
+ * such source, which is exactly why it must read the response. One fact, one
+ * reader, chosen per path.
  *
  * Returns null when the payload names no id, so the caller can confirm the
  * submit instead of navigating to `…/record/undefined`.
  */
 export function readCreatedRecordId(payload: unknown): string | null {
-  if (!payload || typeof payload !== 'object') return null;
-  const body = payload as Record<string, unknown>;
-  const unwrapped =
-    typeof body.success === 'boolean' && 'data' in body
-      ? (body.data as Record<string, unknown> | null | undefined)
-      : body;
-  if (!unwrapped || typeof unwrapped !== 'object') return null;
-  const id = (unwrapped as Record<string, unknown>).id;
+  const unwrapped = unwrapTransportEnvelope(payload);
+  if (!unwrapped) return null;
+  const id = unwrapped.id;
   // The spec declares `id: z.string()`. The numeric branch is a coercion of
   // that SAME key for drivers whose primary key surfaces as an integer — one
   // key, one meaning, so it cannot mask a producer emitting the wrong shape.
@@ -276,14 +402,100 @@ export function readCreatedRecordId(payload: unknown): string | null {
   return null;
 }
 
-/** Apply `?prefill_<field>=<value>` query params to the initial form state. */
+/**
+ * The stored record an edit form starts from, read off the
+ * `GET /api/v1/data/:object/:id` response.
+ *
+ * The response contract is spec-declared — `GetDataResponse = { object, id,
+ * record }` (`@objectstack/spec`, `api/protocol.zod.ts`; the protocol's
+ * `getData` returns exactly that triple and throws `recordNotFoundError`
+ * otherwise, which REST maps to 404). The envelope is handled by
+ * {@link unwrapTransportEnvelope}.
+ *
+ * Throws — rather than returning null — on anything it cannot vouch for,
+ * because #4278 ruling point 2 is fail-closed and this function is the last
+ * place that can tell an unreadable record from an empty one. A null return
+ * would land in the same `values` state as create mode, which is the harm.
+ *
+ * ## The object check, and the honest limit of it
+ *
+ * The `object` key is compared against the FormView's target, and a mismatch
+ * refuses. Measured reachability: the deployed server ECHOES the path object
+ * (`getData` returns `object: request.object`), and we build that path from
+ * the view's own target — so a live `packages/rest` deployment cannot produce
+ * a mismatch here. This is therefore a contract assertion at the consumer, not
+ * a live defect being patched; it costs three lines and it is what makes the
+ * form's object and the record's object one checked fact instead of an
+ * assumption, for any transport that does not echo.
+ *
+ * The case that IS live is the other one, and it is handled by the fetch
+ * rather than by this check: a `recordId` belonging to a DIFFERENT object is
+ * not found under the view's object, so the read 404s and refuses. See
+ * `loadInternalForm`.
+ */
+export function readLoadedRecord(
+  payload: unknown,
+  expectedObject: string,
+  recordId: string,
+): Record<string, unknown> {
+  const unwrapped = unwrapTransportEnvelope(payload);
+  if (!unwrapped) {
+    throw new Error(
+      `Could not read record "${recordId}" of ${expectedObject}: the server returned no record payload.`,
+    );
+  }
+  const servedObject = unwrapped.object;
+  if (typeof servedObject === 'string' && servedObject && servedObject !== expectedObject) {
+    throw new Error(
+      `Record "${recordId}" belongs to ${servedObject}, but this form edits ${expectedObject}. ` +
+        'Refusing to open it — check the action that linked here.',
+    );
+  }
+  const record = unwrapped.record;
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new Error(
+      `Could not read record "${recordId}" of ${expectedObject}: the response carried no "record".`,
+    );
+  }
+  return record as Record<string, unknown>;
+}
+
+/**
+ * The initial form state — every value an input starts life holding.
+ *
+ * Three sources, in strictly increasing precedence (#4278 ruling on prefill):
+ *
+ *  1. the field's `defaultValue` from the object schema — a CREATE-time
+ *     proposal;
+ *  2. the stored `record`, when this form is editing one. Present-but-null
+ *     counts and beats a default: on an edit form the stored value is the
+ *     truth, and letting a default paint over a cleared field would silently
+ *     propose a change the user never made — which a subsequent save would
+ *     then write;
+ *  3. an explicit `?prefill_<field>=` query param, which wins over both.
+ *
+ * Point 3 is the ruling: "explicit `prefill_` params override the loaded
+ * record's values for the fields they name … record values fill the rest". A
+ * producer that forwards `?recordId=` AND `?prefill_x=` in one URL is
+ * expressing intent — edit THIS record, with THIS field pre-changed — and the
+ * narrower, per-field instruction is the more specific one. Fields the params
+ * do not name keep their stored values, so the precedence is per FIELD and
+ * never wholesale.
+ */
 export function readPrefill(
   fields: RenderableField[],
   search: URLSearchParams,
+  record?: Record<string, unknown> | null,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const f of fields) {
     if (f.defaultValue !== undefined) out[f.name] = f.defaultValue;
+    // `hasOwnProperty` rather than a truthiness/undefined test: a stored null
+    // or empty string is a real value on an edit form, and must beat the
+    // default.
+    if (record && Object.prototype.hasOwnProperty.call(record, f.name)) {
+      out[f.name] = record[f.name];
+    }
     const fromQuery = search.get(`prefill_${f.name}`);
     if (fromQuery !== null) out[f.name] = fromQuery;
   }
@@ -310,6 +522,11 @@ interface LoadedForm {
   object: string;
   form: FormViewSpec;
   objectSchema: ObjectSchemaPayload | null;
+  /**
+   * The stored record this form is editing, or null in create mode
+   * (objectui#4278). Non-null iff the load resolved a `?recordId=`.
+   */
+  record: Record<string, unknown> | null;
 }
 
 /** Public mode: hit the anonymous `/forms/:slug` resolver. */
@@ -325,6 +542,9 @@ async function loadPublicForm(slug: string): Promise<LoadedForm> {
     object: payload.object,
     form: payload.form,
     objectSchema: payload.objectSchema,
+    // The anonymous surface never edits a stored record — see
+    // `readFormRecordTarget` for why `?recordId=` is not readable here.
+    record: null,
   };
 }
 
@@ -383,10 +603,22 @@ export function resolveInternalForm(
 
 /**
  * Internal mode: pull the FormView metadata directly + the target object's
- * schema. We use the same `/meta` REST surface the rest of the console
- * already speaks, so anything the user has READ on works automatically.
+ * schema, and — when the URL names a record (objectui#4278) — that record.
+ *
+ * We use the same `/meta` REST surface the rest of the console already speaks,
+ * so anything the user has READ on works automatically.
+ *
+ * ## Why the record read is fatal when the schema read is not
+ *
+ * The object-schema fetch below is deliberately swallowed: without it the
+ * renderer degrades to text inputs, which is a WORSE form but still the right
+ * form, doing the right thing on submit. A failed RECORD read has no such
+ * benign degradation — carrying on would render empty inputs and, on submit,
+ * insert a duplicate. That is #4278's exact harm, so per ruling point 2 this
+ * throws and the caller shows the error state. The gap between the two `catch`
+ * postures is the gap between "less detail" and "wrong operation".
  */
-async function loadInternalForm(name: string): Promise<LoadedForm> {
+async function loadInternalForm(name: string, recordId?: string | null): Promise<LoadedForm> {
   const viewRes = await apiFetch(`/meta/view/${encodeURIComponent(name)}`);
   if (!viewRes.ok) {
     throw new Error(`Form metadata not found: view/${name}`);
@@ -414,11 +646,33 @@ async function loadInternalForm(name: string): Promise<LoadedForm> {
   } catch {
     // Schema fallback is non-fatal — the renderer copes with text inputs.
   }
+
+  // #4278: the edit half. Fetched with the VIEW's object, so a `recordId`
+  // belonging to some other object is simply not found here and 404s into the
+  // refusal below — the live shape of "the record's object doesn't match the
+  // form's" (`readLoadedRecord` documents why the echoed `object` key cannot
+  // be the signal on this server).
+  let record: Record<string, unknown> | null = null;
+  if (recordId) {
+    const recRes = await apiFetch(
+      `/data/${encodeURIComponent(objectName)}/${encodeURIComponent(recordId)}`,
+    );
+    if (!recRes.ok) {
+      const detail = await recRes.text().catch(() => '');
+      throw new Error(
+        `Could not open record "${recordId}" of ${objectName} for editing (${recRes.status})` +
+          `${detail ? `: ${detail}` : recRes.statusText ? `: ${recRes.statusText}` : ''}`,
+      );
+    }
+    record = readLoadedRecord(await recRes.json(), objectName, recordId);
+  }
+
   return {
     label,
     object: objectName,
     form,
     objectSchema,
+    record,
   };
 }
 
@@ -435,18 +689,41 @@ async function submitPublic(slug: string, data: Record<string, unknown>): Promis
   return res.json().catch(() => ({}));
 }
 
-/** Internal mode submit — POST to `/data/:object`. Auth cookie carries identity. */
+/**
+ * Internal mode submit. Auth cookie carries identity.
+ *
+ * `POST /data/:object` to create; `PATCH /data/:object/:id` to update the
+ * record `?recordId=` named (objectui#4278). Before that param was read, this
+ * was an unconditional POST — which is why an "edit" action inserted a second
+ * record instead of changing the one the user was looking at.
+ *
+ * The verb is MEASURED, not chosen: `PATCH /:object/:id → updateData` is the
+ * data plugin's declared route (`@objectstack/spec`,
+ * `api/plugin-rest-api.zod.ts`), it is what `packages/rest`'s server registers,
+ * and `packages/rest/src/openapi-builtin-paths.ts` records that the server
+ * "answers `PATCH` and 405s the `PUT`" — a published document that said `PUT`
+ * was itself filed as a defect (#5588). Every other update client in this
+ * workspace spells the same pair: `ApiDataSource.update` (`packages/core`),
+ * the console's own API discovery and Integrations pages, and app-shell's
+ * `ObjectApiPanel`. The body is the bare field patch, matching create.
+ */
 async function submitInternal(
   objectName: string,
   data: Record<string, unknown>,
+  recordId?: string | null,
 ): Promise<unknown> {
-  const res = await apiFetch(`/data/${encodeURIComponent(objectName)}`, {
-    method: 'POST',
+  const path = recordId
+    ? `/data/${encodeURIComponent(objectName)}/${encodeURIComponent(recordId)}`
+    : `/data/${encodeURIComponent(objectName)}`;
+  const res = await apiFetch(path, {
+    method: recordId ? 'PATCH' : 'POST',
     body: JSON.stringify(data),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
-    throw new Error(`Create failed (${res.status}): ${body || res.statusText}`);
+    throw new Error(
+      `${recordId ? 'Update' : 'Create'} failed (${res.status}): ${body || res.statusText}`,
+    );
   }
   return res.json().catch(() => ({}));
 }
@@ -604,8 +881,9 @@ export interface FormPageProps {
   /** `'public'` for /f/:slug (anonymous), `'internal'` for /forms/:name (authed). */
   mode: FormPageMode;
   /**
-   * Builds the console path of a record an INTERNAL submit just created, so
-   * the default `created-record` behaviour has somewhere to land.
+   * Builds the console path of the record an INTERNAL submit just wrote —
+   * created, or (objectui#4278) updated — so the default `created-record`
+   * behaviour has somewhere to land.
    *
    * Injected rather than computed here because the answer is not a property of
    * the form: a record page is app-scoped (`/apps/<segment>/<object>/record/
@@ -634,6 +912,13 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
   const [search] = useSearchParams();
   const navigate = useNavigate();
   const identifier = (mode === 'public' ? params.slug : params.name) ?? '';
+  /**
+   * Create, edit, or refuse — decided from the URL alone (objectui#4278), so
+   * the whole read/write pair below has ONE switch rather than a `recordId`
+   * truthiness test at each of the three sites that need it.
+   */
+  const target = readFormRecordTarget(mode, search);
+  const editingId = target.kind === 'edit' ? target.recordId : null;
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -642,27 +927,42 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
-  // Load spec on mount / when identifier changes.
+  // Load spec on mount / when identifier or the record it targets changes.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    const loader = mode === 'public' ? loadPublicForm(identifier) : loadInternalForm(identifier);
+    // A `?recordId=` we cannot make sense of never reaches a loader: it is an
+    // edit intent this route cannot honour, and #4278 ruling point 2 says
+    // refuse rather than degrade into the create path.
+    const loader =
+      target.kind === 'refuse'
+        ? Promise.reject(new Error(target.reason))
+        : mode === 'public'
+          ? loadPublicForm(identifier)
+          : loadInternalForm(identifier, editingId);
     loader
       .then((result) => {
         if (cancelled) return;
         setLoaded(result);
         const sections = buildSections(result.form, result.objectSchema);
         const allFields = sections.flatMap((s) => s.fields);
-        setValues(readPrefill(allFields, search));
+        setValues(readPrefill(allFields, search, result.record));
       })
       .catch((e) => {
-        if (!cancelled) setError(e?.message ?? String(e));
+        if (!cancelled) {
+          // Clear any previously loaded form: a refusal must not leave an
+          // editable form on screen behind the error.
+          setLoaded(null);
+          setError(e?.message ?? String(e));
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
+    // `target`/`editingId` are derived from `search`, already a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, identifier, search]);
 
   const sections = useMemo<RenderableSection[]>(
@@ -684,23 +984,31 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
       const result =
         mode === 'public'
           ? await submitPublic(identifier, values)
-          : await submitInternal(loaded.object, values);
+          : await submitInternal(loaded.object, values, editingId);
       toast.success('Submitted');
       // Behaviour after submit
       switch (behavior.kind) {
         case 'created-record': {
-          // The internal default (ruling point 2): land on what was just
-          // created. Client-side `navigate` — NOT `window.location.assign` —
-          // because the record page lives in the same SPA and a full reload
-          // would throw away the shell this route now renders inside.
-          const id = readCreatedRecordId(result);
+          // The internal default (#4109 ruling point 2): land on the record
+          // this submit wrote. Client-side `navigate` — NOT
+          // `window.location.assign` — because the record page lives in the
+          // same SPA and a full reload would throw away the shell this route
+          // now renders inside.
+          //
+          // On an EDIT (#4278) the destination is the id we already hold: it
+          // came from the URL and is the row we just PATCHed, so there is
+          // nothing to read out of the response and no way for it to be
+          // missing. `readCreatedRecordId` is for the create path, which has
+          // no other source — see its docblock for why the update response's
+          // (identical, measured) `id` is deliberately not read back.
+          const id = editingId ?? readCreatedRecordId(result);
           const to = id ? recordPath?.(loaded.object, id) : null;
           if (to) {
             navigate(to);
             break;
           }
           // No id in the response, or no record page to land on. Confirm the
-          // submit rather than navigate somewhere broken — the create itself
+          // submit rather than navigate somewhere broken — the write itself
           // succeeded, so silence would be the worse answer.
           setSubmitted(true);
           break;
@@ -712,9 +1020,11 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
           break;
         }
         case 'continue': {
-          // Reset values to defaults so the user can submit another one.
+          // Reset values so the user can submit again. On an edit form that
+          // means back to the record as loaded — NOT to blank, which would
+          // stage a wipe of every field on the next save.
           const allFields = sections.flatMap((s) => s.fields);
-          setValues(readPrefill(allFields, search));
+          setValues(readPrefill(allFields, search, loaded.record));
           break;
         }
         case 'next-record':

--- a/packages/app-shell/src/urlParams.ts
+++ b/packages/app-shell/src/urlParams.ts
@@ -19,10 +19,13 @@
  *
  * | Param       | Meaning                                        | History      |
  * |-------------|------------------------------------------------|--------------|
- * | `recordId`  | Record detail DRAWER over a list (light        | push (open)  |
- * |             | objects; heavy ones use the `/record/:id`      |              |
- * |             | route instead). URL is the drawer's source of  |              |
- * |             | truth.                                         |              |
+ * | `recordId`  | The record a surface is ABOUT. Two readers on  | push (open)  |
+ * |             | disjoint routes: the record detail drawer over |              |
+ * |             | a list (light objects; heavy ones use the      |              |
+ * |             | `/record/:id` route instead), and the console's|              |
+ * |             | internal form route `/forms/:name`, where it   |              |
+ * |             | means "edit THIS record" (objectui#4278).      |              |
+ * |             | URL is the source of truth for both.           |              |
  * | `form`      | The global record-form overlay: `new` = create,|              |
  * |             | a record id = edit (framework#2604 D1/D2).     | push (open), |
  * |             | Back closes the overlay.                       | replace (close) |
@@ -52,7 +55,16 @@
  * here — but they must not collide with the names above.
  */
 
-/** Record detail drawer over a list (`?recordId=<id>`). */
+/**
+ * Record detail drawer over a list (`?recordId=<id>`).
+ *
+ * The name is shared, deliberately, with the console's internal form route
+ * (`/forms/:name?recordId=` → edit that record — objectui#4278): one meaning,
+ * "the record this surface is about", on route subtrees that can never both
+ * match one URL. `ObjectView` — mounted under `/apps/*` — is this constant's
+ * only reader; `/forms/:name` is a top-level route rendering a form and no
+ * list. A page-scoped param must still never shadow this name.
+ */
 export const RECORD_DRAWER_PARAM = 'recordId';
 
 /** Global record-form overlay: `new` | `<recordId>` (framework#2604). */


### PR DESCRIPTION
Fixes #4278

Builds directly on #4109 / PR #4279 (`resolveSubmitBehavior`, `readCreatedRecordId`, `InternalFormRoute`), whose squash `90e792e11` is this branch's base.

## The defect

`ActionRunner.executeForm` forwards the record an action was fired from as `/forms/:name?recordId=...`, but the internal form route never read that param — it consumed only the `prefill_` ones. So the route rendered **empty** inputs, and `submitInternal` was an unconditional `POST /api/v1/data/:object`, i.e. an INSERT. An "edit this record" action opened a blank form and, on Submit, created a **second** record while leaving the original untouched. In the showcase app: open any Task, click **Log Time**, fill it in, Submit — a new Task appears.

## What this does

`?recordId=` now selects the whole read/write pair, per PM ruling point 1 (implement the read side on this route; do not reroute to the app-shell record-form surface, do not touch `ActionRunner`):

- `GET /api/v1/data/:object/:id` to load, inputs prefilled with the stored values;
- `PATCH /api/v1/data/:object/:id` to save;
- and the user lands back on the record they edited.

### The update convention was measured, not chosen

`PATCH /:object/:id` → `updateData` is the data plugin's declared route (`@objectstack/spec`, `api/plugin-rest-api.zod.ts`), it is what `packages/rest`'s server registers, and `packages/rest/src/openapi-builtin-paths.ts` records that the server "answers `PATCH` and 405s the `PUT`" — a published document that said `PUT` was itself filed as a defect (objectstack#5588). Every other update client in this workspace spells the same pair: `ApiDataSource.update` (`packages/core`), the console's own API-discovery and Integrations pages, and app-shell's `ObjectApiPanel`. The body is the bare field patch, matching create.

The read side is `GetDataResponse = { object, id, record }`, also spec-declared. The `{ success, data }` transport envelope is absorbed by one extracted helper that both the create and the read path share, mirroring `@objectstack/client.unwrapResponse` rather than spelling a second rule.

### Fail closed on a bad recordId (ruling point 2)

A 403/404, a payload whose `object` contradicts the form's target, and a present-but-blank `?recordId=` each render the form's error state. **None** degrades to create mode: a blank form whose submit inserts a duplicate is this bug's exact harm, so silently falling back into it would re-arm the defect. A `recordId` belonging to a different object is not found under the form's own object, so it 404s onto the same refusal path.

Honest reachability note on the object-mismatch guard: the deployed server **echoes** the path object (`getData` returns `object: request.object`) and we build that path from the view's target, so a live `packages/rest` deployment cannot produce a mismatching payload. That guard is a contract assertion at the consumer, pinned with a hand-built body — not a live defect being patched. The reachable half of "wrong object" is the 404, and it is pinned as such.

### Prefill precedence, pinned

Explicit `prefill_` params win for the fields they **name**; the stored record fills the rest; a field's create-time `defaultValue` is lowest. Precedence is per field, never wholesale — a producer forwarding both `?recordId=` and `?prefill_x=` is expressing intent ("edit THIS record, with THIS field pre-changed"), and the narrower instruction is the more specific one. A stored `null` or empty string counts as a real value and beats a default, so opening an edit form never silently proposes a change the user did not make.

### Where an edit lands

The destination is the id from the **URL** — the row we just `PATCH`ed — not one read back off the response. `UpdateDataResponse` was measured and declares the identical `{ object, id, record, droppedFields? }` triple as create, so `readCreatedRecordId` would fit byte for byte; it is deliberately not pointed at one, because the edit path already holds that fact and a second reader could only ever disagree by way of a server bug this renderer would then follow. The create path has no other source, which is exactly why it must read the response. Pinned with an update response naming a **different** id.

### recordId vs the reserved drawer param (ruling point 3)

Measured rather than assumed. `recordId` is **already** reserved in `packages/app-shell/src/urlParams.ts` as `RECORD_DRAWER_PARAM`, so no new registration was warranted — the name is registered, and adding a second constant for the same string would be two spellings of one contract. What was missing is that the registry described only one reader.

The two readers can never see one URL: React Router renders exactly one leaf per location; `ObjectView` (the only `RECORD_DRAWER_PARAM` call site outside the registry) is mounted under `/apps/*`; `/forms/:name` is a top-level route rendering `DefaultHomeLayout` + a form and no list. Disjoint subtrees. And the meaning is the same either way — "the record this surface is about". So the app-shell change here is **prose only**: the registry table now names both readers and the disjointness. The console spells the literal (app-shell exports only its package root, which does not re-export `./urlParams` — the same unreachability `createdRecordPath.ts` documents), and a test pins the two spellings equal so they cannot drift in silence.

## Tests, and the reverse verification

New: `apps/console/src/components/FormPage.recordId.test.tsx` (13 rendered cases) plus unit coverage for the new pure helpers in `FormPage.test.ts`.

With `FormPage.tsx` reverted to its post-#4279 state, the predicted directions were written down first and then measured — **11 red, 2 green**, exactly as predicted:

| Pin | Reverted behaviour |
|---|---|
| renders the record's stored values | RED — inputs empty (`Received: ` blank, the defect verbatim) |
| PATCHes instead of inserting | RED — one POST to the collection |
| lands back on the record it updated | RED — stays on `/forms/...` |
| URL id is the destination, not the response's | RED |
| 404 / 403 ⇒ error state | RED — renders an empty CREATE form |
| object mismatch ⇒ refuses | RED |
| blank `?recordId=` ⇒ refuses | RED |
| `prefill_` overrides the record per field (x2) | RED |
| **control:** no recordId ⇒ create path unchanged | **GREEN both sides** |
| **control:** public `/f/:slug` ignores `?recordId=` | **GREEN both sides** |

The two controls are green on purpose and are not change-detectors. The create-path control is the whole point of the card — this must not move create mode a byte. The public-path control guards a direction nothing in this change can turn red today: `/f/:slug` is anonymous and visitor-controlled, so if `recordId` ever leaked onto it that would be a data-exposure bug (an arbitrary-record reader **and** writer), which is worth a standing pin rather than a comment.

## Verification

- `pnpm exec vitest run apps/console/` — **38 files, 421 tests passed**
- `pnpm exec vitest run packages/app-shell/` — **344 files, 3286 passed** (1 pre-existing skip)
- `type-check` on `@object-ui/console` + `@object-ui/app-shell` (both `tsc` commands each) — clean, after building the dependency closure
- downstream consumer sweep, **prefix** filter `...@object-ui/app-shell` (i.e. the packages that consume it): 4 projects, all green
- `eslint` on the changed files: **0 errors**. Warning delta vs. the pre-fix baseline is +2 `react-refresh/only-export-components`, from the newly exported pure helpers — the same pattern this file already uses for every one of its exported helpers
- changeset gates: `check-changeset-presence.mjs` and `check-changeset-no-major.mjs` both green (`patch`, both packages)

## Out of scope

Filed #4292 while measuring this: `?recordId=` carries no object name, so the id is resolved against the FormView's target object. When an action's target view edits a different object than the record it was fired from **and** ids collide across objects (per-table integer keys), the route silently reads and now writes the wrong record. The producer half lives in `packages/core` (`ActionRunner`), which this card's ruling put out of scope and which #4046 holds. Pre-#4278 the worst case was a duplicate insert; now it is a targeted update, which is why it is worth naming.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_