### PR TITLE
fix(charts): a grouped chart whose SECOND dimension was never projected says so

### DIFF
--- a/.changeset/chart-unprojected-series-dimension.md
+++ b/.changeset/chart-unprojected-series-dimension.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+A grouped chart whose SECOND dimension was never projected says so instead of
+drawing an empty frame.
+
+"Cannot know refuses loudly" was answered on the first dimension only.
+`AdvancedChartImpl`'s `hasNoCategoryKey` (framework#4033) names an unprojected
+x-axis dimension rather than drawing a bare axis; the series axis had no
+counterpart, so a pivot whose second dimension was absent from the result rows
+produced `series: []` and rendered axes, grid, tooltip and legend around zero
+marks — indistinguishable, to the author, from "no data matched".
+
+Such a chart now renders the same explanatory placeholder
+(`data-chart-error="no-plottable-series"`) and logs the same diagnostic pair the
+category-axis guard logs: the axis it did plot, and the keys its rows actually
+carry.
+
+The three-way distinction is unchanged and pinned: null / empty-string group
+values still DRAW (they are real groups with real buckets), a partially
+projected group key still draws what projects — mirroring the category axis,
+which refuses only when NOT ONE row carries the key — and an ordinary pivot
+renders unchanged. The refusal is limited to the families whose marks come from
+`series` and nothing else (bar, horizontal-bar, line, area, combo); pie, donut,
+funnel, radar and scatter draw from a `value` column with no series declared, so
+they are untouched. A caller that computed no series binding at all
+(`series === undefined`) is also untouched.

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -1344,6 +1344,116 @@ function hasNoCategoryKey(props: AdvancedChartImplProps): boolean {
 }
 
 /**
+ * Chart families whose marks come from `series` AND NOTHING ELSE — the set the
+ * series-axis guard below is allowed to refuse for.
+ *
+ * MEASURED in this file, not assumed, and deliberately NARROWER than
+ * {@link CATEGORY_AXIS_CHART_TYPES}: `bar` / `horizontal-bar` / `line` / `area`
+ * share one cartesian tail that renders `series.map(…)` and nothing else, and
+ * `combo`'s `ComposedChart` does the same. Every other family reads
+ * `series[0]?.dataKey || 'value'` — pie, donut, funnel, radar, scatter,
+ * treemap, sankey all fall back to a `value` column and draw a perfectly good
+ * chart with no series declared at all, so a refusal there would blank a
+ * WORKING chart rather than explain a broken one.
+ */
+const SERIES_ONLY_CHART_TYPES: ReadonlySet<string> = new Set([
+  'bar', 'horizontal-bar', 'line', 'area', 'combo',
+]);
+
+/**
+ * The series-axis half of the same doctrine — objectui#4683.
+ *
+ * `hasNoCategoryKey` above answers "cannot know refuses loudly" for the FIRST
+ * dimension. A pivoted chart has a second one, and it had no answer at all: a
+ * pivot whose SECOND dimension was never projected produces
+ * `series: []` with one bucket row per category, so the renderer drew axes,
+ * grid, tooltip and legend around ZERO marks and said nothing. To the author
+ * that reads as "no data matched", when what happened is that a dimension they
+ * grouped BY never arrived.
+ *
+ * ## What this reads, and what it deliberately does NOT read
+ *
+ * The signal is `series: []` — {@link buildChartSeries}' own output — plus rows
+ * to draw it against. NOT `groupKey in row`, which is the objectui#4507 trap
+ * INVERTED: this component is handed the PIVOTED bucket rows, whose columns are
+ * the group's VALUES, so the second dimension's own key is a column of no pivot
+ * ever, ordinary ones included. A `key in row` test here would refuse every
+ * grouped chart in the product.
+ *
+ * That keeps the three-way distinction intact, and each arm is pinned by a test:
+ *
+ *   - **null / `''` group values DRAW** (objectui#4673) — they are real groups,
+ *     they get real buckets, so `series` is non-empty and this never fires;
+ *   - **an unprojected group key REFUSES** — no row carries it, so no bucket
+ *     exists, so `series` is `[]`: this fires;
+ *   - **an ordinary pivot renders unchanged**, and so does a PARTIALLY
+ *     projected one. That last is the mirror of `hasNoCategoryKey`'s own
+ *     `!rows.some(…)`: the first dimension refuses only when NOT ONE row
+ *     carries the key, and draws what projects otherwise. A pivot where some
+ *     rows carry the group key yields those groups' series, so this stays
+ *     silent and the chart draws what projected.
+ *
+ * ## Why the message cannot name the group key, and why that is honest
+ *
+ * `hasNoCategoryKey` names the key it could not find. This cannot, because the
+ * renderer is not told which dimension the pivot grouped by — and the two
+ * upstream shapes that reach it are byte-identical. Measured:
+ * `buildChartSeries(rows, ['status','priority'], ['est_hours'])` with `priority`
+ * unprojected and `buildChartSeries(rows, ['status'], [])` with no measure
+ * selected BOTH return `{data:[{status:'Backlog'},…], xAxisKey:'status',
+ * series:[]}`. Naming one cause would be a sentence that is false half the time,
+ * which is worse than the silence this replaces — so the copy names the failure
+ * and BOTH authoring causes, and the console warning carries the diagnostic pair
+ * (`xAxisKey` + the keys the rows actually carry) exactly as the model does.
+ *
+ * ## Why `[]` and not "no series at all"
+ *
+ * `Array.isArray(series) && series.length === 0` — a binding that was COMPUTED
+ * and came out empty, which is what both `buildChartSeries` call paths hand
+ * over. `series === undefined` means no binding was ever computed (a caller that
+ * never went through the helper); those charts are left byte-for-byte as they
+ * were.
+ */
+function hasNoPlottableSeries(props: AdvancedChartImplProps): boolean {
+  const chartType = props.chartType === 'column' ? 'bar' : (props.chartType ?? 'bar');
+  const rows = Array.isArray(props.data) ? props.data : [];
+  return (
+    SERIES_ONLY_CHART_TYPES.has(chartType) &&
+    rows.length > 0 &&
+    Array.isArray(props.series) &&
+    props.series.length === 0
+  );
+}
+
+/**
+ * The shell both refusals render — one placeholder, two diagnoses.
+ *
+ * Stated once so the series-axis guard cannot drift from the framework#4033 one
+ * it mirrors: same box, same `role="status"` (a refusal is a state, not an
+ * alert), same muted centred type, and a `data-chart-error` code naming WHICH
+ * refusal fired.
+ */
+function ChartRefusal({
+  code,
+  className,
+  children,
+}: {
+  code: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={`flex h-full min-h-[120px] w-full items-center justify-center p-4 text-center text-sm text-muted-foreground ${className ?? ''}`}
+      role="status"
+      data-chart-error={code}
+    >
+      <span>{children}</span>
+    </div>
+  );
+}
+
+/**
  * Public entry point. A THIN wrapper purely so the unreadable-data guard can
  * short-circuit without breaking the rules of hooks: the condition depends on
  * `data`, which arrives asynchronously, so an early return inside the renderer
@@ -1352,6 +1462,11 @@ function hasNoCategoryKey(props: AdvancedChartImplProps): boolean {
  */
 export default function AdvancedChartImpl(props: AdvancedChartImplProps) {
   const missingCategoryKey = hasNoCategoryKey(props);
+  // The x-axis refusal WINS when both apply: a chart whose rows carry no
+  // category key at all cannot plot an axis, which is the more fundamental
+  // failure and the more specific message. Without this gate such a chart would
+  // also warn about its series, printing two diagnoses for one cause.
+  const noPlottableSeries = !missingCategoryKey && hasNoPlottableSeries(props);
   const xAxisKey = props.xAxisKey ?? 'name';
   const firstRowKeys = React.useMemo(
     () => Object.keys((Array.isArray(props.data) ? props.data[0] : undefined) ?? {}),
@@ -1371,18 +1486,35 @@ export default function AdvancedChartImpl(props: AdvancedChartImplProps) {
     );
   }, [missingCategoryKey, xAxisKey, firstRowKeys]);
 
+  React.useEffect(() => {
+    if (!noPlottableSeries) return;
+    // The same diagnostic PAIR the guard above prints, for the same reason: the
+    // axis the chart did plot, and the keys its rows actually carry. In the
+    // objectui#4683 shape that second half is the tell — bucket rows carrying
+    // the category and NOTHING else say the group column was never written.
+    console.warn(
+      `[chart] no series to plot against the category axis "${xAxisKey}" — rendering an ` +
+      `explanatory placeholder instead of an empty frame. Row keys: ${JSON.stringify(firstRowKeys)}. ` +
+      `A grouped chart's SECOND dimension must be PROJECTED by the dataset query, and a ` +
+      `chart with no measure selected has nothing to draw either (objectui#4683, framework#4033).`,
+    );
+  }, [noPlottableSeries, xAxisKey, firstRowKeys]);
+
   if (missingCategoryKey) {
     return (
-      <div
-        className={`flex h-full min-h-[120px] w-full items-center justify-center p-4 text-center text-sm text-muted-foreground ${props.className ?? ''}`}
-        role="status"
-        data-chart-error="missing-category-key"
-      >
-        <span>
-          This chart cannot plot its category axis: no row has a{' '}
-          <code className="font-mono">{xAxisKey}</code> field.
-        </span>
-      </div>
+      <ChartRefusal code="missing-category-key" className={props.className}>
+        This chart cannot plot its category axis: no row has a{' '}
+        <code className="font-mono">{xAxisKey}</code> field.
+      </ChartRefusal>
+    );
+  }
+
+  if (noPlottableSeries) {
+    return (
+      <ChartRefusal code="no-plottable-series" className={props.className}>
+        This chart cannot plot any series: no measure or group reached its{' '}
+        <code className="font-mono">{xAxisKey}</code> axis.
+      </ChartRefusal>
     );
   }
 

--- a/packages/plugin-charts/src/AdvancedChartImpl.unprojectedSeriesDimension.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.unprojectedSeriesDimension.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#4683 — the ANNOUNCING half of "cannot know refuses loudly", on the
+ * SERIES axis.
+ *
+ * `AdvancedChartImpl.missingCategoryKey.test.tsx` pins that answer for the FIRST
+ * dimension (framework#4033): rows that never carried the category key get a
+ * named refusal instead of an axis frame with no marks. A pivot has a SECOND
+ * dimension and had no such answer — an unprojected group key produced
+ * `series: []`, so the chart drew axes, grid, tooltip and legend around ZERO
+ * marks and said nothing. Measured on this file's own fixture with the guard
+ * reverted: an `<svg>`, `0` `.recharts-rectangle` elements, no warning, no text.
+ *
+ * The three-way distinction objectui#4673 landed is what these tests hold still,
+ * one `describe` per arm:
+ *
+ *   - null / `''` group values DRAW — real groups, real buckets, real bars;
+ *   - an unprojected group key REFUSES — nothing exists to draw or to label;
+ *   - an ordinary (and a PARTIALLY projected) pivot renders unchanged.
+ *
+ * Every fixture goes through `buildChartSeries` rather than hand-writing the
+ * props, because the defect lives in the composition the two consumers perform
+ * (`ObjectChart`, `DatasetWidget`) and not in either half alone.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { buildChartSeries, NULL_CATEGORY_LABEL } from '@object-ui/core';
+
+// Recharts' ResponsiveContainer measures via ResizeObserver, which reports 0×0
+// under the headless DOM, so nothing paints. Fix its size.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+const DIMS = ['status', 'priority'];
+const VALS = ['est_hours'];
+
+/**
+ * The card's repro: `dimensions: ['status','priority']`, `values:
+ * ['est_hours']`, and result rows that carry `status` and `est_hours` but no
+ * `priority` KEY AT ALL — grouped by a dimension the query never projected.
+ */
+const UNPROJECTED = [
+  { status: 'Backlog', est_hours: 12 },
+  { status: 'Done', est_hours: 30 },
+];
+
+/** The same pivot, projected. The ordinary case that must not change. */
+const PROJECTED = [
+  { status: 'Backlog', priority: 'High', est_hours: 12 },
+  { status: 'Done', priority: 'Low', est_hours: 30 },
+];
+
+/** Render a pivot result exactly as `DatasetWidget` / `ObjectChart` do. */
+function renderPivot(
+  rows: Array<Record<string, unknown>>,
+  props: Record<string, unknown> = {},
+) {
+  const { data, xAxisKey, series } = buildChartSeries(rows, DIMS, VALS, null, {
+    nullCategoryLabel: NULL_CATEGORY_LABEL,
+  });
+  const { container } = render(
+    <AdvancedChartImpl
+      chartType="bar"
+      data={data as any}
+      xAxisKey={xAxisKey}
+      series={series as any}
+      isAnimationActive={false}
+      {...(props as any)}
+    />,
+  );
+  return { container, data, series };
+}
+
+const refusal = (container: HTMLElement) =>
+  container.querySelector('[data-chart-error="no-plottable-series"]');
+
+describe('AdvancedChartImpl — an unprojected SECOND dimension refuses (objectui#4683)', () => {
+  it('names the failure instead of drawing a frame with no marks', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container, series } = renderPivot(UNPROJECTED);
+
+    // Premise A, re-derived post-#4681 rather than taken from the card: no row
+    // carries `priority`, so no group has a bucket and no series exists.
+    expect(series).toEqual([]);
+
+    const placeholder = refusal(container);
+    expect(placeholder, 'renders the explanatory placeholder').not.toBeNull();
+    // The axis it DID plot is named, as the first dimension's guard names its
+    // own key — that plus the warning's row keys is the author's diagnosis.
+    expect(placeholder?.textContent).toContain('status');
+    // The old behaviour: axes, grid, tooltip and legend around zero marks.
+    // Anything that still paints a plot here is the silence this replaces.
+    expect(container.querySelector('svg')).toBeNull();
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(0);
+    warn.mockRestore();
+  });
+
+  it('warns once, naming the axis key and the keys the rows actually carry', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    renderPivot(UNPROJECTED);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const msg = String(warn.mock.calls[0]?.[0] ?? '');
+    expect(msg).toContain('status');
+    // The bucket rows carry the category and NOTHING else — the tell that the
+    // group column was never written. `est_hours` is absent from them because
+    // no group owned it, which is exactly what the author needs to see.
+    expect(msg).toContain('Row keys: ["status"]');
+    expect(msg).toContain('objectui#4683');
+    warn.mockRestore();
+  });
+
+  it('fires on every family whose marks come only from `series`', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (const chartType of ['bar', 'horizontal-bar', 'line', 'area', 'combo', 'column']) {
+      const { container } = renderPivot(UNPROJECTED, { chartType });
+      expect(refusal(container), `${chartType} refuses`).not.toBeNull();
+      cleanup();
+    }
+    warn.mockRestore();
+  });
+
+  it('stays out of the way of families that draw from a `value` column', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // pie / donut / funnel / radar / scatter / treemap / sankey all fall back to
+    // `series[0]?.dataKey || 'value'`, so no series is not no chart there — a
+    // refusal would blank a working one.
+    for (const chartType of ['pie', 'donut', 'funnel', 'radar', 'scatter']) {
+      const { container } = render(
+        <AdvancedChartImpl
+          chartType={chartType as any}
+          data={[{ name: 'Backlog', value: 12 }, { name: 'Done', value: 30 }]}
+          xAxisKey="name"
+          series={[]}
+          isAnimationActive={false}
+        />,
+      );
+      expect(refusal(container), `${chartType} draws`).toBeNull();
+      expect(container.querySelector('svg'), `${chartType} paints`).not.toBeNull();
+      cleanup();
+    }
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('leaves a caller that computed NO series binding at all untouched', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // `series === undefined` is "no binding was ever computed", not "a binding
+    // came out empty" — a different sentence, and not this card's. Such charts
+    // stay byte-for-byte as they were.
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={[{ status: 'Backlog', est_hours: 12 }]}
+        xAxisKey="status"
+        isAnimationActive={false}
+      />,
+    );
+    expect(refusal(container)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('yields to the category-axis refusal when both apply — one cause, one diagnosis', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={[{ est_hours: 12 }, { est_hours: 30 }]}
+        xAxisKey="status"
+        series={[]}
+        isAnimationActive={false}
+      />,
+    );
+
+    expect(container.querySelector('[data-chart-error="missing-category-key"]')).not.toBeNull();
+    expect(refusal(container)).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0] ?? '')).toContain('no row has the category key');
+    warn.mockRestore();
+  });
+});
+
+describe('AdvancedChartImpl — what the refusal must NOT swallow (objectui#4683)', () => {
+  it('draws a null / empty-string second-dimension group (objectui#4673 intact)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container, series } = renderPivot([
+      { status: 'Backlog', priority: null, est_hours: 12 },
+      { status: 'Done', priority: '', est_hours: 30 },
+    ]);
+
+    // Known to be empty DRAWS: both are real groups with real buckets.
+    expect(series.map((s) => s.dataKey)).toEqual([NULL_CATEGORY_LABEL, '']);
+    expect(refusal(container), 'a known-empty group is not a missing one').toBeNull();
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(2);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('renders an ordinary projected pivot unchanged', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container, series } = renderPivot(PROJECTED);
+
+    expect(series.map((s) => s.dataKey)).toEqual(['High', 'Low']);
+    expect(refusal(container)).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('draws what projects when the group key is only PARTIALLY projected', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { container, series, data } = renderPivot([
+      { status: 'Backlog', priority: 'High', est_hours: 12 },
+      { status: 'Done', est_hours: 30 },
+    ]);
+
+    // Premise C, decided by MIRRORING the first dimension rather than by taste:
+    // `hasNoCategoryKey` refuses only when NOT ONE row carries the key
+    // (`!rows.some(…)`), so a partially projected axis draws what projects. The
+    // series axis inherits that line exactly — one row carries `priority`, so
+    // that group has a bucket, `series` is non-empty and nothing refuses.
+    expect(series.map((s) => s.dataKey)).toEqual(['High']);
+    // The unprojected row still contributes its CATEGORY and no measure — the
+    // objectui#4673 rule this card does not touch.
+    expect(data).toEqual([{ status: 'Backlog', High: 12 }, { status: 'Done' }]);
+    expect(refusal(container)).toBeNull();
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('never fires on a single-dimension chart, which has a measure series', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { data, xAxisKey, series } = buildChartSeries(
+      [{ status: 'Backlog', est_hours: 12 }, { status: 'Done', est_hours: 30 }],
+      ['status'],
+      ['est_hours'],
+    );
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="bar"
+        data={data as any}
+        xAxisKey={xAxisKey}
+        series={series as any}
+        isAnimationActive={false}
+      />,
+    );
+
+    expect(series.map((s) => s.dataKey)).toEqual(['est_hours']);
+    expect(refusal(container)).toBeNull();
+    expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(2);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('says nothing about a chart with no rows to plot at all', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Empty is not unreadable — an empty result set is a legitimate answer and
+    // the chart's own empty state owns it. Same rows.length > 0 precondition
+    // the framework#4033 guard carries.
+    const { container } = render(
+      <AdvancedChartImpl chartType="bar" data={[]} xAxisKey="status" series={[]} isAnimationActive={false} />,
+    );
+    expect(refusal(container)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #4683

Verified at HEAD `bf0d7351e`.

## What was wrong

"Cannot know refuses loudly" was answered on the first dimension only. `AdvancedChartImpl`'s `hasNoCategoryKey` (framework#4033) names an unprojected x-axis dimension instead of drawing a bare axis. The series axis had no counterpart, so a pivot whose SECOND dimension was absent from the result rows produced `series: []` and rendered axes, grid, tooltip and legend around zero marks. To the author that reads as "no data matched", when what happened is that a dimension they grouped BY never arrived.

Measured on this branch's own fixture with the guard reverted: an svg, `0` `.recharts-rectangle` elements, no warning, no text.

## The signal, and the one it is deliberately not

The guard reads `buildChartSeries`' own output — `series` is an array that came out empty, and there are rows to draw against.

It does NOT read `groupKey in row`, which is #4507's trap inverted. This component is handed the PIVOTED bucket rows, whose columns are the group's VALUES, so the second dimension's own key is a column of no pivot ever — ordinary ones included. A key-in-row test here would refuse every grouped chart in the product. #4507 is its own card and is not addressed here; nothing in this PR touches the first dimension's guard beyond extracting the placeholder shell both refusals now render.

The refusal is limited to the families whose marks come from `series` and nothing else — bar, horizontal-bar, line, area, combo. Measured in the file rather than assumed: pie, donut, funnel, radar, scatter, treemap and sankey all fall back to `series[0]?.dataKey || 'value'` and draw a working chart with no series declared at all, so a refusal there would blank a good chart instead of explaining a broken one. That set is narrower than the existing `CATEGORY_AXIS_CHART_TYPES`, and the difference is load-bearing.

## Why the message does not name the group key

`hasNoCategoryKey` names the key it could not find. This one cannot, and saying so is the honest answer rather than a limitation worked around. The renderer is not told which dimension the pivot grouped by, and the two upstream shapes that reach it are byte-identical — measured:

```
buildChartSeries(rows, ['status','priority'], ['est_hours'])   // priority unprojected
  => {"data":[{"status":"Backlog"},{"status":"Done"}],"xAxisKey":"status","series":[]}
buildChartSeries(rows, ['status'], [])                          // no measure selected
  => {"data":[{"status":"Backlog"},{"status":"Done"}],"xAxisKey":"status","series":[]}
```

Naming one cause would print a sentence that is false half the time, which is worse than the silence it replaces. So the copy names the failure and BOTH authoring causes, and the console warning carries the same diagnostic pair the model prints: the axis the chart did plot, and the keys its rows actually carry. In the card's shape that second half is the tell — bucket rows carrying the category and nothing else.

Plumbing the pivoted dimension into the renderer would allow a key-naming message; it is costed as an open question in the report rather than taken unilaterally, because it spans three packages and introduces a prop a future call site can forget — the blindable-guard class #4507 is about.

## The three-way distinction, each arm pinned

- null / empty-string group values DRAW — real groups, real buckets, `series` non-empty, guard silent (#4673 intact, its suite untouched and green);
- an unprojected group key REFUSES;
- an ordinary pivot renders unchanged, and so does a PARTIALLY projected one. That last is premise C, decided by mirroring rather than by taste: the first dimension refuses only when NOT ONE row carries the key, so a partially projected series axis draws what projects. Pinned with its emitted rows.

Also pinned: the x-axis refusal wins when both apply (one cause, one diagnosis, one warning); `series === undefined` is left byte-for-byte alone; an empty result set is still the chart's own empty state.

## Copy and i18n convention

Mirrors the model exactly, measured first: the framework#4033 guard produces a hardcoded English string in JSX plus a hardcoded `console.warn`, with no locale key. This guard matches that convention, so no locale-pack key was added and `check:i18n-keys` / `check:i18n-drift` stay clean.

## Verification (HEAD `bf0d7351e`, clean tree)

| gate | result |
| --- | --- |
| `pnpm exec vitest run packages/core/ packages/plugin-charts/` | `117 passed (117)` files, `2073 passed (2073)` tests |
| new file alone | `11 passed (11)` |
| `pnpm exec vitest run packages/plugin-dashboard/` (downstream consumer of plugin-charts, run by name) | `58 passed (58)` files, `462 passed (462)` |
| `pnpm --filter '@object-ui/plugin-charts^...' build` then `pnpm --filter @object-ui/plugin-charts type-check` | exit 0 (closure built first; the package has `type-check`, not `typecheck`) |
| `pnpm exec eslint --quiet` on both changed files | clean |
| `node scripts/check-changeset-presence.mjs` | OK, 1 changeset declared |
| `pnpm run check:control-bytes` | OK (4225 files) |
| `check:i18n-keys` / `check:i18n-drift` / `check:phantom-deps` | OK |

Reverse verification, direction predicted before running: ablate the guard (`git checkout origin/main -- AdvancedChartImpl.tsx` from the committed state) and exactly the three refusal-arm tests go red while the eight draw/unchanged pins stay green. Observed: `3 failed | 13 passed` across the ablated pair of files — the predicted three, named placeholder, warning, family sweep. Restored from the branch and re-run green.

One flaky failure appeared in the first plugin-dashboard sweep (`DatasetWidget.dottedDimension.test.tsx:269`, `expected [] to deeply equal [ 'crm_opportunity' ]`). Measured on both sides — ablated full suite green, restored full suite green, file alone green — so it is not this change. It is the second site of the race already filed as #4487, and is attached there rather than re-filed.

## Findings filed

- #4695 — a cartesian chart handed no series binding at all (`series === undefined`) draws the same silent empty frame. Unassigned, `finding` label, deliberately outside this card's guard; the current behaviour is pinned by a test here so nobody discovers it as a silent contradiction.
- #4487 — the flaky dotted-dimension assertion above, second site attached as a comment.

#4692 remains open and is untouched; the click-handler region #4694 landed was not edited.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_