### PR TITLE
refactor(core): retire ActionEngine's zero-caller event-mapping API (#3368)

### DIFF
--- a/.changeset/retire-action-engine-event-mapping-3368.md
+++ b/.changeset/retire-action-engine-event-mapping-3368.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/core': minor
+---
+
+Retire `ActionEngine`'s event-mapping API (objectui#3368). `ActionEngine.addMapping()`,
+`ActionEngine.dispatch()`, the private `mappings` registry behind them, and the exported
+`ActionMapping` interface are removed under enforce-or-remove: all four were public surface
+of `@object-ui/core` with zero production callers. Nothing in the repo ever registered a
+mapping, so `dispatch()` had no reachable caller either, and every call site was in the
+engine's own test file.
+
+Breaking for anyone who typed against or called the removed declarations, marked `minor`
+per this repository's version-alignment convention (the major tracks `@objectstack`, never
+an API-break count). Actions are still entered by name (`executeAction`), by location
+(`getActionsForLocation`), by shortcut (`handleShortcut`) and in bulk (`executeBulk`) —
+only the event-keyed entry point is gone, and no runtime behaviour changes because no
+runtime path reached it.
+
+The three ways the retired condition gate had drifted from the `visible` contract that
+`getActionsForLocation` implements die with the path rather than being fixed on it: it
+entered on a raw truthy check (`condition: false` dispatched anyway), typed `condition` as
+`string` only (a `{ dialect: 'cel', source }` envelope could not reach the canonical
+`@objectstack/formula` engine), and evaluated without `throwOnError` (a throwing predicate
+failed OPEN, the opposite of `visible`'s fail-closed posture). Aligning the contract of an
+API nobody calls would only have widened behaviour nobody uses.

--- a/packages/core/src/actions/ActionEngine.ts
+++ b/packages/core/src/actions/ActionEngine.ts
@@ -9,9 +9,8 @@
 /**
  * @object-ui/core - Action Engine
  * 
- * Declarative action dispatch engine. Manages action registration,
- * event-to-action mapping, location-based filtering, keyboard shortcuts,
- * and bulk operation support.
+ * Declarative action engine. Manages action registration, location-based
+ * filtering, keyboard shortcuts, and bulk operation support.
  * 
  * Replaces callback-based patterns with a schema-driven pipeline:
  *   ActionSchema[] → ActionEngine → ActionRunner → ActionResult
@@ -42,16 +41,6 @@ export interface RegisteredAction {
   bulkEnabled?: boolean;
   /** Priority for ordering (lower = first) */
   priority?: number;
-}
-
-/** Event-to-action mapping */
-export interface ActionMapping {
-  /** Event name (e.g., 'row:click', 'toolbar:save', 'keyboard:ctrl+s') */
-  event: string;
-  /** Action name to execute */
-  actionName: string;
-  /** Optional condition expression */
-  condition?: string;
 }
 
 /** Keyboard shortcut handler */
@@ -91,9 +80,35 @@ function warnHiddenPredicate(name: unknown, raw: unknown, err: unknown): void {
   );
 }
 
+/**
+ * Registration + filtering + execution for declared actions.
+ *
+ * Entry points are by NAME (`executeAction`), by LOCATION
+ * (`getActionsForLocation`), by SHORTCUT (`handleShortcut`) and in BULK
+ * (`executeBulk`). There is deliberately no entry point by arbitrary EVENT
+ * name: this class used to carry a second, parallel one — `addMapping()`
+ * registered `{ event, actionName, condition }` triples into a private
+ * `mappings` array and `dispatch(event)` ran every triple matching an event
+ * string. It was retired under enforce-or-remove (objectui#3368) because it
+ * was a public export of `@object-ui/core` with zero production callers: in
+ * its whole lifetime nothing ever registered a mapping, so `dispatch()` had
+ * no reachable caller either, and its four call sites were all in this
+ * class's own test file.
+ *
+ * Its condition gate had drifted three ways from the `visible` contract
+ * `getActionsForLocation` below implements — it entered on a raw truthy check
+ * (so `condition: false` dispatched anyway), typed `condition` as `string`
+ * only (so a `{ dialect: 'cel', source }` envelope could not reach the
+ * canonical engine), and evaluated without `throwOnError` (so a throwing
+ * predicate failed OPEN, the opposite of `visible`'s fail-closed posture).
+ * All three were retired WITH the path rather than fixed on it: aligning the
+ * contract of an API nobody calls only widens behaviour nobody uses. If an
+ * event-keyed entry point is ever genuinely needed, it must be built on the
+ * shared predicate definitions (`hasDeclaredPredicate` + `toPredicateInput`)
+ * that the surviving gate below already uses, not on a fourth spelling.
+ */
 export class ActionEngine {
   private actions = new Map<string, RegisteredAction>();
-  private mappings: ActionMapping[] = [];
   private shortcuts: ShortcutBinding[] = [];
   private normalizedShortcutMap = new Map<string, string>();
   private runner: ActionRunner;
@@ -174,12 +189,6 @@ export class ActionEngine {
     }
     this.actions.delete(name);
     this.shortcuts = this.shortcuts.filter(s => s.actionName !== name);
-    this.mappings = this.mappings.filter(m => m.actionName !== name);
-  }
-
-  /** Add an event-to-action mapping */
-  addMapping(mapping: ActionMapping): void {
-    this.mappings.push(mapping);
   }
 
   /**
@@ -320,30 +329,6 @@ export class ActionEngine {
     return this.runner.execute(registered.action);
   }
 
-  /** Dispatch an event — finds mapped actions and executes them */
-  async dispatch(event: string, contextOverride?: Partial<ActionContext>): Promise<ActionResult[]> {
-    const matchingMappings = this.mappings.filter(m => m.event === event);
-    
-    if (matchingMappings.length === 0) {
-      return [];
-    }
-
-    const results: ActionResult[] = [];
-    for (const mapping of matchingMappings) {
-      // Check condition if present
-      if (mapping.condition) {
-        const evaluator = this.runner.getEvaluator();
-        const shouldRun = evaluator.evaluateCondition(mapping.condition);
-        if (!shouldRun) continue;
-      }
-
-      const result = await this.executeAction(mapping.actionName, contextOverride);
-      results.push(result);
-    }
-
-    return results;
-  }
-
   /** Handle a keyboard shortcut event — returns true if handled */
   async handleShortcut(keys: string, contextOverride?: Partial<ActionContext>): Promise<ActionResult | null> {
     const actionName = this.normalizedShortcutMap.get(normalizeShortcut(keys));
@@ -407,10 +392,9 @@ export class ActionEngine {
     this.runner.updateContext(context);
   }
 
-  /** Clear all registered actions and mappings */
+  /** Clear all registered actions and shortcuts */
   clear(): void {
     this.actions.clear();
-    this.mappings = [];
     this.shortcuts = [];
     this.normalizedShortcutMap.clear();
   }

--- a/packages/core/src/actions/__tests__/ActionEngine.test.ts
+++ b/packages/core/src/actions/__tests__/ActionEngine.test.ts
@@ -72,12 +72,11 @@ describe('ActionEngine', () => {
   });
 
   describe('unregisterAction', () => {
-    it('removes action and its shortcuts/mappings', () => {
+    it('removes action and its shortcuts', () => {
       engine.registerAction({ name: 'save', type: 'api' }, { shortcut: 'ctrl+s' });
-      engine.addMapping({ event: 'toolbar:save', actionName: 'save' });
-      
+
       engine.unregisterAction('save');
-      
+
       expect(engine.getAction('save')).toBeUndefined();
       expect(engine.getShortcuts()).toHaveLength(0);
     });
@@ -104,35 +103,6 @@ describe('ActionEngine', () => {
       
       expect(engine.getBulkActions()).toHaveLength(1);
       expect(engine.getBulkActions()[0].name).toBe('delete');
-    });
-  });
-
-  describe('dispatch', () => {
-    it('executes mapped actions for an event', async () => {
-      engine.registerAction({ name: 'log', type: 'script', target: '"logged"' });
-      engine.addMapping({ event: 'row:click', actionName: 'log' });
-
-      const results = await engine.dispatch('row:click');
-      expect(results).toHaveLength(1);
-      expect(results[0].success).toBe(true);
-    });
-
-    it('returns empty array for unmapped events', async () => {
-      const results = await engine.dispatch('unknown:event');
-      expect(results).toEqual([]);
-    });
-
-    it('skips actions when mapping condition is false', async () => {
-      engine = new ActionEngine({ data: { status: 'locked' } });
-      engine.registerAction({ name: 'edit', type: 'script', target: '"edited"' });
-      engine.addMapping({ 
-        event: 'row:click', 
-        actionName: 'edit',
-        condition: '${data.status === "active"}'
-      });
-
-      const results = await engine.dispatch('row:click');
-      expect(results).toHaveLength(0);
     });
   });
 
@@ -206,10 +176,9 @@ describe('ActionEngine', () => {
   });
 
   describe('clear', () => {
-    it('removes all actions, mappings, and shortcuts', () => {
+    it('removes all actions and shortcuts', () => {
       engine.registerAction({ name: 'save', type: 'api' }, { shortcut: 'ctrl+s' });
-      engine.addMapping({ event: 'test', actionName: 'save' });
-      
+
       engine.clear();
       
       expect(engine.getAction('save')).toBeUndefined();


### PR DESCRIPTION
Fixes #3368

## The ruling

Maintainer ruling of 2026-08-11, recorded on #3368 by the triage seat and quoted verbatim:

> **Maintainer ruling — 2026-08-11.** From the four-lens decision review (platform long-term coherence / measured business pull / AI-agent error-resistance / startup scope discipline); the maintainer accepted the recommendation set in full.
>
> Ruling: **retire `addMapping`** — the enforce-or-remove default for a zero-caller public export; no usage plan exists. Remove the export and its dead registration path. State: `finding` → `pm:queue`.

## Zero-caller evidence, re-measured at this branch point (`f762f5bdf`)

The premise **holds**, unchanged from the four HOLD re-verifications on the card.

| Symbol | Where it occurred, before deletion | Production callers |
|---|---|---|
| `addMapping` | `packages/core/src/actions/ActionEngine.ts:181` (definition) + `__tests__/ActionEngine.test.ts:77, :113, :128, :211` | **0** |
| `ActionEngine.dispatch` | `ActionEngine.ts:324` (definition) + `__tests__/ActionEngine.test.ts:115, :121, :134` | **0** |
| `ActionMapping` | `ActionEngine.ts:48` (interface), `:96` (the private `mappings` field), `:181` (the `addMapping` parameter type) | **0** |

Commands, word-boundary aware, whole tree with `node_modules` excluded:

```
$ git grep -nw 'addMapping' -- . ':!**/node_modules/**'
packages/core/src/actions/ActionEngine.ts:181:  addMapping(mapping: ActionMapping): void {
packages/core/src/actions/__tests__/ActionEngine.test.ts:77:      engine.addMapping({ event: 'toolbar:save', actionName: 'save' });
packages/core/src/actions/__tests__/ActionEngine.test.ts:113:      engine.addMapping({ event: 'row:click', actionName: 'log' });
packages/core/src/actions/__tests__/ActionEngine.test.ts:128:      engine.addMapping({
packages/core/src/actions/__tests__/ActionEngine.test.ts:211:      engine.addMapping({ event: 'test', actionName: 'save' });
```

`dispatch` is a common word in this repo (116 files match it), so it was scoped to the
method rather than the token. Three checks, all clean:

- `git grep -nE '\.dispatch\(' -- packages apps examples scripts` (CHANGELOG excluded) returns **exactly three** hits, all `engine.dispatch(...)` in `ActionEngine.test.ts`.
- Indirect access: `git grep -nE "\[[\"'](dispatch|addMapping)[\"']\]"` returns **zero** hits repo-wide, so nothing reached either method through a string key.
- `packages/react/src/hooks/useActionEngine.ts` — the one React wrapper around this class — contains **zero** occurrences of `dispatch`, `addMapping` or `ActionMapping`, so the hook never re-exposed the event-mapping surface to its consumers.

That last check is what licenses deleting `dispatch` outright: it reads only `this.mappings`,
which only `addMapping` ever wrote, so it serves the event-mapping path and nothing else. The
other four entry points (`executeAction` by name, `getActionsForLocation` by location,
`handleShortcut` by shortcut, `executeBulk` in bulk) are untouched and keep their callers.

## Export layers narrowed

`ActionMapping` **was** public API of `@object-ui/core`, reaching consumers through two star re-exports:

| Layer | Line | Change |
|---|---|---|
| `packages/core/src/actions/ActionEngine.ts` | the `export interface ActionMapping` declaration | **deleted** |
| `packages/core/src/actions/index.ts:10` | `export * from './ActionEngine.js'` | no edit — star; narrows automatically |
| `packages/core/src/index.ts:26` | `export * from './actions/index.js'` | no edit — star; narrows automatically |

Because both barrels are `export *`, the narrowing happens by deleting the declaration and
there is no barrel line to remove — recorded here so the absence of a barrel diff is not read
as an oversight. `packages/core` commits no `dist/*.d.ts` (0 tracked files under `dist/`), so
no generated surface needed regenerating. `ActionMapping` does not exist in `@object-ui/types`,
which was verified before touching that package: it was never in scope.

## Deleted

| What | Where |
|---|---|
| `ActionEngine.addMapping()` | `packages/core/src/actions/ActionEngine.ts` |
| `ActionEngine.dispatch()` | same |
| `private mappings: ActionMapping[]` (the registry state) | same |
| the `this.mappings` line in `unregisterAction()` | same |
| the `this.mappings` line in `clear()` | same |
| `export interface ActionMapping` | same |
| 4 `addMapping` call sites + the 3-test `describe('dispatch')` block | `packages/core/src/actions/__tests__/ActionEngine.test.ts` |

Two of the four `addMapping` call sites were in tests that cover something else, so those
tests were **kept** and only the mapping-specific lines removed — `unregisterAction`'s test
(its assertions were already on `getAction` / `getShortcuts`, never on mappings) and
`clear`'s test (same). Both titles lost their now-false `mappings` clause. The three tests
inside `describe('dispatch')` covered only the deleted path and went whole.

## The three contract inconsistencies die with the path

Per the ruling and the dispatch, the inconsistencies recorded on the card are **not** fixed
anywhere and are **not** ported into a doc note as live behaviour:

- entry gate was a raw truthy check, so `condition: false` dispatched anyway (08-09 addendum);
- `condition` typed as `string` only, so a `{ dialect: 'cel', source }` envelope could not reach the canonical `@objectstack/formula` engine;
- evaluated without `throwOnError`, so a throwing predicate failed OPEN — the opposite of `visible`'s fail-closed posture in `getActionsForLocation`.

Aligning the contract of an API nobody calls would only have widened behaviour nobody uses,
which is the reasoning the card itself gave for grading this observation-class.

## Retirement record — a doc note at the survivor site, per measured precedent

`git log -S` on the prior core-export retirements gives the convention. Commit `d9d346307`
("retire four zero-consumer declared surfaces (#4328) (#4366)") contains all three shapes:

| Prior retirement | Record it left | Why |
|---|---|---|
| `mergeViewsIntoObjects` (core public export, whole file) | barrel line + changeset only, no pin, no tombstone | the declaration site went away entirely |
| `RoleDefinition.permissions` (member of a **surviving** exported type) | expanded docblock on the surviving interface naming what was retired, why, and the issue number | the type survives and a reader needs the history |
| `RecordContextValue.loading` / `error` | negative pin test **added** | live wiring (a memo dependency list) could half-land silently |

This card is the middle shape: members removed from a surviving exported class. So it follows
`RoleDefinition`'s convention — a retirement note on the `ActionEngine` class docblock naming
the retired methods, the registry behind them, the issue, and the three drifted behaviours as
**history**, plus a forward instruction that any future event-keyed entry point must be built
on the shared `hasDeclaredPredicate` + `toPredicateInput` definitions rather than a fourth
spelling. The file header's own "event-to-action mapping" clause was removed in the same pass.

**No negative pin**, and that is a measured decision rather than an omission: the pin in the
third row exists because dead wiring could reappear without any gate noticing. Here it cannot —
every residual reference to the deleted registry is a **compile error**, and the repo-wide
`type-check` below is the gate that would catch a resurrection. That is the same reasoning
that left `mergeViewsIntoObjects` and `RoleDefinition.permissions` unpinned in the precedent
commit.

## Post-deletion sweep — each symbol individually

Every residual hit lands in the intentional retirement note; nothing else survives anywhere in the tree.

| Symbol | Residual hits after deletion |
|---|---|
| `addMapping` | 1 — `ActionEngine.ts:89`, inside the retirement docblock |
| `ActionMapping` | **0** repo-wide |
| `.dispatch(` | **0** across `packages` / `apps` / `examples` / `scripts` |
| `mappings` in `packages/core` | 1 — `ActionEngine.ts:91`, the same docblock |
| `event-to-action` / `event mapping` | 0 outside the docblock (the remaining tree hits are unrelated `drill-event mapping` CHANGELOG rows) |

No README, guide, ADR or doc page ever documented this API, so nothing needed retargeting —
that absence was measured, not assumed.

## Changeset grading

`.changeset/retire-action-engine-event-mapping-3368.md` — `@object-ui/core`: **minor**.

Graded by the measured precedent, not by feel. `ActionMapping` was reachable as
`@object-ui/core`'s public export through the two star barrels above, and `addMapping` /
`dispatch` were public methods of the exported `ActionEngine` class, so **the public surface
narrows** and code typing against or calling any of them stops compiling. That is exactly the
case `d9d346307` graded `'@object-ui/core': minor` for `mergeViewsIntoObjects`, and the same
grading #4403 applied to `common.search` for narrowing an exported type. It is not `patch`:
`patch` would have been right only if the symbols had turned out unexported from the package
barrel, and the export-layer table above measures that they were not. Never `major`, per the
version-alignment rule (the major tracks `@objectstack`; breaking changes ship as `minor` with
the semantics spelled out in the body).

No runtime behaviour changes, because no runtime path reached the deleted code.

## Verification

| Step | Result |
|---|---|
| `pnpm --filter '@object-ui/core^...' build` (build closure first, fresh worktree) | green |
| repo-root `pnpm exec vitest run packages/core/ --maxWorkers=2` | **Test Files 82 passed (82), Tests 1713 passed (1713)** |
| `pnpm --filter @object-ui/core type-check` — **both** tsc commands (`tsc --noEmit && tsc -p tsconfig.test.json`) | green; core's tests compile post-tranche-5 and still do |
| repo-wide `pnpm exec turbo run type-check --concurrency=2` | **78 successful, 78 total** |
| `turbo run lint --filter=@object-ui/core` | **0 errors** (529 pre-existing warnings, all `no-explicit-any` / unused-directive in untouched files) |
| `node scripts/check-control-bytes.mjs` | OK, 4119 tracked text files |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the three changed files | clean |
| `check-changeset-presence.mjs` / `check-changeset-no-major.mjs` | OK / no major |

All heavy runs were serialized through the shared `flock` verification lock and capped at
`--max-old-space-size=4096`.

The repo-wide `type-check` is the **load-bearing** step for this change: an export removal is
only safe if no downstream package typed against it, and 78/78 green across every package,
app and example is that proof. Note the direction — this is the whole workspace, not a
filtered upstream closure, so it necessarily includes every consumer of `@object-ui/core`.

## Reverse verification (direction predicted before running)

Per the #4365 retirement pattern, the zero-caller evidence plus the green ladder after
deletion **is** the verification, and it is what the table above records. Predicted direction
before running: green throughout, because a deletion with zero callers cannot turn a consumer
red — a red anywhere would have falsified the premise rather than revealed a bug in the patch.
That is what measured.

No negative pin was added (see the grading above), so there is no scratch re-introduction to
show red — the compile-time proof is the repo-wide `type-check`, whose 78/78 green is the same
assertion a pin would have made, executed against every package rather than one.

## Surface discipline

Touched exactly three files, all inside the dispatch's stated surface:
`packages/core/src/actions/ActionEngine.ts`, its test, and the changeset. No barrel file
needed editing (both are `export *`), and `packages/types` was verified not to contain
`ActionMapping` before being left alone. None of the parallel agents' reserved surfaces —
`scripts/**` new gates (#4394), the defaults-map files and mirror suite (#4401),
`packages/fields/**` (#4361), `packages/plugin-charts/**` (#4405),
`packages/app-shell/src/views/metadata-admin/**` (#4406) — was read or modified.

No out-of-scope findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
