### PR TITLE
fix(app-shell): restore the avatar menu "My Workspaces" entry

### DIFF
--- a/.changeset/tidy-donkeys-attack.md
+++ b/.changeset/tidy-donkeys-attack.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Restore the avatar menu's "My Workspaces" entry, which navigates to
+`/organizations?manage=1`.
+
+Users belonging to exactly one organization had no UI path to the workspace
+management pages (Members / Invitations / Organization settings). Three
+individually reasonable behaviours closed every door at once: `/organizations`
+auto-skips the picker for single-org users, the header `WorkspaceSwitcher`
+(which carries "Manage members") renders nothing below two organizations, and
+the avatar menu had kept only the `?create=1` entry. Reaching member management
+required hand-typing the URL.
+
+The entry is not gated on `multiOrgEnabled` — that flag governs creating
+organizations, and where self-service creation is disabled this entry is the
+only way in.

--- a/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
+++ b/packages/app-shell/src/console/organizations/OrganizationsPage.tsx
@@ -39,10 +39,15 @@ export function OrganizationsPage() {
   const { t } = useObjectTranslation();
   const navigate = useNavigate();
   // Two deliberate ways to reach this page (vs the auto-skipping post-login
-  // redirect): `?manage=1` (avatar menu "My Organizations") shows the picker;
-  // `?create=1` (avatar menu "Create workspace") additionally opens the create
-  // dialog directly. Both suppress the single-org auto-skip below so a
-  // single-org user can actually reach "New organization" / the dialog.
+  // redirect), both from the avatar menu:
+  //   `?manage=1` ("My Workspaces") — the user came to MANAGE. With ≥2 orgs
+  //     that means the picker; with exactly one it RE-TARGETS the auto-skip
+  //     below at that org's members page rather than suppressing it, since a
+  //     one-item picker is not a choice. Either way they land somewhere they
+  //     can act, which is the point (objectstack#8096).
+  //   `?create=1` ("Create workspace") — suppresses the auto-skip outright and
+  //     opens the create dialog, so a single-org user can reach "New
+  //     organization" instead of being bounced back into their existing org.
   const [searchParams] = useSearchParams();
   const manageMode = searchParams.get('manage') === '1';
   const wantsCreate = searchParams.get('create') === '1';
@@ -128,7 +133,7 @@ export function OrganizationsPage() {
     if (orgList.length !== 1) return;
     autoSelectedRef.current = true;
     // Single-org users have no real choice to make. In manage mode (`?manage=1`,
-    // used by the Cloud app "Members" nav and the avatar "My Organizations"
+    // used by the Cloud app "Members" nav and the avatar "My Workspaces"
     // entry), skip the pointless one-item picker and deep-link straight to that
     // org's member management; otherwise switch into the org and land on home.
     if (manageMode) {

--- a/packages/app-shell/src/layout/AppHeader.tsx
+++ b/packages/app-shell/src/layout/AppHeader.tsx
@@ -44,6 +44,7 @@ import {
   Layers,
   Bot,
   User,
+  Building2,
   BookOpen,
   ExternalLink,
   Keyboard,
@@ -893,10 +894,34 @@ export function AppHeader({
                 <User className="mr-2 h-4 w-4" />
                 {t('user.profile', { defaultValue: 'Profile' })}
               </DropdownMenuItem>
-              {/* "My Organizations" moved to the global WorkspaceSwitcher in the
-                  header-left (switch + manage members live there now). Only the
-                  create-workspace shortcut stays here, so single-org users —
-                  whose switcher has no dropdown — can still create a second org. */}
+              {/*
+               * Workspace entries. The header-left WorkspaceSwitcher carries
+               * the same destinations, but it renders NOTHING below two orgs
+               * (`orgList.length <= 1` → null) — so for the single-org majority
+               * the avatar menu is the ONLY door to workspace management.
+               * Leaving just the create shortcut here is what shut every path
+               * to Members / Invitations / Organization settings for them
+               * (objectstack#8096): the picker at `/organizations` auto-skips
+               * with one org, and the switcher never appears.
+               *
+               * "My Workspaces" → `?manage=1`, which OrganizationsPage reads as
+               * "the user came here to MANAGE": multi-org users get the picker,
+               * a single-org user is deep-linked straight to that org's members
+               * page (there is no choice worth showing them). Deliberately NOT
+               * gated on `multiOrgDisabled` — that flag governs CREATING orgs;
+               * where self-service creation is off this entry is the only way
+               * in, so gating it there would re-close the door.
+               */}
+              {hasOrgSection && (
+                <DropdownMenuItem
+                  onClick={() => navigate('/organizations?manage=1')}
+                  className="cursor-pointer"
+                  data-testid="header-my-organizations"
+                >
+                  <Building2 className="mr-2 h-4 w-4" />
+                  {t('organizations.mine', { defaultValue: 'My Workspaces' })}
+                </DropdownMenuItem>
+              )}
               {hasOrgSection && !multiOrgDisabled && (
                 <DropdownMenuItem
                   onClick={() => navigate('/organizations?create=1')}

--- a/packages/app-shell/src/layout/__tests__/AppHeader.myOrganizations.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/AppHeader.myOrganizations.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectstack#8096 — a user in exactly ONE organization had no UI path to the
+ * workspace management pages (Members / Invitations / Organization settings).
+ * Three individually-reasonable mechanisms closed every door at once:
+ *
+ *   1. `/organizations` auto-skips the picker at one org (UX P0-1, deliberate);
+ *   2. `WorkspaceSwitcher` returns null at `orgList.length <= 1`, so the
+ *      header-left switcher — and its "Manage members" item — never renders;
+ *   3. the avatar menu kept only the `?create=1` entry, having dropped the
+ *      `?manage=1` "My Organizations" one on the assumption that (2) covered it.
+ *
+ * The fix restores (3), which the code's own comments already documented as the
+ * intended design. These cases pin the restored entry AND the reason it has to
+ * be the avatar menu: they assert it with the switcher rendering nothing, which
+ * is precisely the single-org configuration where the defect bit.
+ *
+ * The destination is load-bearing, not cosmetic: `?manage=1` is what
+ * OrganizationsPage reads as "came here to manage", which for a single-org user
+ * re-targets the auto-skip at `/organizations/:slug/members` instead of
+ * bouncing them home. A bare `/organizations` link would dead-end in exactly
+ * the auto-skip this card is about, so the query string is asserted verbatim.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/home', search: '', hash: '', state: null, key: 'test' }),
+  useParams: () => ({}),
+  useNavigate: () => navigate,
+  useSearchParams: () => [new URLSearchParams(), vi.fn()] as const,
+  Link: ({ children, to, ...p }: any) => <a href={String(to)} {...p}>{children}</a>,
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    language: 'en',
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+  }),
+  useObjectLabel: () => ({
+    objectLabel: (n: string) => n,
+    dashboardLabel: (n: string) => n,
+    pageLabel: (n: string) => n,
+    reportLabel: (n: string) => n,
+    viewLabel: (n: string) => n,
+    appLabel: (n: string) => n,
+  }),
+}));
+
+/**
+ * Passthrough menu primitives — unlike the sibling inbox test, the avatar
+ * dropdown's CONTENT is the subject here, so `DropdownMenuContent` must render
+ * its children rather than the `() => null` that suffices when only the bell is
+ * under test. Radix would otherwise keep the closed menu unmounted in jsdom.
+ */
+vi.mock('@object-ui/components', () => {
+  const stripProps = (p: any) => {
+    const { asChild, variant, size, align, sideOffset, ...rest } = p ?? {};
+    return rest;
+  };
+  const Pass = ({ children, ...p }: any) => <div {...stripProps(p)}>{children}</div>;
+  return {
+    Button: ({ children, asChild, variant, size, ...p }: any) => (
+      <button type="button" {...p}>{children}</button>
+    ),
+    DropdownMenu: Pass,
+    DropdownMenuTrigger: Pass,
+    DropdownMenuContent: Pass,
+    // Menu items must be clickable — the assertion is where `onClick` navigates.
+    DropdownMenuItem: ({ children, onClick, ...p }: any) => (
+      <button type="button" onClick={onClick} {...stripProps(p)}>{children}</button>
+    ),
+    DropdownMenuLabel: Pass,
+    DropdownMenuSeparator: () => null,
+    DropdownMenuGroup: Pass,
+    Avatar: Pass,
+    AvatarImage: () => null,
+    AvatarFallback: Pass,
+    Popover: Pass,
+    PopoverTrigger: Pass,
+    PopoverContent: () => null,
+    Tabs: Pass,
+    TabsList: Pass,
+    TabsTrigger: ({ children }: any) => <button type="button">{children}</button>,
+    TabsContent: Pass,
+    cn: (...c: any[]) => c.filter(Boolean).join(' '),
+  };
+});
+
+vi.mock('lucide-react', () => {
+  const Icon = () => <span />;
+  return new Proxy({ __esModule: true } as Record<string | symbol, unknown>, {
+    get: (target, prop) => {
+      if (prop === 'then' || prop === '__esModule' || typeof prop === 'symbol') {
+        return target[prop];
+      }
+      return Icon;
+    },
+    has: (_target, prop) => prop !== 'then',
+  });
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useOffline: () => ({ isOnline: true }),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  PresenceAvatars: () => null,
+  useTenantPresence: () => [],
+}));
+
+vi.mock('../ModeToggle', () => ({ ModeToggle: () => null }));
+vi.mock('../LocaleSwitcher', () => ({ LocaleSwitcher: () => null }));
+vi.mock('../ConnectionStatus', () => ({ ConnectionStatus: () => null }));
+vi.mock('../AppSwitcher', () => ({ AppSwitcher: () => null }));
+vi.mock('../LocalizedSidebarTrigger', () => ({ LocalizedSidebarTrigger: () => null }));
+vi.mock('../PreviewBadge', () => ({ PreviewBadge: () => null }));
+
+/**
+ * The REAL WorkspaceSwitcher, deliberately — mocking it away would erase the
+ * precondition under test. Its `orgList.length <= 1` early return is what
+ * leaves the avatar menu as the only door, so the cases below get to assert
+ * that it renders nothing while the avatar entry is present.
+ */
+vi.mock('../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ apps: [], dashboards: [], pages: [], reports: [] }),
+}));
+
+const ONE_ORG = { id: 'org_1', name: 'Acme', slug: 'acme' };
+
+/** Orgs the mocked `useAuth` reports for the current case. */
+let organizations: Array<Record<string, unknown>> = [ONE_ORG];
+/** `features.multiOrgEnabled` the mocked auth config resolves with. */
+let multiOrgEnabled = true;
+
+vi.mock('@object-ui/auth', () => {
+  /**
+   * ONE stable function identity for the whole file — not a fresh arrow per
+   * `useAuth()` call. Both AppHeader and WorkspaceSwitcher resolve this config
+   * in a `useEffect(..., [getAuthConfig])` that ends in `setState`, so handing
+   * back a new closure each render makes the dep array change every render:
+   * effect → setState → render → effect, until the heap dies (the failure is a
+   * V8 OOM during collection, not a test assertion). Reading the `let` at CALL
+   * time keeps per-case control without touching identity.
+   */
+  const getAuthConfig = () => Promise.resolve({ features: { multiOrgEnabled } });
+  return {
+    useAuth: () => ({
+      user: { id: 'u1', name: 'Zhang San', email: 'zs@example.com' },
+      signOut: vi.fn(),
+      isAuthEnabled: true,
+      organizations,
+      activeOrganization: organizations[0] ?? null,
+      isOrganizationsLoading: false,
+      switchOrganization: vi.fn(),
+      getAuthConfig,
+    }),
+    getUserInitials: () => 'ZS',
+    useIsWorkspaceAdmin: () => false,
+  };
+});
+
+/**
+ * Stable adapter identity, for the same reason as `getAuthConfig` above — the
+ * bell's pollers key their effects off the adapter, so a fresh object per call
+ * would re-arm them on every render.
+ */
+const fakeAdapter = {
+  find: () => Promise.resolve({ data: [] }),
+  getClient: () => undefined,
+};
+
+vi.mock('../../providers/AdapterProvider', () => ({
+  useAdapter: () => fakeAdapter,
+}));
+
+import { AppHeader } from '../AppHeader';
+
+beforeEach(() => {
+  navigate.mockClear();
+  organizations = [ONE_ORG];
+  multiOrgEnabled = true;
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response('{}', { status: 404 }))));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('AppHeader avatar menu — the single-org door to workspace management (#8096)', () => {
+  it('offers "My Workspaces" to a user with exactly one organization', () => {
+    render(<AppHeader variant="home" />);
+
+    expect(screen.getByTestId('header-my-organizations')).toBeInTheDocument();
+  });
+
+  it('navigates to /organizations?manage=1 — the query string the manage flow reads', () => {
+    render(<AppHeader variant="home" />);
+
+    screen.getByTestId('header-my-organizations').click();
+
+    expect(navigate).toHaveBeenCalledWith('/organizations?manage=1');
+  });
+
+  it('is the ONLY door: the workspace switcher renders nothing at one org', () => {
+    render(<AppHeader variant="home" />);
+
+    // The precondition that made #8096 bite. If this ever starts rendering,
+    // the switcher's single-org early return changed and the premise of this
+    // whole file should be re-read — not the assertion silently relaxed.
+    expect(screen.queryByTestId('workspace-switcher')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-manage-members')).not.toBeInTheDocument();
+    expect(screen.getByTestId('header-my-organizations')).toBeInTheDocument();
+  });
+
+  it('survives multi-org self-service being disabled — that flag governs CREATE only', async () => {
+    multiOrgEnabled = false;
+    render(<AppHeader variant="home" />);
+
+    // Where creation is off this entry is the only way into the manage pages,
+    // so gating it on the same flag as "Create workspace" would re-close the
+    // door. Await a tick so the async `getAuthConfig` gate has resolved.
+    await vi.waitFor(() =>
+      expect(screen.queryByTestId('header-create-workspace')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('header-my-organizations')).toBeInTheDocument();
+  });
+
+  it('still offers it to a multi-org user (the switcher is a duplicate, not a replacement)', () => {
+    organizations = [ONE_ORG, { id: 'org_2', name: 'Globex', slug: 'globex' }];
+    render(<AppHeader variant="home" />);
+
+    expect(screen.getByTestId('header-my-organizations')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#8096

## The defect

A user belonging to exactly **one** organization had no UI path to the workspace
management pages (Members / Invitations / Organization settings). Three
individually reasonable behaviours closed every door at once:

1. `/organizations` auto-skips the picker at one org (UX P0-1, deliberate).
2. `WorkspaceSwitcher` returns null at one org or fewer, so the header-left
   switcher — and its "Manage members" item — never renders for them.
3. The avatar menu kept only the `?create=1` entry, having dropped the
   `?manage=1` "My Organizations" one on the assumption that (2) covered it.

Reaching member management required hand-typing `/_console/organizations?manage=1`.

## The fix

Restore (3) — the narrowest change, and the one both `AppHeader`'s and
`OrganizationsPage`'s own comments already documented as the intended design.
The switcher's single-org early return is deliberately left alone, and no
Setup-side links were added.

The destination is load-bearing rather than cosmetic. `?manage=1` is what
`OrganizationsPage` reads as "the user came here to manage": with two or more
orgs it shows the picker, and with exactly one it **re-targets** the auto-skip at
`/organizations/:slug/members` instead of bouncing the user home. So the
restored entry lands a single-org user directly on member management — it does
not dead-end in the very auto-skip this card is about.

The entry is deliberately **not** gated on `multiOrgEnabled`. That flag governs
*creating* organizations (it is why "Create workspace" is gated); where
self-service creation is disabled this entry is the only way in, so gating it the
same way would re-close the door.

### Label

Reuses the existing `organizations.mine` key rather than minting one. It is
already shipped in all ten locale packs and had been left dormant when the entry
was removed — no locale files are touched, and `check:i18n-keys` confirms the
inline `defaultValue` matches the en pack value exactly.

### Comment reconciliation

`OrganizationsPage`'s comment claimed `?manage=1` "shows the picker". For the
single-org majority it does not — it re-targets the auto-skip at that org's
members page, which is what makes the restored entry a real door. Corrected to
describe both branches; `AppHeader`'s comment (which claimed the entry had moved
to the switcher) is rewritten to record why the avatar menu has to carry it.

## Verification

All at `bc89db3` (the tip of this branch; no commits followed the run).

- **New test** `packages/app-shell/src/layout/__tests__/AppHeader.myOrganizations.test.tsx`
  — 5 cases. Asserts the entry exists for a single-org user, navigates to
  `/organizations?manage=1` verbatim, is present *while the real switcher renders
  nothing* (the precondition that made this bite), survives `multiOrgEnabled:
  false`, and is still offered to multi-org users.
- **Reverse verification** — direction predicted before running: since all five
  cases assert on the `header-my-organizations` testid, reverting `AppHeader` to
  `origin/main` must fail all five. Observed exactly `Tests 5 failed (5)`;
  restore confirmed byte-identical to HEAD via `git diff --quiet HEAD`.
- **Blast radius** — `vitest run packages/app-shell/src/layout/ packages/app-shell/src/console/organizations/`:
  `Test Files 36 passed (36)`, `Tests 255 passed (255)`.
- **Type-check** — `@object-ui/app-shell type-check` (`tsc --noEmit` plus
  `tsconfig.test.json`): exit 0.
- **ESLint** on the three changed files: 0 errors (44 warnings, all `any` /
  unused-destructure in the test's mock factories, matching the sibling
  `AppHeader.inboxVariant.test.tsx` house style).
- **Gates** — `check:control-bytes`, `check:i18n-keys`, `check:i18n-drift`,
  `check-changeset-presence`: all green.

A `.changeset` is included: this is a user-visible behaviour change in a
published package.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_