### PR TITLE
test(plugin-view): install the record-level explain-probe double in ObjectView split-mode suites

### DIFF
--- a/.changeset/plugin-view-explain-double.md
+++ b/.changeset/plugin-view-explain-double.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: install the recorded record-level explain-probe double
+(`explainDouble.ts`, per PR #4105's convention) in `plugin-view`'s
+`ObjectView` split-mode overlay-title suites, so they no longer escape to the
+real network under happy-dom. No published behaviour changes.

--- a/packages/plugin-view/src/__tests__/ObjectView.overlayTitleI18n.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.overlayTitleI18n.test.tsx
@@ -46,12 +46,13 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { I18nProvider } from '@object-ui/i18n';
 import type { DataSource } from '@object-ui/types';
 import { ObjectView } from '../ObjectView';
+import { installExplainDouble } from './explainDouble';
 
 const rows = [{ id: '1', name: 'Alice' }];
 
@@ -93,7 +94,15 @@ async function openSplitPanel() {
   fireEvent.click(cell);
 }
 
-afterEach(() => cleanup());
+// objectui#4688 — ObjectGrid batches a record-level explain probe for the
+// rows on screen; with no host `apiFetch` here it would otherwise escape to
+// the real network under happy-dom. See `explainDouble.ts`.
+beforeEach(() => installExplainDouble());
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('ObjectView split-mode detail heading (objectui#3459)', () => {
   it('renders the object label in English under an en session', async () => {

--- a/packages/plugin-view/src/__tests__/ObjectView.overlayTitleNoProviderFallback.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.overlayTitleNoProviderFallback.test.tsx
@@ -46,11 +46,12 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { DataSource } from '@object-ui/types';
 import { ObjectView } from '../ObjectView';
+import { installExplainDouble } from './explainDouble';
 
 const rows = [{ id: '1', name: 'Alice' }];
 
@@ -88,7 +89,15 @@ async function openSplitPanel() {
   fireEvent.click(cell);
 }
 
-afterEach(() => cleanup());
+// objectui#4688 — ObjectGrid batches a record-level explain probe for the
+// rows on screen; with no host `apiFetch` here it would otherwise escape to
+// the real network under happy-dom. See `explainDouble.ts`.
+beforeEach(() => installExplainDouble());
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('ObjectView split heading — English fallback with no provider (objectui#3459)', () => {
   it('interpolates the object label in English, never the raw key', async () => {

--- a/packages/plugin-view/src/__tests__/explainDouble.ts
+++ b/packages/plugin-view/src/__tests__/explainDouble.ts
@@ -1,0 +1,76 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A stand-in for the record-level explain probe, for this package's suites
+ * that render a real `ObjectGrid` (via `ObjectView`) without wiring a host
+ * `apiFetch` themselves.
+ *
+ * [objectui#4688] `ObjectGrid` batches a record-grained write verdict for the
+ * rows on screen (`POST /api/v1/security/explain` with `recordIds`), rooted
+ * in [#4296]. With no host `apiFetch` in the tree the hook falls back to the
+ * GLOBAL fetch — by design, for standalone embeds — which under happy-dom is
+ * a REAL request to the default origin. The verdict fails open on a failed
+ * request, so a suite that ignores it stays green while stderr fills with
+ * `connect ECONNREFUSED 127.0.0.1:3000`: the same class of escape as
+ * objectui#3339 (detail side, closed by PR #4105) and the shape that PR
+ * settled — answer it from a double, never from the network, and never from
+ * a global error sink.
+ *
+ * This is a per-package copy of `packages/plugin-grid/src/__tests__/
+ * explainDouble.ts`, following the #4105 convention (no repo convention for
+ * importing another package's test-only files across a workspace boundary).
+ *
+ * Deliberately NOT a swallow-everything stub: it RECORDS every URL it is
+ * handed and answers only the explain endpoint, so an escape to some other
+ * endpoint stays observable instead of vanishing into a rejection the hook
+ * discards.
+ *
+ * The answer is `visible: true` for every id asked about, which reproduces
+ * the pre-#4296 rendering exactly — a permitted record narrows nothing, so no
+ * assertion in a consuming suite changes meaning.
+ */
+import { vi } from 'vitest';
+
+export interface ExplainDoubleCall {
+  url: string;
+  body: Record<string, unknown> | undefined;
+}
+
+/**
+ * Install the double on the global `fetch`. Pair with `vi.unstubAllGlobals()`
+ * in `afterEach`.
+ *
+ * @returns the live call log, in request order.
+ */
+export function installExplainDouble(): ExplainDoubleCall[] {
+  const calls: ExplainDoubleCall[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: unknown, init?: { body?: unknown }) => {
+      const body = init?.body
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : undefined;
+      calls.push({ url: String(url), body });
+      const recordIds = Array.isArray(body?.recordIds) ? (body!.recordIds as string[]) : undefined;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          allowed: true,
+          object: body?.object,
+          operation: body?.operation,
+          principal: { userId: 'u_test' },
+          layers: [],
+          ...(recordIds ? { records: recordIds.map((id) => ({ recordId: id, visible: true })) } : {}),
+        }),
+      };
+    }),
+  );
+  return calls;
+}


### PR DESCRIPTION
Part of #4688 — this PR closes the `plugin-view` portion (96 → 0 ECONNREFUSED lines); the `app-shell` + `plugin-designer` portion of #4688 does NOT come from the same probe and is filed separately (see below), so this PR alone does not close #4688.

## What this does

`ObjectView.overlayTitleI18n.test.tsx` and `ObjectView.overlayTitleNoProviderFallback.test.tsx` render a real `ObjectGrid` (via `plugin-view`'s `ObjectView`, `navigation.mode: 'split'`) with `objectName: 'contacts'` and an id-carrying row, with no host `apiFetch`. `ObjectGrid` batches the record-level write-verdict probe (`POST /api/v1/security/explain`, #4296), which falls back to the global `fetch` and escapes to the real network under happy-dom — `connect ECONNREFUSED 127.0.0.1:3000`, same class as #3339 / PR #4105.

Per #4105's convention (a per-package copy, not a cross-package test-dir import — no repo convention for the latter, confirmed by grep), added `packages/plugin-view/src/__tests__/explainDouble.ts` (a copy of `plugin-grid/src/__tests__/explainDouble.ts`) and wired `installExplainDouble()` in `beforeEach` / `vi.unstubAllGlobals()` in `afterEach` in both files. The double answers `visible: true` for every id — byte-identical to what the failing network call produced, since the hook fails open — so no existing assertion changes meaning, and it *records* every URL it's handed so an escape to some other endpoint stays observable rather than vanishing.

## Verification

- Re-measured on current `main` (`b4bccc794`, post PR #4689 merge): `packages/plugin-view/` baseline reproduced the issue's exact numbers — 11 files / 111 tests pass, **96** ECONNREFUSED lines.
- After the fix: 11 files / 111 tests pass, **0** ECONNREFUSED lines.
- Reverse verification (fix committed first as `3acab7458`, then reverted with `git checkout` back to the parent commit for the two test files, re-run, then restored): confirmed the predicted direction — ECONNREFUSED returned to exactly 96 with the fix removed, all 111 tests still green throughout (the escape is noise, not a test failure, in both directions).
- `pnpm --filter @object-ui/plugin-view type-check`: green.
- `pnpm exec eslint --quiet` on the three changed files: clean.
- `node scripts/check-changeset-presence.mjs`: green (empty-frontmatter changeset declared, test-only precedent per #4641/#4666/#4671).
- `node scripts/check-control-bytes.mjs`: green.
- HEAD at the union run: `2341cd309`.

## Why this PR does not also fix the `app-shell` + `plugin-designer` 180-line row

#4688 attributes all three packages' ECONNREFUSED noise to the same grid explain probe ("the same escape lands in the consumer packages"). That holds for `plugin-view` (verified above) but **not** for `app-shell` / `plugin-designer`: bisecting the full `app-shell` + `plugin-designer` suite down to individual files (isolated single-file runs, since a batched run undercounts — some in-flight rejections don't settle before the process exits) landed all 180 lines in exactly 9 files under `packages/app-shell/src/views/metadata-admin/inspectors/` (`ConditionBuilder`/`PageBlockInspector`/`HookDefaultInspector`/`ActionDefaultInspector`/`ViewVariantInspector` suites), summing to exactly 180. None of them render `ObjectGrid`. Instrumenting the actual fetch call site (`vi.stubGlobal('fetch', …)` inside `vitest.setup.base.ts`, output via `process.stderr.write` since `console.error` is swallowed by vitest for passing tests) showed the real URLs: `GET /api/v1/meta/object` and `GET /api/v1/meta/object/contact` — the metadata-admin engine's `useObjectFields`/`useObjectOptions` hooks (object-picker / field-list config for page-block inspectors), reached through `useMetadataClient()` → `createConsoleMetadataClient()` → `createAuthenticatedFetch()` → the bare global `fetch`. Unrelated to `ObjectGrid`/`useRecordCrudVerdicts`/#4296.

Per #4688's own acceptance criteria ("a remainder from a DIFFERENT probe is a new finding, not this card's"), filed separately as #4697, evidence and suggested remedy (the same recorded-double shape, for the metadata client) included there. `plugin-designer` needed no change — it contributes 0 lines either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnQd8iMMUwXQEV1crFmQiQ)_
