### PR TITLE
fix(core,app-shell): project every declared recordIdField, and refuse an action that names no record

### DIFF
--- a/.changeset/nervous-pugs-worry.md
+++ b/.changeset/nervous-pugs-worry.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/core': minor
+'@object-ui/app-shell': minor
+'@object-ui/plugin-grid': minor
+'@object-ui/plugin-list': minor
+---
+
+Project every declared `recordIdField`, and refuse an action that names no record
+
+objectstack#8018. An `api` action declaring `recordIdParam` identifies the record
+it acts on by a row field — `recordIdField`, default `id`. The grid built
+`$select` from the listView columns, `id` and the predicate refs only, so an
+action keyed on any other field asked the server for everything except the key
+naming its own record. The row arrived without it, and the injection was skipped
+silently: the request went out anyway, minus the parameter. A backend reading a
+missing selector as "match nothing" then answers success for having changed
+nothing, so a record-scoped mutation reports success and does nothing.
+
+Two independent repairs, both in this change:
+
+- **Projection.** `listViewPredicates` (`@object-ui/core`) now also harvests
+  `recordIdField` from `rowActionDefs`, `bulkActionDefs` and the object's
+  `actions`, spelled as a synthetic `record.<name>` so the one existing harvester
+  handles it. Both projection builders — `ObjectGrid` and `ListView` — read that
+  function, so both gain the key with no call-site change. The existing guards
+  still apply: a name the object does not declare, or one that is not a bare
+  identifier, is dropped rather than put in `$select`, because an unknown key
+  there is not ignored by every backend.
+- **Loud failure.** New `resolveRecordIdParamSeed` (`@object-ui/core`) is the one
+  definition of "can this row identify the record?". `useConsoleActionRuntime`'s
+  api handler now refuses the dispatch — `{ success: false, error }`, before the
+  request — when the row lacks the key, or holds `null` for it. The two refusals
+  are worded differently because they point at different repairs: an absent key
+  is a projection or read-visibility problem, a null value is a data one. Falsy
+  real values (`0`, `''`, `false`) are values and still dispatch.
+
+The second half is what closes the class rather than the common case: a row can
+lack the key for reasons projection cannot fix — a server-side read mask that
+strips the field regardless of `$select`, a partial payload, a field the
+principal cannot read.
+
+Behaviour change worth noting: an action that previously dispatched an
+under-specified request now fails visibly instead. That is the point — the old
+path could not report the failure it was causing.

--- a/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useConsoleActionRuntime.test.tsx
@@ -864,6 +864,105 @@ describe('#2958 — a failure reported under HTTP 200 is a failure, not success'
   });
 });
 
+/**
+ * `recordIdParam` seeding refuses rather than under-specifies (objectstack#8018).
+ *
+ * The injection used to be `if (rowValue != null) body[param] = rowValue;` with a
+ * silent `else`: a row that could not supply the key sent the request anyway,
+ * minus the parameter naming the record. A backend reading a missing selector as
+ * "match nothing" then answers success for having changed nothing — measured on a
+ * session-revocation control that reported success and revoked nothing.
+ *
+ * The projection harvest (`listViewPredicates`, covered in plugin-grid and core)
+ * closes the ordinary route to an absent key. This half closes the class: a row
+ * can still lack the key for reasons projection cannot fix — a server-side read
+ * mask that strips the field regardless of `$select` (`internal: true`), a
+ * partial payload, a field the principal cannot read. The assertion that matters
+ * on every case below is `authFetchSpy` never being called: the refusal must
+ * happen BEFORE the request, not be read out of the response.
+ */
+describe('apiHandler — recordIdParam seeding refuses instead of under-specifying (objectstack#8018)', () => {
+  const REVOKE = {
+    type: 'api',
+    name: 'revoke_session',
+    label: 'Revoke Session',
+    target: '/api/v1/auth/revoke-session',
+    recordIdParam: 'token',
+    recordIdField: 'token',
+  };
+
+  const dispatch = async (action: any, rowRecord: unknown) => {
+    const { result } = renderHook(() => useConsoleActionRuntime({ dataSource: {}, objects: [] }));
+    let res: any;
+    await act(async () => {
+      res = await result.current.apiHandler({
+        ...action,
+        params: { _rowRecord: rowRecord },
+      } as any);
+    });
+    return res;
+  };
+
+  it('refuses when the row lacks the recordIdField key entirely', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ status: true }) });
+    // Exactly what the unharvested projection delivered: every column except
+    // the one the action identifies its record by.
+    const res = await dispatch(REVOKE, { id: 'sess_1', ip_address: '10.0.0.2' });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('Revoke Session');
+    expect(res.error).toContain('token');
+    // The point of the whole card: no request goes out under-specified.
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the key is present but null — a different repair, said differently', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ status: true }) });
+    const res = await dispatch(REVOKE, { id: 'sess_1', token: null });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('this record has no value');
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('injects the value and dispatches when the row supplies it', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ status: true }) });
+    const res = await dispatch(REVOKE, { id: 'sess_1', token: 'tok_abc' });
+
+    expect(res.success).toBe(true);
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(authFetchSpy.mock.calls[0][1].body)).toMatchObject({ token: 'tok_abc' });
+  });
+
+  it('keys off `id` by default, and refuses on a row without one', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ status: true }) });
+    const byId = { ...REVOKE, recordIdField: undefined, recordIdParam: 'recordId' };
+
+    const ok = await dispatch(byId, { id: 'sess_1' });
+    expect(ok.success).toBe(true);
+    expect(JSON.parse(authFetchSpy.mock.calls[0][1].body)).toMatchObject({ recordId: 'sess_1' });
+
+    authFetchSpy.mockClear();
+    const bad = await dispatch(byId, { ip_address: '10.0.0.2' });
+    expect(bad.success).toBe(false);
+    expect(bad.error).toContain('"id"');
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('leaves an action declaring no recordIdParam completely alone', async () => {
+    authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ status: true }) });
+    // No `recordIdParam` ⇒ no injection is declared ⇒ the guard has no opinion,
+    // whatever the row does or does not carry.
+    const res = await dispatch(
+      { type: 'api', name: 'revoke_others', target: '/api/v1/auth/revoke-other-sessions' },
+      { id: 'sess_1' },
+    );
+
+    expect(res.success).toBe(true);
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('serverActionHandler — list_toolbar selection fallback', () => {
   it('uses the single selected row from the runner context as recordId', async () => {
     authFetchSpy.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -39,7 +39,7 @@ import type {
   ResultDialogHandler,
   ToastHandler,
 } from '@object-ui/core';
-import { actionErrorDetail, isRecordScopedAction } from '@object-ui/core';
+import { actionErrorDetail, isRecordScopedAction, resolveRecordIdParamSeed } from '@object-ui/core';
 import { useActionModal } from './useActionModal';
 import { ActionConfirmDialog, type ConfirmDialogState } from '../views/ActionConfirmDialog';
 import { ActionParamDialog, type ParamDialogState } from '../views/ActionParamDialog';
@@ -319,11 +319,18 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
           }
         }
 
-        if (rowRecord && action.recordIdParam) {
-          const rowField = action.recordIdField || 'id';
-          const rowValue = rowRecord[rowField];
-          if (rowValue != null) body[action.recordIdParam] = rowValue;
-        }
+        // Seed the declared `recordIdParam` from the row — or REFUSE
+        // (objectstack#8018). The read used to be `if (rowValue != null)` with a
+        // silent `else`, so a row that could not supply the key sent the request
+        // anyway, minus the parameter naming the record. A backend that reads a
+        // missing selector as "match nothing" then answers success for having
+        // changed nothing, and the user is told the action worked. Refusing is
+        // the contract-first answer (AGENTS.md #0.1): an under-specified request
+        // is rejected at the producer, not sent and hoped about. `error` here is
+        // what makes the runner toast it (see the entitlement note below).
+        const seed = resolveRecordIdParamSeed(action, rowRecord);
+        if (seed.error) return { success: false, error: seed.error };
+        if (seed.value !== undefined) body[action.recordIdParam!] = seed.value;
 
         const isAuthOrgEndpoint = /\/api\/v1\/auth\//.test(resolvedTarget);
         if (isAuthOrgEndpoint && !body.organizationId && activeOrganization?.id) {

--- a/packages/core/src/actions/__tests__/recordIdParam.test.ts
+++ b/packages/core/src/actions/__tests__/recordIdParam.test.ts
@@ -1,0 +1,92 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `resolveRecordIdParamSeed` — the one definition of "can this row identify the
+ * record this action acts on?" (objectstack#8018).
+ *
+ * The three verdicts are deliberately distinct, because they point at different
+ * repairs: no declaration (nothing to do), an ABSENT key (a projection or
+ * read-visibility problem), and a NULL value (a data problem). Collapsing the
+ * last two into one silent skip is the defect this function replaces.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveRecordIdParamSeed } from '../recordIdParam';
+
+const REVOKE = {
+  name: 'revoke_session',
+  label: 'Revoke Session',
+  recordIdParam: 'token',
+  recordIdField: 'token',
+};
+
+describe('resolveRecordIdParamSeed', () => {
+  it('returns the row value when the key is present', () => {
+    expect(resolveRecordIdParamSeed(REVOKE, { id: 's1', token: 'tok_abc' })).toEqual({
+      value: 'tok_abc',
+    });
+  });
+
+  it('refuses an ABSENT key and names both the action and the field', () => {
+    const seed = resolveRecordIdParamSeed(REVOKE, { id: 's1', ip_address: '10.0.0.2' });
+    expect(seed.value).toBeUndefined();
+    expect(seed.error).toContain('Revoke Session');
+    expect(seed.error).toContain('"token"');
+    expect(seed.error).toContain('not present on the row');
+  });
+
+  it('refuses a NULL value with a DIFFERENT message than an absent key', () => {
+    const absent = resolveRecordIdParamSeed(REVOKE, { id: 's1' });
+    const nulled = resolveRecordIdParamSeed(REVOKE, { id: 's1', token: null });
+    expect(nulled.error).toContain('has no value');
+    expect(nulled.error).not.toEqual(absent.error);
+  });
+
+  it('refuses `undefined` stored under a present key — an explicit hole is still a hole', () => {
+    expect(resolveRecordIdParamSeed(REVOKE, { id: 's1', token: undefined }).error)
+      .toContain('has no value');
+  });
+
+  it('defaults the field to `id`', () => {
+    const byId = { name: 'a', recordIdParam: 'recordId' };
+    expect(resolveRecordIdParamSeed(byId, { id: 'r1' })).toEqual({ value: 'r1' });
+    expect(resolveRecordIdParamSeed(byId, { code: 'X' }).error).toContain('"id"');
+  });
+
+  it('has no opinion when the action declares no recordIdParam', () => {
+    expect(resolveRecordIdParamSeed({ name: 'a', recordIdField: 'token' }, {})).toEqual({});
+  });
+
+  it('has no opinion when there is no row record at all', () => {
+    // A path with no row context is not this guard's business — the caller's
+    // own resolution (explicit params, grid selection) owns that case.
+    expect(resolveRecordIdParamSeed(REVOKE, undefined)).toEqual({});
+    expect(resolveRecordIdParamSeed(REVOKE, null)).toEqual({});
+  });
+
+  it('tolerates a missing action', () => {
+    expect(resolveRecordIdParamSeed(null, { id: 'r1' })).toEqual({});
+    expect(resolveRecordIdParamSeed(undefined, { id: 'r1' })).toEqual({});
+  });
+
+  it('falls back to the param name when the action carries no label or name', () => {
+    expect(resolveRecordIdParamSeed({ recordIdParam: 'token' }, {}).error).toContain('"token"');
+  });
+
+  it('passes through falsy-but-real values instead of refusing them', () => {
+    // `0` and `''` are values a record legitimately holds. Only null/undefined
+    // mean "no value" — a `!value` test here would refuse a real record.
+    expect(resolveRecordIdParamSeed({ recordIdParam: 'p', recordIdField: 'n' }, { n: 0 }))
+      .toEqual({ value: 0 });
+    expect(resolveRecordIdParamSeed({ recordIdParam: 'p', recordIdField: 'n' }, { n: '' }))
+      .toEqual({ value: '' });
+    expect(resolveRecordIdParamSeed({ recordIdParam: 'p', recordIdField: 'n' }, { n: false }))
+      .toEqual({ value: false });
+  });
+});

--- a/packages/core/src/actions/index.ts
+++ b/packages/core/src/actions/index.ts
@@ -15,3 +15,4 @@ export * from './bulkFastPath.js';
 export * from './actionErrorDetail.js';
 export * from './actionResponse.js';
 export * from './serverActionHandler.js';
+export * from './recordIdParam.js';

--- a/packages/core/src/actions/recordIdParam.ts
+++ b/packages/core/src/actions/recordIdParam.ts
@@ -1,0 +1,104 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Seeding an action's `recordIdParam` from the row — and refusing to dispatch
+ * when the row cannot supply it (objectstack#8018).
+ *
+ * An `api` action declaring `recordIdParam` names the request key that carries
+ * the record it acts on; `recordIdField` names the row field whose value seeds
+ * it (default `id`). Every call site used to spell the read the same permissive
+ * way:
+ *
+ * ```ts
+ * const rowValue = rowRecord[action.recordIdField || 'id'];
+ * if (rowValue != null) body[action.recordIdParam] = rowValue;   // else: nothing
+ * ```
+ *
+ * The `else` branch is the defect. It cannot distinguish "this row has no such
+ * key" from "this row's value is null", and in both cases it drops the parameter
+ * and lets the request go out anyway. What reaches the server is a mutation with
+ * no record named — and a backend that treats a missing selector as "match
+ * nothing" answers `{ status: true }` for having deleted nothing. The user is
+ * told the action succeeded. The measured instance was a session-revocation
+ * control that revoked nothing, which is the worst shape this can take: a
+ * security affordance that reports success while no-op'ing.
+ *
+ * The absent-key half is reachable from ordinary authoring, not just from bad
+ * data: the grid projects `$select` from the listView columns, so until
+ * `recordIdField` was harvested into it (see `listViewPredicates`) any action
+ * keyed on a non-column field got a row without that key. The harvest closes the
+ * common route; this guard closes the class, because a row can still lack the key
+ * for reasons projection cannot fix — a server-side read mask that strips the
+ * field regardless of projection (`internal: true`), a partial payload handed
+ * down from a host, a field the principal cannot read.
+ *
+ * Contract-first (AGENTS.md #0.1): the answer to an under-specified request is to
+ * refuse it at the producer, loudly, not to send it and hope the server objects.
+ * The two failures are named separately because they point at different repairs —
+ * an absent key is a projection/visibility problem, a null value is a data one.
+ */
+
+/** The minimal action shape this resolution reads. */
+export interface RecordIdParamAction {
+  /** Request key that carries the record id. Absent ⇒ no injection is declared. */
+  recordIdParam?: string;
+  /** Row field whose value seeds it. Defaults to `id`. */
+  recordIdField?: string;
+  /** Used only to make the refusal message name the action. */
+  name?: string;
+  label?: string;
+}
+
+/**
+ * Either the value to inject, or the reason the action must not be dispatched.
+ * `{}` (neither key) means no injection is declared — carry on unchanged.
+ */
+export type RecordIdParamSeed =
+  | { value: unknown; error?: undefined }
+  | { value?: undefined; error: string }
+  | { value?: undefined; error?: undefined };
+
+/**
+ * Resolve the value an action's `recordIdParam` should carry, or the refusal.
+ *
+ * Pure — reads the action and the row, mutates nothing. Returns `{}` when the
+ * action declares no `recordIdParam` (nothing to inject) or when there is no row
+ * record at all (the caller is on a path where no row context exists; that is not
+ * this guard's business).
+ */
+export function resolveRecordIdParamSeed(
+  action: RecordIdParamAction | null | undefined,
+  rowRecord: Record<string, unknown> | null | undefined,
+): RecordIdParamSeed {
+  const param = action?.recordIdParam;
+  if (!param || !rowRecord || typeof rowRecord !== 'object') return {};
+
+  const field = action?.recordIdField || 'id';
+  const label = action?.label || action?.name || param;
+
+  if (!(field in rowRecord)) {
+    return {
+      error:
+        `Action "${label}" identifies its record by "${field}", but that field is not ` +
+        `present on the row. Add it to the view's columns, or check that it is readable ` +
+        `— running without it would send a request that names no record.`,
+    };
+  }
+
+  const value = rowRecord[field];
+  if (value == null) {
+    return {
+      error:
+        `Action "${label}" identifies its record by "${field}", but this record has no ` +
+        `value for it — running without it would send a request that names no record.`,
+    };
+  }
+
+  return { value };
+}

--- a/packages/core/src/utils/__tests__/predicate-fields.test.ts
+++ b/packages/core/src/utils/__tests__/predicate-fields.test.ts
@@ -95,6 +95,57 @@ describe('listViewPredicates', () => {
       ),
     ).toEqual([]);
   });
+
+  // objectstack#8018 — `recordIdField` is a row key an action READS, so the
+  // projection owes it just as it owes a predicate's operands. Without this the
+  // action runtime got `undefined` for it and sent a request naming no record.
+  it('harvests `recordIdField` from every action list', () => {
+    expect(
+      collectPredicateFieldRefs(
+        listViewPredicates({
+          rowActionDefs: [{ name: 'a', recordIdField: 'token' }],
+          bulkActionDefs: [{ name: 'b', recordIdField: 'batch_key' }],
+          objectActions: [{ name: 'c', recordIdField: 'external_ref' }],
+        }),
+      ),
+    ).toEqual(['token', 'batch_key', 'external_ref']);
+  });
+
+  it('harvests a `recordIdField` alongside the same action’s predicates', () => {
+    expect(
+      collectPredicateFieldRefs(
+        listViewPredicates({
+          objectActions: [
+            { name: 'revoke', visible: 'record.active', recordIdField: 'token' },
+          ],
+        }),
+      ),
+    ).toEqual(['active', 'token']);
+  });
+
+  it('adds nothing for the default `id` or a non-string declaration', () => {
+    expect(
+      collectPredicateFieldRefs(
+        listViewPredicates({
+          objectActions: [
+            { name: 'a' },
+            { name: 'b', recordIdField: '' },
+            { name: 'c', recordIdField: 42 },
+          ],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('drops a `recordIdField` that is not a bare identifier', () => {
+    // Not a field name anywhere, and dropping is the safe direction: an unknown
+    // key in `$select` is not ignored by every backend.
+    expect(
+      collectPredicateFieldRefs(
+        listViewPredicates({ objectActions: [{ name: 'a', recordIdField: 'not a field' }] }),
+      ),
+    ).toEqual([]);
+  });
 });
 
 describe('isProjectableField', () => {

--- a/packages/core/src/utils/predicate-fields.ts
+++ b/packages/core/src/utils/predicate-fields.ts
@@ -31,6 +31,12 @@
  * more column and no extra round trip. (A relation that IS displayed still gets
  * expanded for its label, and `toPredicateRecord` collapses it back for the
  * predicate.)
+ *
+ * Since objectstack#8018 the same reader also carries the non-predicate row keys
+ * a view's actions read — today just `recordIdField`. The name kept the
+ * "predicate" spelling because the mechanism is identical (harvest a name, gate
+ * it against the declared fields, add it to `$select`); see
+ * {@link listViewPredicates} for what is in the set and why.
  */
 
 /**
@@ -81,6 +87,15 @@ export function isProjectableField(
  */
 const RECORD_REF = /\b(?:record|data)\.([A-Za-z_][A-Za-z0-9_]*)/g;
 
+/**
+ * A whole bare identifier — what a field name is, and the only shape that can be
+ * spelled as `record.<name>` without the harvester's regex reading a PREFIX of it
+ * as the name (`record.not a field` would otherwise yield `not`). Used to gate
+ * the non-predicate names folded into {@link listViewPredicates}, so a malformed
+ * declaration contributes nothing instead of contributing a plausible wrong name.
+ */
+const BARE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /** Pull the CEL source out of any of the shapes a predicate is authored in. */
 function predicateSource(pred: unknown): string | null {
   if (typeof pred === 'string') return pred.trim() || null;
@@ -122,13 +137,32 @@ export function collectPredicateFieldRefs(predicates: readonly unknown[]): strin
 }
 
 /**
- * Every predicate a list-ish view carries, flattened for
+ * Every record-field reference a list-ish view carries, flattened for
  * {@link collectPredicateFieldRefs}.
  *
  * One reader so the projection cannot fall behind the surfaces: each entry here
- * is a place a predicate is actually evaluated against a row — conditional
- * formatting, the row kebab (custom defs AND the built-in Edit/Delete
- * overrides), the selection bar, and the object's declared actions.
+ * is a place a row field is actually READ — conditional formatting, the row
+ * kebab (custom defs AND the built-in Edit/Delete overrides), the selection bar,
+ * and the object's declared actions.
+ *
+ * Most entries are predicates. Two are not, and both are spelled as a synthetic
+ * `record.<name>` so the one harvester handles them: conditional formatting's
+ * native `{ field, operator, value }` shape, and an action's `recordIdField`
+ * (objectstack#8018). The `recordIdField` case is the same *class* of bug the
+ * predicate harvest exists to close, one surface over — the action runtime reads
+ * `rowRecord[action.recordIdField]` to seed `recordIdParam`, so a key outside the
+ * listView columns arrived absent and the injection was silently skipped, which
+ * turns a record-scoped mutation into one that names no record while still
+ * reporting success. The default (`id`) is already projected unconditionally, so
+ * only an explicit declaration adds anything here.
+ *
+ * A `recordIdField` that is not a bare identifier is dropped here, and one naming
+ * a field the object does not declare is dropped by the caller's
+ * `isProjectableField` guard. Both drops are the safe direction: such a name is
+ * not a column anywhere, and an unknown key in `$select` is not ignored by every
+ * backend. The identifier gate is not decoration — without it the harvester's
+ * regex would read a PREFIX of a malformed name (`record.not a field` → `not`)
+ * and contribute a plausible wrong field instead of nothing.
  *
  * `objectActions` is deliberately the object's WHOLE action set rather than
  * only the ones this view promotes. Narrowing it would mean re-running the
@@ -159,6 +193,13 @@ export function listViewPredicates(view: {
       if (!def || typeof def !== 'object') continue;
       const d = def as Record<string, unknown>;
       preds.push(d.visible, d.disabled);
+      // The row key this action identifies its record by — a field the runtime
+      // READS off the row, so the projection owes it exactly as it owes a
+      // predicate's operands. Spelled as a `record.` reference so the one
+      // harvester handles it (see the doc above).
+      if (typeof d.recordIdField === 'string' && BARE_IDENTIFIER.test(d.recordIdField)) {
+        preds.push(`record.${d.recordIdField}`);
+      }
     }
   }
   for (const override of Object.values(view.userActions ?? {})) {

--- a/packages/plugin-grid/src/__tests__/recordIdFieldProjection.test.tsx
+++ b/packages/plugin-grid/src/__tests__/recordIdFieldProjection.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `recordIdField` is part of a view's field appetite (objectstack#8018).
+ *
+ * The grid projects what it DISPLAYS plus what its PREDICATES read
+ * (objectui#3501). An action's `recordIdField` is neither: it names the row key
+ * whose VALUE the action runtime sends as `recordIdParam`. So an action keyed on
+ * anything other than a listView column asked the server for every field except
+ * the one identifying the record it acts on — the row arrived without the key,
+ * the runtime read `undefined`, and the injection was silently skipped.
+ *
+ * That is a class, not an instance: any object may declare it, and the failure
+ * shape is a mutation that reports success while naming no record. This file
+ * pins the projection half — the harvest — on both routes a `recordIdField`
+ * reaches the grid: the object's own `actions`, and the view's `rowActionDefs` /
+ * `bulkActionDefs`.
+ *
+ * The guard it inherits from the predicate harvest is deliberate: a
+ * `recordIdField` naming a field the object does not declare is DROPPED rather
+ * than projected. An unknown key in `$select` is not ignored by every backend
+ * (the cloud multi-tenant runtime answers with an empty result set), so a typo'd
+ * declaration must not be able to zero the whole list.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { ActionProvider } from '@object-ui/react';
+
+const OBJECT_FIELDS = {
+  name: { type: 'text' },
+  status: { type: 'select' },
+  // The key an action identifies the record by, deliberately NOT a column below
+  // — this is the whole shape of the defect.
+  token: { type: 'text' },
+};
+
+const makeDataSource = (actions?: unknown[]) => ({
+  find: vi.fn().mockResolvedValue({ value: [], '@odata.count': 0 }),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn().mockResolvedValue({
+    name: 'sessions',
+    fields: OBJECT_FIELDS,
+    ...(actions ? { actions } : {}),
+  }),
+});
+
+/** Render a grid showing only `name` and return the `$select` it asked for. */
+const selectFor = async (
+  schemaExtra: Record<string, unknown>,
+  objectActions?: unknown[],
+): Promise<string[]> => {
+  const ds = makeDataSource(objectActions);
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'sessions',
+    columns: ['name'],
+    ...schemaExtra,
+  };
+  render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} dataSource={ds as never} />
+    </ActionProvider>,
+  );
+  await vi.waitFor(() => expect(ds.find).toHaveBeenCalled());
+  return (ds.find.mock.calls.at(-1)?.[1]?.$select ?? []) as string[];
+};
+
+const REVOKE = {
+  name: 'revoke_session',
+  label: 'Revoke Session',
+  type: 'api',
+  locations: ['list_item'],
+  target: '/api/v1/auth/revoke-session',
+  recordIdParam: 'token',
+  recordIdField: 'token',
+};
+
+describe('ObjectGrid — $select harvests every declared `recordIdField` (objectstack#8018)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("projects an object action's `recordIdField` that no column shows", async () => {
+    const select = await selectFor({}, [REVOKE]);
+    expect(select).toContain('token');
+    // The columns and `id` are still there — the harvest ADDS, it never replaces.
+    expect(select).toContain('name');
+    expect(select).toContain('id');
+  });
+
+  it("projects a view `rowActionDefs` entry's `recordIdField`", async () => {
+    const select = await selectFor({ rowActionDefs: [REVOKE] });
+    expect(select).toContain('token');
+  });
+
+  it("projects a view `bulkActionDefs` entry's `recordIdField`", async () => {
+    const select = await selectFor({
+      bulkActionDefs: [{ ...REVOKE, locations: ['list_toolbar'] }],
+    });
+    expect(select).toContain('token');
+  });
+
+  it('drops a `recordIdField` the object does not declare, rather than poisoning `$select`', async () => {
+    const select = await selectFor({}, [{ ...REVOKE, recordIdField: 'toekn' }]);
+    expect(select).not.toContain('toekn');
+    expect(select).toContain('name');
+  });
+
+  it('adds nothing when the action keys off the default `id`', async () => {
+    const select = await selectFor({}, [{ ...REVOKE, recordIdField: undefined }]);
+    expect(select).toEqual(['id', 'name']);
+  });
+
+  it('projects the key once when it is also a column', async () => {
+    const select = await selectFor({ columns: ['name', 'token'] }, [REVOKE]);
+    expect(select.filter((f) => f === 'token')).toHaveLength(1);
+  });
+});

--- a/scripts/check-action-forward-parity.mjs
+++ b/scripts/check-action-forward-parity.mjs
@@ -175,8 +175,18 @@ export const SURFACES = [
 // def arrives as; reads are collected for that identifier only, which is what
 // keeps `objectDef.actions.filter(a => a.locations…)` — a read off the AUTHORED
 // list, in the same files — out of the set.
+//
+// A read that moves BEHIND A HELPER moves out of this extractor's sight — the
+// call site passes the whole def (`resolveRecordIdParamSeed(action, rowRecord)`)
+// and no longer names the key, so the key silently leaves the owed set and the
+// entries excusing it go stale. That is a re-point, not a deletion: the helper is
+// where the forwarded def is read now, so it is listed here (objectstack#8018).
+// The tell that this is the right direction: deleting the stale entries instead
+// would have recorded "no surface owes `recordIdField`" while the runtime still
+// reads it off every forwarded def it is handed.
 export const RUNTIME_CONSUMERS = [
   { file: "packages/core/src/actions/ActionRunner.ts", binding: "action" },
+  { file: "packages/core/src/actions/recordIdParam.ts", binding: "action" },
   { file: "packages/app-shell/src/hooks/useConsoleActionRuntime.tsx", binding: "action" },
   { file: "packages/app-shell/src/views/RecordDetailView.tsx", binding: "action" },
 ];
@@ -211,10 +221,10 @@ export const JUSTIFIED = {
         {
           reason:
             `Unreachable on this surface, not dropped. \`${key}\` is read only under a ` +
-            "`rowRecord` guard — useConsoleActionRuntime.tsx:297 " +
-            "(`if (rowRecord && action.recordIdParam)`), :377 " +
-            "(`rowRecord?.[action.recordIdField || 'id']`) and :398 " +
-            "(`action.undoable && obj && recId && rowRecord && …`) — and `rowRecord` is " +
+            "`rowRecord` guard — useConsoleActionRuntime.tsx seeds `recordIdParam` from the " +
+            "row (`resolveRecordIdParamSeed(action, rowRecord)`, which is where " +
+            "`recordIdField` is read since objectstack#8018), and reads " +
+            "`action.undoable && obj && recId && rowRecord && …` — and `rowRecord` is " +
             "`params._rowRecord`, written only by the spread-based hosts listed above, " +
             "none of which dispatch through this renderer. objectstack#6938 made the same " +
             "reachability call for `recordIdParam`; this gate's own measurement extended it " +


### PR DESCRIPTION
Part of objectstack-ai/objectstack#8018

The objectui **general half** of the card. The silent-success half (`revoke-session`
answering `{ status: true }` while matching nothing) and the `sys_session.revoke_session`
declaration are objectstack-side and are not addressed here, so the card stays open.

## The defect, re-derived against `main`

An `api` action declaring `recordIdParam` identifies the record it acts on by a row
field — `recordIdField`, default `id`. Two independent things were wrong:

1. **The grid never projected it.** `$select` is built from the listView columns, `id`
   and the predicate refs. `recordIdField` was harvested by nothing, so an action keyed
   on any other field asked the server for everything except the key naming its own
   record.
2. **The runtime dropped it silently.** The seeding read was
   `if (rowValue != null) body[param] = rowValue;` with an empty `else` — the request
   went out anyway, minus the parameter. A backend that reads a missing selector as
   "match nothing" then answers success for having changed nothing.

Together: a record-scoped mutation that reports success and does nothing.

**Anchors re-derived** (the card's had drifted): the projection builder is
`ObjectGrid.tsx:877-922`, not `:677-722`; `predicate-fields.ts:141-170` was accurate.
The card missed a **second** projection builder — `plugin-list/src/ListView.tsx:1503-1517`
feeds the same helper, so a fix landing only in `ObjectGrid` would have left the class
open in the other half of the repo.

## What changed

**Projection (`@object-ui/core`).** `listViewPredicates` now also harvests
`recordIdField` from `rowActionDefs`, `bulkActionDefs` and the object's `actions`,
spelled as a synthetic `record.NAME` so the one existing harvester handles it — the
idiom the function already uses for conditional formatting's native
`{ field, operator, value }` shape. **Both** projection builders read that function, so
`ObjectGrid` and `ListView` gain the key with no call-site change; that is what makes
this a class fix rather than a per-surface one. Existing guards still apply: a name the
object does not declare is dropped by `isProjectableField`, and a new identifier gate
drops a non-identifier declaration — without it the harvester's regex would read a
*prefix* of a malformed name (`record.not a field` yields `not`) and contribute a
plausible wrong field instead of nothing.

**Loud failure (`@object-ui/core` + `@object-ui/app-shell`).** New
`resolveRecordIdParamSeed` is the one definition of "can this row identify the record?".
`useConsoleActionRuntime`'s api handler now refuses the dispatch —
`{ success: false, error }`, **before** the request — when the row lacks the key or
holds `null` for it. The two refusals are worded differently because they point at
different repairs: an absent key is a projection or read-visibility problem, a null
value is a data one. Falsy real values (`0`, `''`, `false`) are values and still
dispatch.

The card allowed either half; both are here deliberately, because the projection half
alone closes only the common route. A row can still lack the key for reasons projection
cannot fix — a server-side read mask that strips the field regardless of `$select`, a
partial payload handed down from a host, a field the principal cannot read.

## Every `recordIdField` declaration, enumerated

Grepped across both repos' metadata surfaces (`.ts/.tsx/.json/.yml/.yaml/.js/.mjs`,
excluding `node_modules` and `dist`).

**objectstack — shipped metadata: exactly one**

| Declaration | Value | In a listView column? |
|---|---|---|
| `platform-objects/src/identity/sys-session.object.ts:67` — `sys_session.revoke_session` | `token` | No (`mine` shows `ip_address`, `active_organization_id`, `created_at`, `expires_at`) |

**objectui — shipped metadata: none.** Every hit is machinery or fixture: the spec key
itself (`ui/Action:recordIdField`, `action.zod.ts:1212`, default `id`), `ActionRunner`
/ `actionKeys` / `serverActionHandler` plumbing, the forward-parity gate, and test
fixtures (`recordIdField: 'code'` in `useConsoleActionRuntime.test.tsx` and
`serverActionHandler.test.ts`). Non-shipped fixture in objectstack:
`runtime/src/http-dispatcher.actions-type-dispatch.test.ts:168` (`session_token`).

So the class has **one live instance today**, and the key is authorable by any customer
app — which is what makes the value of this change prospective as much as corrective,
and why a per-action patch would have been the wrong shape.

## Which instances this covers, and what awaits objectstack-ai/objectstack#7823

- **Projection half** covers every `recordIdField` naming a field the object declares
  and the backend returns.
- **`sys_session.revoke_session` is NOT covered by the projection half.** Measured, not
  assumed: on objectstack `origin/main` (`8ac2323`), `sys_session.token` already carries
  `internal: true` (`sys-session.object.ts:219-227`), and an `internal` field is stripped
  from result rows regardless of projection. `$select` will now ask for `token`; the row
  will still arrive without it.
- What that instance gets from this PR is the **loud failure**: "Revoke Session" stops
  reporting success while revoking nothing, and refuses with a message naming the action
  and the field. That is a strictly better failure, not a fix of the instance.
- The instance's real repair needs a mechanism this PR deliberately does not build — an
  action that names the record by `id` and lets the server resolve the token. That is
  objectstack-side, and objectstack-ai/objectstack#7823 (the open ruling on whether
  `internal: true` needs a mint-path exemption) constrains it. Nothing here assumes that
  ruling either way, and no `sys_session`-specific mechanism was added. #7823 remains
  open; #8018 remains open.

## Reproduction and verification

Reproduction is **component-level**, stated honestly — no browser click-path was run
(the original measurement did not run one either). The grid test drives a real
`ObjectGrid` against a stub dataSource and reads the `$select` it emits; before the fix
it was `['id', 'name']` with the declared `recordIdField: 'token'` absent, and the
runtime test shows the request dispatching with the parameter missing.

**Reverse verification**, both halves, run from the committed state, direction predicted
before running:

| Leg | Predicted | Observed |
|---|---|---|
| Revert `predicate-fields.ts` only | 3 grid projection cases + 2 core harvest cases red; app-shell refusal cases green | Exactly that — 5 failed, 68 passed |
| Revert `useConsoleActionRuntime.tsx` only | 3 app-shell refusal cases red; inject/no-declaration cases green; core + grid green | Exactly that — 3 failed, 61 passed |

Both legs restored to a byte-clean tree (`git status --porcelain` empty).

## The gate this change moved, and why it is a re-point rather than a deletion

`check:action-forward-parity` went red — legitimately, and caused by this change.
It derives its owed set from property accesses on the `action` binding, and moving the
`recordIdField` read behind `resolveRecordIdParamSeed(action, rowRecord)` took the key
out of the extractor's sight, which made three `JUSTIFIED` entries look stale.

The gate's message offers "delete the stale entries". That would have been wrong here:
the entries are still true (those renderers never write `_rowRecord`, so the key is
unreachable on them, not dropped), and deleting them would record "no surface owes
`recordIdField`" while the runtime still reads it off every forwarded def. The helper is
simply where the read lives now, so it is registered as a runtime consumer — the gate's
own "re-point this gate at it" instruction for a consumer that moved. The stale
line-number citations in the entry's reason text were corrected at the same time.

Evidence it restored the model exactly rather than papering over it: the runtime-read
union is **40 keys on `main` and 40 keys after**, and every surface's owed count is
unchanged (`24/24/24/24/12`).

## Verification, all at `00738ed57` (final commit)

| Check | Result |
|---|---|
| `pnpm exec vitest run` over `packages/core/`, `packages/plugin-grid/`, `packages/plugin-list/`, `packages/app-shell/src/hooks/`, `scripts/__tests__/check-action-forward-parity.test.ts` | **222 files / 3255 tests passed** |
| `turbo run type-check` — core, app-shell, plugin-grid, plugin-list (closure built via `^build`) | **33 tasks successful**; all four `type-check` tasks confirmed executed |
| `turbo run lint` (same four) + `lint:root` | 0 errors (warnings pre-existing repo-wide) |
| `check:action-forward-parity` | green |
| `check:control-bytes`, `check:phantom-deps`, `check:spec-symbols`, `type-check:scripts`, `lint:coverage`, `type-check:coverage`, `check:i18n-keys`, `check:skills-paths` | green |
| `check-changeset-presence`, `check-changeset-no-major` | green |

Changeset: `.changeset/nervous-pugs-worry.md` (minor — core, app-shell, plugin-grid,
plugin-list; never `major`, per the fixed-group rule).

## Deliberate scope boundaries

- `packages/app-shell/src/views/RecordDetailView.tsx:617-621` carries the **same**
  silent-drop shape and was left untouched: it is held by an in-flight sibling
  (objectstack-ai/objectstack#8499). It can adopt `resolveRecordIdParamSeed` in one
  line later, which is why the guard was put in `@object-ui/core` rather than inlined.
  Filed as objectstack-ai/objectui#4669.
- No objectstack-side code was touched; that repo was read-only enumeration.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_