### PR TITLE
fix(plugins,app-shell): resolve the six spec-named symbol collisions with 17.0.0 GA

### DIFF
--- a/.changeset/spotty-moons-repeat.md
+++ b/.changeset/spotty-moons-repeat.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/plugin-calendar': patch
+'@object-ui/plugin-form': patch
+'@object-ui/plugin-grid': patch
+'@object-ui/plugin-kanban': patch
+'@object-ui/app-shell': patch
+---
+
+Rename four component-props types off the names `@objectstack/spec` starts owning in
+17.0.0, keeping the old spellings as deprecated aliases. No behaviour changes and no
+importer breaks.
+
+`@objectstack/spec/ui` exports `ObjectCalendarProps`, `ObjectFormProps`, `ObjectGridProps`
+and `ObjectKanbanProps` from 17.0.0, where each is the AUTHORED props document of the
+matching element — a serialisable authoring surface (`z.input< typeof
+ObjectGridPropsSchema >`). The same-named interfaces here are the RENDERERS' props: a live
+`dataSource`, records pre-fetched by a parent, and the host callbacks. Two different things
+under one word, so the local ones are renamed rather than derived, following the split this
+repo already made for `PageHeaderProps` -> `PageHeaderComponentProps` and the
+`Record*ComponentProps` family in `@object-ui/types`:
+
+| package | new name | old name |
+|---|---|---|
+| `@object-ui/plugin-calendar` | `ObjectCalendarComponentProps` | `ObjectCalendarProps` |
+| `@object-ui/plugin-form` | `ObjectFormComponentProps` | `ObjectFormProps` |
+| `@object-ui/plugin-grid` | `ObjectGridComponentProps` | `ObjectGridProps` |
+| `@object-ui/plugin-kanban` | `ObjectKanbanComponentProps` | `ObjectKanbanProps` |
+
+Every old name is still exported from its package barrel as a `@deprecated` alias denoting
+the SAME type, pinned per package by `spec-symbol-4650.test.ts`, so existing imports keep
+compiling. New code should use the `ComponentProps` spelling.
+
+`@object-ui/app-shell` carries no API change: its `SECRET_MASK` — the ADR-0100 credential
+read mask, which 17.0.0 moves into `@objectstack/spec/data` — is renamed to
+`OBJECTUI_SECRET_MASK` at its declaration in `views/metadata-admin/widgets.tsx`. That
+constant is package-internal and is not re-exported from the barrel, so nothing published
+changes; the rename exists so the local copy cannot be read as the spec's own definition
+while this repo is still pinned below the release that exports it.

--- a/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
+++ b/packages/app-shell/src/__tests__/spec-symbol-parity.test.ts
@@ -139,9 +139,15 @@ describe('the spec export-name probe itself works', () => {
 });
 
 /**
- * The ten renames. Each entry is `[local dialect name, the spec name it used to
+ * The renames. Each entry is `[local dialect name, the spec name it used to
  * collide with]`, with a one-line note on what the spec's symbol actually means
  * — the thing the old name falsely claimed.
+ *
+ * Split in two by WHEN the spec took the name (objectui#4650): this table holds
+ * the names the PINNED spec already owns, `RENAMES_PENDING_GA` below holds the
+ * ones 17.0.0 GA introduces. Both halves get the "does not collide" ratchet; the
+ * "spec still owns it" ratchet cannot run against a pre-GA pin, so it arms
+ * itself when the pin is raised.
  */
 const RENAMES: Array<[local: string, formerly: string, specMeaning: string]> = [
   ['ScreenFieldInput', 'FieldInput', "the authoring shape of an object FIELD (Omit<Partial<Field>, 'type'>)"],
@@ -154,8 +160,47 @@ const RENAMES: Array<[local: string, formerly: string, specMeaning: string]> = [
   ['InstalledPackageRow', 'InstalledPackage', 'the full install record (installedAt, upgradeHistory, …)'],
 ];
 
+/**
+ * Renames forced by a name `@objectstack/spec` starts owning in **17.0.0 GA**,
+ * which this repo is not pinned to yet (`^17.0.0-rc.6`; #4636 / PR #4639 raises
+ * it). They are listed apart because the second ratchet below — "the spec still
+ * owns the old name" — is FALSE against the pinned rc and true against GA, so
+ * running it unconditionally would fail today's `main` over a rename that is
+ * exactly what makes the GA tree green (`check:spec-symbols`, objectui#4650).
+ *
+ * `SECRET_MASK` is the one case here where the spec's symbol and this package's
+ * are the SAME thing rather than two layers under one word: the protocol moved
+ * the ADR-0100 credential mask into `spec` (objectstack#7572) so its two readers
+ * stop each declaring a byte-identical literal. The doctrine's preferred arm is
+ * therefore to IMPORT it, and this rename is the pre-bump stand-in — see the
+ * declaration in `views/metadata-admin/widgets.tsx`, which carries the one-line
+ * burn-down. Nothing published breaks either way: the constant is not re-exported
+ * from this package's barrel.
+ */
+const RENAMES_PENDING_GA: Array<[local: string, formerly: string, specMeaning: string]> = [
+  [
+    'OBJECTUI_SECRET_MASK',
+    'SECRET_MASK',
+    'the ADR-0100 credential read mask — the same eight-bullet constant, in `@objectstack/spec/data`',
+  ],
+];
+
+/**
+ * Is the installed spec a pre-release? Read from the package the tests actually
+ * resolve, not from a range in `package.json`: the range is what we asked for,
+ * this is what is on disk, and only the second one decides what the ratchet
+ * below can see.
+ */
+const SPEC_IS_PRERELEASE = ((): boolean => {
+  const require = createRequire(import.meta.url);
+  const { version } = JSON.parse(
+    readFileSync(require.resolve('@objectstack/spec/package.json'), 'utf8'),
+  ) as { version: string };
+  return version.includes('-');
+})();
+
 describe('renamed local dialects do not collide with a spec export', () => {
-  it.each(RENAMES)('the spec does not own `%s`', (local) => {
+  it.each([...RENAMES, ...RENAMES_PENDING_GA])('the spec does not own `%s`', (local) => {
     expect(
       SPEC_NAMES.has(local),
       `@objectstack/spec now exports \`${local}\`. This package declares its own ` +
@@ -180,6 +225,31 @@ describe('renamed local dialects do not collide with a spec export', () => {
         `plain name back) or it moved (then re-check what it means now).`,
     ).toBe(true);
   });
+
+  /**
+   * The same ratchet for the GA-introduced names, armed by the pin rather than
+   * skipped forever: it is inert while the installed spec is a pre-release and
+   * asserts the moment #4636 lands. Written as a runtime branch rather than
+   * `it.skipIf` so the pre-GA half still says out loud which mode it ran in.
+   */
+  it.each(RENAMES_PENDING_GA)(
+    'the spec owns `%s` once the pin reaches GA (second value: %s)',
+    (_local, formerly) => {
+      if (SPEC_IS_PRERELEASE) {
+        expect(
+          SPEC_NAMES.size,
+          'the spec export probe came back empty, so this branch proves nothing',
+        ).toBeGreaterThan(1000);
+        return;
+      }
+      expect(
+        SPEC_NAMES.has(formerly),
+        `@objectstack/spec no longer exports \`${formerly}\`, which is the only ` +
+          `reason this package renamed it. Either the spec dropped it (then take ` +
+          `the plain name back) or it moved (then re-check what it means now).`,
+      ).toBe(true);
+    },
+  );
 });
 
 /**

--- a/packages/app-shell/src/views/metadata-admin/SecretWidget.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SecretWidget.test.tsx
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { WIDGETS, SECRET_MASK } from './widgets';
+import { WIDGETS, OBJECTUI_SECRET_MASK } from './widgets';
 
 afterEach(cleanup);
 
@@ -10,7 +10,7 @@ const Secret = WIDGETS['secret'];
 
 /**
  * `secret` widget — write-only/masked credential input for `secret` field types
- * and `format: 'password'` props. A stored secret reads back as SECRET_MASK, so
+ * and `format: 'password'` props. A stored secret reads back as OBJECTUI_SECRET_MASK, so
  * the box starts empty (keep-on-blank); typing replaces; Clear removes.
  */
 describe('secret widget', () => {
@@ -28,20 +28,20 @@ describe('secret widget', () => {
     expect(onChange).toHaveBeenLastCalledWith('hunter2');
   });
 
-  it('starts blank for a stored secret and keeps it (emits SECRET_MASK) when left blank', () => {
+  it('starts blank for a stored secret and keeps it (emits OBJECTUI_SECRET_MASK) when left blank', () => {
     const onChange = vi.fn();
-    render(<Secret value={SECRET_MASK} onChange={onChange} schema={{ type: 'string', format: 'password' }} />);
+    render(<Secret value={OBJECTUI_SECRET_MASK} onChange={onChange} schema={{ type: 'string', format: 'password' }} />);
     const input = screen.getByLabelText('Secret value') as HTMLInputElement;
     expect(input.value).toBe('');
     // type then clear back to blank → keep (no-op write)
     fireEvent.change(input, { target: { value: 'x' } });
     fireEvent.change(input, { target: { value: '' } });
-    expect(onChange).toHaveBeenLastCalledWith(SECRET_MASK);
+    expect(onChange).toHaveBeenLastCalledWith(OBJECTUI_SECRET_MASK);
   });
 
   it('exposes a Clear action for a stored secret that emits null', () => {
     const onChange = vi.fn();
-    render(<Secret value={SECRET_MASK} onChange={onChange} schema={{ type: 'string' }} />);
+    render(<Secret value={OBJECTUI_SECRET_MASK} onChange={onChange} schema={{ type: 'string' }} />);
     fireEvent.click(screen.getByText('Clear'));
     expect(onChange).toHaveBeenLastCalledWith(null);
   });

--- a/packages/app-shell/src/views/metadata-admin/widgets.tsx
+++ b/packages/app-shell/src/views/metadata-admin/widgets.tsx
@@ -1848,24 +1848,48 @@ function ConditionWidget({ value, onChange, readOnly, context }: WidgetProps) {
 /* secret — write-only / masked credential input (encrypt-on-write fields)     */
 /* -------------------------------------------------------------------------- */
 
-/** Mirrors objectql\'s SECRET_MASK: a stored secret reads back as this, never plaintext. */
-export const SECRET_MASK = '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022';
+/**
+ * The ADR-0100 credential read mask: a stored secret reads back as this, never
+ * plaintext.
+ *
+ * Renamed off the bare `SECRET_MASK` (objectui#4650). This is the SAME constant
+ * `@objectstack/spec/data` exports under that name from 17.0.0 \u2014 the protocol
+ * moved it to `spec` (objectstack#7572) precisely so the engine's field-read
+ * path and the settings REST boundary stop each declaring a byte-identical
+ * literal bound by nothing but convention. objectui should therefore IMPORT it
+ * rather than declare it, which is what the #4043 doctrine asks for; that
+ * import cannot be written yet because this repo is still pinned to
+ * `^17.0.0-rc.6`, which does not export the name.
+ *
+ * So the copy stays for now, under a name that cannot be read as the spec's own
+ * definition, and the whole burn-down is this one line: when #4636 / PR #4639
+ * raises the pin, replace the literal with
+ * `export { SECRET_MASK as OBJECTUI_SECRET_MASK } from '@objectstack/spec/data'`
+ * (or re-export it plainly and drop this alias). Nothing outside this package
+ * reads it \u2014 `@object-ui/app-shell`'s barrel does not re-export it \u2014 so that
+ * swap is internal.
+ *
+ * The eight U+2022 BULLET characters are spelled out rather than computed, on
+ * the spec's own reasoning: a plain grep for the mask a client actually received
+ * has to find this declaration. Tripwire: `__tests__/spec-symbol-parity.test.ts`.
+ */
+export const OBJECTUI_SECRET_MASK = '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022';
 
 /**
  * `secret` widget — a write-only credential input for `secret` field types (and
  * `format: 'password'` / `writeOnly` props). A stored secret reads back masked,
  * so the box starts empty with a "leave blank to keep" hint; typing replaces it,
  * a reveal toggle shows what you type, and Clear removes it. Emits the typed
- * value (new secret), `SECRET_MASK` (blank + existing = keep, a no-op on write),
+ * value (new secret), `OBJECTUI_SECRET_MASK` (blank + existing = keep, a no-op on write),
  * `null` (Clear), or `undefined` (blank + none).
  */
 function SecretWidget({ value, onChange, readOnly, schema, id }: WidgetProps) {
-  const stored = value === SECRET_MASK;
+  const stored = value === OBJECTUI_SECRET_MASK;
   const [reveal, setReveal] = React.useState(false);
   const [draft, setDraft] = React.useState<string>(stored || value == null ? '' : String(value));
   const update = (v: string) => {
     setDraft(v);
-    if (v === '') onChange(stored ? SECRET_MASK : undefined); // blank: keep if stored, else unset
+    if (v === '') onChange(stored ? OBJECTUI_SECRET_MASK : undefined); // blank: keep if stored, else unset
     else onChange(v);
   };
   return (

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -61,7 +61,23 @@ export interface CalendarSchema {
   defaultView?: 'month' | 'week' | 'day';
 }
 
-export interface ObjectCalendarProps {
+/**
+ * Props of the `ObjectCalendar` React component.
+ *
+ * Renamed off the bare `ObjectCalendarProps` (objectui#4650): from 17.0.0
+ * `@objectstack/spec/ui` owns that name, where it is the AUTHORED props
+ * document of the `object-calendar` element — `z.input<typeof
+ * ObjectCalendarPropsSchema>`, i.e. serialisable authoring keys only. This is
+ * the RENDERER's props: a live `dataSource`, records pre-fetched by a parent,
+ * and the host callbacks below, none of which can exist in authored metadata.
+ * Two layers under one word, resolved the way this repo already resolved it for
+ * `PageHeaderProps` -> `PageHeaderComponentProps` (app-shell) and the
+ * `Record*ComponentProps` family in `@object-ui/types`.
+ *
+ * The barrel keeps `ObjectCalendarProps` as a deprecated alias of this type, so
+ * no importer breaks. Tripwire: `__tests__/spec-symbol-4650.test.ts`.
+ */
+export interface ObjectCalendarComponentProps {
   schema: ObjectGridSchema | CalendarSchema;
   dataSource?: DataSource;
   className?: string;
@@ -160,7 +176,7 @@ function getCalendarConfig(schema: ObjectGridSchema | CalendarSchema): CalendarC
   return null;
 }
 
-export const ObjectCalendar: React.FC<ObjectCalendarProps> = ({
+export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
   schema,
   dataSource,
   className,

--- a/packages/plugin-calendar/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-calendar/src/__tests__/spec-symbol-4650.test.ts
@@ -1,0 +1,73 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/plugin-calendar` ↔ `@objectstack/spec` symbol-collision tripwire
+ * (objectui#4650). Sibling of `spec-symbol-4650.test.ts` in plugin-grid,
+ * plugin-form and plugin-kanban — one card, four packages, one verdict.
+ *
+ * `@objectstack/spec/ui` owns `ObjectCalendarProps` from 17.0.0: it is the
+ * AUTHORED props document of the `object-calendar` element (`z.input<typeof
+ * ObjectCalendarPropsSchema>`), a serialisable authoring surface. This package's
+ * same-named interface was the RENDERER's props — a live `dataSource`, records
+ * pre-fetched by a parent, eight host callbacks — so the two are different
+ * things under one word, and the local one was renamed to
+ * `ObjectCalendarComponentProps` rather than derived. Same verdict and same
+ * suffix as `PageHeaderProps` -> `PageHeaderComponentProps` (app-shell) and the
+ * `Record*ComponentProps` family in `@object-ui/types`.
+ *
+ * This package had TWO of the card's six collisions, not one: the interface, and
+ * the barrel's `export type { ObjectCalendarProps };` — a re-export with no
+ * `from` clause, which `scripts/check-spec-symbol-derivation.mjs` judges as its
+ * own declaration (the barrel skip it applies to `export … from './x'` cannot
+ * apply when there is no module specifier to recognise). The barrel now spells
+ * the alias with its `from` clause, so the name is judged once, at the
+ * declaration.
+ *
+ * See the plugin-grid sibling for why these are compile-time pins rather than a
+ * runtime name probe, and why the "the spec still owns the old name" half of the
+ * ratchet is not asserted before the pin reaches GA.
+ *
+ * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
+ * that, every `Assert<…>` below is erased before vitest runs and proves nothing.
+ */
+
+import { describe, it } from 'vitest';
+import type * as SpecUi from '@objectstack/spec/ui';
+import type { ObjectCalendarComponentProps, ObjectCalendarProps } from '../index';
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+describe('the rename off the spec name holds', () => {
+  it('is pinned at compile time', () => {
+    // @ts-expect-error `@objectstack/spec/ui` must not own this name. If it
+    // starts to, tsc fails with "Unused '@ts-expect-error' directive" — the
+    // tripwire firing, not a stale suppression.
+    type _NewNameIsFree = SpecUi.ObjectCalendarComponentProps;
+
+    // A local type erased to `any` would satisfy every assertion below while
+    // proving nothing (objectstack#4171 is that failure for other symbols).
+    type _NotAny = Assert<Equal<IsAny<ObjectCalendarComponentProps>, false>>;
+
+    // The deprecated alias denotes the SAME type — the whole promise it makes to
+    // importers that still spell the old name. This is also what keeps the
+    // barrel's re-export a re-export instead of a second declaration.
+    type _AliasIsSameType = Assert<Equal<ObjectCalendarProps, ObjectCalendarComponentProps>>;
+
+    // Still the renderer's props: `dataSource` is a live object no authored
+    // document can carry. If this stops holding, re-triage the symbol rather
+    // than keeping the rename out of habit.
+    type _StillRendererShaped = Assert<
+      Equal<'dataSource' extends keyof ObjectCalendarComponentProps ? true : false, true>
+    >;
+  });
+});

--- a/packages/plugin-calendar/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-calendar/src/__tests__/spec-symbol-4650.test.ts
@@ -29,16 +29,19 @@
  * the alias with its `from` clause, so the name is judged once, at the
  * declaration.
  *
- * See the plugin-grid sibling for why these are compile-time pins rather than a
- * runtime name probe, and why the "the spec still owns the old name" half of the
- * ratchet is not asserted before the pin reaches GA.
+ * The spec is reached through a type-level `import('@objectstack/spec/ui').X`
+ * rather than an `import type * as` statement because a namespace import of that
+ * subpath binds `FormField`/`FormFieldSchema`, which `eslint.config.js` restricts
+ * to an ERROR (objectui#3090). See the plugin-grid sibling for that in full, for
+ * why these are compile-time pins rather than a runtime name probe, and for why
+ * the "the spec still owns the old name" half of the ratchet is not asserted
+ * before the pin reaches GA.
  *
  * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
  * that, every `Assert<…>` below is erased before vitest runs and proves nothing.
  */
 
 import { describe, it } from 'vitest';
-import type * as SpecUi from '@objectstack/spec/ui';
 import type { ObjectCalendarComponentProps, ObjectCalendarProps } from '../index';
 
 type Assert<T extends true> = T;
@@ -52,7 +55,7 @@ describe('the rename off the spec name holds', () => {
     // @ts-expect-error `@objectstack/spec/ui` must not own this name. If it
     // starts to, tsc fails with "Unused '@ts-expect-error' directive" — the
     // tripwire firing, not a stale suppression.
-    type _NewNameIsFree = SpecUi.ObjectCalendarComponentProps;
+    type _NewNameIsFree = import('@objectstack/spec/ui').ObjectCalendarComponentProps;
 
     // A local type erased to `any` would satisfy every assertion below while
     // proving nothing (objectstack#4171 is that failure for other symbols).

--- a/packages/plugin-calendar/src/index.tsx
+++ b/packages/plugin-calendar/src/index.tsx
@@ -14,11 +14,20 @@ import {
   type ElementDataSourceMapping,
 } from '@object-ui/react';
 import { ObjectCalendar } from './ObjectCalendar';
-import type { ObjectCalendarProps } from './ObjectCalendar';
+import type { ObjectCalendarComponentProps } from './ObjectCalendar';
 
 // Export ObjectCalendar component
 export { ObjectCalendar };
-export type { ObjectCalendarProps };
+export type { ObjectCalendarComponentProps };
+
+/**
+ * @deprecated Use `ObjectCalendarComponentProps`. Renamed in objectui#4650
+ * because `@objectstack/spec/ui` owns `ObjectCalendarProps` from 17.0.0, where
+ * it means the AUTHORED props document of the `object-calendar` element — not
+ * this component's props. The alias denotes the SAME type and is kept only so
+ * existing importers keep compiling.
+ */
+export type { ObjectCalendarComponentProps as ObjectCalendarProps } from './ObjectCalendar';
 
 // Export CalendarView component (merged from plugin-calendar-view)
 export { CalendarView } from './CalendarView';
@@ -51,7 +60,7 @@ const OBJECT_CALENDAR_DATA_SOURCE: ElementDataSourceMapping = {
  * own authored keys, the contents of its `props` container, the injected runtime
  * props (`events`, `ariaLabel`/`role`, `data-obj-*`, …) and a host's trailing
  * props — an UNBOUNDED set, spread onto a component whose props are a CLOSED
- * list. `ObjectCalendarProps` declares eight callbacks and a `locale`, so an
+ * list. `ObjectCalendarComponentProps` declares eight callbacks and a `locale`, so an
  * authored value under any of those names landed on the declared prop, and an
  * SDUI author writing JSON can never produce a function.
  *
@@ -73,13 +82,13 @@ const OBJECT_CALENDAR_DATA_SOURCE: ElementDataSourceMapping = {
  * The objectui#4425 phase-2 ruling (option 1, whitelist bounded by declaration)
  * applied to this renderer exactly as objectui#4453 applied it to the sibling
  * `calendar-view` renderer next door: **the forward set is exactly
- * {@link ObjectCalendarProps}, every key resolved to the type that prop
+ * {@link ObjectCalendarComponentProps}, every key resolved to the type that prop
  * declares; everything else is dropped.** `rest` below is READ for the declared
  * keys and is never spread — that is the whole of this fix.
  *
  * A deny-list could not close this: the leak is the open tail of author-supplied
  * keys, which no enumeration can finish. This list is finishable because
- * `ObjectCalendarProps` declares it — and dropping the tail costs nothing,
+ * `ObjectCalendarComponentProps` declares it — and dropping the tail costs nothing,
  * because `ObjectCalendar` DESTRUCTURES a closed list and reads no other prop.
  * ══════════════════════════════════════════════════════════════════════════ */
 
@@ -100,11 +109,11 @@ const OBJECT_CALENDAR_DATA_SOURCE: ElementDataSourceMapping = {
  * a lenient consumer coercion (AGENTS.md #0.1).
  *
  * The whole family is listed rather than the two reported keys, because the
- * defect is the family's: every one of these is a prop `ObjectCalendarProps`
+ * defect is the family's: every one of these is a prop `ObjectCalendarComponentProps`
  * declares, so listing them narrows what may reach the component and widens
  * nothing.
  *
- * `onEdit` and `onDelete` are declared by `ObjectCalendarProps` but are NOT
+ * `onEdit` and `onDelete` are declared by `ObjectCalendarComponentProps` but are NOT
  * destructured by the component (`ObjectCalendar.tsx` — the record drawer builds
  * its own edit/delete handlers from `dataSource`), so forwarding them is inert
  * today. They are listed anyway: the hatch is bounded by the DECLARATION, and a
@@ -124,7 +133,7 @@ const HOST_CALLBACKS = [
   'onEventDrop',
 ] as const;
 
-type HostCallbacks = Pick<ObjectCalendarProps, (typeof HOST_CALLBACKS)[number]>;
+type HostCallbacks = Pick<ObjectCalendarComponentProps, (typeof HOST_CALLBACKS)[number]>;
 
 /**
  * Read the declared callbacks out of the incoming props, keeping only the values
@@ -174,7 +183,7 @@ function resolveAuthoredLocale(raw: unknown): string | undefined {
  * (a non-array was already ignored) and keeps one rule at this boundary rather
  * than an exception.
  */
-function resolveExternalData(raw: unknown): ObjectCalendarProps['data'] {
+function resolveExternalData(raw: unknown): ObjectCalendarComponentProps['data'] {
   return Array.isArray(raw) ? raw : undefined;
 }
 
@@ -182,7 +191,7 @@ function resolveExternalData(raw: unknown): ObjectCalendarProps['data'] {
  * Resolve the declared `loading` prop, which the component honours only
  * alongside external `data`. A boolean or the absent-key answer.
  */
-function resolveExternalLoading(raw: unknown): ObjectCalendarProps['loading'] {
+function resolveExternalLoading(raw: unknown): ObjectCalendarComponentProps['loading'] {
   return typeof raw === 'boolean' ? raw : undefined;
 }
 
@@ -203,9 +212,9 @@ function resolveExternalLoading(raw: unknown): ObjectCalendarProps['loading'] {
  * shape that produced `dataSource.find is not a function` in objectstack#5576.
  * `find` is the method `ObjectCalendar` itself guards on before fetching.
  */
-function resolveHostDataSource(raw: unknown): ObjectCalendarProps['dataSource'] {
+function resolveHostDataSource(raw: unknown): ObjectCalendarComponentProps['dataSource'] {
   return raw && typeof (raw as { find?: unknown }).find === 'function'
-    ? (raw as ObjectCalendarProps['dataSource'])
+    ? (raw as ObjectCalendarComponentProps['dataSource'])
     : undefined;
 }
 
@@ -242,7 +251,7 @@ export const ObjectCalendarRenderer: React.FC<{ schema: any; [key: string]: any 
       errorTitle="This calendar’s data source could not be resolved"
     >
       {/*
-        The forward set is exactly `ObjectCalendarProps` — nothing else can reach
+        The forward set is exactly `ObjectCalendarComponentProps` — nothing else can reach
         the component, because nothing is spread from `rest` (objectui#4492).
         The registry's own declared inputs (`objectName`, `calendar`, and the
         flat `startDateField` / `titleField` / … spelling `ObjectView` and

--- a/packages/plugin-calendar/src/object-calendar-renderer.propsContract.test.tsx
+++ b/packages/plugin-calendar/src/object-calendar-renderer.propsContract.test.tsx
@@ -17,7 +17,7 @@
  *
  * The renderer used to end in `< ObjectCalendar schema={bound} … {...props} />`,
  * where `props` was everything `SchemaRenderer` hands a registered widget.
- * `ObjectCalendarProps` declares eight callbacks and a `locale`, so an authored
+ * `ObjectCalendarComponentProps` declares eight callbacks and a `locale`, so an authored
  * value under any of those names landed on the declared prop — and an SDUI
  * author writing JSON can never produce a function. The card measured three
  * user-reachable failures, all pinned below:

--- a/packages/plugin-calendar/src/registration.test.tsx
+++ b/packages/plugin-calendar/src/registration.test.tsx
@@ -37,7 +37,7 @@ vi.mock(import('@object-ui/react'), async (importOriginal) => ({
 // Mock the implementation. Deliberate whole-module replacement of a LOCAL
 // module: stubbing `ObjectCalendar` is the isolation boundary this test is
 // about, and `./ObjectCalendar`'s only runtime export is the component itself
-// (`ObjectCalendarProps` is type-only and erased at runtime).
+// (`ObjectCalendarComponentProps` is type-only and erased at runtime).
 vi.mock('./ObjectCalendar', () => ({
   ObjectCalendar: ({ dataSource, data, loading }: any) => (
     <div data-testid="calendar-mock">

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -45,7 +45,23 @@ import {
 } from './schemaDefaults';
 import { useOccSave } from './occSave';
 
-export interface ObjectFormProps {
+/**
+ * Props of the `ObjectForm` React component.
+ *
+ * Renamed off the bare `ObjectFormProps` (objectui#4650): from 17.0.0
+ * `@objectstack/spec/ui` owns that name, where it is the AUTHORED props
+ * document of the `object-form` element — `z.input<typeof
+ * ObjectFormPropsSchema>`, i.e. serialisable authoring keys only. This is the
+ * RENDERER's props: a live `dataSource`, submit/cancel callbacks and imperative
+ * handles, none of which can exist in authored metadata. Two layers under one
+ * word, resolved the way this repo already resolved it for `PageHeaderProps` ->
+ * `PageHeaderComponentProps` (app-shell) and the `Record*ComponentProps` family
+ * in `@object-ui/types`.
+ *
+ * The barrel keeps `ObjectFormProps` as a deprecated alias of this type, so no
+ * importer breaks. Tripwire: `__tests__/spec-symbol-4650.test.ts`.
+ */
+export interface ObjectFormComponentProps {
   /**
    * The schema configuration for the form
    */
@@ -77,7 +93,7 @@ export interface ObjectFormProps {
  * Returns the input untouched when neither structured key is present (the
  * common case), so there is no allocation on the hot path.
  */
-function foldFormButtons(schema: ObjectFormProps['schema']): ObjectFormProps['schema'] {
+function foldFormButtons(schema: ObjectFormComponentProps['schema']): ObjectFormComponentProps['schema'] {
   const buttons = (schema as { buttons?: ObjectFormSchema['buttons'] }).buttons;
   const defaults = (schema as { defaults?: Record<string, any> }).defaults;
   if (!buttons && !defaults) return schema;
@@ -89,7 +105,7 @@ function foldFormButtons(schema: ObjectFormProps['schema']): ObjectFormProps['sc
   if (buttons?.cancel?.label != null && s.cancelText === undefined) out.cancelText = buttons.cancel.label;
   if (buttons?.reset?.show !== undefined && s.showReset === undefined) out.showReset = buttons.reset.show;
   if (defaults && s.initialValues === undefined) out.initialValues = defaults;
-  return out as ObjectFormProps['schema'];
+  return out as ObjectFormComponentProps['schema'];
 }
 
 /**
@@ -110,7 +126,7 @@ function foldFormButtons(schema: ObjectFormProps['schema']): ObjectFormProps['sc
  * />
  * ```
  */
-export const ObjectForm: React.FC<ObjectFormProps> = ({
+export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
   schema: rawSchema,
   dataSource,
 }) => {
@@ -119,7 +135,7 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
   // fields) BEFORE dispatching to any variant. This way all variants
   // (Tabbed/Wizard/Split/Drawer/Modal/Simple) transparently honour FLS.
   // Fail-open when no provider mounted (perms.isLoaded false).
-  const schema = useMemo<ObjectFormProps['schema']>(() => {
+  const schema = useMemo<ObjectFormComponentProps['schema']>(() => {
     // framework#1894 / #2998 (ADR-0078): the authored @objectstack/spec
     // FormViewSchema carries the structured `buttons.{submit,cancel,reset}.
     // {show,label}` + `defaults` surface, but this renderer historically read
@@ -133,7 +149,7 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
     // so groups-only metadata actually renders (it used to be silently
     // ignored). Legacy shape maps `title`→`label`, `defaultCollapsed`→`collapsed`.
     const legacyGroups = (folded as any).groups;
-    const base: ObjectFormProps['schema'] =
+    const base: ObjectFormComponentProps['schema'] =
       !folded.sections?.length && Array.isArray(legacyGroups) && legacyGroups.length
         ? {
             ...folded,
@@ -166,7 +182,7 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
         ...s,
         fields: filterArr(s.fields),
       })),
-    } as ObjectFormProps['schema'];
+    } as ObjectFormComponentProps['schema'];
   }, [rawSchema, perms]);
   const { sectionLabel } = useSafeFieldLabel();
   const tSec = (s: any) =>
@@ -358,7 +374,7 @@ export const ObjectForm: React.FC<ObjectFormProps> = ({
 /**
  * SimpleObjectForm — default form variant with auto-generated fields from ObjectQL schema.
  */
-const SimpleObjectForm: React.FC<ObjectFormProps> = ({
+const SimpleObjectForm: React.FC<ObjectFormComponentProps> = ({
   schema,
   dataSource,
 }) => {

--- a/packages/plugin-form/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-form/src/__tests__/spec-symbol-4650.test.ts
@@ -21,16 +21,19 @@
  * `PageHeaderComponentProps` (app-shell) and the `Record*ComponentProps` family
  * in `@object-ui/types`.
  *
- * See the plugin-grid sibling for why these are compile-time pins rather than a
- * runtime name probe, and why the "the spec still owns the old name" half of the
- * ratchet is not asserted before the pin reaches GA.
+ * The spec is reached through a type-level `import('@objectstack/spec/ui').X`
+ * rather than an `import type * as` statement because a namespace import of that
+ * subpath binds `FormField`/`FormFieldSchema`, which `eslint.config.js` restricts
+ * to an ERROR (objectui#3090). See the plugin-grid sibling for that in full, for
+ * why these are compile-time pins rather than a runtime name probe, and for why
+ * the "the spec still owns the old name" half of the ratchet is not asserted
+ * before the pin reaches GA.
  *
  * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
  * that, every `Assert<…>` below is erased before vitest runs and proves nothing.
  */
 
 import { describe, it } from 'vitest';
-import type * as SpecUi from '@objectstack/spec/ui';
 import type { ObjectFormComponentProps, ObjectFormProps } from '../index';
 
 type Assert<T extends true> = T;
@@ -44,7 +47,7 @@ describe('the rename off the spec name holds', () => {
     // @ts-expect-error `@objectstack/spec/ui` must not own this name. If it
     // starts to, tsc fails with "Unused '@ts-expect-error' directive" — the
     // tripwire firing, not a stale suppression.
-    type _NewNameIsFree = SpecUi.ObjectFormComponentProps;
+    type _NewNameIsFree = import('@objectstack/spec/ui').ObjectFormComponentProps;
 
     // A local type erased to `any` would satisfy every assertion below while
     // proving nothing (objectstack#4171 is that failure for other symbols).

--- a/packages/plugin-form/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-form/src/__tests__/spec-symbol-4650.test.ts
@@ -1,0 +1,64 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/plugin-form` ↔ `@objectstack/spec` symbol-collision tripwire
+ * (objectui#4650). Sibling of `spec-symbol-4650.test.ts` in plugin-grid,
+ * plugin-calendar and plugin-kanban — one card, four packages, one verdict.
+ *
+ * `@objectstack/spec/ui` owns `ObjectFormProps` from 17.0.0: it is the AUTHORED
+ * props document of the `object-form` element (`z.input<typeof
+ * ObjectFormPropsSchema>`), a serialisable authoring surface. This package's
+ * same-named interface was the RENDERER's props — a live `dataSource` and the
+ * component's own presentation keys — so the two are different things under one
+ * word, and the local one was renamed to `ObjectFormComponentProps` rather than
+ * derived. Same verdict and same suffix as `PageHeaderProps` ->
+ * `PageHeaderComponentProps` (app-shell) and the `Record*ComponentProps` family
+ * in `@object-ui/types`.
+ *
+ * See the plugin-grid sibling for why these are compile-time pins rather than a
+ * runtime name probe, and why the "the spec still owns the old name" half of the
+ * ratchet is not asserted before the pin reaches GA.
+ *
+ * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
+ * that, every `Assert<…>` below is erased before vitest runs and proves nothing.
+ */
+
+import { describe, it } from 'vitest';
+import type * as SpecUi from '@objectstack/spec/ui';
+import type { ObjectFormComponentProps, ObjectFormProps } from '../index';
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+describe('the rename off the spec name holds', () => {
+  it('is pinned at compile time', () => {
+    // @ts-expect-error `@objectstack/spec/ui` must not own this name. If it
+    // starts to, tsc fails with "Unused '@ts-expect-error' directive" — the
+    // tripwire firing, not a stale suppression.
+    type _NewNameIsFree = SpecUi.ObjectFormComponentProps;
+
+    // A local type erased to `any` would satisfy every assertion below while
+    // proving nothing (objectstack#4171 is that failure for other symbols).
+    type _NotAny = Assert<Equal<IsAny<ObjectFormComponentProps>, false>>;
+
+    // The deprecated alias denotes the SAME type — the whole promise it makes to
+    // importers that still spell the old name.
+    type _AliasIsSameType = Assert<Equal<ObjectFormProps, ObjectFormComponentProps>>;
+
+    // Still the renderer's props: `dataSource` is a live object no authored
+    // document can carry. If this stops holding, re-triage the symbol rather
+    // than keeping the rename out of habit.
+    type _StillRendererShaped = Assert<
+      Equal<'dataSource' extends keyof ObjectFormComponentProps ? true : false, true>
+    >;
+  });
+});

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -16,7 +16,16 @@ import {
 import { ObjectForm } from './ObjectForm';
 
 export { ObjectForm };
-export type { ObjectFormProps } from './ObjectForm';
+export type { ObjectFormComponentProps } from './ObjectForm';
+
+/**
+ * @deprecated Use `ObjectFormComponentProps`. Renamed in objectui#4650 because
+ * `@objectstack/spec/ui` owns `ObjectFormProps` from 17.0.0, where it means the
+ * AUTHORED props document of the `object-form` element — not this component's
+ * props. The alias denotes the SAME type and is kept only so existing importers
+ * keep compiling.
+ */
+export type { ObjectFormComponentProps as ObjectFormProps } from './ObjectForm';
 export { FormSectionContainer } from './FormSection';
 export type { FormSectionContainerProps } from './FormSection';
 export {

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -268,7 +268,7 @@ export interface ObjectGridColumnState {
  * page/sort/search state, and ObjectGrid forwards them straight to its
  * DataTable instead of client-slicing the window it was handed.
  *
- * Kept as its own named interface rather than flattened into `ObjectGridProps`
+ * Kept as its own named interface rather than flattened into `ObjectGridComponentProps`
  * (#4277 裁决 B, 2026-08-11): the two are different classes of contract, and a
  * dozen more members merged into the authoring surface would erase that
  * boundary. Until this existed, every member below was read out of `...rest`
@@ -348,7 +348,24 @@ export interface ObjectGridExternalPaginationProps
   findParams?: Record<string, unknown> | null;
 }
 
-export interface ObjectGridProps extends ObjectGridExternalPaginationProps {
+/**
+ * Props of the `ObjectGrid` React component.
+ *
+ * Renamed off the bare `ObjectGridProps` (objectui#4650): from 17.0.0
+ * `@objectstack/spec/ui` owns that name, where it is the AUTHORED props
+ * document of the `object-grid` element — `z.input<typeof
+ * ObjectGridPropsSchema>`, i.e. serialisable authoring keys only (`label`,
+ * `fields`, `defaultFilters`, `pagination`, …). This is the RENDERER's props: a
+ * live `dataSource`, the host pagination handles below, and eleven callbacks,
+ * none of which can exist in authored metadata. Two layers under one word,
+ * resolved the way this repo already resolved it for `PageHeaderProps` ->
+ * `PageHeaderComponentProps` (app-shell) and the `Record*ComponentProps` family
+ * in `@object-ui/types`.
+ *
+ * The barrel keeps `ObjectGridProps` as a deprecated alias of this type, so no
+ * importer breaks. Tripwire: `__tests__/spec-symbol-4650.test.ts`.
+ */
+export interface ObjectGridComponentProps extends ObjectGridExternalPaginationProps {
   schema: ObjectGridSchema;
   dataSource?: DataSource;
   className?: string;
@@ -499,7 +516,7 @@ function resolveRowHeightMode(rowHeight: unknown): RowHeightMode {
   return rowHeight as RowHeightMode;
 }
 
-export const ObjectGrid: React.FC<ObjectGridProps> = ({
+export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   schema,
   dataSource,
   onEdit,

--- a/packages/plugin-grid/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-grid/src/__tests__/spec-symbol-4650.test.ts
@@ -1,0 +1,84 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/plugin-grid` ↔ `@objectstack/spec` symbol-collision tripwire
+ * (objectui#4650).
+ *
+ * `@objectstack/spec/ui` owns `ObjectGridProps` from 17.0.0: it is the AUTHORED
+ * props document of the `object-grid` element (`z.input<typeof
+ * ObjectGridPropsSchema>` — `label`, `fields`, `defaultFilters`, `pagination`,
+ * …), a serialisable authoring surface. This package's same-named interface was
+ * the RENDERER's props — a live `dataSource`, host pagination handles, eleven
+ * callbacks — so the two are different things under one word, and the local one
+ * was renamed to `ObjectGridComponentProps` rather than derived. That is the
+ * same verdict, and the same suffix, this repo already reached for
+ * `PageHeaderProps` -> `PageHeaderComponentProps` (app-shell) and for the
+ * `Record*ComponentProps` family in `@object-ui/types`.
+ *
+ * A rename only stays a fix while the new name is genuinely free, and an alias
+ * only keeps its promise while it denotes the same type. Both are pinned below.
+ *
+ * ## Why these are compile-time pins and not a runtime name probe
+ *
+ * The sibling tripwires in app-shell and plugin-list read every `@objectstack/
+ * spec` subpath's `.d.ts` through the TypeScript checker, because they need the
+ * spec's export names as DATA (they iterate a table of them). Here the question
+ * is about two names known at authoring time, so `tsc` can answer it directly —
+ * which also keeps this file free of `node:` imports, and so runnable in the two
+ * sibling plugins whose `tsconfig.test.json` deliberately does not pull in
+ * `@types/node`.
+ *
+ * The GA half of the ratchet — "the spec still owns `ObjectGridProps`, so this
+ * rename still has a reason" — is not asserted here, and deliberately so: this
+ * repo is pinned to `^17.0.0-rc.6`, which does not export that name yet (#4636 /
+ * PR #4639 raises it). Asserting it would fail on today's `main` for a rename
+ * that is exactly what makes the GA tree green. The thing that measures the GA
+ * direction is `scripts/check-spec-symbol-derivation.mjs` itself.
+ *
+ * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
+ * that, every `Assert<…>` below is erased before vitest runs and proves nothing.
+ */
+
+import { describe, it } from 'vitest';
+import type * as SpecUi from '@objectstack/spec/ui';
+import type { ObjectGridComponentProps, ObjectGridProps } from '../index';
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+describe('the rename off the spec name holds', () => {
+  it('is pinned at compile time', () => {
+    // The spec must not own the NEW name. If it ever ships an
+    // `ObjectGridComponentProps`, this directive stops suppressing anything and
+    // `tsc` fails with "Unused '@ts-expect-error' directive" — which is the
+    // tripwire firing. Rename again (checking the next name here FIRST), or
+    // derive from the spec if by then the two really are the same thing.
+    // @ts-expect-error `@objectstack/spec/ui` must not own this name.
+    type _NewNameIsFree = SpecUi.ObjectGridComponentProps;
+
+    // Guard against the pin lying: a local type that erased to `any` would
+    // satisfy every assignability question below while proving nothing
+    // (objectstack#4171 is that failure for other symbols).
+    type _NotAny = Assert<Equal<IsAny<ObjectGridComponentProps>, false>>;
+
+    // The deprecated alias denotes the SAME type, which is the whole promise it
+    // makes to importers that still spell the old name. If they ever diverge,
+    // the alias has become a second declaration and the rename leaked.
+    type _AliasIsSameType = Assert<Equal<ObjectGridProps, ObjectGridComponentProps>>;
+
+    // The renderer props are still the renderer's: `dataSource` is a live object
+    // the authored document cannot carry. This is what makes "two layers, one
+    // word" true rather than asserted — if it ever goes away, re-triage the
+    // symbol instead of keeping the rename out of habit.
+    type _StillRendererShaped = Assert<Equal<'dataSource' extends keyof ObjectGridComponentProps ? true : false, true>>;
+  });
+});

--- a/packages/plugin-grid/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-grid/src/__tests__/spec-symbol-4650.test.ts
@@ -34,6 +34,14 @@
  * sibling plugins whose `tsconfig.test.json` deliberately does not pull in
  * `@types/node`.
  *
+ * The spec is reached through a type-level `import('@objectstack/spec/ui').X`
+ * rather than an `import type * as SpecUi` statement, and that is not a style
+ * choice: a namespace import of that subpath necessarily binds `FormField` and
+ * `FormFieldSchema`, which `eslint.config.js` restricts to an ERROR because the
+ * spec's form-view types erase to `any` and importing them silently deletes type
+ * safety (objectui#3090). A type-level `import(…)` names one member and declares
+ * no binding, so it asks the question without opening that door.
+ *
  * The GA half of the ratchet — "the spec still owns `ObjectGridProps`, so this
  * rename still has a reason" — is not asserted here, and deliberately so: this
  * repo is pinned to `^17.0.0-rc.6`, which does not export that name yet (#4636 /
@@ -46,7 +54,6 @@
  */
 
 import { describe, it } from 'vitest';
-import type * as SpecUi from '@objectstack/spec/ui';
 import type { ObjectGridComponentProps, ObjectGridProps } from '../index';
 
 type Assert<T extends true> = T;
@@ -63,7 +70,7 @@ describe('the rename off the spec name holds', () => {
     // tripwire firing. Rename again (checking the next name here FIRST), or
     // derive from the spec if by then the two really are the same thing.
     // @ts-expect-error `@objectstack/spec/ui` must not own this name.
-    type _NewNameIsFree = SpecUi.ObjectGridComponentProps;
+    type _NewNameIsFree = import('@objectstack/spec/ui').ObjectGridComponentProps;
 
     // Guard against the pin lying: a local type that erased to `any` would
     // satisfy every assignability question below while proving nothing

--- a/packages/plugin-grid/src/index.tsx
+++ b/packages/plugin-grid/src/index.tsx
@@ -35,7 +35,16 @@ export { useGroupReorder } from './useGroupReorder';
 export { useColumnSummary } from './useColumnSummary';
 export { FormulaBar } from './FormulaBar';
 export { SplitPaneGrid } from './SplitPaneGrid';
-export type { ObjectGridProps, ObjectGridExternalPaginationProps, ObjectGridColumnState } from './ObjectGrid';
+export type { ObjectGridComponentProps, ObjectGridExternalPaginationProps, ObjectGridColumnState } from './ObjectGrid';
+
+/**
+ * @deprecated Use `ObjectGridComponentProps`. Renamed in objectui#4650 because
+ * `@objectstack/spec/ui` owns `ObjectGridProps` from 17.0.0, where it means the
+ * AUTHORED props document of the `object-grid` element — not this component's
+ * props. The alias denotes the SAME type and is kept only so existing importers
+ * keep compiling.
+ */
+export type { ObjectGridComponentProps as ObjectGridProps } from './ObjectGrid';
 export type { VirtualGridProps, VirtualGridColumn } from './VirtualGrid';
 export type { InlineEditingProps } from './InlineEditing';
 export type { ImportWizardProps, ImportResult } from './ImportWizard';

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -103,7 +103,23 @@ export function resolveKanbanCardFields(
   return [];
 }
 
-export interface ObjectKanbanProps {
+/**
+ * Props of the `ObjectKanban` React component.
+ *
+ * Renamed off the bare `ObjectKanbanProps` (objectui#4650): from 17.0.0
+ * `@objectstack/spec/ui` owns that name, where it is the AUTHORED props
+ * document of the `object-kanban` element — `z.input<typeof
+ * ObjectKanbanPropsSchema>`, i.e. serialisable authoring keys only. This is the
+ * RENDERER's props: a live `dataSource`, records pre-fetched by a parent, and
+ * the host callbacks below, none of which can exist in authored metadata. Two
+ * layers under one word, resolved the way this repo already resolved it for
+ * `PageHeaderProps` -> `PageHeaderComponentProps` (app-shell) and the
+ * `Record*ComponentProps` family in `@object-ui/types`.
+ *
+ * The barrel keeps `ObjectKanbanProps` as a deprecated alias of this type, so
+ * no importer breaks. Tripwire: `__tests__/spec-symbol-4650.test.ts`.
+ */
+export interface ObjectKanbanComponentProps {
   schema: KanbanSchema;
   dataSource?: DataSource;
   className?: string; // Allow override
@@ -115,7 +131,7 @@ export interface ObjectKanbanProps {
   onCardClick?: (record: any) => void;
 }
 
-export const ObjectKanban: React.FC<ObjectKanbanProps> = ({
+export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
   schema,
   dataSource,
   className,

--- a/packages/plugin-kanban/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-kanban/src/__tests__/spec-symbol-4650.test.ts
@@ -1,0 +1,64 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `@object-ui/plugin-kanban` ↔ `@objectstack/spec` symbol-collision tripwire
+ * (objectui#4650). Sibling of `spec-symbol-4650.test.ts` in plugin-grid,
+ * plugin-form and plugin-calendar — one card, four packages, one verdict.
+ *
+ * `@objectstack/spec/ui` owns `ObjectKanbanProps` from 17.0.0: it is the
+ * AUTHORED props document of the `object-kanban` element (`z.input<typeof
+ * ObjectKanbanPropsSchema>`), a serialisable authoring surface. This package's
+ * same-named interface was the RENDERER's props — a live `dataSource`, records
+ * pre-fetched by a parent, host click callbacks — so the two are different
+ * things under one word, and the local one was renamed to
+ * `ObjectKanbanComponentProps` rather than derived. Same verdict and same suffix
+ * as `PageHeaderProps` -> `PageHeaderComponentProps` (app-shell) and the
+ * `Record*ComponentProps` family in `@object-ui/types`.
+ *
+ * See the plugin-grid sibling for why these are compile-time pins rather than a
+ * runtime name probe, and why the "the spec still owns the old name" half of the
+ * ratchet is not asserted before the pin reaches GA.
+ *
+ * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
+ * that, every `Assert<…>` below is erased before vitest runs and proves nothing.
+ */
+
+import { describe, it } from 'vitest';
+import type * as SpecUi from '@objectstack/spec/ui';
+import type { ObjectKanbanComponentProps, ObjectKanbanProps } from '../index';
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+describe('the rename off the spec name holds', () => {
+  it('is pinned at compile time', () => {
+    // @ts-expect-error `@objectstack/spec/ui` must not own this name. If it
+    // starts to, tsc fails with "Unused '@ts-expect-error' directive" — the
+    // tripwire firing, not a stale suppression.
+    type _NewNameIsFree = SpecUi.ObjectKanbanComponentProps;
+
+    // A local type erased to `any` would satisfy every assertion below while
+    // proving nothing (objectstack#4171 is that failure for other symbols).
+    type _NotAny = Assert<Equal<IsAny<ObjectKanbanComponentProps>, false>>;
+
+    // The deprecated alias denotes the SAME type — the whole promise it makes to
+    // importers that still spell the old name.
+    type _AliasIsSameType = Assert<Equal<ObjectKanbanProps, ObjectKanbanComponentProps>>;
+
+    // Still the renderer's props: `dataSource` is a live object no authored
+    // document can carry. If this stops holding, re-triage the symbol rather
+    // than keeping the rename out of habit.
+    type _StillRendererShaped = Assert<
+      Equal<'dataSource' extends keyof ObjectKanbanComponentProps ? true : false, true>
+    >;
+  });
+});

--- a/packages/plugin-kanban/src/__tests__/spec-symbol-4650.test.ts
+++ b/packages/plugin-kanban/src/__tests__/spec-symbol-4650.test.ts
@@ -21,16 +21,19 @@
  * as `PageHeaderProps` -> `PageHeaderComponentProps` (app-shell) and the
  * `Record*ComponentProps` family in `@object-ui/types`.
  *
- * See the plugin-grid sibling for why these are compile-time pins rather than a
- * runtime name probe, and why the "the spec still owns the old name" half of the
- * ratchet is not asserted before the pin reaches GA.
+ * The spec is reached through a type-level `import('@objectstack/spec/ui').X`
+ * rather than an `import type * as` statement because a namespace import of that
+ * subpath binds `FormField`/`FormFieldSchema`, which `eslint.config.js` restricts
+ * to an ERROR (objectui#3090). See the plugin-grid sibling for that in full, for
+ * why these are compile-time pins rather than a runtime name probe, and for why
+ * the "the spec still owns the old name" half of the ratchet is not asserted
+ * before the pin reaches GA.
  *
  * Compiled by this package's `tsconfig.test.json` (objectui#3181) — without
  * that, every `Assert<…>` below is erased before vitest runs and proves nothing.
  */
 
 import { describe, it } from 'vitest';
-import type * as SpecUi from '@objectstack/spec/ui';
 import type { ObjectKanbanComponentProps, ObjectKanbanProps } from '../index';
 
 type Assert<T extends true> = T;
@@ -44,7 +47,7 @@ describe('the rename off the spec name holds', () => {
     // @ts-expect-error `@objectstack/spec/ui` must not own this name. If it
     // starts to, tsc fails with "Unused '@ts-expect-error' directive" — the
     // tripwire firing, not a stale suppression.
-    type _NewNameIsFree = SpecUi.ObjectKanbanComponentProps;
+    type _NewNameIsFree = import('@objectstack/spec/ui').ObjectKanbanComponentProps;
 
     // A local type erased to `any` would satisfy every assertion below while
     // proving nothing (objectstack#4171 is that failure for other symbols).

--- a/packages/plugin-kanban/src/index.tsx
+++ b/packages/plugin-kanban/src/index.tsx
@@ -110,7 +110,16 @@ export function bucketCardsIntoColumns(
 // Export types for external use
 export type { KanbanSchema, KanbanCard, KanbanColumn, CardTemplate, ColumnWidthConfig, InlineFieldDefinition } from './types';
 export { ObjectKanban };
-export type { ObjectKanbanProps } from './ObjectKanban';
+export type { ObjectKanbanComponentProps } from './ObjectKanban';
+
+/**
+ * @deprecated Use `ObjectKanbanComponentProps`. Renamed in objectui#4650
+ * because `@objectstack/spec/ui` owns `ObjectKanbanProps` from 17.0.0, where it
+ * means the AUTHORED props document of the `object-kanban` element — not this
+ * component's props. The alias denotes the SAME type and is kept only so
+ * existing importers keep compiling.
+ */
+export type { ObjectKanbanComponentProps as ObjectKanbanProps } from './ObjectKanban';
 
 // Phase 13 L2/L3: New components and hooks
 export { InlineQuickAdd } from './InlineQuickAdd';


### PR DESCRIPTION
Fixes #4650

Pre-bump adaptation **2 of 2** for #4636 / PR #4639. Resolves all six spec-named symbol
collisions `@objectstack/spec@17.0.0` introduces, so `check-spec-symbol-derivation` is green
on a GA-installed tree — while staying green on current `main` (pinned `^17.0.0-rc.6`). No
dependency change here; that is PR #4639's job.

## The authoritative six

The card named five and left the sixth to be derived. Measured by running the real gate
against a GA-installed tree (method below), the six are:

| # | symbol | kind | site | spec subpath |
|---|---|---|---|---|
| 1 | `SECRET_MASK` | const | `packages/app-shell/src/views/metadata-admin/widgets.tsx:1852` | `@objectstack/spec/data` |
| 2 | `ObjectCalendarProps` | interface | `packages/plugin-calendar/src/ObjectCalendar.tsx:64` | `@objectstack/spec/ui` |
| 3 | `ObjectCalendarProps` | **re-export** | `packages/plugin-calendar/src/index.tsx:21` | `@objectstack/spec/ui` |
| 4 | `ObjectFormProps` | interface | `packages/plugin-form/src/ObjectForm.tsx:48` | `@objectstack/spec/ui` |
| 5 | `ObjectGridProps` | interface | `packages/plugin-grid/src/ObjectGrid.tsx:351` | `@objectstack/spec/ui` |
| 6 | `ObjectKanbanProps` | interface | `packages/plugin-kanban/src/ObjectKanban.tsx:106` | `@objectstack/spec/ui` |

**The unnamed sixth is #3** — the plugin-calendar barrel's `export type { ObjectCalendarProps };`.
It is a separate finding rather than a duplicate of #2 because it carries **no `from` clause**:
the gate skips a re-export whose module specifier is relative or `@object-ui/*` (whatever it
points at is judged at its own declaration), but with no specifier there is nothing to
recognise, so the barrel line is judged as its own declaration. Spelling the alias
`export type { X as Y } from './ObjectCalendar'` is what collapses it back to one judgement.

## Per-symbol disposition

### The four `Object*Props` — different things sharing a name ⇒ rename + deprecated alias

The spec's are **authored props documents** of the `object-*` elements —
`z.input< typeof ObjectGridPropsSchema >`, serialisable authoring keys (`label`, `fields`,
`defaultFilters`, `pagination`, …). Ours are the **renderers' props**: a live `dataSource`,
records pre-fetched by a parent, and the host callbacks. Two layers under one word, so the
local ones are renamed, not derived.

The suffix is not invented — it is the split this repo already made twice for exactly this
shape: `PageHeaderProps` -> `PageHeaderComponentProps` (app-shell, in that package's rename
table) and the `Record*ComponentProps` family in `@object-ui/types`, whose spec counterparts
are `RecordActivityProps` / `RecordDetailsProps` / ….

| package | new name | old name kept as |
|---|---|---|
| `@object-ui/plugin-calendar` | `ObjectCalendarComponentProps` | `@deprecated` barrel alias |
| `@object-ui/plugin-form` | `ObjectFormComponentProps` | `@deprecated` barrel alias |
| `@object-ui/plugin-grid` | `ObjectGridComponentProps` | `@deprecated` barrel alias |
| `@object-ui/plugin-kanban` | `ObjectKanbanComponentProps` | `@deprecated` barrel alias |

Each alias is `export type { New as Old } from './Module';` — the `from` clause is
load-bearing, not cosmetic: without it the gate judges the alias as a fresh declaration
(finding #3 above is precisely that shape).

### `SECRET_MASK` — the SAME thing ⇒ rename now, derive at the bump

This one is genuinely the spec's constant: identical value, and 17.0.0 moved the ADR-0100
credential read mask into `@objectstack/spec/data` (objectstack#7572) so its two readers stop
each declaring a byte-identical literal. The doctrine's preferred arm is therefore to
**import** it — and that import cannot be written on this branch, because `^17.0.0-rc.6` does
not export the name. The two clauses collide, and "must land green on current main" wins.

So the copy stays under a name that cannot be read as canonical, `OBJECTUI_SECRET_MASK`, with
the whole burn-down recorded as one line at the declaration: when #4639 lands, replace the
literal with a re-export from `@objectstack/spec/data`.

**Nothing published changes.** The constant is not part of `@object-ui/app-shell`'s API:
`src/index.ts` re-exports a named list from `./views/metadata-admin`, that barrel does not
re-export `widgets` at all, there is no `export *` on either path, and the package publishes
only `.`. Its only readers are `widgets.tsx` itself and the sibling `SecretWidget.test.tsx`.
No alias is owed, so none is added — a `SECRET_MASK` alias would keep a spec-named symbol in
the tree for zero consumers.

## Evidence — the gate, both directions, at the pushed HEAD

Both readings taken at `66adc24fa` (working tree clean).

**Current `main`'s pin (`17.0.0-rc.6`), before and after:** green either way — the collisions
are GA-introduced, so this change is invisible to today's farm except through the types and
tests it adjusts.

```
✅  spec symbol derivation: 1252 files scanned against 4834 spec export names; 13 declared
    dialects, 3 untriaged collisions in 1 packages.
✅  spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages.
```

**GA tree (`@objectstack/spec@17.0.0`) — the reading this card exists for.** On `origin/main`
it is exit 1 with the six above; at this HEAD:

```
✅  spec symbol derivation: 1252 files scanned against 4912 spec export names; 13 declared
    dialects, 3 untriaged collisions in 1 packages.
✅  spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages.
```

Note both readings keep 13 ALLOW entries matched and the same 3 `@object-ui/types` ledger
entries live: no existing exemption went stale in either direction, which the gate's own
ratchets would have failed on.

**Method for the GA reading** (stated because it is not the obvious one): rather than a
second full install of PR #4639's branch, `npm pack @objectstack/spec@17.0.0` was unpacked
into this worktree's `node_modules/.ga-measure/` and the `@objectstack/spec` symlink
repointed at it, so the real gate script ran unmodified over this branch's sources with GA's
export set; the rc.6 link was then restored. Placing the copy inside the worktree matters —
`zod` and the rest resolve by walking up to the workspace root, so the spec's `.d.ts` files
type-check properly instead of degrading to `any` and under-reporting names. The name counts
above (4834 vs 4912) are the check that the two readings really are different export sets.

## Other gates at `66adc24fa`

| gate | result |
|---|---|
| `check:spec-symbols` (rc.6 pin) | PASS |
| `check:spec-symbols` (GA overlay) | PASS |
| `check:phantom-deps` | PASS |
| `check:control-bytes` | PASS |
| `check:action-forward-parity` | PASS |
| `check:i18n-keys` / `check:i18n-drift` | PASS |
| `check:skills-paths` | PASS |
| `check-changeset-presence` / `-fixed` / `-no-major` | PASS |
| `eslint --quiet` over the changed files | PASS (0 errors) |
| `type-check` — the four plugins + app-shell | PASS |
| `vitest run` over the touched packages | 302 files / 2875 tests passed, 1 skipped |
| `vitest run` over the new + touched test files at this HEAD | 8 files / 61 tests passed |

`check:phantom-deps` is the one worth calling out: the new tests import `@objectstack/spec`
from two packages that do not declare it, which is legal only because they are TOOLING files
served by the workspace root's `devDependencies`. The gate confirms it rather than my reading
of it — "2162 tooling import(s) are declared only by the workspace root". No `package.json`
and no lockfile entry changes here, deliberately: adding a spec devDep to plugin-calendar and
plugin-kanban at the rc range would be a fifth and sixth pin for PR #4639 to find and raise.

## Tripwires, and proof they are load-bearing

The gate's own remedy text asks a rename to come with "a tripwire test asserting the spec does
not own the name". Each of the four plugins gets `__tests__/spec-symbol-4650.test.ts` pinning,
at compile time, that the spec does not own the NEW name and that the deprecated alias still
denotes the SAME type; app-shell's existing `spec-symbol-parity.test.ts` gains the
`SECRET_MASK` entry in a new `RENAMES_PENDING_GA` table, whose "the spec still owns the old
name" half arms itself when the installed spec stops being a pre-release.

Compile-time assertions are erased before vitest runs, so they were verified by ablation
rather than assumed — direction predicted before running, both times red:

- point the directive at a name the pinned spec really exports ⇒
  `error TS2578: Unused '@ts-expect-error' directive.`
- weaken the alias pin to `Equal< ObjectGridProps, string >` ⇒
  `error TS2344: Type 'false' does not satisfy the constraint 'true'.`

Both restored from the commit and re-confirmed green (`git status` clean, i.e. byte-identical).

One implementation note recorded in each test file, because the natural spelling is banned:
the spec is reached through a type-level `import('@objectstack/spec/ui').X` rather than
`import type * as SpecUi`, because a namespace import of that subpath necessarily binds
`FormField` / `FormFieldSchema`, which `eslint.config.js` restricts to an **error**
(objectui#3090 — those spec types erase to `any`, so importing them silently deletes type
safety). This cost a lap; the reason is written down so it is not "cleaned up" back.

## Scope

No file outside this card's surface. `packages/app-shell/src/views/ObjectView.tsx` and
plugin-list / plugin-view (#4649) and the disclosure types/components (#4632) are untouched.
The `striped` / `bordered` / `virtualScroll` retirement and the new GA authoring surfaces
from PR #4639's list are not addressed here — they are separate adaptations.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_