### PR TITLE
fix(types): retire VectorFieldMetadata.indexed and .distance_metric

### DIFF
--- a/.changeset/retire-vectorfield-indexed-and-distance-metric.md
+++ b/.changeset/retire-vectorfield-indexed-and-distance-metric.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/types': minor
+---
+
+Remove `VectorFieldMetadata.indexed` and `VectorFieldMetadata.distance_metric`
+— both declared keys the ObjectStack spec rejects
+
+Two separate dead keys on `VectorFieldMetadata`
+(`packages/types/src/field-types.ts`), found alongside PR #4686's sibling
+`BaseFieldMetadata.indexed` deletion:
+
+- `indexed` was never a `FieldSchema` key — same class as `BaseFieldMetadata`
+  above: the field-level flag built no index (objectstack#2377 removed it),
+  and `FieldSchema.safeParse` rejects it by name (objectstack#4001).
+- `distance_metric` was measured first rather than assumed removable: the
+  installed `@objectstack/spec` 17.0.0-rc.6's vector field shape declares no
+  metric-spelling key under any candidate spelling probed (`metric`,
+  `distanceMetric`, `similarity`, `similarityMetric`, `metricType`,
+  `vectorMetric`) — `dimensions` is the only vector-specific key
+  `FieldSchema` recognizes, and its `FIELD_KEY_GUIDANCE` alias/retirement
+  table carries no entry for `distance_metric` at all. With no equivalent to
+  align to, and zero measured readers/writers, removal takes no capability
+  away.
+
+Both are rejected by `FieldSchema.safeParse` as `unrecognized_keys`; `dimensions`
+is accepted (control). Repo-wide sweep (excluding tests) found zero readers or
+writers of either key on the vector path — `VectorField.tsx` (the renderer)
+reads only `field.dimensions`. Declare the index on the object instead:
+`indexes: [{ name, fields, unique }]`.

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -625,14 +625,24 @@ export interface VectorFieldMetadata extends BaseFieldMetadata {
    * Vector dimensions (e.g., 768 for BERT, 1536 for OpenAI)
    */
   dimensions?: number;
-  /**
-   * Distance metric for similarity search
+  /*
+   * There is deliberately no `distance_metric` here (objectui#4687). It was
+   * never a `FieldSchema` key: the installed `@objectstack/spec`'s vector
+   * field shape declares no metric-spelling key at all (`dimensions` is the
+   * only vector-specific key it recognizes), and `FieldSchema.safeParse`
+   * rejects `distance_metric` by name (`unrecognized_keys`) with no
+   * alias/rename entry pointing anywhere else. It had zero readers and zero
+   * writers repo-wide, so there was no capability to preserve by renaming —
+   * only a dead declaration to remove.
    */
-  distance_metric?: 'cosine' | 'euclidean' | 'dot_product';
-  /**
-   * Whether to index for similarity search
+  /*
+   * There is deliberately no `indexed` here (objectui#4679, objectui#4687).
+   * The ObjectStack spec has no field-level index flag: it built no index
+   * (objectstack#2377 removed it) and `FieldSchema.safeParse` now rejects the
+   * key by name, so any producer that authored it produced a save-blocking
+   * 422. Declare the index on the object instead — `indexes: [{ name,
+   * fields, unique }]`.
    */
-  indexed?: boolean;
   /**
    * Normalization strategy
    */


### PR DESCRIPTION
Fixes #4687

## What

Removes `VectorFieldMetadata.indexed` and `VectorFieldMetadata.distance_metric`
(`packages/types/src/field-types.ts`) — two independently-dead declared keys
`FieldSchema.safeParse` rejects, per the grading comment's conditional frame
on #4687.

- **`indexed`**: same defect class as `BaseFieldMetadata.indexed` (PR #4686,
  merged into this branch below) and `DesignerFieldDefinition.indexed` (PR
  #4675) — never a `FieldSchema` key; the field-level flag built no index
  (objectstack#2377 removed it), and `FieldSchema.safeParse` rejects it by
  name (objectstack#4001). Mechanical deletion, tombstoned in PR #4686's
  style.
- **`distance_metric`**: measured first, per the ruling, rather than assumed
  removable. Probed the installed `@objectstack/spec` 17.0.0-rc.6's
  `FieldSchema` against six candidate metric spellings (`metric`,
  `distanceMetric`, `similarity`, `similarityMetric`, `metricType`,
  `vectorMetric`) — all rejected as `unrecognized_keys`. Read the schema's
  source directly to confirm rather than trust the probe alone: the vector
  field shape declares exactly one vector-specific key, `dimensions`
  (`"Vector field — flat dimensionality (the live authoring path). The
  renderer reads this flat sibling (objectui VectorField.tsx:11)."`), and the
  spec's `FIELD_KEY_GUIDANCE` alias/retirement table (which every other
  renamed/retired field key is catalogued in) has **no entry at all** for
  `distance_metric` under any spelling. **No equivalent key exists** ⇒
  deleted rather than renamed, per the ruling's conditional frame — with zero
  measured readers/writers, removal takes no capability away, and extending
  the spec was explicitly out of scope for this dispatch.

Both are `unrecognized_keys` on `FieldSchema.safeParse`; `dimensions` is
accepted (control, reproduced below). `VectorField.tsx`, the sole renderer
for this field type, reads only `field.dimensions` — confirming zero readers
independently of the repo-wide grep.

## Premise verification (per dispatch §2)

- **Premise A** (consumer sweep, excluding tests): zero hits for
  `distance_metric`/`distanceMetric` anywhere outside the declaration site
  itself; zero hits for `.indexed`/`indexed:` on any code path (the only
  `indexed` hit repo-wide is an unrelated "0-indexed" prose comment in
  `GanttView.tsx`). Confirms the issue's own sweep, fresh on the current
  head.
- **Premise B** (spec rejection reproduces):
  ```
  FieldSchema.safeParse({ name: 'x', type: 'vector', indexed: true })
  → unrecognized_keys: ["indexed"]

  FieldSchema.safeParse({ name: 'x', type: 'vector', dimensions: 768, distance_metric: 'cosine' })
  → unrecognized_keys: ["distance_metric"]

  FieldSchema.safeParse({ name: 'x', type: 'vector', dimensions: 768 })
  → ACCEPTED  (control)
  ```
- **Premise C** (consumers of `VectorFieldMetadata` itself): exactly two —
  its own declaration and the barrel re-export / discriminated-union member
  in `packages/types/src/index.ts` / `field-types.ts`. No external consumer
  destructures `distance_metric` or `indexed` off it. All downstream
  consumers type-check green (below).

## PR #4686 interaction

PR #4686 (the sibling `BaseFieldMetadata.indexed` deletion) had **not**
merged when this branch was created (based on `d298be82a`), but merged
mid-run as `97abb24a9` while this PR's verification was in progress. Per the
dispatch note, I merged `origin/main` forward into this branch (auto-merged
cleanly, disjoint regions) rather than duplicating its tombstone — the reverse
verification below is re-run at the post-merge head, and now also
independently confirms `indexed` alone is rejected (before the merge it was
masked by inheriting from `BaseFieldMetadata`, which #4686 had not yet
retired).

## Scope

One file (`packages/types/src/field-types.ts`, `VectorFieldMetadata` only) +
one changeset. No test harness invented — per dispatch scope, a type-level
deletion's verification is the cross-package type-check, matching PR #4686's
precedent.

## Verification

- `pnpm --filter '@object-ui/types' build && pnpm --filter '@object-ui/types' run type-check` — green.
- `pnpm --filter '@object-ui/types' exec eslint --quiet src/field-types.ts` — clean.
- Full downstream sweep (prefix = consumer direction): `pnpm turbo run type-check --filter='...@object-ui/types' --concurrency=2` — **78 tasks successful, 78 total** (build closure built first: `pnpm --filter '@object-ui/fields^...' build`).
- Reverse verification (proves tsc read the rebuilt `.d.ts`, not a cached one): added a `VectorFieldMetadata`-typed literal with `distance_metric: 'cosine'` and a second with `indexed: true` in `packages/fields/src/`, ran `tsc --noEmit` →
  ```
  error TS2353: Object literal may only specify known properties, and 'distance_metric' does not exist in type 'VectorFieldMetadata'.
  error TS2353: Object literal may only specify known properties, and 'indexed' does not exist in type 'VectorFieldMetadata'.
  ```
  Then removed the probe file (`git status` clean before commit).
- `pnpm exec vitest run packages/types/ --maxWorkers=2` — 420 tests passed (35 files).
- `node scripts/check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `pnpm run check:control-bytes` — all green.
- `node scripts/check-spec-symbol-derivation.mjs` (domain-relevant to a field-types.ts change; re-derived since `scripts/pm/dispatch-gates.mjs` does not exist in this repo) — green, unchanged from baseline.

All of the above re-run at the final commit (post `origin/main` merge): HEAD `72ab7bc72`.

## Out of scope

Nothing new found. (PR #4686 already filed and left `VectorFieldMetadata`'s
two keys as this issue's own finding — now closed out here.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_