### PR TITLE
docs: resolve the four suspected-dead repo paths in content/docs prose (#3867)

### DIFF
--- a/content/docs/guide/plugin-development.md
+++ b/content/docs/guide/plugin-development.md
@@ -50,7 +50,7 @@ pnpm create @object-ui/plugin board
 npm create @object-ui/plugin board
 ```
 
-This produces a ready-to-build plugin under `packages/plugin-board/` with the correct `package.json`, Vite config, test file, and registry call already in place.
+This produces a ready-to-build plugin under `packages/plugin-board/` with the correct `package.json`, Vite config, test file, and registry call already in place. That directory — and the anatomy shown above — is what the generator writes into **your** workspace (`<cwd>/packages/plugin-<name>`, see `packages/create-plugin/src/index.ts`); it is not a package that ships in this repository, so do not expect to find it in a fresh ObjectUI checkout.
 
 After scaffolding, install dependencies:
 

--- a/content/docs/guide/troubleshooting.md
+++ b/content/docs/guide/troubleshooting.md
@@ -164,7 +164,7 @@ The `@object-ui/types` package exports multiple entry points (`base`, `layout`, 
 
 **Symptom:** Page flashes white before switching to dark mode on initial load.
 
-**Cause:** The `ThemeProvider` (`packages/react/src/context/ThemeContext`) is mounted too late, or the theme preference is read asynchronously after first paint.
+**Cause:** The `ThemeProvider` (`packages/react/src/context/ThemeContext.tsx`) is mounted too late, or the theme preference is read asynchronously after first paint.
 
 **Fix:**
 

--- a/content/docs/rfcs/0001-clipboard-paste.md
+++ b/content/docs/rfcs/0001-clipboard-paste.md
@@ -472,6 +472,15 @@ RFC is marked Accepted.
 
 Per Rule #2 (Documentation Driven Development):
 
+> **Status: planned, none of this has landed.** This RFC is still `Draft` (see
+> the front matter) and the capability it proposes was never implemented — there
+> is no `clipboard` submodule in `@object-ui/core`, and no `usePasteToGrid`,
+> `PastePreviewDialog` or `features.clipboardPaste` anywhere in the workspace.
+> The user guide named in item 2 below is therefore a **planned page that does
+> not exist**; the only clipboard code shipping today is `useCellClipboard` and
+> the `ImportWizard` parsers in `@object-ui/plugin-grid`. Read the paths in this
+> section as the plan, not as pages you can open.
+
 1. **This RFC** (`content/docs/rfcs/0001-clipboard-paste.md`) — frozen on
    acceptance.
 2. **User guide** (`content/docs/guide/clipboard-paste.md`) — written


### PR DESCRIPTION
Fixes #3867

Scope is the triage split, unchanged: **the 4 suspected-dead coordinates only**. The `content/docs/**` gate expansion stays a separate card — this PR adds inputs for it (three of the four turned out to be *categories*, not defects) but does not touch any gate.

Per the triage caveat, the per-item deliverable was **fix-or-reclassify-with-evidence**, not blind path surgery. Measured on `origin/main@bb58d1d61`: all four tokens were still dead there before the first edit (instrument reading below).

## Outcome

| # | Location (at bb58d1d61) | Token | Outcome | Evidence |
|---|---|---|---|---|
| 1 | `content/docs/guide/plugin-development.md:53` | `packages/plugin-board/` | **reclassified** (scaffolder output) + clarified | `packages/create-plugin/src/index.ts:74` builds `plugin-` + the sanitized name and `:97` joins it as `path.join(process.cwd(), 'packages', fullPackageName)` — so the documented command `npx @object-ui/create-plugin board` does emit exactly `packages/plugin-board/`, in the reader's workspace. The prose was right; it just never said the directory is generated. One sentence added to say so. |
| 2 | `content/docs/guide/troubleshooting.md:167` (card said `:168`) | `packages/react/src/context/ThemeContext` | **fixed** | The referent is real and correctly attributed: `ThemeProvider` is defined at `packages/react/src/context/ThemeContext.tsx:128` and reaches `@object-ui/react` through `packages/react/src/context/index.ts` (`export * from './ThemeContext'`), which is what the page's own code sample imports from. Only the extension was missing, so the coordinate did not resolve. Added `.tsx`. (Not the other `ThemeProvider`, `packages/providers/src/ThemeProvider.tsx` — that one is not what the sample imports.) |
| 3 | `content/docs/utilities/runner.mdx:146` | `packages/runner/src/app-data/` | **reclassified** (git-ignored, reader-supplied); left unchanged | `packages/runner/.gitignore` line 1 is literally `src/app-data`. The same page already spells this out eight lines below the flagged one, at `runner.mdx:154-156`: "`src/app-data/` is git-ignored (see `packages/runner/.gitignore`) and is **not** part of a fresh checkout — you supply it". `packages/runner/README.md:110` says "**create** `packages/runner/src/app-data/`", and `packages/runner/src/App.navigation.test.tsx:31` stubs the loader for the same reason. Editing here would only duplicate correct prose, so the honest deliverable is the reclassification. |
| 4 | `content/docs/rfcs/0001-clipboard-paste.md:477` | `content/docs/guide/clipboard-paste.md` | **reclassified** (planned deliverable, never landed) + marked | The RFC front matter still reads `status: Draft`, and none of its section-10 deliverables exists: no `clipboard` submodule under `packages/core/src`, and zero repo-wide hits for `usePasteToGrid`, `PastePreviewDialog` or `clipboardPaste`. The only clipboard code shipping today is `useCellClipboard` and the `ImportWizard` parsers in `@object-ui/plugin-grid`. No guide page created (explicitly out of scope); instead a status note now marks section 10 as the plan rather than as openable pages. |

No item was already fixed by an intervening PR — all four were live at `bb58d1d61`.

### Why three of four are categories, not defects

That is the reusable output for the gate-expansion card. Items 1 and 3 are the same shape the card already identified for `packages/plugin-yourplugin` and `apps/console/dist/`: **a path the reader creates or the build produces**, stated correctly by a doc that is doing its job. Item 4 is a fourth shape: **a planned coordinate inside a deliverables list of a Draft RFC**. None of them is fixable by path surgery, and none should be silenced with a per-line exemption entry — they want rules.

## Verification

All commands run at the repo root of the worktree, on the pushed commit.

Instrument re-run — the card's own extractor (`extractPathTokens` imported from `scripts/check-skills-paths.mjs`, not a re-implementation), walked over `content/docs/**` for `.md` **and** `.mdx` (the gate's own walker is `.md`-only, while #3867 measured 183 `.md`/`.mdx` files). Scratch script, deliberately not checked in.

Before (`bb58d1d61`, clean tree):

```
files scanned : 183
assertions    : 114  (patterns excluded: 26)
resolve       : 104
DO NOT EXIST  : 10
    - content/docs/guide/ci-cd-pipeline.md:192 - apps/dev-server
    - content/docs/guide/ci-cd-pipeline.md:200 - apps/dev-server
    - content/docs/guide/ci-cd-pipeline.md:482 - content/docs/guide/foo.md
    - content/docs/guide/ci-cd-pipeline.md:522 - apps/console/src/context/
    - content/docs/guide/deployment.md:13 - apps/console/dist/
    - content/docs/guide/plugin-development.md:53 - packages/plugin-board/
    - content/docs/guide/troubleshooting.md:167 - packages/react/src/context/ThemeContext
    - content/docs/rfcs/0001-clipboard-paste.md:477 - content/docs/guide/clipboard-paste.md
    - content/docs/utilities/runner.mdx:146 - packages/runner/src/app-data/
    - content/docs/utilities/runner.mdx:206 - packages/plugin-yourplugin
```

After:

```
files scanned : 183
assertions    : 115  (patterns excluded: 26)
resolve       : 106
DO NOT EXIST  : 9
    - content/docs/guide/ci-cd-pipeline.md:192 - apps/dev-server
    - content/docs/guide/ci-cd-pipeline.md:200 - apps/dev-server
    - content/docs/guide/ci-cd-pipeline.md:482 - content/docs/guide/foo.md
    - content/docs/guide/ci-cd-pipeline.md:522 - apps/console/src/context/
    - content/docs/guide/deployment.md:13 - apps/console/dist/
    - content/docs/guide/plugin-development.md:53 - packages/plugin-board/
    - content/docs/rfcs/0001-clipboard-paste.md:486 - content/docs/guide/clipboard-paste.md
    - content/docs/utilities/runner.mdx:146 - packages/runner/src/app-data/
    - content/docs/utilities/runner.mdx:206 - packages/plugin-yourplugin
```

Reading: one dead token removed (item 2 now resolves), **zero new dead tokens**. Assertions rise by 1 and resolutions by 2 because the item-1 sentence cites `packages/create-plugin/src/index.ts` — a token that resolves; the `cwd/packages/plugin-NAME` shape in the same sentence carries angle brackets, so `PATTERN_RE` classifies it as a pattern rather than an assertion, which is the same treatment the extractor already gives the other placeholder paths. The three remaining flagged lines are the reclassified ones, unchanged by design, and the other six were already listed by the card as deliberate / template / build-artifact tokens (out of scope here).

Repo gates:

```
$ node scripts/check-doc-links.mjs
Links are valid across 13 scan roots.                                   exit=0

$ node scripts/check-skills-paths.mjs
OK (84/85 stated path(s) resolve across 18 guide file(s); 1 baselined).  exit=0

$ node scripts/check-control-bytes.mjs
OK (scanned 4098 tracked text file(s); skipped 85 binary).              exit=0

$ node scripts/check-changeset-presence.mjs
Compared the working tree with bb58d1d61 (merge-base with origin/main):
3 file(s) changed, 0 of them under the src/ of a package the release
covers, 0 under a package changesets ignores, 0 changeset(s) added.
No source of a released package changed in this range, so no changeset
is owed.                                                               exit=0
```

`check-skills-paths` is unchanged from before this PR (84/85, 1 baselined) — no regression; this PR does not touch `skills/**` or any gate script. The changeset gate self-determines for a docs-only change, so no changeset and no label are needed.

Not run, deliberately: package builds and the vitest suites. Nothing outside `content/docs/**` prose changed — no source, no test, no script, no config.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_