### PR TITLE
docs: bump QUICK_REFERENCE.md Current Release to 17.5.0

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -111,7 +111,7 @@ Every value below is pinned to the manifest that owns it by
 `scripts/__tests__/quick-reference-current-release-4143.test.ts` — edit the anchor and
 that test tells you to edit this block. The one exception is called out on its row.
 
-- **Version:** 17.4.0 (the version every `@object-ui/*` manifest carries — they are one
+- **Version:** 17.5.0 (the version every `@object-ui/*` manifest carries — they are one
   `fixed` group in `.changeset/config.json`, so a release moves all of them together)
 - **Spec:** `@objectstack/spec` ^17.0.0-rc.6 (declared by the root `package.json` and by
   `apps/console/package.json`)


### PR DESCRIPTION
Fixes #4642

## What

`QUICK_REFERENCE.md`'s "Current Release" block stated `Version: 17.4.0`, but the
v17.5.0 release commit (`5bf5d2cb6`, current `origin/main`) moved every
`@object-ui/*` manifest to `17.5.0`. That single row was the only one out of date —
every other anchored row (Spec, Client, Node.js, pnpm, React, TypeScript) already
matched its manifest anchor. One-line fix:

```diff
- **Version:** 17.4.0 (the version every `@object-ui/*` manifest carries — they are one
+ **Version:** 17.5.0 (the version every `@object-ui/*` manifest carries — they are one
```

## Main-red context

`scripts/__tests__/quick-reference-current-release-4143.test.ts` (shard 3/4) is red
on `main` itself, so every open PR currently inherits the failure regardless of its
own diff (confirmed on #4637/#4638/#4639/#4641). This PR's own shard-3 run should be
the first green one since the release landed.

## Verification (at HEAD `275c7701b`)

- `pnpm exec vitest run scripts/__tests__/quick-reference-current-release-4143.test.ts`
  — 8/8 passed.
- `node scripts/check-control-bytes.mjs QUICK_REFERENCE.md` — OK.

## Changeset

Docs-only change to a root-level file, not under any released package's `src/`.
Per `content/docs/guide/ci-cd-pipeline.md`'s Changeset Presence section, this repo
has **no `skip-changeset` label** — the real gate's exemption is derived, not a
label. Ran the gate's own script locally to confirm no changeset is owed:

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with 5bf5d2cb6 (merge-base with origin/main): 1 file(s)
changed, 0 of them under the src/ of a package the release covers, 0 under a
package changesets ignores, 0 changeset(s) added.
No source of a released package changed in this range, so no changeset is owed.
```

No `.changeset/*.md` added.

## File surface

`QUICK_REFERENCE.md` only, as scoped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_