### PR TITLE
fix(i18n): the two hand-rolled provider-less fallback interpolators are literal, like i18next

### DIFF
--- a/.changeset/handrolled-interpolators-literal-4370.md
+++ b/.changeset/handrolled-interpolators-literal-4370.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/plugin-gantt': patch
+'@object-ui/plugin-grid': patch
+---
+
+A gantt task titled `A$&B` no longer prints `{{title}}` back into its own delete dialog — the two hand-rolled provider-less fallback interpolators are literal, like i18next
+
+objectui#3418 fixed the shared helper's fallback interpolator: `String.prototype.replace` became `split(needle).join(value)`, because `replace` and `replaceAll` both interpret `$&`, `` $` ``, `$'` and `$$` in the **replacement** string and i18next does not. Two hand-rolled copies of that interpolator never got the fix. Both are deliberate non-users of `createSafeTranslation` — each falls back per key so a host dictionary that covers the common keys but lags on newer ones still resolves what it has — so the shared fix had no path to reach them.
+
+The reachable one is gantt's. `gantt.delete.body` is `'"{{title}}" will be permanently removed. …'` and its call site interpolates the record's own title, which is user data:
+
+| task title | rendered before | rendered now |
+|---|---|---|
+| `A$&B` | `"A{{title}}B" will be permanently removed.` | `"A$&B" will be permanently removed.` |
+| ``x$`y`` | `"x"y" will be permanently removed.` | ``"x$`y" will be permanently removed.`` |
+| `p$$q` | `"p$q" will be permanently removed.` | `"p$$q" will be permanently removed.` |
+| `u$'v` | `"u" will be permanently removed. …v" will be permanently removed. …` | `"u$'v" will be permanently removed.` |
+
+The first row is the ugly one: `$&` expands to the matched text, so the placeholder itself is printed back to the user inside the record's own name. Gantt's copy also carried the other half of the same defect — a bare string needle substitutes only the **first** occurrence, where i18next substitutes every one — and `split`/`join` fixes both at once.
+
+The import wizard's copy used a `g`-flagged `RegExp`, which covered the repeated-placeholder half but could not touch the `$`-pattern half: that harm lives in the replacement string, not the needle. Its values are authored metadata — field labels and type names spliced into `grid.import.missingRequiredHint` and `grid.import.legacyReferenceBlocked` — so a label containing `$&` corrupted the hint the same way. Retiring the `RegExp` also retires an unescaped needle, since the placeholder name went into the pattern uninterpolated; that was inert while every placeholder name is a bare identifier, and is now structurally impossible.
+
+This is the provider-less path only (standalone embedding, unit tests). With an `I18nProvider` mounted, i18next serves these keys and was already literal on both sides — which is exactly why the divergence was invisible. No pack, key or call site changed; the three `{{count}}` gantt keys take numbers and were never affected, and `gantt.quickFilter.resultSummary`'s deliberate single-brace idiom is resolved by its call site rather than this interpolator and is untouched.

--- a/packages/plugin-gantt/src/useGanttTranslation.test.tsx
+++ b/packages/plugin-gantt/src/useGanttTranslation.test.tsx
@@ -53,3 +53,66 @@ describe('useGanttTranslation per-key fallback', () => {
     expect(result.current.language).toBe('zh');
   });
 });
+
+/**
+ * The provider-less fallback interpolator must be LITERAL on both sides, the
+ * way i18next is — objectui#4370, the hand-rolled copy of the shared helper's
+ * objectui#3418 fix.
+ *
+ * `String.prototype.replace` diverges from i18next twice, and this table pins
+ * both. The values below are record titles: `gantt.delete.body` is rendered
+ * with `t('gantt.delete.body', { title: pendingDelete.title })` at
+ * `ObjectGantt.tsx`, so every one of these is a title a user can type.
+ */
+describe('useGanttTranslation fallback interpolation is literal (objectui#4370)', () => {
+  beforeEach(() => {
+    hostDict = {};
+  });
+
+  // `$&`, `` $` ``, `$'` and `$$` are replacement-string patterns to `replace`
+  // and plain text to i18next. Measured on the pre-fix code, the middle column
+  // is what the delete dialog actually printed.
+  const CORRUPTING_TITLES: ReadonlyArray<readonly [string, string]> = [
+    // title, what `replace` produced before the fix
+    ['A$&B', '"A{{title}}B" will be permanently removed. This action cannot be undone.'],
+    ['x$`y', '"x"y" will be permanently removed. This action cannot be undone.'],
+    ['p$$q', '"p$q" will be permanently removed. This action cannot be undone.'],
+    [
+      "u$'v",
+      '"u" will be permanently removed. This action cannot be undone.v" will be permanently removed. This action cannot be undone.',
+    ],
+  ];
+
+  it.each(CORRUPTING_TITLES)(
+    'renders a task titled %j verbatim in the delete dialog',
+    (title, corrupted) => {
+      const { result } = renderHook(() => useGanttTranslation());
+      const rendered = result.current.t('gantt.delete.body', { title });
+      // The `$&` row is the ugly one: the PLACEHOLDER is printed back to the
+      // user, inside the record's own name.
+      expect(rendered).toBe(`"${title}" will be permanently removed. This action cannot be undone.`);
+      expect(rendered).not.toBe(corrupted);
+      expect(rendered).not.toContain('{{title}}');
+    },
+  );
+
+  it('substitutes EVERY occurrence of a placeholder, not just the first', () => {
+    // `replace` with a string needle stops after the first hit; i18next does
+    // not. No key in the bundled table repeats a placeholder today, so the
+    // template here is a raw key (the table misses it, so `fallback` returns
+    // the key and interpolates into it) — the mechanism is the same one the
+    // shipped keys run through, and this pins it before a locale needs it.
+    const { result } = renderHook(() => useGanttTranslation());
+    expect(result.current.t('{{n}} of {{n}}', { n: 3 })).toBe('3 of 3');
+  });
+
+  it('leaves the single-brace quickFilter idiom alone', () => {
+    // `gantt.quickFilter.resultSummary` is resolved by the call site's own
+    // `.replace('{shown}', …)`, NOT by this interpolator — pinned as the
+    // deliberate exception by `gantt-quickfilter-locale-parity.test.ts`.
+    const { result } = renderHook(() => useGanttTranslation());
+    expect(result.current.t('gantt.quickFilter.resultSummary', { shown: 2, total: 9 })).toBe(
+      GANTT_DEFAULT_TRANSLATIONS['gantt.quickFilter.resultSummary'],
+    );
+  });
+});

--- a/packages/plugin-gantt/src/useGanttTranslation.ts
+++ b/packages/plugin-gantt/src/useGanttTranslation.ts
@@ -113,7 +113,23 @@ function fallback(key: string, options?: Record<string, unknown>): string {
   let v = GANTT_DEFAULT_TRANSLATIONS[key] || key;
   if (options) {
     for (const [k, val] of Object.entries(options)) {
-      v = v.replace(`{{${k}}}`, String(val));
+      // `split(needle).join(value)` — deliberately not `replace`, and not
+      // `replaceAll` either (objectui#4370, the hand-rolled copy of the shared
+      // helper's objectui#3418 fix). This path must agree with i18next, which
+      // serves the *provider* path; any divergence is a silent fork that only
+      // shows up on provider-less hosts, where we are least likely to see it:
+      //   1. `replace` with a string needle substitutes only the FIRST
+      //      occurrence. i18next substitutes every one, so a sentence that
+      //      repeats a placeholder leaked literal braces to users.
+      //   2. `replace` AND `replaceAll` both interpret `$&`, `` $` ``, `$'`
+      //      and `$$` in the *replacement* string. i18next does not. Values
+      //      here are runtime data — `gantt.delete.body` is interpolated with
+      //      the record's own title — so this one was reachable: a task titled
+      //      `A$&B` rendered `"A{{title}}B" will be permanently removed.`,
+      //      printing the placeholder back at the user inside their own data.
+      // split/join is literal on both sides, which is exactly i18next's
+      // behaviour, and needs no regex escaping of the placeholder name.
+      v = v.split(`{{${k}}}`).join(String(val));
     }
   }
   return v;

--- a/packages/plugin-grid/src/ImportWizard.interpolation.test.ts
+++ b/packages/plugin-grid/src/ImportWizard.interpolation.test.ts
@@ -1,0 +1,66 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The wizard's provider-less fallback interpolator must be LITERAL on both
+ * sides, the way i18next is — objectui#4370, the hand-rolled copy of the
+ * shared helper's objectui#3418 fix.
+ *
+ * `String.prototype.replace` interprets `$&`, `` $` ``, `$'` and `$$` in the
+ * REPLACEMENT string; i18next does not. The `g` flag the wizard already used
+ * covered the repeated-placeholder half, but not this one — the patterns live
+ * in the replacement, not the needle. The values below reach this function as
+ * field labels (`grid.import.missingRequiredHint`,
+ * `grid.import.legacyReferenceBlocked`), which are authored metadata.
+ */
+import { describe, it, expect } from 'vitest';
+import { __testables, IMPORT_DEFAULT_TRANSLATIONS } from './ImportWizard';
+
+const { interpolate } = __testables;
+
+describe('ImportWizard fallback interpolation is literal (objectui#4370)', () => {
+  // [value, what `replace` produced before the fix]
+  const CORRUPTING_VALUES: ReadonlyArray<readonly [string, string]> = [
+    ['A$&B', 'Invalid A{{type}}B'],
+    ['x$`y', 'Invalid xInvalid y'],
+    ['p$$q', 'Invalid p$q'],
+    ["u$'v", 'Invalid uv'],
+  ];
+
+  it.each(CORRUPTING_VALUES)('splices %j verbatim', (value, corrupted) => {
+    const rendered = interpolate('Invalid {{type}}', { type: value });
+    // The `$&` row is the ugly one: the PLACEHOLDER is printed back at the user.
+    expect(rendered).toBe(`Invalid ${value}`);
+    expect(rendered).not.toBe(corrupted);
+    expect(rendered).not.toContain('{{type}}');
+  });
+
+  it('keeps a `$`-carrying field label intact in the shipped required-fields hint', () => {
+    const template = IMPORT_DEFAULT_TRANSLATIONS['grid.import.missingRequiredHint'];
+    const rendered = interpolate(template, { fields: 'Total$& (total)' });
+    expect(rendered).toContain('Total$& (total)');
+    expect(rendered).not.toContain('{{fields}}');
+  });
+
+  it('still substitutes EVERY occurrence of a placeholder', () => {
+    // The `g` flag already did this; split/join must not regress it.
+    expect(interpolate('{{n}} of {{n}}', { n: 3 })).toBe('3 of 3');
+  });
+
+  it('treats the placeholder name literally, with no RegExp metacharacter meaning', () => {
+    // The old needle was an unescaped `new RegExp(`{{${k}}}`, 'g')`. Inert while
+    // every placeholder name is a bare identifier, but the needle is now a
+    // plain string, so a name carrying metacharacters can only match itself.
+    expect(interpolate('a {{x.y}} b', { 'x.y': 'V' })).toBe('a V b');
+    expect(interpolate('a {{xAy}} b', { 'x.y': 'V' })).toBe('a {{xAy}} b');
+  });
+
+  it('returns the template untouched when there are no vars', () => {
+    expect(interpolate('Invalid {{type}}')).toBe('Invalid {{type}}');
+  });
+});

--- a/packages/plugin-grid/src/ImportWizard.tsx
+++ b/packages/plugin-grid/src/ImportWizard.tsx
@@ -201,7 +201,25 @@ function interpolate(template: string, vars?: Record<string, unknown>): string {
   if (!vars) return template;
   let out = template;
   for (const [k, v] of Object.entries(vars)) {
-    out = out.replace(new RegExp(`{{${k}}}`, 'g'), String(v));
+    // `split(needle).join(value)` — deliberately not `replace`, and not
+    // `replaceAll` either (objectui#4370, the hand-rolled copy of the shared
+    // helper's objectui#3418 fix). This path must agree with i18next, which
+    // serves the *provider* path; any divergence is a silent fork that only
+    // shows up on provider-less hosts, where we are least likely to see it.
+    //
+    // The `g`-flagged RegExp this replaced already covered repeated
+    // placeholders, but NOT the other half: `replace` and `replaceAll` both
+    // interpret `$&`, `` $` ``, `$'` and `$$` in the *replacement* string,
+    // and i18next does not. That harm lives in the replacement, not the
+    // needle, so the flag could never reach it — a field label `Total$&`
+    // rendered the `{{fields}}` placeholder back into the hint. Values here
+    // are authored metadata (field labels, type names), so it was reachable.
+    //
+    // Retiring the RegExp also retires an unescaped needle: the placeholder
+    // name went into a pattern uninterpolated, so a name carrying regex
+    // metacharacters would have matched more than itself. Inert while every
+    // name is a bare identifier, and now structurally impossible.
+    out = out.split(`{{${k}}}`).join(String(v));
   }
   return out;
 }
@@ -231,6 +249,7 @@ function useImportTranslation(): { t: (key: string, vars?: Record<string, unknow
 
 /** @internal — exported solely for unit tests. */
 export const __testables = {
+  get interpolate() { return interpolate; },
   get mappingToTemplatePayload() { return mappingToTemplatePayload; },
   get applyTemplate() { return applyTemplate; },
   get loadTemplates() { return loadTemplates; },


### PR DESCRIPTION
Fixes #4370

objectui#3418 converted the shared helper's provider-less fallback interpolator from `String.prototype.replace` to `split(needle).join(value)`, because `replace` and `replaceAll` both interpret `$&`, `` $` ``, `$'` and `$$` in the **replacement** string and i18next does not. Two hand-rolled copies of that interpolator never got the fix. Both are deliberate non-users of `createSafeTranslation` — each falls back per key, so a host dictionary that covers the common keys but lags on newer ones still resolves what it has — which is exactly why the shared fix had no path to reach them. Those comments are left in place; only the mechanics my change falsified were updated.

This is the provider-less path only (standalone embedding, unit tests). With an `I18nProvider` mounted, i18next serves these keys and was already literal on both sides — which is why the divergence stayed invisible.

## The reachable one: gantt

`gantt.delete.body` is `'"{{title}}" will be permanently removed. This action cannot be undone.'` and `ObjectGantt.tsx` renders it with `t('gantt.delete.body', { title: pendingDelete.title })` — a record title, i.e. user data. Measured, then re-measured through the hook as tests:

| task title | before | after |
|---|---|---|
| `A$&B` | `"A{{title}}B" will be permanently removed.` | `"A$&B" will be permanently removed.` |
| ``x$`y`` | `"x"y" will be permanently removed.` | ``"x$`y" will be permanently removed.`` |
| `p$$q` | `"p$q" will be permanently removed.` | `"p$$q" will be permanently removed.` |
| `u$'v` | `"u" will be permanently removed. …v" will be permanently removed. …` | `"u$'v" will be permanently removed.` |

The first row is the ugly one: `$&` expands to the matched text, so the **placeholder itself** is printed back to the user inside the record's own name. Gantt's copy carried the other half of the defect too — a bare string needle substitutes only the **first** occurrence where i18next substitutes every one — and split/join fixes both at once.

## The other one: the import wizard

Its needle was a `g`-flagged `RegExp`, which covered the repeated-placeholder half but could never touch the `$`-pattern half: that harm lives in the replacement string, not the needle. Its values are authored metadata — field labels and type names spliced into `grid.import.missingRequiredHint` and `grid.import.legacyReferenceBlocked` — so a label containing `$&` corrupted the hint the same way.

Retiring the `RegExp` also **retires an unescaped needle** as a side effect: the placeholder name went into the pattern uninterpolated, so a name carrying regex metacharacters matched more than itself. Inert while every placeholder name is a bare identifier, and now structurally impossible. Pinned: `interpolate('a {{xAy}} b', { 'x.y': 'V' })` returned `'a V b'` before (the `.` matched the `A`) and returns the template untouched now.

## Pre-fix red evidence

Tests were written first and run against the unconverted code:

```
 Test Files  2 failed (2)
      Tests  11 failed | 6 passed (17)

 FAIL  packages/plugin-gantt/src/useGanttTranslation.test.tsx > … > renders a task titled "A$&B" verbatim in the delete dialog
 Expected: ""A$&B" will be permanently removed. This action cannot be undone."
 Received: ""A{{title}}B" will be permanently removed. This action cannot be undone."

 FAIL  packages/plugin-gantt/src/useGanttTranslation.test.tsx > … > substitutes EVERY occurrence of a placeholder, not just the first
 Expected: "3 of 3"
 Received: "3 of {{n}}"

 FAIL  packages/plugin-grid/src/ImportWizard.interpolation.test.ts > … > splices "A$&B" verbatim
 FAIL  packages/plugin-grid/src/ImportWizard.interpolation.test.ts > … > treats the placeholder name literally, with no RegExp metacharacter meaning
```

## Reverse verification

Each file's fix reverted **individually** on top of the commit, direction predicted before running:

| reverted | predicted | observed |
|---|---|---|
| `useGanttTranslation.ts` | 4 `$`-rows + the repeated-placeholder test red; the quickFilter idiom test stays green | `Tests 5 failed \| 4 passed` — exactly those |
| `ImportWizard.tsx` (interpolator only, `__testables` kept so the harness still resolves) | the 4 `$`-rows, the field-label hint and the metacharacter test red; **"substitutes EVERY occurrence" stays GREEN** — the `g` flag already did that half | `Tests 6 failed \| 2 passed` — the repeated-placeholder test passed as predicted |

The grid row is the honest one to read: a uniform "all new tests go red" would have meant the test was not isolating the half this PR actually changes there.

## Verification

| command | result |
|---|---|
| `pnpm exec vitest run packages/plugin-gantt/ packages/plugin-grid/ --maxWorkers=2` | `Test Files 100 passed (100)` / `Tests 930 passed (930)` |
| `gantt-quickfilter-locale-parity.test.ts` (the single-brace pin) | 23 passed — the idiom is untouched |
| `ImportWizard.i18n-parity.test.ts` | 2 passed |
| `pnpm --filter @object-ui/plugin-gantt type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0 |
| `pnpm --filter @object-ui/plugin-grid type-check` (both projects) | exit 0 |
| `eslint` on the 4 touched files | 0 errors (11 warnings, all pre-existing in `ImportWizard.tsx`) |
| `node scripts/check-control-bytes.mjs` | OK, 4086 files scanned |
| `node scripts/check-changeset-presence.mjs` / `check-changeset-no-major.mjs` | OK — 1 changeset, `patch` on both packages |

## Not touched

The three `{{count}}` gantt keys (numbers, never affected), `gantt.quickFilter.resultSummary`'s deliberate single-brace idiom (resolved by its call site, not this interpolator), every pack, key and call site, and the larger "should these hand-rolled fallbacks exist at all" question — deferred to #3865's option C per the card.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_