### PR TITLE
fix(components): restore the excess-property check on the two action forward literals that lost it, and gate the property

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,22 @@
+---
+---
+
+Compile-time only, no published behaviour change (objectui#4281).
+
+`action:button` and `action:icon` composed their `execute({ … })` payload as a
+single object literal that spread `localContext`. That binding is `any`, and a
+literal spreading an `any` is not excess-property checked — so those two
+renderers absorbed invented and misspelled action keys in silence while
+`action:group` and `action:menu`, whose payloads carry no spread, rejected them
+with `TS2353`. `ActionDef` being a closed surface (objectui#4046) bought those
+two sites nothing.
+
+Their explicit keys now live in an `ActionDef`-annotated binding, with the
+spreads composed around it, which restores the check. The object that reaches
+the runner is unchanged — the same keys, the same values, the same insertion
+order, and the same "host context overrides the authored key" precedence, each
+pinned in `action-forward-precedence.test.tsx`.
+
+`check:action-forward-parity` now enforces the property structurally, so a
+renderer added with the unchecked shape fails CI instead of silently reopening
+the hole.

--- a/packages/components/src/renderers/action/__tests__/action-forward-precedence.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-forward-precedence.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4281 — the hoist that restored the compiler's excess-property check
+ * must not have changed what reaches the runner.
+ *
+ * `action:button` and `action:icon` used to compose their payload as ONE literal
+ * with the spreads inline:
+ *
+ *   execute({ type, name, …, ...paramsPayload, …, resultDialog, ...localContext })
+ *
+ * A literal that spreads an `any` is not excess-property checked (`localContext`
+ * is `any` — `PropsWithoutRef` collapses these index-signature props interfaces),
+ * so an invented key was absorbed in silence while `action:group` / `action:menu`
+ * rejected it. The fix hoists the explicit keys into an `ActionDef`-annotated
+ * binding and composes the spreads around it.
+ *
+ * That is a REFACTOR of an object literal, and object literals have two
+ * observable properties a refactor can silently change — which key wins a
+ * collision, and what order the keys end up in. Both are pinned here.
+ *
+ * ## What the collision semantics actually are (measured, not assumed)
+ *
+ *   `...localContext` is spread LAST, so a host-supplied context key OVERRIDES
+ *   the authored action's own value for that key. That is pre-existing
+ *   behaviour and is deliberately preserved: `context` is documented as an
+ *   "Override context for this specific action".
+ *
+ *   `...paramsPayload` (`action:button` only) can carry only `params` or
+ *   `actionParams`, and NEITHER is an explicit key of the surrounding literal —
+ *   the two key sets are disjoint, so its position cannot decide a collision.
+ *   It is nonetheless kept in its original position, so the resulting key ORDER
+ *   is unchanged too, and that is asserted rather than argued.
+ *
+ * ## Why key ORDER is worth pinning and not over-pinning
+ *
+ * Nothing in the runner reads `Object.keys(def)` today, so order is not a
+ * contract — but it is the sharpest available evidence that the composition is
+ * byte-for-byte what it was. Moving `...paramsPayload` to the end (the obvious
+ * way to write this fix) changes the order and nothing else; without this
+ * assertion that refactor would be indistinguishable from the correct one.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider } from '@object-ui/react';
+// Module-scope side-effect imports — the light `dom` project does not load the
+// `@object-ui/components` graph, and these renderers register themselves on
+// import. Module scope, not a `beforeAll`, per AGENTS.md §测试纪律.
+import '../action-button';
+import '../action-icon';
+
+/**
+ * A declaration touching every key whose FORWARD ORDER the hoist could have
+ * disturbed. `params` is a plain object (a values map), so `action:button` takes
+ * the `{ params }` branch of `paramsPayload` — the branch that sits mid-literal.
+ */
+const ACTION = {
+  name: 'create_environment',
+  type: 'api',
+  label: 'Create Environment',
+  description: 'Provision a new environment for this project',
+  target: 'authoredTarget',
+  openIn: 'new-tab',
+  endpoint: '/api/v1/environments',
+  method: 'POST',
+  params: { region: 'eu-west-1' },
+  bodyExtra: { source: 'console' },
+  bodyShape: { wrap: 'data' },
+  locations: ['list_toolbar'],
+};
+
+/** The host's override bag: one COLLIDING key, one the action never declared. */
+const CONTEXT = { target: 'contextWins', extraFromHost: 'present' };
+
+/**
+ * The exact key order `action:button` composes, top to bottom of its literal.
+ * `params` sits where `...paramsPayload` sits — ninth, not last.
+ */
+const BUTTON_ORDER = [
+  'type', 'name', 'label', 'description', 'target', 'openIn', 'endpoint', 'method',
+  'params',
+  'bodyExtra', 'bodyShape', 'confirmText', 'successMessage', 'errorMessage', 'refreshAfter',
+  'undoable', 'recordIdField', 'locations', 'toast', 'resultDialog',
+];
+
+/** `action:icon` has no `paramsPayload`; `params` is an ordinary explicit key. */
+const ICON_ORDER = [
+  'type', 'name', 'label', 'description', 'target', 'openIn', 'endpoint', 'method',
+  'params',
+  'bodyExtra', 'bodyShape', 'confirmText', 'successMessage', 'errorMessage', 'refreshAfter',
+  'locations', 'toast', 'resultDialog',
+];
+
+let api: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  api = vi.fn(async () => ({ success: true }));
+});
+
+function Renderer({ type, context }: { type: string; context?: Record<string, any> }) {
+  const C = ComponentRegistry.get(type);
+  if (!C) throw new Error(`${type} is not registered`);
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered renderer (stable reference), not a component created during render
+  return <C schema={{ ...ACTION, type: 'api' }} context={context} />;
+}
+
+/** Renders the surface, fires the click, and returns the def the runner got. */
+async function forwarded(type: string, context?: Record<string, any>): Promise<Record<string, any>> {
+  const { container } = render(
+    <ActionProvider handlers={{ api }}>
+      <Renderer type={type} context={context} />
+    </ActionProvider>,
+  );
+  const button = container.querySelector('button');
+  expect(button, `${type} rendered no button`).not.toBeNull();
+  fireEvent.click(button!);
+  await waitFor(() => expect(api).toHaveBeenCalledTimes(1));
+  // The runner hands the handler the very object the renderer composed
+  // (`handler(action, this.context)`, ActionRunner.ts:1014) — no copy, so key
+  // order survives the hop and this assertion is about the literal itself.
+  return api.mock.calls[0][0] as Record<string, any>;
+}
+
+describe.each([
+  ['action:button', BUTTON_ORDER],
+  ['action:icon', ICON_ORDER],
+])('%s composes its forward payload unchanged by the #4281 hoist', (surface, order) => {
+  it('forwards exactly the declared key set, in the declared order', async () => {
+    const def = await forwarded(surface);
+    expect(Object.keys(def)).toEqual(order);
+  });
+
+  it('carries the authored values through', async () => {
+    const def = await forwarded(surface);
+    expect({
+      name: def.name,
+      label: def.label,
+      description: def.description,
+      target: def.target,
+      endpoint: def.endpoint,
+      method: def.method,
+      params: def.params,
+      bodyExtra: def.bodyExtra,
+      bodyShape: def.bodyShape,
+    }).toEqual({
+      name: 'create_environment',
+      label: 'Create Environment',
+      description: 'Provision a new environment for this project',
+      target: 'authoredTarget',
+      endpoint: '/api/v1/environments',
+      method: 'POST',
+      params: { region: 'eu-west-1' },
+      bodyExtra: { source: 'console' },
+      bodyShape: { wrap: 'data' },
+    });
+  });
+
+  it('lets the host context OVERRIDE a declared key — `...localContext` is still merged last', async () => {
+    // The one live collision this composition admits. Pinned in both directions:
+    // the colliding key takes the context's value, and a key only the context
+    // carries still arrives. If the hoist had merged `localContext` before the
+    // explicit keys, the first assertion would read `authoredTarget`.
+    const def = await forwarded(surface, CONTEXT);
+    expect(def.target).toBe('contextWins');
+    expect(def.extraFromHost).toBe('present');
+  });
+
+  it('appends context-only keys after the declared ones, without moving the collided key', async () => {
+    // JS spread semantics, pinned because they are what makes the assertion
+    // above safe: an overriding key keeps its ORIGINAL position (only its value
+    // changes) and a novel key is appended.
+    const def = await forwarded(surface, CONTEXT);
+    expect(Object.keys(def)).toEqual([...order, 'extraFromHost']);
+    expect(Object.keys(def).indexOf('target')).toBe(order.indexOf('target'));
+  });
+});

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -19,6 +19,7 @@
 
 import React, { forwardRef, useCallback, useState } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
+import type { ActionDef } from '@object-ui/core';
 import type { ActionSchema } from '@object-ui/types';
 import { useAction } from '@object-ui/react';
 import { useCondition, toPredicateInput, usePredicateRecordContext } from '@object-ui/react';
@@ -89,11 +90,37 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
         // Route params correctly:
         // - Array of objects with name+type → ActionParamDef[] → pass as actionParams for collection
         // - Otherwise → pass as actual param values
-        const paramsPayload = Array.isArray(schema.params)
+        //
+        // Annotated rather than inferred: a spread SOURCE's own keys are not
+        // excess-property checked through the spread, so an invented key in
+        // either branch would be absorbed silently. Measured on objectui#4281 —
+        // `const p = cond ? { actionParams } : { zzBogus }` is accepted by an
+        // `ActionDef` literal that spreads it; annotating `p` rejects it here.
+        const paramsPayload: ActionDef = Array.isArray(schema.params)
           ? { actionParams: schema.params as any }
           : { params: schema.params as Record<string, any> | undefined };
 
-        await execute({
+        // ── Why this is a named `ActionDef` binding and not an inline literal ──
+        //
+        // `ActionDef` is CLOSED (objectui#4046 / objectstack#4075 step 3), so an
+        // invented or misspelled key at a forward site is a TS2353 — but only
+        // where TypeScript actually RUNS the excess-property (freshness) check.
+        // It does not run it on a literal that spreads a value of type `any`,
+        // and `localContext` is exactly that: `PropsWithoutRef` collapses
+        // `ActionButtonProps` (which carries an `[key: string]: any` index
+        // signature) to a pure index-signature type, so every destructured prop
+        // arrives as `any`. Spreading it into the payload made this site absorb
+        // unknown keys in silence while `action:group` / `action:menu` — same
+        // payload, no spread — rejected them (objectui#4281, measured in both
+        // directions).
+        //
+        // Hoisting the explicit keys into this annotated binding restores the
+        // check on them, independently of what the composed spreads are typed
+        // as. Key ORDER is deliberately unchanged (`...paramsPayload` keeps its
+        // original position and `...localContext` is still merged last), so the
+        // object that reaches `execute` is identical — see
+        // `__tests__/action-forward-precedence.test.tsx`.
+        const forwarded: ActionDef = {
           type: schema.actionType || schema.type,
           name: schema.name,
           // Forward the human label/description so a param-collection dialog
@@ -139,8 +166,9 @@ const ActionButtonRenderer = forwardRef<HTMLButtonElement, ActionButtonProps>(
           // backup codes). Without this forward the ActionRunner falls
           // back to the success toast and the user loses the value.
           resultDialog: (schema as any).resultDialog,
-          ...localContext,
-        });
+        };
+
+        await execute({ ...forwarded, ...localContext });
       } finally {
         setLoading(false);
       }

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -14,6 +14,7 @@
 
 import React, { forwardRef, useCallback, useState } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
+import type { ActionDef } from '@object-ui/core';
 import type { ActionSchema } from '@object-ui/types';
 import { useAction } from '@object-ui/react';
 import { useCondition, toPredicateInput, usePredicateRecordContext } from '@object-ui/react';
@@ -68,7 +69,14 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
       if (loading) return;
       setLoading(true);
       try {
-        await execute({
+        // Annotated binding, not an inline literal — see action-button.tsx for
+        // the mechanism. `localContext` is `any` (the `PropsWithoutRef` collapse
+        // of an index-signature props interface), and a literal that spreads an
+        // `any` is not excess-property checked, so this site absorbed unknown
+        // keys while `action:group` / `action:menu` rejected them
+        // (objectui#4281). `...localContext` is still merged last, so the object
+        // reaching `execute` is unchanged.
+        const forwarded: ActionDef = {
           type: schema.type,
           name: schema.name,
           // See action-button.tsx — the param-collection dialog reads its title
@@ -96,8 +104,9 @@ const ActionIconRenderer = forwardRef<HTMLButtonElement, ActionIconProps>(
           // OAuth secret). Without it the runner falls back to the success
           // toast and the value the user was meant to copy is gone.
           resultDialog: (schema as any).resultDialog,
-          ...localContext,
-        });
+        };
+
+        await execute({ ...forwarded, ...localContext });
       } finally {
         setLoading(false);
       }

--- a/scripts/__tests__/check-action-forward-parity.test.ts
+++ b/scripts/__tests__/check-action-forward-parity.test.ts
@@ -122,7 +122,10 @@ const inlineSurface = [{ id: 'action:x', contract: 'inline', file: RENDERER }];
 function judge(
   fixture: Fixture,
   options: Record<string, unknown> = {},
-): { errors: string[]; report: { owed: string[]; forwarded: string[]; unexcused: string[] }[] } {
+): {
+  errors: string[];
+  report: { owed: string[]; forwarded: string[]; unexcused: string[]; unchecked: unknown[] }[];
+} {
   return withRepo(fixture, (root) =>
     analyze(root, {
       spec: SPEC,
@@ -626,7 +629,10 @@ describe('the real repository', () => {
       const surface = SURFACES.find((s) => s.id === id);
       expect(surface, `${id} is no longer a surface`).toBeDefined();
       expect(uncheckedForwardLiterals(repoRoot, surface), `${id}'s forward literal is unchecked`).toEqual([]);
-      expect(UNCHECKED_FORWARDS[id], `${id} must not be exempt — it is fixed`).toBeUndefined();
+      expect(
+        (UNCHECKED_FORWARDS as Record<string, unknown>)[id],
+        `${id} must not be exempt — it is fixed`,
+      ).toBeUndefined();
     }
   });
 

--- a/scripts/__tests__/check-action-forward-parity.test.ts
+++ b/scripts/__tests__/check-action-forward-parity.test.ts
@@ -14,9 +14,11 @@ import {
   runtimeReadKeys,
   retiredKeys,
   uiActionViewKeys,
+  uncheckedForwardLiterals,
   JUSTIFIED,
   KNOWN_GAPS,
   OPAQUE_SPREADS,
+  UNCHECKED_FORWARDS,
   SURFACES,
   RUNTIME_CONSUMERS,
 } from '../check-action-forward-parity.mjs';
@@ -129,6 +131,7 @@ function judge(
       justified: {},
       knownGaps: {},
       opaqueSpreads: {},
+      uncheckedForwards: {},
       uiActionView: UI_VIEW,
       actionKeysModule: KEYS_MODULE,
       ...options,
@@ -298,10 +301,29 @@ describe('extraction failure throws rather than returning a clean verdict', () =
   });
 
   it('but an OPAQUE_SPREADS entry declares one whose source cannot carry action keys', () => {
+    // The PARITY dimension is excused: the spread carries no authored key, so it
+    // can neither satisfy nor violate the owed-set diff. That is a different
+    // question from whether it switches the compiler's check off — which it
+    // does, and which the freshness half reports separately (objectui#4281).
+    // Both exemptions together are what "green" costs for this shape.
+    const { errors } = judge(repoWith('{ target, undoable, description, ...mystery }'), {
+      opaqueSpreads: { 'action:x:mystery': { reason: 'the host context bag, not the action' } },
+      uncheckedForwards: { 'action:x': { reason: 'declared unchecked', issue: 1 } },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('and an OPAQUE_SPREADS entry alone does NOT excuse the literal being unchecked', () => {
+    // The regression this pins: excusing a spread for parity used to be the only
+    // judgement the gate made about it, so `action:button` and `action:icon` were
+    // green while absorbing invented keys (objectui#4281). One exemption, two
+    // questions — the parity one must not silently answer the freshness one.
     const { errors } = judge(repoWith('{ target, undoable, description, ...mystery }'), {
       opaqueSpreads: { 'action:x:mystery': { reason: 'the host context bag, not the action' } },
     });
-    expect(errors).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('does NOT excess-property check');
+    expect(errors[0]).toContain('...mystery');
   });
 
   it('resolves a conditional payload fragment and unions BOTH branches', () => {
@@ -310,9 +332,12 @@ describe('extraction failure throws rather than returning a clean verdict', () =
     const fixture: Fixture = {
       files: {
         ...repoWith('{}').files,
+        // Annotated because the freshness half judges a spread SOURCE too (see
+        // the `objectui#4281` describe below); the parity property under test —
+        // that BOTH branches count as forwarded — is unaffected either way.
         [RENDERER]:
           'export const R = () => {\n' +
-          '  const frag = cond ? { undoable } : { description };\n' +
+          '  const frag: ActionDef = cond ? { undoable } : { description };\n' +
           '  void execute({ target, ...frag });\n' +
           '};\n',
       },
@@ -388,6 +413,185 @@ describe('extraction failure throws rather than returning a clean verdict', () =
   });
 });
 
+// -- freshness: is the forward literal CHECKED at all? ------------------------
+
+/**
+ * objectui#4281 — the second half of the guarantee.
+ *
+ * #4046 closed `ActionDef` so an invented key at a forward site is a `TS2353`.
+ * It held at two of the four action renderers and not the other two, and nothing
+ * said so: the parity half above was green for all four, because a key nobody
+ * MEANT to write is not a key that was DROPPED. These cases pin the structural
+ * rule that separates them.
+ *
+ * The rule is deliberately STRICTER than TypeScript's own, because this gate has
+ * no type checker — see the script's section 4. Where a case below is red but
+ * the compiler would accept it, that is the conservative direction and is noted
+ * on the case.
+ */
+describe('a forward literal must be one the compiler excess-property checks', () => {
+  const OWED = '{ target, undoable, description }';
+
+  it('is green when the payload is a plain literal — the action:group / action:menu shape', () => {
+    const { errors, report } = judge(repoWith(OWED));
+    expect(errors).toEqual([]);
+    expect(report[0].unchecked).toEqual([]);
+  });
+
+  it('is red when an unresolvable spread rides in the literal — the action:button / action:icon shape', () => {
+    // Measured cause (objectui#4281): `localContext` is `any`, because
+    // `PropsWithoutRef` collapses an index-signature props interface, and a
+    // literal spreading an `any` is not checked. An AST cannot see the type, so
+    // any unresolvable spread is red.
+    const { errors } = judge(repoWith(`{ target, undoable, description, ...localContext }`), {
+      opaqueSpreads: { 'action:x:localContext': { reason: 'the host context bag' } },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('action:x');
+    expect(errors[0]).toContain('does NOT excess-property check');
+    expect(errors[0]).toContain('`target`');
+  });
+
+  it('is green once the keys are hoisted into an ActionDef-annotated binding — the fix', () => {
+    const fixture: Fixture = {
+      files: {
+        ...repoWith('{}').files,
+        [RENDERER]:
+          'export const R = () => {\n' +
+          '  const forwarded: ActionDef = { target, undoable, description };\n' +
+          '  void execute({ ...forwarded, ...localContext });\n' +
+          '};\n',
+      },
+    };
+    const { errors, report } = judge(fixture, {
+      opaqueSpreads: { 'action:x:localContext': { reason: 'the host context bag' } },
+    });
+    expect(errors).toEqual([]);
+    expect(report[0].forwarded).toEqual(['description', 'target', 'undoable']);
+  });
+
+  it('is red when the hoisted binding carries no annotation — hoisting alone is not the fix', () => {
+    // The hole a naive reading of "hoist the spread out" leaves: an unannotated
+    // `const base = {…}` has no contextual type, so its own keys are not checked
+    // either. Measured — probe M in objectui#4281.
+    const fixture: Fixture = {
+      files: {
+        ...repoWith('{}').files,
+        [RENDERER]:
+          'export const R = () => {\n' +
+          '  const forwarded = { target, undoable, description };\n' +
+          '  void execute({ ...forwarded, ...localContext });\n' +
+          '};\n',
+      },
+    };
+    const { errors } = judge(fixture, {
+      opaqueSpreads: { 'action:x:localContext': { reason: 'the host context bag' } },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('neither the `execute({…})` argument nor a binding annotated `ActionDef`');
+  });
+
+  it('is red when the payload is cast away — `as any` switches the check off entirely', () => {
+    // element:button's live shape, and why it needs a declared exemption rather
+    // than the hoist: an assertion asks only for comparability, so excess keys
+    // are accepted whatever the asserted type is.
+    const { errors } = judge(repoWith(`${OWED} as any`));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('sits behind an `as` assertion');
+  });
+
+  it('judges a resolvable spread SOURCE by the same rule — its keys are not checked either', () => {
+    // The second hole objectui#4281 measured (probe Q): a spread source's own
+    // keys ride unchecked through the spread. `action:button`'s `paramsPayload`
+    // was exactly this, and the fix annotates it too.
+    const unannotated: Fixture = {
+      files: {
+        ...repoWith('{}').files,
+        [RENDERER]:
+          'export const R = () => {\n' +
+          '  const frag = cond ? { undoable } : { description };\n' +
+          '  void execute({ target, ...frag });\n' +
+          '};\n',
+      },
+    };
+    // One violation per BRANCH — each is its own literal, and each names the key
+    // riding free in it, so a reader is not left to guess which arm is unchecked.
+    const { errors } = judge(unannotated);
+    expect(errors).toHaveLength(2);
+    for (const error of errors) expect(error).toContain('`const frag`');
+    expect(errors.join('\n')).toContain('`undoable`');
+    expect(errors.join('\n')).toContain('`description`');
+
+    const annotated: Fixture = {
+      files: {
+        ...repoWith('{}').files,
+        [RENDERER]:
+          'export const R = () => {\n' +
+          '  const frag: ActionDef = cond ? { undoable } : { description };\n' +
+          '  void execute({ target, ...frag });\n' +
+          '};\n',
+      },
+    };
+    expect(judge(annotated).errors).toEqual([]);
+  });
+
+  it('accepts `satisfies ActionDef` as well as an annotation — both keep the check on', () => {
+    // Measured in both directions: `satisfies` preserves the excess-property
+    // check, `as` removes it. The gate must not conflate them.
+    const fixture: Fixture = {
+      files: {
+        ...repoWith('{}').files,
+        [RENDERER]:
+          'export const R = () => {\n' +
+          '  const forwarded = { target, undoable, description } satisfies ActionDef;\n' +
+          '  void execute({ ...forwarded, ...localContext });\n' +
+          '};\n',
+      },
+    };
+    const { errors } = judge(fixture, {
+      opaqueSpreads: { 'action:x:localContext': { reason: 'the host context bag' } },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it('is green for a literal that is nothing but spreads — there is no key to check', () => {
+    const fixture: Fixture = {
+      files: {
+        ...repoWith('{}').files,
+        [RENDERER]:
+          'export const R = () => {\n' +
+          '  const forwarded: ActionDef = { target, undoable, description };\n' +
+          '  void execute({ ...forwarded });\n' +
+          '};\n',
+      },
+    };
+    expect(judge(fixture).errors).toEqual([]);
+  });
+
+  it('an UNCHECKED_FORWARDS entry excuses the surface, and is ratcheted like the others', () => {
+    const broken = repoWith(`${OWED} as any`);
+    expect(judge(broken, { uncheckedForwards: { 'action:x': { reason: 'declared', issue: 1 } } }).errors).toEqual([]);
+
+    // …and an entry that excuses nothing must go, or it reserves the surface for
+    // a future unchecked literal under a reason nobody re-examined.
+    const { errors } = judge(repoWith(OWED), {
+      uncheckedForwards: { 'action:x': { reason: 'stale — the payload is checked now', issue: 4321 } },
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('excuses nothing');
+    expect(errors[0]).toContain('#4321');
+  });
+
+  it('reports the unchecked keys, not just the fact — a reader must see what rides free', () => {
+    const { errors } = judge(repoWith('{ target, undoable, description, ...ctx }'), {
+      opaqueSpreads: { 'action:x:ctx': { reason: 'the host context bag' } },
+    });
+    for (const key of ['target', 'undoable', 'description']) {
+      expect(errors[0], `${key} is not named`).toContain(`\`${key}\``);
+    }
+  });
+});
+
 // -- the real repository ------------------------------------------------------
 
 describe('the real repository', () => {
@@ -410,6 +614,35 @@ describe('the real repository', () => {
     expect(real.runtimeRead.size).toBeGreaterThan(20);
     for (const consumer of RUNTIME_CONSUMERS) {
       expect(real.perFile.get(consumer.file)?.size ?? 0, `${consumer.file} read nothing`).toBeGreaterThan(0);
+    }
+  });
+
+  it('holds objectui#4281: all four action renderers write into a CHECKED literal', () => {
+    // The card's measurement, pinned. `action:group` / `action:menu` were always
+    // checked; `action:button` / `action:icon` absorbed invented keys until their
+    // explicit keys were hoisted into an `ActionDef`-annotated binding. A future
+    // renderer written in the broken shape fails here rather than shipping.
+    for (const id of ['action:button', 'action:icon', 'action:group', 'action:menu']) {
+      const surface = SURFACES.find((s) => s.id === id);
+      expect(surface, `${id} is no longer a surface`).toBeDefined();
+      expect(uncheckedForwardLiterals(repoRoot, surface), `${id}'s forward literal is unchecked`).toEqual([]);
+      expect(UNCHECKED_FORWARDS[id], `${id} must not be exempt — it is fixed`).toBeUndefined();
+    }
+  });
+
+  it('every UNCHECKED_FORWARDS entry names a surface that really is unchecked', () => {
+    // Same shrink-only governance as the tables above: the exemption cannot
+    // outlive the shape it excuses. `analyze()` enforces this too; asserting it
+    // here as well is what keeps the entry honest if the CLI half ever changes.
+    for (const [id, meta] of Object.entries(UNCHECKED_FORWARDS)) {
+      const surface = SURFACES.find((s) => s.id === id);
+      expect(surface, `UNCHECKED_FORWARDS names ${id}, which is not a surface`).toBeDefined();
+      expect(
+        uncheckedForwardLiterals(repoRoot, surface).length,
+        `${id} is checked now — delete its exemption`,
+      ).toBeGreaterThan(0);
+      expect(meta.reason.length, `${id} has no reason`).toBeGreaterThan(80);
+      expect(typeof meta.issue, `${id} cites no issue`).toBe('number');
     }
   });
 

--- a/scripts/check-action-forward-parity.mjs
+++ b/scripts/check-action-forward-parity.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 /**
- * An action renderer must forward every authored key the runtime will read.
+ * An action renderer must forward every authored key the runtime will read —
+ * and must write those keys somewhere the compiler will still check them.
+ *
+ * Two halves, two different failures. The first is a key DROPPED from a forward
+ * whitelist (below). The second is a key INVENTED at a forward site and absorbed
+ * in silence, because the literal it was written into is one TypeScript does not
+ * excess-property check — objectui#4281, see section 4. A surface can pass the
+ * first and fail the second: two of the four action renderers did.
  *
  * The failure class (objectui#4050, carried from objectstack#6975): each action
  * renderer hands the `ActionRunner` an explicit key WHITELIST rather than the
@@ -110,7 +117,8 @@
  * returning "no errors" there would be the silent pass the ruling forbids.
  *
  * Run:  node scripts/check-action-forward-parity.mjs
- * Exit: 0 = every surface forwards what it owes, 1 = a key is dropped, an entry
+ * Exit: 0 = every surface forwards what it owes, into a literal the compiler
+ *       checks; 1 = a key is dropped, a forward literal is unchecked, an entry
  *       is stale, or extraction failed.
  */
 
@@ -614,7 +622,252 @@ export function forwardedKeys(root, surface, opaqueSpreads = OPAQUE_SPREADS) {
   return keys;
 }
 
-// ── 4. Diff ──────────────────────────────────────────────────────────────────
+// ── 4. Is the forward literal CHECKED at all? ────────────────────────────────
+// Parity is only half the guarantee. The other half is objectui#4046, which
+// closed `ActionDef` so that an invented or misspelled key at a forward site is
+// a `TS2353` — the objectstack#2169 "Mark Done does nothing" shape, caught by
+// the compiler instead of by a user. objectui#4281 measured that the guarantee
+// held at only two of the four action renderers: `action:group` and
+// `action:menu` rejected an invented key, `action:button` and `action:icon`
+// absorbed it in silence, and NOTHING said so. A reader who knows `ActionDef` is
+// closed would reasonably assume it is closed everywhere.
+//
+// The cause is not the type. TypeScript runs the excess-property ("freshness")
+// check only on an object literal it can see whole, and several ordinary shapes
+// switch it off. Measured on TypeScript 6.0.3, against `packages/components`
+// itself and against a minimal reproduction (objectui#4281):
+//
+//   spread of an `any`-typed value    → check OFF   ← the live defect
+//   `expr as T` (any T, incl. `any`)  → check OFF
+//   a spread SOURCE's own keys        → check OFF   ← probe Q, the second hole
+//   plain `const x = {…}`, unannotated→ check OFF
+//   `const x: ActionDef = {…}`        → check ON
+//   `{…} satisfies ActionDef`         → check ON
+//   spread of `Record<string, any>`   → check ON
+//   spread of a resolvable literal    → check ON
+//
+// The two broken renderers were the two that spread `localContext`, and that
+// binding is `any` — `PropsWithoutRef` collapses a props interface carrying
+// `[key: string]: any` to a pure index-signature type, so every destructured
+// prop arrives as `any`. Note what this means: `...paramsPayload`, which
+// objectui#4281's own table named as `action:button`'s culprit, is NOT one —
+// narrowing only the `localContext` spread restored the check with
+// `...paramsPayload` untouched.
+//
+// ── Why this gate states a STRICTER rule than TypeScript's ───────────────────
+// Every row above turns on a TYPE, and this gate has no type checker: it parses
+// source files, deliberately (see the header — a program-wide check here would
+// be slower than the compile it duplicates). So the rule below is a SUFFICIENT
+// STRUCTURAL CONDITION, not a restatement of the compiler's:
+//
+//   Every object literal contributing an explicit key to a forward payload must
+//   be (a) contextually typed — the direct `execute(…)` argument, or a binding
+//   annotated `ActionDef` / `satisfies ActionDef` — and (b) free of any spread
+//   this gate cannot resolve to object literals.
+//
+// (b) is where it is stricter: a `Record<string, any>` spread would keep the
+// check, but an AST cannot tell one from an `any`. The escape is not an
+// exemption — it is the one-line fix the ruling prescribes, hoisting the
+// explicit keys into an annotated binding, which is checked whatever the
+// composed spreads turn out to be. That the rule is conservative in this exact
+// direction is the point: a future renderer written in the broken shape goes red
+// on the PR that adds it, which is what turns objectui#4046's guarantee from
+// "true today, by luck" into "enforced".
+//
+// Resolvable spreads are transparent for (b) — but their SOURCE literal is
+// judged by the same rule, because a spread source's keys are not checked
+// through the spread either (probe Q above: `const p = cond ? {actionParams} :
+// {zzBogus}` is absorbed whole; annotating `p` rejects it).
+export const UNCHECKED_FORWARDS = {
+  "element:button": {
+    reason:
+      "Its payload is cast `as any` (elements.tsx), so no excess-property check runs and none " +
+      "can be restored by hoisting alone. Unlike the four action renderers, this surface's " +
+      "`action` is a bare `Record<string, any>` prop rather than a typed action, so the cast is " +
+      "load-bearing for more than the forward literal. PRE-EXISTING and out of objectui#4281's " +
+      "scope (that card measured, and its ruling scoped, the two action renderers); filed " +
+      "separately so this gate stops the BLEEDING — a NEW unchecked forward literal is red — " +
+      "without retro-fixing a surface whose fix is a different change. Ratcheted below: drop " +
+      "the cast and this entry fails.",
+    issue: 4321,
+  },
+};
+
+/** Is this type node a reference to `ActionDef`? */
+const isActionDefType = (typeNode) =>
+  !!typeNode &&
+  ts.isTypeReferenceNode(typeNode) &&
+  ts.isIdentifier(typeNode.typeName) &&
+  typeNode.typeName.text === "ActionDef";
+
+/**
+ * The forward literals a surface writes explicit keys into that TypeScript does
+ * not excess-property check.
+ *
+ * Returns `[]` for a compliant surface. Each violation names the literal, the
+ * keys riding in it unchecked, and which clause failed — a message a reader can
+ * act on without knowing the freshness rules, since not knowing them is how
+ * objectui#4281 happened.
+ */
+export function uncheckedForwardLiterals(root, surface, opaqueSpreads = OPAQUE_SPREADS) {
+  if (!existsSync(resolve(root, surface.file))) {
+    fail(`surface ${surface.id}: ${surface.file} does not exist — re-point this gate at the renderer.`);
+  }
+  const sf = parse(root, surface.file);
+
+  // `name -> { init, type }`. The TYPE is what `forwardedKeys`' own local map
+  // does not need and this one cannot work without.
+  const locals = new Map();
+  const collectLocals = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      locals.set(node.name.text, { init: node.initializer, type: node.type ?? null });
+    }
+    ts.forEachChild(node, collectLocals);
+  };
+  collectLocals(sf);
+
+  /**
+   * Strip parens, `as` assertions and `satisfies` down to the payload node,
+   * recording which were crossed. `as` and `satisfies` are opposites here and
+   * the difference is measured, not assumed: `{…} as ActionDef` turns the check
+   * OFF (an assertion asks only for comparability), `{…} satisfies ActionDef`
+   * leaves it ON.
+   */
+  const strip = (node) => {
+    let n = node;
+    let asserted = false;
+    let satisfied = false;
+    for (;;) {
+      if (!n) break;
+      if (ts.isParenthesizedExpression(n)) {
+        n = n.expression;
+        continue;
+      }
+      if (ts.isAsExpression(n) || (ts.isTypeAssertionExpression?.(n) ?? false)) {
+        asserted = true;
+        n = n.expression;
+        continue;
+      }
+      if (ts.isSatisfiesExpression?.(n)) {
+        satisfied = satisfied || isActionDefType(n.type);
+        n = n.expression;
+        continue;
+      }
+      break;
+    }
+    return { node: n, asserted, satisfied };
+  };
+
+  const explicitKeysOf = (obj) =>
+    obj.properties
+      .filter((p) => !ts.isSpreadAssignment(p))
+      .map((p) => (p.name && (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) ? p.name.text : "<computed>"));
+
+  const violations = [];
+  const seen = new Set();
+
+  /**
+   * @param obj     an object literal contributing to the payload
+   * @param checked is it contextually typed AND not behind a type assertion?
+   * @param origin  how a reader finds it
+   */
+  const walk = (obj, checked, origin, depth) => {
+    if (depth > 4) fail(`surface ${surface.id}: spread nesting too deep to resolve in ${surface.file}.`);
+    if (seen.has(obj)) return;
+    seen.add(obj);
+
+    const opaque = [];
+    for (const prop of obj.properties) {
+      if (!ts.isSpreadAssignment(prop)) continue;
+      const spread = strip(prop.expression);
+
+      // An inline `...{ … }` is part of THIS literal's check, either way.
+      if (ts.isObjectLiteralExpression(spread.node) && !spread.asserted) {
+        walk(spread.node, checked, origin, depth + 1);
+        continue;
+      }
+
+      if (ts.isIdentifier(spread.node) && !spread.asserted) {
+        const local = locals.get(spread.node.text);
+        const resolved = local ? strip(local.init) : null;
+        const branches = [];
+        if (resolved && !resolved.asserted) {
+          if (ts.isConditionalExpression(resolved.node)) {
+            const whenTrue = strip(resolved.node.whenTrue);
+            const whenFalse = strip(resolved.node.whenFalse);
+            if (
+              ts.isObjectLiteralExpression(whenTrue.node) &&
+              ts.isObjectLiteralExpression(whenFalse.node) &&
+              !whenTrue.asserted &&
+              !whenFalse.asserted
+            ) {
+              branches.push(whenTrue.node, whenFalse.node);
+            }
+          } else if (ts.isObjectLiteralExpression(resolved.node)) {
+            branches.push(resolved.node);
+          }
+        }
+        if (branches.length > 0) {
+          // Resolvable: transparent for THIS literal, judged on its own terms.
+          const sourceChecked = isActionDefType(local.type) || resolved.satisfied;
+          for (const branch of branches) {
+            walk(branch, sourceChecked, `\`const ${spread.node.text}\` in ${surface.file}`, depth + 1);
+          }
+          continue;
+        }
+      }
+
+      opaque.push(
+        ts.isIdentifier(spread.node) && !spread.asserted ? `...${spread.node.text}` : "...<unresolvable expression>"
+      );
+    }
+
+    const explicit = explicitKeysOf(obj);
+    if (explicit.length === 0) return; // Only spreads — nothing for freshness to check.
+
+    if (!checked) {
+      violations.push({
+        origin,
+        cause: "it is neither the `execute({…})` argument nor a binding annotated `ActionDef`, or it sits behind an `as` assertion",
+        keys: explicit,
+      });
+      return;
+    }
+    if (opaque.length > 0) {
+      const declared = opaque.filter((s) => opaqueSpreads[`${surface.id}:${s.replace(/^\.\.\./, "")}`]);
+      violations.push({
+        origin,
+        cause:
+          `it spreads ${opaque.join(", ")}, which this gate cannot resolve to object literals` +
+          (declared.length > 0
+            ? " (an OPAQUE_SPREADS entry declares it for the PARITY diff — that says the spread carries no authored key, " +
+              "which is a different question from whether it switches the compiler's check off; the measured live case, " +
+              "`localContext`, is typed `any` and does)"
+            : ""),
+        keys: explicit,
+      });
+    }
+  };
+
+  const calls = [];
+  const findCalls = (node) => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "execute") {
+      if (node.arguments.length === 1) calls.push(node.arguments[0]);
+    }
+    ts.forEachChild(node, findCalls);
+  };
+  findCalls(sf);
+  // Arity/shape failures are `forwardedKeys`' red to raise, with its own message.
+  if (calls.length !== 1) return [];
+
+  const argument = strip(calls[0]);
+  if (!ts.isObjectLiteralExpression(argument.node)) return [];
+  walk(argument.node, !argument.asserted, `the \`execute({…})\` payload in ${surface.file}`, 0);
+
+  return violations;
+}
+
+// ── 5. Diff ──────────────────────────────────────────────────────────────────
 /**
  * `owed − forwarded − excused = ∅`, per surface.
  *
@@ -629,6 +882,7 @@ export function analyze(root = REPO_ROOT, options = {}) {
     justified = JUSTIFIED,
     knownGaps = KNOWN_GAPS,
     opaqueSpreads = OPAQUE_SPREADS,
+    uncheckedForwards = UNCHECKED_FORWARDS,
     spec = null,
     uiActionView = UI_ACTION_VIEW,
     actionKeysModule = ACTION_KEYS_MODULE,
@@ -647,6 +901,7 @@ export function analyze(root = REPO_ROOT, options = {}) {
   const errors = [];
   const matchedJustified = new Set();
   const matchedGaps = new Set();
+  const matchedUnchecked = new Set();
   const report = [];
 
   for (const surface of surfaces) {
@@ -679,6 +934,31 @@ export function analyze(root = REPO_ROOT, options = {}) {
       } else unexcused.push(key);
     }
 
+    // Is the payload even excess-property checked? A surface can forward every
+    // key it owes (green above) and still absorb an invented one in silence —
+    // objectui#4281, where two of the four action renderers did exactly that.
+    const unchecked = uncheckedForwardLiterals(root, surface, opaqueSpreads);
+    if (unchecked.length > 0 && uncheckedForwards[surface.id]) {
+      matchedUnchecked.add(surface.id);
+    } else if (unchecked.length > 0) {
+      for (const violation of unchecked) {
+        errors.push(
+          `${surface.id} writes ${violation.keys.length} forward key` +
+            `${violation.keys.length === 1 ? "" : "s"} into a literal TypeScript does NOT excess-property check.\n` +
+            `      Literal: ${violation.origin}\n` +
+            `      Cause:   ${violation.cause}\n` +
+            `      Keys:    \`${violation.keys.join("`, `")}\`\n` +
+            "      So `ActionDef` being closed (objectui#4046) buys this surface nothing: an invented or\n" +
+            "      misspelled key here compiles, publishes, and reaches a runner that silently does\n" +
+            "      nothing — objectstack#2169's shape, which #4046 exists to make a compile error.\n" +
+            "      FIX: hoist the explicit keys into an annotated binding and compose the spreads around\n" +
+            "      it — `const forwarded: ActionDef = { … }; execute({ ...forwarded, ...rest })`. The\n" +
+            "      annotation is what restores the check; hoisting alone does not (an unannotated\n" +
+            "      `const base = {…}` is not checked either). See objectui#4281 for the measurements."
+        );
+      }
+    }
+
     report.push({
       surface,
       owed,
@@ -687,6 +967,7 @@ export function analyze(root = REPO_ROOT, options = {}) {
       justified: excusedJustified,
       gaps: excusedGaps,
       unexcused,
+      unchecked,
     });
 
     if (unexcused.length > 0) {
@@ -719,6 +1000,15 @@ export function analyze(root = REPO_ROOT, options = {}) {
     errors.push(
       `KNOWN_GAPS entry \`${entry}\` is no longer a gap — delete it (and close #${meta.issue} once\n` +
         "      its last entry is gone). Left in, it re-reserves the key for a future drop."
+    );
+  }
+  for (const [surfaceId, meta] of Object.entries(uncheckedForwards)) {
+    if (matchedUnchecked.has(surfaceId)) continue;
+    errors.push(
+      `UNCHECKED_FORWARDS entry \`${surfaceId}\` excuses nothing — the surface's forward literal is\n` +
+        `      excess-property checked now, or the surface is gone. Delete it (and close #${meta.issue} once\n` +
+        "      its last entry is gone): left in, it re-reserves the surface for a future unchecked\n" +
+        "      literal under a reason nobody re-examined."
     );
   }
   for (const entry of Object.keys(opaqueSpreads)) {
@@ -754,21 +1044,24 @@ if (invokedDirectly) {
   if (errors.length === 0) {
     const gaps = Object.keys(KNOWN_GAPS).length;
     const justifiedCount = Object.keys(JUSTIFIED).length;
+    const exempt = Object.keys(UNCHECKED_FORWARDS).length;
     console.log(
       `✅  action forward parity: ${SURFACES.length} surfaces checked against ${runtimeRead.size} runtime-read keys ` +
         `from ${perFile.size} consumers; ${justifiedCount} justified omission` +
-        `${justifiedCount === 1 ? "" : "s"}, ${gaps} known gap${gaps === 1 ? "" : "s"}.`
+        `${justifiedCount === 1 ? "" : "s"}, ${gaps} known gap${gaps === 1 ? "" : "s"}, ` +
+        `${exempt} payload${exempt === 1 ? "" : "s"} exempt from the freshness rule.`
     );
     for (const r of report) {
       console.log(
         `    ${r.surface.id.padEnd(14)} owes ${String(r.owed.length).padStart(2)}, ` +
-          `forwards ${String(r.forwarded.length).padStart(2)}`
+          `forwards ${String(r.forwarded.length).padStart(2)}, ` +
+          `payload ${r.unchecked.length === 0 ? "excess-property CHECKED" : "unchecked (declared)"}`
       );
     }
     process.exit(0);
   }
 
-  console.error("❌  an action renderer drops a key the runtime reads:\n");
+  console.error("❌  an action renderer drops a key the runtime reads, or writes one into an unchecked literal:\n");
   for (const message of errors) console.error(`    • ${message}\n`);
   console.error(
     "Every instance of this class shipped green: the key parses, publishes, and reads as\n" +


### PR DESCRIPTION
Fixes #4281.

Implements the ruling on the card: **option 1 (fix the two sites) + option 3 (make the parity gate structural)**. Option 2 (structural excess-key rejection on `execute()`'s parameter) was rejected and is not attempted.

## What was wrong

#4046 closed `ActionDef`, so an invented or misspelled key at a site that authors an action literal is a `TS2353`. Re-measured on `origin/main` @ `f5e114348`, that guarantee held at two of the four action renderers and not the other two — an invented key at each site, type-checking `@object-ui/components`:

| forward site | invented key | before this PR |
|---|---|---|
| `action-button.tsx` | `zzBogusBtnPre` / `zzBogusBtnMid` | **absorbed, silently** |
| `action-icon.tsx` | `zzBogusIcon` | **absorbed, silently** |
| `action-group.tsx` | `zzBogusGroup` | `TS2353` |
| `action-menu.tsx` | `zzBogusMenu` | `TS2353` |

```
src/renderers/action/action-group.tsx(251,11): error TS2353: Object literal may only specify
known properties, and 'zzBogusGroup' does not exist in type 'ActionDef'.
src/renderers/action/action-menu.tsx(233,13): error TS2353: Object literal may only specify
known properties, and 'zzBogusMenu' does not exist in type 'ActionDef'.
```

Two errors, from the two non-spread sites. The card's premise reproduces exactly.

## The mechanism — one correction to the card

The card attributes `action:button`'s loss of freshness to `...paramsPayload`. **Measured, it is not.** The disabling spread at *both* sites is `...localContext`, and the reason is narrower than "a spread of a non-literal":

- `localContext` is **`any`**. `PropsWithoutRef` collapses `ActionButtonProps` / `ActionIconProps` — both carry `[key: string]: any` — to a pure index-signature type, so every destructured prop arrives as `any`. Assigning `localContext` to an impossible type is silent, which is what proves it.
- Narrowing only that one spread to `Record< string, any >`, leaving `...paramsPayload` untouched, **restores** the check: `zzBogusNarrowed` becomes a `TS2345`.

So on TypeScript 6.0.3 a spread does not generally disable the check. Measured behaviour, against a minimal reproduction and against the real files:

| shape | excess-property check |
|---|---|
| spread of an `any` value | **off** (the live defect) |
| `expr as T` — any `T`, including `any` | **off** |
| a spread SOURCE's own keys | **off** (second hole, see below) |
| `const x = { … }`, unannotated | **off** |
| `const x: ActionDef = { … }` | on |
| `{ … } satisfies ActionDef` | on |
| spread of `Record< string, any >` | on |
| spread of a resolvable local literal | on |

The third row is a second hole the card did not measure: a spread source's own keys are never excess-checked through the spread, so `action:button`'s `paramsPayload` was itself unchecked. Annotating it closes that too.

## The fix (option 1)

At both sites the explicit keys move into an `ActionDef`-annotated binding, with the spreads composed around it. The annotation is what restores the check — hoisting alone does not, since an unannotated `const base = { … }` has no contextual type either.

**Runtime behaviour is preserved byte-for-byte, and that is asserted rather than argued.** `...paramsPayload` keeps its original mid-literal position and `...localContext` is still merged last, so the merged object is identical in key set, values, precedence *and* insertion order.

Precedence as measured today, and preserved:

- `...localContext` is spread **last**, so a host context key **overrides** the authored action's value. Pre-existing and deliberate (`context` is documented as "Override context for this specific action"). Pinned in both directions.
- `...paramsPayload` can carry only `params` or `actionParams`, and **neither is an explicit key of the surrounding literal** — the key sets are disjoint, so its position cannot decide any collision. It is kept in place anyway, so key order is unchanged too.

`packages/components/src/renderers/action/__tests__/action-forward-precedence.test.tsx` pins all of it: exact key order for each surface, authored values, the context override, and that a context-only key is appended without moving the collided key.

## The gate (option 3) — pre-fix red run

`check:action-forward-parity` already parses these forward literals with the compiler API, so it is the natural home. It now also asserts that **every object literal contributing an explicit key to a forward payload is one the compiler excess-property checks**: contextually typed (the `execute(…)` argument, or a binding annotated `ActionDef` / `satisfies ActionDef`), not behind an `as` assertion, and free of any spread the gate cannot resolve to object literals.

The rule is deliberately **stricter** than TypeScript's, and the script says so: every row of the table above turns on a *type*, and this gate has no type checker. The escape is not an exemption, it is the one-line fix — which is the point, since it makes a future renderer written in the broken shape go red on the PR that adds it.

Per the objectstack#4118 ruling for guard changes, here is the gate extension **failing against today's two broken sites, before the site fixes were applied** (commit `b5bfaf1ab` in this branch, with `83a4aa7d3` not yet on top):

```
❌  an action renderer drops a key the runtime reads, or writes one into an unchecked literal:

    • action:button writes 1 forward key into a literal TypeScript does NOT excess-property check.
      Literal: `const paramsPayload` in packages/components/src/renderers/action/action-button.tsx
      Cause:   it is neither the `execute({…})` argument nor a binding annotated `ActionDef`, or it sits behind an `as` assertion
      Keys:    `actionParams`

    • action:button writes 1 forward key into a literal TypeScript does NOT excess-property check.
      Literal: `const paramsPayload` in packages/components/src/renderers/action/action-button.tsx
      Cause:   it is neither the `execute({…})` argument nor a binding annotated `ActionDef`, or it sits behind an `as` assertion
      Keys:    `params`

    • action:button writes 19 forward keys into a literal TypeScript does NOT excess-property check.
      Literal: the `execute({…})` payload in packages/components/src/renderers/action/action-button.tsx
      Cause:   it spreads ...localContext, which this gate cannot resolve to object literals (an
               OPAQUE_SPREADS entry declares it for the PARITY diff — that says the spread carries no
               authored key, which is a different question from whether it switches the compiler's
               check off; the measured live case, `localContext`, is typed `any` and does)
      Keys:    `type`, `name`, `label`, `description`, `target`, `openIn`, `endpoint`, `method`,
               `bodyExtra`, `bodyShape`, `confirmText`, `successMessage`, `errorMessage`,
               `refreshAfter`, `undoable`, `recordIdField`, `locations`, `toast`, `resultDialog`

    • action:icon writes 18 forward keys into a literal TypeScript does NOT excess-property check.
      Literal: the `execute({…})` payload in packages/components/src/renderers/action/action-icon.tsx
      Cause:   it spreads ...localContext, which this gate cannot resolve to object literals (…)
      Keys:    `type`, `name`, `label`, `description`, `target`, `openIn`, `endpoint`, `method`,
               `params`, `bodyExtra`, `bodyShape`, `confirmText`, `successMessage`, `errorMessage`,
               `refreshAfter`, `locations`, `toast`, `resultDialog`

GATE EXIT=1
```

Note it names exactly the two broken surfaces and not the two healthy controls. After the site fixes:

```
✅  action forward parity: 5 surfaces checked against 40 runtime-read keys from 3 consumers;
    19 justified omissions, 7 known gaps, 1 payload exempt from the freshness rule.
    action:button  owes 24, forwards 21, payload excess-property CHECKED
    action:icon    owes 24, forwards 18, payload excess-property CHECKED
    action:group   owes 24, forwards 18, payload excess-property CHECKED
    action:menu    owes 24, forwards 18, payload excess-property CHECKED
    element:button owes 12, forwards 18, payload unchecked (declared)
```

### The one exemption, declared and ratcheted

`element:button` (`renderers/basic/elements.tsx`) is a fifth forward surface whose payload is cast `as any`, which switches the check off for a **different** reason and whose fix is a different change — its `action` prop is a bare `Record< string, any >`, so removing the cast is a contract question, not a mechanical hoist. It ships with a declared `UNCHECKED_FORWARDS` entry, filed as #4321, under the same shrink-only governance as `JUSTIFIED` / `KNOWN_GAPS`: **once the payload becomes checked, the entry itself fails the gate**.

## Verification

**Discrimination proof, after the fix** — the same probe, all four sites now report:

```
src/renderers/action/action-button.tsx(101,73): error TS2322: … 'zzBogusParamsSrc' does not exist in type 'ActionDef'.
src/renderers/action/action-button.tsx(165,11): error TS2353: … 'zzBogusBtnMid' does not exist in type 'ActionDef'.
src/renderers/action/action-group.tsx(251,11): error TS2353: … 'zzBogusGroup' does not exist in type 'ActionDef'.
src/renderers/action/action-icon.tsx(91,11):   error TS2353: … 'zzBogusIcon' does not exist in type 'ActionDef'.
src/renderers/action/action-menu.tsx(233,13):  error TS2353: … 'zzBogusMenu' does not exist in type 'ActionDef'.
```

TypeScript reports one excess-property error per literal, so `zzBogusBtnPre` (before the spread) is suppressed as a second error on the same literal here; probed alone it reports too — `action-button.tsx(137,11): error TS2353 … 'zzBogusBtnPreOnly'`. Both positions are covered.

**Reverse verification** (commit-then-revert, never `git stash`):

- Reverting the site fixes returns the two sites to silence and turns the gate red — that is the pre-fix run pasted above.
- Writing the fix the *naive* way (hoist, but move `...paramsPayload` to the end) leaves the gate **green** — it is order-blind by design, since key order is not a contract — and turns the precedence pin **red** on 2 of its 8 cases. That is what makes the order assertion load-bearing rather than decorative.
- An unannotated hoist and an `as any` payload are each driven red from synthetic fixtures in the gate's own suite.

**Commands** (repo root, per AGENTS.md §怎么跑测试):

```
pnpm exec vitest run scripts/ packages/components/src/renderers/action/
  → Test Files 49 passed (49) · Tests 1096 passed (1096)

packages/components: tsc --noEmit                      → EXIT=0
packages/components: tsc -p tsconfig.typetests.json    → EXIT=0
tsc -p tsconfig.scripts.json                           → EXIT=0
tsc -p tsconfig.vitest-setup.json                      → EXIT=0
node scripts/check-action-forward-parity.mjs           → EXIT=0
node scripts/check-changeset-presence.mjs              → EXIT=0
node scripts/check-control-bytes.mjs                   → EXIT=0
eslint (5 changed files)                               → 0 errors, 30 pre-existing warnings
```

Changeset: empty frontmatter — the site fixes are compile-time only and the gate change ships nothing, which the presence gate accepts as an explicit declaration rather than a workaround.

Refs #4046, #4050, #4192, objectstack#2169, objectstack#4118.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_