### PR TITLE
fix(core): draw a null second-dimension group instead of orphaning its measure

### DIFF
--- a/.changeset/olive-moons-gather.md
+++ b/.changeset/olive-moons-gather.md
@@ -1,0 +1,54 @@
+---
+'@object-ui/core': minor
+---
+
+Draw a null second-dimension group instead of carrying its measure invisibly
+
+objectui#4673. `buildChartSeries`' pivot branch kept the pre-objectui#4466
+answer on the SECOND dimension: it bucketed groups by `String(row[groupKey] ??
+'')` behind a `gId !== ''` gate, so a group whose second dimension is `null`,
+`undefined` or `''` never joined the series list — while the line below the
+gate still wrote its measure into the emitted row under the `''` key. The
+number was in the data and bound to no mark, which is #4466's harm verbatim one
+dimension over: the chart understated its own data without saying so.
+
+Measured on the card's repro — `GROUP BY status, priority` over a Backlog with
+5 hours at High priority and 40 hours at no priority — the transform emitted
+`{status: 'Backlog', High: 5, '': 40}` with a single `High` series, and the
+renderer drew exactly ONE bar. The 40 hours were present in the row, scaled for
+on the y-axis, and painted on nothing.
+
+Two such groups were worse than unbound: `null` and `''` both key `''`, so the
+later group silently overwrote the earlier one's measure and one of the two
+numbers did not survive the transform at all.
+
+**A known-empty group now draws; an unprojected key still refuses.** That split
+is the doctrine the first dimension already used (objectui#4466 versus
+`hasNoCategoryKey`, framework#4033), and it now answers the same way on both
+dimensions. Concretely, a row that does not carry the group key at all gets no
+bucket and contributes no column, where it previously wrote its measure under
+`''`.
+
+`null` and `''` are two different groups with two series, following
+objectui#4508's ruling on the first dimension.
+
+**The series key is collision-safe, not merely unlikely to collide.** Unlike an
+axis bucket's private map key, a series key is a column of the emitted row and
+the `dataKey` a renderer binds to, so it has to be unique within that row. A
+group keys its column by its own display label — leaving an ordinary pivot's
+rows, series, legend, tooltip and drill title exactly as they were — unless
+that label cannot name it: shared with another group (a stored value spelling
+the null bucket's label), reserved by the row itself (the x-axis column, the
+identity carrier), or equal to some group's identity. Those key by identity
+instead, which no other group has. Because no surviving label is any group's
+identity, the two key spaces cannot meet.
+
+Drill-through follows the same assignment: a clicked series key resolves back
+to the group IDENTITY it names, and rows are matched on that. The previous
+`String(r[gDim] ?? '')` comparison was the display-string matching
+objectui#4508 removed on the x-axis — it spelled a null group and an
+empty-string group alike, so the empty-string group's segment resolved to the
+null group's records rather than its own.
+
+No renderer change was needed: the null group's series carries the same
+`nullCategoryLabel` the renderers already pass for the first dimension.

--- a/packages/core/src/utils/chart-series.nullCategory.test.ts
+++ b/packages/core/src/utils/chart-series.nullCategory.test.ts
@@ -38,6 +38,11 @@
  * key is untouched; only the display value is labelled. The drill half is
  * pinned at the bottom of this file, with the measurement behind it.
  *
+ * objectui#4673 is the same defect one dimension over, and the last of the four:
+ * the pivot's SECOND dimension kept the pre-#4466 answer (`gId !== ''`, drop
+ * it) while still writing the dropped group's measure into the bucket. The
+ * blocks at the bottom of this file are its own.
+ *
  * objectui#4508 then answers what #4497 filed instead of widening into: that
  * map KEY was the DISPLAY string, so it could not tell a null group from an
  * empty-string one, nor from a record whose stored value spells the bucket
@@ -614,5 +619,388 @@ describe('chart bucket identity — the encoder and its carrier (objectui#4508)'
         bucketId: '["nobody"]',
       }),
     ).toBe(-1);
+  });
+});
+
+/**
+ * objectui#4673 — the pivot's SECOND dimension, the last of the four cards.
+ *
+ * #4466 / #4497 / #4508 are all about the FIRST dimension's bucket. The series
+ * axis kept the pre-#4466 answer the whole time: `String(row[groupKey] ?? '')`
+ * behind a `gId !== ''` gate, so a null (or empty-string) group never joined
+ * `seriesKeys` — while the very next line still wrote its measure into the
+ * bucket under the `''` key. The number was in the emitted row and no series
+ * bound to it, which is #4466's harm verbatim: the chart understated its own
+ * data without saying so.
+ *
+ * The card's measured repro is the headline case below. The ruled direction
+ * (delegated ruling on #4673, 2026-08-15) is that a KNOWN-EMPTY group draws,
+ * exactly as on the first dimension, while an unprojected key still refuses —
+ * "known to be empty" and "cannot know" are different facts and keep their
+ * different answers on both dimensions.
+ */
+describe('buildChartSeries — a null SECOND-dimension group becomes a series (objectui#4673)', () => {
+  it('binds the card’s 40-hour bar to a series instead of orphaning it', () => {
+    // The card, verbatim. Pre-fix: `data: [{status:'Backlog', High:5, '':40}]`
+    // with `series: [{dataKey:'High'}]` — the 40 present and on no mark.
+    const r = buildChartSeries(
+      [
+        { status: 'Backlog', priority: 'High', est_hours: 5 },
+        { status: 'Backlog', priority: null, est_hours: 40 },
+      ],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([
+      { dataKey: 'High', label: 'High' },
+      { dataKey: NULL_CATEGORY_LABEL, label: NULL_CATEGORY_LABEL },
+    ]);
+    expect(r.data).toEqual([{ status: 'Backlog', High: 5, [NULL_CATEGORY_LABEL]: 40 }]);
+    // The property that was violated, stated as itself: every column holding a
+    // measure is a column some series draws.
+    const bound = new Set(r.series.map((s) => s.dataKey));
+    const measureColumns = Object.keys(r.data[0]).filter((k) => k !== r.xAxisKey);
+    expect(measureColumns.every((k) => bound.has(k))).toBe(true);
+  });
+
+  it('buckets an undefined second-dimension value the same way', () => {
+    const r = buildChartSeries(
+      [{ status: 'Backlog', priority: undefined, est_hours: 7 }],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([{ dataKey: NULL_CATEGORY_LABEL, label: NULL_CATEGORY_LABEL }]);
+    expect(r.data).toEqual([{ status: 'Backlog', [NULL_CATEGORY_LABEL]: 7 }]);
+  });
+
+  it('draws the all-null second dimension rather than an empty grouped chart', () => {
+    const r = buildChartSeries(
+      [
+        { status: 'Backlog', priority: null, est_hours: 40 },
+        { status: 'Done', priority: null, est_hours: 12 },
+      ],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    // Pre-fix: two bucket rows carrying 40 and 12 under `''`, and NO series at
+    // all — the axis drawn, the numbers scaled for, nothing painted.
+    expect(r.series).toHaveLength(1);
+    expect(r.data).toEqual([
+      { status: 'Backlog', [NULL_CATEGORY_LABEL]: 40 },
+      { status: 'Done', [NULL_CATEGORY_LABEL]: 12 },
+    ]);
+  });
+
+  it('takes the caller-supplied (localized) label, from the same one option', () => {
+    const r = buildChartSeries(
+      [{ status: 'Backlog', priority: null, est_hours: 40 }],
+      ['status', 'priority'],
+      ['est_hours'],
+      null,
+      { nullCategoryLabel: '(未指定)' },
+    );
+    expect(r.series).toEqual([{ dataKey: '(未指定)', label: '(未指定)' }]);
+    expect(r.data).toEqual([{ status: 'Backlog', '(未指定)': 40 }]);
+  });
+
+  it('makes null and empty-string TWO series — objectui#4508’s collision 1, on this axis', () => {
+    // The ruling routes the `''`-vs-null question to #4508's answer: they are
+    // different groups. `chartBucketId` spells them `[null]` and `[""]`, and
+    // each keys its own column, so both measures reach a mark of their own.
+    const r = buildChartSeries(
+      [
+        { status: 'Backlog', priority: null, est_hours: 40 },
+        { status: 'Backlog', priority: '', est_hours: 5 },
+      ],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([
+      { dataKey: NULL_CATEGORY_LABEL, label: NULL_CATEGORY_LABEL },
+      { dataKey: '', label: '' },
+    ]);
+    // Pre-fix BOTH wrote to `''` — the second silently overwrote the first, so
+    // one group's number was not merely unbound, it was gone.
+    expect(r.data).toEqual([{ status: 'Backlog', [NULL_CATEGORY_LABEL]: 40, '': 5 }]);
+  });
+
+  it('never mutates the caller rows — drill-through reads the raw null', () => {
+    const rows = [{ status: 'Backlog', priority: null, est_hours: 40 }];
+    buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+    expect(rows[0].priority).toBeNull();
+    expect(rows.every((row) => !(CHART_BUCKET_ID_KEY in row))).toBe(true);
+  });
+
+  it('gives a row that lacks the SECOND dimension key no series and no column', () => {
+    // The other half of the doctrine, on the other dimension: "cannot know"
+    // refuses (framework#4033). Bucketing it would say these records have no
+    // priority, when what happened is that priority was never projected.
+    //
+    // Pre-fix this row's measure went into the bucket under `''`, which is now
+    // the empty-string GROUP's column — so keeping the old write would hand an
+    // unprojected row's number to a real group's bar.
+    const r = buildChartSeries(
+      [
+        { status: 'Backlog', priority: '', est_hours: 5 },
+        { status: 'Backlog', est_hours: 40 },
+      ],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([{ dataKey: '', label: '' }]);
+    expect(r.data).toEqual([{ status: 'Backlog', '': 5 }]);
+  });
+});
+
+describe('buildChartSeries — second-dimension must-not-change (objectui#4673)', () => {
+  it('leaves an ordinary pivot’s series and rows byte-identical', () => {
+    const rows = [
+      { status: 'Backlog', priority: 'High', est_hours: 5 },
+      { status: 'Backlog', priority: 'Low', est_hours: 3 },
+      { status: 'Done', priority: 'High', est_hours: 24 },
+    ];
+    const r = buildChartSeries(rows, ['status', 'priority'], ['est_hours']);
+    // Keys are display strings wherever a display string names the group — the
+    // legend, the tooltip and the drill title all read the group's own text.
+    expect(r.series).toEqual([
+      { dataKey: 'High', label: 'High' },
+      { dataKey: 'Low', label: 'Low' },
+    ]);
+    expect(r.data).toEqual([
+      { status: 'Backlog', High: 5, Low: 3 },
+      { status: 'Done', High: 24 },
+    ]);
+  });
+
+  it('keeps an empty pivot result empty — no phantom null series', () => {
+    const r = buildChartSeries([], ['status', 'priority'], ['est_hours']);
+    expect(r.series).toEqual([]);
+    expect(r.data).toEqual([]);
+  });
+});
+
+/**
+ * The card's binding constraint: a series key is a ROW KEY and a renderer
+ * `dataKey`, so unlike an axis bucket's private map key it has to be unique
+ * within the emitted row. These are the cases where the group's own display
+ * string cannot be that key, and what it falls back to instead.
+ */
+describe('the second-dimension series key is collision-safe (objectui#4673)', () => {
+  it('separates a stored value that literally spells the null label', () => {
+    // objectui#4508's collision 2, on the series axis: two DIFFERENT groups
+    // that read alike. The label cannot name either, so each keys by identity
+    // — and the legend still paints the text both of them genuinely paint.
+    const r = buildChartSeries(
+      [
+        { status: 'Backlog', priority: NULL_CATEGORY_LABEL, est_hours: 1 },
+        { status: 'Backlog', priority: null, est_hours: 2 },
+      ],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([
+      { dataKey: '["(None)"]', label: NULL_CATEGORY_LABEL },
+      { dataKey: '[null]', label: NULL_CATEGORY_LABEL },
+    ]);
+    // Two columns, two numbers. One shared key would have dropped one of them.
+    expect(r.data).toEqual([{ status: 'Backlog', '["(None)"]': 1, '[null]': 2 }]);
+  });
+
+  it('separates a stored value that spells an IDENTITY — the encoder is not a hiding place', () => {
+    // The exclusion that makes the other two safe rather than merely likely: a
+    // record whose stored group value is the literal text `[null]` is a real
+    // value with a real bar, and it must not be able to take the null group's
+    // column out from under it.
+    const r = buildChartSeries(
+      [
+        { status: 'Backlog', priority: '[null]', est_hours: 1 },
+        { status: 'Backlog', priority: null, est_hours: 2 },
+      ],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([
+      { dataKey: '["[null]"]', label: '[null]' },
+      { dataKey: NULL_CATEGORY_LABEL, label: NULL_CATEGORY_LABEL },
+    ]);
+    expect(r.data).toEqual([{ status: 'Backlog', '["[null]"]': 1, [NULL_CATEGORY_LABEL]: 2 }]);
+  });
+
+  it('never takes the x-axis column — that one holds the bucket’s own value', () => {
+    // A group value equal to the FIRST dimension's NAME. Keyed by its display
+    // string it would overwrite the axis value on its own bucket row, and the
+    // bar would be drawn against a category that reads as a number.
+    const r = buildChartSeries(
+      [{ status: 'Backlog', priority: 'status', est_hours: 9 }],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([{ dataKey: '["status"]', label: 'status' }]);
+    expect(r.data).toEqual([{ status: 'Backlog', '["status"]': 9 }]);
+  });
+
+  it('never takes the identity-carrier column either', () => {
+    // objectui#4508 writes `CHART_BUCKET_ID_KEY` onto an ambiguous bucket row
+    // AFTER the series columns, so a series holding that key would be silently
+    // overwritten by the identity — a lost measure and a phantom series.
+    const r = buildChartSeries(
+      [{ status: 'Backlog', priority: CHART_BUCKET_ID_KEY, est_hours: 9 }],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    expect(r.series).toEqual([{ dataKey: '["__bucketId"]', label: CHART_BUCKET_ID_KEY }]);
+    expect(r.data).toEqual([{ status: 'Backlog', '["__bucketId"]': 9 }]);
+  });
+
+  it('does not collide with the MEASURE name — the card’s other named hazard', () => {
+    const r = buildChartSeries(
+      [
+        { status: 'Backlog', priority: 'est_hours', est_hours: 1 },
+        { status: 'Backlog', priority: null, est_hours: 2 },
+      ],
+      ['status', 'priority'],
+      ['est_hours'],
+    );
+    const keys = r.series.map((s) => s.dataKey);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(r.data).toEqual([{ status: 'Backlog', est_hours: 1, [NULL_CATEGORY_LABEL]: 2 }]);
+  });
+
+  it('assigns distinct keys across every spelling at once', () => {
+    // The whole collision surface in one fixture, asserted as the property the
+    // assignment claims: injective into the emitted row's key space.
+    const r = buildChartSeries(
+      [
+        { status: 'S', priority: null, n: 1 },
+        { status: 'S', priority: '', n: 2 },
+        { status: 'S', priority: NULL_CATEGORY_LABEL, n: 3 },
+        { status: 'S', priority: '[null]', n: 4 },
+        { status: 'S', priority: 'status', n: 5 },
+        { status: 'S', priority: 'High', n: 6 },
+      ],
+      ['status', 'priority'],
+      ['n'],
+    );
+    const keys = r.series.map((s) => s.dataKey);
+    expect(keys).toHaveLength(6);
+    expect(new Set([...keys, 'status']).size).toBe(7);
+    // Every group's measure survives to its own column.
+    expect(Object.values(r.data[0]).filter((v) => typeof v === 'number').sort()).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+/**
+ * objectui#4673's DRILL half — the newly-drawn segment resolves to its own rows.
+ *
+ * `findChartSeriesRow` matched the series dimension as `String(r[gDim] ?? '')`,
+ * which is the display-string matching objectui#4508 removed on the x-axis for
+ * spelling a null group and an empty-string group alike. Extending the identity
+ * answer rather than re-widening the tolerance is the card's premise C.
+ */
+describe('findChartSeriesRow — the null second-dimension segment keeps its drill (objectui#4673)', () => {
+  /** Raw dataset rows, the shape `drillRawRows` is index-aligned with. */
+  const RAW = [
+    { status: 'Backlog', priority: 'High', est_hours: 5 },
+    { status: 'Backlog', priority: null, est_hours: 40 },
+    { status: 'Backlog', priority: '', est_hours: 7 },
+  ];
+  const find = (series: string | undefined, opts?: Record<string, unknown>) =>
+    findChartSeriesRow(RAW, ['status', 'priority'], ['est_hours'], 'Backlog', series, opts);
+
+  it('resolves the null group’s segment to the null row', () => {
+    // Pre-fix this click could not happen (no series was ever drawn for it) and
+    // could not have resolved if it had: the key was `''`, which the
+    // empty-string group also answered to.
+    expect(find(NULL_CATEGORY_LABEL)).toBe(1);
+  });
+
+  it('resolves the empty-string group to ITS row, not the null one', () => {
+    expect(find('')).toBe(2);
+  });
+
+  it('leaves an ordinary series drill exactly as it was', () => {
+    expect(find('High')).toBe(0);
+    expect(find('Low')).toBe(-1);
+  });
+
+  it('answers a series key no group carries with -1, not with the first row', () => {
+    // The reader is exactly as wide as the writer — no display-string fallback,
+    // which is what would quietly hand one group's bar another group's records.
+    expect(find('(None) ')).toBe(-1);
+    expect(find('High ')).toBe(-1);
+    // No series key at all, and no empty-string group to absorb it.
+    const noEmpty = [{ status: 'Backlog', priority: 'High', est_hours: 5 }];
+    expect(findChartSeriesRow(noEmpty, ['status', 'priority'], ['est_hours'], 'Backlog', undefined)).toBe(-1);
+  });
+
+  /**
+   * MEASURED, and load-bearing for the empty-string group's drill.
+   *
+   * `String(seriesKey ?? '')` makes an ABSENT series key indistinguishable from
+   * the empty-string group's key, and that coincidence is currently what keeps
+   * that group's click alive end to end: `AdvancedChartImpl.handleCartesianClick`
+   * forwards `ap?.dataKey ? String(ap.dataKey) : undefined`, and `''` is falsy —
+   * so clicking the `''` bar sends `series: undefined`, which lands back on `''`
+   * here and resolves to the right row.
+   *
+   * Pinned rather than relied on silently: the two halves agree today by
+   * arithmetic, not by design, and `handleCartesianClick` is held by another
+   * card (#4672) so this commit does not touch it. Filed separately.
+   */
+  it('reads an absent series key as the empty-string group when one exists', () => {
+    expect(find(undefined)).toBe(2);
+    expect(find('')).toBe(2);
+  });
+
+  it('matches a caller-supplied localized label the same way, from the same option', () => {
+    const rows = [{ status: 'Backlog', priority: null, est_hours: 40 }];
+    expect(
+      findChartSeriesRow(rows, ['status', 'priority'], ['est_hours'], 'Backlog', '(未指定)', {
+        nullCategoryLabel: '(未指定)',
+      }),
+    ).toBe(0);
+    // The default label is not silently also accepted — the two helpers are
+    // documented to take the SAME option, and a mismatch is a dead drill, not
+    // a quietly wrong one.
+    expect(
+      findChartSeriesRow(rows, ['status', 'priority'], ['est_hours'], 'Backlog', NULL_CATEGORY_LABEL, {
+        nullCategoryLabel: '(未指定)',
+      }),
+    ).toBe(-1);
+  });
+
+  it('resolves an identity-keyed series (the label collision) to each group’s own rows', () => {
+    const literal = [
+      { status: 'Backlog', priority: NULL_CATEGORY_LABEL, est_hours: 1 },
+      { status: 'Backlog', priority: null, est_hours: 2 },
+    ];
+    const dims = ['status', 'priority'];
+    const emitted = buildChartSeries(literal, dims, ['est_hours']);
+    const at = (i: number) =>
+      findChartSeriesRow(literal, dims, ['est_hours'], 'Backlog', emitted.series[i].dataKey);
+    expect(at(0)).toBe(0);
+    expect(at(1)).toBe(1);
+  });
+
+  it('never matches a row that lacks the second dimension key', () => {
+    // `chartBucketId(undefined)` is `[null]`, so without the presence guard an
+    // unprojected row would answer the null group's click.
+    const mixed = [{ status: 'Backlog', est_hours: 40 }, { status: 'Backlog', priority: null, est_hours: 2 }];
+    expect(findChartSeriesRow(mixed, ['status', 'priority'], ['est_hours'], 'Backlog', NULL_CATEGORY_LABEL)).toBe(1);
+  });
+
+  it('still honours an x-axis bucket identity alongside the series identity', () => {
+    // The two axes' answers compose: objectui#4508 on x, objectui#4673 on the
+    // series, in the one lookup a click goes through.
+    const both = [
+      { status: NULL_CATEGORY_LABEL, priority: null, n: 1 },
+      { status: null, priority: null, n: 2 },
+    ];
+    const emitted = buildChartSeries(both, ['status', 'priority'], ['n']);
+    expect(
+      findChartSeriesRow(both, ['status', 'priority'], ['n'], NULL_CATEGORY_LABEL, emitted.series[0].dataKey, {
+        bucketId: chartRowBucketId(emitted.data[1]),
+      }),
+    ).toBe(1);
   });
 });

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -27,6 +27,11 @@
  * objectui#4466 for the single-dimension branch, objectui#4497 for the pivot.
  * One doctrine, one predicate (`isNullCategory`), two call sites.
  *
+ * The pivot's SECOND dimension gets the same answer as of objectui#4673, where
+ * it needed one more thing than an axis bucket does: a series bucket's key is a
+ * renderer `dataKey` AND a column in the emitted row, so it has to be
+ * collision-safe as well as drawable. See {@link pivotSeriesBuckets}.
+ *
  * A bucket's IDENTITY is separate from that display label (objectui#4508). The
  * label used to serve as its own key, which conflated two pairs of genuinely
  * different groups; see {@link chartBucketId} for the identity, and
@@ -213,12 +218,22 @@ export interface ChartSegmentClickEvent {
  * sentence and a false one.
  */
 function isNullCategory(row: unknown, key: string): boolean {
-  return (
-    !!row &&
-    typeof row === 'object' &&
-    key in row &&
-    (row as Record<string, unknown>)[key] == null
-  );
+  return carriesKey(row, key) && (row as Record<string, unknown>)[key] == null;
+}
+
+/**
+ * Does this row carry `key` AT ALL — the precondition {@link isNullCategory}
+ * and every bucketing call site share.
+ *
+ * Stated once because the two halves of the doctrine hang off it and the
+ * difference is invisible at a glance: `row[key] == null` is TRUE for a row
+ * that simply has no such column, so reading the raw value alone silently
+ * relabels "this dimension was never projected" as "these records have no
+ * value" (framework#4033's signal, erased). Every place that decides whether a
+ * row has a bucket asks THIS, never the raw value.
+ */
+function carriesKey(row: unknown, key: string): boolean {
+  return !!row && typeof row === 'object' && key in (row as Record<string, unknown>);
 }
 
 /**
@@ -276,21 +291,19 @@ function bucketNullCategories(
   key: string,
   label: string,
 ): Array<Record<string, unknown>> {
-  const carriesKey = (row: unknown): boolean =>
-    !!row && typeof row === 'object' && key in (row as Record<string, unknown>);
   // The value this row's bar will PAINT — the label when its category is null,
   // its own value otherwise. Ambiguity is a question about that string.
   const displayOf = (row: Record<string, unknown>): unknown =>
     isNullCategory(row, key) ? label : row[key];
   const ambiguous = ambiguousDisplays(
-    rows.filter(carriesKey).map((row) => ({
+    rows.filter((row) => carriesKey(row, key)).map((row) => ({
       id: chartBucketId(row[key]),
       display: bucketDisplayKey(displayOf(row)),
     })),
   );
   let changed = false;
   const next = rows.map((row) => {
-    if (!carriesKey(row)) return row;
+    if (!carriesKey(row, key)) return row;
     const isNull = isNullCategory(row, key);
     const shared = ambiguous.has(bucketDisplayKey(displayOf(row)));
     if (!isNull && !shared) return row;
@@ -302,6 +315,87 @@ function bucketNullCategories(
     };
   });
   return changed ? next : rows;
+}
+
+/**
+ * One pivoted SECOND-dimension group: what it is, what it says, and which
+ * column of the emitted row carries its measure.
+ */
+interface PivotSeriesBucket {
+  /** The group's {@link chartBucketId} — what two groups are told apart by. */
+  id: string;
+  /** The text the legend paints: the null bucket's label, or the value itself. */
+  label: string;
+  /** The emitted row's column for this group, and the renderer's `dataKey`. */
+  dataKey: string;
+}
+
+/**
+ * The pivot's series buckets, in first-seen order — objectui#4673.
+ *
+ * The second dimension used to be bucketed by `String(row[groupKey] ?? '')`
+ * behind a `gId !== ''` gate, which is the PRE-objectui#4466 answer one
+ * dimension over: a null (or empty-string) group never joined the series list,
+ * while the line below the gate still wrote its measure into the bucket. The
+ * number was in the emitted row and bound to no mark — the chart understated
+ * its own data without saying so, which is #4466's harm verbatim.
+ *
+ * A series bucket needs one thing an axis bucket does not, and that is the
+ * whole reason this is a function rather than two more lines inline: its key is
+ * a **row column and a renderer `dataKey`**, so it must be UNIQUE within the
+ * emitted row, where an axis bucket's key is a private map key. Hence the
+ * assignment below, which is injective by construction:
+ *
+ *  - a bucket keys its column by its own LABEL — so an ordinary pivot's rows
+ *    and series are byte-identical to what they have always been, and the
+ *    legend, the tooltip and the drill title read the group's own text;
+ *  - unless that label cannot NAME it: shared with another bucket (the null
+ *    bucket beside a stored value spelling its label — objectui#4508's second
+ *    collision, on the series axis), reserved by the row itself (`xKey`, whose
+ *    column IS the axis value, and {@link CHART_BUCKET_ID_KEY}), or equal to
+ *    some bucket's identity;
+ *  - in which case it keys by its own IDENTITY, which no other bucket has.
+ *
+ * The third exclusion is what makes the first two safe rather than merely
+ * likely: identities are pairwise distinct, and no surviving label is one of
+ * them, so the two key spaces cannot meet. That is the card's "collision-safe"
+ * requirement discharged, not approximated — a record whose stored group value
+ * literally spells `[null]` is a real value with a real bar, and it keeps it.
+ *
+ * The empty-string group keys by its own label, `''`, exactly as it paints a
+ * blank legend entry (and a blank tick on the x-axis — objectui#4508 ruled `''`
+ * and `null` two different groups, and this is that ruling on the series axis).
+ * Measured, not assumed: recharts binds `dataKey=""` through the same
+ * `getValueByDataKey` path as any other key and draws the bar at its true
+ * height. That measurement is pinned at the DOM in plugin-charts.
+ *
+ * A row that does not carry `groupKey` at all gets NO bucket and contributes no
+ * column — the other half of the doctrine, unchanged: "known to be empty" draws
+ * and "cannot know" refuses (framework#4033). Inventing a group for it would
+ * merge unprojected rows into the empty-string group and call it data.
+ */
+function pivotSeriesBuckets(
+  rows: Array<Record<string, unknown>>,
+  groupKey: string,
+  nullLabel: string,
+  xKey: string,
+): PivotSeriesBucket[] {
+  const byId = new Map<string, { id: string; label: string }>();
+  for (const row of rows) {
+    if (!carriesKey(row, groupKey)) continue;
+    const id = chartBucketId(row[groupKey]);
+    if (byId.has(id)) continue;
+    byId.set(id, { id, label: isNullCategory(row, groupKey) ? nullLabel : String(row[groupKey]) });
+  }
+  const buckets = Array.from(byId.values());
+  const shared = ambiguousDisplays(buckets.map(({ id, label }) => ({ id, display: label })));
+  const reserved = new Set([xKey, CHART_BUCKET_ID_KEY]);
+  const identities = new Set(buckets.map(({ id }) => id));
+  return buckets.map(({ id, label }) => ({
+    id,
+    label,
+    dataKey: shared.has(label) || reserved.has(label) || identities.has(label) ? id : label,
+  }));
 }
 
 export function buildChartSeries(
@@ -323,7 +417,11 @@ export function buildChartSeries(
     const groupKey = dims[1];
     const measure = vals[0];
     const nullLabel = options?.nullCategoryLabel ?? NULL_CATEGORY_LABEL;
-    const seriesKeys: string[] = [];
+    // Every second-dimension group, INCLUDING the null and empty-string ones
+    // the `gId !== ''` gate used to drop on the floor (objectui#4673), each
+    // already carrying the column its measure lands in.
+    const groups = pivotSeriesBuckets(safeRows, groupKey, nullLabel, xKey);
+    const columnById = new Map(groups.map(({ id, dataKey }) => [id, dataKey]));
     const byX = new Map<string, Record<string, unknown>>();
 
     for (const row of safeRows) {
@@ -348,9 +446,15 @@ export function buildChartSeries(
       if (!byX.has(xId)) {
         byX.set(xId, { [xKey]: isNullCategory(row, xKey) ? nullLabel : xRaw });
       }
-      const gId = String(row[groupKey] ?? '');
-      if (gId !== '' && !seriesKeys.includes(gId)) seriesKeys.push(gId);
-      byX.get(xId)![gId] = row[measure];
+      // The group's own column, or nothing at all when the row carries no
+      // second dimension to be grouped BY. Nothing at all is the point: the
+      // old code wrote such a row's measure under `''` — a column no series
+      // bound to, and after objectui#4673 the empty-string GROUP's column,
+      // which would hand an unprojected row's number to a real group's bar.
+      const column = carriesKey(row, groupKey)
+        ? columnById.get(chartBucketId(row[groupKey]))
+        : undefined;
+      if (column !== undefined) byX.get(xId)![column] = row[measure];
     }
 
     // Two DISTINCT buckets can still render the same axis text — the null
@@ -371,8 +475,10 @@ export function buildChartSeries(
       ),
       xAxisKey: xKey,
       // Series labels are the second-dimension values themselves (already
-      // server-resolved to display labels by queryDataset).
-      series: seriesKeys.map((k) => ({ dataKey: k, label: k })),
+      // server-resolved to display labels by queryDataset), except the null
+      // group, which says so with the bucket label the renderer supplied. The
+      // key is a separate question from the text — see `pivotSeriesBuckets`.
+      series: groups.map(({ dataKey, label }) => ({ dataKey, label })),
     };
   }
 
@@ -459,11 +565,20 @@ export function relabelDimensions(
  *    BOTH the x-axis dimension (`category`) and the series dimension (`seriesKey`).
  *  - **otherwise** → match the x-axis (first) dimension only.
  *
- * Comparison is string-wise on the rows' display values (which is what the chart
- * surfaces as `category` / series key), unless the click carried a bucket
+ * The x-axis comparison is string-wise on the rows' display values (which is
+ * what the chart surfaces as `category`), unless the click carried a bucket
  * IDENTITY — {@link ChartDrillLookupOptions.bucketId} — in which case that is
  * authoritative and the display string is not consulted at all. Returns `-1`
  * when nothing matches.
+ *
+ * The SERIES comparison is not string-wise at all as of objectui#4673: a series
+ * key is a `dataKey` {@link buildChartSeries} assigned, so it is resolved back
+ * through the same {@link pivotSeriesBuckets} assignment (same rows, same
+ * `nullCategoryLabel`) to the group IDENTITY it names, and rows are matched on
+ * that. A null-valued second dimension had no series at all before, so its
+ * segment could not be clicked; now it can, and `String(r[gDim] ?? '')` would
+ * have answered that click with an empty-string group's rows — the same
+ * conflation objectui#4508 removed on the x-axis.
  *
  * The NULL-category bucket {@link buildChartSeries} renders (objectui#4466) is
  * matched back to its row here, and it has to be: the caller passes the rows it
@@ -521,8 +636,23 @@ export function findChartSeriesRow(
       : (r: Record<string, unknown>): boolean => (r[xDim] == null ? nullLabel : String(r[xDim])) === c;
   if (dims.length >= 2 && vals.length === 1) {
     const gDim = dims[1];
-    const s = String(seriesKey ?? '');
-    return safeRows.findIndex((r) => matchesX(r) && String(r[gDim] ?? '') === s);
+    // The clicked series key is a `dataKey` `buildChartSeries` ASSIGNED, so it
+    // is resolved the way it was assigned — through the same buckets, rebuilt
+    // from the same raw rows (`DatasetWidget.handleChartDrill`, the one
+    // production caller, hands both helpers the same array and the same
+    // `nullCategoryLabel`). Matching then compares IDENTITIES, which is
+    // objectui#4508's answer extended to the series axis: `String(r[gDim] ?? '')`
+    // was display-string matching, and it spelled a null group and an
+    // empty-string group alike — the tolerance #4508 removed one dimension over.
+    const groups = pivotSeriesBuckets(safeRows, gDim, nullLabel, xDim);
+    const gId = groups.find(({ dataKey }) => dataKey === String(seriesKey ?? ''))?.id;
+    // No bucket answers to that key: these rows have no such group, so no row
+    // can belong to it. `-1` is the documented "nothing matched" — widening to
+    // a string comparison here would put back exactly what #4508 measured out.
+    if (gId === undefined) return -1;
+    return safeRows.findIndex(
+      (r) => matchesX(r) && carriesKey(r, gDim) && chartBucketId(r[gDim]) === gId,
+    );
   }
   return safeRows.findIndex((r) => matchesX(r));
 }

--- a/packages/plugin-charts/src/AdvancedChartImpl.pivotNullSeries.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.pivotNullSeries.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#4673 — the pivot's null SECOND-dimension group, at the DOM.
+ *
+ * The third sibling of `AdvancedChartImpl.nullCategoryBucket.test.tsx`
+ * (objectui#4466, single dimension) and `AdvancedChartImpl.pivotNullBucket.
+ * test.tsx` (objectui#4497, the pivot's FIRST dimension). All three render the
+ * composition the two consumers actually perform — the shared
+ * `buildChartSeries` transform feeding `AdvancedChartImpl` — and COUNT THE
+ * MARKS, because none of these defects is visible in the transform's return
+ * value alone.
+ *
+ * This one needs the DOM for a second reason the other two did not. The card's
+ * constraint is that a series key is also a renderer `dataKey`, so the fix had
+ * to choose keys a chart library will actually bind to — and the empty-string
+ * group's key is `''`, which is falsy. Whether recharts binds `dataKey=""` at
+ * all is a fact about recharts, not about our transform, and asserting it in a
+ * pure test would be asserting our own belief. Measured here instead:
+ * `getValueByDataKey` routes `''` through lodash `get`, which reads the `''`
+ * property, and the bar draws at its true height.
+ *
+ * Measured on this file's own fixture, with `pivotSeriesBuckets` reverted to
+ * the `gId !== ''` gate: 1 bar rectangle for the card's two-group pivot, the
+ * null group's 40 hours in the emitted row and on no mark at all. Post-fix: 2.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { buildChartSeries, NULL_CATEGORY_LABEL } from '@object-ui/core';
+
+// Recharts' ResponsiveContainer measures via ResizeObserver, which reports 0×0
+// under the headless DOM, so nothing paints. Fix its size.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+const DIMS = ['status', 'priority'];
+const VALS = ['est_hours'];
+
+/** The card's measured repro: the 40 hours belong to a null-priority group. */
+const CARD_RAW = [
+  { status: 'Backlog', priority: 'High', est_hours: 5 },
+  { status: 'Backlog', priority: null, est_hours: 40 },
+];
+
+/** Render a pivot result exactly as `DatasetWidget` / `ObjectChart` do. */
+function renderPivot(rows: Array<Record<string, unknown>>) {
+  const { data, xAxisKey, series } = buildChartSeries(rows, DIMS, VALS);
+  const { container } = render(
+    <AdvancedChartImpl
+      chartType="bar"
+      data={data as any}
+      xAxisKey={xAxisKey}
+      series={series as any}
+      isAnimationActive={false}
+    />,
+  );
+  return { container, data, series };
+}
+
+/** One drawn bar per series, in series order, with the height recharts gave it. */
+function barHeights(container: HTMLElement): number[] {
+  return Array.from(container.querySelectorAll('.recharts-bar')).map((group) => {
+    const rect = group.querySelector('.recharts-rectangle');
+    return Number(rect?.getAttribute('height') ?? NaN);
+  });
+}
+
+describe('AdvancedChartImpl — a null second-dimension group is drawn (objectui#4673)', () => {
+  it('draws the card’s 40-hour bar instead of carrying the number invisibly', () => {
+    const { container, series } = renderPivot(CARD_RAW);
+
+    expect(series.map((s) => s.dataKey)).toEqual(['High', NULL_CATEGORY_LABEL]);
+    // Pre-fix: 1. The 40 was in `data` under `''` and no series bound to it.
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(2);
+
+    // …and it is drawn for its OWN value, not as a zero-height placeholder:
+    // 40 is eight times 5, and so is its bar.
+    const [high, none] = barHeights(container);
+    expect(high).toBeGreaterThan(0);
+    expect(none / high).toBeCloseTo(8, 5);
+  });
+
+  it('binds the empty-string group’s falsy dataKey — measured, not assumed', () => {
+    // `''` is the key the empty-string group paints under (objectui#4508 ruled
+    // it a different group from null), and a falsy `dataKey` is exactly the
+    // kind of thing a chart library quietly ignores. It does not: the bar draws
+    // and reads its own column.
+    const { container, data, series } = renderPivot([
+      { status: 'Backlog', priority: '', est_hours: 40 },
+      { status: 'Backlog', priority: 'High', est_hours: 5 },
+    ]);
+    expect(series.map((s) => s.dataKey)).toEqual(['', 'High']);
+    expect(data).toEqual([{ status: 'Backlog', '': 40, High: 5 }]);
+
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(2);
+    const [empty, high] = barHeights(container);
+    expect(empty / high).toBeCloseTo(8, 5);
+  });
+
+  it('draws BOTH the null and the empty-string group — two facts, two bars', () => {
+    const { container, series } = renderPivot([
+      { status: 'Backlog', priority: null, est_hours: 40 },
+      { status: 'Backlog', priority: '', est_hours: 5 },
+    ]);
+    expect(series.map((s) => s.dataKey)).toEqual([NULL_CATEGORY_LABEL, '']);
+    // Pre-fix: 0 bars for two real groups — both gated out of `seriesKeys`,
+    // and both writing their measure to the same `''` column on the way out,
+    // so one of the two numbers did not even survive the transform.
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(2);
+    const [none, empty] = barHeights(container);
+    expect(none / empty).toBeCloseTo(8, 5);
+  });
+
+  it('leaves an ordinary pivot drawing exactly what it drew before', () => {
+    const { container, series } = renderPivot([
+      { status: 'Backlog', priority: 'High', est_hours: 5 },
+      { status: 'Done', priority: 'Low', est_hours: 3 },
+    ]);
+    expect(series.map((s) => s.dataKey)).toEqual(['High', 'Low']);
+    // Two series over two x-buckets, each series drawing only where it has a
+    // value: recharts renders a rect per (series, bucket) pair it can read.
+    expect(container.querySelectorAll('.recharts-bar')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Fixes #4673

`buildChartSeries`' pivot branch kept the pre-#4466 answer on the **second**
dimension. It bucketed groups by `String(row[groupKey] ?? '')` behind a
`gId !== ''` gate, so a group whose second dimension is `null`, `undefined` or
`''` never joined `seriesKeys` — while the line below the gate still wrote its
measure into the emitted row under the `''` key. The number was in the data and
bound to no mark, which is #4466's harm verbatim one dimension over: the chart
understated its own data without saying so.

## Measured, before the fix

The card's repro, run through the transform and then through the real renderer:

```
data:   [{ status: 'Backlog', High: 5, '': 40 }]
series: [{ dataKey: 'High', label: 'High' }]
rects:  1
```

The 40 hours are in the row, accommodated by the y-axis scale, and painted on
nothing. Two such groups were worse than unbound: `null` and `''` both key `''`,
so the later group silently overwrote the earlier one's measure and one of the
two numbers did not survive the transform at all (measured: `series: []`, zero
bars, for a fixture with both).

## What changed

**A known-empty group draws; an unprojected key still refuses.** That is the
split the first dimension already used (#4466 versus `hasNoCategoryKey`,
framework#4033), now answering the same way on both dimensions. A row that does
not carry the group key at all gets no bucket and contributes no column, where
it previously wrote its measure under `''`. `null` and `''` are two different
groups with two series, following #4508's collision-1 ruling.

**One place decides what a group is, what it says, and which column carries
it.** `pivotSeriesBuckets` returns `{ id, label, dataKey }` per group and both
helpers go through it, so the writer and the reader cannot drift.

**The series key is collision-safe, not merely unlikely to collide.** Unlike an
axis bucket's private map key, a series key is a column of the emitted row and
the `dataKey` a renderer binds to, so it must be unique within that row. A group
keys its column by its own display label — leaving an ordinary pivot's rows,
series, legend, tooltip and drill title exactly as they were — unless that label
cannot name it:

- shared with another group (a stored value spelling the null bucket's label —
  #4508's collision 2, on this axis);
- reserved by the row itself (the x-axis column, the `CHART_BUCKET_ID_KEY`
  carrier);
- equal to some group's identity.

Those key by identity instead, which no other group has. The third exclusion is
what makes the assignment injective rather than merely unlikely to collide: no
surviving label is any group's identity, so the two key spaces cannot meet. A
record whose stored group value literally spells `[null]` is a real value with a
real bar, and it keeps it.

**Drill-through follows the same assignment.** A clicked series key resolves back
to the group identity it names, and rows are matched on that.
`String(r[gDim] ?? '')` was the display-string matching #4508 removed on the
x-axis — it spelled a null group and an empty-string group alike, so the
empty-string group's segment resolved to the null group's records. This is the
card's premise C: extend the identity answer, do not re-widen the tolerance.

**No renderer change was needed.** The null group's series carries the same
`nullCategoryLabel` the renderers already pass for the first dimension, so the
existing plumbing (#4466 / #4497) covers it. The `handleCartesianClick` region
held by #4672 is untouched — see "Not addressed here" below.

### The bounding sweep, named

Two keys beyond the card's own list are treated as reserved, because the
assignment's whole job is to be injective into the emitted row's key space and
that space already contains them:

- **the x-axis column.** A second-dimension group value equal to the first
  dimension's *name* (`priority: 'status'` under `dimensions: ['status',
  'priority']`) would, keyed by its display string, overwrite the axis value on
  its own bucket row — the bar drawn against a category that reads as a number.
- **`CHART_BUCKET_ID_KEY`.** #4508 writes the identity onto an ambiguous bucket
  row *after* the series columns, so a series holding that key would be silently
  overwritten by the identity: a lost measure and a phantom series.

Both are pinned by their own cases. Leaving a known hole in a function whose
entire purpose is collision-safety was the alternative.

## Verification

Gate union run at `a6a2282bb`, which is this branch's head:

- `pnpm exec vitest run packages/core/ packages/plugin-charts/ packages/plugin-dashboard/`
  — **171 files, 2497 tests, all passing.**
- `pnpm --filter @object-ui/core --filter @object-ui/plugin-charts --filter @object-ui/plugin-dashboard --workspace-concurrency=2 run type-check`
  — clean (scope confirmed non-empty: "3 of 47 workspace projects", each running
  a real `tsc`, with the dependency closure built first).
- `eslint --quiet` on the three changed files — clean.
- `check-changeset-presence` / `check-changeset-no-major` /
  `check-changeset-fixed` / `check-control-bytes` — all green.

### Reverse verification, direction predicted before running

**Writer ablated** (the `gId !== ''` gate restored). Predicted red in the
`buildChartSeries` blocks and the DOM file, green in the reader-only drill
cases. Measured exactly that: 14 red / 50 green in core, and 3 red / 1 green at
the DOM. The drill cases that do not derive their key from the writer —
`resolves the null group's segment to the null row`, `resolves the empty-string
group to ITS row`, `never matches a row that lacks the second dimension key` —
stayed **green**, which is the honest statement that the reader half is
independently correct. Every first-dimension suite (#4466 / #4497 / #4508)
stayed green, confirming the change is confined to the second dimension.

**Reader ablated** (`String(r[gDim] ?? '') === s` restored). Predicted red in the
drill block only. Measured 7 red / 57 green — including `expected 1 to be 2`,
which is the *wrong-row* failure rather than a dead one: under display-string
matching the empty-string group's click resolves to the null group's row. The
ordinary-series drills and the #4497 / #4508 pivot drill suites stayed green.

The DOM leg ran against a rebuilt `dist/` in both directions, and the mutation
was proved to have reached the artifact before each run (4 ablation markers
present when ablated, 0 after restore, so no mutated code stays live for later
runs).

## Not addressed here

- **#4672 remains open and its region is untouched.** Its
  `handleCartesianClick` currently forwards `ap?.dataKey ? String(ap.dataKey) : undefined`,
  and `''` is falsy — so clicking the empty-string group's bar sends
  `series: undefined`, which `String(seriesKey ?? '')` lands back on `''` here
  and resolves correctly. The two halves agree by arithmetic rather than by
  design; that constraint is pinned in a core test and noted on #4672 for
  whoever rewrites that handler.
- **The drill dialog title in the label-collision case.** When a group keys by
  identity, `DatasetWidget.handleChartDrill` puts the raw series key into the
  drawer title, so it would read `[null]` rather than `(None)`. The drill
  resolves to the right rows; only the title text is opaque. Carrying a series
  label on `ChartSegmentClickEvent` would mean editing the held
  `handleCartesianClick` region, so it is filed rather than done.
- **An unprojected second dimension** now yields no series at all rather than a
  phantom `''` column, but nothing announces it the way `hasNoCategoryKey` does
  for the first dimension. Filed; related to #4507.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_