### PR TITLE
docs(agents): state the `git stash` ban in AGENTS.md §9 as a rule of its own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,11 +212,20 @@ AGENTS.md 的「只跑受影响的包」指的是**用上面的路径过滤缩�
 
 - **只改你任务需要的文件**;别去"修"无关的 diff、回退或别人的在途编辑,也别管整棵工作树。
 - **必须一个任务一个 git worktree**(`git worktree add ../objectui-<task> -b <branch> main`,新树里跑 `pnpm install`)做物理隔离 —— 这是强制而非「首选」。共享的 `main` checkout **不是**可用退路:HEAD 会被别的 agent 切换、你刚写的文件会在操作中途被 reset 掉。一个 **PreToolUse 钩子**(`.claude/hooks/guard-main-checkout.sh`)**强制**此规则:除非被编辑文件位于专属 **worktree** 否则拦截 `Edit`/`Write`/`NotebookEdit`——在共享 checkout 上开 feature 分支**也不行**(仍会被切走),且按**被编辑文件所属的仓库**判断(sibling 仓 `framework`/`cloud` 一并守住)(确属非任务的临时改动用 `OS_ALLOW_MAIN_EDITS=1` 放行)。即便在自己的 worktree 里,下面这些防御性条款仍然适用。
+- **绝不 `git stash` —— stash 栈不在上一条的 worktree 隔离范围内。** `git stash` 把栈存在**共享 `.git` 目录**里的 `refs/stash`,**每个 worktree 共用同一个 LIFO 栈**:上一条的物理隔离**不覆盖它**。两个 agent 各自在自己的 worktree 里 stash,push/pop 的是同一个栈 —— 你的 `pop` 取回的是对方刚压进去的改动,你自己的改动留在栈上等着被对方取走;而 `pop` **报成功**,唯一的症状是别人的文件出现在你的 `git status` 里,随后一次 `git add -A` 就把对方的在途工作合进了你的 PR。不是假想:objectui#3430 两个并行 agent 在反向验证中间踩实,双方在途改动都丢了(只能作为 unreachable commit 捞回)。替代做法只有下面这些 —— 都不碰共享状态,都在你自己的 worktree 内,且**首选先 commit 再还原**(上面反向验证那条已把它定为标准写法):
+
+  ```bash
+  git commit -am wip                                     # 还原:git reset --soft HEAD~1
+  git diff > /tmp/wip.patch && git checkout -- <paths>   # 还原:git apply /tmp/wip.patch
+  git worktree add ../objectui-<task>-cmp <ref>          # 另开一棵树做对照
+  ```
+
+  三者的共同点是**先把未提交状态捕获下来**再动工作区;任何「先覆盖、事后再从某个 ref 取回」的写法都**不是**替代做法 —— 它假设你的改动已经提交,而反向验证时通常没有(objectstack#7800:那条推荐语害一个 agent 丢了在途改动)。一个 **PreToolUse 钩子**(`.claude/hooks/guard-shared-stash.sh`)**强制**此规则:拦截 push/pop/drop/clear 共享栈的 `Bash` 命令,放行拿不到别人条目的形式 —— `git stash list`/`show`/`create`,以及 `git stash apply <sha>` / `store <sha>` 且 sha 为**字面十六进制 object id**(绝不用 `stash@{N}` —— 那是你并不拥有的那个栈里的一个**位置**)。确知栈只属于你时用 `OS_ALLOW_STASH=1` 放行;改了钩子就重跑 `.claude/hooks/guard-shared-stash.selftest.sh`。
 - **一个任务一个 feature 分支 + 一个 PR**;**绝不**把任务改动直接提交到 `main`。
 - **绝不 `git push --force`/`--force-with-lease`,绝不推 `main`**(会覆盖并行 agent 的工作;`main` 共享,一律走 PR)。
 - **每次 commit/push 前先确认当前分支**(`git rev-parse --abbrev-ref HEAD`);HEAD 可能被别的 agent 切走 —— 不是你的分支就停下重新 checkout。
 - 改**共享文件**(barrel/注册表):编辑→`git add`→commit 一气呵成,并核验提交确实含你的改动(`git show HEAD:<file> | grep <你的改动>`);真冲突只重加*你自己*那几行,其余交给 PR 合并。
-- **要做反向验证(删掉修复 → 看预期的钉子变红 → 还原)就先把修复 commit 掉。** 提交之后,还原是 `git checkout <你的分支> -- <path>`,对着一个真实存在的 commit 取回;直接对**未提交**的改动做同一个删除(`git checkout origin/main -- <path>`)则没有任何还原点 —— 工作区就是唯一副本,而 `git stash` 一律禁用(共享 stash 栈,见 CLAUDE.md),改动当场就没了。同一天两次踩实:#4278(PR #4293)、#4243(PR #4299),两次都靠会话 transcript 逐行重打才找回来 —— transcript 不全就是净损失。#4243 那次是先 commit、再重跑一遍反向验证,最终那组红绿数字才可信。
+- **要做反向验证(删掉修复 → 看预期的钉子变红 → 还原)就先把修复 commit 掉。** 提交之后,还原是 `git checkout <你的分支> -- <path>`,对着一个真实存在的 commit 取回;直接对**未提交**的改动做同一个删除(`git checkout origin/main -- <path>`)则没有任何还原点 —— 工作区就是唯一副本,而 `git stash` 一律禁用(共享 stash 栈,见本节上面「绝不 `git stash`」那条),改动当场就没了。同一天两次踩实:#4278(PR #4293)、#4243(PR #4299),两次都靠会话 transcript 逐行重打才找回来 —— transcript 不全就是净损失。#4243 那次是先 commit、再重跑一遍反向验证,最终那组红绿数字才可信。
 - **本仓由 ruleset 强制走合并队列(merge queue):直接合并会被 405 拒绝。** 实测(objectui#3243,对 15/15 全绿、`mergeable_state: clean`、非 draft 的 PR #3241):
 
   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,4 +47,5 @@ take another agent's entry: `git stash list`/`show`/`create`, and `git stash app
 *position* in a stack you don't own). Deliberate exception: `OS_ALLOW_STASH=1`. Changing
 the hook? Re-run `.claude/hooks/guard-shared-stash.selftest.sh`.
 
-See **AGENTS.md** for the full playbook.
+See **AGENTS.md** for the full playbook — both rules above are stated in full there, in
+§9 多 agent 协作纪律; this file carries them only as the excerpt.


### PR DESCRIPTION
Fixes #4340

Docs-only. The shared-stash ban lived only in `CLAUDE.md` — the excerpt file — while `AGENTS.md`, which declares itself the single source of truth "read natively by Claude Code, GitHub Copilot, and other agents", never stated it. The pointer between the two did not resolve in either direction: `CLAUDE.md` closed with "See **AGENTS.md** for the full playbook", and the canonical file's own reverse-verification rule deferred back out with 见 CLAUDE.md. So the full playbook was the file that did not have the rule, and the non-Claude readers named on line 3 met `guard-shared-stash.sh` as an unexplained Bash block.

## Pointer topology

| | before | after |
|---|---|---|
| `AGENTS.md` §9 | one parenthetical clause, deferring out: `git stash` 一律禁用(共享 stash 栈,见 CLAUDE.md) | **canonical**: the ban stated as a rule of its own, beside the worktree rule — ban, shared `refs/stash` rationale, objectui#3430, the sanctioned substitutes, the hook and its escape hatch |
| `AGENTS.md` reverse-verification rule | pointed at `CLAUDE.md` | points in-file at the new rule |
| `CLAUDE.md` | excerpt whose closing pointer dangled | excerpt, unchanged in substance; closing pointer now names §9 多 agent 协作纪律 and resolves |

One canonical statement plus an in-file pointer — no second drift-capable copy. `CLAUDE.md` keeps its stated purpose ("the one rule that must never be missed is inlined here"); only its last line moved, to make the pointer honest.

## objectstack#7800 avoidance

That card is the content defect in the same doc family: the *first* substitute recipe in objectstack's copy overwrites the working tree from a ref, which silently destroys uncommitted work in exactly the reverse-verification situation it is offered for. It was deliberately not imported here. The promoted block:

- leads with the commit-then-revert idiom PR #4339 canonicalized (`git commit -am wip`, restore with `git reset --soft HEAD~1`);
- carries only the three forms that capture uncommitted state **first** (wip commit, patch file, second worktree) — objectui's `CLAUDE.md` never had the hazardous line, so promotion needed no filtering, only ordering;
- states the shared property explicitly, so the recipe cannot be re-derived wrongly: any "overwrite now, retrieve from a ref later" form is **not** a substitute, because it assumes a commit that reverse verification usually has not made yet.

The one surviving occurrence of that overwrite form in `AGENTS.md` is the pre-existing reverse-verification rule, where it appears as the hazard being warned against, not as a recipe. Unchanged.

## Not touched

`.claude/hooks/guard-shared-stash.sh` and its selftest — the behavior already lives there; this card was the missing prose. No code, no hook, no workflow: the diff is prose in two markdown files.

## Verification

- `node scripts/check-doc-links.mjs` — `Links are valid across 13 scan roots.`
- `node scripts/check-skills-paths.mjs` — `OK (84/85 stated path(s) resolve across 18 guide file(s); 1 baselined)` — no regression in AGENTS.md path claims.
- `node scripts/check-control-bytes.mjs` — `OK (scanned 4152 tracked text file(s); skipped 85 binary)`; plus a targeted control-byte self-scan of both edited files (no hits).
- `node scripts/check-changeset-presence.mjs` — `No source of a released package changed in this range, so no changeset is owed.` The presence gate self-determines; none added.
- `pnpm exec vitest run --maxWorkers=2` over the five suites that read these two files (`check-doc-links`, `check-skills-paths`, `check-control-bytes`, `check-changeset-presence`, `site-next-agent-files-4160`) — `Test Files 5 passed (5) / Tests 193 passed (193)`. No suite pins the old pointer shape, so **zero pins moved**.
- Docs-card reverse verification (claims re-read on the post-edit file): the ban, the rationale, the three substitutes, the hook and the incident are all present in `AGENTS.md` as one rule; the reverse-verification parenthetical points in-file; `CLAUDE.md`'s pointer names §9; and the hazard guard for #7800 confirmed the overwrite-from-ref form appears nowhere as a recommendation.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_