### PR TITLE
docs(ci): close the falsified paths-ignore sweep — three named sites plus five found (#4381)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,15 +645,21 @@ jobs:
       # The docs *link* check is deliberately NOT here any more — do not add it
       # back. `node scripts/check-doc-links.mjs` ran in this job from #3213 /
       # #3292 (PR #3450) until #3448 promoted it to its own workflow,
-      # `docs-links.yml`, with no path filters. The reason is this workflow's own
-      # `paths-ignore`: it lists `content/**` and `'**/*.md'`, and GitHub has no
-      # per-job path filter, so a docs-ONLY pull request never started `ci.yml`
-      # at all and the link check never saw the class of PR most likely to break
-      # a link. It is removed rather than kept in both places: the standalone
-      # workflow's trigger set is a strict superset of this job's, so a copy here
-      # could only ever add a second red check for the same broken link, and a
-      # second place to forget. `scripts/__tests__/docs-links-workflow.test.ts`
-      # pins the gate to exactly one home.
+      # `docs-links.yml`, with no path filters. The reason THEN was this
+      # workflow's own `paths-ignore`, which at the time listed `content/**` and
+      # `'**/*.md'` on both triggers: GitHub has no per-job path filter, so a
+      # docs-ONLY pull request never started `ci.yml` at all and the link check
+      # never saw the class of PR most likely to break a link. Since
+      # objectui#3523 step 2 that filter is gone from `pull_request` and survives
+      # only on `push` (objectui#3857), so the pull-request half of that
+      # blindness is gone — the push half is not, and this job still does not run
+      # on a docs-only push to `main`. objectui#4381 corrected the present tense
+      # this note used to carry. It stays removed rather than kept in both places
+      # either way: the standalone workflow's trigger set is a strict superset of
+      # this job's, so a copy here could only ever add a second red check for the
+      # same broken link, and a second place to forget.
+      # `scripts/__tests__/docs-links-workflow.test.ts` pins the gate to exactly
+      # one home.
 
       - name: Turbo Cache
         if: steps.docs-changes.outputs.should_run == 'true'

--- a/.github/workflows/control-bytes.yml
+++ b/.github/workflows/control-bytes.yml
@@ -1,13 +1,32 @@
 name: Control Bytes
 
-# Why this is its own workflow instead of a job in `ci.yml` or `lint.yml`: both
-# of those list `'**/*.md'`, `content/**`, `docs/**` and `.changeset/**` under
-# `paths-ignore`, and GitHub has no per-job path filter. A raw control byte lands
-# in markdown exactly as easily as in TypeScript — objectstack#4890 was a NUL in
-# a `.claude/` skill file, emitted by the very PR that was writing the rule
-# against it — so a gate that cannot see a markdown-only PR rebuilds the hole it
-# exists to close. `changeset-guard.yml` sits in this repo for the same reason
-# and says so in its own header.
+# Why this is its own workflow instead of a job in `ci.yml` or `lint.yml`: on a
+# markdown-only change neither of those runs anything expensive, so a gate living
+# inside one of them would never see it. A raw control byte lands in markdown
+# exactly as easily as in TypeScript — objectstack#4890 was a NUL in a `.claude/`
+# skill file, emitted by the very PR that was writing the rule against it — so a
+# gate that cannot see a markdown-only PR rebuilds the hole it exists to close.
+# `changeset-guard.yml` sits in this repo for the same reason and says so in its
+# own header.
+#
+# That is no longer the reason this header used to give, and objectui#4381
+# corrected it. It said both of those workflows list `'**/*.md'`, `content/**`,
+# `docs/**` and `.changeset/**` under `paths-ignore`, with no per-job path filter
+# available in GitHub Actions, so a markdown-only PR started neither.
+# objectui#3523 step 2 deleted `paths-ignore` from their `pull_request` trigger;
+# it remains ONLY on `push`. Such a PR does start both workflows and does produce
+# their contexts — measured: PR #3856 (one markdown file) 16 checks, PR #4339
+# (one line added to AGENTS.md) 17. The correction is objectui#3857; an author
+# had already acted on the old sentence and got the opposite result.
+#
+# What #3523 moved rather than deleted is the path DECISION: it is now the
+# `Decide whether this change needs a full run` step in `ci.yml`, with a twin in
+# `lint.yml`, and its exclusion list is that `push` filter unchanged — markdown
+# among it, held identical to it by
+# `scripts/__tests__/merge-queue-reporting.test.ts`. Both workflows therefore
+# start, report, and skip every expensive step on a markdown-only PR, and both
+# still skip the run outright on a markdown-only push to `main`. The conclusion
+# outlived its premise: this gate has to run outside that in-job switch.
 #
 # Hence: no `paths` and no `paths-ignore` here, deliberately.
 # `scripts/__tests__/check-control-bytes.test.ts` fails if either is ever added.

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -2,14 +2,33 @@ name: Docs Links
 
 # Why this is its own workflow instead of a step in `ci.yml`'s `docs` job, which
 # is where this check lived when it first reached CI (#3213 / #3292, PR #3450):
-# `ci.yml` lists `'**/*.md'`, `content/**`, `docs/**` and `apps/site/**` under
-# `paths-ignore`, and GitHub has no per-job path filter. The published site is
-# built from `content/docs/**`, so a docs-ONLY pull request matched every ignore
-# pattern, started no workflow at all, and was never link-checked — while a
-# docs-only PR is the likeliest way an internal link breaks in the first place.
-# The step therefore only ever saw PRs that touched docs *alongside code*, plus
-# pushes to `main`; a broken link could land through a pure-docs PR and only turn
-# `main` red later, under an unrelated author (#3448).
+# `ci.yml` THEN listed `'**/*.md'`, `content/**`, `docs/**` and `apps/site/**`
+# under the `paths-ignore` of both its triggers, and GitHub has no per-job path
+# filter. The published site is built from `content/docs/**`, so a docs-ONLY
+# pull request matched every ignore pattern, started no workflow at all, and was
+# never link-checked — while a docs-only PR is the likeliest way an internal link
+# breaks in the first place. The step therefore only ever saw PRs that touched
+# docs *alongside code*, plus pushes to `main`; a broken link could land through
+# a pure-docs PR and only turn `main` red later, under an unrelated author
+# (#3448).
+#
+# Read that paragraph as history, and do not act on its present tense — the
+# lead-in used to be written as one, which is what objectui#4381 corrected.
+# objectui#3523 step 2 deleted `paths-ignore` from `ci.yml`'s `pull_request`
+# trigger; it survives ONLY on `push`. A docs-only PR therefore DOES start
+# `ci.yml` today and DOES produce its contexts — measured: PR #3856 (one markdown
+# file) 16 checks, PR #4339 (one line added to AGENTS.md) 17. objectui#3857
+# pinned that correction after an author acted on the old sentence and got the
+# opposite result. Nor would the in-job switch keep a link check out the way it
+# keeps the changeset gates out: `ci.yml`'s `docs` job gates its steps on
+# `apps/site/` or `content/` having CHANGED, which a docs-only PR satisfies.
+#
+# Two reasons outlived that premise, and they are why nothing moves back.
+# `ci.yml` still filters its `push` lane, so a docs-only push to `main` starts it
+# not at all and this workflow is the only thing that link-checks that merge. And
+# #3448 settled one gate, one home: this workflow's trigger set is a strict
+# superset of that job's, so a copy there could only add a second red check for
+# one broken link, and a second place to forget.
 #
 # `control-bytes.yml` hit the same wall and its header names the consequence: a
 # gate that cannot see a markdown-only PR "rebuilds the hole it exists to close".

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -456,10 +456,10 @@ all, and `main` sat with a broken link it would have caught (objectui#3213, obje
 
 **Why it is a separate workflow.** This is the second instance of the lesson `control-bytes.yml`
 records, and it was found by the PR that first put this check into CI. That PR added it as a step
-in `ci.yml`'s `docs` job — where it could never see the PRs that matter. `ci.yml` lists
-`'**/*.md'`, `content/**`, `docs/**` and `apps/site/**` under `paths-ignore`, GitHub's
-`paths-ignore` skips the *whole workflow* when every changed file matches, and GitHub has no
-per-job path filter. So a **docs-only** PR — the likeliest way an internal link breaks — started no
+in `ci.yml`'s `docs` job — where it could never see the PRs that matter. `ci.yml` *then* listed
+`'**/*.md'`, `content/**`, `docs/**` and `apps/site/**` under the `paths-ignore` of **both** its
+triggers, GitHub's `paths-ignore` skips the *whole workflow* when every changed file matches, and
+GitHub has no per-job path filter. So a **docs-only** PR — the likeliest way an internal link breaks — started no
 workflow at all, and the check only ever ran on PRs that touched docs alongside code, plus pushes
 to `main`. A bad link could merge through a pure-docs PR and turn `main` red later under an
 unrelated author (objectui#3448).
@@ -674,8 +674,13 @@ covers change, and if so, does this change **add** a `.changeset/*.md`?
   of the guarded surface, free to drift from the config the script reads.
 
 **Why this is separate from `changeset-guard.yml`, which also polices changesets:** that workflow's
-trigger is `paths: ['.changeset/**']`, and the inversion is deliberate — a PR adding *only* a
-changeset starts no other workflow, and that guard exists to see it. A PR that **forgot** its
+trigger is `paths: ['.changeset/**']`, and the inversion is deliberate — on a PR that adds *only* a
+changeset, every gate inside `ci.yml` and `lint.yml` short-circuits, so nothing in either of them
+ever reads the changeset, and that guard exists to see exactly that PR. (It is *not*, as this
+paragraph said until [#4381](https://github.com/objectstack-ai/objectui/issues/4381), that such a PR
+"starts no other workflow": since [#3523](https://github.com/objectstack-ai/objectui/issues/3523)
+both workflows start and report on it — see **Changeset Guard** above, and the path-filter bullets
+at the top of this page.) A PR that **forgot** its
 changeset does not touch `.changeset/**` at all, so the one check able to notice was the one check
 guaranteed not to run. Widening those paths would have broken the case that guard was built for.
 Two workflows, opposite directions: one polices the *level* of a declaration that exists, the other

--- a/scripts/__tests__/check-changeset-presence.test.ts
+++ b/scripts/__tests__/check-changeset-presence.test.ts
@@ -212,11 +212,28 @@ describe('changeset-presence.yml — the gate can start on the PR that needs it'
   });
 
   it('leaves changeset-guard.yml alone — the two gates face opposite directions', () => {
-    // `changeset-guard.yml`'s `paths: ['.changeset/**']` is deliberate: a PR
-    // adding ONLY a changeset starts no other workflow, and that guard exists to
-    // see it. A PR that FORGOT its changeset does not touch `.changeset/**`, so
-    // widening those paths would have broken the case it was built for while
-    // still not catching this one. Two workflows, one direction each.
+    // `changeset-guard.yml`'s `paths: ['.changeset/**']` is deliberate: on a PR
+    // that adds ONLY a changeset, every gate inside `ci.yml` and `lint.yml`
+    // skips, so nothing in either of them ever reads the changeset — and that
+    // guard exists to see exactly that PR. A PR that FORGOT its changeset does
+    // not touch `.changeset/**`, so widening those paths would have broken the
+    // case it was built for while still not catching this one. Two workflows,
+    // one direction each.
+    //
+    // Not the reason this comment used to give — "a PR adding ONLY a changeset
+    // starts no other workflow". That is the sentence PR #4371 rewrote in the
+    // docblock of `check-changeset-presence.mjs`, the script this file
+    // accompanies, and the pair disagreed across the two until objectui#4381.
+    // objectui#3523 step 2 deleted `paths-ignore` from `ci.yml`'s and
+    // `lint.yml`'s `pull_request` trigger; it survives only on `push`. Such a PR
+    // therefore DOES start both and DOES produce their contexts — measured: PR
+    // #3856 (one markdown file) 16 checks, PR #4339 (one line added to
+    // AGENTS.md) 17. What still skips is the expensive work: the `Decide whether
+    // this change needs a full run` step excludes markdown and `.changeset/**`
+    // and skips every step below itself, and its exclusion list is that `push`
+    // filter unchanged, held identical to it by
+    // `scripts/__tests__/merge-queue-reporting.test.ts`. The conclusion outlived
+    // its premise; objectui#3857 pinned the correction.
     const guard = withoutComments(fs.readFileSync(path.join(workflowDir, 'changeset-guard.yml'), 'utf8'));
     expect(guard).toMatch(/^\s+paths:/m);
     expect(guard).toMatch(/\.changeset\//);

--- a/scripts/__tests__/check-control-bytes.test.ts
+++ b/scripts/__tests__/check-control-bytes.test.ts
@@ -363,11 +363,22 @@ describe('wiring — the gate is actually reachable and actually runs', () => {
 
   it('does NOT filter that workflow by path', () => {
     // This is the whole reason it is its own workflow rather than a step in
-    // ci.yml or lint.yml: both of those `paths-ignore` markdown, `content/**`,
-    // `docs/**` and `.changeset/**`. Markdown is precisely the carrier
-    // objectstack#4890 was found in, so a path filter here would rebuild the
-    // hole this guard exists to close. `changeset-guard.yml` is in the repo for
-    // the same reason and says so in its own header.
+    // ci.yml or lint.yml: on a markdown-only change both of those skip every
+    // expensive step, so a gate inside either would never see it. Markdown is
+    // precisely the carrier objectstack#4890 was found in, so a path filter here
+    // would rebuild the hole this guard exists to close. `changeset-guard.yml`
+    // is in the repo for the same reason and says so in its own header.
+    //
+    // Not the reason this comment used to give — "both of those `paths-ignore`
+    // markdown, `content/**`, `docs/**` and `.changeset/**`" — which
+    // objectui#4381 corrected here and in the workflow's own header. Since
+    // objectui#3523 step 2 that filter is gone from their `pull_request` trigger
+    // and survives only on `push`, so a markdown-only PR does start both and
+    // does produce their contexts (measured — PR #3856, one markdown file, 16
+    // checks). What still skips is the work inside them: the `Decide whether
+    // this change needs a full run` step excludes markdown and skips every step
+    // below itself, and the `push` lane is filtered at the trigger as before.
+    // The conclusion outlived its premise; objectui#3857 pinned the correction.
     const workflow = fs.readFileSync(workflowPath, 'utf8');
     expect(workflow).not.toMatch(/paths-ignore:/);
     expect(workflow).not.toMatch(/^\s+paths:/m);

--- a/scripts/__tests__/docs-links-workflow.test.ts
+++ b/scripts/__tests__/docs-links-workflow.test.ts
@@ -10,12 +10,23 @@ import { fileURLToPath } from 'node:url';
  * `.github/` called it, so it had never run in CI at all and `main` carried a
  * broken link it would have caught (#3213, #3292). PR #3450 fixed that by adding
  * it as a step in `ci.yml`'s `docs` job — and rebuilt half the hole in the
- * process: `ci.yml` lists every markdown path, plus `content/**`, `docs/**` and
- * `apps/site/**`, under `paths-ignore`; `paths-ignore` skips the *entire*
- * workflow when every changed file matches it, and GitHub has no per-job path
- * filter. A docs-only PR therefore started no workflow, so the one class of
- * change most likely to break an internal link was the one class the link check
- * could never see.
+ * process: `ci.yml` THEN listed every markdown path, plus `content/**`,
+ * `docs/**` and `apps/site/**`, under the `paths-ignore` of both its triggers;
+ * `paths-ignore` skips the *entire* workflow when every changed file matches it,
+ * and GitHub has no per-job path filter. A docs-only PR therefore started no
+ * workflow, so the one class of change most likely to break an internal link was
+ * the one class the link check could never see.
+ *
+ * That paragraph is history — its lead-in used to be written in the present
+ * tense, which objectui#4381 corrected here and in the workflow's own header.
+ * objectui#3523 step 2 deleted `paths-ignore` from `ci.yml`'s `pull_request`
+ * trigger; it survives only on `push`, so a docs-only PR does start `ci.yml` now
+ * (measured: PR #3856, one markdown file, 16 checks) and objectui#3857 pinned
+ * the correction. The in-job switch would not keep a link check out either — the
+ * `docs` job runs its steps precisely when `content/` or `apps/site/` changed.
+ * What outlived the premise is what the assertions below pin: `ci.yml` keeps the
+ * filter on its `push` lane, so a docs-only push to `main` starts it not at all,
+ * and #3448 settled one gate, one home.
  *
  * `control-bytes.yml` hit this exact wall first and its header states the
  * consequence: a gate that cannot see a markdown-only PR "rebuilds the hole it


### PR DESCRIPTION
Fixes #4381

The closing sweep of the falsified `paths-ignore` premise, third and last in the #3857 → #4369 → #4381 chain. Per the PM ruling on the card, this is not another enumeration: it is the three named sites **plus** a full-tree sweep under multiple phrasings, so the pattern of each card leaving residue for the next one ends here.

**The corrected reality**, mirrored verbatim from PR #4371 and PR #4380: objectui#3523 step 2 deleted `paths-ignore` from `ci.yml`'s and `lint.yml`'s `pull_request` trigger; it survives **only** on `push`. The pull-request path decision is now the in-job `Decide whether this change needs a full run` step, whose exclusion list is that `push` filter unchanged, held identical to it by `scripts/__tests__/merge-queue-reporting.test.ts`. Measured counter-evidence to the retired sentence: PR #3856 (one markdown file) started 16 checks, PR #4339 (one line added to AGENTS.md) 17.

## Sites corrected

### Part 1 — the three sites the card named

| # | Site | Before (gist) | After (gist) |
|---|---|---|---|
| 1 | `scripts/__tests__/check-changeset-presence.test.ts:215` | "a PR adding ONLY a changeset **starts no other workflow**, and that guard exists to see it" | "on a PR that adds ONLY a changeset, **every gate inside `ci.yml` and `lint.yml` skips**, so nothing in either of them ever reads the changeset" + a "Not the reason this comment used to give" paragraph naming PR #4371, #3523 step 2 and the in-job step |
| 2 | `content/docs/guide/ci-cd-pipeline.md:677` | "the inversion is deliberate — a PR adding *only* a changeset **starts no other workflow**" | "on a PR that adds *only* a changeset, **every gate inside `ci.yml` and `lint.yml` short-circuits**" + a parenthetical marking the old sentence and pointing at the two places on this same page that already stated it correctly (lines 47-48 and 601-602) |
| 3 | `.github/workflows/docs-links.yml:5` | "`ci.yml` **lists** … under `paths-ignore` … so a docs-ONLY pull request … started no workflow at all" | "`ci.yml` **THEN listed** … under the `paths-ignore` of **both its triggers**" + "Read that paragraph as history, and do not act on its present tense" + the two reasons that outlived the premise |

Site 1 is the one the card called out as the sharpest: it sat in the test file for the very script PR #4371 corrected, so `check-changeset-presence.mjs` and `check-changeset-presence.test.ts` — same basename, one directory apart — asserted opposite shapes. They now agree.

### Part 2 — five more the full-tree sweep found

| # | Site | Before (gist) | After (gist) |
|---|---|---|---|
| 4 | `.github/workflows/control-bytes.yml:4` | "both of those **list** `'**/*.md'`, `content/**`, `docs/**` and `.changeset/**` under `paths-ignore`, and GitHub has no per-job path filter" | "on a markdown-only change **neither of those runs anything expensive**, so a gate living inside one of them would never see it" + the full "That is no longer the reason this header used to give" correction |
| 5 | `scripts/__tests__/check-control-bytes.test.ts:356` | "both of those **`paths-ignore`** markdown, `content/**`, `docs/**` and `.changeset/**`" | "on a markdown-only change **both of those skip every expensive step**" + "Not the reason this comment used to give" |
| 6 | `scripts/__tests__/docs-links-workflow.test.ts:14` | "`ci.yml` **lists** every markdown path … under `paths-ignore`" | "`ci.yml` **THEN listed** … under the `paths-ignore` of both its triggers" + "That paragraph is history" |
| 7 | `.github/workflows/ci.yml:645` | "The reason **is** this workflow's own `paths-ignore`: it **lists** `content/**` and `'**/*.md'`" | "The reason **THEN was** … which **at the time** listed … on both triggers" + the pull-request half is gone, the push half is not |
| 8 | `content/docs/guide/ci-cd-pipeline.md:460` | "`ci.yml` **lists** `'**/*.md'`, `content/**`, `docs/**` and `apps/site/**` under `paths-ignore`" | "`ci.yml` ***then* listed** … under the `paths-ignore` of **both** its triggers" |

Items 4 and 5 were the only fully present-tense pair left in the repository — no historical marker anywhere in either, unlike the mixed-tense sites the card had already graded. Items 5, 6 and 7 are the companion texts of files fixed in this same PR; correcting a header while leaving its accompanying test docblock asserting the old shape would have rebuilt the exact two-shapes problem this card exists to close.

## The `docs-links.yml` grading (item 3) — **fixed**, and graded apart from the changeset gates

The card asked for this one to be graded before being fixed, with leave-with-reasoning an acceptable outcome. It failed grading, on two counts:

1. **The lead-in is a bare present-tense assertion** — "`ci.yml` lists `'**/*.md'`, `content/**`, `docs/**` and `apps/site/**` under `paths-ignore`" — with no `push` qualifier, in a header whose whole job is to answer a question about *today* ("why is this its own workflow").
2. **It is load-bearing for a pull_request conclusion.** The consequence it carries is about a docs-ONLY *pull request*. That is precisely the "decide by it, decide wrong" class, and it is the sentence shape an author already acted on to get 16 checks.

I did **not** use the card's suggested model wording verbatim. `scripts/__tests__/check-skills-paths.test.ts:402-403` ("lists … under the `paths-ignore` of its `push` trigger") is the right model for a *push* consequence, which is what that file is reasoning about. Here the consequence is a pull request, so qualifying the lead-in to `push` would leave a conclusion that no longer follows from its premise. The history is therefore marked as history ("THEN listed … under the `paths-ignore` of both its triggers"), which is what actually made the consequence true, and today's shape is stated separately.

**One substantive finding while grading, which changes what this header may claim.** The other corrected texts in this chain all conclude "the conclusion outlived its premise, because the in-job switch skips every expensive step on such a PR". That reasoning is **false for docs** and I did not copy it: `ci.yml`'s `docs` job gates its steps on `apps/site/` or `content/` having **CHANGED** (`ci.yml:613-616`) — the inverse direction from the `type-check`/`test`/`e2e` gates — so a docs-only PR *satisfies* it and a link check living there today **would** run. What genuinely outlived the premise is different and is now what the header says:

- `ci.yml` still filters its `push` lane, so a docs-only push to `main` starts it not at all, and `docs-links.yml` is the only thing that link-checks that merge; and
- #3448 settled one gate, one home — this workflow's trigger set is a strict superset of that job's.

Both are exactly what `content/docs/guide/ci-cd-pipeline.md:474-477` already said correctly; the workflow header was the copy that lacked it.

## Sweep

Run against the whole tree over `*.ts *.tsx *.mjs *.md *.yml *.yaml`, excluding `node_modules` and `dist`, under two rounds of phrasings — the card's minimum set plus `start neither` / `started neither` / `starts neither` / `no per-job path filter` / `never started` / `would never start` / `does not start`.

**Falsified-consequence phrasings, after this PR:**

```
grep -rn --include='*.ts' --include='*.tsx' --include='*.mjs' --include='*.md' \
     --include='*.yml' --include='*.yaml' -F "$pat" . | grep -v node_modules | grep -v /dist/
  for pat in: 'starts no other workflow' 'starts nothing else' 'started no workflow'
              'no workflow at all' 'start neither' 'started neither' 'starts neither'
              'matched every ignore pattern' 'list it under'
```

Ten hits remain and every one was read. All ten are either a **quoted correction** (the phrase appears inside quotes in a sentence that then refutes it — `changeset-guard.yml:10`, `changeset-presence.yml:23`, `check-changeset-presence.mjs:38`, `check-changeset-presence.test.ts:224`, `ci-cd-pipeline.md:681`, `control-bytes.yml:15`), **marked history** (`docs-links.yml:8` under "Read that paragraph as history"; `check-changeset-no-major.test.ts:23` under "That last sentence is history"; `merge-queue-reporting.test.ts:25`, the #3523 problem statement), or **true as written** (`skills-paths.yml:7` — "a **push** that only edits a guide would therefore start neither", accurate, since the `push` filter survives).

**Present-tense lead-in class, after this PR:** every remaining "lists … under `paths-ignore`" site carries a `push` qualifier or a history marker — `skills-paths.yml:5-6`, `check-skills-paths.test.ts:403-404`, `ci-cd-pipeline.md:47-48`, `ci-cd-pipeline.md:143`, `ci-cd-pipeline.md:212`, `ci-cd-pipeline.md:261`, `ci-cd-pipeline.md:176`, `ci.yml:115-117`, `lint.yml:100-108`, `merge-queue-reporting.test.ts:252`, `lint-workflow.test.ts:320` — plus the corrections from PR #4371 / PR #4380, which were re-read against their merged versions rather than assumed.

**Acceptance:** **zero remaining present-tense copies of the falsified premise outside the exceptions listed below** — that is, no site now asserts, in the present tense, that a markdown-only or changeset-only pull request starts no workflow, or that `ci.yml`/`lint.yml` filter *pull requests* by path.

## Exceptions — report, don't fix

| Site | Why not fixed here |
|---|---|
| `scripts/__tests__/check-i18n-en-drift.test.ts:739` | **In-flight held surface** (i18n gate scripts, #3878 trio). Also graded below. |
| `scripts/__tests__/check-action-forward-parity.test.ts:712` | Its **near-verbatim twin**. Graded and deliberately left — see below. |
| `content/docs/releases/**` | Never edited in a code PR. Swept: no hit in any round. |
| PR #4380's three files | Already corrected; re-read against the merged `63c75d0fd` version rather than the pre-merge text before concluding they were fine. |
| `CHANGELOG.md` files | Generated history. One `paths-ignore`-adjacent hit, left. |

**Grading for the twin pair**, since leaving them is a judgement and not an oversight. Both read: "ci.yml `paths-ignore`s markdown, content/, docs/, apps/site/ and .changeset/. None can match `packages/…`, so a PR that edits … always starts this workflow." Two reasons to leave them:

1. **They do not assert the falsified consequence, and their conclusion is true today** — in fact *more* strongly true, since nothing filters pull requests at all now. Their premise is accurate about the surviving `push` list, which is precisely what the assertion under each comment parses (`ci.slice(0, ci.indexOf('jobs:'))` reads the `on:` block, whose only quoted entries today are the `push` `paths-ignore`). A reader who acts on either gets the right answer, so neither is in the "decide by it, decide wrong" class the three cards in this chain were filed against.
2. **One of the two is a held surface, and splitting the pair would manufacture a fresh disagreement** — fixing the forward-parity copy while the i18n copy stays would recreate, between two near-identical comments, exactly the two-shapes problem this card exists to end. Fixing neither keeps them consistent; if the maintainer wants them qualified anyway, they should move together once #3878 lands.

## Verification

Comment/prose-only, so no assertion changes and no reverse verification in the usual before-green/after-red sense is available — by construction nothing reads these lines. Stating that plainly rather than manufacturing a red: the meaningful proof for this change is mechanical, and it is stronger than a test result.

- **Diff audit — every changed line in `.ts` is a `//`/docblock line and in `.yml` a `#` line.** Strip the leading `+`/`-` from the `.ts`/`.mjs`/`.yml` hunks, drop comment and blank lines, and **zero lines remain**:
  ```
  git diff -U0 -- '*.ts' '*.mjs' '*.yml' | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
    | sed -E 's/^[+-]//' | grep -vE '^\s*(#|//|\*|/\*\*)' | grep -vE '^\s*$'   ->  count=0
  ```
- **YAML re-parse — all three touched workflows parse to byte-identical objects** (`yaml@2.9.0`, `JSON.stringify` of the parsed document vs `git show origin/main:`): `ci.yml` 12448 → 12448, `control-bytes.yml` 694 → 694, `docs-links.yml` 668 → 668. `ALL PARSED OBJECTS IDENTICAL`.
- **Comment-stripped workflows are byte-identical to `origin/main`** — the strongest form of the same claim, and it directly answers the card's "verify that stays true" about `withoutComments`. Also re-checked the two assertions that read a workflow **raw**, without stripping (`check-control-bytes.test.ts`): `control-bytes.yml` still matches neither `/paths-ignore:/` nor `/^\s+paths:/m`, so the new prose cannot trip them; and `ci.yml` with comments stripped still does not mention `scripts/check-doc-links.mjs`, keeping the one-gate-one-home assertion honest.
- **Tests** — repo-root vitest, `--maxWorkers=1`, `NODE_OPTIONS=--max-old-space-size=2048`. Targeted first (`check-changeset-presence`, `ci-cd-pipeline-doc`, `docs-links-workflow`, `check-skills-paths`, `check-control-bytes`, `merge-queue-reporting`, `check-changeset-no-major`, `lint-workflow`): **8 passed (8), 168 passed (168)**. Then the whole directory, which covers every remaining reader of the touched files: **38 passed (38), 851 passed (851)** — re-run against the committed tree after the commit, same result.
- **Gates**: `check-doc-links.mjs` → "Links are valid across 13 scan roots" (run because this PR edits a docs page); `check-control-bytes.mjs` → OK, 4086 tracked text files; `check-skills-paths.mjs` → OK; `check-changeset-no-major.mjs` → OK; `check-changeset-presence.mjs` → "7 file(s) changed, 0 of them under the src/ of a package the release covers … **no changeset is owed**". `eslint` on the changed `.ts` files: exit 0.
- **Byte discipline**: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the changed files returns no hits.

Resource note, declared: the shared `/tmp/os-heavy-verify.lock` had five holders queued, and these are node-only script suites with no build and no DOM. Measured 13.2 GB available before starting and ran them outside the lock.

No changeset: comment/docs-only, nothing under a released package's `src/`, and the gate itself confirms none is owed. No `skip-changeset` label applied, per dispatch.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
