### PR TITLE
fix(plugin-grid): row kebab ANDs the record-level write verdict, batched per page (#4296)

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,7 @@
+---
+"@object-ui/plugin-grid": patch
+---
+
+The list row kebab now ANDs the RECORD-level write verdict, not just the object-level grant (objectui#4296). A user holding a broad object grant under `writeScope: 'own'` was offered Edit and Delete on every row they could read, including rows the server refuses with `403 "You do not have access to this record"` — while the record detail header, which has folded the record-grained verdict since objectstack#3821, correctly hid both on the same record for the same user. `ObjectGrid` now asks the same authority the detail header asks (`security/explain`), batched once per (object, operation) for the rows on screen using the `recordIds` form from objectstack#8326, and feeds the answer through the row menu's existing per-row visibility decision — so a denied row loses its entries entirely rather than growing a disabled one, and grows no empty overflow trigger.
+
+Fails open on every uncertainty: a row with no verdict yet, an endpoint that is absent or failing, a row missing from the answer, or a row with no id keeps the object-level rendering this list had before. The server remains the authority; hiding a capability on missing data would be worse than the wasted click this removes. No public entry export changes.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -43,7 +43,8 @@ import { useRowColor } from './useRowColor';
 import { useGroupedData } from './useGroupedData';
 import { GroupRow } from './GroupRow';
 import { useColumnSummary } from './useColumnSummary';
-import { resolveRowCrudAffordances } from './rowCrudAffordances';
+import { resolveRowCrudAffordances, resolveRowRecordCrudAffordance } from './rowCrudAffordances';
+import { useRecordCrudVerdicts } from './hooks/useRecordCrudVerdicts';
 import { resolveLegacyRowActions } from './resolveLegacyRowActions';
 import { resolveBulkActions } from './resolveBulkActions';
 import { partitionBulkRows } from './bulkEligibility';
@@ -728,6 +729,87 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // data source), which leaves the affordance verdict untouched.
   const permissionUpdate = objectName ? perms.can(objectName, 'update') : undefined;
   const permissionDelete = objectName ? perms.can(objectName, 'delete') : undefined;
+
+  // When the consumer wired onEdit/onDelete callbacks but the view schema
+  // omits an explicit `operations` block, default to allowing those actions.
+  // This gives every main list a Row actions kebab out of the box without
+  // forcing every view JSON to declare operations: { update: true, delete: true }.
+  const explicitOperations = 'operations' in schema ? schema.operations : undefined;
+  const operations = explicitOperations ?? {
+    update: !!onEdit,
+    delete: !!onDelete,
+  };
+  // Row actions can declare 'edit' / 'delete' as canonical strings — treat
+  // them as equivalent to operations.update / operations.delete so the
+  // dropdown surfaces native Edit/Delete entries (with proper icons) and
+  // routes them to onEdit / onDelete instead of the generic action runner
+  // (which has no 'edit' handler and a parameter-shape mismatch for 'delete').
+  const rowActionsList: string[] = Array.isArray(schema.rowActions) ? schema.rowActions : [];
+  const rowActionDefsList: any[] = Array.isArray((schema as any).rowActionDefs) ? (schema as any).rowActionDefs : [];
+  const wantEditAction = rowActionsList.includes('edit');
+  const wantDeleteAction = rowActionsList.includes('delete');
+  // Legacy `rowActions` carry a bare action NAME, which the runner cannot
+  // execute on its own — resolve each against the object's declared actions so
+  // it dispatches as a real def (and so a name that duplicates an existing
+  // `list_item` def stops rendering a dead twin of it). See
+  // `resolveLegacyRowActions` for the full rationale (objectui#2960).
+  const { defs: resolvedRowActionDefs, unresolved: customRowActions } = resolveLegacyRowActions({
+    rowActions: rowActionsList.filter(a => a !== 'edit' && a !== 'delete'),
+    rowActionDefs: rowActionDefsList,
+    objectActions: (objectSchema as any)?.actions,
+  });
+  // Honor the object's resolved CRUD affordance: the ADR-0103 lifecycle bucket
+  // (`managedBy`), the `userActions.edit`/`delete` override — explicit `false`
+  // opts out of the generic row Edit/Delete (e.g. sys_environment ships a
+  // dedicated Rename + cascade-Delete instead, and the generic entries would
+  // duplicate them) — and [#3720] the server's effective API operation set, so
+  // the row kebab never offers an update/delete the server would reject.
+  // `operations` above only says whether the CONSUMER wired the affordance; it
+  // is not a permission grant, which is why the object verdict is ANDed here
+  // rather than assumed to have been applied upstream.
+  // [#4096] …and neither is `apiOperations`, which describes the OBJECT, not
+  // the caller — so the principal's own `allowEdit` / `allowDelete` is ANDed on
+  // top, matching the toolbar and the record header on the very same screen.
+  //
+  // Resolved HERE, above the error / loading early returns, rather than beside
+  // the row-actions column it feeds: the record-level layer below is a hook and
+  // may not sit behind a conditional return.
+  const { canEdit, canDelete, objectCanDelete, editPredicates, deletePredicates } = resolveRowCrudAffordances({
+    operationsUpdate: operations?.update,
+    operationsDelete: operations?.delete,
+    wantEditAction,
+    wantDeleteAction,
+    hasOnEdit: !!onEdit,
+    hasOnDelete: !!onDelete,
+    managedBy: (objectSchema as any)?.managedBy,
+    userActions: (objectSchema as any)?.userActions,
+    effectiveApiOperations: effectiveApiOps,
+    permissionUpdate,
+    permissionDelete,
+  });
+  // [#4296] …and neither of those describes the ROW. `allowEdit` is the
+  // principal's verdict on the OBJECT; `writeScope`, the sharing model and RLS
+  // narrow it per record, so everything above fails OPEN for every row the
+  // principal does not own — the kebab offered Edit/Delete on rows the server
+  // answers 403 for, while the record detail header (which has ANDed the
+  // record-grained verdict since objectstack#3821) correctly hid both on the
+  // very same record. One batched explain call per (object, operation) for the
+  // rows on screen answers it for the whole page; rows with no answer keep the
+  // object-level verdict (see `useRecordCrudVerdicts` — fail open, never
+  // over-hide).
+  const pageRecordIds = useMemo(
+    () => Array.from(new Set(
+      data.map(rowRecordId).filter((id) => id != null).map((id) => String(id)),
+    )),
+    [data],
+  );
+  const recordVerdict = useRecordCrudVerdicts({
+    objectName,
+    recordIds: pageRecordIds,
+    update: canEdit,
+    delete: canDelete,
+  });
+
   const schemaFields = schema.fields;
   const schemaColumns = schema.columns;
   // The view's declared filter, lowered ONCE through the repo's single filter
@@ -1935,59 +2017,11 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
     });
   }
 
-  // When the consumer wired onEdit/onDelete callbacks but the view schema
-  // omits an explicit `operations` block, default to allowing those actions.
-  // This gives every main list a Row actions kebab out of the box without
-  // forcing every view JSON to declare operations: { update: true, delete: true }.
-  const explicitOperations = 'operations' in schema ? schema.operations : undefined;
-  const operations = explicitOperations ?? {
-    update: !!onEdit,
-    delete: !!onDelete,
-  };
-  // Row actions can declare 'edit' / 'delete' as canonical strings — treat
-  // them as equivalent to operations.update / operations.delete so the
-  // dropdown surfaces native Edit/Delete entries (with proper icons) and
-  // routes them to onEdit / onDelete instead of the generic action runner
-  // (which has no 'edit' handler and a parameter-shape mismatch for 'delete').
-  const rowActionsList: string[] = Array.isArray(schema.rowActions) ? schema.rowActions : [];
-  const rowActionDefsList: any[] = Array.isArray((schema as any).rowActionDefs) ? (schema as any).rowActionDefs : [];
-  const wantEditAction = rowActionsList.includes('edit');
-  const wantDeleteAction = rowActionsList.includes('delete');
-  // Legacy `rowActions` carry a bare action NAME, which the runner cannot
-  // execute on its own — resolve each against the object's declared actions so
-  // it dispatches as a real def (and so a name that duplicates an existing
-  // `list_item` def stops rendering a dead twin of it). See
-  // `resolveLegacyRowActions` for the full rationale (objectui#2960).
-  const { defs: resolvedRowActionDefs, unresolved: customRowActions } = resolveLegacyRowActions({
-    rowActions: rowActionsList.filter(a => a !== 'edit' && a !== 'delete'),
-    rowActionDefs: rowActionDefsList,
-    objectActions: (objectSchema as any)?.actions,
-  });
-  // Honor the object's resolved CRUD affordance: the ADR-0103 lifecycle bucket
-  // (`managedBy`), the `userActions.edit`/`delete` override — explicit `false`
-  // opts out of the generic row Edit/Delete (e.g. sys_environment ships a
-  // dedicated Rename + cascade-Delete instead, and the generic entries would
-  // duplicate them) — and [#3720] the server's effective API operation set, so
-  // the row kebab never offers an update/delete the server would reject.
-  // `operations` above only says whether the CONSUMER wired the affordance; it
-  // is not a permission grant, which is why the object verdict is ANDed here
-  // rather than assumed to have been applied upstream.
-  // [#4096] …and neither is `apiOperations`, which describes the OBJECT, not
-  // the caller — so the principal's own `allowEdit` / `allowDelete` is ANDed on
-  // top, matching the toolbar and the record header on the very same screen.
-  const { canEdit, canDelete, objectCanDelete, editPredicates, deletePredicates } = resolveRowCrudAffordances({
-    operationsUpdate: operations?.update,
-    operationsDelete: operations?.delete,
-    wantEditAction,
-    wantDeleteAction,
-    hasOnEdit: !!onEdit,
-    hasOnDelete: !!onDelete,
-    managedBy: (objectSchema as any)?.managedBy,
-    userActions: (objectSchema as any)?.userActions,
-    effectiveApiOperations: effectiveApiOps,
-    permissionUpdate,
-    permissionDelete,
-  });
+  // `operations`, the row-action lists and the row CRUD affordance verdict are
+  // resolved further up, next to the permission reads they AND with — this
+  // render path sits BELOW the error / loading early returns, and [#4296] the
+  // record-level verdict they feed is fetched by a hook, which may not sit
+  // behind a conditional return.
   const hasActions = !!(operations && (operations.update || operations.delete));
   const hasRowActions = customRowActions.length > 0 || resolvedRowActionDefs.length > 0 || wantEditAction || wantDeleteAction;
 
@@ -2013,8 +2047,14 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
           rowActionDefs={resolvedRowActionDefs as any[]}
           objectFields={objectSchema?.fields}
           maxInlineActions={(schema as any).maxInlineRowActions ?? 1}
-          canEdit={canEdit}
-          canDelete={canDelete}
+          // [#4296] The object verdict ANDed with THIS row's record-level one.
+          // It rides the same per-row channel the #2614 predicates ride —
+          // `planRowActionMenu` conjoins `canEdit`/`canDelete` with
+          // `visibleWhen` in one expression, so the item and the "⋮" guard read
+          // one decision (#3562) and a hidden row grows no empty trigger. An
+          // unanswered row keeps the object verdict, i.e. today's rendering.
+          canEdit={resolveRowRecordCrudAffordance(canEdit, recordVerdict(rowRecordId(row), 'update'))}
+          canDelete={resolveRowRecordCrudAffordance(canDelete, recordVerdict(rowRecordId(row), 'delete'))}
           editPredicates={editPredicates}
           deletePredicates={deletePredicates}
           onEdit={onEdit}

--- a/packages/plugin-grid/src/__tests__/column-features.test.tsx
+++ b/packages/plugin-grid/src/__tests__/column-features.test.tsx
@@ -5,7 +5,7 @@
  *         link column rendering, action column rendering,
  *         and the useColumnSummary hook.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { renderHook } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -13,10 +13,22 @@ import React from 'react';
 
 import { ObjectGrid } from '../ObjectGrid';
 import { useColumnSummary } from '../useColumnSummary';
+import { __clearRecordCrudVerdictCache } from '../hooks/useRecordCrudVerdicts';
+import { installExplainDouble } from './explainDouble';
 import { registerAllFields } from '@object-ui/fields';
 import { ActionProvider } from '@object-ui/react';
 
 registerAllFields();
+
+// [#4296] The action-column grids here carry an objectName and rows with ids,
+// so each render batches a record-level explain probe. Answer it from a double
+// instead of the network (objectui#3339 / PR #4105); `visible: true` for every
+// row keeps the column assertions below measuring what they always measured.
+beforeEach(() => {
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
+});
+afterEach(() => { vi.unstubAllGlobals(); });
 
 // ---------------------------------------------------------------------------
 // Test data

--- a/packages/plugin-grid/src/__tests__/explainDouble.ts
+++ b/packages/plugin-grid/src/__tests__/explainDouble.ts
@@ -1,0 +1,73 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A stand-in for the record-level explain probe, for the plugin-grid suites
+ * that render `ObjectGrid` without wiring one themselves.
+ *
+ * [#4296] `ObjectGrid` batches a record-grained write verdict for the rows on
+ * screen (`POST /api/v1/security/explain` with `recordIds`). With no host
+ * `apiFetch` in the tree the hook falls back to the GLOBAL fetch — by design,
+ * for standalone embeds — which under happy-dom is a REAL request to the
+ * default origin. The verdict fails open on a failed request, so a suite that
+ * ignores it stays green while stderr fills with `connect ECONNREFUSED
+ * 127.0.0.1:3000`: exactly the escape objectui#3339 recorded for the singular
+ * probe on the detail side, and the shape PR #4105 settled — answer it from a
+ * double, never from the network, and never from a global error sink.
+ *
+ * Deliberately NOT a swallow-everything stub: it RECORDS every URL it is handed
+ * and answers only the explain endpoint, so an escape to some other endpoint
+ * stays observable instead of vanishing into a rejection the hook discards.
+ *
+ * The answer is `visible: true` for every id asked about, which reproduces the
+ * pre-#4296 rendering exactly — a permitted record narrows nothing, so no
+ * assertion in a consuming suite changes meaning. A suite that wants a DENYING
+ * verdict is testing this card's behavior and should say so explicitly; see
+ * `rowRecordCrudVerdict.test.tsx`, which serves both directions from a real
+ * verdict table.
+ */
+import { vi } from 'vitest';
+
+export interface ExplainDoubleCall {
+  url: string;
+  body: Record<string, unknown> | undefined;
+}
+
+/**
+ * Install the double on the global `fetch`. Pair with `vi.unstubAllGlobals()`
+ * in `afterEach`, and clear `__clearRecordCrudVerdictCache()` in `beforeEach`
+ * when a suite's rows repeat across tests.
+ *
+ * @returns the live call log, in request order.
+ */
+export function installExplainDouble(): ExplainDoubleCall[] {
+  const calls: ExplainDoubleCall[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: unknown, init?: { body?: unknown }) => {
+      const body = init?.body
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : undefined;
+      calls.push({ url: String(url), body });
+      const recordIds = Array.isArray(body?.recordIds) ? (body!.recordIds as string[]) : undefined;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          allowed: true,
+          object: body?.object,
+          operation: body?.operation,
+          principal: { userId: 'u_test' },
+          layers: [],
+          ...(recordIds ? { records: recordIds.map((id) => ({ recordId: id, visible: true })) } : {}),
+        }),
+      };
+    }),
+  );
+  return calls;
+}

--- a/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
+++ b/packages/plugin-grid/src/__tests__/rowCrudAffordances.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack Inc. MIT.
 import { describe, it, expect } from 'vitest';
-import { resolveRowCrudAffordances } from '../rowCrudAffordances';
+import { resolveRowCrudAffordances, resolveRowRecordCrudAffordance } from '../rowCrudAffordances';
 
 /** The row-level verdict only — drops the object-level bulk-delete bit. */
 const rowGate = (opts: Parameters<typeof resolveRowCrudAffordances>[0]) => {
@@ -287,5 +287,43 @@ describe('resolveRowCrudAffordances', () => {
         permissionDelete: true,
       })).toEqual({ canEdit: true, canDelete: false });
     });
+  });
+});
+
+/**
+ * [#4296] Layer (e) — the RECORD-level verdict, the one narrowing that is
+ * decided per row rather than per object.
+ *
+ * The layer below it (#4096) answers "may this principal write this OBJECT";
+ * `writeScope`, the sharing model and RLS narrow that per record, so the row
+ * kebab offered Edit/Delete on every row the user could READ until this layer
+ * existed — including rows the server answers 403 for.
+ */
+describe('resolveRowRecordCrudAffordance (#4296)', () => {
+  it('hides the entry when the record-level verdict denies THIS row', () => {
+    // The card's cell: the object grant is true, the row is not the caller's.
+    expect(resolveRowRecordCrudAffordance(true, false)).toBe(false);
+  });
+
+  it('keeps the entry when the record-level verdict allows THIS row', () => {
+    expect(resolveRowRecordCrudAffordance(true, true)).toBe(true);
+  });
+
+  it('degrades to the object verdict when the record answer is UNKNOWN', () => {
+    // No answer yet / endpoint down / row missing from the map / no row id.
+    // Unknown must never read as denial: the server already fail-closes, so an
+    // over-hidden row costs a permitted user a capability they actually have.
+    expect(resolveRowRecordCrudAffordance(true, undefined)).toBe(true);
+    expect(resolveRowRecordCrudAffordance(false, undefined)).toBe(false);
+  });
+
+  it('intersects, never unions — a record grant cannot re-open the object verdict', () => {
+    // The whole chain above (bucket, userActions, apiOperations, allowEdit)
+    // stays authoritative; this layer only ever removes.
+    expect(resolveRowRecordCrudAffordance(false, true)).toBe(false);
+  });
+
+  it('an absent object verdict stays absent', () => {
+    expect(resolveRowRecordCrudAffordance(undefined, true)).toBe(false);
   });
 });

--- a/packages/plugin-grid/src/__tests__/rowCrudEffectiveOps.test.tsx
+++ b/packages/plugin-grid/src/__tests__/rowCrudEffectiveOps.test.tsx
@@ -86,6 +86,8 @@ vi.mock('@object-ui/permissions', async (importOriginal) => {
 });
 
 import { ObjectGrid } from '../ObjectGrid';
+import { __clearRecordCrudVerdictCache } from '../hooks/useRecordCrudVerdicts';
+import { installExplainDouble } from './explainDouble';
 import { registerAllFields } from '@object-ui/fields';
 import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
 
@@ -185,8 +187,15 @@ beforeEach(() => {
   state.permUpdate = true;
   state.permDelete = true;
   state.noProvider = false;
+  // [#4296] This file's grids carry an objectName and rows with ids, so each
+  // render batches a record-level explain probe. Answer it from a double
+  // instead of the network (objectui#3339 / PR #4105). It answers `visible:
+  // true` for every row, so the OBJECT-level matrix below — which is what this
+  // file pins — is measured with the record layer contributing nothing.
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
 });
-afterEach(() => { cleanup(); });
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
 
 describe('ObjectGrid row CRUD vs the effective API operation set (#3720)', () => {
   // The exact matrix from the issue: A baseline, B the bug, C control group.

--- a/packages/plugin-grid/src/__tests__/rowRecordCrudVerdict.test.tsx
+++ b/packages/plugin-grid/src/__tests__/rowRecordCrudVerdict.test.tsx
@@ -1,0 +1,504 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * [#4296] The row kebab vs the RECORD-level write verdict.
+ *
+ * The card measured one screen giving two opposite answers for one record and
+ * one user: the row kebab offered Edit and Delete (it ANDed only the
+ * OBJECT-level grant — `rowCrudAffordances` layer (d), #4096), while the record
+ * detail header hid both (it also folds the record-grained verdict, via
+ * `plugin-detail`'s `useRecordEditable`, objectstack#3821). The server agreed
+ * with the detail header: `PATCH` and `DELETE` on that row both answer
+ * `403 "You do not have access to this record"`. The kebab was offering two
+ * buttons that cannot succeed.
+ *
+ * The repro shape reproduced here is the card's, exactly: object-level grant
+ * TRUE (`allowEdit` / `allowDelete`, full `apiOperations`) + `writeScope: 'own'`
+ * + a row owned by somebody else. Nothing about the OBJECT-level chain changes;
+ * every gate above still runs first.
+ *
+ * ## What the fake server is
+ *
+ * ONE fake `security/explain` service, serving BOTH question shapes out of ONE
+ * verdict table: the batch form (`recordIds`, objectstack#8326 / PR #8452) the
+ * grid asks, and the singular form (`recordId`) the detail header asks. That is
+ * what makes the truth-table agreement test below a real agreement test — the
+ * two surfaces are asked the same question about the same record by the same
+ * principal, and the assertion is that they return the same answer. The real
+ * handler guarantees the same thing by construction ("the batch answer for a
+ * record is the singular answer for that record"), so a fake that could answer
+ * the two forms differently would be testing something the platform does not do.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+// Same stable-identity permission stub as `rowCrudEffectiveOps.test.tsx`:
+// ObjectGrid carries `perms` in `useMemo` dependency arrays, so a fresh object
+// per call would churn those memos every render.
+const { permsStub, state } = vi.hoisted(() => {
+  const state: {
+    effectiveOps: string[] | undefined;
+    permUpdate: boolean;
+    permDelete: boolean;
+  } = { effectiveOps: undefined, permUpdate: true, permDelete: true };
+  return {
+    state,
+    permsStub: {
+      isLoaded: false,
+      checkField: () => true,
+      getObjectApiOperations: () => state.effectiveOps,
+      can: (_obj: string, action: string) =>
+        action === 'delete' ? state.permDelete : state.permUpdate,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub };
+});
+
+import { ObjectGrid } from '../ObjectGrid';
+import { __clearRecordCrudVerdictCache } from '../hooks/useRecordCrudVerdicts';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+// READ-ONLY reference to the OTHER surface's real implementation. The agreement
+// pin is worth nothing against a local re-statement of the detail header's
+// logic: it has to consume the same hook `RecordDetailView` consumes, unchanged
+// and unmocked, so that a future divergence on EITHER side fails here.
+import {
+  useRecordEditable,
+  __clearRecordEditableCache,
+} from '../../../plugin-detail/src/useRecordEditable';
+
+registerAllFields();
+
+const OBJECT = 'showcase_project';
+/** The caller's own row — `writeScope: 'own'` admits it. */
+const OWN_ROW = { id: 'r_own', name: 'My Project' };
+/** The card's row: owner `linus@example.com`, refused by the server with 403. */
+const OTHER_ROW = { id: 'r_other', name: 'Legacy Sunset' };
+const ROWS = [OWN_ROW, OTHER_ROW];
+
+const FULL = ['get', 'list', 'create', 'update', 'delete'];
+
+type Operation = 'update' | 'delete';
+
+interface ExplainCall {
+  object?: string;
+  operation?: Operation;
+  recordId?: string;
+  recordIds?: string[];
+}
+
+/**
+ * The fake `security/explain` service. `verdicts` is the record-grained truth
+ * the real engine would derive from `writeScope` / sharing / RLS.
+ */
+const server = {
+  calls: [] as ExplainCall[],
+  responses: [] as Promise<unknown>[],
+  verdicts: new Map<string, Record<Operation, boolean>>(),
+  /** Non-OK response (401 / 403 / 501 / 5xx) — the fail-open path. */
+  ok: true,
+  /** Network / CORS failure — the other fail-open path. */
+  network: true,
+  /** A service predating the batch form: answers object-level, no `records`. */
+  answersBatch: true,
+  /** Set by {@link hold}: responses wait here until {@link release} is called. */
+  gate: null as Promise<void> | null,
+  release: () => {},
+  /** Hold every answer open, so the pre-verdict window is a real, testable state. */
+  hold() {
+    server.gate = new Promise<void>((resolve) => {
+      server.release = () => resolve();
+    });
+  },
+  reset() {
+    server.calls = [];
+    server.responses = [];
+    server.verdicts = new Map();
+    server.ok = true;
+    server.network = true;
+    server.answersBatch = true;
+    server.gate = null;
+    server.release = () => {};
+  },
+};
+
+const apiFetch = async (_input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const body = JSON.parse(String(init?.body ?? '{}')) as ExplainCall;
+  server.calls.push(body);
+  if (!server.network) throw new TypeError('Failed to fetch');
+  const operation = (body.operation ?? 'update') as Operation;
+  // A record the engine cannot resolve fail-closes to `visible: false` — the
+  // platform's own missing-record semantics, mirrored here.
+  const visibleFor = (id: string) => server.verdicts.get(id)?.[operation] ?? false;
+  const base = {
+    allowed: true,
+    object: body.object,
+    operation,
+    principal: { userId: 'u_member' },
+    layers: [],
+  };
+  const payload = !server.answersBatch
+    ? base
+    : Array.isArray(body.recordIds)
+      ? { ...base, records: body.recordIds.map((id) => ({ recordId: id, visible: visibleFor(id) })) }
+      : typeof body.recordId === 'string'
+        ? { ...base, record: { recordId: body.recordId, visible: visibleFor(body.recordId) } }
+        : base;
+  const res = {
+    ok: server.ok,
+    status: server.ok ? 200 : 500,
+    json: async () => payload,
+  } as unknown as Response;
+  const settled = (async () => {
+    if (server.gate) await server.gate;
+    return res;
+  })();
+  server.responses.push(settled);
+  return settled;
+};
+
+/** The detail header's verdict for one record, rendered as observable text. */
+const DetailHeaderProbe: React.FC<{ recordId: string; operation: Operation }> = ({
+  recordId,
+  operation,
+}) => {
+  const allowed = useRecordEditable(OBJECT, recordId, operation);
+  return <span data-testid={`detail-${operation}-${recordId}`}>{String(allowed)}</span>;
+};
+
+interface Case {
+  rows?: Array<Record<string, unknown>>;
+  effectiveOps?: string[];
+  permUpdate?: boolean;
+  permDelete?: boolean;
+  /** Mount the detail-header probes for the truth-table agreement pin. */
+  probes?: Array<{ recordId: string; operation: Operation }>;
+}
+
+function renderGrid(c: Case = {}) {
+  state.effectiveOps = c.effectiveOps ?? FULL;
+  state.permUpdate = c.permUpdate ?? true;
+  state.permDelete = c.permDelete ?? true;
+  const rows = c.rows ?? ROWS;
+  const dataSource: any = {
+    getObjectSchema: async (name: string) => ({
+      name,
+      fields: { id: { type: 'text' }, name: { type: 'text', label: 'Name' } },
+    }),
+  };
+  const schema: any = {
+    type: 'object-grid',
+    objectName: OBJECT,
+    columns: [{ field: 'name', label: 'Name' }],
+    data: { provider: 'value', items: rows },
+    // A page big enough to hold every fixture row, so "the rows on screen" is
+    // the whole fixture and the call-count pins are unambiguous.
+    pageSize: 500,
+  };
+  return render(
+    <ActionProvider>
+      <SchemaRendererProvider dataSource={dataSource} apiFetch={apiFetch}>
+        <ObjectGrid
+          schema={schema}
+          dataSource={dataSource}
+          onEdit={() => {}}
+          onDelete={() => {}}
+          onBulkDelete={() => {}}
+        />
+        {(c.probes ?? []).map((p) => (
+          <DetailHeaderProbe key={`${p.operation}:${p.recordId}`} {...p} />
+        ))}
+      </SchemaRendererProvider>
+    </ActionProvider>,
+  );
+}
+
+/** Wait for the rows to be on screen, then for every explain answer to land. */
+async function settle(expectedCalls: number) {
+  await waitFor(() => expect(server.calls.length).toBe(expectedCalls));
+  await act(async () => {
+    await Promise.allSettled(server.responses);
+  });
+}
+
+/**
+ * What the kebab of the row displaying `label` surfaces.
+ *
+ * Located by ROW rather than by index: a row whose entries are all hidden grows
+ * no "⋮" trigger at all (#3562), so `queryAllByTestId('row-action-trigger')[i]`
+ * silently addresses a different row as soon as the fix works.
+ */
+async function rowKebab(label: string): Promise<{ edit: boolean; delete: boolean }> {
+  const row = screen.getByText(label).closest('tr');
+  const trigger = row?.querySelector('[data-testid="row-action-trigger"]');
+  if (!trigger) return { edit: false, delete: false };
+  await userEvent.click(trigger);
+  const answer = {
+    edit: screen.queryAllByTestId('row-action-builtin-edit').length > 0,
+    delete: screen.queryAllByTestId('row-action-builtin-delete').length > 0,
+  };
+  // Close the (portalled) menu so the next row's read sees only its own items.
+  await userEvent.keyboard('{Escape}');
+  return answer;
+}
+
+beforeEach(() => {
+  server.reset();
+  __clearRecordCrudVerdictCache();
+  __clearRecordEditableCache();
+  server.verdicts.set(OWN_ROW.id, { update: true, delete: true });
+  server.verdicts.set(OTHER_ROW.id, { update: false, delete: false });
+});
+afterEach(() => {
+  cleanup();
+});
+
+describe('[#4296] the row kebab folds the record-level verdict', () => {
+  it('the card repro: object grant true + writeScope own + a NON-OWNED row loses Edit and Delete', async () => {
+    // Pre-fix this returned `{ edit: true, delete: true }` — the whole card.
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await settle(2);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: false, delete: false });
+  });
+
+  it("an owner's OWN row still offers Edit and Delete under writeScope own", async () => {
+    // The control group in the other direction: the fix must not cost a user
+    // the rows they may genuinely write, or it is a capability regression
+    // wearing a bug fix's clothes.
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OWN_ROW.name)).toBeInTheDocument());
+    await settle(2);
+    expect(await rowKebab(OWN_ROW.name)).toEqual({ edit: true, delete: true });
+  });
+
+  it('hides rather than disables — a fully denied row grows no "⋮" trigger at all', async () => {
+    // Ruling: hide, don't disable (the detail header's posture and #4096's
+    // precedent). #3562's invariant rides along: the guard and the items read
+    // ONE decision, so a row with nothing left must not sprout an empty menu.
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await settle(2);
+    const deniedRow = screen.getByText(OTHER_ROW.name).closest('tr');
+    expect(deniedRow?.querySelector('[data-testid="row-action-trigger"]')).toBeNull();
+    // …while the permitted row on the same screen keeps its trigger, so the
+    // assertion above is observing the verdict and not an empty grid.
+    const ownRow = screen.getByText(OWN_ROW.name).closest('tr');
+    expect(ownRow?.querySelector('[data-testid="row-action-trigger"]')).not.toBeNull();
+  });
+
+  it('gates update and delete independently on the same row', async () => {
+    server.verdicts.set(OTHER_ROW.id, { update: false, delete: true });
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await settle(2);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: false, delete: true });
+  });
+});
+
+/**
+ * The card's truth table, as a literal agreement test: same record, same user,
+ * both surfaces. The detail side is the REAL `useRecordEditable` — imported,
+ * not re-implemented — so this fails if either surface drifts.
+ */
+describe('[#4296] kebab answer == detail-header answer, for the same record and user', () => {
+  it('agrees on the NON-OWNED row (both hide) and on the OWN row (both show)', async () => {
+    renderGrid({
+      probes: [
+        { recordId: OTHER_ROW.id, operation: 'update' },
+        { recordId: OTHER_ROW.id, operation: 'delete' },
+        { recordId: OWN_ROW.id, operation: 'update' },
+        { recordId: OWN_ROW.id, operation: 'delete' },
+      ],
+    });
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    // 2 batch calls (one per operation, for the page) + 4 singular probes.
+    await settle(6);
+
+    // The detail header's own verdicts, measured first and independently.
+    await waitFor(() =>
+      expect(screen.getByTestId(`detail-update-${OTHER_ROW.id}`)).toHaveTextContent('false'),
+    );
+    const detail = (recordId: string, operation: Operation) =>
+      screen.getByTestId(`detail-${operation}-${recordId}`).textContent === 'true';
+
+    const otherKebab = await rowKebab(OTHER_ROW.name);
+    const ownKebab = await rowKebab(OWN_ROW.name);
+
+    // The agreement itself — the cell the card measured as contradictory.
+    expect(otherKebab).toEqual({
+      edit: detail(OTHER_ROW.id, 'update'),
+      delete: detail(OTHER_ROW.id, 'delete'),
+    });
+    expect(ownKebab).toEqual({
+      edit: detail(OWN_ROW.id, 'update'),
+      delete: detail(OWN_ROW.id, 'delete'),
+    });
+    // …and the values that agreement lands on, so a mutually-broken pair of
+    // surfaces cannot satisfy the assertions above by agreeing on nonsense.
+    expect(otherKebab).toEqual({ edit: false, delete: false });
+    expect(ownKebab).toEqual({ edit: true, delete: true });
+  });
+});
+
+/**
+ * Ruling 3 — missing data degrades to TODAY, never over-hides. The server is
+ * the authority and already fail-closes with a 403; an over-hidden row costs a
+ * permitted user a capability they actually have, which is strictly worse than
+ * the wasted click this card is about. Same posture as `useRecordEditable`.
+ *
+ * The control group for this whole block is the repro test above: it observes
+ * "hidden" through the identical helper, so a passing degradation case here is
+ * not just a probe that cannot see anything.
+ */
+describe('[#4296] degradation — an unanswered row keeps the object-level verdict', () => {
+  it('a non-OK explain response leaves both entries where they were', async () => {
+    server.ok = false;
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await settle(2);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: true, delete: true });
+  });
+
+  it('a network failure leaves both entries where they were', async () => {
+    server.network = false;
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await settle(2);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: true, delete: true });
+  });
+
+  it('a service that answers no records[] at all (pre-batch backend) changes nothing', async () => {
+    server.answersBatch = false;
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await settle(2);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: true, delete: true });
+  });
+
+  it('a row carrying no id keeps the object-level verdict', async () => {
+    // Nothing to ask the server about, so nothing can narrow it.
+    renderGrid({ rows: [{ name: 'Anonymous Row' }] });
+    await waitFor(() => expect(screen.getByText('Anonymous Row')).toBeInTheDocument());
+    expect(server.calls.length).toBe(0);
+    expect(await rowKebab('Anonymous Row')).toEqual({ edit: true, delete: true });
+  });
+
+  it('the pre-answer window renders today\'s verdict, not a hidden one', async () => {
+    // The rows paint before the round trip resolves. Fail-open means the kebab
+    // shows the object-level answer in that window rather than blinking through
+    // a hidden state — the same window `useRecordEditable` has always had on
+    // the detail header. The answer is HELD open here, so the window is a real
+    // state this test observes rather than a race it hopes to catch.
+    server.hold();
+    renderGrid();
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await waitFor(() => expect(server.calls.length).toBe(2));
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: true, delete: true });
+    // …and once the verdict lands, the entries go.
+    server.release();
+    await settle(2);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: false, delete: false });
+  });
+});
+
+/**
+ * The batch shape — the reason this card was blocked on objectstack#8326 at
+ * all. A per-row probe would cost 2N round trips; the fold asks one batched
+ * question per (object, operation) for the whole page.
+ */
+describe('[#4296] one batched call per (object, operation) per page', () => {
+  const bigPage = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({ id: `r_${i}`, name: `Row ${i}` }));
+
+  it('a 50-row page issues 2 explain calls, not 100', async () => {
+    const rows = bigPage(50);
+    for (const r of rows) server.verdicts.set(r.id, { update: true, delete: true });
+    renderGrid({ rows });
+    await waitFor(() => expect(screen.getByText('Row 49')).toBeInTheDocument());
+    await settle(2);
+
+    expect(server.calls.length).toBe(2);
+    expect(server.calls.map((c) => c.operation).sort()).toEqual(['delete', 'update']);
+    for (const call of server.calls) {
+      expect(call.object).toBe(OBJECT);
+      // The batch spelling, never the singular one — a request carrying both
+      // is a 400 on the real server, and N singular calls is the cost this
+      // whole design exists to avoid.
+      expect(call.recordId).toBeUndefined();
+      expect(call.recordIds).toEqual(rows.map((r) => r.id));
+    }
+  });
+
+  it('paginates under the server\'s 200-id cap instead of sending a request it would refuse', async () => {
+    // The cap is the server's (`EXPLAIN_BATCH_MAX_RECORD_IDS`): over-cap
+    // requests are refused with 400 VALIDATION_FAILED, never truncated, and the
+    // spec directs consumers to paginate under it. Still amortized — 2 calls
+    // per operation for 250 rows, not 250.
+    const rows = bigPage(250);
+    for (const r of rows) server.verdicts.set(r.id, { update: true, delete: true });
+    renderGrid({ rows });
+    await waitFor(() => expect(screen.getByText('Row 249')).toBeInTheDocument());
+    await settle(4);
+
+    expect(server.calls.length).toBe(4);
+    for (const call of server.calls) {
+      expect(call.recordIds!.length).toBeLessThanOrEqual(200);
+      expect(call.recordIds!.length).toBeGreaterThan(0);
+    }
+    for (const operation of ['update', 'delete'] as const) {
+      const asked = server.calls
+        .filter((c) => c.operation === operation)
+        .flatMap((c) => c.recordIds!);
+      expect(asked.sort()).toEqual(rows.map((r) => r.id).sort());
+    }
+  });
+
+  it('asks nothing when the OBJECT-level verdict already hides both entries', async () => {
+    // A question whose answer cannot change anything is not worth a round trip.
+    renderGrid({ permUpdate: false, permDelete: false });
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    expect(server.calls.length).toBe(0);
+  });
+});
+
+/**
+ * [#4096] The object-level chain is untouched — this layer only ever removes.
+ * The pins that matter live in `rowCrudEffectiveOps.test.tsx`; these are the
+ * two directions that could only break through the NEW layer.
+ */
+describe('[#4296] the record layer intersects, never unions', () => {
+  it('a record-level grant cannot re-open an object-level denial', async () => {
+    // The server would happily write this record, but the principal has no
+    // `allowDelete` on the object — Delete stays hidden, and no delete question
+    // is even asked.
+    server.verdicts.set(OTHER_ROW.id, { update: true, delete: true });
+    renderGrid({ permDelete: false });
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    await settle(1);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: true, delete: false });
+    expect(server.calls.map((c) => c.operation)).toEqual(['update']);
+  });
+
+  it('a record-level grant cannot re-open a closed API exposure surface', async () => {
+    server.verdicts.set(OTHER_ROW.id, { update: true, delete: true });
+    renderGrid({ effectiveOps: ['get', 'list'] });
+    await waitFor(() => expect(screen.getByText(OTHER_ROW.name)).toBeInTheDocument());
+    expect(server.calls.length).toBe(0);
+    expect(await rowKebab(OTHER_ROW.name)).toEqual({ edit: false, delete: false });
+  });
+});

--- a/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
+++ b/packages/plugin-grid/src/components/__tests__/RowActionMenu.emptyGuard.test.tsx
@@ -30,7 +30,7 @@
  * surface needs: the inline PRIMARY button path, and the legacy string
  * `rowActions` that carry no predicate.
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
@@ -39,6 +39,8 @@ import { registerAllFields } from '@object-ui/fields';
 import type { CrudAffordances } from '@object-ui/core';
 import { RowActionMenu, planRowActionMenu } from '../RowActionMenu';
 import { ObjectGrid } from '../../ObjectGrid';
+import { __clearRecordCrudVerdictCache } from '../../hooks/useRecordCrudVerdicts';
+import { installExplainDouble } from '../../__tests__/explainDouble';
 
 registerAllFields();
 
@@ -62,7 +64,16 @@ function renderMenu(props: Record<string, unknown>) {
   );
 }
 
-afterEach(() => { cleanup(); });
+// [#4296] The `ObjectGrid` describe at the bottom of this file renders a real
+// grid, which batches a record-level explain probe for its rows. Answer it from
+// a double instead of letting it escape to the network (objectui#3339 / PR
+// #4105); `visible: true` for every row leaves this file's alignment and
+// trigger-count assertions measuring exactly what they measured before.
+beforeEach(() => {
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); });
 
 describe('RowActionMenu — the "⋮" counts renderable items, not handlers (#3562)', () => {
   it('renders NO trigger when every built-in item is predicate-suppressed', () => {

--- a/packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts
+++ b/packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts
@@ -1,0 +1,216 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * May this user write THESE rows? (objectui#4296)
+ *
+ * The object-level grant is not the write verdict on a record. `writeScope`,
+ * the sharing model and RLS narrow it per row, so a list that ANDs only the
+ * object-level answer offers Edit/Delete on every row the user can READ —
+ * including the rows the server answers `403 "You do not have access to this
+ * record"` for. The record detail header has folded the record-grained verdict
+ * since objectstack#3821 (`plugin-detail`'s `useRecordEditable`), which is why
+ * one screen carried two opposite answers for one record and one user.
+ *
+ * This hook is the list-shaped half of the same question. It asks the SAME
+ * authority the detail header asks — the explain engine's record-grained
+ * verdict (`POST /api/v1/security/explain`, ADR-0090 D6 / ADR-0095 C2), the
+ * same pipeline the enforcement middleware runs — so the kebab and the server
+ * cannot disagree, and neither can the kebab and the detail header.
+ *
+ * ## One call per (object, operation) per page, not two per row
+ *
+ * The singular probe the detail header uses answers ONE record. Folding it into
+ * a list row-by-row would cost 2N round trips (a 50-row page = 100 POSTs), and
+ * that cost is why this card sat blocked: the batch form
+ * (`recordIds: string[]`, objectstack#8326, shipped in objectstack PR #8452) is
+ * what makes a page-level fold affordable. `records[i]` answers `recordIds[i]`;
+ * each entry is the verdict the singular form returns for that id, so the list
+ * and the detail header read the same number by construction rather than by
+ * two implementations agreeing.
+ *
+ * ## Fail OPEN on every uncertainty — degrade to today, never over-hide
+ *
+ * No answer yet, a non-OK response, a deployment without
+ * `@objectstack/plugin-security`, a row missing from the verdict map, a split
+ * SPA origin where the cookie doesn't reach the API: the row's verdict is
+ * `undefined` and the caller keeps the OBJECT-level answer, i.e. exactly what
+ * this list rendered before this hook existed. The server is the authority
+ * (ADR-0057 D10) and stays so; hiding a capability on missing data would be a
+ * worse defect than the wasted click this fixes, and it is the same posture
+ * `useRecordEditable` takes for the detail header.
+ *
+ * The probe rides the host's AUTHENTICATED fetch (`SchemaRendererProvider`'s
+ * `apiFetch`) rather than the bare global one: a bearer-token session carries
+ * its credential in a header, not a cookie, so `credentials: 'include'` alone
+ * would 401 on a perfectly valid session and the verdict would always fail open
+ * (framework#3923 ②, measured on the singular probe). Cookies stay on for
+ * cookie-session hosts.
+ */
+import * as React from 'react';
+import { SchemaRendererContext } from '@object-ui/react';
+
+/** The two write verbs a list row's kebab can offer. */
+export type RecordCrudOperation = 'update' | 'delete';
+
+/**
+ * Hard cap on `recordIds` per batch explain request — the SERVER's contract
+ * (`EXPLAIN_BATCH_MAX_RECORD_IDS`, objectstack#8326): over-cap requests are
+ * refused with `400 VALIDATION_FAILED`, never truncated, and the spec's own
+ * TSDoc directs a consumer with more records to paginate under it. A page
+ * larger than the cap is therefore split into ceil(N / 200) requests per
+ * operation — still amortized, never one per row.
+ *
+ * Declared locally because the pinned `@objectstack/spec@17.0.0-rc.6` predates
+ * the batch form and exports neither the constant nor the request/response
+ * types; the pin bump (objectui#4636) supersedes this declaration.
+ */
+const EXPLAIN_BATCH_MAX_RECORD_IDS = 200;
+
+/**
+ * One entry of the batch response's `records` array, narrowed to what this hook
+ * reads. Wire payloads are `unknown` until proven otherwise — a malformed entry
+ * must land on "no verdict for this row" (fail open), never on a coerced
+ * boolean.
+ */
+interface WireRecordVerdict {
+  recordId?: unknown;
+  visible?: unknown;
+}
+
+/**
+ * A settled verdict lookup for the rows on screen.
+ *
+ * `undefined` means UNKNOWN — not "denied". Every caller must treat it as the
+ * instruction to keep the object-level answer.
+ */
+export type RecordCrudVerdictLookup = (
+  recordId: string | number | null | undefined,
+  operation: RecordCrudOperation,
+) => boolean | undefined;
+
+/**
+ * Verdicts memoised across pages and renders, keyed `object:recordId:operation`
+ * — the same key shape and the same "revisiting is free" posture as
+ * `useRecordEditable`'s cache, so paging back and forth costs nothing and the
+ * two surfaces answer a record identically for the life of the session.
+ */
+const verdictCache = new Map<string, boolean>();
+
+const cacheKey = (object: string, recordId: string, operation: RecordCrudOperation): string =>
+  `${object}:${recordId}:${operation}`;
+
+/** Test seam — drops the memoised verdicts. */
+export function __clearRecordCrudVerdictCache(): void {
+  verdictCache.clear();
+}
+
+const NO_VERDICTS: RecordCrudVerdictLookup = () => undefined;
+
+export function useRecordCrudVerdicts(opts: {
+  /** The object the rows belong to; absent (element data source) = no question to ask. */
+  objectName?: string;
+  /** The record ids on screen. Order is irrelevant; duplicates are harmless. */
+  recordIds: readonly string[];
+  /**
+   * Ask about `update` at all. Pass the OBJECT-level verdict: when the object
+   * answer already hides the entry, the record answer cannot change anything,
+   * so the request is not worth sending.
+   */
+  update?: boolean;
+  /** Ask about `delete` at all. Same gate as {@link update}. */
+  delete?: boolean;
+}): RecordCrudVerdictLookup {
+  const { objectName, recordIds, update: wantUpdate, delete: wantDelete } = opts;
+  // Read the context directly (not `useSchemaContext`, which throws when no
+  // provider is mounted): a standalone grid embed has no host fetch and must
+  // still degrade to the global one rather than crash the render.
+  const apiFetch = React.useContext(SchemaRendererContext)?.apiFetch;
+
+  // The id LIST is re-derived from a stable key so this hook cannot loop on a
+  // caller that rebuilds the array each render — and so the effect's dependency
+  // array stays exhaustive rather than suppressed.
+  const idsKey = JSON.stringify(recordIds);
+  const ids = React.useMemo<readonly string[]>(() => JSON.parse(idsKey) as string[], [idsKey]);
+
+  const [verdicts, setVerdicts] = React.useState<ReadonlyMap<string, boolean>>(() => new Map());
+
+  React.useEffect(() => {
+    const operations: RecordCrudOperation[] = [];
+    if (wantUpdate) operations.push('update');
+    if (wantDelete) operations.push('delete');
+    if (!objectName || ids.length === 0 || operations.length === 0) {
+      setVerdicts(new Map());
+      return;
+    }
+    let cancelled = false;
+    const doFetch = apiFetch ?? fetch;
+
+    /** Publish what the cache holds for the rows on screen — nothing else. */
+    const publish = () => {
+      const next = new Map<string, boolean>();
+      for (const operation of operations) {
+        for (const id of ids) {
+          const verdict = verdictCache.get(cacheKey(objectName, id, operation));
+          if (typeof verdict === 'boolean') next.set(`${operation}:${id}`, verdict);
+        }
+      }
+      setVerdicts(next);
+    };
+
+    void (async () => {
+      await Promise.all(operations.map(async (operation) => {
+        const missing = ids.filter((id) => !verdictCache.has(cacheKey(objectName, id, operation)));
+        for (let i = 0; i < missing.length; i += EXPLAIN_BATCH_MAX_RECORD_IDS) {
+          const chunk = missing.slice(i, i + EXPLAIN_BATCH_MAX_RECORD_IDS);
+          try {
+            const res = await doFetch('/api/v1/security/explain', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              credentials: 'include',
+              body: JSON.stringify({ object: objectName, operation, recordIds: chunk }),
+            });
+            if (!res.ok) continue; // 401 / 403 / 501 → fail open
+            const decision: unknown = await res.json();
+            const records = (decision as { records?: unknown } | null)?.records;
+            if (!Array.isArray(records)) continue; // no batch verdict → fail open
+            // Ordering IS the contract: `records[i]` answers `recordIds[i]`.
+            // The echoed `recordId` is checked, not trusted as the key — a
+            // response that disagrees with its own ordering contract is not a
+            // response this hook can safely re-key, so the entry is dropped and
+            // that row falls back to the object-level answer.
+            chunk.forEach((id, index) => {
+              const entry = records[index] as WireRecordVerdict | undefined;
+              if (!entry || typeof entry.visible !== 'boolean') return;
+              if (typeof entry.recordId === 'string' && entry.recordId !== id) return;
+              verdictCache.set(cacheKey(objectName, id, operation), entry.visible);
+            });
+          } catch {
+            /* network / parse failure → fail open */
+          }
+        }
+      }));
+      if (!cancelled) publish();
+    })();
+
+    // Rows already in the cache answer on this render rather than after the
+    // round trip — paging back to a visited page never blinks through the
+    // fail-open state.
+    publish();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [objectName, ids, wantUpdate, wantDelete, apiFetch]);
+
+  return React.useMemo<RecordCrudVerdictLookup>(() => {
+    if (verdicts.size === 0) return NO_VERDICTS;
+    return (recordId, operation) =>
+      recordId == null ? undefined : verdicts.get(`${operation}:${String(recordId)}`);
+  }, [verdicts]);
+}

--- a/packages/plugin-grid/src/rowCrudAffordances.ts
+++ b/packages/plugin-grid/src/rowCrudAffordances.ts
@@ -72,6 +72,24 @@
  * **per record**. The predicates are returned untouched as
  * `editPredicates` / `deletePredicates` for the row renderer to evaluate
  * (they never affect the object-level `canEdit` / `canDelete` verdict).
+ *
+ * On top of all of the above sits one more layer, applied PER ROW rather than
+ * per object and therefore resolved by {@link resolveRowRecordCrudAffordance}
+ * rather than here:
+ *
+ *       e. [#4296] the RECORD-level verdict — the explain engine's answer for
+ *          this one row (`security/explain` with `recordIds`, batched per page
+ *          by `./hooks/useRecordCrudVerdicts`).
+ *
+ * Layers (d) and (e) answer different questions for the same reason (c) and (d)
+ * do. `allowEdit` is the principal's verdict on the OBJECT; `writeScope`, the
+ * sharing model and RLS narrow it per row, so layer (d) fails OPEN for every
+ * record the principal does not own — a user with a legitimately broad object
+ * grant saw Edit/Delete on every row they could read, and the server answered
+ * 403 on the ones it does not own. The record detail header has ANDed the
+ * record-level verdict since objectstack#3821; the row kebab now runs the same
+ * judgement against the same engine, so one screen no longer carries two
+ * opposite answers to "may this user write THIS record".
  */
 
 import { resolveEffectiveCrudAffordances, type RowCrudPredicates, type UserActionOverride } from '@object-ui/core';
@@ -157,4 +175,36 @@ export function resolveRowCrudAffordances(opts: {
     editPredicates: canEdit ? aff.editPredicates : undefined,
     deletePredicates: canDelete ? aff.deletePredicates : undefined,
   };
+}
+
+/**
+ * [#4296] Layer (e): narrow ONE row's Edit/Delete affordance by the
+ * RECORD-level verdict, on top of the object-level answer this module's
+ * {@link resolveRowCrudAffordances} resolved.
+ *
+ * An INTERSECTION like every layer above it: a record-level grant cannot
+ * re-open what the bucket, `userActions`, the effective operation set or the
+ * principal's object permission closed. It only ever removes.
+ *
+ * `recordVerdict === undefined` means the record-grained answer is UNKNOWN —
+ * the batch verdict has not arrived yet, the endpoint failed or is absent, the
+ * row carries no id, or the response did not answer this row. Unknown leaves
+ * the object verdict untouched, i.e. renders exactly what this list rendered
+ * before layer (e) existed. That direction is deliberate and pinned: the server
+ * is the authority and already fail-closes with a 403, so an over-hidden row
+ * would cost a permitted user a capability they have, which is strictly worse
+ * than the wasted click this layer removes. It is the same `!== false` posture
+ * layer (d) takes for an absent `permissionUpdate` / `permissionDelete`, and
+ * the same fail-open posture `useRecordEditable` takes on the detail header.
+ *
+ * @param objectVerdict `canEdit` / `canDelete` for the object, from
+ *   {@link resolveRowCrudAffordances}.
+ * @param recordVerdict this row's `decision.records[i].visible`, or `undefined`
+ *   when no record-grained answer is available for it.
+ */
+export function resolveRowRecordCrudAffordance(
+  objectVerdict: boolean | undefined,
+  recordVerdict: boolean | undefined,
+): boolean {
+  return !!objectVerdict && recordVerdict !== false;
 }


### PR DESCRIPTION
Fixes #4296

The list row kebab ANDed only the OBJECT-level grant, so one screen gave two opposite answers for one record and one user: the kebab offered Edit and Delete, the record detail header hid both, and the server agreed with the detail header (`403 "You do not have access to this record"`). `writeScope`, the sharing model and RLS narrow the object grant per row, so `rowCrudAffordances`' layer (d) fails open for every record the principal does not own — the same argument that layer's own doc header makes about layer (c), one level down.

## What this does

Adds layer (e) to the intersection chain: the explain engine's RECORD-grained verdict, the same authority `plugin-detail`'s `useRecordEditable` has asked since objectstack#3821, so the two surfaces cannot disagree.

- **Batched at page level, not probed per row.** One `POST /api/v1/security/explain` per (object, operation) for the rows on screen, using the `recordIds` form that landed in objectstack#8326 / PR #8452. A 50-row page issues 2 calls, not 100 — the cost that kept this card blocked. Pages above the server's 200-id cap paginate under it (the spec's own documented consumer contract) rather than sending a request the server refuses with `400 VALIDATION_FAILED`.
- **Hide, don't disable.** The verdict rides the row menu's existing per-row visibility decision: `planRowActionMenu` conjoins the object verdict with the #2614 `visibleWhen` predicates in one expression, so the items and the "⋮" guard read ONE decision and a fully denied row grows no empty trigger (#3562's invariant).
- **Fail open on every uncertainty.** No answer yet, endpoint absent or failing, row missing from the answer, row with no id: the row keeps the object-level rendering it had before. The server is the authority and already fail-closes; an over-hidden row would cost a permitted user a capability they actually have, which is worse than the wasted click. Same posture `useRecordEditable` takes.
- No public entry export changes; `objectCanDelete` (the bulk-delete bar) is untouched, so #4096's object-level behaviour is unchanged on every surface.

## Two things the reviewer should look at

**1. Which per-row channel the verdict rides.** The ruling named `RowActionMenu`'s `editPredicates` / `deletePredicates`. The verdict is fed through the `canEdit` / `canDelete` props of the same per-row call instead, because those are the OTHER half of the very same conjunction — `planRowActionMenu` computes `Boolean(canEdit && onEdit) && isBuiltinRowActionVisible(editPredicates, …)`, and `RowActionMenu` is instantiated per row by the `_actions` cell. Same decision, same guard, same #3562 consistency. The literal spelling was not available: `RowCrudPredicates['visibleWhen']` is spec-typed `Expression | ExpressionInput`, so a boolean verdict is not assignable to it, and synthesising a CEL string would have fabricated an authoring artifact to carry a server answer. The authored predicates are passed through untouched.

**2. A local constant for the batch cap.** The pinned `@objectstack/spec@17.0.0-rc.6` predates the batch form and exports neither `EXPLAIN_BATCH_MAX_RECORD_IDS` nor the batch request/response types (verified against the installed package). The hook declares a narrow local constant and reads the wire payload as `unknown` before narrowing; the #4636 pin bump supersedes that declaration. Nothing else was loosened.

## Tests

Verified at `e3c3dc331` (the gate union was re-run at this commit, after the final one).

- `rowRecordCrudVerdict.test.tsx` (new, 15 tests) — the card's exact repro shape (object grant true + `writeScope: 'own'` + a non-owned row loses both entries); an owner's own row keeps both; the fully denied row grows no trigger while the permitted row on the same screen keeps its own; update and delete gated independently; the truth-table cell as a literal agreement test, driving BOTH surfaces against ONE fake explain service out of ONE verdict table, with the detail side consuming the real `useRecordEditable` unchanged and unmocked; five degradation cases (non-OK response, network failure, a pre-batch backend answering no `records`, a row with no id, and the pre-answer window with the response held open); the batch-shape pins (50 rows to 2 calls carrying the ids once, never the singular `recordId`; 250 rows to 2 calls per operation each under the cap; no call at all when the object verdict already hides both); and both intersection directions.
- `rowCrudAffordances.test.ts` — 5 unit tests on the new pure layer, including the unknown-verdict degradation and the never-unions direction.
- `pnpm --filter @object-ui/plugin-grid test` — 72 files / 645 tests pass.
- `pnpm --filter @object-ui/plugin-grid run type-check` — clean (closure built first).
- eslint --quiet on all 9 changed files, `check:control-bytes`, `check:phantom-deps`, `check:spec-symbols`, `check-changeset-presence.mjs`, `check-changeset-no-major.mjs` — all pass.

**Reverse verification** (direction predicted first, then observed): reverting only `ObjectGrid.tsx` to `origin/main` turned 12 of the 15 new tests red and left 3 green. The 3 survivors are the ones asserting that NO explain call happens and the object-level answer stands (no row id; object verdict already closed; closed API exposure surface) — correct, since those hold pre-fix too. One prediction was wrong and is worth recording: the degradation cases went red as well, not green. They wait for the batched request to be issued before asserting that its failure changes nothing, so with the fold absent they fail at that wait — a degradation pin over a mechanism that does not exist is vacuous, so this is the honest coupling, but it is not what the template presumed.

## Test-hygiene fallout, handled in-package and filed for the rest

The probe rides `apiFetch ?? fetch`, matching `useRecordEditable` exactly — the global fallback is what keeps a standalone same-origin embed's kebab agreeing with its detail header. Under happy-dom that fallback is a real request to the default origin, so suites rendering a grid without a host fetch escape to the network: the pattern objectui#3339 recorded and PR #4105 settled (answer it from a recorded double, never a global error sink).

Measured: 0 such lines before this change, 180 after, in three plugin-grid suites. All three now install a double (`src/__tests__/explainDouble.ts`), which answers `visible: true` for every row — so those files' assertions measure exactly what they measured before — and records every URL it is handed, so an escape elsewhere stays visible instead of vanishing into a swallowed rejection. plugin-grid is back to 0.

The same escape lands in consumer packages, which resolve `@object-ui/plugin-grid` to source through the root vitest alias: plugin-view (11 files / 111 tests pass, 96 lines) and app-shell + plugin-designer (409 files / 3843 tests pass, 180 lines). Those files are outside this card's declared surface, so they are filed rather than edited here: objectui#4688, unassigned, with the measurements and the ready-made double. Dropping the global-fetch fallback would remove the escape at its root but would reintroduce this card's contradiction for every same-origin host that does not wire `apiFetch`, so it is not the remedy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_