### PR TITLE
fix(app-shell): the metadata-admin designer's own i18n table uses the typographic ellipsis (#4377)

### DIFF
--- a/.changeset/designer-table-ellipsis-4377.md
+++ b/.changeset/designer-table-ellipsis-4377.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': patch
+---
+
+fix(app-shell): the metadata-admin designer's own i18n table uses the typographic ellipsis
+
+The designer carries its own flat `en`/`zh` table rather than reading the ten locale
+packs, so objectui#3878 — which converged those packs on U+2026 `…` per the
+consistency pass on objectstack#6015 — left it behind. Ten values across five keys
+(`engine.form.select`, `.selectObjectDots`, `.addObjects`, `.selectFieldDots`,
+`.addFields`) still ended in three ASCII full stops, and the designer renders inside
+the console shell, so `Select...` sat on screen beside the packs' `Select…`.
+
+All ten now use `…`, and the table's header records the convention for the next
+author.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -20,6 +20,23 @@
  *
  * The DirectoryPage / PageShell call these to localise headings when
  * the consumer hasn't wired the global i18n provider.
+ *
+ * ## Typographic convention: the ellipsis is U+2026 `…`, never `...`
+ *
+ * Values here end (or interrupt) with the typographic ellipsis `…`, not three
+ * ASCII full stops — per the maintainer-authorized consistency pass registered
+ * on objectstack#6015 (2026-08-09), which objectui#3878 applied to the ten
+ * locale packs in `packages/i18n/src/locales/`.
+ *
+ * This table is NOT one of those packs: the designer carries its own flat
+ * `Record` of dotted keys with `en` and `zh` in one file, so
+ * `packages/i18n/src/__tests__/ellipsis-glyph-3878.test.ts` — which scans the
+ * ten packs and says so in its own header — deliberately does not reach it.
+ * The convention is therefore held by this note rather than by a gate
+ * (objectui#4377: generalising that pin to a second table shape was costed as
+ * more machinery than the defect is worth). Follow it when adding a value; the
+ * designer renders inside the console shell, so a `...` here lands on the same
+ * screen as a `…` from the packs.
  */
 
 import { useObjectTranslation } from '@object-ui/i18n';
@@ -891,7 +908,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.edit.forceSave': 'Force save',
   'engine.cancel': 'Cancel',
   'engine.close': 'Close',
-  'engine.form.select': 'Select...',
+  'engine.form.select': 'Select…',
   'engine.form.selectEllipsis': 'Select…',
   'engine.form.add': 'Add',
   'engine.form.addItem': 'Add item',
@@ -905,13 +922,13 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.form.selectObject': 'Select object…',
   'engine.form.selectComponent': 'Select component…',
   'engine.form.noComponents': 'component_id (no components on this page yet)',
-  'engine.form.selectObjectDots': 'Select object...',
-  'engine.form.addObjects': 'Add objects...',
+  'engine.form.selectObjectDots': 'Select object…',
+  'engine.form.addObjects': 'Add objects…',
   'engine.form.loadingFields': 'Loading fields…',
   'engine.form.selectObjectFirst': '(Select an object first)',
   'engine.form.selectField': 'Select field…',
-  'engine.form.selectFieldDots': 'Select field...',
-  'engine.form.addFields': 'Add fields...',
+  'engine.form.selectFieldDots': 'Select field…',
+  'engine.form.addFields': 'Add fields…',
   'engine.form.noObjectBound': 'No object bound',
   'engine.form.none': '— None —',
   'engine.form.notInObject': '(not in object)',
@@ -2665,7 +2682,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.edit.forceSave': '强制保存',
   'engine.cancel': '取消',
   'engine.close': '关闭',
-  'engine.form.select': '请选择...',
+  'engine.form.select': '请选择…',
   'engine.form.selectEllipsis': '请选择…',
   'engine.form.add': '添加',
   'engine.form.addItem': '添加项',
@@ -2679,13 +2696,13 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.form.selectObject': '选择对象…',
   'engine.form.selectComponent': '选择组件…',
   'engine.form.noComponents': 'component_id（此页面暂无组件）',
-  'engine.form.selectObjectDots': '选择对象...',
-  'engine.form.addObjects': '添加对象...',
+  'engine.form.selectObjectDots': '选择对象…',
+  'engine.form.addObjects': '添加对象…',
   'engine.form.loadingFields': '正在加载字段…',
   'engine.form.selectObjectFirst': '（请先选择对象）',
   'engine.form.selectField': '选择字段…',
-  'engine.form.selectFieldDots': '选择字段...',
-  'engine.form.addFields': '添加字段...',
+  'engine.form.selectFieldDots': '选择字段…',
+  'engine.form.addFields': '添加字段…',
   'engine.form.noObjectBound': '未绑定对象',
   'engine.form.none': '— 无 —',
   'engine.form.notInObject': '（不在对象中）',


### PR DESCRIPTION
Fixes #4377

The metadata-admin designer does not read the ten locale packs — it carries its own flat `en`/`zh` table — so objectui#3878, which converged those packs on the typographic ellipsis U+2026 per the consistency pass on objectstack#6015, left it behind. The designer renders inside the console shell, so its `Select...` sat on screen beside the packs' `Select…`.

## Entry count: 10 — the card's table was exhaustive

Swept the whole file for ASCII `...` in values, not just the five keys the card names:

```
$ grep -c '\.\.\.' packages/app-shell/src/views/metadata-admin/i18n.ts
10
```

All ten are the card's five keys in each of the two blocks — `engine.form.select`, `engine.form.selectObjectDots`, `engine.form.addObjects`, `engine.form.selectFieldDots`, `engine.form.addFields`. No sixth key, and no mid-sentence occurrence. After the change the only `...` left in the file are the two inside the new header note, where the rejected form is quoted deliberately.

For scale: the file already held **126** values using `…`, so the ten were a genuine minority pocket rather than a table-wide convention.

## Before / after

```diff
-  'engine.form.select': 'Select...',
+  'engine.form.select': 'Select…',
   'engine.form.selectEllipsis': 'Select…',
...
-  'engine.form.selectObjectDots': '选择对象...',
-  'engine.form.addObjects': '添加对象...',
+  'engine.form.selectObjectDots': '选择对象…',
+  'engine.form.addObjects': '添加对象…',
```

## Pin sweep: zero tests to move

Measured before editing, over `packages/`, `apps/`, `examples/`, `scripts/`:

```
$ git grep -n "Select\.\.\.\|请选择\.\.\.\|选择对象\.\.\.\|添加对象\.\.\.\|选择字段\.\.\.\|添加字段\.\.\.\|Select object\.\.\.\|Add objects\.\.\.\|Select field\.\.\.\|Add fields\.\.\."
```

Ten hits were the table itself. The other three hits are **not** pins on these values and are untouched here:

- `packages/components/src/custom/action-param-dialog.tsx:198` — an independent hardcoded `'Select...'` fallback placeholder in a different package (filed, see below).
- `packages/components/src/__tests__/action-param-label-association.test.tsx:22` — a comment describing that component's accessible name, not this table.
- `examples/schema-catalog/src/schemas/components-form-select/with-placeholder.json` — an example schema's own `placeholder` value.

A looser sweep for `getByText` / `getByPlaceholderText` near these keys found nothing either. `pins_moved: 0`, measured rather than assumed.

## The header note, and why no gate

The five keys' only consumers are `widgets.tsx:396` and `widgets.tsx:527`; the convention is now recorded in the table's header, citing objectstack#6015, objectui#3878 and `packages/i18n/src/__tests__/ellipsis-glyph-3878.test.ts` — whose own header already records that it scans the ten packs by design and so cannot reach this table. Per the card's costing, which the dispatch accepted, generalising that pin to a second table shape (flat `Record` of dotted keys, `en` and `zh` in one file, no ten-pack parity) is more machinery than the defect is worth. No pin was added.

## Verification

| command | result |
|---|---|
| `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/ --maxWorkers=2` | 144 files passed, 1511 passed / 1 skipped |
| `tsc --noEmit -p tsconfig.json` (app-shell) | exit 0 |
| `tsc -p tsconfig.test.json` (app-shell) | exit 0 |
| `pnpm exec eslint` on the touched file | exit 0 |
| `node scripts/check-control-bytes.mjs` | OK, 4089 files scanned |
| `node scripts/check-changeset-presence.mjs` | OK, 1 changeset declared |
| `node scripts/check-changeset-no-major.mjs` | OK |

Both type-checks first failed with `TS2307 Cannot find module` in a fresh worktree; that is the build-closure trap, not this change — `pnpm --filter '@object-ui/app-shell^...' build` first, then both are clean.

Changeset: `patch` for `@object-ui/app-shell` (user-visible copy), never `major`.

## Filed, not fixed here

- **#4386** — `action-param-dialog.tsx:198` renders a hardcoded English `Select...` fallback with no `t()` anywhere in the file. Both untranslated and ASCII; a different shape from #4375's two concatenation sites, and in a package this PR does not touch.
- **#4387** (`finding`) — three key pairs in this table now hold byte-identical values, because each of `engine.form.select` / `.selectObjectDots` / `.selectFieldDots` had a sibling that already carried `…`. `engine.form.select` additionally has no consumer at all. Collapsing them would put the two `widgets.tsx` call sites in scope, which the dispatch carved out for the in-flight #4373, so it is recorded rather than done.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_