### PR TITLE
fix(app-shell): call saved-view adapter methods bound — Set as Default and reorder work again (#4463)

### DIFF
--- a/.changeset/saved-view-set-default-unbound-4463.md
+++ b/.changeset/saved-view-set-default-unbound-4463.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/app-shell': patch
+---
+
+"Set as Default" and drag-reorder work again on saved views — the adapter's
+`updateView` was being called unbound (objectui#4463).
+
+`handleSetDefaultView` and `handleReorderViews` both detached the method into a
+local before calling it (`const updateView = (dataSource as any).updateView;`
+… `updateView(objectName, target, patch)`). Detached, `this` is `undefined`
+inside the adapter, whose `updateView` opens with `await this.connect()` — so
+every write in the list rejected with `TypeError: Cannot read properties of
+undefined (reading 'connect')` **before a single request was issued**. QA
+measured zero network requests, one console error and a "Failed to set default
+view" toast; the view never gained `isDefault` and the prior default was left
+in place. Rename and pin worked from the same menu because `handlePinView`
+always called the method as a method — that is the convention this restores.
+
+Both call sites now route through one exported helper, `dispatchViewPatches`,
+which issues `dataSource.updateView(...)` as a method call. Having a single
+dispatch site means there is no local left to detach into, so the two handlers
+can no longer drift apart on this. Reorder's write set moves to a matching
+exported helper, `reorderViewPatches`, so the `sortOrder` sequence it persists
+is assertable without mounting the view.
+
+Both handlers now also require a resolved `objectName` before writing, matching
+the guard the view-override effect in the same file already used: the adapter
+keys its cache invalidation on the object name, so a write issued under
+`undefined` would have changed the server and then failed to invalidate what it
+changed.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -469,6 +469,59 @@ export function setDefaultViewPatches(
     return patches;
 }
 
+/**
+ * The `updateView` writes a drag-reorder must issue (objectui#4463) —
+ * `sortOrder` per saved view, in the new order.
+ *
+ * Metadata-only views are filtered out: they have no `sys_view` row to write,
+ * and their position is carried by the `viewOrder:<object>` localStorage key the
+ * handler writes first. `sortOrder` is the index **after** that filter, so the
+ * persisted sequence is dense over the saved views alone.
+ */
+export function reorderViewPatches(
+    savedViews: readonly any[],
+    orderedIds: readonly string[],
+): Array<{ viewId: string; patch: { sortOrder: number } }> {
+    const savedIdSet = new Set(savedViews.map((sv: any) => viewRowId(sv)));
+    return orderedIds
+        .filter(id => savedIdSet.has(id))
+        .map((id, idx) => ({ viewId: id, patch: { sortOrder: idx } }));
+}
+
+/**
+ * Issue one `updateView` per patch — **as a method call on the adapter**
+ * (objectui#4463).
+ *
+ * This exists to make one specific bug unwritable. `handleSetDefaultView` and
+ * `handleReorderViews` both used to detach the method before calling it:
+ *
+ * ```ts
+ * const updateView = (dataSource as any).updateView;   // detached
+ * …
+ * updateView(objectName, target, patch);               // `this` === undefined
+ * ```
+ *
+ * The adapter's `updateView` opens with `await this.connect()`, so every write
+ * in the list rejected with `TypeError: Cannot read properties of undefined
+ * (reading 'connect')` **before any request was issued** — the user got a toast
+ * and the server never heard about it. "Set as Default" was dead on every saved
+ * view for exactly this reason, while rename and pin worked from the same menu:
+ * `handlePinView` always called it as a method, which is the in-file convention
+ * this restores.
+ *
+ * Both call sites now route through here, so there is a single place in the file
+ * that calls `updateView` over a patch list — and it has no local to detach into.
+ */
+export function dispatchViewPatches(
+    dataSource: any,
+    objectName: string,
+    patches: ReadonlyArray<{ viewId: string; patch: Record<string, any> }>,
+): Array<Promise<unknown>> {
+    return patches.map(
+        ({ viewId, patch }) => dataSource.updateView(objectName, viewId, patch),
+    );
+}
+
 export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: any) {
     const { objectName } = useParams();
     const { t } = useObjectTranslation();
@@ -1135,7 +1188,11 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     }, [dataSource, objectName, isSavedView, t]);
 
     const handleSetDefaultView = useCallback(async (vid: string) => {
-        if (!dataSource) return;
+        // `objectName` is narrowed here for the same reason the override effect
+        // above narrows it: the adapter keys its cache invalidation on a real
+        // object name, so passing `undefined` through would write to the server
+        // and then fail to invalidate what it just changed.
+        if (!dataSource || !objectName) return;
         if (!isSavedView(vid)) {
             toast.error(t('console.objectView.cannotEditMetaView'));
             return;
@@ -1143,10 +1200,11 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         try {
             // Clear `isDefault` on all other saved views, then set this one.
             if (typeof (dataSource as any)?.updateView !== 'function') return;
-            const updateView = (dataSource as any).updateView;
             await Promise.all(
-                setDefaultViewPatches(savedViews, vid).map(
-                    ({ viewId: target, patch }) => updateView(objectName, target, patch),
+                dispatchViewPatches(
+                    dataSource,
+                    objectName,
+                    setDefaultViewPatches(savedViews, vid),
                 ),
             );
             setRefreshKey(k => k + 1);
@@ -1167,12 +1225,14 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         } catch { /* ignore */ }
         // Best-effort: also persist `sortOrder` on each saved view so other
         // sessions / users can pick up the order from the backend.
-        if (typeof (dataSource as any)?.updateView === 'function') {
-            const updateView = (dataSource as any).updateView;
-            const savedIdSet = new Set(savedViews.map((sv: any) => viewRowId(sv)));
-            const updates = orderedIds
-                .filter(id => savedIdSet.has(id))
-                .map((id, idx) => updateView(objectName, id, { sortOrder: idx }));
+        // The localStorage write above is deliberately outside this guard — the
+        // UI ordering must survive even when there is no adapter half to persist.
+        if (objectName && typeof (dataSource as any)?.updateView === 'function') {
+            const updates = dispatchViewPatches(
+                dataSource,
+                objectName,
+                reorderViewPatches(savedViews, orderedIds),
+            );
             try {
                 await Promise.all(updates);
             } catch (err) {

--- a/packages/app-shell/src/views/ObjectView.unboundAdapterCall.test.ts
+++ b/packages/app-shell/src/views/ObjectView.unboundAdapterCall.test.ts
@@ -1,0 +1,267 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4463 — "Set as Default" was dead on every saved view, and drag-reorder
+ * with it, because the adapter method was called **unbound**.
+ *
+ * Both `handleSetDefaultView` and `handleReorderViews` detached the method into a
+ * local first and then called the bare reference:
+ *
+ * ```ts
+ * const updateView = (dataSource as any).updateView;   // detached here
+ * …
+ * updateView(objectName, target, patch);               // `this` === undefined
+ * ```
+ *
+ * `ObjectStackAdapter.updateView` opens with `await this.connect()`, so every
+ * write in the list rejected with
+ * `TypeError: Cannot read properties of undefined (reading 'connect')` **before a
+ * single request went out** — QA measured zero network requests, one console
+ * error and a toast. The sibling `handlePinView` called the same method as a
+ * method and worked, which is why rename and pin passed in the same menu while
+ * set-default did not.
+ *
+ * WHY A CLASS-BASED ADAPTER IS LOAD-BEARING HERE. A plain `vi.fn()` spy has no
+ * `this` to lose, so it answers identically bound or unbound: a test built on one
+ * is green against the defect and pins nothing. The fake below therefore
+ * reproduces the one property that makes the bug observable — its `updateView`
+ * dereferences `this` on its first statement, exactly as the real adapter does.
+ * {@link describe} block "the fake reds when the method is detached" is the
+ * control that proves it: it restores the detached call shape and asserts the
+ * verbatim TypeError, so the green assertions below cannot be vacuously green.
+ *
+ * Reverse verification (direction predicted before running, and it holds):
+ * restoring `const updateView = (dataSource as any).updateView` inside
+ * {@link dispatchViewPatches} turns the set-default and reorder blocks RED with
+ * that same TypeError, while the control block stays green — it pins the failure
+ * mode itself, which this change does not move.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  dispatchViewPatches,
+  reorderViewPatches,
+  setDefaultViewPatches,
+} from './ObjectView';
+
+/** One `updateView` call as the fake recorded it. */
+interface RecordedWrite {
+  objectName: string;
+  viewName: string;
+  patch: Record<string, unknown>;
+}
+
+/**
+ * A minimal stand-in for `ObjectStackAdapter` that fails the same way the real
+ * one does when its methods are called unbound.
+ *
+ * `updateView` mirrors the real method's opening statement (`await this.connect()`)
+ * and its `this.writes` bookkeeping — both dereference `this`, so a detached call
+ * rejects instead of quietly recording a write against nothing.
+ */
+class FakeViewAdapter {
+  /** Every write the adapter actually issued, in call order. */
+  readonly writes: RecordedWrite[] = [];
+  /** How many times the connection was established — proof `this` survived. */
+  connectCount = 0;
+
+  async connect(): Promise<void> {
+    this.connectCount += 1;
+  }
+
+  async updateView(
+    objectName: string,
+    viewName: string,
+    patch: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    // The real adapter's first statement, and the one that throws when `this`
+    // is undefined (packages/data-objectstack/src/index.ts — `updateView`).
+    await this.connect();
+    this.writes.push({ objectName, viewName, patch });
+    return { name: viewName, ...patch };
+  }
+}
+
+/** Two saved views: `mine` is the current default, `board` is the target. */
+const SAVED_VIEWS = [
+  { name: 'showcase_task.mine', label: 'My Tasks', isDefault: true },
+  { name: 'showcase_task.rt5_board', label: 'Board', isDefault: false },
+];
+
+const OBJECT = 'showcase_task';
+
+describe('the fake reds when the method is detached (control)', () => {
+  it('rejects with the verbatim TypeError the QA run recorded', async () => {
+    const ds = new FakeViewAdapter();
+    // The exact shape the handlers used to have.
+    const updateView = ds.updateView;
+
+    await expect(
+      updateView(OBJECT, 'showcase_task.rt5_board', { isDefault: true }),
+    ).rejects.toThrow(
+      "Cannot read properties of undefined (reading 'connect')",
+    );
+    await expect(
+      updateView(OBJECT, 'showcase_task.rt5_board', { isDefault: true }),
+    ).rejects.toBeInstanceOf(TypeError);
+
+    // The defining symptom: the failure happens BEFORE any write is issued.
+    expect(ds.writes).toEqual([]);
+    expect(ds.connectCount).toBe(0);
+  });
+
+  it('is green when the same fake is called as a method', async () => {
+    const ds = new FakeViewAdapter();
+    await ds.updateView(OBJECT, 'showcase_task.rt5_board', { isDefault: true });
+    expect(ds.writes).toHaveLength(1);
+    expect(ds.connectCount).toBe(1);
+  });
+});
+
+describe('set as default (#4463)', () => {
+  it('issues every patch against the adapter with `this` intact', async () => {
+    const ds = new FakeViewAdapter();
+
+    await Promise.all(
+      dispatchViewPatches(
+        ds,
+        OBJECT,
+        setDefaultViewPatches(SAVED_VIEWS, 'showcase_task.rt5_board'),
+      ),
+    );
+
+    // The prior default is cleared and the target is set — the two PUTs the
+    // issue expected and measured zero of.
+    expect(ds.writes).toEqual([
+      {
+        objectName: OBJECT,
+        viewName: 'showcase_task.mine',
+        patch: { isDefault: false },
+      },
+      {
+        objectName: OBJECT,
+        viewName: 'showcase_task.rt5_board',
+        patch: { isDefault: true },
+      },
+    ]);
+    // `this` was live on every call, not just the first.
+    expect(ds.connectCount).toBe(2);
+  });
+
+  it('still writes when the target is the only saved view', async () => {
+    const ds = new FakeViewAdapter();
+    const only = [{ name: 'showcase_task.rt5_board', isDefault: false }];
+
+    await Promise.all(
+      dispatchViewPatches(
+        ds,
+        OBJECT,
+        setDefaultViewPatches(only, 'showcase_task.rt5_board'),
+      ),
+    );
+
+    expect(ds.writes).toEqual([
+      {
+        objectName: OBJECT,
+        viewName: 'showcase_task.rt5_board',
+        patch: { isDefault: true },
+      },
+    ]);
+  });
+});
+
+describe('reorder views (#4463)', () => {
+  it('issues a dense `sortOrder` per saved view with `this` intact', async () => {
+    const ds = new FakeViewAdapter();
+    const ordered = ['showcase_task.rt5_board', 'showcase_task.mine'];
+
+    await Promise.all(
+      dispatchViewPatches(ds, OBJECT, reorderViewPatches(SAVED_VIEWS, ordered)),
+    );
+
+    expect(ds.writes).toEqual([
+      {
+        objectName: OBJECT,
+        viewName: 'showcase_task.rt5_board',
+        patch: { sortOrder: 0 },
+      },
+      {
+        objectName: OBJECT,
+        viewName: 'showcase_task.mine',
+        patch: { sortOrder: 1 },
+      },
+    ]);
+    expect(ds.connectCount).toBe(2);
+  });
+
+  it('skips metadata-only views and keeps `sortOrder` dense over the rest', async () => {
+    const ds = new FakeViewAdapter();
+    // `all` and `recent` are metadata-defined — no `sys_view` row to write.
+    const ordered = [
+      'all',
+      'showcase_task.rt5_board',
+      'recent',
+      'showcase_task.mine',
+    ];
+
+    await Promise.all(
+      dispatchViewPatches(ds, OBJECT, reorderViewPatches(SAVED_VIEWS, ordered)),
+    );
+
+    expect(ds.writes.map(w => [w.viewName, w.patch])).toEqual([
+      ['showcase_task.rt5_board', { sortOrder: 0 }],
+      ['showcase_task.mine', { sortOrder: 1 }],
+    ]);
+  });
+
+  it('issues nothing when no reordered id is a saved view', async () => {
+    const ds = new FakeViewAdapter();
+
+    await Promise.all(
+      dispatchViewPatches(
+        ds,
+        OBJECT,
+        reorderViewPatches(SAVED_VIEWS, ['all', 'recent']),
+      ),
+    );
+
+    expect(ds.writes).toEqual([]);
+  });
+});
+
+describe('the detach-then-call pattern stays gone (ratchet)', () => {
+  it('ObjectView.tsx never assigns an adapter method to a local', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./ObjectView.tsx', import.meta.url)),
+      'utf8',
+    );
+
+    // Comments are stripped FIRST, and that is not a detail: the fix's own
+    // docblock quotes the broken line verbatim to explain it, so a scan over the
+    // raw file reports the documentation of the bug as the bug. (Measured — this
+    // assertion failed exactly that way before the strip was added.)
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+    // `const updateView = (dataSource as any).updateView;` and any sibling —
+    // the shape that drops `this`. Calling through the object
+    // (`(dataSource as any).updateView(…)`) does not match, because the capture
+    // requires the statement to END at the member name.
+    const detached = [
+      ...code.matchAll(
+        /const\s+\w+\s*=\s*\(\s*dataSource\s+as\s+any\s*\)[?.]*\.(\w+)\s*;/g,
+      ),
+    ].map(m => m[1]);
+
+    expect(detached).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #4463

## The defect

`handleSetDefaultView` and `handleReorderViews` in `packages/app-shell/src/views/ObjectView.tsx` both detached the adapter method into a local before calling it:

```ts
const updateView = (dataSource as any).updateView;   // detached here
…
updateView(objectName, target, patch);               // `this` === undefined
```

`ObjectStackAdapter.updateView` opens with `await this.connect()`, so every write in the list rejected with `TypeError: Cannot read properties of undefined (reading 'connect')` **before a single request was issued**. QA measured zero network requests, one console error and a "Failed to set default view" toast; the view never gained `isDefault` and the prior default was left untouched.

The sibling `handlePinView` called the same method **as a method** and worked — which is exactly why rename and pin passed in the same menu while set-default did not. That is the in-file convention this PR restores.

**Census — all detach-then-call sites in the file, complete:** exactly two, both fixed. `handleSetDefaultView` (was line 1146) and `handleReorderViews` (was line 1171). Every other adapter call in `ObjectView.tsx` — `listViews`, `updateView` in rename and pin, `deleteView` — already called through the object. A ratchet test now pins that the file has no such assignment left.

## The fix

Both call sites route through one exported helper, `dispatchViewPatches`, which issues `dataSource.updateView(...)` as a method call. One dispatch site means there is no local left to detach into, so the two handlers cannot drift apart on this again. Reorder's write set moves to a matching exported helper, `reorderViewPatches`, so the `sortOrder` sequence it persists is assertable without mounting the view — the same reason `setDefaultViewPatches` was extracted for #4211.

Both handlers now also require a resolved `objectName` before writing, matching the guard the view-override effect in the same file already used. This is not cosmetic: the typed helper signature surfaced that `objectName` is `string | undefined` from `useParams()`, and the adapter keys its cache invalidation on the object name — a write issued under `undefined` would have changed the server and then failed to invalidate what it changed. The localStorage ordering write in `handleReorderViews` stays deliberately outside that guard, so UI ordering still survives with no adapter half.

## Red-first

New file: `packages/app-shell/src/views/ObjectView.unboundAdapterCall.test.ts` (8 tests).

A plain `vi.fn()` spy has no `this` to lose, so it answers identically bound or unbound — a test built on one is green against this defect and pins nothing. The fake adapter here therefore reproduces the one property that makes the bug observable: its `updateView` dereferences `this` on its first statement (`await this.connect()`), exactly as the real adapter does. A dedicated control block asserts the fake really does red when detached, so the green assertions cannot be vacuously green.

**Against the unfixed source — 6 failed | 2 passed.** The ratchet named the defect precisely, finding both sites:

```
AssertionError: expected [ 'updateView', 'updateView' ] to deeply equal []
 Test Files  1 failed (1)
      Tests  6 failed | 2 passed (8)
```

**Reverse verification, direction predicted before running and it holds.** Reintroducing the detach inside `dispatchViewPatches` reds every block that issues a write, with the issue's verbatim symptom:

```
TypeError: Cannot read properties of undefined (reading 'connect')
TypeError: Cannot read properties of undefined (reading 'connect')
TypeError: Cannot read properties of undefined (reading 'connect')
TypeError: Cannot read properties of undefined (reading 'connect')
 Tests  4 failed | 4 passed (8)
```

4 red, not 5 — as predicted. The reorder case whose patch list is empty stays green, because a `.map` over no patches never dereferences the detached method. An empty write set cannot observe binding; that it stays green is the correct result, and it confirms the four reds are exactly the cases that issue writes.

**With the fix — 8 passed.** Coverage: set-default writes both patches (clear prior default, set target) with `connectCount === 2` proving `this` survived every call, not just the first; reorder writes a dense `sortOrder` and skips metadata-only views; plus the control and ratchet blocks.

## Secondary defect — measured, and it is NOT the mechanical mirror

The card's ruling said to fix `deleteView`'s missing draft qualifier in this PR only if it is the mechanical mirror of what `updateView` gained in #4139, and to stop and report otherwise. **It is not mechanical**, so this PR does not touch it. Filed with the full measurement as #4479.

The short version: the draft-discard primitive exists (`MetadataClient.reset(type, name, { state: 'draft' })`), but draft-first means something different for delete than for update. `persistRuntimeMetadata` stages *every* runtime edit as a draft, so published+draft pairs are routine — and on such a pair a naive draft-first delete discards only the draft, leaving the published view alive and the tab still there after reload. That would silently turn **Delete view** into **Discard draft**, which is a distinct operation that already exists as `discardRuntimeDraft` ("the published overlay is untouched"). Getting delete right on the pair needs two calls, an ordering, and a receipt shape that can express a partial outcome — decisions that belong on their own card.

`Closes #4463` is still correct: the ruling explicitly authorises splitting the secondary defect out, and it is filed and tracked rather than left half-done.

## Verification

- `pnpm exec vitest run packages/app-shell/src/views/ObjectView.unboundAdapterCall.test.ts` — 8 passed
- `pnpm exec vitest run packages/app-shell/` — **357 files, 3424 passed, 1 skipped**, exit 0
- `tsc --noEmit` and `tsc -p tsconfig.test.json` for `@object-ui/app-shell` — both exit 0 (dependency closure built first via `pnpm --filter '@object-ui/app-shell^...' build`)
- `eslint` on both changed files — 0 errors (warnings are the file's pre-existing `any` usage)
- `node scripts/check-changeset-presence.mjs` and `check-changeset-no-major.mjs` — both green
- Control-byte self-scan on all changed files — no hits

Changeset: `.changeset/saved-view-set-default-unbound-4463.md`, `@object-ui/app-shell: patch`. No `.d.ts` change is emitted for the app-shell consumer surface beyond two added exported helpers, so patch is the correct grade; never major per the version-alignment rule.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_