### PR TITLE
fix(plugin-map): read map config from the declared `map` input only, not `schema.filter`

### DIFF
--- a/.changeset/objectmap-filter-config-4034.md
+++ b/.changeset/objectmap-filter-config-4034.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/plugin-map': patch
+---
+
+`object-map` reads its configuration from the declared `map` input only — `filter` is the query filter, and a map authored with both stopped rendering markers
+
+`getMapConfig` probed every filter for a `map` key and, on a hit, used it as the MapConfig: `schema.filter.map`, plus a `schema.filter.map.style` half in the style chain. That shape predates the `{ name: 'map', type: 'object' }` input both registrations declare, and it gave `filter` two meanings inside one block — the query filter at `$filter: schema.filter`, and a configuration slot.
+
+The probe was written as `'map' in schema.filter`, and `in` walks the prototype chain. The ordinary filter is an **array**, and every array inherits `Array.prototype.map` — so the probe matched, handed the component a *function* as its map configuration, and the spread of a function is `{}`. The declared `schema.map` was never reached (it sat in the `else` branch), so a map authored with both `map` and `filter` — two documented inputs, no legacy shape required — lost `latitudeField` / `longitudeField` / `titleField`, failed `extractCoordinates` on every record, and rendered zero markers under a "N records with missing or invalid coordinates excluded from the map" banner. The only console output was `[ObjectMap] Invalid map configuration:` from the Zod parse of a function.
+
+This was reachable two ways and both are fixed by the same deletion: an author writing `filter` alongside `map`, and the `dataSource` binding of objectstack#7121, whose merged filter is an `and` node — `['and', [...], [...]]`, still an array, still carrying `Array.prototype.map`.
+
+Both legacy reads are gone; the map consumes only what it declares. The `map` config, the top-level `locationField` / `latitudeField` branch, and the `style` / `mapStyle` reads are untouched, and `filter` is passed to the query verbatim — a field genuinely named `map` still filters on it, and nothing is stripped from the author's filter.
+
+A schema still carrying the legacy `filter.map` stash now gets a dev-mode warning naming the shape and pointing at `schema.map`, rather than silently falling back to the default field names. It is deliberately narrow: own properties only (so an inherited `map` method never triggers it) and object-valued only (so `filter: { map: 'x' }` reads as a filter on a field named `map`), and it warns once per distinct stash because `getMapConfig` runs on every render. Production behavior is unchanged beyond the configuration no longer being read.

--- a/packages/plugin-map/src/ObjectMap.filterConfig.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.filterConfig.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `filter` is the query filter — NOT a container for the map's configuration
+ * (objectui#4034, source thread objectstack#7138).
+ *
+ * `getMapConfig` used to probe every filter for a `map` key and, on a hit, use
+ * it as the MapConfig (`schema.filter.map` / `schema.filter.map.style`) — a
+ * shape that predates the declared `{ name: 'map', type: 'object' }` input. Two
+ * readings of `filter` in one block; the declared one is `schema.map`.
+ *
+ * The probe was written as `'map' in schema.filter`, and `in` walks the
+ * PROTOTYPE CHAIN — so for the ordinary array-shaped filter it matched
+ * `Array.prototype.map` and handed the component a *function* as its map
+ * config. Spreading a function yields `{}`, so the declared `schema.map` was
+ * dropped on the floor and every record failed `extractCoordinates`: a map with
+ * both `filter` and `map` authored rendered ZERO markers, silently. That is the
+ * live half of this card — reachable through fully documented authoring, not
+ * only through the legacy shape.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ObjectMap } from './ObjectMap';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+
+// Registers `object-map` + the ElementDataSourceGate wiring (objectstack#7121).
+// Imported at module scope, not in a hook: the binding case below renders
+// through the registry (AGENTS.md — dynamic import in a hook is lint-blocked).
+import './index';
+
+let capturedProps: any = null;
+
+vi.mock('react-map-gl/maplibre', () => ({
+  default: (props: any) => {
+    capturedProps = props;
+    return <div aria-label="Map">{props.children}</div>;
+  },
+  Map: ({ children }: any) => <div aria-label="Map">{children}</div>,
+  NavigationControl: () => <div data-testid="nav-control" />,
+  Marker: ({ children, longitude, latitude }: any) => (
+    <div data-testid="map-marker" data-lat={latitude} data-lng={longitude}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
+}));
+
+/** Rows whose coordinates live under NON-default field names. */
+const ROWS = [{ id: '1', name: 'HQ', lat: 40, lng: -74 }];
+/** The same place, spelled the way the DEFAULT config expects. */
+const ROWS_DEFAULT_SPELLING = [{ id: '1', name: 'HQ', latitude: 40, longitude: -74 }];
+
+const DECLARED_MAP = { latitudeField: 'lat', longitudeField: 'lng', titleField: 'name' };
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  capturedProps = null;
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+const renderMap = async (schema: Record<string, unknown>) => {
+  const utils = render(<ObjectMap schema={schema as any} />);
+  await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+  return utils;
+};
+
+const warnings = () => warnSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+
+// ---------------------------------------------------------------------------
+// (a) The legacy shape is no longer consumed — and does not vanish silently.
+// ---------------------------------------------------------------------------
+describe('legacy `filter.map` is not map configuration (objectui#4034)', () => {
+  it('ignores a MapConfig stashed under `filter.map` and falls to the default config', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      filter: { map: DECLARED_MAP },
+    });
+
+    // The stash named `lat`/`lng`; it is not read, so the default config
+    // (`latitude`/`longitude`) applies and finds no coordinates on these rows.
+    expect(screen.queryAllByTestId('map-marker')).toHaveLength(0);
+  });
+
+  it('really is the DEFAULT config that applies, not "no config at all"', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS_DEFAULT_SPELLING },
+      filter: { map: { latitudeField: 'lat', longitudeField: 'lng' } },
+    });
+
+    // Same legacy stash, rows spelled the default way: the default config is
+    // live and places the marker. (Pre-fix this rendered nothing — the stash
+    // won and looked for `lat`/`lng`.)
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toHaveAttribute('data-lat', '40');
+  });
+
+  it('warns in dev, naming the legacy shape and pointing at `schema.map`', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      filter: { map: { titleField: 'name', zoom: 4 } },
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnings()).toContain('[ObjectMap]');
+    expect(warnings()).toContain('filter.map');
+    expect(warnings()).toContain('schema.map');
+    expect(warnings()).toContain('objectui#4034');
+  });
+
+  it('stops reading the `filter.map.style` half too', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS_DEFAULT_SPELLING },
+      filter: { map: { style: 'https://legacy.example.com/style.json' } },
+    });
+
+    expect(capturedProps.mapStyle).toBe('https://demotiles.maplibre.org/style.json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) Control — the declared shape keeps working, green on both sides.
+// ---------------------------------------------------------------------------
+describe('the declared `map` input is what configures the map (control)', () => {
+  it('applies `schema.map` and places the marker', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      map: DECLARED_MAP,
+    });
+
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toHaveAttribute('data-lat', '40');
+    expect(markers[0]).toHaveAttribute('data-lng', '-74');
+  });
+
+  it('reads `map.style`, and says nothing about a schema with no legacy shape', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      map: { ...DECLARED_MAP, style: 'https://tiles.example.com/style.json' },
+    });
+
+    expect(capturedProps.mapStyle).toBe('https://tiles.example.com/style.json');
+    expect(warnings()).not.toContain('[ObjectMap]');
+  });
+
+  it('keeps the top-level `latitudeField` branch intact', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      latitudeField: 'lat',
+      longitudeField: 'lng',
+      titleField: 'name',
+    });
+
+    expect(screen.getAllByTestId('map-marker')).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) Control — `filter` keeps its ONE meaning: it filters. Untouched by the fix.
+// ---------------------------------------------------------------------------
+describe('`filter` still reaches the query unchanged (control)', () => {
+  const makeDataSource = () => ({
+    find: vi.fn().mockResolvedValue({ data: [] }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({ name: 'store', fields: {} }),
+  });
+
+  const sentFilter = async (filter: unknown) => {
+    const ds = makeDataSource();
+    render(
+      <ObjectMap
+        schema={{ type: 'object-map', objectName: 'store', map: DECLARED_MAP, filter } as any}
+        dataSource={ds as any}
+      />,
+    );
+    await waitFor(() => expect(ds.find).toHaveBeenCalled());
+    return (ds.find.mock.calls[0] as [string, any])[1].$filter;
+  };
+
+  it('passes an array filter through verbatim', async () => {
+    expect(await sentFilter([['owner', '=', 'me']])).toEqual([['owner', '=', 'me']]);
+  });
+
+  it('passes an object filter through verbatim', async () => {
+    expect(await sentFilter({ status: 'active' })).toEqual({ status: 'active' });
+  });
+
+  it('does NOT strip a `map` key out of the filter — the filter is the author’s', async () => {
+    // The block stops *interpreting* `filter.map` as configuration; it does not
+    // rewrite the query. A field genuinely named `map` still filters on it.
+    expect(await sentFilter({ map: { latitudeField: 'lat' } })).toEqual({
+      map: { latitudeField: 'lat' },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (d) The live defect + the post-#7121 merged-`and` binding path.
+// ---------------------------------------------------------------------------
+describe('an ordinary filter no longer eats the map config', () => {
+  it('applies `schema.map` when an array filter is authored alongside it', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      map: DECLARED_MAP,
+      filter: [['owner', '=', 'me']],
+    });
+
+    // Pre-fix: `'map' in [...]` matched `Array.prototype.map`, the config became
+    // the spread of a function (`{}`), and this rendered zero markers.
+    const markers = screen.getAllByTestId('map-marker');
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toHaveAttribute('data-lat', '40');
+  });
+
+  it('does not warn about a filter that merely has array-ness (no own `map` key)', async () => {
+    await renderMap({
+      type: 'object-map',
+      data: { provider: 'value', items: ROWS },
+      map: DECLARED_MAP,
+      filter: [['owner', '=', 'me']],
+    });
+
+    expect(warnings()).not.toContain('[ObjectMap]');
+  });
+
+  it('survives the merged `and` node a dataSource binding produces (objectstack#7121)', async () => {
+    const adapter = {
+      find: vi.fn().mockResolvedValue({ data: ROWS }),
+      findOne: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      getObjectSchema: vi.fn().mockResolvedValue({
+        name: 'store',
+        fields: { name: { type: 'text' }, rating: { type: 'text' } },
+        listViews: { hot: { name: 'hot', label: 'Hot', filter: [['rating', '=', 'hot']] } },
+      }),
+    };
+
+    render(
+      <SchemaRendererProvider dataSource={adapter as any}>
+        <SchemaRenderer
+          schema={
+            {
+              type: 'object-map',
+              map: DECLARED_MAP,
+              filter: [['owner', '=', 'me']],
+              dataSource: { object: 'store', view: 'hot' },
+            } as any
+          }
+        />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    const sent = (adapter.find.mock.calls[0] as [string, any])[1].$filter;
+
+    // Measured shape of the merge (objectstack#7121 + `mergeFilterNodes`):
+    expect(sent).toEqual(['and', [['owner', '=', 'me']], [['rating', '=', 'hot']]]);
+
+    // Exactly why the deleted probe misfired, pinned so it cannot come back:
+    // the merged node has NO own `map` key, yet `'map' in` it is true.
+    expect(Object.prototype.hasOwnProperty.call(sent, 'map')).toBe(false);
+    expect('map' in (sent as object)).toBe(true);
+
+    // …and the declared config still reaches the markers.
+    await waitFor(() => expect(screen.getAllByTestId('map-marker')).toHaveLength(1));
+    expect(screen.getAllByTestId('map-marker')[0]).toHaveAttribute('data-lat', '40');
+    expect(warnings()).not.toContain('[ObjectMap]');
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -134,15 +134,81 @@ function convertSortToQueryParams(sort: string | any[] | undefined): Record<stri
   return undefined;
 }
 
+const isDev = (): boolean =>
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+    ?.NODE_ENV !== 'production';
+
+/**
+ * Warn once per distinct legacy stash, not once per evaluation: `getMapConfig`
+ * runs on every render of the map (hover, zoom, search all re-render it), and a
+ * warning that floods the console is a warning that gets muted. Mirrors the
+ * warn-once discipline of the visibility-predicate diagnostics in
+ * `app-shell/src/views/metadata-admin/predicate.ts` (objectui#4049).
+ */
+const warnedLegacyFilterMapConfigs = new Set<string>();
+
+/**
+ * `filter` is the query filter, not a configuration slot — objectui#4034
+ * (source thread objectstack#7138).
+ *
+ * `getMapConfig` used to ALSO read the map's configuration out of
+ * `schema.filter.map` (and its `style` half), a shape predating the declared
+ * `{ name: 'map', type: 'object' }` input. That read is gone: the block
+ * consumes only what it declares. Authoring the config under `filter.map`
+ * therefore has no effect, so say so in dev rather than dropping the author's
+ * markers without a trace — the map now renders with the DEFAULT field names,
+ * which looks exactly like "the data is wrong".
+ *
+ * Deliberately narrow, to stay off legitimate query filters:
+ * - OWN property only. `'map' in someArray` is TRUE via `Array.prototype.map`,
+ *   which is precisely how the deleted probe misfired on every array-shaped
+ *   filter — including the `and` node a dataSource binding merges
+ *   (objectstack#7121). An inherited method is not an authoring mistake.
+ * - object-valued only. `filter: { map: 'x' }` reads as a filter on a field
+ *   named `map`, not as a stashed MapConfig.
+ */
+function warnOnLegacyFilterMapConfig(schema: ObjectGridSchema | any): void {
+  if (!isDev()) return;
+
+  const filter = (schema as any)?.filter;
+  if (!filter || typeof filter !== 'object' || Array.isArray(filter)) return;
+  if (!Object.prototype.hasOwnProperty.call(filter, 'map')) return;
+
+  const legacy = (filter as any).map;
+  if (!legacy || typeof legacy !== 'object') return;
+
+  let memo: string;
+  try {
+    memo = `${(schema as any).type ?? 'map'}::${(schema as any).objectName ?? ''}::${JSON.stringify(legacy)}`;
+  } catch {
+    // Circular author data — still worth one warning, just not a keyed one.
+    memo = `${(schema as any).type ?? 'map'}::${(schema as any).objectName ?? ''}::<unserializable>`;
+  }
+  if (warnedLegacyFilterMapConfigs.has(memo)) return;
+  warnedLegacyFilterMapConfigs.add(memo);
+
+  console.warn(
+    '[ObjectMap] `filter.map` is no longer read as map configuration, so this map is ' +
+      'rendering with the DEFAULT field names (`latitude` / `longitude` / `name`). `filter` is ' +
+      'the query filter; the map config belongs under the declared `map` input — move it to ' +
+      '`schema.map` (`{ type: \'object-map\', map: { latitudeField, longitudeField, titleField } }`). ' +
+      'The old spelling was never documented and could not survive a `dataSource` binding, whose ' +
+      'merged filter is an `and` node with no `map` key at all (objectstack#7121). If `map` is ' +
+      'genuinely a field you are filtering on, ignore this — the filter itself is passed through ' +
+      'untouched. objectui#4034.',
+  );
+}
+
 /**
  * Helper to get map configuration from schema
  */
 function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
+  warnOnLegacyFilterMapConfig(schema);
+
   // A custom style may be set alongside any of the shapes below — read it
   // once so every return path can carry it through.
   const style: string | undefined =
-    (schema as any).style || (schema as any).mapStyle
-    || (schema.filter as any)?.map?.style || (schema as any).map?.style;
+    (schema as any).style || (schema as any).mapStyle || (schema as any).map?.style;
 
   // 1. Check top-level properties (ObjectMapSchema style)
   if (schema.locationField || schema.latitudeField) {
@@ -158,16 +224,11 @@ function getMapConfig(schema: ObjectGridSchema | any): MapConfig {
       };
   }
 
-  let config: MapConfig | null = null;
-  // Check if schema has map configuration
-  if (schema.filter && typeof schema.filter === 'object' && 'map' in schema.filter) {
-    config = (schema.filter as any).map as MapConfig;
-  }
-
-  // For backward compatibility, check if schema has map config at root
-  else if ((schema as any).map) {
-    config = (schema as any).map as MapConfig;
-  }
+  // 2. The declared configuration input: `{ name: 'map', type: 'object' }` at
+  // the `object-map` / `map` registrations. The only shape consumed here.
+  const config: MapConfig | null = (schema as any).map
+    ? ((schema as any).map as MapConfig)
+    : null;
 
   if (config) {
      const result = MapConfigSchema.safeParse(config);

--- a/packages/plugin-map/src/index.tsx
+++ b/packages/plugin-map/src/index.tsx
@@ -28,14 +28,12 @@ export type { ObjectMapProps };
  * config names (latitude/longitude/title/description) and its fetch issues no
  * `$top`, so neither key has a read site to write to.
  *
- * One caveat that belongs next to `filter: true` rather than in a changelog:
- * `getMapConfig` ALSO accepts the map's own configuration stashed under
- * `schema.filter.map` (a legacy shape predating the `map` input). A binding whose
- * filter actually composes replaces that object with an AND node, so the legacy
- * stash stops being found — authoring the map config under `map` (the declared
- * input) is the supported spelling and the only one the binding is compatible
- * with. Filed separately as the overload it is; nothing here relies on it, and a
- * schema with no composing filter passes `schema.filter` through untouched.
+ * `filter` here means the query filter and nothing else. `getMapConfig` used to
+ * ALSO accept the map's own configuration stashed under `schema.filter.map` (a
+ * shape predating the `map` input); that read is gone as of objectui#4034 —
+ * the map config is read from the declared `map` input only, and a schema still
+ * carrying the legacy stash gets a dev-mode warning instead of silently losing
+ * its markers. Nothing here ever relied on it.
  */
 const OBJECT_MAP_DATA_SOURCE: ElementDataSourceMapping = {
   filter: true,


### PR DESCRIPTION
Fixes #4034. Source thread: objectstack-ai/objectstack#7138 (triage promotion of record; its anchors re-verified below at current `main`).

`getMapConfig` probed every filter for a `map` key and, on a hit, used it as the map's configuration — `schema.filter.map`, plus a `schema.filter.map.style` half in the style chain. That shape predates the `{ name: 'map', type: 'object' }` input both registrations declare, and it gave `filter` two meanings inside one block: the query filter at `$filter: schema.filter`, and a configuration slot.

Both reads are deleted. The block consumes only what it declares.

## Dispatch guard — grep first, 0 live usages

Run before deleting anything, per the triage ruling. Patterns, across this repo (including `examples/` and the schema-catalog fixtures) and the sibling `objectstack` checkout:

| pattern | scope | hits |
|---|---|---|
| `filter\s*:\s*\{[^{}]{0,400}\bmap\s*:` (multiline) | objectui + objectstack | 0 |
| `"filter"\s*:\s*\{[^{}]{0,400}"map"\s*:` (JSON) | objectui + objectstack | 0 |
| `filter.map` / `filter?.map` | objectui | 3, all unrelated — two `Array.prototype.map` calls, one comment |
| `filter:` block with nested `map:` (YAML) | objectui + objectstack | 0 |

All three `object-map` catalog fixtures (`examples/schema-catalog/src/schemas/plugin-map/`) author the canonical `map`. The docs (`content/docs/plugins/plugin-map.mdx`, package README) document `map` only and never mentioned the legacy shape, so nothing in them became false. The two `objectstack` hits for the string "object-map" are the phrase used to mean a JS object-as-map (`fields` shape) in `packages/rest` export tests, not this block.

## The premise is confirmed, and it is larger than the card recorded

Both anchors were live at `b7da03dd7`: the style half at `ObjectMap.tsx:145`, the config probe at `:163-164`.

The card and triage both describe this as observation-class — "no user hits it today; it needs an undocumented legacy shape". That is true of the `filter.map` stash, but the probe has a second, live effect that neither had measured:

```
'map' in schema.filter
```

`in` walks the **prototype chain**, and the ordinary filter is an **array**. Every array inherits `Array.prototype.map`, so the probe matched on *any* array-shaped filter and assigned the inherited **function** as the MapConfig. The spread of a function is `{}`, and the declared `schema.map` sat unreachable in the `else` branch. Measured:

```
'map' in [['rating','=','hot']]   ->  true
config                            ->  function map() { [native code] }
{...config}                       ->  {}
```

So a map authored with **both** `map` and `filter` — two declared inputs, no legacy shape required — lost `latitudeField` / `longitudeField` / `titleField`, failed `extractCoordinates` on every record, and rendered zero markers behind a "records with missing or invalid coordinates excluded from the map" banner. The only console output was `[ObjectMap] Invalid map configuration:` from the Zod parse of a function.

This also corrects the mechanism the card predicted for the objectstack#7121 binding path. The card expected the merged filter to carry no `map` key and the map to fall back to the **default** config. Measured, the merged node is an array:

```
["and",[["owner","=","me"]],[["rating","=","hot"]]]
```

so the probe **hit** `Array.prototype.map` there too — the result was not the default config but an empty one. Same outcome for the user (no markers), different cause; the test pins the real shape.

## What changed

- Deleted the config probe (`:163-164`) and the `filter.map.style` half (`:145`).
- Kept intact, as the card requires: the declared `schema.map` config, the top-level `locationField` / `latitudeField` branch, and the `style` / `mapStyle` top-level reads.
- `filter` keeps exactly one meaning in the file: `$filter: schema.filter` is untouched, and the filter is **not** rewritten — a field genuinely named `map` still filters on it.
- No silent removal: a schema still carrying the legacy stash gets a dev-mode warning naming the shape and pointing at `schema.map`.

The warning follows the existing warn-once diagnostic idiom of `app-shell/src/views/metadata-admin/predicate.ts` (#4049) rather than a new logging dialect: defensive `globalThis.process?.env?.NODE_ENV` dev gate (the form `plugin-dashboard` uses, since `process` may not exist in a pure browser bundle), a `[ObjectMap]` prefix matching this file's existing warn, and a warn-once memo — `getMapConfig` runs on every render, and a flooding warning is a muted one. It is deliberately narrow: **own** properties only, so an inherited `map` method never trips it, and **object-valued** only, so `filter: { map: 'x' }` reads as a filter on a field named `map`.

Production behavior is unchanged beyond the configuration no longer being read.

## Tests

New `packages/plugin-map/src/ObjectMap.filterConfig.test.tsx`, written red-first with the direction predicted before each run.

Reverse verification by restoring `ObjectMap.tsx` to `origin/main` with the new tests kept (commit-then-revert, never `git stash`) — prediction was "the 7 behavioral tests go red, the 6 controls stay green", and that is exactly what happened, identical to the pre-implementation baseline:

| group | before | after |
|---|---|---|
| legacy stash ignored, falls to the **default** config | red | green |
| the default config is genuinely live (not "no config") | red | green |
| dev warning names the shape and points at `schema.map` | red | green |
| `filter.map.style` half no longer read | red | green |
| control: declared `schema.map` applies, reads `map.style`, no warning | green | green |
| control: top-level `latitudeField` branch | green | green |
| control: `$filter` receives array / object / `map`-keyed filters verbatim | green | green |
| array filter alongside `map` renders markers (the live defect) | red | green |
| no warning from mere array-ness (no own `map` key) | red | green |
| merged `and` binding node keeps the config, no false-positive warning | red | green |

The merged-node test pins the mechanism so it cannot come back: the node has **no own** `map` key, yet `'map' in` it is true.

Commands:

```
pnpm exec vitest run packages/plugin-map/            ->  5 files, 24 tests passed
pnpm --filter '@object-ui/plugin-map' type-check     ->  clean (tsc --noEmit && tsc -p tsconfig.test.json)
pnpm --filter '@object-ui/plugin-map' lint           ->  0 errors (75 pre-existing warnings, unchanged)
node scripts/check-changeset-presence.mjs            ->  1 changeset declared
node scripts/check-changeset-no-major.mjs            ->  no major bump
```

Downstream consumer sweep — only `apps/console` and `apps/site` depend on `@object-ui/plugin-map`; console's `public-contract` and `public-block-binding-reach` suites pass (27 tests). Dependency closure was built before type-checking.

Changeset: `patch` for `@object-ui/plugin-map`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_