### PR TITLE
fix(app-shell): an unloaded attachment list is not an empty one

### DIFF
--- a/.changeset/attachments-unavailable-vs-empty.md
+++ b/.changeset/attachments-unavailable-vs-empty.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/i18n': patch
+---
+
+RecordAttachmentsPanel distinguishes an UNLOADED attachment list from an empty one.
+
+A `sys_attachment` list read that failed for any non-authorization reason — a
+network failure (server unreachable, DNS, aborted request), a 5xx, or a 401 /
+`AUTH_REQUIRED` (an expired session is authentication, not authorization, so the
+denied predicate deliberately does not claim it) — was swallowed into the
+panel's empty state. All three rendered "No attachments yet. Upload a file to
+get started.": an affirmative claim about the record's contents, made by a panel
+that never got an answer, over a record that may hold thousands of files.
+
+The panel now carries the same four-way status vocabulary its siblings use —
+`loading` / `loaded` / `denied` / `unavailable` — and every state that means
+"the panel does not know" is answered before `rows.length === 0` is allowed to
+mean "the record holds nothing". A failed read renders a distinct unavailable
+state ("We couldn't load the attachments for this record.", new
+`detail.attachmentsLoadFailed` and `detail.retryLoadAttachments` keys in all ten
+locale packs) with a **retry** — unlike the denied state, an outage and a lapsed
+session are both things a second attempt can fix — and withdraws the Upload
+affordance, because offering an upload against a list the panel could not reach
+is the same over-assertion as the empty state it replaces. Like the denied
+state, it renders the translated sentence and nothing sourced from the error: no
+status code, no server message, no host.
+
+The empty state is now reserved for a genuine 200-with-zero-rows, and the
+denied state (403 / `PERMISSION_DENIED` / `FORBIDDEN` / a row-level-security
+denial) is unchanged. The "table not provisioned on an older stack" case is
+unaffected: the ObjectStack adapter degrades a bare 404 to `{ data: [], total: 0 }`,
+so it resolves through the success path and still renders the empty state.
+
+This restores a house rule that had already landed twice as a bug fix —
+`HomeActionCenter` may only say "You're all caught up" once the inbox has
+answered, and an unloadable app list is UNKNOWN rather than "no default app".

--- a/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
+++ b/packages/app-shell/src/views/RecordAttachmentsPanel.tsx
@@ -8,7 +8,16 @@
 
 import * as React from 'react';
 import { cn, Button } from '@object-ui/components';
-import { Paperclip, Upload, Trash2, Download, Loader2, Lock } from 'lucide-react';
+import {
+  Paperclip,
+  Upload,
+  Trash2,
+  Download,
+  Loader2,
+  Lock,
+  AlertTriangle,
+  RefreshCw,
+} from 'lucide-react';
 import { createObjectStackUploadAdapter } from '@object-ui/providers';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import { useObjectTranslation, isPermissionError } from '@object-ui/react';
@@ -50,6 +59,43 @@ export interface RecordAttachmentsPanelProps {
   className?: string;
 }
 
+/**
+ * What the panel actually KNOWS about this record's `sys_attachment` list
+ * (#4684) — the same four-way vocabulary the sibling surfaces settled on.
+ *
+ *   - `loading`     — the read is in flight (or has not been issued yet). The
+ *                     panel knows nothing and asserts nothing.
+ *   - `loaded`      — the read ANSWERED. Only in this state is `rows.length`
+ *                     a fact about the record, and only here may the panel say
+ *                     "No attachments yet".
+ *   - `denied`      — refused for AUTHORIZATION reasons (#4269 / PR #4685):
+ *                     403 / `PERMISSION_DENIED` / `FORBIDDEN` / an RLS denial.
+ *                     The caller may not look; the record's contents are
+ *                     unknown.
+ *   - `unavailable` — the read FAILED for any other reason: a network failure
+ *                     (server unreachable, DNS, aborted request), a 5xx, or a
+ *                     401 / `AUTH_REQUIRED` (an expired session is
+ *                     authentication, not authorization, so the `denied`
+ *                     predicate deliberately does not claim it). Also unknown.
+ *
+ * The split that matters is assert-vs-don't-assert. Before #4684 the last two
+ * both collapsed into `rows = []`, so a panel that never got an answer told the
+ * user "No attachments yet. Upload a file to get started." — an affirmative
+ * claim about the record's contents, made from no evidence, over a record that
+ * may hold thousands. The house rule this restores landed twice already as a
+ * bug fix: `HomeActionCenter` (#4235) may only say "You're all caught up" once
+ * the inbox has answered, and an unloadable app list (#4300) is UNKNOWN rather
+ * than "no default app".
+ *
+ * `denied` and `unavailable` are kept apart rather than merged into one
+ * "couldn't read" because they need different copy and different affordances:
+ * a denial is permanent for this caller and retrying it just re-earns the same
+ * 403, while an outage or an expired session is exactly the case a Retry is
+ * for. `unavailable` therefore keeps a retry; `denied` (unchanged from #4685)
+ * does not.
+ */
+type AttachmentListStatus = 'loading' | 'loaded' | 'denied' | 'unavailable';
+
 function formatSize(bytes?: number | null): string {
   if (bytes == null || !Number.isFinite(bytes)) return '';
   if (bytes < 1024) return `${bytes} B`;
@@ -66,20 +112,21 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
 }) => {
   const { t } = useObjectTranslation();
   const [rows, setRows] = React.useState<AttachmentRow[]>([]);
-  const [loading, setLoading] = React.useState(false);
   const [uploading, setUploading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   /**
-   * The list read was refused for AUTHORIZATION reasons (#4269).
+   * See {@link AttachmentListStatus}. Kept separate from `rows.length === 0`
+   * because the two say different things and only one of them is an assertion
+   * the panel is entitled to make: "No attachments yet" claims the record
+   * HOLDS nothing, while a refused or failed read says only that the panel
+   * does not know.
    *
-   * Kept separate from `rows.length === 0` because the two say opposite
-   * things and only one of them is an assertion the panel is entitled to
-   * make. "No attachments yet" claims the record HOLDS nothing; a 403 says
-   * only that this caller may not look. Folding the second into the first
-   * told a denied member that a record with 2095+ attachments was empty —
-   * and offered an Upload the server would refuse.
+   * Opens at `loading`, not `loaded`: before the effect below has run, the
+   * panel has issued no read at all, and a surface that has not read is not
+   * entitled to the empty state either (#4684). The guard in `refresh()`
+   * leaves it here on purpose — see the comment there.
    */
-  const [listDenied, setListDenied] = React.useState(false);
+  const [status, setStatus] = React.useState<AttachmentListStatus>('loading');
   const inputRef = React.useRef<HTMLInputElement | null>(null);
 
   // Same base-URL convention as RecordDetailView's raw API fetches: the
@@ -132,8 +179,15 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
   );
 
   const refresh = React.useCallback(async () => {
+    // No data source / no record yet: no read is ISSUED, so `status` stays at
+    // whatever it was — `loading` on first mount. Deliberately not forced to
+    // `loaded` (that would assert an empty record from zero evidence) and not
+    // to `unavailable` (nothing failed; there is no error to report and a
+    // Retry would have nothing to retry). Every dep here is in the callback's
+    // dependency list, so if one of them arrives later this effect re-runs on
+    // its own and the read happens then.
     if (!dataSource || !objectName || !recordId) return;
-    setLoading(true);
+    setStatus('loading');
     try {
       const res: any = await dataSource.find('sys_attachment', {
         $filter: { parent_object: objectName, parent_id: recordId },
@@ -142,30 +196,38 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
       });
       const items: AttachmentRow[] = Array.isArray(res) ? res : res?.data ?? [];
       setRows(items);
-      setListDenied(false);
+      // The read ANSWERED — only now is `rows.length === 0` a fact about the
+      // record rather than an absence of information, and only now may the
+      // empty state below speak.
+      setStatus('loaded');
     } catch (err) {
       setRows([]);
-      // An authorization refusal is NOT an empty record (#4269). The house
-      // predicate is the same one the kanban/calendar/form surfaces branch
-      // on — HTTP 403, `PERMISSION_DENIED`/`FORBIDDEN`, or an RLS denial.
-      // The adapter throws it: `find()` degrades only a non-authz 404 to
-      // `{ data: [], total: 0 }` (data-objectstack, objectui#4408), so a 403
-      // reaches this catch as a decorated throw.
+      // The read did NOT answer. Which of the two unknown states applies turns
+      // on one question — is this caller forbidden, or did the request simply
+      // not get through?
       //
-      // Nothing from the error is rendered — the denied state below shows the
+      // `denied` (#4269 / PR #4685) uses the same house predicate the
+      // kanban/calendar/form surfaces branch on: HTTP 403,
+      // `PERMISSION_DENIED`/`FORBIDDEN`, or an RLS denial. It deliberately
+      // does NOT claim a 401 — an expired session is authentication, not
+      // authorization, and "you don't have access" is the wrong sentence for a
+      // user who only needs to sign in again.
+      //
+      // `unavailable` (#4684) takes everything else that reaches this catch:
+      // a network failure, a 5xx, a 401/`AUTH_REQUIRED`. Note what does NOT
+      // arrive here — the ObjectStack adapter's `find()` degrades a bare 404
+      // (collection absent on an older stack) to `{ data: [], total: 0 }`
+      // (data-objectstack `is404Error`, objectui#4408), so the "table not yet
+      // provisioned" case still resolves through the success path above and
+      // still renders the empty state. It never depended on this catch
+      // swallowing it.
+      //
+      // Nothing from the error is rendered in either state — both show their
       // i18n sentence and nothing else. objectui#2532's failure mode (raw
-      // dump / status code / leaked row) must stay absent, and `setError` is
-      // deliberately NOT called here.
-      setListDenied(isPermissionError(err));
-      // Everything else keeps the pre-existing behaviour: a 404 (table not
-      // provisioned on older stacks) and any network/5xx failure are tolerated
-      // silently and the panel stays empty. That swallow is the SAME defect
-      // class one status over — an unreachable server also renders "No
-      // attachments yet" — but the honest unknown-vs-empty split is a separate
-      // change (filed, not fixed here) and this line pins today's behaviour
-      // rather than quietly widening the fix.
-    } finally {
-      setLoading(false);
+      // dump / status code / leaked row count) must stay absent, and
+      // `setError` is deliberately NOT called here: a failed LIST is a state
+      // of the panel, not an error banner about an action the user took.
+      setStatus(isPermissionError(err) ? 'denied' : 'unavailable');
     }
   }, [dataSource, objectName, recordId]);
 
@@ -287,11 +349,19 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
           previously unconditional — its only gate was `uploading` — so a
           member the server had just refused was still invited to upload into
           a record whose parent it cannot read, a click the `beforeInsert`
-          gate answers with 403 ATTACHMENT_PARENT_ACCESS. Hiding it here
-          changes nothing for every other caller: this is the sole condition
-          added to a control that had none.
+          gate answers with 403 ATTACHMENT_PARENT_ACCESS.
+
+          `unavailable` withdraws it for the same reason one status over
+          (#4684): offering an upload against a list the panel could not even
+          reach is the same over-assertion as the empty state it replaces —
+          the panel is claiming an attach will work when it has no evidence
+          the server is reachable at all, and the upload's own three-step
+          presigned flow would fail on the same outage. Retry first; the
+          Upload returns with the answer.
+
+          Still shown while `loading` and while `loaded`, exactly as before.
         */}
-        {!listDenied && (
+        {status !== 'denied' && status !== 'unavailable' && (
           <div className="flex items-center gap-2">
             <input
               ref={inputRef}
@@ -323,12 +393,25 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
         </div>
       )}
 
-      {loading && rows.length === 0 ? (
+      {/*
+        The order of this chain IS the assertion discipline (#4235, #4300,
+        #4269, #4684): every state that means "the panel does not know" is
+        answered before `rows.length === 0` is allowed to mean "the record
+        holds nothing". `rows` is emptied on every failure, so any unknown
+        state reaching the empty branch would render the exact lie these
+        cards exist to remove.
+
+        `status === 'loading' && rows.length === 0` (not `status === 'loading'`
+        alone) is unchanged from the pre-#4684 shape: a refresh over an
+        already-populated list keeps showing that list instead of blanking it
+        to a spinner.
+      */}
+      {status === 'loading' && rows.length === 0 ? (
         <div className="px-4 py-6 text-sm text-muted-foreground flex items-center gap-2">
           <Loader2 className="h-4 w-4 animate-spin" />
           {t('detail.loadingAttachments', { defaultValue: 'Loading attachments…' })}
         </div>
-      ) : listDenied ? (
+      ) : status === 'denied' ? (
         // Checked BEFORE the empty state, and rendering only the i18n
         // sentence: no status code, no server message, no row (#2532).
         <div
@@ -340,7 +423,38 @@ export const RecordAttachmentsPanel: React.FC<RecordAttachmentsPanelProps> = ({
             defaultValue: "You don't have access to these attachments.",
           })}
         </div>
+      ) : status === 'unavailable' ? (
+        // The read never answered (#4684): network failure, 5xx, or an expired
+        // session. Like the denied state above this renders ONLY the i18n
+        // sentence — no status code, no server message, no row count (#2532) —
+        // and, unlike it, offers a Retry: an outage and a lapsed session are
+        // both things a second attempt can genuinely fix.
+        //
+        // The Retry cannot double-fetch. `refresh()` sets `status` to
+        // `loading` synchronously and `rows` is already empty here, so the
+        // branch above wins on the very next render and this button — with the
+        // only handler that calls `refresh()` — unmounts for the duration of
+        // the read.
+        <div
+          className="px-4 py-6 text-sm text-muted-foreground flex flex-col items-start gap-3"
+          data-testid="record-attachments-unavailable"
+        >
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            {t('detail.attachmentsLoadFailed', {
+              defaultValue: "We couldn't load the attachments for this record.",
+            })}
+          </div>
+          <Button variant="outline" size="sm" onClick={() => void refresh()}>
+            <RefreshCw className="h-4 w-4 mr-1" />
+            {t('detail.retryLoadAttachments', { defaultValue: 'Retry' })}
+          </Button>
+        </div>
       ) : rows.length === 0 ? (
+        // Reached only with `status === 'loaded'`: every other status is
+        // answered above. This is the one branch entitled to assert that the
+        // record holds nothing, because it is the only one standing on a read
+        // that came back — a genuine 200-with-zero-rows.
         <div className="px-4 py-6 text-sm text-muted-foreground">
           {t('detail.noAttachments', { defaultValue: 'No attachments yet. Upload a file to get started.' })}
         </div>

--- a/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
+++ b/packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx
@@ -188,13 +188,14 @@ describe('RecordAttachmentsPanel — denied vs empty list (#4269)', () => {
     expect(screen.queryByTestId('record-attachments-denied')).not.toBeInTheDocument();
   });
 
-  // PIN, not an endorsement. A non-authz failure keeps the pre-existing
-  // behaviour — swallowed to the empty state, Upload still offered. That is
-  // the same "unknown rendered as empty" defect one status over, but fixing it
-  // needs the loaded/unknown status vocabulary (#4235-style), not this
-  // denied-vs-empty split; filed separately. This test exists so the next
-  // change to that branch is a DELIBERATE one.
-  it('pins today’s behaviour for a NON-authz failure: still the empty state', async () => {
+  // The PIN this file carried for a NON-authz failure ("still the empty
+  // state") existed so that changing it would be a DELIBERATE act rather than
+  // an accident. #4684 is that deliberate act: the assertion is rewritten
+  // below, in `— unavailable vs empty list (#4684)`, where the same
+  // `TypeError('Failed to fetch')` now has to reach the unavailable state.
+  // What the pin protected — that no one widens this branch silently — is
+  // preserved by replacing it with the stricter assertion, not by deleting it.
+  it('a NON-authz failure no longer reaches the DENIED state (that split is authz-only)', async () => {
     setup(
       makeDataSource({
         find: vi.fn(async () => {
@@ -204,12 +205,220 @@ describe('RecordAttachmentsPanel — denied vs empty list (#4269)', () => {
     );
 
     await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    // #4685's denied state is authorization-only and must not creep outward:
+    // an outage is not a refusal, and "You don't have access" is the wrong
+    // sentence for a user whose network dropped.
+    expect(screen.queryByTestId('record-attachments-denied')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("You don't have access to these attachments."),
+    ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * An UNLOADED list is not an empty one (#4684).
+ *
+ * The panel's `catch` split authorization out in #4685 and folded everything
+ * else back into `setRows([])`, so a network failure, a 5xx and a 401 all
+ * rendered "No attachments yet. Upload a file to get started." — an
+ * affirmative claim about the record's contents from a panel that never got an
+ * answer, over a record that may hold thousands of files. Same defect class as
+ * #4269, one status over.
+ *
+ * The house rule these tests enforce landed twice before as a bug fix:
+ * `HomeActionCenter` (#4235) may only say "You're all caught up" once the inbox
+ * has ANSWERED, and an unloadable app list (#4300) is UNKNOWN rather than "no
+ * default app".
+ */
+describe('RecordAttachmentsPanel — unavailable vs empty list (#4684)', () => {
+  /** A dead connection: `fetch` rejects before any HTTP status exists. */
+  function networkFailureSource() {
+    return makeDataSource({
+      find: vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    });
+  }
+
+  it('THE DEFECT — a network failure renders the unavailable state, never "No attachments yet"', async () => {
+    setup(networkFailureSource());
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText("We couldn't load the attachments for this record."),
+    ).toBeInTheDocument();
+    // The empty state is reserved for a genuine 200-with-zero-rows.
+    expect(screen.queryByText(/No attachments yet/)).not.toBeInTheDocument();
+  });
+
+  it('a 5xx renders the unavailable state', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('Internal Server Error'), { httpStatus: 500 });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/No attachments yet/)).not.toBeInTheDocument();
+  });
+
+  // A 401 is AUTHENTICATION, not authorization: the session expired, the user
+  // is not forbidden. `isPermissionError` deliberately does not claim it (it
+  // matches 403 / PERMISSION_DENIED / FORBIDDEN / an RLS denial), so it must
+  // land in `unavailable` — where a Retry, after the session refreshes, is
+  // exactly the right affordance — and never in the denied state, whose
+  // sentence ("You don't have access") would be plainly wrong here.
+  it('a 401 / AUTH_REQUIRED renders UNAVAILABLE, not the denied state', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('Authentication required'), {
+            httpStatus: 401,
+            code: 'AUTH_REQUIRED',
+          });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('record-attachments-denied')).not.toBeInTheDocument();
+    expect(screen.queryByText(/No attachments yet/)).not.toBeInTheDocument();
+  });
+
+  it('withdraws the Upload affordance under an unloaded list', async () => {
+    setup(networkFailureSource());
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    // Offering an upload against a list the panel could not reach is the same
+    // over-assertion as the empty state it replaces.
+    expect(screen.queryByRole('button', { name: 'Upload' })).not.toBeInTheDocument();
+  });
+
+  // Same no-leak bar as the denied state (#2532 / #4685): the unavailable
+  // state renders the i18n sentence and NOTHING sourced from the error.
+  it('leaks nothing from the error — no status code, no server text, no host', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(
+            new Error(
+              'FetchError: request to https://internal-db.corp.example/api/v1/data/sys_attachment failed (ECONNREFUSED 10.4.7.19:5432)',
+            ),
+            { httpStatus: 503, code: 'UPSTREAM_UNAVAILABLE' },
+          );
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    const panel = screen.getByTestId('record-attachments-panel');
+    expect(panel.textContent).not.toMatch(/503/);
+    expect(panel.textContent).not.toMatch(/ECONNREFUSED|10\.4\.7\.19/);
+    expect(panel.textContent).not.toMatch(/internal-db\.corp\.example/);
+    expect(panel.textContent).not.toMatch(/UPSTREAM_UNAVAILABLE|FetchError/);
+    // A failed LIST is a state of the panel, not an error banner about
+    // something the user did.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // The affordance that separates `unavailable` from `denied`: an outage and a
+  // lapsed session are both things a second attempt can genuinely fix, whereas
+  // retrying a 403 just re-earns the same 403.
+  it('offers a retry that re-reads the list and renders it once the read succeeds', async () => {
+    const find = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce([ROW]);
+    setup(makeDataSource({ find }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    expect(find).toHaveBeenCalledTimes(1);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(screen.getByText('report.pdf')).toBeInTheDocument());
+    expect(find).toHaveBeenCalledTimes(2);
+    // Recovery is complete: the unavailable state is gone and the Upload
+    // affordance is back, because the panel now has an answer.
+    expect(screen.queryByTestId('record-attachments-unavailable')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument();
+  });
+
+  it('a retry that fails again stays on the unavailable state', async () => {
+    const find = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    setup(makeDataSource({ find }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId('record-attachments-unavailable')).toBeInTheDocument();
+    expect(screen.queryByText(/No attachments yet/)).not.toBeInTheDocument();
+  });
+
+  // The other three states must keep their own meaning — this card only
+  // reassigns the branch that was lying.
+  it('a 403 still renders the DENIED state, unchanged by this card', async () => {
+    setup(
+      makeDataSource({
+        find: vi.fn(async () => {
+          throw Object.assign(new Error('refused'), {
+            httpStatus: 403,
+            code: 'PERMISSION_DENIED',
+          });
+        }),
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('record-attachments-denied')).toBeInTheDocument(),
+    );
+    expect(screen.getByText("You don't have access to these attachments.")).toBeInTheDocument();
+    expect(screen.queryByTestId('record-attachments-unavailable')).not.toBeInTheDocument();
+    // A denial is permanent for this caller: no Retry, unlike `unavailable`.
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+
+  it('a genuine 200-with-zero-rows still renders the empty state AND the Upload button', async () => {
+    setup(makeDataSource({ find: vi.fn(async () => []) }));
+
+    await waitFor(() =>
       expect(
         screen.getByText('No attachments yet. Upload a file to get started.'),
       ).toBeInTheDocument(),
     );
-    expect(screen.queryByTestId('record-attachments-denied')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument();
+    expect(screen.queryByTestId('record-attachments-unavailable')).not.toBeInTheDocument();
+  });
+
+  it('a successful read still renders the rows', async () => {
+    setup(makeDataSource());
+
+    await waitFor(() => expect(screen.getByText('report.pdf')).toBeInTheDocument());
+    expect(screen.queryByTestId('record-attachments-unavailable')).not.toBeInTheDocument();
+    expect(screen.queryByText(/No attachments yet/)).not.toBeInTheDocument();
   });
 });
 

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -901,6 +901,8 @@ const ar = {
     attachmentAuthRequired: "يرجى تسجيل الدخول لتنزيل هذا المرفق.",
     attachmentPermissionDenied: "ليس لديك إذن للقيام بذلك.",
     attachmentsAccessDenied: "ليس لديك حق الوصول إلى هذه المرفقات.",
+    attachmentsLoadFailed: "تعذر تحميل مرفقات هذا السجل.",
+    retryLoadAttachments: "إعادة المحاولة",
     unifiedDiff: "عرض موحد",
     sideBySideDiff: "عرض جنباً إلى جنب",
     noChanges: "لا توجد تغييرات",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -895,6 +895,8 @@ const de = {
     attachmentAuthRequired: "Bitte melden Sie sich an, um diesen Anhang herunterzuladen.",
     attachmentPermissionDenied: "Sie haben keine Berechtigung für diese Aktion.",
     attachmentsAccessDenied: "Sie haben keinen Zugriff auf diese Anhänge.",
+    attachmentsLoadFailed: "Die Anhänge dieses Datensatzes konnten nicht geladen werden.",
+    retryLoadAttachments: "Erneut versuchen",
     unifiedDiff: "Einheitliche Ansicht",
     sideBySideDiff: "Nebeneinander-Ansicht",
     noChanges: "Keine Änderungen",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1031,6 +1031,8 @@ const en = {
     attachmentAuthRequired: 'Please sign in to download this attachment.',
     attachmentPermissionDenied: "You don't have permission to do that.",
     attachmentsAccessDenied: "You don't have access to these attachments.",
+    attachmentsLoadFailed: "We couldn't load the attachments for this record.",
+    retryLoadAttachments: 'Retry',
     // Diff
     unifiedDiff: 'Unified diff',
     sideBySideDiff: 'Side-by-side diff',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -899,6 +899,8 @@ const es = {
     attachmentAuthRequired: "Inicie sesión para descargar este adjunto.",
     attachmentPermissionDenied: "No tiene permiso para hacer eso.",
     attachmentsAccessDenied: "No tiene acceso a estos adjuntos.",
+    attachmentsLoadFailed: "No se pudieron cargar los adjuntos de este registro.",
+    retryLoadAttachments: "Reintentar",
     unifiedDiff: "Vista unificada",
     sideBySideDiff: "Vista lado a lado",
     noChanges: "Sin cambios",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -897,6 +897,8 @@ const fr = {
     attachmentAuthRequired: "Veuillez vous connecter pour télécharger cette pièce jointe.",
     attachmentPermissionDenied: "Vous n'avez pas la permission de faire cela.",
     attachmentsAccessDenied: "Vous n'avez pas accès à ces pièces jointes.",
+    attachmentsLoadFailed: "Impossible de charger les pièces jointes de cet enregistrement.",
+    retryLoadAttachments: "Réessayer",
     unifiedDiff: "Vue unifiée",
     sideBySideDiff: "Vue côte à côte",
     noChanges: "Aucune modification",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -906,6 +906,8 @@ const ja = {
     attachmentAuthRequired: "この添付ファイルをダウンロードするにはサインインしてください。",
     attachmentPermissionDenied: "この操作を行う権限がありません。",
     attachmentsAccessDenied: "これらの添付ファイルにアクセスする権限がありません。",
+    attachmentsLoadFailed: "このレコードの添付ファイルを読み込めませんでした。",
+    retryLoadAttachments: "再試行",
     unifiedDiff: "統合差分",
     sideBySideDiff: "横並び差分",
     noChanges: "変更なし",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -895,6 +895,8 @@ const ko = {
     attachmentAuthRequired: "이 첨부파일을 다운로드하려면 로그인하세요.",
     attachmentPermissionDenied: "이 작업을 수행할 권한이 없습니다.",
     attachmentsAccessDenied: "이 첨부파일에 접근할 권한이 없습니다.",
+    attachmentsLoadFailed: "이 레코드의 첨부파일을 불러오지 못했습니다.",
+    retryLoadAttachments: "다시 시도",
     unifiedDiff: "통합 보기",
     sideBySideDiff: "나란히 보기",
     noChanges: "변경 없음",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -896,6 +896,8 @@ const pt = {
     attachmentAuthRequired: "Faça login para baixar este anexo.",
     attachmentPermissionDenied: "Você não tem permissão para fazer isso.",
     attachmentsAccessDenied: "Você não tem acesso a estes anexos.",
+    attachmentsLoadFailed: "Não foi possível carregar os anexos deste registro.",
+    retryLoadAttachments: "Tentar novamente",
     unifiedDiff: "Visualização unificada",
     sideBySideDiff: "Visualização lado a lado",
     noChanges: "Sem alterações",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -914,6 +914,8 @@ const ru = {
     attachmentAuthRequired: "Войдите в систему, чтобы скачать это вложение.",
     attachmentPermissionDenied: "У вас нет разрешения на это действие.",
     attachmentsAccessDenied: "У вас нет доступа к этим вложениям.",
+    attachmentsLoadFailed: "Не удалось загрузить вложения этой записи.",
+    retryLoadAttachments: "Повторить",
     unifiedDiff: "Единое представление",
     sideBySideDiff: "Параллельное представление",
     noChanges: "Нет изменений",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -975,6 +975,8 @@ const zh = {
     attachmentAuthRequired: '请登录后再下载此附件。',
     attachmentPermissionDenied: '您没有执行此操作的权限。',
     attachmentsAccessDenied: '您没有访问这些附件的权限。',
+    attachmentsLoadFailed: '无法加载此记录的附件。',
+    retryLoadAttachments: '重试',
     // Diff
     unifiedDiff: '统一视图',
     sideBySideDiff: '并排视图',


### PR DESCRIPTION
Fixes #4684

## The defect

`RecordAttachmentsPanel.refresh()` split authorization out of its `catch` in PR #4685 and folded **everything else** back into `setRows([])`. So three different failures — a network failure (server unreachable, DNS, aborted request), a 5xx, and a 401 / `AUTH_REQUIRED` — all rendered:

> No attachments yet. Upload a file to get started.

That is an affirmative claim about the record's contents, made by a panel that never got an answer, over a record that may hold thousands of files. Same defect class as #4269, one status over. The 401 is the sharpest case: an expired session is *authentication*, not authorization, so `isPermissionError` deliberately does not claim it (verified at source — it matches 403 / `PERMISSION_DENIED` / `FORBIDDEN` / an RLS denial only), which left it landing in the empty state.

## The fix

The panel now carries the sibling four-way status vocabulary — `loading` / `loaded` / `denied` / `unavailable` — replacing the `loading` boolean and PR #4685's `listDenied` boolean with one enum. The render chain **is** the assertion discipline: every state meaning "the panel does not know" is answered before `rows.length === 0` is allowed to mean "the record holds nothing".

- **`unavailable`** (new) — any non-authz failure. Renders "We couldn't load the attachments for this record." with a **Retry**, and withdraws the Upload affordance.
- **`denied`** — unchanged from PR #4685. Its JSX block is untouched; only the condition it hangs on changed from `listDenied` to `status === 'denied'`, so the rendered output is byte-identical.
- **`loaded` + zero rows** — now the *only* branch entitled to the empty state, reached only after a read that came back.

Why `unavailable` keeps a retry and `denied` does not: a denial is permanent for this caller and retrying just re-earns the same 403, while an outage or a lapsed session are exactly what a second attempt fixes. Why Upload is withdrawn under `unavailable` too: offering an upload against a list the panel could not reach is the same over-assertion as the empty state it replaces — and the upload's own three-step presigned flow would fail on the same outage.

**No leaking**, same bar as PR #4685: the unavailable state renders the i18n sentence and nothing sourced from the error — no status code, no server message, no host — and `setError` is not called, because a failed *list* is a state of the panel rather than an error banner about something the user did.

This restores a house rule that had already landed twice as a bug fix: `HomeActionCenter` (#4235) may only say "You're all caught up" once the inbox has answered, and an unloadable app list (#4300) is UNKNOWN rather than "no default app".

## The deliberate pin from PR #4685, rewritten not deleted

PR #4685 planted `pins today's behaviour for a NON-authz failure: still the empty state` precisely so this change would be conscious. It is rewritten in place as `a NON-authz failure no longer reaches the DENIED state (that split is authz-only)` — the same `TypeError('Failed to fetch')` input, now asserting the unavailable state and that the denied state has **not** crept outward to claim outages. What the pin protected (nobody widens this branch silently) survives as a stricter assertion.

## Premises verified before building

- **The catch** folds every non-authz failure into the empty state on current `main` — confirmed at source.
- **401** is not claimed by `isPermissionError` — confirmed by reading the predicate.
- **Retry is safe, no double-fetch.** `refresh()` sets `status` to `loading` synchronously and `rows` is already empty in this state, so the loading branch wins on the very next render and the Retry button — the only handler that calls `refresh()` — unmounts for the duration of the read. Covered by a test that counts `find` calls.
- **The "table not provisioned on an older stack" 404 is unaffected**, and never depended on the catch swallowing it: the ObjectStack adapter's `find()` degrades a bare 404 to `{ data: [], total: 0 }` (`is404Error`, #4408), so it resolves through the *success* path and still renders the empty state.

Two notes on the edges, both deliberate:

- A panel rendered with no `dataSource` / `recordId` issues no read, so `status` stays `loading` (a spinner) instead of showing the empty state. Not forced to `loaded` (that would assert an empty record from zero evidence) nor to `unavailable` (nothing failed). Every guard dep is in the callback's dependency list, so a late-arriving prop re-runs the read on its own.
- An `OBJECT_API_DISABLED` / `OBJECT_API_METHOD_NOT_ALLOWED` refusal folds into `unavailable` rather than getting its own fifth state. Honest (the panel still asserts nothing) but less precise than `ListView.classifyLoadError`'s `api-disabled`, since the retry can never succeed. Filed separately as an observation rather than widened here.

## Classifier reuse

No third classifier was written. `isPermissionError` from `@object-ui/react` is reused exactly as PR #4685 imported it. `ListView.classifyLoadError` was checked and is **not** importable — it is a module-local `function` in `packages/plugin-list/src/ListView.tsx`, not exported from the file or the package — and app-shell does not depend on plugin-list. Its five-way split is also finer than this panel's render needs: the panel only needs assert-vs-don't-assert, plus the denied/retryable distinction that decides the affordance.

## Verification

Local gate union run **after** the final commit, at `37d57c64c` (working tree clean, so the union ran on the tree that is HEAD):

| Gate | Result |
| --- | --- |
| `vitest run packages/app-shell/src/views/__tests__/RecordAttachmentsPanel.test.tsx` | 24 passed (24) |
| `vitest run packages/app-shell/` (full package) | 401 files, 3810 passed, 1 skipped, 0 failed |
| `vitest run packages/i18n/` | 45 files, 804 passed |
| `type-check` for app-shell + i18n | `Scope: 2 of 47 workspace projects`, both Done — filters matched, not a silent zero-match |
| `eslint --quiet` on all changed files | clean |
| `pnpm run check:i18n-keys` | 0 — every call-site key resolves; both inline defaults match their `en` value |
| `pnpm run check:i18n-drift` | 0 — 2 keys added, 0 `en` values changed |
| `pnpm run check:control-bytes` | OK (4215 tracked text files) |
| `node scripts/check-changeset-presence.mjs` | OK — 12 source files of 2 released packages, 1 changeset |

**Reverse verification**, direction predicted before running: reverting only the component (tests kept) should turn red exactly the 8 tests that require `record-attachments-unavailable` and leave the other 16 green. Observed exactly that — `8 failed | 16 passed (24)`, with PR #4685's five denied tests, the empty-state test, the loaded test and the #2755 / #2970 suites all still green, so the new assertions are load-bearing and nothing else was disturbed. The fix was committed first; restoring it left the tree byte-identical to HEAD (`git diff HEAD` empty), and the suite was re-run green from that restored state.

## Scope

`RecordAttachmentsPanel.tsx` + its test file + two new i18n keys (`detail.attachmentsLoadFailed`, `detail.retryLoadAttachments`) in all ten locale packs + a changeset. Nothing else touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_