### PR TITLE
test(plugin-detail): type-check its tests and clear its TEST_DEBT entry (#4040)

### DIFF
--- a/.changeset/great-mails-repeat.md
+++ b/.changeset/great-mails-repeat.md
@@ -1,0 +1,9 @@
+---
+"@object-ui/plugin-detail": patch
+---
+
+`record:related_list` and the detail synthesizer now declare two shapes they already accepted at runtime.
+
+`RecordRelatedListRenderer`'s `schema` prop made `objectName` required, which rejected the exact authoring shape the per-element `dataSource` binding exists to support (`{ relationshipField, dataSource: { object, view } }`) — the gate maps the binding onto `objectName` before the body reads it, so the key is supplied, not missing. It is optional on the wrapper's input now, and required everywhere else.
+
+`ObjectDefLike.fieldGroups` is derived from the spec's authorable field group instead of restating it. The hand-written list had drifted: it omitted `icon` and `description`, both of which the synthesizer passes through to detail section descriptors, so an object definition declaring the group icon the code honours did not type-check against it.

--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -27,7 +27,7 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.typetests.json && tsc -p tsconfig.test.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/plugin-detail/src/__tests__/DetailView.permissions.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailView.permissions.test.tsx
@@ -25,8 +25,13 @@ import type { ObjectPermissionConfig, RoleDefinition } from '@object-ui/types';
  * so they're independent of the /auth/me endpoint.
  */
 
+// `permissions: []` is accurate and required: a role's DIRECT object grants live
+// on `RoleDefinition.permissions`, and this role has none — every grant it uses
+// comes from the `ObjectPermissionConfig` below. (That the field is required and
+// read by nothing is the dormancy filed as #4288; this fixture states the truth
+// for its own role rather than pre-judging that finding.)
 const roles: RoleDefinition[] = [
-  { name: 'restricted', description: 'denies one field' },
+  { name: 'restricted', label: 'Restricted', description: 'denies one field', permissions: [] },
 ];
 
 function makeRestrictedConfig(deniedField: string): ObjectPermissionConfig {
@@ -34,8 +39,22 @@ function makeRestrictedConfig(deniedField: string): ObjectPermissionConfig {
     object: 'account',
     roles: {
       restricted: {
-        roleName: 'restricted',
-        objectPermissions: { read: true, create: false, update: false, delete: false },
+        // `actions` is the declared channel for a role's object-level grants and
+        // the only one `evaluatePermission` reads. This entry used to spell them
+        // `objectPermissions: { read: true, create: false, … }` beside a
+        // `roleName` echo of its own map key — neither key exists on
+        // `ObjectPermissionConfig['roles'][string]`, so both were inert, and the
+        // role in fact granted nothing at all. The rewrite says what the old
+        // shape meant: read allowed, no writes.
+        //
+        // No assertion in this file moves as a result, which is the point worth
+        // recording rather than hiding: the field gate below runs through
+        // `checkField`, which reads `fieldPermissions` directly and never
+        // consults `actions`, so these cases were testing what they claim to
+        // test even while the object grant was empty. The DetailView write gate
+        // (`perms.can(object,'update'|'delete')`) reads `actions` and stays
+        // false either way — 'update'/'delete' are absent before and after.
+        actions: ['read'],
         fieldPermissions: [{ field: deniedField, read: false, write: false }],
       },
     },

--- a/packages/plugin-detail/src/__tests__/DetailView.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailView.test.tsx
@@ -591,7 +591,7 @@ describe('DetailView', () => {
   it('should try fallback with alternate ID when first findOne throws an error', async () => {
     let callCount = 0;
     const mockDataSource = {
-      findOne: vi.fn().mockImplementation((_obj: string, id: string) => {
+      findOne: vi.fn().mockImplementation((_obj: string, _id: string) => {
         callCount++;
         if (callCount === 1) {
           // First call throws (simulate server error)

--- a/packages/plugin-detail/src/__tests__/RelatedList.addPickerGuard.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.addPickerGuard.test.tsx
@@ -33,6 +33,7 @@
  * here.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import { RelatedList } from '../RelatedList';
@@ -79,7 +80,12 @@ const renderList = (ds: any, add?: any) =>
 const queryAddButton = () =>
   screen.queryByRole('button', { name: /Assign position|Grant permission set|^Add$/ });
 
-let warn: ReturnType<typeof vi.spyOn>;
+// Typed at the console method actually spied on, not left generic: bare
+// `ReturnType<typeof vi.spyOn>` resolves the type parameters to their
+// constraints, which erases the call signature and makes every `mock.calls`
+// entry an implicit `any` — so `warnings()` below stringified an untyped bag
+// and could not have caught being handed the wrong argument shape.
+let warn: MockInstance<typeof console.warn>;
 
 beforeEach(() => {
   warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/plugin-detail/src/__tests__/RelatedList.listFilter.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.listFilter.test.tsx
@@ -28,6 +28,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MockInstance } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { RelatedList } from '../RelatedList';
@@ -112,7 +113,9 @@ describe('RelatedList — the list’s own filter reaches the query (objectstack
 });
 
 describe('RelatedList — a filter the raw-URL fallback cannot express (objectstack#7118)', () => {
-  let warn: ReturnType<typeof vi.spyOn>;
+  // Typed at the spied method — see `RelatedList.addPickerGuard.test.tsx` for
+  // why the bare generic form erases the call signature.
+  let warn: MockInstance<typeof console.warn>;
   let originalFetch: typeof globalThis.fetch;
   let fetchMock: ReturnType<typeof vi.fn>;
 

--- a/packages/plugin-detail/src/__tests__/RelatedList.longFormColumns.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.longFormColumns.test.tsx
@@ -41,7 +41,7 @@ import React from 'react';
 // alias; the package's `exports` map publishes only `.` and `./style.css`, so
 // nothing but that alias makes this path resolvable — which is why
 // `tsconfig.test.json` has to restate it as a `paths` entry (see there, and
-// #4324 for the packaging gap itself).
+// #4325 for the packaging gap itself).
 import '@object-ui/fields/widgets/MarkdownContent';
 import { RelatedList } from '../RelatedList';
 

--- a/packages/plugin-detail/src/__tests__/RelatedList.longFormColumns.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.longFormColumns.test.tsx
@@ -30,7 +30,18 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 // The markdown cell renderer is behind `React.lazy`; import the chunk at module
 // scope so the factory resolves immediately and the assertions are not racing
-// the module loader (AGENTS.md §测试纪律). Same specifier the component uses.
+// the module loader (AGENTS.md §测试纪律). This matters most for the NEGATIVE
+// cases: they check `queryByText('Heading')` synchronously after awaiting only
+// the row, so without the pre-load a wrongly-derived richtext column would
+// still read as absent while its chunk was in flight — green for the wrong
+// reason. It resolves to the same module the `React.lazy` factory inside
+// `@object-ui/fields` loads relatively, so the factory finds it already cached.
+//
+// The specifier reaches `@object-ui/fields`' SOURCE through the repo vitest
+// alias; the package's `exports` map publishes only `.` and `./style.css`, so
+// nothing but that alias makes this path resolvable — which is why
+// `tsconfig.test.json` has to restate it as a `paths` entry (see there, and
+// #4324 for the packaging gap itself).
 import '@object-ui/fields/widgets/MarkdownContent';
 import { RelatedList } from '../RelatedList';
 

--- a/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.actionText-i18n.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.actionText-i18n.test.tsx
@@ -63,9 +63,25 @@ function BundleLoader({ bundle, children }: { bundle?: unknown; children: React.
   return ready ? <>{children}</> : null;
 }
 
+/**
+ * The handler signatures, taken from `ActionProvider` rather than restated.
+ *
+ * These mocks are the assertion surface of every case below — each one reads
+ * `.mock.calls[0][0]` to check WHICH STRING the provider was handed. Declared as
+ * bare `vi.fn(async () => true)` / `vi.fn()` they had no parameters at all, so
+ * `calls[0]` was the empty tuple and `calls[0][0]` did not exist: the compiler
+ * could not see the argument these tests exist to inspect, and reported it the
+ * moment this package's tests were type-checked (TS2493). Deriving from the
+ * component's own props types the argument as the message it is, and keeps the
+ * mocks from drifting off the handler contract they impersonate.
+ */
+type ActionProviderProps = React.ComponentProps<typeof ActionProvider>;
+type ConfirmHandler = NonNullable<ActionProviderProps['onConfirm']>;
+type ToastHandler = NonNullable<ActionProviderProps['onToast']>;
+
 function mount(opts: { bundle?: unknown; action?: Record<string, unknown> } = {}) {
-  const onConfirm = vi.fn(async () => true);
-  const onToast = vi.fn();
+  const onConfirm = vi.fn<ConfirmHandler>(async () => true);
+  const onToast = vi.fn<ToastHandler>();
   const handler = vi.fn(async () => ({ success: true }));
   const utils = render(
     <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -52,7 +52,28 @@ const splitDesigner = (props: Record<string, any>) => {
 };
 
 export interface RecordRelatedListRendererProps {
-  schema?: RecordRelatedListComponentProps & Record<string, any>;
+  /**
+   * The AUTHORED node, before the per-element `dataSource` binding is resolved.
+   *
+   * `objectName` is optional HERE and required everywhere else, and the
+   * difference is the whole point of objectstack#6953: the exported name is the
+   * `ElementDataSourceGate` wrapper below, and the gate maps the binding's
+   * `object` onto `objectName` (its default target — see `ElementDataSourceGate`
+   * `objectKey = 'objectName'`) before `RecordRelatedListBody` ever sees the
+   * schema. A related list authored as `{ relationshipField, dataSource: {
+   * object, view } }` is therefore legal input to this component and illegal
+   * input to the spec's `RecordRelatedListProps`, which is correct on both
+   * sides — one describes what an author writes, the other what the block reads.
+   *
+   * Spelling it `RecordRelatedListComponentProps` flat said the opposite, and
+   * said it about the wrapper: the exact authoring shape #6953 added did not
+   * type-check against the component that exists to accept it. The body already
+   * reads the key defensively (`objectName && …`, `objectName || ''`) precisely
+   * because it can arrive unbound; this declaration now agrees with that code.
+   */
+  schema?: Omit<RecordRelatedListComponentProps, 'objectName'> &
+    Partial<Pick<RecordRelatedListComponentProps, 'objectName'>> &
+    Record<string, any>;
   className?: string;
   [k: string]: any;
 }

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -895,7 +895,19 @@ describe('semantic-role hints (ADR-0085 / #2065)', () => {
     });
 
     it('ignores the retired compactLayout spelling (framework#2536) — heuristic applies instead', () => {
-      const derived = deriveHighlightFields({ ...leadDef, compactLayout: ['email', 'phone'] }, 'status');
+      // The cast is the case, not a workaround for it: `compactLayout` was
+      // RETIRED, so `ObjectDefLike` rejecting it is the type doing its job, and
+      // spelling it here in a typed position would only be asserting that the
+      // retirement happened. What this case is about is the other half — an
+      // object definition arriving as untyped runtime metadata (a stored record,
+      // a hand-written JSON file) that still carries the old key. Widening the
+      // type to admit it would un-retire it; asserting through `Record` models
+      // the untyped source exactly and leaves the verdict below untouched.
+      const retiredSpelling = { ...leadDef, compactLayout: ['email', 'phone'] } as Record<
+        string,
+        unknown
+      > as ObjectDefLike;
+      const derived = deriveHighlightFields(retiredSpelling, 'status');
       expect(derived).not.toEqual(['email', 'phone']);
     });
 

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -24,6 +24,7 @@
  */
 
 import { deriveFieldGroupLayout } from '@objectstack/spec/data';
+import type { ServiceObject } from '@objectstack/spec/data';
 import { detectStatusField } from '@object-ui/types';
 import { inferDetailColumns } from '../autoLayout';
 
@@ -52,16 +53,27 @@ export interface ObjectDefLike {
    * Declared field groups from the object designer. Fields opt in via
    * `field.group === group.key`; the detail synthesizer derives sections
    * from them when no explicit sections are provided.
+   *
+   * DERIVED from the spec's own authorable group, not restated. This key is a
+   * pass-through: nothing here reads a member of it, `deriveFieldGroupLayout`
+   * (`@objectstack/spec/data`) does — so the set of members this type should
+   * admit is by definition the set the spec declares, and hand-listing them
+   * could only ever drift from it. It had: the hand-written list this replaces
+   * carried `key`/`label`/`collapse` and the deprecated `collapsible`/`collapsed`
+   * pair, but not `icon`, `description` or `defaultExpanded`. Two of those three
+   * are read by this very file — `deriveFieldGroupDetailSections` passes
+   * `s.icon`/`s.description` through to the section descriptors under a comment
+   * citing #2548 ("Dropping them here made the spec keys silently inert on
+   * detail pages") — so an author declaring the icon the synthesizer honours was
+   * rejected by the type of the function that honours it.
+   *
+   * `Partial` is the one shape difference and it is deliberate: the spec makes
+   * `key`/`label` required and `collapse` defaulted, but this is the duck type
+   * for a raw object definition that has NOT been through a spec parse (the
+   * whole reason it exists — see the interface header), so every member has to
+   * be admissible as absent. Nothing here requires a group member to be present.
    */
-  fieldGroups?: Array<{
-    key?: string;
-    label?: string;
-    collapse?: 'none' | 'expanded' | 'collapsed';
-    /** @deprecated pre-ADR-0085 pair; honoured by the shared derivation. */
-    collapsible?: boolean;
-    /** @deprecated pre-ADR-0085 pair; honoured by the shared derivation. */
-    collapsed?: boolean;
-  }>;
+  fieldGroups?: Array<Partial<NonNullable<ServiceObject['fieldGroups']>[number]>>;
   /**
    * Spec `enable` capability toggles. Only `files` is read here:
    * `enable.files === true` (opt-in, #2727) makes the synthesizer emit an

--- a/packages/plugin-detail/tsconfig.test.json
+++ b/packages/plugin-detail/tsconfig.test.json
@@ -1,0 +1,44 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` excludes.
+  // See `packages/types/tsconfig.test.json` for why that exclusion was a hole:
+  // the build correctly keeps tests out of `dist`, but nothing else compiled
+  // them, so a test could assert a contract the compiler never checked.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The package build emits `dist`; this project emits nothing, so it must
+    // not inherit `composite` / `declaration` from the build config.
+    "composite": false,
+    "declaration": false,
+    // `recordDetailsInputs.spec-parity.test.ts` reads the sibling spec source
+    // off disk to compare the declared input list against the renderer's, so
+    // this project needs Node's globals. Naming `types` at all switches off
+    // automatic `@types/*` inclusion; the `toBeInTheDocument` matchers do not
+    // need naming here because the three files that use them `import
+    // '@testing-library/jest-dom'` explicitly, and a global augmentation
+    // reached by an import applies to the whole program.
+    "types": ["node"],
+    // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` and
+    // `@objectstack/spec` resolve through the workspace dependency's built
+    // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
+    //
+    // The one entry that survives is not a convenience: `@object-ui/fields`'
+    // `exports` map publishes only `.` and `./style.css`, so the deep specifier
+    // `RelatedList.longFormColumns.test.tsx` uses to pre-resolve the lazy
+    // markdown chunk resolves through the repo vitest alias and through nothing
+    // else. Restating that one alias here is what lets `tsc` read the same
+    // program vitest runs; without it the import is TS2882 and the file cannot
+    // be type-checked at all. Narrow on purpose — `widgets/*` only, so no other
+    // sibling source can leak in behind it. The packaging gap it works around
+    // is filed as #4324; when `fields` publishes the subpath this entry goes.
+    // `paths` resolves against `baseUrl`, and the inherited one points at the
+    // REPO ROOT (the root tsconfig declares `"baseUrl": "."` and `extends`
+    // keeps it relative to the config that declared it). Re-anchor it here so
+    // the entry below reads relative to this package, as it appears to.
+    "baseUrl": ".",
+    "paths": {
+      "@object-ui/fields/widgets/*": ["../fields/src/widgets/*"]
+    }
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/plugin-detail/tsconfig.test.json
+++ b/packages/plugin-detail/tsconfig.test.json
@@ -30,7 +30,7 @@
     // program vitest runs; without it the import is TS2882 and the file cannot
     // be type-checked at all. Narrow on purpose — `widgets/*` only, so no other
     // sibling source can leak in behind it. The packaging gap it works around
-    // is filed as #4324; when `fields` publishes the subpath this entry goes.
+    // is filed as #4325; when `fields` publishes the subpath this entry goes.
     // `paths` resolves against `baseUrl`, and the inherited one points at the
     // REPO ROOT (the root tsconfig declares `"baseUrl": "."` and `extends`
     // keeps it relative to the config that declared it). Re-anchor it here so

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -122,7 +122,6 @@ export const TEST_DEBT = {
   "@object-ui/i18n": { errors: 13, issue: 4118, note: "TS2769x9" },
   "@object-ui/plugin-dashboard": { errors: 6, issue: 4118 },
   "@object-ui/plugin-list": { errors: 6, issue: 4118, note: "TS2353x3 — dialect keys" },
-  "@object-ui/plugin-detail": { errors: 5, issue: 4118, note: "TS2353x3 — dialect keys" },
   "@object-ui/plugin-gantt": { errors: 3, issue: 4118 },
   "@object-ui/plugin-grid": { errors: 2, issue: 4118 },
 };


### PR DESCRIPTION
Part of #4040 — one package per PR, per the standing objectstack#4118 ruling. `@object-ui/plugin-detail` now type-checks its 77 test files; its `TEST_DEBT` entry is gone.

## Measured, not trusted

The registry declared **5** errors. At this branch point the package has **11** — 0 config-tier, so 11 real. Tranche 2 established the registry is stale by up to 8x, and the full re-measure of every remaining entry is reported separately to the PM; plugin-detail is 2.2x.

The `tsconfig.test.json` needs no `lib` bump and no `@testing-library/jest-dom` in `types` (three files import it explicitly, and a global augmentation reached by an import applies program-wide). It does need `types: ["node"]` for the one parity test that reads spec sources off disk.

## Two public shapes that contradicted the code under them

**`RecordRelatedListRendererProps.schema` required `objectName`.** The exported `RecordRelatedListRenderer` is the `ElementDataSourceGate` wrapper, and the gate maps the per-element binding's `object` onto `objectName` before `RecordRelatedListBody` sees the schema. So `{ relationshipField, dataSource: { object, view } }` — the exact authoring shape objectstack#6953 added — was legal input at runtime and illegal to the type of the component that exists to accept it. The body already reads the key defensively (`objectName && …`, `objectName || ''`) precisely because it can arrive unbound; the declaration now agrees with that code. Optional on the wrapper's input only; the spec's `RecordRelatedListProps` keeps it required, which is correct — one describes what an author writes, the other what the block reads.

**`ObjectDefLike.fieldGroups` restated the spec's authorable group, and had drifted off it.** The hand-written list carried `key`/`label`/`collapse` plus the deprecated `collapsible`/`collapsed` pair, but not `icon`, `description` or `defaultExpanded`. Two of those three are read by the same file: `deriveFieldGroupDetailSections` passes `s.icon`/`s.description` through to the section descriptors under a comment citing #2548 ("Dropping them here made the spec keys silently inert on detail pages"). So an object definition declaring the group icon the synthesizer honours did not type-check against the synthesizer. It is derived from `ServiceObject['fieldGroups']` now — the key is a pass-through (`deriveFieldGroupLayout` is the real reader), so the members it should admit are by definition the ones the spec declares. `Partial` is the one shape difference, and it is the reason the type exists: a raw object definition that has not been through a spec parse.

## The test-side seven

- **`DetailView.permissions.test.tsx`** — the role config spelled its object grants as `objectPermissions: { read: true, … }` beside a `roleName` echo of its own map key. Neither key exists on `ObjectPermissionConfig['roles'][string]`, so both were inert and the role granted nothing at all. Rewritten to the `actions` channel `evaluatePermission` actually reads. **No assertion moves, and that is worth stating rather than hiding**: the field gate runs through `checkField`, which reads `fieldPermissions` directly and never consults `actions`, so these cases were testing what they claim even while the object grant was empty; the write gate reads `actions` and stays false either way. The `RoleDefinition` fixture gains `label` + `permissions: []` following the convention #4287 set (the dormancy itself is #4288).
- Two spies declared `ReturnType<typeof vi.spyOn>` — the bare generic resolves its type parameters to their constraints, erasing the call signature, so every `mock.calls` entry was an implicit `any`. Now `MockInstance<typeof console.warn>`.
- Two mocks in `record-quick-actions.actionText-i18n.test.tsx` had **no parameters** while every case reads `mock.calls[0][0]` to check which string the provider was handed — `calls[0]` was the empty tuple. Derived from `ActionProvider`'s own props rather than restated.
- One unused parameter; one retired-spelling negative case (`compactLayout`, framework#2536) that now models its untyped source instead of asking the type to re-admit a deliberately retired key.
- `RelatedList.longFormColumns.test.tsx`'s `@object-ui/fields/widgets/MarkdownContent` pre-load resolves **only** through the repo vitest alias — `fields` publishes no such subpath. The import is load-bearing (the negative cases assert synchronously against a `React.lazy` chunk, so without it a wrongly-derived column reads as absent while loading — green for the wrong reason), so it stays, and `tsconfig.test.json` restates the alias as a `paths` entry scoped to `widgets/*`. Packaging gap filed as **#4325**. Its comment also claimed "Same specifier the component uses", which was false — the component imports `./widgets/MarkdownContent` relatively from inside `fields`. Corrected.

## Discrimination proof

**A — the config actually runs.** This is objectui#3009's third failure mode (config exists, nothing invokes it). A provably-false line in a file only the new project reads; the first two compilers pass it and the third reports it:

```
> tsc --noEmit && tsc -p tsconfig.typetests.json && tsc -p tsconfig.test.json
src/__tests__/RelatedList.longFormColumns.test.tsx(49,7): error TS2322: Type 'string' is not
  assignable to type 'number'.
Exit status 2
```

**B — the `fieldGroups` derivation is real, not a widening.** Paste a key the spec does not declare and it is still rejected — and the message quotes the spec's own member list, which is what proves nothing was hand-copied and no index signature was added:

```
buildDefaultPageSchema.test.ts(978,11): error TS2561: Object literal may only specify known
  properties, but 'iconn' does not exist in type 'Partial< { key: string; label: string;
  icon?: string | undefined; description?: string | undefined; collapse?: "none" | "collapsed" |
  "expanded" | undefined; defaultExpanded?: boolean | undefined; collapsible?: boolean |
  undefined; collapsed?: boolean | undefined; } >'. Did you mean to write 'icon'?
```

**C — exactly one key was made optional.** Drop `relationshipField` from the same literal and it is still rejected:

```
RecordRelatedListRenderer.elementDataSource.test.tsx(65,34): error TS2322: ...
  Property 'relationshipField' is missing in type '{ [x: string]: any; }' but required in
  type 'Omit< RecordRelatedListComponentProps, "objectName" >'.
```

## Verification

```
pnpm --workspace-concurrency=2 --filter @object-ui/plugin-detail type-check   → exit 0
npx vitest run packages/plugin-detail --maxWorkers=2   → 77 files, 759 tests passed
node scripts/check-type-check-coverage.mjs
  ✅  test type-check coverage: 34/40 packages compile their tests, 6 declared debt
```

Merged `origin/main` to resolve the expected `check-type-check-coverage.mjs` conflict (tranche 2's #4297/#4317 plus #4283 landed while this was in flight): took main's registry, removed only this package's line, re-ran the script, re-ran `type-check` after the merge. **GitHub silently disables auto-merge on a conflict, so this PR needs it re-armed.**

Changeset: `patch` for `@object-ui/plugin-detail` — the two source type corrections are user-visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_