### PR TITLE
docs(ci): correct the four remaining copies of the falsified paths-ignore premise

### DIFF
--- a/.github/workflows/changeset-presence.yml
+++ b/.github/workflows/changeset-presence.yml
@@ -9,14 +9,33 @@ name: Changeset Presence
 #
 # Why this is a SECOND changeset workflow rather than a wider trigger on the
 # first. `changeset-guard.yml` runs only when `.changeset/**` changes, and that
-# inversion is deliberate and documented in its own header: `ci.yml` and
-# `lint.yml` both list `.changeset/**` under `paths-ignore`, so a PR that adds
-# ONLY a changeset starts nothing else, and that guard exists to see exactly that
-# PR. A PR which FORGOT its changeset does not touch `.changeset/**` at all, so
-# the one check that could notice is the one guaranteed not to run. Widening those
-# paths would break the case it was built for. Hence two workflows, opposite
-# directions: that one polices the level of a declaration that exists, this one
-# polices the existence of a declaration at all.
+# inversion is deliberate and documented in its own header: on a PR that adds
+# ONLY a changeset, every gate inside `ci.yml` and `lint.yml` skips, so nothing
+# in either of them ever reads the changeset — and that guard exists to see
+# exactly that PR. A PR which FORGOT its changeset does not touch `.changeset/**`
+# at all, so the one check that could notice is the one guaranteed not to run.
+# Widening those paths would break the case it was built for. Hence two
+# workflows, opposite directions: that one polices the level of a declaration
+# that exists, this one polices the existence of a declaration at all.
+#
+# That is no longer the reason this header used to give. It said `ci.yml` and
+# `lint.yml` both list `.changeset/**` under `paths-ignore`, so a PR adding ONLY
+# a changeset "starts nothing else". objectui#3523 step 2 deleted `paths-ignore`
+# from their `pull_request` trigger; it remains ONLY on `push`. Such a PR does
+# start both workflows and does produce their contexts — measured: PR #3856 (one
+# markdown file) 16 checks, PR #4339 (one line added to AGENTS.md) 17. The
+# correction is objectui#3857; an author had already acted on the old sentence
+# and got the opposite result.
+#
+# What #3523 moved rather than deleted is the path DECISION: it is now the
+# `Decide whether this change needs a full run` step in `ci.yml`, with a twin in
+# `lint.yml`, and its exclusion list is that `push` filter unchanged — markdown
+# and `.changeset/**` included, held identical to it by
+# `scripts/__tests__/merge-queue-reporting.test.ts`. Both workflows therefore
+# start, report, and skip every expensive step on precisely this PR: the
+# conclusion survives its premise, and `changeset-guard.yml`, running outside
+# that in-job switch with no install and no build, is still the only thing that
+# judges a changeset-only PR at all.
 #
 # Hence also: no `paths` and no `paths-ignore` here, deliberately — the same
 # choice `control-bytes.yml` and `docs-links.yml` made and for a stronger reason.

--- a/scripts/__tests__/check-changeset-no-major.test.ts
+++ b/scripts/__tests__/check-changeset-no-major.test.ts
@@ -18,8 +18,17 @@ import { findMajorBumps, parseFrontmatterBumps } from '../check-changeset-no-maj
  * Four pending changesets had scored `major` (17 package entries) during the
  * 17.x line, which would have shipped 39 packages as 18.0.0 against an
  * `@objectstack` still on 17. The rule was written down and nothing ran it:
- * `ci.yml` and `lint.yml` both `paths-ignore` `.changeset/**`, so a
- * changeset-only PR started no workflow at all.
+ * back then `ci.yml` and `lint.yml` both carried `paths-ignore` on their
+ * `pull_request` trigger with `.changeset/**` in it, so a changeset-only PR
+ * started no workflow at all.
+ *
+ * That last sentence is history. objectui#3523 step 2 deleted `paths-ignore`
+ * from those `pull_request` triggers — it survives only on `push` — so such a
+ * PR does start both workflows and does produce their contexts today. What it
+ * still does not do is run anything expensive in them: the `Decide whether this
+ * change needs a full run` step excludes markdown and `.changeset/**` and skips
+ * every step below itself. Either way no gate inside those workflows reads the
+ * changeset, which is why the locks below still stand (objectui#3857).
  *
  * These tests are the second lock. `.github/workflows/changeset-guard.yml`
  * catches it on the PR that adds the changeset; the repo-state test below
@@ -117,10 +126,25 @@ describe('changeset-guard.yml', () => {
   });
 
   it('triggers on `.changeset/**` — the paths every other workflow ignores', () => {
-    // The inverse pin. `ci.yml` cannot host this check: a changeset-only PR
-    // matches its `paths-ignore` twice over (`**/*.md` and `.changeset/**`), so
-    // no job in it would ever run. If that ever stops being true, this test
-    // fails and the separate workflow can be folded back in.
+    // The inverse pin, and the reason `ci.yml` still cannot host this check: on
+    // a changeset-only PR its `Decide whether this change needs a full run` step
+    // finds nothing outside its exclusion list (markdown and `.changeset/**`
+    // among it) and skips every step below itself, so no gate in that workflow
+    // ever reads the changeset. This one has to run outside that decision.
+    //
+    // Not the reason this comment used to give — "a changeset-only PR matches
+    // its `paths-ignore` twice over, so no job in it would ever run". Since
+    // objectui#3523 step 2, `paths-ignore` is gone from the `pull_request`
+    // trigger and survives only on `push`: such a PR does start `ci.yml` and
+    // does produce its contexts (measured — PR #3856, one markdown file, 16
+    // checks; PR #4339, one line added to AGENTS.md, 17). The conclusion
+    // outlived the premise; objectui#3857 pinned the correction.
+    //
+    // That surviving `push` copy is what the two assertions below read, and it
+    // is why they stay green — `ci.yml` genuinely still declares `paths-ignore`
+    // with markdown in it, on `push`. The in-job exclusion list is held
+    // identical to that filter by `scripts/__tests__/merge-queue-reporting.test.ts`,
+    // so the pair cannot drift apart silently.
     expect(guard).toMatch(/paths:\s*\n\s*- '\.changeset\/\*\*'/);
 
     const ci = fs.readFileSync(path.join(workflowDir, 'ci.yml'), 'utf8');

--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -19,7 +19,19 @@
  * (17 package entries between them) during the 17.x line — enough to publish
  * 39 packages as 18.0.0 against an `@objectstack` still on 17. The rule was
  * already written down; nothing executed it, and no workflow even looked at
- * `.changeset/**` (both `ci.yml` and `lint.yml` list it under `paths-ignore`).
+ * `.changeset/**` (at the time `ci.yml` and `lint.yml` both listed it under
+ * `paths-ignore` on their `pull_request` trigger, so a changeset-only PR started
+ * nothing at all).
+ *
+ * That parenthetical is history, not today's shape: objectui#3523 step 2 deleted
+ * `paths-ignore` from those two `pull_request` triggers and it remains ONLY on
+ * `push`, so such a PR now starts both workflows and produces their contexts.
+ * What skips is the expensive work inside them — the `Decide whether this change
+ * needs a full run` step excludes markdown and `.changeset/**` and skips every
+ * step below itself. So no gate in either workflow reads the changeset either
+ * way, and this one, run by `.github/workflows/changeset-guard.yml` outside that
+ * in-job switch, is still the only thing that judges such a PR. The conclusion
+ * outlived its premise; objectui#3857 pinned the correction.
  *
  * The one legitimate major is the synchronized bump that follows objectstack
  * across ITS major. Set `OBJECTUI_ALLOW_MAJOR=1` for that release, and only


### PR DESCRIPTION
Fixes #4369

Completes the sweep PR #4371 started. That PR corrected three sites after objectui#3523 step 2 deleted `paths-ignore` from `ci.yml`/`lint.yml`'s `pull_request` trigger — it survives **only** on `push` (`ci.yml` line 6, `lint.yml` line 32, verified at this branch point). Four near-verbatim copies of the retired premise sat outside that card's scope; until they are corrected the repository states **both** shapes, and the stale copy in `changeset-presence.yml` is the one physically closest to the gate it explains.

All four are restated in #4371's terminology and shape, so the repo speaks one corrected dialect: `paths-ignore` remains only on `push`; the pull_request path decision is the in-job `Decide whether this change needs a full run` step, whose exclusion list is that `push` filter unchanged (markdown and `.changeset/**`), held identical to it by `scripts/__tests__/merge-queue-reporting.test.ts`; and both changeset gates remain correct as built — the conclusion outlives its premise, because those workflows now start, report, and skip every expensive step on exactly the PRs these gates judge.

## The four sites

| Site | Before (gist) | After (gist) |
|---|---|---|
| `.github/workflows/changeset-presence.yml` header | "`ci.yml` and `lint.yml` both list `.changeset/**` under `paths-ignore`, so a PR that adds ONLY a changeset starts nothing else" | Leads with the reason that holds today (every gate inside both workflows skips, so nothing in either ever reads the changeset), then names the retired premise as retired, cites #3523 step 2 and the measurements (PR #3856 → 16 checks, PR #4339 → 17), then what #3523 *moved*: the in-job decision step and its exclusion list |
| `scripts/check-changeset-no-major.mjs` docblock | historical sentence with a present-tense parenthetical: "(both `ci.yml` and `lint.yml` list it under `paths-ignore`)" | Parenthetical scoped to the past ("at the time … on their `pull_request` trigger"), history intact, followed by today's shape and why this gate is still the only thing that judges a changeset-only PR |
| `scripts/__tests__/check-changeset-no-major.test.ts` file docblock | "`ci.yml` and `lint.yml` both `paths-ignore` `.changeset/**`, so a changeset-only PR started no workflow at all" | Same history, marked as history, plus: such a PR starts both workflows today; what it still does not do is run anything expensive in them, so no gate inside them reads the changeset either way — which is why the two locks below still stand |
| `scripts/__tests__/check-changeset-no-major.test.ts` `changeset-guard.yml` trigger test | "`ci.yml` cannot host this check: a changeset-only PR matches its `paths-ignore` twice over … so no job in it would ever run" | Restated on the reason that holds today — the in-job decision step finds nothing outside its exclusion list and skips every step below itself, so this gate must run outside that decision — plus a note that the surviving `push` copy is exactly what the two assertions below read, and why they stay green |

## Zero behavior change, mechanically

- **Comment-only diff.** Every added/removed line is a `#` comment, a docblock line, or a `//` comment: `git diff -U0` filtered to lines that are **not** comments returns nothing.

  ```
  git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*(#|\*|//|/\*)'
  → (no output)
  ```

- **YAML re-parse, before vs after** (`yaml@2.9.0`, `origin/main` copy vs branch copy):

  ```
  parsed identical: true
  triggers before: {"pull_request":{"branches":["main","develop"]},"merge_group":{"types":["checks_requested"]}}
  triggers after : {"pull_request":{"branches":["main","develop"]},"merge_group":{"types":["checks_requested"]}}
  jobs identical: true
  ```

- **Assertions untouched — 0 changed.** `expect(ci).toContain("paths-ignore:")` and the markdown-glob assertion beside it are byte-identical and still green: `ci.yml`'s `push` trigger genuinely keeps its copy. The `it(...)` titles are code, not comments, and were left alone for the same reason.
- **No suite pinned the old sentences** — measured, not assumed: a grep for the removed phrasings across `scripts/`, `packages/`, `apps/` returns only my own new comment (which quotes the retired sentence deliberately) and unrelated prose. The suites that read these files (`check-changeset-presence`, `merge-queue-reporting`, `docs-links-workflow`, `check-skills-paths`, `check-control-bytes`, `ci-cd-pipeline-doc`) all strip whole-line comments before scanning, and the edited workflow contains no literal `paths-ignore:` token at all.

## Verification

| Command | Result |
|---|---|
| `node --check scripts/check-changeset-no-major.mjs` | OK |
| `pnpm exec eslint scripts/check-changeset-no-major.mjs scripts/__tests__/check-changeset-no-major.test.ts` | exit 0, 0 errors |
| `node scripts/check-changeset-no-major.mjs` | exit 0 — "No changeset declares a `major` bump." |
| `node scripts/check-control-bytes.mjs` | exit 0 — 4085 tracked text files scanned |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "3 file(s) changed, 0 of them under the src/ of a package the release covers … no changeset is owed" |
| repo-root `pnpm exec vitest run` over the eight suites that read these files (`check-changeset-no-major`, `check-changeset-presence`, `merge-queue-reporting`, `lint-workflow`, `ci-cd-pipeline-doc`, `check-control-bytes`, `docs-links-workflow`, `check-skills-paths`) | `Test Files 8 passed (8)`, `Tests 168 passed (168)` |
| CI on this head commit | 18 check runs, 16 success + 2 skipped (`Test (coverage)`, `dependabot`), 0 failures — including `Lint`, `Type Check` and all four `Test (shard N/4)`, which run the whole `scripts/` suite on a fresh install |

**Reverse verification, honestly reported.** The usual before-green/after-red direction does not exist for this change: nothing pins these sentences, in either direction. Measured rather than assumed — with all four sites reverted to `origin/main` (`git checkout origin/main -- …`, never `git stash`) the same suites stayed green, `Test Files 4 passed (4)`, `Tests 85 passed (85)`, then the branch text was restored. That absence of coverage is precisely why these copies outlived two corrections, and it is why the fix is a text sweep rather than a gate.

No changeset: nothing under the `src/` of a released package changed, and the gate self-determines that above.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
