### PR TITLE
fix(mobile): SpecResponsiveConfig derives from its claim's source (#4598)

### DIFF
--- a/.changeset/mobile-responsive-config-derives-4598.md
+++ b/.changeset/mobile-responsive-config-derives-4598.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/mobile': patch
+---
+
+`SpecResponsiveConfig` is now the spec's responsive config rather than a hand copy that said it was
+
+`useResponsiveConfig.ts` declared its own interface over the four responsive keys — `breakpoint`, `hiddenOn`, `columns`, `order` — renamed off the schema's own symbol (`ResponsiveConfig` → `SpecResponsiveConfig`) and introduced by a comment that said it mirrored `ResponsiveConfigSchema`. There was no import, no `z.infer`, and no other compile-time tie: the sentence was the entire connection.
+
+It agreed with the schema key-for-key on the day it was measured, and that is the reason this is worth a line rather than the reason it is not. The agreement was maintained by nobody and checked by nothing, while the comment told every later reader the copy was canonical — so a key added or retired upstream would have moved the two apart in silence, with the comment still vouching for the copy. `ViewNavigationConfig` read exactly like this until it had drifted on `mode`.
+
+The type is now re-exported from `@object-ui/types`, which publishes it imported straight from `@objectstack/spec/ui`. That package is already this one's only runtime dependency, so the binding costs no new dependency edge, and `@object-ui/core`'s `ResponsiveProtocol` already reaches the same type the same way.
+
+Nothing consumers see changes: the published name is the same, and the type it resolves to is invariant-equal to the interface that was there before — the entry `.d.ts` is byte-identical. What changes is where the four keys come from. They are now whatever the schema declares, so the next schema release reaches this package's authors as a type error instead of as silent disagreement.
+
+A new parity test pins the chain to `@objectstack/spec/ui` directly, because the one link the re-export cannot see is `@object-ui/types` re-growing a hand copy of its own.

--- a/packages/mobile/src/__tests__/responsive-config-spec-parity.test.ts
+++ b/packages/mobile/src/__tests__/responsive-config-spec-parity.test.ts
@@ -1,0 +1,168 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/mobile`'s `SpecResponsiveConfig` IS the schema's type (objectui#4598).
+ *
+ * The card: `useResponsiveConfig.ts` hand-declared an interface over the four
+ * responsive keys, renamed off the schema's own symbol (`ResponsiveConfig` →
+ * `SpecResponsiveConfig`), under a comment saying it mirrored
+ * `ResponsiveConfigSchema`. Nothing tied the two together — no import, no
+ * `z.infer`, no compile-time reference of any kind. It AGREED key-for-key when
+ * it was filed, which is the whole point: the agreement was maintained by
+ * nobody and checked by nothing, and the comment already told the next session
+ * the copy was canonical. `ViewNavigationConfig` (objectui#4588) read exactly
+ * like that until it had drifted on `mode`.
+ *
+ * The fix re-exports the type from `@object-ui/types` — this package's only
+ * runtime dependency, which publishes it imported straight from
+ * `@objectstack/spec/ui` — so no new dependency edge was needed and the
+ * published name did not move.
+ *
+ * ── Why this file exists, given the fix is a re-export ──────────────────────
+ *
+ * `scripts/check-spec-symbol-derivation.mjs` stops reporting the declaration
+ * because after the fix there is no declaration: rule 2 collects type aliases,
+ * interfaces, enums and variables, and a bare `export type { … }` is none of
+ * those. That is the right outcome — the hand copy is gone — but the gate got
+ * there by seeing nothing, not by following the chain. It cannot: the binding
+ * now runs mobile → `@object-ui/types` → `@objectstack/spec/ui`, and the gate
+ * reads one package at a time.
+ *
+ * So the middle link is the part no gate covers, and it is the only place this
+ * fix can still rot: if `@object-ui/types` ever replaces its re-export with a
+ * hand copy of its own, mobile inherits the copy silently and every check in
+ * the repo stays green. The assertions below are written against
+ * `@objectstack/spec/ui` DIRECTLY for that reason — pinning against
+ * `@object-ui/types` would compare the import to itself and pass no matter what
+ * either package did.
+ *
+ * The type-level half runs under `tsc -p tsconfig.test.json` (this package's
+ * `type-check`), so a re-grown copy fails the build rather than waiting for a
+ * reviewer. `@objectstack/spec` is a devDependency here — a test may import it;
+ * the published `.d.ts` may not, which is why the source re-exports through
+ * `@object-ui/types` instead of reaching for the spec directly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ResponsiveConfigSchema, type ResponsiveConfig } from '@objectstack/spec/ui';
+import type { SpecResponsiveConfig } from '../index';
+
+/* eslint-disable @typescript-eslint/no-unused-vars --
+ * The pins below are compile-time assertions: `tsc` is their only consumer and
+ * they are erased before anything runs, so "unused" is what a passing one looks
+ * like. The repo's `no-unused-vars` ignores `^_` for ARGUMENTS only, which is
+ * why `packages/types`' equivalent file carries the same warnings; scoping the
+ * exemption to this file keeps it from becoming a repo-wide hole.
+ */
+
+/* ── Type-level helpers ──────────────────────────────────────────────────── */
+
+/**
+ * Invariant equality. `extends` in one direction — or a `satisfies` check —
+ * would accept a NARROWING, so a copy that quietly dropped `order` would still
+ * pass. That is the exact drift this card is about, so the pin has to be
+ * invariant to say anything at all.
+ */
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/* ── The binding itself ──────────────────────────────────────────────────── */
+
+/**
+ * The whole card in one line: what `@object-ui/mobile` publishes under
+ * `SpecResponsiveConfig` and what the schema declares are ONE type. Red on the
+ * day any link in mobile → `@object-ui/types` → `@objectstack/spec/ui` is
+ * replaced by a copy, however byte-identical it starts out.
+ */
+type _IsExactlyTheSchemaType = Expect< Equal< SpecResponsiveConfig, ResponsiveConfig > >;
+
+/**
+ * The four keys `ResponsiveConfigSchema` declares. Adding one here to make a
+ * local read compile is the defect rather than the fix: the key has to exist in
+ * the schema first, or the platform refuses metadata that declares it.
+ */
+type SchemaDeclaredKeys = 'breakpoint' | 'hiddenOn' | 'columns' | 'order';
+
+type _KeysAreExactlyTheSchemaFour = Expect< Equal< keyof SpecResponsiveConfig, SchemaDeclaredKeys > >;
+
+/** Every key is optional on the authoring side — none of the four is required. */
+type _AllFourAreOptional = Expect<
+  Equal< SpecResponsiveConfig, Partial< SpecResponsiveConfig > >
+>;
+
+/**
+ * The breakpoint vocabulary is the schema's six, reached through the same
+ * chain. `NonNullable` keeps this pointed at which names exist rather than at
+ * the `| undefined` the optionality puts there on purpose.
+ */
+type _BreakpointVocabularyIsTheSchemaSix = Expect<
+  Equal<
+    NonNullable< SpecResponsiveConfig['breakpoint'] >,
+    'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+  >
+>;
+
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/* ── Runtime half ────────────────────────────────────────────────────────── */
+
+// The type-level assertions above are erased before anything runs, so the
+// checks below re-ask the same questions of the schema VALUE. Without them this
+// file could keep compiling while the runtime contract moved underneath it.
+describe('SpecResponsiveConfig is the spec responsive config (objectui#4598)', () => {
+  const schemaKeys = Object.keys(ResponsiveConfigSchema.shape).sort();
+
+  it('reads the four declared keys off the schema itself', () => {
+    expect(schemaKeys, 'could not read ResponsiveConfigSchema.shape').toEqual(
+      ['breakpoint', 'columns', 'hiddenOn', 'order'],
+    );
+  });
+
+  it('accepts a fully-populated config, and the schema agrees', () => {
+    const full: SpecResponsiveConfig = {
+      breakpoint: 'md',
+      hiddenOn: ['xs', 'sm'],
+      columns: { xs: 12, sm: 6, lg: 4 },
+      order: { xs: 2, lg: 1 },
+    };
+
+    expect(Object.keys(full).sort()).toEqual(schemaKeys);
+    expect(ResponsiveConfigSchema.parse(full)).toEqual(full);
+  });
+
+  it('accepts the empty config — every key is optional', () => {
+    const empty: SpecResponsiveConfig = {};
+    expect(ResponsiveConfigSchema.parse(empty)).toEqual({});
+  });
+
+  it('carries `2xl`, the breakpoint a five-name copy would be missing', () => {
+    const widest: SpecResponsiveConfig = { breakpoint: '2xl', columns: { '2xl': 3 } };
+    expect(ResponsiveConfigSchema.parse(widest)).toEqual(widest);
+  });
+
+  it('refuses a breakpoint outside the schema enum', () => {
+    const bad: SpecResponsiveConfig = {
+      // @ts-expect-error 'xxl' is not one of the six declared breakpoint names
+      breakpoint: 'xxl',
+    };
+    expect(() => ResponsiveConfigSchema.parse(bad)).toThrow();
+  });
+
+  it('refuses a key the schema does not declare', () => {
+    const bad: SpecResponsiveConfig = {
+      breakpoint: 'lg',
+      // @ts-expect-error `visibleOn` is not a declared responsive key
+      visibleOn: ['xs'],
+    };
+    // The schema is strict, so the undeclared key is a runtime rejection too —
+    // the type and the schema refuse the same authored metadata.
+    expect(() => ResponsiveConfigSchema.parse(bad)).toThrow();
+  });
+});

--- a/packages/mobile/src/useResponsiveConfig.ts
+++ b/packages/mobile/src/useResponsiveConfig.ts
@@ -9,10 +9,30 @@
 import { useMemo } from 'react';
 import { useBreakpoint } from './useBreakpoint';
 import { resolveResponsiveValue } from './breakpoints';
-import type { BreakpointName } from '@object-ui/types';
+import type { BreakpointName, SpecResponsiveConfig } from '@object-ui/types';
 
 /**
- * Spec-aligned ResponsiveConfig (mirrors @objectstack/spec ResponsiveConfigSchema).
+ * The responsive layout config this hook consumes — re-exported, not re-declared
+ * (objectui#4598).
+ *
+ * This used to be a hand-written interface over the same four keys, under a
+ * comment asserting it mirrored the schema. The assertion was true on the day it
+ * was written and maintained by nobody after that: the interface named the
+ * schema without ever referring to it, so a key added or retired upstream would
+ * have moved the two apart in silence. `ViewNavigationConfig` (objectui#4588)
+ * read the same way until it had drifted on `mode`.
+ *
+ * `@object-ui/types` — already this package's only runtime dependency — publishes
+ * the schema's own type at `index.ts` under this exact name, imported from
+ * `@objectstack/spec/ui` rather than copied. Re-exporting it costs no new
+ * dependency edge and leaves the published name unchanged, so the four keys are
+ * now whatever the schema says they are rather than whatever this file last
+ * remembered. `@object-ui/core`'s `ResponsiveProtocol` already binds through the
+ * same re-export.
+ *
+ * `responsive-config-spec-parity.test.ts` pins the chain to the schema itself,
+ * because the one link this file cannot see is `@object-ui/types` re-growing a
+ * hand copy of its own.
  *
  * @example
  * ```ts
@@ -23,16 +43,7 @@ import type { BreakpointName } from '@object-ui/types';
  * };
  * ```
  */
-export interface SpecResponsiveConfig {
-  /** The target breakpoint for this config */
-  breakpoint?: BreakpointName;
-  /** Breakpoints on which the component is hidden */
-  hiddenOn?: BreakpointName[];
-  /** Grid column counts per breakpoint (1-12) */
-  columns?: Partial<Record<BreakpointName, number>>;
-  /** Display order per breakpoint */
-  order?: Partial<Record<BreakpointName, number>>;
-}
+export type { SpecResponsiveConfig };
 
 /**
  * Resolved responsive state from a SpecResponsiveConfig.

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -497,7 +497,6 @@ const CLAIM_DEBT = {
   "@object-ui/i18n": ["SpecDateFormat", "SpecLocaleConfig", "SpecNumberFormat", "SpecPluralRule"],
   "@object-ui/core": ["ResultDialogFieldSpec", "ViewDataConfig"],
   "@object-ui/app-shell": ["RecordLookupBinding"],
-  "@object-ui/mobile": ["SpecResponsiveConfig"],
   "@object-ui/plugin-view": ["ROW_HEIGHT_OPTIONS"],
   "@object-ui/react": ["DensityModeValue"],
 };


### PR DESCRIPTION
Fixes #4598

`packages/mobile/src/useResponsiveConfig.ts:26` hand-declared an interface over the schema's four responsive keys, renamed off the schema's own symbol (`ResponsiveConfig` → `SpecResponsiveConfig`), introduced by a comment saying it mirrored `ResponsiveConfigSchema`. There was no import, no `z.infer`, and no other compile-time tie — the sentence was the entire connection.

It agreed with the schema key-for-key on the day #4592's census measured it, and that is the reason to fix it rather than the reason to leave it: the agreement was maintained by nobody and checked by nothing, while the comment already told the next session the copy was canonical. `ViewNavigationConfig` (#4588) read exactly like this until it had drifted on `mode`.

## The two measurements

**(a) Does `@object-ui/mobile` directly depend on `@objectstack/spec`? — No.**

`packages/mobile/package.json` `dependencies` is `{ "@object-ui/types": "workspace:*" }` and nothing else. `@objectstack/spec` sits in **devDependencies** (`^17.0.0-rc.6`) — usable by a test, not by a published `.d.ts`. `node scripts/check-phantom-dependencies.mjs` passes on this branch, which is the arbiter confirming both halves.

**(b) Does a package mobile already depends on publish a spec-bound `ResponsiveConfig`? — Yes.**

`packages/types/src/index.ts:1223`:

```ts
export type {
  ResponsiveConfig as SpecResponsiveConfig,
  BreakpointName as SpecBreakpointName,
} from '@objectstack/spec/ui';
```

Bound by import, not copied — verified at the source rather than inferred from the name. Two supporting measurements:

- The `BreakpointName` that `useResponsiveConfig.ts` **already** imported from `@object-ui/types` is itself spec-bound: `packages/types/src/mobile.ts:19` imports it from `@objectstack/spec/ui` and re-exports it at `:32`. The file was already reaching the spec through this edge for one of its two types.
- The sibling census hit, `@object-ui/core`'s `ResolvedResponsiveConfig` (`packages/core/src/protocols/ResponsiveProtocol.ts:48`), is **not** spec-bound — it is a local shape over a locally declared `BreakpointKey` union (`:27`), so it was not the edge to use. But `ResponsiveProtocol.ts:21` consumes `SpecResponsiveConfig` **from `@object-ui/types`** — the sibling package already does exactly what this card asks mobile to do.

## Branch taken: 1 of the ruling's hierarchy

An existing dependency edge offers a spec-bound export, so the type is re-exported through it. No new dependency edge; branch 2 not needed, branch 3 (honest comment + `CLAIM_ALLOW`) not reached, and the open question about adding `@objectstack/spec` to mobile's dependencies does not arise.

```ts
import type { BreakpointName, SpecResponsiveConfig } from '@object-ui/types';
export type { SpecResponsiveConfig };
```

`src/index.ts:24` is unchanged, so the published name does not move.

## Red-first: the ratchet, verbatim

Predictions were written before the run (P1–P5). With the source fix applied and the ledger line **still present**, `node scripts/check-spec-symbol-derivation.mjs` exited 1:

```text
❌  a spec-alignment claim has nothing behind it:

    • @object-ui/mobile lists 1 symbol in CLAIM_DEBT whose spec-alignment claim is gone — `SpecResponsiveConfig`.
      Delete them from scripts/check-spec-symbol-derivation.mjs (`--claim-ledger` regenerates
      the block) so the symbol cannot re-acquire an unbacked claim silently (and close #4592 once the ledger is empty).
```

After deleting `"@object-ui/mobile": ["SpecResponsiveConfig"]` — the only edit to `scripts/**`, one line, zero insertions:

```text
✅  spec symbol derivation: 1251 files scanned against 4834 spec export names; 13 declared dialects, 3 untriaged collisions in 1 packages.
✅  spec alignment claims: 2 declared deliberate copies, 26 unbacked claims in 6 packages.
```

Baseline on `origin/main` was `27 unbacked claims in 7 packages`; the mobile key held exactly one symbol, so the key disappears. **No `CLAIM_ALLOW` entry was added** — the claim is structurally backed, which was the ruling's test for branch 1.

### How the gate goes quiet, stated honestly

It stops reporting because after the fix there is no declaration to report: `scanFileForClaims` collects type aliases, interfaces, enums and variables, and a bare `export type { … }` is none of those. That is the right outcome — the hand copy is gone — but the gate got there by seeing nothing, not by following the chain. It cannot: the binding runs mobile → `@object-ui/types` → `@objectstack/spec/ui` and the gate reads one package at a time. That is precisely why the test below is the load-bearing pin.

## The type pin, and why it is not vacuous

An `Equal< … >` against `@object-ui/types`' `SpecResponsiveConfig` **would** be vacuous — same import, true by construction. The new `packages/mobile/src/__tests__/responsive-config-spec-parity.test.ts` pins against `@objectstack/spec/ui`'s `ResponsiveConfig` **directly**, which is falsifiable: it reds if `@object-ui/types` ever replaces its re-export with a hand copy of its own — drift one link up the chain, the only place this fix can still rot, and the one link no gate covers. A `satisfies` or one-way `extends` check would be vacuous here for a different reason: it accepts a narrowing, so a copy that silently dropped `order` would still pass. Hence invariant `Equal< A, B >`. The spec import is legal because `@objectstack/spec` is a devDependency and tests are not published.

**Reverse verification** — re-grew the hand copy with `order` dropped (`git checkout`/file-copy, sha256-verified restore; never `git stash`). `tsc -p tsconfig.test.json`:

```text
src/__tests__/responsive-config-spec-parity.test.ts(76,40): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/__tests__/responsive-config-spec-parity.test.ts(85,45): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/__tests__/responsive-config-spec-parity.test.ts(123,7): error TS2353: Object literal may only specify known properties, and 'order' does not exist in type 'SpecResponsiveConfig'.
src/useResponsiveConfig.ts(95,26): error TS2339: Property 'order' does not exist on type 'SpecResponsiveConfig'.
```

Both type pins red, plus the runtime half's full-config literal, plus — unpredicted — the hook's own body, which reads `config.order`. Restore verified: `packages/mobile/src/useResponsiveConfig.ts: OK` against the recorded sha256, and typecheck green again.

## Runtime must-not-change

`useResponsiveConfig`'s body is untouched — this is a types-only change. **There is no existing test suite for `useResponsiveConfig`**: `packages/mobile/src/__tests__/` held only `breakpoints.test.ts`, `gesture-spec-parity.test.tsx` and `useBreakpoint.test.ts`. Saying that plainly rather than reporting a green suite that does not exist, and not inventing a behavior suite for a types-only change. The new file's runtime half covers the config surface against the schema value, which is what keeps the erased type assertions honest.

## `.d.ts` analysis — patch

Built both ways with `dist/` and `tsconfig.tsbuildinfo` cleared:

- `dist/index.d.ts` — **byte-identical**, `diff` clean. The published entry surface does not move.
- `dist/useResponsiveConfig.d.ts` — `export interface SpecResponsiveConfig { … }` becomes `export type { SpecResponsiveConfig }` re-exported from `@object-ui/types`. Same name, same position in the signature `useResponsiveConfig(config?: SpecResponsiveConfig)`.

Position analysis on the shape itself: a throwaway probe asserted `Equal< OldPublishedShape, SpecResponsiveConfig > ` where `OldPublishedShape` is `origin/main`'s interface copied verbatim — it compiled, so the two are **invariant-equal**, not merely mutually assignable. A pure re-binding with an identical published shape ⇒ **patch**. Not analyze (no surface change), never major.

## Verification

- Build closure: `pnpm --workspace-concurrency=2 --filter "@object-ui/mobile^..." --filter "@object-ui/mobile" build` — green (`packages/types`, `packages/mobile`).
- `pnpm --filter "@object-ui/mobile" type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — exit 0.
- Repo-root `pnpm exec vitest run --maxWorkers=2 packages/mobile/src scripts/__tests__/check-spec-symbol-derivation.test.ts` — **5 files, 49 tests passed**. The gate's own suite is included because this PR edits its source of truth.
- Downstream consumer sweep, **PREFIX direction** (`...@object-ui/mobile` = dependents): `turbo run type-check --filter="...@object-ui/mobile" --concurrency=2` — **48 tasks successful, 48 total**.
- Gate battery, all PASS: `check-control-bytes`, `check-phantom-dependencies`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`, `check-type-check-coverage`, `check-lint-coverage`, `check-spec-symbol-derivation`, `check-doc-links`.
- eslint **net-zero**: 0 errors, 18 warnings, all pre-existing and none in a file this PR touches. The four type pins would otherwise have added `no-unused-vars` warnings — the repo config ignores `^_` for arguments only, which is why `packages/types`' equivalent parity file carries seven of them. Scoped an `eslint-disable`/`enable` pair around the pin block with the reason, rather than widening the shared config.
- Control-byte self-scan (`grep -naP` over every touched file including untracked) — clean.

## Scope

Four files: `packages/mobile/src/useResponsiveConfig.ts`, the new test, the changeset, and the single ledger-line deletion in `scripts/check-spec-symbol-derivation.mjs`. Nothing else in `scripts/**`. #4597's surfaces (i18n spec-formatters, `packages/types/src/views.ts`, their ledger lines), `packages/types` `base.ts`, react, layout, app-shell, and `content/docs/releases/**` are untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_