### PR TITLE
fix(app-shell): the default-inspector family and its panel hosts gate Save on CEL errors (#4527)

### DIFF
--- a/.changeset/default-inspector-family-cel-save-gate-4527.md
+++ b/.changeset/default-inspector-family-cel-save-gate-4527.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The default-inspector family and its panel hosts gate Save on CEL errors — a hook guard, an action predicate or a validation rule that does not parse no longer saves
+
+#4306 gave the SCOPED inspectors a way to say "what I am showing is not saveable" (`MetadataInspectorProps.onBlockingIssuesChange`), and #4527's first half wired the shared CEL editors to it. That left the other half of the console still publishing malformed expressions, for a structural reason rather than an oversight: there are TWO inspector registries, and only one of them had the channel. `MetadataDefaultInspectorProps` — the contract every "no selection" inspector is rendered through — had no such member, so the hook guard, an action's `visible` / `disabled` predicates and a view's conditional-formatting rules on the home panel rendered their inline parse errors while Save stayed writable, and no host could pass a callback that did not exist.
+
+`MetadataDefaultInspectorProps` now carries the same optional `onBlockingIssuesChange`. `HookDefaultInspector` reports its guard; `ActionDefaultInspector` aggregates its two predicate editors through a per-site map, because two editors lint independently and a shared counter would hand back a writable Save the moment one of two broken predicates was fixed; the view home panel already aggregated and now has a contract to report through.
+
+The hosts that own the buttons hold and expire those counts. The metadata editor gates its no-selection branch as well as its scoped one, stamping each so neither reads the other's verdict. Studio's design pillar gates its rail at last — that was an unfinished edge of #4306 rather than new ground, since the same malformed-CEL publish was reachable there with the gate inert, including for the field inspector. The Data pillar gains a second count for its panel family: the validations, actions and settings panels write through the object draft and own no Save, so their faults have to reach the pillar's button, and the count is stamped with the panel tab because only one panel is mounted at a time and a tab the author has left can never retract its verdict. The hooks panel is the one panel that writes on its own (`client.save('hook', …)`), so it gates its own per-hook Save.
+
+Every count is DERIVED from what it describes rather than repaired by a reset effect, and pruned by what still exists: a deleted validation rule or action drops out of the total immediately, so a fault can never wedge Save shut with no editor left on screen to fix it in. A faulty rule the author merely navigates away from stays counted, because it is still in the document and saving would still publish it.
+
+Also wired: the object validations panel, a sixth `ConditionBuilder` consumer that the original report did not list. Still deferred by ruling: `widgets.tsx`'s condition widget, a `SchemaForm` widget needing widget-context plumbing.

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.defaultGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.defaultGate.test.tsx
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The metadata editor's Save must refuse a DEFAULT-inspector fault too —
+ * objectui#4527 phase 2.
+ *
+ * PR #4547 gated this host on the SCOPED inspector's verdict
+ * ({@link file://./ResourceEditPage.celGate.test.tsx}). With no selection the
+ * editor renders the registered DEFAULT inspector instead, and that branch
+ * passed no `onBlockingIssuesChange` — `MetadataDefaultInspectorProps` had no
+ * such member to pass. A view's conditional-formatting rules live on exactly
+ * that branch, so a rule whose CEL does not parse saved and published.
+ *
+ * ## Why `view`, measured rather than assumed
+ *
+ * This host only reaches a default inspector when the type ALSO has a canvas
+ * preview: the panel that renders it sits inside the `PreviewComponent` branch,
+ * and a type without one falls through to a plain `SchemaForm`. Of the types
+ * that have both, `view` is the one whose default inspector mounts CEL
+ * (`ViewDefaultInspector` -> `ViewVariantInspector` -> the formatting editor),
+ * so it is the type this gate is actually reachable through. The `hook` and
+ * `action` default inspectors are NOT reachable from this host at all — they
+ * are edited through the Studio panels and gated in their own suites.
+ *
+ * Only the canvas is stubbed, and only so that a preview exists and no
+ * selection is emitted; everything under test — the registered default
+ * inspector, the real formatting editor, this host's real hold and its real
+ * Save button — is the shipping code.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const viewDef = {
+  name: 'invoices',
+  label: 'Invoices',
+  list: {
+    type: 'grid',
+    object: 'invoice',
+    columns: ['status', 'amount'],
+    conditionalFormatting: [{ condition: '', style: {} }],
+  },
+};
+
+const mockClient = {
+  list: vi.fn(async () => []),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async () => ({ effective: viewDef, code: viewDef, editable: true })),
+  getDraft: vi.fn(async () => null),
+  get: vi.fn(async () => null),
+  saveDraft: vi.fn(async () => ({})),
+};
+
+vi.mock('./useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({
+      entries: [{ type: 'view', name: 'view', label: 'View', allowOrgOverride: true }],
+    }),
+  };
+});
+
+import { MetadataResourceEditPage } from './ResourceEditPage';
+import { registerBuiltinInspectors } from './inspectors';
+import { registerMetadataPreview, getMetadataPreview } from './preview-registry';
+import { __setCelFormulaLoader } from './celAuthoring';
+
+registerBuiltinInspectors();
+
+const DANGLING = /[*+\-/&|=<>]\s*$/;
+
+function stubEngine() {
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: (_role: string, input: unknown) => {
+        const src = typeof input === 'string' ? input : String((input as { source?: string })?.source ?? '');
+        return DANGLING.test(src)
+          ? { ok: false, errors: [{ message: 'Parse error: expression ends after an operator' }], warnings: [] }
+          : { ok: true, errors: [], warnings: [] };
+      },
+      introspectScope: () => ({ fields: ['status', 'amount'], roots: ['record'], functions: ['has'] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+}
+
+/**
+ * Canvas stand-in: exists so the host takes its split-editor branch, and emits
+ * no selection, so the DEFAULT inspector is what fills the rail.
+ */
+function StubViewCanvas() {
+  return <div data-testid="stub-view-canvas" />;
+}
+
+const realViewPreview = getMetadataPreview('view');
+
+beforeEach(() => {
+  stubEngine();
+  registerMetadataPreview('view', StubViewCanvas as never);
+});
+
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+  if (realViewPreview) registerMetadataPreview('view', realViewPreview);
+});
+
+/** The Save icon button, identified by its title in either state. */
+const saveButton = () =>
+  screen.getByRole('button', { name: /Save \(⌘S\)|Fix the CEL syntax errors before saving\./ });
+
+const ruleBox = () =>
+  screen.getByTestId('cf-rule-0').querySelector('[role="combobox"]') as HTMLTextAreaElement;
+
+/** Open the view editor and hand back its first formatting rule's CEL box. */
+async function openRule() {
+  render(
+    <MemoryRouter initialEntries={['/metadata/view/invoices']}>
+      <MetadataResourceEditPage type="view" name="invoices" />
+    </MemoryRouter>,
+  );
+  await screen.findByTestId('cf-rule-0');
+  return ruleBox();
+}
+
+describe('MetadataResourceEditPage — Save is gated on the DEFAULT inspector’s CEL verdict (#4527)', () => {
+  it('refuses a formatting rule whose condition does not parse', async () => {
+    const box = await openRule();
+
+    // A valid condition first: dirties the draft (so Save is live at all) and
+    // pins the must-not-change half — a good condition never blocks.
+    fireEvent.change(box, { target: { value: "record.status == 'overdue'" } });
+    await waitFor(() => expect(saveButton()).toBeEnabled(), { timeout: 4000 });
+
+    fireEvent.change(box, { target: { value: 'record.amount >' } });
+    await waitFor(() => expect(saveButton()).toBeDisabled(), { timeout: 4000 });
+    expect(saveButton()).toHaveAttribute('title', 'Fix the CEL syntax errors before saving.');
+  });
+
+  it('re-enables Save once the condition parses again', async () => {
+    const box = await openRule();
+
+    fireEvent.change(box, { target: { value: 'record.amount >' } });
+    await waitFor(() => expect(saveButton()).toBeDisabled(), { timeout: 4000 });
+
+    fireEvent.change(box, { target: { value: "record.status == 'overdue'" } });
+    await waitFor(() => expect(saveButton()).toBeEnabled(), { timeout: 4000 });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ResourceEditPage.tsx
@@ -508,7 +508,14 @@ function MetadataResourceEditPageImpl({
   // component that has gone away cannot retract its last verdict, and a host
   // that waited for one would wedge Save shut.
   const [blockingReport, setBlockingReport] = React.useState({ key: '', count: 0 });
-  const selectionKey = selection ? `${type}:${name}:${selection.kind}:${selection.id}` : '';
+  // Covers BOTH inspector branches. With no selection the editor renders the
+  // registered DEFAULT inspector instead, and that surface hosts CEL too (a
+  // hook's guard, an action's predicates, a view's formatting rules) — so it
+  // gets its own stamp rather than sharing the scoped one (objectui#4527).
+  // Distinct keys are what stop one branch's verdict from gating the other.
+  const selectionKey = selection
+    ? `${type}:${name}:${selection.kind}:${selection.id}`
+    : `${type}:${name}:default`;
   const inspectorBlocking = blockingReport.key === selectionKey ? blockingReport.count : 0;
   React.useEffect(() => {
     if (!editing) setSelection(null);
@@ -2349,6 +2356,9 @@ function MetadataResourceEditPageImpl({
                               }))
                             }
                             onSelectionChange={setSelection}
+                            onBlockingIssuesChange={(count) =>
+                              setBlockingReport({ key: selectionKey, count })
+                            }
                             readOnly={formReadOnly}
                             locale={locale}
                             serverSchema={entry?.schema as Record<string, unknown> | undefined}

--- a/packages/app-shell/src/views/metadata-admin/default-inspector-registry.ts
+++ b/packages/app-shell/src/views/metadata-admin/default-inspector-registry.ts
@@ -33,6 +33,26 @@ export interface MetadataDefaultInspectorProps {
    * scoped inspector for that selection.
    */
   onSelectionChange?: (next: MetadataSelection | null) => void;
+  /**
+   * Report how many BLOCKING author-time issues the inspector is currently
+   * showing — e.g. a CEL expression that does not parse (objectui#4527).
+   *
+   * Symmetric with `MetadataInspectorProps.onBlockingIssuesChange` (#4306), and
+   * deliberately the SAME shape: the default (no-selection) inspectors host CEL
+   * editors too — the hook guard, an action's visible/disabled predicates, a
+   * view's conditional formatting — and the host owns Save, so only the host
+   * can refuse to write. Without this member no host could pass the callback at
+   * all, which is why the whole default-inspector family published malformed
+   * expressions while the scoped family already refused them.
+   *
+   * Fires whenever the aggregate changes, `0` when everything is clean.
+   *
+   * Optional — an inspector with nothing to block on simply never calls it.
+   * Hosts must expire their own count when the inspected item changes or the
+   * inspector unmounts rather than waiting for a final `0`, since a component
+   * that has gone away cannot report anything.
+   */
+  onBlockingIssuesChange?: (count: number) => void;
   /** Whether the host is in edit mode. False → disable inputs. */
   readOnly: boolean;
   /** Active UI locale for i18n. */

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.celGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.celGate.test.tsx
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Action inspector must REPORT its blocking CEL verdicts upward, so the
+ * host that owns Save can refuse to publish a predicate that does not parse —
+ * objectui#4527 phase 2.
+ *
+ * This inspector mounts TWO ConditionBuilders — "Visible when" (`visible`) and
+ * "Disabled when" (`disabled`) — and is a DEFAULT inspector, so before phase 2
+ * it had no channel to report through at all.
+ *
+ * ## The decisive case
+ *
+ * Two editors report independently and asynchronously, so a single shared
+ * counter lets whichever linted last overwrite the other: fixing "Visible when"
+ * while "Disabled when" is still malformed would hand back a writable Save.
+ * A shared counter passes every single-editor case below and fails only
+ * {@link https://github.com/objectstack-ai/objectui/issues/4527 the both-faulty
+ * case} — which is why the count is a per-SITE map, exactly as
+ * ObjectFieldInspector's is.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, within } from '@testing-library/react';
+
+import { ActionDefaultInspector } from './ActionDefaultInspector';
+import { __setCelFormulaLoader } from '../celAuthoring';
+
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
+
+const DANGLING = /[*+\-/&|=<>]\s*$/;
+
+function stubEngine() {
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: (_role: string, input: unknown) => {
+        const src = typeof input === 'string' ? input : String((input as { source?: string })?.source ?? '');
+        return DANGLING.test(src)
+          ? { ok: false, errors: [{ message: 'Parse error: expression ends after an operator' }], warnings: [] }
+          : { ok: true, errors: [], warnings: [] };
+      },
+      introspectScope: () => ({ fields: ['status'], roots: ['record'], functions: ['has'] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+}
+
+/**
+ * Stateful harness — the inspector is CONTROLLED, so committed predicates must
+ * round-trip through the draft or the next keystroke reverts the last one and
+ * the editors never lint what the author typed.
+ */
+function Harness({ report }: { report: (n: number) => void }) {
+  const [draft, setDraft] = React.useState<Record<string, unknown>>({
+    name: 'approve',
+    label: 'Approve',
+    type: 'script',
+  });
+  return (
+    <ActionDefaultInspector
+      type="action"
+      name="approve"
+      draft={draft}
+      onPatch={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+      readOnly={false}
+      locale={'en-US' as never}
+      onBlockingIssuesChange={report}
+    />
+  );
+}
+
+function renderInspector() {
+  const report = vi.fn();
+  render(<Harness report={report} />);
+  const current = () => report.mock.calls.at(-1)?.[0] as number | undefined;
+  return { report, current };
+}
+
+/**
+ * A ConditionBuilder's own root, located by its label — the two builders are
+ * otherwise identical, so every interaction must be scoped to one of them.
+ */
+function builder(label: string): HTMLElement {
+  return screen.getByText(label).parentElement!.parentElement! as HTMLElement;
+}
+
+/** Switch one builder into raw CEL mode and hand back its editor. */
+function rawEditorFor(label: string): HTMLTextAreaElement {
+  const root = builder(label);
+  fireEvent.click(within(root).getByText('Expression'));
+  return within(root)
+    .getAllByRole('combobox')
+    .find((el) => el.tagName === 'TEXTAREA') as HTMLTextAreaElement;
+}
+
+describe('ActionDefaultInspector — blocking CEL issues reach the host (#4527)', () => {
+  it('counts a "Visible when" predicate that does not parse', async () => {
+    stubEngine();
+    const { current } = renderInspector();
+    fireEvent.change(rawEditorFor('Visible when'), { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+  });
+
+  it('counts a "Disabled when" predicate that does not parse', async () => {
+    stubEngine();
+    const { current } = renderInspector();
+    fireEvent.change(rawEditorFor('Disabled when'), { target: { value: 'record.amount >' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+  });
+
+  it('reports clean predicates as zero, so valid conditions never block Save', async () => {
+    stubEngine();
+    const { current } = renderInspector();
+    fireEvent.change(rawEditorFor('Visible when'), { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(current()).toBe(0), { timeout: 3000 });
+  });
+
+  /**
+   * DECISIVE — the per-site map. One shared counter passes every case above
+   * and fails here: fixing one editor would drop the total to 0 while the
+   * other predicate is still malformed.
+   */
+  it('keeps each editor independent — fixing one leaves the other counted', async () => {
+    stubEngine();
+    const { current } = renderInspector();
+    const visible = rawEditorFor('Visible when');
+    const disabled = rawEditorFor('Disabled when');
+
+    fireEvent.change(visible, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+
+    fireEvent.change(disabled, { target: { value: 'record.amount >' } });
+    await waitFor(() => expect(current()).toBe(2), { timeout: 3000 });
+
+    fireEvent.change(visible, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
@@ -276,12 +276,23 @@ interface ActionParam {
 
 /* ─────────────── inspector ─────────────── */
 
+/**
+ * The CEL editors this inspector mounts, as aggregation keys. Errors are
+ * counted PER SITE rather than into one running total: the two predicate
+ * editors lint independently and asynchronously, so a single shared counter
+ * would let whichever reported last overwrite the other — fixing "Visible
+ * when" would hand back a writable Save while "Disabled when" was still
+ * malformed (objectui#4527, the shape ObjectFieldInspector uses for its four).
+ */
+type ActionCelSite = 'visible' | 'disabled';
+
 export function ActionDefaultInspector({
   draft,
   onPatch,
   readOnly,
   locale,
   serverSchema,
+  onBlockingIssuesChange,
 }: MetadataDefaultInspectorProps) {
   const tr = React.useCallback((key: string) => t(key, locale), [locale]);
 
@@ -295,6 +306,42 @@ export function ActionDefaultInspector({
   // AI exposure — flattened keys (objectui/server convention, read by ActionPreview).
   const aiExposed = draft.aiExposed === true;
   const aiDescription = typeof draft.aiDescription === 'string' ? (draft.aiDescription as string) : '';
+
+  /* ─── Blocking CEL verdicts → the host's Save gate (objectui#4527) ─────
+   *
+   * Per-site map (see {@link ActionCelSite}), STAMPED with the action it
+   * describes so a verdict that lands after the panel switched actions cannot
+   * gate the one now on screen. Mismatch is read as 0 at aggregation time
+   * rather than repaired by a reset effect. */
+  const actionKey = str('name');
+  const [celErrors, setCelErrors] = React.useState<{
+    action: string;
+    sites: Partial<Record<ActionCelSite, number>>;
+  }>({ action: actionKey, sites: {} });
+  const reportCel = React.useCallback(
+    (site: ActionCelSite, count: number) => {
+      setCelErrors((prev) => {
+        if (prev.action !== actionKey) return { action: actionKey, sites: { [site]: count } };
+        if (prev.sites[site] === count) return prev;
+        return { action: actionKey, sites: { ...prev.sites, [site]: count } };
+      });
+    },
+    [actionKey],
+  );
+  const blockingIssues = React.useMemo(() => {
+    if (celErrors.action !== actionKey) return 0;
+    let total = 0;
+    for (const count of Object.values(celErrors.sites)) total += count ?? 0;
+    return total;
+  }, [celErrors, actionKey]);
+  // Held in a ref so an unmemoized host callback cannot re-fire the effect.
+  const onBlockingIssuesChangeRef = React.useRef(onBlockingIssuesChange);
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current = onBlockingIssuesChange;
+  });
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current?.(blockingIssues);
+  }, [blockingIssues]);
 
   const patchBody = (p: Record<string, unknown>) => onPatch({ body: { ...body, ...p } });
   const patchParam = (i: number, p: Partial<ActionParam>) =>
@@ -474,8 +521,8 @@ export function ActionDefaultInspector({
         {/* Both are `ExpressionInputSchema` in the spec (`disabled` as
             `boolean | ExpressionInput`), so a persisted action carries the
             ADR-0089 envelope — same read/write pair as the hook guard (#3218). */}
-        <ConditionBuilder label="Visible when" value={expressionSource(draft.visible)} onCommit={(v) => onPatch({ visible: writeExpressionSource(draft.visible, v) })} objectName={objectName} disabled={readOnly} />
-        <ConditionBuilder label="Disabled when" value={expressionSource(draft.disabled)} onCommit={(v) => onPatch({ disabled: writeExpressionSource(draft.disabled, v) })} objectName={objectName} disabled={readOnly} />
+        <ConditionBuilder label="Visible when" value={expressionSource(draft.visible)} onCommit={(v) => onPatch({ visible: writeExpressionSource(draft.visible, v) })} objectName={objectName} disabled={readOnly} onBlockingIssuesChange={(n) => reportCel('visible', n)} />
+        <ConditionBuilder label="Disabled when" value={expressionSource(draft.disabled)} onCommit={(v) => onPatch({ disabled: writeExpressionSource(draft.disabled, v) })} objectName={objectName} disabled={readOnly} onBlockingIssuesChange={(n) => reportCel('disabled', n)} />
       </div>
 
       {/* 7 ─ AI exposure */}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.celGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.celGate.test.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Hook inspector must REPORT its blocking CEL verdict upward, so the host
+ * that owns Save can refuse to publish a guard that does not parse —
+ * objectui#4527 phase 2.
+ *
+ * Phase 1 (PR #4547) wired the SCOPED inspector family through
+ * `MetadataInspectorProps.onBlockingIssuesChange`. This inspector is a DEFAULT
+ * inspector: it takes `MetadataDefaultInspectorProps`, whose contract carried
+ * no such member, so its "Run only when" guard rendered its inline parse error
+ * and Save still saved. Phase 2 extends that contract symmetrically.
+ *
+ * The engine is stubbed deterministically — the live lint is
+ * `CelPredicateField.test.tsx`'s job; this suite tests WIRING.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { HookSchema } from '@objectstack/spec/data';
+
+import { HookDefaultInspector } from './HookDefaultInspector';
+import { __setCelFormulaLoader } from '../celAuthoring';
+
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
+
+const DANGLING = /[*+\-/&|=<>]\s*$/;
+
+function stubEngine() {
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: (_role: string, input: unknown) => {
+        const src = typeof input === 'string' ? input : String((input as { source?: string })?.source ?? '');
+        return DANGLING.test(src)
+          ? { ok: false, errors: [{ message: 'Parse error: expression ends after an operator' }], warnings: [] }
+          : { ok: true, errors: [], warnings: [] };
+      },
+      introspectScope: () => ({ fields: ['status'], roots: ['record'], functions: ['has'] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+}
+
+/**
+ * Author a hook the way a user does and parse it with the spec. `object: '*'`
+ * keeps ConditionBuilder in raw/no-catalog mode, so no field fetch is involved
+ * — the reporting channel is what is under test.
+ */
+function hookDraft(condition?: unknown): Record<string, unknown> {
+  return HookSchema.parse({
+    name: 'guard_hook',
+    object: '*',
+    events: ['beforeInsert'],
+    handler: 'guard_fn',
+    ...(condition === undefined ? {} : { condition }),
+  }) as unknown as Record<string, unknown>;
+}
+
+/**
+ * Stateful harness — the inspector is CONTROLLED, so the committed guard must
+ * round-trip through the draft or the next keystroke reverts the last one and
+ * the editor never lints what the author typed.
+ */
+function Harness({ initial, report }: { initial: Record<string, unknown>; report: (n: number) => void }) {
+  const [draft, setDraft] = React.useState(initial);
+  return (
+    <HookDefaultInspector
+      type="hook"
+      name="guard_hook"
+      draft={draft}
+      onPatch={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+      readOnly={false}
+      locale={'en-US' as never}
+      onBlockingIssuesChange={report}
+    />
+  );
+}
+
+/** Render and switch the guard into its raw CEL editor. */
+function renderRaw(condition?: unknown) {
+  const report = vi.fn();
+  render(<Harness initial={hookDraft(condition)} report={report} />);
+  fireEvent.click(screen.getByText('Expression'));
+  const box = screen.getAllByRole('combobox').find((el) => el.tagName === 'TEXTAREA') as HTMLTextAreaElement;
+  const current = () => report.mock.calls.at(-1)?.[0] as number | undefined;
+  return { report, current, box };
+}
+
+describe('HookDefaultInspector — blocking CEL issues reach the host (#4527)', () => {
+  it('counts a "Run only when" guard that does not parse', async () => {
+    stubEngine();
+    const { current, box } = renderRaw();
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+  });
+
+  it('reports a clean guard as zero, so a valid condition never blocks Save', async () => {
+    stubEngine();
+    const { current, box } = renderRaw();
+    fireEvent.change(box, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(current()).toBe(0), { timeout: 3000 });
+  });
+
+  it('re-enables Save when the author fixes the guard', async () => {
+    stubEngine();
+    const { current, box } = renderRaw();
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+    fireEvent.change(box, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(current()).toBe(0), { timeout: 3000 });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/HookDefaultInspector.tsx
@@ -115,6 +115,7 @@ export function HookDefaultInspector({
   readOnly,
   locale,
   serverSchema,
+  onBlockingIssuesChange,
 }: MetadataDefaultInspectorProps) {
   const tr = React.useCallback((key: string) => t(key, locale), [locale]);
 
@@ -144,6 +145,37 @@ export function HookDefaultInspector({
     const next = on ? [...new Set([...events, ev])] : events.filter((e) => e !== ev);
     onPatch({ events: next });
   };
+
+  /* ─── Blocking CEL verdicts → the host's Save gate (objectui#4527) ─────
+   *
+   * The "Run only when" guard is this inspector's only CEL site. The count is
+   * STAMPED with the hook it describes and mismatch is read as 0 at
+   * aggregation time, so a verdict that lands after the host switched hooks
+   * cannot gate the one now on screen — derivation, not a reset effect. */
+  const hookKey = str('name');
+  const [celErrors, setCelErrors] = React.useState<{ hook: string; count: number }>({
+    hook: hookKey,
+    count: 0,
+  });
+  const reportCel = React.useCallback(
+    (count: number) => {
+      setCelErrors((prev) => {
+        if (prev.hook !== hookKey) return { hook: hookKey, count };
+        if (prev.count === count) return prev;
+        return { hook: hookKey, count };
+      });
+    },
+    [hookKey],
+  );
+  const blockingIssues = celErrors.hook === hookKey ? celErrors.count : 0;
+  // Held in a ref so an unmemoized host callback cannot re-fire the effect.
+  const onBlockingIssuesChangeRef = React.useRef(onBlockingIssuesChange);
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current = onBlockingIssuesChange;
+  });
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current?.(blockingIssues);
+  }, [blockingIssues]);
 
   // A single object → give ConditionBuilder its fields; '*' / multi → raw mode.
   const conditionObject = !allObjects && objectNames.length === 1 ? objectNames[0] : undefined;
@@ -262,6 +294,7 @@ export function HookDefaultInspector({
           onCommit={(v) => onPatch({ condition: writeExpressionSource(draft.condition, v) })}
           objectName={conditionObject}
           disabled={readOnly}
+          onBlockingIssuesChange={reportCel}
         />
       </div>
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.homeGate.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ViewVariantInspector.homeGate.test.tsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The View "home" panel must report its blocking CEL verdicts too —
+ * objectui#4527 phase 2.
+ *
+ * Phase 1 (PR #4547) wired `ViewVariantInspector`'s aggregation and forwarded
+ * the channel through `ViewInspector`, the SCOPED router. The HOME path goes
+ * through `ViewDefaultInspector` instead, a `MetadataDefaultInspectorProps`
+ * component whose contract had no blocking-issues member — so the very same
+ * inspector, reached with no selection, reported nothing and Save stayed
+ * writable on a formatting rule that does not parse.
+ *
+ * That asymmetry is the whole point of this suite: the aggregation is already
+ * proven by
+ * {@link file://./ViewVariantInspector.celGate.test.tsx}; what is pinned here
+ * is that the HOME route carries the channel, so the fix cannot be "wired on
+ * one of the two paths a user can reach the same editor by".
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+import { ViewDefaultInspector } from './ViewInspector';
+import type { MetadataDefaultInspectorProps } from '../default-inspector-registry';
+import { __setCelFormulaLoader } from '../celAuthoring';
+
+/**
+ * TYPE-LEVEL pin, and the only thing on this path that was actually broken.
+ *
+ * `ViewDefaultInspector` spreads `{...props}` into `ViewVariantInspector`, so
+ * once phase 1 taught the variant inspector to aggregate, the callback ALREADY
+ * reached it at runtime — the two render cases below pass before phase 2 as
+ * well as after, and are pins rather than red signals (reported as such).
+ *
+ * What was missing is the CONTRACT: `MetadataDefaultInspectorProps` did not
+ * declare the member, so no host could pass it without a type error and none
+ * did. This assertion is the red one — it fails to compile in the
+ * `tsconfig.test.json` pass until the contract carries the channel.
+ */
+export const _contractCarriesBlockingChannel: Required<
+  Pick<MetadataDefaultInspectorProps, 'onBlockingIssuesChange'>
+> = { onBlockingIssuesChange: () => {} };
+
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
+
+const DANGLING = /[*+\-/&|=<>]\s*$/;
+
+function stubEngine() {
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: (_role: string, input: unknown) => {
+        const src = typeof input === 'string' ? input : String((input as { source?: string })?.source ?? '');
+        return DANGLING.test(src)
+          ? { ok: false, errors: [{ message: 'Parse error: expression ends after an operator' }], warnings: [] }
+          : { ok: true, errors: [], warnings: [] };
+      },
+      introspectScope: () => ({ fields: ['status', 'amount'], roots: ['record'], functions: ['has'] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+}
+
+function viewDraft(rules: unknown[]): Record<string, unknown> {
+  return {
+    name: 'invoices',
+    label: 'Invoices',
+    list: {
+      type: 'grid',
+      object: 'invoice',
+      columns: ['status', 'amount'],
+      conditionalFormatting: rules,
+    },
+  };
+}
+
+/** Controlled harness — patches must round-trip or the second edit reverts. */
+function Harness({ report }: { report: (n: number) => void }) {
+  const [draft, setDraft] = React.useState(viewDraft([{ condition: '', style: {} }]));
+  return (
+    <ViewDefaultInspector
+      type="view"
+      name="invoices"
+      draft={draft}
+      onPatch={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+      onSelectionChange={() => {}}
+      readOnly={false}
+      locale={'en-US' as never}
+      onBlockingIssuesChange={report}
+    />
+  );
+}
+
+const ruleBox = (i: number) =>
+  screen.getByTestId(`cf-rule-${i}`).querySelector('[role="combobox"]') as HTMLTextAreaElement;
+
+describe('ViewDefaultInspector — the home panel reports blocking CEL issues too (#4527)', () => {
+  it('counts a formatting condition that does not parse on the HOME path', async () => {
+    stubEngine();
+    const report = vi.fn();
+    render(<Harness report={report} />);
+    const current = () => report.mock.calls.at(-1)?.[0] as number | undefined;
+
+    fireEvent.change(ruleBox(0), { target: { value: 'record.amount >' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+  });
+
+  it('reports a clean rule as zero on the HOME path', async () => {
+    stubEngine();
+    const report = vi.fn();
+    render(<Harness report={report} />);
+    const current = () => report.mock.calls.at(-1)?.[0] as number | undefined;
+
+    fireEvent.change(ruleBox(0), { target: { value: "record.status == 'overdue'" } });
+    await waitFor(() => expect(current()).toBe(0), { timeout: 3000 });
+  });
+});

--- a/packages/app-shell/src/views/studio-design/DataPillar.panelGate.test.tsx
+++ b/packages/app-shell/src/views/studio-design/DataPillar.panelGate.test.tsx
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The Data pillar's "Save draft" must refuse an object whose VALIDATION RULE
+ * guard does not parse — objectui#4527 phase 2.
+ *
+ * #4536 gated this same button on the field inspector's CEL verdict
+ * ({@link file://./DataPillar.celGate.test.tsx}). The pillar hosts three more
+ * CEL-bearing surfaces that write through the very same draft and were left
+ * ungated: the validations panel (rule guards), the actions panel (an action's
+ * visible/disabled predicates) and the settings panel. None of them owns a Save
+ * — their own headers say the Data pillar's Save draft owns the write — so the
+ * pillar holds a SECOND stamped count for the panel family and folds it into
+ * the same button.
+ *
+ * The stamp is the panel TAB: only one panel is mounted at a time, so leaving
+ * the tab unmounts the reporter and it can never retract its last verdict.
+ * Deriving the count against the live tab is what stops a fault authored under
+ * "Rules" from wedging Save shut while the author is looking at "Fields".
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const objectDef = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: [{ name: 'status', label: 'Status', type: 'text' }],
+  validations: [
+    {
+      type: 'script',
+      name: 'rule_a',
+      label: 'Rule A',
+      message: 'nope',
+      severity: 'error',
+      active: true,
+    },
+  ],
+};
+
+const mockClient = {
+  list: vi.fn(async () => [{ name: 'showcase_task', label: 'Task' }]),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async () => ({ effective: objectDef, code: objectDef })),
+  getDraft: vi.fn(async () => null),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({ entries: [] }),
+  };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+import { DataPillar } from './StudioDesignSurface';
+import { registerBuiltinInspectors } from '../metadata-admin/inspectors';
+import { __setCelFormulaLoader } from '../metadata-admin/celAuthoring';
+
+registerBuiltinInspectors();
+
+const DANGLING = /[*+\-/&|=<>]\s*$/;
+
+function stubEngine() {
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: (_role: string, input: unknown) => {
+        const src = typeof input === 'string' ? input : String((input as { source?: string })?.source ?? '');
+        return DANGLING.test(src)
+          ? { ok: false, errors: [{ message: 'Parse error: expression ends after an operator' }], warnings: [] }
+          : { ok: true, errors: [], warnings: [] };
+      },
+      introspectScope: () => ({ fields: ['status'], roots: ['record'], functions: ['has'] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+}
+
+beforeEach(stubEngine);
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
+
+const saveDraft = () => screen.getByRole('button', { name: /Save draft/i });
+
+/** Open the pillar's Rules tab and put the selected rule's guard into raw CEL. */
+async function openRuleGuard() {
+  render(
+    <MemoryRouter initialEntries={['/studio/com.example.showcase/data']}>
+      <DataPillar packageId="com.example.showcase" />
+    </MemoryRouter>,
+  );
+  fireEvent.click(await screen.findByRole('button', { name: 'Validations' }));
+  fireEvent.click(await screen.findByText('Expression'));
+  return screen.getAllByRole('combobox').find((el) => el.tagName === 'TEXTAREA') as HTMLTextAreaElement;
+}
+
+describe('DataPillar — Save draft is gated on the validations panel’s CEL verdict (#4527)', () => {
+  it('refuses a rule guard that does not parse', async () => {
+    const box = await openRuleGuard();
+
+    // A valid guard first — dirties the draft and pins that a good guard never
+    // blocks.
+    fireEvent.change(box, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 4000 });
+
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 4000 });
+    expect(saveDraft()).toHaveAttribute('title', 'Fix the CEL syntax errors before saving.');
+  });
+
+  it('re-enables Save draft once the guard parses again', async () => {
+    const box = await openRuleGuard();
+
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 4000 });
+
+    fireEvent.change(box, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 4000 });
+  });
+
+  /**
+   * The tab stamp. Leaving Rules unmounts the panel, so it can never report
+   * `0`; without deriving the count against the live tab, Save would stay
+   * wedged shut on a surface with no CEL editor on screen at all.
+   */
+  it('expires the panel count when the author leaves the Rules tab', async () => {
+    const box = await openRuleGuard();
+
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(saveDraft()).toBeDisabled(), { timeout: 4000 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Form' }));
+    await waitFor(() => expect(saveDraft()).toBeEnabled(), { timeout: 4000 });
+  });
+});

--- a/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
@@ -70,10 +70,18 @@ export function ObjectActionsPanel({
   onPatch,
   disabled,
   actionSchema,
+  onBlockingIssuesChange,
 }: {
   draft: Record<string, unknown>;
   onPatch: (patch: Record<string, unknown>) => void;
   disabled?: boolean;
+  /**
+   * Report how many BLOCKING author-time issues the selected action's editor is
+   * showing — `visible` / `disabled` predicates whose CEL does not parse
+   * (objectui#4527). This panel owns no Save; the object draft's "Save draft"
+   * writes the actions, so the Data pillar holds this count and refuses.
+   */
+  onBlockingIssuesChange?: (count: number) => void;
   /**
    * The live server JSONSchema for the `action` type (`/meta/types`). Handed to
    * ActionDefaultInspector as `serverSchema` so its "More fields" section can
@@ -106,6 +114,39 @@ export function ObjectActionsPanel({
   );
 
   const objectName = typeof draft.name === 'string' ? draft.name : '';
+
+  /* ─── Blocking CEL verdicts → the Data pillar's Save gate (objectui#4527) ──
+   *
+   * Master-detail: only the SELECTED action's inspector is mounted, so the map
+   * is keyed by action NAME and a verdict deliberately survives deselection —
+   * an action whose predicate does not parse is still in the document and
+   * saving would still publish it, and it stays reachable by selecting it
+   * again. A DELETED action's inspector can never report `0`, so the total is
+   * DERIVED against the live action-name set rather than repaired by an effect.
+   */
+  const [celErrors, setCelErrors] = React.useState<Record<string, number>>({});
+  const reportCel = React.useCallback((actionName: string, count: number) => {
+    setCelErrors((prev) => (prev[actionName] === count ? prev : { ...prev, [actionName]: count }));
+  }, []);
+  const liveActionNames = React.useMemo(
+    () => new Set(actions.map((a) => String(a.name ?? ''))),
+    [actions],
+  );
+  const blockingIssues = React.useMemo(() => {
+    let total = 0;
+    for (const [name, count] of Object.entries(celErrors)) {
+      if (!liveActionNames.has(name)) continue; // pruned: the action is gone
+      total += count;
+    }
+    return total;
+  }, [celErrors, liveActionNames]);
+  const onBlockingIssuesChangeRef = React.useRef(onBlockingIssuesChange);
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current = onBlockingIssuesChange;
+  });
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current?.(blockingIssues);
+  }, [blockingIssues]);
 
   const addAction = React.useCallback(() => {
     const name = nextActionName(objectName, actions.map((a) => String(a.name ?? '')));
@@ -221,6 +262,7 @@ export function ObjectActionsPanel({
               readOnly={!!disabled}
               locale={locale}
               serverSchema={actionSchema}
+              onBlockingIssuesChange={(count) => reportCel(String(sel.name ?? ''), count)}
             />
           </>
         ) : (

--- a/packages/app-shell/src/views/studio-design/ObjectHooksPanel.celGate.test.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectHooksPanel.celGate.test.tsx
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The object hooks panel owns its OWN per-hook Save (it writes the hook
+ * directly with `client.save('hook', …, { mode: 'draft' })` — the object's Save
+ * draft does not cover hooks), so it must refuse to write a guard whose CEL
+ * does not parse — objectui#4527 phase 2.
+ *
+ * Of the four panel hosts the #4547 census surfaced, this is the only one that
+ * owns a Save button; the other three write through the Data pillar's draft and
+ * report upward instead. So this suite is the end-to-end proof for the
+ * hook branch of the default-inspector family: HookDefaultInspector's verdict
+ * has to reach a real disabled button, not just a callback.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+const hook = {
+  name: 'guard_hook',
+  label: 'Guard',
+  object: 'invoice',
+  events: ['beforeInsert'],
+  handler: 'guard_fn',
+};
+
+const mockClient = {
+  list: vi.fn(async () => [hook]),
+  listDrafts: vi.fn(async () => []),
+  getDraft: vi.fn(async () => null),
+  // The curated hook editor resolves the bound object's field catalog through
+  // `useObjectFields` -> `client.get`.
+  get: vi.fn(async () => null),
+  save: vi.fn(async () => ({})),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return { ...mod, useMetadataClient: () => mockClient };
+});
+
+import { ObjectHooksPanel } from './ObjectHooksPanel';
+import { registerBuiltinInspectors } from '../metadata-admin/inspectors';
+import { __setCelFormulaLoader } from '../metadata-admin/celAuthoring';
+
+// The panel resolves the curated hook editor through the default registry.
+registerBuiltinInspectors();
+
+const DANGLING = /[*+\-/&|=<>]\s*$/;
+
+function stubEngine() {
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: (_role: string, input: unknown) => {
+        const src = typeof input === 'string' ? input : String((input as { source?: string })?.source ?? '');
+        return DANGLING.test(src)
+          ? { ok: false, errors: [{ message: 'Parse error: expression ends after an operator' }], warnings: [] }
+          : { ok: true, errors: [], warnings: [] };
+      },
+      introspectScope: () => ({ fields: ['status'], roots: ['record'], functions: ['has'] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+}
+
+beforeEach(stubEngine);
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
+
+const saveButton = () => screen.getByRole('button', { name: /Save/i });
+
+/** Open the panel, select the hook, and switch its guard into raw CEL mode. */
+async function openGuard() {
+  render(<ObjectHooksPanel objectName="invoice" packageId="com.example.showcase" />);
+  fireEvent.click(await screen.findByText('Guard'));
+  fireEvent.click(await screen.findByText('Expression'));
+  return screen.getAllByRole('combobox').find((el) => el.tagName === 'TEXTAREA') as HTMLTextAreaElement;
+}
+
+describe('ObjectHooksPanel — its own Save refuses a guard that does not parse (#4527)', () => {
+  it('disables Save while the hook guard is malformed', async () => {
+    const box = await openGuard();
+
+    // A valid guard first: dirties the draft (so Save is live at all) and pins
+    // the must-not-change half — a good guard never blocks.
+    fireEvent.change(box, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(saveButton()).toBeEnabled(), { timeout: 4000 });
+
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(saveButton()).toBeDisabled(), { timeout: 4000 });
+  });
+
+  it('re-enables Save once the guard parses again', async () => {
+    const box = await openGuard();
+
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(saveButton()).toBeDisabled(), { timeout: 4000 });
+
+    fireEvent.change(box, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(saveButton()).toBeEnabled(), { timeout: 4000 });
+  });
+
+  it('never writes the malformed hook', async () => {
+    const box = await openGuard();
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(saveButton()).toBeDisabled(), { timeout: 4000 });
+
+    fireEvent.click(saveButton());
+    expect(mockClient.save).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-shell/src/views/studio-design/ObjectHooksPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectHooksPanel.tsx
@@ -95,6 +95,31 @@ export function ObjectHooksPanel({
   const [saving, setSaving] = React.useState(false);
   const [nonce, setNonce] = React.useState(0);
 
+  /* ─── Blocking CEL verdicts → this panel's OWN Save (objectui#4527) ────────
+   *
+   * Unlike the object's other panels, this one writes the hook itself
+   * (`client.save('hook', …, { mode: 'draft' })`), so it owns the button that
+   * has to refuse. The count is STAMPED with the hook it describes and
+   * mismatch is read as 0, so a verdict that lands after the author switched
+   * hooks cannot gate the one now on screen — derivation, not a reset effect,
+   * and the selected hook always has its editor available to fix in. */
+  const [celErrors, setCelErrors] = React.useState<{ hook: string; count: number }>({
+    hook: '',
+    count: 0,
+  });
+  const selectedHookName = String(draft?.name ?? '');
+  const reportCel = React.useCallback(
+    (count: number) => {
+      setCelErrors((prev) => {
+        if (prev.hook !== selectedHookName) return { hook: selectedHookName, count };
+        if (prev.count === count) return prev;
+        return { hook: selectedHookName, count };
+      });
+    },
+    [selectedHookName],
+  );
+  const blockingIssues = celErrors.hook === selectedHookName ? celErrors.count : 0;
+
   React.useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -250,7 +275,8 @@ export function ObjectHooksPanel({
                 <button
                   type="button"
                   onClick={save}
-                  disabled={!dirty || saving}
+                  disabled={!dirty || saving || blockingIssues > 0}
+                  title={blockingIssues > 0 ? t('perm.cel.saveBlocked', locale) : undefined}
                   className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] hover:bg-muted disabled:opacity-50"
                 >
                   {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
@@ -272,6 +298,7 @@ export function ObjectHooksPanel({
                   readOnly={!!disabled}
                   locale={locale}
                   serverSchema={hookSchema}
+                  onBlockingIssuesChange={reportCel}
                 />
               ) : (
                 <div className="p-3">

--- a/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectSettingsPanel.tsx
@@ -46,12 +46,25 @@ export function ObjectSettingsPanel({
   onPatch,
   disabled,
   locale,
+  onBlockingIssuesChange,
 }: {
   name: string;
   draft: Record<string, unknown>;
   onPatch: (patch: Record<string, unknown>) => void;
   disabled?: boolean;
   locale: SupportedLocale;
+  /**
+   * Forward the object inspector's blocking author-time issue count to the Data
+   * pillar, which owns the Save this panel writes through (objectui#4527).
+   *
+   * INERT TODAY, and deliberately so: `ObjectDefaultInspector` mounts no CEL
+   * editor, so nothing downstream ever calls this. It is wired anyway to keep
+   * the panel-host family uniform — the next CEL editor added to the object
+   * inspector is gated by construction rather than by remembering to come back
+   * here. Only the forwarding is covered by test; there is no verdict to
+   * produce.
+   */
+  onBlockingIssuesChange?: (count: number) => void;
 }) {
   const DefaultInspector = getMetadataDefaultInspector('object');
 
@@ -128,6 +141,7 @@ export function ObjectSettingsPanel({
               onPatch={onPatch}
               readOnly={!!disabled}
               locale={locale}
+              onBlockingIssuesChange={onBlockingIssuesChange}
             />
           ) : (
             <p className="text-[12px] text-muted-foreground">{t('engine.studio.settings.noInspector', locale)}</p>

--- a/packages/app-shell/src/views/studio-design/ObjectValidationsPanel.celGate.test.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectValidationsPanel.celGate.test.tsx
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The object validations panel must REPORT its blocking CEL verdicts upward,
+ * so the Data pillar's "Save draft" can refuse to write a validation rule
+ * whose guard does not parse — objectui#4527 phase 2.
+ *
+ * This is the sixth `ConditionBuilder` consumer, surfaced by PR #4547's census
+ * and not named on the original card. It does NOT own a Save: its own header
+ * says the panel `onPatch({ validations })`s and "the Data pillar's Save draft
+ * owns the write", so what it needs is a reporting channel, not a button.
+ *
+ * ## Master-detail changes what "multi-instance" means here
+ *
+ * The panel is a rule LIST plus a detail pane, so only the SELECTED rule's
+ * ConditionBuilder is ever mounted. Two consequences the derivation must get
+ * right:
+ *
+ *  - A faulty rule that is no longer selected is still faulty, and saving
+ *    would still publish it — so its verdict must SURVIVE deselection. That is
+ *    correctness, not a wedge: the rule stays reachable and fixable by
+ *    selecting it again.
+ *  - A DELETED rule's editor can never retract its verdict, so the count is
+ *    derived against the live rule-name set. Deleting the faulty rule must
+ *    drop it immediately or Save wedges shut with nothing left to fix.
+ *
+ * Known limit, pinned deliberately by the "never opened" case below: the panel
+ * can only report on rules whose editor has actually rendered, because the
+ * lint lives in the editor. A faulty rule the author never opens is not
+ * counted. That is a strict improvement on today (no gating at all) and is the
+ * mechanical scope the #4527 phase-2 ruling asked for.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+import { ObjectValidationsPanel } from './ObjectValidationsPanel';
+import { __setCelFormulaLoader } from '../metadata-admin/celAuthoring';
+
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
+
+const DANGLING = /[*+\-/&|=<>]\s*$/;
+
+function stubEngine() {
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: (_role: string, input: unknown) => {
+        const src = typeof input === 'string' ? input : String((input as { source?: string })?.source ?? '');
+        return DANGLING.test(src)
+          ? { ok: false, errors: [{ message: 'Parse error: expression ends after an operator' }], warnings: [] }
+          : { ok: true, errors: [], warnings: [] };
+      },
+      introspectScope: () => ({ fields: ['status'], roots: ['record'], functions: ['has'] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+}
+
+const rule = (name: string) => ({
+  type: 'script',
+  name,
+  label: name,
+  message: 'nope',
+  severity: 'error',
+  active: true,
+});
+
+/** Controlled harness — the panel is controlled through `onPatch`. */
+function Harness({ names, report }: { names: string[]; report: (n: number) => void }) {
+  const [draft, setDraft] = React.useState<Record<string, unknown>>({
+    name: 'invoice',
+    fields: { status: { type: 'text' } },
+    validations: names.map(rule),
+  });
+  return (
+    <ObjectValidationsPanel
+      draft={draft}
+      onPatch={(patch) => setDraft((d) => ({ ...d, ...patch }))}
+      onBlockingIssuesChange={report}
+    />
+  );
+}
+
+function renderPanel(names: string[]) {
+  const report = vi.fn();
+  render(<Harness names={names} report={report} />);
+  const current = () => report.mock.calls.at(-1)?.[0] as number | undefined;
+  return { report, current };
+}
+
+/** Switch the selected rule's builder into raw CEL mode and return its editor. */
+function rawEditor(): HTMLTextAreaElement {
+  fireEvent.click(screen.getByText('Expression'));
+  return screen.getAllByRole('combobox').find((el) => el.tagName === 'TEXTAREA') as HTMLTextAreaElement;
+}
+
+/** Select a rule in the master list. */
+const selectRule = (name: string) => fireEvent.click(screen.getByText(name));
+
+describe('ObjectValidationsPanel — blocking CEL issues reach the Data pillar (#4527)', () => {
+  it("counts a rule guard that does not parse", async () => {
+    stubEngine();
+    const { current } = renderPanel(['rule_a']);
+    fireEvent.change(rawEditor(), { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+  });
+
+  it('reports a clean guard as zero, so a valid rule never blocks Save', async () => {
+    stubEngine();
+    const { current } = renderPanel(['rule_a']);
+    fireEvent.change(rawEditor(), { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(current()).toBe(0), { timeout: 3000 });
+  });
+
+  it('re-enables Save when the author fixes the guard', async () => {
+    stubEngine();
+    const { current } = renderPanel(['rule_a']);
+    const box = rawEditor();
+    fireEvent.change(box, { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+    fireEvent.change(box, { target: { value: "record.status == 'open'" } });
+    await waitFor(() => expect(current()).toBe(0), { timeout: 3000 });
+  });
+
+  /**
+   * A faulty rule stays counted once the author moves to another rule — it is
+   * still in the document and saving would still publish it.
+   */
+  it('keeps a faulty rule counted after the author selects a different rule', async () => {
+    stubEngine();
+    const { current } = renderPanel(['rule_a', 'rule_b']);
+    fireEvent.change(rawEditor(), { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+
+    selectRule('rule_b');
+    fireEvent.change(rawEditor(), { target: { value: "record.status == 'open'" } });
+    // rule_b is clean, but rule_a's fault survives its deselection.
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+  });
+
+  /**
+   * DECISIVE — the prune. A deleted rule's editor is gone and can never report
+   * `0`, so a remembered verdict would hold Save shut with nothing to fix.
+   */
+  it('drops the count when the faulty rule is deleted, so Save cannot wedge shut', async () => {
+    stubEngine();
+    const { current } = renderPanel(['rule_a']);
+    fireEvent.change(rawEditor(), { target: { value: 'record.status ==' } });
+    await waitFor(() => expect(current()).toBe(1), { timeout: 3000 });
+
+    // `getByText('Delete')` is ambiguous — a lifecycle-event checkbox carries
+    // the same word; the rule's own delete affordance is the BUTTON.
+    fireEvent.click(screen.getByRole('button', { name: /Delete/ }));
+    await waitFor(() => expect(current()).toBe(0), { timeout: 3000 });
+  });
+});

--- a/packages/app-shell/src/views/studio-design/ObjectValidationsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectValidationsPanel.tsx
@@ -272,12 +272,15 @@ function RuleTypeFields({
   patch,
   disabled,
   locale,
+  onBlockingIssuesChange,
 }: {
   rule: ValidationRuleDraft;
   fields: FieldOpt[];
   patch: (p: Partial<ValidationRuleDraft>) => void;
   disabled?: boolean;
   locale: string;
+  /** Blocking CEL error count for this rule's guard (objectui#4527). */
+  onBlockingIssuesChange?: (count: number) => void;
 }) {
   const fieldSelect = (label: string, value: string | undefined, onSet: (v: string) => void) => (
     <label className="block">
@@ -312,6 +315,7 @@ function RuleTypeFields({
         onCommit={(cel) => patch({ condition: writeExpressionSource(rule.condition, cel) })}
         fields={fields}
         disabled={disabled}
+        onBlockingIssuesChange={onBlockingIssuesChange}
       />
     </div>
   );
@@ -433,10 +437,18 @@ export function ObjectValidationsPanel({
   draft,
   onPatch,
   disabled,
+  onBlockingIssuesChange,
 }: {
   draft: Record<string, unknown>;
   onPatch: (patch: Record<string, unknown>) => void;
   disabled?: boolean;
+  /**
+   * Report how many BLOCKING author-time issues the panel is showing — rule
+   * guards whose CEL does not parse (objectui#4527). This panel owns no Save;
+   * the Data pillar's "Save draft" writes the object, so it holds this count
+   * and refuses to write.
+   */
+  onBlockingIssuesChange?: (count: number) => void;
 }) {
   const locale = useMetadataLocale();
   const rules = React.useMemo(() => readRules(draft.validations), [draft.validations]);
@@ -457,6 +469,44 @@ export function ObjectValidationsPanel({
     [draft.fields],
   );
   const firstField = fields.find((f) => !f.hidden)?.name ?? fields[0]?.name;
+
+  /* ─── Blocking CEL verdicts → the Data pillar's Save gate (objectui#4527) ──
+   *
+   * Master-detail: only the SELECTED rule's ConditionBuilder is mounted, so
+   * the map is keyed by rule NAME and a verdict deliberately SURVIVES
+   * deselection — a rule whose guard does not parse is still in the document
+   * and saving would still publish it, and it stays reachable by selecting it
+   * again. What must not survive is a DELETED rule: its editor is gone and can
+   * never report `0`, so the total is DERIVED against the live rule-name set
+   * rather than repaired by a reset effect.
+   *
+   * Known limit: the lint lives in the editor, so a faulty rule the author
+   * never opens is never counted. Strictly better than no gate, and the
+   * mechanical scope the #4527 phase-2 ruling asked for. */
+  const [celErrors, setCelErrors] = React.useState<Record<string, number>>({});
+  const reportCel = React.useCallback((ruleName: string, count: number) => {
+    setCelErrors((prev) => (prev[ruleName] === count ? prev : { ...prev, [ruleName]: count }));
+  }, []);
+  const liveRuleNames = React.useMemo(
+    () => new Set(rules.map((r) => r.name ?? '')),
+    [rules],
+  );
+  const blockingIssues = React.useMemo(() => {
+    let total = 0;
+    for (const [name, count] of Object.entries(celErrors)) {
+      if (!liveRuleNames.has(name)) continue; // pruned: the rule is gone
+      total += count;
+    }
+    return total;
+  }, [celErrors, liveRuleNames]);
+  // Held in a ref so an unmemoized host callback cannot re-fire the effect.
+  const onBlockingIssuesChangeRef = React.useRef(onBlockingIssuesChange);
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current = onBlockingIssuesChange;
+  });
+  React.useEffect(() => {
+    onBlockingIssuesChangeRef.current?.(blockingIssues);
+  }, [blockingIssues]);
 
   const commit = (next: ValidationRuleDraft[]) => onPatch({ validations: next });
 
@@ -636,6 +686,7 @@ export function ObjectValidationsPanel({
               patch={(p) => patchRule(sel.name!, p)}
               disabled={disabled}
               locale={locale}
+              onBlockingIssuesChange={(count) => reportCel(sel.name!, count)}
             />
 
             {/* runs-on events */}

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -1287,6 +1287,20 @@ function InterfacesPillar({
   // block tree, so `selection` never populates; without this the panel would
   // sit permanently on the "click a block" empty state.
   const DefaultInspector = getMetadataDefaultInspector(current?.type ?? '');
+  // Blocking author-time issues the right-rail inspector is showing — a CEL
+  // predicate that does not parse must not be saveable here either
+  // (objectui#4527). #4306 wired the Data pillar only, which left the SAME
+  // malformed-CEL publish reachable through this pillar with the gate inert.
+  //
+  // One hold serves both rail branches, stamped with which of them produced it
+  // and with the selection it described, so it expires by construction when the
+  // selection changes, when the rail swaps scoped for default, or when the leaf
+  // changes — an unmounted inspector can never retract its last verdict.
+  const [blockingReport, setBlockingReport] = React.useState({ key: '', count: 0 });
+  const inspectorKey = `${current?.type ?? ''}:${current?.name ?? ''}:${
+    selection ? `${selection.kind}:${selection.id}` : 'default'
+  }`;
+  const inspectorBlocking = blockingReport.key === inspectorKey ? blockingReport.count : 0;
   // A studio-canvas surface (e.g. object → runtime records grid) renders the
   // running app, not an editable draft — schema editing is the Data pillar's
   // job — so those leaves are not draft-editable in this canvas.
@@ -1544,6 +1558,9 @@ function InterfacesPillar({
           onPatch={onPatch}
           onClearSelection={() => setSelection(null)}
           onSelectionChange={setSelection}
+          onBlockingIssuesChange={(count: number) =>
+            setBlockingReport({ key: inspectorKey, count })
+          }
           readOnly={false}
           locale={locale}
         />
@@ -1595,6 +1612,9 @@ function InterfacesPillar({
           draft={draft}
           onPatch={onPatch}
           onSelectionChange={setSelection}
+          onBlockingIssuesChange={(count: number) =>
+            setBlockingReport({ key: inspectorKey, count })
+          }
           readOnly={false}
           locale={locale}
         />
@@ -1638,8 +1658,14 @@ function InterfacesPillar({
         )}
         <button type="button"
           onClick={doSave}
-          disabled={!current || !isEditable || !!saving || readOnly}
-          title={readOnly ? t('engine.studio.pkg.readonlyHint', locale) : undefined}
+          disabled={!current || !isEditable || !!saving || readOnly || inspectorBlocking > 0}
+          title={
+            inspectorBlocking > 0
+              ? t('perm.cel.saveBlocked', locale)
+              : readOnly
+                ? t('engine.studio.pkg.readonlyHint', locale)
+                : undefined
+          }
           className="ml-auto inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-muted disabled:opacity-50"
         >
           {saving === 'draft' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
@@ -1973,6 +1999,17 @@ export function DataPillar({
   const [blockingReport, setBlockingReport] = React.useState({ key: '', count: 0 });
   const fieldSelKey = fieldSel ? `${current?.name ?? ''}:${fieldSel.kind}:${fieldSel.id}` : '';
   const inspectorBlocking = blockingReport.key === fieldSelKey ? blockingReport.count : 0;
+  // The pillar's PANEL family reports separately (objectui#4527): the
+  // validations, actions and settings panels all write through this same draft
+  // and own no Save of their own, so their CEL faults have to reach this
+  // button too. Kept apart from the field inspector's count above because the
+  // two expire on different things.
+  //
+  // Stamped with the panel TAB: exactly one panel is mounted at a time, so
+  // leaving the tab unmounts the reporter and it can never retract its last
+  // verdict — deriving against the live tab is what stops a fault authored
+  // under Validations from wedging Save on a tab with no CEL editor at all.
+  const [panelBlockingReport, setPanelBlockingReport] = React.useState({ key: '', count: 0 });
   const [dirty, setDirty] = React.useState(false);
   const [hasDraft, setHasDraft] = React.useState(false);
   const [saving, setSaving] = React.useState<false | 'draft' | 'publish'>(false);
@@ -1986,6 +2023,16 @@ export function DataPillar({
   // Validations edits `validations` rules; Settings edits object basics +
   // the ADR-0085 semantic roles. All patch the one `objDraft`.
   const [viewMode, setViewMode] = React.useState<'grid' | 'form' | 'rules' | 'settings' | 'hooks' | 'actions' | 'api'>('grid');
+  // Stamp + read for the panel-family count declared above.
+  const panelKey = `${current?.name ?? ''}:${viewMode}`;
+  const panelBlocking = panelBlockingReport.key === panelKey ? panelBlockingReport.count : 0;
+  const reportPanelBlocking = React.useCallback(
+    (count: number) => setPanelBlockingReport({ key: panelKey, count }),
+    [panelKey],
+  );
+  // Either source closes the door: a malformed field formula and a malformed
+  // rule guard are both unsaveable, and neither excuses the other.
+  const saveBlocking = inspectorBlocking + panelBlocking;
   // Within the Form view: 布局 (WYSIWYG drag/section designer) ⇄ 预览 (live form).
   const [formMode, setFormMode] = React.useState<'layout' | 'preview'>('layout');
   // Tracks which object's baseline is currently loaded — so we (re)load exactly
@@ -2270,9 +2317,9 @@ export function DataPillar({
         )}
         <button type="button"
           onClick={doSave}
-          disabled={!current || !dirty || !!saving || readOnly || inspectorBlocking > 0}
+          disabled={!current || !dirty || !!saving || readOnly || saveBlocking > 0}
           title={
-            inspectorBlocking > 0
+            saveBlocking > 0
               ? t('perm.cel.saveBlocked', locale)
               : readOnly
                 ? t('engine.studio.pkg.readonlyHint', locale)
@@ -2435,7 +2482,12 @@ export function DataPillar({
                 </div>
               )}
               {viewMode === 'rules' ? (
-                <ObjectValidationsPanel draft={objDraft} onPatch={onPatch} disabled={readOnly} />
+                <ObjectValidationsPanel
+                  draft={objDraft}
+                  onPatch={onPatch}
+                  disabled={readOnly}
+                  onBlockingIssuesChange={reportPanelBlocking}
+                />
               ) : viewMode === 'settings' ? (
                 <ObjectSettingsPanel
                   name={current.name}
@@ -2443,6 +2495,7 @@ export function DataPillar({
                   onPatch={onPatch}
                   locale={locale}
                   disabled={readOnly}
+                  onBlockingIssuesChange={reportPanelBlocking}
                 />
               ) : viewMode === 'hooks' ? (
                 <ObjectHooksPanel
@@ -2457,6 +2510,7 @@ export function DataPillar({
                   onPatch={onPatch}
                   disabled={readOnly}
                   actionSchema={typeSchemas.action}
+                  onBlockingIssuesChange={reportPanelBlocking}
                 />
               ) : viewMode === 'api' ? (
                 <ObjectApiPanel name={current.name} draft={objDraft} />


### PR DESCRIPTION
Fixes #4527.

Phase 2, following PR #4547 and the [phase-2 ruling](https://github.com/objectstack-ai/objectui/issues/4527#issuecomment-5277689208). `Fixes` this time: every site the ruling names is wired. `widgets.tsx`'s ConditionWidget remains explicitly deferred by that ruling and does not block closure.

## The structural cause

There are **two** inspector registries and #4306 extended only one. `MetadataInspectorProps` carried `onBlockingIssuesChange`; `MetadataDefaultInspectorProps` — the contract every "no selection" inspector renders through — had no such member. So the whole default family showed its CEL parse errors and saved anyway, and no host could pass a callback that did not exist. That contract now carries the same optional member.

| site | aggregation | reaches Save via |
| --- | --- | --- |
| `HookDefaultInspector` | single count, stamped by hook | ObjectHooksPanel's own Save |
| `ActionDefaultInspector` | **per-site map** over `visible` / `disabled` | Data pillar (via ObjectActionsPanel) |
| `ViewVariantInspector` home path | already aggregated in #4547 | metadata editor's default branch |
| `ObjectValidationsPanel` | **per-rule map**, keyed by rule name | Data pillar |

Hosts wired: metadata editor's no-selection branch, Studio design pillar (both its scoped and default rail renders), Data pillar's panel family, and the hooks panel's own button.

## Two measured corrections to the ruling's model

Both changed what the work actually is, so they are stated rather than smoothed over.

**1. Three of the four panel hosts do not own a Save.** Only `ObjectHooksPanel` writes on its own (`client.save('hook', …)`). `ObjectActionsPanel`, `ObjectValidationsPanel` and `ObjectSettingsPanel` write through the object draft — their own headers say so — and all three are rendered inside `DataPillar`. So they report upward and the pillar holds a **second** count beside the field-inspector count #4306 gave it, stamped with the panel **tab**: exactly one panel is mounted at a time, so a tab the author has left can never retract its verdict.

**2. `ObjectSettingsPanel` is inert today, and is wired anyway — declared, not hidden.** It renders `ObjectDefaultInspector`, which mounts no CEL editor at all, so nothing downstream can ever call the callback. It is wired to keep the host family uniform (the next CEL editor added there is gated by construction), and only its forwarding is covered — there is no verdict to produce. Flagged so nobody reads it as tested behaviour.

A third, smaller one: the metadata editor reaches a default inspector **only** for types that also have a canvas preview, because that panel lives inside the `PreviewComponent` branch; a type without one falls through to a plain `SchemaForm`. `view` is the type where that branch actually hosts CEL, which is why the host test uses it — and why `hook` / `action` default inspectors are not reachable from that host at all, but from the Studio panels, where they are gated in their own suites.

## Red-first

Predicted the split in writing before running. Predicted signature, inherited from #4306/#4547: the reporter is never called, so the count a host would hold is `undefined` and every asserted count fails, the `0` cases included. Measured against unfixed code, verbatim:

```
AssertionError: expected undefined to be 1 // Object.is equality
AssertionError: expected undefined to be +0 // Object.is equality
```

**One prediction was wrong, and informatively so.** I predicted the view home path would go red at runtime. It did not: `ViewDefaultInspector` spreads `{...props}` into `ViewVariantInspector`, so once #4547 taught the variant inspector to aggregate, the callback already reached it. The home path's defect was purely the missing **type** — no host could pass the prop without a compile error, and none did. Those two render cases are therefore reported as **pins, not red signals**, and the actually-red assertion for that path is a type-level one that fails to compile until the contract carries the channel.

Reverse verification removed the fix with `git diff` + `git checkout --` (never `git stash` — objectui#3430) and re-ran all seven suites: **6 files failed, 20 failed / 2 passed** — the 2 passes being exactly the two spread-carried home-path cases above. Restored with `git apply` and sha256 verified on all 9 files.

## Verification

- New suites: **7 files, 22 tests**, all green.
- Regression over metadata-admin + studio-design: **184 files, 1729 passed, 1 skipped, 0 failed** (was 173/1691 before this change). Both #4306 suites and all five #4547 suites untouched and green.
- Both tsc passes green (`tsc --noEmit` and `tsc -p tsconfig.test.json`).
- ESLint **net zero** new warnings, measured both ways on the same scoped set: **76 with the fix, 76 on `origin/main` content**, 0 errors. New test files lint clean.
- `check-control-bytes` OK; plus an explicit `grep -naP` self-scan of every changed file including the untracked ones (the gate only scans tracked files) — zero control bytes.
- `check:phantom-deps` OK, changeset gates OK.

### Changeset

`@object-ui/app-shell`: **patch**, by `.d.ts` measurement both ways with `dist/` and `tsconfig.tsbuildinfo` cleared between builds. `dist/index.d.ts` is **byte-identical** before and after. The ruling forecast minor on the assumption that `MetadataDefaultInspectorProps` is entry-reachable like its sibling; measurement says it is **not** — the package entry re-exports `MetadataInspectorProps` from `inspector-registry` and nothing at all from `default-inspector-registry`, and the package declares no subpath exports. That asymmetry is also why #4536 graded minor and this does not.

## Surface

`inspector-registry.ts` is **not** touched: the type extended here lives in the sibling `default-inspector-registry.ts`, so the conditional authorization for that file was not needed or used. `ObjectFieldInspector.tsx`, the permission editors, plugin packages and `content/docs/releases/` all untouched. `ResourceEditPage.tsx` and `StudioDesignSurface.tsx` were edited under the lifted phase-1 restriction; no `client.get(` call site was modified.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_