### PR TITLE
fix(scripts): check-type-check-coverage sees a chain entry whose project is missing (#4347)

### DIFF
--- a/scripts/__tests__/check-type-check-coverage.test.ts
+++ b/scripts/__tests__/check-type-check-coverage.test.ts
@@ -496,6 +496,174 @@ describe('the narrow type-assertion project is scoped to packages still in debt'
   });
 });
 
+/**
+ * objectui#4347 — chained but missing.
+ *
+ * The gate asks two independent questions about each chained project: does the
+ * file exist (`has*Config`, a `readFileSync` in `collect()`), and does
+ * `type-check` run it (`chains*Config`, a regex over the script string). Three of
+ * the four combinations were reported; the fourth — chained, not on disk — was
+ * skipped by the entry guard of each section, so a `type-check` that fails
+ * immediately with TS5058 passed this gate at exit 0.
+ *
+ * Observed for real during #4291: `git checkout -- packages/auth/package.json`
+ * restored the script while the retired narrow project stayed deleted, and both
+ * green lines printed, `4 with a narrow type-assertion project` included.
+ */
+describe('a "type-check" chain entry pointing at a project that is not there (objectui#4347)', () => {
+  const buildConfig = JSON.stringify({ include: ['src/**/*'], exclude: ['node_modules', 'dist', 'test'] }, null, 2);
+  const fullTestConfig = JSON.stringify(
+    { compilerOptions: { noEmit: true }, include: ['test/**/*.test.ts', 'test/**/*.test.tsx'], exclude: [] },
+    null,
+    2,
+  );
+
+  /**
+   * The two entry guards the gate USED to open with, reproduced verbatim — the
+   * same executable-blind-spot convention the #3968 predicates above follow.
+   * Each fixture below is asserted to have been invisible to the one that hid it.
+   */
+  const legacySection5HalfEntry = (pkg: { hasTypeTestsConfig: boolean }): boolean => pkg.hasTypeTestsConfig;
+  const legacySection5Entry = (pkg: { hasScript: boolean; testFiles: number }): boolean =>
+    pkg.hasScript && pkg.testFiles !== 0;
+
+  it('reports a chained tsconfig.typetests.json that is not on disk — the #4291 shape', () => {
+    withWorkspace(
+      (write) => {
+        // Everything else about this package is correct: its full test project
+        // exists, is chained, and reads every test file the build skips. The
+        // ONLY defect is the narrow project named by a chain entry and absent
+        // from disk, so a second error here would mean the fixture is impure.
+        write(
+          'packages/auth/package.json',
+          manifest('@fixture/auth', 'tsc --noEmit && tsc -p tsconfig.test.json && tsc -p tsconfig.typetests.json'),
+        );
+        write('packages/auth/tsconfig.json', buildConfig);
+        write('packages/auth/tsconfig.test.json', fullTestConfig);
+        write('packages/auth/src/index.ts', 'export const auth = 1;\n');
+        write('packages/auth/test/pins.test.ts', A_TEST);
+      },
+      ({ errors, packages }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('@fixture/auth (packages/auth): "type-check" chains tsconfig.typetests.json,');
+        expect(errors[0]).toContain('which does not exist.');
+        expect(errors[0]).toContain('Delete the chain entry, or restore the project.');
+
+        // The two facts stay separate in `collect()`, which is what makes the
+        // combination expressible at all.
+        expect(packages[0].chainsTypeTestsConfig).toBe(true);
+        expect(packages[0].hasTypeTestsConfig).toBe(false);
+        // And this is what section 5½ used to ask first: nothing, about this
+        // package. The blind spot, executable.
+        expect(legacySection5HalfEntry(packages[0])).toBe(false);
+      },
+    );
+  });
+
+  it('reports a chained tsconfig.test.json that is not on disk, naming it rather than the tests', () => {
+    // Pre-fix this tree was red for the WRONG reason — section 5c's "no `tsc`
+    // invocation reads them", which sends the reader to write a test project
+    // that is already declared. A package carrying a TEST_DEBT entry (as the
+    // #4291 repro's package did) got no message at all.
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit && tsc -p tsconfig.test.json'));
+        write('packages/demo/tsconfig.json', buildConfig);
+        write('packages/demo/src/index.ts', 'export const demo = 1;\n');
+        write('packages/demo/test/a.test.ts', A_TEST);
+      },
+      ({ errors, packages }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('@fixture/demo (packages/demo): "type-check" chains tsconfig.test.json,');
+        expect(errors[0]).toContain('Delete the chain entry, or restore the project.');
+        // Precision, not addition: the vaguer 5c message must not also fire.
+        expect(errors[0]).not.toContain('that no `tsc`');
+        expect(packages[0].chainsTestConfig).toBe(true);
+        expect(packages[0].hasTestConfig).toBe(false);
+      },
+    );
+  });
+
+  it('reports it even when the package has no test files left at all', () => {
+    // Deleting a package's tests and its test project while leaving the chain
+    // entry behind is the other way into this state — and the way section 5's
+    // `testFiles === 0` guard hid completely, in any table configuration.
+    withWorkspace(
+      (write) => {
+        write('packages/demo/package.json', manifest('@fixture/demo', 'tsc --noEmit && tsc -p tsconfig.test.json'));
+        write('packages/demo/tsconfig.json', buildConfig);
+        write('packages/demo/src/index.ts', 'export const demo = 1;\n');
+      },
+      ({ errors, packages }) => {
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('"type-check" chains tsconfig.test.json, which does not exist.');
+        expect(packages[0].testFiles).toBe(0);
+        expect(legacySection5Entry(packages[0])).toBe(false);
+      },
+    );
+  });
+
+  it('reports both kinds separately when a script chains two projects that are both gone', () => {
+    withWorkspace(
+      (write) => {
+        write(
+          'packages/demo/package.json',
+          manifest('@fixture/demo', 'tsc --noEmit && tsc -p tsconfig.test.json && tsc -p tsconfig.typetests.json'),
+        );
+        write('packages/demo/tsconfig.json', buildConfig);
+        write('packages/demo/src/index.ts', 'export const demo = 1;\n');
+        write('packages/demo/test/a.test.ts', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors).toHaveLength(2);
+        expect(errors.some((e) => e.includes('chains tsconfig.test.json, which does not exist.'))).toBe(true);
+        expect(errors.some((e) => e.includes('chains tsconfig.typetests.json, which does not exist.'))).toBe(true);
+      },
+    );
+  });
+
+  it('says nothing when every chained project is really there', () => {
+    // The direction that must stay quiet: chained AND present is the wired-up
+    // state, and the narrow project is legitimate here because the package is
+    // still in debt (no tsconfig.test.json), so section 5½'s redundancy rule
+    // does not apply either. The only error is the undeclared test gap, which
+    // this fixture has because it runs with an empty TEST_DEBT table.
+    withWorkspace(
+      (write) => {
+        write(
+          'packages/demo/package.json',
+          manifest('@fixture/demo', 'tsc --noEmit && tsc -p tsconfig.typetests.json'),
+        );
+        write('packages/demo/tsconfig.json', buildConfig);
+        write(
+          'packages/demo/tsconfig.typetests.json',
+          JSON.stringify({ compilerOptions: { noEmit: true }, include: ['test/pins.test.ts'] }, null, 2),
+        );
+        write('packages/demo/test/pins.test.ts', A_TEST);
+      },
+      ({ errors }) => {
+        expect(errors.some((e) => e.includes('does not exist.'))).toBe(false);
+        expect(errors.some((e) => e.includes('that no `tsc`'))).toBe(true);
+      },
+    );
+  });
+});
+
+describe('no chain entry in this repository points at a project that is not there', () => {
+  const packages = collect(repoRoot);
+
+  it('every chained tsconfig.test.json / tsconfig.typetests.json exists on disk', () => {
+    // The repo-state half of objectui#4347, stated as a test rather than only as
+    // a gate rule. Named, not counted: a failure here has to say which package
+    // and which project, because that is the whole content of the finding.
+    const dangling = packages
+      .filter((p) => (p.chainsTestConfig && !p.hasTestConfig) || (p.chainsTypeTestsConfig && !p.hasTypeTestsConfig))
+      .map((p) => `${p.name}: ${p.typeCheck}`)
+      .sort();
+    expect(dangling).toEqual([]);
+  });
+});
+
 describe('every surviving narrow project is a package still in debt, in this repository', () => {
   const packages = collect(repoRoot);
   const withNarrow = packages.filter((p) => p.hasTypeTestsConfig);

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -45,6 +45,18 @@
  * against throwaway package trees, including the exact #3968 shape, so the
  * blind spots cannot be reintroduced by a simplification.
  *
+ * Both halves ask two independent questions about a chained project — does the
+ * file exist, and does `type-check` run it — and until objectui#4347 one of the
+ * four combinations was never examined: CHAINED BUT MISSING. Section 5½ opened
+ * with `if (!pkg.hasTypeTestsConfig) continue;` and section 5 with a test-file
+ * guard, so a `type-check` reading `tsc -p tsconfig.typetests.json` with no such
+ * file on disk passed at exit 0 (observed on `packages/auth` during #4291: the
+ * script was restored while the retired project stayed deleted). That state is
+ * LOUD — the chained `tsc` exits TS5058 on the very next run, so nothing ships —
+ * but this gate is the one check whose whole subject is the declared-vs-actually
+ * -runs mismatch, so its green line must not read past it. Both project kinds
+ * are now reported before their respective early `continue`.
+ *
  * Run:  node scripts/check-type-check-coverage.mjs
  * Exit: 0 = OK, 1 = coverage regressed or the lists are stale
  */
@@ -422,6 +434,20 @@ export function collect(repoRoot = root) {
 export const testsCovered = (pkg) =>
   !pkg.buildSkipsTests || (pkg.hasTestConfig && pkg.chainsTestConfig && pkg.testConfigSkips.length === 0);
 
+/**
+ * The "chained but missing" error, one spelling for both project kinds
+ * (objectui#4347).
+ *
+ * Written once on purpose: the two kinds are the same defect seen twice, and two
+ * hand-maintained copies of a message are how one of them quietly stops matching
+ * the other.
+ */
+const chainedButMissing = (pkg, config) =>
+  `${pkg.name} (${pkg.dir}): "type-check" chains ${config}, which does not exist.\n` +
+  `      Delete the chain entry, or restore the project. The chained \`tsc -p\` fails with TS5058\n` +
+  `      on the very next run, so nothing can ship in this state — but a coverage gate that reads\n` +
+  `      green here is claiming more than it checked, and this is the mismatch it exists to report.`;
+
 /** Up to `limit` of `paths`, rendered for an error message. */
 const listSome = (paths, limit = 3) =>
   paths.slice(0, limit).join(", ") + (paths.length > limit ? `, +${paths.length - limit} more` : "");
@@ -524,7 +550,21 @@ export function auditPackages(packages, tables = {}) {
 
   // ── 5. Tests are code too ──────────────────────────────────────────────────
   for (const pkg of packages) {
-    if (!pkg.hasScript || pkg.testFiles === 0) continue;
+    if (!pkg.hasScript) continue;
+
+    // 5·—. Chained but missing (objectui#4347). Asked BEFORE the test-file guard
+    //      below, because a dangling chain entry is broken whether or not the
+    //      package still has test files — deleting the tests and their project
+    //      while leaving the chain entry behind is one of the two ways to reach
+    //      this state, and the test-file guard is exactly what hid it. Reported
+    //      instead of the 5c "no `tsc` invocation reads them" message, not
+    //      alongside it: there is one defect here, and this names it.
+    if (pkg.chainsTestConfig && !pkg.hasTestConfig) {
+      errors.push(chainedButMissing(pkg, "tsconfig.test.json"));
+      continue;
+    }
+
+    if (pkg.testFiles === 0) continue;
 
     // 5·0. A config this gate cannot parse: every verdict below would be a guess,
     //      and a tsconfig that fails to parse falls back to including the whole
@@ -606,6 +646,16 @@ export function auditPackages(packages, tables = {}) {
   // `type-check` and one more config to keep in step. objectui#4291 retired the
   // six that had graduated; this ratchet is what stops the seventh appearing.
   for (const pkg of packages) {
+    // Chained but missing (objectui#4347) — the combination this section could
+    // not see, because it opened by skipping every package with no narrow
+    // project on disk. That is the state #4291's own repro landed in: the
+    // package's `type-check` was restored while the retired project stayed
+    // deleted, and the two green lines below printed anyway.
+    if (pkg.chainsTypeTestsConfig && !pkg.hasTypeTestsConfig) {
+      errors.push(chainedButMissing(pkg, "tsconfig.typetests.json"));
+      continue;
+    }
+
     if (!pkg.hasTypeTestsConfig) continue;
 
     // Redundant, not merely unnecessary: `testsCovered` is true only when every

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -53,9 +53,9 @@
  * file on disk passed at exit 0 (observed on `packages/auth` during #4291: the
  * script was restored while the retired project stayed deleted). That state is
  * LOUD — the chained `tsc` exits TS5058 on the very next run, so nothing ships —
- * but this gate is the one check whose whole subject is the declared-vs-actually
- * -runs mismatch, so its green line must not read past it. Both project kinds
- * are now reported before their respective early `continue`.
+ * but this gate is the one check whose whole subject is the mismatch between
+ * what is declared and what CI actually runs, so its green line must not read
+ * past it. Both project kinds are now reported before their early `continue`.
  *
  * Run:  node scripts/check-type-check-coverage.mjs
  * Exit: 0 = OK, 1 = coverage regressed or the lists are stale


### PR DESCRIPTION
Fixes #4347

`scripts/check-type-check-coverage.mjs` asks two independent questions about each chained tsconfig project — does the file exist (`has*Config`, a `readFileSync` in `collect()`) and does `type-check` run it (`chains*Config`, a regex over the script string) — and reported three of the four combinations. The fourth, **chained but missing**, was skipped by each section's entry guard: section 5½ opens with `if (!pkg.hasTypeTestsConfig) continue;`, and section 5 opened on `!pkg.hasScript || pkg.testFiles === 0`. A `type-check` reading `tsc --noEmit && tsc -p tsconfig.typetests.json` with no such file on disk passed this gate at exit 0.

## The change

Both project kinds are now reported before those guards, through one shared message builder so the two spellings cannot drift apart:

```
@object-ui/plugin-dashboard (packages/plugin-dashboard): "type-check" chains tsconfig.test.json, which does not exist.
      Delete the chain entry, or restore the project. The chained `tsc -p` fails with TS5058
      on the very next run, so nothing can ship in this state — but a coverage gate that reads
      green here is claiming more than it checked, and this is the mismatch it exists to report.
```

- **Section 5½** — reported before `if (!pkg.hasTypeTestsConfig) continue;`, exactly as the card specifies.
- **Section 5** — the entry guard is split, and the `tsconfig.test.json` case is asked between the halves, i.e. after `!pkg.hasScript` and before `pkg.testFiles === 0`. A dangling chain entry is broken whether or not the package still has test files, and deleting a package's tests together with their project while leaving the chain entry behind is one of the two ways to reach this state — the one the test-file guard hid completely.
- It **replaces** the vaguer 5c "N test files that no `tsc` invocation reads" message rather than stacking on it: there is one defect here, and 5c sends the reader to write a test project that the script already declares.

## The blind spot, demonstrated (#4118: pre-fix green, post-fix red)

The card's own observed repro, reproduced as a scratch mutation of real package state inside the worktree and reverted after capture: `packages/auth` chaining the `tsconfig.typetests.json` that #4291 retired, and `packages/plugin-dashboard` — the single remaining `TEST_DEBT` entry, as `auth` was at the time — chaining both projects, neither on disk.

Same tree state, both gates:

```
$ node scripts/check-type-check-coverage.mjs        # gate at origin/main
✅  type-check coverage: 43/45 via `type-check`, 1 via their own build, 0 known-broken ...
✅  test type-check coverage: 39/40 packages compile their tests, 1 declared debt ...
gate exit=0

$ node scripts/check-type-check-coverage.mjs        # gate in this PR
❌  type-check coverage regressed:
    • @object-ui/plugin-dashboard (packages/plugin-dashboard): "type-check" chains tsconfig.test.json, which does not exist.
    • @object-ui/auth (packages/auth): "type-check" chains tsconfig.typetests.json, which does not exist.
    • @object-ui/plugin-dashboard (packages/plugin-dashboard): "type-check" chains tsconfig.typetests.json, which does not exist.
gate exit=1
```

That the state really is broken, not merely undeclared:

```
$ cd packages/plugin-dashboard && pnpm exec tsc -p tsconfig.test.json
error TS5058: The specified path does not exist: 'tsconfig.test.json'.
```

## Real-repository verdict: clean

The fixed gate is green against the real repository — no package here chains a project that is not on disk, which is the expected result, and the new repo-state case in the self-test is what keeps it that way (it names the offender and its script rather than counting).

## Tests

`scripts/__tests__/check-type-check-coverage.test.ts` gains one describe block of five fixture cases plus one repo-state ratchet, following the suite's conventions (throwaway package trees, and the pre-fix entry guards reproduced verbatim as executable blind-spot predicates, the way the #3968 predicates are). The #4291 terminal assertions and the retired-list handling are untouched.

```
$ pnpm exec vitest run scripts/__tests__/check-type-check-coverage.test.ts --maxWorkers=1
 Test Files  1 passed (1)
      Tests  33 passed (33)

$ pnpm exec vitest run scripts/ --maxWorkers=1        # whole scripts/ suite
 Test Files  39 passed (39)
      Tests  899 passed (899)
```

Also green: `pnpm exec tsc -p tsconfig.scripts.json` (the program this test file belongs to), `eslint` on both touched files, `node scripts/check-control-bytes.mjs`, `node scripts/check-phantom-dependencies.mjs`, and `node scripts/check-changeset-presence.mjs` — the last reporting `No source of a released package changed in this range, so no changeset is owed` (scripts-only change), so no changeset and no `skip-changeset` label.

## Reverse verification

Direction predicted before running, and it is not uniform — two of the six new cases assert a direction that must NOT change, so they stay green by design:

- **Gate reverted to `origin/main`, new self-test cases kept** → `Tests 4 failed | 29 passed (33)`. The four cases asserting the new error go red; `says nothing when every chained project is really there` stays green (chained AND present was always quiet), and so does the repo-state ratchet (it judges repository state, not gate code — reverting the gate cannot move it).
- **Fix kept, repository mutated into the chained-but-missing state** → the repo-state ratchet goes red and names both offenders: `["@object-ui/auth: tsc --noEmit && tsc -p tsconfig.test.json && tsc -p tsconfig.typetests.json", "@object-ui/plugin-dashboard: ..."]`. The pre-existing #4291 retirement pin also fires on `auth`, which is the half of this combination the suite could already see — for the ten named retired packages only, and only for the narrow project.

Working tree verified clean after every capture; all mutations were made with `git checkout` restores, never `git stash`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_