### PR TITLE
fix(app-shell): RecordDetailView refuses a recordIdParam the record can't supply

### DIFF
--- a/.changeset/four-plans-refuse.md
+++ b/.changeset/four-plans-refuse.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`RecordDetailView`'s `type: 'api'` action handler now refuses to dispatch a
+record-scoped mutation when the record cannot supply the declared
+`recordIdParam` key, instead of sending the request anyway with the
+parameter silently dropped (objectstack#8018, objectui#4669).
+
+The seeding read routes through the shared `resolveRecordIdParamSeed`
+helper (`@object-ui/core`, already adopted by `useConsoleActionRuntime` in
+objectui#4670) so both refusal wordings — an absent key vs. a `null`
+value, which point at different repairs — are worded consistently across
+call sites. This call site's extra fallback sources (a literal `recordId`
+override, and the page-record fallback `record_header` actions rely on
+when no row is stashed) are preserved; the refusal only fires once every
+source has been tried and none can supply the key.
+
+Behaviour change worth noting: an action that previously dispatched an
+under-specified request now fails visibly instead. That is the point — the
+old path could not report the failure it was causing.

--- a/packages/app-shell/src/views/RecordDetailView.recordIdParamSeed.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.recordIdParamSeed.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * RecordDetailView's `type:'api'` handler seeds `recordIdParam` via the
+ * shared `resolveRecordIdParamSeed` helper (objectstack#8018, objectui#4669).
+ *
+ * The read used to be `if (rowValue != null) body[param] = rowValue;` with a
+ * silent `else` — a row (or, on this call site, the fallback chain below)
+ * that could not supply the key sent the request anyway, minus the
+ * parameter naming the record. A backend reading a missing selector as
+ * "match nothing" then answers success for having changed nothing.
+ *
+ * This call site has two sources `resolveRecordIdParamSeed` alone does not
+ * know about, on top of the row: a literal `recordId` override, and the
+ * `pageRecord` fallback `record_header` actions rely on when no row is
+ * stashed (same fallback `interpolationRecord` above uses for `{field}` URL
+ * tokens). Both are preserved — the tests below pin that, alongside the two
+ * refusal wordings and the happy path — so adopting the helper here did not
+ * quietly narrow the sources this call site already read from.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const authFetchSpy = vi.fn(async () =>
+  new Response(JSON.stringify({ data: [] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }),
+);
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => authFetchSpy,
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => [],
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// The dialogs / flow runner are orthogonal chrome; stubbing them keeps this
+// file about the api dispatch (same posture as the modal-dispatch and
+// header-interpolation tests it borrows its harness from).
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+
+vi.mock('../hooks/useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: vi.fn(async () => ({ success: true })),
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: vi.fn(async () => null),
+  }),
+}));
+
+vi.mock('../utils/consoleServerAction', () => ({
+  createConsoleServerActionHandler: () => vi.fn(async () => ({ success: true })),
+}));
+
+// Capture BOTH the handler set and the context each <ActionProvider> receives
+// while KEEPING the real provider — same discriminator as the header
+// interpolation tests: the record page's own provider is the only one whose
+// context carries this page's record, and the mount waits for handlers built
+// against the LOADED record (apiHandler closes over `pageRecord`).
+const captured: Array<{ handlers: Record<string, (action: any) => Promise<any>>; context: any }> = [];
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    ActionProvider: (props: any) => {
+      captured.push({ handlers: props.handlers, context: props.context });
+      return React.createElement(actual.ActionProvider as any, props);
+    },
+    SchemaRenderer: () => null,
+  };
+});
+
+import { MetadataCtx } from '@object-ui/react';
+import { RecordDetailView } from './RecordDetailView';
+
+const OBJECT_NAME = 'os_production_plan';
+const RECORD_ID = 'rec-plan-1';
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'Production Plan',
+    fields: {
+      id: { type: 'text', label: 'Id' },
+      name: { type: 'text', label: 'Name' },
+      code: { type: 'text', label: 'Code' },
+    },
+  },
+];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => ({ id: RECORD_ID, name: 'Plan A' })),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+const METADATA = {
+  objects: OBJECTS,
+  pages: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invalidate: () => {},
+  ensureType: async () => [],
+  getItem: async () => null,
+  getItemsByType: () => [],
+} as any;
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={[`/app/demo/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={METADATA}>
+        <RecordDetailView
+          dataSource={makeDataSource()}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={RECORD_ID}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+}
+
+/** The record page's OWN provider capture, built against the LOADED record. */
+function recordPageCapture() {
+  return [...captured]
+    .reverse()
+    .find((c) => c.handlers && c.context?.record?.id === RECORD_ID);
+}
+
+/** Render the view and hand back its ActionProvider handlers, spies cleared. */
+async function mountAndCaptureHandlers() {
+  renderDetail();
+  await waitFor(() => expect(recordPageCapture()).toBeTruthy());
+  const handlers = recordPageCapture()!.handlers;
+  // Anything the mount itself fetched is not the dispatch under test.
+  authFetchSpy.mockClear();
+  return handlers;
+}
+
+beforeEach(() => {
+  cleanup();
+  captured.length = 0;
+  authFetchSpy.mockClear();
+  // Unrelated chrome on this view (approvals, favourites, …) reaches for the
+  // platform API; in jsdom that is a real socket. Answer it locally so the
+  // only asynchrony left is the record load the capture waits on.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('RecordDetailView api handler — recordIdParam seeding refuses instead of under-specifying (objectstack#8018)', () => {
+  it('refuses when the row lacks the recordIdField key entirely', async () => {
+    const handlers = await mountAndCaptureHandlers();
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'link_code',
+        label: 'Link by Code',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/link`,
+        recordIdParam: 'targetCode',
+        recordIdField: 'code',
+        params: { _rowRecord: { id: 'row-1', name: 'Row' } },
+      });
+    });
+
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('Link by Code');
+    expect(r.error).toContain('code');
+    // The point of the whole card: no under-specified request goes out.
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the key is present but null — a different repair, worded differently', async () => {
+    const handlers = await mountAndCaptureHandlers();
+
+    let r: any;
+    await act(async () => {
+      // `objectName` retargets away from the page's own object, which — same
+      // guard as `interpolationRecord` above — disables the page-record
+      // fallback. That isolates the row's `null` as the value actually
+      // inspected, instead of falling through to a page record that lacks
+      // the key entirely (a *different*, and separately covered, refusal).
+      r = await handlers.api({
+        name: 'link_code',
+        label: 'Link by Code',
+        type: 'api',
+        method: 'POST',
+        objectName: 'other_object',
+        target: '/api/v1/data/other_object/link',
+        recordIdParam: 'targetCode',
+        recordIdField: 'code',
+        params: { _rowRecord: { id: 'row-1', code: null } },
+      });
+    });
+
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('this record has no value');
+    expect(authFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('injects the value and dispatches when the row supplies it', async () => {
+    const handlers = await mountAndCaptureHandlers();
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'link_code',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/link`,
+        recordIdParam: 'targetCode',
+        recordIdField: 'code',
+        params: { _rowRecord: { id: 'row-1', code: 'INV-1' } },
+      });
+    });
+
+    expect(r.success).toBe(true);
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({ targetCode: 'INV-1' });
+  });
+
+  it('falls back to the page record when no row is stashed (record_header actions)', async () => {
+    const handlers = await mountAndCaptureHandlers();
+
+    let r: any;
+    await act(async () => {
+      // A record_header-style action: no `_rowRecord` stash, so the only
+      // source is the page's own loaded record — the fallback
+      // `interpolationRecord` above also relies on. `recordIdField`
+      // defaults to `id`.
+      r = await handlers.api({
+        name: 'archive_plan',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/archive`,
+        recordIdParam: 'planId',
+      });
+    });
+
+    expect(r.success).toBe(true);
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({ planId: RECORD_ID });
+  });
+
+  it('honors a literal `recordId` override ahead of the page-record fallback', async () => {
+    const handlers = await mountAndCaptureHandlers();
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'archive_plan',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/archive`,
+        recordIdParam: 'planId',
+        // Not a declared ActionDef field — the pre-existing escape hatch
+        // this call site read via `(action as any).recordId`.
+        recordId: 'explicit-plan-9',
+      } as any);
+    });
+
+    expect(r.success).toBe(true);
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = authFetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({ planId: 'explicit-plan-9' });
+  });
+
+  it('leaves an action declaring no recordIdParam completely alone', async () => {
+    const handlers = await mountAndCaptureHandlers();
+
+    let r: any;
+    await act(async () => {
+      r = await handlers.api({
+        name: 'ping',
+        type: 'api',
+        method: 'POST',
+        target: `/api/v1/data/${OBJECT_NAME}/ping`,
+      });
+    });
+
+    expect(r.success).toBe(true);
+    expect(authFetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -15,7 +15,7 @@ import { Empty, EmptyTitle, EmptyDescription } from '@object-ui/components';
 import { useAuth, createAuthenticatedFetch } from '@object-ui/auth';
 import { usePermissions } from '@object-ui/permissions';
 import { ActionProvider, useObjectTranslation, useObjectLabel, useActionTextLocalizer, usePageAssignment, RecordContextProvider, SchemaRenderer, DiscussionContextProvider, HighlightFieldsProvider, InlineEditProvider, useGlobalUndo, useDataInvalidation, notifyDataChanged, useRowPredicate } from '@object-ui/react';
-import { buildExpandFields, userActionPredicates } from '@object-ui/core';
+import { buildExpandFields, resolveRecordIdParamSeed, userActionPredicates } from '@object-ui/core';
 import { toast } from 'sonner';
 import { useRecordPresence, PresenceAvatars } from '@object-ui/collaboration';
 import { Database, ChevronLeft } from 'lucide-react';
@@ -615,10 +615,31 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
         const body: Record<string, any> = wrap ? { [wrap]: params } : { ...params };
 
         if (action.recordIdParam) {
-          const rowField = (action as any).recordIdField || 'id';
-          const rowValue = rowRecord?.[rowField] ?? (action as any).recordId
-            ?? (!action.objectName || action.objectName === objectName ? (pageRecord as any)?.[rowField] : undefined);
-          if (rowValue != null) body[action.recordIdParam] = rowValue;
+          const rowField = action.recordIdField || 'id';
+          // This site has two sources resolveRecordIdParamSeed doesn't know
+          // about — a literal `recordId` override (not a declared ActionDef
+          // field; nothing in this repo's metadata sets it today, hence the
+          // cast) and the same page-record fallback `interpolationRecord`
+          // above uses for `record_header` actions dispatched with no
+          // `rowRecord`. Preserve that priority (row -> override ->
+          // page record) and let the helper decide — and word — the
+          // refusal only once every source has been tried, instead of the
+          // silent drop this call site used to fall back to
+          // (objectstack#8018, objectui#4669).
+          const recordIdOverride = (action as { recordId?: unknown }).recordId;
+          const rowHasValue = !!rowRecord && rowRecord[rowField] != null;
+          if (!rowHasValue && recordIdOverride != null) {
+            body[action.recordIdParam] = recordIdOverride;
+          } else {
+            const seedRecord: Record<string, any> | undefined = rowHasValue
+              ? rowRecord
+              : ((!action.objectName || action.objectName === objectName
+                  ? (pageRecord as Record<string, any> | undefined)
+                  : undefined) ?? rowRecord);
+            const seed = resolveRecordIdParamSeed(action, seedRecord);
+            if (seed.error) return { success: false, error: seed.error };
+            if (seed.value !== undefined) body[action.recordIdParam] = seed.value;
+          }
         }
 
         // better-auth org endpoints resolve the session's active org; pass it


### PR DESCRIPTION
Fixes #4669

## The defect

`RecordDetailView.tsx`'s `type: 'api'` action handler seeded a declared
`recordIdParam` with `if (rowValue != null) body[param] = rowValue;` and a
silent `else`. When the record couldn't supply the key, the parameter was
dropped and the request went out anyway — a backend that reads a missing
selector as "match nothing" then answers success for having changed nothing.

Same defect class as objectstack#8018, whose general half landed at the
`useConsoleActionRuntime` call site in #4670 (merged this morning). That PR
deliberately left this call site untouched because it was held by an
in-flight sibling (objectstack#8499, now merged test-only and clear).

## The fix

Routes the seed through the shared `resolveRecordIdParamSeed` helper
(`@object-ui/core`, read-only import — no core changes), same as #4670:

```ts
const seed = resolveRecordIdParamSeed(action, seedRecord);
if (seed.error) return { success: false, error: seed.error };
if (seed.value !== undefined) body[action.recordIdParam] = seed.value;
```

Also drops the `(action as any).recordIdField` cast per the issue's note —
`recordIdField` is a declared `ActionDef` field (`ActionRunner.ts:407`), so
the cast was unneeded and was hiding the read from
`check-action-forward-parity.mjs`'s AST-based extractor.

### One deviation from the issue's one-line reproduction, worth flagging

This call site's actual code (`origin/main`, not the issue's simplified
snippet) has two extra sources beyond the row that the simpler
`useConsoleActionRuntime` call site #4670 touched never had:

```ts
const rowValue = rowRecord?.[rowField] ?? (action as any).recordId
  ?? (!action.objectName || action.objectName === objectName ? (pageRecord as any)?.[rowField] : undefined);
```

- a literal `recordId` override (not a declared `ActionDef` field — nothing
  in this repo's metadata sets it today, confirmed by grep across both
  repos' `.ts/.tsx` sources for `.recordId` as a property write);
- the same page-record fallback `interpolationRecord` (a few lines above)
  uses for `{field}` URL-token interpolation on `record_header` actions
  dispatched with no stashed `_rowRecord`.

Naively swapping in `resolveRecordIdParamSeed(action, rowRecord)` verbatim
(the issue's literal suggestion) would have silently dropped the
page-record fallback: `resolveRecordIdParamSeed(action, undefined)`
returns `{}` (no error, no value) by design — its docstring calls "no row
record at all" not its business — so a `record_header` action seeded from
`pageRecord` today would go back to being **silently** under-specified,
the exact bug this card closes, just moved rather than fixed.

The implementation preserves the original three-source priority (row →
literal override → page record) and only asks the helper to decide — and
word — the refusal once every source has been tried:

```ts
const rowHasValue = !!rowRecord && rowRecord[rowField] != null;
if (!rowHasValue && recordIdOverride != null) {
  body[action.recordIdParam] = recordIdOverride;
} else {
  const seedRecord = rowHasValue
    ? rowRecord
    : ((!action.objectName || action.objectName === objectName
        ? pageRecord
        : undefined) ?? rowRecord);
  const seed = resolveRecordIdParamSeed(action, seedRecord);
  if (seed.error) return { success: false, error: seed.error };
  if (seed.value !== undefined) body[action.recordIdParam] = seed.value;
}
```

(`seedRecord`'s actual declared type in the source is a `Record` of string
keys to `any`, matching `rowRecord`'s own type a few lines up — trimmed
from the snippet above only because this platform's body sanitizer eats a
bare `<` + letter at rest, generics included.)

Verified equivalent to the original for every input combination (worked
through by hand, then pinned by the new test file's 6 cases, including the
page-record-fallback and literal-override cases specifically). No decision
was needed — this is straight behavior-preservation, not an ambiguity in
what "correct" means — but calling it out since it's the one place this PR
is not a literal one-line drop-in.

## Tests

New `RecordDetailView.recordIdParamSeed.test.tsx` (6 cases): absent-key
refusal, null-value refusal, happy path, page-record fallback (no
`_rowRecord` stashed), literal `recordId` override, and an action declaring
no `recordIdParam` left alone. Mirrors #4670's test idiom and the sibling
`RecordDetailView.headerApiInterpolation.test.tsx` harness (same
`ActionProvider` handler-capture pattern).

Reverse verification, direction predicted before running (red, per the
standard pattern): reverted `RecordDetailView.tsx` to `origin/main`'s
version from the committed fix, re-ran the three test files — exactly the
2 new refusal tests failed, the other 4 new cases and both sibling files
(6 tests) stayed green, matching prediction. Restored via
`git checkout claude/issue-4669-recordidparam-seed -- <path>`
(`git status --porcelain` empty afterward); re-ran green (12/12).

## Verification, all at `6f07d682a` (final commit)

| Check | Result |
|---|---|
| Dependency closure build: `pnpm --filter '@object-ui/app-shell^...' build` | success |
| `pnpm --filter @object-ui/app-shell run type-check` | clean, 0 errors |
| `pnpm exec vitest run --maxWorkers=2` — `RecordDetailView.recordIdParamSeed.test.tsx`, `RecordDetailView.headerApiInterpolation.test.tsx`, `RecordDetailView.modalDispatch.test.tsx` | **12/12 passed** |
| `pnpm exec eslint --quiet` on the two changed source files | 0 errors |
| `node scripts/check-action-forward-parity.mjs` — run **before** (file reverted to `origin/main`) and **after** the fix | identical both times: `5 surfaces checked against 40 runtime-read keys from 4 consumers; 19 justified omissions, 7 known gaps` — gate-neutral, as the issue predicted |
| `node scripts/check-changeset-presence.mjs` | 1 changeset declared |
| `node scripts/check-changeset-no-major.mjs` | no `major` bump |
| `node scripts/check-control-bytes.mjs` | 4200 files scanned |

Changeset: `.changeset/four-plans-refuse.md` (`@object-ui/app-shell: patch`
— core is untouched, so only app-shell bumps).

## Scope boundaries

- No `@object-ui/core` edits — `resolveRecordIdParamSeed` consumed
  read-only, per the dispatch's explicit boundary.
- `ActionParamDialog.tsx`, the core evaluator region (#4640), core
  chart-series (#4508), and metadata-admin views (#4644) — untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_
