### PR TITLE
fix(examples,scripts): regenerating the schema catalog stops discarding curated metadata

### DIFF
--- a/examples/schema-catalog/README.md
+++ b/examples/schema-catalog/README.md
@@ -39,23 +39,42 @@ src/
     dashboard/
     forms/
     ...
-  index.ts     # Registry: id -> { schema, meta }
-  types.ts     # ExampleMeta type
+  catalog-meta.json  # Hand-curated title / description / tags, by entry id
+  index.ts           # GENERATED registry: id -> { schema, meta }
+  types.ts           # ExampleMeta type
 test/
   smoke.test.tsx  # Renders every example with SchemaRenderer
 ```
 
+`src/index.ts` is **generated** — a pure function of the schema files and
+`src/catalog-meta.json`. Never edit it by hand: the next person to regenerate
+discards whatever you typed there (objectui#4633, where that is exactly what
+happened to ten entries' curated strings).
+
 ## Adding an example
 
 1. Drop a `.json` file under `src/schemas/<category>/<slug>.json`
-2. Register it in `src/index.ts` with metadata (title, description, tags)
-3. Reference it from MDX:
+2. Give it a real title and description in `src/catalog-meta.json`, keyed by
+   `<category>/<slug>`. Optional — an entry with no curated metadata gets a
+   title derived from its slug and an empty description — but the title and
+   description are user-visible on `/docs/guide/schema-catalog`, so write them.
+3. Regenerate the registry:
+
+   ```bash
+   pnpm --filter @object-ui/example-schema-catalog regenerate
+   ```
+
+   Safe to run on an untouched tree: it produces no diff unless you changed an
+   input. The `regenerate:check` script verifies without writing, and CI runs
+   it (`scripts/__tests__/catalog-index-regenerable-4633.test.ts`).
+
+4. Reference it from MDX:
 
    ```mdx
    <SchemaExample id="auth/login-simple" />
    ```
 
-4. The smoke test picks it up automatically — no per-example test needed.
+5. The smoke test picks it up automatically — no per-example test needed.
 
 ## Consuming from code
 

--- a/examples/schema-catalog/package.json
+++ b/examples/schema-catalog/package.json
@@ -21,6 +21,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "regenerate": "python3 ../../scripts/regenerate-catalog-index.py",
+    "regenerate:check": "python3 ../../scripts/regenerate-catalog-index.py --check",
     "test": "vitest run",
     "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint ."

--- a/examples/schema-catalog/src/catalog-meta.json
+++ b/examples/schema-catalog/src/catalog-meta.json
@@ -1,0 +1,62 @@
+{
+  "auth/forgot-password": {
+    "description": "Request a password reset email.",
+    "tags": [
+      "password",
+      "reset",
+      "form"
+    ]
+  },
+  "auth/login-simple": {
+    "title": "Simple Login Form",
+    "description": "Email + password sign-in with \"remember me\" and a social provider button.",
+    "tags": [
+      "login",
+      "form",
+      "card",
+      "oauth"
+    ]
+  },
+  "auth/signup": {
+    "title": "Sign Up Form",
+    "description": "Two-column registration form with terms acceptance.",
+    "tags": [
+      "signup",
+      "register",
+      "form",
+      "grid"
+    ]
+  },
+  "auth/two-factor": {
+    "title": "Two-Factor Authentication",
+    "description": "6-digit code verification with resend.",
+    "tags": [
+      "2fa",
+      "otp",
+      "verification"
+    ]
+  },
+  "plugin-dashboard/filtered-dashboard": {
+    "description": "Dashboard-level date + region filters driving multiple charts over different objects"
+  },
+  "plugin-dashboard/filtered-dashboard-dataset-widgets": {
+    "title": "Filtered Dashboard — Dataset + Inline Widgets",
+    "description": "Dashboard filters scoping dataset-bound widgets (via the dataset query's runtimeFilter) alongside an inline widget"
+  },
+  "plugin-dashboard/filtered-dashboard-date-presets": {
+    "title": "Filtered Dashboard — Date Presets + Custom Range",
+    "description": "Built-in dateRange with presets and allowCustomRange; per-widget date-field override and a dateRange: false opt-out"
+  },
+  "plugin-dashboard/filtered-dashboard-dynamic-options": {
+    "title": "Filtered Dashboard — Dynamic Options",
+    "description": "Select filter whose options are fetched from object records via optionsFrom (distinct values at runtime)"
+  },
+  "plugin-dashboard/filtered-dashboard-filter-types": {
+    "title": "Filtered Dashboard — Text / Number / Lookup Filters",
+    "description": "Text ($contains), number (equality) and lookup (optionsFrom) filter types, plus a fully opted-out metric"
+  },
+  "plugin-dashboard/filtered-dashboard-target-widgets": {
+    "title": "Filtered Dashboard — Target Widgets Allow-list",
+    "description": "Legacy targetWidgets allow-list: only listed widgets get the default binding; an explicit filterBindings entry still wins"
+  }
+}

--- a/examples/schema-catalog/src/index.ts
+++ b/examples/schema-catalog/src/index.ts
@@ -1,3 +1,15 @@
+/*
+ * GENERATED FILE — DO NOT EDIT BY HAND.
+ *
+ * Rebuild with `pnpm --filter @object-ui/example-schema-catalog regenerate`
+ * (scripts/regenerate-catalog-index.py). Every hand edit to this file is
+ * discarded by the next person who runs it.
+ *
+ * To add an example: drop src/schemas/<category>/<slug>.json, then regenerate.
+ * To give it a real title/description/tags: add an entry to
+ * src/catalog-meta.json — that file is the hand-curated one, and the
+ * generator only ever reads it.
+ */
 import type { Example, ExampleMeta } from './types.js';
 
 import actions_action_button_variants from './schemas/actions/action-button-variants.json' with { type: 'json' };
@@ -433,9 +445,6 @@ export type { Example, ExampleMeta } from './types.js';
  *   - The docs site's <SchemaExample id="..." /> MDX component
  *   - The smoke test that mounts every example
  *   - AI agents performing few-shot retrieval
- *
- * To add an example: drop a JSON file under src/schemas/<cat>/<slug>.json,
- * then re-run `python3 scripts/regenerate-catalog-index.py`.
  */
 const REGISTRY: Record<string, Example> = {
   'actions/action-button-variants': {
@@ -3925,15 +3934,6 @@ const REGISTRY: Record<string, Example> = {
     },
     schema: plugin_dashboard_e_commerce_dashboard,
   },
-  'plugin-dashboard/support-dashboard': {
-    id: 'plugin-dashboard/support-dashboard',
-    meta: {
-      title: "Support Dashboard",
-      description: "",
-      category: 'plugin-dashboard',
-    },
-    schema: plugin_dashboard_support_dashboard,
-  },
   'plugin-dashboard/filtered-dashboard': {
     id: 'plugin-dashboard/filtered-dashboard',
     meta: {
@@ -3987,6 +3987,15 @@ const REGISTRY: Record<string, Example> = {
       category: 'plugin-dashboard',
     },
     schema: plugin_dashboard_filtered_dashboard_target_widgets,
+  },
+  'plugin-dashboard/support-dashboard': {
+    id: 'plugin-dashboard/support-dashboard',
+    meta: {
+      title: "Support Dashboard",
+      description: "",
+      category: 'plugin-dashboard',
+    },
+    schema: plugin_dashboard_support_dashboard,
   },
   'plugin-editor/javascript-editor': {
     id: 'plugin-editor/javascript-editor',

--- a/scripts/__tests__/catalog-index-regenerable-4633.test.ts
+++ b/scripts/__tests__/catalog-index-regenerable-4633.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#4633 — `pnpm --filter @object-ui/example-schema-catalog regenerate`
+ * must be safe to run on an untouched tree.
+ *
+ * The defect: `scripts/regenerate-catalog-index.py` derived every `title` from
+ * the filename and wrote `description: ""` unconditionally. Running the
+ * documented regenerate command on a clean `origin/main` reported success
+ * ("Wrote ... with 423 entries.") while producing a 29-insertion diff that
+ * DISCARDED hand-written metadata for ten entries — six of them
+ * `plugin-dashboard` entries whose strings are user-visible on
+ * /docs/guide/schema-catalog. Anyone adding a catalog entry is expected to run
+ * the script, so every addition silently reverted somebody else's curation, and
+ * the diff looked like ordinary generated-file churn in review.
+ *
+ * The fix moves curated strings into `src/catalog-meta.json`, which the
+ * generator only ever READS, and makes the ordering path-aware. This file pins
+ * both halves:
+ *
+ *  - the checked-in `index.ts` still matches what the generator produces
+ *    (`--check`), so a hand-edit to the generated file — or a curated title
+ *    added there instead of to the sidecar — fails here rather than silently
+ *    at the next author's regeneration;
+ *  - in a hermetic sandbox, that adding an entry and regenerating leaves every
+ *    existing curated string byte-identical, that the ordering is by
+ *    (category, slug), and that `--check` genuinely goes red when the generated
+ *    file drifts.
+ *
+ * The sandbox half is what makes the first half trustworthy: a `--check` that
+ * could never fail would pass forever over a broken generator.
+ *
+ * Reverse verification (direction predicted before running, both measured RED):
+ *  - restore the filename-derived title / empty description in the generator
+ *    and `the checked-in index.ts matches its generator` fails, printing the
+ *    curated strings it would discard;
+ *  - restore the sort over the filename and the same assertion fails on
+ *    `filtered-dashboard` ordering after its `filtered-dashboard-*` siblings.
+ *
+ * The generator is Python because it always has been, and
+ * `examples/schema-catalog/package.json` documents `python3` as the way to run
+ * it; shelling out here keeps ONE source of truth for the output format rather
+ * than re-implementing it in TypeScript and letting the two drift.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+const GENERATOR = path.join(repoRoot, 'scripts', 'regenerate-catalog-index.py');
+const CATALOG = path.join(repoRoot, 'examples', 'schema-catalog');
+
+/** Run the generator rooted at `root`; returns stdout+stderr and the exit code. */
+function runGenerator(
+  root: string,
+  args: string[] = [],
+): { status: number; output: string } {
+  try {
+    const stdout = execFileSync(
+      'python3',
+      [path.join(root, 'scripts', 'regenerate-catalog-index.py'), ...args],
+      { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    return { status: 0, output: stdout };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { status: e.status ?? 1, output: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+/** A minimal repo-shaped tree the generator can run against. */
+function sandbox(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'catalog-regen-4633-'));
+  const schemas = path.join(root, 'examples', 'schema-catalog', 'src', 'schemas');
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  fs.copyFileSync(GENERATOR, path.join(root, 'scripts', 'regenerate-catalog-index.py'));
+
+  fs.mkdirSync(path.join(schemas, 'plugin-dashboard'), { recursive: true });
+  for (const slug of [
+    'filtered-dashboard',
+    'filtered-dashboard-date-presets',
+    'support-dashboard',
+  ]) {
+    fs.writeFileSync(
+      path.join(schemas, 'plugin-dashboard', `${slug}.json`),
+      `${JSON.stringify({ type: 'dashboard' })}\n`,
+    );
+  }
+  fs.writeFileSync(
+    path.join(root, 'examples', 'schema-catalog', 'src', 'catalog-meta.json'),
+    `${JSON.stringify(
+      {
+        'plugin-dashboard/filtered-dashboard-date-presets': {
+          title: 'Filtered Dashboard — Date Presets + Custom Range',
+          description:
+            'Built-in dateRange with presets and allowCustomRange; per-widget date-field override',
+          tags: ['dashboard', 'filters'],
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return root;
+}
+
+const indexOf = (root: string): string =>
+  fs.readFileSync(
+    path.join(root, 'examples', 'schema-catalog', 'src', 'index.ts'),
+    'utf8',
+  );
+
+describe('objectui#4633 — the catalog index is reproducible from its generator', () => {
+  it('the checked-in index.ts matches its generator', () => {
+    const { status, output } = runGenerator(repoRoot, ['--check']);
+    expect(
+      output,
+      'examples/schema-catalog/src/index.ts drifted from ' +
+        'scripts/regenerate-catalog-index.py. Regenerate and commit, and put curated ' +
+        'titles/descriptions in src/catalog-meta.json — never in the generated file.',
+    ).toContain('is up to date');
+    expect(status).toBe(0);
+  });
+
+  it('every id curated in catalog-meta.json still has an entry on disk', () => {
+    const curated = JSON.parse(
+      fs.readFileSync(path.join(CATALOG, 'src', 'catalog-meta.json'), 'utf8'),
+    ) as Record<string, unknown>;
+    expect(Object.keys(curated).length).toBeGreaterThan(0);
+    for (const id of Object.keys(curated)) {
+      const [category, slug] = id.split('/');
+      expect(
+        fs.existsSync(path.join(CATALOG, 'src', 'schemas', category, `${slug}.json`)),
+        `catalog-meta.json curates "${id}", which has no schema file`,
+      ).toBe(true);
+    }
+  });
+
+  it('adding an entry leaves existing curated metadata byte-identical', () => {
+    const root = sandbox();
+    expect(runGenerator(root).status).toBe(0);
+    const before = indexOf(root);
+    const curatedBlock = before.slice(
+      before.indexOf("  'plugin-dashboard/filtered-dashboard-date-presets': {"),
+      before.indexOf('    schema: plugin_dashboard_filtered_dashboard_date_presets,'),
+    );
+    expect(curatedBlock).toContain(
+      'title: "Filtered Dashboard — Date Presets + Custom Range"',
+    );
+    expect(curatedBlock).toContain('tags: ["dashboard", "filters"]');
+
+    fs.writeFileSync(
+      path.join(
+        root,
+        'examples/schema-catalog/src/schemas/plugin-dashboard/brand-new-entry.json',
+      ),
+      `${JSON.stringify({ type: 'dashboard' })}\n`,
+    );
+    expect(runGenerator(root).status).toBe(0);
+    const after = indexOf(root);
+
+    expect(after).toContain("'plugin-dashboard/brand-new-entry'");
+    expect(after).toContain(curatedBlock);
+  });
+
+  it('orders entries by (category, slug), not by filename', () => {
+    const root = sandbox();
+    expect(runGenerator(root).status).toBe(0);
+    const body = indexOf(root).split('const REGISTRY: Record<string, Example> = {')[1];
+    const ids = [...body.matchAll(/^ {2}'([^']+)': \{$/gm)].map((m) => m[1]);
+    // Sorting on the filename compares ".json" and puts the bare slug LAST,
+    // because '-' < '.'; sorting on the parsed slug keeps the prefix first.
+    expect(ids).toEqual([
+      'plugin-dashboard/filtered-dashboard',
+      'plugin-dashboard/filtered-dashboard-date-presets',
+      'plugin-dashboard/support-dashboard',
+    ]);
+  });
+
+  it('--check fails when the generated file is edited by hand', () => {
+    const root = sandbox();
+    expect(runGenerator(root).status).toBe(0);
+    expect(runGenerator(root, ['--check']).status).toBe(0);
+
+    const indexPath = path.join(root, 'examples/schema-catalog/src/index.ts');
+    fs.writeFileSync(
+      indexPath,
+      indexOf(root).replace('description: ""', 'description: "hand-typed, will be lost"'),
+    );
+    const { status, output } = runGenerator(root, ['--check']);
+    expect(status).not.toBe(0);
+    expect(output).toContain('does not match its generator');
+    expect(output).toContain('catalog-meta.json');
+  });
+
+  it('refuses curated metadata for an id with no entry on disk', () => {
+    const root = sandbox();
+    const metaPath = path.join(root, 'examples/schema-catalog/src/catalog-meta.json');
+    const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8')) as Record<string, unknown>;
+    meta['plugin-dashboard/deleted-long-ago'] = { title: 'Gone' };
+    fs.writeFileSync(metaPath, `${JSON.stringify(meta, null, 2)}\n`);
+
+    const { status, output } = runGenerator(root);
+    expect(status).not.toBe(0);
+    expect(output).toContain('plugin-dashboard/deleted-long-ago');
+  });
+});

--- a/scripts/regenerate-catalog-index.py
+++ b/scripts/regenerate-catalog-index.py
@@ -1,49 +1,72 @@
 #!/usr/bin/env python3
 """
-Regenerate examples/schema-catalog/src/index.ts from the JSON files on disk.
+Regenerate examples/schema-catalog/src/index.ts from the files on disk.
 
-Reads every src/schemas/<category>/<slug>.json file and emits a typed registry
-indexed by `<category>/<slug>`. Metadata (title, description, tags) for the
-hand-curated auth category is preserved from a small in-file table; everything
-else gets a title/description derived from /tmp/all-entries.txt (produced by
-the extractor) when available, otherwise from the slug.
+The registry is a PURE FUNCTION of two checked-in inputs:
 
-Run from repo root: python3 scripts/regenerate-catalog-index.py
+  1. examples/schema-catalog/src/schemas/<category>/<slug>.json — the entries
+  2. examples/schema-catalog/src/catalog-meta.json — hand-curated metadata
+     (title / description / tags), keyed by `<category>/<slug>`
+
+Anything not named in (2) gets a slug-derived title and an empty description.
+Run from the repo root:
+
+    python3 scripts/regenerate-catalog-index.py            # rewrite index.ts
+    python3 scripts/regenerate-catalog-index.py --check     # verify, never write
+
+## Why curated metadata lives in a sidecar (objectui#4633)
+
+This script used to derive `title` from the filename and write
+`description: ""` unconditionally, so running it on an untouched tree produced
+a 29-line diff that DISCARDED hand-written titles and descriptions for ten
+entries — six of them `plugin-dashboard` entries whose strings are user-visible
+on /docs/guide/schema-catalog. Anyone adding a catalog entry is expected to run
+this script, so every such addition silently reverted someone else's curation,
+and the churn-shaped diff made it easy to miss in review. The checked-in
+`index.ts` and this script disagreed, and the script won whenever it ran.
+
+The sidecar removes the class rather than the instance: curated strings have a
+home this script only ever READS, so regeneration cannot destroy them, and
+`index.ts` becomes a genuinely derived artifact that nobody is invited to edit.
+
+Two shapes were rejected on the way here:
+
+  - Preserving metadata by parsing the previously generated `index.ts`. That
+    makes the generated artifact its own input — the file can never be rebuilt
+    from scratch, and it keeps authors editing a generated file, which is what
+    made the loss possible in the first place.
+  - Moving metadata into the entry JSON as a `meta` block. `src/types.ts` says
+    metadata is "Kept separate from the schema JSON so the raw schemas remain
+    copy-pasteable into user projects" — and these JSON files are real ObjectUI
+    schemas that the docs site renders, so a non-schema key would ride along
+    into every copy-paste.
+
+Two smaller determinism fixes ship with it:
+
+  - Entries sort by (category, slug), not by filename. Sorting by filename
+    compares the ".json" suffix, so "filtered-dashboard.json" sorted AFTER
+    "filtered-dashboard-dataset-widgets.json" ('-' < '.'), reordering the
+    registry on every run.
+  - The old best-effort read of /tmp/all-entries.txt is gone. Output must not
+    depend on machine-local state outside the repo: with that file present the
+    same tree regenerated to different bytes.
+
+`scripts/__tests__/catalog-index-regenerable-4633.test.ts` runs `--check` in CI,
+so a hand-edit to index.ts (or a curated string added there instead of to the
+sidecar) fails immediately instead of at the next author's regeneration.
 """
 import json
-import os
 import re
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-SCHEMAS = ROOT / 'examples/schema-catalog/src/schemas'
-OUT = ROOT / 'examples/schema-catalog/src/index.ts'
-ENTRIES_FILE = Path('/tmp/all-entries.txt')
+CATALOG = ROOT / 'examples/schema-catalog'
+SCHEMAS = CATALOG / 'src/schemas'
+CURATED_META = CATALOG / 'src/catalog-meta.json'
+OUT = CATALOG / 'src/index.ts'
 
-# Hand-curated metadata for categories migrated before tagging support.
-HANDCRAFTED = {
-    'auth/login-simple': {
-        'title': 'Simple Login Form',
-        'description': 'Email + password sign-in with "remember me" and a social provider button.',
-        'tags': ['login', 'form', 'card', 'oauth'],
-    },
-    'auth/signup': {
-        'title': 'Sign Up Form',
-        'description': 'Two-column registration form with terms acceptance.',
-        'tags': ['signup', 'register', 'form', 'grid'],
-    },
-    'auth/forgot-password': {
-        'title': 'Forgot Password',
-        'description': 'Request a password reset email.',
-        'tags': ['password', 'reset', 'form'],
-    },
-    'auth/two-factor': {
-        'title': 'Two-Factor Authentication',
-        'description': '6-digit code verification with resend.',
-        'tags': ['2fa', 'otp', 'verification'],
-    },
-}
+META_KEYS = ('title', 'description', 'tags')
 
 
 def ident(category: str, slug: str) -> str:
@@ -56,45 +79,74 @@ def slug_to_title(slug: str) -> str:
     return ' '.join(w.capitalize() for w in slug.split('-'))
 
 
-def parse_extracted_meta() -> dict:
-    """Read /tmp/all-entries.txt produced by extract-mdx-demos.mjs and return
-    a map of id -> {title, description}. Best-effort; missing entries fall back
-    to slug-derived titles."""
-    out: dict[str, dict] = {}
-    if not ENTRIES_FILE.exists():
-        return out
-    txt = ENTRIES_FILE.read_text()
-    pattern = re.compile(
-        r"'([^']+)':\s*\{\s*id:\s*'[^']+',\s*meta:\s*\{\s*"
-        r"title:\s*(\"[^\"]*\"|'[^']*'),\s*"
-        r"description:\s*(\"[^\"]*\"|'[^']*'),\s*"
-        r"category:\s*'[^']+'",
-    )
-    for m in pattern.finditer(txt):
-        out[m.group(1)] = {
-            'title': m.group(2)[1:-1],
-            'description': m.group(3)[1:-1],
-        }
-    return out
+def load_curated() -> dict:
+    """Read the hand-curated metadata sidecar.
+
+    Validated rather than merged blindly: a key for an entry that no longer
+    exists, or a metadata field we do not emit, is a silent no-op otherwise —
+    the author sees their curation "land" and never appears in the output.
+    """
+    if not CURATED_META.exists():
+        return {}
+    data = json.loads(CURATED_META.read_text())
+    if not isinstance(data, dict):
+        die(f"{rel(CURATED_META)} must be a JSON object keyed by '<category>/<slug>'.")
+    for entry_id, meta in data.items():
+        if not isinstance(meta, dict):
+            die(f"{rel(CURATED_META)}: '{entry_id}' must map to an object.")
+        unknown = sorted(set(meta) - set(META_KEYS))
+        if unknown:
+            die(
+                f"{rel(CURATED_META)}: '{entry_id}' declares unsupported "
+                f"key(s) {unknown}. Supported: {list(META_KEYS)}.",
+            )
+    return data
 
 
 def collect_examples() -> list[dict]:
+    """Every entry on disk, ordered by (category, slug).
+
+    Sorting on the parsed pair rather than on the filename keeps sibling slugs
+    that share a prefix in their natural order, and makes the order independent
+    of the file extension.
+    """
     examples = []
-    for category_dir in sorted(SCHEMAS.iterdir()):
+    for category_dir in sorted(SCHEMAS.iterdir(), key=lambda p: p.name):
         if not category_dir.is_dir():
             continue
         category = category_dir.name
-        for json_file in sorted(category_dir.glob('*.json')):
+        for json_file in category_dir.glob('*.json'):
             slug = json_file.stem
-            examples.append({'category': category, 'slug': slug, 'id': f'{category}/{slug}'})
+            examples.append(
+                {'category': category, 'slug': slug, 'id': f'{category}/{slug}'},
+            )
+    examples.sort(key=lambda e: (e['category'], e['slug']))
     return examples
 
 
-def main():
-    extracted = parse_extracted_meta()
-    examples = collect_examples()
+def rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
 
+
+def die(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def render(examples: list[dict], curated: dict) -> str:
     lines = []
+    lines.append('/*')
+    lines.append(' * GENERATED FILE — DO NOT EDIT BY HAND.')
+    lines.append(' *')
+    lines.append(' * Rebuild with `pnpm --filter @object-ui/example-schema-catalog regenerate`')
+    lines.append(' * (scripts/regenerate-catalog-index.py). Every hand edit to this file is')
+    lines.append(' * discarded by the next person who runs it.')
+    lines.append(' *')
+    lines.append(' * To add an example: drop src/schemas/<category>/<slug>.json, then regenerate.')
+    lines.append(' * To give it a real title/description/tags: add an entry to')
+    lines.append(' * src/catalog-meta.json — that file is the hand-curated one, and the')
+    lines.append(' * generator only ever reads it.')
+    lines.append(' */')
     lines.append("import type { Example, ExampleMeta } from './types.js';")
     lines.append("")
 
@@ -114,27 +166,22 @@ def main():
     lines.append(" *   - The docs site's <SchemaExample id=\"...\" /> MDX component")
     lines.append(" *   - The smoke test that mounts every example")
     lines.append(" *   - AI agents performing few-shot retrieval")
-    lines.append(" *")
-    lines.append(" * To add an example: drop a JSON file under src/schemas/<cat>/<slug>.json,")
-    lines.append(" * then re-run `python3 scripts/regenerate-catalog-index.py`.")
     lines.append(" */")
     lines.append("const REGISTRY: Record<string, Example> = {")
 
     for e in examples:
         var = ident(e['category'], e['slug'])
-        meta = HANDCRAFTED.get(e['id'], {})
-        title = meta.get('title') or extracted.get(e['id'], {}).get('title') or slug_to_title(e['slug'])
+        meta = curated.get(e['id'], {})
+        title = meta.get('title') or slug_to_title(e['slug'])
         desc = meta.get('description', '')
-        if not desc:
-            desc = extracted.get(e['id'], {}).get('description', '')
         lines.append(f"  '{e['id']}': {{")
         lines.append(f"    id: '{e['id']}',")
         lines.append("    meta: {")
-        lines.append(f"      title: {json.dumps(title)},")
-        lines.append(f"      description: {json.dumps(desc)},")
+        lines.append(f"      title: {json.dumps(title, ensure_ascii=False)},")
+        lines.append(f"      description: {json.dumps(desc, ensure_ascii=False)},")
         lines.append(f"      category: '{e['category']}',")
-        if 'tags' in meta:
-            lines.append(f"      tags: {json.dumps(meta['tags'])},")
+        if meta.get('tags'):
+            lines.append(f"      tags: {json.dumps(meta['tags'], ensure_ascii=False)},")
         lines.append("    },")
         lines.append(f"    schema: {var},")
         lines.append("  },")
@@ -167,8 +214,62 @@ def main():
     lines.append("  return Object.keys(REGISTRY);")
     lines.append("}")
 
-    OUT.write_text("\n".join(lines) + "\n")
-    print(f"Wrote {OUT.relative_to(ROOT)} with {len(examples)} entries.")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    unknown_args = [a for a in args if a != '--check']
+    if unknown_args:
+        die(f"unknown argument(s) {unknown_args}. Usage: {Path(__file__).name} [--check]")
+    check_only = '--check' in args
+
+    curated = load_curated()
+    examples = collect_examples()
+
+    known = {e['id'] for e in examples}
+    stale = sorted(set(curated) - known)
+    if stale:
+        die(
+            f"{rel(CURATED_META)} curates {len(stale)} id(s) with no entry on disk: "
+            + ', '.join(stale)
+            + "\n       Either restore src/schemas/<id>.json or drop the curated entry — "
+            "a curated id that matches nothing is metadata the registry will never show.",
+        )
+
+    content = render(examples, curated)
+
+    if check_only:
+        current = OUT.read_text() if OUT.exists() else ''
+        if current == content:
+            print(f"{rel(OUT)} is up to date ({len(examples)} entries).")
+            return
+        import difflib
+        diff = list(
+            difflib.unified_diff(
+                current.splitlines(keepends=True),
+                content.splitlines(keepends=True),
+                fromfile=f"{rel(OUT)} (checked in)",
+                tofile=f"{rel(OUT)} (regenerated)",
+                n=1,
+            ),
+        )
+        sys.stderr.writelines(diff[:120])
+        if len(diff) > 120:
+            print(f"... ({len(diff) - 120} more diff lines)", file=sys.stderr)
+        die(
+            f"{rel(OUT)} does not match its generator.\n"
+            "       Run `pnpm --filter @object-ui/example-schema-catalog regenerate` and "
+            "commit the result.\n"
+            f"       Curated titles/descriptions belong in {rel(CURATED_META)}, not in the "
+            "generated file.",
+        )
+
+    OUT.write_text(content)
+    print(
+        f"Wrote {rel(OUT)} with {len(examples)} entries "
+        f"({len(curated)} carrying curated metadata from {rel(CURATED_META)}).",
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #4633

## The defect, re-measured against current `origin/main`

The card measured at `69eb6b22b`; three merges have landed on this surface since
(`665661a`, `69eb6b2`, `e028dfc`). Re-measured at `5bf5d2cb6` — **premise still valid,
identical shape and identical counts**:

```
$ git status --short           # clean tree
$ python3 scripts/regenerate-catalog-index.py
Wrote examples/schema-catalog/src/index.ts with 423 entries.
$ git diff --stat
 examples/schema-catalog/src/index.ts | 58 ++++++++++++++++++------------------
 1 file changed, 29 insertions(+), 29 deletions(-)
```

Both mechanisms the card names were confirmed in the script before choosing a fix:

- `title` was derived from the filename and `description: ""` written unconditionally,
  so **ten** entries lost curated metadata (the card measured six `plugin-dashboard`
  entries; the full set is those six plus the four `auth` entries, which survived only
  because the script carried a hard-coded `HANDCRAFTED` table for them).
- Ordering sorted `Path` objects, i.e. the filename **including `.json`**. `'-' < '.'`,
  so `filtered-dashboard.json` sorted *after* `filtered-dashboard-dataset-widgets.json`.

A third source of nondeterminism was found that the card does not mention: the script
read `/tmp/all-entries.txt` as a best-effort metadata source. Output that depends on a
machine-local absolute path outside the repo cannot satisfy "reproducible from its
generator" — with that file present, the same tree regenerates to different bytes.

## The fix — shape (2), via a sidecar rather than the entry JSON

The card offered two shapes and preferred (2), "removing the class rather than the
instance". This PR takes (2), but puts the curated block in a **sidecar**,
`examples/schema-catalog/src/catalog-meta.json`, rather than inside each entry JSON.
The reason is an explicit in-repo invariant — `examples/schema-catalog/src/types.ts`:

> Metadata describing an example. **Kept separate from the schema JSON so the raw
> schemas remain copy-pasteable into user projects.**

Those entry JSONs are real ObjectUI schemas that the docs site renders and that users
copy-paste; a `meta` key inside them would ride along into every copy and add a
non-schema key to a live schema surface. The sidecar gets shape (2)'s durability —
curated strings live somewhere the generator only ever **reads**, so regeneration
cannot destroy them — without contaminating the schemas. `index.ts` becomes a
genuinely derived artifact, and it now carries a `GENERATED FILE — DO NOT EDIT BY HAND`
banner pointing authors at the sidecar.

Shape (1) (preserve by parsing the previously generated `index.ts`) was rejected: it
makes the generated artifact its own input, so the file can never be rebuilt from
scratch, and it keeps authors editing a generated file — which is the very thing that
made the loss possible.

Also in scope, both required for "reproducible from its generator":

- entries sort by `(category, slug)`, not by filename;
- the `/tmp/all-entries.txt` read is gone.

## Verification evidence

### (a) `regenerate` on a clean tree produces zero diff

```
$ git status --short                       # clean, at HEAD of this branch
$ python3 scripts/regenerate-catalog-index.py
Wrote examples/schema-catalog/src/index.ts with 423 entries (10 carrying curated metadata from examples/schema-catalog/src/catalog-meta.json).
$ git diff --stat
                                           # empty — zero diff
```

Byte-level idempotence, two consecutive runs:

```
$ md5sum examples/schema-catalog/src/index.ts
480ae21abd4d445dc0bea3857a5fe440  examples/schema-catalog/src/index.ts
$ python3 scripts/regenerate-catalog-index.py >/dev/null && md5sum examples/schema-catalog/src/index.ts
480ae21abd4d445dc0bea3857a5fe440  examples/schema-catalog/src/index.ts
```

### (b) regenerating after adding a new entry preserves every curated string

```
$ echo '{ "type": "dashboard", "title": "Brand New" }' > examples/schema-catalog/src/schemas/plugin-dashboard/brand-new-entry.json
$ python3 scripts/regenerate-catalog-index.py
Wrote examples/schema-catalog/src/index.ts with 424 entries (10 carrying curated metadata from examples/schema-catalog/src/catalog-meta.json).
$ git diff examples/schema-catalog/src/index.ts
```

The whole diff is the new entry — one import line and one nine-line registry block:

```diff
+import plugin_dashboard_brand_new_entry from './schemas/plugin-dashboard/brand-new-entry.json' with { type: 'json' };
...
+  'plugin-dashboard/brand-new-entry': {
+    id: 'plugin-dashboard/brand-new-entry',
+    meta: {
+      title: "Brand New Entry",
+      description: "",
+      category: 'plugin-dashboard',
+    },
+    schema: plugin_dashboard_brand_new_entry,
+  },
```

Nothing else moved. On `origin/main` the same two commands emit 29 extra destructive
lines alongside that block — that is the whole bug.

### No curated metadata was lost in the migration

The sidecar was extracted mechanically, then the result was proved equal to the
pre-change file. All 423 registry entries were parsed out of `index.ts` before and
after and compared field by field:

```
entries before/after: 423 423
id set identical: True
entries whose meta changed: 0
entries whose registry position changed: 7
  ['plugin-dashboard/support-dashboard', 'plugin-dashboard/filtered-dashboard',
   'plugin-dashboard/filtered-dashboard-dataset-widgets',
   'plugin-dashboard/filtered-dashboard-date-presets',
   'plugin-dashboard/filtered-dashboard-dynamic-options',
   'plugin-dashboard/filtered-dashboard-filter-types',
   'plugin-dashboard/filtered-dashboard-target-widgets']
```

**Zero** `title`/`description`/`tags` changed across all 423 entries. The only
substantive change to `index.ts` in this PR is that `plugin-dashboard/support-dashboard`
moves to its sorted position: the checked-in registry body had it hand-inserted *before*
`filtered-dashboard`, so the file's own import block and registry body were already in
different orders. Both are now canonically `(category, slug)`-sorted. The gallery on
`/docs/guide/schema-catalog` renders in registry order, so one card within the
`plugin-dashboard` group moves; no card gains, loses or changes a string.

### Reverse verification — direction predicted before running, both legs RED

Predicted RED for both, and both were measured RED (each restored from the commit
afterwards; the generator's blob hash was checked equal to `HEAD`'s to prove identity):

1. Restore the filename-derived title and unconditional empty description →
   `the checked-in index.ts matches its generator` **and** `adding an entry leaves
   existing curated metadata byte-identical` both fail, the second naming the exact
   curated string that would be discarded.
2. Restore the sort over the filename →
   `orders entries by (category, slug), not by filename` **and** the `--check`
   assertion both fail, the diff naming `filtered-dashboard` moving after its
   `filtered-dashboard-*` siblings.

### Gate added

`scripts/__tests__/catalog-index-regenerable-4633.test.ts` (6 tests). It runs
`regenerate --check` against the real tree, so a hand-edit to the generated file — or a
curated title typed there instead of into the sidecar — fails in CI rather than silently
at the next author's regeneration. The other five run in a hermetic `mkdtemp` sandbox
and prove the gate can actually fail: adding an entry preserves curated strings
byte-for-byte, ordering is `(category, slug)`, `--check` goes red on a hand-edit, and
curated metadata for an id with no entry on disk is refused rather than silently ignored.
It shells out to `python3` rather than re-implementing the output format in TypeScript,
so there stays exactly one source of truth for the format.

## Local verification (all at `7db3160`, this branch's HEAD)

| Command | Result |
| --- | --- |
| `pnpm exec vitest run examples/schema-catalog scripts/__tests__/catalog-index-regenerable-4633.test.ts scripts/__tests__/turbo-build-inputs.test.ts scripts/__tests__/check-type-check-coverage.test.ts` | 11 files, 1641 tests passed |
| `pnpm --filter @object-ui/example-schema-catalog type-check` | pass |
| `pnpm --filter @object-ui/example-schema-catalog lint` | pass, 0 errors (2 pre-existing warnings, unchanged from `main`) |
| `pnpm type-check:scripts` | pass |
| `node scripts/check-control-bytes.mjs` | pass (4176 files) |
| `node scripts/check-changeset-presence.mjs` | pass — no changeset owed |
| `pnpm --filter '@object-ui/example-schema-catalog^...' build` | pass |

The vitest run includes the catalog package's own eight suites — among them the smoke
test that mounts every one of the 423 examples through `SchemaRenderer`, which is what
covers the ordering change and the new banner against the docs-site gallery.

## Changeset

None, and none is owed. `@object-ui/example-*` is in the `ignore` list of
`.changeset/config.json`, and `scripts/` is not a workspace package, so nothing this PR
touches is under the `src/` of a released package. `node scripts/check-changeset-presence.mjs`
confirms mechanically:

```
Compared the working tree with 5bf5d2cb6 (merge-base with origin/main): 6 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets
ignores, 0 changeset(s) added.
No source of a released package changed in this range, so no changeset is owed.
```

## File surface note

The dispatch named `scripts/regenerate-catalog-index.py` + `examples/schema-catalog/src/index.ts`
(+ entry JSON files if shape 2 were chosen). Four files outside that list are touched, all
inside the same package and all required by the fix — flagged here rather than shipped quietly:

- `examples/schema-catalog/src/catalog-meta.json` — **new**; the sidecar that replaces the
  entry-JSON `meta` block shape 2 would have used.
- `examples/schema-catalog/README.md` — its "Adding an example" section said *"Register it
  in `src/index.ts` with metadata (title, description, tags)"*, i.e. it documented the
  destructive workflow as the correct one. Leaving it would ship a fix whose own docs
  instruct people to do the thing it prevents.
- `examples/schema-catalog/package.json` — adds `regenerate:check` alongside `regenerate`.
- `scripts/__tests__/catalog-index-regenerable-4633.test.ts` — **new**; the gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_