### PR TITLE
fix(components): restore the excess-property check on element:button's forward payload (#4321)

### DIFF
--- a/.changeset/element-button-forward-excess-property-check-4321.md
+++ b/.changeset/element-button-forward-excess-property-check-4321.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/components': patch
+---
+
+`element:button`'s action forward is excess-property checked again — a misspelled key on that payload is now a compile error, not silence
+
+The payload `element:button` hands to `execute(…)` closed with `as any`. An assertion asks only for comparability, so it switched TypeScript's excess-property (freshness) check off for the whole literal: all sixteen keys the renderer forwards rode unchecked, and `ActionDef` being a closed type (objectui#4046) bought this surface nothing. A typo added to that list — `refreshAftr`, `confirmTxt` — would have compiled, published, and reached a runner that silently does nothing, which is the objectstack#2169 "Mark Done does nothing" shape the closed type exists to prevent.
+
+The exemption that recorded this assumed the cast was load-bearing, on the reasoning that `element:button` receives a bare `action?: Record< string, any >` prop rather than a typed action, so removing the cast would be a contract change. Measured on TypeScript 6.0.3, that was wrong on the point that mattered: dropping the cast type-checks clean as-is, because every key the literal writes is already declared on `ActionDef`. The prop's type is a separate question and is deliberately untouched here — the forward literal never needed the cast to compile.
+
+Two literals needed it, not one. The `execute(…)` argument is contextually typed by `execute(action: ActionDef)`, so dropping the cast is enough for the explicit keys. The `paramsPayload` binding spread into it is the second, easily-missed half: a spread source's own keys are not checked *through* the spread, so `{ actionParams }` / `{ params }` could still invent a key while the payload around them was checked. That binding is now annotated `ActionDef` too.
+
+Runtime behaviour is unchanged — the object reaching `execute` is identical, key order included, and the emitted `.d.ts` does not move. What changes is that the compiler now rejects an invented key here, verified in both directions: the same probe key produces `TS2353` after this change and no diagnostic at all before it.
+
+With this surface fixed, `check:action-forward-parity` has no payloads exempt from its freshness rule: all five action-forwarding renderers write into a literal the compiler checks, and the gate's ratchet removed the exemption entry itself as designed.

--- a/packages/components/src/renderers/basic/elements.tsx
+++ b/packages/components/src/renderers/basic/elements.tsx
@@ -26,6 +26,7 @@
 
 import * as React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
+import type { ActionDef } from '@object-ui/core';
 import { useAdapter, useAction } from '@object-ui/react';
 import {
   useObjectTranslation,
@@ -232,9 +233,32 @@ function ElementButtonRenderer({ schema }: { schema: any }) {
     try {
       // Mirror action:button's param routing: an array of {name,type,…} defs is
       // forwarded for in-dialog collection; a plain object is passed as values.
-      const paramsPayload = Array.isArray(action.params)
+      //
+      // Annotated `ActionDef`, not bare: a spread SOURCE's own keys are not
+      // excess-property checked THROUGH the spread (objectui#4281 probe Q —
+      // `const p = cond ? { actionParams } : { zzBogus }` is absorbed whole by
+      // the literal that spreads it). The payload below being checked therefore
+      // does not cover these two branches; this annotation is what does.
+      const paramsPayload: ActionDef = Array.isArray(action.params)
         ? { actionParams: action.params }
         : { params: action.params };
+      // ── Why there is no `as any` here (objectui#4321) ────────────────────
+      //
+      // This literal used to close with `as any`. An assertion asks only for
+      // comparability, so it switched the excess-property (freshness) check OFF
+      // for every key below — `ActionDef` being closed (objectui#4046) bought
+      // this surface nothing, and a typo added to this list would have compiled,
+      // published, and reached a runner that silently does nothing
+      // (objectstack#2169's shape). Measured on TypeScript 6.0.3: dropping the
+      // cast type-checks clean as-is — every key written here is declared on
+      // `ActionDef` — and an invented key is now a TS2353.
+      //
+      // The direct `execute(…)` argument is contextually typed by
+      // `execute(action: ActionDef)`, which is what runs the check; no hoist to
+      // a named binding is needed because this payload spreads nothing typed
+      // `any` (`...paramsPayload` resolves to object literals and keeps the
+      // check ON). Same shape as `action:group` / `action:menu`, the two
+      // surfaces objectui#4281 measured as already correct.
       await execute({
         type: action.actionType || action.type,
         name: action.name,
@@ -260,7 +284,7 @@ function ElementButtonRenderer({ schema }: { schema: any }) {
         errorMessage: action.errorMessage,
         refreshAfter: action.refreshAfter,
         ...paramsPayload,
-      } as any);
+      });
     } finally {
       setRunning(false);
     }

--- a/scripts/__tests__/check-action-forward-parity.test.ts
+++ b/scripts/__tests__/check-action-forward-parity.test.ts
@@ -636,6 +636,34 @@ describe('the real repository', () => {
     }
   });
 
+  it('holds objectui#4321: element:button writes into a CHECKED literal, and nothing is exempt', () => {
+    // The last unchecked forward literal. Its payload closed with `as any`, so
+    // all ~16 explicit keys rode free — `ActionDef` being closed (objectui#4046)
+    // bought this surface nothing. #4321 measured that dropping the cast
+    // type-checks clean as-is (every key is declared on `ActionDef`), which is
+    // what made the exemption deletable rather than a contract change.
+    //
+    // Both halves are pinned because the surface has two literals, and the
+    // second is easy to miss: the `execute(…)` argument, and `paramsPayload`'s
+    // two branches, whose keys are NOT checked through the spread unless that
+    // binding is itself annotated (probe Q).
+    const surface = SURFACES.find((s) => s.id === 'element:button');
+    expect(surface, 'element:button is no longer a surface').toBeDefined();
+    expect(
+      uncheckedForwardLiterals(repoRoot, surface),
+      "element:button's forward literal is unchecked again — the `as any` is back, or a spread " +
+        'this gate cannot resolve was added to the payload',
+    ).toEqual([]);
+
+    // Empty is the finished state, not an accident: with element:button fixed,
+    // every surface in SURFACES is checked. A new entry here means a surface
+    // regressed or was added in the broken shape.
+    expect(
+      Object.keys(UNCHECKED_FORWARDS),
+      'a forward payload is exempt from the freshness rule again',
+    ).toEqual([]);
+  });
+
   it('every UNCHECKED_FORWARDS entry names a surface that really is unchecked', () => {
     // Same shrink-only governance as the tables above: the exemption cannot
     // outlive the shape it excuses. `analyze()` enforces this too; asserting it

--- a/scripts/check-action-forward-parity.mjs
+++ b/scripts/check-action-forward-parity.mjs
@@ -678,20 +678,22 @@ export function forwardedKeys(root, surface, opaqueSpreads = OPAQUE_SPREADS) {
 // judged by the same rule, because a spread source's keys are not checked
 // through the spread either (probe Q above: `const p = cond ? {actionParams} :
 // {zzBogus}` is absorbed whole; annotating `p` rejects it).
-export const UNCHECKED_FORWARDS = {
-  "element:button": {
-    reason:
-      "Its payload is cast `as any` (elements.tsx), so no excess-property check runs and none " +
-      "can be restored by hoisting alone. Unlike the four action renderers, this surface's " +
-      "`action` is a bare `Record<string, any>` prop rather than a typed action, so the cast is " +
-      "load-bearing for more than the forward literal. PRE-EXISTING and out of objectui#4281's " +
-      "scope (that card measured, and its ruling scoped, the two action renderers); filed " +
-      "separately so this gate stops the BLEEDING — a NEW unchecked forward literal is red — " +
-      "without retro-fixing a surface whose fix is a different change. Ratcheted below: drop " +
-      "the cast and this entry fails.",
-    issue: 4321,
-  },
-};
+// EMPTY, and that is the finished state: every surface in SURFACES writes its
+// forward payload into a literal the compiler excess-property checks.
+//
+// It held one entry, `element:button` — the last unchecked forward literal,
+// whose payload closed with `as any`. objectui#4321 measured what that entry
+// assumed could not be done: dropping the cast type-checks clean as-is, because
+// every key the literal writes is already declared on `ActionDef`. The entry's
+// stated reason ("the cast is load-bearing for more than the forward literal")
+// was therefore wrong on the point that mattered — the `Record<string, any>`
+// PROP type is a separate contract question, and the forward literal never
+// needed the cast to compile. Removed by the ratchet immediately below, exactly
+// as designed: the fix made the entry excuse nothing, and the entry failed.
+//
+// Adding one back is a real decision, not a formality — it re-opens a surface to
+// the objectstack#2169 shape. Prefer the one-line fix the rule above prescribes.
+export const UNCHECKED_FORWARDS = {};
 
 /** Is this type node a reference to `ActionDef`? */
 const isActionDefType = (typeNode) =>


### PR DESCRIPTION
Closes #4321

## The defect

`element:button`'s `execute(…)` payload closed with `as any`. An assertion asks only for comparability, so it switched TypeScript's excess-property (freshness) check **off** for the whole literal: all sixteen forwarded keys rode unchecked, and `ActionDef` being a closed type (#4046) bought this surface nothing. A typo added to that list — `refreshAftr`, `confirmTxt` — would have compiled, published, and reached a runner that silently does nothing, which is the objectstack#2169 "Mark Done does nothing" shape the closed type exists to prevent.

Nothing was mis-forwarded in practice: the parity half of `check:action-forward-parity` was already green here. What was missing is the compile-time guarantee.

## The measurement (this card's actual deliverable)

The `UNCHECKED_FORWARDS['element:button']` exemption recorded an assumption: that the cast was *load-bearing for more than the forward literal*, because this renderer receives a bare `action?: Record< string, any >` prop rather than a typed action, so removing the cast would be a contract change.

Measured on TypeScript 6.0.3, in a clean worktree with the dependency closure built first:

| state | `pnpm --filter @object-ui/components type-check` |
|---|---|
| baseline, untouched | exit 0 |
| **`as any` deleted, nothing else changed** | **exit 0 — clean, zero errors** |

Both tsc invocations (`tsc --noEmit && tsc -p tsconfig.test.json`). So the assumption was wrong on the point that mattered: every key the literal writes is already declared on `ActionDef`, and the forward literal never needed the cast to compile. This is the triage hold's restart condition ② ("someone measures that dropping the cast compiles against `ActionDef` as-is — that instantly converts this into a mechanical queue card").

The `Record< string, any >` **prop** type is a separate contract question and is deliberately untouched here, per the ruling.

## The fix

Two literals needed it, not one — the second is easy to miss.

1. **The `execute(…)` argument**: the cast is gone. That argument is contextually typed by `execute(action: ActionDef)`, which is what runs the check on its explicit keys.
2. **`paramsPayload`**: now annotated `ActionDef`. A spread source's own keys are **not** checked *through* the spread (#4281 probe Q), so its two branches could still invent a key while the payload around them was checked.

The gate's own reverse run makes the count concrete: with the fix reverted it reports **3** unchecked literals for this surface — the payload plus both `paramsPayload` branches.

**No hoist to a named binding.** This payload spreads nothing typed `any`, so the direct argument is checked as-is. That is the shape `action:group` and `action:menu` already use — the two surfaces #4281 measured as *always* correct. #4322's `const forwarded: ActionDef = { … }` hoist was a remedy for `...localContext` (typed `any` via `PropsWithoutRef`), which this renderer does not have; adding it here would mean `execute({ ...forwarded })`, a copy existing only to satisfy the gate's AST parser. Flagged for the PM rather than silently chosen — the ruling named the #4322 shape.

## Red-first contrast

The same probe key, both directions, at both sites:

| site | pre-fix | post-fix |
|---|---|---|
| `execute(…)` payload | **exit 0, no diagnostic** | `elements.tsx(286,9): error TS2353: Object literal may only specify known properties, and 'zzBogusKey' does not exist in type 'ActionDef'.` |
| `paramsPayload` branch | **exit 0, no diagnostic** | `elements.tsx(243,42): error TS2322: … Object literal may only specify known properties, and 'zzBogusParamKey' does not exist in type 'ActionDef'.` |

The silence on the left is the defect; the TS2353 on the right is the guarantee this card buys. Probe keys were removed and the tree re-verified clean afterwards.

## The gate entry

The exemption is **ratcheted**, so deleting it is required in this same PR — and the ratchet is observable in both directions:

- entry **retained**, payload fixed → `node scripts/check-action-forward-parity.mjs` exits **1**:
  `UNCHECKED_FORWARDS entry 'element:button' excuses nothing — the surface's forward literal is excess-property checked now… Delete it (and close #4321 once its last entry is gone)`
- entry **deleted** → exits **0**:
  `action forward parity: 5 surfaces checked … 0 payloads exempt from the freshness rule` with `element:button owes 12, forwards 18, payload excess-property CHECKED`

`UNCHECKED_FORWARDS` is now empty, and that is the finished state: every surface writes into a literal the compiler checks. The replacement comment says so and records why re-adding an entry is a real decision.

## Verification

- `pnpm --filter '@object-ui/components^...' build` — dependency closure built **first**, before trusting any tsc.
- `pnpm --filter @object-ui/components type-check` — exit 0 (both tsc commands).
- `pnpm exec vitest run packages/components/` from the repo root — **122 files, 1082 tests, all passing**, including `element-button-action.test.tsx`. Run from the root because the repo's own guard rejects package-level `vitest run` as false-green.
- `pnpm exec vitest run scripts/__tests__/check-action-forward-parity.test.ts` — 48 passing, including the new pin.
- `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed` — all pass.
- ESLint on the three changed files — 0 errors.
- **Emitted `.d.ts` diffed both ways: byte-identical.** Changeset is therefore **patch**, per the ruling's grading.

## Test added

`scripts/__tests__/check-action-forward-parity.test.ts` gains a pin mirroring the existing #4281 one: `element:button`'s forward literal is checked, and `UNCHECKED_FORWARDS` is empty. Reverse-verified — restoring the `as any` turns it red with its own message ("the `as any` is back, or a spread this gate cannot resolve was added to the payload").

## Scope

`packages/components/src/renderers/basic/elements.tsx`, `scripts/check-action-forward-parity.mjs` (exemption-entry deletion only), the gate's test file (the ruling's surface reads "+ test/changeset"), and the changeset. Runtime behaviour is unchanged — the object reaching `execute` is identical, key order included.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_