### PR TITLE
test(dom-leak): one attribute judge, shared by both gates (#4434)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -50,7 +50,8 @@
   "updateInternalDependencies": "patch",
   "ignore": [
     "@object-ui/example-*",
-    "@object-ui/site"
+    "@object-ui/site",
+    "@object-ui/test-support"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true

--- a/.changeset/shared-dom-leak-judge.md
+++ b/.changeset/shared-dom-leak-judge.md
@@ -1,0 +1,13 @@
+---
+---
+
+Test-only (objectui#4434): the DOM-leak attribute judge — `isKnownAttribute`,
+`findLeaks`, `leakReport`, the happy-dom IDL gap table, the SVG presentation
+list and the open attribute families — is now one shared module in the new
+`@object-ui/test-support` package, instead of two already-diverged copies
+defined inline in the `@object-ui/fields` and `@object-ui/app-shell` DOM-leak
+gates. Its calibration fixtures moved with it and prove it once, for both.
+
+Nothing published changes. `@object-ui/test-support` is `private: true` and is
+never released; the two consumers gain a `devDependency` on it and no runtime
+dependency, no `exports` map entry and no public API were added or altered.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -74,7 +74,7 @@ pnpm changeset publish         # Publish to npm (CI only)
 
 | Path | Purpose |
 | --- | --- |
-| `packages/*` | 38 published packages (`@object-ui/*`), plus the private `vscode-extension` |
+| `packages/*` | 38 published packages (`@object-ui/*`), plus the private `vscode-extension` and `test-support` (test-only, never released) |
 | `apps/console` | Full ObjectUI console app (Vite + React) |
 | `apps/site` | Public docs site at <https://www.objectui.org> (fumadocs) |
 | `examples/*` | Runnable examples and the schema catalog — see [`examples/README.md`](./examples/README.md) |

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -88,6 +88,7 @@
     "@object-ui/plugin-list": "workspace:*",
     "@object-ui/plugin-report": "workspace:*",
     "@object-ui/plugin-view": "workspace:*",
+    "@object-ui/test-support": "workspace:*",
     "@types/node": "^26.1.2",
     "@types/qrcode": "^1.5.6",
     "@types/react": "19.2.18",

--- a/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
+++ b/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
@@ -148,16 +148,22 @@
  *    required" placeholder instead of the calendar. Renders go through the
  *    provider, and each target carries the minimum schema its real markup needs.
  *
- * ## The judge is duplicated, deliberately and temporarily
+ * ## The judge is shared — it is no longer this file's to keep
  *
- * `isKnownAttribute` / `findLeaks` below are a copy of the judge in
- * `packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx`. That judge lives
- * INSIDE a test file and is not exported, so reusing it would mean editing
- * `packages/fields` — out of scope for a measurement-only PR, and its gate is
- * the reference the card points at. Two copies of one judge is how one judge
- * becomes two disagreeing judges, so the copy is recorded as a finding rather
- * than left to be discovered: extracting it to a shared home is phase-2 work.
- * The calibration fixtures below are what keep this copy honest in the meantime.
+ * `isKnownAttribute` / `findLeaks` / `leakReport` used to be defined below, as
+ * a copy of the judge in `packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx`.
+ * That copy is gone: objectui#4434 extracted one judge into
+ * `@object-ui/test-support` (private, never published — see its README for why
+ * that home and not a subpath export), carrying the UNION of what the two
+ * copies knew. The sweep-only half of that union is the ten recharts
+ * marker/gradient/pattern attributes this file's SVG list had grown and the
+ * fields copy never had; the calibration fixtures moved with the judge and now
+ * exercise them.
+ *
+ * What did NOT move is everything below: the canary sets, the target
+ * enumeration, the readiness selectors, {@link LEAK_LEDGER} and every
+ * assertion. Only the judge unifies — a judge that starts carrying one gate's
+ * policy is back to being two judges wearing one name.
  */
 
 import type { ComponentType } from 'react';
@@ -180,154 +186,10 @@ import '@object-ui/plugin-charts';
 import '@object-ui/plugin-calendar';
 import '@object-ui/plugin-chatbot';
 import '@object-ui/plugin-dashboard';
-
-/* ════════════════════════════════════════════════════════════════════════════
- * The judge: is this attribute one HTML actually defines?
- * (copy of the #3291 judge — see "The judge is duplicated" above)
- * ══════════════════════════════════════════════════════════════════════════ */
-
-/** Open families. `data-*` is the one open family the widget contract declares. */
-const OPEN_PREFIXES = [
-  'data-',
-  'aria-',
-  // `cmdk-root` / `cmdk-input` / … are marks the cmdk library puts on ITS OWN
-  // DOM. Not prop pass-through.
-  'cmdk-',
-];
-
-/** Global HTML attributes, legitimate on any element. */
-const GLOBAL_HTML_ATTRIBUTES = new Set([
-  'id', 'class', 'style', 'title', 'lang', 'dir', 'hidden', 'tabindex', 'role',
-  'slot', 'part', 'exportparts', 'itemid', 'itemprop', 'itemref', 'itemscope',
-  'itemtype', 'translate', 'draggable', 'spellcheck', 'autocapitalize',
-  'autocorrect', 'contenteditable', 'enterkeyhint', 'inputmode', 'accesskey',
-  'nonce', 'is', 'popover', 'inert', 'autofocus',
-]);
-
-/** Attributes whose IDL property is spelled too differently to match by case. */
-const ATTRIBUTE_TO_IDL_ALIAS: Record<string, string> = {
-  'class': 'className',
-  'for': 'htmlFor',
-  'accept-charset': 'acceptCharset',
-  'http-equiv': 'httpEquiv',
-};
-
-/** MEASURED gaps in happy-dom's IDL — standard attributes it does not reflect. */
-const HAPPY_DOM_IDL_GAPS: Record<string, Set<string>> = {
-  select: new Set(['size']),
-  option: new Set(['label']),
-  textarea: new Set(['wrap']),
-  col: new Set(['span']),
-  colgroup: new Set(['span']),
-};
-
-/**
- * SVG needs its own list: the reflection trick does not hold for SVG under
- * happy-dom, and lucide icons put a fixed set of presentation attributes on
- * every icon. Recharts adds a few more of its own.
- */
-const SVG_ATTRIBUTES = new Set([
-  'xmlns', 'xmlns:xlink', 'version', 'viewbox', 'preserveaspectratio',
-  'width', 'height', 'x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx',
-  'ry', 'd', 'points', 'transform', 'fill', 'fill-rule', 'fill-opacity',
-  'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
-  'stroke-dasharray', 'stroke-dashoffset', 'stroke-opacity', 'opacity',
-  'clip-path', 'clip-rule', 'mask', 'offset', 'stop-color', 'stop-opacity',
-  'gradientunits', 'gradienttransform', 'patternunits', 'text-anchor',
-  'dominant-baseline', 'font-size', 'font-family', 'font-weight',
-  'vector-effect', 'shape-rendering', 'focusable', 'overflow', 'color',
-  'orient', 'refx', 'refy', 'markerwidth', 'markerheight', 'markerunits',
-  'patterncontentunits', 'spreadmethod', 'gradientscale', 'pathlength',
-]);
-
-/** Lowercased IDL property names on a tag's prototype chain, cached per tag. */
-const idlCache = new Map<string, Set<string>>();
-
-function idlPropertiesFor(tagName: string): Set<string> {
-  const tag = tagName.toLowerCase();
-  const cached = idlCache.get(tag);
-  if (cached) return cached;
-
-  const names = new Set<string>();
-  const element = document.createElement(tag);
-  for (const own of Object.getOwnPropertyNames(element)) names.add(own.toLowerCase());
-  for (
-    let proto = Object.getPrototypeOf(element);
-    proto && proto !== Object.prototype;
-    proto = Object.getPrototypeOf(proto)
-  ) {
-    for (const name of Object.getOwnPropertyNames(proto)) names.add(name.toLowerCase());
-  }
-  idlCache.set(tag, names);
-  return names;
-}
-
-/**
- * The rule: an attribute is legitimate when HTML/SVG defines it for that
- * element, or when it belongs to an open family. The reflection check covers
- * `readonly`/`maxlength`/`colspan` and every other per-tag attribute
- * automatically instead of a hand-kept table that would rot.
- */
-function isKnownAttribute(element: Element, attribute: string): boolean {
-  const name = attribute.toLowerCase();
-
-  if (OPEN_PREFIXES.some((prefix) => name.startsWith(prefix))) return true;
-
-  // Inline event handlers reflect as IDL properties on every element; React
-  // never emits them as attributes, so one reaching the DOM means a
-  // handler-shaped prop was stringified onto it. Treat as a leak.
-  if (name.startsWith('on')) return false;
-
-  const tag = element.tagName.toLowerCase();
-
-  if (element.namespaceURI === 'http://www.w3.org/2000/svg') {
-    return SVG_ATTRIBUTES.has(name) || GLOBAL_HTML_ATTRIBUTES.has(name);
-  }
-
-  if (GLOBAL_HTML_ATTRIBUTES.has(name)) return true;
-  if (HAPPY_DOM_IDL_GAPS[tag]?.has(name)) return true;
-
-  const idl = idlPropertiesFor(tag);
-  const alias = ATTRIBUTE_TO_IDL_ALIAS[name];
-  if (alias && idl.has(alias.toLowerCase())) return true;
-  return idl.has(name);
-}
-
-interface Leak {
-  tag: string;
-  attribute: string;
-  value: string;
-  outerHTML: string;
-}
-
-/** Every unexplained attribute on `root` and its descendants. */
-function findLeaks(root: Element): Leak[] {
-  const leaks: Leak[] = [];
-  const elements: Element[] = [root, ...Array.from(root.querySelectorAll('*'))];
-  for (const element of elements) {
-    for (const attribute of Array.from(element.attributes)) {
-      if (isKnownAttribute(element, attribute.name)) continue;
-      leaks.push({
-        tag: element.tagName.toLowerCase(),
-        attribute: attribute.name,
-        value: attribute.value.slice(0, 80),
-        outerHTML: element.outerHTML.slice(0, 300),
-      });
-    }
-  }
-  return leaks;
-}
-
-/** Renders findings as the assertion's "actual", so a failure names everything. */
-function leakReport(target: string, leaks: Leak[]): string {
-  if (leaks.length === 0) return '';
-  const lines = leaks.map(
-    (leak) =>
-      `  <${leak.tag}> leaked ${leak.attribute}="${leak.value}"\n` +
-      `      in: ${leak.outerHTML}`,
-  );
-  return `${target} leaked ${leaks.length} non-DOM attribute(s):\n${lines.join('\n')}`;
-}
+// The attribute judge, shared with `packages/fields`' gate (objectui#4434).
+// Its calibration fixtures live next to it and prove it for both gates.
+import { findLeaks, leakReport } from '@object-ui/test-support';
+import type { Leak } from '@object-ui/test-support';
 
 /* ════════════════════════════════════════════════════════════════════════════
  * The canaries
@@ -660,70 +522,24 @@ afterEach(() => {
 });
 
 /* ════════════════════════════════════════════════════════════════════════════
- * 1. The judge proves itself, BEFORE it is trusted on the sweep
+ * 1. The judge proves itself — in `@object-ui/test-support`, not here
  * ══════════════════════════════════════════════════════════════════════════ */
 
-/** Ordinary, correct markup — several attributes whose IDL name differs. */
-const CLEAN_FIXTURE = `
-  <div id="root" class="a b" title="t" role="group" tabindex="0" hidden
-       data-testid="x" aria-label="l" data-state="open">
-    <input type="text" name="n" value="v" placeholder="p" readonly maxlength="5" />
-    <textarea rows="3" cols="4" wrap="soft" readonly></textarea>
-    <select size="2" multiple><option label="L" value="v" selected></option></select>
-    <button type="button" disabled formnovalidate value="on">b</button>
-    <label for="root">l</label>
-    <table><colgroup><col span="2" /></colgroup><tbody><tr>
-      <td colspan="2" rowspan="1" headers="h"></td></tr></tbody></table>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
-         fill="none" stroke="currentColor" stroke-width="2" class="icon">
-      <path d="M0 0h24v24H0z" /></svg>
-  </div>
-`;
-
-/** Every planted attribute here MUST be reported. */
-const PLANTED_LEAKS: ReadonlyArray<readonly [string, string]> = [
-  ['schema', '[object Object]'],
-  ['events', '[object Object]'],
-  ['bind', 'data.revenue'],
-  ['props', '[object Object]'],
-  ['arialabel', 'Canary label'],
-  ['ariadescribedby', 'canary-desc'],
-  ['datasource', '[object Object]'],
-  ['colorvariant', 'success'],
-  ['zzcanary', 'CANARY-STR'],
-  ['zzcanaryobj', '[object Object]'],
-  ['zzcanarynum', '42'],
-  ['zzcanarycamel', 'CANARY-CAMEL'],
-  ['reference_to', 'contacts'],
-];
-
-describe('the leak judge is calibrated (objectui#3291 / #4425)', () => {
-  it('reports NOTHING on standard markup — no false positives', () => {
-    const host = document.createElement('div');
-    host.innerHTML = CLEAN_FIXTURE;
-    document.body.appendChild(host);
-    try {
-      const leaks = findLeaks(host);
-      expect(leaks.map((l) => `<${l.tag}> ${l.attribute}="${l.value}"`).join('\n')).toBe('');
-    } finally {
-      host.remove();
-    }
-  });
-
-  it('reports EVERY planted fake attribute — no false negatives', () => {
-    const host = document.createElement('div');
-    const planted = PLANTED_LEAKS.map(([name, value]) => `${name}="${value}"`).join(' ');
-    host.innerHTML = `<input type="text" name="n" ${planted} />`;
-    document.body.appendChild(host);
-    try {
-      const found = new Set(findLeaks(host).map((leak) => leak.attribute));
-      const missed = PLANTED_LEAKS.map(([name]) => name).filter((name) => !found.has(name));
-      expect(missed).toEqual([]);
-    } finally {
-      host.remove();
-    }
-  });
-});
+/**
+ * This section used to hold a calibration pair: standard markup that must
+ * yield zero findings, and planted fake attributes that must all be reported.
+ * Both moved to `packages/test-support/src/__tests__/dom-leak-judge.test.tsx`
+ * with the judge (objectui#4434), unioned with the `packages/fields` gate's
+ * pair — which is how the ten recharts SVG attributes THIS file contributed to
+ * the shared list finally got a clean-markup fixture behind them. The judge is
+ * still proven before it is trusted on the sweep; it is proven once, for both
+ * gates, instead of once per copy.
+ *
+ * What stays here is the calibration this gate alone can do: section 2 below,
+ * which proves the CANARIES reach a widget through the real `SchemaRenderer`
+ * path. That is a property of the harness, not of the judge, and no shared
+ * module can assert it.
+ */
 
 /* ════════════════════════════════════════════════════════════════════════════
  * 2. The canary MECHANISM proves itself, end to end through the real path

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@object-ui/test-support": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",

--- a/packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx
+++ b/packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx
@@ -50,17 +50,26 @@
  * 4. **This repo runs happy-dom, not jsdom** (`vitest.config.mts`), whose IDL
  *    coverage has real gaps — `select[size]`, `option[label]`, `textarea[wrap]`
  *    and `col[span]` are all standard HTML that happy-dom does not reflect.
- *    See {@link isKnownAttribute} for how the judge is built, and
- *    {@link HAPPY_DOM_IDL_GAPS} for each measured exception and its reason.
- *    Every one of those four was found BY the calibration fixture below, not
+ *    See `@object-ui/test-support`'s `dom-leak-judge` for how the judge is
+ *    built, and its `HAPPY_DOM_IDL_GAPS` for each measured exception and its
+ *    reason. Every one of those four was found BY a calibration fixture, not
  *    by guesswork.
  *
- * ## The judge proves itself
+ * ## The judge proves itself — next to the judge, not here
  *
- * Two fixtures run before the sweep: standard markup that must yield ZERO
- * findings, and markup with planted fake attributes that must ALL be found.
- * When a happy-dom upgrade changes IDL coverage, those fail loudly instead of
- * the sweep going quietly blind.
+ * `isKnownAttribute` / `findLeaks` / `leakReport` are imported from
+ * `@object-ui/test-support`, which is where they now live for BOTH DOM-leak
+ * gates (objectui#4434). They used to be defined in this file and copied into
+ * `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`, and the
+ * two copies had already drifted.
+ *
+ * The calibration fixtures moved with them: standard markup that must yield
+ * ZERO findings, and markup with planted fake attributes that must ALL be
+ * found, now unioned from both gates' fixtures and run once in
+ * `packages/test-support/src/__tests__/dom-leak-judge.test.tsx`. When a
+ * happy-dom upgrade changes IDL coverage, that fails loudly instead of this
+ * sweep going quietly blind — and it now fails in ONE place instead of needing
+ * to be discovered twice.
  *
  * ## Deliberate coverage boundary
  *
@@ -84,6 +93,11 @@ import { ComponentRegistry } from '@object-ui/core';
 // Module scope: pulls in the form renderer's registration side effect.
 import '@object-ui/components';
 import { SchemaRenderer } from '@object-ui/react';
+// The attribute judge, shared with `packages/app-shell`'s sweep gate
+// (objectui#4434). It used to be defined in this file and copied into that one;
+// its calibration fixtures now live next to it and prove it for both gates.
+// `@object-ui/test-support` is private and never published — see its README.
+import { findLeaks, leakReport } from '@object-ui/test-support';
 
 import { withFieldCarrier } from '../withFieldCarrier';
 import { FORM_FIELD_TYPES } from '../index';
@@ -130,263 +144,6 @@ import { QRCodeField } from '../widgets/QRCodeField';
 import { ObjectRefField } from '../widgets/ObjectRefField';
 import { FilterConditionField } from '../widgets/FilterConditionField';
 import { RecipientPickerField } from '../widgets/RecipientPickerField';
-
-/* ════════════════════════════════════════════════════════════════════════════
- * The judge: is this attribute one HTML actually defines?
- * ══════════════════════════════════════════════════════════════════════════ */
-
-/** Open families. `data-*` is the one open family the widget contract declares. */
-const OPEN_PREFIXES = [
-  'data-',
-  'aria-',
-  // `cmdk-root` / `cmdk-input` / `cmdk-list` … are marks the cmdk library puts
-  // on ITS OWN DOM. Not prop pass-through, and present on every cmdk-based
-  // picker (`object-ref`, `lookup`, …) the moment it renders.
-  'cmdk-',
-];
-
-/**
- * Global HTML attributes. Most are also IDL properties and would be caught by
- * the reflection check below; they are listed because a missing IDL for a
- * genuinely global attribute would otherwise read as a leak.
- */
-const GLOBAL_HTML_ATTRIBUTES = new Set([
-  'id', 'class', 'style', 'title', 'lang', 'dir', 'hidden', 'tabindex', 'role',
-  'slot', 'part', 'exportparts', 'itemid', 'itemprop', 'itemref', 'itemscope',
-  'itemtype', 'translate', 'draggable', 'spellcheck', 'autocapitalize',
-  'autocorrect', 'contenteditable', 'enterkeyhint', 'inputmode', 'accesskey',
-  'nonce', 'is', 'popover', 'inert', 'autofocus',
-]);
-
-/**
- * Attributes whose IDL property is spelled differently enough that the
- * case-insensitive reflection match below cannot find them.
- */
-const ATTRIBUTE_TO_IDL_ALIAS: Record<string, string> = {
-  'class': 'className',
-  'for': 'htmlFor',
-  'accept-charset': 'acceptCharset',
-  'http-equiv': 'httpEquiv',
-};
-
-/**
- * MEASURED gaps in happy-dom's IDL, kept deliberately tiny — each entry is an
- * attribute HTML defines that happy-dom's element does not reflect as a
- * property, so reflection alone would report it as a leak.
- */
-const HAPPY_DOM_IDL_GAPS: Record<string, Set<string>> = {
-  // `HTMLSelectElement.size` is standard; happy-dom does not define it.
-  select: new Set(['size']),
-  // `HTMLOptionElement.label` is standard; happy-dom does not define it.
-  option: new Set(['label']),
-  // `HTMLTextAreaElement.wrap` is standard; happy-dom does not define it.
-  textarea: new Set(['wrap']),
-  // `HTMLTableColElement.span` is standard; happy-dom does not define it.
-  col: new Set(['span']),
-  colgroup: new Set(['span']),
-};
-
-/**
- * SVG needs its own list: the reflection trick does NOT hold for SVG under
- * happy-dom (`SVGElement` reflects almost nothing), and lucide icons put a
- * fixed set of presentation attributes on every icon they render.
- */
-const SVG_ATTRIBUTES = new Set([
-  'xmlns', 'xmlns:xlink', 'version', 'viewbox', 'preserveaspectratio',
-  'width', 'height', 'x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx',
-  'ry', 'd', 'points', 'transform', 'fill', 'fill-rule', 'fill-opacity',
-  'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
-  'stroke-dasharray', 'stroke-dashoffset', 'stroke-opacity', 'opacity',
-  'clip-path', 'clip-rule', 'mask', 'offset', 'stop-color', 'stop-opacity',
-  'gradientunits', 'gradienttransform', 'patternunits', 'text-anchor',
-  'dominant-baseline', 'font-size', 'font-family', 'font-weight', 'vector-effect',
-  'shape-rendering', 'focusable', 'overflow', 'color',
-]);
-
-/** Lowercased IDL property names on a tag's prototype chain, cached per tag. */
-const idlCache = new Map<string, Set<string>>();
-
-function idlPropertiesFor(tagName: string): Set<string> {
-  const tag = tagName.toLowerCase();
-  const cached = idlCache.get(tag);
-  if (cached) return cached;
-
-  const names = new Set<string>();
-  const element = document.createElement(tag);
-  for (const own of Object.getOwnPropertyNames(element)) names.add(own.toLowerCase());
-  for (
-    let proto = Object.getPrototypeOf(element);
-    proto && proto !== Object.prototype;
-    proto = Object.getPrototypeOf(proto)
-  ) {
-    for (const name of Object.getOwnPropertyNames(proto)) names.add(name.toLowerCase());
-  }
-  idlCache.set(tag, names);
-  return names;
-}
-
-/**
- * The rule: an attribute is legitimate when HTML/SVG defines it for that
- * element, or when it belongs to an open family.
- *
- * The reflection check ("does the element's prototype chain carry a property
- * with this name, case-insensitively?") is what makes this maintainable — it
- * covers `readonly→readOnly`, `maxlength→maxLength`, `colspan→colSpan` and
- * every other per-tag attribute automatically, instead of a hand-kept table
- * per element type that would rot.
- */
-function isKnownAttribute(element: Element, attribute: string): boolean {
-  const name = attribute.toLowerCase();
-
-  if (OPEN_PREFIXES.some((prefix) => name.startsWith(prefix))) return true;
-
-  // Inline event handlers (`onclick`) reflect as IDL properties on every
-  // element; React never emits them as attributes, so reaching one means a
-  // handler-shaped prop was stringified onto the DOM. Treat as a leak.
-  if (name.startsWith('on')) return false;
-
-  const tag = element.tagName.toLowerCase();
-
-  if (element.namespaceURI === 'http://www.w3.org/2000/svg') {
-    return SVG_ATTRIBUTES.has(name) || GLOBAL_HTML_ATTRIBUTES.has(name);
-  }
-
-  if (GLOBAL_HTML_ATTRIBUTES.has(name)) return true;
-  if (HAPPY_DOM_IDL_GAPS[tag]?.has(name)) return true;
-
-  const idl = idlPropertiesFor(tag);
-  const alias = ATTRIBUTE_TO_IDL_ALIAS[name];
-  if (alias && idl.has(alias.toLowerCase())) return true;
-  return idl.has(name);
-}
-
-interface Leak {
-  tag: string;
-  attribute: string;
-  value: string;
-  outerHTML: string;
-}
-
-/** Every unexplained attribute on `root` and its descendants. */
-function findLeaks(root: Element): Leak[] {
-  const leaks: Leak[] = [];
-  const elements: Element[] = [root, ...Array.from(root.querySelectorAll('*'))];
-  for (const element of elements) {
-    for (const attribute of Array.from(element.attributes)) {
-      if (isKnownAttribute(element, attribute.name)) continue;
-      leaks.push({
-        tag: element.tagName.toLowerCase(),
-        attribute: attribute.name,
-        value: attribute.value,
-        outerHTML: element.outerHTML.slice(0, 400),
-      });
-    }
-  }
-  return leaks;
-}
-
-/**
- * Renders the finding as the assertion's "actual" value, so a failure names
- * the widget, the element, the attribute, its value and the markup. A 46-widget
- * sweep failing as `expected [] to equal [ …47 items ]` is unusable.
- */
-function leakReport(widgetType: string, variant: string, leaks: Leak[]): string {
-  if (leaks.length === 0) return '';
-  const lines = leaks.map(
-    (leak) =>
-      `  <${leak.tag}> leaked ${leak.attribute}="${leak.value}"\n` +
-      `      in: ${leak.outerHTML}`,
-  );
-  return (
-    `field:${widgetType} [${variant}] leaked ${leaks.length} non-DOM ` +
-    `attribute(s):\n${lines.join('\n')}`
-  );
-}
-
-/* ════════════════════════════════════════════════════════════════════════════
- * The judge proves itself, BEFORE it is trusted on 46 widgets
- * ══════════════════════════════════════════════════════════════════════════ */
-
-/**
- * Ordinary, correct markup. Every attribute here is one HTML defines, several
- * chosen precisely because their IDL name differs from the attribute
- * (`readonly`/`maxlength`/`colspan`/`class`/`for`), plus the two happy-dom IDL
- * gaps (`select[size]`, `option[label]`) and a cmdk mark.
- */
-const CLEAN_FIXTURE = `
-  <div id="root" class="a b" title="t" role="group" tabindex="0" hidden
-       data-testid="x" aria-label="l" data-state="open">
-    <input type="text" name="n" value="v" placeholder="p" readonly maxlength="5"
-           minlength="1" required autofocus autocomplete="off" inputmode="text"
-           step="1" min="0" max="9" pattern=".*" list="dl" />
-    <textarea rows="3" cols="4" wrap="soft" readonly></textarea>
-    <select size="2" multiple><option label="L" value="v" selected></option></select>
-    <button type="button" disabled formnovalidate value="on">b</button>
-    <a href="#" target="_blank" rel="noopener" download hreflang="en"></a>
-    <label for="root">l</label>
-    <img src="s.png" alt="a" width="10" height="10" loading="lazy" decoding="async" />
-    <table><colgroup><col span="2" /></colgroup><tbody><tr>
-      <td colspan="2" rowspan="1" headers="h"></td></tr></tbody></table>
-    <div cmdk-root=""><div cmdk-list=""></div></div>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
-         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-         stroke-linejoin="round" class="icon"><path d="M0 0h24v24H0z" /></svg>
-  </div>
-`;
-
-/** Every planted attribute here MUST be reported. */
-const PLANTED_LEAKS: ReadonlyArray<readonly [string, string]> = [
-  // The renderer-only props that reached the DOM in the audit.
-  ['schema', '[object Object]'],
-  ['error', 'Title is required'],
-  ['emptyhint', 'Select country first'],
-  ['datasource', '[object Object]'],
-  ['dependentvalues', '[object Object]'],
-  ['dependson', 'country'],
-  ['inputtype', 'text'],
-  ['compact', 'true'],
-  ['onselectrecord', 'function'],
-  // The SDUI-only extra.
-  ['label', 'Title'],
-  // The open tail: arbitrary keys an author wrote on the field config.
-  ['zzcanary', 'CANARY-STR'],
-  ['zzcanaryobj', '[object Object]'],
-  ['zzcanarynum', '42'],
-  ['zzcanarycamel', 'CANARY-CAMEL'],
-  ['reference_to', 'contacts'],
-];
-
-describe('the leak judge is calibrated (objectui#3291)', () => {
-  it('reports NOTHING on standard markup — no false positives', () => {
-    const host = document.createElement('div');
-    host.innerHTML = CLEAN_FIXTURE;
-    document.body.appendChild(host);
-    try {
-      const leaks = findLeaks(host);
-      expect(
-        leaks.map((l) => `<${l.tag}> ${l.attribute}="${l.value}"`).join('\n'),
-      ).toBe('');
-    } finally {
-      host.remove();
-    }
-  });
-
-  it('reports EVERY planted fake attribute — no false negatives', () => {
-    const host = document.createElement('div');
-    const planted = PLANTED_LEAKS.map(([name, value]) => `${name}="${value}"`).join(' ');
-    // On an <input>, so nothing can be excused by a permissive container.
-    host.innerHTML = `<input type="text" name="n" ${planted} />`;
-    document.body.appendChild(host);
-    try {
-      const found = new Set(findLeaks(host).map((leak) => leak.attribute));
-      const missed = PLANTED_LEAKS.map(([name]) => name).filter((name) => !found.has(name));
-      expect(missed).toEqual([]);
-      expect(found.size).toBe(PLANTED_LEAKS.length);
-    } finally {
-      host.remove();
-    }
-  });
-});
 
 /* ════════════════════════════════════════════════════════════════════════════
  * Every registered field widget, both hosts
@@ -546,7 +303,7 @@ describe('no field widget leaks non-DOM props to the DOM (objectui#3291)', () =>
   it.each(types)('field:%s — form path, plain field', async (type) => {
     renderForm(fieldConfig(type), false);
     const row = await formRow();
-    expect(leakReport(type, 'form/plain', findLeaks(row))).toBe('');
+    expect(leakReport(`field:${type} [form/plain]`, findLeaks(row))).toBe('');
   });
 
   it.each(types)('field:%s — form path, author-written extra keys', async (type) => {
@@ -555,7 +312,7 @@ describe('no field widget leaks non-DOM props to the DOM (objectui#3291)', () =>
     // put on the field config arrives at the widget as a prop.
     renderForm(fieldConfig(type, AUTHORED_EXTRAS), false);
     const row = await formRow();
-    expect(leakReport(type, 'form/authored-extras', findLeaks(row))).toBe('');
+    expect(leakReport(`field:${type} [form/authored-extras]`, findLeaks(row))).toBe('');
   });
 
   it.each(types)('field:%s — form path, after a real validation failure', async (type) => {
@@ -572,7 +329,9 @@ describe('no field widget leaks non-DOM props to the DOM (objectui#3291)', () =>
       );
     });
 
-    expect(leakReport(type, 'form/validation-error', findLeaks(await formRow()))).toBe('');
+    expect(
+      leakReport(`field:${type} [form/validation-error]`, findLeaks(await formRow())),
+    ).toBe('');
   });
 
   it.each(types)('field:%s — SDUI path, plain node', async (type) => {
@@ -583,7 +342,7 @@ describe('no field widget leaks non-DOM props to the DOM (objectui#3291)', () =>
       <SchemaRenderer schema={{ ...fieldConfig(type), type: `field:${type}` } as any} />,
     );
     await waitFor(() => expect(container.firstElementChild).toBeTruthy());
-    expect(leakReport(type, 'sdui/plain', findLeaks(container))).toBe('');
+    expect(leakReport(`field:${type} [sdui/plain]`, findLeaks(container))).toBe('');
   });
 
   it.each(types)('field:%s — SDUI path, author-written extra keys', async (type) => {
@@ -593,6 +352,6 @@ describe('no field widget leaks non-DOM props to the DOM (objectui#3291)', () =>
       />,
     );
     await waitFor(() => expect(container.firstElementChild).toBeTruthy());
-    expect(leakReport(type, 'sdui/authored-extras', findLeaks(container))).toBe('');
+    expect(leakReport(`field:${type} [sdui/authored-extras]`, findLeaks(container))).toBe('');
   });
 });

--- a/packages/test-support/README.md
+++ b/packages/test-support/README.md
@@ -1,0 +1,57 @@
+# @object-ui/test-support
+
+Internal test-support modules shared between packages' test suites.
+
+**This package is `private: true` and is never published.** It exists so that
+two test suites in two different packages can share one implementation of
+something they both need, without that shared thing becoming public API of a
+released package.
+
+## Why it exists at all
+
+`packages/fields` and `packages/app-shell` each run a DOM-leak gate, and both
+needed the same "is this attribute one HTML actually defines" judge. Neither
+package can import the other's test file, so the judge was copied — and the two
+copies had already drifted apart by the time objectui#4434 was filed.
+
+The three constraints that ruled out every other home:
+
+- both `packages/fields` and `packages/app-shell` must be able to reach it;
+- it must **not** become published runtime API surface (which a `./test-support`
+  subpath export on a released package would be — an entry in a published
+  `exports` map is public API whatever it is named);
+- no unpublished deep-subpath imports. objectui#4325 ruled that shape out after
+  `@object-ui/fields/widgets/MarkdownContent` — a specifier only this repo's
+  vitest alias could resolve, `TS2882` for `tsc`, and unresolvable for anyone
+  outside the repo. A package's surface is its index, including this one.
+
+A private workspace package satisfies all three at once, and costs one
+`devDependency` line in each consumer.
+
+## What may live here
+
+Test *infrastructure* that more than one package's tests need: something both
+suites must agree on, where two copies drifting apart is the real risk.
+
+Not: fixtures for one package's own tests (those belong next to them, e.g.
+`packages/components/src/__tests__/test-utils.tsx`), and not anything shipped
+code imports — nothing in `src/` of a released package may import this.
+
+## Contents
+
+- `src/dom-leak-judge.ts` — the DOM-leak attribute judge: `isKnownAttribute`,
+  `findLeaks`, `leakReport`, the happy-dom IDL gap table, the SVG presentation
+  list and the open attribute families. Consumed by
+  `packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx` and
+  `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`.
+- `src/__tests__/dom-leak-judge.test.tsx` — the calibration fixtures that prove
+  the judge, once, for both gates.
+
+## Conventions
+
+- Consumers add `"@object-ui/test-support": "workspace:*"` to
+  **`devDependencies`** — never `dependencies`, since no consumer ships it.
+- Import the package root (`@object-ui/test-support`), never a deep path.
+- There is no build: consumers resolve the TypeScript source through the
+  `exports` map. `pnpm --filter @object-ui/test-support type-check` reads both
+  the modules and their tests in one program.

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@object-ui/test-support",
+  "version": "17.4.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "description": "Internal, never-published test-support modules shared by other packages' test suites",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/objectstack-ai/objectui.git",
+    "directory": "packages/test-support"
+  },
+  "bugs": {
+    "url": "https://github.com/objectstack-ai/objectui/issues"
+  }
+}

--- a/packages/test-support/src/__tests__/dom-leak-judge.test.tsx
+++ b/packages/test-support/src/__tests__/dom-leak-judge.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * THE JUDGE PROVES ITSELF — once, for every gate that imports it
+ * (objectui#4434).
+ *
+ * Two fixtures, and between them they are the whole reason the judge may be
+ * trusted by a gate that scans hundreds of elements:
+ *
+ *   - CLEAN: ordinary, correct markup that must yield ZERO findings. This is
+ *     the half that catches a happy-dom upgrade CHANGING IDL coverage — every
+ *     entry in `HAPPY_DOM_IDL_GAPS` and every attribute in `SVG_ATTRIBUTES`
+ *     that a gate relies on is exercised here, so an exception that stops being
+ *     needed, or a reflection that stops working, fails loudly instead of
+ *     quietly turning a sweep into noise.
+ *   - PLANTED: markup carrying fake attributes that must ALL be reported. This
+ *     is the half that catches the judge going blind — the failure mode where a
+ *     gate reports "no leaks" because it stopped being able to see any.
+ *
+ * ## These fixtures are the UNION of the two that used to exist
+ *
+ * Both gates carried their own calibration pair, and each only exercised the
+ * knowledge ITS gate happened to need:
+ *
+ *   - the fields pair (#3291) covered lucide's SVG attributes, `<a>`/`<img>`,
+ *     the cmdk marks and the four happy-dom IDL gaps it had measured, and
+ *     planted the field-renderer prop names;
+ *   - the sweep pair (#4425) covered a subset of that markup, and planted the
+ *     SDUI injection names (`schema`, `bind`, `events`, `props`, the camelCase
+ *     ARIA pair) instead.
+ *
+ * Unioning the judge without unioning the fixtures would have left the merged
+ * knowledge half-calibrated, and in one specific place it was calibrated by
+ * NOBODY: the ten recharts marker/gradient/pattern attributes the sweep added
+ * to `SVG_ATTRIBUTES` had no clean-markup fixture behind them in either file.
+ * They do now — see the `<defs>` block below.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findLeaks, isKnownAttribute } from '../dom-leak-judge';
+
+/**
+ * Ordinary, correct markup. Every attribute here is one HTML defines, several
+ * chosen precisely because their IDL name differs from the attribute
+ * (`readonly`/`maxlength`/`colspan`/`class`/`for`), plus every happy-dom IDL
+ * gap the judge excepts (`select[size]`, `option[label]`, `textarea[wrap]`,
+ * `col[span]`, `colgroup[span]`) and a cmdk mark.
+ *
+ * The `<svg>` block is deliberately two producers' markup: the lucide icon
+ * shape both gates have always rendered, and — inside `<defs>` — the recharts
+ * marker/gradient/pattern attributes that only the app-shell sweep renders.
+ */
+const CLEAN_FIXTURE = `
+  <div id="root" class="a b" title="t" role="group" tabindex="0" hidden
+       data-testid="x" aria-label="l" data-state="open">
+    <input type="text" name="n" value="v" placeholder="p" readonly maxlength="5"
+           minlength="1" required autofocus autocomplete="off" inputmode="text"
+           step="1" min="0" max="9" pattern=".*" list="dl" />
+    <textarea rows="3" cols="4" wrap="soft" readonly></textarea>
+    <select size="2" multiple><option label="L" value="v" selected></option></select>
+    <button type="button" disabled formnovalidate value="on">b</button>
+    <a href="#" target="_blank" rel="noopener" download hreflang="en"></a>
+    <label for="root">l</label>
+    <img src="s.png" alt="a" width="10" height="10" loading="lazy" decoding="async" />
+    <table><colgroup span="2"><col span="2" /></colgroup><tbody><tr>
+      <td colspan="2" rowspan="1" headers="h"></td></tr></tbody></table>
+    <div cmdk-root=""><div cmdk-list=""></div></div>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
+         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+         stroke-linejoin="round" class="icon">
+      <defs>
+        <marker orient="auto" refX="5" refY="5" markerWidth="10" markerHeight="10"
+                markerUnits="userSpaceOnUse"><path d="M0 0h4v4H0z" /></marker>
+        <linearGradient gradientUnits="userSpaceOnUse" spreadMethod="pad">
+          <stop offset="0%" stop-color="#000" stop-opacity="1" /></linearGradient>
+        <pattern patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" />
+      </defs>
+      <path d="M0 0h24v24H0z" pathLength="100" /></svg>
+  </div>
+`;
+
+/**
+ * Every planted attribute here MUST be reported — the union of what the two
+ * gates each planted, on one `<input>` so nothing can be excused by a
+ * permissive container.
+ */
+const PLANTED_LEAKS: ReadonlyArray<readonly [string, string]> = [
+  // ── The props a host INJECTS (#4425's sweep) ────────────────────────────
+  ['schema', '[object Object]'],
+  ['events', '[object Object]'],
+  ['bind', 'data.revenue'],
+  ['props', '[object Object]'],
+  ['arialabel', 'Canary label'],
+  ['ariadescribedby', 'canary-desc'],
+  ['datasource', '[object Object]'],
+  ['colorvariant', 'success'],
+  // ── The renderer-only props that reached the DOM in the #3291 audit ─────
+  ['error', 'Title is required'],
+  ['emptyhint', 'Select country first'],
+  ['dependentvalues', '[object Object]'],
+  ['dependson', 'country'],
+  ['inputtype', 'text'],
+  ['compact', 'true'],
+  ['onselectrecord', 'function'],
+  // The SDUI-only extra.
+  ['label', 'Title'],
+  // ── The open tail: arbitrary keys an author wrote on the node ───────────
+  ['zzcanary', 'CANARY-STR'],
+  ['zzcanaryobj', '[object Object]'],
+  ['zzcanarynum', '42'],
+  ['zzcanarycamel', 'CANARY-CAMEL'],
+  ['reference_to', 'contacts'],
+];
+
+describe('the DOM-leak judge is calibrated (objectui#3291 / #4425 / #4434)', () => {
+  it('reports NOTHING on standard markup — no false positives', () => {
+    const host = document.createElement('div');
+    host.innerHTML = CLEAN_FIXTURE;
+    document.body.appendChild(host);
+    try {
+      const leaks = findLeaks(host);
+      expect(
+        leaks.map((l) => `<${l.tag}> ${l.attribute}="${l.value}"`).join('\n'),
+      ).toBe('');
+    } finally {
+      host.remove();
+    }
+  });
+
+  it('reports EVERY planted fake attribute — no false negatives', () => {
+    const host = document.createElement('div');
+    const planted = PLANTED_LEAKS.map(([name, value]) => `${name}="${value}"`).join(' ');
+    // On an `<input>`, so nothing can be excused by a permissive container.
+    host.innerHTML = `<input type="text" name="n" ${planted} />`;
+    document.body.appendChild(host);
+    try {
+      const found = new Set(findLeaks(host).map((leak) => leak.attribute));
+      const missed = PLANTED_LEAKS.map(([name]) => name).filter((name) => !found.has(name));
+      expect(missed).toEqual([]);
+      // Exact count, not "at least": a judge that reported the whole element
+      // would also satisfy the line above.
+      expect(found.size).toBe(PLANTED_LEAKS.length);
+    } finally {
+      host.remove();
+    }
+  });
+
+  it('judges SVG by its own list, because reflection does not hold there', () => {
+    // The mechanism behind the `<defs>` block above, asserted directly: the
+    // recharts half of the union is SVG-namespaced markup, and `markerwidth`
+    // is not an IDL property of anything happy-dom builds. If this ever passes
+    // through reflection instead, the SVG list has stopped being load-bearing
+    // and the clean fixture would no longer be testing it.
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+    expect(isKnownAttribute(svg, 'markerWidth')).toBe(true);
+    expect(isKnownAttribute(svg, 'zzcanary')).toBe(false);
+
+    const div = document.createElement('div');
+    expect(isKnownAttribute(div, 'markerWidth')).toBe(false);
+  });
+});

--- a/packages/test-support/src/dom-leak-judge.ts
+++ b/packages/test-support/src/dom-leak-judge.ts
@@ -1,0 +1,259 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * THE DOM-LEAK JUDGE: is this attribute one HTML actually defines?
+ *
+ * One judge, shared by every DOM-leak gate in the repo (objectui#4434). It
+ * answers exactly one question — given an element and an attribute name, is
+ * that attribute something HTML/SVG defines for that element, or does it only
+ * exist because a non-DOM prop was spread onto the element? — and it knows
+ * nothing about widgets, canaries, targets or ledgers. Those stay in each gate.
+ *
+ * ## Why it lives here instead of in a test file
+ *
+ * It used to live twice, inline, in two test files that cannot import each
+ * other:
+ *
+ *   - `packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx` (#3291, the
+ *     original)
+ *   - `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx` (#4425
+ *     phase 1, the generalized sweep)
+ *
+ * The copies had ALREADY diverged when objectui#4434 was filed: the sweep's SVG
+ * list carried ten recharts presentation attributes the fields copy never
+ * needed, and the two `findLeaks` records truncated differently. What this
+ * module encodes is measured ENVIRONMENT fact — happy-dom's IDL gaps, the SVG
+ * presentation surface, the open attribute families — so it drifts whenever
+ * happy-dom, lucide or recharts is upgraded. Discovering that drift twice, in
+ * two places, is how one judge silently becomes two disagreeing judges.
+ *
+ * The knowledge below is therefore the UNION of the two copies, and the
+ * calibration fixtures that prove it live next door in
+ * `__tests__/dom-leak-judge.test.tsx` — once, rather than once per gate.
+ *
+ * ## Where the line is
+ *
+ * This module holds exactly what was DUPLICATED, and nothing else. Canary
+ * sets, target enumerations, readiness selectors, the sweep's leak ledger and
+ * every assertion stay in the gate that owns them — including helpers that
+ * only ever existed in one gate (`leakedAttributeNames` is the sweep's ledger
+ * unit and stays there). A judge that starts accumulating one gate's policy is
+ * back to being two judges wearing one name.
+ *
+ * ## The mechanism, and why it is reflection rather than a table
+ *
+ * The core check is IDL reflection: "does this element's prototype chain carry
+ * a property with this name, case-insensitively?". That covers
+ * `readonly→readOnly`, `maxlength→maxLength`, `colspan→colSpan` and every other
+ * per-tag attribute automatically, instead of a hand-kept table per element
+ * type that would rot. Everything else in this file is the measured exceptions
+ * where reflection alone gives the wrong answer.
+ */
+
+/**
+ * Open families. `data-*` is the one open family the widget contract declares.
+ */
+export const OPEN_PREFIXES: readonly string[] = [
+  'data-',
+  'aria-',
+  // `cmdk-root` / `cmdk-input` / `cmdk-list` … are marks the cmdk library puts
+  // on ITS OWN DOM. Not prop pass-through, and present on every cmdk-based
+  // picker (`object-ref`, `lookup`, …) the moment it renders.
+  'cmdk-',
+];
+
+/**
+ * Global HTML attributes, legitimate on any element. Most are also IDL
+ * properties and would be caught by the reflection check below; they are listed
+ * because a missing IDL for a genuinely global attribute would otherwise read
+ * as a leak.
+ */
+export const GLOBAL_HTML_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'id', 'class', 'style', 'title', 'lang', 'dir', 'hidden', 'tabindex', 'role',
+  'slot', 'part', 'exportparts', 'itemid', 'itemprop', 'itemref', 'itemscope',
+  'itemtype', 'translate', 'draggable', 'spellcheck', 'autocapitalize',
+  'autocorrect', 'contenteditable', 'enterkeyhint', 'inputmode', 'accesskey',
+  'nonce', 'is', 'popover', 'inert', 'autofocus',
+]);
+
+/**
+ * Attributes whose IDL property is spelled differently enough that the
+ * case-insensitive reflection match below cannot find them.
+ */
+export const ATTRIBUTE_TO_IDL_ALIAS: Readonly<Record<string, string>> = {
+  'class': 'className',
+  'for': 'htmlFor',
+  'accept-charset': 'acceptCharset',
+  'http-equiv': 'httpEquiv',
+};
+
+/**
+ * MEASURED gaps in happy-dom's IDL, kept deliberately tiny — each entry is an
+ * attribute HTML defines that happy-dom's element does not reflect as a
+ * property, so reflection alone would report it as a leak.
+ *
+ * Every one of these was found BY the calibration fixture next door, not by
+ * guesswork, and the fixture is what fails loudly when a happy-dom upgrade
+ * changes IDL coverage in either direction.
+ */
+export const HAPPY_DOM_IDL_GAPS: Readonly<Record<string, ReadonlySet<string>>> = {
+  // `HTMLSelectElement.size` is standard; happy-dom does not define it.
+  select: new Set(['size']),
+  // `HTMLOptionElement.label` is standard; happy-dom does not define it.
+  option: new Set(['label']),
+  // `HTMLTextAreaElement.wrap` is standard; happy-dom does not define it.
+  textarea: new Set(['wrap']),
+  // `HTMLTableColElement.span` is standard; happy-dom does not define it.
+  col: new Set(['span']),
+  colgroup: new Set(['span']),
+};
+
+/**
+ * SVG needs its own list: the reflection trick does NOT hold for SVG under
+ * happy-dom (`SVGElement` reflects almost nothing), and the icon/chart
+ * libraries put a fixed set of presentation attributes on the markup they
+ * render.
+ *
+ * Two producers, one list. The first block is what lucide icons emit — the
+ * only SVG the `packages/fields` gate ever renders. The second block is
+ * recharts' marker/gradient/pattern markup, which only the app-shell sweep
+ * renders; it is the divergence objectui#4434 was filed for, and the union is
+ * what makes one judge serve both gates.
+ */
+export const SVG_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'xmlns', 'xmlns:xlink', 'version', 'viewbox', 'preserveaspectratio',
+  'width', 'height', 'x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx',
+  'ry', 'd', 'points', 'transform', 'fill', 'fill-rule', 'fill-opacity',
+  'stroke', 'stroke-width', 'stroke-linecap', 'stroke-linejoin',
+  'stroke-dasharray', 'stroke-dashoffset', 'stroke-opacity', 'opacity',
+  'clip-path', 'clip-rule', 'mask', 'offset', 'stop-color', 'stop-opacity',
+  'gradientunits', 'gradienttransform', 'patternunits', 'text-anchor',
+  'dominant-baseline', 'font-size', 'font-family', 'font-weight',
+  'vector-effect', 'shape-rendering', 'focusable', 'overflow', 'color',
+  // recharts markup — the sweep-only half of the union (objectui#4434).
+  'orient', 'refx', 'refy', 'markerwidth', 'markerheight', 'markerunits',
+  'patterncontentunits', 'spreadmethod', 'gradientscale', 'pathlength',
+]);
+
+/** Lowercased IDL property names on a tag's prototype chain, cached per tag. */
+const idlCache = new Map<string, Set<string>>();
+
+function idlPropertiesFor(tagName: string): Set<string> {
+  const tag = tagName.toLowerCase();
+  const cached = idlCache.get(tag);
+  if (cached) return cached;
+
+  const names = new Set<string>();
+  const element = document.createElement(tag);
+  for (const own of Object.getOwnPropertyNames(element)) names.add(own.toLowerCase());
+  for (
+    let proto = Object.getPrototypeOf(element);
+    proto && proto !== Object.prototype;
+    proto = Object.getPrototypeOf(proto)
+  ) {
+    for (const name of Object.getOwnPropertyNames(proto)) names.add(name.toLowerCase());
+  }
+  idlCache.set(tag, names);
+  return names;
+}
+
+/**
+ * The rule: an attribute is legitimate when HTML/SVG defines it for that
+ * element, or when it belongs to an open family.
+ *
+ * The reflection check ("does the element's prototype chain carry a property
+ * with this name, case-insensitively?") is what makes this maintainable — it
+ * covers `readonly→readOnly`, `maxlength→maxLength`, `colspan→colSpan` and
+ * every other per-tag attribute automatically, instead of a hand-kept table
+ * per element type that would rot.
+ */
+export function isKnownAttribute(element: Element, attribute: string): boolean {
+  const name = attribute.toLowerCase();
+
+  if (OPEN_PREFIXES.some((prefix) => name.startsWith(prefix))) return true;
+
+  // Inline event handlers (`onclick`) reflect as IDL properties on every
+  // element; React never emits them as attributes, so reaching one means a
+  // handler-shaped prop was stringified onto the DOM. Treat as a leak.
+  if (name.startsWith('on')) return false;
+
+  const tag = element.tagName.toLowerCase();
+
+  if (element.namespaceURI === 'http://www.w3.org/2000/svg') {
+    return SVG_ATTRIBUTES.has(name) || GLOBAL_HTML_ATTRIBUTES.has(name);
+  }
+
+  if (GLOBAL_HTML_ATTRIBUTES.has(name)) return true;
+  if (HAPPY_DOM_IDL_GAPS[tag]?.has(name)) return true;
+
+  const idl = idlPropertiesFor(tag);
+  const alias = ATTRIBUTE_TO_IDL_ALIAS[name];
+  if (alias && idl.has(alias.toLowerCase())) return true;
+  return idl.has(name);
+}
+
+/** One unexplained attribute, with enough context to name it in a failure. */
+export interface Leak {
+  tag: string;
+  attribute: string;
+  value: string;
+  outerHTML: string;
+}
+
+/**
+ * How much of a leaked value and its markup a {@link Leak} record keeps.
+ *
+ * The two copies disagreed here and neither bound is load-bearing for any
+ * assertion — both gates assert on attribute NAMES, so these numbers only
+ * shape the failure message. The union takes the defensive answer on each
+ * axis: the value is BOUNDED (the fields copy kept it whole, and a leaked
+ * value can be an arbitrarily long serialized object), and the markup keeps
+ * the WIDER of the two bounds, because the markup is what tells you which
+ * element in a 46-widget sweep produced the finding.
+ */
+const VALUE_CHARS = 80;
+const OUTER_HTML_CHARS = 400;
+
+/** Every unexplained attribute on `root` and its descendants. */
+export function findLeaks(root: Element): Leak[] {
+  const leaks: Leak[] = [];
+  const elements: Element[] = [root, ...Array.from(root.querySelectorAll('*'))];
+  for (const element of elements) {
+    for (const attribute of Array.from(element.attributes)) {
+      if (isKnownAttribute(element, attribute.name)) continue;
+      leaks.push({
+        tag: element.tagName.toLowerCase(),
+        attribute: attribute.name,
+        value: attribute.value.slice(0, VALUE_CHARS),
+        outerHTML: element.outerHTML.slice(0, OUTER_HTML_CHARS),
+      });
+    }
+  }
+  return leaks;
+}
+
+/**
+ * Renders the findings as the assertion's "actual" value, so a failure names
+ * the element, the attribute, its value and the markup. A 46-widget sweep
+ * failing as `expected [] to equal [ …47 items ]` is unusable.
+ *
+ * `label` is whatever identifies the thing being scanned to the gate that owns
+ * it — the fields gate passes `field:<type> [<variant>]`, the app-shell sweep
+ * passes the registry type. Unifying on one label parameter is what let both
+ * call sites keep the exact message they produced before.
+ */
+export function leakReport(label: string, leaks: readonly Leak[]): string {
+  if (leaks.length === 0) return '';
+  const lines = leaks.map(
+    (leak) =>
+      `  <${leak.tag}> leaked ${leak.attribute}="${leak.value}"\n` +
+      `      in: ${leak.outerHTML}`,
+  );
+  return `${label} leaked ${leaks.length} non-DOM attribute(s):\n${lines.join('\n')}`;
+}

--- a/packages/test-support/src/index.ts
+++ b/packages/test-support/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/test-support` — the surface.
+ *
+ * This package is `private: true` and is never published, so this index is not
+ * public API; it is the ONE specifier other packages' test suites import. The
+ * indirection is the objectui#4325 lesson applied ahead of time: a deep
+ * subpath into another package (`@object-ui/fields/widgets/MarkdownContent`)
+ * resolved only through this repo's vitest alias, was TS2882 for `tsc`, and was
+ * ruled out rather than minted as permanent public API. A package's surface is
+ * its index — including this one.
+ */
+
+export {
+  ATTRIBUTE_TO_IDL_ALIAS,
+  GLOBAL_HTML_ATTRIBUTES,
+  HAPPY_DOM_IDL_GAPS,
+  OPEN_PREFIXES,
+  SVG_ATTRIBUTES,
+  findLeaks,
+  isKnownAttribute,
+  leakReport,
+} from './dom-leak-judge';
+export type { Leak } from './dom-leak-judge';

--- a/packages/test-support/tsconfig.json
+++ b/packages/test-support/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  // One project, covering BOTH the modules and their own tests — the shape
+  // `packages/fields` uses. This package emits nothing (no `build` script, no
+  // `outDir`, and the root config's `noEmit` is inherited): consumers import
+  // its TypeScript source directly through the `exports` map, because it is
+  // `private: true` and never published, so there is no `dist` for anyone to
+  // resolve and no published surface to keep stable.
+  //
+  // Because there is no build config to exclude tests from, there is also no
+  // second `tsconfig.test.json` to chain: `tsc --noEmit` reads
+  // `src/__tests__/dom-leak-judge.test.tsx` as part of the same program, which
+  // is what `scripts/check-type-check-coverage.mjs` asks of every package with
+  // test files.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,9 @@ importers:
       '@object-ui/plugin-view':
         specifier: workspace:*
         version: link:../plugin-view
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
@@ -1257,6 +1260,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -2732,6 +2738,12 @@ importers:
       '@objectstack/spec':
         specifier: ^17.0.0-rc.6
         version: 17.0.0-rc.6(ai@7.0.56(zod@4.4.3))
+
+  packages/test-support:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/types:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -276,6 +276,11 @@ export default defineConfig({
       '@object-ui/permissions': path.resolve(__dirname, './packages/permissions/src'),
       '@object-ui/collaboration': path.resolve(__dirname, './packages/collaboration/src'),
       '@object-ui/app-shell': path.resolve(__dirname, './packages/app-shell/src'),
+      // Private, never-published test-support package (objectui#4434). Aliased
+      // like every other workspace package so a test's import resolves to the
+      // same source file `tsc` reads through the package's `exports` map,
+      // rather than depending on how Vite treats a symlinked dependency.
+      '@object-ui/test-support': path.resolve(__dirname, './packages/test-support/src'),
       '@': path.resolve(__dirname, './packages/components/src'),
       '@object-ui/ui': path.resolve(__dirname, './packages/ui/src'),
     },


### PR DESCRIPTION
Closes #4434

The DOM-leak "is this attribute HTML-defined" judge existed in two copies, inline in two test files that cannot import each other. This extracts it once, carrying the **union** of what the two copies knew, and moves the calibration fixtures next to it so the judge proves itself once instead of once per copy.

Only the **judge** unifies. Each gate keeps its own canary sets, targets, readiness selectors, ledger and assertions — the only non-comment edits to either gate file are the import and, in the fields gate, five `leakReport` call sites re-spelled to the unified label parameter (they produce byte-identical messages).

## The home: measured, then chosen

**Measured first — there is no existing convention to follow.** Nothing in this repo ships shared test code across a package boundary today:

- no `./testing` / `./test-support` subpath in any `exports` map (`grep '"./test'` over every manifest: zero hits);
- the one test-helper module that exists, `packages/components/src/__tests__/test-utils.tsx`, is imported only by its own package's tests;
- zero cross-package relative imports from tests (`grep "from '../../../../"` over every `*.test.ts(x)`: zero hits);
- the only precedent is a **negative** one — #4325, which ruled out `@object-ui/fields/widgets/MarkdownContent`: a specifier only this repo's vitest alias could resolve, TS2882 for `tsc`, unresolvable outside the repo. A package's surface is its index.

So this implements the smallest sound convention, against the three constraints:

| constraint | private workspace package (chosen) | `./test-support` export on a released package |
|---|---|---|
| (a) reachable from `packages/fields` **and** `packages/app-shell` | yes — one `devDependency` line each | yes |
| (b) not published runtime API | **yes — `private: true`, never released** | **no — an entry in a published `exports` map is public API whatever it is named, and it has to ship in the tarball to resolve** |
| (c) no unpublished deep subpath | yes — bare `@object-ui/test-support`, resolved through its own `exports` map | yes |

Constraint (b) is what decides it, so: **`packages/test-support`, `@object-ui/test-support`, `private: true`**.

It resolves the same way for both toolchains, which is the #4325 lesson applied rather than restated:

- `tsc` — through the package `exports` map. Proof that this is not leaning on a repo-only alias: `packages/app-shell/tsconfig.test.json` sets `"paths": {}` precisely to force resolution through the workspace dependency, and `tsc -p tsconfig.test.json --listFiles` lists `packages/test-support/src/dom-leak-judge.ts` and `.../src/index.ts` as program inputs.
- vitest — an alias next to the other 40, so the test resolves the same file `tsc` reads instead of depending on how Vite treats a symlinked dependency.

Home wiring, all of it: the package manifest/tsconfig/README, one `devDependencies` line in each consumer, one vitest alias, and one `.changeset/config.json` `ignore` entry (a never-published package must not be versioned; `scripts/check-changeset-fixed.mjs` requires every workspace package to be classified as one or the other). Verified green: `check-type-check-coverage` (now 46/46 packages, 41 compiling their tests), `check-lint-coverage` (46/46), `check-changeset-fixed`, `check:phantom-deps`, and `changeset status` — the last one matters because changesets rejects a released package depending on an ignored one, and it does not fire here since that check excludes devDependencies.

## The divergence the union absorbed

Diffing the two judge blocks (`fields` lines 134-304 against `app-shell` lines 184-330 on the merge base) gives **three** real divergences; everything else is comment prose.

**1. The SVG presentation list — ten entries the sweep had and the fields copy did not.** This is the divergence the card was filed for: recharts markup the fields gate never renders.

```diff
-  'dominant-baseline', 'font-size', 'font-family', 'font-weight', 'vector-effect',
-  'shape-rendering', 'focusable', 'overflow', 'color',
+  'dominant-baseline', 'font-size', 'font-family', 'font-weight',
+  'vector-effect', 'shape-rendering', 'focusable', 'overflow', 'color',
+  'orient', 'refx', 'refy', 'markerwidth', 'markerheight', 'markerunits',
+  'patterncontentunits', 'spreadmethod', 'gradientscale', 'pathlength',
```

Union = the sweep's superset. Kept as a labelled second block, because the two halves have different producers (lucide icons vs. recharts) and will drift on different upgrades.

**2. `findLeaks` truncated its records differently.**

```diff
-        value: attribute.value,                          // fields: unbounded
-        outerHTML: element.outerHTML.slice(0, 400),
+        value: attribute.value.slice(0, 80),             // sweep: bounded
+        outerHTML: element.outerHTML.slice(0, 300),
```

Neither bound is load-bearing — both gates assert on attribute **names**, so these only shape the failure message. The union takes the defensive answer on each axis independently: the value is **bounded** at 80 (a leaked value can be an arbitrarily long serialized object), and the markup keeps the **wider** of the two bounds at 400 (the markup is what tells you which element in a 46-widget sweep produced the finding). Both are named constants with that reasoning next to them.

**3. `leakReport` had two signatures.**

```diff
-function leakReport(widgetType: string, variant: string, leaks: Leak[]): string   // fields
-function leakReport(target: string, leaks: Leak[]): string                        // sweep
+export function leakReport(label: string, leaks: readonly Leak[]): string
```

Unified on one `label`. The fields gate passes `` `field:${type} [${variant}]` ``, so **both gates emit byte-identical failure text to what they emitted before** — the message format was not changed, only where the label is assembled.

Everything else was identical in content: `OPEN_PREFIXES`, `GLOBAL_HTML_ATTRIBUTES`, `ATTRIBUTE_TO_IDL_ALIAS`, `HAPPY_DOM_IDL_GAPS` (all five entries), `idlPropertiesFor` and `isKnownAttribute` — the last two byte-for-byte.

**The calibration fixtures were also unioned**, and this is where the extraction paid for itself immediately: the fields fixture was the superset of markup, the sweep fixture planted the SDUI injection names, and the ten recharts SVG attributes above had a clean-markup fixture behind them in **neither** file. The merged CLEAN fixture now carries a `defs` block exercising all ten; the merged PLANTED list is 21 attributes (15 from fields, 13 from the sweep, 7 shared), with the fields copy's exact-count assertion kept.

## Red-first

The calibration fixtures are the mechanism that catches happy-dom / library drift, so they have to be shown failing. Both directions were run by deleting one entry from the shared judge and restoring it byte-identically afterwards (verified by `diff -q` against a pre-edit copy; no `git stash` involved).

**Direction 1 — delete the `select[size]` happy-dom IDL gap:**

```
AssertionError: expected '< select> size="2"' to be '' // Object.is equality
- Expected
+ Received
+ < select> size="2"

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

**Direction 2 — delete `markerwidth`, i.e. one of the ten union-only recharts entries** (the half that had no fixture behind it before this PR). Two cases go red, and the second one names the mechanism rather than the symptom:

```
× reports NOTHING on standard markup — no false positives
    AssertionError: expected '< marker> markerWidth="10"' to be ''
× judges SVG by its own list, because reflection does not hold there
    AssertionError: expected false to be true
      at expect(isKnownAttribute(svg, 'markerWidth')).toBe(true);
```

(The two angle brackets above carry a space so GitHub's body sanitizer does not eat them as HTML tags; the real assertion text has none.)

**Both gates green through the shared import**, full runs, repo-root vitest:

```
packages/fields/src/__tests__/widget-dom-leak-e2e.test.tsx     231 passed
packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx  37 passed
packages/test-support/src/__tests__/dom-leak-judge.test.tsx       3 passed
```

**No judge logic left inline.** Grepping both gate files for `isKnownAttribute|idlPropertiesFor|HAPPY_DOM_IDL_GAPS|SVG_ATTRIBUTES|OPEN_PREFIXES|GLOBAL_HTML_ATTRIBUTES|ATTRIBUTE_TO_IDL_ALIAS|function findLeaks|function leakReport|interface Leak` returns **only** docblock prose describing where the judge went — zero declarations. The sweep file keeps `leakedAttributeNames`, which was never duplicated: it is the ledger's unit, and it stays with the ledger.

## Verification

| command | result |
|---|---|
| `pnpm --filter '@object-ui/fields^...' --filter '@object-ui/app-shell^...' build` | dependency closure built first, clean |
| `pnpm exec vitest run packages/test-support/ packages/fields/ packages/app-shell/ --maxWorkers=2` | **445 files, 4795 passed, 1 skipped, 0 failed** |
| `pnpm run type-check` in `test-support` / `fields` / `app-shell` | all green, including app-shell's second project `tsc -p tsconfig.test.json` |
| `pnpm run lint` in the same three | 0 errors (warnings are the repo-wide pre-existing `no-explicit-any` set) |
| `node scripts/check-control-bytes.mjs` | OK, 4196 tracked text files |
| `check-type-check-coverage` / `check-lint-coverage` / `check-changeset-fixed` / `check:phantom-deps` / `check-changeset-no-major` / `check-doc-links` | all green |
| `pnpm exec vitest run scripts/` (after the `QUICK_REFERENCE.md` fix below) | 40 files, 916 passed |
| CI on `d006a001b` | converged, **0 failures** — Type Check, Lint, all four test shards, Build & E2E, Control Byte Scan and both changeset jobs green |

### One more piece of home wiring, found by CI

`scripts/__tests__/quick-reference-commands-4149.test.ts` requires `QUICK_REFERENCE.md`'s `packages/*` row to **name every private package** under `packages/`, so a published count smaller than the directory count is explained rather than "corrected" back to the directory count — which is how objectui#4149 happened. `packages/test-support` makes it the second such package, so the row now names it too. The published count is unchanged at 38; the new package is `private: true`, which is exactly the property that ratchet is measuring.

Second commit, one CI lap: the local run was scoped to the three affected packages, and this gate lives in `scripts/`.

## Surface

Touched: the two gate test files (import swap + the moved calibration block), the new `packages/test-support`, its home wiring (`.changeset/config.json`, `vitest.config.mts`, `QUICK_REFERENCE.md`, the two consumers' `devDependencies`, `pnpm-lock.yaml`), and one changeset.

Not touched: ledger rows, canary sets, target sets, `MetricWidget` / `schemaHostProps`, any renderer source, `console/**`, `plugin-calendar` source, chart files, `content/docs/releases/`.

## Note on the changeset

The card expected "test-only, so none owed". `scripts/check-changeset-presence.mjs` disagrees and it is right: it deliberately has **no carve-out for test files under `src/`**, so editing the two gate files under released packages demands a declaration. The answer it names — and calls "a pass, not a workaround" — is an **empty-frontmatter** changeset declaring that this releases nothing, which is what `.changeset/shared-dom-leak-judge.md` is. The gate now reports: *"Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate."*

No `skip-changeset` label was applied, because in this repo it does not exist: objectui#3724 deleted a doc page that described exactly that mechanism, recording that "neither the workflow nor the label was ever real". The empty-frontmatter changeset is this repo's mechanism.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
