### PR TITLE
fix(app-shell): a denied attachment list is not an empty one

### DIFF
--- a/.changeset/attachments-denied-vs-empty.md
+++ b/.changeset/attachments-denied-vs-empty.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/i18n': patch
+---
+
+RecordAttachmentsPanel distinguishes a DENIED attachment list from an empty one.
+
+A `sys_attachment` list read refused for authorization reasons (HTTP 403 /
+`PERMISSION_DENIED` / `FORBIDDEN` / a row-level-security denial) was swallowed
+into the panel's empty state, so a member denied the parent record was told
+"No attachments yet. Upload a file to get started." about a record holding
+2095+ attachments — and was offered an Upload the server would refuse.
+
+The panel now classifies that refusal with the same `isPermissionError`
+predicate the kanban, calendar and form surfaces branch on, renders a distinct
+denied state ("You don't have access to these attachments.", new
+`detail.attachmentsAccessDenied` key in all ten locale packs), and withdraws
+the Upload affordance. The denied state renders the translated sentence and
+nothing sourced from the error — no status code, no server text, no row count.
+The empty state is now reserved for a genuine 200-with-zero-rows; non-authz
+failures keep their pre-existing handling.

--- a/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
+++ b/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
@@ -8,10 +8,10 @@
 
 import * as React from 'react';
 import { cn, Button } from '@object-ui/components';
-import { Paperclip, Upload, Trash2, Download, Loader2 } from 'lucide-react';
+import { Paperclip, Upload, Trash2, Download, Loader2, Lock } from 'lucide-react';
 import { createObjectStackUploadAdapter } from '@object-ui/providers';
 import { createAuthenticatedFetch } from '@object-ui/auth';
-import { useObjectTranslation } from '@object-ui/react';
+import { useObjectTranslation, isPermissionError } from '@object-ui/react';
 
 /**
  * RecordAttachmentsPanel — generic record Attachments surface (#2727,
@@ -69,6 +69,17 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
   const [loading, setLoading] = React.useState(false);
   const [uploading, setUploading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  /**
+   * The list read was refused for AUTHORIZATION reasons (#4269).
+   *
+   * Kept separate from `rows.length === 0` because the two say opposite
+   * things and only one of them is an assertion the panel is entitled to
+   * make. "No attachments yet" claims the record HOLDS nothing; a 403 says
+   * only that this caller may not look. Folding the second into the first
+   * told a denied member that a record with 2095+ attachments was empty —
+   * and offered an Upload the server would refuse.
+   */
+  const [listDenied, setListDenied] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
 
   // Same base-URL convention as RecordDetailView's raw API fetches: the
@@ -131,10 +142,28 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
       });
       const items: AttachmentRow[] = Array.isArray(res) ? res : res?.data ?? [];
       setRows(items);
-    } catch {
-      // A 404 (table not provisioned on older stacks) is tolerated silently;
-      // the panel just stays empty.
+      setListDenied(false);
+    } catch (err) {
       setRows([]);
+      // An authorization refusal is NOT an empty record (#4269). The house
+      // predicate is the same one the kanban/calendar/form surfaces branch
+      // on — HTTP 403, `PERMISSION_DENIED`/`FORBIDDEN`, or an RLS denial.
+      // The adapter throws it: `find()` degrades only a non-authz 404 to
+      // `{ data: [], total: 0 }` (data-objectstack, objectui#4408), so a 403
+      // reaches this catch as a decorated throw.
+      //
+      // Nothing from the error is rendered — the denied state below shows the
+      // i18n sentence and nothing else. objectui#2532's failure mode (raw
+      // dump / status code / leaked row) must stay absent, and `setError` is
+      // deliberately NOT called here.
+      setListDenied(isPermissionError(err));
+      // Everything else keeps the pre-existing behaviour: a 404 (table not
+      // provisioned on older stacks) and any network/5xx failure are tolerated
+      // silently and the panel stays empty. That swallow is the SAME defect
+      // class one status over — an unreachable server also renders "No
+      // attachments yet" — but the honest unknown-vs-empty split is a separate
+      // change (filed, not fixed here) and this line pins today's behaviour
+      // rather than quietly widening the fix.
     } finally {
       setLoading(false);
     }
@@ -253,28 +282,39 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
             <span className="text-xs text-muted-foreground">({rows.length})</span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          <input
-            ref={inputRef}
-            type="file"
-            multiple
-            className="hidden"
-            onChange={(e) => void handleFiles(e.target.files)}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={uploading}
-            onClick={() => inputRef.current?.click()}
-          >
-            {uploading ? (
-              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-            ) : (
-              <Upload className="h-4 w-4 mr-1" />
-            )}
-            {t('detail.uploadAttachment', { defaultValue: 'Upload' })}
-          </Button>
-        </div>
+        {/*
+          No Upload affordance under a denied list (#4269). The button was
+          previously unconditional — its only gate was `uploading` — so a
+          member the server had just refused was still invited to upload into
+          a record whose parent it cannot read, a click the `beforeInsert`
+          gate answers with 403 ATTACHMENT_PARENT_ACCESS. Hiding it here
+          changes nothing for every other caller: this is the sole condition
+          added to a control that had none.
+        */}
+        {!listDenied && (
+          <div className="flex items-center gap-2">
+            <input
+              ref={inputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(e) => void handleFiles(e.target.files)}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={uploading}
+              onClick={() => inputRef.current?.click()}
+            >
+              {uploading ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              ) : (
+                <Upload className="h-4 w-4 mr-1" />
+              )}
+              {t('detail.uploadAttachment', { defaultValue: 'Upload' })}
+            </Button>
+          </div>
+        )}
       </div>
 
       {error && (
@@ -287,6 +327,18 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
         <div className="px-4 py-6 text-sm text-muted-foreground flex items-center gap-2">
           <Loader2 className="h-4 w-4 animate-spin" />
           {t('detail.loadingAttachments', { defaultValue: 'Loading attachments…' })}
+        </div>
+      ) : listDenied ? (
+        // Checked BEFORE the empty state, and rendering only the i18n
+        // sentence: no status code, no server message, no row (#2532).
+        <div
+          className="px-4 py-6 text-sm text-muted-foreground flex items-center gap-2"
+          data-testid="record-attachments-denied"
+        >
+          <Lock className="h-4 w-4 shrink-0" />
+          {t('detail.attachmentsAccessDenied', {
+            defaultValue: "You don't have access to these attachments.",
+          })}
         </div>
       ) : rows.length === 0 ? (
         <div className="px-4 py-6 text-sm text-muted-foreground">

--- a/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
@@ -94,6 +94,125 @@ describe('RecordAttachmentsPanel — server-denial error mapping (#2755)', () =>
   });
 });
 
+/**
+ * A denied list is not an empty list (#4269).
+ *
+ * A member denied the parent opened a record holding 2095+ attachments; the
+ * `sys_attachment` list read answered 403 and the panel rendered "No
+ * attachments yet. Upload a file to get started." — an assertion about the
+ * record's contents that the panel had no standing to make, plus an Upload
+ * the server would refuse.
+ *
+ * The 403 arrives as a THROW: the ObjectStack adapter's `find()` degrades only
+ * a non-authz 404 to `{ data: [], total: 0 }` and rethrows everything else, so
+ * the panel's `catch` is where the two verdicts were being merged.
+ */
+describe('RecordAttachmentsPanel — denied vs empty list (#4269)', () => {
+  /** The decorated shape the adapter rethrows: `httpStatus` + semantic code. */
+  function deniedListSource() {
+    return makeDataSource({
+      find: vi.fn(async () => {
+        throw Object.assign(
+          new Error(
+            "[Security] Access denied: operation 'find' on sys_attachment for user u-42 (2095 rows withheld)",
+          ),
+          { httpStatus: 403, code: 'PERMISSION_DENIED' },
+        );
+      }),
+    });
+  }
+
+  it('THE DEFECT — a 403 list read renders the denied state, never "No attachments yet"', async () => {
+    setup(deniedListSource());
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-denied')).toBeInTheDocument(),
+    );
+    expect(screen.getByText("You don't have access to these attachments.")).toBeInTheDocument();
+    // The empty state is reserved for a genuine 200-with-zero-rows.
+    expect(screen.queryByText(/No attachments yet/)).not.toBeInTheDocument();
+  });
+
+  it('withdraws the Upload affordance under a denied list', async () => {
+    setup(deniedListSource());
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-denied')).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: 'Upload' })).not.toBeInTheDocument();
+  });
+
+  // The objectui#2532 failure mode — raw error dump, status code, leaked row
+  // counts — was ABSENT before this change and must stay absent: the denied
+  // state renders the i18n sentence and nothing sourced from the error.
+  it('leaks nothing from the error body — no status code, no server text, no row count', async () => {
+    setup(deniedListSource());
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-denied')).toBeInTheDocument(),
+    );
+    const panel = screen.getByTestId('record-attachments-panel');
+    expect(panel.textContent).not.toMatch(/403/);
+    expect(panel.textContent).not.toMatch(/2095/);
+    expect(panel.textContent).not.toMatch(/u-42/);
+    expect(panel.textContent).not.toMatch(/\[Security\]|Access denied: operation/);
+    // The denial is a state, not an error banner.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('classifies a PERMISSION_DENIED code carrying no numeric status', async () => {
+    const dataSource = makeDataSource({
+      find: vi.fn(async () => {
+        const err: any = new Error('refused');
+        err.code = 'PERMISSION_DENIED';
+        throw err;
+      }),
+    });
+    setup(dataSource);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-denied')).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('button', { name: 'Upload' })).not.toBeInTheDocument();
+  });
+
+  it('a genuine 200-with-zero-rows still renders the empty state AND the Upload button', async () => {
+    setup(makeDataSource({ find: vi.fn(async () => []) }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No attachments yet. Upload a file to get started.'),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument();
+    expect(screen.queryByTestId('record-attachments-denied')).not.toBeInTheDocument();
+  });
+
+  // PIN, not an endorsement. A non-authz failure keeps the pre-existing
+  // behaviour — swallowed to the empty state, Upload still offered. That is
+  // the same "unknown rendered as empty" defect one status over, but fixing it
+  // needs the loaded/unknown status vocabulary (#4235-style), not this
+  // denied-vs-empty split; filed separately. This test exists so the next
+  // change to that branch is a DELIBERATE one.
+  it('pins today’s behaviour for a NON-authz failure: still the empty state', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw new TypeError('Failed to fetch');
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No attachments yet. Upload a file to get started.'),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('record-attachments-denied')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument();
+  });
+});
+
 describe('RecordAttachmentsPanel — authenticated signed-URL download (#2970)', () => {
   it('fetches /files/:id/url with auth and opens the signed URL', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -900,6 +900,7 @@ const ar = {
     attachmentDownloadDenied: "ليس لديك صلاحية تنزيل هذا المرفق.",
     attachmentAuthRequired: "يرجى تسجيل الدخول لتنزيل هذا المرفق.",
     attachmentPermissionDenied: "ليس لديك إذن للقيام بذلك.",
+    attachmentsAccessDenied: "ليس لديك حق الوصول إلى هذه المرفقات.",
     unifiedDiff: "عرض موحد",
     sideBySideDiff: "عرض جنباً إلى جنب",
     noChanges: "لا توجد تغييرات",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -894,6 +894,7 @@ const de = {
     attachmentDownloadDenied: "Sie sind nicht berechtigt, diesen Anhang herunterzuladen.",
     attachmentAuthRequired: "Bitte melden Sie sich an, um diesen Anhang herunterzuladen.",
     attachmentPermissionDenied: "Sie haben keine Berechtigung für diese Aktion.",
+    attachmentsAccessDenied: "Sie haben keinen Zugriff auf diese Anhänge.",
     unifiedDiff: "Einheitliche Ansicht",
     sideBySideDiff: "Nebeneinander-Ansicht",
     noChanges: "Keine Änderungen",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1030,6 +1030,7 @@ const en = {
     attachmentDownloadDenied: "You don't have access to download this attachment.",
     attachmentAuthRequired: 'Please sign in to download this attachment.',
     attachmentPermissionDenied: "You don't have permission to do that.",
+    attachmentsAccessDenied: "You don't have access to these attachments.",
     // Diff
     unifiedDiff: 'Unified diff',
     sideBySideDiff: 'Side-by-side diff',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -898,6 +898,7 @@ const es = {
     attachmentDownloadDenied: "No tiene acceso para descargar este adjunto.",
     attachmentAuthRequired: "Inicie sesión para descargar este adjunto.",
     attachmentPermissionDenied: "No tiene permiso para hacer eso.",
+    attachmentsAccessDenied: "No tiene acceso a estos adjuntos.",
     unifiedDiff: "Vista unificada",
     sideBySideDiff: "Vista lado a lado",
     noChanges: "Sin cambios",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -896,6 +896,7 @@ const fr = {
     attachmentDownloadDenied: "Vous n'avez pas accès pour télécharger cette pièce jointe.",
     attachmentAuthRequired: "Veuillez vous connecter pour télécharger cette pièce jointe.",
     attachmentPermissionDenied: "Vous n'avez pas la permission de faire cela.",
+    attachmentsAccessDenied: "Vous n'avez pas accès à ces pièces jointes.",
     unifiedDiff: "Vue unifiée",
     sideBySideDiff: "Vue côte à côte",
     noChanges: "Aucune modification",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -905,6 +905,7 @@ const ja = {
     attachmentDownloadDenied: "この添付ファイルをダウンロードする権限がありません。",
     attachmentAuthRequired: "この添付ファイルをダウンロードするにはサインインしてください。",
     attachmentPermissionDenied: "この操作を行う権限がありません。",
+    attachmentsAccessDenied: "これらの添付ファイルにアクセスする権限がありません。",
     unifiedDiff: "統合差分",
     sideBySideDiff: "横並び差分",
     noChanges: "変更なし",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -894,6 +894,7 @@ const ko = {
     attachmentDownloadDenied: "이 첨부파일을 다운로드할 권한이 없습니다.",
     attachmentAuthRequired: "이 첨부파일을 다운로드하려면 로그인하세요.",
     attachmentPermissionDenied: "이 작업을 수행할 권한이 없습니다.",
+    attachmentsAccessDenied: "이 첨부파일에 접근할 권한이 없습니다.",
     unifiedDiff: "통합 보기",
     sideBySideDiff: "나란히 보기",
     noChanges: "변경 없음",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -895,6 +895,7 @@ const pt = {
     attachmentDownloadDenied: "Você não tem acesso para baixar este anexo.",
     attachmentAuthRequired: "Faça login para baixar este anexo.",
     attachmentPermissionDenied: "Você não tem permissão para fazer isso.",
+    attachmentsAccessDenied: "Você não tem acesso a estes anexos.",
     unifiedDiff: "Visualização unificada",
     sideBySideDiff: "Visualização lado a lado",
     noChanges: "Sem alterações",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -913,6 +913,7 @@ const ru = {
     attachmentDownloadDenied: "У вас нет доступа для скачивания этого вложения.",
     attachmentAuthRequired: "Войдите в систему, чтобы скачать это вложение.",
     attachmentPermissionDenied: "У вас нет разрешения на это действие.",
+    attachmentsAccessDenied: "У вас нет доступа к этим вложениям.",
     unifiedDiff: "Единое представление",
     sideBySideDiff: "Параллельное представление",
     noChanges: "Нет изменений",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -974,6 +974,7 @@ const zh = {
     attachmentDownloadDenied: '您无权下载此附件。',
     attachmentAuthRequired: '请登录后再下载此附件。',
     attachmentPermissionDenied: '您没有执行此操作的权限。',
+    attachmentsAccessDenied: '您没有访问这些附件的权限。',
     // Diff
     unifiedDiff: '统一视图',
     sideBySideDiff: '并排视图',


### PR DESCRIPTION
Fixes #4269

A member denied the parent record opened a record holding 2095+ attachments. The `sys_attachment` list read answered **403**, and `RecordAttachmentsPanel` rendered **"No attachments yet. Upload a file to get started."** — plus an Upload affordance the server would refuse. An operator could not tell "nothing here" from "not yours".

## Premises, re-derived on `origin/main` before building

The card's run was 4 days old, so all three were re-measured against current `main` (`b8818171f`):

**A — how the 403 reaches the component.** It **throws**. `ObjectStackAdapter.find()` degrades only a *non-authz* 404 to `{ data: [], total: 0 }` and rethrows everything else (that carve-out is objectui#4408's, so an `enable`-block denial is not mistaken for a missing collection). So the panel's bare `catch { setRows([]) }` was exactly where "denied" and "empty" were merged. Confirmed at source, not assumed.

**B — what gates the Upload affordance today.** Nothing. Its only condition was `disabled={uploading}`; it rendered unconditionally for every caller. So hiding it under a denied list disturbs no existing permission-based visibility — this is the sole condition added to a control that had none.

**C — is there a house denied-state pattern?** Yes, and it is reused rather than reinvented: `isPermissionError` from `@object-ui/react` (HTTP 403 / `PERMISSION_DENIED` / `FORBIDDEN` / an RLS denial) is the same predicate `ObjectKanban`, `ObjectCalendar` and the form renderer branch on, and the `Lock`-icon denial framing mirrors `ObjectDataPage`'s route gate.

## The change

- `refresh()` classifies a failed list read with `isPermissionError` and sets a `listDenied` state; a successful read clears it.
- A distinct denied state renders "You don't have access to these attachments." with a `Lock` icon, checked **before** the empty state.
- The Upload affordance (button + its file input) is withdrawn under a denied list.
- The empty state is now reserved for a genuine 200-with-zero-rows.
- New `detail.attachmentsAccessDenied` key in `en` + all ten locale packs (ar, de, en, es, fr, ja, ko, pt, ru, zh), matching the panel's existing `useObjectTranslation` mechanism.

**No leaking.** objectui#2532's failure mode (raw error dump, status code, leaked rows) was absent before and stays absent: the denied state renders the translated sentence and nothing sourced from the error, and `setError` is deliberately not called on this path. Pinned by a test asserting the panel's text contains no `403`, no `2095`, no user id and no server message, and that no `alert` role appears.

**Scope.** This is the denied-vs-empty distinction only, not a general error-state framework. Non-authz failures (network, 5xx, 401) keep their pre-existing handling, pinned as-is by a test with a comment saying it is a pin rather than an endorsement. That remaining swallow is the same defect class one status over and is filed separately as #4684 — out of scope here, not fixed in this PR.

## Verification

All gates run **after** the final commit, at `6e3013925` (working tree clean).

| Gate | Result |
| --- | --- |
| `vitest run packages/app-shell/.../RecordAttachmentsPanel.test.tsx` | **14 passed** (8 pre-existing + 6 new) |
| `vitest run packages/i18n/` | **45 files, 804 passed** |
| `type-check` (app-shell + i18n, closure built first) | Done, clean |
| `eslint --quiet` (all 12 changed source files) | exit 0 |
| `pnpm check:i18n-keys` | every call-site key resolves; inline default matches its `en` value |
| `pnpm check:i18n-drift` | 1 key added, 0 `en` values changed |
| `pnpm check:control-bytes` | OK (4209 files) |
| `node scripts/check-changeset-presence.mjs` | 12 source files of 2 released packages, 1 changeset |

Dependency closure was built before testing (`pnpm --filter '@object-ui/app-shell^...' build`).

### Reverse verification — direction predicted first

Predicted: reverting **only** the component and keeping the tests turns exactly the 4 tests that require the denied state red, while the 200-empty test and the non-authz **pin** stay green (the pin asserts unchanged behavior, so it must pass on both trees).

Observed, exactly: **4 failed | 10 passed**. The failure dumps reproduce the reported symptom verbatim — on a 403 the reverted component rendered `Upload` and "No attachments yet. Upload a file to get started." The fix was then restored byte-identically (`git diff HEAD` empty) and re-run green.

_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_