### PR TITLE
chore(build): fields and plugin-editor stop publishing test declarations — coverage moves to the chained test project (#4006)

### DIFF
--- a/.changeset/fields-plugin-editor-dist-test-declarations-4006.md
+++ b/.changeset/fields-plugin-editor-dist-test-declarations-4006.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/fields': patch
+'@object-ui/plugin-editor': patch
+---
+
+`@object-ui/fields` and `@object-ui/plugin-editor` stop publishing their test declarations
+
+Both packages' build tsconfigs set `include: ["src"]` with no test exclude, so every test file entered the declaration program and its `.d.ts` was written into `dist/`. Both are published (`private` is false, `files` contains `dist`), so those declarations shipped: 85 from `@object-ui/fields` and one from `@object-ui/plugin-editor`. Adding the test exclude the other twenty-odd packages already use removes them.
+
+Nothing else about either artifact moves. Measured by building each package both ways from a cleared `dist/`, then diffing the file lists: `@object-ui/fields` goes from 163 files to 78 and `@object-ui/plugin-editor` from 6 to 5, every one of the 86 disappearances is a `*.test.d.ts`, no file appears, and all 83 surviving files are byte-identical by sha256 — including each package's entry `dist/index.d.ts`. The entry type surface is therefore unchanged and no import can break; this is the tarball shedding files nothing resolved.
+
+The type coverage those files were a side effect of did not go with them. Because the build program read the tests, these two packages counted as "tests type-checked" in `scripts/check-type-check-coverage.mjs` — a correct verdict reached through an emit nobody wanted. Excluding the tests alone would have silently dropped 86 test files out of every `tsc` program, so the same change adds a `tsconfig.test.json` per package, chained from each package's `type-check` script, and the coverage gate stays at 41 of 41 packages compiling their tests with zero declared debt on both sides of the change.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc && vite build && node scripts/build-css.mjs",
     "clean": "rm -rf dist",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "test": "vitest run",
     "lint": "eslint ."
   },

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -2,8 +2,24 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    // `..` (i.e. `packages/`), NOT `src` — load-bearing, measured in
+    // objectui#4006. This config inherits the root tsconfig's `paths`, which map
+    // `@object-ui/core` / `@object-ui/types` to their sibling `packages/*/src`
+    // trees, so those sources are real program inputs. Narrowing `rootDir` to
+    // `src` (or dropping it, which defaults it to the common source directory)
+    // turns all 122 of them into TS6059 "not under rootDir" — and it does so
+    // even under `--noEmit`, because TS6059 is a program-level verdict. It does
+    // not affect what is emitted: this config inherits the root's
+    // `noEmit: true`, so `tsc` here only CHECKS; `dist` is written by
+    // vite-plugin-dts, which overrides `rootDir` to `src` and clears `paths`.
     "rootDir": "..",
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Tests are excluded from the BUILD program so they stop being emitted into
+  // the published `dist` (objectui#4006 — 85 `*.test.d.ts` shipped from here).
+  // Their type coverage did not go away with them: it moved to the
+  // `tsconfig.test.json` chained off this package's `type-check` script, which
+  // is what scripts/check-type-check-coverage.mjs verifies.
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/fields/tsconfig.test.json
+++ b/packages/fields/tsconfig.test.json
@@ -1,0 +1,62 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` now excludes.
+  // See `packages/plugin-dashboard/tsconfig.test.json` for the template and
+  // `packages/types/tsconfig.test.json` for why the exclusion would otherwise
+  // be a hole: a test nothing compiles can assert a contract the compiler never
+  // checked and then read as evidence that the contract holds (objectui#3009).
+  //
+  // The hole is NEW here, and that is the whole point of objectui#4006. Until
+  // this file existed these 85 tests were checked — but only as a SIDE EFFECT
+  // of the build config having no test exclude at all, which is also why 85
+  // `*.test.d.ts` were emitted into the published `dist/`. Removing the emit
+  // therefore had to move the coverage in the same commit, not after it:
+  // scripts/check-type-check-coverage.mjs fails 5c the moment the exclude
+  // lands alone (measured — it names all 85 files).
+  //
+  // Chained from this package's `type-check` script, which is what the CI
+  // `Type Check` job runs; the coverage gate enforces the chaining — a config
+  // nothing runs is the objectui#3009 failure itself.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // A checking project, never an emitting one. The build config inherits the
+    // root's `noEmit: true` as well (this package emits `dist` from
+    // vite-plugin-dts, not from `tsc`), but stating it here is what the gate
+    // requires and what keeps this project from ever growing an output.
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "jsx": "react-jsx",
+    // Deliberately NOT raised to ES2022. Measured: no test file in this package
+    // reaches for `Array.prototype.at` or any other ES2021+ builtin, so the
+    // tests are held to the same lib the shipped SOURCE targets.
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    //
+    // `types` is deliberately NOT named, unlike plugin-dashboard's. Naming it
+    // switches off automatic `@types/*` inclusion, and this package's build
+    // program does not name it either — so leaving it unset is what reproduces
+    // the exact program these tests were checked by until now, which is the
+    // property objectui#4006 had to preserve while moving the coverage.
+    // Measured: no test file here uses `global`, and the seven suites that use
+    // `@testing-library/jest-dom` matchers `import '@testing-library/jest-dom'`
+    // explicitly, so its global augmentation reaches the whole program through
+    // that import (plugin-list's lesson).
+    //
+    // `paths` drops the root tsconfig's source-tree mappings so `@object-ui/*`
+    // and `@objectstack/spec/*` resolve through each workspace dependency's
+    // built `.d.ts` rather than pulling sibling package sources in as program
+    // inputs. `type-check` dependsOn `^build` (turbo.json), so those `.d.ts`
+    // exist by the time this runs. This is the one place the project is
+    // deliberately STRICTER than the program it replaces: the build config
+    // keeps the root `paths` (and the `rootDir: ".."` that lets sibling sources
+    // sit inside the root), so until now these tests were checked against
+    // sibling SOURCE. Checking them against the built declarations is what the
+    // published contract actually is, and it is what every other chained test
+    // project in this repo does. Measured: zero new errors either way.
+    "paths": {}
+  },
+  // Only the test files. Note there is no ambient `*.d.ts` under `src/` in this
+  // package today — if one is ever added it must be NAMED here, because being
+  // imported is not enough to make an ambient declaration a program input, and
+  // nothing imports one (plugin-map's lesson, objectui#4270).
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/plugin-editor/package.json
+++ b/packages/plugin-editor/package.json
@@ -27,7 +27,7 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/plugin-editor/tsconfig.json
+++ b/packages/plugin-editor/tsconfig.json
@@ -13,5 +13,14 @@
     "composite": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Tests are excluded from the BUILD program so they stop being emitted into
+  // the published `dist` (objectui#4006 — `dist/index.test.d.ts` shipped from
+  // here). The emitter is vite-plugin-dts, whose own `include: ['src']` in
+  // `vite.config.ts` does NOT displace this `exclude`: measured, the exclude
+  // alone removes `dist/index.test.d.ts`, so no dts-plugin `exclude` is needed.
+  // Their type coverage did not go away with them: it moved to the
+  // `tsconfig.test.json` chained off this package's `type-check` script, which
+  // is what scripts/check-type-check-coverage.mjs verifies.
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/plugin-editor/tsconfig.test.json
+++ b/packages/plugin-editor/tsconfig.test.json
@@ -1,0 +1,45 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` now excludes.
+  // Template: `packages/plugin-dashboard/tsconfig.test.json` (objectui#4530);
+  // rationale: `packages/types/tsconfig.test.json`. A test nothing compiles can
+  // assert a contract the compiler never checked and then read as evidence that
+  // the contract holds (objectui#3009).
+  //
+  // As in `@object-ui/fields`, the hole is new and deliberate: until
+  // objectui#4006 this suite was checked only as a side effect of the build
+  // config having no test exclude, which is also how `dist/index.test.d.ts`
+  // came to be published. The exclude and this project are one change —
+  // scripts/check-type-check-coverage.mjs fails 5c on the exclude alone
+  // (measured).
+  //
+  // Chained from this package's `type-check` script, which is what the CI
+  // `Type Check` job runs; the coverage gate enforces the chaining.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // A checking project, never an emitting one. This matters more here than in
+    // most packages: this package's BUILD config deliberately sets
+    // `noEmit: false` with `declaration` and `composite`, so those three must be
+    // turned back off rather than inherited — this project extends the ROOT
+    // config, not the build one, but stating them keeps that true if the
+    // `extends` target ever changes.
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "jsx": "react-jsx",
+    // Measured: the single suite compiles clean against the root's ES2020
+    // baseline, so the test is held to the same lib the shipped SOURCE targets.
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    // `paths` drops the root tsconfig's source-tree mappings so `@object-ui/*`
+    // resolves through each workspace dependency's built `.d.ts` rather than
+    // pulling sibling package sources in as program inputs. `type-check`
+    // dependsOn `^build` (turbo.json), so those `.d.ts` exist by the time this
+    // runs. The suite imports exactly one workspace specifier,
+    // `@object-ui/core`, plus its own `./index`.
+    "paths": {}
+  },
+  // Only the test files. There is no ambient `*.d.ts` under `src/` in this
+  // package today — if one is ever added it must be NAMED here, because being
+  // imported is not enough to make an ambient declaration a program input
+  // (plugin-map's lesson, objectui#4270).
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}


### PR DESCRIPTION
Fixes #4006

Both packages' build tsconfigs set `include: ["src"]` with no test exclude, so every test file entered the declaration program and its `.d.ts` was written into `dist/`. Both are published (`private` is false, `files` contains `dist`), so those declarations shipped.

## Premise: holds, with the count drifted upward

Measured on `origin/main` @ f56541826, clean `dist/`, both packages built:

```
$ find packages/fields/dist packages/plugin-editor/dist -name '*.test.d.ts' | wc -l
86
```

86, not the 73 the card recorded on 2026-08-09 — 85 from `@object-ui/fields` (one per test file, exactly) and one from `@object-ui/plugin-editor` (`dist/index.test.d.ts`). The suites grew; the defect did not change shape.

One mechanism correction worth recording, because it decides item 4. The card reads as though `tsc` emits these. It does not: **both** packages inherit `noEmit: true` from the root tsconfig, and `packages/fields` never overrides it. So `tsc` in the fields build script only CHECKS, and every file in either `dist/` — the test declarations included — is written by **vite-plugin-dts**.

## Both halves, one commit

Adding the exclude alone would have been a regression, and the card said so. These two packages counted as "tests type-checked" in `scripts/check-type-check-coverage.mjs` precisely BECAUSE the build program read the tests — a correct verdict reached through an emit nobody wanted. Measured, exclude only:

```
❌  type-check coverage regressed:
    • @object-ui/fields (packages/fields) has 85 test files that no `tsc`
      invocation reads: its tsconfig.json program does not include them (correctly — it is the
      build config) and no tsconfig.test.json chains off "type-check".
    • @object-ui/plugin-editor (packages/plugin-editor) has 1 test file that no `tsc`
      invocation reads: ...
```

So the coverage moves in the same commit: a `tsconfig.test.json` per package on the plugin-dashboard (#4530) template, chained from each `type-check` script. Gate on **both** sides of the change:

```
✅  test type-check coverage: 41/41 packages compile their tests, 0 declared debt (0 errors outstanding), 0 with a narrow type-assertion project.
```

`scripts/check-type-check-coverage.mjs` needed no edit — it reads resolved tsconfig programs, so the new projects are picked up with no registry or table entry, as the #4530-era design intends.

## Discrimination proof, direction-checked

A type error planted in one test file per package (`coerce-safe-value.test.ts:37`, `index.test.ts:103`), then all three programs run against it:

| program | fields | plugin-editor |
|---|---|---|
| build config, **pre**-change | RED `TS2322` | RED `TS2322` |
| build config, **post**-change | silent, exit 0 | silent, exit 0 |
| new chained test project | RED `TS2322` on line 37 | RED `TS2322` on line 103 |

```
src/coerce-safe-value.test.ts(37,7): error TS2322: Type 'number' is not assignable to type 'string'.
src/index.test.ts(103,7): error TS2322: Type 'number' is not assignable to type 'string'.
```

The pre-change row is the one that matters: it shows the coverage genuinely **moved** rather than vanished. Plants removed, both files verified byte-identical by sha256 and `git diff` empty.

As predicted, moving the chain surfaced **zero** new type errors — these tests were already being checked, just by the wrong program.

## Published artifact: only the test declarations leave

Each package built both ways from a cleared `dist/` (and any `*.tsbuildinfo` removed between builds), file lists and sha256 diffed:

| | fields | plugin-editor |
|---|---|---|
| files before / after | 163 / 78 | 6 / 5 |
| disappeared | 85, **all** `*.test.d.ts` | 1, `dist/index.test.d.ts` |
| appeared | none | none |
| survivors byte-identical | 78 / 78 | 5 / 5 |
| entry `dist/index.d.ts` | identical `f69dd08…` | identical `d393aee…` |

`dist/__tests__/` and `dist/widgets/__tests__/` are simply no longer created; no `.map` siblings were involved (neither package sets `declarationMap`).

For plugin-editor specifically the card asked whether the exclude reaches what the dts plugin actually reads, since its `vite.config.ts` passes its own `include: ['src']`. Measured: it does — `dist/index.test.d.ts` is gone with the tsconfig `exclude` alone, so **no** `vite.config.ts` change is needed and none was made.

Nothing referenced the removed files: neither package's `exports` map exposes a deep path, and a repo-wide grep for `dist/__tests__` / `dist/index.test` finds only the new comments in this PR.

## Item 4 — `packages/fields`' `rootDir: ".."`: load-bearing, left alone

Blamed first: added in 45093dc36 (2026-01-29, "chore: remove unused fields dependency and update tsconfig for clarity"), with no stated reason.

Measured rather than guessed — removing it:

```
../core/src/actions/ActionRunner.ts(28,59): error TS6059: File '.../packages/core/src/actions/UndoManager.ts' is not under 'rootDir' '.../packages/fields'. 'rootDir' is expected to contain all source files.
```

122 such errors, from `packages/core` and `packages/types`. The config inherits the root tsconfig's `paths`, which map those specifiers to sibling `src` trees, so they are real program inputs and must sit under `rootDir` — and TS6059 fires even under `--noEmit`, being a program-level verdict. It has no effect on what is emitted, since `tsc` here emits nothing.

So it stays, with that reasoning recorded in the file itself so the next reader does not "normalize" it away.

## Verification

- `node scripts/check-type-check-coverage.mjs` — green pre and post, red on the half-change (above)
- `pnpm --filter @object-ui/fields --filter @object-ui/plugin-editor type-check` — both, real scripts, exit 0
- `pnpm exec vitest run packages/fields/ packages/plugin-editor/` — 86 files, 1355 tests, all pass, no test source touched
- Downstream consumer sweep, **prefix** (`...pkg`) direction = consumers: 19 packages, `55 successful, 55 total`
- `check:control-bytes`, `check:phantom-deps`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed` — all green
- `scripts/__tests__/check-type-check-coverage.test.ts` — 37 tests pass

## Changeset

Patch for both packages. The presence gate does not demand one here (`0 of them under the src/ of a package the release covers ... no changeset is owed`), but the published tarball of two released packages does change, so the declaration is written anyway — which the gate accepts and the card's ruling calls for. Never major; `check-changeset-no-major` confirms.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_