### PR TITLE
fix(plugin-detail): the record detail header honors userActions predicates (#4419)

### DIFF
--- a/.changeset/wild-pears-refuse.md
+++ b/.changeset/wild-pears-refuse.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+fix(plugin-detail): the record detail header honors `userActions` predicates
+
+`userActions.delete` reached the record detail header in its **boolean** form
+but not in its **predicate** form. `userActions: { delete: false }` removed
+Delete from the row kebab, the selection bar and the detail header, because the
+host lowers the boolean into `schema.showDelete`. `userActions: { delete: {
+visibleWhen: … } }` reached only the row kebab: the header ANDed
+`schema.showDelete ∧ objectAllowsDelete ∧ canDeleteRecord` and never evaluated
+the predicate, so an author upgrading from "nobody may delete this object" to
+"these records may not be deleted" silently lost the surface they were most
+likely to have tested on.
+
+The header now folds the per-record predicates in as a fourth conjunct,
+evaluated against the open record through the same helper family the row
+surfaces use — `userActionPredicates` from `@object-ui/core` for the parse (the
+import `RelatedList` already makes) and `useRowPredicate` from
+`@object-ui/react` for the evaluation:
+
+- `delete.visibleWhen` / `edit.visibleWhen` false → the header affordance is
+  hidden (fails closed; `visibleWhen: false` counts as a declared gate).
+- `delete.disabledWhen` / `edit.disabledWhen` true → the header affordance
+  renders disabled rather than disappearing, matching the row kebab.
+
+The existing permission and record-writability gates are unchanged, so a
+predicate that holds can never resurrect a button the user may not press. The
+boolean form stays the host's channel — a bare boolean yields no predicate.

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -44,8 +44,8 @@ import { RecordComments } from './RecordComments';
 import { ActivityTimeline } from './ActivityTimeline';
 import { HistoryTimeline } from './HistoryTimeline';
 import { RecordMetaFooter } from './RecordMetaFooter';
-import { SchemaRenderer, useSafeFieldLabel, useDataInvalidation, useInlineEdit } from '@object-ui/react';
-import { buildExpandFields, getRecordDisplayName, formatTitleTemplate } from '@object-ui/core';
+import { SchemaRenderer, useSafeFieldLabel, useDataInvalidation, useInlineEdit, useRowPredicate } from '@object-ui/react';
+import { buildExpandFields, getRecordDisplayName, formatTitleTemplate, userActionPredicates } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
 import type { DetailViewSchema, DataSource, ActionSchema, SchemaNode } from '@object-ui/types';
@@ -300,13 +300,111 @@ export const DetailView: React.FC<DetailViewProps> = ({
     objectAllowsDelete,
   );
 
+  /**
+   * Per-record CRUD predicates from the object's `userActions.edit` / `delete`
+   * OBJECT form (objectui#2614) — the header's fourth gate (objectui#4419).
+   *
+   * The boolean form of the same key already reached this surface: the host
+   * lowers it into `schema.showEdit` / `showDelete` through the affordance
+   * resolver. The predicate form did not, so an author upgrading from "nobody
+   * may delete this object" to "these records may not be deleted" silently
+   * lost the header while keeping the row kebab — a key whose scope SHRANK
+   * when a predicate was added to it (ADR-0078: no silently-inert metadata).
+   *
+   * Parsed by `userActionPredicates` from `@object-ui/core` — THE parser for
+   * this shape, the same import `RelatedList` makes a few files over and the
+   * same one `plugin-grid`'s `resolveRowCrudAffordances` feeds the row kebab
+   * from. A boolean flag yields NO predicates, which is what keeps the boolean
+   * form the host's channel alone rather than growing a second definition of
+   * it here.
+   */
+  const editPredicates = React.useMemo(
+    () => userActionPredicates(objectSchema?.userActions?.edit),
+    [objectSchema],
+  );
+  const deletePredicates = React.useMemo(
+    () => userActionPredicates(objectSchema?.userActions?.delete),
+    [objectSchema],
+  );
+  /**
+   * The object's field definitions, handed to every predicate on this record
+   * for the same reason the row kebab passes them (`ObjectGrid` →
+   * `RowActionMenu`'s `objectFields`): a relation field must bind as the
+   * stored FOREIGN KEY rather than whatever `$expand` substituted for it on
+   * this surface, or `record.owner == os.user.id` answers a different question
+   * here than it does on the list.
+   */
+  const objectFields = objectSchema?.fields;
+
+  /**
+   * `visibleWhen` — fails CLOSED, and counts as DECLARED by `!= null` rather
+   * than by truthiness, so `visibleWhen: false` hides the affordance instead
+   * of reading as "ungated" (the objectui#3492 invariant that
+   * `isBuiltinRowActionVisible` restates for the row surfaces). `?? true`
+   * expresses the ungated default as a boolean, which `useRowPredicate`
+   * short-circuits without touching the engine — a boolean handed to CEL
+   * faults and would fail closed.
+   *
+   * `useRowPredicate` IS the row surfaces' evaluator: `plugin-grid`'s
+   * `evalRowActionVisibility` (the body of `isBuiltinRowActionVisible`)
+   * documents itself as mirroring `useRowPredicate(pred, row, { fallback:
+   * false, warnOnError: true, label, fields })` exactly, boolean
+   * short-circuit included, and is hook-free only because a row loop
+   * evaluates a variable number of actions inside one `useMemo`. The header
+   * evaluates a fixed arity of one record, so the hook form is that same
+   * evaluator without the constraint that shaped the wrapper.
+   */
+  const editVisible = useRowPredicate(editPredicates?.visibleWhen ?? true, data, {
+    fallback: false,
+    warnOnError: true,
+    label: 'builtin:edit:visibleWhen',
+    fields: objectFields,
+  });
+  const deleteVisible = useRowPredicate(deletePredicates?.visibleWhen ?? true, data, {
+    fallback: false,
+    warnOnError: true,
+    label: 'builtin:delete:visibleWhen',
+    fields: objectFields,
+  });
+  /**
+   * `disabledWhen` — fails SOFT (an unevaluable predicate must not grey a
+   * button forever), and the `!= null` gate lives OUTSIDE the evaluation, so
+   * `disabledWhen: ''` reads as "no condition" rather than as "disable".
+   * Verbatim the posture of `DataTableBuiltinRowActionItem`.
+   */
+  const editDisabledPred = useRowPredicate(editPredicates?.disabledWhen, data, {
+    fallback: false,
+    warnOnError: true,
+    label: 'builtin:edit:disabledWhen',
+    fields: objectFields,
+  });
+  const deleteDisabledPred = useRowPredicate(deletePredicates?.disabledWhen, data, {
+    fallback: false,
+    warnOnError: true,
+    label: 'builtin:delete:disabledWhen',
+    fields: objectFields,
+  });
+  const editDisabled = editPredicates?.disabledWhen != null && editDisabledPred;
+  const deleteDisabled = deletePredicates?.disabledWhen != null && deleteDisabledPred;
+
   const schema = React.useMemo<DetailViewSchema>(
     () => ({
       ...gatedSchema,
-      showEdit: gatedSchema.showEdit && objectAllowsUpdate && canEditRecord,
-      showDelete: gatedSchema.showDelete && objectAllowsDelete && canDeleteRecord,
+      // The predicate is a FOURTH conjunct — the permission/writability gates
+      // above are untouched, so a predicate that holds can never resurrect a
+      // button the user is not allowed to press.
+      showEdit: gatedSchema.showEdit && objectAllowsUpdate && canEditRecord && editVisible,
+      showDelete: gatedSchema.showDelete && objectAllowsDelete && canDeleteRecord && deleteVisible,
     }),
-    [gatedSchema, objectAllowsUpdate, canEditRecord, objectAllowsDelete, canDeleteRecord],
+    [
+      gatedSchema,
+      objectAllowsUpdate,
+      canEditRecord,
+      editVisible,
+      objectAllowsDelete,
+      canDeleteRecord,
+      deleteVisible,
+    ],
   );
 
 
@@ -685,6 +783,13 @@ export const DetailView: React.FC<DetailViewProps> = ({
         icon: 'edit',
         type: 'script',
         className: 'sm:hidden',
+        // `edit.disabledWhen` greys this entry exactly as it greys the desktop
+        // CTA below and the row kebab's Edit — one predicate, one answer, on
+        // every breakpoint. Set only when it HOLDS: `action:menu` reads a
+        // declared `disabled` by `!= null`, so a `false` would still be a
+        // declared gate (harmless, but it would say something the object did
+        // not declare).
+        ...(editDisabled ? { disabled: true } : null),
         onClick: handleEdit,
       });
     }
@@ -706,6 +811,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
         type: 'script',
         variant: 'destructive',
         tags: ['separator-before'],
+        // `delete.disabledWhen` — kebab symmetry, same rule as Edit above.
+        ...(deleteDisabled ? { disabled: true } : null),
         onClick: handleDelete,
       });
     }
@@ -715,6 +822,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
     t,
     schema.showEdit,
     schema.showDelete,
+    editDisabled,
+    deleteDisabled,
     handleShare,
     handleEdit,
     handleDelete,
@@ -1025,7 +1134,16 @@ export const DetailView: React.FC<DetailViewProps> = ({
             {schema.showEdit && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button variant="default" onClick={handleEdit} className="gap-2 hidden sm:inline-flex">
+                  {/* `userActions.edit.disabledWhen` greys the CTA instead of
+                      removing it — the kebab's rule for the same key
+                      (objectui#4419): `visibleWhen` decides existence,
+                      `disabledWhen` decides pressability. */}
+                  <Button
+                    variant="default"
+                    disabled={editDisabled}
+                    onClick={() => { if (!editDisabled) handleEdit(); }}
+                    className="gap-2 hidden sm:inline-flex"
+                  >
                     <Edit className="h-4 w-4" />
                     <span className="hidden sm:inline">{t('detail.edit')}</span>
                   </Button>

--- a/packages/plugin-detail/src/__tests__/DetailView.userActionPredicates.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailView.userActionPredicates.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4419 — the record detail header honors `userActions.{delete,edit}`
+ * in its PREDICATE form, not only its boolean one.
+ *
+ * The asymmetry this file pins: `userActions: { delete: false }` reached all
+ * three delete surfaces (row kebab, selection bar, detail header) because the
+ * HOST lowers the boolean into `schema.showDelete`. The object form —
+ * `delete: { visibleWhen: … }` — reached only the row kebab, because the
+ * header ANDed three gates (`schema.showDelete ∧ objectAllowsDelete ∧
+ * canDeleteRecord`) and never evaluated the predicate. An author upgrading
+ * from "nobody may delete this object" to "these records may not be deleted"
+ * silently lost the surface they were most likely to have tested on.
+ *
+ * ## Which evaluator, and why this shape
+ *
+ * The header reuses the SAME helper family the row surfaces use, so one
+ * authored predicate gets one answer platform-wide:
+ *
+ *   • `userActionPredicates()` from `@object-ui/core` — THE parser for the
+ *     boolean/object form, the exact import `RelatedList` already makes
+ *     (`RelatedList.tsx`'s `rowEditPredicates` / `rowDeletePredicates`).
+ *   • `useRowPredicate()` from `@object-ui/react` — the canonical CEL
+ *     evaluation. `plugin-grid`'s `evalRowActionVisibility` (the body of
+ *     `isBuiltinRowActionVisible`) documents itself as mirroring
+ *     `useRowPredicate(pred, row, { fallback: false, warnOnError: true,
+ *     label, fields })` "exactly, boolean short-circuit included" — it is
+ *     hook-FREE only because a row loop evaluates a variable number of
+ *     actions inside one `useMemo`. The header evaluates a fixed arity of
+ *     one record, so the hook form is the same evaluator without that
+ *     constraint.
+ *
+ * Posture copied verbatim from `DataTableBuiltinRowActionItem`: `visibleWhen`
+ * counts as declared by `!= null` (so `visibleWhen: false` HIDES rather than
+ * reading as ungated) and fails CLOSED; `disabledWhen` is gated by `!= null`
+ * too and fails SOFT.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { DetailView } from '../DetailView';
+import { __clearRecordEditableCache } from '../useRecordEditable';
+import { PermissionProvider } from '@object-ui/permissions';
+import type { DetailViewSchema } from '@object-ui/types';
+import type { ObjectPermissionConfig, RoleDefinition } from '@object-ui/types';
+
+/** The card's own fixture: a PAID invoice is the predicate-FALSE record. */
+const PAID = { id: 'INV-1011', name: 'INV-1011', status: 'paid', owner: 'u1' };
+/** …and an OPEN one is the predicate-TRUE control. */
+const OPEN = { id: 'INV-1001', name: 'INV-1001', status: 'open', owner: 'u1' };
+
+/** `showcase_invoice`'s real declaration (`invoice.object.ts:58`). */
+const INVOICE_USER_ACTIONS = {
+  edit: { disabledWhen: "record.status == 'paid'" },
+  delete: { visibleWhen: "record.status != 'paid'" },
+};
+
+const OBJECT_FIELDS = {
+  name: { type: 'text' },
+  status: { type: 'select' },
+  owner: { type: 'lookup', reference_to: 'user' },
+};
+
+/**
+ * The record-level explain probe, served from a double — see the identical
+ * note in `DetailView.test.tsx`. `visible: true` keeps `canEditRecord` /
+ * `canDeleteRecord` true so the ONLY thing moving in this file is the
+ * predicate conjunct.
+ */
+function installExplainDouble() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ record: { visible: true } }) })),
+  );
+}
+
+function makeDataSource(userActions: unknown) {
+  return {
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'showcase_invoice',
+      fields: OBJECT_FIELDS,
+      ...(userActions === undefined ? {} : { userActions }),
+    }),
+  } as any;
+}
+
+function schemaFor(
+  data: Record<string, unknown>,
+  overrides: Partial<DetailViewSchema> = {},
+): DetailViewSchema {
+  return {
+    type: 'detail-view',
+    title: 'Invoice',
+    objectName: 'showcase_invoice',
+    data,
+    fields: [{ name: 'name', label: 'Name' }],
+    showEdit: true,
+    showDelete: true,
+    showBack: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Mount the header and WAIT for the async `getObjectSchema` to land, so a
+ * "Delete is gone" assertion can never pass merely because the object schema
+ * (and therefore the predicate) had not arrived yet.
+ */
+async function mountHeader(
+  data: Record<string, unknown>,
+  userActions: unknown,
+  overrides: Partial<DetailViewSchema> = {},
+  wrap: (ui: React.ReactElement) => React.ReactElement = (ui) => ui,
+) {
+  const dataSource = makeDataSource(userActions);
+  const view = render(wrap(<DetailView schema={schemaFor(data, overrides)} dataSource={dataSource} />));
+  await waitFor(() => expect(dataSource.getObjectSchema).toHaveBeenCalledWith('showcase_invoice'));
+  return view;
+}
+
+/** Open the header's unified "⋯" overflow and return its rendered item labels. */
+async function openHeaderOverflow(): Promise<string[]> {
+  const trigger = screen.getByRole('button', { name: /more actions/i });
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: 'mouse' });
+  await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
+  return screen
+    .getAllByRole('menuitem')
+    .map((el) => (el.textContent ?? '').trim());
+}
+
+/** The header's primary Edit CTA (desktop). */
+function headerEditButton(): HTMLElement | null {
+  return screen.queryByRole('button', { name: /^edit$/i });
+}
+
+const roles: RoleDefinition[] = [
+  { name: 'reader', label: 'Reader', description: 'read only' },
+];
+const READ_ONLY: ObjectPermissionConfig = {
+  object: 'showcase_invoice',
+  roles: { reader: { actions: ['read'] } },
+};
+
+describe('DetailView header — `userActions` predicates (objectui#4419)', () => {
+  beforeEach(() => {
+    __clearRecordEditableCache();
+    installExplainDouble();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // RED #1 — the card's own repro: predicate FALSE ⇒ the header stops offering
+  // Delete. Pre-fix this menu still lists "Delete".
+  // -------------------------------------------------------------------------
+  it('hides the header Delete on a record its `delete.visibleWhen` excludes', async () => {
+    await mountHeader(PAID, INVOICE_USER_ACTIONS);
+    const items = await openHeaderOverflow();
+    expect(items).not.toContain('Delete');
+    // The companion: the overflow itself still rendered, so "no Delete" cannot
+    // be "no menu".
+    expect(items).toContain('Share');
+  });
+
+  // -------------------------------------------------------------------------
+  // RED #2 — new behavior: `edit.disabledWhen` greys the header Edit CTA
+  // (kebab symmetry). Pre-fix the button is enabled.
+  // -------------------------------------------------------------------------
+  it('renders the header Edit DISABLED when `edit.disabledWhen` holds', async () => {
+    const onEdit = vi.fn();
+    const dataSource = makeDataSource(INVOICE_USER_ACTIONS);
+    render(
+      <DetailView schema={schemaFor(PAID)} dataSource={dataSource} onEdit={onEdit} />,
+    );
+    await waitFor(() =>
+      expect(dataSource.getObjectSchema).toHaveBeenCalledWith('showcase_invoice'),
+    );
+    const edit = await waitFor(() => {
+      const btn = headerEditButton();
+      expect(btn).toBeInTheDocument();
+      expect(btn).toBeDisabled();
+      return btn!;
+    });
+    fireEvent.click(edit);
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // MUST-NOT-CHANGE — green on both sides of the fix.
+  // -------------------------------------------------------------------------
+  it('keeps the header Delete on a record its `delete.visibleWhen` admits', async () => {
+    await mountHeader(OPEN, INVOICE_USER_ACTIONS);
+    expect(await openHeaderOverflow()).toContain('Delete');
+  });
+
+  it('keeps the header Edit ENABLED when `edit.disabledWhen` does not hold', async () => {
+    const onEdit = vi.fn();
+    const dataSource = makeDataSource(INVOICE_USER_ACTIONS);
+    render(
+      <DetailView schema={schemaFor(OPEN)} dataSource={dataSource} onEdit={onEdit} />,
+    );
+    await waitFor(() =>
+      expect(dataSource.getObjectSchema).toHaveBeenCalledWith('showcase_invoice'),
+    );
+    const edit = headerEditButton()!;
+    expect(edit).toBeInTheDocument();
+    expect(edit).not.toBeDisabled();
+    fireEvent.click(edit);
+    expect(onEdit).toHaveBeenCalled();
+  });
+
+  it('leaves an object with NO `userActions` completely ungated', async () => {
+    await mountHeader(PAID, undefined);
+    // Asserted BEFORE the overflow opens: Radix `aria-hidden`s the rest of the
+    // page while a menu is open, so a role query would find nothing and the
+    // "not disabled" assertion would pass on a null instead of on the button.
+    expect(headerEditButton()).not.toBeDisabled();
+    expect(await openHeaderOverflow()).toContain('Delete');
+  });
+
+  /**
+   * The BOOLEAN form stays the HOST's channel. `userActionPredicates(false)`
+   * is `undefined` — no predicate — exactly as on the row kebab, so the header
+   * reads `schema.showDelete` and nothing else. The producer that lowers
+   * `delete: false` into `showDelete: false` is what hides it (both halves
+   * asserted below), and this fix must not grow a SECOND definition of the
+   * boolean form on this surface.
+   */
+  it('leaves the boolean form to the host: `delete: false` yields no predicate…', async () => {
+    await mountHeader(PAID, { delete: false });
+    expect(await openHeaderOverflow()).toContain('Delete');
+  });
+
+  it('…and the host lowering it to `showDelete: false` still hides Delete', async () => {
+    await mountHeader(PAID, { delete: false }, { showDelete: false });
+    expect(await openHeaderOverflow()).not.toContain('Delete');
+  });
+
+  it('keeps Delete hidden when the permission gate says no, predicate or not', async () => {
+    // `objectAllowsDelete` is false (the role grants `read` only) while the
+    // predicate HOLDS — the fourth conjunct must not resurrect the button.
+    await mountHeader(OPEN, INVOICE_USER_ACTIONS, {}, (ui) => (
+      <PermissionProvider roles={roles} permissions={[READ_ONLY]} userRoles={['reader']}>
+        {ui}
+      </PermissionProvider>
+    ));
+    expect(await openHeaderOverflow()).not.toContain('Delete');
+  });
+
+  it('leaves non-CRUD header chrome untouched on an excluded record', async () => {
+    await mountHeader(PAID, INVOICE_USER_ACTIONS);
+    expect(await openHeaderOverflow()).toContain('Share');
+  });
+
+  it('accepts the canonical `{ dialect, source }` envelope', async () => {
+    await mountHeader(PAID, {
+      delete: { visibleWhen: { dialect: 'cel', source: "record.status != 'paid'" } },
+    });
+    expect(await openHeaderOverflow()).not.toContain('Delete');
+  });
+
+  /**
+   * `visibleWhen: false` is a DECLARED gate that excludes every record — the
+   * `!= null` rule, not truthiness (the invariant objectui#3492 established
+   * and `isBuiltinRowActionVisible` restates).
+   */
+  it('treats a literal `visibleWhen: false` as declared, not ungated', async () => {
+    await mountHeader(OPEN, { delete: { visibleWhen: false } });
+    expect(await openHeaderOverflow()).not.toContain('Delete');
+  });
+});


### PR DESCRIPTION
Closes #4419

## The asymmetry

`userActions.delete` reached the record detail header in its **boolean** form but not in its **predicate** form.

| form | row kebab | detail header |
| --- | --- | --- |
| `userActions: { delete: false }` | hidden | hidden — the host lowers the boolean into `schema.showDelete` |
| `userActions: { delete: { visibleWhen: … } }` | hidden on excluded records | **still offered** |

The header ANDed three gates and never evaluated the predicate (`DetailView.tsx:306-307` on `main`):

```
showDelete: gatedSchema.showDelete && objectAllowsDelete && canDeleteRecord
```

So an author upgrading from "nobody may delete this object" to "these records may not be deleted" — the exact reason the object form exists — silently lost a surface. A key whose scope *shrinks* when you add a predicate to it is ADR-0078's silently-inert metadata, which is the framing the ruling adopted.

## The fix — one evaluator, one answer

The predicate is folded in as a **fourth conjunct**, evaluated against the open record through the same helper family the row surfaces already use. No fresh predicate-evaluation code on this path:

- **`userActionPredicates`** from `@object-ui/core` for the parse — the exact import `RelatedList.tsx:1130-1131` makes, and the one `plugin-grid`'s `resolveRowCrudAffordances` feeds the row kebab from. It is THE parser for the boolean/object form.
- **`useRowPredicate`** from `@object-ui/react` for the evaluation. `plugin-grid`'s `evalRowActionVisibility` — the body of `isBuiltinRowActionVisible`, which `RowActionMenu.tsx:348-350` calls — documents itself as mirroring `useRowPredicate(pred, row, { fallback: false, warnOnError: true, label, fields })` *"exactly, boolean short-circuit included"*, and is hook-free **only** because a row loop evaluates a variable number of actions inside one `useMemo`. The header evaluates a fixed arity of one record, so the hook form is that same evaluator without the constraint that shaped the wrapper. (`isBuiltinRowActionVisible` itself is not importable here: `plugin-grid` is not a `plugin-detail` dependency, and `@object-ui/components`' copy is not re-exported from its barrel.)

Posture copied verbatim from `DataTableBuiltinRowActionItem`:

- `visibleWhen` false → the header affordance is **hidden**. Fails CLOSED; declared by `!= null`, not truthiness, so `visibleWhen: false` is a gate rather than "ungated" (the objectui#3492 invariant).
- `disabledWhen` true → the affordance renders **disabled**, not removed — kebab symmetry. Applied to the desktop Edit CTA *and* its `sm:hidden` overflow twin, plus the overflow Delete, so one predicate gets one answer at every breakpoint.
- `objectSchema.fields` is passed to every predicate for the same reason `ObjectGrid` passes `objectFields` to `RowActionMenu`: a relation field must bind as the stored foreign key, not whatever `$expand` substituted on this surface.

The existing gates all remain, so a predicate that holds can never resurrect a button the user may not press. A bare boolean yields **no** predicate, which keeps the boolean form the host's channel rather than growing a second definition of it here.

## Red-first

New file `packages/plugin-detail/src/__tests__/DetailView.userActionPredicates.test.tsx`, on the card's own fixture (`showcase_invoice`'s real declaration, paid `INV-1011` vs open `INV-1001`).

Reverse verification was done by removing the fix with `git checkout origin/main -- DetailView.tsx` and restoring from a sha256-verified copy (never `git stash`). Exactly the four new-behaviour cases move; the seven must-not-change cases are green in both directions.

**Pre-fix (fix removed), verbatim** — the failing element's opening tag is spelled with a space after the angle bracket, because GitHub strips a bare bracket-plus-letter from a stored body as an HTML tag and swallowed the line on the first write:

```
 × hides the header Delete on a record its `delete.visibleWhen` excludes 200ms
 × renders the header Edit DISABLED when `edit.disabledWhen` holds 1034ms
 × accepts the canonical `{ dialect, source }` envelope 62ms
 × treats a literal `visibleWhen: false` as declared, not ungated 52ms

AssertionError: expected [ 'Share', 'Edit', 'Delete' ] to not include 'Delete'

Error: expect(element).toBeDisabled()
Received element is not disabled:
  < button
  class="… bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 gap-2 hidden sm:inline-flex"
  data-state="closed"
/ >

 Test Files  1 failed (1)
      Tests  4 failed | 7 passed (11)
```

**Post-fix:**

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Must-not-change, green on both sides: predicate-TRUE record keeps Delete and an enabled Edit; an object with no `userActions` is completely ungated; `delete: false` yields no predicate (the boolean stays the host's channel) while the host lowering it to `showDelete: false` still hides Delete; a read-only role keeps Delete hidden even though the predicate holds; `sys_share` is untouched on an excluded record.

## Verification

```
pnpm --filter '@object-ui/plugin-detail^...' build           exit=0   (dependency closure first)
pnpm exec vitest run packages/plugin-detail/                 81 files, 781 tests passed
pnpm exec tsc --noEmit                        (plugin-detail) exit=0
pnpm exec tsc -p tsconfig.test.json           (plugin-detail) exit=0
pnpm --filter @object-ui/plugin-detail lint                  exit=0 (0 errors; pre-existing warnings)
node scripts/check-control-bytes.mjs                         OK (4221 files)
node scripts/check-changeset-presence.mjs                    OK
node scripts/check-changeset-no-major.mjs                    OK
```

`.d.ts` measured both ways — `dist/index.d.ts` built from `origin/main` and from this branch is **byte-identical** (78 lines, `diff` empty), so no public type surface moves. Changeset: **patch** `@object-ui/plugin-detail`.

## Scope, and one thing the PM should read

Surface is `DetailView.tsx` + its new test + one changeset. Untouched by ruling: `RelatedList.tsx` (already correct, read-only reference), `plugin-grid/**`, selection-bar components (#4420), `console/**`, `content/docs/releases/`.

**Measured, and it does not match the card's repro attribution:** the console record page's header is **not** served by `DetailView`. `plugin-detail/src/renderers/record-details.tsx:257` mounts the inner `detail-view` with `showHeader: schema.showHeader ?? false`, and `app-shell/src/views/RecordDetailView.tsx` has zero `DetailView` mounts — its header Edit/Share/Delete come from `synthSystemActions` at line 1911, which ANDs `resolveRecordHeaderActionGates(objectDef, …)` (the boolean affordance channel) with the record-level verdict and never parses or evaluates the predicate.

So this PR fixes the `DetailView` header — `RecordDetailDrawer` and every host mounting `detail-view` / `detail` with `showEdit` / `showDelete` — which is exactly the site #4419 names and the ruling scoped. It does **not** close the console page-header path that #4419's browser table screenshotted; that surface is already owned by the open #4213, where the file:line evidence has been posted as [a comment](https://github.com/objectstack-ai/objectui/issues/4213#issuecomment-5275474292) rather than as a duplicate issue. No new issue filed.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_