### PR TITLE
test(app-shell): pin relation-field header-action predicates on the console record page

### DIFF
--- a/.changeset/tidy-donkeys-shave.md
+++ b/.changeset/tidy-donkeys-shave.md
@@ -1,0 +1,16 @@
+---
+---
+
+Test-and-docs only: pin the console record page's DECLARED header-action `visible`
+predicates against a **relation** field end to end (objectstack#8500), and document the
+resulting contract on the `page:header` actions page.
+
+No published behaviour changes. Both properties the card reports as broken were measured
+correct on `main` and are now covered so they cannot regress silently:
+
+- `os.user.id == record.manager` reaches ONE verdict whether the detail fetch delivered
+  the lookup as its bare foreign key or as the expanded row — the seam between
+  `toPredicateRecord` (objectui#3501) and the `RecordContext.objectSchema` the console
+  page threads into it, which no component-level test can observe;
+- a faulting spelling (`record.manager.id`) is fail-CLOSED **and** named in one console
+  warning per predicate, per the standing 2026-08-06 ruling on objectui#4051.

--- a/content/docs/layout/page-header.mdx
+++ b/content/docs/layout/page-header.mdx
@@ -68,6 +68,52 @@ the right-aligned slot is `action` → React `children` → `actions` → schema
 defaults to `true` on record pages (a `recordId` in scope) that are not embedded in a
 drawer or modal, and `false` otherwise.
 
+## Gating a header action on a relation field
+
+Each header action's `visible` (and `hidden` / `disabled`) is a CEL predicate evaluated
+against the current record. The most common thing it is asked to express — "only the
+record's manager sees this button" — is written against a `lookup` / `master_detail` /
+`user` / `tree` field, and there is exactly one supported spelling for it:
+
+```yaml
+actions:
+  - name: escalate
+    label: Escalate
+    locations: [record_header]
+    visible: os.user.id == record.manager   # ✅ the relation IS its foreign key
+```
+
+**A relation field binds as the id the server stores, never as the record it points at.**
+That is true here regardless of whether this surface expanded the relation for display —
+the record page expands the relations it renders, and the predicate scope collapses them
+back before evaluating, so one predicate reaches one verdict on every surface and matches
+what the same expression means in a server-side rule.
+
+The consequence is that `record.manager.id` is **not** a second spelling of the same
+thing — it faults, because `record.manager` is a string:
+
+```yaml
+    visible: os.user.id == record.manager.id   # ❌ faults: no such key `id`
+```
+
+A predicate that faults is resolved **fail-closed** — the action is not rendered, because
+a precondition that could not be checked is not a precondition that passed. It is never
+resolved silently: the console carries one warning per broken predicate, naming the action
+and quoting the expression, for example:
+
+```plaintext
+[object-ui] A conditional predicate failed to evaluate (page:header action "escalate"
+visible) and was treated as its safe default: "os.user.id == record.manager.id".
+Reason: [runtime] No such key: id. Check the field names and CEL syntax.
+```
+
+An **empty** relation is not a fault: `record.manager` is `null`, the comparison is a
+clean `false`, and the action is simply hidden with nothing logged.
+
+The identity side of the comparison is `os.user` — the spec's canonical CEL identity
+scope, and the same one the server binds — with `current_user`, `user` and `ctx.user`
+available as aliases of it.
+
 ## Examples
 
 ### Simple Header

--- a/packages/app-shell/src/views/RecordDetailView.headerActionLookupPredicate.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.headerActionLookupPredicate.test.tsx
@@ -1,0 +1,350 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The console record page's DECLARED header actions — a `visible` CEL gated on
+ * a **relation field** (objectstack#8500).
+ *
+ * ## What this file pins, and why here
+ *
+ * "Only the record's manager sees this button" is the most common thing an
+ * author asks a `record_header` action's `visible` to express, and it is
+ * written against a lookup field:
+ *
+ * ```yaml
+ * visible: os.user.id == record.manager
+ * ```
+ *
+ * That predicate has to reach ONE verdict regardless of how the surface
+ * happened to deliver the record. The record page's detail fetch expands the
+ * relations it can, so `manager` arrives at the renderer either as the bare
+ * foreign key the server stores (`'u1'`) or as the whole expanded row
+ * (`{ id: 'u1', … }`) — a display decision no predicate author participates in.
+ * Evaluated as delivered, the same predicate is true in one payload shape and a
+ * clean, silent false in the other, on the author's OWN record.
+ *
+ * `toPredicateRecord` (objectui#3501) is what collapses an expanded relation
+ * back to its id, and `page:header` applies it through `evalRowPredicate`'s
+ * `fields` option. But that normalization is only as live as the field
+ * definitions the surface hands it: `page:header` reads them off
+ * `RecordContext.objectSchema`, which the CONSOLE record page supplies
+ * (`RecordDetailView` passes `objectSchema={objectDef}`). Nothing between the
+ * two is pinned anywhere — a host that stopped threading the object def, or a
+ * synthesizer that stopped routing header actions through `page:header`, would
+ * silently restore the two-verdicts-one-predicate behaviour with every
+ * component-level test still green. That seam is what this file covers: the
+ * component-level guarantee already has
+ * `packages/components/src/__tests__/page-header-lookup-predicate.test.tsx`;
+ * this is the same guarantee asserted END TO END on the console page the
+ * reports come from.
+ *
+ * ## The other half: a faulting predicate is fail-CLOSED and LOUD
+ *
+ * `record.manager.id` is the spelling authors reach for second, and it is not
+ * supported by construction — the relation binds as its id, so `.id` on it
+ * faults. The standing 2026-08-06 ruling on objectui#4051 / objectstack#5149 is
+ * that a predicate fault may be resolved fail-open OR fail-closed, but never
+ * SILENTLY. This surface resolves it fail-closed (never a button whose
+ * precondition could not be checked) and says so once per predicate, naming the
+ * action. Both properties are asserted on substance below — the button is gone
+ * AND the warning names the action — because either one alone is the failure
+ * mode: a silent hide is the objectui#4051 defect, and a warning in front of a
+ * still-rendered button is the fail-open one.
+ *
+ * The warning is warn-ONCE per `(label, source)` pair for the process
+ * (`warnEvalError` in `@object-ui/core`), so every fault case below uses a
+ * distinct action name — sharing one would make the second assertion pass or
+ * fail on test ORDER rather than on behaviour.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => ({ viewers: [], others: [] }),
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// Orthogonal chrome — same posture as RecordDetailView.userActionPredicates.test.
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+import { MetadataCtx } from '@object-ui/react';
+import { RecordDetailView } from './RecordDetailView';
+import { ExpressionProvider } from '../providers/ExpressionProvider';
+
+const OBJECT_NAME = 'qms_defect';
+const RECORD_ID = 'DEF-1';
+
+/** The canonical spelling — the one that also works server-side and in a list. */
+const CANONICAL = 'os.user.id == record.manager';
+
+const FIELDS = {
+  id: { type: 'text', label: 'Id' },
+  name: { type: 'text', label: 'Name' },
+  manager: { type: 'lookup', label: 'Manager', reference_to: 'sys_user' },
+};
+
+/** The record as the detail fetch delivers it when it did NOT expand `manager`. */
+const BARE = { id: RECORD_ID, name: 'Scratched housing', manager: 'u1' };
+/** …and as it delivers it when it DID — the same record, one display decision apart. */
+const EXPANDED = { id: RECORD_ID, name: 'Scratched housing', manager: { id: 'u1', name: 'Ada' } };
+
+function makeDataSource(record: Record<string, unknown>) {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => record),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+function makeMetadata(objects: any[]) {
+  return {
+    objects,
+    pages: [],
+    loading: false,
+    error: null,
+    refresh: async () => {},
+    invalidate: () => {},
+    ensureType: async () => [],
+    getItem: async () => null,
+    getItemsByType: () => [],
+  } as any;
+}
+
+/** A declared `record_header` action, gated on `visible`. */
+const headerAction = (name: string, visible: unknown) => ({
+  name,
+  label: name,
+  type: 'api',
+  target: '/api/v1/noop',
+  locations: ['record_header'],
+  visible,
+});
+
+/**
+ * Mount the real console record page inside the shell's `ExpressionProvider` —
+ * the wiring `AppContent` uses, and what binds `os.user` for the header's
+ * predicate scope — then WAIT for the record read, so a "button is gone"
+ * assertion can never pass merely because the predicate's input had not
+ * arrived yet.
+ */
+async function mountRecordPage(
+  record: Record<string, unknown>,
+  actions: any[],
+  sessionUserId: string,
+) {
+  const objects = [
+    { name: OBJECT_NAME, label: 'Defect', managedBy: 'platform', fields: FIELDS, actions },
+  ];
+  const dataSource = makeDataSource(record);
+  const view = render(
+    <MemoryRouter initialEntries={[`/apps/qms/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={makeMetadata(objects)}>
+        <ExpressionProvider
+          user={{ id: sessionUserId, name: 'Session user' }}
+          app={{ name: 'qms' }}
+          data={{}}
+          features={{}}
+        >
+          <RecordDetailView
+            dataSource={dataSource}
+            objects={objects}
+            onEdit={() => {}}
+            objectNameOverride={OBJECT_NAME}
+            recordIdOverride={RECORD_ID}
+          />
+        </ExpressionProvider>
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(dataSource.findOne).toHaveBeenCalled());
+  await waitFor(() => expect(headerToolbar()).toBeTruthy());
+  return view;
+}
+
+/** The `page:header` action toolbar — the host of every header CTA. */
+function headerToolbar(): HTMLElement | null {
+  return document.querySelector('[role="toolbar"]');
+}
+
+/** Every inline CTA the header currently renders, by visible label. */
+function headerCtaLabels(): string[] {
+  const bar = headerToolbar();
+  if (!bar) return [];
+  return Array.from(bar.querySelectorAll('button'))
+    .map((b) => (b.textContent ?? '').trim())
+    .filter(Boolean);
+}
+
+beforeEach(() => {
+  cleanup();
+  // Unrelated chrome (approvals, favourites, the record-explain probe) reaches
+  // for the platform API; in jsdom that is a real socket. Answer locally so the
+  // only asynchrony here is the record read.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('console record header — a relation field in a declared action `visible` (objectstack#8500)', () => {
+  // -------------------------------------------------------------------------
+  // One predicate, one verdict — whichever shape the payload delivered.
+  // -------------------------------------------------------------------------
+
+  it('shows the action to the manager when the payload carries the BARE foreign key', async () => {
+    await mountRecordPage(BARE, [headerAction('OnlyManager', CANONICAL)], 'u1');
+
+    expect(headerCtaLabels()).toContain('OnlyManager');
+  });
+
+  it('hides it from a non-manager on the same bare payload', async () => {
+    await mountRecordPage(BARE, [headerAction('OnlyManager', CANONICAL)], 'u2');
+
+    const labels = headerCtaLabels();
+    expect(labels).not.toContain('OnlyManager');
+    // The companion assertion: the header itself still rendered, so "no button"
+    // cannot be "no toolbar".
+    expect(labels).toContain('Edit');
+  });
+
+  /**
+   * The card's own repro. The detail fetch EXPANDED `manager`, so without the
+   * relation normalization this is `'u1' == { id: 'u1', … }` — a clean, silent
+   * false on the manager's own record, with no working spelling left.
+   */
+  it('shows the action to the manager when the payload carries the EXPANDED relation', async () => {
+    await mountRecordPage(EXPANDED, [headerAction('OnlyManager', CANONICAL)], 'u1');
+
+    expect(headerCtaLabels()).toContain('OnlyManager');
+  });
+
+  it('hides it from a non-manager on the same expanded payload', async () => {
+    await mountRecordPage(EXPANDED, [headerAction('OnlyManager', CANONICAL)], 'u2');
+
+    const labels = headerCtaLabels();
+    expect(labels).not.toContain('OnlyManager');
+    expect(labels).toContain('Edit');
+  });
+
+  /**
+   * The `{ dialect, source }` envelope is what `@objectstack/spec`'s
+   * `ExpressionInputSchema` normalizes every authored string into, so it — not
+   * the bare string — is the shape a served action actually carries.
+   */
+  it('reaches the same verdict through the canonical `{ dialect, source }` envelope', async () => {
+    await mountRecordPage(
+      EXPANDED,
+      [headerAction('OnlyManager', { dialect: 'cel', source: CANONICAL })],
+      'u1',
+    );
+
+    expect(headerCtaLabels()).toContain('OnlyManager');
+  });
+
+  /**
+   * An empty lookup is a genuine `false`, not a fault: the canonical spelling
+   * must stay quiet and simply not match. (`record.manager.id` is what faults
+   * on this record — see the block below.)
+   */
+  it('treats an EMPTY lookup as a clean false, with no fault warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await mountRecordPage(
+      { id: RECORD_ID, name: 'Scratched housing', manager: null },
+      [headerAction('OnlyManager', CANONICAL)],
+      'u1',
+    );
+
+    expect(headerCtaLabels()).not.toContain('OnlyManager');
+    expect(
+      warn.mock.calls.filter((c) => String(c[0]).includes('OnlyManager')),
+    ).toHaveLength(0);
+    warn.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // A fault is fail-CLOSED and named — never silent (the 2026-08-06 ruling).
+  // Distinct action names per case: the warning is warn-once per (label,
+  // source), so a shared name would decide these by test order.
+  // -------------------------------------------------------------------------
+
+  it('fails CLOSED and names the action when `record.<relation>.id` faults', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await mountRecordPage(
+      EXPANDED,
+      [headerAction('DotIdExpanded', 'os.user.id == record.manager.id')],
+      'u1',
+    );
+
+    // Fail-CLOSED: the button is gone even though the session user IS the
+    // manager — a precondition that could not be checked is not a pass.
+    expect(headerCtaLabels()).not.toContain('DotIdExpanded');
+    expect(headerCtaLabels()).toContain('Edit');
+    // …and NOT silently: one warning, naming the action and quoting the
+    // predicate, so the author can find it without reading the renderer.
+    const faults = warn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('DotIdExpanded'));
+    expect(faults).toHaveLength(1);
+    expect(faults[0]).toContain('record.manager.id');
+    warn.mockRestore();
+  });
+
+  it('does the same on a bare-key payload — the fault is the spelling, not the shape', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await mountRecordPage(
+      BARE,
+      [headerAction('DotIdBare', 'os.user.id  == record.manager.id')],
+      'u1',
+    );
+
+    expect(headerCtaLabels()).not.toContain('DotIdBare');
+    expect(
+      warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('DotIdBare')),
+    ).toHaveLength(1);
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Part of objectstack-ai/objectstack#8500

**No behaviour change.** Both properties that card reports as broken were measured
**already correct** on `main`; what was missing was coverage at the surface the card is
about, and documentation of the resulting contract. Nothing here changes what ships — the
changeset is deliberately empty-frontmatter.

Verified at `f4c7845`.

## The card's premise, re-measured against `origin/main` (5bf5d2cb6, 17.5.0)

The card was reported on `17.0.0-rc.6`. Driving the real console record page
(`RecordDetailView` inside the shell's `ExpressionProvider`, exactly as `AppContent` mounts
it) with a declared `record_header` action gated on a `lookup` field:

| payload shape | predicate | session user | card says (rc.6) | measured now |
|---|---|---|---|---|
| bare FK `manager: 'u1'` | `os.user.id == record.manager` | the manager | hidden | **shown** ✅ |
| bare FK | `os.user.id == record.manager` | someone else | hidden | hidden ✅ |
| expanded `manager: { id: 'u1', … }` | `os.user.id == record.manager` | the manager | hidden | **shown** ✅ |
| expanded | `os.user.id == record.manager` | someone else | — | hidden ✅ |
| either | `os.user.id == record.manager.id` | either | shown to all, silent | **hidden, one named warning** ✅ |

So both halves are already answered on this surface:

- **Lookup value shape** — `toPredicateRecord` (objectui#3501) collapses an expanded
  relation back to the foreign key the server stores, and `page:header` applies it through
  `evalRowPredicate`'s `fields` option. `os.user.id == record.manager` is therefore the
  one stable spelling and works in both payload shapes.
- **Fail-open + silent** — the header-action path fails **closed** and emits one warning
  per predicate naming the action, e.g.
  `[object-ui] A conditional predicate failed to evaluate (page:header action "escalate" visible) and was treated as its safe default: "os.user.id == record.manager.id". Reason: [runtime] No such key: id.`
  That satisfies the standing 2026-08-06 ruling on objectui#4051 / objectstack#5149.

The `catch { return true }` the card quotes out of the minified `RecordDetailView-*.js`
chunk is **not** on this path. It is `filterVisibleParams` in `ActionParamDialog.tsx` — a
different evaluation face (action *param* visibility), which is genuinely still silent and
is filed separately as #4640 rather than folded in here, because either way of fixing it
flips a deliberately-pinned test and wants its own ruling.

## What this PR adds

`packages/app-shell/src/views/RecordDetailView.headerActionLookupPredicate.test.tsx` — 8
cases pinning the table above end to end on the console page. The component-level guarantee
already has `packages/components/src/__tests__/page-header-lookup-predicate.test.tsx`; what
had no coverage anywhere is the **seam**: `page:header` reads the field definitions off
`RecordContext.objectSchema`, and the console page is what threads them in
(`objectSchema={objectDef}`). A host that stopped doing that would silently restore
two-verdicts-for-one-predicate with every component-level test still green.

Each fault case uses a distinct action name on purpose — the warning is warn-once per
`(label, source)`, so a shared name would decide those assertions by test order rather than
by behaviour. The refusal cases assert **substance** on both sides: the button is gone AND
the warning names the action. Either alone is a failure mode (a silent hide is the #4051
defect; a warning in front of a still-rendered button is the fail-open one).

`content/docs/layout/page-header.mdx` — documents the contract the card asked to have
written down: the supported spelling, why `record.manager.id` is not a second one, that an
empty relation is a clean false rather than a fault, the fail-closed + warn-once posture,
and the warning's actual text.

## Reverse verification

Predictions were written before running, and one of them failed — recorded honestly:

| ablation | predicted | observed |
|---|---|---|
| drop `objectSchema={objectDef}` (the seam) | 2 expanded cases RED; bare cases green; `DotIdExpanded` RED **inverted** (normalization off ⇒ `.id` resolves ⇒ button appears, no fault) | exactly that — 3 RED, including `expected [ 'DotIdExpanded', 'Edit' ] to not include 'DotIdExpanded'` |
| `warnOnError: false` on the header call site | warning assertions RED | **GREEN — prediction wrong.** This face is loud via *two* independent mechanisms: `evalRowPredicate`'s non-warn fast route delegates to `evalFieldPredicate`, which has warned once per broken predicate since the rc.5 loudening |
| no-op `warnEvalError` in core | warning assertions RED, buttons still hidden | exactly that — 2 RED, both `expected [] to have a length of 1`, button assertions still passing |

Every ablation was restored from the committed branch and confirmed byte-identical
(`git hash-object` == `git rev-parse HEAD:<path>`).

## Verification

At `f4c7845`:

- `pnpm exec vitest run packages/app-shell` — **395 files, 3733 passed, 1 skipped, 0 failed**
  (run at `9941896`; the only delta to `f4c7845` is one `.changeset/*.md`, which no vitest
  project globs). Re-run at `f4c7845` over the 5 directly-related files: 83 passed.
- `pnpm --filter @object-ui/app-shell type-check` — clean (after
  `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`, without which
  every workspace import reads as a missing module).
- `pnpm --filter @object-ui/app-shell lint` — 0 errors.
- Gates: `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`,
  `check-control-bytes`, `check-doc-links`, `check-lint-coverage`,
  `check-type-check-coverage` — all exit 0. The changeset gate was not named in dispatch
  and was derived from the changed paths: it guards anything under a released package's
  `src/`, which a new test file is.

## What remains on objectstack#8500

Nothing to implement on the header-action path — it needs re-triage, not a fix, which is
why this is `Part of` and not a closing keyword. The remaining live defect the card's
evidence actually points at is tracked as #4640.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_