### PR TITLE
refactor(react): bridgeListView maps only the five rowHeight spellings the spec admits (#4352)

### DIFF
--- a/.changeset/mapdensity-dead-rowheight-spellings-4352.md
+++ b/.changeset/mapdensity-dead-rowheight-spellings-4352.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/react': minor
+---
+
+`bridgeListView` maps the five row heights the spec admits, and only those — the four dead spellings are gone
+
+`mapDensity` carried a nine-key table: `compact`, `short`, `comfortable`,
+`spacious`, `small`, `medium`, `large`, `tall`, `extra_tall`. `RowHeightSchema`
+in `@objectstack/spec` admits five — `short | compact | medium | tall |
+extra_tall` — so `comfortable`, `spacious`, `small` and `large` were unreachable
+from any spec-valid list view. The bridge's own parameter type said as much
+(`Partial< ListView >`), and `mapDensity` widened it back to `rowHeight?: string`
+to let them in. They survived because the fixture asserting three of them
+compiled against nothing: the package's build tsconfig excludes tests and no
+other `tsc` read them, so four branches of renderer-side dialect read as live
+capability (objectui#4352, surfaced by objectui#4040 / PR #4351).
+
+They are deleted. The parameter takes the spec type honestly, and the table is
+now `Record< RowHeight, … >`, so a row height added upstream fails the build here
+instead of arriving with no density. This is AGENTS.md #0.1: a lenient reading
+for off-spec metadata is a second de-facto contract, and one strict contract
+beats N dialects — a bad `rowHeight` gets fixed at the producer, where the schema
+already rejects it.
+
+**Breaking semantics, deliberately graded `minor`** (this repo never publishes
+`major` — its major tracks `@objectstack`). Nothing narrows in the published type
+surface: `mapDensity` is module-local and never appeared in the emitted `.d.ts`,
+and `bridgeListView`'s declaration is unchanged. What changes is runtime output,
+and only for input the spec already rejects: a host handing the bridge
+`rowHeight: 'comfortable'` (or `'spacious'` / `'small'` / `'large'`) used to get
+`density: 'comfortable'` / `'spacious'` / `'compact'` back, and now gets no
+`density` key at all, so the renderer's own default applies. A sweep of this repo,
+the `objectstack` example apps and the console's view metadata found zero authored
+uses of any of the four; the legacy `densityMode` alias cannot produce one either,
+since `DENSITY_MODE_TO_ROW_HEIGHT` is typed `Record< DensityMode, RowHeight >` and
+folds onto `compact` / `medium` / `tall`.

--- a/packages/react/src/spec-bridge/__tests__/SpecBridge.test.ts
+++ b/packages/react/src/spec-bridge/__tests__/SpecBridge.test.ts
@@ -183,6 +183,46 @@ describe('SpecBridge', () => {
       expect(extraTall.density).toBe('spacious');
     });
 
+    // The other half of that enum: `comfortable` / `spacious` / `small` /
+    // `large` used to be mapped too, so four values `RowHeightSchema` does not
+    // admit read as live capability. They are gone (objectui#4352) — AGENTS.md
+    // #0.1, one strict contract beats N dialects — and an off-spec `rowHeight`
+    // now falls through to no density at all rather than being quietly
+    // rehabilitated into one.
+    //
+    // Routed through `SpecBridge.transformListView`, whose parameter is `any`:
+    // that untyped boundary is the one a host's stored JSON actually crosses,
+    // and it is the only way left to get these values into the bridge. Writing
+    // them on `bridgeListView` directly no longer type-checks, which is the
+    // static half of the same fix.
+    it.each(['comfortable', 'spacious', 'small', 'large'])(
+      'leaves density unset for the off-spec rowHeight %s',
+      (rowHeight) => {
+        const node = new SpecBridge().transformListView({
+          name: 'off_spec_density',
+          rowHeight,
+        });
+
+        expect(node.density).toBeUndefined();
+        // Not merely undefined — the key is never written, so the renderer's
+        // own default applies instead of an explicit `density: undefined`.
+        expect('density' in node).toBe(false);
+      },
+    );
+
+    // Control: a string in neither vocabulary already fell through before the
+    // four keys were deleted, and still does. Green on both sides of the
+    // change — it pins the fall-through itself, not the deletion.
+    it('leaves density unset for a rowHeight in no vocabulary at all', () => {
+      const node = new SpecBridge().transformListView({
+        name: 'off_spec_density',
+        rowHeight: 'gargantuan',
+      });
+
+      expect(node.density).toBeUndefined();
+      expect('density' in node).toBe(false);
+    });
+
     it('includes optional list properties', () => {
       const node = bridgeListView(
         {

--- a/packages/react/src/spec-bridge/bridges/list-view.ts
+++ b/packages/react/src/spec-bridge/bridges/list-view.ts
@@ -8,7 +8,7 @@
 
 import type { SchemaNode } from '@object-ui/core';
 import type { BridgeContext, BridgeFn } from '../types';
-import type { ListView, ListColumn } from '@objectstack/spec/ui';
+import type { ListView, ListColumn, RowHeight } from '@objectstack/spec/ui';
 
 /**
  * Bridge input: the spec-canonical ListView (#2231 — the former hand-written
@@ -45,22 +45,36 @@ function mapColumn(col: ListColumn | string): Record<string, any> {
   return mapped;
 }
 
+/**
+ * The spec's five row heights collapsed onto the renderer's three densities.
+ *
+ * `Record<RowHeight, …>` on purpose (objectui#4352): the key set is the spec's,
+ * so a row height added upstream fails the build here instead of silently
+ * arriving with no density. The table used to carry four more keys —
+ * `comfortable`, `spacious`, `small`, `large` — which `RowHeightSchema` does
+ * not admit, so no spec-valid list view could ever reach them; they only
+ * survived because the parameter was widened back to `string` and the fixture
+ * asserting three of them compiled against nothing. Deleting them is AGENTS.md
+ * #0.1: a renderer-side dialect for off-spec metadata is a second de-facto
+ * contract, and one strict contract beats N. An off-spec `rowHeight` now falls
+ * through to `undefined` — the producer is where it gets fixed.
+ */
+const ROW_HEIGHT_TO_DENSITY: Record<
+  RowHeight,
+  'compact' | 'comfortable' | 'spacious'
+> = {
+  compact: 'compact',
+  short: 'compact',
+  medium: 'comfortable',
+  tall: 'spacious',
+  extra_tall: 'spacious',
+};
+
 function mapDensity(
-  rowHeight?: string,
+  rowHeight?: RowHeight,
 ): 'compact' | 'comfortable' | 'spacious' | undefined {
   if (!rowHeight) return undefined;
-  const map: Record<string, 'compact' | 'comfortable' | 'spacious'> = {
-    compact: 'compact',
-    short: 'compact',
-    comfortable: 'comfortable',
-    spacious: 'spacious',
-    small: 'compact',
-    medium: 'comfortable',
-    large: 'spacious',
-    tall: 'spacious',
-    extra_tall: 'spacious',
-  };
-  return map[rowHeight];
+  return ROW_HEIGHT_TO_DENSITY[rowHeight];
 }
 
 /** Transforms a ListView spec into a DataTable SchemaNode */


### PR DESCRIPTION
Fixes #4352

Implements the delegated ruling on #4352: delete the four `rowHeight` spellings `mapDensity` carried that `RowHeightSchema` does not admit, conditioned on the card's own empirical pre-check. AGENTS.md #0.1 — one strict contract beats N dialects.

`mapDensity` had a nine-key table (`compact`, `short`, `comfortable`, `spacious`, `small`, `medium`, `large`, `tall`, `extra_tall`) against a five-value spec enum (`short | compact | medium | tall | extra_tall`), so `comfortable` / `spacious` / `small` / `large` were unreachable from any spec-valid list view. They survived because the parameter was widened back to `rowHeight?: string` to admit them, and the fixture asserting three of them compiled against nothing (the package's build tsconfig excludes tests). PR #4351 re-spelled the fixture; this PR takes the source half.

## Empirical pre-check — the ruling's stop condition, run FIRST

The ruling was conditioned on this: a LIVE authored legacy spelling means STOP (the #0.1 fix would then be metadata conversion, a different card). **Result: clean — zero authored uses of any of the four.**

Swept word-boundary-aware, every hit read and classified, across three repos:

| Scope | What was searched | Legacy spellings authored as a `rowHeight` value |
|---|---|---|
| `objectui` @ `24bb2de4f` — `examples/`, `apps/` (incl. console view metadata), all `packages/`, every `*.json` / `*.yml` / `*.yaml` | `rowHeight` / `densityMode` / `row_height` assigned one of the four; the four words on any line mentioning `rowHeight`; every `comfortable` / `spacious` occurrence repo-wide (75 lines, all read) | **none** |
| `objectstack` @ `5d24f4b94` — `packages/spec`, `examples/app-showcase`, `examples/app-crm`, `packages/platform-objects` | same patterns; plus every authored `rowHeight` value in the repo | **none** — every authored value is either the boolean `userActions.rowHeight` flag or one of `compact` / `short` / `medium` / `tall` |
| `hotcrm` @ `333259a` (a real downstream app on `@objectstack` 17.0.0-rc.5) | same patterns | **none** — `src/views/lead.view.ts:182` authors `rowHeight: 'medium'` |

Classification of what the sweep did turn up, since three of the four words are common English and two of them are also the **output** vocabulary:

- Every `comfortable` / `spacious` in `objectui` is **density-side** — `DensityMode` (`compact | comfortable | spacious`), the three-step vocabulary `mapDensity` maps *onto* — or English prose. The only **rowHeight-side** occurrences in the entire repo were the four dead keys in `list-view.ts` itself.
- `small` / `large` appear only as unrelated component variants (`examples/schema-catalog/.../components-basic-text/small.json` authors `variant: "small"`) and prose.
- Two hits author `densityMode: 'spacious'` — the legacy density alias, not a `rowHeight`. It **cannot** deliver a legacy spelling into this bridge: `normalizeListViewSchema` folds it through `DENSITY_MODE_TO_ROW_HEIGHT`, typed `Record< DensityMode, RowHeight >`, whose codomain is `compact` / `medium` / `tall`. That was the one producer path worth ruling out, and it is ruled out by its type.

## The change

`packages/react/src/spec-bridge/bridges/list-view.ts` only.

The four keys are gone; the parameter takes the spec's `RowHeight` instead of `string`, so the widening dies with the branch; and the table is lifted to a `Record< RowHeight, … >` const, which buys the property `@object-ui/core`'s equivalent maps already have — a row height added upstream fails the build here instead of silently arriving with no density. A non-spec `rowHeight` falls through to `undefined`, and since the bridge writes `if (density) node.density = density`, the key is simply absent.

## Red-first (pre-fix, captured against the still-lenient branch)

The new pin was written and run **before** the source was touched. Exactly four red, one per spelling, each naming the density the legacy value was being rehabilitated into:

```
 × leaves density unset for the off-spec rowHeight comfortable
 × leaves density unset for the off-spec rowHeight spacious
 × leaves density unset for the off-spec rowHeight small
 × leaves density unset for the off-spec rowHeight large

AssertionError: expected 'comfortable' to be undefined
AssertionError: expected 'spacious' to be undefined      (spacious, large)
AssertionError: expected 'compact' to be undefined       (small)

 Test Files  1 failed | 2 passed (3)
      Tests  4 failed | 58 passed (62)
```

The pin routes through `SpecBridge.transformListView`, whose parameter is `any`. That is deliberate and is the honest framing: the untyped boundary is the one a host's stored JSON actually crosses, and after this change it is the *only* way to get such a value in — writing it on `bridgeListView` directly no longer type-checks, which is the static half of the same fix. A control case (`rowHeight: 'gargantuan'`, a string in neither vocabulary) pins the fall-through itself and is green on both sides.

The five spec values keep PR #4351's coverage, unchanged — no gap to extend.

## Changeset grading — measured, not assumed

`.changeset/mapdensity-dead-rowheight-spellings-4352.md`: **`'@object-ui/react': minor`**. Never `major`, per the version-alignment rule.

The measurement that decides it, run as part of reverse verification below: the emitted `packages/react/dist/spec-bridge/bridges/list-view.d.ts` is **byte-identical** before and after. `mapDensity` is module-local and never reached the published surface, and `bridgeListView: BridgeFn< ListViewSpec >` with `ListViewSpec = Partial< ListView >` is untouched. So **nothing published narrows in type** — which is what would have made this #4403's `minor`, and it does not apply.

What does change is runtime output of an exported function, for a class of input: a host passing `rowHeight: 'comfortable'` used to get `density: 'comfortable'` back and now gets no `density` key. The sweep found zero such hosts in the three repos visible to me, but `@object-ui/react` is published, so an out-of-tree host is not excludable — this is exactly the "behaviour change for any host still passing a legacy spelling" #4352 flagged as the separate decision. AGENTS.md's version-alignment rule is decisive for that case: objectui's own breaking changes are graded `minor` with the breaking semantics spelled out in the body, which the changeset does. `patch` (#4403's grading for a module-local, non-exported table) would have been defensible only if nothing observable changed, and something does.

## Verification (local, all green)

- Repo-root vitest `packages/react/` — **38 files, 517 tests passed**.
- `packages/react` **both** tsc commands: `tsc --noEmit` (exit 0) and `tsc -p tsconfig.test.json` (exit 0).
- Build closure first, per the fresh-worktree rule: `pnpm --filter '@object-ui/react^...' build` — exit 0, before any judging.
- `eslint` on both touched files — **0 errors** (2 warnings, both pre-existing `@typescript-eslint/no-explicit-any` on `mapColumn`'s untouched signature at lines 22 / 28).
- `check:control-bytes` — OK, 4140 tracked text files; plus a self-scan of the touched files for the wider control-byte range: no hits.
- `check:phantom-deps` — OK, every in-scope import declared by the package that publishes it.
- `check-changeset-presence` — `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`.
- `check-changeset-no-major` — OK.

## Reverse verification (three directions predicted before running)

Taken out with `git checkout origin/main -- FILE` and put back with `git checkout HEAD -- FILE` — never `git stash`.

**A. Revert the deletion → the new pins red.** Predicted normal direction (red, not the inverted or more-diagnostics case: the assertion reads a value the deleted limb produces, not a count a gate reports). Measured, exactly four:

```
 ❯ SpecBridge.test.ts (23 tests | 4 failed)
       × leaves density unset for the off-spec rowHeight comfortable
       × leaves density unset for the off-spec rowHeight spacious
       × leaves density unset for the off-spec rowHeight small
       × leaves density unset for the off-spec rowHeight large
AssertionError: expected 'comfortable' to be undefined
```

**B. Controls green on both sides.** Predicted and measured: `maps every spec rowHeight to a density` (the five spec values) and `leaves density unset for a rowHeight in no vocabulary at all` both pass in the reverted state — 19 of the file's 23 tests passed there, all four failures being the pins from A. A green cannot be bought by breaking the surviving mappings.

**C. Emitted `.d.ts` identical.** Predicted identical, measured identical (`diff` empty) — the changeset-grading measurement above.

Restored afterwards: `git status` clean, `git diff HEAD` empty, rebuild green, `packages/react/` back to 38 files / 517 tests passed.

## Surface discipline

Touched `packages/react/src/spec-bridge/bridges/list-view.ts`, its `__tests__/SpecBridge.test.ts`, and the changeset. Nothing in `packages/components/**`, `packages/plugin-chatbot/**`, `packages/plugin-dashboard/**`, or any new sweep-gate suite. `P1SpecBridge.test.ts` was read and left alone: its three density cases already use spec values (`short` / `tall` / `extra_tall`) and stay green. No out-of-scope findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_