### PR TITLE
fix(core,charts,dashboard): give a chart bucket an identity distinct from its display label

### DIFF
--- a/.changeset/quiet-moons-decide.md
+++ b/.changeset/quiet-moons-decide.md
@@ -1,0 +1,54 @@
+---
+'@object-ui/core': minor
+'@object-ui/plugin-charts': minor
+'@object-ui/plugin-dashboard': minor
+---
+
+Give a chart bucket an identity distinct from its display label
+
+objectui#4508. `buildChartSeries` used the bucket's DISPLAY string as the
+bucket's own key, so two pairs of genuinely different groups were conflated —
+and the segment click that drills a bar back to its records inherited both
+conflations. The maintainer ruling (2026-08-14) approved the sentinel-identity
+direction, aligning the chart branch with the distinct-bucket-id form the pivot
+TABLE (`buildPivot`) already uses over the same dataset rows.
+
+Two collisions, one cause:
+
+- **A null group and an empty-string group drew ONE bar.** The pivot branch
+  keyed buckets by `String(xRaw ?? '')`, which spells `null` and `''`
+  identically. The bar took its label from whichever row created the bucket, and
+  the other group's segment then resolved to no row at all — a visible bar whose
+  click did nothing.
+- **A record whose stored value spells the bucket label stole the null bucket's
+  drill.** A row storing the literal text `(None)` (or any localized
+  `chart.nullCategory` — `(未指定)` and the other nine packs) kept its own
+  bucket, so two bars carried the same axis text and BOTH resolved to the first.
+  That one is a wrong drill, not a dead one: clicking the null bucket's bar
+  opened the drawer on another group's records.
+
+What changed:
+
+- **`chartBucketId`** (`@object-ui/core`) is the bucket identity — the SAME
+  encoder `buildPivot` keys its buckets with (`pivotBucketId` over
+  `pivotDimensionValue`), so the two surfaces stop answering one question two
+  ways. The pivot branch now buckets by it, which is what makes null and `''`
+  two groups again.
+- **`CHART_BUCKET_ID_KEY`** carries that identity on an emitted row, written
+  exactly where two DISTINCT buckets paint the same axis text — the complete set
+  of cases where the display string cannot name what was clicked. An ordinary
+  chart's rows are returned untouched (by identity), so no renderer-internal key
+  reaches an authoring surface.
+- **`findChartSeriesRow`** takes that identity back as `options.bucketId` and
+  treats it as authoritative. The renderers forward it: the drill event gains
+  `categoryId` (`ChartSegmentClickEvent`, now declared once in
+  `@object-ui/core` instead of inline in three packages), `AdvancedChartImpl`
+  reads it off the clicked row on the cartesian, pie and funnel paths, and
+  `DatasetWidget.handleChartDrill` hands it to the lookup.
+
+Behaviour change worth noting: an empty-string category no longer resolves to a
+null-valued row. That tolerance was justified as the drill layer's own spelling
+of "no group value", but no producer of this lookup's `category` writes it,
+while `''` IS the axis text a genuine empty-string group paints — so the
+tolerance was giving that group's bar a different group's records. A host that
+forwards no `categoryId` keeps its existing drill unchanged.

--- a/packages/core/src/utils/chart-series.nullCategory.test.ts
+++ b/packages/core/src/utils/chart-series.nullCategory.test.ts
@@ -37,9 +37,27 @@
  * row, so a null x was bucketed correctly and STILL reached recharts raw. The
  * key is untouched; only the display value is labelled. The drill half is
  * pinned at the bottom of this file, with the measurement behind it.
+ *
+ * objectui#4508 then answers what #4497 filed instead of widening into: that
+ * map KEY was the DISPLAY string, so it could not tell a null group from an
+ * empty-string one, nor from a record whose stored value spells the bucket
+ * label. The key is now the bucket's IDENTITY (`chartBucketId`, the encoder the
+ * pivot TABLE already uses), and where two distinct buckets still paint the
+ * same axis text the emitted row carries that identity under
+ * `CHART_BUCKET_ID_KEY` for the click to hand back. The three cases #4497
+ * pinned as limits are updated at the bottom of this file, in the commit that
+ * changed them — as that pin's own note said they would have to be.
  */
 import { describe, it, expect } from 'vitest';
-import { buildChartSeries, findChartSeriesRow, NULL_CATEGORY_LABEL } from './chart-series';
+import {
+  buildChartSeries,
+  findChartSeriesRow,
+  chartBucketId,
+  chartRowBucketId,
+  CHART_BUCKET_ID_KEY,
+  NULL_CATEGORY_LABEL,
+} from './chart-series';
+import { pivotBucketId, pivotDimensionValue } from './dataset-pivot';
 
 /** The card's case 3, verbatim — the dominant group is the null-keyed one. */
 const PARTIAL = [
@@ -274,10 +292,25 @@ describe('findChartSeriesRow — the bucket label maps back to its null row (obj
     ).toBe(0);
   });
 
-  it('still resolves the empty-string category to a null row (unchanged)', () => {
-    // The pre-existing `String(r[xDim] ?? '')` behaviour, kept: the pivot/drill
-    // layer already spells "no group value" as '' (see computeDrillFilter).
-    expect(findChartSeriesRow(ALL_NULL, ['user_id'], ['event_count'], '')).toBe(0);
+  /**
+   * THE DELIBERATE-PIN UPDATE (objectui#4508).
+   *
+   * This case used to read "still resolves the empty-string category to a null
+   * row (unchanged)" and asserted `0` — the pre-existing `String(r[xDim] ?? '')`
+   * tolerance, justified on the grounds that the drill layer spells "no group
+   * value" as `''` (`computeDrillFilter`). That justification does not survive
+   * re-measurement: `computeDrillFilter` runs DOWNSTREAM of a resolved drill and
+   * never produces this function's `category`, whose one production producer is
+   * a chart click. What `''` IS, is the axis text a genuine empty-string group
+   * paints — so the tolerance handed that group's bar the records of a null
+   * group instead of its own. A wrong click, and #4508 rules it out.
+   */
+  it('no longer reads an empty-string category as a null row — that is a different group', () => {
+    expect(findChartSeriesRow(ALL_NULL, ['user_id'], ['event_count'], '')).toBe(-1);
+    // …and the empty-string group resolves to ITSELF, which is the point.
+    const both = [{ user_id: null, event_count: 50 }, { user_id: '', event_count: 7 }];
+    expect(findChartSeriesRow(both, ['user_id'], ['event_count'], '')).toBe(1);
+    expect(findChartSeriesRow(both, ['user_id'], ['event_count'], NULL_CATEGORY_LABEL)).toBe(0);
   });
 });
 
@@ -336,8 +369,10 @@ describe('findChartSeriesRow — the pivot bucket bar keeps its drill (objectui#
     ).toBe(1);
   });
 
-  it('keeps the legacy empty-string category spelling working (unchanged)', () => {
-    expect(findChartSeriesRow(PIVOT_RAW, ['status', 'priority'], ['est_hours'], '', 'Low')).toBe(1);
+  it('no longer reads an empty-string category back to a null row (objectui#4508)', () => {
+    // The pin-update above, in the pivot arm: `''` is the empty-string group's
+    // own axis text, and PIVOT_RAW has no such group.
+    expect(findChartSeriesRow(PIVOT_RAW, ['status', 'priority'], ['est_hours'], '', 'Low')).toBe(-1);
   });
 
   it('leaves non-null pivot drills exactly as they were', () => {
@@ -347,79 +382,237 @@ describe('findChartSeriesRow — the pivot bucket bar keeps its drill (objectui#
 });
 
 /**
- * The two MEASURED AMBIGUITIES of the bucket label, pinned as the limits they
- * are (objectui#4497). Neither is created by that card and neither is fixed by
- * it — both are properties of the #4466 doctrine itself, filed rather than
- * widened into this surface. They are pinned so the next change to either
- * branch has to face them explicitly.
+ * objectui#4508 — THE PIN UPDATE THIS WHOLE BLOCK EXISTS FOR.
+ *
+ * The three cases below were pinned by objectui#4497 as "the measured limits of
+ * the bucket label", explicitly AS LIMITS AND NOT AS CORRECT: the label served
+ * as its own bucket key, so it conflated two pairs of genuinely different
+ * groups, and #4497 filed that rather than widening its own card. #4508 is the
+ * card, and the maintainer ruling on it (2026-08-14) is the sentinel-identity
+ * direction — a bucket identity carried alongside the display label, written by
+ * `buildChartSeries` and read back by `findChartSeriesRow`, aligned with the
+ * distinct-bucket-id form `buildPivot` already uses on the table branch.
+ *
+ * So each case keeps its fixture and flips its expectation, in the commit that
+ * changed the behaviour. What they now assert is the ruling's acceptance
+ * condition: **each bar drills to the rows its own bar was drawn from** — no
+ * dead click, no wrong click.
  */
-describe('findChartSeriesRow — the measured limits of the bucket label (objectui#4497)', () => {
-  it('DEAD, not wrong: an empty-string row sharing the null bucket has no drill of its own', () => {
-    // The bucket KEY merges null and '' (`String(xRaw ?? '')`), so these two
-    // raw rows draw ONE bar carrying both series. The bar is labelled from the
-    // row that created the bucket, and the `''` row's segment then matches no
-    // category: -1, which `handleChartDrill` returns on — a no-op click, never
-    // a drill into the wrong records. Pre-#4497 the whole bar was invisible, so
-    // this is strictly more affordance than before, not a regression.
+describe('the bucket carries an identity distinct from its label (objectui#4508)', () => {
+  it('null and empty-string are TWO buckets, and each drills to its own rows', () => {
+    // Was: "DEAD, not wrong — an empty-string row sharing the null bucket has
+    // no drill of its own". They shared a bucket because the key was
+    // `String(xRaw ?? '')`, which spells both as `''`; `chartBucketId` spells
+    // them `[null]` and `[""]`. Two groups, two bars, two live drills.
     const merged = [
       { status: null, priority: 'Low', n: 3 },
       { status: '', priority: 'High', n: 5 },
     ];
     expect(buildChartSeries(merged, ['status', 'priority'], ['n']).data).toEqual([
-      { status: NULL_CATEGORY_LABEL, Low: 3, High: 5 },
+      { status: NULL_CATEGORY_LABEL, Low: 3 },
+      { status: '', High: 5 },
     ]);
+    // Distinct axis text, so neither bar needs to carry its identity.
+    expect(buildChartSeries(merged, ['status', 'priority'], ['n']).data.some(
+      (row) => CHART_BUCKET_ID_KEY in row,
+    )).toBe(false);
     expect(findChartSeriesRow(merged, ['status', 'priority'], ['n'], NULL_CATEGORY_LABEL, 'Low')).toBe(0);
-    expect(findChartSeriesRow(merged, ['status', 'priority'], ['n'], NULL_CATEGORY_LABEL, 'High')).toBe(-1);
+    // Was -1 — the dead click. It is the `''` bar's own row now.
+    expect(findChartSeriesRow(merged, ['status', 'priority'], ['n'], '', 'High')).toBe(1);
   });
 
-  it('and the SAME two groups keep both drills when the empty-string row comes first', () => {
-    // The other row order of the case above, pinned because the two do NOT
-    // behave alike and only one of them loses anything. The bucket takes its
-    // label from whichever row CREATED it: with the `''` row first the label is
-    // the raw empty string, `isNullCategory` never fires, and `xOf` reads a null
-    // row back as `''` whenever the clicked category is not the bucket label —
-    // so BOTH segments resolve, and neither resolves to the wrong record.
-    //
-    // This is the ruling's STOP condition measured to its end (objectui#4497):
-    // "two raw groups mapping to one label" is real, but it costs a drill in
-    // exactly one of the two orders. Widening `findChartSeriesRow` to close that
-    // one would make a bar labelled `(None)` drill to a row whose stored value
-    // is `''` — a wrong click traded for a dead one — so the limit is filed
-    // (objectui#4508) rather than fixed here.
+  it('and answers the same way in the other row order — the asymmetry is gone', () => {
+    // Was: "the SAME two groups keep both drills when the empty-string row
+    // comes first", pinned because the two orders did NOT behave alike (the
+    // bucket took its label from whichever row created it). With the key no
+    // longer the label, row order cannot decide what a bucket IS.
     const merged = [
       { status: '', priority: 'High', n: 5 },
       { status: null, priority: 'Low', n: 3 },
     ];
     expect(buildChartSeries(merged, ['status', 'priority'], ['n']).data).toEqual([
-      { status: '', High: 5, Low: 3 },
+      { status: '', High: 5 },
+      { status: NULL_CATEGORY_LABEL, Low: 3 },
     ]);
     expect(findChartSeriesRow(merged, ['status', 'priority'], ['n'], '', 'High')).toBe(0);
-    expect(findChartSeriesRow(merged, ['status', 'priority'], ['n'], '', 'Low')).toBe(1);
-
-    // MEASURED, and deliberately not what was predicted: the reader is looser
-    // than the writer. `xOf` accepts BOTH spellings of "no value" (the bucket
-    // label and the legacy `''`) unconditionally — #4466's stated design — so
-    // it resolves the label even in this order, where NO bar was labelled with
-    // it. Harmless in the real flow, because the only category a renderer ever
-    // hands back is one recharts actually painted (here: `''`), and it is the
-    // slack that makes the two callers' label agreement a non-issue. Pinned
-    // because the asymmetry is invisible from `buildChartSeries` alone.
     expect(findChartSeriesRow(merged, ['status', 'priority'], ['n'], NULL_CATEGORY_LABEL, 'Low')).toBe(1);
+    // The reader is no longer looser than the writer: `''` names the
+    // empty-string group and the label names the null one, in either order.
+    expect(findChartSeriesRow(merged, ['status', 'priority'], ['n'], '', 'Low')).toBe(-1);
   });
 
-  it('first match wins when a STORED value spells the bucket label literally', () => {
-    // A row whose stored category IS the label string keeps its own bucket (the
-    // key is `'(None)'`, not `''`), so two bars carry the same axis text and the
-    // click resolves to the first. Inherited from the single-dimension branch,
-    // where #4466 shipped exactly this trade — the pivot does not add to it.
+  it('a stored value spelling the label keeps its own bar AND its own drill', () => {
+    // Was: "first match wins when a STORED value spells the bucket label
+    // literally" — the WRONG click of the two collisions, since clicking the
+    // null bucket's bar filtered on a record whose stored status is the literal
+    // text `'(None)'`. Both bars still paint the same axis text (they are two
+    // different groups that happen to read alike), so this is exactly the case
+    // where the display string cannot name the bucket — and exactly where the
+    // identity is written.
     const literal = [
       { status: NULL_CATEGORY_LABEL, priority: 'High', n: 1 },
       { status: null, priority: 'High', n: 2 },
     ];
-    expect(buildChartSeries(literal, ['status', 'priority'], ['n']).data).toEqual([
-      { status: NULL_CATEGORY_LABEL, High: 1 },
-      { status: NULL_CATEGORY_LABEL, High: 2 },
+    const emitted = buildChartSeries(literal, ['status', 'priority'], ['n']).data;
+    expect(emitted).toEqual([
+      { status: NULL_CATEGORY_LABEL, [CHART_BUCKET_ID_KEY]: '["(None)"]', High: 1 },
+      { status: NULL_CATEGORY_LABEL, [CHART_BUCKET_ID_KEY]: '[null]', High: 2 },
     ]);
-    expect(findChartSeriesRow(literal, ['status', 'priority'], ['n'], NULL_CATEGORY_LABEL, 'High')).toBe(0);
+    // The identity a renderer reads off the clicked row, fed back as `bucketId`.
+    const drill = (row: Record<string, unknown>) =>
+      findChartSeriesRow(literal, ['status', 'priority'], ['n'], String(row.status), 'High', {
+        bucketId: chartRowBucketId(row),
+      });
+    expect(drill(emitted[0])).toBe(0);
+    // Was 0 — the wrong record. The null bucket's bar now resolves to the null row.
+    expect(drill(emitted[1])).toBe(1);
+  });
+
+  it('resolves the same collision in the SINGLE-dimension branch', () => {
+    // #4466 shipped this trade one branch over and the pivot inherited it, so
+    // the fix has to answer in both. Here the rows are not aggregated, so the
+    // two bars are the two raw rows.
+    const literal = [
+      { user_id: null, event_count: 51 },
+      { user_id: NULL_CATEGORY_LABEL, event_count: 2 },
+    ];
+    const emitted = buildChartSeries(literal, ['user_id'], ['event_count']).data;
+    expect(emitted).toEqual([
+      { user_id: NULL_CATEGORY_LABEL, [CHART_BUCKET_ID_KEY]: '[null]', event_count: 51 },
+      { user_id: NULL_CATEGORY_LABEL, [CHART_BUCKET_ID_KEY]: '["(None)"]', event_count: 2 },
+    ]);
+    const drill = (row: Record<string, unknown>) =>
+      findChartSeriesRow(literal, ['user_id'], ['event_count'], String(row.user_id), undefined, {
+        bucketId: chartRowBucketId(row),
+      });
+    expect(drill(emitted[0])).toBe(0);
+    expect(drill(emitted[1])).toBe(1);
+    // Without the identity the label alone still cannot separate them — which
+    // is WHY it is written, and the honest statement of what the fallback is.
+    expect(findChartSeriesRow(literal, ['user_id'], ['event_count'], NULL_CATEGORY_LABEL)).toBe(0);
+  });
+
+  it('collides on a LOCALIZED bucket label the same way, and resolves it', () => {
+    // The collision is a property of the label, not of English: every one of the
+    // ten locale packs has a `chart.nullCategory` string a record could store.
+    const opts = { nullCategoryLabel: '(未指定)' };
+    const literal = [
+      { status: '(未指定)', priority: 'High', n: 1 },
+      { status: null, priority: 'High', n: 2 },
+    ];
+    const emitted = buildChartSeries(literal, ['status', 'priority'], ['n'], null, opts).data;
+    expect(emitted).toEqual([
+      { status: '(未指定)', [CHART_BUCKET_ID_KEY]: '["(未指定)"]', High: 1 },
+      { status: '(未指定)', [CHART_BUCKET_ID_KEY]: '[null]', High: 2 },
+    ]);
+    expect(
+      findChartSeriesRow(literal, ['status', 'priority'], ['n'], '(未指定)', 'High', {
+        ...opts,
+        bucketId: chartRowBucketId(emitted[1]),
+      }),
+    ).toBe(1);
+  });
+});
+
+/**
+ * The identity's own contract (objectui#4508) — the properties every consumer
+ * of `CHART_BUCKET_ID_KEY` relies on, stated where they can fail loudly.
+ */
+describe('chart bucket identity — the encoder and its carrier (objectui#4508)', () => {
+  it('is the SAME encoding the pivot table keys its buckets with', () => {
+    // Not a lookalike: the chart and the table answer the same question about
+    // the same dataset rows, and answering it two ways is what #4508 filed.
+    expect(chartBucketId(null)).toBe(pivotBucketId([pivotDimensionValue(null)]));
+    expect(chartBucketId('Backlog')).toBe(pivotBucketId([pivotDimensionValue('Backlog')]));
+  });
+
+  it('separates every spelling a display label cannot', () => {
+    const ids = [null, undefined, '', NULL_CATEGORY_LABEL, 'null', '[null]'].map(chartBucketId);
+    // null and undefined are the same fact (absent); the other four are values.
+    expect(ids[0]).toBe(ids[1]);
+    expect(new Set(ids).size).toBe(5);
+  });
+
+  it('is written ONLY where two distinct buckets paint the same axis text', () => {
+    // An ordinary chart's rows are returned untouched — by identity, even —
+    // so renderer-internal metadata never reaches an authoring surface.
+    const rows = [
+      { status: 'Backlog', est_hours: 5 },
+      { status: 'Done', est_hours: 24 },
+    ];
+    const r = buildChartSeries(rows, ['status'], ['est_hours']);
+    expect(r.data).toBe(rows);
+    expect(r.data.some((row) => CHART_BUCKET_ID_KEY in row)).toBe(false);
+  });
+
+  it('counts DISTINCT buckets, not rows — a repeated category is not ambiguous', () => {
+    const rows = [
+      { status: 'Backlog', est_hours: 5 },
+      { status: 'Backlog', est_hours: 7 },
+    ];
+    expect(buildChartSeries(rows, ['status'], ['est_hours']).data.some(
+      (row) => CHART_BUCKET_ID_KEY in row,
+    )).toBe(false);
+  });
+
+  it('survives the SPREAD COPY a pie sector click hands back', () => {
+    // recharts builds a sector's `payload` as `{...row, ...cellProps}`, so the
+    // identity has to be an ordinary enumerable property — a symbol or a
+    // non-enumerable one would read as "no identity" with nothing red.
+    const literal = [
+      { status: NULL_CATEGORY_LABEL, n: 1 },
+      { status: null, n: 2 },
+    ];
+    const emitted = buildChartSeries(literal, ['status'], ['n']).data;
+    expect(chartRowBucketId({ ...emitted[1] })).toBe('[null]');
+  });
+
+  it('reads no identity off a row that carries none, or a non-row', () => {
+    expect(chartRowBucketId({ status: 'Backlog' })).toBeUndefined();
+    expect(chartRowBucketId(undefined)).toBeUndefined();
+    expect(chartRowBucketId(null)).toBeUndefined();
+    expect(chartRowBucketId({ [CHART_BUCKET_ID_KEY]: 7 })).toBeUndefined();
+  });
+
+  it('never mutates the caller rows, identity or not', () => {
+    const rows = [
+      { status: NULL_CATEGORY_LABEL, n: 1 },
+      { status: null, n: 2 },
+    ];
+    buildChartSeries(rows, ['status'], ['n']);
+    expect(rows[1].status).toBeNull();
+    expect(rows.every((row) => !(CHART_BUCKET_ID_KEY in row))).toBe(true);
+  });
+
+  it('leaves an unsupplied bucketId to the display match — an unplumbed caller is unchanged', () => {
+    // A host that forwards no identity (static SDUI chart data, a renderer not
+    // wired to `categoryId`) keeps exactly the #4466 behaviour it had.
+    expect(findChartSeriesRow(PARTIAL, ['user_id'], ['event_count'], NULL_CATEGORY_LABEL, undefined, {
+      bucketId: undefined,
+    })).toBe(0);
+    expect(findChartSeriesRow(PARTIAL, ['user_id'], ['event_count'], NULL_CATEGORY_LABEL, undefined, {
+      bucketId: '',
+    })).toBe(0);
+  });
+
+  it('ignores the category text entirely once an identity is supplied', () => {
+    // The identity is authoritative, which is the whole reason it exists: the
+    // label a renderer paints can be shared, stale or localized differently.
+    expect(
+      findChartSeriesRow(PARTIAL, ['user_id'], ['event_count'], 'a label nothing painted', undefined, {
+        bucketId: '[null]',
+      }),
+    ).toBe(0);
+    expect(
+      findChartSeriesRow(PARTIAL, ['user_id'], ['event_count'], NULL_CATEGORY_LABEL, undefined, {
+        bucketId: '["Dev Admin"]',
+      }),
+    ).toBe(1);
+    // An identity no row carries resolves to nothing rather than to the first row.
+    expect(
+      findChartSeriesRow(PARTIAL, ['user_id'], ['event_count'], NULL_CATEGORY_LABEL, undefined, {
+        bucketId: '["nobody"]',
+      }),
+    ).toBe(-1);
   });
 });

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -26,7 +26,13 @@
  * ({@link NULL_CATEGORY_LABEL}) so the group renders instead of vanishing —
  * objectui#4466 for the single-dimension branch, objectui#4497 for the pivot.
  * One doctrine, one predicate (`isNullCategory`), two call sites.
+ *
+ * A bucket's IDENTITY is separate from that display label (objectui#4508). The
+ * label used to serve as its own key, which conflated two pairs of genuinely
+ * different groups; see {@link chartBucketId} for the identity, and
+ * {@link CHART_BUCKET_ID_KEY} for how it reaches a click handler.
  */
+import { pivotBucketId, pivotDimensionValue } from './dataset-pivot';
 
 export interface ChartResultField {
   name: string;
@@ -75,6 +81,66 @@ export interface ChartSeriesResult {
  */
 export const NULL_CATEGORY_LABEL = '(None)';
 
+/**
+ * The IDENTITY of the chart bucket a first-dimension raw value falls in —
+ * distinct from the string that bucket DISPLAYS (objectui#4508).
+ *
+ * Deliberately the SAME encoder the pivot TABLE already keys its buckets with
+ * (`pivotBucketId` over a `pivotDimensionValue`-normalized value), because the
+ * two surfaces answer the same question about the same dataset rows and were
+ * answering it differently: `buildPivot` gives a null dimension value a bucket
+ * id no string can spell, while the chart used the display label as its own
+ * key. That gap is the whole of objectui#4508 — see `dataset-pivot.ts` for why
+ * the encoding is JSON rather than a delimiter or a placeholder character.
+ *
+ * Two collisions follow from a label-as-key, and one encoder closes both:
+ *  - `null` and `''` are different groups. `String(x ?? '')` made them one
+ *    bucket, so two groups drew ONE bar and one of them lost its drill.
+ *    `[null]` and `[""]` are different ids.
+ *  - a stored value that literally spells the bucket label (`'(None)'`, or any
+ *    localized `nullCategoryLabel` — `'(未指定)'` and the other nine packs) is
+ *    not the null group. `["(None)"]` and `[null]` are different ids, so the
+ *    click resolves to the rows its own bar was drawn from.
+ */
+export function chartBucketId(rawValue: unknown): string {
+  return pivotBucketId([pivotDimensionValue(rawValue)]);
+}
+
+/**
+ * The key an emitted chart row carries its {@link chartBucketId} under, when it
+ * carries one — the "alongside the display label" half of objectui#4508.
+ *
+ * **Written exactly when the display string does not name one bucket**, i.e.
+ * when two or more DISTINCT buckets render the same axis text. That is not a
+ * cost-saving heuristic, it is the complete condition: with the reader's
+ * matching made exact (see {@link findChartSeriesRow}), a display string that
+ * one bucket alone produces already identifies it, and the rows a chart is
+ * drawn from are also an authoring-visible surface (`data` on a `chart`
+ * schema) that renderer-internal metadata should not appear in for every
+ * ordinary chart. Rows that do not carry the category key at all never get one
+ * — they have no bucket, and that shape belongs to `hasNoCategoryKey`
+ * (framework#4033), not here.
+ *
+ * Read it with {@link chartRowBucketId} rather than the literal key.
+ */
+export const CHART_BUCKET_ID_KEY = '__bucketId';
+
+/**
+ * Read the bucket identity off a row a chart was drawn from, or `undefined`
+ * when the row carries none (an unambiguous bucket, or rows a caller built
+ * itself rather than through {@link buildChartSeries}).
+ *
+ * Takes `unknown` because its callers hold a click payload, not a typed row:
+ * recharts hands a pie/funnel click a SPREAD COPY of the data item, which is
+ * why the identity is an ordinary enumerable property and not a symbol or a
+ * non-enumerable one — either of those would silently not survive the copy.
+ */
+export function chartRowBucketId(row: unknown): string | undefined {
+  if (!row || typeof row !== 'object') return undefined;
+  const id = (row as Record<string, unknown>)[CHART_BUCKET_ID_KEY];
+  return typeof id === 'string' && id !== '' ? id : undefined;
+}
+
 /** Per-call knobs shared by {@link buildChartSeries} / {@link findChartSeriesRow}. */
 export interface ChartSeriesOptions {
   /**
@@ -86,6 +152,48 @@ export interface ChartSeriesOptions {
    * it, so a mismatch costs the null bucket its drill-through.
    */
   nullCategoryLabel?: string;
+}
+
+/** Per-CLICK knobs for {@link findChartSeriesRow}, on top of the shared ones. */
+export interface ChartDrillLookupOptions extends ChartSeriesOptions {
+  /**
+   * The clicked bucket's {@link chartBucketId}, when the renderer could read one
+   * off the row the segment was drawn from ({@link chartRowBucketId} over
+   * {@link CHART_BUCKET_ID_KEY}) — objectui#4508.
+   *
+   * Supplied ⇒ AUTHORITATIVE: the lookup matches on identity and ignores
+   * `category` entirely, which is what lets two bars painting the same axis
+   * text drill to their own rows instead of both resolving to the first.
+   * Absent ⇒ the bucket's display string identified it on its own (that is
+   * exactly when `buildChartSeries` writes no id), or the rows were not built
+   * by `buildChartSeries` at all, and the display match answers.
+   */
+  bucketId?: string;
+}
+
+/**
+ * What a chart renderer hands a drill handler when a segment is clicked.
+ *
+ * Declared HERE, beside the two helpers that write and read a bucket, rather
+ * than re-spelled inline in each of the three packages that pass it along
+ * (`AdvancedChartImpl` builds it, `ChartRenderer` and `ObjectChart` forward it,
+ * `DatasetWidget` consumes it). It was three inline literals when
+ * {@link ChartDrillLookupOptions.bucketId} needed a carrier, and a field added
+ * to one of three copies reaches the consumer as `undefined` with nothing red.
+ */
+export interface ChartSegmentClickEvent {
+  /** The clicked bucket's axis TEXT — what the user sees on the tick. */
+  category?: string;
+  /**
+   * The clicked bucket's IDENTITY, when its row carried one (objectui#4508).
+   * Feed it straight to {@link ChartDrillLookupOptions.bucketId}; it is the
+   * only field that survives two buckets painting the same `category`.
+   */
+  categoryId?: string;
+  /** The clicked series' key — a measure, or a pivoted second-dimension value. */
+  series?: string;
+  /** The measure value at the click point. */
+  value?: number;
 }
 
 /**
@@ -114,23 +222,84 @@ function isNullCategory(row: unknown, key: string): boolean {
 }
 
 /**
- * Map a null/undefined category VALUE to its bucket label, for the
- * single-dimension branch (objectui#4466).
+ * The axis text a bucket paints, from its ALREADY-RESOLVED display value — the
+ * string a chart library puts on the tick and hands back as the clicked
+ * category. Two buckets "look alike" exactly when these are equal: `1` and
+ * `'1'` included (which is why this stringifies rather than comparing raw
+ * values), and an absent display alongside `''` (both paint a blank tick).
  *
- * Returns the input array itself when nothing was null, and copies only the
+ * Takes the display value, never the raw one: in both branches a null category
+ * has ALREADY become the bucket label by the time ambiguity is asked about, and
+ * feeding the raw value here would ask the question about the wrong string.
+ */
+function bucketDisplayKey(displayValue: unknown): string {
+  return displayValue == null ? '' : String(displayValue);
+}
+
+/**
+ * Which display strings are produced by MORE THAN ONE distinct bucket — the
+ * complete set of cases where the axis text cannot name the bucket a user
+ * clicked, and therefore exactly the set that needs {@link CHART_BUCKET_ID_KEY}
+ * written (objectui#4508).
+ *
+ * Counted over DISTINCT ids, not over rows: two rows of the same group share
+ * one id and are one bucket, so an ordinary repeated category is not ambiguous
+ * and its rows stay untouched.
+ */
+function ambiguousDisplays(buckets: Array<{ id: string; display: string }>): Set<string> {
+  const idsByDisplay = new Map<string, Set<string>>();
+  for (const { id, display } of buckets) {
+    let ids = idsByDisplay.get(display);
+    if (!ids) idsByDisplay.set(display, (ids = new Set()));
+    ids.add(id);
+  }
+  const ambiguous = new Set<string>();
+  for (const [display, ids] of idsByDisplay) if (ids.size > 1) ambiguous.add(display);
+  return ambiguous;
+}
+
+/**
+ * Map a null/undefined category VALUE to its bucket label, for the
+ * single-dimension branch (objectui#4466), and give a bucket whose label is
+ * shared with another bucket its own identity (objectui#4508).
+ *
+ * Returns the input array itself when neither applied, and copies only the
  * rows it rewrites, so the caller's rows are never mutated — dataset surfaces
  * drill through by index into the RAW rows, which must keep their null.
+ *
+ * A row that does not carry `key` at all is left ENTIRELY alone: it has no
+ * bucket to label and none to identify, and adding either would erase the
+ * signal `hasNoCategoryKey` (framework#4033) reads.
  */
 function bucketNullCategories(
   rows: Array<Record<string, unknown>>,
   key: string,
   label: string,
 ): Array<Record<string, unknown>> {
+  const carriesKey = (row: unknown): boolean =>
+    !!row && typeof row === 'object' && key in (row as Record<string, unknown>);
+  // The value this row's bar will PAINT — the label when its category is null,
+  // its own value otherwise. Ambiguity is a question about that string.
+  const displayOf = (row: Record<string, unknown>): unknown =>
+    isNullCategory(row, key) ? label : row[key];
+  const ambiguous = ambiguousDisplays(
+    rows.filter(carriesKey).map((row) => ({
+      id: chartBucketId(row[key]),
+      display: bucketDisplayKey(displayOf(row)),
+    })),
+  );
   let changed = false;
   const next = rows.map((row) => {
-    if (!isNullCategory(row, key)) return row;
+    if (!carriesKey(row)) return row;
+    const isNull = isNullCategory(row, key);
+    const shared = ambiguous.has(bucketDisplayKey(displayOf(row)));
+    if (!isNull && !shared) return row;
     changed = true;
-    return { ...row, [key]: label };
+    return {
+      ...row,
+      ...(isNull ? { [key]: label } : {}),
+      ...(shared ? { [CHART_BUCKET_ID_KEY]: chartBucketId(row[key]) } : {}),
+    };
   });
   return changed ? next : rows;
 }
@@ -159,17 +328,23 @@ export function buildChartSeries(
 
     for (const row of safeRows) {
       const xRaw = row[xKey];
-      const xId = String(xRaw ?? '');
-      // The bucket KEY is untouched — `String(xRaw ?? '')` still decides WHICH
-      // rows share a bar, so every existing grouping is byte-identical. What
-      // changes is the DISPLAY value the bucket carries: a null first-dimension
-      // value used to be written into the emitted row raw, so the bar reached
-      // recharts with a null category and drew no mark — the same defect
-      // objectui#4466 fixed one branch below, and the reason key and row value
-      // were two different things here (objectui#4497).
+      // The bucket KEY is the bucket's IDENTITY, not its display string
+      // (objectui#4508). It used to be `String(xRaw ?? '')`, which merged two
+      // groups that are not the same group: a stored `null` and a stored `''`
+      // encoded identically, so they drew ONE bar carrying both groups' series
+      // and the segment belonging to the later one resolved to no row at all.
+      // `chartBucketId` keeps them apart, and every value that can spell the
+      // bucket LABEL apart from the null bucket with it.
+      //
+      // The DISPLAY value stays what objectui#4497 made it: a null
+      // first-dimension value renders under the bucket label rather than
+      // reaching the renderer raw (which drew no mark — the objectui#4466
+      // defect, one branch below). Key and display value are two different
+      // things here, and now they are two different KINDS of thing.
       //
       // The bucket takes its label from the row that CREATED it, exactly as it
       // took its raw value before.
+      const xId = chartBucketId(xRaw);
       if (!byX.has(xId)) {
         byX.set(xId, { [xKey]: isNullCategory(row, xKey) ? nullLabel : xRaw });
       }
@@ -178,8 +353,22 @@ export function buildChartSeries(
       byX.get(xId)![gId] = row[measure];
     }
 
+    // Two DISTINCT buckets can still render the same axis text — the null
+    // bucket beside a stored value that literally spells its label. Those, and
+    // only those, carry their identity to the click handler.
+    const ambiguous = ambiguousDisplays(
+      Array.from(byX.entries()).map(([id, bucket]) => ({
+        id,
+        display: bucketDisplayKey(bucket[xKey]),
+      })),
+    );
+
     return {
-      data: Array.from(byX.values()),
+      data: Array.from(byX.entries()).map(([id, bucket]) =>
+        ambiguous.has(bucketDisplayKey(bucket[xKey]))
+          ? { ...bucket, [CHART_BUCKET_ID_KEY]: id }
+          : bucket,
+      ),
       xAxisKey: xKey,
       // Series labels are the second-dimension values themselves (already
       // server-resolved to display labels by queryDataset).
@@ -271,15 +460,27 @@ export function relabelDimensions(
  *  - **otherwise** → match the x-axis (first) dimension only.
  *
  * Comparison is string-wise on the rows' display values (which is what the chart
- * surfaces as `category` / series key). Returns `-1` when nothing matches.
+ * surfaces as `category` / series key), unless the click carried a bucket
+ * IDENTITY — {@link ChartDrillLookupOptions.bucketId} — in which case that is
+ * authoritative and the display string is not consulted at all. Returns `-1`
+ * when nothing matches.
  *
  * The NULL-category bucket {@link buildChartSeries} renders (objectui#4466) is
  * matched back to its row here, and it has to be: the caller passes the rows it
  * charted FROM (still carrying the raw null) while the click event carries the
  * bucket LABEL, so without this the one bar the fix made visible would resolve
  * to `-1` and its drill-through would silently no-op. Pass the same
- * `nullCategoryLabel` both helpers were given. The pre-existing `''` spelling
- * of "no group value" still matches too — `computeDrillFilter` writes that one.
+ * `nullCategoryLabel` both helpers were given.
+ *
+ * **A null category reads as its bucket LABEL and nothing else** (objectui#4508).
+ * It used to read as the label OR the empty string, on the stated grounds that
+ * `''` is the drill layer's own spelling of "no group value" — but no producer
+ * of this function's `category` argument writes that spelling (the one
+ * production caller feeds it a chart click's category, and `computeDrillFilter`
+ * is downstream of the drill, not upstream of this lookup), while `''` IS what
+ * a genuine empty-string group paints. So the tolerance cost that group its own
+ * drill and gave it a null group's records instead — a WRONG click, not a dead
+ * one. `''` now means the empty-string group, which is what it says.
  *
  * **`xOf` covers BOTH arms, which is what let objectui#4497 bucket the pivot
  * branch without touching this function.** Worth stating because the reverse
@@ -299,7 +500,7 @@ export function findChartSeriesRow(
   values: string[] | null | undefined,
   category: string | undefined,
   seriesKey?: string,
-  options?: ChartSeriesOptions,
+  options?: ChartDrillLookupOptions,
 ): number {
   const dims = (dimensions ?? []).filter(Boolean);
   const vals = (values ?? []).filter(Boolean);
@@ -308,16 +509,22 @@ export function findChartSeriesRow(
   if (!xDim) return -1;
   const c = String(category ?? '');
   const nullLabel = options?.nullCategoryLabel ?? NULL_CATEGORY_LABEL;
-  // A null x reads as BOTH its rendered bucket label and the legacy '' — the
-  // two spellings of the same fact, neither of which a stored value can be.
-  const xOf = (r: Record<string, unknown>): string =>
-    r[xDim] == null ? (c === nullLabel ? nullLabel : '') : String(r[xDim]);
+  const bucketId = options?.bucketId;
+  // Identity wins outright when the click carried one: it is the ONE thing that
+  // survives two buckets painting the same axis text, which is the case the
+  // display string provably cannot answer.
+  const matchesX =
+    typeof bucketId === 'string' && bucketId !== ''
+      ? (r: Record<string, unknown>): boolean => chartBucketId(r[xDim]) === bucketId
+      // Otherwise the bucket's own display string, exactly: a null category
+      // reads as its rendered label, every other value as itself.
+      : (r: Record<string, unknown>): boolean => (r[xDim] == null ? nullLabel : String(r[xDim])) === c;
   if (dims.length >= 2 && vals.length === 1) {
     const gDim = dims[1];
     const s = String(seriesKey ?? '');
-    return safeRows.findIndex((r) => xOf(r) === c && String(r[gDim] ?? '') === s);
+    return safeRows.findIndex((r) => matchesX(r) && String(r[gDim] ?? '') === s);
   }
-  return safeRows.findIndex((r) => xOf(r) === c);
+  return safeRows.findIndex((r) => matchesX(r));
 }
 
 /**

--- a/packages/plugin-charts/src/AdvancedChartImpl.bucketIdentity.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.bucketIdentity.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#4508 — the bucket IDENTITY reaches a drill handler, at the DOM.
+ *
+ * `chart-series.nullCategory.test.ts` pins the transform's two halves (writes
+ * the identity, reads it back). Neither half is worth anything unless the
+ * identity actually survives the trip through the chart library, and that trip
+ * is exactly where a plausible-looking design fails silently: recharts hands a
+ * PIE sector click a `payload` it built as `{...row, ...cellProps}` — a spread
+ * copy — so a symbol key or a non-enumerable property would arrive as "this
+ * bucket has no identity", the drill would fall back to the shared axis text,
+ * and every assertion in the pure tests would still be green.
+ *
+ * So this file clicks a real sector and reads what the handler was given.
+ *
+ * A pie sector's `onClick` is an ordinary DOM handler on the `<path>`, which is
+ * why a real click is simulated here where `AdvancedChartImpl.pivotNullBucket.
+ * test.tsx` deliberately does not: the CARTESIAN click goes through recharts'
+ * hit-test geometry on the container (jsdom/happy-dom report no layout, so it
+ * would test the geometry rather than this seam). The cartesian arm's own
+ * mechanism — reading the row out of `data` by `activeTooltipIndex` — is
+ * asserted directly below instead, against the payload shape recharts
+ * documents (`MouseHandlerDataParam`).
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import { buildChartSeries, chartRowBucketId, NULL_CATEGORY_LABEL } from '@object-ui/core';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+/**
+ * The collision, as a dataset: a record whose stored `status` literally spells
+ * the null bucket's label, beside records that have no status at all. Two
+ * groups, one axis text — the case the display string cannot name.
+ */
+const LITERAL_RAW = [
+  { status: NULL_CATEGORY_LABEL, n: 1 },
+  { status: null, n: 2 },
+];
+
+describe('AdvancedChartImpl — the clicked bucket identity reaches the handler (objectui#4508)', () => {
+  it('hands a pie sector click the identity of the bucket that was clicked', () => {
+    const { data, xAxisKey, series } = buildChartSeries(LITERAL_RAW, ['status'], ['n']);
+    // Precondition, stated rather than assumed: both slices paint the same text.
+    expect(data.map((row) => row[xAxisKey!])).toEqual([NULL_CATEGORY_LABEL, NULL_CATEGORY_LABEL]);
+
+    const clicks: Array<{ category?: string; categoryId?: string }> = [];
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="pie"
+        data={data as any}
+        xAxisKey={xAxisKey}
+        series={series as any}
+        isAnimationActive={false}
+        onChartClick={(ev) => clicks.push(ev)}
+      />,
+    );
+
+    const sectors = container.querySelectorAll('.recharts-sector');
+    expect(sectors.length).toBe(2);
+
+    fireEvent.click(sectors[1]);
+    expect(clicks).toHaveLength(1);
+    // The axis text alone would have named the FIRST bucket for either slice.
+    expect(clicks[0].category).toBe(NULL_CATEGORY_LABEL);
+    // This is the whole test: the identity survived recharts' spread copy.
+    expect(clicks[0].categoryId).toBe('[null]');
+
+    fireEvent.click(sectors[0]);
+    expect(clicks[1].categoryId).toBe('["(None)"]');
+  });
+
+  it('omits the identity for a bucket whose axis text already names it', () => {
+    const rows = [
+      { status: 'Backlog', n: 5 },
+      { status: 'Done', n: 24 },
+    ];
+    const { data, xAxisKey, series } = buildChartSeries(rows, ['status'], ['n']);
+    const clicks: Array<{ category?: string; categoryId?: string }> = [];
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="pie"
+        data={data as any}
+        xAxisKey={xAxisKey}
+        series={series as any}
+        isAnimationActive={false}
+        onChartClick={(ev) => clicks.push(ev)}
+      />,
+    );
+    fireEvent.click(container.querySelectorAll('.recharts-sector')[1]);
+    expect(clicks[0].category).toBe('Done');
+    // Nothing to disambiguate, so nothing is carried — and the lookup's display
+    // match answers, exactly as it did before objectui#4508.
+    expect(clicks[0].categoryId).toBeUndefined();
+  });
+});
+
+/**
+ * The CARTESIAN arm's mechanism, asserted where it can be asserted.
+ *
+ * recharts 3 hands a chart-level `onClick` a `MouseHandlerDataParam`:
+ * `{ activeLabel, activeIndex, activeTooltipIndex, activeDataKey,
+ * activeCoordinate, isTooltipActive }` — an INDEX into this chart's `data` and
+ * no row of its own. That is why `handleCartesianClick` reads the clicked row
+ * out of the `data` array it was given rather than out of the event.
+ */
+describe('AdvancedChartImpl — the cartesian arm reads its row by index (objectui#4508)', () => {
+  it('resolves the identity of the bucket at the clicked index', () => {
+    const { data, xAxisKey, series } = buildChartSeries(LITERAL_RAW, ['status'], ['n']);
+    // What the component does, over the payload recharts documents. Clicking
+    // the second bar reports index 1; both bars carry the same `activeLabel`.
+    const rowAt = (payload: { activeTooltipIndex?: number; activeLabel?: string }) => {
+      const idx = Number(payload.activeTooltipIndex);
+      return Number.isInteger(idx) && idx >= 0 ? data[idx] : undefined;
+    };
+    expect(chartRowBucketId(rowAt({ activeTooltipIndex: 1, activeLabel: NULL_CATEGORY_LABEL })))
+      .toBe('[null]');
+    expect(chartRowBucketId(rowAt({ activeTooltipIndex: 0, activeLabel: NULL_CATEGORY_LABEL })))
+      .toBe('["(None)"]');
+    // No active tick (a click on empty plot area) resolves to no identity
+    // rather than to bucket zero.
+    expect(chartRowBucketId(rowAt({}))).toBeUndefined();
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -49,7 +49,7 @@ import {
 } from './ChartContainerImpl';
 import { mapScatterClick, mapTreemapClick, mapSankeyClick } from './chartDrillEvents';
 import { formatterFor, domainFor, ticksFor, RENDERABLE, SINGLE_VALUE_CHART_TYPES, TABULAR_CHART_TYPES, effectiveChartFamily, comboBaseFamily, type NormalizedAxis, type NormalizedSeries } from './normalizeChartSchema';
-import { buildCategoryRank } from '@object-ui/core';
+import { buildCategoryRank, chartRowBucketId, type ChartSegmentClickEvent } from '@object-ui/core';
 
 // Default color fallback for chart series
 const DEFAULT_CHART_COLOR = 'hsl(var(--primary))';
@@ -140,10 +140,11 @@ export interface AdvancedChartImplProps {
   categoryOrder?: string[];
   /**
    * Optional drill-down click handler. Fires when a chart segment is clicked
-   * with `{ category, series, value }`. Wired for bar/horizontal-bar/line/
-   * area/pie/donut. Other chart types are no-ops in L1.
+   * with `{ category, categoryId, series, value }`. Wired for
+   * bar/horizontal-bar/line/area/pie/donut/funnel. Other chart types are
+   * no-ops in L1.
    */
-  onChartClick?: (event: { category?: string; series?: string; value?: number }) => void;
+  onChartClick?: (event: ChartSegmentClickEvent) => void;
   /**
    * Spec `ChartAxis` presentation for the category axis — `format` (tick
    * formatter), `title`, `showGridLines`. Its `field` already arrived as
@@ -300,23 +301,35 @@ function AdvancedChartImplInner({
   };
   const [isMobile, setIsMobile] = React.useState(false);
 
-  // Recharts' top-level onClick payload: { activeLabel, activePayload, ... }
+  // Recharts' top-level onClick payload: { activeLabel, activeTooltipIndex, … }
+  // — `MouseHandlerDataParam`, which carries an INDEX into this chart's `data`
+  // and no row of its own. So the clicked bucket's row (and with it the
+  // objectui#4508 identity) is read out of OUR OWN array rather than out of the
+  // event: nothing in the payload can be stale or copied, because none of it
+  // came from recharts.
   const handleCartesianClick = React.useCallback((payload: any) => {
     if (!onChartClick || !payload) return;
     const ap = Array.isArray(payload.activePayload) ? payload.activePayload[0] : undefined;
+    const idx = Number(payload.activeTooltipIndex ?? payload.activeIndex);
+    const row = Number.isInteger(idx) && idx >= 0 ? data[idx] : undefined;
     onChartClick({
       category: payload.activeLabel != null ? String(payload.activeLabel) : undefined,
+      categoryId: chartRowBucketId(row),
       series: ap?.dataKey ? String(ap.dataKey) : undefined,
       value: typeof ap?.value === 'number' ? ap.value : undefined,
     });
-  }, [onChartClick]);
+  }, [onChartClick, data]);
 
+  // A pie sector's `payload` is a SPREAD COPY of the data row (recharts builds
+  // it as `{...entry, ...cellProps}`), which is precisely why the bucket
+  // identity is an ordinary enumerable property — see `CHART_BUCKET_ID_KEY`.
   const handlePieClick = React.useCallback((entry: any) => {
     if (!onChartClick || !entry) return;
     const cat = entry.payload?.[xAxisKey];
     const dk = series[0]?.dataKey || 'value';
     onChartClick({
       category: cat != null ? String(cat) : undefined,
+      categoryId: chartRowBucketId(entry.payload),
       series: dk,
       value: typeof entry.payload?.[dk] === 'number' ? entry.payload[dk] : undefined,
     });
@@ -710,6 +723,7 @@ function AdvancedChartImplInner({
           if (!entry) return;
           onChartClick({
             category: entry?.payload?.[xAxisKey] ?? entry?.[xAxisKey],
+            categoryId: chartRowBucketId(entry?.payload) ?? chartRowBucketId(entry),
             value: entry?.payload?.[dataKey] ?? entry?.[dataKey],
           });
         }

--- a/packages/plugin-charts/src/ChartRenderer.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.tsx
@@ -2,6 +2,7 @@
 import React, { Suspense } from 'react';
 import { Skeleton } from '@object-ui/components';
 import type { ChartContainerConfig } from './ChartContainerImpl';
+import type { ChartSegmentClickEvent } from '@object-ui/core';
 import { normalizeChartSchema } from './normalizeChartSchema';
 
 // 🚀 Lazy load the implementation files
@@ -95,7 +96,7 @@ export interface ChartRendererProps {
     isAnimationActive?: boolean;
   };
   /** Drill-down click handler — wired by ObjectChart when drillDown is enabled. */
-  onChartClick?: (event: { category?: string; series?: string; value?: number }) => void;
+  onChartClick?: (event: ChartSegmentClickEvent) => void;
 }
 
 /**

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useContext, useCallback, useMemo, useRef } from 'react';
 import { useDataScope, SchemaRendererContext, SchemaRenderer, useDrillNavigation, useFilterScope, ElementDataSourceGate, type ElementDataSourceMapping } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
-import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, deriveDimensionLabelMaps, dimensionOptionTranslator, loadDimensionFieldMeta, relabelDimensions, localizeFieldOptions, type DimensionFieldMeta, type CompareToConfig, type DrillEvent, type ChartResultField } from '@object-ui/core';
+import { ComponentRegistry, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, deriveDimensionLabelMaps, dimensionOptionTranslator, loadDimensionFieldMeta, relabelDimensions, localizeFieldOptions, type DimensionFieldMeta, type CompareToConfig, type DrillEvent, type ChartResultField, type ChartSegmentClickEvent } from '@object-ui/core';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button, ChartSkeleton } from '@object-ui/components';
 import { AlertCircle, ArrowUpRight } from 'lucide-react';
 import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
@@ -249,7 +249,7 @@ export const ObjectChart = (props: any) => {
   // Optional host-owned segment click. When provided (e.g. a dataset widget
   // that owns precise drill-through), it takes over the chart click and the
   // widget's own object-drill drawer is suppressed.
-  const onSegmentClick: ((ev: { category?: string; series?: string; value?: number }) => void) | undefined = props.onSegmentClick;
+  const onSegmentClick: ((ev: ChartSegmentClickEvent) => void) | undefined = props.onSegmentClick;
   const context = useContext(SchemaRendererContext);
   const dataSource = props.dataSource || context?.dataSource;
   // Host-authenticated fetch for the metadata probes below (#4114). Read from
@@ -908,7 +908,7 @@ export const ObjectChart = (props: any) => {
   }
 
   const internalChartClick = isDrillEnabled(drillDown)
-    ? (ev: { category?: string; series?: string; value?: number }) => {
+    ? (ev: ChartSegmentClickEvent) => {
         const labelCategory = ev.category;
         const rawCategory = labelCategory != null && labelToRaw.has(String(labelCategory))
           ? labelToRaw.get(String(labelCategory))

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -58,6 +58,7 @@ import {
   pivotDimensionValue,
   pivotCellKey,
   compareToTrendLabelKey,
+  type ChartSegmentClickEvent,
   type ChartSeriesBinding,
   type CompareToConfig,
   type DatasetResultField,
@@ -1433,8 +1434,16 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
 
   // Map a clicked chart segment back to its dataset row, then drill through to
   // the underlying records — same governed path the table/pivot rows use.
-  const handleChartDrill = (ev: { category?: string; series?: string; value?: number }) => {
-    const idx = findChartSeriesRow(chartRows, dimensions, values, ev?.category, ev?.series, { nullCategoryLabel });
+  const handleChartDrill = (ev: ChartSegmentClickEvent) => {
+    // `categoryId` is the clicked bucket's IDENTITY (objectui#4508) and is
+    // forwarded whenever the renderer could read one: it is what separates two
+    // bars painting the same axis text — a stored `'(None)'` beside the null
+    // bucket — so each drills to the rows its own bar was drawn from. Absent,
+    // the category text identified the bucket on its own and the lookup says so.
+    const idx = findChartSeriesRow(chartRows, dimensions, values, ev?.category, ev?.series, {
+      nullCategoryLabel,
+      bucketId: ev?.categoryId,
+    });
     if (idx < 0) return;
     // `series` is a real (second) dimension value only when pivoted; otherwise
     // it's the measure name — omit it from the drawer title.

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartBucketIdentity.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartBucketIdentity.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#4508 — the CONSUMER half of the chart bucket identity.
+ *
+ * `DatasetWidget.handleChartDrill` is the one production caller of
+ * `findChartSeriesRow`, so it is where the two collisions were felt: it takes a
+ * clicked segment, resolves it to a raw dataset row, and opens the drawer
+ * filtered by that row. Both collisions were invisible in the transform's
+ * return value and visible here, as the WRONG RECORDS (or none).
+ *
+ * The sibling files pin the other two layers: `chart-series.nullCategory.test.
+ * ts` the transform, `AdvancedChartImpl.bucketIdentity.test.tsx` that the
+ * identity survives the chart library. This one asserts the thing a user
+ * experiences — which records the drawer opens on.
+ *
+ * DIRECTIONS, written before the reverse verification was run:
+ *  - the two collision cases are RED before the change, and each in its own
+ *    way: the literal-label case resolves to the WRONG row (a filter naming
+ *    another group's record), the empty-string case to a null group's row;
+ *  - every BOUNDARY case is GREEN on both sides. A chart with no colliding
+ *    bucket must drill byte-identically to how it drills today, including the
+ *    plain null bucket that objectui#4466/#4500 made work.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry, NULL_CATEGORY_LABEL, chartRowBucketId } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { DatasetWidget } from '../DatasetWidget';
+
+/** Capture what the widget hands the chart renderer (jsdom lays out no SVG). */
+let capturedChartProps: any = null;
+beforeAll(() => {
+  ComponentRegistry.register('chart', (props: any) => {
+    capturedChartProps = props;
+    return null;
+  });
+});
+
+/** Observe the drill filter without rendering the real drawer. */
+const drillFilters: Array<Record<string, unknown>> = [];
+vi.mock('../DrillDownDrawer', () => ({
+  DrillDownDrawer: ({ filter }: { filter: Record<string, unknown> }) => {
+    drillFilters.push(filter);
+    return null;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  capturedChartProps = null;
+  drillFilters.length = 0;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** Plain TEXT dimension field: no option list, so no relabel can blur which
+ *  channel produced the category string under test. */
+const OPPORTUNITY = { name: 'crm_opportunity', fields: { owner_id: { type: 'text' } } };
+
+function installMetaRouter() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ item: OPPORTUNITY }) })),
+  );
+}
+
+/**
+ * `drillRawRows` carries the IDENTITY keys, deliberately spelled differently
+ * from every display value, so a resolved drill names exactly one row and a
+ * lucky string match cannot be mistaken for a correct one.
+ */
+const datasetOf = (rows: Array<Record<string, unknown>>, rawRows: Array<Record<string, unknown>>) => ({
+  queryDataset: vi.fn(async () => ({
+    rows,
+    fields: [
+      { name: 'owner_name', type: 'text', label: 'Owner' },
+      { name: 'deals', type: 'number', label: 'Deals' },
+    ],
+    object: 'crm_opportunity',
+    dimensionFields: { owner_name: 'owner_id' },
+    drillRawRows: rawRows,
+  })),
+});
+
+function renderWidget(dataSource: { queryDataset: unknown }) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false, resources: {} }}>
+      <DatasetWidget
+        widget={{
+          type: 'bar',
+          dataset: 'deals_by_owner',
+          dimensions: ['owner_name'],
+          values: ['deals'],
+          drillDown: { enabled: true },
+        }}
+        dataSource={dataSource as any}
+      />
+    </I18nProvider>,
+  );
+}
+
+/** The rows the widget handed the chart renderer — one per drawn bar. */
+const chartRows = (): Array<Record<string, unknown>> => capturedChartProps?.schema?.data ?? [];
+
+/**
+ * Click the bar drawn from `chartRows()[i]`, exactly as the renderer would:
+ * the axis text it paints, plus whatever identity that row carries.
+ */
+const clickBar = (i: number) => {
+  const row = chartRows()[i];
+  capturedChartProps.onSegmentClick({
+    category: row.owner_name == null ? undefined : String(row.owner_name),
+    categoryId: chartRowBucketId(row),
+  });
+};
+
+const lastFilter = () => drillFilters[drillFilters.length - 1];
+
+describe('DatasetWidget — a bucket drills to ITS OWN rows (objectui#4508)', () => {
+  it('a stored value spelling the bucket label no longer steals the null bucket’s drill', async () => {
+    // Collision 2. Both bars paint `(None)`: one because a record literally
+    // stores that text, one because a group has no value at all. Pre-fix the
+    // click resolved by axis text, so BOTH bars filtered on `user-literal` —
+    // a drill into records the clicked bar was not drawn from.
+    installMetaRouter();
+    renderWidget(
+      datasetOf(
+        [
+          { owner_name: NULL_CATEGORY_LABEL, deals: 1 },
+          { owner_name: null, deals: 2 },
+        ],
+        [{ owner_name: 'user-literal' }, { owner_name: 'user-absent' }],
+      ),
+    );
+
+    await waitFor(() => expect(chartRows().length).toBe(2));
+    // Precondition, stated rather than assumed: the axis text cannot tell them
+    // apart, which is why the identity is carried at all.
+    expect(chartRows().map((r) => r.owner_name)).toEqual([NULL_CATEGORY_LABEL, NULL_CATEGORY_LABEL]);
+
+    clickBar(0);
+    await waitFor(() => expect(drillFilters.length).toBe(1));
+    expect(lastFilter()).toEqual({ owner_id: 'user-literal' });
+
+    clickBar(1);
+    // Pre-fix: `user-literal` again — the wrong records, silently.
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: 'user-absent' }));
+  });
+
+  it('an empty-string group drills to itself, not to the null group', async () => {
+    // Collision 1, on the drill side. `''` and null used to read as the same
+    // "no value" spelling, so the empty-string bar resolved to the null row.
+    installMetaRouter();
+    renderWidget(
+      datasetOf(
+        [
+          { owner_name: null, deals: 3 },
+          { owner_name: '', deals: 5 },
+        ],
+        [{ owner_name: 'user-absent' }, { owner_name: 'user-empty' }],
+      ),
+    );
+
+    await waitFor(() => expect(chartRows().length).toBe(2));
+    // Two DIFFERENT bars: the null one labelled, the empty-string one blank.
+    expect(chartRows().map((r) => r.owner_name)).toEqual([NULL_CATEGORY_LABEL, '']);
+
+    clickBar(1);
+    // Pre-fix: `user-absent` — the null group's records under the blank bar.
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: 'user-empty' }));
+
+    clickBar(0);
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: 'user-absent' }));
+  });
+
+  it('BOUNDARY — the plain null bucket still drills exactly as objectui#4466 made it', async () => {
+    // Green on both sides. Nothing about this widget is ambiguous, so no
+    // identity is carried and the bucket label resolves it, as it always did.
+    installMetaRouter();
+    renderWidget(
+      datasetOf(
+        [
+          { owner_name: 'Ada Lovelace', deals: 5 },
+          { owner_name: null, deals: 3 },
+        ],
+        [{ owner_name: 'user-ada' }, { owner_name: null }],
+      ),
+    );
+
+    await waitFor(() => expect(chartRows().length).toBe(2));
+    expect(chartRows()[1]).toEqual({ owner_name: NULL_CATEGORY_LABEL, deals: 3 });
+
+    clickBar(1);
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: null }));
+  });
+
+  it('BOUNDARY — an ordinary category drills by its stored id, rows untouched', async () => {
+    installMetaRouter();
+    renderWidget(
+      datasetOf(
+        [
+          { owner_name: 'Ada Lovelace', deals: 5 },
+          { owner_name: 'Grace Hopper', deals: 3 },
+        ],
+        [{ owner_name: 'user-ada' }, { owner_name: 'user-grace' }],
+      ),
+    );
+
+    await waitFor(() => expect(chartRows().length).toBe(2));
+    // No renderer-internal key reaches the chart schema for an ordinary chart.
+    expect(chartRows()).toEqual([
+      { owner_name: 'Ada Lovelace', deals: 5 },
+      { owner_name: 'Grace Hopper', deals: 3 },
+    ]);
+
+    clickBar(0);
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: 'user-ada' }));
+  });
+
+  it('BOUNDARY — a host that forwards no identity keeps its current drill', async () => {
+    // The widget must not require the new field: an older renderer (or a chart
+    // family whose click carries no row) still drills by category text.
+    installMetaRouter();
+    renderWidget(
+      datasetOf(
+        [
+          { owner_name: 'Ada Lovelace', deals: 5 },
+          { owner_name: null, deals: 3 },
+        ],
+        [{ owner_name: 'user-ada' }, { owner_name: null }],
+      ),
+    );
+
+    await waitFor(() => expect(chartRows().length).toBe(2));
+    capturedChartProps.onSegmentClick({ category: NULL_CATEGORY_LABEL });
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: null }));
+  });
+});


### PR DESCRIPTION
Fixes #4508

`target:v17` board item. Implements the maintainer ruling of 2026-08-14 on the card (verbatim 「同意」 on the sentinel-identity direction): `buildChartSeries` writes a bucket identity distinct from the display string, `findChartSeriesRow` reads it back, aligned with the distinct-bucket-id form the pivot TABLE (`buildPivot`) already uses over the same dataset rows. One change covering both collisions.

## The two collisions, and the one cause

The bucket's DISPLAY string served as the bucket's own key, so two pairs of genuinely different groups were conflated — and the segment click that drills a bar back to its records inherited both.

1. **A null group and an empty-string group drew ONE bar.** The pivot branch keyed by `String(xRaw ?? '')`, which spells `null` and `''` identically. The bar took its label from whichever row created the bucket, and the other group's segment resolved to no row — a visible bar whose click did nothing.
2. **A record whose stored value spells the bucket label stole the null bucket's drill.** A row storing the literal text `(None)` (or any localized `chart.nullCategory` — `(未指定)` and the other nine packs) kept its own bucket, so two bars carried the same axis text and BOTH resolved to the first. That one is a **wrong** drill, not a dead one: clicking the null bucket's bar opened the drawer on another group's records.

## What changed

- **`chartBucketId`** (`@object-ui/core`) is the identity — the SAME encoder `buildPivot` keys its buckets with (`pivotBucketId` over `pivotDimensionValue`), so the chart and the table stop answering one question two ways. The pivot branch buckets by it, which is what makes null and `''` two groups again.
- **`CHART_BUCKET_ID_KEY`** carries that identity on an emitted row, written **exactly where two DISTINCT buckets paint the same axis text** — the complete set of cases where the display string cannot name what was clicked, given the reader's matching is now exact. An ordinary chart's rows are returned untouched (by identity), so no renderer-internal key reaches an authoring surface (`data` on a `chart` schema). Rows lacking the category key never get one — that shape stays `hasNoCategoryKey`'s (framework#4033).
- **`findChartSeriesRow`** takes it back as `options.bucketId` and treats it as authoritative, ignoring `category` entirely when present.
- **Plumbing.** The drill event gains `categoryId`, via `ChartSegmentClickEvent` — now declared once in core rather than as three inline literals across `AdvancedChartImpl` / `ChartRenderer` / `ObjectChart`, since a field added to one of three copies reaches the consumer as `undefined` with nothing red. `AdvancedChartImpl` reads the identity off the clicked row on the cartesian, pie and funnel paths; `DatasetWidget.handleChartDrill` hands it to the lookup.

### Why the identity is an ordinary enumerable property

Measured, not assumed: recharts builds a pie sector's `payload` as `{ ...row, ...cellProps }` — a spread copy — so a symbol key or a non-enumerable property would arrive as "this bucket has no identity", the drill would fall back to the shared axis text, and every pure test would still be green. There is a DOM test that clicks a real sector for exactly this reason.

On the cartesian path the clicked row is read out of **our own `data` array** by `activeTooltipIndex`, not out of the event: recharts 3 sends a `MouseHandlerDataParam` that carries an index and no row, so nothing in that read can be a stale or copied payload.

## Behaviour change worth reviewing

An empty-string category no longer resolves to a null-valued row. That tolerance was justified in the code as the drill layer's own spelling of "no group value" (`computeDrillFilter`), but re-measurement does not support it: `computeDrillFilter` runs *downstream* of a resolved drill and never produces this lookup's `category`, whose one production producer is a chart click — while `''` **is** the axis text a genuine empty-string group paints. So the tolerance was giving that group's bar a different group's records. A host that forwards no `categoryId` keeps its existing drill unchanged.

## Pin updates

The three cases #4497 pinned in `chart-series.nullCategory.test.ts` as *"the measured limits of the bucket label"* — explicitly as limits and **not** as correct — are flipped here, in the commit that changed them, each keeping its fixture and stating what it now asserts and what it asserted before. The two `''`-reads-as-null pins are updated with the re-measurement above. Every other pin in that file, including all the must-not-change ones, is untouched and green.

## Verification

All at `f3e14d59a` (the final commit), gate union re-run after it.

- `pnpm exec vitest run packages/core/ packages/plugin-charts/ packages/plugin-dashboard/` — **170 files, 2463 tests, all passing**.
- `turbo run type-check lint` for the three packages with the dependency closure built — **19 tasks successful**, `tsc --noEmit && tsc -p tsconfig.test.json` confirmed executed, 0 lint errors (warnings are the packages' pre-existing `any` counts).
- `check:changeset-fixed`, `changeset-no-major`, `changeset-presence`, `control-bytes`, `spec-symbols`, `phantom-deps`, `i18n-keys`, `i18n-drift`, `lint-coverage`, `type-check-coverage`, `skills-paths` — all OK.

**Cross-package type reverse check:** renaming `ev.categoryId` to a non-existent field in `DatasetWidget` fails as `error TS2339: Property 'categoryIdNoSuchField' does not exist on type 'ChartSegmentClickEvent'` — the error names the type from the freshly built core `.d.ts`, proving plugin-dashboard type-checked against the rebuilt declaration rather than a cached one.

**Reverse verification**, directions predicted before running, split into two legs so each collision is attributed to its own half:

| ablation | predicted | observed |
|---|---|---|
| writer (pivot bucket key + identity write) | both collisions' bucketing and every identity-carrier assertion go red; reader-only cases and all boundaries stay green | **9 red / 39 green — exactly the predicted set**, including the pie-click DOM test losing `categoryId` |
| reader (exact display matching) | the empty-string cases go red; identity cases stay green | **4 red / 44 green — the predicted set** |

Each leg was restored byte-for-byte from the committed state before the next (`git checkout` of the commit sha, path-scoped — never a stash), and the final numbers above are from the restored tree.

## Out of scope, filed while measuring

- #4672 — `AdvancedChartImpl`'s cartesian click reads `activePayload`, which recharts 3 does not send, so `series` and `value` are always `undefined`. This kills the **pivoted** drill outright (the lookup's pivot arm requires the series key), independently of this PR. It is why the pivot arm's end-to-end click cannot be demonstrated on a cartesian chart today; the pure and stubbed tests here exercise it directly instead. Not fixed here: different defect class, and the right value for `activeDataKey` under a shared cartesian tooltip needs its own measurement. #4672 is not addressed by this PR.
- #4673 — the pivot's **second** dimension drops a null group's series entirely (`gId !== ''`), so its measure is written into the bucket and never drawn. The #4466 defect one dimension over, and it needs its own ruling because a series key is also a row key. #4673 remains open.

Branch was cut from `b1119ece4`; `main` has since advanced to `541c72425` (#4671), which touches none of this PR's files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_
