### PR TITLE
chore(lint): bring e2e/ under the lint gate; fix the 3 errors it exposes (#4456)

### DIFF
--- a/e2e/import-console/import-console-undo.spec.ts
+++ b/e2e/import-console/import-console-undo.spec.ts
@@ -36,7 +36,9 @@ test.describe('Import Wizard — real console: background import + undo', () => 
       const r = await page.request.get(`${API}/api/v1/data/import/jobs`);
       jobsSupported = r.status() !== 404;
     } catch {
-      jobsSupported = false;
+      // Unreachable backend reads the same as "no import-job route" here, which
+      // is the initialiser above — reassigning it is what `no-useless-assignment`
+      // reports, because nothing can observe the difference.
     }
     test.skip(!jobsSupported, `backend at ${API} has no import-job route (/api/v1/data/import/jobs)`);
 

--- a/e2e/import-harness/import-undo.spec.ts
+++ b/e2e/import-harness/import-undo.spec.ts
@@ -26,7 +26,9 @@ test.describe('Import Wizard — background import + undo (live UI + backend)', 
       const res = await page.request.get(`${baseURL}${HARNESS_PATH}`);
       reachable = res.ok();
     } catch {
-      reachable = false;
+      // A throw reads the same as "not reachable" here, which is the initialiser
+      // above — reassigning it is what `no-useless-assignment` reports, because
+      // nothing can observe the difference.
     }
     test.skip(!reachable, `import harness not reachable at ${baseURL}${HARNESS_PATH}`);
 

--- a/e2e/live/global-setup.ts
+++ b/e2e/live/global-setup.ts
@@ -25,6 +25,7 @@ export default async function globalSetup() {
   } catch (e: any) {
     throw new Error(
       `Live backend unreachable at ${API} (${e?.message}). Start it (e.g. \`objectstack serve --dev\` in examples/app-showcase) before running live e2e.`,
+      { cause: e },
     );
   }
   if (!res.ok()) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "lint": "turbo run lint",
+    "lint:root": "eslint . --ignore-pattern 'packages/*/**' --ignore-pattern 'examples/*/**' --ignore-pattern 'apps/*/**' --ignore-pattern 'docs/**'",
     "lint:coverage": "node scripts/check-lint-coverage.mjs",
     "type-check": "turbo run type-check",
     "type-check:coverage": "node scripts/check-type-check-coverage.mjs",

--- a/scripts/__tests__/turbo-task-guard-coverage.test.ts
+++ b/scripts/__tests__/turbo-task-guard-coverage.test.ts
@@ -32,6 +32,16 @@ import { repoRoot } from './helpers/turbo-inputs';
  *     test:watch  cache: false, persistent   nothing to replay
  *     clean       cache: false               nothing to replay
  *     dev         cache: false, persistent   nothing to replay
+ *     //#lint:root  cache: false             nothing to replay
+ *
+ * `//#lint:root` (objectui#4456) is the root task that lints everything OUTSIDE
+ * the workspace packages — `e2e/`, `scripts/`, `eslint-rules/`, the root config
+ * files — which no package's `lint` script reaches. It is deliberately on the
+ * uncached side of this partition rather than guarded: the files it reads are
+ * "the repo minus the workspaces", so any inputs list enumerating them would go
+ * stale the moment a new root-level directory is added, and a stale inputs list
+ * on a CACHED task replays a green verdict over a directory nothing linted —
+ * which is objectui#4456 itself, one level up. It runs in about four seconds.
  */
 
 interface TurboTask {

--- a/turbo.json
+++ b/turbo.json
@@ -49,11 +49,16 @@
     "lint": {
       "outputs": [],
       "cache": true,
+      "dependsOn": ["//#lint:root"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/eslint.config.js",
         "$TURBO_ROOT$/eslint-rules/*.js"
       ]
+    },
+    "//#lint:root": {
+      "outputs": [],
+      "cache": false
     },
     "type-check": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Closes #4456

## The gap

`pnpm lint` is `turbo run lint`, and turbo's `lint` task runs each **workspace package's** own `lint` script. Anything that is not inside a workspace package is therefore linted by nothing. Measured on `main` at b4d3c2204:

```
$ pnpm exec eslint .
✖ 9898 problems (3 errors, 9895 warnings)

$ pnpm exec turbo run lint
 Tasks:    45 successful, 45 total     <- green
```

All 3 errors sat under `e2e/`. The gap is wider than the errors: `e2e/` (30 files), `scripts/` (70), `eslint-rules/` (11) and the root config files — 111 lintable files in total — are outside every package's `lint` script. They happen to be error-free apart from those 3, so the invariant held only by luck.

## The invariant

Root `eslint .` and `turbo run lint` agree on what is clean — one resolver, one answer.

## The landing

A root turbo task, `//#lint:root`, that lints **the repo minus the workspace globs declared in `pnpm-workspace.yaml`**, with turbo's `lint` task depending on it:

```json
"lint":         { "dependsOn": ["//#lint:root"], ... },
"//#lint:root": { "outputs": [], "cache": false }
```

```
"lint:root": "eslint . --ignore-pattern 'packages/*/**' --ignore-pattern 'examples/*/**' --ignore-pattern 'apps/*/**' --ignore-pattern 'docs/**'"
```

Three properties this shape was chosen for:

1. **Derived by subtraction, not by listing.** The four ignore patterns map 1:1 onto `pnpm-workspace.yaml`'s four entries, so the *covered* set is "everything else". A new root-level directory is linted the day it is added — no enumeration to keep in step, which is what made this a coverage gap in the first place. Drift in the ignore list is fail-safe: a workspace group missing from it gets linted twice, never zero times.
2. **`dependsOn`, so bare `turbo run lint` covers it.** Chaining `eslint` onto the root `lint` *script* would have fixed `pnpm lint` while leaving plain `turbo run lint` green over `e2e/` — the same discrepancy one level up.
3. **`cache: false` is deliberate, not an omission.** `scripts/__tests__/turbo-task-guard-coverage.test.ts` partitions turbo tasks into "cached, therefore guarded by a derived inputs list" and "never cached, therefore exempt". This task belongs on the uncached side: its file set is *the repo minus the workspaces*, so any `inputs` list enumerating it goes stale the moment a root directory is added — and a stale inputs list on a cached task replays a green verdict over a directory nothing linted, which is this issue one level up. Cost is about 4 seconds; package `lint` tasks stay cached (45/46 cached on a warm run).

## Red first

Coverage added, fix not yet applied — `turbo run lint` reds with exactly the 3 known errors:

```
//:lint:root:   34:9  error  The value assigned to 'jobsSupported' is not used in subsequent statements  no-useless-assignment
//:lint:root:   24:9  error  The value assigned to 'reachable' is not used in subsequent statements      no-useless-assignment
//:lint:root:   26:5  error  There is no `cause` attached to the symptom error being thrown              preserve-caught-error
 Failed:    //#lint:root
```

Then green on both sides, which is the invariant asserted directly:

```
FINAL turbo run lint EXIT=0     Tasks: 46 successful, 46 total
FINAL root eslint .  EXIT=0     ✖ 9895 problems (0 errors, 9895 warnings)
```

## The wiring is load-bearing

Checked in the direction that matters for a *coverage* change, which is the inverse of the usual one: removing the wiring must make an existing error **invisible**, not red. With `//#lint:root` reverted and the `reachable` violation restored:

```
$ pnpm exec turbo run lint
 Tasks:    45 successful, 45 total       <- EXIT 0, green

$ pnpm exec eslint e2e/import-harness/import-undo.spec.ts
  24:9  error  The value assigned to 'reachable' is not used ...  no-useless-assignment
✖ 1 problem (1 error, 0 warnings)
```

That pair of commands is issue #4456 reproduced exactly. With the wiring present the same violation reds the run, so the coverage is what does the work.

## The 3 fixes are style-only

- **`no-useless-assignment` (x2)** — `let flag = false; try { flag = ... } catch { flag = false }`. The catch reassigns the initialiser to the value it already holds, so the two paths are indistinguishable. Dropped the reassignment and kept the initialiser (which is now the value the throw path uses). Behaviour identical on both paths.
- **`preserve-caught-error` (x1)** — `e2e/live/global-setup.ts` rethrows a friendlier "live backend unreachable" error and dropped the original. Added `{ cause: e }`. The message is byte-identical; the original error is now attached rather than discarded. Nothing asserts on this error — it is Playwright `globalSetup` for the live suite, and it fails the run either way.

No behaviour change in any of the three, so none of them hit the stop-and-report clause.

## Notes

- **No changeset owed**, confirmed by the gate rather than by judgement: `node scripts/check-changeset-presence.mjs` reports `6 file(s) changed, 0 of them under the src/ of a package the release covers ... no changeset is owed`.
- `scripts/__tests__/turbo-task-guard-coverage.test.ts` is edited for its docblock only — the partition table there enumerates turbo's tasks, and this PR adds one. No assertion changed; all 169 tests across the six turbo/lint guard suites pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_