### PR TITLE
docs(tests): qualify the last two present-tense paths-ignore twins together (#4384)

### DIFF
--- a/scripts/__tests__/check-action-forward-parity.test.ts
+++ b/scripts/__tests__/check-action-forward-parity.test.ts
@@ -710,8 +710,24 @@ describe('the gate is wired to run', () => {
 
   it('is not hidden from the renderers by ci.yml path filters', () => {
     // ci.yml `paths-ignore`s markdown, content/, docs/, apps/site/ and
-    // .changeset/. None can match `packages/components/src/renderers/**`, so a PR
+    // .changeset/ on its `push` trigger — since objectui#3523 step 2 the only
+    // trigger that still carries the filter (ci.yml:6; lint.yml:32 is the twin),
+    // and the only thing the assertion below can see, since it slices the `on:`
+    // block. None can match `packages/components/src/renderers/**`, so a push
     // that edits a forward whitelist always starts this workflow.
+    //
+    // For a PULL REQUEST the conclusion holds for a second and stronger reason.
+    // This lead-in used to state it in a bare present tense that read as if the
+    // filter still applied there; objectui#4384 qualified it, together with its
+    // near-verbatim twin in `check-i18n-en-drift.test.ts`, closing the #3857 /
+    // #4369 / #4381 family (PRs #4371 / #4380 / #4382). No `paths-ignore`
+    // survives on `pull_request` at all, so such a PR starts this workflow a
+    // fortiori — measured there: PR #3856, one markdown file, 16 checks. What
+    // decides a pull request now is the in-job `Decide whether this change needs
+    // a full run` step, whose exclusion list is that `push` filter unchanged,
+    // held identical to it by `scripts/__tests__/merge-queue-reporting.test.ts`
+    // — so the patterns pinned below are also what keeps the expensive steps
+    // running on a renderer PR.
     const ignored = (ci.slice(0, ci.indexOf('jobs:')).match(/^\s+- '.*'$/gm) ?? []).map((line) =>
       line.trim().replace(/^- '/, '').replace(/'$/, ''),
     );

--- a/scripts/__tests__/check-i18n-en-drift.test.ts
+++ b/scripts/__tests__/check-i18n-en-drift.test.ts
@@ -745,11 +745,28 @@ describe('the gate is wired to run', () => {
 
   it('is not hidden from the locale packs by ci.yml path filters', () => {
     // ci.yml `paths-ignore`s markdown, content/, docs/, apps/site/ and
-    // .changeset/. None of them can match `packages/i18n/src/locales/*.ts` or the
-    // ledger, so a PR that edits an en string always starts this workflow. A new
-    // entry that DID cover them would make the gate unreachable for exactly the
-    // PRs it judges — the objectui#3547 / control-bytes.yml lesson, one workflow
-    // over.
+    // .changeset/ on its `push` trigger — since objectui#3523 step 2 the only
+    // trigger that still carries the filter (ci.yml:6; lint.yml:32 is the twin),
+    // and the only thing the assertion below can see, since it slices the `on:`
+    // block. None of them can match `packages/i18n/src/locales/*.ts` or the
+    // ledger, so a push that edits an en string always starts this workflow.
+    //
+    // For a PULL REQUEST the conclusion holds for a second and stronger reason.
+    // This lead-in used to state it in a bare present tense that read as if the
+    // filter still applied there; objectui#4384 qualified it, together with its
+    // near-verbatim twin in `check-action-forward-parity.test.ts`, closing the
+    // #3857 / #4369 / #4381 family (PRs #4371 / #4380 / #4382). No
+    // `paths-ignore` survives on `pull_request` at all, so such a PR starts this
+    // workflow a fortiori — measured there: PR #3856, one markdown file, 16
+    // checks. What decides a pull request now is the in-job `Decide whether this
+    // change needs a full run` step, whose exclusion list is that `push` filter
+    // unchanged, held identical to it by
+    // `scripts/__tests__/merge-queue-reporting.test.ts` — so the patterns pinned
+    // below are also what keeps the expensive steps running on a locale-pack PR.
+    //
+    // A new entry that DID cover them would make the gate unreachable for
+    // exactly the PRs it judges, on both lanes at once — the objectui#3547 /
+    // control-bytes.yml lesson, one workflow over.
     const ignored = ci.slice(0, ci.indexOf('jobs:')).match(/^\s+- '.*'$/gm) ?? [];
     for (const pattern of ignored) {
       expect(pattern).not.toMatch(/packages|scripts|locales/);


### PR DESCRIPTION
Fixes #4384

The two near-verbatim twins PR #4382 graded and deliberately left on its exceptions list — the last unqualified present-tense `paths-ignore` texts in the repository. They move **together in one PR**, per the card's constraint: qualifying either alone would recreate, between two near-identical comments, exactly the two-shapes split the #3857 → #4369 → #4381 family existed to end.

**This is a qualification pass, not a falsehood fix.** Both conclusions are true today — more strongly so, since nothing filters pull requests by path at all any more — and both premises are accurate about the surviving `push` list. Neither was ever in the "decide by it, decide wrong" class. What was missing is the qualifier: each lead-in read as a bare present tense, as if the filter still applied to pull requests.

**The corrected reality**, mirrored from PRs #4371 / #4380 / #4382: objectui#3523 step 2 deleted `paths-ignore` from `ci.yml`'s and `lint.yml`'s `pull_request` trigger; it survives **only** on `push` (`ci.yml:6`, `lint.yml:32`). The pull-request path decision is now the in-job `Decide whether this change needs a full run` step, whose exclusion list is that `push` filter unchanged, held identical to it by `scripts/__tests__/merge-queue-reporting.test.ts`. Measured counter-evidence to the retired sentence: PR #3856 (one markdown file) started 16 checks, PR #4339 (one line added to AGENTS.md) 17.

## The two sites

### 1. `scripts/__tests__/check-i18n-en-drift.test.ts:747`

**Before**

```
// ci.yml `paths-ignore`s markdown, content/, docs/, apps/site/ and
// .changeset/. None of them can match `packages/i18n/src/locales/*.ts` or the
// ledger, so a PR that edits an en string always starts this workflow. A new
// entry that DID cover them would make the gate unreachable for exactly the
// PRs it judges — the objectui#3547 / control-bytes.yml lesson, one workflow
// over.
```

**After** (gist — the premise scoped to `push`, the conclusion re-founded, the closing lesson kept and widened to both lanes)

```
// ci.yml `paths-ignore`s markdown, content/, docs/, apps/site/ and
// .changeset/ on its `push` trigger — since objectui#3523 step 2 the only
// trigger that still carries the filter (ci.yml:6; lint.yml:32 is the twin),
// and the only thing the assertion below can see, since it slices the `on:`
// block. None of them can match `packages/i18n/src/locales/*.ts` or the
// ledger, so a push that edits an en string always starts this workflow.
//
// For a PULL REQUEST the conclusion holds for a second and stronger reason.
// This lead-in used to state it in a bare present tense that read as if the
// filter still applied there; objectui#4384 qualified it, together with its
// near-verbatim twin in `check-action-forward-parity.test.ts`, closing the
// #3857 / #4369 / #4381 family (PRs #4371 / #4380 / #4382). No
// `paths-ignore` survives on `pull_request` at all, so such a PR starts this
// workflow a fortiori — measured there: PR #3856, one markdown file, 16
// checks. What decides a pull request now is the in-job `Decide whether this
// change needs a full run` step, whose exclusion list is that `push` filter
// unchanged, held identical to it by
// `scripts/__tests__/merge-queue-reporting.test.ts` — so the patterns pinned
// below are also what keeps the expensive steps running on a locale-pack PR.
//
// A new entry that DID cover them would make the gate unreachable for
// exactly the PRs it judges, on both lanes at once — the objectui#3547 /
// control-bytes.yml lesson, one workflow over.
```

### 2. `scripts/__tests__/check-action-forward-parity.test.ts:712`

**Before**

```
// ci.yml `paths-ignore`s markdown, content/, docs/, apps/site/ and
// .changeset/. None can match `packages/components/src/renderers/**`, so a PR
// that edits a forward whitelist always starts this workflow.
```

**After** — the same shape, same order, same citations, with the surface-specific clause (`packages/components/src/renderers/**`, "a renderer PR") swapped in. That symmetry is the point of the card: one shape across the pair, not two.

## Why the premise is scoped to `push` *and* today's shape stated separately

PR #4382's grading of `docs-links.yml` (its item 3) established the rule this pair falls under: `check-skills-paths.test.ts:403` ("lists … under the `paths-ignore` of its `push` trigger") is the right model when the consequence is about a **push**, but where the consequence is about a **pull request**, scoping the premise alone would leave a conclusion that no longer follows from its premise.

Both twins conclude about a pull request, so both get the full treatment: the premise scoped to `push` — which is also, precisely, what each assertion below the comment parses (`ci.slice(0, ci.indexOf('jobs:'))` reads the `on:` block, whose only quoted entries today are the `push` `paths-ignore`) — and today's pull-request shape stated separately, so the conclusion stands on the reason that holds now.

## Verification

Comment-only, so no assertion changes and no before-green/after-red reverse verification is available — by construction nothing reads these lines. Stating that plainly rather than manufacturing a red: the meaningful proof here is mechanical, and it is stronger than a test result.

- **Diff audit — every changed line is a `//` line.** Strip the leading `+`/`-`, drop comment and blank lines, and **zero lines remain**:
  ```
  git diff -U0 -- '*.ts' '*.mjs' '*.yml' | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
    | sed -E 's/^[+-]//' | grep -vE '^\s*(#|//|\*|/\*\*)' | grep -vE '^\s*$'   ->  count=0
  ```
- **Comment-stripped files are byte-identical to `origin/main`** — the strongest form of the same claim. Dropping every `^\s*//` line from each file and diffing against `git show origin/main:` gives `IDENTICAL after comment strip` for both. Assertions untouched: 0.
- **Tests** — repo-root vitest, `--maxWorkers=1`, `NODE_OPTIONS=--max-old-space-size=4096`, run under the shared `/tmp/os-heavy-verify.lock` (acquired, not skipped):
  ```
  pnpm exec vitest run scripts/__tests__/check-i18n-en-drift.test.ts \
                       scripts/__tests__/check-action-forward-parity.test.ts --maxWorkers=1
  Test Files  2 passed (2)
       Tests  84 passed (84)
    Duration  14.19s
  ```
- **Sweep — no other unqualified present-tense copy reappeared since PR #4382.** 76 `paths-ignore` hits across `scripts` / `.github` / `content`; the only commit touching any of those trees since #4382 merged is `2f58c8ba2` (#4393), which changed `plugin-development.md`, `troubleshooting.md` and `0001-clipboard-paste.md` — **zero** `paths-ignore` hits in all three. No new copy can have appeared, so #4382's post-sweep acceptance still holds, and with this PR the exceptions list is empty.
- **Gates**: `check-control-bytes.mjs` → OK, 4098 tracked text files scanned; `check-changeset-presence.mjs` → "2 file(s) changed, 0 of them under the src/ of a package the release covers … **no changeset is owed**" (self-determined, so no changeset and no `skip-changeset` label, per dispatch); `eslint` on both files → exit 0.
- **Byte discipline**: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over both changed files returns no hits.

Resource note: the shared lock was free and was taken for the vitest run; these are node-only script suites with no build and no DOM, 13 GB available.

**This closes the family's last unqualified pair.** With these two qualified, no site in the repository asserts, in the present tense, that `ci.yml` or `lint.yml` filter *pull requests* by path.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_