### PR TITLE
refactor(fields): the currency adornment's symbol has one channel (#4414)

### DIFF
--- a/.changeset/dead-currency-symbol-map.md
+++ b/.changeset/dead-currency-symbol-map.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/fields': patch
+---
+
+fields: the currency adornment has one symbol channel
+
+`CurrencyField` carried the same one-entry fact twice — a dead `CURRENCY_SYMBOLS`
+map that nothing read, and a live `currency === 'USD' ? '$' : currency` ternary
+two lines below it. Both were hand copies of knowledge `Intl` already carries,
+and both are gone: a new `currencySymbol(currency, locale)` beside
+`currencyFractionDigits()` reads the `currency` part of the very format the
+widget's readonly branch already renders amounts with.
+
+USD is unchanged at the display-locale default. Other currencies now show their
+real symbol instead of the bare ISO code — `€` for EUR, `¥` for JPY, `£` for
+GBP — which is what the same widget's readonly mode has always displayed; the
+edit adornment simply stopped disagreeing with it. Currencies CLDR has no symbol
+for (KWD, BHD, CHF, ISK, CLP) still render their code, exactly as before.

--- a/packages/fields/src/__tests__/CurrencyField.symbol.test.tsx
+++ b/packages/fields/src/__tests__/CurrencyField.symbol.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4414 — the edit-mode currency adornment has ONE channel.
+ *
+ * Before this card `CurrencyField.tsx` carried the same one-entry fact twice: a
+ * `CURRENCY_SYMBOLS` map that nothing read, and, two lines below it, the live
+ * `currency === 'USD' ? '$' : currency` ternary. The PM ruling (issue #4414,
+ * claim comment) says one channel survives, and that `Intl` — which already
+ * carries this knowledge — is the candidate to MEASURE first.
+ *
+ * Measured, and it fits: `Intl.NumberFormat(locale, { style: 'currency',
+ * currency }).formatToParts()` has a `currency` part, and that part is exactly
+ * the string the widget's OWN readonly branch already renders, because the
+ * readonly branch formats through `formatDisplayNumber(value, { locale,
+ * currency })` — the same `Intl` call. So the adornment was the last hand copy,
+ * and the widget disagreed with itself: at `en`, readonly JPY rendered
+ * `¥1,235` while the edit adornment beside it said `JPY`.
+ *
+ * The one place this helper deliberately DIVERGES from its sibling
+ * `currencyFractionDigits()`: the digit count is locale-independent (measured
+ * across eight locales in `currency.ts`), so that probe drops the locale. The
+ * SYMBOL is not — measured on node 22 / full-ICU:
+ *
+ *     USD -> "$" (en, en-US, de-DE, ja-JP) | "US$" (en-GB, zh-CN) | "$US" (fr-FR)
+ *     JPY -> "¥" (en, de-DE) | "￥" (ja-JP) | "JP¥" (en-GB, zh-CN) | "JPY" (fr-FR)
+ *
+ * so `currencySymbol()` takes the display locale as a parameter and caches on
+ * the PAIR. Keying the cache on the code alone would let whichever locale asked
+ * first answer for every locale after it — pinned below, because that is a
+ * silent wrong-answer bug and not a hypothetical.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LocalizationProvider } from '@object-ui/i18n';
+import { CurrencyField } from '../widgets/CurrencyField';
+import { currencySymbol } from '../currency';
+
+/**
+ * ICU separates a currency CODE from the amount with U+00A0 and sets a SYMBOL
+ * flush against it; normalizing keeps the readonly-agreement pins about the
+ * SYMBOL rather than about ICU's spacing. Written as an escape, never a pasted
+ * byte.
+ */
+const normalizeNbsp = (s: string | null) => (s ?? '').replace(/\u00a0/g, ' ');
+
+const renderField = (
+  field: Record<string, unknown>,
+  opts: { readonly?: boolean; locale?: string; tenantCurrency?: string } = {},
+) =>
+  render(
+    <LocalizationProvider value={{ locale: opts.locale ?? 'en', currency: opts.tenantCurrency }}>
+      <CurrencyField
+        value={1234.5}
+        onChange={vi.fn()}
+        field={{ type: 'currency', ...field } as any}
+        readonly={opts.readonly}
+      />
+    </LocalizationProvider>,
+  );
+
+/** The edit-mode prefix adornment: the only `span` inside the wrapper. */
+const adornment = (container: HTMLElement) =>
+  container.querySelector('div.relative > span')?.textContent ?? null;
+
+describe('CurrencyField adornment — USD is byte-identical at the display-locale default (objectui#4414)', () => {
+  it("`en` — useDisplayLocale()'s own last resort — still renders exactly `$`", () => {
+    const { container } = renderField({ currency: 'USD' });
+    expect(adornment(container)).toBe('$');
+  });
+
+  it('`en-US` still renders exactly `$`', () => {
+    const { container } = renderField({ currency: 'USD' }, { locale: 'en-US' });
+    expect(adornment(container)).toBe('$');
+  });
+
+  it('the tenant default currency reaches the adornment too (ADR-0053)', () => {
+    const { container } = renderField({}, { tenantCurrency: 'USD' });
+    expect(adornment(container)).toBe('$');
+  });
+
+  it('a field with NO currency still renders no adornment and no left padding', () => {
+    const { container } = renderField({});
+    expect(adornment(container)).toBeNull();
+    expect(container.querySelector('input')).not.toHaveClass('pl-8');
+  });
+
+  it('a field WITH a currency still gets the left padding that clears the adornment', () => {
+    const { container } = renderField({ currency: 'USD' });
+    expect(container.querySelector('input')).toHaveClass('pl-8');
+  });
+});
+
+describe('CurrencyField adornment — the DOCUMENTED non-USD change: a real symbol replaces the bare code', () => {
+  // Before #4414 every one of these rendered the three-letter ISO code, because
+  // the ternary had exactly one entry. This is the deliberate improvement the
+  // ruling allowed for, not a side effect — and it is what the widget's own
+  // readonly branch has been rendering all along.
+  it.each([
+    ['EUR', '€'],
+    ['JPY', '¥'],
+    ['GBP', '£'],
+    ['INR', '₹'],
+    ['KRW', '₩'],
+  ])('%s now renders %s instead of the code', (currency, symbol) => {
+    const { container } = renderField({ currency });
+    expect(adornment(container)).toBe(symbol);
+  });
+});
+
+describe('CurrencyField adornment — currencies CLDR has no symbol for keep the code, byte-identical', () => {
+  // ICU answers with the code itself for these, which is exactly what the
+  // ternary produced. Nothing changes, and that is worth pinning: it is the
+  // half of the ruling's "symbol-vs-code nuance" that survives the change.
+  it.each(['KWD', 'BHD', 'CHF', 'ISK', 'CLP'])('%s still renders its bare code', (currency) => {
+    const { container } = renderField({ currency });
+    expect(adornment(container)).toBe(currency);
+  });
+});
+
+describe('CurrencyField adornment — it agrees with the SAME widget\'s readonly rendering', () => {
+  // The real invariant behind this card. The readonly branch already formats
+  // through the display locale, so before #4414 the widget contradicted itself
+  // for every currency with a symbol.
+  it.each([
+    ['en', 'JPY'],
+    ['en', 'EUR'],
+    ['en-GB', 'USD'],
+    ['fr-FR', 'USD'],
+    ['ja-JP', 'JPY'],
+    ['de-DE', 'USD'],
+    ['en', 'KWD'],
+  ])('%s / %s — the readonly text contains the adornment string', (locale, currency) => {
+    const edit = renderField({ currency }, { locale });
+    const symbol = adornment(edit.container);
+    expect(symbol).toBeTruthy();
+    const view = renderField({ currency }, { locale, readonly: true });
+    expect(normalizeNbsp(view.container.textContent)).toContain(symbol as string);
+  });
+});
+
+describe('currencySymbol() — the symbol is locale-dependent, so the locale is a parameter', () => {
+  it('USD is not one string across locales', () => {
+    expect(currencySymbol('USD', 'en')).toBe('$');
+    expect(currencySymbol('USD', 'fr-FR')).toBe('$US');
+    expect(currencySymbol('USD', 'en-GB')).toBe('US$');
+  });
+
+  it('JPY at ja-JP is the FULLWIDTH yen sign, a different codepoint from `en`', () => {
+    // U+FFE5 vs U+00A5 — visually near-identical, so written as escapes.
+    expect(currencySymbol('JPY', 'en')).toBe('\u00a5');
+    expect(currencySymbol('JPY', 'ja-JP')).toBe('\uffe5');
+    expect(currencySymbol('JPY', 'ja-JP')).not.toBe(currencySymbol('JPY', 'en'));
+  });
+
+  it('the cache is keyed on the PAIR — the first locale to ask must not answer for the rest', () => {
+    // The bug this pin exists for: copying `currencyFractionDigits`' code-only
+    // cache key would make these two calls return the same string, whichever
+    // ran first, for the rest of the process.
+    const first = currencySymbol('GBP', 'en-GB');
+    const second = currencySymbol('GBP', 'ar-KW');
+    expect(first).toBe('£');
+    expect(second).toBe('UK£');
+    // …and re-asking returns the cached value, not the other locale's.
+    expect(currencySymbol('GBP', 'en-GB')).toBe('£');
+  });
+});
+
+describe('currencySymbol() — neither a bad code nor a bad locale may escape as a throw', () => {
+  it('an invalid currency code falls back to the code as given', () => {
+    // `Intl` throws `RangeError: Invalid currency code` for these. The fallback
+    // is the code itself, which is both what the ternary produced and what
+    // `formatAmount`'s own bad-code branch renders beside it.
+    expect(currencySymbol('not-a-code', 'en')).toBe('not-a-code');
+    expect(currencySymbol('USDD', 'en')).toBe('USDD');
+  });
+
+  it('a malformed locale tag falls back to the code rather than crashing the widget', () => {
+    // `Intl` throws `RangeError: Incorrect locale information provided` for
+    // `en_US` (underscore) — the failure mode `currencyFractionDigits` dodged
+    // by dropping the locale entirely, which this helper cannot do.
+    expect(currencySymbol('USD', 'en_US')).toBe('USD');
+  });
+
+  it('the widget renders the code instead of throwing when the code is junk', () => {
+    const { container } = renderField({ currency: 'not-a-code' });
+    expect(adornment(container)).toBe('not-a-code');
+  });
+});

--- a/packages/fields/src/currency.ts
+++ b/packages/fields/src/currency.ts
@@ -72,3 +72,73 @@ export function currencyFractionDigits(currency: string): number {
   fractionDigitsByCurrency.set(currency, digits);
   return digits;
 }
+
+/**
+ * Display symbols, memoized per **(locale, currency)** pair.
+ *
+ * The pair, not the code — and this is the one place this helper deliberately
+ * parts company with {@link currencyFractionDigits} above. The digit count is
+ * locale-independent (measured across eight locales, see that map's note), so
+ * its probe drops the locale and keys the cache on the code alone. The SYMBOL
+ * is genuinely locale-dependent, measured on the same runtime:
+ *
+ *   - `USD` → `$` at `en` / `en-US` / `de-DE` / `ja-JP`, `US$` at `en-GB` and
+ *     `zh-CN`, `$US` at `fr-FR`;
+ *   - `JPY` → U+00A5 at `en`, the FULLWIDTH U+FFE5 at `ja-JP`, `JP¥` at
+ *     `en-GB`, and the bare code `JPY` at `fr-FR`.
+ *
+ * Copying the code-only cache key would therefore let whichever locale asked
+ * first answer for every locale after it, for the life of the process — a
+ * silent wrong answer rather than a crash, so it is pinned by test.
+ *
+ * `|` is safe as the key separator: it appears in neither a BCP-47 tag nor an
+ * ISO 4217 code, so no two distinct pairs can collide on one key.
+ */
+const symbolByLocaleAndCurrency = new Map<string, string>();
+
+/**
+ * The string ICU renders in place of `currency` for a reader in `locale` — `$`
+ * for USD at `en`, `€` for EUR, U+00A5 for JPY — taken from the `currency` part
+ * of the very format the display path already uses.
+ *
+ * This is the ONE channel for the symbol (objectui#4414). It is not an
+ * independent opinion about how a currency should look: it is the same
+ * `Intl.NumberFormat(locale, { style: 'currency', currency })` that
+ * `formatDisplayNumber` formats amounts with, read one part at a time. So a
+ * widget that renders an amount in one mode and a bare symbol in another cannot
+ * disagree with itself — which is exactly what the hand-written
+ * `currency === 'USD' ? '$' : currency` ternary did, showing `JPY` beside a
+ * readonly `¥1,235`.
+ *
+ * Falls back to `currency` itself — the code as given — in the three cases
+ * where ICU cannot answer, because a bare code is a legitimate adornment (it is
+ * what ICU itself returns for KWD/BHD/CHF/ISK, and what
+ * `formatAmount`'s own bad-code branch renders beside it):
+ *
+ *  1. an invalid currency code — `Intl` throws `RangeError: Invalid currency
+ *     code`;
+ *  2. a malformed locale tag (`en_US` with an underscore, say) — `Intl` throws
+ *     `RangeError: Incorrect locale information provided`. `currencyFractionDigits`
+ *     dodged this failure mode by dropping the locale from its probe; this
+ *     helper needs the locale, so it catches instead. Neither throw may escape:
+ *     this runs during render, so an escaped `RangeError` is a blank widget.
+ *  3. no `currency` part in the output at all — not observed for
+ *     `style: 'currency'`, but coalesced rather than asserted.
+ */
+export function currencySymbol(currency: string, locale: string): string {
+  const key = `${locale}|${currency}`;
+  const cached = symbolByLocaleAndCurrency.get(key);
+  if (cached !== undefined) return cached;
+  let symbol = currency;
+  try {
+    // The formatted value is irrelevant — only the `currency` part is read — so
+    // the cheapest deterministic input is used.
+    const parts = new Intl.NumberFormat(locale, { style: 'currency', currency }).formatToParts(0);
+    symbol = parts.find((part) => part.type === 'currency')?.value ?? currency;
+  } catch {
+    // Bad code or bad locale — keep the code, and let the caller's own
+    // formatting attempt surface the real problem.
+  }
+  symbolByLocaleAndCurrency.set(key, symbol);
+  return symbol;
+}

--- a/packages/fields/src/standard-widgets.test.tsx
+++ b/packages/fields/src/standard-widgets.test.tsx
@@ -61,7 +61,14 @@ describe('Standard Field Widgets', () => {
           field={{ ...fieldMock, currency: 'EUR' } as any}
         />
       );
-      expect(screen.getByText('EUR')).toBeInTheDocument();
+      // Was `EUR`, the bare code: the adornment came from a hand-written
+      // `currency === 'USD' ? '$' : currency` ternary, so every currency but one
+      // fell through to its code. objectui#4414 converged the symbol on the
+      // single `Intl` channel the readonly branch of this same widget already
+      // formatted through, which answers `€` here — a DOCUMENTED change, pinned
+      // in full (with the locale-dependence it brings) in
+      // `__tests__/CurrencyField.symbol.test.tsx`.
+      expect(screen.getByText('€')).toBeInTheDocument();
     });
   });
 

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -3,7 +3,7 @@ import { Input, EmptyValue } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { useLocalization, useDisplayLocale, formatDisplayNumber } from '@object-ui/i18n';
-import { resolveFieldCurrency, currencyFractionDigits } from '../currency';
+import { resolveFieldCurrency, currencyFractionDigits, currencySymbol } from '../currency';
 
 /**
  * Format currency value for display. When `currency` is undefined the value
@@ -45,10 +45,6 @@ function formatAmount(
     return value.toFixed(precision);
   }
 }
-
-const CURRENCY_SYMBOLS: Record<string, string> = {
-  USD: '$',
-};
 
 export function CurrencyField({ value, onChange, field, readonly, error, className, ...props }: FieldWidgetComponentProps<number>) {
   const currencyField = field as any;
@@ -96,7 +92,16 @@ export function CurrencyField({ value, onChange, field, readonly, error, classNa
     }
   };
 
-  const symbol = currency ? (currency === 'USD' ? '$' : currency) : '';
+  // ONE channel for the symbol (objectui#4414). This used to be a hand-written
+  // `currency === 'USD' ? '$' : currency` ternary, with a dead one-entry
+  // `CURRENCY_SYMBOLS` map sitting two lines above it restating the same fact —
+  // a table that looked like the place to add a currency but that nothing read.
+  // Both were hand copies of knowledge `Intl` already carries, and both are
+  // gone: `currencySymbol` reads the `currency` part of the SAME format the
+  // readonly branch above renders amounts with, so the two modes of this widget
+  // can no longer disagree (they did: `JPY` in the adornment, `¥1,235` in the
+  // readonly span). USD at the display-locale default is `$` either way.
+  const symbol = currency ? currencySymbol(currency, locale) : '';
 
   return (
     <div className="relative">


### PR DESCRIPTION
Fixes #4414

`CurrencyField.tsx` carried the same one-entry fact twice: a dead `CURRENCY_SYMBOLS` map that nothing read, and a live `currency === 'USD' ? '$' : currency` ternary two lines below it. The PM ruling on the card says one channel survives, and that `Intl` is the candidate to **measure first**. It was measured, it fits, and both hand copies are gone.

## The Intl-fit measurement

`Intl.NumberFormat(locale, { style: 'currency', currency }).formatToParts()` has a `currency` part. Measured on node 22 / full-ICU, against what the ternary produces today:

| code | ternary today | Intl `currency` part (`en`) | verdict |
|---|---|---|---|
| USD | `$` | `$` | identical |
| KWD, BHD, CHF, ISK, CLP | the bare code | the bare code | identical — CLDR has no symbol for these, so ICU answers with the code |
| EUR | `EUR` | `€` | improvement |
| JPY | `JPY` | U+00A5 | improvement |
| GBP | `GBP` | `£` | improvement |
| INR | `INR` | `₹` | improvement |
| KRW | `KRW` | `₩` | improvement |

The ruling anticipated that ICU may answer with the CODE for some pairs (KWD was the example) and asked whether that is right for an adornment. Measured: it is, and it is also **what the ternary already did** for exactly those currencies — so that row of the table is byte-identical rather than a compromise.

The decisive finding is not the table, though. It is that the readonly branch of this same widget **already renders the Intl-derived symbol**, because it formats through `formatDisplayNumber(value, { locale, currency })` — the very same `Intl` call. So the widget contradicted itself: at `en` a JPY field rendered `¥1,235` in readonly mode and `JPY` in the edit adornment beside it. The new helper reads one part of the format the widget was already using, so the two modes cannot disagree again.

## The one channel

`currencySymbol(currency, locale)` lands in `packages/fields/src/currency.ts` beside `currencyFractionDigits()`, same memoization shape. Deleted: the `CURRENCY_SYMBOLS` map **and** the ternary. Exactly one spelling remains, and a repo-wide grep finds no other hand-restatement of the symbol.

**It takes the display locale as a parameter, and that is a measured divergence from its sibling.** `currencyFractionDigits()` drops the locale because the digit count is locale-independent. The symbol is not:

- USD is `$` at `en` / `en-US` / `de-DE` / `ja-JP`, `US$` at `en-GB` / `zh-CN`, `$US` at `fr-FR`
- JPY is U+00A5 at `en`, the **fullwidth** U+FFE5 at `ja-JP`, `JP¥` at `en-GB`, and the bare code `JPY` at `fr-FR`

So the cache is keyed on the **(locale, currency) pair**. Copying the code-only cache key would have let whichever locale asked first answer for every locale after it, for the life of the process — a silent wrong answer rather than a crash, so there is a test pinning it directly.

Both `Intl` throws are caught and fall back to the code as given: `RangeError: Invalid currency code`, and `RangeError: Incorrect locale information provided` (which `currencyFractionDigits` dodged by dropping the locale — this helper needs it, so it catches). This runs during render; an escaped `RangeError` would be a blank widget.

## USD byte-identical, and the non-USD change stated

**USD is byte-identical at the display-locale default.** `useDisplayLocale()`'s own last resort is `'en'`, and `currencySymbol('USD', 'en')` is `$` — the same byte the ternary produced. Pinned at `'en'`, at `'en-US'`, and through the ADR-0053 tenant default. The reverse verification below is the proof: reverting the wiring leaves every USD pin **green**.

**The documented change is non-USD**, and it is a deliberate choice rather than a side effect: a currency CLDR has a symbol for now renders that symbol instead of its three-letter code. This is the shortcoming the issue itself flagged as possibly worth fixing ("a widget that shows `KWD` rather than a symbol for every non-USD currency is arguably its own shortcoming"), and it aligns the edit adornment with what this widget's readonly mode has displayed all along. One pre-existing test asserted the old output (`standard-widgets.test.tsx`, "should handle EUR currency", `getByText('EUR')`); it pinned exactly the limb being deleted, so it is re-judged to `€` with a comment recording why.

Layout is unaffected: the adornment is an absolutely-positioned prefix span with the input padded by `pl-8`, and every new string is 1-3 characters — the same width class as the codes it replaces. Pinned that `pl-8` is still applied with a currency and still absent without one.

## Verification

- `pnpm exec vitest run packages/fields/ --maxWorkers=2` (repo root) — **83 files, 1325 tests, all passed**.
- #4413's fresh pins unchanged: `CurrencyField.minorUnits.test.tsx` — **16 passed**, run both in the full pass and targeted. It asserts digit counts and `step`, never the adornment, so it is untouched in both directions.
- `tsc --noEmit` and `tsc` (declaration build) for `packages/fields` — both exit 0. Dependency closure built first (`pnpm --filter '@object-ui/fields^...' build`).
- `check:control-bytes` OK (4128 files), `check:phantom-deps` OK, `check:changeset-presence` / `changeset-fixed` / `changeset-no-major` OK. Changeset is a **patch**.
- **Lint warning delta, measured against a comparison worktree at `origin/main`:** `CurrencyField.tsx` goes **3 warnings to 2**, and the one that disappears is exactly the card's bonus signal — `'CURRENCY_SYMBOLS' is assigned a value but never used  [@typescript-eslint/no-unused-vars]`. The new test file adds 1 `no-explicit-any` (the single unavoidable field-metadata cast, matching the sibling test's convention), so the package total is **757 to 757 — net zero**, 0 errors throughout.

### Red-first

The pins were written and run **before** the source changed: 13 failed / 15 passed. The reds were the 5 non-USD symbol pins (`expected 'EUR' to be '€'`), the 3 self-agreement pins (`expected '¥1,235' to contain 'JPY'` — the contradiction, caught in the act), and the 5 helper unit pins. The 15 that passed pre-change are the controls: every USD pin, the no-currency and padding pins, and the code-only currencies.

### Reverse verification

Committed, then reverted **only the wiring line** (helper and tests left in place), with the direction predicted in writing first. Predicted 9 red and named them; got exactly those 9, with the predicted messages:

```
9 failed | 59 passed (68)

expected 'EUR' to be '€'          expected 'JPY' to be '¥'
expected 'GBP' to be '£'          expected 'INR' to be '₹'
expected 'KRW' to be '₩'          Unable to find an element with the text: €
expected '¥1,235' to contain 'JPY'      expected '€1,234.50' to contain 'EUR'
expected '￥1,235' to contain 'JPY'
```

The controls stayed green, and that is the load-bearing half:

- **every USD pin** — this is what "USD byte-identical" means operationally;
- the KWD / BHD / CHF / ISK / CLP pins — the ternary and the derivation agree there;
- **all 5 `currencySymbol()` unit pins** — a *wiring* revert cannot reach the helper's own behaviour, so predicting "revert, therefore everything red" would have been wrong here. Naming the direction first is what makes the run mean something.

Wiring restored afterwards; the tree matches the commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_