### PR TITLE
fix(types): BaseSchema.visible accepts the predicate string the renderer evaluates (#4581)

### DIFF
--- a/.changeset/base-schema-visible-predicate.md
+++ b/.changeset/base-schema-visible-predicate.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/types': minor
+---
+
+`BaseSchema.visible` accepts the predicate string the renderer evaluates
+
+`visible` was declared `boolean`, but the renderer never read it as one: it
+evaluates the key — `SchemaRenderer.tsx:382` calls
+`evaluator.evaluateCondition(schema.visible)`, and `evaluateCondition` is
+declared `(condition: string | boolean | undefined, context?) => boolean`. The
+sibling keys `visibleWhen` and the deprecated `visibleOn` are `string` for that
+same reason; `visible` simply under-reported a capability it already had, and
+fixtures exercising it had to cast past the declaration.
+
+Now `boolean | string` — exactly what the evaluator accepts, no wider.
+
+Graded **minor** by position analysis of the published `.d.ts`: the only diff is
+`visible?: boolean` becoming `visible?: boolean | string` on an
+authored-input-dominant property, with no union member removed and no other
+declaration touched — the same shape as #4586/#4591. Authors gain a spelling;
+nothing that previously type-checked stops doing so. Code that READS
+`schema.visible` was already coping with `any` through `BaseSchema`'s index
+signature.

--- a/packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx
@@ -11,11 +11,15 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer } from '../SchemaRenderer';
-// `@object-ui/types` declares `BaseSchema.visible` / `.disabled` as `boolean`,
-// but BOTH accept a predicate STRING here — that is the capability these cases
-// exercise, and the renderer evaluates it (`evaluateCondition`). The declaration
-// is the narrow one; until it is widened these fixtures state their real shape
-// through `BaseSchema`'s index signature (objectui#4548 measured the gap).
+// `BaseSchema.visible` now declares `boolean | string` (objectui#4581), so the
+// two visibility cases below state their predicate strings directly — no cast.
+//
+// `.disabled` is the SAME gap and is NOT yet widened: the renderer evaluates it
+// through the same `evaluateCondition` (`SchemaRenderer.tsx:466`) and the
+// `disabledOn?: string` sibling exists for the same reason, but #4581 named only
+// `visible` and `ariaLabel`, so widening `disabled` was left to its own card
+// rather than taken unruled. The two `disabled` casts below are what remains of
+// the gap — drop them when that lands.
 import type { BaseSchema } from '@object-ui/types';
 import { SchemaRendererContext } from '../context/SchemaRendererContext';
 
@@ -49,7 +53,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('evaluates visible expression string', () => {
       render(
         <SchemaRendererContext.Provider value={{ dataSource: { role: 'admin' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' } as unknown as BaseSchema} />
+          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' }} />
         </SchemaRendererContext.Provider>
       );
       expect(screen.getByTestId('test-component')).toBeInTheDocument();
@@ -58,7 +62,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('hides when visible expression evaluates to false', () => {
       const { container } = render(
         <SchemaRendererContext.Provider value={{ dataSource: { role: 'viewer' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' } as unknown as BaseSchema} />
+          <SchemaRenderer schema={{ type: 'test-component', visible: '${data.role === "admin"}' }} />
         </SchemaRendererContext.Provider>
       );
       expect(container.innerHTML).toBe('');

--- a/packages/types/src/__tests__/base-schema-visible-predicate.test.ts
+++ b/packages/types/src/__tests__/base-schema-visible-predicate.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `BaseSchema.visible` admits the predicate string the renderer evaluates
+ * (objectui#4581).
+ *
+ * `BaseSchema` declared `visible?: boolean`. The renderer does not treat it as
+ * a boolean — `packages/react/src/SchemaRenderer.tsx:382` reads:
+ *
+ *   ```ts
+ *   if (newSchema.visible !== undefined) {
+ *     return !evaluator.evaluateCondition(newSchema.visible);
+ *   }
+ *   ```
+ *
+ * and `evaluateCondition` is declared
+ * `(condition: string | boolean | undefined, context?) => boolean`
+ * (`packages/core/dist/evaluator/ExpressionEvaluator.d.ts:143`). So a predicate
+ * STRING is a supported, evaluated input — the sibling keys `visibleWhen` and
+ * the deprecated `visibleOn` are both `string` for the same reason — and the
+ * declared type simply under-reported it. Two fixtures in
+ * `packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx` exercised
+ * exactly that capability through `as unknown as BaseSchema`; PR #4578 is what
+ * made the gap visible, by typing `schema` honestly for the first time.
+ *
+ * The widening is `boolean | string` — what `evaluateCondition` accepts, no
+ * wider. It is authored-input dominant: authors write `visible`, and code that
+ * READS `schema.visible` already had to cope with `any` through
+ * `BaseSchema`'s index signature.
+ *
+ * ## Predictions, written before the first run (red-first)
+ *
+ * Against `origin/main` (`92250d648`), `tsc -p packages/types/tsconfig.test.json`
+ * must report:
+ *
+ *   1. `predicateStringIsAuthorable` — TS2322, `Type 'string' is not
+ *      assignable to type 'boolean | undefined'`.
+ *   2. `assertionVisible` — `Equal< BaseSchema['visible'], boolean | string |
+ *      undefined >` resolves `false`, failing `Expect`'s constraint (TS2344).
+ *
+ * After the fix both compile clean.
+ *
+ * `assertionVisible` is INVARIANT on purpose. A `satisfies`-style check, or a
+ * one-way `extends`, would be vacuous here in both directions: the narrow
+ * `boolean` is assignable to the wide `boolean | string`, so a widening that
+ * never happened and a widening that overshot to `any` would both stay green.
+ * Pinning the exact union is the only assertion that can go red for the right
+ * reason — and `BaseSchema`'s `[key: string]: any` index signature makes the
+ * overshoot a live risk rather than a hypothetical one, since deleting the
+ * declared property altogether would leave `visible` typed `any` and every
+ * fixture below still compiling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { BaseSchema } from '../base';
+
+/* ── Type-level helpers ──────────────────────────────────────────────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/* ── The declared type is exactly what the evaluator accepts ─────────────── */
+
+export type assertionVisible = Expect<
+  Equal< BaseSchema['visible'], boolean | string | undefined >
+>;
+
+/* ── Authorable fixtures ─────────────────────────────────────────────────── */
+
+/** The capability the renderer implements, now declared. */
+export const predicateStringIsAuthorable: BaseSchema = {
+  type: 'test-component',
+  visible: 'record.status == "open"',
+};
+
+/** The template-expression spelling the shipped fixtures use. */
+export const templateExpressionIsAuthorable: BaseSchema = {
+  type: 'test-component',
+  visible: '${data.role === "admin"}',
+};
+
+/** The boolean form is untouched — this is a widening, not a replacement. */
+export const booleanIsStillAuthorable: BaseSchema = {
+  type: 'test-component',
+  visible: false,
+};
+
+/* ── Runtime companion ───────────────────────────────────────────────────── */
+
+describe('BaseSchema.visible (objectui#4581)', () => {
+  it('type-level: visible is boolean | string, pinned invariantly', () => {
+    // Erased at runtime; `tsc -p tsconfig.test.json` is the checker, chained
+    // from this package's `type-check` script. The runtime case exists so a
+    // green vitest run is not mistaken for the proof.
+    expect(predicateStringIsAuthorable.visible).toBe('record.status == "open"');
+    expect(booleanIsStillAuthorable.visible).toBe(false);
+  });
+});

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -102,9 +102,21 @@ export interface BaseSchema {
   /**
    * Controls whether the component is visible.
    * When false, component is not rendered (display: none).
+   *
+   * Accepts a PREDICATE STRING as well as a boolean (objectui#4581): the
+   * renderer does not read this key as a boolean, it evaluates it —
+   * `SchemaRenderer.tsx:382` calls `evaluator.evaluateCondition(schema.visible)`,
+   * and `evaluateCondition` is declared
+   * `(condition: string | boolean | undefined, context?) => boolean`. The
+   * sibling keys `visibleWhen` and the deprecated `visibleOn` are `string` for
+   * the same reason; this one simply under-reported the capability, and
+   * fixtures exercising it had to cast past the declaration.
+   *
    * @default true
+   * @example true
+   * @example "${data.role === 'admin'}"
    */
-  visible?: boolean;
+  visible?: boolean | string;
 
   /**
    * Canonical conditional-visibility predicate (ADR-0089) — the element is shown


### PR DESCRIPTION
Part of #4581.

⚠️ **This PR is deliberately smaller than the card it was dispatched for.** The seat was dispatched to reconcile `SchemaNode` (#4580) and to ride #4581 along with it. Measurement blocked both of those on one unruled contract question, so this PR ships only the half that measured clean, and the rest is escalated rather than guessed. #4580 is **not** touched here and stays open; #4581 is **half** done, hence `Part of`, not `Fixes`.

## What landed

`BaseSchema.visible` is declared `boolean | string`.

It was `boolean`, but the renderer never read it as a boolean — it *evaluates* the key. Both call sites the ruling asked me to verify, cited:

- **`visible`** — `packages/react/src/SchemaRenderer.tsx:382`:
  ```ts
  if (newSchema.visible !== undefined) {
    return !evaluator.evaluateCondition(newSchema.visible);
  }
  ```
  and `evaluateCondition` is declared `(condition: string | boolean | undefined, context?) => boolean` (`packages/core/dist/evaluator/ExpressionEvaluator.d.ts:143`). The sibling keys `visibleWhen` and the deprecated `visibleOn` are `string` for exactly this reason. The widening is `boolean | string` — what the evaluator accepts, no wider.

- **`ariaLabel`** — `packages/react/src/SchemaRenderer.tsx:111` calls `resolveKeyedI18nLabel(schema.ariaLabel)`. **This call site is what disproved the ruling's spelling for the ariaLabel half.** See "Why ariaLabel did not land" below.

Two `as unknown as BaseSchema` casts in `SchemaRenderer.expressions.test.tsx` existed only for this gap and are dropped.

## The census — the recorded "five" is not what is on disk

The ruling said five casts, "each carrying a comment naming this gap". Grepping `as BaseSchema` / `as unknown as BaseSchema` across `packages` and `apps` finds **six**, in three different classes, and only **one** carries such a comment:

| Site | Value | Class |
|---|---|---|
| `react/__tests__/SchemaRenderer.expressions.test.tsx:52` | `visible: '${data.role === "admin"}'` | **visible gap — dropped here** |
| `react/__tests__/SchemaRenderer.expressions.test.tsx:61` | `visible: '${data.role === "admin"}'` | **visible gap — dropped here** |
| `react/__tests__/SchemaRenderer.expressions.test.tsx:132` | `disabled: '${data.status === "locked"}'` | `disabled` gap — **not ruled**, left |
| `react/__tests__/SchemaRenderer.expressions.test.tsx:141` | `disabled: '${data.status === "locked"}'` | `disabled` gap — **not ruled**, left |
| `react/__tests__/SchemaRenderer.aria.test.tsx:59` | `ariaLabel: { key: …, defaultValue: … }` | ariaLabel gap — **blocked**, left |
| `components/__tests__/html-anchor-links.test.tsx:33` | `{ type: 'a', ...schema }` | unrelated — a `Record< string, unknown >` spread, no comment |

So of the six, this card's ruled widenings close **two**. Three further notes:

1. **`disabled` is the same defect as `visible`, with the same evidence** — `SchemaRenderer.tsx:466` evaluates it through the same `evaluateCondition`, and a `disabledOn?: string` sibling exists for the same reason. #4581 named only `visible` and `ariaLabel`, so I did not widen it unruled. Two casts and one one-line widening are waiting on a word.
2. `html-anchor-links.test.tsx` is the file #4581 named, but the cast in it is **not** this gap — it is a `Record< string, unknown >` spread being cast to `BaseSchema`.
3. `plugin-dashboard`'s two `as BaseSchema` are #4548's deliberate narrowing casts, untouched.

## Red-first — predictions written into the test header before the run

`packages/types/src/__tests__/base-schema-visible-predicate.test.ts` pins the widening. Against `origin/main` (`92250d648`), `tsc -p packages/types/tsconfig.test.json` reported, verbatim:

```
src/__tests__/base-schema-visible-predicate.test.ts(67,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/__tests__/base-schema-visible-predicate.test.ts(75,3): error TS2322: Type 'string' is not assignable to type 'boolean | undefined'.
src/__tests__/base-schema-visible-predicate.test.ts(81,3): error TS2322: Type 'string' is not assignable to type 'boolean | undefined'.
```

Post-fix: clean, exit 0.

The equality assertion is **invariant** (`Equal`, not `extends`) on purpose, and the header says why: a `satisfies`-style or one-way `extends` check would be vacuous **in both directions** here — the narrow `boolean` is assignable to the wide `boolean | string`, so a widening that never happened and a widening that overshot to `any` would both stay green. `BaseSchema`'s `[key: string]: any` index signature makes the overshoot a live risk, not a hypothetical: deleting the declared property altogether leaves `visible` typed `any` and every fixture still compiling. Pinning the exact union is the only assertion that can go red for the right reason.

## must-not-change

- **Emitted JS is byte-identical.** All **54** `.js` files in `@object-ui/types`' `dist` have equal sha256 against an `origin/main` compare worktree, built the same way. This is the #4528 bundle-sha256 bar, and a type-only card meets it exactly — ruling 4's "zero runtime behavior change" is satisfied at the strongest available standard rather than argued.
- `packages/types` + `packages/core` suites: **119 files, 2200 tests, all passing**.
- Repo-wide type-check canary, **PREFIX filter** (`--filter='...@object-ui/types'` = the **downstream consumers**, 27 packages): **zero** new errors attributable to this widening. Measured in isolation, with the `SchemaNode` change reverted, precisely so the two changes could not launder each other.
- eslint on the touched files vs the `origin/main` compare worktree: **21 warnings / 0 errors both sides** — net zero; the new test file contributes 0.
- All nine local gate scripts pass; control-byte and NBSP self-scan clean over every touched file including untracked.

## Published `.d.ts` diff, and the grading analysis

Built both ways with `dist/` and `*.tsbuildinfo` cleared between builds. The entire diff:

```diff
      /**
       * Controls whether the component is visible.
       * When false, component is not rendered (display: none).
+      *  … (evidence comment)
       * @default true
       */
-     visible?: boolean;
+     visible?: boolean | string;
```

**Graded `minor`** by position analysis, not by assumption: the diff **adds a member to a union on an authored-input-dominant property**, removes nothing, and touches no other declaration — the #4586/#4591 shape. Authors gain a spelling; nothing that type-checked before stops doing so. Readers of `schema.visible` were already coping with `any` through the index signature. Never major (major tracks `@objectstack`).

`@object-ui/core` gets **no changeset entry**: its declaration is untouched in this PR, so it has no source or declaration diff.

## `toRenderableSchema` in `packages/react` STAYS

Stated explicitly so no future card "cleans it up": `SchemaRenderer`'s component-level union deliberately excludes `number` / `boolean` (#4548 ruling, Q2), so the bridge still normalizes those onto their text form. It is a **total** function, not a cast. Nothing in this PR makes it an identity function, and nothing here is a reason to remove it.

## Why `SchemaNode` (#4580) did not land — the measured blocker

The reconciliation itself works. Implemented as ruled (core's `interface SchemaNode` becomes `export type { SchemaNode } from '@object-ui/types';`), built clean, and the red-first collision pin went **red pre-fix exactly as predicted and clean post-fix** — the #4548 error class, verbatim, naming both `dist` identities:

```
SchemaNode.reconciliation.test.ts(64,34): error TS2344: Type 'false' does not satisfy the constraint 'true'.
SchemaNode.reconciliation.test.ts(77,14): error TS2322: Type 'import(".../packages/types/dist/base").SchemaNode' is not assignable to type 'import(".../packages/core/dist/types/index").SchemaNode'.
SchemaNode.reconciliation.test.ts(81,19): error TS2345: Argument of type 'import(".../packages/types/dist/base").SchemaNode' is not assignable to parameter of type 'import(".../packages/core/dist/types/index").SchemaNode'.
```

`core/dist/index.d.ts` was **unchanged** by it — the entry surface is preserved, as the ruling required.

What stopped it is the repo-wide canary. The reconciliation surfaces **274** errors in `@object-ui/react`:

- **272 in test files** (5 `spec-bridge` suites) — `TS18049` ×134 and `TS2339` ×131, all of the form `Property 'sections' does not exist on type 'string | number | boolean | BaseSchema'`. Mechanical narrowing, in scope, mine — but 272 of them is a cost worth a decision on its own, and it points at the bridges' declared return type as the real lever rather than 272 local narrowings.
- **2 in runtime source**, and these are the blocker — `packages/react/src/spec-bridge/bridges/list-view.ts:180` and `:224`:

```
error TS2322: Type 'string | Record< string, string >' is not assignable to type 'string | undefined'.
```

from `if (spec.label) node.label = spec.label;` and the `description` twin. `spec.label` is the spec's `I18nLabel`; `BaseSchema.label` is `string`. Core's `[key: string]: any` had been **absorbing** that mismatch — remove the duplicate declaration and a real latent defect surfaces. Fixing it needs a cast (the lenient-consumer fallback the contract-first rule forbids) or a producer-side widening that nobody has ruled. Per ruling 4, runtime-source reshaping is a STOP, so I stopped.

## Why `ariaLabel` did not land — the ruling's spelling is the wrong vocabulary

The ruling says widen `ariaLabel` to `string | I18nLabel`. **Measured, that spelling declares a shape the renderer cannot resolve, and still rejects the shape it can.** `@object-ui/types` re-exports `I18nLabel` from `@objectstack/spec/ui`, where it is the **inline locale map** `string | Record< string, string >`. But `SchemaRenderer.tsx:111` resolves `ariaLabel` with `resolveKeyedI18nLabel`, whose declared input is the **keyed** form `string | { key: string; defaultValue?: string; params?: Record< string, any > }`. `packages/react/src/utils/i18n.ts` documents these as two vocabularies that "answer wrongly for the other's input, silently" (objectui#4167, PR #4169).

A throwaway probe measured all four consequences, and all four predictions held:

| Probe | Result |
|---|---|
| `I18nLabel` is `string \| Record< string, string >` | confirmed |
| the shipped fixture `{ key, defaultValue }` under `string \| I18nLabel` | **accepted — for the wrong reason**, as a locale map whose "locales" are named `key` and `defaultValue` |
| the same keyed label carrying `params: { name: 'Ada' }` | **rejected**: `Type '{ name: string; }' is not assignable to type 'string'` |
| the genuine inline map `{ en: 'Owner' }` | **accepted by the type**, and `resolveKeyedI18nLabel` returns `undefined` for it at runtime, rendering an empty `aria-label` |

So the ruled widening would have turned the aria test green **vacuously**, invited a shape that renders empty, and still rejected keyed labels with `params`. That is the opposite of the ruling's own stated intent ("matching what the renderer actually supports"), so I did not write it.

## The two escalations are one question

`BaseSchema` declares three sibling label slots — `label?: string` (:56), `description?: string` (:62), `ariaLabel?: string` (:173) — and **all three under-declare, in two different i18n vocabularies**: `label`/`description` receive the spec's **inline** `I18nLabel` from the bridges, while `ariaLabel` is resolved with the **keyed** resolver. Core's index signature was hiding all of it.

That is why #4580 is blocked on #4581 rather than the other way round: the ruling treated the `ariaLabel` widening as a rider on the reconciliation, but the reconciliation is what *forces* the label-vocabulary decision. One ruling on "which vocabulary does each `BaseSchema` label slot declare" unblocks the reconciliation, the `ariaLabel` widening, and the two `list-view.ts` defects together. Options and a recommendation are in the seat's report.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_