### PR TITLE
fix(types): ariaLabel declares the keyed vocabulary, disabled accepts the predicate string (#4581)

### DIFF
--- a/.changeset/aria-label-keyed-vocabulary-4581.md
+++ b/.changeset/aria-label-keyed-vocabulary-4581.md
@@ -1,0 +1,54 @@
+---
+'@object-ui/types': minor
+'@object-ui/react': patch
+'@object-ui/layout': patch
+'@object-ui/app-shell': patch
+---
+
+`BaseSchema.ariaLabel` declares the keyed i18n vocabulary the renderer actually
+resolves, `.disabled` accepts the predicate string it actually evaluates, and the
+keyed shape finally has a name (objectui#4581)
+
+Three slots on one base type had drifted from what the renderer does with them.
+PR #4593 fixed `visible` and measured the rest; these are the rest.
+
+`ariaLabel` was `string`, but `SchemaRenderer.tsx:111` resolves it with
+`resolveKeyedI18nLabel`, whose input is the KEYED form
+`{ key, defaultValue?, params? }` — a reference into a translation bundle. It is
+now `string | KeyedI18nLabel`, and `KeyedI18nLabel` is a new exported type in
+`@object-ui/types` rather than a fourth inline copy of one object literal: the
+three that existed (`@object-ui/react`'s resolver, `@object-ui/layout`'s
+`resolveLabel`, `@object-ui/app-shell`'s `t`-taking twin) were verified identical
+in their object half first, and two of them now import the name.
+
+The vocabulary matters more than the widening. `#4581` originally asked for
+`string | I18nLabel`, and that spelling was withdrawn as measured-wrong: the
+spec's `I18nLabel` is the INLINE LOCALE MAP (`string | Record<string, string>`),
+a different vocabulary resolved against a BCP-47 locale by a different function
+of a confusingly similar name. Under it the shipped keyed fixture type-checked
+only vacuously — as a locale map whose "locales" are named `key` and
+`defaultValue` — the same label carrying `params` was rejected outright, and a
+genuine `{ en: 'Owner' }` compiled while rendering an EMPTY `aria-label`. Naming
+the keyed shape is the declaration half of the fix objectui#4167 started on the
+naming side; `@object-ui/app-shell`'s copy keeps its inline spelling for now
+because an open PR has a pending change to that file, and the comment there says
+so.
+
+`disabled` was `boolean` on a key the renderer never reads as one:
+`SchemaRenderer.tsx:466` evaluates it through the same `evaluateCondition` as
+`visible`, and a `disabledOn?: string` sibling exists for the same reason. It is
+now `boolean | string`. The asymmetry with `visible` was accidental rather than
+deliberate.
+
+Both are widenings on authored-input-dominant properties: authors gain a
+spelling, nothing that type-checked before stops doing so, and readers already
+coped with `any` through `BaseSchema`'s index signature. Three test fixtures that
+had been casting past these declarations with `as unknown as BaseSchema` state
+their values directly now, and the declared unions are pinned invariantly so
+neither a missing widening nor an overshoot to `any` can pass unnoticed.
+
+`BaseSchema.label` and `.description` are deliberately unchanged and pinned that
+way. They receive the spec's inline `I18nLabel` from the view bridges, which is a
+real defect, but resolving it belongs at the spec-to-schema boundary rather than
+in this declaration — and that work is still blocked on a design question about
+where the display locale enters, so it is not in this release.

--- a/.changeset/aria-label-keyed-vocabulary-4581.md
+++ b/.changeset/aria-label-keyed-vocabulary-4581.md
@@ -3,6 +3,7 @@
 '@object-ui/react': patch
 '@object-ui/layout': patch
 '@object-ui/app-shell': patch
+'@object-ui/components': patch
 ---
 
 `BaseSchema.ariaLabel` declares the keyed i18n vocabulary the renderer actually
@@ -46,6 +47,14 @@ coped with `any` through `BaseSchema`'s index signature. Three test fixtures tha
 had been casting past these declarations with `as unknown as BaseSchema` state
 their values directly now, and the declared unions are pinned invariantly so
 neither a missing widening nor an overshoot to `any` can pass unnoticed.
+
+Declaring the vocabulary honestly also surfaced a real one: the `toggle`
+renderer writes `aria-label` itself instead of going through SchemaRenderer's
+resolver, and it forwarded the raw value. Invoked directly it emitted
+`aria-label="[object Object]"` for a keyed label — announced verbatim by a
+screen reader. It resolves now. Through `SchemaRenderer` the bug was invisible,
+because SchemaRenderer injects its own resolved `aria-label` afterwards; a
+downstream type-check sweep found it, not a test.
 
 `BaseSchema.label` and `.description` are deliberately unchanged and pinned that
 way. They receive the spec's inline `I18nLabel` from the view bridges, which is a

--- a/packages/app-shell/src/utils/index.ts
+++ b/packages/app-shell/src/utils/index.ts
@@ -58,6 +58,15 @@ export {
  * the `@object-ui/react` twin (`packages/react/src/utils/i18n.ts`), which is the
  * same vocabulary without a `t`. Import the spec's as `resolveInlineI18nLabel`
  * when you need the map form; the two names now say which is which.
+ *
+ * NOTE — the inline object literal below is `KeyedI18nLabel` from
+ * `@object-ui/types` (#4581), which named this shape and retired the two other
+ * copies (`packages/react/src/utils/i18n.ts`,
+ * `packages/layout/src/NavigationRenderer.tsx`). This third one is left spelled
+ * out ON PURPOSE: PR #4208 — the rc.6 train, still open and blocked on #4165 —
+ * has a pending change to this file, and a type-spelling swap here would be a
+ * rebase conflict for the train rather than a cleanup. Swap it to the named
+ * type once #4208 lands.
  */
 export function resolveKeyedI18nLabel(
   label: string | { key: string; defaultValue?: string; params?: Record<string, any> } | undefined,

--- a/packages/components/src/__tests__/toggle-aria-label-keyed.test.tsx
+++ b/packages/components/src/__tests__/toggle-aria-label-keyed.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `toggle` renderer resolves a KEYED `ariaLabel` itself (objectui#4581).
+ *
+ * `BaseSchema.ariaLabel` now declares `string | KeyedI18nLabel` — the keyed
+ * vocabulary `SchemaRenderer.tsx:111` resolves with `resolveKeyedI18nLabel`.
+ * This renderer is one of the few that writes `aria-label` ITSELF rather than
+ * relying on SchemaRenderer's `resolveAriaProps`, and it forwarded the value
+ * raw: `aria-label={schema.ariaLabel}`. Under the honest declaration that stops
+ * type-checking, which is how it was found — a downstream `type-check` sweep
+ * over the consumers of `@object-ui/types`, not a test.
+ *
+ * ## The prediction I wrote first was WRONG, and the correction is the point
+ *
+ * I predicted the raw forward would render `aria-label="[object Object]"`
+ * through `SchemaRenderer`. Measured: it does NOT. `SchemaRenderer` injects its
+ * OWN already-resolved `aria-label` into the component's props
+ * (`SchemaRenderer.tsx:599` + `:625`, `...ariaProps`), and this renderer spreads
+ * `{...props}` AFTER its own attribute — so the resolved value always wins and
+ * the raw expression is shadowed on that path. A test driven through
+ * `SchemaRenderer` is therefore GREEN IN BOTH DIRECTIONS: vacuous, and it would
+ * have shipped looking like proof.
+ *
+ * So the discriminating case invokes the registered renderer DIRECTLY, which is
+ * the only path where its own `aria-label` expression is observable. Both paths
+ * are kept below and labelled for what each can and cannot show.
+ *
+ * ## Red-first, measured with the raw forward restored
+ *
+ * The direct case reported, verbatim (1 failed | 3 passed):
+ *
+ *   Expected the element to have attribute:
+ *     aria-label="Close dialog"
+ *   Received:
+ *     aria-label="[object Object]"
+ *
+ * and the SchemaRenderer case stayed green, exactly as the correction above
+ * says it must. Post-fix all four pass.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+/** Invoke the registered renderer directly — no SchemaRenderer aria injection. */
+function renderToggleDirect(schema: Record<string, unknown>) {
+  const Toggle = ComponentRegistry.get('toggle') as React.ComponentType<any>;
+  return render(<Toggle schema={schema} />);
+}
+
+describe('toggle renderer — keyed ariaLabel (objectui#4581)', () => {
+  /* ── The discriminating cases: the renderer's own expression ───────────── */
+
+  it('resolves a keyed ariaLabel to its defaultValue (direct invocation)', () => {
+    renderToggleDirect({
+      type: 'toggle',
+      label: 'Mute',
+      ariaLabel: { key: 'dialog.close', defaultValue: 'Close dialog' },
+    });
+    // Pre-fix this read '[object Object]' — the DOM stringifying the keyed
+    // label object straight into the attribute.
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Close dialog');
+  });
+
+  it('passes a plain-string ariaLabel through unchanged (direct invocation)', () => {
+    renderToggleDirect({ type: 'toggle', label: 'Mute', ariaLabel: 'Mute notifications' });
+    // Green in both directions on purpose: this is the passthrough, and a fix
+    // that resolved too eagerly would break it.
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Mute notifications');
+  });
+
+  it('omits aria-label entirely when the schema declares none (direct invocation)', () => {
+    renderToggleDirect({ type: 'toggle', label: 'Mute' });
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-label');
+  });
+
+  /* ── The end-to-end path: a regression guard, NOT a discriminator ──────── */
+
+  it('renders a resolved aria-label end-to-end through SchemaRenderer', () => {
+    render(
+      <SchemaRenderer
+        schema={{
+          type: 'toggle',
+          label: 'Mute',
+          ariaLabel: { key: 'dialog.close', defaultValue: 'Close dialog' },
+        }}
+      />,
+    );
+    // NOTE: green with or without the renderer's fix — SchemaRenderer's own
+    // `...ariaProps` shadows the renderer's attribute. Kept because it pins the
+    // path an author actually exercises; it cannot prove the fix, and the
+    // header says so rather than letting a reader assume it does.
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Close dialog');
+  });
+});

--- a/packages/components/src/renderers/form/toggle.tsx
+++ b/packages/components/src/renderers/form/toggle.tsx
@@ -7,17 +7,24 @@
  */
 
 import { ComponentRegistry } from '@object-ui/core';
+import { resolveKeyedI18nLabel } from '@object-ui/react';
 import type { ToggleSchema } from '@object-ui/types';
 import { Toggle } from '../../ui';
 import { renderChildren } from '../../lib/utils';
 
-ComponentRegistry.register('toggle', 
+ComponentRegistry.register('toggle',
   ({ schema, ...props }: { schema: ToggleSchema; [key: string]: any }) => (
-    <Toggle 
-      variant={schema.variant} 
-      size={schema.size} 
+    <Toggle
+      variant={schema.variant}
+      size={schema.size}
       pressed={schema.pressed}
-      aria-label={schema.ariaLabel}
+      // `ariaLabel` is `string | KeyedI18nLabel` (objectui#4581) — the keyed
+      // form has to be RESOLVED before it reaches the DOM, exactly as
+      // `SchemaRenderer.tsx:111` does for every other component. Forwarding it
+      // raw put an object into an `aria-label`, which renders the literal text
+      // "[object Object]" to a screen reader. This renderer bypasses
+      // SchemaRenderer's `resolveAriaProps`, so it has to do it itself.
+      aria-label={resolveKeyedI18nLabel(schema.ariaLabel)}
       {...props}
     >
       {schema.label || renderChildren(schema.children)}

--- a/packages/layout/src/NavigationRenderer.tsx
+++ b/packages/layout/src/NavigationRenderer.tsx
@@ -65,7 +65,7 @@ import {
   cn,
   useIsMobile,
 } from '@object-ui/components';
-import type { NavigationItem } from '@object-ui/types';
+import type { NavigationItem, KeyedI18nLabel } from '@object-ui/types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -254,11 +254,19 @@ export function resolveIcon(name?: string): React.ComponentType<any> {
 
 /**
  * Resolve a NavigationItem label to a plain string.
- * Handles both plain strings and I18nLabel objects { key, defaultValue }.
- * When a `t` function is provided, I18nLabel objects are translated via i18next.
+ *
+ * Handles both plain strings and the KEYED i18n form
+ * `{ key, defaultValue?, params? }` — named `KeyedI18nLabel` in
+ * `@object-ui/types` since #4581, which is what this signature now states
+ * instead of a third inline copy of the same object literal. When a `t`
+ * function is provided the key is translated via i18next.
+ *
+ * "Keyed", not the spec's `I18nLabel`: that one is the INLINE LOCALE MAP
+ * (`{ en: 'Owner' }`) resolved against a BCP-47 locale, and the two answer
+ * wrongly for each other's input, silently (objectui#4167).
  */
 export function resolveLabel(
-  label: string | { key: string; defaultValue?: string; params?: Record<string, any> },
+  label: string | KeyedI18nLabel,
   t?: (key: string, options?: any) => string,
 ): string {
   if (typeof label === 'string') return label;

--- a/packages/react/src/__tests__/SchemaRenderer.aria.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.aria.test.tsx
@@ -11,7 +11,10 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer } from '../SchemaRenderer';
-import type { BaseSchema } from '@object-ui/types';
+// No `BaseSchema` import any more: the keyed-`ariaLabel` fixture below was the
+// only thing that needed it, for an `as unknown as BaseSchema` cast that
+// objectui#4581 made unnecessary by declaring the vocabulary the renderer
+// resolves.
 
 // A simple test component that forwards ARIA attributes
 const TestWidget: React.FC<any> = (props) => (
@@ -47,20 +50,43 @@ describe('SchemaRenderer AriaProps injection', () => {
     expect(el).toHaveAttribute('aria-label', 'Close dialog');
   });
 
-  it('should resolve ariaLabel from I18nLabel object', () => {
+  it('should resolve ariaLabel from a KeyedI18nLabel object', () => {
     render(
       <SchemaRenderer
         schema={{
           type: 'test-widget',
-          // AriaPropsSchema declares `ariaLabel: string | I18nLabel` and the
-          // renderer resolves the keyed form; `BaseSchema.ariaLabel` is the
-          // narrower `string` (objectui#4548).
+          // No cast: `BaseSchema.ariaLabel` declares `string | KeyedI18nLabel`
+          // (objectui#4581), which is the vocabulary the renderer actually
+          // resolves — `SchemaRenderer.tsx:111` calls `resolveKeyedI18nLabel`.
+          // This fixture carried `as unknown as BaseSchema` while the
+          // declaration said the narrower `string` (objectui#4548).
           ariaLabel: { key: 'dialog.close', defaultValue: 'Close dialog' },
-        } as unknown as BaseSchema}
+        }}
       />
     );
     const el = screen.getByTestId('test-widget');
     expect(el).toHaveAttribute('aria-label', 'Close dialog');
+  });
+
+  it('should resolve a KeyedI18nLabel carrying params', () => {
+    render(
+      <SchemaRenderer
+        schema={{
+          type: 'test-widget',
+          // `params` is the limb the withdrawn `string | I18nLabel` spelling
+          // REJECTED outright (PR #4593's probe, #4580 ruling Q2-B). Without a
+          // `t`, this package's resolver falls back to `defaultValue` — the
+          // point here is that the shape is authorable at all.
+          ariaLabel: {
+            key: 'greeting.hello',
+            defaultValue: 'Hello, Ada',
+            params: { name: 'Ada' },
+          },
+        }}
+      />
+    );
+    const el = screen.getByTestId('test-widget');
+    expect(el).toHaveAttribute('aria-label', 'Hello, Ada');
   });
 
   it('should inject aria-describedby from ariaDescribedBy', () => {

--- a/packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.expressions.test.tsx
@@ -11,16 +11,17 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer } from '../SchemaRenderer';
-// `BaseSchema.visible` now declares `boolean | string` (objectui#4581), so the
-// two visibility cases below state their predicate strings directly — no cast.
+// `BaseSchema.visible` AND `.disabled` now both declare `boolean | string`
+// (objectui#4581), so every predicate-string case below states its expression
+// directly — no casts left in this file.
 //
-// `.disabled` is the SAME gap and is NOT yet widened: the renderer evaluates it
-// through the same `evaluateCondition` (`SchemaRenderer.tsx:466`) and the
-// `disabledOn?: string` sibling exists for the same reason, but #4581 named only
-// `visible` and `ariaLabel`, so widening `disabled` was left to its own card
-// rather than taken unruled. The two `disabled` casts below are what remains of
-// the gap — drop them when that lands.
-import type { BaseSchema } from '@object-ui/types';
+// The header that stood here said the `disabled` casts were "what remains of
+// the gap — drop them when that lands". This is that landing: #4580's ruling
+// Q3-A widened `disabled` on the same evidence as `visible` (the renderer
+// evaluates it through the same `evaluateCondition` at
+// `SchemaRenderer.tsx:466`, and the `disabledOn?: string` sibling exists for
+// the same reason), and the two casts are gone. The `BaseSchema` import went
+// with them — nothing in this file needs the name any more.
 import { SchemaRendererContext } from '../context/SchemaRendererContext';
 
 // Simple test component
@@ -133,7 +134,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('evaluates disabled expression string', () => {
       render(
         <SchemaRendererContext.Provider value={{ dataSource: { status: 'locked' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' } as unknown as BaseSchema} />
+          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' }} />
         </SchemaRendererContext.Provider>
       );
       expect(screen.getByTestId('test-component')).toHaveAttribute('data-disabled', 'true');
@@ -142,7 +143,7 @@ describe('SchemaRenderer Expression Integration', () => {
     it('does not set disabled when expression is false', () => {
       render(
         <SchemaRendererContext.Provider value={{ dataSource: { status: 'active' } }}>
-          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' } as unknown as BaseSchema} />
+          <SchemaRenderer schema={{ type: 'test-component', disabled: '${data.status === "locked"}' }} />
         </SchemaRendererContext.Provider>
       );
       expect(screen.getByTestId('test-component')).not.toHaveAttribute('data-disabled');

--- a/packages/react/src/utils/i18n.ts
+++ b/packages/react/src/utils/i18n.ts
@@ -1,3 +1,5 @@
+import type { KeyedI18nLabel } from '@object-ui/types';
+
 /**
  * Resolves objectui's KEYED i18n label to a plain string.
  *
@@ -34,8 +36,14 @@
  * convention, which is exactly what objectstack#4115 exists to replace with a
  * rule. `Keyed` is the counterpart of that `Inline`: the name now says which
  * vocabulary it resolves, at every call site, with no comment required.
+ *
+ * The keyed shape itself is now named too — `KeyedI18nLabel` in
+ * `@object-ui/types` (#4581) — so `BaseSchema.ariaLabel`, this parameter and
+ * the layout twin all state one type instead of three copies of one object
+ * literal. The `Inline`/`Keyed` split above is the naming half of #4167; the
+ * named shape is the declaration half.
  */
-export function resolveKeyedI18nLabel(label: string | { key: string; defaultValue?: string; params?: Record<string, any> } | undefined): string | undefined {
+export function resolveKeyedI18nLabel(label: string | KeyedI18nLabel | undefined): string | undefined {
   if (label === undefined || label === null) return undefined;
   if (typeof label === 'string') return label;
   return label.defaultValue || label.key;

--- a/packages/types/src/__tests__/base-schema-label-vocabulary.test.ts
+++ b/packages/types/src/__tests__/base-schema-label-vocabulary.test.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The `BaseSchema` label/state vocabulary, named and declared (objectui#4581).
+ *
+ * Sibling of `base-schema-visible-predicate.test.ts`, which pinned `visible`
+ * in PR #4593. This file pins the three remaining slots that PR measured and
+ * escalated, under the rulings recorded on objectui#4580 (comment 5284007579).
+ *
+ * ## `ariaLabel` declares the KEYED vocabulary (ruling Q2-B)
+ *
+ * `packages/react/src/SchemaRenderer.tsx:111` reads:
+ *
+ *   ```ts
+ *   if (schema.ariaLabel) {
+ *     aria['aria-label'] = resolveKeyedI18nLabel(schema.ariaLabel);
+ *   }
+ *   ```
+ *
+ * `resolveKeyedI18nLabel` (`packages/react/src/utils/i18n.ts`) accepts the
+ * KEYED form — `{ key, defaultValue?, params? }`, a reference INTO a
+ * translation bundle. It is NOT the spec's `I18nLabel`, which since
+ * `@objectstack/spec` 17.0.0-rc.6 is the INLINE LOCALE MAP
+ * `string | Record<string, string>` resolved by the spec's own
+ * `resolveI18nLabel(label, locale)`.
+ *
+ * The original #4581 text asked for `string | I18nLabel`. PR #4593 measured
+ * that spelling and it was wrong in three separate ways, which is why the
+ * ruling withdrew it:
+ *
+ *   - the shipped keyed fixture `{ key, defaultValue }` was accepted *for the
+ *     wrong reason* — as a locale map whose "locales" are named `key` and
+ *     `defaultValue`;
+ *   - the same keyed label carrying `params` was REJECTED
+ *     (`Type '{ name: string; }' is not assignable to type 'string'`);
+ *   - a genuine inline map `{ en: 'Owner' }` type-checked while
+ *     `resolveKeyedI18nLabel` returns `undefined` for it at runtime, rendering
+ *     an EMPTY `aria-label`.
+ *
+ * So the declared vocabulary here is the keyed one, and it gets a NAME —
+ * `KeyedI18nLabel` — rather than a fourth inline copy of the same object
+ * literal. The three that existed before this card
+ * (`packages/react/src/utils/i18n.ts`, `packages/layout/src/NavigationRenderer.tsx`,
+ * `packages/app-shell/src/utils/index.ts`) were verified byte-for-byte
+ * identical in their object half before the name was minted.
+ *
+ * ## `disabled` accepts the predicate string (ruling Q3-A)
+ *
+ * Exactly the `visible` evidence, one slot over: `SchemaRenderer.tsx:466`
+ * evaluates it through the same `evaluateCondition`
+ * (`(condition: string | boolean | undefined, context?) => boolean`), and the
+ * `disabledOn?: string` sibling exists for the same reason. The asymmetry with
+ * `visible` was accidental, not deliberate.
+ *
+ * ## `label` / `description` STAY `string` (ruling Q1-B) — must-not-change
+ *
+ * The two spec bridges hand these slots the spec's INLINE `I18nLabel`, which is
+ * a real defect (#4593's canary: TS2322 at `list-view.ts:180` and `:224`). The
+ * ruling resolves it at the BRIDGE, not by widening these declarations. The two
+ * assertions below are therefore the ruling written down: they are the only
+ * pins in this file expected GREEN pre-fix, and a future card that "fixes" the
+ * bridge defect by widening `BaseSchema.label` turns them red on purpose.
+ *
+ * ## Predictions, written before the first run (red-first)
+ *
+ * Against `origin/main` (`52d878a3b`), `tsc -p packages/types/tsconfig.test.json`
+ * must report:
+ *
+ *   1. the `KeyedI18nLabel` import — TS2305, `Module '"../base"' has no
+ *      exported member 'KeyedI18nLabel'` (the name does not exist yet).
+ *   2. `keyedAriaLabelIsAuthorable` / `keyedAriaLabelWithParamsIsAuthorable` —
+ *      TS2322, an object is not assignable to `string`. The explicit
+ *      `ariaLabel?: string` member wins over `BaseSchema`'s
+ *      `[key: string]: any` index signature, which is precisely why the shipped
+ *      fixture in `SchemaRenderer.aria.test.tsx` needed
+ *      `as unknown as BaseSchema`.
+ *   3. `disabledPredicateStringIsAuthorable` — TS2322, `Type 'string' is not
+ *      assignable to type 'boolean | undefined'`.
+ *   4. `assertionDisabled` — TS2344, `Type 'false' does not satisfy the
+ *      constraint 'true'`.
+ *   5. `assertionAriaLabel` and `assertionKeyedShape` — expected TS2344 as
+ *      well, but for a DERIVED reason: after the TS2305 above, the unresolved
+ *      import degrades to an error type, so what these two report pre-fix is
+ *      not independent evidence. They are listed for completeness, and the
+ *      load-bearing pre-fix reds are 1-4.
+ *   6. `assertionLabel` / `assertionDescription` — NO error, pre-fix and
+ *      post-fix. See must-not-change above.
+ *
+ * MEASURED (`52d878a3b`, before the fix) — 1, 2, 3, 4 and 6 held exactly:
+ *
+ * ```
+ * base-schema-label-vocabulary.test.ts(103,27): error TS2305: Module '"../base"' has no exported member 'KeyedI18nLabel'.
+ * base-schema-label-vocabulary.test.ts(120,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
+ * base-schema-label-vocabulary.test.ts(130,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
+ * base-schema-label-vocabulary.test.ts(143,3): error TS2322: Type '{ key: string; defaultValue: string; }' is not assignable to type 'string'.
+ * base-schema-label-vocabulary.test.ts(149,3): error TS2322: Type '{ key: string; defaultValue: string; params: { name: string; }; }' is not assignable to type 'string'.
+ * base-schema-label-vocabulary.test.ts(161,3): error TS2322: Type 'string' is not assignable to type 'boolean | undefined'.
+ * ```
+ *
+ * Prediction 5 was half wrong, and it is left standing rather than rewritten to
+ * match: `assertionKeyedShape` (120) DID report, but `assertionAriaLabel` (126)
+ * reported NOTHING — TypeScript suppresses the cascade once the import is an
+ * error type. Which is exactly why 5 was flagged as non-independent evidence in
+ * advance: a pin whose pre-fix silence is a compiler artifact proves nothing on
+ * its own. Its value is post-fix, where it pins the union for real.
+ *
+ * After the fix, all of it compiles clean (`tsc -p tsconfig.test.json`, exit 0).
+ *
+ * Every `Equal` below is INVARIANT for the reason
+ * `base-schema-visible-predicate.test.ts` spells out and this card inherits: a
+ * `satisfies`-style or one-way `extends` check is VACUOUS for a widening in
+ * both directions — the narrow `string` is assignable to the wide
+ * `string | KeyedI18nLabel`, so a widening that never happened AND a widening
+ * that overshot to `any` would both stay green. `BaseSchema`'s
+ * `[key: string]: any` makes the overshoot live rather than hypothetical:
+ * deleting a declared property altogether leaves it typed `any` and every
+ * fixture below still compiles.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { BaseSchema, KeyedI18nLabel } from '../base';
+
+/* ── Type-level helpers ──────────────────────────────────────────────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/* ── The named vocabulary is exactly the shape the resolver accepts ──────── */
+
+/**
+ * The census shape, spelled out literally rather than referenced, so this pin
+ * fails if the named type ever drifts from what the three retired inline copies
+ * agreed on and what `resolveKeyedI18nLabel` destructures.
+ */
+export type assertionKeyedShape = Expect<
+  Equal< KeyedI18nLabel, { key: string; defaultValue?: string; params?: Record<string, any> } >
+>;
+
+/* ── The declared slots ──────────────────────────────────────────────────── */
+
+export type assertionAriaLabel = Expect<
+  Equal< BaseSchema['ariaLabel'], string | KeyedI18nLabel | undefined >
+>;
+
+export type assertionDisabled = Expect<
+  Equal< BaseSchema['disabled'], boolean | string | undefined >
+>;
+
+/* ── must-not-change: the Q1-B ruling, written as a pin ──────────────────── */
+
+export type assertionLabel = Expect< Equal< BaseSchema['label'], string | undefined > >;
+export type assertionDescription = Expect< Equal< BaseSchema['description'], string | undefined > >;
+
+/* ── Authorable fixtures ─────────────────────────────────────────────────── */
+
+/** The exact shape the shipped aria fixture had to cast past. */
+export const keyedAriaLabelIsAuthorable: BaseSchema = {
+  type: 'test-widget',
+  ariaLabel: { key: 'dialog.close', defaultValue: 'Close dialog' },
+};
+
+/** `params` — the limb the withdrawn `string | I18nLabel` spelling REJECTED. */
+export const keyedAriaLabelWithParamsIsAuthorable: BaseSchema = {
+  type: 'test-widget',
+  ariaLabel: { key: 'greeting.hello', defaultValue: 'Hello, {{name}}', params: { name: 'Ada' } },
+};
+
+/** The plain string form is untouched — this is a widening, not a replacement. */
+export const plainAriaLabelIsStillAuthorable: BaseSchema = {
+  type: 'test-widget',
+  ariaLabel: 'Close dialog',
+};
+
+/** The capability `SchemaRenderer.tsx:466` implements, now declared. */
+export const disabledPredicateStringIsAuthorable: BaseSchema = {
+  type: 'test-component',
+  disabled: '${data.status === "locked"}',
+};
+
+/** The boolean form is untouched. */
+export const disabledBooleanIsStillAuthorable: BaseSchema = {
+  type: 'test-component',
+  disabled: true,
+};
+
+/* ── Runtime companion ───────────────────────────────────────────────────── */
+
+describe('BaseSchema label vocabulary (objectui#4581)', () => {
+  it('type-level: ariaLabel is string | KeyedI18nLabel, disabled is boolean | string', () => {
+    // Erased at runtime; `tsc -p tsconfig.test.json` is the checker, chained
+    // from this package's `type-check` script. The runtime case exists so a
+    // green vitest run is not mistaken for the proof.
+    expect((keyedAriaLabelWithParamsIsAuthorable.ariaLabel as KeyedI18nLabel).params).toEqual({
+      name: 'Ada',
+    });
+    expect(plainAriaLabelIsStillAuthorable.ariaLabel).toBe('Close dialog');
+    expect(disabledPredicateStringIsAuthorable.disabled).toBe('${data.status === "locked"}');
+    expect(disabledBooleanIsStillAuthorable.disabled).toBe(true);
+  });
+});

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -17,6 +17,40 @@
  */
 
 /**
+ * A KEYED i18n label — a reference INTO a translation bundle (objectui#4581).
+ *
+ * This is objectui's own label vocabulary, and it is NOT the spec's
+ * `I18nLabel`. The two are structurally confusable and answer wrongly for each
+ * other's input, silently — objectui#4167 is the card that names the hazard,
+ * and PR #4169 the one that had to alias five imports by hand because neither
+ * shape had a name that said which it was:
+ *
+ * - KEYED (this type): `{ key, defaultValue?, params? }`, resolved against a
+ *   translation bundle by `resolveKeyedI18nLabel`
+ *   (`packages/react/src/utils/i18n.ts`, and the `t`-taking twin in
+ *   `packages/app-shell/src/utils/index.ts`).
+ * - INLINE (`I18nLabel`, re-exported from `@objectstack/spec/ui`):
+ *   `string | Record<string, string>` — a locale MAP like
+ *   `{ en: 'Owner' }` — resolved against a BCP-47 locale by the spec's own
+ *   `resolveI18nLabel(label, locale)`.
+ *
+ * The shape below is the census of the three inline copies that existed before
+ * this type was minted — `packages/react/src/utils/i18n.ts`,
+ * `packages/layout/src/NavigationRenderer.tsx` and
+ * `packages/app-shell/src/utils/index.ts` — which were verified identical in
+ * their object half first. It is a NAME for what was already there, not a new
+ * capability.
+ */
+export type KeyedI18nLabel = {
+  /** Translation-bundle key, e.g. `dialog.close`. */
+  key: string;
+  /** Rendered when the key is missing from the bundle, or no `t` is available. */
+  defaultValue?: string;
+  /** Interpolation values for the key's placeholders, e.g. `{{name}}`. */
+  params?: Record<string, any>;
+};
+
+/**
  * Base schema interface that all component schemas extend.
  * This is the fundamental building block of the Object UI protocol.
  * 
@@ -150,9 +184,22 @@ export interface BaseSchema {
   /**
    * Controls whether the component is disabled.
    * Applies to interactive components like buttons and inputs.
+   *
+   * Accepts a PREDICATE STRING as well as a boolean (objectui#4581), on exactly
+   * the `visible` evidence one slot over: the renderer does not read this key
+   * as a boolean, it evaluates it — `SchemaRenderer.tsx:466` calls
+   * `evaluator.evaluateCondition(newSchema.disabled)`, and `evaluateCondition`
+   * is declared
+   * `(condition: string | boolean | undefined, context?) => boolean`. The
+   * sibling key `disabledOn` is `string` for the same reason. The asymmetry
+   * with `visible` was accidental rather than deliberate (#4580 ruling Q3-A);
+   * the two fixtures exercising it had been casting past the declaration.
+   *
    * @default false
+   * @example false
+   * @example "${data.status === 'locked'}"
    */
-  disabled?: boolean;
+  disabled?: boolean | string;
 
   /**
    * Expression for conditional disabling.
@@ -169,8 +216,29 @@ export interface BaseSchema {
   /**
    * Accessibility label for screen readers.
    * Rendered as aria-label attribute.
+   *
+   * Accepts the KEYED i18n form as well as a plain string (objectui#4581),
+   * because that is what the renderer resolves:
+   * `packages/react/src/SchemaRenderer.tsx:111` reads
+   * `aria['aria-label'] = resolveKeyedI18nLabel(schema.ariaLabel)`, and
+   * `resolveKeyedI18nLabel` accepts `{ key, defaultValue?, params? }` — the
+   * shape now named {@link KeyedI18nLabel}.
+   *
+   * NOT `I18nLabel`. The original #4581 text asked for `string | I18nLabel`,
+   * and PR #4593 measured that spelling wrong in three ways before the ruling
+   * withdrew it (#4580 Q2-B): `I18nLabel` is the spec's INLINE LOCALE MAP
+   * (`string | Record<string, string>`), so the shipped keyed fixture was
+   * accepted only *vacuously* — as a locale map whose "locales" are named `key`
+   * and `defaultValue`; the same label carrying `params` was REJECTED
+   * (`Type '{ name: string; }' is not assignable to type 'string'`); and a
+   * genuine `{ en: 'Owner' }` type-checked while `resolveKeyedI18nLabel`
+   * returns `undefined` for it, rendering an EMPTY aria-label. The two
+   * vocabularies are structurally confusable — objectui#4167's exact hazard.
+   *
+   * @example "Close dialog"
+   * @example { key: 'dialog.close', defaultValue: 'Close dialog' }
    */
-  ariaLabel?: string;
+  ariaLabel?: string | KeyedI18nLabel;
 
   /**
    * Additional properties specific to the component type.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -83,6 +83,12 @@ export {
 // ============================================================================
 export type {
   BaseSchema,
+  // objectui's KEYED i18n label — `{ key, defaultValue?, params? }`, a
+  // reference INTO a translation bundle. Deliberately NOT the spec's
+  // `I18nLabel` re-exported further down this file, which is the INLINE LOCALE
+  // MAP; the two are structurally confusable (objectui#4167) and this name is
+  // half of what stops them being mixed up (#4581).
+  KeyedI18nLabel,
   SchemaNode,
   ComponentRendererProps,
   ComponentInput,


### PR DESCRIPTION
Fixes #4581.

Executes the label-vocabulary rulings recorded on #4580 (comment 5284007579) — the follow-up seat that ruling asked for. PR #4593 landed the `visible` half and escalated the rest; this lands **Q2-B** and **Q3-A**, and **stops on Q1-B** because its stated premise measured false.

## Q2-B — `ariaLabel` declares the KEYED vocabulary, and the shape gets a name

`BaseSchema.ariaLabel` is now `string | KeyedI18nLabel`, where `KeyedI18nLabel` is a new exported type in `@object-ui/types`:

```ts
export type KeyedI18nLabel = {
  key: string;
  defaultValue?: string;
  params?: Record< string, any >;
};
```

That is the vocabulary the renderer actually resolves — `packages/react/src/SchemaRenderer.tsx:111`:

```ts
if (schema.ariaLabel) {
  aria['aria-label'] = resolveKeyedI18nLabel(schema.ariaLabel);
}
```

**Not `I18nLabel`.** The original #4581 text asked for `string | I18nLabel`; PR #4593 measured that spelling wrong in three ways and the ruling withdrew it. `I18nLabel` is the spec's INLINE LOCALE MAP (`string | Record< string, string >`), so it accepted the shipped keyed fixture only *vacuously* — as a locale map whose "locales" are named `key` and `defaultValue` — **rejected** the same label carrying `params`, and type-checked a genuine `{ en: 'Owner' }` that `resolveKeyedI18nLabel` returns `undefined` for, rendering an empty aria-label. The two vocabularies are structurally confusable: #4167's exact hazard.

### The keyed-shape census (verified before the name was minted)

All three inline copies agreed **exactly** on the object half:

| Site | Object half | Wrapper |
|---|---|---|
| `packages/react/src/utils/i18n.ts:38` | `{ key: string; defaultValue?: string; params?: Record< string, any > }` | `string \| … \| undefined` |
| `packages/layout/src/NavigationRenderer.tsx:261` | identical | `string \| …` (no `undefined`) |
| `packages/app-shell/src/utils/index.ts:63` | identical | `string \| … \| undefined` |

So `KeyedI18nLabel` names the **object half** only; each site keeps its own wrapper. It is a name for what was already there, not a new capability.

### #4208 train-overlap decision, per file — measured, not assumed

The card flagged PR #4208 (the rc.6 train, open and blocked on #4165). GitHub's file list for #4208 is computed against a **stale merge-base** (`6314e87f2`), so it lists files whose changes have since landed on `main`. I measured the **content** delta instead (`git diff origin/main refs/remotes/pr/4208 -- PATH`):

| File | Train content vs `main` | Decision |
|---|---|---|
| `packages/react/src/utils/i18n.ts` | **byte-identical** — the train's change already landed | **retired** the inline copy |
| `packages/layout/src/NavigationRenderer.tsx` | **byte-identical**; not in #4208's file list at all | **retired** the inline copy |
| `packages/app-shell/src/utils/index.ts` | **differs** — a pending hunk still rewrites the `./appRoute` re-export block | **left in place**, with a comment naming the type and why the swap waits |

⚠️ Worth the reviewer's eye: the dispatch card stated "react/utils/i18n.ts has no train overlap" and treated `app-shell/utils/index.ts` as the overlapping one. On the stale-merge-base file list **both** appear; on the content measurement the app-shell judgement is right and the react one is right for a different reason than stated. I followed the measurement. For the record, the app-shell hunk sits ~25 lines from the inline copy (the re-export block, not the signature), so a swap there would most likely **not** have conflicted either — I still left it alone, because the rule was file-granular and app-shell is also #4024's in-flight package. Only that file's doc comment is touched there; nothing else in app-shell.

## Q3-A — `disabled` accepts the predicate string

`BaseSchema.disabled` is now `boolean | string`, on exactly the `visible` evidence one slot over: `SchemaRenderer.tsx:466` evaluates it through the same `evaluateCondition` (`(condition: string | boolean | undefined, context?) =` `> boolean`), and the `disabledOn?: string` sibling exists for the same reason. The asymmetry was accidental.

## Casts dropped — the census is now closed

`SchemaRenderer.expressions.test.tsx` `:132`/`:141` (the two `disabled` casts) and `SchemaRenderer.aria.test.tsx:59` (the `ariaLabel` cast) are gone, and both files' `BaseSchema` imports went with them. The expressions header explicitly said "drop them when that lands" — this is that landing. A new aria case pins a keyed label carrying `params`, the limb the withdrawn spelling rejected.

Of the six `as BaseSchema` casts PR #4593's census recorded, this card's ruled widenings close the three that were this gap. The remaining three are the other classes that census identified and are untouched: `components/__tests__/html-anchor-links.test.tsx:33` (a `Record< string, unknown >` spread), and `plugin-dashboard`'s two #4548 narrowing casts.

## The consumer sweep found a real defect — `@object-ui/components`

Declaring the vocabulary honestly is what surfaced it, and a downstream `type-check` sweep is what caught it, not a test. `packages/components/src/renderers/form/toggle.tsx` is one of the few renderers that writes `aria-label` ITSELF instead of relying on SchemaRenderer's `resolveAriaProps`, and it forwarded the value raw:

```tsx
aria-label={schema.ariaLabel}
```

Under `string | KeyedI18nLabel` that stops type-checking against `Toggle`'s `aria-label: string | undefined`. It now resolves. Invoked directly, the raw forward emitted `aria-label="[object Object]"` — announced verbatim by a screen reader.

**My first prediction about this was wrong, and the test header records that rather than being quietly rewritten.** I predicted the harm would show through `SchemaRenderer`. It does not: SchemaRenderer injects its own already-resolved `aria-label` via `...ariaProps` (`SchemaRenderer.tsx:599` + `:625`), and this renderer spreads `{...props}` AFTER its own attribute, so the resolved value always wins and the raw expression is shadowed. A SchemaRenderer-driven test is therefore **green in both directions** — vacuous, and it would have shipped looking like proof. The discriminating case invokes the registered renderer directly via `ComponentRegistry.get('toggle')`, and that one measured, verbatim:

```
Expected the element to have attribute:
  aria-label="Close dialog"
Received:
  aria-label="[object Object]"
```

Both paths are kept in `packages/components/src/__tests__/toggle-aria-label-keyed.test.tsx` and each is labelled for what it can and cannot show.

## ⛔ Q1-B — STOPPED. The premise measured false on both halves.

The ruling made Q1-B conditional: *"the bridge's invocation context can know the locale AND re-translates on locale change — if measured otherwise, STOP and report."* Measured otherwise, so no bridge code is touched here.

**(a) The call path, and who calls it.** `SpecBridge.transformListView` (`SpecBridge.ts:38`) → `transform()` (`:30`) → `return bridge(spec, this.context)` (`:34`) → `bridgeListView` (`bridges/list-view.ts:166`), sites `:180` and `:224`. `BridgeContext` (`spec-bridge/types.ts:12-20`) declares exactly `user?`, `variables?`, `objectDefs?` — **no locale field**.

An exhaustive grep for `SpecBridge|bridgeListView|bridgeFormView|transformListView|transformFormView` across all of `packages/` and `apps/` finds **zero production callers**. Every reference is the module itself, the barrel re-export (`spec-bridge/index.ts`, `react/src/index.ts:14`), or a test — five suites under `react/src/spec-bridge/__tests__/` plus `plugin-grid/src/__tests__/specBridgeExportFormats.test.tsx:73`. Every in-repo construction is `new SpecBridge()` or `new SpecBridge({ user: … })`. It is a published API surface with no in-repo consumer.

**(b) Can it know the locale? No.** The display-locale channel is `useDisplayLocale()` — `packages/i18n/src/useDisplayLocale.ts:53`, a React **hook** composed of two further context hooks (`useLocalization`, `useObjectTranslation`). `bridgeListView` is a plain function invoked from a plain class method, not a component render. Rules of hooks, not a style preference.

**(c) Does a locale change re-run it? No.** `SpecBridge` assigns `context` once in its constructor to a mutable field and reads it at call time. There is no memoization, no React subscription, no invalidation channel; `updateContext()` (`:47`) has zero callers. `transform()` returns a plain object, so a resolved string is frozen into it at transform time.

So even if `BridgeContext` gained `locale?: string`, resolving at the bridge would bake one audience's language into the node tree with no re-translation channel — the freeze the ruling named as a stop condition. The spec's own resolver doc warns about this class of defect in as many words: the `locale` parameter is *"positional rather than optional so that a producer cannot silently ship one audience's language to every audience by forgetting an argument — the defect #6761 records"*.

`BaseSchema.label` and `.description` therefore stay `string` (which is the ruling), and the two `list-view.ts` sites are unchanged. **#4580's Q1-B blocker is NOT cleared by this PR** — the seat's report carries the measured alternative (read-time resolution in the renderer against `useDisplayLocale()`, which is how every other localized read site in this repo already works) and the tension that makes it a real question rather than a mechanical follow-up: read-time resolution requires the renderer to accept an inline map in `schema.label`, i.e. the `BaseSchema.label` widening Q1-B deliberately declined.

## Red-first — predictions written into the test header before the run

`packages/types/src/__tests__/base-schema-label-vocabulary.test.ts`, the sibling of #4593's `base-schema-visible-predicate.test.ts`. Against `origin/main` (`52d878a3b`), `tsc -p packages/types/tsconfig.test.json` reported, verbatim:

```
base-schema-label-vocabulary.test.ts(103,27): error TS2305: Module '"../base"' has no exported member 'KeyedI18nLabel'.
base-schema-label-vocabulary.test.ts(120,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
base-schema-label-vocabulary.test.ts(130,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
base-schema-label-vocabulary.test.ts(143,3): error TS2322: Type '{ key: string; defaultValue: string; }' is not assignable to type 'string'.
base-schema-label-vocabulary.test.ts(149,3): error TS2322: Type '{ key: string; defaultValue: string; params: { name: string; }; }' is not assignable to type 'string'.
base-schema-label-vocabulary.test.ts(161,3): error TS2322: Type 'string' is not assignable to type 'boolean | undefined'.
```

Post-fix: clean, exit 0.

**One prediction was half wrong, and it is left standing in the header rather than rewritten to match.** I predicted `assertionAriaLabel` and `assertionKeyedShape` would both report TS2344 pre-fix; only `assertionKeyedShape` (120) did — TypeScript suppresses the cascade once the import is an error type, so `assertionAriaLabel` (126) reported nothing. That is why the header flagged those two as non-independent evidence *in advance*: a pin whose pre-fix silence is a compiler artifact proves nothing on its own, and the load-bearing reds are the other four.

Every `Equal` is **invariant**, for the reason #4593 spelled out and this card inherits: a `satisfies`-style or one-way `extends` check is vacuous for a widening **in both directions** — the narrow `string` is assignable to the wide `string | KeyedI18nLabel`, so a widening that never happened and a widening that overshot to `any` would both stay green. `BaseSchema`'s `[key: string]: any` makes the overshoot live, not hypothetical.

## must-not-change

- **`label` / `description` stay `string`** — pinned, not merely left alone. `assertionLabel` and `assertionDescription` are the Q1-B ruling written down: the only two pins in the file expected green *pre*-fix, and a future card that "fixes" the bridge defect by widening `BaseSchema.label` turns them red on purpose. Confirmed in the published `.d.ts`: `label?: string`, `description?: string`, unchanged.
- Reverse verification: fix removed with `git checkout origin/main -- PATHS` (never `git stash` — shared `refs/stash`), the pins re-reported the same errors, then restored from a patch file and verified **byte-identical by sha256** across all 7 tracked files.
- Control-byte and NBSP self-scan clean over every touched file including the untracked test.

## Per-package grading — measured

Both trees built with `dist/` and `*.tsbuildinfo` cleared, then every published `.d.ts` compared file-by-file.

| Package | `.d.ts` files differing | What changed | Grade |
|---|---|---|---|
| `@object-ui/types` | 4 of 54 | `base.d.ts` (+`KeyedI18nLabel`, two widened unions, evidence comments), `index.d.ts` (+the export) — **plus 2 zod files that are order-only, see below** | **minor** |
| `@object-ui/react` | 1 of 63 | `utils/i18n.d.ts` — `resolveKeyedI18nLabel`'s parameter names the type instead of inlining it | **patch** |
| `@object-ui/layout` | 1 of 8 | `NavigationRenderer.d.ts` — same, for `resolveLabel` | **patch** |
| `@object-ui/app-shell` | 1 of 416 | `utils/index.d.ts` — **doc comment only**; the inline copy is deliberately not swapped | **patch** |
| `@object-ui/components` | — | no declaration change (the renderer module exports nothing); the change is runtime | **patch** |

`types` is **minor** by position analysis, not assumption: the diff ADDS an exported name and ADDS members to unions on two authored-input-dominant properties. It removes nothing, and nothing that type-checked before stops doing so — the #4593/#4586/#4591 shape. `react` / `layout` are **patch** because the type is *structurally identical*: naming a shape is a spelling change in the `.d.ts`, not a contract change. `app-shell` is **patch** under the "grade patch if the published `.d.ts` changes at all" rule — flagged plainly because no consumer can observe a comment, so a reviewer who would rather drop that entry has my measurement to do it with.

Never major (major tracks `@objectstack`).

### The two zod `.d.ts` diffs are build nondeterminism, not this change

`types/zod/complex.zod.d.ts` and `types/zod/index.zod.d.ts` differ between the two builds. They are **identical as a multiset of lines** (verified by sorting both and comparing hashes) — pure key-ORDER churn in tsc's zod inference, of the `priority: { medium, critical, low, high }` reordering kind. Neither mentions `KeyedI18nLabel`; no zod `.d.ts` in the package does. I checked rather than waved it away because an unexplained diff in a published declaration is exactly what a grading claim must not contain.

## Verification

- **Tests**: repo-root `vitest run --maxWorkers=2` over the radius (react, components, types, layout, app-shell) — **603 files, 5947 passed, 1 skipped**. Touched suites re-run separately, green.
- **Downstream type-check sweeps, PREFIX filter** (= the *consumers*, the direction that matters for a widening): `...@object-ui/types` → **77/77 packages**, `...@object-ui/react` → **67/67**. Zero errors. The first run of that sweep is what found the `toggle.tsx` defect above.
- **eslint over all 10 touched files**: 0 errors. On the 6 files that existed before, **51 → 50 problems, net −1** (the two retired inline copies each drop a `no-explicit-any`; `KeyedI18nLabel`'s own `params` adds one back).
- **Reverse verification**: sources reverted with `git checkout PATHS` at the fork point (never `git stash` — shared `refs/stash`), the six pins re-reported the same errors, then restored and verified **byte-identical by sha256** on all six files.
- **All 11 local gates pass**: control-bytes, phantom-dependencies, changeset-presence, changeset-no-major, changeset-fixed, type-check-coverage, lint-coverage, spec-symbol-derivation, i18n-call-site-keys, i18n-en-drift, doc-links. Control-byte and NBSP self-scan clean over every touched file including untracked ones.

## Filed, not fixed

**#4605** — the zod mirror in `packages/types/src/zod/base.zod.ts` still declares `visible` and `disabled` as `z.boolean()` and `ariaLabel` as `z.string()`, now narrower than the TypeScript declarations they mirror. `visible` has been drifted since PR #4593; this PR adds the other two. Measured as observation-class: nothing enforces it on the render path (`core`'s `validateSchema` is hand-written and imports only the TS type; `SchemaRenderer`'s `__DEV__` check only sets a `data-obj-schema-invalid` attribute), but `@object-ui/types/zod` is a published validator that would reject spellings the published types invite. Widening it is a contract decision — especially for `ariaLabel`, where the keyed object must not be confused with the spec's inline map — so it is filed rather than guessed at here.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
