### PR TITLE
fix(components): retire ToggleGroupItem.icon, honor item-level disabled

### DIFF
--- a/.changeset/wild-owls-repeat.md
+++ b/.changeset/wild-owls-repeat.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+---
+
+Settle the two declared-but-unread keys on `ToggleGroupItem`: retire `icon`, wire
+`disabled` (objectui#4632).
+
+`ToggleGroupItem` declared `icon?: string` and `disabled?: boolean` while the
+`toggle-group` renderer read neither — it mapped items to value + aria-label +
+label and dropped the rest. Nothing went red, which is what made it durable: an
+author who declared either key got a correctly rendered group with the key
+silently ignored, and the schema catalog (the corpus AI authoring tools retrieve
+from) was teaching `icon` on all three items of
+`components-disclosure-toggle-group/with-labels`.
+
+The two keys are settled in opposite directions, by measurement rather than by
+symmetry:
+
+- **`icon` is retired** from the TypeScript interface, from the `ToggleGroupItemSchema`
+  Zod mirror, from that catalog entry and from the component's docs page. It had zero
+  measured pull — across the repo the single catalog entry was the only site authoring
+  it, no application code or example app declared it, and no renderer resolved it.
+- **`disabled` is honored.** Item-level `disabled` is already live convention here —
+  `tabs`, `select`, `dropdown-menu`, `menubar` and `context-menu` all forward it, and
+  `toggle-group` was the lone outlier. The underlying Radix item supports it natively,
+  so the renderer forwarding the prop is the whole change; the synced `ui/toggle-group.tsx`
+  primitive is untouched.
+
+**Breaking for TypeScript authors of `icon` only** (marked `minor` per this repo's
+version-alignment rule, which reserves `major` for following `@objectstack` across a
+major). Runtime behaviour of an authored `icon` is unchanged — it rendered nothing
+before and renders nothing now; what changes is that the contract no longer claims
+otherwise, so the mistake surfaces at authoring time. Authored `disabled` changes from
+silently ignored to actually disabling that one item.

--- a/content/docs/components/disclosure/toggle-group.mdx
+++ b/content/docs/components/disclosure/toggle-group.mdx
@@ -15,6 +15,9 @@ The Toggle Group component allows users to toggle between multiple options.
 
 ## With Labels
 
+The third item sets `disabled: true`, which the renderer forwards to that toggle
+only — the rest of the group stays interactive.
+
 <SchemaExample id="components-disclosure-toggle-group/with-labels" />
 
 ## Schema
@@ -22,8 +25,8 @@ The Toggle Group component allows users to toggle between multiple options.
 ```plaintext
 interface ToggleGroupItem {
   value: string;
-  icon?: string;
-  label?: string;
+  label: string;
+  disabled?: boolean;             // Disables this item only
 }
 
 interface ToggleGroupSchema {

--- a/examples/schema-catalog/src/schemas/components-disclosure-toggle-group/with-labels.json
+++ b/examples/schema-catalog/src/schemas/components-disclosure-toggle-group/with-labels.json
@@ -4,18 +4,16 @@
   "items": [
     {
       "value": "list",
-      "icon": "list",
       "label": "List"
     },
     {
       "value": "grid",
-      "icon": "grid",
       "label": "Grid"
     },
     {
       "value": "table",
-      "icon": "table",
-      "label": "Table"
+      "label": "Table",
+      "disabled": true
     }
   ]
 }

--- a/packages/components/src/__tests__/toggle-group-item-disabled.test.tsx
+++ b/packages/components/src/__tests__/toggle-group-item-disabled.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `toggle-group` renderer honors item-level `disabled` (objectui#4632).
+ *
+ * `ToggleGroupItem` declared `icon?` and `disabled?` while this renderer read
+ * NEITHER — it mapped items to value + aria-label + label and nothing else. The
+ * finding settled the two keys in opposite directions: `icon` is retired (zero
+ * measured pull — one catalog entry authored it, no code read it), `disabled` is
+ * wired, because item-level `disabled` is already live convention across `tabs`,
+ * `select`, `dropdown-menu`, `menubar` and `context-menu`, and the underlying
+ * Radix item supports it natively.
+ *
+ * That native support is why this needed no edit to `src/ui/toggle-group.tsx`:
+ * the primitive spreads `...props` onto `ToggleGroupPrimitive.Item`, so the
+ * renderer forwarding one prop is the whole fix — `ui/**` is a synced no-touch
+ * zone (AGENTS.md #7) and a fix that required editing it would have been the
+ * wrong shape.
+ *
+ * The declaration half — `icon` gone from the interface and the Zod mirror,
+ * `disabled` kept — is pinned in
+ * `packages/types/src/__tests__/toggle-group-item-authorable-keys.test.ts`.
+ *
+ * Queried by `aria-label` rather than by role deliberately: Radix gives items
+ * `role="radio"` under `selectionType: 'single'` and a pressable button under
+ * `'multiple'`, so a role query would silently pin the selection mode too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import type { ToggleGroupSchema } from '@object-ui/types';
+import { renderComponent } from './test-utils';
+// Module scope, not a hook: this import IS the registration, and an unbounded
+// module load must never be billed to a bounded window (AGENTS.md §测试纪律).
+import '../renderers';
+
+const schema = (selectionType: 'single' | 'multiple'): ToggleGroupSchema => ({
+  type: 'toggle-group',
+  selectionType,
+  items: [
+    { value: 'list', label: 'List' },
+    { value: 'grid', label: 'Grid' },
+    { value: 'table', label: 'Table', disabled: true },
+  ],
+});
+
+describe('toggle-group renderer forwards item-level `disabled` (objectui#4632)', () => {
+  it('disables exactly the item that declares it', () => {
+    renderComponent(schema('single'));
+
+    expect(screen.getByLabelText('Table')).toBeDisabled();
+    // The reverse direction, which is what makes the assertion above mean
+    // "forwarded per item" rather than "the whole group is disabled".
+    expect(screen.getByLabelText('List')).not.toBeDisabled();
+    expect(screen.getByLabelText('Grid')).not.toBeDisabled();
+  });
+
+  it('forwards it in multiple-selection mode too', () => {
+    renderComponent(schema('multiple'));
+
+    expect(screen.getByLabelText('Table')).toBeDisabled();
+    expect(screen.getByLabelText('List')).not.toBeDisabled();
+  });
+
+  it('leaves every item enabled when none declares `disabled`', () => {
+    renderComponent({
+      type: 'toggle-group',
+      selectionType: 'single',
+      items: [
+        { value: 'list', label: 'List' },
+        { value: 'grid', label: 'Grid' },
+      ],
+    } as ToggleGroupSchema);
+
+    expect(screen.getByLabelText('List')).not.toBeDisabled();
+    expect(screen.getByLabelText('Grid')).not.toBeDisabled();
+  });
+
+  it('still renders each item label', () => {
+    const { container } = renderComponent(schema('single'));
+
+    expect(container.textContent).toContain('List');
+    expect(container.textContent).toContain('Grid');
+    expect(container.textContent).toContain('Table');
+  });
+});

--- a/packages/components/src/renderers/disclosure/toggle-group.tsx
+++ b/packages/components/src/renderers/disclosure/toggle-group.tsx
@@ -31,7 +31,7 @@ ComponentRegistry.register('toggle-group',
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
       >
         {schema.items?.map((item, idx) => (
-          <ToggleGroupItem key={idx} value={item.value} aria-label={item.label}>
+          <ToggleGroupItem key={idx} value={item.value} aria-label={item.label} disabled={item.disabled}>
             {item.label}
           </ToggleGroupItem>
         ))}

--- a/packages/types/src/__tests__/toggle-group-item-authorable-keys.test.ts
+++ b/packages/types/src/__tests__/toggle-group-item-authorable-keys.test.ts
@@ -1,0 +1,111 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ToggleGroupItem` declares only keys a renderer actually reads (objectui#4632).
+ *
+ * The interface used to declare `icon?: string` and `disabled?: boolean` while
+ * `packages/components/src/renderers/disclosure/toggle-group.tsx` read NEITHER —
+ * an author who declared either got a correctly rendered toggle group with the
+ * key silently dropped. Nothing went red, which is what made it durable: the
+ * schema catalog (the corpus AI authoring tools retrieve from) was teaching
+ * `icon` on all three items of `components-disclosure-toggle-group/with-labels`.
+ *
+ * The two keys were settled in opposite directions, by measurement:
+ *
+ *   `icon` — RETIRED. Zero measured pull: across this repo the only site
+ *   authoring it was that single catalog entry, no application code and no
+ *   example app declared it, and no renderer resolved it. Under the platform's
+ *   declared=enforced doctrine a slot nobody pulls on is removed rather than
+ *   speculatively implemented.
+ *
+ *   `disabled` — WIRED. Item-level `disabled` is an established live convention
+ *   in this codebase: `tabs`, `select`, `dropdown-menu`, `menubar` and
+ *   `context-menu` all forward it. `toggle-group` was the lone outlier, and the
+ *   underlying Radix item supports it natively, so honoring it needed no new
+ *   mechanism (and no edit to the synced `ui/` primitive).
+ *
+ * This file pins BOTH directions on the declaration surfaces — the TypeScript
+ * interface and the Zod mirror, which are two separate hand-maintained
+ * declarations of one contract (`zod/disclosure.zod.ts` was not named in the
+ * finding; it declared `icon` too). The behavior half — that a disabled item
+ * actually renders disabled — is pinned in
+ * `packages/components/src/__tests__/toggle-group-item-disabled.test.tsx`.
+ *
+ * The `@ts-expect-error` below is REAL enforcement here, not decoration: this
+ * package type-checks its tests through `tsconfig.test.json` (`type-check` =
+ * `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`),
+ * so re-adding `icon?` to the interface fails the build on the unused directive.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ToggleGroupItem } from '../disclosure';
+import { ToggleGroupItemSchema } from '../zod/disclosure.zod';
+
+describe('ToggleGroupItem: `icon` is retired from the authoring surface (objectui#4632)', () => {
+  it('does not declare `icon` on the TypeScript interface', () => {
+    const item: ToggleGroupItem = {
+      value: 'list',
+      label: 'List',
+      // @ts-expect-error `icon` is retired — no renderer ever read it, and
+      // excess-property checking on this literal is what makes the retirement
+      // reach authors writing TypeScript.
+      icon: 'list',
+    };
+
+    // Runtime shape is unaffected by the type-level assertion above; the
+    // assertion that matters is that the file compiles only while `icon` is
+    // absent from the interface.
+    expect(item.value).toBe('list');
+  });
+
+  it('drops `icon` when parsing through the Zod mirror', () => {
+    // `z.object` is non-strict, so an authored `icon` is not an error — it is
+    // simply not part of the declared surface any more, and parse output is the
+    // observable statement of what that surface contains.
+    const parsed = ToggleGroupItemSchema.parse({
+      value: 'list',
+      label: 'List',
+      icon: 'list',
+    });
+
+    expect(parsed).toEqual({ value: 'list', label: 'List' });
+    expect('icon' in parsed).toBe(false);
+  });
+
+  it('keeps `icon` out of the Zod schema shape', () => {
+    expect(Object.keys(ToggleGroupItemSchema.shape).sort()).toEqual([
+      'disabled',
+      'label',
+      'value',
+    ]);
+  });
+});
+
+describe('ToggleGroupItem: `disabled` stays declared, now that it is honored (objectui#4632)', () => {
+  it('declares `disabled` on the TypeScript interface as an optional boolean', () => {
+    const item: ToggleGroupItem = { value: 'table', label: 'Table', disabled: true };
+    expect(item.disabled).toBe(true);
+
+    const withoutDisabled: ToggleGroupItem = { value: 'grid', label: 'Grid' };
+    expect(withoutDisabled.disabled).toBeUndefined();
+  });
+
+  it('preserves `disabled` through the Zod mirror', () => {
+    expect(
+      ToggleGroupItemSchema.parse({ value: 'table', label: 'Table', disabled: true }),
+    ).toEqual({ value: 'table', label: 'Table', disabled: true });
+  });
+
+  it('rejects a non-boolean `disabled`', () => {
+    expect(
+      ToggleGroupItemSchema.safeParse({ value: 'table', label: 'Table', disabled: 'yes' })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/packages/types/src/disclosure.ts
+++ b/packages/types/src/disclosure.ts
@@ -126,11 +126,11 @@ export interface ToggleGroupItem {
    */
   label: string;
   /**
-   * Item icon
-   */
-  icon?: string;
-  /**
    * Whether item is disabled
+   *
+   * Forwarded to the underlying toggle item by the `toggle-group` renderer,
+   * matching the item-level `disabled` that `tabs`, `select`, `dropdown-menu`,
+   * `menubar` and `context-menu` already honor.
    */
   disabled?: boolean;
 }

--- a/packages/types/src/zod/disclosure.zod.ts
+++ b/packages/types/src/zod/disclosure.zod.ts
@@ -63,7 +63,6 @@ export const CollapsibleSchema = BaseSchema.extend({
 export const ToggleGroupItemSchema = z.object({
   value: z.string().describe('Item value'),
   label: z.string().describe('Item label'),
-  icon: z.string().optional().describe('Item icon'),
   disabled: z.boolean().optional().describe('Whether item is disabled'),
 });
 


### PR DESCRIPTION
Fixes #4632

`ToggleGroupItem` declared `icon?: string` and `disabled?: boolean` while the `toggle-group` renderer read **neither** — it mapped items to value + aria-label + label and dropped the rest. Premise re-verified against `origin/main` (`a99233fff`): both keys declared at `packages/types/src/disclosure.ts`, neither read at `packages/components/src/renderers/disclosure/toggle-group.tsx`. The card's mechanism hypothesis held in full, and `disabled` was confirmed unread as the card claimed.

## The measurement (the ruling asked for it first)

Enforce-or-remove, decided per key by measured pull rather than by symmetry:

| key | sites authoring it | code reading it | direction |
|---|---|---|---|
| `icon` | **1** — the single catalog entry `components-disclosure-toggle-group/with-labels.json` | none | **retire** |
| `disabled` | 0 | none *in toggle-group* — but honored by **5 sibling renderers** | **wire** |

- **`icon` — retired.** Swept the whole repo (catalog schemas, docs, example apps, application code) plus the sibling `objectstack` checkout. The only site authoring it was that one catalog entry; the only other mention was the docs page's schema block, which is a mirror of the declaration, not a consumer. The lone `objectstack` hit is `toggle-group` as a *form-field widget name* in a spec test — a different surface, not an item list. Zero pull, so under declared=enforced it is removed rather than speculatively implemented.
- **`disabled` — wired.** Item-level `disabled` is established live convention in this codebase: `tabs`, `select`, `dropdown-menu`, `menubar` and `context-menu` all forward it. `toggle-group` was the lone outlier, so the convention itself is the consumer. The underlying Radix item supports `disabled` natively, so forwarding one prop is the whole change — the synced no-touch `ui/toggle-group.tsx` (AGENTS.md #7) is **untouched**.

## Surfaces changed

- `packages/types/src/disclosure.ts` — `icon` removed; `disabled` kept and documented as forwarded.
- `packages/types/src/zod/disclosure.zod.ts` — **not named in the card or the dispatch**; `ToggleGroupItemSchema` declared `icon` too. A retirement that left this standing would have left half the contract lying, so it is included.
- `packages/components/src/renderers/disclosure/toggle-group.tsx` — forwards `disabled` per item.
- `examples/schema-catalog/.../with-labels.json` — `icon` keys dropped; one item now demonstrates `disabled`, so the corpus teaches a key that works. Contents-only edit, no index regeneration (per #4637's own model).
- `content/docs/components/disclosure/toggle-group.mdx` — **fourth surface, beyond the claimed set**: its schema block taught `icon?: string`. Leaving it would defeat the card's own point (the corpus teaching a dead key), and AGENTS.md #2 is docs-driven. Also corrected `label?` to `label` in the same block to match the interface. The block's separate `type:` / `selectionType` error is left alone and filed instead (below).

## Tests, all at `de398f5d6`

Full verification ran **after** the final commit, tree clean.

- `pnpm exec vitest run packages/types/ packages/components/ examples/schema-catalog/` — **171 files / 3100 tests passed**.
- `pnpm --filter @object-ui/types type-check` and `pnpm --filter @object-ui/components type-check` — clean (the latter after `pnpm --filter '@object-ui/components^...' build`; a fresh worktree fails it on unresolved workspace deps, unrelated to this change).
- `check-changeset-presence` / `check-changeset-no-major` / `check-control-bytes` / `check-doc-links` — all green. ESLint on the changed files: 0 errors.

**Reverse verification, direction predicted before each run:**

1. Ablate the renderer's `disabled` forward ⇒ predicted 2 red / 2 green in the behavior pin (the two forwarding tests fail; "no item declares disabled" and the label test do not depend on the fix). Observed exactly that, with the dump showing the button rendered without `disabled`.
2. Re-add `icon` to both declaration surfaces ⇒ predicted the two Zod pins red and the `@ts-expect-error` pin **green** under vitest, which cannot typecheck. Observed 2 failed / 4 passed; under `tsc` the same state is `error TS2578: Unused '@ts-expect-error' directive` — so the compile-time pin is real enforcement (this package type-checks its tests via `tsconfig.test.json`).
3. Cross-package: authored `icon` in a `@object-ui/components` test against the **rebuilt** `@object-ui/types` d.ts ⇒ `error TS2353: Object literal may only specify known properties, and 'icon' does not exist in type 'ToggleGroupItem'`. The retirement reaches consumers, and that verdict came from the rebuilt declaration, not a cached one.

Each ablation was restored with `git checkout` from the commit and confirmed byte-clean (`git status --porcelain` empty).

## Notes

- Changeset marks `minor` for both packages: breaking for TypeScript authors of `icon`, per this repo's version-alignment rule reserving `major` for following `@objectstack`. Runtime behavior of an authored `icon` is unchanged — it rendered nothing before and renders nothing now; what changes is that the contract stops claiming otherwise. Authored `disabled` changes from silently ignored to actually disabling that one item.
- Out of scope, filed separately: `AccordionItem` in the same file declares `icon?` and `disabled?` and the accordion renderer reads neither — the identical defect one interface up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_