### PR TITLE
fix(types,i18n): doc comments stop citing retired @objectstack/spec symbols (#4597)

### DIFF
--- a/.changeset/dangling-spec-citations-4597.md
+++ b/.changeset/dangling-spec-citations-4597.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/types": patch
+"@object-ui/i18n": patch
+---
+
+Doc comments no longer cite `@objectstack/spec` symbols the pinned spec has retired
+
+Eight exported declarations carried a doc comment claiming alignment with a
+`@objectstack/spec` symbol that `17.0.0-rc.6` does not export — four locale
+formatting shapes in `@object-ui/i18n` (`SpecPluralRule`, `SpecDateFormat`,
+`SpecNumberFormat`, `SpecLocaleConfig`) and four activity-feed shapes in
+`@object-ui/types` (`FieldChangeEntry`, `Mention`, `Reaction`,
+`RecordSubscription`). A citation that points at nothing is worse than a stale
+one: the next reader cannot tell whether the protocol retired the symbol,
+renamed it, or never had it.
+
+Measuring all eight against the published registry answered that question, and
+the answer was not "these names never existed". Every one was a real export the
+protocol retired on purpose, and every local key set was faithful to the schema
+it named. The feed four left `@objectstack/spec/data` in the `16.0.0` major,
+when the feed surface was replaced by the data API over `sys_comment` /
+`sys_activity`. The i18n four left `@objectstack/spec/ui` in `17.0.0-rc.6`
+itself — they were still present in `rc.5` — retired under ADR-0049
+enforce-or-remove because no authorable shape carried them and nothing ever
+parsed them.
+
+Each comment now records that provenance, including the version the symbol left
+and what (if anything) replaced it, so the shapes read as declarations these
+packages own rather than as a view onto a protocol type. Type shapes, runtime
+behaviour and exports are unchanged — the published `.d.ts` files differ only in
+comment text, which is why this is graded `patch`.

--- a/packages/i18n/src/utils/spec-formatters.ts
+++ b/packages/i18n/src/utils/spec-formatters.ts
@@ -7,23 +7,38 @@
  */
 
 /**
- * @object-ui/i18n - Spec-aligned i18n utilities
+ * @object-ui/i18n - locale formatting helpers
  *
- * Runtime consumers for @objectstack/spec v2.0.7 i18n types:
- * - PluralRuleSchema → resolvePlural()
- * - DateFormatSchema → formatDateSpec()
- * - NumberFormatSchema → formatNumberSpec()
- * - LocaleConfigSchema → applyLocaleConfig()
+ * ## Provenance of the four shapes below (objectui#4597)
+ *
+ * They were authored against `@objectstack/spec/ui`, which exported
+ * `PluralRuleSchema`, `DateFormatSchema`, `NumberFormatSchema` and
+ * `LocaleConfigSchema` up to and including 17.0.0-rc.5. The pinned
+ * 17.0.0-rc.6 removed all four under ADR-0049 enforce-or-remove
+ * (objectstack#5055, maintainer ruling 2026-08-06): they carried no key on any
+ * authorable shape and nothing ever parsed them, so the vocabulary was retired
+ * rather than given a door. The key sets here were faithful to the retired
+ * schemas — this is a retirement, not a drift.
+ *
+ * Nothing in the pinned protocol models locale formatting today, so the
+ * interfaces below are declarations this package owns outright, not a view onto
+ * a protocol type. The retirement note records that localisation returns as
+ * authorable metadata through a new ADR — "the formatter that reads a
+ * LocaleConfig first, the vocabulary second" — so re-derive these at that point
+ * instead of assuming they still track anything upstream.
  *
  * @module spec-formatters
  */
 
 // ============================================================================
-// PluralRuleSchema Consumer
+// Plural rules
 // ============================================================================
 
 /**
- * Spec-aligned PluralRule (mirrors @objectstack/spec PluralRuleSchema).
+ * Plural forms for a single translation key, in CLDR categories.
+ *
+ * Local shape — authored against the protocol's `PluralRuleSchema`, retired in
+ * 17.0.0-rc.6 (see the module doc), so there is nothing upstream to derive from.
  */
 export interface SpecPluralRule {
   /** Translation key */
@@ -81,11 +96,14 @@ export function resolvePlural(
 }
 
 // ============================================================================
-// DateFormatSchema Consumer
+// Date formatting
 // ============================================================================
 
 /**
- * Spec-aligned DateFormat (mirrors @objectstack/spec DateFormatSchema).
+ * Date/time formatting options passed through to `Intl.DateTimeFormat`.
+ *
+ * Local shape — authored against the protocol's `DateFormatSchema`, retired in
+ * 17.0.0-rc.6 (see the module doc), so there is nothing upstream to derive from.
  */
 export interface SpecDateFormat {
   dateStyle?: 'full' | 'long' | 'medium' | 'short';
@@ -95,7 +113,7 @@ export interface SpecDateFormat {
 }
 
 /**
- * Format a date using @objectstack/spec DateFormatSchema configuration.
+ * Format a date using a {@link SpecDateFormat} configuration.
  *
  * @example
  * ```ts
@@ -124,11 +142,15 @@ export function formatDateSpec(
 }
 
 // ============================================================================
-// NumberFormatSchema Consumer
+// Number formatting
 // ============================================================================
 
 /**
- * Spec-aligned NumberFormat (mirrors @objectstack/spec NumberFormatSchema).
+ * Number formatting options passed through to `Intl.NumberFormat`.
+ *
+ * Local shape — authored against the protocol's `NumberFormatSchema`, retired
+ * in 17.0.0-rc.6 (see the module doc), so there is nothing upstream to derive
+ * from.
  */
 export interface SpecNumberFormat {
   style?: 'currency' | 'percent' | 'decimal' | 'unit';
@@ -140,7 +162,7 @@ export interface SpecNumberFormat {
 }
 
 /**
- * Format a number using @objectstack/spec NumberFormatSchema configuration.
+ * Format a number using a {@link SpecNumberFormat} configuration.
  *
  * @example
  * ```ts
@@ -170,11 +192,15 @@ export function formatNumberSpec(
 }
 
 // ============================================================================
-// LocaleConfigSchema Consumer
+// Locale configuration
 // ============================================================================
 
 /**
- * Spec-aligned LocaleConfig (mirrors @objectstack/spec LocaleConfigSchema).
+ * One locale's formatting defaults, resolved by `applyLocaleConfig()`.
+ *
+ * Local shape — authored against the protocol's `LocaleConfigSchema`, retired
+ * in 17.0.0-rc.6 (see the module doc), so there is nothing upstream to derive
+ * from.
  */
 export interface SpecLocaleConfig {
   /** BCP 47 language code (e.g., 'en-US', 'zh-CN') */
@@ -190,7 +216,7 @@ export interface SpecLocaleConfig {
 }
 
 /**
- * Apply a LocaleConfigSchema to configure i18n formatting defaults.
+ * Apply a {@link SpecLocaleConfig} to configure i18n formatting defaults.
  * Returns resolved formatting functions bound to the locale config.
  *
  * @example

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -328,9 +328,18 @@ export interface ActivityEntry {
 }
 
 // ============================================================================
-// Feed / Chatter Protocol Types
-// Aligned with @objectstack/spec FeedItemSchema, MentionSchema, ReactionSchema,
-// FieldChangeEntrySchema, RecordSubscriptionSchema
+// Feed / Chatter timeline types
+//
+// Provenance (objectui#4597): `@objectstack/spec/data` exported `FeedItemSchema`,
+// `MentionSchema`, `ReactionSchema`, `FieldChangeEntrySchema` and
+// `RecordSubscriptionSchema` through 15.1.1. The 16.0.0 major removed the whole
+// feed surface, directing consumers to the data API over `sys_comment` /
+// `sys_activity` — reactions and threaded replies are fields on `sys_comment`.
+// `FeedItemType` and `FeedFilterMode` were deliberately KEPT as live activity-
+// timeline config, which is why the import below still resolves.
+//
+// So the interfaces in this section are shapes this package owns: the protocol
+// no longer models them, and there is nothing upstream left to derive from.
 // ============================================================================
 
 /**
@@ -348,7 +357,10 @@ export type { FeedItemType };
 
 /**
  * FeedItem — A single item in the unified activity feed.
- * Aligned with @objectstack/spec FeedItemSchema.
+ *
+ * Local shape; its cited `FeedItemSchema` went with the 16.0.0 feed removal
+ * (see the section banner). Only `type` is still protocol-bound, through the
+ * `FeedItemType` import above.
  */
 export interface FeedItem {
   /** Unique identifier */
@@ -393,7 +405,13 @@ export interface FeedItem {
 
 /**
  * FieldChangeEntry — A single field change within a feed item.
- * Aligned with @objectstack/spec FieldChangeEntrySchema.
+ *
+ * Local shape; its cited `FieldChangeEntrySchema` went with the 16.0.0 feed
+ * removal (see the section banner). The pinned protocol's nearest surviving
+ * shape is `FieldChangeSchema` in `@objectstack/spec/kernel`, but that is a
+ * different thing — change tracking keyed `path` / `originalValue` /
+ * `currentValue` / `changedBy` / `changedAt`, with none of the display keys a
+ * timeline row needs. Do not re-point this at it.
  */
 export interface FieldChangeEntry {
   /** Field API name */
@@ -412,7 +430,10 @@ export interface FieldChangeEntry {
 
 /**
  * Mention — An @mention within a feed item.
- * Aligned with @objectstack/spec MentionSchema.
+ *
+ * Local shape; its cited `MentionSchema` went with the 16.0.0 feed removal (see
+ * the section banner), and no shape of this meaning survives under any other
+ * name in the pinned protocol.
  */
 export interface Mention {
   /** Mention target type */
@@ -429,7 +450,10 @@ export interface Mention {
 
 /**
  * Reaction — An emoji reaction on a feed item.
- * Aligned with @objectstack/spec ReactionSchema.
+ *
+ * Local shape; its cited `ReactionSchema` went with the 16.0.0 feed removal
+ * (see the section banner). Reactions are now persisted as fields on
+ * `sys_comment` rather than modelled as their own protocol shape.
  */
 export interface Reaction {
   /** Emoji identifier (e.g. '👍', '❤️', '🎉') */
@@ -444,7 +468,11 @@ export interface Reaction {
 
 /**
  * RecordSubscription — Notification subscription state for a record.
- * Aligned with @objectstack/spec RecordSubscriptionSchema.
+ *
+ * Local shape; its cited `RecordSubscriptionSchema` went with the 16.0.0 feed
+ * removal (see the section banner). The `Subscription` shapes the pinned
+ * protocol still exports are unrelated — realtime transport channels, event
+ * subscriptions and app billing — so none of them is a replacement.
  */
 export interface RecordSubscription {
   /** Record ID */

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -466,24 +466,33 @@ export const CLAIM_ALLOW = {
 //   - derive it (`z.infer< typeof SpecX >`, `SpecAuthoredInput< … >`, or an
 //     import of the spec type) — the claim becomes structural and the entry goes;
 //   - keep the copy and move it to CLAIM_ALLOW with the reason it exists;
-//   - or delete the claim from the comment, because it was never true. Eight of
-//     these name a spec symbol the installed spec does not export at all
-//     (`DateFormatSchema`, `NumberFormatSchema`, `PluralRuleSchema`,
-//     `LocaleConfigSchema`, `FieldChangeEntrySchema`, `MentionSchema`,
-//     `ReactionSchema`, `RecordSubscriptionSchema`) — a canonical-sounding
-//     pointer to nothing, which is the planted premise in its purest form. The
-//     failure message names them, so the next reader does not have to re-measure.
+//   - or delete the claim from the comment, because it is not true here.
+//
+// Eight entries left by that last route in objectui#4597 — the i18n formatters'
+// four and views.ts's four, which cited `DateFormatSchema`, `NumberFormatSchema`,
+// `PluralRuleSchema`, `LocaleConfigSchema`, `FieldChangeEntrySchema`,
+// `MentionSchema`, `ReactionSchema` and `RecordSubscriptionSchema`. Measuring
+// them answered the question #4597 left open, and the answer was NOT "these
+// names never existed": all eight were real exports the protocol RETIRED, and
+// each local key set was faithful to the schema it named. The feed four went
+// from `@objectstack/spec/data` in the 16.0.0 major (feed surface replaced by
+// the data API over `sys_comment` / `sys_activity`); the i18n four went from
+// `@objectstack/spec/ui` in 17.0.0-rc.6 itself — present through rc.5 — under
+// ADR-0049 enforce-or-remove (objectstack#5055). Their comments now record that
+// provenance instead of vouching for a symbol the pinned spec has dropped.
+//
+// Worth keeping for whoever measures the next batch: "the installed spec does
+// not export it" does not distinguish a name that never existed from one the
+// protocol retired on purpose, and the fix differs. Read the spec's CHANGELOG
+// and its own retirement notes before concluding a citation was always wrong.
 const CLAIM_DEBT_ISSUE = 4592;
 const CLAIM_DEBT = {
   "@object-ui/types": [
-    "FieldChangeEntry",
     "ListViewExportOptions",
     "ManagedByBucket",
-    "Mention",
     "ObjectFormSchema",
     "ObjectFormSection",
     "PageRegionWidth",
-    "Reaction",
     "RecordActivityComponentProps",
     "RecordChatterComponentProps",
     "RecordComponentAriaProps",
@@ -491,10 +500,8 @@ const CLAIM_DEBT = {
     "RecordHighlightsComponentProps",
     "RecordPathComponentProps",
     "RecordRelatedListComponentProps",
-    "RecordSubscription",
     "SubmitBehavior",
   ],
-  "@object-ui/i18n": ["SpecDateFormat", "SpecLocaleConfig", "SpecNumberFormat", "SpecPluralRule"],
   "@object-ui/core": ["ResultDialogFieldSpec", "ViewDataConfig"],
   "@object-ui/app-shell": ["RecordLookupBinding"],
   "@object-ui/plugin-view": ["ROW_HEIGHT_OPTIONS"],


### PR DESCRIPTION
Fixes #4597

Eight exported declarations carried a doc comment claiming alignment with an `@objectstack/spec` symbol that the pinned `17.0.0-rc.6` does not export. This PR measures each one, rewrites the eight comments to state the true relationship, and deletes exactly those eight entries from the `CLAIM_DEBT` ledger.

**Comments and ledger only.** No type shape, no runtime behaviour, no export changed.

## The headline finding: these are retirements, not phantoms

#4597 explicitly left open "whether the spec ever exported these names", and flagged that the fix differs per case. Measured against the published registry, the answer is that **all eight were real exports the protocol retired on purpose**, and **every local key set was faithful to the schema it named**. None of them was ever a wrong citation — they are citations that expired.

That distinction changes the fix. A name that never existed wants the sentence deleted; a name the protocol retired wants the retirement recorded, so the next reader does not re-run this measurement to rediscover it.

## Measurement

Arbiter for (a) is the hardened gate's own `specExportNames` enumeration, reused verbatim: **16 subpaths, 4834 export names** in the installed `@objectstack/spec@17.0.0-rc.6`. All eight are absent from that set.

(c) The registry was reachable. `npm view @objectstack/spec dist-tags` gives `latest = 16.1.0`, `rc = 17.0.0-rc.6` — so **the installed pin is the newest published version**. Nothing here is "premature, awaiting a pin bump"; there is no newer spec to bump to.

| # | cited symbol | (a) in rc.6 | (b) same meaning, other rc.6 name | (c) published history |
|---|---|---|---|---|
| 1 | `PluralRuleSchema` | absent | no — only `PLURAL_TO_SINGULAR` / `singularToPlural`, string inflection helpers | in `spec/ui` through **rc.5**; also in 2.0.7 and `latest` 16.1.0 |
| 2 | `DateFormatSchema` | absent | no — zero export names contain "DateFormat"; zero files mention `dateStyle`/`timeStyle` | same |
| 3 | `NumberFormatSchema` | absent | no — only `AutonumberFormat*` (autonumber field format strings); zero files mention `minimumFractionDigits`/`useGrouping` | same |
| 4 | `LocaleConfigSchema` | absent | no — `TranslationConfigSchema` is app-level (`defaultLocale`/`supportedLocales`/`fallbackLocale`); an internal `ResolveOptions` carries `locale`+`fallbackChain` only | same |
| 5 | `FieldChangeEntrySchema` | absent | **adjacent but different** — `FieldChangeSchema` in `spec/kernel` keys `path`/`originalValue`/`currentValue`/`changedBy`/`changedAt`: **zero** key overlap with the local six | in `spec/data` through **15.1.1**; gone from 16.0.0-rc.0 onward, incl. `latest` |
| 6 | `MentionSchema` | absent | no — zero export names contain "Mention" | same |
| 7 | `ReactionSchema` | absent | no — zero names contain "Reaction"; zero `.d.ts` files mention `emoji` | same |
| 8 | `RecordSubscriptionSchema` | absent | no — `SubscriptionSchema` (realtime transport), `EventSubscriptionSchema`, `AppSubscriptionSchema` (billing) are unrelated meanings | same |

### Corroboration from the spec's own shipped files

Not inference — rc.6 states both retirements itself.

`CHANGELOG.md`, on the feed four:

> `@objectstack/spec/data` — `FeedItemSchema`/`FeedItem`, `FeedActorSchema`/`FeedActor`, `MentionSchema`/`Mention`, `ReactionSchema`/`Reaction`, `FieldChangeEntrySchema`/`FieldChangeEntry`, `FeedVisibility`, `RecordSubscriptionSchema`/`RecordSubscription`, `SubscriptionEventType` … → **removed**. … reactions and threaded replies are fields on `sys_comment`. … `FeedItemType` and `FeedFilterMode` are **kept** (live UI activity-timeline config).

`src/ui/i18n.zod.ts` — still shipped in rc.6, no longer exported from any entrypoint — on the i18n four:

> **REMOVED.** `I18nObjectSchema` / `PluralRuleSchema` / `NumberFormatSchema` / `DateFormatSchema` / `LocaleConfigSchema` — per ADR-0049 enforce-or-remove (#5055, maintainer ruling 2026-08-06 …). They had no carrier key anywhere, were unreachable in that same BFS, and were never parsed in objectstack / objectui / cloud outside this file's own tests.

The same note records the return path, which the reworded module doc now carries: localisation comes back through a new ADR, "the formatter that reads a `LocaleConfig` first, the vocabulary second".

Shape fidelity confirms these were honest mirrors while they lasted: `SpecPluralRule` matches 16.1.0's `PluralRuleSchema` key-for-key (`key`/`zero`/`one`/`two`/`few`/`many`/`other`), and the same holds for the other three.

## Disposition

All eight land on the ruling's third branch — nothing under any name in the pinned spec — so each claim sentence was reworded to stop vouching for a dropped symbol while keeping what is true. No symbol could take the "bind to the real name" branch (none exists to bind to), and none takes the "await the pin bump" branch (rc.6 is already newest). **8 of 8 resolved**, so this closes the card.

Two judgement calls worth review:

1. **`FieldChangeEntry` explicitly warns against `FieldChangeSchema`.** It is the one near-miss in the set — same words, adjacent meaning, and a plausible re-point for the next agent. Its keys are disjoint from the local shape, so re-pointing would be wrong; the comment now says so by name, since a silent absence is what invites the mistake.
2. **Same-file collateral, deliberately included.** `spec-formatters.ts`'s module header advertised "Runtime consumers for @objectstack/spec **v2.0.7** i18n types" and four `// XSchema Consumer` section banners; `views.ts` had a section banner asserting the same alignment for four of the eight, plus `FeedItem`'s own comment citing `FeedItemSchema` (also removed in 16.0.0). Fixing the eight declarations while leaving those in place would have left the files self-contradictory and the planted premise intact on the same symbols. All are inside the card's two files.

`FeedItem` is worth calling out separately: it is **not** in the ledger and rule 2 cannot see it, because it references `FeedItemType` — a live spec import — while *citing* `FeedItemSchema`, which is gone. The tie test is symbol-agnostic, so any declaration with a tie to any spec symbol can cite a retired one and pass. Filed as an observation on the gate rather than fixed here, since `scripts/**` rule logic is #4592's surface.

## Red-first, then green (ratchet #5)

Baseline on `origin/main` — green:

```
✅  spec alignment claims: 2 declared deliberate copies, 26 unbacked claims in 6 packages.
```

Comment fixes applied, ledger entries still present — **red, verbatim**:

```
❌  a spec-alignment claim has nothing behind it:

    • @object-ui/types lists 4 symbols in CLAIM_DEBT whose spec-alignment claim is gone — `FieldChangeEntry`, `Mention`, `Reaction`, `RecordSubscription`.
      Delete them from scripts/check-spec-symbol-derivation.mjs (`--claim-ledger` regenerates
      the block) so the symbol cannot re-acquire an unbacked claim silently (and close #4592 once the ledger is empty).

    • @object-ui/i18n lists 4 symbols in CLAIM_DEBT whose spec-alignment claim is gone — `SpecDateFormat`, `SpecLocaleConfig`, `SpecNumberFormat`, `SpecPluralRule`.
      Delete them from scripts/check-spec-symbol-derivation.mjs (`--claim-ledger` regenerates
      the block) so the symbol cannot re-acquire an unbacked claim silently (and close #4592 once the ledger is empty).
```

After the surgical deletion — green, counts dropped as predicted:

```
✅  spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages.
```

`26 → 18` claims, `6 → 5` packages: the `@object-ui/i18n` key is now empty and removed entirely. The deletion matches `--claim-ledger`'s regenerated block exactly.

**On the reverse-verification direction** — the template's before-green/after-red does not apply here, and reporting it as if it did would be false. This gate was green before (the debt was declared) and is green after (the debt shrank); the **red is the intermediate state**, which is precisely ratchet #5's job. Removing the fix with `git checkout origin/main -- …` restores the original `26 in 6 packages` green, and the fix was restored sha256-verified. No `git stash` at any point.

## Comment-only proof for the published .d.ts

Doc comments on exported declarations do land in the published `.d.ts`, so this is a real published-artifact change and is graded accordingly. Both packages were rebuilt with `dist/` and tsbuildinfo cleared, on each side of the change:

| file | raw `.d.ts` diff | comments stripped | stripped sha256 |
|---|---|---|---|
| `packages/types/dist/views.d.ts` | 39 lines | **0 lines** | `48efa09249f6418912c5cafa69744358` both sides |
| `packages/i18n/dist/utils/spec-formatters.d.ts` | 70 lines | **0 lines** | `2f5a04ba995d63fec1026b40e52c7dff` both sides |

Stripping re-prints each `.d.ts` through the TypeScript printer with `removeComments`. Identical output on both sides is the proof that no declaration, member, modifier or export moved — the #4604 plugin-grid precedent.

**Grading:** `patch` for `@object-ui/types` and `@object-ui/i18n`. The presence gate demands an entry for both; the published artifact genuinely changes (comment text), so the empty-frontmatter exemption would be wrong here. Never `major`.

## Verification

- `node scripts/check-spec-symbol-derivation.mjs` — green, counts above
- Full gate battery, all **PASS**: `check-control-bytes`, `check-phantom-dependencies`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`, `check-type-check-coverage`, `check-lint-coverage`, `check-spec-symbol-derivation`, `check-doc-links`, `check-i18n-call-site-keys`, `check-i18n-en-drift`
- `pnpm exec vitest run --maxWorkers=2 packages/i18n packages/types` plus `scripts/__tests__/check-spec-symbol-derivation.test.ts` (the ledger's own source of truth) — **79 files / 1236 tests passed**; the gate's suite **20/20** on its own run
- `turbo run type-check --filter='...@object-ui/types'` — **77/77 tasks successful**; `--filter='...@object-ui/i18n'` — **69/69**. Prefix filter, i.e. each package **and everything that depends on it** (downstream consumers), 43 and 35 packages in scope
- ESLint on the three touched sources: **8 warnings / 0 errors on both sides**, net zero (all pre-existing `no-explicit-any` / unused-import in `views.ts`)
- Control-byte self-scan over every touched and untracked file, beyond the gate's own surface — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_