### PR TITLE
fix(examples): pin the two plugin-calendar catalog entries onto their own events (#4627)

### DIFF
--- a/examples/schema-catalog/src/schemas/plugin-calendar/month-view-calendar.json
+++ b/examples/schema-catalog/src/schemas/plugin-calendar/month-view-calendar.json
@@ -1,6 +1,7 @@
 {
   "type": "calendar-view",
   "view": "month",
+  "currentDate": "2026-05-15T12:00:00.000Z",
   "data": [
     {
       "id": 1,

--- a/examples/schema-catalog/src/schemas/plugin-calendar/week-view-calendar.json
+++ b/examples/schema-catalog/src/schemas/plugin-calendar/week-view-calendar.json
@@ -1,6 +1,7 @@
 {
   "type": "calendar-view",
   "view": "week",
+  "currentDate": "2026-05-27T12:00:00.000Z",
   "data": [
     {
       "id": 1,

--- a/examples/schema-catalog/test/catalog-gallery-render.test.tsx
+++ b/examples/schema-catalog/test/catalog-gallery-render.test.tsx
@@ -45,12 +45,13 @@
  *   objectui#4626  2 entries were filed as blank tiles, each authoring a key
  *                          its own renderer never reads — one of the two was
  *                          measured to be neither (see below)
- *   objectui#4627  2 entries author 2024 event dates, outside the window
- *                          `calendar-view` paints
+ *   objectui#4627  2 entries author events in a fixed past month, outside the
+ *                          window `calendar-view` paints around today
  *
- * The first three are FIXED in the entries as of objectui#4624's PR, so the
- * eight entries they covered carry the full assertion set here and no longer
- * appear in either table. What that PR measured, and corrects in this header:
+ * All four are FIXED in the entries — the first three as of objectui#4624's
+ * PR, #4627 as of its own — so the ten entries they covered carry the full
+ * assertion set here and no longer appear in either table. What #4624 measured,
+ * and corrects in this header:
  *
  *  - #4625's six now author `ui:calendar`, the namespaced key the primitive is
  *    registered under. Probed through this file's own render path before the
@@ -108,8 +109,9 @@
  * distinction matters in both directions (see the header). For
  * the categories objectui#4616 newly registered, a stronger positive control on
  * top: the titles the entry itself authors are on screen
- * (`AUTHORED_TEXT_EXEMPT` records the two that cannot be asserted that way,
- * with the reason).
+ * (`AUTHORED_TEXT_EXEMPT` records any that cannot be asserted that way, with
+ * the reason — it is empty as of objectui#4627, and every entry in those
+ * categories carries the control).
  *
  * The diagnostic strings are COPIED as literals rather than imported from the
  * packages' internals, for the reason objectui#4600 gave: they are
@@ -242,24 +244,27 @@ const NEWLY_REGISTERED_CATEGORIES = [
 
 /**
  * Entries in those categories whose authored titles provably cannot reach the
- * DOM. Each still carries the full no-red-tile assertion and the
+ * DOM. Each would still carry the full no-red-tile assertion and the
  * DOM-was-produced control above; only the authored-title control is lifted,
  * with the measured reason.
  *
- * date window: `calendar-view` paints the grid for the CURRENT month/week, and
- * both entries author events with fixed 2024 dates, so no event title is in
- * range (measured on a 2026-08-14 run: "August 2026" and "Aug 9 - Aug 15,
- * 2026"). That is a staleness question about the entries' data, not a render
- * defect — filed as objectui#4627. Everything else still applies to them: both
- * draw a real calendar, 163 and 421 elements.
+ * EMPTY, and that is the assertion: every entry in the newly-registered
+ * categories now puts its own authored titles on screen. The table held
+ * `plugin-calendar`'s two until objectui#4627 — `calendar-view` paints the
+ * window around `currentDate`, which defaults to TODAY, and both entries
+ * authored events in a fixed past month, so no event title could ever be in
+ * range (measured on a 2026-08-14 run: the tiles drew "August 2026" and
+ * "Aug 9 - Aug 15, 2026" around an empty grid). That was a staleness question
+ * about the entries' data, not a render defect: both already drew a real
+ * calendar, 163 and 421 elements. Both entries now author `currentDate` — the
+ * registry input `calendar-view` declares, parsed from its documented ISO
+ * string at the renderer boundary since objectui#4452 — pinning each view onto
+ * its own events, so the exemption is gone rather than reworded.
  *
  * (`plugin-editor`'s and `plugin-map`'s six are absent from this table because
  * they are not rendered here at all — see `EXCLUSIONS`.)
  */
-const AUTHORED_TEXT_EXEMPT: Record<string, string> = {
-  'plugin-calendar/month-view-calendar': 'date window',
-  'plugin-calendar/week-view-calendar': 'date window',
-};
+const AUTHORED_TEXT_EXEMPT: Record<string, string> = {};
 
 /**
  * The gallery's data source, in the shape `SchemaThumbnail` supplies it. Kept


### PR DESCRIPTION
Fixes #4627

`calendar-view` paints its month/week window around `currentDate`, which defaults to **today**. Both `plugin-calendar` catalog entries author their events in a fixed past month, so the two tiles whose whole point is to demonstrate events on a calendar drew a correct-but-empty grid — and would have done so on every future day.

## The choice: authored `currentDate`, not relative-to-today dates

The card left this open between two mechanisms and asked for the choice to be stated. **Relative-to-today dates are not available**, so `currentDate` is the option, not merely the preferred one:

- The catalog ships **static JSON that must stay copy-pasteable** — `examples/schema-catalog/src/types.ts` says so in as many words ("Kept separate from the schema JSON so the raw schemas remain copy-pasteable into user projects").
- Nothing in the pipeline or the renderer substitutes date tokens. The renderer maps each record through a plain `new Date(record[startField])` (`packages/plugin-calendar/src/calendar-view-renderer.tsx`), and there is no `{{now}}` / offset-token language anywhere in `examples/schema-catalog/**` or `packages/plugin-calendar/**` — grepped, zero hits.
- Supplying one would mean either inventing a runtime token language on the renderer (a contract change far past an example-data card) or baking dates in at build time, which turns the shipped entry into a generated artifact and destroys the copy-pasteable property this card is required to protect.

`currentDate` costs none of that. It is a **declared registry input** on `calendar-view` — `type: 'string'`, "ISO date string for initial calendar date" — and since #4452 / PR #4484 the renderer parses that documented ISO string into the `Date` the component's prop type declares, at the boundary (`resolveAuthoredCurrentDate`). So the spelling authored here is exactly the spelling the input documents, and the two entries now double as the worked example of a real, declared, working key. The result is deterministic forever rather than dependent on the day the gallery is opened.

Values, chosen mid-window so no timezone can shift the view out of range:

| entry | `currentDate` | window it pins | events |
| --- | --- | --- | --- |
| `month-view-calendar` | `2026-05-15T12:00:00.000Z` | 42-cell grid, Sun Apr 26 → Sat Jun 6 2026 | all 3, incl. the Jun 4–6 "Conference" in the trailing row |
| `week-view-calendar` | `2026-05-27T12:00:00.000Z` | Sun May 24 → Sat May 30 2026 | all 4 |

The events themselves are untouched — the card's shape is to pin the view onto the events, and the existing curated data already forms one coherent month and one coherent week.

## The exemptions are removed, not reworded

`catalog-gallery-render.test.tsx` named both entries in `AUTHORED_TEXT_EXEMPT`, lifting the authored-title control with "date window" as the measured reason. That reason no longer holds, so both entries are **removed from the table** — which is now empty — and each now carries the full control: every authored title must be on screen. The file's header tables and the two prose references to this card are updated to match.

## Verification — all at `715ba9ae6` (final commit, clean tree)

- `pnpm exec vitest run examples/schema-catalog` — **8 files, 1576 tests passed**. Re-run after the final commit on a clean tree; both sha and dirty-count captured in the same command.
- Both entries confirmed running under **both** controls (`--reporter=verbose`), not silently skipped:
  ```
  ✓ plugin-calendar/month-view-calendar renders without a red tile
  ✓ plugin-calendar/week-view-calendar  renders without a red tile
  ✓ plugin-calendar/month-view-calendar puts its authored content on screen
  ✓ plugin-calendar/week-view-calendar  puts its authored content on screen
  ```
- **Reverse verification**, direction predicted before running (red — the titles leave the window): with the exemptions removed and `currentDate` ablated from both entries, exactly the two authored-content cases fail, naming every authored title —
  ```
  × plugin-calendar/month-view-calendar puts its authored content on screen
    AssertionError: expected [ 'Team Meeting', …(2) ] to deeply equal []
  × plugin-calendar/week-view-calendar puts its authored content on screen
    AssertionError: expected [ 'Standup', 'Sprint Planning', …(2) ] to deeply equal []
  ```
  Ablation applied and restored from the commit (`git checkout` of the branch, scoped to the two entry paths), never the shared stash.
- `pnpm --filter @object-ui/example-schema-catalog regenerate:check` — `src/index.ts is up to date (423 entries)`. Contents-only entry edits, so no index regeneration is owed (PR #4637's model); no titles or descriptions changed, so `catalog-meta.json` is untouched.
- `pnpm exec tsc -p examples/schema-catalog/tsconfig.test.json --noEmit` — exit 0.
- `pnpm --filter @object-ui/example-schema-catalog lint` — 0 errors (2 pre-existing warnings, in `src/index.ts` and `vitest.config.ts`, both untouched here).
- `node scripts/check-control-bytes.mjs` — `OK (scanned 4191 tracked text file(s); skipped 85 binary)`.

## Changeset

None owed, per the gate's own output:

```
Compared the working tree with 8871c1463 (merge-base with origin/main): 3 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets
ignores, 0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

## Note for triage — the card's "2024" is imprecise, the premise is not

The issue title and body say the entries author "fixed 2024 event dates". On `origin/main` they author **2026-05/06** dates. The substantive premise is unaffected and was confirmed directly: those dates sit outside the window painted around today either way, which is exactly what the ablation above re-measures. Only the year in the filing's prose was off; nothing about the defect or its fix changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_