### PR TITLE
fix(react): NavigationConfig.mode is optional — the type says what the hook does (#4550)

### DIFF
--- a/.changeset/navigation-config-mode-optional-4550.md
+++ b/.changeset/navigation-config-mode-optional-4550.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/react': minor
+'@object-ui/plugin-list': patch
+---
+
+`NavigationConfig.mode` is optional — the type now says what the hook does
+
+`@object-ui/react` published a `NavigationConfig` that required `mode`, in front of a `useNavigationOverlay` that has always defaulted it. The declaration took the spec's authored config, `Omit`ted `mode`, and re-added it as `NonNullable< … >`; 140 lines below, the hook read `navigation?.mode ?? 'page'`. The type was strictly stricter than the implementation it fronted, and `'page'` is meaningful behaviour rather than a placeholder.
+
+The spec never asked for that. `NavigationConfigSchema` declares `mode: NavigationModeSchema.default('page')`, and a `.default()` lands on the authoring side as `| undefined` — so `navigation: { view: 'summary_view' }` is legal authored metadata that lets the mode default. `@object-ui/types` already re-exported the spec's own `NavigationConfig` unchanged, which meant one monorepo shipped two published types of the same name that disagreed about whether `mode` could be omitted.
+
+The alias is now the spec's authored config verbatim, with no divergence of its own:
+
+```ts
+export type NavigationConfig = SpecAuthoredInput< typeof NavigationConfigSchema >;
+```
+
+The cost of the old spelling was paid by callers. `ListView` carried `schema.navigation as NavigationConfig | undefined` for no reason except to get a valid spec-shaped value past the declaration; that assertion is deleted here, not replaced. A type in front of an implementation must not be stricter than the implementation — when it is, every caller pays in casts, and a cast is exactly the renderer-side workaround that belongs back at the producer.
+
+**Nothing changes at runtime.** `navigation?.mode ?? 'page'` is untouched, and the default is now pinned as observable behaviour (`useNavigationOverlay.modeDefault.test.tsx`) rather than only as a comment — the explicit modes, the `preventNavigation` and `none` short-circuits, the `onRowClick` priority, and the Cmd/Ctrl/middle-click and `new_window` branches are all pinned alongside it.
+
+**Why minor rather than patch**, from the measured `.d.ts`. Optional-izing a property is looser for writers and narrower for readers, so the grade turns on which role the published surface actually plays. In this package `NavigationConfig` occurs only in input positions — `useNavigationOverlay`'s `navigation?:` option and `resolveOverlayWidth`'s parameter — and never in a return type; the package consumes these values and never hands one back. For consumers the change is therefore purely permissive: every call that compiled before still compiles, and spec-shaped configs that previously needed an assertion now compile without one. That gained input shape is a real capability rather than an internal repair, which is more than a patch describes. The reader-side narrowing is real but secondary: code that imports the bare type, annotates its own value with it and reads `.mode` now sees `NavigationMode | undefined`. The in-repo census found exactly one such importer — `ListView` — and it imported the type only to write the assertion this change removes.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -15,7 +15,6 @@ import { ViewSwitcherDropdown, ViewType } from './ViewSwitcher';
 import { ViewSettingsPopover } from './components/ViewSettingsPopover';
 import { UserFilters } from './UserFilters';
 import { SchemaRenderer, useNavigationOverlay } from '@object-ui/react';
-import type { NavigationConfig } from '@object-ui/react';
 import { useDensityMode } from '@object-ui/react';
 import type { ListViewSchema } from '@object-ui/types';
 import { detectStatusField } from '@object-ui/types';
@@ -1727,15 +1726,21 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   }, [onSearchChange]);
 
   // --- NavigationConfig support ---
-  // The assertion bridges two spellings of ONE spec object and changes no
-  // value: `@object-ui/react`'s `NavigationConfig` alias re-declares `mode` as
-  // NON-optional, while the spec-derived `ListViewSchema['navigation']` leaves
-  // it optional. The hook's own body defaults it (`navigation?.mode ?? 'page'`),
-  // so a spec-shaped value is valid input and only the alias is tighter than
-  // its implementation. Surfaced by objectui#4528: this call used to type-check
-  // for the wrong reason, because the erased props type made `schema` `any`.
+  // No assertion, deliberately. `schema.navigation` is the spec-derived
+  // `ListViewSchema['navigation']` and the hook's `NavigationConfig` is now the
+  // spec's authored config verbatim — `mode` optional and all (objectui#4550).
+  // Two spellings of one spec object, so they simply agree.
+  //
+  // This call carried `as NavigationConfig | undefined` from objectui#4528
+  // until then. That cast bridged nothing real: the alias re-declared `mode` as
+  // required while the hook it fronts defaults it (`navigation?.mode ?? 'page'`),
+  // so the cast's only job was to get a valid value past an over-tight type.
+  // objectui#4550 fixed that at the producer, which deleted the reason for the
+  // cast — and a cast kept past its reason is how the next reader learns the
+  // wrong thing about the contract. Neither the cast nor its removal touches
+  // the runtime value.
   const navigation = useNavigationOverlay({
-    navigation: schema.navigation as NavigationConfig | undefined,
+    navigation: schema.navigation,
     objectName: schema.objectName,
     onNavigate: schema.onNavigate,
     onRowClick,

--- a/packages/react/src/hooks/__tests__/offline-nav-performance-spec-parity.test.ts
+++ b/packages/react/src/hooks/__tests__/offline-nav-performance-spec-parity.test.ts
@@ -233,7 +233,7 @@ describe('OfflineCacheConfig keeps its defaulted keys authorable', () => {
   });
 });
 
-describe('NavigationConfig derives from the spec, requiring only `mode`', () => {
+describe('NavigationConfig IS the spec\'s authored navigation config', () => {
   it('is pinned at compile time', () => {
     type SpecNavigationInput = SpecAuthoredInput<typeof NavigationConfigSchema>;
     type _SpecNotAny = Assert<Equal<IsAny<SpecNavigationInput>, false>>;
@@ -247,14 +247,35 @@ describe('NavigationConfig derives from the spec, requiring only `mode`', () => 
     type _NoLocalOnlyKeys = Assert<Equal<Exclude<keyof NavigationConfig, keyof SpecNavigationInput>, never>>;
     type _NoMissingKeys = Assert<Equal<Exclude<keyof SpecNavigationInput, keyof NavigationConfig>, never>>;
 
-    // `mode` is the ONE narrowing, and it is required here. If the spec ever
-    // makes `mode` required itself, `_StillNarrowed` fails and this alias
-    // should collapse to `SpecAuthoredInput<typeof NavigationConfigSchema>`.
-    type _ModeIsRequired = Assert<Equal<undefined extends NavigationConfig['mode'] ? true : false, false>>;
-    type _StillNarrowed = Assert<Equal<Extends<SpecNavigationInput, NavigationConfig>, false>>;
-    type _EverythingElseMatches = Assert<
-      Extends<Omit<SpecNavigationInput, 'mode'>, Omit<NavigationConfig, 'mode'>>
-    >;
+    // objectui#4550 — the narrowing is GONE, and these three pins are the
+    // inverted descendants of the ones that described it.
+    //
+    // The alias used to `Omit` `mode` and re-add it as `NonNullable<…>`, which
+    // made it strictly tighter than BOTH the spec that produces the value and
+    // the hook that consumes it (`navigation?.mode ?? 'page'`, 140 lines below
+    // the declaration). A required key in front of an implementation that
+    // defaults it is not a contract, and the cost was paid at every spec-typed
+    // caller: `ListView` had to write `schema.navigation as NavigationConfig`
+    // to hand the hook a value the hook was always happy to take.
+    //
+    // The previous spelling of this block predicted its own end — "if the spec
+    // ever makes `mode` required itself, `_StillNarrowed` fails and this alias
+    // should collapse to `SpecAuthoredInput<typeof NavigationConfigSchema>`."
+    // The collapse arrived from the other direction (the spec never moved; the
+    // alias was wrong all along), but it is the same collapse.
+    type _IsExactlyTheSpecInput = Assert<Equal<NavigationConfig, SpecNavigationInput>>;
+
+    // `mode` is OPTIONAL to author, because the spec defaults it
+    // (`packages/spec/src/ui/view.zod.ts` → `mode: NavigationModeSchema.default('page')`)
+    // and a `.default()` lands on the AUTHORING side as `| undefined`. This is
+    // the assertion that was false before objectui#4550.
+    type _ModeIsOptional = Assert<Equal<undefined extends NavigationConfig['mode'] ? true : false, true>>;
+
+    // Assignability now runs BOTH ways. `_LocalIsASpecConfig` above is the one
+    // direction that always held; this is the one the narrowing blocked, and
+    // it is the direction every caller actually needs — spec produces, alias
+    // consumes.
+    type _SpecShapedValueFits = Assert<Extends<SpecNavigationInput, NavigationConfig>>;
 
     // The overlay buckets the hook maps to pixel widths are the spec's, and
     // `size` is the key #2578 added — the deprecated `width` is still here too.
@@ -265,7 +286,7 @@ describe('NavigationConfig derives from the spec, requiring only `mode`', () => 
   });
 
   it('still carries every overlay mode the hook switches on', () => {
-    const all: NavigationConfig['mode'][] = [
+    const all: NonNullable<NavigationConfig['mode']>[] = [
       'page',
       'drawer',
       'modal',
@@ -284,19 +305,25 @@ describe('NavigationConfig derives from the spec, requiring only `mode`', () => 
     // spec's `NavigationMode` directly, and this is the pin the declaration
     // promises: the two spellings must stay the SAME type.
     //
-    // They can come apart in a way nothing else would catch. The equality holds
-    // today only because `NavigationConfig` above strips the `undefined` that
-    // `NavigationConfigSchema`'s `.default('page')` puts on `mode`'s authoring
-    // side. If the spec ever stops defaulting `mode`, or defaults it on a
-    // narrower union, `NavigationConfig['mode']` moves and the exported alias
-    // does not — and every call site keeps compiling, because the hook's
+    // They can come apart in a way nothing else would catch. If the spec ever
+    // stops defaulting `mode`, or defaults it on a narrower union,
+    // `NavigationConfig['mode']` moves and the exported alias does not — and
+    // every call site keeps compiling, because the hook's
     // `navigation?.mode ?? 'page'` would still be assignable either way.
     //
     // Both directions, deliberately: a one-way `extends` is satisfied by a
     // narrowing as well as by equality, and a narrowing is exactly the drift
     // that would delete a mode the hook switches on.
+    //
+    // `NonNullable` is objectui#4550's mark on this pin, and it is load-bearing
+    // rather than cosmetic. The alias no longer strips the `undefined` that
+    // `.default('page')` puts on the authoring side, so `NavigationConfig['mode']`
+    // is now `NavigationMode | undefined` — a bare `Equal` here would fail for
+    // a reason that has nothing to do with the drift this test exists to catch.
+    // What must stay pinned is the MEMBERSHIP: the seven modes the hook
+    // switches on are exactly the seven the exported union publishes.
     type _ModeIsSpecMode = Assert<Equal<NavigationMode, SpecNavigationMode>>;
-    type _ModeIsConfigMode = Assert<Equal<NavigationMode, NavigationConfig['mode']>>;
+    type _ModeIsConfigMode = Assert<Equal<NavigationMode, NonNullable<NavigationConfig['mode']>>>;
 
     // Runtime half — the type assertions above are erased, so this is what
     // fails visibly if the union ever loses a member.

--- a/packages/react/src/hooks/__tests__/useNavigationOverlay.modeDefault.test.tsx
+++ b/packages/react/src/hooks/__tests__/useNavigationOverlay.modeDefault.test.tsx
@@ -1,0 +1,327 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `useNavigationOverlay` — the RUNTIME half of objectui#4550.
+ *
+ * The type half lives in `offline-nav-performance-spec-parity.test.ts`, which
+ * pins that `NavigationConfig` IS the spec's authored config (`mode` optional).
+ * That file is compile-time only: every `Assert<…>` in it is erased before a
+ * single line runs, so it can prove the alias accepts a config without `mode`
+ * and prove nothing whatever about what the hook then DOES with it.
+ *
+ * This file is the other half. It exists because objectui#4550 relaxed a
+ * published type over an implementation it never described, and the whole case
+ * for that relaxation is that the implementation already behaved this way —
+ * `navigation?.mode ?? 'page'`, 140 lines below the declaration. A claim of
+ * "behaviour is unchanged" that nothing executes is not a claim, so the default
+ * is pinned here as an observable outcome, alongside every explicit mode the
+ * hook switches on. If a later change moves the default, deletes a branch, or
+ * makes a missing `mode` mean something other than `'page'`, this suite goes
+ * red and the parity file stays green — which is exactly the split of duties
+ * the two files are for.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import type { NavigationConfigSchema } from '@objectstack/spec/ui';
+import type { SpecAuthoredInput } from '../../spec-input';
+import { useNavigationOverlay } from '../useNavigationOverlay';
+import type { NavigationConfig, NavigationMode } from '../useNavigationOverlay';
+
+/**
+ * The exact value objectui#4550 reported the alias rejecting: a spec-authored
+ * navigation config that omits `mode`. The spec permits the omission on
+ * purpose — `packages/spec/src/ui/view.zod.ts` declares
+ * `mode: NavigationModeSchema.default('page')`, and a `.default()` lands on the
+ * authoring side as `| undefined`.
+ *
+ * The second declaration is the pin. Before objectui#4550 it was the bug
+ * itself, and `tsc` said so in as many words (verbatim, trimmed only where the
+ * compiler itself elided the union with "5 more ..."):
+ *
+ *   error TS2322: Type '{ mode?: "none" | "split" | "page" | ... | undefined;
+ *   view?: string | undefined; ... }' is not assignable to type
+ *   'NavigationConfig'.
+ *     Types of property 'mode' are incompatible.
+ *       Type '"none" | "split" | "page" | ... | undefined' is not assignable to
+ *       type 'NonNullable< "none" | "split" | "page" | ... | undefined >'.
+ *         Type 'undefined' is not assignable to type 'NonNullable< ... >'.
+ *
+ * and, for a bare literal, the shorter form:
+ *
+ *   error TS2322: Type '{}' is not assignable to type 'NavigationConfig'.
+ *     Property 'mode' is missing in type '{}' but required in type
+ *     '{ mode: NonNullable< ... >; }'.
+ *
+ * A spec-shaped value that the spec-derived alias will not accept is the whole
+ * finding in two lines, which is why it is pinned as a declaration rather than
+ * described in a comment.
+ */
+const AUTHORED_WITHOUT_MODE: SpecAuthoredInput<typeof NavigationConfigSchema> = {
+  view: 'summary_view',
+};
+const AS_ALIAS: NavigationConfig = AUTHORED_WITHOUT_MODE;
+
+/** Every mode the hook's `handleClick` switches on, for the exhaustiveness pin. */
+const EVERY_MODE: NavigationMode[] = [
+  'page',
+  'drawer',
+  'modal',
+  'split',
+  'popover',
+  'new_window',
+  'none',
+];
+
+const OVERLAY_MODES: NavigationMode[] = ['drawer', 'modal', 'split', 'popover'];
+
+const RECORD = { id: 'r1', name: 'Ada' };
+
+describe('useNavigationOverlay: a config without `mode` defaults to `page` (objectui#4550)', () => {
+  it('resolves `mode` to `page` and reports a non-overlay surface', () => {
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: AS_ALIAS, objectName: 'contacts', onNavigate }),
+    );
+
+    expect(result.current.mode).toBe('page');
+    expect(result.current.isOverlay).toBe(false);
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('routes a click through the `page` branch, carrying the declared view', () => {
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: AS_ALIAS, objectName: 'contacts', onNavigate }),
+    );
+
+    act(() => {
+      result.current.handleClick(RECORD);
+    });
+
+    // `view ?? 'view'` — the authored `view` survives the default-mode path.
+    expect(onNavigate).toHaveBeenCalledWith('r1', 'summary_view');
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('falls back to the `view` action when the config declares neither key', () => {
+    const onNavigate = vi.fn();
+    // A present-but-empty config is a different input from NO config: it takes
+    // the `mode === 'page'` branch rather than the `!navigation` early return.
+    // Both end at `onNavigate(id, 'view')`, and that agreement is the point —
+    // omitting `mode` must not become a third behaviour.
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: {}, objectName: 'contacts', onNavigate }),
+    );
+
+    expect(result.current.mode).toBe('page');
+    act(() => {
+      result.current.handleClick(RECORD);
+    });
+    expect(onNavigate).toHaveBeenCalledWith('r1', 'view');
+  });
+
+  it('agrees with the no-config path it has to be indistinguishable from', () => {
+    const withEmpty = vi.fn();
+    const withNothing = vi.fn();
+
+    const a = renderHook(() =>
+      useNavigationOverlay({ navigation: {}, objectName: 'contacts', onNavigate: withEmpty }),
+    );
+    const b = renderHook(() =>
+      useNavigationOverlay({ objectName: 'contacts', onNavigate: withNothing }),
+    );
+
+    act(() => {
+      a.result.current.handleClick(RECORD);
+      b.result.current.handleClick(RECORD);
+    });
+
+    expect(withEmpty.mock.calls).toEqual(withNothing.mock.calls);
+    expect(a.result.current.mode).toBe(b.result.current.mode);
+  });
+});
+
+describe('useNavigationOverlay: explicit modes behave exactly as before', () => {
+  it('reports `isOverlay` for the four overlay modes and no others', () => {
+    for (const mode of EVERY_MODE) {
+      const { result } = renderHook(() => useNavigationOverlay({ navigation: { mode } }));
+      expect(result.current.mode).toBe(mode);
+      expect(result.current.isOverlay).toBe(OVERLAY_MODES.includes(mode));
+    }
+  });
+
+  it('opens the overlay and captures the record for drawer/modal/split/popover', () => {
+    for (const mode of OVERLAY_MODES) {
+      const onNavigate = vi.fn();
+      const { result } = renderHook(() =>
+        useNavigationOverlay({ navigation: { mode }, objectName: 'contacts', onNavigate }),
+      );
+
+      act(() => {
+        result.current.handleClick(RECORD);
+      });
+
+      expect(result.current.isOpen).toBe(true);
+      expect(result.current.selectedRecord).toEqual(RECORD);
+      expect(onNavigate).not.toHaveBeenCalled();
+    }
+  });
+
+  it('delegates `page` to onNavigate and leaves the overlay shut', () => {
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: { mode: 'page' }, objectName: 'contacts', onNavigate }),
+    );
+
+    act(() => {
+      result.current.handleClick(RECORD);
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('r1', 'view');
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('does nothing at all for `none`, and nothing for `preventNavigation`', () => {
+    const onNavigate = vi.fn();
+    const none = renderHook(() =>
+      useNavigationOverlay({ navigation: { mode: 'none' }, objectName: 'contacts', onNavigate }),
+    );
+    const prevented = renderHook(() =>
+      useNavigationOverlay({
+        navigation: { mode: 'drawer', preventNavigation: true },
+        objectName: 'contacts',
+        onNavigate,
+      }),
+    );
+
+    act(() => {
+      none.result.current.handleClick(RECORD);
+      prevented.result.current.handleClick(RECORD);
+    });
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(none.result.current.isOpen).toBe(false);
+    expect(prevented.result.current.isOpen).toBe(false);
+  });
+
+  it('hands an external onRowClick full priority, whatever the mode says', () => {
+    const onRowClick = vi.fn();
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({
+        navigation: { mode: 'drawer' },
+        objectName: 'contacts',
+        onNavigate,
+        onRowClick,
+      }),
+    );
+
+    act(() => {
+      result.current.handleClick(RECORD);
+    });
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(result.current.isOpen).toBe(false);
+  });
+});
+
+describe('useNavigationOverlay: the modifier-key and new_window branches', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it.each([
+    ['metaKey', { metaKey: true }],
+    ['ctrlKey', { ctrlKey: true }],
+    ['middle click', { button: 1 }],
+  ])('%s opens a new window regardless of the configured mode', (_label, event) => {
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: { mode: 'drawer' }, objectName: 'contacts', onNavigate }),
+    );
+
+    act(() => {
+      result.current.handleClick(RECORD, event);
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('r1', 'new_window');
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('applies the same modifier override when `mode` is absent entirely', () => {
+    // The objectui#4550 shape: the modifier branch runs BEFORE the mode is
+    // consulted, so a defaulted mode must not change it.
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: AS_ALIAS, objectName: 'contacts', onNavigate }),
+    );
+
+    act(() => {
+      result.current.handleClick(RECORD, { metaKey: true });
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('r1', 'new_window');
+  });
+
+  it('delegates `new_window` to onNavigate when one is supplied', () => {
+    const onNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({
+        navigation: { mode: 'new_window' },
+        objectName: 'contacts',
+        onNavigate,
+      }),
+    );
+
+    act(() => {
+      result.current.handleClick(RECORD);
+    });
+
+    expect(onNavigate).toHaveBeenCalledWith('r1', 'new_window');
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('opens the routed record URL itself when no onNavigate is supplied', () => {
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: { mode: 'new_window' }, objectName: 'contacts' }),
+    );
+
+    act(() => {
+      result.current.handleClick(RECORD);
+    });
+
+    expect(openSpy).toHaveBeenCalledWith('/contacts/record/r1', '_blank');
+  });
+});
+
+describe('useNavigationOverlay: overlay width still resolves off the spec keys', () => {
+  it('maps a `size` bucket and lets an explicit `width` win, with `mode` omitted', () => {
+    // `size`/`width` are read off the same config whose `mode` is now optional;
+    // this pins that relaxing `mode` did not disturb the #2578 size path.
+    const bucketed = renderHook(() => useNavigationOverlay({ navigation: { size: 'lg' } }));
+    expect(bucketed.result.current.width).toBe('min(92vw, 960px)');
+
+    const explicit = renderHook(() =>
+      useNavigationOverlay({ navigation: { size: 'lg', width: '640px' } }),
+    );
+    expect(explicit.result.current.width).toBe('640px');
+
+    const auto = renderHook(() => useNavigationOverlay({ navigation: { size: 'auto' } }));
+    expect(auto.result.current.width).toBeUndefined();
+  });
+});

--- a/packages/react/src/hooks/useNavigationOverlay.ts
+++ b/packages/react/src/hooks/useNavigationOverlay.ts
@@ -23,7 +23,8 @@ import type { NavigationConfigSchema, NavigationMode as SpecNavigationMode } fro
 import type { SpecAuthoredInput } from '../spec-input';
 
 /**
- * The spec's `NavigationConfigSchema`, authoring side, with `mode` required.
+ * The spec's `NavigationConfigSchema`, authoring side — by reference, with no
+ * divergence of its own.
  *
  * This was a hand copy carrying the note "inline … to avoid importing from
  * @object-ui/types (which may not be a direct dependency of @object-ui/react)".
@@ -33,10 +34,35 @@ import type { SpecAuthoredInput } from '../spec-input';
  * `@object-ui/app-shell`, where the dependency had likewise been there all
  * along. Check `package.json` before believing such a note (objectstack#4115).
  *
- * The ONE divergence: the spec defaults `mode`, so its authoring side makes it
- * optional; this hook dispatches on `mode` and its callers always supply one,
- * so it is required here. Every other key is the spec's, by reference. Pinned
- * by `__tests__/offline-nav-performance-spec-parity.test.ts`.
+ * `mode` is OPTIONAL, because the spec says so and this hook agrees.
+ * `packages/spec/src/ui/view.zod.ts` declares
+ * `mode: NavigationModeSchema.default('page')`, and a `.default()` lands on the
+ * AUTHORING side as `| undefined` — so `navigation: { view: 'summary_view' }`
+ * is legal authored metadata that lets the mode default.
+ *
+ * Until objectui#4550 this alias `Omit`ted `mode` and re-added it as
+ * `NonNullable<…>`, on the stated reasoning that "this hook dispatches on
+ * `mode` and its callers always supply one". Both halves were false.
+ * `useNavigationOverlay` does not require `mode` — it DEFAULTS it
+ * (`navigation?.mode ?? 'page'`, ~140 lines below), and `'page'` is meaningful
+ * behaviour rather than a placeholder. And callers did not always supply one:
+ * `ListView` carried `schema.navigation as NavigationConfig | undefined` purely
+ * to get a spec-shaped value past this declaration — a value the hook had
+ * always been willing to take.
+ *
+ * The rule that makes this a producer-side fix rather than a caller-side one:
+ * a type in front of an implementation must not be stricter than the
+ * implementation. When it is, every caller pays in assertions, and an assertion
+ * is exactly the renderer-side workaround AGENTS.md #0.1 sends back to the
+ * producer. Here the producer was this line.
+ *
+ * `@object-ui/types` re-exports the spec's own `NavigationConfig` unchanged, so
+ * that published name and this one now agree — they did not before, which is
+ * how one monorepo shipped two `NavigationConfig`s that disagreed about whether
+ * `mode` could be omitted. Pinned by
+ * `__tests__/offline-nav-performance-spec-parity.test.ts` (the type) and
+ * `__tests__/useNavigationOverlay.modeDefault.test.tsx` (the default behaviour
+ * the relaxation rests on).
  *
  * Two per-key notes the hand copy carried, kept here because a derived alias
  * has no members to hang them on:
@@ -45,12 +71,7 @@ import type { SpecAuthoredInput } from '../spec-input';
  *  - `width` is DEPRECATED by #2578 in favour of `size`. It still wins when
  *    present, because app-shell pre-resolves `size` into it.
  */
-export type NavigationConfig = Omit<
-  SpecAuthoredInput<typeof NavigationConfigSchema>,
-  'mode'
-> & {
-  mode: NonNullable<SpecAuthoredInput<typeof NavigationConfigSchema>['mode']>;
-};
+export type NavigationConfig = SpecAuthoredInput<typeof NavigationConfigSchema>;
 
 /**
  * Pixel cap per overlay `size` bucket, clamped to the viewport at render —
@@ -89,7 +110,7 @@ export function resolveOverlayWidth(navigation: NavigationConfig | undefined): s
  * The overlay modes — the spec's own union, DERIVED since objectui#4167.
  *
  * rc.6 publishes `NavigationMode` (`z.input<typeof NavigationModeSchema>`), and
- * this alias resolved to exactly it already: `NavigationConfig['mode']` above is
+ * this alias resolved to exactly it already: `NavigationConfig['mode']` was then
  * `NonNullable<…['mode']>`, and stripping the `undefined` that the schema's
  * `.default()` puts on the authoring side leaves the seven-member enum itself.
  * So the spec reference was one hop away rather than absent — the alias just
@@ -98,8 +119,16 @@ export function resolveOverlayWidth(navigation: NavigationConfig | undefined): s
  *
  * Bound to the spec directly instead: the seven members now arrive from the
  * schema that validates them. `__tests__/offline-nav-performance-spec-parity.test.ts`
- * pins that this stays the same type as `NavigationConfig['mode']`, so the two
- * spellings cannot silently come apart if the spec ever stops defaulting `mode`.
+ * pins that this stays the same type as `NonNullable<NavigationConfig['mode']>`,
+ * so the two spellings cannot silently come apart if the spec ever stops
+ * defaulting `mode` or defaults it on a narrower union.
+ *
+ * The `NonNullable` in that pin is objectui#4550's mark and is load-bearing:
+ * `NavigationConfig` no longer strips the authoring-side `undefined`, so
+ * `NavigationConfig['mode']` is `NavigationMode | undefined` and a bare
+ * equality would now fail for a reason unrelated to the drift being guarded.
+ * What stays pinned is the MEMBERSHIP — the seven modes this hook switches on
+ * are exactly the seven the exported union publishes.
  */
 export type NavigationMode = SpecNavigationMode;
 


### PR DESCRIPTION
Fixes #4550

## The mismatch, measured

`@object-ui/react` published a `NavigationConfig` that required `mode`, in front of a `useNavigationOverlay` that has always defaulted it.

```ts
// packages/react/src/hooks/useNavigationOverlay.ts:48 (before)
export type NavigationConfig = Omit< SpecAuthoredInput< typeof NavigationConfigSchema >, 'mode' > & {
  mode: NonNullable< SpecAuthoredInput< typeof NavigationConfigSchema >['mode'] >;
};

// ...140 lines below, in the hook it fronts:
const mode: NavigationMode = navigation?.mode ?? 'page';
```

The type was strictly stricter than the implementation it fronts, and `'page'` is meaningful behaviour rather than a placeholder.

**The spec never asked for that.** `packages/spec/src/ui/view.zod.ts:1210`:

```ts
mode: NavigationModeSchema.default('page'),
```

A `.default()` lands on the **authoring** side as `| undefined`, so `navigation: { view: 'summary_view' }` is legal authored metadata that lets the mode default. The spec publishes exactly that as its own type (`view.zod.ts:3466`, `z.input< typeof NavigationConfigSchema >`).

**Corroboration:** `@object-ui/types` (`packages/types/src/index.ts:1087`) already re-exports the spec's `NavigationConfig` **unchanged**. So this monorepo shipped two published types of the same name that disagreed about whether `mode` could be omitted — and the react one was the odd one out.

## Writer / reader census (repo-wide)

**Writers** — 12 sites construct a value passed as `navigation`. Only **one** carried an assertion caused by this defect:

| Site | Expression | Disposition |
|---|---|---|
| `plugin-list/src/ListView.tsx:1738` | `schema.navigation as NavigationConfig \| undefined` | **assertion deleted** — this PR |
| `plugin-grid/src/ObjectGrid.tsx:1032`, `plugin-list/src/ObjectGallery.tsx:236` | `schema.navigation` | already compiled; unchanged |
| `app-shell` InterfaceListPage:240, ObjectDataPage:283, ObjectView:1525 | literal / `ViewNavigationConfig`, explicit `mode` | unchanged |
| map:561, tree:379, timeline:413, gantt:1150, calendar:398 | `(schema as any).navigation` | **untouched** — a different defect (the props type lacks `navigation` at all), not this alias |

**Readers** — sites that destructure `.mode`:

- `useNavigationOverlay` itself — `navigation?.mode ?? 'page'`, already handles `undefined`.
- `ObjectGrid.tsx:3301` — reads the hook's **result** (`NavigationOverlayState.mode`), always defined. Unaffected.
- calendar:396 / gantt:1148 / kanban:536 — `navConfig.mode === 'drawer' | ...` on `any`-typed values. Undefined-mode already yields `false` (non-overlay), which **agrees** with the hook's `'page'` default (also non-overlay).
- `plugin-view/src/ObjectView.tsx:542+` — a different alias (`ViewNavigationConfig` from `@object-ui/types`), guarded by `if (navigationConfig)`.

So ruling item 2's "fix any reader that inherits the default" is a **measured no-op**: no reader of this alias reads `.mode` unguarded. Reported as a measurement rather than manufactured into edits.

## Red-first

A spec-authored config without `mode`, assigned to the alias — verbatim `tsc` output before the change:

```
error TS2322: Type '{ mode?: "none" | "split" | "page" | ... | undefined; view?: string | undefined; ... }'
  is not assignable to type 'NavigationConfig'.
    Types of property 'mode' are incompatible.
      Type '"none" | "split" | "page" | ... | undefined' is not assignable to type 'NonNullable< ... >'.
        Type 'undefined' is not assignable to type 'NonNullable< ... >'.

error TS2322: Type '{}' is not assignable to type 'NavigationConfig'.
  Property 'mode' is missing in type '{}' but required in type '{ mode: NonNullable< ... >; }'.
```

9 errors total across the two test files. After the change: `tsc --noEmit && tsc -p tsconfig.test.json` both clean.

## What changed

```ts
export type NavigationConfig = SpecAuthoredInput< typeof NavigationConfigSchema >;
```

That, the doc comments, the `ListView` assertion removal, three inverted pins, and a new behaviour suite. **The hook body is untouched.**

Three pins in `offline-nav-performance-spec-parity.test.ts` encoded the defect and are inverted: `_ModeIsRequired` becomes `_ModeIsOptional`, `_StillNarrowed` becomes `_SpecShapedValueFits`, and a new `_IsExactlyTheSpecInput` pins the collapse. That file's own comment predicted this ("if the spec ever makes `mode` required itself ... this alias should collapse to `SpecAuthoredInput< typeof NavigationConfigSchema >`") — the collapse arrived from the other direction, since the spec never moved and the alias was wrong all along.

One pin needed care rather than inversion: `_ModeIsConfigMode` compared `NavigationMode` to `NavigationConfig['mode']`, which now carries `| undefined`. A bare equality would fail for a reason unrelated to the drift it guards, so it compares against `NonNullable< NavigationConfig['mode'] >` — the **membership** of the seven modes stays pinned, which is what that test is for.

## Reverse verification — direction stated up front

This is a **type-only** change, so the honest direction is a **tsc** red, not a suite red. Both were run:

- Fix removed (patch file + `git checkout --`, never `git stash`): `tsc -p tsconfig.test.json` → **9 errors** (exit 2). `vitest` on the new suite → **16/16 still green**, because the runtime is untouched. Reporting a vitest red here would have been a fabrication.
- Restore verified **byte-exact** by sha256 on all four touched files.
- To prove the new runtime pins are not vacuous, the default was then mutated (`?? 'page'` to `?? 'drawer'`): **4 of 16 failed**, with `expected 'drawer' to be 'page'` and `expected [] to deeply equal [ [ 'r1', 'view' ] ]`. The other 12 stayed green — correct, since they pin explicit modes that do not consult the default. Restored and sha256-verified again.

## Verification

- `pnpm --filter '@object-ui/react^...' --filter '@object-ui/react' build` — green (dependency closure first).
- `pnpm --filter @object-ui/react type-check` — green, **both** passes (`tsc --noEmit` and `tsc -p tsconfig.test.json`).
- `pnpm exec vitest run --maxWorkers=2 packages/react` — **43 files, 598 tests passed**; the new suite is 16 of them, confirmed running in the `dom` project.
- `pnpm exec vitest run --maxWorkers=2 packages/plugin-list packages/plugin-grid` — **103 files, 1144 tests passed**.
- **Consumer sweep**, prefix direction (`...@object-ui/react` = **downstream consumers**, after a full 43-task build so no stale artifacts): **31 packages green**, including `apps/console`, `app-shell`, all nine hook-consuming plugins and three examples.
- ESLint vs the merge-base `3f5f87cc7` in a comparison worktree: **NET ZERO** — react 350/350, plugin-list 417/417, 0 errors both sides.
- `check:control-bytes`, `check:phantom-deps`, `changeset:check`, `check:spec-symbols`, `check-changeset-presence` — all green. `grep -naP` control-byte self-scan over all four touched files: clean.

## Changeset grade: `minor` for `@object-ui/react`

Optional-izing is looser for writers and narrower for readers, so the grade turns on which role the published surface plays. Measured from the `.d.ts`: `NavigationConfig` occurs **only in input positions** — `useNavigationOverlay`'s `navigation?:` option and `resolveOverlayWidth`'s parameter — and **never in a return type**. The package consumes these values and never hands one back, so for consumers the change is purely permissive: everything that compiled still compiles, and spec-shaped configs that needed an assertion now compile without one. That gained input shape is a capability rather than an internal repair, which is more than `patch` describes. The reader-side narrowing is real but secondary, and the in-repo census found exactly one type-importer — `ListView` — which imported it only to write the assertion this PR deletes.

The only type-level line in the whole `.d.ts` diff is the alias; everything else is doc comment.

## Surface

`packages/react` (hook + 2 test files), `packages/plugin-list/src/ListView.tsx` (the censused caller), one changeset. Untouched as instructed: `SchemaRenderer.tsx` / `schema-input.ts` (landed #4578), `apps/console` (#4563), `types` + `ObjectGrid` exportOptions (#4535), `SettingsView` (#4570), plugin-report / previews (#4575), `content/docs/releases/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_