### PR TITLE
fix(console): key the API Console storage group by the canonical `file-storage` slot (#4240)

### DIFF
--- a/.changeset/api-console-storage-slot-key-4240.md
+++ b/.changeset/api-console-storage-slot-key-4240.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/console': patch
+---
+
+API Console renders the Storage group again — its catalog key now names the canonical `file-storage` slot instead of the route
+
+The API Console's service-gated groups are keyed by canonical service-slot name, because the key is looked up directly in `/discovery`'s `services` map — and the framework keys that map by `CoreServiceName`. The storage group was keyed `storage`, which is the *route* (`/api/v1/storage`), not the slot (`file-storage`). So the lookup missed on every host, and because a miss is indistinguishable from "no such service" the deliberate fail-closed branch (ADR-0076 D12) hid all three storage endpoints — upload, download, delete — on every deployment, whether or not a storage service was registered and healthy.
+
+The fail-closed posture was never the defect and is unchanged; only the key moves. The group's user-facing name stays `Storage` — that is the route's name, and it was never derived from the catalog key, so no display string and no i18n resource changes.
+
+The mis-key survived because nothing tied the catalog's keys to the vocabulary they are spelled in: a wrong key produces silence, not an error, and an empty group is exactly what a legitimately absent service looks like. A tripwire now derives that vocabulary from `@objectstack/spec` itself and asserts every service-gated catalog key against it, so a rename on either side fails a test instead of quietly emptying a group. Deriving it also surfaced two further keys that name no slot and therefore can never render — `workflow` (slot retired upstream) and `feed` (never a slot) — recorded as a documented exception set pointing at objectui#4303 rather than fixed here, since neither has a correctly-spelled name to move to.

--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * useApiDiscovery — service-gated endpoint groups (#4240).
+ *
+ * ## The defect this file pins
+ *
+ * `SERVICE_ENDPOINT_CATALOG` keys are looked up straight in `/discovery`'s
+ * `services` map, which the framework keys by `CoreServiceName`. The storage
+ * group was keyed `storage`; the canonical slot is `file-storage`. So the
+ * lookup missed on every host, and a miss is indistinguishable from "no such
+ * service" — the deliberate fail-closed branch (ADR-0076 D12) then hid all
+ * three storage endpoints everywhere, on every deployment, forever.
+ *
+ * That is the nastiest shape this page can fail in: fail-closed is *correct*
+ * behaviour, so the symptom is silence rather than an error, and a mis-keyed
+ * group is indistinguishable from a legitimately absent service.
+ *
+ * ## What is asserted, and why the gate is left real
+ *
+ * `isServiceUsable` (`@object-ui/react`) is NOT stubbed here — it is the
+ * contract under test on the "hidden" cases, and a transcription of it would
+ * be free to agree with itself. Only `fetch` is stubbed. No adapter provider
+ * is mounted, so `useAdapter()` returns `null` by design and the metadata /
+ * data / schema endpoint families stay empty — that isolates these assertions
+ * to the service-gated path without mocking any module.
+ *
+ * The last block is the tripwire the fix would have needed to be caught: it
+ * derives the expected key vocabulary from the spec itself rather than
+ * restating it, so a rename on EITHER side goes red instead of going quiet.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { CoreServiceName } from '@objectstack/spec/system';
+
+import {
+  useApiDiscovery,
+  SERVICE_ENDPOINT_CATALOG,
+  type EndpointGroup,
+} from './useApiDiscovery';
+
+interface ServiceEntry {
+  enabled?: boolean;
+  status?: string;
+  handlerReady?: boolean;
+  route?: string;
+}
+
+/** A storage slot that is registered, honest and serving. */
+const USABLE_STORAGE: ServiceEntry = {
+  enabled: true,
+  status: 'available',
+  handlerReady: true,
+  route: '/api/v1/storage',
+};
+
+function stubDiscovery(services: Record<string, ServiceEntry>, routes: Record<string, string> = {}) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: unknown) => {
+      if (String(url).endsWith('/api/v1/discovery')) {
+        return { ok: true, json: async () => ({ data: { routes, services } }) } as unknown as Response;
+      }
+      return { ok: false, json: async () => ({}) } as unknown as Response;
+    }),
+  );
+}
+
+async function groupsFor(
+  services: Record<string, ServiceEntry>,
+  routes: Record<string, string> = {},
+): Promise<EndpointGroup[]> {
+  stubDiscovery(services, routes);
+  const { result } = renderHook(() => useApiDiscovery());
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  return result.current.groups;
+}
+
+const storageGroup = (groups: EndpointGroup[]) => groups.find(g => g.key === 'Storage');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useApiDiscovery — the storage group (#4240)', () => {
+  it('renders the Storage group with its 3 endpoints when /discovery reports the `file-storage` slot usable', async () => {
+    const groups = await groupsFor({ 'file-storage': USABLE_STORAGE });
+
+    const storage = storageGroup(groups);
+    expect(storage, 'Storage group must render when the file-storage slot is filled and usable').toBeDefined();
+    expect(storage!.endpoints.map(e => `${e.method} ${e.path}`)).toEqual([
+      'POST /api/v1/storage/upload',
+      'GET /api/v1/storage/:fileId',
+      'DELETE /api/v1/storage/:fileId',
+    ]);
+  });
+
+  it('honours the route /discovery advertises for the slot, not just the default', async () => {
+    const groups = await groupsFor({
+      'file-storage': { ...USABLE_STORAGE, route: '/api/v2/files' },
+    });
+
+    expect(storageGroup(groups)!.endpoints.map(e => e.path)).toEqual([
+      '/api/v2/files/upload',
+      '/api/v2/files/:fileId',
+      '/api/v2/files/:fileId',
+    ]);
+  });
+
+  // The canonical name is the ONLY accepted spelling. A tolerant reader here
+  // (accepting `storage` as well) would be a consumer-side workaround for a
+  // producer-side vocabulary, and would re-hide the real defect the moment the
+  // framework changed anything.
+  it('does not resurrect the group from the legacy `storage` spelling', async () => {
+    const groups = await groupsFor({ storage: USABLE_STORAGE });
+    expect(storageGroup(groups)).toBeUndefined();
+  });
+});
+
+// Fail-closed control (ADR-0076 D12). Green both before and after the #4240
+// fix: the posture was never the bug, the key was. These cases are what stops
+// a future "just render it anyway" from passing as a fix for #4240.
+describe('useApiDiscovery — fail-closed posture is preserved (ADR-0076 D12)', () => {
+  it('hides the Storage group when the slot is absent from /discovery', async () => {
+    expect(storageGroup(await groupsFor({ ai: { enabled: true } }))).toBeUndefined();
+  });
+
+  // Annotated rather than inferred: `it.each` widens heterogeneous tuples to a
+  // union that includes `string`, which would make `entry` unassignable below.
+  const notUsable: Array<[string, ServiceEntry]> = [
+    ['enabled:false (not registered)', { enabled: false }],
+    ['status unavailable', { enabled: true, status: 'unavailable' }],
+    ['status stub (a dev fake is not the real service)', { enabled: true, status: 'stub', handlerReady: true }],
+    ['handlerReady:false (route advertised, no real handler)', { enabled: true, handlerReady: false }],
+  ];
+
+  it.each(notUsable)('hides the Storage group when the slot is present but not usable — %s', async (_label, entry) => {
+    expect(storageGroup(await groupsFor({ 'file-storage': entry }))).toBeUndefined();
+  });
+
+  it('still renders the group when the slot is degraded — a serving fallback must stay visible', async () => {
+    const groups = await groupsFor({
+      'file-storage': { enabled: true, status: 'degraded', handlerReady: true, route: '/api/v1/storage' },
+    });
+    expect(storageGroup(groups)?.endpoints).toHaveLength(3);
+  });
+});
+
+/**
+ * The tripwire (#4240 dispatch rider).
+ *
+ * The mis-key survived because nothing tied the catalog's keys to the
+ * vocabulary they are spelled in. This block derives that vocabulary from
+ * `@objectstack/spec` — the same package the framework declares it in — so a
+ * rename on either side fails here rather than silently emptying a group.
+ */
+describe('SERVICE_ENDPOINT_CATALOG keys are canonical service-slot names', () => {
+  const SLOTS = new Set<string>(CoreServiceName.options);
+
+  /**
+   * Catalog keys that are NOT slots and are known-dead, with the finding that
+   * tracks them: objectui#4303. `workflow`'s slot was retired in
+   * objectstack#4451 and `feed` never was one, so neither can ever appear in
+   * `/discovery` — there is no correctly-spelled name to rename them to, which
+   * is why they are excepted here instead of fixed in #4240.
+   *
+   * This is a subset check, so REMOVING either key keeps this green; only
+   * adding a new non-slot key goes red.
+   */
+  const KNOWN_DEAD_NON_SLOT_KEYS = new Set(['workflow', 'feed']);
+
+  it('the spec exports a usable slot vocabulary (guards the derivation itself)', () => {
+    expect(SLOTS.size).toBeGreaterThan(5);
+    expect(SLOTS.has('file-storage'), 'file-storage must be a declared CoreServiceName slot').toBe(true);
+  });
+
+  it('the storage group is keyed by the canonical slot name, not by its route', () => {
+    expect(SERVICE_ENDPOINT_CATALOG['file-storage'], 'catalog must be keyed `file-storage`').toBeDefined();
+    expect(SERVICE_ENDPOINT_CATALOG.storage, '`storage` is the ROUTE, never the slot key').toBeUndefined();
+    expect(SERVICE_ENDPOINT_CATALOG['file-storage'].defaultRoute).toBe('/api/v1/storage');
+  });
+
+  it('every service-gated catalog key is a canonical slot, except the documented dead ones (#4303)', () => {
+    const nonSlot = Object.keys(SERVICE_ENDPOINT_CATALOG).filter(k => !SLOTS.has(k));
+    const undocumented = nonSlot.filter(k => !KNOWN_DEAD_NON_SLOT_KEYS.has(k));
+
+    expect(
+      undocumented,
+      'these catalog keys name no CoreServiceName slot, so /discovery can never report them '
+        + 'and their groups will never render on any host — key them by the canonical slot name, '
+        + 'or retire the entry (see objectui#4303)',
+    ).toEqual([]);
+  });
+});

--- a/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
+++ b/apps/console/src/pages/developer/hooks/useApiDiscovery.ts
@@ -44,6 +44,18 @@ function buildAuthEndpoints(authBase: string): EndpointDef[] {
   ];
 }
 
+/**
+ * Service-gated endpoint groups, keyed by **canonical service-slot name**.
+ *
+ * The key is not a label and not a route — it is the name this page looks up in
+ * `/discovery`'s `services` map, which the framework keys by `CoreServiceName`
+ * (`@objectstack/spec/system`). A key that is not a member of that vocabulary
+ * can never match, and because the lookup miss is deliberately fail-closed
+ * (ADR-0076 D12) the group then renders NOWHERE, silently, on every host.
+ *
+ * `useApiDiscovery.test.ts` pins the keys against the spec's slot enum so a
+ * rename on either side goes red instead of going quiet.
+ */
 export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRoute: string; endpoints: ServiceEndpointEntry[] }> = {
   // The `/api/v1/ai/**` family, in ledger order (framework#3718).
   //
@@ -205,7 +217,16 @@ export const SERVICE_ENDPOINT_CATALOG: Record<string, { group: string; defaultRo
       { method: 'POST', path: '/:object/:recordId', desc: 'Post feed item', bodyTemplate: { body: '' } },
     ],
   },
-  storage: {
+  // The KEY is the canonical service-slot name, because it is looked up
+  // straight in `/discovery`'s `services` map (`discoveredServices[serviceName]`
+  // below) — and that map is keyed by `CoreServiceName`. The slot is
+  // `file-storage`; the ROUTE is `/api/v1/storage`. Keying this `storage` (as it
+  // was until #4240) missed on every host, and the miss is indistinguishable
+  // from "no such service" — so the deliberate fail-closed branch hid all three
+  // endpoints everywhere, forever. The group's display name stays `Storage`:
+  // that is the route's name and the user-facing one, and it is not derived
+  // from the key.
+  'file-storage': {
     group: 'Storage',
     defaultRoute: '/api/v1/storage',
     endpoints: [


### PR DESCRIPTION
Fixes #4240

## What was wrong

`SERVICE_ENDPOINT_CATALOG` in `apps/console/src/pages/developer/hooks/useApiDiscovery.ts` keys each service-gated group by a name that is looked up **directly** in `/discovery`'s `services` map:

```ts
const serviceInfo = discoveredServices[serviceName];
const usable = serviceInfo ? isServiceUsable(serviceInfo) : false;
```

That map is keyed by canonical slot name (`CoreServiceName`). The storage group was keyed `storage` — which is the **route** (`/api/v1/storage`), not the **slot** (`file-storage`). The lookup therefore missed on every host, and a miss is indistinguishable from "no such service", so the deliberate fail-closed branch of **ADR-0076 D12** hid all three endpoints (upload / download / delete) on every deployment, healthy storage service or not.

Re-verified on this branch's merge base rather than trusting the card: the key was still at `useApiDiscovery.ts:208` with `defaultRoute: '/api/v1/storage'` at `:210`, exactly as triage pinned it at `5e2e9fa`.

## The fix

The key becomes `file-storage`. That is the whole behavioural change.

- The fail-closed posture is untouched — it was never the defect.
- The group's user-facing name stays **Storage**. It is not derived from the catalog key (the rendered group's `key`/`label` come from `ep.group`, and `GROUP_SORT_ORDER` lists the display name), so no display string and no i18n resource moves. Counter-probed: `storage` as a group key appears nowhere else in `apps/console/src` — the remaining hits are route strings in `ApprovalsInboxPage`/`approvalsApi` and a comment in `AppContent`.
- No lenient alias. Accepting `storage` as well would be a consumer-side workaround for a producer-side vocabulary; a test pins that the legacy spelling does **not** resurrect the group.

## The tripwire (dispatch rider)

The mis-key survived because nothing tied the catalog's keys to the vocabulary they are spelled in — a wrong key yields silence, and an empty group is exactly what a legitimately absent service looks like.

**Measured first: the slot vocabulary IS importable.** `CoreServiceName` is exported from the vendored `@objectstack/spec@17.0.0-rc.6` at the `./system` subpath (not from the root entry), and `apps/console` already depends on the package. So this is a real **derivation pin**, not a fixture pin:

```
node -e "import('@objectstack/spec/system').then(m => console.log(m.CoreServiceName.options))"
[metadata, data, auth, file-storage, search, cache, queue, automation,
 analytics, realtime, job, notification, ai, i18n, ui]
```

`useApiDiscovery.test.ts` derives the expected vocabulary from that export and asserts every service-gated catalog key against it, so a rename on **either** side goes red instead of going quiet.

## What deriving the pin surfaced (filed, not fixed)

Two more catalog keys name no slot and therefore can never render, for the same mechanical reason as this card:

- `workflow` (5 endpoints) — slot retired upstream in objectstack#4451; counter-probed: no `registerService('workflow')` and no mounted `/api/v1/workflow` anywhere.
- `feed` (2 endpoints) — never a slot; zero hits for an `/api/v1/feed` route in objectstack `packages/`.

Unlike this card, neither has a correctly-spelled name to be renamed to — the remedy is retire-or-repoint, a product decision. Filed as **#4303** and carried here as a documented, exhaustive exception set in the pin. The check is a **subset** assertion, so removing either key keeps it green; only adding a **new** non-slot key goes red.

## Reverse verification

Committed first, then took the fix out with `git checkout` (never `git stash`), keeping the tests. Direction was predicted per pin **before** running; all of them held, and all three directions show up.

With the fix in place: `Test Files 1 passed (1)`, `Tests 12 passed (12)`.
With the fix reverted: `Test Files 1 failed (1)`, `Tests 6 failed | 6 passed (12)`.

| pin | fix reverted | note |
|---|---|---|
| Storage group renders with 3 endpoints | RED | the card's symptom — `expected undefined to be defined` |
| advertised route is honoured | RED | same miss |
| tripwire: key is the canonical slot | RED | `catalog must be keyed file-storage: expected undefined to be defined` |
| tripwire: every key is a slot (except #4303) | RED | `expected [ 'storage' ] to deeply equal []` — the pin names the offending key |
| slot `degraded` still renders | RED | requires the group to be **present**, so it is not an absence assertion |
| legacy `storage` spelling does not resurrect the group | **RED — inverted** | green *before* the fix, red after revert: `expected { key: 'Storage', … } to be undefined`. With the old key that payload matched, so this pin runs backwards relative to the others |
| tripwire: spec exports a usable vocabulary | GREEN | independent of the fix, guards the derivation itself |
| fail-closed: slot absent / 4 not-usable cases | GREEN | control — see the honesty note below |

**Honesty note on the fail-closed controls.** With the fix reverted they stay green **vacuously**: the group is hidden because the key misses, not because the gate rejected the entry. They are a guard against a future over-correction ("just render it anyway"), not evidence for this fix. Only with the correct key do they actually exercise `isServiceUsable`. The `degraded` case is the one that proves they are not merely asserting absence — it requires the group to be **present**, and it is red when the fix is reverted.

## Verification

```
pnpm exec vitest run apps/console --maxWorkers=2
  Test Files  39 passed (39)
       Tests  433 passed (433)

pnpm --filter @object-ui/console type-check
  tsc --noEmit && tsc -b tsconfig.node.json --force     # clean, exit 0

npx eslint (the two changed files)
  8 problems (0 errors, 8 warnings)   # all pre-existing in the hook
                                      # (`any`, setState-in-effect); none new
```

The dependency closure was built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/console^...' build`) — `apps/console/tsconfig.json` has no `paths` mapping, so `tsc` resolves the workspace packages through `dist`, and in a fresh worktree those did not exist. Without that step the type-check would have been reading nothing.

## Scope

`apps/console/src/pages/developer/hooks/**` only, plus the changeset. No files touched in the areas held by in-flight #4233, #4292, #4243 or #4040.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_