### PR TITLE
chore(types): bring e2e/ under a tsconfig; fix what 30 never-compiled specs accumulated (#4471)

### DIFF
--- a/e2e/live/master-detail.spec.ts
+++ b/e2e/live/master-detail.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { selectOption, fillLookup, addLineItem } from './helpers';
+import { selectOption, fillLookup } from './helpers';
 
 /**
  * Live e2e for the master-detail entry form (showcase "New Project + Tasks").
@@ -42,7 +42,18 @@ test('Create submits the populated parent in one atomic batch', async ({ page })
   await expect(page.getByText('Northwind', { exact: false })).toBeVisible();
 
   await Promise.all([
-    page.waitForRequest((r) => r.url().includes('/api/v1/batch') && r.request?.().method?.() !== 'GET', { timeout: 15_000 }).catch(() => null),
+    // This predicate used to end `&& r.request?.().method?.() !== 'GET'`, which
+    // objectui#4471's first-ever compile of this file reported as TS2339:
+    // `Request` has no `request` member (that is `Response.request()`). Because
+    // the whole chain is optional, it evaluated to `undefined !== 'GET'` — always
+    // true — so the non-GET filter has never been in effect for a single run.
+    // Deleted rather than repaired: removing a provably-always-true conjunct
+    // cannot change what this wait resolves on, whereas restoring the intent as
+    // `r.method() !== 'GET'` WOULD, and that needs the live stack to validate.
+    // Nothing this test asserts depends on it either way — the `batches` array
+    // below does its own `r.method() === 'POST'` filtering, and this wait's
+    // result is discarded (`.catch(() => null)`); it only races the click.
+    page.waitForRequest((r) => r.url().includes('/api/v1/batch'), { timeout: 15_000 }).catch(() => null),
     page.getByTestId('md-form-submit').click(),
   ]);
   await page.waitForTimeout(500);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint:coverage": "node scripts/check-lint-coverage.mjs",
     "type-check": "turbo run type-check",
     "type-check:coverage": "node scripts/check-type-check-coverage.mjs",
+    "type-check:e2e": "tsc -p tsconfig.e2e.json",
     "type-check:scripts": "tsc -p tsconfig.scripts.json",
     "type-check:vitest-setup": "tsc -p tsconfig.vitest-setup.json",
     "check:spec-symbols": "node scripts/check-spec-symbol-derivation.mjs",

--- a/scripts/__tests__/e2e-type-check.test.ts
+++ b/scripts/__tests__/e2e-type-check.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+/**
+ * objectui#4471 — the 30 Playwright specs under `e2e/` were compiled by nothing.
+ *
+ * `e2e/` is not a workspace package, so `pnpm type-check` (i.e. `turbo run
+ * type-check`, which walks package.json `scripts`) structurally cannot reach it;
+ * and no tsconfig in the repo included it — the root `tsconfig.json` includes
+ * only `packages`/`examples`/`apps`, `tsconfig.scripts.json` only `scripts/**`,
+ * `tsconfig.vitest-setup.json` only the root `vitest.setup*` files. Playwright
+ * TRANSPILES specs rather than type-checking them, so nothing ever read them.
+ *
+ * That is objectui#3494's shape one directory over, and objectui#3515's one
+ * directory across. It matters more for a test directory than for most: a spec
+ * the compiler never reads can call a method that does not exist and still print
+ * green, because the call sits in a branch the run never takes. The first compile
+ * found exactly that in `e2e/live/master-detail.spec.ts` — a `waitForRequest`
+ * predicate ending `r.request?.().method?.() !== 'GET'`, where `Request` has no
+ * `request` member, so the optional chain made the whole conjunct
+ * `undefined !== 'GET'`: always true, for the life of the file.
+ *
+ * `tsconfig.e2e.json` closes it. This file is what stops it reopening, and like
+ * its two siblings it deliberately asserts BEHAVIOUR — which files the project
+ * really resolves, what its options really accept, whether the pipeline really
+ * runs it — rather than the config's spelling. A test that only checked the
+ * spelling would be satisfied by a config that compiles nothing, which is the
+ * failure mode it exists to prevent.
+ *
+ * The one structural difference from `scripts-type-check.test.ts`: that gate is
+ * a direct step in ci.yml's `type-check` job, this one is a turbo ROOT TASK
+ * (`//#type-check:e2e`) that the `type-check` task `dependsOn` — the shape
+ * objectui#4456 introduced for `//#lint:root`. So the wiring assertions below
+ * are about turbo.json rather than about a workflow step, and they include the
+ * `cache: false` half: see `turbo-task-guard-coverage.test.ts` for why a task
+ * that turbo could replay would owe a derived-inputs guard instead.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const configPath = path.join(repoRoot, 'tsconfig.e2e.json');
+const e2eDir = path.join(repoRoot, 'e2e');
+
+/** The root script a contributor runs, and the turbo root task that drives it. */
+const SCRIPT_NAME = 'type-check:e2e';
+const TURBO_TASK = `//#${SCRIPT_NAME}`;
+
+/**
+ * The project as TypeScript itself resolves it: the same parse `tsc -p` does,
+ * so `fileNames` is the real program root set rather than a re-implementation
+ * of TypeScript's glob semantics.
+ */
+function parsedProject(): ts.ParsedCommandLine {
+  const read = ts.readConfigFile(configPath, ts.sys.readFile);
+  expect(
+    read.error && ts.flattenDiagnosticMessageText(read.error.messageText, ' '),
+    'tsconfig.e2e.json must parse as JSON with comments',
+  ).toBeFalsy();
+
+  return ts.parseJsonConfigFileContent(read.config, ts.sys, repoRoot, undefined, configPath);
+}
+
+/** Every TypeScript source on disk under `e2e/`, repo-relative, POSIX-separated. */
+function typeScriptSourcesOnDisk(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+        walk(full);
+      } else if (/\.tsx?$/.test(entry.name) && !entry.name.endsWith('.d.ts')) {
+        out.push(path.relative(repoRoot, full).split(path.sep).join('/'));
+      }
+    }
+  };
+  walk(e2eDir);
+  return out.sort();
+}
+
+/** Repo-relative, POSIX-separated program root files. */
+function programFiles(): Set<string> {
+  return new Set(
+    parsedProject().fileNames.map((f) => path.relative(repoRoot, f).split(path.sep).join('/')),
+  );
+}
+
+/**
+ * Compile one throwaway source file with THIS project's real options and return
+ * its diagnostics.
+ *
+ * The point is to ask the option set a question it can only answer by being
+ * correct, instead of asserting the strings in `lib`. `"lib": ["ES2022", ...]`
+ * spelled right but paired with a `target` that overrides it, or an `ES2022`
+ * that a later edit trims back to `ES2021`, both pass a spelling check and both
+ * reintroduce the defect.
+ */
+function diagnosticsFor(source: string): string[] {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-type-check-'));
+  try {
+    const file = path.join(dir, 'probe.ts');
+    fs.writeFileSync(file, source);
+    const program = ts.createProgram([file], { ...parsedProject().options, noEmit: true });
+    return ts
+      .getPreEmitDiagnostics(program)
+      .filter((d) => d.file?.fileName === file.split(path.sep).join('/'))
+      .map((d) => `TS${d.code}: ${ts.flattenDiagnosticMessageText(d.messageText, ' ')}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('tsconfig.e2e.json — the project itself (objectui#4471)', () => {
+  /**
+   * A tsconfig that fails to parse does not fail loudly: TypeScript falls back
+   * to defaults, and with no `include` surviving, `tsc -p` cheerfully compiles
+   * the ENTIRE repository. `tsconfig.scripts.json` records how that was found —
+   * a `**` immediately followed by `/` inside a block comment closes the comment
+   * early — which is why this config, like its siblings, uses `//` comments.
+   */
+  it('parses with no diagnostics at all', () => {
+    const parsed = parsedProject();
+    const messages = parsed.errors.map((d) => ts.flattenDiagnosticMessageText(d.messageText, ' '));
+    expect(messages, 'tsconfig.e2e.json emitted config diagnostics').toEqual([]);
+  });
+
+  it('is a checking project, not an emitting one', () => {
+    const { options } = parsedProject();
+
+    // It must not emit: these are checks, and a stray `.js` landing next to a
+    // spec would be picked up by `playwright.config.ts`'s `testDir: './e2e'` as
+    // a test in its own right.
+    expect(options.noEmit, 'tsconfig.e2e.json must set "noEmit": true').toBe(true);
+    expect(options.strict, 'tsconfig.e2e.json must set "strict": true').toBe(true);
+
+    // `noEmit` is only legal here because the project is standalone. If someone
+    // makes it `composite` or gives it `references`, TS6310 fires and the two
+    // assertions above become mutually unsatisfiable — fail on the cause, not
+    // on the symptom.
+    expect(options.composite, 'a composite project may not set "noEmit" (TS6310)').toBeFalsy();
+    expect(parsedProject().projectReferences ?? [], 'this project must stay standalone').toEqual([]);
+  });
+});
+
+describe('tsconfig.e2e.json — the option set answers the questions e2e/ asks (objectui#4471)', () => {
+  /**
+   * The caveat objectui#4471 measured before anyone started: PR #4470 added
+   * `new Error(msg, { cause: e })` to `e2e/live/global-setup.ts` to satisfy the
+   * `preserve-caught-error` lint rule, and `ErrorOptions` does not exist before
+   * ES2022 — so a config inheriting the root `tsconfig.json`'s ES2020 reds with
+   * `TS2554: Expected 0-1 arguments, but got 2` on a file that runs before every
+   * live-suite run.
+   */
+  it('accepts `new Error(msg, { cause })`, so the lib is ES2022 or newer', () => {
+    expect(
+      diagnosticsFor('export const e = new Error("boom", { cause: new Error("why") });'),
+      'tsconfig.e2e.json’s lib no longer provides ErrorOptions. e2e/live/global-setup.ts ' +
+        'constructs `new Error(msg, { cause: e })` for `preserve-caught-error`; on an ES2020 lib ' +
+        'that is TS2554 (objectui#4471 measured it). Restore "lib": ["ES2022", ...].',
+    ).toEqual([]);
+  });
+
+  /**
+   * `page.evaluate(...)` callbacks are compiled in this program while executing
+   * in the browser, so DOM globals must resolve. Measured on first run: without
+   * DOM, three errors — `document` in `e2e/helpers/index.ts` and
+   * `e2e/smoke.spec.ts`, `HTMLElement` in `e2e/live/cascading-options.spec.ts`.
+   */
+  it('resolves DOM globals, which page.evaluate callbacks are written against', () => {
+    expect(
+      diagnosticsFor('export const n = document.getElementById("root")?.children.length ?? 0;'),
+      'tsconfig.e2e.json must keep "DOM" in `lib` — page.evaluate callbacks are type-checked here.',
+    ).toEqual([]);
+  });
+
+  /**
+   * The specs are Node programs outside the browser callbacks: `process.env` in
+   * 11 files, `Buffer` in three, `node:fs`/`node:path` in two. Measured with
+   * `"types": []`: 26 errors across 12 files, every one TS2591.
+   */
+  it('resolves Node globals and `node:` builtins', () => {
+    expect(
+      diagnosticsFor(
+        'import { readFileSync } from "node:fs";\n' +
+          'export const p = process.env.LIVE_API_URL ?? readFileSync("x").toString();\n' +
+          'export const b: Buffer = Buffer.from("x");',
+      ),
+      'tsconfig.e2e.json must keep "types": ["node"] — the specs read process.env and node: builtins.',
+    ).toEqual([]);
+  });
+});
+
+describe('tsconfig.e2e.json — coverage of e2e/ (objectui#4471)', () => {
+  it('resolves every TypeScript source under e2e/, with none left out', () => {
+    const onDisk = typeScriptSourcesOnDisk();
+
+    // Non-vacuity first. Every other assertion here is satisfied by a project
+    // that resolves nothing, and "compiles nothing, exits 0" is exactly what
+    // this gate exists to make impossible.
+    expect(onDisk.length, 'no .ts sources found under e2e/ — the walk is broken').toBeGreaterThan(20);
+
+    const inProject = programFiles();
+    const uncovered = onDisk.filter((f) => !inProject.has(f));
+
+    expect(
+      uncovered,
+      'These TypeScript files under e2e/ are not in tsconfig.e2e.json’s program, so nothing ' +
+        'type-checks them:\n' +
+        uncovered.map((f) => `  - ${f}`).join('\n') +
+        '\n\nWiden the "include" glob in tsconfig.e2e.json. A spec under e2e/ that no tsc ' +
+        'invocation reads is objectui#4471 all over again — and Playwright transpiles without ' +
+        'checking, so the only thing that would ever report it is a red run in CI.',
+    ).toEqual([]);
+  });
+
+  it('really does cover the specs and the live global-setup, by name', () => {
+    // The forward assertion above is a set difference, which stays green if the
+    // directory walk ever stops descending. Name a few outright — one per
+    // sub-directory shape the glob has to reach.
+    const inProject = programFiles();
+    for (const file of [
+      'e2e/smoke.spec.ts',
+      'e2e/helpers/index.ts',
+      'e2e/import-console/import-console-undo.spec.ts',
+      'e2e/live/global-setup.ts',
+      'e2e/live/master-detail.spec.ts',
+    ]) {
+      expect(inProject, `${file} must be type-checked by tsconfig.e2e.json`).toContain(file);
+    }
+  });
+
+  /**
+   * The premise behind the wiring below: this project needs no built workspace
+   * declarations, so it can be a root task that runs without waiting for
+   * `^build`. `tsconfig.vitest-setup.json` is the counterexample — its program
+   * side-effect-imports four `@object-ui/*` packages, which is why its ci.yml
+   * step has to sit after `pnpm type-check`. If a spec ever imports a workspace
+   * package, this goes red and the wiring has to be reconsidered rather than
+   * silently starting to depend on `dist`.
+   */
+  it('imports no workspace package, so it needs no build', () => {
+    const workspaceImports = parsedProject()
+      .fileNames.flatMap((f) => [
+        ...fs.readFileSync(f, 'utf8').matchAll(/from\s+'(@object-ui\/[^']+)'/g),
+      ])
+      .map((m) => m[1]);
+
+    expect(
+      [...new Set(workspaceImports)],
+      'tsconfig.e2e.json’s program now imports workspace packages, so it needs their built ' +
+        'declaration files — but `//#type-check:e2e` is a root task with no `dependsOn`, so ' +
+        'turbo does not build anything for it. Give the task `dependsOn: ["^build"]` (and check ' +
+        'that a ROOT task can express what you need), or drop the import.',
+    ).toEqual([]);
+  });
+});
+
+describe('the gate is actually wired up (objectui#4471)', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+    scripts?: Record<string, string>;
+  };
+  const turbo = JSON.parse(fs.readFileSync(path.join(repoRoot, 'turbo.json'), 'utf8')) as {
+    tasks: Record<string, { cache?: boolean; dependsOn?: string[]; inputs?: string[] }>;
+  };
+
+  it('is runnable locally, by name', () => {
+    // A gate nobody can reproduce locally is a gate people learn to ignore.
+    expect(pkg.scripts?.[SCRIPT_NAME], `package.json must define "${SCRIPT_NAME}"`).toBeDefined();
+    expect(pkg.scripts?.[SCRIPT_NAME]).toContain('tsconfig.e2e.json');
+  });
+
+  it('is a turbo root task, which is what makes `pnpm type-check` reach e2e/', () => {
+    // Turbo resolves `//#x` to the ROOT package.json's `x` script. Declaring the
+    // task without the script (or renaming the script out from under it) is a
+    // hard turbo error rather than a silent skip, but pin the pairing anyway:
+    // it is the whole reason the script above is not dead weight.
+    expect(
+      turbo.tasks[TURBO_TASK],
+      `turbo.json must declare the root task \`${TURBO_TASK}\`. Without it, ` +
+        `\`pnpm type-check\` (turbo run type-check) never reaches e2e/ and this config is ` +
+        'CI-invisible unless someone adds a workflow step — which is the shape objectui#4456 ' +
+        'moved away from.',
+    ).toBeDefined();
+    expect(
+      pkg.scripts?.[SCRIPT_NAME],
+      `\`${TURBO_TASK}\` resolves to the root package.json script "${SCRIPT_NAME}"`,
+    ).toBeDefined();
+  });
+
+  it('runs as part of `pnpm type-check`', () => {
+    expect(
+      turbo.tasks['type-check']?.dependsOn ?? [],
+      `turbo.json's \`type-check\` task must \`dependsOn\` \`${TURBO_TASK}\`. That dependency is ` +
+        'the entire wiring: ci.yml’s existing `Run type-check` step gains e2e/ coverage with ' +
+        'no new workflow entry, exactly as `lint` gained `//#lint:root` in objectui#4456.',
+    ).toContain(TURBO_TASK);
+  });
+
+  /**
+   * The partition rule from `turbo-task-guard-coverage.test.ts`, restated where
+   * it bites. That file requires every CACHEABLE task to have a
+   * `turbo-<task>-inputs.test.ts` deriving its out-of-package reads — and for a
+   * `//#`-prefixed task the derived name is not even a legal path, so a cached
+   * root task cannot satisfy the family at all. The substantive reason is the
+   * same one: tsc's real read set is the import closure (`@playwright/test`'s
+   * declarations, `@types/node`), and the sibling guards deliberately narrow to
+   * config root files. A cached verdict over that is replayable in a way nobody
+   * derives, which is objectui#3514 with a type gate attached.
+   */
+  it('is uncached, the side of the guard-coverage partition it belongs on', () => {
+    expect(
+      turbo.tasks[TURBO_TASK]?.cache,
+      `\`${TURBO_TASK}\` must stay "cache": false. If it becomes cacheable, ` +
+        'turbo-task-guard-coverage.test.ts starts demanding a derived-inputs guard for it — and ' +
+        'the name that guard would have to carry (turbo-//#type-check:e2e-inputs.test.ts) is not ' +
+        'a path. It costs a few seconds; leave it uncached.',
+    ).toBe(false);
+  });
+});

--- a/scripts/__tests__/turbo-task-guard-coverage.test.ts
+++ b/scripts/__tests__/turbo-task-guard-coverage.test.ts
@@ -32,7 +32,8 @@ import { repoRoot } from './helpers/turbo-inputs';
  *     test:watch  cache: false, persistent   nothing to replay
  *     clean       cache: false               nothing to replay
  *     dev         cache: false, persistent   nothing to replay
- *     //#lint:root  cache: false             nothing to replay
+ *     //#lint:root        cache: false       nothing to replay
+ *     //#type-check:e2e   cache: false       nothing to replay
  *
  * `//#lint:root` (objectui#4456) is the root task that lints everything OUTSIDE
  * the workspace packages — `e2e/`, `scripts/`, `eslint-rules/`, the root config
@@ -42,6 +43,24 @@ import { repoRoot } from './helpers/turbo-inputs';
  * stale the moment a new root-level directory is added, and a stale inputs list
  * on a CACHED task replays a green verdict over a directory nothing linted —
  * which is objectui#4456 itself, one level up. It runs in about four seconds.
+ *
+ * `//#type-check:e2e` (objectui#4471) is the same move for the TYPE gate: `e2e/`
+ * is not a workspace package, so `turbo run type-check` could not reach it and
+ * the 30 Playwright specs were compiled by nothing. It runs
+ * `tsc -p tsconfig.e2e.json`, and `type-check` `dependsOn` it, so `pnpm
+ * type-check` now covers `e2e/`. Uncached for two reasons, one structural and
+ * one substantive. Structural: `guardFor` below derives a guard NAME from the
+ * task name, and `turbo-//#type-check:e2e-inputs.test.ts` is not a legal path —
+ * a cacheable root task cannot be expressed in this family at all. Substantive:
+ * a tsc program's real read set is its IMPORT CLOSURE (`@playwright/test`'s
+ * declarations, `@types/node`), while the four derived guards deliberately
+ * narrow to config root files — a narrowing that is sound for a composite
+ * package project, which must list its own files, and unsound here. A cached
+ * verdict over a set nobody derives is objectui#3514 with a type gate attached.
+ * Measured cost of not caching it: 2.3s (three consecutive cold runs, 2.29 /
+ * 2.41 / 2.37). `scripts/__tests__/e2e-type-check.test.ts`
+ * restates the `cache: false` half from the other side, so removing it goes red
+ * in two places rather than quietly demanding a guard that cannot be written.
  */
 
 interface TurboTask {

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,122 @@
+// Type-checks the `.ts` files under `e2e/` — the Playwright specs, their shared
+// helpers, and `e2e/live/global-setup.ts`, which runs before every live-suite run.
+//
+// objectui#4471: nothing compiled them. `e2e/` is not a workspace package, so
+// `turbo run type-check` — which is driven by package.json `scripts` — cannot
+// structurally reach it, the same reason given verbatim in
+// `tsconfig.scripts.json`'s header for `scripts/`. And no tsconfig in the repo
+// included it either: the root `tsconfig.json` includes only
+// `packages`/`examples`/`apps`, `tsconfig.scripts.json` only `scripts/**`,
+// `tsconfig.vitest-setup.json` only the root `vitest.setup*` files. Playwright
+// TRANSPILES specs rather than type-checking them, so the 30 `.ts` files here
+// had been read by no `tsc` invocation, ever.
+//
+// That is objectui#3494's shape one directory over, and for a test suite it is
+// the expensive half: a spec the compiler never reads can call a method that
+// does not exist and still print green, because the call sits in a branch the
+// run does not take — which is exactly what the first compile found. See
+// `e2e/live/master-detail.spec.ts`: a `waitForRequest` predicate ending
+// `r.request?.().method?.() !== 'GET'` had been `undefined !== 'GET'`, always
+// true, for its whole life. Playwright would never have told anyone.
+//
+// This project is standalone and cheap: it imports no workspace package — every
+// e2e import is `@playwright/test`, `./helpers`, or a `node:` builtin — so unlike
+// `tsconfig.vitest-setup.json` it needs no built declarations and can run before,
+// or independently of, any build. `scripts/__tests__/e2e-type-check.test.ts` pins
+// that premise, so if a spec ever imports `@object-ui/*` the wiring has to be
+// reconsidered rather than silently starting to depend on `dist`.
+//
+// Comments here are `//`, not `/* */`, for the reason recorded in
+// `tsconfig.scripts.json`: a glob containing `**` immediately followed by `/`
+// closes a block comment early, and a tsconfig that silently fails to parse does
+// not fail loudly — it falls back to compiling the entire repository.
+//
+// Run it with `pnpm type-check:e2e`. It is also a turbo ROOT task
+// (`//#type-check:e2e`) that the `type-check` task `dependsOn`, so plain
+// `pnpm type-check` — and therefore ci.yml's existing `Run type-check` step —
+// covers `e2e/` with no new workflow step. That is the shape objectui#4456 used
+// for `//#lint:root`, and it is why this file needs no ci.yml entry of its own
+// the way `type-check:scripts` and `type-check:vitest-setup` do.
+//
+// NOT covered here, deliberately: the four root `playwright*.config.ts` files,
+// which sit beside this file rather than under `e2e/` and are in no tsc program
+// either. They compile clean against this exact option set today (measured,
+// exit 0), so it is a dormant gap rather than a live defect — filed as
+// objectui#4477 instead of widened into objectui#4471's surface.
+{
+  "compilerOptions": {
+    // Node 22 (`engines.node: ">=22"`) runs the Playwright worker that executes
+    // these files. ES2022 is load-bearing rather than tidy: PR #4470 added
+    // `new Error(msg, { cause: e })` to `e2e/live/global-setup.ts` to satisfy
+    // `preserve-caught-error`, and `ErrorOptions` does not exist before ES2022.
+    // Measured, at the root tsconfig's ES2020:
+    //   e2e/live/global-setup.ts(28,7): error TS2554: Expected 0-1 arguments, but got 2.
+    // So this project must NOT inherit the root `tsconfig.json`'s ES2020, and
+    // `tsconfig.scripts.json` settled the same question the same way for the
+    // same reason.
+    "target": "ES2022",
+
+    // DOM is load-bearing too. `page.evaluate(...)` callbacks are compiled in
+    // THIS program while executing in the browser, so their globals must
+    // resolve. Measured, dropping DOM from `lib`: 3 errors —
+    //   e2e/helpers/index.ts(12,12): error TS2584: Cannot find name 'document'.
+    //   e2e/live/cascading-options.spec.ts(45,28): error TS2304: Cannot find name 'HTMLElement'.
+    //   e2e/smoke.spec.ts(45,14): error TS2584: Cannot find name 'document'.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+
+    // `process.env` in 11 files, `Buffer` in three, `node:fs`/`node:path` in two.
+    // Measured, with `types: []`: 26 errors, every one TS2591 for `process`,
+    // `Buffer` or a `node:` builtin, across 12 files.
+    "types": ["node"],
+
+    "strict": true,
+
+    // Stricter than `tsconfig.scripts.json`, and it can afford to be: no other
+    // project compiles `e2e/**`, so there is no "green in one project, red in
+    // the other" hazard to match an option set against (the constraint that
+    // pinned `tsconfig.scripts.json` to apps/console's set). Measured cost of
+    // the four flags on first run: exactly one error, and a real one —
+    //   e2e/live/master-detail.spec.ts(2,36): error TS6133: 'addLineItem' is declared but its value is never read.
+    // a helper import left behind when that spec stopped using it. Nothing else
+    // catches that: the root lint task's `no-unused-vars` did not report it when
+    // objectui#4456 first linted this directory.
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // Playwright transpiles each spec on its own with no cross-file type
+    // information, so a construct `isolatedModules` rejects breaks at RUNTIME
+    // here rather than being caught. Costs nothing today; it states a constraint
+    // the loader genuinely imposes.
+    "isolatedModules": true,
+
+    // No `allowJs`, unlike `tsconfig.scripts.json`: nothing under `e2e/` imports
+    // a `.js`/`.mjs` module and nothing carries a `@ts-expect-error`, so it would
+    // buy nothing while walking into the TS2578 interaction documented in
+    // `apps/console/tsconfig.node.json` (objectui#3513).
+    "allowJs": false,
+
+    // Legal only because this project is standalone — TS6310 forbids `noEmit` on
+    // a project that is `composite` or referenced by another. Standalone is also
+    // what keeps stray `.js`/`.d.ts` from landing next to the specs, where
+    // `playwright.config.ts`'s `testDir: './e2e'` would pick them up as tests.
+    "noEmit": true
+  },
+
+  // The whole directory, by glob. Not a file list: a list is a thing to forget,
+  // and the point of objectui#4471 is that a NEW spec under `e2e/` must not be
+  // able to land outside every program again.
+  // `scripts/__tests__/e2e-type-check.test.ts` pins that this glob really does
+  // reach every `.ts` file on disk under `e2e/`.
+  "include": ["e2e/**/*.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -61,7 +61,7 @@
       "cache": false
     },
     "type-check": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "//#type-check:e2e"],
       "outputs": [],
       "cache": true,
       "inputs": [
@@ -71,6 +71,10 @@
         "$TURBO_ROOT$/tsconfig.json",
         "$TURBO_ROOT$/tsconfig.base.json"
       ]
+    },
+    "//#type-check:e2e": {
+      "outputs": [],
+      "cache": false
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
Closes #4471

## The gap

`e2e/` is not a workspace package, so `turbo run type-check` — which is driven by package.json `scripts` — structurally cannot reach it. And no tsconfig in the repo included it either:

| config | include |
| --- | --- |
| `tsconfig.json` | `packages`, `examples`, `apps` |
| `tsconfig.scripts.json` | `scripts/**/*.ts` |
| `tsconfig.vitest-setup.json` | the root `vitest.setup*` files |

Playwright **transpiles** specs rather than type-checking them, so the 30 `.ts` files under `e2e/` — including `e2e/live/global-setup.ts`, which runs before every live-suite run — had been read by no `tsc` invocation, ever. That is #3494's shape one directory over, and for a test directory it is the expensive half: a spec the compiler never reads can call a method that does not exist and still print green, because the call sits in a branch the run does not take.

## The wiring — the #3494 remedy shape, with #4456's delivery

Mirrors `tsconfig.scripts.json` for the project, and `//#lint:root` (PR #4470) for how it reaches CI:

- new root `tsconfig.e2e.json`, `include: ["e2e/**/*.ts"]` — a **glob, not a file list**, so a new spec cannot land outside every program again;
- root script `type-check:e2e` → `tsc -p tsconfig.e2e.json`, so the gate is runnable locally rather than CI-only;
- turbo root task `//#type-check:e2e`, and `type-check` now `dependsOn` it — so plain `pnpm type-check`, and therefore ci.yml's existing `Run type-check` step, covers `e2e/` with **no new workflow entry**. Verified in the real task graph:

```
$ turbo run type-check --dry=json
root task present: true
{"taskId":"//#type-check:e2e","command":"tsc -p tsconfig.e2e.json","cache":{"local":false,"remote":false,...}}
sample pkg deps: ["//#type-check:e2e","@object-ui/auth#build", ...]
```

### `cache: false`, decided by the partition rule rather than by taste

`scripts/__tests__/turbo-task-guard-coverage.test.ts` states the rule: a task turbo **caches** has a verdict that can be replayed, so it owes a `turbo-{task}-inputs.test.ts` deriving its out-of-package reads; a task turbo never caches owes nothing. This one sits on the uncached side for two reasons:

- **Structural.** That guard derives the required file NAME from the task name, and for a `//#`-prefixed task the result is not a legal path — as its own failure message shows when the flag is flipped: *"There is no scripts/\_\_tests\_\_/turbo-//#type-check:e2e-inputs.test.ts deriving what `//#type-check:e2e` reads."* A cacheable root task cannot be expressed in this family at all.
- **Substantive.** A tsc program's real read set is its **import closure** (`@playwright/test`'s declarations, `@types/node`), while the four derived guards deliberately narrow to config root files — sound for a composite package project, which must list its own files, and unsound here. A cached verdict over a set nobody derives is #3514 with a type gate attached.

Measured cost of not caching it: **2.3s** (three consecutive cold runs: 2.29 / 2.41 / 2.37).

`lib: ES2022` is likewise measured, not tidy — exactly the caveat #4471 recorded before dispatch. Under the root tsconfig's ES2020 lib:

```
e2e/live/global-setup.ts(28,7): error TS2554: Expected 0-1 arguments, but got 2.
```

`ErrorOptions` does not exist before ES2022, and PR #4470 added `new Error(msg, { cause: e })` there for `preserve-caught-error`. Same for `DOM` (3 errors without it: `document` twice, `HTMLElement` once) and `types: ["node"]` (26 errors without it, all TS2591, across 12 files). All three are pinned **behaviourally** — the pin test compiles probe sources with the project's real options rather than asserting the strings in `lib`, because a right-looking `lib` paired with a wrong `target` passes a spelling check and reintroduces the defect.

## Red-first — the first `tsc` ever run over these 30 files

```
$ tsc -p tsconfig.e2e.json
e2e/live/master-detail.spec.ts(45,71): error TS2339: Property 'request' does not exist on type 'Request'.
```

Adding the four strictness flags this project can afford (no other program compiles `e2e/**`, so there is no shared-file option-set hazard to match) surfaced a second:

```
e2e/live/master-detail.spec.ts(2,36): error TS6133: 'addLineItem' is declared but its value is never read.
```

Two errors, both in one file. Thirty specs is a small yield — but the yield is not the point, and the one real error is worth the whole change.

### One of them is a real test defect, and it is NOT repaired here

The TS2339 is not a typing nit. The predicate read:

```ts
page.waitForRequest((r) => r.url().includes('/api/v1/batch') && r.request?.().method?.() !== 'GET', ...)
```

`Request` has no `request` member — that is `Response.request()`. Because the whole chain is optional, the conjunct evaluated to `undefined !== 'GET'`: **always true**. The non-GET filter has never been in effect for a single run, and Playwright would never have told anyone.

It is **deleted, not repaired**. Removing a provably-always-true conjunct cannot change what the wait resolves on; restoring the author's intent as `r.method() !== 'GET'` **would**, and validating that needs the live stack (backend :3000 + console :5180), which this change cannot exercise. The deletion carries an in-file comment recording both the defect and why the intent was not restored. Nothing this test asserts depends on it either way — the `batches` array does its own `r.method() === 'POST'` filtering, and the wait's result is discarded via `.catch(() => null)`; it only races the click.

The TS6133 is mechanical: a helper import left behind when that spec stopped using it. Nothing else catches that — the root lint task's `no-unused-vars` did not report it when #4456 first linted this directory.

## The pin

`scripts/__tests__/e2e-type-check.test.ts`, in the #3494 family style, asserting **behaviour** rather than spelling: the config parses with zero diagnostics; it is a checking project and stays standalone; its option set accepts `{ cause }`, DOM globals and `node:` builtins (compiled probes); it resolves every `.ts` on disk under `e2e/` with named spot-checks per directory shape; its program imports no workspace package, so the root task genuinely needs no `^build`; and the turbo wiring holds, `cache: false` included.

`turbo-task-guard-coverage.test.ts`'s partition docblock gains the `//#type-check:e2e` row and its reasoning, the way #4470 did for `//#lint:root` — that comment-table staying current is part of the guard family's contract.

**Reverse verification**, direction predicted before running:

| perturbation | predicted | observed |
| --- | --- | --- |
| `cache: true` on the root task | red in **two** files | red: 3 assertions across `turbo-task-guard-coverage.test.ts` (guard missing, no `$TURBO_DEFAULT$`) and `e2e-type-check.test.ts` |
| drop `//#type-check:e2e` from `type-check.dependsOn` | red, naming the edge | red: *"expected [ '^build' ] to include '//#type-check:e2e'"* |
| `lib: ES2020` | red on `global-setup.ts` | red: `TS2554: Expected 0-1 arguments, but got 2` |
| restore the dead conjunct | red on `master-detail.spec.ts` | that IS the red-first output above |

## Verification

| command | result |
| --- | --- |
| `pnpm type-check:e2e` | exit 0 |
| `turbo run type-check --concurrency=2` (repo-wide) | **79/79 successful**, 3m56s; `//:type-check:e2e` executed (`cache bypass, force executing`) |
| `pnpm type-check:scripts` (compiles the new pin test) | exit 0 |
| `vitest run --project unit scripts/` | **40 files, 914 tests passed** |
| `node scripts/check-type-check-coverage.mjs` | exit 0 — 43/45 via `type-check`, 1 via own build, 1 not compiled |
| `pnpm lint:root` | exit 0 — 0 errors (22 pre-existing warnings) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — *"No source of a released package changed in this range, so no changeset is owed."* |
| `node scripts/check-control-bytes.mjs` | exit 0 — 4166 files scanned |

## Scope

Root `tsconfig.e2e.json` (new), root `package.json` / `turbo.json` wiring, one `e2e/` spec, `scripts/__tests__/` pin plus the partition docblock. Nothing under `packages/` or `apps/`; no workflow file needed changing.

Filed out of scope: **#4477** — the four root `playwright*.config.ts` files are in no tsc program either. They sit beside `tsconfig.e2e.json` rather than under `e2e/`, and compile clean against this exact option set today (exit 0), so it is a dormant gap rather than a live defect. `tsconfig.e2e.json` records the exclusion in its header so the next reader is not misled into thinking e2e is fully covered.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_