### PR TITLE
fix(plugin-calendar): authored `events` never reaches CalendarView's events prop (#4433)

### DIFF
--- a/.changeset/calm-schools-tease.md
+++ b/.changeset/calm-schools-tease.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-calendar': patch
+---
+
+fix(plugin-calendar): authoring `events` on a `calendar-view` node no longer takes the calendar down
+
+`calendar-view`'s renderer computed a `CalendarEvent[]` from `schema.data`, passed it
+as `events={…}`, then spread the remaining props **after** it. `SchemaRenderer`
+forwards a node's `events` key as a plain prop, so a node authoring `events` — the
+ordinary SDUI action metadata, legal on any node — landed its `{ onClick: [...] }`
+object on the `events` array prop: `CalendarView` iterated it and threw
+`events is not iterable`, and a spec-legal node rendered an error card instead of its
+calendar.
+
+The authored key is now destructured out before the spread, so the computed array
+always wins. This also closes the quiet half of the same collision: an authored
+`events` **array** never threw — it silently replaced the calendar's contents with
+itself.
+
+No capability is removed. Nothing in the renderer layer consumes a node's `events`
+key (the action path is `properties.action` through `ActionRunner`), and the
+component's own `onAction` channel is unaffected.

--- a/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
+++ b/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
@@ -35,10 +35,15 @@
  *
  * 5 of 23 targets leak. The two clean packages are clean for opposite reasons
  * worth keeping straight: `plugin-charts` never spreads the node onto its
- * container at all, while `plugin-calendar` is clean only because its one
- * spreading target is swept with a canary WITHHELD — authoring `events` crashes
- * it outright (objectui#4433), which is a worse failure than the leak this gate
- * was looking for, and is pinned by its own case below.
+ * container at all, while `plugin-calendar`'s components take a declared prop
+ * list and drop what they do not name, so the node's keys never reach an
+ * element.
+ *
+ * `calendar-view` was originally swept with the `events` canary WITHHELD, because
+ * authoring it crashed the component outright (objectui#4433) — a worse failure
+ * than the leak this gate was looking for, and one that would have read as a
+ * clean pass. That is fixed, so the omission is gone and the target is swept
+ * with the full canary set; section 5 below carries what is left of it.
  *
  * ## The divergence this repo is living with, recorded deliberately
  *
@@ -396,23 +401,6 @@ const CALENDAR_OBJECT_EXTRAS = {
   titleField: 'name',
 };
 
-/**
- * `plugin-calendar:calendar-view` is rendered WITHOUT the `events` canary.
- *
- * Not a convenience: authoring `events` — the ordinary SDUI action metadata of
- * AGENTS.md section 4, legal on any node — CRASHES this component outright. Its
- * renderer computes a `CalendarEvent[]` from `schema.data`, passes it as
- * `events={…}`, and then spreads `{...props}` AFTER it, so the SDUI `events`
- * object overwrites the array and `CalendarView` throws `events is not
- * iterable`. `SchemaErrorBoundary` then renders its own tidy alert, which has no
- * leaked attributes — so including the canary here would replace a leak
- * measurement with a crash measurement AND read as clean (trap 3).
- *
- * The crash is pinned instead by its own case below, so it cannot regress
- * unnoticed while the fix is pending.
- */
-const CALENDAR_VIEW_OMITS = ['events'] as const;
-
 const TARGETS: Readonly<Record<string, readonly Target[]>> = {
   'plugin-charts': [
     { type: 'plugin-charts:bar-chart', schemaExtras: { data: CHART_DATA }, ready: '.recharts-responsive-container' },
@@ -426,7 +414,7 @@ const TARGETS: Readonly<Record<string, readonly Target[]>> = {
     { type: 'view:chart', schemaExtras: OBJECT_CHART_EXTRAS, ready: '[data-slot="chart"]' },
   ],
   'plugin-calendar': [
-    { type: 'plugin-calendar:calendar-view', ready: '[role="region"][aria-label="Calendar"]', omitCanaries: CALENDAR_VIEW_OMITS },
+    { type: 'plugin-calendar:calendar-view', ready: '[role="region"][aria-label="Calendar"]' },
     { type: 'plugin-calendar:object-calendar', schemaExtras: CALENDAR_OBJECT_EXTRAS, ready: '[role="region"][aria-label="Calendar"]' },
     { type: 'view:calendar', schemaExtras: CALENDAR_OBJECT_EXTRAS, ready: '[role="region"][aria-label="Calendar"]' },
   ],
@@ -936,21 +924,37 @@ describe.each(Object.keys(TARGETS))(
 );
 
 /* ════════════════════════════════════════════════════════════════════════════
- * 5. The withheld canary is a recorded defect, not an exemption
+ * 5. The canary that was withheld, and is not any more
  * ══════════════════════════════════════════════════════════════════════════ */
 
 /**
- * `plugin-calendar:calendar-view` is swept without the `events` canary
- * ({@link CALENDAR_VIEW_OMITS}). This case is the price of that omission: it
- * pins the crash that forced it, so the defect cannot regress unnoticed and the
- * omission cannot quietly outlive it.
+ * `plugin-calendar:calendar-view` used to be swept WITHOUT the `events` canary,
+ * because authoring `events` — the ordinary SDUI action metadata of AGENTS.md
+ * section 4, legal on any node — crashed the component outright: its renderer
+ * computed a `CalendarEvent[]`, passed it as `events={…}`, then spread
+ * `{...props}` AFTER it, so the authored object overwrote the array and
+ * `CalendarView` threw `events is not iterable`. A crashing render produces
+ * tidy, attribute-clean error-boundary DOM, so the canary had to be withheld or
+ * the target would have read as a clean pass (trap 3).
  *
- * When the crash is fixed, this case goes red and BOTH halves are removed in the
- * same change — the `omitCanaries` entry and this pin — putting `events` back
- * into the sweep for that target.
+ * objectui#4433 fixed that — the renderer destructures the authored key out
+ * before the spread — so BOTH halves came out in the same change: the
+ * `omitCanaries` entry is gone (this target is swept with the full canary set
+ * above, `events` included) and this case flipped from pinning the crash to
+ * pinning the render.
+ *
+ * It is kept rather than deleted because it is the DIAGNOSIS the sweep case
+ * cannot be: the sweep plants the whole canary set at once, so a regression
+ * there says only "calendar-view broke". This one plants `events` alone, and
+ * names the key.
+ *
+ * The `omitCanaries` facility itself stays. Nothing withholds a canary today,
+ * but it carries the discipline — a withheld canary is a recorded defect with
+ * its own pin, never a quiet exemption — that objectui#4425 phase 2 will need
+ * the next time a target cannot take the full set.
  */
-describe('the canary withheld from calendar-view records a real crash (objectui#4425)', () => {
-  it('authoring `events` on a calendar-view node throws instead of rendering', async () => {
+describe('the canary once withheld from calendar-view is swept again (objectui#4433)', () => {
+  it('authoring `events` on a calendar-view node renders the calendar', async () => {
     const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
       render(
@@ -966,13 +970,18 @@ describe('the canary withheld from calendar-view records a real crash (objectui#
           />
         </SchemaRendererProvider>,
       );
+      // The real component, not the error boundary `SchemaErrorBoundary`
+      // rendered here before the fix.
       await waitFor(() => {
-        expect(document.body.textContent ?? '').toContain(ERROR_BOUNDARY_MARKER);
+        expect(
+          document.body.querySelector('[role="region"][aria-label="Calendar"]'),
+        ).not.toBeNull();
       });
-      // The mechanism, not just the symptom: the SDUI `events` OBJECT lands on
-      // `CalendarView`'s `events` ARRAY prop because the renderer's `{...props}`
-      // is spread after it.
-      expect(document.body.textContent ?? '').toContain('events is not iterable');
+      expect(document.body.textContent ?? '').not.toContain(ERROR_BOUNDARY_MARKER);
+      // The mechanism, not just the symptom: the authored `events` OBJECT no
+      // longer reaches `CalendarView`'s `events` ARRAY prop, so nothing tries to
+      // iterate it.
+      expect(document.body.textContent ?? '').not.toContain('events is not iterable');
     } finally {
       errors.mockRestore();
     }

--- a/packages/plugin-calendar/src/calendar-view-renderer.eventsCollision.test.tsx
+++ b/packages/plugin-calendar/src/calendar-view-renderer.eventsCollision.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `plugin-calendar:calendar-view` — the authored `events` collision
+ * (objectui#4433, measured by the objectui#4425 phase-1 sweep).
+ *
+ * The renderer computes a `CalendarEvent[]` from `schema.data` and passes it as
+ * `events={…}`, then spreads the remaining props AFTER it. `SchemaRenderer`
+ * forwards a node's `events` key as a prop — it is not on the renderer's strip
+ * list — so a node authoring `events`, the ordinary SDUI action metadata of
+ * AGENTS.md section 4 that is legal on any node, landed its `{ onClick: [...] }`
+ * OBJECT on the `events` ARRAY prop. `CalendarView` iterates it and throws
+ * `events is not iterable`: a spec-legal node lost its calendar to an error
+ * card.
+ *
+ * Two shapes, one collision, and the second is the quiet one:
+ *
+ *   - an authored `events` OBJECT crashed the component (the reported defect);
+ *   - an authored `events` ARRAY did NOT crash — it is iterable, so it silently
+ *     REPLACED the computed calendar with itself. Same overwrite, no error
+ *     card, so nothing would have reported it.
+ *
+ * Both are pinned below, because a fix that only stopped the throw would leave
+ * the second half live.
+ *
+ * The authored key is destructured out before the spread (the objectui#4357 /
+ * PR #4428 deny-list precedent), so the computed array always wins. That is not
+ * a disabled feature: no code in the renderer layer consumes a node's `events`
+ * key — `SchemaRenderer` forwards it as a prop and nothing reads it, and the
+ * repo's action path is `properties.action` through `ActionRunner`. On this node
+ * type the key has never done anything but crash. The last case here pins the
+ * action channel this component DOES have, so the strip cannot be mistaken for
+ * removing one.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Module scope: the registration side effect this file renders through
+// (AGENTS.md 测试纪律 — never inside a hook).
+import './index';
+
+/** The text `SchemaErrorBoundary` renders when a widget throws. */
+const ERROR_BOUNDARY_MARKER = 'failed to render';
+
+/** The SDUI action metadata of AGENTS.md section 4 — legal on any node. */
+const AUTHORED_EVENTS = { onClick: [{ action: 'navigate', params: { url: '/x' } }] };
+
+/** Two records in the CURRENT month, so the default month view shows them. */
+function currentMonthRecords() {
+  const now = new Date();
+  const day = (n: number) => new Date(now.getFullYear(), now.getMonth(), n, 10, 0, 0, 0).toISOString();
+  return [
+    { id: 'r1', title: 'Computed Standup', start: day(10) },
+    { id: 'r2', title: 'Computed Review', start: day(12) },
+  ];
+}
+
+function calendarRegion(): Element | null {
+  return document.body.querySelector('[role="region"][aria-label="Calendar"]');
+}
+
+describe('calendar-view: authored `events` never reaches CalendarView (objectui#4433)', () => {
+  it('renders the calendar for a node whose only authored key is `events`', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        <SchemaRenderer
+          schema={
+            {
+              type: 'plugin-calendar:calendar-view',
+              id: 'n',
+              events: AUTHORED_EVENTS,
+            } as never
+          }
+        />,
+      );
+
+      // The card's own minimal repro. Before the fix this rendered
+      // `SchemaErrorBoundary` with `events is not iterable`.
+      await waitFor(() => expect(calendarRegion()).not.toBeNull());
+      expect(document.body.textContent ?? '').not.toContain(ERROR_BOUNDARY_MARKER);
+      expect(document.body.textContent ?? '').not.toContain('events is not iterable');
+    } finally {
+      errors.mockRestore();
+    }
+  });
+
+  it('still displays the events computed from `schema.data` when `events` is authored', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        <SchemaRenderer
+          schema={
+            {
+              type: 'plugin-calendar:calendar-view',
+              id: 'n',
+              data: currentMonthRecords(),
+              events: AUTHORED_EVENTS,
+            } as never
+          }
+        />,
+      );
+
+      // Protecting the prop into emptiness would satisfy "does not crash" and
+      // still lose the calendar's contents, so the computed events are asserted
+      // present, not merely non-throwing.
+      await waitFor(() => expect(calendarRegion()).not.toBeNull());
+      expect(await screen.findByRole('button', { name: 'Computed Standup' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Computed Review' })).toBeTruthy();
+    } finally {
+      errors.mockRestore();
+    }
+  });
+
+  it('does not let an authored `events` ARRAY replace the computed events', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(
+        <SchemaRenderer
+          schema={
+            {
+              type: 'plugin-calendar:calendar-view',
+              id: 'n',
+              data: currentMonthRecords(),
+              // Iterable, so this half of the collision never threw: it just
+              // took the calendar over.
+              events: [
+                {
+                  id: 'authored',
+                  title: 'Authored Overwrite',
+                  start: new Date(),
+                },
+              ],
+            } as never
+          }
+        />,
+      );
+
+      await waitFor(() => expect(calendarRegion()).not.toBeNull());
+      expect(await screen.findByRole('button', { name: 'Computed Standup' })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Authored Overwrite' })).toBeNull();
+    } finally {
+      errors.mockRestore();
+    }
+  });
+
+  it('leaves the component\'s own action channel working while `events` is authored', async () => {
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onAction = vi.fn();
+    try {
+      render(
+        <SchemaRenderer
+          schema={
+            {
+              type: 'plugin-calendar:calendar-view',
+              id: 'n',
+              data: currentMonthRecords(),
+              events: AUTHORED_EVENTS,
+            } as never
+          }
+          onAction={onAction}
+        />,
+      );
+
+      await waitFor(() => expect(calendarRegion()).not.toBeNull());
+      fireEvent.click(await screen.findByRole('button', { name: 'Computed Standup' }));
+
+      // `onAction` is this component's real action channel (the host's prop),
+      // and it is unaffected by stripping the authored key.
+      expect(onAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'event-click',
+          payload: expect.objectContaining({ id: 'r1', title: 'Computed Standup' }),
+        }),
+      );
+    } finally {
+      errors.mockRestore();
+    }
+  });
+});

--- a/packages/plugin-calendar/src/calendar-view-renderer.tsx
+++ b/packages/plugin-calendar/src/calendar-view-renderer.tsx
@@ -12,8 +12,33 @@ import { CalendarView, type CalendarEvent } from './CalendarView';
 import React from 'react';
 
 // Calendar View Renderer - Airtable-style calendar for displaying records as events
-ComponentRegistry.register('calendar-view', 
-  ({ schema, className, onAction, ...props }: { schema: CalendarViewSchema; className?: string; onAction?: (action: any) => void; [key: string]: any }) => {
+ComponentRegistry.register('calendar-view',
+  ({
+    schema,
+    className,
+    onAction,
+    // The authored SDUI `events` key, destructured out so the `{...props}`
+    // spread below cannot overwrite the `CalendarEvent[]` computed from
+    // `schema.data` (objectui#4433; the deny-list precedent is objectui#4357 /
+    // PR #4428, where `SchemaRenderer`'s injected schema-shaped props are
+    // stripped at the component's own signature).
+    //
+    // `events` is the ordinary action metadata of AGENTS.md section 4, legal on
+    // ANY node, and `SchemaRenderer` forwards it as a plain prop — it is not on
+    // that renderer's strip list. Both channels land here: the node's own
+    // `events` key and a `props: { events }` container, since the renderer
+    // spreads the container's contents too.
+    //
+    // Nothing is disabled by dropping it. No code in the renderer layer reads a
+    // node's `events` key — `SchemaRenderer` forwards it and nothing consumes
+    // it; this repo's action path is `properties.action` through `ActionRunner`.
+    // On this node type the key has never done anything but overwrite the
+    // calendar: an OBJECT threw `events is not iterable` (the reported crash),
+    // and an ARRAY silently replaced the computed calendar with itself. This
+    // component's real action channel is `onAction` below, which is untouched.
+    events: _authoredEvents,
+    ...props
+  }: { schema: CalendarViewSchema; className?: string; onAction?: (action: any) => void; [key: string]: any }) => {
     // Transform schema data to CalendarEvent format
     const events = React.useMemo(() => {
       if (!schema.data || !Array.isArray(schema.data)) return [];
@@ -58,8 +83,10 @@ ComponentRegistry.register('calendar-view',
     };
 
     return (
-      <CalendarView 
+      <CalendarView
         className={className}
+        // Always the computed array: the authored `events` key is destructured
+        // out above, so this spread can no longer reach it (objectui#4433).
         events={events}
         onEventClick={handleEventClick}
         // Pass validation or other props


### PR DESCRIPTION
Fixes #4433

The `calendar-view` renderer computed a `CalendarEvent[]` from `schema.data`, passed it as `events={…}`, then spread the remaining props **after** it. `SchemaRenderer` forwards a node's `events` key as a plain prop — it is not on that renderer's strip list — so a node authoring `events`, the ordinary SDUI action metadata of AGENTS.md section 4 that is legal on any node, landed its `{ onClick: [...] }` object on the array prop and `CalendarView` threw `events is not iterable`.

The authored key is destructured out before the spread, per the #4357 / PR #4428 deny-list precedent. The computed array always wins.

## The semantics measurement first (ruling condition 1a)

**Did authored `events` ever do anything on this node type? No — measured, and it never could.**

- Nothing in the renderer layer consumes a node's `events` key. Grepped across `packages/react/src`, `packages/core/src/{registry,actions}` and `packages/components/src/renderers`: `SchemaRenderer` forwards `events` as a prop and no consumer reads it. Re-measured after this branch merged `origin/main` (#4450 touches `SchemaRenderer.tsx`): the strip-list destructure at `SchemaRenderer.tsx` still names only `dataSource`, `_hidden`, `_disabled` and `responsiveStyles`, and the string `events` does not occur anywhere in that file. The one `.events` hit in the renderer/core layer is `object-validation-engine.ts`'s validation-rule field, which is unrelated to a node key.
- This repo's action path is `properties.action` executed through `ActionRunner` — the wiring `element:button` uses.
- `packages/types` does declare `EventableSchema.events`, but as `UIEventHandler[]` — a different shape from the `{ onClick: [...] }` map, and nothing runtime reads either one.
- On `calendar-view` specifically the key reached exactly one place: `CalendarView`'s `events` prop, whose declared type is `CalendarEvent[]`. `CalendarView` takes a fixed prop list and spreads nothing onto the DOM, so the key had no other destination.

So this strip disables nothing. **Pre-existing state, not a regression**: the key was a landmine, never a feature. The component's real action channel is `onAction`, and the last test case pins it still firing while `events` is authored.

## The collision grading (ruling condition 1b)

Every prop the renderer declares **before** the spread, plus the neighbouring surface, measured node-by-node through the real SDUI host rather than reasoned about:

| computed prop | reachable by an authored key? | measured behaviour | grade | action |
|---|---|---|---|---|
| `events` | **yes**, both channels (node key and `props: { events }`) | OBJECT → error boundary, `events is not iterable`. ARRAY → **no throw**, the authored array silently replaced the computed calendar | crash-capable **and** data-destroying | **fixed here** |
| `className` | **no** | destructured out of the renderer's own params, so the rest object cannot carry it; `SchemaRenderer` also assigns `className` after the node's `props` container. Authored `props.className` never reached the region; node-level `className` composes correctly | not exposed | none |
| `onEventClick` | **yes**, both channels | renders normally; a click throws `onEventClick is not a function` as an **uncaught window error** — React does not route event-handler errors to `SchemaErrorBoundary` | crash-capable, but needs a contract decision | **filed #4453** |

⚠️ **Flagged deviation from ruling condition 1b, deliberately not silent.** The condition reads "fix the crash-capable ones, record the benign ones", and `onEventClick` graded crash-capable yet is **not** fixed here. Unlike `events` it has a producer that works today: a React host rendering `SchemaRenderer schema={…} onEventClick={fn}` reaches the same channel through the renderer's trailing `...props`, and that is the component's genuine escape hatch. The key name cannot separate the working producer from the broken one — only the value's type can — so closing it is a choice between breaking a live path, adding value-type discrimination (AGENTS.md #0.1's lenient-coercion shape), or bounding the spread by declaration (#4425 phase 2). That is a contract decision this card's ruling did not make, so it is filed rather than guessed — but if the ruling intends `onEventClick` closed inside this card, this PR should be re-titled `Part of #4433` and #4453 folded in instead.

The remaining canaries (`bind`, `props`, `ariaLabel`, `ariaDescribedBy`, `dataSource`, `schema`, the authored open tail) reach `CalendarView` and are dropped there — it names its props and never spreads onto an element. That is why `plugin-calendar` measured zero leaks in the phase-1 sweep, and it stays true with `events` back in the set.

## Red-first evidence — re-derived on the final tree

The fix is already committed, so the red is re-established by **mutation**: revert only `packages/plugin-calendar/src/calendar-view-renderer.tsx` to its pre-fix blob (`git checkout c10c16c12^ -- path`), keep the new tests and the gate flip, run, then restore with `git checkout HEAD -- path` and confirm `git status --porcelain` is empty. Never `git stash` — that stack is shared across worktrees.

Verbatim, on the post-merge tree:

```
 × renders the calendar for a node whose only authored key is `events` 1125ms
 × still displays the events computed from `schema.data` when `events` is authored 1033ms
 × does not let an authored `events` ARRAY replace the computed events 1090ms
 × leaves the component's own action channel working while `events` is authored 1027ms
 × plugin-calendar:calendar-view 10062ms
 × authoring `events` on a calendar-view node renders the calendar 1027ms

 Test Files  2 failed (2)
      Tests  6 failed | 37 passed (43)
```

with the card's own reported DOM, captured by the sweep's readiness failure:

```
Component "plugin-calendar:calendar-view" failed to render
events is not iterable
```

## Reverse verification — direction predicted first

| case | predicted | observed |
|---|---|---|
| the 3 crash-shaped new cases | red, error boundary, `expected null not to be null` | exactly that |
| "authored `events` ARRAY" case | red **differently** — an array is iterable, so it renders and fails on the missing `Computed Standup` | exactly that: `TestingLibraryElementError: Unable to find role="button" and name "Computed Standup"` |
| the flipped sweep pin | red, region never appears | exactly that: `expected null not to be null` |
| sweep case `plugin-calendar:calendar-view` | red **on the readiness selector**, not on the error-boundary assertion or a leak diff — readiness is checked first | exactly that: ``readiness selector `[role="region"][aria-label="Calendar"]` never matched`` |
| `plugin-calendar:object-calendar`, `view:calendar` | green — they render through `ObjectCalendarRenderer`, the mutation cannot reach them | green |
| every charts / chatbot / dashboard target, both calibration fixtures, the ledger cases | green, untouched controls | green (37 passed alongside the 6 red) |

Six red, each in its predicted direction. **Correction to an earlier revision of this body**: it reported the itemized six but summarised them as "5 tests failed, 7 files" — a miscount, with the file count carried over from a run that still included a since-deleted scratch probe. The re-derivation above is the measured truth: `2 failed (2)` files, `6 failed | 37 passed (43)` tests. The per-case directions, which are the substance, were right both times; only the arithmetic under them was wrong, and it is corrected rather than quietly dropped.

Post-fix the same four new cases are green, and the second one is the one that matters for "protected into emptiness": with `data` **and** authored `events` present, `Computed Standup` and `Computed Review` both render. The third pins the quiet half — pre-fix the authored array rendered `Authored Overwrite` and the computed events were gone; post-fix the computed events are back and the authored title is absent.

## The gate's two halves, together

- `CALENDAR_VIEW_OMITS` and the target's `omitCanaries` entry are **removed**: `plugin-calendar:calendar-view` is swept with the full canary set, `events` included, and passes — so no leak was hiding behind the crash.
- The dedicated pin **flipped**: from "authoring `events` throws instead of rendering" to "authoring `events` renders the calendar", asserting `role="region" aria-label="Calendar"` with no error boundary.
- The pin is kept rather than deleted because it is the diagnosis the sweep case cannot be: the sweep plants the whole canary set at once and can only say "calendar-view broke", while this one plants `events` alone and names the key.
- The `omitCanaries` facility itself stays, with no current user. It carries the discipline the docblock spells out — a withheld canary is a recorded defect with its own pin, never a quiet exemption — which #4425 phase 2 will need the next time a target cannot take the full set. Flagged here as a deliberate non-removal, not an oversight.
- The file's top docblock said `plugin-calendar` was clean "only because its one spreading target is swept with a canary WITHHELD". That sentence is now false, so it was corrected to the measured reason.

Depends on #4441 (the gate file is its surface), which is in `main` at `716c5ae91`.

## Verification — all re-run on the final tree, after merging `origin/main`

```
pnpm --filter '@object-ui/plugin-calendar^...' --filter '@object-ui/app-shell^...' build   exit 0 (closure first)
pnpm exec vitest run packages/plugin-calendar/ \
  packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
      → Test Files  6 passed (6)      Tests  62 passed (62)
pnpm --filter @object-ui/plugin-calendar type-check    exit 0 — BOTH passes (tsc --noEmit && tsc -p tsconfig.test.json)
pnpm --filter @object-ui/app-shell     type-check      exit 0 — BOTH passes
eslint (the three touched source/test files)           exit 0 — 0 errors (4 pre-existing warnings: 3 `any` on the
                                                       signature line the fix reformats, 1 unused `handleAddClick`, which is #4454)
node scripts/check-control-bytes.mjs                   exit 0 — 4160 tracked text files scanned, clean
```

Repo-root vitest with paths relative to the repo root, per AGENTS.md 怎么跑测试. `origin/main` moved again mid-flight (#4450, #4449, #4447, #4448 — including a change to `SchemaRenderer.tsx` and a new `button-has-type` lint rule); it was merged in **with no conflicts** (the four touched paths are disjoint from all of it), and every command above was run **after** that merge.

Changeset: `patch` on `@object-ui/plugin-calendar` — measured, not assumed. `calendar-view-renderer.tsx` has **no exports** (it is a registration side-effect module, pulled in by `import './calendar-view-renderer'`), and building the package pre-fix and post-fix emits a **byte-identical** `dist/index.d.ts` (433 bytes both ways, `diff` empty). No exported type moves, so the ruling's grade-up condition does not fire, and never `major`. The `app-shell` half is test-only and correctly carries no changeset of its own.

## Filed from the measurement

- #4452 — `currentDate` authored as the ISO string its **own registry input documents** crashes the component (`selectedDate.toLocaleDateString is not a function`). Same renderer, opposite shape: a declared input that is never converted, not a collision. Measured again after this fix — unchanged, so the two are independent.
- #4453 — the `onEventClick` exposure above, with the four options and why it needs a ruling.
- #4454 — `finding`: `allowCreate` is declared and inert, and `handleAddClick` is built and never passed, so the "New event" button cannot exist on the SDUI path.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
