### PR TITLE
fix(app-shell): invitation links resolve through the console mount helper instead of rebuilding BASE_URL (#4472)

### DIFF
--- a/.changeset/invitation-link-console-mount-4472.md
+++ b/.changeset/invitation-link-console-mount-4472.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The copied invitation link is one the recipient can actually open — both copy sites resolve through the console mount instead of rebuilding it from `BASE_URL`
+
+Copying a link from the workspace **Invitations** tab produced `http://localhost:8080./accept-invitation/<id>` — unusable twice over. Both copy sites (the Invitations tab's per-row copy button and the invite dialog's freshly-created "Accept link" field) carried their own `buildAcceptUrl`, glueing `${window.location.origin}` to `import.meta.env.BASE_URL`. In the portable build the console ships (`base: './'`) `BASE_URL` is the literal `'.'`, so that concatenation put a dot straight after the authority — a trailing-dot host. Removing the dot by hand did not help either: the resulting `/accept-invitation/<id>` skips the deployment mount, and a console served under `/_console/` answers that path with `{"error":"Not found"}`. An invited user had no working way in.
+
+Both local copies are deleted. The two sites now call `resolveConsoleUrl`, the mount-aware helper `WorkspaceSwitcher` and `OrganizationsPage` already use for full-page navigations — it resolves against the `<base href>` the server injects, which is exactly the trailing-dot failure `resolveHomeUrl`'s header documents as retired. One resolver, one answer: no URL assembly survives in either file, and the invite dialog resolves once so its displayed field and its clipboard cannot drift apart.

--- a/packages/app-shell/src/console/organizations/__tests__/acceptInvitationLink.mount.test.tsx
+++ b/packages/app-shell/src/console/organizations/__tests__/acceptInvitationLink.mount.test.tsx
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The copied invitation link must be one the recipient can actually open
+ * (objectui#4472).
+ *
+ * Both copy sites — the Invitations tab's per-row "Copy invitation link" and
+ * the invite dialog's freshly-created "Accept link" — used to rebuild the URL
+ * locally from `${window.location.origin}${import.meta.env.BASE_URL}`. In the
+ * portable build the console ships with (`base: './'`, see
+ * `apps/console/vite.config.ts`) `BASE_URL` is `'.'`, so that form produced
+ *
+ *     http://localhost:8080./accept-invitation/<id>
+ *
+ * — a trailing-dot host — and, once the dot was removed by hand, still missed
+ * the deployment mount: the console is served under `/_console/` (the server
+ * injects `<base href="/_console/">`), and `GET /accept-invitation/<id>`
+ * answers `{"error":"Not found"}`.
+ *
+ * These cases pin the two properties a recipient depends on, at both copy
+ * sites and in both deployment shapes (`/_console/` mount and root mount):
+ * no trailing-dot host, and the console mount is present.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+}));
+
+const listInvitations = vi.fn();
+const cancelInvitation = vi.fn();
+const inviteMember = vi.fn();
+const describeDelegableScope = vi.fn();
+// Only `useAuth` is faked — the role vocabulary stays REAL (same convention as
+// the sibling InviteMemberDialog specs).
+vi.mock('@object-ui/auth', async (importActual) => ({
+  ...(await importActual<typeof import('@object-ui/auth')>()),
+  useAuth: () => ({
+    listInvitations,
+    cancelInvitation,
+    inviteMember,
+    describeDelegableScope,
+    activeMember: { role: 'owner' },
+  }),
+}));
+
+// InvitationsPage reads the org from the router outlet; the org identity is
+// irrelevant here, only the invitation id reaches the URL.
+vi.mock('../manage/orgContext', () => ({
+  useOrgContext: () => ({ org: { id: 'org-42', name: 'Acme', slug: 'acme' } }),
+}));
+
+// Passthrough primitives — these cases assert a string, not the design system.
+vi.mock('@object-ui/components', () => ({
+  Avatar: (p: any) => <div {...p} />,
+  AvatarFallback: (p: any) => <div {...p} />,
+  Badge: (p: any) => <span {...p} />,
+  Button: ({ children, ...rest }: any) => <button {...rest}>{children}</button>,
+  Separator: () => <hr />,
+  AlertDialog: ({ open, children }: any) => (open ? <div>{children}</div> : null),
+  AlertDialogAction: (p: any) => <button {...p} />,
+  AlertDialogCancel: (p: any) => <button {...p} />,
+  AlertDialogContent: (p: any) => <div {...p} />,
+  AlertDialogDescription: (p: any) => <p {...p} />,
+  AlertDialogFooter: (p: any) => <div {...p} />,
+  AlertDialogHeader: (p: any) => <div {...p} />,
+  AlertDialogTitle: (p: any) => <h2 {...p} />,
+  Dialog: ({ open, children }: any) => (open ? <div>{children}</div> : null),
+  DialogContent: (p: any) => <div {...p} />,
+  DialogDescription: (p: any) => <p {...p} />,
+  DialogFooter: (p: any) => <div {...p} />,
+  DialogHeader: (p: any) => <div {...p} />,
+  DialogTitle: (p: any) => <h2 {...p} />,
+  Input: (p: any) => <input {...p} />,
+  Label: (p: any) => <label {...p} />,
+  Select: ({ value, onValueChange, children }: any) => (
+    <select data-testid="select" value={value} onChange={(e) => onValueChange(e.target.value)}>
+      <option value="" />
+      {children}
+    </select>
+  ),
+  SelectContent: (p: any) => <>{p.children}</>,
+  SelectItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+  SelectTrigger: (p: any) => <>{p.children}</>,
+  SelectValue: () => null,
+}));
+vi.mock('lucide-react', () => ({
+  Loader2: () => <span />,
+  Copy: () => <span />,
+  Check: () => <span />,
+  X: () => <span />,
+  Mail: () => <span />,
+}));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { InvitationsPage } from '../manage/InvitationsPage';
+import { InviteMemberDialog } from '../manage/InviteMemberDialog';
+
+const INVITATION_ID = 'bgn1XAfRuCQUS1l9NBqOMGgJDUYm5l56';
+const ORIGIN = 'http://localhost:8080';
+
+function setBaseHref(href: string | null): void {
+  document.head.querySelectorAll('base').forEach((el) => el.remove());
+  if (href != null) {
+    const base = document.createElement('base');
+    base.setAttribute('href', href);
+    document.head.appendChild(base);
+  }
+}
+
+let writeText: ReturnType<typeof vi.fn>;
+
+/**
+ * The whole answer, not a prefix: one resolver, one URL. Asserting the full
+ * string also catches a doubled mount segment, and the two explicit guards
+ * below name the defects this pins so a failure reads as the bug report did.
+ */
+function expectOpenableAcceptUrl(url: string, expected: string): void {
+  // Defect 1 — the portable-build trailing-dot host: `${origin}` + `'.'`
+  // glued a dot onto the authority (`localhost:8080.`).
+  expect(url).not.toMatch(/:\d+\./);
+  expect(new URL(url).hostname.endsWith('.')).toBe(false);
+  // Defect 2 — the missing console mount (this is the half that goes red on a
+  // reintroduced local builder; see the BASE_URL note in beforeEach).
+  expect(url).toBe(expected);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The portable build the console actually ships (`base: './'`), under which
+  // the retired local builder produced the trailing-dot host.
+  //
+  // Caveat, measured: this stub reaches only the EXACT `import.meta.env.BASE_URL`
+  // spelling. The retired builder read `(import.meta as any).env?.BASE_URL`, and
+  // Vite inlines a bare `import.meta.env` as an object literal at transform
+  // time, so that read always saw `'/'` here and no stub could move it. The
+  // trailing-dot half of this pin therefore cannot go red on its own in vitest;
+  // the mount assertion is what fails when a local builder comes back (verified
+  // red-first — it reported `/accept-invitation/…` against `/_console/…`).
+  vi.stubEnv('BASE_URL', '.');
+  // The issue's repro ran against a dev server on :8080; happy-dom defaults to
+  // :3000. Pinning it keeps the asserted URL the one in the bug report.
+  (
+    window as unknown as { happyDOM?: { setURL?: (url: string) => void } }
+  ).happyDOM?.setURL?.('http://localhost:8080/_console/organizations/org-42/invitations');
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+  listInvitations.mockResolvedValue([
+    {
+      id: INVITATION_ID,
+      email: 'lisi@acme-test.com',
+      role: 'member',
+      status: 'pending',
+      expiresAt: null,
+    },
+  ]);
+  inviteMember.mockResolvedValue({
+    id: INVITATION_ID,
+    email: 'lisi@acme-test.com',
+    role: 'member',
+  });
+  describeDelegableScope.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  setBaseHref(null);
+});
+
+async function copyFromInvitationsTab(): Promise<string> {
+  render(<InvitationsPage />);
+  fireEvent.click(await screen.findByLabelText('Copy invitation link'));
+  await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+  return writeText.mock.calls[0][0] as string;
+}
+
+async function shareLinkFromInviteDialog(): Promise<{ shown: string; copied: string }> {
+  const { container } = render(
+    <InviteMemberDialog organizationId="org-42" open onOpenChange={() => {}} />,
+  );
+  fireEvent.change(screen.getByTestId('invite-email-input'), {
+    target: { value: 'lisi@acme-test.com' },
+  });
+  fireEvent.submit(container.querySelector('form')!);
+  await waitFor(() => expect(inviteMember).toHaveBeenCalledTimes(1));
+
+  // The "share link" view: a read-only field holding the accept URL, plus a
+  // copy button. Both must carry the same openable URL.
+  const field = await screen.findByRole('textbox');
+  fireEvent.click(screen.getByLabelText('Copy'));
+  await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+  return { shown: (field as HTMLInputElement).value, copied: writeText.mock.calls[0][0] as string };
+}
+
+describe('copied invitation link — console mount (objectui#4472)', () => {
+  describe('served under the /_console/ mount', () => {
+    beforeEach(() => setBaseHref('/_console/'));
+
+    it('Invitations tab: the copied link keeps the mount and has no trailing-dot host', async () => {
+      expectOpenableAcceptUrl(
+        await copyFromInvitationsTab(),
+        `${ORIGIN}/_console/accept-invitation/${INVITATION_ID}`,
+      );
+    });
+
+    it('invite dialog: the shared link keeps the mount and has no trailing-dot host', async () => {
+      const { shown, copied } = await shareLinkFromInviteDialog();
+      expectOpenableAcceptUrl(shown, `${ORIGIN}/_console/accept-invitation/${INVITATION_ID}`);
+      // The displayed field and the clipboard must not drift apart.
+      expect(copied).toBe(shown);
+    });
+  });
+
+  describe('served at the document root', () => {
+    beforeEach(() => setBaseHref('/'));
+
+    it('Invitations tab: the copied link is the plain root accept route', async () => {
+      expectOpenableAcceptUrl(
+        await copyFromInvitationsTab(),
+        `${ORIGIN}/accept-invitation/${INVITATION_ID}`,
+      );
+    });
+
+    it('invite dialog: the shared link is the plain root accept route', async () => {
+      const { shown } = await shareLinkFromInviteDialog();
+      expectOpenableAcceptUrl(shown, `${ORIGIN}/accept-invitation/${INVITATION_ID}`);
+    });
+  });
+});

--- a/packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx
+++ b/packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx
@@ -26,14 +26,9 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import { Loader2, Copy, Check, X, Mail } from 'lucide-react';
 import { toast } from 'sonner';
 import { useOrgContext } from './orgContext';
+import { resolveConsoleUrl } from '../resolveHomeUrl';
 
 type StatusFilter = 'all' | 'pending' | 'accepted' | 'rejected' | 'canceled';
-
-function buildAcceptUrl(invitationId: string): string {
-  const base = (import.meta as any).env?.BASE_URL ?? '/';
-  const normalized = base.endsWith('/') ? base : `${base}/`;
-  return `${window.location.origin}${normalized}accept-invitation/${invitationId}`;
-}
 
 function statusBadgeVariant(status: string): 'outline' | 'default' | 'destructive' | 'secondary' {
   switch (status) {
@@ -79,7 +74,11 @@ export function InvitationsPage() {
   }, [fetchInvitations]);
 
   const handleCopyLink = async (inv: AuthInvitation) => {
-    const url = buildAcceptUrl(inv.id);
+    // The recipient opens this link outside React Router, so it must carry the
+    // deployment mount (`/_console/`). Rebuilding it from `BASE_URL` produced a
+    // trailing-dot host in the portable build and dropped the mount — see
+    // resolveHomeUrl's header for that history (objectui#4472).
+    const url = resolveConsoleUrl(`accept-invitation/${inv.id}`);
     try {
       await navigator.clipboard.writeText(url);
       setCopiedId(inv.id);

--- a/packages/app-shell/src/console/organizations/manage/InviteMemberDialog.tsx
+++ b/packages/app-shell/src/console/organizations/manage/InviteMemberDialog.tsx
@@ -28,18 +28,13 @@ import type { AuthInvitation, DelegableScope, OrgRole } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Loader2, Copy, Check } from 'lucide-react';
 import { toast } from 'sonner';
+import { resolveConsoleUrl } from '../resolveHomeUrl';
 
 interface InviteMemberDialogProps {
   organizationId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onInvited?: (invitation: AuthInvitation) => void;
-}
-
-function buildAcceptUrl(invitationId: string): string {
-  const base = (import.meta as any).env?.BASE_URL ?? '/';
-  const normalized = base.endsWith('/') ? base : `${base}/`;
-  return `${window.location.origin}${normalized}accept-invitation/${invitationId}`;
 }
 
 export function InviteMemberDialog({
@@ -138,18 +133,26 @@ export function InviteMemberDialog({
     [email, role, organizationId, inviteMember, onInvited, canPlace, businessUnitId, positions],
   );
 
+  // The invitee opens this link outside React Router, so it must carry the
+  // deployment mount (`/_console/`). Rebuilding it from `BASE_URL` produced a
+  // trailing-dot host in the portable build and dropped the mount — see
+  // resolveHomeUrl's header for that history (objectui#4472). Resolved once so
+  // the displayed field and the clipboard cannot drift apart.
+  const acceptUrl = createdInvitation
+    ? resolveConsoleUrl(`accept-invitation/${createdInvitation.id}`)
+    : null;
+
   const handleCopy = useCallback(async () => {
-    if (!createdInvitation) return;
-    const url = buildAcceptUrl(createdInvitation.id);
+    if (!acceptUrl) return;
     try {
-      await navigator.clipboard.writeText(url);
+      await navigator.clipboard.writeText(acceptUrl);
       setCopied(true);
       toast.success(t('organization.invitations.linkCopied', { defaultValue: 'Invitation link copied' }));
       setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error(t('organization.invitations.copyFailed', { defaultValue: 'Failed to copy link' }));
     }
-  }, [createdInvitation, t]);
+  }, [acceptUrl, t]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -171,7 +174,7 @@ export function InviteMemberDialog({
               <div className="flex items-center gap-2">
                 <Input
                   readOnly
-                  value={buildAcceptUrl(createdInvitation.id)}
+                  value={acceptUrl ?? ''}
                   className="font-mono text-xs"
                   onFocus={(e) => e.currentTarget.select()}
                 />


### PR DESCRIPTION
Closes #4472

## The defect

Copying an invitation link from the workspace **Invitations** tab produced a URL the recipient cannot open:

```
http://localhost:8080./accept-invitation/bgn1XAfRuCQUS1l9NBqOMGgJDUYm5l56
```

Both copy sites carried their own `buildAcceptUrl`, glueing `${window.location.origin}` onto `import.meta.env.BASE_URL`:

- `packages/app-shell/src/console/organizations/manage/InvitationsPage.tsx:32` — the Invitations tab's per-row copy button;
- `packages/app-shell/src/console/organizations/manage/InviteMemberDialog.tsx:39` — the freshly-created invitation's "Accept link" field (and its copy button).

In the portable build the console ships (`base: './'`, `apps/console/vite.config.ts`) `BASE_URL` is the literal `'.'`, so the concatenation put a dot straight after the authority — a trailing-dot host. Removing the dot by hand did not rescue the link either: the resulting `/accept-invitation/:id` skips the deployment mount, and a console served under `/_console/` answers that path with `{"error":"Not found"}`. This is precisely the failure `resolveHomeUrl.ts`'s own header records as retired.

## The fix

Both local copies are deleted. The two sites call `resolveConsoleUrl` from `packages/app-shell/src/console/organizations/resolveHomeUrl.ts` — the mount-aware helper `WorkspaceSwitcher` and `OrganizationsPage` already use for full-page navigations. It resolves against the base-href tag (`base href="/_console/"`) the server injects when it serves the console (`objectstack packages/cli/src/utils/console.ts`), so the copied link carries the mount in every deployment shape. One resolver, one answer: no URL assembly survives in either file. The invite dialog resolves **once** into a single `acceptUrl`, so its displayed field and its clipboard cannot drift apart.

No public surface moved: the emitted `.d.ts` for both modules is byte-identical to the `origin/main` build (measured, two builds diffed) — hence `patch`.

## Red-first

`packages/app-shell/src/console/organizations/__tests__/acceptInvitationLink.mount.test.tsx` drives both copy sites through the real components and asserts the produced URL whole, in both deployment shapes (`/_console/` mount and root mount).

Against the **current** builder the mount half failed exactly as reported:

```
AssertionError: expected '/accept-invitation/bgn1XAfRuCQUS1l9NB…' to be '/_console/accept-invitation/bgn1XAfRu…'
Expected: "/_console/accept-invitation/bgn1XAfRuCQUS1l9NBqOMGgJDUYm5l56"
Received: "/accept-invitation/bgn1XAfRuCQUS1l9NBqOMGgJDUYm5l56"
```

The **trailing-dot** half needed one measurement before it could be trusted, and the finding is worth recording: `vi.stubEnv('BASE_URL', '.')` reaches only the exact `import.meta.env.BASE_URL` spelling. The retired builders read `(import.meta as any).env?.BASE_URL`, and Vite inlines a bare `import.meta.env` as an object literal at transform time — so that read saw `'/'` in vitest no matter what was stubbed, and the portable-build condition could not be reproduced through it. Switching only the spelling in the two retired builders (temporarily, then reverted with `git checkout`) made the pin produce the bug report's string verbatim:

```
AssertionError: expected 'http://localhost:8080./accept-invitat…' not to match /:\d+\./
Received: "http://localhost:8080./accept-invitation/bgn1XAfRuCQUS1l9NBqOMGgJDUYm5l56"
```

So the shipped pin goes red on a reintroduced local builder via the **mount** assertion; the trailing-dot assertion is carried alongside it and documented in the test as unable to fail on its own in vitest, rather than left to read as coverage it does not have.

After the fix, all 4 cases green.

## Verification

- `pnpm exec vitest run packages/app-shell/` — **357 files, 3420 passed**, 1 skipped
- `pnpm --filter @object-ui/app-shell type-check` (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`) — exit 0
- `pnpm exec eslint` on the three changed files — 0 errors (26 pre-existing `set-state-in-effect` warnings in untouched code)
- `node scripts/check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-control-bytes.mjs` — all green

## Copy census

Swept for other `accept-invitation/` assembly and `BASE_URL`-based origin concatenation in console code. No further in-family defects; two sites listed for the record, neither touched here:

- `packages/app-shell/src/console/ai/AiChatPage.tsx:986` (`publicShareBase`) — a third hand-rolled mount resolution, but a **correct** one: it reads the document's base-href tag and yields `${origin}/_console/s`. Duplicated mechanism, no user-visible defect; a candidate to fold into `resolveConsoleUrl` separately.
- `apps/console/src/utils/consoleBase.ts:42` — reads `import.meta.env.BASE_URL` deliberately and never concatenates an origin; documented for all three mount shapes and covered by its own tests. Not in family.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_