### PR TITLE
fix(app-shell,core): action param visible — one dialect answer, faults fail-open and loud

### DIFF
--- a/.changeset/dirty-pumpkins-shout.md
+++ b/.changeset/dirty-pumpkins-shout.md
@@ -1,0 +1,61 @@
+---
+'@object-ui/core': minor
+'@object-ui/app-shell': minor
+---
+
+Action param `visible`: one dialect answer, and a fault that is fail-open and LOUD
+
+`ActionParamDialog`'s `filterVisibleParams` was the last predicate face never
+converted to the canonical entry. It evaluated each param's `visible` on a bare
+`ExpressionEvaluator` inside `try { … } catch { return true }`, and that produced
+two defects at once (objectui#4640, measured on `main`):
+
+- **Silence.** Three of the four fault shapes emitted nothing at all — an
+  unparseable source, an unbound identifier and a faulting legacy predicate all
+  resolved without a word, so a broken `visible` was indistinguishable from an
+  absent one. The standing 2026-08-06 ruling on objectui#4051 /
+  objectstack#5149 names silence as the one option that is not available.
+- **The fail DIRECTION was decided by the predicate's dialect, not by the
+  surface.** A bare string ran the legacy JS evaluator (lenient → falsy → param
+  silently DROPPED); a `{ dialect, source }` envelope ran CEL (fault → param
+  silently KEPT). One `visible` key, two opposite outcomes, chosen by whether
+  the authored text happened to contain `${…}` / `===` — the objectui#3314
+  shape. Both halves hurt: a dropped param means the dialog never collects a
+  value the server requires and the action fails at submit with nothing pointing
+  at the predicate; a kept one offers a field the backend rejects.
+
+`filterVisibleParams` now routes through `evalRowPredicate`. A param whose
+`visible` cannot be evaluated is **shown**, and reported once, with the action
+and the param named and the predicate quoted. Fail-open is the ruled direction
+for this surface: an extra offered field is rejected by the server with a
+message, while a silently hidden required param is undiagnosable. (Row surfaces
+keep failing closed — there the harm runs the other way.) Boolean and blank
+predicates are answered before the evaluator, so `visible: false` hides the
+param and an empty predicate is not reported as broken.
+
+**Behaviour change worth knowing before you upgrade.** On the canonical CEL
+engine an ABSENT key is a runtime fault, not a falsy read. A param gated on
+`features.phoneNumber == true` in a deployment whose scope carries no
+`phoneNumber` key at all now takes the fail-open branch: the param is SHOWN,
+with a warning naming it, where it used to be hidden. The conservative outcome
+is still available, in the spelling that is portable to the server's own engine:
+
+```
+has(features.phoneNumber) && features.phoneNumber == true
+```
+
+Deployments that DECLARE the flag (`features: { phoneNumber: false }`) are
+unaffected — that is a genuine verdict on both engines, and it did not move.
+
+`@object-ui/core` gains the two evaluator changes this needed:
+
+- `evalRowPredicate` accepts **`rowless`** — "this surface has no row of its
+  own", so nothing is bound over the host scope and a `record` / `data` the
+  scope carries survives instead of being shadowed by an empty row. Row surfaces
+  are untouched: without the option the row is still the subject (objectui#3796).
+- A faulting **`{ dialect, source }` envelope now reports its own source**.
+  It used to print the literal `"(expression)"`, and because the warn-once key
+  is (label, predicate), the first faulting envelope under a label silenced
+  every other one. The envelope is what `@objectstack/spec` normalizes every
+  authored predicate into, so this was the likeliest shape in served metadata
+  and the least diagnosable one.

--- a/packages/app-shell/src/views/ActionParamDialog.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.test.tsx
@@ -13,6 +13,13 @@
  * `visible: 'features.phoneNumber == true'`, so it's hidden unless the opt-in
  * phoneNumber auth plugin is loaded.
  *
+ * Since objectui#4640 the gate evaluates on the canonical `evalRowPredicate`
+ * entry: one dialect answer, faults fail-OPEN and are reported once with the
+ * action and param named. The four blocks below the render tests carry that
+ * contract — including the one outcome the change knowingly traded (an ABSENT
+ * feature key faults on CEL, so it now shows the param instead of hiding it,
+ * and `has()` is the portable spelling that keeps the old outcome).
+ *
  * ActionParamDialog render tests — the dialog routes every param through the
  * shared form field-widget renderer (ADR-0059), so these pin the behavior
  * contract across the swap: each type renders its real widget (lazy, behind
@@ -33,6 +40,22 @@ const p = (name: string, visible?: string): ActionParamDef => ({
   ...(visible ? { visible } : {}),
 });
 
+/**
+ * Capture the `console.warn` lines one call emits. Every case below uses its
+ * OWN predicate text: the fault report is warn-once per (label, predicate) in
+ * `evalRowPredicate`, so cases sharing a predicate string would silence each
+ * other and the suite would pass or fail by file order.
+ */
+function withWarnings<T>(run: () => T): { result: T; warnings: string[] } {
+  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const result = run();
+    return { result, warnings: spy.mock.calls.map((c) => String(c[0])) };
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 describe('filterVisibleParams', () => {
   it('keeps params that have no visible predicate', () => {
     const params = [p('email'), p('name')];
@@ -51,16 +74,6 @@ describe('filterVisibleParams', () => {
     expect(out.map((x) => x.name)).toEqual(['email', 'phoneNumber', 'name']);
   });
 
-  it('hides a feature-gated param when the flag is absent (conservative)', () => {
-    const params = [p('phoneNumber', 'features.phoneNumber == true')];
-    expect(filterVisibleParams(params, { features: {} })).toEqual([]);
-  });
-
-  it('defaults to visible when the predicate is malformed (fail-open)', () => {
-    const params = [p('x', 'this is ((( not valid')];
-    expect(filterVisibleParams(params, {}).map((x) => x.name)).toEqual(['x']);
-  });
-
   it('handles the normalized {dialect, source} form the spec serializes to', () => {
     // The framework's ExpressionInputSchema normalizes the authored string to
     // `{ dialect: 'cel', source: '...' }`, so the served param carries the object
@@ -70,6 +83,249 @@ describe('filterVisibleParams', () => {
     ];
     expect(filterVisibleParams(params, { features: { phoneNumber: false } })).toEqual([]);
     expect(filterVisibleParams(params, { features: { phoneNumber: true } }).map((x) => x.name)).toEqual(['phoneNumber']);
+  });
+});
+
+/**
+ * objectui#4640 — a `visible` that cannot be evaluated resolves FAIL-OPEN and
+ * says so, once, naming the action and the param and quoting the predicate.
+ *
+ * Both halves are ruled, not chosen in this file:
+ *  - LOUD is the standing 2026-08-06 ruling (objectui#4051 / objectstack#5149):
+ *    fail-open or fail-closed may be chosen, *silent may not*. Three of the four
+ *    fault shapes measured on this function were silent.
+ *  - OPEN is the direction ruled for this surface (2026-08-15): a silently
+ *    dropped param is undiagnosable — the action fails at submit with nothing
+ *    pointing at the predicate — while an extra offered field is rejected by the
+ *    server with a message.
+ *
+ * These cases assert SUBSTANCE, not just the verdict: a fail-open that lost its
+ * warning would pass a verdict-only assertion while being exactly the bug.
+ */
+describe('filterVisibleParams — faults are fail-open and LOUD (objectui#4640)', () => {
+  it('shows a param whose predicate cannot be PARSED, and names it in one warning', () => {
+    // Previously: shown, in total silence (the bare `catch { return true }`).
+    const params = [p('nickname', 'this is ((( not parseable')];
+    const { result, warnings } = withWarnings(() =>
+      filterVisibleParams(params, {}, 'Create user'),
+    );
+    expect(result.map((x) => x.name)).toEqual(['nickname']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('param "nickname" of action "Create user"');
+    expect(warnings[0]).toContain('this is ((( not parseable');
+  });
+
+  it('shows a param whose predicate names an UNBOUND identifier, loudly', () => {
+    // Previously: shown, silently — indistinguishable from having no gate.
+    const params = [p('quota', 'nope_undeclared_4640 == 1')];
+    const { result, warnings } = withWarnings(() =>
+      filterVisibleParams(params, { os: { user: { id: 'u1' } } }, 'Create user'),
+    );
+    expect(result.map((x) => x.name)).toEqual(['quota']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('param "quota"');
+    expect(warnings[0]).toContain('nope_undeclared_4640');
+  });
+
+  it('quotes the predicate of a faulting ENVELOPE too, and warns per predicate', () => {
+    // The envelope is the shape `@objectstack/spec` normalizes every authored
+    // predicate into, so it is the likeliest real spelling — and it was the
+    // least diagnosable: `evalRowPredicate` reported it as the literal
+    // "(expression)" and keyed its warn-once on that, so the FIRST faulting
+    // envelope under a label silenced every other one.
+    const a: ActionParamDef = { name: 'alpha', label: 'Alpha', type: 'text', visible: { dialect: 'cel', source: 'alpha_4640 ] (' } as any };
+    const b: ActionParamDef = { name: 'beta', label: 'Beta', type: 'text', visible: { dialect: 'cel', source: 'beta_4640 ] (' } as any };
+    const { result, warnings } = withWarnings(() => filterVisibleParams([a, b], {}, 'Create user'));
+    expect(result.map((x) => x.name)).toEqual(['alpha', 'beta']);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('alpha_4640 ] (');
+    expect(warnings[1]).toContain('beta_4640 ] (');
+    expect(warnings.some((w) => w.includes('(expression)'))).toBe(false);
+  });
+
+  it('warns ONCE for the same param + predicate, however often it is filtered', () => {
+    const params = [p('repeat', 'once_only_4640 == 1')];
+    const { warnings } = withWarnings(() => {
+      filterVisibleParams(params, {}, 'Create user');
+      filterVisibleParams(params, {}, 'Create user');
+      filterVisibleParams(params, {}, 'Create user');
+    });
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('a blank or absent predicate is NOT a fault — kept, and silent', () => {
+    // `''`, whitespace, and the empty `{ dialect, source: '' }` envelope a
+    // spec-normalized empty predicate compiles to all mean "no gate declared"
+    // (objectui#3850 / #3960) — they must never reach the evaluator to be
+    // reported as broken.
+    const params: ActionParamDef[] = [
+      p('a', ''),
+      p('b', '   '),
+      { name: 'c', label: 'C', type: 'text', visible: { dialect: 'cel', source: '' } as any },
+      { name: 'd', label: 'D', type: 'text', visible: { dialect: 'cel', source: '  ' } as any },
+    ];
+    const { result, warnings } = withWarnings(() => filterVisibleParams(params, {}, 'Create user'));
+    expect(result.map((x) => x.name)).toEqual(['a', 'b', 'c', 'd']);
+    expect(warnings).toEqual([]);
+  });
+
+  it('a BOOLEAN visible is a verdict, not an expression (objectui#3492)', () => {
+    // Short-circuited before the evaluator: handing a boolean to the engine
+    // yields `{ dialect: 'cel', source: undefined }`, which faults — and on
+    // this surface's fail-open that would turn `visible: false`, the most
+    // explicit "never offer this" an author can write, into a shown param.
+    const params: ActionParamDef[] = [
+      { name: 'never', label: 'Never', type: 'text', visible: false as any },
+      { name: 'always', label: 'Always', type: 'text', visible: true as any },
+    ];
+    const { result, warnings } = withWarnings(() => filterVisibleParams(params, {}, 'Create user'));
+    expect(result.map((x) => x.name)).toEqual(['always']);
+    expect(warnings).toEqual([]);
+  });
+});
+
+/**
+ * objectui#4640 — the fail direction no longer depends on the predicate's
+ * DIALECT. Before this change a bare string ran the legacy JS evaluator (lenient
+ * → falsy → param silently DROPPED) while a `{ dialect, source }` envelope ran
+ * CEL (fault → param silently KEPT): one `visible` key, two opposite outcomes,
+ * decided by whether the authored text happened to contain `${…}` / `===`
+ * (the objectui#3314 shape). Both spellings now reach one entry, one direction
+ * and one warning.
+ */
+describe('filterVisibleParams — one value, one answer (objectui#3314)', () => {
+  it('a broken bare string and a broken envelope resolve the SAME way, both loudly', () => {
+    const bare = p('bare', 'dialect_fork_4640 ] (');
+    const env: ActionParamDef = {
+      name: 'envelope',
+      label: 'Envelope',
+      type: 'text',
+      visible: { dialect: 'cel', source: 'dialect_fork_env_4640 ] (' } as any,
+    };
+    const { result, warnings } = withWarnings(() => filterVisibleParams([bare, env], {}, 'Create user'));
+    // Same verdict for both spellings — fail-open.
+    expect(result.map((x) => x.name)).toEqual(['bare', 'envelope']);
+    // …and neither is silent.
+    expect(warnings).toHaveLength(2);
+  });
+
+  it('a legacy-dialect string that faults fails OPEN as well, and is reported', () => {
+    // `${…}` routes to the legacy engine for back-compat, but its faults now
+    // land on the same fallback as the CEL path instead of the opposite one.
+    const params = [p('legacy', '${legacy_fault_4640(((}')];
+    const { result, warnings } = withWarnings(() => filterVisibleParams(params, {}, 'Create user'));
+    expect(result.map((x) => x.name)).toEqual(['legacy']);
+    // The deprecation notice plus the fault report — the predicate is named by
+    // both, and by neither was it named before.
+    expect(warnings.some((w) => w.includes('legacy expression dialect'))).toBe(true);
+    expect(warnings.some((w) => w.includes('failed to evaluate'))).toBe(true);
+  });
+});
+
+/**
+ * objectui#4640 — this surface has NO ROW, so the host predicate scope keeps its
+ * own `record` / `data`.
+ *
+ * `evalRowPredicate`'s subject is a row and it pins `record` / `data` over the
+ * scope (objectui#3796). Routing this function through it without saying "no row
+ * here" would write an EMPTY record over the host's real one, and every
+ * `record.*` / `data.*` param predicate would fault ("No such key") and — under
+ * fail-open — silently start showing params it was written to hide. The
+ * `rowless` option is what keeps that from happening; these cases are its proof
+ * at this surface.
+ */
+describe('filterVisibleParams — the host scope keeps its own data/record', () => {
+  it('resolves a data.* predicate against the host scope, with no fault', () => {
+    const params = [p('advanced', 'data.mode == "advanced"')];
+    const { result, warnings } = withWarnings(() =>
+      filterVisibleParams(params, { data: { mode: 'advanced' } }, 'Create user'),
+    );
+    expect(result.map((x) => x.name)).toEqual(['advanced']);
+    expect(warnings).toEqual([]);
+    // …and reaches the opposite verdict when the host data says otherwise —
+    // proving it read the value, not a fail-open default.
+    const { result: hidden, warnings: quiet } = withWarnings(() =>
+      filterVisibleParams(params, { data: { mode: 'basic' } }, 'Create user'),
+    );
+    expect(hidden).toEqual([]);
+    expect(quiet).toEqual([]);
+  });
+
+  it('resolves a record.* predicate against the host scope, with no fault', () => {
+    const params = [p('reassign', 'record.manager == os.user.id')];
+    const scope = { os: { user: { id: 'u1' } }, record: { manager: 'u1' } };
+    const { result, warnings } = withWarnings(() => filterVisibleParams(params, scope, 'Reassign'));
+    expect(result.map((x) => x.name)).toEqual(['reassign']);
+    expect(warnings).toEqual([]);
+    const { result: hidden } = withWarnings(() =>
+      filterVisibleParams(params, { os: { user: { id: 'u2' } }, record: { manager: 'u1' } }, 'Reassign'),
+    );
+    expect(hidden).toEqual([]);
+  });
+});
+
+/**
+ * objectui#4640 — the honest counter-pull, recorded rather than lost.
+ *
+ * The pin this block replaces was *"hides a feature-gated param when the flag is
+ * absent (conservative)"*: `features.phoneNumber == true` against `features: {}`
+ * returned false on the legacy evaluator, so the param stayed hidden. On the
+ * canonical CEL engine an absent key is NOT a falsy read — it is a runtime fault
+ * (`[runtime] No such key: phoneNumber`), so it takes the ruled fail-open branch
+ * and the param is now SHOWN, with a warning naming it.
+ *
+ * That was measured, not assumed, and it is the one outcome this card's ruling
+ * knowingly traded: the delegated ruling of 2026-08-15 requires the fault to be
+ * fail-open and loud, and requires this case to be documented in code rather
+ * than quietly re-spelled. The degradation is bounded and self-announcing — the
+ * server rejects the unsupported param with a message, and the console names the
+ * predicate — whereas the fail-closed alternative hides a REQUIRED param with
+ * nothing pointing at the predicate.
+ *
+ * The conservative outcome remains available, and in the spelling that is
+ * portable to the server's own CEL engine: guard the key with `has()`. That is
+ * the migration this file documents for anyone who was relying on the old
+ * behavior.
+ */
+describe('filterVisibleParams — the feature-flag case, after the flip (objectui#4640)', () => {
+  const gated = (source: string): ActionParamDef[] => [
+    { name: 'phoneNumber', label: 'Phone', type: 'text', visible: source } as ActionParamDef,
+  ];
+
+  it('an ABSENT feature key now SHOWS the param and says why (was: silently hidden)', () => {
+    const { result, warnings } = withWarnings(() =>
+      filterVisibleParams(gated('features.phoneNumber == true'), { features: {} }, 'Create user'),
+    );
+    expect(result.map((x) => x.name)).toEqual(['phoneNumber']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('param "phoneNumber" of action "Create user"');
+    expect(warnings[0]).toContain('features.phoneNumber == true');
+    // The engine's own reason is the line that sends the author to the fix.
+    expect(warnings[0]).toContain('No such key');
+  });
+
+  it('has() keeps the conservative outcome — hidden, and with no fault at all', () => {
+    const { result, warnings } = withWarnings(() =>
+      filterVisibleParams(
+        gated('has(features.phoneNumber) && features.phoneNumber == true'),
+        { features: {} },
+        'Create user',
+      ),
+    );
+    expect(result).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('a DECLARED flag is unaffected by the flip, either way', () => {
+    // The common deployment shape — the scope carries the key — reaches a
+    // genuine verdict on both engines and did not move.
+    expect(
+      filterVisibleParams(gated('features.phoneNumber == true'), { features: { phoneNumber: false } }),
+    ).toEqual([]);
+    expect(
+      filterVisibleParams(gated('features.phoneNumber == true'), { features: { phoneNumber: true } })
+        .map((x) => x.name),
+    ).toEqual(['phoneNumber']);
   });
 });
 

--- a/packages/app-shell/src/views/ActionParamDialog.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.tsx
@@ -30,7 +30,7 @@ import {
 } from '@object-ui/components';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionParamDef } from '@object-ui/core';
-import { ExpressionEvaluator } from '@object-ui/core';
+import { evalRowPredicate, hasDeclaredPredicate } from '@object-ui/core';
 import { usePredicateScope } from '@object-ui/react';
 import { getLazyFieldWidget, fileIdOf } from '@object-ui/fields';
 import { paramToField } from '../utils/paramToField';
@@ -52,24 +52,86 @@ interface ActionParamDialogProps {
 }
 
 /**
- * Filter action params by their optional `visible` CEL predicate, evaluated
- * against the expression scope (features / user / app / data). A param with no
- * predicate is always kept; a predicate that throws defaults to visible (mirrors
- * the ExpressionProvider "auth config not loaded yet → visible" contract). Pure
- * + exported so the gating is unit-testable without the dialog render tree.
+ * Filter action params by their optional `visible` predicate, evaluated on the
+ * canonical entry (`evalRowPredicate`) against the host predicate scope
+ * (features / user / app / data). Pure + exported so the gating is unit-testable
+ * without the dialog render tree.
+ *
+ * ## Fail-open, and LOUD (objectui#4640)
+ *
+ * A param whose `visible` cannot be evaluated — unparseable source, unbound
+ * identifier, a key the scope does not carry — is SHOWN, and says so once, with
+ * the action and param named and the predicate quoted. Both halves are ruled,
+ * not chosen here:
+ *
+ *  - **Loud** is the standing 2026-08-06 ruling on objectui#4051 /
+ *    objectstack#5149: fail-open or fail-closed may be chosen, *silent may not*.
+ *    This function used to be silent in three of the four fault shapes — the
+ *    bare `catch { return true }` below the old `evaluateCondition` call swallowed
+ *    parse errors and unbound identifiers without a word, so a broken predicate
+ *    was indistinguishable from an absent one.
+ *  - **Open** is the direction ruled for THIS surface: a silently dropped param
+ *    is the undiagnosable failure — the dialog never collects a value the server
+ *    requires, and the action then fails at submit with nothing pointing at the
+ *    predicate. An extra offered field fails the other way, with a server
+ *    rejection that carries a message. Two harms; the self-diagnosing one wins.
+ *    (Row surfaces rule the opposite way — a faulting row-action `visible` stays
+ *    hidden — because there the harm is acting on records the predicate excluded.)
+ *
+ * ## One value, one answer (objectui#3314)
+ *
+ * The old implementation's fail DIRECTION was decided by the predicate's
+ * DIALECT, not by this surface: a bare string ran the legacy JS evaluator
+ * (lenient → falsy → param silently DROPPED) while a `{ dialect, source }`
+ * envelope ran CEL (fault → param silently KEPT). One `visible` key, two
+ * opposite outcomes, chosen by whether the authored text happened to contain
+ * `${…}` / `===`. That fork is deleted, not braced: every spelling now reaches
+ * one entry, one fail direction and one warning. (`evalRowPredicate` still
+ * routes a legacy-dialect STRING to the old engine for back-compat — with its
+ * own deprecation warning naming the predicate — but the fault direction is the
+ * same on both of its paths, so the surface no longer has two answers.)
+ *
+ * ## No row here — the scope keeps its own `data` / `record`
+ *
+ * `evalRowPredicate`'s subject is a row, and it pins `record` / `data` to it
+ * over the host scope (objectui#3796). This surface has no row: its scope IS the
+ * host predicate scope, `data` and all. So it passes `rowless: true`, which
+ * binds nothing over the scope — an author's `data.*` / `record.*` param
+ * predicate keeps reading the host's values instead of faulting on an empty
+ * object written over them.
+ *
+ * @param actionLabel The action's own label, so the fault warning names the
+ *                    action as well as the param. Optional — the param name
+ *                    alone is still a locator.
  */
 export function filterVisibleParams(
   params: ActionParamDef[],
   scope: Record<string, any>,
+  actionLabel?: string,
 ): ActionParamDef[] {
-  const evaluator = new ExpressionEvaluator(scope);
   return params.filter((p) => {
-    if (!p.visible) return true;
-    try {
-      return evaluator.evaluateCondition(p.visible);
-    } catch {
-      return true;
-    }
+    const raw: unknown = p.visible;
+    // "Is a gate declared?" is asked once, by the canonical definition —
+    // absent, `''`, whitespace-only, an empty `{ dialect, source: '' }` envelope
+    // (what a spec-normalized empty predicate compiles to) and junk all mean
+    // "no gate", and must not reach the evaluator to be reported as a fault.
+    if (!hasDeclaredPredicate(raw)) return true;
+    // A BOOLEAN `visible` is a verdict, not an expression — short-circuited the
+    // same way `useRowPredicate` / the row kebab / `bulkEligibility` do
+    // (objectui#3492). Handing it to the engine yields
+    // `{ dialect: 'cel', source: undefined }`, which faults; on this surface's
+    // fail-open that would turn `visible: false` — the most explicit "never
+    // offer this" an author can write — into a shown param plus a bogus warning.
+    if (typeof raw === 'boolean') return raw;
+    return evalRowPredicate(raw as never, null, {
+      fallback: true,
+      scope,
+      rowless: true,
+      warnOnError: true,
+      label: actionLabel
+        ? `param "${p.name}" of action "${actionLabel}"`
+        : `param "${p.name}"`,
+    });
   });
 }
 
@@ -150,10 +212,15 @@ export function ActionParamDialog({ state, onOpenChange }: ActionParamDialogProp
   // A param may carry a `visible` predicate (CEL) gating it on the same scope as
   // action visibility (features / user / app / data) — e.g. `create_user`'s
   // phoneNumber param is `features.phoneNumber == true`, so the form never offers
-  // a field the backend rejects. Absent = visible; a predicate that errors
-  // defaults to visible (mirrors the ExpressionProvider "config not loaded" note).
+  // a field the backend rejects. Absent = visible; a predicate that cannot be
+  // evaluated is shown AND reported once, naming this action and the param
+  // (objectui#4640) — `state.title` is the action's own label, so the console
+  // line points at the dialog the user is looking at.
   const scope = usePredicateScope();
-  const visibleParams = useMemo(() => filterVisibleParams(state.params, scope), [state.params, scope]);
+  const visibleParams = useMemo(
+    () => filterVisibleParams(state.params, scope, state.title),
+    [state.params, scope, state.title],
+  );
 
   // Reset values when params change
   useEffect(() => {

--- a/packages/core/src/evaluator/__tests__/listConditional.test.ts
+++ b/packages/core/src/evaluator/__tests__/listConditional.test.ts
@@ -455,3 +455,114 @@ describe('evalRowPredicate — relation fields', () => {
     });
   });
 });
+
+/**
+ * objectui#4640 — `rowless`: a surface with NO ROW keeps the host scope's own
+ * `record` / `data`.
+ *
+ * The default above is the right rule for a row surface and exactly the wrong
+ * one for a surface that has no row: pinning then writes an EMPTY `record` /
+ * `data` over the host's real ones, and every `record.*` predicate faults with
+ * "No such key". "This surface has no row of its own" and "this surface's row
+ * is empty" are different facts, and only the second is entitled to shadow the
+ * scope — the same distinction `usePredicateRecordContext` makes on the binding
+ * side (objectui#4075). The first caller is `ActionParamDialog`'s param
+ * `visible` gate, whose scope IS the host predicate scope, `data` and all.
+ */
+describe('evalRowPredicate — rowless (objectui#4640)', () => {
+  const HOST = { record: { tag: 'HOST' }, data: { tag: 'HOST' }, features: { on: true } };
+
+  it("leaves the host scope's own `record` / `data` standing", () => {
+    expect(evalRowPredicate("record.tag == 'HOST'", null, { scope: HOST, rowless: true })).toBe(true);
+    expect(evalRowPredicate("data.tag == 'HOST'", null, { scope: HOST, rowless: true })).toBe(true);
+    // …on the legacy path too — one answer per value, not one per dialect.
+    expect(evalRowPredicate("record.tag === 'HOST'", null, { scope: HOST, rowless: true })).toBe(true);
+    expect(evalRowPredicate("data.tag === 'HOST'", null, { scope: HOST, rowless: true })).toBe(true);
+  });
+
+  it('is what stops those predicates from faulting into the fallback', () => {
+    // The reverse of the case above, and the reason the option exists: without
+    // it the empty row shadows the host's `record`, the predicate faults, and
+    // the caller silently gets its fallback instead of a verdict.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(
+        evalRowPredicate("record.tag == 'HOST'", null, {
+          scope: HOST,
+          fallback: true,
+          warnOnError: true,
+          label: 'shadowed',
+        }),
+      ).toBe(true); // ← the FALLBACK, not a verdict …
+      expect(String(warn.mock.calls[0][0])).toContain('No such key');
+      warn.mockClear();
+      // … and with `rowless` the same call reaches the real verdict, quietly.
+      expect(
+        evalRowPredicate("record.tag == 'NOPE'", null, {
+          scope: HOST,
+          fallback: true,
+          rowless: true,
+          warnOnError: true,
+          label: 'shadowed',
+        }),
+      ).toBe(false);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps the rest of the host scope bound, and the blank/absent rules intact', () => {
+    expect(evalRowPredicate('features.on == true', null, { scope: HOST, rowless: true })).toBe(true);
+    expect(evalRowPredicate(null, null, { scope: HOST, rowless: true, fallback: true })).toBe(true);
+    expect(evalRowPredicate('   ', null, { scope: HOST, rowless: true, fallback: true })).toBe(true);
+  });
+
+  it('does not disturb the row-surface default (no `rowless`, row still wins)', () => {
+    expect(evalRowPredicate("record.tag == 'ROW'", { tag: 'ROW' }, { scope: HOST })).toBe(true);
+    expect(evalRowPredicate("record.tag == 'HOST'", { tag: 'ROW' }, { scope: HOST })).toBe(false);
+  });
+});
+
+/**
+ * objectui#4640 — a faulting ENVELOPE reports its own source.
+ *
+ * `source` is `undefined` for an envelope by design (it drives dialect routing,
+ * and an envelope is never routed to the legacy engine), and the fault report
+ * used to reuse it — so every faulting envelope printed the literal
+ * "(expression)" instead of the predicate, and, since the warn-once key is
+ * (label, source), the FIRST faulting envelope under a label silenced every
+ * other one. The envelope is what `@objectstack/spec`'s `ExpressionInputSchema`
+ * normalizes every authored predicate into, so this was the likeliest shape in
+ * served metadata and the least diagnosable one.
+ */
+describe("evalRowPredicate — the fault report quotes an envelope's source (objectui#4640)", () => {
+  it('names each broken envelope, instead of collapsing them into "(expression)"', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const opts = { warnOnError: true, label: 'one label', fallback: false } as const;
+      expect(evalRowPredicate({ dialect: 'cel', source: 'env_a_4640 ] (' }, {}, opts)).toBe(false);
+      expect(evalRowPredicate({ dialect: 'cel', source: 'env_b_4640 ] (' }, {}, opts)).toBe(false);
+
+      const lines = warn.mock.calls.map((c) => String(c[0]));
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain('env_a_4640 ] (');
+      expect(lines[1]).toContain('env_b_4640 ] (');
+      expect(lines.some((l) => l.includes('(expression)'))).toBe(false);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('still warns once per (label, predicate)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const pred = { dialect: 'cel', source: 'env_once_4640 ] (' } as const;
+      evalRowPredicate(pred, {}, { warnOnError: true, label: 'L' });
+      evalRowPredicate(pred, {}, { warnOnError: true, label: 'L' });
+      expect(warn.mock.calls).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/evaluator/listConditional.ts
+++ b/packages/core/src/evaluator/listConditional.ts
@@ -69,7 +69,14 @@ function warnLegacyDialect(source: string): void {
 
 const warnedError = new Set<string>();
 /**
- * One-time fail-closed report for a predicate that could not be evaluated.
+ * One-time report for a predicate that could not be evaluated.
+ *
+ * The message names the caller's `fallback` as "its safe default" without
+ * asserting a direction, because the direction is the caller's: row surfaces
+ * fail CLOSED (a faulting `visible` hides the action), while a param-collection
+ * dialog fails OPEN (objectui#4640 — a silently hidden required param is the
+ * undiagnosable failure). Both are loud; only silence was ever ruled out
+ * (2026-08-06 on objectui#4051 / objectstack#5149).
  *
  * `reason` is the engine's own description of the failure (`"[runtime] No such
  * key: owner_id"`) — the single most useful line for the author, and precisely
@@ -162,6 +169,30 @@ export interface RowPredicateOptions {
   /** Label used in warning messages (e.g. an action name or rule index). */
   label?: string;
   /**
+   * This surface has **no row of its own** — bind NOTHING for the row instead
+   * of binding an empty one, so a `record` / `data` the HOST SCOPE carries
+   * survives to the predicate (objectui#4640).
+   *
+   * The default (`false`) is this function's whole subject rule: the row is
+   * pinned over the scope, on both dialect paths, so `record` / `data` always
+   * name THIS row even when the host scope carries keys of those names
+   * (objectui#3796). That is right for every row surface — and exactly wrong
+   * for a surface that has no row, because the pin then writes an EMPTY
+   * `record` / `data` over the host's real ones and every `record.*` predicate
+   * faults with "No such key". "This surface has no row of its own" and "this
+   * surface's row is empty" are different facts; only the latter is entitled to
+   * shadow the scope. Same distinction, same words, as `usePredicateRecordContext`
+   * in `@object-ui/react` (objectui#4075) — which is the BINDING half of this
+   * rule for the `useCondition` tier; this is the evaluation-entry half.
+   *
+   * Set it where the predicate is scoped to a *dialog / shell / page* rather
+   * than to a record — `ActionParamDialog`'s param `visible` gates are the
+   * first caller (objectui#4640): their scope IS the host predicate scope,
+   * `data` and all. `opts.fields` is meaningless here (there is no row to
+   * collapse relations on) and is ignored.
+   */
+  rowless?: boolean;
+  /**
    * The object's field definitions (`objectSchema.fields`). Supplying them lets
    * a relation field be bound as the FOREIGN KEY the server stores, rather than
    * as whatever `$expand` happened to substitute for it on this surface — see
@@ -180,6 +211,10 @@ export interface RowPredicateOptions {
  * alongside so `features.*` / `user.*` predicates keep working — but the row is
  * the subject: `record` and `data` always name THIS row, on both dialect paths,
  * even when the host scope carries keys of those names (objectui#3796).
+ *
+ * A caller with no row at all passes {@link RowPredicateOptions.rowless}, and
+ * then nothing is bound over the scope — see that option for why an absent row
+ * must not be spelled as an empty one.
  */
 export function evalRowPredicate(
   pred: FieldRulePredicate | undefined | null,
@@ -194,7 +229,10 @@ export function evalRowPredicate(
   // Relations collapse to the foreign key the server stores, so `record.owner`
   // means one thing whether or not this surface expanded the column
   // (objectui#3501). Returned by reference when there is nothing to collapse.
-  const rowObj = toPredicateRecord(row && typeof row === 'object' ? row : {}, opts.fields);
+  // A `rowless` caller has no row to collapse, so `opts.fields` is moot there.
+  const rowObj = opts.rowless
+    ? {}
+    : toPredicateRecord(row && typeof row === 'object' ? row : {}, opts.fields);
   // Bare fields + `data.*` + `record.*` + the host scope, all top-level.
   //
   // `data` AND `record` are pinned AFTER the spread, so a host scope that
@@ -207,7 +245,30 @@ export function evalRowPredicate(
   // string happens to contain `===`/`${…}`, which no author is choosing
   // deliberately (objectui#3796). Pinning here fixes both paths at the merge,
   // independently of either engine's precedence.
-  const scope = { ...(opts.scope ?? {}), ...rowObj, data: rowObj, record: rowObj };
+  //
+  // …UNLESS the caller has no row (`rowless`), in which case there is nothing
+  // to pin and the host scope keeps its own `record` / `data` — see the option.
+  const scope = opts.rowless
+    ? { ...(opts.scope ?? {}) }
+    : { ...(opts.scope ?? {}), ...rowObj, data: rowObj, record: rowObj };
+
+  // The predicate TEXT for diagnostics: a bare string is itself, an envelope is
+  // its `source`. Reported separately from `source` above, which is `undefined`
+  // for an envelope *by design* (it drives the dialect routing, and an envelope
+  // is never routed to the legacy engine). Reusing it for the warning is what
+  // made every faulting envelope report as the literal `"(expression)"` — no
+  // predicate text for the author, and, because the one-time key is
+  // (label, source), the FIRST faulting envelope on a given label silenced every
+  // other one under it (objectui#4640: measured on `evalRowPredicate` — a second
+  // envelope with a different, also-broken source warned zero times). The
+  // envelope is not an exotic spelling: `@objectstack/spec`'s
+  // `ExpressionInputSchema` normalizes every authored predicate into one, so it
+  // is the likeliest shape in served metadata and was the least diagnosable.
+  const predicateText =
+    source ??
+    (pred && typeof pred === 'object' && typeof (pred as { source?: unknown }).source === 'string'
+      ? (pred as { source: string }).source
+      : '(expression)');
 
   // Legacy-dialect *strings* route to the legacy engine (back-compat). The
   // `{ dialect: 'cel', source }` envelope is never routed here — it is CEL.
@@ -237,7 +298,7 @@ export function evalRowPredicate(
   }
   const verdict = evalCel(pred, rowObj, scope);
   if (!verdict.ok) {
-    warnEvalError(source ?? '(expression)', opts.label, verdict.reason);
+    warnEvalError(predicateText, opts.label, verdict.reason);
     return fallback;
   }
   return verdict.value;


### PR DESCRIPTION
Fixes #4640

Implements the delegated ruling of 2026-08-15 (Option A): `filterVisibleParams`
routes through the canonical `evalRowPredicate` with `throwOnError` + warn-once, a
faulting param `visible` resolves **fail-open** with one named warning, and the
bare-string-vs-envelope dialect fork is deleted rather than braced.

## The card's table, re-derived on current `main` (`b1119ece4`)

The premise holds; the measurement is unchanged from `5bf5d2cb6`. Probed directly
against `filterVisibleParams`, scope `{ os: { user: { id: 'u1' } }, record: { manager: 'u1' } }`:

| `visible` | before: kept? | before: warnings | after: kept? | after: warnings |
|---|---|---|---|---|
| `record.@@@ bad` (unparseable) | kept | **0 — silent** | kept | 1, named |
| `nope_undeclared == 1` (unbound) | kept | **0 — silent** | kept | 1, named |
| `${record.missing.id == 1}` (legacy) | **dropped** | **0 — silent** | dropped (genuine legacy verdict) | 1 (deprecation, quotes it) |
| `{ dialect: 'cel', source: 'not ] valid (' }` | kept | 1 | kept | 1, named |
| `os.user.id == "u1"` / `== "u2"` | kept / dropped | 0 | kept / dropped | 0 |

Both halves the card named are gone: the silence, and the fail direction being
decided by the predicate's **dialect** instead of by the surface (bare string →
legacy JS → lenient falsy → param silently DROPPED; envelope → CEL → fault →
param silently KEPT — the #3314 shape). Every spelling now reaches one entry, one
direction, one warning.

## How the `record` / `data` shadowing is handled — named, as the ruling requires

`evalRowPredicate`'s subject is a row: it pins `record` and `data` over the host
scope on both dialect paths (#3796). This surface has **no row** — its scope *is*
the host predicate scope, `data` and all — so routing through it unchanged would
write an **empty** `record`/`data` over the host's real ones, and every
`record.*` / `data.*` param predicate would fault with "No such key" and, under
fail-open, silently start showing params it was written to hide.

The mechanism is a new option on the canonical entry (the evaluator region named
in the claim): **`rowless`** — "this surface has no row of its own", so nothing is
bound over the scope. It is the evaluation-entry half of a rule this repo already
states on the binding side: `usePredicateRecordContext` (#4075) draws exactly this
line — "no row → bind NOTHING, do not bind an empty one", because "this surface
has no row" and "this surface's row is empty" are different facts and only the
second is entitled to shadow the scope. Row surfaces are untouched: without the
option the row still wins, and the #3796 suite still pins that.

## The counter-pull, recorded rather than lost

Measured, not assumed: on the canonical CEL engine an **absent key is a runtime
fault**, not a falsy read — `features.phoneNumber == true` over `features: {}`
fails with `[runtime] No such key: phoneNumber`. So it takes the ruled fail-open
branch and the param is now **shown, loudly**, where the old evaluator hid it
silently. This is the outcome the ruling knowingly traded, and it is documented in
code (`filterVisibleParams — the feature-flag case, after the flip`) rather than
quietly re-spelled.

⚠️ **One point for the PM to see, since two comments on the card differ.** The
earlier ruling comment (2026-08-15 01:59) asserts that "an absent-key comparison
is a *verdict*, not a fault" and adds a stop-clause if (a) and (b) cannot both
hold. On this engine that premise is false — the fault above is measured. The
later DELEGATED RULING (06:00), which the dispatch names as the spec, anticipates
exactly this and requires the case to be documented as new behavior. I implemented
the later ruling and did not stop, because it resolves the very case the earlier
one reserved. Flagging it rather than deciding it.

The conservative outcome remains available, in the spelling that is portable to
the server's own engine: `has(features.phoneNumber) && features.phoneNumber == true`
evaluates **false** with no fault and no warning. Notably this spelling does **not**
work on the old code path (the legacy evaluator cannot answer `has()`), so the
migration only exists because of this change. Deployments that DECLARE the flag
(`features: { phoneNumber: false }`) are unaffected — a genuine verdict on both
engines, unmoved.

## Also in the declared surface, with its evidence

A faulting `{ dialect, source }` **envelope reported its own source as the literal
`"(expression)"`** — and since the warn-once key is (label, predicate), the first
faulting envelope under a label silenced every other one. Measured on
`evalRowPredicate` before the fix: two different broken envelopes under one label
produced **one** warning, and it quoted neither. The envelope is what
`@objectstack/spec`'s `ExpressionInputSchema` normalizes every authored predicate
into, so it is the likeliest shape in served metadata and was the least
diagnosable — and it is the shape this card's own deliverable ("one named warning
quoting the predicate") is most often about. Same defect class, same file, same
gates; named here rather than left as an unreviewable drive-by.

Two smaller guards the routing itself required: a **boolean** `visible` is
short-circuited as a verdict (#3492 — handing it to the engine yields
`{ dialect: 'cel', source: undefined }`, which faults, so fail-open would have
turned `visible: false` into a shown param), and declaredness is asked once via
the canonical `hasDeclaredPredicate`, so `''`, whitespace and the empty envelope
are "no gate" rather than reported faults (#3850 / #3960).

## Tests

The two deliberately-pinned cases flip and assert the new **substance**, not just a
verdict:

- *"defaults to visible when the predicate is malformed (fail-open)"* → the verdict
  survives, and the case now also asserts the warning names the action and the param
  and quotes the predicate. A fail-open that lost its warning would have passed the
  old assertion while being exactly the bug.
- *"hides a feature-gated param when the flag is absent (conservative)"* → replaced by
  the three-case block above (flip + `has()` migration + declared-flag unmoved).

## Verification — all at `461d3bfa2`, the final commit

- `pnpm exec vitest run packages/app-shell/src/views packages/core/src/evaluator` →
  **254 files, 2672 passed | 1 skipped**.
- Downstream consumers of the touched core entry (`useExpression`, `page-header-*`,
  `action-record-predicate-root`, `predicate-surface-parity`, `bulkEligibility`,
  `ConditionalFormattingEditor`) → **7 files, 213 passed**.
- `type-check` for `@object-ui/core` + `@object-ui/app-shell`, **closure built first**
  (`pnpm --filter '@object-ui/app-shell^...' build`; verified `rowless?: boolean`
  present in the rebuilt `packages/core/dist/evaluator/listConditional.d.ts`).
- Gates: `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`,
  `check-changeset-fixed`, `check-phantom-dependencies`, `check-type-check-coverage`,
  `check-lint-coverage`, plus `lint` for both packages (0 errors) — all green.

**Reverse verification, predicted before each run:**

1. *Restore the old `catch { return true }`* — predicted the card's silent verdicts
   would resurrect. **8 red**: the two loudness cases, warn-once, the boolean verdict,
   both dialect-fork cases, and the feature-flag flip. Two of the eight I had predicted
   green: `has()` fails on the old path too, because the legacy evaluator cannot answer
   it — so the migration spelling is itself a product of this change. Reported as
   measured, not as predicted.
2. *Drop `rowless` only* — predicted exactly the two host-scope cases. **2 red**, both
   of them, confirming the option is load-bearing and not decorative.
3. *Revert the envelope-source fix in core* — predicted one case in each package.
   **2 red**, exactly those.
4. *Cross-package type check*: `rowless: "yes"` from app-shell →
   `TS2322: Type 'string' is not assignable to type 'boolean | undefined'`, proving
   app-shell compiles against the **rebuilt** core `.d.ts`, not a cached one.

Each leg was run from the committed state and restored with `git checkout` of the
branch ref at the affected path; the tree was confirmed byte-identical to
`461d3bfa2` (`git diff HEAD --quiet`) before the final green pass.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_