### PR TITLE
fix(plugin-charts): the schema normalizer and chart registration are reachable through the published surface (#4529)

### DIFF
--- a/.changeset/plugin-charts-publish-normalize-chart-schema.md
+++ b/.changeset/plugin-charts-publish-normalize-chart-schema.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/plugin-charts': minor
+---
+
+Publish `normalizeChartSchema` from the package entry.
+
+`normalizeChartSchema` is the single place the author-facing chart schema is translated into the renderer's internal pipeline contract, and `ChartRenderer` calls it on every render. It was not reachable from the package's only entry point, so a consumer that wanted to assert what `AdvancedChartImpl` is actually handed had to restate the translation rather than run it. It is now exported from the entry, along with the `NormalizedChartSchema` type it returns.
+
+Additive only: nothing is removed or renamed, and the module was already in the entry's eager import graph via `ChartRenderer`, so this publishes a name rather than shipping new bytes.

--- a/packages/plugin-charts/src/index.tsx
+++ b/packages/plugin-charts/src/index.tsx
@@ -15,6 +15,19 @@ export type { BarChartSchema } from './types';
 export { ChartBarRenderer, ChartRenderer };
 export { ObjectChart, ObjectChartBlock } from './ObjectChart';
 
+// The ONE place the author-facing chart schema is translated into the
+// renderer's internal pipeline contract (#2880 S1). Published from this entry
+// — the package's only door — because a consumer that wants to know what
+// `AdvancedChartImpl` is actually handed has to run the schema through the SAME
+// translation the runtime applies; restating the translation instead would make
+// the assertion a copy of the thing under test (objectui#4529, #4471).
+//
+// Costs nothing to ship: `ChartRenderer` above already imports this module
+// statically, so it is in this entry's eager graph either way. This adds a
+// name, not a byte.
+export { normalizeChartSchema } from './normalizeChartSchema';
+export type { NormalizedChartSchema } from './normalizeChartSchema';
+
 // Standard Export Protocol - for manual integration
 export const chartComponents = {
   'bar-chart': ChartBarRenderer,

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartConfig.dom.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartConfig.dom.test.tsx
@@ -26,16 +26,19 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup, screen, waitFor } from '@testing-library/react';
 
 // Registers `chart` in the ComponentRegistry, which is what `SchemaRenderer`
-// resolves the widget's `{ type: 'chart' }` schema through.
+// resolves the widget's `{ type: 'chart' }` schema through. This is the
+// package's whole published surface, and it is all this file needs: production
+// reaches `AdvancedChartImpl` ONLY through the `React.lazy(() =>
+// import('./AdvancedChartImpl'))` factory inside `ChartRenderer`, so this test
+// reaches it the same way — by rendering the real chain and awaiting the
+// Suspense boundary (objectui#4529). It used to also side-effect import
+// `@object-ui/plugin-charts/AdvancedChartImpl` to pre-warm that chunk, but the
+// package publishes `"."` alone, so that specifier resolved only through this
+// repo's vitest alias — the objectui#4325 packaging gap, whose ruling (PR
+// #4460) is that the unpublished deep subpath goes rather than the surface
+// growing to keep it alive. See `renderWidget` for how the wait it used to
+// shorten is now budgeted instead.
 import '@object-ui/plugin-charts';
-// `ChartRenderer` renders its implementation behind
-// `React.lazy(() => import('./AdvancedChartImpl'))`, and every assertion below
-// lives inside that Suspense boundary. Loading it is unbounded work — under full
-// parallelism a first import of the recharts graph can outlast RTL's 1000ms
-// `waitFor` window — so pay it in the import phase, which no test or hook
-// timeout applies to (AGENTS.md §测试纪律). The alias maps this specifier to the
-// very file the lazy factory imports, so the ESM cache already holds it.
-import '@object-ui/plugin-charts/AdvancedChartImpl';
 import { DatasetWidget } from '../DatasetWidget';
 
 afterEach(cleanup);
@@ -61,7 +64,21 @@ const renderWidget = async (chartConfig?: Record<string, unknown>) => {
   );
   // The chart container only exists once the dataset resolves AND the lazy chart
   // chunk has mounted — i.e. once the whole dashboard chart path really ran.
-  await waitFor(() => expect(view.container.querySelector('[data-slot="chart"]')).not.toBeNull());
+  //
+  // Every witness in this file is post-boundary DOM by design (that is the point
+  // of the file — see the header), so unlike objectui#4325's case the race
+  // cannot be removed by choosing a witness that survives every state of the
+  // boundary. It is BUDGETED instead. Measured on an idle container: 359 ms from
+  // render to chart mount with the lazy chunk cold, against 91 ms when it had
+  // been eagerly pre-imported — so dropping the pre-import moves ~270 ms inside
+  // this wait. That fits RTL's 1000 ms default here and would still be a coin
+  // flip on a loaded machine: AGENTS.md records first-`import()` latencies up to
+  // 976 ms under full parallelism. The budget below is generous on purpose —
+  // `waitFor` polls and returns as soon as the node appears, so a large timeout
+  // costs nothing when the chunk is warm and only spends time it actually needs.
+  await waitFor(() => expect(view.container.querySelector('[data-slot="chart"]')).not.toBeNull(), {
+    timeout: 15000,
+  });
   return view;
 };
 

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.comboPresentation.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.comboPresentation.test.tsx
@@ -47,9 +47,10 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
 // The renderer's own translation layer, imported read-only so these assertions
 // are made against what `AdvancedChartImpl` receives rather than a restatement
-// of it. `plugin-charts` is a devDependency of this package and vitest aliases
-// it to source.
-import { normalizeChartSchema } from '@object-ui/plugin-charts/normalizeChartSchema';
+// of it. `plugin-charts` is a devDependency of this package, and this is its
+// PUBLISHED root entry — the same module `ChartRenderer` calls, reached the way
+// any consumer outside this repo would reach it (objectui#4529).
+import { normalizeChartSchema } from '@object-ui/plugin-charts';
 
 let lastChartSchema: any = null;
 

--- a/packages/plugin-dashboard/tsconfig.test.json
+++ b/packages/plugin-dashboard/tsconfig.test.json
@@ -39,38 +39,23 @@
     //
     // `paths` drops the root tsconfig's source-tree mappings so `@object-ui/*`
     // and `@objectstack/spec` resolve through each workspace dependency's built
-    // `.d.ts` rather than pulling sibling sources in as program inputs (TS6059)
-    // — with ONE deliberate exception, which is not a workaround but a
-    // restatement of what the runtime already does:
+    // `.d.ts` rather than pulling sibling sources in as program inputs (TS6059).
     //
-    //   Two suites import `@object-ui/plugin-charts` SUBPATHS, and the repo's
-    //   vitest config (`vitest.config.mts`) aliases the whole package to its
-    //   source, which is the only reason they resolve when the tests RUN:
-    //     - `DatasetWidget.chartConfig.dom.test.tsx` side-effect imports
-    //       `.../AdvancedChartImpl` at module scope to pre-load the chunk
-    //       `ChartRenderer` reaches through `React.lazy`, so the unbounded first
-    //       import is paid in the import phase instead of inside RTL's 1000 ms
-    //       `waitFor` (AGENTS.md §测试纪律).
-    //     - `DatasetWidget.comboPresentation.test.tsx` imports
-    //       `.../normalizeChartSchema` as a VALUE and runs the emitted schema
-    //       through it, so what it pins is what `AdvancedChartImpl` receives
-    //       rather than a restatement of it.
-    //   Neither subpath is published: `@object-ui/plugin-charts`' `exports` map
-    //   declares `"."` alone, and neither name is on the barrel either, so both
-    //   specifiers exist only inside this repo — the same packaging gap
-    //   objectui#4325 found behind `@object-ui/fields/widgets/*`. Filed as
-    //   objectui#4529 rather than fixed here: what this package publishes is a
-    //   product call, and #4325's own answer ("drop the import") does not
-    //   transfer to `normalizeChartSchema`, which is a VALUE the assertions run
-    //   the emitted schema through. The mapping below points `tsc` at the
-    //   very files vitest loads, so the compiler checks the real modules; it is
-    //   the honest description of today's state, and it should be DELETED the
-    //   moment either the subpaths are published or the imports are rebuilt on
-    //   a witness that does not need them. Values are relative to the inherited
-    //   `baseUrl` (the repo root), not to this file.
-    "paths": {
-      "@object-ui/plugin-charts/*": ["packages/plugin-charts/src/*"]
-    }
+    // Empty, like every other wired-up package's. It briefly carried one
+    // exception — `@object-ui/plugin-charts/*` mapped to that package's source —
+    // because two suites imported subpaths the package does not publish (its
+    // `exports` map declares `"."` alone), so they resolved only through the
+    // repo's vitest alias. objectui#4529 ruled both, and both imports now go
+    // through the published root entry, so the mapping is gone rather than
+    // maintained:
+    //   - `normalizeChartSchema` is a genuine cross-package contract — the
+    //     assertions run the emitted schema through the SAME translation layer
+    //     the runtime applies — so plugin-charts publishes it from its entry.
+    //   - `AdvancedChartImpl` was an eager pre-warm of a chunk production only
+    //     ever reaches through `React.lazy`; the surface does not grow to keep
+    //     an eager deep import alive (objectui#4325 / PR #4460), so the import
+    //     is gone and the wait it shortened is budgeted explicitly instead.
+    "paths": {}
   },
   // `src/**/*.d.ts` is pulled in explicitly: the build program gets ambient
   // declarations for free from `"include": ["src"]`, but an ambient declaration


### PR DESCRIPTION
Fixes #4529.

`@object-ui/plugin-charts` publishes exactly one entry point, and two `plugin-dashboard` suites imported subpaths of it. Both resolved only through the repo's vitest alias; under Node's own resolution, or from any consumer outside this repo, both are `ERR_PACKAGE_PATH_NOT_EXPORTED`. PR #4530 could not fix that from a test-surface card, so it restated the alias as one narrow, commented `paths` entry in `packages/plugin-dashboard/tsconfig.test.json`, with the instruction to delete it once this card ruled.

The two imports are different kinds of dependency and get two different dispositions, each measured rather than assumed.

## 1. `normalizeChartSchema` — a load-bearing value, published from the root entry

**Measured first, per the ruling: is it already reachable from the root entry?** No. `packages/plugin-charts/src/index.tsx` exported `ChartBarRenderer`, `ChartRenderer`, `ObjectChart`, `ObjectChartBlock`, `chartComponents` and the `BarChartSchema` type, and nothing else.

**Is the exclusion deliberate — a lazy-loading or bundle-size constraint?** No, and this is the measurement that decides it: `ChartRenderer.tsx` line 5 imports `normalizeChartSchema` **statically**, and `index.tsx` imports `ChartRenderer` statically. The module is already in the entry's eager graph. Publishing it adds a name, not a byte. So the ruling's fallback (a subpath export for a deliberately-excluded module) does not apply, and the primary branch lands: it is exported from the package root entry, together with the `NormalizedChartSchema` type it returns so the published function's contract is nameable.

This is a genuine cross-package contract, not a test convenience. The assertions run the widget's emitted schema through the same translation layer the runtime applies, which is exactly what a consumer does; restating that translation in the test instead would replace the test with a copy of the thing under test (#4471).

## 2. `AdvancedChartImpl` — the #4325 precedent transfers, and the deep import goes

**Measured: how does production load it?** One way only. `ChartRenderer.tsx`:

```
const LazyAdvancedChart = React.lazy(() => import('./AdvancedChartImpl'));
```

There is no eager path anywhere in production. The test's side-effect import existed only to pre-warm that chunk so the unbounded first import was paid in the import phase rather than inside RTL's 1000 ms `waitFor`.

**Measured: does the published barrel preload it?** No — #4460's refutation of "preload through the public index" reproduces here rather than being cited. After importing `@object-ui/plugin-charts`, a first dynamic import of the implementation costs **60.3 ms**; a genuine cache hit immediately after costs **0.0 ms**. The barrel evaluates the module that *declares* the lazy factory; the factory never runs.

So the surface does not grow to keep an eager deep import alive (#4325, PR #4460). The import is deleted and the test reaches the registration exactly the way production does: render the real chain and await the Suspense boundary.

**Measured: what does that cost, and how is it handled?** Unlike #4325's case, the race cannot be removed by choosing a better witness — every witness in this file is post-boundary DOM *by design*, which is the entire point of the file. So it is budgeted instead. On an idle container, render to chart mount takes **359.1 ms** with the chunk cold against **91.4 ms** when eagerly pre-imported, so dropping the pre-import moves about 270 ms inside that one wait. That fits the 1000 ms default here and would still be a coin flip on a loaded machine — AGENTS.md records first-import latencies up to 976 ms under full parallelism — so the single `waitFor` that spans the boundary is given an explicit 15 s budget. `waitFor` polls and returns as soon as the node appears, so the budget costs nothing when the chunk is warm.

**No test semantics changed.** Same assertions, same witnesses, same `renderWidget`, in both files. The deleted import was a preload, never a witness; the changed import in `DatasetWidget.comboPresentation.test.tsx` is the same function reached by its published spelling.

## 3. The transitional `paths` entry is deleted

`packages/plugin-dashboard/tsconfig.test.json` now carries `"paths": {}`, like every other wired-up package, with the comment rewritten to record what was ruled rather than what was owed.

## Red-first

Predicted in writing before running: deleting the `paths` entry with the imports unchanged reports **exactly** the two errors #4529 quoted, and nothing else.

```
src/__tests__/DatasetWidget.chartConfig.dom.test.tsx(38,8): error TS2882: Cannot find module or type declarations for side-effect import of '@object-ui/plugin-charts/AdvancedChartImpl'.
src/__tests__/DatasetWidget.comboPresentation.test.tsx(52,38): error TS2307: Cannot find module '@object-ui/plugin-charts/normalizeChartSchema' or its corresponding type declarations.
```

Exit 2, error count 2. After the fix, `tsc -p tsconfig.test.json` exits **0** with `"paths": {}` — both imports resolving through the published surface.

## Reverse verification — direction predicted first, and it is not the obvious one

Reverting all four files returns to `origin/main`, which was **green** (the `paths` entry restated the alias), so that direction proves nothing. The load-bearing question is whether the new published surface is what carries the value import, so the limb removed was `packages/plugin-charts/src/index.tsx` **alone**, with the tests' new spellings and the emptied `paths` left in place. Three predictions, all confirmed:

| predicted | measured |
|---|---|
| `dist/index.d.ts` returns byte-identical to the pre-fix baseline | sha256 `05539ce9…` both times |
| exactly one error, **TS2305** (missing member, not TS2307/TS2882 — the module resolves now) | `DatasetWidget.comboPresentation.test.tsx(53,10): error TS2305: Module '"@object-ui/plugin-charts"' has no exported member 'normalizeChartSchema'.` — 1 error |
| `chartConfig.dom.test.tsx` stays **silent**, since it imports only the barrel for its side effect | silent — which is the evidence the two dispositions are genuinely independent |

Taken out with `git checkout --` and restored from a sha256-verified copy (`2c6f2834…`, matched after restore), never `git stash`. Rebuilt and re-checked green afterwards.

## The `.d.ts` diff, measured both ways

`dist/` and `tsconfig.tsbuildinfo` cleared between builds. The entire diff:

```
4a5,6
> export { normalizeChartSchema } from './normalizeChartSchema';
> export type { NormalizedChartSchema } from './normalizeChartSchema';
```

Additive only — nothing removed, nothing renamed, no signature narrowed. Measured in the other direction too: removing the limb returns the file to the baseline hash exactly. Minor, never major.

## Green, and what must not change

| check | result |
|---|---|
| `tsc -p tsconfig.test.json` (plugin-dashboard tests) | exit 0 |
| `pnpm --filter @object-ui/plugin-dashboard type-check` (both passes) | exit 0 |
| `pnpm --filter @object-ui/plugin-charts type-check` | exit 0 |
| `vitest run packages/plugin-dashboard/` | **47 files, 388 tests passed** — the #4530 number, unchanged |
| `vitest run packages/plugin-dashboard/ packages/plugin-charts/` | 72 files, 575 tests passed |
| `node scripts/check-type-check-coverage.mjs` | exit 0 — 41/41 tests compiled, 0 declared debt (#4530's wiring intact) |
| `node scripts/check-control-bytes.mjs` | exit 0 (4252 files) |
| `node scripts/check-phantom-dependencies.mjs` | exit 0 |
| `check-changeset-presence` / `-no-major` / `-fixed` | exit 0 |
| `eslint` on all changed files | **0 errors** |

## One declared deviation

ESLint gains **one new warning**, not zero: `react-refresh/only-export-components` at `packages/plugin-charts/src/index.tsx:28`, on the new `export { normalizeChartSchema }` line. Baseline for that file on `origin/main` is 1 warning of the same rule on the same grounds (its pre-existing `chartComponents` export); my tree has 2. It is an inherent consequence of adding a value export to a barrel that already trips this rule, and it is left un-suppressed rather than silenced with a disable comment that its identical neighbour does not carry. Zero errors, and the lint workflow deliberately does not set `--max-warnings`. The two test files are unchanged at 13 warnings / 0 errors, all pre-existing `no-explicit-any`.

Changeset: `@object-ui/plugin-charts` **minor** — entry-reachable additive growth, as ruled. `plugin-dashboard`'s changes are two test files and a test-only tsconfig, which release nothing.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_