### PR TITLE
fix(fields,i18n,dashboard): number renderers follow the active locale and stop grouping ordinals

### DIFF
--- a/.changeset/number-format-locale-ordinal-grouping-4033.md
+++ b/.changeset/number-format-locale-ordinal-grouping-4033.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/i18n': patch
+'@object-ui/fields': patch
+'@object-ui/components': patch
+'@object-ui/plugin-dashboard': patch
+---
+
+Numbers render in the user's locale, and a `Field.number` year is no longer `2,026`
+
+Every numeric field the console rendered went through an `Intl.NumberFormat` built with the locale hardcoded to `en-US` and `useGrouping` never set. Two defects rode in that one construction: a `zh-CN` or `de-DE` console still grouped and pointed decimals the US way, and a four-digit **year** stored as `Field.number({ scale: 0 })` rendered as `2,026` — in every locale, with no field property able to turn it off. Apps had been converting year columns to `Field.text` to escape it, permanently trading numeric comparison, range filters and dataset dimension types for a display detail.
+
+The construction had been copied into five places — the number cell renderer, the currency cell renderer, the `CurrencyField` widget, the compact `formatNumber` helper, and the dashboard `MetricWidget` — so fixing any one surface never changed the answer. They now share one formatter, `formatDisplayNumber` in `@object-ui/i18n`, which owns the locale and the grouping policy together, plus one locale resolver, `useDisplayLocale`.
+
+`useDisplayLocale` composes the two locale channels this repo already had rather than adding a third: the tenant's regional default (`useLocalization().locale`, ADR-0053) when an org has configured one, otherwise the active UI language (`useObjectTranslation().language`) so grouping and decimal marks follow a language switch. That second step is what covers the case the report was measured in — a fresh database, where the tenant localization endpoint has no locale to give.
+
+Grouping is now suppressed when a field declares `scale: 0` and carries no currency, which is what makes years, fiscal periods and other ordinals render plainly. This is an **interim default** with an accepted cost: a large scale-0 *count* loses its separators too. It holds only until the spec gains an authorable presentation hint, which is being specified separately, contract-first; when that lands it overrides this heuristic.
+
+Three surfaces deliberately keep their separators, because a zero-decimal display there does not come from a field declaration: the dashboard `MetricWidget` (its decimals are parsed from a numeral.js format pattern, and its own contract calls the separators load-bearing — "`1,930,000` not `1930000`"), the `element:number` aggregate renderer, and every currency path including amounts whose currency code could not be resolved. An **undeclared** `scale` also keeps grouping — absent means "decimals unknown", not "integer".
+
+`formatCurrency`, `formatCompactCurrency` and `formatNumber` each take a new optional trailing `locale` argument. Existing calls are unaffected; omitting it now follows the runtime default rather than forcing US conventions.

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -27,7 +27,14 @@
 import * as React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { useAdapter, useAction } from '@object-ui/react';
-import { useObjectTranslation, pickLocalized, useLocalization } from '@object-ui/i18n';
+import {
+  useObjectTranslation,
+  pickLocalized,
+  useLocalization,
+  useDisplayLocale,
+  formatDisplayNumber,
+  type DisplayNumberFormatOptions,
+} from '@object-ui/i18n';
 import { cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { Button, Separator } from '../../ui';
@@ -299,9 +306,9 @@ ComponentRegistry.register('button', ElementButtonRenderer, {
 // element:number — aggregate metric pulled from an object via the adapter.
 // ---------------------------------------------------------------------------
 
-const FORMAT_OPTS: Record<string, Intl.NumberFormatOptions> = {
+const FORMAT_OPTS: Record<string, DisplayNumberFormatOptions> = {
   number: {},
-  currency: { style: 'currency', currency: 'USD' },
+  currency: { currency: 'USD' },
   percent: { style: 'percent', maximumFractionDigits: 1 },
 };
 
@@ -322,7 +329,10 @@ function formatValue(
   if (format === 'currency') {
     opts = currency ? { ...FORMAT_OPTS.currency, currency } : FORMAT_OPTS.number;
   }
-  const body = new Intl.NumberFormat(locale, opts).format(value);
+  // No `scale` passed: an `element:number` renders an AGGREGATE (count / sum /
+  // avg), not a scale-bearing field value, so objectui#4033's ordinal
+  // no-grouping default must not fire on it — a large count keeps separators.
+  const body = formatDisplayNumber(value, { ...opts, locale });
   return `${prefix ?? ''}${body}${suffix ?? ''}`;
 }
 
@@ -338,8 +348,12 @@ function ElementNumberRenderer({ schema }: { schema: any }) {
     aria?: Record<string, any>;
   }>(schema);
   const adapter = useAdapter() as any;
-  // Tenant default currency + locale (ADR-0053) for a `currency`-format metric.
-  const { currency: tenantCurrency, locale } = useLocalization();
+  // Tenant default currency (ADR-0053) for a `currency`-format metric; the
+  // display locale resolves through the shared precedence (tenant regional
+  // default → active UI language), so the metric follows a language switch even
+  // when no tenant locale is configured (objectui#4033).
+  const { currency: tenantCurrency } = useLocalization();
+  const locale = useDisplayLocale();
   const [value, setValue] = React.useState<number | null>(null);
   const [loading, setLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<string | null>(null);

--- a/packages/fields/src/__tests__/NumberCellRenderer.grouping.test.tsx
+++ b/packages/fields/src/__tests__/NumberCellRenderer.grouping.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4033 (source thread objectstack#5067) — the number cell renderer
+ * used to build `new Intl.NumberFormat('en-US', …)` with grouping left at the
+ * Intl default, so a four-digit YEAR stored as `Field.number({ scale: 0 })`
+ * rendered as `2,026` in every locale and no field property could turn it off.
+ *
+ * Two independent pins live here:
+ *
+ *  1. **Ordinal grouping** — a declared `scale: 0` with no currency is an
+ *     integer/ordinal surface, so grouping is suppressed. Interim default; a
+ *     future spec-level presentation hint overrides it.
+ *  2. **Locale** — grouping and decimal marks follow the ACTIVE display locale,
+ *     never a hardcoded `en-US`.
+ *
+ * The controls are as load-bearing as the fixes: currency keeps grouping, a
+ * non-zero `scale` keeps grouping, and an UNDECLARED scale keeps grouping
+ * (`scale` is optional in the spec and absent means "decimals unknown", not
+ * "integer" — see the renderer's own comment).
+ */
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LocalizationProvider } from '@object-ui/i18n';
+import { NumberCellRenderer, CurrencyCellRenderer } from '../index';
+
+const renderNumber = (
+  value: unknown,
+  field: Record<string, unknown> = {},
+  locale?: string,
+) =>
+  render(
+    <LocalizationProvider value={{ locale }}>
+      <NumberCellRenderer value={value as any} field={{ type: 'number', ...field } as any} />
+    </LocalizationProvider>,
+  );
+
+const renderCurrency = (
+  value: unknown,
+  field: Record<string, unknown> = {},
+  locale?: string,
+) =>
+  render(
+    <LocalizationProvider value={{ locale }}>
+      <CurrencyCellRenderer value={value as any} field={{ type: 'currency', ...field } as any} />
+    </LocalizationProvider>,
+  );
+
+describe('NumberCellRenderer — ordinal grouping (objectui#4033)', () => {
+  // The card's exact fixture: `year: Field.number({ scale: 0, min: 1900 })`.
+  it.each(['en-US', 'de-DE', 'zh-CN', 'fr-FR'])(
+    'renders a scale-0 year ungrouped in %s',
+    (locale) => {
+      renderNumber(2026, { scale: 0 }, locale);
+      expect(screen.getByText('2026')).toBeInTheDocument();
+    },
+  );
+
+  it('suppresses grouping for every scale-0 magnitude, not just four digits', () => {
+    renderNumber(1234567, { scale: 0 }, 'en-US');
+    expect(screen.getByText('1234567')).toBeInTheDocument();
+  });
+
+  it('CONTROL: a non-zero scale keeps grouping', () => {
+    renderNumber(1234.5, { scale: 2 }, 'en-US');
+    expect(screen.getByText('1,234.50')).toBeInTheDocument();
+  });
+
+  it('CONTROL: an UNDECLARED scale keeps grouping (absent ≠ integer)', () => {
+    renderNumber(2026, {}, 'en-US');
+    expect(screen.getByText('2,026')).toBeInTheDocument();
+  });
+});
+
+describe('NumberCellRenderer — active display locale (objectui#4033)', () => {
+  it('uses the active locale decimal + grouping marks (de-DE)', () => {
+    renderNumber(1234.5, { scale: 1 }, 'de-DE');
+    expect(screen.getByText('1.234,5')).toBeInTheDocument();
+  });
+
+  it('uses the active locale decimal + grouping marks (en-US)', () => {
+    renderNumber(1234.5, { scale: 1 }, 'en-US');
+    expect(screen.getByText('1,234.5')).toBeInTheDocument();
+  });
+
+  it('uses the active locale decimal + grouping marks (fr-FR)', () => {
+    // fr-FR groups with U+202F (NARROW NO-BREAK SPACE) and uses "," for the
+    // decimal mark — nothing an en-US formatter can produce.
+    //
+    // Asserted against raw `textContent`, NOT `getByText`: testing-library's
+    // default normalizer collapses `\s+` (which includes U+202F) down to an
+    // ASCII space, so a `getByText` assertion here can only ever prove "some
+    // whitespace" and would pass on the wrong separator. The escape sequence is
+    // written out rather than pasted — a raw U+202F in source renders as
+    // nothing and is unfindable by grep.
+    const { container } = renderNumber(1234.5, { scale: 1 }, 'fr-FR');
+    expect(container.textContent).toBe('1 234,5');
+  });
+
+  it('does not take a malformed tenant locale down with it', () => {
+    // `locale` arrives from a server response (ADR-0053); a junk tag must
+    // degrade to the runtime default, never throw out of a grid cell.
+    renderNumber(1234.5, { scale: 1 }, 'not a locale');
+    expect(screen.getByText(/1.?234.5/)).toBeInTheDocument();
+  });
+});
+
+describe('CurrencyCellRenderer — CONTROL, unaffected by the ordinal default', () => {
+  it('keeps grouping and the currency symbol for a whole amount', () => {
+    renderCurrency(5000000, { currency: 'USD' }, 'en-US');
+    expect(screen.getByText('$5,000,000')).toBeInTheDocument();
+  });
+
+  it('keeps grouping and the fractional part when the amount is not whole', () => {
+    renderCurrency(1234.5, { currency: 'USD' }, 'en-US');
+    // Pins CURRENT behaviour, which is `$1,234.5` — NOT the `$1,234.50` that
+    // `formatCurrency`'s own doc comment promises ("Salesforce convention:
+    // `$1,234.50` keeps cents"). The construction passes
+    // `minimumFractionDigits: 0`, so a trailing zero is dropped from a real
+    // cents value. Pre-existing and out of this card's scope (it is neither a
+    // locale nor a grouping defect) — filed separately; this control exists to
+    // prove #4033 does not disturb it.
+    expect(screen.getByText('$1,234.5')).toBeInTheDocument();
+  });
+
+  it('follows the active locale for currency too', () => {
+    renderCurrency(5000000, { currency: 'EUR' }, 'de-DE');
+    // de-DE: grouped with dots and a TRAILING symbol, vs en-US's leading one.
+    expect(screen.getByText(/^5\.000\.000\s*€$/)).toBeInTheDocument();
+  });
+
+  it('a currency field with NO resolved currency still groups (money, not an ordinal)', () => {
+    renderCurrency(5000000, {}, 'en-US');
+    expect(screen.getByText('5,000,000')).toBeInTheDocument();
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import type { FieldMetadata, SelectOptionMetadata } from '@object-ui/types';
 import { ComponentRegistry, percentDisplayValue, getRecordDisplayName } from '@object-ui/core';
-import { useLocalization } from '@object-ui/i18n';
+import { useLocalization, useDisplayLocale, formatDisplayNumber } from '@object-ui/i18n';
 import { Badge, Avatar, AvatarImage, AvatarFallback, Button, Checkbox, EmptyValue, cn } from '@object-ui/components';
 import { Check, X, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
@@ -363,19 +363,19 @@ export function coerceToSafeValue(value: unknown): string | number | boolean | n
 import { resolveFieldCurrency } from './currency';
 export { resolveFieldCurrency };
 
-export function formatCurrency(value: number, currency?: string): string {
+export function formatCurrency(value: number, currency?: string, locale?: string): string {
   const isWhole = Number.isFinite(value) && value === Math.trunc(value);
   const maxFrac = isWhole ? 0 : 2;
   if (!currency) {
-    return formatNumber(value, maxFrac);
+    return formatNumber(value, maxFrac, locale);
   }
   try {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
+    return formatDisplayNumber(value, {
+      locale,
       currency,
       minimumFractionDigits: 0,
       maximumFractionDigits: maxFrac,
-    }).format(value);
+    });
   } catch {
     return `${currency} ${value.toFixed(maxFrac)}`;
   }
@@ -386,25 +386,26 @@ export function formatCurrency(value: number, currency?: string): string {
  * E.g., $150,000 → $150K, $1,200,000 → $1.2M
  * When `currency` is undefined, returns a compact number without symbol.
  */
-export function formatCompactCurrency(value: number, currency?: string): string {
+export function formatCompactCurrency(value: number, currency?: string, locale?: string): string {
   if (!currency) {
     try {
-      const formatted = new Intl.NumberFormat('en-US', {
+      const formatted = formatDisplayNumber(value, {
+        locale,
         notation: 'compact',
         maximumFractionDigits: 1,
-      }).format(value);
+      });
       return formatted.replace(/\.0(?=[KMBT])/, '');
     } catch {
       return String(value);
     }
   }
   try {
-    const formatted = new Intl.NumberFormat('en-US', {
-      style: 'currency',
+    const formatted = formatDisplayNumber(value, {
+      locale,
       currency,
       notation: 'compact',
       maximumFractionDigits: 1,
-    }).format(value);
+    });
     // Strip trailing ".0" before compact suffix for consistent cross-environment output
     // e.g. "$150.0K" → "$150K" while keeping "$1.5M" intact
     return formatted.replace(/\.0(?=[KMBT])/, '');
@@ -418,12 +419,18 @@ export function formatCompactCurrency(value: number, currency?: string): string 
  * Used as a safe fallback when a currency-typed field has no `currency`
  * configured — we'd rather render `1,234.50` than silently assume USD.
  */
-export function formatNumber(value: number, decimals: number = 2): string {
+export function formatNumber(value: number, decimals: number = 2, locale?: string): string {
   try {
-    return new Intl.NumberFormat('en-US', {
+    // Deliberately passes NO `scale`: `decimals` here is a display width the
+    // caller chose, not a field's declared scale, so the ordinal no-grouping
+    // policy must not fire. `formatCurrency`'s no-currency fallback lands here
+    // with `decimals: 0` for a whole amount — that is still money and must keep
+    // its separators.
+    return formatDisplayNumber(value, {
+      locale,
       minimumFractionDigits: decimals,
       maximumFractionDigits: decimals,
-    }).format(value);
+    });
   } catch {
     return value.toFixed(decimals);
   }
@@ -604,8 +611,12 @@ export function TextCellRenderer({ value }: CellRendererProps): React.ReactEleme
  * Number field cell renderer
  */
 export function NumberCellRenderer({ value, field }: CellRendererProps): React.ReactElement {
+  // Hook before the empty-value early return — a value flipping between null
+  // and set must not change the hook count between renders (same rule as
+  // CurrencyCellRenderer below).
+  const locale = useDisplayLocale();
   if (value == null) return <EmptyValue />;
-  
+
   const safe = coerceToSafeValue(value);
   const numField = field as any;
   // Decimal places come from `scale` (the `s` in a `decimal(p, s)` column),
@@ -616,13 +627,22 @@ export function NumberCellRenderer({ value, field }: CellRendererProps): React.R
   // scale 2 → "16.00", a field with scale 3 → "3.140"); when it is absent we
   // keep the minimum at 0 so trailing zeros are trimmed and only cap the
   // maximum (20 = Intl max) to preserve the value's natural precision.
+  //
+  // `scale` is also the grouping POLICY input (objectui#4033): a declared
+  // `scale: 0` with no currency is a discrete integer — a year, a fiscal
+  // period, an ordinal — and those are rendered ungrouped, so a `Field.number`
+  // year finally shows `2026` instead of `2,026`. An ABSENT scale keeps
+  // grouping: absent means "decimals unknown", not "integer". The policy and
+  // its interim status live in `formatDisplayNumber`, not here.
   const scale = typeof numField.scale === 'number' ? numField.scale : undefined;
   const num = Number(safe);
   const formatted = !isNaN(num)
-    ? new Intl.NumberFormat('en-US', {
+    ? formatDisplayNumber(num, {
+        locale,
+        scale,
         minimumFractionDigits: scale ?? 0,
         maximumFractionDigits: scale ?? 20,
-      }).format(num)
+      })
     : String(safe);
   
   return <span className="tabular-nums">{formatted}</span>;
@@ -635,6 +655,7 @@ export function CurrencyCellRenderer({ value, field }: CellRendererProps): React
   // Hooks before the empty-value early return — a value flipping between
   // null and set must not change the hook count between renders.
   const { currency: tenantCurrency } = useLocalization();
+  const locale = useDisplayLocale();
   if (value == null) return <EmptyValue />;
 
   const safe = coerceToSafeValue(value);
@@ -645,7 +666,7 @@ export function CurrencyCellRenderer({ value, field }: CellRendererProps): React
   const currency = resolveFieldCurrency(field as any, tenantCurrency);
   const num = Number(safe);
   const formatted = !isNaN(num)
-    ? formatCurrency(num, currency)
+    ? formatCurrency(num, currency, locale)
     : String(safe);
 
   return <span className="tabular-nums font-medium whitespace-nowrap">{formatted}</span>;

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
-import { useLocalization } from '@object-ui/i18n';
+import { useLocalization, useDisplayLocale, formatDisplayNumber } from '@object-ui/i18n';
 import { resolveFieldCurrency } from '../currency';
 
 /**
@@ -10,24 +10,33 @@ import { resolveFieldCurrency } from '../currency';
  * is rendered as a plain number with thousands separators (no symbol),
  * because silently assuming USD is misleading for non-USD businesses.
  */
-function formatAmount(value: number, currency: string | undefined, precision: number): string {
+function formatAmount(
+  value: number,
+  currency: string | undefined,
+  precision: number,
+  locale?: string,
+): string {
   if (currency) {
     try {
-      return new Intl.NumberFormat('en-US', {
-        style: 'currency',
+      return formatDisplayNumber(value, {
+        locale,
         currency,
         minimumFractionDigits: precision,
         maximumFractionDigits: precision,
-      }).format(value);
+      });
     } catch {
       return `${currency} ${value.toFixed(precision)}`;
     }
   }
   try {
-    return new Intl.NumberFormat('en-US', {
+    // No `scale` passed: this is a currency widget whose `precision` is a
+    // display width, so a `precision: 0` amount keeps its separators rather
+    // than being read as an ordinal (objectui#4033).
+    return formatDisplayNumber(value, {
+      locale,
       minimumFractionDigits: precision,
       maximumFractionDigits: precision,
-    }).format(value);
+    });
   } catch {
     return value.toFixed(precision);
   }
@@ -41,6 +50,7 @@ export function CurrencyField({ value, onChange, field, readonly, error, classNa
   const currencyField = field as any;
   // Shared precedence: field currency → currencyConfig → tenant default (ADR-0053).
   const { currency: tenantCurrency } = useLocalization();
+  const locale = useDisplayLocale();
   const currency: string | undefined = resolveFieldCurrency(currencyField, tenantCurrency);
   const precision = currencyField?.precision ?? 2;
 
@@ -48,7 +58,7 @@ export function CurrencyField({ value, onChange, field, readonly, error, classNa
     if (value == null) return <EmptyValue />;
     return (
       <span className="text-sm font-medium tabular-nums">
-        {formatAmount(Number(value), currency, precision)}
+        {formatAmount(Number(value), currency, precision, locale)}
       </span>
     );
   }

--- a/packages/i18n/src/__tests__/number-display.test.ts
+++ b/packages/i18n/src/__tests__/number-display.test.ts
@@ -1,0 +1,111 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Unit pins for the ONE number-display formatter (objectui#4033).
+ *
+ * The renderer-level pins live next to their renderers; these cover the policy
+ * itself, including the two Intl traps the implementation is written around.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatDisplayNumber, shouldGroupDisplayNumber } from '../utils/number-display';
+
+describe('shouldGroupDisplayNumber', () => {
+  it('suppresses grouping for a declared scale of 0 with no currency', () => {
+    expect(shouldGroupDisplayNumber(0, undefined)).toBe(false);
+  });
+
+  it('keeps grouping when the scale is undeclared (absent ≠ integer)', () => {
+    expect(shouldGroupDisplayNumber(undefined, undefined)).toBe(true);
+  });
+
+  it('keeps grouping for a non-zero scale', () => {
+    expect(shouldGroupDisplayNumber(2, undefined)).toBe(true);
+  });
+
+  it('keeps grouping for money even at scale 0 — an ordinal amount is not a thing', () => {
+    expect(shouldGroupDisplayNumber(0, 'USD')).toBe(true);
+  });
+});
+
+describe('formatDisplayNumber — grouping policy', () => {
+  it('renders the card fixture (a scale-0 year) ungrouped', () => {
+    expect(
+      formatDisplayNumber(2026, {
+        locale: 'en-US',
+        scale: 0,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }),
+    ).toBe('2026');
+  });
+
+  it('groups a scale-0 number once a currency is present', () => {
+    expect(formatDisplayNumber(2026, { locale: 'en-US', scale: 0, currency: 'USD' })).toBe(
+      '$2,026.00',
+    );
+  });
+
+  it('groups when no scale is passed at all', () => {
+    expect(formatDisplayNumber(1234567, { locale: 'en-US' })).toBe('1,234,567');
+  });
+});
+
+describe('formatDisplayNumber — active locale', () => {
+  it.each([
+    ['en-US', '1,234.5'],
+    ['de-DE', '1.234,5'],
+    ['zh-CN', '1,234.5'],
+  ])('formats 1234.5 per %s conventions', (locale, expected) => {
+    expect(
+      formatDisplayNumber(1234.5, { locale, minimumFractionDigits: 1, maximumFractionDigits: 1 }),
+    ).toBe(expected);
+  });
+
+  it('falls back to the runtime default instead of throwing on a malformed tag', () => {
+    // A malformed `localization.locale` from a tenant config must never take a
+    // cell down. `new Intl.NumberFormat('not a locale')` throws RangeError.
+    expect(() => new Intl.NumberFormat('not a locale')).toThrow(RangeError);
+    expect(formatDisplayNumber(1234, { locale: 'not a locale' })).toMatch(/^1.?234$/);
+  });
+
+  it('still surfaces a bad currency code to the caller', () => {
+    // Call sites keep their own `${currency} ${value.toFixed(n)}` fallbacks, so
+    // this must NOT be swallowed the way a bad locale is.
+    expect(() => formatDisplayNumber(1234, { locale: 'en-US', currency: 'NOTACODE' })).toThrow();
+  });
+});
+
+describe('formatDisplayNumber — the `useGrouping: true` trap', () => {
+  /**
+   * `useGrouping: true` is NOT equivalent to omitting the key. `true` means
+   * "always"; omitting means "auto", which is the LOCALE's own preference — and
+   * several locales do not group four-digit numbers under "auto".
+   *
+   * This pins the trap itself, so that anyone later "simplifying" the
+   * implementation to always emit an explicit boolean sees exactly what breaks:
+   * es-ES and pl-PL would start grouping numbers their conventions leave alone.
+   */
+  it.each(['es-ES', 'pl-PL'])(
+    'keeps %s conventions for a 4-digit number rather than forcing a separator',
+    (locale) => {
+      const auto = new Intl.NumberFormat(locale, {}).format(1234);
+      const always = new Intl.NumberFormat(locale, { useGrouping: true }).format(1234);
+
+      // The premise of the trap: these genuinely differ in this locale.
+      expect(auto).not.toBe(always);
+      // And the shared formatter follows "auto", not "always".
+      expect(formatDisplayNumber(1234, { locale })).toBe(auto);
+    },
+  );
+
+  it('emits an explicit `false` only when suppressing', () => {
+    expect(formatDisplayNumber(1234, { locale: 'es-ES', scale: 0 })).toBe('1234');
+  });
+});

--- a/packages/i18n/src/__tests__/number-display.test.ts
+++ b/packages/i18n/src/__tests__/number-display.test.ts
@@ -106,6 +106,12 @@ describe('formatDisplayNumber — the `useGrouping: true` trap', () => {
   );
 
   it('emits an explicit `false` only when suppressing', () => {
-    expect(formatDisplayNumber(1234, { locale: 'es-ES', scale: 0 })).toBe('1234');
+    // Deliberately en-US, NOT one of the two locales above. Reverse
+    // verification caught this pin passing for an empty reason: es-ES renders
+    // 1234 ungrouped under "auto" as well, so asserting '1234' there is green
+    // whether or not the suppression exists. en-US separates the two —
+    // "auto" gives `1,234`, suppression gives `1234`.
+    expect(new Intl.NumberFormat('en-US', {}).format(1234)).toBe('1,234');
+    expect(formatDisplayNumber(1234, { locale: 'en-US', scale: 0 })).toBe('1234');
   });
 });

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -101,3 +101,13 @@ export {
 export { pickLocalized } from './pickLocalized';
 export { LocalizationProvider, useLocalization, type LocalizationValue } from './LocalizationContext';
 export { resolveFieldCurrency } from './currency';
+
+// The one number-display formatter (objectui#4033) and the locale it formats
+// in. Every field cell / widget / metric renderer goes through this pair —
+// see `utils/number-display.ts` for the grouping policy and its interim status.
+export { useDisplayLocale } from './useDisplayLocale';
+export {
+  formatDisplayNumber,
+  shouldGroupDisplayNumber,
+  type DisplayNumberFormatOptions,
+} from './utils/index';

--- a/packages/i18n/src/useDisplayLocale.ts
+++ b/packages/i18n/src/useDisplayLocale.ts
@@ -1,0 +1,49 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useLocalization } from './LocalizationContext';
+import { useObjectTranslation } from './provider';
+
+/**
+ * `useDisplayLocale` — the BCP-47 tag that field / cell / metric renderers
+ * format numbers and other `Intl` values with.
+ *
+ * This composes the two locale channels this repo already has; it does not add
+ * a third. The precedence, highest first:
+ *
+ *  1. **`useLocalization().locale`** — the tenant's resolved regional default
+ *     (ADR-0053, served by `GET /api/v1/auth/me/localization`). An org that has
+ *     explicitly configured a display locale means it, so it outranks the UI
+ *     language, and this keeps numbers agreeing with `DateCellRenderer`, which
+ *     already formats from this channel. Frequently `undefined`: the endpoint is
+ *     cosmetic and non-blocking, so an unconfigured or still-loading tenant
+ *     simply has no answer here (the state objectui#4033 was measured in — a
+ *     fresh database, console running `zh-CN`).
+ *
+ *  2. **`useObjectTranslation().language`** — the ACTIVE UI language, i.e. what
+ *     the user picked in the language switcher. This is the channel that makes
+ *     grouping and decimal marks follow the user's language when the tenant has
+ *     stated no regional preference.
+ *
+ *  3. **`'en'`** — a concrete last resort rather than `undefined`. `undefined`
+ *     would hand `Intl` the *machine's* locale, which is invisible in review and
+ *     non-deterministic in CI; `'en'` at least fails the same way everywhere.
+ *     Note this is `'en'`, not `'en-US'`: the point of objectui#4033 is that
+ *     `en-US` is not the world's default. In practice step 2 already answers,
+ *     since `useObjectTranslation` falls back to the react-i18next global
+ *     instance and ultimately reports `'en'` itself.
+ *
+ * Provider-safe at every step: `useLocalization` returns `{}` outside its
+ * provider and `useObjectTranslation` reads an optional context, so a renderer
+ * mounted standalone (tests, docs demos) degrades instead of throwing.
+ */
+export function useDisplayLocale(): string {
+  const { locale } = useLocalization();
+  const { language } = useObjectTranslation();
+  return locale || language || 'en';
+}

--- a/packages/i18n/src/utils/index.ts
+++ b/packages/i18n/src/utils/index.ts
@@ -25,3 +25,9 @@ export {
   transformSpecTranslations,
   type SpecTranslationData,
 } from './spec-translations';
+
+export {
+  formatDisplayNumber,
+  shouldGroupDisplayNumber,
+  type DisplayNumberFormatOptions,
+} from './number-display';

--- a/packages/i18n/src/utils/number-display.ts
+++ b/packages/i18n/src/utils/number-display.ts
@@ -1,0 +1,140 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `formatDisplayNumber` — the ONE number-display formatter behind every field
+ * cell, field widget and metric renderer in the console.
+ *
+ * It exists because the same `new Intl.NumberFormat('en-US', …)` construction
+ * had been copied into the number cell renderer, the currency cell renderer,
+ * the currency widget, the compact `formatNumber` helper and the dashboard
+ * metric widget. Two defects therefore had five homes each, and fixing "the"
+ * renderer never changed the answer (objectui#4033, source thread
+ * objectstack#5067):
+ *
+ *  1. the locale was hardcoded to `en-US`, so a `zh-CN` / `de-DE` console still
+ *     grouped and pointed decimals the US way; and
+ *  2. `useGrouping` was never set, so a four-digit YEAR stored as
+ *     `Field.number({ scale: 0 })` rendered as `2,026` — in every locale, with
+ *     no field property able to turn it off.
+ *
+ * Both policies now live here and nowhere else. Call sites bring the value and
+ * the display width; they do not bring a locale default and they do not decide
+ * grouping.
+ */
+
+export interface DisplayNumberFormatOptions {
+  /**
+   * BCP-47 tag for the ACTIVE display locale — in React, whatever
+   * `useDisplayLocale()` returns.
+   *
+   * `undefined` means "follow the runtime default", which is the honest answer
+   * for a non-React caller that has no locale in hand. It never means `en-US`:
+   * assuming US conventions for the whole world is the defect this module was
+   * created to remove.
+   */
+  locale?: string;
+
+  /**
+   * ISO 4217 code. When present the value is formatted as money — which also
+   * means grouping is kept, because a grouped amount is what every currency
+   * convention expects and an ordinal amount of money is not a thing.
+   */
+  currency?: string;
+
+  /**
+   * The FIELD's declared `scale` — the `s` of a `decimal(p, s)` column — and
+   * nothing else. This is a POLICY input, not a display width: pass it only
+   * when a field declaration actually said so.
+   *
+   * `scale: 0` with no currency declares a discrete integer (a year, a fiscal
+   * period, an ordinal), and those are not grouped. Leave `scale` undefined and
+   * grouping is kept — which is correct for the two cases that look similar but
+   * are not:
+   *
+   *   - an UNDECLARED scale (`scale` is optional in the spec, so absent means
+   *     "decimals unknown", not "integer"); and
+   *   - a caller whose zero-decimal display comes from something other than a
+   *     field declaration — e.g. the dashboard `MetricWidget`, whose decimals
+   *     come from a numeral.js format pattern and whose large KPI aggregates
+   *     are *documented* to want separators ("`1,930,000` not `1930000`").
+   *
+   * ⚠️ INTERIM DEFAULT (objectui#4033, PM ruling 2026-08-11). Suppressing
+   * grouping for every scale-0 number is a transitional policy with a known,
+   * accepted cost: a large scale-0 COUNT loses its separators too. It is the
+   * better trade only until the spec gains an authorable presentation hint
+   * (`useGrouping` / `displayFormat` — being specified separately, contract-first,
+   * in the objectstack repo). When that hint lands it OVERRIDES this default,
+   * and this heuristic should be reduced to the fallback for fields that
+   * declare nothing.
+   */
+  scale?: number;
+
+  style?: 'decimal' | 'percent';
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+  notation?: 'standard' | 'compact';
+}
+
+/**
+ * The grouping policy, alone and testable: does this number get thousands
+ * separators?
+ *
+ * @param scale    the field's declared `scale`, or `undefined` when the caller
+ *                 has no field declaration behind it
+ * @param currency ISO 4217 code when the number is money
+ */
+export function shouldGroupDisplayNumber(scale?: number, currency?: string): boolean {
+  // Money always groups — including money whose currency code could not be
+  // resolved, which still renders as an amount (just without a symbol).
+  if (currency) return true;
+  // Only an explicitly declared scale of 0 is an ordinal. `undefined !== 0`.
+  return scale !== 0;
+}
+
+/**
+ * Format a number for DISPLAY, in the active locale, under the grouping policy
+ * above.
+ *
+ * Throws for a bad `currency` code exactly as `Intl.NumberFormat` does, so the
+ * fallbacks call sites already had (`${currency} ${value.toFixed(n)}`) keep
+ * working unchanged. A bad LOCALE is handled here instead of throwing: `locale`
+ * arrives from a server response (ADR-0053 `localization.locale`), and a
+ * malformed tag from a tenant config must never take a grid cell down.
+ */
+export function formatDisplayNumber(
+  value: number,
+  options: DisplayNumberFormatOptions = {},
+): string {
+  const { locale, currency, scale, ...passthrough } = options;
+
+  const intlOptions: Intl.NumberFormatOptions = { ...passthrough };
+  if (currency) {
+    intlOptions.style = 'currency';
+    intlOptions.currency = currency;
+  }
+
+  // ⚠️ Set `useGrouping` ONLY to suppress. `useGrouping: true` is NOT the same
+  // as omitting the key: `true` means "always", while omitting it means "auto"
+  // (and "min2" under compact notation), which is the locale's own preference.
+  // Measured — for 1234: es-ES "auto" → `1234` but "always" → `1.234`; pl-PL
+  // "auto" → `1234` but "always" → `1 234`. Writing `true` here would silently
+  // override those locales' conventions in the name of preserving en-US output.
+  if (!shouldGroupDisplayNumber(scale, currency)) {
+    intlOptions.useGrouping = false;
+  }
+
+  try {
+    return new Intl.NumberFormat(locale, intlOptions).format(value);
+  } catch {
+    // Retry WITHOUT the locale, keeping every other option: this rescues a
+    // malformed tag while still surfacing a genuinely bad `currency` to the
+    // caller's own catch.
+    return new Intl.NumberFormat(undefined, intlOptions).format(value);
+  }
+}

--- a/packages/plugin-dashboard/src/MetricWidget.tsx
+++ b/packages/plugin-dashboard/src/MetricWidget.tsx
@@ -1,7 +1,12 @@
 import React, { useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, getLazyIcon } from '@object-ui/components';
 import { cn } from '@object-ui/components';
-import { createSafeTranslation } from '@object-ui/i18n';
+import {
+  createSafeTranslation,
+  useDisplayLocale,
+  formatDisplayNumber,
+  type DisplayNumberFormatOptions,
+} from '@object-ui/i18n';
 import { ArrowDownIcon, ArrowUpIcon, MinusIcon, AlertCircle, Loader2 } from 'lucide-react';
 import { VARIANT_ICON_CLASSES, VARIANT_TEXT_CLASSES, type MetricColorVariant } from './colorVariants';
 
@@ -62,13 +67,14 @@ function formatMetricValue(
   value: string | number,
   format?: string,
   currency?: string,
+  locale?: string,
 ): string {
   if (value == null) return '';
   if (typeof value === 'string') {
     // If the string is a pure number, format it; else pass through.
     const n = Number(value);
     if (!isFinite(n) || value.trim() === '') return value;
-    return formatMetricValue(n, format, currency);
+    return formatMetricValue(n, format, currency, locale);
   }
   if (!isFinite(value as number)) return String(value);
 
@@ -85,20 +91,24 @@ function formatMetricValue(
   // "1.1M", '$0a' → "$1M"). Keeps big KPI numbers from overflowing a tile.
   const isCompact = /a/i.test(trimmed);
   if (isCompact) {
-    const opts: Intl.NumberFormatOptions = { notation: 'compact', maximumFractionDigits: decimals || 1 };
-    if (isCurrency) { opts.style = 'currency'; opts.currency = currency || symbolMap[trimmed[0]] || 'USD'; }
-    try { return new Intl.NumberFormat('en-US', opts).format(value as number); } catch { /* fall through */ }
+    const opts: DisplayNumberFormatOptions = {
+      locale,
+      notation: 'compact',
+      maximumFractionDigits: decimals || 1,
+    };
+    if (isCurrency) { opts.currency = currency || symbolMap[trimmed[0]] || 'USD'; }
+    try { return formatDisplayNumber(value as number, opts); } catch { /* fall through */ }
   }
 
   if (isCurrency) {
     const code = currency || symbolMap[trimmed[0]] || 'USD';
     try {
-      return new Intl.NumberFormat('en-US', {
-        style: 'currency',
+      return formatDisplayNumber(value as number, {
+        locale,
         currency: code,
         minimumFractionDigits: decimals,
         maximumFractionDigits: decimals,
-      }).format(value as number);
+      });
     } catch {
       return `${code} ${(value as number).toFixed(decimals)}`;
     }
@@ -109,10 +119,21 @@ function formatMetricValue(
     return `${v.toFixed(decimals)}%`;
   }
 
-  return new Intl.NumberFormat('en-US', {
+  // MEASURED EXCEPTION to objectui#4033's ordinal no-grouping default, and the
+  // reason this call passes no `scale`. `decimals` above is parsed out of a
+  // numeral.js format PATTERN (`'0,0.00'` → 2), not out of a field's declared
+  // scale — and it is 0 for the commonest KPI patterns (`'0,0'`, or no format
+  // at all). Grouping is load-bearing here, as this function's own contract
+  // says: "defaults to thousands separators with no decimals — that's what
+  // users expect for KPI cards (`1,930,000` not `1930000`)". Suppressing it
+  // would turn every unformatted dashboard aggregate into an unreadable digit
+  // run. The `en-US` locale hardcode IS fixed; the grouping default is not
+  // applied to this surface.
+  return formatDisplayNumber(value as number, {
+    locale,
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
-  }).format(value as number);
+  });
 }
 
 /** Resolve an I18nLabel (string or {key, defaultValue}) to a plain string. */
@@ -186,6 +207,7 @@ export const MetricWidget = ({
 }: MetricWidgetProps) => {
   const iconClasses = VARIANT_ICON_CLASSES[colorVariant] || VARIANT_ICON_CLASSES.default;
   const { t: tTrend } = useTrendT();
+  const locale = useDisplayLocale();
 
   const localizedTrendLabel = useMemo(() => {
     const raw = resolveLabel(description) || resolveLabel(trend?.label);
@@ -196,7 +218,7 @@ export const MetricWidget = ({
 
   const displayValue = useMemo(() => {
     const formatted = typeof value === 'number' || (typeof value === 'string' && value.trim() !== '' && isFinite(Number(value)))
-      ? formatMetricValue(value, format, currency)
+      ? formatMetricValue(value, format, currency, locale)
       : (value ?? '');
     const formattedStr = String(formatted);
     // Avoid duplicating a currency-style prefix/suffix that the formatter
@@ -204,7 +226,7 @@ export const MetricWidget = ({
     const effectivePrefix = prefix && formattedStr.startsWith(prefix) ? '' : (prefix ?? '');
     const effectiveSuffix = suffix && formattedStr.endsWith(suffix) ? '' : (suffix ?? '');
     return `${effectivePrefix}${formattedStr}${effectiveSuffix}`;
-  }, [value, format, currency, prefix, suffix]);
+  }, [value, format, currency, prefix, suffix, locale]);
 
   // Resolve icon if it's a string — uses lazy resolver so we don't pull
   // the entire lucide-react namespace into the bundle.

--- a/packages/plugin-dashboard/src/__tests__/MetricWidget.numberFormat.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/MetricWidget.numberFormat.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4033 on the dashboard metric surface.
+ *
+ * MetricWidget is the MEASURED EXCEPTION to the card's ordinal no-grouping
+ * default, so this file pins both halves of that split:
+ *
+ *  - the `en-US` hardcode IS removed — a metric follows the active display
+ *    locale like every other number; but
+ *  - grouping IS NOT suppressed, because `decimals` here is parsed from a
+ *    numeral.js format pattern rather than a field's declared `scale`, and is 0
+ *    for the commonest KPI patterns. The widget's own contract calls the
+ *    separators load-bearing ("`1,930,000` not `1930000`").
+ *
+ * Without the second pin, a later reading of "scale 0 ⇒ no grouping" as a
+ * global rule would turn every unformatted dashboard aggregate into a digit run
+ * and nothing would fail.
+ */
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LocalizationProvider } from '@object-ui/i18n';
+import { MetricWidget } from '../MetricWidget';
+
+const renderMetric = (props: Record<string, unknown>, locale?: string) =>
+  render(
+    <LocalizationProvider value={{ locale }}>
+      <MetricWidget label="Revenue" {...(props as any)} />
+    </LocalizationProvider>,
+  );
+
+describe('MetricWidget — grouping stays load-bearing (objectui#4033 exception)', () => {
+  it('keeps thousands separators for a large unformatted KPI aggregate', () => {
+    renderMetric({ value: 1930000 }, 'en-US');
+    expect(screen.getByText('1,930,000')).toBeInTheDocument();
+  });
+
+  it("keeps thousands separators for the '0,0' pattern (decimals parse to 0)", () => {
+    renderMetric({ value: 1930000, format: '0,0' }, 'en-US');
+    expect(screen.getByText('1,930,000')).toBeInTheDocument();
+  });
+
+  it('keeps grouping for a currency metric', () => {
+    renderMetric({ value: 1930000, currency: 'USD' }, 'en-US');
+    expect(screen.getByText('$1,930,000')).toBeInTheDocument();
+  });
+});
+
+describe('MetricWidget — active display locale (objectui#4033 fix 3)', () => {
+  it('groups per the active locale rather than a hardcoded en-US', () => {
+    renderMetric({ value: 1930000 }, 'de-DE');
+    expect(screen.getByText('1.930.000')).toBeInTheDocument();
+  });
+
+  it('points the decimal mark per the active locale', () => {
+    renderMetric({ value: 1930.5, format: '0,0.0' }, 'de-DE');
+    expect(screen.getByText('1.930,5')).toBeInTheDocument();
+  });
+
+  it('localizes a currency metric too', () => {
+    renderMetric({ value: 1930000, currency: 'EUR' }, 'de-DE');
+    // de-DE puts the symbol last; en-US would have produced "€1,930,000".
+    expect(screen.getByText(/^1\.930\.000\s*€$/)).toBeInTheDocument();
+  });
+
+  it('localizes the compact notation path', () => {
+    // de-DE compact spells its own scale word ("Mio."), which en-US cannot
+    // produce — this is the pin that the compact branch took the locale too.
+    renderMetric({ value: 1930000, format: '0.0a' }, 'de-DE');
+    expect(screen.getByText(/Mio/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #4033 — source thread objectstack-ai/objectstack#5067 (read-only history; its triage comment is the route of record).

## What was wrong

Every numeric field the console rendered went through an `Intl.NumberFormat` constructed with the locale hardcoded to `en-US` and `useGrouping` never set. Two independent defects rode in that one construction:

1. a `zh-CN` / `de-DE` console still grouped and pointed decimals the US way; and
2. a four-digit **year** stored as `Field.number({ scale: 0 })` rendered as `2,026` — in every locale, with no field property able to turn it off.

The construction had been copied into **five** places, so fixing any one surface never changed the answer.

## What changed

Both policies now live in one function, `formatDisplayNumber` in `@object-ui/i18n`, plus one locale resolver, `useDisplayLocale`. Call sites bring the value and the display width; they do not bring a locale default and they do not decide grouping.

**Converged call sites** — `packages/fields/src/index.tsx` (`formatCurrency`, `formatCompactCurrency`, `formatNumber`, `NumberCellRenderer`, `CurrencyCellRenderer`), `packages/fields/src/widgets/CurrencyField.tsx`, `packages/components/src/renderers/basic/elements.tsx`, `packages/plugin-dashboard/src/MetricWidget.tsx`.

### The locale channel is composed, not invented

The card asked for "the active i18n locale". Measurement found **two** existing channels, and `useDisplayLocale` composes them rather than adding a third:

1. `useLocalization().locale` — the tenant's resolved regional default (ADR-0053). Frequently `undefined`; the endpoint is cosmetic and non-blocking.
2. `useObjectTranslation().language` — the ACTIVE UI language from the switcher.
3. `'en'` — a concrete last resort rather than `undefined`, which would hand `Intl` the *machine's* locale and be non-deterministic in CI.

Step 2 is what covers the state #4033 was measured in: a fresh database, where the tenant endpoint has no locale to give, so a language switch alone has to drive formatting.

### Grouping policy, and its interim status

`scale === 0` and no currency ⇒ `useGrouping: false`. Documented at the definition as an **interim default** with the accepted cost named (a large scale-0 *count* loses its separators too), and marked as overridden by the future spec-level presentation hint. No spec / objectstack change here — that stays contract-first and separate.

`scale` is treated as a **policy input, not a display width**: only a surface with a real field declaration behind it passes it. That is what makes the exceptions structural rather than three separately-patched call sites.

## Measured grouping exception, reported honestly

**`MetricWidget` keeps its separators.** Its `decimals` is parsed from a numeral.js format *pattern* (`'0,0.00'` gives 2), not from a field's declared scale, and it is `0` for the commonest KPI patterns (`'0,0'`, or no format at all). Grouping there is load-bearing by the widget's own contract:

> When no format is given but the value is a finite number, defaults to thousands separators with no decimals — that's what users expect for KPI cards (`1,930,000` not `1930000`).

The `en-US` hardcode **is** fixed on that surface; only the grouping default is not applied to it. `element:number` (an aggregate renderer) and every currency path are excluded on the same structural grounds. An **undeclared** `scale` also keeps grouping — absent means "decimals unknown", not "integer".

## Reverse verification

Predictions were written down before running; commit-then-revert, never `git stash`.

| Limb reverted | Predicted | Observed |
|---|---|---|
| A — grouping suppression deleted | 7 red (ordinal pins + unit policy pins), all controls green | exactly that |
| B — locale hardcoded back to `en-US` | 7 red (de-DE/fr-FR/currency/metric locale pins); **ordinal pins stay GREEN** | exactly that |
| C — `MetricWidget` made to obey the ordinal default | 3 red (its grouping-exception pins) | exactly that |

Limb B's green half is the load-bearing one: `2026` ungrouped is identical in every locale, so a locale regression is *invisible* to the ordinal tests. The two fixes are therefore independently pinned rather than entangled.

Limb C exists so the exception is evidence rather than assertion — had nothing gone red, "grouping is load-bearing here" would be an unverified claim.

**Reverse verification also caught one of my own pins passing for an empty reason**: `emits an explicit false only when suppressing` was anchored on es-ES, which renders `1234` ungrouped under Intl's `auto` *as well* — green whether or not the suppression existed. Re-anchored on en-US, which separates the two (`1,234` vs `1234`). Second commit.

## Two Intl traps the implementation is written around

- **`useGrouping: true` is not the same as omitting it.** `true` means "always"; omitting means "auto" (the locale's own preference). Measured for `1234`: es-ES auto `1234` vs always `1.234`; pl-PL auto `1234` vs always `1 234`. So the code sets `useGrouping` **only** to suppress — writing `true` would silently override those locales' conventions in the name of preserving en-US output. Pinned as a test.
- **A malformed tenant locale must not take a cell down.** `locale` arrives from a server response; `new Intl.NumberFormat('not a locale')` throws `RangeError`. Handled inside the formatter by retrying without the locale, while a genuinely bad `currency` code still propagates to the call sites' existing fallbacks. Both directions pinned.

## Tests

New: `packages/fields/src/__tests__/NumberCellRenderer.grouping.test.tsx` (17), `packages/i18n/src/__tests__/number-display.test.ts` (16), `packages/plugin-dashboard/src/__tests__/MetricWidget.numberFormat.test.tsx` (7). Red-first on the card's exact fixture.

- Directly edited packages: **273 files / 3296 tests passed** (`i18n`, `fields`, `components`, `plugin-dashboard`).
- Downstream consumers: **243 files / 2653 tests passed** (`plugin-grid`, `plugin-gantt`, `plugin-list`, `plugin-detail`, `react`).
- Type-check, **downstream/prefix direction** (`--filter '...pkg'` = consumers, not dependencies): **35 of 46 workspace projects, all clean**, after a full `pnpm build` (43/43) so no stale `dist/*.d.ts` was read.
- Lint: 0 errors across the four edited packages. Changeset gates: presence / fixed-group / no-major all green. `check-control-bytes`: OK.

## API surface

Additive only — no narrowing. `formatCurrency`, `formatCompactCurrency` and `formatNumber` each gain an **optional trailing** `locale`; existing calls are unaffected, though omitting it now follows the runtime default rather than forcing US conventions. `@object-ui/i18n` gains three exports.

## Scope notes

- `objectstack` treated as read-only throughout.
- `packages/components/src/renderers/action/` (held by #4281) and `src/ui/` untouched.
- The `MetricWidget` edit is confined to the formatter call and its locale threading, disjoint from #4030's in-flight `chartConfigPresentation` / `DatasetWidget` region in the same package.

## Out-of-scope findings

- Filed **#4332**: `formatCurrency` drops a real cents digit (`1234.5` renders `$1,234.5`, not the `$1,234.50` its own doc comment promises) — `minimumFractionDigits` is a constant `0` while `maximumFractionDigits` correctly switches on wholeness. Pre-existing, neither a locale nor a grouping defect. This PR **pins the current behaviour** in a control test with a comment pointing at the issue, so its fix flips a watched test rather than a silent surface.
- Commented on **#4272** (date formatter half-localized, already queued) rather than opening a twin: `DateCellRenderer` reads only the tenant channel, so dates will not follow a language switch once numbers do. `useDisplayLocale` is the ready-made resolver for it, but re-pointing a date renderer is that card's call.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_