### PR TITLE
fix(core,console): an id never travels without its object on the form route (#4292)

### DIFF
--- a/.changeset/tall-eagles-repeat.md
+++ b/.changeset/tall-eagles-repeat.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/core': patch
+'@object-ui/console': patch
+---
+
+Form actions no longer carry a record id across an object boundary (#4292).
+
+`ActionRunner.executeForm` forwarded `/forms/:name?recordId=<id>` unconditionally,
+and that URL says nothing about which object the id belongs to — so the form route
+resolved it against the FormView's own target object. When an action fired from a
+record of a DIFFERENT object and ids collide across objects (per-table integer
+keys), the form silently prefilled and, since the route learned to honour the param,
+`PATCH`ed a same-id record of the wrong object.
+
+- **Producer**: the id is forwarded only when the firing context record's object
+  (`context.objectName`) matches the target view's object; on a mismatch no id is
+  forwarded, preserving create semantics. When it IS forwarded, the object travels
+  with it as `?recordObject=`.
+- **Consumer**: `/forms/:name` refuses — no record read, no write — when
+  `recordObject` disagrees with the FormView's object. A URL without the param
+  behaves exactly as before, so existing deep links are unaffected.

--- a/apps/console/src/components/FormPage.recordObject.test.tsx
+++ b/apps/console/src/components/FormPage.recordObject.test.tsx
@@ -1,0 +1,328 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4292 — the CONSUMER half: a form refuses an id that says it belongs
+ * to another object.
+ *
+ * `?recordId=` names an id and nothing else, so #4278's read/write pair
+ * resolves it against the FormView's own target object. Where primary keys are
+ * per-table integers — which several drivers produce — `GET /data/showcase_task/42`
+ * answers for the user who was looking at Account 42: the form prefills Task
+ * 42's values and its submit PATCHes Task 42, with no error anywhere and the
+ * record the user was actually on left untouched. The server cannot flag it
+ * either, because it echoes the path's object back (`getData` returns
+ * `object: request.object`), so the response is perfectly self-consistent —
+ * which is why #4278's payload-mismatch guard cannot see this shape at all.
+ *
+ * PM ruling pinned here (issue #4292, on the claim comment): an id must never
+ * travel without its object identity, and a mismatch fails closed at BOTH ends.
+ * For this end: when `recordObject` is present AND differs from the FormView's
+ * target object, the existing fail-closed error state (no load, no write); when
+ * absent, current behaviour unchanged.
+ *
+ * ## Why BOTH halves, when the producer already refuses to forward
+ *
+ * `ActionRunner.executeForm` no longer emits a cross-object id at all, so in a
+ * healthy console this guard never fires. It is not therefore redundant: URLs
+ * arrive bookmarked, hand-written, pasted from chat, or from a producer that
+ * predates the fix, and a shared identity means the console cannot tell those
+ * apart. Defence in depth is the ruling's "both ends" — the producer stops
+ * emitting the bad URL, the consumer stops honouring one.
+ *
+ * ## Reverse verification — predicted directions
+ *
+ * Reverting the CONSUMER half alone (`FormPage.tsx` back to origin/main) turns
+ * RED only the forged-URL cases in the first block — the producer half cannot
+ * defend a URL it never produced:
+ *
+ *   - "a mismatching recordObject ⇒ error state"   → prefills the WRONG record
+ *   - "…issues no /data/ request at all"           → one GET to the wrong object
+ *   - "…and no write can follow"                   → the form is submittable
+ *
+ * Reverting the PRODUCER half alone leaves every case here GREEN — this file
+ * tests URLs directly, so it never asks the runner anything. The producer's own
+ * pins live in `packages/core/…/ActionRunner.formObjectIdentity.test.ts`, and
+ * `FormPage.test.ts` pins the two ends against each other end to end.
+ *
+ * GREEN BOTH SIDES (controls — #4292 must move neither):
+ *
+ *   - "recordObject agreeing with the view ⇒ #4278's edit path, unchanged";
+ *   - "recordId with NO recordObject ⇒ #4278's behaviour, unchanged";
+ *   - "the PUBLIC path ignores recordObject as it ignores recordId".
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { FormPage } from './FormPage';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+/** `showcase_task.edit` — the FormView the mis-scoped action targets. */
+const VIEW_ENVELOPE = {
+  name: 'showcase_task.edit',
+  object: 'showcase_task',
+  viewKind: 'form',
+  label: 'Log Time',
+  config: {
+    type: 'simple',
+    sections: [{ label: 'Task', fields: ['title', 'hours'] }],
+  },
+};
+
+const OBJECT_SCHEMA = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: {
+    title: { type: 'text', label: 'Title' },
+    hours: { type: 'text', label: 'Hours', defaultValue: '0' },
+  },
+};
+
+/**
+ * The collision the card is about: id `42` exists in BOTH objects, and the
+ * server answers this read without complaint — `object` echoes the path, so
+ * nothing in the payload betrays that the user meant Account 42.
+ */
+const GET_RESPONSE = {
+  object: 'showcase_task',
+  id: '42',
+  record: { id: '42', title: 'Write the report', hours: '3' },
+};
+
+interface Call {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+let calls: Call[] = [];
+
+function stubFetch(routes: Array<{
+  method?: string;
+  match: string;
+  body?: unknown;
+  status?: number;
+  statusText?: string;
+}>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    calls.push({
+      url: String(url),
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+    const route = routes.find(
+      (r) => (r.method ?? 'GET').toUpperCase() === method && String(url).includes(r.match),
+    );
+    if (!route) throw new Error(`unstubbed fetch: ${method} ${url}`);
+    const status = route.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: route.statusText ?? 'OK',
+      json: async () => route.body,
+      text: async () => (route.body === undefined ? '' : JSON.stringify(route.body)),
+    } as unknown as Response;
+  });
+}
+
+const recordPath = (objectName: string, recordId: string) =>
+  `/apps/ai.objectstack.showcase/${objectName}/record/${recordId}`;
+
+function renderInternal(query = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/forms/showcase_task.edit${query}`]}>
+      <Routes>
+        <Route
+          path="/forms/:name"
+          element={<FormPage mode="internal" recordPath={recordPath} />}
+        />
+        <Route
+          path="/apps/:appName/:objectName/record/:recordId"
+          element={<div data-testid="record-page">record page</div>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** The happy-path route table: metadata + object schema + the record read. */
+function editRoutes(extra: Parameters<typeof stubFetch>[0] = []) {
+  return stubFetch([
+    { match: '/meta/view/', body: VIEW_ENVELOPE },
+    { match: '/meta/object/', body: OBJECT_SCHEMA },
+    { match: '/data/showcase_task/42', body: GET_RESPONSE },
+    {
+      method: 'PATCH',
+      match: '/data/showcase_task/42',
+      body: { object: 'showcase_task', id: '42', record: {} },
+    },
+    ...extra,
+  ]);
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('a recordObject naming another object FAILS CLOSED (#4292)', () => {
+  /**
+   * The same two assertions #4278 established: an error panel IS shown, and no
+   * editable form is left behind it. A create form here would re-arm the
+   * original harm — the user fills it in and inserts a duplicate.
+   */
+  async function expectRefusal(pattern: RegExp) {
+    const panel = await screen.findByText(pattern);
+    expect(panel).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Submit/ })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Title/)).not.toBeInTheDocument();
+  }
+
+  it('a mismatching recordObject ⇒ error state, not the other object\'s record', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=42&recordObject=showcase_account');
+
+    // RED before the fix: the guard does not exist, the read is issued under
+    // the VIEW's object, id 42 resolves to Task 42, and the form prefills
+    // "Write the report" — a record the user never opened.
+    await expectRefusal(/This form edits showcase_task.*belongs to showcase_account/s);
+  });
+
+  it('issues no /data/ request at all — the refusal precedes the read', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=42&recordObject=showcase_account');
+
+    await screen.findByText(/Refusing to open it/);
+    // The view metadata IS fetched — the object it declares is what the claim
+    // is compared against, so it cannot be known any earlier. Everything after
+    // that point is skipped, including the object schema.
+    expect(calls.filter((c) => c.url.includes('/data/'))).toHaveLength(0);
+    expect(calls.map((c) => c.url).filter((u) => u.includes('/meta/view/'))).toHaveLength(1);
+  });
+
+  it('and no write can follow, since there is no form to submit', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=42&recordObject=showcase_account');
+
+    await screen.findByText(/Refusing to open it/);
+    expect(calls.filter((c) => c.method === 'POST' || c.method === 'PATCH')).toHaveLength(0);
+  });
+
+  it('refuses on case difference too — object names are not case-folded', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=42&recordObject=Showcase_Task');
+
+    await expectRefusal(/belongs to Showcase_Task/);
+  });
+});
+
+/**
+ * CONTROLS — #4278's paths, byte for byte. Each of these is a URL a healthy
+ * console produces today, and #4292 must be invisible on all of them.
+ */
+describe('control: a recordObject that AGREES changes nothing (#4278 main path)', () => {
+  it('loads, prefills and PATCHes exactly as without the param', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=42&recordObject=showcase_task');
+
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('Write the report');
+    expect(screen.getByLabelText(/Hours/)).toHaveValue('3');
+    const read = calls.find((c) => c.method === 'GET' && c.url.includes('/data/'));
+    expect(read?.url).toContain('/data/showcase_task/42');
+
+    await userEvent.clear(screen.getByLabelText(/Title/));
+    await userEvent.type(screen.getByLabelText(/Title/), 'Write the report v2');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() => expect(calls.some((c) => c.method === 'PATCH')).toBe(true));
+    const write = calls.find((c) => c.method === 'PATCH')!;
+    expect(write.url).toContain('/data/showcase_task/42');
+    expect(write.body).toMatchObject({ title: 'Write the report v2' });
+    expect(calls.filter((c) => c.method === 'POST')).toHaveLength(0);
+  });
+});
+
+describe('control: recordId with NO recordObject keeps #4278 behaviour', () => {
+  it('still loads and prefills — an old link is not refused', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=42');
+
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('Write the report');
+    expect(calls.some((c) => c.url.includes('/data/showcase_task/42'))).toBe(true);
+  });
+
+  it('an empty recordObject asserts nothing and is treated as absent', async () => {
+    vi.stubGlobal('fetch', editRoutes());
+    renderInternal('?recordId=42&recordObject=');
+
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('Write the report');
+  });
+
+  /**
+   * #4278's payload-mismatch guard still fires on its own condition, and its
+   * wording stays distinct — a failure must name WHICH check refused: the
+   * link's claim (#4292) or what the server served (#4278).
+   */
+  it('leaves the payload-mismatch guard in place for what the SERVER serves', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/meta/view/', body: VIEW_ENVELOPE },
+        { match: '/meta/object/', body: OBJECT_SCHEMA },
+        {
+          match: '/data/showcase_task/42',
+          body: { object: 'showcase_account', id: '42', record: { title: 'Acme' } },
+        },
+      ]),
+    );
+    renderInternal('?recordId=42&recordObject=showcase_task');
+
+    // The link agreed with the view, so #4292 passed it through; the SERVER
+    // then contradicted both, and #4278's guard caught it.
+    expect(await screen.findByText(/belongs to showcase_account, but this form edits/))
+      .toBeInTheDocument();
+  });
+});
+
+describe('control: the PUBLIC /f/:slug path ignores recordObject too', () => {
+  const PUBLIC_PAYLOAD = {
+    slug: 'contact-us',
+    object: 'showcase_inquiry',
+    label: 'Contact us',
+    form: { type: 'simple', sections: [{ fields: ['title'] }] },
+    objectSchema: {
+      name: 'showcase_inquiry',
+      fields: { title: { type: 'text', label: 'Title' } },
+    },
+  };
+
+  it('renders the create form and reads no record, whatever the URL claims', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch([
+        { match: '/forms/contact-us', body: PUBLIC_PAYLOAD },
+        { method: 'POST', match: '/forms/contact-us/submit', body: { ok: true } },
+      ]),
+    );
+    render(
+      <MemoryRouter
+        initialEntries={['/f/contact-us?recordId=42&recordObject=showcase_account']}
+      >
+        <Routes>
+          <Route path="/f/:slug" element={<FormPage mode="public" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    // Neither param is read on the anonymous surface: no refusal, no read.
+    expect(await screen.findByLabelText(/Title/)).toHaveValue('');
+    expect(calls.filter((c) => c.url.includes('/data/'))).toHaveLength(0);
+    expect(screen.queryByText(/Refusing to open it/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/console/src/components/FormPage.test.ts
+++ b/apps/console/src/components/FormPage.test.ts
@@ -7,9 +7,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { ActionRunner } from '@object-ui/core';
 import {
   buildSections,
   FORM_RECORD_ID_PARAM,
+  FORM_RECORD_OBJECT_PARAM,
   normalizeColumns,
   normalizeOptions,
   readCreatedRecordId,
@@ -265,15 +267,18 @@ describe('readFormRecordTarget', () => {
   });
 
   it('is edit mode when the param names a record', () => {
+    // `recordObject: null` — no object asserted (#4292). The pre-#4292 URL, and
+    // still exactly the pre-#4292 behaviour.
     expect(readFormRecordTarget('internal', new URLSearchParams('recordId=task-42')))
-      .toEqual({ kind: 'edit', recordId: 'task-42' });
+      .toEqual({ kind: 'edit', recordId: 'task-42', recordObject: null });
   });
 
   it('decodes a percent-encoded id (ActionRunner encodes it)', () => {
     // `ActionRunner.executeForm` builds the URL with encodeURIComponent, and
     // URLSearchParams decodes on read — so an id carrying `/` or `#` survives.
     const search = new URLSearchParams(`recordId=${encodeURIComponent('a/b#c')}`);
-    expect(readFormRecordTarget('internal', search)).toEqual({ kind: 'edit', recordId: 'a/b#c' });
+    expect(readFormRecordTarget('internal', search))
+      .toEqual({ kind: 'edit', recordId: 'a/b#c', recordObject: null });
   });
 
   /**
@@ -299,6 +304,140 @@ describe('readFormRecordTarget', () => {
       .toEqual({ kind: 'create' });
     expect(readFormRecordTarget('public', new URLSearchParams('recordId=')))
       .toEqual({ kind: 'create' });
+  });
+});
+
+/**
+ * objectui#4292 — the object half of the URL contract, read (not yet judged).
+ *
+ * The comparison itself needs the FormView's object and therefore lives in the
+ * loader; what this function owns is carrying the claim through unaltered, and
+ * deciding what "no claim" means. Reverse verification: with the read reverted
+ * every `recordObject` below reads back `null`, the loader has nothing to
+ * compare, and the forged-URL guard silently disarms — green tests, absent
+ * protection, which is why the DOM suite pins the refusal itself.
+ */
+describe('readFormRecordTarget carries the record object (#4292)', () => {
+  it('spells the param exactly as ActionRunner emits it', () => {
+    // Literal on both sides — `@object-ui/core` sits below this app and
+    // app-shell exports no `./urlParams`. The behavioural pin below is what
+    // actually holds them together.
+    expect(FORM_RECORD_OBJECT_PARAM).toBe('recordObject');
+  });
+
+  it('reads the object the URL claims the id belongs to', () => {
+    expect(
+      readFormRecordTarget(
+        'internal',
+        new URLSearchParams('recordId=task-42&recordObject=showcase_task'),
+      ),
+    ).toEqual({ kind: 'edit', recordId: 'task-42', recordObject: 'showcase_task' });
+  });
+
+  it('carries a MISMATCHING claim through untouched — the loader judges it', () => {
+    // Refusing here would be wrong: this function cannot know the FormView's
+    // object, so it must not pretend to. It reports what the URL said.
+    expect(
+      readFormRecordTarget(
+        'internal',
+        new URLSearchParams('recordId=42&recordObject=showcase_account'),
+      ),
+    ).toEqual({ kind: 'edit', recordId: '42', recordObject: 'showcase_account' });
+  });
+
+  /**
+   * Ruling point 2: the guard tightens only where identity information is
+   * present. Absent or blank asserts nothing — and a hand-authored URL can
+   * always just omit the param, so treating blank as a mismatch would buy no
+   * protection while breaking the old deep links the ruling preserves.
+   */
+  it('treats an absent or blank claim as no claim at all', () => {
+    for (const raw of [
+      'recordId=task-42',
+      'recordId=task-42&recordObject=',
+      'recordId=task-42&recordObject=%20%20',
+    ]) {
+      expect(readFormRecordTarget('internal', new URLSearchParams(raw)))
+        .toEqual({ kind: 'edit', recordId: 'task-42', recordObject: null });
+    }
+  });
+
+  it('is still CREATE when an object is claimed but no record is named', () => {
+    // Nothing for the assertion to be about; the form creates, as it always did.
+    expect(readFormRecordTarget('internal', new URLSearchParams('recordObject=showcase_task')))
+      .toEqual({ kind: 'create' });
+  });
+
+  it('never reads it in PUBLIC mode either', () => {
+    expect(
+      readFormRecordTarget(
+        'public',
+        new URLSearchParams('recordId=task-42&recordObject=showcase_task'),
+      ),
+    ).toEqual({ kind: 'create' });
+  });
+});
+
+/**
+ * The two halves of #4292, pinned against each other by BEHAVIOUR rather than
+ * by spelling: the real `ActionRunner` produces a URL, and this route's real
+ * reader consumes it. A rename on either side fails here — which matters more
+ * than usual, because a silently disarmed guard is invisible: the form would go
+ * back to loading whatever the id happened to hit, with every test still green.
+ *
+ * (`@object-ui/core` is a declared dependency of this app, so this is an
+ * ordinary import — no new coupling, and the only place the two ends meet.)
+ */
+describe('producer → consumer round trip (#4292)', () => {
+  /** Run the real producer and return the URL it navigated to. */
+  async function produce(context: Record<string, unknown>, target: string): Promise<string> {
+    const runner = new ActionRunner(context);
+    let url = '';
+    runner.setNavigationHandler((to) => {
+      url = to;
+    });
+    await runner.execute({ type: 'form', target });
+    return url;
+  }
+
+  function searchOf(url: string): URLSearchParams {
+    return new URLSearchParams(url.split('?')[1] ?? '');
+  }
+
+  it('a same-object action yields an edit target carrying the object', async () => {
+    const url = await produce(
+      { record: { id: 'task-42' }, objectName: 'showcase_task' },
+      'showcase_task.edit',
+    );
+
+    expect(readFormRecordTarget('internal', searchOf(url))).toEqual({
+      kind: 'edit',
+      recordId: 'task-42',
+      recordObject: 'showcase_task',
+    });
+  });
+
+  it('a cross-object action yields a CREATE target — no id crossed the boundary', async () => {
+    const url = await produce(
+      { record: { id: 42 }, objectName: 'showcase_account' },
+      'showcase_task.edit',
+    );
+
+    expect(url).toBe('/forms/showcase_task.edit');
+    expect(readFormRecordTarget('internal', searchOf(url))).toEqual({ kind: 'create' });
+  });
+
+  it('survives an id needing percent-encoding, end to end', async () => {
+    const url = await produce(
+      { record: { id: 'a/b#c' }, objectName: 'showcase_task' },
+      'showcase_task.edit',
+    );
+
+    expect(readFormRecordTarget('internal', searchOf(url))).toEqual({
+      kind: 'edit',
+      recordId: 'a/b#c',
+      recordObject: 'showcase_task',
+    });
   });
 });
 

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -27,6 +27,16 @@
  * {@link readFormRecordTarget} for the create/edit/refuse decision and
  * {@link readPrefill} for what wins when a `prefill_` param and a stored value
  * name the same field.
+ *
+ * ## Which object that id belongs to (objectui#4292)
+ *
+ * An id alone does not say which object it names, so the read/write pair above
+ * resolves it against the FormView's own target — right when the action fired
+ * from a record of that object, silently wrong when it did not. `?recordObject=`
+ * now travels with the id and this route refuses when the two disagree; see
+ * {@link FORM_RECORD_OBJECT_PARAM} for why it can only ever refuse, and the
+ * guard in {@link loadInternalForm} for where it fires (before any `/data/`
+ * request, so a mismatch reads nothing and writes nothing).
  */
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
@@ -117,6 +127,43 @@ export type FormPageMode = 'public' | 'internal';
 export const FORM_RECORD_ID_PARAM = 'recordId';
 
 /**
+ * The object the accompanying {@link FORM_RECORD_ID_PARAM} belongs to
+ * (objectui#4292) — `ActionRunner.executeForm` forwards the two together.
+ *
+ * ## Why an id needed an object at all
+ *
+ * `?recordId=` names an id and nothing else, so this route has to pick an
+ * object to resolve it against, and it picks the FormView's own target — the
+ * only one it knows. That is right whenever the action fired from a record OF
+ * that object, and until #4292 nothing checked that it had: an action whose
+ * `locations` put it on an Account but whose `target` is `showcase_task.edit`
+ * is publishable metadata, and where primary keys are per-table integers
+ * `GET /data/showcase_task/42` answers happily for the user who was looking at
+ * Account 42. The server cannot flag it either — it echoes the path's object
+ * back (`getData` returns `object: request.object`), so the response is
+ * self-consistent. #4278 shipped the read/write pair that turned that from a
+ * duplicate INSERT into a targeted UPDATE of the wrong record, which is what
+ * made the missing identity worth closing.
+ *
+ * ## An ASSERTION, never an override — the whole point
+ *
+ * This param cannot change which object the form edits; that comes from the
+ * view metadata and only from there. Its sole power is to make the form
+ * REFUSE. Reading it as a selector instead would let any hand-authored URL aim
+ * a form at an arbitrary object — the same hole, re-opened from the other side.
+ * (The registry's `formObject` is deliberately the other thing: it selects the
+ * object the record-form OVERLAY edits. Same `<param>Object` naming, opposite
+ * powers, separate surfaces.)
+ *
+ * Spelled as a literal here and in `ActionRunner` for the reason
+ * {@link FORM_RECORD_ID_PARAM} documents — `@object-ui/core` sits below this
+ * app and app-shell exports no `./urlParams`. `FormPage.test.ts` pins the two
+ * ends together by running the real producer and reading its URL back here,
+ * so a rename on either side fails rather than silently disarming the guard.
+ */
+export const FORM_RECORD_OBJECT_PARAM = 'recordObject';
+
+/**
  * What the URL says this internal form is FOR: creating a record, editing a
  * named one, or nothing coherent.
  *
@@ -130,7 +177,7 @@ export const FORM_RECORD_ID_PARAM = 'recordId';
  */
 export type FormRecordTarget =
   | { kind: 'create' }
-  | { kind: 'edit'; recordId: string }
+  | { kind: 'edit'; recordId: string; recordObject: string | null }
   | { kind: 'refuse'; reason: string };
 
 /**
@@ -141,7 +188,18 @@ export type FormRecordTarget =
  * controls the URL and the backend resolver deliberately exposes one
  * submit-only endpoint. Honouring `?recordId=` there would turn a public form
  * into an arbitrary-record reader and writer. The public path is unchanged by
- * every part of #4278, and this line is where that holds.
+ * every part of #4278, and this line is where that holds — `recordObject`
+ * (#4292) is read on the same terms, i.e. not at all on that surface.
+ *
+ * `recordObject` is carried to the loader rather than judged here: the object
+ * it must agree with is the FormView's, which only the view metadata knows, so
+ * the comparison happens where that arrives ({@link loadInternalForm}). What
+ * this function decides is unchanged — create, edit, or refuse from the URL
+ * alone. A blank or whitespace-only `recordObject` is treated as ABSENT, not as
+ * a mismatch: it asserts nothing, and #4292 ruling point 2 tightens the guard
+ * only where identity information is actually present (a URL can always just
+ * omit the param, so refusing here would buy nothing and would break the
+ * hand-authored deep links the ruling preserves).
  */
 export function readFormRecordTarget(
   mode: FormPageMode,
@@ -149,6 +207,8 @@ export function readFormRecordTarget(
 ): FormRecordTarget {
   if (mode !== 'internal') return { kind: 'create' };
   const raw = search.get(FORM_RECORD_ID_PARAM);
+  // No id ⇒ create, whatever `recordObject` says: with no record named there is
+  // nothing for an object assertion to be about.
   if (raw === null) return { kind: 'create' };
   const recordId = raw.trim();
   if (!recordId) {
@@ -159,7 +219,8 @@ export function readFormRecordTarget(
         'Re-open it from the record, or drop the parameter to create a new one.',
     };
   }
-  return { kind: 'edit', recordId };
+  const declaredObject = (search.get(FORM_RECORD_OBJECT_PARAM) ?? '').trim();
+  return { kind: 'edit', recordId, recordObject: declaredObject || null };
 }
 
 /**
@@ -618,7 +679,11 @@ export function resolveInternalForm(
  * throws and the caller shows the error state. The gap between the two `catch`
  * postures is the gap between "less detail" and "wrong operation".
  */
-async function loadInternalForm(name: string, recordId?: string | null): Promise<LoadedForm> {
+async function loadInternalForm(
+  name: string,
+  recordId?: string | null,
+  recordObject?: string | null,
+): Promise<LoadedForm> {
   const viewRes = await apiFetch(`/meta/view/${encodeURIComponent(name)}`);
   if (!viewRes.ok) {
     throw new Error(`Form metadata not found: view/${name}`);
@@ -627,6 +692,23 @@ async function loadInternalForm(name: string, recordId?: string | null): Promise
   const { label, object: objectName, form } = resolveInternalForm(name, viewBody);
   if (!objectName) {
     throw new Error(`FormView "${name}" is missing an "object" target`);
+  }
+  // #4292, the consumer half: the URL asserted which object the id belongs to,
+  // and it is not this form's. Refuse HERE — before the object-schema fetch and
+  // well before the record read — so a mismatch costs zero `/data/` traffic and
+  // can never reach a write. This is the second half of a check the producer
+  // already made (`ActionRunner.executeForm` will not forward an id across an
+  // object boundary at all); it is not redundant with it, because URLs also
+  // arrive hand-written, bookmarked, or from a producer that predates the fix.
+  //
+  // Distinct from `readLoadedRecord`'s mismatch check, deliberately: that one
+  // judges what the SERVER served, this one what the LINK claimed, and the two
+  // wordings stay different so a failure names which of them fired.
+  if (recordObject && recordObject !== objectName) {
+    throw new Error(
+      `This form edits ${objectName}, but the link says record "${recordId}" belongs to ` +
+        `${recordObject}. Refusing to open it — check the action that linked here.`,
+    );
   }
   let objectSchema: ObjectSchemaPayload | null = null;
   try {
@@ -919,6 +1001,8 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
    */
   const target = readFormRecordTarget(mode, search);
   const editingId = target.kind === 'edit' ? target.recordId : null;
+  /** The object the URL claims `editingId` belongs to (#4292), or null. */
+  const editingObject = target.kind === 'edit' ? target.recordObject : null;
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -940,7 +1024,7 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
         ? Promise.reject(new Error(target.reason))
         : mode === 'public'
           ? loadPublicForm(identifier)
-          : loadInternalForm(identifier, editingId);
+          : loadInternalForm(identifier, editingId, editingObject);
     loader
       .then((result) => {
         if (cancelled) return;

--- a/packages/app-shell/src/urlParams.ts
+++ b/packages/app-shell/src/urlParams.ts
@@ -26,6 +26,14 @@
  * |             | internal form route `/forms/:name`, where it   |              |
  * |             | means "edit THIS record" (objectui#4278).      |              |
  * |             | URL is the source of truth for both.           |              |
+ * | `recordObject` | Travels WITH `recordId` on `/forms/:name`: the |           |
+ * |             | object that id belongs to, so the route can    | with         |
+ * |             | refuse a cross-object link instead of editing  | `recordId`   |
+ * |             | a same-id row of the wrong object              |              |
+ * |             | (objectui#4292). An assertion, never an        |              |
+ * |             | override — unlike `formObject` below. Declared |              |
+ * |             | by `apps/console`'s `FormPage`; listed here so |              |
+ * |             | no page repurposes the name.                   |              |
  * | `form`      | The global record-form overlay: `new` = create,|              |
  * |             | a record id = edit (framework#2604 D1/D2).     | push (open), |
  * |             | Back closes the overlay.                       | replace (close) |

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -638,6 +638,81 @@ function withIdentityAlias(context: ActionContext): ActionContext {
   return { ...context, os: { ...(os && typeof os === 'object' ? os : {}), user } };
 }
 
+/**
+ * The query param naming the record a form route opens (`?recordId=<id>`).
+ *
+ * The console's reserved-param registry (`@object-ui/app-shell`,
+ * `src/urlParams.ts` → `RECORD_DRAWER_PARAM`) owns this spelling and
+ * `apps/console`'s `FormPage` re-declares it as `FORM_RECORD_ID_PARAM`. It is a
+ * literal in all three places because `@object-ui/core` sits BELOW both in the
+ * dependency graph and cannot import either; the console's `FormPage.test.ts`
+ * pins the spellings equal so they cannot drift apart in silence.
+ */
+const FORM_RECORD_ID_PARAM = 'recordId';
+
+/**
+ * The query param carrying the OBJECT the forwarded {@link FORM_RECORD_ID_PARAM}
+ * belongs to (objectui#4292).
+ *
+ * It is an ASSERTION, never an override: the form's object always comes from the
+ * FormView metadata, and this param exists solely so the consumer can refuse
+ * when the two disagree. (The registry's `formObject` is the other thing — it
+ * SELECTS which object the record-form overlay edits. Same `<param>Object`
+ * naming, deliberately opposite powers, which is why they are separate names on
+ * separate surfaces.) Widening it into a selector would hand any hand-authored
+ * URL the ability to point a form at an arbitrary object — the hole this closes,
+ * re-opened from the other side.
+ */
+const FORM_RECORD_OBJECT_PARAM = 'recordObject';
+
+/**
+ * The object the firing context's record belongs to, or `undefined` when the
+ * host did not say (objectui#4292).
+ *
+ * `context.objectName` is MEASURED to be this repo's one spelling of that fact,
+ * not a new convention invented here:
+ *
+ *  - `@object-ui/react`'s `ActionProvider` documents the flat trio `record`,
+ *    `user`, `objectName` and mirrors it into the canonical `ctx.*` scope;
+ *  - `useConsoleActionRuntime` seeds `context: { ...(objectName ? { objectName }
+ *    : {}), … }` — so every console surface that fires a record action
+ *    (`DeclaredActionsBar`, `ObjectView`, `RecordDetailView`) already publishes
+ *    it, and `RecordDetailView` passes it explicitly a second time;
+ *  - `app-shell`'s `recordFormNavigation` resolver already reads exactly this
+ *    key as its last precedence step for `navigate_create` / `navigate_edit`.
+ *
+ * `action.objectName` is deliberately NOT consulted. It declares which object an
+ * ACTION belongs to, which is a statement about the action's placement, not
+ * about the record the id was read from — and trusting metadata about the action
+ * to describe the record is precisely the conflation that made this defect
+ * possible.
+ */
+function readContextObjectName(context: ActionContext): string | undefined {
+  const name = context.objectName;
+  return typeof name === 'string' && name.trim() !== '' ? name.trim() : undefined;
+}
+
+/**
+ * Whether opening FormView `viewName` from a record of `contextObject` would
+ * cross an object boundary (objectui#4292).
+ *
+ * View identity is `<object>.<key>` (ADR-0017; `viewEnvelope` builds exactly
+ * that, `defaultListViewId` compares exactly this way), so the question is
+ * answered as a PREFIX match against the object we already hold rather than by
+ * parsing an object name out of the view name — the target's object is a fact
+ * the metadata owns, and this runner only asks whether it is the one in hand.
+ *
+ * Answers `false` — "not comparable, carry on" — whenever either end is missing:
+ * no `contextObject` (host published none), or an unqualified `viewName` (no
+ * dot, so it names no object). Only a qualified name under a DIFFERENT object
+ * is a boundary crossing.
+ */
+function crossesObjectBoundary(viewName: string, contextObject: string | undefined): boolean {
+  if (!contextObject) return false;
+  if (!viewName.includes('.')) return false;
+  return !viewName.startsWith(`${contextObject}.`);
+}
+
 /*
  * ## The two predicate gates in `execute`, and the one question they ask first
  *
@@ -1424,6 +1499,37 @@ export class ActionRunner {
    * through to `executeActionSchema` and silently no-opped (the "Log Time does
    * nothing" report). The current record id is forwarded as `?recordId=` for
    * hosts that support it; the form route ignores unknown query params.
+   *
+   * ## An id never travels without its object (objectui#4292)
+   *
+   * `?recordId=` names an id and nothing else, so the consumer has to pick an
+   * object to resolve it against, and the only one it can pick is the FormView's
+   * own target object (`/forms/:name` does exactly that since objectui#4278).
+   * That is right whenever the action fired from a record OF that object, and
+   * nothing here used to check that it did: `target: 'showcase_task.edit'` on an
+   * Account record header is publishable metadata, and with per-table integer
+   * keys `GET /data/showcase_task/42` cheerfully answers for Account 42. Before
+   * #4278 the damage stopped at a duplicate insert; now that the route honours
+   * the param, the same mis-scoped action PATCHes a different object's record
+   * with no error anywhere. So the id is forwarded only when the two objects
+   * MATCH, and the object identity rides along as the consumer's second half of
+   * the check ({@link FORM_RECORD_OBJECT_PARAM}).
+   *
+   * The three outcomes, and why the third preserves rather than refuses:
+   *
+   *  - **match** — forward `?recordId=&recordObject=`. The #4278 edit path,
+   *    plus the identity the consumer re-checks against its own view metadata;
+   *  - **mismatch** — forward NEITHER, i.e. the bare `/forms/:name`. A "log
+   *    time" action fired from a Task at another object's create view is not a
+   *    broken edit, it is a CREATE that happens to be launched from a record —
+   *    which is exactly what this route did before #4278 taught it to read the
+   *    param. Refusing here would break a shape that works;
+   *  - **not comparable** — either end unknown ⇒ forward as before. A host that
+   *    publishes no `objectName`, or an unqualified target name, gives this
+   *    runner nothing to compare; tightening on absent information would turn
+   *    working edit flows into creates on every such host. The guard only ever
+   *    fires on information it actually has, and the consumer half applies the
+   *    same rule to a missing `recordObject`.
    */
   private async executeForm(action: ActionDef): Promise<ActionResult> {
     const name = this.evaluator.evaluate(action.target) as string;
@@ -1434,7 +1540,14 @@ export class ActionRunner {
       (this.context.record && (this.context.record as { id?: unknown }).id) ??
       (this.context.data && (this.context.data as { id?: unknown }).id);
     const base = `/forms/${name}`;
-    const to = recordId != null ? `${base}?recordId=${encodeURIComponent(String(recordId))}` : base;
+    const contextObject = readContextObjectName(this.context);
+    const to =
+      recordId == null || crossesObjectBoundary(name, contextObject)
+        ? base
+        : `${base}?${FORM_RECORD_ID_PARAM}=${encodeURIComponent(String(recordId))}` +
+          (contextObject
+            ? `&${FORM_RECORD_OBJECT_PARAM}=${encodeURIComponent(contextObject)}`
+            : '');
 
     if (this.navigationHandler) {
       this.navigationHandler(to, { external: false });

--- a/packages/core/src/actions/__tests__/ActionRunner.formObjectIdentity.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.formObjectIdentity.test.ts
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4292 — the PRODUCER half: an id never travels without its object.
+ *
+ * `executeForm` forwards the record an action fired from as
+ * `/forms/:name?recordId=<id>`. That URL says nothing about WHICH object the id
+ * belongs to, so the consumer resolves it against the FormView's own target —
+ * correct whenever the action fired from a record of that object, and nothing
+ * checked that it had. `target: 'showcase_task.edit'` on an Account record
+ * header is publishable metadata, and with per-table integer keys
+ * `GET /data/showcase_task/42` answers happily for the user who was on Account
+ * 42. Since #4278 taught the route to honour the param, that stopped being a
+ * duplicate INSERT and became a targeted UPDATE of another object's record.
+ *
+ * PM ruling pinned here (issue #4292, on the claim comment): an id must never
+ * travel without its object identity, and a mismatch fails closed at BOTH ends.
+ * For this end: forward `?recordId=` only when the firing context record's
+ * object matches the target view's object (the `<object>.<view>` prefix),
+ * forward NO id on a mismatch so create semantics are preserved, and forward the
+ * object identity alongside the id when it IS forwarded, as the consumer's
+ * defence-in-depth input.
+ *
+ * ## Where the object identity comes from — measured, not invented
+ *
+ * `context.objectName`, which is this repo's existing spelling of the fact:
+ * `ActionProvider` documents the flat trio (`record`, `user`, `objectName`) and
+ * mirrors it into `ctx.*`; `useConsoleActionRuntime` seeds it for every console
+ * surface that fires record actions; `recordFormNavigation`'s resolver already
+ * reads that same key. `action.objectName` is NOT consulted — it describes the
+ * action's placement, not the record the id came from.
+ *
+ * ## Reverse verification — predicted directions, fix reverted
+ *
+ * Restoring the unconditional `recordId != null ? … : base` line turns RED:
+ *
+ *   - "a cross-object target forwards NO record id"  → `?recordId=42` appended
+ *   - "forwards the object alongside the id"          → `recordObject` absent
+ *   - "…through the navigation handler too"           → same, on the handler arg
+ *   - "encodes an object name"                        → param absent entirely
+ *
+ * GREEN BOTH SIDES, on purpose (controls — this card must not move them):
+ *
+ *   - "a host that publishes no objectName is unchanged" — the pre-#4292
+ *     contract for every host that cannot answer the question. Tightening on
+ *     absent information would turn working edit flows into creates;
+ *   - "no record id at all ⇒ bare form route";
+ *   - "an unqualified target name is not comparable".
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ActionRunner, type ActionContext } from '../ActionRunner';
+
+/** The "log time" shape: fired from a Task, targeting a Task form view. */
+const TASK_CONTEXT: ActionContext = {
+  record: { id: 42, title: 'Write the report' },
+  objectName: 'showcase_task',
+  user: { id: 'u1' },
+};
+
+/**
+ * The defect's shape: the user is on an ACCOUNT record, the action targets a
+ * TASK form view, and both objects number their rows from 1 — so `42` names a
+ * real row in each.
+ */
+const ACCOUNT_CONTEXT: ActionContext = {
+  record: { id: 42, name: 'Acme Corp' },
+  objectName: 'showcase_account',
+  user: { id: 'u1' },
+};
+
+describe('same object ⇒ forward the id AND its object (#4292)', () => {
+  it('forwards the object alongside the id', async () => {
+    const runner = new ActionRunner(TASK_CONTEXT);
+    const result = await runner.execute({ type: 'form', target: 'showcase_task.edit' });
+
+    expect(result.success).toBe(true);
+    // RED before the fix: `?recordId=42` with no object — the id travelling
+    // alone is the defect itself.
+    expect(result.redirect).toBe(
+      '/forms/showcase_task.edit?recordId=42&recordObject=showcase_task',
+    );
+  });
+
+  it('does the same through the navigation handler', async () => {
+    const runner = new ActionRunner(TASK_CONTEXT);
+    const navHandler = vi.fn();
+    runner.setNavigationHandler(navHandler);
+    await runner.execute({ type: 'form', target: 'showcase_task.edit' });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      '/forms/showcase_task.edit?recordId=42&recordObject=showcase_task',
+      expect.objectContaining({ external: false }),
+    );
+  });
+
+  it('reads the id from `data` when there is no `record`, same as before', async () => {
+    const runner = new ActionRunner({
+      data: { id: 7 },
+      objectName: 'showcase_task',
+    } as ActionContext);
+    const result = await runner.execute({ type: 'form', target: 'showcase_task.edit' });
+
+    expect(result.redirect).toBe('/forms/showcase_task.edit?recordId=7&recordObject=showcase_task');
+  });
+
+  /**
+   * Both values are percent-encoded, so an id carrying `/` or `#` cannot break
+   * the query string apart or smuggle a second param in. `URLSearchParams`
+   * decodes them on the consumer side — pinned end-to-end in the console's
+   * `FormPage.test.ts`.
+   */
+  it('encodes the values it appends', async () => {
+    const runner = new ActionRunner({
+      record: { id: 'a/b#c' },
+      objectName: 'showcase_task',
+    } as ActionContext);
+    const result = await runner.execute({ type: 'form', target: 'showcase_task.edit' });
+
+    expect(result.redirect).toBe(
+      `/forms/showcase_task.edit?recordId=${encodeURIComponent('a/b#c')}` +
+        '&recordObject=showcase_task',
+    );
+  });
+});
+
+describe('cross-object ⇒ forward NO id, preserving create semantics (#4292)', () => {
+  /**
+   * The card's own collision scenario. Pre-#4278 this shape produced an empty
+   * form and an INSERT — which for a "log time on this account" action pointed
+   * at a Task create view is the CORRECT outcome, not a bug. So the fix
+   * restores it rather than refusing: a create launched from a record is a
+   * legitimate shape, and only the id is wrong to carry across the boundary.
+   */
+  it('a cross-object target forwards NO record id', async () => {
+    const runner = new ActionRunner(ACCOUNT_CONTEXT);
+    const result = await runner.execute({ type: 'form', target: 'showcase_task.edit' });
+
+    expect(result.success).toBe(true);
+    // RED before the fix: `/forms/showcase_task.edit?recordId=42`, which the
+    // consumer then resolves as Task 42 — a different record entirely.
+    expect(result.redirect).toBe('/forms/showcase_task.edit');
+    expect(result.redirect).not.toContain('recordId');
+    expect(result.redirect).not.toContain('recordObject');
+  });
+
+  it('withholds it through the navigation handler too', async () => {
+    const runner = new ActionRunner(ACCOUNT_CONTEXT);
+    const navHandler = vi.fn();
+    runner.setNavigationHandler(navHandler);
+    await runner.execute({ type: 'form', target: 'showcase_task.edit' });
+
+    expect(navHandler).toHaveBeenCalledWith(
+      '/forms/showcase_task.edit',
+      expect.objectContaining({ external: false }),
+    );
+  });
+
+  /**
+   * Prefix matching is on the WHOLE object segment, so an object whose name is
+   * a string-prefix of another's does not read as a match.
+   */
+  it('does not mistake a name-prefix for the same object', async () => {
+    const runner = new ActionRunner({
+      record: { id: 42 },
+      objectName: 'showcase_task',
+    } as ActionContext);
+    const result = await runner.execute({ type: 'form', target: 'showcase_task_archive.edit' });
+
+    expect(result.redirect).toBe('/forms/showcase_task_archive.edit');
+  });
+});
+
+/**
+ * CONTROLS — green before and after. The guard fires only on information it
+ * actually has; everything else keeps the pre-#4292 contract byte for byte.
+ */
+describe('control: not comparable ⇒ unchanged behaviour', () => {
+  it('a host that publishes no objectName still gets the plain id', async () => {
+    // Exactly the context `ActionRunner.test.ts` has always used.
+    const runner = new ActionRunner({
+      data: { id: 1, name: 'Test' },
+      record: { id: 1, status: 'active' },
+      user: { id: 'u1', role: 'admin' },
+    } as ActionContext);
+    const result = await runner.execute({ type: 'form', target: 'showcase_task.default' });
+
+    expect(result.redirect).toBe('/forms/showcase_task.default?recordId=1');
+  });
+
+  it('treats a blank objectName as absent rather than as a mismatch', async () => {
+    for (const objectName of ['', '   ']) {
+      const runner = new ActionRunner({ record: { id: 1 }, objectName } as ActionContext);
+      const result = await runner.execute({ type: 'form', target: 'showcase_task.default' });
+      expect(result.redirect).toBe('/forms/showcase_task.default?recordId=1');
+    }
+  });
+
+  it('an unqualified target name names no object, so nothing is compared', async () => {
+    const runner = new ActionRunner(ACCOUNT_CONTEXT);
+    const result = await runner.execute({ type: 'form', target: 'quick_intake' });
+
+    // The id still travels — plus the identity, which is what lets the
+    // consumer make the call this runner cannot.
+    expect(result.redirect).toBe(
+      '/forms/quick_intake?recordId=42&recordObject=showcase_account',
+    );
+  });
+
+  it('no record id at all ⇒ bare form route', async () => {
+    const runner = new ActionRunner({ objectName: 'showcase_task', user: { id: 'u1' } });
+    const result = await runner.execute({ type: 'form', target: 'showcase_task.edit' });
+
+    expect(result.redirect).toBe('/forms/showcase_task.edit');
+  });
+
+  it('still errors when no form target is given', async () => {
+    const runner = new ActionRunner(TASK_CONTEXT);
+    const result = await runner.execute({ type: 'form' } as never);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/form target/i);
+  });
+});
+
+/**
+ * The action's OWN `objectName` is a statement about where the action is
+ * declared, not about the record the id was read from. Trusting it to describe
+ * the record is the conflation that made this defect possible, so it must not
+ * be able to talk the runner into forwarding across a boundary.
+ */
+describe('action.objectName cannot stand in for the context record (#4292)', () => {
+  it('is ignored: the context record still decides', async () => {
+    const runner = new ActionRunner(ACCOUNT_CONTEXT);
+    const result = await runner.execute({
+      type: 'form',
+      target: 'showcase_task.edit',
+      objectName: 'showcase_task',
+    });
+
+    expect(result.redirect).toBe('/forms/showcase_task.edit');
+  });
+});


### PR DESCRIPTION
Fixes #4292. Builds directly on #4278 (PR #4293), which is the reason this became worth closing now.

## The defect

`ActionRunner.executeForm` forwarded `/forms/:name?recordId=` for any context record, and that URL carries no object. The form route therefore has to resolve the id against the only object it knows — the FormView's own target — which is right whenever the action fired from a record of that object, and which nothing checked. An action whose `locations` put it on an Account but whose `target` is `showcase_task.edit` is publishable metadata today.

Where primary keys are per-table integers, `GET /api/v1/data/showcase_task/42` answers happily for the user who was looking at Account 42. The server cannot flag it either — `getData` echoes the path's object back, so the response is perfectly self-consistent, which is exactly why #4278's payload-mismatch guard cannot see this shape.

Pre-#4278 the blast radius stopped at a duplicate INSERT. Now that the route honours the param, the same mis-scoped action performs a targeted **UPDATE of a different object's record**, with no error anywhere and the record the user was actually on left untouched.

## The ruling this implements

Per the PM ruling on the card (quoted verbatim):

> 裁决(不变量表述):**id 不得脱离其对象身份旅行;不匹配在两端都 fail-closed。**

Both halves land here, in one PR.

### Producer — `packages/core/src/actions/ActionRunner.ts` (`executeForm`)

The id is forwarded **only** when the firing context record's object matches the target view's object; on a mismatch neither param is forwarded, so the bare `/forms/:name` preserves create semantics — a "log time" action fired from a Task at another object's create view is a CREATE launched from a record, which is what that shape did before #4278 and is not a broken edit. When the id IS forwarded, the object rides with it as `?recordObject=`.

**Object identity is measured, not invented.** The source is `context.objectName`, which is already this repo's one spelling of that fact:

- `@object-ui/react`'s `ActionProvider` documents the flat trio (`record`, `user`, `objectName`) and mirrors it into the canonical `ctx.*` scope;
- `useConsoleActionRuntime` seeds `context: { ...(objectName ? { objectName } : {}), … }`, so every console surface that fires record actions (`DeclaredActionsBar`, `ObjectView`, `RecordDetailView`) already publishes it — and `RecordDetailView` passes it explicitly a second time;
- app-shell's `recordFormNavigation` resolver already reads that same key as its last precedence step.

`action.objectName` is deliberately **not** consulted: it declares where an action is placed, not which record the id came from, and trusting metadata about the action to describe the record is the conflation that made this defect possible. A test pins that it cannot talk the runner into forwarding across a boundary.

The target's object is asked as a **prefix match** against the object already in hand rather than by parsing an object name out of the view name — view identity is `object` + `.` + `key` (ADR-0017; `viewEnvelope` builds exactly that, `defaultListViewId` compares exactly this way), so the metadata keeps owning that fact.

### Consumer — `apps/console/src/components/FormPage.tsx`

When `recordObject` is present and disagrees with the FormView's object, the route takes #4278's existing fail-closed path: the refusal fires **before the object-schema fetch and before the record read**, so a mismatch costs zero `/data/` traffic and can never reach a write. When the param is absent or blank it asserts nothing and behaviour is unchanged, so hand-authored deep links and old links keep working — the guard only tightens where identity information is actually present.

`recordObject` is an **assertion, never an override**: it cannot change which object the form edits (that comes from the view metadata alone), only make the form refuse. Reading it as a selector would let any hand-authored URL aim a form at an arbitrary object — the same hole re-opened from the other side. The registry's `formObject` is deliberately the other thing (it selects the object the record-form *overlay* edits); same naming shape, opposite powers, separate surfaces.

## Why both halves, when the producer already refuses to emit the bad URL

Defence in depth is the ruling's 两端. The producer stops emitting a cross-object id at all, so in a healthy console the consumer guard never fires. It is still not redundant: URLs arrive bookmarked, hand-written, pasted, or from a producer that predates this fix, and the console cannot tell those apart.

## Tests

New: `packages/core/src/actions/__tests__/ActionRunner.formObjectIdentity.test.ts` (13 cases) and `apps/console/src/components/FormPage.recordObject.test.tsx` (9 cases), plus #4292 cases in `FormPage.test.ts` including a **behavioural round-trip pin** — the real `ActionRunner` produces a URL and this route's real reader consumes it, so a rename on either side fails rather than silently disarming the guard.

Reverse verification per half, directions predicted before running and recorded in each file's docblock (`git checkout origin/main -- FILE` after committing, never `git stash`):

| Reverted | Predicted | Observed |
|---|---|---|
| producer only | the 9 identity/cross-object producer pins red, the 4 "not comparable" controls green; the consumer DOM suite entirely green, since it feeds URLs directly and never asks the runner | exactly that — `9 failed \| 4 passed (13)`, consumer DOM suite `9 passed`. The headline failure is the defect verbatim: `expected '/forms/showcase_task.edit?recordId=42' to be '/forms/showcase_task.edit'` (Account 42's id handed to a Task form) |
| consumer only | only the 4 forged-URL cases red; all 13 producer pins green | exactly that — `4 failed \| 18 passed (22)`, each failure "Unable to find … /Refusing to open it/", i.e. the refusal is gone and the form loaded the other object's record |

One honest gap: with the consumer reverted, `FormPage.test.ts` cannot be run at all — it imports `FORM_RECORD_OBJECT_PARAM`, which lives in the reverted file, so it fails at collection rather than producing a verdict. Its round-trip pin was exercised in the producer-reverted direction instead, where it went red on all 3 cases (the only console-side signal that can catch a producer regression).

Controls, green both sides on purpose: same-object edit (#4278's main path — load, prefill, PATCH) byte-identical; `recordId` with no `recordObject` unchanged; a host publishing no `objectName` still gets the plain `?recordId=`; the public `/f/:slug` surface reads neither param; #4278's payload-mismatch guard still fires on its own condition with its own distinct wording.

Local verification: the affected suites plus, because `@object-ui/core` sits upstream of 36 packages, the full repo suite — `1254 files, 15929 passed | 1 skipped`, exit 0. `type-check` green on `@object-ui/core`, `@object-ui/app-shell` and `@object-ui/console` (both tsc commands each, after building the dependency closure). `check:action-forward-parity`, `check:control-bytes`, `check:changeset-presence` and `check:changeset-no-major` all green.

## Scope

`ActionDef` / `actionKeys` untouched — this is behaviour in `executeForm`, not new vocabulary, and `check:action-forward-parity` is green without a whitelist edit. The only app-shell change is one prose row in the `urlParams` registry table so no page repurposes the name; no functional change there.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_