### PR TITLE
fix(i18n): resolve an action's confirmText/successMessage from the same bundle entry as its label (#4265)

### DIFF
--- a/.changeset/action-confirm-text-translation-4265.md
+++ b/.changeset/action-confirm-text-translation-4265.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/react': patch
+'@object-ui/components': patch
+'@object-ui/plugin-detail': patch
+'@object-ui/app-shell': patch
+---
+
+Action confirm dialogs and success toasts now honour the bundle's translated
+`confirmText` / `successMessage`, not just `label` (objectui#4265).
+
+A TranslationBundle entry for an action carries three keys under one
+`_actions.<name>` node — `label`, `confirmText`, `successMessage` — and
+`useObjectLabel()` has always exposed a resolver for each. What had drifted was
+the call sites: `page:header` (authored record pages), `record:quick_actions`
+and the related-list row menu resolved the button `label` only and dispatched
+the authored `confirmText` / `successMessage` untouched. One bundle entry met
+two fates: the button rendered the translation, the confirm dialog rendered the
+authored English.
+
+All action-rendering surfaces now go through one resolver,
+`useActionTextLocalizer()` (new, exported from `@object-ui/react`), which
+applies the existing `actionLabel` / `actionConfirm` / `actionSuccess`
+resolvers over the three keys together. Fallback is unchanged: with no bundle
+entry — or an entry lacking a key — the authored text renders. A bundle cannot
+introduce a `confirmText` or `successMessage` the metadata never declared.

--- a/packages/app-shell/src/views/DeclaredActionsBar.tsx
+++ b/packages/app-shell/src/views/DeclaredActionsBar.tsx
@@ -38,9 +38,10 @@ import {
   useCondition,
   toPredicateInput,
   usePredicateRecordContext,
+  useActionTextLocalizer,
 } from '@object-ui/react';
 import type { ActionDef } from '@object-ui/core';
-import { useObjectLabel, useObjectTranslation } from '@object-ui/i18n';
+import { useObjectTranslation } from '@object-ui/i18n';
 import { Loader2 } from 'lucide-react';
 import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
 import { useAdapter } from '../providers/AdapterProvider';
@@ -111,9 +112,11 @@ const DeclaredActionButton: React.FC<{
   // Localize the SERVER-DECLARED strings through the `_actions.<name>.*`
   // translation convention (objectui#2762 P0-3) — the metadata's literal
   // label/confirmText/successMessage are the fallback, exactly like
-  // ObjectView/RecordDetailView do for their toolbars. The param dialog's
-  // labels localize downstream in useConsoleActionRuntime.
-  const { actionLabel, actionConfirm, actionSuccess } = useObjectLabel();
+  // ObjectView/RecordDetailView do for their toolbars. Since objectui#4265 the
+  // three keys go through ONE call, so no surface can localize the button and
+  // leave the confirm dialog behind. The param dialog's labels localize
+  // downstream in useConsoleActionRuntime.
+  const localizeActionTexts = useActionTextLocalizer();
   // Chrome strings the bar itself authors — as opposed to the declared metadata
   // above — go through the normal locale bundle. The decision-output params are
   // synthesized here from `decision_output_defs`, so their key path is dynamic
@@ -200,20 +203,12 @@ const DeclaredActionButton: React.FC<{
         ? decisionOutputParams(decisionOutputDefs(recordData), t, { decision })
         : [];
       const dispatch: any = {
-        ...rest,
         // Localized copies ride the dispatch: the runner reads `label` for the
         // param-dialog title, `confirmText` for the confirm prompt and
         // `successMessage` for the toast. A nameless action has no translation
-        // key, so it keeps its literal strings.
-        ...(action.name && {
-          label: actionLabel(objectName, action.name, action.label || action.name),
-          ...(rest.confirmText !== undefined && {
-            confirmText: actionConfirm(objectName, action.name, (rest as any).confirmText),
-          }),
-          ...(rest.successMessage !== undefined && {
-            successMessage: actionSuccess(objectName, action.name, (rest as any).successMessage),
-          }),
-        }),
+        // key, so it keeps its literal strings — that rule lives in the
+        // localizer now rather than being re-spelled per surface.
+        ...localizeActionTexts(objectName, rest as Record<string, any>),
         objectName,
         params: { _rowRecord: record },
       };
@@ -225,7 +220,7 @@ const DeclaredActionButton: React.FC<{
     } finally {
       setLoading(false);
     }
-  }, [action, execute, loading, objectName, record, actionLabel, actionConfirm, actionSuccess, t]);
+  }, [action, execute, loading, objectName, record, localizeActionTexts, t]);
 
   // Does the action DECLARE a `visible` gate? `hasDeclaredVisibilityGate`
   // (`!= null && !== ''`) is the one definition on the question, imported rather
@@ -259,8 +254,9 @@ const DeclaredActionButton: React.FC<{
     : declaredVariant === 'danger'
       ? 'destructive'
       : (declaredVariant || 'outline');
-  const fallbackLabel = action.label || action.name || '';
-  const label = action.name ? actionLabel(objectName, action.name, fallbackLabel) : fallbackLabel;
+  // Same resolver as the dispatch above, so the button text and the confirm
+  // dialog body can never come from different bundle reads (objectui#4265).
+  const label = (localizeActionTexts(objectName, action as Record<string, any>).label as string) || '';
 
   return (
     <Button

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -70,7 +70,7 @@ import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useRealtimeSubscription, useConflictResolution } from '@object-ui/collaboration';
-import { ActionProvider, useNavigationOverlay, SchemaRenderer } from '@object-ui/react';
+import { ActionProvider, useNavigationOverlay, SchemaRenderer, useActionTextLocalizer } from '@object-ui/react';
 import { toast } from 'sonner';
 import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
 import { useEnvironmentEntitlements } from '../environment/useEnvironmentEntitlements';
@@ -521,7 +521,9 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const location = useLocation();
     const { showDebug } = useMetadataInspector();
     const { t } = useObjectTranslation();
-    const { objectLabel, objectDescription: objectDesc, viewLabel, viewEmptyState, actionLabel, actionConfirm, actionSuccess, actionParamText, fieldLabel, fieldOptionLabel } = useObjectLabel();
+    const { objectLabel, objectDescription: objectDesc, viewLabel, viewEmptyState, actionParamText, fieldLabel, fieldOptionLabel } = useObjectLabel();
+    // label + confirmText + successMessage through ONE call (objectui#4265).
+    const localizeActionTexts = useActionTextLocalizer();
     const { isFavorite, toggleFavorite } = useFavorites();
     // ADR-0105: under group posture default list columns get a trailing
     // organization_id attribution column (reads span all the user's orgs).
@@ -743,13 +745,8 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     // Localized `list_toolbar` actions, shared by the generic action bar and the
     // environment-aware toolbar (the action:bar renderer filters by location).
     const localizedToolbarActions = useMemo(
-        () => (objectDef.actions || []).map((a: any) => ({
-            ...a,
-            label: actionLabel(objectDef.name, a.name, a.label || a.name),
-            ...(a.confirmText !== undefined && { confirmText: actionConfirm(objectDef.name, a.name, a.confirmText) }),
-            ...(a.successMessage !== undefined && { successMessage: actionSuccess(objectDef.name, a.name, a.successMessage) }),
-        })),
-        [objectDef, actionLabel, actionConfirm, actionSuccess],
+        () => (objectDef.actions || []).map((a: any) => localizeActionTexts(objectDef.name, a)),
+        [objectDef, localizeActionTexts],
     );
 
     // Resolve which generic CRUD affordances belong in the toolbar for
@@ -1637,20 +1634,12 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                     .filter((a: any) =>
                       Array.isArray(a?.locations) && a.locations.includes('list_item'))
                     // Localize label / confirm / success the same way the
-                    // record_header and list_toolbar paths do — the row kebab
-                    // previously rendered raw English `a.label`. The `visible`
-                    // CEL is forwarded untouched (spread) and evaluated per-row
-                    // at render time inside RowActionMenu.
-                    .map((a: any) => ({
-                      ...a,
-                      label: actionLabel(objectDef.name, a.name, a.label || a.name),
-                      ...(a.confirmText !== undefined && {
-                        confirmText: actionConfirm(objectDef.name, a.name, a.confirmText),
-                      }),
-                      ...(a.successMessage !== undefined && {
-                        successMessage: actionSuccess(objectDef.name, a.name, a.successMessage),
-                      }),
-                    }))
+                    // record_header and list_toolbar paths do — through the ONE
+                    // shared resolver (objectui#4265), so this surface cannot
+                    // drift back to a label-only resolution. The `visible` CEL
+                    // is forwarded untouched (spread inside the localizer) and
+                    // evaluated per-row at render time inside RowActionMenu.
+                    .map((a: any) => localizeActionTexts(objectDef.name, a))
                 : []),
             /**
              * Selection-bar actions. Unlike `rowActionDefs` above, these are

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -14,7 +14,7 @@ import { RecordChatterPanel, InlineEditSaveBar, buildDefaultPageSchema, deriveFi
 import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { useAuth, createAuthenticatedFetch } from '@object-ui/auth';
 import { usePermissions } from '@object-ui/permissions';
-import { ActionProvider, useObjectTranslation, useObjectLabel, usePageAssignment, RecordContextProvider, SchemaRenderer, DiscussionContextProvider, HighlightFieldsProvider, InlineEditProvider, useGlobalUndo, useDataInvalidation, notifyDataChanged } from '@object-ui/react';
+import { ActionProvider, useObjectTranslation, useObjectLabel, useActionTextLocalizer, usePageAssignment, RecordContextProvider, SchemaRenderer, DiscussionContextProvider, HighlightFieldsProvider, InlineEditProvider, useGlobalUndo, useDataInvalidation, notifyDataChanged } from '@object-ui/react';
 import { buildExpandFields } from '@object-ui/core';
 import { toast } from 'sonner';
 import { useRecordPresence, PresenceAvatars } from '@object-ui/collaboration';
@@ -263,7 +263,11 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
     };
   }, [originFromState, location.search, appName]);
   const { t, language } = useObjectTranslation();
-  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionLabel, actionConfirm, actionSuccess, actionParamText, actionParamOptionLabel, actionDescription, actionResultDialog, fieldLabel, fieldOptionLabel } = useObjectLabel();
+  const { objectLabel, viewLabel: _vLabel, sectionLabel, actionParamText, actionParamOptionLabel, actionDescription, actionResultDialog, fieldLabel, fieldOptionLabel } = useObjectLabel();
+  // label + confirmText + successMessage through ONE call (objectui#4265) —
+  // the three keys of an `_actions.<name>` bundle entry can no longer be
+  // localized apart from one another on this surface.
+  const localizeActionTexts = useActionTextLocalizer();
   const { isFavorite, toggleFavorite, refreshLabel: refreshFavoriteLabel } = useFavorites();
   const { addRecentItem } = useRecentItems();
   const [isLoading, setIsLoading] = useState(true);
@@ -1725,16 +1729,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         if (seen.has(a.name)) return false;
         seen.add(a.name);
         return true;
-      }).map((a: any) => ({
-        ...a,
-        label: actionLabel(objectDef.name, a.name, a.label || a.name),
-        ...(a.confirmText !== undefined && {
-          confirmText: actionConfirm(objectDef.name, a.name, a.confirmText),
-        }),
-        ...(a.successMessage !== undefined && {
-          successMessage: actionSuccess(objectDef.name, a.name, a.successMessage),
-        }),
-      }));
+      }).map((a: any) => localizeActionTexts(objectDef.name, a));
 
       // ⛔ No approval actions are injected here any more (objectui#3055).
       // They used to be two hand-written buttons (approve/reject only, no
@@ -2163,7 +2158,6 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
                 appName={appName}
                 objects={objects}
                 dataSource={dataSource}
-                actionLabel={actionLabel}
                 parentObjectName={objectName}
                 parentRecordId={pureRecordId ?? undefined}
                 parentTitle={recordTitle}

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -44,6 +44,8 @@ import {
   RelatedRecordActionsProvider,
   notifyDataChanged,
   useAction,
+  useActionTextLocalizer,
+  type ActionTextLocalizer,
   type RelatedRecordActionsValue,
   type RelatedRecordHandlers,
   type RelatedRowActionDef,
@@ -67,9 +69,6 @@ export function notifyRelatedChanged(objectName: string): void {
   notifyDataChanged({ objectName });
 }
 
-/** i18n label resolver signature (matches `useObjectLabel().actionLabel`). */
-type ActionLabelFn = (objectName: string | undefined, actionName: string, fallback: string) => string;
-
 export interface RelatedRecordActionsBridgeProps {
   /** Current app segment used to build `/apps/:appName/...` routes. */
   appName?: string;
@@ -77,8 +76,6 @@ export interface RelatedRecordActionsBridgeProps {
   objects: any[];
   /** Data source for delete + action dispatch. */
   dataSource: any;
-  /** Localizes a child action's label (falls back to the raw label). */
-  actionLabel: ActionLabelFn;
   /**
    * The record this bridge is mounted under — the PARENT of any related row a
    * user drills into. Threaded into the child record's `?from=` trail so the
@@ -98,23 +95,23 @@ export interface RelatedRecordActionsBridgeProps {
  */
 function deriveActions(
   childDef: any,
-  actionLabel: ActionLabelFn,
+  localizeActionTexts: ActionTextLocalizer,
   location: 'list_item' | 'list_toolbar',
 ): RelatedRowActionDef[] {
   const actions = Array.isArray(childDef?.actions) ? childDef.actions : [];
   return actions
     .filter((a: any) => Array.isArray(a?.locations) && a.locations.includes(location))
-    .map((a: any) => ({
-      ...a,
-      label: actionLabel(childDef.name, a.name, a.label || a.name),
-    }));
+    // One bundle entry, one fate (objectui#4265): the row menu's label used to
+    // be the ONLY string resolved here, so `runRowAction` below dispatched the
+    // child action's `confirmText` / `successMessage` in the authored language
+    // next to a translated menu item.
+    .map((a: any) => localizeActionTexts(childDef.name, a) as RelatedRowActionDef);
 }
 
 export function RelatedRecordActionsBridge({
   appName,
   objects,
   dataSource,
-  actionLabel,
   parentObjectName,
   parentRecordId,
   parentTitle,
@@ -124,6 +121,12 @@ export function RelatedRecordActionsBridge({
   const { execute } = useAction();
   const [, setSearchParams] = useSearchParams();
   const { getObjectApiOperations, can } = usePermissions();
+  // The child action's authored strings go through the ONE shared resolver
+  // (objectui#4265). This used to arrive as an `actionLabel` prop injected by
+  // RecordDetailView — an injection point that could only ever carry the LABEL,
+  // which is precisely how the row menu ended up translated while its confirm
+  // dialog stayed in the authored language.
+  const localizeActionTexts = useActionTextLocalizer();
   const base = appName ? `/apps/${appName}` : '';
 
   // #2604 D3 — open a child create/edit task as the console's global record
@@ -247,7 +250,7 @@ export function RelatedRecordActionsBridge({
           };
         }
 
-        const rowActions = deriveActions(childDef, actionLabel, 'list_item');
+        const rowActions = deriveActions(childDef, localizeActionTexts, 'list_item');
         if (rowActions.length > 0) {
           handlers.rowActions = rowActions;
           handlers.onRowAction = (action, record) =>
@@ -258,7 +261,7 @@ export function RelatedRecordActionsBridge({
         // header buttons — the related-list equivalent of the object list's
         // toolbar. Executed through the same dispatch as row actions, just
         // without a row record.
-        const toolbarActions = deriveActions(childDef, actionLabel, 'list_toolbar');
+        const toolbarActions = deriveActions(childDef, localizeActionTexts, 'list_toolbar');
         if (toolbarActions.length > 0) {
           handlers.toolbarActions = toolbarActions;
           handlers.onToolbarAction = (action) =>
@@ -268,7 +271,7 @@ export function RelatedRecordActionsBridge({
         return handlers;
       },
     }),
-    [objects, base, navigate, dataSource, actionLabel, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle, getObjectApiOperations, can],
+    [objects, base, navigate, dataSource, localizeActionTexts, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle, getObjectApiOperations, can],
   );
 
   return (

--- a/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
+++ b/packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx
@@ -59,13 +59,17 @@ vi.mock('../../utils/getIcon', () => ({ getIcon: () => () => null }));
 // authored literal, which is what the render assertions below expect); the
 // bar's OWN chrome resolves through `t`. Marking `t` output makes it visible
 // whether a string went through the locale bundle or was baked in English.
+// (`useActionTextLocalizer` — the shared action-text resolver the bar calls
+// since objectui#4265 — is the REAL one from `@object-ui/react`; it reads these
+// three resolvers plus `pickLocalized`, so the double has to carry all four.)
 vi.mock('@object-ui/i18n', () => ({
   useObjectLabel: () => ({
     actionLabel: (_o: unknown, _n: unknown, fallback: string) => fallback,
     actionConfirm: (_o: unknown, _n: unknown, fallback?: string) => fallback,
     actionSuccess: (_o: unknown, _n: unknown, fallback?: string) => fallback,
   }),
-  useObjectTranslation: () => ({ t: (key: string) => `t:${key}` }),
+  useObjectTranslation: () => ({ t: (key: string) => `t:${key}`, language: 'en' }),
+  pickLocalized: (value: unknown) => (typeof value === 'string' ? value : ''),
 }));
 
 // The components barrel stays doubled (its full graph is what the light `dom`

--- a/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.effectiveOps.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RelatedRecordActionsBridge.effectiveOps.test.tsx
@@ -67,7 +67,6 @@ function resolveHandlers(): Record<string, boolean> {
         appName="crm"
         objects={objects}
         dataSource={{ delete: vi.fn() }}
-        actionLabel={(_o, _n, fallback) => fallback}
       >
         <Probe onResolve={(p) => { captured = p; }} />
       </RelatedRecordActionsBridge>

--- a/packages/components/src/__tests__/page-header-action-i18n.test.tsx
+++ b/packages/components/src/__tests__/page-header-action-i18n.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `page:header` actions — one bundle entry, one fate (objectui#4265).
+ *
+ * An AUTHORED record page embeds its action buttons on `page:header.actions`
+ * (the surface `page-header-actions.test.tsx` covers), and those defs reach
+ * this renderer straight from page metadata — no host pre-localizes them. The
+ * header used to resolve `label` through the `_actions.<name>.label`
+ * convention and then dispatch the SAME action's `confirmText` /
+ * `successMessage` untouched, which is the card's symptom exactly: the button
+ * renders 转化线索 while the confirm dialog body renders the authored English.
+ *
+ * These pins run the real ActionRunner (via `ActionProvider`) and read what the
+ * confirm handler and the toast handler actually receive.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider, RecordContextProvider } from '@object-ui/react';
+import { I18nProvider, useObjectTranslation } from '@object-ui/i18n';
+
+/** The authored action, as `src/actions/lead.actions.ts` declares it. */
+const CONVERT_LEAD = {
+  name: 'convert_lead',
+  type: 'custom-run',
+  label: 'Convert Lead',
+  confirmText: 'Are you sure you want to convert this lead?',
+  successMessage: 'Lead converted.',
+  locations: ['record_header'],
+};
+
+const ZH_BUNDLE = {
+  crm: {
+    objects: {
+      lead: {
+        _actions: {
+          convert_lead: {
+            label: '转化线索',
+            confirmText: '确认要转化此线索吗？',
+            successMessage: '线索转化成功！',
+          },
+        },
+      },
+    },
+  },
+};
+
+function PageHeader({ schema }: { schema: any }) {
+  const Component = ComponentRegistry.get('page:header');
+  if (!Component) throw new Error('page:header not registered');
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
+  return <Component schema={schema} />;
+}
+
+/**
+ * Loads the bundle into the live i18next instance before the header renders,
+ * so the first paint already sees it (no act() churn mid-assertion).
+ */
+function BundleLoader({ bundle, children }: { bundle: unknown; children: React.ReactNode }) {
+  const { i18n } = useObjectTranslation();
+  const [ready, setReady] = React.useState(!bundle);
+  React.useEffect(() => {
+    if (!bundle) return;
+    i18n.addResourceBundle('en', 'translation', bundle as Record<string, unknown>, true, true);
+    setReady(true);
+  }, [bundle, i18n]);
+  return ready ? <>{children}</> : null;
+}
+
+function renderHeader(opts: { bundle?: unknown; action?: Record<string, unknown> }) {
+  const onConfirm = vi.fn(async () => true);
+  const onToast = vi.fn();
+  const handler = vi.fn(async () => ({ success: true }));
+  const utils = render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <BundleLoader bundle={opts.bundle}>
+        <ActionProvider
+          onConfirm={onConfirm}
+          onToast={onToast}
+          handlers={{ 'custom-run': handler }}
+        >
+          <RecordContextProvider
+            objectName="lead"
+            recordId="lead_1"
+            data={{ id: 'lead_1', name: 'Ada' }}
+            objectSchema={{ name: 'lead', label: 'Lead' }}
+          >
+            <PageHeader
+              schema={{
+                type: 'page:header',
+                title: 'Lead',
+                actions: [opts.action ?? CONVERT_LEAD],
+              }}
+            />
+          </RecordContextProvider>
+        </ActionProvider>
+      </BundleLoader>
+    </I18nProvider>,
+  );
+  return { ...utils, onConfirm, onToast, handler };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('page:header actions — translated confirmText (objectui#4265)', () => {
+  it('renders the translated button AND opens the confirm dialog with the translated body', async () => {
+    const { onConfirm } = renderHeader({ bundle: ZH_BUNDLE });
+
+    const button = await screen.findByRole('button', { name: '转化线索' });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled());
+    // The reported defect: this argument used to be the authored English
+    // literal while the button above already read 转化线索.
+    expect(onConfirm.mock.calls[0][0]).toBe('确认要转化此线索吗？');
+  });
+
+  it('passes the translated successMessage to the toast', async () => {
+    const { onToast } = renderHeader({ bundle: ZH_BUNDLE });
+
+    fireEvent.click(await screen.findByRole('button', { name: '转化线索' }));
+
+    await waitFor(() => expect(onToast).toHaveBeenCalled());
+    expect(onToast.mock.calls[0][0]).toBe('线索转化成功！');
+  });
+
+  it('renders the authored strings when the bundle has no entry (control)', async () => {
+    const { onConfirm, onToast } = renderHeader({ bundle: undefined });
+
+    const button = await screen.findByRole('button', { name: 'Convert Lead' });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled());
+    expect(onConfirm.mock.calls[0][0]).toBe('Are you sure you want to convert this lead?');
+    await waitFor(() => expect(onToast).toHaveBeenCalled());
+    expect(onToast.mock.calls[0][0]).toBe('Lead converted.');
+  });
+
+  it('does not open a confirm dialog for an action that declares no confirmText', async () => {
+    const { confirmText: _c, ...noConfirm } = CONVERT_LEAD;
+    const { onConfirm, handler } = renderHeader({ bundle: ZH_BUNDLE, action: noConfirm });
+
+    fireEvent.click(await screen.findByRole('button', { name: '转化线索' }));
+
+    await waitFor(() => expect(handler).toHaveBeenCalled());
+    // A bundle entry must not be able to bolt a confirmation gate onto an
+    // action whose metadata never declared one.
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/__tests__/page-header-actions.test.tsx
+++ b/packages/components/src/__tests__/page-header-actions.test.tsx
@@ -537,8 +537,27 @@ describe('PageHeaderRenderer — record dispatch shape (objectui#3391)', () => {
     fireEvent.click(screen.getByRole('button', { name: /No Record/i }));
     await waitFor(() => expect(api).toHaveBeenCalledTimes(1));
     const dispatched: any = api.mock.calls[0][0];
-    expect(dispatched).toBe(action);
+    // Value-equal, not reference-equal. Since objectui#4265 every header action
+    // is run through the shared action-text localizer before it is rendered or
+    // dispatched, so what reaches the runner is always a localized COPY — which
+    // is what the record-context branch was already doing deliberately (see
+    // `dispatchHeaderAction`: a fresh object keeps the runner's in-place
+    // collected-params merge off the authored schema node). This case is about
+    // the SHAPE staying untouched outside a record context, and the assertion
+    // that carries that is the `params` pin below: no `_rowRecord` stash is
+    // added when there is no record. Identity was never the contract — it was
+    // how "unchanged" happened to be spelled when only the record branch
+    // rebuilt.
+    expect(dispatched).toStrictEqual(action);
     expect(dispatched.params).toBeUndefined();
+    // …and the authored node itself is not mutated on the way through.
+    expect(action).toStrictEqual({
+      name: 'no_record_3391',
+      type: 'api',
+      locations: ['record_header'],
+      label: 'No Record',
+      target: '/api/v1/misc/ping',
+    });
   });
 });
 

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { ComponentRegistry, ExpressionEvaluator, evalRowPredicate, getRecordDisplayName, toPredicateRecord } from '@object-ui/core';
 import type { ComponentInput } from '@object-ui/core';
 import { actionRendersAt } from '@object-ui/types';
-import { useRecordContext, useAction, useCapabilityGate, usePredicateScope, usePageVariables, useInlineEdit } from '@object-ui/react';
+import { useRecordContext, useAction, useCapabilityGate, usePredicateScope, usePageVariables, useInlineEdit, useActionTextLocalizer } from '@object-ui/react';
 import { renderChildren, cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { RelatedCountStore, useRelatedCountVersion } from '../../hooks/related-count-store';
@@ -975,7 +975,14 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   // [ADR-0066 D4 / framework#3923] Shared capability gate — see filterAction.
   const mayInvoke = useCapabilityGate();
   const isMobile = useIsMobile();
-  const { objectLabel: tObjectLabel, actionLabel: tActionLabel } = useObjectLabel();
+  const { objectLabel: tObjectLabel } = useObjectLabel();
+  // The ONE resolver for a declared action's authored strings (objectui#4265).
+  // This header used to localize `label` only — via `useObjectLabel().actionLabel`
+  // inline below — and dispatch the action's `confirmText` / `successMessage`
+  // untouched, so on an authored record page one bundle entry met two fates: the
+  // button rendered the translation and the confirm dialog rendered the English
+  // literal from the metadata.
+  const localizeActionTexts = useActionTextLocalizer();
   const { fieldOptionLabel } = useSafeFieldLabel();
   const { language } = useObjectTranslation();
   // Console-supplied chrome copy (objectstack#5407). `detail.moreActions` is
@@ -1128,7 +1135,7 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     [ctx?.data, headerPredicateScope, headerPredicateFields],
   );
 
-  const headerActions = React.useMemo<any[]>(() => {
+  const headerActionsRaw = React.useMemo<any[]>(() => {
     const recordData: any = ctx?.data;
     // The record binds three ways inside `evalRowPredicate` — `record.status`
     // (spec/canonical), bare `status` (the row-action shorthand) and
@@ -1262,6 +1269,35 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     // scope in this list rather than adding to it.
   }, [rawHeaderActions, hostSystemActions, ctx?.data, evalHeaderPredicate]);
 
+  /**
+   * Localize the surviving actions ONCE, here, so the button text and the
+   * dispatched def cannot disagree (objectui#4265).
+   *
+   * Both the display path (`resolveLabel` below) and the execution path
+   * (`dispatchHeaderAction` → ActionRunner, which reads `confirmText` for the
+   * confirm dialog body and `successMessage` for the toast) read this same
+   * list, so one localization covers both. Localizing after the filter/order
+   * memo keeps translation out of the predicate gates — a `visible` CEL is
+   * evaluated against the record, never against display text.
+   *
+   * Idempotent by construction: a host that already localized these actions
+   * (RecordDetailView's `recordHeaderActions`, which feeds the SYNTHESIZED page
+   * schema) passes the translated string back in as the bundle fallback, and
+   * the same key resolves to the same value. Only the authored-page path —
+   * where `schema.actions` reaches this renderer straight from page metadata —
+   * changes behaviour.
+   */
+  const headerActions = React.useMemo<any[]>(
+    () => headerActionsRaw.map((a: any, idx: number) =>
+      localizeActionTexts(ctx?.objectName, a, {
+        // Last-resort display text only; `ActionDef.name` is the translation
+        // key and the spec makes it required.
+        fallbackLabel: (typeof a?.id === 'string' && a.id) || `Action ${idx + 1}`,
+      }),
+    ),
+    [headerActionsRaw, localizeActionTexts, ctx?.objectName],
+  );
+
   // Dispatch shape for record-page header actions (objectui#3391) — the same
   // shape ObjectGrid row actions, RelatedRecordActionsBridge, and
   // DeclaredActionsBar use: stash the current record under `params._rowRecord`
@@ -1293,15 +1329,13 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
 
   const renderHeaderActions = () => {
     if (headerActions.length === 0) return null;
-    // Resolve a translated label for an action via the
-    // `{ns}.objects.{objectName}._actions.{name}.label` convention. Falls
-    // back to authored `action.label`, then `action.name`.
-    const resolveLabel = (action: any, idx: number) => {
-      const key = (action?.name || action?.id) as string | undefined;
-      const fallback = action?.label || key || `Action ${idx + 1}`;
-      if (!key) return fallback;
-      return tActionLabel(ctx?.objectName, key, fallback);
-    };
+    // The label is already resolved — the `headerActions` memo above ran every
+    // action through the shared localizer (`{ns}.objects.{objectName}
+    // ._actions.{name}.label`, authored literal as fallback), together with the
+    // `confirmText` / `successMessage` that ride the same dispatch. Reading it
+    // back off the def is what keeps the button and the confirm dialog on one
+    // bundle entry (objectui#4265).
+    const resolveLabel = (action: any) => action?.label ?? '';
     // Inline/overflow split (objectui#2361) — up to `maxVisible` actions
     // render side-by-side as buttons; the rest collapse into a `⋯` overflow
     // menu. Which actions stay inline is metadata-driven:
@@ -1369,7 +1403,7 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       (inlineEditing && action?.disableDuringInlineEdit === true) ||
       resolveDisabled(action?.disabled, action?.name ?? action?.id);
     const renderButton = (action: any, idx: number) => {
-      const label = resolveLabel(action, idx);
+      const label = resolveLabel(action);
       // `variant: 'primary'` is valid ActionSchema but not a Shadcn Button
       // variant — map it to `default` (same as action-button.tsx).
       const variant = action.variant === 'primary' ? 'default' : (action.variant || 'default');
@@ -1417,7 +1451,7 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-44">
               {overflowActions.map((action, idx) => {
-                const label = resolveLabel(action, idx + inlineActions.length);
+                const label = resolveLabel(action);
                 const disabled = isActionDisabled(action);
                 const icon = typeof action.icon === 'string' ? action.icon : null;
                 const isDestructive =

--- a/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.actionText-i18n.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.actionText-i18n.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:quick_actions` — one bundle entry, one fate (objectui#4265).
+ *
+ * This bar resolved the button `label` through the `_actions.<name>.label`
+ * convention, but `executeAction(name)` ran the def straight out of the array
+ * it was given — so the ActionRunner saw the AUTHORED `confirmText` /
+ * `successMessage` while the button beside it already read the translation.
+ * That is the card's "same entry, two fates" verbatim.
+ *
+ * Nothing about the resolution is stubbed: a real `I18nProvider` holds the
+ * zh-CN bundle, a real `ActionProvider` runs the real ActionRunner, and the
+ * assertions read what the confirm / toast handlers actually received.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ActionProvider, RecordContextProvider } from '@object-ui/react';
+import { I18nProvider, useObjectTranslation } from '@object-ui/i18n';
+import { RecordQuickActionsRenderer } from '../record-quick-actions';
+
+/** The authored action, as `src/actions/lead.actions.ts` declares it. */
+const CONVERT_LEAD = {
+  name: 'convert_lead',
+  type: 'custom-run',
+  label: 'Convert Lead',
+  confirmText: 'Are you sure you want to convert this lead?',
+  successMessage: 'Lead converted.',
+  locations: ['record_header'],
+};
+
+const ZH_BUNDLE = {
+  crm: {
+    objects: {
+      lead: {
+        _actions: {
+          convert_lead: {
+            label: '转化线索',
+            confirmText: '确认要转化此线索吗？',
+            successMessage: '线索转化成功！',
+          },
+        },
+      },
+    },
+  },
+};
+
+function BundleLoader({ bundle, children }: { bundle?: unknown; children: React.ReactNode }) {
+  const { i18n } = useObjectTranslation();
+  const [ready, setReady] = React.useState(!bundle);
+  React.useEffect(() => {
+    if (!bundle) return;
+    i18n.addResourceBundle('en', 'translation', bundle as Record<string, unknown>, true, true);
+    setReady(true);
+  }, [bundle, i18n]);
+  return ready ? <>{children}</> : null;
+}
+
+function mount(opts: { bundle?: unknown; action?: Record<string, unknown> } = {}) {
+  const onConfirm = vi.fn(async () => true);
+  const onToast = vi.fn();
+  const handler = vi.fn(async () => ({ success: true }));
+  const utils = render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <BundleLoader bundle={opts.bundle}>
+        <ActionProvider onConfirm={onConfirm} onToast={onToast} handlers={{ 'custom-run': handler }}>
+          <RecordContextProvider objectName="lead" recordId="lead_1" data={{ id: 'lead_1' }}>
+            <RecordQuickActionsRenderer
+              schema={{ actions: [opts.action ?? CONVERT_LEAD] } as any}
+            />
+          </RecordContextProvider>
+        </ActionProvider>
+      </BundleLoader>
+    </I18nProvider>,
+  );
+  return { ...utils, onConfirm, onToast, handler };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('record:quick_actions — translated confirmText (objectui#4265)', () => {
+  it('resolves the button AND the confirm dialog body from the same bundle entry', async () => {
+    const { onConfirm } = mount({ bundle: ZH_BUNDLE });
+
+    fireEvent.click(await screen.findByRole('button', { name: '转化线索' }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled());
+    expect(onConfirm.mock.calls[0][0]).toBe('确认要转化此线索吗？');
+  });
+
+  it('resolves successMessage from the same entry', async () => {
+    const { onToast } = mount({ bundle: ZH_BUNDLE });
+
+    fireEvent.click(await screen.findByRole('button', { name: '转化线索' }));
+
+    await waitFor(() => expect(onToast).toHaveBeenCalled());
+    expect(onToast.mock.calls[0][0]).toBe('线索转化成功！');
+  });
+
+  it('falls back to the authored strings with no bundle entry (control)', async () => {
+    const { onConfirm, onToast } = mount();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Convert Lead' }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled());
+    expect(onConfirm.mock.calls[0][0]).toBe('Are you sure you want to convert this lead?');
+    await waitFor(() => expect(onToast).toHaveBeenCalled());
+    expect(onToast.mock.calls[0][0]).toBe('Lead converted.');
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-quick-actions.tsx
+++ b/packages/plugin-detail/src/renderers/record-quick-actions.tsx
@@ -16,8 +16,7 @@
  */
 
 import React from 'react';
-import { useRecordContext, useActionEngine, useMetadataItem, useCondition, toPredicateInput, useSafeFieldLabel } from '@object-ui/react';
-import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
+import { useRecordContext, useActionEngine, useMetadataItem, useCondition, toPredicateInput, useActionTextLocalizer } from '@object-ui/react';
 import { usePermissions } from '@object-ui/permissions';
 import { Button, cn, hasDeclaredVisibilityGate } from '@object-ui/components';
 import { Loader2 } from 'lucide-react';
@@ -52,8 +51,12 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
   const ctx = useRecordContext();
   const { designer } = splitDesigner(props);
   const perms = usePermissions();
-  const { language } = useObjectTranslation();
-  const i18n = useSafeFieldLabel();
+  // The ONE resolver for a declared action's authored strings (objectui#4265).
+  // This bar used to localize the button `label` only, while `executeAction`
+  // ran the RAW def looked up out of the object's metadata — so its confirm
+  // dialog rendered the authored English `confirmText` next to a translated
+  // button, from the same `_actions.<name>` bundle entry.
+  const localizeActionTexts = useActionTextLocalizer();
 
   // Spec bridge inlines `properties.*` onto the node but also preserves the
   // raw bag. Read from both for compatibility.
@@ -82,7 +85,7 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
   const needsLookup = namesToResolve.length > 0 && !!objectName;
   const { item: objectMeta } = useMetadataItem('object', needsLookup ? objectName : null);
 
-  const actions: ActionDef[] = needsLookup
+  const authoredActions: ActionDef[] = needsLookup
     ? (() => {
         const all: ActionDef[] = Array.isArray(objectMeta?.actions) ? objectMeta!.actions : [];
         const byName = new Map(all.map((a) => [a.name, a]));
@@ -91,6 +94,20 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
           .filter((a): a is ActionDef => !!a);
       })()
     : (Array.isArray(rawActions) ? (rawActions as ActionDef[]) : []);
+
+  /**
+   * Localize once, before the defs reach `useActionEngine` (objectui#4265).
+   *
+   * `executeAction(name)` runs the def out of THIS array, and the button below
+   * renders `action.label` out of the same array — so localizing here is what
+   * keeps the button and the confirm dialog on one bundle entry. Resolving only
+   * the display label (what this renderer used to do) left `executeAction`
+   * dispatching the untranslated `confirmText` / `successMessage` straight from
+   * the object's metadata.
+   */
+  const actions: ActionDef[] = authoredActions.map((a, idx) =>
+    localizeActionTexts(objectName || undefined, a, { fallbackLabel: `Action ${idx + 1}` }),
+  );
   const required: string[] = Array.isArray(schema.requiredPermissions)
     ? schema.requiredPermissions
     : [];
@@ -166,10 +183,9 @@ export const RecordQuickActionsRenderer: React.FC<RecordQuickActionsRendererProp
           record={ctx?.data}
           variant={(action as any).variant || schema.variant || 'default'}
           size={(action as any).size || schema.size || 'sm'}
-          label={(() => {
-            const raw = pickLocalized(action.label, language) || action.name || `Action ${idx + 1}`;
-            return action.name ? (i18n as any).actionLabel(objectName || undefined, action.name, raw) : raw;
-          })()}
+          // Already resolved (with the confirm/success strings that ride the
+          // same dispatch) in the `actions` memo above — objectui#4265.
+          label={(action.label as string) || `Action ${idx + 1}`}
           onRun={async () => {
             if (typeof action.onClick === 'function') await action.onClick();
             else if (action.name) await executeAction(action.name);

--- a/packages/react/src/hooks/__tests__/useActionTextLocalizer.test.tsx
+++ b/packages/react/src/hooks/__tests__/useActionTextLocalizer.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `useActionTextLocalizer` (objectui#4265) — one bundle entry, one fate.
+ *
+ * The card's shape verbatim: a zh-CN bundle translates `convert_lead`
+ * completely (label + confirmText + successMessage under the SAME
+ * `_actions.convert_lead` node), and the reported defect was that the button
+ * picked up `label` while the confirm dialog rendered the authored English
+ * `confirmText`. These pins assert the three keys of one entry resolve
+ * together, and that an entry which is absent (or lacks a key) leaves the
+ * authored literal in place.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { I18nProvider, useObjectTranslation } from '@object-ui/i18n';
+import { useActionTextLocalizer } from '../useActionTextLocalizer';
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    I18nProvider,
+    { config: { defaultLanguage: 'en', detectBrowserLanguage: false } },
+    children,
+  );
+
+/** The authored action, exactly as `src/actions/lead.actions.ts` declares it. */
+const CONVERT_LEAD = {
+  name: 'convert_lead',
+  type: 'api',
+  label: 'Convert Lead',
+  confirmText: 'Are you sure you want to convert this lead?',
+  successMessage: 'Lead converted.',
+  locations: ['record_header'],
+};
+
+function setup() {
+  const { result } = renderHook(
+    () => ({ localize: useActionTextLocalizer(), i18n: useObjectTranslation().i18n }),
+    { wrapper },
+  );
+  result.current.i18n.addResourceBundle(
+    'en',
+    'translation',
+    {
+      crm: {
+        objects: {
+          lead: {
+            _actions: {
+              // The card's bundle entry — all three keys, one node.
+              convert_lead: {
+                label: '转化线索',
+                confirmText: '确认要转化此线索吗？',
+                successMessage: '线索转化成功！',
+              },
+              // An entry that translates the button only, so the per-key
+              // fallback is pinned separately from the no-entry case.
+              label_only: { label: '仅标签' },
+            },
+          },
+        },
+      },
+    },
+    true,
+    true,
+  );
+  return result;
+}
+
+describe('useActionTextLocalizer — one entry, three keys (objectui#4265)', () => {
+  it('resolves label, confirmText and successMessage from the SAME bundle entry', () => {
+    const result = setup();
+    const localized = result.current.localize('lead', CONVERT_LEAD);
+    expect(localized.label).toBe('转化线索');
+    // The reported defect: this used to stay English while `label` above went
+    // Chinese, on the same render, from the same entry.
+    expect(localized.confirmText).toBe('确认要转化此线索吗？');
+    expect(localized.successMessage).toBe('线索转化成功！');
+  });
+
+  it('falls back to the authored literals when the bundle has no entry (control)', () => {
+    const result = setup();
+    const localized = result.current.localize('lead', { ...CONVERT_LEAD, name: 'no_entry' });
+    expect(localized.label).toBe('Convert Lead');
+    expect(localized.confirmText).toBe('Are you sure you want to convert this lead?');
+    expect(localized.successMessage).toBe('Lead converted.');
+  });
+
+  it('falls back per key when the entry translates the label only', () => {
+    const result = setup();
+    const localized = result.current.localize('lead', { ...CONVERT_LEAD, name: 'label_only' });
+    expect(localized.label).toBe('仅标签');
+    expect(localized.confirmText).toBe('Are you sure you want to convert this lead?');
+    expect(localized.successMessage).toBe('Lead converted.');
+  });
+
+  it('does not invent a confirmText the metadata never declared', () => {
+    const result = setup();
+    const { confirmText: _c, successMessage: _s, ...noConfirm } = CONVERT_LEAD;
+    const localized = result.current.localize('lead', noConfirm);
+    expect(localized.label).toBe('转化线索');
+    // A bundle must not bolt a confirmation gate (or a toast) onto an action
+    // whose metadata never asked for one.
+    expect('confirmText' in localized).toBe(false);
+    expect('successMessage' in localized).toBe(false);
+  });
+
+  it('leaves a nameless action untranslated (no key exists) but normalizes its label', () => {
+    const result = setup();
+    const localized = result.current.localize('lead', {
+      type: 'api',
+      confirmText: 'Are you sure?',
+    } as Record<string, any>, { fallbackLabel: 'Action 3' });
+    expect(localized.label).toBe('Action 3');
+    expect(localized.confirmText).toBe('Are you sure?');
+  });
+
+  it('collapses an I18nLabel map before offering it to the bundle as the fallback', () => {
+    const result = setup();
+    const localized = result.current.localize('lead', {
+      name: 'no_entry',
+      label: { en: 'Convert Lead', 'zh-CN': '转化线索(内联)' },
+      confirmText: 'Are you sure?',
+    } as Record<string, any>);
+    // Active language is `en` here, so the map's `en` arm is the authored text.
+    expect(localized.label).toBe('Convert Lead');
+  });
+});

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -37,6 +37,9 @@ export * from './useSchemaPersistence';
 export * from './useGlobalUndo';
 export * from './useDebugMode';
 export * from './useActionEngine';
+// The ONE application of `useObjectLabel`'s action resolvers over the three
+// authored strings an action carries (label / confirmText / successMessage).
+export * from './useActionTextLocalizer';
 export * from './useCapabilityGate';
 export * from './useDataRefresh';
 export * from './usePageAssignment';

--- a/packages/react/src/hooks/useActionTextLocalizer.ts
+++ b/packages/react/src/hooks/useActionTextLocalizer.ts
@@ -1,0 +1,119 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `useActionTextLocalizer` — the ONE place a declared action's authored,
+ * user-visible strings are resolved against the active locale's bundle.
+ *
+ * ## Why this hook exists (objectui#4265)
+ *
+ * A TranslationBundle entry for an action carries THREE keys, all under the
+ * same `_actions.<name>.*` node:
+ *
+ * ```ts
+ * convert_lead: {
+ *   label: '...',           // the button
+ *   confirmText: '...',     // the confirm dialog BODY
+ *   successMessage: '...',  // the success toast
+ * }
+ * ```
+ *
+ * `useObjectLabel()` has always exposed a resolver for each of them
+ * (`actionLabel` / `actionConfirm` / `actionSuccess`, one `resolve()` and one
+ * key convention behind all three). What drifted is the CALL SITES: some
+ * render surfaces called all three, others called only `actionLabel`. On those
+ * surfaces one bundle entry met two fates — the button rendered the
+ * translation while the confirm dialog rendered the authored English literal,
+ * which is exactly what objectui#4265 reports.
+ *
+ * So this is deliberately NOT a new resolution dialect. It is a single
+ * application of the existing resolvers over the three keys, so a surface can
+ * no longer localize one of them and forget the others: there is one function
+ * to call, and it can only do all three.
+ *
+ * ## Pinned semantics
+ *
+ * - **Fallback**: no bundle entry, or an entry lacking the key, renders the
+ *   AUTHORED text. That is `useObjectLabel`'s own fallback contract; nothing
+ *   here overrides it.
+ * - **A nameless action is not translatable.** Without `action.name` there is
+ *   no `_actions.<name>` key to look up, so the literals pass through.
+ * - **`confirmText` / `successMessage` are resolved only when the action
+ *   DECLARES them.** A bundle must not be able to bolt a confirmation gate
+ *   onto an action whose metadata never asked for one (nor a success toast).
+ *   Translation localizes what exists; it does not add behaviour. This mirrors
+ *   what the already-correct call sites (`RecordDetailView`, `ObjectView`,
+ *   `DeclaredActionsBar`) each spelled out by hand.
+ * - **`label` is reduced through `pickLocalized` first**, because since rc.6 an
+ *   authored `label` may be an `I18nLabel` map rather than a string. The map is
+ *   collapsed to the active language BEFORE it is offered to the bundle as the
+ *   fallback, so a per-locale literal and a bundle entry cannot disagree about
+ *   what "the authored label" is.
+ */
+
+import { useMemo } from 'react';
+import { useObjectLabel, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
+
+export interface ActionTextLocalizerOptions {
+  /**
+   * Last-resort display text, used only when the action declares neither a
+   * `label` nor a `name` (e.g. a positional `Action 3` placeholder).
+   */
+  fallbackLabel?: string;
+}
+
+/**
+ * Returns a copy of `action` with `label` — plus `confirmText` and
+ * `successMessage` when the action declares them — resolved from the active
+ * locale's bundle, falling back to the authored literals.
+ */
+export type ActionTextLocalizer = <T extends Record<string, any>>(
+  objectName: string | undefined,
+  action: T,
+  options?: ActionTextLocalizerOptions,
+) => T;
+
+export function useActionTextLocalizer(): ActionTextLocalizer {
+  const { actionLabel, actionConfirm, actionSuccess } = useObjectLabel();
+  const { language } = useObjectTranslation();
+
+  return useMemo<ActionTextLocalizer>(() => {
+    return (<T extends Record<string, any>>(
+      objectName: string | undefined,
+      action: T,
+      options?: ActionTextLocalizerOptions,
+    ): T => {
+      if (!action || typeof action !== 'object') return action;
+
+      // An `I18nLabel` map collapses to the active language here, so what the
+      // bundle receives as its fallback is always a plain string.
+      const authoredLabel = pickLocalized((action as any).label, language);
+      const name = typeof (action as any).name === 'string' && (action as any).name
+        ? ((action as any).name as string)
+        : undefined;
+      const displayLabel = authoredLabel || name || options?.fallbackLabel || '';
+
+      // No name, no translation key: the literals are the answer. The label is
+      // still normalized (map to string, last-resort placeholder applied) so
+      // every caller reads one shape.
+      if (!name) {
+        return displayLabel === (action as any).label ? action : { ...action, label: displayLabel };
+      }
+
+      const out: Record<string, any> = {
+        ...action,
+        label: actionLabel(objectName, name, displayLabel),
+      };
+      if ((action as any).confirmText !== undefined) {
+        out.confirmText = actionConfirm(objectName, name, (action as any).confirmText);
+      }
+      if ((action as any).successMessage !== undefined) {
+        out.successMessage = actionSuccess(objectName, name, (action as any).successMessage);
+      }
+      return out as T;
+    }) as ActionTextLocalizer;
+  }, [actionLabel, actionConfirm, actionSuccess, language]);
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -96,6 +96,7 @@ const heavyDomTests = [
   'packages/components/src/__tests__/action-bar.test.tsx',
   'packages/components/src/__tests__/action-group.test.tsx',
   'packages/components/src/__tests__/page-card-i18n-title.test.tsx',
+  'packages/components/src/__tests__/page-header-action-i18n.test.tsx',
   'packages/components/src/__tests__/page-header-actions.test.tsx',
   'packages/components/src/__tests__/page-header-capability-gate.test.tsx',
   'packages/components/src/__tests__/page-header-lookup-predicate.test.tsx',


### PR DESCRIPTION
Fixes #4265

## The measurement first

`useObjectLabel()` has always exposed a resolver for all three keys a
TranslationBundle action entry carries — `actionLabel` / `actionConfirm` /
`actionSuccess`, one `resolve()` and one key convention behind all three
(`{ns}.objects.{obj}._actions.{name}.{label|confirmText|successMessage}`).
The channel was never missing. What had drifted was the **call sites**:

| Surface | label | confirmText / successMessage |
|---|---|---|
| `RecordDetailView` record header | resolved | resolved |
| `ObjectView` toolbar + row kebab | resolved | resolved |
| `DeclaredActionsBar` | resolved | resolved |
| **`page:header` actions** (authored record pages) | resolved | **raw** |
| **`record:quick_actions`** | resolved | **raw** |
| **related-list row menu** | resolved | **raw** |

The three bottom rows are the card's "same entry, two fates": the button
picked up the bundle, the confirm dialog and the toast got the authored
English. `page:header` is the surface an AUTHORED record page uses — its
`schema.actions` reach the renderer straight from page metadata with no host
to pre-localize them — and `record:quick_actions` resolves its defs by name
out of the object's own metadata, which is where the card's
`src/actions/lead.actions.ts` text comes from.

The confirm plumbing named in triage (`useObjectActions.ts:28` →
`views/ActionConfirmDialog.tsx:23`) turned out to be a faithful carrier: it
passes through whatever string the runner hands it. The defect was upstream of
it, at the point where the def is built.

## The fix

One resolver, not an N+1th dialect. New `useActionTextLocalizer()` in
`@object-ui/react` is a single application of the **existing**
`useObjectLabel()` resolvers over the three keys — so a surface can no longer
localize one and forget the others; there is one function to call and it can
only do all three. Every action-rendering surface now calls it, including the
three that were already correct, and `RelatedRecordActionsBridge` loses its
`actionLabel` prop — an injection point that could only ever carry the label.

Pinned semantics (unchanged fallback contract):

- no bundle entry, or an entry lacking a key ⇒ the **authored** text renders;
- a nameless action has no `_actions` key of its own, so its literals pass through;
- `confirmText` / `successMessage` are resolved **only when the action declares
  them** — a bundle must not be able to bolt a confirmation gate or a toast
  onto an action whose metadata never asked for one;
- `label` is reduced through `pickLocalized` first, since an authored `label`
  may be an `I18nLabel` map since rc.6.

## Reverse verification — prediction stated before running

Reverting only the two consumer surfaces (helper and tests kept) was predicted
to turn the four translated-confirm/toast pins RED while both no-bundle
controls stayed GREEN. That is exactly what happened — 4 failed, 3 passed:

```
AssertionError: expected 'Are you sure you want to convert this…' to be '确认要转化此线索吗？'
AssertionError: expected 'Lead converted.' to be '线索转化成功！'
Test Files  2 failed (2)
     Tests  4 failed | 3 passed (7)
```

The detail that makes this the card's bug rather than a neighbouring one: on
the reverted code the buttons were **still found by their Chinese name**
(`findByRole({ name: '转化线索' })` never failed) while the confirm body came
back English. Label resolved, confirmText did not — one entry, two fates.

## Tests

New pins run the real `I18nProvider` (real bundle) and the real `ActionRunner`,
asserting what the confirm and toast handlers actually receive:

- `packages/react/src/hooks/__tests__/useActionTextLocalizer.test.tsx` — the
  three keys of one entry; per-key fallback; no-entry control; "does not invent
  a confirmText"; nameless action; `I18nLabel` collapse.
- `packages/components/src/__tests__/page-header-action-i18n.test.tsx`
- `packages/plugin-detail/src/renderers/__tests__/record-quick-actions.actionText-i18n.test.tsx`

One existing fixture was re-spelled rather than deleted:
`page-header-actions.test.tsx` "dispatches unchanged outside a record context"
asserted `toBe(action)` — reference identity. Every header action now goes
through the localizer, so both branches dispatch a localized copy, which is
what the record branch already did deliberately (a fresh object keeps the
runner's in-place params merge off the authored node). The case's real content
— no `_rowRecord` stash without a record — is unchanged, and it gained an
assertion that the authored node is not mutated.

## Verification run

- `pnpm exec vitest run packages/react packages/components packages/plugin-detail packages/app-shell`
  → **5618 passed, 1 skipped, 575 files** (the single failure in the first pass
  was the identity fixture above; re-spelled and green).
- `type-check` (both `tsc` commands each) green on `@object-ui/react`,
  `@object-ui/components`, `@object-ui/plugin-detail`, `@object-ui/app-shell`.
- **Downstream consumer sweep** — `pnpm --filter '...@object-ui/react' --filter
  '...@object-ui/components' type-check`, i.e. the PREFIX/consumer direction,
  33 downstream packages including `apps/console` and the examples: green after
  a full build closure. (The first two passes failed only on unbuilt `dist/`
  for packages this PR does not touch.)
- Cross-package type change reverse-verified: re-adding the removed
  `actionLabel` prop to the bridge mount goes red with
  `TS2322: … not assignable to type 'IntrinsicAttributes &
  RelatedRecordActionsBridgeProps'`, then restored — so the narrowed props type
  is genuinely being read, not a cached `.d.ts`.
- Gates on this surface: `check:i18n-keys`, `check:i18n-drift`,
  `check:action-forward-parity`, `check:control-bytes` — all green.
- `lint` on the four packages: **0 errors** (warnings are the repo baseline).

Changeset: `patch` for the four packages (never `major`, per the fixed-group
rule).


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_