### PR TITLE
refactor(components): derive the row-menu predicate parameters from the authoring type (#4354)

### DIFF
--- a/.changeset/data-table-row-menu-predicate-derive-4354.md
+++ b/.changeset/data-table-row-menu-predicate-derive-4354.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/components': patch
+---
+
+data-table row menu — the built-in Edit/Delete predicate parameters are derived from the authoring type, not hand-restated
+
+One authoring shape (`DataTableSchema.rowEditPredicates` / `rowDeletePredicates`, objectui#2614) had grown four separate declarations in `renderers/complex/data-table.tsx`: the shared `isBuiltinRowActionVisible` gate and `planDataTableRowMenu` each hand-wrote `{ visibleWhen?: unknown }`, and the row-menu ITEM component hand-wrote the full `{ visibleWhen?: unknown; disabledWhen?: unknown }` pair. Nothing tied any of them to the type whose values they receive, so a rename in `@object-ui/types` would have left all four compiling against a shape that no longer existed — the objectui#3009 hand-copy family, in miniature.
+
+Each one now derives. The planner keeps its deliberate visibility-only subset, `Pick`ed from the very key its caller passes (`Pick<NonNullable<DataTableSchema['rowEditPredicates']>, 'visibleWhen'>` and the delete twin), so the signature still tells the truth about what the function reads while becoming structurally unable to drift from what it subsets. The two consumers that serve both built-ins share one derived alias taken from the union of the twins, so they may only read keys both schema keys declare. Measured: with `visibleWhen` renamed in `@object-ui/types`, the previous hand-written declarations still type-check clean, the derived ones fail to compile.
+
+No behavior change — no runtime code was touched, and the package's suite passes unchanged. Alongside it, the "a disabled item still counts toward the menu" rule gains the pin it never had where a user meets it: a row whose only action is `disabledWhen`-gated keeps its "⋮" trigger, and that trigger opens the item, present and `aria-disabled`. The two halves of that rule live in different functions, and each half's own test stayed green while the other regressed.

--- a/packages/components/src/renderers/complex/__tests__/data-table-row-menu-empty-guard.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-row-menu-empty-guard.test.tsx
@@ -24,7 +24,7 @@
  * header no matter which rows kept a trigger.
  */
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
@@ -45,6 +45,8 @@ const MIXED_ROWS = [
 
 /** The real `userActions.edit.visibleWhen` shape (objectui#2614). */
 const NOT_FROZEN = 'record.frozen != true';
+/** Its `disabledWhen` counterpart — HOLDS for the frozen rows, so they grey out. */
+const IS_FROZEN = 'record.frozen == true';
 
 const BASE_SCHEMA = {
   type: 'data-table',
@@ -152,6 +154,37 @@ describe('data-table row overflow menu — the trigger counts renderable items (
     });
     expect(triggers()).toHaveLength(0);
   });
+
+  /**
+   * The other side of #3562's rule, observed where a user meets it: a row whose
+   * only item is greyed out is NOT an empty menu. `disabledWhen` is a rendering
+   * verdict, not a visibility one, so the item counts, the trigger survives, and
+   * what it opens is that item — present and `aria-disabled` (objectui#4354).
+   *
+   * End-to-end on purpose: the two halves live apart — the count in
+   * `planDataTableRowMenu`, the greying in `DataTableBuiltinRowActionItem` — and
+   * each half's own test stays green while the other regresses. Neither could
+   * observe this pairing before: the planner's cases read its return value, and
+   * the item's own cases (`data-table-builtin-row-action-predicates.test.tsx`)
+   * render the item directly inside an already-open menu, never through the
+   * table that decides whether a trigger exists at all.
+   */
+  it('keeps the trigger for a row whose only item renders merely DISABLED', async () => {
+    renderTable({
+      data: FROZEN_ROWS,
+      onRowEdit: () => {},
+      rowEditPredicates: { disabledWhen: IS_FROZEN },
+    });
+
+    // Counted: a greyed-out item is still an item, so every row keeps its "⋮".
+    expect(triggers()).toHaveLength(FROZEN_ROWS.length);
+
+    // Radix opens on `pointerdown` (a plain click does nothing) and portals its
+    // content on the next tick, hence the async find.
+    fireEvent.pointerDown(triggers()[0], { button: 0, ctrlKey: false, pointerType: 'mouse' });
+    const item = await screen.findByTestId('row-action-builtin-edit');
+    expect(item).toHaveAttribute('aria-disabled', 'true');
+  });
 });
 
 /**
@@ -222,18 +255,24 @@ describe('planDataTableRowMenu', () => {
     expect(plan.count).toBe(2);
   });
 
-  it('still counts an item that renders merely DISABLED', () => {
+  // Renamed from "still counts an item that renders merely DISABLED"
+  // (objectui#4354). The planner never reads `disabledWhen`, so this fixture
+  // behaves identically to `{}` and could not pin the disabled-counting claim
+  // its old name made — that claim now lives where it can actually be observed,
+  // in "keeps the trigger for a row whose only item renders merely DISABLED"
+  // above. What survives here is the verdict this case really does decide, and
+  // it is worth deciding: a predicate object is not itself a gate.
+  it('an object with no `visibleWhen` does not hide the item', () => {
     // Typed as what the production caller actually hands the planner —
     // `schema.rowEditPredicates`, whose declared shape carries `disabledWhen`
     // alongside `visibleWhen` (`@object-ui/types`, objectui#2614). The planner's
-    // own parameter names only `visibleWhen`, because visibility is all it
-    // decides; a bare object literal therefore tripped excess-property checking
-    // once this package started type-checking its tests, while the identical
-    // value reaches it unremarked in production (objectui#4040). Deriving the
-    // annotation keeps the fixture honest about which key is being ignored,
-    // rather than deleting the key and quietly renaming the case.
+    // own parameter is now `Pick`ed from that same key rather than hand-restated
+    // (#4354), so it stays the deliberate `visibleWhen`-only subset: a bare
+    // object literal still trips excess-property checking, while the identical
+    // value reaches it unremarked in production (objectui#4040). Annotating from
+    // the authoring type keeps the fixture honest about which key is ignored.
     const editPredicates: DataTableSchema['rowEditPredicates'] = {
-      disabledWhen: 'record.frozen == true',
+      disabledWhen: IS_FROZEN,
     };
     const plan = planDataTableRowMenu({
       onRowEdit: noop,

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -189,6 +189,23 @@ function extractSaveErrorMessage(error: unknown): string {
 type RowActionDef = NonNullable<DataTableSchema['rowActionDefs']>[number];
 
 /**
+ * The authoring shape of the built-in row Edit/Delete predicates — derived from
+ * `DataTableSchema`, never restated by hand (objectui#4354). Everything below
+ * reads what the production caller hands it (`schema.rowEditPredicates` /
+ * `rowDeletePredicates`), so a hand-written `{ visibleWhen?: unknown; … }` here
+ * would be a second definition of one authoring shape, free to drift from the
+ * type it is supposed to mirror without a single test going red.
+ *
+ * The union of the two twins is deliberate: every consumer below serves BOTH
+ * built-ins (`name: 'edit' | 'delete'`), so it may only read keys that BOTH
+ * schema keys declare — if either twin dropped one, the read stops compiling
+ * instead of silently reading `undefined`.
+ */
+type BuiltinRowPredicates = NonNullable<
+  DataTableSchema['rowEditPredicates'] | DataTableSchema['rowDeletePredicates']
+>;
+
+/**
  * Evaluate a row-action visibility predicate the way the row menu's items do —
  * on the canonical CEL engine, failing CLOSED with a diagnosable warning — but
  * WITHOUT a hook.
@@ -234,9 +251,14 @@ function evalRowActionVisibility(
  *
  * `visibleWhen` counts as a declared gate by `!= null`, not by truthiness —
  * `visibleWhen: false` hides the item rather than reading as "ungated".
+ *
+ * The parameter is consumption-shaped — visibility is all this decides, so
+ * `disabledWhen` is deliberately absent — but `Pick`ed from the authoring type
+ * rather than hand-written, so it is a SUBSET of that type by construction
+ * (objectui#4354).
  */
 export function isBuiltinRowActionVisible(
-  predicates: { visibleWhen?: unknown } | undefined,
+  predicates: Pick<BuiltinRowPredicates, 'visibleWhen'> | undefined,
   name: 'edit' | 'delete',
   row: any,
   scope: Record<string, unknown>,
@@ -296,13 +318,23 @@ export interface DataTableRowMenuPlan {
  * trigger decision lives here and is recomputed for every row.
  *
  * Only visibility is decided here — a `disabled` item still renders (greyed
- * out) and still counts, exactly as before.
+ * out) and still counts, exactly as before. That counting is pinned where it
+ * can be OBSERVED, on the rendered menu, by
+ * `data-table-row-menu-empty-guard.test.tsx`'s "keeps the trigger for a row
+ * whose only item renders merely DISABLED".
+ *
+ * The predicate parameters are consumption-shaped — this function reads
+ * `visibleWhen` and nothing else, and the signature keeps saying so — but each
+ * is `Pick`ed from the authoring key its production caller passes, rather than
+ * hand-restated (objectui#4354). Same subset, minus the drift: a rename in
+ * `@object-ui/types` fails here at compile time instead of leaving a stale
+ * hand-copy that still type-checks against nothing.
  */
 export function planDataTableRowMenu(input: {
   onRowEdit?: unknown;
   onRowDelete?: unknown;
-  editPredicates?: { visibleWhen?: unknown };
-  deletePredicates?: { visibleWhen?: unknown };
+  editPredicates?: Pick<NonNullable<DataTableSchema['rowEditPredicates']>, 'visibleWhen'>;
+  deletePredicates?: Pick<NonNullable<DataTableSchema['rowDeletePredicates']>, 'visibleWhen'>;
   customActions: readonly RowActionDef[];
   row: any;
   scope: Record<string, unknown>;
@@ -392,7 +424,11 @@ export const DataTableRowActionItem: React.FC<{
  */
 export const DataTableBuiltinRowActionItem: React.FC<{
   name: 'edit' | 'delete';
-  predicates?: { visibleWhen?: unknown; disabledWhen?: unknown };
+  /**
+   * The whole authoring pair, because this component reads both keys — derived
+   * from `DataTableSchema` rather than hand-copied (objectui#4354).
+   */
+  predicates?: BuiltinRowPredicates;
   row: any;
   icon: React.ReactNode;
   label: string;


### PR DESCRIPTION
Fixes #4354

## Three hand-copies (four, once counted) collapse to one derivation

One authoring shape — `DataTableSchema.rowEditPredicates` / `rowDeletePredicates` (objectui#2614) — had grown four independent declarations inside `packages/components/src/renderers/complex/data-table.tsx`, none of which referenced the type whose values they receive:

| site | was | reads |
|---|---|---|
| `isBuiltinRowActionVisible` | `{ visibleWhen?: unknown }` | `visibleWhen` |
| `planDataTableRowMenu` (x2 params) | `{ visibleWhen?: unknown }` | `visibleWhen` |
| `DataTableBuiltinRowActionItem` | `{ visibleWhen?: unknown; disabledWhen?: unknown }` | both |

The issue counted three; the shared gate is a fourth, three lines above the planner, and leaving it hand-written would have kept a copy of the very shape this change exists to stop duplicating.

Per the ruling (option **b**, derivation over widening), each site now derives, and the signatures keep telling the truth about what each function reads:

- `planDataTableRowMenu` stays consumption-shaped — it decides visibility and nothing else — but each parameter is `Pick`ed from the exact schema key its production caller passes: `editPredicates?: Pick< NonNullable< DataTableSchema['rowEditPredicates'] >, 'visibleWhen' >`, and the delete twin from `rowDeletePredicates`. Same subset as before, minus the drift.
- The two consumers that serve **both** built-ins (`isBuiltinRowActionVisible`, and the item component whose prop is `name: 'edit' | 'delete'`) share one derived alias taken from the union of the twins, so they may only read keys that both schema keys declare — if either twin dropped one, the read stops compiling instead of silently reading `undefined`.

### The ITEM component: derived, not left

It was a hand-copy of the full pair with no reason to be one — it evaluates both keys, so it derives the whole authoring shape (`BuiltinRowPredicates`) rather than a `Pick`. This is the site with the most to gain; see the measurement below.

No runtime code was touched. `@object-ui/types` is untouched — this derives **from** it.

## The rider: measured unpinned, now pinned

**Measurement.** The rule "an item that renders merely disabled still counts toward the menu's non-empty decision" was **not** pinned anywhere that could observe it:

- `data-table-row-menu-empty-guard.test.tsx`'s `still counts an item that renders merely DISABLED` asserted the **planner's return value**, and the planner never reads `disabledWhen` — the fixture behaved identically to `{}`, which is what made it vacuous.
- `data-table-builtin-row-action-predicates.test.tsx` does pin the disabled **rendering** observably (`aria-disabled` + click suppressed), but it renders the item directly inside an already-open dropdown — it never goes through the table, so it cannot see whether the row got a trigger at all.
- The table-level DOM cases in the guard file used only `visibleWhen`. Nothing joined the two halves.

**Added** (`keeps the trigger for a row whose only item renders merely DISABLED`): a table whose single action is `disabledWhen`-gated keeps its per-row trigger, and opening that trigger finds the item present and `aria-disabled="true"`. End-to-end, because the two halves live in different functions and each half's own test stays green while the other regresses — demonstrated below.

**The vacuous case is renamed**, not deleted: `an object with no visibleWhen does not hide the item`. That is the verdict it actually decides, it is worth deciding, and the misleading name is gone. Its comment now points at where the disabled-counting claim really lives. The derived annotation on its fixture (tranche 4's work) is kept and still necessary: the planner's parameter remains a deliberate `visibleWhen`-only subset, so a bare object literal still trips excess-property checking.

## Reverse verification

**1. The derivation tracks its source — and the reported direction is not the one the template presumes.** Renaming `visibleWhen` to `visibleWhenRenamed` in `@object-ui/types` (scratch, reverted), then type-checking `@object-ui/components` both ways:

- **Derived (this PR): 7 errors**, three of them `TS2344` pointed straight at the derived declarations themselves — the compiler names the line that must be updated.
- **Hand-written (`origin/main`): 2 errors**, and this is the interesting half. I predicted green; it is not quite green, but the two errors are incidental — TS *weak type* detection firing at a **call site** ("has no properties in common"), never at a declaration. The declarations all compile clean against a type that no longer has the key.
- **The item component drifts completely silently in the hand-written form**: its hand-copy keeps `disabledWhen` in common with the renamed type, so weak-type detection is satisfied, and neither its declaration nor either of its two call sites produces a single diagnostic. It would go on reading `predicates.visibleWhen === undefined` forever — i.e. the built-in gate silently becomes "always visible". Derived, that exact path is `TS2345` at the line where the item hands its predicates to the visibility gate.

That is the real value here, and it is stronger than "before green, after red": the compiler goes from *silent on the site that matters* to *naming it*.

(Recorded for the next reader: this package's `tsconfig.json` overrides the root `paths`, so `@object-ui/types` resolves through the built `.d.ts`, not sources. The first run of this simulation was a false green until `@object-ui/types` was rebuilt.)

**2. The new pin is red-first against the counting half.** Scratch: make a `disabledWhen`-gated item not count toward the trigger. Predicted the new pin red and every planner-level case green — measured exactly that: `1 failed | 21 passed`, the failure being `expected [] to have a length of 2`. Every pre-existing case, including the renamed planner one, stayed green — which is precisely why the pin was needed.

**3. And against the rendering half.** Scratch: let the item return `null` when disabled. Predicted two reds — the new pin plus the pre-existing item-level case. Measured `2 failed | 20 passed`, both `Unable to find an element by: [data-testid="row-action-builtin-edit"]`.

Both scratches reverted; the tree was re-verified green afterwards.

## Verification

- `pnpm exec vitest run packages/components/ --maxWorkers=2` (repo root) — **121 files / 1078 tests passed**, no failures.
- `tsc --noEmit` **and** `tsc -p tsconfig.test.json` for `@object-ui/components` — both exit 0 (build closure built first).
- `eslint` on both touched files — exit 0, 0 errors; the 5 remaining `no-explicit-any` warnings are pre-existing `as any` casts on untouched lines.
- `check-control-bytes` / `check-phantom-dependencies` / `check-spec-symbol-derivation` / `check-changeset-presence` / `check-changeset-no-major` — all green.
- Changeset: `patch` for `@object-ui/components`, never `major`.

## Scope

Only `packages/components` plus the changeset. Nothing in `packages/fields`, `plugin-charts`, `plugin-chatbot` or `plugin-dashboard` was touched. No out-of-scope findings to file.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_