### PR TITLE
fix(plugin-grid): the link column renders a real anchor when the host publishes record URLs (#4490)

### DIFF
--- a/.changeset/list-link-column-real-anchor.md
+++ b/.changeset/list-link-column-real-anchor.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/plugin-grid': patch
+'@object-ui/app-shell': patch
+---
+
+fix(plugin-grid): the list link column renders a real anchor when the host publishes record URLs
+
+The list's `link: true` column (and the auto-linked primary field) rendered as
+a `span role="link"` with no `href`, navigating only through a click handler.
+So the surface users actually open records from had none of a link's native
+affordances — no middle-click / ⌘-click open-in-new-tab, no "copy link
+address", no hover status-bar URL — and `role="link"` without an href is a
+weaker contract for assistive tech than a real anchor. It was also the odd one
+out: the previous release gave record-detail and related-list lookup VALUES
+real anchors, leaving the list column as the weakest of the three surfaces.
+
+`LinkCell` now renders a real `<a href>` with the same click split: a plain
+left click is prevented and handed to the existing in-app navigation, so drawer
+/ modal / page behavior is completely unchanged, while modifier and
+middle-clicks are left to the browser.
+
+The URL is not assembled in the grid. The object list page publishes its own
+record-URL builder through `RelatedRecordActionsContext.recordHref` — the same
+seam the lookup links use, and the same expression its "open in new window"
+action already navigated with, so the anchor and that action cannot address
+different records. A host that publishes no URL renders exactly what it
+rendered before: the Studio designer, embedded renderers and standalone grids
+are untouched.
+
+Neither package's published `dist/index.d.ts` changes (measured both ways —
+byte-identical), so this is a patch on both: the list host's new helpers are
+module-level exports behind a barrel that re-exports only `ObjectView`.

--- a/packages/app-shell/src/views/ObjectView.listRecordHref.test.ts
+++ b/packages/app-shell/src/views/ObjectView.listRecordHref.test.ts
@@ -1,0 +1,124 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4490, the HOST half — the object list page publishes its record-URL
+ * builder so the grid's link column can render a real anchor.
+ *
+ * The seam was the measured question. `RelatedRecordActionsProvider` mounted
+ * only on the record DETAIL body (`RelatedRecordActionsBridge`), which is why
+ * PR #4489's anchors reached lookup values there and never the list page. Of
+ * the two candidate seams — mount the existing provider on the list host, or
+ * thread an href callback through the grid's navigation context — the first
+ * needs no new package dependency and no new schema key: app-shell and
+ * plugin-grid both already depend on `@object-ui/react`, where the context and
+ * its `recordHref` (added by #4489) live.
+ *
+ * What is pinned here is the part that is this file's own: the URL is built
+ * ONCE, by the host, from the same expression its "open in new window" action
+ * has always used — so the anchor a user middle-clicks and the tab the row's
+ * ⌘-click opens address the same record by construction, not by coincidence.
+ *
+ * REVERSE VERIFICATION — direction predicted, then measured. These are pure
+ * functions that do not exist on `origin/main`, so reverting the source does
+ * not produce a value mismatch: the import fails and the whole file dies before
+ * an assertion runs. Stated plainly because it bounds what this file proves —
+ * it pins the builder's CONTRACT going forward (scoping, encoding, the `/view/`
+ * strip); the case that discriminates old behavior from new is the anchor
+ * itself, in `plugin-grid/src/__tests__/ObjectGrid.linkCellAnchor.test.tsx`.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { listRecordDetailUrl, listRecordActionsValue } from './ObjectView';
+
+describe('listRecordDetailUrl — one record-route shape for the list surface (#4490)', () => {
+  it('strips the trailing view segment and appends the record route', () => {
+    expect(listRecordDetailUrl('/apps/demo/crm_lead/view/all', 'r1')).toBe(
+      '/apps/demo/crm_lead/record/r1',
+    );
+  });
+
+  it('works on the object page with no view segment', () => {
+    expect(listRecordDetailUrl('/apps/demo/crm_lead', 'r1')).toBe(
+      '/apps/demo/crm_lead/record/r1',
+    );
+  });
+
+  it('encodes the record id', () => {
+    expect(listRecordDetailUrl('/apps/demo/crm_lead', 'a/b c')).toBe(
+      '/apps/demo/crm_lead/record/a%2Fb%20c',
+    );
+  });
+
+  it('numeric ids survive as ids, not as coincidental path segments', () => {
+    expect(listRecordDetailUrl('/apps/demo/crm_lead/view/mine', 42)).toBe(
+      '/apps/demo/crm_lead/record/42',
+    );
+  });
+});
+
+describe('listRecordActionsValue — what the list page publishes (#4490)', () => {
+  const pathname = () => '/apps/demo/crm_lead/view/all';
+
+  it('publishes an href for the object this view lists', () => {
+    const value = listRecordActionsValue('crm_lead', vi.fn(), pathname);
+    expect(value.recordHref!('crm_lead', 'r1')).toBe('/apps/demo/crm_lead/record/r1');
+  });
+
+  it('publishes NO href for any other object — this builder cannot name one', () => {
+    const value = listRecordActionsValue('crm_lead', vi.fn(), pathname);
+    // A lookup cell pointing at a third object must render as the plain value,
+    // which is what `null` means to the consumer. The console-wide builder is
+    // the detail page's bridge, which has the routable-object set this page
+    // does not — inventing a URL here is exactly the #4472 mistake.
+    expect(value.recordHref!('crm_account', 'acc-1')).toBeNull();
+  });
+
+  it('publishes NO href for a record with no id', () => {
+    const value = listRecordActionsValue('crm_lead', vi.fn(), pathname);
+    expect(value.recordHref!('crm_lead', '')).toBeNull();
+  });
+
+  it('openRecord routes through the host own record navigation', () => {
+    const openPage = vi.fn();
+    const value = listRecordActionsValue('crm_lead', openPage, pathname);
+
+    value.openRecord!('crm_lead', 'r1');
+    expect(openPage).toHaveBeenCalledTimes(1);
+    expect(openPage).toHaveBeenCalledWith('r1');
+  });
+
+  it('openRecord is a no-op for an object this page cannot address', () => {
+    const openPage = vi.fn();
+    const value = listRecordActionsValue('crm_lead', openPage, pathname);
+
+    value.openRecord!('crm_account', 'acc-1');
+    expect(openPage).not.toHaveBeenCalled();
+  });
+
+  it('reads the pathname at CALL time, so a view switch cannot leave a stale base', () => {
+    let current = '/apps/demo/crm_lead/view/all';
+    const value = listRecordActionsValue('crm_lead', vi.fn(), () => current);
+    expect(value.recordHref!('crm_lead', 'r1')).toBe('/apps/demo/crm_lead/record/r1');
+
+    current = '/apps/other/crm_lead/view/mine';
+    expect(value.recordHref!('crm_lead', 'r1')).toBe('/apps/other/crm_lead/record/r1');
+  });
+
+  it('resolves NO related-list handlers — a list page has no child collection', () => {
+    const value = listRecordActionsValue('crm_lead', vi.fn(), pathname);
+    // The context reads an omitted handler as "capability unavailable", i.e.
+    // the same read-only outcome a consumer gets with no provider at all. So
+    // mounting this provider grants no affordance that was not there before.
+    expect(value.resolve({ objectName: 'crm_lead' })).toEqual({});
+    // Stable identity, so a consumer memoizing on it does not churn.
+    expect(value.resolve({ objectName: 'crm_lead' })).toBe(
+      value.resolve({ objectName: 'anything' }),
+    );
+  });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -70,7 +70,8 @@ import { useObjectTranslation, useObjectLabel } from '@object-ui/i18n';
 import { usePermissions } from '@object-ui/permissions';
 import { useAuth, useIsWorkspaceAdmin } from '@object-ui/auth';
 import { useRealtimeSubscription, useConflictResolution } from '@object-ui/collaboration';
-import { ActionProvider, useNavigationOverlay, SchemaRenderer, useActionTextLocalizer } from '@object-ui/react';
+import { ActionProvider, useNavigationOverlay, SchemaRenderer, useActionTextLocalizer, RelatedRecordActionsProvider } from '@object-ui/react';
+import type { RelatedRecordActionsValue, RelatedRecordHandlers } from '@object-ui/react';
 import { toast } from 'sonner';
 import { useConsoleActionRuntime } from '../hooks/useConsoleActionRuntime';
 import { useEnvironmentEntitlements } from '../environment/useEnvironmentEntitlements';
@@ -158,6 +159,83 @@ export function timelineViewOptions(viewDef: any, objectDef: any): Record<string
         ...(declaredStart ? { startDateField: declaredStart } : {}),
         titleField: viewDef?.timeline?.titleField || objectDef?.titleField || 'name',
         descriptionField: viewDef?.timeline?.descriptionField,
+    };
+}
+
+/**
+ * THE record-detail URL this list surface builds — one route shape, one place.
+ *
+ * Derived from the LIST's own pathname rather than re-assembled from route
+ * params, because that is what the "open in new window" navigation action has
+ * always used here: strip a trailing `/view/:viewId` and append
+ * `/record/:recordId`. It therefore works wherever this page is mounted, and —
+ * more to the point — every affordance that opens a record in a new tab from
+ * this page addresses the SAME URL by construction.
+ *
+ * Since objectui#4490 it also backs the href the list's link column publishes
+ * through {@link RelatedRecordActionsValue.recordHref}, so the anchor a user
+ * middle-clicks and the tab the row's ⌘-click opens cannot drift apart.
+ *
+ * Exported for the pin test.
+ */
+export function listRecordDetailUrl(pathname: string, recordId: string | number): string {
+    const basePath = pathname.replace(/\/view\/.*$/, '');
+    return `${basePath}/record/${encodeURIComponent(String(recordId))}`;
+}
+
+/** No related-list handlers — see {@link listRecordActionsValue}. */
+const NO_RELATED_HANDLERS: RelatedRecordHandlers = Object.freeze({});
+
+/**
+ * What the object LIST page publishes on `RelatedRecordActionsContext`
+ * (objectui#4490).
+ *
+ * `RelatedRecordActionsProvider` was mounted only on the record DETAIL body
+ * (by `RelatedRecordActionsBridge`), which is why PR #4489's real anchors
+ * reached lookup values there and the list page's own `link: true` column was
+ * left with a click-only `span role="link"`. The list host publishes the same
+ * pair here, so `LinkCell` can render a real anchor without knowing anything
+ * about routes — one mechanism, all three surfaces.
+ *
+ * Two deliberate limits:
+ *
+ *  - **`resolve` returns no handlers.** This surface has no related lists — a
+ *    list page's rows are not a child collection — so there is nothing to
+ *    resolve. An empty handler set is exactly what the context documents as
+ *    "capability unavailable", i.e. the same read-only outcome a consumer gets
+ *    with no provider at all, so nothing that renders under this page gains an
+ *    affordance it did not have.
+ *  - **`recordHref` addresses THIS view's object only.** {@link
+ *    listRecordDetailUrl} is derived from the current list's pathname, so it
+ *    can only name records of the object being listed; any other object is
+ *    `null`, which consumers must render as the plain value (a lookup cell
+ *    pointing at a third object stays exactly as it renders today). The
+ *    console-wide, any-object builder lives on the detail page's bridge, which
+ *    has the routable-object set this page does not.
+ *
+ * `pathname` is read at CALL time (not captured) so a view switch or a drill-in
+ * cannot leave a stale base behind — the same freshness rule the bridge's
+ * builder documents for its `?from=` trail.
+ *
+ * Exported for the pin test.
+ */
+export function listRecordActionsValue(
+    objectName: string,
+    openRecordPage: (recordId: string | number) => void,
+    getPathname: () => string = () => window.location.pathname,
+): RelatedRecordActionsValue {
+    const addressable = (targetObjectName: string, recordId: string | number) =>
+        targetObjectName === objectName && recordId != null && recordId !== '';
+    return {
+        resolve: () => NO_RELATED_HANDLERS,
+        recordHref: (targetObjectName, recordId) =>
+            addressable(targetObjectName, recordId)
+                ? listRecordDetailUrl(getPathname(), recordId)
+                : null,
+        openRecord: (targetObjectName, recordId) => {
+            if (!addressable(targetObjectName, recordId)) return;
+            openRecordPage(recordId);
+        },
     };
 }
 
@@ -1404,9 +1482,10 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     const handleNavOverlayNavigate = useCallback(
         (recordId: string | number, action?: string) => {
             if (action === 'new_window') {
-                // Open record detail in a new browser tab with Console-correct URL
-                const basePath = window.location.pathname.replace(/\/view\/.*$/, '');
-                window.open(`${basePath}/record/${encodeURIComponent(String(recordId))}`, '_blank');
+                // Open record detail in a new browser tab with Console-correct URL.
+                // Same builder the list's link column publishes as its href
+                // (objectui#4490) — one record-route shape for this surface.
+                window.open(listRecordDetailUrl(window.location.pathname, recordId), '_blank');
                 return;
             }
             // Default: navigate to record detail page.
@@ -1427,6 +1506,20 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
             }
         },
         [navigate, viewId, location.pathname, location.search, objectDef, activeView?.name, activeView?.label, viewLabel, objectLabel]
+    );
+    /**
+     * The list surface's half of the record-link mechanism (objectui#4490):
+     * publish this page's record-URL builder so the grid's `link: true` column
+     * can render a real anchor instead of a click-only `span role="link"`.
+     * See {@link listRecordActionsValue} for what this does and does NOT claim.
+     *
+     * The record drawer/overlay below mounts `RecordDetailView`, which brings
+     * its own `RelatedRecordActionsBridge` around the whole detail body — that
+     * nearer provider keeps owning the detail surface, exactly as before.
+     */
+    const listRecordActions = useMemo(
+        () => listRecordActionsValue(objectDef.name, handleNavOverlayNavigate),
+        [objectDef.name, handleNavOverlayNavigate],
     );
     const navOverlay = useNavigationOverlay({
         navigation: detailNavigation,
@@ -1954,6 +2047,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
 
     return (
         <ActionProvider {...actionRuntime.actionProviderProps}>
+        <RelatedRecordActionsProvider value={listRecordActions}>
         <div className="h-full flex flex-col bg-background min-w-0 overflow-hidden">
              {/* 1. Header with breadcrumb + description.
                  The managed-by badge sits inline with the title so the
@@ -2344,6 +2438,7 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
              )}
         </div>
         {actionRuntime.dialogs}
+        </RelatedRecordActionsProvider>
         </ActionProvider>
     );
 }

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -25,7 +25,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { ObjectGridSchema, DataSource, ListColumn, ViewData, TableSortItem, DataTableSchema } from '@object-ui/types';
 import { isSystemManagedField } from '@object-ui/types';
 import type { I18nLabel } from '@objectstack/spec/ui';
-import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useSafeFieldLabel, usePredicateScope } from '@object-ui/react';
+import { SchemaRenderer, useDataScope, useNavigationOverlay, useAction, useSafeFieldLabel, usePredicateScope, useRelatedRecordActions } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { getCellRenderer, resolveCellRendererType, formatCurrency, formatCompactCurrency, formatDate, formatPercent, humanizeLabel, getBadgeColorClasses, FieldEditWidget, hasFieldEditWidget, DISCRETE_EDIT_TYPES, coerceToSafeValue } from '@object-ui/fields';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
@@ -80,36 +80,126 @@ export function parseSchemaSort(sort: unknown): TableSortItem[] {
   return items;
 }
 
+/**
+ * The class list both faces of {@link LinkCell} wear — the anchor is a visual
+ * no-op against the span it upgrades, so a list does not change appearance
+ * depending on whether its host publishes record URLs.
+ */
+const LINK_CELL_CLASS =
+  'text-primary font-medium underline-offset-4 hover:underline cursor-pointer truncate block max-w-full';
+
+/**
+ * A row's primary key — the value the host's record-URL builder addresses.
+ * Mirrors what `useNavigationOverlay.handleClick` reads off the same row, so
+ * the anchor's href and the click path can never point at different records.
+ */
+function rowRecordId(row: unknown): string | number | undefined {
+  const rec = row as Record<string, unknown> | null | undefined;
+  const id = rec?.id ?? rec?._id;
+  return typeof id === 'string' || typeof id === 'number' ? id : undefined;
+}
+
 // Clickable text cell that can safely contain other interactive content
 // (e.g., EmailCellRenderer's copy button). Using <button> here would
 // produce an invalid <button> > <button> nesting (hydration error +
 // breaks the inner copy click). role="link" + tabIndex + keyboard
 // handlers preserves accessibility while allowing arbitrary children.
+//
+// objectui#4490 — that span was the whole cell, so the list's link column had
+// none of a link's native affordances: no middle-click / ⌘-click open-in-new-
+// tab, no "copy link address", no hover status-bar URL, and `role="link"` with
+// no `href` is a weaker contract for assistive tech than a real anchor. PR
+// #4489 had just given detail-page and related-list lookup VALUES real anchors,
+// which left the list — the surface users open records from — as the weakest of
+// the three.
+//
+// So when the host publishes a record URL this renders a real `<a href>`, with
+// the split #4489 established:
+//   - plain left click → `preventDefault()` + the existing `onActivate`, so SPA
+//     navigation (drawer / modal / page, whatever the view configured) is
+//     completely unchanged;
+//   - modifier / non-primary click → NOT prevented, so the browser does what it
+//     does with any link.
+//
+// **The URL is not built here.** This package has no router and no business
+// knowing what a record route looks like; the host publishes its own builder
+// through `RelatedRecordActionsContext.recordHref` — the same seam #4489 used,
+// and for the console list surface the same builder its "open in new window"
+// action already navigates with. No host, or a host that cannot route to this
+// object, renders EXACTLY the span below: same markup, same behavior, nothing
+// to un-learn (the Studio designer, embedded renderers, standalone grids).
 const LinkCell: React.FC<{
   testId: string;
   onActivate: () => void;
+  /** Object whose record this row is — passed to the host's URL builder. */
+  objectName?: string;
+  /** This row's primary key. Absent (a row with no id) ⇒ no anchor. */
+  recordId?: string | number | null;
   children: React.ReactNode;
-}> = ({ testId, onActivate, children }) => (
-  <span
-    role="link"
-    tabIndex={0}
-    data-testid={testId}
-    className="text-primary font-medium underline-offset-4 hover:underline cursor-pointer truncate block max-w-full"
-    onClick={(e) => {
-      e.stopPropagation();
-      onActivate();
-    }}
-    onKeyDown={(e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
+}> = ({ testId, onActivate, objectName, recordId, children }) => {
+  const host = useRelatedRecordActions();
+  const href =
+    objectName && recordId != null && recordId !== '' && host?.recordHref
+      ? host.recordHref(objectName, recordId)
+      : null;
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        data-testid={testId}
+        className={LINK_CELL_CLASS}
+        onClick={(e) => {
+          // The row underneath carries its own click handler (open the record,
+          // and on a modifier click open it in a new tab). Following this link
+          // must never ALSO fire that — on a modifier click that would open two
+          // tabs, one from the anchor and one from the row.
+          e.stopPropagation();
+          // Modifier and non-primary clicks belong to the browser (new tab, new
+          // window) — that is the entire point of rendering a real href.
+          if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+          e.preventDefault();
+          onActivate();
+        }}
+        onKeyDown={(e) => {
+          // Enter is the anchor's OWN activation: the browser fires a click for
+          // it, which the handler above turns into the SPA path. Handling it
+          // here too would activate twice. Space is the one the span had that a
+          // link does not do natively, so it is carried over explicitly.
+          if (e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            onActivate();
+          }
+        }}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <span
+      role="link"
+      tabIndex={0}
+      data-testid={testId}
+      className={LINK_CELL_CLASS}
+      onClick={(e) => {
         e.stopPropagation();
         onActivate();
-      }
-    }}
-  >
-    {children}
-  </span>
-);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          onActivate();
+        }
+      }}
+    >
+      {children}
+    </span>
+  );
+};
 
 
 // Default English fallback translations for the grid
@@ -1278,6 +1368,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
                     <LinkCell
                       testId={isPrimaryField ? 'primary-field-link' : 'link-cell'}
                       onActivate={() => navigation.handleClick(row)}
+                      objectName={schema.objectName}
+                      recordId={rowRecordId(row)}
                     >
                       {displayContent}
                     </LinkCell>
@@ -1293,6 +1385,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
                     <LinkCell
                       testId={isPrimaryField ? 'primary-field-link' : 'link-cell'}
                       onActivate={() => navigation.handleClick(row)}
+                      objectName={schema.objectName}
+                      recordId={rowRecordId(row)}
                     >
                       {displayContent}
                     </LinkCell>
@@ -1432,6 +1526,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
                 <LinkCell
                   testId="primary-field-link"
                   onActivate={() => navigation.handleClick(row)}
+                  objectName={schema.objectName}
+                  recordId={rowRecordId(row)}
                 >
                   {displayContent}
                 </LinkCell>
@@ -1442,6 +1538,8 @@ export const ObjectGrid: React.FC<ObjectGridProps> = ({
               <LinkCell
                 testId="primary-field-link"
                 onActivate={() => navigation.handleClick(row)}
+                objectName={schema.objectName}
+                recordId={rowRecordId(row)}
               >
                 {value != null && value !== '' ? String(value) : <span className="text-muted-foreground/50 text-xs italic">—</span>}
               </LinkCell>

--- a/packages/plugin-grid/src/__tests__/ObjectGrid.linkCellAnchor.test.tsx
+++ b/packages/plugin-grid/src/__tests__/ObjectGrid.linkCellAnchor.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4490 — the list's `link: true` column renders a REAL anchor when the
+ * host publishes record URLs.
+ *
+ * The column was a `span role="link"` with no `href`, navigating only through
+ * `navigation.handleClick(row)`. So the one surface users open records from had
+ * none of a link's native affordances — no middle-click / ⌘-click open-in-new-
+ * tab, no "copy link address", no hover status-bar URL — and `role="link"`
+ * without an href is a weaker contract for assistive tech than an anchor. PR
+ * #4489 had just given detail-page and related-list lookup VALUES real anchors,
+ * which left the list column as the weakest of the three surfaces.
+ *
+ * The mechanism is #4489's, unchanged: the host publishes its own record-URL
+ * builder on `RelatedRecordActionsContext` (`recordHref`), the renderer never
+ * assembles a URL, and the click splits — plain left click is prevented and
+ * handed to the existing SPA path, modifier / non-primary clicks are left to
+ * the browser.
+ *
+ * RED-FIRST, measured on this file against the unfixed `ObjectGrid`:
+ *   ✗ renders a real anchor at the host-built record URL
+ *       → AssertionError: expected null not to be null   (the span, no <a>)
+ *   ✗ plain left click is prevented and takes the existing SPA path
+ *       → TypeError: Cannot read properties of null (reading 'dispatchEvent')
+ *   ✗ ⌘/Ctrl click is NOT prevented and does not run the SPA path
+ *       → TypeError: Cannot read properties of null (reading 'dispatchEvent')
+ *   ✗ middle click is NOT prevented and does not run the SPA path
+ *       → TypeError: Cannot read properties of null (reading 'dispatchEvent')
+ * The whole `must-not-change` block below is GREEN in both worlds — that is
+ * what makes it a control rather than a restatement of the fix.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider, RelatedRecordActionsProvider } from '@object-ui/react';
+
+registerAllFields();
+
+const rows = [
+  { id: 'r1', name: 'Alice', amount: 100, account_id: 'acc-1' },
+  { id: 'r2', name: 'Bob', amount: 200, account_id: 'acc-2' },
+];
+
+/**
+ * A host that can route to records, mirroring what `ObjectView` publishes for
+ * the list surface (`listRecordActionsValue`): a URL for the object being
+ * listed, `null` for anything else.
+ */
+function makeHost(overrides: Record<string, unknown> = {}) {
+  return {
+    resolve: () => ({}),
+    recordHref: (objectName: string, recordId: string | number) =>
+      objectName === 'test_object'
+        ? `/apps/demo/${objectName}/record/${encodeURIComponent(String(recordId))}`
+        : null,
+    openRecord: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+function renderGrid(opts?: Record<string, any>, host?: any) {
+  const { onRowClick, ...schemaOverrides } = opts ?? {};
+  const schema: any = {
+    type: 'object-grid' as const,
+    objectName: 'test_object',
+    columns: [
+      { field: 'name', label: 'Name', link: true },
+      { field: 'amount', label: 'Amount', type: 'number' },
+    ],
+    data: { provider: 'value', items: rows },
+    ...schemaOverrides,
+  };
+
+  const grid = <ObjectGrid schema={schema} onRowClick={onRowClick} />;
+  return render(
+    <ActionProvider>
+      {host === null ? grid : (
+        <RelatedRecordActionsProvider value={host ?? makeHost()}>{grid}</RelatedRecordActionsProvider>
+      )}
+    </ActionProvider>,
+  );
+}
+
+/** The first row's link cell, once the grid has rendered its columns. */
+async function firstLinkCell(): Promise<HTMLElement> {
+  await waitFor(() => expect(screen.getByText('Name')).toBeInTheDocument());
+  const cells = await screen.findAllByTestId('link-cell');
+  return cells[0] as HTMLElement;
+}
+
+describe('ObjectGrid link column — a real anchor when the host publishes record URLs (#4490)', () => {
+  it('renders a real anchor at the host-built record URL', async () => {
+    const { container } = renderGrid();
+    await firstLinkCell();
+
+    const anchor = container.querySelector('a[data-testid="link-cell"]');
+    expect(anchor).not.toBeNull();
+    expect(anchor).toHaveAttribute('href', '/apps/demo/test_object/record/r1');
+    // Accessible name is the display text — the cell's content, unchanged.
+    expect(anchor).toHaveAccessibleName('Alice');
+    // Each row addresses its OWN record.
+    const hrefs = Array.from(container.querySelectorAll('a[data-testid="link-cell"]')).map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(hrefs).toEqual([
+      '/apps/demo/test_object/record/r1',
+      '/apps/demo/test_object/record/r2',
+    ]);
+  });
+
+  it('the auto-linked primary field gets the same anchor', async () => {
+    const { container } = renderGrid({
+      columns: [
+        { field: 'name', label: 'Name' },
+        { field: 'amount', label: 'Amount', type: 'number' },
+      ],
+    });
+    await waitFor(() => expect(screen.getByText('Name')).toBeInTheDocument());
+
+    const anchor = container.querySelector('a[data-testid="primary-field-link"]');
+    expect(anchor).toHaveAttribute('href', '/apps/demo/test_object/record/r1');
+  });
+
+  it('plain left click is prevented and takes the existing SPA path, exactly once', async () => {
+    const onRowClick = vi.fn();
+    const { container } = renderGrid({ onRowClick });
+    await firstLinkCell();
+
+    const anchor = container.querySelector('a[data-testid="link-cell"]')!;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    fireEvent(anchor, event);
+
+    // The SPA handler ran once — and only once: the click must not ALSO reach
+    // the row's own click handler underneath (that is what would open the
+    // record twice, or open a second tab on a modifier click).
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0][0]).toMatchObject({ id: 'r1' });
+    // Prevented, so the browser does not ALSO follow the href.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('⌘/Ctrl click is NOT prevented and does not run the SPA path — the browser opens the tab', async () => {
+    const onRowClick = vi.fn();
+    const { container } = renderGrid({ onRowClick });
+    await firstLinkCell();
+
+    const anchor = container.querySelector('a[data-testid="link-cell"]')!;
+    for (const modifier of [{ metaKey: true }, { ctrlKey: true }, { shiftKey: true }, { altKey: true }]) {
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0, ...modifier });
+      fireEvent(anchor, event);
+      expect(event.defaultPrevented).toBe(false);
+    }
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('middle click is NOT prevented and does not run the SPA path', async () => {
+    const onRowClick = vi.fn();
+    const { container } = renderGrid({ onRowClick });
+    await firstLinkCell();
+
+    const anchor = container.querySelector('a[data-testid="link-cell"]')!;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 1 });
+    fireEvent(anchor, event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('a host that cannot route to this object publishes no href — the span stays', async () => {
+    const { container } = renderGrid({}, makeHost({ recordHref: () => null }));
+    const cell = await firstLinkCell();
+
+    expect(container.querySelector('a[data-testid="link-cell"]')).toBeNull();
+    expect(cell.tagName).toBe('SPAN');
+    expect(cell).toHaveAttribute('role', 'link');
+  });
+
+  it('a host published without `recordHref` at all publishes no href', async () => {
+    const { container } = renderGrid({}, { resolve: () => ({}) } as any);
+    const cell = await firstLinkCell();
+
+    expect(container.querySelector('a[data-testid="link-cell"]')).toBeNull();
+    expect(cell.tagName).toBe('SPAN');
+  });
+});
+
+describe('ObjectGrid link column — must-not-change (#4490)', () => {
+  /**
+   * The graceful-degradation pin. A provider-less host (the Studio designer, an
+   * embedded renderer, a standalone grid) must render the cell it rendered
+   * before this change — asserted as the full markup, not just "no anchor", so
+   * a stray class or attribute cannot slip in unnoticed.
+   */
+  it('no host: the link cell is the byte-identical `span role="link"`', async () => {
+    const { container } = renderGrid({}, null);
+    const cell = await firstLinkCell();
+
+    expect(container.querySelector('a[data-testid="link-cell"]')).toBeNull();
+    expect(cell.outerHTML).toBe(
+      '<span role="link" tabindex="0" data-testid="link-cell" ' +
+        'class="text-primary font-medium underline-offset-4 hover:underline cursor-pointer ' +
+        'truncate block max-w-full">Alice</span>',
+    );
+  });
+
+  it('no host: plain click still takes the SPA path, and does not double-fire', async () => {
+    const onRowClick = vi.fn();
+    const { container } = renderGrid({ onRowClick }, null);
+    const cell = await firstLinkCell();
+
+    fireEvent.click(cell);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('a[data-testid="link-cell"]')).toBeNull();
+  });
+
+  it('non-link columns are untouched — no anchor anywhere but the link column', async () => {
+    const { container } = renderGrid();
+    await firstLinkCell();
+
+    const anchors = Array.from(container.querySelectorAll('a'));
+    expect(anchors.every((a) => a.getAttribute('data-testid') === 'link-cell')).toBe(true);
+    // The number column renders its value, with no link affordance.
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('100').closest('a')).toBeNull();
+  });
+
+  it('a lookup column pointing at ANOTHER object stays plain — this host cannot route there', async () => {
+    const { container } = renderGrid({
+      columns: [
+        { field: 'name', label: 'Name', link: true },
+        { field: 'account_id', label: 'Account', type: 'lookup', reference_to: 'crm_account' },
+      ],
+    });
+    await firstLinkCell();
+
+    // `recordHref('crm_account', …)` is null for this host, so #4489's lookup
+    // link stays unrendered — exactly as it renders today.
+    const anchors = Array.from(container.querySelectorAll('a'));
+    expect(anchors.every((a) => a.getAttribute('data-testid') === 'link-cell')).toBe(true);
+  });
+
+  it('a row with no id gets no anchor — nothing to address', async () => {
+    const { container } = renderGrid({
+      data: { provider: 'value', items: [{ name: 'Nameless', amount: 1 }] },
+    });
+    await firstLinkCell();
+
+    expect(container.querySelector('a[data-testid="link-cell"]')).toBeNull();
+  });
+});

--- a/packages/plugin-grid/src/__tests__/ObjectGrid.linkCellAnchor.test.tsx
+++ b/packages/plugin-grid/src/__tests__/ObjectGrid.linkCellAnchor.test.tsx
@@ -24,17 +24,29 @@
  * handed to the existing SPA path, modifier / non-primary clicks are left to
  * the browser.
  *
- * RED-FIRST, measured on this file against the unfixed `ObjectGrid`:
+ * RED-FIRST — the fix was committed, then `ObjectGrid.tsx` and `ObjectView.tsx`
+ * were reverted to `origin/main` with these tests kept. MEASURED, 5 red / 7
+ * green in this file:
  *   ✗ renders a real anchor at the host-built record URL
  *       → AssertionError: expected null not to be null   (the span, no <a>)
- *   ✗ plain left click is prevented and takes the existing SPA path
- *       → TypeError: Cannot read properties of null (reading 'dispatchEvent')
+ *   ✗ the auto-linked primary field gets the same anchor
+ *       → expect(received).toHaveAttribute()  (received null)
+ *   ✗ plain left click is prevented and takes the existing SPA path, exactly once
+ *       → Unable to fire a "click" event - please provide a DOM element
  *   ✗ ⌘/Ctrl click is NOT prevented and does not run the SPA path
- *       → TypeError: Cannot read properties of null (reading 'dispatchEvent')
+ *       → Unable to fire a "click" event - please provide a DOM element
  *   ✗ middle click is NOT prevented and does not run the SPA path
- *       → TypeError: Cannot read properties of null (reading 'dispatchEvent')
- * The whole `must-not-change` block below is GREEN in both worlds — that is
- * what makes it a control rather than a restatement of the fix.
+ *       → Unable to fire a "click" event - please provide a DOM element
+ *
+ * The three click cases fail by NOT FINDING the anchor rather than by
+ * observing the wrong click behavior — worth stating, because it bounds what
+ * they prove against `origin/main`: there, "no anchor" and "an anchor that
+ * mishandles modifier clicks" are indistinguishable. They discriminate in the
+ * FORWARD direction, pinning the split as `LinkCell` is edited from here on.
+ *
+ * The whole `must-not-change` block below, plus the two "host publishes no
+ * href" cases, are GREEN in both worlds — that is what makes them controls
+ * rather than a restatement of the fix.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';


### PR DESCRIPTION
Closes #4490

## What was wrong

The list's `link: true` column — and the auto-linked primary field — rendered as
a `span role="link"` with no `href`, navigating only through
`navigation.handleClick(row)`. So the surface users actually open records from
had none of a link's native affordances: no middle-click / Cmd-click
open-in-new-tab, no "copy link address", no hover status-bar URL. And
`role="link"` without an href is a weaker contract for assistive tech than a
real anchor.

It was also the odd one out. PR #4489 had just given record-detail and
related-list lookup VALUES real anchors, which left the list column as the
weakest of the three surfaces — the reverse of the situation #4336 opened with.

## The seam (the measured question)

`RelatedRecordActionsProvider` mounted only on the record DETAIL body, via
`RelatedRecordActionsBridge` inside `RecordDetailView`. That is exactly why
#4489's anchors reached lookup values there and never reached the list page.

Two candidate seams were measured:

| Seam | Cost |
|---|---|
| **Mount the existing provider on the list host** (`app-shell` `ObjectView`) | No new package dependency — `app-shell` and `plugin-grid` both already depend on `@object-ui/react`, where the context and its `recordHref` (added by #4489) live. No new schema key, no new context member. |
| Thread an href callback through the grid's navigation context | Needs a new `ObjectGridSchema` member in `@object-ui/types` plus threading through `useNavigationOverlay` — a third package and a new public schema surface, for the same result. |

The first was taken: provider-mounting + context consumption, exactly the shape
the ruling allowed. `packages/react`'s context file is **untouched** — #4489
already added `recordHref` / `openRecord`, so no new optional member was
required.

**The URL is not built in the grid.** `ObjectView` publishes its own builder,
and that builder is the SAME expression its "open in new window" navigation
action has always used (strip a trailing `/view/:viewId`, append
`/record/:recordId`, derived from the live pathname). Both now call one
extracted `listRecordDetailUrl`, so the anchor a user middle-clicks and the tab
the row's Cmd-click opens address the same record by construction rather than by
coincidence. That mirrors what #4489 did in the bridge, where `onView` and
`recordHref` were collapsed onto one builder.

Two deliberate limits on what the list host publishes:

- **`recordHref` addresses THIS view's object only.** The builder is derived
  from the current list's pathname, so it cannot name a record of another
  object; any other object returns `null`, which consumers render as the plain
  value. A lookup cell pointing at a third object therefore renders exactly as
  it does today. Inventing a URL for it here is the #4472 mistake — the
  console-wide, any-object builder stays on the detail page's bridge, which has
  the routable-object set this page does not.
- **`resolve` returns no handlers.** A list page has no related lists. The
  context reads an omitted handler as "capability unavailable", i.e. the same
  read-only outcome a consumer gets with no provider at all, so mounting this
  provider grants nothing that was not there before. The record drawer mounts
  `RecordDetailView`, whose bridge wraps the whole detail body — that nearer
  provider keeps owning the detail surface, unchanged.

## The change

`LinkCell` consumes `recordHref` when the host publishes one and renders a real
anchor, with #4489's click split:

- plain left click: `preventDefault()` + the existing `navigation.handleClick(row)`,
  so the SPA path (drawer / modal / page, whatever the view configured) is
  completely unchanged;
- modifier and non-primary clicks: **not** prevented — the browser does what it
  does with any link;
- `stopPropagation()` on every click, including modifier clicks: without it a
  Cmd-click would ALSO reach the row handler, which opens its own tab, for two
  tabs from one click;
- Enter is the anchor's native activation (the browser fires a click, which the
  handler above turns into the SPA path). Space is the one affordance a link
  does not do natively, so it is carried over from the span explicitly.

Accessible name is the display text, unchanged.

## Graceful degradation, pinned

No host `recordHref` (Studio designer, embedded renderers, standalone grids), a
host that cannot route to this object, or a row with no id — all render exactly
today's `span role="link"`. Pinned as the full markup string, not merely "no
anchor", so a stray class or attribute cannot slip in unnoticed.

## Red-first (measured, not predicted)

The fix was committed, then `ObjectGrid.tsx` and `ObjectView.tsx` were reverted
to `origin/main` with the new tests kept. **16 red / 7 green.**

Grid file, 5 red:

```
× renders a real anchor at the host-built record URL
    AssertionError: expected null not to be null      (the span, no anchor)
× the auto-linked primary field gets the same anchor
    expect(received).toHaveAttribute()                (received null)
× plain left click is prevented and takes the existing SPA path, exactly once
    Unable to fire a "click" event - please provide a DOM element
× Cmd/Ctrl click is NOT prevented and does not run the SPA path
    Unable to fire a "click" event - please provide a DOM element
× middle click is NOT prevented and does not run the SPA path
    Unable to fire a "click" event - please provide a DOM element
```

Reported honestly rather than dressed up: the three click cases fail by **not
finding the anchor**, not by observing wrong click behavior. Against
`origin/main`, "no anchor" and "an anchor that mishandles modifier clicks" are
indistinguishable, so those three discriminate in the FORWARD direction only —
they pin the split as `LinkCell` is edited from here on. The case that
discriminates old from new is the first one.

Host file, 11 red — all `TypeError: listRecordDetailUrl is not a function` /
`listRecordActionsValue is not a function`. Also stated plainly in the file:
these are pure functions that do not exist on `origin/main`, so the module dies
at import before an assertion runs. They pin the builder's contract (object
scoping, encoding, the `/view/` strip, call-time pathname read) rather than
proving a behavior change.

**Green in BOTH worlds** (the controls, 7): the whole must-not-change block —
the byte-identical span, plain click still taking the SPA path with no
double-fire, non-link columns untouched, a lookup column pointing at another
object staying plain, a row with no id getting no anchor — plus the two "host
publishes no href" cases.

## Verification

- `pnpm exec vitest run packages/plugin-grid/ …` — **64 files, 605 tests
  passed**.
- `pnpm exec vitest run packages/app-shell/` — **366 files, 3539 passed**, 1
  skipped.
- The landed #4503 / #4510 pins re-run by name alongside the new suites and the
  existing `column-features` link-cell tests: **6 files, 87 tests passed**.
- `tsc --noEmit` and `tsc -p tsconfig.test.json` for **both** touched packages:
  4/4 clean.
- ESLint, baselined against `origin/main` on the two changed source files: **0
  errors both sides**. `ObjectGrid.tsx` 244 warnings unchanged; `ObjectView.tsx`
  157 to 159 — the 2 new ones are `react-refresh/only-export-components`, the
  same warning this file already carries 8 times, one per exported helper its
  tests import. CI deliberately sets no `--max-warnings`.
- `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`:
  all green.

## Grading

Patch on both packages. Measured both ways with `dist/` and `*.tsbuildinfo`
cleared between builds: each package's **entry** `dist/index.d.ts` — the only
path in either `exports` map — is **byte-identical**. The full emitted tree
differs in exactly one module-local file, `app-shell/dist/views/ObjectView.d.ts`,
which gains the two helper declarations; it is not reachable from the entry
(`grep` finds 0 occurrences there) and `views/index.ts` re-exports only
`ObjectView`. Module-local additive, so patch — not minor, never major.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_