### PR TITLE
fix(types): remove BaseFieldMetadata.indexed — dead declared key

### DIFF
--- a/.changeset/retire-basefield-metadata-indexed.md
+++ b/.changeset/retire-basefield-metadata-indexed.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/types': minor
+---
+
+Remove `BaseFieldMetadata.indexed` — the ObjectStack spec has no field-level
+index flag
+
+`indexed` was never a `FieldSchema` key. The field-level flag built no index
+(objectstack#2377 removed it) and, since objectstack#4001 replaced silent
+drops with loud rejection, `FieldSchema.safeParse` refuses it by name. PR
+#4675 already removed the designer-side declaration
+(`DesignerFieldDefinition.indexed`) and retired the Studio control that wrote
+it; this was the *other* declaration of the same dead key, on the
+renderer-side field-metadata type (`BaseFieldMetadata`, the type
+`FieldWidgetComponentProps.field` resolves to). Measured on current `main`:
+zero readers and zero writers anywhere in `packages/*/src` or `apps/*/src`
+outside of an unrelated "0-indexed" prose comment.
+
+Declare indexes on the object instead: `indexes: [{ name, fields, unique }]`.

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -129,11 +129,14 @@ export interface BaseFieldMetadata {
    */
   depends_on?: string[];
   
-  /**
-   * Field index for database optimization
+  /*
+   * There is deliberately no `indexed` here (objectui#4679). The ObjectStack
+   * spec has no field-level index flag: it built no index (objectstack#2377
+   * removed it) and `FieldSchema.safeParse` now rejects the key by name, so
+   * any producer that authored it produced a save-blocking 422. Declare the
+   * index on the object instead — `indexes: [{ name, fields, unique }]`.
    */
-  indexed?: boolean;
-  
+
   /**
    * Field is unique constraint
    */


### PR DESCRIPTION
Fixes #4679

## What

Removes `BaseFieldMetadata.indexed` (`packages/types/src/field-types.ts`) —
a declared field-metadata key with zero readers and zero writers anywhere in
`packages/*/src` or `apps/*/src` (verified fresh on `origin/main`), replaced
with a tombstone comment in the same style PR #4675 used in `designer.ts`
for the sibling `DesignerFieldDefinition.indexed` deletion.

`indexed` was never a `FieldSchema` key: the field-level flag built no index
(objectstack#2377 removed it), and since objectstack#4001 `FieldSchema.safeParse`
rejects the key by name (`unrecognized_keys`, probed against the installed
`@objectstack/spec` 17.0.0-rc.6). PR #4675 already removed the designer-side
declaration (`DesignerFieldDefinition.indexed`) and retired the Studio
control that wrote it; this is the *other* declaration of the same dead key,
on the renderer-side field-metadata type — the type
`FieldWidgetComponentProps.field` resolves to. Object-level
`indexes: [{ name, fields, unique }]` is the real surface.

## Scope

One file (`packages/types/src/field-types.ts`) + one changeset. No test was
added: PR #4675 set no precedent for a type-level pin test alongside this
kind of interface-field deletion, and per dispatch scope a type deletion's
verification is the cross-package type-check, not an invented test harness.

## Out of scope (noted, not touched)

While investigating, I found `VectorFieldMetadata.indexed`
(`packages/types/src/field-types.ts:635`, "Whether to index for similarity
search") is a **different** declared key on a **different** interface that
also has zero readers/writers and is also rejected by `FieldSchema.safeParse`
by name. I did not fold it into this PR: probing further showed
`VectorFieldMetadata` also declares `distance_metric`, which
`FieldSchema.safeParse` likewise rejects as `unrecognized_keys` — meaning
`VectorFieldMetadata` has broader drift from spec than a single dead key, and
a narrow "just delete `indexed`" fix there would leave a sibling problem
unaddressed in the same interface. That's outside this card's bounded
in-place exemption (mechanical + single-issue evidence), so I'm leaving it
for triage. Filed as a new unassigned finding — see the linked report.

## Verification

- `pnpm --filter '@object-ui/types' build && pnpm --filter '@object-ui/types' type-check` — green.
- Full downstream sweep: `pnpm turbo run type-check --filter='...@object-ui/types' --concurrency=2` (build closure + type-check across all 41 consumer packages, prefix/downstream direction) — **78 tasks successful, 78 total**.
- Reverse verification (proves tsc read the rebuilt `.d.ts`, not a cached one): added `indexed: true` to a `BaseFieldMetadata`-typed literal in `packages/fields/src/`, ran `tsc --noEmit` → `TS2353: Object literal may only specify known properties, and 'indexed' does not exist in type 'BaseFieldMetadata'.` Then removed the probe file (`git status` clean before commit).
- `pnpm exec vitest run packages/types/ --maxWorkers=2` — 420 tests passed (35 files).
- `pnpm --filter '@object-ui/types' exec eslint --quiet src/field-types.ts` — clean.
- `node scripts/check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-changeset-fixed.mjs`, `pnpm run check:control-bytes` — all green.

All of the above re-run at the final commit: HEAD `62f7c94ad`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_