### PR TITLE
fix(app-shell,data-objectstack): route every view write through one cache invalidation seam

### DIFF
--- a/.changeset/view-invalidation-seam-4373.md
+++ b/.changeset/view-invalidation-seam-4373.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/data-objectstack': patch
+'@object-ui/app-shell': patch
+---
+
+Publishing a view from the console no longer serves a five-minute-stale override map — every writer now routes through one invalidation seam
+
+`ObjectStackAdapter` caches two view-shaped reads: `getView` under `view:{object}:{name}` and `listViewOverrides` under `view-overrides:{object}`, with `MetadataCache`'s default 5-minute TTL. objectui#4363 made the adapter's own four write paths drop both. But the console's real create-a-view flow never calls any of them: `ObjectView.handleViewCreate` writes through the ADR-0034 metadata seam (`createRuntimeMetadata` → `metadataClient.save`), and Publish goes `RuntimeDraftBar` → `publishRuntimeMetadata` → `metadataClient.publish`. Two writers into the same `/meta/view/:name` rows; only one of them invalidated anything.
+
+Publish is the sharp end. A create lands an invisible per-item draft, and `listViewOverrides` enumerates published rows, so the map is still honest there. Publish promotes the row into exactly the world the map describes — and nothing dropped the key, so the object page kept applying its pre-publish snapshot for the rest of the TTL. It does not self-heal: `loadViewOverrides` treats a resolved map as authoritative and deliberately does not re-probe per view (objectui#3774, correct — re-probing reinstates the 404 flurry the batch read exists to remove), so the per-view `getView` fallback that would have masked a stale map is by design unreachable.
+
+The fix is one seam rather than a fifth copy of the key list. `ObjectStackAdapter.invalidateViewKeys(objectName, viewName)` is now the only place that knows which keys a view-row write drops; the adapter's four write paths call it instead of restating the pair, app-shell's ADR-0034 persistence module calls it for `view` saves, creates, publishes and discards, and `MetadataService.saveMetadataItem` calls it when the category is `view` (where it previously named `view:{name}`, which no reader has). Restatement is what this repo keeps paying for — objectui#3778 removed five copies of a key no reader populated, objectui#4363 fixed four copies that named half the live set, and objectui#4373 is the measured proof that a new writer forgets the list by default. A pin suite can only guard writers that exist; a seam makes the next one unable to forget.
+
+No cache key, no read path and no public signature changed. The adapter's eight existing invalidation pins pass unchanged, which is the evidence that routing four paths through a seam changed nothing observable; two new structural guards keep the key set from being restated again — one asserting each key template appears exactly twice in the adapter (its reader, and the seam), one asserting no app-shell file spells either.

--- a/packages/app-shell/src/services/MetadataService.ts
+++ b/packages/app-shell/src/services/MetadataService.ts
@@ -16,7 +16,7 @@
  * @module services/MetadataService
  */
 
-import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { viewItemObjectName, type ObjectStackAdapter } from '@object-ui/data-objectstack';
 import type { ObjectDefinition, DesignerFieldDefinition } from '@object-ui/types';
 
 // ---------------------------------------------------------------------------
@@ -133,16 +133,49 @@ export class MetadataService {
 
   /**
    * Persist a metadata item (upsert) for any category.
+   *
+   * `${category}:${name}` is the key the adapter's generic metadata read
+   * caches under, and it is right for every category but one. A `view` row is
+   * also read back under two OBJECT-scoped keys (`view:{object}:{name}` and
+   * `view-overrides:{object}`), which `view:{name}` names neither of — so a
+   * caller passing `'view'` here would leave the object page's override map
+   * stale for the cache's 5-minute TTL, which is objectui#4373's defect on a
+   * third writer. That is why this routes through the adapter's one seam
+   * instead of restating the pair (the third restatement would have been the
+   * third time this repo paid for one; see `invalidateViewKeys`).
+   *
+   * No in-repo caller passes `'view'` today — but this class is public API
+   * (`useMetadataService`, exported from app-shell's barrel), so "unreachable"
+   * would have been an unmeasured claim about consumers we do not own.
+   *
+   * The object binding comes from the body being written, via the same
+   * accessor `listViewOverrides` narrows those rows by — not from a fourth
+   * private copy of "which object is this?".
    */
   async saveMetadataItem(category: string, name: string, data: Record<string, unknown>): Promise<void> {
     const client = this.adapter.getClient();
     await client.meta.saveItem(category, name, data);
     this.adapter.invalidateCache(`${category}:${name}`);
+    if (category === 'view') {
+      const objectName = viewItemObjectName(data);
+      if (objectName) this.adapter.invalidateViewKeys(objectName, name);
+    }
   }
 
   /**
    * Soft-delete a metadata item by persisting it with `enabled: false` and
    * `_deleted: true`. Works for any metadata category.
+   *
+   * **Not wired to the view seam, and the reason is structural** (objectui#4373):
+   * both view cache keys are OBJECT-scoped, this signature has no object
+   * parameter, and the tombstone body it writes (`{ name, enabled, _deleted }`)
+   * carries no object binding either — so unlike {@link saveMetadataItem} there
+   * is nothing here to derive one from. Splitting `name` on `.` would be a
+   * second, silently-wrong identity rule (a source-declared view's name is not
+   * qualified), and inventing an object argument for a method with no callers
+   * is a surface we would be guessing at. If a `'view'` caller ever appears,
+   * the fix is to give it the object it already knows and call
+   * `adapter.invalidateViewKeys(objectName, name)` here.
    */
   async deleteMetadataItem(category: string, name: string): Promise<void> {
     const client = this.adapter.getClient();

--- a/packages/app-shell/src/services/MetadataService.viewInvalidation.test.ts
+++ b/packages/app-shell/src/services/MetadataService.viewInvalidation.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `MetadataService` is the third writer into the `/meta/view` rows the adapter
+ * caches, and it names the wrong key for them (objectui#4373's dormant sibling).
+ *
+ * `saveMetadataItem` / `deleteMetadataItem` invalidate `${category}:${name}` —
+ * exactly right for the adapter's generic metadata read, and wrong for one
+ * category. A `view` row is ALSO read back under two OBJECT-scoped keys
+ * (`view:{object}:{name}` via `getView`, `view-overrides:{object}` via
+ * `listViewOverrides`), and `view:{name}` is neither of them. So a caller
+ * passing `'view'` would leave the object page's override map stale for
+ * `MetadataCache`'s 5-minute TTL — the same defect this card fixes on the
+ * console's create/publish flow, on a third door.
+ *
+ * ## What was measured before wiring it
+ *
+ * The card left the choice open — wire it, or document it as unreachable,
+ * whichever is honest. Measured:
+ *
+ * - **No in-repo caller passes `'view'`.** In fact no production code calls
+ *   either method at all; the only call anywhere is one `'flow'` save in
+ *   `MetadataService.saveAdvisories.test.ts`.
+ * - **But the class is public API.** `useMetadataService()` is exported from
+ *   `packages/app-shell/src/index.ts`, so a consumer outside this repo can hold
+ *   a `MetadataService` and call `saveMetadataItem('view', …)` today. "No
+ *   caller" is a fact about this repo; "unreachable" would have been an
+ *   unmeasured claim about consumers we do not own.
+ *
+ * So the save half is wired. The delete half is NOT, and that is structural
+ * rather than an oversight — see the case at the bottom, which pins the reason
+ * so the asymmetry reads as a decision.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { MetadataService } from './MetadataService';
+
+function makeAdapter() {
+  const invalidatedKeys: string[] = [];
+  const viewSeamCalls: Array<[string, string]> = [];
+  const saveItem = vi.fn(
+    async (_category: string, _name: string, _data: Record<string, unknown>) => ({ success: true }),
+  );
+
+  const adapter = {
+    getClient: () => ({ meta: { saveItem } }),
+    invalidateCache: (key: string) => invalidatedKeys.push(key),
+    invalidateViewKeys: (objectName: string, viewName: string) => {
+      viewSeamCalls.push([objectName, viewName]);
+    },
+  };
+
+  return { adapter, invalidatedKeys, viewSeamCalls, saveItem };
+}
+
+describe('MetadataService routes view writes through the adapter seam (#4373)', () => {
+  it('saveMetadataItem("view", ...) calls invalidateViewKeys with the object from the body', async () => {
+    const { adapter, viewSeamCalls } = makeAdapter();
+
+    await new MetadataService(adapter as unknown as ObjectStackAdapter).saveMetadataItem('view', 'account.mine', {
+      name: 'account.mine',
+      object: 'account',
+      viewKind: 'list',
+    });
+
+    expect(viewSeamCalls).toEqual([['account', 'account.mine']]);
+  });
+
+  it('reads the object binding the same way listViewOverrides narrows those rows', async () => {
+    // Not "any spelling of object" — the SAME spelling. `viewItemObjectName`
+    // (exported from the adapter for exactly this) reads
+    // `data.object ?? object ?? objectName` off the row, and it is the accessor
+    // `listViewOverrides` itself narrows those rows by. Using it here is what
+    // makes the key this names provably the map that write invalidates; a
+    // fourth private copy of "which object is this?" is the drift it prevents.
+    //
+    // This body is the adapter's own `createView` shape (top-level `data`),
+    // which the previous case's `object` covers by a different limb.
+    const { adapter, viewSeamCalls } = makeAdapter();
+
+    await new MetadataService(adapter as unknown as ObjectStackAdapter).saveMetadataItem('view', 'account.mine', {
+      name: 'account.mine',
+      data: { provider: 'object', object: 'account' },
+    });
+
+    expect(viewSeamCalls).toEqual([['account', 'account.mine']]);
+  });
+
+  it('does not invent a limb the shared accessor lacks — a nested config.data is NOT a binding', async () => {
+    // Measured, not assumed: `viewItemObjectName` reads `data.object` off the
+    // ROW, not `config.data.object`. So a body that only nests its provider
+    // target under `config` names no object here — and that is correct rather
+    // than a gap, because `listViewOverrides` reads those rows through the very
+    // same accessor and would not have matched such a row into the map either.
+    // Adding a `config.data.object` limb HERE (and only here) is precisely the
+    // consumer-side leniency AGENTS.md #0.1 forbids: it would key an
+    // invalidation to a map entry that does not exist.
+    const { adapter, viewSeamCalls } = makeAdapter();
+
+    await new MetadataService(adapter as unknown as ObjectStackAdapter).saveMetadataItem('view', 'account.mine', {
+      name: 'account.mine',
+      config: { data: { provider: 'object', object: 'account' } },
+    });
+
+    expect(viewSeamCalls).toEqual([]);
+  });
+
+  it('leaves every other category exactly as it was', async () => {
+    const { adapter, invalidatedKeys, viewSeamCalls } = makeAdapter();
+
+    await new MetadataService(adapter as unknown as ObjectStackAdapter).saveMetadataItem('flow', 'nightly_purge', {
+      name: 'nightly_purge',
+    });
+
+    expect(invalidatedKeys).toEqual(['flow:nightly_purge']);
+    expect(viewSeamCalls).toEqual([]);
+  });
+
+  it('a view body with no object binding names nothing object-scoped', async () => {
+    // Both keys are object-scoped. With no object in the body there is nothing
+    // to derive one from, and splitting `name` on `.` would be a second,
+    // silently-wrong identity rule (a source-declared view's name is not
+    // qualified). The generic key still drops, as before.
+    const { adapter, invalidatedKeys, viewSeamCalls } = makeAdapter();
+
+    await new MetadataService(adapter as unknown as ObjectStackAdapter).saveMetadataItem('view', 'account.mine', {
+      name: 'account.mine',
+    });
+
+    expect(viewSeamCalls).toEqual([]);
+    expect(invalidatedKeys).toEqual(['view:account.mine']);
+  });
+
+  it('deleteMetadataItem cannot name the view keys, and the reason is its payload', async () => {
+    // Pinned as a decision, not left as an absence. The tombstone this method
+    // writes is `{ name, enabled: false, _deleted: true }` — no object binding
+    // — and the signature has no object parameter either, so unlike the save
+    // half there is nothing here to derive the keys from. Inventing an object
+    // argument for a method with no callers would be guessing at a surface.
+    // If a `'view'` caller ever appears, give it the object it already knows
+    // and call `adapter.invalidateViewKeys(objectName, name)` here.
+    const { adapter, invalidatedKeys, viewSeamCalls, saveItem } = makeAdapter();
+
+    await new MetadataService(adapter as unknown as ObjectStackAdapter).deleteMetadataItem('view', 'account.mine');
+
+    expect(saveItem).toHaveBeenCalledWith('view', 'account.mine', {
+      name: 'account.mine',
+      enabled: false,
+      _deleted: true,
+    });
+    // The written body carries no object — this is the measurement, not a wish.
+    const [, , written] = saveItem.mock.calls[0];
+    expect(written.object).toBeUndefined();
+    expect(viewSeamCalls).toEqual([]);
+    expect(invalidatedKeys).toEqual(['view:account.mine']);
+  });
+});

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -367,7 +367,13 @@ export function ObjectDataPage({ dataSource, objects }: any) {
           name: config.name,
           label: config.label,
         });
-        const createdId = await createRuntimeMetadata('view', env.name, env, { metadataClient });
+        // #4373: the third writer into the `/meta/view` rows the adapter caches
+        // — same seam, same key set, decided by the adapter.
+        const createdId = await createRuntimeMetadata('view', env.name, env, {
+          metadataClient,
+          dataSource,
+          objectName,
+        });
         if (createdId) {
           const previewSuffix = previewDrafts
             ? ''
@@ -378,7 +384,7 @@ export function ObjectDataPage({ dataSource, objects }: any) {
         console.error('[ObjectDataPage] Failed to save view:', err);
       }
     },
-    [columns, urlFilters, metadataClient, navigate, objectName, previewDrafts],
+    [columns, urlFilters, metadataClient, dataSource, navigate, objectName, previewDrafts],
   );
 
   if (!objectDef) {

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -614,13 +614,19 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         // Publish (RuntimeDraftBar) promotes it + records a version.
         const vid = draft.id;
         if (metadataClient && vid) {
-            persistRuntimeMetadata('view', vid, draft, { metadataClient }).catch((err: any) => {
+            // `dataSource` + `objectName` let the seam drop this object's view
+            // cache keys (#4373) — the adapter owns which keys those are.
+            persistRuntimeMetadata('view', vid, draft, {
+                metadataClient,
+                dataSource,
+                objectName,
+            }).catch((err: any) => {
                 console.error('[ViewConfigPanel] Failed to persist view config:', err);
             });
         } else {
             console.warn('[ViewConfigPanel] Cannot persist view config: missing metadataClient or viewId.');
         }
-    }, [metadataClient]);
+    }, [metadataClient, dataSource, objectName]);
 
     /** Create a new view via the config panel */
     const handleViewCreate = useCallback(async (config: Record<string, any>) => {
@@ -671,6 +677,12 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 });
                 createdId = await createRuntimeMetadata('view', env.name, env, {
                     metadataClient,
+                    // #4373: this flow is the second door into the same rows the
+                    // adapter caches. Hand it the adapter (the `dataSource` prop
+                    // IS the `ObjectStackAdapter`, via `AppContent`'s
+                    // `useAdapter()`) so the seam can drop the object's view keys.
+                    dataSource,
+                    objectName,
                 });
             }
             setShowViewConfigPanel(false);
@@ -2232,6 +2244,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                         onViewUpdate={handleViewUpdate}
                         onCreate={handleViewCreate}
                         metadataClient={metadataClient}
+                        dataSource={dataSource}
                         onAfterChange={() => setRefreshKey(k => k + 1)}
                     />
                 </div>

--- a/packages/app-shell/src/views/RuntimeDraftBar.tsx
+++ b/packages/app-shell/src/views/RuntimeDraftBar.tsx
@@ -31,6 +31,17 @@ export interface RuntimeDraftBarProps {
   /** Studio metadata client (flag-ON path). */
   metadataClient: any;
   /**
+   * The DataSource whose view caches this bar's Publish / Discard stales
+   * (objectui#4373). Publish is the write that matters: it promotes an
+   * invisible draft into a PUBLISHED row, which is the world
+   * `listViewOverrides` enumerates and caches for 5 minutes. Optional — a
+   * `report` / `page` bar needs nothing here, and the seam ignores it for
+   * non-`view` types.
+   */
+  dataSource?: any;
+  /** The object a `view` artifact belongs to — the object half of the keys. */
+  objectName?: string;
+  /**
    * Disable Publish while the panel has unsaved local edits, mirroring
    * studio's "save first, then publish" rule.
    */
@@ -56,6 +67,8 @@ export function RuntimeDraftBar({
   type,
   name,
   metadataClient,
+  dataSource,
+  objectName,
   dirty,
   onResume,
   onAfterChange,
@@ -115,7 +128,7 @@ export function RuntimeDraftBar({
     if (!name) return;
     setBusy(true);
     try {
-      await publishRuntimeMetadata(type, name, { metadataClient });
+      await publishRuntimeMetadata(type, name, { metadataClient, dataSource, objectName });
       setHasDraft(false);
       onAfterChange?.();
     } catch (err) {
@@ -123,7 +136,7 @@ export function RuntimeDraftBar({
     } finally {
       setBusy(false);
     }
-  }, [type, name, metadataClient, onAfterChange]);
+  }, [type, name, metadataClient, dataSource, objectName, onAfterChange]);
 
   const handleDiscard = useCallback(async () => {
     if (!name) return;
@@ -135,7 +148,7 @@ export function RuntimeDraftBar({
     }
     setBusy(true);
     try {
-      await discardRuntimeDraft(type, name, { metadataClient });
+      await discardRuntimeDraft(type, name, { metadataClient, dataSource, objectName });
       setHasDraft(false);
       onAfterChange?.();
     } catch (err) {
@@ -143,7 +156,7 @@ export function RuntimeDraftBar({
     } finally {
       setBusy(false);
     }
-  }, [type, name, metadataClient, onAfterChange, locale]);
+  }, [type, name, metadataClient, dataSource, objectName, onAfterChange, locale]);
 
   // flag OFF, or nothing pending → render nothing (zero DOM, zero layout shift).
   // Nothing pending → render nothing (no indicator, no buttons).

--- a/packages/app-shell/src/views/ViewConfigPanel.tsx
+++ b/packages/app-shell/src/views/ViewConfigPanel.tsx
@@ -76,6 +76,13 @@ export interface ViewConfigPanelProps {
      * chrome ({@link RuntimeDraftBar}).
      */
     metadataClient?: any;
+    /**
+     * The DataSource whose view caches a publish / discard from this panel
+     * stales (objectui#4373). Forwarded to {@link RuntimeDraftBar}; the object
+     * half of the cache keys comes from `objectDef.name`, so nothing here has
+     * to know what those keys are.
+     */
+    dataSource?: any;
     /** Called after a publish / discard so the host can refresh its read. */
     onAfterChange?: () => void;
 }
@@ -99,7 +106,7 @@ function mapObjectFields(objectDef: ViewConfigPanelProps['objectDef']): ObjectFi
     });
 }
 
-export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, objectDef, onViewUpdate, onSave, onCreate, metadataClient, onAfterChange }: ViewConfigPanelProps) {
+export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, objectDef, onViewUpdate, onSave, onCreate, metadataClient, dataSource, onAfterChange }: ViewConfigPanelProps) {
     const { t } = useObjectTranslation();
     const panelRef = useRef<HTMLDivElement>(null);
     const locale = useMetadataLocale();
@@ -270,6 +277,8 @@ export function ViewConfigPanel({ open, onClose, mode = 'edit', activeView, obje
                         type="view"
                         name={activeView.id}
                         metadataClient={metadataClient}
+                        dataSource={dataSource}
+                        objectName={objectDef.name}
                         dirty={isDirty}
                         onResume={handleResumeDraft}
                         savedSignal={savedSignal}

--- a/packages/app-shell/src/views/runtime-metadata-persistence.ts
+++ b/packages/app-shell/src/views/runtime-metadata-persistence.ts
@@ -16,6 +16,16 @@
  * The bespoke per-type tables (`sys_view` / `sys_report` / `sys_dashboard`) and
  * their shape adapters have been retired — there is no longer a feature flag or
  * a legacy write path here.
+ *
+ * **This seam is a view WRITER, so it invalidates the DataSource's view caches**
+ * (objectui#4373). `ObjectStackAdapter` caches two view-shaped reads, and the
+ * rows this module writes are the rows those reads enumerate — but the two
+ * writers were disjoint: the adapter's own `createView`/`updateView`/… fixed
+ * their key lists in objectui#4363, while the console's real create-and-publish
+ * flow comes through HERE and invalidated nothing. Which keys they are stays the
+ * adapter's business ({@link ViewCacheInvalidator}); all this module decides is
+ * whether a given write is a view write, and it hands the object name down from
+ * the call site.
  */
 
 import { slugify } from './metadata-admin/createDerive';
@@ -57,10 +67,85 @@ export function recordPageEnvelope(
   };
 }
 
-/** Everything the seam needs to persist any of the three artifact types. */
+/**
+ * The adapter-side cache seam this module routes view writes through.
+ *
+ * Structural on purpose: the only implementation is `ObjectStackAdapter`
+ * (`@object-ui/data-objectstack`), and the call sites already hold it as the
+ * `dataSource` prop `AppContent` takes from `useAdapter()` — so this module
+ * needs the SHAPE, not the class, and app-shell gains no import it did not have.
+ * Every other `dataSource` view call in `ObjectView` is duck-typed the same way.
+ */
+export interface ViewCacheInvalidator {
+  /** Drop `view:{object}:{name}` + `view-overrides:{object}`. */
+  invalidateViewKeys(objectName: string, viewName: string): void;
+}
+
+/** Everything the seam needs to persist any of the four artifact types. */
 export interface RuntimePersistCtx {
   /** Studio metadata client — the `/meta` draft/publish/version API. */
   metadataClient: any;
+  /**
+   * The DataSource whose view caches this write stales (objectui#4373).
+   *
+   * `metadataClient` writes the `/meta/view/:name` rows that
+   * `ObjectStackAdapter` caches under two view-shaped keys, and until #4373
+   * nothing connected the two: a user created a view in the console and
+   * published it, and the object's override map kept answering from its
+   * pre-publish snapshot for the rest of the cache's 5-minute TTL. It does not
+   * self-heal — `loadViewOverrides` treats a RESOLVED map as authoritative and
+   * deliberately does not re-probe per view (objectui#3774) — so the per-view
+   * `getView` fallback that would have masked it is by design unreachable.
+   *
+   * Optional: report / dashboard / page writes need nothing here, and a call
+   * site without an adapter still persists exactly as before.
+   */
+  dataSource?: Partial<ViewCacheInvalidator> | null;
+  /**
+   * The object a `view` write belongs to — the `{object}` half of both keys.
+   *
+   * Required to invalidate, and taken from the call site rather than parsed out
+   * of `name`. A runtime-created view's name is the qualified `<object>.<key>`
+   * ({@link viewEnvelope}), but a source-declared view's is not, so splitting
+   * the name would be a second, silently-wrong identity rule (AGENTS.md #0.1).
+   * Absent → nothing object-scoped can be named, and the write is left alone.
+   */
+  objectName?: string | null;
+}
+
+/**
+ * Drop the view-shaped cache keys a just-written view row stales.
+ *
+ * The key set itself lives in ONE place — the adapter's `invalidateViewKeys`
+ * (objectui#4373) — so this module never spells `view-overrides:` and cannot
+ * drift from it. Here we only decide WHETHER a write is a view write.
+ *
+ * Applied uniformly to every function in this module, including the draft-only
+ * ones, and that is deliberate over-invalidation: both cached readers enumerate
+ * PUBLISHED rows, so a draft save or a discard stales neither. It matches the
+ * rule the adapter's own draft half already follows, for the same reason — an
+ * unnecessary invalidation costs one refetch, a missed one costs up to the
+ * 5-minute TTL, and a per-function exception list is precisely how this key set
+ * got forgotten twice already.
+ *
+ * Never throws: a cache drop that fails must not fail the persist that
+ * succeeded. The worst case is the staleness this fix removes.
+ */
+function invalidateViewCaches(
+  type: RuntimeArtifactType,
+  name: string,
+  ctx: RuntimePersistCtx,
+): void {
+  if (type !== 'view') return;
+  const objectName = ctx.objectName;
+  if (!objectName || !name) return;
+  const invalidate = ctx.dataSource?.invalidateViewKeys;
+  if (typeof invalidate !== 'function') return;
+  try {
+    invalidate.call(ctx.dataSource, objectName, name);
+  } catch (err) {
+    console.warn('[runtime-metadata] view cache invalidation failed:', err);
+  }
 }
 
 /**
@@ -98,6 +183,7 @@ export async function persistRuntimeMetadata(
   ctx: RuntimePersistCtx,
 ): Promise<void> {
   await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
+  invalidateViewCaches(type, name, ctx);
 }
 
 /**
@@ -204,6 +290,7 @@ export async function createRuntimeMetadata(
     );
   }
   await ctx.metadataClient.save(type, name, body, { mode: 'draft' });
+  invalidateViewCaches(type, name, ctx);
   return name;
 }
 
@@ -231,11 +318,18 @@ export async function discardRuntimeDraft(
   ctx: RuntimePersistCtx,
 ): Promise<void> {
   await ctx.metadataClient.reset(type, name, { state: 'draft' });
+  invalidateViewCaches(type, name, ctx);
 }
 
 /**
  * Publish a previously-staged runtime edit: promote the pending draft to the
  * active overlay and record a version.
+ *
+ * **This is the moment objectui#4373 measures.** Publish is what turns an
+ * invisible draft into a published row, which is the world both cached readers
+ * enumerate — so it is the write that genuinely stales
+ * `view-overrides:{object}`, and the one that used to leave it stale for the
+ * full TTL. See {@link RuntimePersistCtx.dataSource}.
  */
 export async function publishRuntimeMetadata(
   type: RuntimeArtifactType,
@@ -243,4 +337,5 @@ export async function publishRuntimeMetadata(
   ctx: RuntimePersistCtx,
 ): Promise<void> {
   await ctx.metadataClient.publish(type, name);
+  invalidateViewCaches(type, name, ctx);
 }

--- a/packages/app-shell/src/views/viewCacheInvalidation.guard.test.tsx
+++ b/packages/app-shell/src/views/viewCacheInvalidation.guard.test.tsx
@@ -1,0 +1,326 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Publishing a view from the console must not leave the adapter's override map
+ * stale (objectui#4373).
+ *
+ * ## The defect
+ *
+ * `ObjectStackAdapter` caches two view-shaped reads — `getView` under
+ * `view:{object}:{name}`, and `listViewOverrides` under
+ * `view-overrides:{object}` — with `MetadataCache`'s default **5-minute** TTL.
+ * objectui#4363 made the adapter's own four write paths drop both keys. But the
+ * console's real create-a-view flow never calls any of them: `handleViewCreate`
+ * writes through the ADR-0034 metadata seam (`createRuntimeMetadata` →
+ * `metadataClient.save`), and Publish goes `RuntimeDraftBar` →
+ * `publishRuntimeMetadata` → `metadataClient.publish`. Two writers into the same
+ * `/meta/view/:name` rows; only one of them invalidated anything.
+ *
+ * Publish is the sharp end. A create lands an invisible per-item DRAFT, and
+ * `listViewOverrides` enumerates PUBLISHED rows — so the map is still honest
+ * there. Publish promotes the row into exactly the world the map describes, and
+ * nothing dropped the key, so the object page kept applying its pre-publish
+ * snapshot for the rest of the TTL.
+ *
+ * It does not self-heal. `loadViewOverrides` (`ObjectView`) treats a RESOLVED
+ * map as authoritative and deliberately does not re-probe per view — that is
+ * objectui#3774, and it is correct, since re-probing reinstates the 404 flurry
+ * the batch read exists to remove. So the per-view `getView` fallback that would
+ * have masked a stale map is by design unreachable, and the stale map is served
+ * in full.
+ *
+ * ## What these cases assert, and why in this shape
+ *
+ * Against a **real `ObjectStackAdapter` with its real `MetadataCache`**, not a
+ * recording stand-in: the claim under test is "the second read is fresh", which
+ * is a statement about the cache's behaviour. A test that asserted
+ * `invalidate` was *called* with the right strings would restate the fix rather
+ * than measure it — and would have been just as green before #4373 if the
+ * strings had been restated in app-shell (the restatement this fix exists to
+ * remove: the key set lives in `invalidateViewKeys` and nowhere else).
+ *
+ * `RuntimeDraftBar` is driven through the DOM for the same reason: the seam
+ * being called is not the claim, the user's Publish click closing the staleness
+ * is.
+ *
+ * ## Reverse verification (performed when written)
+ *
+ * Deleting the `invalidateViewCaches(type, name, ctx)` line from
+ * `publishRuntimeMetadata` — i.e. restoring the pre-#4373 body — turns the
+ * publish cases red with the map still missing `account.mine` and `getItems`
+ * still at ONE call, which is precisely the measured defect. Deleting it from
+ * `createRuntimeMetadata` reddens the create case the same way. The type
+ * discrimination case is the control in the other direction: it stays green
+ * either way, because a `report` publish must not touch view keys.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { RuntimeDraftBar } from './RuntimeDraftBar';
+import { createRuntimeMetadata, publishRuntimeMetadata } from './runtime-metadata-persistence';
+
+const PUBLISHED_VIEW = {
+  name: 'account.all',
+  object: 'account',
+  viewKind: 'list',
+  label: 'All Accounts',
+  config: { type: 'grid', data: { object: 'account' } },
+};
+
+const NEW_VIEW = {
+  name: 'account.mine',
+  object: 'account',
+  viewKind: 'list',
+  label: 'My Accounts',
+  config: { type: 'grid', data: { object: 'account' } },
+};
+
+/**
+ * A real adapter over a fake `client.meta`, with the REAL `MetadataCache` left
+ * in place. `published` is the server's row set and the test mutates it to
+ * model a publish landing — so "did the map go stale?" is answered by what the
+ * second `listViewOverrides` returns, not by inspecting the cache.
+ */
+function makeAdapter() {
+  const published: any[] = [PUBLISHED_VIEW];
+  const getItems = vi.fn(async () => ({ items: [...published] }));
+
+  const adapter: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  });
+  // Skip the handshake; this suite is about the cache, not the transport.
+  adapter.connected = true;
+  adapter.connectionState = 'connected';
+  adapter.client = {
+    meta: {
+      getItems,
+      saveItem: vi.fn(async () => ({ success: true })),
+      deleteItem: vi.fn(async () => ({ deleted: true })),
+      getItem: vi.fn(async () => ({ item: PUBLISHED_VIEW })),
+    },
+  };
+
+  return { adapter: adapter as ObjectStackAdapter, getItems, published };
+}
+
+/** The `/meta` draft-publish client the ADR-0034 seam talks to. */
+function makeMetadataClient(draftItem: unknown = null) {
+  return {
+    get: vi.fn().mockResolvedValue(draftItem),
+    save: vi.fn().mockResolvedValue(undefined),
+    publish: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('objectui#4373 — the console publish flow invalidates the override map', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('a Publish click makes the next listViewOverrides read fresh', async () => {
+    const { adapter, getItems, published } = makeAdapter();
+    const metadataClient = makeMetadataClient({
+      type: 'view',
+      name: NEW_VIEW.name,
+      item: NEW_VIEW,
+    });
+
+    // 1. The user is on the object page: the batch override map is read and
+    //    cached. `account.mine` is still an invisible draft, so its absence
+    //    here is CORRECT — this snapshot is honest at the moment it is taken.
+    const before = await adapter.listViewOverrides('account');
+    expect(Object.keys(before)).toEqual(['account.all']);
+    expect(getItems).toHaveBeenCalledTimes(1);
+
+    // 2. The user clicks Publish in the view config panel's draft bar.
+    render(
+      <RuntimeDraftBar
+        type="view"
+        name={NEW_VIEW.name}
+        metadataClient={metadataClient}
+        dataSource={adapter}
+        objectName="account"
+      />,
+    );
+    const publishBtn = await screen.findByTestId('runtime-draft-publish');
+    // The server promotes the draft into a published row.
+    metadataClient.publish.mockImplementation(async () => {
+      published.push(NEW_VIEW);
+    });
+    fireEvent.click(publishBtn);
+    // Wait on the bar clearing its pending-draft state, not on `publish` having
+    // been called: `setHasDraft(false)` runs strictly AFTER the seam call in
+    // `handlePublish`, so this cannot observe a half-finished publish.
+    await waitFor(() =>
+      expect(screen.queryByTestId('runtime-draft-bar')).toBeNull(),
+    );
+    expect(metadataClient.publish).toHaveBeenCalledWith('view', NEW_VIEW.name);
+
+    // 3. The object page re-reads. Before #4373 this was served from the
+    //    pre-publish snapshot for the rest of the 5-minute TTL — one call to
+    //    the transport, and a map that never learns about the new view.
+    const after = await adapter.listViewOverrides('account');
+    expect(getItems).toHaveBeenCalledTimes(2);
+    expect(Object.keys(after).sort()).toEqual(['account.all', 'account.mine']);
+  });
+
+  it('publish also drops the per-view getView key', async () => {
+    // The other half of the pair. `getView` is the read a per-view probe would
+    // use, and an upsert-shaped publish can change a row it already holds.
+    const { adapter } = makeAdapter();
+    const metadataClient = makeMetadataClient({ item: NEW_VIEW });
+
+    await adapter.getView('account', NEW_VIEW.name);
+    expect(adapter.getCached(`view:account:${NEW_VIEW.name}`)).toBeTruthy();
+
+    await publishRuntimeMetadata('view', NEW_VIEW.name, {
+      metadataClient,
+      dataSource: adapter,
+      objectName: 'account',
+    });
+
+    expect(adapter.getCached(`view:account:${NEW_VIEW.name}`)).toBeUndefined();
+  });
+
+  it('creating a view drops the same keys — the other door into these rows', async () => {
+    // `handleViewCreate` / `ObjectDataPage`'s "Save as view". A create lands a
+    // DRAFT, so neither cached reader is genuinely staled by it — this is the
+    // seam's uniform per-write rule applied on purpose, matching the adapter's
+    // own draft half (objectui#4363). An unnecessary invalidation costs one
+    // refetch; a per-function exception list is how this key set got forgotten
+    // twice already.
+    const { adapter, getItems } = makeAdapter();
+    const metadataClient = makeMetadataClient();
+
+    await adapter.listViewOverrides('account');
+    expect(getItems).toHaveBeenCalledTimes(1);
+
+    await createRuntimeMetadata('view', NEW_VIEW.name, NEW_VIEW, {
+      metadataClient,
+      dataSource: adapter,
+      objectName: 'account',
+    });
+
+    await adapter.listViewOverrides('account');
+    expect(getItems).toHaveBeenCalledTimes(2);
+  });
+
+  it('a report publish touches no view key — the type guard is real', async () => {
+    // The control in the opposite direction. `RuntimeDraftBar` is shared with
+    // ReportConfigPanel, and over-invalidating there would be a silent cost on
+    // an unrelated surface.
+    const { adapter, getItems } = makeAdapter();
+    const metadataClient = makeMetadataClient();
+
+    await adapter.listViewOverrides('account');
+    expect(getItems).toHaveBeenCalledTimes(1);
+
+    await publishRuntimeMetadata('report', 'pipeline', {
+      metadataClient,
+      dataSource: adapter,
+      objectName: 'account',
+    });
+
+    await adapter.listViewOverrides('account');
+    // Still served from cache: one transport call, not two.
+    expect(getItems).toHaveBeenCalledTimes(1);
+  });
+
+  it('a call site with no adapter still persists — invalidation is additive', async () => {
+    // Every seam caller kept working without passing a `dataSource`, which is
+    // what lets `ReportView` and the record-page paths stay untouched.
+    const metadataClient = makeMetadataClient();
+
+    await expect(
+      publishRuntimeMetadata('view', NEW_VIEW.name, { metadataClient }),
+    ).resolves.toBeUndefined();
+    expect(metadataClient.publish).toHaveBeenCalledWith('view', NEW_VIEW.name);
+  });
+
+  it('an invalidation failure does not fail the publish that succeeded', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const metadataClient = makeMetadataClient();
+    const exploding = {
+      invalidateViewKeys: () => {
+        throw new Error('cache exploded');
+      },
+    };
+
+    await expect(
+      publishRuntimeMetadata('view', NEW_VIEW.name, {
+        metadataClient,
+        dataSource: exploding,
+        objectName: 'account',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(metadataClient.publish).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('without an object name nothing object-scoped is named', async () => {
+    // Both keys are object-scoped, and `name` is NOT a path to split: a
+    // runtime-created view is `<object>.<key>` but a source-declared one is
+    // not, so deriving the object from the name would be a second, silently
+    // wrong identity rule (AGENTS.md #0.1).
+    const metadataClient = makeMetadataClient();
+    const invalidateViewKeys = vi.fn();
+
+    await publishRuntimeMetadata('view', 'account.mine', {
+      metadataClient,
+      dataSource: { invalidateViewKeys },
+    });
+
+    expect(metadataClient.publish).toHaveBeenCalled();
+    expect(invalidateViewKeys).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The structural half: app-shell routes through the seam and never restates the
+ * key set. A behavioural test cannot see the difference between "calls the
+ * seam" and "spells the same two strings inline", and an inline copy here is
+ * exactly the recurrence #4373 was filed about.
+ */
+describe('objectui#4373 — app-shell never spells a view cache key', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const srcRoot = path.resolve(here, '..');
+
+  function walk(dir: string, out: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full, out);
+      else if (/\.tsx?$/.test(entry)) out.push(full);
+    }
+    return out;
+  }
+
+  const files = walk(srcRoot);
+
+  it('is reading the real tree, not an empty one', () => {
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  it('no app-shell file interpolates `view:` or `view-overrides:` as a cache key', () => {
+    // Code occurrences only — the `${` marker excludes the prose form
+    // (`view-overrides:{object}`) these files legitimately use to EXPLAIN the
+    // adapter's keys. Which keys they are is `invalidateViewKeys`' business.
+    const offenders = files.filter((f) => {
+      const src = readFileSync(f, 'utf8');
+      return /`view:\$\{/.test(src) || /`view-overrides:\$\{/.test(src);
+    });
+
+    expect(offenders.map((f) => path.relative(srcRoot, f))).toEqual([]);
+  });
+});

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -924,8 +924,15 @@ function withoutNoOpDrops(
  * framework's overlay heals onto identity-less personalization rows —
  * objectstack#2555); `data.object` is the config's data-provider target and
  * `objectName` the legacy artifact spelling.
+ *
+ * **Exported** since objectui#4373, for the same one-spelling reason: a writer
+ * outside this module that holds a view BODY but not its object name (app-shell's
+ * `MetadataService`) needs the object to name the keys
+ * {@link ObjectStackAdapter.invalidateViewKeys} drops, and a fourth private copy
+ * of "which object is this?" is exactly the drift this accessor exists to
+ * prevent. Identity only — it names no cache key.
  */
-function viewItemObjectName(item: any): string | undefined {
+export function viewItemObjectName(item: any): string | undefined {
   // Handle both bare view spec and `{list: {...}}` artifact wrapper
   const spec = item?.list ?? item;
   return spec?.data?.object ?? spec?.object ?? spec?.objectName;
@@ -2890,6 +2897,53 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   }
 
   /**
+   * **The one place that knows which cache keys a view-row write invalidates.**
+   *
+   * Two reads are cached under view-shaped keys, and both go stale when any
+   * writer touches a view row for `objectName`:
+   *
+   * | reader                     | key                        |
+   * |----------------------------|----------------------------|
+   * | {@link getView}            | `view:{object}:{viewName}` |
+   * | {@link listViewOverrides}  | `view-overrides:{object}`  |
+   *
+   * Every writer routes here rather than restating that pair. The repo has now
+   * paid twice for restatement: objectui#3778 removed five copies of a key
+   * (`views:{object}`) that no reader had ever populated, and objectui#4363
+   * fixed four copies that named only half the live set — and objectui#4373 is
+   * the measured proof that the failure recurs by default, because the console's
+   * real create/publish flow writes these same rows through the ADR-0034
+   * metadata seam and never learned the key list at all. A pin suite can only
+   * guard the writers that exist; a mandatory seam makes the next writer
+   * structurally unable to forget.
+   *
+   * The rule is uniform per WRITE, not per branch: a write to a view row drops
+   * both keys, in that order. Draft-addressed writes over-invalidate on purpose
+   * — both readers enumerate PUBLISHED rows, so a draft write stales neither —
+   * because the costs are not symmetric. An unnecessary invalidation costs one
+   * refetch; a missed one costs up to the cache's 5-minute TTL of stale
+   * overrides, and "which half am I in?" is not a question a future writer
+   * should have to re-answer to stay correct.
+   *
+   * Public because the writers are not all in this class: app-shell's ADR-0034
+   * seam (`runtime-metadata-persistence.ts`) and `MetadataService` write the
+   * same rows through `client.meta` / the `/meta` draft-publish API, and they
+   * reach this adapter as the `dataSource` they were already handed.
+   *
+   * @param objectName - Object the view belongs to (the `{object}` in both keys)
+   * @param viewName - The view's canonical `name` — the identity
+   *   {@link getView} reads back by and {@link listViewOverrides} keys its map
+   *   with. Callers that hold a qualified `<object>.<key>` name pass it as-is:
+   *   it is the row key, not a path to be split.
+   */
+  invalidateViewKeys(objectName: string, viewName: string): void {
+    // Ordered per-view key first, then the object's map — the order the pin
+    // suite records, so a reordering is a visible decision rather than drift.
+    this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
+    this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
+  }
+
+  /**
    * Batch-fetch all persisted view overrides for an object.
    *
    * Per-view runtime overrides (density, column widths, sort, hidden
@@ -2917,10 +2971,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * (the cache stores on success only), so a transient failure does not
    * pin an empty answer for the TTL.
    *
-   * Result is cached identically to {@link getView}, and EVERY view write path
-   * on this adapter invalidates it — {@link updateViewConfig},
-   * {@link createView}, {@link updateView} and {@link deleteView}. For a long
-   * time only the first did (objectui#4363), which left the other three stale
+   * Result is cached identically to {@link getView}, and EVERY view write —
+   * on this adapter and above it — invalidates it through the one seam,
+   * {@link invalidateViewKeys}. For a long time only {@link updateViewConfig}
+   * did (objectui#4363), which left the other three adapter paths stale
    * for the cache's 5-minute TTL. That gap does not self-heal: the consumer
    * (`loadViewOverrides`, app-shell `ObjectView`) treats a RESOLVED map as
    * authoritative and deliberately does not re-probe per view — objectui#3774,
@@ -3022,11 +3076,8 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       viewId,
       merged
     );
-    // Invalidate cached read so next getView reflects the change
-    const cacheKey = `view:${objectName}:${viewId}`;
-    this.metadataCache.invalidate?.(cacheKey);
-    // Also invalidate the batch override map so listViewOverrides re-fetches
-    this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
+    // One seam names the key set for every writer (objectui#4373).
+    this.invalidateViewKeys(objectName, viewId);
     if (result && result.item) return result.item;
     return result ?? undefined;
   }
@@ -3159,9 +3210,9 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * Generates a snake_case name if `spec.name` is not provided by appending
    * a short timestamp suffix to the source-name hint.
    *
-   * Invalidates both view-shaped cache keys for the object, exactly as
-   * {@link updateViewConfig} does — see {@link listViewOverrides} for why the
-   * batch map is the one that cannot heal itself (objectui#4363).
+   * Invalidates through {@link invalidateViewKeys}, like every other writer —
+   * see {@link listViewOverrides} for why the batch map is the one that cannot
+   * heal itself (objectui#4363).
    */
   async createView(
     objectName: string,
@@ -3191,14 +3242,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       data: spec?.data || { provider: 'object', object: objectName },
     };
     const result: any = await this.client.meta.saveItem('view', name, fullSpec);
-    // Same key set as `updateViewConfig` — this is the other `saveItem('view', …)`
-    // write, and `saveItem` is an UPSERT: an explicit `spec.name` that already
-    // exists overwrites the published row, which a prior `getView` may hold.
-    // (A generated name cannot collide, and a miss is a `Map.delete` on an absent
+    // `saveItem` is an UPSERT: an explicit `spec.name` that already exists
+    // overwrites the published row, which a prior `getView` may hold. (A
+    // generated name cannot collide, and a miss is a `Map.delete` on an absent
     // key, so the uniform rule costs nothing on the create-a-new-row path.)
-    this.metadataCache.invalidate?.(`view:${objectName}:${name}`);
-    // The batch override map gains a row and cannot notice on its own (#4363).
-    this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
+    this.invalidateViewKeys(objectName, name);
     if (result && result.item) return result.item;
     return fullSpec;
   }
@@ -3235,14 +3283,10 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * *published* view (no draft pending) is unchanged — it writes the
    * published overlay, as before.
    *
-   * **Both halves invalidate the same two keys** (objectui#4363): the per-view
-   * {@link getView} key and the batch {@link listViewOverrides} map. On the
-   * draft half that is deliberate over-invalidation — both readers enumerate
-   * PUBLISHED rows, so a draft write stales neither, exactly as was already
-   * true of the per-view line this joins. The costs are not symmetric: an
-   * unnecessary invalidation costs one refetch, a missed one costs up to the
-   * cache's 5-minute TTL of stale overrides, and "which half am I in?" is not
-   * a question a future edit to this method should have to re-answer.
+   * **Both halves invalidate through {@link invalidateViewKeys}** (objectui#4363,
+   * #4373) — same call, same key set, so the draft half's deliberate
+   * over-invalidation is the seam's uniform rule rather than a per-branch
+   * decision this method has to keep re-making.
    *
    * @throws when the view resolves in neither home, or when either read fails
    *   for any other reason (network, permission). Both used to be swallowed
@@ -3267,8 +3311,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     if (draft) {
       const mergedDraft = mergeViewPatch(draft, partial, viewName, objectName);
       await metaClient.save('view', viewName, mergedDraft, { mode: 'draft' });
-      this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
-      this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
+      this.invalidateViewKeys(objectName, viewName);
       return mergedDraft;
     }
 
@@ -3298,8 +3341,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
 
     const merged = mergeViewPatch(current, partial, viewName, objectName);
     const result: any = await this.client.meta.saveItem('view', viewName, merged);
-    this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
-    this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
+    this.invalidateViewKeys(objectName, viewName);
     if (result && result.item) return result.item;
     return merged;
   }
@@ -3309,9 +3351,9 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * remove entirely if it was a user-created view). Routes to
    * `DELETE /api/v1/meta/view/:name`.
    *
-   * Invalidates both view-shaped keys: the deleted row leaves the batch
-   * override map too, and a ghost entry there is what the object page would
-   * keep applying (objectui#4363).
+   * Invalidates through {@link invalidateViewKeys}: the deleted row leaves the
+   * batch override map too, and a ghost entry there is what the object page
+   * would keep applying (objectui#4363).
    */
   async deleteView(
     objectName: string,
@@ -3319,8 +3361,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
   ): Promise<{ deleted: boolean }> {
     await this.connect();
     const result: any = await this.client.meta.deleteItem('view', viewName);
-    this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
-    this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
+    this.invalidateViewKeys(objectName, viewName);
     return { deleted: !!(result?.deleted ?? result?.reset ?? true) };
   }
 

--- a/packages/data-objectstack/src/viewInvalidationSeam.pin.test.ts
+++ b/packages/data-objectstack/src/viewInvalidationSeam.pin.test.ts
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import ts from 'typescript';
+import { ObjectStackAdapter } from './index';
+
+/**
+ * `invalidateViewKeys` is the ONE place that knows the view cache key set
+ * (objectui#4373).
+ *
+ * The behavioural half of this rule is already pinned next door, in
+ * `viewCacheInvalidation.pin.test.ts`: eight cases assert the exact key list
+ * every adapter write path emits. Those eight are deliberately unchanged by
+ * #4373 — routing the four paths through a seam must change nothing they can
+ * observe, and their staying green IS the refactor's acceptance evidence.
+ *
+ * But that is also their blind spot. A future edit that re-inlines
+ * ``this.metadataCache.invalidate?.(`view-overrides:${objectName}`)`` back into
+ * one write path emits the identical keys in the identical order, so every one
+ * of those eight stays green while the seam quietly stops being the single
+ * source of truth — and the next writer after that inherits a key list to
+ * forget. That is not a hypothetical failure mode, it is the repo's measured
+ * history: objectui#3778 removed five restated copies of a key no reader ever
+ * populated, objectui#4363 fixed four restated copies that named half the live
+ * set, and objectui#4373 is the third instalment — a writer OUTSIDE this class
+ * (the console's create/publish flow through app-shell's ADR-0034 seam) that
+ * never learned the key list at all.
+ *
+ * So the guard has to be structural, and the assertions below are on the SOURCE
+ * TEXT of `index.ts`:
+ *
+ * | key template          | may appear exactly twice                        |
+ * |-----------------------|-------------------------------------------------|
+ * | `` `view:${…}:${…}` ``     | the `getView` READ + the seam               |
+ * | `` `view-overrides:${…}` ``| the `listViewOverrides` READ + the seam     |
+ *
+ * Two, not one: a reader must spell the key it caches under — that is where the
+ * key is *defined*. What must not recur is a THIRD spelling, because the only
+ * thing a third spelling can be is a writer restating what the seam already
+ * knows. Re-inline any write path's key list and the count goes to three.
+ *
+ * If this goes red on a legitimate change: adding a new cached view-shaped READ
+ * is the one case that raises a count honestly — pin the new reader here (and
+ * teach {@link ObjectStackAdapter.invalidateViewKeys} to drop its key), rather
+ * than relaxing the assertion to "at most N".
+ */
+
+/**
+ * Read through `ts.sys`, not `node:fs` — the convention this package's
+ * `cloud-surface-retired-4152.pin.test.ts` records and explains: `tsconfig.json`
+ * compiles the whole test tree here, and keeping `@types/node` out of a
+ * browser-side adapter's type environment is deliberate. TypeScript's own
+ * system host is typed by the `typescript` devDependency.
+ */
+const INDEX_TS = new URL(import.meta.url).pathname.replace(/[^/]+$/, 'index.ts');
+const adapterSrc = (() => {
+  const raw = ts.sys.readFile(INDEX_TS);
+  if (!raw) throw new Error(`cannot read ${INDEX_TS}`);
+  return raw;
+})();
+
+/**
+ * Code occurrences only. Both keys are also written out in prose in this
+ * file's neighbours and in `index.ts`'s own doc comments, in the placeholder
+ * form `view-overrides:{object}` — documentation is not a second source of
+ * truth and must not be counted as one. Requiring the `${` interpolation
+ * marker separates the two exactly.
+ */
+const PER_VIEW_KEY = /`view:\$\{/g;
+const OVERRIDE_MAP_KEY = /`view-overrides:\$\{/g;
+
+function count(re: RegExp, src: string): number {
+  return src.match(re)?.length ?? 0;
+}
+
+describe('the view cache key set has exactly one owner (objectui#4373)', () => {
+  it('is reading real source, not an empty string', () => {
+    // Premise guard: a path typo would make every count 0, and every
+    // assertion below would pass by reading nothing.
+    expect(adapterSrc.length).toBeGreaterThan(10_000);
+    expect(adapterSrc).toContain('invalidateViewKeys(objectName: string, viewName: string): void');
+  });
+
+  it('spells `view:{object}:{name}` exactly twice — the getView read, and the seam', () => {
+    expect(count(PER_VIEW_KEY, adapterSrc)).toBe(2);
+  });
+
+  it('spells `view-overrides:{object}` exactly twice — the listViewOverrides read, and the seam', () => {
+    expect(count(OVERRIDE_MAP_KEY, adapterSrc)).toBe(2);
+  });
+
+  it('no write path names a view cache key itself — they all call the seam', () => {
+    // The complementary statement of the two counts, asserted where a reader
+    // will look for it: every `invalidate` call in the adapter that concerns a
+    // view goes through `invalidateViewKeys`, so the ONLY `metadataCache
+    // .invalidate` lines naming a view key are the seam's own two.
+    const invalidateLines = adapterSrc
+      .split('\n')
+      .filter((l: string) => l.includes('metadataCache.invalidate'))
+      .filter((l: string) => /`view(-overrides)?:/.test(l));
+
+    expect(invalidateLines.map((l: string) => l.trim())).toEqual([
+      'this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);',
+      'this.metadataCache.invalidate?.(`view-overrides:${objectName}`);',
+    ]);
+  });
+});
+
+describe('invalidateViewKeys — the seam itself', () => {
+  function makeAdapter() {
+    const invalidated: string[] = [];
+    const ds: any = new ObjectStackAdapter({
+      baseUrl: 'http://test.local',
+      fetch: vi.fn(async () =>
+        new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    });
+    ds.metadataCache = { invalidate: (key: string) => invalidated.push(key) };
+    return { ds: ds as ObjectStackAdapter, invalidated };
+  }
+
+  it('drops the per-view key then the object override map, in that order', () => {
+    const { ds, invalidated } = makeAdapter();
+
+    ds.invalidateViewKeys('account', 'account.mine');
+
+    expect(invalidated).toEqual(['view:account:account.mine', 'view-overrides:account']);
+  });
+
+  it('takes a qualified `<object>.<key>` name as-is — it is a row key, not a path', () => {
+    // The console's runtime-created views are named `<object>.<key>`
+    // (`viewEnvelope`, app-shell). Splitting that on `.` would key the cache
+    // under something no reader asks for, which is the objectui#3774 class of
+    // bug one rename later.
+    const { ds, invalidated } = makeAdapter();
+
+    ds.invalidateViewKeys('account', 'account.top_deals');
+
+    expect(invalidated[0]).toBe('view:account:account.top_deals');
+  });
+
+  it('is callable from outside the class — the writers are not all in it', () => {
+    // The seam is public because app-shell's ADR-0034 persistence module and
+    // `MetadataService` write the same rows. A structural (non-class) caller
+    // must be able to hold it; this is that call shape.
+    const { ds, invalidated } = makeAdapter();
+    const seam: { invalidateViewKeys(o: string, v: string): void } = ds;
+
+    seam.invalidateViewKeys('lead', 'lead.hot');
+
+    expect(invalidated).toEqual(['view:lead:lead.hot', 'view-overrides:lead']);
+  });
+});


### PR DESCRIPTION
Fixes #4373

Implements the PM ruling recorded in the [triage comment](https://github.com/objectstack-ai/objectui/issues/4373#issuecomment-5259862131): **one exported invalidation seam, routed by every writer** (option B), rather than a fifth restatement of the key list.

## The defect

`ObjectStackAdapter` caches two view-shaped reads — `getView` under `view:{object}:{name}` and `listViewOverrides` under `view-overrides:{object}` — with `MetadataCache`'s default 5-minute TTL. #4363 fixed the adapter's own four write paths, but the console's real create-a-view flow is a **second writer** into the same `/meta/view/:name` rows and invalidated nothing:

- `ObjectView.handleViewCreate` to `createRuntimeMetadata` to `metadataClient.save`
- Publish: `RuntimeDraftBar` to `publishRuntimeMetadata` to `metadataClient.publish`

Publish is the sharp end. A create lands an invisible per-item **draft**, and `listViewOverrides` enumerates **published** rows, so the map is still honest there. Publish promotes the row into exactly the world the map describes — and nothing dropped the key. It does not self-heal: `loadViewOverrides` treats a RESOLVED map as authoritative and deliberately does not re-probe per view (#3774, correct — re-probing reinstates the 404 flurry the batch read exists to remove), so the per-view `getView` fallback that would have masked a stale map is by design unreachable.

## The seam

```ts
invalidateViewKeys(objectName: string, viewName: string): void {
  this.metadataCache.invalidate?.(`view:${objectName}:${viewName}`);
  this.metadataCache.invalidate?.(`view-overrides:${objectName}`);
}
```

The ONE place that knows the key set. Public because the writers are not all in the class. `viewName` is taken as-is — a runtime-created view is named `account.mine`, but a source-declared one is not qualified, so splitting on `.` would be a second, silently-wrong identity rule (AGENTS.md #0.1).

The rule is uniform per **write**, not per branch: draft-addressed writes over-invalidate on purpose. An unnecessary invalidation costs one refetch; a missed one costs up to the 5-minute TTL, and "which half am I in?" is exactly the question that got this key set forgotten twice.

## Routing evidence

| writer | routed |
|---|---|
| `updateViewConfig` | seam |
| `createView` | seam |
| `updateView` (draft half) | seam |
| `updateView` (published half) | seam |
| `deleteView` | seam |
| app-shell `persistRuntimeMetadata` / `createRuntimeMetadata` / `publishRuntimeMetadata` / `discardRuntimeDraft` | seam, when `type === 'view'` |
| `MetadataService.saveMetadataItem` | seam, when `category === 'view'` |

**The four adapter paths' 8 pins in `viewCacheInvalidation.pin.test.ts` are byte-for-byte unchanged and pass** — that is the ruling's acceptance evidence that routing them through a seam changed nothing observable.

The object name is handed **down from the call site** (`ObjectView`, `ObjectDataPage`, `ViewConfigPanel` to `RuntimeDraftBar`), never parsed out of the row name. `MetadataService` derives it from the body via the exported `viewItemObjectName` — the same accessor `listViewOverrides` narrows those rows by, not a fourth private copy.

## MetadataService sibling — measured, not assumed

- `saveMetadataItem`: **wired**. No in-repo caller passes `'view'` today, but the class is public API (`useMetadataService`, exported from app-shell's barrel), so "unreachable" would have been an unmeasured claim about consumers we do not own.
- `deleteMetadataItem`: **documented as structurally unable**, not wired. Both keys are object-scoped; this signature has no object parameter and the tombstone body it writes (`{ name, enabled, _deleted }`) carries no object binding either — there is nothing to derive one from. The doc comment records what to do if a `'view'` caller ever appears.

## Pre-fix red (reverse verification)

Directions were predicted before each run. Five reversals:

| # | reversal | predicted | measured |
|---|---|---|---|
| 1 | drop seam call from `publishRuntimeMetadata` | red on publish cases | **3 red** — `getItems` stuck at 1 call, map never learns `account.mine`, `getView` key still populated. The 3 controls (report type / no adapter / no objectName) stayed green |
| 2 | drop seam call from `createRuntimeMetadata` | red only on create | **1 red**, exactly the create case; all publish cases green |
| 3 | re-inline the pair into `deleteView` | 8 pins green, structural pin red | **all 8 behavioural pins green** (including `deleteView invalidates both keys`), structural pin **3 red** (counts 3 not 2; `invalidateLines` 4 not 2) |
| 4 | drop the `category === 'view'` branch | red on the 2 positive cases | **2 red**, 4 green |
| 5 | restore `node:fs` in the new pin test | red typecheck | **TS2591 x3** — this package has no `@types/node` |

**Reversal 3 is the one that matters.** It is the measured proof that the behavioural pins cannot see a restatement: re-inlining the key pair into a write path emits identical keys in identical order, so all 8 stay green while the seam quietly stops being the single source of truth. That blind spot is why the new guard is **structural** — it asserts each key template appears exactly **twice** in `index.ts` (its reader, plus the seam), and that no app-shell file interpolates either key at all.

Honest correction to my own prediction: I called reversal 1 for 2 red and it produced 3. The third, `an invalidation failure does not fail the publish that succeeded`, observes the seam call through its `console.warn`, so it is a positive publish case — I had mis-binned it as a control. Direction correct, count off by one.

## Verification

- `pnpm exec vitest run packages/data-objectstack/ packages/app-shell/ --maxWorkers=2` — **383 files, 3787 passed, 1 skipped**
- `type-check` both packages (3 tsc invocations incl. `tsconfig.test.json`) — clean
- repo-wide `turbo run type-check --concurrency=2` — **78/78**
- `eslint` both packages — **0 errors** (warnings pre-existing `no-explicit-any`)
- `check-control-bytes` OK; changeset presence OK; no-major OK (`patch` for both packages)

## Recovered after host restart

A host restart killed the previous agent for this issue mid-task. Recorded for review:

**Inherited and verified (not rewritten):** the worktree, and one `wip: baseline for reverse verification` commit holding the whole implementation — adapter seam, four routed paths, app-shell wiring, `MetadataService`, three test files, changeset. Audited against the ruling's four points before trusting it; all four were already satisfied.

**Inherited dirty file, kept:** `viewInvalidationSeam.pin.test.ts` was uncommitted, mid-switch from `node:fs` to `ts.sys`. Diffed against the commit and kept as forward progress rather than discarded as a revert artifact — reversal 5 above confirms it was a genuine fix in flight (`data-objectstack` carries no `@types/node`, and the sibling `cloud-surface-retired-4152.pin.test.ts` records the same `ts.sys` convention).

**Redone from scratch by me:** all five reverse verifications (the previous agent died mid-reversal, so none of its results were trusted), the entire verification ladder above, the `origin/main` merge, and the history — the `wip` commit was soft-reset into one clean commit with a real message. Nothing had been pushed, so no remote state needed reconciling.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_