### PR TITLE
fix(docs): toggle-group schema teaches selectionType, not type, for selection mode

### DIFF
--- a/content/docs/components/disclosure/toggle-group.mdx
+++ b/content/docs/components/disclosure/toggle-group.mdx
@@ -31,7 +31,7 @@ interface ToggleGroupItem {
 
 interface ToggleGroupSchema {
   type: 'toggle-group';
-  type: 'single' | 'multiple';    // Selection mode
+  selectionType?: 'single' | 'multiple';  // Selection mode
   items: ToggleGroupItem[];       // Toggle items
   value?: string | string[];      // Selected value(s)
   variant?: 'default' | 'outline';


### PR DESCRIPTION
Fixes #4653

## What was wrong

`content/docs/components/disclosure/toggle-group.mdx`'s Schema block declared
`type` twice in one interface — once correctly as the component discriminator
(`'toggle-group'`), and once, invalidly, for the selection mode:

```ts
interface ToggleGroupSchema {
  type: 'toggle-group';
  type: 'single' | 'multiple';    // Selection mode
  ...
```

`ToggleGroupSchema` in `packages/types/src/disclosure.ts` declares
`selectionType?: 'single' | 'multiple'`, and the renderer
(`packages/components/src/renderers/disclosure/toggle-group.tsx`) reads
`schema.selectionType` (defaulting to `'single'`). An author following the old
doc would write `type: 'single'`, which collides with the discriminator and
is silently dropped — the group would stay single-select no matter what the
author intended.

## Fix

Renamed the duplicated line to `selectionType?: 'single' | 'multiple';`,
matching the contract and the renderer, and matching how the three
`SchemaExample` catalog entries on the same page already author it
(`examples/schema-catalog/src/schemas/components-disclosure-toggle-group/*.json`).

## Sweep of the rest of the block (per card scope)

Checked every other key in the doc's `ToggleGroupSchema` / `ToggleGroupItem`
blocks against `packages/types/src/disclosure.ts` (and `BaseSchema` for
`className`):

| Doc key | Contract | Match |
|---|---|---|
| `type: 'toggle-group'` | `type: 'toggle-group'` | ok |
| `items` | `items?: ToggleGroupItem[]` | ok (key name matches; doc omits `?`, not a wrong-key defect) |
| `value` | `value?: string \| string[]` | ok |
| `variant` | `variant?: 'default' \| 'outline'` | ok |
| `size` | `size?: 'default' \| 'sm' \| 'lg'` | ok (doc lists the literals in a different order, same set) |
| `disabled` | `disabled?: boolean` | ok |
| `className` | `BaseSchema.className?: string` | ok |
| `onValueChange?: string \| ActionConfig` | `onValueChange?: (value) => void` | key exists in the contract; the doc's JSON-authoring form (`string \| ActionConfig`) is the same convention used identically on `button-group.mdx`, `combobox.mdx`, and `radio-group.mdx` — not page-specific drift, left untouched |
| `ToggleGroupItem.value/label/disabled` | same on `ToggleGroupItem` | ok |

**Result: no other key on this page names something the contract doesn't
declare.** The only defect was the duplicated `type` row / `selectionType`
mismatch called out in the issue.

## Gates run

- `node scripts/check-doc-links.mjs` → `Links are valid across 13 scan roots.`
- `node scripts/check-control-bytes.mjs` → `OK (scanned 4191 tracked text file(s); skipped 85 binary).`
- `node scripts/check-changeset-presence.mjs` → `No source of a released package changed in this range, so no changeset is owed.` (docs-only change, exemption confirmed the same way as PR #4643)

All three gates run at `6bf152dc5` (this branch's head).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_