### PR TITLE
docs(plugin-list): the sort remedy names a stored denormalised field — not the formula type the server refuses (#4335)

### DIFF
--- a/packages/plugin-list/README.md
+++ b/packages/plugin-list/README.md
@@ -227,10 +227,22 @@ user's side). The server cannot order by the related name without a join, and
 `objectstack#4256` settled that it will not add one.
 
 So the sort picker withholds relational fields and says so. To sort by a related
-record's name, denormalize it onto this object with a **formula field** and sort
-that column like any other text column. A relational field that the view's
-CURRENT sort already uses stays listed, labelled `(by ID)`, so existing view
-metadata round-trips instead of silently losing its sort.
+record's name, denormalize that name onto this object as a **stored field,
+written when the source changes**, then sort by that field — the remedy the
+server's own refusal prescribes, in the same words the sort panel's hint uses.
+
+**Not a formula field.** A formula value is computed on read, so no driver
+materializes a column behind it, and since `objectstack#6994` the server answers
+a sort that names one with a hard `400 INVALID_SORT` (before that it degraded
+silently: the rows came back in an arbitrary order under a `200`, `asc` and
+`desc` identical). The picker withholds formula fields for the same reason
+(`objectui#4243`), so there is no formula column here to sort "like any other
+text column" — the column you sort is the stored one the denormalization writes.
+
+A field the view's CURRENT sort already uses stays listed under both rules —
+relational ones labelled `(by ID)` — so existing view metadata round-trips
+instead of silently losing its sort, and a sort the server would refuse can
+still be edited away in the picker that otherwise hides its field.
 
 Column-header sorting inside the grid is unaffected: it is client-side over the
 rows already loaded, where the label the cell shows IS available, so it orders by


### PR DESCRIPTION
Fixes #4335

`packages/plugin-list/README.md`, section *"Sorting (and why relational columns are not offered)"*, prescribed the one field type the server hard-refuses to order by — and the sentence after it described a column the picker no longer offers. Docs-only: one file, no runtime change, no strings, no tests.

## Before

```
So the sort picker withholds relational fields and says so. To sort by a related
record's name, denormalize it onto this object with a **formula field** and sort
that column like any other text column. A relational field that the view's
CURRENT sort already uses stays listed, labelled `(by ID)`, so existing view
metadata round-trips instead of silently losing its sort.
```

## After

```
So the sort picker withholds relational fields and says so. To sort by a related
record's name, denormalize that name onto this object as a **stored field,
written when the source changes**, then sort by that field — the remedy the
server's own refusal prescribes, in the same words the sort panel's hint uses.

**Not a formula field.** A formula value is computed on read, so no driver
materializes a column behind it, and since `objectstack#6994` the server answers
a sort that names one with a hard `400 INVALID_SORT` (before that it degraded
silently: the rows came back in an arbitrary order under a `200`, `asc` and
`desc` identical). The picker withholds formula fields for the same reason
(`objectui#4243`), so there is no formula column here to sort "like any other
text column" — the column you sort is the stored one the denormalization writes.

A field the view's CURRENT sort already uses stays listed under both rules —
relational ones labelled `(by ID)` — so existing view metadata round-trips
instead of silently losing its sort, and a sort the server would refuse can
still be edited away in the picker that otherwise hides its field.
```

## Every factual claim, verified at its source

Read-only, at objectui `origin/main` @ `a90888230` and objectstack `origin/main` @ `5d24f4b94`.

1. **"denormalize ... as a stored field, written when the source changes" is the shared vocabulary.** Measured first, per the ruling. The landed #4294 hint — `packages/i18n/src/locales/en.ts` `list.sortRelationalHint`, byte-identical to the provider-less fallback in `packages/plugin-list/src/ListView.tsx` — reads: *"To sort by that name, denormalize it onto this object as a stored field, written when the source changes, and sort by that. Not a formula field: it is virtual, so no column is stored for it and the server refuses to sort by one."* The server's refusal hint (objectstack `packages/metadata-protocol/src/protocol.ts`) says the same thing in the same words: *"Denormalise the value onto '${object}' (a stored field, written when the source changes) and sort by that. A formula field is virtual: with no column behind it the ORDER BY reaches the driver, finds nothing, and is dropped."* The README now uses that vocabulary too, so the three surfaces read as one voice.

2. **"a hard `400 INVALID_SORT`".** objectstack `protocol.ts`: `UNMATERIALIZED_SORT_TYPES` is `new Set(['formula'])`; the sort gate filters the requested names through it and, on a hit, throws via `invalidSortError`, which sets `err.status = 400` and `err.code = 'INVALID_SORT'`. Cited by behavior, not line number — the card's `:1593` and the triage comment's `:1903` disagree, and the constant is what is stable.

3. **"since `objectstack#6994`"** — the refusal branch is introduced by a comment naming that issue as "the third verdict on this axis".

4. **"before that it degraded silently: ... arbitrary order under a `200`, `asc` and `desc` identical".** The same comment carries the measurement that motivated the refusal: a formula `orderBy` returned five rows under a 200 in an order matching neither direction, with `asc` and `desc` byte-identical.

5. **"The picker withholds formula fields for the same reason (`objectui#4243`)".** `ListView.tsx`: `UNSORTABLE_FIELD_TYPES = new Set(['formula'])`, and the `sortFields` memo pushes a field only when it is neither relational nor in that set — so the old "sort that column like any other text column" named a column the picker does not list. That is what the repaired clause now says.

6. **"stays listed under both rules ... a sort the server would refuse can still be edited away".** Same memo: the `inUse` exception applies to both the relational and the unsortable branch, and only relational entries get the `(by ID)` suffix (`list.sortByIdSuffix`). The README previously described this exception as relational-only.

## Verification

```
node scripts/check-control-bytes.mjs
  OK (scanned 4309 tracked text file(s); skipped 85 binary).
node scripts/check-doc-links.mjs
  Links are valid across 13 scan roots.
node scripts/check-changeset-presence.mjs
  Compared the working tree with a90888230 (merge-base with origin/main): 1 file(s)
  changed, 0 of them under the src/ of a package the release covers, 0 under a package
  changesets ignores, 0 changeset(s) added.
  No source of a released package changed in this range, so no changeset is owed.
```

Plus a self-scan of the edited file for raw control bytes beyond the gate's surface — `grep -naP` over the `x00-x08 / x0b / x0c / x0e-x1f / x7f` range: no matches. `eslint` / `tsc` / `vitest` are not implicated by a `.md`-only change and were not run.

**Changeset:** none — the presence gate's own verdict, quoted above. `README.md` is not under a package's `src/`.

## Surface

`packages/plugin-list/README.md` only (16 insertions, 4 deletions, one file). No locale packs, no `src`, no `content/docs/releases/`.

## Out of scope, filed not fixed

#4559 — `ListView.tsx`'s own comment above the `sortFields` memo still calls a formula field "the supported alternative ... which sorts like any text column", describing a hint that has said the opposite since #4294 and code that filters it out. Observation-class (a comment; nothing renders it), so `finding`, unassigned, no `pm:queue`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_