### PR TITLE
fix(react): SchemaRenderer states its real contract — typed schema, deliberate forwarding, no accidental erasure (#4548)

### DIFF
--- a/.changeset/schemarenderer-open-contract-4548.md
+++ b/.changeset/schemarenderer-open-contract-4548.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/react': minor
+'@object-ui/plugin-dashboard': patch
+'@object-ui/plugin-report': patch
+'@object-ui/plugin-detail': patch
+'@object-ui/plugin-view': patch
+'@object-ui/components': patch
+---
+
+`SchemaRenderer` states its real contract — a typed, required `schema` and a deliberate forwarding surface
+
+`SchemaRenderer` is the renderer loop: every registered SDUI component is rendered through it. It handed `forwardRef` a props type of `{ schema: SchemaNode } & Record<string, any>`, which puts `string` into `keyof Props`, so `'ref' extends keyof Props` was always true, React's `PropsWithoutRef` took its `Omit` branch, and `Omit` over a type carrying a string index signature keeps only the index signature. Every declared prop was erased. Measured on the pre-fix source: `keyof ComponentProps<typeof SchemaRenderer>` was `string` and `ComponentProps<typeof SchemaRenderer>['schema']` was `any`, while the type argument went on declaring `SchemaNode`. The other half is the same defect seen from the call site — `<SchemaRenderer />` with no schema at all, `<SchemaRenderer schema={12345} />`, and an arbitrary misspelled prop each type-checked in silence. This is objectui#4422 / PR #4438's trap in the most central component in the repo, spelled `Record<string, any>` rather than `[key: string]: any`, which is why every previous sweep's grep and both shipped guards' detector reported the site as clean.
+
+Graded **minor, not major**, on objectui#4528's reasoning: the type argument has always DECLARED `schema`; the index signature erased it from the resolved type, and restoring what the declaration documents is a fix to the published contract rather than a contract break.
+
+**The forwarding surface is kept, deliberately.** This component forwards every prop it does not read to the component the schema names, resolved at runtime from a plugin-extensible registry — `packages/react/README.md` documents exactly that, and `@object-ui/components`' form renderer consumes the `onSubmit` it shows being forwarded. Closing that surface would state a false contract and would force every leaf plugin's props into this package. So the two halves are separated: the `forwardRef` type argument is the honest `SchemaRendererProps`, with no index signature for `PropsWithoutRef` to collapse, and the open surface is stated once in an explicit export annotation, which nothing routes through `Omit`. The published `.d.ts` shows the erasure disappearing: `ForwardRefExoticComponent<Omit<{ schema: SchemaNode } & Record<string, any>, "ref"> & RefAttributes<any>>` becomes `ForwardRefExoticComponent<SchemaRendererProps & Record<string, any> & RefAttributes<any>>`.
+
+`SchemaRendererProps.schema` is declared as `BaseSchema | string | null | undefined` — what this component actually handles. It previously declared `@object-ui/core`'s `SchemaNode` interface, which requires `type: string` and so contradicted the component's own early returns for strings and nullish, while every caller held `@object-ui/types`' wider union. The erasure hid that mismatch completely.
+
+**One declared behaviour change.** A non-object, non-string primitive schema now renders as its own text. It previously fell through to the shallow copy `{ ...schema }`, which spreads a primitive to an empty object, lost the `type` the renderer then looked up, and surfaced the red "Unknown component type: undefined" box — an accident of the spread rather than a decision. The declared props type excludes `number` / `boolean` so no author is invited to pass them; the runtime handling is defence-in-depth for untyped callers and stored metadata. Strings, `null`, `undefined`, `0` and `false` render exactly as before, and an object naming an unregistered type still gets the error box; all four are pinned.
+
+Latent defects the erasure had been hiding, each surfaced by the repo-wide type-check and fixed at its call site: `DashboardRenderer` cast its widget schema to `Record<string, any>`, dropping the `type` every branch of `getComponentSchema` sets; `DashboardGridLayout`'s equivalent now states its return type instead of inferring a union that admitted a shape with no `type`; and `ReportViewer` handed a section's `content` array to the renderer whole, so a multi-node section rendered the unknown-component box instead of its content — arrays are mapped rather than widened into the renderer's declared input.
+
+A repo-wide structural guard replaces the two per-package siblings' blocked direction: it judges every `forwardRef` in `packages/*/src` (219 sites) and its detector resolves `Record<string, …>` and `string`-keyed mapped types in addition to literal index signatures — the spelling the previous detector went blind on. It judges the type argument only, where an index signature is an accidental eraser, and never an export annotation, where one is a stated contract.

--- a/packages/components/src/__tests__/html-anchor-links.test.tsx
+++ b/packages/components/src/__tests__/html-anchor-links.test.tsx
@@ -20,7 +20,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { SchemaRenderer, ActionProvider } from '@object-ui/react';
 import type { NavigationHandler } from '@object-ui/core';
-import type { SchemaNode } from '@object-ui/types';
+import type { BaseSchema } from '@object-ui/types';
 // Registers the renderers at module scope, NOT inside a `beforeAll` — there the
 // cold transform is billed to `hookTimeout`, which is why this carried a raised
 // timeout. See object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
@@ -30,7 +30,7 @@ function renderAnchor(
   schema: Record<string, unknown>,
   onNavigate?: NavigationHandler,
 ) {
-  const tree = <SchemaRenderer schema={{ type: 'a', ...schema } as SchemaNode} />;
+  const tree = <SchemaRenderer schema={{ type: 'a', ...schema } as BaseSchema} />;
   return render(
     onNavigate ? (
       <ActionProvider onNavigate={onNavigate}>{tree}</ActionProvider>

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -13,8 +13,8 @@
  */
 
 import React, { useMemo } from 'react';
-import type { PageNodeSchema, PageNodeRegion, SchemaNode } from '@object-ui/types';
-import { SchemaRenderer, PageVariablesProvider, PageVariableActionBridge } from '@object-ui/react';
+import type { BaseSchema, PageNodeSchema, PageNodeRegion, SchemaNode } from '@object-ui/types';
+import { SchemaRenderer, toRenderableSchema, PageVariablesProvider, PageVariableActionBridge } from '@object-ui/react';
 import { ComponentRegistry } from '@object-ui/core';
 import { compile, manifestFromConfigs } from '@object-ui/sdui-parser';
 import { ReactKindPage } from './react-page';
@@ -179,7 +179,7 @@ const RegionContent: React.FC<{
       data-region={region.name}
     >
       {components.map((node: SchemaNode, idx: number) => (
-        <SchemaRenderer key={(node as any)?.id || `${region.name}-${idx}`} schema={node} />
+        <SchemaRenderer key={(node as any)?.id || `${region.name}-${idx}`} schema={toRenderableSchema(node)} />
       ))}
     </div>
   );
@@ -557,7 +557,7 @@ export const PageRenderer: React.FC<{
           </div>
         );
       }
-      return tree ? <SchemaRenderer schema={tree as unknown as SchemaNode} /> : null;
+      return tree ? <SchemaRenderer schema={tree as unknown as BaseSchema} /> : null;
     }
     const TemplateLayout = resolveTemplate(schema);
     if (TemplateLayout) {

--- a/packages/components/src/renderers/navigation/header-bar.tsx
+++ b/packages/components/src/renderers/navigation/header-bar.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import type { HeaderBarSchema, BreadcrumbItem as BreadcrumbItemType } from '@object-ui/types';
-import { resolveKeyedI18nLabel, SchemaRenderer } from '@object-ui/react';
+import { resolveKeyedI18nLabel, SchemaRenderer, toRenderableSchema } from '@object-ui/react';
 import {
   SidebarTrigger,
   Separator,
@@ -93,9 +93,9 @@ ComponentRegistry.register('header-bar',
           </div>
         )}
         {schema.actions?.map((action, idx) => (
-          <SchemaRenderer key={idx} schema={action} />
+          <SchemaRenderer key={idx} schema={toRenderableSchema(action)} />
         ))}
-        {schema.rightContent && <SchemaRenderer schema={schema.rightContent} />}
+        {schema.rightContent && <SchemaRenderer schema={toRenderableSchema(schema.rightContent)} />}
       </div>
     </header>
   ),

--- a/packages/plugin-dashboard/src/DashboardGridLayout.tsx
+++ b/packages/plugin-dashboard/src/DashboardGridLayout.tsx
@@ -5,7 +5,7 @@ import { cn, Card, CardHeader, CardTitle, CardContent, Button } from '@object-ui
 import { Edit, GripVertical, Save, X, RefreshCw } from 'lucide-react';
 import { SchemaRenderer, useHasDndProvider, useDnd } from '@object-ui/react';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
-import type { DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
+import type { BaseSchema, DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
 import { isObjectProvider } from './utils';
 import { classifyWidgetType } from './widgetDispatch';
 
@@ -378,7 +378,16 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
         >
           {schema.widgets?.map((widget, index) => {
             const widgetId = widget.id || `widget-${index}`;
-            const componentSchema = getComponentSchema(widget);
+            // `getComponentSchema` builds a node for `SchemaRenderer` in every
+            // branch, but its inferred union is wider than the renderer's
+            // declared input: the passthrough fallback spreads a
+            // `DashboardWidgetSchema` whose `type` is OPTIONAL, and the metric
+            // branches carry `widget.title`'s `I18nLabel` where `BaseSchema`
+            // declares a plain `string`. Both are pre-existing looseness in the
+            // widget types rather than anything this call site can state
+            // truthfully, so the narrowing is named here once (objectui#4548)
+            // instead of being spread across the two render sites below.
+            const componentSchema = getComponentSchema(widget) as BaseSchema | string | null | undefined;
             const isSelfContained = widget.type === 'metric';
             // `DashboardWidget.title` is the spec's `I18nLabel`: since
             // 17.0.0-rc.6 an author may inline a per-locale map

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
+import type { BaseSchema, DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
 import { SchemaRenderer, useActionEngine, useObjectLabel, PageVariablesProvider, usePageVariables } from '@object-ui/react';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionDef, ActionResult, ActionContext, ModalHandler, SduiDomPassThroughKey } from '@object-ui/core';
@@ -749,7 +749,14 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
             ? buildWidgetScopedFilter(widget, filterDefs, filterValues)
             : undefined;
         const componentSchema = (() => {
-            const cs = getComponentSchema() as Record<string, any>;
+            // `as BaseSchema`, not `as Record< string, any >` (objectui#4548):
+            // the old cast dropped the `type` every branch of
+            // `getComponentSchema` actually sets, so what reached
+            // `SchemaRenderer` was a bag with no component descriptor as far as
+            // the type system knew. Both spellings keep arbitrary key access
+            // (BaseSchema carries an index signature); only this one keeps
+            // `type`.
+            const cs = getComponentSchema() as BaseSchema;
             if (scopedFilter && cs && FILTERABLE_COMPONENT_TYPES.has(cs.type)) {
                 return { ...cs, filter: mergeFilters(cs.filter, scopedFilter) };
             }

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -25,7 +25,7 @@ import {
   LazyIcon,
 } from '@object-ui/components';
 import { ChevronDown, ChevronRight, Copy, Check, Eye, EyeOff, Pencil } from 'lucide-react';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
 import { getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
 import type { DetailViewSection as DetailViewSectionType, DetailViewField, FieldMetadata } from '@object-ui/types';
 import { applyDetailAutoLayout } from './autoLayout';
@@ -205,7 +205,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     
     // If custom renderer provided
     if (field.render) {
-      return <SchemaRenderer schema={field.render} data={{ ...data, value }} />;
+      return <SchemaRenderer schema={toRenderableSchema(field.render)} data={{ ...data, value }} />;
     }
 
     // Calculate responsive span class so col-span never exceeds the visible

--- a/packages/plugin-detail/src/DetailTabs.tsx
+++ b/packages/plugin-detail/src/DetailTabs.tsx
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent, Badge } from '@object-ui/components';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
 import type { DetailViewTab } from '@object-ui/types';
 
 export interface DetailTabsProps {
@@ -65,11 +65,11 @@ export const DetailTabs: React.FC<DetailTabsProps> = ({
             {Array.isArray(tab.content) ? (
               <div className="space-y-4">
                 {tab.content.map((schema, index) => (
-                  <SchemaRenderer key={index} schema={schema} data={data} />
+                  <SchemaRenderer key={index} schema={toRenderableSchema(schema)} data={data} />
                 ))}
               </div>
             ) : (
-              <SchemaRenderer schema={tab.content} data={data} />
+              <SchemaRenderer schema={toRenderableSchema(tab.content)} data={data} />
             )}
           </React.Suspense>
         </TabsContent>

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -44,7 +44,7 @@ import { RecordComments } from './RecordComments';
 import { ActivityTimeline } from './ActivityTimeline';
 import { HistoryTimeline } from './HistoryTimeline';
 import { RecordMetaFooter } from './RecordMetaFooter';
-import { SchemaRenderer, useSafeFieldLabel, useDataInvalidation, useInlineEdit, useRowPredicate } from '@object-ui/react';
+import { SchemaRenderer, toRenderableSchema, useSafeFieldLabel, useDataInvalidation, useInlineEdit, useRowPredicate } from '@object-ui/react';
 import { buildExpandFields, getRecordDisplayName, formatTitleTemplate, userActionPredicates } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { useLocalization, resolveFieldCurrency } from '@object-ui/i18n';
@@ -1157,7 +1157,7 @@ export const DetailView: React.FC<DetailViewProps> = ({
                 menu sits at the far right edge — the standard placement
                 for "more options" affordances. */}
             {headerActionNodes.map((action, index) => (
-              <SchemaRenderer key={`header-action-${index}`} schema={action} data={data} />
+              <SchemaRenderer key={`header-action-${index}`} schema={toRenderableSchema(action)} data={data} />
             ))}
           </div>
         </div>
@@ -1166,7 +1166,7 @@ export const DetailView: React.FC<DetailViewProps> = ({
       {/* Custom Header */}
       {schema.header && (
         <div>
-          <SchemaRenderer schema={schema.header} data={data} />
+          <SchemaRenderer schema={toRenderableSchema(schema.header)} data={data} />
         </div>
       )}
 
@@ -1696,7 +1696,7 @@ export const DetailView: React.FC<DetailViewProps> = ({
       {/* Custom Footer */}
       {schema.footer && (
         <div>
-          <SchemaRenderer schema={schema.footer} data={data} />
+          <SchemaRenderer schema={toRenderableSchema(schema.footer)} data={data} />
         </div>
       )}
       </div>

--- a/packages/plugin-report/src/ReportViewer.tsx
+++ b/packages/plugin-report/src/ReportViewer.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, Button, Badge, Skeleton } from '@object-ui/components';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
 import type { ReportViewerSchema, ReportSection, ReportExportFormat, ReportField, ReportGroupBy } from '@object-ui/types';
 import { Download, Printer, RefreshCw } from 'lucide-react';
 import { exportReport } from './ReportExportEngine';
@@ -405,9 +405,20 @@ export const ReportViewer: React.FC<ReportViewerProps> = ({ schema, onRefresh })
                   <div className="border-t-2 border-dashed my-8 print:page-break-after-always" />
                 )}
 
-                {section.content && (
-                  <SchemaRenderer schema={section.content} />
-                )}
+                {/* `content` may be a single node OR a list of them. The list
+                    case used to be handed to `SchemaRenderer` whole
+                    (objectui#4548): an array has no `type`, so the shallow copy
+                    inside the renderer produced an index-keyed object and the
+                    section rendered the red "Unknown component type: undefined"
+                    box instead of its content. Arrays are mapped here rather
+                    than widened into the renderer's declared input. */}
+                {Array.isArray(section.content)
+                  ? section.content.map((node, nodeIndex) => (
+                      <SchemaRenderer key={nodeIndex} schema={toRenderableSchema(node)} />
+                    ))
+                  : section.content && (
+                      <SchemaRenderer schema={toRenderableSchema(section.content)} />
+                    )}
               </div>
             );
           })}

--- a/packages/plugin-view/src/ViewSwitcher.tsx
+++ b/packages/plugin-view/src/ViewSwitcher.tsx
@@ -20,7 +20,7 @@ import {
   SelectValue,
 } from '@object-ui/components';
 import { cva } from 'class-variance-authority';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
 import type { ViewSwitcherSchema, ViewType } from '@object-ui/types';
 import {
   Activity,
@@ -368,7 +368,7 @@ export const ViewSwitcher: React.FC<ViewSwitcherProps> = ({
       );
     }
 
-    return <SchemaRenderer schema={currentViewConfig.schema} {...props} />;
+    return <SchemaRenderer schema={toRenderableSchema(currentViewConfig.schema)} {...props} />;
   })();
 
   return (

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -6,9 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { forwardRef, useContext, useMemo, useEffect, useReducer, useState, Component } from 'react';
+import React, { forwardRef, useContext, useMemo, useEffect, useReducer, useState, Component, type ForwardRefExoticComponent, type RefAttributes } from 'react';
+import type { BaseSchema } from '@object-ui/types';
 import {
-  SchemaNode,
   ComponentRegistry,
   ExpressionEvaluator,
   isObjectUIError,
@@ -201,7 +201,88 @@ export class SchemaErrorBoundary extends Component<
  */
 const NO_DATA_SOURCE: Record<string, any> = {};
 
-export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<string, any>>(({ schema, ...props }, _ref) => {
+/**
+ * The props `SchemaRenderer` DECLARES and reads itself (objectui#4548).
+ *
+ * ## Why `schema` is spelled as this union and not as a `SchemaNode`
+ *
+ * The repo carries two competing `SchemaNode` types: `@object-ui/core`'s
+ * interface (which requires `type: string`) and `@object-ui/types`' union
+ * (`BaseSchema | string | number | boolean | null | undefined`). This component
+ * matched NEITHER. It declared core's — narrower than what it accepts, so every
+ * caller holding the types union was wrong and could not be told — while its
+ * runtime returns early for strings and nullish, which core's interface forbids.
+ * The erasure below hid the mismatch completely: with props collapsed to an
+ * index signature, `schema` resolved to `any` and no call site was ever checked.
+ *
+ * So the contract is STATED HERE, by this component, as what it actually
+ * handles: an object schema, a bare string (rendered as text), or nothing at
+ * all. `number` / `boolean` are deliberately excluded — the runtime tolerates
+ * them defensively (see the primitive guard in the evaluation memo) but no
+ * author should be invited to pass them. Reconciling the two repo-wide
+ * `SchemaNode` spellings is a separate concern and deliberately not done here.
+ */
+export interface SchemaRendererProps {
+  schema: BaseSchema | string | null | undefined;
+}
+
+/**
+ * The open forwarding surface, named once so it reads as the decision it is.
+ *
+ * `SchemaRenderer` passes every prop it does not itself read straight through to
+ * the component the schema names, which is resolved at RUNTIME from a
+ * plugin-extensible registry — so the set of valid keys is not knowable here,
+ * and `packages/react/README.md` documents callers relying on it. The `any` is
+ * the point: this is a pass-through channel, not a typed prop.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see above: the
+// forwarded value is opaque to this component by construction.
+type ForwardedProps = Record<string, any>;
+
+/**
+ * The renderer loop.
+ *
+ * ## The explicit type annotation is the contract, and it is deliberate
+ *
+ * `forwardRef< T, P >` routes `P` through React's `PropsWithoutRef`:
+ *
+ *     Props extends any ? ('ref' extends keyof Props ? Omit< Props, 'ref' > : Props) : Props
+ *
+ * A string index signature on `P` puts `string` into `keyof Props`, so
+ * `'ref' extends keyof Props` is ALWAYS true, the `Omit` branch always runs, and
+ * `Omit` over a type carrying a string index signature keeps ONLY the index
+ * signature. Every declared prop is erased — on both sides. This component used
+ * to hand `forwardRef` a props type of `{ schema: SchemaNode } & Record< string,
+ * any >`, so its own `schema` resolved to `any` at every one of the ~376 call
+ * sites in this repo, and was not even REQUIRED: `< SchemaRenderer / >` with no
+ * schema at all type-checked (objectui#4548, measured).
+ *
+ * The fix is NOT to close the surface. This is the renderer loop: it forwards
+ * every prop it does not read to the component the schema names, resolved at
+ * RUNTIME from a plugin-extensible `ComponentRegistry`. That forwarding is a
+ * documented, load-bearing feature — `packages/react/README.md` shows
+ * `< SchemaRenderer schema={formSchema} onSubmit={handleSubmit} / >`, and
+ * `@object-ui/components`' form renderer consumes that `onSubmit` as a React
+ * prop. A closed props type would state a FALSE contract and would force every
+ * leaf plugin's props into this package to stay usable.
+ *
+ * So the two halves are separated deliberately:
+ *
+ *   * the `forwardRef` TYPE ARGUMENT is the honest `SchemaRendererProps`, with
+ *     no index signature — nothing for `PropsWithoutRef` to collapse, so
+ *     `schema` survives to the call site typed and required; and
+ *   * the open forwarding surface is stated ONCE, here, in this export
+ *     annotation. Because the annotation is applied to the already-built
+ *     component, `PropsWithoutRef` never runs over it, so `Record< string, any >`
+ *     widens the surface WITHOUT erasing anything.
+ *
+ * The repo-wide guard (`scripts/__tests__/forwardref-props-erasure.guard.test.ts`)
+ * judges the TYPE ARGUMENT only, for exactly this reason: an index signature
+ * there is an accidental eraser, whereas one here is a stated contract.
+ */
+export const SchemaRenderer: ForwardRefExoticComponent<
+  SchemaRendererProps & ForwardedProps & RefAttributes<unknown>
+> = forwardRef<unknown, SchemaRendererProps>(({ schema, ...props }: SchemaRendererProps & ForwardedProps, _ref) => {
   const context = useContext(SchemaRendererContext);
   const dataSource = context?.dataSource || NO_DATA_SOURCE;
   // Ambient host scope (user / app / features), fed by app-shell's
@@ -233,7 +314,19 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
 
   // Evaluate schema expressions against the data source
   const evaluatedSchema = useMemo(() => {
-    if (!schema || typeof schema === 'string') return schema;
+    // Nothing to evaluate unless the node is an OBJECT. `!schema` covers the
+    // nullish/empty cases and `typeof !== 'object'` covers every primitive —
+    // both return the value untouched for the render pass below to place.
+    //
+    // The `typeof` half is what used to be missing (objectui#4548): the guard
+    // named `string` only, so a `number` or `true` fell through to the
+    // `{ ...schema }` shallow copy on the next line, spread to an EMPTY object,
+    // lost its `type`, and surfaced as the red "Unknown component type:
+    // undefined" box — an accident of the spread, not a decision. The declared
+    // props type now excludes those primitives outright; this guard is the
+    // defence-in-depth behind it, and it is what makes the copy below provably
+    // an object spread.
+    if (!schema || typeof schema !== 'object') return schema;
 
     // `data` (record/datasource) plus the ambient host scope. `current_user`
     // is aliased to `user` so both `user.email` and `current_user.email`
@@ -386,10 +479,22 @@ export const SchemaRenderer = forwardRef<any, { schema: SchemaNode } & Record<st
   }, [schema, dataSource, predicateScope, pageVariables]);
 
   if (!evaluatedSchema) return null;
-  // Handle visibility: if evaluated schema is hidden, render nothing
-  if (evaluatedSchema?._hidden) return null;
   // If schema is just a string, render it as text
   if (typeof evaluatedSchema === 'string') return <>{evaluatedSchema}</>;
+  // Any other primitive that reached here renders as its text too
+  // (objectui#4548). The declared props type does not admit `number` /
+  // `boolean`, so this is unreachable from typed code and exists for untyped
+  // callers and stored metadata; it replaces the empty-spread "Unknown
+  // component type: undefined" box, which said nothing true about the input.
+  if (typeof evaluatedSchema !== 'object') return <>{String(evaluatedSchema)}</>;
+  // Handle visibility: if evaluated schema is hidden, render nothing.
+  //
+  // Reads AFTER the primitive narrowing above (objectui#4548) so the property
+  // access is on a known object. Behaviour is unchanged: `_hidden` is only ever
+  // set on the object copy built in the memo, so for a string or any other
+  // primitive this test was always falsy and fell through to exactly the
+  // branches that now precede it.
+  if (evaluatedSchema._hidden) return null;
 
   // Dev-mode validation: log once per schema object, attach visual flag
   // when invalid. Production path returns { valid: true, messages: [] }

--- a/packages/react/src/__tests__/SchemaRenderer.aria.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.aria.test.tsx
@@ -11,6 +11,7 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer } from '../SchemaRenderer';
+import type { BaseSchema } from '@object-ui/types';
 
 // A simple test component that forwards ARIA attributes
 const TestWidget: React.FC<any> = (props) => (
@@ -51,8 +52,11 @@ describe('SchemaRenderer AriaProps injection', () => {
       <SchemaRenderer
         schema={{
           type: 'test-widget',
+          // AriaPropsSchema declares `ariaLabel: string | I18nLabel` and the
+          // renderer resolves the keyed form; `BaseSchema.ariaLabel` is the
+          // narrower `string` (objectui#4548).
           ariaLabel: { key: 'dialog.close', defaultValue: 'Close dialog' },
-        }}
+        } as unknown as BaseSchema}
       />
     );
     const el = screen.getByTestId('test-widget');

--- a/packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx
@@ -11,6 +11,12 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer } from '../SchemaRenderer';
+// `@object-ui/types` declares `BaseSchema.visible` / `.disabled` as `boolean`,
+// but BOTH accept a predicate STRING here — that is the capability these cases
+// exercise, and the renderer evaluates it (`evaluateCondition`). The declaration
+// is the narrow one; until it is widened these fixtures state their real shape
+// through `BaseSchema`'s index signature (objectui#4548 measured the gap).
+import type { BaseSchema } from '@object-ui/types';
 import { SchemaRendererContext } from '../context/SchemaRendererContext';
 
 // Simple test component
@@ -43,7 +49,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('evaluates visible expression string', () => {
       render(
         <SchemaRendererContext.Provider value={{ dataSource: { role: 'admin' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' }} />
+          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' } as unknown as BaseSchema} />
         </SchemaRendererContext.Provider>
       );
       expect(screen.getByTestId('test-component')).toBeInTheDocument();
@@ -52,7 +58,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('hides when visible expression evaluates to false', () => {
       const { container } = render(
         <SchemaRendererContext.Provider value={{ dataSource: { role: 'viewer' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' }} />
+          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' } as unknown as BaseSchema} />
         </SchemaRendererContext.Provider>
       );
       expect(container.innerHTML).toBe('');
@@ -123,7 +129,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('evaluates disabled expression string', () => {
       render(
         <SchemaRendererContext.Provider value={{ dataSource: { status: 'locked' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' }} />
+          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' } as unknown as BaseSchema} />
         </SchemaRendererContext.Provider>
       );
       expect(screen.getByTestId('test-component')).toHaveAttribute('data-disabled', 'true');
@@ -132,7 +138,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('does not set disabled when expression is false', () => {
       render(
         <SchemaRendererContext.Provider value={{ dataSource: { status: 'active' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' }} />
+          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' } as unknown as BaseSchema} />
         </SchemaRendererContext.Provider>
       );
       expect(screen.getByTestId('test-component')).not.toHaveAttribute('data-disabled');

--- a/packages/react/src/__tests__/SchemaRenderer.primitiveSchema.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.primitiveSchema.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4548 — what `SchemaRenderer` does with a NON-OBJECT schema.
+ *
+ * ## Why this suite exists
+ *
+ * The evaluation memo used to guard only `!schema || typeof schema === 'string'`.
+ * A `number` or a `boolean` therefore fell through to the shallow copy
+ * `{ ...schema }`, which spreads a primitive to an EMPTY object — losing the
+ * `type` the renderer then looked up, so the node surfaced as the red
+ * "Unknown component type: undefined" box. That was an accident of the spread,
+ * not a decision, and it was invisible because the props type had collapsed to
+ * an index signature and `schema` resolved to `any`.
+ *
+ * The declared props type now excludes `number` / `boolean` outright, so typed
+ * callers cannot reach this at all. The runtime handling below is
+ * defence-in-depth for untyped callers and stored metadata, and the rendering it
+ * produces is the DECLARED behaviour change of objectui#4548: a stray primitive
+ * renders as its own text.
+ *
+ * The string and nullish paths are pinned byte-identical alongside it — those
+ * were correct before and must not move.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+
+const originalWarn = console.warn;
+beforeEach(() => {
+  console.warn = vi.fn();
+});
+afterEach(() => {
+  console.warn = originalWarn;
+});
+
+describe('objectui#4548 — non-object schema values', () => {
+  describe('the declared change: a stray primitive renders as its text', () => {
+    it('renders a number as text, not as an "Unknown component type" box', () => {
+      // Untyped caller — the declared props type does not admit `number`.
+      const { container } = render(<SchemaRenderer schema={42 as never} />);
+      expect(container.textContent).toBe('42');
+      // The old behaviour, explicitly: the empty spread lost `type`, so this
+      // rendered the unknown-component error box. It must not come back.
+      expect(container.textContent).not.toContain('Unknown component type');
+      expect(container.querySelector('[role="alert"]')).toBeNull();
+    });
+
+    it('renders a boolean as text', () => {
+      const { container } = render(<SchemaRenderer schema={true as never} />);
+      expect(container.textContent).toBe('true');
+      expect(container.textContent).not.toContain('Unknown component type');
+    });
+  });
+
+  describe('unchanged paths (pinned byte-identical)', () => {
+    it('renders a string schema as its own text', () => {
+      const { container } = render(<SchemaRenderer schema="just some text" />);
+      expect(container.textContent).toBe('just some text');
+    });
+
+    it('renders nothing for null / undefined / empty string', () => {
+      for (const value of [null, undefined, ''] as const) {
+        const { container } = render(<SchemaRenderer schema={value} />);
+        expect(container.innerHTML).toBe('');
+      }
+    });
+
+    it('renders nothing for the falsy primitives that never reached the spread', () => {
+      // `0` and `false` were caught by the pre-existing `!schema` leg and
+      // returned null; they keep doing so rather than becoming "0" / "false".
+      for (const value of [0, false] as const) {
+        const { container } = render(<SchemaRenderer schema={value as never} />);
+        expect(container.innerHTML).toBe('');
+      }
+    });
+
+    it('still shows the error box for an OBJECT whose type is unregistered', () => {
+      // The unknown-component box is correct HERE — an object that names a type
+      // nothing implements. Only the primitive case stopped producing it.
+      const { container } = render(<SchemaRenderer schema={{ type: 'no-such-component-4548' }} />);
+      expect(container.textContent).toContain('Unknown component type');
+      expect(container.textContent).toContain('no-such-component-4548');
+    });
+
+    it('still renders a registered component normally', () => {
+      const Probe: React.FC<{ schema?: { type?: string } }> = props => (
+        <div data-testid="ok">{props.schema?.type}</div>
+      );
+      ComponentRegistry.register('test-4548-div', Probe);
+      const { getByTestId } = render(<SchemaRenderer schema={{ type: 'test-4548-div' }} />);
+      expect(getByTestId('ok').textContent).toBe('test-4548-div');
+    });
+  });
+});

--- a/packages/react/src/__tests__/SchemaRenderer.propsResolution.test.ts
+++ b/packages/react/src/__tests__/SchemaRenderer.propsResolution.test.ts
@@ -1,0 +1,129 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4548 — COMPILE-TIME pins on the props a `SchemaRenderer` JSX call
+ * site is actually held to. The sibling of `plugin-list`'s and
+ * `plugin-dashboard`'s `*.propsResolution` pins (objectui#4528 / PR #4551).
+ *
+ * These assertions are erased at runtime; `tsc` is the only thing that can
+ * check them, which is why this file is carried by
+ * `packages/react/tsconfig.test.json` and why the `expect` below is deliberately
+ * trivial — the real assertions are the `Assert< Equal< … > >` types, and a
+ * violation is a compile error, not a red test.
+ *
+ * ## What was measured before the fix
+ *
+ * Probed on the pre-fix source, compiled through this same project:
+ *
+ *     keyof ComponentProps< typeof SchemaRenderer >            ->  string
+ *     ComponentProps< typeof SchemaRenderer >['schema']        ->  any
+ *     ({ schema: SchemaNode } & Record< string, any >)['schema'] ->  SchemaNode
+ *
+ * and — the half the sibling packages did not have — these three all compiled
+ * SILENTLY, which is the same defect seen from the other side:
+ *
+ *     < SchemaRenderer / >                       // no schema at all
+ *     < SchemaRenderer schema={12345} / >
+ *     < SchemaRenderer schema={{…}} bogusProp={1} / >
+ *
+ * The declaration was right and nobody was held to it. The props type argument
+ * carried `Record< string, any >`, which puts `string` into `keyof Props`, so
+ * React's `PropsWithoutRef` took its `Omit` branch and `Omit` over a string
+ * index signature keeps ONLY the index signature.
+ *
+ * ## What is pinned, and what is deliberately NOT
+ *
+ * The forwarding surface is intentionally still open — this is the renderer
+ * loop, and `packages/react/README.md` documents forwarding a component's own
+ * props through it. So `keyof` is still `string` and an unknown prop is still
+ * accepted; assertion 6 pins that openness as a DECISION rather than leaving it
+ * to be read as the bug it used to be. What is pinned is that the openness no
+ * longer costs the declared props: `schema` is typed, and it is required.
+ */
+
+/*
+ * The `Assert< … >` aliases below are the assertions themselves — they are
+ * deliberately never referenced, and a violation is a COMPILE error rather than
+ * a use site. `no-unused-vars` has nothing to say about that here.
+ */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { describe, it, expect } from 'vitest';
+import type { ComponentProps } from 'react';
+import type { BaseSchema } from '@object-ui/types';
+import { SchemaRenderer, type SchemaRendererProps } from '../SchemaRenderer';
+import { toRenderableSchema } from '../schema-input';
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/** The props a JSX call site is held to. */
+type CallSiteProps = ComponentProps<typeof SchemaRenderer>;
+
+// 1. THE assertion. `schema` survives to the call site with its declared type.
+//    Before the fix this was `any`, so every schema — and any prop typo next to
+//    it — passed silently.
+type _SchemaIsDeclared = Assert<
+  Equal<CallSiteProps['schema'], BaseSchema | string | null | undefined>
+>;
+
+// 2. …and that is not vacuously true because the whole thing is `any`. On the
+//    pre-fix shape assertion 1 would have "passed" against `any` for any type
+//    written on the right-hand side; this is what discriminates.
+type _SchemaIsNotAny = Assert<Equal<IsAny<CallSiteProps['schema']>, false>>;
+
+// 3. The call-site type agrees with the DECLARED interface on `schema`.
+type _CallSiteAgreesWithInterface = Assert<
+  Equal<CallSiteProps['schema'], SchemaRendererProps['schema']>
+>;
+
+// 4. `schema` is REQUIRED. Pre-fix `< SchemaRenderer / >` type-checked: the
+//    props had collapsed to a bare index signature, which requires nothing.
+//    Asked via `Required<…>` rather than the usual `{} extends …` idiom — the
+//    `{}` type is banned by `@typescript-eslint/no-empty-object-type`, and this
+//    spelling says the same thing: an OPTIONAL property is absent-able, so its
+//    `Pick` does not extend its own `Required` form.
+type _SchemaIsRequired = Assert<
+  Equal<
+    Pick<SchemaRendererProps, 'schema'> extends Required<Pick<SchemaRendererProps, 'schema'>>
+      ? true
+      : false,
+    true
+  >
+>;
+
+// 5. The declared union does NOT admit `number` / `boolean`. The runtime
+//    tolerates them (defence in depth, pinned in the behaviour suite), but no
+//    author is invited to author them.
+type _NumberIsNotDeclared = Assert<Equal<number extends CallSiteProps['schema'] ? true : false, false>>;
+type _BooleanIsNotDeclared = Assert<Equal<boolean extends CallSiteProps['schema'] ? true : false, false>>;
+
+// 6. The forwarding surface stays OPEN, deliberately (see the header). An
+//    arbitrary prop is still assignable — this is the renderer loop, and it
+//    forwards to the component the schema names. If this ever flips, it is a
+//    contract change and not a cleanup.
+type _ForwardingSurfaceStaysOpen = Assert<
+  Equal<{ schema: string; anyOtherProp: number } extends CallSiteProps ? true : false, true>
+>;
+
+// 7. `toRenderableSchema` lands exactly on the declared input — it is the
+//    documented bridge from `@object-ui/types`' wider `SchemaNode`, so its
+//    return type must not drift away from what the renderer accepts.
+type _BridgeLandsOnDeclaredInput = Assert<
+  Equal<ReturnType<typeof toRenderableSchema>, SchemaRendererProps['schema']>
+>;
+
+describe('objectui#4548 — SchemaRenderer serves its declared props', () => {
+  it('pins the resolved call-site props at compile time', () => {
+    // The assertions are the types above; this body only keeps the file a test.
+    const probe: CallSiteProps['schema'] = { type: 'text' };
+    expect(typeof probe).toBe('object');
+  });
+});

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 export * from './SchemaRenderer';
+export * from './schema-input';
 export * from './hooks'; // will be empty for now
 export * from './context'; // will be empty for now
 export * from './LazyPluginLoader';

--- a/packages/react/src/schema-input.ts
+++ b/packages/react/src/schema-input.ts
@@ -1,0 +1,38 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { BaseSchema } from '@object-ui/types';
+import type { SchemaRendererProps } from './SchemaRenderer';
+
+/**
+ * Narrow a loosely-typed metadata node onto {@link SchemaRendererProps.schema}.
+ *
+ * `@object-ui/types` declares `SchemaNode` as
+ * `BaseSchema | string | number | boolean | null | undefined`, and a lot of
+ * metadata plumbing (page regions, header-bar actions, detail tabs, view
+ * configs) is typed with it. `SchemaRenderer` deliberately does NOT declare the
+ * `number` / `boolean` members — nobody should be invited to author them — so
+ * forwarding such a value needs one honest step in between.
+ *
+ * This is that step, and it is a TOTAL function rather than a cast: it maps the
+ * two primitive members onto their text form, which is precisely what the
+ * renderer's own defensive branch does with them. So it changes no behaviour and
+ * tells no lie — the value a caller forwards renders identically whether or not
+ * it passes through here.
+ *
+ * It exists because the two competing repo-wide `SchemaNode` spellings
+ * (`@object-ui/core`'s interface vs `@object-ui/types`' union) have not been
+ * reconciled; that reconciliation is tracked separately. When it lands, the
+ * call sites using this can go back to forwarding directly.
+ */
+export function toRenderableSchema(
+  node: BaseSchema | string | number | boolean | null | undefined,
+): SchemaRendererProps['schema'] {
+  return typeof node === 'number' || typeof node === 'boolean' ? String(node) : node;
+}
+

--- a/scripts/__tests__/forwardref-props-erasure.guard.test.ts
+++ b/scripts/__tests__/forwardref-props-erasure.guard.test.ts
@@ -1,0 +1,392 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4548 — the REPO-WIDE closure of the `forwardRef` prop-erasure family
+ * (objectui#4422 / PR #4438, objectui#4528 / PR #4551), and the direction the
+ * two per-package siblings recorded as blocked.
+ *
+ * ## The trap
+ *
+ * `forwardRef< T, P >` routes `P` through `PropsWithoutRef`, defined in
+ * `@types/react` as:
+ *
+ *     Props extends any ? ('ref' extends keyof Props ? Omit< Props, 'ref' > : Props) : Props
+ *
+ * A string index signature puts `string` into `keyof Props`, so
+ * `'ref' extends keyof Props` is ALWAYS true and the `Omit` branch always runs.
+ * `Omit` over a type carrying a string index signature keeps only the index
+ * signature — every declared property is erased, on BOTH sides: the render
+ * function reads its own props as `any`, and every JSX CALL SITE goes unchecked.
+ * It is silent, because the props type is right there in the source and
+ * `noImplicitAny` never fires — the `any` is supplied explicitly.
+ *
+ * ## Why this guard is repo-wide where its predecessors were per-package
+ *
+ * #4438's ratchet resolves its scan root as `packages/components/src`, and
+ * #4551's two siblings theirs as their own package. Each could only see the
+ * package it lived in, which is exactly how each successive offender survived.
+ * Measured across every `packages/*` `src` at the time of writing: **219**
+ * `forwardRef` sites own their props type, and exactly **one** carried the
+ * erasure — `packages/react/src/SchemaRenderer.tsx`, the renderer loop itself,
+ * which this card fixed. One offender, then zero: the population is small enough
+ * and the rule uniform enough that a single repo-wide assertion is now the
+ * honest shape.
+ *
+ * ## The detector, and the spelling that motivated it
+ *
+ * `SchemaRenderer` spelled its erasure `Record< string, any >`, not
+ * `[key: string]: any`. Both predecessors' `hasStringIndexSignature` walks for a
+ * `ts.isIndexSignatureDeclaration` member and resolves type references only
+ * through types declared in the SAME file, so `localTypes.get('Record')` missed
+ * — `Record` is a global mapped type — and the function returned `false`. Both
+ * guards reported the site CLEAN, and every sweep's grep for
+ * `[key: string]: any` missed it too. So this detector resolves, in addition:
+ *
+ *   * `Record< string, … >` by name plus its first type argument;
+ *   * any mapped type whose key constraint is `string` (`{ [K in string]: … }`),
+ *     so the hole cannot be reopened by hand-rolling what `Record` expands to.
+ *
+ * ## Scope: the forwardRef TYPE ARGUMENT only — this is deliberate
+ *
+ * This guard judges the props TYPE ARGUMENT, and never an export annotation.
+ * The distinction is the whole point:
+ *
+ *   * an index signature on the TYPE ARGUMENT is an ACCIDENTAL ERASER — it is
+ *     fed to `PropsWithoutRef`, whose `Omit` then deletes every declared prop.
+ *     Nobody writing it intends that, and nothing reports it;
+ *   * an index signature in an EXPORT ANNOTATION is a STATED CONTRACT. It is
+ *     applied to the already-built component, so `PropsWithoutRef` never runs
+ *     over it and nothing is erased. `SchemaRenderer` is exactly this case: it
+ *     is the renderer loop, it forwards unread props to the component the schema
+ *     names at runtime, and `packages/react/README.md` documents that. Closing
+ *     it would state a false contract.
+ *
+ * So the fixed `SchemaRenderer` passes this guard on the merits, not by
+ * exemption — there is no allowlist here, and adding one would be the wrong
+ * repair for anything this catches.
+ *
+ * ## What is NOT swept here
+ *
+ * #4551's second assertion — "every destructuring forwardRef annotates its props
+ * parameter" — stays PER-PACKAGE and is deliberately not lifted to this file.
+ * Measured repo-wide it names **200** sites, overwhelmingly the shadcn/ui
+ * primitives in `packages/components/src/ui/*` plus `plugin-timeline`. None of
+ * those is erased: their type arguments carry no index signature at all, so
+ * `PropsWithoutRef` takes its identity branch and their props are intact. There
+ * the annotation is a style preference, not a correctness gate, and sweeping it
+ * repo-wide would turn 200 non-defects red and bury the one assertion that does
+ * name a defect.
+ *
+ * ## If this fails
+ *
+ * Take the index signature OFF the type argument. If the component really does
+ * forward arbitrary keys, put it on the render function's parameter annotation
+ * (so the runtime spread stays typed) and, when the open surface is part of the
+ * component's contract, state it in an explicit export annotation the way
+ * `SchemaRenderer` does. Do not add an allowlist, and do not delete a parameter
+ * annotation to quiet the error — that silently untypes every prop the render
+ * function reads.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// scripts/__tests__  ->  <repo root>
+const repoRoot = path.resolve(here, '..', '..');
+const packagesRoot = path.join(repoRoot, 'packages');
+
+function collectSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const name = entry.name;
+      if (name === 'node_modules' || name === 'dist' || name === '__tests__') continue;
+      const full = path.join(dir, name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.tsx?$/.test(name) && !/\.(test|spec)\.tsx?$/.test(name)) out.push(full);
+    }
+  };
+  if (statSync(root).isDirectory()) walk(root);
+  return out;
+}
+
+/** A `forwardRef` call site, reduced to the facts this guard judges. */
+interface Site {
+  file: string;
+  line: number;
+  /** The props TYPE ARGUMENT syntactically carries a string index signature. */
+  indexSignatureOnTypeArg: boolean;
+  /** Which spelling matched — reported so a failure names the shape. */
+  how: string | null;
+}
+
+/**
+ * Does this type node carry a string index signature, in ANY of its spellings?
+ * Resolves local aliases, intersections, unions, `Record< string, … >`, and
+ * mapped types keyed by `string`.
+ */
+export function hasStringIndexSignature(
+  node: ts.TypeNode | undefined,
+  localTypes: Map<string, ts.Node>,
+  seen = new Set<string>(),
+): { hit: boolean; how: string | null } {
+  if (!node) return { hit: false, how: null };
+  let how: string | null = null;
+
+  const members = (n: ts.Node): readonly ts.TypeElement[] | undefined =>
+    ts.isTypeLiteralNode(n) || ts.isInterfaceDeclaration(n) ? n.members : undefined;
+
+  const scan = (n: ts.Node): boolean => {
+    const ms = members(n);
+    if (ms) {
+      for (const m of ms) {
+        if (ts.isIndexSignatureDeclaration(m)) {
+          const p = m.parameters[0];
+          if (p?.type && p.type.kind === ts.SyntaxKind.StringKeyword) {
+            how = 'index-signature';
+            return true;
+          }
+        }
+      }
+      // an interface may inherit one
+      if (ts.isInterfaceDeclaration(n) && n.heritageClauses) {
+        for (const h of n.heritageClauses) {
+          for (const t of h.types) {
+            if (ts.isIdentifier(t.expression) && localTypes.has(t.expression.text)) {
+              const name = t.expression.text;
+              if (!seen.has(name)) {
+                seen.add(name);
+                if (scan(localTypes.get(name)!)) return true;
+              }
+            }
+          }
+        }
+      }
+      return false;
+    }
+    if (ts.isTypeAliasDeclaration(n)) return scan(n.type);
+    if (ts.isIntersectionTypeNode(n) || ts.isUnionTypeNode(n)) return n.types.some(scan);
+    if (ts.isParenthesizedTypeNode(n)) return scan(n.type);
+    // `{ [K in string]: … }` — what `Record< string, … >` expands to.
+    if (ts.isMappedTypeNode(n)) {
+      const constraint = n.typeParameter?.constraint;
+      if (constraint && constraint.kind === ts.SyntaxKind.StringKeyword) {
+        how = 'mapped-type';
+        return true;
+      }
+      return false;
+    }
+    if (ts.isTypeReferenceNode(n) && ts.isIdentifier(n.typeName)) {
+      const name = n.typeName.text;
+      // The global mapped type, which a local-declaration lookup cannot see.
+      // This is the objectui#4548 spelling.
+      if (name === 'Record') {
+        const key = n.typeArguments?.[0];
+        if (key && key.kind === ts.SyntaxKind.StringKeyword) {
+          how = 'Record< string, … >';
+          return true;
+        }
+        return false;
+      }
+      if (seen.has(name)) return false;
+      seen.add(name);
+      const decl = localTypes.get(name);
+      return decl ? scan(decl) : false;
+    }
+    return false;
+  };
+
+  const hit = scan(node);
+  return { hit, how };
+}
+
+/** Every `forwardRef(...)` whose props type argument this file can resolve. */
+export function collectSitesFrom(file: string, text: string): Site[] {
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+
+  const localTypes = new Map<string, ts.Node>();
+  const indexDecls = (n: ts.Node): void => {
+    if (ts.isInterfaceDeclaration(n) || ts.isTypeAliasDeclaration(n)) localTypes.set(n.name.text, n);
+    ts.forEachChild(n, indexDecls);
+  };
+  indexDecls(sf);
+
+  const sites: Site[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const isForwardRef =
+        (ts.isIdentifier(callee) && callee.text === 'forwardRef') ||
+        (ts.isPropertyAccessExpression(callee) && callee.name.text === 'forwardRef');
+      if (isForwardRef) {
+        const typeArg = node.typeArguments?.[1];
+        // In scope only when THIS file owns the props contract: an inline type
+        // literal, a named type declared here, or a bare global mapped type
+        // (`Record< string, any >`) whose shape is fully readable from source.
+        // A props type IMPORTED from elsewhere is out of a source scan's reach
+        // and is covered where it is declared instead.
+        let ownsProps = false;
+        if (typeArg) {
+          ownsProps =
+            !ts.isTypeReferenceNode(typeArg) ||
+            !ts.isIdentifier(typeArg.typeName) ||
+            localTypes.has(typeArg.typeName.text) ||
+            typeArg.typeName.text === 'Record';
+        }
+        const render = node.arguments[0];
+        if (ownsProps && render && (ts.isArrowFunction(render) || ts.isFunctionExpression(render))) {
+          const r = hasStringIndexSignature(typeArg, localTypes);
+          sites.push({
+            file,
+            line: sf.getLineAndCharacterOfPosition(node.getStart()).line + 1,
+            indexSignatureOnTypeArg: r.hit,
+            how: r.how,
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return sites;
+}
+
+const collectSites = (file: string): Site[] => collectSitesFrom(file, readFileSync(file, 'utf8'));
+
+const ALL_SITES = readdirSync(packagesRoot, { withFileTypes: true })
+  .filter(d => d.isDirectory())
+  .flatMap(d => {
+    const src = path.join(packagesRoot, d.name, 'src');
+    try {
+      if (!statSync(src).isDirectory()) return [];
+    } catch {
+      return [];
+    }
+    return collectSourceFiles(src).flatMap(collectSites);
+  });
+
+const rel = (s: Site) => `${path.relative(repoRoot, s.file)}:${s.line}`;
+
+describe('objectui#4548 — no forwardRef props type is erased, repo-wide', () => {
+  it('finds the population (guards against a broken scan)', () => {
+    // 219 sites at the time of writing. If this collapses, the walk or the AST
+    // matcher has gone stale and the guard would silently pass on nothing.
+    expect(ALL_SITES.length).toBeGreaterThanOrEqual(150);
+  });
+
+  it('detects every spelling it is meant to ban (guards against a dead matcher)', () => {
+    const scan = (src: string): Site[] =>
+      collectSitesFrom(path.join(packagesRoot, '__inmemory__.tsx'), src);
+
+    // 1. objectui#4548's OWN pre-fix shape — the spelling both shipped guards
+    //    report as CLEAN, and the reason this detector exists.
+    const record = scan(
+      'const C = React.forwardRef<any, { schema: SchemaNode } & Record<string, any>>' +
+        '(({ schema, ...props }, _ref) => null);',
+    );
+    expect(record).toHaveLength(1);
+    expect(record[0].indexSignatureOnTypeArg).toBe(true);
+    expect(record[0].how).toBe('Record< string, … >');
+
+    // 2. The classic literal spelling (objectui#4422 / #4528).
+    const named = scan(
+      'interface P { schema: XSchema; [key: string]: any }\n' +
+        'const C = React.forwardRef<H, P>(({ schema, ...props }, ref) => null);',
+    );
+    expect(named).toHaveLength(1);
+    expect(named[0].indexSignatureOnTypeArg).toBe(true);
+    expect(named[0].how).toBe('index-signature');
+
+    // 3. Hidden behind a local alias and an intersection.
+    const aliased = scan(
+      'type Pass = { [key: string]: any };\n' +
+        'type P = { schema: XSchema } & Pass;\n' +
+        'const C = React.forwardRef<H, P>(({ schema }, ref) => null);',
+    );
+    expect(aliased[0].indexSignatureOnTypeArg).toBe(true);
+
+    // 4. `Record` behind a local alias — both extensions cooperating.
+    const aliasedRecord = scan(
+      'type P = { schema: XSchema } & Record<string, unknown>;\n' +
+        'const C = React.forwardRef<H, P>((props, ref) => null);',
+    );
+    expect(aliasedRecord[0].indexSignatureOnTypeArg).toBe(true);
+    expect(aliasedRecord[0].how).toBe('Record< string, … >');
+
+    // 5. A hand-rolled mapped type — what `Record` expands to. The hole must
+    //    not be reopenable by spelling it out.
+    const mapped = scan(
+      'type P = { [K in string]: any };\n' +
+        'const C = React.forwardRef<H, P>((props, ref) => null);',
+    );
+    expect(mapped[0].indexSignatureOnTypeArg).toBe(true);
+    expect(mapped[0].how).toBe('mapped-type');
+
+    // 6. The COMPLIANT shape reads as compliant: signature off the type
+    //    argument, on the parameter annotation, so the spread still collects
+    //    arbitrary keys while the declared props survive.
+    const fixed = scan(
+      'interface P { schema: XSchema }\n' +
+        'const C = React.forwardRef<H, P>(' +
+        '({ schema, ...props }: P & { [key: string]: any }, ref) => null);',
+    );
+    expect(fixed).toHaveLength(1);
+    expect(fixed[0].indexSignatureOnTypeArg).toBe(false);
+
+    // 7. And so does SchemaRenderer's shipped shape: a clean type argument with
+    //    the open surface stated in the EXPORT ANNOTATION, which this guard
+    //    does not read (see the header — stated contract, not accidental
+    //    eraser). This is the case that would be an allowlist entry if the
+    //    claim were drawn any wider.
+    const stated = scan(
+      'interface P { schema: XSchema }\n' +
+        'export const C: ForwardRefExoticComponent<P & Record<string, any> & RefAttributes<any>> =\n' +
+        '  forwardRef<any, P>(({ schema, ...props }: P & Record<string, any>, _ref) => null);',
+    );
+    expect(stated).toHaveLength(1);
+    expect(stated[0].indexSignatureOnTypeArg).toBe(false);
+
+    // 8. `Record< number, … >` does NOT collapse (`keyof` still excludes the
+    //    string `'ref'`), so it must not be reported.
+    const numericRecord = scan(
+      'const C = React.forwardRef<H, { schema: X } & Record<number, any>>(({ schema }, ref) => null);',
+    );
+    expect(numericRecord[0].indexSignatureOnTypeArg).toBe(false);
+
+    // 9. Nor does a NUMBER index signature.
+    const numeric = scan(
+      'const C = React.forwardRef<H, { schema: X; [i: number]: any }>(({ schema }, ref) => null);',
+    );
+    expect(numeric[0].indexSignatureOnTypeArg).toBe(false);
+
+    // 10. A props type IMPORTED from another file is out of a source scan's
+    //     reach, and this guard does not pretend otherwise: it reports nothing
+    //     rather than a false verdict.
+    const imported = scan(
+      "import type { P } from './Other';\n" +
+        'const C = React.forwardRef<H, P>((props, ref) => null);',
+    );
+    expect(imported).toEqual([]);
+  });
+
+  it('no forwardRef carries a string index signature on its props type argument', () => {
+    // If this fails: read the header. Take the signature OFF the type argument —
+    // on it, `PropsWithoutRef` collapses the props to the bare index signature,
+    // erasing every declared property from the render function AND from every
+    // JSX call site. Do not allowlist.
+    const offenders = ALL_SITES.filter(s => s.indexSignatureOnTypeArg).map(
+      s => `${rel(s)} [${s.how}]`,
+    );
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #4548

`SchemaRenderer` is the renderer loop — every registered SDUI component is rendered through it, and it is the thing that hands widgets their props. Its own props were erased.

## Measured first, on the pre-fix source

Probed through `packages/react/tsconfig.test.json` before anything was edited (the probe was throwaway; the permanent pin is `SchemaRenderer.propsResolution.test.ts`):

```
__probe4548__.test.tsx(20,7): Type 'string' is not assignable to type 'never'.        // keyof ComponentProps< typeof SchemaRenderer >
__probe4548__.test.tsx(22,7): Type 'any' is not assignable to type 'never'.           // ComponentProps< typeof SchemaRenderer >['schema']
__probe4548__.test.tsx(24,7): Type 'SchemaNode' is not assignable to type 'never'.    // the DECLARED type argument's ['schema']
__probe4548__.test.tsx(26,7): Type '"ERASED"' is not assignable to type 'never'.      // string extends keyof CallSiteProps
```

Declaration right, nobody held to it. The other half is the same defect seen from the call site — these three compiled **silently**, which is the measurement:

```tsx
< SchemaRenderer / >                                  // no schema at all
< SchemaRenderer schema={12345} / >
< SchemaRenderer schema={{…}} bogusPropNoOneReads={1} / >
```

`forwardRef< T, P >` routes `P` through `PropsWithoutRef`, which is `'ref' extends keyof Props ? Omit< Props, 'ref' > : Props`. A string index signature puts `string` into `keyof Props`, so the `Omit` branch always runs, and `Omit` over a type carrying a string index signature keeps only the index signature. Spelled `Record< string, any >` rather than `[key: string]: any`, which is why every previous sweep's grep and both shipped guards' detector reported this site as clean.

## The fix keeps the forwarding surface, deliberately

This component forwards every prop it does not read to the component the schema names, resolved at runtime from a plugin-extensible registry. `packages/react/README.md` documents exactly that — `< SchemaRenderer schema={formSchema} onSubmit={handleSubmit} / >` — and `@object-ui/components`' form renderer destructures that `onSubmit` as a React prop and invokes it. Closing the surface would state a false contract and force every leaf plugin's props into this package.

So the two halves are separated:

- the **forwardRef type argument** is the honest `SchemaRendererProps`, with no index signature — nothing for `PropsWithoutRef` to collapse; and
- the **open surface is stated once** in an explicit export annotation, which nothing routes through `Omit`, so it widens without erasing.

Visible in the shipped `.d.ts` (built both ways from a clean `dist`, spaces after each `<` for the sanitizer):

```diff
- export declare const SchemaRenderer: React.ForwardRefExoticComponent< Omit< {
-     schema: SchemaNode;
- } & Record< string, any >, "ref" > & React.RefAttributes< any > >;
+ export declare const SchemaRenderer: ForwardRefExoticComponent< SchemaRendererProps & ForwardedProps & RefAttributes< unknown > >;
```

That `Omit< …, "ref" >` is the erasure itself, materialised in the published artifact.

## The declared input, and one declared behaviour change

`SchemaRendererProps.schema` is `BaseSchema | string | null | undefined` — what this component actually handles. It previously declared `@object-ui/core`'s `SchemaNode` interface, which **requires** `type: string` and so contradicted the component's own early returns for strings and nullish, while every caller held `@object-ui/types`' wider union. The erasure hid that mismatch completely.

A non-object, non-string primitive now renders **as its own text**. It previously fell through to `{ ...schema }`, which spreads a primitive to an empty object, lost the `type` the renderer then looked up, and surfaced the red "Unknown component type: undefined" box — an accident of the spread, not a decision. The declared type still excludes `number` / `boolean` so no author is invited to pass them; the runtime handling is defence-in-depth. Strings, `null`, `undefined`, `0` and `false` render exactly as before, and an object naming an unregistered type still gets the error box — all pinned in `SchemaRenderer.primitiveSchema.test.tsx`.

## Canary: the full repo-wide type-check

Baseline on the unmodified worktree was **80/80**. The fix is **80/80** again, with these latent defects — every one hidden by the erasure — fixed at their call sites:

1. **`DashboardRenderer`** cast its widget schema `as Record< string, any >`, dropping the `type` that every branch of `getComponentSchema` actually sets.
2. **`DashboardGridLayout`**'s equivalent inferred a union admitting a shape with **no `type`** (the passthrough fallback spreads a `DashboardWidgetSchema`, whose `type` is optional), narrowed once at the definition site.
3. **`ReportViewer`** handed a section's `content` **array** to the renderer whole — an array has no `type`, so a multi-node section rendered the unknown-component box instead of its content. Arrays are mapped, not widened into the declared input.

Forwarding sites that hold `@object-ui/types`' wider `SchemaNode` go through `toRenderableSchema`, a **total** function rather than a cast: it maps the two primitive members onto their text form, which is precisely what the renderer's own defensive branch does, so it changes no behaviour.

No consumer relies on arbitrary passthrough in a way this breaks: the surface is kept, and the canary reports **zero** excess-prop errors.

## Guard: repo-wide, with the Record-aware detector

`scripts/__tests__/forwardref-props-erasure.guard.test.ts` replaces the two per-package siblings' blocked direction 3. Measured across every `packages/*` `src`: **219** forwardRef sites own their props type, **1** carried the erasure, now **0**.

Discrimination proof, run against the pre-fix shape (fix removed via `git checkout`, restored and sha256-verified byte-identical):

```
FAIL  scripts/__tests__/forwardref-props-erasure.guard.test.ts > no forwardRef carries a string index signature on its props type argument
  + [ "packages/react/src/SchemaRenderer.tsx:204 [Record< string, … >]" ]

Test Files  1 failed (1)
     Tests  1 failed | 2 passed (3)
```

Against this branch: **3 passed (3)**. The detector resolves `Record< string, … >` by name plus its first type argument, and any mapped type keyed by `string`, in addition to literal index signatures — the gap this card documents.

It judges the **type argument only**, never an export annotation. That distinction is the claim, not an exemption: an index signature on the type argument is an **accidental eraser** (it is fed to `PropsWithoutRef`), whereas one in an export annotation is a **stated contract** applied to the already-built component, where nothing collapses. The fixed `SchemaRenderer` therefore passes on the merits — there is no allowlist.

#4551's second assertion (every destructuring forwardRef annotates its parameter) stays **per-package** and is deliberately not lifted: repo-wide it names **200** sites, overwhelmingly the shadcn/ui primitives in `packages/components/src/ui/*` plus `plugin-timeline`. None is erased — their type arguments carry no index signature, so `PropsWithoutRef` takes its identity branch. Sweeping it would turn 200 non-defects red and bury the one assertion that names a defect. Recorded in the guard header.

## Grading

`@object-ui/react` **minor**, on #4528's reasoning quoted in the changeset: the type argument has always declared `schema`; the index signature erased it from the resolved type, and restoring what the declaration documents is a fix to the published contract, not a break. Consumers **patch**, per their own diffs. Never major.

## must-not-change

Bundle byte-identity does **not** apply here and is not claimed: the `SchemaNode` source and the new primitive guard change the emitted JS. It is replaced by behaviour pins — strings / nullish / `0` / `false` render identically, unknown-type objects keep the error box, and the touched packages' runtime suites are green and untouched.

## Verification

All re-run after rebasing onto current `main` (`eb7f586b6`), since `packages/types` and `packages/core` both moved under this branch:

- `turbo run type-check` (full, as CI runs it): **80 successful, 80 total** — baseline-matching
- all six touched packages build clean; both `tsc` passes per package via `type-check`
- `@object-ui/react`: **41 files, 566 tests** green (all of them), plus the repo-wide guard
- touched consumers (`components`, `plugin-dashboard`, `plugin-detail`, `plugin-report`, `plugin-view`): **273 files, 2475 tests** green
- eslint on the modified files: **164 warnings vs 165 baseline, 0 errors** — net negative; the new source files add 0
- `check-control-bytes`, `check-changeset-presence` / `-no-major` / `-fixed`, `check-phantom-dependencies`: green
- control-byte self-scan (`grep -naP`) over every created and edited file, including untracked: clean

Left as **draft** for PM step-7 review.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
