### PR TITLE
fix(examples): catalog entries author the keys their renderers read (#4624)

### DIFF
--- a/examples/schema-catalog/src/schemas/components-disclosure-toggle-group/with-labels.json
+++ b/examples/schema-catalog/src/schemas/components-disclosure-toggle-group/with-labels.json
@@ -1,5 +1,6 @@
 {
-  "type": "single",
+  "type": "toggle-group",
+  "selectionType": "single",
   "items": [
     {
       "value": "list",

--- a/examples/schema-catalog/src/schemas/components-form-calendar/custom-style.json
+++ b/examples/schema-catalog/src/schemas/components-form-calendar/custom-style.json
@@ -1,5 +1,5 @@
 {
-  "type": "calendar",
+  "type": "ui:calendar",
   "mode": "single",
   "className": "rounded-xl border-2 shadow-lg"
 }

--- a/examples/schema-catalog/src/schemas/components-form-calendar/date-range.json
+++ b/examples/schema-catalog/src/schemas/components-form-calendar/date-range.json
@@ -1,5 +1,5 @@
 {
-  "type": "calendar",
+  "type": "ui:calendar",
   "mode": "range",
   "className": "rounded-md border"
 }

--- a/examples/schema-catalog/src/schemas/components-form-calendar/form-integration.json
+++ b/examples/schema-catalog/src/schemas/components-form-calendar/form-integration.json
@@ -8,7 +8,7 @@
       "className": "text-sm font-medium"
     },
     {
-      "type": "calendar",
+      "type": "ui:calendar",
       "mode": "single",
       "className": "rounded-md border"
     }

--- a/examples/schema-catalog/src/schemas/components-form-calendar/multiple-dates.json
+++ b/examples/schema-catalog/src/schemas/components-form-calendar/multiple-dates.json
@@ -1,5 +1,5 @@
 {
-  "type": "calendar",
+  "type": "ui:calendar",
   "mode": "multiple",
   "className": "rounded-md border shadow-sm"
 }

--- a/examples/schema-catalog/src/schemas/components-form-calendar/simple-calendar.json
+++ b/examples/schema-catalog/src/schemas/components-form-calendar/simple-calendar.json
@@ -1,5 +1,5 @@
 {
-  "type": "calendar",
+  "type": "ui:calendar",
   "mode": "single",
   "className": "rounded-md border"
 }

--- a/examples/schema-catalog/src/schemas/components-form-calendar/single-date.json
+++ b/examples/schema-catalog/src/schemas/components-form-calendar/single-date.json
@@ -1,5 +1,5 @@
 {
-  "type": "calendar",
+  "type": "ui:calendar",
   "mode": "single",
   "className": "rounded-md border"
 }

--- a/examples/schema-catalog/src/schemas/components-overlay-hover-card/basic-hover-card.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-hover-card/basic-hover-card.json
@@ -1,8 +1,9 @@
 {
   "type": "hover-card",
   "trigger": {
-    "type": "text",
-    "value": "Hover over me"
+    "type": "button",
+    "variant": "link",
+    "label": "Hover over me"
   },
   "content": {
     "type": "text",

--- a/examples/schema-catalog/src/schemas/components-overlay-tooltip/basic-tooltip.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-tooltip/basic-tooltip.json
@@ -1,7 +1,7 @@
 {
   "type": "tooltip",
   "content": "Helpful information",
-  "children": [
+  "trigger": [
     {
       "type": "button",
       "label": "Hover me"

--- a/examples/schema-catalog/test/catalog-gallery-render.test.tsx
+++ b/examples/schema-catalog/test/catalog-gallery-render.test.tsx
@@ -37,19 +37,47 @@
  * registerCatalogBlocks.ts` now loads the nine further packages that census
  * resolves to, which takes 31 of those 33 tiles from the panel to a drawn
  * component. What registration cannot reach is named — never skipped silently —
- * in the tables below. Four classes are defects in the entries, one issue each:
+ * in the tables below. Four classes were defects in the entries, one issue each:
  *
  *   objectui#4624  1 entry  names root type "single", which nothing registers
  *   objectui#4625  6 entries author the bare `calendar` keyword, which belongs
  *                          to plugin-calendar's data-bound ObjectCalendar
- *   objectui#4626  2 entries render a blank tile — each authors a key its own
- *                          renderer never reads (found by the control below)
+ *   objectui#4626  2 entries were filed as blank tiles, each authoring a key
+ *                          its own renderer never reads — one of the two was
+ *                          measured to be neither (see below)
  *   objectui#4627  2 entries author 2024 event dates, outside the window
  *                          `calendar-view` paints
  *
- * #4625 is the reason this file asserts three diagnostic strings rather than
- * one: registering a package is not the same as a tile drawing, and a pin that
- * named only OBJUI-001 would have reported those six as fixed.
+ * The first three are FIXED in the entries as of objectui#4624's PR, so the
+ * eight entries they covered carry the full assertion set here and no longer
+ * appear in either table. What that PR measured, and corrects in this header:
+ *
+ *  - #4625's six now author `ui:calendar`, the namespaced key the primitive is
+ *    registered under. Probed through this file's own render path before the
+ *    rewrite: `type: 'ui:calendar'` resolves and paints the date-picker grid
+ *    (115 elements), because `Registry.get(type)` looks the string up verbatim
+ *    and `register()` stores the namespaced form as `ui:calendar`. The bare
+ *    keyword still reaches `ObjectCalendar` — that is not a bug to route
+ *    around, it is `skipFallback: true` working as designed.
+ *  - #4626's `basic-tooltip` was a real blank tile: it authored its trigger
+ *    under `children`, which the tooltip renderer never reads. Now `trigger`.
+ *  - #4626's `basic-hover-card` was NOT blank and authored no unread key.
+ *    Measured: the text renderer reads `schema.content || schema.value`
+ *    (`packages/components/src/renderers/basic/text.tsx:35,40`), so the
+ *    authored `value` WAS read and the tile drew the text node "Hover over
+ *    me" — which `drewSomething` accepts, and which an element-only view of
+ *    the DOM (the one the filing reports) cannot see. Its real defect was
+ *    that a bare text node is not an element, so `HoverCardTrigger asChild`
+ *    had nothing to attach to and the card could never open; the trigger is
+ *    now a link-variant button, the shape the renderer's own `defaultProps`
+ *    declare. Removing its exclusion turns nothing red — verified by removing
+ *    it BEFORE touching the entry.
+ *
+ * DATASOURCE_REQUIRED stays asserted, for the reason #4625 first supplied:
+ * registering a package is not the same as a tile drawing, and a pin naming
+ * only OBJUI-001 would have reported those six as fixed. It is now a
+ * regression guard — an entry sliding back to the bare `calendar` keyword
+ * fails on that string rather than on the panel.
  *
  * Six further entries are not rendered here at all, for reasons that are limits
  * of the environment rather than defects in anything: `plugin-editor`'s three
@@ -69,10 +97,15 @@
  *
  * ## What is asserted, per entry
  *
- * None of the three diagnostics, and — the non-vacuity half, since an entry
- * that renders nothing at all trivially satisfies all three — the tile actually
- * produced DOM or text of its own. That control is not decoration: it is what
- * found objectui#4626's two blank tiles, which no red-tile sweep can see. For
+ * None of the three diagnostics — all three, for every entry: there are no
+ * per-entry diagnostic exemptions left — and, the non-vacuity half, since an
+ * entry that renders nothing at all trivially satisfies all three, the tile
+ * actually produced DOM or text of its own. That control is not decoration: it
+ * is what found objectui#4626's blank tooltip tile, which no red-tile sweep can
+ * see. Note what it deliberately does NOT claim: text alone satisfies it, so a
+ * tile drawing a bare text node passes — correctly, since `components-basic-
+ * text/*` are exactly that. `basic-hover-card` is the case that proves the
+ * distinction matters in both directions (see the header). For
  * the categories objectui#4616 newly registered, a stronger positive control on
  * top: the titles the entry itself authors are on screen
  * (`AUTHORED_TEXT_EXEMPT` records the two that cannot be asserted that way,
@@ -121,9 +154,11 @@ const FAILED_TO_RENDER = 'failed to render';
  * The data-bound plugins' guard when the host supplies no data source
  * (`ObjectCalendar.tsx`, `ObjectGantt.tsx`, `ObjectMap.tsx` all throw it).
  * Asserted alongside the other two because registering a package is not the
- * same as the tile drawing: `components-form-calendar/*` trades the OBJUI-001
- * panel for exactly this string, and a pin that named only the panel would
- * report those six as fixed.
+ * same as the tile drawing: `components-form-calendar/*` used to trade the
+ * OBJUI-001 panel for exactly this string, and a pin that named only the panel
+ * would have reported those six as fixed. They now author `ui:calendar` and
+ * draw the primitive, so this string is what would catch them sliding back to
+ * the bare keyword.
  */
 const DATASOURCE_REQUIRED = 'DataSource required for object/api providers';
 
@@ -153,18 +188,6 @@ const HOST_PACKAGES = [
 const EXCLUSIONS: Record<string, string> = {
   'core-schema-renderer/unknown-component-type':
     'Demonstrates the OBJUI-001 panel on purpose — the panel IS the example.',
-  'components-disclosure-toggle-group/with-labels':
-    'Authoring defect, not registration: the entry names root type "single", which no ' +
-    'package registers. Its two siblings spell the same thing "toggle-group" + ' +
-    '"selectionType": "single". Filed as objectui#4624.',
-  'components-overlay-tooltip/basic-tooltip':
-    'Blank tile, not a red one, and not registration: the entry authors its trigger under ' +
-    '"children", which the tooltip renderer never reads (it reads "trigger" / "body"), so ' +
-    'the tile renders nothing at all. Filed as objectui#4626.',
-  'components-overlay-hover-card/basic-hover-card':
-    'Blank tile, not a red one, and not registration: both slots author {"type":"text", ' +
-    '"value":…} and the text renderer reads "content", so both render empty. ' +
-    'Filed as objectui#4626.',
   // The three below are an ENVIRONMENT limit, not a defect in the entries.
   // Rendering `code-editor` mounts `@monaco-editor/react`, which appends its
   // loader as a `script` tag pointing at a CDN. happy-dom cannot fetch it and
@@ -195,29 +218,6 @@ const EXCLUSIONS: Record<string, string> = {
   'plugin-map/event-venue-finder': 'maplibre needs WebGL2 and a live tile host.',
   'plugin-map/real-time-delivery-tracking': 'maplibre needs WebGL2 and a live tile host.',
   'plugin-map/store-locator-map': 'maplibre needs WebGL2 and a live tile host.',
-};
-
-/**
- * Entries allowed ONE named diagnostic, because that diagnostic is a defect
- * this card measured and filed rather than caused. Every other assertion still
- * applies to them — including the other two diagnostics — so the exemption is
- * one string wide, not one entry wide.
- *
- * All six `components-form-calendar` entries author the bare `calendar`
- * keyword, which `@object-ui/components` deliberately registers as
- * `ui:calendar` only ("collides with the plugin-calendar full CRUD calendar
- * VIEW", `skipFallback: true`). So the bare keyword reaches `ObjectCalendar`,
- * which has no data source here and says so. Registering the package is what
- * exposed it; correcting six entries' authored type is a separate decision,
- * filed as objectui#4625.
- */
-const KNOWN_DIAGNOSTIC: Record<string, string> = {
-  'components-form-calendar/custom-style': DATASOURCE_REQUIRED,
-  'components-form-calendar/date-range': DATASOURCE_REQUIRED,
-  'components-form-calendar/form-integration': DATASOURCE_REQUIRED,
-  'components-form-calendar/multiple-dates': DATASOURCE_REQUIRED,
-  'components-form-calendar/simple-calendar': DATASOURCE_REQUIRED,
-  'components-form-calendar/single-date': DATASOURCE_REQUIRED,
 };
 
 /**
@@ -302,10 +302,6 @@ interface Rendered {
  */
 const drewSomething = (elements: number, text: string) =>
   elements > WRAPPER_ELEMENTS || text.trim().length > 0;
-
-/** Which diagnostics this entry must not show. */
-const diagnosticsFor = (id: string) =>
-  ALL_DIAGNOSTICS.filter((d) => d !== KNOWN_DIAGNOSTIC[id]);
 
 /** Render one entry exactly as `SchemaThumbnail` does, then let it settle. */
 async function renderEntry(schema: unknown): Promise<Rendered> {
@@ -426,11 +422,7 @@ describe('objectui#4616 — every catalog entry renders in the docs gallery', ()
 
   it('every exclusion still names a real entry', () => {
     const ids = new Set(entries.map((e) => e.id));
-    for (const id of [
-      ...Object.keys(EXCLUSIONS),
-      ...Object.keys(KNOWN_DIAGNOSTIC),
-      ...Object.keys(AUTHORED_TEXT_EXEMPT),
-    ]) {
+    for (const id of [...Object.keys(EXCLUSIONS), ...Object.keys(AUTHORED_TEXT_EXEMPT)]) {
       expect(ids.has(id), `${id} is excluded but no longer exists in the catalog`).toBe(true);
     }
   });
@@ -440,7 +432,7 @@ describe('objectui#4616 — every catalog entry renders in the docs gallery', ()
     async (id, schema) => {
       const r = await renderEntry(schema);
       try {
-        for (const diagnostic of diagnosticsFor(id)) {
+        for (const diagnostic of ALL_DIAGNOSTICS) {
           expect(r.text, `${id} shows "${diagnostic}"`).not.toContain(diagnostic);
         }
         // Positive control: the tile drew something of its own.
@@ -494,7 +486,7 @@ describe('objectui#4616 — every catalog entry renders in the docs gallery', ()
       if (EXCLUSIONS[entry.id]) continue;
       const r = await renderEntry(entry.schema);
       const hits: string[] = [];
-      for (const diagnostic of diagnosticsFor(entry.id)) {
+      for (const diagnostic of ALL_DIAGNOSTICS) {
         const n = occurrences(r.text, diagnostic);
         counts[diagnostic] += n;
         if (n) hits.push(`${diagnostic} x${n}`);


### PR DESCRIPTION
Fixes #4624
Fixes #4626
Fixes #4625

Three catalog-authoring defects on one surface, plus the #4616 render pin's exclusion tables shrinking to match reality. Authoring-side only: no renderer or package source is touched.

One of the three filings turned out to be partly mis-diagnosed. That is reported below rather than papered over, and the pin's header is corrected to match what was measured.

## Piece 1 — #4624, `components-disclosure-toggle-group/with-labels`

Named root type `"single"`, which nothing registers. Now `"toggle-group"` + `"selectionType": "single"`, the spelling both siblings already use. The `items` keep their `icon` keys: `ToggleGroupItem.icon` is a declared field (`packages/types/src/disclosure.ts:131`), so this is not the entry inventing a key — though no renderer reads it, filed as #4632.

This was the last unintentional OBJUI-001 tile in the corpus.

## Piece 2 — #4626, the two "blank tile" entries

**`components-overlay-tooltip/basic-tooltip` — filing confirmed.** It authored its trigger under `children`. Renderer prop reads, `packages/components/src/renderers/overlay/tooltip.tsx`:

- line 28 `renderChildren(schema.trigger)` inside `TooltipTrigger asChild`
- line 31 `(schema.content || renderChildren(schema.body))` inside `TooltipContent`

`children` is read nowhere, so the tile drew nothing at all. Measured as authored: 2 elements (both harness wrappers), empty text. Now authors `trigger`; measured after: 3 elements, text `"Hover me"`.

**`components-overlay-hover-card/basic-hover-card` — filing falsified on both of its claims.** The issue states the text renderer reads `content` and that `value` is therefore never read. It reads both:

- `packages/components/src/renderers/basic/text.tsx:35` and `:40` both evaluate `schema.content || schema.value`

So the authored `value` WAS read, and the tile was not blank: measured as authored, it drew the text node `"Hover over me"`. The pin's own non-vacuity control accepts text as well as elements (deliberately — `components-basic-text/*` are bare text nodes), so **removing this entry's exclusion turns nothing red**. That was verified by removing the exclusion BEFORE touching the entry: the run went red on 9 cases and this was not one of them.

What the entry did have is a different defect, one the filing did not name: a bare text node is not an element, so `HoverCardTrigger asChild` had nothing to clone and the card could never open. Measured contrast, same harness — a `text` trigger carrying a `className` renders a span that Radix wires (`data-state="closed"`), while the bare one renders no element at all. The trigger is now a link-variant button, which is the shape the renderer's own `defaultProps` declare for this slot (`hover-card.tsx:50`). The content slot keeps `value`, which is the key `TextSchema` declares (`packages/types/src/layout.ts:56`).

Note the deliberate non-change: the ruled correction `value` to `content` is a no-op at render time AND would author a key `TextSchema` does not declare. `content` appears only in the registry meta. That three-way disagreement is the real class question and is filed as #4631.

## Piece 3 — #4625, the six `components-form-calendar` entries

**Verify-first, as ruled. `ui:calendar` IS addressable as a schema type.** Measured, not inferred:

- `Registry.get(type)` with no namespace argument looks the string up verbatim (`packages/core/src/registry/Registry.ts:350-358`), and `register()` stores the namespaced form under exactly `ui:calendar` (line 163). `SchemaRenderer` passes the authored type straight in: `ComponentRegistry.get(evaluatedSchema.type)` at `packages/react/src/SchemaRenderer.tsx:506`.
- Probe-rendered through this pin's own harness, before any entry was edited: `{ "type": "ui:calendar", "mode": "single" }` produced **115 elements** and painted the date-picker grid (`"August 2026 SuMoTuWeThFrSa..."`). The bare `calendar` keyword in the same probe produced 5 elements and `"Error: DataSource required for object/api providers"`.

So all six now author `ui:calendar` and reach the form-calendar primitive the category exists to demo. `form-integration` is a `div` whose nested child was the offending node; only that child changed.

The bare keyword still resolves to plugin-calendar's `ObjectCalendar`. That is `skipFallback: true` working as designed, not something this PR routes around.

## Piece 4 — the pin

`examples/schema-catalog/test/catalog-gallery-render.test.tsx`:

- All three entry exclusions removed (#4624's, and #4626's two). Those entries now carry the full assertion set.
- The `KNOWN_DIAGNOSTIC` table is **deleted entirely** — it held only #4625's six DATASOURCE_REQUIRED exemptions. With no exemptions left, `diagnosticsFor()` is gone too and all three diagnostics are asserted for every non-excluded entry. Strictly stronger, and `DATASOURCE_REQUIRED` stays asserted as the regression guard that catches an entry sliding back to the bare keyword.
- Header prose corrected where this run falsified it, including the claim that the non-vacuity control "found #4626's two blank tiles" — it found one.

Untouched, as ruled: the deliberate OBJUI-001 demo entry, the three Monaco and three maplibre environment abstentions, and `AUTHORED_TEXT_EXEMPT` (#4627).

## Red-first, then green

Predictions were written before the run. Pin edits made first, entries untouched, so the red is the pin reporting on the real corpus:

```
× components-disclosure-toggle-group/with-labels renders without a red tile 11ms
× components-form-calendar/custom-style renders without a red tile 12ms
× components-form-calendar/date-range renders without a red tile 6ms
× components-form-calendar/form-integration renders without a red tile 7ms
× components-form-calendar/multiple-dates renders without a red tile 6ms
× components-form-calendar/simple-calendar renders without a red tile 6ms
× components-form-calendar/single-date renders without a red tile 6ms
× components-overlay-tooltip/basic-tooltip renders without a red tile 1010ms
× the whole corpus produces zero unknown-type panels and zero error tiles 3003ms

Tests  9 failed | 431 passed (440)
```

Verbatim diagnostics:

```
AssertionError: components-disclosure-toggle-group/with-labels shows "Unknown component type":
expected 'Unknown component type: single...' not to contain 'Unknown component type'
+ Unknown component type: single (OBJUI-001)

AssertionError: components-form-calendar/custom-style shows "DataSource required for object/api providers":
Received: "Error: DataSource required for object/api providers"

AssertionError: components-form-calendar/form-integration ...
Received: "Select a dateError: DataSource required for object/api providers"
```

`basic-tooltip` and the corpus case fail differently — on the non-vacuity control inside `renderEntry`, `expected true, received false` at the `drewSomething` waitFor — because a tile that draws nothing never settles. That is the blank-tile signature, and it is the one #4626 half that reproduced.

**`components-overlay-hover-card/basic-hover-card` is absent from that list**: it passes with its exclusion removed and no entry change. Predicted red, measured green — reported rather than forced.

After the entry re-authoring, same command:

```
Test Files  1 passed (1)
     Tests  440 passed (440)
```

440 vs the 437 of the pre-change baseline: three entries left the exclusion table and became asserted cases.

**Reverse verification.** Fix taken back out with `git checkout origin/main -- ...` (never `git stash`), pin left in place: the same 9 cases fail, `basic-hover-card` again absent. Restored with `git checkout HEAD -- ...` and all nine files verified bit-identical by `sha256sum -c`.

## Verification

```
pnpm exec vitest run --maxWorkers=2 scripts/ examples/schema-catalog
  Test Files  50 passed (50)
       Tests  2531 passed (2531)

pnpm --filter '@object-ui/example-schema-catalog^...' build   (build closure first)
pnpm --filter @object-ui/example-schema-catalog type-check     (clean)
pnpm --filter @object-ui/example-schema-catalog lint           (0 errors; 2 pre-existing warnings in untouched files)
```

Gate battery, all PASS: `check-control-bytes`, `check-phantom-dependencies`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`, `check-type-check-coverage`, `check-lint-coverage`, `check-doc-links`. Control-byte self-scan over the changed files (and untracked: none) is clean.

## Changeset

None owed, and `skip-changeset` is applied instead: `@object-ui/example-*` is in `.changeset/config.json`'s `ignore` list and `@object-ui/example-schema-catalog` is `"private": true`. The diff is entirely under `examples/schema-catalog/**`. `check-changeset-presence` passes.

## Out of scope, filed rather than fixed here

- #4631 — a component type has three declared surfaces (TS interface / registry meta `inputs` / renderer reads) that disagree. This is #4626's class question, re-filed standalone with the tooltip and text specimens measured above. `TooltipSchema` declaring a required `children` that the renderer ignores means an author following the published type gets a blank tile.
- #4632 — `ToggleGroupItem.icon` is declared but no renderer reads it (observation-class).
- #4633 — `pnpm --filter @object-ui/example-schema-catalog regenerate` is **destructive on current main**: it blanks six `plugin-dashboard` entries' curated titles and descriptions. NOT run for this PR and not needed (no entry added, removed or renamed; `index.ts` only imports the JSON by path), so `index.ts` is unchanged here.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Qqyix2QcnpUC9XeYVDzx3)_