### PR TITLE
fix(i18n): every date branch threads the active locale — future-relative and absolute forms localize (#4468)

### DIFF
--- a/.changeset/wild-pugs-tickle.md
+++ b/.changeset/wild-pugs-tickle.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/fields': patch
+'@object-ui/i18n': patch
+---
+
+fix(i18n): every date branch threads the active locale, so a `zh` session no longer renders half its dates in English
+
+Date rendering had two locale channels and only one followed the user's
+language, so the same row could read `逾期 6 天` in one column and `In 3 days`
+in the next, with a datetime column showing `8/11/2026 12:00 am`
+(objectui#4468).
+
+The overdue phrase resolves through the translate fn (the active UI language),
+while every `Intl` branch took its tag from the raw tenant locale
+(`useLocalization().locale`) — which is `undefined` on any workspace that never
+configured one, and `undefined` makes `Intl` use the *machine's* locale.
+`DateTimeCellRenderer` passed no tag at all.
+
+Every date-formatting site in `@object-ui/fields` now resolves through the one
+existing channel, `useDisplayLocale()` (tenant regional default → active UI
+language → `en`): `DateCellRenderer` (relative past, relative future, near-today
+and the beyond-±7-days absolute fallback), `DateTimeCellRenderer`, the read-only
+`DateField` / `DateTimeField` / `FormulaField` faces, and the sub-grid's
+temporal cells. English output is unchanged, and the already-localized overdue
+wording is untouched.
+
+No public signature changed. `@object-ui/i18n` carries a documentation
+correction only: `useDisplayLocale`'s docstring claimed `DateCellRenderer`
+already formatted from this channel, which was the very thing that was not true.

--- a/packages/fields/src/__tests__/DateCellRenderer.test.tsx
+++ b/packages/fields/src/__tests__/DateCellRenderer.test.tsx
@@ -52,6 +52,15 @@ describe('formatRelativeDate', () => {
   });
 });
 
+/**
+ * Nothing in this file mounts an `I18nProvider`, and that is load-bearing
+ * rather than incidental (objectui#4468): these cases are the pin on
+ * `useDisplayLocale()`'s LAST resort — the concrete `'en'` a renderer resolves
+ * to when neither a tenant locale nor an active UI language exists. The
+ * session-locale cases live in `date-locale-channel.test.tsx`; mounting a
+ * provider here would leave react-i18next's global instance on that language
+ * and quietly turn these into assertions about test ordering.
+ */
 describe('DateCellRenderer', () => {
   it('does not label a past start_date as "Overdue" (regression: field-role-agnostic formatter)', () => {
     render(<DateCellRenderer value={daysAgo(6)} field={{ type: 'date', name: 'start_date' } as any} />);

--- a/packages/fields/src/__tests__/date-locale-channel.test.tsx
+++ b/packages/fields/src/__tests__/date-locale-channel.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4468 — every date branch threads the ACTIVE locale.
+ *
+ * ── The measured split ───────────────────────────────────────────────────
+ * On a `zh` console the same task row rendered `逾期 6 天` in one column and
+ * `In 3 days` in the next, and the datetime column read `8/11/2026 12:00 am`.
+ * Not a missing translation: the field labels around it were fully Chinese.
+ *
+ * The cause is that the date renderers had TWO locale channels and only one
+ * of them followed the user's language:
+ *
+ *   - the OVERDUE phrase resolves through `useFieldTranslate()` → the ACTIVE
+ *     UI language → `逾期 6 天`;
+ *   - every `Intl` branch (relative past, relative future, the >±7d absolute
+ *     fallback) took its tag from `useLocalization().locale` — the TENANT's
+ *     regional default (ADR-0053), which is `undefined` on any workspace that
+ *     has not configured one. `Intl` with `undefined` reads the MACHINE's
+ *     locale, so those branches rendered en-US next to the Chinese one;
+ *   - `DateTimeCellRenderer` passed no tag at all, hence `8/11/2026 12:00 am`.
+ *
+ * The one resolver is `useDisplayLocale()` (tenant locale → active UI
+ * language → `'en'`), which `@object-ui/i18n` already owns and whose own
+ * docstring claimed `DateCellRenderer` "already formats from this channel" —
+ * it did not. `'zh'` is a valid BCP-47 tag, so there is no `'zh'`→`zh-CN`
+ * mapping anywhere: `useDisplayLocale()` IS the single mapping point.
+ *
+ * ── Directions ───────────────────────────────────────────────────────────
+ * Reverting the renderers to `origin/main` and keeping this file turns every
+ * `zh session` case RED and leaves every `en session` case GREEN. The `en`
+ * cases are green on BOTH sides on purpose — that is the must-not-change
+ * half: the English output has to be byte-identical after the change, since
+ * `'en'` and the CI machine's `en-US` agree on all of these forms.
+ *
+ * `已逾期`/`Overdue Nd` is likewise green on both sides: it never used the
+ * broken channel, and this file pins that the fix did not disturb it.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider, LocalizationProvider } from '@object-ui/i18n';
+import { DateCellRenderer, DateTimeCellRenderer } from '../index';
+import { DateField } from '../widgets/DateField';
+import { DateTimeField } from '../widgets/DateTimeField';
+import { FormulaField } from '../widgets/FormulaField';
+import { GridField } from '../widgets/GridField';
+
+/**
+ * `n` days from today, pinned to local noon so a run that starts near
+ * midnight can never land the value on the neighbouring day.
+ */
+function daysFromNow(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  d.setHours(12, 0, 0, 0);
+  return d.toISOString();
+}
+
+/**
+ * A fixed instant, built from LOCAL parts so the rendered day/time is the
+ * same in every timezone the suite might run in. This is the exact value
+ * shape the card captured: `8/11/2026 12:00 am` on an en machine.
+ */
+const FIXED_INSTANT = new Date(2026, 7, 11, 0, 0, 0).toISOString();
+
+/**
+ * A session: the UI language the user picked, plus the tenant's regional
+ * default (usually absent — the state the card was measured in).
+ *
+ * `persistLanguage={false}` keeps each case on its own language instead of
+ * inheriting whatever the previous one wrote to `localStorage`.
+ */
+function renderSession(
+  language: string,
+  node: React.ReactNode,
+  tenantLocale?: string,
+) {
+  return render(
+    <I18nProvider
+      config={{ defaultLanguage: language, detectBrowserLanguage: false }}
+      persistLanguage={false}
+    >
+      <LocalizationProvider value={{ locale: tenantLocale }}>{node}</LocalizationProvider>
+    </I18nProvider>,
+  );
+}
+
+const dateField = (name: string) => ({ type: 'date', name }) as any;
+
+afterEach(() => cleanup());
+
+describe('zh session — every date branch renders Chinese (objectui#4468)', () => {
+  it('future-relative: the branch the card caught as "In 3 days"', () => {
+    renderSession('zh', <DateCellRenderer value={daysFromNow(3)} field={dateField('end_date')} />);
+    expect(screen.getByText('3天后')).toBeInTheDocument();
+    expect(screen.queryByText('In 3 days')).not.toBeInTheDocument();
+  });
+
+  it('past-relative, non-due: the branch the card caught as "6 days ago"', () => {
+    renderSession('zh', <DateCellRenderer value={daysFromNow(-6)} field={dateField('start_date')} />);
+    expect(screen.getByText('6天前')).toBeInTheDocument();
+    expect(screen.queryByText('6 days ago')).not.toBeInTheDocument();
+  });
+
+  it('near-today: today / tomorrow / yesterday', () => {
+    renderSession('zh', <DateCellRenderer value={daysFromNow(0)} field={dateField('start_date')} />);
+    expect(screen.getByText('今天')).toBeInTheDocument();
+    cleanup();
+
+    renderSession('zh', <DateCellRenderer value={daysFromNow(1)} field={dateField('start_date')} />);
+    expect(screen.getByText('明天')).toBeInTheDocument();
+    cleanup();
+
+    renderSession('zh', <DateCellRenderer value={daysFromNow(-1)} field={dateField('start_date')} />);
+    expect(screen.getByText('昨天')).toBeInTheDocument();
+  });
+
+  it('absolute fallback beyond the ±7-day window', () => {
+    const value = daysFromNow(30);
+    // The formatter drops the year when it is the current one, so the
+    // expectation is built the same way rather than hardcoding a month that
+    // depends on the day this suite runs.
+    const d = new Date(value);
+    const sameYear = d.getFullYear() === new Date().getFullYear();
+    const expected = d.toLocaleDateString('zh', {
+      year: sameYear ? undefined : 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+    const enForm = d.toLocaleDateString('en', {
+      year: sameYear ? undefined : 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+
+    renderSession('zh', <DateCellRenderer value={value} field={dateField('start_date')} />);
+    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(screen.queryByText(enForm)).not.toBeInTheDocument();
+  });
+
+  it('absolute datetime: the branch the card caught as "8/11/2026 12:00 am"', () => {
+    const { container } = renderSession(
+      'zh',
+      <DateTimeCellRenderer value={FIXED_INSTANT} field={{ type: 'datetime', name: 'created_at' } as any} />,
+    );
+    expect(container.textContent).toContain('2026/8/11');
+    expect(container.textContent).toContain('上午12:00');
+    expect(container.textContent).not.toContain('8/11/2026');
+    expect(container.textContent).not.toContain('12:00 am');
+  });
+
+  it('read-only DateField / DateTimeField widgets', () => {
+    const { container } = renderSession(
+      'zh',
+      <DateField value={FIXED_INSTANT} onChange={() => {}} field={dateField('start_date')} readonly />,
+    );
+    expect(container.textContent).toContain('2026/8/11');
+    cleanup();
+
+    const dt = renderSession(
+      'zh',
+      <DateTimeField
+        value={FIXED_INSTANT}
+        onChange={() => {}}
+        field={{ type: 'datetime', name: 'created_at' } as any}
+        readonly
+      />,
+    );
+    expect(dt.container.textContent).toContain('2026/8/11');
+  });
+
+  /**
+   * The sub-grid (`GridField`) read-only face. Its cases live here rather than
+   * beside the rest of `widgets/GridField.test.tsx`: mounting an `I18nProvider`
+   * in that file changes what its later PROVIDER-LESS renders resolve, and one
+   * of them asserts a translated `aria-label`.
+   */
+  it('the sub-grid read-only table', () => {
+    const temporalField = {
+      columns: [
+        { field: 'merchant', label: 'Merchant', type: 'text' as const },
+        { field: 'incurred_on', label: 'Incurred On', type: 'date' as const },
+      ],
+    } as any;
+    renderSession(
+      'zh',
+      <GridField
+        value={[{ merchant: 'Chipotle', incurred_on: '2026-06-17T00:00:00.000Z' }]}
+        onChange={() => {}}
+        field={temporalField}
+        readonly
+      />,
+    );
+    const table = screen.getByTestId('line-items-readonly');
+    expect(table.textContent).toContain('2026/6/17');
+    expect(table.textContent).not.toContain('6/17/2026');
+  });
+
+  it('a formula field returning a date', () => {
+    const { container } = renderSession(
+      'zh',
+      <FormulaField
+        value={FIXED_INSTANT}
+        onChange={() => {}}
+        field={{ type: 'formula', name: 'computed_on', return_type: 'date' } as any}
+      />,
+    );
+    expect(container.textContent).toContain('2026/8/11');
+    expect(container.textContent).not.toContain('8/11/2026');
+  });
+});
+
+describe('en session — output is byte-identical (must-not-change)', () => {
+  it('future-relative', () => {
+    renderSession('en', <DateCellRenderer value={daysFromNow(3)} field={dateField('end_date')} />);
+    expect(screen.getByText('In 3 days')).toBeInTheDocument();
+  });
+
+  it('past-relative, non-due', () => {
+    renderSession('en', <DateCellRenderer value={daysFromNow(-6)} field={dateField('start_date')} />);
+    expect(screen.getByText('6 days ago')).toBeInTheDocument();
+  });
+
+  it('near-today', () => {
+    renderSession('en', <DateCellRenderer value={daysFromNow(0)} field={dateField('start_date')} />);
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    cleanup();
+
+    renderSession('en', <DateCellRenderer value={daysFromNow(1)} field={dateField('start_date')} />);
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument();
+    cleanup();
+
+    renderSession('en', <DateCellRenderer value={daysFromNow(-1)} field={dateField('start_date')} />);
+    expect(screen.getByText('Yesterday')).toBeInTheDocument();
+  });
+
+  it('absolute datetime', () => {
+    const { container } = renderSession(
+      'en',
+      <DateTimeCellRenderer value={FIXED_INSTANT} field={{ type: 'datetime', name: 'created_at' } as any} />,
+    );
+    expect(container.textContent).toContain('8/11/2026');
+    expect(container.textContent).toContain('12:00 am');
+  });
+
+  it('read-only DateField', () => {
+    const { container } = renderSession(
+      'en',
+      <DateField value={FIXED_INSTANT} onChange={() => {}} field={dateField('start_date')} readonly />,
+    );
+    expect(container.textContent).toContain('8/11/2026');
+  });
+});
+
+describe('the already-localized overdue branch is undisturbed (green both sides)', () => {
+  it('resolves through the translate fn, not through Intl — zh', () => {
+    renderSession('zh', <DateCellRenderer value={daysFromNow(-6)} field={dateField('due_date')} />);
+    const el = screen.getByText('逾期 6 天');
+    expect(el).toBeInTheDocument();
+    expect(el.className).toMatch(/text-red-600/);
+  });
+
+  it('resolves through the translate fn, not through Intl — en', () => {
+    renderSession('en', <DateCellRenderer value={daysFromNow(-6)} field={dateField('due_date')} />);
+    expect(screen.getByText('Overdue 6d')).toBeInTheDocument();
+  });
+});
+
+describe('channel precedence is unchanged (green both sides)', () => {
+  /**
+   * `useDisplayLocale()` puts the TENANT locale above the UI language: an org
+   * that configured `en` means it, even for a user reading Chinese chrome.
+   * This is the one case the old code got right, and it must survive.
+   */
+  it('an explicit tenant locale outranks the active UI language', () => {
+    renderSession('zh', <DateCellRenderer value={daysFromNow(3)} field={dateField('end_date')} />, 'en');
+    expect(screen.getByText('In 3 days')).toBeInTheDocument();
+    expect(screen.queryByText('3天后')).not.toBeInTheDocument();
+  });
+
+  /**
+   * The third step of the precedence — the provider-less `'en'` last resort —
+   * is pinned in `DateCellRenderer.test.tsx`, deliberately NOT here.
+   *
+   * It cannot be measured in this file: `useObjectTranslation()` outside a
+   * provider reports `i18n.language` from react-i18next's GLOBAL instance, and
+   * every `I18nProvider` mounted above leaves that global on the language it
+   * was given. So a provider-less render placed after these cases resolves
+   * `'zh'` — which is the state react-i18next is in, not the fallback under
+   * test. Written here it would assert a fact about test ordering.
+   *
+   * `DateCellRenderer.test.tsx` mounts no provider at all, so its
+   * `6 days ago` / `Overdue 6d` / `Tomorrow` cases ARE that pin, and they hold
+   * for the real reason.
+   */
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -814,7 +814,14 @@ export function BooleanCellRenderer({ value, field }: CellRendererProps): React.
  * Date field cell renderer
  */
 export function DateCellRenderer({ value, field }: CellRendererProps): React.ReactElement {
-  const { locale } = useLocalization();
+  // `useDisplayLocale()`, NOT `useLocalization().locale` (objectui#4468). The
+  // raw tenant locale is `undefined` on any workspace that never configured
+  // one, and `Intl` reads the MACHINE's locale from `undefined` — so a `zh`
+  // console rendered `逾期 6 天` (which resolves through `t`, the ACTIVE UI
+  // language) beside `In 3 days` and `6 days ago` (which resolve through
+  // `Intl`) on the SAME row. One channel for both halves, or the row
+  // disagrees with itself.
+  const locale = useDisplayLocale();
   const t = useFieldTranslate();
   if (!value) return <EmptyValue />;
   const safe = coerceToSafeValue(value);
@@ -851,17 +858,26 @@ export function DateCellRenderer({ value, field }: CellRendererProps): React.Rea
  * DateTime field cell renderer (Airtable-style with date and time visually separated)
  */
 export function DateTimeCellRenderer({ value }: CellRendererProps): React.ReactElement {
+  // Hook before every early return — a value flipping between null and set
+  // must not change the hook count between renders (same rule as the number /
+  // currency renderers above). This is the site objectui#4468 caught rendering
+  // `8/11/2026 12:00 am` inside an otherwise Chinese grid: both calls passed
+  // `undefined`, i.e. the machine's locale, on every session.
+  const locale = useDisplayLocale();
   if (!value) return <EmptyValue />;
   const safe = coerceToSafeValue(value);
   const date = safe != null ? new Date(safe as string | number) : null;
   if (date === null || isNaN(date.getTime())) return <EmptyValue />;
 
-  const datePart = date.toLocaleDateString(undefined, {
+  const datePart = date.toLocaleDateString(locale, {
     month: 'numeric',
     day: 'numeric',
     year: 'numeric',
   });
-  const timePart = date.toLocaleTimeString(undefined, {
+  // `hour12` stays declared: this is the compact Airtable-style cell, and the
+  // 12-hour face is its design, not a locale artefact. Locales that write no
+  // am/pm marker simply ignore it.
+  const timePart = date.toLocaleTimeString(locale, {
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,

--- a/packages/fields/src/widgets/DateField.tsx
+++ b/packages/fields/src/widgets/DateField.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
+import { useDisplayLocale } from '@object-ui/i18n';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { openNativePicker } from './openNativePicker';
@@ -10,8 +11,12 @@ import { toDateInputValue } from './nativeDateValue';
  * Uses native date input and displays locale-formatted date in readonly mode
  */
 export function DateField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
+  // Before the readonly early return: the hook count must not depend on a prop
+  // (objectui#4468). A bare `toLocaleDateString()` reads the MACHINE's locale,
+  // which is how a Chinese form ended up with an `8/11/2026` value in it.
+  const locale = useDisplayLocale();
   if (readonly) {
-    return value ? <span className="text-sm">{new Date(value).toLocaleDateString()}</span> : <EmptyValue />;
+    return value ? <span className="text-sm">{new Date(value).toLocaleDateString(locale)}</span> : <EmptyValue />;
   }
 
   const domProps = toDomProps(props);

--- a/packages/fields/src/widgets/DateTimeField.tsx
+++ b/packages/fields/src/widgets/DateTimeField.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
+import { useDisplayLocale } from '@object-ui/i18n';
 import { FieldWidgetComponentProps } from './types';
 import { toDomProps } from './toDomProps';
 import { openNativePicker } from './openNativePicker';
@@ -10,12 +11,16 @@ import { toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue'
  * Displays both date and time in locale format when readonly
  */
 export function DateTimeField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
+  // Before the readonly early return — the hook count must not depend on a
+  // prop. See DateField for why the bare `toLocale*` calls were wrong
+  // (objectui#4468).
+  const locale = useDisplayLocale();
   if (readonly) {
     if (!value) return <EmptyValue />;
     const date = new Date(value);
     return (
       <span className="text-sm">
-        {date.toLocaleDateString()} {date.toLocaleTimeString()}
+        {date.toLocaleDateString(locale)} {date.toLocaleTimeString(locale)}
       </span>
     );
   }

--- a/packages/fields/src/widgets/FormulaField.tsx
+++ b/packages/fields/src/widgets/FormulaField.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { EmptyValue } from '@object-ui/components';
+import { useDisplayLocale } from '@object-ui/i18n';
 import { FieldWidgetComponentProps } from './types';
 
 /**
@@ -7,6 +8,10 @@ import { FieldWidgetComponentProps } from './types';
  * Values are computed on the backend and cannot be edited
  */
 export function FormulaField({ value, field, ...props }: FieldWidgetComponentProps<any>) {
+  // Before the empty-value early return — the hook count must not change when
+  // a value flips between null and set. A `date` return type used to format
+  // through the MACHINE's locale (objectui#4468).
+  const locale = useDisplayLocale();
   const formulaField = field as any;
   const returnType = formulaField?.return_type || 'text';
 
@@ -20,7 +25,7 @@ export function FormulaField({ value, field, ...props }: FieldWidgetComponentPro
   } else if (returnType === 'boolean') {
     displayValue = value ? 'Yes' : 'No';
   } else if (returnType === 'date') {
-    displayValue = new Date(value).toLocaleDateString();
+    displayValue = new Date(value).toLocaleDateString(locale);
   } else {
     displayValue = String(value);
   }

--- a/packages/fields/src/widgets/GridField.test.tsx
+++ b/packages/fields/src/widgets/GridField.test.tsx
@@ -293,9 +293,15 @@ describe('GridField / LineItemsField — editable line items', () => {
      */
     describe('read-only display formats each temporal type as itself', () => {
       const row = { merchant: 'Chipotle', incurred_on: '2026-06-17T00:00:00.000Z', incurred_at: STORED_ISO, started_at: '14:30' };
-      const expectedDay = new Date(2026, 5, 17).toLocaleDateString();
+      // Spelled `'en'` rather than bare `toLocaleDateString()` (objectui#4468):
+      // the bare call reads the MACHINE's locale, so these pins agreed with the
+      // widget only by the accident of a CI runner set to en-US — and they
+      // would have kept agreeing with it after the widget started following the
+      // session locale, which is the bug this suite has to be able to see.
+      // `'en'` is what `useDisplayLocale()` resolves to with no provider.
+      const expectedDay = new Date(2026, 5, 17).toLocaleDateString('en');
       const dt = new Date(STORED_ISO);
-      const expectedInstant = `${dt.toLocaleDateString()} ${dt.toLocaleTimeString()}`;
+      const expectedInstant = `${dt.toLocaleDateString('en')} ${dt.toLocaleTimeString('en')}`;
 
       it('formats date / datetime / time in the read-only table', () => {
         render(<GridField value={[row]} onChange={() => {}} field={temporalField} readonly />);
@@ -323,6 +329,13 @@ describe('GridField / LineItemsField — editable line items', () => {
         );
         expect(screen.getByTestId('line-items-readonly').textContent).toContain('not-a-date');
       });
+
+      // The `zh` half of this — the sub-grid following the SESSION locale
+      // (objectui#4468) — lives in `__tests__/date-locale-channel.test.tsx`,
+      // not here. Mounting an `I18nProvider` anywhere in THIS file changes what
+      // the provider-less renders further down resolve, and the file-columns
+      // chip test reads a translated `aria-label`; keeping the provider in its
+      // own file keeps that coupling out of the way.
     });
   });
 

--- a/packages/fields/src/widgets/GridField.tsx
+++ b/packages/fields/src/widgets/GridField.tsx
@@ -17,6 +17,7 @@ import {
 } from '@object-ui/components';
 import { Plus, Trash2, SlidersHorizontal, Maximize2, Copy, GripVertical } from 'lucide-react';
 import { resolveFieldRuleState } from '@object-ui/core';
+import { useDisplayLocale } from '@object-ui/i18n';
 import { LookupField } from './LookupField';
 import { FileCell } from './FileField';
 import { toDateInputValue, toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue';
@@ -290,27 +291,31 @@ const isTemporal = (t?: string) => t === 'date' || t === 'datetime' || t === 'ti
  *
  * An unparseable value falls through to its raw string rather than rendering
  * "Invalid Date" — showing the user what is actually stored beats hiding it.
+ *
+ * `locale` is threaded rather than left to `Intl`'s default (objectui#4468):
+ * the default is the MACHINE's locale, which has nothing to do with the
+ * session, so a Chinese form rendered `6/17/2026` in its line items.
  */
-function temporalText(type: string | undefined, value: any): string {
+function temporalText(type: string | undefined, value: any, locale: string): string {
   const raw = String(value);
   if (type === 'time') return raw;
   if (type === 'date') {
     const ymd = toDateInputValue(value);
     if (!ymd) return raw;
     const [y, m, d] = ymd.split('-').map(Number);
-    return new Date(y, m - 1, d).toLocaleDateString();
+    return new Date(y, m - 1, d).toLocaleDateString(locale);
   }
   const dt = value instanceof Date ? value : new Date(raw);
   if (Number.isNaN(dt.getTime())) return raw;
-  return `${dt.toLocaleDateString()} ${dt.toLocaleTimeString()}`;
+  return `${dt.toLocaleDateString(locale)} ${dt.toLocaleTimeString(locale)}`;
 }
 
 /** Read-only display text for a cell in list mode (select → option label,
  *  currency/number → formatted, date/datetime/time → localized, empty → em
  *  dash). Lookups render separately. */
-function displayText(c: GridColumn, value: any): string {
+function displayText(c: GridColumn, value: any, locale: string): string {
   if (value === null || value === undefined || value === '') return '—';
-  if (isTemporal(c.type)) return temporalText(c.type, value);
+  if (isTemporal(c.type)) return temporalText(c.type, value, locale);
   if (c.type === 'file') {
     const files = Array.isArray(value) ? value : [value];
     if (files.length === 0) return '—';
@@ -389,6 +394,10 @@ export function GridField({
   const allColumns: GridColumn[] = cfg.columns || [];
   const rows: Row[] = Array.isArray(value) ? value : [];
   const contextRecord = props.contextRecord;
+  // The one locale channel every field renderer resolves through: tenant
+  // regional default → active UI language → 'en' (objectui#4468). Read here
+  // and passed down, since `displayText` is a pure helper.
+  const displayLocale = useDisplayLocale();
 
   // Per-cell CEL rule state (B2 in grids). A column with no readonlyWhen/
   // requiredWhen resolves to its static flags (cheap fast-path — no engine
@@ -693,7 +702,7 @@ export function GridField({
                         // for a date, and for a datetime it would ALSO have been
                         // wrong to render as a bare day (objectui#3569). Now that
                         // the three types are distinct, each formats as itself.
-                        displayText(c, row[c.field])
+                        displayText(c, row[c.field], displayLocale)
                       ) : row[c.field] != null && row[c.field] !== '' ? (
                         String(row[c.field])
                       ) : (
@@ -753,7 +762,7 @@ export function GridField({
       }
       return (
         <span className={cn('px-2 text-sm text-foreground', isNumeric(c.type) && 'tabular-nums', (val == null || val === '') && 'text-muted-foreground')}>
-          {displayText(c, val)}
+          {displayText(c, val, displayLocale)}
         </span>
       );
     }
@@ -765,7 +774,7 @@ export function GridField({
           title="Computed"
           data-computed={c.field}
         >
-          {displayText(c, val)}
+          {displayText(c, val, displayLocale)}
         </span>
       );
     }

--- a/packages/i18n/src/useDisplayLocale.ts
+++ b/packages/i18n/src/useDisplayLocale.ts
@@ -19,8 +19,7 @@ import { useObjectTranslation } from './provider';
  *  1. **`useLocalization().locale`** — the tenant's resolved regional default
  *     (ADR-0053, served by `GET /api/v1/auth/me/localization`). An org that has
  *     explicitly configured a display locale means it, so it outranks the UI
- *     language, and this keeps numbers agreeing with `DateCellRenderer`, which
- *     already formats from this channel. Frequently `undefined`: the endpoint is
+ *     language. Frequently `undefined`: the endpoint is
  *     cosmetic and non-blocking, so an unconfigured or still-loading tenant
  *     simply has no answer here (the state objectui#4033 was measured in — a
  *     fresh database, console running `zh-CN`).
@@ -41,6 +40,15 @@ import { useObjectTranslation } from './provider';
  * Provider-safe at every step: `useLocalization` returns `{}` outside its
  * provider and `useObjectTranslation` reads an optional context, so a renderer
  * mounted standalone (tests, docs demos) degrades instead of throwing.
+ *
+ * **This composition is also the whole `'zh'` ↔ BCP-47 story** (objectui#4468).
+ * There is no mapping table anywhere and none is needed: the UI language codes
+ * this renderer ships (`'zh'`, `'ja'`, `'de'`, …) are already well-formed
+ * BCP-47 language subtags, so `Intl` accepts them verbatim. The one thing a
+ * caller must not do is reach past this hook for the raw tenant locale and hand
+ * `Intl` the `undefined` it gets on an unconfigured workspace — `undefined`
+ * means "the MACHINE's locale", which is neither channel. Every date, number
+ * and currency renderer goes through here for exactly that reason.
  */
 export function useDisplayLocale(): string {
   const { locale } = useLocalization();


### PR DESCRIPTION
Closes #4468

On a `zh` session the same task row rendered `逾期 6 天` in one column and `In 3 days` in the next, with the datetime column reading `8/11/2026 12:00 am`. Not a missing translation — a second locale channel that nobody was following.

## 1. Census — every date-formatting site the affected surfaces reach

The console list / all-views pages render date columns through `getCellRenderer('date' | 'datetime')` in `@object-ui/fields`; the same records' detail and form faces go through the read-only field widgets. Column 3 is the locale each site threaded **before** this PR.

| # | Site | Branch | Locale threaded before | Disposition |
|---|---|---|---|---|
| 1 | `packages/fields/src/index.tsx:824` `DateCellRenderer` | relative past, relative future, near-today, and the beyond-±7d absolute fallback | `useLocalization().locale` — the **tenant** default only, `undefined` on an unconfigured workspace | **fixed** |
| 2 | `packages/fields/src/index.tsx:866` `DateTimeCellRenderer` | absolute date + time | none at all — both calls passed `undefined` | **fixed** |
| 3 | `packages/fields/src/widgets/DateField.tsx:17` (readonly) | absolute date | none | **fixed** |
| 4 | `packages/fields/src/widgets/DateTimeField.tsx:17` (readonly) | absolute date + time | none | **fixed** |
| 5 | `packages/fields/src/widgets/FormulaField.tsx:14` (`return_type: 'date'`) | absolute date | none | **fixed** |
| 6 | `packages/fields/src/widgets/GridField.tsx:400` sub-grid `temporalText` / `displayText` | absolute date, datetime | none | **fixed** |
| 7 | `packages/fields/src/index.tsx:506` `formatRelativeDays` | relative, both directions | `options.locale` — already correct | unchanged (it was never the defect; its **caller** was) |
| 8 | `packages/fields/src/index.tsx:555` `formatDate` default branch | absolute | `options.locale` — already correct | unchanged (same: fixed by site 1) |
| 9 | the overdue phrase, `fields.relativeDate.overdue` | relative past, due-like | `options.t` → the ACTIVE UI language | unchanged — this is the half that always worked |
| 10 | `packages/fields/src/index.tsx:562` `formatDate` `'short'` branch | absolute | hardcoded `'en-US'` | **reported, not fixed** — see §5 |
| 11 | `packages/fields/src/index.tsx:588` `formatDateTime` | absolute | none, and no parameter to give it one | **reported, not fixed** — see §5 |
| 12 | `packages/fields/src/widgets/RecordPickerDialog.tsx:863` `$date` fallback | absolute | none | **reported, not fixed** — see §5 |

### The mechanism the census exposes

There are two locale channels, and each half of a row was reading a different one:

- the overdue phrase resolves through `useFieldTranslate()` → the **active UI language** → `逾期 6 天`;
- every `Intl` branch took its tag from `useLocalization().locale` — the **tenant's regional default** (ADR-0053), which is `undefined` on any workspace that never configured one. `Intl` reads `undefined` as *the machine's locale*, so those branches rendered en-US beside the Chinese one. A language switch moves the i18next instance and never touches that channel, which is why switching to Chinese fixed the labels and not the dates.

## 2. One resolver

`useDisplayLocale()` in `@object-ui/i18n` already composes both channels with a documented precedence — tenant regional default → active UI language → `'en'` — and is already what every number and currency renderer uses. Every site above now resolves through it, so a date and the number beside it can no longer disagree.

Measured before adopting it, as the ruling asked:

- **The `'zh'` ↔ BCP-47 mapping lives in exactly one place, and that place is this hook** — because no mapping is needed. The UI language codes this renderer ships (`'zh'`, `'ja'`, `'de'`, …) are already well-formed BCP-47 language subtags, so `Intl` accepts them verbatim: `Intl.RelativeTimeFormat('zh', { numeric: 'auto' }).format(3, 'day')` is `3天后`, identical to what `'zh-CN'` produces. There is no table to centralize and none was added. The card's note that `'zh-CN'` is rejected by `isKnownLanguage()` is about the *language* channel's input, not about what `Intl` is handed.
- **The mechanism the localized half already used is the one that survives.** `formatRelativeDays` was already `Intl.RelativeTimeFormat`; the overdue phrase was already `t()`. Neither moved. The change is entirely in which tag reaches the first one.
- **Blast radius, measured before moving anything.** `useDisplayLocale()` is a hook, so each of the six sites had to be a component that could call it — all six are. No call site moved between modules, no exported signature changed, and the two module-private helpers that gained a `locale` parameter (`temporalText`, `displayText`) have three call sites, all inside `GridField` itself.
- **Existing pins moved: two, deliberately.** `GridField.test.tsx` pinned its temporal expectations with bare `toLocaleDateString()` / `toLocaleTimeString()` — i.e. against *the machine*. They agreed with the widget only because the runner is en-US, and they would have kept agreeing after the widget started following the session, which is precisely the bug they now need to be able to see. They are spelled `'en'` now — the value `useDisplayLocale()` resolves to with no provider — so the pin states what it means. No other existing expectation changed.

## 3. Red-first, per measured branch

Captured verbatim from the run against unmodified renderers, then re-measured after. Every `zh` case below was red before and green after; the reverse verification (reverting the five source files onto `origin/main` while keeping the tests) turns **exactly** these eight red again and nothing else.

| Branch | Before (verbatim) | After |
|---|---|---|
| future-relative | `In 3 days` | `3天后` |
| past-relative, non-due | `6 days ago` | `6天前` |
| near-today | `Today` | `今天` |
| absolute, beyond ±7d | `Sep 12` | `9月12日` |
| absolute datetime | `8/11/2026` + `12:00 am` | `2026/8/11` + `上午12:00` |
| readonly `DateField` | `8/11/2026` | `2026/8/11` |
| sub-grid read-only cell | `6/17/2026` | `2026/6/17` |
| formula field, date | `8/11/2026` | `2026/8/11` |

## 4. Must-not-change — green on **both** sides

- **English is byte-identical.** `In 3 days`, `6 days ago`, `Today`, `Tomorrow`, `Yesterday`, `8/11/2026`, `12:00 am` — asserted as literals, and green before and after. `'en'` and the runner's `en-US` agree on every one of these forms, which is why this is a pin rather than a hope.
- **The already-localized past/overdue branch is undisturbed**: `逾期 6 天` (zh) and `Overdue 6d` (en) still resolve through `t()`, not through `Intl`, and the overdue cell keeps its `text-red-600`.
- **Channel precedence is unchanged**: an explicit tenant locale still outranks the active UI language (`zh` chrome + tenant `en` → `In 3 days`).
- **`.d.ts` is byte-identical.** `packages/fields/dist/index.d.ts` hashes `f69dd0821892347bc4f8d69951ed587580046ec5ae043f1f0b8cb960853cb54f` both before and after — no public surface grew, hence `patch` and not `minor`. `@object-ui/i18n`'s diff is comment-only (a docstring in `useDisplayLocale` claimed `DateCellRenderer` "already formats from this channel" — the one thing that was not true).

One test expectation I wrote **had to be withdrawn rather than made to pass**, and it is worth recording: a provider-less case asserting the `'en'` last resort cannot live in the new file. `useObjectTranslation()` outside a provider reports `i18n.language` from react-i18next's **global** instance, and every `I18nProvider` mounted above leaves that global on the language it was given — so a provider-less render placed after the `zh` cases resolves `zh`, and the assertion would have been about test ordering, not about the fallback. That pin lives in `DateCellRenderer.test.tsx`, which mounts no provider at all, and both files now say so. Filed as a repo-wide trap in the findings below.

## 5. Census sites deliberately NOT fixed here

- **Site 10, `formatDate(…, 'short')`'s hardcoded `'en-US'`** — its only consumers are `plugin-grid/src/ObjectGrid.tsx:2778,2795`, which is the ⛔ in-flight #4501 surface, and neither call site threads a locale at all. Changing the `fields` half alone would move nothing for any current caller; the fix has to land on both halves at once.
- **Site 11, `formatDateTime`** — takes no options parameter, so no caller can localize it. Its only in-repo consumers are `plugin-gantt/src/ObjectGantt.tsx:648,655` (and `646,653` for `formatDate`), which is neither a measured surface nor covered by this card's scope; adding a parameter here with nothing passing it would grow the public surface for no consumer.
- **Site 12, `RecordPickerDialog`'s `$date` fallback** — a MongoDB-shaped value in a lookup picker column, reachable by no test in the repo.

All three are recorded on #4272 (see below) rather than fixed on a rider.

## 6. Note for triage — #4272 looks like this card's twin

[#4272](https://github.com/objectstack-ai/objectui/issues/4272) is open, `pm:queue`, undispatched, and describes the same defect from the same QA run (objectstack-ai/objectstack#7640). Its comment thread independently predicted the exact root cause measured here — `DateCellRenderer` reading channel 1 only, `useDisplayLocale()` as the resolver. This PR does **not** close it: #4272's stated root cause also names `formatDateTime`'s missing parameter, which is site 11 above and is left alone on purpose. Flagging for the PM to dedupe rather than acting on it.

## Verification

```
pnpm exec vitest run packages/fields/                       → 85 files, 1348 tests, all passed
pnpm exec vitest run packages/plugin-{grid,list,detail,form,gantt,kanban,calendar,timeline}/ \
                     packages/mobile/ packages/i18n/        → 324 files, 3620 tests, all passed
pnpm exec vitest run packages/{components,react,collaboration}/ → 166 files, 1709 tests, all passed
pnpm exec vitest run packages/app-shell/                    → 363 files, 3492 passed, 1 skipped
pnpm exec turbo run type-check --filter='...@object-ui/fields'  → 54/54 successful
      (prefix filter = the DOWNSTREAM consumers of @object-ui/fields)
pnpm exec turbo run lint --filter=@object-ui/fields --filter=@object-ui/i18n → 0 errors
node scripts/check-control-bytes.mjs                        → OK (4218 files)
node scripts/check-changeset-presence.mjs / -no-major / -fixed → all OK
```

Reverse verification: `git checkout origin/main -- ` the five source files, tests kept → `8 failed | 1340 passed`, the eight being exactly the `zh` rows in §3.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_