### PR TITLE
refactor(core): rowHeightToDensityMode abstains for an off-spec rowHeight, matching the spec bridge (#4440)

### DIFF
--- a/.changeset/rowheight-density-one-answer-4440.md
+++ b/.changeset/rowheight-density-one-answer-4440.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/core': minor
+'@object-ui/plugin-list': minor
+---
+
+`rowHeightToDensityMode` answers only for the five spec row heights — the coerce-to-`comfortable` fallback is gone
+
+Two surfaces narrow a list view's `rowHeight` onto the renderer's three-step
+density vocabulary, and since objectui#4352 they answered differently for the
+same off-spec input: `@object-ui/react`'s spec bridge declined to answer, while
+`@object-ui/core`'s `rowHeightToDensityMode` rehabilitated anything unknown into
+`comfortable`. One metadata-driven system, two answers for one input
+(objectui#4440).
+
+The strict answer wins, per AGENTS.md #0.1: a renderer-side rehabilitation of
+off-spec metadata is a second de-facto contract, and one strict contract beats N
+dialects — a bad `rowHeight` gets fixed at the producer, where the schema already
+rejects it. The five mappings themselves are untouched (`compact`/`short` →
+`compact`, `medium` → `comfortable`, `tall`/`extra_tall` → `spacious`), and the
+table keeps its `Record< RowHeight, … >` typing, so a row height added upstream
+still fails the build here.
+
+**Breaking semantics, deliberately graded `minor`** (this repo never publishes
+`major` — its major tracks `@objectstack`). Two things change:
+
+- **Published type.** `rowHeightToDensityMode` is exported from
+  `@object-ui/core`, and its return widens from `DensityMode` to
+  `DensityMode | undefined`. A host assigning the result straight into a
+  `DensityMode` now has to say what an off-spec row height should mean to it.
+- **Rendered output, for input the spec already rejects.** `ListView` — the one
+  in-repo caller — used to render an off-spec `rowHeight` one step looser than an
+  ABSENT one (`comfortable`, 40px rows, vs `compact`, 32px). It now renders it
+  exactly like an absent one, `compact`, which is also `ObjectGrid`'s own default.
+  A sweep of this repo, the `objectstack` example apps and one downstream app
+  found zero authored off-spec values, and the legacy `densityMode` alias cannot
+  produce one (`DENSITY_MODE_TO_ROW_HEIGHT` is typed
+  `Record< DensityMode, RowHeight >`).
+
+Also closed while retiring the branch: the lookup guarded membership with `in`,
+which walks the prototype chain, so `rowHeight: 'toString'` returned
+`Object.prototype.toString` — a function — from something typed `DensityMode`. It
+is an own-property check now.

--- a/packages/core/src/utils/__tests__/normalize-list-view.test.ts
+++ b/packages/core/src/utils/__tests__/normalize-list-view.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   normalizeListViewSchema,
+  rowHeightToDensityMode,
   DENSITY_MODE_TO_ROW_HEIGHT,
   ROW_HEIGHT_TO_DENSITY_MODE,
 } from '../normalize-list-view.js';
@@ -287,6 +288,51 @@ describe('normalizeListViewSchema (#2890)', () => {
       expect(normalizeListViewSchema(null)).toBeNull();
       expect(normalizeListViewSchema(undefined)).toBeUndefined();
       expect(normalizeListViewSchema('list-view')).toBe('list-view');
+    });
+  });
+});
+
+describe('rowHeightToDensityMode (#4440)', () => {
+  describe('the five spec row heights — the mapping itself, unchanged', () => {
+    it.each([
+      ['compact', 'compact'],
+      ['short', 'compact'],
+      ['medium', 'comfortable'],
+      ['tall', 'spacious'],
+      ['extra_tall', 'spacious'],
+    ] as const)('maps the spec row height %s to %s', (rowHeight, density) => {
+      expect(rowHeightToDensityMode(rowHeight)).toBe(density);
+    });
+  });
+
+  describe('off-spec input — abstain, do not rehabilitate', () => {
+    // The retired branch answered `'comfortable'` here, while
+    // `@object-ui/react`'s spec bridge answered "no density at all" for the
+    // same string after #4352 (PR #4439). One metadata-driven system, two
+    // answers for one input, was #4440; this is the surviving answer.
+    it.each([
+      'comfortable', // the OUTPUT vocabulary, never a spec row height
+      'spacious',
+      'small',
+      'large',
+      'gargantuan', // a string in neither vocabulary
+      '',
+    ])('gives no density for the off-spec rowHeight %j', (rowHeight) => {
+      expect(rowHeightToDensityMode(rowHeight)).toBeUndefined();
+    });
+
+    it('gives no density for non-string metadata', () => {
+      // Stored view definitions reach this function from a database that
+      // TypeScript never saw, so the runtime guard is load-bearing, not
+      // decoration: `ListViewSchema.rowHeight` is statically `RowHeight`.
+      for (const value of [undefined, null, 42, true, {}, ['medium']]) {
+        expect(rowHeightToDensityMode(value)).toBeUndefined();
+      }
+    });
+
+    it('does not answer for an inherited Object.prototype key', () => {
+      expect(rowHeightToDensityMode('toString')).toBeUndefined();
+      expect(rowHeightToDensityMode('constructor')).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/utils/normalize-list-view.ts
+++ b/packages/core/src/utils/normalize-list-view.ts
@@ -53,17 +53,38 @@ export const ROW_HEIGHT_TO_DENSITY_MODE: Record<RowHeight, DensityMode> = {
 };
 
 /**
- * Tolerant reader for {@link ROW_HEIGHT_TO_DENSITY_MODE}. View metadata is
- * user-authored, so `rowHeight` is not guaranteed to be one of the five spec
- * values — an unknown one lands on `comfortable` rather than rendering an
- * undefined density. Keeping the fallback here means every surface collapses
- * the same way.
+ * Runtime reader for {@link ROW_HEIGHT_TO_DENSITY_MODE}: the spec's five row
+ * heights narrowed onto the renderer's three densities, and **nothing else**.
+ *
+ * The parameter stays `unknown` because this is the boundary user-authored view
+ * metadata actually crosses — `ListViewSchema.rowHeight` is statically a
+ * `RowHeight`, but the value arrives from stored view definitions TypeScript
+ * never saw (`ObjectView`: `viewDef.rowHeight ?? listSchema.rowHeight`). The
+ * type-level half of the guarantee is the `Record<RowHeight, …>` on the table
+ * above, which fails the build when the spec grows a row height.
+ *
+ * An off-spec value gets NO density (objectui#4440). It used to be coerced to
+ * `comfortable`, which is the opposite of what `@object-ui/react`'s spec bridge
+ * answers for the same string after objectui#4352 — one metadata-driven system
+ * holding two answers for one input. AGENTS.md #0.1 decides which one survives:
+ * a renderer-side rehabilitation of off-spec metadata is a second de-facto
+ * contract, and one strict contract beats N. The producer is where a bad
+ * `rowHeight` gets fixed.
+ *
+ * Callers apply their own "nothing was said" default to `undefined`, so an
+ * off-spec row height now renders exactly like an absent one — `'compact'` in
+ * both `ListView` and `ObjectGrid`.
+ *
+ * `hasOwnProperty`, not `in`: `in` walks the prototype chain, so `'toString'`
+ * used to come back as `Object.prototype.toString` — a FUNCTION returned from
+ * something typed `DensityMode`.
  */
-export function rowHeightToDensityMode(rowHeight: unknown): DensityMode {
-  if (typeof rowHeight === 'string' && rowHeight in ROW_HEIGHT_TO_DENSITY_MODE) {
-    return ROW_HEIGHT_TO_DENSITY_MODE[rowHeight as RowHeight];
+export function rowHeightToDensityMode(rowHeight: unknown): DensityMode | undefined {
+  if (typeof rowHeight !== 'string') return undefined;
+  if (!Object.prototype.hasOwnProperty.call(ROW_HEIGHT_TO_DENSITY_MODE, rowHeight)) {
+    return undefined;
   }
-  return 'comfortable';
+  return ROW_HEIGHT_TO_DENSITY_MODE[rowHeight as RowHeight];
 }
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1034,10 +1034,18 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // legacy `densityMode` is folded into it by `normalizeListViewSchema` above —
   // it used to be read FIRST here, so a view carrying both rendered the legacy
   // value, backwards from every other pair's canonical-wins precedence.
-  const resolvedDensity = React.useMemo(() => {
-    if (schema.rowHeight) return rowHeightToDensityMode(schema.rowHeight);
-    return 'compact';
-  }, [schema.rowHeight]);
+  //
+  // `rowHeightToDensityMode` answers only for the five spec row heights and
+  // abstains for anything else (#4440), so an off-spec value lands on the same
+  // `'compact'` an ABSENT `rowHeight` has always landed on — which is also
+  // `ObjectGrid`'s own default (`schema.rowHeight ?? 'compact'`). Do NOT drop
+  // the `??` and let `undefined` reach `useDensityMode`: its parameter default
+  // is `'comfortable'`, so the coercion #4440 retired would simply reappear one
+  // frame lower, and the two surfaces would disagree again.
+  const resolvedDensity = React.useMemo(
+    () => rowHeightToDensityMode(schema.rowHeight) ?? 'compact',
+    [schema.rowHeight],
+  );
   const density = useDensityMode(resolvedDensity, {
     onChange: schema.onDensityChange,
   });

--- a/packages/plugin-list/src/__tests__/ListView.density.offspec.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.density.offspec.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SchemaRendererProvider } from '@object-ui/react';
+import type { ListViewSchema } from '@object-ui/types';
+import { ListView } from '../ListView';
+
+/**
+ * What an off-spec `rowHeight` actually RENDERS — the empirical half of
+ * objectui#4440, pinned on the live path rather than argued from the mapping.
+ *
+ * `ListView` is the only in-repo caller of `@object-ui/core`'s
+ * `rowHeightToDensityMode`. Before #4440 that function coerced an unknown
+ * `rowHeight` to `'comfortable'`, so a garbage value rendered the toolbar (and
+ * the rows it forwards its density to) one step looser than an ABSENT
+ * `rowHeight` did — absent has always resolved to `'compact'` here, and
+ * `ObjectGrid` independently defaults `schema.rowHeight ?? 'compact'` too.
+ *
+ * After #4440 the mapping abstains and the caller's own "nothing was said"
+ * default applies, so off-spec renders exactly like absent. That is the
+ * measured consequence of aligning with `@object-ui/react`'s spec bridge, and
+ * this file is where it is visible: the density button's `aria-label` is
+ * `density.mode` verbatim.
+ *
+ * Note the abstain deliberately does NOT fall through to `useDensityMode`'s own
+ * parameter default, which is `'comfortable'` — landing there would have
+ * re-created the retired coercion one stack frame further down and left the two
+ * surfaces disagreeing exactly as before, while looking like a fix.
+ */
+
+const mockDataSource = {
+  find: vi.fn().mockResolvedValue([]),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+};
+
+const renderListView = (rowHeight?: unknown) => {
+  const schema = {
+    type: 'list-view',
+    objectName: 'contacts',
+    viewType: 'grid',
+    columns: ['name', 'email'],
+    ...(rowHeight === undefined ? {} : { rowHeight }),
+  } as ListViewSchema;
+
+  return render(
+    <SchemaRendererProvider dataSource={mockDataSource}>
+      <ListView schema={schema} />
+    </SchemaRendererProvider>,
+  );
+};
+
+/** The toolbar's density button labels itself `Density: <mode>`. */
+const renderedDensity = () =>
+  screen
+    .getByRole('button', { name: /^Density: / })
+    .getAttribute('aria-label')
+    ?.replace('Density: ', '');
+
+describe('ListView density for an off-spec rowHeight (#4440)', () => {
+  describe('spec row heights — controls, unaffected by the change', () => {
+    it.each([
+      ['compact', 'Compact'],
+      ['short', 'Compact'],
+      ['medium', 'Comfortable'],
+      ['tall', 'Spacious'],
+      ['extra_tall', 'Spacious'],
+    ])('renders %s as %s', (rowHeight, expected) => {
+      renderListView(rowHeight);
+      expect(renderedDensity()).toBe(expected);
+    });
+
+    it('renders an absent rowHeight as Compact', () => {
+      renderListView(undefined);
+      expect(renderedDensity()).toBe('Compact');
+    });
+  });
+
+  describe('off-spec rowHeight renders exactly like an absent one', () => {
+    // Every one of these rendered `Comfortable` before #4440. No authored
+    // metadata in objectui, objectstack or the surveyed downstream app spells
+    // any of them (the PR #4439 sweep, re-run for objectui and objectstack),
+    // so this is the rendered consequence of a value that does not exist —
+    // documented because it was measured, not because it was reachable.
+    it.each(['comfortable', 'spacious', 'small', 'large', 'gargantuan'])(
+      'renders the off-spec rowHeight %s as Compact',
+      (rowHeight) => {
+        renderListView(rowHeight);
+        expect(renderedDensity()).toBe('Compact');
+      },
+    );
+
+    it('renders a non-string rowHeight as Compact', () => {
+      // Stored view definitions cross an untyped boundary
+      // (`ObjectView`: `viewDef.rowHeight ?? listSchema.rowHeight`), so the
+      // value is only statically a `RowHeight`.
+      renderListView(42);
+      expect(renderedDensity()).toBe('Compact');
+    });
+  });
+});

--- a/packages/react/src/spec-bridge/__tests__/RowHeightDensityAgreement.test.ts
+++ b/packages/react/src/spec-bridge/__tests__/RowHeightDensityAgreement.test.ts
@@ -1,0 +1,90 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { rowHeightToDensityMode, type DensityMode } from '@object-ui/core';
+import { SpecBridge } from '../SpecBridge';
+
+/**
+ * The agreement pin for objectui#4440.
+ *
+ * Two surfaces narrow a list view's `rowHeight` onto the renderer's three-step
+ * density vocabulary, and for a while they answered differently for the same
+ * off-spec input: `@object-ui/core`'s `rowHeightToDensityMode` coerced anything
+ * unknown to `'comfortable'`, while this package's `mapDensity` — after #4352
+ * (PR #4439) — declined to answer at all. One metadata-driven system, two
+ * answers for one input. #4440 retired the coercion; this test is what stops
+ * the disagreement regrowing silently on either side.
+ *
+ * It lives HERE, not in `@object-ui/core`, because the dependency direction
+ * decides: `@object-ui/react` depends on `@object-ui/core`, so this package can
+ * see both surfaces, and core cannot import react without inverting the graph.
+ * The pin therefore imports core's function by its PUBLISHED specifier
+ * (`@object-ui/core`, a declared dependency of this package) and reaches the
+ * bridge through `SpecBridge.transformListView`, whose parameter is `any` —
+ * the untyped boundary a host's stored JSON actually crosses, and after #4352
+ * the only way an off-spec `rowHeight` can enter the bridge at all.
+ */
+
+/** What the bridge answers for a `rowHeight`, in core's return shape. */
+function bridgeDensityFor(rowHeight: unknown): DensityMode | undefined {
+  const node = new SpecBridge().transformListView({
+    name: 'row_height_agreement',
+    rowHeight,
+  });
+  // The bridge writes the key only when it has an answer, so an absent key and
+  // an explicit `undefined` are the same statement: "no density, use yours".
+  return 'density' in node ? (node.density as DensityMode | undefined) : undefined;
+}
+
+describe('rowHeight → density: core and the spec bridge give one answer (#4440)', () => {
+  describe('the five spec row heights — controls, green on both sides', () => {
+    it.each([
+      ['compact', 'compact'],
+      ['short', 'compact'],
+      ['medium', 'comfortable'],
+      ['tall', 'spacious'],
+      ['extra_tall', 'spacious'],
+    ] as const)('both surfaces map %s to %s', (rowHeight, expected) => {
+      expect(rowHeightToDensityMode(rowHeight)).toBe(expected);
+      expect(bridgeDensityFor(rowHeight)).toBe(expected);
+    });
+  });
+
+  describe('off-spec row heights — both abstain', () => {
+    // `comfortable` / `spacious` / `small` / `large` are the four spellings
+    // #4352 deleted from the bridge; `gargantuan` is a string in neither
+    // vocabulary. Before #4440 core answered `'comfortable'` for every one of
+    // them while the bridge answered nothing.
+    it.each(['comfortable', 'spacious', 'small', 'large', 'gargantuan'])(
+      'neither surface invents a density for the off-spec rowHeight %s',
+      (rowHeight) => {
+        expect(rowHeightToDensityMode(rowHeight)).toBeUndefined();
+        expect(bridgeDensityFor(rowHeight)).toBeUndefined();
+      },
+    );
+
+    // NOT pinned here, deliberately: `Object.prototype` member names
+    // (`toString`, `constructor`, …). Core abstains for them since #4440, but
+    // the bridge still indexes its table with an unguarded key and hands back
+    // `Object.prototype.toString` — a FUNCTION — as the density. That is a
+    // different defect from the coercion this file is about, it lives in source
+    // outside #4440's surface, and it is filed as #4442. Extending the two
+    // `it.each` lists above with those keys is the assertion that fails until
+    // #4442 lands, and is the natural test half of its fix.
+
+    it('agrees for every off-spec input without either side being read first', () => {
+      // Same assertion phrased as the invariant itself: whatever the answer is,
+      // it is ONE answer. A future edit that re-adds a fallback to either
+      // surface breaks this even if it re-adds it to both differently.
+      for (const rowHeight of ['comfortable', 'spacious', 'small', 'large', 'gargantuan', '']) {
+        expect(rowHeightToDensityMode(rowHeight)).toBe(bridgeDensityFor(rowHeight));
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes #4440

Implements the delegated ruling on #4440: `@object-ui/core`'s `rowHeightToDensityMode` stops coercing an unknown `rowHeight` to `comfortable` and gives the same no-mapping answer `@object-ui/react`'s spec bridge has given since #4352 (PR #4439). One system, one answer. AGENTS.md #0.1 — one strict contract beats N dialects, and a bad `rowHeight` gets fixed at the producer.

## 1. Empirical check — run FIRST, as the ruling required

The card's own caution was that this fallback sits on a **live render path**, unlike #4352's unreachable keys. So the callers were enumerated and the rendered outcome measured on both sides before anything was edited.

### Callers of `rowHeightToDensityMode` — the complete set

| # | Caller | What it does with the answer |
|---|---|---|
| 1 | `packages/plugin-list/src/ListView.tsx:1038` | feeds `useDensityMode`, whose `density.mode` drives the toolbar button, the row padding/font, and the `rowHeight` forwarded to every child view |

**Exactly one in-repo caller** (the card cited `ListView.tsx:877`; the line has moved, the caller has not). Plus out-of-tree hosts: `packages/core/src/index.ts:72` re-exports the whole module, so this is a published surface.

Checked and **not** callers: `app-shell/ObjectView.tsx` imports `DENSITY_MODE_TO_ROW_HEIGHT` (the write direction only); `plugin-grid/ObjectGrid.tsx` reads `schema.rowHeight` directly and never routes through this function.

### What can put an off-spec value into that caller

| Producer | Off-spec possible? |
|---|---|
| Stored view definitions — `app-shell/ObjectView.tsx:1545` (`viewDef.rowHeight ?? listSchema.rowHeight`), `plugin-view/ObjectView.tsx:1001` | **Yes in principle** — an untyped DB boundary. This is the per-user-override path the card flagged. |
| Authored view metadata | Only if authored off-spec — swept, none |
| Toolbar persistence, `ObjectView.tsx:1572` | No — `Record< DensityMode, RowHeight >` codomain |
| Legacy `densityMode` fold, `normalize-list-view.ts:221` | No — same typed table |
| `ListView.tsx:1698`, density forwarded to children | No — computed as `compact`/`medium`/`tall` |

### Is any off-spec value actually authored? Sweep re-run at today's HEADs

| Scope | Result |
|---|---|
| `objectui` @ `d7f3e308b` — every `ts/tsx/json/yml/yaml` | **none.** 57 `rowHeight` hits, all classified: i18n labels for the key name (9 locales), the boolean `userActions.rowHeight` flag, pixel-number props on unrelated widgets (gantt / VirtualGrid / dashboard), the typed tables, pass-throughs |
| `objectstack` @ `5d24f4b94` — showcase, CRM, `packages/spec`, `platform-objects` | **none.** Every authored value is the boolean flag or one of `compact` / `medium` / `short` / `tall` |
| `hotcrm` | not present in this container — inherited from PR #4439's sweep (`lead.view.ts:182` authors `rowHeight: 'medium'`) |

Independently confirms PR #4439's three-repo sweep, at newer HEADs.

### TODAY vs AFTER, measured on the live render path

Not argued from the mapping — **rendered**. `packages/plugin-list/src/__tests__/ListView.density.offspec.test.tsx` renders the real `ListView` and reads the density button's `aria-label`, which is `density.mode` verbatim.

| `schema.rowHeight` | TODAY | AFTER | Delta |
|---|---|---|---|
| absent | Compact | Compact | — |
| `compact` / `short` | Compact | Compact | — |
| `medium` | Comfortable | Comfortable | — |
| `tall` / `extra_tall` | Spacious | Spacious | — |
| `comfortable`, `spacious`, `small`, `large`, `gargantuan` | **Comfortable** | **Compact** | changes |
| `42` (non-string, from a stored view) | **Comfortable** | **Compact** | changes |
| `toString` / `constructor` | **`[Function toString]`** | **Compact** | changes — see §5 |

What the changed rows mean on screen: density `comfortable` → `compact` is row height 40px → 32px, padding `py-2 px-3` → `py-1 px-2`, font `text-sm` → `text-xs` (`react/src/hooks/useDensityMode.ts:46-62`), and the `rowHeight` forwarded to child views goes `'medium'` → `'compact'`.

**Reading: reachable code path, unreachable input class.** The delta is real and is reported as the ruling asked, but no metadata in existence reaches it. It moves the caller onto the bridge's answer, which is the intended direction.

## 2. Where the abstain lands — the measurement that changed the implementation

`undefined` has to land somewhere, and the obvious landing is a trap.

- **Chosen:** `rowHeightToDensityMode(schema.rowHeight) ?? 'compact'` — the consumer's own "nothing was said" default. It was already there in the branch this replaces (`if (schema.rowHeight) … return 'compact'`), and `ObjectGrid` independently picks the same one (`schema.rowHeight ?? 'compact'`).
- **Rejected:** letting `undefined` flow into `useDensityMode`. Its signature is `initialMode: DensityModeValue = 'comfortable'`, so `undefined` **compiles** and lands on `comfortable` — rebuilding the exact coercion this PR retires, one frame lower, while every unit test of the mapping goes green. Reverse verification B below measures this: it is invisible to core's own pins and to the agreement pin, and only the render pin catches it.

## 3. Ruling condition 2 — the `Record< RowHeight, … >` typing

**Already present, nothing added.** `normalize-list-view.ts:47` has declared `ROW_HEIGHT_TO_DENSITY_MODE: Record< RowHeight, DensityMode >` with `RowHeight` re-exported from `@objectstack/spec/ui` since objectstack#4115. The upstream-enum-growth build-failure property #4439 bought for the react twin was already held here. Measured, not assumed — and the honest answer to a condition can be "it is already true".

## 4. Ruling condition 3 — the agreement pin, and why it lives where it does

`packages/react/src/spec-bridge/__tests__/RowHeightDensityAgreement.test.ts` (new file).

**Placement is decided by the dependency direction, and core cannot host it.** `@object-ui/react` depends on `@object-ui/core`, so this package can see both surfaces; core importing react would invert the graph. The pin therefore imports core's function by its published specifier (`@object-ui/core`, a declared dependency — `check:phantom-deps` green) and reaches the bridge through `SpecBridge.transformListView`, whose parameter is `any` — the untyped boundary a host's stored JSON crosses, and since #4352 the only way an off-spec `rowHeight` can enter the bridge at all. A new file rather than an edit to `SpecBridge.test.ts`, so it cannot collide with in-flight work on that surface.

It asserts both surfaces agree for the five spec values (controls) and for the off-spec class, plus the invariant itself (`core(x) === bridge(x)` for every off-spec `x`) so a future fallback re-added to either side breaks it even if re-added to both differently.

**One honest exclusion, stated in the file:** `Object.prototype` member names are deliberately not in the pin. Core abstains for them now; the bridge still indexes its table with an unguarded key and hands back `Object.prototype.toString` as a density. That is a different defect in source outside this card's surface — filed as #4442, with the comment pointing there.

## 5. A latent defect the empirical check surfaced

The guard was `rowHeight in ROW_HEIGHT_TO_DENSITY_MODE`, and `in` walks the prototype chain. So `rowHeightToDensityMode('toString')` returned `Object.prototype.toString` — a **function**, from a signature that says `DensityMode`. Caught by a red-first case, not by reasoning:

```
AssertionError: expected [Function toString] to be undefined
- Expected: undefined
+ Received: [Function toString]
```

Now an own-property check, matching the repo convention (`Object.prototype.hasOwnProperty.call`, as in `core/src/utils/freeze-schema.ts:135`).

## 6. Red-first, captured against the unmodified source

All three pins were written and run **before** the source was touched:

```
 Test Files  3 failed (3)
      Tests  20 failed | 50 passed (70)

AssertionError: expected 'comfortable' to be undefined          (core unit, 8 cases)
AssertionError: expected 'comfortable' to be undefined          (agreement pin, 6 cases)
AssertionError: expected 'Comfortable' to be 'Compact'          (rendered, 6 cases)
AssertionError: expected [Function toString] to be undefined    (prototype key)
```

The 50 green are the controls: the five spec mappings on each of the three surfaces, plus absent-rowHeight. After the change: **70 passed (70)**.

## 7. Verification (local, all green)

- Build closure first, per the fresh-worktree rule: `pnpm --filter '@object-ui/plugin-list^...' build` — exit 0, before any judging.
- Repo-root vitest `packages/core/ packages/react/ packages/plugin-list/` — **154 files, 2772 tests passed**.
- **Both** tsc commands for all three packages — `tsc --noEmit` and `tsc -p tsconfig.test.json`, six runs, all exit 0.
- **Downstream consumer sweep**, run AFTER rebuilding core so consumers read the NEW `.d.ts`, not a stale one: `turbo run type-check --concurrency=2` repo-wide — **78 successful, 78 total**. Repo-wide is a superset of the `...@object-ui/core` prefix filter (downstream consumers), which is the direction a return-type widening breaks.
- `eslint` on all five touched files — **0 errors**. 168 warnings, every one pre-existing `no-explicit-any` / `exhaustive-deps` in `ListView.tsx`; none in the edited region (1033-1048), none in the three test files.
- `check:control-bytes` — OK, 4148 tracked text files; plus a self-scan of the touched files across the wider control-byte range: no hits.
- `check:phantom-deps` — OK. `check:spec-symbols` — OK.
- `check-changeset-presence` — 1 changeset declared. `check-changeset-no-major` — OK.

## 8. Reverse verification (both directions predicted before running)

Taken out with `git checkout origin/main -- FILE`, restored with `git checkout HEAD -- FILE` — never `git stash`.

**A. Restore the coercion in core → the pins red.** Predicted the normal direction (the assertions read a value the restored branch produces, not a count a gate reports). Measured **21 failed | 49 passed**, on all three surfaces:

```
 × gives no density for the off-spec rowHeight "comfortable"      (core unit)
 × neither surface invents a density for the off-spec rowHeight … (agreement)
 × renders the off-spec rowHeight gargantuan as Compact           (rendered)
AssertionError: expected 'comfortable' to be undefined
AssertionError: expected 'Comfortable' to be 'Compact'
```

21, not the 20 of the red-first run, and the extra one is worth naming rather than rounding off: `renders an absent rowHeight as Compact` also fails here. This state is a **mixture** — old core, new caller — and the old function coerced `undefined` to `comfortable` too, which is precisely why the caller needed its `if (schema.rowHeight)` guard. That the guard becomes unnecessary once the function can abstain is evidence for the change, not a defect in the pin.

**B. Restore only the CALLER, keeping core fixed → only the render pins red.** Predicted: core's unit pins and the agreement pin stay green (the mapping is correct), the six off-spec render cases go red because `undefined` reaches `useDensityMode`'s `= 'comfortable'` default, and the absent-rowHeight control stays green (the old caller's explicit `return 'compact'`). Measured exactly that — **6 failed | 64 passed**, one file red:

```
 × renders the off-spec rowHeight comfortable as Compact
 × renders the off-spec rowHeight spacious as Compact
 × renders the off-spec rowHeight small as Compact
 × renders the off-spec rowHeight large as Compact
 × renders the off-spec rowHeight gargantuan as Compact
 × renders a non-string rowHeight as Compact
AssertionError: expected 'Comfortable' to be 'Compact'
```

This is the measurement that makes the render pin load-bearing rather than a duplicate of the unit pin: the §2 trap is green on every mapping-level assertion and red only here.

**Controls green in both directions**, and after restoring: `git status` clean, `git diff HEAD` empty, `packages/core/ packages/react/ packages/plugin-list/` back to **154 files / 2772 tests passed**.

## 9. Changeset grading — measured

`.changeset/rowheight-density-one-answer-4440.md`: **`'@object-ui/core': minor`, `'@object-ui/plugin-list': minor`**. Never `major`, per the version-alignment rule.

The measurement, run as part of reverse verification: unlike #4439 — where the emitted `.d.ts` was byte-identical and `minor` rested on runtime behaviour alone — here the **published type itself moves**:

```diff
-export declare function rowHeightToDensityMode(rowHeight: unknown): DensityMode;
+export declare function rowHeightToDensityMode(rowHeight: unknown): DensityMode | undefined;
```

The function is re-exported by `packages/core/src/index.ts:72`, so it is published surface, and a host assigning the result straight into a `DensityMode` must now say what an off-spec row height means to it. `plugin-list` is graded alongside it because its rendered output changes for the same input class (§1). `patch` would only have been defensible if nothing observable changed; two things do.

## 10. Surface discipline and out-of-scope findings

Touched: `packages/core/src/utils/normalize-list-view.ts` + its test, `packages/plugin-list/src/ListView.tsx` + one new test, one new test in `packages/react/src/spec-bridge/__tests__/`, and the changeset. Nothing in `app-shell/console/ai/**`, `eslint-rules/**`, root config, or the #4425 sweep suite. No bridge **source** was edited.

Filed unassigned, not fixed here:

- **#4442** — `mapDensity` indexes `ROW_HEIGHT_TO_DENSITY` with an unguarded key, so `rowHeight: 'toString'` returns a function as the density. The same hole core had; its fix lives in the surface this card was told to leave alone, and extending this PR's agreement pin to prototype keys is the natural test half of it.
- **#4443** (`finding`) — a standalone `ObjectGrid` still renders an off-spec `rowHeight` as `medium` via its styling ternary's terminal `else`, while resolving an ABSENT one to `compact`: the third answer to the question this PR unified, on a surface #4440 does not name.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_