### PR TITLE
fix(components,plugin-dashboard): the static-data table widget renders instead of looping (#4618)

### DIFF
--- a/.changeset/plain-tables-stop-looping.md
+++ b/.changeset/plain-tables-stop-looping.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/components": patch
+"@object-ui/plugin-dashboard": patch
+---
+
+fix(components,plugin-dashboard): a static-data `table` widget renders instead of crashing
+
+A dashboard widget authored as `{ type: 'table', options: { data: [ … ] } }` fell into the
+error boundary with "Maximum update depth exceeded" the moment its tile re-rendered, while
+every chart family on the identical static surface rendered clean.
+
+- `data-table` no longer re-renders itself to death. Its `columns` / `data` fallbacks are
+  module-scope empties instead of per-render array literals, and the prop→state column sync
+  re-seeds on a value change rather than on a new identity — so a consumer that derives its
+  columns each render (which both dashboard surfaces do) costs the table nothing.
+- Both dashboard surfaces now give the static table the `columns` key `DataTableSchema`
+  requires, derived from the rows when the author declared none — the same derivation the
+  `provider: 'object'` half of the widget family already performed. Previously such a table
+  drew one empty row per record: no headers, no cells.
+- `DashboardGridLayout` reads an authored `options.data` ARRAY for its static table, which
+  its `widgetData?.items` expression resolved to `[]`. `DashboardRenderer` had the arm all
+  along.

--- a/packages/components/src/renderers/complex/__tests__/data-table-render-loop.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-render-loop.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4618 — `data-table` must not re-render itself to death.
+ *
+ * The reported crash ("Maximum update depth exceeded", thrown at the
+ * `setMeasuredStickyLefts` call in the sticky-offset layout effect) is NOT
+ * about sticky offsets. The loop is three hops of prop→state synchronization,
+ * all inside `data-table.tsx`:
+ *
+ *   1. `columns: rawColumns = []` — the destructuring DEFAULT. When the schema
+ *      carries no `columns` key, this evaluates a FRESH array literal on every
+ *      render, so `rawColumns` has a new identity each time even though the
+ *      schema object never changed.
+ *   2. `initialColumns = useMemo(() => rawColumns.map(…), [rawColumns])` — an
+ *      identity-keyed memo over hop 1, so it recomputes to a new array each
+ *      render.
+ *   3. `useEffect(() => setColumns(initialColumns), [initialColumns])` — the
+ *      prop→state sync. New identity ⇒ new state ⇒ re-render ⇒ hop 1 again.
+ *
+ * Self-sustaining, because the unstable value is derived INSIDE the component:
+ * the table's own re-render regenerates it, so nothing external has to change.
+ * React throws from the layout effect keyed on `columns` (the synchronous
+ * nested-update path it counts), which is why the stack points at a line that
+ * has nothing to do with the cause.
+ *
+ * Mount alone is safe — `useState(initialColumns)` seeds from the very array
+ * the mount-render's effect then re-sets, so the first sync is an Object.is
+ * no-op. The loop starts at render #2, i.e. the first time ANY host re-renders
+ * the tile. That is why this went unseen: every existing suite renders once.
+ *
+ * The negative control below is the load-bearing half: with `columns` declared
+ * (a stable array off the schema), the same host churn must stay flat — the
+ * fix must not have been "stop syncing columns".
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import '../data-table';
+
+afterEach(cleanup);
+
+const ROWS = [
+  { name: 'INV-1', amount: 100 },
+  { name: 'INV-2', amount: 200 },
+];
+
+/**
+ * Render `schema` (a STABLE object, declared once) inside a host that can
+ * re-render on demand, counting the tile's commits. A host re-render is the
+ * most ordinary thing on a dashboard — a filter change, a resize, a parent
+ * state update — and must cost the tile a bounded number of commits.
+ */
+function renderUnderHostChurn(schema: Record<string, unknown>) {
+  const DataTable = ComponentRegistry.get('data-table') as React.ComponentType<{ schema: unknown }>;
+  if (!DataTable) throw new Error('data-table not registered');
+  let commits = 0;
+  let bump: (() => void) | null = null;
+  const Host = () => {
+    const [, setTick] = React.useState(0);
+    bump = () => setTick((n) => n + 1);
+    return (
+      <React.Profiler id="tile" onRender={() => { commits += 1; }}>
+        <DataTable schema={schema} />
+      </React.Profiler>
+    );
+  };
+  const utils = render(<Host />);
+  return {
+    ...utils,
+    churn: (times: number) => {
+      for (let i = 0; i < times; i += 1) act(() => { bump!(); });
+    },
+    get commits() { return commits; },
+  };
+}
+
+describe('data-table survives host re-renders (#4618)', () => {
+  it('does not exceed the update depth when the schema declares no columns', () => {
+    // Pre-fix this threw on the FIRST host re-render, after ~50 nested commits:
+    //   "Maximum update depth exceeded. This can happen when a component
+    //    repeatedly calls setState inside componentWillUpdate or
+    //    componentDidUpdate…"
+    const tile = renderUnderHostChurn({ data: ROWS, searchable: false, pagination: false, className: 'border-0' });
+    expect(() => tile.churn(3)).not.toThrow();
+    // Bounded, not merely finite: one commit per host render (plus the mount
+    // pair). A regression that re-introduced a per-render state write would
+    // still "not throw" while doubling this.
+    expect(tile.commits).toBeLessThanOrEqual(6);
+  });
+
+  it('keeps syncing declared columns — the negative control stays flat too', () => {
+    const tile = renderUnderHostChurn({
+      data: ROWS,
+      columns: [{ header: 'Name', accessorKey: 'name' }, { header: 'Amount', accessorKey: 'amount' }],
+      searchable: false,
+      pagination: false,
+    });
+    expect(() => tile.churn(3)).not.toThrow();
+    expect(tile.commits).toBeLessThanOrEqual(6);
+    // Declared columns still reach the DOM — the sync was hardened, not removed.
+    const headers = Array.from(tile.container.querySelectorAll('th')).map((th) => th.textContent);
+    expect(headers.join('|')).toContain('Name');
+    expect(headers.join('|')).toContain('Amount');
+    expect(tile.container.textContent).toContain('INV-1');
+  });
+
+  it('re-syncs when the host actually changes the declared columns', () => {
+    const DataTable = ComponentRegistry.get('data-table') as React.ComponentType<{ schema: unknown }>;
+    let setCols: ((c: Array<Record<string, unknown>>) => void) | null = null;
+    const Host = () => {
+      const [cols, set] = React.useState<Array<Record<string, unknown>>>([
+        { header: 'Name', accessorKey: 'name' },
+      ]);
+      setCols = set;
+      return <DataTable schema={{ data: ROWS, columns: cols, searchable: false, pagination: false }} />;
+    };
+    const { container } = render(<Host />);
+    expect(container.textContent).toContain('Name');
+    expect(container.textContent).not.toContain('Amount');
+    act(() => { setCols!([{ header: 'Name', accessorKey: 'name' }, { header: 'Amount', accessorKey: 'amount' }]); });
+    expect(container.textContent).toContain('Amount');
+    expect(container.textContent).toContain('200');
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -611,7 +611,7 @@ function resolveSelectionMode(selectable: DataTableSchema['selectable'] | 'none'
  * shared instance for every other table on the page.
  */
 const EMPTY_COLUMNS = Object.freeze([]) as unknown as DataTableSchema['columns'];
-const EMPTY_ROWS = Object.freeze([]) as unknown as any[];
+const EMPTY_ROWS = Object.freeze([]) as unknown as DataTableSchema['data'];
 
 /**
  * Value-equality over two normalized column lists (objectui#4618).
@@ -628,16 +628,18 @@ const EMPTY_ROWS = Object.freeze([]) as unknown as any[];
  * (`cell`, `render`), and comparing those by identity is what the sync already
  * did — deep-comparing them is neither possible nor wanted.
  */
-function columnsAreEquivalent(a: readonly any[], b: readonly any[]): boolean {
+function columnsAreEquivalent(a: readonly unknown[], b: readonly unknown[]): boolean {
   if (a === b) return true;
   if (a.length !== b.length) return false;
   return a.every((col, i) => {
     const other = b[i];
     if (col === other) return true;
     if (!col || !other || typeof col !== 'object' || typeof other !== 'object') return false;
-    const keys = Object.keys(col);
-    if (keys.length !== Object.keys(other).length) return false;
-    return keys.every((k) => Object.is(col[k], other[k]));
+    const left = col as Record<string, unknown>;
+    const right = other as Record<string, unknown>;
+    const keys = Object.keys(left);
+    if (keys.length !== Object.keys(right).length) return false;
+    return keys.every((k) => Object.is(left[k], right[k]));
   });
 }
 

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -596,6 +596,52 @@ function resolveSelectionMode(selectable: DataTableSchema['selectable'] | 'none'
 }
 
 /**
+ * Shared empty fallbacks for the `columns` / `data` props (objectui#4618).
+ *
+ * A destructuring default (`columns: rawColumns = []`) or an inline fallback
+ * (`Array.isArray(raw) ? raw : []`) evaluates a FRESH array on every render, so
+ * an absent prop churns identity on a schema that never changed. Downstream
+ * that identity is a `useMemo` key and — for `columns` — a `useEffect` key whose
+ * body writes state, which closes a self-sustaining render loop: the table's own
+ * re-render regenerates the literal that scheduled it. Hoisting the empties to
+ * module scope makes "absent" a stable value, so the memo and the effect see
+ * what is actually true — nothing changed.
+ *
+ * Frozen so a consumer that mutates the array it was handed cannot corrupt the
+ * shared instance for every other table on the page.
+ */
+const EMPTY_COLUMNS = Object.freeze([]) as unknown as DataTableSchema['columns'];
+const EMPTY_ROWS = Object.freeze([]) as unknown as any[];
+
+/**
+ * Value-equality over two normalized column lists (objectui#4618).
+ *
+ * The prop→state sync below re-seeds `columns` whenever `initialColumns` is a
+ * new object. That is the right trigger for a real change and the wrong one for
+ * identity churn, which every consumer that derives its columns per render
+ * produces — `ObjectDataTable` and both dashboard surfaces build the node fresh
+ * on each of their renders. Comparing the values instead lets the sync stay
+ * exactly as eager as before for genuine edits (a renamed header, an added
+ * column, a hidden one) while a re-derived-but-identical list costs nothing.
+ *
+ * Shallow per column, on purpose: column entries carry render functions
+ * (`cell`, `render`), and comparing those by identity is what the sync already
+ * did — deep-comparing them is neither possible nor wanted.
+ */
+function columnsAreEquivalent(a: readonly any[], b: readonly any[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((col, i) => {
+    const other = b[i];
+    if (col === other) return true;
+    if (!col || !other || typeof col !== 'object' || typeof other !== 'object') return false;
+    const keys = Object.keys(col);
+    if (keys.length !== Object.keys(other).length) return false;
+    return keys.every((k) => Object.is(col[k], other[k]));
+  });
+}
+
+/**
  * Enterprise-level data table component with Airtable-like features.
  *
  * Provides comprehensive table functionality including:
@@ -634,8 +680,9 @@ function resolveSelectionMode(selectable: DataTableSchema['selectable'] | 'none'
 const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const {
     caption,
-    columns: rawColumns = [],
-    data: rawData = [],
+    // Module-scope empties, never `[]` literals — see EMPTY_COLUMNS/EMPTY_ROWS.
+    columns: rawColumns = EMPTY_COLUMNS,
+    data: rawData = EMPTY_ROWS,
     pagination = true,
     pageSize: initialPageSize = 10,
     pageSizeOptions,
@@ -715,8 +762,10 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   }, [language]);
 
   // Ensure data is always an array – provider config objects or null/undefined
-  // must not reach array operations like .filter() / .some()
-  const data = Array.isArray(rawData) ? rawData : [];
+  // must not reach array operations like .filter() / .some(). The non-array
+  // fallback is the shared empty, so a provider-config schema does not re-key
+  // every downstream memo on each render (objectui#4618).
+  const data = Array.isArray(rawData) ? rawData : EMPTY_ROWS;
 
   // Normalize columns to support legacy keys (label/name) from existing JSONs
   const initialColumns = useMemo(() => {
@@ -862,9 +911,15 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   // pending change existed" from "the pending value was undefined".
   const editRevertRef = useRef<{ had: boolean; value: any } | null>(null);
 
-  // Update columns when schema changes
+  // Update columns when schema changes.
+  //
+  // Re-seed only on a real change: `initialColumns` is a fresh array whenever
+  // its memo recomputes, and every consumer that derives columns per render
+  // hands us one. Writing state for a value-identical list re-renders the whole
+  // table for nothing, and — when the churn originates inside this component —
+  // schedules the render that regenerates the churn (objectui#4618).
   useEffect(() => {
-    setColumns(initialColumns);
+    setColumns((prev) => (columnsAreEquivalent(prev, initialColumns) ? prev : initialColumns));
   }, [initialColumns]);
 
   // Clear the internal checkbox selection when the host bumps selectionResetKey.

--- a/packages/plugin-dashboard/src/DashboardGridLayout.tsx
+++ b/packages/plugin-dashboard/src/DashboardGridLayout.tsx
@@ -6,7 +6,7 @@ import { Edit, GripVertical, Save, X, RefreshCw } from 'lucide-react';
 import { SchemaRenderer, useHasDndProvider, useDnd } from '@object-ui/react';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { BaseSchema, DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
-import { isObjectProvider } from './utils';
+import { isObjectProvider, deriveStaticTableColumns } from './utils';
 import { classifyWidgetType } from './widgetDispatch';
 import { LEGACY_RETIRED_WIDGET_SCHEMA, isLegacyRetiredWidget } from './legacyRetiredWidget';
 import { DatasetWidget } from './DatasetWidget';
@@ -313,10 +313,21 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
         };
       }
 
+      // Static (data-array) table. The `Array.isArray` arm is not decoration:
+      // `options.data` for this widget is authored as a plain ARRAY, and
+      // `widgetData?.items` is `undefined` for one — so this branch resolved
+      // every authored static table to `[]` while `DashboardRenderer`'s mirror
+      // of it read the array all along (objectui#4618).
+      const staticRows = Array.isArray(widgetData) ? widgetData : widgetData?.items || [];
       return {
         type: 'data-table',
         ...options,
-        data: widgetData?.items || [],
+        data: staticRows,
+        // See DashboardRenderer: `columns` is required, and an author who
+        // declared none got a table of empty rows. Explicit columns win.
+        columns: Array.isArray(options.columns) && options.columns.length > 0
+          ? options.columns
+          : deriveStaticTableColumns(staticRows),
         searchable: false,
         pagination: false,
         className: "border-0"

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -37,7 +37,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { isObjectProvider } from './utils';
+import { isObjectProvider, deriveStaticTableColumns } from './utils';
 import { classifyWidgetType, METRIC_LIKE_TYPES } from './widgetDispatch';
 import { LEGACY_RETIRED_WIDGET_SCHEMA, isLegacyRetiredWidget } from './legacyRetiredWidget';
 import { DatasetWidget } from './DatasetWidget';
@@ -686,10 +686,20 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                 }
 
                 // Static (data-array) table — drill-to-record stays opt-in.
+                const staticRows = Array.isArray(widgetData) ? widgetData : widgetData?.items || [];
                 return {
                     type: 'data-table',
                     ...options,
-                    data: Array.isArray(widgetData) ? widgetData : widgetData?.items || [],
+                    data: staticRows,
+                    // `columns` is a REQUIRED key of `DataTableSchema`, and this
+                    // branch used to omit it whenever the author declared none —
+                    // a table of empty rows, no headers, no cells (objectui#4618).
+                    // Derive from the rows, as the `provider: 'object'` half of
+                    // this same family already does. An explicit list always wins:
+                    // a declared column set is a whitelist, never a starting point.
+                    columns: Array.isArray(options.columns) && options.columns.length > 0
+                        ? options.columns
+                        : deriveStaticTableColumns(staticRows),
                     searchable: false,
                     pagination: false,
                     className: "border-0"

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -12,7 +12,7 @@ import { extractRecords, isDrillEnabled } from '@object-ui/core';
 import type { DrillDownConfig } from '@object-ui/types';
 import { Skeleton, RefreshIndicator, cn } from '@object-ui/components';
 import { useSafeFieldLabel, useObjectTranslation, useLocalization, useDisplayLocale } from '@object-ui/i18n';
-import { resolveFilterPlaceholders } from './utils';
+import { resolveFilterPlaceholders, humanizeFieldKey } from './utils';
 import {
   buildFieldMeta,
   renderFieldValue,
@@ -56,17 +56,9 @@ interface NormalizedColumn {
 export function normalizeColumns(columns: (string | Record<string, any>)[]): NormalizedColumn[] {
   return columns.map((col) => {
     if (typeof col === 'string') {
-      return {
-        header: col
-          // snake_case → spaces
-          .replace(/_/g, ' ')
-          // camelCase → spaces before uppercase letters
-          .replace(/([A-Z])/g, ' $1')
-          .trim()
-          // Title Case each word
-          .replace(/\b\w/g, (c: string) => c.toUpperCase()),
-        accessorKey: col,
-      };
+      // Shared with the static-table derivation so both halves of the `table`
+      // widget family spell a header the same way (objectui#4618).
+      return { header: humanizeFieldKey(col), accessorKey: col };
     }
     return col as NormalizedColumn;
   });

--- a/packages/plugin-dashboard/src/__tests__/StaticTableWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/StaticTableWidget.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4618 — the static-data `table` widget, on both dashboard surfaces.
+ *
+ * Filed shape (measured on `origin/main` @ `c1d939f7f`): a widget authored as
+ *
+ *   { id, type: 'table', options: { data: [ {…}, {…} ] } }
+ *
+ * rendered through `DashboardRenderer` produced ONE `role="alert"` reading
+ * `Component "data-table" failed to render / Maximum update depth exceeded…`,
+ * while `bar` / `line` / `area` / `donut` / `metric` off the identical static
+ * surface rendered clean.
+ *
+ * The crash and the emptiness are two DIFFERENT defects on the same authored
+ * widget, and this suite pins both — a "no alert" assertion alone would have
+ * passed on a tile that renders nothing at all, which is exactly the silent
+ * blank #4612/#4613/#4614 spent three cards removing from these surfaces:
+ *
+ *   1. CRASH — `data-table`'s own prop→state loop, traced in
+ *      `packages/components/src/renderers/complex/__tests__/data-table-render-loop.test.tsx`.
+ *      A dashboard tile re-renders (filters, resize, any parent state), and the
+ *      table then re-renders itself to the nested-update limit.
+ *   2. EMPTY — `DataTableSchema.columns` is REQUIRED
+ *      (`packages/types/src/data-display.ts:369`), and both surfaces built the
+ *      static node WITHOUT it whenever the author declared no `options.columns`.
+ *      Measured: zero `th`, zero `td`, and one empty `tr` per row — the table
+ *      drew rows it had no cells for. The sibling path already derives them
+ *      (`ObjectDataTable.tsx:327-339` maps the first row's keys), so the static
+ *      path was the odd one out within one widget family.
+ *   3. EMPTY, grid only — `DashboardGridLayout` read the rows as
+ *      `widgetData?.items || []`, which is `[]` for the authored ARRAY shape.
+ *      `DashboardRenderer` has carried the `Array.isArray` arm all along; the
+ *      grid's mirror of the same branch never grew it.
+ *
+ * `@object-ui/components` and `@object-ui/plugin-charts` are imported at module
+ * scope (never in a hook — the cold transform must not be billed to a bounded
+ * test budget, AGENTS.md 测试纪律) for the reason the #4614 suite records: with
+ * `data-table` / `chart` unregistered, `SchemaRenderer` renders its own red
+ * "Unknown component type" box — which also carries `role="alert"`, so the
+ * crash assertion would have passed on a surface that never mounted the table,
+ * and the chart control would have failed for a reason unrelated to this card.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup, act, within } from '@testing-library/react';
+import type { DashboardComponentSchema } from '@object-ui/types';
+import '@object-ui/components';
+import '@object-ui/plugin-charts';
+import { DashboardRenderer } from '../DashboardRenderer';
+import { DashboardGridLayout } from '../DashboardGridLayout';
+
+afterEach(cleanup);
+
+const ROWS = [
+  { name: 'INV-1', amount: 100 },
+  { name: 'INV-2', amount: 200 },
+];
+
+/** The widget exactly as #4618 filed it. */
+const staticTableWidget = {
+  id: 't',
+  title: 'Recent Invoices',
+  type: 'table',
+  options: { data: ROWS },
+};
+
+const dash = (widget: Record<string, unknown>): DashboardComponentSchema =>
+  ({ type: 'dashboard', columns: 2, gap: 4, widgets: [widget] }) as unknown as DashboardComponentSchema;
+
+/**
+ * Both surfaces, driven identically. A dashboard tile is re-rendered by its
+ * host all the time; `churn` is that, and it is what turns the latent loop into
+ * the reported crash (mount alone never did).
+ */
+const SURFACES: Array<[string, React.ComponentType<{ schema: DashboardComponentSchema }>]> = [
+  ['DashboardRenderer', DashboardRenderer as React.ComponentType<{ schema: DashboardComponentSchema }>],
+  ['DashboardGridLayout', DashboardGridLayout as React.ComponentType<{ schema: DashboardComponentSchema }>],
+];
+
+function renderSurface(Surface: React.ComponentType<{ schema: DashboardComponentSchema }>, widget: Record<string, unknown>) {
+  const schema = dash(widget);
+  let bump: (() => void) | null = null;
+  const Host = () => {
+    const [, setTick] = React.useState(0);
+    bump = () => setTick((n) => n + 1);
+    return <Surface schema={schema} />;
+  };
+  const utils = render(<Host />);
+  return { ...utils, churn: () => act(() => { bump!(); }) };
+}
+
+describe.each(SURFACES)('%s renders a static-data table widget (#4618)', (_name, Surface) => {
+  it('does not crash into the error boundary when the tile re-renders', () => {
+    const surface = renderSurface(Surface, staticTableWidget);
+    expect(() => surface.churn()).not.toThrow();
+    // The boundary's own text, verbatim from the filing.
+    expect(screen.queryByText(/failed to render/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Maximum update depth exceeded/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders a real table — headers derived from the rows, and the cells', () => {
+    const surface = renderSurface(Surface, staticTableWidget);
+    const table = surface.container.querySelector('table');
+    expect(table).toBeTruthy();
+    const headers = Array.from(table!.querySelectorAll('th')).map((th) => th.textContent?.trim());
+    // Humanized from the row keys, the way the object-bound sibling does it.
+    expect(headers).toContain('Name');
+    expect(headers).toContain('Amount');
+    // …and the rows are actually in cells, not empty `tr`s.
+    const cells = Array.from(table!.querySelectorAll('td')).map((td) => td.textContent?.trim());
+    expect(cells).toContain('INV-1');
+    expect(cells).toContain('200');
+    // The widget's own title still frames it.
+    expect(within(surface.container).getByText('Recent Invoices')).toBeInTheDocument();
+  });
+
+  it('honours author-declared columns instead of deriving them', () => {
+    const surface = renderSurface(Surface, {
+      id: 't',
+      title: 'Recent Invoices',
+      type: 'table',
+      options: { data: ROWS, columns: [{ header: 'Invoice', accessorKey: 'name' }] },
+    });
+    const table = surface.container.querySelector('table')!;
+    const headers = Array.from(table.querySelectorAll('th')).map((th) => th.textContent?.trim());
+    expect(headers).toContain('Invoice');
+    // The undeclared key stays out — derivation must not widen an explicit list.
+    expect(headers).not.toContain('Amount');
+    expect(surface.container.textContent).toContain('INV-1');
+    expect(surface.container.textContent).not.toContain('200');
+  });
+
+  it('renders an empty static table without inventing headers', () => {
+    const surface = renderSurface(Surface, { id: 't', title: 'Nothing yet', type: 'table', options: { data: [] } });
+    expect(() => surface.churn()).not.toThrow();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(surface.container.querySelector('table')!.querySelectorAll('th')).toHaveLength(0);
+  });
+
+  it('leaves the other widget families alone — a static bar widget still renders clean', () => {
+    const surface = renderSurface(Surface, {
+      id: 'b',
+      title: 'Revenue',
+      type: 'bar',
+      options: { data: [{ name: 'Jan', value: 1 }] },
+    });
+    expect(() => surface.churn()).not.toThrow();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(within(surface.container).getByText('Revenue')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-dashboard/src/utils.ts
+++ b/packages/plugin-dashboard/src/utils.ts
@@ -16,6 +16,55 @@ export function isObjectProvider(widgetData: unknown): widgetData is { provider:
   );
 }
 
+/**
+ * A record key → a human column header: `unit_price` / `unitPrice` → "Unit Price".
+ *
+ * Single home for the convention, because both halves of the `table` widget
+ * family need it and they must agree: the object-bound path normalizes an
+ * author's `string[]` shorthand with it (`normalizeColumns`), and the static
+ * path derives headers with it when no columns were declared at all.
+ */
+export function humanizeFieldKey(key: string): string {
+  return key
+    // snake_case → spaces
+    .replace(/_/g, ' ')
+    // camelCase → spaces before uppercase letters
+    .replace(/([A-Z])/g, ' $1')
+    .trim()
+    // Title Case each word
+    .replace(/\b\w/g, (c: string) => c.toUpperCase());
+}
+
+/**
+ * Columns for a STATIC (inline `options.data`) table widget whose author
+ * declared none — objectui#4618.
+ *
+ * `DataTableSchema.columns` is a REQUIRED key (`@object-ui/types`
+ * `data-display.ts`), and a `data-table` handed rows but no columns draws one
+ * empty `tr` per row: no `th`, no `td`, nothing readable. Both dashboard
+ * surfaces built exactly that node whenever the widget carried only
+ * `options.data`, so a documented authoring surface rendered a silent blank.
+ *
+ * The object-bound half of the same widget family has always derived columns
+ * from the fetched rows when none were declared (`ObjectDataTable`), so this is
+ * that behaviour reaching the static half — not a new capability. Keys come
+ * from the FIRST row for the same reason it does there: the first record is the
+ * shape the author is describing, and scanning every row would let one ragged
+ * record widen the table.
+ *
+ * `_`-prefixed keys are internal bookkeeping and stay out. Non-record rows
+ * (strings, numbers, arrays) have no keys to name, so they derive nothing and
+ * the table renders its own empty state rather than a header row of noise.
+ */
+export function deriveStaticTableColumns(rows: unknown): Array<{ header: string; accessorKey: string }> {
+  if (!Array.isArray(rows) || rows.length === 0) return [];
+  const first = rows[0];
+  if (first == null || typeof first !== 'object' || Array.isArray(first)) return [];
+  return Object.keys(first as Record<string, unknown>)
+    .filter((key) => !key.startsWith('_'))
+    .map((key) => ({ header: humanizeFieldKey(key), accessorKey: key }));
+}
+
 // Re-export the date-macro resolver from core so existing internal imports
 // (`import { resolveDateMacros } from './utils'`) keep working.
 //


### PR DESCRIPTION
Fixes #4618

A dashboard widget authored as `{ id, type: 'table', options: { data: [ … ] } }` fell into the
error boundary with **"Maximum update depth exceeded"**, while `bar` / `line` / `area` / `donut` /
`metric` off the identical static surface rendered clean.

Three defects, measured separately. The crash is one of them; the other two are why the same widget
still rendered nothing once it stopped crashing.

## 1. The loop — `packages/components/src/renderers/complex/data-table.tsx`

The filing pointed at `data-table.tsx:788`, which is `setMeasuredStickyLefts(null)` inside the
sticky-offset layout effect. That is the **throw site, not the cause** — a layout-effect state write
is the synchronous nested-update path React counts, so it is where the limit trips.

The actual cycle, every hop inside `data-table.tsx`:

| hop | line (pre-fix) | what happens |
| --- | --- | --- |
| 1 | `:637` `columns: rawColumns = []` | the destructuring DEFAULT evaluates a **fresh array literal on every render** when the schema carries no `columns` key |
| 2 | `:722-728` `initialColumns = useMemo(() =` `> rawColumns.map(…), [rawColumns])` | identity-keyed memo over hop 1 — recomputes to a new array each render |
| 3 | `:866-868` `useEffect(() =` `> setColumns(initialColumns), [initialColumns])` | prop→state sync: new identity ⇒ new state ⇒ re-render ⇒ **hop 1 again** |
| throw | `:785-815` layout effect keyed on `[stickyLeadingCount, columns]` → `:788` | React counts the nested update here and throws |

Self-sustaining, because the unstable value is derived **inside** the component: the table's own
re-render regenerates the literal that scheduled it. Nothing external has to change.

Why it was never seen: `useState(initialColumns)` seeds from the very array the mount-render's effect
then re-sets, so the first sync is an `Object.is` no-op. **Mount is safe; the loop starts at render
#2** — the first time any host re-renders the tile. Every existing suite renders once.

Fix, at both hops:

* module-scope frozen `EMPTY_COLUMNS` / `EMPTY_ROWS` replace the per-render `[]` literals (the
  destructuring defaults and the non-array `data` fallback), so "absent" is a stable value;
* the columns sync re-seeds on a **value** change, not a new identity
  (`setColumns(prev =` `> columnsAreEquivalent(prev, initialColumns) ? prev : initialColumns)`).

The second half is load-bearing rather than belt-and-braces: both dashboard surfaces rebuild the
child node on every render, so with fix 3 below they now hand the table a freshly-derived `columns`
array each time. Shallow per column, on purpose — column entries carry render functions, and
comparing those by identity is exactly what the sync already did.

## 2. The blank — `columns` is a REQUIRED key neither surface supplied

`DataTableSchema.columns` is required (`packages/types/src/data-display.ts:369`), and both surfaces
built the static node without it whenever the author declared no `options.columns`. Measured on
`origin/main`: zero `th`, zero `td`, one **empty `tr` per row** — the table drew rows it had no cells
for. A "no error boundary" assertion alone would have passed on that, which is the silent blank
#4612 / #4613 / #4614 spent three cards removing from these surfaces.

The `provider: 'object'` half of this same widget family has always derived columns from the rows
when none were declared (`ObjectDataTable.tsx:327-339`), so the static half was the odd one out
inside one family. `deriveStaticTableColumns` (`plugin-dashboard/src/utils.ts`) is that behaviour
reaching it — first row's keys, `_`-prefixed dropped, headers humanized through the helper the
object path now shares (`humanizeFieldKey`, lifted out of `normalizeColumns` unchanged so the two
halves cannot drift). **An author-declared column list always wins**: a whitelist is never a
starting point.

## 3. `DashboardGridLayout` never read an authored array

Its static branch resolved rows as `widgetData?.items || []` — `undefined`, hence `[]`, for the
authored ARRAY shape. `DashboardRenderer`'s mirror of the same branch has carried the
`Array.isArray` arm all along. Visible pre-fix as "No results found" under correct headers whenever
columns were declared (so the loop did not mask it).

## Red-first, verbatim

`pnpm exec vitest run --maxWorkers=2` on the two new suites, pre-fix — both dashboard surfaces:

```
FAIL  StaticTableWidget.test.tsx > DashboardRenderer … > does not crash into the error boundary
expected document not to contain element, found < p class="font-medium" >
  Component "data-table" failed to render
</p> instead
```

```
Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState
inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to
prevent infinite loops.
    at dispatchSetState (react-dom-client.development.js:9127:7)
    at /packages/components/src/renderers/complex/data-table.tsx:788:7
    at commitHookLayoutEffects (react-dom-client.development.js:13213:11)
The above error occurred in the < DataTableRenderer > component.
```

Angle brackets in the two quoted snippets above are spaced (`< p`, `< DataTableRenderer >`) so the
GitHub body sanitizer does not eat them as HTML tags; nothing else about them is altered. The
boundary's rendered text matched the filing exactly, including the "Retry" button. Also red
pre-fix: `renders a real table …` (`expected null to be truthy` — the boundary replaced the
`table`), and, for the grid only, `honours author-declared columns …`
(`'…Recent InvoicesInvoiceNo results foundTry adjusting your filters or search query.' to contain
'INV-1'` — defect 3 with the loop out of the way).

Component-level, pre-fix, with the schema stable and only the host re-rendering:

```
AssertionError: expected [Function] to not throw an error but
'Error: Maximum update depth exceeded.…' was thrown
 ❯ data-table-render-loop.test.tsx:92:37   expect(() => tile.churn(3)).not.toThrow();
```

## Coverage

* `packages/components/…/__tests__/data-table-render-loop.test.tsx` — the loop at the renderer
  level, plus the two controls that stop the fix from being "we removed the sync": declared columns
  still reach the DOM under the same host churn, and a real column change still re-syncs.
* `packages/plugin-dashboard/src/__tests__/StaticTableWidget.test.tsx` — `describe.each` over BOTH
  surfaces: no boundary under churn; a real table (derived headers **and** cells); declared columns
  honoured and not widened; an empty `data: []` invents no headers; a static `bar` widget on the
  same surface unchanged.

## Verification

**Consumer radius** — census by import: `data-table` is consumed by `plugin-dashboard`
(`DashboardRenderer` / `DashboardGridLayout` / `ObjectDataTable`), `plugin-detail` (`RelatedList`) and
`plugin-grid` (`ObjectGrid`); `plugin-list` and `app-shell` reach it through those. Repo-root
`pnpm exec vitest run --maxWorkers=2` over all six: **767 files, 7228 passed, 1 skipped, 0 failed.**

**Reverse verification** (patch + `git checkout` + sha256-verified restore, never `git stash`) was run
as a partition rather than one revert, and the result corrected my own expectation — worth reading
before review:

| reverted | components loop suite | dashboard "does not crash" | dashboard "renders a real table" |
| --- | --- | --- | --- |
| nothing | green | green | green |
| **A** — `data-table.tsx` only | **RED** | green | green |
| **B** — both dashboard surfaces only | green | **green** | **RED** (both surfaces) + grid's declared-columns case RED |
| both (= `origin/main`) | RED | RED | RED |

Row A is the one I predicted wrong. With the dashboard supplying `columns`, reverting the components
fix does **not** bring the crash back on either dashboard surface: a declared `columns` array comes
off the schema, which is stable across the table's own re-renders, so the churn is no longer
self-sustaining. In other words the dashboard-side fix alone would have made the reported symptom
disappear — which is exactly why it is not the fix. Row A's red is the components-level suite, the
only thing pinning the cause, and it stays live for any consumer that omits `columns`. Row B is the
mirror: the components fix alone removes the crash and leaves the blank. Neither half papers over the
other, and each is load-bearing on its own.

sha256 of all three files matched their pre-revert values after every restore; `git status` clean.

**Grading — patch, by measurement.** Full `.d.ts` manifest (231 files across both packages) rebuilt
with `dist/` and `*.tsbuildinfo` cleared, reproducible across three builds, diffed against
`origin/main`: `@object-ui/components` is **byte-identical** — a pure behaviour fix. The single delta
in the whole set is `plugin-dashboard/dist/utils.d.ts`, which gains two additive declarations
(`humanizeFieldKey`, `deriveStaticTableColumns`) and is **not reachable through the package entry** —
`index.d.ts` never references it and `exports` maps only `.`. Module-local, additive, nothing removed
or narrowed: patch on the #4496 precedent. Never major.

**Type-check**, PREFIX-filtered (direction: **downstream consumers**,
`--filter '...@object-ui/components' --filter '...@object-ui/plugin-dashboard'`) — 31 packages,
0 errors. Two false reds along the way were missing sibling artifacts (`@object-ui/mobile`,
`@object-ui/permissions` had no `dist/`), cleared by a full workspace build, not by any source change.

**ESLint, net −2** against an `origin/main` compare worktree (same filter, both sides):
`@object-ui/components` 920 → **918** warnings, `plugin-dashboard` 327 → 327, and the entire delta is
the removal of

```
warning  The 'data' conditional could make the dependencies of useMemo Hook (at line 759 / 899)
         change on every render.        react-hooks/exhaustive-deps
```

— the linter had been reporting this defect's own shape on `main` all along. No warning added: the
guard is typed `readonly unknown[]` with a `Record< string, unknown >` narrowing rather than `any`.

**Gate battery**, all PASS: `check-{control-bytes, phantom-dependencies, changeset-presence,
changeset-no-major, changeset-fixed, type-check-coverage, lint-coverage, doc-links}.mjs`. Control-byte
self-scan over every changed file including untracked
(`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`): no hits. One changeset, patch/patch.

**Surface respected**: nothing under `apps/site/**` or `examples/schema-catalog/test/**` — a
catalog-side render pin for the static `table` widget (there is still no catalog entry exercising it,
which is why nothing caught this) belongs to the #4616 seat's render-pin extension, not here.
`content/docs/releases/**` untouched.

**Filed, not fixed**: #4629 — `ObjectDataTable`'s `finalData` fallback is the same per-render literal
one file over, feeding the `derivedColumns` memo. It cannot loop (memo only, and the child's state
write does not re-render it), so it is observation-class and out of this card's scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_
