### PR TITLE
fix(i18n): six bare pack keys get their consumers' defaults rows (#4396)

### DIFF
--- a/.changeset/six-bare-keys-defaults-4396.md
+++ b/.changeset/six-bare-keys-defaults-4396.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/plugin-detail': patch
+'@object-ui/plugin-list': patch
+'@object-ui/plugin-designer': patch
+---
+
+Six i18n keys no longer render as raw key strings on hosts with no `I18nProvider` (objectui#4396)
+
+`detail.saving`, `list.resetSortToDefault`, `appDesigner.widgetProperties`, `appDesigner.addWidget`, `appDesigner.modeEdit` and `common.delete` were read through `createSafeTranslation` without a row in their hook's defaults table and without an inline `defaultValue` at the call site — the only two fallbacks that path has. On a provider-less host (standalone embedding, the preview gallery, host apps that never mount a provider) `fallbackT` therefore returned the key itself, so users saw `detail.saving` in the inline-edit save button, `list.resetSortToDefault` on the sort popover's reset control, `appDesigner.widgetProperties` as the dashboard inspector heading, `appDesigner.addWidget` as its toolbar label, `appDesigner.modeEdit` as a button's accessible name, and `common.delete` on the designer's destructive confirm.
+
+Each key now has a row in its consumer hook's defaults table, byte-identical to the `en` pack value. No pack was edited, no key added, no call site changed.

--- a/packages/plugin-designer/src/__tests__/bareKeysNoProviderFallback.test.tsx
+++ b/packages/plugin-designer/src/__tests__/bareKeysNoProviderFallback.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The four `useDesignerTranslation` keys objectui#4396 backfills resolve to
+ * ENGLISH when no `I18nProvider` is mounted.
+ *
+ * All four — `appDesigner.widgetProperties`, `appDesigner.addWidget`,
+ * `appDesigner.modeEdit`, `common.delete` — are among the six keys PR #4372's
+ * census measured as reading **outside** their hook's defaults table with **no
+ * inline `defaultValue`** at the call site. #4372 taught
+ * `createSafeTranslation`'s fallback to honour an inline default, which fixed
+ * the other 20 outside-table keys; these carry neither, so until this card they
+ * fell through to `fallbackT`'s last resort — the raw key. A provider-less
+ * designer showed `appDesigner.widgetProperties` as an inspector heading,
+ * `appDesigner.addWidget` as a toolbar label, `appDesigner.modeEdit` as a
+ * button's accessible name, and `common.delete` on a destructive confirm.
+ *
+ * `common.delete` is the key the census left unattributed ("outside table
+ * without default", no consumer named). Both of its call sites —
+ * `FieldDesigner.tsx` and `ObjectManager.tsx` — resolve through
+ * `useDesignerTranslation`, so the row belongs to THIS package's table, not to
+ * `packages/components`. `ObjectManager` is the cheaper of the two to mount, so
+ * it carries the pin.
+ *
+ * The call sites are bare on purpose and stay bare; the fix is four rows in
+ * `DESIGNER_DEFAULT_TRANSLATIONS`, each byte-identical to its `en` pack value.
+ *
+ * Direction: this file was RED before the change (four raw keys) and is GREEN
+ * after.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, and `initReactI18next`
+ * registers that instance as **react-i18next's module-global default**. The
+ * registration survives unmount and `cleanup()`, so one `<I18nProvider>` mount
+ * anywhere in a file silently resolves every later "no provider" render in that
+ * same file against it — a green-looking file that asserts nothing about the
+ * fallback. Vitest's `dom` project runs with `isolate: true`, so a file that
+ * never mounts a provider gets a genuinely clean global. Keep it that way:
+ * **do not import or mount `I18nProvider` here.**
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
+import type { DashboardComponentSchema, ObjectDefinition } from '@object-ui/types';
+import { DashboardEditor } from '../DashboardEditor';
+import { ObjectManager } from '../ObjectManager';
+
+vi.mock('@object-ui/plugin-grid', () => import('./__mocks__/plugin-grid'));
+vi.mock('@object-ui/plugin-form', () => import('./__mocks__/plugin-form'));
+
+const DASHBOARD = {
+  type: 'dashboard',
+  name: 'sales',
+  title: 'Sales dashboard',
+  widgets: [{ id: 'w1', type: 'metric', title: 'Revenue' }],
+} as DashboardComponentSchema;
+
+const OBJECTS: ObjectDefinition[] = [
+  {
+    id: 'obj-1',
+    name: 'accounts',
+    label: 'Accounts',
+    group: 'Custom Objects',
+    isSystem: false,
+    fieldCount: 12,
+  },
+];
+
+afterEach(() => cleanup());
+
+describe('DashboardEditor — English fallback with no provider (objectui#4396)', () => {
+  it('labels the add-widget toolbar in English, never the raw key', () => {
+    render(<DashboardEditor schema={DASHBOARD} onChange={() => {}} />);
+
+    expect(screen.getByText('Add Widget:')).toBeTruthy();
+    expect(screen.queryByText(/appDesigner\.addWidget/)).toBeNull();
+  });
+
+  it('heads the widget property panel in English, never the raw key', () => {
+    render(<DashboardEditor schema={DASHBOARD} onChange={() => {}} />);
+    fireEvent.click(screen.getByTestId('dashboard-widget-w1'));
+
+    // Non-vacuity: the panel really did mount.
+    expect(screen.getByTestId('widget-property-panel')).toBeTruthy();
+    expect(screen.getByText('Widget Properties')).toBeTruthy();
+    expect(screen.queryByText(/appDesigner\.widgetProperties/)).toBeNull();
+  });
+
+  it('names the preview toggle’s edit state in English, never the raw key', () => {
+    render(<DashboardEditor schema={DASHBOARD} onChange={() => {}} />);
+    const toggle = screen.getByTestId('dashboard-preview-toggle');
+
+    // In edit mode the toggle offers "Preview" (already in the table); the
+    // `modeEdit` half only appears once preview mode is ON, so the click is
+    // what puts this key on screen at all.
+    expect(toggle.getAttribute('aria-label')).toBe('Preview');
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-label')).toBe('Edit');
+  });
+
+  it('leaves no `appDesigner.` raw key anywhere in the editor', () => {
+    render(<DashboardEditor schema={DASHBOARD} onChange={() => {}} />);
+    fireEvent.click(screen.getByTestId('dashboard-widget-w1'));
+
+    expect(document.body.textContent).not.toMatch(/appDesigner\.[a-zA-Z]/);
+  });
+});
+
+describe('ObjectManager delete confirm — English fallback with no provider (objectui#4396)', () => {
+  it('labels the destructive confirm in English, never the raw key', async () => {
+    render(<ObjectManager objects={OBJECTS} onObjectsChange={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('grid-delete-obj-1')).toBeDefined());
+    fireEvent.click(screen.getByTestId('grid-delete-obj-1'));
+
+    // Scoped to the dialog: the stub grid renders its own "Delete" control, so
+    // an unscoped `getByText('Delete')` matches two nodes and throws.
+    const dialog = await waitFor(() => {
+      const el = document.querySelector('dialog');
+      expect(el).not.toBeNull();
+      return within(el as HTMLElement);
+    });
+
+    // `Cancel` is already in the table and pins that the dialog is mounted, so
+    // the assertions below are about the key rather than about an empty DOM.
+    expect(dialog.getByText('Cancel')).toBeTruthy();
+    expect(dialog.getByText('Delete')).toBeTruthy();
+    expect(dialog.queryByText('common.delete')).toBeNull();
+  });
+});

--- a/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
+++ b/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
@@ -107,6 +107,13 @@ const DESIGNER_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'appDesigner.widgetHeight': 'Height',
   'appDesigner.dashboardPreview': 'Dashboard Preview',
   'appDesigner.noWidgetsPreview': 'No widgets to preview',
+  // objectui#4396 — DashboardEditor's inspector heading, its add-widget picker
+  // label, and the edit half of its preview/edit toggle. All three are read
+  // bare (no inline `defaultValue`), so before these rows a provider-less host
+  // rendered the raw keys into a heading, a label and an `aria-label`.
+  'appDesigner.widgetProperties': 'Widget Properties',
+  'appDesigner.addWidget': 'Add Widget',
+  'appDesigner.modeEdit': 'Edit',
   // Page Canvas Editor
   'appDesigner.pageCanvasEditor': 'Page Canvas Editor',
   'appDesigner.emptyPage': 'Empty page. Click a button above to add a component.',
@@ -192,6 +199,12 @@ const DESIGNER_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'appDesigner.fieldDesigner.typeCategory.advanced': 'Advanced',
   // Common
   'common.edit': 'Edit',
+  // objectui#4396 — the confirm label on FieldDesigner's and ObjectManager's
+  // delete dialogs (`confirmLabel={t('common.delete')}`, read bare). The census
+  // in PR #4372 recorded this key as "outside table, no default" without naming
+  // its consumer; both call sites resolve through THIS hook, so the row belongs
+  // here beside the other borrowed `common.*` entries — not in `packages/components`.
+  'common.delete': 'Delete',
 };
 
 /**

--- a/packages/plugin-detail/src/__tests__/InlineEditSaveBar.savingNoProviderFallback.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineEditSaveBar.savingNoProviderFallback.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `InlineEditSaveBar`'s in-flight label resolves to ENGLISH when no
+ * `I18nProvider` is mounted — objectui#4396.
+ *
+ * `detail.saving` is one of the six keys PR #4372's census measured as reading
+ * **outside** its hook's defaults table with **no inline `defaultValue`** at
+ * the call site. #4372 taught `createSafeTranslation`'s fallback to honour an
+ * inline default, which fixed the other 20 outside-table keys; these six carry
+ * neither, so until this card they fell through to `fallbackT`'s last resort —
+ * the raw key. The button announced `detail.saving` to the user mid-save.
+ *
+ * The call site is bare on purpose and stays bare (`t('detail.saving')`,
+ * `InlineEditSaveBar.tsx`); the fix is the row in
+ * `DETAIL_DEFAULT_TRANSLATIONS`, byte-identical to `en.detail.saving`.
+ *
+ * Direction: this file was RED before the change (it rendered the raw key) and
+ * is GREEN after. The negative assertion is the load-bearing half — asserting
+ * only `'Saving…'` would also pass if the bar rendered both.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, and `initReactI18next`
+ * registers that instance as **react-i18next's module-global default**. The
+ * registration survives unmount and `cleanup()`, so one `<I18nProvider>` mount
+ * anywhere in a file silently resolves every later "no provider" render in that
+ * same file against it — a green-looking file that asserts nothing about the
+ * fallback. Vitest's `dom` project runs with `isolate: true`, so a file that
+ * never mounts a provider gets a genuinely clean global. Keep it that way:
+ * **do not import or mount `I18nProvider` here.**
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { InlineEditProvider, useInlineEdit } from '@object-ui/react';
+import { InlineEditSaveBar } from '../InlineEditSaveBar';
+
+/**
+ * Drives the shared inline-edit context into the one state that renders the
+ * label: `editing` (the bar returns `null` otherwise) with `saving` true.
+ */
+function Harness() {
+  const inline = useInlineEdit()!;
+  return (
+    <>
+      <button onClick={() => inline.enter('status')}>edit-enter</button>
+      <button onClick={() => inline.setSaving(true)}>edit-saving</button>
+    </>
+  );
+}
+
+function renderSavingBar() {
+  render(
+    <InlineEditProvider canEdit>
+      <Harness />
+      <InlineEditSaveBar objectName="proj" recordId="p1" data={{ updated_at: 'v1' }} />
+    </InlineEditProvider>,
+  );
+  fireEvent.click(screen.getByText('edit-enter'));
+  fireEvent.click(screen.getByText('edit-saving'));
+}
+
+afterEach(() => cleanup());
+
+describe('InlineEditSaveBar saving label — English fallback with no provider (objectui#4396)', () => {
+  it('renders the en value, never the raw key', () => {
+    renderSavingBar();
+
+    expect(screen.getByText('Saving…')).toBeTruthy();
+    expect(screen.queryByText('detail.saving')).toBeNull();
+  });
+
+  it('leaves no `detail.` raw key anywhere in the bar', () => {
+    // Non-vacuity for the case above: a bar that rendered nothing at all would
+    // satisfy `queryByText(...) === null` for the empty reason. This asserts
+    // the bar IS mounted (its Cancel control resolves) while carrying no raw
+    // key of any kind.
+    renderSavingBar();
+
+    expect(screen.getByText('Cancel')).toBeTruthy();
+    expect(document.body.textContent).not.toMatch(/detail\.[a-zA-Z]/);
+  });
+});

--- a/packages/plugin-detail/src/useDetailTranslation.ts
+++ b/packages/plugin-detail/src/useDetailTranslation.ts
@@ -39,6 +39,10 @@ export const DETAIL_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'detail.editInline': 'Edit',
   'detail.save': 'Save',
   'detail.saveChanges': 'Save changes',
+  // objectui#4396 — InlineEditSaveBar's in-flight label. Read bare
+  // (`t('detail.saving')`, no inline `defaultValue`), so before this row a
+  // provider-less host rendered the raw key `detail.saving` into the button.
+  'detail.saving': 'Saving…',
   'detail.editFieldsInline': 'Edit fields inline',
   'detail.editInlineHint': 'Double-click to edit',
   'detail.cancel': 'Cancel',

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -484,6 +484,10 @@ const LIST_DEFAULT_TRANSLATIONS: Record<string, string> = {
   // `t(key, { defaultValue })` options, never a `createSafeTranslation` table.
   'list.sortRelationalHint':
     'Columns that link to another record are not listed: they can only be sorted by the stored ID, not by the name shown in the cell. To sort by that name, denormalize it onto this object as a stored field, written when the source changes, and sort by that. Not a formula field: it is virtual, so no column is stored for it and the server refuses to sort by one.',
+  // objectui#4396 — the sort popover's reset action. Read bare
+  // (`t('list.resetSortToDefault')`, no inline `defaultValue`), so before this
+  // row a provider-less host rendered the raw key as the menu item's label.
+  'list.resetSortToDefault': 'Reset to view default',
   'list.group': 'Group',
   'list.groupBy': 'Group By',
   'list.export': 'Export',

--- a/packages/plugin-list/src/__tests__/ListView.resetSortToDefaultNoProviderFallback.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.resetSortToDefaultNoProviderFallback.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ListView`'s reset-to-declared-sort control resolves to ENGLISH when no
+ * `I18nProvider` is mounted — objectui#4396.
+ *
+ * `list.resetSortToDefault` is one of the six keys PR #4372's census measured
+ * as reading **outside** its hook's defaults table with **no inline
+ * `defaultValue`** at the call site. #4372 taught `createSafeTranslation`'s
+ * fallback to honour an inline default, which fixed the other 20 outside-table
+ * keys; these six carry neither, so until this card they fell through to
+ * `fallbackT`'s last resort — the raw key. The control in the sort popover was
+ * labelled `list.resetSortToDefault`.
+ *
+ * The call site is bare on purpose and stays bare
+ * (`t('list.resetSortToDefault')`, `ListView.tsx`); the fix is the row in
+ * `LIST_DEFAULT_TRANSLATIONS`, byte-identical to `en.list.resetSortToDefault`.
+ * That table is the same one objectui#4294 pinned byte-for-byte one row above,
+ * for the same reason: on a provider-less host it is this copy that renders.
+ *
+ * Direction: this file was RED before the change (the button's accessible name
+ * was the raw key) and is GREEN after.
+ *
+ * ── Why this is its own FILE, not a describe block ────────────────────────
+ * `createI18n` calls `instance.use(initReactI18next)`, and `initReactI18next`
+ * registers that instance as **react-i18next's module-global default**. The
+ * registration survives unmount and `cleanup()`, so one `<I18nProvider>` mount
+ * anywhere in a file silently resolves every later "no provider" render in that
+ * same file against it — a green-looking file that asserts nothing about the
+ * fallback. Vitest's `dom` project runs with `isolate: true`, so a file that
+ * never mounts a provider gets a genuinely clean global. Keep it that way:
+ * **do not import or mount `I18nProvider` here.**
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRendererProvider } from '@object-ui/react';
+import { ListView } from '../ListView';
+import type { ListViewSchema } from '@object-ui/types';
+
+const objectDef = {
+  name: 'projects',
+  label: 'Projects',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    plan_start_date: { type: 'date', label: 'Plan Start Date' },
+    status: { type: 'select', label: 'Status' },
+  },
+};
+
+// Rows matter: with an empty result set ListView renders `DataEmptyState`
+// instead of the grid, and the toolbar the sort popover hangs off never mounts.
+const ROWS = [
+  { id: 'p-1', name: 'Alpha', plan_start_date: '2026-01-01', status: 'open' },
+  { id: 'p-2', name: 'Beta', plan_start_date: '2026-02-01', status: 'done' },
+];
+
+/**
+ * The control renders only when the view DECLARES a sort — with nothing
+ * declared there is no default to return to, so the fixture must declare one.
+ */
+const DECLARED_SORT = [
+  { field: 'plan_start_date', order: 'asc' },
+  { field: 'name', order: 'asc' },
+];
+
+let prevObjectGrid: ReturnType<typeof ComponentRegistry.get>;
+
+beforeAll(() => {
+  // plugin-grid is not a dependency of plugin-list (that would be a cycle), so
+  // the grid is stubbed — the same device the neighbouring sort tests use.
+  prevObjectGrid = ComponentRegistry.get('object-grid');
+  ComponentRegistry.register('object-grid', () => <div data-testid="grid-stub" />);
+});
+
+afterAll(() => {
+  if (prevObjectGrid) ComponentRegistry.register('object-grid', prevObjectGrid);
+  else ComponentRegistry.unregister('object-grid');
+});
+
+afterEach(() => cleanup());
+
+async function openSortPanel() {
+  const dataSource = {
+    find: vi.fn().mockResolvedValue({ data: ROWS, total: ROWS.length }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(objectDef),
+  };
+  render(
+    <SchemaRendererProvider dataSource={dataSource as never}>
+      <ListView
+        schema={
+          {
+            type: 'list-view',
+            objectName: 'projects',
+            viewType: 'grid',
+            columns: ['name', 'plan_start_date', 'status'],
+            sort: DECLARED_SORT,
+          } as unknown as ListViewSchema
+        }
+        dataSource={dataSource as never}
+      />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(dataSource.getObjectSchema).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: /^sort/i }));
+  await screen.findByText('Sort Records');
+}
+
+describe('ListView reset-sort control — English fallback with no provider (objectui#4396)', () => {
+  it('names the reset control in English, never the raw key', async () => {
+    await openSortPanel();
+
+    const reset = screen.getByTestId('sort-reset-default');
+    expect(reset.textContent).toBe('Reset to view default');
+    expect(reset.textContent).not.toBe('list.resetSortToDefault');
+  });
+
+  it('leaves no `list.` raw key anywhere in the sort popover', async () => {
+    // Non-vacuity: `Sort Records` (already in the table) proves the popover is
+    // genuinely mounted, so the absence below is a fact about the keys rather
+    // than about an empty DOM.
+    await openSortPanel();
+
+    expect(screen.getByText('Sort Records')).toBeTruthy();
+    expect(document.body.textContent).not.toMatch(/list\.[a-zA-Z]/);
+  });
+});


### PR DESCRIPTION
Fixes #4396

The six keys PR #4372's census left behind — read through `createSafeTranslation` with **neither** a row in their hook's defaults table **nor** an inline `defaultValue` at the call site, the only two fallbacks that path has. `fallbackT`'s last resort is the key itself, so a provider-less host rendered the raw key string to the user.

All six were fixable in this PR's surface: one row each in the consumer hook's defaults table, byte-identical to the `en` pack value. No pack edits, no new keys, no call-site changes.

## Per-key outcome

| key | consumer hook | outcome | row added to |
|---|---|---|---|
| `detail.saving` | `useDetailTranslation` | **fixed** | `plugin-detail/src/useDetailTranslation.ts` |
| `list.resetSortToDefault` | `useListViewTranslation` | **fixed** | `plugin-list/src/ListView.tsx` (`LIST_DEFAULT_TRANSLATIONS`) |
| `appDesigner.widgetProperties` | `useDesignerTranslation` | **fixed** | `plugin-designer/src/hooks/useDesignerTranslation.ts` |
| `appDesigner.addWidget` | `useDesignerTranslation` | **fixed** | same |
| `appDesigner.modeEdit` | `useDesignerTranslation` | **fixed** | same |
| `common.delete` | `useDesignerTranslation` | **fixed** — attribution resolved, see below | same |

Every census attribution was re-verified against this branch's base rather than trusted: each key still reached through the named hook, still absent from that hook's table, still bare at the call site. None were stale.

### `common.delete` — the one the census did not attribute

The census recorded it only as "outside table, no default", and the claim comment ruled it **report-don't-fix if its call site landed in a held surface** (notably `packages/components`, held by #4386). It does not. Its two call sites are

- `plugin-designer/src/FieldDesigner.tsx:413`
- `plugin-designer/src/ObjectManager.tsx:269`

both `confirmLabel={t('common.delete')}`, and both resolve through `useDesignerTranslation`. So the row belongs in **plugin-designer**'s table, beside the `common.cancel` / `common.back` / `common.next` / `common.close` / `common.edit` entries that map already borrows from the shared namespace. Nothing in `packages/components` was touched.

`packages/collaboration` has its own `common.delete` row already (`useCollaborationTranslation.ts:110`) and is untouched — a separate hook with a separate table.

## Byte-identity

Each value was resolved by **evaluating the `en` pack**, not by reading the source near a grep hit. That mattered: `en.dashboard.addWidget` is `'Add widget'` while `en.appDesigner.addWidget` is `'Add Widget'`, and the two sit 99 lines apart in the same file. Checked codepoint by codepoint — `detail.saving` ends in U+2026, not three dots:

```
OK   detail.saving                  map="Saving…" pack="Saving…" cp=83,97,118,105,110,103,8230
OK   list.resetSortToDefault        map="Reset to view default" pack="Reset to view default"
OK   appDesigner.widgetProperties   map="Widget Properties" pack="Widget Properties"
OK   appDesigner.addWidget          map="Add Widget" pack="Add Widget"
OK   appDesigner.modeEdit           map="Edit" pack="Edit"
OK   common.delete                  map="Delete" pack="Delete"
ALL SIX BYTE-IDENTICAL
```

On the #3440 enforcement precedent the card cites: the only mechanical map-vs-pack gate in the repo today is `presence-avatars-i18n.test.tsx`'s "the collaboration defaults map mirrors the en pack", and it covers the **collaboration** map only. No equivalent gate exists for these three maps — `check:i18n-keys` judges inline `t(key, { defaultValue })` options, never a `createSafeTranslation` table, as `LIST_DEFAULT_TRANSLATIONS`'s own #4294 comment already records. **No whole-map equality test was added here**, because one would land red for a reason outside this card. Measured across all three maps, source rows against the evaluated pack:

```
plugin-detail  DETAIL_DEFAULT_TRANSLATIONS    rows 148  drifted 1  key-absent-from-pack 0
plugin-list    LIST_DEFAULT_TRANSLATIONS      rows  59  drifted 0  key-absent-from-pack 0
plugin-designer DESIGNER_DEFAULT_TRANSLATIONS rows 165  drifted 0  key-absent-from-pack 0
```

One drifted row in 372 — `detail.editFieldsInline`, `'Edit fields inline'` in the map against `'Edit fields'` in the pack. Filed as #4401 rather than fixed here: which side is correct is a copy decision, and generalizing the gate has to allow the deliberate exceptions these maps carry.

## Tests — red-first, one file per touched package

Three new files, each a **dedicated file that never mounts I18nProvider**. That is the local convention and it is load-bearing: `createI18n` calls `instance.use(initReactI18next)`, which registers the instance as react-i18next's module-global default and survives unmount and `cleanup()`, so one provider mount anywhere in a file makes every later "no provider" render in that file resolve against it — a green file asserting nothing.

- `plugin-detail/src/__tests__/InlineEditSaveBar.savingNoProviderFallback.test.tsx`
- `plugin-list/src/__tests__/ListView.resetSortToDefaultNoProviderFallback.test.tsx`
- `plugin-designer/src/__tests__/bareKeysNoProviderFallback.test.tsx`

Each case pairs a positive assertion with a negative one, and each file carries a non-vacuity assertion on a key **already** in the table (`detail.cancel`, `list.sortRecords`, `common.cancel`) so the "no raw key" sweeps are facts about the keys rather than about an empty DOM.

### Pre-fix red evidence

Reverse verification by commit-then-revert: the three map files restored to the fork point, the three test files kept. **Predicted before running — all 9 red, each rendering its raw key. Observed: 9 failed / 9.**

```
 Test Files  3 failed (3)
      Tests  9 failed (9)
```

All six keys directly witnessed in the failure output:

```
appDesigner.addWidget                                       (rendered in the toolbar label)
appDesigner.widgetProperties                                (rendered as the inspector heading)
AssertionError: expected 'appDesigner.modeEdit' to be 'Edit'
common.delete                                               (rendered on the destructive confirm)
Unable to find an element with the text: Saving…
  → "edit-enteredit-savingCanceldetail.saving"
AssertionError: expected 'list.resetSortToDefault' to be 'Reset to view default'
  → "FilterGroupSort22 recordsSort Recordslist.resetSortToDefaultSort by…"
```

Restoring the three files returns 9/9 green.

## Verification

```
pnpm exec vitest run packages/plugin-detail/ packages/plugin-list/ packages/plugin-designer/
                                              116 files, 1308 tests passed
pnpm exec vitest run (the three new files)    3 files, 9 tests passed
pnpm --filter @object-ui/plugin-detail --filter @object-ui/plugin-list \
     --filter @object-ui/plugin-designer type-check    Done (both tsc passes each)
pnpm --filter (same three) lint                        0 errors (warnings pre-existing)
node scripts/check-i18n-call-site-keys.mjs             PASS
node scripts/check-i18n-en-drift.mjs                   PASS
node scripts/check-control-bytes.mjs                   PASS
node scripts/check-changeset-presence.mjs              PASS
node scripts/check-changeset-no-major.mjs              PASS
```

Type-check first failed with `Cannot find module '@object-ui/components'` — a fresh worktree with unbuilt dependency dists, not a defect. `pnpm --filter '@object-ui/plugin-detail^...' … build` first, then clean.

Control-byte self-scan beyond the gate over all seven touched files: clean.

Changeset: `.changeset/six-bare-keys-defaults-4396.md`, **patch** on the three packages (user-visible: strings that rendered as raw keys now render English). Never `major`, per AGENTS.md's version-alignment rule.

`origin/main` moved three commits during the work and was merged in; no overlap with these three packages. One of those, #4397, put `common.select` into `packages/components`' own table — the adjacent half of the same family, which is consistent with `common.delete` belonging to plugin-designer rather than to components.

## Out of scope

**#4401** — `detail.editFieldsInline` renders `Edit fields inline` on a provider-less host and `Edit fields` in the console, because the map row and the pack disagree. The only such row in these three maps (1 of 372, measured above), and no gate can see it. Filed unassigned for triage; this PR adds six rows and deliberately does not touch existing ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_