### PR TITLE
fix(detail): lookup field values link to the referenced record (#4336)

### DIFF
--- a/.changeset/lookup-values-link-to-referenced-record.md
+++ b/.changeset/lookup-values-link-to-referenced-record.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/react': minor
+'@object-ui/fields': patch
+'@object-ui/app-shell': patch
+---
+
+fix(detail): lookup field values link to the referenced record
+
+A valued lookup on a record detail page rendered as plain text plus a copy
+button — the referenced document's name was visible but unreachable, so users
+copied the number and searched for it from the list page instead. Lookup cells
+inside a related list that pointed at a third object were dead the same way.
+
+`LookupCellRenderer` — the one cell renderer both surfaces resolve through —
+now renders the display value as a link to the referenced record. The display
+name resolution, the copy affordance and every non-lookup field are unchanged,
+and a lookup with no value still renders its placeholder rather than an empty
+link.
+
+The URL is not assembled in the renderer. `RelatedRecordActionsContext` gains
+an optional `recordHref` / `openRecord` pair, published by the console's
+`RelatedRecordActionsBridge` from the SAME builder its related-list row
+navigation already used, so there is one record-route shape rather than a
+second one. A host that does not provide it (Studio designer, embedded
+renderers, standalone grids) renders exactly what it rendered before.

--- a/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
+++ b/packages/app-shell/src/views/RelatedRecordActionsBridge.tsx
@@ -129,6 +129,58 @@ export function RelatedRecordActionsBridge({
   const localizeActionTexts = useActionTextLocalizer();
   const base = appName ? `/apps/${appName}` : '';
 
+  /** Objects this host can route to — the record route exists per object def. */
+  const routableObjects = useMemo(
+    () => new Set((objects ?? []).map((o: any) => o?.name).filter(Boolean)),
+    [objects],
+  );
+
+  /**
+   * THE record-detail URL builder for this page — one route shape, one place.
+   *
+   * Serves both the related list's row navigation (`onView`, below) and, since
+   * objectui#4336, the lookup values rendered anywhere under this bridge: a
+   * lookup points at a record of another object, and `LookupCellRenderer` has
+   * no router, so it asks for the href instead of re-deriving `/apps/:app/
+   * :object/record/:id` a second time (the #4472 lesson — one resolver).
+   *
+   * `null` when the host cannot route there (no app segment, or an object that
+   * is not in this console's metadata), which renders as the plain value.
+   */
+  const recordHref = useCallback(
+    (objectName: string, recordId: string | number): string | null => {
+      if (!base || !objectName || !routableObjects.has(objectName)) return null;
+      const url = `${base}/${objectName}/record/${encodeURIComponent(String(recordId))}`;
+      // Carry the parent record into the target's `?from=` trail so the
+      // breadcrumb (and the record body's back link) can path back up.
+      // Read the current trail off the live URL — this bridge outlives a
+      // single search-params snapshot, so a fresh read avoids a stale
+      // closure and keeps nested drill-ins accumulating correctly.
+      if (parentObjectName && parentRecordId) {
+        const rawFrom = new URLSearchParams(window.location.search).get(RECORD_TRAIL_PARAM);
+        const trail = appendRecordTrail(rawFrom, {
+          o: parentObjectName,
+          i: parentRecordId,
+          ...(parentTitle ? { t: parentTitle } : {}),
+        });
+        const sp = new URLSearchParams();
+        sp.set(RECORD_TRAIL_PARAM, trail);
+        return `${url}?${sp.toString()}`;
+      }
+      return url;
+    },
+    [base, routableObjects, parentObjectName, parentRecordId, parentTitle],
+  );
+
+  /** SPA-navigate to the destination {@link recordHref} addresses. */
+  const openRecord = useCallback(
+    (objectName: string, recordId: string | number) => {
+      const href = recordHref(objectName, recordId);
+      if (href) navigate(href);
+    },
+    [recordHref, navigate],
+  );
+
   // #2604 D3 — open a child create/edit task as the console's global record
   // form overlay, by URL params. Pushes ONE history entry (Back = close, the
   // parent detail stays mounted underneath). The read side lives in
@@ -202,30 +254,10 @@ export function RelatedRecordActionsBridge({
           edit: rawAff.edit && can(objectName, 'update'),
           delete: rawAff.delete && can(objectName, 'delete'),
         };
-        const detailUrl = (id: string | number) => {
-          const url = `${base}/${objectName}/record/${encodeURIComponent(String(id))}`;
-          // Carry the parent record into the child's `?from=` trail so the
-          // breadcrumb (and the record body's back link) can path back up.
-          // Read the current trail off the live URL — this bridge outlives a
-          // single search-params snapshot, so a fresh read avoids a stale
-          // closure and keeps nested drill-ins accumulating correctly.
-          if (parentObjectName && parentRecordId) {
-            const rawFrom = new URLSearchParams(window.location.search).get(RECORD_TRAIL_PARAM);
-            const trail = appendRecordTrail(rawFrom, {
-              o: parentObjectName,
-              i: parentRecordId,
-              ...(parentTitle ? { t: parentTitle } : {}),
-            });
-            const sp = new URLSearchParams();
-            sp.set(RECORD_TRAIL_PARAM, trail);
-            return `${url}?${sp.toString()}`;
-          }
-          return url;
-        };
-
         const handlers: RelatedRecordHandlers = {
           // Viewing a child record is always allowed when the list is visible.
-          onView: (id) => navigate(detailUrl(id)),
+          // Same builder the lookup links use — `recordHref` above.
+          onView: (id) => openRecord(objectName, id),
         };
 
         if (aff.create) {
@@ -270,8 +302,10 @@ export function RelatedRecordActionsBridge({
 
         return handlers;
       },
+      recordHref,
+      openRecord,
     }),
-    [objects, base, navigate, dataSource, localizeActionTexts, runRowAction, openChildForm, parentObjectName, parentRecordId, parentTitle, getObjectApiOperations, can],
+    [objects, base, dataSource, localizeActionTexts, runRowAction, openChildForm, recordHref, openRecord, getObjectApiOperations, can],
   );
 
   return (

--- a/packages/fields/src/__tests__/lookupCellRecordLink.test.tsx
+++ b/packages/fields/src/__tests__/lookupCellRecordLink.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4336 — a lookup value rendered read-only was plain text: the record
+ * detail page showed `TYG1WX20260812001001` with a copy button and no way to
+ * reach the referenced work order, and the related list's lookup columns had
+ * the same dead cells (the reporter's own check: no `<a>` anywhere over the
+ * value, every `href` null).
+ *
+ * `LookupCellRenderer` is the ONE cell renderer both surfaces resolve through
+ * (`DetailSection` and `RelatedList` each call `getCellRenderer('lookup')`), so
+ * the link belongs here — same path, both halves.
+ *
+ * The href is NOT assembled here. This package has no router and no idea what
+ * an app's record route looks like; the host that owns record URLs publishes
+ * them through `RelatedRecordActionsContext` (`recordHref` / `openRecord`),
+ * which is the same builder the related list's row navigation already uses. No
+ * host → no link, and the value renders exactly as it did before.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { LookupCellRenderer } from '../index';
+import { RelatedRecordActionsProvider } from '@object-ui/react';
+
+/** The reporter's shape: `$expand`-ed lookup value (display name + record id). */
+const WORK_ORDER = { id: 'wo-1', name: 'TYG1WX20260812001001' };
+const FIELD = { type: 'lookup', reference_to: 'mtc_work_order' } as any;
+
+/** A host that can route to records, mirroring the console bridge's shape. */
+function makeHost(overrides: Record<string, unknown> = {}) {
+  return {
+    resolve: () => ({}),
+    recordHref: (objectName: string, recordId: string | number) =>
+      `/apps/demo/${objectName}/record/${encodeURIComponent(String(recordId))}`,
+    openRecord: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+function renderWithHost(node: React.ReactElement, host: any = makeHost()) {
+  return render(
+    <RelatedRecordActionsProvider value={host}>{node}</RelatedRecordActionsProvider>,
+  );
+}
+
+describe('LookupCellRenderer — the value links to the referenced record (#4336)', () => {
+  it('expanded value: renders an anchor at the host-built record href', () => {
+    const { container } = renderWithHost(
+      <LookupCellRenderer value={WORK_ORDER} field={FIELD} />,
+    );
+
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor).toHaveAttribute('href', '/apps/demo/mtc_work_order/record/wo-1');
+    // Display-name resolution is untouched — the anchor carries the same text.
+    expect(anchor).toHaveTextContent('TYG1WX20260812001001');
+  });
+
+  it('primitive id value: links through the same host builder', () => {
+    const { container } = renderWithHost(
+      <LookupCellRenderer
+        value="wo-2"
+        field={{ ...FIELD, options: [{ value: 'wo-2', label: 'TYG1WX20260812001002' }] }}
+      />,
+    );
+
+    const anchor = container.querySelector('a');
+    expect(anchor).toHaveAttribute('href', '/apps/demo/mtc_work_order/record/wo-2');
+    expect(anchor).toHaveTextContent('TYG1WX20260812001002');
+  });
+
+  it('multi-value: each referenced record gets its own anchor', () => {
+    const { container } = renderWithHost(
+      <LookupCellRenderer
+        value={[WORK_ORDER, { id: 'wo-3', name: 'TYG1WX20260812001003' }]}
+        field={FIELD}
+      />,
+    );
+
+    const hrefs = Array.from(container.querySelectorAll('a')).map((a) => a.getAttribute('href'));
+    expect(hrefs).toEqual([
+      '/apps/demo/mtc_work_order/record/wo-1',
+      '/apps/demo/mtc_work_order/record/wo-3',
+    ]);
+  });
+
+  it('plain click navigates through the host (SPA) instead of reloading', () => {
+    const host = makeHost();
+    const rowClick = vi.fn();
+    const { container } = render(
+      <RelatedRecordActionsProvider value={host}>
+        {/* The surfaces around this cell carry their own click handlers — the
+            detail row copies the value, a related-list row opens the row's own
+            record. Activating the link must do neither. */}
+        <div onClick={rowClick}>
+          <LookupCellRenderer value={WORK_ORDER} field={FIELD} />
+        </div>
+      </RelatedRecordActionsProvider>,
+    );
+
+    const anchor = container.querySelector('a')!;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(anchor, event);
+
+    expect(host.openRecord).toHaveBeenCalledWith('mtc_work_order', 'wo-1');
+    expect(event.defaultPrevented).toBe(true);
+    expect(rowClick).not.toHaveBeenCalled();
+  });
+
+  it('modifier click keeps the browser default (open in a new tab)', () => {
+    const host = makeHost();
+    const { container } = renderWithHost(
+      <LookupCellRenderer value={WORK_ORDER} field={FIELD} />,
+      host,
+    );
+
+    const anchor = container.querySelector('a')!;
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      metaKey: true,
+    });
+    fireEvent(anchor, event);
+
+    expect(host.openRecord).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe('LookupCellRenderer — must-not-change (#4336)', () => {
+  it('no host: renders exactly as before, with no anchor', () => {
+    const { container } = render(<LookupCellRenderer value={WORK_ORDER} field={FIELD} />);
+
+    expect(container.querySelector('a')).toBeNull();
+    expect(screen.getByText('TYG1WX20260812001001')).toBeInTheDocument();
+  });
+
+  it('host cannot route to the target object: no anchor, same text', () => {
+    const { container } = renderWithHost(
+      <LookupCellRenderer value={WORK_ORDER} field={FIELD} />,
+      makeHost({ recordHref: () => null }),
+    );
+
+    expect(container.querySelector('a')).toBeNull();
+    expect(screen.getByText('TYG1WX20260812001001')).toBeInTheDocument();
+  });
+
+  it('no reference target declared: no anchor', () => {
+    const { container } = renderWithHost(
+      <LookupCellRenderer value={WORK_ORDER} field={{ type: 'lookup' } as any} />,
+    );
+
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('empty value: the placeholder stays a placeholder — no empty link', () => {
+    const { container } = renderWithHost(<LookupCellRenderer value={null} field={FIELD} />);
+
+    expect(container.querySelector('a')).toBeNull();
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -14,6 +14,7 @@ import { Badge, Avatar, AvatarImage, AvatarFallback, Button, Checkbox, EmptyValu
 import { Check, X, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import { SchemaRendererContext as _SchemaRendererContext } from '@object-ui/react';
+import { useRelatedRecordActions } from '@object-ui/react';
 import { withFieldCarrier } from './withFieldCarrier';
 // Pure formatting rule shared with `AddressField`'s readonly branch — no React,
 // so this does not pull the widget out of its lazy chunk (objectui#4037).
@@ -1424,6 +1425,89 @@ export function ImageCellRenderer({ value }: CellRendererProps): React.ReactElem
 }
 
 /**
+ * The referenced record's id inside one lookup value — an `$expand`-ed record
+ * object (`{ id, name, … }`) or the raw foreign key itself. `undefined` when
+ * the value carries no id we could address (e.g. an unresolved external-id
+ * reference), which the link below reads as "not navigable".
+ */
+function referencedRecordId(item: unknown): string | number | undefined {
+  if (item == null || item === '') return undefined;
+  if (typeof item === 'object') {
+    const id = (item as Record<string, unknown>).id ?? (item as Record<string, unknown>)._id;
+    if (typeof id === 'number') return id;
+    return typeof id === 'string' && id !== '' ? id : undefined;
+  }
+  if (typeof item === 'string' || typeof item === 'number') return item;
+  return undefined;
+}
+
+/**
+ * Wrap a lookup's display value in a link to the record it references
+ * (objectui#4336).
+ *
+ * On the record detail page a valued lookup used to render as plain text plus
+ * a copy button — the referenced document's name was right there and there was
+ * no way to reach it, so users copied the number and searched for it from the
+ * list. Related-list cells pointing at a third object were dead in the same
+ * way. Both surfaces resolve through `LookupCellRenderer`, so the affordance
+ * belongs here, once.
+ *
+ * **The URL is not built here.** This package has no router and no business
+ * knowing what a record route looks like; the host publishes its own builder
+ * through `RelatedRecordActionsContext` (`recordHref` / `openRecord`) — the
+ * same one the related list's row navigation uses. No host, or a host that
+ * cannot route to that object, renders the value EXACTLY as before: no anchor,
+ * no styling change, nothing to un-learn (Studio designer, embedded renderers,
+ * standalone grids).
+ *
+ * A real `href` rather than a click handler, so middle-click / ⌘-click / "copy
+ * link address" behave the way a link is supposed to; a plain left click is
+ * handed to the host so navigation stays in-app.
+ */
+function ReferencedRecordLink({
+  objectName,
+  recordId,
+  className,
+  children,
+}: {
+  objectName?: string;
+  recordId?: string | number;
+  className?: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  const host = useRelatedRecordActions();
+  const navigable = !!objectName && recordId != null && recordId !== '';
+  const href =
+    navigable && host?.recordHref
+      ? host.recordHref(objectName as string, recordId as string | number)
+      : null;
+
+  if (!href) return <>{children}</>;
+
+  return (
+    <a
+      href={href}
+      className={cn('text-primary underline-offset-4 hover:underline', className)}
+      onClick={(e) => {
+        // The rows this cell sits in carry their own click handlers — the
+        // detail row copies the field value, a related-list row opens ITS own
+        // record. Following the reference must not also fire those.
+        e.stopPropagation();
+        // Modifier and non-primary clicks belong to the browser (new tab, new
+        // window) — that is the point of rendering a real href.
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+        // No SPA handler: let the anchor navigate on its own.
+        if (!host?.openRecord) return;
+        e.preventDefault();
+        host.openRecord(objectName as string, recordId as string | number);
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
  * Lookup/Master-Detail field cell renderer.
  *
  * Display order:
@@ -1495,15 +1579,24 @@ export function LookupCellRenderer({ value, field }: CellRendererProps): React.R
       // Compute inside try, render outside — constructing JSX in a try/catch
       // doesn't catch its render errors anyway (react-hooks/error-boundaries).
       let parsedDisplay = '';
+      let parsedId: string | number | undefined;
       try {
         const parsed = JSON.parse(s) as Record<string, unknown>;
         if (parsed && typeof parsed === 'object') {
           parsedDisplay =
             resolveLookupRecordName(parsed, refSchema, displayField) ||
             String(parsed.externalId ?? parsed.id ?? parsed._id ?? '');
+          // An external-id reference has no record id yet — stays unlinked.
+          parsedId = referencedRecordId(parsed);
         }
       } catch { /* not JSON — fall through to normal resolution */ }
-      if (parsedDisplay) return <TruncatedText text={parsedDisplay} />;
+      if (parsedDisplay) {
+        return (
+          <ReferencedRecordLink objectName={referenceTo} recordId={parsedId}>
+            <TruncatedText text={parsedDisplay} />
+          </ReferencedRecordLink>
+        );
+      }
     }
   }
 
@@ -1514,7 +1607,11 @@ export function LookupCellRenderer({ value, field }: CellRendererProps): React.R
     const display =
       resolveLookupRecordName(obj, refSchema, displayField) || String(obj.id || obj._id || '');
     if (display) {
-      return <TruncatedText text={display} />;
+      return (
+        <ReferencedRecordLink objectName={referenceTo} recordId={referencedRecordId(obj)}>
+          <TruncatedText text={display} />
+        </ReferencedRecordLink>
+      );
     }
   }
 
@@ -1552,18 +1649,26 @@ export function LookupCellRenderer({ value, field }: CellRendererProps): React.R
             label = r.text;
             muted = r.muted;
           }
+          // Each chip is one referenced record, so each links on its own —
+          // there is no single destination a multi-value cell could point at.
           return (
-            <span
+            <ReferencedRecordLink
               key={idx}
-              className={cn(
-                'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
-                muted
-                  ? 'bg-muted/40 text-muted-foreground'
-                  : 'bg-gray-50 text-gray-700 dark:bg-gray-800/50 dark:text-gray-200',
-              )}
+              objectName={referenceTo}
+              recordId={referencedRecordId(item)}
+              className="text-inherit"
             >
-              {label}
-            </span>
+              <span
+                className={cn(
+                  'inline-flex items-center px-2 py-0.5 rounded text-xs font-medium',
+                  muted
+                    ? 'bg-muted/40 text-muted-foreground'
+                    : 'bg-gray-50 text-gray-700 dark:bg-gray-800/50 dark:text-gray-200',
+                )}
+              >
+                {label}
+              </span>
+            </ReferencedRecordLink>
           );
         })}
       </div>
@@ -1574,12 +1679,23 @@ export function LookupCellRenderer({ value, field }: CellRendererProps): React.R
     const label =
       resolveLookupRecordName(value as Record<string, unknown>, refSchema, displayField) ||
       String((value as any).id || (value as any)._id || '[Object]');
-    return <TruncatedText text={label} />;
+    return (
+      <ReferencedRecordLink objectName={referenceTo} recordId={referencedRecordId(value)}>
+        <TruncatedText text={label} />
+      </ReferencedRecordLink>
+    );
   }
 
   // Primitive value (e.g. raw ID): try options → resolver → opaque-ID placeholder → raw
+  // The value IS the foreign key, so it addresses the record even when the
+  // display name could not be resolved (the muted placeholder) — a reference
+  // that is present but unnamed is still worth being able to open.
   const { text, muted } = resolveLabel(value);
-  return <TruncatedText text={text} className={muted ? 'text-muted-foreground' : undefined} />;
+  return (
+    <ReferencedRecordLink objectName={referenceTo} recordId={referencedRecordId(value)}>
+      <TruncatedText text={text} className={muted ? 'text-muted-foreground' : undefined} />
+    </ReferencedRecordLink>
+  );
 }
 
 /**

--- a/packages/plugin-detail/src/__tests__/DetailSection.lookupLink.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.lookupLink.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4336 — the reporter's check, at the end of the real path.
+ *
+ * On a record detail page a valued lookup (`关联维修派工单` → 维修派工单)
+ * rendered as plain text plus a copy button: hovering showed no link state,
+ * clicking did nothing, and `document.querySelector('a')` over the field's
+ * value region found nothing. Both readonly and non-readonly fields behaved
+ * the same way, so this is display-mode rendering, not an editability gate.
+ *
+ * These drive the real `DetailSection`, not the cell renderer, so they stay
+ * red if the link is wired anywhere the detail body does not actually reach.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { DetailSection } from '../DetailSection';
+import { RelatedRecordActionsProvider } from '@object-ui/react';
+import type { DetailViewSection } from '@object-ui/types';
+
+// The desktop read row (the one carrying the copy affordance) only renders
+// above the mobile breakpoint.
+beforeAll(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+});
+
+const objectSchema = {
+  fields: {
+    work_order_id: { type: 'lookup', reference: 'mtc_work_order', readonly: true },
+    inspection_task_id: { type: 'lookup', reference_to: 'mtc_task' },
+    empty_order_id: { type: 'lookup', reference_to: 'mtc_work_order' },
+    remark: { type: 'text' },
+    operator: { type: 'text' },
+  },
+};
+
+// Five rows with ONE empty: below the section's auto-hide-empty ratio (≥25%),
+// so the empty lookup really renders and its "no empty link" pin can be read.
+const section: DetailViewSection = {
+  fields: [
+    { name: 'work_order_id', label: '关联维修派工单' },
+    { name: 'inspection_task_id', label: '点检任务' },
+    { name: 'empty_order_id', label: '生成的维修派工单' },
+    { name: 'remark', label: '备注' },
+    { name: 'operator', label: '操作人' },
+  ],
+} as DetailViewSection;
+
+const data = {
+  // readonly lookup, expanded by the server ($expand → { id, name })
+  work_order_id: { id: 'wo-1', name: 'TYG1WX20260812001001' },
+  // non-readonly lookup, same shape — the issue reports both behave alike
+  inspection_task_id: { id: 'task-9', name: '#1072b埋弧焊机日常点检(TYWI003)' },
+  empty_order_id: null,
+  remark: 'plain text field',
+  operator: '张三',
+};
+
+function makeHost(overrides: Record<string, unknown> = {}) {
+  return {
+    resolve: () => ({}),
+    recordHref: (objectName: string, recordId: string | number) =>
+      `/apps/demo/${objectName}/record/${encodeURIComponent(String(recordId))}`,
+    openRecord: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+function renderSection(host: any = makeHost()) {
+  return render(
+    <RelatedRecordActionsProvider value={host}>
+      <DetailSection section={section} data={data} objectSchema={objectSchema} />
+    </RelatedRecordActionsProvider>,
+  );
+}
+
+/** The value region of one field row, located from its label. */
+function valueRegion(container: HTMLElement, label: string): HTMLElement {
+  const labelEl = screen.getByText(label);
+  const row = labelEl.parentElement as HTMLElement;
+  expect(row).toBeTruthy();
+  expect(container.contains(row)).toBe(true);
+  return row;
+}
+
+describe('DetailSection — lookup values link to the referenced record (#4336)', () => {
+  it('readonly lookup: the value region carries an anchor at the record href', () => {
+    const { container } = renderSection();
+
+    const anchor = valueRegion(container, '关联维修派工单').querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor).toHaveAttribute('href', '/apps/demo/mtc_work_order/record/wo-1');
+    expect(anchor).toHaveTextContent('TYG1WX20260812001001');
+  });
+
+  it('non-readonly lookup: same treatment — readonly is irrelevant here', () => {
+    const { container } = renderSection();
+
+    const anchor = valueRegion(container, '点检任务').querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor).toHaveAttribute('href', '/apps/demo/mtc_task/record/task-9');
+    expect(anchor).toHaveTextContent('#1072b埋弧焊机日常点检(TYWI003)');
+  });
+});
+
+describe('DetailSection — must-not-change (#4336)', () => {
+  it('the copy affordance still sits beside the linked value', () => {
+    const { container } = renderSection();
+
+    const row = valueRegion(container, '关联维修派工单');
+    expect(row.querySelector('a')).not.toBeNull();
+    // The copy button is the row's only <button>; it is rendered for any
+    // non-inline-editable field with a value, alongside the link.
+    expect(row.querySelectorAll('button').length).toBe(1);
+  });
+
+  it('a lookup with no value renders the placeholder, never an empty link', () => {
+    const { container } = renderSection();
+
+    const row = valueRegion(container, '生成的维修派工单');
+    expect(row.querySelector('a')).toBeNull();
+    expect(row.textContent).toContain('—');
+  });
+
+  it('non-lookup fields are untouched', () => {
+    const { container } = renderSection();
+
+    const row = valueRegion(container, '备注');
+    expect(row.querySelector('a')).toBeNull();
+    expect(row).toHaveTextContent('plain text field');
+  });
+
+  it('no host record routing (designer / embedded): plain text, exactly as before', () => {
+    const { container } = render(
+      <DetailSection section={section} data={data} objectSchema={objectSchema} />,
+    );
+
+    expect(container.querySelector('a')).toBeNull();
+    expect(screen.getByText('TYG1WX20260812001001')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RelatedList.lookupCellLink.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.lookupCellLink.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4336, the follow-up's widening — the related list's own lookup
+ * columns were dead too.
+ *
+ * On 设备详情页 → 相关 → 维保履历 the ROW navigates (to that 维保履历 record),
+ * but every lookup cell pointing at a THIRD object (`执行责任人`,
+ * `来源维保派工单`) was plain text: "逐格取 href 全部为 null,整行 6 个单元格
+ * 没有任何 <a>".
+ *
+ * Measurement put both halves on ONE path: `RelatedList.makeCell` and
+ * `DetailSection`'s read branch each resolve the cell through
+ * `getCellRenderer('lookup')` → `LookupCellRenderer`. So this pin exists to
+ * keep the related-list half honest at the end of ITS path — the detail body
+ * being green is not evidence for this one.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+
+import { RelatedList } from '../RelatedList';
+import { RelatedRecordActionsProvider } from '@object-ui/react';
+
+// Capture the schema RelatedList hands to SchemaRenderer (the data-table), so
+// a column's cell can be rendered directly — the same lever
+// `RelatedList.lookupLabelResolution.test.tsx` uses.
+const h = vi.hoisted(() => ({ schema: null as any }));
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    SchemaRenderer: (props: any) => {
+      h.schema = props.schema;
+      return null;
+    },
+  };
+});
+
+const historySchema = {
+  name: 'mtc_history',
+  fields: {
+    equipment_id: { type: 'lookup', label: '设备', reference_to: 'mtc_equipment' },
+    work_order_id: { type: 'lookup', label: '来源维保派工单', reference_to: 'mtc_work_order' },
+  },
+};
+
+const rows = [{ id: 'h1', equipment_id: 'eq_1', work_order_id: 'wo_1' }];
+
+const makeDataSource = () => ({
+  getObjectSchema: vi.fn(async () => historySchema),
+  find: vi.fn(async () => ({ data: rows, total: rows.length })),
+});
+
+function makeHost(overrides: Record<string, unknown> = {}) {
+  return {
+    resolve: () => ({}),
+    recordHref: (objectName: string, recordId: string | number) =>
+      `/apps/demo/${objectName}/record/${encodeURIComponent(String(recordId))}`,
+    openRecord: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+/**
+ * Render one column's cell for `value` INSIDE the host provider — production
+ * mounts the whole related list under the console's bridge, so the cell reads
+ * the same context there.
+ */
+function renderCell(accessorKey: string, value: unknown, host: any = makeHost()) {
+  const col = h.schema?.columns?.find((c: any) => c?.accessorKey === accessorKey);
+  expect(col?.cell).toBeTypeOf('function');
+  return render(
+    <RelatedRecordActionsProvider value={host}>
+      <>{col.cell(value)}</>
+    </RelatedRecordActionsProvider>,
+  );
+}
+
+function mountList(dataSource: any) {
+  return render(
+    <RelatedRecordActionsProvider value={makeHost()}>
+      <RelatedList
+        title="维保履历"
+        type="table"
+        api="mtc_history"
+        objectName="mtc_history"
+        referenceField="equipment_id"
+        parentId="eq_1"
+        columns={[
+          { accessorKey: 'equipment_id', header: '设备' },
+          { accessorKey: 'work_order_id', header: '来源维保派工单' },
+        ]}
+        dataSource={dataSource as any}
+      />
+    </RelatedRecordActionsProvider>,
+  );
+}
+
+beforeEach(() => {
+  h.schema = null;
+});
+
+describe('RelatedList — lookup cells link to their referenced record (#4336)', () => {
+  it('a lookup column pointing at a third object renders an anchor', async () => {
+    const dataSource = makeDataSource();
+    mountList(dataSource);
+    await waitFor(() => expect(h.schema?.columns?.length).toBeGreaterThan(0));
+
+    const { container } = renderCell('work_order_id', 'wo_1');
+    const anchor = container.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor).toHaveAttribute('href', '/apps/demo/mtc_work_order/record/wo_1');
+  });
+
+  it('must-not-change: no host routing → the cell stays plain text', async () => {
+    const dataSource = makeDataSource();
+    mountList(dataSource);
+    await waitFor(() => expect(h.schema?.columns?.length).toBeGreaterThan(0));
+
+    const { container } = renderCell('work_order_id', 'wo_1', makeHost({ recordHref: () => null }));
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('must-not-change: an empty cell keeps its placeholder, with no link', async () => {
+    const dataSource = makeDataSource();
+    mountList(dataSource);
+    await waitFor(() => expect(h.schema?.columns?.length).toBeGreaterThan(0));
+
+    const { container } = renderCell('work_order_id', null);
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('—');
+  });
+});

--- a/packages/react/src/context/RelatedRecordActionsContext.tsx
+++ b/packages/react/src/context/RelatedRecordActionsContext.tsx
@@ -25,6 +25,12 @@
  * affordance. When no provider is present at all (e.g. the Studio designer, or
  * a standalone embedded renderer) the related list stays read-only, which is
  * the correct graceful fallback.
+ *
+ * Since objectui#4336 the same host also publishes its record-URL builder
+ * ({@link RelatedRecordActionsValue.recordHref} / `openRecord`) for any object
+ * it can route to, so the low-level renderers on a record page can turn a
+ * lookup VALUE into a link to the referenced record without assembling a URL
+ * of their own. Same provider, same builder, one route shape.
  */
 
 import React, { createContext, useContext } from 'react';
@@ -98,6 +104,29 @@ export interface RelatedRecordActionsValue {
    * identity.
    */
   resolve: (input: ResolveRelatedRecordActionsInput) => RelatedRecordHandlers;
+  /**
+   * The host's record-detail URL for ANY object it can route to — the SAME
+   * builder {@link RelatedRecordHandlers.onView} navigates with, published as
+   * an href so a renderer can present the destination as a real anchor
+   * (middle-click, "open in new tab", "copy link address") instead of a
+   * click-only affordance.
+   *
+   * Added for objectui#4336: a lookup value is a reference to a record of a
+   * DIFFERENT object, and the renderer that displays it (`LookupCellRenderer`,
+   * shared by the detail body and the related list's cells) has no router and
+   * no knowledge of the console's route shape. Route building stays here, in
+   * the one place that already owns it — never re-derived renderer-side.
+   *
+   * Returns `null` when the host cannot route to that object (unknown object,
+   * no app context), which consumers must render as the plain value.
+   */
+  recordHref?: (objectName: string, recordId: string | number) => string | null;
+  /**
+   * SPA-navigate to the destination {@link recordHref} addresses. Consumers
+   * call this from a plain left click on the anchor so navigation stays
+   * in-app; a modifier click is left to the browser and the href.
+   */
+  openRecord?: (objectName: string, recordId: string | number) => void;
 }
 
 const RelatedRecordActionsContext = createContext<RelatedRecordActionsValue | null>(null);


### PR DESCRIPTION
Closes #4336

## The defect

A valued lookup on a record detail page rendered as plain text plus a copy button: the referenced document's display name was right there, and there was no way to reach it. The reporter's own check — no `a` element anywhere over the field's value region, every `href` null — held for readonly and non-readonly lookups alike, across several objects, which is what makes this display-mode rendering rather than an editability gate.

The follow-up comment widened it: on a related list, the ROW navigates to its own record, but lookup cells pointing at a THIRD object were dead in the same way (`执行责任人`, `管理责任人`, `来源维保派工单` — "逐格取 href 全部为 null").

## Measurement: one path, so both halves land here

`DetailSection`'s read branch and `RelatedList.makeCell` each resolve the cell through `getCellRenderer('lookup')` → `LookupCellRenderer` (`packages/fields/src/index.tsx`). Same renderer, same path — so the related-list half is **covered here**, not split into a second card. Pinned separately all the same: the detail body being green is not evidence for the related-list cell.

## The URL resolver — measured, and what I found

The ruling asked me to reuse the shared mechanism the list page's `link: true` columns and related-row navigation build record URLs with. Measured, that mechanism is **not** a URL helper — the repo has none reachable from a low-level renderer:

- `ObjectGrid`'s `link: true` / primary column renders a `span role="link"` and calls `navigation.handleClick(row)`; `useNavigationOverlay` delegates to the host's `onNavigate`.
- A related list's row navigation calls `useRelatedRecordActions().resolve({objectName}).onView(id)`.
- In both, the **host** (app-shell) owns URL assembly — `/apps/:app/:object/record/:id` is written out in ~15 host-side places, and the one exported helper (`deriveRecordPageHref`) derives its prefix by finding `/{objectName}` in the current path, so it cannot address a **different** object's record.

So the shared mechanism is "host-provided callbacks through React context, host owns the route shape". I reused exactly that, and added no new assembly: `RelatedRecordActionsContext` — already mounted around the whole detail page body, already the channel the related list navigates through — gains an optional `recordHref` / `openRecord` pair. `RelatedRecordActionsBridge` publishes them from the **same** builder `onView` already navigated with: its inner `detailUrl` is hoisted to `recordHref(objectName, id)`, `?from=` breadcrumb trail included, and `onView` now calls it. One route shape, one place; nothing re-derived renderer-side.

A real anchor with an `href` rather than a click handler, so middle-click / Cmd-click / "copy link address" behave the way a link should; a plain left click is handed to `openRecord` so navigation stays in-app, and the click is stopped from reaching the row underneath (which would otherwise ALSO fire the detail row's copy-to-clipboard or the related row's own open).

No host, or a host that cannot route to the target object → **no link, and the value renders exactly as before** (Studio designer, embedded renderers, standalone grids).

## Red-first

Pre-fix, over the three surfaces, verbatim:

```
FAIL |dom| packages/fields/.../lookupCellRecordLink.test.tsx > expanded value: renders an anchor at the host-built record href
AssertionError: expected null not to be null
FAIL |dom| packages/plugin-detail/.../DetailSection.lookupLink.test.tsx > readonly lookup: the value region carries an anchor at the record href
AssertionError: expected null not to be null
FAIL |dom| packages/plugin-detail/.../DetailSection.lookupLink.test.tsx > non-readonly lookup: same treatment — readonly is irrelevant here
AssertionError: expected null not to be null
FAIL |dom| packages/plugin-detail/.../RelatedList.lookupCellLink.test.tsx > a lookup column pointing at a third object renders an anchor
AssertionError: expected null not to be null

 Test Files  3 failed (3)
      Tests  10 failed | 8 passed (18)
```

Post-fix: `Test Files 3 passed (3) · Tests 18 passed (18)` — the anchor's `href` is the host-built record URL (`/apps/demo/mtc_work_order/record/wo-1`).

**Must-not-change (green on both sides):** display-name resolution unchanged (the anchor carries the same text); the copy button still sits beside the linked value; non-lookup fields untouched; a lookup with **no** value keeps its placeholder and grows no empty link; no host → plain text.

## Edge cases

| case | answer |
|---|---|
| no value | placeholder, no anchor (unchanged) |
| target object not routable by the host | `recordHref` returns null → plain value, exactly as before |
| multi-value | each chip is one referenced record, so each links on its own — there is no single destination a multi-value cell could point at |
| value present, display name unresolvable (opaque id → muted placeholder) | linked; the value IS the foreign key, so the record is addressable even unnamed |
| unresolved external-id reference (`{"externalId":…}`) | no record id → unlinked |

## Verification

- `pnpm exec vitest run packages/fields/ packages/plugin-detail/ packages/react/ packages/plugin-grid/ packages/plugin-dashboard/ packages/plugin-kanban/ packages/plugin-list/` → **350 files / 4166 tests passed**
- `pnpm exec vitest run packages/app-shell/ apps/console/` → **404 files / 3945 passed, 1 skipped**
- `type-check` (both `tsc` commands where the package has them) for `@object-ui/fields`, `@object-ui/react`, `@object-ui/app-shell` → all exit 0
- `check:control-bytes`, `check:changeset-presence`, `check:changeset-no-major`, `check:spec-symbols`, `check:phantom-deps`, `check:i18n-keys`, `eslint` on touched files (0 errors) → green

## Grading

`.d.ts` measured after a dependency-closure build: `@object-ui/react`'s emitted declaration gains the two optional members → **minor**. `@object-ui/fields`' declaration is unchanged (`LookupCellRenderer`'s signature identical; the link component and id helper are module-private) and `@object-ui/app-shell`'s bridge props are unchanged → **patch** for both.

## Not in scope

The `${param._rowRecord.«lookupField»}` shape inconsistency from the follow-up's item 4 (expand-object in header actions vs bare id in row actions) is untouched, per the ruling.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
