### PR TITLE
fix(console): an inaccessible landing app bounces to /home instead of stranding the user chrome-less (#4473)

### DIFF
--- a/.changeset/landing-app-no-strand-4473.md
+++ b/.changeset/landing-app-no-strand-4473.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+console: an inaccessible landing app bounces to `/home` instead of stranding the user on a chrome-less page
+
+Switching organization (and accepting an invitation, which switches as its last step) could land a `member` on `/apps/setup` rendering the bare "No apps configured" screen — no header, no navigation, no workspace switcher, and no way back except editing the URL by hand.
+
+`GET /meta/apps` is filtered per session server-side, so an empty list means "nothing here is yours to open", not "this workspace has no apps". When the app surface has no app to enter, it now redirects to `/home`, which renders inside the shell chrome and already carries the copy for this state. A workspace admin still gets the first-run empty state with its create-app / system-settings actions, and a user with access to the app enters it exactly as before.

--- a/apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx
+++ b/apps/console/src/__tests__/AppContent.systemHubRoutes.test.tsx
@@ -150,6 +150,12 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
   }),
 }));
 
+// A workspace admin: the zero-app branch below is measured through the "no apps
+// configured" empty state, which since objectui#4473 renders for admins only —
+// any other viewer is bounced to `/home` with the shell chrome rather than left
+// on that chrome-less screen (pinned in
+// `packages/app-shell/src/console/__tests__/AppContent.inaccessibleAppStrand.test.tsx`).
+// The legacy `/system/*` redirect targets this file measures are unchanged.
 vi.mock('@object-ui/auth', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useAuth: () => ({
@@ -157,7 +163,7 @@ vi.mock('@object-ui/auth', async (importOriginal) => ({
     getAuthConfig: async () => ({ features: {} }),
     activeOrganization: null,
   }),
-  useIsWorkspaceAdmin: () => false,
+  useIsWorkspaceAdmin: () => true,
 }));
 
 const dataSourceStub = {

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -17,7 +17,7 @@ import { toast } from 'sonner';
 import { useActionRunner, useGlobalUndo, useMutationInvalidationBridge, notifyDataChanged, FilterScopeProvider } from '@object-ui/react';
 import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import type { ConnectionState } from '@object-ui/data-objectstack';
-import { useAuth } from '@object-ui/auth';
+import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useMetadata } from '../providers/MetadataProvider';
 import { useAdapter } from '../providers/AdapterProvider';
 import { usePreviewDrafts } from '../preview/PreviewModeContext';
@@ -115,6 +115,9 @@ function DraftReviewNavigator({ appName }: { appName: string | undefined }) {
 export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = {}) {
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
   const { user, getAuthConfig, activeOrganization } = useAuth();
+  // objectui#4473 — read at the top (hooks are unconditional); consumed by the
+  // no-app guard far below, where the comment explains what it decides.
+  const isWorkspaceAdmin = useIsWorkspaceAdmin();
   const dataSource = useAdapter();
 
   // Deployment-level feature flags from `/api/v1/auth/config`. Used by
@@ -580,6 +583,45 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
         </Empty>
       </div>
     );
+  }
+
+  // objectui#4473 — a viewer with NO app to enter here must not be left on a
+  // chrome-less screen. `GET /meta/apps` is filtered PER SESSION server-side
+  // (`filterAppForUser`), so an empty list on a `member` means "nothing here is
+  // yours to open", not "this workspace has no apps" — and switching
+  // organization lands exactly there: `WorkspaceSwitcher` reloads onto the
+  // console root, `RootLandingRedirect` resolves the landing from the app
+  // metadata `MetadataProvider` seeded out of sessionStorage (the PREVIOUS
+  // org's, keyed by type only), and the resulting `/apps/setup` settles with an
+  // empty list. Every no-app surface in this file returns ABOVE the single
+  // `ConsoleLayout` mount, so what renders has no header, no navigation and no
+  // workspace switcher: no way back except editing the URL by hand.
+  //
+  // The bounce is role-aware because that is what the empty state below already
+  // presupposes, not as a stand-in for per-app access: its copy asserts a
+  // WORKSPACE-level fact ("no apps are registered") that a per-user-filtered
+  // list cannot establish, and offers two actions — create an app, open system
+  // settings — that a non-admin cannot perform. For a workspace admin it stays
+  // the deliberate first-run surface (#3573 / #3590). For everyone else `/home`
+  // is the honest destination: it renders inside the shell (top bar + workspace
+  // switcher) and already carries the role-aware copy for this state ("No
+  // applications yet — your workspace is being set up…", `home/HomePage.tsx`).
+  // `replace`, so the strand is not left in history behind them.
+  //
+  // Router-relative on purpose: `<Navigate>` resolves through the host's
+  // `basename`, so the console's `/_console` mount is preserved without
+  // building a URL by hand (`resolveConsoleUrl` is for full-page navigations
+  // that leave the router — see `organizations/resolveHomeUrl.ts`). `/home` is
+  // part of the outer skeleton every host that mounts this component provides
+  // (see this file's header), and `RequireAiSurface` in `ConsoleShell.tsx`
+  // already bounces the same way for a surface this runtime cannot serve.
+  //
+  // Telling "you may not enter THIS app" apart from "this app is not published"
+  // is the other half of #4473 and stays gated on the backend permission-denied
+  // envelope (objectstack#8013 → objectui#4252). Nothing here waits on it: the
+  // guard reads only the per-user-filtered list that ships today.
+  if (!activeApp && !isCreateAppRoute && !isSystemRoute && !isMetadataRoute && !isWorkspaceAdmin) {
+    return <Navigate to="/home" replace />;
   }
 
   if (!activeApp && !isCreateAppRoute && !isSystemRoute && !isMetadataRoute) return (

--- a/packages/app-shell/src/console/__tests__/AppContent.inaccessibleAppStrand.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.inaccessibleAppStrand.test.tsx
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Switching organization must never strand a member on a chrome-less page
+ * (objectui#4473).
+ *
+ * ## The measured strand
+ *
+ * `WorkspaceSwitcher.handleSwitch` full-page-navigates to the console root
+ * (`window.location.href = resolveRootUrl()`), so `RootLandingRedirect` re-runs
+ * and resolves the landing from app METADATA — and `MetadataProvider` seeds the
+ * app list from `sessionStorage` (`objectui:metadata:app`, keyed by TYPE only,
+ * not by org) before the org-scoped fetch lands, which is how the PREVIOUS
+ * workspace's single visible app (`setup`) still decides the landing after the
+ * switch. The user therefore arrives at `/apps/setup`.
+ *
+ * `GET /api/v1/meta/apps` is already filtered PER SESSION server-side
+ * (`filterAppForUser`, `packages/rest/src/rest-server.ts` — see
+ * objectstack#8013), so for a `member` with no app access the settled list is
+ * EMPTY. In `AppContent` that means: `isSetupRoute` ⇒ `requestedAppMissing` is
+ * false ⇒ the pseudo-route fallback finds no `launcherApps[0]` ⇒ `activeApp` is
+ * undefined ⇒ the `!activeApp && !isCreateAppRoute && !isSystemRoute &&
+ * !isMetadataRoute` branch returns a bare `<div className="h-screen …">`
+ * **before `ConsoleLayout` is ever mounted**. That early return is WHY there is
+ * no chrome — not a route mounted outside the shell: every surface in this file
+ * that renders without an app returns above the single `ConsoleLayout` mount at
+ * the bottom of the component. Hence the issue's own diagnostic,
+ * `document.querySelectorAll('header').length === 0`: no top bar, no workspace
+ * switcher, no way back except editing the URL by hand.
+ *
+ * ## What is asserted here
+ *
+ * The invariant is "switching into an organization never strands the user", and
+ * the guard lands at the APP SURFACE, so it covers a hand-typed
+ * `/_console/apps/<name>` URL identically (second test).
+ *
+ * The bounce is role-aware, and that is not a proxy for the missing per-app
+ * access envelope — it is what the empty state's own copy presupposes. "No apps
+ * configured — create your first app, or go to system settings" states a
+ * WORKSPACE-level fact, which a per-user-filtered list cannot establish, and
+ * offers two actions a non-admin cannot perform. For a workspace admin the
+ * screen is the deliberate first-run surface (objectui#3573 / #3590) and stays;
+ * for everyone else the honest destination is `/home`, which the issue verifies
+ * renders correctly in this very state and which already carries the role-aware
+ * copy for it ("No applications yet — your workspace is being set up…",
+ * `console/home/HomePage.tsx`).
+ *
+ * Distinguishing "denied" from "not published" per app is the OTHER half of
+ * #4473 and stays gated on the backend envelope (objectstack#8013 / #4252) —
+ * nothing here depends on it: the bounce reads only the per-user-filtered list
+ * that ships today.
+ *
+ * NOTE ON SCOPE: this file measures ROUTING (which surface renders, which URL
+ * results). `ConsoleLayout` and the lazily-imported pages are stubbed — none of
+ * their internals are part of the question (same approach as
+ * `AppContent.pseudoRouteSegments.test.tsx`).
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, Navigate, useLocation, useNavigationType } from 'react-router-dom';
+
+// ---------------------------------------------------------------------------
+// Mocks — everything that takes part in the ROUTING decision (AppContent's own
+// guards, its nested <Routes>) stays real.
+// ---------------------------------------------------------------------------
+
+vi.mock('@object-ui/plugin-designer', () => ({
+  CreateAppPage: () => <div data-testid="create-app-page">create app</div>,
+  EditAppPage: () => <div data-testid="edit-app-page" />,
+  DashboardDesignPage: () => <div data-testid="dashboard-design-page" />,
+}));
+
+/** Probe for the with-access direction: reports WHICH app's shell rendered. */
+vi.mock('../../layout/ConsoleLayout', () => ({
+  ConsoleLayout: ({ activeAppName, children }: { activeAppName?: string; children?: React.ReactNode }) => (
+    <div data-testid="console-layout" data-active-app={activeAppName}>
+      <header data-testid="app-chrome">chrome</header>
+      {children}
+    </div>
+  ),
+}));
+vi.mock('../../chrome/CommandPalette', () => ({ CommandPalette: () => null }));
+vi.mock('../../chrome/KeyboardShortcutsDialog', () => ({ KeyboardShortcutsDialog: () => null }));
+vi.mock('../../chrome/OnboardingWalkthrough', () => ({ OnboardingWalkthrough: () => null }));
+vi.mock('../../views/ObjectView', () => ({
+  ObjectView: () => <div data-testid="object-view" />,
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: ({ label }: { label?: string }) => label,
+  }),
+}));
+
+/** The viewer under test: a `member` by default, an admin where stated. */
+let isWorkspaceAdmin = false;
+vi.mock('@object-ui/auth', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAuth: () => ({
+    user: { id: 'u_b', name: 'B', email: 'b@example.com', role: 'member' },
+    getAuthConfig: async () => ({ features: {} }),
+    activeOrganization: { id: 'org_jia', name: '甲' },
+  }),
+  useIsWorkspaceAdmin: () => isWorkspaceAdmin,
+}));
+
+const dataSourceStub = {
+  onConnectionStateChange: () => () => {},
+  getConnectionState: () => 'connected',
+};
+vi.mock('../../providers/AdapterProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => dataSourceStub,
+}));
+
+/**
+ * The list as the SERVER already hands it to this session. Empty is the member
+ * case from the issue (the setup app exists in the workspace; `filterAppForUser`
+ * withholds it); the with-access case below puts a real app back.
+ */
+let metadataApps: unknown[] = [];
+const refreshMetadata = vi.fn(async () => {});
+vi.mock('../../providers/MetadataProvider', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useMetadata: () => ({
+    apps: metadataApps,
+    objects: [],
+    loading: false,
+    // `undefined` — no bucket preloading to await, so the surface is settled on
+    // first render (mirrors a host that ships metadata eagerly).
+    ensureType: undefined,
+    error: null,
+    refresh: refreshMetadata,
+  }),
+}));
+
+const actionRunnerStub = { registerHandler: vi.fn(), getContext: () => ({}) };
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useActionRunner: () => ({ execute: vi.fn(), runner: actionRunnerStub }),
+  useGlobalUndo: () => {},
+  useMutationInvalidationBridge: () => {},
+}));
+
+import { AppContent } from '../AppContent';
+
+/**
+ * Reports the live URL so a bounce is visible as a URL, not just a screen, plus
+ * the transition that produced it (PUSH / REPLACE / POP).
+ */
+function LocationProbe() {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  return (
+    <>
+      <div data-testid="pathname">{location.pathname}</div>
+      <div data-testid="navigation-type">{navigationType}</div>
+    </>
+  );
+}
+
+/**
+ * The reference host's route tree, reduced to the parts that decide this
+ * question (mirrors `apps/console/src/App.tsx`). `/home` renders a `<header>`
+ * because that is precisely what the issue measured as missing on the strand
+ * and present at `/home`: the real route mounts `HomeLayout`, whose top bar
+ * carries the workspace switcher — the way back the stranded user has none of.
+ */
+const systemRoutesStub = (
+  <Route path="system" element={<div data-testid="system-hub-page">system hub</div>} />
+);
+
+function renderConsoleAt(initialUrl: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/apps/:appName/*" element={<AppContent extraRoutesNoApp={systemRoutesStub} />} />
+        <Route path="/" element={<div data-testid="root-landing">landing</div>} />
+        <Route
+          path="/home"
+          element={
+            <div data-testid="home-launcher">
+              <header data-testid="home-chrome">workspace switcher</header>
+              home
+            </div>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const pathname = () => screen.getByTestId('pathname').textContent;
+/** The issue's own diagnostic, verbatim. */
+const headerCount = () => document.querySelectorAll('header').length;
+
+describe('AppContent — an inaccessible landing app bounces to /home (objectui#4473)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isWorkspaceAdmin = false;
+    metadataApps = [];
+  });
+
+  it('bounces a member with no accessible app off /apps/setup instead of the chrome-less empty state', async () => {
+    renderConsoleAt('/apps/setup');
+
+    expect(await screen.findByTestId('home-launcher')).toBeInTheDocument();
+    expect(pathname()).toBe('/home');
+    // Pre-fix this screen rendered with ZERO headers — the strand.
+    expect(headerCount()).toBe(1);
+    expect(screen.queryByTestId('create-first-app-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('go-to-settings-btn')).not.toBeInTheDocument();
+  });
+
+  // Title spelled `/apps/:name` (router style) rather than with angle brackets:
+  // GitHub's body sanitizer strips `<` + letter as an HTML tag, so a test name
+  // quoted into a PR body or an issue comment would arrive truncated.
+  it('covers a hand-typed /apps/:name URL at any depth, not just the resolved landing', async () => {
+    renderConsoleAt('/apps/setup/sys_inbox_message');
+
+    expect(await screen.findByTestId('home-launcher')).toBeInTheDocument();
+    expect(pathname()).toBe('/home');
+    expect(headerCount()).toBe(1);
+  });
+
+  it('replaces the strand rather than pushing over it', async () => {
+    // Asserted through react-router's own navigation type, NOT `window.history`:
+    // under `MemoryRouter` the window history object is inert, so a
+    // `history.back()` here would pass whatever the bounce did — a green that
+    // measures nothing. `useNavigationType()` reports the transition that
+    // produced the current entry, so PUSH vs REPLACE is directly observable.
+    renderConsoleAt('/apps/setup');
+
+    expect(await screen.findByTestId('home-launcher')).toBeInTheDocument();
+    // A push would leave `/apps/setup` one Back away, where it bounces again —
+    // Back becomes a no-op the user cannot escape.
+    expect(screen.getByTestId('navigation-type').textContent).toBe('REPLACE');
+  });
+
+  it('MUST NOT CHANGE — a user WITH access to the app still enters it normally', async () => {
+    // The same member, in a workspace where the server DOES hand them an app.
+    metadataApps = [{ name: 'crm', label: 'CRM', navigation: [] }];
+    renderConsoleAt('/apps/crm');
+
+    const layout = await screen.findByTestId('console-layout');
+    expect(layout).toHaveAttribute('data-active-app', 'crm');
+    expect(pathname()).toBe('/apps/crm');
+    expect(screen.queryByTestId('home-launcher')).not.toBeInTheDocument();
+  });
+
+  it('MUST NOT CHANGE — a workspace admin with zero apps keeps the first-run empty state', async () => {
+    // objectui#3573 / #3590: the CTAs are live for the one viewer who can act
+    // on them, and that screen is not a strand for them.
+    isWorkspaceAdmin = true;
+    renderConsoleAt('/apps/setup');
+
+    expect(await screen.findByTestId('create-first-app-btn')).toBeInTheDocument();
+    expect(pathname()).toBe('/apps/setup');
+    expect(screen.queryByTestId('home-launcher')).not.toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.noAppComponentRoutes.test.tsx
@@ -143,6 +143,11 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
   }),
 }));
 
+// A workspace admin: since objectui#4473 the zero-app empty state this file
+// uses as its "not a component route" marker renders for admins only — every
+// other viewer is bounced to `/home` (its CTAs are admin-only actions, and the
+// screen carries no shell chrome). The component/metadata routing this file
+// measures is viewer-independent.
 vi.mock('@object-ui/auth', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useAuth: () => ({
@@ -150,7 +155,7 @@ vi.mock('@object-ui/auth', async (importOriginal) => ({
     getAuthConfig: async () => ({ features: {} }),
     activeOrganization: null,
   }),
-  useIsWorkspaceAdmin: () => false,
+  useIsWorkspaceAdmin: () => true,
 }));
 
 const dataSourceStub = {

--- a/packages/app-shell/src/console/__tests__/AppContent.noAppsCta.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.noAppsCta.test.tsx
@@ -92,6 +92,12 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
   }),
 }));
 
+// The viewer is a workspace admin because since objectui#4473 that is who this
+// empty state is FOR: its CTAs (create an app, open system settings) are
+// admin-only actions, and a viewer without them is bounced to `/home` with the
+// shell chrome instead of being stranded on this chrome-less screen (pinned in
+// `AppContent.inaccessibleAppStrand.test.tsx`). The routing question this file
+// measures — which URL each CTA resolves to — is unchanged.
 vi.mock('@object-ui/auth', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useAuth: () => ({
@@ -99,7 +105,7 @@ vi.mock('@object-ui/auth', async (importOriginal) => ({
     getAuthConfig: async () => ({ features: {} }),
     activeOrganization: null,
   }),
-  useIsWorkspaceAdmin: () => false,
+  useIsWorkspaceAdmin: () => true,
 }));
 
 const dataSourceStub = {

--- a/packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx
+++ b/packages/app-shell/src/console/__tests__/AppContent.pseudoRouteSegments.test.tsx
@@ -192,6 +192,12 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
   }),
 }));
 
+// A workspace admin: the zero-app cases below land on the "no apps configured"
+// empty state, which since objectui#4473 renders for admins only — a viewer who
+// cannot act on its CTAs is bounced to `/home` with the shell chrome instead of
+// being stranded there (`AppContent.inaccessibleAppStrand.test.tsx`). Which
+// BRANCH a segment reaches — the question this file measures — does not depend
+// on the viewer.
 vi.mock('@object-ui/auth', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useAuth: () => ({
@@ -199,7 +205,7 @@ vi.mock('@object-ui/auth', async (importOriginal) => ({
     getAuthConfig: async () => ({ features: {} }),
     activeOrganization: null,
   }),
-  useIsWorkspaceAdmin: () => false,
+  useIsWorkspaceAdmin: () => true,
 }));
 
 const dataSourceStub = {


### PR DESCRIPTION
Closes #4473

## The defect

Switching the active organization (and accepting an invitation, which switches as its last step) could land a `member` on `/apps/setup` rendering the bare "no apps configured" screen — `document.querySelectorAll('header').length === 0`: no top bar, no navigation, no workspace switcher, and no way back except editing the URL by hand.

Measured chain, end to end:

1. `WorkspaceSwitcher.handleSwitch` full-page-navigates to the console root (`window.location.href = resolveRootUrl()`) — correct, and untouched here.
2. `MetadataProvider` seeds the app list from `sessionStorage` (`objectui:metadata:app`, keyed by TYPE only, not by org) and clears `loading` before the org-scoped fetch lands, so `RootLandingRedirect` resolves the landing from the PREVIOUS workspace's list — its single visible app, `setup` — and rule 2 sends the user to `/apps/setup`.
3. `GET /api/v1/meta/apps` is already filtered PER SESSION server-side (`filterAppForUser`, `packages/rest/src/rest-server.ts` — see objectstack-ai/objectstack#8013), so for a member with no app access the settled list is **empty**.
4. In `AppContent`, `isSetupRoute` suppresses `requestedAppMissing`, the pseudo-route fallback finds no `launcherApps[0]`, and the `!activeApp` guard returns a bare `div` — **above the single `ConsoleLayout` mount**. That early return is why there is no chrome: it is not a route mounted outside the shell, it is a return that precedes the shell.

## The invariant

Switching into an organization never strands the user. The guard lands at the **app surface**, so a hand-typed `/_console/apps/:name` URL is covered identically; the resolver (`RootLandingRedirect`) stays a metadata-only product decision and is not touched.

## What changed

`packages/app-shell/src/console/AppContent.tsx` — when the surface has no app to enter and the viewer is not a workspace admin, it returns a `Navigate` element to `/home` with `replace` instead of the chrome-less empty state. Router-relative on purpose: `Navigate` resolves through the host's `basename`, so the `/_console` mount is preserved without building a URL by hand (`resolveConsoleUrl` is for full-page navigations that leave the router). `RequireAiSurface` in `ConsoleShell.tsx` already bounces the same way for a surface the runtime cannot serve.

**The role-aware condition is not a stand-in for per-app access** — it is what the empty state's own copy already presupposes. "No apps configured — create your first app, or go to system settings" asserts a WORKSPACE-level fact that a per-user-filtered list cannot establish, and offers two actions a non-admin cannot perform. For a workspace admin it stays the deliberate first-run surface (#3573 / #3590); for everyone else `/home` is the honest destination — it renders inside the shell chrome and already carries the role-aware copy for exactly this state ("No applications yet — your workspace is being set up…", `console/home/HomePage.tsx`), which the issue verified renders correctly in the same state.

## The half that stays gated (dependency)

Telling "you may not enter THIS app" apart from "this app is not published" per app needs the backend permission-denied envelope, objectstack-ai/objectstack#8013 → console half #4252. Nothing here waits on it: the bounce reads only the per-user-filtered list that ships today, so `/meta/apps` returning an app is the whole "can enter" signal it needs. When #4252 lands, the `requestedAppMissing` branch ("App not available — it may still be publishing") is where the denied-vs-unpublished distinction belongs; that branch is deliberately unchanged here.

## Red-first

New pin `packages/app-shell/src/console/__tests__/AppContent.inaccessibleAppStrand.test.tsx`. Against `origin/main`'s `AppContent.tsx` (taken out with `git checkout`, restored after):

```
 ❯ AppContent.inaccessibleAppStrand.test.tsx (5 tests | 3 failed)
   × bounces a member with no accessible app off /apps/setup instead of the chrome-less empty state
   × covers a hand-typed /apps/:name URL at any depth, not just the resolved landing
   × replaces the strand rather than pushing over it
 Tests  3 failed | 2 passed (5)
```

The failure dump is the strand itself: the `div.h-screen.flex.items-center.justify-center` wrapper carrying `empty.noAppsConfigured`, `create-first-app-btn`, `go-to-settings-btn` — and zero `header` elements. After the fix, 5 passed (5).

The two cases that pass in BOTH directions are the must-not-change ones, and that is the point:

- a user WITH access still enters the app normally (`console-layout` with `data-active-app="crm"`, URL unchanged);
- a workspace admin with zero apps still gets the first-run empty state.

The history assertion uses react-router's `useNavigationType()` rather than `window.history.back()`: under `MemoryRouter` the window history object is inert, so a `history.back()` there would have gone green whatever the bounce did.

## Knock-on to existing pins

Four suites drove the zero-app empty state with `useIsWorkspaceAdmin: () => false`; that screen now renders for admins only, so their viewer mock is flipped to `true` (with the reason recorded in each file). The subjects those files measure — CTA target resolution (#3573 / #3590), component/metadata routes in the zero-app branch (#3610), pseudo-route segment matching (#3638), the legacy `/system/*` redirect targets (#3655) — are viewer-independent and their assertions are unchanged.

## Verification

- `pnpm exec vitest run packages/app-shell/ apps/console/` → **402 files / 3933 passed, 1 skipped**.
- `pnpm --filter @object-ui/app-shell type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) → exit 0; `pnpm --filter @object-ui/console type-check` (`tsc --noEmit && tsc -b tsconfig.node.json --force`) → exit 0. Dependency closures built first (`--filter '@object-ui/app-shell^...' build`).
- Emitted declaration `dist/console/AppContent.d.ts` built from `origin/main` vs from this branch: **byte-identical** — no public type surface change, hence `patch`.
- `eslint` on the six touched files: 0 errors (37 pre-existing `any` warnings).
- `node scripts/check-changeset-presence.mjs` → OK (`.changeset/landing-app-no-strand-4473.md`, `@object-ui/app-shell` patch); `node scripts/check-control-bytes.mjs` → OK.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_