### PR TITLE
chore(tooling): a spec-alignment claim is judged by the symbols it cites, not by incidental ties (#4607)

### DIFF
--- a/.changeset/citation-aware-claim-tie-4607.md
+++ b/.changeset/citation-aware-claim-tie-4607.md
@@ -1,0 +1,29 @@
+---
+---
+
+Tooling only — a CI guard and its own test suite, no package source, so no release.
+
+`check:spec-symbols` rule 2 flags an exported declaration whose doc comment claims
+`@objectstack/spec` alignment while the declaration references nothing spec-bound.
+That tie test was symbol-AGNOSTIC: it asked whether the declaration referenced ANY
+spec-bound identifier, so a claim about symbol X passed on an incidental reference
+to an unrelated symbol Y.
+
+`FeedItem` (packages/types/src/views.ts) was the live specimen (objectui#4607). It
+cited `FeedItemSchema`, removed from `@objectstack/spec/data` in the 16.0.0 major,
+and never appeared in a single gate run — purely because one member is typed
+`FeedItemType`, the one feed symbol that removal kept. It sat four lines from a
+section banner making the same claim, in the same file as four declarations that
+WERE flagged, and it was found by reading the file rather than by any run.
+
+The tie is now judged against the symbols the claim CITES: when a claim names
+symbols and the installed spec exports none of them, the declaration is flagged
+whatever else it references. A claim naming at least one live symbol stays governed
+by the tie test unchanged — a claim-vs-tie mismatch among LIVE symbols is a
+documented non-goal, since it needs a name-relatedness allowance for the legitimate
+`type: FeedItemType` shape.
+
+Measured repo-wide with the sharpened rule: the hidden population is zero. Of the
+three declarations that carry a claim and pass the tie test, two cite only live
+symbols and one is mixed, so no verdict in the tree changes and no ledger entry
+moves (CLAIM_ALLOW 2, CLAIM_DEBT 18 in 5 packages, before and after).

--- a/scripts/__tests__/check-spec-symbol-derivation.test.ts
+++ b/scripts/__tests__/check-spec-symbol-derivation.test.ts
@@ -53,10 +53,29 @@ function withFixture<T>(files: Record<string, string>, run: (paths: Record<strin
   }
 }
 
-/** The spec export names the fixtures below refer to. `ReactionSchema` is deliberately absent. */
+/**
+ * The spec export names the fixtures below refer to, faithful to the pinned
+ * 17.0.0-rc.6: every name a fixture CITES and the spec really exports is here,
+ * and the retired ones (`ReactionSchema`, `FeedItemSchema`, …) are deliberately
+ * absent.
+ *
+ * Faithfulness became load-bearing in objectui#4607 and was not before. Until
+ * then `specNames` was consulted only to decorate the message of a declaration
+ * that had ALREADY failed the tie test, so a name missing from this map changed
+ * nothing; now it decides whether the tie test applies at all. `ListView` is the
+ * instance — cited by two green fixtures below, really exported by
+ * `@objectstack/spec/ui`, and absent from this map until #4607 measured it.
+ * Omitting a live name here makes a green fixture red for a reason that exists
+ * nowhere but this map.
+ */
 const SPEC_NAMES = new Map<string, Set<string>>([
   ['NavigationConfig', new Set(['@objectstack/spec/ui'])],
   ['NavigationConfigSchema', new Set(['@objectstack/spec/ui'])],
+  ['ListView', new Set(['@objectstack/spec/ui'])],
+  // Kept when the 16.0.0 major removed the rest of the feed surface — the live
+  // half of the objectui#4607 specimen.
+  ['FeedItemType', new Set(['@objectstack/spec/data'])],
+  ['FeedFilterMode', new Set(['@objectstack/spec/data'])],
 ]);
 
 const scan = (file: string) => scanFileForClaims(file, SPEC_NAMES);
@@ -309,6 +328,215 @@ export type { InternalNavigationConfig };
   });
 });
 
+// ── The tie is judged against the symbols the claim CITES (objectui#4607) ────
+
+/**
+ * The tie test above is symbol-AGNOSTIC: it asks whether the declaration
+ * references ANY spec-bound identifier. So a claim about symbol X passed on an
+ * incidental reference to unrelated symbol Y — and the more spec-integrated a
+ * declaration was, the weaker the check on its prose became.
+ *
+ * `FeedItem` (packages/types/src/views.ts) was the live specimen: it cited
+ * `FeedItemSchema`, removed from `@objectstack/spec/data` in the 16.0.0 major,
+ * and never appeared in a single gate run because one member is typed
+ * `FeedItemType` — the one feed symbol the removal kept. Measured on
+ * origin/main@92876f097 before this change, the scanner returned `0 findings`
+ * for the fixture below; it returns the finding asserted here after it.
+ */
+describe('a claim citing only symbols the spec does not export is flagged despite a live tie', () => {
+  /** The objectui#4607 specimen: dangling citation, live tie to a DIFFERENT symbol. */
+  const FEED_ITEM_SPECIMEN = `
+import type { FeedItemType } from '@objectstack/spec/data';
+
+/**
+ * FeedItem — A single item in the unified activity feed.
+ * Aligned with @objectstack/spec FeedItemSchema.
+ */
+export interface FeedItem {
+  id: string;
+  type: FeedItemType;
+  body?: string;
+  createdAt: string;
+}
+`;
+
+  it('(a) flags the specimen, and names the symbol the spec has dropped', () => {
+    withFixture({ 'views.ts': FEED_ITEM_SPECIMEN }, ({ 'views.ts': file }) => {
+      const found = scan(file);
+      expect(found).toHaveLength(1);
+      expect(found[0].name).toBe('FeedItem');
+      expect(found[0].phrase.toLowerCase()).toBe('aligned with');
+      expect(found[0].dangling).toEqual(['FeedItemSchema']);
+    });
+  });
+
+  it('(a) the tie itself is real — only the CITATION differs from a green declaration', () => {
+    // The discrimination proof's other half, and the reason this rule is not
+    // just "flag anything with a retired name in the comment": the fixture is
+    // byte-identical to the one above except that the claim cites the symbol the
+    // declaration is actually tied to. Same import, same member, same claim
+    // phrase — green.
+    withFixture(
+      { 'views.ts': FEED_ITEM_SPECIMEN.replace('FeedItemSchema', 'FeedItemType') },
+      ({ 'views.ts': file }) => expect(scan(file)).toEqual([])
+    );
+  });
+
+  it('(c) a claim citing a LIVE symbol the declaration is tied to stays green', () => {
+    withFixture(
+      {
+        'tied.ts': `
+import type { NavigationConfig } from '@objectstack/spec/ui';
+
+/** Navigation node. Aligned with @objectstack/spec NavigationConfig. */
+export interface TiedNavigationNode {
+  navigation?: NavigationConfig;
+  columns?: string[];
+}
+`,
+      },
+      ({ 'tied.ts': file }) => expect(scan(file)).toEqual([])
+    );
+  });
+
+  it('(d) a claim citing a LIVE symbol while tied to a DIFFERENT live one stays green', () => {
+    // The KNOWN NON-GOAL recorded on objectui#4607. This is a claim-vs-tie
+    // MISMATCH, not a dangling citation: both symbols exist, so the claim points
+    // at something real and the reader can check it. Judging these needs a
+    // name-relatedness allowance for the legitimate `type: FeedItemType` shape,
+    // where citation and tie are genuinely different-but-related symbols — a
+    // different instrument, deliberately not built here.
+    withFixture(
+      {
+        'mismatch.ts': `
+import type { NavigationConfig } from '@objectstack/spec/ui';
+
+/** List view node. Aligned with @objectstack/spec ListView. */
+export interface MismatchedListViewNode {
+  navigation?: NavigationConfig;
+  columns?: string[];
+}
+`,
+      },
+      ({ 'mismatch.ts': file }) => expect(scan(file)).toEqual([])
+    );
+  });
+
+  it('a claim naming no symbol at all is still governed by the tie test', () => {
+    withFixture(
+      {
+        'unnamed.ts': `
+import type { NavigationConfig } from '@objectstack/spec/ui';
+
+/** Navigation node, aligned with @objectstack/spec. */
+export interface UnnamedClaimNode {
+  navigation?: NavigationConfig;
+}
+`,
+      },
+      ({ 'unnamed.ts': file }) => expect(scan(file)).toEqual([])
+    );
+  });
+
+  it('with no spec export set to check against, the rule stays out of the way', () => {
+    // "Dangling" is a statement about the installed spec. Given no export set,
+    // every citation would read as dangling and the rule would flag every claim
+    // in the repo at once — a verdict manufactured from ignorance of the spec.
+    withFixture({ 'views.ts': FEED_ITEM_SPECIMEN }, ({ 'views.ts': file }) => {
+      expect(scanFileForClaims(file, new Map())).toEqual([]);
+    });
+  });
+});
+
+// ── The retirement-record idiom must never re-trigger the gate (#4597/#4606) ─
+
+describe('(b) an honest provenance note is not a claim', () => {
+  /**
+   * PR #4606 rewrote eight comments that cited retired spec symbols so they
+   * RECORD the retirement instead of vouching for the symbol. That idiom names
+   * the dead symbol on purpose — it is the provenance a reader needs — so a rule
+   * that turned on it would punish exactly the fix it is meant to produce. What
+   * makes these green is that they claim nothing: no alignment phrase sits next
+   * to a `@objectstack/spec` mention, so there is no claim to have anything
+   * behind.
+   */
+  it('the @object-ui/i18n idiom — "authored against the protocol\'s X, retired in …"', () => {
+    withFixture(
+      {
+        'spec-formatters.ts': `
+/**
+ * Plural forms for a single translation key, in CLDR categories.
+ *
+ * Local shape — authored against the protocol's \`PluralRuleSchema\`, retired in
+ * 17.0.0-rc.6 (see the module doc), so there is nothing upstream to derive from.
+ */
+export interface SpecPluralRule {
+  key: string;
+  zero?: string;
+  one?: string;
+  other: string;
+}
+`,
+      },
+      ({ 'spec-formatters.ts': file }) => expect(scan(file)).toEqual([])
+    );
+  });
+
+  it('the @object-ui/types idiom — "its cited X went with the 16.0.0 feed removal"', () => {
+    withFixture(
+      {
+        'views.ts': `
+import type { FeedItemType } from '@objectstack/spec/data';
+
+/**
+ * FeedItem — A single item in the unified activity feed.
+ *
+ * Local shape; its cited \`FeedItemSchema\` went with the 16.0.0 feed removal
+ * (see the section banner). Only \`type\` is still protocol-bound, through the
+ * \`FeedItemType\` import above.
+ */
+export interface FeedItem {
+  id: string;
+  type: FeedItemType;
+  createdAt: string;
+}
+`,
+      },
+      ({ 'views.ts': file }) => expect(scan(file)).toEqual([])
+    );
+  });
+
+  /**
+   * The fixtures above are a copy of the idiom; these two are the REAL FILES.
+   * A copy can drift from what shipped, and the guarantee #4607 owes #4606 is
+   * about the tree, not about a paraphrase of it: the sharpened rule must be
+   * green on the very comments that card wrote.
+   *
+   * If one of these ever fails, read it as a defect in the RULE first. The
+   * rewordings are the honest retirement record the guard exists to produce, so
+   * a rule that flags them has turned on its own remedy.
+   */
+  const REWORDED_BY_4606 = [
+    '../../packages/types/src/views.ts',
+    '../../packages/i18n/src/utils/spec-formatters.ts',
+  ];
+
+  it.each(REWORDED_BY_4606)('stays green on the real tree: %s', (rel) => {
+    expect(scan(path.join(here, rel))).toEqual([]);
+  });
+
+  it('and those files still carry the provenance the pin is about', () => {
+    // Deleting the comments outright would satisfy the pin above while throwing
+    // away the record. Pin the idiom's load-bearing phrases too.
+    const views = fs.readFileSync(path.join(here, REWORDED_BY_4606[0]), 'utf8');
+    const i18n = fs.readFileSync(path.join(here, REWORDED_BY_4606[1]), 'utf8');
+    expect(views).toContain('went with the 16.0.0 feed removal');
+    expect(views).toContain('`FeedItemType` and `FeedFilterMode` were deliberately KEPT');
+    expect(i18n).toContain('authored against the protocol');
+    expect(i18n).toContain('retired in');
+  });
+});
+
 // ── The claim detector itself ────────────────────────────────────────────────
 
 describe('findClaim', () => {
@@ -350,6 +578,47 @@ describe('findClaim', () => {
 
   it('every documented pattern is case-insensitive', () => {
     for (const pattern of CLAIM_PATTERNS) expect(pattern.flags, String(pattern)).toContain('i');
+  });
+
+  it("takes cited symbols from the mention's own sentence, not the next one", () => {
+    // Live case: `ActionDef` (packages/core/src/actions/ActionRunner.ts) reads
+    // "…mirroring `@objectstack/spec`'s `ActionSchema`. Open key set on a data
+    // bag is correct". `Open` opens the NEXT sentence and is prose, not a
+    // citation. This was harmless while `symbols` only decorated the failure
+    // message; since objectui#4607 it decides whether the tie test applies, so a
+    // scraped prose word could make a green declaration read as citing nothing
+    // but symbols the spec does not export.
+    const claim = findClaim(
+      "/** A declared metadata contract mirroring `@objectstack/spec`'s `ActionSchema`. Open key set on a data bag is correct. */"
+    );
+    expect(claim).not.toBeNull();
+    expect(claim!.symbols).toEqual(['ActionSchema']);
+  });
+
+  it('still reads a symbol followed by a dotted member path', () => {
+    // The truncation must not fire on `ListView.navigation` — the `.` there is a
+    // member separator, not a sentence end, which is why the test is
+    // "terminator followed by whitespace or end", the same shape the
+    // claim/mention sentence test uses.
+    expect(findClaim('/** Aligned with @objectstack/spec ListView.navigation. */')!.symbols).toEqual(['ListView']);
+  });
+
+  it('KNOWN LIMITATION: a sentence that never terminates still donates prose words', () => {
+    // `PageNodeSchema` (packages/types/src/layout.ts) is the live instance: the
+    // claim line ends without punctuation and the next line continues "This is
+    // the SDUI NODE, not the authored page DOCUMENT", so `normalizeDoc` joins
+    // them into ONE sentence and the window scrapes three prose words.
+    //
+    // Pinned rather than fixed, and it costs nothing today: the claim also cites
+    // `PageSchema`, which the spec DOES export, so the declaration is governed
+    // by the tie test exactly as before. It would only matter for a comment that
+    // cites no real symbol at all AND has an incidental live tie — measured at
+    // zero instances repo-wide (objectui#4607). Tightening it further means
+    // deciding what a citation LOOKS like, which is a different instrument.
+    const claim = findClaim(
+      '/**\n * Aligned with @objectstack/spec PageSchema\n *\n * This is the SDUI NODE, not the authored page DOCUMENT\n */'
+    );
+    expect(claim!.symbols).toEqual(['PageSchema', 'This', 'SDUI', 'NODE']);
   });
 });
 

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -99,6 +99,44 @@
  *     so "Aligned with @objectstack/spec ReactionSchema" on a `<ReactionPicker>`
  *     is a statement about what it draws.
  *
+ * ── The tie is judged against the symbols the claim CITES (objectui#4607) ────
+ * The tie test above asks "does this declaration reference ANY spec-bound
+ * identifier". That question is symbol-AGNOSTIC, so a claim about symbol X
+ * passed on an incidental reference to an unrelated symbol Y.
+ *
+ * The measured specimen: `FeedItem` (packages/types/src/views.ts) carried
+ * "Aligned with @objectstack/spec FeedItemSchema" while `FeedItemSchema` had
+ * been removed from `@objectstack/spec/data` in the 16.0.0 major — and it never
+ * appeared in a single gate run, purely because one member is typed
+ * `FeedItemType`, the one feed symbol that survived the removal. It sat four
+ * lines from a section banner making the same claim, in the same file as four
+ * declarations that WERE flagged, and it was found by reading the file rather
+ * than by any run of this script.
+ *
+ * Note the asymmetry, which is what made it expensive: the more spec-integrated
+ * a declaration is, the weaker the check on its prose became. A fully
+ * hand-written fork got its claim scrutinised; one importing a single live spec
+ * type for one member did not.
+ *
+ * Hence the fourth precision rule, deliberately narrow:
+ *
+ *   When the claim NAMES symbols and EVERY one of them is absent from the
+ *   installed spec's export set, the declaration is flagged whatever else it
+ *   references. A tie to a DIFFERENT symbol is not something behind THIS claim.
+ *
+ * Two limits on it, both deliberate:
+ *
+ *   - A claim naming at least one LIVE symbol stays governed by the tie test
+ *     above, unchanged. A claim citing live `A` while tied to live `B` is a
+ *     claim-vs-tie MISMATCH, and judging those is a KNOWN NON-GOAL of this rule
+ *     (objectui#4607). It would need a name-relatedness allowance for the
+ *     legitimate `type: FeedItemType` shape — where the citation and the tie are
+ *     genuinely different-but-related symbols — and that allowance is a
+ *     different instrument, not a tightening of this one.
+ *   - Given no spec export set to check against, nothing can be known to dangle
+ *     and this rule stays out of the way entirely. A verdict fabricated from
+ *     ignorance of the spec would flag every citation in the repo at once.
+ *
  * `SpecAuthoredInput` (@object-ui/react) counts as derivation evidence by name:
  * its entire purpose is to bind a local type to a spec schema's authoring input.
  *
@@ -685,7 +723,12 @@ const SPEC_MENTION = "@objectstack/spec";
  * Does this doc comment CLAIM alignment with `@objectstack/spec`?
  * Returns `{ phrase, distance, symbols }` or null. `symbols` are the capitalised
  * identifiers named right after a spec mention — the symbols the claim points
- * at, used only to sharpen the failure message.
+ * at.
+ *
+ * `symbols` is load-bearing, not decoration: since objectui#4607 it decides
+ * whether the tie test applies at all (a claim every one of whose cited symbols
+ * is absent from the spec is flagged regardless of an incidental tie), as well
+ * as sharpening the failure message it always did.
  */
 export function findClaim(docText) {
   const text = normalizeDoc(docText);
@@ -713,7 +756,18 @@ export function findClaim(docText) {
       for (const m of mentions) {
         // `@objectstack/spec/ui ReactionSchema` — take the identifiers the claim
         // names just after the mention (its subpath included, then skipped).
-        const tail = text.slice(m + SPEC_MENTION.length, m + SPEC_MENTION.length + 48);
+        let tail = text.slice(m + SPEC_MENTION.length, m + SPEC_MENTION.length + 48);
+        // Stop at the end of the SENTENCE, the same discipline the claim/mention
+        // pairing above applies. Without it the window scrapes the capitalised
+        // opening words of the NEXT sentence and reports them as cited symbols:
+        // `ActionDef` (packages/core/src/actions/ActionRunner.ts) reads
+        // "…mirroring `@objectstack/spec`'s `ActionSchema`. Open key set on a
+        // data bag is correct", and `Open` is prose, not a citation. Harmless
+        // while `symbols` only decorated a message; since objectui#4607 it
+        // decides whether the tie test applies, and a claim whose only "cited
+        // symbols" are prose words would read as citing nothing but dangling.
+        const sentenceEnd = tail.search(/[.;!?](?:\s|$)/);
+        if (sentenceEnd !== -1) tail = tail.slice(0, sentenceEnd);
         for (const s of tail.matchAll(/[`'"\s(]([A-Z][A-Za-z0-9_]{2,})\b/g)) symbols.push(s[1]);
       }
       return { phrase: hit[0], distance, symbols: [...new Set(symbols)], text };
@@ -777,11 +831,23 @@ export function scanFileForClaims(file, specNames = new Map()) {
 
     const claim = findClaim(attachedDoc(stmt, text));
     if (!claim) continue;
+
+    const dangling = claim.symbols.filter((s) => !specNames.has(s));
+    // The tie is judged against the symbols the claim CITES (objectui#4607) —
+    // see the header's fourth precision rule. When the claim names symbols and
+    // the spec exports NONE of them, no reference elsewhere in the declaration
+    // can be evidence for THIS claim, so the tie test below is not consulted.
+    // Guarded on a non-empty `specNames`: with no export set to check against,
+    // "dangling" is unknowable and the rule must not manufacture a verdict from
+    // ignorance of the spec.
+    const citesOnlyDanglingSymbols =
+      specNames.size > 0 && claim.symbols.length > 0 && dangling.length === claim.symbols.length;
+
     // `skipLiterals: false` on purpose — rule 1 asks "is this THE spec's symbol",
     // where only a structural position counts. Rule 2 asks the weaker question
     // "does this declaration have ANY compile-time tie to what it claims", and a
     // spec type used on a member is a tie a spec change can still break.
-    if (referencesSpec(stmt, specBindings, false, nameNode)) continue;
+    if (!citesOnlyDanglingSymbols && referencesSpec(stmt, specBindings, false, nameNode)) continue;
 
     const { line } = sf.getLineAndCharacterOfPosition(stmt.getStart(sf));
     findings.push({
@@ -789,7 +855,7 @@ export function scanFileForClaims(file, specNames = new Map()) {
       file,
       line: line + 1,
       phrase: claim.phrase,
-      dangling: claim.symbols.filter((s) => !specNames.has(s)),
+      dangling,
     });
   }
   return findings;


### PR DESCRIPTION
Fixes #4607

## The hole

Rule 2 of `check:spec-symbols` flags an exported declaration whose doc comment claims
`@objectstack/spec` alignment while the declaration references nothing spec-bound. That
tie test was symbol-AGNOSTIC — it asked only

> does this declaration reference **any** identifier bound to a `@objectstack/spec` import?

so a claim about symbol X passed on an incidental reference to an unrelated symbol Y.

`FeedItem` (`packages/types/src/views.ts`) was the live specimen: it cited `FeedItemSchema`,
removed from `@objectstack/spec/data` in the 16.0.0 major, and never appeared in a single
gate run — purely because one member is typed `FeedItemType`, the one feed symbol that
removal kept. It sat four lines from a section banner making the same claim, in the same
file as four declarations that **were** flagged, and it was found by reading the file
rather than by any run of the script.

The asymmetry is what made it expensive: the more spec-integrated a declaration was, the
weaker the check on its prose became. A fully hand-written fork got its claim scrutinised;
one importing a single live spec type for one member did not.

## The rule

> When a claim NAMES symbols and the installed spec exports NONE of them, the declaration
> is flagged whatever else it references. A tie to a DIFFERENT symbol is not something
> behind THIS claim.

Deliberately narrow, per the ruling recorded on #4607:

- a claim naming at least one **live** symbol stays governed by the existing tie test,
  unchanged;
- a claim-vs-tie **mismatch** among live symbols is a documented **non-goal** — it needs a
  name-relatedness allowance for the legitimate `type: FeedItemType` shape, where citation
  and tie are genuinely different-but-related symbols, and that is a different instrument;
- given no spec export set to check against, nothing can be known to dangle and the rule
  stays out of the way entirely, rather than manufacturing a verdict from ignorance of the
  spec.

The failure message keeps its existing shape — the `dangling` list was already rendered
("…and names `X`, which @objectstack/spec does not export"). What changed is that an
incidental live tie no longer suppresses the finding.

## Discrimination proof, verbatim both ways

One fixture (the specimen: claim phrase, citation of a dangling symbol, live tie to a
different symbol via `import` + member use), one spec-name map faithful to the pinned
17.0.0-rc.6 (`FeedItemType` live, `FeedItemSchema` absent — both verified against the
installed package), run through both scanners:

```
CURRENT gate (origin/main 92876f097): 0 finding(s)
```

```
SHARPENED gate (this branch): 1 finding(s)
  FeedItem  line 7  claim: "Aligned with"  dangling: [FeedItemSchema]
```

The current gate provably passes it. Both halves are pinned in the suite, and the green
half of the pair is byte-identical to the red one except for which symbol the claim cites
(`FEED_ITEM_SPECIMEN.replace('FeedItemSchema', 'FeedItemType')`) — so the discrimination is
the citation, not the fixture.

Reverse verification (rule reverted by patch + `git checkout`, tests kept, restored and
sha256-verified identical — no `git stash`):

```
× (a) flags the specimen, and names the symbol the spec has dropped
    AssertionError: expected [] to have a length of 1 but got +0
× takes cited symbols from the mention's own sentence, not the next one
    AssertionError: expected [ 'ActionSchema', 'Open' ] to deeply equal [ 'ActionSchema' ]
 Test Files  1 failed (1)
      Tests  2 failed | 32 passed (34)
```

Exactly the two tests that pin this change go red; every #4592 must-not-change fixture and
every new precision guard stays green without the fix, which is what makes them guards
rather than restatements of the rule.

## Population census, verbatim

Both scanners over the identical file set, diffing raw finding lists rather than the gate
verdict (the verdict hides anything already in the `CLAIM_DEBT` ledger):

```
files scanned:              1251
spec export names:          4834
findings, CURRENT rule:     20
findings, SHARPENED rule:   20
NEWLY FLAGGED (population): 0
NO LONGER FLAGGED:          0
```

**The hidden population is zero.** So that zero is a measurement and not an absence of
firing, here is the surface the sharpened rule newly examines — every exported declaration
carrying a claim that the old tie test waved through:

```
Declarations carrying a spec-alignment claim AND passing the old tie test: 3
  cites no symbol at all:      0   (rule cannot fire - unchanged)
  every cited symbol LIVE:     2   (tie test governs - unchanged, non-goal (d))
  mixed live + dangling:       1   (tie test governs - unchanged)
  ALL cited symbols dangling:  0   [the population this card measures]

  all-cited-live      ActionDef        packages/core/src/actions/ActionRunner.ts:112  cites: [ActionSchema]  dangling: []
  all-cited-live      ActionType       packages/types/src/ui-action.ts:126            cites: [ActionType]    dangling: []
  mixed               PageNodeSchema   packages/types/src/layout.ts:533               cites: [PageSchema, This, SDUI, NODE]  dangling: [This, SDUI, NODE]
```

**Dispositions: none needed.** No instance requires a reword, a `CLAIM_DEBT` entry, or a
`CLAIM_ALLOW` entry — the population is empty, so the `10`-instance STOP condition is not
approached. PR #4606 removed the only known specimen as in-file collateral; this card
closes the hole it demonstrated and confirms the tree has no second one. Nothing under
#4580-round2's in-flight surfaces was read for a verdict or edited: the only files this PR
touches are `scripts/**` plus one changeset.

## Two things the change exposed

Making `symbols` load-bearing surfaced two defects that were invisible while it only
decorated a failure message. Both are fixed here because both are ways this change could
have gone wrong, not scope growth:

1. **The citation window scraped the next sentence.** `ActionDef` reads "…mirroring
   `@objectstack/spec`'s `ActionSchema`. Open key set on a data bag is correct" — and
   `Open` was reported as a cited symbol. Harmless as message decoration; as a rule input
   it is a **new false-positive class**: a claim whose only "citations" are prose words is
   all-dangling, so a green declaration with a live tie would go red with a nonsense
   message. Measured and reproduced before fixing. Symbols are now taken from the
   mention's own sentence — the same discipline the claim/mention pairing already applies —
   and the truncation is a measured no-op on the tree (census above is post-containment;
   `ActionDef` moved from `mixed` to `all-cited-live` with no verdict change). It must not
   fire on `ListView.navigation`, where the `.` is a member separator; pinned.

2. **The suite's spec-name stub omitted `ListView`.** The real spec exports it from
   `@objectstack/spec/ui` (verified). While `specNames` was decoration the omission changed
   nothing; the moment it decides whether the tie test applies, two long-standing green
   fixtures went red for a reason existing nowhere but that map. The map is now faithful to
   rc.6 for every name the fixtures touch, with the reason written at the declaration.

Residual, pinned as a **known limitation** rather than fixed: a claim sentence that never
terminates still donates prose words (`PageNodeSchema` cites `PageSchema, This, SDUI,
NODE`). It costs nothing today — `PageSchema` is live, so the tie test governs — and
tightening it further means deciding what a citation *looks like*, which is a different
instrument. See the open question below.

## The #4606 idiom stays green — pinned against the real tree

PR #4606's rewordings name the dead symbol on purpose; that provenance is the remedy this
guard exists to produce, so a rule that turned on it would punish its own fix. Pinned two
ways:

- copies of both idioms as fixtures — "Local shape — authored against the protocol's
  `PluralRuleSchema`, retired in 17.0.0-rc.6…" and "its cited `FeedItemSchema` went with
  the 16.0.0 feed removal";
- and the **real files**, because a copy can drift from what shipped:
  `packages/types/src/views.ts` and `packages/i18n/src/utils/spec-formatters.ts` are
  scanned as they exist on `main` and must return no finding, plus a check that they still
  carry the load-bearing provenance phrases so the pin cannot be satisfied by deleting the
  comments. Both green. What makes them green is that they claim nothing: no alignment
  phrase sits next to a `@objectstack/spec` mention, so there is no claim to have anything
  behind.

## Governance — unchanged, both sides

| | before | after |
|---|---|---|
| `CLAIM_ALLOW` | 2 declared deliberate copies | 2 |
| `CLAIM_DEBT` | 18 unbacked claims in 5 packages | 18 in 5 |
| rule 1 `ALLOW` / `DEBT` | 13 dialects, 3 collisions in 1 package | unchanged |

No ledger regeneration was needed (nothing new to ledger), `CLAIM_PATTERNS` was **not**
widened, and all three ratchets are untouched. Gate output is identical before and after:

```
✅  spec symbol derivation: 1251 files scanned against 4834 spec export names; 13 declared dialects, 3 untriaged collisions in 1 packages.
✅  spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages.
```

## Verification

- `pnpm exec vitest run --maxWorkers=2 scripts/` — **42 files, 957 tests passed** (943 before;
  14 added).
- `pnpm type-check:scripts` — green.
- `eslint` on both changed files — clean, 0 problems.
- Gate battery, all exit 0: `check-{control-bytes,phantom-dependencies,changeset-presence,changeset-no-major,changeset-fixed,type-check-coverage,lint-coverage,spec-symbol-derivation,doc-links}.mjs`.
- Control-byte self-scan over every touched file including the untracked changeset — clean.
- No `packages/**` file changed, so no `.d.ts` moves and no per-package patch is owed;
  `check-changeset-presence` agrees ("0 of them under the src/ of a package the release
  covers"). The changeset is empty-frontmatter, tooling-only, never major.

## Open question for the PM

The sentence-scoped citation window (item 1 above) is a **narrowing** I made inside this
card because the false-positive class it contains is one this change would otherwise have
introduced. If you would rather it were a separate instrument change, it is a self-contained
15-line hunk in `findClaim` plus three tests and can be split out — the sharpened tie rule
does not depend on it, only its precision does.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_