### PR TITLE
refactor(app-shell): AiChatPage narrows the chat hook's messages through toRuntimeMessages (#4437)

### DIFF
--- a/.changeset/aichatpage-runtime-message-seam-4437.md
+++ b/.changeset/aichatpage-runtime-message-seam-4437.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`AiChatPage` narrows the chat hook's messages through the exported `toRuntimeMessages` adapter instead of five casts
+
+`useObjectChat` returns `ObjectChatMessage[]` — the shape both of its modes really produce (objectui#4424) — which is wide where local mode is wide: it keeps the authored `'tool'` role and the legacy `'partial-call'`/`'call'`/`'result'` tool states. This page wants the runtime shape, and said so five times with `messages as ChatMessage[]` (plus one `as unknown as` double cast). The narrowing was real and the casts were legal; what was missing is that a cast erases the whole difference rather than the intentional part of it, so nothing recorded which narrowing was meant and nothing could go red when it changed.
+
+There is now one conversion where the hook's values enter the page's runtime-typed world, memoized on `messages` exactly as the plugin's own three renderers do (objectui#4399). All five sites read it; no cast replaces them, and the `as unknown as` double cast at the bound-package derivation turned out to be unnecessary once the value is honestly typed.
+
+One behaviour changes, and it is the one the fold was measured for. `sanitizeChatMessagesForCache` declares its parameter's role as `'user' | 'assistant' | 'system'` — it has always asked for folded roles, and the cast is what let an unfolded `'tool'` past that declaration. Measured on a thread carrying one: the entry was cached as `role: 'tool'`, which the cache's own reader then rejects, so the message vanished on a cache-fallback reload; and because sanitize gates tool serialization on `role === 'assistant'`, that turn's tool invocations — including the re-serialized draft envelope behind "Review N changes / Publish" — never reached the cache at all. Folded, both survive the reload they exist to survive. The other two compute sites were measured to be fold-insensitive and are unchanged: `isConversationZh` reads `role === 'user'` and the text, which the fold can neither create nor destroy, and `deriveBoundPackageId` walks every message irrespective of role and reads keys the adapter spreads through.
+
+Nothing on screen moves today: neither a `'tool'` role nor a legacy tool state is producible on this page's own paths, since hydration yields runtime roles and API mode's values come from `mapMessages` with v6 states already. This closes the hole ahead of a value that can reach it, and makes a future vocabulary move surface as a type error at the host rather than as rendering behaviour.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -73,6 +73,10 @@ import {
   detectBuilderHandoff,
   detectProposedChanges,
   buildProgressFromDraftReview,
+  // The authoring/honest -> runtime message seam (objectui#4399 / PR #4416),
+  // consumed here one hop up from the plugin's own renderers (objectui#4437).
+  // See `runtimeMessages` below for why this host calls it exactly once.
+  toRuntimeMessages,
   type AgentDescriptor,
   type ChatbotEnhancedToolInvocation,
   // The ENHANCED message shape — the one `<ChatbotEnhanced>` renders and the
@@ -1585,12 +1589,52 @@ export function ChatPane({
     setMessagesRef.current = setMessages;
   }, [setMessages]);
 
+  // ── The one conversion: where the hook's values enter this page's
+  // runtime-typed world (objectui#4437) ──────────────────────────────────────
+  //
+  // `useObjectChat` returns `ObjectChatMessage[]` — the shape BOTH of its modes
+  // really produce (objectui#4424 / PR #4436): wide where local mode is wide,
+  // so it keeps the authored `'tool'` role and the legacy
+  // `'partial-call'`/`'call'`/`'result'` tool states. Everything below this
+  // line wants the RUNTIME shape instead, and used to say so with five
+  // `as ChatMessage[]` casts. A cast erases the whole difference rather than
+  // the intentional part of it: a new authored role, or a newly required
+  // runtime key, kept compiling at all five sites and surfaced as behaviour.
+  //
+  // `toRuntimeMessages` is the same seam the plugin's own three renderers use
+  // (`renderer.tsx`, objectui#4399), with each narrowing decision named and
+  // tested in `chatMessageAdapter.ts`: `'tool'` renders as an assistant bubble,
+  // legacy tool states map to their v6 equivalents, and every render-only key
+  // (`buildProgress`, `draftReview`, `pendingActionId`, …) is spread through.
+  // Memoized on `messages` exactly as those renderers do, so this array's
+  // identity is neither more nor less stable than the hook's own output.
+  //
+  // All four consumers below take the converted array. The one that is
+  // fold-SENSITIVE is the cache write, and it is sensitive in the direction it
+  // wants — see the comment on that effect.
+  const runtimeMessages = useMemo(() => toRuntimeMessages(messages), [messages]);
+
+  // The cache write is the one measured behaviour change of objectui#4437, and
+  // it is a fix: `sanitizeChatMessagesForCache` declares its parameter's role as
+  // `'user' | 'assistant' | 'system'` — it has always ASKED for folded roles,
+  // and the cast is what let an unfolded `'tool'` past that declaration. Two
+  // consequences, both measured on a message set carrying a `'tool'` role:
+  //   - the entry was cached as `role: 'tool'`, which `readMessageCache`'s own
+  //     validator then rejects, so the message vanished on a cache-fallback
+  //     reload. Folded, it restores as the assistant bubble it renders as.
+  //   - sanitize gates tool serialization on `role === 'assistant'`, so that
+  //     message's tool invocations — including the re-serialized draft envelope
+  //     behind "Review N changes / Publish" — were dropped from the cache
+  //     entirely. Folded, they survive the reload they exist to survive.
+  // Not reachable from this page's own paths today (hydration and `mapMessages`
+  // both produce runtime roles and v6 states already), so nothing on screen
+  // moves; this closes the hole ahead of a value that can reach it.
   useEffect(() => {
     writeConversationMessagesCache(
       conversationId,
-      sanitizeChatMessagesForCache(messages as ChatMessage[]),
+      sanitizeChatMessagesForCache(runtimeMessages),
     );
-  }, [conversationId, messages]);
+  }, [conversationId, runtimeMessages]);
 
   // #772 — the confirm-card SEND messages must match the CONVERSATION's
   // language, not the console UI locale: a Chinese thread under an English UI
@@ -1611,9 +1655,12 @@ export function ChatPane({
   // ungated `planAnswerMessage` sent the UI locale in both directions.
   // `outboundAgentText` resolves all four from the `zh`/`en` packs by
   // conversation language and never consults the UI pack.
+  // Fold-insensitive, measured: the probe reads `role === 'user'` and the text,
+  // and the fold only maps `'tool'` -> `'assistant'` — it can neither create nor
+  // destroy a user turn, and it leaves `content`/`parts` untouched.
   const convZh = useMemo(
-    () => isConversationZh(messages as ChatMessage[]) || isConversationZh(initialMessages),
-    [messages, initialMessages],
+    () => isConversationZh(runtimeMessages) || isConversationZh(initialMessages),
+    [runtimeMessages, initialMessages],
   );
   const outboundText = useCallback(
     (key: OutboundAgentTextKey, vars?: Readonly<Record<string, string>>) =>
@@ -1657,7 +1704,7 @@ export function ChatPane({
   }, [isLoading, canvasApp]);
 
   const hitl = useHitlInChat({
-    messages: messages as ChatMessage[],
+    messages: runtimeMessages,
     apiBase,
     continueConversation: (prompt) => {
       sendMessage(prompt);
@@ -1753,9 +1800,11 @@ export function ChatPane({
   // derivations below read fields without per-access casts.
   const metadataApps = apps as MetadataAppItem[] | undefined;
   const { appLabel } = useObjectLabel();
+  // Fold-insensitive, measured: this walks every message irrespective of role
+  // and reads `draftReview`/`builderHandoff`, which the adapter spreads through.
   const boundPackageId = useMemo(
-    () => deriveBoundPackageId(messages as unknown as readonly PackageBearingMessage[], editPackageId),
-    [messages, editPackageId],
+    () => deriveBoundPackageId(runtimeMessages, editPackageId),
+    [runtimeMessages, editPackageId],
   );
   const boundPackageLabel = useMemo(() => {
     if (!boundPackageId) return undefined;
@@ -2032,7 +2081,7 @@ export function ChatPane({
         surface="plain"
         maxHeight="100%"
         headerSlot={headerSlot}
-        messages={messages as ChatMessage[]}
+        messages={runtimeMessages}
         placeholder={
           activeAgent
             ? agentRouteName(activeAgent) === 'ask'

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.runtimeMessageSeam.test.tsx
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.runtimeMessageSeam.test.tsx
@@ -1,0 +1,342 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#4437 — `AiChatPage` narrows the chat hook's messages through the
+ * exported `toRuntimeMessages` adapter, not through five casts.
+ *
+ * `useObjectChat` returns `ObjectChatMessage[]` (objectui#4424 / PR #4436): the
+ * shape BOTH of its modes really produce, which is wide where local mode is
+ * wide — it keeps the authored `'tool'` role and the legacy
+ * `'partial-call'`/`'call'`/`'result'` tool states. This page wants the runtime
+ * shape, and used to say so with `messages as ChatMessage[]` at five sites. A
+ * cast erases the whole difference rather than the intentional part of it, so
+ * nothing recorded WHICH narrowing was meant and nothing could go red when it
+ * changed.
+ *
+ * Why these pins are worth their weight even though the page cannot produce a
+ * `'tool'` role today (hydration yields `HydratedUIMessage['role']`, and API
+ * mode's values come from `mapMessages` with v6 states): the difference between
+ * "the cast happens to erase this" and "the adapter decides this" is invisible
+ * until something reaches the page carrying one. These drive the REAL page and
+ * assert the adapter's named decisions at the two boundaries that consume the
+ * result — what `<ChatbotEnhanced>` renders, and what the reload cache keeps.
+ *
+ * The fold-sensitivity measurement itself is pinned in the second describe: the
+ * two compute sites that are fold-INSENSITIVE must stay that way, or the
+ * decision to route them through the one conversion stops being justified.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import React from 'react';
+
+import { toRuntimeMessages, type ObjectChatMessage } from '@object-ui/plugin-chatbot';
+import { isConversationZh } from '../conversationLanguage';
+
+/** What the faked hook hands the page — the honest, UNFOLDED shape. */
+let hookMessages: ObjectChatMessage[] = [];
+/** The `messages` prop the page passes down to `<ChatbotEnhanced>`. */
+let renderedMessages: Array<Record<string, unknown>> = [];
+/** The `messages` option the page passes to `useHitlInChat`. */
+let hitlMessages: Array<Record<string, unknown>> = [];
+
+vi.mock('@object-ui/plugin-chatbot', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useAgents: () => ({
+      agents: [{ name: 'metadata_assistant', label: 'Build', capabilities: ['build'] }],
+      loading: false,
+      error: undefined,
+      refetch: vi.fn(),
+    }),
+    useAiModels: () => ({ models: [], defaultModelId: undefined }),
+    useHitlInChat: (opts: { messages: Array<Record<string, unknown>> }) => {
+      hitlMessages = opts.messages;
+      return { decide: vi.fn(), decisions: {} };
+    },
+    // The honest hook: it hands out exactly what the real one declares —
+    // including a role and tool states the runtime type does not have.
+    useObjectChat: () => ({
+      messages: hookMessages,
+      isLoading: false,
+      error: undefined,
+      sendMessage: vi.fn(),
+      stop: vi.fn(),
+      reload: vi.fn(),
+      clear: vi.fn(),
+      setMessages: vi.fn(),
+    }),
+    ChatbotEnhanced: (props: Record<string, unknown>) => {
+      renderedMessages = (props.messages ?? []) as Array<Record<string, unknown>>;
+      return <div data-testid="pane" />;
+    },
+  };
+});
+
+vi.mock('@object-ui/auth', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useAuth: () => ({ user: { id: 'u1' } }) };
+});
+vi.mock('../../../providers/MetadataProvider', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useMetadata: () => ({ apps: [] }) };
+});
+vi.mock('../../../providers/AdapterProvider', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, useAdapter: () => null };
+});
+vi.mock('../ConversationsSidebar', () => ({
+  ConversationsSidebar: () => <div data-testid="sidebar" />,
+}));
+vi.mock('../LiveCanvas', () => ({ LiveCanvas: () => <div data-testid="live-canvas" /> }));
+
+import { AiChatPage, deriveBoundPackageId } from '../AiChatPage';
+
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as unknown as typeof window.matchMedia;
+
+const CACHE_KEY = 'objectstack:ai-chat-messages:conv-seam';
+
+/**
+ * A thread carrying BOTH things the honest type keeps and the runtime type
+ * folds: a `'tool'`-role message, and a legacy `'result'` tool state on it.
+ */
+const TOOL_ROLE_THREAD: ObjectChatMessage[] = [
+  { id: 'u1', role: 'user', content: 'build me a CRM' },
+  {
+    id: 'tool-turn',
+    role: 'tool',
+    content: 'apply_blueprint finished',
+    toolInvocations: [
+      {
+        toolCallId: 't1',
+        toolName: 'apply_blueprint',
+        state: 'result',
+        draftReview: { items: [{ type: 'object', name: 'lead' }], packageId: 'app.crm' },
+        pendingActionId: 'pa-1',
+      },
+    ],
+  },
+];
+
+function installFetch(): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      // `useChatConversation` has to RESOLVE the id before the page caches
+      // anything under it — `writeConversationMessagesCache` is a no-op without
+      // a conversation.
+      if (/\/conversations\/conv-seam$/.test(url)) {
+        return new Response(JSON.stringify({ id: 'conv-seam', messages: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ success: true, data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+async function renderPage(): Promise<void> {
+  render(
+    <MemoryRouter initialEntries={['/ai/build/conv-seam']}>
+      <Routes>
+        <Route path="/ai/:agent/:conversationId" element={<AiChatPage />} />
+        <Route path="/ai/:agent" element={<AiChatPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByTestId('pane')).toBeInTheDocument());
+}
+
+describe("AiChatPage routes the hook's messages through toRuntimeMessages (#4437)", () => {
+  beforeEach(() => {
+    hookMessages = TOOL_ROLE_THREAD;
+    renderedMessages = [];
+    hitlMessages = [];
+    localStorage.clear();
+    installFetch();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a 'tool' message as an assistant bubble, with its legacy tool state folded", async () => {
+    await renderPage();
+
+    // The adapter's named decision (`toRuntimeRole`): an authored `'tool'`
+    // message IS an assistant message by the time it reaches the components.
+    // Under the old cast the role arrived at `<ChatbotEnhanced>` as `'tool'`
+    // and only `formatMessageProps`' not-'user' fallthrough made it LOOK right.
+    expect(renderedMessages.map((m) => m.role)).toEqual(['user', 'assistant']);
+
+    // `toRuntimeToolState`: the legacy spelling never reaches the components.
+    const tools = (renderedMessages[1]?.toolInvocations ?? []) as Array<Record<string, unknown>>;
+    expect(tools[0]?.state).toBe('output-available');
+
+    // The pass-through is what keeps the render-only keys alive across the
+    // conversion — the affordances would silently vanish if it rebuilt.
+    expect(tools[0]?.draftReview).toEqual({
+      items: [{ type: 'object', name: 'lead' }],
+      packageId: 'app.crm',
+    });
+    expect(tools[0]?.pendingActionId).toBe('pa-1');
+  });
+
+  it('hands useHitlInChat the same converted array (it reads a runtime-only key)', async () => {
+    await renderPage();
+
+    expect(hitlMessages.map((m) => m.role)).toEqual(['user', 'assistant']);
+    const tools = (hitlMessages[1]?.toolInvocations ?? []) as Array<Record<string, unknown>>;
+    expect(tools[0]?.pendingActionId).toBe('pa-1');
+  });
+
+  it('caches the tool turn as an assistant message, tool part included (the measured change)', async () => {
+    await renderPage();
+
+    await waitFor(() => expect(localStorage.getItem(CACHE_KEY)).not.toBeNull());
+    const cached = JSON.parse(localStorage.getItem(CACHE_KEY) as string) as Array<{
+      id: string;
+      role: string;
+      parts: Array<Record<string, unknown>>;
+    }>;
+
+    const toolTurn = cached.find((m) => m.id === 'tool-turn');
+    expect(toolTurn).toBeDefined();
+
+    // Cached as `'tool'` (what the cast let through), this entry is written and
+    // then DROPPED by `readMessageCache`'s own role validator on the way back
+    // in — the message disappears on a cache-fallback reload.
+    expect(toolTurn?.role).toBe('assistant');
+
+    // `sanitizeChatMessagesForCache` gates tool serialization on
+    // `role === 'assistant'`, so pre-fold this turn cached its text and nothing
+    // else: the re-serialized draft envelope behind "Review N changes /
+    // Publish" never made it into the cache at all.
+    const toolPart = toolTurn?.parts.find((p) => p.type === 'tool-apply_blueprint');
+    expect(toolPart).toBeDefined();
+    expect(toolPart?.state).toBe('output-available');
+    expect(toolPart?.output).toMatchObject({
+      status: 'drafted',
+      packageId: 'app.crm',
+      drafted: [{ type: 'object', name: 'lead' }],
+    });
+  });
+});
+
+/**
+ * The measurement that decided the placement, kept executable.
+ *
+ * Both sites below are reached through the ONE conversion in the page, which is
+ * only defensible while folding cannot change what they compute. If a future
+ * adapter decision makes either of them fold-sensitive, this goes red and the
+ * placement has to be re-argued rather than silently drifting.
+ */
+describe('#4437 fold-sensitivity: the two insensitive compute sites stay insensitive', () => {
+  const zhLastUserTurn: ObjectChatMessage[] = [
+    ...TOOL_ROLE_THREAD,
+    { id: 'u2', role: 'user', content: '继续' },
+  ];
+  // The sharp case: Chinese present ONLY on the message whose role the fold
+  // rewrites. A folded `'tool'` becomes `'assistant'`, never `'user'`, so it
+  // can never start being read as the conversation's language.
+  const zhOnlyOnToolTurn: ObjectChatMessage[] = [
+    { id: 'u1', role: 'user', content: 'go ahead' },
+    { id: 'tool-turn', role: 'tool', content: '这是中文的工具输出' },
+  ];
+
+  it('isConversationZh: same verdict before and after the fold', () => {
+    expect(isConversationZh(zhLastUserTurn)).toBe(true);
+    expect(isConversationZh(toRuntimeMessages(zhLastUserTurn))).toBe(true);
+
+    expect(isConversationZh(TOOL_ROLE_THREAD)).toBe(false);
+    expect(isConversationZh(toRuntimeMessages(TOOL_ROLE_THREAD))).toBe(false);
+
+    expect(isConversationZh(zhOnlyOnToolTurn)).toBe(false);
+    expect(isConversationZh(toRuntimeMessages(zhOnlyOnToolTurn))).toBe(false);
+  });
+
+  it('deriveBoundPackageId: same package before and after the fold', () => {
+    // Newest-wins, and the packageId here rides the message whose role the fold
+    // rewrites — so a role-dependence would show up as it appearing or
+    // disappearing from the answer.
+    expect(deriveBoundPackageId(TOOL_ROLE_THREAD, undefined)).toBe('app.crm');
+    expect(deriveBoundPackageId(toRuntimeMessages(TOOL_ROLE_THREAD), undefined)).toBe('app.crm');
+  });
+});
+
+/**
+ * The source net — the half of this card the behavioural pins above CANNOT
+ * cover, and the reason it is here rather than assumed.
+ *
+ * Of the five cast sites, only two are observable: the `<ChatbotEnhanced>` prop
+ * and the cache write both change what they produce when the fold is skipped,
+ * so restoring their cast reds a test above. The other three cannot red by
+ * construction — `isConversationZh` and `deriveBoundPackageId` are
+ * fold-INSENSITIVE (that is the measurement, pinned just above), and
+ * `useHitlInChat` reads a key the pass-through preserves either way. A cast
+ * coming back at any of those three is invisible to every runtime assertion in
+ * this file AND to `tsc`, because a cast is precisely the instruction to stop
+ * checking. This net is what makes them non-silent.
+ *
+ * Follows PR #4436's precedent, including the refinement it needed: comment
+ * lines are stripped first, because the page NAMES the deleted expression in
+ * the comment explaining why it is gone (as does this test). Prose about a cast
+ * is not a cast.
+ */
+describe('#4437 source net: the five casts do not come back', () => {
+  const PAGE = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'AiChatPage.tsx');
+  const source = readFileSync(PAGE, 'utf8');
+  const codeOnly = source
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\/\*|\*)/.test(line))
+    .join('\n');
+
+  it('finds the page it is guarding', () => {
+    // If the file moves or is renamed, fail here rather than pass vacuously.
+    expect(source).toContain('export function AiChatPage(');
+  });
+
+  it("casts the chat hook's `messages` nowhere", () => {
+    const casts = codeOnly.match(/\bmessages\s+as\s+\w/g) ?? [];
+    expect(
+      casts,
+      "packages/app-shell/src/console/ai/AiChatPage.tsx narrows the chat hook's " +
+        '`messages` with a cast again. The honest -> runtime seam is ' +
+        '`toRuntimeMessages` (objectui#4399 / PR #4416); a cast here erases every ' +
+        'narrowing decision it records, at a site where two of the five consumers ' +
+        'cannot show the difference at runtime (objectui#4437).',
+    ).toEqual([]);
+  });
+
+  it('converts exactly once, memoized on the hook output', () => {
+    // "One conversion where the values enter the page's runtime-typed world" is
+    // the card's shape, not a stylistic preference: a second conversion is a
+    // second array identity for the same thread, and these values feed effects
+    // and memos keyed on it.
+    expect(codeOnly.match(/toRuntimeMessages\(/g) ?? []).toHaveLength(1);
+    expect(codeOnly).toContain(
+      'const runtimeMessages = useMemo(() => toRuntimeMessages(messages), [messages]);',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #4437

`useObjectChat` returns `ObjectChatMessage[]` — the shape **both** of its modes really produce (#4424 / PR #4436) — which is wide where local mode is wide: it keeps the authored `'tool'` role and the legacy `'partial-call'`/`'call'`/`'result'` tool states. `AiChatPage` wants the runtime shape, and said so five times:

| survey row | site | was |
|---|---|---|
| 4 | `sanitizeChatMessagesForCache(...)` | `messages as ChatMessage[]` |
| 5 | `isConversationZh(...)` | `messages as ChatMessage[]` |
| 6 | `useHitlInChat({ messages })` | `messages as ChatMessage[]` |
| 7 | `deriveBoundPackageId(...)` | `messages as unknown as readonly PackageBearingMessage[]` |
| 8 | the `ChatbotEnhanced` `messages` prop | `messages as ChatMessage[]` |

The narrowing was real and every cast was legal — that is the card's premise, and it survived re-verification at the branch point. What was missing is that a cast erases the **whole** difference rather than the intentional part of it: a new authored role, or a newly required runtime key, kept compiling at all five sites and surfaced as rendering behaviour.

## The conversion

One conversion where the hook's values enter the page's runtime-typed world, memoized on `messages` exactly as the plugin's own three renderers do (#4399 / PR #4416):

```ts
const runtimeMessages = useMemo(() => toRuntimeMessages(messages), [messages]);
```

All five sites read it. **No cast replaces them, and no new `as` is introduced** — the `as unknown as` double cast at row 7 turned out to be unnecessary once the value is honestly typed, which is itself a small piece of evidence that the double cast existed to paper over the mis-declaration rather than over a real structural gap.

Placement is right after the `useObjectChat` destructure, above the first consumer. Identity is neither more nor less stable than before: the hook rebuilds `apiMessages` every render, so both the old `messages as ChatMessage[]` and the new memo change identity on exactly the same renders.

## Per-site fold sensitivity — measured, not assumed

The card's binding clause. Each site was called twice — once on the honest pre-fold array (what the casts handed it), once on `toRuntimeMessages(...)` output — over a thread carrying a `'tool'` role and two legacy states. The fold itself, measured:

```
roles  ['user','tool','assistant','user'] -> ['user','assistant','assistant','user']
states ['result','call']                  -> ['output-available','input-available']
```

| site | outcome | measured |
|---|---|---|
| `sanitizeChatMessagesForCache` | **affected** — change taken, it is the desirable one | 3 deltas, below |
| `isConversationZh` | **unaffected** | zh-last `true`/`true`; en-last `false`/`false`; zh-only-on-the-tool-turn `false`/`false` |
| `deriveBoundPackageId` | **unaffected** | assistant-last `app.crm2`/`app.crm2`; **tool-role-last** `app.crm`/`app.crm` |

Neither insensitive result is vacuous by construction: the zh probe includes a variant that answers `true` on both sides and one where the Chinese text sits **only** on the message whose role the fold rewrites; the package probe puts the `'tool'` message **last** (the derivation is newest-wins), so a role-dependence would show as its packageId appearing or disappearing.

Both are insensitive structurally, not incidentally. `isConversationZh` reads `role === 'user'` and the text — the fold maps `'tool'` to `'assistant'`, so it can neither create nor destroy a user turn, and `content`/`parts` ride the pass-through untouched. `deriveBoundPackageId` walks every message irrespective of role and reads `draftReview`/`builderHandoff`, which `toRuntimeToolInvocation` spreads through.

### The one affected site, and why the change is the one it wants

`sanitizeChatMessagesForCache` declares its parameter's role as `'user' | 'assistant' | 'system'`. It has **always asked for folded roles** — the cast is precisely what let an unfolded `'tool'` past that declaration, so routing through the conversion makes the call type-checked rather than cast-asserted. Three measured deltas, all on the `'tool'`-role message:

1. cached `role`: `'tool'` -> `'assistant'`. `readMessageCache`'s own validator accepts only user/assistant/system, so the pre-fold entry was written and then **silently dropped on restore** — the message disappeared on a cache-fallback reload.
2. its tool-invocation part: **absent** pre-fold (sanitize gates tool serialization on `role === 'assistant'`), **present** post-fold — including the re-serialized draft envelope `{status:'drafted', drafted:[…], packageId:'app.crm'}`, i.e. the "Review N changes / Publish" affordance survives the reload it exists to survive only post-fold.
3. a legacy state on an assistant turn: `'call'` -> `'input-available'` (that one was already serialized; only the spelling changed, and the restore path names the v6 states while catching legacy only via a default branch).

So the site's own semantics — cache round-trip fidelity, expressed in its own parameter type — want the folded value. Adapting at the last moment per call site was the alternative the card offered; it would have preserved a write the cache's reader rejects.

**Reachability, stated so the table is not over-read:** neither a `'tool'` role nor a legacy state is producible on this page's own paths today. `initialMessages` comes from `hydratedMessagesToChatMessages`, whose roles are `HydratedUIMessage['role']` (user/assistant/system) and whose states come from `partToolState` (v6 only); API mode's values come from `mapMessages`, also v6. The rendered-output bar is therefore **zero at runtime right now**, and this delta is a latent-correctness fix that becomes live the day such a value reaches the page.

## Tests

`packages/app-shell/src/console/ai/__tests__/AiChatPage.runtimeMessageSeam.test.tsx` — 8 tests, three groups, driving the **real page** with a faked hook that hands out the honest unfolded shape:

- the render path: a `'tool'` message reaches the `ChatbotEnhanced` element as `role: 'assistant'` with its legacy state folded to `'output-available'`, and `draftReview` / `pendingActionId` survive the conversion (the pass-through);
- `useHitlInChat` receives the same converted array (it reads the runtime-only `pendingActionId`);
- the cache write: the tool turn is cached as an assistant message **with** its tool part and the re-serialized draft envelope;
- the fold-sensitivity measurement itself, kept executable, so the two insensitive sites cannot quietly become sensitive and leave the placement unargued;
- a source net (PR #4436's precedent, comment-stripped — prose about a cast is not a cast) asserting no cast returns on the hook's `messages`, and that the conversion happens exactly once.

## Reverse verification — direction predicted first

The card's premise is that the casts are legal, so "restore a cast and watch `tsc`" cannot be the probe: the prediction at **every** site is that it compiles. What has to red is a behavioural pin or the net. Predictions were written down before running; all three matched.

| probe | predicted | measured |
|---|---|---|
| **A** restore row 8 (the `ChatbotEnhanced` prop) | tsc green; render pin red; net red | `TSC=0`, empty output. `AssertionError: expected [ 'user', 'tool' ] to deeply equal [ 'user', 'assistant' ]`. Net red. 2 failed / 6 passed |
| **B** restore row 4 (the cache write) | tsc green; cache pin red; net red | `TSC=0`. `AssertionError: expected 'tool' to be 'assistant'`. Net red. 2 failed / 6 passed |
| **C** restore row 5 (`isConversationZh`) | tsc green; **every behavioural test green**; only the net reds | `TSC=0`. **1 failed / 115 passed** over the whole `ai/` suite — the single failure is the source net |

Probe C is the honest negative and the reason the net exists rather than being assumed. Stated plainly: **of the five sites, only two can red behaviourally.** Rows 5 and 7 are fold-insensitive (that is the measurement), and row 6 reads a key the pass-through preserves either way — a cast coming back at any of those three is invisible to every runtime assertion **and** to `tsc`, because a cast is exactly the instruction to stop checking. The net is what makes them non-silent; nothing else in this PR can.

Baseline restored after each probe, tree verified clean.

## Verification

- `pnpm exec vitest run packages/app-shell/src/console/ai/` — **116 passed (18 files)**, up from 108 passed (17 files) on `origin/main`: +8 tests in +1 file, nothing existing changed.
- `pnpm exec vitest run packages/app-shell/` — **3377 passed | 1 skipped (355 files)**, 0 failed.
- Both `tsc` commands for app-shell (`tsc --noEmit` and `tsc -p tsconfig.test.json`) — green, after `pnpm --filter '@object-ui/app-shell^...' build` (the package-level `tsc` resolves `@object-ui/*` through `dist/*.d.ts`, absent in a fresh worktree; only vitest and the root tsconfig alias to `src`).
- `eslint` on both touched files — **0 errors**. Warning count is **26 before and 26 after** on `AiChatPage.tsx` (measured by running eslint on the `origin/main` copy of the file), i.e. no new finding on a touched line.
- `check-changeset-presence` / `check-changeset-no-major` / `check-changeset-fixed` / `check-control-bytes` / `check-phantom-dependencies` — all exit 0.

Changeset: `@object-ui/app-shell` **patch**. Internal page wiring — nothing published moves: no export is added, removed or retyped, and `toRuntimeMessages` was already exported from `@object-ui/plugin-chatbot`'s barrel by PR #4416. Never `major` (fixed group; `check-changeset-no-major`).

## Observed and deliberately left alone

`AiChatPage.tsx:862` carries a structurally identical `as unknown as readonly PackageBearingMessage[]` on `hydratedMessagesToChatMessages(messages)`. It is **not** one of the card's five — that value is the page's own locally-produced runtime array, not the hook's `messages` — so it is out of this card's surface and untouched. Noting it because the same simplification would now apply there; not a defect, so not filed.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_