### PR TITLE
fix(components): SidebarProvider reads back the sidebar_state cookie it writes (#4234)

### DIFF
--- a/.changeset/sidebar-collapse-survives-reload-4234.md
+++ b/.changeset/sidebar-collapse-survives-reload-4234.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/components': patch
+---
+
+A collapsed sidebar now survives a reload — `SidebarProvider` reads the `sidebar_state` cookie it has always written
+
+The cookie half of this feature only ever ran in one direction. `setOpen` wrote `sidebar_state` on every toggle with a 7-day max-age, and nothing ever read it back: `SidebarProvider` seeded its state from `defaultOpen` (default `true`), so a sidebar you collapsed came back expanded on the next load with the correct cookie sitting right there, unread. QA measured it at 255px and `data-state=expanded` at +2s, +4s and +8s after load, reproduced three times.
+
+Upstream Shadcn closes this loop in a **server component** — it reads the cookie there and passes the value down as `defaultOpen`. A pure SPA like the console has no such step, which is why nothing downstream could paper over it: passing a cookie-derived `defaultOpen` from one shell would have fixed that shell and left every other consumer of the primitive broken. The read therefore happens client-side, in the provider, as a lazy `useState` initialiser rather than a mount effect — the state has to be right on the first render, since a post-mount correction would still flash an expanded sidebar at the user.
+
+Precedence is now pinned, in this order: a controlled `open` prop, then the cookie, then `defaultOpen`, then `true`. The cookie overrides the *default*, never a controlled usage. With no cookie present the behaviour is exactly what it was before, which is what keeps explicit `defaultOpen={false}` call sites — the marketing demos in `apps/site` — rendering unchanged; those cases are controls in the new test file and are green on both sides of the change.
+
+Only the two values the writer produces are honoured (`"true"` / `"false"`), matched on an exact cookie name; anything else, including an absent or malformed value, falls through to `defaultOpen` rather than inventing a preference the user never expressed. The reader is SSR-safe, which `apps/site` needs: those primitives are `"use client"`, and Next still renders them on the server for the initial HTML, where there is no `document`.
+
+Because `packages/components/src/ui/**` is regenerated from the Shadcn registry, the primitive itself only gains two anchored one-liners. All of the parsing lives in `packages/components/src/lib/sidebar-cookie.ts`, which the sync never touches, and the two edits are declared in `scripts/shadcn-local-patches.mjs` so `pnpm shadcn:update` re-applies them instead of silently reverting the fix — the same mechanism already used for the translated `Sheet`/`Dialog` close labels.

--- a/packages/components/src/__tests__/sidebar-cookie-restore.test.tsx
+++ b/packages/components/src/__tests__/sidebar-cookie-restore.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A collapsed sidebar survives a reload — objectui#4234.
+ *
+ * `SidebarProvider` wrote `sidebar_state` on every toggle (7-day max-age) and
+ * never read it back, so the cookie was present and correct after a reload and
+ * nothing consulted it: the sidebar came back expanded (QA measured 255px /
+ * `data-state=expanded` at +2s, +4s and +8s, reproduced 3x). Upstream Shadcn
+ * reads that cookie in a **server component** and passes it down as
+ * `defaultOpen`; the console is a pure SPA with no such step, so the read
+ * happens client-side in the provider.
+ *
+ * ## The precedence these tests pin
+ *
+ *   controlled `open` prop  >  cookie  >  `defaultOpen` prop  >  `true`
+ *
+ * The cookie overrides the DEFAULT — never a controlled usage. With no cookie
+ * present, `defaultOpen` semantics are unchanged, which is what keeps the
+ * `defaultOpen={false}` marketing demos in `apps/site` behaving exactly as
+ * before; those cases are controls here and are green on both sides of the fix.
+ *
+ * ## Why "first render" and not "eventually"
+ *
+ * The reported symptom is measured at first paint, so a mount effect that
+ * collapses after one expanded frame would still be the bug. Every assertion
+ * below is therefore synchronous — no `waitFor` — and `renderSequence` pins the
+ * state of the FIRST render, which an effect-based implementation would fail
+ * (it would record `['expanded', 'collapsed']`).
+ *
+ * The source-level half of this contract — that the primitive keeps carrying
+ * the patch through a `pnpm shadcn:update`, since `src/ui/**` is regenerated —
+ * lives in `scripts/__tests__/shadcn-local-patches.test.ts`.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { Sidebar, SidebarProvider, SidebarTrigger, useSidebar } from '../ui/sidebar';
+import { readSidebarStateCookie } from '../lib/sidebar-cookie';
+
+const COOKIE = 'sidebar_state';
+
+function clearCookies() {
+  for (const entry of document.cookie.split(';')) {
+    const name = entry.split('=')[0]?.trim();
+    if (name) {
+      document.cookie = `${name}=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    }
+  }
+}
+
+afterEach(() => {
+  // Unstub FIRST — the SSR case stubs `document` away, and `clearCookies`
+  // needs the real one back before it can run.
+  vi.unstubAllGlobals();
+  cleanup();
+  clearCookies();
+});
+
+/** Records the sidebar state of every render pass, first one first. */
+function StateProbe({ sequence }: { sequence: string[] }) {
+  const { state } = useSidebar();
+  sequence.push(state);
+  return null;
+}
+
+/**
+ * Renders the primitive the way a shell does, and returns the state observed
+ * on the very first render pass plus the committed `data-state`.
+ *
+ * `data-state` is read off the element that actually carries it — `Sidebar`'s
+ * outer wrapper, which is also the element QA measured. That element does NOT
+ * receive `{...props}` (the primitive spreads those onto an inner div), so it
+ * cannot be tagged with a `data-testid`; scoping the query to this render's own
+ * `container` is what keeps it unambiguous when a test mounts twice.
+ */
+function renderSidebar(props: React.ComponentProps<typeof SidebarProvider> = {}) {
+  const sequence: string[] = [];
+  const { container } = render(
+    <SidebarProvider {...props}>
+      <StateProbe sequence={sequence} />
+      <Sidebar>
+        <div>nav</div>
+      </Sidebar>
+    </SidebarProvider>,
+  );
+  return {
+    sequence,
+    // Read synchronously: no waitFor, so a post-mount correction cannot pass.
+    state: () => container.querySelector('[data-state]')?.getAttribute('data-state') ?? null,
+  };
+}
+
+describe('SidebarProvider restores the persisted collapse state (objectui#4234)', () => {
+  it('starts collapsed on the first render when the cookie says collapsed', () => {
+    document.cookie = `${COOKIE}=false; path=/`;
+
+    const sidebar = renderSidebar();
+
+    // The QA repro: cookie present and false, sidebar must not come back open.
+    expect(sidebar.state()).toBe('collapsed');
+    // ...and it must never have rendered expanded, not even for one frame.
+    expect(sidebar.sequence[0]).toBe('collapsed');
+    expect(sidebar.sequence).not.toContain('expanded');
+  });
+
+  it('starts expanded on the first render when the cookie says expanded', () => {
+    document.cookie = `${COOKIE}=true; path=/`;
+
+    const sidebar = renderSidebar();
+
+    expect(sidebar.state()).toBe('expanded');
+    expect(sidebar.sequence[0]).toBe('expanded');
+  });
+});
+
+describe('precedence: controlled open > cookie > defaultOpen > true', () => {
+  it('lets the cookie override an explicit defaultOpen, in both directions', () => {
+    document.cookie = `${COOKIE}=true; path=/`;
+    const expanded = renderSidebar({ defaultOpen: false });
+    expect(expanded.state()).toBe('expanded');
+    expect(expanded.sequence[0]).toBe('expanded');
+
+    cleanup();
+    clearCookies();
+
+    document.cookie = `${COOKIE}=false; path=/`;
+    const collapsed = renderSidebar({ defaultOpen: true });
+    expect(collapsed.state()).toBe('collapsed');
+    expect(collapsed.sequence[0]).toBe('collapsed');
+  });
+
+  it('lets a controlled open prop override the cookie, in both directions', () => {
+    document.cookie = `${COOKIE}=false; path=/`;
+    const forcedOpen = renderSidebar({ open: true });
+    expect(forcedOpen.state()).toBe('expanded');
+
+    cleanup();
+    clearCookies();
+
+    document.cookie = `${COOKIE}=true; path=/`;
+    const forcedClosed = renderSidebar({ open: false });
+    expect(forcedClosed.state()).toBe('collapsed');
+  });
+
+  /**
+   * The control pin. No cookie ⇒ behaviour is exactly what it was before the
+   * fix, which is what the `defaultOpen={false}` demos in `apps/site` rely on.
+   * Green on both sides of the change.
+   */
+  it('honours defaultOpen unchanged when no cookie is present', () => {
+    // The precondition is "no persisted preference", which is exactly what the
+    // reader reports — not "the substring is absent from the jar". (happy-dom
+    // keeps a cleared cookie around as an empty value; an empty value IS no
+    // preference, and the assertion should say so rather than describe the
+    // host's deletion bookkeeping.)
+    expect(readSidebarStateCookie(COOKIE)).toBeUndefined();
+
+    const collapsed = renderSidebar({ defaultOpen: false });
+    expect(collapsed.state()).toBe('collapsed');
+
+    cleanup();
+
+    const explicitlyOpen = renderSidebar({ defaultOpen: true });
+    expect(explicitlyOpen.state()).toBe('expanded');
+
+    cleanup();
+
+    // `defaultOpen` omitted entirely still defaults to `true`.
+    const byDefault = renderSidebar();
+    expect(byDefault.state()).toBe('expanded');
+  });
+});
+
+describe('the write side still works, and round-trips', () => {
+  /** Control: the behaviour the issue reported as already correct. */
+  it('still writes the cookie on every toggle', () => {
+    render(
+      <SidebarProvider>
+        <SidebarTrigger />
+      </SidebarProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(document.cookie).toContain(`${COOKIE}=false`);
+  });
+
+  /**
+   * End-to-end version of the QA repro: collapse it, throw the whole tree away
+   * (the reload), mount it again against the cookie that survived.
+   */
+  it('comes back collapsed after a remount, which is what a reload is', () => {
+    const { container } = render(
+      <SidebarProvider>
+        <SidebarTrigger />
+        <Sidebar>
+          <div>nav</div>
+        </Sidebar>
+      </SidebarProvider>,
+    );
+    const state = () => container.querySelector('[data-state]')?.getAttribute('data-state');
+    expect(state()).toBe('expanded');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(state()).toBe('collapsed');
+
+    cleanup();
+    expect(document.cookie).toContain(`${COOKIE}=false`);
+
+    const reloaded = renderSidebar();
+    expect(reloaded.state()).toBe('collapsed');
+    expect(reloaded.sequence[0]).toBe('collapsed');
+  });
+});
+
+describe('readSidebarStateCookie', () => {
+  it('reads only the two values the write side produces', () => {
+    document.cookie = `${COOKIE}=true; path=/`;
+    expect(readSidebarStateCookie(COOKIE)).toBe(true);
+
+    clearCookies();
+    document.cookie = `${COOKIE}=false; path=/`;
+    expect(readSidebarStateCookie(COOKIE)).toBe(false);
+  });
+
+  it('returns undefined for a value it did not write, so the caller keeps its default', () => {
+    for (const value of ['1', '0', 'collapsed', 'TRUE', '']) {
+      clearCookies();
+      document.cookie = `${COOKIE}=${value}; path=/`;
+      expect(readSidebarStateCookie(COOKIE)).toBeUndefined();
+    }
+  });
+
+  it('returns undefined when the cookie is absent', () => {
+    document.cookie = 'unrelated=value; path=/';
+    expect(readSidebarStateCookie(COOKIE)).toBeUndefined();
+  });
+
+  it('matches the cookie name exactly, not by substring', () => {
+    document.cookie = `my_${COOKIE}=false; path=/`;
+    document.cookie = `${COOKIE}_v2=false; path=/`;
+
+    expect(readSidebarStateCookie(COOKIE)).toBeUndefined();
+
+    // ...and a neighbour with a confusable name does not shadow the real one.
+    document.cookie = `${COOKIE}=true; path=/`;
+    expect(readSidebarStateCookie(COOKIE)).toBe(true);
+  });
+
+  it('reads a cookie sitting anywhere in the jar', () => {
+    document.cookie = 'first=a; path=/';
+    document.cookie = `${COOKIE}=false; path=/`;
+    document.cookie = 'last=z; path=/';
+
+    expect(readSidebarStateCookie(COOKIE)).toBe(false);
+  });
+
+  /**
+   * `apps/site` is Next.js and these primitives are `"use client"`, which Next
+   * still renders on the SERVER for the initial HTML — where there is no
+   * `document`. The guard is load-bearing, not defensive noise.
+   */
+  it('does not throw where there is no document (SSR)', () => {
+    vi.stubGlobal('document', undefined);
+
+    expect(() => readSidebarStateCookie(COOKIE)).not.toThrow();
+    expect(readSidebarStateCookie(COOKIE)).toBeUndefined();
+  });
+});

--- a/packages/components/src/lib/sidebar-cookie.ts
+++ b/packages/components/src/lib/sidebar-cookie.ts
@@ -1,0 +1,81 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+"use client"
+
+/**
+ * Reads the persisted sidebar collapse state back out of `document.cookie` —
+ * objectui#4234.
+ *
+ * `SidebarProvider` has always WRITTEN `sidebar_state` on every toggle (7-day
+ * max-age) and never read it back, so a collapsed sidebar came back expanded
+ * on the next load: the cookie was present and correct, and nothing consulted
+ * it. Upstream Shadcn closes that loop in a **server component** — it reads the
+ * cookie there and hands the value down as `defaultOpen`. A pure SPA (the
+ * console) has no such step, so the read has to happen client-side, which is
+ * what this function is for.
+ *
+ * ## Why the implementation lives HERE and not in the primitive
+ *
+ * `packages/components/src/ui/**` is regenerated from the Shadcn registry
+ * (AGENTS.md Commandment #7) — anything written there is overwritten by the
+ * next `pnpm shadcn:update`. `src/lib/` is not part of that regeneration, so
+ * this file is permanent. `sidebar.tsx` gets only a one-line call, re-applied
+ * on every sync by the declared patch in `scripts/shadcn-local-patches.mjs`.
+ * Keeping the payload out of the regenerated zone is what makes the patch small
+ * enough to survive upstream churn — the same shape as `close-label.tsx`.
+ *
+ * ## Why the cookie NAME is a parameter
+ *
+ * The name is owned by the write side: `SIDEBAR_COOKIE_NAME` in `sidebar.tsx`,
+ * the same constant the `document.cookie =` assignment interpolates. Passing it
+ * in keeps that the single source of truth — a second spelling here could drift
+ * from the writer and would read a cookie nobody writes. (Importing the
+ * constant instead would make `sidebar.tsx` and this module circular.)
+ *
+ * ## Strict values, deliberately
+ *
+ * Only the two literals the write side produces are accepted. Anything else —
+ * absent, empty, `"1"`, `"collapsed"`, a truncated value — returns `undefined`
+ * so the caller falls through to its `defaultOpen`. That is contract-first
+ * (AGENTS.md #0.1): the writer is ours and emits exactly `true`/`false`, so a
+ * tolerant parse here would only serve values no part of this system writes,
+ * and would silently invent a preference the user never expressed.
+ *
+ * @param name Cookie name to look up, matched EXACTLY (not by prefix or
+ *   substring), so `sidebar_state_v2` / `my_sidebar_state` never answer for
+ *   `sidebar_state`.
+ * @returns `true` / `false` for a persisted preference, or `undefined` when
+ *   there is none to honour — including on the server, where there is no
+ *   `document` to read (Next.js SSRs `"use client"` components for the initial
+ *   HTML, so this guard is load-bearing for `apps/site`, not defensive noise).
+ */
+export function readSidebarStateCookie(name: string): boolean | undefined {
+  if (typeof document === "undefined") return undefined
+
+  const jar = document.cookie
+  if (!jar) return undefined
+
+  for (const entry of jar.split(";")) {
+    const separator = entry.indexOf("=")
+    // A bare `foo` segment carries no value — it cannot be our `name=value`.
+    if (separator === -1) continue
+    if (entry.slice(0, separator).trim() !== name) continue
+
+    // First exact-name match decides. Browsers order `document.cookie` most
+    // specific path first, so that is the cookie this document would send —
+    // scanning past it for a better-looking value would answer with a cookie
+    // the server never sees.
+    const value = entry.slice(separator + 1).trim()
+    if (value === "true") return true
+    if (value === "false") return false
+    return undefined
+  }
+
+  return undefined
+}

--- a/packages/components/src/ui/sidebar.tsx
+++ b/packages/components/src/ui/sidebar.tsx
@@ -15,6 +15,7 @@ import { PanelLeft } from "lucide-react"
 
 import { useIsMobile } from "../hooks/use-mobile"
 import { cn } from "../lib/utils"
+import { readSidebarStateCookie } from "../lib/sidebar-cookie"
 import { Button } from "./button"
 import { Input } from "./input"
 import { Separator } from "./separator"
@@ -86,7 +87,7 @@ const SidebarProvider = React.forwardRef<
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen)
+    const [_open, _setOpen] = React.useState(() => readSidebarStateCookie(SIDEBAR_COOKIE_NAME) ?? defaultOpen)
     const open = openProp ?? _open
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {

--- a/scripts/__tests__/shadcn-local-patches.test.ts
+++ b/scripts/__tests__/shadcn-local-patches.test.ts
@@ -43,6 +43,19 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
 const uiDir = path.join(repoRoot, 'packages/components/src/ui');
 
 /**
+ * The components carrying the i18n close-label patch family.
+ *
+ * The registry is a general mechanism and now holds an unrelated family too
+ * (`sidebar`, objectui#4234), so the close-label assertions below must iterate
+ * THIS list and not `patchedComponents()` — the latter would assert one
+ * family's ids and marker on every patched primitive. Derived rather than
+ * hardcoded so a third `Sheet`-like primitive is picked up automatically.
+ */
+const closeLabelComponents = patchedComponents().filter((name: string) =>
+  LOCAL_PATCHES[name].some((p: { marker: string }) => p.marker === '<CloseSrLabel />'),
+);
+
+/**
  * A faithful excerpt of what the registry serves for `dialog`, AFTER
  * `rewriteRegistryImports` (so `@/lib/utils` already reads `../lib/utils`).
  * This is the exact shape the patch engine sees during `--update`.
@@ -70,9 +83,15 @@ const DialogContent = React.forwardRef((props, ref) => (
 `;
 
 describe('shadcn local patches — application to fresh upstream (objectstack#5505)', () => {
-  it.each(patchedComponents())('%s declares the i18n close patch', (name: string) => {
+  it.each(closeLabelComponents)('%s declares the i18n close patch', (name: string) => {
     const ids = LOCAL_PATCHES[name].map((p: { id: string }) => p.id);
     expect(ids).toEqual([`${name}-i18n-close-import`, `${name}-i18n-close-label`]);
+  });
+
+  /** The other declared family: the sidebar collapse-persistence patch. */
+  it('sidebar declares the cookie-read patch', () => {
+    const ids = LOCAL_PATCHES.sidebar.map((p: { id: string }) => p.id);
+    expect(ids).toEqual(['sidebar-cookie-read-import', 'sidebar-cookie-read-initial-state']);
   });
 
   it('turns an unpatched upstream file into the translated form', () => {
@@ -184,11 +203,20 @@ describe('shipped primitives still carry every declared patch (objectstack#5505)
    * English literal must not be back in the file under any spelling of the
    * span. Rendering-level negatives live in
    * `packages/components/src/__tests__/sheet-dialog-close-i18n.test.tsx`.
+   *
+   * Scoped to `closeLabelComponents` (see the top of this file), NOT to
+   * `patchedComponents()`: "contains `<CloseSrLabel />`" is simply false for
+   * the unrelated `sidebar` family.
    */
-  it.each(patchedComponents())('%s.tsx has no hardcoded English close label', (name: string) => {
+  it.each(closeLabelComponents)('%s.tsx has no hardcoded English close label', (name: string) => {
     const content = fs.readFileSync(path.join(uiDir, `${name}.tsx`), 'utf-8');
 
     expect(content).not.toMatch(/<span className="sr-only">\s*Close\s*<\/span>/);
     expect(content).toContain('<CloseSrLabel />');
+  });
+
+  /** The derivation above must never silently select nothing. */
+  it('still covers the close-label primitives', () => {
+    expect(closeLabelComponents).toEqual(['sheet', 'dialog']);
   });
 });

--- a/scripts/shadcn-local-patches.mjs
+++ b/scripts/shadcn-local-patches.mjs
@@ -104,6 +104,62 @@ function i18nCloseLabelPatches(primitive) {
 }
 
 /**
+ * The sidebar collapse-persistence patch (objectui#4234).
+ *
+ * `SidebarProvider` writes `sidebar_state` on every toggle and never reads it
+ * back, so a collapsed sidebar returns expanded after a reload — the cookie is
+ * present and correct, and nothing consults it. Upstream closes the loop in a
+ * **server component** (read the cookie there, pass it down as `defaultOpen`),
+ * a step a pure SPA like the console does not have, so the read must happen
+ * client-side inside the provider itself.
+ *
+ * Fixing it at a call site instead was rejected on the issue: passing a
+ * cookie-derived `defaultOpen` from one shell leaves every other SPA consumer
+ * of this primitive broken.
+ *
+ * As with the i18n patches above, the payload stays OUT of `src/ui/`: all of
+ * the parsing lives in `packages/components/src/lib/sidebar-cookie.ts`, and the
+ * primitive gets two anchored one-liners. The lazy `useState` initialiser (not
+ * a mount effect) is the point — the state must be right on the FIRST render,
+ * because the reported symptom is measured at first paint and a mount-then-
+ * collapse effect would still flash expanded.
+ *
+ * @type {LocalPatch[]}
+ */
+const sidebarCookieReadPatches = [
+  {
+    id: 'sidebar-cookie-read-import',
+    issue: 'objectui#4234',
+    reason:
+      'Imports the cookie reader that restores the persisted collapse state. ' +
+      'Anchored on the `cn` import, which every Shadcn component carries.',
+    find: 'import { cn } from "../lib/utils"',
+    replace:
+      'import { cn } from "../lib/utils"\nimport { readSidebarStateCookie } from "../lib/sidebar-cookie"',
+    marker: 'from "../lib/sidebar-cookie"',
+    occurrences: 1,
+  },
+  {
+    id: 'sidebar-cookie-read-initial-state',
+    issue: 'objectui#4234',
+    reason:
+      "Seeds the provider's uncontrolled state from the `sidebar_state` cookie " +
+      'that its own `setOpen` writes, so a collapsed sidebar survives a reload. ' +
+      'A lazy initialiser rather than an effect: the value must be correct on ' +
+      'the first render, not applied after one expanded paint. Precedence is ' +
+      'cookie > `defaultOpen`; the controlled `open` prop still wins, because ' +
+      'it is applied downstream of this state (`openProp ?? _open`). ' +
+      'SIDEBAR_COOKIE_NAME is passed in so the cookie name keeps exactly one ' +
+      'spelling — the write side\'s.',
+    find: 'const [_open, _setOpen] = React.useState(defaultOpen)',
+    replace:
+      'const [_open, _setOpen] = React.useState(() => readSidebarStateCookie(SIDEBAR_COOKIE_NAME) ?? defaultOpen)',
+    marker: 'readSidebarStateCookie(SIDEBAR_COOKIE_NAME)',
+    occurrences: 1,
+  },
+];
+
+/**
  * Component name (as tracked in `shadcn-components.json`) → patches it needs.
  *
  * @type {Record<string, LocalPatch[]>}
@@ -111,6 +167,7 @@ function i18nCloseLabelPatches(primitive) {
 export const LOCAL_PATCHES = {
   sheet: i18nCloseLabelPatches('Sheet'),
   dialog: i18nCloseLabelPatches('Dialog'),
+  sidebar: sidebarCookieReadPatches,
 };
 
 /** Components that carry at least one declared patch. */


### PR DESCRIPTION
Fixes #4234

## The defect

The cookie half of this feature only ever ran in one direction. `setOpen` wrote `sidebar_state` on every toggle with a 7-day max-age, and nothing read it back: `SidebarProvider` seeded its state from `defaultOpen` (default `true`). So a sidebar you collapsed came back expanded on the next load with the correct cookie sitting right there, unread — QA measured 255px and `data-state=expanded` at +2s, +4s and +8s after load, reproduced 3x.

Re-verified at `3b7d1cc6d` (current main, later than the card's `bb68488`): the premise holds unchanged. `sidebar_state` appears exactly three times in the repo, all in `packages/components/src/ui/sidebar.tsx` — the two constants and the one write. There is no read anywhere.

## Why the read has to be client-side, in the provider

Upstream Shadcn closes this loop in a **server component**: it reads the cookie there and passes the value down as `defaultOpen`. A pure SPA like the console has no equivalent step, which is why nothing downstream could paper over it — passing a cookie-derived `defaultOpen` from one shell would have fixed that shell and left every other consumer of the primitive broken.

It is a lazy `useState` initialiser rather than a mount effect, deliberately: the reported symptom is measured at first paint, so a post-mount correction would still flash an expanded sidebar. The tests assert this directly rather than assuming it — a probe records the state of every render pass, and the first entry must already be `collapsed`.

## Where the fix lives — shadcn-sync divergence, measured before editing

`packages/components/src/ui/**` is a No-Touch zone (AGENTS.md Commandment #7), so the first question was how this repo treats an intentional divergence. Measured:

- `scripts/shadcn-sync.js` counts `localOnlyLines` and **refuses** to overwrite a diverged file — but `--force` bypasses that by design, and a type-check cannot see the loss (upstream drops a local addition and its usages consistently, so the regenerated file still compiles).
- The repo's actual pattern for divergences that must survive is therefore **declarative**: `scripts/shadcn-local-patches.mjs` holds them as data (`find` / `replace` / `marker` / `occurrences` / `issue` / `reason`) and the sync re-applies them on every write. Its own header states the rule for adding one — *"Keep the payload OUT of `src/ui/`… a small anchored reference survives upstream churn far better than an inlined implementation."*
- Enforcement already exists on both sides: `scripts/__tests__/shadcn-local-patches.test.ts` verifies the markers against the files on disk, offline, on every PR; `.github/workflows/shadcn-check.yml` opens a tracking issue when a declared patch stops applying to current upstream.
- Precedent: the translated `Sheet` / `Dialog` close labels (objectstack#5505), whose payload lives in `packages/components/src/lib/close-label.tsx`.

So the file does **not** have to stay pristine — divergence is allowed when it is declared. This change follows that pattern exactly:

- all parsing lives in the new `packages/components/src/lib/sidebar-cookie.ts`, which the sync never regenerates;
- the primitive gains **two anchored one-liners** (an import, and the initialiser), declared as `sidebar-cookie-read-import` and `sidebar-cookie-read-initial-state`;
- `SIDEBAR_COOKIE_NAME` is passed **into** the reader, so the cookie name keeps exactly one spelling in the repo — the write side's. (Importing the constant instead would make the two modules circular.)

`pnpm shadcn:check` cannot reach the registry from this sandbox (HTTP 403, `Host not in allowlist: ui.shadcn.com`) and exits 0 on that path by design, so the online half is unproven here; the offline half is the unit test above, and it is green.

## Precedence, pinned in tests

Per the ruling on the issue, quoted verbatim:

> **优先级序**,须在 PR 钉住:受控 `open` prop > cookie(用户已持久化的选择)> `defaultOpen` prop > `true`。cookie 覆盖的是"默认值",不覆盖受控用法;显式 `defaultOpen={false}` 的营销 demo 在 cookie 缺席时行为不变(对照 pin)。

The controlled prop wins for free — it is applied downstream of this state (`openProp ?? _open`) — and that is pinned rather than assumed. Only the two values the writer produces are honoured (`"true"` / `"false"`), matched on an **exact** cookie name; anything else, including an absent, empty or malformed value, falls through to `defaultOpen` rather than inventing a preference the user never expressed (AGENTS.md #0.1 — the writer is ours, so a tolerant parse would only serve values nothing in this system writes).

The `defaultOpen={false}` marketing demos in `apps/site` are covered by a control that is green on **both** sides of the change: with no cookie present, semantics are unchanged.

## Reverse verification

Committed first, then reverted only `sidebar.tsx` (`git checkout origin/main -- …`) and re-ran. Predicted before running: 3 discriminating render pins plus the patch-registry gate go red, every control holds. Observed exactly that — **4 failed | 25 passed**:

| red when reverted | why |
| --- | --- |
| `starts collapsed on the first render when the cookie says collapsed` | the QA repro |
| `lets the cookie override an explicit defaultOpen, in both directions` | precedence |
| `comes back collapsed after a remount, which is what a reload is` | the reload, end to end |
| `sidebar.tsx carries its declared patches` | the sync gate protecting the fix |

Controls that stayed green both ways: `honours defaultOpen unchanged when no cookie is present` (the `apps/site` pin), `lets a controlled open prop override the cookie`, `still writes the cookie on every toggle`, and every `readSidebarStateCookie` unit case.

Worth stating honestly: `starts expanded when the cookie says expanded` is **not** discriminating on its own — `defaultOpen` already defaults to `true`, so it passes both before and after. It is kept as a directional control, not counted as a pin.

## One incidental test fix

Two assertions in `scripts/__tests__/shadcn-local-patches.test.ts` iterated `patchedComponents()` while asserting the **close-label family's** ids and marker (`ids === [name-i18n-close-import, …]`, and `content` contains `CloseSrLabel`). That was invisible while every patched component belonged to one family; a second family makes it fail for the wrong reason. Both are now scoped to a derived `closeLabelComponents` list, with a guard asserting that list still selects `['sheet', 'dialog']` so it cannot silently narrow to nothing, plus a sidebar-specific declaration test.

## Known consequence — SSR hydration on `apps/site`

`apps/site` is Next.js 16 and these demos are `"use client"`, which Next still renders on the **server** for the initial HTML, where there is no `document`. The reader is guarded for that (`typeof document === "undefined"` returns `undefined`), so the server keeps rendering from `defaultOpen` and nothing throws — the guard is load-bearing, not defensive noise, and it is pinned by a test.

The residue: if a visitor toggles a demo sidebar on that domain (which writes the cookie at `path=/`) and then reloads, the server HTML and the client's first render can disagree, producing a React hydration mismatch that React corrects. The final rendered state is correct; the cost is a console error in dev. This follows directly from the ruled precedence (cookie beats `defaultOpen`) and is flagged here rather than silently deviated from — the alternatives are an effect (fails the first-paint requirement the issue is about) or ignoring the cookie when `defaultOpen` is explicit (contradicts the ruling). The console, which is the surface the issue reports, is a pure Vite SPA with no SSR and no such window.

## Verification

All commands from the repo root, heavy phases serialized under the shared lock.

- `pnpm --filter '@object-ui/components^...' build` — exit 0 (dependency closure, before any type-check)
- `pnpm --filter @object-ui/components type-check` (`tsc --noEmit` + `tsconfig.typetests.json`) — exit 0
- `pnpm type-check:scripts` — exit 0
- `pnpm exec eslint` over the five changed files — 0 errors (1 pre-existing `react-refresh` warning on the upstream `useSidebar` export block, byte-identical on main)
- `pnpm exec vitest run packages/components/ scripts/` — **155 files, 1892 tests passed**
- Consumer sweep, `packages/layout/` + `packages/app-shell/` (everything that renders the provider) — **353 files, 3417 passed, 1 skipped**
- `apps/console/` (the SPA the issue reports) — **40 files, 451 passed**
- `node scripts/check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-control-bytes.mjs` — all exit 0

Changeset: `.changeset/sidebar-collapse-survives-reload-4234.md`, `@object-ui/components: patch`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_