### PR TITLE
fix(fields): formatCurrency keeps both cents digits on a fractional amount

### DIFF
--- a/.changeset/curvy-donkeys-shave.md
+++ b/.changeset/curvy-donkeys-shave.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/fields': patch
+---
+
+fix(fields): `formatCurrency` keeps both cents digits on a fractional amount
+
+The symbol branch passed `minimumFractionDigits: 0` against a
+wholeness-switched `maximumFractionDigits`, which handed `Intl` the range
+`[0, 2]` — and `Intl` emits the shortest representation in range, so a real
+cents value of `.50` was printed as `.5`. Any price ending in a zero cent digit
+rendered one digit short: `$1,234.50` as `$1,234.5`, `$19.90` as `$19.9`,
+`$0.50` as `$0.5` — money on a record page and in grid cells reading as a data
+error rather than a formatting one.
+
+Both bounds now take the same wholeness-switched width, so the function
+delivers the contract its own doc comment states: a fractional amount shows
+exactly two digits, a whole amount still drops `.00` (`$1,234`). The
+no-currency branch and the bad-currency fallback already behaved this way; only
+the symbol branch disagreed.
+
+Reaches every consumer of the shared helper: `CurrencyCellRenderer`,
+`ObjectGrid`, the dashboard `recordFields` and `ObjectGantt`.

--- a/packages/fields/src/__tests__/NumberCellRenderer.grouping.test.tsx
+++ b/packages/fields/src/__tests__/NumberCellRenderer.grouping.test.tsx
@@ -122,14 +122,15 @@ describe('CurrencyCellRenderer — CONTROL, unaffected by the ordinal default', 
 
   it('keeps grouping and the fractional part when the amount is not whole', () => {
     renderCurrency(1234.5, { currency: 'USD' }, 'en-US');
-    // Pins CURRENT behaviour, which is `$1,234.5` — NOT the `$1,234.50` that
-    // `formatCurrency`'s own doc comment promises ("Salesforce convention:
-    // `$1,234.50` keeps cents"). The construction passes
-    // `minimumFractionDigits: 0`, so a trailing zero is dropped from a real
-    // cents value. Pre-existing and out of this card's scope (it is neither a
-    // locale nor a grouping defect) — filed separately; this control exists to
-    // prove #4033 does not disturb it.
-    expect(screen.getByText('$1,234.5')).toBeInTheDocument();
+    // This control pinned the CURRENT behaviour when #4033 landed — `$1,234.5`,
+    // NOT the `$1,234.50` that `formatCurrency`'s own doc comment promises
+    // ("Salesforce convention: `$1,234.50` keeps cents"). That was a real
+    // defect, deliberately filed rather than folded in (objectui#4332) and
+    // pinned here so its fix would flip a watched test instead of silently
+    // changing an unwatched surface. #4332 is now fixed, so the expectation
+    // moves to the promised form; grouping — this control's actual subject —
+    // is unchanged, which is still what #4033 needs it to prove.
+    expect(screen.getByText('$1,234.50')).toBeInTheDocument();
   });
 
   it('follows the active locale for currency too', () => {

--- a/packages/fields/src/__tests__/formatCurrency.centsDigit.test.tsx
+++ b/packages/fields/src/__tests__/formatCurrency.centsDigit.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4332 — `formatCurrency` dropped a real cents digit.
+ *
+ * The symbol branch passed `minimumFractionDigits: 0` against a
+ * wholeness-switched `maximumFractionDigits`, handing Intl the RANGE `[0, 2]`.
+ * Intl then emits the shortest representation in range, so a genuine cents
+ * value of `.50` printed as `.5`: `$1,234.5`, `$19.9`, `$0.5` — money on a
+ * record page reading as a data error rather than a formatting one.
+ *
+ * The fix is one width for both bounds (`isWhole ? 0 : 2`), which also makes
+ * the function's three branches agree: the no-currency branch already routed
+ * through `formatNumber` (both bounds = the width), and the bad-currency
+ * fallback already used `toFixed`. Only the symbol branch disagreed.
+ *
+ * What is pinned here, and why each half matters:
+ *
+ *  1. **Fractional amounts keep both cents digits** — the defect.
+ *  2. **Whole amounts still drop `.00`** — the OTHER half of the wholeness
+ *     switch, which the doc comment promises just as explicitly ("Salesforce
+ *     convention: `$1,234.50` keeps cents; `$1,234` does not") and which
+ *     objectui#4033 independently pinned through the renderer. Widening the
+ *     minimum to a constant 2 would have "fixed" this card by breaking that
+ *     one, so it is a control, not a decoration.
+ *  3. **The branches that were already correct are unchanged** — no-currency,
+ *     bad-currency fallback, and `formatCompactCurrency` (a different function
+ *     with its own `maximumFractionDigits: 1` compact policy).
+ */
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LocalizationProvider } from '@object-ui/i18n';
+import {
+  formatCurrency,
+  formatCompactCurrency,
+  formatNumber,
+  CurrencyCellRenderer,
+} from '../index';
+
+describe('formatCurrency — a fractional amount keeps both cents digits (objectui#4332)', () => {
+  it("renders the card's fixture as the doc comment promises", () => {
+    expect(formatCurrency(1234.5, 'USD', 'en-US')).toBe('$1,234.50');
+  });
+
+  it.each([
+    [19.9, '$19.90'],
+    [0.5, '$0.50'],
+    [1234.5, '$1,234.50'],
+  ])('an amount ending in a zero cent digit keeps it: %s', (value, expected) => {
+    // The issue's impact list — every price whose cents end in 0 was truncated
+    // by one digit (`$19.9`, `$0.5`).
+    expect(formatCurrency(value as number, 'USD', 'en-US')).toBe(expected as string);
+  });
+
+  it('keeps the sign in front of a truncated-then-restored amount', () => {
+    expect(formatCurrency(-1234.5, 'USD', 'en-US')).toBe('-$1,234.50');
+  });
+
+  it('a fractional amount that ROUNDS to zero cents still shows them', () => {
+    // Sub-cent precision: `1234.001` is not whole, so it keeps cents and
+    // rounds into them. Before the fix the `[0, 2]` range rounded to `.00` and
+    // then trimmed it away, printing a bare `$1,234` for a value that is NOT
+    // the whole number that spelling claims. Deliberate: wholeness — not the
+    // rounded output — decides whether cents are shown.
+    expect(formatCurrency(1234.001, 'USD', 'en-US')).toBe('$1,234.00');
+  });
+
+  it('still caps at two digits (the maximum is unchanged)', () => {
+    expect(formatCurrency(1234.567, 'USD', 'en-US')).toBe('$1,234.57');
+    expect(formatCurrency(1234.56, 'USD', 'en-US')).toBe('$1,234.56');
+  });
+
+  it('follows the active locale while doing it (objectui#4033 is not disturbed)', () => {
+    // de-DE: dot grouping, comma decimal mark, TRAILING symbol separated by
+    // U+00A0. Matched loosely on the separator (written as an escape, never a
+    // raw byte) so an ICU spacing change cannot fail the digits this pins.
+    expect(formatCurrency(1234.5, 'EUR', 'de-DE')).toMatch(/^1\.234,50\s*€$/);
+  });
+});
+
+describe('formatCurrency — CONTROL: the whole-number half of the switch is untouched', () => {
+  it.each([
+    [1234, '$1,234'],
+    [5000000, '$5,000,000'],
+    [0, '$0'],
+  ])('a whole amount still drops `.00`: %s', (value, expected) => {
+    // The doc comment promises this as explicitly as it promises the cents,
+    // and objectui#4033 pinned it through `CurrencyCellRenderer`. A constant
+    // `minimumFractionDigits: 2` would turn all three of these into `.00`.
+    expect(formatCurrency(value as number, 'USD', 'en-US')).toBe(expected as string);
+  });
+
+  it('a non-finite amount is unaffected (it is not "whole")', () => {
+    expect(formatCurrency(Number.NaN, 'USD', 'en-US')).toBe('$NaN');
+  });
+});
+
+describe('formatCurrency — CONTROL: the branches that were already correct', () => {
+  it('the no-currency branch is unchanged — it never had the defect', () => {
+    // It routes through `formatNumber`, which sets BOTH bounds to the width it
+    // is given, so it already rendered `1,234.50` while the symbol branch
+    // rendered `$1,234.5`. That disagreement is what the fix removes.
+    expect(formatCurrency(1234.5, undefined, 'en-US')).toBe('1,234.50');
+    expect(formatCurrency(1234.5, undefined, 'en-US')).toBe(formatNumber(1234.5, 2, 'en-US'));
+    // A whole amount with no currency is still money and keeps its separators
+    // (objectui#4033: `formatNumber` passes no `scale`, so the ordinal
+    // no-grouping policy cannot fire here).
+    expect(formatCurrency(5000000, undefined, 'en-US')).toBe('5,000,000');
+  });
+
+  it('the bad-currency fallback is unchanged — it always used toFixed', () => {
+    // `Intl` throws `RangeError: Invalid currency code` for a non-ISO-4217
+    // code, and `formatDisplayNumber`'s locale retry re-throws it rather than
+    // swallowing it, so this lands in `formatCurrency`'s own catch.
+    expect(formatCurrency(1234.5, 'NOT_A_CODE', 'en-US')).toBe('NOT_A_CODE 1234.50');
+  });
+
+  it('formatCompactCurrency is a different function and keeps its own policy', () => {
+    // Compact notation caps at ONE fraction digit and strips a trailing `.0`;
+    // it never had the `[0, max]` range, and this card does not touch it.
+    expect(formatCompactCurrency(1234.5, 'USD', 'en-US')).toBe('$1.2K');
+    expect(formatCompactCurrency(150000, 'USD', 'en-US')).toBe('$150K');
+  });
+});
+
+describe('CurrencyCellRenderer — the user-visible surface (objectui#4332)', () => {
+  const renderCurrency = (value: unknown, field: Record<string, unknown>, locale?: string) =>
+    render(
+      <LocalizationProvider value={{ locale }}>
+        <CurrencyCellRenderer value={value as any} field={{ type: 'currency', ...field } as any} />
+      </LocalizationProvider>,
+    );
+
+  it('a grid cell shows the cents digit the amount actually has', () => {
+    renderCurrency(1234.5, { currency: 'USD' }, 'en-US');
+    expect(screen.getByText('$1,234.50')).toBeInTheDocument();
+  });
+
+  it('CONTROL: a declared `scale` is inert on the currency cell path', () => {
+    // Measured, not assumed: `CurrencyCellRenderer` reads `currency` and never
+    // `scale`, and `formatCurrency` takes no scale argument — on this path
+    // `scale` is neither a display width nor (money always groups) a grouping
+    // input. So a currency field declaring `scale: 0` renders exactly like one
+    // declaring nothing, before and after this card. Pinned so that a future
+    // change making `scale` load-bearing here has to say so out loud.
+    renderCurrency(1234.5, { currency: 'USD', scale: 0 }, 'en-US');
+    expect(screen.getByText('$1,234.50')).toBeInTheDocument();
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -358,26 +358,38 @@ export function coerceToSafeValue(value: unknown): string | number | boolean | n
  * RMB amount showing as dollars?" bug reports.
  *
  * Trailing `.00` is dropped when the value is a whole number — Salesforce
- * convention: `$1,234.50` keeps cents; `$1,234` does not.
+ * convention: `$1,234.50` keeps cents; `$1,234` does not. Wholeness picks ONE
+ * fraction-digit width, never a range: a whole amount shows 0 digits, and a
+ * fractional amount shows exactly 2 — so a real cents value of `.50` renders
+ * `.50`, not `.5`.
  */
 import { resolveFieldCurrency } from './currency';
 export { resolveFieldCurrency };
 
 export function formatCurrency(value: number, currency?: string, locale?: string): string {
   const isWhole = Number.isFinite(value) && value === Math.trunc(value);
-  const maxFrac = isWhole ? 0 : 2;
+  // ONE width for both bounds, not a range (objectui#4332). The symbol branch
+  // used to pass `minimumFractionDigits: 0` against a wholeness-switched
+  // maximum, which handed Intl the range [0, 2] — and Intl then emits the
+  // SHORTEST representation in range, so a genuine cents value of `.50` was
+  // printed as `.5`: `$1,234.5` instead of the `$1,234.50` promised above.
+  // It was the only branch that did: the no-currency branch reaches
+  // `formatNumber`, which sets both bounds to the width it is given, and the
+  // bad-currency fallback below has always used `toFixed`. Both already
+  // rendered `1,234.50` for the same amount.
+  const fracDigits = isWhole ? 0 : 2;
   if (!currency) {
-    return formatNumber(value, maxFrac, locale);
+    return formatNumber(value, fracDigits, locale);
   }
   try {
     return formatDisplayNumber(value, {
       locale,
       currency,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: maxFrac,
+      minimumFractionDigits: fracDigits,
+      maximumFractionDigits: fracDigits,
     });
   } catch {
-    return `${currency} ${value.toFixed(maxFrac)}`;
+    return `${currency} ${value.toFixed(fracDigits)}`;
   }
 }
 


### PR DESCRIPTION
Fixes #4332 — filed out of #4033's implementation (PR #4333), which deliberately pinned the wrong behaviour so this fix would flip a watched test.

## What was wrong

`formatCurrency` renders a currency amount whose fractional part has one significant digit with **one** decimal place instead of two. Any price ending in a zero cent digit came out a digit short:

| amount | before | after |
|---|---|---|
| `1234.5` | `$1,234.5` | `$1,234.50` |
| `19.9` | `$19.9` | `$19.90` |
| `0.5` | `$0.5` | `$0.50` |
| `1234` | `$1,234` | `$1,234` (unchanged) |

Its own doc comment promised the opposite: *"Salesforce convention: `$1,234.50` keeps cents; `$1,234` does not."* This is money on a record page and in grid cells, so it reads as a data error rather than a formatting one.

## The one policy point

`minimumFractionDigits` was a constant `0` while `maximumFractionDigits` switched on wholeness, which handed `Intl` the **range** `[0, 2]` — and `Intl` emits the *shortest* representation in range, so a genuine cents value of `.50` printed as `.5`.

Re-anchored post-#4333: the fraction-digit policy did **not** move into the shared `formatDisplayNumber`. That formatter passes `minimumFractionDigits` / `maximumFractionDigits` straight through to `Intl` (its own policies are locale and grouping only), so the wholeness switch still lives at the `packages/fields/src/index.tsx` call site. That is the single point changed — both bounds now take the same wholeness-switched width:

```ts
const fracDigits = isWhole ? 0 : 2;   // one width, never a range
```

That also makes `formatCurrency`'s three branches agree. The **no-currency** branch routes through `formatNumber`, which sets both bounds to the width it is given, and the **bad-currency** fallback uses `toFixed` — both already rendered `1,234.50` for the same amount. Only the symbol branch disagreed with the other two and with the doc comment.

## Doc comment vs. whole-number behaviour: no conflict, so nothing was rewritten

The card asked which to follow if the doc's literal promise and the whole-number rendering disagree. Measured: **they do not.** The doc comment states both halves explicitly — `$1,234.50` keeps cents **and** `$1,234` does not — and the whole-number half was independently pinned as intended by #4333 (`keeps grouping and the currency symbol for a whole amount`, expecting `$5,000,000`). So whole=0 / fractional=2 is kept, the code now delivers what the comment already said, and the comment gains one sentence making the widths unambiguous rather than changing its promise.

The "doc promises 2 always" reading is not merely unattractive — it is mechanically rejected. See limb B below.

## Reverse verification

Predictions written down before running (`commit-then-revert`, never `git stash`).

| Limb | Predicted | Observed |
|---|---|---|
| **A** — the fix taken back out (`minimumFractionDigits: 0` restored) | exactly **10** red: 9 fractional pins in the new file plus #4033's flipped control; every whole-amount / no-currency / bad-currency / compact / ordinal / locale control stays **green** | exactly that — 10 failed, 22 passed, and the 10 identities match one for one |
| **B** — the over-reach: a constant `minimumFractionDigits: 2` (the "doc promises 2 always" reading) | exactly **5** red: the three whole-amount pins in the new file plus #4033's two whole-amount currency controls; every fractional pin stays green | exactly that — 5 failed, 27 passed |

Limb B is the load-bearing one for the ruling above: it is what makes "the whole-number half is deliberate" evidence rather than assertion, and it proves the new whole-amount controls are not decoration — they are the tripwire that catches the wrong fix.

Limb A's **green** half matters too: `1234.567` renders `$1,234.57` under both policies, so that case can never separate them. It is pinned as a control and labelled as one, not offered as evidence.

## Tests

New: `packages/fields/src/__tests__/formatCurrency.centsDigit.test.tsx` (17 tests) — the fix, plus a control for every branch it must not disturb (whole amounts, non-finite, no-currency, bad-currency fallback, `formatCompactCurrency`, locale marks, and a declared `scale`).

Flipped: `NumberCellRenderer.grouping.test.tsx` — the control #4033 left pinned on `$1,234.5` with a comment pointing at this card now expects `$1,234.50`. Its actual subject, grouping, is unchanged.

Swept for other assertions of the truncated form across `packages/` and `apps/`: none. The dashboard's money strings come from numeral.js format patterns, not this helper, and every other currency expectation in the repo uses a whole amount.

- `packages/fields` + `packages/i18n`: **120 files / 1943 tests passed**.
- Downstream consumers of the helper (`plugin-grid`, `plugin-gantt`, `plugin-dashboard`, `plugin-list`, `react`): **204 files / 2223 tests passed**.
- Type-check, **downstream/prefix direction** (`--filter '...@object-ui/fields'` = consumers, not dependencies): 19 projects in scope, 18 with a `type-check` script, **all clean, exit 0** — after a full `pnpm build` (43/43) so no missing or stale `dist/*.d.ts` was read. (The first attempt failed on `examples/schema-catalog` for exactly that reason: a fresh worktree with only the dependency closure built.)
- Lint `@object-ui/fields`: **0 errors** (the new file adds 2 pre-existing-style `no-explicit-any` warnings, matching the sibling test's prop casting).
- `check-control-bytes`: OK. Changeset presence / fixed-group / no-major: all green.

## Measured, so it is not guessed

`formatCurrency` takes no `scale` and `CurrencyCellRenderer` never reads one, so a declared `scale` is inert on the currency cell path — before and after. Pinned as a control so a future change making it load-bearing has to say so out loud. `formatCompactCurrency` is a separate function with its own one-digit compact policy and is untouched.

## Scope

`packages/fields` only (one src file, two test files, one changeset). No `packages/react` or `packages/components` test infrastructure (#4040 t4), no plugin-dashboard (#4032), no app-shell home (#4329), no tailwind configs (#4065). `objectstack` read-only.

## Out-of-scope finding

Filed **#4361**: currency formatting overrides each currency's own fraction-digit convention. Both paths hardcode a width and hand it to `Intl`, which knows JPY has 0 decimals and KWD has 3 — so a 0-decimal currency renders `¥1,234.50` where the default is `¥1,235`, and a 3-decimal one renders `KWD 1.50` where the default is `KWD 1.500`. Pre-existing on both sides of this change and not a regression: this PR moves the second digit of an amount that was already showing decimals a yen amount should not have. Kept separate because it is not a one-line flip — letting `Intl` decide would also retire the Salesforce whole-number convention that #4033 pinned, and `CurrencyField`'s authorable `precision` raises a contract question underneath it.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_