### PR TITLE
fix(charts): build the cartesian drill event from the payload recharts 3 actually sends

### DIFF
--- a/.changeset/silly-jars-drill.md
+++ b/.changeset/silly-jars-drill.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+Cartesian chart clicks report the clicked series and value again
+
+objectui#4672. `AdvancedChartImpl`'s chart-level click handler built its drill
+event from `payload.activePayload[0]` — a **recharts 2** field. This package is
+on recharts 3, which hands a chart-level `onClick` a `MouseHandlerDataParam`:
+`{ activeCoordinate, activeDataKey, activeIndex, activeLabel, activeTooltipIndex,
+isTooltipActive }`, and nothing else. `activePayload` appears nowhere in the
+shipped library, so the read was `undefined` on **every** cartesian click and
+every bar / line / area drill event carried `series: undefined, value: undefined`.
+Nothing went red: the payload is typed `any` at the call site, and every existing
+drill test either calls the pure lookup directly or stubs the chart.
+
+The handler now works from the payload recharts 3 actually sends:
+
+- **The value** is read off the clicked row — `data[activeTooltipIndex]`, the
+  array this component was given — for the resolved measure, the same way the
+  bucket identity has been read since objectui#4508.
+- **The series** comes from `activeDataKey` when the payload carries one, and
+  otherwise from the chart's own series list when it plots exactly one series,
+  where the clicked column can belong to nothing else.
+- **A click with no active tick** (the plot margins, an axis label) resolves to
+  no row instead of to bucket zero. recharts reports a **null** index there, not
+  an absent one, and `Number(null)` is `0` — so such a click used to drill the
+  first bucket's records. That is a wrong drill, not a dead one.
+
+A drill on a single-measure chart therefore names its measure and carries its
+value again — `resolveDrillTitle` composes the drawer title from them, and an
+authored drill filter can reference `${event.value}`.
+
+**Still open, deliberately:** a chart plotting several series under the default
+SHARED cursor. Measured against recharts 3.10.1, an axis interaction is
+dispatched with `activeDataKey` hard-coded `undefined` (bar, line and area
+alike, on the mark and on empty plot area), so the payload names no series at
+all — and a pivoted dataset chart's drill lookup requires one. The series is
+left unresolved rather than guessed: naming a series the user did not click
+drills to another group's records, which is worse than the dead click. Resolving
+it needs the clicked mark rather than this payload; objectui#4672 carries that
+half.

--- a/packages/plugin-charts/src/AdvancedChartImpl.cartesianClickPayload.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.cartesianClickPayload.test.tsx
@@ -1,0 +1,326 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#4672 — the CARTESIAN click event, pinned against the payload
+ * recharts 3 actually sends.
+ *
+ * The handler used to read `payload.activePayload[0]` for both the clicked
+ * series and its value. That is a recharts 2 field: recharts 3 hands a
+ * chart-level `onClick` a `MouseHandlerDataParam`, which is exactly
+ * `{ activeCoordinate, activeDataKey, activeIndex, activeLabel,
+ * activeTooltipIndex, isTooltipActive }` — no payload array, no row, no value.
+ * So the read was `undefined` on every click, silently: the call site types the
+ * payload `any`, so nothing went red, and every cartesian drill event carried
+ * `series: undefined, value: undefined`.
+ *
+ * Nothing covered that seam. The existing drill tests either call the pure
+ * lookup (`findChartSeriesRow`) directly or assert the transform, so all of
+ * them stayed green while the one thing between them — what the chart library
+ * hands the handler — was wrong. This file works from that payload only:
+ * through a real click on a real recharts chart where the DOM can carry one,
+ * and through the handler the component hands recharts where it cannot.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
+import { BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import {
+  buildChartSeries,
+  CHART_BUCKET_ID_KEY,
+  NULL_CATEGORY_LABEL,
+  type ChartSegmentClickEvent,
+} from '@object-ui/core';
+
+// The handler AdvancedChartImpl hands the recharts chart element, captured as
+// the component passes it. Feeding it a payload is not a re-derivation of the
+// component's logic (which is what a hand-rolled `rowAt()` helper would be) —
+// it is the component's own callback, invoked the way recharts invokes it.
+const seam = vi.hoisted(() => ({ onClick: undefined as undefined | ((p: any) => void) }));
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+    BarChart: (props: any) => {
+      seam.onClick = props.onClick;
+      return React.createElement(actual.BarChart, props);
+    },
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(() => {
+  cleanup();
+  seam.onClick = undefined;
+});
+
+/**
+ * recharts throttles pointer moves through `requestAnimationFrame`
+ * (`eventSettingsSlice`: `throttleDelay: 'raf'`), and the click reads the
+ * tooltip state that move left behind. Without flushing the frame the chart
+ * reports `activeTooltipIndex: null` for every click — a real browser never
+ * sees that because the move lands a frame before the click.
+ */
+const flushFrame = async () => {
+  await act(async () => {
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    await new Promise<void>((r) => setTimeout(r, 0));
+  });
+};
+
+const clickChartAt = async (el: Element, clientX: number, clientY: number) => {
+  fireEvent.mouseMove(el, { clientX, clientY });
+  await flushFrame();
+  fireEvent.click(el, { clientX, clientY });
+  await flushFrame();
+};
+
+const ROWS = [
+  { status: 'Open', est_hours: 10 },
+  { status: 'Done', est_hours: 30 },
+];
+
+describe('AdvancedChartImpl — a cartesian click reports the clicked series and value (objectui#4672)', () => {
+  it('carries the series and the measure value through a REAL click on a real recharts 3 bar', async () => {
+    const { data, xAxisKey, series } = buildChartSeries(ROWS, ['status'], ['est_hours']);
+    // Stated rather than assumed: one measure, so one plotted series.
+    expect(series.map((s: any) => s.dataKey)).toEqual(['est_hours']);
+
+    const clicks: ChartSegmentClickEvent[] = [];
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={data as any}
+        xAxisKey={xAxisKey}
+        series={series as any}
+        isAnimationActive={false}
+        onChartClick={(ev) => clicks.push(ev)}
+      />,
+    );
+
+    const bars = container.querySelectorAll('.recharts-rectangle');
+    expect(bars.length).toBe(2);
+    const second = bars[1] as SVGElement;
+    const x = Number(second.getAttribute('x')) + Number(second.getAttribute('width')) / 2;
+    const y = Number(second.getAttribute('y')) + Number(second.getAttribute('height')) / 2;
+
+    await clickChartAt(second, x, y);
+
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0].category).toBe('Done');
+    // Both of these were `undefined` for every cartesian click before this fix.
+    expect(clicks[0].series).toBe('est_hours');
+    expect(clicks[0].value).toBe(30);
+  });
+
+  it('reads the value off the row the index names, not off the event', async () => {
+    // The same click on the FIRST bucket — the value must follow the bucket,
+    // which is the whole reason it is read out of `data[activeTooltipIndex]`.
+    const { data, xAxisKey, series } = buildChartSeries(ROWS, ['status'], ['est_hours']);
+    const clicks: ChartSegmentClickEvent[] = [];
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={data as any}
+        xAxisKey={xAxisKey}
+        series={series as any}
+        isAnimationActive={false}
+        onChartClick={(ev) => clicks.push(ev)}
+      />,
+    );
+    const first = container.querySelectorAll('.recharts-rectangle')[0] as SVGElement;
+    const x = Number(first.getAttribute('x')) + Number(first.getAttribute('width')) / 2;
+    const y = Number(first.getAttribute('y')) + Number(first.getAttribute('height')) / 2;
+
+    await clickChartAt(first, x, y);
+
+    expect(clicks[0].category).toBe('Open');
+    expect(clicks[0].value).toBe(10);
+  });
+});
+
+/**
+ * The payload arms, fed the shapes recharts 3 was MEASURED to send (recharts
+ * 3.10.1, `state/externalEventsMiddleware.js` assembling the object from the
+ * tooltip selectors). The per-series-cursor payload below is a verbatim capture
+ * of a real click on a `Tooltip shared={false}` bar chart; the shared-cursor
+ * one is a verbatim capture of the same click with the default cursor.
+ */
+describe('AdvancedChartImpl — the cartesian handler over the recharts 3 payload arms', () => {
+  const renderPivoted = (onChartClick: (ev: ChartSegmentClickEvent) => void) => {
+    // 2 dimensions, 1 measure — the pivot that ADR-0021 introduced and the
+    // shape objectui#4672 reports dead: the second dimension becomes the
+    // series, so the drill lookup REQUIRES the series to find its row.
+    const raw = [
+      { status: 'Open', priority: 'High', est_hours: 3 },
+      { status: 'Open', priority: 'Low', est_hours: 5 },
+      { status: 'Done', priority: 'High', est_hours: 7 },
+      { status: 'Done', priority: 'Low', est_hours: 11 },
+    ];
+    const { data, xAxisKey, series } = buildChartSeries(raw, ['status', 'priority'], ['est_hours']);
+    expect(series.map((s: any) => s.dataKey)).toEqual(['High', 'Low']);
+    render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={data as any}
+        xAxisKey={xAxisKey}
+        series={series as any}
+        isAnimationActive={false}
+        onChartClick={onChartClick}
+      />,
+    );
+    return series;
+  };
+
+  it('takes the series from `activeDataKey` when the payload carries one', () => {
+    const clicks: ChartSegmentClickEvent[] = [];
+    renderPivoted((ev) => clicks.push(ev));
+    expect(seam.onClick).toBeTypeOf('function');
+
+    // Captured from a real per-series-cursor click on recharts 3.10.1. Note
+    // the index arrives as a STRING — recharts dispatches `String(index)`.
+    seam.onClick!({
+      activeCoordinate: { x: 414.5, y: 145 },
+      activeDataKey: 'Low',
+      activeIndex: '1',
+      activeLabel: 'Done',
+      activeTooltipIndex: '1',
+      isTooltipActive: true,
+    });
+
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0].category).toBe('Done');
+    expect(clicks[0].series).toBe('Low');
+    // The measure value of THAT series in THAT bucket — read off the row.
+    expect(clicks[0].value).toBe(11);
+  });
+
+  it('leaves the series unresolved when the shared cursor names none — it does not guess one', () => {
+    const clicks: ChartSegmentClickEvent[] = [];
+    renderPivoted((ev) => clicks.push(ev));
+
+    // The same click under the DEFAULT (shared/axis) cursor these charts
+    // render: recharts dispatches axis interactions with `activeDataKey`
+    // hard-coded `undefined`, so the payload names no series at all.
+    seam.onClick!({
+      activeCoordinate: { x: 372.5, y: 200 },
+      activeDataKey: undefined,
+      activeIndex: '1',
+      activeLabel: 'Done',
+      activeTooltipIndex: '1',
+      isTooltipActive: true,
+    });
+
+    expect(clicks).toHaveLength(1);
+    // What IS known is still reported...
+    expect(clicks[0].category).toBe('Done');
+    // ...and the series is left open rather than filled with series[0], which
+    // would drill to another group's records — a WRONG drill, worse than the
+    // dead one. Resolving this needs the clicked mark, not this payload:
+    // objectui#4672's open half.
+    expect(clicks[0].series).toBeUndefined();
+    expect(clicks[0].value).toBeUndefined();
+  });
+
+  it('resolves no row at all when no tick is active, rather than bucket zero', () => {
+    // The fixture is the objectui#4508 collision — a stored value that spells
+    // the null bucket's label, beside a genuine null — because those are the
+    // buckets that carry an IDENTITY. That is what makes this assertion able to
+    // fail: over ordinary buckets, "bucket zero" and "no bucket" both report no
+    // identity, so a wrong row would pass unnoticed.
+    const { data, xAxisKey, series } = buildChartSeries(
+      [
+        { status: NULL_CATEGORY_LABEL, est_hours: 1 },
+        { status: null, est_hours: 2 },
+      ],
+      ['status'],
+      ['est_hours'],
+    );
+    expect((data[0] as any)[CHART_BUCKET_ID_KEY]).toBe('["(None)"]');
+
+    const clicks: ChartSegmentClickEvent[] = [];
+    render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={data as any}
+        xAxisKey={xAxisKey}
+        series={series as any}
+        isAnimationActive={false}
+        onChartClick={(ev) => clicks.push(ev)}
+      />,
+    );
+
+    // A click on the plot margins / an axis label. recharts reports a NULL
+    // index here, not an absent one — and `Number(null)` is 0, so a bare
+    // `Number()` read resolves this to the FIRST bucket and drills records the
+    // user never clicked.
+    seam.onClick!({
+      activeCoordinate: undefined,
+      activeDataKey: undefined,
+      activeIndex: null,
+      activeLabel: undefined,
+      activeTooltipIndex: null,
+      isTooltipActive: false,
+    });
+
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0].category).toBeUndefined();
+    expect(clicks[0].categoryId).toBeUndefined();
+    expect(clicks[0].value).toBeUndefined();
+  });
+});
+
+/**
+ * The measurement the open half rests on, kept executable.
+ *
+ * This one drives recharts DIRECTLY — no ObjectUI component in the way — so it
+ * pins a fact about the library rather than about our handler: under the
+ * shared (axis) cursor, a multi-series cartesian click reports an index and a
+ * label but NO `activeDataKey`. That is why the pivoted drill cannot be
+ * resolved from this payload, and it is the premise to re-measure when recharts
+ * is upgraded.
+ */
+describe('recharts 3 — what a shared-cursor cartesian click actually reports', () => {
+  it('reports an index and a label, and no series key', async () => {
+    const payloads: any[] = [];
+    const { container } = render(
+      <BarChart
+        width={480}
+        height={320}
+        data={[
+          { name: 'Open', a: 10, b: 20 },
+          { name: 'Done', a: 30, b: 40 },
+        ]}
+        onClick={(p: any) => payloads.push(p)}
+      >
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="a" isAnimationActive={false} />
+        <Bar dataKey="b" isAnimationActive={false} />
+      </BarChart>,
+    );
+    // The last rectangle is series `b` of the second category — a click landing
+    // squarely on one series' mark, not on shared empty space.
+    const rects = container.querySelectorAll('.recharts-rectangle');
+    const target = rects[rects.length - 1] as SVGElement;
+    const x = Number(target.getAttribute('x')) + Number(target.getAttribute('width')) / 2;
+    await clickChartAt(target, x, 200);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].activeLabel).toBe('Done');
+    expect(String(payloads[0].activeTooltipIndex)).toBe('1');
+    // Even though the click landed on series `b`'s bar.
+    expect(payloads[0].activeDataKey).toBeUndefined();
+    // And the recharts 2 field the handler used to read is gone entirely.
+    expect(payloads[0].activePayload).toBeUndefined();
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -96,6 +96,43 @@ const comparisonStyle = (s: any, kind: 'line' | 'area' | 'bar' | 'scatter') => {
   return { strokeOpacity, fillOpacity, strokeDasharray };
 };
 
+/**
+ * Which series did a CARTESIAN click land on? (objectui#4672)
+ *
+ * recharts 3 answers with `activeDataKey` on the chart-level click payload —
+ * but only when the interaction was dispatched by a graphical ITEM, which is
+ * the per-series cursor (`Tooltip shared={false}`). Under the SHARED (axis)
+ * cursor these charts render, the click is an AXIS interaction, and recharts
+ * dispatches those with `activeDataKey: undefined` hard-coded
+ * (`recharts/lib/state/mouseEventsMiddleware.js`) — the cursor spans every
+ * series at that tick, so the payload names no single one. Measured against
+ * the installed recharts 3.10.1 for bar, line and area, clicking a mark and
+ * empty plot area alike: the key is absent in every shared-cursor case.
+ *
+ * So take the payload's answer when it has one; failing that, the only click
+ * with an unambiguous answer is on a chart plotting exactly ONE series, where
+ * the clicked column can belong to nothing else. A multi-series chart under
+ * the shared cursor is left UNRESOLVED rather than guessed: naming a series
+ * the user did not click drills to the wrong records, which is worse than the
+ * dead click. Resolving that half needs a different mechanism (an item-level
+ * handler, which changes what a cartesian drill means) — it is the open half
+ * of objectui#4672, deliberately not answered here.
+ */
+const resolveClickedSeriesKey = (
+  activeDataKey: unknown,
+  plotted: NormalizedSeries[],
+): string | undefined => {
+  if (typeof activeDataKey === 'string' || typeof activeDataKey === 'number') {
+    const fromPayload = String(activeDataKey);
+    if (fromPayload !== '') return fromPayload;
+  }
+  if (plotted.length === 1) {
+    const only = plotted[0]?.dataKey;
+    if (only != null && String(only) !== '') return String(only);
+  }
+  return undefined;
+};
+
 export interface AdvancedChartImplProps {
   /**
    * Chart family. `combo` is renderer-local and rarely needs to be passed:
@@ -307,18 +344,33 @@ function AdvancedChartImplInner({
   // objectui#4508 identity) is read out of OUR OWN array rather than out of the
   // event: nothing in the payload can be stale or copied, because none of it
   // came from recharts.
+  //
+  // The measure VALUE is read the same way, off that row — for the same reason,
+  // and because the payload has no value either. (recharts 2 carried both in an
+  // `activePayload` array; recharts 3 dropped the field, so the objectui#4672
+  // read of it was `undefined` on every click and every cartesian drill lost
+  // its series and its value.)
+  //
+  // WHICH SERIES was clicked is the one thing the payload cannot always answer
+  // — see the resolver below.
   const handleCartesianClick = React.useCallback((payload: any) => {
     if (!onChartClick || !payload) return;
-    const ap = Array.isArray(payload.activePayload) ? payload.activePayload[0] : undefined;
-    const idx = Number(payload.activeTooltipIndex ?? payload.activeIndex);
+    // A click with no active tick (the plot margins, an axis label) reports a
+    // NULL index, not an absent one — and `Number(null)` is 0, which would
+    // resolve to bucket ZERO and drill the wrong bucket. Only a real index
+    // selects a row.
+    const rawIdx = payload.activeTooltipIndex ?? payload.activeIndex;
+    const idx = rawIdx == null ? Number.NaN : Number(rawIdx);
     const row = Number.isInteger(idx) && idx >= 0 ? data[idx] : undefined;
+    const clickedKey = resolveClickedSeriesKey(payload.activeDataKey, series);
+    const cell = clickedKey != null && row ? (row as Record<string, any>)[clickedKey] : undefined;
     onChartClick({
       category: payload.activeLabel != null ? String(payload.activeLabel) : undefined,
       categoryId: chartRowBucketId(row),
-      series: ap?.dataKey ? String(ap.dataKey) : undefined,
-      value: typeof ap?.value === 'number' ? ap.value : undefined,
+      series: clickedKey,
+      value: typeof cell === 'number' ? cell : undefined,
     });
-  }, [onChartClick, data]);
+  }, [onChartClick, data, series]);
 
   // A pie sector's `payload` is a SPREAD COPY of the data row (recharts builds
   // it as `{...entry, ...cellProps}`), which is precisely why the bucket


### PR DESCRIPTION
Part of #4672

`Part of`, not `Fixes`: the card's headline harm — the dead click on a PIVOTED
dataset chart — is **not** resolved here, and the card stays open for it. What is
resolved is everything the recharts 3 payload can answer; the half it cannot is
measured, argued and escalated below.

## What was wrong

`AdvancedChartImpl.handleCartesianClick` built its drill event from
`payload.activePayload[0]` — a **recharts 2** field. This package is on recharts
3.10.1, whose chart-level `onClick` receives a `MouseHandlerDataParam`:
`{ activeCoordinate, activeDataKey, activeIndex, activeLabel, activeTooltipIndex,
isTooltipActive }` and nothing else. Re-verified on `origin/main` at
`9ce096fb0`: the read is still there, and `activePayload` appears nowhere in the
shipped `lib/` or `types/` except an unrelated local in `component/Cursor.js`. So
the read was `undefined` on every cartesian click, and every bar / line / area
drill event carried `series: undefined, value: undefined`. Nothing went red — the
payload is typed `any` at the call site, and every existing drill test either
calls the pure lookup directly or stubs the chart component.

## What this PR changes

- **The value** is read off the clicked row — `data[activeTooltipIndex]`, this
  component's own array — for the resolved measure, the same way the bucket
  identity has been read since #4508.
- **The series** comes from `activeDataKey` when the payload carries one, and
  otherwise from the chart's own series list when it plots exactly **one**
  series, where the clicked column can belong to nothing else.
- **A click with no active tick** now resolves to no row instead of to bucket
  zero — see "Adjacent fix" below.

## The measurement (recharts 3.10.1, as installed)

Driving real recharts charts in the DOM and reading the payload the chart-level
handler is actually given:

| case | `activeDataKey` | `activeTooltipIndex` |
|---|---|---|
| multi-series bar, default (shared) cursor, click on a series' own bar | absent | `"1"` |
| multi-series bar, shared cursor, click on empty plot area | absent | `"0"` |
| single-series bar, shared cursor | absent | `"1"` |
| multi-series line, shared cursor | absent | `"1"` |
| multi-series area, shared cursor | absent | `"1"` |
| no `Tooltip` element at all | absent | `"1"` |
| multi-series bar, per-series cursor (`Tooltip shared={false}`) | `"b"` | `"1"` |

The mechanism, not just the observation: a chart-level cartesian click is an
**axis** interaction, and recharts dispatches those with `activeDataKey:
undefined` hard-coded — `setMouseClickAxisIndex({ activeIndex, activeDataKey:
undefined, … })` in `lib/state/mouseEventsMiddleware.js`, mirrored for hover in
`setMouseOverAxisIndex`. Only an **item** interaction carries a `dataKey`
(`useMouseClickItemDispatch` in `lib/context/tooltipContext.js`), and the
selector only reads item state when the tooltip event type is `item`, i.e. when
`shared={false}`. These charts render the shared cursor. recharts says so itself
in `lib/cartesian/Bar.js`: *"With shared Tooltip, the activeDataKey is
undefined."*

So the card's premise held with a **wider** radius than filed: `activeDataKey` is
not merely ambiguous under a shared tooltip, it is absent for every cartesian
click these charts produce, single-series included.

Also measured (the index arrives as a **string**, `"1"` not `1`, and is **null**
— not absent — when no tick is active). Both are pinned in the tests.

## What is still open (the reason this is `Part of`)

A chart plotting several series under the shared cursor: the payload names no
series, and the pivoted drill lookup requires one —
`findChartSeriesRow`'s pivot arm is `String(r[gDim] ?? '') === s`. Measured on
the card's repro shape (`dimensions: ['status','priority'], values:
['est_hours']`): `series=undefined` returns `-1` (the dead click),
`series='Low'` returns `3`, `series='High'` returns `2`.

The series is left **unresolved** rather than guessed. Filling it with
`series[0]` would turn a dead click into a click that drills **another group's**
records — a wrong answer is worse than no answer, and the user did click
something specific. Resolving it needs the clicked **mark** (an item-level
`onClick` on each `Bar` / `Line` / `Area`), which changes what a cartesian drill
means — hit targets, the plot-area fallback, double-fire suppression. That is a
contract decision, not an implementation detail, so it is escalated on the card
rather than guessed here.

## Adjacent fix, named (same handler, same defect class)

A click with no active tick — plot margins, an axis label — reports
`activeTooltipIndex: null`, and `Number(null)` is `0`. The index read (landed by
#4677) therefore resolved such a click to **bucket zero** and drilled the first
bucket's records. Evidence it is wrong rather than intended:
`AdvancedChartImpl.bucketIdentity.test.tsx` states the intended behaviour in
prose — *"No active tick (a click on empty plot area) resolves to no identity
rather than to bucket zero"* — but asserts it with `undefined`, which takes the
`NaN` path and never exercises `null`, which is what recharts actually sends.
Fixed in place (same file, same handler, same gate families, mechanical): only a
non-null index selects a row. Pinned by test 5 below.

## Tests

New: `packages/plugin-charts/src/AdvancedChartImpl.cartesianClickPayload.test.tsx`

1. A **real click on a real recharts 3 bar** through `AdvancedChartImpl` — no
   stub between the click and the assertion — reports `series: 'est_hours'` and
   `value: 30`.
2. The same click on the first bucket reports `value: 10` (the value follows the
   bucket, which is why it is read out of `data[activeTooltipIndex]`).
3. The `activeDataKey` arm, over a payload captured verbatim from a real
   per-series-cursor click, on a pivoted chart: `series: 'Low'`, `value: 11`.
4. The shared-cursor arm on the same chart: category reported, series left
   `undefined` — the non-guessing contract, pinned so a later "helpful" default
   cannot land silently.
5. No active tick (`activeTooltipIndex: null`) over the #4508 collision fixture
   — the only fixture where "bucket zero" and "no bucket" are distinguishable —
   reports no identity.
6. A pin on **recharts itself**, driving it directly: a shared-cursor
   multi-series click reports an index and a label and **no** `activeDataKey`,
   and no `activePayload` at all. This is the premise the open half rests on, and
   the thing to re-measure on a recharts upgrade.

The tests flush a `requestAnimationFrame` between the pointer move and the click,
because recharts throttles pointer moves through rAF (`eventSettingsSlice`:
`throttleDelay: 'raf'`) and the click reads the state that move left behind. A
real browser never sees the un-flushed shape; a test that skips it measures
`activeTooltipIndex: null` for every click and proves nothing.

**Reverse verification** (direction predicted before running: red on 1, 2, 3, 5;
green on 4 and 6, since neither depends on this change). Restoring the
`activePayload` handler on top of the new tests: `Tests 4 failed | 2 passed (6)`
— exactly those four, with test 5 failing as `expected '["(None)"]' to be
undefined`, i.e. the wrong-bucket drill made visible. Restored byte-identically
from the commit (empty `git diff HEAD`) and re-run green.

## Local verification — all at `0440c7654` (this PR's head)

```
pnpm --filter '@object-ui/plugin-charts^...' build          → dependency closure built first
pnpm --filter @object-ui/plugin-charts run type-check       → tsc --noEmit, clean
pnpm exec vitest run packages/plugin-charts/                → 27 files, 196 tests, all passed
pnpm exec vitest run packages/plugin-dashboard/             → 57 files, 455 tests, all passed
pnpm exec eslint --quiet [the two changed source files]     → clean
node scripts/check-changeset-presence.mjs                   → 1 changeset for 2 changed source files
pnpm run check:control-bytes                                → OK (4208 tracked text files)
```

`plugin-dashboard` is included because `DatasetWidget.handleChartDrill` is this
event's production consumer. It needed no change: it already reads `ev.series`
and `ev.categoryId`, and the fix only changes what reaches it.

## Scope

`AdvancedChartImpl.tsx` (the `handleCartesianClick` region and one module-local
helper beside it) plus the new test and the changeset. No core files — the
`ChartSegmentClickEvent` contract is unchanged and needed no new field. The pie,
funnel, scatter, treemap and sankey paths are untouched; they build their events
from the clicked entry, not from this payload.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_