### PR TITLE
test(parity): adapt the spec parity gates to 17.0.0 GA (ruled items 1-5); fork the four-block exemption

### DIFF
--- a/.changeset/brave-pandas-invent.md
+++ b/.changeset/brave-pandas-invent.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: adapts the spec parity gates to `@objectstack/spec` 17.0.0 GA ahead of the pin bump — pin-aware coverage for the four `object-*` blocks GA adds, GA-pending exemptions for five keys the renderers already honour, a reasoned exemption for `FormFieldSchema.publicPicker`, and the `record:details` / `record:highlights` gates now reading GA's `unrecognized_keys` refusal instead of rc.6's silent strip. No renderer, no registry `inputs` and no published authoring surface changes; declared as releasing nothing.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -212,12 +212,43 @@ const registeredWithoutInputs = Object.keys(ComponentPropsMap)
   .sort();
 
 /**
- * Every block with a spec entry AND a declared authoring surface, in sorted
- * order. Exact rather than `toContain` for the reason `public-contract.test.ts`
- * gives: the dangerous direction is a SHRINKING contract, which a containment
- * assertion sails straight past.
+ * The four `object-*` blocks `@objectstack/spec` 17.0.0 GA adds to
+ * `ComponentPropsMap` and the pinned `17.0.0-rc.6` does not carry at all
+ * (objectui#4648, measured on a GA-installed tree).
+ *
+ * This repo has registered all four with `inputs` since long before the spec
+ * described them — `plugin-form/src/index.tsx:100` (`object-form`) and `:252`
+ * (`object-master-detail-form`), `plugin-grid/src/index.tsx:129`
+ * (`object-grid`), `plugin-dashboard/src/index.tsx:141` (`object-metric`) —
+ * so what moves at the pin bump is the SPEC's side, not this repo's: they enter
+ * `covered` the moment the installed spec carries them, and the reverse
+ * direction then asks each of them for the keys it does not publish.
  */
-const EXPECTED_COVERED = [
+const GA_ONLY_BLOCKS = [
+  'object-form',
+  'object-grid',
+  'object-master-detail-form',
+  'object-metric',
+];
+
+/**
+ * Does the installed `@objectstack/spec` carry the GA element set?
+ *
+ * The spec ships no version constant, so the observable fact is used instead —
+ * and it is the fact this file actually depends on. `every` rather than `some`
+ * on purpose: the four arrived in one release, so a half-carried state is a
+ * broken premise rather than a pin somewhere in between, and the assertion
+ * below fails on it instead of silently expecting the wrong coverage set.
+ */
+const specCarriesGaBlocks = GA_ONLY_BLOCKS.every((type) => type in ComponentPropsMap);
+
+/**
+ * Blocks the spec has carried since before the GA line, all of them declared in
+ * this repo. Exact rather than `toContain` for the reason
+ * `public-contract.test.ts` gives: the dangerous direction is a SHRINKING
+ * contract, which a containment assertion sails straight past.
+ */
+const PINNED_EXPECTED_COVERED = [
   'element:button',
   'element:number',
   'element:record_picker',
@@ -237,6 +268,21 @@ const EXPECTED_COVERED = [
   'record:path',
   'record:related_list',
 ];
+
+/**
+ * Every block with a spec entry AND a declared authoring surface, in sorted
+ * order.
+ *
+ * Pin-dependent, and that is not a loosening: the expectation stays EXACT on
+ * either pin, and which of the two it is gets asserted on its own below rather
+ * than inferred. The alternative — hard-coding the GA four — would fail on
+ * current `main`, and hard-coding only the eighteen fails the day the pin moves;
+ * both readings are correct facts about different installed contracts.
+ */
+const EXPECTED_COVERED = [
+  ...PINNED_EXPECTED_COVERED,
+  ...(specCarriesGaBlocks ? GA_ONLY_BLOCKS : []),
+].sort();
 
 /**
  * Registered, spec-carried, and deliberately propless. `nav:*` / `global:search`
@@ -480,7 +526,99 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
     "Spec's own declarative hint with zero read points repo-wide; the live binding is the reverse lookup in usePageVariableBinding(schema.id) (text-input.tsx:60). Whether to publish an intent-only key is an open judgement: objectui#3834.",
   'element:record_picker.targetVariable':
     "Spec's own declarative hint with zero read points repo-wide; the live binding is the reverse lookup by component id, as on element:text_input. Whether to publish an intent-only key is an open judgement: objectui#3834.",
+
+  // ── GA-added keys the renderers already honour — held by the PIN (5 keys) ──
+  // A different class from every entry above, and the difference is the whole
+  // reason they are here rather than declared: publishing them is the RIGHT
+  // answer and this file's own bar says so ("a spec key the renderer HONOURS
+  // and `inputs` omits is a plain defect and gets declared"). What blocks it is
+  // the installed contract, not a judgement.
+  //
+  // @objectstack/spec 17.0.0 GA declares all five; the pinned 17.0.0-rc.6
+  // declares none of them. Declaring the inputs today would therefore fail the
+  // FORWARD direction of this very file on the pinned spec — and a forward
+  // exemption to cover THAT would go stale, and red, the moment the pin moves.
+  // The two clauses collide and "must stay green on current main" wins, the
+  // same resolution PR objectui#4660 recorded for `SECRET_MASK`.
+  //
+  // So these five are dormant on this pin and fully judged on a GA tree (see
+  // `GA_PENDING_UNPUBLISHED_KEYS`), and objectui#4668 owns declaring them once
+  // objectui#4636 / PR objectui#4639 lands the GA pin. Each dies the moment its
+  // input exists — `carries no stale unpublished-key exemption` is what kills
+  // it, exactly as it killed `element:record_picker.filter` when #3830 declared
+  // that one.
+  'page:header.maxVisible':
+    'GA declares it and PageHeaderRenderer HONOURS it already — containers.tsx:1360, `readMax(schema?.maxVisible ?? schema?.properties?.maxVisible) ?? 3`, the desktop inline/overflow action budget. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it, so the input would fail this file\'s forward direction today. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
+  'page:header.mobileMaxVisible':
+    'GA declares it and PageHeaderRenderer HONOURS it already — containers.tsx:1359, the mobile half of the same overflow budget (`?? 1`). Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
+  'page:tabs.alwaysShowStrip':
+    'GA declares it and PageTabsRenderer HONOURS it already — containers.tsx:637, `itemsWithValue.length > 1 || schema?.properties?.alwaysShowStrip === true` keeps the strip visible for a single tab. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
+  'record:details.inlineEdit':
+    'GA declares it and RecordDetailsRenderer HONOURS it already — renderers/record-details.tsx:234, `(schema.inlineEdit ?? true) && objectInlineEditable` gates the inline-edit affordance. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
+  'record:details.showHeader':
+    'GA declares it and RecordDetailsRenderer HONOURS it already — renderers/record-details.tsx:257, `showHeader: schema.showHeader ?? false` reaches DetailView, which reads it at DetailView.tsx:909/:1183. Not published only because the pinned @objectstack/spec@17.0.0-rc.6 does not declare it. Declared by objectui#4668 on the GA pin (objectui#4636 / PR #4639); dormant on this pin, dies when the input lands.',
 };
+
+/**
+ * Exemption entries whose KEY the installed spec is allowed not to declare yet.
+ *
+ * Every other entry in `UNPUBLISHED_EXEMPTIONS` describes a key the installed
+ * spec declares right now — that is what `every unpublished-key exemption names
+ * a key the spec really declares` asserts, and it is why a typo cannot hide in
+ * the list. These five describe keys only @objectstack/spec 17.0.0 GA has, so
+ * on the pinned 17.0.0-rc.6 they describe nothing yet.
+ *
+ * Pinning them as a SET rather than skipping "any entry the spec does not
+ * declare" is the whole safety of the mechanism: only these five may be
+ * dormant, and `every GA-pending exemption arms exactly with the installed
+ * spec` asserts that their dormancy tracks the installed element set in BOTH
+ * directions — so a GA release that dropped one of them fails here instead of
+ * leaving an entry that quietly covers nothing.
+ */
+const GA_PENDING_UNPUBLISHED_KEYS = [
+  'page:header.maxVisible',
+  'page:header.mobileMaxVisible',
+  'page:tabs.alwaysShowStrip',
+  'record:details.inlineEdit',
+  'record:details.showHeader',
+];
+
+/** Split a `BLOCK.KEY` exemption id into its two halves. */
+const splitExemptionKey = (exemptionKey: string): [string, string] => {
+  const dot = exemptionKey.indexOf('.');
+  return [exemptionKey.slice(0, dot), exemptionKey.slice(dot + 1)];
+};
+
+/**
+ * Is this a GA-pending entry the installed spec does not carry? Such an entry
+ * is judged by neither the dangling nor the stale check — both of those ask
+ * questions about a key that does not exist on this pin.
+ */
+const isDormantOnThisPin = (exemptionKey: string): boolean => {
+  if (!GA_PENDING_UNPUBLISHED_KEYS.includes(exemptionKey)) return false;
+  const [type, specKey] = splitExemptionKey(exemptionKey);
+  return !specTopLevelKeys(type).includes(specKey);
+};
+
+/*
+ * THE FOUR GA BLOCKS HAVE NO ENTRIES HERE, DELIBERATELY — objectui#4648.
+ *
+ * On a GA tree `object-form` / `object-grid` / `object-master-detail-form` /
+ * `object-metric` enter `covered` (see `GA_ONLY_BLOCKS`) and the reverse
+ * direction goes RED on 78 spec keys their `inputs` do not publish. That red is
+ * unresolved on purpose: the card's ruling chose reasoned exemptions on the
+ * premise that nothing in this repo reads those keys, and the implementation
+ * measurement contradicted the premise — all 78 are honoured today, either off
+ * `schema.*` in the renderer or through `SchemaRenderer`'s rest-prop spread
+ * onto components whose props declare them one for one (`ObjectGridSchema` in
+ * `@object-ui/types`, `ObjectMetricWidget`'s props, the form renderers').
+ *
+ * Under this file's stated bar that makes them A-class defects to DECLARE, not
+ * keys to exempt — so writing the exemptions would have required rewriting the
+ * bar as well as acting on a falsified premise. Both are the maintainer's call
+ * and neither is silent: the measurement went back to objectui#4648 as a fork
+ * report. Add nothing here until that card rules again.
+ */
 
 const exemptedFor = (type: string): string[] =>
   Object.keys(OFF_SPEC_EXEMPTIONS)
@@ -605,13 +743,60 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
     // The dangling check, in the reverse direction. Two ways to be wrong here,
     // and both read as deliberate cover while licensing nothing: a typo'd key,
     // and an entry for a block this gate does not judge.
-    const dangling = Object.keys(UNPUBLISHED_EXEMPTIONS).filter((key) => {
-      const dot = key.indexOf('.');
-      const type = key.slice(0, dot);
-      const specKey = key.slice(dot + 1);
-      return !covered.includes(type) || !specTopLevelKeys(type).includes(specKey);
-    });
+    //
+    // GA-pending entries are excluded only while the installed spec really does
+    // not carry their key — the set of entries allowed to be dormant is pinned,
+    // and the assertion below judges the dormancy itself.
+    const dangling = Object.keys(UNPUBLISHED_EXEMPTIONS)
+      .filter((key) => !isDormantOnThisPin(key))
+      .filter((key) => {
+        const [type, specKey] = splitExemptionKey(key);
+        return !covered.includes(type) || !specTopLevelKeys(type).includes(specKey);
+      });
     expect(dangling).toEqual([]);
+  });
+
+  it('every GA-pending exemption arms exactly with the installed spec, all five together', () => {
+    // The non-vacuity and self-arming half of `GA_PENDING_UNPUBLISHED_KEYS`.
+    // Without it the pinned set could name keys no entry covers (licensing
+    // nothing while reading as cover) or stay dormant forever on a GA tree that
+    // dropped one of the keys — the two ways a "pending" mechanism rots.
+    expect(GA_PENDING_UNPUBLISHED_KEYS.length).toBeGreaterThan(0);
+    for (const key of GA_PENDING_UNPUBLISHED_KEYS) {
+      expect(
+        Object.keys(UNPUBLISHED_EXEMPTIONS),
+        `${key} is pinned as GA-pending but has no exemption entry`,
+      ).toContain(key);
+      // Dormant exactly when the installed spec predates the GA element set,
+      // live exactly when it carries it. An equality, not an implication, so
+      // both regressions fail: a key GA dropped, and a key rc.6 somehow has.
+      expect(
+        isDormantOnThisPin(key),
+        `${key} dormancy disagrees with the installed spec's element set`,
+      ).toBe(!specCarriesGaBlocks);
+    }
+  });
+
+  it('the four GA blocks enter coverage exactly when the installed spec carries them', () => {
+    // The pin-dependence of `EXPECTED_COVERED`, asserted rather than assumed.
+    // The registration half is pin-INDEPENDENT and checked first: all four are
+    // registered with inputs by this repo on either pin, so a block dropping
+    // out of `covered` can only ever mean the spec stopped carrying it — never
+    // that a plugin quietly stopped registering an authoring surface.
+    for (const type of GA_ONLY_BLOCKS) {
+      expect(
+        (declaredInputs(type) ?? []).length,
+        `${type} is no longer registered with inputs in this repo`,
+      ).toBeGreaterThan(0);
+      expect(
+        covered.includes(type),
+        `${type} coverage disagrees with the installed spec`,
+      ).toBe(type in ComponentPropsMap);
+    }
+    // Half-carried is a broken premise, not an in-between pin: they shipped in
+    // one release, so `specCarriesGaBlocks` may not be a partial truth.
+    const carried = GA_ONLY_BLOCKS.filter((type) => type in ComponentPropsMap);
+    expect([0, GA_ONLY_BLOCKS.length]).toContain(carried.length);
   });
 
   it('every unpublished-key exemption states a reason and references a tracking issue', () => {
@@ -632,12 +817,12 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
     // the spec genuinely deletes the key — note that ADR-0087 D2 retirement is
     // NOT a deletion, so the `element:record_picker` trio does not go stale on
     // the pin bump; objectui#3809 is what resolves those.
-    const stale = Object.keys(UNPUBLISHED_EXEMPTIONS).filter((key) => {
-      const dot = key.indexOf('.');
-      const type = key.slice(0, dot);
-      const specKey = key.slice(dot + 1);
-      return !undiscoverableSpecKeys(type).includes(specKey);
-    });
+    const stale = Object.keys(UNPUBLISHED_EXEMPTIONS)
+      .filter((key) => !isDormantOnThisPin(key))
+      .filter((key) => {
+        const [type, specKey] = splitExemptionKey(key);
+        return !undiscoverableSpecKeys(type).includes(specKey);
+      });
     expect(stale).toEqual([]);
   });
 

--- a/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
@@ -124,6 +124,23 @@ const specSectionKeys = (): string[] =>
  */
 const RENDERER_ONLY_SECTION_KEYS = ['title', 'showBorder', 'hideEmpty'];
 
+/**
+ * Does the installed spec REFUSE an undeclared key inside a `sections[]` entry,
+ * or drop it in silence? (objectui#4648, measured on a GA-installed tree.)
+ *
+ * `@objectstack/spec` 17.0.0 GA closed the section object under
+ * objectstack#4001 batch A; the pinned `17.0.0-rc.6` strips. The verdict this
+ * file asserts is the same on both — those keys are not an authoring surface,
+ * so the `sections` description may not teach them — but the evidence differs.
+ *
+ * Probed behaviourally, on the section object specifically: strictness is per
+ * schema, so the top-level probe in the sibling `record:highlights` file says
+ * nothing about this one.
+ */
+const specRefusesUnknownSectionKeys = !RecordDetailsProps.safeParse({
+  sections: [{ label: 'Contact', fields: ['phone'], __objectui_4648_probe__: true }],
+}).success;
+
 const config = () => ComponentRegistry.getConfig('record:details');
 const inputs = () => config()?.inputs ?? [];
 const input = (name: string) => inputs().find((i) => i.name === name);
@@ -193,12 +210,12 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     expect(description).toMatch(/string/i);
   });
 
-  it('publishes no section member key the spec strips on parse', () => {
+  it('publishes no section member key the spec refuses to carry', () => {
     // The renderer honours `title` / `showBorder` / `hideEmpty` per section,
-    // but the spec's section object does not declare them, so they are dropped
-    // with no error. Documenting them here would tell authors to write keys the
-    // contract discards — the member-level twin of publishing a top-level input
-    // the props schema rejects.
+    // but the spec's section object does not declare them, so an author who
+    // writes them gets nothing back from the contract. Documenting them here
+    // would teach keys the contract does not carry — the member-level twin of
+    // publishing a top-level input the props schema rejects.
     const stripped = RENDERER_ONLY_SECTION_KEYS.filter(
       (key) => !specSectionKeys().includes(key),
     );
@@ -207,8 +224,26 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     const parsed = RecordDetailsProps.safeParse({
       sections: [{ label: 'Contact', fields: ['phone'], title: 'T', showBorder: true, hideEmpty: false }],
     });
-    expect(parsed.success).toBe(true);
-    expect(Object.keys(parsed.data?.sections?.[0] ?? {}).sort()).toEqual(['fields', 'label']);
+
+    if (specRefusesUnknownSectionKeys) {
+      // 17.0.0 GA closed the section object too (objectstack#4001 batch A), so
+      // the three arrive as a named refusal instead of vanishing. Envelope, not
+      // a bare failure: the code, and the keys it names — `label` / `fields`
+      // must NOT be among them, which a plain `success === false` cannot tell.
+      expect(parsed.success).toBe(false);
+      expect(parsed.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+      const refused = parsed.error?.issues.flatMap(
+        (i) => (i as unknown as { keys?: string[] }).keys ?? [],
+      );
+      expect(refused).toEqual(expect.arrayContaining(stripped));
+      expect(refused).not.toContain('label');
+      expect(refused).not.toContain('fields');
+    } else {
+      // The pinned rc.6: dropped in silence, which is the harm this file was
+      // filed over — success receipt, section renders without them.
+      expect(parsed.success).toBe(true);
+      expect(Object.keys(parsed.data?.sections?.[0] ?? {}).sort()).toEqual(['fields', 'label']);
+    }
 
     // Word-boundary, not substring: this direction asks "does the text teach
     // this KEY", and prose legitimately contains words that merely embed one

--- a/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
@@ -66,6 +66,27 @@ const config = () => ComponentRegistry.getConfig('record:highlights');
 const inputs = () => config()?.inputs ?? [];
 const fieldsInput = () => inputs().find((i) => i.name === 'fields');
 
+/**
+ * Does the installed spec REFUSE an undeclared top-level key, or drop it in
+ * silence? (objectui#4648, measured on a GA-installed tree.)
+ *
+ * `@objectstack/spec` 17.0.0 GA closed `RecordHighlightsProps` under
+ * objectstack#4001 batch A, so an undeclared key now raises `unrecognized_keys`
+ * with a named message; the pinned `17.0.0-rc.6` still strips it silently. The
+ * VERDICT under test is identical either way — a top-level `readonly` is not an
+ * authoring surface and must not be published — but the evidence differs, and
+ * asserting the wrong one turns this file red for a reason that has nothing to
+ * do with what it guards.
+ *
+ * Probed behaviourally rather than off a version string: the strictness IS the
+ * fact this file cares about, a probe cannot go stale against a pin it never
+ * reads, and the probe key is a name no spec would ever declare.
+ */
+const specRefusesUnknownTopLevelKeys = !RecordHighlightsProps.safeParse({
+  fields: ['amount'],
+  __objectui_4648_probe__: true,
+}).success;
+
 describe('record:highlights — registry inputs vs @objectstack/spec', () => {
   it('is registered with a non-empty `inputs` surface', () => {
     expect(config()).toBeDefined();
@@ -81,11 +102,31 @@ describe('record:highlights — registry inputs vs @objectstack/spec', () => {
     expect(specTopLevelKeys()).not.toContain('readonly');
   });
 
-  it('a top-level `readonly` is silently stripped by the spec, so it must not be published', () => {
-    // The concrete harm: no throw, no diagnostic, key gone.
-    const parsed = RecordHighlightsProps.parse({ fields: ['amount'], readonly: true });
-    expect(parsed).not.toHaveProperty('readonly');
-    // …while the per-entry spelling survives, which is the one authors need.
+  it('the spec does not carry a top-level `readonly`, so it must not be published', () => {
+    // A KEY-reachability verdict: the question is whether a top-level
+    // `readonly` is an authoring surface at all, and the answer is no on both
+    // pins — the contract just says it two different ways (see
+    // `specRefusesUnknownTopLevelKeys`).
+    const parsed = RecordHighlightsProps.safeParse({ fields: ['amount'], readonly: true });
+
+    if (specRefusesUnknownTopLevelKeys) {
+      // 17.0.0 GA: a loud refusal. Asserted as an envelope — the code AND the
+      // key it names — because a bare "it failed" would also be satisfied by a
+      // rejection of `fields`, which is the half that must stay valid.
+      expect(parsed.success).toBe(false);
+      expect(parsed.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+      expect(
+        parsed.error?.issues.flatMap((i) => (i as unknown as { keys?: string[] }).keys ?? []),
+      ).toContain('readonly');
+    } else {
+      // The pinned rc.6, and the concrete harm objectui#3407 was filed over:
+      // no throw, no diagnostic, key gone, author told nothing.
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).not.toHaveProperty('readonly');
+    }
+
+    // …while the per-entry spelling survives on both pins, which is the one
+    // authors need and the one the `fields` description teaches.
     const perEntry = RecordHighlightsProps.parse({ fields: [{ name: 'amount', readonly: true }] });
     expect(perEntry.fields[0]).toMatchObject({ name: 'amount', readonly: true });
   });

--- a/packages/plugin-form/src/sectionFields.spec-parity.test.ts
+++ b/packages/plugin-form/src/sectionFields.spec-parity.test.ts
@@ -36,6 +36,10 @@ import { describe, it, expect } from 'vitest';
 // eslint.config.js (#3090).
 // eslint-disable-next-line no-restricted-imports
 import { FormFieldSchema as SpecFormFieldSchema } from '@objectstack/spec/ui';
+// Not restricted, and not a layer violation: `ComponentPropsMap` is read ONLY
+// as the marker of which spec line is installed (see the GA-pending block
+// below), never for a form field's shape.
+import { ComponentPropsMap } from '@objectstack/spec/ui';
 import { mapFieldTypeToFormType } from '@object-ui/fields';
 import { normalizeSectionField } from './sectionFields';
 
@@ -115,24 +119,72 @@ const TABLE: Record<string, (f: (def: Record<string, unknown>) => any) => void> 
 };
 
 /** Spec keys the normalizer deliberately does not carry, each with a reason.
- * Empty today — add entries here (never silently) when the spec grows a key
- * that genuinely has no runtime destination. */
-const EXEMPT: Record<string, string> = {};
+ * Add entries here (never silently) when the spec grows a key that genuinely
+ * has no runtime destination — and state WHY there is none, since "no row yet"
+ * and "no destination" are the two things this list must keep apart. */
+const EXEMPT: Record<string, string> = {
+  publicPicker:
+    "A server-side authorization opt-in, not a presentation delta: it gates objectstack's public-lookup route (`GET /forms/:slug/lookup/:field` answers only for a field whose form declaration carries it, `403 LOOKUP_NOT_PUBLIC` otherwise, objectstack#7467), and the public-form resolve route strips undeclared lookup fields from the rendered sections. `normalizeSectionField` builds the runtime widget config for an in-app authenticated form and has NO destination for it — zero read points repo-wide (`grep -rn publicPicker packages/ apps/` is empty) — so mapping it anywhere would invent a client-side meaning for a capability only the server enforces. Reasoned exemption ruled on objectui#4648 (delegated ruling item 5, 2026-08-15); it becomes an implementation card if objectui ever renders anonymous public forms.",
+};
+
+/**
+ * EXEMPT keys the installed spec is allowed not to declare yet.
+ *
+ * `publicPicker` arrives in `@objectstack/spec` 17.0.0 GA; this repo is pinned
+ * to `^17.0.0-rc.6`, which has no such key, so on the current pin the entry
+ * describes nothing and both checks below would read it as stale. Pinned as a
+ * SET, not a blanket "skip anything the spec lacks", so exactly one entry may
+ * be dormant and a typo in any other still fails.
+ */
+const GA_PENDING_EXEMPT = ['publicPicker'];
 
 describe('normalizeSectionField covers the spec FormFieldSchema key set', () => {
   // `.strict().transform()` wraps the object in a ZodPipe; `.in` is the
   // strict object carrying the authoring shape.
   const specKeys = Object.keys((SpecFormFieldSchema as any).in.shape).sort();
 
+  /** A GA-pending exemption the installed spec does not declare yet. */
+  const isDormant = (key: string) => GA_PENDING_EXEMPT.includes(key) && !specKeys.includes(key);
+
   it('has a behavioral row (or an exemption with a reason) for every spec key', () => {
-    const covered = [...Object.keys(TABLE), ...Object.keys(EXEMPT)].sort();
+    const covered = [
+      ...Object.keys(TABLE),
+      ...Object.keys(EXEMPT).filter((key) => !isDormant(key)),
+    ].sort();
     expect(covered).toEqual(specKeys);
   });
 
   it('has no stale rows for keys the spec has retired', () => {
     for (const key of [...Object.keys(TABLE), ...Object.keys(EXEMPT)]) {
+      if (isDormant(key)) continue; // pre-GA pin: the key is not there to be stale
       expect(specKeys, `'${key}' is no longer a spec FormField key`).toContain(key);
     }
+  });
+
+  it('every GA-pending exemption is a real entry, and arms with the installed spec', () => {
+    // Non-vacuity for the pending set: an entry named here but absent from
+    // EXEMPT licenses nothing while reading as a decision, and a key that stays
+    // dormant on a GA tree is an exemption covering nothing at all.
+    expect(GA_PENDING_EXEMPT.length).toBeGreaterThan(0);
+    const specCarriesGaElements = 'object-form' in ComponentPropsMap;
+    for (const key of GA_PENDING_EXEMPT) {
+      expect(Object.keys(EXEMPT), `'${key}' is pinned as GA-pending but has no entry`).toContain(key);
+      // The spec ships no version constant, so GA is read off the element set
+      // it carries — `object-form` is the forms-side member of the four blocks
+      // 17.0.0 added (objectui#4648).
+      expect(isDormant(key), `'${key}' dormancy disagrees with the installed spec`).toBe(
+        !specCarriesGaElements,
+      );
+    }
+  });
+
+  it('every exemption states a reason and cites a tracking issue', () => {
+    // Same discipline as the repo-wide gate in apps/console: an exemption
+    // without an owner is a permanent allowlist entry with extra steps.
+    const unjustified = Object.entries(EXEMPT)
+      .filter(([, reason]) => !/#\d+/.test(reason))
+      .map(([key]) => key);
+    expect(unjustified).toEqual([]);
   });
 
   for (const [key, assertRow] of Object.entries(TABLE)) {


### PR DESCRIPTION
Part of #4648 — the ruled items whose measurement held. The card's headline item (reasoned exemptions for the four new GA `object-*` blocks) is **not** implemented here: the implementation measurement contradicted the ruling's premise, so it goes back as a fork report rather than being re-decided in a diff. The card stays open for that.

Pre-re-point adaptation for the GA pin bump (#4636 / PR #4639), alongside PR #4660 (symbol collisions) and #4649 (retirement unwind).

## Per-item disposition

| # | item | measurement | disposition |
|---|---|---|---|
| — | four new GA blocks (`object-form`, `object-grid`, `object-master-detail-form`, `object-metric`) | all 78 unpublished spec keys are **honoured today** by this repo's renderers — the premise said none were | **FORKED back to #4648.** No exemptions written |
| 1 | `element:record_picker.filter` | **applied**: `record-picker.tsx` composes `composed?.filter ?? props.filter` and the fetch effect sets `query.$filter = filter` before `adapter.find` | already published (#3830); ruling satisfied, no change |
| 2 | `element:text_input.defaultValue` | **applied**: `text-input.tsx:73-76` seeds the bound page variable once on mount, `:119` passes it as the uncontrolled initial value | already published (#3808); ruling satisfied, no change |
| 3 | `record:highlights` top-level `readonly` | premise corrected: the key set did **not** move (rc.6 and GA both carry `fields`/`layout`/`aria` top-level and `readonly` per entry), and this repo never published it. What moved is the **refusal mode** | gate adapted, nothing to stop publishing |
| 4 | `record:details` stripped section member key | same shape: section member keys are identical on both pins (`name`/`label`/`columns`/`fields`); the renderer-only `title`/`showBorder`/`hideEmpty` are the undeclared three, and they are now refused instead of stripped | gate adapted, nothing to stop publishing |
| 5 | new `FormFieldSchema` key | the key is `publicPicker`; **zero read points repo-wide** — it gates objectstack's public-lookup REST route (`403 LOOKUP_NOT_PUBLIC` without it, objectstack#7467), a server capability with no destination in `normalizeSectionField` | **reasoned exemption** in `sectionFields.spec-parity` |
| 6 | `$like` / `$ilike` | out of scope per the ruling (folded into #4023 / #3567) | untouched |
| + | five GA keys on existing covered blocks | not among the ruled six, surfaced by the same measurement — `page:header.maxVisible` / `.mobileMaxVisible`, `page:tabs.alwaysShowStrip`, `record:details.inlineEdit` / `.showHeader` are all **honoured today** | GA-pending exemptions, declarations owned by #4668 |

## The forked item, in one paragraph

The ruling chose reasoned exemptions on the measured premise that nothing in this repo reads the four blocks' authoring surfaces. Measured in implementation, the opposite holds: all four blocks are long-standing objectui renderers, and every one of the 78 keys their `inputs` omit is honoured today — either read off `schema.*` in the renderer, or delivered by `SchemaRenderer`'s rest-prop spread onto a component whose props declare it one for one. `ObjectGridSchema` in `@object-ui/types` declares `label` / `fields` / `sort` / `pagination` / `pageSize` / `showSearch` / `selectable` / `staticData` and the rest of GA's list (several as its own `@deprecated` legacy spellings, which GA has now declared); `ObjectMetricWidget` declares `format` / `currency` / `prefix` / `suffix` / `trend` / `compareTo` / `colorVariant` / `invert` / `fallbackValue`; the form renderers declare `submitText` / `cancelText` / `showSubmit` / `readOnly` / `initialValues` and their siblings.

That inverts the defect class. These are not keys the renderer ignores (the silent-success class the ruling wanted to close) — they are keys that **work** while `sdui-parser` reports `unknown-prop` on the author who writes them, the designer panel hides them and `sdui-intrinsics.d.ts` denies them. Under this gate's own stated bar ("a spec key the renderer HONOURS and `inputs` omits is a plain defect and gets declared") they are A-class defects to declare. Writing the exemptions anyway would have meant acting on a falsified premise **and** rewriting the bar that governs the list. Both are the maintainer's call, so the measurement goes back to #4648 and nothing was added to `UNPUBLISHED_EXEMPTIONS` for those four blocks — a comment block in the file says so, so the next reader does not "fix" the red by quietly adding them.

**Consequence, stated plainly:** on a GA tree this PR takes the parity suites from 8 failures to 4, and the 4 remaining are exactly that forked item. It does not make the GA tree fully green, and it cannot until #4648 rules again.

## What the code does

**`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`**

- `EXPECTED_COVERED` becomes pin-aware: the four GA blocks are expected in `covered` exactly when the installed spec carries them. The expectation stays EXACT on either pin — the shrinking-contract reading is not weakened — and the pin-dependence itself is asserted, together with the pin-INDEPENDENT half (this repo registers all four with `inputs` either way, so a block leaving `covered` can only ever mean the spec stopped carrying it).
- five GA-pending entries in `UNPUBLISHED_EXEMPTIONS`, one per honoured-but-unpublished key, each naming its read site and #4668. They are dormant on the rc.6 pin and fully judged on a GA tree; the set allowed to be dormant is pinned by name, and its dormancy is asserted to track the installed element set **in both directions**, so a GA release that dropped one of these keys fails here instead of leaving an entry that covers nothing.

Why exemptions and not declarations: the pinned `17.0.0-rc.6` does not declare any of the five, so publishing the inputs today fails this same file's FORWARD direction, and a forward exemption to cover that would itself go stale — and red — the moment the pin moves. "Must stay green on current main" wins, the same collision PR #4660 recorded for `SECRET_MASK`. #4668 declares them once the pin lands, and each entry then dies by the file's own stale check.

**`packages/plugin-form/src/sectionFields.spec-parity.test.ts`** — `publicPicker` exemption with the same GA-pending mechanism, plus an "every exemption cites an issue" assertion the console gate already had and this file did not.

**`packages/plugin-detail/src/__tests__/record{Details,Highlights}Inputs.spec-parity.test.ts`** — GA closed `RecordHighlightsProps` and the `record:details` section object under objectstack#4001 batch A, so an undeclared key raises `unrecognized_keys` with a named message where rc.6 dropped it silently. Both gates now assert the same verdict through whichever evidence the installed contract gives, with the mode probed **behaviourally** (a probe key no spec would declare) rather than read off a version string. The rejection branches assert the envelope — code plus the keys named — not a bare failure, so a refusal of `fields` or `label` cannot satisfy them.

A wrong probe cannot go vacuously green: taking the wrong branch fails on either pin, which is how these two were caught in the first place.

## Evidence — both pins, at `6f96911dc` (working tree clean)

GA readings use the npm-pack overlay from PR #4660's body: `npm pack @objectstack/spec@17.0.0` unpacked inside this worktree's virtual store with the peer links mirrored, every `@objectstack/spec` symlink repointed at it, the real suites run unmodified, rc.6 restored afterwards. Version confirmed per package before each run (`17.0.0-rc.6` vs `17.0.0`).

**Current pin, `17.0.0-rc.6` — green:**

```
 Test Files  4 passed (4)
      Tests  103 passed (103)
```

**GA tree, `@objectstack/spec@17.0.0` — 4 failures, all of them the forked item:**

```
 × object-form publishes every top-level key its spec props schema declares
 × object-grid publishes every top-level key its spec props schema declares
 × object-master-detail-form publishes every top-level key its spec props schema declares
 × object-metric publishes every top-level key its spec props schema declares
 Test Files  1 failed | 3 passed (4)
      Tests  4 failed | 107 passed (111)
```

Before this branch the same GA tree failed **8**: the four above plus the coverage-set pin, `page:header`, `page:tabs` and `record:details` — and, on the per-block gates next door, the two strictness assertions.

| gate | rc.6 | GA |
|---|---|---|
| the four touched parity files | PASS (103) | 4 failed / 107 passed — the forked item only |
| `plugin-detail` package suite | PASS (68 files / 582 tests) | the two parity files PASS (18) |
| `apps/console` + `plugin-form` + `plugin-detail` scope sweep | PASS (118 files / 1165 tests) | — |
| other parity suites (`types`, `components`, `plugin-list`, `plugin-grid`, `plugin-dashboard`) | — | PASS (21 parity tests) — no further strictness fallout there |
| `check-changeset-presence` | PASS | — |
| `check-changeset-fixed` / `check-changeset-no-major` | PASS | — |
| `type-check` (`plugin-detail`, `plugin-form`, `console`) | PASS — "Scope: 3 of 47 workspace projects", closure built first | — |
| `eslint --quiet` over the 4 changed files | PASS (0 errors) | — |
| `check:control-bytes` | PASS (4191 files) | — |

The suite, type-check, lint and control-byte readings above were first taken at `7eeda7e93` and re-confirmed on both pins at `6f96911dc`; the only delta between those two commits is the changeset file (`git diff --stat 7eeda7e93 6f96911dc` = 1 file, 4 insertions).

Reverse verification, direction predicted before running, both pins:

- delete one GA-pending entry while leaving it in the pinned set, and rename the `publicPicker` entry ⇒ **GA: 9 failures** (the block assertion, both pending-set guards, `has a behavioral row`, `has no stale rows`); **rc.6: 4 failures** (the pending-set guards and the two plugin-form checks only — the block assertion stays green because rc.6 has no such key, which is the dormancy the mechanism claims). Restored from the commit, `git status` clean, re-run green.
- the strictness adaptation's ablation is the pre-fix state itself, recorded above: red on GA, green on rc.6.

## Scope and the changeset

Four test files, no source, no registry `inputs` and no published authoring surface change. Two of the four nevertheless live under released packages' `src/` (`plugin-form`, `plugin-detail`), which the Changeset Declaration gate counts, so this carries the repo's explicit exemption for that case: an **empty-frontmatter** `.changeset/brave-pandas-invent.md`, the same answer PRs #4641 and #4666 gave the same gate. Its output at this head:

```
Compared the working tree with 6d4f5bd59 (merge-base with origin/main): 4 file(s) changed,
4 of them under the src/ of a package the release covers, 0 under a package changesets
ignores, 1 changeset(s) added.
✅  4 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s):
    .changeset/brave-pandas-invent.md.
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

(An earlier revision of this body claimed a `skip-changeset` label instead. That label does not exist in this repo — the empty-frontmatter changeset is the mechanism, and the label has been removed from this PR.)

No file outside this card's declared surface; the in-flight siblings' files (`app-shell/views/RecordDetailView.tsx`, plugin-grid + `useConsoleActionRuntime`, the catalog calendar entries) are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_