### PR TITLE
fix(plugin-dashboard): keep schema-shaped props off the KPI card DOM (#4357)

### DIFF
--- a/.changeset/metric-widget-dom-spread-4357.md
+++ b/.changeset/metric-widget-dom-spread-4357.md
@@ -16,13 +16,22 @@ stringifying object values. Every KPI card therefore carried
 props container carried `events="[object Object]"`, `bind="data.revenue"` and
 `props="[object Object]"` beside it.
 
-Six props were measured arriving at the call site that are not HTML attribute
+Seven props were measured arriving at the call site that are not HTML attribute
 names — `schema`, `events`, `props`, `bind`, `ariaLabel`, `ariaDescribedBy` (the
 last two are the camelCase authored forms of ARIA the renderer already emits in
-their dashed spelling). They are destructured out; the spread survives untouched
-for everything that IS a DOM attribute: `id`, `name`, `role`, `disabled`,
-`aria-*`, `data-*`, `className`. Nothing else about the render moves — no text,
-no class, no element.
+their dashed spelling) and `dataSource`. They are destructured out; the spread
+survives untouched for everything that IS a DOM attribute: `id`, `name`, `role`,
+`disabled`, `aria-*`, `data-*`, `className`. Nothing else about the render moves
+— no text, no class, no element.
+
+`dataSource` is the one that only a live dashboard shows. It is not a schema key
+(the renderer strips the schema's own `dataSource` binding by name); it is the
+injected adapter `DashboardRenderer` hands its `SchemaRenderer` call, which
+arrives through the renderer's trailing props. Every fixture in this package
+renders without an adapter, so it read `undefined` and wrote nothing — while
+every deployment that actually loads data put `datasource="[object Object]"` on
+the card. The pin renders a dashboard with an adapter so the case that only
+production had is now a test.
 
 The cost of this was never visible; it was that the defect poisoned the
 assertion this area attracts. objectui#4163 pins

--- a/.changeset/metric-widget-dom-spread-4357.md
+++ b/.changeset/metric-widget-dom-spread-4357.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+KPI cards no longer write their own schema onto the DOM — `MetricWidget` and
+`MetricCard` keep `SchemaRenderer`'s schema-shaped props out of the `...props`
+spread (objectui#4357).
+
+Both components are two things at once: an SDUI block reached through
+`SchemaRenderer`, and a plain React component a host may render directly. The
+React half wants a `...props` spread on its root so callers can pass `aria-*`,
+`data-*`, `id`, `role`. The SDUI half means that spread also received the node's
+own metadata — and React writes unknown lowercase attributes straight to the DOM,
+stringifying object values. Every KPI card therefore carried
+`schema="[object Object]"`, and a widget authored with events, a binding or a
+props container carried `events="[object Object]"`, `bind="data.revenue"` and
+`props="[object Object]"` beside it.
+
+Six props were measured arriving at the call site that are not HTML attribute
+names — `schema`, `events`, `props`, `bind`, `ariaLabel`, `ariaDescribedBy` (the
+last two are the camelCase authored forms of ARIA the renderer already emits in
+their dashed spelling). They are destructured out; the spread survives untouched
+for everything that IS a DOM attribute: `id`, `name`, `role`, `disabled`,
+`aria-*`, `data-*`, `className`. Nothing else about the render moves — no text,
+no class, no element.
+
+The cost of this was never visible; it was that the defect poisoned the
+assertion this area attracts. objectui#4163 pins
+`not.toContain('[object Object]')` on the dashboard grid, and objectui#4032
+wanted the same pin on the metric path but could not write it: the card carried
+the attribute before and after any i18n fix, so the container assertion was red
+for a reason unrelated to labels and the tempting repair was to loosen it. That
+suite asserted on the card heading instead, with a comment. The workaround is
+now removed and the container assertion is back.
+
+The exported `MetricWidgetProps` / `MetricCardProps` interfaces are unchanged —
+the components' accepted props widen only by the optional, ignored
+`SchemaHostProps` keys, so no consumer type narrows.

--- a/packages/plugin-dashboard/src/MetricCard.tsx
+++ b/packages/plugin-dashboard/src/MetricCard.tsx
@@ -12,6 +12,7 @@ import { cn } from '@object-ui/components';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { I18nLabel } from '@object-ui/types';
 import { ArrowDownIcon, ArrowUpIcon, MinusIcon, AlertCircle, Loader2 } from 'lucide-react';
+import type { SchemaHostProps } from './schemaHostProps';
 
 export interface MetricCardProps {
   /**
@@ -36,7 +37,7 @@ export interface MetricCardProps {
  * MetricCard - Standalone metric card component for dashboard KPIs
  * Displays a metric value with optional icon, trend indicator, and description
  */
-export const MetricCard: React.FC<MetricCardProps> = ({
+export const MetricCard: React.FC<MetricCardProps & SchemaHostProps> = ({
   title,
   value,
   icon,
@@ -46,7 +47,18 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   className,
   loading,
   error,
-  ...props
+  // Schema-shaped props `SchemaRenderer` injects, destructured out so the
+  // spread below cannot write them to the DOM (objectui#4357). Named and
+  // measured in `./schemaHostProps`; `schema` alone put a
+  // `schema="[object Object]"` attribute on every card. The rest spread
+  // survives — it is the component's genuine DOM/aria passthrough.
+  schema: _schema,
+  bind: _bind,
+  events: _events,
+  props: _propsBag,
+  ariaLabel: _ariaLabel,
+  ariaDescribedBy: _ariaDescribedBy,
+  ...domProps
 }) => {
   // Resolve icon via lazy resolver — each icon ships as its own micro-chunk
   const IconComponent = icon ? getLazyIcon(icon) : null;
@@ -54,7 +66,7 @@ export const MetricCard: React.FC<MetricCardProps> = ({
   const { language } = useObjectTranslation();
 
   return (
-    <Card className={cn("h-full", className)} {...props}>
+    <Card className={cn("h-full", className)} {...domProps}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">
           {pickLocalized(title, language)}

--- a/packages/plugin-dashboard/src/MetricCard.tsx
+++ b/packages/plugin-dashboard/src/MetricCard.tsx
@@ -58,6 +58,7 @@ export const MetricCard: React.FC<MetricCardProps & SchemaHostProps> = ({
   props: _propsBag,
   ariaLabel: _ariaLabel,
   ariaDescribedBy: _ariaDescribedBy,
+  dataSource: _dataSource,
   ...domProps
 }) => {
   // Resolve icon via lazy resolver — each icon ships as its own micro-chunk

--- a/packages/plugin-dashboard/src/MetricWidget.tsx
+++ b/packages/plugin-dashboard/src/MetricWidget.tsx
@@ -222,6 +222,7 @@ export const MetricWidget = ({
   props: _propsBag,
   ariaLabel: _ariaLabel,
   ariaDescribedBy: _ariaDescribedBy,
+  dataSource: _dataSource,
   ...domProps
 }: MetricWidgetProps & SchemaHostProps) => {
   const iconClasses = VARIANT_ICON_CLASSES[colorVariant] || VARIANT_ICON_CLASSES.default;

--- a/packages/plugin-dashboard/src/MetricWidget.tsx
+++ b/packages/plugin-dashboard/src/MetricWidget.tsx
@@ -12,6 +12,7 @@ import {
 import type { I18nLabel } from '@object-ui/types';
 import { ArrowDownIcon, ArrowUpIcon, MinusIcon, AlertCircle, Loader2 } from 'lucide-react';
 import { VARIANT_ICON_CLASSES, VARIANT_TEXT_CLASSES, type MetricColorVariant } from './colorVariants';
+import type { SchemaHostProps } from './schemaHostProps';
 
 const TREND_LABEL_DEFAULTS: Record<string, string> = {
   'dashboard.trend.vsLastQuarter': 'vs last quarter',
@@ -210,8 +211,19 @@ export const MetricWidget = ({
   suffix,
   onClick,
   variant = 'card',
-  ...props
-}: MetricWidgetProps) => {
+  // Schema-shaped props `SchemaRenderer` injects, destructured out so the
+  // spread below cannot write them to the DOM (objectui#4357). Named and
+  // measured in `./schemaHostProps`; `schema` alone put a
+  // `schema="[object Object]"` attribute on every KPI card. The rest spread
+  // survives — it is the component's genuine DOM/aria passthrough.
+  schema: _schema,
+  bind: _bind,
+  events: _events,
+  props: _propsBag,
+  ariaLabel: _ariaLabel,
+  ariaDescribedBy: _ariaDescribedBy,
+  ...domProps
+}: MetricWidgetProps & SchemaHostProps) => {
   const iconClasses = VARIANT_ICON_CLASSES[colorVariant] || VARIANT_ICON_CLASSES.default;
   const { t: tTrend } = useTrendT();
   // Two locale channels, deliberately distinct. `useDisplayLocale` is the
@@ -298,7 +310,7 @@ export const MetricWidget = ({
           onClick();
         }
       } : undefined}
-      {...props}
+      {...domProps}
     >
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium truncate">

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.metricI18n.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.metricI18n.test.tsx
@@ -86,13 +86,6 @@ function dashboard(widget: Record<string, unknown>): DashboardComponentSchema {
   } as unknown as DashboardComponentSchema;
 }
 
-/** The KPI card's heading row — the slot every assertion below is about. */
-function cardHeading(): HTMLElement {
-  const el = document.querySelector('.tracking-tight.text-sm.font-medium');
-  if (!el) throw new Error('metric card heading not rendered');
-  return el as HTMLElement;
-}
-
 function renderIn(language: string, schema: DashboardComponentSchema) {
   return render(
     <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false, resources: ZH_BUNDLE }}>
@@ -116,7 +109,7 @@ describe('DashboardRenderer — KPI cards translate from the widget convention k
   });
 
   it('(b) resolves an inline per-locale title map, and never leaks the widget type', () => {
-    renderIn('zh', dashboard({
+    const { container } = renderIn('zh', dashboard({
       id: 'unkeyed',
       type: 'metric',
       title: { en: 'Total Revenue', 'zh-CN': '总收入' },
@@ -128,17 +121,19 @@ describe('DashboardRenderer — KPI cards translate from the widget convention k
     // so `|| widgetType` rendered the literal string "metric".
     expect(screen.queryByText('metric')).toBeNull();
     // And the sibling surface's failure mode, which this path never had.
-    // Asserted on the HEADING, not on `container.innerHTML`: the card also
-    // carries an unrelated `schema="[object Object]"` DOM attribute, present on
-    // this path before and after this change and on plain-string titles too —
-    // `SchemaRenderer` hands the widget schema down and `MetricWidget` spreads
-    // `...props` onto the `Card`. Filed separately rather than widened into
-    // this pin, which would have made the assertion pass for the wrong reason.
-    expect(cardHeading().innerHTML).not.toContain('[object Object]');
+    // Asserted on the CONTAINER, which is where this pin belongs and where
+    // #4163 puts the sibling one. It used to be scoped to the card heading:
+    // the card carried an unrelated `schema="[object Object]"` attribute on
+    // every render — `SchemaRenderer` hands the widget schema down and
+    // `MetricWidget` spread `...props` onto the `Card` — so the container
+    // assertion was red for a reason that had nothing to do with labels, and
+    // the tempting repair was to delete it. objectui#4357 removed the leak at
+    // its source (`src/schemaHostProps.ts`), so the assertion is writable now.
+    expect(container.innerHTML).not.toContain('[object Object]');
   });
 
   it('(b2) resolves the inline map for `en` too — the authored en text, not the raw map', () => {
-    renderIn('en', dashboard({
+    const { container } = renderIn('en', dashboard({
       id: 'unkeyed',
       type: 'metric',
       title: { en: 'Total Revenue', 'zh-CN': '总收入' },
@@ -146,7 +141,7 @@ describe('DashboardRenderer — KPI cards translate from the widget convention k
     }));
 
     expect(screen.getByText('Total Revenue')).toBeTruthy();
-    expect(cardHeading().innerHTML).not.toContain('[object Object]');
+    expect(container.innerHTML).not.toContain('[object Object]');
   });
 
   it('(b3) prefers the bundle over the inline map when both exist', () => {

--- a/packages/plugin-dashboard/src/__tests__/MetricWidget.domProps.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/MetricWidget.domProps.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4357 — `MetricWidget` / `MetricCard` ended their prop lists with
+ * `...props` and spread the whole thing onto the Shadcn `Card`. Reached through
+ * `SchemaRenderer` (every KPI tile is), the renderer hands a component its
+ * widget schema plus the schema's own keys, so SDUI metadata landed on the DOM:
+ * React passes unknown lowercase attributes straight through and stringifies
+ * object values.
+ *
+ * MEASURED at the `SchemaRenderer` call site (`packages/react/src/SchemaRenderer.tsx`,
+ * the `React.createElement(Component, …)` block) — the props a widget receives
+ * that are NOT DOM attributes, and the attribute each one emitted before the fix:
+ *
+ *   | prop             | emitted as                    | what it is                          |
+ *   |------------------|-------------------------------|-------------------------------------|
+ *   | `schema`         | `schema="[object Object]"`    | the node, injected on EVERY render  |
+ *   | `events`         | `events="[object Object]"`    | SDUI action metadata                |
+ *   | `props`          | `props="[object Object]"`     | the props container (spread already)|
+ *   | `bind`           | `bind="data.revenue"`         | SDUI data-binding path              |
+ *   | `ariaLabel`      | `arialabel="…"`               | camelCase twin of `aria-label`      |
+ *   | `ariaDescribedBy`| `ariadescribedby="…"`         | camelCase twin of `aria-describedby`|
+ *
+ * The line the fix draws is "is this an HTML attribute name": the six above are
+ * not (the renderer already emits the two dashed `aria-*` forms itself), so they
+ * are destructured out. Everything that IS one keeps flowing through the spread —
+ * `id`, `name`, `role`, `disabled`, `aria-*`, `data-*`, `className` — because the
+ * spread is genuine DOM/aria passthrough and stays.
+ *
+ * WHY THE ASSERTION IS `container.innerHTML` AND NOT THE HEADING. This defect's
+ * cost was never a visible one; it was that it POISONED the assertion this area
+ * attracts. #4163 pinned `not.toContain('[object Object]')` on
+ * `DashboardGridLayout`, and #4032 wanted the same pin on the metric path but
+ * could not write it — the card carried `schema="[object Object]"` before and
+ * after any i18n fix, so the pin would have been red for a reason unrelated to
+ * labels, and the tempting repair (loosen it) throws the real pin away. #4032
+ * asserted on the card heading instead, with a comment pointing here. That
+ * workaround is now removed: the container assertion below is the one that could
+ * not be written, and `DashboardRenderer.metricI18n.test.tsx` asserts on the
+ * container again.
+ *
+ * DIRECTIONS, written before the run: (a)–(d) RED before the fix — (a)/(c)/(d)
+ * by `MetricWidget`, (b) by `MetricCard`; (e)/(f) GREEN on both sides, they are
+ * the acceptance boundary (nothing else about the render may move).
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import type { DashboardComponentSchema } from '@object-ui/types';
+import { SchemaRenderer } from '@object-ui/react';
+// Both widgets are resolved from the registry, populated as a side effect of
+// the package barrel. Imported at MODULE scope (never in a hook) per AGENTS.md's
+// flaky-test rule: the cost lands in the import phase, unbounded by any timeout.
+import { DashboardRenderer } from '../index';
+
+afterEach(cleanup);
+
+/** Every SDUI key at once, so one render measures the whole surface. */
+const SCHEMA_METADATA = {
+  id: 'revenue',
+  name: 'revenue_kpi',
+  bind: 'data.revenue',
+  events: { onClick: [{ action: 'navigate', params: { url: '/deals' } }] },
+  ariaLabel: 'Revenue KPI',
+  ariaDescribedBy: 'desc-1',
+  role: 'group',
+} as const;
+
+/** Attribute names that must never appear — none of them is an HTML attribute. */
+const LEAKED_ATTRIBUTES = ['schema', 'events', 'props', 'bind', 'arialabel', 'ariadescribedby'];
+
+function renderSchema(schema: Record<string, unknown>) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false, resources: {} }}>
+      <SchemaRenderer schema={schema as never} />
+    </I18nProvider>,
+  );
+}
+
+function card(container: HTMLElement): HTMLElement {
+  const el = container.firstElementChild;
+  if (!el) throw new Error('nothing rendered');
+  return el as HTMLElement;
+}
+
+function attributeNames(el: HTMLElement): string[] {
+  return Array.from(el.attributes).map((a) => a.name);
+}
+
+describe('MetricWidget / MetricCard — schema-shaped props stay off the DOM (#4357)', () => {
+  it('(a) MetricWidget: the metric container carries no stringified schema', () => {
+    const { container } = renderSchema({
+      type: 'metric',
+      label: 'Total Revenue',
+      value: 1930000,
+      ...SCHEMA_METADATA,
+      props: { colorVariant: 'success' },
+    });
+
+    // THE pin — the assertion this defect used to block, on the container.
+    expect(container.innerHTML).not.toContain('[object Object]');
+    expect(attributeNames(card(container))).not.toContain('schema');
+  });
+
+  it('(b) MetricCard: same, through its own registry type', () => {
+    const { container } = renderSchema({
+      type: 'metric-card',
+      title: 'Total Revenue',
+      value: 1930000,
+      ...SCHEMA_METADATA,
+    });
+
+    expect(container.innerHTML).not.toContain('[object Object]');
+    expect(attributeNames(card(container))).not.toContain('schema');
+  });
+
+  it('(c) neither component emits any of the six measured non-DOM props', () => {
+    for (const schema of [
+      { type: 'metric', label: 'Total Revenue', value: 1930000, ...SCHEMA_METADATA, props: { colorVariant: 'success' } },
+      { type: 'metric-card', title: 'Total Revenue', value: 1930000, ...SCHEMA_METADATA, props: {} },
+    ]) {
+      const { container } = renderSchema(schema);
+      const names = attributeNames(card(container));
+      for (const leaked of LEAKED_ATTRIBUTES) {
+        expect(names, `${schema.type} emitted ${leaked}=`).not.toContain(leaked);
+      }
+      cleanup();
+    }
+  });
+
+  it('(d) the dashboard KPI path — the container assertion #4032 could not write', () => {
+    const schema = {
+      type: 'dashboard',
+      name: 'sales',
+      widgets: [{ id: 'revenue', type: 'metric', title: 'Total Revenue', options: { value: 1930000 } }],
+    } as unknown as DashboardComponentSchema;
+
+    const { container } = render(
+      <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false, resources: {} }}>
+        <DashboardRenderer schema={schema} />
+      </I18nProvider>,
+    );
+
+    expect(container.innerHTML).not.toContain('[object Object]');
+  });
+
+  it('(e) genuine DOM / aria passthrough survives — the spread is not removed', () => {
+    const { container } = renderSchema({
+      type: 'metric',
+      label: 'Total Revenue',
+      value: 1930000,
+      ...SCHEMA_METADATA,
+      className: 'kpi-tile',
+    });
+
+    const el = card(container);
+    // Authored DOM identity and ARIA, plus the renderer's own data attributes.
+    expect(el.getAttribute('id')).toBe('revenue');
+    expect(el.getAttribute('name')).toBe('revenue_kpi');
+    expect(el.getAttribute('role')).toBe('group');
+    expect(el.getAttribute('aria-label')).toBe('Revenue KPI');
+    expect(el.getAttribute('aria-describedby')).toBe('desc-1');
+    expect(el.getAttribute('data-obj-id')).toBe('revenue');
+    expect(el.getAttribute('data-obj-type')).toBe('metric');
+    expect(el.className).toContain('kpi-tile');
+  });
+
+  it('(f) rendered output is otherwise byte-identical — label and formatted value', () => {
+    const { container } = renderSchema({
+      type: 'metric',
+      label: 'Total Revenue',
+      value: 1930000,
+      ...SCHEMA_METADATA,
+    });
+
+    expect(container.textContent).toContain('Total Revenue');
+    // The KPI formatter's own contract: thousands separators, no decimals.
+    expect(container.textContent).toContain('1,930,000');
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/MetricWidget.domProps.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/MetricWidget.domProps.test.tsx
@@ -26,12 +26,23 @@
  *   | `bind`           | `bind="data.revenue"`         | SDUI data-binding path              |
  *   | `ariaLabel`      | `arialabel="…"`               | camelCase twin of `aria-label`      |
  *   | `ariaDescribedBy`| `ariadescribedby="…"`         | camelCase twin of `aria-describedby`|
+ *   | `dataSource`     | `datasource="[object Object]"`| the injected data-source ADAPTER    |
  *
- * The line the fix draws is "is this an HTML attribute name": the six above are
+ * The line the fix draws is "is this an HTML attribute name": the seven above are
  * not (the renderer already emits the two dashed `aria-*` forms itself), so they
  * are destructured out. Everything that IS one keeps flowing through the spread —
  * `id`, `name`, `role`, `disabled`, `aria-*`, `data-*`, `className` — because the
  * spread is genuine DOM/aria passthrough and stays.
+ *
+ * `dataSource` is why case (g) exists and why it renders the dashboard WITH an
+ * adapter. It is the only one of the seven that never appears in a schema —
+ * `SchemaRenderer` strips the schema's own `dataSource` binding by name
+ * (objectstack#5576) and this is the ADAPTER `DashboardRenderer` hands its
+ * `SchemaRenderer` call, arriving through the renderer's trailing props. Every
+ * fixture in this package renders without one, so it reads `undefined` and
+ * writes nothing; every live dashboard has one, so the attribute was there in
+ * production and in no test. A pin that only ever renders dataless dashboards
+ * cannot see it.
  *
  * WHY THE ASSERTION IS `container.innerHTML` AND NOT THE HEADING. This defect's
  * cost was never a visible one; it was that it POISONED the assertion this area
@@ -45,9 +56,10 @@
  * not be written, and `DashboardRenderer.metricI18n.test.tsx` asserts on the
  * container again.
  *
- * DIRECTIONS, written before the run: (a)–(d) RED before the fix — (a)/(c)/(d)
- * by `MetricWidget`, (b) by `MetricCard`; (e)/(f) GREEN on both sides, they are
- * the acceptance boundary (nothing else about the render may move).
+ * DIRECTIONS, written before the run: (a)–(d) and (g) RED before the fix —
+ * (a)/(c)/(d)/(g) by `MetricWidget`, (b) by `MetricCard`; (e)/(f) GREEN on both
+ * sides, they are the acceptance boundary (nothing else about the render may
+ * move).
  */
 
 import * as React from 'react';
@@ -75,7 +87,13 @@ const SCHEMA_METADATA = {
 } as const;
 
 /** Attribute names that must never appear — none of them is an HTML attribute. */
-const LEAKED_ATTRIBUTES = ['schema', 'events', 'props', 'bind', 'arialabel', 'ariadescribedby'];
+const LEAKED_ATTRIBUTES = ['schema', 'events', 'props', 'bind', 'arialabel', 'ariadescribedby', 'datasource'];
+
+/**
+ * A data-source adapter, shaped like the one a live dashboard injects. Only its
+ * identity matters here: it must reach the widget and not the DOM.
+ */
+const ADAPTER = { name: 'fake', find: async () => ({ items: [] }), findOne: async () => null };
 
 function renderSchema(schema: Record<string, unknown>) {
   return render(
@@ -122,7 +140,7 @@ describe('MetricWidget / MetricCard — schema-shaped props stay off the DOM (#4
     expect(attributeNames(card(container))).not.toContain('schema');
   });
 
-  it('(c) neither component emits any of the six measured non-DOM props', () => {
+  it('(c) neither component emits any of the seven measured non-DOM props', () => {
     for (const schema of [
       { type: 'metric', label: 'Total Revenue', value: 1930000, ...SCHEMA_METADATA, props: { colorVariant: 'success' } },
       { type: 'metric-card', title: 'Total Revenue', value: 1930000, ...SCHEMA_METADATA, props: {} },
@@ -150,6 +168,30 @@ describe('MetricWidget / MetricCard — schema-shaped props stay off the DOM (#4
     );
 
     expect(container.innerHTML).not.toContain('[object Object]');
+  });
+
+  it('(g) the dashboard KPI path WITH a data source — the production shape', () => {
+    const schema = {
+      type: 'dashboard',
+      name: 'sales',
+      widgets: [{ id: 'revenue', type: 'metric', title: 'Total Revenue', options: { value: 1930000 } }],
+    } as unknown as DashboardComponentSchema;
+
+    const { container } = render(
+      <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false, resources: {} }}>
+        <DashboardRenderer schema={schema} dataSource={ADAPTER as never} />
+      </I18nProvider>,
+    );
+
+    const tile = container.querySelector('[data-obj-type="metric"]');
+    if (!tile) throw new Error('metric tile not rendered');
+
+    // Case (d) renders the same dashboard with no adapter and cannot see this:
+    // `dataSource` is `undefined` there, so React writes nothing.
+    expect(container.innerHTML).not.toContain('[object Object]');
+    expect(attributeNames(tile as HTMLElement)).not.toContain('datasource');
+    // The KPI still renders its number — the adapter is dropped, not the widget.
+    expect(container.textContent).toContain('1,930,000');
   });
 
   it('(e) genuine DOM / aria passthrough survives — the spread is not removed', () => {

--- a/packages/plugin-dashboard/src/schemaHostProps.ts
+++ b/packages/plugin-dashboard/src/schemaHostProps.ts
@@ -1,0 +1,62 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The props `SchemaRenderer` hands a widget that are NOT DOM attributes
+ * (objectui#4357).
+ *
+ * A dashboard widget is two things at once: an SDUI block reached through
+ * `SchemaRenderer`, and a plain React component a host may render directly.
+ * The React half wants a `...props` spread onto its root element so callers can
+ * pass `aria-*`, `data-*`, `id`, `role`, `className`. The SDUI half means that
+ * spread also receives the node's own metadata — and React writes unknown
+ * lowercase attributes straight to the DOM, stringifying object values. That is
+ * how every KPI card ended up with `schema="[object Object]"`.
+ *
+ * MEASURED at the call site (`packages/react/src/SchemaRenderer.tsx`, the
+ * `React.createElement(Component, …)` block), one render carrying every SDUI key
+ * at once. What a widget receives, and the attribute each one emitted:
+ *
+ *   | prop              | emitted as                   | what it is                           |
+ *   |-------------------|------------------------------|--------------------------------------|
+ *   | `schema`          | `schema="[object Object]"`   | the node itself, injected EVERY render |
+ *   | `events`          | `events="[object Object]"`   | SDUI action metadata (`onClick: […]`) |
+ *   | `props`           | `props="[object Object]"`    | the props container — the renderer already spreads its CONTENTS separately, so the container is pure metadata |
+ *   | `bind`            | `bind="data.revenue"`        | SDUI data-binding path                |
+ *   | `ariaLabel`       | `arialabel="…"`              | camelCase authored form; the renderer already emits the resolved `aria-label` |
+ *   | `ariaDescribedBy` | `ariadescribedby="…"`        | ditto for `aria-describedby`          |
+ *
+ * The line this type draws is **"is the key an HTML attribute name"**. None of
+ * the six is (the two dashed `aria-*` forms the renderer emits itself are, and
+ * they keep flowing). Everything that IS one stays in the spread and reaches the
+ * DOM exactly as before: `id`, `name`, `role`, `disabled`, `aria-*`, `data-*`,
+ * `className`. Removing the spread instead would have been the wrong fix — it is
+ * the component's only accessibility passthrough.
+ *
+ * The renderer strips its own schema metadata (`type` / `children` / `visible` /
+ * `dataSource` / …) before spreading, so those never arrive; this type covers
+ * only what survives that strip. Declared here rather than in each component
+ * because two copies of one key list is how a list becomes two disagreeing
+ * lists — the same reason `colorVariants` was extracted. The pin that keeps the
+ * declaration honest for BOTH components is
+ * `__tests__/MetricWidget.domProps.test.tsx`.
+ */
+export interface SchemaHostProps {
+  /** The widget's own schema node, injected by `SchemaRenderer` on every render. */
+  schema?: unknown;
+  /** SDUI data-binding path (`'user.address.city'`). */
+  bind?: unknown;
+  /** SDUI event handlers (`{ onClick: [ActionDef, …] }`) — data, not DOM. */
+  events?: unknown;
+  /** The schema's props container; its contents are spread separately. */
+  props?: unknown;
+  /** Authored camelCase ARIA; the renderer emits the resolved `aria-label`. */
+  ariaLabel?: unknown;
+  /** Authored camelCase ARIA; the renderer emits `aria-describedby`. */
+  ariaDescribedBy?: unknown;
+}

--- a/packages/plugin-dashboard/src/schemaHostProps.ts
+++ b/packages/plugin-dashboard/src/schemaHostProps.ts
@@ -30,17 +30,29 @@
  *   | `bind`            | `bind="data.revenue"`        | SDUI data-binding path                |
  *   | `ariaLabel`       | `arialabel="…"`              | camelCase authored form; the renderer already emits the resolved `aria-label` |
  *   | `ariaDescribedBy` | `ariadescribedby="…"`        | ditto for `aria-describedby`          |
+ *   | `dataSource`      | `datasource="[object Object]"` | the injected data-source ADAPTER    |
+ *
+ * `dataSource` is the one a schema-only measurement misses, and the only one
+ * that leaks on a *production* dashboard rather than an authored edge case.
+ * It does not come from the node: `SchemaRenderer` strips the schema's own
+ * `dataSource` BINDING by name (objectstack#5576) — this is the adapter object
+ * `DashboardRenderer` hands its `SchemaRenderer` call, which arrives through the
+ * renderer's trailing `...props` and lands on whatever the widget spreads onto.
+ * A dashboard rendered without a data source (every test fixture) leaves it
+ * `undefined` and nothing shows; a dashboard rendered with one — every live
+ * deployment — put `datasource="[object Object]"` on the card.
  *
  * The line this type draws is **"is the key an HTML attribute name"**. None of
- * the six is (the two dashed `aria-*` forms the renderer emits itself are, and
+ * the seven is (the two dashed `aria-*` forms the renderer emits itself are, and
  * they keep flowing). Everything that IS one stays in the spread and reaches the
  * DOM exactly as before: `id`, `name`, `role`, `disabled`, `aria-*`, `data-*`,
  * `className`. Removing the spread instead would have been the wrong fix — it is
  * the component's only accessibility passthrough.
  *
  * The renderer strips its own schema metadata (`type` / `children` / `visible` /
- * `dataSource` / …) before spreading, so those never arrive; this type covers
- * only what survives that strip. Declared here rather than in each component
+ * the schema's `dataSource` binding / …) before spreading, so those never
+ * arrive; this type covers only what survives that strip — including the
+ * adapter, which arrives by a different door. Declared here rather than in each component
  * because two copies of one key list is how a list becomes two disagreeing
  * lists — the same reason `colorVariants` was extracted. The pin that keeps the
  * declaration honest for BOTH components is
@@ -59,4 +71,10 @@ export interface SchemaHostProps {
   ariaLabel?: unknown;
   /** Authored camelCase ARIA; the renderer emits `aria-describedby`. */
   ariaDescribedBy?: unknown;
+  /**
+   * The injected data-source adapter, forwarded by `DashboardRenderer` through
+   * `SchemaRenderer`'s trailing props. Neither metric component reads it — the
+   * async, object-aware KPI is `ObjectMetricWidget`.
+   */
+  dataSource?: unknown;
 }


### PR DESCRIPTION
Fixes #4357

`MetricWidget` and `MetricCard` ended their prop lists with `...props` and spread the whole thing onto the Shadcn `Card`. Reached through `SchemaRenderer` — which every dashboard KPI tile is — the renderer hands a component its widget schema plus the schema's own keys, so SDUI metadata landed on the DOM: React passes unknown lowercase attributes straight through and stringifies object values.

## Measured, not assumed

One render carrying every SDUI key at once, through the real `SchemaRenderer` path (`packages/react/src/SchemaRenderer.tsx`, the `React.createElement(Component, …)` block). The props a widget receives that are **not** HTML attribute names, and the attribute each emitted before this change:

| prop | emitted as | what it is |
|---|---|---|
| `schema` | `schema="[object Object]"` | the node itself, injected on **every** render |
| `events` | `events="[object Object]"` | SDUI action metadata |
| `props` | `props="[object Object]"` | the props container — the renderer already spreads its *contents* separately |
| `bind` | `bind="data.revenue"` | SDUI data-binding path |
| `ariaLabel` | `arialabel="…"` | camelCase authored form; the renderer already emits the resolved `aria-label` |
| `ariaDescribedBy` | `ariadescribedby="…"` | ditto for `aria-describedby` |
| `dataSource` | `datasource="[object Object]"` | the injected data-source **adapter** |

Raw pre-fix DOM, `type: 'metric'` through `SchemaRenderer`:

```
class="rounded-lg border bg-card text-card-foreground shadow-sm h-full overflow-hidden"
role="group"
schema="[object Object]"
id="revenue"
name="revenue_kpi"
bind="data.revenue"
events="[object Object]"
arialabel="Revenue KPI"
ariadescribedby="desc-1"
props="[object Object]"
aria-label="Revenue KPI"
aria-describedby="desc-1"
data-obj-id="revenue"
data-obj-type="metric"
```

**`dataSource` is the one a schema-only measurement misses, and the only one that leaked on a production dashboard rather than an authored edge case.** It is not a schema key — `SchemaRenderer` strips the schema's own `dataSource` binding by name (objectstack#5576) — it is the adapter `DashboardRenderer` hands its `SchemaRenderer` call (`DashboardRenderer.tsx:735`/`:764`), arriving through the renderer's trailing props. Every fixture in this package renders a dashboard without an adapter, so it read `undefined` and wrote nothing in every test, while every deployment that actually loads data put `datasource="[object Object]"` on the card. My first pass enumerated six keys and shipped that gap; the second measurement, with an adapter attached, found it. Case (g) of the pin now renders the dashboard **with** an adapter, so the shape only production had is a test.

All seven are destructured out in both components. **The spread survives**: everything that *is* a DOM attribute still reaches the element unchanged — `id`, `name`, `role`, `disabled`, `aria-*`, `data-*`, `className`. Removing the spread would have deleted the components' only accessibility passthrough. The list and its measurement live in one place, `packages/plugin-dashboard/src/schemaHostProps.ts`, rather than being copied into two components. The line drawn is "is the key an HTML attribute name".

## The pin, and the workaround it replaces

Pre-fix RED, both components at `origin/main` (`MetricWidget.domProps.test.tsx`):

```
× (a) MetricWidget: the metric container carries no stringified schema
× (b) MetricCard: same, through its own registry type
× (c) neither component emits any of the seven measured non-DOM props
× (d) the dashboard KPI path — the container assertion #4032 could not write
× (g) the dashboard KPI path WITH a data source — the production shape
✓ (e) genuine DOM / aria passthrough survives — the spread is not removed
✓ (f) rendered output is otherwise byte-identical — label and formatted value
  Tests  5 failed | 2 passed (7)
```

(e) and (f) are the acceptance boundary and were predicted to pass on both sides: nothing about the render moves except the bogus attributes disappearing. Post-fix the whole package is green — 43 files, 363 tests.

`DashboardRenderer.metricI18n.test.tsx` (#4032) asserted on the card *heading* because the container assertion was unwritable: the card carried `schema="[object Object]"` before and after any i18n fix, so the natural pin was red for a reason unrelated to labels and the tempting repair was to loosen it. That workaround is removed — cases (b) and (b2) now assert `not.toContain('[object Object]')` on the container, the comment points at this fix, and the now-unused `cardHeading()` helper goes with it.

## Reverse verification

Committed first, then took one component's destructuring out with `git checkout origin/main -- FILE` (never `git stash`), predicting the split beforehand: **(a)/(c)/(d)/(g) are `MetricWidget`'s, (b) is `MetricCard`'s.**

| run | red | green |
|---|---|---|
| `MetricWidget` reverted | (a) (c) (d) (g) + i18n (b) (b2) | (b), i18n (a) (b3) (f) (f2), (e) (f) |
| `MetricCard` reverted | (b) (c) | (a) (d) (g) (e) (f), all six i18n |
| restored | — | 13 / 13 |

The i18n cases going red only in the first run is the direct evidence that replacing #4032's workaround is load-bearing rather than cosmetic — that assertion now fails if this fix regresses.

Type surface, against the rebuilt `dist/index.d.ts` from a consumer package: a probe using both components normally, passing the injected metadata, and assigning `MetricCard` to a narrower `React.FC` compiles clean; a negative probe stays red on a bad `label`, a `colorVariant` outside the vocabulary, a bad `trend` and an undeclared prop — so tsc read the new declaration, not a cached one.

## One thing the reviewer should weigh: this repo already has a decided answer for this class

objectui#3291 / PR #3313 closed the same defect in `packages/fields` with a **whitelist** (`toDomProps`), and its docstring argues explicitly against the deny-list shape — "a blacklist enumerating today's renderer-only keys … would not stop the next authored key either" — while naming this very path as the harder one, "`SchemaRenderer` … has no strip layer at all, so on the SDUI path a widget's own spread is the ONLY line of defence".

This PR is a deny-list because that is what the ruling on #4357 specified (destructuring enumeration; allow-list only if enumeration is impossible). It is correct and verified for the seven measured props, and the `dataSource` miss above is a live miniature of the weakness that doc predicted. What remains uncovered is the open tail: an authored key a component does not declare still reaches the DOM (measured — `props: { colorVariant }` on `metric-card` lands as `colorvariant="success"`, since `MetricCard` has no such prop). Filed as #4425 with both options and the sweep-gate question, rather than changed unilaterally here.

Also filed: #4426 — the mirror image, pre-existing and untouched. Neither props interface declares the DOM passthrough the spread accepts, so `id` / `role` / `aria-label` are a type error for a TS consumer while working at runtime.

## Changeset

`patch`. The exported `MetricWidgetProps` / `MetricCardProps` interfaces are byte-identical — the components' *accepted* props widen only by the optional, ignored `SchemaHostProps` keys, which is additive and narrows nothing, so the #4403 precedent (minor for a props-type change) does not apply. Never major, per the fixed-group rule.

## Verification

- `pnpm exec vitest run packages/plugin-dashboard/` from the repo root — 43 files, 363 tests, green
- `tsc --noEmit` in `packages/plugin-dashboard` (no `tsconfig.test.json` exists here — confirmed, matching PR #4388's report)
- build closure first (`--filter '@object-ui/plugin-dashboard^...' build`), then a package rebuild before judging any type
- `eslint` on the five touched files: 0 errors
- `check-control-bytes`, `check-phantom-dependencies`, `check-changeset-presence`, `check-changeset-fixed`, `check-changeset-no-major`: green

Consumer sweep, honest about its limit: `--filter '...@object-ui/plugin-dashboard'` (**prefix** = the five downstream consumers, not the suffix form that walks upstream) type-checks red — but all 204 errors are `Cannot find module '@object-ui/auth' | '@object-ui/layout' | '@object-ui/plugin-*'`, i.e. packages whose `dist` a dependency-scoped build never produces, and not one names a metric symbol. It is a missing-artifact red, so it neither confirms nor denies anything about this change; the type evidence that does count is the consumer-side probe against the rebuilt `.d.ts` above.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_