### PR TITLE
test(plugin-detail): drop the unpublished @object-ui/fields deep subpath (#4325)

### DIFF
--- a/.changeset/fields-subpath-surface-4325.md
+++ b/.changeset/fields-subpath-surface-4325.md
@@ -1,0 +1,35 @@
+---
+---
+
+Internal only — a test and a test-only tsconfig, no source change, so no release.
+
+#4325 asked what `@object-ui/fields` publishes. `packages/fields/package.json`
+exports exactly `.` and `./style.css`, but
+`plugin-detail`'s `RelatedList.longFormColumns.test.tsx` side-effect-imported a
+third path, `@object-ui/fields/widgets/MarkdownContent`, to pre-resolve the lazy
+markdown chunk before asserting a column's ABSENCE. That specifier resolved only
+through this repo's vitest source alias — under Node's own resolution it is
+`ERR_PACKAGE_PATH_NOT_EXPORTED`, and under `tsc` with the standard `paths: {}`
+template it was TS2882, which is why `plugin-detail/tsconfig.test.json` carried
+the repo's only source-tree `paths` entry to restate the alias.
+
+The ruling was to NOT publish the subpath: the package's surface is its index,
+and one test's preload does not justify minting permanent public API plus a
+matching `dist` layout to maintain forever. So the import is gone, the tsconfig's
+`paths` is now `{}` like every other wired-up package's, and the test's anti-race
+guarantee was rebuilt rather than dropped.
+
+Preloading through the sanctioned entry was measured, not assumed, and does not
+work: importing `@object-ui/fields` only evaluates the module that DECLARES
+`React.lazy(() => import('./widgets/MarkdownContent'))` — the factory does not
+run, the chunk stays cold, and a probe waited 321.8ms for it on an idle
+container (AGENTS.md records up to 976ms under load, against RTL's 1000ms
+default). The race is therefore removed instead of won: the cases now assert on
+a witness present in every state of the lazy boundary — the Suspense fallback's
+raw value, the resolved markup, and the data-table cell wrapper's `title=`.
+
+Measured three ways with the `#4250` derivation scratch-broken: the new witness
+reports 2 document cells and goes red; the OLD assertions
+(`queryByText('Heading')`, `td h1`) pass all 5 cases against that same broken
+derivation once the preload is gone — the green-for-wrong-reason trap the issue
+predicted, now pinned shut.

--- a/packages/plugin-detail/src/__tests__/RelatedList.longFormColumns.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.longFormColumns.test.tsx
@@ -28,25 +28,61 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-// The markdown cell renderer is behind `React.lazy`; import the chunk at module
-// scope so the factory resolves immediately and the assertions are not racing
-// the module loader (AGENTS.md §测试纪律). This matters most for the NEGATIVE
-// cases: they check `queryByText('Heading')` synchronously after awaiting only
-// the row, so without the pre-load a wrongly-derived richtext column would
-// still read as absent while its chunk was in flight — green for the wrong
-// reason. It resolves to the same module the `React.lazy` factory inside
-// `@object-ui/fields` loads relatively, so the factory finds it already cached.
-//
-// The specifier reaches `@object-ui/fields`' SOURCE through the repo vitest
-// alias; the package's `exports` map publishes only `.` and `./style.css`, so
-// nothing but that alias makes this path resolvable — which is why
-// `tsconfig.test.json` has to restate it as a `paths` entry (see there, and
-// #4325 for the packaging gap itself).
-import '@object-ui/fields/widgets/MarkdownContent';
 import { RelatedList } from '../RelatedList';
 
 /** Multi-block markdown — the shape whose formatted render is `<h1>` + `<ul>`. */
 const DOC = '# Heading\n\n**bold** and `code`\n\n- one\n- two';
+
+/**
+ * HOW EVERY CASE IN THIS FILE STAYS NON-VACUOUS (#4325).
+ *
+ * The markdown cell renderer sits behind `React.lazy` in `@object-ui/fields`,
+ * so a richtext column is on screen for a while before it renders anything a
+ * text query recognises. This file used to win that race by side-effect-
+ * importing the lazy chunk at module scope
+ * (`@object-ui/fields/widgets/MarkdownContent`) — a specifier the package's
+ * `exports` map does not publish and only the repo's vitest source alias
+ * resolved. #4325 ruled that subpath out: `@object-ui/fields`' surface is its
+ * index, and one test's preload does not justify minting permanent public API.
+ *
+ * Preloading through the SANCTIONED entry does not replace it — measured, not
+ * assumed. Importing `@object-ui/fields` at module scope leaves the chunk cold:
+ * the index only DECLARES `React.lazy(() => import('./widgets/MarkdownContent'))`
+ * (src/index.tsx), and evaluating the declaring module never runs the factory.
+ * A probe rendering `MarkdownCellRenderer` straight after that import saw the
+ * Suspense fallback synchronously (`h1` absent) and waited 321.8ms for the
+ * chunk on an IDLE container. AGENTS.md §测试纪律 records first-`import()`
+ * latencies up to 976ms under full parallel load against RTL's 1000ms default,
+ * so any `findBy`/`waitFor` on post-boundary content is a coin flip decided by
+ * machine load, not by the code under test.
+ *
+ * So the race is REMOVED rather than won: every case asserts on a witness that
+ * is present in EVERY state of the lazy boundary, via `documentCells()` —
+ *
+ *   - unresolved — `MarkdownCellRenderer`'s Suspense fallback renders the raw
+ *     value, `<span># Heading\n\n**bold** …</span>`;
+ *   - resolved — `<h1>Heading</h1>` + `<ul>`;
+ *   - either way — for a normal (non-`fitContent`) column the data-table cell
+ *     wrapper carries the raw value in `title=`
+ *     (`components/renderers/complex/data-table.tsx`), and that wrapper is
+ *     rendered OUTSIDE the Suspense boundary, so the witness survives even if
+ *     the fallback is ever changed to render nothing.
+ *
+ * The same predicate reports both directions, which is what makes the absence
+ * assertions provably non-vacuous: measured on this tree with the chunk cold, a
+ * richtext column that IS present reads as `queryByText('Heading') === null`
+ * and `querySelector('td h1') === null` — the assertions this file used to
+ * make, green for the wrong reason — while `documentCells()` already sees it.
+ */
+function documentCells(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll('td')).filter(
+    (td) =>
+      td.textContent?.includes('Heading') ||
+      Array.from(td.querySelectorAll('[title]')).some((el) =>
+        el.getAttribute('title')?.includes('Heading'),
+      ),
+  );
+}
 
 const fields = {
   subject: { type: 'text', label: 'Subject' },
@@ -93,20 +129,26 @@ function renderList(extra: Record<string, unknown> = {}) {
 describe('RelatedList — long-form types stay out of auto-derived columns (#4250)', () => {
   it('does not derive a column for a spec-spelled `richtext` field', async () => {
     const { container } = renderList();
+    // Readiness signal: the row's own `subject` cell. `text` has no lazy
+    // boundary, so this is bounded by the data fetch alone — and once it is on
+    // screen the table BODY is committed, which is what makes the absence
+    // assertions below meaningful (a derived column's cell would be in that
+    // same commit). Awaiting a header would not carry that guarantee.
+    await waitFor(() => expect(screen.getByText('Note one')).toBeTruthy());
     // Control: the walk ran and produced real columns.
-    await waitFor(() => expect(screen.getByText('Subject')).toBeTruthy());
+    expect(screen.getByText('Subject')).toBeTruthy();
     expect(screen.getByText('Amount')).toBeTruthy();
 
     expect(screen.queryByText('Body Rich')).toBeNull();
-    // …and nothing rendered the document into a cell.
-    expect(container.querySelector('td h1')).toBeNull();
-    expect(screen.queryByText('Heading')).toBeNull();
+    // …and nothing rendered the document into a cell, in any lazy state.
+    expect(documentCells(container)).toHaveLength(0);
   });
 
   it('does not derive a column for a `markdown` field either', async () => {
-    renderList();
-    await waitFor(() => expect(screen.getByText('Subject')).toBeTruthy());
+    const { container } = renderList();
+    await waitFor(() => expect(screen.getByText('Note one')).toBeTruthy());
     expect(screen.queryByText('Body Markdown')).toBeNull();
+    expect(documentCells(container)).toHaveLength(0);
   });
 
   it('keeps the pre-existing `html` / `json` exclusions', async () => {
@@ -128,8 +170,14 @@ describe('RelatedList — long-form types stay out of auto-derived columns (#425
     // The set filters the zero-config auto-derive walk only. An explicit column
     // is the author saying they want it — over-skipping that is the objectui#2360
     // harm, and this is the control that says the fix did not reintroduce it.
-    renderList({ columns: ['subject', 'body_rt'] });
+    const { container } = renderList({ columns: ['subject', 'body_rt'] });
     await waitFor(() => expect(screen.getByText('Body Rich')).toBeTruthy());
-    expect(await screen.findByText('Heading')).toBeTruthy();
+    // Same witness as the absence cases, read the other way. It used to be
+    // `findByText('Heading')`, which only ever passed because the deleted
+    // module-scope preload had already resolved the chunk; without that preload
+    // it would be a 1000ms budget racing a load measured at up to 976ms. The
+    // pair also closes the loop on the absence assertions above — one predicate
+    // that reports 1 here and 0 there cannot be silently vacuous in either.
+    expect(documentCells(container)).toHaveLength(1);
   });
 });

--- a/packages/plugin-detail/tsconfig.test.json
+++ b/packages/plugin-detail/tsconfig.test.json
@@ -31,23 +31,17 @@
     // `@objectstack/spec` resolve through the workspace dependency's built
     // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
     //
-    // The one entry that survives is not a convenience: `@object-ui/fields`'
-    // `exports` map publishes only `.` and `./style.css`, so the deep specifier
-    // `RelatedList.longFormColumns.test.tsx` uses to pre-resolve the lazy
-    // markdown chunk resolves through the repo vitest alias and through nothing
-    // else. Restating that one alias here is what lets `tsc` read the same
-    // program vitest runs; without it the import is TS2882 and the file cannot
-    // be type-checked at all. Narrow on purpose — `widgets/*` only, so no other
-    // sibling source can leak in behind it. The packaging gap it works around
-    // is filed as #4325; when `fields` publishes the subpath this entry goes.
-    // `paths` resolves against `baseUrl`, and the inherited one points at the
-    // REPO ROOT (the root tsconfig declares `"baseUrl": "."` and `extends`
-    // keeps it relative to the config that declared it). Re-anchor it here so
-    // the entry below reads relative to this package, as it appears to.
-    "baseUrl": ".",
-    "paths": {
-      "@object-ui/fields/widgets/*": ["../fields/src/widgets/*"]
-    }
+    // This is now empty like every other wired-up package's. It briefly carried
+    // one entry — `@object-ui/fields/widgets/*` → `../fields/src/widgets/*` —
+    // restating the repo vitest alias so `tsc` could resolve the deep specifier
+    // `RelatedList.longFormColumns.test.tsx` used to pre-resolve the lazy
+    // markdown chunk (TS2882 without it). #4325 ruled that specifier out rather
+    // than publishing it: `@object-ui/fields`' surface is its index, so the
+    // subpath was never resolvable outside this repo's vitest config, and the
+    // test's anti-race guarantee was rebuilt on a witness that does not need it
+    // (see that file's header). With the import gone the entry has no subject,
+    // and no source-tree path survives here.
+    "paths": {}
   },
   "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Closes #4325.

## The defect

`packages/fields/package.json` publishes exactly two entry points — `.` and
`./style.css`. `packages/plugin-detail/src/__tests__/RelatedList.longFormColumns.test.tsx`
side-effect-imported a third:

```
import '@object-ui/fields/widgets/MarkdownContent';
```

It resolved only because `vitest.config.mts` aliases the whole package name to
its SOURCE directory. Under Node's own resolution it is
`ERR_PACKAGE_PATH_NOT_EXPORTED`; under `tsc` with the standard `paths: {}`
template every wired-up package uses, it was TS2882. That is why
`plugin-detail/tsconfig.test.json` carried the repo's **only** source-tree
`paths` entry — restating the vitest alias so the file could be type-checked at
all.

The import was load-bearing, not decorative: the two "no column derived" cases
assert absence right after awaiting the row, and the markdown cell renderer sits
behind `React.lazy`, so without the preload a wrongly-derived column reads as
absent while its chunk is still in flight.

## The ruling, and the fix

#4325 ruled the subpath **out**: `@object-ui/fields`' surface is its index, and
one test's preload does not justify minting permanent public API plus a matching
`dist` layout to maintain forever. So the import is deleted, `paths` is now `{}`
like every other wired-up package's, and the anti-race guarantee is **rebuilt**
rather than dropped.

The ruling's preferred option (a) — preload through the public index — was
measured and **refuted**. Importing `@object-ui/fields` only evaluates the module
that DECLARES `React.lazy(() => import('./widgets/MarkdownContent'))`; the
factory never runs, so the chunk stays cold. A probe rendering
`MarkdownCellRenderer` straight after that import saw the Suspense fallback
synchronously and waited **321.8 ms** for the chunk on an idle container.
AGENTS.md records first-`import()` latencies up to 976 ms under full parallel
load against RTL's 1000 ms default, so any `findBy`/`waitFor` on post-boundary
content is a coin flip decided by machine load.

Option (b) therefore lands: the race is **removed** instead of won. Every case
asserts through one `documentCells()` predicate, on a witness present in every
state of the lazy boundary — the Suspense fallback's raw value, the resolved
markup, and (for a normal non-`fitContent` column) the data-table cell wrapper's
`title=`, which is rendered outside the Suspense boundary. The fallback `paths`
option (c) was not needed.

The positive case moved to the same predicate too. It used to be
`findByText('Heading')`, which only ever passed because the deleted preload had
already resolved the chunk — leaving it would have converted the fixed flake
into a new one. One predicate reporting 1 there and 0 in the absence cases is
also what makes both directions provably non-vacuous.

## Red-first — three stages, `SKIP_TYPES` scratch-broken back to the #4250 defect

| stage | shape under test | result |
|---|---|---|
| 1 | new file, unmodified | **RED** — 2 failed, on the header assertions |
| 2 | header assertions neutralised, witness alone | **RED** — `expected [ td, td ] to have a length of +0 but got 2` |
| 3 | the OLD assertions restored verbatim, no preload | **GREEN — 5 passed** |

Stage 3 is the point of the card: with the derivation genuinely broken and the
preload gone, `queryByText('Heading')` and `querySelector('td h1')` both pass —
the green-for-wrong-reason trap #4325 predicted, reproduced and now pinned shut.
Stage 2 shows the replacement catches exactly that case. Both files were restored
from the commit afterwards and re-verified.

## Green

```
pnpm --filter @object-ui/plugin-detail test        →  78 files, 761 tests passed
pnpm --filter @object-ui/plugin-detail type-check  →  exit 0 (tsc --noEmit && tsc -p tsconfig.test.json)
pnpm --filter @object-ui/plugin-detail lint        →  0 errors
node scripts/check-type-check-coverage.mjs         →  OK
node scripts/check-changeset-presence.mjs          →  OK
node scripts/check-changeset-no-major.mjs          →  OK
pnpm run check:control-bytes                       →  OK
```

Zero behaviour change: no package source is touched, so the changeset declares an
empty frontmatter (releases nothing). The dispatch's default "patch" grade
assumed the other branch of the ruling — publishing `./widgets/*` would have been
a real package change; ruling the subpath out leaves nothing to release.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_