### PR TITLE
fix(types): ViewNavigationConfig.mode is optional — the second navigation spelling agrees with the spec (#4588)

### DIFF
--- a/.changeset/view-navigation-config-mode-optional-4588.md
+++ b/.changeset/view-navigation-config-mode-optional-4588.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/types': minor
+---
+
+`ViewNavigationConfig` IS the spec's navigation config — the second spelling stops requiring `mode` (objectui#4588)
+
+`@object-ui/types` published **two** types for one spec object, and they disagreed
+about whether `mode` may be omitted. `index.ts` re-exports the spec's
+`NavigationConfig` unchanged, while `objectql.ts` hand-declared a
+`ViewNavigationConfig` covering the same six keys with `mode` **required** — under
+a doc comment that itself claimed `@default 'page'`.
+
+The spec never asked for that. `@objectstack/spec` declares
+`mode: NavigationModeSchema.default('page')` in `NavigationConfigSchema`, and a
+`.default()` lands on the **authoring** side as `| undefined`, which is why the
+spec publishes its own type as the schema's `z.input`. So
+`navigation: { view: 'summary_view' }` is legal authored metadata that lets the
+mode default — and the hand copy refused it, at the three schema interfaces that
+spell `navigation?: ViewNavigationConfig` (`ObjectGridSchema`, `ObjectViewSchema`,
+`NamedListView`). Authoring one meant inventing a `mode` the renderer was going to
+default anyway, or writing an assertion.
+
+`ViewNavigationConfig` is now that spec type, per this file's own standing rule —
+"Never Redefine Types. ALWAYS import them." Measured against the published spec
+build, the hand copy had drifted on `mode` and nothing else: the other five keys
+carried the spec's exact value domains. The per-key documentation now lives with
+the schema in the spec instead of being restated here, so the `'page'` default no
+longer has a third place to fall out of sync.
+
+**No runtime behaviour changes.** A census of every `.mode` read in the repo found
+all of them to be `=== 'x'` comparisons or `navigation?.mode ?? 'page'` — no reader
+of this alias reads `mode` unguarded, so nothing observes the difference at run
+time. This is objectui#4550 / PR objectui#4586 one package over: that one collapsed
+`@object-ui/react`'s `NavigationConfig` to the same spec input, and this is the
+remaining half.
+
+Graded `minor` on the published-position analysis: in the built `.d.ts`
+`ViewNavigationConfig` occurs **only in input positions** — the three `navigation?:`
+properties of authored schema interfaces — and in **no** return type, since this
+package publishes no function that hands one back. For consumers the change is
+therefore purely permissive: everything that compiled still compiles, and
+spec-shaped configs that previously needed an invented `mode` now compile without
+one. That gained input shape is a capability rather than an internal repair, which
+is more than `patch` describes. The reader-side narrowing (`mode` is now
+`| undefined`) is real but secondary, and in-repo it has no affected reader.

--- a/packages/types/src/__tests__/view-navigation-config-spec-parity.test.ts
+++ b/packages/types/src/__tests__/view-navigation-config-spec-parity.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `ViewNavigationConfig` IS the spec's navigation config (objectui#4588).
+ *
+ * The card behind this file: `@object-ui/types` published **two** types for one
+ * spec object, and they disagreed about whether `mode` may be omitted.
+ * `index.ts` re-exports the spec's `NavigationConfig` unchanged, while
+ * `objectql.ts` hand-declared a `ViewNavigationConfig` covering the same six
+ * keys with `mode` REQUIRED — under a doc comment that itself claimed
+ * `@default 'page'`. The spec never asked for that: `packages/spec/src/ui/
+ * view.zod.ts:1210` declares `mode: NavigationModeSchema.default('page')`, and
+ * a `.default()` lands on the AUTHORING side as `| undefined`, which is why the
+ * spec publishes its own type as `z.input< typeof NavigationConfigSchema >`
+ * (view.zod.ts:3466). So `{ view: 'summary_view' }` is legal authored metadata
+ * that lets the mode default — and it did not type-check against the three
+ * schema interfaces that spell `navigation?: ViewNavigationConfig`.
+ *
+ * This is objectui#4550 / PR objectui#4586 one package over: that one collapsed
+ * `@object-ui/react`'s `NavigationConfig` to the spec's authored input. This
+ * file pins the same collapse here, so the two published spellings can no
+ * longer drift apart again.
+ *
+ * The assertions are mostly type-level on purpose. They run in
+ * `tsc -p tsconfig.test.json` (part of this package's `type-check`), so
+ * re-growing a hand copy fails the build rather than waiting for a reviewer to
+ * notice — which is the failure mode this card was reported for.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  NamedListView,
+  NavigationConfig,
+  ObjectGridSchema,
+  ObjectViewSchema,
+  ViewNavigationConfig,
+} from '../index';
+
+/* ── Type-level helpers ──────────────────────────────────────────────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/* ── The collapse itself ─────────────────────────────────────────────────── */
+
+/**
+ * The whole point of the card: the two names this package publishes for the
+ * spec's navigation config are ONE type. `NavigationConfig` is the spec
+ * re-export at `index.ts`; `ViewNavigationConfig` is the name `objectql.ts`
+ * publishes. If a future edit re-grows a hand copy — even one that starts out
+ * byte-identical — this line goes red on the day it drifts.
+ */
+type _IsExactlyTheSpecInput = Expect< Equal< ViewNavigationConfig, NavigationConfig > >;
+
+/**
+ * The six keys the spec declares (`view.zod.ts` `NavigationConfigSchema`).
+ * Adding a key here to make a new local read compile is the defect, not the
+ * fix: the key has to exist in the spec first, or the platform refuses metadata
+ * that declares it.
+ */
+type SpecDeclaredKeys = 'mode' | 'view' | 'preventNavigation' | 'openNewTab' | 'size' | 'width';
+
+type _KeysAreExactlyTheSpecSix = Expect< Equal< keyof ViewNavigationConfig, SpecDeclaredKeys > >;
+
+/* ── `mode` is optional, because the spec defaults it ────────────────────── */
+
+/**
+ * The defect this card names. `undefined` is assignable to `mode` because
+ * `.default('page')` makes it optional on the authoring side.
+ */
+type _ModeIsOptional = Expect<
+  Equal< undefined extends ViewNavigationConfig['mode'] ? true : false, true >
+>;
+
+/**
+ * Membership of the seven modes, pinned through `NonNullable`.
+ *
+ * A BARE `Equal< ViewNavigationConfig['mode'], …the seven… >` would now be
+ * `false` — but for the wrong reason: the `| undefined` that the `.default()`
+ * puts there on purpose, not a drift in which modes exist. `NonNullable` keeps
+ * this assertion pointed at the thing it guards. (Same care PR objectui#4586
+ * took with `_ModeIsConfigMode` one package over.)
+ */
+type _ModeMembershipIsTheSevenSpecModes = Expect<
+  Equal<
+    NonNullable< ViewNavigationConfig['mode'] >,
+    'page' | 'drawer' | 'modal' | 'split' | 'popover' | 'new_window' | 'none'
+  >
+>;
+
+/* ── The three schema sites use the shared type ──────────────────────────── */
+
+/**
+ * `objectql.ts` spells `navigation?: ViewNavigationConfig` in three interfaces.
+ * Each must be the spec type itself, so one authoring surface cannot outgrow
+ * another — the same guard `objectql.exportOptions.test.ts` puts on
+ * `exportOptions`.
+ */
+type _GridUsesTheSharedType = Expect<
+  Equal< NonNullable< ObjectGridSchema['navigation'] >, ViewNavigationConfig >
+>;
+type _ObjectViewUsesTheSharedType = Expect<
+  Equal< NonNullable< ObjectViewSchema['navigation'] >, ViewNavigationConfig >
+>;
+type _NamedViewUsesTheSharedType = Expect<
+  Equal< NonNullable< NamedListView['navigation'] >, ViewNavigationConfig >
+>;
+
+/* ── Runtime half ────────────────────────────────────────────────────────── */
+
+describe('ViewNavigationConfig is the spec navigation config (objectui#4588)', () => {
+  it('accepts the spec-valid config that omits `mode`', () => {
+    // The exact value from the card. Before the collapse this line was
+    // `TS2741: Property 'mode' is missing`.
+    const navigation: ViewNavigationConfig = { view: 'summary_view' };
+
+    // Runtime half: the type-level assertions above are erased, so without a
+    // value that actually omits `mode`, the requirement could come back and
+    // this file would still compile.
+    expect(Object.keys(navigation)).toEqual(['view']);
+    expect(navigation.mode).toBeUndefined();
+  });
+
+  it('accepts a mode-less config at each of the three schema sites', () => {
+    const grid: Pick< ObjectGridSchema, 'navigation' > = { navigation: { view: 'summary_view' } };
+    const view: Pick< ObjectViewSchema, 'navigation' > = { navigation: { view: 'summary_view' } };
+    const named: Pick< NamedListView, 'navigation' > = { navigation: { view: 'summary_view' } };
+
+    for (const site of [grid, view, named]) {
+      expect(site.navigation?.mode).toBeUndefined();
+      expect(site.navigation?.view).toBe('summary_view');
+    }
+  });
+
+  it('still accepts every spec key, so the collapse did not narrow the surface', () => {
+    const full: ViewNavigationConfig = {
+      mode: 'drawer',
+      view: 'summary_view',
+      preventNavigation: false,
+      openNewTab: false,
+      size: 'lg',
+      width: '600px',
+    };
+    expect(Object.keys(full).sort()).toEqual(
+      ['mode', 'openNewTab', 'preventNavigation', 'size', 'view', 'width'],
+    );
+  });
+
+  it('refuses a mode outside the spec enum', () => {
+    const bad: ViewNavigationConfig = {
+      // @ts-expect-error 'sidebar' is not one of the seven spec navigation modes
+      mode: 'sidebar',
+    };
+    expect(bad).toBeDefined();
+  });
+
+  it('refuses a key the spec does not declare', () => {
+    const bad: ViewNavigationConfig = {
+      mode: 'page',
+      // @ts-expect-error `placement` is not a declared navigation key
+      placement: 'right',
+    };
+    expect(bad).toBeDefined();
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -95,6 +95,7 @@ import type {
   RowColorConfig,
   GalleryConfig,
   TimelineConfig,
+  NavigationConfig,
   GanttConfig as SpecGanttConfig,
 } from '@objectstack/spec/ui';
 
@@ -1769,42 +1770,30 @@ export interface NamedListView {
 }
 
 /**
- * Navigation configuration for row/item click behavior.
- * Aligned with @objectstack/spec ListView.navigation.
+ * Navigation configuration for row/item click behavior — the spec's
+ * `NavigationConfig`, under this package's older local name.
+ *
+ * This used to be a hand-written interface mirroring the spec's six keys, and
+ * it had drifted on exactly one of them: it required `mode`, under a doc
+ * comment that itself said `@default 'page'` (objectui#4588). The spec declares
+ * `mode: NavigationModeSchema.default('page')`
+ * (`@objectstack/spec` `ui/view.zod.ts` `NavigationConfigSchema`), and a
+ * `.default()` lands on the AUTHORING side as `| undefined` — which is why the
+ * spec publishes its own type as `z.input< typeof NavigationConfigSchema >`.
+ * So `navigation: { view: 'summary_view' }` is legal authored metadata that
+ * lets the mode default, and the hand copy refused it.
+ *
+ * `index.ts` already re-exports that same spec type under its own name
+ * (`NavigationConfig`), so this package published two disagreeing spellings of
+ * one spec object. They are one type now. Per this file's rule above —
+ * "Never Redefine Types. ALWAYS import them." — the per-key documentation lives
+ * with the schema in the spec rather than being restated here, so there is no
+ * third place to keep the `'page'` default in sync.
+ *
+ * objectui#4550 / PR objectui#4586 made the same collapse for
+ * `@object-ui/react`'s `NavigationConfig`.
  */
-export interface ViewNavigationConfig {
-  /**
-   * How to open the target view on interaction
-   * - page: Full page navigation
-   * - drawer: Slide-out panel
-   * - modal: Dialog overlay
-   * - split: Side-by-side panel
-   * - popover: Hover/click preview card
-   * - new_window: Open in new browser tab
-   * - none: No navigation on click
-   * @default 'page'
-   */
-  mode: 'page' | 'drawer' | 'modal' | 'split' | 'popover' | 'new_window' | 'none';
-  
-  /** Target view/form config name */
-  view?: string;
-  
-  /** Prevent default navigation behavior */
-  preventNavigation?: boolean;
-  
-  /** Open in new tab (for page/new_window modes) */
-  openNewTab?: boolean;
-  
-  /**
-   * [#2578] Overlay size bucket for drawer/modal detail. `'auto'` (default):
-   * the renderer derives it from field count and clamps to the viewport.
-   * Prefer this over the pixel `width`.
-   */
-  size?: 'auto' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
-
-  /** @deprecated [#2578 → `size`] Pixel/percent width — can't be authored blind. Renderer fallback only. */
-  width?: string | number;
-}
+export type ViewNavigationConfig = NavigationConfig;
 
 /**
  * ListView component node — DERIVED from the zod `ListViewSchema` (issue #2231), which


### PR DESCRIPTION
Fixes #4588

## The mismatch, measured

`@object-ui/types` published **two** types for one spec object, and they disagreed about whether `mode` may be omitted.

```ts
// packages/types/src/index.ts — the spec's own type, re-exported unchanged
export type { …, NavigationConfig, … } from '@objectstack/spec/ui';

// packages/types/src/objectql.ts:1775 (before) — the same six keys, by hand
export interface ViewNavigationConfig {
  /** … @default 'page' */
  mode: 'page' | 'drawer' | 'modal' | 'split' | 'popover' | 'new_window' | 'none';
  view?: string;
  preventNavigation?: boolean;
  openNewTab?: boolean;
  size?: 'auto' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
  width?: string | number;
}
```

The doc comment claimed `@default 'page'` on the one key it then made required.

**The spec never asked for that.** `NavigationConfigSchema` declares `mode: NavigationModeSchema.default('page')`, and a `.default()` lands on the **authoring** side as `| undefined` — so the spec publishes its own type as `z.input< typeof NavigationConfigSchema >`. `navigation: { view: 'summary_view' }` is legal authored metadata that lets the mode default.

Measured against the **published** spec build actually resolved here (`@objectstack/spec@17.0.0-rc.6`, `dist/view.zod-CN_gQt7k.d.ts:826`), the hand copy had drifted on `mode` and **nothing else** — the other five keys carried the spec's exact value domains:

| key | spec (published `.d.ts`) | hand copy | agrees? |
|---|---|---|---|
| `mode` | `ZodDefault< ZodEnum >` → input-optional | **required** | **no** |
| `view` | `ZodOptional< ZodString >` | `view?: string` | yes |
| `preventNavigation` | `ZodDefault< ZodBoolean >` | `preventNavigation?: boolean` | yes |
| `openNewTab` | `ZodDefault< ZodBoolean >` | `openNewTab?: boolean` | yes |
| `size` | `ZodDefault< ZodEnum >`, 6 members | same 6 | yes |
| `width` | `ZodOptional< ZodUnion >` | `string \| number` | yes |

## Alias shape: collapse, not restate — the convention, measured

The ruling preferred collapsing to the spec type if the file's conventions allow it. They do, emphatically:

- `objectql.ts:28-30` carries the rule as a banner: **"Spec-Canonical Types — imported from `@objectstack/spec/ui`. Rule: 'Never Redefine Types. ALWAYS import them.'"**
- Nine spec re-exports already live in this file (`:51 :57 :68 :74 :80 :86 :134 :143`, plus the multi-import at `:89-99`), and `:51` is even a **renaming** one.
- No cycle is possible: `@object-ui/types` has **zero** workspace dependencies (`--filter '@object-ui/types^...' build` matched 0 projects); `@objectstack/spec` is an external dependency the file already imports, and `index.ts` already re-exports this very symbol from the same entry point.

One correction along the way, worth recording: `export type { NavigationConfig as ViewNavigationConfig } from '@objectstack/spec/ui'` re-exports but creates **no local binding**, so the three in-file uses failed with `TS2304: Cannot find name 'ViewNavigationConfig'`. The file already has the right idiom for that case — the `import type { … } from '@objectstack/spec/ui'` block at `:89` labelled *"Import spec types for local use in interfaces below"*. So:

```ts
import type { …, NavigationConfig, … } from '@objectstack/spec/ui';

export type ViewNavigationConfig = NavigationConfig;
```

That is a structural derivation, which is one of the two forms `check:spec-symbols` sanctions.

## Writer / reader census

**The three `navigation?: ViewNavigationConfig` sites** (`objectql.ts` `:852` `ObjectGridSchema`, `:1453` `ObjectViewSchema`, `:1674` `NamedListView`) now accept a mode-less config. Each is pinned in the new suite.

**Readers** — every `.mode` read in the repo, and its disposition:

| Site | Expression | Disposition |
|---|---|---|
| `plugin-view/ObjectView.tsx:542-570` | `navigationConfig.mode === 'x'`, behind `if (navigationConfig)` | **byte-unchanged** (re-verified) |
| `plugin-view/ObjectView.tsx:1174-1177` | `navigationConfig?.mode === 'x'` | unchanged |
| `app-shell/views/ObjectView.tsx:1421` | `authored.mode === 'page'` | unchanged |
| `react/useNavigationOverlay.ts:224` | `navigation?.mode ?? 'page'` | unchanged — already handles `undefined` |
| kanban `:536` / calendar `:396` / gantt `:1148` | `navConfig.mode === 'x'` on `any`-typed values | untouched; undefined-mode yields `false` (non-overlay), agreeing with the `'page'` default |
| `plugin-grid/ObjectGrid.tsx:3309` | reads the **hook result**, always defined | unaffected |

So "fix any reader that inherits the default" is again a **measured no-op** — no reader of this alias reads `mode` unguarded. Reported as measurement, not manufactured into edits.

**Obsoleted assertions: none, measured.** No test in `packages/types` referenced `ViewNavigationConfig` at all before this PR (`grep` over `src/__tests__`), and `navigation-spec-parity.test.ts` guards `NavigationItemSchema` — app navigation, a different object. No assertion existed for this change to obsolete, so none was invented.

**A convergence worth naming:** `app-shell/views/ObjectView.tsx:1414` declares `detailNavigation: ViewNavigationConfig` and feeds it straight to `useNavigationOverlay({ navigation: detailNavigation })` — whose option type #4586 already made mode-optional. The two halves now agree instead of colliding.

## Red-first

Predictions were written before the edit; all four materialised. Verbatim `tsc -p tsconfig.test.json` against the **unchanged** alias:

```
src/__tests__/view-navigation-config-spec-parity.test.ts(55,39): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/__tests__/view-navigation-config-spec-parity.test.ts(74,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/__tests__/view-navigation-config-spec-parity.test.ts(117,11): error TS2741: Property 'mode' is missing in type '{ view: string; }' but required in type 'ViewNavigationConfig'.
src/__tests__/view-navigation-config-spec-parity.test.ts(127,60): error TS2741: Property 'mode' is missing in type '{ view: string; }' but required in type 'ViewNavigationConfig'.
src/__tests__/view-navigation-config-spec-parity.test.ts(128,60): error TS2741: Property 'mode' is missing in type '{ view: string; }' but required in type 'ViewNavigationConfig'.
src/__tests__/view-navigation-config-spec-parity.test.ts(129,58): error TS2741: Property 'mode' is missing in type '{ view: string; }' but required in type 'ViewNavigationConfig'.
```

6 errors, exit 2 — line 117 is the card's own `{ view: 'summary_view' }`. After the change all three `tsc` passes are clean.

Two pins did **not** go red pre-change, and that is the finding rather than a gap: `_KeysAreExactlyTheSpecSix` and `_ModeMembershipIsTheSevenSpecModes` already held. The hand copy had the right six keys and the right seven modes — `mode`'s optionality was its *only* drift. Both pins stay, because they are what catches the next drift.

## Type-level pins, per the #4586 idiom

`_ModeMembershipIsTheSevenSpecModes` compares against `NonNullable< ViewNavigationConfig['mode'] >`. A bare `Equal` would now be `false` for the **wrong reason** — the `| undefined` the `.default()` puts there deliberately, not a change in which modes exist — so `NonNullable` keeps the assertion pointed at the membership it guards. Same care `_ModeIsConfigMode` needed one package over.

`_IsExactlyTheSpecInput` pins the collapse itself: the two names this package publishes for the spec's navigation config are now invariantly one type, so a re-grown hand copy fails the build on the day it drifts.

## Reverse verification — direction stated up front

A type-only change, so the honest red is a **tsc** red, not a suite red. Both were run:

- Fix removed (`git diff > fix.patch` + `git checkout --`, never `git stash`): `tsc -p tsconfig.test.json` → the **same 6 errors**, exit 2.
- `vitest` over `packages/types packages/plugin-view` with the fix removed → **522/522 still green**, because the runtime is untouched. Reporting a vitest red here would have been a fabrication.
- Restore verified **byte-exact** by `sha256sum -c` on both files.
- Non-vacuity of the refusal pins: widening the alias to `Record< string, unknown >` produced `TS2578: Unused '@ts-expect-error' directive.` at both refusal sites, plus reds on the collapse, key-set and membership pins. Restored and sha256-verified again.

## Verification

- `pnpm --filter '@object-ui/types^...' build` — **0 projects**: this package has no workspace dependencies (measured, not assumed).
- `pnpm --filter @object-ui/types type-check` — green, **all three** passes (`tsc --noEmit`, `tsconfig.examples.json`, `tsconfig.test.json`).
- `pnpm exec vitest run --maxWorkers=2 packages/types packages/plugin-view` — **43 files, 522 tests passed** (32 types + 11 plugin-view). The new suite is 5 of them, confirmed running in the `unit` project rather than assumed.
- **Consumer sweep**, prefix direction (`...@object-ui/types` = **downstream consumers**), after a full 47-project workspace build so no stale artifacts: **40 packages green**, including `app-shell`, `plugin-view`, `plugin-list`, `plugin-grid`, `react`, `apps/console` and three examples. The first attempt failed `TS2307` on `@object-ui/collaboration` → `@object-ui/i18n`, which sits *outside* the filter's scope (42 of 47) — the known stale-artifact trap, fixed by the full build, not by touching anything.
- ESLint vs `origin/main` in a comparison worktree, on the edited source file: **15 → 15, NET ZERO, 0 errors both sides.** The new test file adds 7 `no-unused-vars` warnings for its type-level pins — exactly the class the sibling pin file `objectql.exportOptions.test.ts` already emits (4 of them), which carries no `eslint-disable`, so this follows the established convention.
- `check:control-bytes`, `check:phantom-deps`, `changeset:check`, `check:spec-symbols` — all green. `grep -naP` control-byte self-scan over both touched files: clean.

## Changeset grade: `minor` for `@object-ui/types`

Measured from the built `.d.ts` (clean `dist/` + `tsconfig.tsbuildinfo` between both builds). `ViewNavigationConfig` occurs in **only three** consumer-facing positions — the `navigation?:` properties of `ObjectGridSchema`, `ObjectViewSchema` and `NamedListView` — and in **no** return position: a regex for `): ViewNavigationConfig` / `=> ViewNavigationConfig` over the whole `dist` matched nothing, and this is a pure type package that publishes no function to hand one back. Every published position is an **input** position.

So for consumers the change is purely permissive: everything that compiled still compiles, and spec-shaped configs that previously needed an invented `mode` now compile without one. That gained input shape is a capability rather than an internal repair, which is more than `patch` describes. The reader-side narrowing is real but secondary, and the in-repo census found no reader affected by it. Never `major`.

The `.d.ts` diff is **two hunks**: the import line, and the interface replaced by the alias. `index.d.ts` is byte-identical. The only type-level lines in the whole diff are those two.

## Surface

`packages/types/src/objectql.ts`, one new test file in `packages/types`, one changeset. `plugin-view` was **read-only and is byte-unchanged** — the census did not demand an edit there. Untouched as instructed: `packages/react` (#4585), `core`/`i18n` (#4576), `ObjectGrid`, `content/docs/releases/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_