### PR TITLE
feat(lint): require an explicit type on plain button elements; fix the 114-site population (#4045)

### DIFF
--- a/.changeset/button-has-type-lint-4045.md
+++ b/.changeset/button-has-type-lint-4045.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/components': patch
+'@object-ui/console': patch
+'@object-ui/plugin-ai': patch
+'@object-ui/plugin-designer': patch
+'@object-ui/plugin-kanban': patch
+'@object-ui/plugin-map': patch
+'@object-ui/plugin-view': patch
+'@object-ui/react': patch
+'@object-ui/runner': patch
+---
+
+Every plain `<button>` now declares its `type`. HTML defaults an untyped button to
+`type="submit"`, so any of these buttons would submit the form it was composed into
+instead of running its own handler — a real risk for renderers (`drawer`, `tree-view`,
+`navigation-overlay`) whose placement inside a form is a JSON metadata decision. 114
+sites were converted to `type="button"`; no site was a genuine submit button, and the
+DOM is otherwise unchanged.
+
+The defect class is now closed mechanically by a new `object-ui/button-has-type` ESLint
+rule (error), so the next untyped button fails CI at write time rather than being found
+by a fourth audit round (objectui#4045, closing the objectui#3344 family).

--- a/apps/console/src/components/PerformanceDashboard.tsx
+++ b/apps/console/src/components/PerformanceDashboard.tsx
@@ -129,7 +129,7 @@ export function PerformanceDashboard() {
   // Floating toggle button when closed
   if (!open) {
     return (
-      <button
+      <button type="button"
         onClick={() => setOpen(true)}
         className="fixed bottom-4 right-4 z-50 flex h-8 w-8 items-center justify-center rounded-full border border-border bg-background shadow-lg hover:bg-muted transition-colors"
         title="Performance Dashboard (Ctrl+Shift+P)"
@@ -163,14 +163,14 @@ export function PerformanceDashboard() {
           )}
         </div>
         <div className="flex items-center gap-1">
-          <button
+          <button type="button"
             onClick={() => setCollapsed(prev => !prev)}
             className="rounded p-1 hover:bg-muted transition-colors"
             title={collapsed ? 'Expand' : 'Collapse'}
           >
             {collapsed ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
           </button>
-          <button
+          <button type="button"
             onClick={() => setOpen(false)}
             className="rounded p-1 hover:bg-muted transition-colors"
             title="Close (Ctrl+Shift+P)"

--- a/apps/console/src/pages/developer/ApiConsolePage.tsx
+++ b/apps/console/src/pages/developer/ApiConsolePage.tsx
@@ -233,7 +233,7 @@ export function ApiConsolePage() {
         <div className="p-3 border-b space-y-2">
           <div className="flex items-center gap-2">
             <h3 className="text-sm font-semibold text-foreground flex-1">API Endpoints</h3>
-            <button
+            <button type="button"
               onClick={refresh}
               disabled={discovering}
               className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
@@ -271,7 +271,7 @@ export function ApiConsolePage() {
               return (
                 <Collapsible key={group.key} open={isExpanded} onOpenChange={() => toggleGroup(group.key)}>
                   <CollapsibleTrigger asChild>
-                    <button className="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors">
+                    <button type="button" className="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors">
                       <ChevronRight className={`h-3 w-3 shrink-0 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`} />
                       <span className="flex-1 text-left truncate">{group.label}</span>
                       <span className="shrink-0 text-[10px] tabular-nums opacity-60">{group.endpoints.length}</span>
@@ -282,7 +282,7 @@ export function ApiConsolePage() {
                       {group.endpoints.map((ep, i) => {
                         const isActive = selectedEndpoint === ep;
                         return (
-                          <button
+                          <button type="button"
                             key={`${ep.method}-${ep.path}-${i}`}
                             onClick={() => selectEndpoint(ep)}
                             className={`w-full text-left flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${
@@ -309,7 +309,7 @@ export function ApiConsolePage() {
         <div className="p-3 border-t space-y-2">
           <div className="flex items-center justify-between">
             <h4 className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Query Parameters</h4>
-            <button
+            <button type="button"
               onClick={() => addQueryParam()}
               className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
             >
@@ -320,7 +320,7 @@ export function ApiConsolePage() {
 
           <div className="flex flex-wrap gap-1">
             {QUERY_PARAM_PRESETS.map(preset => (
-              <button
+              <button type="button"
                 key={preset.key}
                 onClick={() => addQueryParam(preset.key, '')}
                 className="text-[10px] px-1.5 py-0.5 rounded border bg-muted/30 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors font-mono"
@@ -355,7 +355,7 @@ export function ApiConsolePage() {
                     placeholder="value"
                     className="flex-1 min-w-0 rounded border bg-background px-1.5 py-0.5 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-ring"
                   />
-                  <button
+                  <button type="button"
                     onClick={() => removeQueryParam(param.id)}
                     className="shrink-0 p-0.5 rounded text-muted-foreground hover:text-destructive transition-colors"
                   >
@@ -388,7 +388,7 @@ export function ApiConsolePage() {
               placeholder="/api/v1/..."
               onKeyDown={e => { if (e.key === 'Enter') sendRequest(); }}
             />
-            <button
+            <button type="button"
               onClick={sendRequest}
               disabled={loading || !effectiveUrl}
               className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
@@ -437,7 +437,7 @@ export function ApiConsolePage() {
                     {response.duration}ms
                   </span>
                 </div>
-                <button
+                <button type="button"
                   onClick={copyResponse}
                   className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
                 >
@@ -467,7 +467,7 @@ export function ApiConsolePage() {
                 <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   History ({history.length})
                 </h4>
-                <button
+                <button type="button"
                   onClick={() => setHistory([])}
                   className="inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
                 >
@@ -478,7 +478,7 @@ export function ApiConsolePage() {
               <div className="space-y-0.5 px-2 pb-2 max-h-60 overflow-auto">
                 {history.map(entry => (
                   <div key={entry.id} className="rounded border">
-                    <button
+                    <button type="button"
                       onClick={() => setExpandedHistory(expandedHistory === entry.id ? null : entry.id)}
                       className="w-full flex items-center gap-2 px-2 py-1.5 text-xs hover:bg-muted/30 transition-colors"
                     >
@@ -494,7 +494,7 @@ export function ApiConsolePage() {
                         {entry.status}
                       </span>
                       <span className="shrink-0 text-muted-foreground">{entry.duration}ms</span>
-                      <button
+                      <button type="button"
                         onClick={e => { e.stopPropagation(); replayHistoryEntry(entry); }}
                         className="shrink-0 p-0.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                         title="Replay request"

--- a/apps/site/app/playground/page.tsx
+++ b/apps/site/app/playground/page.tsx
@@ -1285,7 +1285,7 @@ export default function PlaygroundPage() {
                       ecommerce: 'E-commerce'
                     };
                     return (
-                      <button
+                      <button type="button"
                         key={key}
                         onClick={() => loadExample(key)}
                         className={`px-4 py-2 text-sm font-medium rounded-lg transition-all duration-200 ${
@@ -1346,7 +1346,7 @@ export default function PlaygroundPage() {
           </div>
 
           {/* Collapse/Expand Button */}
-          <button
+          <button type="button"
             onClick={() => setIsEditorCollapsed(!isEditorCollapsed)}
             className="absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-r-lg p-2 shadow-lg hover:shadow-xl hover:bg-slate-50 dark:hover:bg-slate-700 group transition-all duration-300"
             style={{ 
@@ -1371,7 +1371,7 @@ export default function PlaygroundPage() {
                 {(Object.keys(VIEW_MODES) as ViewMode[]).map((mode) => {
                   const ModeIcon = VIEW_MODES[mode].icon;
                   return (
-                    <button
+                    <button type="button"
                       key={mode}
                       onClick={() => setViewMode(mode)}
                       className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 ${

--- a/apps/site/components/ai/page-actions.tsx
+++ b/apps/site/components/ai/page-actions.tsx
@@ -40,7 +40,7 @@ export function LLMCopyButton({
   });
 
   return (
-    <button
+    <button type="button"
       disabled={isLoading}
       className={cn(
         buttonVariants({

--- a/eslint-rules/button-has-type.js
+++ b/eslint-rules/button-has-type.js
@@ -1,0 +1,100 @@
+/**
+ * ObjectUI ESLint rule: button-has-type
+ *
+ * Requires every plain `<button>` JSX element to declare `type`.
+ *
+ * HTML's default for a `<button>` with no `type` is `type="submit"`. Inside a
+ * `<form>` that makes every untyped button a submit button: one click submits
+ * the enclosing form (full page reload / duplicate save / lost draft) instead
+ * of running its own handler. The trap is that the button's own file usually
+ * looks innocent — the defect only appears once the component is COMPOSED into
+ * a form, which in a server-driven-UI renderer is a JSON metadata decision made
+ * by someone who never reads this file. So "it isn't in a form today" is not a
+ * defence, it is the dormancy.
+ *
+ * This is mechanical because the prose did not hold. The same defect class was
+ * patched one instance at a time three times — objectui#3344 (combobox
+ * trigger), objectstack#5236 / PR #3926 (`filter-tab-add`), objectstack#6952 /
+ * PR #3948 (`UserFilters`) — and each round only covered the sites that were
+ * being looked at that day, while the population stayed in the hundreds and
+ * nothing stopped the next one from being written (objectui#4045). The rule
+ * ends the class instead of the instances: `type` is not in the type system
+ * (React's `ButtonHTMLAttributes.type` is optional), so nothing else rejects it
+ * at write time.
+ *
+ * Flagged: the lowercase intrinsic `button` only. A `<Button>` COMPONENT is a
+ * different contract — its own implementation is responsible for the DOM
+ * attribute, and `@object-ui/components`' Button already sets it.
+ *
+ * A `{...spread}` does NOT satisfy the rule. It may or may not carry `type` at
+ * runtime and no checker can tell which, so exempting it would reopen the hole
+ * for exactly the buttons whose props come from elsewhere. Measured cost of the
+ * strict reading at the time of writing: one site in the whole repo has a real
+ * JSX spread attribute on a `<button>` (`plugin-view/ManageViewsDialog.tsx`)
+ * and it already declares `type="button"` explicitly.
+ *
+ * Radix `*Trigger asChild` children are NOT special-cased. They are flagged
+ * like any other button — deliberately. Radix's `Primitive.button` does supply
+ * `type="button"` through its Slot today (verified on
+ * `@radix-ui/react-popover@1.1.23`, `dist/index.mjs:89`), so those sites are
+ * covered *at runtime*, but that is an upstream implementation detail, not a
+ * contract — which is precisely the note
+ * `packages/components/src/custom/combobox.tsx` already carries ("declare the
+ * contract locally"). Declaring it locally is cheap and survives an upstream
+ * change.
+ *
+ * No autofixer on purpose. `type="button"` is the right answer for nearly every
+ * site, but "nearly" is the problem: a genuine submit button silently rewritten
+ * to `type="button"` stops submitting its form, and that failure is invisible
+ * to every test that does not click it. The author picks `button` / `submit` /
+ * `reset`; the rule only refuses to let the choice go unmade.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+
+const CORRECTION =
+  'Add `type="button"` (or `type="submit"` / `type="reset"` if that is genuinely what it does).';
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require an explicit `type` on plain `<button>` elements — HTML defaults to type="submit", so an untyped button submits any form it is composed into (objectui#3344 family, objectui#4045).',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      missingType: `This <button> does not declare \`type\`, so HTML defaults it to \`type="submit"\` — composed into a <form> it submits the form instead of running its own handler (objectui#3344 family, objectui#4045). ${CORRECTION}`,
+      spreadType: `This <button> does not declare \`type\` — a {...spread} may or may not carry one at runtime, which is exactly the case that cannot be checked (objectui#4045). Declare it on the element: ${CORRECTION}`,
+    },
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        // Intrinsic `button` only — `<Button>` is a component contract.
+        if (node.name?.type !== 'JSXIdentifier' || node.name.name !== 'button') {
+          return;
+        }
+        let hasSpread = false;
+        for (const attr of node.attributes) {
+          if (attr.type === 'JSXSpreadAttribute') {
+            hasSpread = true;
+            continue;
+          }
+          if (
+            attr.type === 'JSXAttribute' &&
+            attr.name?.type === 'JSXIdentifier' &&
+            attr.name.name === 'type'
+          ) {
+            return;
+          }
+        }
+        context.report({
+          node,
+          messageId: hasSpread ? 'spreadType' : 'missingType',
+        });
+      },
+    };
+  },
+};

--- a/eslint-rules/button-has-type.test.js
+++ b/eslint-rules/button-has-type.test.js
@@ -1,0 +1,90 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit test for the local ESLint rule that requires an explicit `type` on plain
+ * <button> elements (objectui#4045). Plain JS so it needs no package tsconfig.
+ */
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from './button-has-type.js';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run('button-has-type', rule, {
+  valid: [
+    // The three legal values, each declared explicitly.
+    '<button type="button">Go</button>',
+    '<button type="submit">Save</button>',
+    '<button type="reset">Reset</button>',
+    // An expression is a declaration too — the author made the choice.
+    '<button type={isSubmit ? "submit" : "button"}>Go</button>',
+    // Order does not matter; `type` may sit after other props.
+    '<button onClick={run} className="x" type="button">Go</button>',
+    // A spread PLUS an explicit type is fine — the element declares it.
+    '<button type="button" {...props}>Go</button>',
+    // A <Button> COMPONENT is a different contract (its implementation owns the
+    // DOM attribute); only the lowercase intrinsic is this rule's business.
+    '<Button onClick={run}>Go</Button>',
+    '<UI.Button onClick={run}>Go</UI.Button>',
+    // Other intrinsics are untouched, including ones with their own `type`.
+    '<input onChange={run} />',
+    '<div role="button" onClick={run} />',
+    // Not a JSX element at all.
+    'const button = { type: undefined };',
+  ],
+  invalid: [
+    // The bare case — the whole population's shape.
+    {
+      code: '<button onClick={run}>Go</button>',
+      errors: [{ messageId: 'missingType' }],
+    },
+    // No attributes at all.
+    {
+      code: '<button>Go</button>',
+      errors: [{ messageId: 'missingType' }],
+    },
+    // Self-closing.
+    {
+      code: '<button className="x" />',
+      errors: [{ messageId: 'missingType' }],
+    },
+    // A spread cannot stand in for the declaration: whether it carries `type`
+    // is unknowable statically, which is the case the rule exists for. Distinct
+    // messageId so the report says why the spread did not save it.
+    {
+      code: '<button {...props}>Go</button>',
+      errors: [{ messageId: 'spreadType' }],
+    },
+    {
+      code: '<button {...attributes} {...listeners} aria-label="Drag" />',
+      errors: [{ messageId: 'spreadType' }],
+    },
+    // A near-miss attribute name does not count as declaring `type`.
+    {
+      code: '<button buttonType="submit" data-type="x">Go</button>',
+      errors: [{ messageId: 'missingType' }],
+    },
+    // A Radix `asChild` trigger child is flagged like any other button: Radix's
+    // Primitive.button supplies `type` through its Slot today, but that is an
+    // upstream implementation detail, not a contract (objectui#4045, and the
+    // note in packages/components/src/custom/combobox.tsx).
+    {
+      code: '<PopoverTrigger asChild><button onClick={run}>Filter</button></PopoverTrigger>',
+      errors: [{ messageId: 'missingType' }],
+    },
+    // Every untyped button reports — the rule counts sites, not files.
+    {
+      code: '<div><button>A</button><button>B</button></div>',
+      errors: [{ messageId: 'missingType' }, { messageId: 'missingType' }],
+    },
+  ],
+});

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -5,6 +5,7 @@ import noSyntheticEventTrigger from './no-synthetic-event-trigger.js';
 import noInlineSpecConfig from './no-inline-spec-config.js';
 import noTryCatchAroundHook from './no-try-catch-around-hook.js';
 import noDynamicImportInTestHook from './no-dynamic-import-in-test-hook.js';
+import buttonHasType from './button-has-type.js';
 
 export default {
   rules: {
@@ -12,5 +13,6 @@ export default {
     'no-inline-spec-config': noInlineSpecConfig,
     'no-try-catch-around-hook': noTryCatchAroundHook,
     'no-dynamic-import-in-test-hook': noDynamicImportInTestHook,
+    'button-has-type': buttonHasType,
   },
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,6 +98,29 @@ export default tseslint.config({
     'object-ui/no-dynamic-import-in-test-hook': 'error',
   },
 }, {
+  // objectui#4045 ratchet — a `<button>` with no `type` is `type="submit"` per
+  // HTML, so it submits any <form> it is composed into instead of running its
+  // own handler. In an SDUI renderer that composition is a JSON metadata
+  // decision made far from the button's own file, so "not in a form today" is
+  // the dormancy, not a defence. Three per-instance rounds (objectui#3344,
+  // objectstack#5236, objectstack#6952) each fixed the sites in view and left
+  // the rest; nothing rejected the next one at write time, because `type` is
+  // optional in React's ButtonHTMLAttributes. Error so the next one fails CI;
+  // the whole population was converted first, so this lints clean today.
+  //
+  // Ignores mirror the population's counting rules exactly (objectui#4045):
+  //  - `src/ui/**` is the upstream Shadcn zone, overwritten by the sync script
+  //    and never hand-edited (AGENTS.md #7) — enforcing there would demand an
+  //    edit the repo forbids.
+  //  - test files render buttons into a test DOM, never into a product form,
+  //    and their fixtures are deliberately minimal.
+  files: ['**/*.tsx'],
+  ignores: ['**/src/ui/**', '**/*.test.tsx', '**/__tests__/**'],
+  plugins: { 'object-ui': objectUi },
+  rules: {
+    'object-ui/button-has-type': 'error',
+  },
+}, {
   // Type-discipline ratchet, scoped to the canonical view-schema file: a
   // spec-backed view-config field must reference its @objectstack/spec type,
   // never redefine it inline (a hand mirror silently drifts from the spec →

--- a/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
+++ b/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
@@ -234,7 +234,7 @@ export function OrganizationsPage() {
             const isActive = org.id === activeOrganization?.id;
             const isSwitching = switchingId === org.id;
             return (
-              <button
+              <button type="button"
                 key={org.id}
                 onClick={() => handleSelect(org)}
                 disabled={isSwitching}

--- a/packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx
+++ b/packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx
@@ -149,7 +149,7 @@ export function InvitationsPage() {
       {/* Filter tabs */}
       <div className="flex gap-1 border-b">
         {tabs.map((tab) => (
-          <button
+          <button type="button"
             key={tab}
             onClick={() => setFilter(tab)}
             className={`px-3 py-2 text-sm font-medium border-b-2 transition-colors capitalize ${

--- a/packages/app-shell/src/console/organizations/manage/OrganizationLayout.tsx
+++ b/packages/app-shell/src/console/organizations/manage/OrganizationLayout.tsx
@@ -91,7 +91,7 @@ export function OrganizationLayout() {
               would just dump them on home. Hide it for them; they leave via the
               global header (logo / app switcher). */}
           {(organizations ?? []).length > 1 && (
-            <button
+            <button type="button"
               onClick={() => navigate('/organizations')}
               className="mb-3 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
             >

--- a/packages/app-shell/src/layout/AppSwitcher.tsx
+++ b/packages/app-shell/src/layout/AppSwitcher.tsx
@@ -53,7 +53,7 @@ export function AppSwitcher({ activeAppName, onAppChange }: AppSwitcherProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="flex items-center gap-1 rounded-md px-1.5 py-1 text-sm font-medium text-foreground/80 hover:bg-accent hover:text-foreground transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring max-w-[40vw] sm:max-w-none">
+        <button type="button" className="flex items-center gap-1 rounded-md px-1.5 py-1 text-sm font-medium text-foreground/80 hover:bg-accent hover:text-foreground transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring max-w-[40vw] sm:max-w-none">
           <span className="truncate whitespace-nowrap">{appLabelText}</span>
           <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         </button>

--- a/packages/app-shell/src/views/MetadataInspector.tsx
+++ b/packages/app-shell/src/views/MetadataInspector.tsx
@@ -89,7 +89,7 @@ export function MetadataPanel({ sections, open }: Omit<MetadataInspectorProps, '
           return (
             <div key={index} className="border-b last:border-b-0">
               <div className="flex items-center justify-between px-4 py-3 hover:bg-muted/5 transition-colors">
-                <button
+                <button type="button"
                   onClick={() => toggleSection(sectionId)}
                   className="flex-1 flex items-center justify-between text-left"
                 >
@@ -102,7 +102,7 @@ export function MetadataPanel({ sections, open }: Omit<MetadataInspectorProps, '
                     <ChevronRight className="h-3 w-3 text-muted-foreground ml-2" />
                   )}
                 </button>
-                <button
+                <button type="button"
                   onClick={() => handleCopy(section.data, index)}
                   className="p-1 hover:bg-muted rounded transition-colors ml-2"
                   title={t('layout.metadata.copyJson')}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -890,7 +890,7 @@ function NavTree({
         const Icon: React.ElementType = node.icon ? getIcon(node.icon) : objIcon ? getIcon(objIcon) : navIcon(node.type);
         const isActive = !!surface && active?.type === surface.type && active?.name === surface.name;
         return (
-          <button
+          <button type="button"
             key={node.id ?? i}
             onClick={() => surface && onPick(surface)}
             disabled={!surface}
@@ -1636,7 +1636,7 @@ function InterfacesPillar({
             {t('engine.studio.unpublishedDraft', locale)}
           </span>
         )}
-        <button
+        <button type="button"
           onClick={doSave}
           disabled={!current || !isEditable || !!saving || readOnly}
           title={readOnly ? t('engine.studio.pkg.readonlyHint', locale) : undefined}
@@ -1698,7 +1698,7 @@ function InterfacesPillar({
                     {t('engine.studio.unpublished', locale)}
                   </span>
                 )}
-                <button
+                <button type="button"
                   onClick={doNavSave}
                   disabled={!navDirty || !!navSaving}
                   className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] hover:bg-muted disabled:opacity-50"
@@ -2257,7 +2257,7 @@ export function DataPillar({
             })}
           </span>
         )}
-        <button
+        <button type="button"
           onClick={doSave}
           disabled={!current || !dirty || !!saving || readOnly}
           title={readOnly ? t('engine.studio.pkg.readonlyHint', locale) : undefined}
@@ -2311,7 +2311,7 @@ export function DataPillar({
               .map((o) => {
                 const Icon = getIcon(o.icon);
                 return (
-                  <button
+                  <button type="button"
                     key={o.name}
                     onClick={() => {
                       setCurrent(o);
@@ -2995,7 +2995,7 @@ function AutomationsPillar({
             {flowEnabled ? t('engine.studio.auto.enabled', locale) : t('engine.studio.auto.disabled', locale)}
           </button>
         )}
-        <button
+        <button type="button"
           onClick={doSave}
           disabled={!current || !isEditable || !!saving || readOnly}
           title={readOnly ? t('engine.studio.pkg.readonlyHint', locale) : undefined}
@@ -3039,7 +3039,7 @@ function AutomationsPillar({
           </div>
           {flows.length > 0 &&
             flows.map((f) => (
-              <button
+              <button type="button"
                 key={f.name}
                 onClick={() => {
                   setCurrent(f);
@@ -3481,7 +3481,7 @@ export function AccessPillar({
               </p>
             )}
             {filtered.map((p) => (
-              <button
+              <button type="button"
                 key={p.name}
                 onClick={() => {
                   // Re-clicking the already-open set is a no-op — nothing

--- a/packages/components/src/custom/navigation-overlay.tsx
+++ b/packages/components/src/custom/navigation-overlay.tsx
@@ -525,7 +525,7 @@ export const NavigationOverlay: React.FC<NavigationOverlayProps> = ({
           <div className="h-full overflow-y-auto p-4">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold">{resolvedTitle}</h3>
-              <button
+              <button type="button"
                 onClick={close}
                 className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                 aria-label={t('common.closePanel')}

--- a/packages/components/src/debug/DebugPanel.tsx
+++ b/packages/components/src/debug/DebugPanel.tsx
@@ -272,7 +272,7 @@ export function DebugPanel({
         <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           🛠 Debug Panel
         </span>
-        <button
+        <button type="button"
           onClick={onClose}
           className="text-muted-foreground hover:text-foreground text-sm leading-none px-1"
           aria-label="Close debug panel"
@@ -285,7 +285,7 @@ export function DebugPanel({
       {/* Tabs */}
       <div className="flex border-b overflow-x-auto" role="tablist">
         {allTabs.map((tab) => (
-          <button
+          <button type="button"
             key={tab.id}
             role="tab"
             aria-selected={tab.id === activeTab?.id}

--- a/packages/components/src/renderers/data-display/tree-view.tsx
+++ b/packages/components/src/renderers/data-display/tree-view.tsx
@@ -45,7 +45,7 @@ const TreeNodeComponent = ({
         onClick={handleClick}
       >
         {hasChildren ? (
-          <button
+          <button type="button"
             onClick={handleToggle}
             className="mr-2 p-0.5 h-5 w-5 flex items-center justify-center rounded-sm hover:bg-muted text-muted-foreground transition-colors"
           >

--- a/packages/components/src/renderers/overlay/drawer.tsx
+++ b/packages/components/src/renderers/overlay/drawer.tsx
@@ -35,7 +35,7 @@ ComponentRegistry.register('drawer',
         {schema.footer && (
           <DrawerFooter>
              {renderChildren(schema.footer)}
-             {schema.showClose && <DrawerClose asChild><button>Close</button></DrawerClose>} 
+             {schema.showClose && <DrawerClose asChild><button type="button">Close</button></DrawerClose>} 
           </DrawerFooter>
         )}
       </DrawerContent>

--- a/packages/plugin-ai/src/NLQueryInput.tsx
+++ b/packages/plugin-ai/src/NLQueryInput.tsx
@@ -106,7 +106,7 @@ export const NLQueryInput: React.FC<NLQueryInputProps> = ({ schema, onSubmit: on
           {suggestions.length > 0 && !result && (
             <div className="mt-3 flex flex-wrap gap-2">
               {suggestions.map((suggestion: string, idx: number) => (
-                <button
+                <button type="button"
                   key={idx}
                   onClick={() => handleSuggestionClick(suggestion)}
                   className="text-xs px-2.5 py-1 rounded-full border bg-muted/30 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
@@ -190,7 +190,7 @@ export const NLQueryInput: React.FC<NLQueryInputProps> = ({ schema, onSubmit: on
           </CardHeader>
           <CardContent className="space-y-1">
             {history.slice(0, 5).map((item: { query: string; timestamp: string }, idx: number) => (
-              <button
+              <button type="button"
                 key={idx}
                 onClick={() => handleSuggestionClick(item.query)}
                 className="w-full flex items-center gap-2 p-2 rounded-md text-sm text-left hover:bg-muted/50 transition-colors"

--- a/packages/plugin-designer/src/DataModelDesigner.tsx
+++ b/packages/plugin-designer/src/DataModelDesigner.tsx
@@ -508,7 +508,7 @@ export function DataModelDesigner({
 
           {/* Undo/Redo */}
           <div className="flex items-center gap-1 ml-2 border-l pl-2">
-            <button
+            <button type="button"
               onClick={() => undoRedo.undo()}
               disabled={!undoRedo.canUndo}
               aria-label="Undo"
@@ -517,7 +517,7 @@ export function DataModelDesigner({
             >
               <Undo2 className="h-3.5 w-3.5" />
             </button>
-            <button
+            <button type="button"
               onClick={() => undoRedo.redo()}
               disabled={!undoRedo.canRedo}
               aria-label="Redo"
@@ -530,7 +530,7 @@ export function DataModelDesigner({
 
           {/* Zoom controls */}
           <div className="flex items-center gap-1 border-l pl-2">
-            <button
+            <button type="button"
               onClick={panZoom.zoomOut}
               aria-label="Zoom Out"
               title="Zoom Out"
@@ -539,7 +539,7 @@ export function DataModelDesigner({
               <ZoomOut className="h-3.5 w-3.5" />
             </button>
             <span className="text-xs tabular-nums w-10 text-center">{Math.round(panZoom.zoom * 100)}%</span>
-            <button
+            <button type="button"
               onClick={panZoom.zoomIn}
               aria-label="Zoom In"
               title="Zoom In"
@@ -547,7 +547,7 @@ export function DataModelDesigner({
             >
               <ZoomIn className="h-3.5 w-3.5" />
             </button>
-            <button
+            <button type="button"
               onClick={panZoom.resetZoom}
               aria-label="Reset Zoom"
               title="Reset Zoom"
@@ -560,7 +560,7 @@ export function DataModelDesigner({
           {/* Copy/Paste */}
           {!readOnly && (
             <div className="flex items-center gap-1 border-l pl-2">
-              <button
+              <button type="button"
                 onClick={handleCopy}
                 disabled={multiSelect.count === 0}
                 aria-label="Copy"
@@ -569,7 +569,7 @@ export function DataModelDesigner({
               >
                 <Copy className="h-3.5 w-3.5" />
               </button>
-              <button
+              <button type="button"
                 onClick={handlePaste}
                 disabled={!clipboard.hasContent}
                 aria-label="Paste"
@@ -583,7 +583,7 @@ export function DataModelDesigner({
 
           {/* Auto-layout */}
           {!readOnly && (
-            <button
+            <button type="button"
               onClick={handleAutoLayout}
               aria-label="Auto Layout"
               title="Auto Layout"
@@ -611,14 +611,14 @@ export function DataModelDesigner({
           {/* Add entity / relationship buttons */}
           {!readOnly && (
             <>
-              <button
+              <button type="button"
                 onClick={handleAddEntity}
                 aria-label="Add Entity"
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-primary text-primary-foreground hover:bg-primary/90"
               >
                 <Plus className="h-3 w-3" /> Add Entity
               </button>
-              <button
+              <button type="button"
                 aria-label="Add Relationship"
                 title="Add Relationship (coming soon)"
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-secondary text-secondary-foreground hover:bg-secondary/80"
@@ -748,7 +748,7 @@ export function DataModelDesigner({
                     </span>
                   )}
                   {!readOnly && (
-                    <button
+                    <button type="button"
                       onClick={(e) => {
                         e.stopPropagation();
                         void handleDeleteEntity(entity.id);
@@ -826,7 +826,7 @@ export function DataModelDesigner({
                 {/* Add field button */}
                 {!readOnly && (
                   <div className="px-3 py-1 border-t">
-                    <button
+                    <button type="button"
                       onClick={(e) => {
                         e.stopPropagation();
                         handleAddField(entity.id);
@@ -859,7 +859,7 @@ export function DataModelDesigner({
       <div className="w-64 border-l flex flex-col bg-background shrink-0">
         {/* Properties panel */}
         <div className="flex flex-col flex-1 min-h-0">
-          <button
+          <button type="button"
             onClick={() => setShowProperties((v) => !v)}
             className="flex items-center gap-1 px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-accent/50 border-b"
             aria-expanded={showProperties}
@@ -881,7 +881,7 @@ export function DataModelDesigner({
 
         {/* Minimap toggle */}
         <div className="border-t">
-          <button
+          <button type="button"
             onClick={() => setShowMinimap((v) => !v)}
             className="flex items-center gap-1 px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-accent/50 w-full"
             aria-expanded={showMinimap}

--- a/packages/plugin-designer/src/PageDesigner.tsx
+++ b/packages/plugin-designer/src/PageDesigner.tsx
@@ -411,7 +411,7 @@ export function PageDesigner({
                       {category.label}
                     </div>
                     {category.items.map((item: DesignerPaletteItem) => (
-                      <button
+                      <button type="button"
                         key={item.type}
                         onClick={() => handleAddComponent(item.type, item.label)}
                         className="w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded hover:bg-accent text-left"
@@ -438,7 +438,7 @@ export function PageDesigner({
         >
           {/* Left panel toggle */}
           {!readOnly && (
-            <button
+            <button type="button"
               className="p-1.5 rounded hover:bg-accent"
               title={leftPanelOpen ? 'Collapse palette' : 'Expand palette'}
               aria-label={leftPanelOpen ? 'Collapse palette' : 'Expand palette'}
@@ -452,7 +452,7 @@ export function PageDesigner({
           {undoRedoEnabled && !readOnly && (
             <>
               <div className="w-px h-5 bg-border mx-1" />
-              <button
+              <button type="button"
                 className={cn('p-1.5 rounded hover:bg-accent', !history.canUndo && 'opacity-40 pointer-events-none')}
                 title="Undo (Ctrl+Z)"
                 aria-label="Undo"
@@ -461,7 +461,7 @@ export function PageDesigner({
               >
                 <Undo2 className="h-4 w-4" />
               </button>
-              <button
+              <button type="button"
                 className={cn('p-1.5 rounded hover:bg-accent', !history.canRedo && 'opacity-40 pointer-events-none')}
                 title="Redo (Ctrl+Shift+Z)"
                 aria-label="Redo"
@@ -477,7 +477,7 @@ export function PageDesigner({
           {/* Copy / Paste */}
           {!readOnly && (
             <>
-              <button
+              <button type="button"
                 className={cn('p-1.5 rounded hover:bg-accent', multiSelect.count === 0 && 'opacity-40 pointer-events-none')}
                 title="Copy (Ctrl+C)"
                 aria-label="Copy"
@@ -486,7 +486,7 @@ export function PageDesigner({
               >
                 <Copy className="h-4 w-4" />
               </button>
-              <button
+              <button type="button"
                 className={cn('p-1.5 rounded hover:bg-accent', !clipboard.hasContent && 'opacity-40 pointer-events-none')}
                 title="Paste (Ctrl+V)"
                 aria-label="Paste"
@@ -501,7 +501,7 @@ export function PageDesigner({
 
           {/* Delete selected */}
           {!readOnly && (
-            <button
+            <button type="button"
               className={cn('p-1.5 rounded hover:bg-accent', multiSelect.count === 0 && 'opacity-40 pointer-events-none')}
               title="Delete selected"
               aria-label="Delete selected"
@@ -512,12 +512,12 @@ export function PageDesigner({
             </button>
           )}
 
-          <button className="p-1.5 rounded hover:bg-accent" title="Preview" aria-label="Preview">
+          <button type="button" className="p-1.5 rounded hover:bg-accent" title="Preview" aria-label="Preview">
             <Eye className="h-4 w-4" />
           </button>
 
           {/* Minimap toggle */}
-          <button
+          <button type="button"
             className={cn('p-1.5 rounded hover:bg-accent', minimapVisible && 'bg-accent')}
             title="Toggle minimap"
             aria-label="Toggle minimap"
@@ -530,7 +530,7 @@ export function PageDesigner({
 
           {/* Zoom controls */}
           <div className="flex items-center gap-1">
-            <button
+            <button type="button"
               className="p-1 rounded hover:bg-accent text-xs"
               aria-label="Zoom out"
               onClick={panZoom.zoomOut}
@@ -540,14 +540,14 @@ export function PageDesigner({
             <span className="text-xs text-muted-foreground w-10 text-center">
               {Math.round(zoom * 100)}%
             </span>
-            <button
+            <button type="button"
               className="p-1 rounded hover:bg-accent text-xs"
               aria-label="Zoom in"
               onClick={panZoom.zoomIn}
             >
               <Plus className="h-3 w-3" />
             </button>
-            <button
+            <button type="button"
               className="p-1 rounded hover:bg-accent text-xs"
               aria-label="Reset zoom"
               onClick={panZoom.resetZoom}
@@ -558,7 +558,7 @@ export function PageDesigner({
 
           {/* Right panel toggle */}
           {showComponentTree && (
-            <button
+            <button type="button"
               className="p-1.5 rounded hover:bg-accent"
               title={rightPanelOpen ? 'Collapse panel' : 'Expand panel'}
               aria-label={rightPanelOpen ? 'Collapse panel' : 'Expand panel'}
@@ -625,7 +625,7 @@ export function PageDesigner({
                     <GripVertical className="h-3 w-3 text-muted-foreground" />
                     <span className="truncate">{comp.label ?? comp.type}</span>
                     {!readOnly && (
-                      <button
+                      <button type="button"
                         onClick={(e) => {
                           e.stopPropagation();
                           handleDeleteComponent(comp.id);
@@ -678,7 +678,7 @@ export function PageDesigner({
                   </div>
                 ) : (
                   components.map((comp) => (
-                    <button
+                    <button type="button"
                       key={comp.id}
                       onClick={(e) => multiSelect.toggle(comp.id, e.shiftKey)}
                       className={cn(

--- a/packages/plugin-designer/src/ProcessDesigner.tsx
+++ b/packages/plugin-designer/src/ProcessDesigner.tsx
@@ -556,7 +556,7 @@ export function ProcessDesigner({
           {!readOnly && (
             <div className="flex items-center gap-1">
               {/* Undo / Redo */}
-              <button
+              <button type="button"
                 onClick={() => undoRedo.undo()}
                 disabled={!undoRedo.canUndo}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent disabled:opacity-40"
@@ -565,7 +565,7 @@ export function ProcessDesigner({
               >
                 <Undo2 className="h-3 w-3" />
               </button>
-              <button
+              <button type="button"
                 onClick={() => undoRedo.redo()}
                 disabled={!undoRedo.canRedo}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent disabled:opacity-40"
@@ -578,7 +578,7 @@ export function ProcessDesigner({
               <div className="w-px h-4 bg-border mx-1" />
 
               {/* Copy / Paste */}
-              <button
+              <button type="button"
                 onClick={handleCopy}
                 disabled={multiSelect.count === 0 && !selectedNodeId}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent disabled:opacity-40"
@@ -587,7 +587,7 @@ export function ProcessDesigner({
               >
                 <Copy className="h-3 w-3" />
               </button>
-              <button
+              <button type="button"
                 onClick={handlePaste}
                 disabled={!clipboard.hasContent}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent disabled:opacity-40"
@@ -600,7 +600,7 @@ export function ProcessDesigner({
               <div className="w-px h-4 bg-border mx-1" />
 
               {/* Connect mode */}
-              <button
+              <button type="button"
                 onClick={handleToggleConnectMode}
                 className={cn(
                   'flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent',
@@ -614,7 +614,7 @@ export function ProcessDesigner({
               </button>
 
               {/* Auto-layout */}
-              <button
+              <button type="button"
                 onClick={handleAutoLayout}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Auto layout"
@@ -626,7 +626,7 @@ export function ProcessDesigner({
               <div className="w-px h-4 bg-border mx-1" />
 
               {/* Zoom controls */}
-              <button
+              <button type="button"
                 onClick={panZoom.zoomIn}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Zoom in"
@@ -637,7 +637,7 @@ export function ProcessDesigner({
               <span className="text-xs tabular-nums min-w-[3ch] text-center" aria-label="Zoom level">
                 {Math.round(panZoom.zoom * 100)}%
               </span>
-              <button
+              <button type="button"
                 onClick={panZoom.zoomOut}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Zoom out"
@@ -645,7 +645,7 @@ export function ProcessDesigner({
               >
                 <ZoomOut className="h-3 w-3" />
               </button>
-              <button
+              <button type="button"
                 onClick={panZoom.resetZoom}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Reset zoom"
@@ -657,7 +657,7 @@ export function ProcessDesigner({
               <div className="w-px h-4 bg-border mx-1" />
 
               {/* Add node buttons */}
-              <button
+              <button type="button"
                 onClick={() => handleAddNode('start-event', 'Start')}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Add Start Event"
@@ -665,7 +665,7 @@ export function ProcessDesigner({
               >
                 <Play className="h-3 w-3 text-green-600" /> Start
               </button>
-              <button
+              <button type="button"
                 onClick={() => handleAddNode('user-task', 'User Task')}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Add User Task"
@@ -673,7 +673,7 @@ export function ProcessDesigner({
               >
                 <Square className="h-3 w-3 text-blue-600" /> Task
               </button>
-              <button
+              <button type="button"
                 onClick={() => handleAddNode('exclusive-gateway', 'Decision')}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Add Gateway"
@@ -681,7 +681,7 @@ export function ProcessDesigner({
               >
                 <Diamond className="h-3 w-3 text-yellow-600" /> Gateway
               </button>
-              <button
+              <button type="button"
                 onClick={() => handleAddNode('end-event', 'End')}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title="Add End Event"
@@ -693,7 +693,7 @@ export function ProcessDesigner({
               <div className="w-px h-4 bg-border mx-1" />
 
               {/* Toggle property panel */}
-              <button
+              <button type="button"
                 onClick={() => setShowPropertyPanel((p) => !p)}
                 className="flex items-center gap-1 px-2 py-1 text-xs rounded hover:bg-accent"
                 title={showPropertyPanel ? 'Hide properties' : 'Show properties'}
@@ -905,7 +905,7 @@ export function ProcessDesigner({
 
                   {/* Delete button */}
                   {!readOnly && isSelected && !connectMode && (
-                    <button
+                    <button type="button"
                       onClick={(e) => {
                         e.stopPropagation();
                         handleDeleteNode(node.id);

--- a/packages/plugin-designer/src/ReportDesigner.tsx
+++ b/packages/plugin-designer/src/ReportDesigner.tsx
@@ -527,7 +527,7 @@ export function ReportDesigner({
             {!readOnly && (
               <>
                 <div className="w-px h-5 bg-border mx-1" />
-                <button
+                <button type="button"
                   className={cn('p-1.5 rounded hover:bg-accent', !history.canUndo && 'opacity-40 pointer-events-none')}
                   title={LABELS.undoShortcut}
                   aria-label={LABELS.undo}
@@ -536,7 +536,7 @@ export function ReportDesigner({
                 >
                   <Undo2 className="h-4 w-4" />
                 </button>
-                <button
+                <button type="button"
                   className={cn('p-1.5 rounded hover:bg-accent', !history.canRedo && 'opacity-40 pointer-events-none')}
                   title={LABELS.redoShortcut}
                   aria-label={LABELS.redo}
@@ -552,7 +552,7 @@ export function ReportDesigner({
             {/* Copy / Paste */}
             {!readOnly && (
               <>
-                <button
+                <button type="button"
                   className={cn('p-1.5 rounded hover:bg-accent', multiSelect.count === 0 && 'opacity-40 pointer-events-none')}
                   title={LABELS.copyShortcut}
                   aria-label={LABELS.copy}
@@ -561,7 +561,7 @@ export function ReportDesigner({
                 >
                   <Copy className="h-4 w-4" />
                 </button>
-                <button
+                <button type="button"
                   className={cn('p-1.5 rounded hover:bg-accent', !clipboard.hasContent && 'opacity-40 pointer-events-none')}
                   title={LABELS.pasteShortcut}
                   aria-label={LABELS.paste}
@@ -576,7 +576,7 @@ export function ReportDesigner({
 
             {/* Delete selected */}
             {!readOnly && (
-              <button
+              <button type="button"
                 className={cn('p-1.5 rounded hover:bg-accent', multiSelect.count === 0 && 'opacity-40 pointer-events-none')}
                 title={LABELS.deleteSelected}
                 aria-label={LABELS.deleteSelected}
@@ -604,7 +604,7 @@ export function ReportDesigner({
 
             {/* Property panel toggle */}
             {showPropertyPanel && (
-              <button
+              <button type="button"
                 className="p-1.5 rounded hover:bg-accent"
                 title={propertyPanelOpen ? LABELS.collapsePanel : LABELS.expandPanel}
                 aria-label={propertyPanelOpen ? LABELS.collapsePanel : LABELS.expandPanel}
@@ -642,7 +642,7 @@ export function ReportDesigner({
                 {/* Add element buttons */}
                 {!readOnly && (
                   <div className="absolute right-1 top-0 flex items-center gap-0.5">
-                    <button
+                    <button type="button"
                       onClick={() => handleAddElement(sectionIndex, 'text')}
                       className="p-0.5 rounded hover:bg-accent"
                       title={LABELS.addText}
@@ -650,7 +650,7 @@ export function ReportDesigner({
                     >
                       <Type className="h-3 w-3" />
                     </button>
-                    <button
+                    <button type="button"
                       onClick={() => handleAddElement(sectionIndex, 'field')}
                       className="p-0.5 rounded hover:bg-accent"
                       title={LABELS.addField}
@@ -658,7 +658,7 @@ export function ReportDesigner({
                     >
                       <Plus className="h-3 w-3" />
                     </button>
-                    <button
+                    <button type="button"
                       onClick={() => handleAddElement(sectionIndex, 'image')}
                       className="p-0.5 rounded hover:bg-accent"
                       title={LABELS.addImage}
@@ -666,7 +666,7 @@ export function ReportDesigner({
                     >
                       <ImageIcon className="h-3 w-3" />
                     </button>
-                    <button
+                    <button type="button"
                       onClick={() => handleAddElement(sectionIndex, 'chart')}
                       className="p-0.5 rounded hover:bg-accent"
                       title={LABELS.addChart}
@@ -674,7 +674,7 @@ export function ReportDesigner({
                     >
                       <BarChart3 className="h-3 w-3" />
                     </button>
-                    <button
+                    <button type="button"
                       onClick={() => handleAddElement(sectionIndex, 'table')}
                       className="p-0.5 rounded hover:bg-accent"
                       title={LABELS.addTable}
@@ -721,7 +721,7 @@ export function ReportDesigner({
                           {element.type === 'table' && LABELS.elementTable}
                         </span>
                         {!readOnly && isSelected && (
-                          <button
+                          <button type="button"
                             onClick={(e) => {
                               e.stopPropagation();
                               handleDeleteElement(element.id);

--- a/packages/plugin-designer/src/components/ConfirmDialog.tsx
+++ b/packages/plugin-designer/src/components/ConfirmDialog.tsx
@@ -81,13 +81,13 @@ export function ConfirmDialog({
         </div>
         <p id="confirm-message" className="text-sm text-muted-foreground mb-6">{message}</p>
         <div className="flex justify-end gap-2">
-          <button
+          <button type="button"
             onClick={onCancel}
             className="px-4 py-2 text-sm rounded-md border hover:bg-accent"
           >
             {cancelLabel}
           </button>
-          <button
+          <button type="button"
             onClick={onConfirm}
             className={cn(
               'px-4 py-2 text-sm rounded-md font-medium',

--- a/packages/plugin-designer/src/components/PropertyEditor.tsx
+++ b/packages/plugin-designer/src/components/PropertyEditor.tsx
@@ -83,7 +83,7 @@ export function PropertyEditor({
       <div className="flex-1 overflow-y-auto">
         {Object.entries(grouped).map(([group, groupFields]) => (
           <div key={group} className="border-b last:border-b-0">
-            <button
+            <button type="button"
               onClick={() => toggleGroup(group)}
               className="w-full flex items-center gap-1 px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-accent/50"
             >

--- a/packages/plugin-designer/src/components/VersionHistory.tsx
+++ b/packages/plugin-designer/src/components/VersionHistory.tsx
@@ -91,7 +91,7 @@ export function VersionHistory({
                     <span>{new Date(entry.timestamp).toLocaleString()}</span>
                   </div>
                   {!entry.isCurrent && onRestore && (
-                    <button
+                    <button type="button"
                       onClick={() => onRestore(entry.version)}
                       className="mt-1 text-[0.65rem] text-primary hover:underline"
                     >

--- a/packages/plugin-grid/demo/main.tsx
+++ b/packages/plugin-grid/demo/main.tsx
@@ -101,7 +101,7 @@ function Demo() {
         }}
       >{SAMPLE_TSV}</pre>
 
-      <button
+      <button type="button"
         onClick={() => { setResult(null); setOpen(true); }}
         style={{
           background: 'hsl(var(--primary))',

--- a/packages/plugin-kanban/src/KanbanImpl.tsx
+++ b/packages/plugin-kanban/src/KanbanImpl.tsx
@@ -696,7 +696,7 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
             return (
               <div key={lane} className="border rounded-lg bg-muted/10">
                 {/* Lane header */}
-                <button
+                <button type="button"
                   className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/30 transition-colors"
                   onClick={() => toggleLane(lane)}
                   aria-expanded={!isCollapsed}

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -763,10 +763,10 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
                         )}
                         <div className="mt-2 text-xs flex gap-2">
                              {onEdit && (
-                                <button className="text-blue-500 hover:underline" onClick={() => onEdit(selectedMarker.data)}>Edit</button>
+                                <button type="button" className="text-blue-500 hover:underline" onClick={() => onEdit(selectedMarker.data)}>Edit</button>
                              )}
                              {onDelete && (
-                                <button className="text-red-500 hover:underline" onClick={() => onDelete(selectedMarker.data)}>Delete</button>
+                                <button type="button" className="text-red-500 hover:underline" onClick={() => onDelete(selectedMarker.data)}>Delete</button>
                              )}
                         </div>
                     </div>
@@ -802,13 +802,13 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
              </div>
              <div className="mt-3 flex flex-wrap gap-2 text-xs">
                {onEdit && (
-                 <button
+                 <button type="button"
                    className="px-3 py-1.5 rounded-md border bg-card hover:bg-accent"
                    onClick={() => onEdit(selectedMarker.data)}
                  >Edit</button>
                )}
                {onDelete && (
-                 <button
+                 <button type="button"
                    className="px-3 py-1.5 rounded-md border border-destructive/30 text-destructive hover:bg-destructive/10"
                    onClick={() => onDelete(selectedMarker.data)}
                  >Delete</button>

--- a/packages/plugin-view/src/ViewTabBar.tsx
+++ b/packages/plugin-view/src/ViewTabBar.tsx
@@ -799,7 +799,7 @@ export const ViewTabBar: React.FC<ViewTabBarProps> = ({
         {overflowViews.length > 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button
+              <button type="button"
                 data-testid="view-tab-overflow"
                 className="inline-flex items-center gap-1 px-2 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
@@ -848,7 +848,7 @@ export const ViewTabBar: React.FC<ViewTabBarProps> = ({
         {showAddButton && onAddView && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
+              <button type="button"
                 data-testid="view-tab-add"
                 onClick={onAddView}
                 className="inline-flex items-center px-2 py-2 text-muted-foreground hover:text-foreground transition-colors"

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -177,7 +177,7 @@ export class SchemaErrorBoundary extends Component<
               ) : null}
             </p>
           )}
-          <button
+          <button type="button"
             onClick={this.handleRetry}
             className="mt-2 text-sm underline hover:no-underline"
           >

--- a/packages/runner/src/App.tsx
+++ b/packages/runner/src/App.tsx
@@ -190,7 +190,7 @@ export default function RunnerApp() {
       <div className="flex flex-col items-center justify-center h-full p-12 text-red-600">
         <h1 className="text-2xl font-bold">404</h1>
         <p className="mt-2 text-slate-600">{error || 'Page not found'}</p>
-        <button onClick={() => handleNavigate('/')} className="mt-4 text-blue-600 hover:underline">
+        <button type="button" onClick={() => handleNavigate('/')} className="mt-4 text-blue-600 hover:underline">
           Go Home
         </button>
       </div>

--- a/packages/runner/src/LayoutRenderer.tsx
+++ b/packages/runner/src/LayoutRenderer.tsx
@@ -210,7 +210,7 @@ export const LayoutRenderer = ({ app, children, currentPath, onNavigate }: Layou
         <header className="h-14 flex items-center justify-between px-4 md:px-6 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b z-20 sticky top-0">
            <div className="flex items-center gap-4">
              {/* Toggle Sidebar Button */}
-             <button 
+             <button type="button" 
                 onClick={() => setSidebarOpen(!isSidbarOpen)}
                 className="p-2 -ml-2 text-muted-foreground hover:bg-muted hover:text-foreground rounded-md transition-colors"
              >
@@ -229,7 +229,7 @@ export const LayoutRenderer = ({ app, children, currentPath, onNavigate }: Layou
            </div>
            <div className="flex items-center gap-2">
              {/* Theme Toggle */}
-             <button 
+             <button type="button" 
                onClick={toggleTheme}
                className="p-2 text-muted-foreground hover:text-foreground transition-colors rounded-md hover:bg-muted"
                title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
@@ -241,7 +241,7 @@ export const LayoutRenderer = ({ app, children, currentPath, onNavigate }: Layou
              {app.actions?.filter(a => a.type === 'button').map((action, i) => {
                  const Icon = action.icon ? getIcon(action.icon) : null;
                  return (
-                    <button 
+                    <button type="button" 
                         key={i}
                         className={action.variant === 'ghost' ? "relative p-2 text-muted-foreground hover:text-foreground transition-colors hover:bg-muted rounded-md" : "p-2"}
                         title={action.label}
@@ -266,7 +266,7 @@ export const LayoutRenderer = ({ app, children, currentPath, onNavigate }: Layou
              */}
 
              {(!app.actions || !app.actions.some(a => a.type === 'button')) && (
-                 <button className="relative p-2 text-muted-foreground hover:text-foreground transition-colors">
+                 <button type="button" className="relative p-2 text-muted-foreground hover:text-foreground transition-colors">
                     <Bell className="h-5 w-5" />
                     <span className="absolute top-1.5 right-1.5 h-2 w-2 bg-red-600 rounded-full border-2 border-background"></span>
                  </button>
@@ -275,7 +275,7 @@ export const LayoutRenderer = ({ app, children, currentPath, onNavigate }: Layou
              {app.actions?.filter(a => a.type === 'user').map((userAction, i) => (
                  <DropdownMenu key={i}>
                     <DropdownMenuTrigger asChild>
-                        <button className="relative h-8 w-8 rounded-full border bg-muted overflow-hidden focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover:opacity-90 transition-opacity">
+                        <button type="button" className="relative h-8 w-8 rounded-full border bg-muted overflow-hidden focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover:opacity-90 transition-opacity">
                             <Avatar className="h-full w-full">
                                 <AvatarImage 
                                     src={userAction.avatar} 


### PR DESCRIPTION
Fixes #4045

Ends the missing-`type="button"` defect class mechanically, and fixes the whole
population in the same PR.

An HTML `button` element with no `type` defaults to `type="submit"`, so it submits any
form it is composed into instead of running its own handler. In an SDUI renderer that
composition is a JSON metadata decision made far from the button's own file — so "it is
not in a form today" is the dormancy, not a defence. Per-instance patching ran three
rounds (objectui#3344, objectstack#5236, objectstack#6952) and nothing rejected the next
one at write time, because `type` is optional in React's `ButtonHTMLAttributes`.

Per the ruling on #4045: option A, the **in-repo custom rule** (not the
`eslint-plugin-react` dependency), population fixed in the same PR.

## Re-measured population — the card's table was a ~3x undercount

The card's table (39 sites, measured at `ebb579dbb` with a regex scanner) is **not** the
population. Re-measured at this branch point with the rule itself — an AST measurement,
not a text scan — the population is **114 sites in 29 files**.

This is not drift. Re-running a scanner against `ebb579dbb` **itself** finds 113 there,
and the card's 39 is a strict per-file subset of it: the card's scan missed whole files,
most visibly all four plugin-designer surfaces (`PageDesigner` 15, `ProcessDesigner` 15,
`DataModelDesigner` 14, `ReportDesigner` 12 = 56 sites, none of them listed on the card).
The card's conclusion is unaffected — a bigger population argues harder for option A —
but the number quoted for triage was wrong, and the class-closing gate is what makes the
count stop mattering.

Real drift since the card is small and in the expected direction:
`objectDetailWidgets.tsx` (4 sites) was deleted by #4365, and 2 of the 3 `UserFilters`
sites the card counted were fixed by #3948.

| file | sites |
|---|---|
| `packages/plugin-designer/src/PageDesigner.tsx` | 15 |
| `packages/plugin-designer/src/ProcessDesigner.tsx` | 15 |
| `packages/plugin-designer/src/DataModelDesigner.tsx` | 14 |
| `packages/plugin-designer/src/ReportDesigner.tsx` | 12 |
| `apps/console/src/pages/developer/ApiConsolePage.tsx` | 11 |
| `packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx` | 8 |
| `packages/runner/src/LayoutRenderer.tsx` | 5 |
| `packages/plugin-map/src/ObjectMap.tsx` | 4 |
| `apps/console/src/components/PerformanceDashboard.tsx` | 3 |
| `apps/site/app/playground/page.tsx` | 3 |
| `packages/app-shell/src/views/MetadataInspector.tsx` | 2 |
| `packages/components/src/debug/DebugPanel.tsx` | 2 |
| `packages/plugin-ai/src/NLQueryInput.tsx` | 2 |
| `packages/plugin-designer/src/components/ConfirmDialog.tsx` | 2 |
| `packages/plugin-view/src/ViewTabBar.tsx` | 2 |
| 14 further files, 1 site each | 14 |
| **total** | **114** |

All 114 became `type="button"`. **No site was a genuine submit button** — not one
population file contains a form element at all, so the "expect ~zero" in the card's
step 4 is confirmed by measurement rather than by inspection.

**Zero behaviour change beyond the attribute, proved mechanically**: every changed
`.tsx` is byte-identical to its parent once the inserted attribute string is removed.

## The rule

`eslint-rules/button-has-type.js` + `eslint-rules/button-has-type.test.js`, following
`no-synthetic-event-trigger.js`'s shape exactly (default-exported rule module, `meta` /
`messages` / `create`, RuleTester suite in plain JS, registered in
`eslint-rules/index.js`). Wired in `eslint.config.js` as **error** in its own config
block, like the other scoped custom rules.

Grading notes, each decided by measurement rather than taste:

- **Spreads do not satisfy the rule.** A `{...spread}` may or may not carry `type` at
  runtime and no checker can tell which, so exempting it would reopen the hole for
  exactly the buttons whose props come from elsewhere. Measured cost of the strict
  reading: **zero** — the whole repo has one button with a real JSX spread attribute
  (`plugin-view/ManageViewsDialog.tsx`) and it already declares `type="button"`. The
  spread case gets its own `messageId` (`spreadType`) so the report says why the spread
  did not save it. The sibling rules gave no precedent here: none of them look at JSX.
- **Exclusions are config, not rule logic** — `files: ['**/*.tsx']`,
  `ignores: ['**/src/ui/**', '**/*.test.tsx', '**/__tests__/**']`, mirroring the
  population's counting rules. The `src/ui` ignore is load-bearing, not decorative:
  `packages/components/src/ui/sidebar.tsx:314` (SidebarRail) is an untyped button, and
  without the ignore the rule would demand an edit in a zone AGENTS.md #7 forbids
  touching and the Shadcn sync script overwrites. See "Known residual" below.
- **Only the lowercase intrinsic is flagged.** A `Button` *component* is a different
  contract — its own implementation owns the DOM attribute.
- **No autofixer, on purpose** (same reasoning `no-dynamic-import-in-test-hook.js`
  records for itself): `type="button"` is right for nearly every site, and "nearly" is
  the problem — a genuine submit button silently rewritten stops submitting its form,
  invisibly to any test that does not click it.

## Radix `asChild` children — a declared deviation from the ruling

The ruling put the card's 2 Radix-trigger children out of scope
(`ApiConsolePage.tsx:274` CollapsibleTrigger, `AppSwitcher.tsx:49` DropdownMenuTrigger),
on the card's own correct finding that Radix's `Primitive.button` already supplies
`type="button"` through its Slot. **Both are fixed here anyway**, because the rule
cannot see the difference: the alternative was leaving two permanent lint errors or
writing two `eslint-disable` comments, and a disable comment is a hole that reads as
sanctioned. This is runtime-neutral — Radix merges the identical value onto a child that
declares none, so the rendered DOM is unchanged either way — and it is exactly what
`packages/components/src/custom/combobox.tsx:74-80` already prescribes and the card
quotes approvingly: *"that is an upstream implementation detail — declare the contract
locally"*.

## Pre-fix red (#4118) — the non-vacuity proof

The rule was run against the **unfixed** tree first: **114 firings**, all `missingType`,
0 `spreadType`. Two independent methods agree on the population — the AST rule and a
standalone regex scanner — with **zero** disagreements in the direction that would mean
a false positive (every site the scanner flagged, the rule flagged). The rule found 2
sites the scanner missed (`ApiConsolePage.tsx:323`, `DataModelDesigner.tsx:751`), where
an apostrophe in JSX text swallowed a region during string masking; both are genuine.
Post-fix the same run reports 0.

## Verification

- `pnpm exec vitest run eslint-rules/button-has-type.test.js` — 19 passed (10 valid /
  9 invalid cases).
- `turbo run lint --concurrency=2`, repo-wide: **45/45 tasks successful, 0 errors**,
  0 `button-has-type` firings. This is the load-bearing check — the rule is live in
  every package, not just the ones edited here.
- `pnpm exec vitest run` over the 11 touched packages (repo-root invocation, path
  filters, per AGENTS.md §9): **599 files / 5779 passed, 1 skipped, 0 failed**.
- `turbo run type-check` over the touched packages + `type-check:scripts` +
  `type-check:vitest-setup`: all green. As predicted, type-check does not move — the
  change is attribute-only.
- `check-control-bytes` (4147 files), `check-phantom-dependencies`,
  `check-changeset-presence`, `check-changeset-fixed`, `check-changeset-no-major`: green.
- Re-run after merging `origin/main` (4 commits, incl. #4352 / #4425 / #4437): 0 new
  firings in the merged-in files, and the repo-wide lint re-run stayed 45/45 green.

### Reverse verification (direction predicted before running)

1. *Predicted:* removing `type` from one fixed site reds the rule naming exactly that
   site. *Observed:* `drawer.tsx:38:56 object-ui/button-has-type missingType`, exactly
   one firing. Restored.
2. *Predicted:* with that violation still in place, deleting the rule from
   `eslint.config.js` makes lint green again — i.e. the **wiring** is load-bearing, not
   just the rule file. *Observed:* 0 `button-has-type` messages. Restored.

## Known residual

`packages/components/src/ui/sidebar.tsx:314` (SidebarRail) is still an untyped button.
It sits in the upstream Shadcn zone that the sync script overwrites and AGENTS.md #7
forbids editing, so it is out of the rule's reach by the card's own counting rules. It
is upstream's to fix; filed separately as an observation rather than patched here.

## What is NOT absorbed

PR #3948's scan-style assertion in `plugin-list/src/__tests__/UserFilters.test.tsx` and
the family prototype `components/src/__tests__/combobox-trigger-type.test.tsx` **stay**.
They assert the *rendered DOM* — including buttons produced by dependencies, which a
source-static rule cannot see — and that clicking does not submit an enclosing form,
which lint cannot assert at all. Complementary, not superseded.

## objectstack#7074 thread compliance

The source thread was read before acting, per the card's mandate. It carries the
finding-triage promotion (`finding` to `pm:queue`, 2026-08-10, spot-checked live) and
the migration note closing it as *moved, not rejected* under objectstack#7167 — no hold
or restart condition applies. Its substantive ruling, the Radix-mechanism correction, is
honoured above and its reasoning is recorded in the rule's own header so the next reader
does not re-derive it.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_